### PR TITLE
fix(chromeless): show "Upload Plugin" button on plugin-install.php

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -97,6 +97,16 @@ html.wp-toolbar:has( body.wp-desktop-chromeless ) {
 	display: none;
 }
 
+/*
+ * Exception: plugin-install.php exposes "Upload Plugin" via
+ * .page-title-action — the only entry point to the upload UI. Keep
+ * it visible there. See issue #38.
+ */
+.wp-desktop-chromeless.plugin-install-php .wrap > .page-title-action {
+	display: inline-block;
+	margin-top: 12px;
+}
+
 /* ---------------------------------------------------------------
  * Dashboard welcome panel
  * The default 16px top margin pushes the panel down and creates a


### PR DESCRIPTION
Fixes #38

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-58-e8cd3b77849e0a0cfe9776e0515dbdc04e1077f6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->