### PR TITLE
Surface progress during the long CI wait in release.sh

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -71,13 +71,17 @@ else
 fi
 
 sha=$(git rev-parse HEAD)
-echo "Waiting for CI on ${sha}..."
+echo "Waiting for CI to register a run on ${sha} (polling for up to 5 min)..."
 
 # CI may take a few minutes to register the run after the push.
 run_id=""
-for _ in $(seq 1 100); do
+for i in $(seq 1 100); do
 	run_id=$(gh run list --branch trunk --workflow ci.yml --commit "$sha" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
 	[[ -n "$run_id" ]] && break
+	# Heartbeat every 30 s so the script doesn't look frozen while CI registers.
+	if (( i % 10 == 0 )); then
+		printf '  …%ds elapsed, still polling\n' $((i * 3))
+	fi
 	sleep 3
 done
 
@@ -86,7 +90,14 @@ if [[ -z "$run_id" ]]; then
 	exit 1
 fi
 
+run_url=$(gh run view "$run_id" --json url -q '.url' 2>/dev/null || true)
+echo "CI run ${run_id} registered — watching until it finishes (typically 3-5 min)."
+[[ -n "$run_url" ]] && echo "  ${run_url}"
+echo "  (gh run watch is silent until each job completes; this is normal.)"
+
 gh run watch "$run_id" --exit-status
+
+echo "CI passed — tagging ${tag} and pushing..."
 
 git tag "$tag"
 git push origin "$tag"


### PR DESCRIPTION
## Summary

Daniel reported `bin/release.sh` appeared stuck at "Waiting for CI on \<sha>..." during a release. CI was running fine — the script was just silent for the whole 3-5 minute wait. Two changes:

1. The polling loop that waits for the CI run to register now prints a heartbeat every 30 s.
2. After the run is found, the script prints the run id + URL and a one-line note that \`gh run watch\` is intentionally quiet between step completions. After the watch returns, "CI passed — tagging X and pushing..." makes the next phase visible.

No behavioural change — just chatter so the operator can tell the script is alive.

## Test plan

- [ ] Run \`bin/release.sh\` against a test bump and confirm the heartbeat prints at 30 s, 60 s, 90 s while the run is being registered.
- [ ] Confirm the new "CI run X registered — watching..." line appears once the run id is found.
- [ ] Confirm "CI passed — tagging X and pushing..." appears after \`gh run watch\` returns.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-29-a5e77e3caf8f147745f06ecb916fae80f41d6e7a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->