### PR TITLE
Plugin review: scope set_time_limit() to the OpenAI HTTP call only

### DIFF
--- a/includes/ai-copilot/hooks.php
+++ b/includes/ai-copilot/hooks.php
@@ -72,14 +72,16 @@ function desktop_mode_ai_schedule_job( $hook, array $args, $dedup_key ) {
 			// function; in other SAPIs (CLI, Apache mod_php) it is
 			// not available and we proceed without it — the analysis
 			// still runs, it just blocks the request exit briefly.
+			//
+			// The OpenAI HTTP call itself bumps `set_time_limit()`
+			// when (and only when) it is about to fire — see
+			// `desktop_mode_ai_do_request()` in `openai.php`.
+			// Bumping it here would widen the scope to every
+			// scheduled job whether or not it ends up hitting the
+			// remote API, which the WordPress.org plugin review
+			// guidelines discourage.
 			if ( function_exists( 'fastcgi_finish_request' ) ) {
 				fastcgi_finish_request();
-			}
-
-			// Bump execution time so a slow OpenAI response doesn't
-			// hit the default 30 s limit.
-			if ( ! ini_get( 'safe_mode' ) ) { // phpcs:ignore
-				@set_time_limit( 120 ); // phpcs:ignore
 			}
 
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- generic dispatcher; caller passes a desktop_mode_* hook name.

--- a/includes/ai-copilot/openai.php
+++ b/includes/ai-copilot/openai.php
@@ -52,6 +52,18 @@ function desktop_mode_ai_do_request( $api_key, array $body ) {
 		return new WP_Error( 'desktop_mode_ai_encode', 'Failed to JSON-encode request body.' );
 	}
 
+	// Narrowly-scoped execution-time bump: this is the ONE function
+	// that performs the slow OpenAI HTTP round-trip. The HTTP timeout
+	// (`DESKTOP_MODE_AI_REQUEST_TIMEOUT`, currently 30 s) equals PHP's
+	// default `max_execution_time`, so a near-timeout response could
+	// be killed by PHP before `wp_remote_post()` returns. The bump
+	// only applies to the request that reaches this line — every
+	// other code path runs under the host's normal limit. The `@`
+	// suppresses the warning on hosts where `set_time_limit()` is
+	// disabled in `disable_functions`; the request still proceeds
+	// under whatever limit the host enforces.
+	@set_time_limit( 120 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
 	$http = wp_remote_post(
 		DESKTOP_MODE_AI_OPENAI_ENDPOINT,
 		array(


### PR DESCRIPTION
## Summary

Addresses the WordPress.org review feedback **"Don't Force Set PHP Limits Globally"** flagged at \`includes/ai-copilot/hooks.php:82\`.

The previous \`@set_time_limit(120)\` lived in the generic shutdown dispatcher (\`desktop_mode_ai_schedule_job\`), so it ran for **every** scheduled AI job whether or not that job actually ended up making a slow OpenAI HTTP call. That's the broad scope the reviewer flagged.

This PR narrows the scope to exactly one function — \`desktop_mode_ai_do_request()\` in \`openai.php\` — which is the single entry point for the OpenAI Responses API HTTP round-trip. The bump now happens immediately before \`wp_remote_post()\`, so it only applies to requests that actually reach the slow remote call. Every other code path runs under the host's normal \`max_execution_time\`.

The \`safe_mode\` check was dead code (removed in PHP 5.4, plugin requires PHP 7.4+) and went with it.

The other \`@set_time_limit(120)\` in \`search.php\` line 2169 is inside the SSE streaming endpoint (\`desktop_mode_ai_ajax_search_stream\`) — already narrowly scoped to a single dedicated heavy function whose entire purpose is holding a long-lived stream open. Left untouched.

## Test plan

- [x] \`npm run build\` (all bundles)
- [x] \`npm run lint\`
- [x] \`tsc --noEmit\`
- [x] \`npm run test:js\` — 768 passed
- [x] CI — Plugin Check, PHPUnit 8.1/8.2
- [x] Manual: save a post with the AI Copilot enabled and observe that the analysis still completes (the bump now lives next to the actual HTTP call)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-88-e4f30bc727547f8914fb5191f40d5c7a02772859.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->