### PR TITLE
fix(pwa): hide install tile when running inside the standalone PWA

### DIFF
--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -102,7 +102,7 @@ import {
 	bootstrapPwa,
 	type NotifyOptions,
 } from './pwa';
-import { getInstallTileDef } from './pwa/install';
+import { getInstallTileDef, isStandaloneDisplay } from './pwa/install';
 import { type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
 import {
@@ -1736,17 +1736,22 @@ function init(): void {
 
 		// PWA install tile — sits next to OS Settings on the same
 		// rail (`'core'` affinity) so users see install / settings as
-		// peer shell-owned actions. The tile registers
-		// unconditionally; its onOpen handles the
-		// "browser hasn't decided we're installable yet" path with a
-		// contextual toast rather than disappearing.
-		layoutDispatcher.appendSystemTile(
-			getInstallTileDef(
-				config.pwa?.appName || 'WordPress',
-				showToast,
-			),
-			'core',
-		);
+		// peer shell-owned actions. Skipped entirely when the shell
+		// itself is already running inside the installed PWA window
+		// (`display-mode: standalone`) — there's nothing to install
+		// from there, and a perpetually-no-op icon is just noise.
+		// Browsers' window mode is fixed at boot, so a single check
+		// here is sufficient — there's no transition during a
+		// session that would change the answer.
+		if ( ! isStandaloneDisplay() ) {
+			layoutDispatcher.appendSystemTile(
+				getInstallTileDef(
+					config.pwa?.appName || 'WordPress',
+					showToast,
+				),
+				'core',
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Inside the installed PWA's standalone window, the dock-side install tile kept showing — even though clicking it could only ever fall through to the "already installed" toast (Chrome doesn't fire `beforeinstallprompt` for an app that's already running as a PWA). Hiding it.

## Change

One conditional guard in `src/desktop.ts` around the `appendSystemTile` call:

```ts
if ( ! isStandaloneDisplay() ) {
    layoutDispatcher.appendSystemTile( getInstallTileDef( ... ), 'core' );
}
```

`isStandaloneDisplay()` already lives in `src/pwa/install.ts` from the original PWA PR — it checks `matchMedia('(display-mode: standalone)')` plus the iOS-specific `navigator.standalone` fallback. Display mode is fixed at window-creation time, so a single check at boot is sufficient — no event subscription needed.

## What stays the same

- Regular browser tabs still get the tile, including after the user has installed the app there. Clicking from a regular tab still shows the "already installed" toast (driven by `getInstalledRelatedApps`), which is useful for users who want to launch the standalone window from inside the dock.
- `wp.desktop.pwa.promptInstall()` and the rest of the public PWA surface are unchanged.

## Test plan

- [x] `npm run lint` clean.
- [x] `tsc --noEmit` clean.
- [x] `npm run test:js` — 954 / 954 pass.
- [ ] Verify in the installed PWA window: tile no longer appears on the side dock.
- [ ] Verify in a regular browser tab (post-install): tile still appears, click → "already installed" toast.
- [ ] Verify in a regular browser tab (pre-install): tile appears, click → install prompt fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-121-c8b3996744093e80a5b6afb577274380a4fded99.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->