### PR TITLE
fix: resolve 3 PHPUnit failures + 1 error on trunk test code

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -485,22 +485,6 @@ function wpdm_sanitize_dock_icon( $icon ) {
 		return preg_replace( '/[^a-z0-9_-]/', '', $icon );
 	}
 
-	// SVG data URI — the JS dock renders these as CSS background-image,
-	// which does NOT execute script in any currently shipping browser
-	// (Chrome/Firefox/Safari all treat SVG-in-CSS-background as an
-	// image-only context since ~2017). Strict validation on the base64
-	// payload prevents anything other than proper base64 from reaching
-	// the DOM; any other data:* scheme (javascript:, text/html, etc.)
-	// is rejected outright by the prefix check.
-	$svg_prefix = 'data:image/svg+xml;base64,';
-	if ( 0 === stripos( $icon, $svg_prefix ) ) {
-		$payload = substr( $icon, strlen( $svg_prefix ) );
-		if ( preg_match( '/^[A-Za-z0-9+\/=]+$/', $payload ) ) {
-			return $icon;
-		}
-		return $fallback;
-	}
-
 	// http/https URL — the icon is a hosted image.
 	if ( 0 === stripos( $icon, 'http://' ) || 0 === stripos( $icon, 'https://' ) ) {
 		$clean = esc_url_raw( $icon, array( 'http', 'https' ) );

--- a/includes/session.php
+++ b/includes/session.php
@@ -172,7 +172,17 @@ function wpdm_clear_session( $user_id ) {
  */
 function wpdm_sanitize_session( $session ) {
 	$clean = wpdm_empty_session();
-	$clean['updated'] = time();
+
+	// Preserve the client's `updated` timestamp when present — it's what
+	// wpdm_save_session compares to detect stale writes from another tab.
+	// Stamping `time()` here would overwrite it before the comparison ran,
+	// so equal-timestamp writes could never be distinguished from stale
+	// ones. Fall back to server time only when the incoming value is
+	// missing or invalid.
+	$incoming_updated = ( is_array( $session ) && isset( $session['updated'] ) )
+		? (int) $session['updated']
+		: 0;
+	$clean['updated'] = $incoming_updated > 0 ? $incoming_updated : time();
 
 	if ( ! is_array( $session ) ) {
 		return $clean;

--- a/tests/phpunit/tests/wpDesktopBuildDockItems.php
+++ b/tests/phpunit/tests/wpDesktopBuildDockItems.php
@@ -53,7 +53,10 @@ class Tests_DesktopMode_WpDesktopBuildDockItems extends WP_UnitTestCase {
 			$slug,
 			$page_title,
 			$classes,
-			$hookname ?: 'menu-' . sanitize_key( $slug ),
+			// Real WP hooknames normalize dots to dashes (`index.php` → `menu-index-php`),
+			// but `sanitize_key` would strip the dot and produce `menu-indexphp`.
+			// Pre-replace so the synthetic ids the tests assert against match.
+			$hookname ?: 'menu-' . sanitize_key( str_replace( '.', '-', $slug ) ),
 			$icon,
 		);
 	}


### PR DESCRIPTION
Depends on #2 for the working `vendor/bin/phpunit` + WP test-suite install. Once the CI infra from #2 started actually running PHPUnit, four real issues became visible in trunk's code/tests. Each fix below is targeted and explains *why* rather than re-stating *what*.

## Fixes

### 1. `WpDesktopBuildDockItems::test_placement_distinguishes_core_from_plugin_menus` — ERROR

`Undefined array key "menu-index-php"`.

The test helper `make_menu_row` built synthetic hooknames as `'menu-' . sanitize_key( $slug )`. `sanitize_key` strips `.` entirely, so `index.php` → `indexphp`, producing dock id `menu-indexphp`. The assertion expects `menu-index-php` (the real WP hookname style that normalizes dots to dashes).

**Fix:** pre-replace `.` → `-` in the slug before passing it to `sanitize_key` inside the helper.

### 2+3. `Security::test_data_uri_rejected` and `WpDesktopBuildDockItems::test_icon_data_svg_rejected` — FAILURES

Both expect every `data:` URI (including `data:image/svg+xml;base64,…`) to fall back to `dashicons-admin-generic`. `wpdm_sanitize_dock_icon` carried a special-case branch that *accepted* base64-encoded SVG data URIs, directly contradicting its own `@since 0.11.0 Rejects data: URIs outright` docstring.

**Fix:** drop the branch so every `data:` URI falls through to the fallback, matching the documented Phase-11 intent.

### 4. `WpDesktopSession::test_save_session_accepts_equal_timestamp` — FAILURE

`Failed asserting that false is true.` on the second save.

`wpdm_sanitize_session` always stamped `$clean['updated'] = time()` before the save logic ran, overwriting whatever `updated` the client sent. That meant the stale-write guard compared `incoming` against a server-time `stored`, so equal-timestamp writes looked strictly-older and got rejected.

**Fix:** preserve the client's `updated` when valid, fall back to `time()` only when missing or invalid. `test_save_session_rejects_stale_write` and `test_save_session_accepts_missing_timestamp` continue to pass under the same logic.

## Test plan

- [ ] CI: `Tests: 331, Assertions: 698, Errors: 0, Failures: 0` on both PHP 8.1 and 8.2 matrix legs
- [ ] `js` lane: still green