### PR TITLE
Feat/os settings help tab

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -544,3 +544,211 @@
 	color: #646970;
 	font-style: italic;
 }
+
+/*
+ * Help tab — developer-facing component reference. Two-column layout
+ * (nav + detail) on desktop, stacks naturally on narrow windows via
+ * the same container the OS Settings panel lives in.
+ */
+.wp-desktop-os-settings__help-count {
+	margin: 4px 0 0;
+	font-size: 12px;
+	color: #646970;
+}
+
+.wp-desktop-os-settings__help-layout {
+	display: grid;
+	grid-template-columns: 200px 1fr;
+	gap: 20px;
+	align-items: start;
+}
+
+@container (max-width: 640px) {
+	.wp-desktop-os-settings__help-layout {
+		grid-template-columns: 1fr;
+	}
+}
+
+.wp-desktop-os-settings__help-nav {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	max-height: 480px;
+	overflow-y: auto;
+	padding: 4px;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+}
+
+.wp-desktop-os-settings__help-nav-item {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	align-items: flex-start;
+	width: 100%;
+	padding: 6px 10px;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 6px;
+	text-align: start;
+	cursor: pointer;
+	font: inherit;
+	color: inherit;
+}
+
+.wp-desktop-os-settings__help-nav-item:hover {
+	background: #fff;
+	border-color: #dcdcde;
+}
+
+.wp-desktop-os-settings__help-nav-item.is-active {
+	background: #fff;
+	border-color: var( --wp-admin-theme-color, #2271b1 );
+}
+
+.wp-desktop-os-settings__help-nav-title {
+	font-weight: 600;
+	font-size: 13px;
+}
+
+.wp-desktop-os-settings__help-nav-tag {
+	font-family: Menlo, Consolas, monospace;
+	font-size: 11px;
+	color: #646970;
+}
+
+.wp-desktop-os-settings__help-detail {
+	min-width: 0;
+	padding: 16px 18px 18px;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+}
+
+.wp-desktop-os-settings__help-head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 8px;
+	margin: 0 0 8px;
+}
+
+.wp-desktop-os-settings__help-title {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+}
+
+.wp-desktop-os-settings__help-code {
+	font-family: Menlo, Consolas, monospace;
+	font-size: 12px;
+	color: #646970;
+}
+
+.wp-desktop-os-settings__help-badge {
+	padding: 1px 8px;
+	border-radius: 999px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	background: #e4e7eb;
+	color: #1d2327;
+}
+
+.wp-desktop-os-settings__help-badge.is-experimental {
+	background: #fcf9e8;
+	color: #996800;
+}
+
+.wp-desktop-os-settings__help-badge.is-planned {
+	background: #e1e8ff;
+	color: #123fb3;
+}
+
+.wp-desktop-os-settings__help-since {
+	font-size: 11px;
+	color: #646970;
+}
+
+.wp-desktop-os-settings__help-summary {
+	margin: 0 0 16px;
+	color: #1d2327;
+}
+
+.wp-desktop-os-settings__help-group {
+	margin: 0 0 16px;
+}
+
+.wp-desktop-os-settings__help-group h4 {
+	margin: 0 0 8px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: #646970;
+}
+
+.wp-desktop-os-settings__help-example {
+	padding: 16px;
+	background: #fff;
+	border: 1px dashed #c3c4c7;
+	border-radius: 6px;
+}
+
+.wp-desktop-os-settings__help-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 12px;
+}
+
+.wp-desktop-os-settings__help-table th,
+.wp-desktop-os-settings__help-table td {
+	padding: 6px 8px;
+	border-bottom: 1px solid #dcdcde;
+	text-align: start;
+	vertical-align: top;
+}
+
+.wp-desktop-os-settings__help-table th {
+	font-weight: 600;
+	color: #646970;
+	background: #fff;
+}
+
+.wp-desktop-os-settings__help-table code,
+.wp-desktop-os-settings__help-list code {
+	font-family: Menlo, Consolas, monospace;
+	font-size: 11px;
+	padding: 1px 4px;
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 3px;
+}
+
+.wp-desktop-os-settings__help-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.wp-desktop-os-settings__help-list li {
+	padding: 4px 0;
+	border-bottom: 1px solid #ececee;
+	font-size: 12px;
+}
+
+.wp-desktop-os-settings__help-list li:last-child {
+	border-bottom: 0;
+}
+
+.wp-desktop-os-settings__help-note {
+	margin: 12px 0 0;
+	padding: 10px 12px;
+	background: #fcf9e8;
+	border: 1px solid #f5e6a5;
+	border-radius: 6px;
+	font-size: 12px;
+	color: #996800;
+}

--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -11,7 +11,6 @@
  * @since 0.5.0
  */
 .wp-desktop-os-settings {
-	padding: 20px 24px 24px;
 	font-size: 13px;
 	line-height: 1.5;
 }
@@ -103,9 +102,8 @@
  * than any outer descendant selector, and overriding it from outside
  * breaks the auto-swap (hidden panels stay visible). The component's
  * own `:host { display: block }` already handles the shown state. */
-.wp-desktop-os-settings > wpd-tabs {
+.wp-desktop-os-settings wpd-tabs {
 	display: block;
-	margin-bottom: 16px;
 }
 
 /* `__reset` now renders as `<wpd-button variant="ghost">`. */
@@ -560,7 +558,6 @@
 	display: grid;
 	grid-template-columns: 200px 1fr;
 	gap: 20px;
-	align-items: start;
 }
 
 @container (max-width: 640px) {
@@ -573,7 +570,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
-	max-height: 480px;
+	align-self: stretch;
 	overflow-y: auto;
 	padding: 4px;
 	background: #f6f7f7;

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -65,6 +65,7 @@ import { buildAccentSection } from './sections/accent';
 import { buildAiSection } from './sections/ai';
 import { buildDockSizeSection } from './sections/dock-size';
 import { buildExtendedSection } from './sections/extended';
+import { buildHelpSection } from './sections/help';
 import {
 	buildWallpaperSection,
 	registerCustomGradient,
@@ -184,11 +185,6 @@ export class OsSettings implements SettingsCtx {
 
 		render(
 			html`
-				<p class="wp-desktop-os-settings__intro">
-					${ __(
-		'Personalize your desktop. Changes apply instantly and are saved to this browser.',
-	) }
-				</p>
 				<wpd-tabs value="appearance" label=${ __( 'Settings sections' ) }>
 					<wpd-tab value="appearance"
 						>${ __( 'Appearance' ) }</wpd-tab
@@ -197,8 +193,16 @@ export class OsSettings implements SettingsCtx {
 					${ this.config.isAdmin
 						? html`<wpd-tab value="extended">${ __( 'Extended Options' ) }</wpd-tab>`
 						: html`` }
+					${ this.config.isAdmin
+						? html`<wpd-tab value="help">${ __( 'Help' ) }</wpd-tab>`
+						: html`` }
 				</wpd-tabs>
 				<wpd-tabpanel for="appearance">
+					<p class="wp-desktop-os-settings__intro">
+						${ __(
+							'Personalize your desktop. Changes apply instantly and are saved to this browser.',
+						) }
+					</p>
 					${ buildWallpaperSection( this, body ) }
 					${ buildAccentSection( this ) }
 					${ buildDockSizeSection( this ) }
@@ -209,6 +213,11 @@ export class OsSettings implements SettingsCtx {
 				${ this.config.isAdmin
 					? html`<wpd-tabpanel for="extended">
 							${ buildExtendedSection( this ) }
+						</wpd-tabpanel>`
+					: html`` }
+				${ this.config.isAdmin
+					? html`<wpd-tabpanel for="help">
+							${ buildHelpSection() }
 						</wpd-tabpanel>`
 					: html`` }
 				<div class="wp-desktop-os-settings__footer">

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -198,33 +198,35 @@ export class OsSettings implements SettingsCtx {
 						: html`` }
 				</wpd-tabs>
 				<wpd-tabpanel for="appearance">
-					<p class="wp-desktop-os-settings__intro">
-						${ __(
-							'Personalize your desktop. Changes apply instantly and are saved to this browser.',
-						) }
-					</p>
-					${ buildWallpaperSection( this, body ) }
-					${ buildAccentSection( this ) }
-					${ buildDockSizeSection( this ) }
+					<wpd-panel>
+						<p class="wp-desktop-os-settings__intro">
+							${ __(
+								'Personalize your desktop. Changes apply instantly and are saved to this browser.',
+							) }
+						</p>
+						${ buildWallpaperSection( this, body ) }
+						${ buildAccentSection( this ) }
+						${ buildDockSizeSection( this ) }
+					</wpd-panel>
 				</wpd-tabpanel>
 				<wpd-tabpanel for="ai">
-					${ buildAiSection( this ) }
+					<wpd-panel>${ buildAiSection( this ) }</wpd-panel>
 				</wpd-tabpanel>
 				${ this.config.isAdmin
 					? html`<wpd-tabpanel for="extended">
-							${ buildExtendedSection( this ) }
+							<wpd-panel>${ buildExtendedSection( this ) }</wpd-panel>
 						</wpd-tabpanel>`
 					: html`` }
 				${ this.config.isAdmin
 					? html`<wpd-tabpanel for="help">
-							${ buildHelpSection() }
+							<wpd-panel>${ buildHelpSection() }</wpd-panel>
 						</wpd-tabpanel>`
 					: html`` }
-				<div class="wp-desktop-os-settings__footer">
+				<wpd-panel class="wp-desktop-os-settings__footer">
 					<wpd-button variant="ghost" @click=${ onReset }
 						>${ __( 'Reset to defaults' ) }</wpd-button
 					>
-				</div>
+				</wpd-panel>
 			`,
 			body,
 		);

--- a/src/settings/sections/help.ts
+++ b/src/settings/sections/help.ts
@@ -1,0 +1,348 @@
+/**
+ * Help tab — developer-facing component reference.
+ *
+ * Iterates `WPD_COMPONENT_TAGS`, looks up each registered custom
+ * element on `customElements.get( tag )`, and reads the optional
+ * `static help: WpdHelp` descriptor off the class. Components without
+ * a descriptor still render with a minimal fallback built from
+ * `static props`, so the tab is useful on day one and grows richer as
+ * authors fill in descriptors.
+ *
+ * Admin-gated alongside Extended Options — surfacing the component
+ * library to every editor would be noise. The descriptors live next
+ * to their components so renaming a prop forces a descriptor update
+ * in the same diff (no separate docs file to drift).
+ *
+ * @since 0.16.0
+ */
+
+import { __ } from '../../i18n';
+import { html, render, type WpdHelp } from '../../ui/core';
+import { WPD_COMPONENT_TAGS } from '../../ui/components';
+
+type CtorWithHelp = CustomElementConstructor & {
+	help?: WpdHelp;
+	props?: readonly string[];
+};
+
+interface ComponentEntry {
+	tag: string;
+	title: string;
+	help: WpdHelp | null;
+	props: readonly string[];
+}
+
+export function buildHelpSection(): HTMLElement {
+	const entries = collectEntries();
+	const el = document.createElement( 'div' );
+	el.classList.add( 'wp-desktop-os-settings__help' );
+
+	let activeTag = entries[ 0 ]?.tag ?? '';
+
+	const paint = (): void => {
+		const active = entries.find( ( e ) => e.tag === activeTag ) ?? entries[ 0 ];
+		render(
+			html`
+				<wpd-section
+					heading=${ __( 'Component library' ) }
+					description=${ __(
+						'Every <wpd-*> web component shipped by this plugin, with its props, slots, and a live example. Descriptors live next to each component class — the list stays in sync with the code.',
+					) }
+				>
+					<p class="wp-desktop-os-settings__help-count">
+						${ String( entries.length ) } ${ __( 'components registered.' ) }
+					</p>
+				</wpd-section>
+
+				<div class="wp-desktop-os-settings__help-layout">
+					<nav
+						class="wp-desktop-os-settings__help-nav"
+						aria-label=${ __( 'Components' ) }
+					>
+						${ entries.map(
+							( entry ) => html`
+								<button
+									type="button"
+									class=${ classNames(
+										'wp-desktop-os-settings__help-nav-item',
+										entry.tag === ( active?.tag ?? '' )
+											? 'is-active'
+											: '',
+									) }
+									aria-pressed=${ entry.tag === ( active?.tag ?? '' )
+										? 'true'
+										: 'false' }
+									@click=${ () => {
+			activeTag = entry.tag;
+			paint();
+		} }
+								>
+									<span class="wp-desktop-os-settings__help-nav-title"
+										>${ entry.title }</span
+									>
+									<span class="wp-desktop-os-settings__help-nav-tag"
+										>&lt;${ entry.tag }&gt;</span
+									>
+								</button>
+							`,
+						) }
+					</nav>
+					<div class="wp-desktop-os-settings__help-detail">
+						${ active ? renderDetail( active ) : renderEmpty() }
+					</div>
+				</div>
+			`,
+			el,
+		);
+	};
+
+	paint();
+	return el;
+}
+
+function renderDetail( entry: ComponentEntry ) {
+	const help = entry.help;
+	const status = help?.status ?? 'stable';
+	const since = help?.since;
+
+	return html`
+		<header class="wp-desktop-os-settings__help-head">
+			<h3 class="wp-desktop-os-settings__help-title">${ entry.title }</h3>
+			<code class="wp-desktop-os-settings__help-code"
+				>&lt;${ entry.tag }&gt;</code
+			>
+			<span
+				class=${ classNames(
+					'wp-desktop-os-settings__help-badge',
+					`is-${ status }`,
+				) }
+				>${ statusLabel( status ) }</span
+			>
+			${ since
+				? html`<span class="wp-desktop-os-settings__help-since"
+						>${ __( 'Since' ) } ${ since }</span
+					>`
+				: html`` }
+		</header>
+
+		${ help?.summary
+			? html`<p class="wp-desktop-os-settings__help-summary">
+					${ help.summary }
+				</p>`
+			: html`` }
+
+		${ help?.example
+			? html`
+					<section class="wp-desktop-os-settings__help-group">
+						<h4>${ __( 'Example' ) }</h4>
+						<div class="wp-desktop-os-settings__help-example">
+							${ help.example }
+						</div>
+					</section>
+				`
+			: html`` }
+		${ renderPropsTable( entry, help ) } ${ renderSlots( help ) }
+		${ renderEvents( help ) } ${ renderParts( help ) }
+		${ renderCssProps( help ) }
+		${ ! help
+			? html`<p class="wp-desktop-os-settings__help-note">
+					${ __(
+						'This component has no help descriptor yet. Add `static help` to its class for a fuller reference.',
+					) }
+				</p>`
+			: html`` }
+	`;
+}
+
+function renderPropsTable( entry: ComponentEntry, help: WpdHelp | null ) {
+	const documented = help?.props ?? [];
+	const documentedNames = new Set( documented.map( ( p ) => p.name ) );
+	const undocumented = entry.props.filter( ( p ) => ! documentedNames.has( p ) );
+
+	if ( documented.length === 0 && undocumented.length === 0 ) {
+		return html``;
+	}
+
+	return html`
+		<section class="wp-desktop-os-settings__help-group">
+			<h4>${ __( 'Props' ) }</h4>
+			<table class="wp-desktop-os-settings__help-table">
+				<thead>
+					<tr>
+						<th>${ __( 'Name' ) }</th>
+						<th>${ __( 'Type' ) }</th>
+						<th>${ __( 'Default' ) }</th>
+						<th>${ __( 'Description' ) }</th>
+					</tr>
+				</thead>
+				<tbody>
+					${ documented.map(
+						( p ) => html`
+							<tr>
+								<td><code>${ p.name }</code></td>
+								<td>${ p.type ?? '—' }</td>
+								<td>${ p.default ?? '—' }</td>
+								<td>${ p.description ?? '' }</td>
+							</tr>
+						`,
+					) }
+					${ undocumented.map(
+						( name ) => html`
+							<tr>
+								<td><code>${ name }</code></td>
+								<td>—</td>
+								<td>—</td>
+								<td>
+									<em
+										>${ __(
+											'Undocumented — declared via static props.',
+										) }</em
+									>
+								</td>
+							</tr>
+						`,
+					) }
+				</tbody>
+			</table>
+		</section>
+	`;
+}
+
+function renderSlots( help: WpdHelp | null ) {
+	if ( ! help?.slots?.length ) {
+		return html``;
+	}
+	return html`
+		<section class="wp-desktop-os-settings__help-group">
+			<h4>${ __( 'Slots' ) }</h4>
+			<ul class="wp-desktop-os-settings__help-list">
+				${ help.slots.map(
+					( s ) => html`
+						<li>
+							<code>${ s.name }</code>
+							${ s.description
+								? html` — ${ s.description }`
+								: html`` }
+						</li>
+					`,
+				) }
+			</ul>
+		</section>
+	`;
+}
+
+function renderEvents( help: WpdHelp | null ) {
+	if ( ! help?.events?.length ) {
+		return html``;
+	}
+	return html`
+		<section class="wp-desktop-os-settings__help-group">
+			<h4>${ __( 'Events' ) }</h4>
+			<ul class="wp-desktop-os-settings__help-list">
+				${ help.events.map(
+					( e ) => html`
+						<li>
+							<code>${ e.name }</code>
+							${ e.detail
+								? html` — <code>${ e.detail }</code>`
+								: html`` }
+							${ e.description ? html` — ${ e.description }` : html`` }
+						</li>
+					`,
+				) }
+			</ul>
+		</section>
+	`;
+}
+
+function renderParts( help: WpdHelp | null ) {
+	if ( ! help?.parts?.length ) {
+		return html``;
+	}
+	return html`
+		<section class="wp-desktop-os-settings__help-group">
+			<h4>${ __( 'Shadow parts' ) }</h4>
+			<ul class="wp-desktop-os-settings__help-list">
+				${ help.parts.map(
+					( p ) => html`
+						<li>
+							<code>::part(${ p.name })</code>
+							${ p.description ? html` — ${ p.description }` : html`` }
+						</li>
+					`,
+				) }
+			</ul>
+		</section>
+	`;
+}
+
+function renderCssProps( help: WpdHelp | null ) {
+	if ( ! help?.cssProps?.length ) {
+		return html``;
+	}
+	return html`
+		<section class="wp-desktop-os-settings__help-group">
+			<h4>${ __( 'CSS custom properties' ) }</h4>
+			<ul class="wp-desktop-os-settings__help-list">
+				${ help.cssProps.map(
+					( v ) => html`
+						<li>
+							<code>${ v.name }</code>
+							${ v.default
+								? html`
+										(${ __( 'default' ) }
+										<code>${ v.default }</code>)
+									`
+								: html`` }
+							${ v.description ? html` — ${ v.description }` : html`` }
+						</li>
+					`,
+				) }
+			</ul>
+		</section>
+	`;
+}
+
+function renderEmpty() {
+	return html`<p>${ __( 'No components registered.' ) }</p>`;
+}
+
+function collectEntries(): ComponentEntry[] {
+	const entries: ComponentEntry[] = [];
+	for ( const tag of WPD_COMPONENT_TAGS ) {
+		const ctor = customElements.get( tag ) as CtorWithHelp | undefined;
+		if ( ! ctor ) {
+			continue;
+		}
+		const help = ctor.help ?? null;
+		const title = help?.title ?? defaultTitleFromTag( tag );
+		const props = ctor.props ?? [];
+		entries.push( { tag, title, help, props } );
+	}
+	// Stable alphabetical sort by title so plugin authors can find
+	// components without having to memorise registration order.
+	entries.sort( ( a, b ) => a.title.localeCompare( b.title ) );
+	return entries;
+}
+
+function defaultTitleFromTag( tag: string ): string {
+	// "wpd-text-field" → "Text field".
+	const bare = tag.replace( /^wpd-/, '' ).replace( /-/g, ' ' );
+	return bare.charAt( 0 ).toUpperCase() + bare.slice( 1 );
+}
+
+function statusLabel( status: NonNullable<WpdHelp[ 'status' ]> ): string {
+	switch ( status ) {
+		case 'experimental':
+			return __( 'Experimental' );
+		case 'planned':
+			return __( 'Planned' );
+		case 'stable':
+		default:
+			return __( 'Stable' );
+	}
+}
+
+function classNames( ...parts: Array<string | false | null | undefined> ): string {
+	return parts.filter( Boolean ).join( ' ' );
+}

--- a/src/ui/components/wpd-body/wpd-body.ts
+++ b/src/ui/components/wpd-body/wpd-body.ts
@@ -43,6 +43,50 @@ export class WpdBody extends Component {
 	static props = [ 'gap', 'padding', 'scroll' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Body',
+		summary:
+			'Top-level native-window body wrapper. Fills the parent, stacks children in a flex column, and optionally owns the scrollable region so overflowing content scrolls inside the body rather than the window frame.',
+		status: 'stable',
+		since: '0.12.0',
+		props: [
+			{
+				name: 'gap',
+				type: 'integer (px)',
+				default: '12',
+				description: 'Space between children.',
+			},
+			{
+				name: 'padding',
+				type: 'integer (px)',
+				default: '16',
+				description: 'Inset around children. Pass 0 for edge-to-edge canvas content.',
+			},
+			{
+				name: 'scroll',
+				type: 'boolean attribute',
+				description: 'Applies overflow: auto so tall content scrolls within the body.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Body content — typically one or more <wpd-panel>s.' },
+		],
+		cssProps: [
+			{ name: '--wpd-body-gap', default: '12px' },
+			{ name: '--wpd-body-padding', default: '16px' },
+		],
+		example: html`
+			<wpd-body scroll>
+				<wpd-panel>
+					<wpd-section heading="Profile">Edit profile info here.</wpd-section>
+				</wpd-panel>
+				<wpd-panel>
+					<wpd-section heading="Danger zone">Irreversible actions.</wpd-section>
+				</wpd-panel>
+			</wpd-body>
+		`,
+	} as const;
+
 	protected render() {
 		const gap = ( this as unknown as { gap: string | null } ).gap;
 		const padding = ( this as unknown as { padding: string | null } ).padding;

--- a/src/ui/components/wpd-button/wpd-button.ts
+++ b/src/ui/components/wpd-button/wpd-button.ts
@@ -51,6 +51,67 @@ export class WpdButton extends Component {
 	static props = [ 'variant', 'disabled', 'type', 'busy', 'fill-cell' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Button',
+		summary:
+			'Thin wrapper around <button> with consistent variant styling and a slot for the label.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'variant',
+				type: "'primary' | 'secondary' | 'ghost' | 'danger' | 'link'",
+				default: 'ghost',
+				description:
+					'Visual weight of the button. Use primary for the single attention-grabbing action per surface.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean attribute',
+				description: 'Disable pointer + keyboard interaction and dim the chrome.',
+			},
+			{
+				name: 'type',
+				type: "'button' | 'submit' | 'reset'",
+				default: 'button',
+				description: 'Forwarded to the underlying native <button>.',
+			},
+			{
+				name: 'busy',
+				type: 'boolean attribute',
+				description: 'Marks the button as in-progress (e.g., awaiting a fetch).',
+			},
+			{
+				name: 'fill-cell',
+				type: 'boolean attribute',
+				description:
+					'Grow to fill the parent flex/grid cell. Useful for tiled keypads.',
+			},
+		],
+		slots: [ { name: '(default)', description: 'Button label.' } ],
+		parts: [ { name: 'button', description: 'Underlying <button> element.' } ],
+		cssProps: [
+			{ name: '--wpd-button-bg', description: 'Background color.' },
+			{ name: '--wpd-button-fg', description: 'Text color.' },
+			{ name: '--wpd-button-border', description: 'Border shorthand.' },
+			{ name: '--wpd-button-border-radius', default: '6px' },
+			{ name: '--wpd-button-padding', default: '6px 12px' },
+			{
+				name: '--wpd-button-min-height',
+				description: 'Minimum height when fill-cell is set.',
+			},
+		],
+		example: html`
+			<wpd-cluster gap="8">
+				<wpd-button variant="primary">Primary</wpd-button>
+				<wpd-button variant="secondary">Secondary</wpd-button>
+				<wpd-button variant="ghost">Ghost</wpd-button>
+				<wpd-button variant="danger">Danger</wpd-button>
+				<wpd-button variant="link">Link</wpd-button>
+			</wpd-cluster>
+		`,
+	} as const;
+
 	protected render() {
 		const disabled =
 			( this as unknown as { disabled: string | null } ).disabled !== null;

--- a/src/ui/components/wpd-checkbox-label/wpd-checkbox-label.ts
+++ b/src/ui/components/wpd-checkbox-label/wpd-checkbox-label.ts
@@ -10,6 +10,39 @@ export class WpdCheckboxLabel extends Component {
 	static props = [ 'label', 'checked' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Checkbox label',
+		summary:
+			'Opinionated label-row variant of <wpd-checkbox>: label text + checkbox in a single aligned row. Use when you want the shipped layout without any layout work.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Visible label text, paired with the checkbox via a native <label>.',
+			},
+			{
+				name: 'checked',
+				type: 'boolean attribute',
+				description: 'Reflects and controls the checked state.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-checkbox-change',
+				description: 'Fires when the user toggles the checkbox.',
+				detail: '{ checked: boolean }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Label colour.' },
+		],
+		example: html`
+			<wpd-checkbox-label label="Reduce motion" checked></wpd-checkbox-label>
+		`,
+	} as const;
+
 	protected render() {
 		const label = ( this as unknown as { label: string | null } ).label || '';
 		const checked =

--- a/src/ui/components/wpd-checkbox/wpd-checkbox.ts
+++ b/src/ui/components/wpd-checkbox/wpd-checkbox.ts
@@ -33,6 +33,53 @@ export class WpdCheckbox extends Component {
 	static props = [ 'checked', 'value', 'label', 'disabled' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Checkbox',
+		summary:
+			'Standalone checkbox primitive. Paints the native control with the admin accent colour and optionally renders an inline label. Use when you need full control over label placement.',
+		status: 'stable',
+		since: '0.11.0',
+		props: [
+			{
+				name: 'checked',
+				type: 'boolean attribute',
+				description: 'Reflects + controls the checked state; updated on user toggle.',
+			},
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Identifier returned in the event detail — useful when several checkboxes share a listener.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Optional inline label rendered to the right of the box.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean attribute',
+				description: 'Disables the native input.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-checkbox-change',
+				description: 'Fires when the user toggles the checkbox.',
+				detail: '{ checked: boolean, value: string | null }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Label colour.' },
+		],
+		example: html`
+			<wpd-stack gap="4">
+				<wpd-checkbox value="hd" label="HD only" checked></wpd-checkbox>
+				<wpd-checkbox value="subs" label="Require subtitles"></wpd-checkbox>
+				<wpd-checkbox value="locked" label="Locked" disabled></wpd-checkbox>
+			</wpd-stack>
+		`,
+	} as const;
+
 	protected render() {
 		const checked =
 			( this as unknown as { checked: string | null } ).checked !== null;

--- a/src/ui/components/wpd-cluster/wpd-cluster.ts
+++ b/src/ui/components/wpd-cluster/wpd-cluster.ts
@@ -29,6 +29,48 @@ export class WpdCluster extends Component {
 	static props = [ 'gap', 'justify', 'align' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Cluster',
+		summary:
+			'Horizontal flex layout with a gap + wrap. The sibling of <wpd-stack> — use it for rows of controls (button groups, toolbars). Children wrap gracefully when the container narrows.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'gap',
+				type: 'integer (px)',
+				default: '8',
+				description: 'Space between children.',
+			},
+			{
+				name: 'justify',
+				type: "'start' | 'center' | 'end' | 'space-between' | 'space-around'",
+				default: 'start',
+				description: 'Main-axis alignment (justify-content).',
+			},
+			{
+				name: 'align',
+				type: "'start' | 'center' | 'end' | 'stretch' | 'baseline'",
+				default: 'center',
+				description: 'Cross-axis alignment (align-items).',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Inline children.' },
+		],
+		cssProps: [
+			{ name: '--wpd-cluster-gap', default: '8px' },
+			{ name: '--wpd-cluster-justify', default: 'start' },
+			{ name: '--wpd-cluster-align', default: 'center' },
+		],
+		example: html`
+			<wpd-cluster gap="8" justify="end">
+				<wpd-button>Cancel</wpd-button>
+				<wpd-button variant="primary">Save</wpd-button>
+			</wpd-cluster>
+		`,
+	} as const;
+
 	protected render() {
 		const gap = ( this as unknown as { gap: string | null } ).gap;
 		const justify = ( this as unknown as { justify: string | null } ).justify;

--- a/src/ui/components/wpd-color-field/wpd-color-field.ts
+++ b/src/ui/components/wpd-color-field/wpd-color-field.ts
@@ -16,6 +16,46 @@ export class WpdColorField extends Component {
 	static props = [ 'label', 'value', 'variant' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Color field',
+		summary:
+			'Label + native color input. Reflects the value attribute both ways and emits wpd-color-change live on every edit (no debounce — callers debounce upstream).',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Visible label rendered next to the swatch.',
+			},
+			{
+				name: 'value',
+				type: 'CSS hex color',
+				default: '#000000',
+				description: 'Current color. Two-way reflected with the native picker.',
+			},
+			{
+				name: 'variant',
+				type: 'string',
+				description: 'Optional visual variant hint for the stylesheet.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-color-change',
+				description: 'Fires on every user edit.',
+				detail: '{ value: string }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-border', description: 'Swatch outline.' },
+			{ name: '--wp-desktop-muted', description: 'Label colour.' },
+		],
+		example: html`
+			<wpd-color-field label="Accent" value="#8b5cf6"></wpd-color-field>
+		`,
+	} as const;
+
 	protected render() {
 		const label = ( this as unknown as { label: string | null } ).label || '';
 		const value =

--- a/src/ui/components/wpd-display/wpd-display.ts
+++ b/src/ui/components/wpd-display/wpd-display.ts
@@ -41,6 +41,53 @@ export class WpdDisplay extends Component {
 	static props = [ 'value', 'size', 'align' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Display',
+		summary:
+			'Single-line numeric/text readout — right-aligned, tabular-nums, auto-ellipsized. The readout every calculator, stopwatch, ticker, counter, or meter reinvents. Host is aria-live="polite" so screen readers announce value changes without yanking focus.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Convenience readout. Ignored when the caller slots their own content.',
+			},
+			{
+				name: 'size',
+				type: "'sm' | 'md' | 'lg' | 'xl'",
+				default: 'lg',
+				description: 'Typography scale. lg is calculator-sized.',
+			},
+			{
+				name: 'align',
+				type: "'start' | 'center' | 'end'",
+				default: 'end',
+				description: 'Text alignment. `end` matches ledger/calculator right-alignment.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Custom readout markup (currency prefix, unit suffix, etc.). Only rendered when `value` is not set.' },
+			{ name: 'label', description: 'Optional leading label.' },
+		],
+		parts: [
+			{ name: 'output', description: 'Inner <output> element holding the readout.' },
+		],
+		cssProps: [
+			{ name: '--wpd-display-size' },
+			{ name: '--wpd-display-align' },
+			{ name: '--wpd-display-bg' },
+			{ name: '--wpd-display-fg' },
+			{ name: '--wpd-display-border-radius' },
+		],
+		example: html`
+			<wpd-stack gap="8">
+				<wpd-display value="1,234.00" size="xl"></wpd-display>
+				<wpd-display value="00:42.19" size="lg" align="center"></wpd-display>
+			</wpd-stack>
+		`,
+	} as const;
+
 	connectedCallback(): void {
 		super.connectedCallback?.();
 		// Live-region semantics so screen readers announce

--- a/src/ui/components/wpd-empty-state/wpd-empty-state.ts
+++ b/src/ui/components/wpd-empty-state/wpd-empty-state.ts
@@ -35,6 +35,50 @@ export class WpdEmptyState extends Component {
 	static props = [ 'icon', 'heading', 'description' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Empty state',
+		summary:
+			'Centered placeholder for "nothing here yet" UI: icon + heading + description + optional CTA. A canonical shape so empty states look consistent across the shell.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'icon',
+				type: 'string (dashicons slug)',
+				description: 'Dashicons identifier (with or without the dashicons- prefix).',
+			},
+			{
+				name: 'heading',
+				type: 'string',
+				description: 'Bold first line.',
+			},
+			{
+				name: 'description',
+				type: 'string',
+				description: 'Secondary paragraph below the heading.',
+			},
+		],
+		slots: [
+			{ name: 'cta', description: 'Call-to-action button row below the description.' },
+			{ name: '(default)', description: 'Any additional content rendered after the CTA.' },
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Heading colour.' },
+			{ name: '--wp-desktop-muted', description: 'Description colour.' },
+			{ name: '--wpd-empty-state-fg' },
+			{ name: '--wpd-empty-state-icon-color' },
+		],
+		example: html`
+			<wpd-empty-state
+				icon="admin-plugins"
+				heading="No plugins installed yet"
+				description="Install a plugin to see it here."
+			>
+				<wpd-button slot="cta" variant="primary">Browse plugins</wpd-button>
+			</wpd-empty-state>
+		`,
+	} as const;
+
 	protected render() {
 		const icon = ( this as unknown as { icon: string | null } ).icon || '';
 		const heading = ( this as unknown as { heading: string | null } ).heading || '';

--- a/src/ui/components/wpd-grid/wpd-grid.ts
+++ b/src/ui/components/wpd-grid/wpd-grid.ts
@@ -33,6 +33,52 @@ export class WpdGrid extends Component {
 	static props = [ 'columns', 'rows', 'gap', 'column-gap', 'row-gap' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Grid',
+		summary:
+			'Neutral CSS grid container. The 2-D twin of <wpd-stack>/<wpd-cluster>. No role is emitted — callers wrap in role="grid"/"radiogroup" if warranted.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'columns',
+				type: 'integer',
+				default: '1',
+				description: 'Number of equal-width columns (repeat(N, minmax(0, 1fr))).',
+			},
+			{
+				name: 'rows',
+				type: 'integer',
+				description: 'Optional fixed row count. Omit for content-driven sizing.',
+			},
+			{ name: 'gap', type: 'integer (px)', description: 'Cell spacing on both axes.' },
+			{ name: 'column-gap', type: 'integer (px)', description: 'x-axis override.' },
+			{ name: 'row-gap', type: 'integer (px)', description: 'y-axis override.' },
+		],
+		slots: [
+			{ name: '(default)', description: 'Grid children.' },
+		],
+		cssProps: [
+			{ name: '--wpd-grid-columns' },
+			{ name: '--wpd-grid-rows' },
+			{ name: '--wpd-grid-gap' },
+			{ name: '--wpd-grid-column-gap' },
+			{ name: '--wpd-grid-row-gap' },
+		],
+		example: html`
+			<wpd-grid columns="4" gap="8">
+				<wpd-button>7</wpd-button>
+				<wpd-button>8</wpd-button>
+				<wpd-button>9</wpd-button>
+				<wpd-button variant="primary">÷</wpd-button>
+				<wpd-button>4</wpd-button>
+				<wpd-button>5</wpd-button>
+				<wpd-button>6</wpd-button>
+				<wpd-button variant="primary">×</wpd-button>
+			</wpd-grid>
+		`,
+	} as const;
+
 	protected render() {
 		const columns = ( this as unknown as { columns: string | null } ).columns;
 		const rows = ( this as unknown as { rows: string | null } ).rows;

--- a/src/ui/components/wpd-icon/wpd-icon.ts
+++ b/src/ui/components/wpd-icon/wpd-icon.ts
@@ -30,6 +30,37 @@ export class WpdIcon extends Component {
 	static props = [ 'name', 'size' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Icon',
+		summary:
+			'Dashicon wrapper that inherits theme colour + sizing from its context. Accepts either the dashicon suffix ("calculator") or the full class ("dashicons-calculator"). Marked aria-hidden; wrap in a button/link with its own label for accessible use.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'name',
+				type: 'string',
+				description: 'Dashicon identifier, with or without the `dashicons-` prefix.',
+			},
+			{
+				name: 'size',
+				type: 'integer (px)',
+				default: '16',
+				description: 'Glyph size in pixels.',
+			},
+		],
+		cssProps: [
+			{ name: '--wpd-icon-size', default: '16px' },
+		],
+		example: html`
+			<wpd-cluster gap="8" align="center">
+				<wpd-icon name="admin-post"></wpd-icon>
+				<wpd-icon name="calculator" size="20"></wpd-icon>
+				<wpd-icon name="dashicons-star-filled" size="32"></wpd-icon>
+			</wpd-cluster>
+		`,
+	} as const;
+
 	protected render() {
 		const rawName = ( this as unknown as { name: string | null } ).name || '';
 		// Tolerate both `calculator` and `dashicons-calculator` — the

--- a/src/ui/components/wpd-key/wpd-key.ts
+++ b/src/ui/components/wpd-key/wpd-key.ts
@@ -73,6 +73,100 @@ export class WpdKey extends Component {
 	] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Key',
+		summary:
+			'Semantic key cap — a press-sensitive tile that fires wpd-key on click AND when the matching event.key/event.code is pressed anywhere on the document. Use for calculators, on-screen keyboards, synths, and keybinding demos.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'key',
+				type: 'string (KeyboardEvent.key)',
+				description: 'Key value to match. Case-sensitive per the spec.',
+			},
+			{
+				name: 'code',
+				type: 'string (KeyboardEvent.code)',
+				description: 'Positional key code to match. Takes priority over `key` when set.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Visible text on the cap. Falls back to slotted content.',
+			},
+			{
+				name: 'variant',
+				type: "'primary' | 'secondary' | 'ghost' | 'danger'",
+				default: 'ghost',
+				description: 'Visual weight (mirrors <wpd-button>).',
+			},
+			{
+				name: 'fill-cell',
+				type: 'boolean attribute',
+				description: 'Grow to fill the parent grid cell. Usually on for calculator layouts.',
+			},
+			{
+				name: 'hold',
+				type: 'boolean attribute',
+				description: 'Switch from a single wpd-key to paired wpd-key-down / wpd-key-up events. Useful for synths and games.',
+			},
+			{
+				name: 'modifier',
+				type: "'ctrl' | 'alt' | 'shift' | 'meta', combos joined by '+'",
+				description: 'Required modifier set for a keyboard match. Strict matching prevents bare `7` firing on Ctrl+7.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean attribute',
+				description: 'Disables click + keyboard matching.',
+			},
+		],
+		parts: [
+			{ name: 'button', description: 'Underlying <button> element.' },
+		],
+		events: [
+			{
+				name: 'wpd-key',
+				description: 'Fires once per press (click OR keydown) when `hold` is not set.',
+				detail: "{ key, code, label, source: 'click' | 'keyboard' }",
+			},
+			{
+				name: 'wpd-key-down',
+				description: 'When `hold` is set, fires on press.',
+				detail: "{ key, code, label, source: 'click' | 'keyboard' }",
+			},
+			{
+				name: 'wpd-key-up',
+				description: 'When `hold` is set, fires on release.',
+				detail: "{ key, code, label, source: 'click' | 'keyboard' }",
+			},
+		],
+		cssProps: [
+			{ name: '--wpd-key-bg' },
+			{ name: '--wpd-key-bg-hover' },
+			{ name: '--wpd-key-bg-pressed' },
+			{ name: '--wpd-key-fg' },
+			{ name: '--wpd-key-border' },
+			{ name: '--wpd-key-border-radius' },
+			{ name: '--wpd-key-padding' },
+			{ name: '--wpd-key-min-height' },
+			{ name: '--wpd-key-font-size' },
+		],
+		example: html`
+			<wpd-grid columns="4" gap="4">
+				<wpd-key key="7" label="7"></wpd-key>
+				<wpd-key key="8" label="8"></wpd-key>
+				<wpd-key key="9" label="9"></wpd-key>
+				<wpd-key key="/" label="÷" variant="primary"></wpd-key>
+				<wpd-key key="Escape" label="AC" variant="danger"></wpd-key>
+				<wpd-key key="Backspace" label="⌫"></wpd-key>
+				<wpd-key key="%" label="%"></wpd-key>
+				<wpd-key key="Enter" label="=" variant="primary"></wpd-key>
+			</wpd-grid>
+		`,
+	} as const;
+
 	private _onKeyDown: ( ( e: KeyboardEvent ) => void ) | null = null;
 	private _onKeyUp: ( ( e: KeyboardEvent ) => void ) | null = null;
 	private _keyHeldByKeyboard = false;

--- a/src/ui/components/wpd-menu/wpd-menu.ts
+++ b/src/ui/components/wpd-menu/wpd-menu.ts
@@ -25,6 +25,29 @@ import { menuItemStyles, menuStyles } from './wpd-menu.styles';
 export class WpdMenu extends Component {
 	static styles = [ menuStyles ];
 
+	static help = {
+		title: 'Menu',
+		summary:
+			'Popover menu used in window title bars and other overflow triggers. Presentation-only: the consumer owns open/close state via the `hidden` attribute and any outside-click dismissal.',
+		status: 'stable',
+		since: '0.9.0',
+		slots: [
+			{ name: '(default)', description: '<wpd-menu-item> children.' },
+		],
+		cssProps: [
+			{ name: '--wp-desktop-window-bg', description: 'Menu background.' },
+			{ name: '--wp-desktop-window-border', description: 'Menu border.' },
+			{ name: '--wp-desktop-text', description: 'Item text colour.' },
+		],
+		example: html`
+			<wpd-menu>
+				<wpd-menu-item value="new" icon="dashicons-plus">Open another window</wpd-menu-item>
+				<wpd-menu-item value="startup" role="menuitemcheckbox" checked>Open on startup</wpd-menu-item>
+				<wpd-menu-item value="close">Close window</wpd-menu-item>
+			</wpd-menu>
+		`,
+	} as const;
+
 	connectedCallback(): void {
 		super.connectedCallback();
 		this.setAttribute( 'role', 'menu' );
@@ -39,6 +62,41 @@ defineComponent( 'wpd-menu', WpdMenu );
 export class WpdMenuItem extends Component {
 	static props = [ 'icon', 'value', 'checked' ] as const;
 	static styles = [ menuItemStyles ];
+
+	static help = {
+		title: 'Menu item',
+		summary:
+			'Single row inside a <wpd-menu>. Supports three looks: plain label, left-aligned dashicon (icon="dashicons-…"), or a checkbox indicator (role="menuitemcheckbox" + checked).',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'icon',
+				type: 'string (dashicons class)',
+				description: 'Dashicons class rendered on the left. Ignored when role="menuitemcheckbox".',
+			},
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Identifier emitted in wpd-menu-item-click.detail.value.',
+			},
+			{
+				name: 'checked',
+				type: 'boolean attribute',
+				description: 'Visible check indicator. Only honoured when role="menuitemcheckbox".',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Menu item label.' },
+		],
+		events: [
+			{
+				name: 'wpd-menu-item-click',
+				description: 'Fires when the item is clicked; bubbles so the <wpd-menu> parent can delegate.',
+				detail: '{ value: string | null }',
+			},
+		],
+	} as const;
 
 	connectedCallback(): void {
 		super.connectedCallback();

--- a/src/ui/components/wpd-number-field/wpd-number-field.ts
+++ b/src/ui/components/wpd-number-field/wpd-number-field.ts
@@ -56,6 +56,65 @@ export class WpdNumberField extends Component {
 	] as const;
 	static styles = [ textFieldStyles ];
 
+	static help = {
+		title: 'Number field',
+		summary:
+			'Labelled numeric input. Wraps <wpd-text-field> semantics but forces type="number" and emits already-parsed numbers, clamping to min/max on commit.',
+		status: 'stable',
+		since: '0.11.0',
+		props: [
+			{ name: 'label', type: 'string', description: 'Visible label above the input.' },
+			{ name: 'value', type: 'number (string)', description: 'Current numeric value; two-way reflected.' },
+			{ name: 'placeholder', type: 'string', description: 'Native placeholder string.' },
+			{ name: 'disabled', type: 'boolean attribute', description: 'Disables the native input.' },
+			{ name: 'readonly', type: 'boolean attribute', description: 'Marks the input readonly.' },
+			{ name: 'name', type: 'string', description: 'Forwarded for form submission.' },
+			{ name: 'suffix', type: 'string', description: 'Unit text rendered at the right edge (e.g. "€", "px").' },
+			{ name: 'min', type: 'number (string)', description: 'Lower clamp applied on commit.' },
+			{ name: 'max', type: 'number (string)', description: 'Upper clamp applied on commit.' },
+			{
+				name: 'step',
+				type: 'number (string) | "any"',
+				default: 'any',
+				description: 'Native step granularity.',
+			},
+			{ name: 'invalid', type: 'boolean attribute', description: 'Marks the field aria-invalid.' },
+		],
+		events: [
+			{
+				name: 'wpd-input-change',
+				description: 'Fires on each keystroke when the current text parses as a finite number. Not clamped.',
+				detail: '{ value: number }',
+			},
+			{
+				name: 'wpd-input-commit',
+				description: 'Fires on blur / native change, clamped to min/max.',
+				detail: '{ value: number }',
+			},
+			{
+				name: 'wpd-submit',
+				description: 'Fires on Enter (without Shift/Alt/Meta), clamped.',
+				detail: '{ value: number }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Text colour.' },
+			{ name: '--wp-desktop-muted', description: 'Label + suffix colour.' },
+			{ name: '--wp-desktop-border', description: 'Input outline.' },
+			{ name: '--wp-desktop-window-bg', description: 'Input background.' },
+		],
+		example: html`
+			<wpd-number-field
+				label="Amount"
+				value="100"
+				min="0"
+				max="9999"
+				step="0.01"
+				suffix="€"
+			></wpd-number-field>
+		`,
+	} as const;
+
 	connectedCallback(): void {
 		super.connectedCallback();
 		ensureAutoId( this );

--- a/src/ui/components/wpd-panel/wpd-panel.ts
+++ b/src/ui/components/wpd-panel/wpd-panel.ts
@@ -33,6 +33,39 @@ export class WpdPanel extends Component {
 	static props = [ 'gap', 'padding' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Panel',
+		summary:
+			'Padded, flex-column container matching the default inset and rhythm of a native-window body. Opt-in for the OS-Settings-style padded layout.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'gap',
+				type: 'integer (px)',
+				default: '12',
+				description: 'Space between children.',
+			},
+			{
+				name: 'padding',
+				type: 'integer (px)',
+				default: '16',
+				description: 'Inset around children. Pass 0 to drop the inset.',
+			},
+		],
+		slots: [ { name: '(default)', description: 'Panel body.' } ],
+		cssProps: [
+			{ name: '--wpd-panel-gap', default: '12px' },
+			{ name: '--wpd-panel-padding', default: '16px' },
+		],
+		example: html`
+			<wpd-panel>
+				<wpd-section heading="Look">Panel section A</wpd-section>
+				<wpd-section heading="Feel">Panel section B</wpd-section>
+			</wpd-panel>
+		`,
+	} as const;
+
 	protected render() {
 		const gap = ( this as unknown as { gap: string | null } ).gap;
 		const padding = ( this as unknown as { padding: string | null } ).padding;

--- a/src/ui/components/wpd-range-field/wpd-range-field.ts
+++ b/src/ui/components/wpd-range-field/wpd-range-field.ts
@@ -12,6 +12,71 @@ export class WpdRangeField extends Component {
 	static props = [ 'label', 'value', 'min', 'max', 'step', 'suffix' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Range field',
+		summary:
+			'Label + range slider + live numeric readout. Emits wpd-range-change with an already-parsed number.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Visible label above the slider.',
+			},
+			{
+				name: 'value',
+				type: 'number (string)',
+				default: '0',
+				description: 'Current slider value.',
+			},
+			{
+				name: 'min',
+				type: 'number (string)',
+				default: '0',
+				description: 'Lower bound of the slider range.',
+			},
+			{
+				name: 'max',
+				type: 'number (string)',
+				default: '100',
+				description: 'Upper bound of the slider range.',
+			},
+			{
+				name: 'step',
+				type: 'number (string)',
+				default: '1',
+				description: 'Slider step granularity.',
+			},
+			{
+				name: 'suffix',
+				type: 'string',
+				description: 'Text appended to the readout (e.g. "px", "%").',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-range-change',
+				description: 'Fires on every slider movement.',
+				detail: '{ value: number }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Readout + label colour.' },
+			{ name: '--wp-desktop-muted', description: 'Secondary colour.' },
+		],
+		example: html`
+			<wpd-range-field
+				label="Dock size"
+				value="48"
+				min="32"
+				max="80"
+				step="4"
+				suffix="px"
+			></wpd-range-field>
+		`,
+	} as const;
+
 	protected render() {
 		const label = ( this as unknown as { label: string | null } ).label || '';
 		const value =

--- a/src/ui/components/wpd-row/wpd-row.ts
+++ b/src/ui/components/wpd-row/wpd-row.ts
@@ -40,6 +40,46 @@ export class WpdRow extends Component {
 	static props = [ 'gap', 'column-gap', 'row-gap' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Row',
+		summary:
+			'Horizontal 12-column grid row. Children declare their width via a `col="N"` attribute (1..12); a child without `col` spans the full row. The col attribute lives on the child, so any element type works.',
+		status: 'stable',
+		since: '0.12.0',
+		props: [
+			{
+				name: 'gap',
+				type: 'integer (px)',
+				default: '12',
+				description: 'Cell spacing on both axes.',
+			},
+			{
+				name: 'column-gap',
+				type: 'integer (px)',
+				description: 'x-axis override — takes precedence over `gap` for columns.',
+			},
+			{
+				name: 'row-gap',
+				type: 'integer (px)',
+				description: 'y-axis override for wrapped rows.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Children with optional `col="N"` attributes.' },
+		],
+		cssProps: [
+			{ name: '--wpd-row-gap', default: '12px' },
+			{ name: '--wpd-row-column-gap' },
+			{ name: '--wpd-row-row-gap' },
+		],
+		example: html`
+			<wpd-row>
+				<wpd-text-field col="6" label="First name"></wpd-text-field>
+				<wpd-text-field col="6" label="Last name"></wpd-text-field>
+			</wpd-row>
+		`,
+	} as const;
+
 	protected render() {
 		const gap = ( this as unknown as { gap: string | null } ).gap;
 		const cg = (

--- a/src/ui/components/wpd-section/wpd-section.ts
+++ b/src/ui/components/wpd-section/wpd-section.ts
@@ -19,6 +19,44 @@ export class WpdSection extends Component {
 	static props = [ 'heading', 'description' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Section',
+		summary:
+			'Titled panel with heading + description + a body slot. The canonical OS Settings section wrapper.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'heading',
+				type: 'string',
+				description: 'Section title, rendered as an <h3>.',
+			},
+			{
+				name: 'description',
+				type: 'string',
+				description: 'Secondary descriptive paragraph below the heading.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Section body content.' },
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Heading colour.' },
+			{ name: '--wp-desktop-muted', description: 'Description colour.' },
+		],
+		example: html`
+			<wpd-section
+				heading="Wallpaper"
+				description="Pick a backdrop for the desktop."
+			>
+				<wpd-swatch-grid>
+					<wpd-swatch value="a" preview="#b1e7b9"></wpd-swatch>
+					<wpd-swatch value="b" preview="#e7b1c9"></wpd-swatch>
+				</wpd-swatch-grid>
+			</wpd-section>
+		`,
+	} as const;
+
 	protected render() {
 		const heading = ( this as unknown as { heading: string | null } ).heading || '';
 		const description =

--- a/src/ui/components/wpd-segmented/wpd-segmented.ts
+++ b/src/ui/components/wpd-segmented/wpd-segmented.ts
@@ -17,6 +17,31 @@ export class WpdSegment extends Component {
 	static props = [ 'value' ] as const;
 	static styles = [ segmentStyles ];
 
+	static help = {
+		title: 'Segment',
+		summary:
+			'Single pill inside a <wpd-segmented> group. Value identifies it for selection; aria-checked is mirrored by the parent.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Identifier this segment contributes to the parent group selection.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Visible segment label.' },
+		],
+		events: [
+			{
+				name: 'wpd-segment-pick',
+				description: 'Internal event bubbled to the parent <wpd-segmented>. Consumers should listen for wpd-pick on the group instead.',
+				detail: '{ value: string }',
+			},
+		],
+	} as const;
+
 	protected render() {
 		this.setAttribute( 'role', 'radio' );
 		return html`
@@ -37,6 +62,48 @@ defineComponent( 'wpd-segment', WpdSegment );
 export class WpdSegmented extends Component {
 	static props = [ 'value', 'label' ] as const;
 	static styles = [ segmentedStyles ];
+
+	static help = {
+		title: 'Segmented',
+		summary:
+			'iOS-style segmented radio group. Pill-shaped bar of equal-width <wpd-segment> children where exactly one is active.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Currently selected segment value. Mirrored onto child aria-checked.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'aria-label for the radiogroup.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: '<wpd-segment value="…"> children.' },
+		],
+		events: [
+			{
+				name: 'wpd-pick',
+				description: 'Fires when the selected segment changes.',
+				detail: '{ value: string }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-window-bg', description: 'Pill background.' },
+			{ name: '--wp-desktop-text', description: 'Active label colour.' },
+			{ name: '--wp-desktop-muted', description: 'Inactive label colour.' },
+		],
+		example: html`
+			<wpd-segmented value="md" label="Dock size">
+				<wpd-segment value="sm">Small</wpd-segment>
+				<wpd-segment value="md">Medium</wpd-segment>
+				<wpd-segment value="lg">Large</wpd-segment>
+			</wpd-segmented>
+		`,
+	} as const;
 
 	connectedCallback(): void {
 		super.connectedCallback();

--- a/src/ui/components/wpd-select/wpd-select.ts
+++ b/src/ui/components/wpd-select/wpd-select.ts
@@ -42,6 +42,29 @@ export class WpdOption extends Component {
 	static props = [ 'value', 'disabled' ] as const;
 	static styles = [ optionStyles ];
 
+	static help = {
+		title: 'Option',
+		summary:
+			'Opaque data carrier for <wpd-select>. Carries its identifier in `value` and its visible label in textContent. Not rendered directly — the parent reads these and builds a native <select>.',
+		status: 'stable',
+		since: '0.11.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Option identifier read by the parent <wpd-select>.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean attribute',
+				description: 'Renders the option disabled in the parent <select>.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Label text read from textContent.' },
+		],
+	} as const;
+
 	protected render() {
 		// Intentionally empty — the option is a data carrier. Its
 		// label lives in its light-DOM textContent, which the parent
@@ -60,6 +83,62 @@ export class WpdSelect extends Component {
 		'name',
 	] as const;
 	static styles = [ selectStyles ];
+
+	static help = {
+		title: 'Select',
+		summary:
+			'Dropdown picker that wraps a native <select>. Mirrors the <wpd-segmented> contract (set value, listen for wpd-pick) so callers can swap tag names when a list outgrows a pill bar.',
+		status: 'stable',
+		since: '0.11.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Currently selected option value.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Visible label rendered above the select and forwarded to the native control as aria-label.',
+			},
+			{
+				name: 'placeholder',
+				type: 'string',
+				description: 'Disabled leading option shown when no value is set.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean attribute',
+				description: 'Disables the native select and dims the chrome.',
+			},
+			{
+				name: 'name',
+				type: 'string',
+				description: 'Forwarded to the native <select name=…> for form submission.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: '<wpd-option value="…"> children.' },
+		],
+		events: [
+			{
+				name: 'wpd-pick',
+				description: 'Fires when the user picks a new option.',
+				detail: '{ value: string }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Label + value colour.' },
+			{ name: '--wp-desktop-muted', description: 'Placeholder + chevron colour.' },
+		],
+		example: html`
+			<wpd-select value="eur" label="Currency">
+				<wpd-option value="eur">Euro</wpd-option>
+				<wpd-option value="usd">US Dollar</wpd-option>
+				<wpd-option value="jpy">Japanese Yen</wpd-option>
+			</wpd-select>
+		`,
+	} as const;
 
 	/**
 	 * Declarative item-list setter. Replaces the existing

--- a/src/ui/components/wpd-stack/wpd-stack.ts
+++ b/src/ui/components/wpd-stack/wpd-stack.ts
@@ -29,6 +29,41 @@ export class WpdStack extends Component {
 	static props = [ 'gap', 'align' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Stack',
+		summary:
+			'Vertical flex layout with a gap — the "stack" primitive every design system eventually invents. Use it instead of hand-rolling display:flex; flex-direction:column.',
+		status: 'stable',
+		since: '0.10.0',
+		props: [
+			{
+				name: 'gap',
+				type: 'integer (px)',
+				default: '12',
+				description: 'Space between children.',
+			},
+			{
+				name: 'align',
+				type: "'start' | 'center' | 'end' | 'stretch'",
+				default: 'stretch',
+				description: 'Cross-axis alignment (align-items).',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Stacked children.' },
+		],
+		cssProps: [
+			{ name: '--wpd-stack-gap', default: '12px' },
+			{ name: '--wpd-stack-align', default: 'stretch' },
+		],
+		example: html`
+			<wpd-stack gap="12">
+				<wpd-section heading="Foo">First</wpd-section>
+				<wpd-section heading="Bar">Second</wpd-section>
+			</wpd-stack>
+		`,
+	} as const;
+
 	protected render() {
 		const gap = ( this as unknown as { gap: string | null } ).gap;
 		const align = ( this as unknown as { align: string | null } ).align;

--- a/src/ui/components/wpd-swatch-grid/wpd-swatch-grid.ts
+++ b/src/ui/components/wpd-swatch-grid/wpd-swatch-grid.ts
@@ -11,6 +11,44 @@ export class WpdSwatchGrid extends Component {
 	static props = [ 'label', 'columns', 'mode' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Swatch grid',
+		summary:
+			'Flex grid container for <wpd-swatch> children. Emits radiogroup semantics so screen readers announce the tiles as a unit.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'label',
+				type: 'string',
+				description: 'aria-label describing the group (e.g. "Accent color").',
+			},
+			{
+				name: 'columns',
+				type: 'CSS grid track template',
+				description: 'Overrides the default column track via --wpd-swatch-grid-cols.',
+			},
+			{
+				name: 'mode',
+				type: 'string',
+				description: 'Optional rendering variant forwarded to child swatches.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: '<wpd-swatch> children.' },
+		],
+		cssProps: [
+			{ name: '--wpd-swatch-grid-cols', description: 'Grid column template.' },
+		],
+		example: html`
+			<wpd-swatch-grid label="Wallpaper">
+				<wpd-swatch value="a" preview="linear-gradient(135deg,#f093fb,#f5576c)"></wpd-swatch>
+				<wpd-swatch value="b" preview="linear-gradient(135deg,#4facfe,#00f2fe)"></wpd-swatch>
+				<wpd-swatch value="c" preview="linear-gradient(135deg,#43e97b,#38f9d7)"></wpd-swatch>
+			</wpd-swatch-grid>
+		`,
+	} as const;
+
 	protected render() {
 		const label = ( this as unknown as { label: string | null } ).label || '';
 		const cols =

--- a/src/ui/components/wpd-swatch/wpd-swatch.ts
+++ b/src/ui/components/wpd-swatch/wpd-swatch.ts
@@ -14,6 +14,63 @@ export class WpdSwatch extends Component {
 	static props = [ 'value', 'label', 'selected', 'preview', 'size', 'variant' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Swatch',
+		summary:
+			'Selectable color/wallpaper tile. Renders as an aria-pressed button with a background driven by the preview attribute.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Identifier emitted on the wpd-pick event when the swatch is clicked.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'aria-label + title for the button.',
+			},
+			{
+				name: 'selected',
+				type: 'boolean attribute',
+				description: 'Marks the swatch as the active choice within a swatch-grid.',
+			},
+			{
+				name: 'preview',
+				type: 'CSS background value',
+				description: 'Raw CSS background (color, gradient, url()) painted on the tile.',
+			},
+			{
+				name: 'size',
+				type: 'string',
+				description: 'Visual size hint (e.g. sm, md, lg). Consumed by the stylesheet.',
+			},
+			{
+				name: 'variant',
+				type: 'string',
+				description: 'Optional visual variant (e.g. color vs wallpaper).',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Optional overlay content rendered inside the tile.' },
+		],
+		events: [
+			{
+				name: 'wpd-pick',
+				description: 'Fires when the swatch is clicked.',
+				detail: '{ value: string }',
+			},
+		],
+		example: html`
+			<wpd-swatch-grid label="Accent">
+				<wpd-swatch value="red" preview="#ef4444" label="Red" selected></wpd-swatch>
+				<wpd-swatch value="blue" preview="#3b82f6" label="Blue"></wpd-swatch>
+				<wpd-swatch value="green" preview="#10b981" label="Green"></wpd-swatch>
+			</wpd-swatch-grid>
+		`,
+	} as const;
+
 	protected render() {
 		const selected =
 			( this as unknown as { selected: string | null } ).selected !== null;

--- a/src/ui/components/wpd-tab-chip/wpd-tab-chip.ts
+++ b/src/ui/components/wpd-tab-chip/wpd-tab-chip.ts
@@ -19,6 +19,30 @@ export class WpdTabChip extends Component {
 	static props = [ 'variant' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Tab chip',
+		summary:
+			'Small action button dropped inside an external sub-tab. `detach` lifts with an accent wash on hover; `close` uses a red destructive wash. Click bubbles as a native click — consumers read `variant` if they need to distinguish.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'variant',
+				type: "'detach' | 'close'",
+				description: 'Selects the built-in SVG icon and the hover wash colour.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Optional custom icon markup when `variant` is omitted.' },
+		],
+		example: html`
+			<wpd-cluster gap="4">
+				<wpd-tab-chip variant="detach"></wpd-tab-chip>
+				<wpd-tab-chip variant="close"></wpd-tab-chip>
+			</wpd-cluster>
+		`,
+	} as const;
+
 	protected render() {
 		const variant =
 			( this as unknown as { variant: string | null } ).variant || '';

--- a/src/ui/components/wpd-tabs/wpd-tabs.ts
+++ b/src/ui/components/wpd-tabs/wpd-tabs.ts
@@ -37,6 +37,31 @@ export class WpdTab extends Component {
 	static props = [ 'value' ] as const;
 	static styles = [ tabStyles ];
 
+	static help = {
+		title: 'Tab',
+		summary:
+			'Single tab inside a <wpd-tabs> strip. Carries its identifier via `value`; aria-selected + tabindex are mirrored by the parent.',
+		status: 'stable',
+		since: '0.7.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Identifier the tab contributes to the parent strip selection.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Visible tab label.' },
+		],
+		events: [
+			{
+				name: 'wpd-tab-pick',
+				description: 'Internal event bubbled to the parent <wpd-tabs>. Consumers should listen for wpd-tab-change on the strip instead.',
+				detail: '{ value: string | null }',
+			},
+		],
+	} as const;
+
 	protected render() {
 		this.setAttribute( 'role', 'tab' );
 		return html`
@@ -57,6 +82,49 @@ defineComponent( 'wpd-tab', WpdTab );
 export class WpdTabs extends Component {
 	static props = [ 'value', 'label' ] as const;
 	static styles = [ tabsStyles ];
+
+	static help = {
+		title: 'Tabs',
+		summary:
+			'Underline-accent tab strip. Pair with sibling <wpd-tabpanel for="…"> elements and the strip auto-toggles their hidden attribute on selection.',
+		status: 'stable',
+		since: '0.7.0',
+		props: [
+			{
+				name: 'value',
+				type: 'string',
+				description: 'Currently active tab value. Mirrored to child <wpd-tab> aria-selected.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'aria-label for the tablist — describe the tab group for assistive tech.',
+			},
+		],
+		slots: [
+			{
+				name: '(default)',
+				description: '<wpd-tab value="…"> children forming the strip.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-tab-change',
+				description: 'Fires when the active tab changes.',
+				detail: '{ value: string }',
+			},
+		],
+		example: html`
+			<wpd-tabs value="one" label="Demo tabs">
+				<wpd-tab value="one">One</wpd-tab>
+				<wpd-tab value="two">Two</wpd-tab>
+				<wpd-tab value="three">Three</wpd-tab>
+			</wpd-tabs>
+			<wpd-tabpanel for="one">First panel.</wpd-tabpanel>
+			<wpd-tabpanel for="two">Second panel.</wpd-tabpanel>
+			<wpd-tabpanel for="three">Third panel.</wpd-tabpanel>
+		`,
+	} as const;
 
 	connectedCallback(): void {
 		super.connectedCallback();
@@ -157,6 +225,24 @@ defineComponent( 'wpd-tabs', WpdTabs );
 export class WpdTabPanel extends Component {
 	static props = [ 'for' ] as const;
 	static styles = [ tabPanelStyles ];
+
+	static help = {
+		title: 'Tab panel',
+		summary:
+			'Auto-managed panel paired with a sibling <wpd-tabs>. Declares which tab it belongs to via `for="<tab-value>"`; the parent strip toggles `hidden` whenever the active tab changes. role="tabpanel" and tabindex="0" are set automatically.',
+		status: 'stable',
+		since: '0.11.0',
+		props: [
+			{
+				name: 'for',
+				type: 'string',
+				description: 'Matches the `value` of the owning <wpd-tab>. Panel is shown when its parent tabs strip is on that value.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Panel body content.' },
+		],
+	} as const;
 	// Shadow DOM — the render target for this component is its
 	// own shadow root, which holds a single `<slot>` that projects
 	// whatever the caller placed between the `<wpd-tabpanel>` open

--- a/src/ui/components/wpd-text-field/wpd-text-field.ts
+++ b/src/ui/components/wpd-text-field/wpd-text-field.ts
@@ -58,6 +58,77 @@ export class WpdTextField extends Component {
 	] as const;
 	static styles = [ textFieldStyles ];
 
+	static help = {
+		title: 'Text field',
+		summary:
+			'Labelled text input primitive. Two-way reflects `value`, emits wpd-input-change per keystroke, wpd-input-commit on blur/change, and wpd-submit on Enter. Optional password reveal toggle.',
+		status: 'stable',
+		since: '0.11.0',
+		props: [
+			{ name: 'label', type: 'string', description: 'Visible label above the input.' },
+			{ name: 'value', type: 'string', description: 'Current input value; reflected two-way.' },
+			{ name: 'placeholder', type: 'string', description: 'Native placeholder string.' },
+			{ name: 'disabled', type: 'boolean attribute', description: 'Disables the native input.' },
+			{ name: 'readonly', type: 'boolean attribute', description: 'Marks the input readonly.' },
+			{
+				name: 'autocomplete',
+				type: 'string',
+				default: 'off',
+				description: 'Forwarded to the native input autocomplete attribute.',
+			},
+			{
+				name: 'type',
+				type: 'string',
+				default: 'text',
+				description: 'Native input type (text, password, email, search, tel, url).',
+			},
+			{ name: 'maxlength', type: 'integer (string)', description: 'Native maxlength.' },
+			{ name: 'minlength', type: 'integer (string)', description: 'Native minlength.' },
+			{ name: 'pattern', type: 'regex string', description: 'Native validation pattern.' },
+			{ name: 'name', type: 'string', description: 'Forwarded to the native input for form submission.' },
+			{ name: 'suffix', type: 'string', description: 'Text rendered inside the right edge of the input row.' },
+			{
+				name: 'invalid',
+				type: 'boolean attribute',
+				description: 'Marks the field aria-invalid and applies the error style.',
+			},
+			{
+				name: 'reveal',
+				type: 'boolean attribute',
+				description: 'On type="password" fields, adds an eye-icon toggle that flips the input between hidden and visible text.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-input-change',
+				description: 'Fires on every input keystroke.',
+				detail: '{ value: string }',
+			},
+			{
+				name: 'wpd-input-commit',
+				description: 'Fires on the native change event (blur / Enter).',
+				detail: '{ value: string }',
+			},
+			{
+				name: 'wpd-submit',
+				description: 'Fires when the user presses Enter (without Shift/Alt/Meta).',
+				detail: '{ value: string }',
+			},
+		],
+		cssProps: [
+			{ name: '--wp-desktop-text', description: 'Text colour.' },
+			{ name: '--wp-desktop-muted', description: 'Label + suffix colour.' },
+			{ name: '--wp-desktop-border', description: 'Input outline.' },
+			{ name: '--wp-desktop-window-bg', description: 'Input background.' },
+		],
+		example: html`
+			<wpd-stack gap="8">
+				<wpd-text-field label="Note title" value="Untitled" placeholder="Name this note"></wpd-text-field>
+				<wpd-text-field type="password" reveal label="API key"></wpd-text-field>
+			</wpd-stack>
+		`,
+	} as const;
+
 	/** Whether the password text is currently visible. Internal state, not reflected to an attribute. */
 	private _revealed = false;
 

--- a/src/ui/components/wpd-toast/wpd-toast.ts
+++ b/src/ui/components/wpd-toast/wpd-toast.ts
@@ -19,6 +19,26 @@ import { containerStyles, toastStyles } from './wpd-toast.styles';
 export class WpdToastContainer extends Component {
 	static styles = [ containerStyles ];
 
+	static help = {
+		title: 'Toast container',
+		summary:
+			'Singleton stack beneath <body> that hosts transient <wpd-toast> notifications in the top-right. Created lazily by showToast(); authors rarely place one themselves.',
+		status: 'stable',
+		since: '0.9.0',
+		slots: [
+			{ name: '(default)', description: '<wpd-toast> children, stacked vertically.' },
+		],
+		cssProps: [
+			{ name: '--wp-desktop-z-fullscreen', description: 'z-index base — toasts sit above fullscreen windows.' },
+		],
+		example: html`
+			<wpd-toast-container>
+				<wpd-toast state="in">Settings saved.</wpd-toast>
+				<wpd-toast state="in" action="Undo">Theme changed.</wpd-toast>
+			</wpd-toast-container>
+		`,
+	} as const;
+
 	connectedCallback(): void {
 		super.connectedCallback();
 		this.setAttribute( 'aria-live', 'polite' );
@@ -33,6 +53,39 @@ defineComponent( 'wpd-toast-container', WpdToastContainer );
 export class WpdToast extends Component {
 	static props = [ 'action', 'state' ] as const;
 	static styles = [ toastStyles ];
+
+	static help = {
+		title: 'Toast',
+		summary:
+			'Single transient notification. Message is slotted; fade-in / fade-out is CSS-driven by flipping the state attribute between "in" and "out". Usually created via the showToast() helper rather than authored by hand.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'action',
+				type: 'string',
+				description: 'Optional action button label. When set, a button renders on the right and emits wpd-toast-action on click.',
+			},
+			{
+				name: 'state',
+				type: "'in' | 'out'",
+				description: 'Drives the CSS fade transition. Set to "in" when rendered, flip to "out" before removal.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Message text.' },
+		],
+		events: [
+			{
+				name: 'wpd-toast-action',
+				description: 'Fires when the action button is clicked.',
+				detail: '{}',
+			},
+		],
+		example: html`
+			<wpd-toast state="in" action="Undo">Post moved to trash.</wpd-toast>
+		`,
+	} as const;
 
 	connectedCallback(): void {
 		super.connectedCallback();

--- a/src/ui/components/wpd-window-button/wpd-window-button.ts
+++ b/src/ui/components/wpd-window-button/wpd-window-button.ts
@@ -54,6 +54,50 @@ export class WpdWindowButton extends Component {
 	static props = [ 'icon', 'active', 'danger' ] as const;
 	static styles = [ styles ];
 
+	static help = {
+		title: 'Window button',
+		summary:
+			'Chrome button used in native-window title bars. Built-in icons cover the standard controls (minimize, maximize, fullscreen, detach, close, menu). Focused/unfocused coloring is driven by --wpd-btn-* CSS custom properties the window shell owns.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'icon',
+				type: "'minimize' | 'maximize' | 'fullscreen' | 'fullscreen-exit' | 'detach' | 'close' | 'menu'",
+				description: 'Which built-in inline SVG to paint. Omit to supply your own via the slot.',
+			},
+			{
+				name: 'active',
+				type: 'boolean attribute',
+				description: 'Applies the pressed-down look (used e.g. while a menu it triggers is open).',
+			},
+			{
+				name: 'danger',
+				type: 'boolean attribute',
+				description: 'Swaps the hover wash to red — used by the close button.',
+			},
+		],
+		slots: [
+			{ name: '(default)', description: 'Optional custom icon markup (inline SVG) when `icon` is omitted.' },
+		],
+		cssProps: [
+			{ name: '--wpd-btn-color', description: 'Resting foreground.' },
+			{ name: '--wpd-btn-color-hover', description: 'Hover foreground.' },
+			{ name: '--wpd-btn-bg-hover', description: 'Hover background wash.' },
+			{ name: '--wpd-btn-bg-active', description: 'Pressed background.' },
+			{ name: '--wpd-btn-danger-hover', description: 'Hover background for danger variant.' },
+			{ name: '--wpd-btn-outline', description: 'Focus outline colour.' },
+		],
+		example: html`
+			<wpd-cluster gap="2">
+				<wpd-window-button icon="minimize"></wpd-window-button>
+				<wpd-window-button icon="maximize"></wpd-window-button>
+				<wpd-window-button icon="menu"></wpd-window-button>
+				<wpd-window-button icon="close" danger></wpd-window-button>
+			</wpd-cluster>
+		`,
+	} as const;
+
 	protected render() {
 		const iconKey =
 			( this as unknown as { icon: string | null } ).icon || '';

--- a/src/ui/core/component.ts
+++ b/src/ui/core/component.ts
@@ -28,6 +28,7 @@
 
 import { render, type TemplateResult } from './html';
 import type { StyleDef } from './css';
+import type { WpdHelp } from './help';
 
 /**
  * Prop-accessor declaration. For now every prop is a string at the
@@ -60,6 +61,13 @@ export abstract class Component extends HTMLElement {
 	 * slotting or isolation (rare).
 	 */
 	static shadow = true;
+
+	/**
+	 * Optional in-product help descriptor. Consumed by the Help tab
+	 * in OS Settings — components without one fall back to a minimal
+	 * rendering built from `static props`. See {@link WpdHelp}.
+	 */
+	static help?: WpdHelp;
 
 	static get observedAttributes(): string[] {
 		return ( this.props as readonly string[] ).map( kebab );

--- a/src/ui/core/help.ts
+++ b/src/ui/core/help.ts
@@ -1,0 +1,80 @@
+/**
+ * wpd-ui — in-product component help descriptors.
+ *
+ * Every `<wpd-*>` component may declare a `static help: WpdHelp`
+ * descriptor on its class. Those descriptors power the Help tab in
+ * OS Settings (developer-facing, admin-gated) so plugin authors can
+ * browse the component library without leaving WordPress.
+ *
+ * Keeping help metadata on the class — rather than in a separate
+ * docs file — means:
+ *
+ *   - It ships with the component at runtime (no build step).
+ *   - It is type-checked against the real component.
+ *   - It cannot drift silently: renaming a prop forces a descriptor
+ *     update if the help table asserts on it.
+ *
+ * Components without a descriptor still appear in the Help tab with
+ * a fallback rendering built from `static props`; the descriptor is
+ * how authors enrich that baseline.
+ *
+ * @since 0.16.0
+ */
+
+import type { TemplateResult } from './html';
+
+/** Stability contract label, borrowed from `docs/hooks-reference.md`. */
+export type WpdHelpStatus = 'stable' | 'experimental' | 'planned';
+
+export interface WpdHelpProp {
+	name: string;
+	type?: string;
+	default?: string;
+	description?: string;
+}
+
+export interface WpdHelpSlot {
+	/** Slot name; use `'(default)'` for the unnamed default slot. */
+	name: string;
+	description?: string;
+}
+
+export interface WpdHelpPart {
+	name: string;
+	description?: string;
+}
+
+export interface WpdHelpCssProp {
+	name: string;
+	description?: string;
+	default?: string;
+}
+
+export interface WpdHelpEvent {
+	name: string;
+	description?: string;
+	/** One-line shape hint for the event's `detail` payload. */
+	detail?: string;
+}
+
+export interface WpdHelp {
+	/** Human-readable title — e.g., `'Button'`. Defaults to the tag name. */
+	title?: string;
+	/** One-paragraph summary. Keep short; examples carry the nuance. */
+	summary?: string;
+	/** Stability label. Defaults to `'stable'` when omitted. */
+	status?: WpdHelpStatus;
+	/** Semver the component first shipped in (e.g. `'0.9.0'`). */
+	since?: string;
+	props?: readonly WpdHelpProp[];
+	slots?: readonly WpdHelpSlot[];
+	parts?: readonly WpdHelpPart[];
+	cssProps?: readonly WpdHelpCssProp[];
+	events?: readonly WpdHelpEvent[];
+	/**
+	 * Live example rendered inside the Help panel. Must be a plain
+	 * `html\`\`` template — the panel renders it into an isolated
+	 * container so the example can exercise the real component.
+	 */
+	example?: TemplateResult;
+}

--- a/src/ui/core/index.ts
+++ b/src/ui/core/index.ts
@@ -14,3 +14,12 @@ export type { TemplateResult } from './html';
 export { css } from './css';
 export type { StyleDef } from './css';
 export { computeAutoId, ensureAutoId } from './auto-id';
+export type {
+	WpdHelp,
+	WpdHelpCssProp,
+	WpdHelpEvent,
+	WpdHelpPart,
+	WpdHelpProp,
+	WpdHelpSlot,
+	WpdHelpStatus,
+} from './help';


### PR DESCRIPTION
This just adds the current available web components to use. We can move it in the future to a different place.
<img width="1004" height="943" alt="image" src="https://github.com/user-attachments/assets/abfe674b-45aa-44cc-9865-852c0e7bf044" />

