### PR TITLE
Add 'Exit Desktop Mode' tile to the dock

### DIFF
--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -32,6 +32,7 @@ import {
 	registerDockSelector,
 } from './dock-helpers';
 import { OsSettings } from './settings';
+import { getExitDesktopModeTileDef } from './exit-desktop-mode';
 import { deriveWindowId, urlMatchKey } from './utils';
 import {
 	HOOKS,
@@ -1811,6 +1812,16 @@ function init(): void {
 				},
 				onOpen: openBugReport,
 			},
+			'core',
+		);
+
+		// Exit Desktop Mode tile — last on the core rail so users have
+		// a discoverable in-shell way out, complementing the admin-bar
+		// "Switch to Classic Admin" toggle. Reuses the existing
+		// save-desktop-mode AJAX endpoint via the
+		// `window.desktopModeAdminBar` global; no new PHP surface.
+		layoutDispatcher.appendSystemTile(
+			getExitDesktopModeTileDef(),
 			'core',
 		);
 	}

--- a/src/exit-desktop-mode.ts
+++ b/src/exit-desktop-mode.ts
@@ -1,0 +1,109 @@
+/**
+ * Exit Desktop Mode dock tile.
+ *
+ * Builds the {@link SystemDockItem} for the "Exit Desktop Mode" entry on
+ * the primary dock rail and the click handler that disables the user's
+ * desktop-mode preference and routes them back to classic admin.
+ *
+ * Reuses the existing `save-desktop-mode` AJAX endpoint
+ * (`includes/ajax.php`) via the `window.desktopModeAdminBar` global
+ * already published by `includes/admin-bar.php` for the admin-bar
+ * toggle. Same nonce, same redirect contract — no new PHP surface.
+ *
+ * @since 0.7.3
+ */
+
+import type { SystemDockItem } from './dock';
+import { __ } from './i18n';
+
+export const EXIT_DESKTOP_MODE_TILE_ID = 'desktop-mode-exit';
+
+interface AdminBarConfig {
+	nonce?: string;
+	classicUrl?: string;
+	ajaxUrl?: string;
+}
+
+declare global {
+	interface Window {
+		desktopModeAdminBar?: AdminBarConfig;
+	}
+}
+
+/**
+ * Build the dock-tile definition. Kept as a factory so desktop.ts can
+ * register it the same way the OS Settings / Bug Report / PWA install
+ * tiles are registered, and so the click logic stays unit-testable.
+ */
+export function getExitDesktopModeTileDef(): SystemDockItem {
+	return {
+		id: EXIT_DESKTOP_MODE_TILE_ID,
+		title: __( 'Exit Desktop Mode' ),
+		// `dashicons-exit` (door with arrow) is the clearest "leave"
+		// glyph in the WordPress set, distinct from `dashicons-desktop`
+		// used by OS Settings.
+		icon: 'dashicons-exit',
+		onOpen: () => {
+			void exitDesktopMode();
+		},
+	};
+}
+
+/**
+ * Disable the user's desktop-mode preference, then navigate the top
+ * window to the redirect URL the server returns (or `classicUrl` if
+ * the response is missing one). Mirrors the admin-bar toggle's flow in
+ * `assets/js/admin-bar.js`; if the global is absent for any reason,
+ * falls back to navigating straight to `wp-admin`.
+ */
+export async function exitDesktopMode(): Promise< void > {
+	const cfg = window.desktopModeAdminBar;
+	const fallback = cfg?.classicUrl || '/wp-admin/';
+
+	if ( ! cfg?.ajaxUrl || ! cfg?.nonce ) {
+		navigateTop( fallback );
+		return;
+	}
+
+	const body = new URLSearchParams();
+	body.set( 'action', 'save-desktop-mode' );
+	body.set( 'nonce', cfg.nonce );
+	body.set( 'enabled', '' );
+
+	let target = fallback;
+	try {
+		const res = await fetch( cfg.ajaxUrl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: body.toString(),
+			credentials: 'same-origin',
+		} );
+		if ( res.ok ) {
+			const json = ( await res.json() ) as
+				| { success?: boolean; data?: { redirect?: string } }
+				| null;
+			if ( json?.success && json.data?.redirect ) {
+				target = json.data.redirect;
+			}
+		}
+	} catch {
+		// Network error — fall through to navigate to the fallback.
+	}
+
+	navigateTop( target );
+}
+
+/**
+ * Drive a full top-window navigation. The dock tile may be hosted in
+ * the shell page (top window) or — in tests / embedded scenarios — in
+ * an iframe; either way we want the whole tab to land on the new URL.
+ */
+function navigateTop( url: string ): void {
+	try {
+		window.top!.location.href = url;
+	} catch {
+		window.location.href = url;
+	}
+}


### PR DESCRIPTION
## Summary

Closes #99 (and supersedes #103).

Adds an "Exit Desktop Mode" tile to the bottom of the primary dock rail, complementing the admin-bar "Switch to Classic Admin" toggle with a more discoverable in-shell affordance. Per discussion on #103 the OS Settings entry was the wrong place; the dock matches user mental model better and reuses an existing API.


<img width="3424" height="2830" alt="CleanShot 2026-05-07 at 13 41 44@2x" src="https://github.com/user-attachments/assets/c6ece521-1c43-46df-a427-76283ae43977" />



## Changes

- **New `src/exit-desktop-mode.ts`**: factory `getExitDesktopModeTileDef()` returns a `SystemDockItem` (id `desktop-mode-exit`, title `__( 'Exit Desktop Mode' )`, icon `dashicons-exit`). The click handler POSTs to the existing `save-desktop-mode` AJAX endpoint via the `window.desktopModeAdminBar` global already published by `includes/admin-bar.php`, then navigates the top window to the redirect the server returns. Falls back to `classicUrl` / `/wp-admin/` if the global is absent.
- **`src/desktop.ts`**: registers the tile via `layoutDispatcher.appendSystemTile( ..., 'core' )` immediately after the Bug Report tile, so it lands at the bottom of the core rail next to OS Settings / PWA install / Bug Report and survives layout rebuilds.

No new PHP surface, no new nonce, no new shell-config keys, no payload-shape changes.

## Verified

- `npm run lint` — clean
- `tsc --noEmit` — clean
- `npm run build` — 6 Vite targets built
- `npm run test:js` — 803 / 87 files all green

## Notes

- POT/PO/JSON regeneration is intentionally NOT in this PR; that's batched as a separate pre-translation step.
- Icon is `dashicons-exit` (door + arrow-out) so it's visually distinct from `dashicons-desktop` (used by OS Settings).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-111-8f69b27eeaf2a3e484235e3089cdc1848d27f8c3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->