### PR TITLE
Change the Author name and URI as requested by WordPress.org

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -6,8 +6,8 @@
  * Version:           0.7.2
  * Requires at least: 6.0
  * Requires PHP:      7.4
- * Author:            Daniel López Sánchez
- * Author URI:        https://github.com/allterraindeveloper
+ * Author:            WordPress.org
+ * Author URI:        https://profiles.wordpress.org/wordpressdotorg/
  * License:           GPLv2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       desktop-mode


### PR DESCRIPTION
The plugin author for "Desktop Mode" was requested to be changed to “[WordPress.org](https://profiles.wordpress.org/wordpressdotorg/)”, making the plugin an officially maintained project, similar to Classic Editor or Create Block Theme plugins.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-108-99bd1254e425828291de60de92b2e5f431b9a0f6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->