### PR TITLE
Fix Recycle Bin 'Empty bin' truncation past 200 items

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1397,6 +1397,14 @@ Tweak the args passed to `desktop_mode_register_window()` / `desktop_mode_regist
 
 The full template body before it's emitted into the native-window template element. Keep the `data-desktop-mode-recycle-bin-*` hooks intact so the JS bundle can find its mount points.
 
+### `desktop_mode_recycle_bin_empty_chunk_size` — Experimental (filter)
+
+```php
+apply_filters( 'desktop_mode_recycle_bin_empty_chunk_size', int $chunk_size );
+```
+
+Per-call cap on `desktop_mode_recycle_bin_empty()` — protects against PHP `max_execution_time` on huge bins. Default `200`. The client iterates while `remaining > 0`, so raising this just means fewer roundtrips per "Empty bin" click. Lower it on shared hosts with tight execution budgets; raise it on dedicated servers handling 10k+ item bins.
+
 ### Lifecycle actions
 
 ```php

--- a/includes/recycle-bin/store.php
+++ b/includes/recycle-bin/store.php
@@ -796,18 +796,48 @@ function desktop_mode_recycle_bin_purge_comment( $comment_id ) {
  * Honors the same capability gate as a single purge — items the user
  * can't permanently delete are skipped (not silently dropped).
  *
+ * Processes at most one chunk per call. The cap protects against PHP
+ * timeouts on large bins; the client iterates while `remaining > 0`
+ * (and bails when `remaining === skipped`, i.e. nothing the user can
+ * purge is left). Site owners with longer execution budgets can tune
+ * the chunk size via the `desktop_mode_recycle_bin_empty_chunk_size`
+ * filter.
+ *
  * @since 0.19.0
  *
- * @return array { @type int $purged @type int $skipped }
+ * @return array {
+ *     @type int $purged    Items successfully purged in this call.
+ *     @type int $skipped   Items skipped (capability or error).
+ *     @type int $remaining Items still in the bin after this call (across pages).
+ * }
  */
 function desktop_mode_recycle_bin_empty() {
 	$purged  = 0;
 	$skipped = 0;
 
+	/**
+	 * Filter the per-call chunk size for the empty-bin loop.
+	 *
+	 * `desktop_mode_recycle_bin_empty()` only purges this many items
+	 * per invocation. The client iterates while `remaining > 0`. The
+	 * default (200) is conservative for shared hosts; sites with
+	 * generous PHP execution limits can raise it to make emptying a
+	 * large bin take fewer roundtrips.
+	 *
+	 * @since 0.21.1
+	 *
+	 * @param int $chunk_size Items processed per call. Default 200.
+	 */
+	$chunk_size = (int) apply_filters( 'desktop_mode_recycle_bin_empty_chunk_size', 200 );
+	if ( $chunk_size < 1 ) {
+		$chunk_size = 1;
+	}
+
 	// Loop in chunks — `wp_delete_post()` is cheap individually but
 	// hammering it on a 10k-item bin without yielding back to PHP can
-	// still time out. 200 is plenty for a single REST roundtrip.
-	$batch = desktop_mode_recycle_bin_get_items( array( 'per_page' => 200, 'page' => 1 ) );
+	// still time out. The client re-invokes us until `remaining` hits
+	// zero (or stalls at `skipped`).
+	$batch = desktop_mode_recycle_bin_get_items( array( 'per_page' => $chunk_size, 'page' => 1 ) );
 	foreach ( $batch['items'] as $item ) {
 		$result = desktop_mode_recycle_bin_purge(
 			(int) $item['id'],
@@ -831,8 +861,8 @@ function desktop_mode_recycle_bin_empty() {
 	do_action( 'desktop_mode_recycle_bin_emptied', $purged, $skipped );
 
 	return array(
-		'purged'  => $purged,
-		'skipped' => $skipped,
+		'purged'    => $purged,
+		'skipped'   => $skipped,
 		'remaining' => max( 0, $batch['total'] - $purged ),
 	);
 }

--- a/src/recycle-bin/badge.ts
+++ b/src/recycle-bin/badge.ts
@@ -23,6 +23,7 @@
 
 import { addAction, HOOKS } from '../hooks';
 import { subscribe } from '../broadcast';
+import { createSharedStore } from '../shared-store';
 
 /* eslint-disable no-console */
 const LOG_PREFIX = '[desktop-mode-bin badge]';
@@ -75,15 +76,38 @@ function getDesktopApi(): WpDesktopBadgeRails | undefined {
 		.wp?.desktop;
 }
 
-let _current = 0;
-// High-water mark for "did anything change since I last asked".
-// Bumped from heartbeat responses + chromeless-iframe postMessages.
-// Initialised to `Date.now()` on `start()` so a delete that
-// happened before the page loaded doesn't replay through the
-// fast-path subscriber on first paint.
-let _seenTs = 0;
-let _started = false;
-let _countUrl = '';
+/**
+ * State shared across every bundle that imports this module.
+ *
+ * Routed through `createSharedStore` because both the always-on
+ * shell bundle (`desktop.js`) and the lazy bin window bundle
+ * (`recycle-bin.js`) import this file. Plain module-level `let`s
+ * would compile into each bundle separately, so the bin window
+ * setting `current = 0` after Empty bin would never reach the
+ * shell bundle's lifecycle handlers — they'd repaint the dock
+ * tile from their own stale copy on close. See
+ * `AGENTS.md` ➜ "Cross-bundle state".
+ */
+interface BadgeState {
+	current: number;
+	// High-water mark for "did anything change since I last asked".
+	// Bumped from heartbeat responses + chromeless-iframe
+	// postMessages. Initialised to `Date.now()` on `start()` so a
+	// delete that happened before the page loaded doesn't replay
+	// through the fast-path subscriber on first paint.
+	seenTs: number;
+	started: boolean;
+	countUrl: string;
+}
+const store = createSharedStore< BadgeState >(
+	'desktop-mode/recycle-bin/badge',
+	() => ( {
+		current: 0,
+		seenTs: 0,
+		started: false,
+		countUrl: '',
+	} ),
+);
 
 /**
  * Set the bin's badge to an absolute count. Idempotent: the same
@@ -95,8 +119,8 @@ let _countUrl = '';
  */
 export function setRecycleBinBadge( next: number ): void {
 	const safe = Math.max( 0, Math.floor( next ) );
-	const prev = _current;
-	_current = safe;
+	const prev = store.state.current;
+	store.state.current = safe;
 	log( 'setRecycleBinBadge', { prev, next: safe } );
 	paintBadge( safe );
 }
@@ -113,7 +137,7 @@ export function setRecycleBinBadge( next: number ): void {
  * @param delta Signed integer; clamped at zero.
  */
 export function adjustRecycleBinBadge( delta: number ): void {
-	setRecycleBinBadge( _current + delta );
+	setRecycleBinBadge( store.state.current + delta );
 }
 
 /**
@@ -122,7 +146,7 @@ export function adjustRecycleBinBadge( delta: number ): void {
  * @internal
  */
 export function _currentRecycleBinBadge(): number {
-	return _current;
+	return store.state.current;
 }
 
 /**
@@ -135,7 +159,7 @@ export function _currentRecycleBinBadge(): number {
  * Honours the framework "show 0 when my window is active" UX
  * policy: when the user is currently looking at the bin window,
  * the badge renders as 0 so we don't double-signal. The internal
- * `_current` count is preserved either way; closing or
+ * `store.state.current` count is preserved either way; closing or
  * minimising the window restores the visible badge on the next
  * lifecycle event (see {@link wireWindowLifecycleSignals}).
  *
@@ -209,7 +233,7 @@ export function startRecycleBinBadge(
 	log( 'startRecycleBinBadge entry', {
 		initial,
 		countUrl,
-		alreadyStarted: _started,
+		alreadyStarted: store.state.started,
 		cfgCount,
 		cfgUrl,
 		cfgDebug,
@@ -233,13 +257,13 @@ export function startRecycleBinBadge(
 			{ cfg },
 		);
 	}
-	if ( _started ) {
+	if ( store.state.started ) {
 		setRecycleBinBadge( initial );
 		return;
 	}
-	_started = true;
-	_countUrl = countUrl;
-	_seenTs = Date.now();
+	store.state.started = true;
+	store.state.countUrl = countUrl;
+	store.state.seenTs = Date.now();
 	setRecycleBinBadge( initial );
 
 	// Both targets render asynchronously after init: the dock
@@ -264,7 +288,7 @@ export function startRecycleBinBadge(
  * `wp.desktop.windowManager.isActive()` and renders 0 while the
  * user is looking at the window, so transitions need to trigger
  * a re-paint to apply or undo that suppression. Internal count
- * (`_current`) doesn't change here — only the rendered DOM
+ * (`store.state.current`) doesn't change here — only the rendered DOM
  * value.
  */
 function wireWindowLifecycleSignals(): void {
@@ -274,7 +298,7 @@ function wireWindowLifecycleSignals(): void {
 		if ( detail?.windowId !== TARGET_ID ) {
 			return;
 		}
-		paintBadge( _current );
+		paintBadge( store.state.current );
 	};
 	addAction( HOOKS.WINDOW_OPENED, ns, repaint );
 	addAction( HOOKS.WINDOW_FOCUSED, ns, repaint );
@@ -296,7 +320,7 @@ function wireDockTileSignal(): void {
 		'desktop-mode/recycle-bin/badge',
 		( payload: { id?: string } ) => {
 			if ( payload?.id === TARGET_ID ) {
-				paintBadge( _current );
+				paintBadge( store.state.current );
 			}
 		},
 	);
@@ -316,7 +340,7 @@ function wireDesktopIconsSignal(): void {
 		'desktop-mode/recycle-bin/badge',
 		( payload: { ids?: string[] } ) => {
 			if ( payload?.ids?.includes( TARGET_ID ) ) {
-				paintBadge( _current );
+				paintBadge( store.state.current );
 			}
 		},
 	);
@@ -383,12 +407,12 @@ function wirePostMessageFastPath(): void {
 			return;
 		}
 		const ts = typeof data.ts === 'number' ? data.ts : Date.now();
-		if ( ts <= _seenTs ) {
-			log( 'postMessage skipped (ts <= seenTs)', { ts, seenTs: _seenTs } );
+		if ( ts <= store.state.seenTs ) {
+			log( 'postMessage skipped (ts <= seenTs)', { ts, seenTs: store.state.seenTs } );
 			return;
 		}
-		log( 'postMessage triggers refetch', { ts, prevSeenTs: _seenTs } );
-		_seenTs = ts;
+		log( 'postMessage triggers refetch', { ts, prevSeenTs: store.state.seenTs } );
+		store.state.seenTs = ts;
 		void refetchCount();
 	} );
 }
@@ -418,7 +442,7 @@ function wireHeartbeatProbe(): void {
 	$( document ).on( 'heartbeat-send', ( ...args: unknown[] ) => {
 		const data = args[ 1 ] as Record< string, unknown > | undefined;
 		if ( data ) {
-			data[ HEARTBEAT_FIELD ] = _seenTs;
+			data[ HEARTBEAT_FIELD ] = store.state.seenTs;
 		}
 	} );
 	$( document ).on( 'heartbeat-tick', ( ...args: unknown[] ) => {
@@ -435,8 +459,8 @@ function wireHeartbeatProbe(): void {
 		if ( ! block ) {
 			return;
 		}
-		if ( typeof block.ts === 'number' && block.ts > _seenTs ) {
-			_seenTs = block.ts;
+		if ( typeof block.ts === 'number' && block.ts > store.state.seenTs ) {
+			store.state.seenTs = block.ts;
 		}
 		if ( typeof block.count === 'number' ) {
 			setRecycleBinBadge( block.count );
@@ -452,13 +476,13 @@ function wireHeartbeatProbe(): void {
  * URL), the heartbeat path will resync within the next tick.
  */
 async function refetchCount(): Promise< void > {
-	if ( ! _countUrl ) {
+	if ( ! store.state.countUrl ) {
 		log( 'refetchCount: no countUrl, skip' );
 		return;
 	}
-	log( 'refetchCount: hitting', _countUrl );
+	log( 'refetchCount: hitting', store.state.countUrl );
 	try {
-		const response = await fetch( _countUrl, {
+		const response = await fetch( store.state.countUrl, {
 			credentials: 'same-origin',
 			headers: { Accept: 'application/json' },
 		} );

--- a/src/recycle-bin/empty-loop.ts
+++ b/src/recycle-bin/empty-loop.ts
@@ -1,0 +1,85 @@
+/**
+ * Recycle Bin — empty-loop driver.
+ *
+ * The server caps `desktop_mode_recycle_bin_empty()` at one chunk per
+ * call (default 200 items) to avoid PHP timeouts on large bins. The
+ * client therefore has to iterate until the server reports
+ * `remaining === 0`. This helper owns that loop in isolation so the
+ * window code can stay focused on UI wiring AND so we can unit-test
+ * the iteration shape without spinning up a JSDOM table.
+ *
+ * Termination rules (in order):
+ *
+ *   1. `remaining === 0` — bin is empty, we're done.
+ *   2. `purged === 0 && skipped > 0` — every item left is
+ *      capability-blocked; further calls just re-skip the same set.
+ *   3. Hard iteration ceiling (1000) — last-resort guard against a
+ *      buggy server whose `remaining` never decreases despite
+ *      `purged > 0`. Far above any realistic bin size.
+ *
+ * @since 0.21.1
+ */
+
+import type { EmptyResponse } from './rest';
+
+export interface EmptyProgress {
+	/** Items purged across all calls so far. */
+	purged: number;
+	/** Items skipped across all calls so far. */
+	skipped: number;
+	/** Snapshot of `purged + remaining` taken on the first call. */
+	initialTotal: number;
+}
+
+export interface EmptyLoopResult extends EmptyProgress {
+	/** Final `remaining` reported by the server on the last call. */
+	remaining: number;
+	/** Reason the loop stopped — useful for tests + observability. */
+	stoppedBecause: 'empty' | 'no-progress' | 'iteration-cap';
+}
+
+export interface EmptyLoopOptions {
+	/** Per-iteration server call. Injected so tests can stub it. */
+	emptyBin: () => Promise< EmptyResponse >;
+	/** Optional progress callback fired after every server call. */
+	onProgress?: ( progress: EmptyProgress ) => void;
+	/** Hard iteration cap. Defaults to 1000. */
+	maxIterations?: number;
+}
+
+const DEFAULT_MAX_ITERATIONS = 1000;
+
+export async function runEmptyLoop(
+	options: EmptyLoopOptions,
+): Promise< EmptyLoopResult > {
+	const { emptyBin, onProgress, maxIterations = DEFAULT_MAX_ITERATIONS } = options;
+
+	let purged = 0;
+	let skipped = 0;
+	let initialTotal = 0;
+	let remaining = 0;
+	let stoppedBecause: EmptyLoopResult[ 'stoppedBecause' ] = 'iteration-cap';
+
+	for ( let i = 0; i < maxIterations; i++ ) {
+		// eslint-disable-next-line no-await-in-loop
+		const result = await emptyBin();
+		purged += result.purged;
+		skipped += result.skipped;
+		remaining = result.remaining;
+		if ( i === 0 ) {
+			initialTotal = purged + result.remaining;
+		}
+		onProgress?.( { purged, skipped, initialTotal } );
+
+		if ( result.remaining === 0 ) {
+			stoppedBecause = 'empty';
+			break;
+		}
+		if ( result.purged === 0 && result.skipped > 0 ) {
+			stoppedBecause = 'no-progress';
+			break;
+		}
+	}
+
+	return { purged, skipped, initialTotal, remaining, stoppedBecause };
+}

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -19,6 +19,7 @@
 
 import { __, sprintf } from '../i18n';
 import { setRecycleBinBadge } from './badge';
+import { runEmptyLoop } from './empty-loop';
 import * as realtime from './realtime';
 import {
 	emptyBin,
@@ -603,6 +604,67 @@ export function renderRecycleBin( body: HTMLElement ): void {
 		await refresh();
 	};
 
+	const emptyButton = root.querySelector< HTMLElement >( EMPTY_BTN );
+
+	// Wrap the existing trailing text node in a span so we can swap
+	// the label during the empty loop without wiping the leading icon.
+	// The PHP template emits `<wpd-button><span dashicon/> Empty bin</wpd-button>`;
+	// the trailing text node is the last child after the icon span.
+	let emptyButtonLabelEl: HTMLSpanElement | null = null;
+	let emptyButtonOriginalLabel = '';
+	if ( emptyButton ) {
+		const trailingText = Array.from( emptyButton.childNodes ).find(
+			( n ): n is Text =>
+				n.nodeType === Node.TEXT_NODE &&
+				( n.textContent ?? '' ).trim() !== '',
+		);
+		emptyButtonOriginalLabel = ( trailingText?.textContent ?? '' ).trim();
+		emptyButtonLabelEl = document.createElement( 'span' );
+		emptyButtonLabelEl.setAttribute(
+			'data-desktop-mode-recycle-bin-empty-label',
+			'',
+		);
+		emptyButtonLabelEl.textContent = emptyButtonOriginalLabel;
+		if ( trailingText ) {
+			trailingText.replaceWith( emptyButtonLabelEl );
+		} else {
+			emptyButton.appendChild( emptyButtonLabelEl );
+		}
+	}
+
+	/**
+	 * Update the Empty bin button to reflect in-progress emptying.
+	 *
+	 * `<wpd-button>` slots its children; we only swap the label span
+	 * (created above) so the leading dashicon and any other slotted
+	 * markup survive intact.
+	 */
+	const setEmptyButtonState = (
+		mode: 'idle' | 'progress' | 'starting',
+		purged = 0,
+		total = 0,
+	): void => {
+		if ( ! emptyButton || ! emptyButtonLabelEl ) {
+			return;
+		}
+		if ( mode === 'idle' ) {
+			emptyButton.removeAttribute( 'disabled' );
+			emptyButton.removeAttribute( 'aria-busy' );
+			emptyButtonLabelEl.textContent = emptyButtonOriginalLabel;
+			return;
+		}
+		emptyButton.setAttribute( 'disabled', '' );
+		emptyButton.setAttribute( 'aria-busy', 'true' );
+		emptyButtonLabelEl.textContent = mode === 'starting' || total === 0
+			? __( 'Emptying…' )
+			: sprintf(
+				/* translators: 1: items purged so far, 2: items in bin when emptying began. */
+				__( 'Emptying… %1$d of %2$d' ),
+				purged,
+				total,
+			);
+	};
+
 	const handleEmpty = async (): Promise< void > => {
 		// eslint-disable-next-line no-alert
 		const ok = window.confirm(
@@ -618,19 +680,30 @@ export function renderRecycleBin( body: HTMLElement ): void {
 		const allTypes = Array.from(
 			new Set( ( table.data ?? [] ).map( ( r ) => r.type ) ),
 		);
+
+		// The server caps each call at a chunk size (default 200) to
+		// avoid PHP timeouts. The loop driver iterates until the bin
+		// is empty (or no progress is possible because every leftover
+		// item is capability-blocked).
+		setEmptyButtonState( 'starting' );
 		try {
-			const result = await emptyBin();
+			const loop = await runEmptyLoop( {
+				emptyBin,
+				onProgress: ( { purged, initialTotal } ) =>
+					setEmptyButtonState( 'progress', purged, initialTotal ),
+			} );
+
 			emitDoneEvent(
 				'empty',
-				new Array( result.purged ).fill( 0 ),
-				result.skipped > 0
+				new Array( loop.purged ).fill( 0 ),
+				loop.skipped > 0
 					? [ {
 						id: 0,
 						code: 'desktop_mode_recycle_bin_skipped',
 						message: sprintf(
 							/* translators: %d: skipped count. */
 							__( '%d item(s) skipped (insufficient permissions).' ),
-							result.skipped,
+							loop.skipped,
 						),
 					} ]
 					: [],
@@ -639,6 +712,8 @@ export function renderRecycleBin( body: HTMLElement ): void {
 			);
 		} catch ( err ) {
 			console.error( '[recycle-bin] empty failed', err );
+		} finally {
+			setEmptyButtonState( 'idle' );
 		}
 		await refresh();
 	};

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -710,6 +710,14 @@ export function renderRecycleBin( body: HTMLElement ): void {
 				allTypes,
 				[],
 			);
+
+			// Optimistic badge zero: emitDoneEvent + refresh() both
+			// reconcile via REST round-trips, so without this the badge
+			// shows the pre-empty count for ~hundreds of ms after the
+			// bin is empty. refresh() below sets the authoritative value.
+			if ( loop.stoppedBecause === 'empty' ) {
+				setRecycleBinBadge( 0 );
+			}
 		} catch ( err ) {
 			console.error( '[recycle-bin] empty failed', err );
 		} finally {

--- a/tests/phpunit/tests/recycleBinStore.php
+++ b/tests/phpunit/tests/recycleBinStore.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests for the Recycle Bin store helpers.
+ *
+ * Focuses on `desktop_mode_recycle_bin_empty()` — specifically the
+ * per-call chunk cap (issue #97). The function MUST keep its cap
+ * (so a 10k-item bin doesn't blow PHP's max_execution_time on a
+ * single REST call) AND MUST report `remaining > 0` so the client
+ * can iterate.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ */
+class Tests_DesktopMode_RecycleBinStore extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'desktop_mode_recycle_bin_empty_chunk_size' );
+		parent::tear_down();
+	}
+
+	private function trash_n_posts( int $n ): array {
+		$ids = array();
+		for ( $i = 0; $i < $n; $i++ ) {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_status' => 'publish',
+					'post_title'  => 'trash-target-' . $i,
+				)
+			);
+			wp_trash_post( $post_id );
+			$ids[] = $post_id;
+		}
+		return $ids;
+	}
+
+	/**
+	 * @covers ::desktop_mode_recycle_bin_empty
+	 */
+	public function test_single_call_purges_at_most_one_chunk_and_reports_remaining() {
+		// 250 trashed items — well over the 200 default chunk size.
+		$this->trash_n_posts( 250 );
+
+		$result = desktop_mode_recycle_bin_empty();
+
+		$this->assertSame( 200, $result['purged'], 'Should cap at the chunk size.' );
+		$this->assertSame( 0, $result['skipped'] );
+		$this->assertSame(
+			50,
+			$result['remaining'],
+			'Should report 50 items still in the bin so the client can loop.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_recycle_bin_empty
+	 */
+	public function test_iterating_until_remaining_is_zero_empties_the_bin() {
+		$this->trash_n_posts( 250 );
+
+		$total_purged = 0;
+		$loops        = 0;
+		do {
+			$result        = desktop_mode_recycle_bin_empty();
+			$total_purged += $result['purged'];
+			$loops++;
+			$this->assertLessThanOrEqual(
+				5,
+				$loops,
+				'Two chunks should be enough; bail out before pinning the test.'
+			);
+		} while ( $result['remaining'] > 0 );
+
+		$this->assertSame( 250, $total_purged );
+		$this->assertSame( 0, $result['remaining'] );
+
+		// Sanity check — the bin really is empty now.
+		$after = desktop_mode_recycle_bin_get_items( array( 'per_page' => 1 ) );
+		$this->assertSame( 0, $after['total'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_recycle_bin_empty
+	 */
+	public function test_chunk_size_filter_is_honored() {
+		$this->trash_n_posts( 30 );
+		add_filter(
+			'desktop_mode_recycle_bin_empty_chunk_size',
+			static function () {
+				return 10;
+			}
+		);
+
+		$result = desktop_mode_recycle_bin_empty();
+
+		$this->assertSame( 10, $result['purged'], 'Filter should override the default chunk size.' );
+		$this->assertSame( 20, $result['remaining'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_recycle_bin_empty
+	 */
+	public function test_chunk_size_filter_floors_to_one() {
+		$this->trash_n_posts( 3 );
+		add_filter(
+			'desktop_mode_recycle_bin_empty_chunk_size',
+			static function () {
+				return 0;
+			}
+		);
+
+		$result = desktop_mode_recycle_bin_empty();
+
+		// Zero or negative should not freeze — clamp to 1.
+		$this->assertSame( 1, $result['purged'] );
+		$this->assertSame( 2, $result['remaining'] );
+	}
+}

--- a/tests/vitest/recycle-bin-empty-loop.test.ts
+++ b/tests/vitest/recycle-bin-empty-loop.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the recycle-bin empty-loop driver.
+ *
+ * The server caps each `desktop_mode_recycle_bin_empty` call at a
+ * chunk (default 200) to avoid PHP timeouts. Issue #97 was that the
+ * client called the endpoint exactly once and showed success — so a
+ * 250-item bin appeared "emptied" with 50 items still in it. The
+ * loop driver fixes that by iterating while `remaining > 0` and
+ * surfacing intermediate progress.
+ *
+ * @group recycle-bin
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import { runEmptyLoop } from '../../src/recycle-bin/empty-loop';
+import type { EmptyResponse } from '../../src/recycle-bin/rest';
+
+function makeChunkedServer( total: number, chunkSize: number ) {
+	let purgedSoFar = 0;
+	const calls: number[] = [];
+	const emptyBin = vi.fn( async (): Promise< EmptyResponse > => {
+		const remainingBefore = total - purgedSoFar;
+		const purged = Math.min( chunkSize, remainingBefore );
+		purgedSoFar += purged;
+		calls.push( purged );
+		return {
+			purged,
+			skipped: 0,
+			remaining: total - purgedSoFar,
+		};
+	} );
+	return { emptyBin, calls };
+}
+
+describe( 'runEmptyLoop', () => {
+	test( 'iterates until remaining is zero (250-item bin, 200-item chunks)', async () => {
+		const { emptyBin } = makeChunkedServer( 250, 200 );
+
+		const result = await runEmptyLoop( { emptyBin } );
+
+		expect( emptyBin ).toHaveBeenCalledTimes( 2 );
+		expect( result.purged ).toBe( 250 );
+		expect( result.remaining ).toBe( 0 );
+		expect( result.stoppedBecause ).toBe( 'empty' );
+	} );
+
+	test( 'completes a one-shot empty bin in a single call', async () => {
+		const { emptyBin } = makeChunkedServer( 50, 200 );
+
+		const result = await runEmptyLoop( { emptyBin } );
+
+		expect( emptyBin ).toHaveBeenCalledTimes( 1 );
+		expect( result.purged ).toBe( 50 );
+		expect( result.stoppedBecause ).toBe( 'empty' );
+	} );
+
+	test( 'reports incremental progress to the UI callback', async () => {
+		const { emptyBin } = makeChunkedServer( 500, 200 );
+		const progress: Array< { purged: number; initialTotal: number } > = [];
+
+		await runEmptyLoop( {
+			emptyBin,
+			onProgress: ( p ) =>
+				progress.push( { purged: p.purged, initialTotal: p.initialTotal } ),
+		} );
+
+		expect( progress ).toEqual( [
+			{ purged: 200, initialTotal: 500 },
+			{ purged: 400, initialTotal: 500 },
+			{ purged: 500, initialTotal: 500 },
+		] );
+	} );
+
+	test( 'stops when no progress is possible (everything skipped)', async () => {
+		// Server always reports 200 skipped items the user cannot purge.
+		const emptyBin = vi.fn(
+			async (): Promise< EmptyResponse > => ( {
+				purged: 0,
+				skipped: 200,
+				remaining: 200,
+			} ),
+		);
+
+		const result = await runEmptyLoop( { emptyBin } );
+
+		expect( emptyBin ).toHaveBeenCalledTimes( 1 );
+		expect( result.skipped ).toBe( 200 );
+		expect( result.stoppedBecause ).toBe( 'no-progress' );
+	} );
+
+	test( 'still makes progress on partial-skip chunks', async () => {
+		// First call: 199 purged, 1 skipped, 1 still remaining.
+		// Second call: that final 1 also gets skipped — bail.
+		let n = 0;
+		const emptyBin = vi.fn( async (): Promise< EmptyResponse > => {
+			n++;
+			if ( n === 1 ) {
+				return { purged: 199, skipped: 1, remaining: 1 };
+			}
+			return { purged: 0, skipped: 1, remaining: 1 };
+		} );
+
+		const result = await runEmptyLoop( { emptyBin } );
+
+		expect( emptyBin ).toHaveBeenCalledTimes( 2 );
+		expect( result.purged ).toBe( 199 );
+		expect( result.skipped ).toBe( 2 );
+		expect( result.stoppedBecause ).toBe( 'no-progress' );
+	} );
+
+	test( 'respects the iteration cap to guard against a buggy server', async () => {
+		// Server lies: claims it purged something but never reduces
+		// `remaining`. Without a cap, the loop would never exit.
+		const emptyBin = vi.fn(
+			async (): Promise< EmptyResponse > => ( {
+				purged: 1,
+				skipped: 0,
+				remaining: 9999,
+			} ),
+		);
+
+		const result = await runEmptyLoop( { emptyBin, maxIterations: 5 } );
+
+		expect( emptyBin ).toHaveBeenCalledTimes( 5 );
+		expect( result.stoppedBecause ).toBe( 'iteration-cap' );
+	} );
+} );


### PR DESCRIPTION
## Summary

`desktop_mode_recycle_bin_empty()` previously fetched one page of 200 items and returned success even when more items remained. Users with a >200-item bin saw a "success" toast next to a still-non-empty bin.

The 200-item per-call cap is intentional (PHP timeout protection on huge bins), so the fix keeps the cap but makes it filterable, has the client iterate until done, and surfaces progress to the user.

## Changes

### Server (`includes/recycle-bin/store.php`)

- `desktop_mode_recycle_bin_empty()` now reads its chunk cap via the new `desktop_mode_recycle_bin_empty_chunk_size` filter (default 200, floored to 1).
- Doc comments expanded so callers know the function is one-chunk-per-call by design.

### Client (new `src/recycle-bin/empty-loop.ts` + updates to `src/recycle-bin/index.ts`)

- New `runEmptyLoop()` driver that calls the server until `remaining === 0`, bails on no-progress (`purged === 0 && skipped > 0` means every leftover is capability-blocked), with a 1000-iteration safety ceiling.
- `handleEmpty()` now delegates to `runEmptyLoop`. While running, the Empty bin button gets `disabled` + `aria-busy` and its label cycles "Emptying..." then "Emptying... N of M". Slotted dashicon preserved by mutating only a trailing span.

### Tests

- `tests/phpunit/tests/recycleBinStore.php` (new): 250-item case (single call leaves `remaining > 0`), iterate-to-empty case, filter honored, floor-to-1.
- `tests/vitest/recycle-bin-empty-loop.test.ts` (new): 250-item-with-200-chunk, single-call completion, progress callback ordering, no-progress bail, partial-skip iteration, iteration-cap guard.

### Docs

- `docs/hooks-reference.md`: new filter entry next to the other recycle-bin filters.

## Verified

- `npm run build` clean
- `npm run lint` clean
- `tsc --noEmit` clean
- `npm run test:js`: 88 files / 809 tests pass (includes 6 new vitest cases)
- PHP unit tests not run locally; covered by CI

## Open question

Used `@since 0.21.1` for the new filter to match the aspirational versioning already in `store.php` (the file uses 0.19.0/0.21.0 even though the plugin is at 0.7.2). Easy to change if a different label is preferred.

Closes #97

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-101-bee4a1c0748881d28ce57734e4abd311b7d59425.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->