### PR TITLE
Remove stray typescript file and gitignore future script(1) recordings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /assets/js/recycle-bin.min.js
 
 .DS_Store
+
+# Default output file of macOS/BSD `script(1)` — a terminal session
+# recorder. Easy to commit by accident with `git add .`.
+/typescript

--- a/typescript
+++ b/typescript
@@ -1,10 +1,0 @@
-Script started on Mon May  4 12:33:32 2026
-^DRestored session: sábado,  2 de mayo de 2026, 11:34:15 CEST
-[1m[7m%[27m[1m[0m                                                                                ]7;file://Mac/Users/daniellopez/Documents/Repositories/alcazaba-plugin[0m[27m[24m[J(base) daniellopez@Mac alcazaba-plugin % [K[?2004h[?2004l
-
-Saving session...
-...saving history...truncating history files...
-...completed.
-Deleting expired sessions...       2 completed.
-
-Script done on Mon May  4 12:33:34 2026


### PR DESCRIPTION
## Summary

`npm run package` was shipping a `typescript` file inside the plugin zip. The file is a BSD/macOS `script(1)` terminal session recording — `script` writes to a file literally named `typescript` when no output path is given. It was committed by accident in #77 (likely a `git add .` after someone ran `script` to capture a terminal session) and `git archive` has been carrying it into every release zip since.

Two-part fix:

- Remove the file from the repo.
- Add `/typescript` to `.gitignore` so a future stray recording can't slip through `git add .` without an explicit `git add -f`.

## Verification

```
$ file typescript
typescript: Unicode text, UTF-8 text, with CRLF, CR, LF line terminators, with escape sequences, with overstriking
$ head typescript
Script started on Mon May  4 12:33:32 2026
…
Script done on Mon May  4 12:33:34 2026
```

Confirms the file is just terminal output, no plugin content.

## Test plan

- [ ] After merge, run `npm run package` and unzip — `desktop-mode/typescript` should not be present.
- [ ] `script typescript-test` then `exit` and confirm the resulting file is gitignored (won't show under `git status`).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-90-c0c87efde5fc384bb622b386f5f012bad1ec5e72.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->