### PR TITLE
Distinguish Author URI from Plugin URI

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -7,7 +7,7 @@
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            Daniel López Sánchez
- * Author URI:        https://github.com/WordPress/desktop-mode
+ * Author URI:        https://github.com/allterraindeveloper
  * License:           GPLv2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       desktop-mode


### PR DESCRIPTION
## Summary

The wp.org Plugin Review team rejects submissions where `Plugin URI` and `Author URI` in the plugin file header point at the same URL — they're meant to identify different resources (the project page vs. the author's page). Both were set to the GitHub repo.

`Author URI` now points at Daniel's GitHub user page (https://github.com/allterraindeveloper); `Plugin URI` keeps pointing at the repository.

## Test plan

- [ ] `npm run build && npm run package` produces a fresh `desktop-mode.zip`.
- [ ] Re-submit through https://wordpress.org/plugins/developers/add/ and confirm the "URIs are the same" rejection no longer fires.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-27-a63f86bec13f78bbb98f97e5c0fbe2f6aa19dcc3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->