### PR TITLE
Render admin-bar discovery toggle for fresh admins

### DIFF
--- a/docs/examples/gate-by-role.md
+++ b/docs/examples/gate-by-role.md
@@ -27,7 +27,9 @@ add_filter( 'desktop_mode_mode_enabled', function ( $enabled, $user_id ) {
 Returning `false` has two effects:
 
 1. The **AJAX save** endpoint refuses to flip the user meta to `'1'` (it returns `desktop_mode_disabled`).
-2. Any existing `'1'` value is ignored — `desktop_mode_is_enabled()` returns `false` for this user.
+2. The **admin-bar "Switch to Desktop Mode"** discovery toggle is hidden for users whose desktop mode is currently off — they don't see a button that would do nothing.
+
+Users who *already* have desktop mode enabled (`desktop_mode_mode` user-meta is `'1'`) keep seeing the toggle so they can always switch back to classic admin, even if the filter flips to `false` mid-session.
 
 ## Disable the portal auto-enable too
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -365,7 +365,7 @@ do_action( 'desktop_mode_prepare_window', string $page, array $args );
 
 ### `desktop_mode_mode_enabled` — Stable
 
-Gates whether desktop mode can be activated (or stay active) for a given user. The AJAX save endpoint consults this after the nonce check.
+Gates whether desktop mode can be activated (or stay active) for a given user. The AJAX save endpoint consults this after the nonce check; the admin-bar discovery toggle consults it before rendering so users who can't enable the feature don't see a button that does nothing.
 
 ```php
 apply_filters( 'desktop_mode_mode_enabled', bool $enabled, int $user_id );
@@ -382,7 +382,12 @@ add_filter( 'desktop_mode_mode_enabled', function ( $enabled, $user_id ) {
 }, 10, 2 );
 ```
 
-A `false` return means the user cannot toggle the mode on — the AJAX endpoint returns `desktop_mode_disabled`.
+A `false` return has these effects:
+
+- The AJAX `save-desktop-mode` endpoint refuses to flip the user's preference and returns `desktop_mode_disabled`.
+- The "Switch to Desktop Mode" admin-bar entry is hidden for users whose desktop mode is currently off.
+
+Users who already have desktop mode active (`desktop_mode_mode = '1'`) still see the admin-bar entry so they can switch back to classic admin — otherwise a filter flipped to `false` mid-session would trap them in the shell with no exit affordance.
 
 ---
 

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -25,6 +25,34 @@ function desktop_mode_admin_bar_toggle( $wp_admin_bar ) {
 		return;
 	}
 
+	// Discovery affordance: render the toggle for any user who could
+	// actually use desktop mode, regardless of whether their
+	// `desktop_mode_mode` user meta is set yet. Without this, a freshly-
+	// activated plugin offers no on-screen path into the shell — the
+	// only entry point would be the `/desktop-mode/` portal URL, which
+	// the user has to already know.
+	//
+	// Cap + filter mirror the AJAX `save-desktop-mode` endpoint and the
+	// `/desktop-mode/` portal: `read` is the minimum cap every admin-
+	// visible role carries, and `desktop_mode_mode_enabled` is the
+	// documented surface plugins use to gate the feature by role
+	// (see docs/examples/gate-by-role.md). A user who fails either gate
+	// can't flip the toggle anyway — surfacing it to them would render
+	// a button that does nothing.
+	//
+	// Users who already have desktop mode enabled still see the toggle
+	// even if a later filter would gate them out — so they can always
+	// switch back to classic admin. Without this carve-out a plugin
+	// that flips `desktop_mode_mode_enabled` to false mid-session would
+	// trap users in the shell with no UI affordance to leave.
+	$user_id  = get_current_user_id();
+	$can_use  = desktop_mode_is_enabled()
+		|| ( current_user_can( 'read' )
+			&& (bool) apply_filters( 'desktop_mode_mode_enabled', true, $user_id ) );
+	if ( ! $can_use ) {
+		return;
+	}
+
 	// "Active" means "the user is *currently viewing* desktop mode",
 	// not "the preference is enabled in user meta." These diverge on
 	// requests carrying the per-request classic override
@@ -288,6 +316,17 @@ add_action( 'admin_bar_menu', 'desktop_mode_admin_bar_toggle', 190 );
  */
 function desktop_mode_enqueue_toggle_assets() {
 	if ( ! is_admin() || ! is_user_logged_in() ) {
+		return;
+	}
+
+	// Mirror the gate inside `desktop_mode_admin_bar_toggle()` — no point
+	// shipping the CSS + click handler to a user who'd never see the
+	// toggle node anyway.
+	$user_id = get_current_user_id();
+	$can_use = desktop_mode_is_enabled()
+		|| ( current_user_can( 'read' )
+			&& (bool) apply_filters( 'desktop_mode_mode_enabled', true, $user_id ) );
+	if ( ! $can_use ) {
 		return;
 	}
 

--- a/tests/phpunit/tests/adminBarDesktopToggle.php
+++ b/tests/phpunit/tests/adminBarDesktopToggle.php
@@ -43,6 +43,7 @@ class Tests_DesktopMode_AdminBarDesktopToggle extends WP_UnitTestCase {
 		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
 		remove_all_filters( 'desktop_mode_shell_config' );
 		remove_all_filters( 'desktop_mode_arrange_menu_items' );
+		remove_all_filters( 'desktop_mode_mode_enabled' );
 		unset( $_GET['desktop_mode_chromeless'] );
 		parent::tear_down();
 	}
@@ -114,6 +115,83 @@ class Tests_DesktopMode_AdminBarDesktopToggle extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'Desktop Mode', $node->title );
 		$this->assertSame( '', $node->meta['class'] );
+	}
+
+	/**
+	 * Discovery affordance — issue #98. A fresh admin (no
+	 * `desktop_mode_mode` meta set) MUST see the "Switch to Desktop
+	 * Mode" entry; otherwise the only entry point is the
+	 * `/desktop-mode/` portal URL the user has to already know.
+	 *
+	 * @covers ::desktop_mode_admin_bar_toggle
+	 */
+	public function test_toggle_renders_for_fresh_admin_without_meta() {
+		wp_set_current_user( self::$admin_id );
+		// No user meta set — the default state for a freshly-activated
+		// plugin.
+		$this->assertSame( '', get_user_meta( self::$admin_id, 'desktop_mode_mode', true ) );
+
+		$bar  = $this->build_admin_bar();
+		$node = $bar->get_node( 'desktop-mode-toggle' );
+
+		$this->assertNotNull( $node, 'Fresh admin should see the discovery toggle.' );
+		$this->assertStringContainsString( 'Desktop Mode', $node->title );
+	}
+
+	/**
+	 * The toggle is gated on `desktop_mode_mode_enabled` so plugins that
+	 * disable the feature for a role (e.g. contributors) don't surface a
+	 * button that would do nothing. Mirrors the AJAX endpoint's gate.
+	 *
+	 * @covers ::desktop_mode_admin_bar_toggle
+	 */
+	public function test_toggle_hidden_when_mode_enabled_filter_returns_false() {
+		wp_set_current_user( self::$admin_id );
+		add_filter( 'desktop_mode_mode_enabled', '__return_false' );
+
+		$bar = $this->build_admin_bar();
+		$this->assertNull( $bar->get_node( 'desktop-mode-toggle' ) );
+	}
+
+	/**
+	 * Carve-out: a user already in desktop mode keeps the toggle even
+	 * when the gate filter would deny them. Without this, a plugin that
+	 * flips `desktop_mode_mode_enabled` to false mid-session would trap
+	 * the user in the shell with no UI affordance to leave.
+	 *
+	 * @covers ::desktop_mode_admin_bar_toggle
+	 */
+	public function test_toggle_renders_for_active_user_even_when_filter_denies() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		add_filter( 'desktop_mode_mode_enabled', '__return_false' );
+
+		$bar  = $this->build_admin_bar();
+		$node = $bar->get_node( 'desktop-mode-toggle' );
+
+		$this->assertNotNull( $node );
+		$this->assertStringContainsString( 'Classic Admin', $node->title );
+	}
+
+	/**
+	 * Subscribers on sites that revoked `read` from admin can't flip
+	 * the toggle (the AJAX endpoint refuses), so we also hide the
+	 * affordance from them. Belt-and-braces — most installs grant
+	 * `read` to every admin-visible role, but the gate matches the
+	 * AJAX side so the two never disagree.
+	 *
+	 * @covers ::desktop_mode_admin_bar_toggle
+	 */
+	public function test_toggle_hidden_for_user_without_read_cap() {
+		$factory = self::factory();
+		$user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		// Revoke `read` so the cap check fails.
+		$user = get_userdata( $user_id );
+		$user->remove_cap( 'read' );
+		wp_set_current_user( $user_id );
+
+		$bar = $this->build_admin_bar();
+		$this->assertNull( $bar->get_node( 'desktop-mode-toggle' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fresh admins had no on-screen discovery path for Desktop Mode after activating the plugin. Investigation showed the admin-bar toggle was actually rendering for all logged-in users, but with no capability gate, so subscribers and roles denied by `desktop_mode_mode_enabled` saw a non-functional toggle.

This PR adds the right capability gate and an active-user carve-out so policy flips can't trap users in the shell.

## Changes

### Capability gate

`current_user_can( 'read' ) && apply_filters( 'desktop_mode_mode_enabled', true, $user_id )` — exactly mirroring the AJAX `save-desktop-mode` endpoint at `includes/ajax.php:23,37` and the `/desktop-mode/` portal at `includes/portal.php:74`.

**Carve-out:** a user who already has Desktop Mode active sees the toggle even if the filter would deny them, so a mid-session policy flip can't trap them in the shell.

### Files

- `includes/admin-bar.php` — gate added to both `desktop_mode_admin_bar_toggle()` and `desktop_mode_enqueue_toggle_assets()` (so we don't ship CSS/JS to a user who has no node).
- `tests/phpunit/tests/adminBarDesktopToggle.php` — 4 new tests:
  - `test_toggle_renders_for_fresh_admin_without_meta` (pins the discovery affordance for #98)
  - `test_toggle_hidden_when_mode_enabled_filter_returns_false`
  - `test_toggle_renders_for_active_user_even_when_filter_denies` (the carve-out)
  - `test_toggle_hidden_for_user_without_read_cap`
  - Plus `remove_all_filters( 'desktop_mode_mode_enabled' )` in `tear_down`.
- `docs/hooks-reference.md` — `desktop_mode_mode_enabled` entry now notes the admin-bar render-side gate and active-user carve-out.
- `docs/examples/gate-by-role.md` — replaced an inaccurate claim (that the filter affects `desktop_mode_is_enabled()` directly) with the actual effects (AJAX refusal + admin-bar hide + active-user carve-out).

## Verified

- `npm run build` clean (5 Vite targets)
- `npm run lint` clean
- `tsc --noEmit` clean
- `npm run test:js`: 803/803 pass
- `php -l` on edited PHP files: no syntax errors

## Open question (separate follow-up)

The doc previously claimed `desktop_mode_is_enabled()` returns false when the filter returns false. It doesn't, the helper only reads user meta. I corrected the doc to match code; if the doc was the intended contract, the helper should consult the filter, but that's a behavior change affecting every render-time gate. Filed as a follow-up.

Closes #98

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-102-6713a0f18042db913a77e9149f1e4e72dd009de6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->