### PR TITLE
Resume-mode bump check: inspect all version locations, not just package.json

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -41,17 +41,27 @@ if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; the
 	exit 1
 fi
 
-# Resume-friendly: skip bump+commit+push if HEAD is already at the target
-# version (the sync check above guarantees HEAD == origin/trunk).
-current=$(node -p "require('./package.json').version")
-if [[ "$current" == "$new" ]]; then
-	echo "package.json already at $new — skipping bump, resuming at CI wait."
+# Resume-friendly: skip bump+commit+push only if ALL version locations
+# already match the target. Checking just package.json is not enough —
+# a previous mid-flow failure (or a past bug in bump-version.sh) may
+# have left some files out of sync, and a naive resume would silently
+# skip the catch-up.
+pkg=$(node -p "require('./package.json').version")
+header=$(grep -oP '^\s*\*\s*Version:\s*\K\S+' desktop-mode.php)
+constant=$(grep -oP "DESKTOP_MODE_VERSION',\s*'\K[^']+" desktop-mode.php)
+
+if [[ "$pkg" == "$new" && "$header" == "$new" && "$constant" == "$new" ]]; then
+	echo "All version locations already at $new — skipping bump, resuming at CI wait."
 else
 	./bin/bump-version.sh "$new"
-	git commit -am "chore: bump to $new"
-	# Skip the interactive pre-push trunk prompt — the preflight checks above
-	# already verify this is an intentional release push.
-	git push --no-verify origin trunk
+	if git diff --quiet; then
+		echo "bump-version.sh produced no changes — versions already in sync."
+	else
+		git commit -am "chore: bump to $new"
+		# Skip the interactive pre-push trunk prompt — the preflight checks above
+		# already verify this is an intentional release push.
+		git push --no-verify origin trunk
+	fi
 fi
 
 sha=$(git rev-parse HEAD)


### PR DESCRIPTION
## Summary

`bin/release.sh`'s resume-friendly bump check only looked at `package.json` to decide whether to skip the bump. If a prior mid-flow failure (or a bug in `bin/bump-version.sh`, like the `WPDM_VERSION` rename oversight fixed in #22) left other files out of sync, the script would silently skip the bump and proceed to tag a version whose constant still pointed at the previous release. The release workflow's verify step would then fail.

This change makes the resume check inspect all three locations — `package.json`, plugin header `Version:`, and `DESKTOP_MODE_VERSION` — and only skip the bump when all three match. If any are out of sync, `bin/bump-version.sh` is re-run to catch up, and a normal bump commit/push follows.

## Test plan

- [ ] Fresh release path still works: from a clean trunk where all versions are at the previous release, `./bin/release.sh X.Y.Z` still produces a single `chore: bump to X.Y.Z` commit.
- [ ] Resume after CI failure (everything already at target): script prints "All version locations already at X.Y.Z — skipping bump" and proceeds to CI wait.
- [ ] Resume with stale constant: with `package.json` and header at target but constant lagging, script re-runs `bump-version.sh`, commits the catch-up diff, and pushes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-23-4227af64c601b2570d0f86e43a47468907bdcc71.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->