### PR TITLE
Fix/plugin real time activation icon refresh

### DIFF
--- a/assets/css/window-states.css
+++ b/assets/css/window-states.css
@@ -30,7 +30,7 @@
 	position: absolute;
 	width: var(--desktop-mode-resize-size);
 	height: var(--desktop-mode-resize-size);
-	z-index: 1;
+	z-index: 999;
 }
 
 .desktop-mode-window__resize-handle--se {

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -649,6 +649,100 @@ function desktop_mode_chromeless_bridge_script() {
 	 *   - themes.php          — theme switch (rare but can add menus).
 	 */
 	var __DESKTOP_MODE_MENU_PAYLOAD__ = /*__DESKTOP_MODE_MENU_PAYLOAD__*/;
+	/*
+	 * Icon harvest from the iframe's authoritative #adminmenu.
+	 *
+	 * The server-side payload only knows what the plugin set on
+	 * $menu[$i][6]. Plugins that register their icon with 'none' /
+	 * 'div' and paint it via a CSS rule on `#adminmenu .menu-icon-X`
+	 * (All in One WP Migration, plus a long tail of older plugins)
+	 * end up serialized with the gear fallback.
+	 *
+	 * On a regular page load the parent shell's resolveIcon() falls
+	 * back to the parent's hidden #adminmenu DOM and reads the icon
+	 * from there — but on a live activation the parent's #adminmenu
+	 * is stale (it was rendered before the plugin existed). This
+	 * iframe just rendered plugins.php in real admin context, so its
+	 * own #adminmenu DOM IS authoritative; harvest each menu item's
+	 * resolved icon here and patch the dockItems before postMessage.
+	 */
+	try {
+		if (
+			__DESKTOP_MODE_MENU_PAYLOAD__
+			&& Array.isArray( __DESKTOP_MODE_MENU_PAYLOAD__.dockItems )
+		) {
+			var __wpdAdminMenu = document.getElementById( 'adminmenu' );
+			if ( __wpdAdminMenu ) {
+				var __wpdHarvest = {};
+				var __wpdLinks = __wpdAdminMenu.querySelectorAll( 'li.menu-top > a' );
+				for ( var __wpdLi = 0; __wpdLi < __wpdLinks.length; __wpdLi++ ) {
+					var __wpdLink = __wpdLinks[ __wpdLi ];
+					var __wpdKey;
+					try {
+						var __wpdU = new URL( __wpdLink.href || '', window.location.href );
+						__wpdKey = ( __wpdU.pathname.split( '/' ).pop() || '' ) + __wpdU.search;
+					} catch ( __wpdE1 ) { continue; }
+					if ( ! __wpdKey ) { continue; }
+					var __wpdImgWrap = __wpdLink.querySelector( '.wp-menu-image' );
+					if ( ! __wpdImgWrap ) { continue; }
+
+					/* (a) <img src> nested inside .wp-menu-image */
+					var __wpdImg = __wpdImgWrap.querySelector( 'img' );
+					if ( __wpdImg && __wpdImg.src ) {
+						__wpdHarvest[ __wpdKey ] = __wpdImg.src;
+						continue;
+					}
+
+					/* (b) dashicon class on the wrap div itself */
+					var __wpdDash = ( __wpdImgWrap.className || '' ).match( /\bdashicons-[\w-]+\b/ );
+					if (
+						__wpdDash
+						&& __wpdDash[ 0 ] !== 'dashicons-before'
+						&& __wpdDash[ 0 ] !== 'dashicons-admin-generic'
+					) {
+						__wpdHarvest[ __wpdKey ] = __wpdDash[ 0 ];
+						continue;
+					}
+
+					/* (c) ::before background-image — pass the raw
+					 * `url(...)` CSS value through; the parent's
+					 * resolveIcon can hand it straight to _makeSvgIcon
+					 * regardless of whether it's base64-encoded SVG,
+					 * URL-encoded SVG, or a plain http(s) URL. */
+					try {
+						var __wpdBefore = window.getComputedStyle( __wpdImgWrap, '::before' );
+						var __wpdBg = __wpdBefore && __wpdBefore.backgroundImage;
+						if ( __wpdBg && __wpdBg !== 'none' && __wpdBg.indexOf( 'url("")' ) === -1 ) {
+							__wpdHarvest[ __wpdKey ] = __wpdBg;
+							continue;
+						}
+						/* (d) background on the wrap itself */
+						var __wpdWrapBg = window.getComputedStyle( __wpdImgWrap ).backgroundImage;
+						if ( __wpdWrapBg && __wpdWrapBg !== 'none' && __wpdWrapBg.indexOf( 'url("")' ) === -1 ) {
+							__wpdHarvest[ __wpdKey ] = __wpdWrapBg;
+						}
+					} catch ( __wpdE2 ) { /* getComputedStyle may throw on detached nodes */ }
+				}
+
+				var __wpdItems = __DESKTOP_MODE_MENU_PAYLOAD__.dockItems;
+				for ( var __wpdDi = 0; __wpdDi < __wpdItems.length; __wpdDi++ ) {
+					var __wpdItem = __wpdItems[ __wpdDi ];
+					if ( ! __wpdItem || __wpdItem.icon !== 'dashicons-admin-generic' ) { continue; }
+					if ( typeof __wpdItem.url !== 'string' || ! __wpdItem.url ) { continue; }
+					try {
+						var __wpdItemU = new URL( __wpdItem.url, window.location.href );
+						var __wpdItemKey = ( __wpdItemU.pathname.split( '/' ).pop() || '' ) + __wpdItemU.search;
+						if ( __wpdHarvest[ __wpdItemKey ] ) {
+							__wpdItem.icon = __wpdHarvest[ __wpdItemKey ];
+						}
+					} catch ( __wpdE3 ) { /* malformed url — leave icon alone */ }
+				}
+			}
+		}
+	} catch ( __wpdHarvestErr ) {
+		/* Harvest is best-effort; on any failure we still ship the
+		 * server-built payload, which is exactly the pre-fix behavior. */
+	}
 	try {
 		if ( __DESKTOP_MODE_MENU_PAYLOAD__ ) {
 			window.parent.postMessage(

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -968,6 +968,17 @@ export class Dock {
 			// Malformed — skip this case and try native-menu extraction.
 		}
 
+		// 3a. Raw CSS `url(...)` value — only the live-activation icon
+		//     harvest in includes/render/chromeless-bridge.php produces
+		//     this shape. It hands us the iframe's computed
+		//     `::before { background-image }` verbatim so we can paint it
+		//     identically to how F5 would (via _extractNativeMenuIcon's
+		//     shape-c branch), without losing fidelity through a data-URI
+		//     re-encode. Server-built icons never take this branch.
+		if ( icon.startsWith( 'url(' ) ) {
+			return this._makeSvgIcon( icon );
+		}
+
 		// 3. http(s) URL — direct image.
 		if ( icon.startsWith( 'http://' ) || icon.startsWith( 'https://' ) ) {
 			const img = document.createElement( 'img' );

--- a/tests/vitest/dock-icon-resolve.test.ts
+++ b/tests/vitest/dock-icon-resolve.test.ts
@@ -73,6 +73,44 @@ describe( 'dock icon resolution', () => {
 		expect( icon?.style.backgroundImage ).toContain( 'data:image/svg+xml;base64,' );
 	} );
 
+	test( 'raw CSS url(...) value renders a background-image span (live-activation harvest path)', () => {
+		// includes/render/chromeless-bridge.php harvests the iframe's
+		// computed `::before { background-image }` for plugins whose
+		// menu icon is registered via CSS (icon = 'none'/'div'). The
+		// harvested value is a raw `url(...)` string and must reach the
+		// dock without going through a data-URI re-encode.
+		const { container } = mountDock( [
+			makeItem( {
+				icon: 'url("data:image/svg+xml;base64,PHN2Zy8+")',
+				title: 'All in One WP Migration',
+			} ),
+		] );
+		const icon = container.querySelector< HTMLElement >(
+			'.desktop-mode-dock__item-svg',
+		);
+		expect( icon ).not.toBeNull();
+		expect( icon?.style.backgroundImage ).toContain( 'data:image/svg+xml;base64,' );
+		// And it must NOT have collapsed to the gear or a letter badge.
+		expect( container.querySelector( '.desktop-mode-dock__item-letter' ) ).toBeNull();
+		expect(
+			container.querySelector( '.dashicons-admin-generic' ),
+		).toBeNull();
+	} );
+
+	test( 'raw CSS url(...) accepts a URL-encoded SVG data URI', () => {
+		// The harvest also needs to round-trip non-base64 data URIs
+		// (some plugins use `data:image/svg+xml,<percent-encoded>` in
+		// their CSS). _makeSvgIcon takes the value verbatim, so this
+		// branch is just a fidelity check.
+		const url = 'url("data:image/svg+xml,%3Csvg/%3E")';
+		const { container } = mountDock( [ makeItem( { icon: url } ) ] );
+		const icon = container.querySelector< HTMLElement >(
+			'.desktop-mode-dock__item-svg',
+		);
+		expect( icon ).not.toBeNull();
+		expect( icon?.style.backgroundImage ).toContain( 'data:image/svg+xml,' );
+	} );
+
 	test( 'http URL renders an <img>', () => {
 		const { container } = mountDock( [
 			makeItem( { icon: 'http://localhost/plugin-icon.png' } ),


### PR DESCRIPTION
Fixes/Improves https://github.com/WordPress/desktop-mode/issues/123

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-127-17ccd3eb679a3209b47d83a1a26b857f7d22cc63.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->