### PR TITLE
package.sh: explicit allow-list of shipped paths instead of deny-list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,11 @@
-# Files excluded from `git archive` (and therefore from the plugin ZIP
-# produced by bin/package.sh). Runtime code, CSS, images, vendored libs,
-# language files, LICENSE, README.md, and readme.txt are NOT listed here
-# and ship in the ZIP. Dev tooling, build config, source TS, tests, and
-# developer docs are excluded.
+# Defense-in-depth deny-list applied by `git archive`.
+#
+# The primary mechanism for deciding what ships in the plugin zip is
+# the explicit allow-list at the top of bin/package.sh — only the
+# top-level paths named there are passed to `git archive`. The rules
+# below stay as a second layer in case someone runs `git archive HEAD`
+# directly, or in case a tracked file inside an allow-listed directory
+# (e.g. assets/) should still be excluded from a release.
 
 # Dotfiles / dev tooling
 /.github/           export-ignore

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -2,6 +2,12 @@
 #
 # Build a WordPress-installable plugin zip from HEAD.
 #
+# Allow-list packaging: only the paths listed in `include` below ship.
+# Anything else committed to the repo (build config, tests, dev tooling,
+# stray editor recordings, etc.) is excluded by default. To ship a new
+# top-level directory or file, add it here intentionally — accidental
+# commits at the repo root never end up in a release.
+#
 # Why not `git archive --format=zip` directly? Git's zip output stores
 # Unix mode 0600 for files / 0700 for dirs — after extraction by the WP
 # plugin installer, those files are unreadable by the web-server user.
@@ -20,6 +26,27 @@ root=$(pwd)
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
+# Allow-list: the only top-level paths that ship in the zip.
+include=(
+	"desktop-mode.php"
+	"readme.txt"
+	"LICENSE"
+	"README.md"
+	"assets"
+	"includes"
+	"languages"
+)
+
+# Verify each allow-listed path is actually in HEAD — catches typos and
+# files that have been removed from the repo without updating the list.
+for path in "${include[@]}"; do
+	if ! git cat-file -e "HEAD:$path" 2>/dev/null; then
+		echo "error: '$path' is in the package allow-list but not present in HEAD." >&2
+		echo "       Update the 'include' array in bin/package.sh." >&2
+		exit 1
+	fi
+done
+
 built=(
 	"assets/js/desktop.js"
 	"assets/js/desktop.min.js"
@@ -36,7 +63,7 @@ for file in "${built[@]}"; do
 	fi
 done
 
-git archive --worktree-attributes --prefix="$prefix/" HEAD | tar -x -C "$tmp"
+git archive --worktree-attributes --prefix="$prefix/" HEAD -- "${include[@]}" | tar -x -C "$tmp"
 
 for file in "${built[@]}"; do
 	cp "$file" "$tmp/$prefix/$file"


### PR DESCRIPTION
## Summary

`bin/package.sh` was running `git archive HEAD` over the whole repo and relying on `.gitattributes` `export-ignore` rules to keep dev-only content out of the zip. That model is opt-out: anything new committed at the repo root ships by default unless someone remembers to update `.gitattributes`. That's how the stray `script(1)` recording from #77 ended up inside `desktop-mode.zip` (fixed in #90).

This PR flips the model. `bin/package.sh` now ships only the explicit allow-list:

- `desktop-mode.php`
- `readme.txt`
- `LICENSE`
- `README.md`
- `assets/`
- `includes/`
- `languages/`

Anything else tracked in the repo — build config, tests, docs, dev tooling, accidental root-level files — is excluded by default. Adding a new top-level path to a release now requires consciously appending it to the `include` array in the script.

The script also runs `git cat-file -e` against each allow-listed path up front so a typo or removed-but-not-updated entry fails the package step instead of silently producing an incomplete zip.

`.gitattributes` deny-list rules stay in place as a second layer (in case someone runs `git archive HEAD` directly, or to exclude individual files within an allow-listed directory). The header comment is updated to reflect the new layered model.

## Verification

Local run, before this change:

```
$ unzip -l desktop-mode.zip | awk '{print $4}' | grep -E '^desktop-mode/[^/]+/?$'
desktop-mode/LICENSE
desktop-mode/README.md
desktop-mode/assets/
desktop-mode/desktop-mode.php
desktop-mode/includes/
desktop-mode/languages/
desktop-mode/readme.txt
desktop-mode/typescript    ← stray script(1) recording
```

After this change:

```
$ unzip -l desktop-mode.zip | awk '{print $4}' | grep -E '^desktop-mode/[^/]+/?$'
desktop-mode/LICENSE
desktop-mode/README.md
desktop-mode/assets/
desktop-mode/desktop-mode.php
desktop-mode/includes/
desktop-mode/languages/
desktop-mode/readme.txt
```

All 6 Vite-built bundles + 2 hand-written `assets/js/*.js` files still get spliced in correctly.

## Test plan

- [x] Run `npm run package` and confirm only the 7 top-level entries above appear.
- [x] Confirm the built JS bundles (`assets/js/{desktop,iframe-bridge,recycle-bin}{,.min}.js`) and the hand-written ones (`admin-bar.js`, `media-library-enhanced.js`) are inside the zip.
- [ ] Touch a file at the repo root (e.g. `git add foo.txt && git commit`), re-run `npm run package`, confirm `foo.txt` is NOT in the zip.
- [ ] Temporarily add a non-existent path to the `include` array and confirm the script errors out instead of silently producing an incomplete zip.
- [ ] Cut a release end-to-end via `bin/release.sh` once merged, confirm the published zip matches expectations.

## Relationship to #90

#90 removes the existing stray `typescript` file and gitignores the `script(1)` default name. This PR is the structural follow-up: even if a future stray file slips past `.gitignore` and gets committed, it can no longer end up in a release zip without someone explicitly allow-listing it.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-91-426a8a018fd7f50d9e1e1f5b79f87851de43e1df.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->