### PR TITLE
release.sh: check gh auth status up front

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -13,6 +13,10 @@ new="$1"
 tag="v$new"
 
 command -v gh >/dev/null || { echo "error: 'gh' CLI required (for CI polling)" >&2; exit 1; }
+if ! gh auth status >/dev/null 2>&1; then
+	echo "error: gh CLI is not authenticated. Run:  gh auth login" >&2
+	exit 1
+fi
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$branch" != "trunk" ]]; then


### PR DESCRIPTION
## Summary

`bin/release.sh` already verified `gh` was installed but did not check whether the user was authenticated. An unauthenticated `gh` only surfaces deep into the script (CI-run polling silently returns nothing → "no CI run found"), which is misleading — the run probably exists, the CLI just can't see it.

Adding a `gh auth status` probe right after the install check, with a clear next-step:

```
error: gh CLI is not authenticated. Run:  gh auth login
```

## Test plan

- [ ] `gh auth logout` then run `./bin/release.sh X.Y.Z` — should fail immediately with the auth error before touching the working tree.
- [ ] With `gh` authenticated, the script proceeds past the check as before.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-30-c9d21dedfd58acc57ef20a86ec5b7d9b71b71aad.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->