### PR TITLE
docs: split 'How to run' into quick install vs development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,15 @@ Leave it running in a separate terminal; refresh the browser after each save. Se
 
 You need a running WordPress to load the plugin into. Pick whichever is easier.
 
-**Clone `wordpress-develop` and symlink** — best dev loop: `npm run dev` rebuilds on save, a browser refresh picks it up.
+##### Studio, wp-env, or a hosted WP
+
+Run `npm run package` to build a zip from `HEAD` (with correct 0644 / 0755 permissions), then follow the [Quick install](#quick-install) steps 2–3 to upload and activate it. Re-package and re-upload after each change.
+
+> If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
+
+##### Clone `wordpress-develop` and symlink
+
+Gives you the full dev loop: `npm run dev` rebuilds on save, a browser refresh picks it up.
 
 ```bash
 # clone Core's Docker-based dev host alongside this repo
@@ -210,11 +218,7 @@ Site: **http://localhost:8889**
 Admin: **http://localhost:8889/wp-admin/**
 Credentials: `admin` / `password`
 
-Stop the environment with `npm run env:stop` (from the `wordpress-develop` directory).
-
-**Studio, wp-env, or a hosted WP** — run `npm run package` to build a zip from `HEAD` (with correct 0644 / 0755 permissions), then upload it the same way as the [Quick install](#quick-install) flow. Re-package and re-upload after each change. If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
-
-Then activate as in the [Quick install](#quick-install) steps 2–3.
+Stop the environment with `npm run env:stop` (from the `wordpress-develop` directory). Activate the plugin per [Quick install](#quick-install) steps 2–3.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ You need a running WordPress to load the plugin into. Pick whichever is easier.
 
 Run `npm run package` to build a zip from `HEAD` (with correct 0644 / 0755 permissions), then follow the [Quick install](#quick-install) steps 2–3 to upload and activate it. Re-package and re-upload after each change.
 
-> If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
+> If you changed source, run `npm run build` before `npm run package` — the Vite output is gitignored, and `bin/package.sh` splices the built files into the zip from your working tree.
 
 ##### Clone `wordpress-develop` and symlink
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,12 @@ Leave it running in a separate terminal; refresh the browser after each save. Se
 
 #### 3. Load into a local WordPress
 
-Clone Core's Docker-based dev host alongside this repo and symlink the plugin in:
+You need a running WordPress to load the plugin into. Pick whichever is easier.
+
+**Clone `wordpress-develop` and symlink** — best dev loop: `npm run dev` rebuilds on save, a browser refresh picks it up.
 
 ```bash
+# clone Core's Docker-based dev host alongside this repo
 git clone https://github.com/WordPress/wordpress-develop.git
 cd wordpress-develop
 npm install
@@ -209,9 +212,9 @@ Credentials: `admin` / `password`
 
 Stop the environment with `npm run env:stop` (from the `wordpress-develop` directory).
 
-Then activate as in the [Quick install](#quick-install) steps 2–3.
+**Studio, wp-env, or a hosted WP** — run `npm run package` to build a zip from `HEAD` (with correct 0644 / 0755 permissions), then upload it the same way as the [Quick install](#quick-install) flow. Re-package and re-upload after each change. If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
 
-> Prefer to test against a hosted WP instead? Run `npm run package` to build a zip from `HEAD` (with correct 0644 / 0755 permissions) and upload it the same way as the Quick install path. If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
+Then activate as in the [Quick install](#quick-install) steps 2–3.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,12 @@ You need a running WordPress for the plugin to load into. Pick whichever is easi
 
 Works with any WordPress you already have: [Studio by WordPress.com](https://developer.wordpress.com/studio/), [`wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/), or a hosted site.
 
-Package the repo as a plugin zip:
+Grab the latest zip from GitHub Releases:
+
+- **Latest** — [`wp-desktop-mode.zip`](https://github.com/WordPress/desktop-mode/releases/latest/download/wp-desktop-mode.zip) (always points at the most recent release)
+- **All releases** — [github.com/WordPress/desktop-mode/releases](https://github.com/WordPress/desktop-mode/releases)
+
+Or package the repo yourself from a local clone:
 
 ```bash
 npm run package

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ Zero Core patches. Every feature is wired through public WordPress hooks.
 - [Still ahead](#still-ahead)
 - [Repository layout](#repository-layout)
 - [How to run it](#how-to-run-it)
-  - [1. Install dependencies](#1-install-dependencies)
-  - [2. Build the TypeScript bundle](#2-build-the-typescript-bundle)
-  - [3. Get it running in WordPress](#3-get-it-running-in-wordpress)
-  - [4. Activate & toggle](#4-activate--toggle)
+  - [Quick install](#quick-install)
+  - [Development setup](#development-setup)
 - [Requirements](#requirements)
 - [For plugin authors](#for-plugin-authors)
 - [License](#license)
@@ -147,13 +145,25 @@ See [`docs/architecture.md`](./docs/architecture.md) for how the pieces fit toge
 
 ## How to run it
 
-### 1. Install dependencies
+### Quick install
+
+Just want to try it? Grab the pre-built zip and upload it to any WordPress — [Studio by WordPress.com](https://developer.wordpress.com/studio/), [`wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/), or a hosted site. No Node, no build step.
+
+1. Download [`wp-desktop-mode.zip`](https://github.com/WordPress/desktop-mode/releases/latest/download/wp-desktop-mode.zip) from the latest release (or pick a specific version from the [releases page](https://github.com/WordPress/desktop-mode/releases)).
+2. In WP Admin: **Plugins → Add New → Upload Plugin**, choose the zip, and activate.
+3. Click the **desktop** icon in the admin bar's top-right corner. The admin reloads inside the desktop shell. Click the same icon again to return to classic admin.
+
+### Development setup
+
+For hacking on the plugin: clone the repo, run the build in watch mode, and load it into a local WordPress via symlink so every save is one browser refresh away.
+
+#### 1. Install dependencies
 
 ```bash
 npm install
 ```
 
-### 2. Build the TypeScript bundle
+#### 2. Build the TypeScript bundle
 
 The plugin uses **[Vite](https://vitejs.dev/)** in library mode. esbuild handles transpile and minify, so builds finish in ~70 ms per bundle.
 
@@ -176,37 +186,11 @@ npm run dev
 
 Leave it running in a separate terminal; refresh the browser after each save. Set `define( 'SCRIPT_DEBUG', true )` in `wp-config.php` so WordPress picks up the unminified bundle during development.
 
-### 3. Get it running in WordPress
+#### 3. Load into a local WordPress
 
-You need a running WordPress for the plugin to load into. Pick whichever is easier.
-
-#### Option A — Install as a zip (easiest)
-
-Works with any WordPress you already have: [Studio by WordPress.com](https://developer.wordpress.com/studio/), [`wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/), or a hosted site.
-
-Grab the latest zip from GitHub Releases:
-
-- **Latest** — [`wp-desktop-mode.zip`](https://github.com/WordPress/desktop-mode/releases/latest/download/wp-desktop-mode.zip) (always points at the most recent release)
-- **All releases** — [github.com/WordPress/desktop-mode/releases](https://github.com/WordPress/desktop-mode/releases)
-
-Or package the repo yourself from a local clone:
+Clone Core's Docker-based dev host alongside this repo and symlink the plugin in:
 
 ```bash
-npm run package
-```
-
-> Packages `HEAD` with correct file/dir permissions (0644 / 0755) so WordPress can read the files after extraction. If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
-
-Then in WP Admin go to **Plugins → Add New → Upload Plugin**, choose `wp-desktop-mode.zip`, and activate. Skip ahead to [§4 Activate & toggle](#4-activate--toggle).
-
-> Good for trying it out. Not ideal for active development — every change requires a rebuild + re-upload.
-
-#### Option B — Clone `wordpress-develop` (for active development)
-
-This gives you the full dev loop: `npm run dev` in the plugin rebuilds on save, and a browser refresh picks it up.
-
-```bash
-# clone Core's Docker-based dev host alongside this repo
 git clone https://github.com/WordPress/wordpress-develop.git
 cd wordpress-develop
 npm install
@@ -225,14 +209,9 @@ Credentials: `admin` / `password`
 
 Stop the environment with `npm run env:stop` (from the `wordpress-develop` directory).
 
-### 4. Activate & toggle
+Then activate as in the [Quick install](#quick-install) steps 2–3.
 
-1. Log in at `/wp-admin`.
-2. **Plugins → WP Desktop Mode → Activate**.
-3. Click the **desktop** icon in the admin bar's top-right corner.
-4. The admin reloads inside the desktop shell.
-
-Click the same icon again to return to classic admin.
+> Prefer to test against a hosted WP instead? Run `npm run package` to build a zip from `HEAD` (with correct 0644 / 0755 permissions) and upload it the same way as the Quick install path. If you changed source, run `npm run build` and commit the regenerated `assets/js/desktop*.js` first — they're tracked.
 
 ---
 


### PR DESCRIPTION
## Summary

- Collapse the four-step \"How to run\" into two paths: a three-step **Quick install** (download zip → upload in WP Admin → toggle) and a **Development setup** for contributors (clone, build, symlink into \`wordpress-develop\`).
- Quick install links the stable \`/releases/latest/download/wp-desktop-mode.zip\` asset plus the releases index.
- Drop the Option A / Option B split — the zip path is now the default, and \`npm run package\` lives as a footnote under Development setup for devs who want to test a local build against a hosted WP.
- Update the TOC to match.

## Test plan

- [x] Render README on GitHub and confirm the Quick install zip link and releases-page link resolve.
- [x] Confirm the Quick install flow reads end-to-end: download → Upload Plugin → activate → toggle.
- [x] Confirm the Development setup still has the full symlink-into-wordpress-develop path.
- [x] TOC anchors (\`#quick-install\`, \`#development-setup\`) jump to the right headings.