### PR TITLE
Feat/intercept wp admin calls

### DIFF
--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -2052,3 +2052,4 @@ JS;
 
 	wp_print_inline_script_tag( $js );
 }
+add_action( 'admin_footer', 'desktop_mode_chromeless_bridge_script' );

--- a/tests/phpunit/tests/desktopModeRender.php
+++ b/tests/phpunit/tests/desktopModeRender.php
@@ -322,6 +322,32 @@ class Tests_DesktopMode_Render extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The bridge script carries the link/form interceptor that keeps
+	 * iframe navigations chromeless. If the function isn't actually
+	 * hooked to admin_footer, the first click on any /wp-admin/ link
+	 * inside an iframe re-renders the full desktop shell inside the
+	 * iframe (inception bug). Calling the function directly in the
+	 * other tests doesn't prove WordPress will call it — only this
+	 * has_action check does.
+	 *
+	 * @covers ::desktop_mode_chromeless_bridge_script
+	 */
+	public function test_chromeless_bridge_is_wired_on_admin_footer() {
+		$this->assertNotFalse(
+			has_action( 'admin_footer', 'desktop_mode_chromeless_bridge_script' )
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_chromeless_offset_neutralizer_script
+	 */
+	public function test_chromeless_offset_neutralizer_is_wired_on_admin_head() {
+		$this->assertNotFalse(
+			has_action( 'admin_head', 'desktop_mode_chromeless_offset_neutralizer_script' )
+		);
+	}
+
+	/**
 	 * @covers ::desktop_mode_chromeless_bridge_script
 	 */
 	public function test_chromeless_after_action_fires_in_iframes() {


### PR DESCRIPTION
The previous refactor missed to call this hook. Added a test for it so it won't happen any more ;)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-118-08c543941fa22e06dd146f6b2da595df97b071a0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->