### PR TITLE
Add `<wpd-spinner>` + OS Settings polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,8 @@ docs/
     ├── data-table.md            UPDATE/READ WHEN: <wpd-table> contract changes — column descriptor
     │                            shape, filter kinds, sticky-columns/header behavior, sub-table API,
     │                            or wpd-table-{filter-change,row-click,expand-change} event details.
+    ├── spinner.md               UPDATE/READ WHEN: <wpd-spinner> contract changes — preset list,
+    │                            attribute names, CSS-variable surface, or accessibility defaults.
     ├── register-icon.md        UPDATE/READ WHEN: wp_register_desktop_icon() contract changes.
     ├── register-wallpaper.md   UPDATE/READ WHEN: WallpaperDef or wp_register_desktop_wallpaper() changes.
     └── window-lifecycle.md     UPDATE/READ WHEN: window state machine / lifecycle hooks change.

--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -749,3 +749,108 @@
 	font-size: 12px;
 	color: #996800;
 }
+
+/* ---------------------------------------------------------------
+ * Window-fit scrolling.
+ *
+ * Without this block the OS Settings panel grows past the native
+ * window's viewport and the whole body scrolls — fine for short tabs
+ * but actively wrong for the Components tab, where a 200px nav rail
+ * and a tall detail pane should each scroll inside their own column,
+ * not in lockstep down a giant single-column page.
+ *
+ * Strategy:
+ *   1. The native window body normally has overflow:auto. Override it
+ *      to `hidden` ONLY when the OS Settings root is mounted (via
+ *      :has()) so other native windows keep their default page-scroll.
+ *   2. Make the OS Settings root a flex column that fills the body.
+ *      The tab strip + footer hug the top/bottom; the active
+ *      tabpanel takes the remaining height.
+ *   3. Each tabpanel scrolls itself (overflow:auto) — replaces the
+ *      whole-body scroll, visually identical for the simple tabs
+ *      (Appearance, AI, Extended) but pins the reset footer.
+ *   4. The Components tab opts OUT of overflow:auto so its inner
+ *      grid (nav + detail) can scroll independently per pane.
+ *
+ * `:has()` is supported in every evergreen engine (Chrome 105+,
+ * Safari 15.4+, Firefox 121+); fine for an admin-context shell.
+ * --------------------------------------------------------------- */
+.wp-desktop-window__body--native:has( .wp-desktop-os-settings ) {
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+}
+
+.wp-desktop-os-settings {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+/* The tab strip + footer must NOT shrink when the active panel
+   wants more height. Marking them flex-shrink:0 also keeps them
+   pinned visually as the panel below scrolls. */
+.wp-desktop-os-settings > wpd-tabs,
+.wp-desktop-os-settings > .wp-desktop-os-settings__footer {
+	flex: 0 0 auto;
+}
+
+.wp-desktop-os-settings > wpd-tabpanel {
+	flex: 1;
+	min-height: 0;
+	overflow: auto;
+}
+
+/* Components tab — split-pane layout. Don't scroll the whole panel;
+   let the inner grid distribute height to nav + detail, each with
+   their own overflow.
+ *
+ * The `:not([hidden])` guard is load-bearing: a bare
+ * `wpd-tabpanel[for='help'] { display: flex }` rule has specificity
+ * (0,0,2,1) which outranks the shadow-DOM `:host([hidden]) {
+ * display: none }` rule (specificity 0,0,1,0), so the panel would
+ * keep rendering when it should be hidden — bleeding the Components
+ * UI into every other tab. Pinning the rule to the visible state
+ * leaves the hidden state to the shadow-DOM default. */
+.wp-desktop-os-settings > wpd-tabpanel[ for='help' ]:not( [ hidden ] ) {
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+}
+.wp-desktop-os-settings
+	> wpd-tabpanel[ for='help' ]:not( [ hidden ] )
+	> wpd-panel {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.wp-desktop-os-settings__help {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+/* The intro card (Component library description) shouldn't grow —
+   it's content-sized so the grid below gets the remaining height. */
+.wp-desktop-os-settings__help > wpd-section {
+	flex: 0 0 auto;
+}
+.wp-desktop-os-settings__help-layout {
+	flex: 1;
+	min-height: 0;
+}
+
+/* Each split pane is its own scroll container. min-height:0 unlocks
+   shrinking in a grid item (default is `auto` which equals content
+   height — would defeat the overflow). max-height:100% pins the
+   pane to the grid track. */
+.wp-desktop-os-settings__help-nav,
+.wp-desktop-os-settings__help-detail {
+	min-height: 0;
+	max-height: 100%;
+	overflow-y: auto;
+}

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) || exit;
 - [Native window with tabs (auto-swap pattern)](./native-window-with-tabs.md)
 - [Layout primitives (body → panel → row → col)](./layout-primitives.md)
 - [Render a data table — filters, sticky columns, sub-tables](./data-table.md)
+- [Loading spinner — presets and color overrides](./spinner.md)
 - [Native windows — overview + render-callback contract](./native-windows.md)
 - [Open a file in the Code editor (deep-link from any window)](./code-editor-open.md)
 - [Cross-window devtools — instrumentation primitives](./devtools-instrumentation.md)

--- a/docs/examples/spinner.md
+++ b/docs/examples/spinner.md
@@ -1,0 +1,135 @@
+# Example: loading spinner
+
+`<wpd-spinner>` is a self-contained, animated WordPress-mark loading indicator with four curated presets and full per-attribute overrides. CSS variables drive both the disc color and the W-mark accent so the spinner matches any theme.
+
+> Status: **Experimental** since 0.18.0.
+
+## Drop-in
+
+```html
+<wpd-spinner></wpd-spinner>                              <!-- classic, 48px, WP blue -->
+<wpd-spinner preset="comet" size="80"></wpd-spinner>
+<wpd-spinner preset="orbit" color="#0f4c6b"></wpd-spinner>
+<wpd-spinner preset="pulse" accent="#fff8e7"></wpd-spinner>
+```
+
+## Presets
+
+| Preset | Look |
+|---|---|
+| `classic` (default) | Three concentric arcs, no dots, no pulse — the canonical WordPress loader. |
+| `comet` | Long arcs + 5 trailing dots all spinning the same way. Reads as a comet trail. |
+| `orbit` | Half-rings counter-rotating with an opacity breathe. Reads as a planetary orbit. |
+| `pulse` | Short arcs + 8 dots + scale + opacity pulse. Reads as a heartbeat. |
+
+Pick one and stop:
+
+```html
+<wpd-spinner preset="comet"></wpd-spinner>
+```
+
+Want to remix? Every knob from the prototype is overridable on the same element. Attribute-specified values win over the preset's defaults:
+
+```html
+<wpd-spinner preset="comet" sp1="6" dots="8"></wpd-spinner>
+```
+
+## Colors
+
+Two colors, both CSS-variable-driven:
+
+| Variable | Default | Drives |
+|---|---|---|
+| `--wpd-spinner-color` | `var(--wp-admin-theme-color, #21759b)` | Disc + ring + dot color |
+| `--wpd-spinner-accent` | `#fff` | The W mark inside the disc |
+| `--wpd-spinner-size` | `48px` | Host width/height |
+
+Set them via attribute shortcuts (HTML-friendly) or via CSS directly (themeable):
+
+```html
+<wpd-spinner color="#1a5f85" accent="#fff8e7" size="80"></wpd-spinner>
+```
+
+```css
+/* Theme override — works without touching markup */
+wpd-spinner.brand {
+    --wpd-spinner-color: #6f42c1;
+    --wpd-spinner-accent: #ffe;
+    --wpd-spinner-size: 64px;
+}
+```
+
+The accent (W mark) defaults to white because the canonical WP loader is white-on-blue, but it's a real CSS variable — set it to anything for dark-on-light marks, themed brands, or accessibility-driven contrast tweaks.
+
+## Sizing
+
+`size` accepts a bare number (treated as px) or any CSS length:
+
+```html
+<wpd-spinner size="32"></wpd-spinner>      <!-- 32px -->
+<wpd-spinner size="2em"></wpd-spinner>     <!-- 2em — scales with font-size -->
+<wpd-spinner size="clamp(40px, 6vw, 96px)"></wpd-spinner>
+```
+
+## Full attribute reference
+
+| Attribute | Type | What it does |
+|---|---|---|
+| `preset` | `"classic" \| "comet" \| "orbit" \| "pulse"` | Visual personality. Default `classic`. |
+| `size` | integer (px) or CSS length | Sets `--wpd-spinner-size`. |
+| `color` | CSS color | Sets `--wpd-spinner-color`. |
+| `accent` | CSS color | Sets `--wpd-spinner-accent` (the W). |
+| `sp1`, `sp2`, `sp3` | integer (deciseconds) | Per-ring rotation duration; 12 → 1.2s. |
+| `a1`, `a2`, `a3` | integer (0–100) | Per-ring arc length as % of circumference. |
+| `gap` | integer | Gap between concentric rings. |
+| `dir2`, `dir3` | `"1" \| "-1" \| "cw" \| "ccw"` | Per-ring direction; ring 1 is always CW. |
+| `pulse` | `"none" \| "scale" \| "opacity" \| "both"` | Pulse animation on the disc + W mark. |
+| `dots` | integer | Outer trailing dot count. Sensible: 0, 3, 5, 8. |
+| `label` | string | Accessible name. Default `"Loading"`. |
+
+## Accessibility
+
+The component renders an `<svg role="img" aria-label="Loading">`. Customize the label whenever the spinner has a more specific meaning:
+
+```html
+<wpd-spinner label="Saving changes"></wpd-spinner>
+<wpd-spinner label="Uploading 3 files"></wpd-spinner>
+```
+
+`prefers-reduced-motion: reduce` disables every animation inside the SVG; the mark + rings still render, just statically.
+
+## Common patterns
+
+**Inline with text** — the host is `display: inline-block; vertical-align: middle`:
+
+```html
+<button disabled>
+    <wpd-spinner size="16"></wpd-spinner>
+    Saving…
+</button>
+```
+
+**Centered overlay** — combine with `<wpd-empty-state>` or any container:
+
+```html
+<div class="loading-overlay">
+    <wpd-spinner preset="orbit" size="120"></wpd-spinner>
+</div>
+```
+
+**Programmatic preset switching** — the component re-paints on attribute change:
+
+```js
+spinner.setAttribute( 'preset', isError ? 'pulse' : 'classic' );
+```
+
+## Programmatic preset registry
+
+Need the preset config in JS (e.g. to render a "preset picker" UI)? The exported `WPD_SPINNER_PRESETS` is a frozen record of every config:
+
+```ts
+import { WPD_SPINNER_PRESETS, type WpdSpinnerPreset } from 'wp-desktop/ui';
+
+const names: WpdSpinnerPreset[] = Object.keys( WPD_SPINNER_PRESETS ) as WpdSpinnerPreset[];
+console.log( WPD_SPINNER_PRESETS.comet.dots ); // 5
+```

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -304,7 +304,7 @@ export class OsSettings implements SettingsCtx {
 			rows.push( {
 				id: 'help',
 				order: 40,
-				tab: html`<wpd-tab value="help">${ __( 'Help' ) }</wpd-tab>`,
+				tab: html`<wpd-tab value="help">${ __( 'Components' ) }</wpd-tab>`,
 				panel: html`<wpd-tabpanel for="help">
 					<wpd-panel>${ buildHelpSection() }</wpd-panel>
 				</wpd-tabpanel>`,

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -53,6 +53,12 @@ export type {
 	WpdTableSubTableFn,
 	WpdTableSubTableResult,
 } from './wpd-table/wpd-table';
+export { WpdSpinner, WPD_SPINNER_PRESETS } from './wpd-spinner/wpd-spinner';
+export type {
+	WpdSpinnerConfig,
+	WpdSpinnerPreset,
+	WpdSpinnerPulse,
+} from './wpd-spinner/wpd-spinner';
 
 // List of tags registered by this barrel. `doAction(
 // COMPONENTS_REGISTERED, { tags } )` fires once from
@@ -99,4 +105,5 @@ export const WPD_COMPONENT_TAGS = [
 	'wpd-steps',
 	'wpd-step',
 	'wpd-table',
+	'wpd-spinner',
 ] as const;

--- a/src/ui/components/wpd-spinner/wpd-spinner.styles.ts
+++ b/src/ui/components/wpd-spinner/wpd-spinner.styles.ts
@@ -1,0 +1,68 @@
+import { css } from '../../core';
+
+export const styles = css`
+	:host {
+		display: inline-block;
+		--wpd-spinner-color: var(
+			--wp-admin-theme-color,
+			#21759b
+		);
+		--wpd-spinner-accent: #fff;
+		--wpd-spinner-size: 48px;
+		width: var( --wpd-spinner-size );
+		height: var( --wpd-spinner-size );
+		/* SVG inner elements use currentColor for the primary fill /
+		   stroke; inheriting the host's text color makes a single
+		   variable drive every ring. */
+		color: var( --wpd-spinner-color );
+		vertical-align: middle;
+		line-height: 0;
+	}
+	:host( [ hidden ] ) {
+		display: none;
+	}
+
+	.root,
+	.root svg {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	/* The W mark inside the disc — accent color, defaults to white,
+	   configurable via the host's --wpd-spinner-accent (or the
+	   shorthand "accent" attribute). */
+	.root svg .mark {
+		fill: var( --wpd-spinner-accent, #fff );
+	}
+
+	@keyframes wpd-spinner-spin {
+		to {
+			transform: rotate( 360deg );
+		}
+	}
+	@keyframes wpd-spinner-scale {
+		0%,
+		100% {
+			transform: scale( 1 );
+		}
+		50% {
+			transform: scale( 1.045 );
+		}
+	}
+	@keyframes wpd-spinner-opacity {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.7;
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.root svg [ style*='animation' ] {
+			animation: none !important;
+		}
+	}
+`;

--- a/src/ui/components/wpd-spinner/wpd-spinner.test.ts
+++ b/src/ui/components/wpd-spinner/wpd-spinner.test.ts
@@ -1,0 +1,180 @@
+/**
+ * `<wpd-spinner>` — smoke tests covering preset selection, attribute
+ * overrides, the CSS-variable color/accent/size sync, and the
+ * accessibility surface (role + aria-label).
+ *
+ * Pixel-level animation timing is a runtime concern (jsdom doesn't
+ * lay out CSS animations); these tests assert the shape of the
+ * rendered SVG and that knobs reach the right places.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import './wpd-spinner';
+// eslint-disable-next-line no-duplicate-imports
+import { WPD_SPINNER_PRESETS } from './wpd-spinner';
+
+const tick = (): Promise< void > =>
+	new Promise( ( r ) => queueMicrotask( () => queueMicrotask( () => r() ) ) );
+
+describe( '<wpd-spinner>', () => {
+	let host: HTMLElement;
+	beforeEach( () => {
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+	} );
+	afterEach( () => host.remove() );
+
+	test( 'renders an SVG with role=img and the default aria-label', async () => {
+		host.innerHTML = `<wpd-spinner></wpd-spinner>`;
+		await tick();
+		const spinner = host.querySelector( 'wpd-spinner' )!;
+		const svg = spinner.shadowRoot!.querySelector( 'svg' );
+		expect( svg ).not.toBeNull();
+		expect( svg!.getAttribute( 'role' ) ).toBe( 'img' );
+		expect( svg!.getAttribute( 'aria-label' ) ).toBe( 'Loading' );
+	} );
+
+	test( '`label` attribute customizes the SVG\'s aria-label', async () => {
+		host.innerHTML = `<wpd-spinner label="Saving changes"></wpd-spinner>`;
+		await tick();
+		const svg = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		expect( svg.getAttribute( 'aria-label' ) ).toBe( 'Saving changes' );
+	} );
+
+	test( 'classic preset renders without trailing dots; comet adds them', async () => {
+		host.innerHTML = `<wpd-spinner preset="classic"></wpd-spinner>`;
+		await tick();
+		const classic = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		// Classic has zero dots — six base circles (3 tracks + 3 active arcs)
+		// plus the disc, totalling 7 circles inside the SVG.
+		expect( classic.querySelectorAll( 'circle' ).length ).toBe( 7 );
+
+		host.innerHTML = `<wpd-spinner preset="comet"></wpd-spinner>`;
+		await tick();
+		const comet = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		// Comet adds 5 dots → 7 + 5 = 12.
+		expect( comet.querySelectorAll( 'circle' ).length ).toBe(
+			7 + WPD_SPINNER_PRESETS.comet.dots,
+		);
+	} );
+
+	test( 'individual attributes override the active preset', async () => {
+		// Comet defaults to 5 dots; override to 8.
+		host.innerHTML = `<wpd-spinner preset="comet" dots="8"></wpd-spinner>`;
+		await tick();
+		const svg = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		expect( svg.querySelectorAll( 'circle' ).length ).toBe( 7 + 8 );
+	} );
+
+	test( 'unknown preset name falls back to classic', async () => {
+		host.innerHTML = `<wpd-spinner preset="not-a-real-preset"></wpd-spinner>`;
+		await tick();
+		const svg = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		// Classic = 0 dots = 7 circles.
+		expect( svg.querySelectorAll( 'circle' ).length ).toBe( 7 );
+	} );
+
+	test( 'color/accent/size attributes write CSS variables on the host', async () => {
+		host.innerHTML = `<wpd-spinner
+			color="#1a5f85"
+			accent="#fff8e7"
+			size="80"
+		></wpd-spinner>`;
+		await tick();
+		const spinner = host.querySelector( 'wpd-spinner' ) as HTMLElement;
+		expect( spinner.style.getPropertyValue( '--wpd-spinner-color' ).trim() ).toBe(
+			'#1a5f85',
+		);
+		expect(
+			spinner.style.getPropertyValue( '--wpd-spinner-accent' ).trim(),
+		).toBe( '#fff8e7' );
+		// Bare integer → px.
+		expect( spinner.style.getPropertyValue( '--wpd-spinner-size' ).trim() ).toBe(
+			'80px',
+		);
+	} );
+
+	test( '`size` accepts CSS lengths verbatim', async () => {
+		host.innerHTML = `<wpd-spinner size="2em"></wpd-spinner>`;
+		await tick();
+		const spinner = host.querySelector( 'wpd-spinner' ) as HTMLElement;
+		expect( spinner.style.getPropertyValue( '--wpd-spinner-size' ).trim() ).toBe(
+			'2em',
+		);
+	} );
+
+	test( 'removing color/accent attributes clears the CSS variables', async () => {
+		host.innerHTML = `<wpd-spinner color="red" accent="black"></wpd-spinner>`;
+		await tick();
+		const spinner = host.querySelector( 'wpd-spinner' ) as HTMLElement;
+		expect( spinner.style.getPropertyValue( '--wpd-spinner-color' ) ).toBe(
+			'red',
+		);
+		spinner.removeAttribute( 'color' );
+		spinner.removeAttribute( 'accent' );
+		await tick();
+		expect( spinner.style.getPropertyValue( '--wpd-spinner-color' ) ).toBe(
+			'',
+		);
+		expect( spinner.style.getPropertyValue( '--wpd-spinner-accent' ) ).toBe(
+			'',
+		);
+	} );
+
+	test( 'pulse="both" wires both scale + opacity animations onto the disc group', async () => {
+		host.innerHTML = `<wpd-spinner pulse="both"></wpd-spinner>`;
+		await tick();
+		const svg = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		const discGroup = svg.querySelector( 'g' ) as SVGGElement;
+		const style = discGroup.getAttribute( 'style' ) || '';
+		expect( style ).toContain( 'wpd-spinner-scale' );
+		expect( style ).toContain( 'wpd-spinner-opacity' );
+	} );
+
+	test( 'dir2="-1" reverses ring 2 via animation-direction reverse', async () => {
+		host.innerHTML = `<wpd-spinner dir2="-1"></wpd-spinner>`;
+		await tick();
+		const svg = host
+			.querySelector( 'wpd-spinner' )!
+			.shadowRoot!.querySelector( 'svg' )!;
+		// Active ring circles are the ones with stroke-dasharray.
+		const activeRings = svg.querySelectorAll(
+			'circle[stroke-dasharray]',
+		);
+		// Ring 2 is the second active ring (index 1).
+		const ring2Style = ( activeRings[ 1 ] as SVGCircleElement ).getAttribute(
+			'style',
+		);
+		expect( ring2Style ).toMatch( /reverse/ );
+	} );
+
+	test( 'live attribute change re-paints the SVG', async () => {
+		// Regression: the architectural fix in component.ts means
+		// attribute changes route through requestUpdate, which we
+		// override to schedule a paint. Toggle preset and verify the
+		// dot count changes accordingly.
+		host.innerHTML = `<wpd-spinner preset="classic"></wpd-spinner>`;
+		await tick();
+		const spinner = host.querySelector( 'wpd-spinner' )!;
+		expect(
+			spinner.shadowRoot!.querySelectorAll( 'svg circle' ).length,
+		).toBe( 7 );
+
+		spinner.setAttribute( 'preset', 'pulse' );
+		await tick();
+		expect(
+			spinner.shadowRoot!.querySelectorAll( 'svg circle' ).length,
+		).toBe( 7 + WPD_SPINNER_PRESETS.pulse.dots );
+	} );
+} );

--- a/src/ui/components/wpd-spinner/wpd-spinner.ts
+++ b/src/ui/components/wpd-spinner/wpd-spinner.ts
@@ -1,0 +1,508 @@
+/**
+ * `<wpd-spinner>` — animated WordPress-mark loading indicator.
+ *
+ * Drop-in:
+ *
+ * ```html
+ * <wpd-spinner></wpd-spinner>                              <!-- classic, 48px, WP blue -->
+ * <wpd-spinner preset="comet" size="80"></wpd-spinner>
+ * <wpd-spinner preset="orbit" color="#0f4c6b"></wpd-spinner>
+ * <wpd-spinner preset="pulse" accent="#fff8e7"></wpd-spinner>
+ * ```
+ *
+ * ## Presets
+ *
+ * Four curated looks. Pick one with the `preset` attribute; every
+ * other knob (speeds, arc lengths, ring directions, pulse, dot count)
+ * defaults to the preset's value but can be individually overridden:
+ *
+ *   - `classic` (default) — clean three-ring WordPress mark.
+ *   - `comet` — long arcs + 5 trailing dots, all spinning the same
+ *     way. Reads as a comet trail.
+ *   - `orbit` — half-rings counter-rotating with an opacity breathe.
+ *     Reads as planetary orbit.
+ *   - `pulse` — short arcs + 8 dots + scale + opacity pulse. Reads
+ *     as a heartbeat.
+ *
+ * Override anything from the preset:
+ *
+ * ```html
+ * <wpd-spinner preset="comet" sp1="6" dots="8"></wpd-spinner>
+ * ```
+ *
+ * ## Color model
+ *
+ * Two colors are driven by CSS custom properties — set them via the
+ * `color` / `accent` attributes (string shortcuts) or via CSS
+ * directly. The accent (the W mark inside the disc) defaults to
+ * white but is fully configurable so a dark-on-light mark works the
+ * same way as the canonical white-on-blue.
+ *
+ *   - `--wpd-spinner-color` — disc + ring + dot color. Default:
+ *     `var( --wp-admin-theme-color, #21759b )`.
+ *   - `--wpd-spinner-accent` — W-mark color. Default: `#fff`.
+ *   - `--wpd-spinner-size` — host width/height. Default: `48px`.
+ *     The shorthand `size` attribute writes a px value here.
+ *
+ * ## Reduced motion
+ *
+ * `prefers-reduced-motion: reduce` disables every animation inside
+ * the SVG. The mark + rings still render statically.
+ *
+ * @since 0.18.0
+ */
+
+import { Component, defineComponent, html, type TemplateResult } from '../../core';
+import { styles } from './wpd-spinner.styles';
+
+export type WpdSpinnerPreset = 'classic' | 'comet' | 'orbit' | 'pulse';
+
+export type WpdSpinnerPulse = 'none' | 'scale' | 'opacity' | 'both';
+
+/**
+ * Numeric configuration shape mirrored from the prototype. `sp*`
+ * values are deciseconds (sp1=12 → 1.2s); arcs are 0–100 percent
+ * of the ring's circumference. `dir2` / `dir3` flip ring direction;
+ * ring 1 is always clockwise (the "anchor" ring).
+ */
+export interface WpdSpinnerConfig {
+	sp1: number;
+	sp2: number;
+	sp3: number;
+	a1: number;
+	a2: number;
+	a3: number;
+	gap: number;
+	dir2: 1 | -1;
+	dir3: 1 | -1;
+	pulse: WpdSpinnerPulse;
+	dots: number;
+}
+
+/**
+ * The four curated presets. Tuned so each reads as a distinct
+ * "personality" at any size — classic is the canonical WP loader,
+ * the other three each emphasise a different visual idea
+ * (trails / orbit / pulse).
+ */
+export const WPD_SPINNER_PRESETS: Readonly<
+	Record< WpdSpinnerPreset, Readonly< WpdSpinnerConfig > >
+> = Object.freeze( {
+	classic: {
+		sp1: 12,
+		sp2: 24,
+		sp3: 40,
+		a1: 28,
+		a2: 15,
+		a3: 8,
+		gap: 4,
+		dir2: 1,
+		dir3: -1,
+		pulse: 'none',
+		dots: 0,
+	},
+	comet: {
+		sp1: 8,
+		sp2: 14,
+		sp3: 26,
+		a1: 50,
+		a2: 28,
+		a3: 12,
+		gap: 3,
+		dir2: 1,
+		dir3: 1,
+		pulse: 'none',
+		dots: 5,
+	},
+	orbit: {
+		sp1: 10,
+		sp2: 10,
+		sp3: 32,
+		a1: 50,
+		a2: 50,
+		a3: 8,
+		gap: 5,
+		dir2: -1,
+		dir3: -1,
+		pulse: 'opacity',
+		dots: 3,
+	},
+	pulse: {
+		sp1: 6,
+		sp2: 18,
+		sp3: 30,
+		a1: 20,
+		a2: 12,
+		a3: 6,
+		gap: 4,
+		dir2: 1,
+		dir3: -1,
+		pulse: 'both',
+		dots: 8,
+	},
+} );
+
+/**
+ * Geometry constants from the original WordPress mark SVG. The disc
+ * radius (DISC_R) and centre (CX/CY) are baked into the path data —
+ * don't change them without re-deriving the W path coordinates.
+ */
+const CX = 61.26;
+const CY = 61.26;
+const DISC_R = 58.453;
+
+/**
+ * Compound paths for the WordPress "W" mark. Lifted as-is from the
+ * original SVG. Drawn over the disc using `--wpd-spinner-accent`
+ * (white by default) so the same paths work on any disc color.
+ */
+const W_PATHS =
+	'<path d="m8.708 61.26c0 20.802 12.089 38.779 29.619 47.298l-25.069-68.686c-2.916 6.536-4.55 13.769-4.55 21.388z"/>' +
+	'<path d="m96.74 58.608c0-6.495-2.333-10.993-4.334-14.494-2.664-4.329-5.161-7.995-5.161-12.324 0-4.831 3.664-9.328 8.825-9.328.233 0 .454.029.681.042-9.35-8.566-21.807-13.796-35.489-13.796-18.36 0-34.513 9.42-43.91 23.688 1.233.037 2.395.063 3.382.063 5.497 0 14.006-.667 14.006-.667 2.833-.167 3.167 3.994.337 4.329 0 0-2.847.335-6.015.501l19.138 56.925 11.501-34.493-8.188-22.434c-2.83-.166-5.511-.501-5.511-.501-2.832-.166-2.5-4.496.332-4.329 0 0 8.679.667 13.843.667 5.496 0 14.006-.667 14.006-.667 2.835-.167 3.168 3.994.337 4.329 0 0-2.853.335-6.015.501l18.992 56.494 5.242-17.517c2.272-7.269 4.001-12.49 4.001-16.989z"/>' +
+	'<path d="m62.184 65.857-15.768 45.819c4.708 1.384 9.687 2.141 14.846 2.141 6.12 0 11.989-1.058 17.452-2.979-.141-.225-.269-.464-.374-.724z"/>' +
+	'<path d="m107.376 36.046c.226 1.674.354 3.471.354 5.404 0 5.333-.996 11.328-3.996 18.824l-16.053 46.413c15.624-9.111 26.133-26.038 26.133-45.426.001-9.137-2.333-17.729-6.438-25.215z"/>';
+
+export class WpdSpinner extends Component {
+	static props = [
+		'preset',
+		'size',
+		'color',
+		'accent',
+		'sp1',
+		'sp2',
+		'sp3',
+		'a1',
+		'a2',
+		'a3',
+		'gap',
+		'dir2',
+		'dir3',
+		'pulse',
+		'dots',
+		'label',
+	] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Spinner',
+		summary:
+			'Animated WordPress-mark loading indicator with four curated presets and full per-attribute overrides. CSS variables drive disc + accent colors and size; reduced-motion preferences are respected.',
+		status: 'experimental',
+		since: '0.18.0',
+		props: [
+			{
+				name: 'preset',
+				type: '"classic" | "comet" | "orbit" | "pulse"',
+				default: 'classic',
+				description:
+					'Visual personality. Every other attribute defaults to the preset\'s value and can be overridden individually.',
+			},
+			{
+				name: 'size',
+				type: 'integer (px) or CSS length',
+				default: '48',
+				description:
+					'Sets `--wpd-spinner-size`. Bare numbers are treated as px; pass a CSS length (e.g. `2em`) to opt into ems / rems.',
+			},
+			{
+				name: 'color',
+				type: 'CSS color',
+				description:
+					'Disc + ring + dot color. Sets `--wpd-spinner-color`. Default inherits the WP admin theme color.',
+			},
+			{
+				name: 'accent',
+				type: 'CSS color',
+				default: '#fff',
+				description:
+					'Color of the W mark inside the disc. Sets `--wpd-spinner-accent`. Default white — change for dark-on-light or themed marks.',
+			},
+			{
+				name: 'sp1, sp2, sp3',
+				type: 'integer (deciseconds)',
+				description:
+					'Per-ring rotation duration in tenths-of-a-second (12 → 1.2s). Higher = slower.',
+			},
+			{
+				name: 'a1, a2, a3',
+				type: 'integer (0-100)',
+				description: 'Per-ring arc length as a percentage of the ring circumference.',
+			},
+			{
+				name: 'gap',
+				type: 'integer',
+				description: 'Gap between concentric rings (units approximate to px at 120-viewport).',
+			},
+			{
+				name: 'dir2, dir3',
+				type: '"1" | "-1" | "cw" | "ccw"',
+				description: 'Per-ring direction; ring 1 is always clockwise.',
+			},
+			{
+				name: 'pulse',
+				type: '"none" | "scale" | "opacity" | "both"',
+				description: 'Pulse animation applied to the disc + W mark.',
+			},
+			{
+				name: 'dots',
+				type: 'integer',
+				description: 'Outer trailing dot count. Sensible values: 0, 3, 5, 8.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				default: 'Loading',
+				description: 'Accessible name for the SVG (`role="img"` + `aria-label`).',
+			},
+		],
+		cssProps: [
+			{ name: '--wpd-spinner-color', default: 'var(--wp-admin-theme-color, #21759b)' },
+			{ name: '--wpd-spinner-accent', default: '#fff' },
+			{ name: '--wpd-spinner-size', default: '48px' },
+		],
+		example: html`<wpd-spinner preset="comet" size="80"></wpd-spinner>`,
+	} as const;
+
+	private _paintScheduled = false;
+
+	connectedCallback(): void {
+		super.connectedCallback();
+		this._schedulePaint();
+	}
+
+	protected render(): TemplateResult {
+		// Static skeleton — the actual SVG is painted imperatively.
+		// SVG can't be reliably built via the html template tag because
+		// inner SVG elements parse in HTML namespace when nested
+		// templates are involved.
+		return html`<div class="root" part="root"></div>`;
+	}
+
+	protected requestUpdate(): void {
+		super.requestUpdate();
+		this._schedulePaint();
+	}
+
+	private _schedulePaint(): void {
+		if ( this._paintScheduled || ! this.isConnected ) {
+			return;
+		}
+		this._paintScheduled = true;
+		queueMicrotask( () => {
+			this._paintScheduled = false;
+			if ( ! this.isConnected ) {
+				return;
+			}
+			this._paint();
+		} );
+	}
+
+	private _paint(): void {
+		this._syncCssVars();
+		const root = this.shadowRoot?.querySelector(
+			'.root',
+		) as HTMLElement | null;
+		if ( ! root ) {
+			return;
+		}
+		root.innerHTML = this._buildSvg();
+	}
+
+	/**
+	 * Reflect the color / accent / size attributes onto CSS custom
+	 * properties on the host. Removing the attribute clears the var
+	 * so the default cascades back in.
+	 */
+	private _syncCssVars(): void {
+		const sync = (
+			attr: string,
+			varName: string,
+			transform?: ( v: string ) => string,
+		): void => {
+			const v = this.getAttribute( attr );
+			if ( v === null ) {
+				this.style.removeProperty( varName );
+			} else {
+				this.style.setProperty(
+					varName,
+					transform ? transform( v ) : v,
+				);
+			}
+		};
+		sync( 'color', '--wpd-spinner-color' );
+		sync( 'accent', '--wpd-spinner-accent' );
+		sync( 'size', '--wpd-spinner-size', ( v ) =>
+			/^-?\d+(\.\d+)?$/.test( v.trim() ) ? `${ v }px` : v,
+		);
+	}
+
+	private _effectiveConfig(): WpdSpinnerConfig {
+		const presetName = this.getAttribute( 'preset' ) ?? 'classic';
+		const preset =
+			WPD_SPINNER_PRESETS[ presetName as WpdSpinnerPreset ] ??
+			WPD_SPINNER_PRESETS.classic;
+
+		const num = ( attr: string, fallback: number ): number => {
+			const v = this.getAttribute( attr );
+			if ( v === null ) {
+				return fallback;
+			}
+			const n = parseFloat( v );
+			return Number.isFinite( n ) ? n : fallback;
+		};
+		const dir = ( attr: string, fallback: 1 | -1 ): 1 | -1 => {
+			const v = this.getAttribute( attr );
+			if ( v === null ) {
+				return fallback;
+			}
+			const lc = v.toLowerCase();
+			if ( lc === '-1' || lc === 'ccw' || lc === 'reverse' ) {
+				return -1;
+			}
+			return 1;
+		};
+		const pulse = (): WpdSpinnerPulse => {
+			const v = this.getAttribute( 'pulse' );
+			if (
+				v === 'scale' ||
+				v === 'opacity' ||
+				v === 'both' ||
+				v === 'none'
+			) {
+				return v;
+			}
+			return preset.pulse;
+		};
+
+		return {
+			sp1: num( 'sp1', preset.sp1 ),
+			sp2: num( 'sp2', preset.sp2 ),
+			sp3: num( 'sp3', preset.sp3 ),
+			a1: num( 'a1', preset.a1 ),
+			a2: num( 'a2', preset.a2 ),
+			a3: num( 'a3', preset.a3 ),
+			gap: num( 'gap', preset.gap ),
+			dir2: dir( 'dir2', preset.dir2 ),
+			dir3: dir( 'dir3', preset.dir3 ),
+			pulse: pulse(),
+			dots: Math.max( 0, Math.floor( num( 'dots', preset.dots ) ) ),
+		};
+	}
+
+	private _buildSvg(): string {
+		const cfg = this._effectiveConfig();
+		const label = escAttr( this.getAttribute( 'label' ) ?? 'Loading' );
+
+		const pad = cfg.gap * 3 + 14;
+		const vbMin = -pad;
+		const vbSize = 122.52 + pad * 2;
+
+		const r1 = DISC_R + cfg.gap + 2;
+		const r2 = r1 + cfg.gap + 2;
+		const r3 = r2 + cfg.gap + 1.5;
+
+		const ring1Anim = `animation: wpd-spinner-spin ${ ( cfg.sp1 / 10 ).toFixed( 2 ) }s linear infinite`;
+		const ring2Anim = `animation: wpd-spinner-spin ${ ( cfg.sp2 / 10 ).toFixed( 2 ) }s linear infinite${
+			cfg.dir2 < 0 ? ' reverse' : ''
+		}`;
+		const ring3Anim = `animation: wpd-spinner-spin ${ ( cfg.sp3 / 10 ).toFixed( 2 ) }s linear infinite${
+			cfg.dir3 < 0 ? ' reverse' : ''
+		}`;
+
+		// Pulse durations scale with ring 1 so a fast spinner pulses
+		// fast and a slow one breathes — matches the prototype's feel.
+		const pspd = ( ( cfg.sp1 * 1.8 ) / 10 ).toFixed( 1 );
+		const ospd = ( ( cfg.sp1 * 2.3 ) / 10 ).toFixed( 1 );
+		let pulseStyle = '';
+		if ( cfg.pulse === 'scale' ) {
+			pulseStyle = `animation: wpd-spinner-scale ${ pspd }s ease-in-out infinite`;
+		} else if ( cfg.pulse === 'opacity' ) {
+			pulseStyle = `animation: wpd-spinner-opacity ${ ospd }s ease-in-out infinite`;
+		} else if ( cfg.pulse === 'both' ) {
+			pulseStyle = `animation: wpd-spinner-scale ${ pspd }s ease-in-out infinite, wpd-spinner-opacity ${ ospd }s ease-in-out infinite`;
+		}
+
+		// Trailing dots — equally-spaced points on a fourth ring,
+		// rotated together with ring 1's tempo so they read as a tail.
+		let dotEls = '';
+		if ( cfg.dots > 0 ) {
+			const dr = r3 + cfg.gap + 1;
+			const dc2 = 2 * Math.PI * dr;
+			const dsz = 1.6;
+			const dotDur = ( ( cfg.sp1 * 0.65 ) / 10 ).toFixed( 2 );
+			for ( let i = 0; i < cfg.dots; i++ ) {
+				const offset = -( i / cfg.dots ) * dc2;
+				dotEls +=
+					`<circle cx="${ CX }" cy="${ CY }" r="${ dr.toFixed( 2 ) }"` +
+					` fill="none" stroke="currentColor" stroke-width="${ dsz }"` +
+					` stroke-dasharray="${ dsz.toFixed( 2 ) } ${ ( dc2 - dsz ).toFixed( 2 ) }"` +
+					` stroke-dashoffset="${ offset.toFixed( 2 ) }"` +
+					` stroke-linecap="round" stroke-opacity="0.65"` +
+					` style="transform-origin:${ CX }px ${ CY }px;animation: wpd-spinner-spin ${ dotDur }s linear infinite"/>`;
+			}
+		}
+
+		return (
+			`<svg xmlns="http://www.w3.org/2000/svg"` +
+			` viewBox="${ vbMin } ${ vbMin } ${ vbSize } ${ vbSize }"` +
+			` role="img" aria-label="${ label }">` +
+			`<g style="transform-origin:${ CX }px ${ CY }px${ pulseStyle ? ';' + pulseStyle : '' }">` +
+			`<circle cx="${ CX }" cy="${ CY }" r="${ DISC_R }" fill="currentColor"/>` +
+			`<g class="mark">${ W_PATHS }</g>` +
+			`</g>` +
+			// Ring 1 — anchor track + active arc.
+			`<circle cx="${ CX }" cy="${ CY }" r="${ r1.toFixed( 2 ) }"` +
+			` fill="none" stroke="currentColor" stroke-width="0.6" stroke-opacity="0.2"/>` +
+			`<circle cx="${ CX }" cy="${ CY }" r="${ r1.toFixed( 2 ) }"` +
+			` fill="none" stroke="currentColor" stroke-width="2.2"` +
+			` stroke-dasharray="${ dasharray( r1, cfg.a1 ) }"` +
+			` stroke-linecap="round"` +
+			` style="transform-origin:${ CX }px ${ CY }px;${ ring1Anim }"/>` +
+			// Ring 2.
+			`<circle cx="${ CX }" cy="${ CY }" r="${ r2.toFixed( 2 ) }"` +
+			` fill="none" stroke="currentColor" stroke-width="0.5" stroke-opacity="0.15"/>` +
+			`<circle cx="${ CX }" cy="${ CY }" r="${ r2.toFixed( 2 ) }"` +
+			` fill="none" stroke="currentColor" stroke-width="1.6" stroke-opacity="0.8"` +
+			` stroke-dasharray="${ dasharray( r2, cfg.a2 ) }"` +
+			` stroke-linecap="round"` +
+			` style="transform-origin:${ CX }px ${ CY }px;${ ring2Anim }"/>` +
+			// Ring 3.
+			`<circle cx="${ CX }" cy="${ CY }" r="${ r3.toFixed( 2 ) }"` +
+			` fill="none" stroke="currentColor" stroke-width="0.4" stroke-opacity="0.12"/>` +
+			`<circle cx="${ CX }" cy="${ CY }" r="${ r3.toFixed( 2 ) }"` +
+			` fill="none" stroke="currentColor" stroke-width="1.0" stroke-opacity="0.6"` +
+			` stroke-dasharray="${ dasharray( r3, cfg.a3 ) }"` +
+			` stroke-linecap="round"` +
+			` style="transform-origin:${ CX }px ${ CY }px;${ ring3Anim }"/>` +
+			dotEls +
+			`</svg>`
+		);
+	}
+}
+
+/**
+ * Compute the `stroke-dasharray` pair (visible, gap) that draws an
+ * arc covering `pct`% of a circle of radius `r`.
+ */
+function dasharray( r: number, pct: number ): string {
+	const c = 2 * Math.PI * r;
+	const visible = ( pct / 100 ) * c;
+	const gap = c - visible;
+	return `${ visible.toFixed( 2 ) } ${ gap.toFixed( 2 ) }`;
+}
+
+/**
+ * Minimal HTML attribute escape for user-provided strings (color
+ * values, the aria-label). We never accept arbitrary markup, but
+ * setting `innerHTML` from `aria-label` content makes belt-and-braces
+ * escaping cheap insurance.
+ */
+function escAttr( s: string ): string {
+	return String( s )
+		.replace( /&/g, '&amp;' )
+		.replace( /"/g, '&quot;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' );
+}
+
+defineComponent( 'wpd-spinner', WpdSpinner );


### PR DESCRIPTION
## Summary
<img width="266" height="229" alt="Spinner" src="https://github.com/user-attachments/assets/101c830e-8ad2-49db-a473-90155c276526" />

Three changes:

1. **New `<wpd-spinner>` component** — animated WordPress-mark loading indicator with four curated presets and full per-attribute overrides.
2. **Renamed "Help" tab → "Components"** in OS Settings to match what the tab actually shows (the wpd-* component reference).
3. **Window-fit scrolling for OS Settings** — each tab now scrolls inside its own viewport instead of stretching the entire window body, and the Components tab's split view scrolls each pane independently.

## 1. `<wpd-spinner>`

Drop-in:

```html
<wpd-spinner></wpd-spinner>                              <!-- classic, 48px, WP blue -->
<wpd-spinner preset="comet" size="80"></wpd-spinner>
<wpd-spinner preset="orbit" color="#0f4c6b"></wpd-spinner>
<wpd-spinner preset="pulse" accent="#fff8e7"></wpd-spinner>
```

### Four curated presets

| Preset | Look |
|---|---|
| `classic` (default) | Three concentric arcs, no dots, no pulse — the canonical WordPress loader. |
| `comet` | Long arcs + 5 trailing dots all spinning the same way — reads as a comet trail. |
| `orbit` | Half-rings counter-rotating with an opacity breathe — reads as planetary orbit. |
| `pulse` | Short arcs + 8 dots + scale + opacity pulse — reads as a heartbeat. |

Pick one and stop. Or override anything from the preset on the same element — speeds, arc lengths, ring directions, pulse mode, dot count are all individual attributes that win over the preset's defaults:

```html
<wpd-spinner preset="comet" sp1="6" dots="8"></wpd-spinner>
```

### Color model

Two CSS variables, both with attribute shortcuts. The accent (the W mark inside the disc) defaults to white but is fully configurable so dark-on-light marks, themed brands, or accessibility-driven contrast tweaks work the same way as the canonical white-on-blue:

| Variable | Attribute shortcut | Default |
|---|---|---|
| `--wpd-spinner-color` | `color="…"` | `var(--wp-admin-theme-color, #21759b)` |
| `--wpd-spinner-accent` | `accent="…"` | `#fff` |
| `--wpd-spinner-size` | `size="…"` | `48px` |

`size` accepts a bare number (treated as px) or any CSS length (`2em`, `clamp(40px, 6vw, 96px)`).

### Accessibility

`<svg role="img" aria-label="Loading">` by default; override via `label="…"`. `prefers-reduced-motion: reduce` disables every animation inside the SVG — the mark + rings still render, just statically.

### TypeScript surface

```ts
import {
    WPD_SPINNER_PRESETS,
    type WpdSpinnerPreset,
    type WpdSpinnerConfig,
    type WpdSpinnerPulse,
} from 'wp-desktop/ui';
```

`WPD_SPINNER_PRESETS` is a frozen record of every preset config — useful for building a preset-picker UI.

## 2. "Help" → "Components"

The tab label was a holdover from when the tab held mixed help content. It now exclusively shows the wpd-* component reference (props, slots, events, CSS variables, live examples), so the new label says what's actually there. Internal IDs (`id: 'help'`, `for="help"`, `help.ts`) stay put — only the user-facing string changed.

## 3. Window-fit scrolling

Before this change, the OS Settings panel grew past the window's viewport and the entire body scrolled — fine for short tabs, but actively wrong for the Components tab where the 200px nav rail and the tall detail pane scrolled in lockstep down a giant single-column page.

After:

1. **Per-tab scroll instead of whole-body scroll.** The native window body becomes `overflow: hidden` (only when the OS Settings root is mounted, scoped via `:has()` so other native windows are unaffected). The OS Settings root is a flex column that fills the body. Tab strip + reset footer hug the top/bottom; the active tabpanel takes the remaining height and scrolls itself.
2. **Components tab gets independent split-pane scroll.** The tabpanel for Components opts out of the per-panel scroll and uses a flex column instead. Its inner grid fills the available height; the nav rail and detail pane each scroll inside their own column. Scrolling the left side no longer drags the right.
3. **Reset footer is now pinned.** Always visible without scrolling all the way down — drops a UX paper cut on the long Appearance tab.

`:has()` is supported in every evergreen engine (Chrome 105+, Safari 15.4+, Firefox 121+); fine for an admin-context shell.

## Files changed

```
src/ui/components/wpd-spinner/
├── wpd-spinner.ts             ~470 lines — component
├── wpd-spinner.styles.ts      Host CSS variables + keyframes
└── wpd-spinner.test.ts        11 vitest tests

src/ui/components/index.ts     Barrel + WPD_COMPONENT_TAGS

src/settings/index.ts          "Help" → "Components" label

assets/css/os-settings.css     Window-fit scrolling (flex column,
                               per-panel overflow, split-pane grid)

docs/examples/spinner.md       Full DX example with presets, colors,
                               sizing, a11y, common patterns,
                               programmatic registry
docs/examples/README.md        Example index entry
CLAUDE.md                      docs/examples doc-tree map entry
```

## Tests

- 11 new wpd-spinner tests covering: SVG shape + role, preset selection, attribute overrides, unknown-preset fallback, color/accent/size CSS-variable sync, length-vs-px size handling, attribute removal cleanup, pulse animation wiring, ring-direction reversal, live attribute repaint.
- Full project test suite: **524/524 green**.
- Lint + `tsc --noEmit` clean.
- Both Vite builds (dev + prod) clean.

## Test plan

- [ ] Drop a `<wpd-spinner></wpd-spinner>` somewhere and verify it renders the classic three-ring loader at 48px in WP blue.
- [ ] Cycle `preset="classic|comet|orbit|pulse"` — each reads as a visually distinct personality.
- [ ] Override a single attribute on top of a preset (`<wpd-spinner preset="comet" dots="8">`) and verify the override wins.
- [ ] Set `accent="#000"` on a `comet` spinner — the W mark turns black; rings stay WP blue.
- [ ] Set `size="2em"` and confirm the spinner scales with parent font-size.
- [ ] System-level toggle `prefers-reduced-motion: reduce` → animations stop, mark still renders.
- [ ] Open OS Settings, verify the rightmost tab is now labeled "Components" (was "Help").
- [ ] On every tab (Appearance, AI, Extended Options, Components), confirm the body no longer pushes the window content past its viewport.
- [ ] On the Components tab specifically: scroll the left nav — right detail does NOT scroll. Scroll the right detail — left nav does NOT scroll.
- [ ] Verify the "Reset to defaults" footer button is always visible regardless of scroll position.
- [ ] Resize the OS Settings window — split-pane heights track correctly.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-34-b22f5876a15b30016ea7f8f3a11240f9ac5e5c10.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->