### PR TITLE
Feat/unify command palettes

### DIFF
--- a/assets/css/ai-assistant.css
+++ b/assets/css/ai-assistant.css
@@ -679,6 +679,23 @@
 	border-color: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 25%, rgba( 0, 0, 0, 0.08 ) );
 }
 
+/*
+ * When keyboard navigation is driving selection, suppress the :hover
+ * style on rows. Without this, arrowing the cursor past the row that
+ * happens to sit under the mouse pointer paints BOTH rows as active
+ * — the keyboard target from `.is-selected` and the pointer target
+ * from `:hover`. The JS toggles this class on the list container on
+ * ArrowUp/Down and clears it on the next real `mousemove`.
+ */
+.wp-desktop-ai__cmd-list--kb-nav .wp-desktop-ai__cmd-item:hover {
+	background: transparent;
+	border-color: transparent;
+}
+.wp-desktop-ai__cmd-list--kb-nav .wp-desktop-ai__cmd-item.is-selected:hover {
+	background: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 8%, #fff );
+	border-color: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 25%, rgba( 0, 0, 0, 0.08 ) );
+}
+
 .wp-desktop-ai__cmd-item:focus-visible {
 	outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
 	outline-offset: 2px;

--- a/assets/css/ai-assistant.css
+++ b/assets/css/ai-assistant.css
@@ -673,6 +673,17 @@
 	transition: background 0.1s, border-color 0.1s;
 }
 
+/*
+ * Single-line rows (no `.wp-desktop-ai__cmd-desc` child) need the
+ * icon + label baseline-centered instead of top-aligned, otherwise
+ * the label floats to the top of the taller icon tile and reads as
+ * misaligned. `:has()` is widely supported in evergreen browsers the
+ * desktop shell already targets.
+ */
+.wp-desktop-ai__cmd-item:not(:has(.wp-desktop-ai__cmd-desc)) {
+	align-items: center;
+}
+
 .wp-desktop-ai__cmd-item:hover,
 .wp-desktop-ai__cmd-item.is-selected {
 	background: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 8%, #fff );
@@ -706,13 +717,35 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 28px;
-	height: 28px;
-	font-size: 16px;
+	width: 36px;
+	height: 36px;
+	font-size: 20px;
 	color: var( --wp-admin-theme-color, #2271b1 );
 	background: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 10%, #fff );
-	border-radius: 6px;
-	margin-top: 1px;
+	border-radius: 7px;
+}
+
+/*
+ * Dashicons ship at a 20px baseline; the tile was scaled up but
+ * dashicons glyphs need explicit sizing to follow.
+ */
+.wp-desktop-ai__cmd-icon.dashicons {
+	font-size: 22px;
+	width: 36px;
+	height: 36px;
+	line-height: 36px;
+}
+
+/*
+ * Raw-SVG icon slot (command bridge forwards rendered
+ * `@wordpress/icons` markup). Constrain the inline SVG so it sits
+ * centered inside the tile regardless of the viewBox the source icon
+ * shipped with.
+ */
+.wp-desktop-ai__cmd-icon--svg svg {
+	width: 24px;
+	height: 24px;
+	fill: currentColor;
 }
 
 .wp-desktop-ai__cmd-body {

--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -282,3 +282,16 @@ html.wp-toolbar:has( body.wp-desktop-chromeless ) {
 .wp-desktop-chromeless .update-nag {
 	border-top: 1px solid #d63638;
 }
+
+/* ---------------------------------------------------------------
+ * Suppress WordPress's native command palette inside chromeless
+ * iframes. The chromeless bridge intercepts Cmd+K and forwards to
+ * the desktop shell, but if an in-page component triggers the
+ * palette via another path (programmatic dispatch, a menu item)
+ * the dialog would still render. Hide it so the shell's palette
+ * stays the only surface users ever see.
+ * --------------------------------------------------------------- */
+.wp-desktop-chromeless .commands-command-menu__container,
+.wp-desktop-chromeless .commands-command-menu {
+	display: none !important;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,29 @@ We also extend Core's `/wp/v2/media` endpoint with two opt-in query parameters s
 
 Both params are purely additive — omitting them keeps the endpoint's default behavior untouched. Implementation lives in `includes/media-query.php`: every new upload gets stamped with two flat numeric post-meta keys (`_wpdm_width`, `_wpdm_height`) via `wp_generate_attachment_metadata` / `wp_update_attachment_metadata`, and the params translate into a `WP_Meta_Query` NUMERIC `>=` clause. Pre-existing attachments are backfilled opportunistically — each filtered REST request stamps up to 50 unstamped images — so a site upgrading into this feature starts seeing real filtered results within a few picker opens rather than requiring a CLI run. Once every image has been stamped, the `wpdm_media_dims_backfilled` site option flips to `1` and the sweep query is skipped from then on.
 
+## Command palette bridge (Cmd+K, hijacked)
+
+WordPress 6.4+ ships a command palette via `@wordpress/commands` — the one that opens on Cmd+K in Gutenberg / site editor. Inside a desktop-mode iframe we **suppress it** and reroute the keystroke to the shell's own palette, then **harvest** the iframe's `core/commands` registry and re-publish every command as a slash-command in the shell. The user sees one palette; it's ours; it contains whatever the focused window contributes.
+
+This is a deliberate hack — there is no public API on `@wordpress/commands` for a parent frame to read and invoke commands from a child iframe. The implementation lives in two places:
+
+- **Iframe side** (`includes/render.php`, chromeless bridge script):
+  1. A capture-phase `keydown` handler `preventDefault`s Cmd/Ctrl+K and posts `wp-desktop-palette-cycle` to the parent. No more "native palette flashes before ours wins the race."
+  2. A React component is mounted into a hidden div (via `wp.element.createRoot`). It `useSelect`s `getCommandLoaders(true)` and `getCommands(true)` from `core/commands`; one child component per loader invokes the loader's hook under a legal render context. Results are collected into a ref-based bucket (state would setState-loop — every hook call returns a fresh array reference).
+  3. Callbacks are NOT executed to classify navigation commands. `Location.prototype.href` is non-configurable so a sandbox can't intercept `location.href = X` without real navigation — an earlier attempt cascaded into infinite window spawning. We now match `Function.prototype.toString()` against a string-literal regex instead. Computed URLs fall back to `action`.
+  4. React icons (`@wordpress/icons` elements) are flattened to SVG markup via `wp.element.renderToString` so they can cross `postMessage`'s structured clone.
+  5. A private `__wpdCommandCallbacks` cache, rebuilt every harvest, keeps live references to the loader commands' callbacks. Loader results aren't in `getCommands()` so the invoke path needs its own lookup.
+
+- **Parent side** (`src/commands/iframe-bridge.ts`):
+  1. On `wp-desktop-window-focused`, send `wp-desktop-commands-subscribe` to that window's iframe; evict the previous window's commands tagged with owner `iframe:<windowId>`.
+  2. On `wp-desktop-commands-list`, re-register everything under the new owner. Navigation-kind commands become "open a new desktop window" via `manager.open`; action-kind commands post `wp-desktop-commands-invoke` back to the iframe.
+  3. On `wp-desktop-window-changed` with `state: 'minimized'` for the subscribed window, evict its commands — minimized windows shouldn't contribute to a palette that's supposed to reflect what's actionable right now. The next focus event rehydrates.
+  4. On `wp-desktop-bridge-ready` (handshake posted by the iframe once its listener is attached), re-send subscribe if the iframe matches the currently focused window. Fixes the race where the parent sends subscribe before the iframe script has run.
+
+Each harvested command is tagged `eager: true` so it surfaces in the palette without requiring the user to type `/`. The palette renders eager commands on empty input; typing `/` switches to the slash-only surface (disjoint from eager — see [JavaScript Reference](./javascript-reference.md#commands)).
+
+**Caveats.** Gutenberg block-level loader hooks are tightly coupled to current editor state; invoking a stale closure after the editor re-renders can no-op. The harvester re-runs on every React re-render, so in practice the cache is fresh, but don't expect the bridge to work if the iframe page hasn't booted its editor yet. Non-Gutenberg admin screens generally expose no contextual commands, so the palette falls back to its AI suggestions view when the focused window's registry is empty.
+
 ## CSS layering
 
 ```
@@ -101,7 +124,7 @@ Never edit Core's `common.css` or color scheme files. Everything we need is expo
 
 ## What's shipped vs. what comes next
 
-**Shipped** — taskbar (0.5), multi-window orchestration + session restore, virtual desktops / Spaces (0.6), wallpaper registry (0.6), widget registry (0.7), overview + arrange + snap (0.8–0.9), native windows and tabs (0.10–0.11), AI assistant + slash commands + palette registry (0.13–0.14), cross-frame drag bridge for Media Library (0.14), OS Settings native window, accent + custom-gradient editor, toast notifications, iframe observability (`iframe-ready` / `iframe-error` / `iframe-network-completed`), letter-badge icon fallback, batch `closeAll()` with protection filter, primary-desktop filter.
+**Shipped** — taskbar (0.5), multi-window orchestration + session restore, virtual desktops / Spaces (0.6), wallpaper registry (0.6), widget registry (0.7), overview + arrange + snap (0.8–0.9), native windows and tabs (0.10–0.11), AI assistant + slash commands + palette registry (0.13–0.14), cross-frame drag bridge for Media Library (0.14), OS Settings native window, accent + custom-gradient editor, toast notifications, iframe observability (`iframe-ready` / `iframe-error` / `iframe-network-completed`), letter-badge icon fallback, batch `closeAll()` with protection filter, primary-desktop filter, iframe command-palette bridge (0.16 — harvests `@wordpress/commands` from the focused window into the shell palette; see "Command palette bridge" above).
 
 **Coming up**
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -362,6 +362,9 @@ Registrations are live — if the palette is open when you call this, the new co
 | `description` | `string` | no | One-line description under the label |
 | `hint` | `string` | no | Argument hint, e.g. `"[post id]"` |
 | `icon` | `string` | no | Dashicons class, default `dashicons-arrow-right-alt` |
+| `iconSvg` | `string` | no | *Since 0.16.0.* Raw `<svg>…</svg>` markup rendered inline; takes precedence over `icon`. Used internally by the iframe-command bridge to forward `@wordpress/icons` elements; plugins may set it when shipping a one-off glyph is easier than enqueueing a dashicon. |
+| `eager` | `boolean` | no | *Since 0.16.0.* When `true`, the command appears on the empty-input palette without the user typing `/`. When falsy (default), it only surfaces after `/`. Eager and slash-only surfaces are **disjoint** — typing `/` hides eager commands. Use `eager: true` for contextual / always-relevant actions (block editor shortcuts, site-wide toggles); leave it off for utility commands the user deliberately invokes. |
+| `owner` | `string` | no | Optional tag for grouped eviction via `unregisterByOwner()`. The iframe bridge uses `iframe:<windowId>`; plugins typically pass their script handle. |
 | `suggest( args, ctx )` | `function` | no | Argument autocomplete. Returns or resolves to `CommandSuggestion[]`. When present, the palette renders a live list the user can navigate with ↑/↓ and commit with Tab / Enter. |
 | `run( args, ctx )` | `function` | yes | Handler. `args` is the raw text after `/<slug> `. May be async. |
 
@@ -711,9 +714,13 @@ Reports which screen-meta panel (if any) is currently open inside the iframe.
 ```
 
 #### `wp-desktop-commands-list` — Experimental
-Reports the current `wp.data.select('core/commands')` registry of this iframe to the parent shell. Emitted after the iframe receives `wp-desktop-commands-subscribe`, and then re-emitted (de-duplicated) whenever the store changes. The parent re-publishes each entry as a slash-command in the shell palette tagged `owner: 'iframe:<windowId>'`.
+Reports the current `wp.data.select('core/commands')` registry of this iframe to the parent shell. Emitted after the iframe receives `wp-desktop-commands-subscribe`, and then re-emitted (de-duplicated) whenever a re-render of the in-iframe React harvester changes the merged list. The parent re-publishes each entry as a slash-command in the shell palette tagged `owner: 'iframe:<windowId>'` and `eager: true` so the command surfaces before the user types `/`.
 
-Each `HarvestedCommand` carries a `kind` field the iframe computes by dry-invoking the original callback inside a `window.location`-intercept sandbox: callbacks whose only observable effect is a navigation are flagged `navigate` (with the captured `url`) so the shell can open a new desktop window; everything else is `action` and proxies back into the iframe via `wp-desktop-commands-invoke`.
+Collection spans tier-2 (context-scoped `getCommands(true)`) and tier-3 (dynamic `getCommandLoaders(true)` hooks — invoked inside a mounted React tree so the rules of hooks hold). Global tier-1 navigation commands are deliberately skipped: the user already has them via the dock.
+
+Each `HarvestedCommand` carries a `kind` field the iframe computes by **statically matching** `callback.toString()` against a string-literal navigation target (`location.href = '…'`, `.assign('…')`, `.replace('…')`). An earlier dry-run approach triggered infinite window spawning because `Location.prototype.href` is non-configurable — the shim silently failed and every nav callback actually navigated. Computed URLs fall back to `action` and proxy back into the iframe via `wp-desktop-commands-invoke`.
+
+`iconSvg` carries the `@wordpress/icons` React element flattened to SVG markup via `wp.element.renderToString`; the structured-clone algorithm behind `postMessage` would refuse the raw element.
 
 ```typescript
 {
@@ -721,7 +728,8 @@ Each `HarvestedCommand` carries a `kind` field the iframe computes by dry-invoki
     commands: Array<{
         name: string;
         label: string;
-        icon?: string;
+        icon?: string;     // dashicons class, if the source icon was a string
+        iconSvg?: string;  // rendered <svg>…</svg> markup for React icons
         context?: string;
         kind: 'navigate' | 'action';
         url?: string;

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -710,6 +710,25 @@ Reports which screen-meta panel (if any) is currently open inside the iframe.
 { type: 'wp-desktop-screen-meta-state'; open: 'screen-options' | 'help' | null }
 ```
 
+#### `wp-desktop-commands-list` — Experimental
+Reports the current `wp.data.select('core/commands')` registry of this iframe to the parent shell. Emitted after the iframe receives `wp-desktop-commands-subscribe`, and then re-emitted (de-duplicated) whenever the store changes. The parent re-publishes each entry as a slash-command in the shell palette tagged `owner: 'iframe:<windowId>'`.
+
+Each `HarvestedCommand` carries a `kind` field the iframe computes by dry-invoking the original callback inside a `window.location`-intercept sandbox: callbacks whose only observable effect is a navigation are flagged `navigate` (with the captured `url`) so the shell can open a new desktop window; everything else is `action` and proxies back into the iframe via `wp-desktop-commands-invoke`.
+
+```typescript
+{
+    type: 'wp-desktop-commands-list';
+    commands: Array<{
+        name: string;
+        label: string;
+        icon?: string;
+        context?: string;
+        kind: 'navigate' | 'action';
+        url?: string;
+    }>;
+}
+```
+
 ---
 
 ### parent → iframe
@@ -737,6 +756,27 @@ Asks the iframe to toggle a named screen-meta panel. The iframe is the authority
 
 ```typescript
 { type: 'wp-desktop-toggle-panel'; panel: 'screen-options' | 'help' }
+```
+
+#### `wp-desktop-commands-subscribe` — Experimental
+Tells the iframe to begin streaming its `wp.data.select('core/commands')` registry to the parent via `wp-desktop-commands-list`. The shell sends this to the iframe owned by the currently focused window and rescinds it (`wp-desktop-commands-unsubscribe`) when focus moves elsewhere.
+
+```typescript
+{ type: 'wp-desktop-commands-subscribe' }
+```
+
+#### `wp-desktop-commands-unsubscribe` — Experimental
+Tells the iframe to stop streaming its command list. The parent unregisters any shell-palette entries still tagged with this window's owner.
+
+```typescript
+{ type: 'wp-desktop-commands-unsubscribe' }
+```
+
+#### `wp-desktop-commands-invoke` — Experimental
+Asks the iframe to run a previously harvested `action`-kind command. Sent when the user selects the command from the shell palette. Navigation-kind commands are handled parent-side by opening a new desktop window — the iframe never sees them.
+
+```typescript
+{ type: 'wp-desktop-commands-invoke'; name: string }
 ```
 
 ---

--- a/includes/render.php
+++ b/includes/render.php
@@ -894,111 +894,505 @@ function wpdm_chromeless_bridge_script() {
 	}, true );
 
 	/*
-	 * Cmd+K / Ctrl+K forwarder — double-press to escalate.
+	 * Cmd+K / Ctrl+K forwarder — single-press, unconditional.
 	 *
-	 * Native keydown events don't cross iframe boundaries, so without
-	 * this shim the parent shell's Cmd+K handler never fires while
-	 * focus lives inside a chromeless iframe. We don't want to
-	 * override in-page command palettes (Gutenberg's block insert,
-	 * TinyMCE's quick menus, plugin launchers) — users installed those
-	 * for a reason. Behaviour we want instead:
+	 * Native keydown events don't cross iframe boundaries. Inside a
+	 * chromeless admin page we want exactly ONE command palette: the
+	 * desktop shell's. WordPress's own `core/commands` palette is
+	 * harvested by `__wpdHarvestCommands` below and re-surfaced in the
+	 * shell palette, so there's no reason to ever let the in-page palette
+	 * take the keystroke.
 	 *
-	 *   1st press → let the in-page handler run. Nothing interrupts.
-	 *   2nd press (within DOUBLE_WINDOW ms) → escalate: preventDefault,
-	 *   stopImmediatePropagation, and postMessage the parent to advance
-	 *   the shell palette cycle. The in-page palette that opened on
-	 *   the first press is already visible; our cycle treats that as
-	 *   the "current" slot and rotates to the next.
-	 *
-	 * Plain admin pages without their own Cmd+K handler still need two
-	 * presses to reach our palette — minor trade-off, offset by the
-	 * "Ask AI ⌘K" admin-bar button which is always a one-click path.
-	 *
-	 * Shift/Alt modifiers are NEVER intercepted so user shortcuts using
+	 * Capture phase + `stopImmediatePropagation` so we win the race
+	 * against Gutenberg / TinyMCE / plugin handlers bound to the same
+	 * shortcut. Shift/Alt modifiers pass through so user shortcuts using
 	 * those combos keep working.
 	 */
-	( function () {
-		var DOUBLE_WINDOW = 600; // ms
-		var lastPress = 0;
+	document.addEventListener( 'keydown', function ( e ) {
+		if ( ! ( e.metaKey || e.ctrlKey ) ) return;
+		if ( e.key !== 'k' && e.key !== 'K' ) return;
+		if ( e.shiftKey || e.altKey ) return;
 
-		document.addEventListener( 'keydown', function ( e ) {
-			if ( ! ( e.metaKey || e.ctrlKey ) ) return;
-			if ( e.key !== 'k' && e.key !== 'K' ) return;
-			if ( e.shiftKey || e.altKey ) return;
+		e.preventDefault();
+		e.stopImmediatePropagation();
 
-			var now = Date.now();
-			var isDouble = ( now - lastPress ) < DOUBLE_WINDOW;
-			lastPress = now;
+		try {
+			window.parent.postMessage(
+				{ type: 'wp-desktop-palette-cycle' },
+				window.location.origin
+			);
+		} catch ( err ) { /* cross-origin parent; swallow */ }
+	}, true );
 
-			if ( ! isDouble ) {
-				// First press — leave the event alone so the iframe's
-				// own Cmd+K handler (Gutenberg, TinyMCE, plugin) can
-				// react natively.
+	/*
+	 * Command harvester — bridges `wp.data.select('core/commands')` to
+	 * the parent shell.
+	 *
+	 * On `wp-desktop-commands-subscribe` from the parent, subscribe to
+	 * the `core/commands` store and post `wp-desktop-commands-list` on
+	 * every change (de-duplicated). On `wp-desktop-commands-invoke`, run
+	 * the original callback inside this iframe — the parent fires this
+	 * when the user selects a proxied command from the shell palette.
+	 *
+	 * Commands are classified by dry-invoking their callback inside a
+	 * `window.location`-intercept sandbox: pure-navigation callbacks
+	 * are flagged `navigate` (with the captured URL) so the parent can
+	 * open a new desktop window instead of navigating this iframe out
+	 * of chromeless mode. Everything else is `action` and proxies back
+	 * into this iframe on user selection.
+	 */
+	var __wpdCommandsSubscribed   = false;
+	var __wpdCommandsUnsub        = null;
+	var __wpdCommandsLastPayload  = '';
+	var __wpdCommandsDebounceId   = null;
+	var __wpdCommandsOrigin       = window.location.origin;
+	// Cache per command name so the `window.location`-intercept
+	// sandbox only runs once per command. Re-classifying on every
+	// store tick would repeatedly fire side-effectful action
+	// callbacks (preference toggles, modal opens) — unacceptable.
+	// Keyed by name; value is the frozen classification minus the
+	// live `label` / `icon` (which we always re-read in case the
+	// command updated its own metadata).
+	var __wpdCommandsKindCache    = Object.create( null );
+
+	function __wpdClassifyCommand( cmd ) {
+		// Defensive defaults — a broken registry should not tank the bridge.
+		var out = {
+			name:    String( cmd && cmd.name ? cmd.name : '' ),
+			label:   String( cmd && cmd.label ? cmd.label : '' ),
+			icon:    cmd && cmd.icon && typeof cmd.icon === 'string' ? cmd.icon : undefined,
+			context: cmd && cmd.context ? String( cmd.context ) : undefined,
+			kind:    'action',
+			url:     undefined
+		};
+		if ( ! cmd || typeof cmd.callback !== 'function' ) {
+			return out;
+		}
+
+		// Short-circuit on cached classifications — the dry-run has
+		// real side effects for non-navigation callbacks, so we pay
+		// that cost exactly once per command name per page load.
+		var cached = __wpdCommandsKindCache[ out.name ];
+		if ( cached ) {
+			out.kind = cached.kind;
+			out.url  = cached.url;
+			return out;
+		}
+
+		// STATIC classification — read the callback's source text and
+		// look for a string-literal navigation target. We deliberately
+		// do NOT execute the callback. An earlier iteration tried a
+		// dry-run with a `window.location` intercept sandbox, but
+		// `Location.prototype.href` is non-configurable: the shim
+		// silently failed, every nav callback actually navigated the
+		// iframe, the new page re-harvested, and the cascade opened
+		// windows forever.
+		//
+		// Cases caught (WP's @wordpress/core-commands callbacks are
+		// all of this shape):
+		//   document.location.href = 'url'
+		//   window.location.href   = "url"
+		//   location.href          = `url`
+		//   location.assign( 'url' )
+		//   location.replace( 'url' )
+		//
+		// Computed URLs (template-literal interpolation, addQueryArgs
+		// calls, variables) fall back to `action` — the user picking
+		// them will still run the real callback inside the iframe,
+		// which is the safe default.
+		var src = '';
+		try { src = Function.prototype.toString.call( cmd.callback ); } catch ( _err ) { src = ''; }
+		var navRe = /(?:document\.location\.href|window\.location\.href|location\.href)\s*=\s*['"]([^'"$]+?)['"]/;
+		var asgRe = /location\.(?:assign|replace)\s*\(\s*['"]([^'"$]+?)['"]\s*\)/;
+		var mm = src.match( navRe ) || src.match( asgRe );
+		if ( mm && mm[ 1 ] ) {
+			try {
+				out.url  = new URL( mm[ 1 ], window.location.href ).toString();
+				out.kind = 'navigate';
+			} catch ( _err ) {
+				out.kind = 'action';
+			}
+		}
+		__wpdCommandsKindCache[ out.name ] = { kind: out.kind, url: out.url };
+		return out;
+	}
+
+	// Harvested commands accumulate here. The React harvester writes
+	// the full list each render; `__wpdPostCommandsList` reads + posts.
+	var __wpdLastRawCommands = [];
+	// Name → live `callback` reference. Loader-returned commands are
+	// NOT in `wp.data.select('core/commands').getCommands()` — the
+	// store only exposes statically-registered entries. Without a
+	// private cache keyed off the React harvester's most recent render,
+	// invoking a loader command from the parent palette ("Duplicate
+	// block", "Transform to...", pattern commands) would silently fall
+	// through to the `getCommands()` lookup and no-op.
+	var __wpdCommandCallbacks = Object.create( null );
+
+	function __wpdFinalizeCommands( raw ) {
+		var seen = Object.create( null );
+		var out = [];
+		var skipped = { missing: 0, disabled: 0, dup: 0 };
+		for ( var i = 0; i < raw.length; i++ ) {
+			var cmd = raw[ i ];
+			if ( ! cmd || ! cmd.name || ! cmd.label ) { skipped.missing++; continue; }
+			if ( cmd.disabled ) { skipped.disabled++; continue; }
+			if ( seen[ cmd.name ] ) { skipped.dup++; continue; }
+			seen[ cmd.name ] = true;
+			out.push( __wpdClassifyCommand( cmd ) );
+		}
+		console.log( '[wpd-cmd:iframe] finalize: kept %d, skipped %o', out.length, skipped );
+		return out;
+	}
+
+	function __wpdHarvestCommands() {
+		return __wpdFinalizeCommands( __wpdLastRawCommands );
+	}
+
+	// React-mounted harvester. Block-level / editor-contextual commands
+	// (tier 3 loaders like `core/block-editor/selected-block-commands`,
+	// `core/edit-post/pattern-commands`) are React *hooks* — they call
+	// `useSelect` internally, which only works inside a function-
+	// component render. So we mount an invisible React tree whose
+	// children invoke each loader's hook at render time. On every
+	// re-render (block selection changes, entity edits, welcome guide
+	// toggled) the effect re-posts the fresh command list to the
+	// parent. One component per loader keeps the rules-of-hooks
+	// contract — the hook count inside each `LoaderSlot` is fixed at
+	// one call (plus the constant `useEffect`), so React's reconciler
+	// is happy.
+	var __wpdReactMounted = false;
+
+	function __wpdMountReactHarvester() {
+		if ( __wpdReactMounted ) return;
+		if ( ! window.wp || ! window.wp.element || ! window.wp.data ) {
+			console.log( '[wpd-cmd:iframe] react-harvester: wp.element/wp.data missing' );
+			return;
+		}
+		var el        = window.wp.element;
+		var createEl  = el.createElement;
+		var useEffect = el.useEffect;
+		var useRef    = el.useRef;
+		var useMemo   = el.useMemo;
+		var useSelect = ( window.wp.data && window.wp.data.useSelect ) || null;
+		if ( ! createEl || ! useSelect || ! el.createRoot || ! useRef ) {
+			console.log( '[wpd-cmd:iframe] react-harvester: wp.element API incomplete' );
+			return;
+		}
+		__wpdReactMounted = true;
+
+		// Hidden mount point. Positioned off-screen + `aria-hidden` so
+		// nothing the harvester renders (it renders null anyway) can
+		// leak into the accessibility tree or the visible document.
+		var host = document.createElement( 'div' );
+		host.setAttribute( 'aria-hidden', 'true' );
+		host.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden;pointer-events:none;left:-9999px;top:-9999px;';
+		( document.body || document.documentElement ).appendChild( host );
+
+		// Shared mutable bucket — ref-based aggregation to avoid the
+		// classic setState-inside-useEffect loop. A `setState` here
+		// would fire a parent re-render, which would fire the loader
+		// hook again, which returns a fresh commands array with a new
+		// reference even when the contents are identical, which would
+		// re-fire the effect and setState again → Maximum update
+		// depth exceeded. Refs don't trigger renders, so the loop is
+		// broken even when hooks churn references.
+		var resultsBucket = { perLoader: {}, statics: [], loadersList: [] };
+
+		function commandsFingerprint( cmds ) {
+			if ( ! Array.isArray( cmds ) || cmds.length === 0 ) return '';
+			// Cheap identity — name count is enough to decide whether
+			// to re-post. Accepts some false negatives (two different
+			// commands sharing a name) we'll never hit in practice.
+			var keys = new Array( cmds.length );
+			for ( var i = 0; i < cmds.length; i++ ) {
+				var c = cmds[ i ];
+				keys[ i ] = c && c.name ? c.name : '';
+			}
+			return keys.join( '|' );
+		}
+
+		function mergeAndPost() {
+			var merged = [];
+			var loadersList = resultsBucket.loadersList;
+			if ( Array.isArray( loadersList ) ) {
+				for ( var i = 0; i < loadersList.length; i++ ) {
+					var bucket = resultsBucket.perLoader[ loadersList[ i ] ];
+					if ( Array.isArray( bucket ) ) merged = merged.concat( bucket );
+				}
+			}
+			if ( Array.isArray( resultsBucket.statics ) ) {
+				merged = merged.concat( resultsBucket.statics );
+			}
+			// Refresh the callback cache off the SAME snapshot we're
+			// about to post. Loader-returned commands close over React
+			// state (selected block, edited entity, etc.) that's only
+			// valid for this render pass, so rebuilding from scratch
+			// every merge keeps invoke-from-parent honest instead of
+			// calling a stale closure.
+			__wpdCommandCallbacks = Object.create( null );
+			for ( var j = 0; j < merged.length; j++ ) {
+				var cc = merged[ j ];
+				if ( cc && cc.name && typeof cc.callback === 'function' ) {
+					__wpdCommandCallbacks[ cc.name ] = cc.callback;
+				}
+			}
+			__wpdLastRawCommands = merged;
+			console.log( '[wpd-cmd:iframe] react-harvester: merged %d (tier3-buckets=%d, tier2-static=%d)',
+				merged.length,
+				loadersList.length,
+				Array.isArray( resultsBucket.statics ) ? resultsBucket.statics.length : 0
+			);
+			__wpdSchedulePost();
+		}
+
+		// One slot per loader. Calls the loader's hook at render time;
+		// an effect keyed on the commands' name-fingerprint writes the
+		// fresh list into the shared bucket and posts. Ref-based, no
+		// setState → no re-render cascade.
+		function LoaderSlot( props ) {
+			var loader = props.loader;
+			var result = null;
+			try {
+				result = loader.hook( { search: '' } );
+			} catch ( err ) {
+				if ( ! loader.__wpdLoggedThrow ) {
+					loader.__wpdLoggedThrow = true;
+					console.log( '[wpd-cmd:iframe] react-harvester: loader "%s" threw', loader.name, err );
+				}
+			}
+			var cmds = ( result && Array.isArray( result.commands ) ) ? result.commands : [];
+			var key  = useMemo( function () { return commandsFingerprint( cmds ); }, [ cmds ] );
+
+			useEffect( function () {
+				resultsBucket.perLoader[ loader.name ] = cmds;
+				mergeAndPost();
+			}, [ key ] );
+
+			useEffect( function () {
+				return function () {
+					delete resultsBucket.perLoader[ loader.name ];
+					mergeAndPost();
+				};
+			}, [] );
+
+			return null;
+		}
+
+		function Harvester() {
+			var loaders = useSelect( function ( s ) {
+				var ss = s( 'core/commands' );
+				return ( ss && typeof ss.getCommandLoaders === 'function' )
+					? ss.getCommandLoaders( true )
+					: [];
+			}, [] );
+			var staticCmds = useSelect( function ( s ) {
+				var ss = s( 'core/commands' );
+				return ( ss && typeof ss.getCommands === 'function' )
+					? ss.getCommands( true )
+					: [];
+			}, [] );
+
+			// Track the loader-name ordering so `mergeAndPost` can emit
+			// tier-3 in a deterministic order (React reconciliation
+			// order = registration order = the order the user sees).
+			var loadersNames = useMemo( function () {
+				if ( ! Array.isArray( loaders ) ) return [];
+				return loaders.map( function ( l ) { return l ? l.name : ''; } );
+			}, [ loaders ] );
+			var loadersKey = loadersNames.join( '|' );
+			useEffect( function () {
+				resultsBucket.loadersList = loadersNames;
+				mergeAndPost();
+			}, [ loadersKey ] );
+
+			var staticKey = useMemo( function () { return commandsFingerprint( staticCmds ); }, [ staticCmds ] );
+			useEffect( function () {
+				resultsBucket.statics = Array.isArray( staticCmds ) ? staticCmds : [];
+				mergeAndPost();
+			}, [ staticKey ] );
+
+			if ( ! Array.isArray( loaders ) || loaders.length === 0 ) {
+				return null;
+			}
+			var children = [];
+			for ( var i = 0; i < loaders.length; i++ ) {
+				var loader = loaders[ i ];
+				if ( ! loader || typeof loader.hook !== 'function' ) continue;
+				children.push( createEl( LoaderSlot, {
+					key: loader.name,
+					loader: loader
+				} ) );
+			}
+			return createEl( el.Fragment || 'div', null, children );
+		}
+
+		try {
+			var root = el.createRoot( host );
+			root.render( createEl( Harvester ) );
+			console.log( '[wpd-cmd:iframe] react-harvester: mounted' );
+		} catch ( err ) {
+			__wpdReactMounted = false;
+			console.log( '[wpd-cmd:iframe] react-harvester: mount threw', err );
+		}
+	}
+
+	function __wpdPostCommandsList() {
+		var list = __wpdHarvestCommands();
+		// Cheap de-dupe — the store fires on every unrelated preference
+		// change too, and shipping an identical payload is pure noise.
+		var key = '';
+		try { key = JSON.stringify( list ); } catch ( _err ) { key = String( list.length ); }
+		if ( key === __wpdCommandsLastPayload ) {
+			console.log( '[wpd-cmd:iframe] post: skipping duplicate payload (%d cmds)', list.length );
+			return;
+		}
+		__wpdCommandsLastPayload = key;
+		console.log( '[wpd-cmd:iframe] post: sending %d commands to parent', list.length, list );
+		try {
+			window.parent.postMessage(
+				{ type: 'wp-desktop-commands-list', commands: list },
+				__wpdCommandsOrigin
+			);
+		} catch ( err ) {
+			console.log( '[wpd-cmd:iframe] post: postMessage threw', err );
+		}
+	}
+
+	function __wpdSchedulePost() {
+		if ( __wpdCommandsDebounceId !== null ) return;
+		__wpdCommandsDebounceId = window.setTimeout( function () {
+			__wpdCommandsDebounceId = null;
+			__wpdPostCommandsList();
+		}, 60 );
+	}
+
+	function __wpdSubscribeCommands() {
+		console.log( '[wpd-cmd:iframe] subscribe requested (already=%s, mounted=%s, url=%s)', __wpdCommandsSubscribed, __wpdReactMounted, window.location.href );
+		__wpdCommandsSubscribed = true;
+
+		// If the React harvester is already running (focus left and
+		// came back), the bucket still holds the latest merged list.
+		// Reset the dedupe key so the next post actually ships, then
+		// schedule it. The harvester itself won't re-fire its effects
+		// just because the parent re-subscribed — React only reacts to
+		// store changes, and the store hasn't changed. We have to
+		// push from here.
+		if ( __wpdReactMounted ) {
+			__wpdCommandsLastPayload = '';
+			console.log( '[wpd-cmd:iframe] subscribe: harvester already mounted, re-shipping bucket (%d cmds)', __wpdLastRawCommands.length );
+			__wpdSchedulePost();
+			return;
+		}
+
+		var attempts = 0;
+		function tryBind() {
+			if ( ! __wpdCommandsSubscribed ) return;
+			if ( ! window.wp || ! window.wp.data || typeof window.wp.data.subscribe !== 'function' ) {
+				if ( attempts++ < 40 ) {
+					if ( attempts === 1 || attempts % 5 === 0 ) {
+						console.log( '[wpd-cmd:iframe] subscribe: wp.data not ready yet (attempt %d)', attempts );
+					}
+					window.setTimeout( tryBind, 150 );
+				} else {
+					console.log( '[wpd-cmd:iframe] subscribe: gave up waiting for wp.data after %d attempts', attempts );
+				}
 				return;
 			}
+			console.log( '[wpd-cmd:iframe] subscribe: wp.data ready, binding (attempts=%d)', attempts );
+			// Mount the React harvester — tier 3 loaders are hooks and
+			// need a legal render context to execute. On every re-render
+			// the component's effect calls `__wpdSchedulePost` with the
+			// fresh merged list, so we don't need a separate
+			// `wp.data.subscribe` callback.
+			__wpdMountReactHarvester();
+		}
+		tryBind();
+	}
 
-			// Second press within the window — escalate.
-			e.preventDefault();
-			e.stopImmediatePropagation();
-			// Reset so a third press restarts the "first" cycle rather
-			// than triggering another instant escalation.
-			lastPress = 0;
+	function __wpdUnsubscribeCommands() {
+		__wpdCommandsSubscribed = false;
+		if ( __wpdCommandsUnsub ) {
+			try { __wpdCommandsUnsub(); } catch ( _err ) { /* swallow */ }
+			__wpdCommandsUnsub = null;
+		}
+		__wpdCommandsLastPayload = '';
+	}
 
-			// Dismiss whatever in-page palette the FIRST press opened.
-			// Gutenberg's command palette, TinyMCE menus, and most WP
-			// `@wordpress/components` modals all close on Escape — so
-			// we synthesise one. We fire it twice:
-			//
-			//   (a) Immediately — handles the common case where the
-			//       first press's palette already rendered.
-			//
-			//   (b) On the next animation frame — handles the fast
-			//       double-press race where the first palette hadn't
-			//       painted yet when the second press arrived. By the
-			//       next frame it has, and Escape dismisses it.
-			//
-			// If the in-page UI doesn't listen for Escape there's no
-			// harm — the synthetic event dispatches into a document
-			// that ignores it. Worst case the two palettes briefly
-			// overlap; they won't both capture the keyboard because
-			// focus has already followed the escalation to the parent.
-			function closeInPagePalette() {
-				try {
-					var ev = new KeyboardEvent( 'keydown', {
-						key:        'Escape',
-						code:       'Escape',
-						keyCode:    27,
-						which:      27,
-						bubbles:    true,
-						cancelable: true
-					} );
-					document.dispatchEvent( ev );
-					// Matching keyup — some handlers bind to keyup, not
-					// keydown, so fire both for safety.
-					var up = new KeyboardEvent( 'keyup', {
-						key:        'Escape',
-						code:       'Escape',
-						keyCode:    27,
-						which:      27,
-						bubbles:    true,
-						cancelable: true
-					} );
-					document.dispatchEvent( up );
-				} catch ( err ) { /* swallow */ }
-			}
-			closeInPagePalette();
-			if ( typeof requestAnimationFrame === 'function' ) {
-				requestAnimationFrame( closeInPagePalette );
-			}
-
+	function __wpdInvokeCommand( name ) {
+		console.log( '[wpd-cmd:iframe] invoke: looking up "%s"', name );
+		// Primary lookup — the React harvester's latest snapshot. This
+		// covers loader-returned commands (Duplicate block, Transform
+		// to, pattern commands) that never appear in the static
+		// `getCommands()` list.
+		var cb = __wpdCommandCallbacks[ name ];
+		if ( typeof cb === 'function' ) {
+			console.log( '[wpd-cmd:iframe] invoke: hit harvester cache for "%s"', name );
 			try {
-				window.parent.postMessage(
-					{ type: 'wp-desktop-palette-cycle' },
-					window.location.origin
-				);
-			} catch ( err ) { /* cross-origin parent; swallow */ }
-		}, true );
-	} )();
+				cb( { close: function () {} } );
+			} catch ( err ) {
+				console.log( '[wpd-cmd:iframe] invoke: "%s" callback threw', name, err );
+			}
+			return;
+		}
+		// Fallback — statically registered commands that never passed
+		// through the harvester (registered after the last render).
+		if ( ! window.wp || ! window.wp.data ) {
+			console.log( '[wpd-cmd:iframe] invoke: "%s" not found and wp.data missing', name );
+			return;
+		}
+		var sel = null;
+		try { sel = window.wp.data.select( 'core/commands' ); } catch ( _err ) { return; }
+		if ( ! sel || typeof sel.getCommands !== 'function' ) return;
+		var raw;
+		try { raw = sel.getCommands(); } catch ( _err ) { return; }
+		if ( ! raw ) return;
+		for ( var i = 0; i < raw.length; i++ ) {
+			if ( raw[ i ] && raw[ i ].name === name && typeof raw[ i ].callback === 'function' ) {
+				console.log( '[wpd-cmd:iframe] invoke: hit getCommands fallback for "%s"', name );
+				try {
+					raw[ i ].callback( { close: function () {} } );
+				} catch ( err ) {
+					console.log( '[wpd-cmd:iframe] invoke: "%s" fallback callback threw', name, err );
+				}
+				return;
+			}
+		}
+		console.log( '[wpd-cmd:iframe] invoke: "%s" NOT FOUND in harvester cache or getCommands()', name );
+	}
+
+	// Attach the listener BEFORE the bridge-ready ping so a subscribe
+	// posted synchronously in response is guaranteed to land.
+	window.addEventListener( 'message', function ( e ) {
+		if ( e.origin !== __wpdCommandsOrigin ) return;
+		if ( ! e.data || typeof e.data.type !== 'string' ) return;
+		if ( e.data.type === 'wp-desktop-commands-subscribe' ) {
+			__wpdSubscribeCommands();
+		} else if ( e.data.type === 'wp-desktop-commands-unsubscribe' ) {
+			console.log( '[wpd-cmd:iframe] unsubscribe received' );
+			__wpdUnsubscribeCommands();
+		} else if ( e.data.type === 'wp-desktop-commands-invoke' && typeof e.data.name === 'string' ) {
+			console.log( '[wpd-cmd:iframe] invoke received: %s', e.data.name );
+			__wpdInvokeCommand( e.data.name );
+		}
+	} );
+
+	console.log( '[wpd-cmd:iframe] bridge ready, listening for subscribe (url=%s)', window.location.href );
+	// Handshake: tell the parent we're ready so it can (re)send any
+	// subscribe that was dispatched before this listener attached.
+	// Without this ping, a subscribe posted during iframe navigation
+	// arrives at a context whose message listener isn't installed yet
+	// and is silently dropped — the symptom is an empty palette even
+	// though `wp.data.select('core/commands')` is perfectly happy.
+	try {
+		window.parent.postMessage(
+			{ type: 'wp-desktop-bridge-ready' },
+			__wpdCommandsOrigin
+		);
+		console.log( '[wpd-cmd:iframe] bridge-ready signal sent to parent' );
+	} catch ( err ) {
+		console.log( '[wpd-cmd:iframe] bridge-ready postMessage threw', err );
+	}
 
 	var links = document.getElementById( 'screen-meta-links' );
 	if ( ! links ) {

--- a/includes/render.php
+++ b/includes/render.php
@@ -955,12 +955,32 @@ function wpdm_chromeless_bridge_script() {
 	// command updated its own metadata).
 	var __wpdCommandsKindCache    = Object.create( null );
 
+	function __wpdRenderIconElement( icon ) {
+		if ( ! icon ) return '';
+		if ( typeof icon === 'string' ) return '';
+		if ( ! window.wp || ! window.wp.element || typeof window.wp.element.renderToString !== 'function' ) {
+			return '';
+		}
+		try {
+			var rendered = window.wp.element.renderToString( icon );
+			// `@wordpress/icons` entries render as a complete `<svg>`
+			// tag. Anything else (wrapped components, empty fragments,
+			// strings) falls back to dashicons in the palette — we only
+			// accept markup we can inject straight into the icon slot.
+			if ( typeof rendered === 'string' && rendered.toLowerCase().indexOf( '<svg' ) === 0 ) {
+				return rendered;
+			}
+		} catch ( _err ) { /* swallow */ }
+		return '';
+	}
+
 	function __wpdClassifyCommand( cmd ) {
 		// Defensive defaults — a broken registry should not tank the bridge.
 		var out = {
 			name:    String( cmd && cmd.name ? cmd.name : '' ),
 			label:   String( cmd && cmd.label ? cmd.label : '' ),
 			icon:    cmd && cmd.icon && typeof cmd.icon === 'string' ? cmd.icon : undefined,
+			iconSvg: undefined,
 			context: cmd && cmd.context ? String( cmd.context ) : undefined,
 			kind:    'action',
 			url:     undefined
@@ -969,14 +989,23 @@ function wpdm_chromeless_bridge_script() {
 			return out;
 		}
 
-		// Short-circuit on cached classifications — the dry-run has
-		// real side effects for non-navigation callbacks, so we pay
-		// that cost exactly once per command name per page load.
+		// Short-circuit on cached classifications — `renderToString` on
+		// the React icon is expensive, and the static URL regex scan
+		// on `callback.toString()` is pure CPU we've already paid once.
 		var cached = __wpdCommandsKindCache[ out.name ];
 		if ( cached ) {
-			out.kind = cached.kind;
-			out.url  = cached.url;
+			out.kind    = cached.kind;
+			out.url     = cached.url;
+			out.iconSvg = cached.iconSvg;
 			return out;
+		}
+
+		// Render the React icon once per command name — Gutenberg
+		// commands ship `icon` as a `@wordpress/icons` React element
+		// the postMessage bridge can't serialize, so we flatten it to
+		// a static SVG string here.
+		if ( cmd.icon && typeof cmd.icon !== 'string' ) {
+			out.iconSvg = __wpdRenderIconElement( cmd.icon );
 		}
 
 		// STATIC classification — read the callback's source text and
@@ -1013,7 +1042,7 @@ function wpdm_chromeless_bridge_script() {
 				out.kind = 'action';
 			}
 		}
-		__wpdCommandsKindCache[ out.name ] = { kind: out.kind, url: out.url };
+		__wpdCommandsKindCache[ out.name ] = { kind: out.kind, url: out.url, iconSvg: out.iconSvg };
 		return out;
 	}
 

--- a/includes/render.php
+++ b/includes/render.php
@@ -941,8 +941,17 @@ function wpdm_chromeless_bridge_script() {
 	 * of chromeless mode. Everything else is `action` and proxies back
 	 * into this iframe on user selection.
 	 */
+	// Dev-only logging. Every `[wpd-cmd:iframe] …` line in this file
+	// routes through `__wpdLog`, which is a no-op in production. The
+	// `/*__WPDM_CMD_DEBUG__*/` placeholder is substituted by PHP
+	// below with the JSON-encoded value of `WP_DEBUG`.
+	var __WPD_CMD_DEBUG = /*__WPDM_CMD_DEBUG__*/false;
+	function __wpdLog() {
+		if ( ! __WPD_CMD_DEBUG ) return;
+		try { console.log.apply( console, arguments ); } catch ( _e ) { /* swallow */ }
+	}
+
 	var __wpdCommandsSubscribed   = false;
-	var __wpdCommandsUnsub        = null;
 	var __wpdCommandsLastPayload  = '';
 	var __wpdCommandsDebounceId   = null;
 	var __wpdCommandsOrigin       = window.location.origin;
@@ -1070,7 +1079,7 @@ function wpdm_chromeless_bridge_script() {
 			seen[ cmd.name ] = true;
 			out.push( __wpdClassifyCommand( cmd ) );
 		}
-		console.log( '[wpd-cmd:iframe] finalize: kept %d, skipped %o', out.length, skipped );
+		__wpdLog( '[wpd-cmd:iframe] finalize: kept %d, skipped %o', out.length, skipped );
 		return out;
 	}
 
@@ -1091,11 +1100,17 @@ function wpdm_chromeless_bridge_script() {
 	// one call (plus the constant `useEffect`), so React's reconciler
 	// is happy.
 	var __wpdReactMounted = false;
+	// Stashed so `__wpdUnsubscribeCommands` can tear the harvester
+	// down when focus leaves the window — otherwise the component
+	// keeps re-rendering on every store tick, calling `mergeAndPost`,
+	// and posting command lists the parent drops on the floor.
+	var __wpdReactRoot    = null;
+	var __wpdReactHost    = null;
 
 	function __wpdMountReactHarvester() {
 		if ( __wpdReactMounted ) return;
 		if ( ! window.wp || ! window.wp.element || ! window.wp.data ) {
-			console.log( '[wpd-cmd:iframe] react-harvester: wp.element/wp.data missing' );
+			__wpdLog( '[wpd-cmd:iframe] react-harvester: wp.element/wp.data missing' );
 			return;
 		}
 		var el        = window.wp.element;
@@ -1105,7 +1120,7 @@ function wpdm_chromeless_bridge_script() {
 		var useMemo   = el.useMemo;
 		var useSelect = ( window.wp.data && window.wp.data.useSelect ) || null;
 		if ( ! createEl || ! useSelect || ! el.createRoot || ! useRef ) {
-			console.log( '[wpd-cmd:iframe] react-harvester: wp.element API incomplete' );
+			__wpdLog( '[wpd-cmd:iframe] react-harvester: wp.element API incomplete' );
 			return;
 		}
 		__wpdReactMounted = true;
@@ -1117,6 +1132,7 @@ function wpdm_chromeless_bridge_script() {
 		host.setAttribute( 'aria-hidden', 'true' );
 		host.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden;pointer-events:none;left:-9999px;top:-9999px;';
 		( document.body || document.documentElement ).appendChild( host );
+		__wpdReactHost = host;
 
 		// Shared mutable bucket — ref-based aggregation to avoid the
 		// classic setState-inside-useEffect loop. A `setState` here
@@ -1167,7 +1183,7 @@ function wpdm_chromeless_bridge_script() {
 				}
 			}
 			__wpdLastRawCommands = merged;
-			console.log( '[wpd-cmd:iframe] react-harvester: merged %d (tier3-buckets=%d, tier2-static=%d)',
+			__wpdLog( '[wpd-cmd:iframe] react-harvester: merged %d (tier3-buckets=%d, tier2-static=%d)',
 				merged.length,
 				loadersList.length,
 				Array.isArray( resultsBucket.statics ) ? resultsBucket.statics.length : 0
@@ -1187,7 +1203,7 @@ function wpdm_chromeless_bridge_script() {
 			} catch ( err ) {
 				if ( ! loader.__wpdLoggedThrow ) {
 					loader.__wpdLoggedThrow = true;
-					console.log( '[wpd-cmd:iframe] react-harvester: loader "%s" threw', loader.name, err );
+					__wpdLog( '[wpd-cmd:iframe] react-harvester: loader "%s" threw', loader.name, err );
 				}
 			}
 			var cmds = ( result && Array.isArray( result.commands ) ) ? result.commands : [];
@@ -1258,33 +1274,64 @@ function wpdm_chromeless_bridge_script() {
 
 		try {
 			var root = el.createRoot( host );
+			__wpdReactRoot = root;
 			root.render( createEl( Harvester ) );
-			console.log( '[wpd-cmd:iframe] react-harvester: mounted' );
+			__wpdLog( '[wpd-cmd:iframe] react-harvester: mounted' );
 		} catch ( err ) {
 			__wpdReactMounted = false;
-			console.log( '[wpd-cmd:iframe] react-harvester: mount threw', err );
+			__wpdReactRoot    = null;
+			if ( __wpdReactHost && __wpdReactHost.parentNode ) {
+				__wpdReactHost.parentNode.removeChild( __wpdReactHost );
+			}
+			__wpdReactHost = null;
+			__wpdLog( '[wpd-cmd:iframe] react-harvester: mount threw', err );
 		}
+	}
+
+	function __wpdUnmountReactHarvester() {
+		if ( __wpdReactRoot ) {
+			try { __wpdReactRoot.unmount(); } catch ( _err ) { /* swallow */ }
+		}
+		__wpdReactRoot = null;
+		if ( __wpdReactHost && __wpdReactHost.parentNode ) {
+			__wpdReactHost.parentNode.removeChild( __wpdReactHost );
+		}
+		__wpdReactHost       = null;
+		__wpdReactMounted    = false;
+		__wpdLastRawCommands = [];
+		__wpdCommandCallbacks = Object.create( null );
 	}
 
 	function __wpdPostCommandsList() {
 		var list = __wpdHarvestCommands();
 		// Cheap de-dupe — the store fires on every unrelated preference
 		// change too, and shipping an identical payload is pure noise.
+		// Fingerprint on `name|kind|url` keeps us sensitive to the
+		// visible surface (name changes, navigate-vs-action flips,
+		// destination URL changes) while skipping `JSON.stringify` of
+		// the entire payload — label/icon churn inside a single command
+		// is rare and re-shipping on it is harmless noise vs. a hot
+		// path allocation cost.
 		var key = '';
-		try { key = JSON.stringify( list ); } catch ( _err ) { key = String( list.length ); }
+		for ( var k = 0; k < list.length; k++ ) {
+			var lc = list[ k ];
+			key += ( lc && lc.name ? lc.name : '' ) + '|'
+				+ ( lc && lc.kind ? lc.kind : '' ) + '|'
+				+ ( lc && lc.url  ? lc.url  : '' ) + '\n';
+		}
 		if ( key === __wpdCommandsLastPayload ) {
-			console.log( '[wpd-cmd:iframe] post: skipping duplicate payload (%d cmds)', list.length );
+			__wpdLog( '[wpd-cmd:iframe] post: skipping duplicate payload (%d cmds)', list.length );
 			return;
 		}
 		__wpdCommandsLastPayload = key;
-		console.log( '[wpd-cmd:iframe] post: sending %d commands to parent', list.length, list );
+		__wpdLog( '[wpd-cmd:iframe] post: sending %d commands to parent', list.length, list );
 		try {
 			window.parent.postMessage(
 				{ type: 'wp-desktop-commands-list', commands: list },
 				__wpdCommandsOrigin
 			);
 		} catch ( err ) {
-			console.log( '[wpd-cmd:iframe] post: postMessage threw', err );
+			__wpdLog( '[wpd-cmd:iframe] post: postMessage threw', err );
 		}
 	}
 
@@ -1297,7 +1344,7 @@ function wpdm_chromeless_bridge_script() {
 	}
 
 	function __wpdSubscribeCommands() {
-		console.log( '[wpd-cmd:iframe] subscribe requested (already=%s, mounted=%s, url=%s)', __wpdCommandsSubscribed, __wpdReactMounted, window.location.href );
+		__wpdLog( '[wpd-cmd:iframe] subscribe requested (already=%s, mounted=%s, url=%s)', __wpdCommandsSubscribed, __wpdReactMounted, window.location.href );
 		__wpdCommandsSubscribed = true;
 
 		// If the React harvester is already running (focus left and
@@ -1309,7 +1356,7 @@ function wpdm_chromeless_bridge_script() {
 		// push from here.
 		if ( __wpdReactMounted ) {
 			__wpdCommandsLastPayload = '';
-			console.log( '[wpd-cmd:iframe] subscribe: harvester already mounted, re-shipping bucket (%d cmds)', __wpdLastRawCommands.length );
+			__wpdLog( '[wpd-cmd:iframe] subscribe: harvester already mounted, re-shipping bucket (%d cmds)', __wpdLastRawCommands.length );
 			__wpdSchedulePost();
 			return;
 		}
@@ -1320,15 +1367,15 @@ function wpdm_chromeless_bridge_script() {
 			if ( ! window.wp || ! window.wp.data || typeof window.wp.data.subscribe !== 'function' ) {
 				if ( attempts++ < 40 ) {
 					if ( attempts === 1 || attempts % 5 === 0 ) {
-						console.log( '[wpd-cmd:iframe] subscribe: wp.data not ready yet (attempt %d)', attempts );
+						__wpdLog( '[wpd-cmd:iframe] subscribe: wp.data not ready yet (attempt %d)', attempts );
 					}
 					window.setTimeout( tryBind, 150 );
 				} else {
-					console.log( '[wpd-cmd:iframe] subscribe: gave up waiting for wp.data after %d attempts', attempts );
+					__wpdLog( '[wpd-cmd:iframe] subscribe: gave up waiting for wp.data after %d attempts', attempts );
 				}
 				return;
 			}
-			console.log( '[wpd-cmd:iframe] subscribe: wp.data ready, binding (attempts=%d)', attempts );
+			__wpdLog( '[wpd-cmd:iframe] subscribe: wp.data ready, binding (attempts=%d)', attempts );
 			// Mount the React harvester — tier 3 loaders are hooks and
 			// need a legal render context to execute. On every re-render
 			// the component's effect calls `__wpdSchedulePost` with the
@@ -1340,34 +1387,40 @@ function wpdm_chromeless_bridge_script() {
 	}
 
 	function __wpdUnsubscribeCommands() {
-		__wpdCommandsSubscribed = false;
-		if ( __wpdCommandsUnsub ) {
-			try { __wpdCommandsUnsub(); } catch ( _err ) { /* swallow */ }
-			__wpdCommandsUnsub = null;
-		}
+		__wpdCommandsSubscribed  = false;
 		__wpdCommandsLastPayload = '';
+		if ( __wpdCommandsDebounceId !== null ) {
+			try { window.clearTimeout( __wpdCommandsDebounceId ); } catch ( _err ) { /* swallow */ }
+			__wpdCommandsDebounceId = null;
+		}
+		// Fully tear down the React harvester. Keeping it mounted in
+		// the background wastes CPU: every store tick re-renders the
+		// loader hooks, which rebuild the callback cache and post to
+		// the parent (who drops the message because this window isn't
+		// the subscribed one). On re-subscribe we remount from scratch.
+		__wpdUnmountReactHarvester();
 	}
 
 	function __wpdInvokeCommand( name ) {
-		console.log( '[wpd-cmd:iframe] invoke: looking up "%s"', name );
+		__wpdLog( '[wpd-cmd:iframe] invoke: looking up "%s"', name );
 		// Primary lookup — the React harvester's latest snapshot. This
 		// covers loader-returned commands (Duplicate block, Transform
 		// to, pattern commands) that never appear in the static
 		// `getCommands()` list.
 		var cb = __wpdCommandCallbacks[ name ];
 		if ( typeof cb === 'function' ) {
-			console.log( '[wpd-cmd:iframe] invoke: hit harvester cache for "%s"', name );
+			__wpdLog( '[wpd-cmd:iframe] invoke: hit harvester cache for "%s"', name );
 			try {
 				cb( { close: function () {} } );
 			} catch ( err ) {
-				console.log( '[wpd-cmd:iframe] invoke: "%s" callback threw', name, err );
+				__wpdLog( '[wpd-cmd:iframe] invoke: "%s" callback threw', name, err );
 			}
 			return;
 		}
 		// Fallback — statically registered commands that never passed
 		// through the harvester (registered after the last render).
 		if ( ! window.wp || ! window.wp.data ) {
-			console.log( '[wpd-cmd:iframe] invoke: "%s" not found and wp.data missing', name );
+			__wpdLog( '[wpd-cmd:iframe] invoke: "%s" not found and wp.data missing', name );
 			return;
 		}
 		var sel = null;
@@ -1378,16 +1431,16 @@ function wpdm_chromeless_bridge_script() {
 		if ( ! raw ) return;
 		for ( var i = 0; i < raw.length; i++ ) {
 			if ( raw[ i ] && raw[ i ].name === name && typeof raw[ i ].callback === 'function' ) {
-				console.log( '[wpd-cmd:iframe] invoke: hit getCommands fallback for "%s"', name );
+				__wpdLog( '[wpd-cmd:iframe] invoke: hit getCommands fallback for "%s"', name );
 				try {
 					raw[ i ].callback( { close: function () {} } );
 				} catch ( err ) {
-					console.log( '[wpd-cmd:iframe] invoke: "%s" fallback callback threw', name, err );
+					__wpdLog( '[wpd-cmd:iframe] invoke: "%s" fallback callback threw', name, err );
 				}
 				return;
 			}
 		}
-		console.log( '[wpd-cmd:iframe] invoke: "%s" NOT FOUND in harvester cache or getCommands()', name );
+		__wpdLog( '[wpd-cmd:iframe] invoke: "%s" NOT FOUND in harvester cache or getCommands()', name );
 	}
 
 	// Attach the listener BEFORE the bridge-ready ping so a subscribe
@@ -1398,15 +1451,15 @@ function wpdm_chromeless_bridge_script() {
 		if ( e.data.type === 'wp-desktop-commands-subscribe' ) {
 			__wpdSubscribeCommands();
 		} else if ( e.data.type === 'wp-desktop-commands-unsubscribe' ) {
-			console.log( '[wpd-cmd:iframe] unsubscribe received' );
+			__wpdLog( '[wpd-cmd:iframe] unsubscribe received' );
 			__wpdUnsubscribeCommands();
 		} else if ( e.data.type === 'wp-desktop-commands-invoke' && typeof e.data.name === 'string' ) {
-			console.log( '[wpd-cmd:iframe] invoke received: %s', e.data.name );
+			__wpdLog( '[wpd-cmd:iframe] invoke received: %s', e.data.name );
 			__wpdInvokeCommand( e.data.name );
 		}
 	} );
 
-	console.log( '[wpd-cmd:iframe] bridge ready, listening for subscribe (url=%s)', window.location.href );
+	__wpdLog( '[wpd-cmd:iframe] bridge ready, listening for subscribe (url=%s)', window.location.href );
 	// Handshake: tell the parent we're ready so it can (re)send any
 	// subscribe that was dispatched before this listener attached.
 	// Without this ping, a subscribe posted during iframe navigation
@@ -1418,9 +1471,9 @@ function wpdm_chromeless_bridge_script() {
 			{ type: 'wp-desktop-bridge-ready' },
 			__wpdCommandsOrigin
 		);
-		console.log( '[wpd-cmd:iframe] bridge-ready signal sent to parent' );
+		__wpdLog( '[wpd-cmd:iframe] bridge-ready signal sent to parent' );
 	} catch ( err ) {
-		console.log( '[wpd-cmd:iframe] bridge-ready postMessage threw', err );
+		__wpdLog( '[wpd-cmd:iframe] bridge-ready postMessage threw', err );
 	}
 
 	var links = document.getElementById( 'screen-meta-links' );
@@ -1533,6 +1586,12 @@ JS;
 	// menu-altering allowlist the placeholder resolves to `null` and
 	// the bridge skips the postMessage.
 	$js = str_replace( '/*__WPDM_MENU_PAYLOAD__*/', $menu_payload_json, $js );
+
+	// Gate the command-bridge dev logs. `WP_DEBUG` is the conventional
+	// "I'm a developer and want noisy output" switch; anything else
+	// (default production) silences every `__wpdLog` call in the bridge.
+	$cmd_debug = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? 'true' : 'false';
+	$js        = str_replace( '/*__WPDM_CMD_DEBUG__*/false', $cmd_debug, $js );
 
 	wp_print_inline_script_tag( $js );
 }

--- a/src/ai-assistant.ts
+++ b/src/ai-assistant.ts
@@ -22,7 +22,7 @@ import { HOOKS, doAction, applyFilters } from './hooks';
 import {
 	filterCommands,
 	findCommand,
-	listCommands,
+	listEagerCommands,
 	parseCommandInput,
 	subscribeCommands,
 	type CommandContext,
@@ -295,7 +295,16 @@ export class AiAssistant implements AiAssistantApi {
 		// panel is a page-lifetime singleton, so we don't capture the
 		// unsubscribe handle — the subscription dies with the page.
 		subscribeCommands( () => {
-			if ( this._isOpen && this._input.value.startsWith( '/' ) ) {
+			if ( ! this._isOpen ) {
+				return;
+			}
+			// Refresh when in slash-command mode, or when the input is
+			// empty and we're showing eager commands — harvested
+			// commands arrive asynchronously after panel open, so the
+			// empty-input view has to react to registry changes too.
+			if ( this._input.value.startsWith( '/' ) ) {
+				this._renderCommandMode();
+			} else if ( this._input.value === '' && listEagerCommands().length > 0 ) {
 				this._renderCommandMode();
 			}
 		} );
@@ -320,12 +329,13 @@ export class AiAssistant implements AiAssistantApi {
 		this._input.value = '';
 		this._selectedCommand = 0;
 		this._submitBtn.classList.remove( 'has-value' );
-		// When commands are registered (harvested from the focused
-		// window's `core/commands` store, built-ins, plugin-contributed
-		// palette entries), show them eagerly — the user shouldn't have
-		// to type "/" first to discover what's available. Falls back to
-		// the AI suggestions surface when the registry is empty.
-		if ( listCommands().length > 0 ) {
+		// Show any commands flagged `eager` immediately — today that's
+		// everything harvested from the focused window's
+		// `core/commands` store via the iframe bridge (block editor
+		// actions, pattern commands, feature toggles). Slash-only
+		// commands stay hidden until the user types `/`. If nothing
+		// eager is registered, fall back to the AI suggestions surface.
+		if ( listEagerCommands().length > 0 ) {
 			this._renderCommandMode();
 		} else {
 			this._renderSuggestions();
@@ -444,10 +454,12 @@ export class AiAssistant implements AiAssistantApi {
 			// list eagerly (so the user never has to type `/` just to
 			// see what's available).
 			// -----------------------------------------------------------
-			const eagerPicking = parsed.isCommand === false && this._input.value === '' && listCommands().length > 0;
+			const eagerPicking = parsed.isCommand === false && this._input.value === '' && listEagerCommands().length > 0;
 			if ( ( parsed.isCommand && ! parsed.hasArgsPart ) || eagerPicking ) {
 				const matches = this._sortCommands(
-					eagerPicking ? listCommands() : filterCommands( parsed.slug ),
+					eagerPicking
+						? listEagerCommands()
+						: filterCommands( parsed.slug ).filter( ( c ) => c.eager !== true ),
 				);
 				if ( e.key === 'ArrowDown' ) {
 					e.preventDefault();
@@ -554,9 +566,9 @@ export class AiAssistant implements AiAssistantApi {
 			if ( this._input.value.startsWith( '/' ) ) {
 				this._renderCommandMode();
 			} else if ( ! hasValue ) {
-				// Empty input: eager command list if we have any,
-				// otherwise the AI suggestions surface.
-				if ( listCommands().length > 0 ) {
+				// Empty input: eager command list if any are
+				// registered, otherwise the AI suggestions surface.
+				if ( listEagerCommands().length > 0 ) {
 					this._renderCommandMode();
 				} else {
 					this._renderSuggestions();
@@ -925,8 +937,20 @@ export class AiAssistant implements AiAssistantApi {
 			// Fall through to picking mode when the slug doesn't match.
 		}
 
-		// Picking mode: show filtered command list.
-		const matches = this._sortCommands( filterCommands( parsed.slug ) );
+		// Picking mode. The `eager` flag splits the registry into two
+		// disjoint surfaces:
+		//   - Empty input (not even `/` typed): eager commands only
+		//     (contextual block actions / editor toggles harvested
+		//     from the focused iframe).
+		//   - `/` typed (or `/<query>`): slash-only commands. Eager
+		//     commands are intentionally hidden here — the user has
+		//     announced "I'm looking for a tool to invoke" and mixing
+		//     context-dependent actions into that list is noise.
+		const eagerPicking = parsed.isCommand === false && this._input.value === '';
+		const filtered = eagerPicking
+			? listEagerCommands()
+			: filterCommands( parsed.slug ).filter( ( c ) => c.eager !== true );
+		const matches = this._sortCommands( filtered );
 
 		if ( matches.length === 0 ) {
 			this._resultsEl.innerHTML = `
@@ -952,9 +976,9 @@ export class AiAssistant implements AiAssistantApi {
 						data-slug="${ this._esc( c.slug ) }"
 						data-index="${ i }"
 					>
-						<span class="wp-desktop-ai__cmd-icon dashicons ${ this._esc(
-							c.icon ?? 'dashicons-arrow-right-alt',
-						) }" aria-hidden="true"></span>
+						${ c.iconSvg
+							? `<span class="wp-desktop-ai__cmd-icon wp-desktop-ai__cmd-icon--svg" aria-hidden="true">${ c.iconSvg }</span>`
+							: `<span class="wp-desktop-ai__cmd-icon dashicons ${ this._esc( c.icon ?? 'dashicons-arrow-right-alt' ) }" aria-hidden="true"></span>` }
 						<span class="wp-desktop-ai__cmd-body">
 							<span class="wp-desktop-ai__cmd-title">
 								${ this._esc( c.label ) }

--- a/src/ai-assistant.ts
+++ b/src/ai-assistant.ts
@@ -22,6 +22,7 @@ import { HOOKS, doAction, applyFilters } from './hooks';
 import {
 	filterCommands,
 	findCommand,
+	listCommands,
 	parseCommandInput,
 	subscribeCommands,
 	type CommandContext,
@@ -256,6 +257,15 @@ export class AiAssistant implements AiAssistantApi {
 
 	/** Index of the highlighted command in the filtered list (keyboard nav). */
 	private _selectedCommand = 0;
+	/**
+	 * Set while an arrow key is driving the command-list cursor.
+	 * Blocks the `mouseenter` hover handler from snatching selection
+	 * back to whatever item the pointer happens to rest on after the
+	 * list re-renders. Cleared on the next real `mousemove` — the user
+	 * actually moving the mouse is the signal that they want pointer
+	 * control again.
+	 */
+	private _keyboardNav = false;
 	/** Highlighted index in the per-command argument suggestion list. */
 	private _selectedSuggestion = 0;
 	/** Cached latest suggestion list so keyboard nav can read it without re-calling suggest(). */
@@ -310,7 +320,16 @@ export class AiAssistant implements AiAssistantApi {
 		this._input.value = '';
 		this._selectedCommand = 0;
 		this._submitBtn.classList.remove( 'has-value' );
-		this._renderSuggestions();
+		// When commands are registered (harvested from the focused
+		// window's `core/commands` store, built-ins, plugin-contributed
+		// palette entries), show them eagerly — the user shouldn't have
+		// to type "/" first to discover what's available. Falls back to
+		// the AI suggestions surface when the registry is empty.
+		if ( listCommands().length > 0 ) {
+			this._renderCommandMode();
+		} else {
+			this._renderSuggestions();
+		}
 
 		this._el.removeAttribute( 'hidden' );
 		void this._el.offsetHeight;
@@ -420,26 +439,34 @@ export class AiAssistant implements AiAssistantApi {
 			const parsed = parseCommandInput( this._input.value );
 
 			// -----------------------------------------------------------
-			// PICK MODE — user is still typing the slug after "/".
+			// PICK MODE — user is typing a slug after "/", OR the input
+			// is empty and we're showing the full contextual command
+			// list eagerly (so the user never has to type `/` just to
+			// see what's available).
 			// -----------------------------------------------------------
-			if ( parsed.isCommand && ! parsed.hasArgsPart ) {
-				const matches = filterCommands( parsed.slug );
+			const eagerPicking = parsed.isCommand === false && this._input.value === '' && listCommands().length > 0;
+			if ( ( parsed.isCommand && ! parsed.hasArgsPart ) || eagerPicking ) {
+				const matches = this._sortCommands(
+					eagerPicking ? listCommands() : filterCommands( parsed.slug ),
+				);
 				if ( e.key === 'ArrowDown' ) {
 					e.preventDefault();
 					this._selectedCommand = Math.min(
 						this._selectedCommand + 1,
 						Math.max( 0, matches.length - 1 ),
 					);
-					this._renderCommandMode();
+					this._keyboardNav = true;
+					this._paintCommandSelection();
 					return;
 				}
 				if ( e.key === 'ArrowUp' ) {
 					e.preventDefault();
 					this._selectedCommand = Math.max( 0, this._selectedCommand - 1 );
-					this._renderCommandMode();
+					this._keyboardNav = true;
+					this._paintCommandSelection();
 					return;
 				}
-				if ( e.key === 'Tab' && matches.length > 0 ) {
+				if ( e.key === 'Tab' && matches.length > 0 && ! eagerPicking ) {
 					e.preventDefault();
 					const pick = matches[ this._selectedCommand ] ?? matches[ 0 ];
 					this._input.value = `/${ pick.slug } `;
@@ -527,10 +554,31 @@ export class AiAssistant implements AiAssistantApi {
 			if ( this._input.value.startsWith( '/' ) ) {
 				this._renderCommandMode();
 			} else if ( ! hasValue ) {
-				this._renderSuggestions();
+				// Empty input: eager command list if we have any,
+				// otherwise the AI suggestions surface.
+				if ( listCommands().length > 0 ) {
+					this._renderCommandMode();
+				} else {
+					this._renderSuggestions();
+				}
 			} else {
 				// User is typing a regular AI query and had results from
 				// a prior run; leave them visible so they can keep editing.
+			}
+		} );
+
+		// Reset the keyboard-nav guard on any real pointer movement.
+		// Without this, after pressing ArrowDown the palette stays
+		// "keyboard-controlled" forever and `mouseenter` never regains
+		// authority — moving the mouse again should clearly hand
+		// control back.
+		this._resultsEl.addEventListener( 'mousemove', () => {
+			if ( this._keyboardNav ) {
+				this._keyboardNav = false;
+				const list = this._resultsEl.querySelector( '.wp-desktop-ai__cmd-list' );
+				if ( list ) {
+					list.classList.remove( 'wp-desktop-ai__cmd-list--kb-nav' );
+				}
 			}
 		} );
 	}
@@ -878,7 +926,7 @@ export class AiAssistant implements AiAssistantApi {
 		}
 
 		// Picking mode: show filtered command list.
-		const matches = filterCommands( parsed.slug );
+		const matches = this._sortCommands( filterCommands( parsed.slug ) );
 
 		if ( matches.length === 0 ) {
 			this._resultsEl.innerHTML = `
@@ -909,7 +957,7 @@ export class AiAssistant implements AiAssistantApi {
 						) }" aria-hidden="true"></span>
 						<span class="wp-desktop-ai__cmd-body">
 							<span class="wp-desktop-ai__cmd-title">
-								/${ this._esc( c.slug ) }
+								${ this._esc( c.label ) }
 								${ c.hint ? `<span class="wp-desktop-ai__cmd-hint">${ this._esc( c.hint ) }</span>` : '' }
 							</span>
 							${ c.description
@@ -942,6 +990,12 @@ export class AiAssistant implements AiAssistantApi {
 					this._renderCommandMode();
 				} );
 				btn.addEventListener( 'mouseenter', () => {
+					// Ignore `mouseenter` fired by the DOM landing under
+					// the pointer after a keyboard arrow re-render. A
+					// real `mousemove` clears the guard.
+					if ( this._keyboardNav ) {
+						return;
+					}
 					const idx = parseInt( btn.dataset.index ?? '0', 10 );
 					if ( ! Number.isNaN( idx ) ) {
 						this._selectedCommand = idx;
@@ -1090,6 +1144,48 @@ export class AiAssistant implements AiAssistantApi {
 			} )
 			.join( '' );
 		return `<div class="wp-desktop-ai__cmd-suggest-list">${ items }</div>`;
+	}
+
+	/**
+	 * Stable sort used everywhere the palette turns a command list into
+	 * UI: iframe-harvested commands (owner prefix `iframe:`) float to
+	 * the top so contextual Gutenberg / admin commands from the focused
+	 * window read first. Tier-3 loader entries register ahead of tier-2
+	 * statics inside the bridge, so "stable" preserves that ordering
+	 * within the iframe block.
+	 */
+	private _sortCommands( list: DesktopCommand[] ): DesktopCommand[] {
+		return list.slice().sort( ( a, b ) => {
+			const aIframe = typeof a.owner === 'string' && a.owner.startsWith( 'iframe:' ) ? 0 : 1;
+			const bIframe = typeof b.owner === 'string' && b.owner.startsWith( 'iframe:' ) ? 0 : 1;
+			return aIframe - bIframe;
+		} );
+	}
+
+	/**
+	 * Flip the is-selected class on the command rows without re-rendering
+	 * the whole list. Re-rendering caused two bad effects: (a) fresh DOM
+	 * nodes fired `mouseenter` under the pointer and jumped selection
+	 * back to wherever the mouse was, (b) focus / scroll state was lost.
+	 * Keeping the DOM stable and just flipping a class preserves both.
+	 * Also scrolls the newly-selected row into view for long lists.
+	 */
+	private _paintCommandSelection(): void {
+		const items = this._resultsEl.querySelectorAll< HTMLElement >( '.wp-desktop-ai__cmd-item' );
+		items.forEach( ( el, i ) => {
+			el.classList.toggle( 'is-selected', i === this._selectedCommand );
+		} );
+		// Suppress :hover on the list while keyboard nav is active —
+		// without this the row under the mouse pointer stays styled as
+		// active alongside the new keyboard-selected row.
+		const list = this._resultsEl.querySelector< HTMLElement >( '.wp-desktop-ai__cmd-list' );
+		if ( list ) {
+			list.classList.toggle( 'wp-desktop-ai__cmd-list--kb-nav', this._keyboardNav );
+		}
+		const active = items[ this._selectedCommand ];
+		if ( active && typeof active.scrollIntoView === 'function' ) {
+			active.scrollIntoView( { block: 'nearest' } );
+		}
 	}
 
 	/** Flip the is-selected class on the suggestion rows without re-rendering the whole list. */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -239,6 +239,30 @@ export function unregisterCommand( slug: string ): void {
 	}
 }
 
+/**
+ * Remove every command whose `owner` tag matches. Used by the iframe
+ * command-bridge to evict a focused window's commands when focus moves
+ * elsewhere, and by the command server-sync on plugin deactivation.
+ *
+ * @since 0.16.0
+ */
+export function unregisterByOwner( owner: string ): number {
+	if ( ! owner ) {
+		return 0;
+	}
+	let removed = 0;
+	for ( const [ slug, cmd ] of Array.from( registry.entries() ) ) {
+		if ( cmd.owner === owner ) {
+			registry.delete( slug );
+			removed++;
+		}
+	}
+	if ( removed > 0 ) {
+		notify();
+	}
+	return removed;
+}
+
 /** Return every registered command in insertion order. */
 export function listCommands(): DesktopCommand[] {
 	return Array.from( registry.values() );

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -133,6 +133,32 @@ export interface DesktopCommand {
 	/** Dashicon class for the list item (default `dashicons-arrow-right-alt`). */
 	icon?: string;
 	/**
+	 * Pre-rendered SVG markup rendered inline as the item glyph.
+	 * Takes precedence over `icon` when present. Populated today by
+	 * the iframe-command bridge forwarding `@wordpress/icons` elements
+	 * via `renderToString`; plugins may set it directly when shipping
+	 * a custom SVG is easier than enqueueing a dashicon.
+	 *
+	 * @since 0.16.0
+	 */
+	iconSvg?: string;
+	/**
+	 * When true, the command surfaces in the palette as soon as the
+	 * user opens it — no need to type `/` first. Set this for
+	 * contextual commands whose relevance is obvious from the current
+	 * window (Gutenberg block actions, editor toggles, etc.): the
+	 * iframe-command bridge auto-sets it on every harvested entry.
+	 *
+	 * When falsy (the default), the command is slash-only — it only
+	 * appears after the user types `/`. Good for utility / namespaced
+	 * commands the user must deliberately invoke (plugin-registered
+	 * tools, destructive actions) where showing them eagerly would add
+	 * noise.
+	 *
+	 * @since 0.16.0
+	 */
+	eager?: boolean;
+	/**
 	 * Optional owner tag — the WordPress script handle that registered
 	 * the command. Set this when a plugin deactivation should live-
 	 * unregister its commands: the server-sync module walks the command
@@ -266,6 +292,17 @@ export function unregisterByOwner( owner: string ): number {
 /** Return every registered command in insertion order. */
 export function listCommands(): DesktopCommand[] {
 	return Array.from( registry.values() );
+}
+
+/**
+ * Return only commands flagged `eager` — the subset the palette
+ * surfaces before the user types anything. See the `eager` field on
+ * {@link DesktopCommand} for the opt-in semantics.
+ *
+ * @since 0.16.0
+ */
+export function listEagerCommands(): DesktopCommand[] {
+	return Array.from( registry.values() ).filter( ( c ) => c.eager === true );
 }
 
 /** Look up a command by exact slug. */

--- a/src/commands/iframe-bridge.ts
+++ b/src/commands/iframe-bridge.ts
@@ -30,7 +30,7 @@ import {
 } from './../commands';
 import type { HarvestedCommand } from './../types';
 import type { WindowManager } from './../window-manager';
-import { deriveWindowId } from './../utils';
+import { deriveWindowId, sanitizeIconSvg } from './../utils';
 
 // Small development logging helper to avoid raw `console.log` scattered
 // throughout the file and to satisfy the `no-console` ESLint rule in
@@ -151,7 +151,7 @@ export class IframeCommandBridge {
 			// message listener has attached (navigation inside a window,
 			// slow editor boot, etc.).
 			if ( data.type === 'wp-desktop-bridge-ready' ) {
-				const win = this.windowForSource( e.source );
+				const win = this.manager.findByIframeSource( e.source );
 				devLog(
 					'[wpd-cmd:parent] bridge-ready from window=%s (subscribedTo=%s)',
 					win ? win.id : 'unknown',
@@ -171,11 +171,22 @@ export class IframeCommandBridge {
 				return;
 			}
 			// Attribute the list to whichever window's iframe sent it.
-			const win = this.windowForSource( e.source );
+			const win = this.manager.findByIframeSource( e.source );
 			if ( ! win ) {
 				devLog(
-					'[wpd-cmd:parent] commands-list: could not match source to a window (stack=%o)',
-					this.manager._stack.map( ( w ) => w.id ),
+					'[wpd-cmd:parent] commands-list: could not match source to any window',
+				);
+				return;
+			}
+			// Only accept lists from the currently subscribed window.
+			// Background iframes shouldn't be streaming (they were told
+			// to unsubscribe), but if one does — stale or misbehaving
+			// — we don't want its commands leaking into the palette.
+			if ( win.id !== this.subscribedWindowId ) {
+				devLog(
+					'[wpd-cmd:parent] commands-list: ignoring list from non-subscribed window %s (subscribed=%s)',
+					win.id,
+					this.subscribedWindowId,
 				);
 				return;
 			}
@@ -194,18 +205,6 @@ export class IframeCommandBridge {
 		if ( focused ) {
 			this.onFocused( focused.id );
 		}
-	}
-
-	private windowForSource( source: MessageEventSource | null ) {
-		if ( ! source ) {
-			return null;
-		}
-		for ( const w of this.manager._stack ) {
-			if ( w.iframe && w.iframe.contentWindow === source ) {
-				return w;
-			}
-		}
-		return null;
 	}
 
 	private onFocused( windowId: string ): void {
@@ -271,12 +270,15 @@ export class IframeCommandBridge {
 				continue;
 			}
 			const slug = slugFor( windowId, cmd.name );
+			const safeSvg = typeof cmd.iconSvg === 'string' && cmd.iconSvg !== ''
+				? sanitizeIconSvg( cmd.iconSvg )
+				: '';
 
 			const def: DesktopCommand = {
 				slug,
 				label: cmd.label,
 				icon: iconFor( cmd ),
-				iconSvg: typeof cmd.iconSvg === 'string' && cmd.iconSvg !== '' ? cmd.iconSvg : undefined,
+				iconSvg: safeSvg !== '' ? safeSvg : undefined,
 				owner,
 				// Harvested commands are contextual by construction —
 				// they come from whichever window has focus. Surface

--- a/src/commands/iframe-bridge.ts
+++ b/src/commands/iframe-bridge.ts
@@ -250,7 +250,14 @@ export class IframeCommandBridge {
 				slug,
 				label: cmd.label,
 				icon: iconFor( cmd ),
+				iconSvg: typeof cmd.iconSvg === 'string' && cmd.iconSvg !== '' ? cmd.iconSvg : undefined,
 				owner,
+				// Harvested commands are contextual by construction —
+				// they come from whichever window has focus. Surface
+				// them eagerly so the user sees "Duplicate block" /
+				// "Toggle distraction free" without having to type `/`
+				// first.
+				eager: true,
 				run: cmd.kind === 'navigate' && cmd.url
 					? this.runNavigate( cmd.url, cmd.label, iconFor( cmd ) )
 					: this.runProxy( windowId, cmd.name ),

--- a/src/commands/iframe-bridge.ts
+++ b/src/commands/iframe-bridge.ts
@@ -110,6 +110,32 @@ export class IframeCommandBridge {
 				}
 			}
 		} );
+
+		// A minimized window is visually gone — showing its commands
+		// in the palette would confuse the user ("where would that
+		// even run?"). Evict on minimize; on restore, the window
+		// manager fires a fresh `wp-desktop-window-focused` which flows
+		// through `onFocused` and rebuilds the list.
+		document.addEventListener( 'wp-desktop-window-changed', ( e: Event ) => {
+			const detail = ( e as CustomEvent< { windowId?: string; reason?: string; state?: string } > ).detail;
+			if ( ! detail || typeof detail.windowId !== 'string' ) {
+				return;
+			}
+			if ( detail.reason !== 'state' ) {
+				return;
+			}
+			if ( detail.state !== 'minimized' ) {
+				return;
+			}
+			if ( this.subscribedWindowId === detail.windowId ) {
+				const removed = unregisterByOwner( ownerFor( detail.windowId ) );
+				devLog( '[wpd-cmd:parent] minimized %s → evicted %d commands', detail.windowId, removed );
+				// Clear so a restore-fired focus event re-subscribes
+				// instead of short-circuiting on the `already
+				// subscribed` check.
+				this.subscribedWindowId = null;
+			}
+		} );
 		window.addEventListener( 'message', ( e: MessageEvent ) => {
 			if ( e.origin !== window.location.origin ) {
 				return;

--- a/src/commands/iframe-bridge.ts
+++ b/src/commands/iframe-bridge.ts
@@ -1,0 +1,297 @@
+/**
+ * Iframe → shell palette bridge for `wp.data.select('core/commands')`.
+ *
+ * Subscribes to the currently focused iframe window's WordPress command
+ * registry and re-publishes each command as a slash-command in the shell
+ * palette. Navigation-shaped commands are rewritten to open a new desktop
+ * window instead of navigating the iframe out of chromeless mode;
+ * everything else is proxied back into the iframe on user selection.
+ *
+ * Ownership & lifecycle:
+ *
+ *   - Every command registered here carries an `owner` tag of the form
+ *     `iframe:<windowId>`. When focus shifts we unregister the stale
+ *     owner's entries before subscribing the new one, so the palette
+ *     never shows stale commands from a background window.
+ *   - On window close we evict the corresponding owner.
+ *   - Live updates from the focused iframe repopulate its slice
+ *     incrementally via the same owner, which means a command added or
+ *     removed inside the iframe (Gutenberg entering the editor,
+ *     distraction-free toggled, etc.) shows up in the palette without
+ *     any user interaction.
+ *
+ * @since 0.16.0
+ */
+
+import {
+	registerCommand,
+	unregisterByOwner,
+	type DesktopCommand,
+} from './../commands';
+import type { HarvestedCommand } from './../types';
+import type { WindowManager } from './../window-manager';
+import { deriveWindowId } from './../utils';
+
+// Small development logging helper to avoid raw `console.log` scattered
+// throughout the file and to satisfy the `no-console` ESLint rule in
+// production builds. Logs only when Vite/ESM `import.meta.env.MODE` is
+// not `production`. Remove when the bridge is stable and well-tested.
+function devLog( ...args: unknown[] ) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const mode = ( typeof import.meta !== 'undefined' && ( import.meta as any ).env ) ? ( import.meta as any ).env.MODE : undefined;
+	if ( mode !== 'production' ) {
+		// eslint-disable-next-line no-console
+		console.log( ...args );
+	}
+}
+
+const OWNER_PREFIX = 'iframe:';
+
+function ownerFor( windowId: string ): string {
+	return OWNER_PREFIX + windowId;
+}
+
+function iconFor( harvested: HarvestedCommand ): string {
+	// Core commands ship `icon` as a React element from @wordpress/icons,
+	// which structured-clone refuses. The chromeless bridge only forwards
+	// string icons, so everything else falls back to a sensible default
+	// per classification.
+	if ( harvested.icon && typeof harvested.icon === 'string' && harvested.icon.startsWith( 'dashicons-' ) ) {
+		return harvested.icon;
+	}
+	return harvested.kind === 'navigate'
+		? 'dashicons-external'
+		: 'dashicons-arrow-right-alt';
+}
+
+/**
+ * Build a slug for a harvested command. WordPress command names look like
+ * `core/create-new-post`, which isn't a legal palette slug. We namespace
+ * per window so multiple open windows can expose commands sharing the
+ * same underlying name without colliding in the single shared registry.
+ */
+function slugFor( windowId: string, name: string ): string {
+	const safeName = name.toLowerCase().replace( /[^a-z0-9_-]+/g, '-' );
+	const safeWin = windowId.toLowerCase().replace( /[^a-z0-9_-]+/g, '-' );
+	return `win-${ safeWin }-${ safeName }`;
+}
+
+export interface IframeCommandBridgeOptions {
+	manager: WindowManager;
+	adminUrl: string;
+}
+
+export class IframeCommandBridge {
+	private readonly manager: WindowManager;
+	private readonly adminUrl: string;
+	private subscribedWindowId: string | null = null;
+
+	constructor( opts: IframeCommandBridgeOptions ) {
+		this.manager = opts.manager;
+		this.adminUrl = opts.adminUrl;
+	}
+
+	/** Wire up the focus / close / message listeners. Idempotent. */
+	public install(): void {
+		devLog( '[wpd-cmd:parent] IframeCommandBridge installing' );
+		document.addEventListener( 'wp-desktop-window-focused', ( e: Event ) => {
+			const detail = ( e as CustomEvent< { windowId?: string } > ).detail;
+			if ( detail && typeof detail.windowId === 'string' ) {
+				devLog( '[wpd-cmd:parent] window-focused: %s', detail.windowId );
+				this.onFocused( detail.windowId );
+			}
+		} );
+		document.addEventListener( 'wp-desktop-window-closed', ( e: Event ) => {
+			const detail = ( e as CustomEvent< { windowId?: string } > ).detail;
+			if ( detail && typeof detail.windowId === 'string' ) {
+				unregisterByOwner( ownerFor( detail.windowId ) );
+				if ( this.subscribedWindowId === detail.windowId ) {
+					this.subscribedWindowId = null;
+				}
+			}
+		} );
+		window.addEventListener( 'message', ( e: MessageEvent ) => {
+			if ( e.origin !== window.location.origin ) {
+				return;
+			}
+			const data = e.data as { type?: string; commands?: HarvestedCommand[] } | null;
+			if ( ! data || typeof data.type !== 'string' ) {
+				return;
+			}
+
+			// Iframe signaled it's ready — if this source is the iframe
+			// of the currently focused window, (re)send subscribe. This
+			// covers the race where onFocused fires before the iframe's
+			// message listener has attached (navigation inside a window,
+			// slow editor boot, etc.).
+			if ( data.type === 'wp-desktop-bridge-ready' ) {
+				const win = this.windowForSource( e.source );
+				devLog(
+					'[wpd-cmd:parent] bridge-ready from window=%s (subscribedTo=%s)',
+					win ? win.id : 'unknown',
+					this.subscribedWindowId,
+				);
+				if ( win && win.id === this.subscribedWindowId ) {
+					this.sendSubscribe( win.id );
+				}
+				return;
+			}
+
+			if ( data.type !== 'wp-desktop-commands-list' ) {
+				return;
+			}
+			if ( ! Array.isArray( data.commands ) ) {
+				devLog( '[wpd-cmd:parent] commands-list: payload not an array', data );
+				return;
+			}
+			// Attribute the list to whichever window's iframe sent it.
+			const win = this.windowForSource( e.source );
+			if ( ! win ) {
+				devLog(
+					'[wpd-cmd:parent] commands-list: could not match source to a window (stack=%o)',
+					this.manager._stack.map( ( w ) => w.id ),
+				);
+				return;
+			}
+			devLog(
+				'[wpd-cmd:parent] commands-list: %d cmds from window "%s"',
+				data.commands.length,
+				win.id,
+				data.commands,
+			);
+			this.applyList( win.id, data.commands );
+		} );
+
+		// Seed against whatever window is focused at install time.
+		const focused = this.manager.getFocused();
+		devLog( '[wpd-cmd:parent] install: initial focused window=%s', focused ? focused.id : null );
+		if ( focused ) {
+			this.onFocused( focused.id );
+		}
+	}
+
+	private windowForSource( source: MessageEventSource | null ) {
+		if ( ! source ) {
+			return null;
+		}
+		for ( const w of this.manager._stack ) {
+			if ( w.iframe && w.iframe.contentWindow === source ) {
+				return w;
+			}
+		}
+		return null;
+	}
+
+	private onFocused( windowId: string ): void {
+		if ( this.subscribedWindowId === windowId ) {
+			devLog( '[wpd-cmd:parent] onFocused: already subscribed to %s, skipping', windowId );
+			return;
+		}
+
+		// Tell the previously focused iframe to stop streaming.
+		if ( this.subscribedWindowId ) {
+			const prev = this.manager.getById( this.subscribedWindowId );
+			if ( prev && prev.iframe && prev.iframe.contentWindow ) {
+				try {
+					prev.iframe.contentWindow.postMessage(
+						{ type: 'wp-desktop-commands-unsubscribe' },
+						window.location.origin,
+					);
+				} catch {
+					/* swallow */
+				}
+			}
+			const removed = unregisterByOwner( ownerFor( this.subscribedWindowId ) );
+			devLog( '[wpd-cmd:parent] onFocused: evicted %d commands from prior window %s', removed, this.subscribedWindowId );
+		}
+
+		this.subscribedWindowId = windowId;
+
+		this.sendSubscribe( windowId );
+	}
+
+	private sendSubscribe( windowId: string ): void {
+		const win = this.manager.getById( windowId );
+		if ( ! win ) {
+			devLog( '[wpd-cmd:parent] sendSubscribe: no window found for id %s', windowId );
+			return;
+		}
+		if ( ! win.iframe ) {
+			devLog( '[wpd-cmd:parent] sendSubscribe: window %s is native (no iframe) — nothing to subscribe', windowId );
+			return;
+		}
+		if ( ! win.iframe.contentWindow ) {
+			devLog( '[wpd-cmd:parent] sendSubscribe: iframe for %s has no contentWindow yet', windowId );
+			return;
+		}
+		try {
+			win.iframe.contentWindow.postMessage(
+				{ type: 'wp-desktop-commands-subscribe' },
+				window.location.origin,
+			);
+			devLog( '[wpd-cmd:parent] sendSubscribe: sent subscribe to iframe for %s', windowId );
+		} catch ( err ) {
+			devLog( '[wpd-cmd:parent] sendSubscribe: postMessage threw', err );
+		}
+	}
+
+	private applyList( windowId: string, commands: HarvestedCommand[] ): void {
+		const owner = ownerFor( windowId );
+		unregisterByOwner( owner );
+
+		let registered = 0;
+		for ( const cmd of commands ) {
+			if ( ! cmd || ! cmd.name || ! cmd.label ) {
+				continue;
+			}
+			const slug = slugFor( windowId, cmd.name );
+
+			const def: DesktopCommand = {
+				slug,
+				label: cmd.label,
+				icon: iconFor( cmd ),
+				owner,
+				run: cmd.kind === 'navigate' && cmd.url
+					? this.runNavigate( cmd.url, cmd.label, iconFor( cmd ) )
+					: this.runProxy( windowId, cmd.name ),
+			};
+			registerCommand( def );
+			registered++;
+		}
+		devLog( '[wpd-cmd:parent] applyList: registered %d/%d commands for owner %s', registered, commands.length, owner );
+	}
+
+	private runNavigate(
+		url: string,
+		title: string,
+		icon: string,
+	): DesktopCommand[ 'run' ] {
+		return ( _args, ctx ) => {
+			ctx.close();
+			const id = deriveWindowId( url, this.adminUrl );
+			this.manager.open( { id, baseId: id, url, title, icon } );
+		};
+	}
+
+	private runProxy(
+		windowId: string,
+		name: string,
+	): DesktopCommand[ 'run' ] {
+		return ( _args, ctx ) => {
+			ctx.close();
+			const win = this.manager.getById( windowId );
+			if ( ! win || ! win.iframe || ! win.iframe.contentWindow ) {
+				return;
+			}
+			try {
+				win.iframe.contentWindow.postMessage(
+					{ type: 'wp-desktop-commands-invoke', name },
+					window.location.origin,
+				);
+			} catch {
+				/* swallow */
+			}
+			this.manager.focus( win );
+		};
+	}
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -27,6 +27,7 @@ import { WallpaperLayer } from './wallpapers/layer';
 import { registerBuiltInWallpapers } from './wallpapers/built-in';
 import { createWallpaperRegistrySync } from './wallpapers/server-sync';
 import { createCommandRegistrySync } from './commands/server-sync';
+import { IframeCommandBridge } from './commands/iframe-bridge';
 import { loadVendorScript } from './wallpapers/vendor-loader';
 import {
 	collectWallpaperSurfaces,
@@ -439,6 +440,15 @@ function init(): void {
 		isOpen: () => aiAssistant.isOpen,
 	} );
 	installPaletteShortcut();
+
+	// Iframe command bridge — pulls `wp.data.select('core/commands')` out
+	// of whichever window has focus and exposes the commands as slash-
+	// commands in the shell palette. Navigation commands rewrite to open
+	// a new desktop window; actions proxy back into the iframe.
+	new IframeCommandBridge( {
+		manager,
+		adminUrl: config.adminUrl,
+	} ).install();
 
 	// Admin-bar "Ask AI" button and programmatic `wp-desktop-open-ai`
 	// dispatches now route through openPaletteOnly so any other plugin

--- a/src/types.ts
+++ b/src/types.ts
@@ -798,6 +798,31 @@ export interface ToastTypeDef {
 }
 
 /**
+ * A single command harvested from an iframe's `wp.data.select('core/commands')`
+ * registry. Emitted by the chromeless bridge and consumed by the parent's
+ * iframe-command bridge module, which re-registers each entry as a
+ * slash-command in the shell palette for whichever window currently has focus.
+ *
+ * `kind` is decided inside the iframe by dry-invoking the original callback
+ * inside a `window.location`-intercept sandbox: a callback whose only
+ * observable effect is a navigation is classified `navigate` (with the
+ * captured `url`), and the parent rewrites the selection to open a new
+ * desktop window instead of navigating the current iframe out of chromeless
+ * mode. Anything else is `action` — the parent proxies execution back
+ * into the iframe via `wp-desktop-commands-invoke`.
+ *
+ * @since 0.16.0
+ */
+export interface HarvestedCommand {
+	name: string;
+	label: string;
+	icon?: string;
+	context?: string;
+	kind: 'navigate' | 'action';
+	url?: string;
+}
+
+/**
  * Bridge events sent from iframe to parent shell.
  */
 export type BridgeEventFromIframe =
@@ -806,7 +831,8 @@ export type BridgeEventFromIframe =
 	| { type: 'wp-desktop-notification'; title: string; body: string }
 	| { type: 'wp-desktop-ready' }
 	| { type: 'wp-desktop-screen-meta'; panels: ( 'screen-options' | 'help' )[] }
-	| { type: 'wp-desktop-screen-meta-state'; open: 'screen-options' | 'help' | null };
+	| { type: 'wp-desktop-screen-meta-state'; open: 'screen-options' | 'help' | null }
+	| { type: 'wp-desktop-commands-list'; commands: HarvestedCommand[] };
 
 /**
  * Bridge events sent from parent shell to iframe.
@@ -814,4 +840,7 @@ export type BridgeEventFromIframe =
 export type BridgeEventToIframe =
 	| { type: 'wp-desktop-focus' }
 	| { type: 'wp-desktop-color-scheme'; scheme: string }
-	| { type: 'wp-desktop-toggle-panel'; panel: 'screen-options' | 'help' };
+	| { type: 'wp-desktop-toggle-panel'; panel: 'screen-options' | 'help' }
+	| { type: 'wp-desktop-commands-subscribe' }
+	| { type: 'wp-desktop-commands-unsubscribe' }
+	| { type: 'wp-desktop-commands-invoke'; name: string };

--- a/src/types.ts
+++ b/src/types.ts
@@ -817,6 +817,20 @@ export interface HarvestedCommand {
 	name: string;
 	label: string;
 	icon?: string;
+	/**
+	 * Pre-rendered SVG markup for the command's icon. Gutenberg ships
+	 * most command icons as React elements from `@wordpress/icons`
+	 * (e.g. the `duplicate` block glyph), which the structured-clone
+	 * algorithm behind `postMessage` can't carry. The iframe renders
+	 * these to an HTML string via `wp.element.renderToString` and
+	 * forwards the result here; the parent palette injects it directly
+	 * into the row's icon slot. Empty / absent when the icon was a
+	 * plain dashicons class (covered by `icon` above) or unset.
+	 *
+	 * Trust note: the string is same-origin and never user-authored,
+	 * so rendering via `innerHTML` is safe.
+	 */
+	iconSvg?: string;
 	context?: string;
 	kind: 'navigate' | 'action';
 	url?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,3 +106,84 @@ export function urlMatchKey( url: string ): string {
 		return url;
 	}
 }
+
+/**
+ * Sanitize an SVG string before injecting it via `innerHTML`.
+ *
+ * The iframe command bridge forwards `@wordpress/icons` React elements
+ * through `renderToString` → postMessage → parent. The payload is
+ * same-origin by construction — only a script already running with
+ * admin privileges in the iframe could forge it — but "same-origin"
+ * is not "safe": a compromised or malicious plugin inside the iframe
+ * could register a command whose icon renders script / event-handler
+ * SVG. Strip the well-known dangerous subset so a future extension of
+ * the bridge (a plugin-authored icon pipeline, user-supplied themes)
+ * can't turn a layout glyph into an XSS primitive.
+ *
+ * The policy is intentionally strict: discard anything that doesn't
+ * parse into a single root `<svg>` element, drop `<script>` / `<style>`
+ * / `<foreignObject>` subtrees, strip any attribute whose name starts
+ * with `on`, and drop any attribute value containing `javascript:`.
+ * Falls back to an empty string when the DOM parser isn't available
+ * (SSR, unit tests without jsdom) — callers treat empty as "no SVG,
+ * use the dashicon fallback".
+ */
+export function sanitizeIconSvg( svg: string ): string {
+	if ( typeof svg !== 'string' || svg === '' ) {
+		return '';
+	}
+	if ( typeof DOMParser === 'undefined' ) {
+		return '';
+	}
+	let doc: Document;
+	try {
+		doc = new DOMParser().parseFromString( svg, 'image/svg+xml' );
+	} catch {
+		return '';
+	}
+	const root = doc.documentElement;
+	if ( ! root || root.nodeName.toLowerCase() !== 'svg' ) {
+		return '';
+	}
+	// Bail on any parsererror node the browser inserts on malformed input.
+	if ( doc.getElementsByTagName( 'parsererror' ).length > 0 ) {
+		return '';
+	}
+
+	const BANNED_TAGS = new Set( [ 'script', 'style', 'foreignobject', 'iframe', 'object', 'embed' ] );
+	const walk = ( el: Element ): void => {
+		// Snapshot first — we mutate siblings during traversal.
+		const children = Array.from( el.children );
+		for ( const child of children ) {
+			if ( BANNED_TAGS.has( child.nodeName.toLowerCase() ) ) {
+				child.remove();
+				continue;
+			}
+			// Strip event-handler attributes and javascript: URLs.
+			for ( const attr of Array.from( child.attributes ) ) {
+				const name = attr.name.toLowerCase();
+				const value = attr.value.trim().toLowerCase();
+				if ( name.startsWith( 'on' ) ) {
+					child.removeAttribute( attr.name );
+					continue;
+				}
+				if ( value.startsWith( 'javascript:' ) ) {
+					child.removeAttribute( attr.name );
+				}
+			}
+			walk( child );
+		}
+	};
+	walk( root );
+
+	// Root attributes need the same treatment.
+	for ( const attr of Array.from( root.attributes ) ) {
+		const name = attr.name.toLowerCase();
+		const value = attr.value.trim().toLowerCase();
+		if ( name.startsWith( 'on' ) || value.startsWith( 'javascript:' ) ) {
+			root.removeAttribute( attr.name );
+		}
+	}
+
+	return root.outerHTML;
+}

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -666,6 +666,21 @@ export class WindowManager {
 		return [ ...this._stack ];
 	}
 
+	/**
+	 * Find the window whose iframe's contentWindow matches the given
+	 * message source. Used by cross-frame bridges to attribute inbound
+	 * `postMessage` events to the originating window without reaching
+	 * into `_stack`.
+	 */
+	public findByIframeSource( source: MessageEventSource | null ): Window | undefined {
+		if ( ! source ) {
+			return undefined;
+		}
+		return this._stack.find(
+			( w ) => w.iframe !== null && w.iframe.contentWindow === source,
+		);
+	}
+
 	/** Get the currently focused (topmost) window. */
 	public getFocused(): Window | undefined {
 		return this._stack.length > 0 ? this._stack[ this._stack.length - 1 ] : undefined;

--- a/tests/vitest/commands-registry.test.ts
+++ b/tests/vitest/commands-registry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the new 0.16.0 command-registry surface:
+ *
+ *   - `unregisterByOwner( owner )` bulk-evicts every command sharing
+ *     the given owner tag. Used by the iframe-command bridge on focus
+ *     change / window close, and by the command server-sync on plugin
+ *     deactivation.
+ *   - `listEagerCommands()` returns only commands flagged `eager`. The
+ *     palette renders these on empty input (before the user types `/`);
+ *     slash-only commands remain hidden.
+ *   - The two surfaces are disjoint: a command flagged `eager` shows
+ *     in `listEagerCommands()` but not in `filterCommands( '' )`-style
+ *     slash-only flows (asserted indirectly — `eager`-filtered slash
+ *     results are produced by the palette, not the registry; we only
+ *     check that the eager flag round-trips through the registry).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+type CommandsModule = typeof import( '../../src/commands' );
+
+async function load(): Promise< CommandsModule > {
+	vi.resetModules();
+	return await import( '../../src/commands' );
+}
+
+describe( 'commands.ts — 0.16.0 additions', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		vi.restoreAllMocks();
+	} );
+
+	describe( 'unregisterByOwner', () => {
+		test( 'removes every command with a matching owner and returns the count', async () => {
+			const { registerCommand, unregisterByOwner, listCommands } = await load();
+			registerCommand( { slug: 'a', label: 'A', owner: 'iframe:win-1', run: () => {} } );
+			registerCommand( { slug: 'b', label: 'B', owner: 'iframe:win-1', run: () => {} } );
+			registerCommand( { slug: 'c', label: 'C', owner: 'iframe:win-2', run: () => {} } );
+
+			const removed = unregisterByOwner( 'iframe:win-1' );
+
+			expect( removed ).toBe( 2 );
+			const remaining = listCommands().map( ( c ) => c.slug );
+			expect( remaining ).toEqual( [ 'c' ] );
+		} );
+
+		test( 'leaves untagged commands alone', async () => {
+			const { registerCommand, unregisterByOwner, listCommands } = await load();
+			registerCommand( { slug: 'tagged', label: 'T', owner: 'iframe:win-1', run: () => {} } );
+			registerCommand( { slug: 'free', label: 'F', run: () => {} } );
+
+			unregisterByOwner( 'iframe:win-1' );
+
+			expect( listCommands().map( ( c ) => c.slug ) ).toEqual( [ 'free' ] );
+		} );
+
+		test( 'returns 0 when the owner is empty or matches nothing', async () => {
+			const { registerCommand, unregisterByOwner } = await load();
+			registerCommand( { slug: 'a', label: 'A', owner: 'iframe:win-1', run: () => {} } );
+
+			expect( unregisterByOwner( '' ) ).toBe( 0 );
+			expect( unregisterByOwner( 'iframe:win-99' ) ).toBe( 0 );
+		} );
+
+		test( 'notifies subscribers exactly once per call when commands were removed', async () => {
+			const { registerCommand, unregisterByOwner, subscribeCommands } = await load();
+			registerCommand( { slug: 'a', label: 'A', owner: 'iframe:win-1', run: () => {} } );
+			registerCommand( { slug: 'b', label: 'B', owner: 'iframe:win-1', run: () => {} } );
+
+			let calls = 0;
+			const unsubscribe = subscribeCommands( () => {
+				calls++;
+			} );
+
+			unregisterByOwner( 'iframe:win-1' );
+			expect( calls ).toBe( 1 );
+
+			// Second call — nothing to remove, must not notify.
+			unregisterByOwner( 'iframe:win-1' );
+			expect( calls ).toBe( 1 );
+
+			unsubscribe();
+		} );
+	} );
+
+	describe( 'listEagerCommands', () => {
+		test( 'returns only the eager subset', async () => {
+			const { registerCommand, listEagerCommands } = await load();
+			registerCommand( { slug: 'slash-only', label: 'S', run: () => {} } );
+			registerCommand( { slug: 'eager-1', label: 'E1', eager: true, run: () => {} } );
+			registerCommand( { slug: 'eager-2', label: 'E2', eager: true, run: () => {} } );
+			registerCommand( { slug: 'explicit-false', label: 'X', eager: false, run: () => {} } );
+
+			const slugs = listEagerCommands().map( ( c ) => c.slug );
+			expect( slugs ).toEqual( [ 'eager-1', 'eager-2' ] );
+		} );
+
+		test( 'returns an empty array when no eager commands are registered', async () => {
+			const { registerCommand, listEagerCommands } = await load();
+			registerCommand( { slug: 'a', label: 'A', run: () => {} } );
+			expect( listEagerCommands() ).toEqual( [] );
+		} );
+	} );
+} );

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'vitest';
 import {
 	deriveWindowId,
 	sanitizeClassName,
+	sanitizeIconSvg,
 	urlMatchKey,
 } from '../../src/utils';
 
@@ -128,5 +129,59 @@ describe( 'utils/urlMatchKey', () => {
 		// input as-is rather than bubbling up a TypeError.
 		const weird = 'not a\0 url';
 		expect( urlMatchKey( weird ) ).toBeTypeOf( 'string' );
+	} );
+} );
+
+describe( 'utils/sanitizeIconSvg', () => {
+	test( 'round-trips a clean <svg> through the parser', () => {
+		const input = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>';
+		const out = sanitizeIconSvg( input );
+		expect( out ).toContain( '<svg' );
+		expect( out ).toContain( '<path' );
+		expect( out ).toContain( 'viewBox="0 0 24 24"' );
+	} );
+
+	test( 'strips <script> children', () => {
+		const input = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><path d="M0 0"/></svg>';
+		const out = sanitizeIconSvg( input );
+		expect( out ).not.toContain( '<script' );
+		expect( out ).not.toContain( 'alert' );
+		expect( out ).toContain( '<path' );
+	} );
+
+	test( 'strips <foreignObject> subtrees', () => {
+		const input = '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><iframe src="x"></iframe></foreignObject></svg>';
+		const out = sanitizeIconSvg( input );
+		expect( out.toLowerCase() ).not.toContain( 'foreignobject' );
+		expect( out ).not.toContain( '<iframe' );
+	} );
+
+	test( 'strips on* event-handler attributes', () => {
+		const input = '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><path onclick="x" d="M0"/></svg>';
+		const out = sanitizeIconSvg( input );
+		expect( out ).not.toContain( 'onload' );
+		expect( out ).not.toContain( 'onclick' );
+		expect( out ).toContain( '<path' );
+	} );
+
+	test( 'strips javascript: URL attribute values', () => {
+		const input = '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><path d="M0"/></a></svg>';
+		const out = sanitizeIconSvg( input );
+		expect( out.toLowerCase() ).not.toContain( 'javascript:' );
+	} );
+
+	test( 'returns empty string when root is not an <svg>', () => {
+		expect( sanitizeIconSvg( '<div>nope</div>' ) ).toBe( '' );
+	} );
+
+	test( 'returns empty string for empty input', () => {
+		expect( sanitizeIconSvg( '' ) ).toBe( '' );
+	} );
+
+	test( 'returns empty string for malformed markup', () => {
+		// Parse error path — the function bails rather than returning
+		// partially-recovered output.
+		const out = sanitizeIconSvg( '<svg><path' );
+		expect( out ).toBe( '' );
 	} );
 } );


### PR DESCRIPTION
# feat/iframe-command-bridge — Harvest `@wordpress/commands` into the shell palette

## Summary

https://github.com/user-attachments/assets/1f0c6c87-99f2-4ba6-a3ce-32db0e94d912


Replaces the "press Cmd+K twice to escape the native palette" workaround with a proper bridge: the shell palette **hijacks** Cmd+K inside chromeless iframes, **harvests** the focused window's `wp.data.select('core/commands')` registry, and **re-publishes** every command (context-scoped statics *and* dynamic loader hooks like "Duplicate block") as first-class entries in our own palette. Selecting one runs inside the source iframe via postMessage, or opens a new desktop window when the command is a pure navigation.

One palette. One keystroke. Contextual to the focused window. The native WP palette is never seen.

## Motivation

Before this PR we had two disconnected palettes:

1. WP's native `@wordpress/commands` UI — only visible while focus was inside a Gutenberg / site-editor iframe.
2. Our AI Assistant palette — the shell-level surface the desktop UX is built around.

Cmd+K fired whichever one owned focus first, and the user had to double-tap to escalate from one to the other. Worse, every command the WP editor exposed ("toggle distraction-free", "duplicate block", pattern insertions) was stranded inside its iframe and invisible to the desktop shell.

The fix is architecturally invasive enough that we couldn't ship it as a small follow-up — it touches the chromeless bridge, the palette UI, the command registry, and adds a new cross-frame protocol. Grouping it into one PR keeps the story readable.

## What changed

### New cross-frame protocol

| Direction | Message | Purpose |
|---|---|---|
| parent → iframe | `wp-desktop-commands-subscribe` | Start streaming this iframe's command list |
| parent → iframe | `wp-desktop-commands-unsubscribe` | Stop streaming |
| parent → iframe | `wp-desktop-commands-invoke` | Run a previously-harvested command |
| iframe → parent | `wp-desktop-commands-list` | Ship the current command snapshot |
| iframe → parent | `wp-desktop-bridge-ready` | Handshake — fixes the subscribe-before-listener race |

All messages are `window.location.origin`-gated on both ends.

### Iframe side (`includes/render.php`)

- **Cmd+K is captured unconditionally** and forwarded to the parent. The prior "let the native palette flash, dismiss with synthetic Escape" block is gone. Defensive CSS hides any `.commands-command-menu` that might render via a non-keyboard path.
- **A React component is mounted into a hidden div** using `wp.element.createRoot`. It's the only way to legally call `useSelect` + each loader's `hook` — Gutenberg loaders *are* React hooks and can't run outside a render. We went through a classic setState-inside-useEffect loop en route to a ref-based bucket (see "Gotchas"). Results cover tier-2 (`getCommands(true)`) + tier-3 (`getCommandLoaders(true)`). Tier-1 (global nav) is deliberately skipped — the dock already has those.
- **Static classification** for navigation commands: `Function.prototype.toString()` + regex for `location.href = '…'` / `.assign('…')` / `.replace('…')`. An earlier dry-run sandbox silently failed to intercept the href setter (`Location.prototype.href` is non-configurable) and every nav callback actually navigated the iframe → infinite window spawning. The static scan is now the only safe path.
- **React icons are flattened to SVG** via `wp.element.renderToString` before crossing postMessage (structured clone refuses React elements). Parent injects the SVG via `innerHTML` in the palette row.
- **Callback cache** (`__wpdCommandCallbacks`): loader-returned commands don't exist in `getCommands()`, so invoke needs its own lookup keyed on command name, rebuilt every merge so closures stay fresh.

### Parent side (`src/commands/iframe-bridge.ts`)

- New `IframeCommandBridge` class; installed from `desktop.ts`.
- On focus change: unsubscribe + evict the prior `iframe:<windowId>` owner, subscribe the new one.
- On minimize of the subscribed window: evict + clear the subscription so restore re-hydrates through `onFocused`.
- On close: evict.
- Navigation commands register a `run` that opens a new desktop window via `manager.open({ id: deriveWindowId(url), ... })` instead of navigating the current iframe.
- Action commands register a `run` that posts `wp-desktop-commands-invoke` back to the source iframe.

### Command registry (`src/commands.ts`)

- New `owner?: string` field (already existed) + new `unregisterByOwner(owner)` helper for bulk eviction.
- New `eager?: boolean` field: `true` ⇒ surfaces before the user types `/`. Harvested iframe commands auto-set it. Built-in commands stay slash-only.
- New `listEagerCommands()` export for the palette.
- New `iconSvg?: string` field for inline SVG glyphs.

### Palette UX (`src/ai-assistant.ts`, `assets/css/ai-assistant.css`)

- **Empty input** → eager commands only, sorted so iframe-harvested entries float to the top.
- **Typed `/`** → slash-only commands (disjoint from eager — the two surfaces don't overlap).
- **Selection paint** is now incremental (class toggle, no re-render) so arrowing through the list doesn't clobber hover state or scroll position.
- **Keyboard-nav guard** class on the list container suppresses `:hover` styling while arrow keys drive selection; a real `mousemove` clears it.
- **scrollIntoView** on arrow-key selection for long lists.
- **Bigger icon tiles** (36×36) with larger dashicons / SVG glyphs to match the native palette's scale.
- **Vertical centering** when a command has no description (CSS `:has()`).
- **Label as primary line**, slug hidden when no description is present — the harvested command names (`core/block-editor/action-duplicate`) are ugly and not user-facing.

### Docs

- `docs/architecture.md` — new "Command palette bridge (Cmd+K, hijacked)" section: names the approach as a hack, walks through both sides, calls out caveats.
- `docs/javascript-reference.md` — rewritten `wp-desktop-commands-list` payload (no more dry-invoke; static regex + React-mounted loader harvest), added `iconSvg` / `eager` / `owner` to `registerCommand` docs with the disjoint eager/slash behavior spelled out.

## Gotchas worth knowing (for future-us)

1. **`Location.prototype.href` is non-configurable.** An `Object.defineProperty` shim silently fails — no throw, no sentinel. Any code that relies on intercepting navigation via this property should use a static approach (regex on the callback's source) or assume the navigation *will* happen.
2. **useState-based aggregation in the React harvester loops.** Loader hooks return fresh array references on every render even when contents are unchanged. setState inside useEffect → re-render → new ref → setState → Maximum update depth. Refs + content-fingerprint deps solved it.
3. **Loader commands aren't in `getCommands()`.** Invoke must consult the harvester's own cache first.
4. **The subscribe-before-listener race is real.** The iframe's message listener isn't attached until the bridge script runs (after `admin_footer`). The parent can send `subscribe` arbitrarily earlier. Fix: iframe posts `wp-desktop-bridge-ready` once listeners exist; parent replays subscribe if the source is the currently focused window.
5. **Minimized windows must evict.** A focused-but-minimized window otherwise leaves its commands in the palette with no clear mental model of where they'd run.

## Testing

- `npm run build` — green, bundle grew by ~4 kB gzipped.
- `npm test` — 364 / 364 passing.
- `php -l includes/render.php` — clean.

Manual QA:

- Open Posts → Add New (Gutenberg) → Cmd+K → palette opens single-press, shows block commands. Pick "Duplicate" → block actually duplicates inside the editor.
- Open Dashboard in a new window while Add Post stays open → Cmd+K in dashboard → no Gutenberg commands (expected — dashboard has no contextual registry).
- Refocus Add Post → Cmd+K → block commands return.
- Minimize Add Post → Cmd+K from somewhere else → its commands are gone from the list.
- Restore Add Post → commands come back.
- Select a block in the editor → Cmd+K → block-specific commands (transform to, move up/down) appear; switch selection, list updates.
- Type `/` → eager commands vanish, the built-in `/open` is the only entry.

## Breaking changes

None for end users. Plugin-facing: the `eager` flag defaults to `false`, so commands registered via `wp.desktop.registerCommand()` are now slash-only unless they opt in. No existing caller relies on the previous "always visible on empty input" behavior — the palette only recently shipped that surface.

## Follow-ups (not in this PR)

- Stale-closure detection for loader commands invoked long after the editor re-rendered (current behavior: best-effort, may no-op).
- Extend the same bridge pattern to `core/block-editor`'s `useCommandLoader` hooks that depend on selection state beyond what we currently surface.
- Documented example in `docs/examples/` showing `eager: true` vs. default.