### PR TITLE
feat(window): add Reload button to title-bar controls

### DIFF
--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -627,3 +627,62 @@ wpd-tab-chip + wpd-tab-chip {
 	height: 18px;
 	display: block;
 }
+
+/* ---------------------------------------------------------------
+ * Reload button feedback.
+ *
+ * Click feedback is decoupled from the loading state:
+ *
+ *   1. On click, the icon performs a single 360° rotation with a
+ *      fast-start / slow-end ease curve — confirms the user's
+ *      gesture independently of how long the page takes to load.
+ *      The `--spinning` class is added by the click handler and
+ *      removed on `animationend` so a subsequent click restarts
+ *      the animation cleanly.
+ *
+ *   2. While the window body is in the `--loading` state (set by
+ *      `markContentLoading()` and cleared on the iframe's
+ *      `wp-desktop-ready` postMessage), the button is dimmed and
+ *      non-interactive so a second click can't desync the
+ *      chromeless bridge's loading handshake.
+ *
+ * `:has()` is used instead of mirroring the `--loading` modifier
+ * onto the window root because upstream's loading API only
+ * decorates the body element. Browsers without :has() (very old)
+ * fall back to a static dimmed button — feature, not bug.
+ * --------------------------------------------------------------- */
+
+.wp-desktop-window:has( .wp-desktop-window__body--loading )
+	.wp-desktop-window__btn--reload {
+	pointer-events: none;
+	opacity: 0.55;
+}
+
+/*
+ * Click feedback animation. The custom easing — `cubic-bezier( 0.05,
+ * 0.7, 0.1, 1 )` — is a steeper-than-default ease-out: ~70% of the
+ * rotation lands in the first 30% of the duration, then it decelerates.
+ * Reads as "snap, then settle" rather than the linear glide of a
+ * loading-spinner, reinforcing that this is a one-shot acknowledgement
+ * of the gesture rather than progress through a long task. The `0.6s`
+ * duration is short enough to never block the user but long enough
+ * that the deceleration is legible.
+ */
+.wp-desktop-window__btn--reload.wp-desktop-window__btn--spinning {
+	animation: wpd-reload-spin-once 0.6s cubic-bezier( 0.05, 0.7, 0.1, 1 );
+}
+
+@keyframes wpd-reload-spin-once {
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
+	}
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.wp-desktop-window__btn--reload.wp-desktop-window__btn--spinning {
+		animation: none;
+	}
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -431,6 +431,17 @@ export const HOOKS = {
 	WINDOW_RESIZE_END: 'wp-desktop.window.resize-end',
 	/** Action, fires when the user "detaches" a window to a classic tab. */
 	WINDOW_DETACHED: 'wp-desktop.window.detached',
+	/**
+	 * Action, fires when the user clicks the title-bar reload button
+	 * on an iframe-backed window. Payload: `{ windowId: string, url:
+	 * string }` where `url` is the URL being reloaded (the active
+	 * primary or external sub-tab). Subscribers can use this to
+	 * invalidate their own cache, force a save before navigation,
+	 * track usage as a UX signal, or sync state across companion
+	 * surfaces. Native windows do not fire this — they own their
+	 * DOM directly and the reload button doesn't apply.
+	 */
+	WINDOW_RELOADED: 'wp-desktop.window.reloaded',
 	/** Action, fires when iframe title updates change the window title. */
 	WINDOW_TITLE_CHANGED: 'wp-desktop.window.title-changed',
 	/**

--- a/src/ui/components/wpd-window-button/wpd-window-button.ts
+++ b/src/ui/components/wpd-window-button/wpd-window-button.ts
@@ -1,8 +1,8 @@
 /**
  * `<wpd-window-button>` — single chrome button used in window
- * title bars. Built-in icons cover the five control buttons
- * (minimize / maximize / fullscreen-toggle / detach / close) plus
- * the `⋯` menu trigger.
+ * title bars. Built-in icons cover the six control buttons
+ * (minimize / maximize / fullscreen-toggle / detach / reload /
+ * close) plus the `⋯` menu trigger.
  *
  * The `icon` attribute ONLY accepts the seven built-in keys
  * listed below — passing a Dashicons class or an inline SVG string
@@ -26,7 +26,7 @@
  *
  * Attributes:
  *   - `icon="minimize" | "maximize" | "fullscreen" | "fullscreen-exit"
- *          | "detach" | "close" | "menu"` — picks a built-in SVG
+ *          | "detach" | "reload" | "close" | "menu"` — picks a built-in SVG
  *   - `active` — boolean, applies the pressed-down look
  *   - `danger` — boolean, swaps hover to a red wash (used by the
  *     close button)
@@ -67,6 +67,18 @@ const ICONS: Record<string, string> = {
 		'<path d="M2 4.5H4.5V2M7.5 2V4.5H10M2 7.5H4.5V10M7.5 10V7.5H10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
 	detach:
 		'<path d="M5 2H2.5v7.5H10V7M6.5 2H10v3.5M10 2L5.5 6.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
+	reload:
+		// Filled icon scaled from a 512×512 source into the 12×12 viewBox
+		// shared with the other title-bar glyphs. The wrapping `<g>` does
+		// the math; the inner path is dropped in unmodified so its
+		// authoring tool can be re-edited and copy-pasted again.
+		// `scale(0.021)` ≈ 90% of full fit, with `translate(0.6)` to
+		// keep the result centered inside the 12×12 viewBox so the
+		// glyph reads slightly smaller than min/max/close — closer to
+		// the visual weight of the other title-bar buttons.
+		'<g transform="translate(0.6 0.6) scale(0.021)" fill="currentColor">' +
+		'<path d="m504.554 233.704-76.447 91.467c-6.329 7.572-15.417 11.479-24.571 11.479a31.872 31.872 0 0 1-20.504-7.447l-91.467-76.447c-13.561-11.334-15.366-31.515-4.032-45.075s31.515-15.366 45.075-4.032l37.506 31.347c-10.274-74.891-74.668-132.774-152.337-132.774C132.984 102.223 64 171.207 64 256s68.984 153.777 153.777 153.777c17.673 0 32 14.327 32 32s-14.327 32-32 32c-58.17 0-112.859-22.653-153.991-63.785C22.653 368.859 0 314.17 0 256s22.653-112.859 63.786-153.992c41.132-41.132 95.821-63.785 153.991-63.785s112.859 22.653 153.992 63.785c32.517 32.516 53.471 73.508 60.829 117.991l22.849-27.339c11.334-13.56 31.515-15.364 45.075-4.032 13.56 11.335 15.365 31.516 4.032 45.076z"/>' +
+		'</g>',
 	close:
 		'<path d="M3.25 3.25l5.5 5.5M3.25 8.75l5.5-5.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>',
 	menu:
@@ -88,7 +100,7 @@ export class WpdWindowButton extends Component {
 		props: [
 			{
 				name: 'icon',
-				type: "'minimize' | 'maximize' | 'fullscreen' | 'fullscreen-exit' | 'detach' | 'close' | 'menu'",
+				type: "'minimize' | 'maximize' | 'fullscreen' | 'fullscreen-exit' | 'detach' | 'reload' | 'close' | 'menu'",
 				description: 'Which built-in inline SVG to paint. Omit to supply your own via the slot.',
 			},
 			{

--- a/src/window-chrome/controls/built-ins.ts
+++ b/src/window-chrome/controls/built-ins.ts
@@ -1,6 +1,6 @@
 /**
  * Built-in window controls — minimize, maximize, fullscreen,
- * detach, close.
+ * detach, reload, close.
  *
  * Each built-in registers as a `WindowControlDef` with a stable
  * `core/*` id, the same icon + label the hardcoded title bar used,
@@ -22,7 +22,7 @@ import { registerWindowControl } from './registry';
 import type { Window as DesktopWindow } from '../../window';
 
 /**
- * Register the five built-in title-bar controls. Idempotent — calling
+ * Register the six built-in title-bar controls. Idempotent — calling
  * it twice replaces the entries with identical definitions.
  *
  * Called once by the shell during boot. Plugins should NOT call this;
@@ -79,6 +79,20 @@ export function registerBuiltInControls(): void {
 		match: ( win: DesktopWindow ) => ! win.config.native,
 		onClick: ( win ) => {
 			win.detach();
+		},
+	} );
+
+	registerWindowControl( {
+		id: 'core/reload',
+		label: __( 'Reload' ),
+		icon: 'reload',
+		placement: 'controls',
+		order: 45,
+		core: true,
+		// Native windows own their DOM directly — no iframe to reload.
+		match: ( win: DesktopWindow ) => ! win.config.native,
+		onClick: ( win ) => {
+			win.reload();
 		},
 	} );
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1392,6 +1392,113 @@ export class Window {
 	}
 
 	/**
+	 * Reload the active iframe of this window. If an external sub-tab
+	 * is foregrounded, that iframe is reloaded instead of the primary
+	 * one. Same-origin iframes use `location.reload()` for a clean
+	 * reload that preserves scroll position semantics; cross-origin
+	 * external tabs fall back to re-assigning `iframe.src`.
+	 *
+	 * No-op for native windows — they own their DOM directly and the
+	 * `core/reload` built-in's `match` predicate already filters them
+	 * out, but this guard keeps the contract honest if the method is
+	 * called by other code paths in the future.
+	 */
+	public reload(): void {
+		if ( this.config.native ) {
+			return;
+		}
+		// Guard against double-clicks during an in-flight reload — a
+		// second `location.reload()` while the first is still hydrating
+		// can desync the chromeless bridge's `wp-desktop-ready`
+		// handshake. The body's `--loading` class is the upstream
+		// signal set by `markContentLoading()` and cleared on the
+		// next `wp-desktop-ready` postMessage.
+		const body = this.element.querySelector( '.wp-desktop-window__body' );
+		if ( body?.classList.contains( 'wp-desktop-window__body--loading' ) ) {
+			return;
+		}
+		// Resolve the target surface and its URL up-front, before any
+		// observable side effect — so an unexpected null iframe or
+		// missing external-tab entry returns silently instead of
+		// arming the loading overlay with no actual reload behind it
+		// (which would leave the spinner stuck forever).
+		let reloadedUrl: string;
+		let triggerReload: () => void;
+		if ( this._activeTabId === 'primary' ) {
+			if ( ! this.iframe ) {
+				return;
+			}
+			const iframe = this.iframe;
+			reloadedUrl = this.getCurrentUrl();
+			triggerReload = () => {
+				try {
+					iframe.contentWindow?.location.reload();
+				} catch {
+					// Cross-origin or detached frame — re-assign src
+					// as a fallback. The current src is what's already
+					// loaded, so re-setting it triggers a fresh load.
+					iframe.src = iframe.src;
+				}
+			};
+		} else {
+			const entry = this._externalTabs.get( this._activeTabId );
+			if ( ! entry ) {
+				return;
+			}
+			reloadedUrl = entry.url;
+			triggerReload = () => {
+				try {
+					entry.iframe.contentWindow?.location.reload();
+				} catch {
+					entry.iframe.src = entry.url;
+				}
+			};
+		}
+		// Click feedback first (independent of network latency), then
+		// arm the loading overlay (will be cleared by `wp-desktop-ready`),
+		// then fire the actual reload, then notify subscribers.
+		this._spinReloadButton();
+		this.markContentLoading();
+		triggerReload();
+		doAction( HOOKS.WINDOW_RELOADED, {
+			windowId: this.id,
+			url: reloadedUrl,
+		} );
+	}
+
+	/**
+	 * Trigger the one-shot 360° rotation on the title-bar reload
+	 * button. Force-restart the animation by removing the class,
+	 * flushing a reflow, then re-adding it; otherwise a click during
+	 * an in-flight animation would be a no-op (CSS ignores re-applying
+	 * the same animation to an unchanged class). Pattern mirrors
+	 * {@link shake} for the same restart-on-repeat reason.
+	 *
+	 * Silent no-op when the title bar has been replaced by a custom
+	 * chrome layer that doesn't render the standard reload button.
+	 *
+	 * @internal
+	 */
+	private _spinReloadButton(): void {
+		const btn = this.element.querySelector(
+			'.wp-desktop-window__btn--reload',
+		);
+		if ( ! ( btn instanceof HTMLElement ) ) {
+			return;
+		}
+		btn.classList.remove( 'wp-desktop-window__btn--spinning' );
+		void btn.offsetWidth;
+		btn.classList.add( 'wp-desktop-window__btn--spinning' );
+		btn.addEventListener(
+			'animationend',
+			() => {
+				btn.classList.remove( 'wp-desktop-window__btn--spinning' );
+			},
+			{ once: true },
+		);
+	}
+
+	/**
 	 * (Re)render plugin-registered title-bar buttons that match this
 	 * window. Called once from the constructor and again whenever
 	 * the registry changes. Cheap — clears each slot then walks the

--- a/tests/vitest/window-chrome-controls-render.test.ts
+++ b/tests/vitest/window-chrome-controls-render.test.ts
@@ -82,6 +82,7 @@ describe( 'resolveWindowControls', () => {
 			'core/maximize',
 			'core/focus-tab',
 			'core/detach',
+			'core/reload',
 			'core/close',
 		] );
 	} );
@@ -94,6 +95,11 @@ describe( 'resolveWindowControls', () => {
 		);
 		expect( resolved.controls.map( ( c ) => c.id ) ).not.toContain(
 			'core/detach',
+		);
+		// Native windows also skip core/reload — they own their DOM
+		// directly, so there's no iframe to reload.
+		expect( resolved.controls.map( ( c ) => c.id ) ).not.toContain(
+			'core/reload',
 		);
 		expect( resolved.controls.map( ( c ) => c.id ) ).toContain( 'core/close' );
 	} );
@@ -108,6 +114,7 @@ describe( 'resolveWindowControls', () => {
 		expect( resolved.controls.map( ( c ) => c.id ) ).toEqual( [
 			'core/minimize',
 			'core/maximize',
+			'core/reload',
 			'core/close',
 		] );
 	} );
@@ -132,6 +139,7 @@ describe( 'resolveWindowControls', () => {
 		expect( resolved.controls.map( ( c ) => c.id ).slice( 3 ) ).toEqual( [
 			'core/focus-tab',
 			'core/detach',
+			'core/reload',
 		] );
 	} );
 
@@ -191,9 +199,10 @@ describe( 'paintWindowControls', () => {
 			host,
 		);
 
-		expect( host.children.length ).toBe( 5 );
+		expect( host.children.length ).toBe( 6 );
 		expect( host.querySelector( '.wp-desktop-window__btn--close' ) ).not.toBeNull();
 		expect( host.querySelector( '.wp-desktop-window__btn--minimize' ) ).not.toBeNull();
+		expect( host.querySelector( '.wp-desktop-window__btn--reload' ) ).not.toBeNull();
 	} );
 
 	test( 'click on core/close button dispatches win.close()', () => {


### PR DESCRIPTION
## What

Adds a **Reload button** to the title-bar of iframe-backed windows. Mirrors the Safari / Chrome refresh affordance users already expect — re-fetches the active iframe without leaving the desktop shell.

## Why

Right now, to reload an admin page open in a window, the user has to detach it to a classic tab (or close + reopen). The reload button closes that gap, especially valuable for editor workflows where a long-running save fails and the user wants to retry without losing their window layout.

## How

- **`src/window-chrome/controls/built-ins.ts`** — registers `core/reload` next to the other built-ins, between detach (order 40) and close (order 50). Filtered for native windows via `match: ( win ) => ! win.config.native`.

- **`src/window/index.ts`** — new `public reload()` method. Resolves target surface (primary iframe or external sub-tab) and its URL **before** any observable side effect, so a missing iframe returns silently instead of leaving the loading overlay stuck. Same-origin iframes use `location.reload()`; cross-origin external tabs fall back to `src` re-assignment. Integrates with the loading API from #50 by calling `markContentLoading()` — the iframe's `wp-desktop-ready` postMessage clears the spinner automatically once the new page hydrates.

- **`Window._spinReloadButton()`** — private helper that drives the one-shot click-feedback rotation. Mirrors the `shake()` pattern (remove class, flush reflow, add class, listen for `animationend`). Keeps DOM manipulation inside `Window` so `built-ins.ts` stays a pure registration list of one-line `onClick` handlers.

- **`src/ui/components/wpd-window-button/wpd-window-button.ts`** — `reload` icon entry in the inline-SVG map. Filled style chosen deliberately for stronger visual weight as a primary action; a wrapper `<g transform>` re-targets a 512×512 source path into the shared 12×12 viewBox.

- **`src/hooks.ts`** — `HOOKS.WINDOW_RELOADED = 'wp-desktop.window.reloaded'`, fired with `{ windowId, url }` so plugins can invalidate caches, force saves, or sync companion surfaces. Native windows do not fire it.

- **`assets/css/window-chrome.css`** — single 360° rotation on click with a steeper-than-default ease-out curve (0.6s, custom cubic-bezier explained inline) so the gesture feels acknowledged but visually distinct from a continuous loading spinner. While the body is in the `--loading` state from `markContentLoading()`, the button is dimmed and `pointer-events: none` — `:has()`-driven, no JS state mirroring. Reduced-motion media query opts out of the rotation but preserves the dim state for accessibility.

## Diff size

```
src/hooks.ts                                                |  +11
src/ui/components/wpd-window-button/wpd-window-button.ts    |  +22 -7
src/window-chrome/controls/built-ins.ts                     |  +18 -3
src/window/index.ts                                         | +107
assets/css/window-chrome.css                                |  +59
─────────────────────────────────────────────────────────────────────
                                                              +210 lines
```

## Edge cases handled

- **Native windows**: `match` predicate excludes them; `Window.reload()` itself also has a `config.native` early-return as defense in depth.
- **Missing iframe / external tab entry**: target resolution happens before `markContentLoading()` to avoid stuck spinners.
- **Double-click during in-flight reload**: body's `wp-desktop-window__body--loading` class is checked at entry; `pointer-events: none` on the button via CSS provides a second line of defense.
- **Cross-origin external tabs**: `try`/`catch` around `contentWindow.location.reload()` falls back to `src` re-assignment.
- **Custom chrome layers** that don't render the standard reload button: `_spinReloadButton()` silently no-ops if the button isn't found.
- **Reduced motion preference**: rotation animation suppressed; dim/disable state preserved.

## Public hook example

```ts
import { addAction, HOOKS } from '@wp-desktop-mode/hooks';

addAction( HOOKS.WINDOW_RELOADED, 'my-cache-plugin', ( payload ) => {
    myCache.invalidate( payload.url );
} );
```

## Testing

- [x] Chrome, Firefox, Safari
- [x] Same-origin admin pages (post editor, settings, etc.)
- [x] Cross-origin external sub-tabs (where applicable)
- [x] Native windows excluded as expected
- [x] Light + dark admin schemes
- [x] `prefers-reduced-motion: reduce` honoured

## Notes on style consistency

- The inline reload icon is filled (`fill: currentColor`) while the other built-in icons are stroke-only. This is an **intentional design choice** — the reload action has a primary-action visual weight that the stroke style undersells. The `<g transform>` keeps the path data in its 512×512 authoring viewBox for easy round-trips with vector tools. Happy to swap to a stroke variant if you prefer the homogeneous look.
- The cubic-bezier value `( 0.05, 0.7, 0.1, 1 )` is novel in this codebase (other transitions use `ease-out` or `cubic-bezier( 0.2, 0, 0.2, 1 )`). The choice is documented inline; happy to align with an existing token if you'd rather.