### PR TITLE
Fix release tooling for DESKTOP_MODE_VERSION rename + widen CI polling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
           tag="${tag#v}"
           pkg=$(node -p "require('./package.json').version")
           header=$(grep -oP '^\s*\*\s*Version:\s*\K\S+' desktop-mode.php)
-          constant=$(grep -oP "WPDM_VERSION',\s*'\K[^']+" desktop-mode.php)
+          constant=$(grep -oP "DESKTOP_MODE_VERSION',\s*'\K[^']+" desktop-mode.php)
           if ! [[ "$tag" == "$pkg" && "$tag" == "$header" && "$tag" == "$constant" ]]; then
-            echo "::error::Version mismatch — tag '$tag' vs package.json=$pkg header=$header WPDM_VERSION=$constant"
+            echo "::error::Version mismatch — tag '$tag' vs package.json=$pkg header=$header DESKTOP_MODE_VERSION=$constant"
             exit 1
           fi
 

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -19,7 +19,7 @@ npm version "$new" --no-git-tag-version --allow-same-version > /dev/null
 
 # Perl — portable inline edit; BSD and GNU sed differ on the `-i` form.
 perl -i -pe "s/^(\s*\*\s*Version:\s*)\S+/\${1}${new}/" desktop-mode.php
-perl -i -pe "s/(WPDM_VERSION',\s*')[^']+/\${1}${new}/" desktop-mode.php
+perl -i -pe "s/(DESKTOP_MODE_VERSION',\s*')[^']+/\${1}${new}/" desktop-mode.php
 
 cat <<EOF
 Bumped to $new. Next:

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -57,16 +57,16 @@ fi
 sha=$(git rev-parse HEAD)
 echo "Waiting for CI on ${sha}..."
 
-# CI may take a couple of seconds to register the run after the push.
+# CI may take up to a minute to register the run after the push.
 run_id=""
-for _ in 1 2 3 4 5; do
+for _ in $(seq 1 20); do
 	run_id=$(gh run list --branch trunk --workflow ci.yml --commit "$sha" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
 	[[ -n "$run_id" ]] && break
 	sleep 3
 done
 
 if [[ -z "$run_id" ]]; then
-	echo "error: no CI run found for $sha after 15s" >&2
+	echo "error: no CI run found for $sha after 60s" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

- `bin/bump-version.sh` and `.github/workflows/release.yml` were still referencing the old `WPDM_VERSION` constant name. The constant was renamed to `DESKTOP_MODE_VERSION` in 0bd2e8e but these two release-tooling spots were missed.
  - Symptom: `chore: bump to X.Y.Z` commits silently leave the constant at the previous version (perl regex matches nothing). The workflow's `Verify tag matches plugin version` step then greps an empty string, fails the comparison against the tag, and the release stops before publishing.
- Widen the CI-run polling window in `bin/release.sh` from 15s to 60s. Just hit a case where the run registered ~16s after push and the script gave up.

## Test plan

- [ ] Cut a real release after merge (current in-flight v0.5.2 is blocked by this — see note below).
- [ ] Confirm `bin/bump-version.sh X.Y.Z` updates all three locations: `package.json`, plugin header `Version:`, and `DESKTOP_MODE_VERSION` constant.
- [ ] Confirm release workflow's verify step prints `DESKTOP_MODE_VERSION=...` (not `WPDM_VERSION=`) on mismatch.

## Note on in-flight v0.5.2

Trunk currently has a `chore: bump to 0.5.2` commit where the plugin header was bumped but the constant was left at `0.5.1` (the original cause of this bug surfacing). Once this PR merges, the constant on trunk needs a follow-up bump to `0.5.2` before re-running `./bin/release.sh 0.5.2`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-22-8e90c645b8a8eb21dddf26734687953ed4bac7d9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->