### PR TITLE
ci: add PR preview workflow for WordPress Playground

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -48,7 +48,7 @@ jobs:
           artifact-filename: 'wp-desktop-mode.zip'
           pr-number: ${{ github.event.pull_request.number }}
           commit-sha: ${{ github.sha }}
-          artifacts-to-keep: '2'
+          artifacts-to-keep: '20'
 
   create-blueprint:
     needs: expose-build

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,83 @@
+name: PR Preview with Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Build
+        run: |
+          npm ci
+          npm run build
+          npm run package
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: built-plugin
+          path: wp-desktop-mode.zip
+
+  expose-build:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      artifact-url: ${{ steps.expose.outputs.artifact-url }}
+    steps:
+      - name: Expose built artifact
+        id: expose
+        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+        with:
+          artifact-name: 'built-plugin'
+          pr-number: ${{ github.event.pull_request.number }}
+          commit-sha: ${{ github.sha }}
+          artifacts-to-keep: '2'
+
+  create-blueprint:
+    needs: expose-build
+    runs-on: ubuntu-latest
+    outputs:
+      blueprint: ${{ steps.blueprint.outputs.result }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/github-script@v7
+        id: blueprint
+        env:
+          ARTIFACT_URL: ${{ needs.expose-build.outputs.artifact-url }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '.wordpress-org/blueprints/blueprint.json';
+            const blueprint = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const install = blueprint.steps.find((s) => s.step === 'installPlugin');
+            install.pluginData.url = process.env.ARTIFACT_URL;
+            return JSON.stringify(blueprint);
+          result-encoding: string
+
+  preview:
+    needs: create-blueprint
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: WordPress/action-wp-playground-pr-preview@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          blueprint: ${{ needs.create-blueprint.outputs.blueprint }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -45,6 +45,7 @@ jobs:
         uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
         with:
           artifact-name: 'built-plugin'
+          artifact-filename: 'wp-desktop-mode.zip'
           pr-number: ${{ github.event.pull_request.number }}
           commit-sha: ${{ github.sha }}
           artifacts-to-keep: '2'


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-preview.yml` so every PR builds the plugin, exposes `wp-desktop-mode.zip` via a public URL, and posts an **Open in Playground** button.
- Blueprint is generated from `.wordpress-org/blueprints/blueprint.json` (login + `installPlugin` with `activate: true`, preserving the existing landing page) with only `pluginData.url` swapped for the per-PR artifact URL.
- `Build` job runs `npm ci && npm run build && npm run package` on Node 24 (matches `engines`), then uploads `wp-desktop-mode.zip` as the `built-plugin` artifact.

## Notes
- Artifact URL is injected into the `github-script` step via `env:` rather than expression interpolation to avoid script-injection risk.
- `actionlint` passes clean on the new workflow.

## Test plan
- [ ] Open this PR and confirm the `build` → `expose-build` → `create-blueprint` → `preview` jobs all succeed.
- [ ] Verify the **Open in Playground** comment appears on the PR.
- [ ] Click the button and confirm Playground boots `/wp-admin/`, logs in, and the plugin is installed + activated.
- [ ] Push a follow-up commit and confirm the preview refreshes (workflow re-runs on `synchronize`).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-14-c7ad4f667dd613036c8caec746bfc925c07ca2b9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->