### PR TITLE
release.sh: replace grep -oP with awk for BSD/macOS portability

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -50,9 +50,10 @@ fi
 # a previous mid-flow failure (or a past bug in bump-version.sh) may
 # have left some files out of sync, and a naive resume would silently
 # skip the catch-up.
+# awk (instead of `grep -oP`) for BSD/macOS portability — `-P` is GNU-only.
 pkg=$(node -p "require('./package.json').version")
-header=$(grep -oP '^\s*\*\s*Version:\s*\K\S+' desktop-mode.php)
-constant=$(grep -oP "DESKTOP_MODE_VERSION',\s*'\K[^']+" desktop-mode.php)
+header=$(awk '/^[[:space:]]*\*[[:space:]]*Version:/ { print $3; exit }' desktop-mode.php)
+constant=$(awk -F"'" '/DESKTOP_MODE_VERSION/ { print $4; exit }' desktop-mode.php)
 
 if [[ "$pkg" == "$new" && "$header" == "$new" && "$constant" == "$new" ]]; then
 	echo "All version locations already at $new — skipping bump, resuming at CI wait."


### PR DESCRIPTION
## Summary

`bin/release.sh` used `grep -oP` (Perl regex), a GNU-grep-only flag, in the resume-friendly version check from #23. macOS ships BSD grep, so running `./bin/release.sh X.Y.Z` locally aborted with:

```
grep: invalid option -- P
```

The release workflow on Ubuntu was unaffected (GNU grep there), so this only bit local invocations.

Switched to awk, which works the same on BSD and GNU:

- Header line (` * Version:           X.Y.Z`) → field 3 with default whitespace splitting.
- `DESKTOP_MODE_VERSION` constant line → field 4 when splitting on the apostrophe.

Verified locally that both extract the expected values from a real `desktop-mode.php`.

## Test plan

- [ ] `./bin/release.sh X.Y.Z` runs to the bump check on macOS without grep errors.
- [ ] When all three locations match the target version, the script prints "All version locations already at X.Y.Z" and proceeds to CI wait.
- [ ] When the constant lags behind, the script runs `bin/bump-version.sh` and creates a catch-up commit.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-25-e3f37af5ec9468574d5ed842accedd96b6c54a4b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->