### PR TITLE
Auto-include built JS in releases — no manual list updates per bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,15 +4,13 @@
 /dist/
 /tests/phpunit/.phpunit.result.cache
 
-# Vite build output — regenerate locally with `npm run build`.
-# One pair per target in vite.config.js. Hand-written JS in assets/js/
-# (admin-bar.js, media-library-enhanced.js) is intentionally tracked.
-/assets/js/desktop.js
-/assets/js/desktop.min.js
-/assets/js/iframe-bridge.js
-/assets/js/iframe-bridge.min.js
-/assets/js/recycle-bin.js
-/assets/js/recycle-bin.min.js
+# Vite build output under assets/js/ — regenerate locally with `npm run
+# build`. Adding a new bundle in vite.config.js does not require updating
+# this list. Hand-written JS files that should stay tracked are explicitly
+# re-included below.
+/assets/js/*.js
+!/assets/js/admin-bar.js
+!/assets/js/media-library-enhanced.js
 
 .DS_Store
 

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -47,21 +47,17 @@ for path in "${include[@]}"; do
 	fi
 done
 
-built=(
-	"assets/js/desktop.js"
-	"assets/js/desktop.min.js"
-	"assets/js/iframe-bridge.js"
-	"assets/js/iframe-bridge.min.js"
-	"assets/js/recycle-bin.js"
-	"assets/js/recycle-bin.min.js"
-)
+# Vite build output: every gitignored .js under assets/js/. Listed by
+# `git ls-files --others --ignored --exclude-standard`, which only
+# returns files that exist on disk — so a missing build is detected as
+# "no files found", not as a stale hard-coded list. Adding a new bundle
+# in vite.config.js does not require updating this script.
+mapfile -t built < <(git ls-files --others --ignored --exclude-standard -- 'assets/js/*.js')
 
-for file in "${built[@]}"; do
-	if [[ ! -f "$file" ]]; then
-		echo "error: $file is missing — run 'npm run build' first." >&2
-		exit 1
-	fi
-done
+if (( ${#built[@]} == 0 )); then
+	echo "error: no built JS found under assets/js/ — run 'npm run build' first." >&2
+	exit 1
+fi
 
 git archive --worktree-attributes --prefix="$prefix/" HEAD -- "${include[@]}" | tar -x -C "$tmp"
 


### PR DESCRIPTION
## Summary

Adding a new Vite-built bundle previously required editing two files:

1. `.gitignore` — to keep the build output out of git.
2. `bin/package.sh` — to splice the build output into the plugin zip.

Both were hand-maintained lists that drift the first time anyone forgets a step. Concretely, `assets/js/sw.js` and `assets/js/sw.min.js` recently appeared in the worktree as new build output but with no entries in either list.

This PR collapses both spots to a wildcard.

### `.gitignore`

```
/assets/js/*.js
!/assets/js/admin-bar.js
!/assets/js/media-library-enhanced.js
```

Anything new built into `assets/js/` is gitignored automatically; the two hand-written tracked files are explicitly re-included.

### `bin/package.sh`

The hard-coded `built` array is replaced with:

```bash
mapfile -t built < <(git ls-files --others --ignored --exclude-standard -- 'assets/js/*.js')
```

`git ls-files --others --ignored` only returns files that exist on disk, so:
- If the build was run → all built bundles get spliced into the zip, including new ones.
- If the build was not run → empty array → the script errors with the same "run npm run build first" message as before.

### Sync script

`bin/sync-to-wp-develop.sh` already rsyncs the entire `assets/` directory, so no change is needed there. Same allow-list philosophy, different mechanism.

## Verification

Local zip after this change:

```
$ unzip -l desktop-mode.zip | grep 'assets/js/.*\.js$' | sort
desktop-mode/assets/js/admin-bar.js
desktop-mode/assets/js/desktop.js
desktop-mode/assets/js/desktop.min.js
desktop-mode/assets/js/iframe-bridge.js
desktop-mode/assets/js/iframe-bridge.min.js
desktop-mode/assets/js/media-library-enhanced.js
desktop-mode/assets/js/recycle-bin.js
desktop-mode/assets/js/recycle-bin.min.js
desktop-mode/assets/js/sw.js
desktop-mode/assets/js/sw.min.js
```

`sw.js` / `sw.min.js` are picked up without any explicit listing in the script.

`git check-ignore` confirms the right files are ignored:

```
ignored:    desktop.js, desktop.min.js, iframe-bridge.js, iframe-bridge.min.js,
            recycle-bin.js, recycle-bin.min.js, sw.js, sw.min.js
not ignored: admin-bar.js, media-library-enhanced.js  (still tracked)
```

## Test plan

- [ ] `npm run build && npm run package` produces a zip with all 8 built bundles + the 2 hand-written tracked ones.
- [ ] `rm -rf assets/js/*.js && npm run package` errors with the "build first" message instead of producing an empty zip.
- [ ] `git status` after running `npm run build` shows nothing under `assets/js/` (all built files correctly ignored).
- [ ] Adding a hypothetical `build:foo` script that emits `assets/js/foo.js` and `foo.min.js`, then re-running `npm run package`, includes both files in the zip with no edits to `.gitignore` or `bin/package.sh`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-93-6b1910f575c7077eee6834b2a894efb15d6f15e2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->