### PR TITLE
Fix: AI Assistant 'Open in desktop' throws config.id TypeError

### DIFF
--- a/src/ai-assistant.ts
+++ b/src/ai-assistant.ts
@@ -228,12 +228,20 @@ interface ContinueHint {
 // Minimal shape of the window manager we use — avoids pulling full types.
 interface WindowManagerLite {
 	open( cfg: {
-		id?: string;
+		id: string;
 		url: string;
 		title: string;
 		icon?: string;
 		native?: boolean;
 	} ): unknown;
+}
+
+// Subset of `wp.desktop.*` we read at runtime. Both `windowManager` and
+// `deriveWindowId` ship together (initialised by the shell bundle's
+// `setupDesktopMode()`), so when one is present the other is too.
+interface DesktopShellLite {
+	windowManager?: WindowManagerLite;
+	deriveWindowId?: ( url: string, adminUrl?: string ) => string;
 }
 
 // ---------------------------------------------------------------------------
@@ -944,22 +952,36 @@ export class AiAssistant implements AiAssistantApi {
 	// new browser tab, so the admin experience stays inside the desktop.
 	// ------------------------------------------------------------------
 
-	private _getWindowManager(): WindowManagerLite | null {
-		const wm = ( window as unknown as {
-			wp?: { desktop?: { windowManager?: WindowManagerLite } };
-		} ).wp?.desktop?.windowManager;
-		return wm ?? null;
+	private _getDesktopShell(): DesktopShellLite | null {
+		const shell = ( window as unknown as {
+			wp?: { desktop?: DesktopShellLite };
+		} ).wp?.desktop;
+		return shell ?? null;
 	}
 
 	private _openInLegacyWindow( url: string, title: string, icon?: string ): void {
-		const wm = this._getWindowManager();
-		if ( ! wm ) {
+		const shell = this._getDesktopShell();
+		if ( ! shell || ! shell.windowManager ) {
 			// Graceful fallback — if the shell isn't initialised yet,
 			// just open in a new tab rather than silently doing nothing.
 			window.open( url, '_blank', 'noopener' );
 			return;
 		}
-		wm.open( { url, title, icon: icon ?? 'dashicons-admin-generic' } );
+		// `windowManager.open()` requires a non-empty `id`. Use the
+		// shell's own URL→id helper so the window we open coalesces
+		// with any existing window pointing at the same admin page
+		// (matches what clicking the dock would do). Fall back to a
+		// URL-derived synthetic id when the helper isn't exposed —
+		// older shells, or contrived test environments.
+		const id = shell.deriveWindowId
+			? shell.deriveWindowId( url )
+			: 'desktop-mode-ai-' + url.replace( /[^a-z0-9]+/gi, '-' ).slice( 0, 80 );
+		shell.windowManager.open( {
+			id,
+			url,
+			title,
+			icon: icon ?? 'dashicons-admin-generic',
+		} );
 		this.close();
 	}
 


### PR DESCRIPTION
## Reproduce

1. Open the AI Assistant (Cmd+K).
2. Ask "open my latest post".
3. Click **Open post in desktop** on the entity result.

The console throws:

```
Uncaught TypeError: windowManager.open(): config.id must be a non-empty string.
    at WindowManager.open                    (desktop.js:8352:15)
    at AiAssistant._openInLegacyWindow       (desktop.js:23571:10)
    at HTMLButtonElement.<anonymous>         (desktop.js:23874:18)
```

## Cause

`_openInLegacyWindow()` in `src/ai-assistant.ts` called `wm.open({ url, title, icon })` without `id`. The WindowManager strict-checks `config.id` (boundary validation in `src/window-manager/index.ts:373`) — every other shell call site already passes a derived id via `wp.desktop.deriveWindowId(url)`, but the AI assistant slipped through.

## Fix

- Derive the id from the URL using the existing `wp.desktop.deriveWindowId(url)` helper. Coalesces with any existing window pointing at the same admin page (matches "click the dock" behaviour for that entity).
- Fall back to a URL-slugified synthetic id when the helper isn't exposed (older shells / contrived test envs).
- Tightened the local `WindowManagerLite` interface to make `id` required so future callers fail at compile time, not at runtime.

## Test plan

- [x] `npm run lint`
- [x] `tsc --noEmit`
- [x] `npm run test:js` — 768 passed
- [x] Manual: AI Assistant → ask "open my latest post" → click **Open post in desktop** → window opens, no console error
- [x] Manual: AI Assistant → ask "take me to plugin settings" → click an admin-link result → window opens

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-89-fcbf477dedfa12701c8fabf19623b0624c717bf3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->