### PR TITLE
Keep readme.txt Stable tag in sync with plugin Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,9 @@ jobs:
           pkg=$(node -p "require('./package.json').version")
           header=$(grep -oP '^\s*\*\s*Version:\s*\K\S+' desktop-mode.php)
           constant=$(grep -oP "DESKTOP_MODE_VERSION',\s*'\K[^']+" desktop-mode.php)
-          if ! [[ "$tag" == "$pkg" && "$tag" == "$header" && "$tag" == "$constant" ]]; then
-            echo "::error::Version mismatch — tag '$tag' vs package.json=$pkg header=$header DESKTOP_MODE_VERSION=$constant"
+          stable=$(grep -oP '^Stable tag:\s*\K\S+' readme.txt)
+          if ! [[ "$tag" == "$pkg" && "$tag" == "$header" && "$tag" == "$constant" && "$tag" == "$stable" ]]; then
+            echo "::error::Version mismatch — tag '$tag' vs package.json=$pkg header=$header DESKTOP_MODE_VERSION=$constant readme.txt Stable tag=$stable"
             exit 1
           fi
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,13 +33,14 @@ Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps 
 
 ## Version locations
 
-Three places, kept in sync by `bin/bump-version.sh`:
+Four places, kept in sync by `bin/bump-version.sh`:
 
 - `package.json` → `"version"` (and `package-lock.json` via `npm version`)
 - `desktop-mode.php` → plugin header `Version:`
 - `desktop-mode.php` → `DESKTOP_MODE_VERSION` constant
+- `readme.txt` → `Stable tag:` (wp.org rejects submissions when this drifts from the plugin header `Version:`)
 
-The `release` job re-reads all three at tag time and fails with a clear error if any doesn't match the tag. This catches "forgot to bump one".
+The `release` job re-reads all four at tag time and fails with a clear error if any doesn't match the tag. This catches "forgot to bump one".
 
 ## Versioning scheme
 

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -20,6 +20,9 @@ npm version "$new" --no-git-tag-version --allow-same-version > /dev/null
 # Perl — portable inline edit; BSD and GNU sed differ on the `-i` form.
 perl -i -pe "s/^(\s*\*\s*Version:\s*)\S+/\${1}${new}/" desktop-mode.php
 perl -i -pe "s/(DESKTOP_MODE_VERSION',\s*')[^']+/\${1}${new}/" desktop-mode.php
+# wp.org rejects submissions whose readme.txt Stable tag doesn't match
+# the plugin header Version, so keep them in lockstep.
+perl -i -pe "s/^(Stable tag:\s*)\S+/\${1}${new}/" readme.txt
 
 cat <<EOF
 Bumped to $new. Next:

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -54,8 +54,9 @@ fi
 pkg=$(node -p "require('./package.json').version")
 header=$(awk '/^[[:space:]]*\*[[:space:]]*Version:/ { print $3; exit }' desktop-mode.php)
 constant=$(awk -F"'" '/DESKTOP_MODE_VERSION/ { print $4; exit }' desktop-mode.php)
+stable=$(awk '/^Stable tag:/ { print $3; exit }' readme.txt)
 
-if [[ "$pkg" == "$new" && "$header" == "$new" && "$constant" == "$new" ]]; then
+if [[ "$pkg" == "$new" && "$header" == "$new" && "$constant" == "$new" && "$stable" == "$new" ]]; then
 	echo "All version locations already at $new — skipping bump, resuming at CI wait."
 else
 	./bin/bump-version.sh "$new"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: desktop, admin, ui, productivity, ai
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 0.5.1
+Stable tag: 0.5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary

wp.org's automated submission scanner rejected the v0.5.3 upload with `stable_tag_mismatch: 0.5.1 != 0.5.3`. `readme.txt`'s `Stable tag` is what wp.org uses to decide which SVN tag to serve, so a mismatch with the plugin-header `Version:` is treated as a hard error.

The four version locations are now:

- \`package.json\` → \`version\`
- \`desktop-mode.php\` → plugin header \`Version:\`
- \`desktop-mode.php\` → \`DESKTOP_MODE_VERSION\` constant
- \`readme.txt\` → \`Stable tag:\` *(this PR adds the fourth)*

Changes:

- \`readme.txt\`: bump Stable tag to \`0.5.3\` so the rejected submission can be re-uploaded.
- \`bin/bump-version.sh\`: rewrite \`Stable tag:\` alongside the other three locations on every bump.
- \`bin/release.sh\`: include \`Stable tag\` in the resume-detection check so a partial-release resume catches up \`readme.txt\` too.
- \`.github/workflows/release.yml\`: preflight verifies all four locations match the tag (was three).
- \`RELEASE.md\`: doc reflects the four-location reality.

## Test plan

- [ ] On merge, run \`bin/release.sh 0.5.4\` (or whatever the next bump is) and confirm \`readme.txt\` ends up at \`Stable tag: 0.5.4\` automatically.
- [ ] Re-upload \`desktop-mode.zip\` to wp.org and confirm the \`stable_tag_mismatch\` error is gone.
- [ ] Inspect a release-workflow run on a tag to confirm the preflight reports all four version locations on mismatch.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-28-2677b599d884f2b4d0fc1beba35925876dc00dd2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->