### PR TITLE
feat(ai): add live-progress transport options for AI search functionality

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1736,7 +1736,7 @@ Register a tab in the OS Settings window. The tab is appended (or sorted-in by `
 | Field | Type | Notes |
 |---|---|---|
 | `isAdmin` | `boolean` | `true` when current user has `manage_options`. |
-| `getOsSettings()` | `function` | Snapshot of the persisted OS Settings state — `{ wallpaper, accent, dockSize, ai: { enabled, provider, apiKey } }`. Read-only; returns a defensive copy. Equivalent to what the built-in AI tab sees. |
+| `getOsSettings()` | `function` | Snapshot of the persisted OS Settings state — `{ wallpaper, accent, dockSize, ai: { enabled, provider, apiKey, transport } }`. `transport` is `'sse' \| 'off'` (default `'off'`) — the user's preferred live-progress transport for AI search; SSE is opt-in because some hosts block long-lived `text/event-stream` connections. Read-only; returns a defensive copy. Equivalent to what the built-in AI tab sees. |
 | `subscribeOsSettings( cb )` | `function` | Subscribe to in-panel OS Settings changes (user edits the AI key in the adjacent AI tab, etc.). Returns an unsubscribe function. Fires on local edits only — cross-device changes arrive on the next page load. |
 
 ```javascript

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -24,6 +24,20 @@ const DESKTOP_MODE_OS_SETTINGS_DOCK_SIZES = array( 'compact', 'default', 'large'
 const DESKTOP_MODE_OS_SETTINGS_DESKTOP_LAYOUTS = array( 'classic', 'unified', 'spatial' );
 
 /**
+ * Valid AI live-progress transports — mirrors the TS `AI_TRANSPORTS` constant.
+ *
+ * - `sse` — Server-Sent Events; real-time progress ticks. Requires the host
+ *   to allow long-lived `text/event-stream` connections.
+ * - `off` — single request, no progress ticks. Works everywhere; the user
+ *   sees "Thinking…" until the final answer.
+ *
+ * Default is `off` because some hosts (locked-down shared environments,
+ * proxies that buffer responses) silently drop SSE mid-stream, which surfaces
+ * to the user as "Lost connection to the assistant".
+ */
+const DESKTOP_MODE_OS_SETTINGS_AI_TRANSPORTS = array( 'sse', 'off' );
+
+/**
  * Built-in AI provider IDs.
  *
  * Other providers register themselves via {@see desktop_mode_register_ai_provider()};
@@ -59,10 +73,11 @@ function desktop_mode_default_os_settings() {
 		'customImage'  => null,
 		'libraryHdOnly' => true,
 		'ai'           => array(
-			'enabled'  => false,
-			'provider' => 'openai',
-			'apiKey'   => '',     // Legacy field — treated as the OpenAI key for backwards compat.
-			'apiKeys'  => array(), // Per-provider keys: { [provider_id]: string }.
+			'enabled'   => false,
+			'provider'  => 'openai',
+			'apiKey'    => '',     // Legacy field — treated as the OpenAI key for backwards compat.
+			'apiKeys'   => array(), // Per-provider keys: { [provider_id]: string }.
+			'transport' => 'off',   // Live-progress transport: 'sse' | 'off'. Default off — see DESKTOP_MODE_OS_SETTINGS_AI_TRANSPORTS.
 		),
 	);
 }
@@ -229,6 +244,15 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		// real API key while preventing runaway meta writes.
 		if ( isset( $raw_ai['apiKey'] ) && is_string( $raw_ai['apiKey'] ) ) {
 			$ai['apiKey'] = substr( sanitize_text_field( $raw_ai['apiKey'] ), 0, 512 );
+		}
+
+		// Live-progress transport — must be one of the known values.
+		if (
+			isset( $raw_ai['transport'] )
+			&& is_string( $raw_ai['transport'] )
+			&& in_array( $raw_ai['transport'], DESKTOP_MODE_OS_SETTINGS_AI_TRANSPORTS, true )
+		) {
+			$ai['transport'] = $raw_ai['transport'];
 		}
 
 		// Per-provider keys map. Limited to 32 entries to bound storage.

--- a/src/ai-assistant.ts
+++ b/src/ai-assistant.ts
@@ -265,6 +265,12 @@ export class AiAssistant implements AiAssistantApi {
 	private _aiSearchStreamUrl: string;
 	private _restNonce: string;
 	private _currentStream: EventSource | null = null;
+	/**
+	 * Reads the user's preferred live-progress transport from OS Settings.
+	 * Defaults to `'off'` when the shell hasn't wired one in — the
+	 * conservative choice for hosts that may block SSE.
+	 */
+	private _getTransport: () => 'sse' | 'off';
 
 	/** Index of the highlighted command in the filtered list (keyboard nav). */
 	private _selectedCommand = 0;
@@ -284,10 +290,16 @@ export class AiAssistant implements AiAssistantApi {
 	/** Monotonic counter to discard stale async suggest() results. */
 	private _suggestToken = 0;
 
-	constructor( config: { aiSearchUrl: string; aiSearchStreamUrl: string; restNonce: string } ) {
+	constructor( config: {
+		aiSearchUrl: string;
+		aiSearchStreamUrl: string;
+		restNonce: string;
+		getTransport?: () => 'sse' | 'off';
+	} ) {
 		this._aiSearchUrl = config.aiSearchUrl;
 		this._aiSearchStreamUrl = config.aiSearchStreamUrl;
 		this._restNonce = config.restNonce;
+		this._getTransport = config.getTransport ?? ( () => 'off' );
 
 		this._el = this._buildDOM();
 		document.body.appendChild( this._el );
@@ -783,11 +795,22 @@ export class AiAssistant implements AiAssistantApi {
 		this._input.disabled = true;
 		this._showThinking( 'Thinking…' );
 
-		// Prefer SSE streaming so the user sees real-time progress ticks
-		// ("Looking through your posts…"). Falls back to a plain fetch
-		// against the REST endpoint if EventSource is unavailable or the
-		// stream URL wasn't provisioned by PHP.
-		if ( typeof EventSource !== 'undefined' && this._aiSearchStreamUrl ) {
+		// Two transports, picked by the user in OS Settings → AI Settings:
+		//   - 'sse' — real-time progress ticks via EventSource. Preferred
+		//     UX, but some hosts (locked-down shared environments,
+		//     buffering proxies) drop the stream and surface as "Lost
+		//     connection to the assistant". Power users opt in.
+		//   - 'off' (default) — single REST request. No progress ticks;
+		//     the user sees "Thinking…" until the final answer. Reliable
+		//     everywhere.
+		// We additionally fall back to fetch when EventSource is missing
+		// or PHP didn't provision a stream URL, so an SSE pick on a host
+		// that can't actually run it still degrades gracefully.
+		const useSse =
+			this._getTransport() === 'sse' &&
+			typeof EventSource !== 'undefined' &&
+			!! this._aiSearchStreamUrl;
+		if ( useSse ) {
 			this._runSearchStream( query, resumeTool, startOffset );
 		} else {
 			this._runSearchFetch( query, resumeTool, startOffset );

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1366,6 +1366,10 @@ function init(): void {
 		aiSearchUrl: config.aiSearchUrl ?? '',
 		aiSearchStreamUrl: config.aiSearchStreamUrl ?? '',
 		restNonce: config.restNonce,
+		// Transport picker lives in OS Settings → AI Settings. Read live
+		// (not captured at construction) so a change applies on the next
+		// search without a page reload.
+		getTransport: () => osSettings.getOsSettingsSnapshot().ai.transport,
 	} );
 
 	// Late-bind the programmatic `ask` entry point. Passing `config`

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -163,8 +163,23 @@ export const DEFAULTS: OsSettingsState = {
 		provider: 'openai',
 		apiKey: '',
 		apiKeys: {},
+		transport: 'off',
 	},
 };
+
+/**
+ * Live-progress transport options. Order is the picker order in OS Settings.
+ *
+ * Default `off` is reliable on every host; `sse` is faster but needs the
+ * server (and any reverse proxy in front of it) to allow long-lived
+ * `text/event-stream` connections.
+ *
+ * @since 0.18.1
+ */
+export const AI_TRANSPORTS = [
+	{ id: 'off', label: 'Off' },
+	{ id: 'sse', label: 'Streaming (SSE)' },
+] as const;
 
 /**
  * Hard-coded fallback list — the only provider we know about without

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -53,6 +53,14 @@ export interface OsSettingsSnapshot {
 		enabled: boolean;
 		provider: string;
 		apiKey: string;
+		/**
+		 * Live-progress transport for AI search: `'sse' | 'off'`. Default
+		 * `'off'`. Surfaced so a third-party AI tab can read the user's
+		 * preferred transport without rebuilding the picker.
+		 *
+		 * @since 0.18.1
+		 */
+		transport: 'sse' | 'off';
 	};
 }
 

--- a/src/settings/sections/ai.ts
+++ b/src/settings/sections/ai.ts
@@ -15,8 +15,8 @@
 
 import { __ } from '../../i18n';
 import { html, render } from '../../ui/core';
-import { getAiProviders } from '../constants';
-import type { SettingsCtx } from '../types';
+import { AI_TRANSPORTS, getAiProviders } from '../constants';
+import type { AiTransportId, SettingsCtx } from '../types';
 
 // ---------------------------------------------------------------------------
 // Personal settings
@@ -59,6 +59,15 @@ export function buildAiSection( ctx: SettingsCtx ): HTMLElement {
 		const apiKeys = { ...( ctx.state.ai.apiKeys ?? {} ) };
 		apiKeys[ ctx.state.ai.provider ] = value;
 		ctx.state.ai = { ...ctx.state.ai, apiKey: value, apiKeys };
+		ctx.save();
+	};
+
+	const onTransport = ( e: Event ): void => {
+		const id = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
+		if ( ! AI_TRANSPORTS.some( ( t ) => t.id === id ) ) {
+			return;
+		}
+		ctx.state.ai = { ...ctx.state.ai, transport: id as AiTransportId };
 		ctx.save();
 	};
 
@@ -107,6 +116,20 @@ export function buildAiSection( ctx: SettingsCtx ): HTMLElement {
 						?disabled=${ ! ctx.state.ai.enabled }
 						@wpd-input-change=${ onApiKey }
 					></wpd-text-field>
+
+					<wpd-select
+						label=${ __( 'Live progress updates' ) }
+						value=${ ctx.state.ai.transport }
+						?disabled=${ ! ctx.state.ai.enabled }
+						@wpd-pick=${ onTransport }
+					>
+						${ AI_TRANSPORTS.map(
+							( t ) => html`<wpd-option value=${ t.id }>${ t.label }</wpd-option>`,
+						) }
+					</wpd-select>
+					<p class="wp-desktop-ext__hint">
+						${ __( 'How the assistant streams progress while it works. Pick Off if your host blocks long-lived connections (e.g. you see "Lost connection to the assistant" errors).' ) }
+					</p>
 				</wpd-section>
 
 				${ ctx.config.isAdmin ? _buildGlobalSection( ctx ) : html`` }

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -20,6 +20,7 @@
 import type { DesktopConfig } from '../types';
 import {
 	getAiProviders,
+	AI_TRANSPORTS,
 	DEFAULTS,
 	DESKTOP_LAYOUTS,
 	DOCK_SIZES,
@@ -30,6 +31,7 @@ import {
 import type {
 	AccentId,
 	AiSettings,
+	AiTransportId,
 	CustomGradient,
 	CustomImage,
 	DesktopLayoutId,
@@ -209,7 +211,7 @@ export function sanitizeAi( raw: unknown ): AiSettings {
 	if ( ! raw || typeof raw !== 'object' ) {
 		return { ...DEFAULTS.ai, apiKeys: {} };
 	}
-	const { enabled, provider, apiKey, apiKeys } = raw as Partial< AiSettings >;
+	const { enabled, provider, apiKey, apiKeys, transport } = raw as Partial< AiSettings >;
 	const known = getAiProviders();
 	const validProvider =
 		typeof provider === 'string' && known.some( ( p ) => p.id === provider )
@@ -225,11 +227,18 @@ export function sanitizeAi( raw: unknown ): AiSettings {
 		}
 	}
 
+	const validTransport: AiTransportId =
+		typeof transport === 'string' &&
+		AI_TRANSPORTS.some( ( t ) => t.id === transport )
+			? ( transport as AiTransportId )
+			: DEFAULTS.ai.transport;
+
 	return {
 		enabled: typeof enabled === 'boolean' ? enabled : DEFAULTS.ai.enabled,
 		provider: validProvider,
 		apiKey: typeof apiKey === 'string' ? apiKey : DEFAULTS.ai.apiKey,
 		apiKeys: cleanKeys,
+		transport: validTransport,
 	};
 }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -56,6 +56,22 @@ export interface CustomImage {
  */
 export type AiProviderId = string;
 
+/**
+ * Live-progress transport for the AI Copilot search.
+ *
+ * - `sse` — Server-Sent Events. Real-time progress ticks; preferred where the
+ *   host allows long-lived `text/event-stream` connections.
+ * - `off` — single REST request, no progress ticks. Works everywhere; the
+ *   user sees "Thinking…" until the final answer arrives.
+ *
+ * Default `off` because some hosts silently drop SSE mid-stream, which
+ * surfaces to the user as "Lost connection to the assistant". Power users
+ * on hosts known to support SSE can opt in.
+ *
+ * @since 0.18.1
+ */
+export type AiTransportId = 'sse' | 'off';
+
 /** AI integration preferences — provider choice + per-provider API keys. */
 export interface AiSettings {
 	enabled: boolean;
@@ -64,6 +80,12 @@ export interface AiSettings {
 	apiKey: string;
 	/** Per-provider key map. Falls back to `apiKey` for `openai`. */
 	apiKeys: Record< string, string >;
+	/**
+	 * Live-progress transport. See {@link AiTransportId}. Default `off`.
+	 *
+	 * @since 0.18.1
+	 */
+	transport: AiTransportId;
 }
 
 /** Provider entry surfaced via `wpDesktopConfig.aiProviders`. */

--- a/tests/phpunit/tests/osSettings.php
+++ b/tests/phpunit/tests/osSettings.php
@@ -110,4 +110,33 @@ class Tests_DesktopMode_OsSettings extends WP_UnitTestCase {
 		$loaded = desktop_mode_get_os_settings( $user_id );
 		$this->assertSame( 'fan', $loaded['dockRailRenderer'] );
 	}
+
+	/**
+	 * @covers ::desktop_mode_default_os_settings
+	 */
+	public function test_default_ai_transport_is_off() {
+		$defaults = desktop_mode_default_os_settings();
+		$this->assertArrayHasKey( 'transport', $defaults['ai'] );
+		$this->assertSame( 'off', $defaults['ai']['transport'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_keeps_known_ai_transport() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array( 'ai' => array( 'transport' => 'sse' ) )
+		);
+		$this->assertSame( 'sse', $clean['ai']['transport'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_rejects_unknown_ai_transport() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array( 'ai' => array( 'transport' => 'websocket' ) )
+		);
+		$this->assertSame( 'off', $clean['ai']['transport'] );
+	}
 }


### PR DESCRIPTION
https://www.youtube.com/watch?v=akAPAnA3LZk&lc=UgyfLgw1gta39RCtu9N4AaABAg.AWEZ35ajoytAWE_TgQOny5

There is a comment in that video stating the AI is flaky. That's due to SSE. Not every hosting supports SSE so openly. We are adding a OS setting that enables/disables SSE. Disabled by default

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-61-96bd512492d82f85d4cd57d269c178c28a30262b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->