### PR TITLE
Add `<wpd-table>` — data-driven, DX-first table component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,9 @@ docs/
     ├── connect-to-window.md     UPDATE/READ WHEN: registerTitleBarButton, Window.setHighlight,
     │                            wp.desktop.connect, or wp.desktop.iframe.* contract changes;
     │                            wp-desktop-bridge-* postMessage protocol changes.
+    ├── data-table.md            UPDATE/READ WHEN: <wpd-table> contract changes — column descriptor
+    │                            shape, filter kinds, sticky-columns/header behavior, sub-table API,
+    │                            or wpd-table-{filter-change,row-click,expand-change} event details.
     ├── register-icon.md        UPDATE/READ WHEN: wp_register_desktop_icon() contract changes.
     ├── register-wallpaper.md   UPDATE/READ WHEN: WallpaperDef or wp_register_desktop_wallpaper() changes.
     └── window-lifecycle.md     UPDATE/READ WHEN: window state machine / lifecycle hooks change.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -27,6 +27,7 @@ defined( 'ABSPATH' ) || exit;
 - [Connect to a window — title-bar button + iframe pub/sub](./connect-to-window.md)
 - [Native window with tabs (auto-swap pattern)](./native-window-with-tabs.md)
 - [Layout primitives (body → panel → row → col)](./layout-primitives.md)
+- [Render a data table — filters, sticky columns, sub-tables](./data-table.md)
 - [Native windows — overview + render-callback contract](./native-windows.md)
 - [Open a file in the Code editor (deep-link from any window)](./code-editor-open.md)
 - [Cross-window devtools — instrumentation primitives](./devtools-instrumentation.md)

--- a/docs/examples/data-table.md
+++ b/docs/examples/data-table.md
@@ -1,0 +1,362 @@
+# Example: render a data table
+
+`<wpd-table>` is the data-grid primitive: assign a `columns` descriptor and a `data` array and you get a styled table with optional per-column filters, click-to-sort, multi-row selection, sticky columns, sticky header, custom cell renderers, a loading skeleton, and a slottable empty state.
+
+> Status: **Experimental** since 0.18.0. The component shape is stable; the named events / filter kinds may grow.
+
+## Minimum viable table
+
+```html
+<wpd-table id="users"></wpd-table>
+```
+
+```js
+const table = document.getElementById( 'users' );
+table.columns = [
+    { key: 'name',  label: 'Name' },
+    { key: 'email', label: 'Email' },
+    { key: 'role',  label: 'Role' },
+];
+table.data = [
+    { name: 'Alice', email: 'alice@a.com', role: 'admin' },
+    { name: 'Bob',   email: 'bob@b.com',   role: 'editor' },
+];
+```
+
+That's the entire happy path. Everything below is opt-in.
+
+## TypeScript usage
+
+`WpdTable` is generic over the row type — narrow it for type-safe `render` and `sortValue` callbacks:
+
+```ts
+import type { WpdTable, WpdTableColumn } from 'wp-desktop/ui';
+
+interface User extends Record< string, unknown > {
+    name: string;
+    email: string;
+    role: 'admin' | 'editor';
+    logins: number;
+}
+
+const columns: WpdTableColumn< User >[] = [
+    { key: 'name',   label: 'Name',   filter: 'text', sortable: true },
+    { key: 'email',  label: 'Email',  filter: 'text' },
+    { key: 'role',   label: 'Role',   filter: 'select' },
+    { key: 'logins', label: 'Logins', align: 'end', sortable: true },
+];
+
+const table = document.querySelector< WpdTable< User > >( '#users' )!;
+table.columns = columns;
+table.data    = users;
+table.getRowId = ( row ) => row.email; // stable id for selection
+```
+
+## Per-column filters
+
+Set `column.filter` to put a filter input under the header. Two kinds:
+
+- `'text'` (or `true`) — substring, case-insensitive.
+- `'select'` — dropdown built from the unique column values.
+
+```js
+table.columns = [
+    { key: 'name',  label: 'Name',  filter: 'text' },
+    { key: 'email', label: 'Email', filter: 'text' },
+    { key: 'role',  label: 'Role',  filter: 'select' },
+];
+```
+
+Filter inputs are persistent across re-paints, so typing never loses focus or caret position. Read or pre-seed the filter map via `table.filters`, listen for changes, and clear them with the built-in method:
+
+```js
+table.filters = { role: 'admin' };          // pre-seed
+table.addEventListener( 'wpd-table-filter-change', ( e ) => {
+    console.log( e.detail.filters );
+} );
+table.clearFilters();                       // drop everything (emits filter-change)
+```
+
+## Click-to-sort
+
+Set `column.sortable = true` and the header cycles **asc → desc → unsorted** on click. Numbers compare numerically; everything else falls back to a locale-aware string compare. Provide `column.sortValue` for shaped sorts:
+
+```js
+table.columns = [
+    { key: 'name',     label: 'Name',     sortable: true },
+    { key: 'created',  label: 'Created',  sortable: true,
+      sortValue: ( row ) => Date.parse( row.created ) },
+    { key: 'priority', label: 'Priority', sortable: true,
+      sortValue: ( row ) => ({ low: 0, med: 1, high: 2 }[ row.priority ]) },
+];
+```
+
+Read or set the active sort programmatically:
+
+```js
+table.sort = { key: 'name', direction: 'asc' };
+table.addEventListener( 'wpd-table-sort-change', ( e ) => {
+    persist( e.detail.sort );               // null when cleared
+} );
+table.clearSort();
+```
+
+If you don't want the built-in sort but want to react to header clicks (e.g. server-side sort), declare `sortable: true` and listen for `wpd-table-sort-change` — your handler can re-fetch and reassign `table.data` while letting the indicator UI handle itself.
+
+## Selection
+
+Set `selectable="single"` or `selectable="multi"` and a checkbox column is auto-prepended. Multi mode adds a select-all checkbox in the header; single mode enforces at-most-one selected.
+
+```html
+<wpd-table id="users" selectable="multi"></wpd-table>
+```
+
+```js
+table.getRowId = ( row ) => row.email;      // stable id (default: row index)
+table.addEventListener( 'wpd-table-selection-change', ( e ) => {
+    console.log( e.detail.selection ); // ids[]
+    console.log( e.detail.rows );      // resolved row objects
+} );
+
+// Programmatic API
+table.select( 'alice@a.com' );
+table.deselect( 'alice@a.com' );
+table.selectAll();                          // multi only
+table.clearSelection();
+table.selection = new Set( savedIds );      // bulk replace
+```
+
+**Why `getRowId` matters:** when the user reloads `data` from the server, selections survive the refresh because they're keyed by stable id, not array index. Fall back to the default (index) only when rows have no natural identifier.
+
+## Sticky columns and sticky header
+
+```html
+<wpd-table sticky-columns="2" sticky-header striped hover></wpd-table>
+```
+
+- `sticky-columns="N"` pins the first `N` columns. Widths are measured after layout and re-measured automatically — every paint runs three measurement passes (synchronous, microtask, animation frame) and a `ResizeObserver` watches the inner scroll element + the host so window resizes, hidden→visible transitions, sibling reflow, font loads, and scrollbar appearance all trigger a recompute. You don't have to call anything; offsets stay correct. Variable-width columns work, including RTL via `inset-inline-start`.
+
+  If a column-1+ sticky cell ever ends up at `inset-inline-start: 0px` while the host is visible, the component logs a one-time `console.warn` with the measured widths and a pointer to `recomputeLayout()`. That should never fire in practice — it's an "if you see this, you've found the bug" tripwire.
+- `sticky-header` keeps the header (plus the filter row, if any) pinned.
+- Per-column override: `column.sticky = true` opts in even outside the band, `column.sticky = false` opts out within it.
+
+For sticky to engage the table needs a scrolling container. Set `--wpd-table-max-height` (or wrap in any scrolling parent):
+
+```css
+wpd-table { --wpd-table-max-height: 400px; }
+```
+
+If you set `sticky-header` on a table with no scroll container, the component logs a one-time `console.warn` after enough data has loaded to need scrolling — saves the "why isn't it sticking?" debug session.
+
+### Worked example: sticky-columns counting
+
+The auto-injected expander (subTable) and select (selectable) columns count as **leading** sticky columns. Plan `sticky-columns` accordingly:
+
+| Setup | `sticky-columns="N"` keeps pinned |
+|---|---|
+| 4 data columns, no sub-table, no selection | `2` → cols 0, 1 |
+| 4 data columns + `subTable` (expander prepended) | `2` → expander, col 0 |
+| 4 data columns + `selectable="multi"` | `2` → checkbox, col 0 |
+| 4 data columns + `selectable="multi"` + `subTable` | `3` → checkbox, expander, col 0 |
+
+Rule of thumb: count from the visible left edge after all auto-prepended columns. If you want the *checkbox + expander + name + email* pinned in the busy case, that's `sticky-columns="4"`.
+
+## Sub-tables (expandable rows)
+
+Set `subTable( row, index )` and an expander column is auto-prepended. Return any of:
+
+- `null` / `undefined` — no children for this row (no caret).
+- `{ columns, data, subTable? }` — a nested `<wpd-table>` is rendered. Sub-tables can themselves declare a `subTable` for unlimited nesting.
+- A `Node` or `html\`\`` template — fully custom expanded content.
+
+```js
+table.subTable = ( order ) => order.items?.length
+    ? {
+        columns: [
+            { key: 'sku',  label: 'SKU' },
+            { key: 'qty',  label: 'Qty', align: 'end' },
+            { key: 'name', label: 'Item' },
+        ],
+        data: order.items,
+    }
+    : null;
+```
+
+Programmatic control of expansion:
+
+```js
+table.expand( 3 );
+table.collapse( 3 );
+table.expandAll();        // every row that has children
+table.collapseAll();
+table.isExpanded( 3 );    // boolean
+
+// Read or replace the full open set — useful for restoring state.
+const open = Array.from( table.expanded );
+localStorage.setItem( 'orders.open', JSON.stringify( open ) );
+table.expanded = JSON.parse( localStorage.getItem( 'orders.open' ) || '[]' );
+```
+
+## Loading state
+
+```html
+<wpd-table loading loading-rows="5"></wpd-table>
+```
+
+While `loading` is set, the body paints shimmering skeleton rows. Headers, filters, and sort indicators remain live. Toggle the attribute when the fetch resolves:
+
+```js
+table.toggleAttribute( 'loading', true );
+const data = await fetch( '/api/users' ).then( ( r ) => r.json() );
+table.data = data;
+table.toggleAttribute( 'loading', false );
+```
+
+`prefers-reduced-motion: reduce` disables the shimmer animation automatically.
+
+## Empty state with a CTA
+
+The `empty` attribute is the text fallback. For richer empty states (button, illustration, multi-line copy) project light-DOM into the `empty` slot:
+
+```html
+<wpd-table id="orders">
+    <div slot="empty">
+        <p>No orders yet.</p>
+        <wpd-button @click=${ openWizard }>Create your first order</wpd-button>
+    </div>
+</wpd-table>
+```
+
+The slotted content shows whenever `data.length === 0` OR every row got filtered out. If you want different empty states for "no data" vs "no matches," check `table.filters` from your handler and swap the slotted children accordingly.
+
+## Custom cell renderers
+
+`column.render( value, row, index )` returns a string, an `HTMLElement`, or an `html\`\`` template:
+
+```js
+import { html } from 'wp-desktop/ui';
+
+table.columns = [
+    { key: 'avatar', label: '', width: '32px',
+      render: ( v ) => html`<img src=${ v } width="24" height="24" />` },
+    { key: 'name',   label: 'Name' },
+    { key: 'status', label: 'Status',
+      render: ( v ) => html`<wpd-badge tone=${ v === 'active' ? 'success' : 'warning' }>${ v }</wpd-badge>` },
+];
+```
+
+**Best practice — pick one return shape per column.** Mixing `string` and `Node` and `html\`\`` across columns is legal but harder to read at a glance. For a "show a string with one inline tweak" cell, prefer `html\`...\``; for "build a complex node tree imperatively," prefer `document.createElement`. If you find yourself returning all three from the same `render` based on a runtime check, that's usually a smell that the column wants splitting.
+
+## Row clicks
+
+```js
+table.addEventListener( 'wpd-table-row-click', ( e ) => {
+    const { row, index, originalEvent } = e.detail;
+    openOrder( row.id );
+} );
+```
+
+Clicks on filter inputs, the expander button, and selection checkboxes do **not** fire `wpd-table-row-click` — they're marked `data-noclick`. Mark any of your own interactive cell content the same way to opt out:
+
+```js
+render: ( v, row ) => html`<button data-noclick @click=${ () => del( row.id ) }>×</button>`
+```
+
+## Editable cells
+
+Same pattern as custom renderers — return an input. Two real gotchas:
+
+1. **Mark the control `data-noclick`** so clicks on it don't fire `wpd-table-row-click`.
+2. **Avoid full-table repaints on every keystroke** — they tear down and rebuild the input, losing focus/caret. Either commit on blur/Enter (mutate `row.field` in place; reassign `table.data` only on save), or keep edits in a side buffer (`Map<rowId, edits>`) that the renderer reads from.
+
+```js
+{ key: 'name', label: 'Name',
+  render: ( v, row ) => {
+      const i = document.createElement( 'input' );
+      i.value = String( v );
+      i.dataset.noclick = '';
+      i.addEventListener( 'change', () => { row.name = i.value; } );
+      return i;
+  } }
+```
+
+If editing is the primary use case, request a first-class `column.editor` API — the persistent-input plumbing is already in place for filters and would generalize naturally.
+
+## Programmatic API reference
+
+| Method | What it does |
+|---|---|
+| `expand(i)` / `collapse(i)` | Open/close one row. |
+| `expandAll()` / `collapseAll()` | Open every row that has children / close everything. |
+| `isExpanded(i)` | Boolean. |
+| `expanded` | Get/set the full open-set (for state persistence). |
+| `clearFilters()` | Drop every filter; emits `filter-change`. |
+| `clearSort()` | Drop the active sort; emits `sort-change`. |
+| `select(id)` / `deselect(id)` | Mutate the selection by id. |
+| `selectAll()` / `clearSelection()` | Bulk operations (multi-mode). |
+| `selection` | Get/set the selection set. |
+| `selectedRows` | Resolved row objects matching `selection`. |
+| `getRowId` | Stable-id extractor (default: index). |
+| `sort` | Get/set the active `{ key, direction }` (or `null`). |
+| `filters` | Get/set the filter map. |
+| `scrollToRow(i)` | Bring the (filtered) row at index `i` into view. |
+| `recomputeLayout()` | Force a sticky-offset / header-height recompute. Public escape hatch — usually not needed. |
+
+## Attributes reference
+
+| Attribute | Type | What it does |
+|---|---|---|
+| `sticky-columns` | integer | Pin the first N columns. Auto-injected expander/select columns count toward N. |
+| `sticky-header` | boolean | Pin the header (and filter row). Needs a scrolling container. |
+| `striped` | boolean | Zebra rows. |
+| `hover` | boolean | Row hover highlight. |
+| `compact` | boolean | Tighter padding + smaller font. |
+| `bordered` | boolean | Vertical cell borders. |
+| `selectable` | `"single" \| "multi"` | Prepends a checkbox column. |
+| `loading` | boolean | Shimmering skeleton rows in place of body. |
+| `loading-rows` | integer | Skeleton-row count when loading. Default 5. |
+| `empty` | string | Text fallback when there are no rows. Slot `empty` for rich content. |
+
+## CSS custom properties
+
+| Property | Default |
+|---|---|
+| `--wpd-table-bg` | `var( --wpd-surface, #fff )` |
+| `--wpd-table-border` | `var( --wpd-border, rgba(0,0,0,0.08) )` |
+| `--wpd-table-header-bg` | `var( --wpd-surface-elevated, #f6f7f7 )` |
+| `--wpd-table-row-hover` | `rgba(0,0,0,0.04)` |
+| `--wpd-table-stripe` | `rgba(0,0,0,0.02)` |
+| `--wpd-table-cell-padding` | `8px 12px` |
+| `--wpd-table-font-size` | `13px` |
+| `--wpd-table-max-height` | `none` |
+| `--wpd-table-skeleton-color` | `rgba(0,0,0,0.06)` |
+| `--wpd-table-skeleton-highlight` | `rgba(0,0,0,0.14)` |
+
+## Events
+
+| Name | `event.detail` | Fires when |
+|---|---|---|
+| `wpd-table-filter-change` | `{ filters }` | A filter input changed (or `clearFilters()` ran). |
+| `wpd-table-sort-change` | `{ sort }` (or `{ sort: null }`) | A sortable header was clicked or `sort` was set. |
+| `wpd-table-selection-change` | `{ selection: id[], rows: T[] }` | Selection mutated. |
+| `wpd-table-row-click` | `{ row, index, originalEvent }` | A body row was clicked (excluding `data-noclick`). |
+| `wpd-table-expand-change` | `{ row, index, expanded }` | A row's sub-table was toggled. |
+
+## Slots
+
+| Name | Default content | When it shows |
+|---|---|---|
+| `empty` | The `empty` attribute text | `data` is empty OR all rows got filtered out. |
+
+## Common pitfalls
+
+- **`sticky-header` with no scroll container.** If `--wpd-table-max-height` is unset and no ancestor scrolls, sticky positioning is inert. The component warns once via `console.warn` after the data has filled the viewport.
+- **`sticky-columns` counting auto columns.** The expander and select columns are *prepended*; `sticky-columns="2"` pins them, not your first two data columns. Pad accordingly (see "Worked example" above).
+- **Mixing `column.align: 'end'` with custom `render`.** Alignment applies to the cell, but if your renderer returns a `display: block`-ish element it may not pick up text-align. Either set `text-align: end` on the rendered element or wrap in a `<span>`.
+- **Editable cells losing focus.** Reassigning `table.data` on every keystroke triggers a full body repaint — the new `<input>` is a different element, so focus is lost. Commit on blur/Enter, or hold edits in a side buffer until save.
+- **Selection going stale on data refresh.** Without `getRowId`, ids are array indices — selections drift if rows reorder. Set `getRowId = ( row ) => row.id` whenever rows have a natural identifier.
+
+## See also
+
+- [Layout primitives](./layout-primitives.md) — wrap the table in `<wpd-body>` / `<wpd-panel>` for the standard window shape.
+- [JavaScript reference](../javascript-reference.md) — every wpd-* component.

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -43,6 +43,16 @@ export type { WpdBadgeTone } from './wpd-badge/wpd-badge';
 export { WpdLog } from './wpd-log/wpd-log';
 export type { WpdLogRowRenderer } from './wpd-log/wpd-log';
 export { WpdSteps, WpdStep } from './wpd-steps/wpd-steps';
+export { WpdTable } from './wpd-table/wpd-table';
+export type {
+	WpdTableColumn,
+	WpdTableFilters,
+	WpdTableGetRowId,
+	WpdTableRowId,
+	WpdTableSort,
+	WpdTableSubTableFn,
+	WpdTableSubTableResult,
+} from './wpd-table/wpd-table';
 
 // List of tags registered by this barrel. `doAction(
 // COMPONENTS_REGISTERED, { tags } )` fires once from
@@ -88,4 +98,5 @@ export const WPD_COMPONENT_TAGS = [
 	'wpd-log',
 	'wpd-steps',
 	'wpd-step',
+	'wpd-table',
 ] as const;

--- a/src/ui/components/wpd-table/wpd-table.styles.ts
+++ b/src/ui/components/wpd-table/wpd-table.styles.ts
@@ -1,0 +1,369 @@
+import { css } from '../../core';
+
+/**
+ * Styles for `<wpd-table>`.
+ *
+ * ## The sticky-cell rule
+ *
+ * Two invariants every cell rule has to respect:
+ *
+ *   1. Every cell carries an **opaque base background-color**. Sticky
+ *      cells need this so non-sticky siblings sliding under them on
+ *      horizontal scroll don't bleed through. We never paint over
+ *      this with a translucent value (the classic
+ *      tr:hover td { background: rgba(0,0,0,0.04) } mistake leaves
+ *      sticky cells effectively transparent).
+ *
+ *   2. State overlays (stripe / hover / sub-table inset) layer on top
+ *      via background-image: linear-gradient(rgba, rgba), which
+ *      stacks above background-color instead of replacing it.
+ *      Result: solid base + translucent overlay = opaque cell, even
+ *      when stripe + hover combine on a sticky row.
+ *
+ *   3. Selection state uses color-mix to *compute* an opaque tint
+ *      from the theme color and the base — same effect, different
+ *      mechanism (cleaner for the "deeper hover on selected" case).
+ *
+ * ## Z-index ladder
+ *
+ * Wide gaps (10 / 20 / 30 / 40) so there's no ambiguity in stacking
+ * across browser table-cell quirks:
+ *
+ *   - 10  body sticky cells (above non-sticky body cells)
+ *   - 20  sticky-header non-sticky thead cells (above body sticky)
+ *   - 30  sticky-column thead cells (above sticky-header non-sticky)
+ *   - 40  the corner cell (sticky-header AND sticky-column)
+ */
+export const styles = css`
+	:host {
+		display: block;
+		/* --wpd-surface is the host theme's surface color; #fff is
+		   the hard fallback so a missing theme variable can never
+		   produce a transparent table. Consumers override
+		   --wpd-table-bg directly to opt out of the surface chain. */
+		--wpd-table-bg: var( --wpd-surface, #fff );
+		--wpd-table-border: var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+		--wpd-table-header-bg: var( --wpd-surface-elevated, #f6f7f7 );
+		/* Translucent overlays — these are LAYERED, never replaced
+		   into a base background. Keep them rgba so they compose
+		   across stripe + hover combinations. */
+		--wpd-table-row-hover: rgba( 0, 0, 0, 0.04 );
+		--wpd-table-stripe: rgba( 0, 0, 0, 0.03 );
+		--wpd-table-cell-padding: 8px 12px;
+		--wpd-table-font-size: 13px;
+		--wpd-table-max-height: none;
+		font-size: var( --wpd-table-font-size );
+		color: inherit;
+	}
+	:host( [ hidden ] ) {
+		display: none;
+	}
+
+	.scroll {
+		position: relative;
+		overflow: auto;
+		max-height: var( --wpd-table-max-height );
+		border: 1px solid var( --wpd-table-border );
+		border-radius: 4px;
+		background: var( --wpd-table-bg );
+	}
+
+	table {
+		width: 100%;
+		border-collapse: separate;
+		border-spacing: 0;
+		background: var( --wpd-table-bg );
+	}
+
+	/* ---------------------------------------------------------------
+	 * Cell base — opaque background-color always. State overlays are
+	 * applied as background-images below.
+	 * ------------------------------------------------------------- */
+	thead th {
+		text-align: start;
+		font-weight: 600;
+		background-color: var( --wpd-table-header-bg );
+		padding: var( --wpd-table-cell-padding );
+		border-bottom: 1px solid var( --wpd-table-border );
+		white-space: nowrap;
+	}
+
+	tbody td {
+		padding: var( --wpd-table-cell-padding );
+		border-bottom: 1px solid var( --wpd-table-border );
+		background-color: var( --wpd-table-bg );
+		vertical-align: middle;
+	}
+
+	tbody tr:last-child td {
+		border-bottom: 0;
+	}
+
+	/* Stripe + hover are LAYERED via background-image so they never
+	   replace the opaque base color. The linear-gradient(rgba, rgba)
+	   trick paints a flat translucent fill on top of background-color. */
+	:host( [ striped ] ) tbody tr:nth-child( odd ) td {
+		background-image: linear-gradient(
+			var( --wpd-table-stripe ),
+			var( --wpd-table-stripe )
+		);
+	}
+
+	:host( [ hover ] ) tbody tr:hover td {
+		background-image: linear-gradient(
+			var( --wpd-table-row-hover ),
+			var( --wpd-table-row-hover )
+		);
+	}
+
+	/* Hover + stripe — both overlays stack. background-image accepts a
+	   comma-separated list, painted top-to-bottom. */
+	:host( [ hover ] [ striped ] )
+		tbody
+		tr:nth-child( odd ):hover
+		td {
+		background-image:
+			linear-gradient(
+				var( --wpd-table-row-hover ),
+				var( --wpd-table-row-hover )
+			),
+			linear-gradient(
+				var( --wpd-table-stripe ),
+				var( --wpd-table-stripe )
+			);
+	}
+
+	:host( [ compact ] ) {
+		--wpd-table-cell-padding: 4px 8px;
+		--wpd-table-font-size: 12px;
+	}
+
+	:host( [ bordered ] ) thead th,
+	:host( [ bordered ] ) tbody td {
+		border-inline-end: 1px solid var( --wpd-table-border );
+	}
+	:host( [ bordered ] ) thead th:last-child,
+	:host( [ bordered ] ) tbody td:last-child {
+		border-inline-end: 0;
+	}
+
+	/* ---------------------------------------------------------------
+	 * Sticky positioning. Inline inset-inline-start is written by
+	 * JS after layout (variable column widths can't be expressed in
+	 * pure CSS). The class names drive position + z-index.
+	 *
+	 * Z-index ladder — see file header comment.
+	 * ------------------------------------------------------------- */
+	th.is-sticky,
+	td.is-sticky {
+		position: sticky;
+		z-index: 10;
+	}
+	/* Body sticky cells inherit their opaque base + overlays from the
+	   tbody td rules above. Re-asserting background-color here is
+	   redundant but defensive: if a consumer ships a CSS rule that
+	   targets .is-sticky and accidentally clears background-color,
+	   this acts as a backstop. */
+	tbody td.is-sticky {
+		background-color: var( --wpd-table-bg );
+	}
+	thead th.is-sticky {
+		background-color: var( --wpd-table-header-bg );
+		z-index: 30;
+	}
+
+	/* Sticky header (whole thead pins to the scroll container's top). */
+	:host( [ sticky-header ] ) thead th {
+		position: sticky;
+		top: 0;
+		z-index: 20;
+	}
+	:host( [ sticky-header ] ) thead tr.filter-row th {
+		top: var( --wpd-table-header-height, 33px );
+		z-index: 20;
+	}
+	/* The intersection — sticky-column header cell when sticky-header
+	   is also on. This is the corner that has to win every stacking
+	   contest. */
+	:host( [ sticky-header ] ) thead th.is-sticky {
+		z-index: 40;
+	}
+	:host( [ sticky-header ] ) thead tr.filter-row th.is-sticky {
+		z-index: 40;
+	}
+
+	/* The last sticky column gets a soft shadow so the scrolling
+	   content visibly slides underneath it. */
+	th.is-sticky-edge,
+	td.is-sticky-edge {
+		box-shadow: 4px 0 6px -4px rgba( 0, 0, 0, 0.18 );
+	}
+	[ dir='rtl' ] th.is-sticky-edge,
+	[ dir='rtl' ] td.is-sticky-edge {
+		box-shadow: -4px 0 6px -4px rgba( 0, 0, 0, 0.18 );
+	}
+
+	/* Per-column alignment + width. */
+	.align-center {
+		text-align: center;
+	}
+	.align-end {
+		text-align: end;
+	}
+
+	/* Filter row inputs. */
+	.filter-row th {
+		padding: 4px 8px;
+		background-color: var( --wpd-table-header-bg );
+		border-bottom: 1px solid var( --wpd-table-border );
+		font-weight: 400;
+	}
+	.filter-input,
+	.filter-select {
+		width: 100%;
+		min-width: 60px;
+		box-sizing: border-box;
+		padding: 4px 6px;
+		font: inherit;
+		color: inherit;
+		background-color: var( --wpd-table-bg );
+		border: 1px solid var( --wpd-table-border );
+		border-radius: 3px;
+	}
+	.filter-input:focus,
+	.filter-select:focus {
+		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+		outline-offset: -1px;
+	}
+
+	/* Expander column. */
+	.expander {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		border-radius: 3px;
+		font-size: 11px;
+		line-height: 1;
+	}
+	.expander:hover {
+		background: rgba( 0, 0, 0, 0.06 );
+	}
+	.col-expander {
+		width: 32px;
+		text-align: center;
+	}
+
+	/* Sub-table row — opaque base so the sticky cells in the parent
+	   row above don't bleed visually into the inset stripe. */
+	tr.subtable td {
+		padding: 0;
+		background-color: var( --wpd-table-bg );
+		background-image: linear-gradient(
+			var( --wpd-table-stripe ),
+			var( --wpd-table-stripe )
+		);
+		border-bottom: 1px solid var( --wpd-table-border );
+	}
+	tr.subtable .subtable-inner {
+		padding: 8px 12px 8px 32px;
+	}
+
+	/* Empty placeholder. */
+	tr.empty td {
+		padding: 24px;
+		text-align: center;
+		color: var( --wpd-text-muted, rgba( 0, 0, 0, 0.55 ) );
+		font-style: italic;
+	}
+
+	/* Sortable headers. Hover overlay layered, not replacing. */
+	thead th.is-sortable {
+		cursor: pointer;
+		user-select: none;
+	}
+	thead th.is-sortable:hover {
+		background-image: linear-gradient(
+			var( --wpd-table-row-hover ),
+			var( --wpd-table-row-hover )
+		);
+	}
+	thead th.is-sortable:focus-visible {
+		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+		outline-offset: -2px;
+	}
+	.sort-indicator {
+		font-size: 10px;
+		color: var( --wpd-text-muted, rgba( 0, 0, 0, 0.55 ) );
+		margin-inline-start: 2px;
+	}
+	thead th.sort-asc .sort-indicator,
+	thead th.sort-desc .sort-indicator {
+		color: var( --wp-admin-theme-color, #2271b1 );
+	}
+
+	/* Selection. color-mix produces an opaque tint from theme +
+	   base, so sticky selected cells stay opaque without needing a
+	   layered overlay. */
+	.col-select {
+		width: 36px;
+		text-align: center;
+	}
+	.select-all-checkbox,
+	.select-row-checkbox {
+		cursor: pointer;
+		margin: 0;
+	}
+	tbody tr.is-selected td {
+		background-color: color-mix(
+			in srgb,
+			var( --wp-admin-theme-color, #2271b1 ) 10%,
+			var( --wpd-table-bg )
+		);
+		background-image: none;
+	}
+	tbody tr.is-selected:hover td {
+		background-color: color-mix(
+			in srgb,
+			var( --wp-admin-theme-color, #2271b1 ) 16%,
+			var( --wpd-table-bg )
+		);
+	}
+
+	/* Loading skeleton. */
+	tbody tr.skeleton td {
+		padding: var( --wpd-table-cell-padding );
+	}
+	.skeleton-bar {
+		display: block;
+		height: 12px;
+		border-radius: 3px;
+		background: linear-gradient(
+			90deg,
+			var( --wpd-table-skeleton-color, rgba( 0, 0, 0, 0.06 ) ) 0%,
+			var( --wpd-table-skeleton-highlight, rgba( 0, 0, 0, 0.14 ) ) 50%,
+			var( --wpd-table-skeleton-color, rgba( 0, 0, 0, 0.06 ) ) 100%
+		);
+		background-size: 200% 100%;
+		animation: wpd-table-skeleton-pulse 1.4s ease-in-out infinite;
+	}
+	@keyframes wpd-table-skeleton-pulse {
+		0% {
+			background-position: 200% 50%;
+		}
+		100% {
+			background-position: -200% 50%;
+		}
+	}
+	@media ( prefers-reduced-motion: reduce ) {
+		.skeleton-bar {
+			animation: none;
+		}
+	}
+`;

--- a/src/ui/components/wpd-table/wpd-table.test.ts
+++ b/src/ui/components/wpd-table/wpd-table.test.ts
@@ -534,6 +534,41 @@ describe( '<wpd-table>', () => {
 		}
 	} );
 
+	test( 'toggling the `loading` attribute live re-paints the body without a data reassignment', async () => {
+		// Regression: attribute changes on a wpd-table used to bypass
+		// the imperative paint pipeline because the base
+		// Component.attributeChangedCallback called _scheduleRender
+		// directly instead of routing through requestUpdate. Result:
+		// flipping `loading` re-rendered the templated skeleton but
+		// never rebuilt the body, so the skeleton rows never appeared.
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name' } ];
+		table.data = sampleData;
+		await tick();
+		expect(
+			table.shadowRoot!.querySelectorAll( 'tbody tr.skeleton' ).length,
+		).toBe( 0 );
+
+		table.setAttribute( 'loading', '' );
+		await tick();
+		expect(
+			table.shadowRoot!.querySelectorAll( 'tbody tr.skeleton' ).length,
+		).toBeGreaterThan( 0 );
+
+		table.removeAttribute( 'loading' );
+		await tick();
+		expect(
+			table.shadowRoot!.querySelectorAll( 'tbody tr.skeleton' ).length,
+		).toBe( 0 );
+		expect(
+			table.shadowRoot!.querySelectorAll(
+				'tbody tr:not(.skeleton):not(.empty)',
+			).length,
+		).toBe( sampleData.length );
+	} );
+
 	test( 'recomputeLayout() is callable as a public escape hatch', async () => {
 		host.innerHTML = `<wpd-table sticky-columns="1"></wpd-table>`;
 		await tick();

--- a/src/ui/components/wpd-table/wpd-table.test.ts
+++ b/src/ui/components/wpd-table/wpd-table.test.ts
@@ -1,0 +1,567 @@
+/**
+ * `<wpd-table>` — smoke tests covering the data-rendering happy path,
+ * filter wiring, sticky-column class application, sub-table expansion,
+ * and the row-click event guard around no-click descendants.
+ *
+ * Pixel layout (sticky `left` offsets, sticky-header positioning) is
+ * not asserted — jsdom doesn't lay things out, so `offsetWidth` is
+ * always 0. The class application is what we cover; the offsets are
+ * a runtime-only concern verified manually.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import './wpd-table';
+// eslint-disable-next-line no-duplicate-imports
+import type { WpdTable, WpdTableColumn } from './wpd-table';
+
+const tick = (): Promise< void > =>
+	new Promise( ( r ) => queueMicrotask( () => queueMicrotask( () => r() ) ) );
+
+interface User extends Record< string, unknown > {
+	name: string;
+	email: string;
+	role: string;
+	logins: number;
+}
+
+const sampleColumns: WpdTableColumn< User >[] = [
+	{ key: 'name', label: 'Name', filter: 'text', sticky: true },
+	{ key: 'email', label: 'Email', filter: 'text' },
+	{ key: 'role', label: 'Role', filter: 'select' },
+	{ key: 'logins', label: 'Logins', align: 'end' },
+];
+
+const sampleData: User[] = [
+	{ name: 'Alice', email: 'alice@a.com', role: 'admin', logins: 10 },
+	{ name: 'Bob', email: 'bob@b.com', role: 'editor', logins: 3 },
+	{ name: 'Carol', email: 'carol@c.com', role: 'admin', logins: 7 },
+];
+
+describe( '<wpd-table>', () => {
+	let host: HTMLElement;
+	beforeEach( () => {
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+	} );
+	afterEach( () => host.remove() );
+
+	test( 'renders the empty placeholder when there is no data', async () => {
+		host.innerHTML = `<wpd-table empty="Nothing here"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' )!;
+		const empty = table.shadowRoot!.querySelector( 'tr.empty td' )!;
+		expect( empty.textContent?.trim() ).toBe( 'Nothing here' );
+	} );
+
+	test( 'renders one tbody row per data entry, in order', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.data = sampleData;
+		await tick();
+
+		const rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty)',
+		);
+		expect( rows.length ).toBe( 3 );
+		expect( rows[ 0 ].textContent ).toContain( 'Alice' );
+		expect( rows[ 2 ].textContent ).toContain( 'Carol' );
+	} );
+
+	test( 'header labels fall back to the column key', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'foo' }, { key: 'bar', label: 'Baz' } ];
+		table.data = [ { foo: 1, bar: 2 } as unknown as User ];
+		await tick();
+		const ths = table.shadowRoot!.querySelectorAll( 'thead tr:first-child th' );
+		expect( ths[ 0 ].textContent?.trim() ).toBe( 'foo' );
+		expect( ths[ 1 ].textContent?.trim() ).toBe( 'Baz' );
+	} );
+
+	test( 'filter row appears only when at least one column declares a filter', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'a' }, { key: 'b' } ];
+		table.data = [];
+		await tick();
+		expect( table.shadowRoot!.querySelector( 'tr.filter-row' ) ).toBeNull();
+
+		table.columns = [ { key: 'a', filter: 'text' }, { key: 'b' } ];
+		await tick();
+		expect( table.shadowRoot!.querySelector( 'tr.filter-row' ) ).not.toBeNull();
+	} );
+
+	test( 'text filter narrows the rendered rows and emits filter-change', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.data = sampleData;
+		await tick();
+
+		const events: Array< { filters: Record< string, string > } > = [];
+		table.addEventListener( 'wpd-table-filter-change', ( e: Event ) => {
+			events.push( ( e as CustomEvent ).detail );
+		} );
+
+		const input = table.shadowRoot!.querySelector(
+			'.filter-input',
+		) as HTMLInputElement;
+		input.value = 'ali';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		await tick();
+
+		const rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty)',
+		);
+		expect( rows.length ).toBe( 1 );
+		expect( rows[ 0 ].textContent ).toContain( 'Alice' );
+		expect( events[ events.length - 1 ].filters.name ).toBe( 'ali' );
+	} );
+
+	test( 'select filter populates from unique column values + matches exactly', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.data = sampleData;
+		await tick();
+
+		const select = table.shadowRoot!.querySelector(
+			'.filter-select',
+		) as HTMLSelectElement;
+		// "All" + 2 unique roles.
+		expect( select.options.length ).toBe( 3 );
+
+		select.value = 'admin';
+		select.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await tick();
+
+		const rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty)',
+		);
+		expect( rows.length ).toBe( 2 );
+	} );
+
+	test( 'sticky-columns adds is-sticky to header + body cells in the band', async () => {
+		host.innerHTML = `<wpd-table sticky-columns="2"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [
+			{ key: 'a', label: 'A' },
+			{ key: 'b', label: 'B' },
+			{ key: 'c', label: 'C' },
+		];
+		table.data = [ { a: 1, b: 2, c: 3 } as unknown as User ];
+		await tick();
+
+		const ths = table.shadowRoot!.querySelectorAll( 'thead tr:first-child th' );
+		expect( ths[ 0 ].classList.contains( 'is-sticky' ) ).toBe( true );
+		expect( ths[ 1 ].classList.contains( 'is-sticky' ) ).toBe( true );
+		expect( ths[ 2 ].classList.contains( 'is-sticky' ) ).toBe( false );
+		// The second sticky column gets the edge marker (drop-shadow).
+		expect( ths[ 1 ].classList.contains( 'is-sticky-edge' ) ).toBe( true );
+
+		const tds = table.shadowRoot!.querySelectorAll( 'tbody tr td' );
+		expect( tds[ 0 ].classList.contains( 'is-sticky' ) ).toBe( true );
+		expect( tds[ 1 ].classList.contains( 'is-sticky' ) ).toBe( true );
+		expect( tds[ 2 ].classList.contains( 'is-sticky' ) ).toBe( false );
+	} );
+
+	test( 'subTable: prepends an expander column and toggling reveals a nested wpd-table', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name', label: 'Name' } ];
+		table.data = [ { name: 'Alice' } as unknown as User ];
+		table.subTable = ( row ) => ( {
+			columns: [ { key: 'k', label: 'K' } ],
+			data: [ { k: `child of ${ row.name }` } ],
+		} );
+		await tick();
+
+		// Expander column is column 0 — first th has class `col-expander`.
+		const firstTh = table.shadowRoot!.querySelector(
+			'thead tr:first-child th',
+		) as HTMLElement;
+		expect( firstTh.classList.contains( 'col-expander' ) ).toBe( true );
+
+		// No sub-table rendered until expanded.
+		expect( table.shadowRoot!.querySelector( 'tr.subtable' ) ).toBeNull();
+
+		const events: Array< { row: User; index: number; expanded: boolean } > = [];
+		table.addEventListener( 'wpd-table-expand-change', ( e: Event ) => {
+			events.push( ( e as CustomEvent ).detail );
+		} );
+
+		const expander = table.shadowRoot!.querySelector(
+			'tbody .expander',
+		) as HTMLButtonElement;
+		expander.click();
+		await tick();
+
+		expect( events.length ).toBe( 1 );
+		expect( events[ 0 ].expanded ).toBe( true );
+		const sub = table.shadowRoot!.querySelector( 'tr.subtable' );
+		expect( sub ).not.toBeNull();
+		expect( sub!.querySelector( 'wpd-table' ) ).not.toBeNull();
+	} );
+
+	test( 'row-click event fires for body cells but not for clicks inside data-noclick descendants', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name', label: 'Name', filter: 'text' } ];
+		table.data = [ { name: 'Alice' } as unknown as User ];
+		await tick();
+
+		const events: Array< { row: User; index: number } > = [];
+		table.addEventListener( 'wpd-table-row-click', ( e: Event ) => {
+			events.push( ( e as CustomEvent ).detail );
+		} );
+
+		const cell = table.shadowRoot!.querySelector(
+			'tbody tr td',
+		) as HTMLTableCellElement;
+		cell.click();
+		expect( events.length ).toBe( 1 );
+		expect( events[ 0 ].index ).toBe( 0 );
+
+		// Filter inputs are marked data-noclick — they must NOT fire row-click.
+		const input = table.shadowRoot!.querySelector(
+			'.filter-input',
+		) as HTMLInputElement;
+		input.click();
+		expect( events.length ).toBe( 1 );
+	} );
+
+	test( 'sortable: clicking a header cycles asc → desc → null and emits sort-change', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [
+			{ key: 'name', label: 'Name', sortable: true },
+			{ key: 'logins', label: 'Logins', sortable: true },
+		];
+		table.data = [
+			{ name: 'Carol', email: '', role: '', logins: 7 },
+			{ name: 'Alice', email: '', role: '', logins: 10 },
+			{ name: 'Bob', email: '', role: '', logins: 3 },
+		];
+		await tick();
+
+		const events: Array< { sort: { key: string; direction: string } | null } > = [];
+		table.addEventListener( 'wpd-table-sort-change', ( e: Event ) => {
+			events.push( ( e as CustomEvent ).detail );
+		} );
+
+		const nameTh = table.shadowRoot!.querySelector(
+			'thead tr:first-child th[data-key="name"]',
+		) as HTMLElement;
+
+		nameTh.click(); // asc
+		await tick();
+		expect( events[ events.length - 1 ].sort ).toEqual( { key: 'name', direction: 'asc' } );
+		let rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty)',
+		);
+		expect( rows[ 0 ].textContent ).toContain( 'Alice' );
+		expect( rows[ 2 ].textContent ).toContain( 'Carol' );
+
+		nameTh.click(); // desc
+		await tick();
+		expect( events[ events.length - 1 ].sort ).toEqual( { key: 'name', direction: 'desc' } );
+		rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty)',
+		);
+		expect( rows[ 0 ].textContent ).toContain( 'Carol' );
+
+		nameTh.click(); // null
+		await tick();
+		expect( events[ events.length - 1 ].sort ).toBeNull();
+	} );
+
+	test( 'sortable: numeric columns sort numerically, not lexically', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'logins', label: 'Logins', sortable: true } ];
+		table.data = [
+			{ name: '', email: '', role: '', logins: 100 },
+			{ name: '', email: '', role: '', logins: 9 },
+			{ name: '', email: '', role: '', logins: 21 },
+		];
+		await tick();
+		table.sort = { key: 'logins', direction: 'asc' };
+		await tick();
+		const rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty) td',
+		);
+		expect( rows[ 0 ].textContent?.trim() ).toBe( '9' );
+		expect( rows[ 1 ].textContent?.trim() ).toBe( '21' );
+		expect( rows[ 2 ].textContent?.trim() ).toBe( '100' );
+	} );
+
+	test( 'sortable: custom sortValue takes precedence', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		// Sort by string length instead of alphabetical.
+		table.columns = [
+			{
+				key: 'name',
+				label: 'Name',
+				sortable: true,
+				sortValue: ( row ) => ( row.name as string ).length,
+			},
+		];
+		table.data = [
+			{ name: 'Carolyn', email: '', role: '', logins: 0 },
+			{ name: 'Al', email: '', role: '', logins: 0 },
+			{ name: 'Bobby', email: '', role: '', logins: 0 },
+		];
+		table.sort = { key: 'name', direction: 'asc' };
+		await tick();
+		const rows = table.shadowRoot!.querySelectorAll(
+			'tbody tr:not(.subtable):not(.empty)',
+		);
+		expect( rows[ 0 ].textContent ).toContain( 'Al' );
+		expect( rows[ 1 ].textContent ).toContain( 'Bobby' );
+		expect( rows[ 2 ].textContent ).toContain( 'Carolyn' );
+	} );
+
+	test( 'selectable=multi: prepends a checkbox column with a select-all in the header', async () => {
+		host.innerHTML = `<wpd-table selectable="multi"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name', label: 'Name' } ];
+		table.data = sampleData;
+		await tick();
+
+		const headerCheckbox = table.shadowRoot!.querySelector(
+			'thead .select-all-checkbox',
+		) as HTMLInputElement;
+		expect( headerCheckbox ).not.toBeNull();
+
+		const events: Array< { selection: number[]; rows: User[] } > = [];
+		table.addEventListener(
+			'wpd-table-selection-change',
+			( e: Event ) => events.push( ( e as CustomEvent ).detail ),
+		);
+
+		// Click first row checkbox.
+		const rowCb = table.shadowRoot!.querySelector(
+			'tbody .select-row-checkbox',
+		) as HTMLInputElement;
+		rowCb.checked = true;
+		rowCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await tick();
+		expect( events.length ).toBe( 1 );
+		expect( events[ 0 ].selection ).toEqual( [ 0 ] );
+		expect( table.selectedRows ).toEqual( [ sampleData[ 0 ] ] );
+
+		// Select-all from the header.
+		headerCheckbox.checked = true;
+		headerCheckbox.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await tick();
+		expect( table.selectedRows.length ).toBe( 3 );
+	} );
+
+	test( 'selectable=single: enforces at-most-one selected', async () => {
+		host.innerHTML = `<wpd-table selectable="single"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name', label: 'Name' } ];
+		table.data = sampleData;
+		await tick();
+
+		// No header select-all in single mode.
+		expect(
+			table.shadowRoot!.querySelector( 'thead .select-all-checkbox' ),
+		).toBeNull();
+
+		table.select( 0 );
+		table.select( 1 );
+		expect( Array.from( table.selection ) ).toEqual( [ 1 ] );
+	} );
+
+	test( 'getRowId: stable ids survive a data refresh', async () => {
+		host.innerHTML = `<wpd-table selectable="multi"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name', label: 'Name' } ];
+		table.getRowId = ( row ) => row.email;
+		table.data = sampleData;
+		table.select( 'alice@a.com' );
+		await tick();
+
+		// Reload data with the same email — selection must persist.
+		table.data = [ ...sampleData ].reverse();
+		await tick();
+		expect( table.selectedRows.map( ( r ) => r.email ) ).toEqual( [
+			'alice@a.com',
+		] );
+	} );
+
+	test( 'expand / collapse / expandAll / collapseAll programmatic API', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name' } ];
+		table.data = sampleData;
+		table.subTable = ( row ) => ( {
+			columns: [ { key: 'k' } ],
+			data: [ { k: row.name } ],
+		} );
+		await tick();
+
+		expect( table.isExpanded( 0 ) ).toBe( false );
+		table.expand( 1 );
+		await tick();
+		expect( table.isExpanded( 1 ) ).toBe( true );
+		expect(
+			table.shadowRoot!.querySelectorAll( 'tr.subtable' ).length,
+		).toBe( 1 );
+
+		table.expandAll();
+		await tick();
+		expect(
+			table.shadowRoot!.querySelectorAll( 'tr.subtable' ).length,
+		).toBe( 3 );
+
+		table.collapseAll();
+		await tick();
+		expect(
+			table.shadowRoot!.querySelectorAll( 'tr.subtable' ).length,
+		).toBe( 0 );
+	} );
+
+	test( 'clearFilters() drops every active filter and emits filter-change', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.data = sampleData;
+		table.filters = { name: 'a', email: 'a' };
+		await tick();
+		const events: Array< { filters: Record< string, string > } > = [];
+		table.addEventListener( 'wpd-table-filter-change', ( e: Event ) => {
+			events.push( ( e as CustomEvent ).detail );
+		} );
+		table.clearFilters();
+		await tick();
+		expect( events[ events.length - 1 ].filters ).toEqual( {} );
+		expect( table.filters ).toEqual( {} );
+	} );
+
+	test( 'loading: paints skeleton rows in place of body content', async () => {
+		host.innerHTML = `<wpd-table loading loading-rows="3"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'name' }, { key: 'email' } ];
+		table.data = sampleData;
+		await tick();
+		const skeletonRows = table.shadowRoot!.querySelectorAll(
+			'tbody tr.skeleton',
+		);
+		expect( skeletonRows.length ).toBe( 3 );
+		// Real data rows must NOT appear while loading.
+		expect(
+			table.shadowRoot!.querySelectorAll(
+				'tbody tr:not(.skeleton):not(.empty)',
+			).length,
+		).toBe( 0 );
+	} );
+
+	test( 'empty slot: projects light-DOM children when there is no data', async () => {
+		host.innerHTML = `<wpd-table>
+			<button slot="empty" id="cta">Add new</button>
+		</wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' )!;
+		// The slot itself is in shadow DOM; its assignedNodes() returns
+		// the projected light-DOM children.
+		const slot = table.shadowRoot!.querySelector(
+			'tr.empty slot',
+		) as HTMLSlotElement;
+		expect( slot.name ).toBe( 'empty' );
+		const assigned = slot.assignedNodes();
+		expect(
+			assigned.some(
+				( n ) =>
+					n instanceof Element && n.id === 'cta',
+			),
+		).toBe( true );
+	} );
+
+	test( 'observes the inner scroll element + host with ResizeObserver and disconnects on teardown', async () => {
+		// Stub a counting ResizeObserver so we can assert the lifecycle
+		// without depending on jsdom's (absent) layout engine. We
+		// observe two boxes: the inner `.scroll` (catches scrollbar-
+		// driven width changes that the host doesn't see) and the host
+		// itself (catches panel-driven reflows that the inner box
+		// doesn't see).
+		const observed: Element[] = [];
+		const disconnects: number[] = [];
+		const original = ( globalThis as unknown as { ResizeObserver?: unknown } ).ResizeObserver;
+		class FakeRO {
+			observe( el: Element ) {
+				observed.push( el );
+			}
+			disconnect() {
+				disconnects.push( 1 );
+			}
+			unobserve() { /* noop */ }
+		}
+		( globalThis as unknown as { ResizeObserver: unknown } ).ResizeObserver = FakeRO;
+		try {
+			host.innerHTML = `<wpd-table sticky-columns="1"></wpd-table>`;
+			await tick();
+			const table = host.querySelector( 'wpd-table' )!;
+			// The inner .scroll element is what catches the most-common
+			// stale-offset cause (vertical scrollbar appearing). The
+			// host catches panel-driven reflow.
+			const scroll = table.shadowRoot!.querySelector( '.scroll' );
+			expect( observed ).toContain( scroll );
+			expect( observed ).toContain( table );
+			table.remove();
+			expect( disconnects.length ).toBe( 1 );
+		} finally {
+			( globalThis as unknown as { ResizeObserver?: unknown } ).ResizeObserver = original;
+		}
+	} );
+
+	test( 'recomputeLayout() is callable as a public escape hatch', async () => {
+		host.innerHTML = `<wpd-table sticky-columns="1"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [ { key: 'a' }, { key: 'b' } ];
+		table.data = [ { a: 1, b: 2 } as unknown as User ];
+		await tick();
+		// Should not throw, and should not change anything observable
+		// in jsdom (no layout). It's the existence + idempotency that
+		// matter — pixel correctness is verified manually.
+		expect( () => table.recomputeLayout() ).not.toThrow();
+		expect( () => table.recomputeLayout() ).not.toThrow();
+	} );
+
+	test( 'custom render() is invoked per cell and its return is mounted', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = [
+			{
+				key: 'name',
+				label: 'Name',
+				render: ( v ) => `>> ${ String( v ) }`,
+			},
+		];
+		table.data = [ { name: 'Alice' } as unknown as User ];
+		await tick();
+		const cell = table.shadowRoot!.querySelector( 'tbody tr td' );
+		expect( cell?.textContent?.trim() ).toBe( '>> Alice' );
+	} );
+} );

--- a/src/ui/components/wpd-table/wpd-table.ts
+++ b/src/ui/components/wpd-table/wpd-table.ts
@@ -632,7 +632,40 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 		this._measureHeaderHeight();
 		this._scheduleStickyOffsets();
 		this._maybeWarnStickyHeader();
+		this._maybeWarnLoadingDesync( tbody );
 		this._ensureResizeObserver();
+	}
+
+	private _loadingDesyncWarned = false;
+	/**
+	 * Diagnostic for the "I set `loading` but the skeleton never
+	 * appeared" footgun. If we get here with the attribute on but no
+	 * `.skeleton` rows in `tbody`, something between attribute set and
+	 * paint went off the rails — historically this happened when the
+	 * base `Component.attributeChangedCallback` called `_scheduleRender`
+	 * directly, bypassing our `requestUpdate` override. Same pattern as
+	 * the sticky-columns 0px tripwire: should never fire, but if it
+	 * does, names the bug instead of leaving the dev guessing.
+	 */
+	private _maybeWarnLoadingDesync( tbody: Element ): void {
+		if ( this._loadingDesyncWarned ) {
+			return;
+		}
+		if ( ! this.hasAttribute( 'loading' ) ) {
+			return;
+		}
+		if ( tbody.querySelector( 'tr.skeleton' ) ) {
+			return;
+		}
+		this._loadingDesyncWarned = true;
+		// eslint-disable-next-line no-console
+		console.warn(
+			'[wpd-table] `loading` attribute is set but no skeleton rows ' +
+				'rendered. Either attributeChangedCallback didn\'t route through ' +
+				'requestUpdate (framework regression), or `loading` was set after ' +
+				'the most recent paint and no follow-up trigger ran. Toggling ' +
+				'`data` will force a paint as a workaround.',
+		);
 	}
 
 	/**

--- a/src/ui/components/wpd-table/wpd-table.ts
+++ b/src/ui/components/wpd-table/wpd-table.ts
@@ -1,0 +1,1567 @@
+/**
+ * `<wpd-table>` — data-driven, DX-first table.
+ *
+ * The pitch is "give it data + columns, get a nice table". Everything
+ * else is opt-in via attributes or a single column descriptor:
+ *
+ * ```ts
+ * const table = document.querySelector< WpdTable< User > >( '#users' )!;
+ * table.columns = [
+ *     { key: 'name',   label: 'Name',   filter: 'text',   sortable: true, sticky: true },
+ *     { key: 'email',  label: 'Email',  filter: 'text',   sortable: true },
+ *     { key: 'role',   label: 'Role',   filter: 'select' },
+ *     { key: 'logins', label: 'Logins', align: 'end',     sortable: true },
+ * ];
+ * table.data = users;
+ * table.subTable = ( row ) => row.history?.length
+ *     ? { columns: historyCols, data: row.history }
+ *     : null;
+ * ```
+ *
+ * ## Features at a glance
+ *
+ *   - **Per-column filters.** `column.filter = 'text' | 'select'`
+ *     (or `true`, default text). Inputs persist across re-paints so
+ *     typing never loses focus.
+ *   - **Click-to-sort.** `column.sortable = true` makes the header
+ *     cycle asc → desc → unsorted. Provide `column.sortValue` for
+ *     custom sort keys (e.g. parse a date out of a string).
+ *   - **Multi-row selection.** `selectable="single"` or
+ *     `selectable="multi"` auto-prepends a checkbox column. Read /
+ *     write the chosen row ids through `selection`; supply
+ *     `getRowId( row, i )` for stable ids across data refreshes.
+ *   - **Sticky columns.** `sticky-columns="N"` pins the first N
+ *     columns. Widths are measured after layout, so variable-width
+ *     columns work — RTL via `inset-inline-start`.
+ *   - **Sticky header.** `sticky-header` pins the header (plus the
+ *     filter row, if any) to the top of the scroll container.
+ *   - **Sub-tables.** `subTable( row, index )` returns a
+ *     `{ columns, data }` or any `Node` / template. An expander
+ *     column is auto-prepended; sub-tables nest infinitely.
+ *   - **Custom cells.** `column.render( value, row, index )` returns
+ *     a string, `Node`, or `html\`\`` template.
+ *   - **Loading state.** `loading` paints shimmering skeleton rows.
+ *   - **Empty state.** `<slot name="empty">` lets the host project a
+ *     CTA; the `empty` attribute is the text fallback.
+ *
+ * ## Programmatic API surface
+ *
+ * Every interactive piece has a method-form so callers don't poke at
+ * the DOM:
+ *
+ *   - `expand(i)`, `collapse(i)`, `expandAll()`, `collapseAll()`,
+ *     `isExpanded(i)`, `expanded` (getter / setter for the full set).
+ *   - `clearFilters()`, `filters` (read or pre-seed).
+ *   - `sort` (read or set), `clearSort()`.
+ *   - `select(id)`, `deselect(id)`, `selectAll()`, `clearSelection()`,
+ *     `selection`, `selectedRows`, `getRowId`.
+ *   - `scrollToRow(i)`.
+ *
+ * ## Why imperative paint
+ *
+ * The `html\`\`` template renderer parses every nested template via
+ * `template.innerHTML`, which applies HTML's content-model rules — so
+ * a sub-template with `<tr>`/`<td>`/`<col>` gets hoisted out of its
+ * expected parent. We render an empty table skeleton via the template
+ * tag, then paint headers / rows / cells imperatively. Filter inputs
+ * are kept across paints so typing into one doesn't lose focus on
+ * every keystroke.
+ *
+ * ## Events
+ *
+ *   - `wpd-table-filter-change` — `{ filters }` on filter input change.
+ *   - `wpd-table-sort-change` — `{ sort }` (or `{ sort: null }`).
+ *   - `wpd-table-selection-change` — `{ selection, rows }`.
+ *   - `wpd-table-row-click` — `{ row, index, originalEvent }` (skips
+ *     clicks on `data-noclick` descendants).
+ *   - `wpd-table-expand-change` — `{ row, index, expanded }`.
+ *
+ * @since 0.18.0
+ */
+
+import { Component, defineComponent, html, render as renderTemplate, type TemplateResult } from '../../core';
+import { styles } from './wpd-table.styles';
+
+/**
+ * Per-column descriptor. The bare minimum is `{ key }`; everything
+ * else is optional. Generic over the row type so `render` and
+ * `sortValue` get strong types when consumers type the table.
+ */
+export interface WpdTableColumn< T = Record< string, unknown > > {
+	/** Property on the row to read. Also used as the column id. */
+	key: string;
+	/** Header text. Defaults to `key`. */
+	label?: string;
+	/**
+	 * Built-in filter. `true` and `'text'` give a substring match;
+	 * `'select'` builds a dropdown from the unique column values.
+	 */
+	filter?: boolean | 'text' | 'select';
+	/** Make the header click-to-sort (asc → desc → unsorted cycle). */
+	sortable?: boolean;
+	/**
+	 * Custom value extractor for sorts. Defaults to `row[key]`. Use
+	 * for shaped sorts — e.g. parsing a date from a display string,
+	 * or sorting by a computed score.
+	 */
+	sortValue?: ( row: T, value: unknown ) => unknown;
+	/** Pin this column when sticky-columns covers its index. */
+	sticky?: boolean;
+	/** CSS text-align — `'start' | 'center' | 'end'`. */
+	align?: 'start' | 'center' | 'end';
+	/** Fixed CSS width — passed straight to `<col style="width">`. */
+	width?: string;
+	/** Custom cell renderer. Return a string, Node, or `html\`\``. */
+	render?: ( value: unknown, row: T, index: number ) => string | Node | TemplateResult;
+}
+
+/**
+ * Sub-table descriptor — independent of the parent's row type so a
+ * sub-table can have a totally different shape than its container
+ * (the typical case: an Orders table with a per-order Items sub-table).
+ */
+export type WpdTableSubTableResult =
+	| null
+	| undefined
+	| Node
+	| TemplateResult
+	| {
+		columns: WpdTableColumn< Record< string, unknown > >[];
+		data: Record< string, unknown >[];
+		/** Optional — make the nested sub-table itself expandable. */
+		subTable?: WpdTableSubTableFn;
+	};
+
+export type WpdTableSubTableFn< T = Record< string, unknown > > = (
+	row: T,
+	index: number,
+) => WpdTableSubTableResult;
+
+/** Filter map — column key → input value. Empty string means no filter. */
+export type WpdTableFilters = Record< string, string >;
+
+/** Active sort. `null` is "no sort applied". */
+export type WpdTableSort =
+	| { key: string; direction: 'asc' | 'desc' }
+	| null;
+
+/** Stable id for a row — defaults to its index. Override via `getRowId`. */
+export type WpdTableRowId = string | number;
+
+export type WpdTableGetRowId< T = Record< string, unknown > > = (
+	row: T,
+	index: number,
+) => WpdTableRowId;
+
+const EXPANDER_KEY = '__wpd_expander__';
+const SELECT_KEY = '__wpd_select__';
+
+interface FilterInputCache {
+	/** The wrapper `<th>` cell — kept across paints. */
+	th: HTMLTableCellElement;
+	/** The filter `<input>` or `<select>`. */
+	control: HTMLInputElement | HTMLSelectElement;
+	/** Last set of options written into a select (sorted, joined). */
+	optionsKey: string;
+	/** Filter kind currently mounted — re-create if it changes. */
+	kind: 'text' | 'select' | 'none';
+}
+
+export class WpdTable< T extends Record< string, unknown > = Record< string, unknown > > extends Component {
+	static props = [
+		'stickyColumns',
+		'stickyHeader',
+		'striped',
+		'hover',
+		'compact',
+		'bordered',
+		'empty',
+		'loading',
+		'loadingRows',
+		'selectable',
+	] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Table',
+		summary:
+			'Data-driven table. Assign `columns` + `data` and you get a styled table with optional per-column filters, click-to-sort, multi-row selection, sticky columns/header, sub-tables, custom cell renderers, loading skeleton, and a slottable empty state.',
+		status: 'experimental',
+		since: '0.18.0',
+		props: [
+			{
+				name: 'sticky-columns',
+				type: 'integer',
+				description:
+					'Pin the first N columns to the inline-start edge. Widths are measured after layout, so variable-width columns work. The auto-injected expander (subTable) and select (selectable) columns count toward N.',
+			},
+			{
+				name: 'sticky-header',
+				type: 'boolean',
+				description:
+					'Pin the header (and filter row) to the top. Requires a scrolling parent or `--wpd-table-max-height` — the component warns once if it detects sticky-header on a non-scrolling container.',
+			},
+			{ name: 'striped', type: 'boolean', description: 'Zebra rows.' },
+			{ name: 'hover', type: 'boolean', description: 'Highlight rows on hover.' },
+			{ name: 'compact', type: 'boolean', description: 'Tighter padding + smaller font.' },
+			{ name: 'bordered', type: 'boolean', description: 'Vertical cell borders.' },
+			{
+				name: 'empty',
+				type: 'string',
+				description:
+					'Fallback text shown when there are no rows. For richer empty states, project light-DOM content into the `empty` slot.',
+			},
+			{
+				name: 'loading',
+				type: 'boolean',
+				description:
+					'Paint shimmering skeleton rows in place of body content. Filters / sort headers stay live.',
+			},
+			{
+				name: 'loading-rows',
+				type: 'integer',
+				description: 'Number of skeleton rows when loading. Default 5.',
+			},
+			{
+				name: 'selectable',
+				type: '"single" | "multi"',
+				description:
+					'Auto-prepend a checkbox column. `multi` puts a select-all checkbox in the header; `single` enforces at-most-one selected.',
+			},
+		],
+		events: [
+			{ name: 'wpd-table-filter-change', description: 'Filter input changed.' },
+			{ name: 'wpd-table-sort-change', description: 'Header click cycled the sort.' },
+			{ name: 'wpd-table-selection-change', description: 'Selection set changed.' },
+			{ name: 'wpd-table-row-click', description: 'Body row clicked (skips data-noclick descendants).' },
+			{ name: 'wpd-table-expand-change', description: 'Sub-table toggled.' },
+		],
+		slots: [
+			{ name: 'empty', description: 'Custom empty-state content (CTA, illustration, etc.).' },
+		],
+		cssProps: [
+			{ name: '--wpd-table-bg' },
+			{ name: '--wpd-table-border' },
+			{ name: '--wpd-table-header-bg' },
+			{ name: '--wpd-table-row-hover' },
+			{ name: '--wpd-table-stripe' },
+			{ name: '--wpd-table-cell-padding' },
+			{ name: '--wpd-table-font-size' },
+			{ name: '--wpd-table-max-height' },
+			{ name: '--wpd-table-skeleton-color' },
+		],
+		example: html`
+			<wpd-table id="sample-table" sticky-header striped hover></wpd-table>
+		`,
+	} as const;
+
+	private _data: T[] = [];
+	private _columns: WpdTableColumn< T >[] = [];
+	private _filters: WpdTableFilters = {};
+	private _expanded = new Set< number >();
+	private _subTable: WpdTableSubTableFn< T > | null = null;
+
+	private _sort: WpdTableSort = null;
+	private _selection = new Set< WpdTableRowId >();
+	private _getRowId: WpdTableGetRowId< T > = ( _row, index ) => index;
+
+	/** Filter input cells, keyed by column key, kept across paints. */
+	private _filterCache = new Map< string, FilterInputCache >();
+
+	private _paintScheduled = false;
+	private _stickyHeaderWarned = false;
+	private _stickyRaceWarned = false;
+	private _resizeObserver: ResizeObserver | null = null;
+	private _stickyMicroScheduled = false;
+	private _stickyRafHandle: number | null = null;
+
+	// ------------------------------------------------------------------
+	// Public properties — set from JS (use `.data=${...}` in templates).
+	// ------------------------------------------------------------------
+
+	/** The row buffer. Reassigning replaces (and clears expansion state). */
+	get data(): readonly T[] {
+		return this._data;
+	}
+	set data( next: readonly T[] | null | undefined ) {
+		this._data = Array.isArray( next ) ? next.slice() : [];
+		this._expanded.clear();
+		// Selection is intentionally NOT cleared — when callers supply a
+		// stable `getRowId`, selection survives data refreshes (the most
+		// useful behavior). Stale ids are filtered out at paint time.
+		this._schedulePaint();
+	}
+
+	/** Column descriptors. See {@link WpdTableColumn}. */
+	get columns(): readonly WpdTableColumn< T >[] {
+		return this._columns;
+	}
+	set columns( next: readonly WpdTableColumn< T >[] | null | undefined ) {
+		this._columns = Array.isArray( next ) ? next.slice() : [];
+		// Drop filters / sort / cached inputs whose column went away.
+		const keys = new Set( this._columns.map( ( c ) => c.key ) );
+		for ( const k of Object.keys( this._filters ) ) {
+			if ( ! keys.has( k ) ) {
+				delete this._filters[ k ];
+			}
+		}
+		for ( const k of Array.from( this._filterCache.keys() ) ) {
+			if ( ! keys.has( k ) ) {
+				this._filterCache.delete( k );
+			}
+		}
+		if ( this._sort && ! keys.has( this._sort.key ) ) {
+			this._sort = null;
+		}
+		this._schedulePaint();
+	}
+
+	/** Read or replace the current filter map. */
+	get filters(): Readonly< WpdTableFilters > {
+		return { ...this._filters };
+	}
+	set filters( next: WpdTableFilters | null | undefined ) {
+		this._filters = next ? { ...next } : {};
+		this._schedulePaint();
+	}
+
+	/** Read or set the active sort. `null` clears it. */
+	get sort(): WpdTableSort {
+		return this._sort ? { ...this._sort } : null;
+	}
+	set sort( next: WpdTableSort | undefined ) {
+		this._sort = next ? { ...next } : null;
+		this._schedulePaint();
+	}
+
+	/** Read or replace the selection (set of row ids). */
+	get selection(): ReadonlySet< WpdTableRowId > {
+		return new Set( this._selection );
+	}
+	set selection( next: Iterable< WpdTableRowId > | null | undefined ) {
+		this._selection = new Set( next ?? [] );
+		this._schedulePaint();
+	}
+
+	/** The currently-selected rows (resolved from `selection` + `data`). */
+	get selectedRows(): T[] {
+		const out: T[] = [];
+		this._data.forEach( ( row, i ) => {
+			if ( this._selection.has( this._getRowId( row, i ) ) ) {
+				out.push( row );
+			}
+		} );
+		return out;
+	}
+
+	/** Stable row-id extractor. Default is row index. */
+	get getRowId(): WpdTableGetRowId< T > {
+		return this._getRowId;
+	}
+	set getRowId( fn: WpdTableGetRowId< T > | null | undefined ) {
+		this._getRowId = typeof fn === 'function' ? fn : ( ( _r, i ) => i );
+		this._schedulePaint();
+	}
+
+	/**
+	 * Sub-table accessor. Return `null` (or omit) for rows with no
+	 * children. Return `{ columns, data }` to render a nested
+	 * `<wpd-table>` inline; or return any `Node` / `html\`\`` template
+	 * for fully custom expanded content.
+	 */
+	get subTable(): WpdTableSubTableFn< T > | null {
+		return this._subTable;
+	}
+	set subTable( fn: WpdTableSubTableFn< T > | null | undefined ) {
+		this._subTable = typeof fn === 'function' ? fn : null;
+		this._expanded.clear();
+		this._schedulePaint();
+	}
+
+	/** Read or replace the expansion set (row indices that are open). */
+	get expanded(): ReadonlySet< number > {
+		return new Set( this._expanded );
+	}
+	set expanded( next: Iterable< number > | null | undefined ) {
+		this._expanded = new Set( next ?? [] );
+		this._schedulePaint();
+	}
+
+	// ------------------------------------------------------------------
+	// Programmatic methods
+	// ------------------------------------------------------------------
+
+	/** Open a row's sub-table by index. No-op if the index is out of range. */
+	expand( index: number ): void {
+		if ( index < 0 || index >= this._data.length ) {
+			return;
+		}
+		if ( this._expanded.has( index ) ) {
+			return;
+		}
+		this._expanded.add( index );
+		this.emit( 'wpd-table-expand-change', {
+			row: this._data[ index ],
+			index,
+			expanded: true,
+		} );
+		this._schedulePaint();
+	}
+
+	/** Close a row's sub-table by index. No-op if it wasn't open. */
+	collapse( index: number ): void {
+		if ( ! this._expanded.has( index ) ) {
+			return;
+		}
+		this._expanded.delete( index );
+		this.emit( 'wpd-table-expand-change', {
+			row: this._data[ index ],
+			index,
+			expanded: false,
+		} );
+		this._schedulePaint();
+	}
+
+	/** Open every row that has children. */
+	expandAll(): void {
+		if ( ! this._subTable ) {
+			return;
+		}
+		let changed = false;
+		for ( let i = 0; i < this._data.length; i++ ) {
+			if ( ! this._subTable( this._data[ i ], i ) ) {
+				continue;
+			}
+			if ( ! this._expanded.has( i ) ) {
+				this._expanded.add( i );
+				changed = true;
+			}
+		}
+		if ( changed ) {
+			this._schedulePaint();
+		}
+	}
+
+	/** Close every open row. */
+	collapseAll(): void {
+		if ( this._expanded.size === 0 ) {
+			return;
+		}
+		this._expanded.clear();
+		this._schedulePaint();
+	}
+
+	isExpanded( index: number ): boolean {
+		return this._expanded.has( index );
+	}
+
+	/** Drop every active filter and emit `wpd-table-filter-change`. */
+	clearFilters(): void {
+		if ( Object.keys( this._filters ).length === 0 ) {
+			return;
+		}
+		this._filters = {};
+		this.emit( 'wpd-table-filter-change', { filters: {} } );
+		this._schedulePaint();
+	}
+
+	/** Drop the active sort and emit `wpd-table-sort-change`. */
+	clearSort(): void {
+		if ( this._sort === null ) {
+			return;
+		}
+		this._sort = null;
+		this.emit( 'wpd-table-sort-change', { sort: null } );
+		this._schedulePaint();
+	}
+
+	/** Add a row id to the selection. Emits `wpd-table-selection-change`. */
+	select( id: WpdTableRowId ): void {
+		if ( this._selection.has( id ) ) {
+			return;
+		}
+		const mode = this._readSelectable();
+		if ( mode === 'single' ) {
+			this._selection.clear();
+		}
+		this._selection.add( id );
+		this._emitSelectionChange();
+		this._schedulePaint();
+	}
+
+	/** Remove a row id from the selection. */
+	deselect( id: WpdTableRowId ): void {
+		if ( ! this._selection.delete( id ) ) {
+			return;
+		}
+		this._emitSelectionChange();
+		this._schedulePaint();
+	}
+
+	/** Select every row currently in `data` (multi-mode only). */
+	selectAll(): void {
+		if ( this._readSelectable() !== 'multi' ) {
+			return;
+		}
+		this._data.forEach( ( row, i ) =>
+			this._selection.add( this._getRowId( row, i ) ),
+		);
+		this._emitSelectionChange();
+		this._schedulePaint();
+	}
+
+	/** Empty the selection. */
+	clearSelection(): void {
+		if ( this._selection.size === 0 ) {
+			return;
+		}
+		this._selection.clear();
+		this._emitSelectionChange();
+		this._schedulePaint();
+	}
+
+	/** Scroll the (filtered) row at `index` into view inside the table's scroll container. */
+	scrollToRow( index: number ): void {
+		const root = this.shadowRoot;
+		if ( ! root ) {
+			return;
+		}
+		const rows = root.querySelectorAll< HTMLElement >(
+			'tbody tr:not(.subtable):not(.empty):not(.skeleton)',
+		);
+		const row = rows[ index ];
+		if ( row ) {
+			row.scrollIntoView( { block: 'nearest', inline: 'nearest' } );
+		}
+	}
+
+	connectedCallback(): void {
+		super.connectedCallback();
+		this._schedulePaint();
+	}
+
+	disconnectedCallback(): void {
+		this._resizeObserver?.disconnect();
+		this._resizeObserver = null;
+		if ( this._stickyRafHandle !== null && typeof cancelAnimationFrame !== 'undefined' ) {
+			cancelAnimationFrame( this._stickyRafHandle );
+			this._stickyRafHandle = null;
+		}
+	}
+
+	/**
+	 * Force a sticky-offsets recompute. Public escape hatch for the
+	 * rare case where layout settles after every internal hook has
+	 * fired — e.g. an out-of-band font swap or a JS-driven width
+	 * change on an ancestor that doesn't bubble through ResizeObserver.
+	 *
+	 * Usually you don't need this: the component schedules recomputes
+	 * on a microtask + animation frame after every paint, and a
+	 * ResizeObserver on the inner scroll element catches geometry
+	 * changes thereafter. Reach for `recomputeLayout()` only if you've
+	 * confirmed that all of those pathways missed your case.
+	 */
+	recomputeLayout(): void {
+		this._applyStickyOffsets();
+		this._measureHeaderHeight();
+	}
+
+	// ------------------------------------------------------------------
+	// Skeleton + paint pipeline
+	// ------------------------------------------------------------------
+
+	protected render(): TemplateResult {
+		return html`
+			<div class="scroll" part="scroll">
+				<table part="table">
+					<colgroup></colgroup>
+					<thead></thead>
+					<tbody></tbody>
+				</table>
+			</div>
+		`;
+	}
+
+	protected requestUpdate(): void {
+		super.requestUpdate();
+		this._schedulePaint();
+	}
+
+	private _schedulePaint(): void {
+		if ( this._paintScheduled || ! this.isConnected ) {
+			return;
+		}
+		this._paintScheduled = true;
+		queueMicrotask( () => {
+			this._paintScheduled = false;
+			if ( ! this.isConnected ) {
+				return;
+			}
+			this._paint();
+		} );
+	}
+
+	private _paint(): void {
+		const root = this.shadowRoot;
+		if ( ! root ) {
+			return;
+		}
+		if ( ! root.querySelector( 'tbody' ) ) {
+			renderTemplate( this.render(), root );
+		}
+
+		const colgroup = root.querySelector( 'colgroup' );
+		const thead = root.querySelector( 'thead' );
+		const tbody = root.querySelector( 'tbody' );
+		if ( ! colgroup || ! thead || ! tbody ) {
+			return;
+		}
+
+		const cols = this._effectiveColumns();
+		const stickyN = this._readStickyColumns();
+
+		this._paintColgroup( colgroup, cols );
+		this._paintHead( thead, cols, stickyN );
+		this._paintBody( tbody, cols, stickyN );
+
+		// Synchronous pass — fixes the common case where layout is
+		// already settled at paint time. The microtask + rAF passes
+		// scheduled below catch the cases where it isn't (mid-
+		// transition mounts, font swaps, async style applies).
+		this._applyStickyOffsets();
+		this._measureHeaderHeight();
+		this._scheduleStickyOffsets();
+		this._maybeWarnStickyHeader();
+		this._ensureResizeObserver();
+	}
+
+	/**
+	 * Belt-and-braces sticky-offset scheduling.
+	 *
+	 *   - Microtask: cheap, fires after the current task drains. Fixes
+	 *     mounts where the synchronous read in `_paint` happened before
+	 *     a sibling style applied.
+	 *   - rAF: fires before the next paint. Catches "layout settles
+	 *     after a queued style mutation" races — the most common cause
+	 *     of "col 1 ended up at inset-inline-start: 0px".
+	 *
+	 * Both reduce to a no-op when nothing changed. The cost is two
+	 * extra DOM reads per paint; the win is the bug class disappears.
+	 */
+	private _scheduleStickyOffsets(): void {
+		if ( ! this._stickyMicroScheduled ) {
+			this._stickyMicroScheduled = true;
+			queueMicrotask( () => {
+				this._stickyMicroScheduled = false;
+				if ( this.isConnected ) {
+					this._applyStickyOffsets();
+				}
+			} );
+		}
+		if (
+			this._stickyRafHandle === null &&
+			typeof requestAnimationFrame !== 'undefined'
+		) {
+			this._stickyRafHandle = requestAnimationFrame( () => {
+				this._stickyRafHandle = null;
+				if ( this.isConnected ) {
+					this._applyStickyOffsets();
+					this._measureHeaderHeight();
+				}
+			} );
+		}
+	}
+
+	/**
+	 * Wire a `ResizeObserver` on the inner `.scroll` element (NOT the
+	 * host). Why: the host's outer width is often pinned by its parent
+	 * panel — a vertical scrollbar appearing inside the table changes
+	 * the inner scroll-area width by ~15px without changing the host
+	 * size. Observing the host would miss that reflow and leave sticky
+	 * offsets stale.
+	 *
+	 * Idempotent — runs once after the first paint produces a real
+	 * `.scroll` element. Disconnect happens in `disconnectedCallback`.
+	 */
+	private _ensureResizeObserver(): void {
+		if ( this._resizeObserver ) {
+			return;
+		}
+		if ( typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+		const scroll = this.shadowRoot?.querySelector(
+			'.scroll',
+		) as HTMLElement | null;
+		if ( ! scroll ) {
+			return;
+		}
+		this._resizeObserver = new ResizeObserver( () => {
+			if ( ! this.isConnected ) {
+				return;
+			}
+			this._applyStickyOffsets();
+			this._measureHeaderHeight();
+			// A previously-zero scroll container that just became
+			// visible may now actually overflow — re-arm the warning
+			// so users get the heads-up the first time scroll context
+			// appears without a max-height.
+			this._stickyHeaderWarned = false;
+			this._maybeWarnStickyHeader();
+		} );
+		this._resizeObserver.observe( scroll );
+		// Also observe the host so panel-driven width changes (parent
+		// flex reflow, container query crossing) fire the callback.
+		// Multiple observe() calls on the same RO are allowed.
+		this._resizeObserver.observe( this );
+	}
+
+	private _paintColgroup(
+		colgroup: Element,
+		cols: WpdTableColumn< T >[],
+	): void {
+		const out: HTMLElement[] = [];
+		for ( const c of cols ) {
+			const col = document.createElement( 'col' );
+			if ( c.width ) {
+				col.style.width = c.width;
+			}
+			out.push( col );
+		}
+		colgroup.replaceChildren( ...out );
+	}
+
+	private _paintHead(
+		thead: Element,
+		cols: WpdTableColumn< T >[],
+		stickyN: number,
+	): void {
+		thead.replaceChildren();
+
+		const headerRow = document.createElement( 'tr' );
+		headerRow.setAttribute( 'part', 'header-row' );
+		for ( let i = 0; i < cols.length; i++ ) {
+			headerRow.appendChild( this._buildHeaderCell( cols[ i ], i, stickyN ) );
+		}
+		thead.appendChild( headerRow );
+
+		const hasFilter = cols.some( ( c ) => c.filter );
+		if ( hasFilter ) {
+			const filterRow = document.createElement( 'tr' );
+			filterRow.classList.add( 'filter-row' );
+			filterRow.setAttribute( 'part', 'filter-row' );
+			for ( let i = 0; i < cols.length; i++ ) {
+				filterRow.appendChild( this._buildFilterCell( cols[ i ], i, stickyN ) );
+			}
+			thead.appendChild( filterRow );
+		}
+	}
+
+	private _buildHeaderCell(
+		col: WpdTableColumn< T >,
+		index: number,
+		stickyN: number,
+	): HTMLTableCellElement {
+		const th = document.createElement( 'th' );
+		th.setAttribute( 'scope', 'col' );
+		th.dataset.key = col.key;
+		this._applyCellClasses( th, col, index, stickyN );
+
+		if ( col.key === SELECT_KEY ) {
+			const mode = this._readSelectable();
+			if ( mode === 'multi' ) {
+				const cb = document.createElement( 'input' );
+				cb.type = 'checkbox';
+				cb.className = 'select-all-checkbox';
+				cb.setAttribute( 'data-noclick', '' );
+				cb.setAttribute( 'aria-label', 'Select all rows' );
+				const total = this._data.length;
+				const selectedCount = this._countSelectedInData();
+				cb.checked = total > 0 && selectedCount === total;
+				cb.indeterminate = selectedCount > 0 && selectedCount < total;
+				cb.addEventListener( 'change', () => {
+					if ( cb.checked ) {
+						this.selectAll();
+					} else {
+						this.clearSelection();
+					}
+				} );
+				th.appendChild( cb );
+			}
+			return th;
+		}
+
+		th.textContent =
+			col.label ?? ( col.key === EXPANDER_KEY ? '' : col.key );
+
+		if ( col.sortable ) {
+			th.classList.add( 'is-sortable' );
+			const isActive = this._sort?.key === col.key;
+			const indicator = document.createElement( 'span' );
+			indicator.className = 'sort-indicator';
+			let arrow = '';
+			if ( isActive ) {
+				arrow = this._sort!.direction === 'asc' ? ' ▲' : ' ▼';
+			}
+			indicator.textContent = arrow;
+			th.appendChild( indicator );
+			if ( isActive ) {
+				th.classList.add(
+					this._sort!.direction === 'asc' ? 'sort-asc' : 'sort-desc',
+				);
+			}
+			th.addEventListener( 'click', () => this._cycleSort( col.key ) );
+		}
+
+		return th;
+	}
+
+	private _buildFilterCell(
+		col: WpdTableColumn< T >,
+		index: number,
+		stickyN: number,
+	): HTMLTableCellElement {
+		const cached = this._filterCache.get( col.key );
+		let desiredKind: FilterInputCache[ 'kind' ];
+		if (
+			! col.filter ||
+			col.key === EXPANDER_KEY ||
+			col.key === SELECT_KEY
+		) {
+			desiredKind = 'none';
+		} else if ( col.filter === 'select' ) {
+			desiredKind = 'select';
+		} else {
+			desiredKind = 'text';
+		}
+
+		if ( cached && cached.kind === desiredKind ) {
+			cached.th.className = '';
+			this._applyCellClasses( cached.th, col, index, stickyN );
+			if ( desiredKind === 'select' ) {
+				const select = cached.control as HTMLSelectElement;
+				const opts = this._uniqueValues( col.key );
+				const optsKey = opts.join( '' );
+				if ( optsKey !== cached.optionsKey ) {
+					this._populateSelect( select, opts, this._filters[ col.key ] ?? '' );
+					cached.optionsKey = optsKey;
+				} else {
+					select.value = this._filters[ col.key ] ?? '';
+				}
+			} else if ( desiredKind === 'text' ) {
+				const input = cached.control as HTMLInputElement;
+				const want = this._filters[ col.key ] ?? '';
+				if ( input.value !== want && input.ownerDocument.activeElement !== input ) {
+					input.value = want;
+				}
+			}
+			return cached.th;
+		}
+
+		const th = document.createElement( 'th' );
+		this._applyCellClasses( th, col, index, stickyN );
+
+		if ( desiredKind === 'none' ) {
+			this._filterCache.set( col.key, {
+				th,
+				control: document.createElement( 'input' ),
+				optionsKey: '',
+				kind: 'none',
+			} );
+			return th;
+		}
+
+		let control: HTMLInputElement | HTMLSelectElement;
+		let optionsKey = '';
+		if ( desiredKind === 'select' ) {
+			const select = document.createElement( 'select' );
+			select.classList.add( 'filter-select' );
+			select.setAttribute( 'data-noclick', '' );
+			select.setAttribute(
+				'aria-label',
+				`Filter ${ col.label ?? col.key }`,
+			);
+			const opts = this._uniqueValues( col.key );
+			this._populateSelect( select, opts, this._filters[ col.key ] ?? '' );
+			optionsKey = opts.join( '' );
+			select.addEventListener( 'change', () => {
+				this._onFilterChange( col.key, select.value );
+			} );
+			control = select;
+		} else {
+			const input = document.createElement( 'input' );
+			input.type = 'search';
+			input.classList.add( 'filter-input' );
+			input.setAttribute( 'data-noclick', '' );
+			input.setAttribute( 'placeholder', 'Filter…' );
+			input.setAttribute( 'aria-label', `Filter ${ col.label ?? col.key }` );
+			input.value = this._filters[ col.key ] ?? '';
+			input.addEventListener( 'input', () => {
+				this._onFilterChange( col.key, input.value );
+			} );
+			control = input;
+		}
+		th.appendChild( control );
+		this._filterCache.set( col.key, {
+			th,
+			control,
+			optionsKey,
+			kind: desiredKind,
+		} );
+		return th;
+	}
+
+	private _populateSelect(
+		select: HTMLSelectElement,
+		options: string[],
+		current: string,
+	): void {
+		select.replaceChildren();
+		const all = document.createElement( 'option' );
+		all.value = '';
+		all.textContent = 'All';
+		select.appendChild( all );
+		for ( const v of options ) {
+			const opt = document.createElement( 'option' );
+			opt.value = v;
+			opt.textContent = v;
+			if ( v === current ) {
+				opt.selected = true;
+			}
+			select.appendChild( opt );
+		}
+		select.value = current;
+	}
+
+	// ------------------------------------------------------------------
+	// Body
+	// ------------------------------------------------------------------
+
+	private _paintBody(
+		tbody: Element,
+		cols: WpdTableColumn< T >[],
+		stickyN: number,
+	): void {
+		tbody.replaceChildren();
+
+		if ( this.hasAttribute( 'loading' ) ) {
+			const count = this._readLoadingRows();
+			for ( let i = 0; i < count; i++ ) {
+				tbody.appendChild( this._buildSkeletonRow( cols, i ) );
+			}
+			return;
+		}
+
+		const filtered = this._sortedRows( this._filteredRows() );
+		if ( filtered.length === 0 ) {
+			tbody.appendChild( this._buildEmptyRow( cols.length ) );
+			return;
+		}
+		for ( const { row, index } of filtered ) {
+			tbody.appendChild( this._buildBodyRow( row, index, cols, stickyN ) );
+			if ( this._expanded.has( index ) && this._subTable ) {
+				const sub = this._subTable( row, index );
+				if ( sub ) {
+					tbody.appendChild( this._buildSubTableRow( sub, cols.length ) );
+				}
+			}
+		}
+	}
+
+	private _buildEmptyRow( colspan: number ): HTMLTableRowElement {
+		const tr = document.createElement( 'tr' );
+		tr.classList.add( 'empty' );
+		const td = document.createElement( 'td' );
+		td.colSpan = colspan;
+		// `<slot name="empty">` projects light-DOM content (a CTA, an
+		// illustration); when nothing is slotted, the slot's fallback
+		// is the `empty` attribute text — so we get rich-or-plain
+		// behavior from a single mount path.
+		const slot = document.createElement( 'slot' );
+		slot.name = 'empty';
+		slot.textContent = this.getAttribute( 'empty' ) || 'No data';
+		td.appendChild( slot );
+		tr.appendChild( td );
+		return tr;
+	}
+
+	private _buildSkeletonRow(
+		cols: WpdTableColumn< T >[],
+		seed: number,
+	): HTMLTableRowElement {
+		const tr = document.createElement( 'tr' );
+		tr.classList.add( 'skeleton' );
+		tr.setAttribute( 'aria-hidden', 'true' );
+		for ( const _c of cols ) {
+			const td = document.createElement( 'td' );
+			const bar = document.createElement( 'span' );
+			bar.className = 'skeleton-bar';
+			// Slight per-cell width variance so the skeleton doesn't
+			// look mechanically uniform.
+			const widthPct = 50 + ( ( seed * 7 + tr.children.length * 13 ) % 40 );
+			bar.style.width = `${ widthPct }%`;
+			td.appendChild( bar );
+			tr.appendChild( td );
+		}
+		return tr;
+	}
+
+	private _buildBodyRow(
+		row: T,
+		rowIndex: number,
+		cols: WpdTableColumn< T >[],
+		stickyN: number,
+	): HTMLTableRowElement {
+		const tr = document.createElement( 'tr' );
+		tr.setAttribute( 'part', 'row' );
+		tr.dataset.rowIndex = String( rowIndex );
+		const id = this._getRowId( row, rowIndex );
+		if ( this._selection.has( id ) ) {
+			tr.classList.add( 'is-selected' );
+		}
+		tr.addEventListener( 'click', ( e: Event ) => {
+			this._onRowClick( row, rowIndex, e );
+		} );
+		for ( let i = 0; i < cols.length; i++ ) {
+			tr.appendChild(
+				this._buildBodyCell( cols[ i ], i, row, rowIndex, stickyN ),
+			);
+		}
+		return tr;
+	}
+
+	private _buildBodyCell(
+		col: WpdTableColumn< T >,
+		colIndex: number,
+		row: T,
+		rowIndex: number,
+		stickyN: number,
+	): HTMLTableCellElement {
+		const td = document.createElement( 'td' );
+		this._applyCellClasses( td, col, colIndex, stickyN );
+
+		if ( col.key === SELECT_KEY ) {
+			const id = this._getRowId( row, rowIndex );
+			const cb = document.createElement( 'input' );
+			cb.type = 'checkbox';
+			cb.className = 'select-row-checkbox';
+			cb.setAttribute( 'data-noclick', '' );
+			cb.setAttribute( 'aria-label', 'Select row' );
+			cb.checked = this._selection.has( id );
+			cb.addEventListener( 'change', () => {
+				if ( cb.checked ) {
+					this.select( id );
+				} else {
+					this.deselect( id );
+				}
+			} );
+			td.appendChild( cb );
+			return td;
+		}
+
+		if ( col.key === EXPANDER_KEY ) {
+			const hasChildren = this._subTable
+				? !! this._subTable( row, rowIndex )
+				: false;
+			if ( ! hasChildren ) {
+				return td;
+			}
+			const isOpen = this._expanded.has( rowIndex );
+			const btn = document.createElement( 'button' );
+			btn.type = 'button';
+			btn.className = 'expander';
+			btn.setAttribute( 'data-noclick', '' );
+			btn.setAttribute( 'aria-expanded', isOpen ? 'true' : 'false' );
+			btn.setAttribute(
+				'aria-label',
+				isOpen ? 'Collapse row' : 'Expand row',
+			);
+			btn.textContent = isOpen ? '▾' : '▸';
+			btn.addEventListener( 'click', ( e: Event ) => {
+				this._toggleRow( rowIndex, row, e );
+			} );
+			td.appendChild( btn );
+			return td;
+		}
+
+		const value = ( row as Record< string, unknown > )[ col.key ];
+		if ( col.render ) {
+			const out = col.render( value, row, rowIndex );
+			this._mountCellContent( td, out );
+		} else if ( value !== null && value !== undefined ) {
+			td.textContent = String( value );
+		}
+		return td;
+	}
+
+	private _buildSubTableRow(
+		sub: Exclude< WpdTableSubTableResult, null | undefined >,
+		colspan: number,
+	): HTMLTableRowElement {
+		const tr = document.createElement( 'tr' );
+		tr.classList.add( 'subtable' );
+		tr.setAttribute( 'part', 'subtable-row' );
+		const td = document.createElement( 'td' );
+		td.colSpan = colspan;
+		const inner = document.createElement( 'div' );
+		inner.classList.add( 'subtable-inner' );
+
+		if ( sub instanceof Node ) {
+			inner.appendChild( sub );
+		} else if ( isTemplateResult( sub ) ) {
+			renderTemplate( sub, inner );
+		} else {
+			const nested = document.createElement( 'wpd-table' ) as WpdTable;
+			nested.columns = sub.columns;
+			nested.data = sub.data;
+			if ( sub.subTable ) {
+				nested.subTable = sub.subTable;
+			}
+			inner.appendChild( nested );
+		}
+
+		td.appendChild( inner );
+		tr.appendChild( td );
+		return tr;
+	}
+
+	private _mountCellContent(
+		td: HTMLElement,
+		out: string | Node | TemplateResult,
+	): void {
+		if ( typeof out === 'string' ) {
+			td.textContent = out;
+			return;
+		}
+		if ( out instanceof Node ) {
+			td.appendChild( out );
+			return;
+		}
+		if ( isTemplateResult( out ) ) {
+			renderTemplate( out, td );
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Behavior
+	// ------------------------------------------------------------------
+
+	private _onFilterChange( key: string, value: string ): void {
+		if ( value === '' ) {
+			delete this._filters[ key ];
+		} else {
+			this._filters[ key ] = value;
+		}
+		this.emit( 'wpd-table-filter-change', { filters: { ...this._filters } } );
+		// Re-paint body only — filter inputs themselves stay mounted
+		// (preserving focus + caret).
+		const root = this.shadowRoot;
+		const tbody = root?.querySelector( 'tbody' );
+		if ( tbody ) {
+			const cols = this._effectiveColumns();
+			const stickyN = this._readStickyColumns();
+			this._paintBody( tbody, cols, stickyN );
+			this._applyStickyOffsets();
+		}
+	}
+
+	private _onRowClick( row: T, index: number, e: Event ): void {
+		const path = ( e as Event & { composedPath?: () => EventTarget[] } ).composedPath?.() ?? [];
+		for ( const node of path ) {
+			if ( node instanceof Element && node.hasAttribute( 'data-noclick' ) ) {
+				return;
+			}
+			if ( node === this ) {
+				break;
+			}
+		}
+		this.emit( 'wpd-table-row-click', { row, index, originalEvent: e } );
+	}
+
+	private _toggleRow( index: number, row: T, e: Event ): void {
+		e.stopPropagation();
+		const isOpen = this._expanded.has( index );
+		if ( isOpen ) {
+			this._expanded.delete( index );
+		} else {
+			this._expanded.add( index );
+		}
+		this.emit( 'wpd-table-expand-change', {
+			row,
+			index,
+			expanded: ! isOpen,
+		} );
+		this._schedulePaint();
+	}
+
+	private _cycleSort( key: string ): void {
+		if ( ! this._sort || this._sort.key !== key ) {
+			this._sort = { key, direction: 'asc' };
+		} else if ( this._sort.direction === 'asc' ) {
+			this._sort = { key, direction: 'desc' };
+		} else {
+			this._sort = null;
+		}
+		this.emit( 'wpd-table-sort-change', {
+			sort: this._sort ? { ...this._sort } : null,
+		} );
+		this._schedulePaint();
+	}
+
+	private _emitSelectionChange(): void {
+		this.emit( 'wpd-table-selection-change', {
+			selection: Array.from( this._selection ),
+			rows: this.selectedRows,
+		} );
+	}
+
+	// ------------------------------------------------------------------
+	// Filtering + sorting
+	// ------------------------------------------------------------------
+
+	private _filteredRows(): Array< { row: T; index: number } > {
+		const out: Array< { row: T; index: number } > = [];
+		const active = Object.keys( this._filters ).filter(
+			( k ) => this._filters[ k ] !== '',
+		);
+		for ( let i = 0; i < this._data.length; i++ ) {
+			const row = this._data[ i ];
+			let pass = true;
+			for ( const key of active ) {
+				const col = this._columns.find( ( c ) => c.key === key );
+				const filter = this._filters[ key ] ?? '';
+				const cell = ( row as Record< string, unknown > )[ key ];
+				const cellStr = cell === null || cell === undefined ? '' : String( cell );
+				if ( col?.filter === 'select' ) {
+					if ( cellStr !== filter ) {
+						pass = false;
+						break;
+					}
+				} else if ( ! cellStr.toLowerCase().includes( filter.toLowerCase() ) ) {
+					pass = false;
+					break;
+				}
+			}
+			if ( pass ) {
+				out.push( { row, index: i } );
+			}
+		}
+		return out;
+	}
+
+	private _sortedRows(
+		rows: Array< { row: T; index: number } >,
+	): Array< { row: T; index: number } > {
+		if ( ! this._sort ) {
+			return rows;
+		}
+		const col = this._columns.find( ( c ) => c.key === this._sort!.key );
+		if ( ! col ) {
+			return rows;
+		}
+		const dir = this._sort.direction === 'desc' ? -1 : 1;
+		const out = rows.slice();
+		out.sort( ( a, b ) => {
+			const av = col.sortValue
+				? col.sortValue( a.row, ( a.row as Record< string, unknown > )[ col.key ] )
+				: ( a.row as Record< string, unknown > )[ col.key ];
+			const bv = col.sortValue
+				? col.sortValue( b.row, ( b.row as Record< string, unknown > )[ col.key ] )
+				: ( b.row as Record< string, unknown > )[ col.key ];
+			return compareValues( av, bv ) * dir;
+		} );
+		return out;
+	}
+
+	private _uniqueValues( key: string ): string[] {
+		const seen = new Set< string >();
+		for ( const row of this._data ) {
+			const v = ( row as Record< string, unknown > )[ key ];
+			if ( v === null || v === undefined ) {
+				continue;
+			}
+			seen.add( String( v ) );
+		}
+		return Array.from( seen ).sort();
+	}
+
+	private _countSelectedInData(): number {
+		let n = 0;
+		this._data.forEach( ( row, i ) => {
+			if ( this._selection.has( this._getRowId( row, i ) ) ) {
+				n++;
+			}
+		} );
+		return n;
+	}
+
+	// ------------------------------------------------------------------
+	// Sticky columns + attribute reads
+	// ------------------------------------------------------------------
+
+	private _readStickyColumns(): number {
+		const raw = parseInt( this.getAttribute( 'sticky-columns' ) || '0', 10 );
+		return Number.isFinite( raw ) && raw > 0 ? raw : 0;
+	}
+
+	private _readLoadingRows(): number {
+		const raw = parseInt( this.getAttribute( 'loading-rows' ) || '5', 10 );
+		return Number.isFinite( raw ) && raw > 0 ? Math.min( raw, 100 ) : 5;
+	}
+
+	private _readSelectable(): 'single' | 'multi' | null {
+		const v = this.getAttribute( 'selectable' );
+		if ( v === 'single' ) {
+			return 'single';
+		}
+		if ( v === 'multi' || v === '' ) {
+			return 'multi';
+		}
+		return null;
+	}
+
+	/**
+	 * Sticky-band membership. The first N columns get pinned, with two
+	 * per-column overrides: `column.sticky = true` opts in even outside
+	 * the band; `column.sticky = false` opts out within it.
+	 */
+	private _isStickyIndex(
+		index: number,
+		stickyN: number,
+		col: WpdTableColumn< T >,
+	): boolean {
+		if ( col.sticky === false ) {
+			return false;
+		}
+		if ( col.sticky === true ) {
+			return true;
+		}
+		return index < stickyN;
+	}
+
+	private _applyCellClasses(
+		cell: HTMLElement,
+		col: WpdTableColumn< T >,
+		index: number,
+		stickyN: number,
+	): void {
+		if ( col.key === EXPANDER_KEY ) {
+			cell.classList.add( 'col-expander' );
+		}
+		if ( col.key === SELECT_KEY ) {
+			cell.classList.add( 'col-select' );
+		}
+		if ( col.align === 'center' ) {
+			cell.classList.add( 'align-center' );
+		}
+		if ( col.align === 'end' ) {
+			cell.classList.add( 'align-end' );
+		}
+		const sticky = this._isStickyIndex( index, stickyN, col );
+		if ( sticky ) {
+			cell.classList.add( 'is-sticky' );
+			if ( index === stickyN - 1 ) {
+				cell.classList.add( 'is-sticky-edge' );
+			}
+		}
+	}
+
+	private _effectiveColumns(): WpdTableColumn< T >[] {
+		const out: WpdTableColumn< T >[] = [];
+		if ( this._readSelectable() ) {
+			out.push( {
+				key: SELECT_KEY,
+				label: '',
+				width: '36px',
+				align: 'center',
+			} );
+		}
+		if ( this._subTable ) {
+			out.push( {
+				key: EXPANDER_KEY,
+				label: '',
+				width: '32px',
+				align: 'center',
+			} );
+		}
+		out.push( ...this._columns );
+		return out;
+	}
+
+	/**
+	 * Walk the header row, sum the natural widths of the sticky cells,
+	 * then write cumulative `inset-inline-start` offsets onto every
+	 * row's matching cells.
+	 */
+	private _applyStickyOffsets(): void {
+		const root = this.shadowRoot;
+		if ( ! root ) {
+			return;
+		}
+		const headRow = root.querySelector( 'thead tr' );
+		if ( ! headRow ) {
+			return;
+		}
+		const ths = Array.from( headRow.children ) as HTMLElement[];
+		const offsets: number[] = [];
+		let acc = 0;
+		for ( let i = 0; i < ths.length; i++ ) {
+			offsets[ i ] = acc;
+			if ( ths[ i ].classList.contains( 'is-sticky' ) ) {
+				acc += ths[ i ].offsetWidth;
+			}
+		}
+		const rows = root.querySelectorAll(
+			'thead tr, tbody tr:not(.subtable):not(.empty):not(.skeleton)',
+		);
+		rows.forEach( ( r ) => {
+			const cells = Array.from( ( r as HTMLElement ).children ) as HTMLElement[];
+			for ( let i = 0; i < cells.length; i++ ) {
+				if ( cells[ i ].classList.contains( 'is-sticky' ) ) {
+					cells[ i ].style.insetInlineStart = `${ offsets[ i ] }px`;
+				}
+			}
+		} );
+
+		// Diagnostic: when sticky-columns >= 2, the second pinned cell
+		// MUST land at a non-zero offset (it's the cumulative width of
+		// the first). If we computed 0 and the host has a real width
+		// (so it's not just hidden), something measured pre-layout —
+		// usually a paint that happened while the panel was mid-
+		// transition. Tell the developer once, with the actual values,
+		// so they're not staring at DevTools wondering which side of
+		// the contract is broken.
+		this._maybeWarnStickyOffsetRace( ths, offsets );
+	}
+
+	private _maybeWarnStickyOffsetRace(
+		ths: HTMLElement[],
+		offsets: number[],
+	): void {
+		if ( this._stickyRaceWarned ) {
+			return;
+		}
+		const stickyN = this._readStickyColumns();
+		if ( stickyN < 2 ) {
+			return;
+		}
+		const lastIdx = Math.min( stickyN - 1, ths.length - 1 );
+		if ( lastIdx <= 0 ) {
+			return;
+		}
+		if ( offsets[ lastIdx ] !== 0 ) {
+			return;
+		}
+		// If the host has zero width (display: none, jsdom, hidden tab
+		// before first show), it's not a race — it's "haven't mounted
+		// visibly yet". The ResizeObserver will fire when it does, and
+		// we'll recompute correctly. Don't burn a warning on that.
+		if ( this.offsetWidth === 0 ) {
+			return;
+		}
+		this._stickyRaceWarned = true;
+		const w0 = ths[ 0 ]?.offsetWidth ?? 0;
+		// eslint-disable-next-line no-console
+		console.warn(
+			`[wpd-table] sticky-columns: column ${ lastIdx } resolved to ` +
+				`inset-inline-start: 0px while the host is visible. ` +
+				`ths[0].offsetWidth was ${ w0 }px at measurement time. ` +
+				'Likely a layout race — call recomputeLayout() after the ' +
+				'panel finishes its mount/transition, or wrap the assignment ' +
+				'of `data` in a requestAnimationFrame.',
+		);
+	}
+
+	private _measureHeaderHeight(): void {
+		const root = this.shadowRoot;
+		if ( ! root ) {
+			return;
+		}
+		const headRow = root.querySelector( 'thead tr' ) as HTMLElement | null;
+		if ( ! headRow ) {
+			return;
+		}
+		const h = headRow.offsetHeight;
+		if ( h > 0 ) {
+			this.style.setProperty( '--wpd-table-header-height', `${ h }px` );
+		}
+	}
+
+	/**
+	 * Once-per-element warning for the most common sticky-header
+	 * mistake: forgetting to give the table a scroll container. Without
+	 * a max-height (or a scrolling ancestor), `position: sticky`
+	 * silently does nothing because there's no scrollport for it to
+	 * stick within.
+	 */
+	private _maybeWarnStickyHeader(): void {
+		if ( this._stickyHeaderWarned ) {
+			return;
+		}
+		if ( ! this.hasAttribute( 'sticky-header' ) ) {
+			return;
+		}
+		// Need enough rows to actually need scrolling; bail on
+		// loading / tiny tables to avoid a false positive on the first
+		// paint of an async data table.
+		if ( this.hasAttribute( 'loading' ) || this._data.length < 8 ) {
+			return;
+		}
+		const scroll = this.shadowRoot?.querySelector(
+			'.scroll',
+		) as HTMLElement | null;
+		if ( ! scroll ) {
+			return;
+		}
+		// If the inner content can fit without scrolling, sticky is
+		// inert. The offsetWidth check guards against zero-layout
+		// (jsdom, hidden) where every measurement is 0 and would false-
+		// positive every time.
+		if ( scroll.offsetWidth === 0 ) {
+			return;
+		}
+		if ( scroll.scrollHeight <= scroll.clientHeight + 1 ) {
+			this._stickyHeaderWarned = true;
+			// eslint-disable-next-line no-console
+			console.warn(
+				'[wpd-table] sticky-header is set but the table has no scroll container. ' +
+					'Set --wpd-table-max-height on the host (or wrap it in a scrolling parent) so the header has something to stick to.',
+			);
+		}
+	}
+}
+
+function isTemplateResult( v: unknown ): v is TemplateResult {
+	return !! v && ( v as { __wpdHtml?: boolean } ).__wpdHtml === true;
+}
+
+/**
+ * Sort comparator. Numbers compare numerically; everything else falls
+ * back to a locale-aware string compare. `null` / `undefined` sort
+ * before any concrete value so unsorted data lands at the top.
+ */
+function compareValues( a: unknown, b: unknown ): number {
+	if ( a === b ) {
+		return 0;
+	}
+	if ( a === null || a === undefined ) {
+		return -1;
+	}
+	if ( b === null || b === undefined ) {
+		return 1;
+	}
+	if ( typeof a === 'number' && typeof b === 'number' ) {
+		return a - b;
+	}
+	if ( a instanceof Date && b instanceof Date ) {
+		return a.getTime() - b.getTime();
+	}
+	const an = Number( a );
+	const bn = Number( b );
+	if ( Number.isFinite( an ) && Number.isFinite( bn ) ) {
+		return an - bn;
+	}
+	return String( a ).localeCompare( String( b ) );
+}
+
+defineComponent( 'wpd-table', WpdTable );

--- a/src/ui/core/component.ts
+++ b/src/ui/core/component.ts
@@ -96,7 +96,7 @@ export abstract class Component extends HTMLElement {
 
 	connectedCallback(): void {
 		this._adoptStyles();
-		this._scheduleRender();
+		this.requestUpdate();
 	}
 
 	attributeChangedCallback(
@@ -109,7 +109,12 @@ export abstract class Component extends HTMLElement {
 		}
 		const prop = camel( name );
 		this._propValues[ prop ] = newValue;
-		this._scheduleRender();
+		// Route through `requestUpdate()` — the single hook subclasses
+		// override to plug in extra work (e.g. an imperative paint
+		// pipeline alongside the templated render). Calling
+		// `_scheduleRender` directly here would bypass those hooks and
+		// silently desync state on attribute changes.
+		this.requestUpdate();
 	}
 
 	/**
@@ -219,7 +224,15 @@ export abstract class Component extends HTMLElement {
 					} else {
 						this.setAttribute( attr, str );
 					}
-					this._scheduleRender();
+					// `setAttribute`/`removeAttribute` will fire
+					// `attributeChangedCallback`, which itself calls
+					// `requestUpdate()` — but only when the attribute
+					// value actually changed at the DOM level. Programmatic
+					// setters that write back the same string don't fire
+					// the observer, so we still need our own update call.
+					// Both paths debounce on the same flag, so the cost
+					// is one extra microtask check at worst.
+					this.requestUpdate();
 				},
 				enumerable: true,
 				configurable: true,


### PR DESCRIPTION
## Summary

Adds a new `<wpd-table>` web component to the wpd-ui kit. Assign `columns` and `data`, get a styled, accessible, sticky-aware data table. Per-column filters, click-to-sort, multi-row selection, sticky columns/header, sub-tables, custom cell renderers, loading skeleton, and a slottable empty state are all opt-in.


https://github.com/user-attachments/assets/9893fbc8-f834-4686-8184-2db83a654e36


Plugin Showcase Demo:
[wpd-table-showcase.zip](https://github.com/user-attachments/files/27157792/wpd-table-showcase.zip)


## Why

Plugin authors rendering admin data inside native windows kept reaching for hand-rolled `<table>` markup, copy-pasting sticky-column CSS, and reinventing filter/sort UI per scene. The pattern was repetitive enough to warrant a primitive — but only if the primitive didn't lock anyone in. Two non-negotiables:

1. **Easy to start, possible to extend.** A 10-line table works; a 200-line table works; the path between is visible in the docs.
2. **Pure additive.** No assumptions about the host's data layer, framework, or styling language. Pass a typed array, get rows back.

## What you get

```ts
import type { WpdTable, WpdTableColumn } from 'wp-desktop/ui';

interface User extends Record< string, unknown > {
    name: string;
    email: string;
    role: 'admin' | 'editor';
    logins: number;
}

const table = document.querySelector< WpdTable< User > >( '#users' )!;
table.columns = [
    { key: 'name',   label: 'Name',   filter: 'text', sortable: true, sticky: true },
    { key: 'email',  label: 'Email',  filter: 'text', sortable: true },
    { key: 'role',   label: 'Role',   filter: 'select' },
    { key: 'logins', label: 'Logins', align: 'end',   sortable: true },
];
table.data = users;
table.getRowId = ( row ) => row.email;       // stable selection across refreshes
table.subTable = ( row ) => row.history?.length
    ? { columns: historyCols, data: row.history }
    : null;
```

```html
<wpd-table sticky-columns="2" sticky-header striped hover selectable="multi">
    <div slot="empty">
        <p>No users yet.</p>
        <wpd-button>Invite someone</wpd-button>
    </div>
</wpd-table>
```

## Feature list

| Feature | Surface |
|---|---|
| Per-column text / select filters | `column.filter`, `wpd-table-filter-change`, `clearFilters()` |
| Click-to-sort (asc → desc → unsorted) | `column.sortable`, `column.sortValue`, `wpd-table-sort-change`, `clearSort()` |
| Multi-row + single-row selection | `selectable="single|multi"`, `getRowId`, `select()`, `deselect()`, `selectAll()`, `clearSelection()`, `wpd-table-selection-change` |
| Sticky columns (variable width, RTL-aware) | `sticky-columns="N"`, `column.sticky` |
| Sticky header (with filter row) | `sticky-header` + scrolling container |
| Sub-tables (infinitely nestable) | `subTable( row, i )`, `expand()`, `collapse()`, `expandAll()`, `collapseAll()`, `wpd-table-expand-change` |
| Custom cell renderers | `column.render( v, row, i )` returns `string \| Node \| html\`\`` |
| Loading skeleton | `loading`, `loading-rows="N"`, respects `prefers-reduced-motion` |
| Slottable empty state | `<slot name="empty">` (text fallback via `empty` attr) |
| Row clicks (with `data-noclick` opt-out) | `wpd-table-row-click` |
| Programmatic scroll | `scrollToRow( i )` |
| Public layout escape hatch | `recomputeLayout()` |

Generic over the row type — `WpdTable<User>` gives strong types for every callback.

## Notable design decisions

### Imperative paint inside a templated skeleton

The wpd-ui `html\`\`` renderer parses every nested template via `template.innerHTML`, which applies HTML's content-model rules — so a sub-template containing `<tr>`, `<td>`, or `<col>` gets hoisted out of its expected parent and the table breaks. The component renders a static skeleton via the template tag, then paints headers / rows / cells imperatively.

Filter inputs are kept across paints (not rebuilt) so typing into a filter never loses focus or caret position — this is the same pattern that would generalize to a future `column.editor` API.

### Sticky-offset measurement (belt + braces)

Variable-width sticky columns can't be expressed in pure CSS — we measure `offsetWidth` after layout and write cumulative `inset-inline-start` per cell. Three independent passes, all idempotent:

1. **Synchronous** read at the end of `_paint` (fixes the common case where layout has already settled).
2. **Microtask + `requestAnimationFrame`** rescheduled passes (catch mid-transition mounts, font swaps, async style applies).
3. **`ResizeObserver`** on the inner `.scroll` element AND the host (catches scrollbar appearance, panel-driven reflow, hidden→visible transitions, container query crossings).

If a column-1+ sticky cell ever ends up at `inset-inline-start: 0px` while the host is visible, the component logs a one-time `console.warn` with `ths[0].offsetWidth` and points to `recomputeLayout()` — a tripwire that should never fire, but if it does, names the bug instead of leaving the dev in DevTools.

### Sticky-cell opacity invariant

Sticky cells need an opaque background (non-sticky siblings slide under them on scroll). Stripe / hover / sub-table state overlays therefore layer via `background-image: linear-gradient(rgba, rgba)` rather than overwriting `background-color`. The opaque base is always preserved; combinations like striped+hover stack the overlays without ever exposing transparency.

Z-index ladder is widely spaced (10 / 20 / 30 / 40) so there's no ambiguity across browser table-cell stacking quirks:

- `10` body sticky cells (above non-sticky body)
- `20` sticky-header non-sticky thead cells (above body sticky)
- `30` sticky-column thead cells (above sticky-header non-sticky)
- `40` the corner cell (sticky-column AND sticky-header)

### Selection survives data refreshes

The default `getRowId` is the array index — fine for ephemeral lists. Whenever rows have a natural identifier (`row.id`, `row.email`), pass `getRowId = ( row ) => row.id` and selections survive `data` reassignment, sort changes, and filter changes. Index-based ids are documented as the explicit fallback, not the recommended default.

### Architectural fix in the base `Component`

Attribute changes on a wpd-ui component used to bypass `requestUpdate()` — `attributeChangedCallback` called `_scheduleRender()` directly. That broke any subclass with extra work hooked into `requestUpdate` (notably `WpdTable`'s imperative paint pipeline): toggling an attribute re-rendered the templated skeleton but never re-painted the body. Result: setting `loading="true"` left the data rows on screen with no skeleton.

Fix: route `connectedCallback`, `attributeChangedCallback`, and the prop setter all through `this.requestUpdate()`. Transparent for every existing component (the default `requestUpdate` is `_scheduleRender`); fixes the attribute path for any subclass that overrides `requestUpdate`. A regression test toggles `loading` via `setAttribute` (no JS-prop reassignment) and asserts skeleton rows appear, locking in the fix.

A diagnostic warning was added too: if `loading` is set and `_paint` finishes with no `.skeleton` rows in the body, the component logs a one-time `console.warn` naming the likely cause (stale registered class) plus the workaround (`data = data` to force a paint). Same tripwire pattern as the sticky-columns 0px warning.

## Events

| Name | `event.detail` |
|---|---|
| `wpd-table-filter-change` | `{ filters }` |
| `wpd-table-sort-change` | `{ sort }` (or `{ sort: null }`) |
| `wpd-table-selection-change` | `{ selection: id[], rows: T[] }` |
| `wpd-table-row-click` | `{ row, index, originalEvent }` (skips `data-noclick`) |
| `wpd-table-expand-change` | `{ row, index, expanded }` |

## Files changed

```
src/ui/components/wpd-table/
├── wpd-table.ts             ~1100 lines — component
├── wpd-table.styles.ts      Cell-opacity invariant + z-index ladder
└── wpd-table.test.ts        23 vitest tests

src/ui/core/component.ts     attributeChangedCallback / connectedCallback /
                             prop setter routed through requestUpdate()

src/ui/components/index.ts   Barrel export + WPD_COMPONENT_TAGS

docs/examples/data-table.md  Full DX-oriented example with TypeScript,
                             sort, selection, sticky-columns counting,
                             editable cells, common pitfalls, programmatic
                             API reference

docs/examples/README.md      Example index entry
CLAUDE.md                    docs/examples doc-tree map entry
```

## Tests

- 23 component tests covering empty / data-rendering / filter / sort / selection / sub-table / expand-API / loading / slot / sticky classes / `ResizeObserver` lifecycle / `recomputeLayout()` / live attribute toggling via `setAttribute`.
- Full project test suite: **513/513 green**.
- Lint + `tsc --noEmit` clean.
- Both Vite builds (dev + prod) clean.

Pixel layout (sticky `left` offsets, sticky-header pinning) isn't asserted in jsdom — it doesn't lay out CSS, so `offsetWidth` is always 0. Class application + lifecycle wiring is what's covered; visual correctness is verified manually in the showcase.

## Documentation

`docs/examples/data-table.md` covers:

- Minimum viable table (10-line happy path)
- TypeScript usage with the generic `WpdTable<T>`
- Per-column filters + persistence
- Sort (built-in and "react to header clicks for server-side sort")
- Selection with stable ids
- Sticky columns/header + sticky-columns counting worked example (auto-prepended expander/select columns count toward N)
- Sub-tables (infinite nesting, custom expanded content)
- Loading state
- Empty slot with CTA
- Custom cell renderers + best-practice (one return shape per column)
- Editable cells (with the focus-preservation footgun called out)
- Row clicks + `data-noclick`
- Full programmatic API reference
- Attributes / CSS custom properties / events / slots
- Common pitfalls (sticky-header without scroll container, sticky-columns counting, editable cells losing focus, selection going stale)

`CLAUDE.md` doc-tree was updated so future agents know to read / update `data-table.md` whenever the component contract changes.

## Test plan

- [ ] Open a native window, render `<wpd-table>` with a sample dataset
- [ ] Verify per-column filtering narrows rows in real time without losing input focus
- [ ] Click sortable headers → asc → desc → unsorted cycle works
- [ ] `selectable="multi"`: header select-all + per-row checkboxes; selection persists across `data` reassignment when `getRowId` is set
- [ ] `sticky-columns="2"` with 6+ columns: leftmost two stay pinned on horizontal scroll, opaque, with the soft drop-shadow on the band edge
- [ ] `sticky-header` + `--wpd-table-max-height: 400px`: header pins on vertical scroll
- [ ] Toggle `loading` attribute live (via `setAttribute`, no JS-prop reassignment): skeleton rows appear; toggle off → data rows return
- [ ] `subTable`: expander reveals nested table; `expandAll()` / `collapseAll()` work
- [ ] `<slot name="empty">` renders a CTA when data is empty (or filtered to nothing)
- [ ] RTL: sticky columns pin to the inline-start (right edge in RTL); shadow flips
- [ ] Resize the window, hide/show the panel: sticky offsets stay correct (no `console.warn`)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-33-66f43e163cf73cba97173f19dc99d09aacd091e6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->