### PR TITLE
feat(package): add recycle-bin scripts to build process

### DIFF
--- a/bin/package.sh
+++ b/bin/package.sh
@@ -27,6 +27,8 @@ built=(
 	"assets/js/iframe-bridge.min.js"
 	"assets/js/code-editor.js"
 	"assets/js/code-editor.min.js"
+	"assets/js/recycle-bin.js"
+	"assets/js/recycle-bin.min.js"
 )
 
 for file in "${built[@]}"; do


### PR DESCRIPTION
Release script is not adding the recycle bin. Now it's being added :)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-65-64de356601d9c0cf8a87a5c3c32e0c1ec5d725d1.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->