### PR TITLE
feat(mobile): purpose-built phone view with a radial launcher

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -48,6 +48,19 @@ html.wp-toolbar:has( body.wp-desktop-chromeless ) {
 	padding-inline-start: 0 !important;
 }
 
+/*
+ * WordPress core's narrow-viewport stylesheet pins
+ * `#wpbody { padding-top: 46px }` under 600 px to clear the
+ * mobile admin bar on the classic shell. In chromeless mode the
+ * admin bar is suppressed (the parent shell paints its own), so
+ * that padding is dead space at the top of every iframed page.
+ * Zero it out so the page content renders flush against the
+ * window's title bar / tab strip.
+ */
+.wp-desktop-chromeless #wpbody {
+	padding-top: 0 !important;
+}
+
 /* ---------------------------------------------------------------
  * Screen Meta (Screen Options / Help panels)
  * The toggle buttons (#screen-meta-links) are hidden because

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -1,0 +1,924 @@
+/**
+ * Desktop Mode — Mobile / responsive layer styles.
+ *
+ * All rules scope under `html[data-wp-desktop-mode="mobile"]`. The
+ * attribute is set by `src/mobile/index.ts` from the responsive
+ * probe. When mode flips to `desktop`/`tablet` these rules become
+ * inert and the classic shell layout takes over.
+ *
+ * @since 0.7.0
+ */
+
+/*
+ * Strip-height var. Set live by the switcher's ResizeObserver; the
+ * default keeps mobile layout sane when the switcher isn't mounted
+ * yet (e.g. between mode-flip and first paint).
+ */
+html[data-wp-desktop-mode="mobile"] {
+	/*
+	 * Strip height is now ZERO — the radial FAB floats over the
+	 * window content instead of reserving its own bottom band. The
+	 * variable still exists in case a plugin pinned to it; the
+	 * rule below force-clears the desktop-area's bottom inset.
+	 */
+	--wp-desktop-mobile-strip-height: 0px;
+	--wp-desktop-mobile-titlebar-height: 56px;
+	--wp-desktop-mobile-adminbar-height: 40px;
+	--wp-desktop-radial-fab-size: 64px;
+
+	/*
+	 * Pin Core's admin-bar height var so the shell's `inset-block-start`
+	 * (driven by `var(--wp-admin--admin-bar--height)`) collapses too.
+	 * Without this, Core's narrow-viewport stylesheet inflates the bar
+	 * to 46px+ and any per-row expansion (multi-line submenu titles,
+	 * larger touch targets WP applies under 600px) eats into the
+	 * window title-bar's vertical real estate.
+	 */
+	--wp-admin--admin-bar--height: var(--wp-desktop-mobile-adminbar-height);
+}
+
+/*
+ * Keep the admin bar visually compact on mobile. The bar must stay
+ * visible (it hosts the only escape hatch — the "Switch to Classic
+ * Admin" toggle), but every Core rule that grows it under 600px /
+ * 782px competes with our shell layout. Pin every load-bearing
+ * dimension so a single row of icons fits cleanly above the window
+ * title bar.
+ */
+html[data-wp-desktop-mode="mobile"] #wpadminbar {
+	height: var(--wp-desktop-mobile-adminbar-height) !important;
+	min-height: var(--wp-desktop-mobile-adminbar-height) !important;
+}
+
+html[data-wp-desktop-mode="mobile"] #wpadminbar .ab-item,
+html[data-wp-desktop-mode="mobile"] #wpadminbar a.ab-item,
+html[data-wp-desktop-mode="mobile"] #wpadminbar > #wp-toolbar > ul > li > .ab-item,
+html[data-wp-desktop-mode="mobile"] #wpadminbar > #wp-toolbar > ul > li > a.ab-item {
+	height: var(--wp-desktop-mobile-adminbar-height) !important;
+	line-height: var(--wp-desktop-mobile-adminbar-height) !important;
+	padding: 0 8px !important;
+}
+
+/*
+ * Drop the admin-bar avatar / user-info badges that Core stretches
+ * into multi-line blocks at narrow widths. The user menu remains
+ * accessible via the toggle button in the bar.
+ */
+html[data-wp-desktop-mode="mobile"] #wpadminbar #wp-admin-bar-my-account .display-name,
+html[data-wp-desktop-mode="mobile"] #wpadminbar #wp-admin-bar-my-account .username {
+	display: none !important;
+}
+
+/*
+ * Mobile shell offset — the desktop CSS hard-codes 46px under 782px.
+ * Override with our pinned height so the window title bar lines up
+ * directly under the admin bar with no gap. Use the literal value
+ * (not the var) so any inherited fallback inside the shell stylesheet
+ * loses, and pin a `!important` to outrank Core's narrow-viewport
+ * stylesheet which forces `#wpadminbar` styling at the same
+ * specificity.
+ */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-shell {
+	/*
+	 * The shell already lays out via `position: fixed` + `inset: 0`
+	 * (with start overridden here). We deliberately avoid an
+	 * explicit `height: calc(100vh - …)` because mobile Safari's
+	 * `100vh` excludes the dynamic URL bar and would clip the
+	 * radial FAB while the URL bar is shown.
+	 */
+	inset-block-start: var(--wp-desktop-mobile-adminbar-height) !important;
+	inset-block-end: 0 !important;
+}
+
+/*
+ * Kill the body / wpbody padding Core applies under 782px — they
+ * push our shell content down (the window title bar ends up tucked
+ * under the admin bar) because Core's mobile stylesheet adds
+ * vertical padding intended for the classic admin layout. The
+ * shell uses `position: fixed`, so it doesn't need any of that
+ * padding and any leftover inflates the wpbody bottom region the
+ * window chrome lives inside.
+ */
+html[data-wp-desktop-mode="mobile"].wp-toolbar,
+html[data-wp-desktop-mode="mobile"] {
+	padding-top: 0 !important;
+}
+
+html[data-wp-desktop-mode="mobile"] body.wp-desktop-active {
+	padding-bottom: 0 !important;
+	margin-bottom: 0 !important;
+}
+
+html[data-wp-desktop-mode="mobile"] #wpbody,
+html[data-wp-desktop-mode="mobile"] #wpbody-content,
+html[data-wp-desktop-mode="mobile"] #wpcontent {
+	padding: 0 !important;
+	margin: 0 !important;
+}
+
+/*
+ * Hide the dock entirely on mobile — the home grid takes its place.
+ * Mobile users get every menu item as a wallpaper icon.
+ */
+html[data-wp-desktop-mode="mobile"] #wp-desktop-dock,
+html[data-wp-desktop-mode="mobile"] .wp-desktop-dock {
+	display: none !important;
+}
+
+/*
+ * Hide the widget rail entirely on mobile. Widgets (and the
+ * "Add widget" placeholder) belong to the desktop metaphor; on
+ * a phone the wallpaper is filled with home-screen icons and
+ * the dashed-border placeholder is just visual noise. Plugin-
+ * registered widgets remain registered — they just don't render
+ * on this surface while the viewport is in mobile mode.
+ */
+html[data-wp-desktop-mode="mobile"] #wp-desktop-widgets,
+html[data-wp-desktop-mode="mobile"] .wp-desktop-widgets {
+	display: none !important;
+}
+
+/*
+ * Drop the dock-reserved inset from the desktop area, AND zero out
+ * the bottom inset — the radial FAB floats over the window content
+ * instead of reserving its own band. Window content extends edge to
+ * edge from the admin bar to the bottom of the viewport.
+ */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-area--with-dock,
+html[data-wp-desktop-mode="mobile"] .wp-desktop-area {
+	inset-inline-start: 0 !important;
+	inset-block-end: 0 !important;
+}
+
+/*
+ * Force-maximized windows in mobile mode. The TS layer also calls
+ * `maximize()` on every open; the CSS belt-and-suspenders pin keeps
+ * a window pinned to the area even if a plugin tries to apply a
+ * floating geometry mid-flight.
+ */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window {
+	border-radius: 0 !important;
+	box-shadow: none !important;
+}
+
+/*
+ * Hide the resize handles entirely so users can't initiate a drag
+ * even by mouse. Belt to the JS filter gate.
+ */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window__resize-handle,
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window__resize {
+	display: none !important;
+}
+
+/*
+ * Title bar removed entirely on mobile. Chrome reduces to body +
+ * tabs strip (the submenu navigation row). Close + reload move
+ * to floating chips that flank the radial FAB so the user always
+ * has thumb-friendly access without giving up vertical real estate
+ * for a 56 px banner per window. The tabs strip stays at the top
+ * of the body; everything else stays as-is.
+ */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window__titlebar {
+	display: none !important;
+}
+
+/* Body fills the area the title bar used to occupy. */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window__body {
+	border-radius: 0 !important;
+}
+
+/*
+ * Bigger, touch-friendly title bar with larger hit targets.
+ * `align-items: center` is already declared in the desktop
+ * stylesheet but we re-pin it under our taller `min-height`
+ * so every direct child — controls cluster, title, slot
+ * containers — vertically centres in the 56 px row.
+ */
+/*
+ * Title bar is removed entirely on mobile (rule earlier in this
+ * stylesheet). The reload + close actions migrate to the radial
+ * FAB chips. Plugin-registered title-bar buttons effectively
+ * disappear too — they sit in the same slot — and that's
+ * accepted: mobile mode is opinionated about chrome.
+ */
+
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window {
+	z-index: 1;
+}
+
+/*
+ * Hide the tabs strip on mobile entirely. The radial menu owns
+ * navigation across submenus — drilling into a parent dock item
+ * fans out its children, so the in-window tab strip would just
+ * duplicate that path. Drops a horizontal band of chrome and
+ * gives the iframe content the full body area.
+ */
+html[data-wp-desktop-mode="mobile"] .wp-desktop-window__tabs {
+	display: none !important;
+}
+
+/* Tabs are fully hidden on mobile (rule above). The 2-column
+ * grid layout that used to live here was deleted along with the
+ * decision to drop the strip — radial submenu drilling covers
+ * the same navigation. */
+
+/*
+ * Mobile radial launcher. Replaces the bottom thumbnail strip with
+ * a single floating "+" button anchored bottom-centre. Tapping the
+ * FAB expands a fan of icons in an upward arc above it; the user
+ * pans left/right to scroll through items. Tapping a parent item
+ * re-roots the radial — the parent slides to the centre and its
+ * submenu fans out. The same icon doubles as the back affordance.
+ *
+ * The radial is the ONLY launcher surface in mobile mode — the dock,
+ * the desktop-icons grid, and the old bottom strip are all hidden.
+ */
+.wp-desktop-radial {
+	position: fixed;
+	inset: 0;
+	pointer-events: none; /* see __backdrop / __fab / __arc rules below */
+	z-index: 99999;
+	display: none;
+}
+
+html[data-wp-desktop-mode="mobile"] .wp-desktop-radial {
+	display: block;
+}
+
+.wp-desktop-radial__backdrop {
+	position: absolute;
+	inset: 0;
+	background: radial-gradient(
+		circle at 50% calc(100% - 60px),
+		rgba(0, 0, 0, 0.55) 0%,
+		rgba(0, 0, 0, 0.35) 35%,
+		rgba(0, 0, 0, 0) 70%
+	);
+	backdrop-filter: blur(8px);
+	-webkit-backdrop-filter: blur(8px);
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.22s ease;
+}
+
+.wp-desktop-radial--open .wp-desktop-radial__backdrop {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+/*
+ * Gesture pad — invisible square covering the entire radial
+ * footprint (apex + lateral icons + a comfortable margin). All
+ * pointer events for the pan gesture register here so the user
+ * can start a drag from anywhere inside the radial, not just on
+ * a tile. Sits behind tiles in z-order; the gesture handler uses
+ * `elementFromPoint` on pointerup to dispatch tile taps.
+ */
+.wp-desktop-radial__gesture-pad {
+	position: absolute;
+	left: 50%;
+	bottom: calc(24px + var(--wp-desktop-radial-fab-size) / 2);
+	width: 420px;
+	height: 240px;
+	margin-left: -210px;
+	margin-bottom: -10px;
+	pointer-events: none;
+	touch-action: none;
+}
+
+.wp-desktop-radial--open .wp-desktop-radial__gesture-pad {
+	pointer-events: auto;
+}
+
+/* The arc is anchored at the centre of the FAB (bottom centre of the
+ * viewport) and items position themselves via `--wpdm-radial-x/y`
+ * relative to the arc origin. */
+.wp-desktop-radial__arc {
+	position: absolute;
+	left: 50%;
+	bottom: calc(24px + var(--wp-desktop-radial-fab-size) / 2);
+	width: 1px;
+	height: 1px;
+	pointer-events: none;
+	touch-action: none;
+}
+
+.wp-desktop-radial--open .wp-desktop-radial__arc {
+	pointer-events: auto;
+}
+
+.wp-desktop-radial__tile {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 64px;
+	height: 64px;
+	margin-left: -32px;
+	margin-top: -32px;
+	padding: 0;
+	transform: translate(var(--wpdm-radial-x, 0), var(--wpdm-radial-y, 0)) scale(0.5);
+	display: block;
+	border-radius: 50%;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	background: rgba(28, 28, 32, 0.85);
+	color: #fff;
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+	box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+	opacity: 0;
+	transition:
+		transform 0.32s cubic-bezier(0.2, 0.9, 0.2, 1.05),
+		opacity 0.22s ease,
+		background 0.15s ease,
+		border-color 0.15s ease;
+}
+
+/* Tile is visible only while the radial is open. Visibility comes
+ * from a CSS var stamped by the JS layer (per-tile, depends on
+ * how far off the visible arc the item lives). When the radial
+ * closes — or a tile leaves on a scene change — both `opacity`
+ * and `transform` revert through the transition above. */
+.wp-desktop-radial--open .wp-desktop-radial__tile {
+	transform: translate(var(--wpdm-radial-x, 0), var(--wpdm-radial-y, 0)) scale(1);
+	opacity: var(--wpdm-radial-visibility, 1);
+}
+
+/*
+ * Exit animation. When a tile no longer matches the active scene
+ * (radial closed, drilled into submenu, etc.) the JS adds this
+ * class. The class targets a smaller scale + zero opacity with the
+ * same transition duration, so the tile fades and shrinks back
+ * toward the FAB before the JS cleanup removes it from the DOM
+ * 260ms later.
+ */
+.wp-desktop-radial__tile--leaving {
+	transform: translate(var(--wpdm-radial-x, 0), var(--wpdm-radial-y, 0)) scale(0.4) !important;
+	opacity: 0 !important;
+	pointer-events: none !important;
+}
+
+/*
+ * Entry animation. The keyframe is preferable to a transition
+ * because the new tile is appended to a parent that already
+ * carries `.--open`, so its computed style would jump straight
+ * to the open-state values and skip the transition. A keyframe
+ * runs once on append regardless and gives us a guaranteed
+ * scale-up + fade-in for every newly-introduced tile (radial
+ * open, drill into submenu, drill back out).
+ */
+.wp-desktop-radial__tile--entering {
+	animation: wp-desktop-radial-tile-enter 0.36s cubic-bezier(0.2, 0.9, 0.2, 1.05) both;
+}
+
+@keyframes wp-desktop-radial-tile-enter {
+	from {
+		transform: translate(var(--wpdm-radial-x, 0), var(--wpdm-radial-y, 0)) scale(0.4);
+		opacity: 0;
+	}
+	to {
+		transform: translate(var(--wpdm-radial-x, 0), var(--wpdm-radial-y, 0)) scale(1);
+		opacity: var(--wpdm-radial-visibility, 1);
+	}
+}
+
+/* Icon centered in the tile and grown to fill most of the circle.
+ * The curved label hugs the inner bottom arc behind it so the
+ * label doesn't shift the icon's optical centre off-axis — the
+ * text and the glyph share the same geometric centre point. */
+.wp-desktop-radial__tile-icon {
+	position: absolute;
+	left: 50%;
+	top: 38%;
+	transform: translate(-50%, -50%);
+	font-size: 22px;
+	width: 22px;
+	height: 22px;
+	line-height: 1;
+	pointer-events: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.wp-desktop-radial__tile-icon.dashicons,
+.wp-desktop-radial__tile-icon.dashicons::before {
+	font-size: 22px !important;
+	line-height: 1 !important;
+	width: 22px;
+	height: 22px;
+}
+
+/* SVG layer that hosts the curved <textPath>. Same dimensions as
+ * the tile so the path coordinate space matches the tile's
+ * geometry (viewBox is 0..80). */
+.wp-desktop-radial__tile-svg {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+	overflow: visible;
+}
+
+.wp-desktop-radial__tile-curve-text {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	fill: rgba(255, 255, 255, 0.95);
+	text-transform: uppercase;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	/* Outline so the curved label stays legible at any background. */
+	paint-order: stroke;
+	stroke: rgba(0, 0, 0, 0.65);
+	stroke-width: 2.5;
+	stroke-linejoin: round;
+}
+
+/* Items that correspond to a currently-open window get an accent
+ * ring so the radial doubles as the app switcher. */
+.wp-desktop-radial__tile--open {
+	border-color: var(--wp-admin-theme-color, #2271b1);
+	box-shadow:
+		0 0 0 2px rgba(255, 255, 255, 0.05),
+		0 0 0 3px var(--wp-admin-theme-color, #2271b1),
+		0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+/* Open-window prefix tiles (the radial's app-switcher slots).
+ * Tinted accent-colour fill so they read as a distinct group
+ * from the dock-item tiles next to them — "switch to" vs. "open
+ * for the first time". */
+.wp-desktop-radial__tile--window {
+	background: color-mix(in srgb, var(--wp-admin-theme-color, #2271b1) 70%, #1c1c20);
+	border-color: var(--wp-admin-theme-color, #2271b1);
+}
+
+/* The currently-focused window pulses subtly. */
+.wp-desktop-radial__tile--focused {
+	background: var(--wp-admin-theme-color, #2271b1);
+}
+
+/* Submenu indicator dot was visually noisy on mobile — every
+ * dock item has children so the dot was on every tile. The
+ * "tap to drill" affordance comes from the radial behaviour
+ * itself. Rule retained as a no-op marker so the JS class
+ * toggle keeps making sense for future styling. */
+.wp-desktop-radial__tile--has-children {
+	/* intentionally empty */
+}
+
+/* The FAB. Always visible in mobile mode. Doubles as a "back"
+ * button while drilled into a submenu. */
+.wp-desktop-radial__fab {
+	position: absolute;
+	left: 50%;
+	bottom: 24px;
+	width: var(--wp-desktop-radial-fab-size);
+	height: var(--wp-desktop-radial-fab-size);
+	margin-left: calc(var(--wp-desktop-radial-fab-size) / -2);
+	border-radius: 50%;
+	border: none;
+	background: var(--wp-admin-theme-color, #2271b1);
+	color: #fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+	pointer-events: auto;
+	box-shadow:
+		0 8px 24px rgba(0, 0, 0, 0.45),
+		0 0 0 4px rgba(0, 0, 0, 0.15);
+	transition: transform 0.25s cubic-bezier(0.2, 0.9, 0.2, 1.1), background 0.2s ease;
+}
+
+.wp-desktop-radial__fab:active {
+	transform: scale(0.94);
+}
+
+.wp-desktop-radial--open .wp-desktop-radial__fab {
+	transform: rotate(45deg);
+}
+
+.wp-desktop-radial--drilled .wp-desktop-radial__fab {
+	transform: rotate(0deg);
+	background: rgba(28, 28, 32, 0.9);
+}
+
+.wp-desktop-radial__fab-icon {
+	font-size: 28px;
+	width: 28px;
+	height: 28px;
+	line-height: 1;
+	transition: transform 0.2s ease;
+}
+
+.wp-desktop-radial--drilled .wp-desktop-radial__fab-icon {
+	/* Show a back chevron treatment via a small inset ring while
+	 * drilled — keeps the dashicon recognisable. */
+	box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.5);
+	border-radius: 50%;
+}
+
+/*
+ * Window action chips (Reload, Close) — fan out either side of
+ * the FAB while the radial is open. Title bars are removed in
+ * mobile mode so these are the user's only path to those
+ * actions; they live close to the same thumb-zone as the FAB.
+ */
+.wp-desktop-radial__actions {
+	position: absolute;
+	left: 50%;
+	bottom: calc(24px + var(--wp-desktop-radial-fab-size) / 2);
+	display: flex;
+	gap: 0;
+	pointer-events: none;
+	transform: translate(-50%, 50%);
+}
+
+.wp-desktop-radial__action {
+	position: absolute;
+	width: 48px;
+	height: 48px;
+	margin-left: -24px;
+	margin-top: -24px;
+	border-radius: 50%;
+	border: 1px solid rgba(255, 255, 255, 0.18);
+	background: rgba(28, 28, 32, 0.85);
+	color: #fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+	box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+	opacity: 0;
+	transform: translate(0, 0) scale(0.5);
+	pointer-events: none;
+	transition:
+		transform 0.32s cubic-bezier(0.2, 0.9, 0.2, 1.05),
+		opacity 0.22s ease,
+		background 0.15s ease;
+}
+
+/* Visible only when the radial is open AND a window is focused.
+ * Without a focused window the chips have nothing to act on, so
+ * we hide them — JS toggles `--has-focus` on the root. */
+.wp-desktop-radial--open.wp-desktop-radial--has-focus .wp-desktop-radial__action {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+/*
+ * Reload (upper-left) and Close (upper-right) sit at the top
+ * corners of the radial — diagonally up-and-out from the FAB,
+ * past the bounding box of the icon arc. Geometry: items occupy
+ * a circle of radius 140 around the FAB; placing the chips at
+ * (±170, -170) puts them about 50 px clear of any item edge,
+ * comfortably in the screen corners but still tied to the
+ * radial's overall shape.
+ */
+.wp-desktop-radial--open.wp-desktop-radial--has-focus .wp-desktop-radial__action--reload {
+	transform: translate(-170px, -170px) scale(1);
+}
+
+/* Close (upper-right) mirrored. Tinted red on press so the
+ * dangerous action visually telegraphs itself. */
+.wp-desktop-radial--open.wp-desktop-radial--has-focus .wp-desktop-radial__action--close {
+	transform: translate(170px, -170px) scale(1);
+}
+
+.wp-desktop-radial__action--close:hover {
+	background: rgba(214, 54, 56, 0.85);
+	border-color: rgba(214, 54, 56, 1);
+}
+
+.wp-desktop-radial__action .dashicons {
+	font-size: 22px !important;
+	width: 22px;
+	height: 22px;
+	line-height: 1 !important;
+}
+
+/*
+ * FAB visibility state machine — `peeking` half-hides the button
+ * below the viewport edge so it's discoverable but unobtrusive
+ * while the user works inside a window. Tapping it (or any
+ * interaction with the open radial) lifts it to its `revealed`
+ * resting position; 3 s of inactivity re-engages `peeking`.
+ *
+ * Implementation: translate the FAB down by ~55% of its diameter
+ * when the root carries `--peeking`. The button stays clickable
+ * (top half remains in the viewport) so the user can lift it.
+ */
+.wp-desktop-radial--peeking .wp-desktop-radial__fab {
+	/*
+	 * Show only a quarter of the FAB. With the chevron pinned
+	 * near the top (see below) the visible sliver acts as a
+	 * thin "lift me" tab on the bottom edge of the viewport.
+	 */
+	transform: translateY(90%);
+	opacity: 0.95;
+}
+
+/* Icon swap when peeking: hide the canonical plus, show the
+ * chevron. The chevron is anchored to the TOP of the FAB so it
+ * remains visible regardless of how aggressively the FAB hides. */
+.wp-desktop-radial__fab-peek-icon {
+	display: none;
+	position: absolute;
+	left: 50%;
+	top: 12px;
+	transform: translateX(-50%);
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	line-height: 1;
+	color: #fff;
+	pointer-events: none;
+}
+
+.wp-desktop-radial--peeking .wp-desktop-radial__fab-icon {
+	visibility: hidden;
+}
+
+.wp-desktop-radial--peeking .wp-desktop-radial__fab-peek-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: wp-desktop-radial-peek-bob 1.4s ease-in-out infinite;
+}
+
+@keyframes wp-desktop-radial-peek-bob {
+	0%, 100% { transform: translate(-50%, 0); }
+	50%      { transform: translate(-50%, -3px); }
+}
+
+.wp-desktop-radial--peeking.wp-desktop-radial--open .wp-desktop-radial__fab {
+	/* Defensive — `open` always wins over `peeking`; the radial
+	 * boot-state path keeps these mutually exclusive but a CSS
+	 * race during a transition could overlap them briefly. */
+	transform: rotate(45deg);
+}
+
+/* Subtle glow on the peeking edge so the user knows there's
+ * something to tap. Pulses gently every 4 seconds — frequent
+ * enough to be discovered, slow enough to fade into the chrome. */
+.wp-desktop-radial--peeking .wp-desktop-radial__fab::before {
+	content: "";
+	position: absolute;
+	inset: -8px;
+	border-radius: 50%;
+	background: var(--wp-admin-theme-color, #2271b1);
+	opacity: 0.25;
+	z-index: -1;
+	animation: wp-desktop-radial-peek-pulse 4s ease-in-out infinite;
+}
+
+@keyframes wp-desktop-radial-peek-pulse {
+	0%, 100% { transform: scale(1); opacity: 0.18; }
+	50%      { transform: scale(1.18); opacity: 0.32; }
+}
+
+/*
+ * Sweep hint — a small double-headed arrow that travels along the
+ * arc above the radial items, scrubbing left to right and back to
+ * tell the user "this whole strip slides". The SVG's coordinate
+ * system is anchored at the FAB centre (translated below), and
+ * the path matches the radial's natural arc but at a slightly
+ * larger radius so it floats just above the icons.
+ */
+.wp-desktop-radial__sweep {
+	position: absolute;
+	left: 50%;
+	bottom: calc(24px + var(--wp-desktop-radial-fab-size) / 2);
+	width: 500px;
+	height: 250px;
+	margin-left: -250px;
+	overflow: visible;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.3s ease 0.15s;
+}
+
+.wp-desktop-radial--open .wp-desktop-radial__sweep {
+	opacity: 1;
+}
+
+/*
+ * Travel the arrow along an arc above the items via CSS
+ * `offset-path`. The path mirrors the natural item arc (radius
+ * 175 from the FAB centre, spanning roughly -100° to +100°) so
+ * the sweep visually rides the upper border of the radial. The
+ * arrow's transform-origin is auto so it stays tangent to the
+ * curve as it moves.
+ */
+.wp-desktop-radial__sweep-arrow {
+	/* Static "scrub" hint pinned above the topmost tile. No
+	 * animation — the icon's presence alone telegraphs that the
+	 * arc is interactive. */
+	transform: translate(0, -188px);
+}
+
+/*
+ * Centre-screen preview thumbnail. When the radial snaps a tile
+ * into the apex slot AND a window of that kind is already open,
+ * this floats in the middle of the viewport. Tapping focuses the
+ * existing window so the user doesn't have to commit to opening
+ * a duplicate. Hidden by default; the JS toggles `--visible` on
+ * snap and clears it on close / no-match.
+ */
+.wp-desktop-radial__preview {
+	position: absolute;
+	left: 50%;
+	top: 38%;
+	transform: translate(-50%, -50%) scale(0.85);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 22px 28px;
+	min-width: 180px;
+	max-width: 75vw;
+	border-radius: 18px;
+	border: 1px solid rgba(255, 255, 255, 0.18);
+	background: rgba(28, 28, 32, 0.55);
+	backdrop-filter: blur(20px) saturate(160%);
+	-webkit-backdrop-filter: blur(20px) saturate(160%);
+	color: #fff;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+	pointer-events: none;
+	opacity: 0;
+	transition:
+		opacity 0.22s ease,
+		transform 0.28s cubic-bezier(0.2, 0.9, 0.2, 1.05);
+}
+
+.wp-desktop-radial__preview--visible {
+	pointer-events: auto;
+	opacity: 1;
+	transform: translate(-50%, -50%) scale(1);
+}
+
+.wp-desktop-radial__preview:active {
+	transform: translate(-50%, -50%) scale(0.96);
+}
+
+.wp-desktop-radial__preview-icon {
+	font-size: 36px;
+	width: 36px;
+	height: 36px;
+	line-height: 1;
+}
+
+.wp-desktop-radial__preview-icon.dashicons,
+.wp-desktop-radial__preview-icon.dashicons::before {
+	font-size: 36px !important;
+	line-height: 1 !important;
+	width: 36px;
+	height: 36px;
+}
+
+.wp-desktop-radial__preview-label {
+	font-size: 15px;
+	font-weight: 600;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	letter-spacing: 0.01em;
+}
+
+.wp-desktop-radial__preview-hint {
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.04em;
+	opacity: 0.7;
+	text-transform: uppercase;
+}
+
+/* Single-match card — same visual as the parent preview but with
+ * the click target being the card itself. Drops border+padding
+ * so the parent preview owns those. */
+.wp-desktop-radial__preview-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 0;
+	background: transparent;
+	border: none;
+	color: inherit;
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+	font: inherit;
+}
+
+/* Multi-match preview: header with summary, then a horizontal
+ * pill strip with one button per matching window. User taps
+ * the pill of the window they want to focus. */
+.wp-desktop-radial__preview--multi {
+	min-width: 240px;
+	max-width: 90vw;
+	padding: 14px 18px 16px;
+}
+
+.wp-desktop-radial__preview-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 10px;
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.wp-desktop-radial__preview-header .wp-desktop-radial__preview-icon {
+	font-size: 22px;
+	width: 22px;
+	height: 22px;
+}
+
+.wp-desktop-radial__preview-header .wp-desktop-radial__preview-icon.dashicons,
+.wp-desktop-radial__preview-header .wp-desktop-radial__preview-icon.dashicons::before {
+	font-size: 22px !important;
+	width: 22px;
+	height: 22px;
+}
+
+.wp-desktop-radial__preview-strip {
+	display: flex;
+	gap: 6px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: none;
+	margin: 0 -4px;
+	padding: 0 4px;
+	scroll-snap-type: x proximity;
+}
+
+.wp-desktop-radial__preview-strip::-webkit-scrollbar {
+	display: none;
+}
+
+.wp-desktop-radial__preview-pill {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 14px;
+	min-height: 36px;
+	min-width: 80px;
+	max-width: 200px;
+	border-radius: 999px;
+	border: 1px solid rgba(255, 255, 255, 0.18);
+	background: rgba(255, 255, 255, 0.08);
+	color: #fff;
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
+	transition: background 0.15s ease, border-color 0.15s ease;
+	scroll-snap-align: start;
+}
+
+.wp-desktop-radial__preview-pill:hover {
+	background: rgba(255, 255, 255, 0.16);
+	border-color: rgba(255, 255, 255, 0.28);
+}
+
+.wp-desktop-radial__preview-pill--focused {
+	background: var(--wp-admin-theme-color, #2271b1);
+	border-color: var(--wp-admin-theme-color, #2271b1);
+}
+
+.wp-desktop-radial__preview-pill-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/*
+ * Make the desktop-icons grid (which renders dock items + plugin
+ * icons in mobile via the `desktop_mode_mobile_grid_items` filter)
+ * feel like a phone home screen. Larger tiles, more breathing
+ * room, multi-column auto-fill.
+ */
+html[data-wp-desktop-mode="mobile"] #wp-desktop-icons,
+html[data-wp-desktop-mode="mobile"] .wp-desktop-icons {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+	gap: 16px;
+	padding: 24px;
+	align-content: start;
+}
+
+html[data-wp-desktop-mode="mobile"] .wp-desktop-icon {
+	position: static !important;
+	left: auto !important;
+	top: auto !important;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,7 @@ Never edit Core's `common.css` or color scheme files. Everything we need is expo
 **Coming up**
 
 - **Polish** — color-scheme-aware variables across every shell surface, View Transitions API animations, full accessibility audit (ARIA, focus traps, keyboard navigation).
-- **Mobile (phone OS)** — `responsive.ts` + `mobile.ts`: home-screen grid, full-screen apps, app switcher, gesture nav, bottom tab bar. `wp.desktop.mode` returns `'desktop' | 'tablet' | 'mobile'`.
+- **Mobile (phone OS)** — `src/mobile/index.ts` (shipped 0.7.0): viewport probe, force-maximize on every window, drag/resize vetoes via `wp-desktop.window.{drag,resize}-allowed` filters, hidden dock, bottom thumbnail switcher (`wp-desktop-mobile-switcher`), `data-wp-desktop-mode="mobile"` attribute on `<html>`. `wp.desktop.mode()` returns the current mode; `wp.desktop.responsive.subscribe(fn)` reacts to flips. The breakpoints (`mobile <= 640`, `tablet <= 1024`) are filterable server-side via `desktop_mode_responsive_breakpoints`. Still planned: gesture nav, pull-to-refresh, app-switcher cards with live thumbnails.
 - **Tablet hybrid** — split view, slide-over overlay, horizontal bottom dock, optional desktop-mode toggle for large tablets.
 - **The North Star — cross-window drag & drop** — extend the existing cross-frame drag bridge beyond Media Library attachments: pluggable mime-type negotiation (`desktop_mode_drag_mime_types` / `desktop_mode_drag_payload` / `desktop_mode_drop_accepts`), Gutenberg block-insertion target, visual lift-and-drop feedback.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -45,5 +45,6 @@ defined( 'ABSPATH' ) || exit;
 - [Render a keyed list without losing clicks — `renderKeyedList()`](./keyed-list.md)
 - [Share state across multi-bundle plugins — `wp.desktop.createSharedStore()`](./shared-store.md)
 - [Track who's around — `wp.desktop.presence`](./presence.md)
+- [React to mobile / responsive mode](./mobile-mode.md)
 
 If your use case isn't here, check [Hooks Reference](../hooks-reference.md) and [JavaScript Reference](../javascript-reference.md) — everything we fire is documented there.

--- a/docs/examples/mobile-mode.md
+++ b/docs/examples/mobile-mode.md
@@ -1,0 +1,107 @@
+# React to mobile / responsive mode
+
+Available since: **0.7.0**.
+
+The shell auto-detects mobile / tablet / desktop viewports, stamps
+`data-wp-desktop-mode="…"` on `<html>`, and enforces a touch-shaped
+window policy in mobile (force-maximize, no drag/resize, hidden dock,
+bottom thumbnail switcher).
+
+Plugins read the current mode via `wp.desktop.mode()` and subscribe
+to flips via `wp.desktop.responsive.subscribe(fn)` or the hook bus.
+
+## CSS-only branching
+
+Most plugin CSS just needs to scope rules under the attribute:
+
+```css
+.my-plugin-sidebar {
+    width: 320px;
+}
+
+html[data-wp-desktop-mode="mobile"] .my-plugin-sidebar {
+    width: 100%;
+    border-radius: 0;
+}
+```
+
+## JS-side branching
+
+```js
+wp.desktop.ready( () => {
+    if ( wp.desktop.mode() === 'mobile' ) {
+        myPlugin.collapseSidebar();
+    }
+
+    wp.desktop.responsive.subscribe( ( mode ) => {
+        document.documentElement.dataset.myAppLayout = mode;
+    } );
+
+    // Or via the action hook for plugin authors already on the bus:
+    wp.desktop.hooks.addAction(
+        wp.desktop.HOOKS.RESPONSIVE_MODE_CHANGED,
+        'myplugin/responsive',
+        ( { from, to, viewport } ) => {
+            console.log( `flipped ${ from } → ${ to } @ ${ viewport.width }px` );
+        }
+    );
+} );
+```
+
+## Force a mode (testing / power-user override)
+
+```js
+// Pin desktop layout regardless of viewport.
+wp.desktop.responsive.override( 'desktop' );
+
+// Resume viewport-driven detection.
+wp.desktop.responsive.override( null );
+```
+
+The override is in-memory only — refresh restores the probe-driven
+default. If you need a persistent "always desktop on this device"
+preference, store the flag in your plugin's user-meta and re-apply
+on every page load.
+
+## Re-tune breakpoints (server-side)
+
+```php
+add_filter( 'desktop_mode_responsive_breakpoints', function ( $bp ) {
+    $bp['mobile'] = 720; // treat 720px and below as mobile
+    return $bp;
+} );
+```
+
+## Veto drag / resize for a specific window
+
+The mobile module already returns `false` for these filters when the
+mode is `'mobile'`. Plugins can layer additional vetoes — e.g. while
+a custom modal is showing inside a window:
+
+```js
+wp.desktop.hooks.addFilter(
+    wp.desktop.HOOKS.WINDOW_DRAG_ALLOWED,
+    'myplugin/lock-during-modal',
+    ( allowed, { windowId } ) => (
+        allowed && ! myPlugin.isModalOpen( windowId )
+    )
+);
+```
+
+## Replace the bottom switcher tile list
+
+```js
+wp.desktop.hooks.addFilter(
+    'desktop_mode_mobile_app_switcher',
+    'myplugin/highlight-active',
+    ( windows ) => {
+        // Move the focused window to the front of the strip.
+        const focused = wp.desktop.windowManager.getFocused();
+        if ( ! focused ) return windows;
+        return [
+            focused,
+            ...windows.filter( ( w ) => w.id !== focused.id ),
+        ];
+    }
+);
+```

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1207,14 +1207,44 @@ apply_filters( 'desktop_mode_icon',         array  $icon_config, string $icon_id
 
 > `desktop_mode_icons` and `desktop_mode_wallpapers` and the widget registry filter are **shipped** — see their Stable entries above. `desktop_mode_widgets` is not a PHP filter; the JS-side `wp-desktop.widgets` filter is the canonical hook (widgets are declared via `desktop_mode_register_widget()` server-side).
 
-### Responsive — Phase 5–6
+### Responsive — Stable (mobile mode shipped 0.7.0)
+
 ```php
-apply_filters( 'desktop_mode_mode_type',           string $mode );   // 'desktop' | 'tablet' | 'mobile'
+apply_filters( 'desktop_mode_mode_type',                string $mode );   // 'desktop' | 'tablet' | 'mobile'
+apply_filters( 'desktop_mode_responsive_breakpoints',   array  $bps );    // { mobile: 640, tablet: 1024 }
+```
+
+`desktop_mode_mode_type` is the server-side initial guess (defaults
+to `wp_is_mobile() ? 'mobile' : 'desktop'`). The JS probe corrects
+on first paint based on the actual viewport — the filter exists to
+seed the `data-wp-desktop-mode` attribute so phones don't see a
+one-frame flash of desktop chrome.
+
+`desktop_mode_responsive_breakpoints` lets admins retune the cutoff:
+viewports `<= mobile` become mobile, `<= tablet` (and `> mobile`)
+become tablet, anything wider is desktop.
+
+JS-side filters (callable via `wp.desktop.hooks.addFilter`):
+
+| Filter | Default | Context | Notes |
+|---|---|---|---|
+| `desktop_mode_responsive_resolve` | `'desktop' \| 'tablet' \| 'mobile'` | `{ width }` | Final say on the resolved mode. Plugins can pin a mode regardless of viewport (e.g. always desktop on a specific tab). |
+| `wp-desktop.window.drag-allowed` | `true` | `{ windowId, mode, event }` | Mobile module returns `false` here. Plugins can layer additional drag vetoes (e.g. while a modal is showing). |
+| `wp-desktop.window.resize-allowed` | `true` | `{ windowId, mode, event }` | Same shape — mobile pins it `false`. |
+| `desktop_mode_mobile_app_switcher` | `Window[]` | none | Filters the tile list shown in the bottom switcher. Active-desktop only by default. |
+
+Reserved-but-not-yet-fired:
+
+```php
 apply_filters( 'desktop_mode_mobile_grid_items',   array  $items );
 apply_filters( 'desktop_mode_mobile_tab_bar',      array  $tabs );
-apply_filters( 'desktop_mode_mobile_app_switcher', array  $cards );
 apply_filters( 'desktop_mode_tablet_split_config', array  $config );
 ```
+
+The `RESPONSIVE_MODE_CHANGED` action fires on every mode flip;
+subscribe via `wp.desktop.hooks.addAction( wp.desktop.HOOKS.RESPONSIVE_MODE_CHANGED, … )`. The
+`wp-desktop-mode-changed` `CustomEvent` on `document` carries the
+same `{ from, to, viewport }` detail.
 
 ### Native windows — reserved extensions
 ```php

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -241,6 +241,34 @@ document.addEventListener( 'wp-desktop-layout-changed', ( e ) => {
 
 ---
 
+### `wp-desktop-mode-changed` — Stable *(since 0.7.0)*
+Fires whenever the responsive layout mode flips. Mode is one of
+`'desktop' | 'tablet' | 'mobile'`. The shell stamps the resolved
+mode on `<html data-wp-desktop-mode="…">` so plugins can also
+key off the attribute via CSS.
+
+```typescript
+{
+    from:    'desktop' | 'tablet' | 'mobile',
+    to:      'desktop' | 'tablet' | 'mobile',
+    viewport: { width: number, height: number },
+}
+```
+
+The matching `wp.desktop.HOOKS.RESPONSIVE_MODE_CHANGED` action fires
+on the same payload (preferred entry point for plugins already
+hook-bus aware). Plugin-side detection of mobile mode:
+
+```javascript
+if ( wp.desktop.mode() === 'mobile' ) { /* … */ }
+
+const off = wp.desktop.responsive.subscribe( ( mode ) => {
+    document.documentElement.dataset.myAppLayout = mode;
+} );
+```
+
+---
+
 ### `wp-desktop-drag-start` — Planned (Phase 8)
 Will fire when a drag operation escalates across window boundaries.
 
@@ -753,6 +781,45 @@ A debounced function that schedules a session write. Call it after mutating wind
 ```javascript
 window.wp.desktop.windowManager.focus( someWindow );
 window.wp.desktop.saveSession();
+```
+
+---
+
+### `mode()` / `responsive` — Stable *(since 0.7.0)*
+
+`wp.desktop.mode()` is a synchronous accessor for the current
+responsive layout — `'desktop' | 'tablet' | 'mobile'`. The
+mode is also stamped on `<html data-wp-desktop-mode="…">` so
+plugin CSS can react without subscribing.
+
+`wp.desktop.responsive.subscribe( fn )` returns an unsubscribe.
+`fn` is invoked on every flip (not on initial mount — combine with
+a synchronous `wp.desktop.mode()` read if you need both).
+
+`wp.desktop.responsive.override( mode | null )` pins the mode
+in-memory (does **not** persist) regardless of viewport. Pass
+`null` to resume viewport-driven detection. Useful for tests and
+power-user "always desktop on this phone" preferences.
+
+Mobile mode behavior:
+- `<html>` carries `data-wp-desktop-mode="mobile"`.
+- The dock is hidden; an icon grid on the wallpaper replaces it.
+- Windows are force-maximized; drag and resize are vetoed via the
+  `wp-desktop.window.{drag,resize}-allowed` filters.
+- The minimize / maximize controls are hidden in the title bar.
+- A bottom thumbnail strip (`wp-desktop-mobile-switcher`) lists
+  every open window on the active desktop.
+
+```javascript
+if ( wp.desktop.mode() === 'mobile' ) {
+    // hide a feature that doesn't make sense on small screens
+}
+
+const off = wp.desktop.responsive.subscribe( ( mode ) => {
+    if ( mode === 'mobile' ) {
+        myPlugin.collapseSidebar();
+    }
+} );
 ```
 
 ---

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -59,6 +59,12 @@ function desktop_mode_register_assets() {
 		$version
 	);
 	wp_register_style(
+		'wp-desktop-mobile',
+		DESKTOP_MODE_URL . 'assets/css/mobile.css',
+		array( 'wp-desktop-variables', 'wp-desktop' ),
+		$version
+	);
+	wp_register_style(
 		'wp-desktop-chromeless',
 		DESKTOP_MODE_URL . 'assets/css/chromeless.css',
 		array( 'wp-desktop' ),

--- a/includes/render.php
+++ b/includes/render.php
@@ -94,6 +94,7 @@ function desktop_mode_enqueue_assets() {
 	wp_enqueue_style( 'wp-desktop' );
 	wp_enqueue_style( 'wp-desktop-windows' );
 	wp_enqueue_style( 'wp-desktop-dock' );
+	wp_enqueue_style( 'wp-desktop-mobile' );
 	wp_enqueue_style( 'wp-desktop-ai-assistant' );
 
 	// JS.
@@ -279,6 +280,38 @@ function desktop_mode_enqueue_assets() {
 			'currentUserIsAdmin'    => current_user_can( 'manage_options' ),
 			'portalUrl'        => esc_url( desktop_mode_portal_url() ),
 			'fromPortal'       => $from_portal,
+			/**
+			 * Filters the responsive breakpoints used by the JS probe.
+			 *
+			 * Viewports `<= mobile` are mobile, viewports `<= tablet`
+			 * (and `> mobile`) are tablet, anything wider is desktop.
+			 *
+			 * @since 0.7.0
+			 *
+			 * @param array $breakpoints { mobile: int, tablet: int }.
+			 */
+			'responsiveBreakpoints' => apply_filters(
+				'desktop_mode_responsive_breakpoints',
+				array(
+					'mobile' => 640,
+					'tablet' => 1024,
+				)
+			),
+			/**
+			 * Filters the server-side initial guess at the responsive
+			 * mode. The JS probe corrects on first paint based on the
+			 * actual viewport — this value just sets the initial
+			 * `data-wp-desktop-mode` attribute so phones don't see a
+			 * one-frame flash of desktop chrome.
+			 *
+			 * @since 0.7.0
+			 *
+			 * @param string $mode One of 'desktop', 'tablet', 'mobile'.
+			 */
+			'initialMode'      => apply_filters(
+				'desktop_mode_mode_type',
+				wp_is_mobile() ? 'mobile' : 'desktop'
+			),
 		)
 	);
 

--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -36,7 +36,7 @@
 
 import { activity } from './activity';
 import { __, _n, sprintf } from './i18n';
-import { doAction, HOOKS } from './hooks';
+import { applyFilters, doAction, HOOKS } from './hooks';
 import { sanitizeClassName } from './utils';
 import type { DesktopIconServerEntry } from './types';
 import type { WindowManager } from './window-manager';
@@ -259,6 +259,47 @@ function fingerprintIcons(
 }
 
 let _lastFingerprint = '';
+let _lastRender:
+	| {
+		host: HTMLElement;
+		icons: readonly DesktopIconServerEntry[] | undefined;
+		deps: DesktopIconRenderDeps;
+	}
+	| null = null;
+
+/**
+ * Bust the icon-fingerprint cache so the next call to
+ * `renderDesktopIcons` always rebuilds, even when the input
+ * `icons` array hasn't changed. Used by the mobile layer when
+ * the responsive mode flips — the input list is the same but
+ * the `desktop_mode_desktop_icons` filter now produces a
+ * different output, and the fingerprint can't see filter output.
+ *
+ * @internal
+ */
+export function resetDesktopIconsFingerprint(): void {
+	_lastFingerprint = '';
+}
+
+/**
+ * Re-run the most recent `renderDesktopIcons` call with the
+ * fingerprint cache cleared. Lets the mobile layer force an
+ * immediate repaint when its `desktop_mode_desktop_icons`
+ * filter starts producing different output (mode flip), without
+ * waiting for the next live menu refresh REST round-trip.
+ *
+ * Returns `false` when no prior render has been recorded.
+ *
+ * @internal
+ */
+export function repaintDesktopIcons(): boolean {
+	if ( ! _lastRender ) {
+		return false;
+	}
+	_lastFingerprint = '';
+	renderDesktopIcons( _lastRender.host, _lastRender.icons, _lastRender.deps );
+	return true;
+}
 
 /**
  * Mount the icons grid on the desktop area. Safe to call repeatedly —
@@ -282,6 +323,23 @@ export function renderDesktopIcons(
 	icons: readonly DesktopIconServerEntry[] | undefined,
 	deps: DesktopIconRenderDeps,
 ): void {
+	// Snapshot the last call before the filter so `repaintDesktopIcons`
+	// can re-run with the original input — the filter's output
+	// depends on live state (responsive mode, plugin filters), so
+	// reapplying the filter to a stored result would compound.
+	_lastRender = { host, icons, deps };
+
+	// Filter pass — lets plugins (and the mobile module) inject,
+	// reorder, or remove icons before the grid is built. The
+	// filter receives the full list and returns the list to
+	// render. Mobile mode hooks this to merge every admin-menu
+	// item into the icon grid so the wallpaper acts as a phone
+	// home screen.
+	icons = applyFilters< readonly DesktopIconServerEntry[] | undefined, [] >(
+		'desktop_mode_desktop_icons',
+		icons,
+	);
+
 	// Bail when the icon list hasn't changed since our last
 	// render. This is the cheapest correct fix for "any plugin
 	// that decorates an icon (drag handle, status dot) has its

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -13,6 +13,12 @@
 import { WindowManager } from './window-manager';
 import { installWindowSwitcherShortcut } from './window-manager/switcher';
 import {
+	bootMobile,
+	getMode as getResponsiveMode,
+	getResponsiveApi,
+	type ResponsiveApi,
+} from './mobile';
+import {
 	installWindowLoadingTransitions,
 	repaintLoadingOverlays,
 } from './window/loading';
@@ -338,6 +344,24 @@ export interface WpDesktopPublicApi {
 	 * ```
 	 */
 	HOOKS: typeof import( './hooks' ).HOOKS;
+	/**
+	 * Current responsive layout mode — `'desktop' | 'tablet' | 'mobile'`.
+	 * Cheap synchronous accessor; for change notifications subscribe via
+	 * `wp.desktop.responsive.subscribe(fn)` or the
+	 * `wp-desktop.responsive.mode-changed` hook.
+	 *
+	 * @since 0.7.0
+	 */
+	mode: () => import( './types' ).DesktopMode;
+	/**
+	 * Responsive helpers. `subscribe(fn)` returns an unsubscribe; calls
+	 * `fn(mode)` on every flip. `override(mode | null)` forces a mode
+	 * (in-memory only — does not persist) for testing or the rare
+	 * power-user "always desktop" preference.
+	 *
+	 * @since 0.7.0
+	 */
+	responsive: ResponsiveApi;
 	/**
 	 * True when the desktop shell is mounted and active on this page.
 	 * Cheap capability check for plugins that also run in classic
@@ -2021,6 +2045,8 @@ function init(): void {
 		saveSession,
 		hooks: rawHooks(),
 		HOOKS,
+		mode: getResponsiveMode,
+		responsive: getResponsiveApi(),
 		isActive: () => !! document.getElementById( 'wp-desktop-shell' ),
 		registerWallpaper: ( def: WallpaperDef ) => {
 			registry.register( def );
@@ -2284,6 +2310,15 @@ function init(): void {
 	// `wp-desktop.open-command.items` can rely on the command being
 	// in the registry.
 	registerBuiltInCommands();
+
+	// Mobile / responsive layer — detection, force-maximize, bottom
+	// switcher, drag/resize gates. Boots before HOOKS.INIT so plugin
+	// init subscribers can subscribe to RESPONSIVE_MODE_CHANGED.
+	bootMobile( manager, {
+		breakpoints: config.responsiveBreakpoints,
+		initialMode: config.initialMode,
+		config,
+	} );
 
 	doAction( HOOKS.INIT, { config } );
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -978,6 +978,41 @@ export const HOOKS = {
 	 * @since 0.18.0
 	 */
 	IFRAME_CONNECTION_REQUEST: 'wp-desktop.iframe.connection-request',
+
+	// ------------------------------------------------------------------
+	// Responsive / mobile mode (since 0.7.0).
+	// ------------------------------------------------------------------
+	/**
+	 * Action — fires when the responsive mode flips between
+	 * `'desktop'`, `'tablet'`, and `'mobile'`. Payload:
+	 * `{ from: DesktopMode, to: DesktopMode, viewport: { width: number; height: number } }`.
+	 * Plugins that maintain mode-specific UI (a sidebar that should
+	 * collapse on phone widths, a toolbar that should reshape) listen
+	 * here. The matching `wp-desktop-mode-changed` CustomEvent is
+	 * dispatched on `document` with the same detail.
+	 *
+	 * @since 0.7.0
+	 */
+	RESPONSIVE_MODE_CHANGED: 'wp-desktop.responsive.mode-changed',
+	/**
+	 * Filter — gates whether a window may begin a drag session. Fires
+	 * at the top of the title-bar pointerdown handler with default
+	 * value `true`. Return `false` to suppress drag (used by mobile
+	 * mode to make windows non-draggable). `$context` carries
+	 * `{ windowId, mode, event }`.
+	 *
+	 * @since 0.7.0
+	 */
+	WINDOW_DRAG_ALLOWED: 'wp-desktop.window.drag-allowed',
+	/**
+	 * Filter — gates whether a window may begin a resize session.
+	 * Fires at the top of the resize-handle pointerdown handler with
+	 * default value `true`. Return `false` to suppress resize.
+	 * `$context` carries `{ windowId, mode, event }`.
+	 *
+	 * @since 0.7.0
+	 */
+	WINDOW_RESIZE_ALLOWED: 'wp-desktop.window.resize-allowed',
 } as const;
 
 /**

--- a/src/mobile/index.ts
+++ b/src/mobile/index.ts
@@ -1,0 +1,357 @@
+/**
+ * Desktop Mode — Mobile / responsive layer.
+ *
+ * Detects the responsive mode (`'desktop' | 'tablet' | 'mobile'`),
+ * stamps it on `<html data-wp-desktop-mode="…">`, dispatches a
+ * `RESPONSIVE_MODE_CHANGED` action + `wp-desktop-mode-changed`
+ * CustomEvent on every flip, and — when the mode is `'mobile'` —
+ * mounts the bottom thumbnail switcher and applies the mobile
+ * window-shape policy (force-maximize, suppress drag/resize,
+ * suppress min/max controls).
+ *
+ * The CSS in `assets/css/mobile.css` does the heavy visual lifting.
+ * This module owns the thin TS layer that has to react to runtime
+ * state — viewport changes, window open/close/focus, mode flips.
+ *
+ * @since 0.7.0
+ */
+
+import {
+	HOOKS,
+	addAction,
+	addFilter,
+	applyFilters,
+	doAction,
+} from '../hooks';
+import type { DesktopConfig, DesktopMode } from '../types';
+import type { WindowManager } from '../window-manager';
+import { RadialLauncher } from './radial';
+import { repaintDesktopIcons } from '../desktop-icons';
+
+const MODE_ATTR = 'data-wp-desktop-mode';
+
+const DEFAULT_BREAKPOINTS = { mobile: 640, tablet: 1024 } as const;
+
+let _override: DesktopMode | null = null;
+let _currentMode: DesktopMode = 'desktop';
+let _breakpoints: { mobile: number; tablet: number } = { ...DEFAULT_BREAKPOINTS };
+const _subscribers = new Set<( mode: DesktopMode ) => void>();
+
+/**
+ * Resolve a mode for a given viewport width. Plugins can override
+ * the result via the `desktop_mode_responsive_resolve` filter.
+ */
+export function resolveMode( width: number ): DesktopMode {
+	let base: DesktopMode;
+	if ( _override ) {
+		base = _override;
+	} else if ( width <= _breakpoints.mobile ) {
+		base = 'mobile';
+	} else if ( width <= _breakpoints.tablet ) {
+		base = 'tablet';
+	} else {
+		base = 'desktop';
+	}
+	return applyFilters< DesktopMode, [ { width: number } ] >(
+		'desktop_mode_responsive_resolve',
+		base,
+		{ width },
+	);
+}
+
+/** Read the current resolved mode. Cheap synchronous accessor. */
+export function getMode(): DesktopMode {
+	return _currentMode;
+}
+
+/** Subscribe to mode flips. Returns an unsubscribe function. */
+export function subscribe( fn: ( mode: DesktopMode ) => void ): () => void {
+	_subscribers.add( fn );
+	return () => {
+		_subscribers.delete( fn );
+	};
+}
+
+/**
+ * Force a mode regardless of viewport (in-memory only — does not
+ * persist). Pass `null` to clear the override and resume
+ * viewport-driven detection. Useful for testing and for the rare
+ * power-user "always desktop on this phone" preference.
+ */
+export function setOverride( mode: DesktopMode | null ): void {
+	_override = mode;
+	tick();
+}
+
+/**
+ * Mobile mode pins every window to the maximized rect. This
+ * supersedes the saved geometry while mobile is active; on flip back
+ * to desktop the windows return to their saved geometry through
+ * `toggleMaximize` because we set `state = 'maximized'` and capture
+ * `_savedGeometry` first.
+ */
+function maximizeAll( manager: WindowManager ): void {
+	for ( const win of manager.getAll() ) {
+		if ( win.state !== 'maximized' && win.state !== 'minimized' ) {
+			try {
+				win.maximize();
+			} catch {
+				/* swallow — one bad window mustn't strand the rest */
+			}
+		}
+	}
+}
+
+/**
+ * Tick the probe — recompute mode from the viewport, apply the
+ * attribute, fire events when it changes.
+ */
+let _scheduled = false;
+function tick(): void {
+	if ( _scheduled ) {
+		return;
+	}
+	_scheduled = true;
+	requestAnimationFrame( () => {
+		_scheduled = false;
+		const width = window.innerWidth;
+		const next = resolveMode( width );
+		if ( next === _currentMode ) {
+			return;
+		}
+		const prev = _currentMode;
+		_currentMode = next;
+		document.documentElement.setAttribute( MODE_ATTR, next );
+		const detail = {
+			from: prev,
+			to: next,
+			viewport: { width, height: window.innerHeight },
+		};
+		doAction( HOOKS.RESPONSIVE_MODE_CHANGED, detail );
+		document.dispatchEvent(
+			new CustomEvent( 'wp-desktop-mode-changed', { detail } ),
+		);
+		_subscribers.forEach( ( fn ) => {
+			try {
+				fn( next );
+			} catch {
+				/* swallow */
+			}
+		} );
+	} );
+}
+
+/**
+ * Bootstrap the responsive layer. Called from `desktop.ts` after the
+ * window manager exists. Idempotent.
+ */
+export function bootMobile(
+	manager: WindowManager,
+	options: {
+		breakpoints?: { mobile: number; tablet: number };
+		initialMode?: DesktopMode;
+		config?: DesktopConfig;
+	} = {},
+): void {
+	if ( options.breakpoints ) {
+		_breakpoints = { ...options.breakpoints };
+	}
+
+	// Use the server's initial guess to stamp the attribute before the
+	// first probe tick — eliminates a one-frame flash of desktop chrome
+	// on phones. Leave `_currentMode` at the default `'desktop'` so the
+	// first real tick fires `RESPONSIVE_MODE_CHANGED` and the
+	// subscribers below mount the launcher / force-maximize windows.
+	if ( options.initialMode ) {
+		document.documentElement.setAttribute( MODE_ATTR, options.initialMode );
+	}
+
+	// Mode-driven radial launcher mount/unmount. Replaces the old
+	// bottom thumbnail strip — see `./radial.ts`.
+	let launcher: RadialLauncher | null = null;
+	subscribe( ( mode ) => {
+		if ( mode === 'mobile' ) {
+			if ( ! launcher && options.config ) {
+				launcher = new RadialLauncher( manager, options.config );
+				launcher.mount();
+			}
+			maximizeAll( manager );
+		} else if ( launcher ) {
+			launcher.unmount();
+			launcher = null;
+		}
+	} );
+
+	// Mobile mode vetoes drag and resize. The pointer handlers read
+	// the mode attribute directly to avoid an import cycle, so the
+	// filter only needs to fire — no module-level state to maintain
+	// here. Plugins can layer additional vetoes on top.
+	addFilter<
+		boolean,
+		[ { windowId: string; mode: DesktopMode; event: PointerEvent } ]
+	>(
+		HOOKS.WINDOW_DRAG_ALLOWED,
+		'wp-desktop-mode/mobile',
+		( allowed, { mode } ) => ( mode === 'mobile' ? false : allowed ),
+	);
+	addFilter<
+		boolean,
+		[ { windowId: string; mode: DesktopMode; event: PointerEvent } ]
+	>(
+		HOOKS.WINDOW_RESIZE_ALLOWED,
+		'wp-desktop-mode/mobile',
+		( allowed, { mode } ) => ( mode === 'mobile' ? false : allowed ),
+	);
+
+	// Force-maximize on every new window while in mobile mode.
+	addAction< [ { windowId: string } ] >(
+		HOOKS.WINDOW_OPENED,
+		'wp-desktop-mode/mobile-maximize',
+		( { windowId } ) => {
+			if ( _currentMode !== 'mobile' ) {
+				return;
+			}
+			const win = manager.getById( windowId );
+			if ( win && win.state !== 'maximized' ) {
+				try {
+					win.maximize();
+				} catch {
+					/* swallow */
+				}
+			}
+		},
+	);
+
+	// Scroll new iframes to the top once their bridge announces
+	// readiness. WordPress admin pages on narrow viewports often
+	// land scrolled to a focused field, an admin notice, or the
+	// last save's status banner — fine on desktop where a 1080-px
+	// page rarely scrolls, jarring on mobile where the user
+	// instinctively expects "open page = top of page". Same-origin
+	// iframes let us call `contentWindow.scrollTo` directly.
+	addAction< [ { windowId: string } ] >(
+		HOOKS.IFRAME_READY,
+		'wp-desktop-mode/mobile-scroll-top',
+		( { windowId } ) => {
+			if ( _currentMode !== 'mobile' ) {
+				return;
+			}
+			const win = manager.getById( windowId );
+			if ( ! win ) {
+				return;
+			}
+			const iframe = ( win as unknown as { iframe?: HTMLIFrameElement } )
+				.iframe;
+			if ( ! iframe ) {
+				return;
+			}
+			try {
+				iframe.contentWindow?.scrollTo( 0, 0 );
+				iframe.contentDocument?.documentElement?.scrollTo( 0, 0 );
+				if ( iframe.contentDocument?.body ) {
+					iframe.contentDocument.body.scrollTop = 0;
+				}
+			} catch {
+				/* cross-origin or torn-down — give up silently */
+			}
+		},
+	);
+
+	// In mobile mode, every admin-menu item the dock would render
+	// (Dashboard, Posts, Pages, Plugins, Users, Settings, every
+	// CPT, every plugin-contributed top-level page…) becomes a
+	// home-screen icon on the wallpaper alongside the
+	// server-registered desktop icons. Outside mobile mode we
+	// don't touch the list — the dock is visible and rendering
+	// dock items twice would be noise.
+	type IconEntry = import( '../types' ).DesktopIconServerEntry;
+	addFilter<
+		readonly IconEntry[] | undefined,
+		[]
+	>(
+		'desktop_mode_desktop_icons',
+		'wp-desktop-mode/mobile-home-grid',
+		( icons ) => {
+			// Read live from the attribute the probe stamps on
+			// `<html>` rather than the module-local `_currentMode`
+			// — the attribute is set as soon as `bootMobile` runs
+			// (using the server's `initialMode` guess), whereas
+			// `_currentMode` lags by one rAF until the first probe
+			// tick. On a phone the very first `renderDesktopIcons`
+			// call would otherwise see `_currentMode === 'desktop'`
+			// even though the layout is already mobile, and skip
+			// the merge.
+			const liveMode = document.documentElement.getAttribute(
+				'data-wp-desktop-mode',
+			);
+			if ( liveMode !== 'mobile' ) {
+				return icons;
+			}
+			const dockItems = options.config?.dockItems ?? [];
+			if ( dockItems.length === 0 ) {
+				return icons;
+			}
+			const existingIds = new Set( ( icons ?? [] ).map( ( i ) => i.id ) );
+			const synthetic: IconEntry[] = [];
+			dockItems.forEach( ( item, idx ) => {
+				const id = `wpdm-mobile-dock:${ item.id }`;
+				if ( existingIds.has( id ) ) {
+					return;
+				}
+				synthetic.push( {
+					id,
+					title: item.title,
+					icon: item.icon || 'dashicons-admin-generic',
+					window: '',
+					url: item.url,
+					// Render dock-derived icons after the
+					// server-registered ones; large offset keeps
+					// custom plugin icon ordering predictable.
+					position: 1000 + idx,
+				} );
+			} );
+			return [ ...( icons ?? [] ), ...synthetic ];
+		},
+	);
+
+	// Re-render the icon grid whenever we flip in or out of mobile
+	// mode so the merged list takes effect immediately. We replay
+	// the last `renderDesktopIcons` call with the fingerprint
+	// cache busted; the filter chain re-applies under the new
+	// mode and the wallpaper grid repaints in-place — no REST
+	// round-trip required.
+	subscribe( () => {
+		try {
+			repaintDesktopIcons();
+		} catch {
+			/* swallow — best-effort live refresh */
+		}
+	} );
+
+	// Probe — single ResizeObserver on the documentElement gives us
+	// width changes coalesced cheaply.
+	const probe = new ResizeObserver( () => tick() );
+	probe.observe( document.documentElement );
+
+	// Also tick on orientationchange (some browsers fire that without
+	// a resize) and on pageshow (BFCache restore).
+	window.addEventListener( 'orientationchange', tick );
+	window.addEventListener( 'pageshow', tick );
+
+	// Initial tick — runs on next rAF so the desktop bootstrap has a
+	// chance to settle first.
+	tick();
+}
+
+/**
+ * Public mobile API — exposed via `wp.desktop.mode` /
+ * `wp.desktop.responsive`.
+ */
+export interface ResponsiveApi {
+	subscribe: ( fn: ( mode: DesktopMode ) => void ) => () => void;
+	override: ( mode: DesktopMode | null ) => void;
+}
+
+export function getResponsiveApi(): ResponsiveApi {
+	return { subscribe, override: setOverride };
+}

--- a/src/mobile/radial.ts
+++ b/src/mobile/radial.ts
@@ -1,0 +1,1171 @@
+/**
+ * Mobile radial launcher.
+ *
+ * Replaces the bottom thumbnail strip with a single floating "+"
+ * button that expands into a radial fan of icons above it. Items
+ * scroll left/right by horizontal pan. Tapping a leaf opens (or
+ * focuses) its window; tapping a parent re-roots the radial on
+ * that item and fans out its submenu, with a back affordance on
+ * the centre. Items whose URL matches an open window get an
+ * "active" ring so the radial doubles as the app switcher — tap
+ * to focus instead of re-open.
+ *
+ * @since 0.7.0
+ */
+
+import { addAction, applyFilters, HOOKS } from '../hooks';
+import type { WindowManager } from '../window-manager';
+import type { DesktopConfig, DockItemConfig } from '../types';
+import { urlMatchKey } from '../utils';
+
+interface RadialNode {
+	id: string;
+	title: string;
+	icon: string;
+	url: string;
+	children: RadialNode[];
+	/**
+	 * When set, tapping this node focuses the matching open
+	 * window directly (by `windowManager.getById`) instead of
+	 * routing through the URL-match-or-open path. Used for the
+	 * "open windows" prefix at the root of the radial.
+	 */
+	windowId?: string;
+	/**
+	 * Whether this admin page supports multiple simultaneous
+	 * windows. List screens (Posts, Pages, Media, Users) are
+	 * true; singletons (Dashboard, Settings) are false. Drives
+	 * the "tap icon = open new" vs. "tap icon = focus existing"
+	 * branch in `activate()`.
+	 */
+	multi: boolean;
+	/**
+	 * Native-window id (`config.nativeWindows[].id`). When set,
+	 * tapping routes through `wp.desktop.openWindow(id)` —
+	 * native windows have no admin URL to load, only a registered
+	 * id the shell resolves to a `<template>` clone.
+	 */
+	nativeId?: string;
+}
+
+const ARC_RADIUS = 140;
+/** Step in radians between adjacent items inside the visible arc. ~46°. */
+const ITEM_STEP = ( 46 * Math.PI ) / 180;
+/** Visible half-arc in radians (items outside collapse + fade). ~95°. */
+const VISIBLE_HALF = ( 95 * Math.PI ) / 180;
+/**
+ * Outside the visible cone we collapse adjacent items into the same
+ * angular slot so they overlap at the edge — that overlap reads as
+ * "more icons live here, scroll to reveal" without spreading the
+ * out-of-view items wide enough to need extra screen real estate.
+ */
+const OFF_ARC_COMPRESSION = 0.18;
+
+function adaptDockItem( item: DockItemConfig ): RadialNode {
+	const multi = !! item.multi;
+	const parentIcon = item.icon || 'dashicons-admin-generic';
+	return {
+		id: item.id,
+		title: item.title,
+		icon: parentIcon,
+		url: item.url,
+		multi,
+		children: ( item.submenu || [] ).map( ( s, idx ) => ( {
+			id: `${ item.id }/sub-${ idx }`,
+			title: s.title,
+			// Submenu items inherit the parent's icon — the radial
+			// reads "I'm inside Posts" via the centre FAB switching
+			// to the Posts dashicon, and every fan-out tile sharing
+			// that same icon reinforces "still in Posts" rather
+			// than displaying a generic chevron that says nothing.
+			icon: parentIcon,
+			url: s.url,
+			children: [],
+			// Submenu items inherit the parent's multi flag — a
+			// "Posts > All Posts" landing is just as multi-able as
+			// "Posts" itself, while "Settings > General" stays
+			// singleton-by-default.
+			multi,
+		} ) ),
+	};
+}
+
+export class RadialLauncher {
+	private manager: WindowManager;
+	private config: DesktopConfig;
+	private root: HTMLElement;
+	private fab: HTMLButtonElement;
+	private arc: HTMLElement;
+	private gesturePad!: HTMLElement;
+	private backdrop: HTMLElement;
+	private centreLabel: HTMLElement;
+	private preview!: HTMLDivElement;
+	private actions!: HTMLDivElement;
+	private rotation = 0;
+	private isOpen = false;
+	/** Stack of nodes representing the current drill path. Top = current parent. */
+	private path: Array< RadialNode | null > = [ null ];
+	private hookNs = 'wp-desktop-mode/mobile-radial';
+	/** State machine for the FAB visibility — peeking (half hidden) ↔ revealed. */
+	private peekState: 'peeking' | 'revealed' = 'peeking';
+	private peekTimer: number | null = null;
+	private readonly PEEK_TIMEOUT_MS = 3000;
+	/** Pixels of movement that disqualify a pointerup as a tap. */
+	private readonly DRAG_THRESHOLD_PX = 8;
+	/** Last rendered scene id. Used to decide enter animations. */
+	private lastSceneId: string | null = null;
+
+	constructor( manager: WindowManager, config: DesktopConfig ) {
+		this.manager = manager;
+		this.config = config;
+
+		this.root = document.createElement( 'div' );
+		this.root.className = 'wp-desktop-radial';
+		this.root.setAttribute( 'role', 'navigation' );
+		this.root.setAttribute( 'aria-label', 'Mobile launcher' );
+
+		this.backdrop = document.createElement( 'div' );
+		this.backdrop.className = 'wp-desktop-radial__backdrop';
+		this.backdrop.addEventListener( 'pointerup', () => this.close() );
+		this.root.appendChild( this.backdrop );
+
+		// Gesture pad — a wide invisible hit-area covering the
+		// entire arc region (and some breathing room around it).
+		// Drag anywhere inside this pad rotates the radial; the
+		// previous design only registered drags on the 1×1 arc
+		// origin, so the user had to start from a tile to scroll.
+		// Sits behind the actual arc element in z-order so taps on
+		// individual tiles still reach the tile (the gesture
+		// handler uses `elementFromPoint` to tell the two apart).
+		this.gesturePad = document.createElement( 'div' );
+		this.gesturePad.className = 'wp-desktop-radial__gesture-pad';
+		this.gesturePad.setAttribute( 'aria-hidden', 'true' );
+		this.root.appendChild( this.gesturePad );
+
+		this.arc = document.createElement( 'div' );
+		this.arc.className = 'wp-desktop-radial__arc';
+		this.root.appendChild( this.arc );
+
+		// Centre-preview thumbnail. When the user pans the radial
+		// the icon nearest the apex "snaps" into focus; if a window
+		// of that kind is already open we float a translucent
+		// thumbnail in the middle of the screen so the user can
+		// jump to the existing instance with one tap. Hidden by
+		// default, populated on snap.
+		this.preview = document.createElement( 'div' );
+		this.preview.className = 'wp-desktop-radial__preview';
+		this.preview.setAttribute( 'aria-hidden', 'true' );
+		this.preview.setAttribute( 'role', 'group' );
+		this.root.appendChild( this.preview );
+
+		// Window action chips — Refresh + Close for the currently
+		// focused window. Title bars are removed in mobile mode so
+		// these chips are the user's only path to those actions.
+		// They fan out either side of the FAB only while the radial
+		// is open and a window is focused; closed-radial mode keeps
+		// the bottom edge clean for the peeking FAB alone.
+		this.actions = document.createElement( 'div' );
+		this.actions.className = 'wp-desktop-radial__actions';
+		this.actions.setAttribute( 'aria-hidden', 'true' );
+		this.actions.innerHTML = `
+			<button type="button"
+				class="wp-desktop-radial__action wp-desktop-radial__action--reload"
+				aria-label="Reload current window">
+				<span class="dashicons dashicons-update-alt" aria-hidden="true"></span>
+			</button>
+			<button type="button"
+				class="wp-desktop-radial__action wp-desktop-radial__action--close"
+				aria-label="Close current window">
+				<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+			</button>
+		`;
+		const reloadBtn = this.actions.querySelector< HTMLButtonElement >(
+			'.wp-desktop-radial__action--reload',
+		);
+		const closeBtn = this.actions.querySelector< HTMLButtonElement >(
+			'.wp-desktop-radial__action--close',
+		);
+		reloadBtn?.addEventListener( 'click', ( ev ) => {
+			ev.stopPropagation();
+			this.markInteraction();
+			const focused = this.manager.getFocused();
+			if ( focused && typeof ( focused as unknown as { reload?: () => void } ).reload === 'function' ) {
+				try {
+					( focused as unknown as { reload: () => void } ).reload();
+				} catch {
+					/* swallow */
+				}
+			}
+		} );
+		closeBtn?.addEventListener( 'click', ( ev ) => {
+			ev.stopPropagation();
+			this.markInteraction();
+			const focused = this.manager.getFocused();
+			if ( focused ) {
+				try {
+					focused.close();
+				} catch {
+					/* swallow */
+				}
+			}
+			this.close();
+		} );
+		this.root.appendChild( this.actions );
+
+		// Sweep hint — a small double-arrow icon that animates back
+		// and forth along the radial's arc border (above the items).
+		// Visible only while the radial is open. Pure SVG so the
+		// motion path stays smooth at any device pixel ratio.
+		const sweep = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'svg',
+		);
+		sweep.setAttribute( 'class', 'wp-desktop-radial__sweep' );
+		sweep.setAttribute( 'viewBox', '-250 -220 500 250' );
+		sweep.setAttribute( 'aria-hidden', 'true' );
+		sweep.innerHTML = `
+			<g class="wp-desktop-radial__sweep-arrow">
+				<path
+					d="M -10 -4 L -16 0 L -10 4 M -16 0 L 16 0 M 10 -4 L 16 0 L 10 4"
+					fill="none"
+					stroke="rgba(255,255,255,0.95)"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</g>
+		`;
+		this.root.appendChild( sweep );
+
+		this.fab = document.createElement( 'button' );
+		this.fab.type = 'button';
+		this.fab.className = 'wp-desktop-radial__fab';
+		this.fab.setAttribute( 'aria-label', 'Open launcher' );
+		this.fab.setAttribute( 'aria-expanded', 'false' );
+
+		// Two stacked icons inside the FAB. CSS toggles which one is
+		// visible based on the `--peeking` state so the user sees a
+		// "lift me up" chevron when the FAB is half-hidden, and the
+		// canonical plus glyph when it's at rest.
+		this.centreLabel = document.createElement( 'span' );
+		this.centreLabel.className = 'wp-desktop-radial__fab-icon dashicons dashicons-plus-alt2';
+		this.fab.appendChild( this.centreLabel );
+
+		const peekIcon = document.createElement( 'span' );
+		peekIcon.className =
+			'wp-desktop-radial__fab-peek-icon dashicons dashicons-arrow-up-alt2';
+		peekIcon.setAttribute( 'aria-hidden', 'true' );
+		this.fab.appendChild( peekIcon );
+
+		this.fab.addEventListener( 'click', ( ev ) => {
+			ev.stopPropagation();
+			// Peeking branch FIRST — we don't want
+			// `markInteraction()` to silently flip the state to
+			// `revealed` before this check, which would have made
+			// a peeking tap fall through to `toggle()` instead of
+			// the explicit reveal+open path. Each branch resets
+			// the auto-peek timer through its own callees
+			// (`reveal()` / `open()` / `pop()` / `toggle()` all
+			// schedule).
+			if ( this.peekState === 'peeking' ) {
+				this.reveal();
+				this.open();
+				return;
+			}
+			this.markInteraction();
+			if ( this.path.length > 1 ) {
+				this.pop();
+				return;
+			}
+			this.toggle();
+		} );
+		this.root.appendChild( this.fab );
+
+		this.bindGestures();
+		this.scheduleAutoPeek();
+	}
+
+	mount(): void {
+		const shell = document.getElementById( 'wp-desktop-shell' );
+		if ( ! shell ) {
+			return;
+		}
+		shell.appendChild( this.root );
+
+		const repaint = (): void => {
+			if ( this.isOpen ) {
+				this.paint();
+			}
+		};
+		const onWindowChange = (): void => {
+			repaint();
+			this.refreshFocusState();
+		};
+		addAction( HOOKS.WINDOW_OPENED, this.hookNs, onWindowChange );
+		addAction( HOOKS.WINDOW_CLOSED, this.hookNs, onWindowChange );
+		addAction( HOOKS.WINDOW_FOCUSED, this.hookNs, onWindowChange );
+		addAction( HOOKS.WINDOW_TITLE_CHANGED, this.hookNs, onWindowChange );
+		// Menu-refresh path: when the chromeless bridge captures a
+		// fresh `wp-desktop-plugins-changed` payload, the shell
+		// rebuilds the dock + desktop-icons grid. Both fire their
+		// own "after-render" hooks. We piggy-back to invalidate the
+		// scene cache so the next paint pulls the updated
+		// `config.dockItems` / `config.nativeWindows` rather than
+		// the stale snapshot the radial first rendered.
+		const onMenuRefresh = (): void => {
+			this.lastSceneId = null;
+			repaint();
+		};
+		addAction( HOOKS.DOCK_AFTER_RENDER, this.hookNs, onMenuRefresh );
+		addAction( HOOKS.DESKTOP_ICONS_RENDERED, this.hookNs, onMenuRefresh );
+		this.refreshFocusState();
+
+		// Boot in peeking state — the FAB sits half-hidden until the
+		// user taps it. Class is applied here (rather than in the
+		// constructor) so the transition runs cleanly the first time
+		// the user reveals it.
+		this.root.classList.add( 'wp-desktop-radial--peeking' );
+	}
+
+	unmount(): void {
+		const raw = window.wp?.hooks;
+		if ( raw ) {
+			for ( const name of [
+				HOOKS.WINDOW_OPENED,
+				HOOKS.WINDOW_CLOSED,
+				HOOKS.WINDOW_FOCUSED,
+				HOOKS.WINDOW_TITLE_CHANGED,
+				HOOKS.DOCK_AFTER_RENDER,
+				HOOKS.DESKTOP_ICONS_RENDERED,
+			] ) {
+				raw.removeAction( name, this.hookNs );
+			}
+		}
+		this.root.remove();
+	}
+
+	toggle(): void {
+		if ( this.isOpen ) {
+			this.close();
+		} else {
+			this.open();
+		}
+	}
+
+	open(): void {
+		this.isOpen = true;
+		this.path = [ null ];
+		this.rotation = 0;
+		this.root.classList.add( 'wp-desktop-radial--open' );
+		this.root.classList.remove( 'wp-desktop-radial--peeking' );
+		this.fab.setAttribute( 'aria-expanded', 'true' );
+		this.peekState = 'revealed';
+		this.paint();
+		this.markInteraction();
+		// Initial snap so the apex item triggers a preview if it
+		// matches an open window.
+		const nodes = this.currentNodes();
+		if ( nodes.length > 0 ) {
+			this.updateCenterPreview( nodes[ Math.floor( ( nodes.length - 1 ) / 2 ) ] );
+		}
+	}
+
+	close(): void {
+		this.isOpen = false;
+		this.path = [ null ];
+		this.rotation = 0;
+		this.root.classList.remove( 'wp-desktop-radial--open' );
+		this.root.classList.remove( 'wp-desktop-radial--drilled' );
+		this.fab.setAttribute( 'aria-expanded', 'false' );
+		this.centreLabel.className =
+			'wp-desktop-radial__fab-icon dashicons dashicons-plus-alt2';
+		this.fab.setAttribute( 'aria-label', 'Open launcher' );
+		this.preview.classList.remove( 'wp-desktop-radial__preview--visible' );
+		this.preview.setAttribute( 'aria-hidden', 'true' );
+		this.preview.tabIndex = -1;
+		this.preview.onclick = null;
+		this.scheduleAutoPeek();
+	}
+
+	/** Drill down: replace centre with `node`, fan its children out. */
+	private push( node: RadialNode ): void {
+		if ( ! node.children.length ) {
+			// Leaf — open / focus instead of drilling.
+			this.activate( node );
+			return;
+		}
+		this.path.push( node );
+		this.rotation = 0;
+		this.root.classList.add( 'wp-desktop-radial--drilled' );
+		this.centreLabel.className =
+			`wp-desktop-radial__fab-icon dashicons ${ node.icon }`;
+		this.fab.setAttribute( 'aria-label', `Back from ${ node.title }` );
+		this.paint();
+	}
+
+	private pop(): void {
+		this.path.pop();
+		if ( this.path.length === 1 ) {
+			this.root.classList.remove( 'wp-desktop-radial--drilled' );
+			this.centreLabel.className =
+				'wp-desktop-radial__fab-icon dashicons dashicons-plus-alt2';
+			this.fab.setAttribute( 'aria-label', 'Open launcher' );
+		} else {
+			const parent = this.path[ this.path.length - 1 ];
+			if ( parent ) {
+				this.centreLabel.className =
+					`wp-desktop-radial__fab-icon dashicons ${ parent.icon }`;
+			}
+		}
+		this.rotation = 0;
+		this.paint();
+		this.markInteraction();
+	}
+
+	private activate( node: RadialNode ): void {
+		// Direct-id path for "open window" tiles — tapping one of
+		// the open-window prefix tiles always focuses that exact
+		// window instance, even if multiple windows share a URL.
+		if ( node.windowId ) {
+			const win = this.manager.getById( node.windowId );
+			if ( win ) {
+				if ( win.state === 'minimized' ) {
+					win.maximize();
+				}
+				this.manager.focus( win );
+				this.close();
+				return;
+			}
+		}
+
+		// Native-window path — OS Settings, Code Editor, Recycle
+		// Bin, plugin-registered native windows. OS Settings has
+		// its own dedicated entry point (`openOsSettings`) because
+		// it isn't routed through the public native-window
+		// registry; everything else goes through `openWindow(id)`.
+		if ( node.nativeId ) {
+			try {
+				const api = window.wp?.desktop;
+				if ( node.nativeId === 'wp-desktop-os-settings' && api?.openOsSettings ) {
+					api.openOsSettings();
+				} else {
+					api?.openWindow?.( node.nativeId );
+				}
+			} catch {
+				/* swallow */
+			}
+			this.close();
+			return;
+		}
+
+		// Tapping a dock-item icon while a window of that kind is
+		// already open:
+		//   • multi = true  → stack a new instance (Posts, Pages,
+		//                     Media — list screens where you'd
+		//                     want two side-by-side comparison
+		//                     windows).
+		//   • multi = false → focus the existing one (Settings,
+		//                     Dashboard, Tools — singleton pages
+		//                     where two of the same is nonsense).
+		// The "Tap to switch" preview thumb is the dedicated
+		// affordance for focusing an existing instance regardless
+		// of `multi` — it lives outside this code path.
+		const target = urlMatchKey( node.url );
+		const existing = this.manager
+			.getAll()
+			.find( ( w ) => !! w.config.url && urlMatchKey( w.config.url ) === target );
+
+		if ( existing && ! node.multi ) {
+			if ( existing.state === 'minimized' ) {
+				existing.maximize();
+			}
+			this.manager.focus( existing );
+		} else if ( existing && node.multi ) {
+			// Open a sibling instance via `openNew()` so the
+			// existing window keeps its identity and the new one
+			// gets a unique id from the manager.
+			this.manager.openNew( {
+				id: node.id,
+				url: node.url,
+				title: node.title,
+				icon: node.icon,
+			} );
+		} else {
+			this.manager.open( {
+				id: node.id,
+				url: node.url,
+				title: node.title,
+				icon: node.icon,
+			} );
+		}
+		this.close();
+	}
+
+	private currentNodes(): RadialNode[] {
+		const top = this.path[ this.path.length - 1 ];
+		const dockItems = this.config.dockItems || [];
+
+		let nodes: RadialNode[];
+		if ( top ) {
+			// Prepend the parent itself as a leaf so the user can open
+			// the parent's own page (e.g. the Plugins landing screen),
+			// not only its submenu items.
+			nodes = [
+				{
+					id: `${ top.id }/__self__`,
+					title: top.title,
+					icon: top.icon,
+					url: top.url,
+					children: [],
+					multi: top.multi,
+				},
+				...top.children,
+			];
+		} else {
+			// Root level — every actionable thing the user could
+			// reach from the desktop, in priority order:
+			//
+			//   1. Currently-open windows (radial doubles as
+			//      app switcher).
+			//   2. Native shell windows (OS Settings, Code Editor,
+			//      Recycle Bin, Cron Jobs, …) registered via
+			//      `wp_register_desktop_window()`.
+			//   3. Server-registered desktop icons (the wallpaper
+			//      shortcut tiles).
+			//   4. Every admin-menu top-level item (the dock list).
+			//
+			// Tapping #2 routes through `wp.desktop.openWindow(id)`
+			// because native windows don't have an admin URL.
+			// Tapping #3 routes through the URL flow when the icon
+			// targets a URL, or through `openWindow(id)` when it
+			// targets a native window.
+			const openWindowNodes: RadialNode[] = this.manager
+				.getAll()
+				.filter( ( w ) => w.config.url || w.config.title )
+				.map( ( w ) => ( {
+					id: `__win__/${ w.id }`,
+					title: w.config.title || w.id,
+					icon: w.config.icon || 'dashicons-desktop',
+					url: w.config.url ?? '',
+					children: [],
+					windowId: w.id,
+					multi: false,
+				} ) );
+
+			const nativeWindowNodes: RadialNode[] = ( this.config.nativeWindows ?? [] )
+				.filter( ( n ) => n.placement !== 'none' )
+				.map( ( n ) => ( {
+					id: `__native__/${ n.id }`,
+					title: n.title,
+					icon: n.icon || 'dashicons-admin-generic',
+					url: '',
+					children: [],
+					multi: false,
+					nativeId: n.id,
+				} ) );
+
+			// OS Settings is an internal shell window — it isn't
+			// registered through the public `wp_register_desktop_window`
+			// API so it's missing from `config.nativeWindows`. Add it
+			// manually with a sentinel `nativeId` the activation path
+			// recognises and routes through `openOsSettings()`.
+			nativeWindowNodes.push( {
+				id: '__native__/wp-desktop-os-settings',
+				title: 'OS Settings',
+				icon: 'dashicons-admin-generic',
+				url: '',
+				children: [],
+				multi: false,
+				nativeId: 'wp-desktop-os-settings',
+			} );
+
+			const desktopIconNodes: RadialNode[] = ( this.config.desktopIcons ?? [] )
+				// Skip icons whose id collides with a native window
+				// — many plugins register both a native window and
+				// a desktop-icon shortcut for the same target.
+				.filter(
+					( i ) =>
+						! nativeWindowNodes.some(
+							( n ) => n.nativeId === ( i.window || '' ),
+						),
+				)
+				.map( ( i ) => ( {
+					id: `__icon__/${ i.id }`,
+					title: i.title,
+					icon: i.icon || 'dashicons-admin-generic',
+					url: i.url || '',
+					children: [],
+					multi: false,
+					nativeId: i.window || undefined,
+				} ) );
+
+			nodes = [
+				...openWindowNodes,
+				...nativeWindowNodes,
+				...desktopIconNodes,
+				...dockItems.map( adaptDockItem ),
+			];
+		}
+
+		// Plugins can rewrite or extend the radial — same hook that the
+		// (now-removed) bottom switcher used, but the payload is a flat
+		// list of nodes instead of Window instances.
+		return applyFilters< RadialNode[], [ { level: number; parent: RadialNode | null } ] >(
+			'desktop_mode_mobile_app_switcher',
+			nodes,
+			{ level: this.path.length - 1, parent: top },
+		);
+	}
+
+	private bindGestures(): void {
+		// Single pointer-event handler attached to the arc layer.
+		// Tracks movement; if the pointer ends up >= DRAG_THRESHOLD_PX
+		// from where it started, treat as a drag (rotate, suppress
+		// tile click). Otherwise treat the release as a tap on the
+		// nearest tile and dispatch its node action. Works for mouse,
+		// touch, and pen via a single code path.
+		let startX = 0;
+		let startY = 0;
+		let startRot = 0;
+		let active = false;
+		let dragged = false;
+		let pid = -1;
+
+		const onDown = ( ev: PointerEvent ): void => {
+			// Only react to primary button / first finger.
+			if ( ev.button !== 0 && ev.pointerType === 'mouse' ) {
+				return;
+			}
+			active = true;
+			dragged = false;
+			pid = ev.pointerId;
+			startX = ev.clientX;
+			startY = ev.clientY;
+			startRot = this.rotation;
+			this.markInteraction();
+			try {
+				this.gesturePad.setPointerCapture( pid );
+			} catch {
+				/* swallow */
+			}
+		};
+
+		const onMove = ( ev: PointerEvent ): void => {
+			if ( ! active || ev.pointerId !== pid ) {
+				return;
+			}
+			const dx = ev.clientX - startX;
+			const dy = ev.clientY - startY;
+			if ( ! dragged && dx * dx + dy * dy >= this.DRAG_THRESHOLD_PX * this.DRAG_THRESHOLD_PX ) {
+				dragged = true;
+				this.arc.classList.add( 'wp-desktop-radial__arc--dragging' );
+			}
+			if ( ! dragged ) {
+				return;
+			}
+			// 1px → 0.005 rad (~0.29°). Tweak feel without shrinking
+			// the maximum reach because the rotation clamp scales with
+			// item count.
+			const next = startRot + dx * 0.005;
+			const nodes = this.currentNodes();
+			const max = Math.max(
+				0,
+				( ( nodes.length - 1 ) * ITEM_STEP ) / 2,
+			);
+			this.rotation = Math.max( -max, Math.min( max, next ) );
+			this.paintArc( nodes );
+			this.markInteraction();
+		};
+
+		const onUp = ( ev: PointerEvent ): void => {
+			if ( ev.pointerId !== pid ) {
+				return;
+			}
+			active = false;
+			this.arc.classList.remove( 'wp-desktop-radial__arc--dragging' );
+			try {
+				this.gesturePad.releasePointerCapture( pid );
+			} catch {
+				/* swallow */
+			}
+			pid = -1;
+			if ( dragged ) {
+				// Snap the rotation so the nearest item lands at
+				// the apex (angle 0 = straight up) and update the
+				// centre preview if there's a matching open window.
+				this.snapToCenter();
+				this.markInteraction();
+				return;
+			}
+			// Tap — find which tile the pointer is over and activate it.
+			// `setPointerCapture` redirects pointerup `target` to the
+			// captured element (the arc), so `ev.target` is useless
+			// here. `document.elementFromPoint` looks up the node
+			// under the actual release coordinates instead, which
+			// reliably resolves to the tile the user lifted on.
+			const hit = document.elementFromPoint( ev.clientX, ev.clientY );
+			const tile = hit?.closest( '.wp-desktop-radial__tile' ) as
+				| HTMLElement
+				| null;
+			if ( tile && tile.dataset.nodeId ) {
+				const nodes = this.currentNodes();
+				const node = nodes.find( ( n ) => n.id === tile.dataset.nodeId );
+				if ( node ) {
+					this.push( node );
+				}
+			}
+			this.markInteraction();
+		};
+
+		// Bind on the root so events from EITHER the gesture pad
+		// (empty area) OR the tiles inside the arc bubble up to a
+		// single handler. The FAB and action chips stopPropagation
+		// in their own click handlers, so they never reach here.
+		this.root.addEventListener( 'pointerdown', onDown );
+		this.root.addEventListener( 'pointermove', onMove );
+		this.root.addEventListener( 'pointerup', onUp );
+		this.root.addEventListener( 'pointercancel', onUp );
+	}
+
+	/**
+	 * Snap the rotation so the item nearest the apex (angle 0)
+	 * lands exactly there, then refresh the centre preview. Runs
+	 * after every drag-release so a partial swipe always settles
+	 * on a discrete tile.
+	 */
+	private snapToCenter(): void {
+		const nodes = this.currentNodes();
+		if ( nodes.length === 0 ) {
+			return;
+		}
+		const N = nodes.length;
+		let bestIdx = 0;
+		let bestDist = Infinity;
+		for ( let i = 0; i < N; i++ ) {
+			const baseAngle = ( i - ( N - 1 ) / 2 ) * ITEM_STEP;
+			const angle = baseAngle + this.rotation;
+			const d = Math.abs( angle );
+			if ( d < bestDist ) {
+				bestDist = d;
+				bestIdx = i;
+			}
+		}
+		const targetBase = ( bestIdx - ( N - 1 ) / 2 ) * ITEM_STEP;
+		this.rotation = -targetBase;
+		this.paintArc( nodes );
+		this.updateCenterPreview( nodes[ bestIdx ] );
+	}
+
+	/**
+	 * Refresh the centre-screen preview for the currently-snapped
+	 * node. If at least one window is open whose URL matches the
+	 * node, render a translucent thumb the user can tap to focus
+	 * the existing instance. With no match, hide the preview.
+	 */
+	private updateCenterPreview( node: RadialNode ): void {
+		const matches = this.manager
+			.getAll()
+			.filter(
+				( w ) =>
+					!! w.config.url &&
+					urlMatchKey( w.config.url ) === urlMatchKey( node.url ),
+			);
+		if ( matches.length === 0 || ! this.isOpen ) {
+			this.hidePreview();
+			return;
+		}
+
+		this.preview.innerHTML = '';
+		this.preview.classList.toggle(
+			'wp-desktop-radial__preview--multi',
+			matches.length > 1,
+		);
+
+		if ( matches.length === 1 ) {
+			// Single match — one big card. The whole card is the
+			// click target; tapping focuses the window.
+			const target = matches[ 0 ];
+			const card = this.buildPreviewCard(
+				node.icon || 'dashicons-desktop',
+				target.config.title || node.title,
+				'Tap to switch',
+			);
+			card.addEventListener( 'click', ( ev ) => {
+				ev.stopPropagation();
+				this.markInteraction();
+				if ( target.state === 'minimized' ) {
+					target.maximize();
+				}
+				this.manager.focus( target );
+				this.close();
+			} );
+			this.preview.appendChild( card );
+		} else {
+			// Multiple matches — header + horizontal pill strip,
+			// one pill per open window. Tapping a pill focuses
+			// that specific window so the user can pick exactly
+			// which instance to bring forward.
+			const header = document.createElement( 'div' );
+			header.className = 'wp-desktop-radial__preview-header';
+			const headerIc = document.createElement( 'span' );
+			headerIc.className = `wp-desktop-radial__preview-icon dashicons ${
+				node.icon || 'dashicons-desktop'
+			}`;
+			header.appendChild( headerIc );
+			const headerLabel = document.createElement( 'span' );
+			headerLabel.className = 'wp-desktop-radial__preview-label';
+			headerLabel.textContent = `${ matches.length } open · ${ node.title }`;
+			header.appendChild( headerLabel );
+			this.preview.appendChild( header );
+
+			const strip = document.createElement( 'div' );
+			strip.className = 'wp-desktop-radial__preview-strip';
+			matches.forEach( ( target, idx ) => {
+				const pill = document.createElement( 'button' );
+				pill.type = 'button';
+				pill.className = 'wp-desktop-radial__preview-pill';
+				pill.dataset.windowId = target.id;
+				const pillTitle = document.createElement( 'span' );
+				pillTitle.className =
+					'wp-desktop-radial__preview-pill-title';
+				pillTitle.textContent = target.config.title || `#${ idx + 1 }`;
+				pill.appendChild( pillTitle );
+				if ( target === this.manager.getFocused() ) {
+					pill.classList.add(
+						'wp-desktop-radial__preview-pill--focused',
+					);
+				}
+				pill.addEventListener( 'click', ( ev ) => {
+					ev.stopPropagation();
+					this.markInteraction();
+					if ( target.state === 'minimized' ) {
+						target.maximize();
+					}
+					this.manager.focus( target );
+					this.close();
+				} );
+				strip.appendChild( pill );
+			} );
+			this.preview.appendChild( strip );
+		}
+
+		this.preview.classList.add( 'wp-desktop-radial__preview--visible' );
+		this.preview.setAttribute( 'aria-hidden', 'false' );
+	}
+
+	private buildPreviewCard(
+		icon: string,
+		title: string,
+		hint: string,
+	): HTMLElement {
+		const card = document.createElement( 'button' );
+		card.type = 'button';
+		card.className = 'wp-desktop-radial__preview-card';
+		const ic = document.createElement( 'span' );
+		ic.className = `wp-desktop-radial__preview-icon dashicons ${ icon }`;
+		card.appendChild( ic );
+		const label = document.createElement( 'span' );
+		label.className = 'wp-desktop-radial__preview-label';
+		label.textContent = title;
+		card.appendChild( label );
+		const hintEl = document.createElement( 'span' );
+		hintEl.className = 'wp-desktop-radial__preview-hint';
+		hintEl.textContent = hint;
+		card.appendChild( hintEl );
+		return card;
+	}
+
+	private refreshFocusState(): void {
+		const hasFocus = !! this.manager.getFocused();
+		this.root.classList.toggle( 'wp-desktop-radial--has-focus', hasFocus );
+	}
+
+	private hidePreview(): void {
+		this.preview.classList.remove( 'wp-desktop-radial__preview--visible' );
+		this.preview.classList.remove( 'wp-desktop-radial__preview--multi' );
+		this.preview.setAttribute( 'aria-hidden', 'true' );
+		this.preview.innerHTML = '';
+	}
+
+	/**
+	 * State machine — `peeking` ↔ `revealed`.
+	 *
+	 * `peeking`: FAB is half-hidden below the viewport edge. Tapping
+	 * it lifts to `revealed`. After a 3-second window of no
+	 * interaction the FAB returns to `peeking`.
+	 */
+	private reveal(): void {
+		this.peekState = 'revealed';
+		this.root.classList.remove( 'wp-desktop-radial--peeking' );
+		this.scheduleAutoPeek();
+	}
+
+	private peek(): void {
+		// Auto-retract: 3 s of inactivity collapses the whole
+		// radial back to the peeking state. If the radial happens
+		// to be open we close it inline (skipping `close()` so we
+		// don't kick off yet another auto-peek timer).
+		if ( this.isOpen ) {
+			this.isOpen = false;
+			this.path = [ null ];
+			this.rotation = 0;
+			this.root.classList.remove( 'wp-desktop-radial--open' );
+			this.root.classList.remove( 'wp-desktop-radial--drilled' );
+			this.fab.setAttribute( 'aria-expanded', 'false' );
+			this.centreLabel.className =
+				'wp-desktop-radial__fab-icon dashicons dashicons-plus-alt2';
+			this.fab.setAttribute( 'aria-label', 'Open launcher' );
+			this.preview.classList.remove( 'wp-desktop-radial__preview--visible' );
+			this.preview.setAttribute( 'aria-hidden', 'true' );
+			this.preview.tabIndex = -1;
+			this.preview.onclick = null;
+		}
+		this.peekState = 'peeking';
+		this.root.classList.add( 'wp-desktop-radial--peeking' );
+		if ( this.peekTimer !== null ) {
+			window.clearTimeout( this.peekTimer );
+			this.peekTimer = null;
+		}
+	}
+
+	private markInteraction(): void {
+		if ( this.peekState === 'peeking' ) {
+			this.reveal();
+		}
+		this.scheduleAutoPeek();
+	}
+
+	private scheduleAutoPeek(): void {
+		if ( this.peekTimer !== null ) {
+			window.clearTimeout( this.peekTimer );
+		}
+		this.peekTimer = window.setTimeout( () => {
+			this.peekTimer = null;
+			this.peek();
+		}, this.PEEK_TIMEOUT_MS );
+	}
+
+	private paint(): void {
+		const nodes = this.currentNodes();
+		this.paintArc( nodes );
+	}
+
+	private paintArc( nodes: RadialNode[] ): void {
+		// Diff-driven render: reuse tiles whose node id is still in
+		// the active set, animate-out tiles that no longer match,
+		// build only what's actually new. Rotation re-renders fly
+		// through the "everything matches" branch — no DOM churn,
+		// no transition restart, no flicker.
+
+		// Track scene changes (open ↔ close, drill in/out) so we
+		// only run the entry animation on new tiles when the user
+		// actually navigated. During rotation the scene id stays
+		// the same; new tiles wandering into view from compression
+		// fade in via their normal `--open` transition without
+		// kicking the keyframe animation.
+		const sceneId = this.path
+			.map( ( n ) => ( n ? n.id : 'root' ) )
+			.join( '/' );
+		const sceneChanged = this.lastSceneId !== sceneId;
+		this.lastSceneId = sceneId;
+
+		// Open windows: build a fast lookup so the active ring lights
+		// up for any item whose url matches a live window.
+		const openKeys = new Set<string>();
+		for ( const w of this.manager.getAll() ) {
+			if ( w.config.url ) {
+				openKeys.add( urlMatchKey( w.config.url ) );
+			}
+		}
+		const focusedKey = ( () => {
+			const f = this.manager.getFocused();
+			return f && f.config.url ? urlMatchKey( f.config.url ) : '';
+		} )();
+
+		// Distribute nodes around the arc with a fixed angular step so
+		// adding items extends the scrollable range instead of shrinking
+		// individual icons. Centre item sits at the top (angle 0).
+		// Outside the visible cone we compress the spacing so out-of-
+		// view items stack tightly at the edge — this reads as a
+		// "more behind here" stack without eating screen space.
+		const N = nodes.length;
+		let offLeft = 0;
+		let offRight = 0;
+
+		// Index existing live tiles by node id so we can decide
+		// reuse vs. exit-animate.
+		const existing = new Map<string, HTMLElement>();
+		for ( const el of Array.from( this.arc.children ) as HTMLElement[] ) {
+			if ( el.classList.contains( 'wp-desktop-radial__tile--leaving' ) ) {
+				continue;
+			}
+			const id = el.dataset.nodeId;
+			if ( id ) {
+				existing.set( id, el );
+			}
+		}
+
+		const placedIds = new Set<string>();
+
+		for ( let i = 0; i < N; i++ ) {
+			const node = nodes[ i ];
+			const baseAngle = ( i - ( N - 1 ) / 2 ) * ITEM_STEP;
+			const angle = baseAngle + this.rotation;
+			const absAngle = Math.abs( angle );
+			const overshoot = absAngle - VISIBLE_HALF;
+
+			let placedAngle = angle;
+			let visibility = 1;
+			if ( overshoot > 0 ) {
+				const sign = angle < 0 ? -1 : 1;
+				placedAngle =
+					sign *
+					( VISIBLE_HALF +
+						Math.min( overshoot * OFF_ARC_COMPRESSION, ITEM_STEP * 0.9 ) );
+				visibility = Math.max( 0, 1 - overshoot / ( ITEM_STEP * 1.2 ) );
+				if ( sign < 0 ) {
+					offLeft++;
+				} else {
+					offRight++;
+				}
+				if ( visibility <= 0.05 ) {
+					continue;
+				}
+			}
+
+			const x = Math.sin( placedAngle ) * ARC_RADIUS;
+			const y = -Math.cos( placedAngle ) * ARC_RADIUS;
+
+			const key = urlMatchKey( node.url );
+			const isOpen = openKeys.has( key );
+			const isFocused = key === focusedKey && focusedKey !== '';
+			const hasChildren = node.children.length > 0;
+
+			const isWindowTile = !! node.windowId;
+
+			let tile = existing.get( node.id );
+			if ( ! tile ) {
+				tile = this.buildTile( node );
+				if ( isWindowTile ) {
+					tile.classList.add( 'wp-desktop-radial__tile--window' );
+				}
+				if ( sceneChanged ) {
+					// Stamp the entry animation. The CSS keyframe
+					// runs from scale(0.4)+opacity 0 to the configured
+					// placement; without this the tile would have
+					// matched the `--open` rules immediately on append
+					// and skipped the transition entirely.
+					tile.classList.add( 'wp-desktop-radial__tile--entering' );
+					const t = tile;
+					window.setTimeout( () => {
+						t.classList.remove( 'wp-desktop-radial__tile--entering' );
+					}, 360 );
+				}
+				this.arc.appendChild( tile );
+			}
+			placedIds.add( node.id );
+			this.applyPlacement( tile, x, y, visibility );
+			tile.classList.toggle( 'wp-desktop-radial__tile--open', isOpen );
+			tile.classList.toggle( 'wp-desktop-radial__tile--focused', isFocused );
+			tile.classList.toggle( 'wp-desktop-radial__tile--has-children', hasChildren );
+		}
+
+		// Anything in `existing` that wasn't placed is leaving —
+		// add the leaving class and schedule removal after the CSS
+		// transition completes. `--leaving` defines its own scaled-
+		// down + fade-out target so the inline visibility var no
+		// longer wins.
+		for ( const [ id, el ] of existing ) {
+			if ( placedIds.has( id ) ) {
+				continue;
+			}
+			el.classList.add( 'wp-desktop-radial__tile--leaving' );
+			window.setTimeout( () => el.remove(), 260 );
+		}
+
+		this.arc.classList.toggle( 'wp-desktop-radial__arc--has-left', offLeft > 0 );
+		this.arc.classList.toggle( 'wp-desktop-radial__arc--has-right', offRight > 0 );
+	}
+
+	/** Build a fresh tile DOM tree for `node`. Position-agnostic. */
+	private buildTile( node: RadialNode ): HTMLElement {
+		const tile = document.createElement( 'button' );
+		tile.type = 'button';
+		tile.className = 'wp-desktop-radial__tile';
+		tile.dataset.nodeId = node.id;
+		tile.setAttribute( 'aria-label', node.title );
+
+		const ic = document.createElement( 'span' );
+		ic.className = `wp-desktop-radial__tile-icon dashicons ${ node.icon }`;
+		tile.appendChild( ic );
+
+		const labelText = node.title;
+		if ( labelText ) {
+			const ns = 'http://www.w3.org/2000/svg';
+			const svg = document.createElementNS( ns, 'svg' );
+			svg.setAttribute( 'class', 'wp-desktop-radial__tile-svg' );
+			svg.setAttribute( 'viewBox', '0 0 64 64' );
+			svg.setAttribute( 'aria-hidden', 'true' );
+
+			const pathId = `wpdm-radial-curve-${ node.id }`.replace(
+				/[^a-z0-9_-]/gi,
+				'-',
+			);
+			const defs = document.createElementNS( ns, 'defs' );
+			const path = document.createElementNS( ns, 'path' );
+			path.setAttribute( 'id', pathId );
+			// Inner bottom arc — ~170° sweep on a 27 px radius
+			// inscribed inside a 64×64 tile. Endpoints at (5, 35)
+			// and (59, 35), bulging down to ~y=62. Arc length is
+			// ≈ 79 px — comfortably fits a 13-character label at
+			// the configured 10 px font without any compression.
+			path.setAttribute( 'd', 'M 5 35 A 27 27 0 0 0 59 35' );
+			path.setAttribute( 'fill', 'none' );
+			defs.appendChild( path );
+			svg.appendChild( defs );
+
+			const text = document.createElementNS( ns, 'text' );
+			text.setAttribute( 'class', 'wp-desktop-radial__tile-curve-text' );
+			const textPath = document.createElementNS( ns, 'textPath' );
+			textPath.setAttribute( 'href', `#${ pathId }` );
+			textPath.setAttribute( 'startOffset', '50%' );
+			textPath.setAttribute( 'text-anchor', 'middle' );
+
+			// Truncate at 13 chars with an ellipsis. No `textLength` /
+			// `lengthAdjust` — those distort glyphs differently for
+			// every label length, which reads as inconsistent typography
+			// across the radial. Truncation keeps every visible label at
+			// the same kerning and sized identically.
+			const MAX_CHARS = 13;
+			const display =
+				labelText.length > MAX_CHARS
+					? labelText.slice( 0, MAX_CHARS - 1 ) + '…'
+					: labelText;
+			textPath.textContent = display;
+
+			text.appendChild( textPath );
+			svg.appendChild( text );
+
+			tile.appendChild( svg );
+		}
+		return tile;
+	}
+
+	/**
+	 * Apply position + visibility to a tile. Visibility goes through
+	 * a CSS variable so the open/leaving classes can fully override
+	 * (an inline `opacity` would beat any class rule, breaking the
+	 * exit animation).
+	 */
+	private applyPlacement(
+		tile: HTMLElement,
+		x: number,
+		y: number,
+		visibility: number,
+	): void {
+		tile.style.setProperty( '--wpdm-radial-x', `${ x }px` );
+		tile.style.setProperty( '--wpdm-radial-y', `${ y }px` );
+		tile.style.setProperty( '--wpdm-radial-visibility', String( visibility ) );
+		tile.style.pointerEvents = visibility > 0.4 ? 'auto' : 'none';
+	}
+}

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -40,6 +40,7 @@
 export type {
 	Desktop,
 	DesktopConfig,
+	DesktopMode,
 	DockItemConfig,
 	MonitorEntry,
 	DesktopSettingsTabScriptServerEntry,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1619,7 +1619,39 @@ export interface DesktopConfig {
 	 * @since 0.14.0
 	 */
 	extendedOptionsUrl?: string;
+	/**
+	 * Responsive breakpoints used by the mode-detection probe.
+	 * `mobile`: viewports `<=` this width are mobile.
+	 * `tablet`: viewports `<=` this width (and `>` mobile) are tablet.
+	 * Anything wider is `'desktop'`. Filterable server-side via
+	 * `desktop_mode_responsive_breakpoints`.
+	 *
+	 * @since 0.7.0
+	 */
+	responsiveBreakpoints?: { mobile: number; tablet: number };
+	/**
+	 * Server-side initial guess at the responsive mode, derived from
+	 * `wp_is_mobile()`. The JS probe corrects on first paint based on
+	 * the actual viewport, but having a guess lets the shell apply
+	 * the right `data-wp-desktop-mode` attribute before first JS tick
+	 * — eliminates a one-frame flash of desktop chrome on phones.
+	 * Filterable server-side via `desktop_mode_mode_type`.
+	 *
+	 * @since 0.7.0
+	 */
+	initialMode?: DesktopMode;
 }
+
+/**
+ * Responsive layout mode. `'desktop'` is the default classic shell.
+ * `'mobile'` collapses the dock into a wallpaper home grid, drops
+ * window drag/resize/min/max, force-maximizes every window, and
+ * paints a fixed bottom switcher strip. `'tablet'` is detected but
+ * currently behaves like desktop — reserved for future hybrid UI.
+ *
+ * @since 0.7.0
+ */
+export type DesktopMode = 'desktop' | 'tablet' | 'mobile';
 
 /**
  * A single entry in the OS Settings accent-color picker.

--- a/src/ui/components/wpd-window-button/wpd-window-button.styles.ts
+++ b/src/ui/components/wpd-window-button/wpd-window-button.styles.ts
@@ -19,8 +19,15 @@ export const styles = css`
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 30px;
-		height: 30px;
+		/*
+		 * Size driven by --wpd-btn-size so callers can scale
+		 * the whole button (and its icon, via the matched
+		 * --wpd-btn-icon-size below) without forking styles.
+		 * The mobile shell pumps these up so the touch target
+		 * matches a finger; desktop keeps the canonical 30 px.
+		 */
+		width: var( --wpd-btn-size, 30px );
+		height: var( --wpd-btn-size, 30px );
 		padding: 0;
 		border: none;
 		border-radius: 5px;
@@ -28,6 +35,20 @@ export const styles = css`
 		color: var( --wpd-btn-color, currentColor );
 		cursor: pointer;
 		transition: background-color 0.15s ease, color 0.15s ease;
+	}
+	/* Built-in inline SVG icon. Fallback matches the legacy 14 px
+	 * size; mobile bumps this via --wpd-btn-icon-size. */
+	svg {
+		width: var( --wpd-btn-icon-size, 14px );
+		height: var( --wpd-btn-icon-size, 14px );
+	}
+	/* Slotted dashicons span. Fallback is 20 px (the dashicons
+	 * font's natural metric, declared in WP core). When the
+	 * caller sets --wpd-btn-icon-size the glyph scales with it. */
+	::slotted( span.dashicons ) {
+		font-size: var( --wpd-btn-icon-size, 20px ) !important;
+		width: var( --wpd-btn-icon-size, 20px );
+		height: var( --wpd-btn-icon-size, 20px );
 	}
 	button:hover {
 		color: var( --wpd-btn-color-hover, currentColor );

--- a/src/window/pointer.ts
+++ b/src/window/pointer.ts
@@ -13,9 +13,21 @@
  * @since 0.8.1
  */
 
-import { doAction, HOOKS } from '../hooks';
+import { applyFilters, doAction, HOOKS } from '../hooks';
 import { DRAG_THRESHOLD_SQUARED, EDGE_MARGIN } from './constants';
 import type { Window } from './index';
+
+/**
+ * Read the current responsive mode without taking a hard dependency
+ * on `src/mobile`. The mobile module writes a `data-wp-desktop-mode`
+ * attribute on `<html>` whenever the probe ticks; reading it here
+ * keeps pointer.ts free of an import cycle. Returns `'desktop'` when
+ * the attribute is absent (classic mode, tests).
+ */
+function readResponsiveMode(): 'desktop' | 'tablet' | 'mobile' {
+	const value = document.documentElement.getAttribute( 'data-wp-desktop-mode' );
+	return value === 'mobile' || value === 'tablet' ? value : 'desktop';
+}
 
 /**
  * Build a rAF-coalesced emitter for `WINDOW_BOUNDS_CHANGED` during a
@@ -96,6 +108,23 @@ interface UnstateParams {
 
 /** Title-bar pointerdown → drag session. */
 export function handleDragStart( win: Window, e: PointerEvent ): void {
+	// Mode-aware gate. Mobile mode subscribes to this filter and
+	// returns `false` so windows are pinned to the maximized rect.
+	// Plugins can also veto drag for individual windows (e.g. while
+	// a modal is showing). Default `true` keeps desktop behavior.
+	const mode = readResponsiveMode();
+	const allowed = applyFilters<
+		boolean,
+		[ { windowId: string; mode: 'desktop' | 'tablet' | 'mobile'; event: PointerEvent } ]
+	>(
+		HOOKS.WINDOW_DRAG_ALLOWED,
+		true,
+		{ windowId: win.id, mode, event: e },
+	);
+	if ( ! allowed ) {
+		return;
+	}
+
 	// Only drag from the title bar background, not from any buttons.
 	//
 	// The class-level guard (`__btn` / `__custom-buttons`) catches
@@ -408,6 +437,20 @@ type ResizeDir = 'ne' | 'nw' | 'se' | 'sw';
 
 /** Resize-handle pointerdown → resize session. */
 export function handleResizeStart( win: Window, e: PointerEvent ): void {
+	// Mode-aware gate — see `handleDragStart` for the rationale.
+	const mode = readResponsiveMode();
+	const allowed = applyFilters<
+		boolean,
+		[ { windowId: string; mode: 'desktop' | 'tablet' | 'mobile'; event: PointerEvent } ]
+	>(
+		HOOKS.WINDOW_RESIZE_ALLOWED,
+		true,
+		{ windowId: win.id, mode, event: e },
+	);
+	if ( ! allowed ) {
+		return;
+	}
+
 	// Maximized/fullscreen windows take the whole area — a resize
 	// drag would fight the max-geometry loop in window-manager's
 	// ResizeObserver, so bail early. Snapped windows DO allow resize

--- a/tests/vitest/mobile.test.ts
+++ b/tests/vitest/mobile.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for `src/mobile/index.ts` — the responsive detection
+ * layer. Covers `resolveMode()`, override behavior, and the
+ * mode-attribute application.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { resolveMode, getMode, setOverride, subscribe } from '../../src/mobile';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+describe( 'mobile.ts — resolveMode', () => {
+	beforeEach( () => {
+		installHooksStub();
+		setOverride( null );
+		document.documentElement.removeAttribute( 'data-wp-desktop-mode' );
+	} );
+
+	afterEach( () => {
+		setOverride( null );
+		clearHooksStub();
+	} );
+
+	test( 'classifies wide viewports as desktop', () => {
+		expect( resolveMode( 1440 ) ).toBe( 'desktop' );
+		expect( resolveMode( 1025 ) ).toBe( 'desktop' );
+	} );
+
+	test( 'classifies tablet-width viewports as tablet', () => {
+		expect( resolveMode( 1024 ) ).toBe( 'tablet' );
+		expect( resolveMode( 800 ) ).toBe( 'tablet' );
+		expect( resolveMode( 641 ) ).toBe( 'tablet' );
+	} );
+
+	test( 'classifies narrow viewports as mobile', () => {
+		expect( resolveMode( 640 ) ).toBe( 'mobile' );
+		expect( resolveMode( 375 ) ).toBe( 'mobile' );
+		expect( resolveMode( 320 ) ).toBe( 'mobile' );
+	} );
+
+	test( 'override pins the mode regardless of width', () => {
+		setOverride( 'mobile' );
+		expect( resolveMode( 1920 ) ).toBe( 'mobile' );
+		setOverride( 'desktop' );
+		expect( resolveMode( 320 ) ).toBe( 'desktop' );
+		setOverride( null );
+		expect( resolveMode( 320 ) ).toBe( 'mobile' );
+	} );
+
+	test( 'plugins can hijack via desktop_mode_responsive_resolve', () => {
+		const hooks = installHooksStub();
+		hooks.addFilter(
+			'desktop_mode_responsive_resolve',
+			'vitest',
+			() => 'tablet',
+		);
+		expect( resolveMode( 1920 ) ).toBe( 'tablet' );
+		expect( resolveMode( 320 ) ).toBe( 'tablet' );
+	} );
+
+	test( 'subscribe returns an unsubscribe', () => {
+		const fn = (): void => {};
+		const off = subscribe( fn );
+		expect( typeof off ).toBe( 'function' );
+		// Calling the unsubscribe is a no-throw.
+		off();
+	} );
+
+	test( 'getMode returns the cached current mode', () => {
+		// No tick has fired in this isolated test — getMode falls back
+		// to the module's default initial value.
+		expect( getMode() ).toBe( 'desktop' );
+	} );
+} );


### PR DESCRIPTION
Ship a real mobile experience for Desktop Mode. Auto-detects narrow
viewports, swaps the chrome for a touch-shaped policy, and replaces
the dock + title bar with a single floating radial launcher that
covers navigation, app-switching, and per-window actions.


https://github.com/user-attachments/assets/cdb7f044-07ac-49fe-b3db-6025f09386d9

Closes #55 


## Why

The desktop metaphor breaks at phone widths: dragging windows is
useless on touch, the dock crowds the viewport, and the 56 px title
bar plus tabs strip eats every spare pixel of admin content. Mobile
mode is a separate UX rather than a degraded desktop — opinionated,
gesture-first, and reachable with one thumb.

## What ships

### Detection

- Single `ResizeObserver` probe in `src/mobile/index.ts` resolves
  `'desktop' | 'tablet' | 'mobile'` from viewport width. Stamps the
  result on `<html data-wp-desktop-mode="…">` so CSS rules cascade
  off the attribute and JS reads it live (no module-level lag).
- Server seeds the initial mode from `wp_is_mobile()` so phones don't
  flash desktop chrome before the first JS tick.
- Public API:
  - `wp.desktop.mode()` — synchronous accessor.
  - `wp.desktop.responsive.subscribe(fn)` — fires on every flip.
  - `wp.desktop.responsive.override('mobile' | null)` — in-memory pin
    for testing / power-user "always desktop" preference.
- New `RESPONSIVE_MODE_CHANGED` action (and matching
  `wp-desktop-mode-changed` `CustomEvent`) for plugins on the bus.

### Window policy

In mobile mode every window is full-bleed and uneditable:

- **Title bar removed** entirely. Tabs strip removed too — the
  radial owns submenu navigation.
- **Force-maximize** on every open via a `WINDOW_OPENED` subscriber
  and a CSS pin (belt-and-suspenders against plugin geometry writes).
- **Drag and resize vetoed** through two new filters,
  `wp-desktop.window.drag-allowed` and `…resize-allowed`. Plugins
  can layer additional vetoes (e.g. while a modal is showing).
- **Resize handles hidden** so even a mouse can't initiate a drag.
- Iframes auto-scroll to the top on `IFRAME_READY` so a fresh page
  always lands at the top — not wherever Core's last save banner /
  scroll-restoration left it.

### Radial launcher (the centrepiece)

A single floating `+` button at the bottom centre of the viewport
expands into an arc of icons above it. Replaces the dock, the
bottom thumbnail switcher, and the in-window tab strip in one
component.

#### State machine

- **Peeking** — only ~25 % of the FAB pokes above the viewport
  edge, with a `dashicons-arrow-up-alt2` chevron at the very top
  and a gentle accent-coloured pulse so it's discoverable without
  being noisy. Tap → reveals + opens in one motion.
- **Open** — fan of tiles in an arc, scroll-hint arrow pinned at
  the apex, action chips fan out at the upper corners.
- **Auto-retract** — 3 s of no interaction collapses the radial
  back to peeking. Every interaction resets the timer:
  pointerdown / move / up on the gesture pad, taps on tiles,
  taps on action chips, taps on the preview thumb, FAB taps,
  drill in / drill back.

#### Tile presentation

- 64 × 64 round tiles in dark glass with a 1 px hairline border.
- Centred dashicon glyph at 22 px (driven through new shadow-DOM
  CSS vars `--wpd-btn-size` / `--wpd-btn-icon-size` so the same
  style scales the embedded `<wpd-window-button>`).
- Curved label hugging the inner bottom arc via inline SVG
  `<defs><path>` + `<text><textPath>`. 11 px font with a 2.5 px
  dark stroke (`paint-order: stroke`) so labels stay legible if
  they graze the icon. Labels truncate at 13 chars with an
  ellipsis — no `textLength`/`lengthAdjust` distortion.

#### Layout & gestures

- 46° angular step inside the visible cone (~95° half-arc).
- Off-arc items compress into a tight stack at the edges with
  fading opacity — natural "more behind here" affordance, no
  separate UI element.
- Snap-to-centre after every drag-release: the item nearest the
  apex animates into the exact 0° slot.
- **Drag from anywhere inside the radial** — invisible 420 × 240
  px gesture pad anchored on the FAB centre. Pointer events bubble
  to the radial root which feeds the unified gesture handler.
  Movement threshold of 8 px discriminates tap from drag, so a
  quick tap on a tile activates it cleanly.
- Mouse + touch + pen via one pointer-event code path.

#### Animations

- Diff-driven render keyed by node id: rotation re-renders reuse
  existing tile DOM, so a continuous drag doesn't churn nodes or
  flicker transitions.
- **Scene-change animation** — drilling into a submenu animates
  the parent set out (`scale(0.4)` + opacity 0) and the children
  in (`scale(0.4) → 1`, opacity fade) via a CSS keyframe.
  Visibility is driven by a `--wpdm-radial-visibility` CSS var so
  the open/leaving classes can override cleanly (an inline
  `opacity` would have beaten any class rule).
- Tile fade-in / fade-out fully animated; rotation re-renders skip
  the keyframe so they don't restart on every pointermove.

#### Content

The root level merges, in priority order:

1. **Open windows** — every currently-open `Window` instance,
   tinted accent-colour to read as "switch to" rather than "open".
   Tapping uses `manager.focus()` directly so identity is
   preserved even when multiple windows share a URL.
2. **Native shell windows** — OS Settings, Code Editor, Recycle
   Bin, plugin-registered native windows from
   `desktop_mode_register_window()`. OS Settings has a sentinel
   route through `wp.desktop.openOsSettings()` because it isn't
   in the public registry.
3. **Server-registered desktop icons** — wallpaper shortcuts via
   `wp_register_desktop_icon()`. De-duplicated against #2 when
   they target the same native id.
4. **Every admin-menu top-level item** — Dashboard, Posts, Pages,
   Plugins, Users, Settings, every CPT and plugin-contributed
   page. Drilling into one fans out its submenu items, with the
   parent itself re-prepended as a leaf so the user can still
   reach the parent landing page.

Submenu tiles inherit their parent's icon — drilled into Posts,
every fan-out tile carries the Posts dashicon to reinforce "still
in Posts" rather than displaying a generic chevron that conveys
nothing.

The home grid on the wallpaper does the same merge: a new
`desktop_mode_desktop_icons` JS filter at the top of
`renderDesktopIcons()` injects every dock item as a synthetic
icon when `[data-wp-desktop-mode="mobile"]` is set on `<html>`.
A `repaintDesktopIcons()` helper synchronously replays the last
`renderDesktopIcons` call (with the fingerprint cache busted) so
mode flips take effect immediately — no REST round-trip.

#### Smart preview thumbnail

When the snapped apex item matches an open window, a translucent
glass card floats in the middle of the screen:

- **One match** — a single big card with icon, title and
  "Tap to switch". One tap focuses the existing window.
- **Multiple matches** — header + horizontally scrollable strip of
  pills, one per window, with the focused window's pill tinted
  accent. Pick exactly which instance to bring forward.
- Tapping the **icon** itself respects the dock item's `multi`
  flag: list-screen URLs (Posts, Pages, Media, Users) stack a new
  instance via `openNew()`, singleton URLs (Settings, Dashboard)
  focus the existing one. The "Tap to switch" thumb is the
  dedicated affordance for focusing regardless of `multi`.

#### Window action chips

Reload + Close fan out at the **upper-left** and **upper-right**
corners of the radial when it's open AND a window is focused.
Title bars are gone in mobile mode — these are the user's only
path to those actions, deliberately reachable in the same thumb
zone as the FAB. Close tints red on press as the danger telegraph.
Hidden when no window is focused (nothing to act on) via a
`--has-focus` root class kept in sync with WindowManager hooks.

### CSS and chrome adjustments

- Admin bar pinned to 40 px on mobile (Core's narrow-viewport
  stylesheet inflates it to 46 px+ otherwise) with row items
  pinned to match. The "Howdy, admin" / username badges hide so
  the bar stays single-row.
- Body / `#wpbody` / `#wpbody-content` / `#wpcontent` padding +
  margin zeroed on the parent shell, and `#wpbody { padding-top: 0 }`
  added to chromeless mode (Core's `@media (max-width:600px)` rule
  was leaving 46 px of dead space at the top of every iframed page).
- Dock and widget rail hidden entirely on mobile — the wallpaper
  grid replaces them.

## Hooks added

PHP filters:

| Filter | Default | Purpose |
|---|---|---|
| `desktop_mode_mode_type` | `wp_is_mobile() ? 'mobile' : 'desktop'` | Server-side initial mode guess (eliminates first-paint flash). |
| `desktop_mode_responsive_breakpoints` | `{ mobile: 640, tablet: 1024 }` | Retune cutoff widths. |

JS filters / actions (via `wp.desktop.hooks`):

| Hook | Type | Notes |
|---|---|---|
| `RESPONSIVE_MODE_CHANGED` | action | `{ from, to, viewport }` on every flip. |
| `WINDOW_DRAG_ALLOWED` | filter | Default `true`; mobile returns `false`. |
| `WINDOW_RESIZE_ALLOWED` | filter | Same shape. |
| `desktop_mode_responsive_resolve` | filter | Override the resolved mode regardless of viewport. |
| `desktop_mode_desktop_icons` | filter | Inject / reorder the wallpaper icon list. |
| `desktop_mode_mobile_app_switcher` | filter | Reshape the radial node list at any drill level. |

## Tests + verification

- `tests/vitest/mobile.test.ts` — covers `resolveMode`, breakpoint
  classification, override behavior, plugin filter override,
  subscribe API.
- `npm run lint`, `tsc --noEmit`, `npm run test:js` — all green
  (746 / 746).
- `npm run build` — desktop bundle clean (~205 KB gzipped).

## Files

**Added**
- `src/mobile/index.ts` — detection, force-maximize, drag/resize
  filter subscribers, scroll-to-top, mode flips.
- `src/mobile/radial.ts` — RadialLauncher class (FAB, gesture pad,
  arc, tiles, snap, preview, action chips, state machine).
- `assets/css/mobile.css` — every `[data-wp-desktop-mode="mobile"]`
  rule.
- `tests/vitest/mobile.test.ts`
- `docs/examples/mobile-mode.md`

**Modified**
- `src/hooks.ts` — three new HOOKS constants.
- `src/types.ts` — `DesktopMode`, `responsiveBreakpoints`,
  `initialMode` on `DesktopConfig`.
- `src/desktop.ts` — boot `bootMobile`; expose `mode()` /
  `responsive` on the public API.
- `src/window/pointer.ts` — drag/resize filter gates with attribute-
  driven mode lookup (avoids import cycle).
- `src/desktop-icons.ts` — `desktop_mode_desktop_icons` filter,
  `repaintDesktopIcons()` / `resetDesktopIconsFingerprint()`
  helpers.
- `src/ui/components/wpd-window-button/wpd-window-button.styles.ts` —
  shadow-DOM CSS vars `--wpd-btn-size`, `--wpd-btn-icon-size`.
- `src/public-api.ts` / `src/global.d.ts` — surface `DesktopMode`.
- `assets/css/chromeless.css` — `#wpbody` padding zero.
- `includes/render.php` — payload extends with
  `responsiveBreakpoints` + `initialMode`; enqueue mobile CSS.
- `includes/assets.php` — register `wp-desktop-mobile` style.
- `docs/architecture.md`, `docs/javascript-reference.md`,
  `docs/hooks-reference.md`, `docs/examples/README.md` — every
  surface documented.

## Out of scope

- Tablet-specific UI — `'tablet'` is detected but currently
  behaves like desktop. Reserved for a future hybrid pass
  (split view, slide-over, horizontal bottom dock).
- Live or snapshot thumbnails inside the preview pills.
- Pull-to-refresh, edge-swipe gestures, swipe-to-close on tiles.
- Persisted "always desktop on this device" toggle (the in-memory
  override is the testing affordance only).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-62-0733befe1567c1b93941dbd8e442da1d3c33475f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->