### PR TITLE
release.sh: include git tag -d / push --delete hint in tag-exists errors

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -33,11 +33,15 @@ fi
 
 # Refuse to clobber an existing release.
 if git rev-parse "$tag" >/dev/null 2>&1; then
-	echo "error: tag $tag already exists locally. Delete it or choose a different version." >&2
+	echo "error: tag $tag already exists locally." >&2
+	echo "  delete it with:  git tag -d $tag" >&2
+	echo "  or choose a different version." >&2
 	exit 1
 fi
 if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-	echo "error: tag $tag already exists on origin. Choose a different version." >&2
+	echo "error: tag $tag already exists on origin." >&2
+	echo "  delete it with:  git push --delete origin $tag" >&2
+	echo "  or choose a different version." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

When `bin/release.sh` aborts because a tag already exists, the error said "Delete it or choose a different version." without showing the actual deletion command. Anyone hitting this for the first time has to look up the right git incantation. Now both error variants include a copy-pasteable command:

```
error: tag v0.5.2 already exists locally.
  delete it with:  git tag -d v0.5.2
  or choose a different version.
```

```
error: tag v0.5.2 already exists on origin.
  delete it with:  git push --delete origin v0.5.2
  or choose a different version.
```

## Test plan

- [ ] Trigger each branch by pre-creating a local tag, then by pre-creating a remote-only tag, and confirm the right command shows up in each message.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-24-0bdb304c2864bd5491d59a59f97e5b5d2c99be5d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->