### PR TITLE
fix: increase z-index of resize handle to prevent iframe pointer event issues

### DIFF
--- a/assets/css/window-states.css
+++ b/assets/css/window-states.css
@@ -30,7 +30,7 @@
 	position: absolute;
 	width: var(--desktop-mode-resize-size);
 	height: var(--desktop-mode-resize-size);
-	z-index: 1;
+	z-index: 999;
 }
 
 .desktop-mode-window__resize-handle--se {


### PR DESCRIPTION
Closes https://github.com/WordPress/desktop-mode/issues/114

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-126-51fb29d1bb7a1b633906dabb8310cc6d8c1dd69a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->