### PR TITLE
feat: implement cross-page admin link routing in chromeless bridge

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -115,6 +115,24 @@ A native window registered via `wp.desktop.registerWindow({ iframeContent })` is
    - Forwards every message (bridge or not) to `cfg.onMessage?.()` so plugins that want raw access still get it.
 4. On window close, the cleanup chain (passed through `onClose`) calls `unregisterSynth()` so closed windows don't leak.
 
+## Admin link routing inside chromeless iframes
+
+The chromeless bridge intercepts every same-origin `<a href="/wp-admin/…">` click inside an iframe and lets the parent shell decide where the navigation should actually land. The decision lives in the parent because the iframe doesn't know the shell's window slug rules (which query params are identity-bearing, which URLs are remapped to a native window, which already-open window owns the destination, and so on).
+
+| Type | Direction | Carries | Purpose |
+|---|---|---|---|
+| `desktop-mode-iframe-admin-link` | iframe → parent | `{ url }` | Posted from the chromeless bridge's link interceptor for every admin-internal click that survived the modifier-key / target / download filters. The bridge `preventDefault`s the click first; the parent owns the navigation. |
+
+Parent dispatch (in `src/window/iframe-bridge.ts`, wired by `bindAdminLinkDispatch` in `desktop.ts`):
+
+1. **Native-window remap** — the URL goes through `tryNativeUrlRemap`. On a hit the parent opens the native window and closes the source iframe so the brief in-flight nav never paints.
+2. **Same-slug click** — `deriveWindowId(url, adminUrl)` matches the source window's `baseId`. The parent calls `iframe.contentWindow.location.assign(url)`, which navigates the iframe in place AND adds a session-history entry. Pagination, list filtering, and per-window tab strips ride this path.
+3. **Cross-slug click** — slug differs from the source. The parent calls `windowManager.open({ id, baseId, url, title, icon })` with title/icon copied from the matching dock entry (or fallbacks when no dock tile owns the destination). The source iframe is left untouched, so the user keeps both contexts.
+
+Modifier-key clicks (cmd / ctrl / shift / alt, middle-click, `target="_blank"`, `target` other than `_self`, `download` attribute) short-circuit the bridge's interceptor entirely — the browser's native open-in-new-tab path runs unchanged.
+
+Forms submit through a separate `submit` listener that only rewrites the action URL (to keep `desktop_mode_chromeless=1`) and never `preventDefault`s. Same-origin form posts to a different page would currently navigate the iframe in place; if that becomes a UX problem it can join this protocol as a `desktop-mode-iframe-admin-form-submit` message.
+
 ## Public hooks
 
 | Hook | Kind | Status | Payload |

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1024,20 +1024,48 @@ function desktop_mode_menu_item_url( $slug ) {
 	}
 
 	// Plugin page slug with embedded query parameters
-	// (e.g., 'wc-admin&path=/customers'). Split off the extra
-	// query and let `add_query_arg()` rebuild a properly encoded
-	// URL — avoids `rawurlencode()`-ing the `&` and `=`
-	// separators into `%26` / `%3D`.
+	// (e.g., 'wc-admin&path=/customers'). Split the page slug from
+	// the trailing args; we'll resolve the page slug below and
+	// layer the args back on at the end. This avoids the naive
+	// `rawurlencode()` packing the `&` separator into `%26`.
+	$extra_args = array();
 	if ( false !== strpos( $slug, '&' ) ) {
-		list( $page_slug, $extras ) = array_pad( explode( '&', $slug, 2 ), 2, '' );
-		$extra_args                 = array();
-		if ( '' !== $extras ) {
-			parse_str( $extras, $extra_args );
+		list( $slug, $tail ) = array_pad( explode( '&', $slug, 2 ), 2, '' );
+		if ( '' !== $tail ) {
+			parse_str( $tail, $extra_args );
 		}
-		$args = array_merge( array( 'page' => $page_slug ), $extra_args );
-		return esc_url_raw( add_query_arg( $args, admin_url( 'admin.php' ) ) );
 	}
 
-	// Plain plugin page slug — route through admin.php.
-	return esc_url_raw( admin_url( 'admin.php?page=' . rawurlencode( $slug ) ) );
+	// Plain page slug — defer to WordPress's canonical resolver.
+	//
+	// `$_parent_pages` is the same global `menu_page_url()` reads;
+	// we mirror its 4-line decision tree directly so we can return
+	// a `esc_url_raw`-style raw URL (the `menu_page_url()` helper
+	// runs its result through `esc_url()`, which entity-encodes the
+	// `&` separators we need to keep raw for the downstream
+	// `add_query_arg()` and the JS slug compare).
+	//
+	// Resolution rules, identical to core:
+	//   1. Slug registered under a `.php` parent that itself isn't
+	//      a parent (Tools → `tools.php?page=…`, Settings →
+	//      `options-general.php?page=…`).
+	//   2. Slug registered as a top-level menu, OR under a slug-
+	//      based parent (WC: `woocommerce` → `admin.php?page=…`).
+	//   3. Slug not registered at all → fall back to `admin.php`
+	//      so the URL still targets a real dispatcher (matches the
+	//      pre-resolver behavior callers depended on).
+	global $_parent_pages;
+	$host = 'admin.php?page=' . rawurlencode( $slug );
+	if ( isset( $_parent_pages[ $slug ] ) ) {
+		$parent_slug = $_parent_pages[ $slug ];
+		if ( $parent_slug && ! isset( $_parent_pages[ $parent_slug ] ) ) {
+			$host = add_query_arg( 'page', $slug, $parent_slug );
+		}
+	}
+
+	$url = admin_url( $host );
+	if ( ! empty( $extra_args ) ) {
+		$url = add_query_arg( $extra_args, $url );
+	}
+	return esc_url_raw( $url );
 }

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -777,25 +777,54 @@ function desktop_mode_chromeless_bridge_script() {
 				link.setAttribute( 'href', rewritten );
 			}
 			/*
-			 * Tell the parent shell about the click so it can run
-			 * the URL through the native-window remap registry.
-			 * When a remap hits (e.g. `edit.php` with the user's
-			 * native-Posts opt-in on), the parent opens the native
-			 * window and closes this iframe — which is the only
-			 * sensible answer to "Exit editor" / "Back to posts"
-			 * links inside a locked-post takeover dialog. When no
-			 * remap hits, the iframe's natural navigation proceeds.
+			 * Hand admin-internal navigation to the parent shell.
 			 *
-			 * Best-effort: we still let the click proceed, so on
-			 * remap-miss the iframe loads the link as before. On
-			 * remap-hit the iframe gets torn down (window close)
-			 * before the navigation paints, so the brief in-flight
-			 * load is invisible.
+			 * The parent decides what to do with each click:
+			 *
+			 *   - Native-window remap hits (e.g. `edit.php` while the
+			 *     user has the native Posts opt-in on) → parent opens
+			 *     the native window and closes THIS iframe.
+			 *   - Same-page nav (pagination, filtering on the same
+			 *     `edit.php?post_type=page` screen, etc.) → parent
+			 *     drives the iframe's `location.assign()` so the
+			 *     in-place navigation matches the user's intent.
+			 *   - Cross-page nav (e.g. clicking "Posts" from inside
+			 *     the Pages window) → parent opens a new window for
+			 *     the destination and leaves THIS iframe untouched,
+			 *     so the user keeps both contexts.
+			 *
+			 * We `preventDefault()` so the iframe never starts a
+			 * navigation the parent might want to suppress; otherwise
+			 * cross-page clicks would trash the source window before
+			 * the parent had a chance to react. Modifier-key clicks
+			 * (cmd/ctrl/shift/alt, middle-click) are already filtered
+			 * upstream so the browser's native "open in new tab" path
+			 * still works.
 			 */
+			e.preventDefault();
 			try {
 				var absolute = new URL( rewritten || href, window.location.href ).toString();
+				/*
+				 * Ship the link's visible text along with the URL so
+				 * the parent can title a freshly-opened window with
+				 * something the user recognises ("Scheduler") instead
+				 * of the URL slug ("tools-php-page-scheduler") when
+				 * the destination has no dock tile to copy a title
+				 * from. The iframe itself never auto-emits a
+				 * title-change, so without this hint the slug-as-
+				 * title fallback would persist for the lifetime of
+				 * the new window.
+				 */
+				var adminLabel = ( link.textContent || '' ).trim() ||
+					link.getAttribute( 'title' ) ||
+					link.getAttribute( 'aria-label' ) ||
+					'';
 				window.parent.postMessage(
-					{ type: 'desktop-mode-iframe-admin-link', url: absolute },
+					{
+						type: 'desktop-mode-iframe-admin-link',
+						url: absolute,
+						label: adminLabel.slice( 0, 80 )
+					},
 					window.location.origin
 				);
 			} catch ( bridgeErr ) {

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -20,6 +20,7 @@ import {
 	bindNativeUrlRemap,
 	registerNativeUrlRemap,
 } from './native-url-remap';
+import { bindAdminLinkDispatch } from './window/iframe-bridge';
 // Tile-decoration helpers and the dock-selector registry live in
 // `src/dock-helpers.ts` — `src/api/facade.ts` is the only consumer
 // in this bundle since 0.8.1.
@@ -1590,6 +1591,57 @@ function init(): void {
 		getSnapshot: () => osSettings.getOsSettingsSnapshot(),
 		openById: ( id ) => nativeWindows.openById( id ),
 		adminUrl: config.adminUrl,
+	} );
+
+	// Cross-page admin-link dispatcher (since 0.8.2). The chromeless
+	// bridge `preventDefault`s every admin-internal click and posts
+	// `desktop-mode-iframe-admin-link` to us; this binding tells the
+	// bridge how to compute slugs, find a destination's title/icon
+	// from the dock, and open windows. The lookup falls back to the
+	// boot dockItems snapshot before the layout dispatcher exists,
+	// so clicks that race the dispatcher's first paint still resolve
+	// to a sensible window title.
+	const findDockEntryForUrl = (
+		url: string,
+	): import( './window/iframe-bridge' ).AdminLinkDockEntry | null => {
+		const targetSlug = deriveWindowId( url, config.adminUrl );
+		const items = layoutDispatcher
+			? layoutDispatcher.getMenuItems()
+			: ( config.dockItems ?? [] );
+		for ( const item of items ) {
+			if ( deriveWindowId( item.url, config.adminUrl ) === targetSlug ) {
+				return {
+					title: item.title,
+					icon: item.icon,
+					submenu: item.submenu,
+					multi: item.multi,
+				};
+			}
+			for ( const sub of item.submenu ?? [] ) {
+				if (
+					deriveWindowId( sub.url, config.adminUrl ) === targetSlug
+				) {
+					return {
+						title: sub.title,
+						// Sub-menu entries inherit the parent tile's
+						// icon — that's the dock's own convention and
+						// avoids painting a generic glyph on a window
+						// the user knows by its parent's identity.
+						icon: item.icon,
+						multi: item.multi,
+					};
+				}
+			}
+		}
+		return null;
+	};
+	bindAdminLinkDispatch( {
+		adminUrl: config.adminUrl,
+		deriveSlug: ( url ) => deriveWindowId( url, config.adminUrl ),
+		openWindow: ( windowConfig ) => {
+			manager.open( windowConfig );
+		},
+		findDockEntry: findDockEntryForUrl,
 	} );
 
 	// Native Posts window (replaces `edit.php` when the user opts in

--- a/src/window/iframe-bridge.test.ts
+++ b/src/window/iframe-bridge.test.ts
@@ -6,7 +6,7 @@
  * observability tests under `tests/vitest/`.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { handleWindowMessage } from './iframe-bridge';
+import { bindAdminLinkDispatch, handleWindowMessage } from './iframe-bridge';
 import { HOOKS } from '../hooks';
 import type { Window } from './index';
 import {
@@ -202,6 +202,195 @@ describe( 'iframe-bridge: desktop-mode-notification', () => {
 		} );
 
 		expect( document.querySelector( 'wpd-toast' ) ).toBeNull();
+	} );
+} );
+
+describe( 'iframe-bridge: desktop-mode-iframe-admin-link', () => {
+	type DispatchDeps = Parameters< typeof bindAdminLinkDispatch >[ 0 ];
+
+	const adminUrl = window.location.origin + '/wp-admin/';
+
+	function bindFakeDispatcher( overrides: Partial< NonNullable< DispatchDeps > > = {} ) {
+		const openWindow = vi.fn();
+		const findDockEntry = vi.fn().mockReturnValue( null );
+		const deps: NonNullable< DispatchDeps > = {
+			adminUrl,
+			deriveSlug: ( url ) => {
+				const parsed = new URL( url, adminUrl );
+				const path = parsed.pathname.replace( /.*\/wp-admin\//, '' ).replace( /\.php$/, '-php' );
+				const postType = parsed.searchParams.get( 'post_type' );
+				return postType ? `${ path }-post-type-${ postType }` : path;
+			},
+			openWindow,
+			findDockEntry,
+			...overrides,
+		};
+		bindAdminLinkDispatch( deps );
+		return { openWindow, findDockEntry };
+	}
+
+	function mockAdminWindow( opts: { id: string; baseId?: string } ): {
+		win: Window;
+		assignSpy: ReturnType< typeof vi.fn >;
+	} {
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const assignSpy = vi.fn();
+		// JSDOM's `Location.assign` is non-configurable, so swap the
+		// whole `contentWindow` for a stub we control. The bridge
+		// only reads `contentWindow.location.assign` — no other
+		// surface needs to round-trip.
+		const fakeContentWindow = { location: { assign: assignSpy } };
+		Object.defineProperty( iframe, 'contentWindow', {
+			value: fakeContentWindow,
+			configurable: true,
+		} );
+		const element = document.createElement( 'div' );
+		const win = {
+			id: opts.id,
+			element,
+			iframe,
+			config: { baseId: opts.baseId ?? opts.id },
+			onFocusRequest: null,
+			setTitle: vi.fn(),
+			close: vi.fn(),
+		} as unknown as Window;
+		return { win, assignSpy };
+	}
+
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		bindAdminLinkDispatch( null );
+		document.querySelectorAll( 'iframe' ).forEach( ( el ) => el.remove() );
+		clearHooksStub();
+	} );
+
+	test( 'same-slug click drives the source iframe via location.assign', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( {
+			id: 'edit-php-post-type-page',
+		} );
+
+		const target =
+			window.location.origin + '/wp-admin/edit.php?post_type=page&paged=2';
+		postToWindow( win, { type: 'desktop-mode-iframe-admin-link', url: target } );
+
+		expect( assignSpy ).toHaveBeenCalledWith( target );
+		expect( openWindow ).not.toHaveBeenCalled();
+		expect( win.close ).not.toHaveBeenCalled();
+	} );
+
+	test( 'different-slug click opens a fresh window and leaves the source intact', () => {
+		const { openWindow, findDockEntry } = bindFakeDispatcher();
+		findDockEntry.mockReturnValue( {
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			submenu: [],
+			multi: true,
+		} );
+		const { win, assignSpy } = mockAdminWindow( {
+			id: 'edit-php-post-type-page',
+		} );
+
+		const target =
+			window.location.origin + '/wp-admin/edit.php?post_type=post';
+		postToWindow( win, { type: 'desktop-mode-iframe-admin-link', url: target } );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		expect( openWindow.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			id: 'edit-php-post-type-post',
+			baseId: 'edit-php-post-type-post',
+			url: target,
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			multi: true,
+		} );
+		expect( assignSpy ).not.toHaveBeenCalled();
+		expect( win.close ).not.toHaveBeenCalled();
+	} );
+
+	test( 'different-slug click without a dock entry uses the link label as title', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win } = mockAdminWindow( { id: 'edit-php-post-type-page' } );
+
+		const target =
+			window.location.origin +
+			'/wp-admin/options-general.php?page=some-plugin';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+			label: 'Scheduler',
+		} );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		const arg = openWindow.mock.calls[ 0 ][ 0 ];
+		expect( arg.icon ).toBe( 'dashicons-admin-generic' );
+		expect( arg.title ).toBe( 'Scheduler' );
+	} );
+
+	test( 'different-slug click without dock entry or label falls back to slug', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win } = mockAdminWindow( { id: 'edit-php-post-type-page' } );
+
+		const target =
+			window.location.origin +
+			'/wp-admin/options-general.php?page=some-plugin';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		const arg = openWindow.mock.calls[ 0 ][ 0 ];
+		expect( arg.title ).toBe( arg.id );
+	} );
+
+	test( 'dock entry title beats the link label', () => {
+		const { openWindow, findDockEntry } = bindFakeDispatcher();
+		findDockEntry.mockReturnValue( {
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			submenu: [],
+			multi: true,
+		} );
+		const { win } = mockAdminWindow( { id: 'edit-php-post-type-page' } );
+
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: window.location.origin + '/wp-admin/edit.php?post_type=post',
+			label: 'All the posts',
+		} );
+
+		expect( openWindow.mock.calls[ 0 ][ 0 ].title ).toBe( 'Posts' );
+	} );
+
+	test( 'cross-origin URL is silently refused', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( {
+			id: 'edit-php-post-type-page',
+		} );
+
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: 'https://evil.example.com/wp-admin/edit.php',
+		} );
+
+		expect( openWindow ).not.toHaveBeenCalled();
+		expect( assignSpy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'unbound deps drops the click without crashing', () => {
+		// No bindFakeDispatcher() — leave deps null.
+		const { win } = mockAdminWindow( { id: 'edit-php-post-type-page' } );
+
+		expect( () => {
+			postToWindow( win, {
+				type: 'desktop-mode-iframe-admin-link',
+				url: window.location.origin + '/wp-admin/upload.php',
+			} );
+		} ).not.toThrow();
 	} );
 } );
 

--- a/src/window/iframe-bridge.ts
+++ b/src/window/iframe-bridge.ts
@@ -28,6 +28,74 @@ import { tryNativeUrlRemap } from '../native-url-remap';
 const INITIAL_ORIGIN = window.location.origin;
 
 /**
+ * Look-up shape for "title + icon for the dock entry whose URL slug
+ * matches this destination." Returned from `findDockEntry`; consumed
+ * when we have to open a fresh window for a cross-page admin link
+ * click. `null` when no entry matches — the handler falls back to a
+ * generic icon and the destination URL's slug as the title (the new
+ * window's iframe will retitle itself once it loads).
+ */
+export interface AdminLinkDockEntry {
+	title: string;
+	icon: string;
+	submenu?: { title: string; url: string }[];
+	multi?: boolean;
+}
+
+/**
+ * Dependencies for the cross-page admin-link dispatcher. Wired by
+ * `desktop.ts` at boot via {@link bindAdminLinkDispatch}. The bridge
+ * stays a pure router until the deps are bound; while unbound, admin-
+ * link messages are silently ignored (apart from the native-window
+ * remap path, which is dep-free).
+ */
+interface AdminLinkDispatchDeps {
+	/** Shell's admin URL — used as the base for URL parsing. */
+	adminUrl: string;
+	/**
+	 * Compute a window slug from an admin URL. Should match the
+	 * shell's canonical `deriveWindowId( url, adminUrl )`.
+	 */
+	deriveSlug( url: string ): string;
+	/**
+	 * Open (or focus) a window for a destination URL — wraps
+	 * `windowManager.open()` so the bridge module doesn't have to
+	 * import the manager directly.
+	 */
+	openWindow( config: {
+		id: string;
+		baseId: string;
+		url: string;
+		title: string;
+		icon: string;
+		submenu?: { title: string; url: string }[];
+		multi?: boolean;
+	} ): void;
+	/**
+	 * Look up the dock entry whose URL slug matches this destination —
+	 * used to seed the new window's title + icon. Returns `null` when
+	 * nothing matches (link points to a page that has no dock tile,
+	 * e.g. `options-general.php?page=foo` reached from a sub-link).
+	 */
+	findDockEntry( url: string ): AdminLinkDockEntry | null;
+}
+
+let adminLinkDeps: AdminLinkDispatchDeps | null = null;
+
+/**
+ * Wire the cross-page admin-link dispatcher. Called once from
+ * `desktop.ts` after the window manager and dock layout are
+ * constructed. Tests can call this directly to inject fakes.
+ *
+ * @internal
+ */
+export function bindAdminLinkDispatch(
+	deps: AdminLinkDispatchDeps | null,
+): void {
+	adminLinkDeps = deps;
+}
+
+/**
  * Entry point for the `message` event listener the Window binds
  * during `bindEvents`. Filters out foreign-origin and foreign-source
  * events, then dispatches on the `data.type` payload string.
@@ -114,19 +182,31 @@ export function handleWindowMessage( win: Window, event: MessageEvent ): void {
 		);
 	}
 
-	// Best-effort native-window remap on link clicks inside chromeless
-	// iframes. The chromeless bridge posts this for every admin-internal
-	// link click. When the URL maps to a native window (e.g. `edit.php`
-	// → native Posts when the user has the opt-in on, or `users.php` →
-	// the future native Users window), we open the native window AND
-	// close the source iframe. The iframe's natural click was already
-	// in flight when this fires — closing the window destroys the
-	// iframe before any visible navigation paint, which is exactly
-	// what users want when they click "Exit editor" on a locked-post
-	// takeover dialog: don't dump them into classic edit.php inside
-	// the editor window.
+	// Cross-page admin-link dispatch.
 	//
-	// Remap miss → no-op; the iframe finishes its natural navigation.
+	// The chromeless bridge `preventDefault`s every admin-internal link
+	// click and posts this message; the parent owns the routing. Three
+	// possible outcomes, in priority order:
+	//
+	//   1. Native-window remap hit (e.g. `edit.php` while the user has
+	//      the native Posts opt-in on) → open the native window and
+	//      close the source iframe. Same behavior as the original
+	//      "Exit editor" path on a locked-post takeover dialog.
+	//
+	//   2. Same-page slug → drive the source iframe's
+	//      `location.assign()` so the in-place navigation matches the
+	//      user's intent. Pagination, list filters, and tab strips
+	//      hang off this branch.
+	//
+	//   3. Different slug → open a NEW window for the destination and
+	//      leave the source iframe untouched. The user keeps the
+	//      original page's context (e.g. a Pages window stays Pages
+	//      after they click into Posts).
+	//
+	// The bridge stays a passive router until `bindAdminLinkDispatch`
+	// has wired the deps. Unbound state should only happen in tests
+	// or pre-boot; we bail out without navigating so the user sees a
+	// dropped click instead of a broken iframe state.
 	if (
 		data.type === 'desktop-mode-iframe-admin-link' &&
 		typeof data.url === 'string' &&
@@ -134,6 +214,10 @@ export function handleWindowMessage( win: Window, event: MessageEvent ): void {
 	) {
 		if ( tryNativeUrlRemap( data.url ) ) {
 			win.close();
+		} else if ( adminLinkDeps ) {
+			const linkLabel =
+				typeof data.label === 'string' ? data.label : '';
+			handleCrossPageAdminLink( win, data.url, linkLabel, adminLinkDeps );
 		}
 	}
 
@@ -334,6 +418,88 @@ function handleDesktopNavigate(
 	if ( win.iframe ) {
 		win.iframe.src = url.toString();
 	}
+}
+
+/**
+ * Route an admin-internal link click that the chromeless bridge
+ * `preventDefault`d for us. See the case-3 outcome list at the call
+ * site for the full decision table; this function implements the
+ * same-slug-vs-different-slug split and the new-window opening.
+ *
+ * Same-slug navigation prefers `location.assign()` over `iframe.src`
+ * because `assign` creates a real entry in the iframe's session
+ * history (Back / Forward inside the iframe still work, screen
+ * readers announce the page change). Setting `iframe.src` from the
+ * parent overwrites the current entry instead.
+ */
+function handleCrossPageAdminLink(
+	win: Window,
+	rawUrl: string,
+	linkLabel: string,
+	deps: AdminLinkDispatchDeps,
+): void {
+	let url: URL;
+	try {
+		url = new URL( rawUrl, deps.adminUrl );
+	} catch {
+		return;
+	}
+	if ( url.origin !== INITIAL_ORIGIN ) {
+		return;
+	}
+	const absolute = url.toString();
+
+	const targetSlug = deps.deriveSlug( absolute );
+	const sourceSlug = win.config.baseId || win.id;
+
+	if ( targetSlug === sourceSlug ) {
+		const inner = win.iframe?.contentWindow;
+		if ( inner ) {
+			try {
+				inner.location.assign( absolute );
+			} catch {
+				// `location.assign` can throw if the iframe was torn
+				// down between the click and our handler; fall back
+				// to setting `src`, which never throws.
+				if ( win.iframe ) {
+					win.iframe.src = absolute;
+				}
+			}
+		}
+		return;
+	}
+
+	// Different slug — the user clicked into a different admin page.
+	// Open a fresh window for the destination and leave the source
+	// iframe where it is.
+	//
+	// Title resolution (best → worst):
+	//   1. Dock entry's `title` — recognises canonical pages.
+	//   2. `linkLabel` — the visible text of the link the user just
+	//      clicked. Catches in-app sub-pages (e.g. an Action Scheduler
+	//      tab whose URL has no dock tile but whose link text is
+	//      meaningful: "Scheduler", "Logs", "Settings").
+	//   3. The slug itself — last-resort fallback so a missing label
+	//      surfaces an ugly-but-stable id rather than an empty title
+	//      bar.
+	//
+	// The iframe-side bridge does not auto-emit `title-change` after
+	// load, so this single resolution is what the user sees for the
+	// lifetime of the window unless the destination's own JS reaches
+	// for `wp.desktop.send` / `setTitle`.
+	const entry = deps.findDockEntry( absolute );
+	const trimmedLabel = linkLabel.trim();
+	const title =
+		entry?.title || ( trimmedLabel !== '' ? trimmedLabel : targetSlug );
+	deps.openWindow( {
+		id: targetSlug,
+		baseId: targetSlug,
+		url: absolute,
+		title,
+		icon: entry?.icon ?? 'dashicons-admin-generic',
+		submenu: entry?.submenu,
+		multi: entry?.multi,
+	} );
 }
 
 /**

--- a/tests/phpunit/tests/desktopModeMenuItemUrl.php
+++ b/tests/phpunit/tests/desktopModeMenuItemUrl.php
@@ -98,6 +98,101 @@ class Tests_DesktopMode_MenuItemUrl extends WP_UnitTestCase {
 		$this->assertSame( 'year', $args['period'] );
 	}
 
+	/**
+	 * Submenus registered under a `.php` parent (Tools, Settings,
+	 * Appearance, etc.) get linked by classic admin as
+	 * `parent.php?page=<slug>`, not `admin.php?page=<slug>`. The
+	 * resolver mirrors `menu_page_url()`'s read of `$_parent_pages`
+	 * so dockItems URLs match what WordPress actually renders in
+	 * the iframe — the prerequisite for the link router's slug-
+	 * equality lookup to match Tools→Scheduled Actions,
+	 * Settings→Permalinks, etc.
+	 *
+	 * Tests pin `$_parent_pages` directly: that's the same global
+	 * `add_submenu_page()` populates and `menu_page_url()` reads.
+	 * Going through `add_submenu_page()` would couple the test to
+	 * the runner's current-user cap, which isn't the surface under
+	 * test.
+	 */
+	public function test_routes_submenu_slug_through_php_parent() {
+		global $_parent_pages;
+		$_parent_pages['scheduler'] = 'tools.php';
+
+		$this->assertSame(
+			esc_url_raw( admin_url( 'tools.php?page=scheduler' ) ),
+			desktop_mode_menu_item_url( 'scheduler' )
+		);
+
+		unset( $_parent_pages['scheduler'] );
+	}
+
+	public function test_routes_submenu_slug_through_php_parent_with_embedded_query() {
+		global $_parent_pages;
+		$_parent_pages['scheduler'] = 'tools.php';
+
+		$result = desktop_mode_menu_item_url( 'scheduler&status=past-due' );
+
+		parse_str( wp_parse_url( html_entity_decode( $result ), PHP_URL_QUERY ), $args );
+		$this->assertSame( 'scheduler', $args['page'] );
+		$this->assertSame( 'past-due', $args['status'] );
+		$this->assertStringContainsString( 'tools.php', $result );
+
+		unset( $_parent_pages['scheduler'] );
+	}
+
+	/**
+	 * Submenus registered under a slug-based parent (WooCommerce's
+	 * `wc-admin` under `woocommerce`) collapse to `admin.php?page=…`
+	 * — the same fallback `menu_page_url()` lands on. Validates the
+	 * resolver doesn't accidentally route through a phantom
+	 * `woocommerce.php`.
+	 */
+	public function test_routes_submenu_slug_under_slug_parent_through_admin_php() {
+		global $_parent_pages;
+		$_parent_pages['woocommerce'] = 'woocommerce';
+		$_parent_pages['wc-admin']    = 'woocommerce';
+
+		$this->assertSame(
+			esc_url_raw( admin_url( 'admin.php?page=wc-admin' ) ),
+			desktop_mode_menu_item_url( 'wc-admin' )
+		);
+
+		unset( $_parent_pages['woocommerce'], $_parent_pages['wc-admin'] );
+	}
+
+	/**
+	 * Top-level slug menus (registered with `add_menu_page()`)
+	 * record themselves as their own parent — `$_parent_pages[$slug]
+	 * = $slug`. Core's resolver collapses these to
+	 * `admin.php?page=…`; mirror that exactly.
+	 */
+	public function test_routes_top_level_slug_through_admin_php() {
+		global $_parent_pages;
+		$_parent_pages['my-top-level'] = 'my-top-level';
+
+		$this->assertSame(
+			esc_url_raw( admin_url( 'admin.php?page=my-top-level' ) ),
+			desktop_mode_menu_item_url( 'my-top-level' )
+		);
+
+		unset( $_parent_pages['my-top-level'] );
+	}
+
+	/**
+	 * Unregistered slug → fall back to `admin.php?page=…`. Slugs
+	 * land here when a plugin populates `$submenu` directly without
+	 * routing through `add_submenu_page()` (rare but seen in older
+	 * plugins). Returning a valid `admin.php` URL keeps the dock
+	 * functional even on those quirky registrations.
+	 */
+	public function test_falls_back_to_admin_php_for_unregistered_slug() {
+		// No `$_parent_pages` entry — no fixture set up.
+		$this->assertSame(
+			esc_url_raw( admin_url( 'admin.php?page=unhooked' ) ),
+			desktop_mode_menu_item_url( 'unhooked' )
+		);
+	}
+
 	public function test_embedded_query_param_with_only_key() {
 		// Trailing `&` with no value — must not crash, must still
 		// produce a valid `?page=…` URL.

--- a/tests/phpunit/tests/desktopModeRender.php
+++ b/tests/phpunit/tests/desktopModeRender.php
@@ -278,6 +278,37 @@ class Tests_DesktopMode_Render extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Cross-page admin-link routing depends on the chromeless bridge
+	 * preventing the iframe's natural navigation; the parent shell
+	 * decides between same-page in-iframe nav and a fresh window. If
+	 * the bridge ever stops calling preventDefault on admin links,
+	 * cross-page clicks would trash the source iframe before the
+	 * parent could react.
+	 *
+	 * @covers ::desktop_mode_chromeless_bridge_script
+	 */
+	public function test_bridge_script_prevents_default_on_admin_links() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['desktop_mode_chromeless'] = '1';
+
+		ob_start();
+		desktop_mode_chromeless_bridge_script();
+		$output = ob_get_clean();
+
+		// Pin the admin-branch shape: the prevent-default must sit
+		// inside the `kind === 'admin'` block, paired with the
+		// admin-link postMessage. A regression that drops the
+		// prevent-default would still emit the message, so we assert
+		// both substrings are present.
+		$this->assertStringContainsString( "kind === 'admin'", $output );
+		$this->assertStringContainsString( 'desktop-mode-iframe-admin-link', $output );
+		$this->assertMatchesRegularExpression(
+			"/kind === 'admin'.*?e\\.preventDefault\\(\\).*?desktop-mode-iframe-admin-link/s",
+			$output
+		);
+	}
+
+	/**
 	 * @covers ::desktop_mode_classic_link_interceptor
 	 */
 	public function test_classic_interceptor_emits_nothing_without_flag() {


### PR DESCRIPTION
I have spotted where internal navigation was causing "inceptions". Eg, open Desktop Mode in Desktop Mode :)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-119-296b8ab48b7d69a00249c38ad1bee8e4aeed9549.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->