### PR TITLE
ci: remove workflow_dispatch release path, keep script-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,81 +1,23 @@
 name: Release
 
-# Two entry points, same outcome (tag + published Release with zip):
-#   1. push a vX.Y.Z tag       → skips the `bump` job, goes straight to build+publish
-#   2. workflow_dispatch with a version → `bump` job edits trunk and pushes the tag,
-#      then build+publish runs against it.
+# Triggered by pushing a vX.Y.Z tag. Builds the plugin zip and creates a
+# GitHub Release with it attached. Use `bin/release.sh` locally to cut a
+# release end-to-end (bump + commit + tag + push).
 
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (no v prefix, e.g., 0.5.0 or 0.5.0-rc1)'
-        required: true
-        type: string
 
 permissions:
   contents: write
 
 jobs:
-  bump:
-    name: Bump and tag
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: trunk
-          fetch-depth: 0
-
-      - name: Validate version
-        run: |
-          v="${{ inputs.version }}"
-          if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
-            echo "::error::'$v' is not a valid version (expected X.Y.Z or X.Y.Z-prerelease)"
-            exit 1
-          fi
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump, commit, tag, push
-        run: |
-          v="${{ inputs.version }}"
-          ./bin/bump-version.sh "$v"
-          git commit -am "chore: bump to $v"
-          git push origin trunk
-          git tag "v$v"
-          git push origin "v$v"
-
   release:
     name: Build & publish release
-    needs: [bump]
-    # Runs in both paths: when `bump` succeeded (dispatch) or was skipped (tag push).
-    if: always() && (needs.bump.result == 'success' || needs.bump.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - name: Determine tag
-        id: tag
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -89,7 +31,7 @@ jobs:
 
       - name: Verify tag matches plugin version
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
+          tag="${{ github.ref_name }}"
           tag="${tag#v}"
           pkg=$(node -p "require('./package.json').version")
           header=$(grep -oP '^\s*\*\s*Version:\s*\K\S+' wp-desktop-mode.php)
@@ -109,7 +51,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
+          tag="${{ github.ref_name }}"
           flags=()
           if [[ "$tag" == *-* ]]; then
             flags+=(--prerelease)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,29 +2,21 @@
 
 Maintainer guide. Users install by downloading `/releases/latest/download/wp-desktop-mode.zip`.
 
-## Three ways to cut a release
+## Two ways to cut a release
 
-All three end at the same place: a `vX.Y.Z` tag on origin, which fires the build-and-publish half of [`.github/workflows/release.yml`](.github/workflows/release.yml) to produce a GitHub Release with `wp-desktop-mode.zip` attached. Pick whichever is least friction at the moment.
+Both end at the same place: a `vX.Y.Z` tag on origin, which fires [`.github/workflows/release.yml`](.github/workflows/release.yml) to build and publish a GitHub Release with `wp-desktop-mode.zip` attached.
 
-### 1. GitHub UI — one click
-
-Actions → **Release** workflow → **Run workflow** → type `0.5.0` → **Run workflow**.
-
-The workflow bumps all three version locations on `trunk`, commits, tags, builds, and publishes. No local git needed. Best for quick releases from anywhere, including your phone.
-
-> **Note**: requires the repo's branch protection / ruleset to allow `github-actions[bot]` to push to `trunk`. See [First-time setup](#first-time-setup-checks).
-
-### 2. Local one-liner
+### 1. Local one-liner (recommended)
 
 ```bash
 ./bin/release.sh 0.5.0
 ```
 
-Bumps, commits, pushes to trunk, **waits for CI green**, tags, pushes tag. Aborts cleanly if the tree is dirty, you're not on trunk, or CI fails. Best when you want the extra "CI passed before tagging" guarantee.
+Bumps all three version locations, commits, pushes to trunk, **waits for CI green**, tags, pushes the tag. Aborts cleanly if the tree is dirty, you're not on trunk, local trunk is out of sync with origin, or CI fails. Resumable — re-running after a mid-flow failure picks up where it left off.
 
 Requires the `gh` CLI authenticated (`gh auth status`).
 
-### 3. Manual, step by step
+### 2. Manual, step by step
 
 ```bash
 ./bin/bump-version.sh 0.5.0
@@ -39,19 +31,17 @@ Full transparency, useful when something in the automation breaks.
 
 Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps pointing at the last stable. The workflow detects the hyphen and sets `--prerelease` automatically. Drop the prerelease tag wherever the stable version goes:
 
-- UI: type `0.5.0-rc1` in the Run workflow dialog.
-- Local: `./bin/release.sh 0.5.0-rc1`.
-- Manual: tag as `v0.5.0-rc1`.
+- Script: `./bin/release.sh 0.5.0-rc1`
+- Manual: tag as `v0.5.0-rc1`
 
 ## What each tool does
 
 | Tool | Purpose |
 |---|---|
-| `bin/bump-version.sh <version>` | Syncs `package.json`, `package-lock.json`, plugin header, `WPDM_VERSION`. Used by both the UI workflow and the local script. |
+| `bin/bump-version.sh <version>` | Syncs `package.json`, `package-lock.json`, plugin header, `WPDM_VERSION`. |
 | `bin/package.sh` | Packages `wp-desktop-mode.zip` from HEAD + current built JS. Errors if the build is stale. |
-| `bin/release.sh <version>` | Full local release (Option 2). |
-| `release.yml` — `workflow_dispatch` | Full UI release (Option 1). |
-| `release.yml` — `push: tags: v*` | Build + publish. Fires for all three options. |
+| `bin/release.sh <version>` | Full local release (Option 1). |
+| `release.yml` — `push: tags: v*` | Build + publish. Fires for both options. |
 
 ## Version locations
 
@@ -88,9 +78,6 @@ The zip has the exact contents the workflow uploads.
 **`Version mismatch — tag 'X' vs package.json=Y header=Y WPDM_VERSION=Y`**
 You pushed a tag without bumping first, or bumped but didn't push the bump commit before tagging. Fix locally, delete the broken tag (`git push --delete origin vX.Y.Z`), re-tag from the correct commit, push again.
 
-**UI workflow fails at "Bump, commit, tag, push" with a permission error**
-Your branch protection / ruleset forbids `github-actions[bot]` from pushing to `trunk`. Fix: add the bot to the ruleset's bypass actors (Settings → Rules → your trunk ruleset → Bypass list), or fall back to Option 2 / 3.
-
 **`bin/release.sh` aborts with "working tree is dirty"**
 Commit or stash your in-progress work first. The script refuses to bundle unrelated changes into the bump commit.
 
@@ -104,7 +91,6 @@ Shouldn't happen — `bin/package.sh` errors out if the build artifacts aren't p
 
 Before cutting the first release, confirm:
 
-- Repo Settings → Actions → General → Workflow permissions is set to **Read and write permissions** (needed for `gh release create` and for the UI workflow's pushes).
-- For Option 1 (UI): the trunk ruleset / branch protection allows `github-actions[bot]` to push. If the repo enforces "Changes must be made through a pull request", add the bot to bypass actors, or use Option 2 / 3.
+- Repo Settings → Actions → General → Workflow permissions is set to **Read and write permissions** (needed for `gh release create`).
 - The `v*` tag pattern isn't blocked by a tag protection rule.
-- CI is passing on `trunk`. Options 1 and 3 trust you to eyeball this; Option 2 enforces it automatically.
+- CI is passing on `trunk`. Option 1 enforces this automatically; Option 2 trusts you to eyeball it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,7 @@
 
 Maintainer guide. Users install by downloading `/releases/latest/download/wp-desktop-mode.zip`.
 
-## Two ways to cut a release
-
-Both end at the same place: a `vX.Y.Z` tag on origin, which fires [`.github/workflows/release.yml`](.github/workflows/release.yml) to build and publish a GitHub Release with `wp-desktop-mode.zip` attached.
-
-### 1. Local one-liner (recommended)
+## Cutting a release
 
 ```bash
 ./bin/release.sh 0.5.0
@@ -14,25 +10,17 @@ Both end at the same place: a `vX.Y.Z` tag on origin, which fires [`.github/work
 
 Bumps all three version locations, commits, pushes to trunk, **waits for CI green**, tags, pushes the tag. Aborts cleanly if the tree is dirty, you're not on trunk, local trunk is out of sync with origin, or CI fails. Resumable — re-running after a mid-flow failure picks up where it left off.
 
+The tag push fires [`.github/workflows/release.yml`](.github/workflows/release.yml), which builds and publishes a GitHub Release with `wp-desktop-mode.zip` attached.
+
 Requires the `gh` CLI authenticated (`gh auth status`).
-
-### 2. Manual, step by step
-
-```bash
-./bin/bump-version.sh 0.5.0
-git commit -am "chore: bump to 0.5.0" && git push origin trunk
-# wait for CI green on the bump commit
-git tag v0.5.0 && git push origin v0.5.0
-```
-
-Full transparency, useful when something in the automation breaks.
 
 ## Pre-releases
 
-Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps pointing at the last stable. The workflow detects the hyphen and sets `--prerelease` automatically. Drop the prerelease tag wherever the stable version goes:
+Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps pointing at the last stable. The workflow detects the hyphen and sets `--prerelease` automatically:
 
-- Script: `./bin/release.sh 0.5.0-rc1`
-- Manual: tag as `v0.5.0-rc1`
+```bash
+./bin/release.sh 0.5.0-rc1
+```
 
 ## What each tool does
 
@@ -40,8 +28,8 @@ Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps 
 |---|---|
 | `bin/bump-version.sh <version>` | Syncs `package.json`, `package-lock.json`, plugin header, `WPDM_VERSION`. |
 | `bin/package.sh` | Packages `wp-desktop-mode.zip` from HEAD + current built JS. Errors if the build is stale. |
-| `bin/release.sh <version>` | Full local release (Option 1). |
-| `release.yml` — `push: tags: v*` | Build + publish. Fires for both options. |
+| `bin/release.sh <version>` | Full end-to-end release. |
+| `release.yml` — `push: tags: v*` | Build + publish the GitHub Release. |
 
 ## Version locations
 
@@ -93,4 +81,4 @@ Before cutting the first release, confirm:
 
 - Repo Settings → Actions → General → Workflow permissions is set to **Read and write permissions** (needed for `gh release create`).
 - The `v*` tag pattern isn't blocked by a tag protection rule.
-- CI is passing on `trunk`. Option 1 enforces this automatically; Option 2 trusts you to eyeball it.
+- CI is passing on `trunk` (the script enforces this before tagging).


### PR DESCRIPTION
## Summary

- Drop the \`workflow_dispatch\` UI button from \`release.yml\` and the \`bump\` job that backed it.
- Simplify the \`release\` job: no more \`needs\`, no conditional, no tag-derivation step — it reads \`github.ref_name\` directly now that tag push is the only trigger.
- Update \`RELEASE.md\`: "Three ways" → "Two ways" (local script + manual); drop UI-specific troubleshooting and first-time setup items.

## Why

The UI button required \`github-actions[bot]\` to push directly to \`trunk\`, which hits the ruleset. Every alternative path (PR + auto-merge, chained workflows) runs into GitHub's rule that \`GITHUB_TOKEN\`-triggered events don't start new workflow runs — so bot-opened PRs never get CI, auto-merge deadlocks, and the only real fix is a PAT. Not worth the complexity for a button that saves ~10s over \`./bin/release.sh\`.

Tag-triggered build + \`bin/release.sh\` for local end-to-end releases is the most common pattern for small-to-medium OSS projects and has zero permission friction.

## Test plan

- [ ] CI green on this branch
- [ ] After merge, confirm \`gh workflow list\` no longer shows the \`workflow_dispatch\` option for Release
- [ ] Next release via \`./bin/release.sh\` still produces a GitHub Release with \`wp-desktop-mode.zip\` attached

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-16-436eee77c2430f1e3942d860d79d7bfe6141dcf4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->