### PR TITLE
ci: deploy to WordPress.org on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,15 @@ jobs:
             --generate-notes \
             "${flags[@]}" \
             desktop-mode.zip
+
+      - name: Unpack zip for wp.org deploy
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: unzip -q desktop-mode.zip -d build/
+
+      - name: Deploy to WordPress.org
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          BUILD_DIR: ./build/desktop-mode


### PR DESCRIPTION
## Summary

- Extends `.github/workflows/release.yml` with a wp.org SVN deploy step using [`10up/action-wordpress-plugin-deploy`](https://github.com/10up/action-wordpress-plugin-deploy).
- Reuses the artifact built by `bin/package.sh`: unzips `desktop-mode.zip` into `build/` and points the action at it via `BUILD_DIR`. The release zip stays the single source of truth for what ships — no `.distignore` to keep in sync with the allow-list in `bin/package.sh`.
- Skipped for prerelease tags (any tag with a `-`), since SVN deploy makes the version live for everyone the moment it commits. Stable tags only.

## How it works

The 10up action is an SVN sync, not a zip uploader: it checks out `https://plugins.svn.wordpress.org/desktop-mode/`, rsyncs `BUILD_DIR/` into `trunk/`, copies `.wordpress-org/` into SVN `assets/`, then `svn cp trunk → tags/$VERSION` and commits. `SLUG` defaults to the repo name, which already matches (`WordPress/desktop-mode`).

`.wordpress-org/` (banners, icons, blueprints) keeps working — it's read from the repo root independently of `BUILD_DIR`.

## Required before merging

Add repo secrets in **Settings → Secrets and variables → Actions**:

- `SVN_USERNAME` — WordPress.org username with commit access on the `desktop-mode` SVN repo
- `SVN_PASSWORD`

(Until those are set, the GitHub Actions linter warns "Context access might be invalid" on the `env` lines. Cosmetic; resolves once the secrets exist.)

## Test plan

- [ ] Add `SVN_USERNAME` / `SVN_PASSWORD` secrets to the repo
- [ ] Cut a prerelease tag (e.g. `vX.Y.Z-rc.1`) and confirm the wp.org steps are skipped while the GitHub release is still created with the zip attached
- [ ] Cut a stable tag and confirm:
  - GitHub release is created with `desktop-mode.zip`
  - wp.org SVN `trunk/` is updated and `tags/X.Y.Z` is created
  - `.wordpress-org/` assets land in SVN `assets/`

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-95-ca368680aefda2cb4c399b150a4e5c92a6553cba.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->