### PR TITLE
fix(pwa): hide install tile in installed PWA + transparent SW updates

### DIFF
--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -102,7 +102,11 @@ import {
 	bootstrapPwa,
 	type NotifyOptions,
 } from './pwa';
-import { getInstallTileDef, isStandaloneDisplay } from './pwa/install';
+import {
+	getInstallTileDef,
+	isStandaloneDisplay,
+	isLikelyInstalled,
+} from './pwa/install';
 import { type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
 import {
@@ -1766,6 +1770,25 @@ function init(): void {
 					);
 				}
 			} );
+
+		// Async post-boot: if the PWA is already installed in the
+		// current browser profile (Chrome's `Open in app` indicator
+		// in the address bar), drop the install tile from regular
+		// browser tabs too. The synchronous boot-time check only
+		// covers the standalone display case; this handles the
+		// "regular tab where the user has already installed" case
+		// that otherwise leaves a no-op install icon on the dock
+		// and a confusing "already installed" toast on click.
+		// `getInstalledRelatedApps()` is async and Chromium-only,
+		// so this resolves to a no-op on Safari / Firefox where
+		// the tile stays as a fallback.
+		void isLikelyInstalled().then( ( installed ) => {
+			if ( installed ) {
+				layoutDispatcher?.removeSystemTile(
+					'desktop-mode-pwa-install',
+				);
+			}
+		} );
 	}
 
 	/**

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1740,9 +1740,14 @@ function init(): void {
 		// itself is already running inside the installed PWA window
 		// (`display-mode: standalone`) — there's nothing to install
 		// from there, and a perpetually-no-op icon is just noise.
-		// Browsers' window mode is fixed at boot, so a single check
-		// here is sufficient — there's no transition during a
-		// session that would change the answer.
+		//
+		// **Two-phase guard.** Chrome cold-starts a PWA window with
+		// the document briefly reporting `display-mode: browser`
+		// before flipping to standalone. The boot-time check covers
+		// the common case (display mode already settled); the
+		// matchMedia `'change'` listener catches the cold-start race
+		// and removes the tile retroactively when the flip arrives,
+		// so the icon never lingers in the installed PWA.
 		if ( ! isStandaloneDisplay() ) {
 			layoutDispatcher.appendSystemTile(
 				getInstallTileDef(
@@ -1752,6 +1757,15 @@ function init(): void {
 				'core',
 			);
 		}
+		window
+			.matchMedia( '(display-mode: standalone)' )
+			.addEventListener( 'change', ( e ) => {
+				if ( e.matches ) {
+					layoutDispatcher?.removeSystemTile(
+						'desktop-mode-pwa-install',
+					);
+				}
+			} );
 	}
 
 	/**

--- a/src/pwa/install.ts
+++ b/src/pwa/install.ts
@@ -87,7 +87,7 @@ export function isStandaloneDisplay(): boolean {
  * because it acknowledges the most common cause (already installed)
  * without falsely claiming we know the answer.
  */
-async function isLikelyInstalled(): Promise< boolean > {
+export async function isLikelyInstalled(): Promise< boolean > {
 	if ( isStandaloneDisplay() ) {
 		return true;
 	}

--- a/src/pwa/sw-register.ts
+++ b/src/pwa/sw-register.ts
@@ -29,6 +29,56 @@ import type { PwaConfig } from '../types';
 
 let _registration: ServiceWorkerRegistration | null = null;
 let _registrationFailed = false;
+let _controllerChangeBound = false;
+let _reloadingForSwUpdate = false;
+
+/**
+ * Wire up the auto-reload on SW takeover. Two scenarios distinguished:
+ *
+ *   - **Cold start** — page loaded with NO prior SW controller, then
+ *     just registered + activated one. No reload: the bundle was
+ *     fetched directly from the network (the SW couldn't have
+ *     intercepted requests it didn't yet exist for), so it's already
+ *     fresh. Reloading here would be a gratuitous flicker on every
+ *     first PWA open.
+ *
+ *   - **Deploy mid-session** — page was already controlled by an
+ *     older SW, the new SW just activated and replaced it. Reload
+ *     once so subsequent fetches go through the new SW (which is
+ *     network-first for JS) and the freshly-deployed bundle takes
+ *     effect immediately.
+ *
+ * The discriminator is `navigator.serviceWorker.controller` at bind
+ * time: truthy → already controlled (any future controllerchange is
+ * a deploy); falsy → cold start (the upcoming controllerchange is
+ * the first activation, no reload needed).
+ *
+ * Idempotent — guarded by `_controllerChangeBound` /
+ * `_reloadingForSwUpdate` so a second controllerchange event (rare,
+ * but spec-permitted) doesn't loop.
+ */
+function bindControllerChangeReload(): void {
+	if ( _controllerChangeBound ) {
+		return;
+	}
+	_controllerChangeBound = true;
+	const hadInitialController = !! navigator.serviceWorker.controller;
+	navigator.serviceWorker.addEventListener( 'controllerchange', () => {
+		if ( ! hadInitialController ) {
+			// Cold start — first-ever SW activation for this page.
+			// Bundle is already fresh; no reload.
+			return;
+		}
+		if ( _reloadingForSwUpdate ) {
+			return;
+		}
+		_reloadingForSwUpdate = true;
+		// One-frame delay so any in-flight UI work has a chance to
+		// settle before the navigation. Not strictly required, but
+		// avoids a class of "click → reload races input" surprises.
+		setTimeout( () => window.location.reload(), 0 );
+	} );
+}
 
 /**
  * Register the service worker. No-op outside browsers, on insecure
@@ -84,6 +134,10 @@ export async function registerServiceWorker(
 			scope: '/',
 			updateViaCache: 'none',
 		} );
+		// Auto-reload when the new SW takes control. Bound only after a
+		// successful registration so we never reload a page that has no
+		// SW relationship in the first place.
+		bindControllerChangeReload();
 		return _registration;
 	} catch ( err ) {
 		_registrationFailed = true;
@@ -106,4 +160,6 @@ export function getServiceWorkerRegistration(): ServiceWorkerRegistration | null
 export function _resetSwRegistration(): void {
 	_registration = null;
 	_registrationFailed = false;
+	_controllerChangeBound = false;
+	_reloadingForSwUpdate = false;
 }

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -90,7 +90,7 @@ interface SWGlobal {
 // concise.
 const sw = globalThis as unknown as SWGlobal;
 
-const VERSION = '0.8.0-pwa-2';
+const VERSION = '0.8.0-pwa-3';
 const STATIC_CACHE = `desktop-mode-static-${ VERSION }`;
 const RUNTIME_CACHE = `desktop-mode-runtime-${ VERSION }`;
 const OFFLINE_URL = '/desktop-mode/?offline=1';
@@ -258,12 +258,25 @@ function isJsAssetPath( pathname: string ): boolean {
  * waiting for stale-while-revalidate to catch up. The cache still
  * gets populated so offline users see the most-recent successful
  * fetch.
+ *
+ * **`cache: 'reload'` is load-bearing.** Without it, `fetch(req)`
+ * still honours the browser's *HTTP* cache — a separate layer below
+ * the SW. WordPress plugin static assets ship without a
+ * `Cache-Control` header from nginx, so Chrome falls back to
+ * heuristic freshness and may serve a stale bundle from the HTTP
+ * cache without ever hitting the origin. That's how a reinstalled
+ * PWA window kept showing the pre-fix bundle: the freshly-opened
+ * window inherited Chrome's shared HTTP cache from the regular
+ * browser tab that had loaded the old code a minute earlier.
+ * `cache: 'reload'` forces a true network fetch (the fetch spec's
+ * "reload" mode bypasses the HTTP cache on both request and
+ * response paths).
  */
 async function networkFirstForAsset( req: Request ): Promise< Response > {
 	const cache = await caches.open( RUNTIME_CACHE );
 	try {
 		// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.desktop` global available; raw fetch is the API.
-		const fresh = await fetch( req );
+		const fresh = await fetch( req.url, { cache: 'reload' } );
 		if ( fresh && fresh.status === 200 ) {
 			cache.put( req, fresh.clone() ).catch( () => undefined );
 		}

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -90,7 +90,7 @@ interface SWGlobal {
 // concise.
 const sw = globalThis as unknown as SWGlobal;
 
-const VERSION = '0.8.0-pwa-1';
+const VERSION = '0.8.0-pwa-2';
 const STATIC_CACHE = `desktop-mode-static-${ VERSION }`;
 const RUNTIME_CACHE = `desktop-mode-runtime-${ VERSION }`;
 const OFFLINE_URL = '/desktop-mode/?offline=1';
@@ -150,6 +150,20 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
 		'/wp-content/plugins/desktop-mode/',
 	);
 	if ( ! isPortal && ! isAdmin && ! isPluginAsset ) {
+		return;
+	}
+
+	if ( isPluginAsset && isJsAssetPath( url.pathname ) ) {
+		// JS bundles change per deploy — `network-first` ensures
+		// online users see the latest code immediately, with no
+		// stale-revalidate window where a freshly-pushed fix is
+		// invisible until the next reload. The cache is still
+		// populated as a fallback for offline use. The previous
+		// stale-while-revalidate strategy caused PR #121's
+		// "install icon hidden in standalone" fix to require a
+		// manual refresh inside the PWA window, because the first
+		// post-deploy navigation served the cached pre-fix bundle.
+		event.respondWith( networkFirstForAsset( req ) );
 		return;
 	}
 
@@ -229,9 +243,38 @@ function pluginAssetBase(): string {
 }
 
 function isStaticAssetPath( pathname: string ): boolean {
-	return /\.(css|js|png|jpg|jpeg|svg|webp|woff2?|ttf|gif|ico)$/i.test(
+	return /\.(css|png|jpg|jpeg|svg|webp|woff2?|ttf|gif|ico)$/i.test(
 		pathname,
 	);
+}
+
+function isJsAssetPath( pathname: string ): boolean {
+	return /\.js$/i.test( pathname );
+}
+
+/**
+ * Network-first with cache fallback. Used for JS bundles so a fresh
+ * deploy reaches online users on the very next page load instead of
+ * waiting for stale-while-revalidate to catch up. The cache still
+ * gets populated so offline users see the most-recent successful
+ * fetch.
+ */
+async function networkFirstForAsset( req: Request ): Promise< Response > {
+	const cache = await caches.open( RUNTIME_CACHE );
+	try {
+		// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.desktop` global available; raw fetch is the API.
+		const fresh = await fetch( req );
+		if ( fresh && fresh.status === 200 ) {
+			cache.put( req, fresh.clone() ).catch( () => undefined );
+		}
+		return fresh;
+	} catch {
+		const cached = await cache.match( req );
+		if ( cached ) {
+			return cached;
+		}
+		return new Response( '', { status: 504 } );
+	}
 }
 
 async function staleWhileRevalidate( req: Request ): Promise< Response > {


### PR DESCRIPTION
## Summary

Three layered fixes that together eliminate the "install icon visible inside the installed PWA" bug, plus make every future deploy land transparently without a manual reload.

## Why this PR exists

After #121 (the `! isStandaloneDisplay()` boot guard) was merged, the install tile *still* appeared inside the standalone PWA window in many cases. Tracing through Chrome's PWA cold-start path uncovered three layered causes — none of which #121 alone could cover:

1. Chrome cold-starts a PWA window with the document briefly reporting `display-mode: browser` before flipping to standalone. The boot-time check ran during that window, registering the tile before the flip.
2. The SW was caching JS under stale-while-revalidate, so even after deploying the fix the first PWA navigation served the cached pre-fix bundle.
3. WordPress plugin static assets ship without a `Cache-Control` header from nginx. Plain `fetch(req)` inside the SW honours Chrome's HTTP cache layer below it, so heuristic freshness could serve a stale bundle without ever hitting origin.

And one related concern surfaced during test: even *after* installing the PWA, regular browser tabs kept showing the install icon — clicking it surfaced an "already installed" toast that was technically helpful but visually noisy alongside Chrome's own "Open in app" address-bar indicator.

## Changes

### 1. Two-phase standalone-display guard (`src/desktop.ts`)

The boot-time `! isStandaloneDisplay()` check covers the common case where Chrome has already settled the display mode by the time JS runs. A `matchMedia('(display-mode: standalone)')` `'change'` listener catches Chrome's cold-start race — the document briefly reports `display-mode: browser` before flipping — and removes the install tile retroactively when the flip arrives. The icon never lingers in the installed PWA.

### 2. Network-first for JS bundles, with `cache: 'reload'` (`src/pwa/sw.ts`)

JS bundles were on stale-while-revalidate. Switched to network-first with a cache fallback for offline. CSS / images / fonts stay on SWR (their churn is rare and SWR's instant-paint win is real).

`cache: 'reload'` is load-bearing: plain `fetch(req)` honours the browser's HTTP cache, which on WordPress plugin assets is governed by Chrome's heuristic freshness (no `Cache-Control` from nginx). `cache: 'reload'` forces a true network fetch on every JS request.

`isStaticAssetPath` no longer matches `.js`; a new `isJsAssetPath` routes JS bundles to the new strategy. SW `VERSION` → `'0.8.0-pwa-3'` so the activate handler purges previous-version runtime caches.

### 3. Smart `controllerchange` auto-reload (`src/pwa/sw-register.ts`)

Discriminates cold start vs deploy mid-session via `navigator.serviceWorker.controller` at bind time:

- **Cold start** (`controller` was falsy at bind time): the upcoming `controllerchange` is the freshly-activated SW claiming this client for the first time. The bundle was fetched directly from the network, it's already fresh, **no reload**. Avoids the gratuitous flicker on every first PWA open.
- **Deploy mid-session** (`controller` was truthy at bind time): a subsequent `controllerchange` means a new SW activated and replaced the old one. **One reload** so subsequent fetches go through the new SW (network-first) and the freshly-deployed code takes effect immediately.

### 4. Hide install tile when PWA is already installed (`src/desktop.ts`, `src/pwa/install.ts`)

After the synchronous boot-time check, an async `getInstalledRelatedApps()` probe (Chromium-only) runs. If the call resolves with "this app is installed in the current profile", the tile is removed retroactively. Plays well with Chrome's "Open in app" address-bar indicator: regular browser tabs no longer show a redundant install icon once the PWA is installed.

`isLikelyInstalled()` was already used by the click handler to drive the "already installed" toast — promoted from internal to exported so desktop.ts can hook the registration site to it.

## Behaviour matrix

| Browser context | `display-mode: standalone` | Installed (per `getInstalledRelatedApps`) | Tile visible? |
|---|---|---|---|
| Regular tab, no install yet | false | false | **shown** |
| Regular tab, PWA installed (Chromium) | false | true | **hidden** (after async check) |
| Standalone PWA window | true | true (or n/a) | **hidden** (boot guard + matchMedia listener) |
| Safari / Firefox (no `getInstalledRelatedApps`) | false | n/a | **shown** as fallback |

Safari / Firefox don't expose `getInstalledRelatedApps`, so the tile stays visible there. Acceptable: those browsers don't fire `beforeinstallprompt` either, so the tile's click already routes to the contextual "install not available" toast.

## Test plan

- [x] `npm run lint` clean.
- [x] `tsc --noEmit` clean.
- [x] `npm run test:js` — 954 / 954 pass.
- [x] Cold-start parent-shell navigation count via Playwright: was 2 (manual + auto-reload), now 1 (auto-reload skipped).
- [x] Install tile correctly absent inside standalone PWA window — confirmed locally.
- [x] Install tile correctly absent in regular browser tabs once Chrome shows "Open in app" — confirmed locally.
- [x] Install tile correctly present in regular browser tabs before installation — confirmed via Playwright clean profile.
- [ ] Verify on Safari / Firefox: tile stays visible as fallback (no `getInstalledRelatedApps` to drive auto-hide).
- [ ] Verify offline: kill network; open PWA; cached version should serve via the SW's cache fallback.

## Why not just bump SW `VERSION` per deploy?

That would invalidate ALL caches (CSS, images, fonts) on every deploy and lose SWR's first-paint speedup for static art that rarely changes. Network-first scoped to JS bundles is more surgical and preserves the offline / cache benefits for everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-122-024a1378805eca5086686697ed8ebae4444bd0d3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->