### PR TITLE
Dock hover-peek + title-bar menu cleanup + native "Open on startup"

### DIFF
--- a/assets/css/dock-peek.css
+++ b/assets/css/dock-peek.css
@@ -1,0 +1,619 @@
+/**
+ * Desktop Mode — Dock Peek.
+ *
+ * Hover-reveal popover that fans out from a multi-instance dock tile.
+ * Each card is styled as a miniature window — faux titlebar with
+ * traffic-light dots + the page icon + the live window title, tinted
+ * body with ghosted content lines. The trailing Ghost Card matches
+ * the geometry but is dashed + breathing to announce itself as the
+ * "open new" affordance.
+ *
+ * Click an instance card → `document.startViewTransition()` morphs
+ * it into the focused window. Click the Ghost Card → same API
+ * morphs it into the freshly-spawned window.
+ *
+ * Three motion layers:
+ *   1. Tile lift     — the dock icon springs up + magnifies on hover.
+ *   2. Card fan-out  — cards slide in staggered, with a subtle peel.
+ *   3. Ghost pulse   — the trailing card breathes until hovered.
+ *
+ * @since 0.6.2
+ */
+
+/* ──────────────────────────────────────────────────────────────────
+   Tile lift — applied to ANY dock tile on hover. Cheap and additive
+   to the existing dock styles; doesn't depend on the peek being
+   present (the icon should feel responsive even when there's no
+   peek to show).
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock__item-primary {
+	transition:
+		transform 240ms cubic-bezier( 0.34, 1.56, 0.64, 1 ),
+		filter 240ms ease-out;
+}
+
+.wp-desktop-dock__item:hover .wp-desktop-dock__item-primary {
+	transform: scale( 1.08 );
+	filter: drop-shadow( 0 4px 8px rgba( 0, 0, 0, 0.18 ) );
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.wp-desktop-dock__item-primary,
+	.wp-desktop-dock__item:hover .wp-desktop-dock__item-primary {
+		transition: none;
+		transform: none;
+	}
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Popover surface — glass material, body-attached.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek {
+	position: fixed;
+	z-index: 999999;
+	padding: 10px;
+	border-radius: 16px;
+	background: color-mix( in srgb, var( --wp-desktop-bg, #1d2327 ) 76%, transparent );
+	backdrop-filter: blur( 28px ) saturate( 180% );
+	-webkit-backdrop-filter: blur( 28px ) saturate( 180% );
+	border: 1px solid rgba( 255, 255, 255, 0.12 );
+	box-shadow:
+		0 1px 0 rgba( 255, 255, 255, 0.08 ) inset,
+		0 16px 40px -10px rgba( 0, 0, 0, 0.55 ),
+		0 6px 16px -4px rgba( 0, 0, 0, 0.36 );
+	color: var( --wp-desktop-fg, #fff );
+	pointer-events: auto;
+	opacity: 0;
+	display: flex;
+	flex-direction: column;
+	transition: opacity 160ms ease-out;
+	/* Default (left/right docks) — vertical column. The popover caps
+	   in height; cards scroll inside. */
+	max-height: min( 80vh, 480px );
+	max-width: min( 90vw, 320px );
+}
+
+/* Bottom-dock orientation: cards form a horizontal reel. The popover
+   caps in WIDTH instead of height, and the cards container scrolls
+   horizontally. Visually mirrors how taskbar-style docks work — a
+   row of mini-windows above the icon, not a stack. */
+.wp-desktop-dock-peek[ data-orientation = "bottom" ] {
+	max-height: none;
+	max-width: min( 92vw, 920px );
+}
+
+.wp-desktop-dock-peek--open {
+	opacity: 1;
+}
+
+/* Anchor flips by orientation. The popover's anchor point (the
+   coordinate set in JS) sits ON the tile edge; we translate from
+   there so the popover floats off-edge with a gap. The
+   `--peek-clamp-x/y` props are added by JS when the popover would
+   otherwise overflow the viewport — they nudge it inward without
+   losing the orientation translate. */
+.wp-desktop-dock-peek[ data-orientation = "left" ] {
+	transform:
+		translate(
+			var( --peek-clamp-x, 0 ),
+			calc( -50% + var( --peek-clamp-y, 0px ) )
+		);
+}
+.wp-desktop-dock-peek[ data-orientation = "right" ] {
+	transform:
+		translate(
+			calc( -100% + var( --peek-clamp-x, 0px ) ),
+			calc( -50% + var( --peek-clamp-y, 0px ) )
+		);
+}
+.wp-desktop-dock-peek[ data-orientation = "bottom" ] {
+	transform:
+		translate(
+			calc( -50% + var( --peek-clamp-x, 0px ) ),
+			calc( -100% + var( --peek-clamp-y, 0px ) )
+		);
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Cards.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek__cards {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	min-width: 280px;
+	/* Take up whatever vertical space the popover offers and scroll
+	   internally once the cards spill beyond it. Subtract the
+	   popover's padding so the scrollbar doesn't flush against the
+	   rounded outer edge. */
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	overflow-x: hidden;
+	/* Hide the scrollbar visually until hover — the peek surface is
+	   meant to feel weightless, not "yet another panel with a
+	   scrollbar." Falls back to the platform scrollbar where the
+	   custom-scrollbar pseudo isn't supported. */
+	scrollbar-width: thin;
+	scrollbar-color: rgba( 255, 255, 255, 0.18 ) transparent;
+}
+
+/* Bottom dock: cards lay out as a horizontal reel and scroll on the
+   X-axis instead of Y. */
+.wp-desktop-dock-peek[ data-orientation = "bottom" ] .wp-desktop-dock-peek__cards {
+	flex-direction: row;
+	min-width: 0;
+	overflow-x: auto;
+	overflow-y: hidden;
+	max-width: 100%;
+}
+
+.wp-desktop-dock-peek[ data-orientation = "bottom" ] .wp-desktop-dock-peek__card {
+	/* Bottom-dock cards are narrower than left/right dock cards —
+	   a horizontal reel reads better with thumbnail-shaped tiles
+	   (Mission Control / Stage Manager) than with full-width
+	   sidebar-shaped ones. flex: 0 0 auto so a long reel doesn't
+	   squish each card down to nothing. */
+	flex: 0 0 auto;
+	width: 200px;
+	min-height: 116px;
+	/* Cards translate from BELOW into the reel (towards the dock
+	   tile they peeled off of), so the directional motion still
+	   points back at the icon. */
+	transform: translateY( 10px ) scale( 0.96 );
+}
+
+.wp-desktop-dock-peek[ data-orientation = "bottom" ] .wp-desktop-dock-peek__card--ghost {
+	width: 200px;
+	min-height: 116px;
+}
+
+.wp-desktop-dock-peek[ data-orientation = "bottom" ].wp-desktop-dock-peek--open
+	.wp-desktop-dock-peek__card {
+	transform: translateY( 0 ) scale( 1 );
+}
+
+.wp-desktop-dock-peek__cards::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+.wp-desktop-dock-peek__cards::-webkit-scrollbar-track {
+	background: transparent;
+}
+.wp-desktop-dock-peek__cards::-webkit-scrollbar-thumb {
+	background: rgba( 255, 255, 255, 0.18 );
+	border-radius: 8px;
+	border: 2px solid transparent;
+	background-clip: padding-box;
+}
+.wp-desktop-dock-peek__cards::-webkit-scrollbar-thumb:hover {
+	background: rgba( 255, 255, 255, 0.32 );
+	background-clip: padding-box;
+}
+
+.wp-desktop-dock-peek__card {
+	/* Card frame — looks like a tiny window. */
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	width: 280px;
+	min-height: 92px;
+	padding: 0;
+	border: 1px solid rgba( 255, 255, 255, 0.10 );
+	border-radius: 10px;
+	background: rgba( 255, 255, 255, 0.04 );
+	color: inherit;
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
+	view-transition-name: var( --peek-card-vt-name, none );
+	/* Animation start state — cards begin slightly displaced toward
+	   the tile they "peeled off of". CSS resets to identity once the
+	   `--open` class on the parent triggers the transition. */
+	opacity: 0;
+	transform: translateX( -10px ) scale( 0.96 );
+	transition:
+		opacity 240ms ease-out var( --peek-card-delay, 0ms ),
+		transform 320ms cubic-bezier( 0.34, 1.56, 0.64, 1 ) var( --peek-card-delay, 0ms ),
+		border-color 180ms ease-out,
+		box-shadow 180ms ease-out;
+}
+
+.wp-desktop-dock-peek--open .wp-desktop-dock-peek__card {
+	opacity: 1;
+	transform: translateX( 0 ) scale( 1 );
+}
+
+.wp-desktop-dock-peek__card:hover {
+	border-color: rgba( 255, 255, 255, 0.24 );
+	box-shadow: 0 4px 14px -4px rgba( 0, 0, 0, 0.4 );
+}
+
+.wp-desktop-dock-peek__card:focus-visible {
+	outline: 2px solid var( --wp-desktop-accent, #2271b1 );
+	outline-offset: 2px;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Mini-window chrome — instance card faux titlebar.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek__card-titlebar {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	/* Use the live window's titlebar background so the mini-window
+	   reads as a faithful shrink of the real window. Falls back to a
+	   neutral translucent gradient when the variable isn't set (early
+	   load, theme without the token, tests). */
+	background: var(
+		--wp-desktop-titlebar-bg-focused,
+		linear-gradient(
+			to bottom,
+			rgba( 255, 255, 255, 0.10 ),
+			rgba( 255, 255, 255, 0.04 )
+		)
+	);
+	color: var(
+		--wp-desktop-titlebar-color-focused,
+		var( --wp-desktop-fg, #fff )
+	);
+	border-bottom: 1px solid rgba( 0, 0, 0, 0.12 );
+	font-size: 12px;
+	line-height: 1.2;
+}
+
+.wp-desktop-dock-peek__card-dots {
+	display: inline-flex;
+	gap: 4px;
+	flex: 0 0 auto;
+}
+
+.wp-desktop-dock-peek__card-dots i {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: rgba( 255, 255, 255, 0.22 );
+}
+
+.wp-desktop-dock-peek__card-dots i:nth-child( 1 ) {
+	background: #ff5f57;
+}
+.wp-desktop-dock-peek__card-dots i:nth-child( 2 ) {
+	background: #febc2e;
+}
+.wp-desktop-dock-peek__card-dots i:nth-child( 3 ) {
+	background: #28c840;
+}
+
+.wp-desktop-dock-peek__card-icon {
+	flex: 0 0 auto;
+	width: 14px;
+	height: 14px;
+	font-size: 14px;
+	line-height: 1;
+	opacity: 0.92;
+}
+
+.wp-desktop-dock-peek__card-label {
+	flex: 1 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: 500;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Mini-window body — tinted by the page hue, ghosted content lines.
+
+   The hue comes from `hashTitleToHue(window.id || title)`, so two
+   instances of the same page (`edit.php` and `edit.php-2`) read as
+   visually distinct without us having to invent unique colors.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek__card-body {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 12px 12px 14px;
+	background:
+		linear-gradient(
+			135deg,
+			hsl( var( --peek-card-hue, 210 ) 55% 22% / 0.65 ),
+			hsl( var( --peek-card-hue, 210 ) 55% 14% / 0.5 )
+		);
+}
+
+.wp-desktop-dock-peek__card-line {
+	display: block;
+	height: 6px;
+	border-radius: 3px;
+	background: rgba( 255, 255, 255, 0.16 );
+}
+
+.wp-desktop-dock-peek__card-line:nth-child( 1 ) {
+	width: 80%;
+}
+.wp-desktop-dock-peek__card-line:nth-child( 2 ) {
+	width: 60%;
+}
+.wp-desktop-dock-peek__card-line:nth-child( 3 ) {
+	width: 70%;
+}
+
+/* Plugin-customized body — drop the default tinted background +
+   ghost-line padding so the plugin's own markup gets a clean canvas.
+   Plugins that want the tinted look back can re-add their own
+   background; otherwise they get a transparent flex container. */
+.wp-desktop-dock-peek__card-body--custom {
+	background: transparent;
+	padding: 0;
+	gap: 0;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Built-in renderer: OS Settings.
+
+   A big tinted hero icon + a phrase + a row of three tab-icon
+   chips representing the inner Settings tabs. Tinted with the
+   user's WP profile accent so the card "belongs" to the active
+   color scheme.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek__card-body--os-settings {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 14px 12px;
+	background: linear-gradient(
+		135deg,
+		color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 65%, #1d2327 ) 0%,
+		color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 35%, #1d2327 ) 100%
+	);
+	color: #fff;
+}
+
+.wp-desktop-dock-peek__os-hero {
+	font-size: 32px;
+	width: 32px;
+	height: 32px;
+	line-height: 1;
+	opacity: 0.95;
+	filter: drop-shadow( 0 1px 2px rgba( 0, 0, 0, 0.4 ) );
+}
+
+.wp-desktop-dock-peek__os-subtitle {
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	opacity: 0.85;
+	text-shadow: 0 1px 2px rgba( 0, 0, 0, 0.3 );
+}
+
+.wp-desktop-dock-peek__os-tabs {
+	display: flex;
+	gap: 6px;
+	margin-top: 2px;
+}
+
+.wp-desktop-dock-peek__os-tab {
+	width: 18px;
+	height: 18px;
+	font-size: 13px;
+	line-height: 18px;
+	border-radius: 4px;
+	background: rgba( 255, 255, 255, 0.18 );
+	color: rgba( 255, 255, 255, 0.92 );
+	text-align: center;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Built-in renderer: Recycle Bin.
+
+   Empty state: a single trash icon, dim. Full state: a stack of
+   three "slips" peeking from behind the icon + a count chip in the
+   corner. The `data-empty` attribute toggles between the two.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek__card-body--recycle-bin {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 14px 12px;
+	background: linear-gradient(
+		135deg,
+		#3a3f47 0%,
+		#23272b 100%
+	);
+	color: rgba( 255, 255, 255, 0.92 );
+}
+
+.wp-desktop-dock-peek__bin-stage {
+	position: relative;
+	width: 44px;
+	height: 44px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.wp-desktop-dock-peek__bin-icon {
+	font-size: 32px;
+	width: 32px;
+	height: 32px;
+	line-height: 1;
+	opacity: 0.95;
+	filter: drop-shadow( 0 1px 2px rgba( 0, 0, 0, 0.4 ) );
+	z-index: 1;
+}
+
+.wp-desktop-dock-peek__bin-stack {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 200ms ease-out;
+}
+
+.wp-desktop-dock-peek__card-body--recycle-bin[ data-empty = "false" ]
+	.wp-desktop-dock-peek__bin-stack {
+	opacity: 1;
+}
+
+.wp-desktop-dock-peek__bin-slip {
+	position: absolute;
+	width: 22px;
+	height: 4px;
+	border-radius: 1px;
+	background: rgba( 255, 255, 255, 0.55 );
+	bottom: 6px;
+}
+
+.wp-desktop-dock-peek__bin-slip:nth-child( 1 ) {
+	transform: translate( -10px, -16px ) rotate( -8deg );
+	background: rgba( 255, 255, 255, 0.45 );
+}
+.wp-desktop-dock-peek__bin-slip:nth-child( 2 ) {
+	transform: translate( 8px, -20px ) rotate( 6deg );
+	background: rgba( 255, 255, 255, 0.5 );
+}
+.wp-desktop-dock-peek__bin-slip:nth-child( 3 ) {
+	transform: translate( -2px, -22px ) rotate( -2deg );
+	background: rgba( 255, 255, 255, 0.6 );
+}
+
+.wp-desktop-dock-peek__bin-label {
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	color: rgba( 255, 255, 255, 0.78 );
+}
+
+.wp-desktop-dock-peek__card-body--recycle-bin[ data-empty = "false" ]
+	.wp-desktop-dock-peek__bin-label {
+	color: var( --wp-admin-theme-color, #4f9cff );
+	font-weight: 600;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Ghost Card — the "open new" affordance.
+
+   Same geometry as instance cards (so the fan reads as one stack)
+   but visually distinct via:
+     * Dashed border (vs solid)
+     * Lower base opacity
+     * Breathing pulse (slow scale + opacity loop)
+     * Centered "+" + label, no faux titlebar / body lines
+   On hover, the dashes resolve to a solid line, the pulse stops,
+   and opacity ramps to full — the card "solidifies" into the same
+   visual weight as an instance card.
+   ────────────────────────────────────────────────────────────────── */
+
+.wp-desktop-dock-peek__card--ghost {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	width: 280px;
+	min-height: 64px;
+	padding: 16px;
+	border-style: dashed;
+	border-color: rgba( 255, 255, 255, 0.34 );
+	/* A self-contained dark translucent fill so the white label
+	   reads on light wallpapers / light color schemes too. The
+	   popover's parent surface uses `color-mix(--wp-desktop-bg)`,
+	   which goes near-white on light themes — without our own
+	   backdrop the Ghost Card was white-on-white. */
+	background: rgba( 0, 0, 0, 0.32 );
+	color: #fff;
+	text-shadow: 0 1px 2px rgba( 0, 0, 0, 0.45 );
+	font-size: 13px;
+	font-weight: 500;
+	animation: wp-desktop-dock-peek-breathe 2400ms ease-in-out infinite;
+}
+
+.wp-desktop-dock-peek__card--ghost:hover {
+	border-style: solid;
+	border-color: rgba( 255, 255, 255, 0.55 );
+	background: rgba( 0, 0, 0, 0.45 );
+	color: #fff;
+	animation: none;
+	transform: scale( 1.02 );
+	box-shadow: 0 4px 14px -4px rgba( 0, 0, 0, 0.5 );
+}
+
+.wp-desktop-dock-peek__card-plus {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	font-size: 22px;
+	line-height: 1;
+	font-weight: 300;
+	/* Slightly more presence than before (was 0.42 alpha). The
+	   "+" is the only glyph the user sees in the resting state,
+	   so it has to read at a glance even against the breathing
+	   pulse's lower-opacity moments. */
+	color: rgba( 255, 255, 255, 0.78 );
+	text-shadow: 0 1px 2px rgba( 0, 0, 0, 0.45 );
+	transition: color 160ms ease-out;
+}
+
+.wp-desktop-dock-peek__card--ghost:hover .wp-desktop-dock-peek__card-plus {
+	color: var( --wp-desktop-accent, #4f9cff );
+}
+
+@keyframes wp-desktop-dock-peek-breathe {
+	0%, 100% {
+		opacity: 0.74;
+		transform: scale( 1 );
+	}
+	50% {
+		opacity: 1;
+		transform: scale( 1.018 );
+	}
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.wp-desktop-dock-peek,
+	.wp-desktop-dock-peek__card,
+	.wp-desktop-dock-peek__card--ghost {
+		transition: opacity 80ms linear;
+		animation: none !important;
+		transform: none !important;
+	}
+	.wp-desktop-dock-peek--open .wp-desktop-dock-peek__card {
+		transform: none;
+	}
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   View Transitions — when supported, an instance card morphs into
+   its window on click (and the Ghost Card morphs into the new
+   spawned window). The transition group is named per-card via
+   `--peek-card-vt-name`, set in JS at click time so the source +
+   destination share an identity.
+   ────────────────────────────────────────────────────────────────── */
+
+@supports ( view-transition-name: none ) {
+	::view-transition-old( root ),
+	::view-transition-new( root ) {
+		animation-duration: 280ms;
+		animation-timing-function: cubic-bezier( 0.22, 1, 0.36, 1 );
+	}
+}

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -501,7 +501,7 @@ add_filter( 'desktop_mode_dock_item', function ( $item, $slug ) {
 
 ### `desktop_mode_dock_item_multi` — Stable
 
-Controls whether a dock item supports multiple simultaneous windows. Multi-capable pages expose a "+" chip on the dock icon and an "Open another" action in the window's title-bar menu; singletons always focus the existing window when re-opened.
+Controls whether a dock item supports multiple simultaneous windows. Multi-capable pages expose a hover-peek popover on the dock icon (one card per open instance + a Ghost Card that spawns a new instance) and an "Open another" action in the window's title-bar menu; singletons always focus the existing window when re-opened.
 
 Built-in defaults: `edit.php`, `edit-tags.php`, `upload.php`, `users.php`, and `edit-comments.php` are multi; everything else is singleton. The base filename is matched against the list, so every CPT (`edit.php?post_type=page`) and every taxonomy inherits the same rule as its parent admin file.
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -405,7 +405,40 @@ document.addEventListener( 'wp-desktop-init', () => {
 
 Calling `open()` with an id (or `baseId`) that's already on screen focuses the existing window and restores it if minimized.
 
-**Multi-instance windows.** When `multi: true` is passed, the window gets an extra actions menu in its title bar (leading edge, before the icon) whose "Open another" item calls `openNew()`. `openNew()` always creates a fresh window — even when one with the same `baseId` is already open — assigning a suffixed id (`${baseId}-2`, `${baseId}-3`, …) so every instance can be tracked independently while the dock still groups them under the same icon.
+**Title-bar actions menu (iframe windows).** Every iframe-backed window renders a three-dots actions menu on the leading edge of its title bar. Built-in items:
+
+- **"Open on startup"** — checkable; toggles this window as the user's default-window preference.
+- **"Open another <Page>"** — only when the window was opened with `multi: true`. Calls `openNew()` with the window's *original* landing URL.
+- **"Open in new window"** — opens a fresh sibling window seeded with the *current* iframe URL (post in-window navigation). Useful when the user has drilled into a sub-page (e.g. editing a specific post) and wants to peel a copy off without losing their place. The new window cascades and uses the same multi-instance id suffixing as `openNew()`.
+
+**Multi-instance windows.** When `multi: true` is passed, the window gets the "Open another" item described above. `openNew()` always creates a fresh window — even when one with the same `baseId` is already open — assigning a suffixed id (`${baseId}-2`, `${baseId}-3`, …) so every instance can be tracked independently while the dock still groups them under the same icon.
+
+**Dock hover-peek.** Multi-capable dock tiles render a hover-reveal *peek* popover instead of the legacy "+" chip. Hovering a multi tile that has at least one open instance fans out a stack of cards next to the tile (works on left, right, and bottom dock orientations):
+
+- **Instance cards** — one per currently open window of this dock item, styled as miniature windows: faux titlebar with traffic-light dots, the page icon, the live window title (titlebar background uses `--wp-desktop-titlebar-bg-focused` so the mini-window matches the real window's chrome), plus a hash-tinted body. **Hovering an instance card raises that window to front** ("scrub through windows" — Mission Control / Aero Peek). **Clicking** focuses the window through `document.startViewTransition()` so the card morphs into the window position.
+- **Ghost Card** — the trailing card with a dashed outline and a slow breathing pulse. Clicking it calls `windowManager.openNew()` for this tile, also animated through `startViewTransition()` (graceful fade fallback otherwise).
+
+The popover caps at `min(80vh, 480px)` and **scrolls internally** when more cards exist than fit. After mount, JS measures and clamps the popover position so it never overflows the viewport edges (top/bottom/sides).
+
+The peek is mouse-only — touch and pen pointers fall back to plain tap-to-focus / tap-to-open. It also suppresses itself for singleton tiles (no Ghost Card is meaningful) and for multi tiles with zero open instances (a plain click already does the only useful thing). The icon itself springs up + magnifies on hover for tactile feedback even when the peek isn't shown. `prefers-reduced-motion` disables every animation.
+
+**Customizing peek cards.** Two filters let plugins reshape what each card looks like:
+
+- `wp-desktop.dock.peek-card-content` — receives the default body element (`<span class="wp-desktop-dock-peek__card-body">`) and a `{ window, item }` context. Return a different element to replace just the body — perfect for rendering a real thumbnail, a status block, a chart, or anything else inside the card while keeping the default mini-window chrome (titlebar with dots + icon + title). When a plugin returns a non-default body, the peek adds a `--custom` modifier class so the default tinted background and ghost-line padding drop out, giving the plugin a clean canvas.
+- `wp-desktop.dock.peek-card-element` — receives the fully-built default card and the same `{ window, item }` context. Return a different element to replace the **whole card** (chrome included). Plugins that take this path are responsible for preserving the `wp-desktop-dock-peek__card` class (the fan-out animation keys off it) and for re-wiring the click handler if focus-on-click should still work. Use `peek-card-content` when you only need to swap the body; reach for `peek-card-element` when you need to control titlebar + body together.
+
+```javascript
+window.wp.hooks.addFilter(
+    'wp-desktop.dock.peek-card-content',
+    'my-plugin/thumbnail',
+    ( body, { window: win } ) => {
+        const img = document.createElement( 'img' );
+        img.src = `/wp-json/my-plugin/v1/thumbnail/${ win.id }`;
+        img.alt = win.config.title;
+        return img;
+    }
+);
+```
 
 ```javascript
 // Open a second Posts list alongside the first.
@@ -2611,7 +2644,7 @@ interface DockItem {
     url:      string;        // admin URL the tile opens
     badge:    number;        // numeric badge; 0 = no badge
     submenu:  { title: string; url: string }[];
-    multi:    boolean;       // multi-instance "+" chip eligibility
+    multi:    boolean;       // hover-peek + Ghost Card eligibility
     isCore:   boolean;       // true for WP-shipped menus, false for plugin-contributed
 }
 ```

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -266,7 +266,11 @@ function desktop_mode_enqueue_toggle_assets() {
 			position: relative;
 		}
 		#wp-admin-bar-desktop-mode-toggle.desktop-mode-active .ab-icon.dashicons::before {
-			color: #72aee6;
+			/* Inherit the admin-bar text color so the active state
+			   matches the +New, Home, Comments dashicons. Previously
+			   hardcoded #72aee6, which forced blue regardless of the
+			   profile color scheme. */
+			color: inherit;
 		}
 		@media screen and (max-width: 782px) {
 			#wp-admin-bar-desktop-mode-toggle .ab-label,
@@ -288,12 +292,20 @@ function desktop_mode_enqueue_toggle_assets() {
 			content: "\f101";
 			top: 2px;
 			position: relative;
-			color: #72aee6;
+			/* See note on desktop-mode-toggle above — inherit so the
+			   icon matches the rest of the admin-bar dashicons
+			   across all WP profile color schemes. */
+			color: inherit;
 		}
-		/* ⌘K badge rendered purely in CSS to the right of the label */
+		/* ⌘K badge rendered purely in CSS to the right of the label.
+		   inline-flex + align-items:center centers the glyph inside
+		   its own padding box; a 1px upward translate compensates
+		   for the optical sag from the admin-bar label baseline. */
 		#wpadminbar #wp-admin-bar-desktop-ai-assistant .ab-label::after {
 			content: "\2318K";
-			display: inline-block;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
 			margin-inline-start: 5px;
 			font-size: 10px;
 			line-height: 1;
@@ -305,6 +317,8 @@ function desktop_mode_enqueue_toggle_assets() {
 			vertical-align: middle;
 			font-weight: 400;
 			letter-spacing: 0;
+			position: relative;
+			top: -1px;
 		}
 		@media screen and (max-width: 782px) {
 			#wp-admin-bar-desktop-ai-assistant .ab-label {

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -59,6 +59,12 @@ function desktop_mode_register_assets() {
 		$version
 	);
 	wp_register_style(
+		'wp-desktop-dock-peek',
+		DESKTOP_MODE_URL . 'assets/css/dock-peek.css',
+		array( 'wp-desktop-dock' ),
+		$version
+	);
+	wp_register_style(
 		'wp-desktop-chromeless',
 		DESKTOP_MODE_URL . 'assets/css/chromeless.css',
 		array( 'wp-desktop' ),

--- a/includes/default-window.php
+++ b/includes/default-window.php
@@ -126,6 +126,20 @@ function desktop_mode_validate_default_window_url( $url ) {
 		return '';
 	}
 
+	// Native-window marker: "native:<slug>" stores a registered native
+	// window id (OS Settings, Recycle Bin, plugin-registered native
+	// apps) instead of an admin URL. The slug must match
+	// /^[a-z0-9_-]+$/i so a malicious save cannot smuggle path
+	// traversal or whitespace through the marker. The shell handles
+	// the actual open-on-startup at boot via nativeWindows.openById.
+	if ( 0 === strpos( $url, 'native:' ) ) {
+		$slug = substr( $url, strlen( 'native:' ) );
+		if ( '' === $slug || ! preg_match( '/^[a-z0-9_\-]+$/i', $slug ) ) {
+			return '';
+		}
+		return 'native:' . $slug;
+	}
+
 	// Allow same-origin http(s) URLs only.
 	$parsed = wp_parse_url( $url );
 	if ( ! is_array( $parsed ) || empty( $parsed['path'] ) ) {

--- a/includes/portal.php
+++ b/includes/portal.php
@@ -272,6 +272,15 @@ function desktop_mode_portal_entry_url( $user_id ) {
 	$default_window = desktop_mode_get_default_window( $user_id );
 	$fallback       = $default_window['url'];
 
+	// Native marker (e.g. "native:wp-desktop-os-settings") is not a
+	// redirectable URL. The portal MUST forward somewhere — the
+	// redirect happens at HTTP level — so we land on the admin home
+	// and let the shell pick up `defaultWindow.url` from the config
+	// after init and call nativeWindows.openById( <slug> ).
+	if ( is_string( $fallback ) && 0 === strpos( $fallback, 'native:' ) ) {
+		$fallback = admin_url();
+	}
+
 	if ( empty( $session['focused'] ) || empty( $session['windows'] ) ) {
 		return $fallback;
 	}

--- a/includes/render.php
+++ b/includes/render.php
@@ -94,6 +94,7 @@ function desktop_mode_enqueue_assets() {
 	wp_enqueue_style( 'wp-desktop' );
 	wp_enqueue_style( 'wp-desktop-windows' );
 	wp_enqueue_style( 'wp-desktop-dock' );
+	wp_enqueue_style( 'wp-desktop-dock-peek' );
 	wp_enqueue_style( 'wp-desktop-ai-assistant' );
 
 	// JS.

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -118,7 +118,8 @@ import {
 	installBroadcastReceiver,
 	subscribe,
 } from './broadcast';
-import { startRecycleBinBadge } from './recycle-bin/badge';
+import { startRecycleBinBadge, _currentRecycleBinBadge } from './recycle-bin/badge';
+import { registerBuiltInPeekRenderers } from './dock-peek/built-in-renderers';
 import { showToast, type ToastOptions } from './toast';
 import { renderKeyedList, clearKeyedList, type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
@@ -1607,8 +1608,13 @@ function init(): void {
 		restoreSession( manager, config, desktopArea );
 	}
 	const defaultEnabled = config.defaultWindow?.enabled !== false;
+	const defaultUrlEarly = config.defaultWindow?.url ?? '';
+	const isNativeDefault =
+		typeof defaultUrlEarly === 'string' &&
+		defaultUrlEarly.startsWith( 'native:' );
 	const suppressAutoOpen =
-		config.fromPortal && ( hasSession || ! defaultEnabled );
+		config.fromPortal &&
+		( hasSession || ! defaultEnabled || isNativeDefault );
 	if ( ! suppressAutoOpen ) {
 		openCurrentPage( manager, config );
 	}
@@ -1660,14 +1666,55 @@ function init(): void {
 	// in a window's ⋯ menu, the manager calls this callback with the
 	// window. We either set this window's URL as the default, or — if
 	// it's already the default — disable it.
+	//
+	// Native windows (OS Settings, Recycle Bin, plugin-registered)
+	// have no admin URL — `getCurrentUrl()` returns the `#<id>` hash
+	// fallback, which isn't a redirectable URL the portal can forward
+	// to. We store a `native:<id>` marker instead; the PHP validator
+	// accepts the marker, the portal redirects to admin home when it
+	// sees one, and this module's boot flow opens the right native
+	// window after init.
 	manager.onToggleStartupRequested = ( win ) => {
 		const currentPref = config.defaultWindow;
-		const winUrl = win.getCurrentUrl();
-		const alreadyDefault =
-			!! currentPref?.enabled &&
-			urlMatchKey( currentPref.url ) === urlMatchKey( winUrl );
-		void setDefaultWindow( alreadyDefault ? null : winUrl );
+		const isNative = !! win.config.native;
+		const winValue = isNative ? `native:${ win.id }` : win.getCurrentUrl();
+		const matchesCurrent = isNative
+			? currentPref?.url === winValue
+			: urlMatchKey( currentPref?.url ?? '' ) === urlMatchKey( winValue );
+		const alreadyDefault = !! currentPref?.enabled && matchesCurrent;
+		void setDefaultWindow( alreadyDefault ? null : winValue );
 	};
+
+	// Open the native default window on portal entry. The portal
+	// redirected the user to admin home (because `native:` markers
+	// aren't redirectable), so `openCurrentPage` was suppressed
+	// above. Open the user's choice here, after the manager + native
+	// registry are wired.
+	//
+	// Two opener paths because the shell registers built-in native
+	// windows (OS Settings) directly against the manager via local
+	// closures, NOT through `nativeWindows.openById` — that registry
+	// only carries server-payload entries (plugin-registered native
+	// windows). Built-ins are matched by id first; everything else
+	// falls through to the registry.
+	if (
+		config.defaultWindow?.enabled &&
+		config.fromPortal &&
+		! hasSession &&
+		isNativeDefault
+	) {
+		const nativeId = defaultUrlEarly.slice( 'native:'.length );
+		// Defer one tick so the dispatcher / system tiles have
+		// finished mounting — both built-in openers and the
+		// registry assume the layout pass is complete.
+		queueMicrotask( () => {
+			if ( nativeId === OS_SETTINGS_WINDOW_ID ) {
+				openOsSettings();
+				return;
+			}
+			void nativeWindows.openById( nativeId );
+		} );
+	}
 
 	/**
 	 * Place a system tile on the bottom dock rail via the layout
@@ -1893,6 +1940,15 @@ function init(): void {
 			? cfgWithBin.recycleBinCountUrl
 			: '',
 	);
+
+	// Register custom dock-peek renderers for shell-owned native
+	// windows (OS Settings, Recycle Bin). Plugins use the
+	// `wp-desktop.dock.peek-card-content` filter directly to surface
+	// their own thumbnails — this is just the built-in set so the
+	// in-tree windows look like first-class apps.
+	registerBuiltInPeekRenderers( {
+		getRecycleBinCount: _currentRecycleBinBadge,
+	} );
 
 	// Auto-reload iframes on `wp-desktop.<post_type>.changed` is
 	// handled IN THE IFRAME (see the chromeless bridge in

--- a/src/dock-peek/built-in-renderers.ts
+++ b/src/dock-peek/built-in-renderers.ts
@@ -1,0 +1,204 @@
+/**
+ * Desktop Mode — built-in dock-peek thumbnail renderers.
+ *
+ * The generic mini-window card (faux titlebar + ghosted content
+ * lines) is fine for admin-page windows where the only signal
+ * worth showing is "this window is open." Native shell apps —
+ * OS Settings, Recycle Bin — are different: they have a visual
+ * identity and a useful piece of state worth surfacing on hover.
+ *
+ * This module hooks `wp-desktop.dock.peek-card-content` once and,
+ * for each known built-in window id, returns a custom body element
+ * instead of the default ghosted lines. The renderer set is closed
+ * to shell-owned windows; third-party plugins use the public
+ * filter directly to register their own.
+ *
+ * Bootstrapped from `desktop.ts` once the hook bus is up.
+ *
+ * @since 0.6.2
+ */
+
+import { __ } from '../i18n';
+import type { Window as WPWindow } from '../window';
+
+/** Window id used by the OS Settings native window. Shared with `desktop.ts`. */
+const OS_SETTINGS_ID = 'wp-desktop-os-settings';
+
+/** Window id used by the Recycle Bin native window. Shared with `recycle-bin/badge.ts`. */
+const RECYCLE_BIN_ID = 'wpdm-recycle-bin';
+
+/**
+ * Reader for the live recycle-bin count. Delayed-bound at registration
+ * time because `desktop.ts` imports this module before the recycle-bin
+ * module has finished bootstrapping its store; trying to import the
+ * count getter at module top would create a load-order dependency we
+ * don't want to enforce.
+ */
+type CountReader = () => number;
+
+/**
+ * Filter context — shape mirrors `DockPeekCardContext` from
+ * `src/dock-peek/index.ts`. Duplicated here as a structural type
+ * to avoid the circular import.
+ */
+interface PeekCardContext {
+	window: WPWindow;
+	item: { id: string; title: string; icon: string; url: string };
+}
+
+interface RegisterOpts {
+	/**
+	 * Returns the current recycle-bin count. Called every time the
+	 * peek opens — fresh value, no staleness. The Recycle Bin
+	 * module passes its `_currentRecycleBinBadge` getter.
+	 */
+	getRecycleBinCount: CountReader;
+}
+
+/**
+ * Wire the built-in peek renderers. Idempotent: calling twice
+ * registers the filter twice, so guard at the call site.
+ */
+export function registerBuiltInPeekRenderers( opts: RegisterOpts ): void {
+	const wpHooks = getWpHooks();
+	if ( ! wpHooks ) {
+		return;
+	}
+	wpHooks.addFilter(
+		'wp-desktop.dock.peek-card-content',
+		'wp-desktop-mode/built-in-peek-renderers',
+		( body: unknown, ctx: unknown ): HTMLElement => {
+			const context = ctx as PeekCardContext;
+			const id = context.window.id;
+			if ( id === OS_SETTINGS_ID ) {
+				return renderOsSettings( context );
+			}
+			if ( id === RECYCLE_BIN_ID ) {
+				return renderRecycleBin( context, opts.getRecycleBinCount );
+			}
+			return body as HTMLElement;
+		},
+	);
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   OS Settings renderer.
+
+   Visual: large dashicon + a mosaic of three "tab tiles" beneath
+   the big icon, hinting at the Settings tabs (Appearance, AI,
+   Help — interleaved with whatever a plugin's added). Accent color
+   inherits from the user's WP profile scheme via
+   `--wp-admin-theme-color`.
+   ────────────────────────────────────────────────────────────────── */
+
+function renderOsSettings( _ctx: PeekCardContext ): HTMLElement {
+	const root = document.createElement( 'span' );
+	root.className =
+		'wp-desktop-dock-peek__card-body wp-desktop-dock-peek__card-body--os-settings';
+	root.setAttribute( 'aria-hidden', 'true' );
+
+	const hero = document.createElement( 'span' );
+	hero.className = 'wp-desktop-dock-peek__os-hero dashicons dashicons-admin-generic';
+	root.appendChild( hero );
+
+	const subtitle = document.createElement( 'span' );
+	subtitle.className = 'wp-desktop-dock-peek__os-subtitle';
+	subtitle.textContent = __( 'System Preferences' );
+	root.appendChild( subtitle );
+
+	const tabs = document.createElement( 'span' );
+	tabs.className = 'wp-desktop-dock-peek__os-tabs';
+	for ( const cls of [
+		'dashicons-art',
+		'dashicons-admin-customizer',
+		'dashicons-editor-help',
+	] ) {
+		const tab = document.createElement( 'span' );
+		tab.className = `wp-desktop-dock-peek__os-tab dashicons ${ cls }`;
+		tabs.appendChild( tab );
+	}
+	root.appendChild( tabs );
+
+	return root;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Recycle Bin renderer.
+
+   Visual: trash dashicon — open lid when empty, closed lid with a
+   stack of "items" peeking out when full — plus a live count
+   badge when ≥1 item exists. The count is read fresh on every
+   peek build via the injected `getRecycleBinCount` getter, so the
+   thumbnail always reflects current state without subscriptions.
+   ────────────────────────────────────────────────────────────────── */
+
+function renderRecycleBin(
+	_ctx: PeekCardContext,
+	getCount: CountReader,
+): HTMLElement {
+	const root = document.createElement( 'span' );
+	root.className =
+		'wp-desktop-dock-peek__card-body wp-desktop-dock-peek__card-body--recycle-bin';
+	root.setAttribute( 'aria-hidden', 'true' );
+
+	const count = Math.max( 0, Math.floor( getCount() || 0 ) );
+	root.dataset.empty = count === 0 ? 'true' : 'false';
+
+	const stage = document.createElement( 'span' );
+	stage.className = 'wp-desktop-dock-peek__bin-stage';
+
+	// "Stack" — three layered slips representing trashed items.
+	// Hidden when empty; revealed (with a slight stagger) when full.
+	const stack = document.createElement( 'span' );
+	stack.className = 'wp-desktop-dock-peek__bin-stack';
+	for ( let i = 0; i < 3; i++ ) {
+		const slip = document.createElement( 'span' );
+		slip.className = 'wp-desktop-dock-peek__bin-slip';
+		stack.appendChild( slip );
+	}
+	stage.appendChild( stack );
+
+	const icon = document.createElement( 'span' );
+	icon.className = `wp-desktop-dock-peek__bin-icon dashicons ${
+		count === 0 ? 'dashicons-trash' : 'dashicons-trash'
+	}`;
+	stage.appendChild( icon );
+
+	root.appendChild( stage );
+
+	const label = document.createElement( 'span' );
+	label.className = 'wp-desktop-dock-peek__bin-label';
+	if ( count === 0 ) {
+		label.textContent = __( 'Recycle Bin — empty' );
+	} else if ( count === 1 ) {
+		label.textContent = __( '1 item' );
+	} else if ( count > 99 ) {
+		label.textContent = '99+ items';
+	} else {
+		// translators: %d is the number of items in the recycle bin.
+		label.textContent = `${ count } items`;
+	}
+	root.appendChild( label );
+
+	return root;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Hook bus accessor — duplicated from `src/hooks.ts` so this module
+   doesn't pull the full hooks framework into the load path. The bus
+   is mounted on `window.wp.hooks` by the time we're called from
+   `desktop.ts`.
+   ────────────────────────────────────────────────────────────────── */
+
+interface FakeWpHooks {
+	addFilter: (
+		hookName: string,
+		ns: string,
+		cb: ( ...a: unknown[] ) => unknown,
+	) => void;
+}
+
+function getWpHooks(): FakeWpHooks | null {
+	const wp = ( window as unknown as { wp?: { hooks?: FakeWpHooks } } ).wp;
+	return wp?.hooks ?? null;
+}

--- a/src/dock-peek/index.ts
+++ b/src/dock-peek/index.ts
@@ -1,0 +1,606 @@
+/**
+ * Desktop Mode — Dock Peek.
+ *
+ * On pointerenter of a multi-capable dock tile that has at least one
+ * open window, fan out a stack of "peek cards" anchored to the tile:
+ *   - One card per open instance (click → focus that window).
+ *   - A trailing "Ghost Card" with a dashed outline + breathing pulse
+ *     (click → spawn a fresh instance via `windowManager.openNew()`).
+ *
+ * The peek replaces the legacy "+" chip on multi-instance dock items.
+ * Visible affordance, no keyboard required — the Ghost Card visually
+ * announces itself as a slot for "something that doesn't exist yet."
+ *
+ * Pointer-only: touch devices skip the peek and fall back to plain
+ * tap-to-focus / tap-to-open. Hover popovers don't translate to touch
+ * cleanly, and Phase 5–6 is where the mobile shell takes over.
+ *
+ * @since 0.6.2
+ */
+
+import { __, sprintf } from '../i18n';
+import type { WindowManager } from '../window-manager';
+import type { Window as WPWindow } from '../window';
+import type { DockOrientation } from '../dock';
+import { sanitizeClassName } from '../utils';
+import { hashTitleToHue } from '../ui/util/hash-hue';
+import { applyFilters, HOOKS } from '../hooks';
+
+/**
+ * Detail passed to the {@link HOOKS.DOCK_PEEK_CARD_CONTENT} filter.
+ * Plugins receive this alongside the default body element so they
+ * can render a custom thumbnail / status / arbitrary HTML in place
+ * of (or in addition to) the default ghosted-lines mini-window body.
+ */
+export interface DockPeekCardContext {
+	/** The live window this card represents. */
+	window: WPWindow;
+	/** The dock item descriptor — id / title / icon / url. */
+	item: { id: string; title: string; icon: string; url: string };
+}
+
+/** Args needed to attach a peek to one dock tile. */
+export interface DockPeekDeps {
+	tile: HTMLElement;
+	item: {
+		id: string;
+		title: string;
+		icon: string;
+		url: string;
+	};
+	/**
+	 * Returns the live windows the peek should render cards for.
+	 * Decoupled from any specific lookup rule so the peek works for
+	 * both menu-derived multi tiles (where the dock looks up by URL-
+	 * derived `baseId`) and system tiles like native windows (where
+	 * the lookup is just `getById(item.id)`).
+	 */
+	getInstances: () => WPWindow[];
+	/**
+	 * Whether to render the trailing Ghost Card (the "open new"
+	 * affordance). Defaults to `true`. Pass `false` for tiles whose
+	 * window is a singleton — native windows for OS Settings,
+	 * Jorvy, etc. — where spawning a second copy is meaningless.
+	 */
+	enableGhost?: boolean;
+	windowManager: WindowManager;
+	getOrientation: () => DockOrientation;
+	/**
+	 * Spawn a fresh instance for this tile. Owned by the dock so the
+	 * peek doesn't have to re-derive `baseId` or reach back into the
+	 * Dock's URL helpers. Ignored when `enableGhost` is `false`.
+	 */
+	openNew: () => void;
+	/**
+	 * The tile's resolved tooltip element (shared across the dock).
+	 * Suppressed while the peek is visible so we don't stack two
+	 * hover surfaces.
+	 */
+	suppressTooltip: ( on: boolean ) => void;
+}
+
+/** How long pointerenter must dwell before the peek shows. */
+const SHOW_DELAY_MS = 180;
+/** How long pointerleave must dwell before the peek hides. */
+const HIDE_DELAY_MS = 220;
+/** Stagger between cards in the fan-out (ms). */
+const STAGGER_MS = 32;
+
+/**
+ * Attach hover-peek behavior to a dock tile. Returns a teardown
+ * function that detaches every listener and removes the popover.
+ */
+export function attachDockPeek( deps: DockPeekDeps ): () => void {
+	const { tile } = deps;
+
+	let popover: HTMLElement | null = null;
+	let showTimer: number | null = null;
+	let hideTimer: number | null = null;
+	let inside = false;
+
+	const cancelShow = (): void => {
+		if ( showTimer !== null ) {
+			window.clearTimeout( showTimer );
+			showTimer = null;
+		}
+	};
+	const cancelHide = (): void => {
+		if ( hideTimer !== null ) {
+			window.clearTimeout( hideTimer );
+			hideTimer = null;
+		}
+	};
+
+	const tearDown = (): void => {
+		cancelShow();
+		cancelHide();
+		if ( popover ) {
+			popover.remove();
+			popover = null;
+		}
+		deps.suppressTooltip( false );
+	};
+
+	const onPointerEnterTile = ( e: PointerEvent ): void => {
+		// Touch / pen → no peek. Mobile shell owns these gestures.
+		if ( e.pointerType !== 'mouse' ) {
+			return;
+		}
+		// Re-evaluate on every enter — open windows might have changed
+		// since the tile was constructed.
+		if ( ! shouldShowPeek( deps ) ) {
+			return;
+		}
+		inside = true;
+		cancelHide();
+		if ( popover ) {
+			return;
+		}
+		showTimer = window.setTimeout( () => {
+			showTimer = null;
+			if ( ! inside ) {
+				return;
+			}
+			showPeek();
+		}, SHOW_DELAY_MS );
+	};
+
+	const onPointerLeaveTile = ( e: PointerEvent ): void => {
+		// Treat moves into the popover as still-inside.
+		if ( popover && e.relatedTarget instanceof Node && popover.contains( e.relatedTarget ) ) {
+			return;
+		}
+		inside = false;
+		cancelShow();
+		scheduleHide();
+	};
+
+	const scheduleHide = (): void => {
+		cancelHide();
+		hideTimer = window.setTimeout( () => {
+			hideTimer = null;
+			if ( inside ) {
+				return;
+			}
+			tearDown();
+		}, HIDE_DELAY_MS );
+	};
+
+	const showPeek = (): void => {
+		deps.suppressTooltip( true );
+		popover = buildPopover( deps, () => tearDown() );
+		document.body.appendChild( popover );
+		// Inherit the user's WP color-scheme variables. The popover is
+		// body-attached (outside `.wp-desktop-shell`), so the scheme
+		// overrides scoped to the shell — e.g. midnight's
+		// `--wp-desktop-titlebar-bg-focused: #1e1e1e` — never cascade
+		// here. Copy the resolved values onto the popover root so the
+		// card titlebars match the live windows.
+		inheritShellSchemeVars( popover );
+		positionPopover( popover, tile, deps.getOrientation() );
+
+		// Trigger the fan-out animation on the next frame so the
+		// initial frame's `transform` from CSS is the start of the
+		// transition (not the end of it).
+		requestAnimationFrame( () => {
+			popover?.classList.add( 'wp-desktop-dock-peek--open' );
+		} );
+
+		popover.addEventListener( 'pointerenter', () => {
+			inside = true;
+			cancelHide();
+		} );
+		popover.addEventListener( 'pointerleave', ( e: PointerEvent ) => {
+			if ( e.relatedTarget instanceof Node && tile.contains( e.relatedTarget ) ) {
+				return;
+			}
+			inside = false;
+			scheduleHide();
+		} );
+	};
+
+	tile.addEventListener( 'pointerenter', onPointerEnterTile );
+	tile.addEventListener( 'pointerleave', onPointerLeaveTile );
+
+	return (): void => {
+		tile.removeEventListener( 'pointerenter', onPointerEnterTile );
+		tile.removeEventListener( 'pointerleave', onPointerLeaveTile );
+		tearDown();
+	};
+}
+
+/**
+ * Whether the peek has anything interesting to offer right now.
+ * The peek shows for any tile that has ≥1 open window — gating by
+ * "is multi" is the dock's call (multi tiles call `attachDockPeek`,
+ * singletons don't), so the peek only needs to verify there's
+ * something to peek at.
+ */
+function shouldShowPeek( deps: DockPeekDeps ): boolean {
+	return deps.getInstances().length >= 1;
+}
+
+/** Build the popover surface + cards. */
+function buildPopover( deps: DockPeekDeps, dismiss: () => void ): HTMLElement {
+	const root = document.createElement( 'div' );
+	root.className = 'wp-desktop-dock-peek';
+	root.setAttribute( 'role', 'menu' );
+	root.setAttribute( 'aria-label', sprintf(
+		// translators: %s is the dock item's admin-page title (e.g., "Posts")
+		__( '%s — open windows' ),
+		deps.item.title,
+	) );
+
+	const cards = document.createElement( 'div' );
+	cards.className = 'wp-desktop-dock-peek__cards';
+	root.appendChild( cards );
+
+	const instances = deps.getInstances();
+	let cardIndex = 0;
+	for ( const win of instances ) {
+		const card = buildInstanceCard( win, deps, cardIndex++, dismiss );
+		cards.appendChild( card );
+	}
+
+	if ( deps.enableGhost !== false ) {
+		const ghost = buildGhostCard( deps, cardIndex, dismiss );
+		cards.appendChild( ghost );
+	}
+
+	return root;
+}
+
+/**
+ * A card representing one open window of this dock item — styled
+ * like a miniature window: faux titlebar with traffic-light dots +
+ * the page icon + the window's live title, and a body tinted by the
+ * page's hash-derived hue with ghosted content lines.
+ *
+ * Not a real screenshot — that would require an html2canvas-grade
+ * capture path with the perf cost to match. The mini-window styling
+ * gives each card a distinct visual identity (color + title + icon),
+ * which is what users actually use to recognize an open window at a
+ * glance.
+ */
+function buildInstanceCard(
+	win: WPWindow,
+	deps: DockPeekDeps,
+	index: number,
+	dismiss: () => void,
+): HTMLElement {
+	const card = document.createElement( 'button' );
+	card.type = 'button';
+	card.setAttribute( 'role', 'menuitem' );
+	card.className =
+		'wp-desktop-dock-peek__card wp-desktop-dock-peek__card--instance';
+	card.style.setProperty( '--peek-card-index', String( index ) );
+	card.style.setProperty(
+		'--peek-card-delay',
+		`${ index * STAGGER_MS }ms`,
+	);
+	const title = win.config.title || deps.item.title;
+	card.style.setProperty(
+		'--peek-card-hue',
+		`${ hashTitleToHue( win.id || title ) }`,
+	);
+
+	// View-transition-name: lets the focus click morph the card into
+	// the actual window. The name must be unique per card or the API
+	// rejects ambiguous pairings. Cleared in `spawnFocusViewTransition`
+	// after the click so a subsequent peek doesn't dangle a stale name.
+	card.style.setProperty(
+		'--peek-card-vt-name',
+		`wp-desktop-peek-card-${ win.id }`,
+	);
+
+	const titlebar = document.createElement( 'span' );
+	titlebar.className = 'wp-desktop-dock-peek__card-titlebar';
+
+	const dots = document.createElement( 'span' );
+	dots.className = 'wp-desktop-dock-peek__card-dots';
+	dots.setAttribute( 'aria-hidden', 'true' );
+	for ( let i = 0; i < 3; i++ ) {
+		dots.appendChild( document.createElement( 'i' ) );
+	}
+	titlebar.appendChild( dots );
+
+	const iconHost = document.createElement( 'span' );
+	iconHost.className = 'wp-desktop-dock-peek__card-icon';
+	iconHost.setAttribute( 'aria-hidden', 'true' );
+	const iconCls = win.config.icon || deps.item.icon;
+	if ( iconCls.startsWith( 'dashicons-' ) ) {
+		iconHost.classList.add( 'dashicons', sanitizeClassName( iconCls ) );
+	} else {
+		iconHost.classList.add( 'dashicons', 'dashicons-admin-generic' );
+	}
+	titlebar.appendChild( iconHost );
+
+	const label = document.createElement( 'span' );
+	label.className = 'wp-desktop-dock-peek__card-label';
+	label.textContent = title;
+	titlebar.appendChild( label );
+
+	card.appendChild( titlebar );
+
+	// Body — tinted "page" surface with three ghost content lines.
+	// Pure decoration by default; readers can't infer page state.
+	// Plugins can swap the body wholesale (or mutate it) by hooking
+	// `wp-desktop.dock.peek-card-content` — that's how a window can
+	// render a real thumbnail, a status panel, a chart, etc.
+	const defaultBody = document.createElement( 'span' );
+	defaultBody.className = 'wp-desktop-dock-peek__card-body';
+	defaultBody.setAttribute( 'aria-hidden', 'true' );
+	for ( let i = 0; i < 3; i++ ) {
+		const line = document.createElement( 'span' );
+		line.className = 'wp-desktop-dock-peek__card-line';
+		defaultBody.appendChild( line );
+	}
+	const ctx: DockPeekCardContext = { window: win, item: deps.item };
+	const body = applyFilters< HTMLElement, [ DockPeekCardContext ] >(
+		HOOKS.DOCK_PEEK_CARD_CONTENT,
+		defaultBody,
+		ctx,
+	);
+	// Mark plugin-customized bodies so CSS can opt out of the default
+	// padding / gradient when a plugin wants pixel control.
+	if ( body !== defaultBody ) {
+		body.classList.add( 'wp-desktop-dock-peek__card-body--custom' );
+	}
+	card.appendChild( body );
+
+	card.addEventListener( 'click', () => {
+		spawnFocusViewTransition( deps, win, card, dismiss );
+	} );
+
+	// Hover-to-raise: bringing the live window forward on pointerenter
+	// gives the peek a "scrub through my windows" feel — Mission
+	// Control on macOS, Windows 7 Aero Peek. Skip if the target is
+	// already focused so a re-enter into the same card doesn't churn
+	// the focus stack and re-fire window-focused listeners.
+	card.addEventListener( 'pointerenter', () => {
+		if ( deps.windowManager.getFocused() === win ) {
+			return;
+		}
+		deps.windowManager.focus( win );
+	} );
+
+	// Apply the whole-card filter LAST so plugins can wrap or replace
+	// the fully-built node (chrome + body + listeners). Plugins that
+	// return a brand-new element are responsible for re-wiring the
+	// click handler and preserving the `__card` class — see the
+	// HOOKS.DOCK_PEEK_CARD_ELEMENT docblock.
+	const finalCard = applyFilters< HTMLElement, [ DockPeekCardContext ] >(
+		HOOKS.DOCK_PEEK_CARD_ELEMENT,
+		card,
+		ctx,
+	);
+
+	return finalCard;
+}
+
+/**
+ * Focus the target window inside `document.startViewTransition()`
+ * when supported. Tagging both the source card and the destination
+ * window with a matching `view-transition-name` lets the browser
+ * morph one into the other — a card-to-window flight that makes
+ * "click to focus" feel spatial. Falls back to a plain `focus()`
+ * call where the API isn't available.
+ */
+function spawnFocusViewTransition(
+	deps: DockPeekDeps,
+	win: WPWindow,
+	card: HTMLElement,
+	dismiss: () => void,
+): void {
+	const doc = document as Document & {
+		startViewTransition?: ( cb: () => void ) => unknown;
+	};
+	const vtName = `wp-desktop-peek-card-${ win.id }`;
+	const focus = (): void => {
+		dismiss();
+		deps.windowManager.focus( win );
+	};
+	if ( typeof doc.startViewTransition !== 'function' ) {
+		focus();
+		return;
+	}
+	// Tag the destination window element so the API has a pair of
+	// matching names to morph between. The name is removed after the
+	// transition settles, so a subsequent click on the same window
+	// doesn't carry over a stale tag.
+	const targetEl = win.element;
+	card.style.setProperty( 'view-transition-name', vtName );
+	targetEl.style.setProperty( 'view-transition-name', vtName );
+	const transition = doc.startViewTransition( focus );
+	const cleanup = (): void => {
+		card.style.removeProperty( 'view-transition-name' );
+		targetEl.style.removeProperty( 'view-transition-name' );
+	};
+	const t = transition as { finished?: Promise< void > };
+	if ( t.finished && typeof t.finished.then === 'function' ) {
+		t.finished.then( cleanup, cleanup );
+	} else {
+		// Older / stubbed implementations: fall back to a microtask.
+		Promise.resolve().then( cleanup );
+	}
+}
+
+/** The trailing "spawn" card with dashed outline + breathing pulse. */
+function buildGhostCard(
+	deps: DockPeekDeps,
+	index: number,
+	dismiss: () => void,
+): HTMLElement {
+	const card = document.createElement( 'button' );
+	card.type = 'button';
+	card.setAttribute( 'role', 'menuitem' );
+	card.className =
+		'wp-desktop-dock-peek__card wp-desktop-dock-peek__card--ghost';
+	card.style.setProperty( '--peek-card-index', String( index ) );
+	card.style.setProperty(
+		'--peek-card-delay',
+		`${ index * STAGGER_MS }ms`,
+	);
+
+	// Ghost label uses a phrase, not a glyph. The "+" sits beside it
+	// at quarter opacity — decoration, not the affordance itself.
+	const plus = document.createElement( 'span' );
+	plus.className = 'wp-desktop-dock-peek__card-plus';
+	plus.setAttribute( 'aria-hidden', 'true' );
+	plus.textContent = '+';
+	card.appendChild( plus );
+
+	const label = document.createElement( 'span' );
+	label.className = 'wp-desktop-dock-peek__card-label';
+	label.textContent = sprintf(
+		// translators: %s is the admin-page title (e.g., "Posts")
+		__( 'New %s' ),
+		deps.item.title,
+	);
+	card.appendChild( label );
+
+	card.addEventListener( 'click', () => {
+		spawnWithViewTransition( deps, dismiss );
+	} );
+
+	return card;
+}
+
+/**
+ * Spawn a new window through the View Transitions API when supported,
+ * so the Ghost Card appears to morph into the new window. Fallback:
+ * call openNew directly — the existing CSS `--open` keyframe still
+ * gives the new window a soft entrance.
+ */
+function spawnWithViewTransition(
+	deps: DockPeekDeps,
+	dismiss: () => void,
+): void {
+	const doc = document as Document & {
+		startViewTransition?: ( cb: () => void ) => unknown;
+	};
+	const spawn = (): void => {
+		dismiss();
+		deps.openNew();
+	};
+	if ( typeof doc.startViewTransition === 'function' ) {
+		doc.startViewTransition( spawn );
+		return;
+	}
+	spawn();
+}
+
+/** Distance from each viewport edge that the popover must respect. */
+const VIEWPORT_MARGIN_PX = 12;
+
+/**
+ * CSS custom properties whose resolved value must be copied from the
+ * `.wp-desktop-shell` element onto the body-attached peek popover.
+ *
+ * The desktop shell scopes per-color-scheme overrides to itself
+ * (`.wp-desktop-shell[data-wp-desktop-scheme=…] { --x: … }`) — so a
+ * popover appended to `document.body` gets the `:root` defaults
+ * instead of the user's selected scheme. Inheriting these by hand
+ * keeps the card chrome a faithful shrink of the real window
+ * titlebar regardless of which profile color scheme is active.
+ */
+const SHELL_SCHEME_VARS = [
+	'--wp-admin-theme-color',
+	'--wp-desktop-titlebar-bg',
+	'--wp-desktop-titlebar-bg-focused',
+	'--wp-desktop-titlebar-color',
+	'--wp-desktop-titlebar-color-focused',
+] as const;
+
+function inheritShellSchemeVars( popover: HTMLElement ): void {
+	const shell = document.querySelector< HTMLElement >( '.wp-desktop-shell' );
+	if ( ! shell ) {
+		return;
+	}
+	const computed = window.getComputedStyle( shell );
+	for ( const name of SHELL_SCHEME_VARS ) {
+		const value = computed.getPropertyValue( name ).trim();
+		if ( value ) {
+			popover.style.setProperty( name, value );
+		}
+	}
+}
+
+/**
+ * Position the popover next to the tile, flipping per dock
+ * orientation, then clamp to the viewport so a tall stack of cards
+ * never lands off-screen. The CSS sets a max-height + internal
+ * scroll, so once the available vertical space is constrained by
+ * `clampToViewport()` the cards container starts scrolling instead
+ * of growing.
+ */
+function positionPopover(
+	popover: HTMLElement,
+	tile: HTMLElement,
+	orientation: DockOrientation,
+): void {
+	const rect = tile.getBoundingClientRect();
+	popover.dataset.orientation = orientation;
+	if ( orientation === 'bottom' ) {
+		popover.style.left = `${ rect.left + rect.width / 2 }px`;
+		popover.style.top = `${ rect.top - 12 }px`;
+	} else if ( orientation === 'right' ) {
+		popover.style.top = `${ rect.top + rect.height / 2 }px`;
+		popover.style.left = `${ rect.left - 12 }px`;
+	} else {
+		// Left dock (default).
+		popover.style.top = `${ rect.top + rect.height / 2 }px`;
+		popover.style.left = `${ rect.right + 12 }px`;
+	}
+
+	// Wait one frame so the popover has been laid out before we read
+	// its measured height — `clampToViewport` translates it inward
+	// against `window.innerHeight`. Without this the popover briefly
+	// renders off-screen on a stack of 6+ instance cards.
+	requestAnimationFrame( () => clampToViewport( popover, orientation ) );
+}
+
+/**
+ * Translate the popover so it stays inside the viewport. The CSS
+ * `max-height: min(80vh, 480px)` already caps growth; this handles
+ * the residual case where the anchor point sits near the top or
+ * bottom edge and the popover would still overflow.
+ */
+function clampToViewport(
+	popover: HTMLElement,
+	orientation: DockOrientation,
+): void {
+	const rect = popover.getBoundingClientRect();
+	const vh = window.innerHeight;
+	const vw = window.innerWidth;
+	const min = VIEWPORT_MARGIN_PX;
+
+	let dy = 0;
+	let dx = 0;
+
+	if ( rect.top < min ) {
+		dy = min - rect.top;
+	} else if ( rect.bottom > vh - min ) {
+		dy = vh - min - rect.bottom;
+	}
+	if ( rect.left < min ) {
+		dx = min - rect.left;
+	} else if ( rect.right > vw - min ) {
+		dx = vw - min - rect.right;
+	}
+
+	if ( dx === 0 && dy === 0 ) {
+		return;
+	}
+
+	// Append a clamp translation onto the orientation-specific
+	// transform set in CSS. We can't just overwrite `transform`
+	// (that would lose the orientation translate), so we set a
+	// custom property the CSS reads inside `translate(...)`.
+	popover.style.setProperty( '--peek-clamp-x', `${ dx }px` );
+	popover.style.setProperty( '--peek-clamp-y', `${ dy }px` );
+	popover.classList.add( 'wp-desktop-dock-peek--clamped' );
+	// Suppress orientation/clamp variables for `bottom`'s horizontal
+	// case on left/right docks — handled in CSS via the data attribute.
+	void orientation;
+}

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -15,6 +15,7 @@ import type { WindowManager } from './window-manager';
 import { deriveWindowId } from './utils';
 import { __, _n, sprintf } from './i18n';
 import { hashTitleToHue } from './ui/util/hash-hue';
+import { attachDockPeek } from './dock-peek';
 
 /**
  * A JS-registered dock tile appended below the admin-menu items.
@@ -197,6 +198,12 @@ export class Dock {
 	 * before the previous duration has elapsed.
 	 */
 	private attentionTimers: Map<string, number> = new Map();
+
+	/**
+	 * Per-tile teardown callbacks for the hover-peek. Populated on
+	 * tile creation, drained on `destroy()` and on every `replaceItems`.
+	 */
+	private peekTeardowns: Map<string, () => void> = new Map();
 
 	/**
 	 * Window-lifecycle listener captured here so `destroy()` can
@@ -630,6 +637,14 @@ export class Dock {
 	 * reordered everything into one class).
 	 */
 	private render(): void {
+		// Tear down peeks from the previous render — each tile is about
+		// to be discarded, so its hover listeners would dangle on a
+		// detached node. Idempotent.
+		for ( const teardown of this.peekTeardowns.values() ) {
+			teardown();
+		}
+		this.peekTeardowns.clear();
+
 		this.container.innerHTML = '';
 
 		const base = this.buildHookContextBase();
@@ -711,6 +726,40 @@ export class Dock {
 		tile.appendChild( primary );
 		this.bindTooltipFiltered( tile, item.title, ctx );
 
+		// System items represent native windows (OS Settings, Jorvy,
+		// plugin-registered native windows). When the window is open
+		// the peek shows a thumbnail card matching the live window's
+		// chrome — same as a multi tile, minus the Ghost Card since
+		// system windows are singletons by convention. The instance
+		// lookup is the system-item id directly (system items aren't
+		// URL-derived and the window-manager files them under the id
+		// that `appendSystemItem` was called with).
+		const teardown = attachDockPeek( {
+			tile,
+			item: {
+				id: item.id,
+				title: item.title,
+				icon: item.icon,
+				url: '',
+			},
+			getInstances: () => {
+				const win = this.windowManager.getById( item.id );
+				return win ? [ win ] : [];
+			},
+			enableGhost: false,
+			windowManager: this.windowManager,
+			getOrientation: () => this.orientation,
+			openNew: () => undefined,
+			suppressTooltip: ( on: boolean ) => {
+				if ( on ) {
+					this.tooltip.classList.remove(
+						'wp-desktop-dock__tooltip--visible',
+					);
+				}
+			},
+		} );
+		this.peekTeardowns.set( `system:${ item.id }`, teardown );
+
 		return applyFilters< HTMLElement >(
 			HOOKS.DOCK_TILE_ELEMENT,
 			tile,
@@ -781,61 +830,57 @@ export class Dock {
 
 		tile.appendChild( primary );
 
-		if ( item.multi ) {
-			// "Open another" chip floats off the right edge of the tile.
-			// Hidden until ≥1 instance is open — nothing to add
-			// alongside otherwise. Instance switching happens via the
-			// per-window controls, not the dock.
-			const addBtn = document.createElement( 'button' );
-			addBtn.type = 'button';
-			addBtn.className = 'wp-desktop-dock__item-new';
-			addBtn.hidden = true;
-			addBtn.setAttribute(
-				'aria-label',
-				// translators: %s is the admin-page title (e.g., "Posts")
-				sprintf( __( 'Open another %s' ), item.title ),
-			);
-			addBtn.innerHTML =
-				'<svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true" focusable="false">' +
-				'<path d="M6 2v8M2 6h8" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>' +
-				'</svg>';
-			addBtn.addEventListener( 'click', ( e: Event ) => {
-				e.stopPropagation();
-				this.openNewInstance( item );
-			} );
-
-			// Override the tile's shared tooltip while hovering the chip:
-			// the default says the page name, but on the chip we want the
-			// action verb. On pointerleave back into the tile we restore
-			// the default text; leaving the tile entirely hides the
-			// tooltip as usual. Touch devices never fire pointerenter
-			// without an immediate click, so this is effectively
-			// desktop-only by nature.
-			addBtn.addEventListener( 'pointerenter', () => {
-				this.positionTooltip(
-					addBtn,
-					// translators: %s is the admin-page title (e.g., "Posts")
-					sprintf( __( 'Open new %s' ), item.title ),
-				);
-				this.tooltip.classList.add( 'wp-desktop-dock__tooltip--visible' );
-			} );
-			addBtn.addEventListener( 'pointerleave', ( e: PointerEvent ) => {
-				const next = e.relatedTarget as Node | null;
-				if ( next && tile.contains( next ) ) {
-					// Restore the bind-time tooltip text — filtered
-					// once via {@link HOOKS.DOCK_TILE_TOOLTIP}, stored
-					// on the dataset by `bindTooltipFiltered`.
-					const restored = tile.dataset.dockTooltip ?? item.title;
-					this.positionTooltip( tile, restored );
-					return;
-				}
-				this.tooltip.classList.remove( 'wp-desktop-dock__tooltip--visible' );
-			} );
-
-			tile.appendChild( addBtn );
-		}
-
 		this.bindTooltipFiltered( tile, item.title, ctx );
+
+		// Every dock tile gets the hover-peek when its window is open.
+		// Multi-capable tiles fan out one card per open instance + a
+		// Ghost Card that spawns a fresh instance. Singleton tiles
+		// (Plugins, Appearance, Tools, Settings, plus any plugin page
+		// not flagged `multi`) show a single focus card with no Ghost
+		// Card — there's nothing meaningful about "open another
+		// Settings."
+		//
+		// `baseId` MUST be the URL-derived slug — that's the key the
+		// window-manager stores instances under. Passing the raw
+		// `item.id` (admin-menu slug like `edit.php`) would look up
+		// `edit.php` in a manager that filed the window under
+		// `edit-php`, finding nothing.
+		const baseId = this.deriveWindowId( item.url );
+		const teardown = attachDockPeek( {
+			tile,
+			item: {
+				id: item.id,
+				title: item.title,
+				icon: item.icon,
+				url: item.url,
+			},
+			getInstances: () => {
+				if ( item.multi ) {
+					return this.windowManager.getAllByBaseId( baseId );
+				}
+				// Singleton: one window per baseId. `getById` is the
+				// canonical lookup, but a window opened via
+				// `manager.open({ id, baseId })` is keyed by the
+				// id — which equals baseId for singletons. We try
+				// both to be safe.
+				const single =
+					this.windowManager.getById( baseId ) ||
+					this.windowManager.getById( item.id );
+				return single ? [ single ] : [];
+			},
+			enableGhost: !! item.multi,
+			windowManager: this.windowManager,
+			getOrientation: () => this.orientation,
+			openNew: () => this.openNewInstance( item ),
+			suppressTooltip: ( on: boolean ) => {
+				if ( on ) {
+					this.tooltip.classList.remove(
+						'wp-desktop-dock__tooltip--visible',
+					);
+				}
+			},
+		} );
+		this.peekTeardowns.set( item.id, teardown );
 
 		return applyFilters< HTMLElement >(
 			HOOKS.DOCK_TILE_ELEMENT,
@@ -1238,6 +1283,10 @@ export class Dock {
 			window.clearTimeout( handle );
 		}
 		this.attentionTimers.clear();
+		for ( const teardown of this.peekTeardowns.values() ) {
+			teardown();
+		}
+		this.peekTeardowns.clear();
 		this.tooltip.remove();
 		while ( this.container.firstChild ) {
 			this.container.removeChild( this.container.firstChild );
@@ -1289,15 +1338,6 @@ export class Dock {
 
 			tile.classList.toggle( 'wp-desktop-dock__item--active', isOpen );
 			tile.classList.toggle( 'wp-desktop-dock__item--focused', isFocused );
-
-			if ( item.multi ) {
-				const addBtn = tile.querySelector<HTMLElement>(
-					'.wp-desktop-dock__item-new',
-				);
-				if ( addBtn ) {
-					addBtn.hidden = instances.length === 0;
-				}
-			}
 		}
 
 		// System items — active dot driven by the caller's predicate. No

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -734,6 +734,60 @@ export const HOOKS = {
 	 * @since 0.18.0
 	 */
 	DOCK_TILE_TOOLTIP: 'wp-desktop.dock.tile-tooltip',
+	/**
+	 * Filter, resolves the body content of a single hover-peek card.
+	 * Runs once per card build (i.e., on every show of the peek for
+	 * a multi-instance dock tile that has ≥1 open window). Lets a
+	 * plugin render a custom thumbnail, status block, or any other
+	 * markup inside the card in place of (or alongside) the default
+	 * mini-window styling.
+	 *
+	 * Signature:
+	 *   ( body: HTMLElement, detail: DockPeekCardContext ) => HTMLElement
+	 *
+	 * Where `body` is the `<span class="wp-desktop-dock-peek__card-body">`
+	 * element that the peek would otherwise populate with ghosted
+	 * content lines. The filter may:
+	 *   - Mutate `body` in place (e.g., append a custom child) and
+	 *     return it.
+	 *   - Empty `body` and append plugin-owned children.
+	 *   - Return an entirely different element to replace `body`.
+	 *
+	 * `detail.window` is the live `Window` instance the card represents
+	 * — plugins can read `window.config`, call `window.getCurrentUrl()`,
+	 * subscribe to lifecycle events, etc. `detail.item` is the dock
+	 * item descriptor (id / title / icon / url).
+	 *
+	 * The filter is invoked under the `applyFilters` namespace
+	 * `wp-desktop.dock.peek-card-content`.
+	 *
+	 * @since 0.6.2
+	 */
+	DOCK_PEEK_CARD_CONTENT: 'wp-desktop.dock.peek-card-content',
+	/**
+	 * Filter, runs once per peek card right before it's appended to
+	 * the popover. Receives the fully-built default card (with its
+	 * mini-window chrome already populated) and can return either
+	 * the same node, a mutated version, or an entirely different
+	 * element to replace the card outright. Use this when the
+	 * `peek-card-content` body filter isn't enough — e.g., when a
+	 * plugin wants to swap the whole card chrome (custom titlebar,
+	 * different shape) or wrap the card in a third-party component.
+	 *
+	 * Signature:
+	 *   ( card: HTMLElement, detail: DockPeekCardContext ) => HTMLElement
+	 *
+	 * If a plugin returns a brand-new node, it is responsible for
+	 * preserving anything the peek relies on:
+	 *   - The `wp-desktop-dock-peek__card` class (used by the
+	 *     fan-out animation timing + hover styles).
+	 *   - A `click` handler if the card should still focus the
+	 *     window. The default click handler lives on the original
+	 *     node — replacing the node loses it.
+	 *
+	 * @since 0.6.2
+	 */
+	DOCK_PEEK_CARD_ELEMENT: 'wp-desktop.dock.peek-card-element',
 
 	// ------------------------------------------------------------------
 	// Overview / Arrange lifecycle actions.

--- a/src/window-chrome/controls/built-ins.ts
+++ b/src/window-chrome/controls/built-ins.ts
@@ -1,6 +1,13 @@
 /**
  * Built-in window controls — minimize, maximize, fullscreen,
- * detach, reload, close.
+ * close.
+ *
+ * `core/detach` (Open in browser tab) and `core/reload` used to live
+ * here but moved into the title-bar three-dots menu in 0.6.2 — those
+ * actions are infrequent enough that they didn't earn permanent real
+ * estate alongside minimize / maximize / close. The wiring lives in
+ * `src/window/dom.ts` (menu-item construction) and
+ * `src/window/index.ts` (click → `win.detach()` / `win.reload()`).
  *
  * Each built-in registers as a `WindowControlDef` with a stable
  * `core/*` id, the same icon + label the hardcoded title bar used,
@@ -18,8 +25,6 @@
 
 import { __ } from '../../i18n';
 import { registerWindowControl } from './registry';
-
-import type { Window as DesktopWindow } from '../../window';
 
 /**
  * Register the six built-in title-bar controls. Idempotent — calling
@@ -65,34 +70,6 @@ export function registerBuiltInControls(): void {
 		match: () => true,
 		onClick: ( win ) => {
 			win.toggleFullscreen();
-		},
-	} );
-
-	registerWindowControl( {
-		id: 'core/detach',
-		label: __( 'Detach to new tab' ),
-		icon: 'detach',
-		placement: 'controls',
-		order: 40,
-		core: true,
-		// Native windows have no admin URL to hand off to a classic tab.
-		match: ( win: DesktopWindow ) => ! win.config.native,
-		onClick: ( win ) => {
-			win.detach();
-		},
-	} );
-
-	registerWindowControl( {
-		id: 'core/reload',
-		label: __( 'Reload' ),
-		icon: 'reload',
-		placement: 'controls',
-		order: 45,
-		core: true,
-		// Native windows own their DOM directly — no iframe to reload.
-		match: ( win: DesktopWindow ) => ! win.config.native,
-		onClick: ( win ) => {
-			win.reload();
 		},
 	} );
 

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -508,6 +508,23 @@ export class WindowManager {
 				multi: true,
 			} );
 		};
+		// "Open in new window" — like open-another, but seeds the new
+		// window with the source's *current* URL (post in-window
+		// navigation) instead of the original landing URL. Lets a user
+		// keep the page they're looking at while peeling a fresh copy
+		// off the same window.
+		win.onOpenInNewWindow = ( w: Window ) => {
+			const currentUrl = w.getCurrentUrl();
+			this.openNew( {
+				id: w.config.baseId || w.id,
+				baseId: w.config.baseId || w.id,
+				url: currentUrl || w.config.url || '',
+				title: w.config.title,
+				icon: w.config.icon,
+				submenu: w.config.submenu,
+				multi: true,
+			} );
+		};
 		// "Open on startup" toggles the user's default-window
 		// preference to point at this window's current URL — or
 		// disables it entirely when the window is already the default.

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -321,64 +321,106 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 	const titleBar = document.createElement( 'div' );
 	titleBar.className = 'wp-desktop-window__titlebar';
 
-	// Leading menu button — sits before the icon + title. Shown for any
-	// iframe-backed window; native windows (OS Settings, future plugins)
-	// have no admin URL and so skip the menu. Contents vary:
+	// Leading menu button — sits before the icon + title. Rendered for
+	// every window, native or iframe; per-item gating below decides
+	// which actions actually apply. Native windows skip "Open in
+	// browser tab" since they have no admin URL to hand off.
 	//
-	//   - Every iframe window gets "Open on startup" — a checkable item
-	//     that marks this window as the default-window preference.
-	//   - Multi-capable windows additionally get "Open another <page>".
-	//
-	// Future window-management verbs ("Tile left", "Duplicate", etc.)
-	// should migrate here so the title bar stops growing controls.
-	let menuBtn: HTMLElement | null = null;
-	let menuPanel: HTMLElement | null = null;
+	// Items in order:
+	//   - Open on startup        — checkable, marks this window as
+	//                              the default-window preference.
+	//   - Open another <Page>    — only when `config.multi`.
+	//   - Open in new window     — opens the current iframe URL as a
+	//                              fresh sibling.
+	//   - Reload                 — reloads the iframe (no-op for
+	//                              native windows; harmless to show).
+	//   - Open in browser tab    — detach to a classic admin tab.
+	//                              Iframe-only — skipped for native.
+	const menuBtn = document.createElement( 'wpd-window-button' );
+	menuBtn.setAttribute( 'icon', 'menu' );
+	menuBtn.setAttribute( 'aria-label', __( 'Window actions' ) );
+	menuBtn.setAttribute( 'aria-haspopup', 'menu' );
+	menuBtn.setAttribute( 'aria-expanded', 'false' );
+	// Keep the legacy classes so the title-bar layout selector that
+	// reshapes around the menu button (see windows.css
+	// `:has(.wp-desktop-window__menu-btn)`) still matches.
+	menuBtn.classList.add( 'wp-desktop-window__btn' );
+	menuBtn.classList.add( 'wp-desktop-window__menu-btn' );
+
+	const menuPanel = document.createElement( 'wpd-menu' );
+	menuPanel.classList.add( 'wp-desktop-window__menu-panel' );
+	menuPanel.hidden = true;
+
+	// "Open on startup" — checkable. Checked state is hydrated in
+	// `bindEvents()` once `window.wp.desktop.config` is populated;
+	// the item just needs to exist here.
+	const startup = document.createElement( 'wpd-menu-item' );
+	startup.setAttribute( 'role', 'menuitemcheckbox' );
+	startup.setAttribute( 'value', 'startup' );
+	// Legacy classes preserved so settings-refresh code can still
+	// find the item by class during the `default-window-changed`
+	// repaint.
+	startup.classList.add( 'wp-desktop-window__menu-item' );
+	startup.classList.add( 'wp-desktop-window__menu-item--startup' );
+	startup.textContent = __( 'Open on startup' );
+	menuPanel.appendChild( startup );
+
+	if ( config.multi ) {
+		const openAnother = document.createElement( 'wpd-menu-item' );
+		openAnother.setAttribute( 'role', 'menuitem' );
+		openAnother.setAttribute( 'value', 'open-another' );
+		openAnother.setAttribute( 'icon', 'dashicons-plus-alt2' );
+		openAnother.classList.add( 'wp-desktop-window__menu-item' );
+		openAnother.classList.add(
+			'wp-desktop-window__menu-item--open-another',
+		);
+		openAnother.textContent = sprintf(
+			// translators: %s is the window's admin-page name (e.g., "Posts")
+			__( 'Open another %s' ),
+			config.title,
+		);
+		menuPanel.appendChild( openAnother );
+	}
+
 	if ( ! config.native ) {
-		menuBtn = document.createElement( 'wpd-window-button' );
-		menuBtn.setAttribute( 'icon', 'menu' );
-		menuBtn.setAttribute( 'aria-label', __( 'Window actions' ) );
-		menuBtn.setAttribute( 'aria-haspopup', 'menu' );
-		menuBtn.setAttribute( 'aria-expanded', 'false' );
-		// Keep the legacy classes so the title-bar layout selector that
-		// reshapes around the menu button (see windows.css
-		// `:has(.wp-desktop-window__menu-btn)`) still matches.
-		menuBtn.classList.add( 'wp-desktop-window__btn' );
-		menuBtn.classList.add( 'wp-desktop-window__menu-btn' );
+		// "Open in new window" — opens the *current* iframe URL (where
+		// the user has navigated to) as a fresh sibling window.
+		// Iframe-only because there's no addressable URL on native.
+		const openInNew = document.createElement( 'wpd-menu-item' );
+		openInNew.setAttribute( 'role', 'menuitem' );
+		openInNew.setAttribute( 'value', 'open-in-new-window' );
+		openInNew.setAttribute( 'icon', 'dashicons-plus-alt' );
+		openInNew.classList.add( 'wp-desktop-window__menu-item' );
+		openInNew.classList.add( 'wp-desktop-window__menu-item--open-in-new-window' );
+		openInNew.textContent = __( 'Open in new window' );
+		menuPanel.appendChild( openInNew );
+	}
 
-		menuPanel = document.createElement( 'wpd-menu' );
-		menuPanel.classList.add( 'wp-desktop-window__menu-panel' );
-		menuPanel.hidden = true;
+	// "Reload" — was a built-in title-bar control until 0.6.2. Moved
+	// here because it's an infrequent action that didn't earn the
+	// permanent real estate. No-op for native windows; safe to show.
+	if ( ! config.native ) {
+		const reload = document.createElement( 'wpd-menu-item' );
+		reload.setAttribute( 'role', 'menuitem' );
+		reload.setAttribute( 'value', 'reload' );
+		reload.setAttribute( 'icon', 'dashicons-update' );
+		reload.classList.add( 'wp-desktop-window__menu-item' );
+		reload.classList.add( 'wp-desktop-window__menu-item--reload' );
+		reload.textContent = __( 'Reload' );
+		menuPanel.appendChild( reload );
 
-		// "Open on startup" — checkable. Checked state is hydrated in
-		// `bindEvents()` once `window.wp.desktop.config` is populated;
-		// the item just needs to exist here.
-		const startup = document.createElement( 'wpd-menu-item' );
-		startup.setAttribute( 'role', 'menuitemcheckbox' );
-		startup.setAttribute( 'value', 'startup' );
-		// Legacy classes preserved so settings-refresh code can still
-		// find the item by class during the `default-window-changed`
-		// repaint.
-		startup.classList.add( 'wp-desktop-window__menu-item' );
-		startup.classList.add( 'wp-desktop-window__menu-item--startup' );
-		startup.textContent = __( 'Open on startup' );
-		menuPanel.appendChild( startup );
-
-		if ( config.multi ) {
-			const openAnother = document.createElement( 'wpd-menu-item' );
-			openAnother.setAttribute( 'role', 'menuitem' );
-			openAnother.setAttribute( 'value', 'open-another' );
-			openAnother.setAttribute( 'icon', 'dashicons-plus-alt2' );
-			openAnother.classList.add( 'wp-desktop-window__menu-item' );
-			openAnother.classList.add(
-				'wp-desktop-window__menu-item--open-another',
-			);
-			openAnother.textContent = sprintf(
-				// translators: %s is the window's admin-page name (e.g., "Posts")
-				__( 'Open another %s' ),
-				config.title,
-			);
-			menuPanel.appendChild( openAnother );
-		}
+		// "Open in browser tab" — was the title bar's detach button.
+		// Strips chromeless params and opens the page in a classic
+		// admin tab. Iframe-only — native windows have no URL to
+		// hand off to the browser.
+		const openExternal = document.createElement( 'wpd-menu-item' );
+		openExternal.setAttribute( 'role', 'menuitem' );
+		openExternal.setAttribute( 'value', 'open-external' );
+		openExternal.setAttribute( 'icon', 'dashicons-external' );
+		openExternal.classList.add( 'wp-desktop-window__menu-item' );
+		openExternal.classList.add( 'wp-desktop-window__menu-item--open-external' );
+		openExternal.textContent = __( 'Open in browser tab' );
+		menuPanel.appendChild( openExternal );
 	}
 
 	// Slot host helpers — Layer 3 of the chrome framework. Each

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -291,6 +291,14 @@ export class Window {
 	public onOpenAnother: ( ( win: Window ) => void ) | null = null;
 
 	/**
+	 * Invoked when the title-bar menu's "Open in new window" item is
+	 * clicked. Like `onOpenAnother`, but the manager opens the new
+	 * window at the *current* iframe URL (post-navigation), not the
+	 * original page URL.
+	 */
+	public onOpenInNewWindow: ( ( win: Window ) => void ) | null = null;
+
+	/**
 	 * Invoked when the title-bar menu's "Open on startup" item is
 	 * toggled. The shell wires this to the public
 	 * `wp.desktop.setDefaultWindow()` call, which writes the user's
@@ -810,6 +818,41 @@ export class Window {
 					e.stopPropagation();
 					closeActionsMenu( this );
 					this.onOpenAnother?.( this );
+				} );
+			}
+			const openInNew = menuPanel.querySelector(
+				'.wp-desktop-window__menu-item--open-in-new-window',
+			);
+			if ( openInNew ) {
+				openInNew.addEventListener( 'wpd-menu-item-click', ( e: Event ) => {
+					e.stopPropagation();
+					closeActionsMenu( this );
+					this.onOpenInNewWindow?.( this );
+				} );
+			}
+			// "Reload" + "Open in browser tab" moved here from the
+			// title-bar controls cluster in 0.6.2. Both call straight
+			// into the existing `Window` API — no new manager wiring
+			// needed. Click closes the menu first so the iframe
+			// reload doesn't compete with a still-painted popover.
+			const reload = menuPanel.querySelector(
+				'.wp-desktop-window__menu-item--reload',
+			);
+			if ( reload ) {
+				reload.addEventListener( 'wpd-menu-item-click', ( e: Event ) => {
+					e.stopPropagation();
+					closeActionsMenu( this );
+					this.reload();
+				} );
+			}
+			const openExternal = menuPanel.querySelector(
+				'.wp-desktop-window__menu-item--open-external',
+			);
+			if ( openExternal ) {
+				openExternal.addEventListener( 'wpd-menu-item-click', ( e: Event ) => {
+					e.stopPropagation();
+					closeActionsMenu( this );
+					this.detach();
 				} );
 			}
 			// "Open on startup" — checkable menu item. Hydrate its

--- a/src/window/menus.ts
+++ b/src/window/menus.ts
@@ -145,12 +145,20 @@ export function refreshStartupCheckState(
 	const pref = window.wp?.desktop?.config?.defaultWindow;
 	let isDefault = false;
 	if ( pref && pref.enabled && typeof pref.url === 'string' ) {
-		try {
-			const currentKey = urlMatchKey( win.getCurrentUrl() );
-			const prefKey = urlMatchKey( pref.url );
-			isDefault = currentKey === prefKey;
-		} catch {
-			isDefault = false;
+		// Native windows store their preference as `native:<id>` rather
+		// than a URL — `urlMatchKey` would normalize an unrelated
+		// string and false-match. Compare exactly for native windows;
+		// fall back to URL-key matching for iframe windows.
+		if ( win.config.native ) {
+			isDefault = pref.url === `native:${ win.id }`;
+		} else {
+			try {
+				const currentKey = urlMatchKey( win.getCurrentUrl() );
+				const prefKey = urlMatchKey( pref.url );
+				isDefault = currentKey === prefKey;
+			} catch {
+				isDefault = false;
+			}
 		}
 	}
 	if ( isDefault ) {

--- a/tests/phpunit/tests/wpDesktopDefaultWindow.php
+++ b/tests/phpunit/tests/wpDesktopDefaultWindow.php
@@ -169,6 +169,49 @@ class Tests_DesktopMode_WpDefaultWindow extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Native marker — `native:<slug>` — is accepted by the validator
+	 * and round-trips through the user-meta storage. Used for
+	 * native windows (OS Settings, Recycle Bin, plugin-registered
+	 * native apps) which have no admin URL to forward to.
+	 *
+	 * @covers ::desktop_mode_validate_default_window_url
+	 */
+	public function test_validate_accepts_native_marker() {
+		$clean = desktop_mode_validate_default_window_url( 'native:wp-desktop-os-settings' );
+		$this->assertSame( 'native:wp-desktop-os-settings', $clean );
+	}
+
+	/**
+	 * @covers ::desktop_mode_validate_default_window_url
+	 */
+	public function test_validate_rejects_native_marker_with_unsafe_slug() {
+		// Slashes / spaces / empty / characters outside [a-z0-9_-]
+		// must be rejected so the marker can't smuggle a path
+		// traversal or a redirect through the validator.
+		$this->assertSame( '', desktop_mode_validate_default_window_url( 'native:' ) );
+		$this->assertSame( '', desktop_mode_validate_default_window_url( 'native:foo/bar' ) );
+		$this->assertSame( '', desktop_mode_validate_default_window_url( 'native:foo bar' ) );
+		$this->assertSame( '', desktop_mode_validate_default_window_url( 'native:../etc/passwd' ) );
+	}
+
+	/**
+	 * Portal redirects to admin home when the saved preference is a
+	 * native marker — the marker isn't a routable URL, but the
+	 * redirect must succeed at HTTP level so the shell can pick up
+	 * `defaultWindow.url` from the config and call
+	 * `nativeWindows.openById( <slug> )` after init.
+	 *
+	 * @covers ::desktop_mode_portal_entry_url
+	 */
+	public function test_portal_entry_url_falls_back_for_native_marker() {
+		desktop_mode_set_default_window( self::$admin_id, 'native:wp-desktop-os-settings' );
+
+		$url = desktop_mode_portal_entry_url( self::$admin_id );
+
+		$this->assertSame( admin_url(), $url );
+	}
+
+	/**
 	 * REST endpoint: happy path — string URL sets the preference.
 	 *
 	 * @covers ::desktop_mode_rest_set_default_window

--- a/tests/vitest/dock-peek.test.ts
+++ b/tests/vitest/dock-peek.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for the dock hover-peek — the fan-out popover that replaces
+ * the legacy "+" chip on multi-instance dock tiles AND surfaces
+ * thumbnails for native-window system tiles.
+ *
+ * Covers the surface that's worth pinning: trigger condition (≥1
+ * open instance), card composition (one per instance + an optional
+ * Ghost Card), and the click handlers (focus existing vs spawn new).
+ * Animation timing is intentionally elided — the show-delay is
+ * driven by `setTimeout`, which `vi.useFakeTimers` flushes.
+ *
+ * @group dock
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { attachDockPeek } from '../../src/dock-peek';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+function makeTile( multi: boolean ): HTMLElement {
+	const tile = document.createElement( 'div' );
+	tile.className = 'wp-desktop-dock__item';
+	if ( multi ) {
+		tile.classList.add( 'wp-desktop-dock__item--multi' );
+	}
+	tile.dataset.menuSlug = 'edit.php';
+	tile.dataset.dockTooltip = 'Posts';
+	Object.defineProperty( tile, 'getBoundingClientRect', {
+		value: () =>
+			( {
+				left: 10,
+				top: 100,
+				right: 50,
+				bottom: 140,
+				width: 40,
+				height: 40,
+				x: 10,
+				y: 100,
+				toJSON: () => ( {} ),
+			} ) as DOMRect,
+	} );
+	document.body.appendChild( tile );
+	return tile;
+}
+
+function makeWindowStub( title: string, baseId: string ) {
+	return {
+		id: baseId,
+		config: {
+			title,
+			icon: 'dashicons-admin-post',
+			baseId,
+		},
+	};
+}
+
+function pointerEnter( el: HTMLElement, opts: { type?: string } = {} ): void {
+	const evt = new Event( 'pointerenter' );
+	Object.defineProperty( evt, 'pointerType', {
+		value: opts.type ?? 'mouse',
+	} );
+	el.dispatchEvent( evt );
+}
+
+function pointerLeave( el: HTMLElement ): void {
+	const evt = new Event( 'pointerleave' );
+	Object.defineProperty( evt, 'relatedTarget', { value: null } );
+	el.dispatchEvent( evt );
+}
+
+type Deps = Parameters< typeof attachDockPeek >[ 0 ];
+
+/**
+ * Build a fully-stubbed deps object — tests override only the keys
+ * they care about. Keeps the test file focused on behavior, not
+ * scaffolding.
+ */
+function makeDeps( overrides: Partial< Deps > = {} ): Deps {
+	const tile = overrides.tile ?? makeTile( true );
+	return {
+		tile,
+		item: { id: 'edit.php', title: 'Posts', icon: 'dashicons-admin-post', url: '/' },
+		getInstances: () => [],
+		enableGhost: true,
+		windowManager: {
+			focus: vi.fn(),
+			getFocused: () => undefined,
+		} as unknown as Deps[ 'windowManager' ],
+		getOrientation: () => 'left',
+		openNew: vi.fn(),
+		suppressTooltip: () => undefined,
+		...overrides,
+	};
+}
+
+describe( 'dock-peek', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+		document.body.innerHTML = '';
+		clearHooksStub();
+	} );
+
+	test( 'does not show on tiles with zero open instances', () => {
+		const tile = makeTile( true );
+		attachDockPeek( makeDeps( { tile, getInstances: () => [] } ) );
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).toBeNull();
+	} );
+
+	test( 'native-window (system) tile peek shows a thumbnail card without a Ghost Card', () => {
+		// Native windows are singletons by convention — OS Settings,
+		// Jorvy, plugin-registered native windows. The peek shows
+		// their live thumbnail when open but suppresses the Ghost
+		// Card since "open another OS Settings" is meaningless.
+		const tile = makeTile( false );
+		const win = makeWindowStub( 'OS Settings', 'os-settings' );
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				item: {
+					id: 'os-settings',
+					title: 'OS Settings',
+					icon: 'dashicons-admin-settings',
+					url: '',
+				},
+				getInstances: () => [ win ],
+				enableGhost: false,
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+		const peek = document.querySelector( '.wp-desktop-dock-peek' );
+		expect( peek ).not.toBeNull();
+		expect(
+			peek!.querySelectorAll( '.wp-desktop-dock-peek__card--instance' )
+				.length,
+		).toBe( 1 );
+		expect(
+			peek!.querySelectorAll( '.wp-desktop-dock-peek__card--ghost' )
+				.length,
+		).toBe( 0 );
+	} );
+
+	test( 'does not show on touch / pen pointers', () => {
+		const tile = makeTile( true );
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'Posts #1', 'edit-php' ) ],
+			} ),
+		);
+		pointerEnter( tile, { type: 'touch' } );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).toBeNull();
+	} );
+
+	test( 'fans out one card per instance + a trailing Ghost Card', () => {
+		const tile = makeTile( true );
+		const instances = [
+			makeWindowStub( 'All Posts', 'edit-php' ),
+			makeWindowStub( 'Editing post 42', 'edit-php' ),
+		];
+		attachDockPeek(
+			makeDeps( { tile, getInstances: () => instances } ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		const peek = document.querySelector( '.wp-desktop-dock-peek' )!;
+		expect( peek ).not.toBeNull();
+		expect(
+			peek.querySelectorAll( '.wp-desktop-dock-peek__card--instance' )
+				.length,
+		).toBe( 2 );
+		const ghosts = peek.querySelectorAll(
+			'.wp-desktop-dock-peek__card--ghost',
+		);
+		expect( ghosts.length ).toBe( 1 );
+		const allCards = peek.querySelectorAll( '.wp-desktop-dock-peek__card' );
+		expect( allCards[ allCards.length - 1 ] ).toBe( ghosts[ 0 ] );
+	} );
+
+	test( 'plugins can replace the card body via the content filter', () => {
+		const wpHooks = (
+			window as unknown as {
+				wp: {
+					hooks: {
+						addFilter: (
+							hookName: string,
+							ns: string,
+							cb: ( ...a: unknown[] ) => unknown,
+						) => void;
+						removeFilter: ( hookName: string, ns: string ) => number;
+					};
+				};
+			}
+		).wp.hooks;
+
+		wpHooks.addFilter(
+			'wp-desktop.dock.peek-card-content',
+			'test/dock-peek-filter',
+			( body, ctx ) => {
+				const replacement = document.createElement( 'div' );
+				replacement.className = 'plugin-owned-thumb';
+				replacement.dataset.windowId = (
+					ctx as { window: { id: string } }
+				).window.id;
+				return replacement;
+			},
+		);
+
+		const tile = makeTile( true );
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'All Posts', 'edit-php' ) ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		const card = document.querySelector< HTMLElement >(
+			'.wp-desktop-dock-peek__card--instance',
+		)!;
+		expect( card.querySelector( '.plugin-owned-thumb' ) ).not.toBeNull();
+		expect( card.querySelector( '.plugin-owned-thumb' )?.getAttribute( 'data-window-id' ) ).toBe( 'edit-php' );
+		expect( card.querySelectorAll( '.wp-desktop-dock-peek__card-line' ).length ).toBe( 0 );
+		const customBody = card.querySelector(
+			'.wp-desktop-dock-peek__card-body--custom',
+		);
+		expect( customBody ).not.toBeNull();
+
+		wpHooks.removeFilter(
+			'wp-desktop.dock.peek-card-content',
+			'test/dock-peek-filter',
+		);
+	} );
+
+	test( 'instance cards render the mini-window chrome', () => {
+		const tile = makeTile( true );
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'All Posts', 'edit-php' ) ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		const card = document.querySelector< HTMLElement >(
+			'.wp-desktop-dock-peek__card--instance',
+		)!;
+		expect(
+			card.querySelectorAll( '.wp-desktop-dock-peek__card-dots i' ).length,
+		).toBe( 3 );
+		expect(
+			card.querySelector( '.wp-desktop-dock-peek__card-label' )
+				?.textContent,
+		).toBe( 'All Posts' );
+		expect(
+			card.querySelectorAll( '.wp-desktop-dock-peek__card-line' ).length,
+		).toBe( 3 );
+		expect( card.style.getPropertyValue( '--peek-card-hue' ) ).toMatch(
+			/^\d+$/,
+		);
+	} );
+
+	test( 'hovering an instance card raises that window to front', () => {
+		const tile = makeTile( true );
+		const winA = makeWindowStub( 'All Posts', 'edit-php' );
+		const winB = makeWindowStub( 'Editing post 42', 'edit-php' );
+		const focus = vi.fn();
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ winA, winB ],
+				windowManager: {
+					getFocused: () => winA,
+					focus,
+				} as unknown as Deps[ 'windowManager' ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		const cards = document.querySelectorAll< HTMLElement >(
+			'.wp-desktop-dock-peek__card--instance',
+		);
+		pointerEnter( cards[ 1 ] );
+		expect( focus ).toHaveBeenCalledTimes( 1 );
+		expect( focus ).toHaveBeenCalledWith( winB );
+	} );
+
+	test( 'whole-card filter can replace the entire card', () => {
+		const wpHooks = (
+			window as unknown as {
+				wp: {
+					hooks: {
+						addFilter: (
+							hookName: string,
+							ns: string,
+							cb: ( ...a: unknown[] ) => unknown,
+						) => void;
+						removeFilter: ( hookName: string, ns: string ) => number;
+					};
+				};
+			}
+		).wp.hooks;
+
+		wpHooks.addFilter(
+			'wp-desktop.dock.peek-card-element',
+			'test/whole-card',
+			() => {
+				const replacement = document.createElement( 'div' );
+				replacement.className =
+					'wp-desktop-dock-peek__card plugin-replaced-card';
+				return replacement;
+			},
+		);
+
+		const tile = makeTile( true );
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'All Posts', 'edit-php' ) ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		expect(
+			document.querySelector( '.plugin-replaced-card' ),
+		).not.toBeNull();
+		expect(
+			document.querySelector( '.wp-desktop-dock-peek__card-titlebar' ),
+		).toBeNull();
+
+		wpHooks.removeFilter(
+			'wp-desktop.dock.peek-card-element',
+			'test/whole-card',
+		);
+	} );
+
+	test( 'clicking an instance card focuses that window', () => {
+		const tile = makeTile( true );
+		const instances = [ makeWindowStub( 'All Posts', 'edit-php' ) ];
+		const focus = vi.fn();
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => instances,
+				windowManager: {
+					getFocused: () => undefined,
+					focus,
+				} as unknown as Deps[ 'windowManager' ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		const instanceCard = document.querySelector< HTMLElement >(
+			'.wp-desktop-dock-peek__card--instance',
+		)!;
+		instanceCard.click();
+		expect( focus ).toHaveBeenCalledTimes( 1 );
+		expect( focus ).toHaveBeenCalledWith( instances[ 0 ] );
+	} );
+
+	test( 'clicking the Ghost Card calls openNew', () => {
+		const tile = makeTile( true );
+		const openNew = vi.fn();
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'All Posts', 'edit-php' ) ],
+				openNew,
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+
+		const ghost = document.querySelector< HTMLElement >(
+			'.wp-desktop-dock-peek__card--ghost',
+		)!;
+		ghost.click();
+		expect( openNew ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'leaving the tile (with no relatedTarget into popover) tears down', () => {
+		const tile = makeTile( true );
+		attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'All Posts', 'edit-php' ) ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).not.toBeNull();
+
+		pointerLeave( tile );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).toBeNull();
+	} );
+
+	test( 'teardown function detaches listeners + removes popover', () => {
+		const tile = makeTile( true );
+		const detach = attachDockPeek(
+			makeDeps( {
+				tile,
+				getInstances: () => [ makeWindowStub( 'All Posts', 'edit-php' ) ],
+			} ),
+		);
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).not.toBeNull();
+
+		detach();
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).toBeNull();
+
+		pointerEnter( tile );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelector( '.wp-desktop-dock-peek' ) ).toBeNull();
+	} );
+} );

--- a/tests/vitest/window-chrome-controls-render.test.ts
+++ b/tests/vitest/window-chrome-controls-render.test.ts
@@ -75,6 +75,9 @@ afterEach( () => {
 
 describe( 'resolveWindowControls', () => {
 	test( 'returns built-ins in registered order for an iframe window', () => {
+		// `core/detach` + `core/reload` lived here until 0.6.2 — they
+		// moved into the title-bar three-dots menu (see
+		// `src/window/dom.ts`). The cluster now ships four entries.
 		registerBuiltInControls();
 		const win = fakeWin( 'edit-post' );
 		const resolved = resolveWindowControls(
@@ -84,27 +87,31 @@ describe( 'resolveWindowControls', () => {
 			'core/minimize',
 			'core/maximize',
 			'core/focus-tab',
-			'core/detach',
-			'core/reload',
 			'core/close',
 		] );
 	} );
 
-	test( 'native windows skip core/detach (match predicate)', () => {
+	test( 'native windows still get the basic control cluster', () => {
+		// Pre-0.6.2 this test asserted that `core/detach` /
+		// `core/reload` were skipped for native windows. Both are
+		// gone from the cluster entirely now (relocated to the
+		// menu), so the assertion collapses to "native windows
+		// render the same minimize/maximize/focus/close set as
+		// iframe windows."
 		registerBuiltInControls();
 		const win = fakeWin( 'os-settings', { native: true } );
 		const resolved = resolveWindowControls(
 			win as unknown as Parameters< typeof resolveWindowControls >[ 0 ],
 		);
+		expect( resolved.controls.map( ( c ) => c.id ) ).toContain(
+			'core/close',
+		);
 		expect( resolved.controls.map( ( c ) => c.id ) ).not.toContain(
 			'core/detach',
 		);
-		// Native windows also skip core/reload — they own their DOM
-		// directly, so there's no iframe to reload.
 		expect( resolved.controls.map( ( c ) => c.id ) ).not.toContain(
 			'core/reload',
 		);
-		expect( resolved.controls.map( ( c ) => c.id ) ).toContain( 'core/close' );
 	} );
 
 	test( 'appearance.controls.hide drops specific built-ins', () => {
@@ -112,12 +119,11 @@ describe( 'resolveWindowControls', () => {
 		const win = fakeWin( 'edit-post' );
 		const resolved = resolveWindowControls(
 			win as unknown as Parameters< typeof resolveWindowControls >[ 0 ],
-			{ hide: [ 'core/detach', 'core/focus-tab' ] },
+			{ hide: [ 'core/focus-tab' ] },
 		);
 		expect( resolved.controls.map( ( c ) => c.id ) ).toEqual( [
 			'core/minimize',
 			'core/maximize',
-			'core/reload',
 			'core/close',
 		] );
 	} );
@@ -131,18 +137,16 @@ describe( 'resolveWindowControls', () => {
 				order: [ 'core/close', 'core/minimize', 'core/maximize' ],
 			},
 		);
-		// First three follow the explicit order, then everything not
-		// mentioned in `order` keeps registry order.
 		expect( resolved.controls.map( ( c ) => c.id ).slice( 0, 3 ) ).toEqual( [
 			'core/close',
 			'core/minimize',
 			'core/maximize',
 		] );
-		// The remainder is appended in registry order.
+		// Whatever isn't named in `order` keeps registry order — for
+		// the post-0.6.2 cluster that's just `core/focus-tab`. The
+		// detach + reload built-ins moved to the title-bar menu.
 		expect( resolved.controls.map( ( c ) => c.id ).slice( 3 ) ).toEqual( [
 			'core/focus-tab',
-			'core/detach',
-			'core/reload',
 		] );
 	} );
 
@@ -202,10 +206,12 @@ describe( 'paintWindowControls', () => {
 			host,
 		);
 
-		expect( host.children.length ).toBe( 6 );
+		// minimize / maximize / focus-tab / close — detach + reload
+		// moved to the three-dots menu in 0.6.2.
+		expect( host.children.length ).toBe( 4 );
 		expect( host.querySelector( '.wp-desktop-window__btn--close' ) ).not.toBeNull();
 		expect( host.querySelector( '.wp-desktop-window__btn--minimize' ) ).not.toBeNull();
-		expect( host.querySelector( '.wp-desktop-window__btn--reload' ) ).not.toBeNull();
+		expect( host.querySelector( '.wp-desktop-window__btn--reload' ) ).toBeNull();
 	} );
 
 	test( 'click on core/close button dispatches win.close()', () => {
@@ -225,45 +231,25 @@ describe( 'paintWindowControls', () => {
 		expect( win.close ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	// Regression net for the title-bar Reload button. We've already had
-	// one merge silently drop pieces of this wiring; lock the full
-	// contract — registration, icon, label, click target — so a future
-	// regression fails loudly instead of vanishing the button.
-	test( 'core/reload registration locks icon, label, and click target', () => {
+	test( 'core/reload + core/detach are no longer registered', () => {
+		// In 0.6.2 these moved from the controls cluster to the
+		// title-bar three-dots menu (see `src/window/dom.ts`). Lock
+		// that the registry no longer carries them so a regression
+		// that re-adds them surfaces here.
 		registerBuiltInControls();
-		const def = listWindowControls().find( ( c ) => c.id === 'core/reload' );
-		expect( def ).toBeDefined();
-		expect( def?.icon ).toBe( 'reload' );
-		expect( def?.label ).toBe( 'Reload' );
-		expect( def?.placement ).toBe( 'controls' );
-		expect( def?.core ).toBe( true );
+		const ids = listWindowControls().map( ( c ) => c.id );
+		expect( ids ).not.toContain( 'core/reload' );
+		expect( ids ).not.toContain( 'core/detach' );
 	} );
 
-	test( 'Window class exposes a reload() method (click-target contract)', async () => {
-		// The reload control's onClick calls `win.reload()`. Lock that
-		// the real Window class still ships that method — a rename or
-		// removal would otherwise leave the button click no-oping at
+	test( 'Window class still exposes reload() + detach() (menu click targets)', async () => {
+		// The menu items wire to `win.reload()` / `win.detach()`. Lock
+		// that the Window class still ships both methods — a rename
+		// or removal would otherwise leave the menu items no-oping at
 		// runtime with no static error.
 		const mod = await import( '../../src/window' );
 		expect( typeof mod.Window.prototype.reload ).toBe( 'function' );
-	} );
-
-	test( 'click on core/reload button dispatches win.reload()', () => {
-		registerBuiltInControls();
-		const win = fakeWin( 'edit-post' );
-		const host = document.createElement( 'div' );
-		paintWindowControls(
-			win as unknown as Parameters< typeof paintWindowControls >[ 0 ],
-			host,
-		);
-		const reloadBtn = host.querySelector(
-			'.wp-desktop-window__btn--reload',
-		) as HTMLElement;
-		expect( reloadBtn ).not.toBeNull();
-		reloadBtn.dispatchEvent(
-			new CustomEvent( 'wpd-button-activate', { bubbles: true } ),
-		);
-		expect( win.reload ).toHaveBeenCalledTimes( 1 );
+		expect( typeof mod.Window.prototype.detach ).toBe( 'function' );
 	} );
 
 	test( 'repaint replaces previous buttons; teardown drops listeners', () => {

--- a/tests/vitest/window-submenu.test.ts
+++ b/tests/vitest/window-submenu.test.ts
@@ -208,4 +208,53 @@ describe( 'WindowManager — opening a window with a submenu', () => {
 			menuPanel.querySelector( '.wp-desktop-window__menu-item--open-another' ),
 		).not.toBeNull();
 	} );
+
+	test( '"Open in new window" item renders for every iframe window', () => {
+		// Singleton (non-multi) windows still get this item — the
+		// distinction from "Open another" is that this seeds the new
+		// window with the *current* URL, so it makes sense even for
+		// pages that aren't formally multi-instance.
+		const win = manager.open( {
+			id: 'edit-comments.php',
+			url: 'http://example.test/wp-admin/edit-comments.php',
+			title: 'Comments',
+			icon: 'dashicons-admin-comments',
+			multi: false,
+		} );
+		const menuPanel = win.element.querySelector( '.wp-desktop-window__menu-panel' )!;
+		const item = menuPanel.querySelector(
+			'.wp-desktop-window__menu-item--open-in-new-window',
+		);
+		expect( item ).not.toBeNull();
+		expect( item!.getAttribute( 'role' ) ).toBe( 'menuitem' );
+	} );
+
+	test( '"Open in new window" opens a sibling at the current iframe URL', () => {
+		const win = manager.open( {
+			id: 'edit.php',
+			url: 'http://example.test/wp-admin/edit.php',
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			multi: true,
+		} );
+
+		// Stub `getCurrentUrl()` to simulate the user having navigated
+		// in-window from the listing into editing a specific post.
+		const navigatedUrl = 'http://example.test/wp-admin/post.php?post=42&action=edit';
+		win.getCurrentUrl = () => navigatedUrl;
+
+		expect( manager.getAll().length ).toBe( 1 );
+		win.onOpenInNewWindow!( win );
+
+		const all = manager.getAll();
+		expect( all.length ).toBe( 2 );
+		const sibling = all.find( ( w ) => w !== win )!;
+		expect( sibling ).toBeDefined();
+		// New window inherits the source's baseId so the dock still
+		// groups instances under one icon, but its url is the *current*
+		// (post-navigation) URL — not the original landing URL.
+		expect( sibling.config.baseId ).toBe( 'edit.php' );
+		expect( sibling.config.url ).toBe( navigatedUrl );
+		expect( sibling.id ).not.toBe( win.id );
+	} );
 } );


### PR DESCRIPTION
## Summary

Replaces the dock's legacy `+` chip with a hover-reveal **peek** popover, moves a couple of infrequent title-bar actions into the existing three-dots menu, and makes "Open on startup" actually work for native windows (OS Settings, Recycle Bin, plugin-registered native apps). Adds two extension hooks so plugins can render their own thumbnails inside peek cards. A few small admin-bar polish fixes ride along.

## Changes

### Dock hover-peek (new)
- `src/dock-peek/` — fan-out popover anchored to a dock tile. Shows when the tile has ≥1 open window.
- Mini-window cards: faux titlebar (traffic-light dots + page icon + live window title), hash-tinted body. Titlebar background uses `--wp-desktop-titlebar-bg-focused` so cards inherit the user's WP profile color scheme (the variables are read off `.wp-desktop-shell` and inlined on the body-attached popover so they cascade correctly).
- **Ghost Card** — trailing dashed/breathing card for "open new instance." Click → `windowManager.openNew()` wrapped in `document.startViewTransition()` so the card morphs into the new window.
- **Hover-to-raise** on instance cards: pointerenter calls `windowManager.focus(win)` so the live window jumps to front behind the popover (Mission-Control / Aero-Peek feel).
- Glass material (`backdrop-filter: blur(28px) saturate(180%)`), capped at `min(80vh, 480px)` with internal scroll, JS clamp pass to keep the popover inside the viewport.
- **Bottom dock**: cards lay out as a horizontal reel (200×116 thumbnails) with X-axis scroll instead of a vertical column.
- Native windows get the peek too — singletons render a focus card without a Ghost Card. Built-in renderers ship for **OS Settings** (tinted hero icon + "System Preferences" + tab chips) and **Recycle Bin** (trash icon + live count + paper-slips stack when full).
- Replaces the legacy `+` chip on multi tiles; chip code removed from `src/dock.ts`.

### Title-bar three-dots menu
- New item: **"Open in new window"** — opens the *current* iframe URL as a fresh sibling (distinct from "Open another `<Page>`" which uses the landing URL).
- Moved from controls cluster into the menu: **"Reload"** and **"Open in browser tab"**.
- Menu now renders for **native windows** too (with non-iframe-applicable items hidden).

### "Open on startup" works for native windows
- New `native:<slug>` marker form for the saved preference. PHP validator accepts it (slug constrained to `^[a-z0-9_-]+$`); portal redirect falls back to `admin_url()` when it sees the marker (markers aren't HTTP-redirectable).
- JS toggle saves `native:${win.id}` for native windows; boot flow detects the marker and opens the right window after init. Built-in OS Settings is opened via its local closure; plugin-registered native windows go through `nativeWindows.openById`.
- "Open on startup" checkbox state now reflects native-marker matches in the menu's `refreshStartupCheckState`.

### Admin-bar polish
- Ask AI + Switch-to-Desktop icons no longer hardcode `#72aee6` blue — they `color: inherit` and pick up the user's profile color scheme.
- ⌘K badge re-centered (`inline-flex` + 1px optical nudge).
- Fixed PHP fatal: apostrophes inside CSS comments inside `$css = '…'` were terminating the single-quoted string. Lesson logged in memory.

## New hooks (plugin extension points)

| Hook | Type | Signature |
|---|---|---|
| `wp-desktop.dock.peek-card-content` | filter | `(body: HTMLElement, { window, item }) => HTMLElement` |
| `wp-desktop.dock.peek-card-element` | filter | `(card: HTMLElement, { window, item }) => HTMLElement` |

`peek-card-content` swaps just the card body (default mini-window chrome stays). `peek-card-element` replaces the **whole card** — plugin owns chrome and click wiring; the `wp-desktop-dock-peek__card` class must be preserved (the fan-out animation keys off it).

```javascript
window.wp.hooks.addFilter(
    'wp-desktop.dock.peek-card-content',
    'my-plugin/thumbnail',
    ( body, { window: win } ) => {
        const img = document.createElement( 'img' );
        img.src = `/wp-json/my-plugin/v1/thumbnail/${ win.id }`;
        img.alt = win.config.title;
        return img;
    }
);
```

## Test plan

- [ ] Hover the Posts dock icon with multiple Posts windows open — fan-out reel + Ghost Card appear; instance cards hover-raise the matching window; click morphs the card into focus.
- [ ] Hover the OS Settings / Recycle Bin tile when open — bespoke thumbnail renderer (gear / trash + count) shows.
- [ ] Hover Plugins / Appearance / Tools / Settings (singletons) when open — single focus card, no Ghost Card.
- [ ] Move the dock to bottom — peek opens above the icon as a horizontal reel.
- [ ] In a window's three-dots menu: Reload, Open in browser tab, Open in new window all work; native windows show the menu with only the relevant items.
- [ ] Mark OS Settings as "Open on startup" → reload from the portal → OS Settings auto-opens.
- [ ] Switch admin profile color scheme to Midnight / Coffee / Modern → card titlebars + admin-bar Ask AI / Switch icons match the scheme.
- [ ] `prefers-reduced-motion`: no card animations, no breathing pulse, no spring magnify.
- [ ] PHPUnit: `desktop_mode_validate_default_window_url` accepts `native:<slug>`, rejects `native:`, `native:foo bar`, `native:foo/bar`, `native:../etc/passwd`.

## Files

```
src/dock-peek/index.ts                                   (new)
src/dock-peek/built-in-renderers.ts                      (new)
assets/css/dock-peek.css                                 (new)
src/dock.ts                                              (peek wiring + chip removal)
src/desktop.ts                                           (boot-flow native default + renderer bootstrap)
src/window/dom.ts                                        (menu item additions, native-window menu unlock)
src/window/index.ts                                      (menu click handlers)
src/window/menus.ts                                      (native-marker check)
src/window-chrome/controls/built-ins.ts                  (removed core/detach + core/reload)
src/hooks.ts                                             (DOCK_PEEK_CARD_CONTENT, DOCK_PEEK_CARD_ELEMENT)
includes/default-window.php                              (native: validator)
includes/portal.php                                      (native: redirect fallback)
includes/admin-bar.php                                   (icon color + ⌘K alignment + apostrophe fix)
includes/assets.php, includes/render.php                 (enqueue dock-peek.css)
docs/javascript-reference.md                             (peek + filters documented)
docs/hooks-reference.md                                  (multi flag wording updated)
tests/vitest/dock-peek.test.ts                           (new — 12 cases)
tests/vitest/window-submenu.test.ts                      (Open in new window cases)
tests/vitest/window-chrome-controls-render.test.ts       (cluster size 6→4)
tests/phpunit/tests/wpDesktopDefaultWindow.php           (3 native: cases)
```

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-69-d448b5213b042d1378dc89481c4fab3d54e5bb85.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->