### PR TITLE
feat: cycle window focus with backtick hotkey

### DIFF
--- a/includes/render.php
+++ b/includes/render.php
@@ -1492,9 +1492,15 @@ function wpdm_chromeless_bridge_script() {
 		if ( e.ctrlKey || e.metaKey || e.altKey ) return;
 		if ( e.code !== 'Backquote' ) return;
 
+		// IFRAME case catches Gutenberg: the block canvas is a nested
+		// iframe, and Gutenberg re-dispatches cloned keydowns up to
+		// this document for its shortcut system. Without this branch
+		// typing ` in a block would cycle windows. Any other nested
+		// iframe owning keyboard handling gets the same treatment.
 		var el = document.activeElement;
 		if ( el ) {
 			var tag = el.tagName;
+			if ( tag === 'IFRAME' ) return;
 			if ( tag === 'TEXTAREA' ) return;
 			if ( tag === 'INPUT' ) {
 				var type = ( el.type || '' ).toLowerCase();

--- a/includes/render.php
+++ b/includes/render.php
@@ -1000,6 +1000,52 @@ function wpdm_chromeless_bridge_script() {
 		}, true );
 	} )();
 
+	/*
+	 * ` / Shift+` forwarder — window switcher.
+	 *
+	 * Bare backtick with no modifier. Must skip when focus is in a
+	 * text-entry element, otherwise typing ` into a block, a text
+	 * field, or TinyMCE would steal the keystroke. Non-text inputs
+	 * (checkbox, button, select) don't accept character input, so
+	 * cycling on those is fine.
+	 *
+	 * Same iframe-crossing rationale as the Cmd+K forwarder above:
+	 * native keydown doesn't reach the parent, so we postMessage.
+	 */
+	document.addEventListener( 'keydown', function ( e ) {
+		if ( e.ctrlKey || e.metaKey || e.altKey ) return;
+		if ( e.code !== 'Backquote' ) return;
+
+		var el = document.activeElement;
+		if ( el ) {
+			var tag = el.tagName;
+			if ( tag === 'TEXTAREA' ) return;
+			if ( tag === 'INPUT' ) {
+				var type = ( el.type || '' ).toLowerCase();
+				var textTypes = [
+					'text', 'search', 'url', 'email', 'password',
+					'tel', 'number', 'date', 'datetime-local',
+					'month', 'week', 'time'
+				];
+				if ( textTypes.indexOf( type ) !== -1 ) return;
+			}
+			if ( el.isContentEditable ) return;
+		}
+
+		e.preventDefault();
+		e.stopImmediatePropagation();
+
+		try {
+			window.parent.postMessage(
+				{
+					type:      'wp-desktop-window-switch',
+					direction: e.shiftKey ? 'prev' : 'next'
+				},
+				window.location.origin
+			);
+		} catch ( err ) { /* cross-origin parent; swallow */ }
+	}, true );
+
 	var links = document.getElementById( 'screen-meta-links' );
 	if ( ! links ) {
 		return;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -11,6 +11,7 @@
  */
 
 import { WindowManager } from './window-manager';
+import { installWindowSwitcherShortcut } from './window-manager/switcher';
 import { Dock, type SystemDockItem } from './dock';
 import { OsSettings } from './settings';
 import { deriveWindowId, urlMatchKey } from './utils';
@@ -439,6 +440,7 @@ function init(): void {
 		isOpen: () => aiAssistant.isOpen,
 	} );
 	installPaletteShortcut();
+	installWindowSwitcherShortcut( manager );
 
 	// Admin-bar "Ask AI" button and programmatic `wp-desktop-open-ai`
 	// dispatches now route through openPaletteOnly so any other plugin

--- a/src/window-manager/switcher.ts
+++ b/src/window-manager/switcher.ts
@@ -93,18 +93,27 @@ let installed = false;
 
 /**
  * True when the given document's focused element consumes bare
- * keystrokes as text — INPUT (text-ish types), TEXTAREA, or anything
- * with `contenteditable`. Caller uses this to skip the window-cycle
- * when the user is typing, so `` ` `` still reaches the field.
+ * keystrokes as text — INPUT (text-ish types), TEXTAREA, anything
+ * with `contenteditable`, or a nested IFRAME (focus is inside some
+ * child frame that owns its own keyboard handling; we must not
+ * steal keystrokes from it).
  *
- * We deliberately treat SELECT, checkbox / radio / button INPUTs as
- * non-text: they don't accept character input, so stealing `` ` `` from
- * them is fine.
+ * The IFRAME case is what catches Gutenberg: the block canvas is a
+ * nested iframe, and Gutenberg re-dispatches a cloned keydown up to
+ * the outer document for its shortcut system. Without this branch
+ * we'd cycle windows while the user is typing into a block.
+ *
+ * SELECT, checkbox / radio / button INPUTs are treated as non-text:
+ * they don't accept character input, so stealing `` ` `` from them
+ * is fine.
  */
-function isTextEntryFocus( doc: Document ): boolean {
+export function isTextEntryFocus( doc: Document ): boolean {
 	const el = doc.activeElement as HTMLElement | null;
 	if ( ! el ) {
 		return false;
+	}
+	if ( el instanceof HTMLIFrameElement ) {
+		return true;
 	}
 	if ( el instanceof HTMLTextAreaElement ) {
 		return true;
@@ -129,7 +138,13 @@ function isTextEntryFocus( doc: Document ): boolean {
 		] );
 		return textTypes.has( el.type );
 	}
-	return el.isContentEditable;
+	if ( el.isContentEditable === true ) {
+		return true;
+	}
+	// Fallback for environments (jsdom) that don't implement
+	// `HTMLElement.isContentEditable` — check the attribute directly.
+	const ce = el.getAttribute( 'contenteditable' );
+	return ce !== null && ce !== 'false';
 }
 
 /**

--- a/src/window-manager/switcher.ts
+++ b/src/window-manager/switcher.ts
@@ -1,0 +1,187 @@
+/**
+ * Desktop Mode — Window switcher shortcut.
+ *
+ * Cycles focus between open windows on the active desktop via bare
+ * `` ` `` (next) and `Shift+` ` ` (previous), on both macOS and
+ * Windows/Linux. Uses no modifier because Chrome and macOS between
+ * them swallow almost every Cmd/Ctrl-based window-management combo
+ * (`Cmd+` ` ` is OS-level, `Ctrl+Tab` collides with tab-cycling, etc.).
+ *
+ * Because bare `` ` `` is a printable character, the handler skips the
+ * cycle when focus is inside a text-entry element (INPUT, TEXTAREA,
+ * contenteditable) — typing a backtick into a field still produces a
+ * backtick. Presses landing on the desktop, dock, window chrome, or
+ * anywhere else trigger the switch.
+ *
+ * Mirrors the shell-wide palette shortcut pattern in
+ * `src/palette-registry.ts`: a capture-phase listener on `document`
+ * handles presses that land on the shell, and a `postMessage` bridge
+ * from the chromeless iframe (`includes/render.php`) covers presses
+ * that land inside a wp-admin iframe (where the iframe applies its
+ * own text-entry gate before forwarding).
+ *
+ * @since 0.16.0
+ */
+
+import type { Window } from '../window';
+import type { WindowManager } from './index';
+
+export type CycleDirection = 'next' | 'prev';
+
+/**
+ * Windows eligible for focus cycling, ordered by DOM insertion —
+ * a stable order independent of z-stack / MRU, so repeated presses
+ * advance through all windows instead of ping-ponging between the
+ * top two.
+ *
+ * Filters to the active desktop only: windows parked on hidden
+ * virtual desktops are `display: none` and would visually no-op.
+ */
+function cycleableWindows( mgr: WindowManager ): Window[] {
+	const activeDesktopId = mgr.getActiveDesktopId();
+	const domOrder = Array.from( mgr._desktop.children );
+	return mgr
+		.getAll()
+		.filter( ( w ) => {
+			const winDesktop = w.config.desktopId || activeDesktopId;
+			return winDesktop === activeDesktopId;
+		} )
+		.sort(
+			( a, b ) =>
+				domOrder.indexOf( a.element ) - domOrder.indexOf( b.element ),
+		);
+}
+
+/**
+ * Focus the next (or previous) window on the active desktop,
+ * wrapping at the ends. Minimized targets are restored on the way in,
+ * matching what a user expects from a "next window" shortcut.
+ *
+ * No-op during overview mode — that UI owns keyboard focus and has
+ * its own click/enter-to-select flow.
+ */
+export function cycleFocus( mgr: WindowManager, direction: CycleDirection ): void {
+	if ( mgr._overviewActive ) {
+		return;
+	}
+	const list = cycleableWindows( mgr );
+	if ( list.length < 2 ) {
+		return;
+	}
+
+	const focused = mgr.getFocused();
+	const currentIdx = focused ? list.indexOf( focused ) : -1;
+	const step = direction === 'next' ? 1 : -1;
+	// `+ list.length` before modulo handles the negative case for 'prev'
+	// when currentIdx is 0 (or -1 — fall through to last/first as a sensible
+	// starting point when somehow nothing is focused).
+	const nextIdx = ( currentIdx + step + list.length ) % list.length;
+	const target = list[ nextIdx ];
+
+	if ( target.state === 'minimized' ) {
+		target.restore();
+	} else {
+		mgr.focus( target );
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Global shortcut installer
+// ---------------------------------------------------------------------------
+
+let installed = false;
+
+/**
+ * True when the given document's focused element consumes bare
+ * keystrokes as text — INPUT (text-ish types), TEXTAREA, or anything
+ * with `contenteditable`. Caller uses this to skip the window-cycle
+ * when the user is typing, so `` ` `` still reaches the field.
+ *
+ * We deliberately treat SELECT, checkbox / radio / button INPUTs as
+ * non-text: they don't accept character input, so stealing `` ` `` from
+ * them is fine.
+ */
+function isTextEntryFocus( doc: Document ): boolean {
+	const el = doc.activeElement as HTMLElement | null;
+	if ( ! el ) {
+		return false;
+	}
+	if ( el instanceof HTMLTextAreaElement ) {
+		return true;
+	}
+	if ( el instanceof HTMLInputElement ) {
+		// Types that accept character input. Anything not in this set
+		// (checkbox, radio, button, file, color, range, submit, reset,
+		// image, hidden) can't show a backtick anyway.
+		const textTypes = new Set( [
+			'text',
+			'search',
+			'url',
+			'email',
+			'password',
+			'tel',
+			'number',
+			'date',
+			'datetime-local',
+			'month',
+			'week',
+			'time',
+		] );
+		return textTypes.has( el.type );
+	}
+	return el.isContentEditable;
+}
+
+/**
+ * Install the `` ` `` / `Shift+` ` ` window-switcher shortcut. Idempotent.
+ *
+ * Uses `e.code === 'Backquote'` for layout stability — on AZERTY or
+ * other non-US layouts the backtick glyph lives on a different
+ * physical key, but `code` doesn't move. Skips the cycle when focus
+ * is in a text-entry element so typing `` ` `` into fields still works.
+ *
+ * The iframe forwarder lives in `includes/render.php`: it postMessages
+ * `wp-desktop-window-switch` so presses inside a wp-admin iframe reach
+ * this handler even though native keydown events don't cross iframe
+ * boundaries. The iframe applies its own text-entry gate before
+ * forwarding, so a backtick typed into the block editor or a plain
+ * admin input still reaches that field unmodified.
+ */
+export function installWindowSwitcherShortcut( mgr: WindowManager ): void {
+	if ( installed ) {
+		return;
+	}
+	installed = true;
+
+	document.addEventListener(
+		'keydown',
+		( e: KeyboardEvent ) => {
+			if ( e.ctrlKey || e.metaKey || e.altKey ) {
+				return;
+			}
+			if ( e.code !== 'Backquote' ) {
+				return;
+			}
+			if ( isTextEntryFocus( document ) ) {
+				return;
+			}
+			e.preventDefault();
+			cycleFocus( mgr, e.shiftKey ? 'prev' : 'next' );
+		},
+		true,
+	);
+
+	const origin = window.location.origin;
+	window.addEventListener( 'message', ( e: MessageEvent ) => {
+		if ( e.origin !== origin ) {
+			return;
+		}
+		const data = e.data as
+			| { type?: string; direction?: CycleDirection }
+			| null;
+		if ( ! data || data.type !== 'wp-desktop-window-switch' ) {
+			return;
+		}
+		cycleFocus( mgr, data.direction === 'prev' ? 'prev' : 'next' );
+	} );
+}

--- a/tests/vitest/switcher.test.ts
+++ b/tests/vitest/switcher.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the window switcher: cycleFocus rotates focus through the
+ * active desktop's windows in stable DOM order, restoring minimized
+ * targets along the way.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { cycleFocus } from '../../src/window-manager/switcher';
+import {
+	clearHooksStub,
+	installHooksStub,
+	type FakeWpHooks,
+} from './helpers/hooks-stub';
+
+function openConfig( id: string ) {
+	return {
+		id,
+		url: `http://example.test/wp-admin/${ id }.php`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+	};
+}
+
+describe( 'WindowManager — window switcher (cycleFocus)', () => {
+	let hooks: FakeWpHooks;
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		hooks = installHooksStub();
+		void hooks;
+		desktop = document.createElement( 'div' );
+		Object.defineProperty( desktop, 'clientWidth', {
+			value: 1600,
+			configurable: true,
+		} );
+		Object.defineProperty( desktop, 'clientHeight', {
+			value: 900,
+			configurable: true,
+		} );
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const win of manager.getAll() ) {
+			win.close();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'no-op with fewer than two windows', () => {
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBeUndefined();
+
+		const only = manager.open( openConfig( 'a' ) );
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBe( only );
+	} );
+
+	test( 'next cycles forward through DOM order and wraps', () => {
+		const a = manager.open( openConfig( 'a' ) );
+		const b = manager.open( openConfig( 'b' ) );
+		const c = manager.open( openConfig( 'c' ) );
+		expect( manager.getFocused() ).toBe( c );
+
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBe( a );
+
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBe( b );
+
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBe( c );
+	} );
+
+	test( 'prev cycles backward through DOM order and wraps', () => {
+		const a = manager.open( openConfig( 'a' ) );
+		const b = manager.open( openConfig( 'b' ) );
+		const c = manager.open( openConfig( 'c' ) );
+		expect( manager.getFocused() ).toBe( c );
+
+		cycleFocus( manager, 'prev' );
+		expect( manager.getFocused() ).toBe( b );
+
+		cycleFocus( manager, 'prev' );
+		expect( manager.getFocused() ).toBe( a );
+
+		cycleFocus( manager, 'prev' );
+		expect( manager.getFocused() ).toBe( c );
+	} );
+
+	test( 'restores a minimized target on the way in', () => {
+		const a = manager.open( openConfig( 'a' ) );
+		manager.open( openConfig( 'b' ) );
+		a.minimize();
+		expect( a.state ).toBe( 'minimized' );
+
+		cycleFocus( manager, 'next' );
+
+		expect( a.state ).toBe( 'normal' );
+		expect( manager.getFocused() ).toBe( a );
+	} );
+
+	test( 'no-op while overview mode is active', () => {
+		const a = manager.open( openConfig( 'a' ) );
+		const b = manager.open( openConfig( 'b' ) );
+		expect( manager.getFocused() ).toBe( b );
+
+		manager._overviewActive = true;
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBe( b );
+
+		manager._overviewActive = false;
+		cycleFocus( manager, 'next' );
+		expect( manager.getFocused() ).toBe( a );
+	} );
+} );

--- a/tests/vitest/switcher.test.ts
+++ b/tests/vitest/switcher.test.ts
@@ -5,7 +5,10 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
-import { cycleFocus } from '../../src/window-manager/switcher';
+import {
+	cycleFocus,
+	isTextEntryFocus,
+} from '../../src/window-manager/switcher';
 import {
 	clearHooksStub,
 	installHooksStub,
@@ -115,5 +118,64 @@ describe( 'WindowManager — window switcher (cycleFocus)', () => {
 		manager._overviewActive = false;
 		cycleFocus( manager, 'next' );
 		expect( manager.getFocused() ).toBe( a );
+	} );
+
+	describe( 'isTextEntryFocus gate', () => {
+		let transient: HTMLElement[] = [];
+
+		function mount<T extends HTMLElement>( el: T ): T {
+			document.body.appendChild( el );
+			transient.push( el );
+			return el;
+		}
+
+		afterEach( () => {
+			for ( const el of transient ) {
+				el.remove();
+			}
+			transient = [];
+		} );
+
+		test( 'returns true when a nested iframe is focused (Gutenberg case)', () => {
+			const iframe = mount( document.createElement( 'iframe' ) );
+			iframe.tabIndex = 0;
+			iframe.focus();
+			expect( document.activeElement ).toBe( iframe );
+			expect( isTextEntryFocus( document ) ).toBe( true );
+		} );
+
+		test( 'returns true when a TEXTAREA is focused', () => {
+			const ta = mount( document.createElement( 'textarea' ) );
+			ta.focus();
+			expect( isTextEntryFocus( document ) ).toBe( true );
+		} );
+
+		test( 'returns true when a text INPUT is focused', () => {
+			const input = mount( document.createElement( 'input' ) );
+			input.type = 'text';
+			input.focus();
+			expect( isTextEntryFocus( document ) ).toBe( true );
+		} );
+
+		test( 'returns false when a button INPUT is focused', () => {
+			const input = mount( document.createElement( 'input' ) );
+			input.type = 'button';
+			input.focus();
+			expect( isTextEntryFocus( document ) ).toBe( false );
+		} );
+
+		test( 'returns true when a contenteditable DIV is focused', () => {
+			const div = mount( document.createElement( 'div' ) );
+			div.setAttribute( 'contenteditable', 'true' );
+			div.tabIndex = 0;
+			div.focus();
+			expect( isTextEntryFocus( document ) ).toBe( true );
+		} );
+
+		test( 'returns false when a plain button is focused', () => {
+			const btn = mount( document.createElement( 'button' ) );
+			btn.focus();
+			expect( isTextEntryFocus( document ) ).toBe( false );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

- Press `` ` `` to cycle focus to the next window on the active desktop; `Shift+` ` ` cycles back. Minimized targets are restored on the way in.
- Skips cycling when focus is in a text-entry element (INPUT text-ish types, TEXTAREA, contenteditable) so typing a backtick into fields / the block editor / TinyMCE still works.
- Works from both the shell and inside chromeless wp-admin iframes via a `postMessage` bridge — mirrors the existing `Cmd+K` palette-forwarder pattern in `includes/render.php`.

## Why bare backtick (and not Cmd+` / Ctrl+Tab)

- `Cmd+` ` ` on macOS Chrome is intercepted at the browser level (native window-cycling) before the renderer sees it — `preventDefault()` can't help when the event never arrives.
- `Ctrl+Tab` reaches the page but collides with Chrome's tab-cycling and wasn't ergonomic in testing.
- Bare `` ` `` is the only combo that reliably reaches the page on every platform. The text-entry gate keeps it from stealing keystrokes while typing.

## Test plan

- [x] With two or more windows open, press `` ` `` on the desktop background — focus advances to the next window.
- [x] Press `Shift+` ` ` — focus moves backward through the same list.
- [x] Minimize a window, then cycle into it — it restores instead of staying hidden.
- [x] Open the Posts screen, click into the post title input, press `` ` `` — the backtick is typed, windows do **not** cycle.
- [x] Same test inside a Gutenberg block (contenteditable) and a TinyMCE editor.
- [x] In overview mode, pressing `` ` `` is a no-op (overview has its own keyboard flow).
- [x] With only one window open, the shortcut is a no-op.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-13-d5eae1fa48b8a16f5b3157d3750655f9f9d0e9df.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->