### PR TITLE
Add Exit Desktop Mode affordance to OS Settings → Appearance

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -71,6 +71,7 @@ import { buildAccentSection } from './sections/accent';
 import { buildAiSection } from './sections/ai';
 import { buildDesktopLayoutSection } from './sections/desktop-layout';
 import { buildDockSizeSection } from './sections/dock-size';
+import { buildExitSection } from './sections/exit';
 import { buildExtendedSection } from './sections/extended';
 import { buildFeaturesSection } from './sections/features';
 import { buildDockRailRendererSection } from './sections/dock-rail-renderer';
@@ -362,6 +363,7 @@ export class OsSettings implements SettingsCtx {
 						${ buildDesktopLayoutSection( this ) }
 						${ buildDockSizeSection( this ) }
 						${ buildDockRailRendererSection( this ) }
+						${ buildExitSection() }
 					</wpd-panel>
 				</wpd-tabpanel>`,
 			},

--- a/src/settings/sections/exit.ts
+++ b/src/settings/sections/exit.ts
@@ -1,0 +1,151 @@
+/**
+ * Exit Desktop Mode section — clearly labeled affordance to switch back
+ * to classic WP admin from inside OS Settings.
+ *
+ * Lives at the bottom of the Appearance tab. The admin-bar toggle
+ * (`includes/admin-bar.php` + `assets/js/admin-bar.js`) is the original
+ * exit path; this is a more discoverable mirror of the same action for
+ * users who don't think of the admin bar as "settings."
+ *
+ * Implementation: reuses the existing `save-desktop-mode` admin-ajax
+ * endpoint via the `desktopModeAdminBar` global already published by the
+ * admin-bar inline script (same nonce, same endpoint, same redirect
+ * shape). No new PHP surface, no new REST route. If the global isn't
+ * available for some reason (admin bar suppressed by a third party,
+ * etc.), we fall back to navigating to `adminUrl` from the shell config,
+ * which lands in classic admin and lets the user re-enable on next
+ * load.
+ *
+ * @since 0.18.x
+ */
+
+import { __ } from '../../i18n';
+import { html, render } from '../../ui/core';
+
+/**
+ * Shape of the global published by `includes/admin-bar.php` →
+ * `wp_add_inline_script( 'desktop-mode-admin-bar', 'var desktopModeAdminBar = …' )`.
+ * Matches the consumer in `assets/js/admin-bar.js`.
+ */
+interface DesktopModeAdminBarConfig {
+	nonce?: string;
+	active?: boolean;
+	classicUrl?: string;
+	portalUrl?: string;
+	ajaxUrl?: string;
+}
+
+declare global {
+	interface Window {
+		desktopModeAdminBar?: DesktopModeAdminBarConfig;
+	}
+}
+
+export function buildExitSection(): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.classList.add( 'desktop-mode-os-settings__exit' );
+
+	let busy = false;
+	let error = '';
+
+	const navigate = ( url: string ): void => {
+		// Mirror the admin-bar handler — drive the whole tab, not just
+		// the shell window, in case anything ever embeds OS Settings in
+		// an iframe.
+		try {
+			if ( window.top ) {
+				window.top.location.href = url;
+				return;
+			}
+		} catch {
+			// Cross-origin — fall through.
+		}
+		window.location.href = url;
+	};
+
+	const onClick = (): void => {
+		if ( busy ) {
+			return;
+		}
+		const cfg = window.desktopModeAdminBar;
+		const fallbackUrl =
+			window.desktopModeConfig?.adminUrl || '/wp-admin/';
+
+		// No admin-bar global on the page — best-effort: navigate
+		// straight to classic admin. The user can re-enable from there.
+		// This path also hits when something has actively suppressed
+		// the admin bar (chromeless iframes do, but OS Settings doesn't
+		// run in one).
+		if ( ! cfg || ! cfg.ajaxUrl || ! cfg.nonce ) {
+			navigate( cfg?.classicUrl || fallbackUrl );
+			return;
+		}
+
+		busy = true;
+		error = '';
+		paint();
+
+		const body = new URLSearchParams();
+		body.set( 'action', 'save-desktop-mode' );
+		body.set( 'nonce', cfg.nonce );
+		body.set( 'enabled', '' );
+
+		fetch( cfg.ajaxUrl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			credentials: 'same-origin',
+			body: body.toString(),
+		} )
+			.then( async ( res ) => {
+				if ( ! res.ok ) {
+					throw new Error( `HTTP ${ res.status }` );
+				}
+				const json = ( await res.json().catch( () => null ) ) as
+					| { success?: boolean; data?: { redirect?: string } }
+					| null;
+				const target = json?.data?.redirect || cfg.classicUrl || fallbackUrl;
+				navigate( target );
+			} )
+			.catch( () => {
+				busy = false;
+				error = __(
+					'Could not switch back to classic admin. Check your connection and try again.',
+				);
+				paint();
+			} );
+	};
+
+	const paint = (): void =>
+		render(
+			html`
+				<wpd-section
+					heading=${ __( 'Exit Desktop Mode' ) }
+					description=${ __(
+						'Switch back to the standard WordPress admin. You can return to Desktop Mode from the admin bar at any time.',
+					) }
+				>
+					<wpd-button
+						variant="secondary"
+						?busy=${ busy }
+						?disabled=${ busy }
+						@click=${ onClick }
+					>
+						${ busy
+							? __( 'Switching…' )
+							: __( 'Switch to Classic Admin' ) }
+					</wpd-button>
+					${ error
+						? html`<p class="desktop-mode-os-settings__exit-error" role="alert">
+								${ error }
+							</p>`
+						: html`` }
+				</wpd-section>
+			`,
+			el,
+		);
+
+	paint();
+	return el;
+}


### PR DESCRIPTION
## Summary

The only way to leave Desktop Mode from inside the shell was the admin-bar "Switch to Classic Admin" toggle, easy to miss for users not fluent with the WP admin bar. This PR adds a clearly labeled exit option to OS Settings → Appearance, the most discoverable surface.

## Changes

- New `src/settings/sections/exit.ts` rendering a `<wpd-section>` + `<wpd-button variant="secondary">` at the bottom of the Appearance tab.
- `src/settings/index.ts` imports `buildExitSection` and renders it as the last item inside the Appearance `<wpd-tabpanel>`.
- All UI strings wrapped via `__( ..., 'desktop-mode' )`.

The admin-bar toggle in `includes/admin-bar.php` + `assets/js/admin-bar.js` was NOT touched, both paths coexist.

### Wording

- Section heading: "Exit Desktop Mode"
- Section description: "Switch back to the standard WordPress admin. You can return to Desktop Mode from the admin bar at any time."
- Button label (idle): "Switch to Classic Admin" (matches the admin-bar toggle exactly)
- Button label (busy): "Switching…"
- Error: "Could not switch back to classic admin. Check your connection and try again."

### Implementation note

Reuses the existing `save-desktop-mode` admin-ajax endpoint via the `window.desktopModeAdminBar` global already published by `includes/admin-bar.php` for the admin-bar toggle. Same nonce, same redirect contract. Falls back to navigating to `desktopModeConfig.adminUrl` if the global isn't present.

No new PHP surface (no new shell-config keys, no new REST route, no new nonce).

## Verified

- `npm run build` clean (6 Vite targets)
- `npm run lint` clean
- `tsc --noEmit` clean
- `npm run test:js`: 803 / 87 files all green

## Design choices to confirm

- **Cross-bundle global vs shell config:** leaned on `window.desktopModeAdminBar` (always present on shell pages) instead of adding `exitNonce` + `exitUrl` to `desktop_mode_shell_config`. Lighter touch but couples the OS Settings bundle to the admin-bar bundle's global. Happy to switch to a dedicated config payload if preferred.
- **Variant `secondary` not `danger`:** exiting the shell isn't destructive (no data loss, user can flip back any time), so `danger` would feel alarmist. Easy to adjust.

Closes #99

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-103-b8d0ab38153a4397a1f08eb572528890eb06eede.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->