### PR TITLE
docs: add Playground demo button to README

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,18 @@
+{
+  "landingPage": "/wp-admin/",
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "url",
+        "url": "https://github.com/WordPress/desktop-mode/releases/latest/download/wp-desktop-mode.zip"
+      },
+      "options": { "activate": true }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A WordPress plugin that reimagines `/wp-admin` as a desktop operating system. Ad
 
 Zero Core patches. Every feature is wired through public WordPress hooks.
 
-<a href="https://playground.wordpress.net#%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Flatest%2Fdownload%2Fwp-desktop-mode.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D">
+<a href="https://playground.wordpress.net?blueprint-url=https://raw.githubusercontent.com/WordPress/desktop-mode/refs/heads/trunk/.wordpress-org/blueprints/blueprint.json">
   <img src="https://raw.githubusercontent.com/WordPress/action-wp-playground-pr-preview/v2/assets/playground-preview-button.svg" alt="Playground Demo Link" width="180">
 </a>
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A WordPress plugin that reimagines `/wp-admin` as a desktop operating system. Ad
 
 Zero Core patches. Every feature is wired through public WordPress hooks.
 
+<a href="https://playground.wordpress.net#%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Flatest%2Fdownload%2Fwp-desktop-mode.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D">
+  <img src="https://raw.githubusercontent.com/WordPress/action-wp-playground-pr-preview/v2/assets/playground-preview-button.svg" alt="Playground Demo Link" width="180">
+</a>
+
 ## Demo
 
 <video src="https://github.com/user-attachments/assets/590aacc2-e9d7-4213-889e-b91e060e1bd8" controls width="720"></video>


### PR DESCRIPTION
## Summary
- Adds a "Playground Demo Link" button near the top of the README that launches the plugin in WordPress Playground with PHP 8.2 + latest WP, installing and activating the latest release zip on boot.

## Test plan
- [ ] Preview the README on GitHub and confirm the button renders above the Demo section
- [ ] Click the button and verify Playground boots to /wp-admin/ with the plugin installed and activated