### PR TITLE
Land Playground blueprint on /desktop-mode/

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,5 +1,5 @@
 {
-  "landingPage": "/wp-admin/",
+  "landingPage": "/desktop-mode/",
   "steps": [
     {
       "step": "login",


### PR DESCRIPTION
## Summary
- Switch the wp.org plugin-directory Playground blueprint to land on `/desktop-mode/` instead of `/wp-admin/`.
- The portal URL auto-enables desktop mode (`update_user_meta( 'desktop_mode_mode', '1' )` in `includes/portal.php`) for the logged-in admin and forwards into the shell, so visitors see the plugin in action immediately rather than having to click the 'Switch to Desktop Mode' button in the admin bar first.

## Test plan
- [x] Verified locally: visiting `http://localhost:8889/desktop-mode/` from a disabled state lands directly in the desktop shell with windows restored, no extra click required.
- [x] After merge, smoke-test the "Live Preview" link on the wp.org plugin directory page to confirm Playground respects `landingPage` and lands in the shell.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-110-0f66d6995713fffb7951dadf2afa94261461531b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->