### PR TITLE
feat(bug-report): add "Report a bug" feature with native window integration

### DIFF
--- a/assets/css/bug-report.css
+++ b/assets/css/bug-report.css
@@ -1,0 +1,171 @@
+/**
+ * Desktop Mode — Bug Report native window styles.
+ *
+ * Compact form: type radio strip + title input + two textareas + a
+ * collapsible environment block + a primary submit. Designed to fit
+ * the default 560×620 window without scrolling on most viewports.
+ *
+ * @since 0.6.2
+ */
+
+.wp-desktop-bug-report {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	background: var( --wp-desktop-window-bg, #fff );
+	color: var( --wp-desktop-fg, #1d2327 );
+}
+
+.wp-desktop-bug-report__form {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	padding: 18px 20px 20px;
+	overflow-y: auto;
+}
+
+.wp-desktop-bug-report__intro {
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var( --wp-desktop-muted-fg, #50575e );
+}
+
+.wp-desktop-bug-report__error {
+	padding: 8px 10px;
+	border: 1px solid #d63638;
+	border-radius: 4px;
+	background: #fcf0f1;
+	color: #b32d2e;
+	font-size: 12px;
+}
+
+.wp-desktop-bug-report__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.wp-desktop-bug-report__label {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var( --wp-desktop-fg, #1d2327 );
+}
+
+.wp-desktop-bug-report__radio-group {
+	display: flex;
+	gap: 14px;
+	flex-wrap: wrap;
+	margin-top: 2px;
+}
+
+.wp-desktop-bug-report__radio {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	font-weight: 400;
+	color: var( --wp-desktop-fg, #1d2327 );
+	cursor: pointer;
+}
+
+.wp-desktop-bug-report__radio input[ type = "radio" ] {
+	margin: 0;
+}
+
+.wp-desktop-bug-report__input,
+.wp-desktop-bug-report__textarea {
+	width: 100%;
+	padding: 8px 10px;
+	border: 1px solid var( --wp-desktop-border, #c3c4c7 );
+	border-radius: 4px;
+	background: #fff;
+	font: inherit;
+	font-size: 13px;
+	line-height: 1.45;
+	color: inherit;
+	box-sizing: border-box;
+	transition:
+		border-color 120ms ease-out,
+		box-shadow 120ms ease-out;
+}
+
+.wp-desktop-bug-report__textarea {
+	resize: vertical;
+	min-height: 80px;
+	font-family: inherit;
+}
+
+.wp-desktop-bug-report__input:focus,
+.wp-desktop-bug-report__textarea:focus {
+	outline: none;
+	border-color: var( --wp-admin-theme-color, #2271b1 );
+	box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 );
+}
+
+.wp-desktop-bug-report__metadata {
+	margin-top: 4px;
+	border: 1px solid var( --wp-desktop-border, #c3c4c7 );
+	border-radius: 4px;
+	background: #f6f7f7;
+	font-size: 12px;
+}
+
+.wp-desktop-bug-report__metadata > summary {
+	padding: 8px 10px;
+	cursor: pointer;
+	font-weight: 500;
+	color: var( --wp-desktop-fg, #1d2327 );
+	user-select: none;
+}
+
+.wp-desktop-bug-report__metadata-body {
+	margin: 0;
+	padding: 0 10px 10px;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+	font-size: 11px;
+	line-height: 1.5;
+	color: var( --wp-desktop-muted-fg, #50575e );
+	white-space: pre-wrap;
+	word-break: break-all;
+}
+
+.wp-desktop-bug-report__actions {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-top: 4px;
+}
+
+.wp-desktop-bug-report__submit {
+	padding: 8px 16px;
+	border: 1px solid var( --wp-admin-theme-color, #2271b1 );
+	border-radius: 4px;
+	background: var( --wp-admin-theme-color, #2271b1 );
+	color: #fff;
+	font: inherit;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	transition:
+		filter 120ms ease-out,
+		box-shadow 120ms ease-out;
+}
+
+.wp-desktop-bug-report__submit:hover {
+	filter: brightness( 1.05 );
+	box-shadow: 0 1px 4px rgba( 0, 0, 0, 0.15 );
+}
+
+.wp-desktop-bug-report__submit:focus-visible {
+	outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+	outline-offset: 2px;
+}
+
+.wp-desktop-bug-report__hint {
+	font-size: 12px;
+	color: var( --wp-desktop-muted-fg, #50575e );
+}

--- a/assets/js/admin-bar.js
+++ b/assets/js/admin-bar.js
@@ -162,4 +162,15 @@
 			document.dispatchEvent( new CustomEvent( 'wp-desktop-open-ai' ) );
 		} );
 	}
+
+	// Bug Report button — same decoupling pattern as Ask AI. Dispatches
+	// `wp-desktop-open-bug-report`; the shell answers by opening the
+	// Bug Report native window. Wired in `src/desktop.ts`.
+	var bugBtn = document.getElementById( 'wp-admin-bar-desktop-bug-report' );
+	if ( bugBtn ) {
+		bugBtn.addEventListener( 'click', function( e ) {
+			e.preventDefault();
+			document.dispatchEvent( new CustomEvent( 'wp-desktop-open-bug-report' ) );
+		} );
+	}
 } )();

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -55,6 +55,29 @@ function desktop_mode_admin_bar_toggle( $wp_admin_bar ) {
 		)
 	);
 
+	// "Report a bug" trigger — shown only when desktop mode is active.
+	// Clicking dispatches a `wp-desktop-open-bug-report` document
+	// CustomEvent that the shell listens for and answers by opening the
+	// Bug Report native window. PHP doesn't know the JS side exists; the
+	// event lets us add the button without coupling to any specific
+	// shell module.
+	if ( $is_active ) {
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'top-secondary',
+				'id'     => 'desktop-bug-report',
+				'title'  => '<span class="ab-icon dashicons dashicons-buddicons-replies" aria-hidden="true"></span>'
+					. '<span class="ab-label">' . esc_html__( 'Report a bug', 'desktop-mode' ) . '</span>',
+				'href'   => '#',
+				'meta'   => array(
+					'class'    => 'desktop-bug-report-btn',
+					'title'    => __( 'Open the Bug Report window', 'desktop-mode' ),
+					'tabindex' => 0,
+				),
+			)
+		);
+	}
+
 	// AI Assistant trigger — shown when desktop mode is active AND the
 	// current user has AI features configured. Clicking (or pressing
 	// Cmd+K anywhere) opens the spotlight-style AI overlay.
@@ -308,6 +331,27 @@ function desktop_mode_enqueue_toggle_assets() {
 		}
 		@media screen and (max-width: 782px) {
 			#wp-admin-bar-desktop-ai-assistant .ab-label {
+				display: none;
+			}
+		}
+
+		/* Bug Report admin-bar button — same dashicons rendering pattern
+		   as the toggle. dashicons-buddicons-replies is a speech bubble
+		   with stylized lines that reads as a comment / report glyph at
+		   admin-bar size, while dashicons-bug is too literal and small. */
+		#wp-admin-bar-desktop-bug-report .ab-icon.dashicons {
+			font: normal 20px/1 dashicons;
+			-webkit-font-smoothing: antialiased;
+			-moz-osx-font-smoothing: grayscale;
+		}
+		#wp-admin-bar-desktop-bug-report .ab-icon.dashicons::before {
+			/* dashicons-buddicons-replies */
+			content: "\f465";
+			top: 2px;
+			position: relative;
+		}
+		@media screen and (max-width: 782px) {
+			#wp-admin-bar-desktop-bug-report .ab-label {
 				display: none;
 			}
 		}

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -73,6 +73,13 @@ function desktop_mode_register_assets() {
 	);
 
 	wp_register_style(
+		'wp-desktop-bug-report',
+		DESKTOP_MODE_URL . 'assets/css/bug-report.css',
+		array( 'wp-desktop-variables' ),
+		$version
+	);
+
+	wp_register_style(
 		'wp-desktop-code-editor',
 		DESKTOP_MODE_URL . 'assets/css/code-editor.css',
 		array( 'wp-desktop-variables', 'dashicons' ),

--- a/includes/render.php
+++ b/includes/render.php
@@ -95,6 +95,7 @@ function desktop_mode_enqueue_assets() {
 	wp_enqueue_style( 'wp-desktop-windows' );
 	wp_enqueue_style( 'wp-desktop-dock' );
 	wp_enqueue_style( 'wp-desktop-ai-assistant' );
+	wp_enqueue_style( 'wp-desktop-bug-report' );
 
 	// JS.
 	wp_enqueue_script( 'wp-desktop' );

--- a/src/bug-report/index.ts
+++ b/src/bug-report/index.ts
@@ -1,0 +1,354 @@
+/**
+ * Desktop Mode — Bug Report native window.
+ *
+ * A built-in native app that lets users file issues against the
+ * plugin's GitHub repo without leaving the admin. The form gathers
+ * a small structured payload (type, title, description, repro
+ * steps, environment) and opens GitHub's `/issues/new` URL with
+ * `?title=…&body=…&labels=…` pre-filled — the user reviews on
+ * GitHub before submitting, so we never POST on their behalf and
+ * never need an OAuth token.
+ *
+ * Three entry points all converge here:
+ *   1. The admin-bar "Report a bug" button (PHP node, dispatches
+ *      `wp-desktop-open-bug-report`).
+ *   2. The dock system tile registered in `src/desktop.ts`.
+ *   3. Future: a desktop widget. Same target, no special-casing.
+ *
+ * @since 0.6.2
+ */
+
+import { __ } from '../i18n';
+
+/** Public window id — shared with `src/desktop.ts` for tile + opener wiring. */
+export const BUG_REPORT_WINDOW_ID = 'wp-desktop-bug-report';
+
+/** GitHub repo the issue is filed against. Filterable per-site. */
+const REPO_OWNER = 'WordPress';
+const REPO_NAME = 'desktop-mode';
+
+/**
+ * Conservative cap on the body length passed via `?body=…`. GitHub
+ * accepts up to ~8KB of URL, but the rest of the URL (origin + path
+ * + title param + labels) eats some of that — 6KB for `body` keeps
+ * us under the limit with a comfortable margin.
+ */
+const MAX_BODY_LENGTH = 6000;
+
+interface FormState {
+	type: 'bug' | 'feature' | 'question';
+	title: string;
+	description: string;
+	steps: string;
+}
+
+/**
+ * Render the Bug Report form into a native window body.
+ *
+ * Called by the manager via `config.render(body)` when the window
+ * opens. Returns nothing — mutates `body` in place.
+ */
+export function renderBugReport( body: HTMLElement ): void {
+	body.classList.add( 'wp-desktop-bug-report' );
+	body.replaceChildren();
+
+	const form = document.createElement( 'form' );
+	form.className = 'wp-desktop-bug-report__form';
+	form.setAttribute( 'novalidate', '' );
+
+	const intro = document.createElement( 'p' );
+	intro.className = 'wp-desktop-bug-report__intro';
+	intro.textContent = __(
+		'Found a bug or have a feature idea? Fill this in and we will open a pre-filled GitHub issue for you to review and submit.',
+	);
+	form.appendChild( intro );
+
+	form.appendChild( buildTypeField() );
+	form.appendChild( buildTextField( 'title', __( 'Title' ), {
+		placeholder: __( 'A short summary' ),
+		required: true,
+	} ) );
+	form.appendChild( buildTextareaField( 'description', __( 'What happened? What did you expect?' ), {
+		placeholder: __( 'Describe the issue or the feature you have in mind.' ),
+		rows: 5,
+		required: true,
+	} ) );
+	form.appendChild( buildTextareaField( 'steps', __( 'Steps to reproduce (bug only)' ), {
+		placeholder: __( 'One step per line' ),
+		rows: 4,
+	} ) );
+
+	const meta = buildMetadataPreview();
+	form.appendChild( meta );
+
+	const actions = document.createElement( 'div' );
+	actions.className = 'wp-desktop-bug-report__actions';
+
+	const submit = document.createElement( 'button' );
+	submit.type = 'submit';
+	submit.className = 'wp-desktop-bug-report__submit';
+	submit.textContent = __( 'Open issue on GitHub' );
+	actions.appendChild( submit );
+
+	const hint = document.createElement( 'span' );
+	hint.className = 'wp-desktop-bug-report__hint';
+	hint.textContent = __( 'You will review and submit on GitHub.' );
+	actions.appendChild( hint );
+
+	form.appendChild( actions );
+
+	form.addEventListener( 'submit', ( e: Event ) => {
+		e.preventDefault();
+		const state = readFormState( form );
+		if ( ! state.title.trim() || ! state.description.trim() ) {
+			// Lightweight inline validation — title + description are
+			// both load-bearing; the rest is optional. Native HTML
+			// validation would clobber our submit handler with a
+			// browser-rendered tooltip, so keep it form-driven.
+			showInlineError( form, __( 'Title and description are both required.' ) );
+			return;
+		}
+		const url = buildGithubIssueUrl( state );
+		window.open( url, '_blank', 'noopener' );
+	} );
+
+	body.appendChild( form );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Field builders.
+   ────────────────────────────────────────────────────────────────── */
+
+function buildTypeField(): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'wp-desktop-bug-report__field wp-desktop-bug-report__field--type';
+
+	const label = document.createElement( 'span' );
+	label.className = 'wp-desktop-bug-report__label';
+	label.textContent = __( 'Type' );
+	wrap.appendChild( label );
+
+	const group = document.createElement( 'div' );
+	group.className = 'wp-desktop-bug-report__radio-group';
+	group.setAttribute( 'role', 'radiogroup' );
+
+	const options: { value: FormState[ 'type' ]; label: string; checked?: boolean }[] = [
+		{ value: 'bug', label: __( 'Bug' ), checked: true },
+		{ value: 'feature', label: __( 'Feature request' ) },
+		{ value: 'question', label: __( 'Question' ) },
+	];
+	for ( const opt of options ) {
+		const radioLabel = document.createElement( 'label' );
+		radioLabel.className = 'wp-desktop-bug-report__radio';
+		const input = document.createElement( 'input' );
+		input.type = 'radio';
+		input.name = 'type';
+		input.value = opt.value;
+		if ( opt.checked ) {
+			input.checked = true;
+		}
+		radioLabel.appendChild( input );
+		const text = document.createElement( 'span' );
+		text.textContent = opt.label;
+		radioLabel.appendChild( text );
+		group.appendChild( radioLabel );
+	}
+	wrap.appendChild( group );
+	return wrap;
+}
+
+function buildTextField(
+	name: keyof FormState,
+	labelText: string,
+	opts: { placeholder?: string; required?: boolean } = {},
+): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'wp-desktop-bug-report__field';
+
+	const label = document.createElement( 'label' );
+	label.className = 'wp-desktop-bug-report__label';
+	label.textContent = labelText;
+	wrap.appendChild( label );
+
+	const input = document.createElement( 'input' );
+	input.type = 'text';
+	input.name = name;
+	input.className = 'wp-desktop-bug-report__input';
+	if ( opts.placeholder ) {
+		input.placeholder = opts.placeholder;
+	}
+	if ( opts.required ) {
+		input.setAttribute( 'aria-required', 'true' );
+	}
+	label.appendChild( input );
+
+	return wrap;
+}
+
+function buildTextareaField(
+	name: keyof FormState,
+	labelText: string,
+	opts: { placeholder?: string; rows?: number; required?: boolean } = {},
+): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'wp-desktop-bug-report__field';
+
+	const label = document.createElement( 'label' );
+	label.className = 'wp-desktop-bug-report__label';
+	label.textContent = labelText;
+	wrap.appendChild( label );
+
+	const textarea = document.createElement( 'textarea' );
+	textarea.name = name;
+	textarea.className = 'wp-desktop-bug-report__textarea';
+	textarea.rows = opts.rows ?? 4;
+	if ( opts.placeholder ) {
+		textarea.placeholder = opts.placeholder;
+	}
+	if ( opts.required ) {
+		textarea.setAttribute( 'aria-required', 'true' );
+	}
+	label.appendChild( textarea );
+
+	return wrap;
+}
+
+/**
+ * Read-only summary of what we'll append to the issue body. Showing
+ * it inline keeps the user honest about what gets sent — no surprise
+ * data leak when the GitHub URL opens.
+ */
+function buildMetadataPreview(): HTMLElement {
+	const details = document.createElement( 'details' );
+	details.className = 'wp-desktop-bug-report__metadata';
+
+	const summary = document.createElement( 'summary' );
+	summary.textContent = __( 'Environment included with the report' );
+	details.appendChild( summary );
+
+	const pre = document.createElement( 'pre' );
+	pre.className = 'wp-desktop-bug-report__metadata-body';
+	pre.textContent = formatMetadata( collectMetadata() );
+	details.appendChild( pre );
+
+	return details;
+}
+
+function showInlineError( form: HTMLFormElement, msg: string ): void {
+	let banner = form.querySelector< HTMLElement >( '.wp-desktop-bug-report__error' );
+	if ( ! banner ) {
+		banner = document.createElement( 'div' );
+		banner.className = 'wp-desktop-bug-report__error';
+		banner.setAttribute( 'role', 'alert' );
+		form.prepend( banner );
+	}
+	banner.textContent = msg;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   State + URL building.
+   ────────────────────────────────────────────────────────────────── */
+
+function readFormState( form: HTMLFormElement ): FormState {
+	const data = new FormData( form );
+	return {
+		type: ( data.get( 'type' ) as FormState[ 'type' ] ) ?? 'bug',
+		title: ( data.get( 'title' ) as string ) ?? '',
+		description: ( data.get( 'description' ) as string ) ?? '',
+		steps: ( data.get( 'steps' ) as string ) ?? '',
+	};
+}
+
+/**
+ * Compose the GitHub issue URL with `?title=…&body=…&labels=…`.
+ * Exported so tests can pin the contract independently of the form
+ * scaffolding.
+ */
+export function buildGithubIssueUrl( state: FormState ): string {
+	const labels = labelsForType( state.type );
+	const body = composeIssueBody( state );
+	const params = new URLSearchParams();
+	params.set( 'title', state.title.trim() );
+	params.set( 'body', body );
+	if ( labels.length ) {
+		params.set( 'labels', labels.join( ',' ) );
+	}
+	return `https://github.com/${ REPO_OWNER }/${ REPO_NAME }/issues/new?${ params.toString() }`;
+}
+
+function labelsForType( type: FormState[ 'type' ] ): string[] {
+	switch ( type ) {
+		case 'bug':
+			return [ 'bug' ];
+		case 'feature':
+			return [ 'enhancement' ];
+		case 'question':
+			return [ 'question' ];
+		default:
+			return [];
+	}
+}
+
+function composeIssueBody( state: FormState ): string {
+	const parts: string[] = [];
+	parts.push( state.description.trim() );
+	if ( state.type === 'bug' && state.steps.trim() ) {
+		parts.push( '' );
+		parts.push( '## Steps to reproduce' );
+		parts.push( '' );
+		parts.push( state.steps.trim() );
+	}
+	parts.push( '' );
+	parts.push( '<details><summary>Environment</summary>' );
+	parts.push( '' );
+	parts.push( '```' );
+	parts.push( formatMetadata( collectMetadata() ) );
+	parts.push( '```' );
+	parts.push( '' );
+	parts.push( '</details>' );
+	let out = parts.join( '\n' );
+	if ( out.length > MAX_BODY_LENGTH ) {
+		out =
+			out.slice( 0, MAX_BODY_LENGTH ) +
+			'\n\n…(truncated to fit GitHub URL length limit)';
+	}
+	return out;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Metadata collection.
+   ────────────────────────────────────────────────────────────────── */
+
+interface Metadata {
+	pluginVersion: string;
+	wordpressVersion: string;
+	userAgent: string;
+	viewport: string;
+	platform: string;
+	currentUrl: string;
+}
+
+function collectMetadata(): Metadata {
+	const cfg = ( window as unknown as {
+		wp?: { desktop?: { config?: { pluginVersion?: string; wordpressVersion?: string } } };
+	} ).wp?.desktop?.config;
+	return {
+		pluginVersion: cfg?.pluginVersion ?? 'unknown',
+		wordpressVersion: cfg?.wordpressVersion ?? 'unknown',
+		userAgent: navigator.userAgent,
+		viewport: `${ window.innerWidth }x${ window.innerHeight }`,
+		platform: navigator.platform || 'unknown',
+		currentUrl: window.location.href,
+	};
+}
+
+function formatMetadata( m: Metadata ): string {
+	return [
+		`Plugin version:    ${ m.pluginVersion }`,
+		`WordPress version: ${ m.wordpressVersion }`,
+		`User agent:        ${ m.userAgent }`,
+		`Viewport:          ${ m.viewport }`,
+		`Platform:          ${ m.platform }`,
+		`Current URL:       ${ m.currentUrl }`,
+	].join( '\n' );
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -119,6 +119,10 @@ import {
 	subscribe,
 } from './broadcast';
 import { startRecycleBinBadge } from './recycle-bin/badge';
+import {
+	BUG_REPORT_WINDOW_ID,
+	renderBugReport,
+} from './bug-report';
 import { showToast, type ToastOptions } from './toast';
 import { renderKeyedList, clearKeyedList, type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
@@ -1565,6 +1569,60 @@ function init(): void {
 			minWidth: 560,
 			minHeight: 480,
 		} );
+	}
+
+	/**
+	 * Open (or focus) the Bug Report native window. Routed through
+	 * `manager.open` so the admin-bar button, the dock system tile,
+	 * and any future widget all reach the same window instance.
+	 */
+	function openBugReport(): void {
+		manager.open( {
+			id: BUG_REPORT_WINDOW_ID,
+			baseId: BUG_REPORT_WINDOW_ID,
+			url: `#${ BUG_REPORT_WINDOW_ID }`,
+			title: 'Report a bug',
+			icon: 'dashicons-buddicons-replies',
+			native: true,
+			render: ( body ) => renderBugReport( body ),
+			width: 560,
+			height: 620,
+			minWidth: 420,
+			minHeight: 480,
+		} );
+	}
+
+	// Admin-bar "Report a bug" button. Inline JS in
+	// `assets/js/admin-bar.js` dispatches the event; the shell
+	// answers here, decoupled from the early-running admin-bar IIFE.
+	document.addEventListener( 'wp-desktop-open-bug-report', () => {
+		openBugReport();
+	} );
+
+	// Dock system tile — sits next to OS Settings on the primary
+	// rail. Tracked by the layout dispatcher so it survives a layout
+	// rebuild (Classic ↔ Unified ↔ Spatial).
+	if ( layoutDispatcher ) {
+		layoutDispatcher.appendSystemTile(
+			{
+				id: BUG_REPORT_WINDOW_ID,
+				title: 'Report a bug',
+				icon: 'dashicons-buddicons-replies',
+				isOpen: () => {
+					const win = manager.getById( BUG_REPORT_WINDOW_ID );
+					if ( ! win ) {
+						return false;
+					}
+					return (
+						( win.config.desktopId ||
+							manager.getActiveDesktopId() ) ===
+						manager.getActiveDesktopId()
+					);
+				},
+				onOpen: openBugReport,
+			},
+			'core',
+		);
 	}
 	const dock: Dock | null = layoutDispatcher?.getPrimary() ?? null;
 

--- a/tests/vitest/bug-report.test.ts
+++ b/tests/vitest/bug-report.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the Bug Report native window — primarily the
+ * GitHub-issue URL builder. The render path is covered by a small
+ * integration test that confirms the form's structure.
+ *
+ * @group bug-report
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { buildGithubIssueUrl, renderBugReport } from '../../src/bug-report';
+
+beforeEach( () => {
+	// `collectMetadata()` reads navigator + window.location; jsdom
+	// gives both deterministic values, so no setup needed beyond a
+	// clean DOM.
+	document.body.innerHTML = '';
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'buildGithubIssueUrl', () => {
+	test( 'targets WordPress/desktop-mode/issues/new', () => {
+		const url = buildGithubIssueUrl( {
+			type: 'bug',
+			title: 'Something is broken',
+			description: 'I expected X, got Y.',
+			steps: '',
+		} );
+		expect( url.startsWith( 'https://github.com/WordPress/desktop-mode/issues/new?' ) ).toBe(
+			true,
+		);
+	} );
+
+	test( 'encodes title + body + labels into query params', () => {
+		const url = buildGithubIssueUrl( {
+			type: 'bug',
+			title: 'Window does not close',
+			description: 'Closing leaves a ghost element.',
+			steps: '1. open\n2. close',
+		} );
+		const params = new URL( url ).searchParams;
+		expect( params.get( 'title' ) ).toBe( 'Window does not close' );
+		expect( params.get( 'labels' ) ).toBe( 'bug' );
+		const body = params.get( 'body' ) ?? '';
+		expect( body ).toContain( 'Closing leaves a ghost element.' );
+		expect( body ).toContain( '## Steps to reproduce' );
+		expect( body ).toContain( '1. open' );
+		expect( body ).toContain( '<details><summary>Environment</summary>' );
+	} );
+
+	test( 'omits "Steps to reproduce" section for non-bug types', () => {
+		const url = buildGithubIssueUrl( {
+			type: 'feature',
+			title: 'Add dark mode',
+			description: 'Auto-switch with the OS preference.',
+			steps: '',
+		} );
+		const params = new URL( url ).searchParams;
+		expect( params.get( 'labels' ) ).toBe( 'enhancement' );
+		expect( params.get( 'body' ) ?? '' ).not.toContain( '## Steps to reproduce' );
+	} );
+
+	test( 'truncates oversized bodies with a note', () => {
+		// GitHub URLs cap around 8KB; we cap body at ~6KB for safety.
+		// Feeding 20KB of text exercises the truncation branch.
+		const huge = 'x'.repeat( 20_000 );
+		const url = buildGithubIssueUrl( {
+			type: 'bug',
+			title: 'Long report',
+			description: huge,
+			steps: '',
+		} );
+		const body = new URL( url ).searchParams.get( 'body' ) ?? '';
+		expect( body.length ).toBeLessThan( 6_200 );
+		expect( body ).toContain( 'truncated' );
+	} );
+
+	test( 'maps the three types to expected labels', () => {
+		const labelFor = ( type: 'bug' | 'feature' | 'question' ): string =>
+			new URL(
+				buildGithubIssueUrl( {
+					type,
+					title: 't',
+					description: 'd',
+					steps: '',
+				} ),
+			).searchParams.get( 'labels' ) ?? '';
+		expect( labelFor( 'bug' ) ).toBe( 'bug' );
+		expect( labelFor( 'feature' ) ).toBe( 'enhancement' );
+		expect( labelFor( 'question' ) ).toBe( 'question' );
+	} );
+} );
+
+describe( 'renderBugReport', () => {
+	test( 'renders the form with all expected fields', () => {
+		const body = document.createElement( 'div' );
+		document.body.appendChild( body );
+		renderBugReport( body );
+
+		expect( body.querySelector( '.wp-desktop-bug-report__form' ) ).not.toBeNull();
+		expect(
+			body.querySelectorAll( 'input[ name = "type" ]' ).length,
+		).toBe( 3 );
+		expect( body.querySelector( 'input[ name = "title" ]' ) ).not.toBeNull();
+		expect( body.querySelector( 'textarea[ name = "description" ]' ) ).not.toBeNull();
+		expect( body.querySelector( 'textarea[ name = "steps" ]' ) ).not.toBeNull();
+		expect( body.querySelector( '.wp-desktop-bug-report__submit' ) ).not.toBeNull();
+		expect( body.querySelector( '.wp-desktop-bug-report__metadata' ) ).not.toBeNull();
+	} );
+
+	test( 'shows an inline error when title or description is empty', () => {
+		const body = document.createElement( 'div' );
+		document.body.appendChild( body );
+		renderBugReport( body );
+
+		const form = body.querySelector< HTMLFormElement >(
+			'.wp-desktop-bug-report__form',
+		)!;
+		// jsdom's HTMLFormElement.requestSubmit isn't always
+		// implemented; fire `submit` directly so the handler runs.
+		form.dispatchEvent( new Event( 'submit', { cancelable: true } ) );
+
+		expect( body.querySelector( '.wp-desktop-bug-report__error' ) ).not.toBeNull();
+	} );
+} );


### PR DESCRIPTION
Easy error report from Desktop Mode

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-70-70b12b6c7dc1267872d0cbd8010c8c3da349cf8e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->