### PR TITLE
Enhance AI Provider Integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ docs/
     ├── react-to-window-events.md
     │                            UPDATE/READ WHEN: window-lifecycle CustomEvent shape changes.
     ├── register-command.md     UPDATE/READ WHEN: command registry API (JS or PHP) changes.
+    ├── register-ai-provider.md  UPDATE/READ WHEN: wp_register_desktop_ai_provider() contract,
+    │                            provider callback shapes, or active-provider resolution rules change.
     ├── ai-ask.md                UPDATE/READ WHEN: wp.desktop.ai.ask() contract, AI-tool-calling
     │                            protocol, or wp_register_desktop_ai_tool() signature changes.
     ├── connect-to-window.md     UPDATE/READ WHEN: registerTitleBarButton, Window.setHighlight,

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
 - [Register a desktop icon (Jorvy)](./register-icon.md)
 - [Register a slash-command for the AI palette](./register-command.md)
 - [Programmatic AI Copilot — `wp.desktop.ai.ask()`](./ai-ask.md)
+- [Register a custom AI provider (Anthropic / Gemini / local LLM)](./register-ai-provider.md)
 - [Connect to a window — title-bar button + iframe pub/sub](./connect-to-window.md)
 - [Native window with tabs (auto-swap pattern)](./native-window-with-tabs.md)
 - [Layout primitives (body → panel → row → col)](./layout-primitives.md)

--- a/docs/examples/register-ai-provider.md
+++ b/docs/examples/register-ai-provider.md
@@ -1,0 +1,200 @@
+# Register a custom AI provider
+
+The shell ships with the OpenAI Responses API as the default provider. Other back-ends — Anthropic Claude, Google Gemini, a self-hosted Ollama instance — register through the same registry that powers OpenAI. The shell drives the agentic loop, observability, and tool dispatch; the provider is responsible only for translating the shell's normalized request into its vendor's wire format and back.
+
+This page walks through a minimal Anthropic implementation. The same shape applies to any provider.
+
+## What you implement
+
+Three callables, all small:
+
+- `make_turn_input( $kind, $payload )` — build whatever you'd like to receive in `agentic_call` next turn. Opaque to the shell.
+- `agentic_call( $api_key, $turn_input, $tools, $text_format, $instructions, $state )` — one turn of the agentic loop.
+- `structured_request( $api_key, $messages, $schema, $schema_name, $model )` — single-shot structured-output request (used by the post / term / comment analysis jobs).
+
+Plus metadata: a label, a link to where the user gets an API key, an optional default model.
+
+## Registration
+
+```php
+add_action( 'wp_desktop_ai_register_providers', function () {
+    wp_register_desktop_ai_provider( 'anthropic', array(
+        'label'              => 'Anthropic Claude',
+        'description'        => 'Anthropic Messages API.',
+        'api_key_label'      => 'Anthropic API key',
+        'api_key_link'       => 'https://console.anthropic.com/settings/keys',
+        'default_model'      => 'claude-sonnet-4-6',
+        'capabilities'       => array( 'tools', 'structured_output' ),
+        'make_turn_input'    => 'my_anthropic_make_turn_input',
+        'agentic_call'       => 'my_anthropic_agentic_call',
+        'structured_request' => 'my_anthropic_structured_request',
+    ) );
+} );
+```
+
+Use `wp_desktop_ai_register_providers` rather than `init` directly — registration runs lazily on first lookup, so order doesn't depend on plugin load priority.
+
+## Building turn inputs
+
+```php
+/**
+ * @param string $kind    'user_message' | 'tool_results'
+ * @param mixed  $payload string for 'user_message'; array of {call_id, output} for 'tool_results'.
+ */
+function my_anthropic_make_turn_input( $kind, $payload ) {
+    if ( 'user_message' === $kind ) {
+        return array(
+            array( 'role' => 'user', 'content' => (string) $payload ),
+        );
+    }
+
+    if ( 'tool_results' === $kind && is_array( $payload ) ) {
+        // Anthropic carries tool results in a user-role message containing
+        // tool_result content blocks.
+        $blocks = array();
+        foreach ( $payload as $r ) {
+            $blocks[] = array(
+                'type'        => 'tool_result',
+                'tool_use_id' => (string) ( $r['call_id'] ?? '' ),
+                'content'     => (string) ( $r['output'] ?? '' ),
+            );
+        }
+        return array( array( 'role' => 'user', 'content' => $blocks ) );
+    }
+
+    return array();
+}
+```
+
+The shell never inspects the return value — it just hands it back to your `agentic_call` for the next turn.
+
+## One agentic turn
+
+```php
+function my_anthropic_agentic_call(
+    $api_key,
+    $turn_input,
+    array $tools,
+    $text_format,
+    $instructions,
+    $state = null
+) {
+    // Anthropic doesn't have OpenAI's `previous_response_id` — accumulate
+    // the full message history in $state instead.
+    $messages = is_array( $state['messages'] ?? null ) ? $state['messages'] : array();
+    $messages = array_merge( $messages, (array) $turn_input );
+
+    $response = wp_remote_post(
+        'https://api.anthropic.com/v1/messages',
+        array(
+            'timeout' => 30,
+            'headers' => array(
+                'Content-Type'      => 'application/json',
+                'x-api-key'         => $api_key,
+                'anthropic-version' => '2023-06-01',
+            ),
+            'body' => wp_json_encode( array(
+                'model'       => apply_filters( 'wp_desktop_ai_model', 'claude-sonnet-4-6', 'agentic_search' ),
+                'system'      => $instructions,
+                'messages'    => $messages,
+                'tools'       => my_anthropic_translate_tools( $tools ),
+                'max_tokens'  => 4096,
+            ) ),
+        )
+    );
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+
+    $code = (int) wp_remote_retrieve_response_code( $response );
+    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+    if ( 200 !== $code || ! is_array( $body ) ) {
+        return new WP_Error(
+            'my_anthropic_http',
+            isset( $body['error']['message'] ) ? $body['error']['message'] : "HTTP {$code}.",
+            array( 'status' => $code )
+        );
+    }
+
+    // Pull text + tool calls out of Anthropic's content blocks.
+    $text           = null;
+    $function_calls = array();
+    $assistant_msg  = array( 'role' => 'assistant', 'content' => $body['content'] ?? array() );
+
+    foreach ( (array) ( $body['content'] ?? array() ) as $block ) {
+        if ( 'text' === ( $block['type'] ?? '' ) ) {
+            $text = $block['text'];
+        }
+        if ( 'tool_use' === ( $block['type'] ?? '' ) ) {
+            $function_calls[] = array(
+                'name'      => (string) ( $block['name'] ?? '' ),
+                'call_id'   => (string) ( $block['id'] ?? '' ),
+                'arguments' => wp_json_encode( $block['input'] ?? new stdClass() ),
+            );
+        }
+    }
+
+    return array(
+        'text'           => $text,
+        'function_calls' => $function_calls,
+        // Anthropic needs full history every turn — stash it in state.
+        'next_state'     => array( 'messages' => array_merge( $messages, array( $assistant_msg ) ) ),
+        'raw'            => $body,
+    );
+}
+```
+
+`my_anthropic_translate_tools()` is a small helper that reshapes the OpenAI Responses API tool list (the format the shell ships) into Anthropic's `{ name, description, input_schema }` shape. Keep it next to your provider for clarity.
+
+## Single-shot structured output
+
+```php
+function my_anthropic_structured_request(
+    $api_key,
+    array $messages,
+    array $schema,
+    $schema_name,
+    $model = ''
+) {
+    // Anthropic doesn't ship native structured output today; emulate it
+    // by passing a single tool whose only purpose is to return the data
+    // shape, and reading the tool_use block off the response.
+    $tool = array(
+        'name'         => (string) $schema_name,
+        'description'  => 'Return the structured analysis.',
+        'input_schema' => $schema,
+    );
+    // … same wp_remote_post call as agentic_call, with this single tool
+    // and tool_choice forced to it; pull the input off the tool_use block.
+    return array( /* parsed JSON object */ );
+}
+```
+
+## API keys
+
+Each provider gets its own slot in OS Settings → AI. Users can keep keys for several providers and switch between them without losing any. The active key resolves through:
+
+1. Per-user `apiKeys[<provider_id>]` (preferred).
+2. Per-user legacy `apiKey` field — only honoured for `openai` (backwards compat).
+3. Platform `apiKeys[<provider_id>]`.
+4. Platform legacy `apiKey` — only for `openai`.
+
+You don't have to do anything to participate; the shell already plumbs the resolved key into your callbacks via the `$api_key` argument.
+
+## Picking the active provider per-request
+
+If you want to route specific requests to a specific provider — say, "force admins to use Anthropic" — filter `wp_desktop_ai_active_provider`:
+
+```php
+add_filter( 'wp_desktop_ai_active_provider', function ( $id, $user_id ) {
+    return user_can( $user_id, 'manage_options' ) ? 'anthropic' : $id;
+}, 10, 2 );
+```
+
+The filter runs every time the system asks "which provider for this user?", so you can branch on `$_REQUEST`, `request_id` from the AI observability hooks, or anything else in scope.
+
+## Built-in providers
+
+The OpenAI provider lives in `includes/ai-copilot/openai.php`. It's the reference implementation — read it whenever you need a template for what each callback returns.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -807,7 +807,112 @@ add_filter( 'wp_desktop_native_window_tab_wrap_padding', function ( $padding, $w
 
 ## AI Copilot hooks — Stable
 
-The AI assistant (Cmd+K palette) runs an OpenAI agentic loop server-side, analyses entities on save, and exposes a search REST endpoint. Every decision point is hookable so plugins can adjust model selection, customise prompts, limit which entities get analysed, or react to analysis completion.
+The AI assistant (Cmd+K palette) runs an agentic loop server-side, analyses entities on save, and exposes a search REST endpoint. Every decision point is hookable so plugins can adjust model selection, customise prompts, limit which entities get analysed, or react to analysis completion.
+
+The shell ships with a built-in **OpenAI** provider (Responses API). Other providers are pluggable — see [`wp_register_desktop_ai_provider`](#wp_register_desktop_ai_provider-args--experimental-php-function-since-0180) below.
+
+### `wp_register_desktop_ai_provider( $args )` — Experimental (PHP function, since 0.18.0)
+
+Register an alternative AI back-end (Anthropic, Gemini, a local LLM, …). Each provider supplies three callables that fully encapsulate its wire format; the shell drives the agentic loop, observability, and tool dispatch unchanged.
+
+```php
+wp_register_desktop_ai_provider( string $id, array $args ): true|WP_Error
+```
+
+`$args`:
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `label` | `string` | optional | Human-readable display name. |
+| `description` | `string` | optional | Shown under the picker. |
+| `api_key_label` | `string` | optional | Label for the API-key field in OS Settings → AI. |
+| `api_key_link` | `string` | optional | URL where the user obtains a key. |
+| `default_model` | `string` | optional | Model id used when `wp_desktop_ai_model` returns ''. |
+| `capabilities` | `string[]` | optional | Informational tags (e.g., `tools`, `structured_output`). |
+| `make_turn_input` | `callable` | **required** | Builds an opaque turn-input the shell hands to `agentic_call` next turn. |
+| `agentic_call` | `callable` | **required** | One turn of the agentic loop. |
+| `structured_request` | `callable` | **required** | Single-shot structured-output request. |
+
+Required callable signatures:
+
+```php
+// $kind: 'user_message' | 'tool_results'
+// payload: string for 'user_message'; array of [{call_id, output (json string)}, …] for 'tool_results'.
+function make_turn_input( string $kind, mixed $payload ): mixed;
+
+// Returns array{ text:?string, function_calls: array, next_state: mixed, raw: mixed }
+// or WP_Error. function_calls items: { name, call_id, arguments (json string) }.
+function agentic_call(
+    string $api_key,
+    mixed  $turn_input,
+    array  $tools,
+    ?array $text_format,
+    string $instructions,
+    mixed  $state
+): array|WP_Error;
+
+function structured_request(
+    string $api_key,
+    array  $messages,    // [ { role, content }, … ]
+    array  $schema,       // JSON Schema
+    string $schema_name,
+    string $model         // '' → use the provider's default_model
+): array|WP_Error;
+```
+
+Hook `wp_desktop_ai_register_providers` (fires lazily on first lookup) for registration:
+
+```php
+add_action( 'wp_desktop_ai_register_providers', function () {
+    wp_register_desktop_ai_provider( 'anthropic', array(
+        'label'              => 'Anthropic Claude',
+        'api_key_label'      => 'Anthropic API key',
+        'api_key_link'       => 'https://console.anthropic.com/settings/keys',
+        'default_model'      => 'claude-sonnet-4-6',
+        'make_turn_input'    => 'my_anthropic_make_turn_input',
+        'agentic_call'       => 'my_anthropic_agentic_call',
+        'structured_request' => 'my_anthropic_structured_request',
+    ) );
+} );
+```
+
+See [`docs/examples/register-ai-provider.md`](./examples/register-ai-provider.md) for a worked example.
+
+### `wp_unregister_desktop_ai_provider( $id )` — Experimental (PHP function, since 0.18.0)
+
+Removes a provider from the registry. Returns `true` if a provider was removed, `false` if the id was unknown.
+
+### `wp_desktop_ai_register_providers` — Experimental (since 0.18.0)
+
+Action fired exactly once per request, the first time the registry is read. Hook it to call `wp_register_desktop_ai_provider()`.
+
+```php
+do_action( 'wp_desktop_ai_register_providers' );
+```
+
+### `wp_desktop_ai_provider_registered` — Experimental (since 0.18.0)
+
+Fires after a provider has been successfully registered.
+
+```php
+do_action( 'wp_desktop_ai_provider_registered', string $id, array $def );
+```
+
+### `wp_desktop_ai_active_provider` — Experimental (since 0.18.0)
+
+Filter the resolved active-provider id. Useful for per-request pinning (e.g., based on capability or query content).
+
+```php
+apply_filters( 'wp_desktop_ai_active_provider', string $provider_id, int $user_id );
+```
+
+```php
+// Force admins to use Anthropic; everyone else stays on the default.
+add_filter( 'wp_desktop_ai_active_provider', function ( $id, $user_id ) {
+    return user_can( $user_id, 'manage_options' ) ? 'anthropic' : $id;
+}, 10, 2 );
+```
+
 
 ### `wp_desktop_ai_model` — Stable
 

--- a/includes/ai-copilot/bootstrap.php
+++ b/includes/ai-copilot/bootstrap.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/platform-settings.php';
 require_once __DIR__ . '/settings.php';
+require_once __DIR__ . '/providers-registry.php';
 require_once __DIR__ . '/openai.php';
 require_once __DIR__ . '/analysis.php';
 require_once __DIR__ . '/jobs.php';

--- a/includes/ai-copilot/jobs.php
+++ b/includes/ai-copilot/jobs.php
@@ -56,7 +56,7 @@ function wpdm_ai_job_analyze_post( $post_id, $user_id ) {
 	$messages = wpdm_ai_messages_for_post( $post );
 	$schema   = wpdm_ai_schema_content();
 
-	$result = wpdm_ai_openai_structured_request( $api_key, $messages, $schema, 'content_analysis' );
+	$result = wpdm_ai_provider_structured_request( $user_id, $api_key, $messages, $schema, 'content_analysis' );
 
 	if ( is_wp_error( $result ) ) {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -109,7 +109,7 @@ function wpdm_ai_job_analyze_term( $term_id, $taxonomy, $user_id ) {
 	$messages = wpdm_ai_messages_for_term( $term );
 	$schema   = wpdm_ai_schema_content();
 
-	$result = wpdm_ai_openai_structured_request( $api_key, $messages, $schema, 'content_analysis' );
+	$result = wpdm_ai_provider_structured_request( $user_id, $api_key, $messages, $schema, 'content_analysis' );
 
 	if ( is_wp_error( $result ) ) {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -161,7 +161,7 @@ function wpdm_ai_job_analyze_comment( $comment_id, $user_id ) {
 	$messages = wpdm_ai_messages_for_comment( $comment );
 	$schema   = wpdm_ai_schema_comment();
 
-	$result = wpdm_ai_openai_structured_request( $api_key, $messages, $schema, 'comment_analysis' );
+	$result = wpdm_ai_provider_structured_request( $user_id, $api_key, $messages, $schema, 'comment_analysis' );
 
 	if ( is_wp_error( $result ) ) {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/includes/ai-copilot/openai.php
+++ b/includes/ai-copilot/openai.php
@@ -290,3 +290,161 @@ function wpdm_ai_openai_responses_call(
 
 	return wpdm_ai_do_request( $api_key, $body );
 }
+
+// ---------------------------------------------------------------------------
+// Provider-registry adapters
+//
+// These wire the OpenAI implementation as the built-in default provider.
+// Each callback simply translates between the registry's normalized shape
+// and the existing OpenAI helpers above. New providers (Anthropic, Gemini,
+// local LLMs, …) ship their own equivalents and register the same way.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an opaque "turn input" for the OpenAI provider.
+ *
+ * For the Responses API a turn input is the `input` array. We accept two
+ * kinds — a fresh user message, or a batch of tool results to resume an
+ * agentic loop with `previous_response_id` already in state.
+ *
+ * @since 0.18.0
+ *
+ * @param string $kind 'user_message' | 'tool_results'.
+ * @param mixed  $payload For 'user_message': string. For 'tool_results':
+ *                        array of [{ call_id, output (json string) }, …].
+ * @return array Input items array, ready for the Responses API.
+ */
+function wpdm_ai_openai_make_turn_input( $kind, $payload ) {
+	if ( 'user_message' === $kind ) {
+		return array(
+			array(
+				'role'    => 'user',
+				'content' => is_string( $payload ) ? $payload : (string) wp_json_encode( $payload ),
+			),
+		);
+	}
+
+	if ( 'tool_results' === $kind && is_array( $payload ) ) {
+		$items = array();
+		foreach ( $payload as $r ) {
+			if ( ! is_array( $r ) ) {
+				continue;
+			}
+			$items[] = array(
+				'type'    => 'function_call_output',
+				'call_id' => isset( $r['call_id'] ) ? (string) $r['call_id'] : '',
+				'output'  => isset( $r['output'] ) ? (string) $r['output'] : '',
+			);
+		}
+		return $items;
+	}
+
+	return array();
+}
+
+/**
+ * One turn of the agentic loop via the OpenAI Responses API.
+ *
+ * @since 0.18.0
+ *
+ * @param string     $api_key      OpenAI key.
+ * @param array      $turn_input   Output of {@see wpdm_ai_openai_make_turn_input}.
+ * @param array      $tools        Responses-API tool definitions (flat shape).
+ * @param array|null $text_format  Optional `text.format` object for structured output.
+ * @param string     $instructions System-level instructions.
+ * @param mixed      $state        Provider state ['previous_response_id' => …] | null.
+ * @return array|WP_Error
+ */
+function wpdm_ai_openai_provider_agentic_call(
+	$api_key,
+	$turn_input,
+	array $tools,
+	$text_format,
+	$instructions,
+	$state = null
+) {
+	$previous_response_id = '';
+	if ( is_array( $state ) && ! empty( $state['previous_response_id'] ) ) {
+		$previous_response_id = (string) $state['previous_response_id'];
+	}
+
+	$response = wpdm_ai_openai_responses_call(
+		$api_key,
+		is_array( $turn_input ) ? $turn_input : array(),
+		$tools,
+		$text_format,
+		$instructions,
+		$previous_response_id
+	);
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	// Normalize function-call shape — registry contract is { name, call_id, arguments (string) }.
+	$function_calls = array();
+	foreach ( wpdm_ai_extract_function_calls( $response ) as $fc ) {
+		$function_calls[] = array(
+			'name'      => isset( $fc['name'] ) ? (string) $fc['name'] : '',
+			'call_id'   => isset( $fc['call_id'] ) ? (string) $fc['call_id'] : '',
+			'arguments' => isset( $fc['arguments'] ) ? (string) $fc['arguments'] : '',
+		);
+	}
+
+	return array(
+		'text'           => wpdm_ai_extract_text( $response ),
+		'function_calls' => $function_calls,
+		'next_state'     => array( 'previous_response_id' => isset( $response['id'] ) ? (string) $response['id'] : '' ),
+		'raw'            => $response,
+	);
+}
+
+/**
+ * OpenAI provider — single-shot structured output adapter.
+ *
+ * Thin wrapper that selects a default model when the caller passes ''.
+ *
+ * @since 0.18.0
+ *
+ * @param string $api_key
+ * @param array  $messages
+ * @param array  $schema
+ * @param string $schema_name
+ * @param string $model       Empty string → use the provider default.
+ * @return array|WP_Error
+ */
+function wpdm_ai_openai_provider_structured_request(
+	$api_key,
+	array $messages,
+	array $schema,
+	$schema_name,
+	$model = ''
+) {
+	$model = '' === (string) $model ? WPDM_AI_DEFAULT_MODEL : (string) $model;
+	return wpdm_ai_openai_structured_request( $api_key, $messages, $schema, (string) $schema_name, $model );
+}
+
+/**
+ * Register the built-in OpenAI provider.
+ *
+ * Registration runs on `wp_desktop_ai_register_providers` (fired lazily on
+ * first lookup) so the registry doesn't depend on plugin load order.
+ *
+ * @since 0.18.0
+ */
+function wpdm_ai_register_openai_provider() {
+	wp_register_desktop_ai_provider(
+		'openai',
+		array(
+			'label'              => 'OpenAI',
+			'description'        => 'OpenAI Responses API (gpt-5 family). Default provider.',
+			'api_key_label'      => 'OpenAI API key',
+			'api_key_link'       => 'https://platform.openai.com/api-keys',
+			'default_model'      => WPDM_AI_DEFAULT_MODEL,
+			'capabilities'       => array( 'tools', 'structured_output', 'previous_response_id' ),
+			'make_turn_input'    => 'wpdm_ai_openai_make_turn_input',
+			'agentic_call'       => 'wpdm_ai_openai_provider_agentic_call',
+			'structured_request' => 'wpdm_ai_openai_provider_structured_request',
+		)
+	);
+}
+add_action( 'wp_desktop_ai_register_providers', 'wpdm_ai_register_openai_provider' );

--- a/includes/ai-copilot/platform-settings.php
+++ b/includes/ai-copilot/platform-settings.php
@@ -36,7 +36,8 @@ function wpdm_ai_get_platform_settings() {
 	$defaults = array(
 		'enabled'  => false,
 		'provider' => 'openai',
-		'apiKey'   => '',
+		'apiKey'   => '',     // Legacy — kept for backwards compat with 0.14–0.17 callers.
+		'apiKeys'  => array(), // Per-provider keys.
 	);
 
 	$raw = get_option( WPDM_AI_PLATFORM_OPTION, array() );
@@ -44,14 +45,35 @@ function wpdm_ai_get_platform_settings() {
 		return $defaults;
 	}
 
+	$provider = $defaults['provider'];
+	if ( isset( $raw['provider'] ) && is_string( $raw['provider'] ) ) {
+		$slug = sanitize_key( $raw['provider'] );
+		if ( '' !== $slug ) {
+			$provider = $slug;
+		}
+	}
+
+	$keys = array();
+	if ( isset( $raw['apiKeys'] ) && is_array( $raw['apiKeys'] ) ) {
+		foreach ( $raw['apiKeys'] as $pid => $val ) {
+			if ( count( $keys ) >= 32 ) {
+				break;
+			}
+			$slug = sanitize_key( (string) $pid );
+			if ( '' === $slug || ! is_string( $val ) ) {
+				continue;
+			}
+			$keys[ $slug ] = $val;
+		}
+	}
+
 	return array(
 		'enabled'  => ! empty( $raw['enabled'] ),
-		'provider' => ( isset( $raw['provider'] ) && in_array( $raw['provider'], WPDM_OS_SETTINGS_AI_PROVIDERS, true ) )
-			? (string) $raw['provider']
-			: $defaults['provider'],
+		'provider' => $provider,
 		'apiKey'   => ( isset( $raw['apiKey'] ) && is_string( $raw['apiKey'] ) )
 			? $raw['apiKey']
 			: $defaults['apiKey'],
+		'apiKeys'  => $keys,
 	);
 }
 
@@ -68,14 +90,35 @@ function wpdm_ai_save_platform_settings( $raw ) {
 		return false;
 	}
 
+	$provider = 'openai';
+	if ( isset( $raw['provider'] ) && is_string( $raw['provider'] ) ) {
+		$slug = sanitize_key( $raw['provider'] );
+		if ( '' !== $slug ) {
+			$provider = $slug;
+		}
+	}
+
+	$keys = array();
+	if ( isset( $raw['apiKeys'] ) && is_array( $raw['apiKeys'] ) ) {
+		foreach ( $raw['apiKeys'] as $pid => $val ) {
+			if ( count( $keys ) >= 32 ) {
+				break;
+			}
+			$slug = sanitize_key( (string) $pid );
+			if ( '' === $slug || ! is_string( $val ) ) {
+				continue;
+			}
+			$keys[ $slug ] = substr( sanitize_text_field( $val ), 0, 512 );
+		}
+	}
+
 	$clean = array(
 		'enabled'  => ! empty( $raw['enabled'] ),
-		'provider' => ( isset( $raw['provider'] ) && in_array( $raw['provider'], WPDM_OS_SETTINGS_AI_PROVIDERS, true ) )
-			? (string) $raw['provider']
-			: 'openai',
+		'provider' => $provider,
 		'apiKey'   => ( isset( $raw['apiKey'] ) && is_string( $raw['apiKey'] ) )
 			? substr( sanitize_text_field( $raw['apiKey'] ), 0, 512 )
 			: '',
+		'apiKeys'  => $keys,
 	);
 
 	return update_option( WPDM_AI_PLATFORM_OPTION, $clean, false );

--- a/includes/ai-copilot/providers-registry.php
+++ b/includes/ai-copilot/providers-registry.php
@@ -1,0 +1,442 @@
+<?php
+/**
+ * Desktop Mode — AI provider registry.
+ *
+ * Lets plugins register additional AI back-ends (OpenAI, Anthropic, Gemini,
+ * local models) the AI Copilot can dispatch through. Each provider supplies
+ * a small set of callables that fully encapsulate its wire format; the
+ * shell drives the agentic loop and observability without knowing which
+ * vendor is on the other end.
+ *
+ * Registration timing: hook `wp_desktop_ai_register_providers` (fires on
+ * `init` at default priority). Plugins can also call
+ * {@see wp_register_desktop_ai_provider()} at any time before the first
+ * dispatch — the registry is just an in-memory map.
+ *
+ * Provider contract (every key is required unless noted):
+ *
+ *   array(
+ *       'label'           => __( 'OpenAI', 'my-plugin' ),
+ *       'description'     => __( 'OpenAI Responses API.', 'my-plugin' ),     // optional
+ *       'api_key_label'   => __( 'OpenAI API key', 'my-plugin' ),            // optional
+ *       'api_key_link'    => 'https://platform.openai.com/api-keys',         // optional
+ *       'default_model'   => 'gpt-5.4-nano',                                 // optional
+ *       'capabilities'    => array( 'tools', 'structured_output' ),          // optional, informational
+ *
+ *       // Required: opaque "turn input" factory. Two kinds:
+ *       //   'user_message' — payload is the user's query (string)
+ *       //   'tool_results' — payload is array of [{call_id, output (json string)}, ...]
+ *       // Returns whatever the provider wants to receive in agentic_call().
+ *       'make_turn_input' => 'my_provider_make_turn_input',
+ *
+ *       // Required: one turn of the agentic loop.
+ *       // Returns array{ text: ?string, function_calls: array, next_state: mixed, raw: array }
+ *       // or WP_Error. function_calls items: { name, call_id, arguments (json string) }.
+ *       'agentic_call'    => 'my_provider_agentic_call',
+ *
+ *       // Required: single-shot structured-output request.
+ *       // $messages are chat-style: [{role, content}, ...]. Returns parsed
+ *       // array matching $schema, or WP_Error.
+ *       'structured_request' => 'my_provider_structured_request',
+ *   )
+ *
+ * @package WPDesktopMode
+ * @since 0.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Default provider id when none is selected. */
+const WPDM_AI_DEFAULT_PROVIDER = 'openai';
+
+/** Required callback keys every registered provider must supply. */
+const WPDM_AI_PROVIDER_REQUIRED_CALLBACKS = array(
+	'make_turn_input',
+	'agentic_call',
+	'structured_request',
+);
+
+// ---------------------------------------------------------------------------
+// Registry storage
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal registry accessor — process-scoped map of provider definitions.
+ *
+ * Acts as both reader and writer; we avoid a global by keeping the array
+ * as a static inside this function. Pass an array action to mutate
+ * (`set`, `unset`, `clear`); omit to read.
+ *
+ * @since 0.18.0
+ *
+ * @param string|null $action 'set' | 'unset' | 'clear' | null.
+ * @param string      $id     Provider id.
+ * @param array|null  $def    Provider definition (for 'set').
+ * @return array Current registry snapshot.
+ */
+function wpdm_ai_providers_storage( $action = null, $id = '', $def = null ) {
+	static $providers = array();
+
+	if ( 'set' === $action ) {
+		$providers[ $id ] = $def;
+	} elseif ( 'unset' === $action ) {
+		unset( $providers[ $id ] );
+	} elseif ( 'clear' === $action ) {
+		$providers = array();
+	}
+
+	return $providers;
+}
+
+// ---------------------------------------------------------------------------
+// Public registration API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register an AI provider.
+ *
+ * @since 0.18.0
+ *
+ * @param string $id   Lowercase provider slug (e.g. 'openai', 'anthropic').
+ *                     Validated with `sanitize_key()`.
+ * @param array  $args Provider definition. See file header for the contract.
+ * @return true|WP_Error True on success, WP_Error if the definition is invalid.
+ */
+function wp_register_desktop_ai_provider( $id, array $args ) {
+	$id = sanitize_key( (string) $id );
+	if ( '' === $id ) {
+		return new WP_Error( 'wpdm_ai_provider_id', 'Provider id cannot be empty.' );
+	}
+
+	foreach ( WPDM_AI_PROVIDER_REQUIRED_CALLBACKS as $key ) {
+		if ( ! isset( $args[ $key ] ) || ! is_callable( $args[ $key ] ) ) {
+			return new WP_Error(
+				'wpdm_ai_provider_callback',
+				sprintf( 'Provider "%s" is missing required callable "%s".', $id, $key )
+			);
+		}
+	}
+
+	$def = array(
+		'id'                 => $id,
+		'label'              => isset( $args['label'] ) ? (string) $args['label'] : ucfirst( $id ),
+		'description'        => isset( $args['description'] ) ? (string) $args['description'] : '',
+		'api_key_label'      => isset( $args['api_key_label'] ) ? (string) $args['api_key_label'] : 'API key',
+		'api_key_link'       => isset( $args['api_key_link'] ) ? esc_url_raw( (string) $args['api_key_link'] ) : '',
+		'default_model'      => isset( $args['default_model'] ) ? (string) $args['default_model'] : '',
+		'capabilities'       => isset( $args['capabilities'] ) && is_array( $args['capabilities'] )
+			? array_values( array_filter( array_map( 'strval', $args['capabilities'] ) ) )
+			: array(),
+		'make_turn_input'    => $args['make_turn_input'],
+		'agentic_call'       => $args['agentic_call'],
+		'structured_request' => $args['structured_request'],
+	);
+
+	wpdm_ai_providers_storage( 'set', $id, $def );
+
+	/**
+	 * Fires after a provider has been registered. Useful for telemetry.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param string $id  Provider id.
+	 * @param array  $def Stored provider definition.
+	 */
+	do_action( 'wp_desktop_ai_provider_registered', $id, $def );
+
+	return true;
+}
+
+/**
+ * Unregister a provider.
+ *
+ * @since 0.18.0
+ *
+ * @param string $id Provider id.
+ * @return bool True if a provider was removed.
+ */
+function wp_unregister_desktop_ai_provider( $id ) {
+	$id      = sanitize_key( (string) $id );
+	$before  = wpdm_ai_providers_storage();
+	if ( ! isset( $before[ $id ] ) ) {
+		return false;
+	}
+	wpdm_ai_providers_storage( 'unset', $id );
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy-loading hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fires the registration action exactly once per request.
+ *
+ * Plugins should hook `wp_desktop_ai_register_providers` to register their
+ * providers. We fire it lazily on first lookup so registration order
+ * doesn't depend on plugin load order.
+ *
+ * @since 0.18.0
+ */
+function wpdm_ai_ensure_providers_registered() {
+	static $fired = false;
+	if ( $fired ) {
+		return;
+	}
+	$fired = true;
+
+	/**
+	 * Provider registration action — register any custom providers here.
+	 *
+	 * @since 0.18.0
+	 */
+	do_action( 'wp_desktop_ai_register_providers' );
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the registered providers in a JS-safe shape (no callables).
+ *
+ * Used by `wp_desktop_shell_config` to populate the OS Settings provider
+ * picker so the dropdown reflects whatever any plugin has registered.
+ *
+ * @since 0.18.0
+ *
+ * @return array<int, array{ id:string, label:string, description:string, api_key_label:string, api_key_link:string, capabilities:array }>
+ */
+function wpdm_ai_get_providers_for_config() {
+	$out = array();
+	foreach ( wp_desktop_ai_get_providers() as $id => $def ) {
+		$out[] = array(
+			'id'            => (string) $id,
+			'label'         => (string) $def['label'],
+			'description'   => (string) $def['description'],
+			'api_key_label' => (string) $def['api_key_label'],
+			'api_key_link'  => (string) $def['api_key_link'],
+			'capabilities'  => (array) $def['capabilities'],
+		);
+	}
+	return $out;
+}
+
+/**
+ * Returns all currently-registered providers.
+ *
+ * @since 0.18.0
+ *
+ * @return array<string, array> Map of provider id → definition.
+ */
+function wp_desktop_ai_get_providers() {
+	wpdm_ai_ensure_providers_registered();
+	return wpdm_ai_providers_storage();
+}
+
+/**
+ * Returns a single provider by id.
+ *
+ * @since 0.18.0
+ *
+ * @param string $id Provider id.
+ * @return array|null Provider definition, or null if unregistered.
+ */
+function wp_desktop_ai_get_provider( $id ) {
+	$id        = sanitize_key( (string) $id );
+	$providers = wp_desktop_ai_get_providers();
+	return $providers[ $id ] ?? null;
+}
+
+/**
+ * Returns the active provider id for a given user.
+ *
+ * Resolution order:
+ *   1. Per-user OS Settings 'provider' field (if it points at a registered
+ *      provider).
+ *   2. Platform settings 'provider' field (same check).
+ *   3. WPDM_AI_DEFAULT_PROVIDER ('openai').
+ *
+ * The `wp_desktop_ai_active_provider` filter wraps the resolved value so
+ * a plugin can pin a specific provider per-request (e.g., based on
+ * request_id, query content, or admin capability).
+ *
+ * @since 0.18.0
+ *
+ * @param int $user_id User id (0 for anonymous contexts).
+ * @return string Provider id. Always a string; may not point at a
+ *                registered provider if every fallback misses.
+ */
+function wp_desktop_ai_get_active_provider_id( $user_id ) {
+	$user_id   = (int) $user_id;
+	$providers = wp_desktop_ai_get_providers();
+
+	$candidate = '';
+	if ( $user_id > 0 && function_exists( 'wpdm_ai_get_settings' ) ) {
+		$ai = wpdm_ai_get_settings( $user_id );
+		if ( ! empty( $ai['provider'] ) && isset( $providers[ $ai['provider'] ] ) ) {
+			$candidate = (string) $ai['provider'];
+		}
+	}
+
+	if ( '' === $candidate && function_exists( 'wpdm_ai_get_platform_settings' ) ) {
+		$platform = wpdm_ai_get_platform_settings();
+		if ( ! empty( $platform['provider'] ) && isset( $providers[ $platform['provider'] ] ) ) {
+			$candidate = (string) $platform['provider'];
+		}
+	}
+
+	if ( '' === $candidate ) {
+		$candidate = WPDM_AI_DEFAULT_PROVIDER;
+	}
+
+	/**
+	 * Filter the resolved active-provider id.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param string $candidate Resolved provider id.
+	 * @param int    $user_id   User id (0 for anonymous).
+	 */
+	return (string) apply_filters( 'wp_desktop_ai_active_provider', $candidate, $user_id );
+}
+
+/**
+ * Returns the active provider definition for a given user, or WP_Error.
+ *
+ * @since 0.18.0
+ *
+ * @param int $user_id
+ * @return array|WP_Error
+ */
+function wp_desktop_ai_get_active_provider( $user_id ) {
+	$id  = wp_desktop_ai_get_active_provider_id( $user_id );
+	$def = wp_desktop_ai_get_provider( $id );
+	if ( null === $def ) {
+		return new WP_Error(
+			'wpdm_ai_no_provider',
+			sprintf( 'AI provider "%s" is not registered.', $id ),
+			array( 'provider' => $id )
+		);
+	}
+	return $def;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch helpers — the shell calls these instead of touching providers
+// directly. Each one resolves the active provider and forwards.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an opaque turn-input object via the active provider.
+ *
+ * @since 0.18.0
+ *
+ * @param int    $user_id User id (used to resolve active provider).
+ * @param string $kind    'user_message' | 'tool_results'.
+ * @param mixed  $payload Kind-specific payload (see file header).
+ * @return mixed|WP_Error Turn-input opaque value, or WP_Error.
+ */
+function wpdm_ai_provider_make_turn_input( $user_id, $kind, $payload ) {
+	$provider = wp_desktop_ai_get_active_provider( $user_id );
+	if ( is_wp_error( $provider ) ) {
+		return $provider;
+	}
+	return call_user_func( $provider['make_turn_input'], (string) $kind, $payload );
+}
+
+/**
+ * Run one turn of the agentic loop via the active provider.
+ *
+ * @since 0.18.0
+ *
+ * @param int        $user_id      User id.
+ * @param string     $api_key      Provider API key.
+ * @param mixed      $turn_input   Opaque value from {@see wpdm_ai_provider_make_turn_input}.
+ * @param array      $tools        Tool definitions (provider format).
+ * @param array|null $text_format  Optional structured-output schema (provider format).
+ * @param string     $instructions System prompt.
+ * @param mixed      $state        Provider-specific continuation state, or null on first turn.
+ * @return array|WP_Error Normalized turn result or WP_Error.
+ */
+function wpdm_ai_provider_agentic_call(
+	$user_id,
+	$api_key,
+	$turn_input,
+	array $tools,
+	$text_format,
+	$instructions,
+	$state = null
+) {
+	$provider = wp_desktop_ai_get_active_provider( $user_id );
+	if ( is_wp_error( $provider ) ) {
+		return $provider;
+	}
+
+	$result = call_user_func(
+		$provider['agentic_call'],
+		(string) $api_key,
+		$turn_input,
+		$tools,
+		$text_format,
+		(string) $instructions,
+		$state
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		return new WP_Error(
+			'wpdm_ai_provider_shape',
+			sprintf( 'Provider "%s" agentic_call returned a non-array.', $provider['id'] )
+		);
+	}
+
+	return wp_parse_args(
+		$result,
+		array(
+			'text'           => null,
+			'function_calls' => array(),
+			'next_state'     => null,
+			'raw'            => null,
+		)
+	);
+}
+
+/**
+ * Run a single-shot structured-output request via the active provider.
+ *
+ * @since 0.18.0
+ *
+ * @param int    $user_id     User id.
+ * @param string $api_key     Provider API key.
+ * @param array  $messages    Chat-style messages.
+ * @param array  $schema      JSON schema.
+ * @param string $schema_name Identifier for the schema.
+ * @param string $model       Optional model override; '' lets the provider pick its default.
+ * @return array|WP_Error
+ */
+function wpdm_ai_provider_structured_request(
+	$user_id,
+	$api_key,
+	array $messages,
+	array $schema,
+	$schema_name,
+	$model = ''
+) {
+	$provider = wp_desktop_ai_get_active_provider( $user_id );
+	if ( is_wp_error( $provider ) ) {
+		return $provider;
+	}
+
+	return call_user_func(
+		$provider['structured_request'],
+		(string) $api_key,
+		$messages,
+		$schema,
+		(string) $schema_name,
+		(string) $model
+	);
+}

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -980,20 +980,30 @@ INSTRUCTIONS;
 
 	// -----------------------------------------------------------------------
 	// First call — user query as input, instructions as system guidance.
+	// Dispatched through the active provider (default: OpenAI). State is
+	// opaque to the loop — providers stash whatever continuation token
+	// they need (OpenAI: previous_response_id; others may use nothing).
 	// -----------------------------------------------------------------------
-	$response = wpdm_ai_openai_responses_call(
-		$api_key,
-		array( array( 'role' => 'user', 'content' => $query ) ),
-		$tools,
-		$text_format,
-		$instructions
-	);
-
-	if ( is_wp_error( $response ) ) {
-		return $response;
+	$turn_input = wpdm_ai_provider_make_turn_input( $user_id, 'user_message', $query );
+	if ( is_wp_error( $turn_input ) ) {
+		return $turn_input;
 	}
 
-	$previous_id   = $response['id'] ?? '';
+	$turn = wpdm_ai_provider_agentic_call(
+		$user_id,
+		$api_key,
+		$turn_input,
+		$tools,
+		$text_format,
+		$instructions,
+		null
+	);
+
+	if ( is_wp_error( $turn ) ) {
+		return $turn;
+	}
+
+	$state         = $turn['next_state'];
 	$last_tool     = $initial_tool ?? 'search_posts';
 	$last_offset   = $start_offset;
 	$last_has_more = true;
@@ -1005,21 +1015,22 @@ INSTRUCTIONS;
 	// conversation state; we only send what's new each turn.
 	// -----------------------------------------------------------------------
 	for ( $i = 0; $i < WPDM_AI_SEARCH_MAX_ITERATIONS; $i++ ) {
-		$function_calls = wpdm_ai_extract_function_calls( $response );
+		$function_calls = is_array( $turn['function_calls'] ?? null ) ? $turn['function_calls'] : array();
 
 		// No tool calls in this response → final answer.
 		if ( empty( $function_calls ) ) {
 			$emit( array( 'phase' => 'composing', 'message' => 'Putting together your answer…' ) );
-			$text = wpdm_ai_extract_text( $response );
+			$text = $turn['text'] ?? null;
 			if ( ! is_string( $text ) ) {
-				// Log the raw output so mismatches in the Responses API shape
-				// are visible without having to re-run with a debugger.
+				// Log the raw output so mismatches in the provider response
+				// shape are visible without having to re-run with a debugger.
+				$raw = is_array( $turn['raw'] ?? null ) ? $turn['raw'] : array();
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( '[WP Desktop Mode AI] Unexpected output shape: ' . wp_json_encode( $response['output'] ?? [] ) );
+				error_log( '[WP Desktop Mode AI] Unexpected output shape: ' . wp_json_encode( $raw ) );
 				return new WP_Error(
 					'wpdm_ai_empty',
-					'Responses API returned no text in the final turn.',
-					array( 'output' => $response['output'] ?? [] )
+					'AI provider returned no text in the final turn.',
+					array( 'raw' => $raw )
 				);
 			}
 
@@ -1151,7 +1162,10 @@ INSTRUCTIONS;
 			return $final;
 		}
 
-		// Execute each tool call and collect results.
+		// Execute each tool call and collect results in the registry's
+		// normalized shape — `{ call_id, output (json string) }`. The
+		// provider's `make_turn_input('tool_results', …)` reshapes them
+		// for the underlying API.
 		$tool_outputs = array();
 		foreach ( $function_calls as $fc ) {
 			$tool_name = $fc['name'] ?? '';
@@ -1159,7 +1173,6 @@ INSTRUCTIONS;
 
 			if ( ! in_array( $tool_name, $valid_tools, true ) ) {
 				$tool_outputs[] = array(
-					'type'    => 'function_call_output',
 					'call_id' => $call_id,
 					'output'  => wp_json_encode( array( 'error' => "Unknown tool '{$tool_name}'." ) ),
 				);
@@ -1229,7 +1242,6 @@ INSTRUCTIONS;
 			);
 
 			$tool_outputs[] = array(
-				'type'    => 'function_call_output',
 				'call_id' => $call_id,
 				'output'  => wp_json_encode( $batch ),
 			);
@@ -1237,22 +1249,30 @@ INSTRUCTIONS;
 
 		$iterations++;
 
-		// Next turn — only send the tool results; OpenAI reconstructs
-		// the full context via previous_response_id.
-		$response = wpdm_ai_openai_responses_call(
+		// Next turn — only send the tool results. Providers that support
+		// server-side context chaining (OpenAI's previous_response_id)
+		// use the opaque $state we threaded through; others can read
+		// the tool results and append them to whatever history they keep.
+		$turn_input = wpdm_ai_provider_make_turn_input( $user_id, 'tool_results', $tool_outputs );
+		if ( is_wp_error( $turn_input ) ) {
+			return $turn_input;
+		}
+
+		$turn = wpdm_ai_provider_agentic_call(
+			$user_id,
 			$api_key,
-			$tool_outputs,
+			$turn_input,
 			$tools,
 			$text_format,
 			'',
-			$previous_id
+			$state
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
+		if ( is_wp_error( $turn ) ) {
+			return $turn;
 		}
 
-		$previous_id = $response['id'] ?? $previous_id;
+		$state = $turn['next_state'] ?? $state;
 	}
 
 	// -----------------------------------------------------------------------
@@ -1495,30 +1515,37 @@ INSTRUCTIONS;
 		)
 	);
 
-	$response = wpdm_ai_openai_responses_call(
+	$turn_input = wpdm_ai_provider_make_turn_input( $user_id, 'user_message', $user_message );
+	if ( is_wp_error( $turn_input ) ) {
+		return $turn_input;
+	}
+
+	$turn = wpdm_ai_provider_agentic_call(
+		$user_id,
 		$api_key,
-		array( array( 'role' => 'user', 'content' => $user_message ) ),
-		array(),        // no tools — we want a plain reply
-		null,           // no JSON schema — free-form text
-		$instructions
+		$turn_input,
+		array(),  // no tools — we want a plain reply
+		null,     // no JSON schema — free-form text
+		$instructions,
+		null
 	);
 
-	if ( is_wp_error( $response ) ) {
+	if ( is_wp_error( $turn ) ) {
 		do_action(
 			'wp_desktop_ai_search_error',
 			array(
-				'code'       => $response->get_error_code(),
-				'message'    => $response->get_error_message(),
-				'data'       => $response->get_error_data(),
+				'code'       => $turn->get_error_code(),
+				'message'    => $turn->get_error_message(),
+				'data'       => $turn->get_error_data(),
 				'user_id'    => $user_id,
 				'request_id' => $request_id,
 				'phase'      => 'follow_up',
 			)
 		);
-		return $response;
+		return $turn;
 	}
 
-	$text     = wpdm_ai_extract_text( $response );
+	$text     = $turn['text'] ?? null;
 	$fallback = false;
 	if ( ! is_string( $text ) || '' === trim( $text ) ) {
 		// Graceful degrade — if OpenAI returned nothing usable, fall

--- a/includes/ai-copilot/settings.php
+++ b/includes/ai-copilot/settings.php
@@ -25,6 +25,7 @@ function wpdm_ai_get_settings( $user_id ) {
 		'enabled'  => false,
 		'provider' => 'openai',
 		'apiKey'   => '',
+		'apiKeys'  => array(),
 	);
 	$ai = isset( $os['ai'] ) && is_array( $os['ai'] ) ? $os['ai'] : array();
 	return array_merge( $defaults, $ai );
@@ -44,25 +45,56 @@ function wpdm_ai_get_settings( $user_id ) {
  * @return bool
  */
 function wpdm_ai_is_enabled( $user_id ) {
-	// 1. Platform key — works for any user, including anonymous contexts.
+	$user_id  = (int) $user_id;
 	$platform = wpdm_ai_get_platform_settings();
-	if ( ! empty( $platform['enabled'] ) && ! empty( $platform['apiKey'] ) ) {
+	$active   = function_exists( 'wp_desktop_ai_get_active_provider_id' )
+		? wp_desktop_ai_get_active_provider_id( $user_id )
+		: 'openai';
+
+	// 1. Platform key — works for any user, including anonymous contexts.
+	// Resolve via the per-provider map first, then fall back to the
+	// legacy single `apiKey` field (which is treated as the openai key).
+	if ( ! empty( $platform['enabled'] ) && '' !== wpdm_ai_resolve_key_for_provider( $platform, $active ) ) {
 		return true;
 	}
 
 	// 2. Per-user override.
-	$ai = wpdm_ai_get_settings( (int) $user_id );
+	$ai = wpdm_ai_get_settings( $user_id );
 	if ( empty( $ai['enabled'] ) ) {
 		return false;
 	}
-	if ( 'openai' !== $ai['provider'] ) {
-		return false;
-	}
-	if ( empty( $ai['apiKey'] ) || ! is_string( $ai['apiKey'] ) ) {
+	if ( '' === wpdm_ai_resolve_key_for_provider( $ai, $active ) ) {
 		return false;
 	}
 
 	return true;
+}
+
+/**
+ * Resolve which key — from a settings block — applies to a given provider.
+ *
+ * Order: explicit `apiKeys[provider]` → legacy `apiKey` (only when the
+ * provider is `openai`, since that's what the legacy field meant) → ''.
+ *
+ * @since 0.18.0
+ *
+ * @param array  $settings    `apiKeys` and `apiKey` carrying settings block.
+ * @param string $provider_id Provider id to resolve for.
+ * @return string Trimmed API key, or '' if none.
+ */
+function wpdm_ai_resolve_key_for_provider( array $settings, $provider_id ) {
+	$provider_id = (string) $provider_id;
+	$keys        = isset( $settings['apiKeys'] ) && is_array( $settings['apiKeys'] ) ? $settings['apiKeys'] : array();
+
+	if ( isset( $keys[ $provider_id ] ) && is_string( $keys[ $provider_id ] ) && '' !== $keys[ $provider_id ] ) {
+		return (string) $keys[ $provider_id ];
+	}
+
+	if ( 'openai' === $provider_id && isset( $settings['apiKey'] ) && is_string( $settings['apiKey'] ) && '' !== $settings['apiKey'] ) {
+		return (string) $settings['apiKey'];
+	}
+
+	return '';
 }
 
 /**
@@ -78,13 +110,19 @@ function wpdm_ai_is_enabled( $user_id ) {
  * @return string API key, or empty string if none configured.
  */
 function wpdm_ai_get_api_key( $user_id ) {
+	$user_id = (int) $user_id;
+	$active  = function_exists( 'wp_desktop_ai_get_active_provider_id' )
+		? wp_desktop_ai_get_active_provider_id( $user_id )
+		: 'openai';
+
 	// Per-user override takes precedence.
-	$ai = wpdm_ai_get_settings( (int) $user_id );
-	if ( ! empty( $ai['apiKey'] ) && is_string( $ai['apiKey'] ) ) {
-		return $ai['apiKey'];
+	$ai  = wpdm_ai_get_settings( $user_id );
+	$key = wpdm_ai_resolve_key_for_provider( $ai, $active );
+	if ( '' !== $key ) {
+		return $key;
 	}
 
 	// Fall back to platform key.
 	$platform = wpdm_ai_get_platform_settings();
-	return ! empty( $platform['apiKey'] ) ? (string) $platform['apiKey'] : '';
+	return wpdm_ai_resolve_key_for_provider( $platform, $active );
 }

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -20,7 +20,15 @@ const WPDM_OS_SETTINGS_META_KEY = 'wp_desktop_os_settings';
 /** Valid dock-size IDs — mirrors the TS `DOCK_SIZES` constant. */
 const WPDM_OS_SETTINGS_DOCK_SIZES = array( 'compact', 'default', 'large' );
 
-/** Valid AI provider IDs — mirrors the TS `AI_PROVIDERS` constant. */
+/**
+ * Built-in AI provider IDs.
+ *
+ * Other providers register themselves via {@see wp_register_desktop_ai_provider()};
+ * sanitization no longer gates the field against this list (the active-provider
+ * resolver does the existence check at lookup time).
+ *
+ * @deprecated 0.18.0 Kept for backwards compatibility; use the provider registry.
+ */
 const WPDM_OS_SETTINGS_AI_PROVIDERS = array( 'openai' );
 
 /**
@@ -48,7 +56,8 @@ function wpdm_default_os_settings() {
 		'ai'           => array(
 			'enabled'  => false,
 			'provider' => 'openai',
-			'apiKey'   => '',
+			'apiKey'   => '',     // Legacy field — treated as the OpenAI key for backwards compat.
+			'apiKeys'  => array(), // Per-provider keys: { [provider_id]: string }.
 		),
 	);
 }
@@ -176,11 +185,15 @@ function wpdm_sanitize_os_settings( $raw ) {
 			$ai['enabled'] = (bool) $raw_ai['enabled'];
 		}
 
-		if (
-			isset( $raw_ai['provider'] ) &&
-			in_array( $raw_ai['provider'], WPDM_OS_SETTINGS_AI_PROVIDERS, true )
-		) {
-			$ai['provider'] = (string) $raw_ai['provider'];
+		// Provider — accept any sanitize_key()-clean string. We don't gate
+		// on the registry here because providers register on `init` and
+		// sanitize may run earlier (REST boot). Existence is checked at
+		// lookup time by `wp_desktop_ai_get_active_provider_id()`.
+		if ( isset( $raw_ai['provider'] ) && is_string( $raw_ai['provider'] ) ) {
+			$slug = sanitize_key( $raw_ai['provider'] );
+			if ( '' !== $slug ) {
+				$ai['provider'] = $slug;
+			}
 		}
 
 		// API key — strip tags and limit length. The key is opaque to us;
@@ -188,6 +201,22 @@ function wpdm_sanitize_os_settings( $raw ) {
 		// real API key while preventing runaway meta writes.
 		if ( isset( $raw_ai['apiKey'] ) && is_string( $raw_ai['apiKey'] ) ) {
 			$ai['apiKey'] = substr( sanitize_text_field( $raw_ai['apiKey'] ), 0, 512 );
+		}
+
+		// Per-provider keys map. Limited to 32 entries to bound storage.
+		if ( isset( $raw_ai['apiKeys'] ) && is_array( $raw_ai['apiKeys'] ) ) {
+			$keys = array();
+			foreach ( $raw_ai['apiKeys'] as $pid => $val ) {
+				if ( count( $keys ) >= 32 ) {
+					break;
+				}
+				$slug = sanitize_key( (string) $pid );
+				if ( '' === $slug || ! is_string( $val ) ) {
+					continue;
+				}
+				$keys[ $slug ] = substr( sanitize_text_field( $val ), 0, 512 );
+			}
+			$ai['apiKeys'] = $keys;
 		}
 	}
 

--- a/includes/render.php
+++ b/includes/render.php
@@ -242,6 +242,7 @@ function wpdm_enqueue_assets() {
 			'aiSearchStreamUrl'     => esc_url_raw( add_query_arg( 'action', 'wpdm_ai_search_stream', admin_url( 'admin-ajax.php' ) ) ),
 			'aiPlatformSettings'    => current_user_can( 'manage_options' ) ? wpdm_ai_get_platform_settings() : null,
 			'aiPlatformSettingsUrl' => esc_url_raw( rest_url( 'wp-desktop/v1/ai/platform-settings' ) ),
+			'aiProviders'           => wpdm_ai_get_providers_for_config(),
 			'extendedOptions'       => current_user_can( 'manage_options' ) ? wpdm_get_extended_options() : null,
 			'extendedOptionsUrl'    => esc_url_raw( rest_url( 'wp-desktop/v1/extended-options' ) ),
 			'currentUserIsAdmin'    => current_user_can( 'manage_options' ),

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -132,13 +132,70 @@ export const DEFAULTS: OsSettingsState = {
 		enabled: false,
 		provider: 'openai',
 		apiKey: '',
+		apiKeys: {},
 	},
 };
 
 /**
- * Available AI providers. Single-entry for now — the picker is still a
- * `<wpd-select>` so adding the next provider is zero-UI-churn.
+ * Hard-coded fallback list — the only provider we know about without
+ * reading the runtime registry. {@link getAiProviders} prefers the
+ * runtime `wpDesktopConfig.aiProviders` list when present, so adding a
+ * new provider is a pure PHP concern.
  */
-export const AI_PROVIDERS = [
-	{ id: 'openai' as const, label: 'OpenAI' },
-] as const;
+export const AI_PROVIDERS: ReadonlyArray< {
+	id: string;
+	label: string;
+	description?: string;
+	apiKeyLabel?: string;
+	apiKeyLink?: string;
+} > = [
+	{
+		id: 'openai',
+		label: 'OpenAI',
+		apiKeyLabel: 'OpenAI API key',
+		apiKeyLink: 'https://platform.openai.com/api-keys',
+	},
+];
+
+/**
+ * Returns the runtime list of registered AI providers.
+ *
+ * Falls back to {@link AI_PROVIDERS} when the shell config is missing
+ * (rare — happens in some test contexts and the very first frame
+ * before `wpDesktopConfig` is populated).
+ */
+export function getAiProviders(): ReadonlyArray< {
+	id: string;
+	label: string;
+	description?: string;
+	apiKeyLabel?: string;
+	apiKeyLink?: string;
+} > {
+	const cfg = (
+		window as typeof window & {
+			wpDesktopConfig?: {
+				aiProviders?: Array< {
+					id: string;
+					label: string;
+					description?: string;
+					api_key_label?: string;
+					api_key_link?: string;
+					capabilities?: string[];
+				} >;
+			};
+		}
+	).wpDesktopConfig;
+
+	const list = cfg?.aiProviders;
+	if ( ! Array.isArray( list ) || list.length === 0 ) {
+		return AI_PROVIDERS;
+	}
+
+	return list.map( ( p ) => ( {
+		id: p.id,
+		label: p.label,
+		description: p.description,
+		apiKeyLabel: p.api_key_label,
+		apiKeyLink: p.api_key_link,
+	} ) );
+}

--- a/src/settings/sections/ai.ts
+++ b/src/settings/sections/ai.ts
@@ -15,8 +15,8 @@
 
 import { __ } from '../../i18n';
 import { html, render } from '../../ui/core';
-import { AI_PROVIDERS } from '../constants';
-import type { AiProviderId, SettingsCtx } from '../types';
+import { getAiProviders } from '../constants';
+import type { SettingsCtx } from '../types';
 
 // ---------------------------------------------------------------------------
 // Personal settings
@@ -34,16 +34,31 @@ export function buildAiSection( ctx: SettingsCtx ): HTMLElement {
 
 	const onProvider = ( e: Event ): void => {
 		const id = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
-		if ( ! AI_PROVIDERS.some( ( p ) => p.id === id ) ) {
+		if ( ! getAiProviders().some( ( p ) => p.id === id ) ) {
 			return;
 		}
-		ctx.state.ai = { ...ctx.state.ai, provider: id as AiProviderId };
+		// Stash the current key under the previous provider before switching
+		// so each provider keeps its own key even if the user toggles back.
+		const prev = ctx.state.ai.provider;
+		const apiKeys = { ...( ctx.state.ai.apiKeys ?? {} ) };
+		if ( ctx.state.ai.apiKey ) {
+			apiKeys[ prev ] = ctx.state.ai.apiKey;
+		}
+		ctx.state.ai = {
+			...ctx.state.ai,
+			provider: id,
+			apiKeys,
+			apiKey: apiKeys[ id ] ?? '',
+		};
 		ctx.save();
+		paint();
 	};
 
 	const onApiKey = ( e: Event ): void => {
 		const value = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
-		ctx.state.ai = { ...ctx.state.ai, apiKey: value };
+		const apiKeys = { ...( ctx.state.ai.apiKeys ?? {} ) };
+		apiKeys[ ctx.state.ai.provider ] = value;
+		ctx.state.ai = { ...ctx.state.ai, apiKey: value, apiKeys };
 		ctx.save();
 	};
 
@@ -51,6 +66,9 @@ export function buildAiSection( ctx: SettingsCtx ): HTMLElement {
 		const platformEnabled =
 			ctx.config.aiPlatformSettings?.enabled === true &&
 			!! ctx.config.aiPlatformSettings?.apiKey;
+		const activeProvider =
+			getAiProviders().find( ( p ) => p.id === ctx.state.ai.provider ) ?? getAiProviders()[ 0 ];
+		const apiKeyLabel = activeProvider?.apiKeyLabel ?? __( 'API key' );
 
 		render(
 			html`
@@ -72,13 +90,13 @@ export function buildAiSection( ctx: SettingsCtx ): HTMLElement {
 						?disabled=${ ! ctx.state.ai.enabled }
 						@wpd-pick=${ onProvider }
 					>
-						${ AI_PROVIDERS.map(
+						${ getAiProviders().map(
 							( p ) => html`<wpd-option value=${ p.id }>${ p.label }</wpd-option>`,
 						) }
 					</wpd-select>
 
 					<wpd-text-field
-						label=${ __( 'API key' ) }
+						label=${ apiKeyLabel }
 						type="password"
 						reveal
 						autocomplete="off"
@@ -177,7 +195,7 @@ function _buildGlobalSection( ctx: SettingsCtx ): HTMLElement {
 
 	const onProvider = ( e: Event ): void => {
 		const id = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
-		if ( ! AI_PROVIDERS.some( ( p ) => p.id === id ) ) {
+		if ( ! getAiProviders().some( ( p ) => p.id === id ) ) {
 			return;
 		}
 		state.provider = id;
@@ -211,7 +229,7 @@ function _buildGlobalSection( ctx: SettingsCtx ): HTMLElement {
 						?disabled=${ ! state.enabled || state.saving }
 						@wpd-pick=${ onProvider }
 					>
-						${ AI_PROVIDERS.map(
+						${ getAiProviders().map(
 							( p ) => html`<wpd-option value=${ p.id }>${ p.label }</wpd-option>`,
 						) }
 					</wpd-select>

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -19,7 +19,7 @@
 
 import type { DesktopConfig } from '../types';
 import {
-	AI_PROVIDERS,
+	getAiProviders,
 	DEFAULTS,
 	DOCK_SIZES,
 	STORAGE_KEY,
@@ -192,16 +192,29 @@ export function structuredDefaults(): OsSettingsState {
 
 export function sanitizeAi( raw: unknown ): AiSettings {
 	if ( ! raw || typeof raw !== 'object' ) {
-		return { ...DEFAULTS.ai };
+		return { ...DEFAULTS.ai, apiKeys: {} };
 	}
-	const { enabled, provider, apiKey } = raw as Partial<AiSettings>;
-	const validProvider = AI_PROVIDERS.some( ( p ) => p.id === provider )
-		? ( provider as AiSettings[ 'provider' ] )
-		: DEFAULTS.ai.provider;
+	const { enabled, provider, apiKey, apiKeys } = raw as Partial< AiSettings >;
+	const known = getAiProviders();
+	const validProvider =
+		typeof provider === 'string' && known.some( ( p ) => p.id === provider )
+			? provider
+			: DEFAULTS.ai.provider;
+
+	const cleanKeys: Record< string, string > = {};
+	if ( apiKeys && typeof apiKeys === 'object' ) {
+		for ( const [ pid, val ] of Object.entries( apiKeys ) ) {
+			if ( typeof val === 'string' ) {
+				cleanKeys[ pid ] = val.slice( 0, 512 );
+			}
+		}
+	}
+
 	return {
 		enabled: typeof enabled === 'boolean' ? enabled : DEFAULTS.ai.enabled,
 		provider: validProvider,
 		apiKey: typeof apiKey === 'string' ? apiKey : DEFAULTS.ai.apiKey,
+		apiKeys: cleanKeys,
 	};
 }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -35,16 +35,30 @@ export interface CustomImage {
 
 /**
  * AI provider id. Kept as a plain string so new providers can be added
- * without touching the sanitization ladder — only registered ids in the
- * AI section's own picker are offered in the UI.
+ * without touching the sanitization ladder — the picker is driven by the
+ * runtime list in `wpDesktopConfig.aiProviders`, populated by every
+ * plugin that calls `wp_register_desktop_ai_provider()`.
  */
-export type AiProviderId = 'openai';
+export type AiProviderId = string;
 
-/** AI integration preferences — provider choice + API key. */
+/** AI integration preferences — provider choice + per-provider API keys. */
 export interface AiSettings {
 	enabled: boolean;
 	provider: AiProviderId;
+	/** Legacy single-key field; treated as the OpenAI key for backwards compat. */
 	apiKey: string;
+	/** Per-provider key map. Falls back to `apiKey` for `openai`. */
+	apiKeys: Record< string, string >;
+}
+
+/** Provider entry surfaced via `wpDesktopConfig.aiProviders`. */
+export interface AiProviderEntry {
+	id: string;
+	label: string;
+	description: string;
+	api_key_label: string;
+	api_key_link: string;
+	capabilities: string[];
 }
 
 /** Shape of the persisted settings. Defaults merged on load. */
@@ -91,7 +105,12 @@ export interface OsSettingsConfig {
 	/** Whether the current user has manage_options capability. */
 	isAdmin: boolean;
 	/** Platform-wide AI settings — null for non-admins. */
-	aiPlatformSettings: { enabled: boolean; provider: string; apiKey: string } | null;
+	aiPlatformSettings: {
+		enabled: boolean;
+		provider: string;
+		apiKey: string;
+		apiKeys?: Record< string, string >;
+	} | null;
 	/** REST endpoint for reading/writing platform AI settings. */
 	aiPlatformSettingsUrl: string;
 	/** Platform-wide extended options — null for non-admins. */

--- a/tests/phpunit/tests/aiProviderRegistry.php
+++ b/tests/phpunit/tests/aiProviderRegistry.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Tests for the AI provider registry — `wp_register_desktop_ai_provider()`,
+ * lookups, dispatch helpers, and active-provider resolution.
+ *
+ * The registry uses a process-static store, so each test cleans up after
+ * itself rather than relying on tear_down to walk an unknown set of ids.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-ai
+ */
+class Tests_DesktopMode_AiProviderRegistry extends WP_UnitTestCase {
+
+	private function unique_id( $prefix = 'p' ) {
+		return $prefix . '_' . substr( md5( uniqid( '', true ) ), 0, 8 );
+	}
+
+	private function noop_provider_args() {
+		return array(
+			'label'              => 'Test',
+			'make_turn_input'    => static function ( $kind, $payload ) {
+				return array( 'kind' => $kind, 'payload' => $payload );
+			},
+			'agentic_call'       => static function () {
+				return array(
+					'text'           => 'hello',
+					'function_calls' => array(),
+					'next_state'     => null,
+					'raw'            => array(),
+				);
+			},
+			'structured_request' => static function () {
+				return array( 'ok' => true );
+			},
+		);
+	}
+
+	// -----------------------------------------------------------------
+	// Registration
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wp_register_desktop_ai_provider
+	 */
+	public function test_registers_a_provider() {
+		$id = $this->unique_id();
+		$ok = wp_register_desktop_ai_provider( $id, $this->noop_provider_args() );
+		$this->assertTrue( $ok );
+
+		$def = wp_desktop_ai_get_provider( $id );
+		$this->assertIsArray( $def );
+		$this->assertSame( $id, $def['id'] );
+		$this->assertSame( 'Test', $def['label'] );
+
+		wp_unregister_desktop_ai_provider( $id );
+	}
+
+	/**
+	 * @covers ::wp_register_desktop_ai_provider
+	 */
+	public function test_empty_id_returns_wp_error() {
+		$err = wp_register_desktop_ai_provider( '', $this->noop_provider_args() );
+		$this->assertInstanceOf( 'WP_Error', $err );
+		$this->assertSame( 'wpdm_ai_provider_id', $err->get_error_code() );
+	}
+
+	/**
+	 * @covers ::wp_register_desktop_ai_provider
+	 */
+	public function test_missing_callback_returns_wp_error() {
+		$args = $this->noop_provider_args();
+		unset( $args['agentic_call'] );
+
+		$err = wp_register_desktop_ai_provider( $this->unique_id(), $args );
+		$this->assertInstanceOf( 'WP_Error', $err );
+		$this->assertSame( 'wpdm_ai_provider_callback', $err->get_error_code() );
+	}
+
+	/**
+	 * @covers ::wp_register_desktop_ai_provider
+	 */
+	public function test_non_callable_callback_returns_wp_error() {
+		$args                 = $this->noop_provider_args();
+		$args['make_turn_input'] = 'not_a_function_that_exists_anywhere';
+
+		$err = wp_register_desktop_ai_provider( $this->unique_id(), $args );
+		$this->assertInstanceOf( 'WP_Error', $err );
+		$this->assertSame( 'wpdm_ai_provider_callback', $err->get_error_code() );
+	}
+
+	/**
+	 * @covers ::wp_unregister_desktop_ai_provider
+	 */
+	public function test_unregister_returns_true_when_present_false_otherwise() {
+		$id = $this->unique_id();
+		wp_register_desktop_ai_provider( $id, $this->noop_provider_args() );
+
+		$this->assertTrue( wp_unregister_desktop_ai_provider( $id ) );
+		$this->assertFalse( wp_unregister_desktop_ai_provider( $id ) );
+		$this->assertNull( wp_desktop_ai_get_provider( $id ) );
+	}
+
+	// -----------------------------------------------------------------
+	// Lookup + active-provider resolution
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wp_desktop_ai_get_providers
+	 */
+	public function test_get_providers_includes_built_in_openai() {
+		$providers = wp_desktop_ai_get_providers();
+		$this->assertArrayHasKey( 'openai', $providers );
+		$this->assertSame( 'OpenAI', $providers['openai']['label'] );
+	}
+
+	/**
+	 * @covers ::wp_desktop_ai_get_active_provider_id
+	 */
+	public function test_active_provider_falls_back_to_openai_default() {
+		$user_id = self::factory()->user->create();
+		$this->assertSame( 'openai', wp_desktop_ai_get_active_provider_id( $user_id ) );
+	}
+
+	/**
+	 * @covers ::wp_desktop_ai_get_active_provider_id
+	 */
+	public function test_active_provider_filter_overrides_default() {
+		$user_id = self::factory()->user->create();
+
+		$pinned = $this->unique_id();
+		wp_register_desktop_ai_provider( $pinned, $this->noop_provider_args() );
+
+		add_filter(
+			'wp_desktop_ai_active_provider',
+			static function () use ( $pinned ) {
+				return $pinned;
+			}
+		);
+
+		$this->assertSame( $pinned, wp_desktop_ai_get_active_provider_id( $user_id ) );
+
+		remove_all_filters( 'wp_desktop_ai_active_provider' );
+		wp_unregister_desktop_ai_provider( $pinned );
+	}
+
+	/**
+	 * @covers ::wp_desktop_ai_get_active_provider
+	 */
+	public function test_active_provider_returns_wp_error_when_unregistered() {
+		$user_id = self::factory()->user->create();
+
+		add_filter(
+			'wp_desktop_ai_active_provider',
+			static function () {
+				return 'definitely_not_registered';
+			}
+		);
+
+		$result = wp_desktop_ai_get_active_provider( $user_id );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'wpdm_ai_no_provider', $result->get_error_code() );
+
+		remove_all_filters( 'wp_desktop_ai_active_provider' );
+	}
+
+	// -----------------------------------------------------------------
+	// Dispatch helpers
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wpdm_ai_provider_make_turn_input
+	 */
+	public function test_make_turn_input_dispatches_to_active_provider() {
+		$user_id = self::factory()->user->create();
+		$id      = $this->unique_id();
+
+		wp_register_desktop_ai_provider( $id, $this->noop_provider_args() );
+		add_filter(
+			'wp_desktop_ai_active_provider',
+			static function () use ( $id ) {
+				return $id;
+			}
+		);
+
+		$out = wpdm_ai_provider_make_turn_input( $user_id, 'user_message', 'hi' );
+		$this->assertSame( array( 'kind' => 'user_message', 'payload' => 'hi' ), $out );
+
+		remove_all_filters( 'wp_desktop_ai_active_provider' );
+		wp_unregister_desktop_ai_provider( $id );
+	}
+
+	/**
+	 * @covers ::wpdm_ai_provider_agentic_call
+	 */
+	public function test_agentic_call_normalizes_provider_response() {
+		$user_id = self::factory()->user->create();
+		$id      = $this->unique_id();
+
+		wp_register_desktop_ai_provider( $id, $this->noop_provider_args() );
+		add_filter(
+			'wp_desktop_ai_active_provider',
+			static function () use ( $id ) {
+				return $id;
+			}
+		);
+
+		$turn = wpdm_ai_provider_agentic_call(
+			$user_id,
+			'sk-test',
+			null,
+			array(),
+			null,
+			'',
+			null
+		);
+		$this->assertSame( 'hello', $turn['text'] );
+		$this->assertSame( array(), $turn['function_calls'] );
+		$this->assertNull( $turn['next_state'] );
+
+		remove_all_filters( 'wp_desktop_ai_active_provider' );
+		wp_unregister_desktop_ai_provider( $id );
+	}
+
+	/**
+	 * @covers ::wpdm_ai_provider_agentic_call
+	 */
+	public function test_agentic_call_propagates_wp_error() {
+		$user_id = self::factory()->user->create();
+		$id      = $this->unique_id();
+		$args    = $this->noop_provider_args();
+		$args['agentic_call'] = static function () {
+			return new WP_Error( 'boom', 'bad things' );
+		};
+
+		wp_register_desktop_ai_provider( $id, $args );
+		add_filter(
+			'wp_desktop_ai_active_provider',
+			static function () use ( $id ) {
+				return $id;
+			}
+		);
+
+		$turn = wpdm_ai_provider_agentic_call(
+			$user_id,
+			'sk-test',
+			null,
+			array(),
+			null,
+			'',
+			null
+		);
+		$this->assertInstanceOf( 'WP_Error', $turn );
+		$this->assertSame( 'boom', $turn->get_error_code() );
+
+		remove_all_filters( 'wp_desktop_ai_active_provider' );
+		wp_unregister_desktop_ai_provider( $id );
+	}
+
+	// -----------------------------------------------------------------
+	// JS-safe shape
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wpdm_ai_get_providers_for_config
+	 */
+	public function test_providers_for_config_strips_callables() {
+		$entries = wpdm_ai_get_providers_for_config();
+		$this->assertNotEmpty( $entries );
+		foreach ( $entries as $entry ) {
+			$this->assertArrayNotHasKey( 'agentic_call', $entry );
+			$this->assertArrayNotHasKey( 'make_turn_input', $entry );
+			$this->assertArrayNotHasKey( 'structured_request', $entry );
+			$this->assertArrayHasKey( 'id', $entry );
+			$this->assertArrayHasKey( 'label', $entry );
+		}
+	}
+
+	// -----------------------------------------------------------------
+	// Per-provider key resolution
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wpdm_ai_resolve_key_for_provider
+	 */
+	public function test_resolve_key_prefers_per_provider_map() {
+		$settings = array(
+			'apiKey'  => 'legacy-openai-key',
+			'apiKeys' => array(
+				'anthropic' => 'sk-ant-…',
+			),
+		);
+		$this->assertSame( 'sk-ant-…', wpdm_ai_resolve_key_for_provider( $settings, 'anthropic' ) );
+	}
+
+	/**
+	 * @covers ::wpdm_ai_resolve_key_for_provider
+	 */
+	public function test_resolve_key_falls_back_to_legacy_for_openai_only() {
+		$settings = array(
+			'apiKey'  => 'legacy-openai-key',
+			'apiKeys' => array(),
+		);
+		$this->assertSame( 'legacy-openai-key', wpdm_ai_resolve_key_for_provider( $settings, 'openai' ) );
+		$this->assertSame( '', wpdm_ai_resolve_key_for_provider( $settings, 'anthropic' ) );
+	}
+}


### PR DESCRIPTION
# AI provider extensibility

Make the AI Copilot pluggable so other developers can ship their own providers (Anthropic, Gemini, local LLMs, …) without forking. The shell still ships the OpenAI Responses API as the built-in default — it just registers itself through the new public API like any other provider would.

## What's new

### `wp_register_desktop_ai_provider( $id, $args )` — Experimental (since 0.18.0)

A new PHP API for registering AI back-ends. Each provider supplies three callables that fully encapsulate its wire format; the shell drives the agentic loop, observability, and tool dispatch unchanged.

```php
add_action( 'wp_desktop_ai_register_providers', function () {
    wp_register_desktop_ai_provider( 'anthropic', array(
        'label'              => 'Anthropic Claude',
        'api_key_label'      => 'Anthropic API key',
        'api_key_link'       => 'https://console.anthropic.com/settings/keys',
        'default_model'      => 'claude-sonnet-4-6',
        'make_turn_input'    => 'my_anthropic_make_turn_input',
        'agentic_call'       => 'my_anthropic_agentic_call',
        'structured_request' => 'my_anthropic_structured_request',
    ) );
} );
```

Companion surface:

- `wp_unregister_desktop_ai_provider( $id )`
- `wp_desktop_ai_register_providers` — action, fires lazily on first lookup.
- `wp_desktop_ai_provider_registered` — observability action.
- `wp_desktop_ai_active_provider` — filter, lets a plugin pin a provider per-request.

### Per-provider API keys

OS Settings → AI now stores `apiKeys: { [provider_id]: string }` alongside the legacy single `apiKey`. The picker is driven by `wpDesktopConfig.aiProviders` (whatever's been registered) instead of a hardcoded list. Switching providers in the UI preserves each provider's key so users can flip back and forth without re-entering credentials.

### Built-in OpenAI provider

`includes/ai-copilot/openai.php` keeps every existing function and adds three small adapter callbacks (`wpdm_ai_openai_make_turn_input`, `wpdm_ai_openai_provider_agentic_call`, `wpdm_ai_openai_provider_structured_request`). On `wp_desktop_ai_register_providers` it registers itself as `'openai'`. Any installation that hasn't configured a different provider behaves identically to before.

### Call-site refactor

`includes/ai-copilot/search.php` and `jobs.php` now dispatch through the registry (`wpdm_ai_provider_make_turn_input`, `_agentic_call`, `_structured_request`) instead of calling the OpenAI helpers directly. The agentic loop's `previous_response_id` is now stored as opaque "state" the provider returns and consumes — OpenAI uses it; other providers can stash full message history there or ignore it.

## Files

| | |
|---|---|
| **New** | `includes/ai-copilot/providers-registry.php` |
| | `docs/examples/register-ai-provider.md` |
| | `tests/phpunit/tests/aiProviderRegistry.php` |
| **Modified** | `includes/ai-copilot/openai.php` (registers as built-in provider) |
| | `includes/ai-copilot/search.php`, `jobs.php` (dispatch through registry) |
| | `includes/ai-copilot/settings.php`, `platform-settings.php` (per-provider keys) |
| | `includes/os-settings.php` (apiKeys map + dynamic provider validation) |
| | `includes/render.php` (surface `aiProviders` to JS) |
| | `includes/ai-copilot/bootstrap.php` (load registry) |
| | `src/settings/{constants,state,types,sections/ai}.ts` (runtime provider list, per-provider key persistence, active-provider key label) |
| | `docs/hooks-reference.md`, `docs/examples/README.md`, `CLAUDE.md` |

## Backwards compatibility

- The OpenAI provider stays the default when nothing else is registered.
- Existing per-user / platform `apiKey` storage continues to work — `wpdm_ai_resolve_key_for_provider()` falls back to it for `'openai'` resolutions.
- All existing AI hooks (`wp_desktop_ai_model`, `wp_desktop_ai_system_prompt`, `wp_desktop_ai_tools`, observability actions, …) keep firing — they operate on the normalized request before transport, so they're provider-agnostic by definition.
- No JS API was removed; `AI_PROVIDERS` constant kept as a fallback for the rare contexts where `wpDesktopConfig` isn't populated yet.

## Test plan

- [ ] `npm run test:php` — new `aiProviderRegistry.php` suite covers register/unregister, validation, active-provider resolution + filter, dispatch helpers, JS-safe shape, and per-provider key resolution. Existing `aiSearchExtensibility.php` + `aiToolsRegistry.php` still pass.
- [ ] `npm run test:js` — 436 vitest tests pass locally.
- [ ] `npm run lint` + `tsc --noEmit` — clean.
- [ ] `npm run build` — both bundles rebuild without warnings.
- [ ] **Manual**: open OS Settings → AI as the default user; confirm picker still shows OpenAI, key field labelled "OpenAI API key", links to https://platform.openai.com/api-keys.
- [ ] **Manual**: AI search end-to-end with the existing OpenAI key — slash commands, server tools, follow-up summarisation, structured search answer all behave as before.
- [ ] **Manual**: register a stub second provider in a throwaway plugin (`add_action('wp_desktop_ai_register_providers', …)`); confirm dropdown shows both, switching providers preserves keys, and `wp_desktop_ai_active_provider` filter routes a single request.
- [ ] **Manual**: post-save / comment-save analysis jobs still run (they go through `wpdm_ai_provider_structured_request` now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-18-a66cee371e2f4d4d00028dd20051cca66972f5e2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->