### PR TITLE
Add comprehensive drag-and-drop tests for DragManager and DropTargetRegistry

### DIFF
--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -92,18 +92,40 @@
 }
 
 .desktop-mode-file-tile--dragging {
-	opacity: 0.85;
+	/* The DragManager renders a separate ghost element that follows
+	 * the pointer; the SOURCE tile stays in place but is dimmed so
+	 * the user has a stable reference for "this is what I'm
+	 * dragging."
+	 *
+	 * @since 0.18.0
+	 */
+	opacity: 0.4;
 	cursor: grabbing;
-	z-index: 10;
 }
 
-/* Pinned tiles (registered via `desktop_mode_register_icon( …,
- * [ 'pinned' => true ] )`) anchor to a fixed slot and never wire
- * up drag handlers. Switch the cursor so the affordance matches
- * the (lack of) interaction. @since 0.8.0 */
+/* Pinned tiles ("My WordPress", Recycle Bin) anchor to a fixed slot
+ * and DO NOT wire drag. The `not-allowed` cursor signals "this tile
+ * is intentionally fixed" so the user understands the (lack of)
+ * interaction instead of suspecting a bug. The `--bump` keyframe
+ * fires on pointerdown for explicit feedback that the gesture
+ * landed but the tile is anchored.
+ *
+ * @since 0.18.0
+ */
 .desktop-mode-file-tile--pinned {
-	cursor: pointer;
+	cursor: not-allowed;
 	touch-action: auto;
+}
+
+.desktop-mode-file-tile--bump {
+	animation: desktop-mode-file-tile-bump 220ms ease-out;
+}
+
+@keyframes desktop-mode-file-tile-bump {
+	0%   { transform: translate( 0, 0 ); }
+	30%  { transform: translate( 0, -3px ) scale( 1.02 ); }
+	60%  { transform: translate( 0, 1px ) scale( 0.99 ); }
+	100% { transform: translate( 0, 0 ); }
 }
 
 /* Folder tile is the drop target during a cross-window shortcut
@@ -611,4 +633,32 @@ button.desktop-mode-folder-status-bar__segment:hover {
 	text-shadow: var( --desktop-mode-tile-label-shadow, 0 1px 2px rgba( 0, 0, 0, 0.5 ) );
 	-webkit-font-smoothing: var( --desktop-mode-tile-label-smoothing, auto );
 	-moz-osx-font-smoothing: grayscale;
+}
+
+/*
+ * DragManager ghost element (the visual that follows the cursor
+ * during a drag). Cloned from the source by `mountGhost()` and
+ * pinned to the body with `position: fixed` + transform-based
+ * movement. `pointer-events: none` ensures the ghost itself
+ * never obscures the drop targets underneath during hit-testing.
+ *
+ * The accept / reject classes are toggled on each hover transition
+ * so the cursor matches the drop semantics: `copy` over an
+ * accepting target, `no-drop` over rejecting (or no) target.
+ *
+ * @since 0.18.0
+ */
+.desktop-mode-drag-ghost {
+	box-shadow: 0 6px 24px rgba( 0, 0, 0, 0.45 );
+	border-radius: 6px;
+	opacity: 0.95;
+	transition: none;
+}
+
+.desktop-mode-drag-ghost--accept {
+	cursor: copy;
+}
+
+.desktop-mode-drag-ghost--reject {
+	cursor: no-drop;
 }

--- a/assets/css/recycle-bin.css
+++ b/assets/css/recycle-bin.css
@@ -113,6 +113,27 @@
 	transition: box-shadow 80ms ease;
 }
 
+/* Dock-icon variant: when the recycle-bin window is closed, the
+ * desktop drag handler highlights the dock tile instead. Same
+ * affordance — outline + faint tint — so the user reads the icon
+ * as a valid drop target without needing to open the window
+ * first. The selector matches the dock tile's `data-system-id`
+ * so this CSS applies wherever the recycle-bin dock entry
+ * renders (left rail, bottom rail, future placements). */
+.desktop-mode-dock__item[ data-system-id="desktop-mode-recycle-bin" ][ data-desktop-mode-trash-drop-active ] {
+	outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+	outline-offset: 2px;
+	border-radius: 12px;
+	background: color-mix(
+		in srgb,
+		var( --wp-admin-theme-color, #2271b1 ) 14%,
+		transparent
+	);
+	transition:
+		outline-color 80ms ease,
+		background 80ms ease;
+}
+
 .desktop-mode-recycle-bin[ data-desktop-mode-trash-drop-active ]::before {
 	content: '';
 	position: absolute;

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -26,7 +26,7 @@ A **file** on the desktop is a `Desktop_Mode_File` subclass adapting one WordPre
 
 A placement is a **reference** to a WordPress entity, not a copy of it. Removing a placement (`DELETE /placements/<id>` or `desktop_mode_files_remove()`) drops the placement row only — the underlying post, user, attachment, comment, or term is **never** touched. Folder deletion cascades placements via tombstones but still leaves referenced entities intact. This is asserted in `Tests_DesktopMode_FilesStore::test_remove_does_not_delete_underlying_entity` and is the core safety contract of the system. Plugins that want a "delete the post too" flow must call `wp_delete_post()` (or equivalent) themselves — the framework will not do it for them.
 
-A **file type** is a slug that points the registry at the right subclass. The seven built-ins are:
+A **file type** is a slug that points the registry at the right subclass. The built-ins are:
 
 | Slug | Class | Reference shape |
 |---|---|---|
@@ -37,6 +37,10 @@ A **file type** is a slug that points the registry at the right subclass. The se
 | `comment` | `Desktop_Mode_Comment_File` | comment id |
 | `folder` | `Desktop_Mode_Folder_File` | folder row id (Phase 2) |
 | `bookmark` | `Desktop_Mode_Bookmark_File` | URL string |
+| `link` | `Desktop_Mode_Link_File` | URL string — opens in a new browser tab |
+| `embed` | `Desktop_Mode_Embed_File` | URL string — opens in an iframe-backed desktop window; geometry persists on `placement.meta.window` |
+
+`link` and `embed` placements both carry an optional human-friendly label on `placement.meta.name` (set by the wallpaper-menu "New" submenu) — the tile renderer prefers it over `file.title()` so two tiles pointing at the same URL can carry different labels. `embed` placements additionally persist `{ x, y, width, height }` on `placement.meta.window` after every drag-end / resize-end of the spawned window; the next open clamps that geometry to the current desktop area before restoring.
 
 `page` and any custom post type collapse into `post`; `category` and `post_tag` collapse into `term`. UI labels per concrete post type / taxonomy come from the `desktop_mode_file_serialize` filter — there's no need to register a separate type for every CPT.
 
@@ -217,6 +221,8 @@ Three handler kinds:
 | `wp-term-editor` | `term` | `url` | `term.php?taxonomy=…&tag_ID=…` |
 | `wp-comment-editor` | `comment` | `url` | `comment.php?action=editcomment&c=…` |
 | `browser-navigate` | `bookmark` | `js` | `window.open(url, '_blank', 'noopener,noreferrer')` |
+| `desktop-mode-link-opener` | `link` | `js` | `window.open(url, '_blank', 'noopener,noreferrer')` |
+| `desktop-mode-embed-opener` | `embed` | `js` | Opens an iframe-backed window at `url`. Reads `placement.meta.window` for restored geometry, clamps it to the current desktop area, and persists subsequent drag-end / resize-end back to `placement.meta.window` via REST. |
 
 The `folder` type doesn't ship a built-in opener yet — it lands in Phase 3 alongside the folder native window.
 
@@ -348,9 +354,84 @@ A `FilesLayer` is the renderer that mounts on a host element (the `#desktop-mode
 
 The class names and `data-*` attributes are part of the stable contract. The tile is built with `buildTile()` in `src/desktop-files/file-tile.ts`.
 
-### Drag
+### Drag *(reworked in 0.18.0)*
 
-Drag is `PointerEvent`-based with `setPointerCapture`. During pointermove the layer mutates the tile's `style.left` / `style.top` only — no store mutation per frame. On pointerup it optimistically upserts the new position into the store and persists via `PATCH /placements/<id>`. A REST failure rolls back to the previous geometry.
+Drag is owned end-to-end by the centralized `DragManager`
+(`wp.desktop.dragManager`). A tile's `pointerdown` calls
+`dragManager.start({ payload, origin, … })`; the manager attaches its
+own document-level pointermove / pointerup / pointercancel listeners
+and drives the gesture from there. Tiles do NOT call `setPointerCapture`
+— pointer capture is incompatible with HTML5 `dragstart` detection on
+draggable elements (the My WordPress entity-tile drag-out bug, fixed
+in 0.18.0).
+
+Lifecycle:
+
+  1. `pointerdown` → manager session armed (no visual change yet).
+  2. First `pointermove` past 4 px threshold → ghost mounts under the
+     pointer; source tile gets `--dragging` (opacity 0.4).
+  3. Subsequent moves → ghost follows; the registry hit-tests under
+     the cursor; matching drop targets fire `onEnter` / `onLeave`;
+     ghost cursor flips between `copy` / `no-drop`.
+  4. `pointerup` → re-hit-test; an accepting target fires `onDrop`
+     (the FilesLayer's canvas / a folder tile / the Recycle Bin);
+     non-accepting hover ends with `desktop-mode.drag.cancel`
+     (`reason: 'rejected'` or `'no-target'`).
+
+Drop target contract (`wp.desktop.dragManager.registerDropTarget`):
+
+```ts
+const deregister = wp.desktop.dragManager.registerDropTarget( {
+    id: 'my-plugin/dropzone',
+    element: document.querySelector( '#my-zone' ),
+    accept: ( payload ) => payload.type === 'desktop-file',
+    onEnter: ( session ) => { /* visual feedback */ },
+    onLeave: ( session ) => { /* clear feedback */ },
+    onDrop: ( session, ev ) => { /* handle the drop */ },
+} );
+// Later, when the surface unmounts:
+deregister();
+```
+
+Window claim boundary: when the manager's hit-test walks up the DOM
+from `elementFromPoint` and crosses a `.desktop-mode-window` element
+BEFORE finding a registered target, it returns null. This is what
+makes "drop over a Gutenberg admin window" produce reject feedback
+instead of silently routing the drop to the wallpaper underneath. A
+window opts INTO accepting drops by registering a target on its own
+body — the Recycle Bin's `[data-desktop-mode-recycle-bin-root]` is
+the canonical example.
+
+Cancellation: `Escape`, `window.blur`, `document.visibilitychange` to
+hidden, and `pointercancel` all cancel the active session and run a
+single idempotent cleanup (`--dragging`, `--drop-target`,
+`data-desktop-mode-trash-drop-active`, `data-files-drop-active` are
+all stripped from the document). Plugins observing the bus see
+`document` CustomEvents — `desktop-mode.drag.{start,move,enter,leave,
+rejected,commit,cancel,end}`.
+
+For desktop-files specifically, the FilesLayer registers two drop
+targets:
+
+  - The layer host (`#desktop-mode-area` for the wallpaper, the
+    folder window's body for sub-folders) — accepts `'desktop-file'`
+    moves and `'shortcut'` creations. On drop, computes the snapped
+    grid cell and `PATCH`/`POST`s.
+  - Each folder tile — accepts the same payloads but routes them
+    INTO that folder (sets `parentId` on the move, or POSTs a new
+    placement with `parentId = folderId`).
+
+Pinned tiles (registered with `pinned: true` via
+`desktop_mode_register_icon`) skip drag wiring entirely. A pointerdown
+on a pinned tile flashes a `--bump` animation and shows the
+`not-allowed` cursor so the (lack of) interaction reads as
+intentional rather than buggy.
+
+Legacy: HTML5 drag (`setShortcutDragPayload` /
+`hasShortcutPayload` / `readShortcutPayload`) remains exported from
+`drag-shortcut.ts` for plugins that emit cross-window drags via
+`dataTransfer`, but is `@deprecated since 0.18.0`. New code uses the
+manager.
 
 ### Open
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -241,21 +241,48 @@ document.addEventListener( 'desktop-mode-layout-changed', ( e ) => {
 
 ---
 
-### `desktop-mode-drag-start` — Planned (Phase 8)
-Will fire when a drag operation escalates across window boundaries.
+### Drag-and-drop CustomEvents — Stable *(since 0.18.0)*
 
-```typescript
-{ sourceWindowId: string, payload: { id, url, title, thumbnail } }
+Fired on `document` by `wp.desktop.dragManager` for every in-shell
+drag gesture (file tile, entity tile, plugin-defined sources). All
+share `event.detail.payload` carrying the originating
+`{ type, source, data, ghost? }`.
+
+```javascript
+document.addEventListener( 'desktop-mode.drag.start', ( e ) => {
+    // The drag has crossed the threshold; ghost is mounted.
+    // e.detail.payload — see `DragPayload`.
+} );
+document.addEventListener( 'desktop-mode.drag.move', ( e ) => {
+    // Each pointermove past lift. e.detail.{ payload, clientX, clientY }
+} );
+document.addEventListener( 'desktop-mode.drag.enter', ( e ) => {
+    // Cursor entered an accepting target. e.detail.{ payload, targetId }
+} );
+document.addEventListener( 'desktop-mode.drag.leave', ( e ) => {
+    // Cursor left an accepting target. e.detail.{ payload, targetId }
+} );
+document.addEventListener( 'desktop-mode.drag.rejected', ( e ) => {
+    // Cursor over a registered target whose accept() returned false.
+    // e.detail.{ payload, targetId }
+} );
+document.addEventListener( 'desktop-mode.drag.commit', ( e ) => {
+    // Drop landed; target.onDrop has fired.
+    // e.detail.{ payload, targetId }
+} );
+document.addEventListener( 'desktop-mode.drag.cancel', ( e ) => {
+    // Drag aborted (Escape, blur, no-target, rejected, …).
+    // e.detail.{ payload, reason }
+} );
+document.addEventListener( 'desktop-mode.drag.end', ( e ) => {
+    // Always fires last — pair with .start for symmetric bookkeeping.
+    // e.detail.{ payload, reason }
+} );
 ```
 
----
-
-### `desktop-mode-drop` — Planned (Phase 8)
-Will fire when a cross-window drop completes.
-
-```typescript
-{ sourceWindowId: string, targetWindowId: string, payload: { ... } }
-```
+The cross-iframe `wp-desktop-drag-*` events from `wp.desktop.dragBridge`
+(Media Library payload channel) are a separate, lower-level surface
+and remain Stable since 0.14.0.
 
 ---
 

--- a/includes/desktop-files/bootstrap.php
+++ b/includes/desktop-files/bootstrap.php
@@ -27,6 +27,8 @@ require_once DESKTOP_MODE_DIR . 'includes/desktop-files/types/class-desktop-mode
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/types/class-desktop-mode-bookmark-file.php';
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/types/class-desktop-mode-folder-file.php';
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/types/class-desktop-mode-shortcut-file.php';
+require_once DESKTOP_MODE_DIR . 'includes/desktop-files/types/class-desktop-mode-link-file.php';
+require_once DESKTOP_MODE_DIR . 'includes/desktop-files/types/class-desktop-mode-embed-file.php';
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/built-in-types.php';
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/openers.php';
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/built-in-openers.php';

--- a/includes/desktop-files/built-in-openers.php
+++ b/includes/desktop-files/built-in-openers.php
@@ -61,6 +61,18 @@ function desktop_mode_register_builtin_file_openers() {
 			'types' => array( 'bookmark' ),
 			'sort'  => 10,
 		),
+		array(
+			'id'    => 'desktop-mode-link-opener',
+			'label' => __( 'Open in browser', 'desktop-mode' ),
+			'types' => array( 'link' ),
+			'sort'  => 10,
+		),
+		array(
+			'id'    => 'desktop-mode-embed-opener',
+			'label' => __( 'Open as window', 'desktop-mode' ),
+			'types' => array( 'embed' ),
+			'sort'  => 10,
+		),
 	);
 
 	foreach ( $openers as $args ) {

--- a/includes/desktop-files/built-in-types.php
+++ b/includes/desktop-files/built-in-types.php
@@ -70,6 +70,18 @@ function desktop_mode_register_builtin_file_types() {
 			'class' => 'Desktop_Mode_Shortcut_File',
 			'sort'  => 1,
 		),
+		array(
+			'type'  => 'link',
+			'label' => __( 'Web link', 'desktop-mode' ),
+			'class' => 'Desktop_Mode_Link_File',
+			'sort'  => 70,
+		),
+		array(
+			'type'  => 'embed',
+			'label' => __( 'Embedded web window', 'desktop-mode' ),
+			'class' => 'Desktop_Mode_Embed_File',
+			'sort'  => 80,
+		),
 	);
 
 	foreach ( $types as $args ) {

--- a/includes/desktop-files/types/class-desktop-mode-embed-file.php
+++ b/includes/desktop-files/types/class-desktop-mode-embed-file.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Desktop Mode — `embed` file type.
+ *
+ * An "embedded web window" tile — double-click opens the stored URL
+ * in an iframe-based desktop window so the page renders inside the
+ * shell instead of a new browser tab. The URL is the entity
+ * reference; an optional human-friendly name lives on the
+ * placement row's `meta.name`. The window's last `{ x, y, width,
+ * height }` is persisted on `meta.window` after every drag /
+ * resize end so the next open restores that geometry (clamped to
+ * the current desktop area on the JS side).
+ *
+ * @package WPDesktopMode
+ * @since   0.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 0.18.0
+ */
+class Desktop_Mode_Embed_File extends Desktop_Mode_File {
+
+	public static function type(): string {
+		return 'embed';
+	}
+
+	public function exists(): bool {
+		return '' !== $this->url();
+	}
+
+	public function title(): string {
+		$url = $this->url();
+		if ( '' === $url ) {
+			return __( '(missing embed)', 'desktop-mode' );
+		}
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		return is_string( $host ) && '' !== $host ? $host : $url;
+	}
+
+	public function icon(): string {
+		return 'dashicons-welcome-view-site';
+	}
+
+	public function serialize(): array {
+		$shape        = parent::serialize();
+		$shape['url'] = $this->url();
+		return $shape;
+	}
+
+	private function url(): string {
+		$url = esc_url_raw( $this->ref );
+		return is_string( $url ) ? $url : '';
+	}
+}

--- a/includes/desktop-files/types/class-desktop-mode-link-file.php
+++ b/includes/desktop-files/types/class-desktop-mode-link-file.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Desktop Mode — `link` file type.
+ *
+ * A "web link" tile — double-click opens the stored URL in a new
+ * browser tab via `window.open( url, '_blank', 'noopener,noreferrer' )`.
+ * The URL itself is the entity reference; an optional human-friendly
+ * name lives on the placement row's `meta.name` so two tiles
+ * pointing at the same URL can carry different labels.
+ *
+ * @package WPDesktopMode
+ * @since   0.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * @since 0.18.0
+ */
+class Desktop_Mode_Link_File extends Desktop_Mode_File {
+
+	public static function type(): string {
+		return 'link';
+	}
+
+	public function exists(): bool {
+		return '' !== $this->url();
+	}
+
+	public function title(): string {
+		$url = $this->url();
+		if ( '' === $url ) {
+			return __( '(missing link)', 'desktop-mode' );
+		}
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		return is_string( $host ) && '' !== $host ? $host : $url;
+	}
+
+	public function icon(): string {
+		return 'dashicons-admin-links';
+	}
+
+	public function serialize(): array {
+		$shape        = parent::serialize();
+		$shape['url'] = $this->url();
+		return $shape;
+	}
+
+	private function url(): string {
+		$url = esc_url_raw( $this->ref );
+		return is_string( $url ) ? $url : '';
+	}
+}

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -127,6 +127,7 @@ import type { FilesApi } from '../desktop-files';
 import type { WidgetLayer } from '../widgets/layer';
 import type { AiAssistantApi } from '../ai-assistant';
 import type { DragBridgeApi } from '../drag-bridge';
+import type { DragManagerApi } from '../drag';
 import type { WindowConnection, ConnectOptions } from '../connection';
 import type { WallpaperDef } from '../wallpapers/types';
 import type { NativeWindowDef, DesktopConfig } from '../types';
@@ -150,7 +151,7 @@ export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'registerSystemTile', 'registerWindow', 'openWindow', 'cloneTemplate',
 	'onWindow', 'loadVendorScript', 'getWallpaperSurfaces', 'registerModule',
 	'loadModules', 'whenReady', 'ready', 'isReady', 'setDefaultWindow',
-	'refreshMenu', 'config', 'ai', 'dragBridge', 'registerCommand',
+	'refreshMenu', 'config', 'ai', 'dragBridge', 'dragManager', 'registerCommand',
 	'unregisterCommand', 'listCommands', 'registerSettingsTab',
 	'unregisterSettingsTab', 'listSettingsTabs',
 	'registerDockRailRenderer', 'unregisterDockRailRenderer', 'listDockRailRenderers',
@@ -203,6 +204,7 @@ export interface BuildPublicApiDeps {
 	openOsSettings: () => void;
 	aiAssistant: AiAssistantApi;
 	dragBridge: DragBridgeApi;
+	dragManager: DragManagerApi;
 	connect: ( targetWindowId: string, opts?: ConnectOptions ) => WindowConnection;
 	config: DesktopConfig;
 }
@@ -235,6 +237,7 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 		openOsSettings,
 		aiAssistant,
 		dragBridge,
+		dragManager,
 		connect,
 		config,
 	} = deps;
@@ -292,6 +295,7 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 		config,
 		ai: aiAssistant,
 		dragBridge,
+		dragManager,
 		registerCommand,
 		unregisterCommand,
 		listCommands,

--- a/src/desktop-files/built-in-openers.ts
+++ b/src/desktop-files/built-in-openers.ts
@@ -34,6 +34,7 @@ import {
 	snapToEmptyCell,
 } from './grid';
 import { renderPlacementPreview, renderPreviewEmpty } from './preview';
+import { openEmbedWindow } from './embed-window';
 
 interface ConfigShape {
 	adminUrl?: string;
@@ -468,6 +469,38 @@ export function registerBuiltInFileOpeners(): void {
 				// `window.opener` — important since bookmarks
 				// can point anywhere.
 				window.open( url, '_blank', 'noopener,noreferrer' );
+			},
+		},
+	} );
+
+	registerOpener( {
+		id: 'desktop-mode-link-opener',
+		label: 'Open in browser',
+		types: [ 'link' ],
+		isDefault: true,
+		sort: 10,
+		handler: {
+			kind: 'js',
+			open: ( file: DesktopFile ) => {
+				const url = file.ref();
+				if ( ! url ) {
+					return;
+				}
+				window.open( url, '_blank', 'noopener,noreferrer' );
+			},
+		},
+	} );
+
+	registerOpener( {
+		id: 'desktop-mode-embed-opener',
+		label: 'Open as window',
+		types: [ 'embed' ],
+		isDefault: true,
+		sort: 10,
+		handler: {
+			kind: 'js',
+			open: ( file: DesktopFile, ctx ) => {
+				openEmbedWindow( file, ctx );
 			},
 		},
 	} );

--- a/src/desktop-files/built-in-types.ts
+++ b/src/desktop-files/built-in-types.ts
@@ -27,4 +27,6 @@ export function registerBuiltInFileTypes(): void {
 	registerType( { type: 'term', label: 'Taxonomy term', sort: 40 } );
 	registerType( { type: 'comment', label: 'Comment', sort: 50 } );
 	registerType( { type: 'bookmark', label: 'Bookmark', sort: 60 } );
+	registerType( { type: 'link', label: 'Web link', sort: 70 } );
+	registerType( { type: 'embed', label: 'Embedded web window', sort: 80 } );
 }

--- a/src/desktop-files/drag-payloads.ts
+++ b/src/desktop-files/drag-payloads.ts
@@ -1,0 +1,59 @@
+/**
+ * Desktop Mode — Files-on-the-desktop drag payload contracts.
+ *
+ * Two payload shapes flow through the DragManager for desktop-files
+ * gestures. Drop targets switch on `payload.type` and read the
+ * matching `data` shape:
+ *
+ *   - `'desktop-file'` — an existing tile is being moved. The drop
+ *     target either reposistions it (within the same folder) or
+ *     re-parents it (drop on another folder, or drop on the
+ *     wallpaper to move out of a folder).
+ *
+ *   - `'shortcut'`     — a new shortcut is being created. The
+ *     payload carries the external entity reference (`kind` + `ref`,
+ *     e.g. `kind: 'post', ref: '42'`) — the drop target POSTs a new
+ *     placement.
+ *
+ * Both shapes are framework-internal but stable for plugin authors
+ * who want to register their own drop targets that accept these.
+ *
+ * @since 0.18.0
+ */
+
+import type { RestPlacementShape } from './rest';
+
+export interface DesktopFileDragData {
+	/** The placement being dragged (full record). */
+	placement: RestPlacementShape;
+	/** Folder the source tile lives in, BEFORE the drop. */
+	sourceFolderId: number;
+}
+
+export interface ShortcutDragData {
+	/** File-type slug — `'post'`, `'page'`, `'user'`, plugin-defined. */
+	kind: string;
+	/** Opaque ref the file type resolves (post id as string, etc.). */
+	ref: string;
+	/** Optional human-readable label for diagnostics + ghost. */
+	title?: string;
+	/** Optional dashicon class for diagnostics + ghost. */
+	icon?: string;
+}
+
+/** Concrete payload shapes consumed by drop targets. */
+export interface DesktopFileDragPayload {
+	type: 'desktop-file';
+	source: HTMLElement;
+	data: DesktopFileDragData;
+}
+
+export interface ShortcutDragPayload {
+	type: 'shortcut';
+	source: HTMLElement;
+	data: ShortcutDragData;
+}
+
+export type DesktopFilesDragPayload =
+	| DesktopFileDragPayload
+	| ShortcutDragPayload;

--- a/src/desktop-files/drag-shortcut.ts
+++ b/src/desktop-files/drag-shortcut.ts
@@ -1,21 +1,39 @@
 /**
- * Desktop Mode — Cross-window shortcut drag protocol.
+ * Desktop Mode — Cross-window shortcut drag protocol (legacy).
  *
- * A drag source (e.g. the My WordPress entity-list post tiles)
- * sets `application/x-desktop-mode-shortcut+json` on its
- * `dataTransfer` with a `{ type, ref, title, icon }` payload.
- * Drop targets (the FilesLayer on the wallpaper or inside any
- * folder window) read it on `dragover` / `drop` and turn it into
- * a placement at the drop coordinates.
+ * @deprecated since 0.18.0 — superseded by the centralized
+ * {@link DragManagerApi}. The shell no longer wires HTML5
+ * `dragstart` / `drop` for in-shell tile gestures; everything routes
+ * through `wp.desktop.dragManager`. This module remains for
+ * backwards compatibility with third-party plugins that still emit
+ * HTML5 drags with the legacy MIME `application/x-desktop-mode-shortcut+json`,
+ * but new code SHOULD use the manager directly:
  *
- * Native HTML5 drag is the right choice here because it crosses
- * any DOM boundary uniformly — wallpaper, folder windows, future
- * native windows all share the same protocol with no shell-internal
- * plumbing.
+ * ```ts
+ * tile.addEventListener( 'pointerdown', ( e ) => {
+ *     window.wp.desktop.dragManager.start( {
+ *         payload: {
+ *             type: 'shortcut',
+ *             source: tile,
+ *             data: { kind: 'post', ref: String( id ) },
+ *         },
+ *         origin: e,
+ *     } );
+ * } );
+ * ```
  *
- * This module is deliberately tiny and dependency-free so feature
- * bundles (My WordPress, future Posts/Users windows) can import the
- * helper without dragging in the FilesLayer module's full graph.
+ * Why we left HTML5 drag behind:
+ *
+ *   1. `setPointerCapture` (used by tile-rearrange handlers) silently
+ *      breaks HTML5 `dragstart` detection on `draggable=true` elements.
+ *      The browser never fires `dragstart`, so payloads attached to
+ *      `DataTransfer` never reach a drop target. This was the
+ *      long-standing My WordPress entity-tile drag bug.
+ *   2. HTML5 drag has no programmatic cancel. Pressing Escape, alt-
+ *      tabbing, or system modals leave drag state stranded.
+ *   3. The "Lift and Drop" cross-iframe pattern (see architecture.md)
+ *      needs a parent-shell-controlled drag. Pointer-event-driven
+ *      gives us a single mental model.
  *
  * @public
  * @since 0.8.0
@@ -32,10 +50,9 @@ export interface DesktopShortcutDragPayload {
 
 /**
  * Stamp a shortcut payload on a dataTransfer object during a
- * `dragstart`. Sets a `text/plain` fallback so dragging into a
- * plain-text field (notes app, address bar) yields the title rather
- * than `[object Object]`. Marks the drag as `copy` because we never
- * MOVE a tile out of My WordPress — the source survives.
+ * `dragstart`.
+ *
+ * @deprecated since 0.18.0 — use `dragManager.start()` instead.
  */
 export function setShortcutDragPayload(
 	dt: DataTransfer,
@@ -51,9 +68,10 @@ export function setShortcutDragPayload(
 }
 
 /**
- * Whether the drag event carries a shortcut payload. Drop targets
- * use this on `dragover` to decide whether to call
- * `e.preventDefault()` (and so accept the drop).
+ * Whether the drag event carries a shortcut payload.
+ *
+ * @deprecated since 0.18.0 — drop targets register via
+ * `dragManager.registerDropTarget()` and switch on `payload.type`.
  */
 export function hasShortcutPayload( e: DragEvent ): boolean {
 	const types = e.dataTransfer?.types;
@@ -71,6 +89,9 @@ export function hasShortcutPayload( e: DragEvent ): boolean {
 /**
  * Read a shortcut payload from a `drop` event. Returns `null` for
  * malformed / missing data — caller should bail.
+ *
+ * @deprecated since 0.18.0 — drop targets receive the typed payload
+ * directly via `DragSession.payload.data`.
  */
 export function readShortcutPayload(
 	e: DragEvent,

--- a/src/desktop-files/embed-window.ts
+++ b/src/desktop-files/embed-window.ts
@@ -1,0 +1,235 @@
+/**
+ * Desktop Mode — `embed` file-type opener glue.
+ *
+ * Opens a stored URL in an iframe-backed desktop window. Window
+ * geometry persists per-placement: every drag-end / resize-end on
+ * the spawned window writes `{ x, y, width, height }` back into the
+ * placement's `meta.window` via REST so the next open restores the
+ * same shape. On open, the saved geometry is clamped to the
+ * current desktop area — a window saved on a 4K monitor still
+ * fits when the user comes back on a laptop.
+ *
+ * @since 0.18.0
+ */
+
+import { addAction, removeAction, HOOKS } from '../hooks';
+import * as filesRest from './rest';
+import type { DesktopFile } from './file';
+import type { OpenerContext } from './openers';
+
+interface SavedGeometry {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+interface EmbedMeta {
+	name?: string;
+	window?: SavedGeometry;
+}
+
+interface WindowManagerLike {
+	open: ( cfg: Record< string, unknown > ) => unknown;
+	getById?: (
+		id: string,
+	) => { element?: HTMLElement } | undefined;
+}
+
+const ID_PREFIX = 'desktop-mode-embed-';
+
+const DEFAULT_W = 800;
+const DEFAULT_H = 600;
+const MIN_W = 360;
+const MIN_H = 240;
+const PADDING = 16;
+
+/** Tracks placement id -> last persisted geometry, to skip noop PATCHes. */
+const lastPersisted = new Map< string, SavedGeometry >();
+
+/**
+ * Open the embed window for `file` with placement context `ctx`.
+ * No-op when the URL is empty or the window manager isn't ready.
+ */
+export function openEmbedWindow(
+	file: DesktopFile,
+	ctx?: OpenerContext,
+): void {
+	const url = file.ref();
+	if ( ! url ) {
+		return;
+	}
+	// External URLs only — same-origin URLs would be served as
+	// chromeless admin pages anyway, but we don't second-guess the
+	// user; whatever they pasted lands in the iframe src as-is.
+	const wm = ( window.wp as
+		| { desktop?: { windowManager?: WindowManagerLike } }
+		| undefined )?.desktop?.windowManager;
+	if ( ! wm ) {
+		return;
+	}
+
+	const placement = ctx?.placement;
+	const meta = ( placement?.meta ?? null ) as EmbedMeta | null;
+
+	const windowId = placement
+		? `${ ID_PREFIX }${ placement.id }`
+		: `${ ID_PREFIX }anon-${ hash( url ) }`;
+	const customName = meta?.name?.trim() ?? '';
+	const title = customName !== '' ? customName : file.title();
+
+	const cfg: Record< string, unknown > = {
+		id: windowId,
+		baseId: windowId,
+		url,
+		title,
+		icon: file.icon(),
+		minWidth: MIN_W,
+		minHeight: MIN_H,
+	};
+
+	const saved = meta?.window;
+	const area = document.getElementById( 'desktop-mode-area' );
+	const aw = area?.clientWidth ?? window.innerWidth;
+	const ah = area?.clientHeight ?? window.innerHeight;
+
+	if ( saved && Number.isFinite( saved.width ) && Number.isFinite( saved.height ) ) {
+		const { x, y, width, height } = clampGeometry( saved, aw, ah );
+		cfg.x = x;
+		cfg.y = y;
+		cfg.width = width;
+		cfg.height = height;
+	} else {
+		cfg.width = Math.min( DEFAULT_W, Math.max( MIN_W, aw - PADDING * 2 ) );
+		cfg.height = Math.min( DEFAULT_H, Math.max( MIN_H, ah - PADDING * 2 ) );
+	}
+
+	if ( placement ) {
+		// Subscribe to drag/resize-end for this window so we
+		// persist geometry as the user moves it. We don't
+		// subscribe more than once per placement — `installEmbedPersistence`
+		// installs the global router, this just ensures the
+		// `lastPersisted` cache reflects the on-open state.
+		if ( saved ) {
+			lastPersisted.set( windowId, { ...saved } );
+		}
+	}
+
+	wm.open( cfg );
+}
+
+/**
+ * Wire global drag-end / resize-end listeners that persist the
+ * geometry of any embed window back to its placement. Called once
+ * from the bundle entry. Idempotent.
+ */
+let installed = false;
+export function installEmbedPersistence(): void {
+	if ( installed ) {
+		return;
+	}
+	installed = true;
+
+	const onChange = ( payload: unknown ): void => {
+		const p = payload as { windowId?: string } | null;
+		const id = p?.windowId;
+		if ( ! id || ! id.startsWith( ID_PREFIX ) ) {
+			return;
+		}
+		const placementIdStr = id.slice( ID_PREFIX.length );
+		const placementId = parseInt( placementIdStr, 10 );
+		if ( ! placementId ) {
+			return; // anon embed — nowhere to persist
+		}
+		const wm = ( window.wp as
+			| { desktop?: { windowManager?: WindowManagerLike } }
+			| undefined )?.desktop?.windowManager;
+		const win = wm?.getById?.( id );
+		const el = win?.element;
+		if ( ! el ) {
+			return;
+		}
+		const next: SavedGeometry = {
+			x: el.offsetLeft,
+			y: el.offsetTop,
+			width: el.offsetWidth,
+			height: el.offsetHeight,
+		};
+		const prev = lastPersisted.get( id );
+		if (
+			prev &&
+			prev.x === next.x &&
+			prev.y === next.y &&
+			prev.width === next.width &&
+			prev.height === next.height
+		) {
+			return;
+		}
+		lastPersisted.set( id, next );
+		void persist( placementId, next );
+	};
+
+	addAction( HOOKS.WINDOW_DRAG_END, 'desktop-mode-embed-persist', onChange );
+	addAction( HOOKS.WINDOW_RESIZE_END, 'desktop-mode-embed-persist', onChange );
+}
+
+/** For tests only — tear down the persistence wiring. */
+export function __uninstallEmbedPersistenceForTests(): void {
+	if ( ! installed ) {
+		return;
+	}
+	removeAction( HOOKS.WINDOW_DRAG_END, 'desktop-mode-embed-persist' );
+	removeAction( HOOKS.WINDOW_RESIZE_END, 'desktop-mode-embed-persist' );
+	lastPersisted.clear();
+	installed = false;
+}
+
+async function persist( placementId: number, geo: SavedGeometry ): Promise< void > {
+	try {
+		// Read current placement to preserve other meta keys
+		// (notably `meta.name`). We can't fetch a single placement
+		// directly — list the root and find it. Cheap enough for
+		// the resize-end cadence; if it ever shows up in a profile
+		// we add a single-placement REST GET.
+		// NOTE: REST `updatePlacement` replaces `meta` wholesale,
+		// so we MUST send the merged shape.
+		const list = await filesRest.listPlacements( 0 );
+		const row = list.placements.find( ( p ) => p.id === placementId );
+		const prevMeta = ( row?.meta ?? {} ) as Record< string, unknown >;
+		const nextMeta: Record< string, unknown > = {
+			...prevMeta,
+			window: geo,
+		};
+		await filesRest.updatePlacement( placementId, { meta: nextMeta } );
+	} catch ( err ) {
+		// Persistence is best-effort; user can still drag/resize
+		// the window in the active session even if the write fails.
+		// eslint-disable-next-line no-console
+		console.warn( '[desktop-mode] embed window persist failed:', err );
+	}
+}
+
+function clampGeometry(
+	g: SavedGeometry,
+	areaW: number,
+	areaH: number,
+): SavedGeometry {
+	const width = Math.max( MIN_W, Math.min( g.width, areaW - PADDING ) );
+	const height = Math.max( MIN_H, Math.min( g.height, areaH - PADDING ) );
+	const x = Math.max( 0, Math.min( g.x, Math.max( 0, areaW - width ) ) );
+	const y = Math.max( 0, Math.min( g.y, Math.max( 0, areaH - height ) ) );
+	return { x, y, width, height };
+}
+
+function hash( s: string ): string {
+	// Cheap deterministic hash for anonymous embed window ids.
+	// 32-bit math via Math.imul keeps the loop branch-free without
+	// reaching for bitwise ops (bitwise ops are linted off in the
+	// shell). Collision risk is irrelevant — these ids only need to
+	// be stable per URL within a single session.
+	let h = 0;
+	for ( let i = 0; i < s.length; i++ ) {
+		h = ( Math.imul( h, 31 ) + s.charCodeAt( i ) ) % 0x7fffffff;
+	}
+	return Math.abs( h ).toString( 36 );
+}

--- a/src/desktop-files/file-tile.ts
+++ b/src/desktop-files/file-tile.ts
@@ -45,7 +45,16 @@ export function buildTile( placement: RestPlacementShape, folderId: number ): HT
 	tile.style.left = `${ placement.x }px`;
 	tile.style.top = `${ placement.y }px`;
 	tile.setAttribute( 'role', 'listitem' );
-	tile.setAttribute( 'aria-label', file.title() );
+	tile.setAttribute(
+		'aria-label',
+		(
+			placement.meta &&
+			typeof ( placement.meta as { name?: unknown } ).name === 'string' &&
+			( ( placement.meta as { name: string } ).name.trim() !== '' )
+		)
+			? ( placement.meta as { name: string } ).name.trim()
+			: file.title(),
+	);
 	if ( ! placement.file.exists ) {
 		tile.classList.add( `${ TILE_CLASS }--missing` );
 	}
@@ -69,7 +78,15 @@ export function buildTile( placement: RestPlacementShape, folderId: number ): HT
 
 	const label = document.createElement( 'span' );
 	label.className = `${ TILE_CLASS }__label`;
-	label.textContent = file.title();
+	// Per-placement name override — set by the wallpaper menu's
+	// "New web link / window" flow so two tiles pointing at the same
+	// URL can carry different labels. Generic enough that any
+	// type/plugin can opt in by writing `meta.name` on the placement.
+	const metaName =
+		placement.meta && typeof ( placement.meta as { name?: unknown } ).name === 'string'
+			? ( placement.meta as { name: string } ).name.trim()
+			: '';
+	label.textContent = metaName !== '' ? metaName : file.title();
 	tile.appendChild( label );
 
 	// Plugin extension point: custom DOM injected at the end of the
@@ -87,7 +104,14 @@ export function buildTile( placement: RestPlacementShape, folderId: number ): HT
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
 		e.stopPropagation();
-		void openFile( file );
+		void openFile( file, {
+			placement: {
+				id: placement.id,
+				x: placement.x,
+				y: placement.y,
+				meta: placement.meta,
+			},
+		} );
 	} );
 
 	doAction( 'desktop-mode.files.tile-rendered', { tile, placement } );

--- a/src/desktop-files/grid.ts
+++ b/src/desktop-files/grid.ts
@@ -95,6 +95,41 @@ export function snapToEmptyCell(
 }
 
 /**
+ * Find the first empty grid cell in row-major order — fills row 0
+ * across all columns first, then row 1, etc. This is the right pack
+ * order for "drop a new shortcut into a folder" because new tiles
+ * land at the TOP of the visible canvas instead of piling down
+ * column 0 (where they may fall below a short folder window's
+ * fold). `cols` defaults to 4 when no host is supplied.
+ *
+ * Different from {@link snapToEmptyCell}, which is column-major and
+ * is the right order for "clean up" / sort. Both share the
+ * `cellKey()` occupancy convention.
+ *
+ * @since 0.18.0
+ */
+export function nextRowMajorCell(
+	occupied: Set< string >,
+	host?: HTMLElement | null,
+): GridPos {
+	const cols = host
+		? Math.max(
+			1,
+			Math.floor( ( host.clientWidth - GRID_PADDING ) / GRID_CELL_W ),
+		)
+		: 4;
+	const maxCols = Math.max( 1, cols );
+	for ( let row = 0; row < 999; row++ ) {
+		for ( let col = 0; col < maxCols; col++ ) {
+			if ( ! occupied.has( cellKey( col, row ) ) ) {
+				return cellToPos( col, row );
+			}
+		}
+	}
+	return cellToPos( 0, 0 );
+}
+
+/**
  * Build the occupied-set from a placement list. Anything that
  * hits a grid cell counts; placements positioned off-grid are
  * still recorded against the cell their corner snaps to so

--- a/src/desktop-files/index.ts
+++ b/src/desktop-files/index.ts
@@ -40,6 +40,7 @@ import {
 import { installOpenDeps, openFile, type OpenDeps } from './open';
 import { registerBuiltInFileTypes } from './built-in-types';
 import { registerBuiltInFileOpeners } from './built-in-openers';
+import { installEmbedPersistence } from './embed-window';
 import { registerFileAssociationsTab } from './settings-tab';
 import * as filesRest from './rest';
 import {
@@ -58,6 +59,7 @@ import type { DesktopFileShape, DesktopFileTypeServerEntry } from './types';
 
 registerBuiltInFileTypes();
 registerBuiltInFileOpeners();
+installEmbedPersistence();
 registerFileAssociationsTab();
 
 /**

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -28,10 +28,6 @@ import { rest, store as filesStoreApi } from './layer-deps';
 import { buildTile, setTilePosition, TILE_CLASS } from './file-tile';
 import { openTileMenu, type TileMenuItem } from './tile-menu';
 import { openCreateFolderDialog } from './create-folder-dialog';
-import {
-	hasShortcutPayload,
-	readShortcutPayload,
-} from './drag-shortcut';
 import { openFile } from './open';
 import { resolve as resolveFileType } from './registry';
 import {
@@ -41,11 +37,33 @@ import {
 	GRID_CELL_H,
 	GRID_CELL_W,
 	GRID_PADDING,
+	nextRowMajorCell,
 	pointToCell,
 	snapToEmptyCell,
 } from './grid';
 import type { RestPlacementShape } from './rest';
 import type { FilesState } from './store';
+import type { DragManagerApi, DropTarget } from '../drag';
+import { trashFolderWithUndo, trashPlacementWithUndo } from './trash';
+import type {
+	DesktopFileDragData,
+	ShortcutDragData,
+} from './drag-payloads';
+
+/**
+ * Read the runtime DragManager. Boot order guarantees this exists by
+ * the time any layer mounts: `desktop.ts` constructs the manager and
+ * exposes it on `wp.desktop.dragManager` BEFORE `mountFilesLayer()`
+ * is called. We re-read each access rather than caching to make
+ * per-test overrides possible (vitest can stub `wp.desktop.dragManager`
+ * before the layer mounts).
+ */
+function getDragManager(): DragManagerApi | null {
+	const api = (
+		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
+	).wp?.desktop?.dragManager;
+	return api ?? null;
+}
 
 const LAYER_CLASS = 'desktop-mode-files-layer';
 
@@ -92,16 +110,6 @@ export interface FilesLayer {
 	 */
 	reflow: () => void;
 	dispose: () => void;
-}
-
-interface DragState {
-	pointerId: number;
-	tile: HTMLElement;
-	placementId: number;
-	startX: number;
-	startY: number;
-	originX: number;
-	originY: number;
 }
 
 /**
@@ -175,6 +183,20 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		// Wholesale rebuild — simplest correct strategy. Plugins that
 		// want stable decorations re-attach via `tile-rendered`.
 		container.replaceChildren();
+		// Folder drop targets are tile-scoped — the previous tile DOM
+		// nodes are detached by `replaceChildren` above. Deregister
+		// before rebuilding so the registry doesn't keep stale
+		// references (registry uses `id`, so a re-register would
+		// overwrite, but deregistering keeps the list tight while
+		// the new tiles are being built).
+		for ( const [ , deregister ] of folderDropDeregisters ) {
+			try {
+				deregister();
+			} catch {
+				// ignore
+			}
+		}
+		folderDropDeregisters.clear();
 
 		// Pinned tiles (registered with `pinned: true` —
 		// `desktop_mode_register_icon`) anchor to a fixed slot and
@@ -238,8 +260,15 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				setTilePosition( tile, pinnedSlot.x, pinnedSlot.y );
 				tile.classList.add( `${ TILE_CLASS }--pinned` );
 				tile.setAttribute( 'aria-roledescription', 'pinned shortcut' );
-				// No drag wiring; right-click context menu is still
-				// useful (Open / Cleanup / etc.).
+				tile.setAttribute( 'aria-disabled', 'true' );
+				// No drag wiring on pinned tiles by design — they
+				// anchor to a fixed slot. We DO wire a pointerdown
+				// handler that flashes a `--bump` class so the user
+				// gets explicit feedback ("this tile is pinned"
+				// instead of silent non-response) plus the title
+				// attribute that surfaces in browser tooltips and
+				// to assistive tech.
+				attachPinnedTileFeedback( tile );
 				attachContextMenu( tile, placement );
 				attachSelectOnClick( tile, placement );
 				container.appendChild( tile );
@@ -249,18 +278,26 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			if ( moved ) {
 				setTilePosition( tile, moved.x, moved.y );
 			}
-			attachDragHandlers( tile, placement, folderId );
+			attachTileDrag( tile, placement, folderId );
 			attachContextMenu( tile, placement );
 			attachSelectOnClick( tile, placement );
 			// Folder tiles also accept drag-out drops — dropping a
 			// post (or any shortcut payload) on a folder icon files
 			// the shortcut INTO that folder rather than next to the
-			// folder on the wallpaper. Stops propagation so the
-			// layer-level drop handler doesn't also fire.
+			// folder on the wallpaper.
 			if ( placement.file.type === 'folder' ) {
 				const targetFolderId = parseInt( placement.file.ref, 10 );
 				if ( targetFolderId > 0 ) {
-					attachFolderDropTarget( tile, targetFolderId );
+					const dragManager = getDragManager();
+					if ( dragManager ) {
+						const deregister = registerFolderDropTarget(
+							dragManager,
+							tile,
+							targetFolderId,
+							folderId,
+						);
+						folderDropDeregisters.set( placement.id, deregister );
+					}
 				}
 			}
 			container.appendChild( tile );
@@ -286,92 +323,112 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		} );
 	};
 
-	// HTML5 drag-and-drop receiver for cross-window shortcut drops.
-	// Source surfaces (e.g. the My WordPress entity-list post tiles)
-	// set `application/x-desktop-mode-shortcut+json` on their
-	// dataTransfer; here we read it on dragover/drop and turn it
-	// into a placement at the drop coordinates. Same protocol works
-	// uniformly on the wallpaper root layer and inside every folder
-	// window — only the `parentId` differs.
-	const onDragOver = ( e: DragEvent ): void => {
-		if ( ! hasShortcutPayload( e ) ) {
-			return;
-		}
-		e.preventDefault();
-		// Stop bubbling — without this, a folder window nested
-		// inside the wallpaper area would also light up the
-		// wallpaper's drop highlight while the user is hovering
-		// inside the folder window body.
-		e.stopPropagation();
-		if ( e.dataTransfer ) {
-			e.dataTransfer.dropEffect = 'copy';
-		}
-		host.setAttribute( 'data-files-drop-active', '' );
+	// Drop target for the layer's host element. Accepts both
+	// `'desktop-file'` payloads (an existing tile being moved into
+	// this folder, or repositioned within it) and `'shortcut'`
+	// payloads (an external entity — post, page, user — being filed
+	// as a new shortcut). The DragManager hit-tests deepest-first,
+	// so a folder tile WITHIN this canvas claims its own region
+	// before the canvas does.
+	const dropTargetDeregisters: Array< () => void > = [];
+	// Per-folder-tile drop registrations — keyed by placement id so a
+	// repaint can deregister stale entries before rebuilding the
+	// container's children.
+	const folderDropDeregisters: Map< number, () => void > = new Map();
+	const canvasDropTarget: DropTarget = {
+		id: `desktop-mode-files-canvas-${ folderId }`,
+		element: host,
+		accept: ( payload ) =>
+			payload.type === 'desktop-file' || payload.type === 'shortcut',
+		onEnter: () => {
+			host.setAttribute( 'data-files-drop-active', '' );
+		},
+		onLeave: () => {
+			host.removeAttribute( 'data-files-drop-active' );
+		},
+		onDrop: ( session, ev ) => {
+			host.removeAttribute( 'data-files-drop-active' );
+			const rect = container.getBoundingClientRect();
+			const rawX = Math.max( 0, ev.clientX - rect.left );
+			const rawY = Math.max( 0, ev.clientY - rect.top );
+			const peers =
+				filesStoreApi.getState().placementsByFolder.get( folderId ) ?? [];
+
+			if ( session.payload.type === 'desktop-file' ) {
+				const data = session.payload.data as unknown as DesktopFileDragData;
+				const occupied = buildOccupiedSet( peers, data.placement.id );
+				const cell = snapToEmptyCell( rawX, rawY, occupied, host );
+				const next: RestPlacementShape = {
+					...data.placement,
+					x: cell.x,
+					y: cell.y,
+					parentId: folderId,
+				};
+				filesStoreApi.upsertPlacement( next );
+				void rest
+					.updatePlacement( data.placement.id, {
+						x: cell.x,
+						y: cell.y,
+						parentId: folderId,
+					} )
+					.then( ( server ) => {
+						filesStoreApi.upsertPlacement( server, 'remote' );
+					} )
+					.catch( ( err ) => {
+						// eslint-disable-next-line no-console
+						console.error(
+							'[desktop-mode] files: drag persist failed',
+							err,
+						);
+						filesStoreApi.upsertPlacement( data.placement );
+					} );
+				return;
+			}
+
+			if ( session.payload.type === 'shortcut' ) {
+				const data = session.payload.data as unknown as ShortcutDragData;
+				// New shortcut — pack row-major (top-left, then across)
+				// so the new tile lands at a visible cell regardless of
+				// where the user released the cursor. Cursor-position
+				// snap is wrong for shortcut creates because users
+				// rarely aim precisely; row-major is the "tidy" outcome.
+				const occupied = buildOccupiedSet( peers );
+				const cell = nextRowMajorCell( occupied, host );
+				void rest
+					.createPlacement( {
+						parentId: folderId,
+						type: data.kind,
+						ref: data.ref,
+						x: cell.x,
+						y: cell.y,
+					} )
+					.then( ( placement ) => {
+						filesStoreApi.upsertPlacement( placement );
+						doAction( 'desktop-mode.files.shortcut-dropped', {
+							folderId,
+							placement,
+						} );
+					} )
+					.catch( ( err: unknown ) => {
+						// eslint-disable-next-line no-console
+						console.error(
+							'[desktop-mode] shortcut drop failed:',
+							err,
+						);
+					} );
+				// `rawX` / `rawY` retained for parity with desktop-file
+				// case logging if a future hook needs the cursor pos.
+				void rawX;
+				void rawY;
+			}
+		},
 	};
-	const onDragLeave = ( e: DragEvent ): void => {
-		// Only clear the highlight when the pointer truly left the
-		// host — a transition between a child and the host fires
-		// dragleave on the host with `relatedTarget` still inside.
-		if (
-			e.relatedTarget instanceof Node &&
-			host.contains( e.relatedTarget )
-		) {
-			return;
-		}
-		host.removeAttribute( 'data-files-drop-active' );
-	};
-	const onDrop = ( e: DragEvent ): void => {
-		host.removeAttribute( 'data-files-drop-active' );
-		const payload = readShortcutPayload( e );
-		if ( ! payload ) {
-			return;
-		}
-		// If the drop target landed on a folder tile, route into
-		// that folder instead of the current canvas. The folder
-		// tile's own `dragover`/`drop` handlers (attached in
-		// `attachFolderDropTarget` below) handle that case and
-		// stopPropagation on drop, so reaching this branch means
-		// the drop was on bare canvas.
-		e.preventDefault();
-		// Stop bubbling — critical for nested layers (folder
-		// window inside the wallpaper). Without this, dropping in
-		// a folder-window body fires the folder layer's `drop` AND
-		// then bubbles to the wallpaper layer's `drop`, producing
-		// a duplicate placement at the wallpaper root.
-		e.stopPropagation();
-		const rect = container.getBoundingClientRect();
-		const rawX = Math.max( 0, e.clientX - rect.left );
-		const rawY = Math.max( 0, e.clientY - rect.top );
-		const peers =
-			filesStoreApi.getState().placementsByFolder.get( folderId ) ?? [];
-		const occupied = buildOccupiedSet( peers );
-		const cell = snapToEmptyCell( rawX, rawY, occupied, host );
-		void rest
-			.createPlacement( {
-				parentId: folderId,
-				type: payload.type,
-				ref: payload.ref,
-				x: cell.x,
-				y: cell.y,
-			} )
-			.then( ( placement ) => {
-				filesStoreApi.upsertPlacement( placement );
-				doAction( 'desktop-mode.files.shortcut-dropped', {
-					folderId,
-					placement,
-				} );
-			} )
-			.catch( ( err: unknown ) => {
-				// eslint-disable-next-line no-console
-				console.error(
-					'[desktop-mode] shortcut drop failed:',
-					err,
-				);
-			} );
-	};
-	host.addEventListener( 'dragover', onDragOver );
-	host.addEventListener( 'dragleave', onDragLeave );
-	host.addEventListener( 'drop', onDrop );
+	const dragManagerForLayer = getDragManager();
+	if ( dragManagerForLayer ) {
+		dropTargetDeregisters.push(
+			dragManagerForLayer.registerDropTarget( canvasDropTarget ),
+		);
+	}
 
 	// Single-click on tile = select; click on bare canvas =
 	// deselect. Same model as macOS Finder / Explorer. Tile clicks
@@ -595,9 +652,22 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			off();
 			resizeObserver?.disconnect();
 			resizeObserver = null;
-			host.removeEventListener( 'dragover', onDragOver );
-			host.removeEventListener( 'dragleave', onDragLeave );
-			host.removeEventListener( 'drop', onDrop );
+			for ( const deregister of dropTargetDeregisters ) {
+				try {
+					deregister();
+				} catch {
+					// ignore
+				}
+			}
+			dropTargetDeregisters.length = 0;
+			for ( const deregister of folderDropDeregisters.values() ) {
+				try {
+					deregister();
+				} catch {
+					// ignore
+				}
+			}
+			folderDropDeregisters.clear();
 			host.removeEventListener( 'click', onCanvasClick );
 			selectionListeners.clear();
 			container.remove();
@@ -633,221 +703,65 @@ function isPinned( placement: RestPlacementShape ): boolean {
 	return Boolean( placement.file.pinned );
 }
 
-function attachFolderDropTarget(
-	tile: HTMLElement,
-	folderId: number,
-): void {
-	const onOver = ( e: DragEvent ) => {
-		if ( ! hasShortcutPayload( e ) ) {
-			return;
-		}
-		e.preventDefault();
-		e.stopPropagation();
-		if ( e.dataTransfer ) {
-			e.dataTransfer.dropEffect = 'copy';
-		}
-		tile.classList.add( `${ TILE_CLASS }--drop-target` );
-	};
-	const onLeave = ( e: DragEvent ) => {
-		if (
-			e.relatedTarget instanceof Node &&
-			tile.contains( e.relatedTarget )
-		) {
-			return;
-		}
-		tile.classList.remove( `${ TILE_CLASS }--drop-target` );
-	};
-	const onDrop = ( e: DragEvent ) => {
-		tile.classList.remove( `${ TILE_CLASS }--drop-target` );
-		const payload = readShortcutPayload( e );
-		if ( ! payload ) {
-			return;
-		}
-		// Stop the layer-level drop from also firing — it would
-		// otherwise file the shortcut on the canvas next to the
-		// folder.
-		e.preventDefault();
-		e.stopPropagation();
-		const peers =
-			filesStoreApi
-				.getState()
-				.placementsByFolder.get( folderId ) ?? [];
-		const occupied = buildOccupiedSet( peers );
-		const cell = snapToEmptyCell( 0, 0, occupied );
-		void rest
-			.createPlacement( {
-				parentId: folderId,
-				type: payload.type,
-				ref: payload.ref,
-				x: cell.x,
-				y: cell.y,
-			} )
-			.then( ( placement ) => {
-				filesStoreApi.upsertPlacement( placement );
-				doAction( 'desktop-mode.files.shortcut-dropped', {
-					folderId,
-					placement,
-				} );
-			} )
-			.catch( ( err: unknown ) => {
-				// eslint-disable-next-line no-console
-				console.error(
-					'[desktop-mode] shortcut drop into folder failed:',
-					err,
-				);
-			} );
-	};
-	tile.addEventListener( 'dragover', onOver );
-	tile.addEventListener( 'dragleave', onLeave );
-	tile.addEventListener( 'drop', onDrop );
-}
-
 /**
- * Attach pointer-based drag handlers. Drag is transform-only
- * during pointermove (so we don't churn the fingerprint cache
- * on every frame); on pointerup we persist via REST and let
- * the store update flip the fingerprint, which triggers one
- * paint at the new resting position.
+ * Register a folder tile as a drop target. Folder tiles claim their
+ * own hit-test region; the DragManager routes the drop here when the
+ * cursor releases over a folder (the registry's deepest-match wins
+ * over the layer-level canvas target). Returns a deregister function
+ * the caller stores so the next repaint can release the registration
+ * before rebuilding the DOM.
  */
-function attachDragHandlers(
+function registerFolderDropTarget(
+	dragManager: DragManagerApi,
 	tile: HTMLElement,
-	placement: RestPlacementShape,
-	folderId: number,
-): void {
-	let drag: DragState | null = null;
-
-	const onPointerDown = ( e: PointerEvent ): void => {
-		if ( e.button !== 0 ) {
-			return;
-		}
-		// Read the tile's CURRENT visible position from the inline
-		// styles, not the placement's server-stored (x, y). They
-		// diverge when the layer has displaced this tile to dodge
-		// a pinned slot — using `placement.x` would snap the tile
-		// back to its stored coords on the first pointermove
-		// (the "drag jumps to the My WordPress slot" bug).
-		const visibleX = parseFloat( tile.style.left ) || placement.x;
-		const visibleY = parseFloat( tile.style.top ) || placement.y;
-		drag = {
-			pointerId: e.pointerId,
-			tile,
-			placementId: placement.id,
-			startX: e.clientX,
-			startY: e.clientY,
-			originX: visibleX,
-			originY: visibleY,
-		};
-		tile.setPointerCapture( e.pointerId );
-		tile.classList.add( `${ TILE_CLASS }--dragging` );
-	};
-
-	let hoveredTrash: HTMLElement | null = null;
-	const updateTrashHover = ( clientX: number, clientY: number ): void => {
-		// Pointer-capture routes the events to the tile, but
-		// `elementFromPoint` still reports the actual visual stack
-		// — perfect for "is the user currently over a drop zone?".
-		// We highlight `[data-desktop-mode-recycle-bin-root]` (the
-		// only cross-window drop target today) so the user gets a
-		// visual cue that releasing here will trash the tile.
-		const el = document.elementFromPoint( clientX, clientY );
-		const next = el instanceof Element
-			? el.closest< HTMLElement >( '[data-desktop-mode-recycle-bin-root]' )
-			: null;
-		if ( next === hoveredTrash ) {
-			return;
-		}
-		if ( hoveredTrash ) {
-			hoveredTrash.removeAttribute( 'data-desktop-mode-trash-drop-active' );
-		}
-		if ( next ) {
-			next.setAttribute( 'data-desktop-mode-trash-drop-active', '' );
-		}
-		hoveredTrash = next;
-	};
-	const clearTrashHover = (): void => {
-		if ( hoveredTrash ) {
-			hoveredTrash.removeAttribute( 'data-desktop-mode-trash-drop-active' );
-			hoveredTrash = null;
-		}
-	};
-
-	const onPointerMove = ( e: PointerEvent ): void => {
-		if ( ! drag || drag.pointerId !== e.pointerId ) {
-			return;
-		}
-		const dx = e.clientX - drag.startX;
-		const dy = e.clientY - drag.startY;
-		setTilePosition( tile, drag.originX + dx, drag.originY + dy );
-		updateTrashHover( e.clientX, e.clientY );
-	};
-
-	const onPointerEnd = ( e: PointerEvent ): void => {
-		if ( ! drag || drag.pointerId !== e.pointerId ) {
-			return;
-		}
-		tile.classList.remove( `${ TILE_CLASS }--dragging` );
-		clearTrashHover();
-		try {
-			tile.releasePointerCapture( e.pointerId );
-		} catch {
-			// Already released — ignore.
-		}
-		const dx = e.clientX - drag.startX;
-		const dy = e.clientY - drag.startY;
-		const moved = Math.abs( dx ) > 2 || Math.abs( dy ) > 2;
-		const finalX = drag.originX + dx;
-		const finalY = drag.originY + dy;
-		const placementId = drag.placementId;
-		drag = null;
-
-		if ( ! moved ) {
-			// Treat as a click — let the dblclick handler in the tile
-			// builder fire if the user intended that.
-			return;
-		}
-
-		// Cross-window drop targets — these live OUTSIDE the
-		// canvas (e.g. the Recycle Bin native window) and the
-		// pointer-event drag never fires `drop` on them. Hit-test
-		// the cursor's actual element via `elementFromPoint` and
-		// route the gesture before falling through to the canvas
-		// snap. Same hook surface as future drop targets (folder
-		// browsers, share dialogs) — declare a marker attribute
-		// (`data-desktop-mode-shortcut-drop-target="<kind>"`) on
-		// the receiving native window's body and we route here.
-		const dropEl = document.elementFromPoint( e.clientX, e.clientY );
-		const trashTarget = dropEl instanceof Element
-			? dropEl.closest< HTMLElement >( '[data-desktop-mode-recycle-bin-root]' )
-			: null;
-		if ( trashTarget ) {
-			// Snap the tile back optimistically so the user doesn't
-			// see it floating in the wrong cell, then soft-trash via
-			// the existing helper (handles the Undo toast + cross-
-			// window broadcast).
-			void trashPlacementWithUndo( placement );
-			return;
-		}
-
-		// Determine the target cell + whether the drop landed on
-		// another tile. If the occupier is a folder we move INTO
-		// that folder; if it's anything else we snap to the next
-		// empty cell so tiles never overlap.
-		const peers = filesStoreApi.getState().placementsByFolder.get( folderId ) ?? [];
-
-		const droppedOn = findDropTarget( peers, finalX, finalY, placementId );
-		if ( droppedOn && droppedOn.file.type === 'folder' ) {
-			const newParent = parseInt( droppedOn.file.ref, 10 );
-			if ( newParent ) {
-				// Move the tile out of the current folder bucket
-				// (parent change) — the local store handles the
-				// cross-bucket bookkeeping in `upsertPlacement`.
+	targetFolderId: number,
+	currentFolderId: number,
+): () => void {
+	const target: DropTarget = {
+		id: `desktop-mode-files-folder-${ targetFolderId }-tile-${ tile.dataset.placementId ?? '?' }`,
+		element: tile,
+		accept: ( payload ) => {
+			if ( payload.type !== 'desktop-file' && payload.type !== 'shortcut' ) {
+				return false;
+			}
+			if ( payload.type === 'desktop-file' ) {
+				const data = payload.data as unknown as DesktopFileDragData;
+				// Don't accept a folder dropped onto itself.
+				if (
+					data.placement.file.type === 'folder' &&
+					parseInt( data.placement.file.ref, 10 ) === targetFolderId
+				) {
+					return false;
+				}
+				// No-op move: dropping a tile from folder X onto folder
+				// X's own tile would just round-trip via REST. Reject
+				// so the user gets reject feedback instead of a silent
+				// no-op.
+				if ( data.placement.parentId === targetFolderId ) {
+					return false;
+				}
+			}
+			return true;
+		},
+		onEnter: () => {
+			tile.classList.add( `${ TILE_CLASS }--drop-target` );
+		},
+		onLeave: () => {
+			tile.classList.remove( `${ TILE_CLASS }--drop-target` );
+		},
+		onDrop: ( session ) => {
+			tile.classList.remove( `${ TILE_CLASS }--drop-target` );
+			if ( session.payload.type === 'desktop-file' ) {
+				const data = session.payload.data as unknown as DesktopFileDragData;
 				const next: RestPlacementShape = {
-					...placement,
-					parentId: newParent,
+					...data.placement,
+					parentId: targetFolderId,
 				};
 				filesStoreApi.upsertPlacement( next );
 				void rest
-					.updatePlacement( placementId, { parentId: newParent } )
+					.updatePlacement( data.placement.id, {
+						parentId: targetFolderId,
+					} )
 					.then( ( server ) => {
 						filesStoreApi.upsertPlacement( server, 'remote' );
 					} )
@@ -857,73 +771,143 @@ function attachDragHandlers(
 							'[desktop-mode] files: move-into-folder persist failed',
 							err,
 						);
-						// Roll back to the previous parent + position.
-						filesStoreApi.upsertPlacement( placement );
+						filesStoreApi.upsertPlacement( data.placement );
 					} );
 				return;
 			}
-		}
-
-		const occupiedSet = buildOccupiedSet( peers, placementId );
-		// `tile.parentElement` is the layer container; its parent
-		// is the host (desktop area or folder-window body) — that's
-		// the element whose height the snap respects.
-		const host = tile.parentElement?.parentElement ?? null;
-		const cell = snapToEmptyCell( finalX, finalY, occupiedSet, host );
-		const snappedX = cell.x;
-		const snappedY = cell.y;
-
-		// Optimistic store update so the tile stays where it was
-		// dropped even before REST returns.
-		const next: RestPlacementShape = {
-			...placement,
-			x: snappedX,
-			y: snappedY,
-			parentId: folderId,
-		};
-		filesStoreApi.upsertPlacement( next );
-
-		void rest
-			.updatePlacement( placementId, { x: snappedX, y: snappedY } )
-			.then( ( server ) => {
-				filesStoreApi.upsertPlacement( server, 'remote' );
-			} )
-			.catch( ( err ) => {
-				// eslint-disable-next-line no-console
-				console.error( '[desktop-mode] files: drag persist failed', err );
-				// Roll back the optimistic update.
-				filesStoreApi.upsertPlacement( placement );
-			} );
+			if ( session.payload.type === 'shortcut' ) {
+				const data = session.payload.data as unknown as ShortcutDragData;
+				const peers =
+					filesStoreApi
+						.getState()
+						.placementsByFolder.get( targetFolderId ) ?? [];
+				// Row-major pack so newly-filed shortcuts land at the
+				// top of the (likely-not-yet-mounted) folder window.
+				// We can't read the destination folder window's host
+				// width from here, so default to 4 cols inside
+				// `nextRowMajorCell` — sensible for any folder window.
+				const cell = nextRowMajorCell( buildOccupiedSet( peers ) );
+				void rest
+					.createPlacement( {
+						parentId: targetFolderId,
+						type: data.kind,
+						ref: data.ref,
+						x: cell.x,
+						y: cell.y,
+					} )
+					.then( ( placement ) => {
+						filesStoreApi.upsertPlacement( placement );
+						doAction( 'desktop-mode.files.shortcut-dropped', {
+							folderId: targetFolderId,
+							placement,
+						} );
+					} )
+					.catch( ( err: unknown ) => {
+						// eslint-disable-next-line no-console
+						console.error(
+							'[desktop-mode] shortcut drop into folder failed:',
+							err,
+						);
+					} );
+			}
+		},
 	};
-
-	tile.addEventListener( 'pointerdown', onPointerDown );
-	tile.addEventListener( 'pointermove', onPointerMove );
-	tile.addEventListener( 'pointerup', onPointerEnd );
-	tile.addEventListener( 'pointercancel', onPointerEnd );
+	// `currentFolderId` is preserved in the closure so a future
+	// extension (e.g. tracking moves vs. shortcut creations from the
+	// SAME folder) has the parameter ready.
+	void currentFolderId;
+	return dragManager.registerDropTarget( target );
 }
 
 /**
- * Find the placement currently sitting on the cell `(x, y)` maps
- * to (excluding the moving placement). Returns null when the
- * target cell is empty.
+ * Attach the pointer-based drag start handler to a draggable tile.
+ * The DragManager owns everything after `pointerdown`: the document-
+ * level pointermove/up listeners, the ghost element, hit-testing,
+ * cancellation. We just translate the visible position into the
+ * payload `data` so drop targets can compute snap geometry without
+ * a second round-trip through the layer.
+ *
+ * Crucially: we do NOT call `setPointerCapture` here. Pointer capture
+ * redirects subsequent pointer events to the captured element, which
+ * historically broke HTML5 drag-detection on tiles that were also
+ * `draggable=true` (the My WordPress entity-tile bug). The
+ * DragManager's document-level listeners need no capture and pay
+ * nothing for not having one.
  */
-function findDropTarget(
-	peers: RestPlacementShape[],
-	x: number,
-	y: number,
-	excludeId: number,
-): RestPlacementShape | null {
-	const cell = pointToCell( x, y );
-	for ( const p of peers ) {
-		if ( p.id === excludeId ) {
-			continue;
+function attachTileDrag(
+	tile: HTMLElement,
+	placement: RestPlacementShape,
+	folderId: number,
+): void {
+	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		if ( e.button !== 0 ) {
+			return;
 		}
-		const c = pointToCell( p.x, p.y );
-		if ( c.col === cell.col && c.row === cell.row ) {
-			return p;
+		const dragManager = getDragManager();
+		if ( ! dragManager ) {
+			// Manager not available (test, headless boot). Fall
+			// through to the click/select handler so the tile is at
+			// least selectable.
+			return;
 		}
-	}
-	return null;
+		// Read the tile's CURRENT visible position from the inline
+		// styles, not the placement's server-stored (x, y). They
+		// diverge when the layer has displaced this tile to dodge
+		// a pinned slot — using `placement.x` would snap the tile
+		// back to its stored coords on the first pointermove (the
+		// "drag jumps to the pinned slot" bug).
+		const visibleX = parseFloat( tile.style.left ) || placement.x;
+		const visibleY = parseFloat( tile.style.top ) || placement.y;
+		const session = dragManager.start( {
+			payload: {
+				type: 'desktop-file',
+				source: tile,
+				data: {
+					placement,
+					sourceFolderId: folderId,
+				} satisfies DesktopFileDragData,
+				ghost: {
+					offsetX: e.clientX - tile.getBoundingClientRect().left,
+					offsetY: e.clientY - tile.getBoundingClientRect().top,
+				},
+			},
+			origin: e,
+			// `onClickOnly` intentionally empty — a tile click is
+			// handled by the dedicated `attachSelectOnClick` listener
+			// below, which fires from the regular `click` event after
+			// a sub-threshold pointerup. The manager won't fire a
+			// `click` itself; the browser does.
+		} );
+		// Preserve a reference for diagnostics — the manager owns
+		// lifecycle past this point.
+		void session;
+		void visibleX;
+		void visibleY;
+	} );
+}
+
+/**
+ * Pinned tiles ("My WordPress", Recycle Bin) anchor to a fixed slot
+ * by design. We don't wire drag, but we DO add a "bumped" cosmetic
+ * affordance on pointerdown so the user gets explicit feedback —
+ * silent non-response feels broken; an animated bump + a tooltip
+ * reads as "this tile is intentionally fixed."
+ */
+function attachPinnedTileFeedback( tile: HTMLElement ): void {
+	tile.title = tile.title || 'Pinned shortcut — anchored to this slot';
+	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		if ( e.button !== 0 ) {
+			return;
+		}
+		tile.classList.remove( `${ TILE_CLASS }--bump` );
+		// Force a reflow so re-adding the class restarts the CSS
+		// animation. `void` discards the read.
+		void tile.offsetWidth;
+		tile.classList.add( `${ TILE_CLASS }--bump` );
+	} );
+	tile.addEventListener( 'animationend', () => {
+		tile.classList.remove( `${ TILE_CLASS }--bump` );
+	} );
 }
 
 /**
@@ -933,126 +917,6 @@ function findDropTarget(
  * Trash" that drops only the placement (the entity stays
  * intact — that's the file-references-not-copies contract).
  */
-
-/**
- * Surface a toast for soft-trashed items with an Undo affordance.
- * Used by both placement and folder trash flows so the message
- * shape stays consistent.
- */
-/**
- * Broadcast a "this kind of thing changed in trash state" event so
- * cross-window listeners (recycle-bin, badge counters, …) can
- * refresh without waiting for the next Heartbeat tick. Mirrors the
- * per-domain channels the bin subscribes to for posts / comments.
- */
-function broadcastFilesChange( kind: 'placement' | 'shortcut' | 'folder' ): void {
-	const api = ( window as { wp?: { desktop?: { broadcast?: ( topic: string, payload: unknown ) => void } } } )
-		.wp?.desktop;
-	api?.broadcast?.( `desktop-mode.${ kind }.changed`, { reason: 'trash' } );
-}
-
-function showTrashedToast(
-	message: string,
-	onUndo: () => void,
-): void {
-	const api = ( window as { wp?: { desktop?: { showToast?: ( opts: unknown ) => void } } } )
-		.wp?.desktop;
-	if ( ! api?.showToast ) {
-		return;
-	}
-	api.showToast( {
-		message,
-		duration: 6000,
-		action: {
-			label: 'Undo',
-			onClick: onUndo,
-		},
-	} );
-}
-
-/**
- * Soft-trash a placement with optimistic local eviction + an
- * Undo toast. Rollback on REST failure re-hydrates the parent
- * folder so the store catches up with whatever the server thinks.
- */
-async function trashPlacementWithUndo(
-	placement: RestPlacementShape,
-): Promise< void > {
-	const placementId = placement.id;
-	const parentId = placement.parentId;
-	const title = placement.file?.title ?? 'Item';
-	const kind: 'placement' | 'shortcut' =
-		placement.file?.type === 'shortcut' ? 'shortcut' : 'placement';
-	filesStoreApi.removePlacement( placementId );
-	try {
-		await rest.deletePlacement( placementId );
-		broadcastFilesChange( kind );
-		showTrashedToast(
-			`"${ title }" moved to Trash`,
-			async () => {
-				try {
-					await rest.restoreTrashedItem( placementId, 'placement' );
-					const res = await rest.listPlacements( parentId );
-					filesStoreApi.setFolderPlacements( parentId, res.placements );
-					broadcastFilesChange( kind );
-				} catch ( err ) {
-					// eslint-disable-next-line no-console
-					console.error( '[desktop-mode] restore failed:', err );
-				}
-			},
-		);
-	} catch ( err ) {
-		// eslint-disable-next-line no-console
-		console.error( '[desktop-mode] deletePlacement failed:', err );
-		void rest.listPlacements( parentId ).then( ( res ) => {
-			filesStoreApi.setFolderPlacements( parentId, res.placements );
-		} );
-	}
-}
-
-/**
- * Soft-trash a folder placement. Cascades server-side to every
- * child placement; Undo restores the folder + its cascaded
- * children in one round-trip via the recycle-bin endpoint.
- */
-async function trashFolderWithUndo(
-	placement: RestPlacementShape,
-): Promise< void > {
-	const folderId = parseInt( placement.file.ref, 10 );
-	if ( ! folderId ) {
-		return;
-	}
-	const placementId = placement.id;
-	const parentId = placement.parentId;
-	const title = placement.file?.title ?? 'Folder';
-	filesStoreApi.removePlacement( placementId );
-	filesStoreApi.removeFolder( folderId );
-	try {
-		await rest.deleteFolder( folderId );
-		broadcastFilesChange( 'folder' );
-		showTrashedToast(
-			`"${ title }" moved to Trash`,
-			async () => {
-				try {
-					await rest.restoreTrashedItem( folderId, 'folder' );
-					const res = await rest.listPlacements( parentId );
-					filesStoreApi.setFolderPlacements( parentId, res.placements );
-					broadcastFilesChange( 'folder' );
-				} catch ( err ) {
-					// eslint-disable-next-line no-console
-					console.error( '[desktop-mode] restore folder failed:', err );
-				}
-			},
-		);
-	} catch ( err ) {
-		// eslint-disable-next-line no-console
-		console.error( '[desktop-mode] deleteFolder failed:', err );
-		void rest.listPlacements( parentId ).then( ( res ) => {
-			filesStoreApi.setFolderPlacements( parentId, res.placements );
-		} );
-	}
-}
-
 function attachContextMenu(
 	tile: HTMLElement,
 	placement: RestPlacementShape,

--- a/src/desktop-files/open.ts
+++ b/src/desktop-files/open.ts
@@ -11,7 +11,7 @@
  */
 
 import { doAction } from '../hooks';
-import { resolveOpener } from './openers';
+import { resolveOpener, type OpenerContext } from './openers';
 import type { DesktopFile } from './file';
 
 export interface OpenDeps {
@@ -35,7 +35,10 @@ export function installOpenDeps( next: OpenDeps ): void {
  * when something opened, `false` when no opener could handle the
  * file (caller may surface a "no app" toast).
  */
-export async function openFile( file: DesktopFile ): Promise< boolean > {
+export async function openFile(
+	file: DesktopFile,
+	ctx?: OpenerContext,
+): Promise< boolean > {
 	if ( ! deps ) {
 		// eslint-disable-next-line no-console
 		console.warn(
@@ -79,7 +82,7 @@ export async function openFile( file: DesktopFile ): Promise< boolean > {
 			return opened;
 		}
 		// 'js'.
-		await handler.open( file );
+		await handler.open( file, ctx );
 		doAction( 'desktop-mode.files.opened', { file, openerId: opener.id, kind: 'js' } );
 		return true;
 	} catch ( err ) {

--- a/src/desktop-files/openers.ts
+++ b/src/desktop-files/openers.ts
@@ -52,10 +52,30 @@ export interface NativeWindowOpenerHandler {
 	config?: ( file: DesktopFile ) => unknown;
 }
 
+/**
+ * Optional context passed to opener handlers. Provided when the
+ * caller knows which placement triggered the open (e.g. a tile
+ * dblclick); openers that need the placement's `meta` (saved
+ * window geometry, custom names, …) can read it here.
+ */
+export interface OpenerContext {
+	/** The placement that originated the open, when known. */
+	placement?: {
+		id: number;
+		x: number;
+		y: number;
+		meta: Record< string, unknown > | null;
+	};
+}
+
 export interface JsOpenerHandler {
 	kind: 'js';
-	/** Free-form opener — runs in the shell context. */
-	open: ( file: DesktopFile ) => void | Promise< void >;
+	/**
+	 * Free-form opener — runs in the shell context. The `ctx`
+	 * argument is populated when the caller has placement context;
+	 * legacy openers that ignore it keep working.
+	 */
+	open: ( file: DesktopFile, ctx?: OpenerContext ) => void | Promise< void >;
 }
 
 export type OpenerHandler =

--- a/src/desktop-files/recycle-bin-targets.ts
+++ b/src/desktop-files/recycle-bin-targets.ts
@@ -1,0 +1,240 @@
+/**
+ * Desktop Mode — Recycle bin drop targets.
+ *
+ * Registers the cross-window drop zones that accept a soft-trash
+ * gesture from a desktop file tile:
+ *
+ *   1. The recycle-bin tile on the wallpaper. The bin is registered
+ *      via `desktop_mode_register_icon()` and surfaces in the unified
+ *      files layer as a `'shortcut'` placement carrying
+ *      `data-file-ref="desktop-mode-recycle-bin"`. We also accept the
+ *      legacy desktop-icon rail (`[data-icon-id]`) and any dock-side
+ *      bridge (`[data-system-id]`) so the registration is robust to
+ *      future layout shifts.
+ *
+ *   2. The recycle-bin native window's body
+ *      (`[data-desktop-mode-recycle-bin-root]`). Registered on
+ *      `WINDOW_OPENED`, deregistered on `WINDOW_CLOSED`.
+ *
+ * Both targets accept payloads of type `'desktop-file'`. On drop they
+ * route to `trashByFileType()` — the same flow the right-click "Move
+ * to Trash" menu uses, including the Undo toast and the cross-window
+ * broadcast.
+ *
+ * Re-discovery: the wallpaper's bin tile is rebuilt on every store
+ * change (the FilesLayer's wholesale repaint). We listen for both
+ * `desktop-mode-files-changed` (store mutations) and
+ * `HOOKS.DOCK_AFTER_RENDER` (legacy dock rebuild) and a
+ * `MutationObserver` on the wallpaper area as a belt-and-braces
+ * fallback so the drop target is guaranteed to point at the LIVE
+ * DOM element.
+ *
+ * @since 0.18.0
+ */
+
+import { addAction, HOOKS } from '../hooks';
+import type { DragManagerApi, DragSession } from '../drag';
+import { trashByFileType } from './trash';
+import type { RestPlacementShape } from './rest';
+
+const TRASH_DROP_ACTIVE_ATTR = 'data-desktop-mode-trash-drop-active';
+const RECYCLE_BIN_WINDOW_ID = 'desktop-mode-recycle-bin';
+
+/**
+ * Selectors that all match the recycle bin tile, in order of
+ * preference. The first matching element wins.
+ *
+ *   - `.desktop-mode-file-tile[data-file-ref="…"]` — the unified
+ *     files layer's representation (current default since 0.9.0).
+ *   - `[data-icon-id="…"]` — legacy desktop-icons rail
+ *     (`src/desktop-icons.ts`), still rendered when the files
+ *     layer is absent.
+ *   - `[data-system-id="…"]` — any dock-side system-tile bridge.
+ */
+const BIN_TILE_SELECTORS = [
+	`.desktop-mode-file-tile[data-file-ref="${ RECYCLE_BIN_WINDOW_ID }"]`,
+	`[data-icon-id="${ RECYCLE_BIN_WINDOW_ID }"]`,
+	`[data-system-id="${ RECYCLE_BIN_WINDOW_ID }"]`,
+];
+
+function findBinTile(): HTMLElement | null {
+	for ( const sel of BIN_TILE_SELECTORS ) {
+		const el = document.querySelector( sel );
+		if ( el instanceof HTMLElement ) {
+			return el;
+		}
+	}
+	return null;
+}
+
+let _installed = false;
+let _dockDeregister: ( () => void ) | null = null;
+let _windowDeregister: ( () => void ) | null = null;
+let _binMutationObserver: MutationObserver | null = null;
+
+interface DesktopFilePayloadData {
+	placement: RestPlacementShape;
+}
+
+function isDesktopFilePayload(
+	session: DragSession,
+): session is DragSession & { payload: { type: 'desktop-file'; data: DesktopFilePayloadData } } {
+	return session.payload.type === 'desktop-file';
+}
+
+function registerOn(
+	dragManager: DragManagerApi,
+	id: string,
+	el: HTMLElement,
+): () => void {
+	return dragManager.registerDropTarget( {
+		id,
+		element: el,
+		accept: ( payload ) => payload.type === 'desktop-file',
+		onEnter: () => {
+			el.setAttribute( TRASH_DROP_ACTIVE_ATTR, '' );
+		},
+		onLeave: () => {
+			el.removeAttribute( TRASH_DROP_ACTIVE_ATTR );
+		},
+		onDrop: ( session ) => {
+			el.removeAttribute( TRASH_DROP_ACTIVE_ATTR );
+			if ( ! isDesktopFilePayload( session ) ) {
+				return;
+			}
+			const placement = session.payload.data.placement;
+			void trashByFileType( placement );
+		},
+	} );
+}
+
+/**
+ * Wire up the recycle-bin drop targets. Idempotent — calling twice
+ * is safe (the second call is a no-op).
+ */
+export function installRecycleBinDropTargets( dragManager: DragManagerApi ): void {
+	if ( _installed ) {
+		return;
+	}
+	_installed = true;
+
+	// Re-register the bin TILE drop target whenever the wallpaper
+	// might have rebuilt it. The unified files layer rebuilds tile
+	// DOM on every store change (`desktop-mode-files-changed`); the
+	// legacy dock rail rebuilds on `DOCK_AFTER_RENDER`. We listen to
+	// both and re-discover via `findBinTile()`. Idempotent
+	// re-registration via the registry's id-based replacement.
+	const reprobeTile = (): void => {
+		const el = findBinTile();
+		if ( ! el ) {
+			// Tile gone (legacy rail, no placement yet) — drop the
+			// stale registration so the registry doesn't keep a
+			// detached element.
+			_dockDeregister?.();
+			_dockDeregister = null;
+			return;
+		}
+		// If the registered element is still the live tile, no work.
+		if ( _dockDeregister && getRegisteredElementId( dragManager ) === el ) {
+			return;
+		}
+		_dockDeregister?.();
+		_dockDeregister = registerOn( dragManager, 'recycle-bin-dock', el );
+	};
+
+	// Initial probe — covers the case where the dock has already
+	// rendered or the wallpaper layer has already mounted by the
+	// time we run.
+	reprobeTile();
+
+	// Files-layer rebuild signal. Fires after every placement
+	// upsert/remove that flips the layer's fingerprint. The bin's
+	// tile DOM is replaced wholesale, so re-discover and re-register.
+	document.addEventListener( 'desktop-mode-files-changed', reprobeTile );
+
+	// Legacy desktop-icons rail rebuild signal — `renderDesktopIcons`
+	// fires this CustomEvent (and the dock-after-render hook) on each
+	// render.
+	document.addEventListener( 'desktop-mode-desktop-icons-rendered', reprobeTile );
+	addAction(
+		HOOKS.DOCK_AFTER_RENDER,
+		'desktop-mode/files/recycle-bin-dock-target',
+		reprobeTile,
+	);
+
+	// Belt-and-braces: a MutationObserver on the wallpaper area
+	// catches any DOM swap we missed (third-party plugin replacing
+	// the tile, future renderer we don't know about). Disconnects
+	// only on test reset; in production it lives forever.
+	if ( typeof MutationObserver !== 'undefined' ) {
+		_binMutationObserver = new MutationObserver( () => {
+			reprobeTile();
+		} );
+		const desktopArea =
+			document.getElementById( 'desktop-mode-area' ) ?? document.body;
+		_binMutationObserver.observe( desktopArea, {
+			childList: true,
+			subtree: true,
+		} );
+	}
+
+	// Window body — register on open, deregister on close.
+	addAction(
+		HOOKS.WINDOW_OPENED,
+		'desktop-mode/files/recycle-bin-window-target',
+		( detail: { windowId?: string } ) => {
+			if ( detail.windowId !== RECYCLE_BIN_WINDOW_ID ) {
+				return;
+			}
+			_windowDeregister?.();
+			_windowDeregister = null;
+			const el = document.querySelector(
+				'[data-desktop-mode-recycle-bin-root]',
+			);
+			if ( el instanceof HTMLElement ) {
+				_windowDeregister = registerOn(
+					dragManager,
+					'recycle-bin-window',
+					el,
+				);
+			}
+		},
+	);
+
+	addAction(
+		HOOKS.WINDOW_CLOSED,
+		'desktop-mode/files/recycle-bin-window-cleanup',
+		( detail: { windowId?: string } ) => {
+			if ( detail.windowId !== RECYCLE_BIN_WINDOW_ID ) {
+				return;
+			}
+			_windowDeregister?.();
+			_windowDeregister = null;
+		},
+	);
+}
+
+/**
+ * Read the live `element` of the currently-registered
+ * `recycle-bin-dock` target, or `null` if not registered. Used by
+ * `reprobeTile` to skip re-registration when the element hasn't
+ * changed.
+ */
+function getRegisteredElementId( dragManager: DragManagerApi ): HTMLElement | null {
+	const t = dragManager
+		.debug()
+		.listTargets()
+		.find( ( target ) => target.id === 'recycle-bin-dock' );
+	return t ? t.element : null;
+}
+
+/** Test-only — resets the install latch + clears registrations. */
+export function __resetRecycleBinDropTargetsForTests(): void {
+	_dockDeregister?.();
+	_windowDeregister?.();
+	_binMutationObserver?.disconnect();
+	_dockDeregister = null;
+	_windowDeregister = null;
+	_binMutationObserver = null;
+	_installed = false;
+}

--- a/src/desktop-files/store.ts
+++ b/src/desktop-files/store.ts
@@ -67,21 +67,45 @@ export function setFolderPlacements( folderId: number, placements: RestPlacement
 
 /** Insert / replace a single placement (post-create, post-update). */
 export function upsertPlacement( placement: RestPlacementShape, source: 'local' | 'remote' = 'local' ): void {
+	// Guard: a malformed REST response or a caller passing a
+	// stale promise resolution can land here with `null` /
+	// `undefined`. Earlier this would throw inside the bucket
+	// `findIndex` callback (`p.id === placement.id`) and the
+	// caller's catch block would log a confusing
+	// "Cannot read properties of null" trace; the underlying
+	// failure was the upstream call returning nothing useful.
+	// Bail loudly instead so debugging starts at the real cause.
+	if ( ! placement || typeof placement.id !== 'number' ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'[desktop-mode] upsertPlacement called with a non-placement value; ignoring.',
+			placement,
+		);
+		return;
+	}
+
 	const store = getFilesStore();
 	const next = new Map( store.state.placementsByFolder );
 
 	// Remove from any existing folder bucket so a parent change
-	// doesn't leave a ghost copy in the previous folder.
+	// doesn't leave a ghost copy in the previous folder. Filter
+	// nulls defensively — a buggy plugin (or an interrupted
+	// optimistic update) could have left a hole that would
+	// otherwise crash the comparison callback.
 	for ( const [ folderId, list ] of next ) {
-		const idx = list.findIndex( ( p ) => p.id === placement.id );
+		const idx = list.findIndex( ( p ) => p && p.id === placement.id );
 		if ( idx >= 0 && folderId !== placement.parentId ) {
-			const copy = list.slice();
-			copy.splice( idx, 1 );
+			const copy = list.filter( Boolean ) as RestPlacementShape[];
+			const removeAt = copy.findIndex( ( p ) => p.id === placement.id );
+			if ( removeAt >= 0 ) {
+				copy.splice( removeAt, 1 );
+			}
 			next.set( folderId, copy );
 		}
 	}
 
-	const target = next.get( placement.parentId )?.slice() ?? [];
+	const rawTarget = next.get( placement.parentId )?.slice() ?? [];
+	const target = rawTarget.filter( Boolean ) as RestPlacementShape[];
 	const idx = target.findIndex( ( p ) => p.id === placement.id );
 	if ( idx >= 0 ) {
 		target[ idx ] = placement;
@@ -101,10 +125,11 @@ export function removePlacement( placementId: number, source: 'local' | 'remote'
 	const next = new Map( store.state.placementsByFolder );
 	let touchedFolder: number | undefined;
 	for ( const [ folderId, list ] of next ) {
-		const idx = list.findIndex( ( p ) => p.id === placementId );
+		const idx = list.findIndex( ( p ) => p && p.id === placementId );
 		if ( idx >= 0 ) {
-			const copy = list.slice();
-			copy.splice( idx, 1 );
+			const copy = ( list.filter( Boolean ) as RestPlacementShape[] ).filter(
+				( p ) => p.id !== placementId,
+			);
 			next.set( folderId, copy );
 			touchedFolder = folderId;
 		}

--- a/src/desktop-files/trash.ts
+++ b/src/desktop-files/trash.ts
@@ -1,0 +1,146 @@
+/**
+ * Desktop Mode — Files-on-the-desktop trash helpers.
+ *
+ * Soft-trash a placement (or folder placement) with optimistic local
+ * eviction, an Undo toast, and a cross-window broadcast so other
+ * shell surfaces (Recycle Bin badge, ancestral folder windows) refresh
+ * without waiting for the next Heartbeat tick.
+ *
+ * Lives in its own module so:
+ *
+ *   - The wallpaper layer (`layer.ts`) can call it from a tile drop
+ *     onto the recycle bin.
+ *   - The recycle-bin-targets module can call it directly from its
+ *     own globally-registered drop targets (dock icon + window body).
+ *   - Tests can stub the REST surface and assert just the toast +
+ *     broadcast plumbing.
+ *
+ * Extracted from `layer.ts` in 0.18.0 (drag-and-drop rework).
+ *
+ * @since 0.18.0
+ */
+
+import { rest, store as filesStoreApi } from './layer-deps';
+import type { RestPlacementShape } from './rest';
+
+/**
+ * Broadcast a "this kind of thing changed in trash state" event so
+ * cross-window listeners (recycle-bin, badge counters, …) can refresh
+ * without waiting for the next Heartbeat tick.
+ */
+function broadcastFilesChange( kind: 'placement' | 'shortcut' | 'folder' ): void {
+	const api = (
+		window as {
+			wp?: { desktop?: { broadcast?: ( topic: string, payload: unknown ) => void } };
+		}
+	).wp?.desktop;
+	api?.broadcast?.( `desktop-mode.${ kind }.changed`, { reason: 'trash' } );
+}
+
+function showTrashedToast( message: string, onUndo: () => void ): void {
+	const api = (
+		window as {
+			wp?: { desktop?: { showToast?: ( opts: unknown ) => void } };
+		}
+	).wp?.desktop;
+	if ( ! api?.showToast ) {
+		return;
+	}
+	api.showToast( {
+		message,
+		duration: 6000,
+		action: {
+			label: 'Undo',
+			onClick: onUndo,
+		},
+	} );
+}
+
+/**
+ * Soft-trash a placement with optimistic local eviction + an Undo
+ * toast. Rollback on REST failure re-hydrates the parent folder so
+ * the store catches up with whatever the server thinks.
+ */
+export async function trashPlacementWithUndo(
+	placement: RestPlacementShape,
+): Promise< void > {
+	const placementId = placement.id;
+	const parentId = placement.parentId;
+	const title = placement.file?.title ?? 'Item';
+	const kind: 'placement' | 'shortcut' =
+		placement.file?.type === 'shortcut' ? 'shortcut' : 'placement';
+	filesStoreApi.removePlacement( placementId );
+	try {
+		await rest.deletePlacement( placementId );
+		broadcastFilesChange( kind );
+		showTrashedToast( `"${ title }" moved to Trash`, async () => {
+			try {
+				await rest.restoreTrashedItem( placementId, 'placement' );
+				const res = await rest.listPlacements( parentId );
+				filesStoreApi.setFolderPlacements( parentId, res.placements );
+				broadcastFilesChange( kind );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( '[desktop-mode] restore failed:', err );
+			}
+		} );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( '[desktop-mode] deletePlacement failed:', err );
+		void rest.listPlacements( parentId ).then( ( res ) => {
+			filesStoreApi.setFolderPlacements( parentId, res.placements );
+		} );
+	}
+}
+
+/**
+ * Soft-trash a folder placement. Cascades server-side to every child
+ * placement; Undo restores the folder + its cascaded children in one
+ * round-trip via the recycle-bin endpoint.
+ */
+export async function trashFolderWithUndo(
+	placement: RestPlacementShape,
+): Promise< void > {
+	const folderId = parseInt( placement.file.ref, 10 );
+	if ( ! folderId ) {
+		return;
+	}
+	const placementId = placement.id;
+	const parentId = placement.parentId;
+	const title = placement.file?.title ?? 'Folder';
+	filesStoreApi.removePlacement( placementId );
+	filesStoreApi.removeFolder( folderId );
+	try {
+		await rest.deleteFolder( folderId );
+		broadcastFilesChange( 'folder' );
+		showTrashedToast( `"${ title }" moved to Trash`, async () => {
+			try {
+				await rest.restoreTrashedItem( folderId, 'folder' );
+				const res = await rest.listPlacements( parentId );
+				filesStoreApi.setFolderPlacements( parentId, res.placements );
+				broadcastFilesChange( 'folder' );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( '[desktop-mode] restore folder failed:', err );
+			}
+		} );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( '[desktop-mode] deleteFolder failed:', err );
+		void rest.listPlacements( parentId ).then( ( res ) => {
+			filesStoreApi.setFolderPlacements( parentId, res.placements );
+		} );
+	}
+}
+
+/**
+ * Trash an item by routing to the placement / folder helper based on
+ * the file type. Convenience for drop targets that don't want to
+ * branch on type.
+ */
+export function trashByFileType( placement: RestPlacementShape ): Promise< void > {
+	if ( placement.file?.type === 'folder' ) {
+		return trashFolderWithUndo( placement );
+	}
+	return trashPlacementWithUndo( placement );
+}

--- a/src/desktop-files/url-dialog.ts
+++ b/src/desktop-files/url-dialog.ts
@@ -1,0 +1,229 @@
+/**
+ * Desktop Mode — "New web link / window" dialog.
+ *
+ * Two-field modal (name + URL) used by the wallpaper context menu's
+ * "New" submenu. Title / labels / submit copy are configurable so
+ * the same dialog renders for both `link` (opens in browser) and
+ * `embed` (opens in iframe window) flows.
+ *
+ * Mirrors the create-folder dialog's structure (overlay, focused
+ * input, Escape/Enter, busy state, error) so the shell's two
+ * built-in modals feel identical. Built on the framework's
+ * `<wpd-text-field>` so it inherits keyboard nav, focus styling,
+ * and color-scheme tokens for free.
+ *
+ * @since 0.18.0
+ */
+
+import { applyFilters, doAction } from '../hooks';
+import '../ui/components/wpd-text-field/wpd-text-field';
+
+const ROOT_CLASS = 'desktop-mode-url-dialog';
+
+export interface UrlDialogOptions {
+	/** Heading copy. */
+	title: string;
+	/** Helper line below the heading. Optional. */
+	description?: string;
+	/** Label for the name input. Defaults to 'Name'. */
+	nameLabel?: string;
+	/** Label for the URL input. Defaults to 'URL'. */
+	urlLabel?: string;
+	/** Initial name. */
+	initialName?: string;
+	/** Initial URL. */
+	initialUrl?: string;
+	/** Submit button copy. Defaults to 'Create'. */
+	submitLabel?: string;
+	/** Called with `{ name, url }` on submit. May return a Promise. */
+	onSubmit: ( values: { name: string; url: string } ) => Promise< unknown > | unknown;
+	/** Optional cancel callback. */
+	onCancel?: () => void;
+}
+
+let active: HTMLElement | null = null;
+
+export function isUrlDialogOpen(): boolean {
+	return active !== null;
+}
+
+export function closeUrlDialog(): void {
+	if ( ! active ) {
+		return;
+	}
+	active.dispatchEvent( new CustomEvent( 'url-dialog-closed' ) );
+	active.remove();
+	active = null;
+	doAction( 'desktop-mode.files.url-dialog.closed', {} );
+}
+
+/** Open the dialog. */
+export function openUrlDialog( options: UrlDialogOptions ): void {
+	closeUrlDialog();
+
+	// Plugins can short-circuit by returning `false`.
+	const decision = applyFilters< unknown, [ UrlDialogOptions ] >(
+		'desktop-mode.files.url-dialog',
+		null,
+		options,
+	);
+	if ( decision === false ) {
+		return;
+	}
+
+	const overlay = document.createElement( 'div' );
+	overlay.className = `${ ROOT_CLASS }__overlay desktop-mode-create-folder-dialog__overlay`;
+	overlay.setAttribute( 'role', 'presentation' );
+
+	const dialog = document.createElement( 'div' );
+	dialog.className = `${ ROOT_CLASS } desktop-mode-create-folder-dialog`;
+	dialog.setAttribute( 'role', 'dialog' );
+	dialog.setAttribute( 'aria-modal', 'true' );
+	dialog.setAttribute( 'aria-labelledby', `${ ROOT_CLASS }-title` );
+
+	const title = document.createElement( 'h2' );
+	title.id = `${ ROOT_CLASS }-title`;
+	title.className = 'desktop-mode-create-folder-dialog__title';
+	title.textContent = options.title;
+	dialog.appendChild( title );
+
+	if ( options.description ) {
+		const desc = document.createElement( 'p' );
+		desc.className = `${ ROOT_CLASS }__description`;
+		desc.textContent = options.description;
+		dialog.appendChild( desc );
+	}
+
+	const nameField = document.createElement( 'wpd-text-field' );
+	nameField.setAttribute( 'label', options.nameLabel ?? 'Name' );
+	nameField.setAttribute( 'value', options.initialName ?? '' );
+	nameField.setAttribute( 'placeholder', 'My web app' );
+	nameField.setAttribute( 'autocomplete', 'off' );
+	dialog.appendChild( nameField );
+
+	const urlField = document.createElement( 'wpd-text-field' );
+	urlField.setAttribute( 'label', options.urlLabel ?? 'URL' );
+	urlField.setAttribute( 'value', options.initialUrl ?? 'https://' );
+	urlField.setAttribute( 'placeholder', 'https://example.com' );
+	urlField.setAttribute( 'type', 'url' );
+	urlField.setAttribute( 'autocomplete', 'off' );
+	dialog.appendChild( urlField );
+
+	const error = document.createElement( 'p' );
+	error.className = 'desktop-mode-create-folder-dialog__error';
+	error.hidden = true;
+	error.setAttribute( 'role', 'alert' );
+	dialog.appendChild( error );
+
+	const actions = document.createElement( 'div' );
+	actions.className = 'desktop-mode-create-folder-dialog__actions';
+
+	const cancel = document.createElement( 'button' );
+	cancel.type = 'button';
+	cancel.className =
+		'desktop-mode-create-folder-dialog__btn desktop-mode-create-folder-dialog__btn--secondary';
+	cancel.textContent = 'Cancel';
+
+	const submit = document.createElement( 'button' );
+	submit.type = 'button';
+	submit.className =
+		'desktop-mode-create-folder-dialog__btn desktop-mode-create-folder-dialog__btn--primary';
+	submit.textContent = options.submitLabel ?? 'Create';
+
+	actions.appendChild( cancel );
+	actions.appendChild( submit );
+	dialog.appendChild( actions );
+
+	overlay.appendChild( dialog );
+	document.body.appendChild( overlay );
+	active = overlay;
+
+	// Focus the name field on open. Web components upgrade async,
+	// so we wait a tick before reaching for the inner native input.
+	queueMicrotask( () => {
+		const input = nameField.shadowRoot?.querySelector< HTMLInputElement >( 'input' );
+		input?.focus();
+		input?.select();
+	} );
+
+	doAction( 'desktop-mode.files.url-dialog.opened', {} );
+
+	const readValue = ( field: HTMLElement ): string => {
+		const v = ( field as unknown as { value?: string } ).value;
+		if ( typeof v === 'string' ) {
+			return v;
+		}
+		return field.shadowRoot?.querySelector< HTMLInputElement >( 'input' )?.value ?? '';
+	};
+
+	const setBusy = ( busy: boolean ): void => {
+		( nameField as unknown as { disabled: boolean } ).disabled = busy;
+		( urlField as unknown as { disabled: boolean } ).disabled = busy;
+		cancel.disabled = busy;
+		submit.disabled = busy;
+		dialog.classList.toggle( 'desktop-mode-create-folder-dialog--busy', busy );
+	};
+
+	const showError = ( msg: string ): void => {
+		error.textContent = msg;
+		error.hidden = false;
+	};
+
+	const doCancel = (): void => {
+		closeUrlDialog();
+		options.onCancel?.();
+	};
+
+	const doSubmit = async (): Promise< void > => {
+		const url = readValue( urlField ).trim();
+		if ( ! url ) {
+			showError( 'Please enter a URL.' );
+			return;
+		}
+		// Coerce bare hostnames into a fully-qualified https:// URL.
+		const finalUrl = /^[a-z][a-z0-9+\-.]*:/i.test( url ) ? url : `https://${ url }`;
+		try {
+			// Validate by parsing.
+			// eslint-disable-next-line no-new
+			new URL( finalUrl );
+		} catch {
+			showError( 'That doesn\'t look like a valid URL.' );
+			return;
+		}
+		const name = readValue( nameField ).trim();
+		error.hidden = true;
+		setBusy( true );
+		try {
+			await options.onSubmit( { name, url: finalUrl } );
+			closeUrlDialog();
+		} catch ( err ) {
+			setBusy( false );
+			showError( err instanceof Error ? err.message : 'Could not save.' );
+		}
+	};
+
+	cancel.addEventListener( 'click', () => doCancel() );
+	submit.addEventListener( 'click', () => void doSubmit() );
+
+	overlay.addEventListener( 'click', ( e: MouseEvent ) => {
+		if ( e.target === overlay ) {
+			doCancel();
+		}
+	} );
+
+	// Submit on Enter from either field; Escape cancels.
+	const onKey = ( e: KeyboardEvent ): void => {
+		if ( e.key === 'Escape' ) {
+			e.preventDefault();
+			doCancel();
+		} else if ( e.key === 'Enter' && ! e.isComposing ) {
+			e.preventDefault();
+			void doSubmit();
+		}
+	};
+	dialog.addEventListener( 'keydown', onKey );
+
+	overlay.addEventListener( 'url-dialog-closed', () => {
+		dialog.removeEventListener( 'keydown', onKey );
+	} );
+}

--- a/src/desktop-files/wallpaper-menu.ts
+++ b/src/desktop-files/wallpaper-menu.ts
@@ -287,6 +287,34 @@ export function buildMenuItems( deps: WallpaperMenuDeps ): WallpaperMenuItem[] {
 			sort: 10,
 			onClick: () => deps.createFolder(),
 		},
+		// Temporarily hidden — the "New" submenu (web link / embedded
+		// window) is staged code that hasn't shipped yet. Keep the
+		// branch and supporting modules (`url-dialog.ts`,
+		// `embed-window.ts`, `deps.createLink/Embed`, the labels) so
+		// re-enabling is a one-block uncomment.
+		// {
+		// 	id: 'new',
+		// 	label: deps.labels.newHeading,
+		// 	icon: 'dashicons-plus-alt',
+		// 	sort: 12,
+		// 	onClick: () => undefined,
+		// 	children: [
+		// 		{
+		// 			id: 'new-link',
+		// 			label: deps.labels.newLink,
+		// 			icon: 'dashicons-admin-links',
+		// 			sort: 10,
+		// 			onClick: () => deps.createLink(),
+		// 		},
+		// 		{
+		// 			id: 'new-embed',
+		// 			label: deps.labels.newEmbed,
+		// 			icon: 'dashicons-welcome-view-site',
+		// 			sort: 20,
+		// 			onClick: () => deps.createEmbed(),
+		// 		},
+		// 	],
+		// },
 		{
 			id: 'sort-by',
 			label: deps.labels.sortHeading,
@@ -386,6 +414,8 @@ export type SortMode = 'name-asc' | 'name-desc' | 'date-asc' | 'date-desc';
 
 export interface WallpaperMenuDeps {
 	createFolder: () => void;
+	createLink: () => void;
+	createEmbed: () => void;
 	toggleShowDesktop: () => void;
 	openOsSettings: () => void;
 	openWallpapers: () => void;
@@ -400,6 +430,9 @@ export interface WallpaperMenuDeps {
 		sortNameDesc: string;
 		sortDateAsc: string;
 		sortDateDesc: string;
+		newHeading: string;
+		newLink: string;
+		newEmbed: string;
 	};
 	serverItems?: ServerWallpaperMenuItem[];
 	serverCallbacks?: Record< string, () => void | Promise< void > >;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -109,6 +109,7 @@ import {
 } from './pwa/install';
 import { type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
+import { DragManager, type DragManagerApi } from './drag';
 import {
 	type DesktopCommand,
 } from './commands';
@@ -160,6 +161,7 @@ import {
 	type FilesApi,
 } from './desktop-files';
 import { mountFilesLayer } from './desktop-files/layer';
+import { installRecycleBinDropTargets } from './desktop-files/recycle-bin-targets';
 import { startFilesHeartbeat } from './desktop-files/heartbeat';
 import { buildOccupiedSet, snapToEmptyCell } from './desktop-files/grid';
 import {
@@ -170,6 +172,7 @@ import {
 	type ServerWallpaperMenuItem,
 } from './desktop-files/wallpaper-menu';
 import { openCreateFolderDialog } from './desktop-files/create-folder-dialog';
+import { openUrlDialog } from './desktop-files/url-dialog';
 import type {
 	DesktopConfig,
 	NativeWindowDef,
@@ -582,6 +585,21 @@ export interface WpDesktopPublicApi {
 	 * @since 0.14.0
 	 */
 	dragBridge: DragBridgeApi;
+	/**
+	 * Centralized in-shell drag-and-drop manager. Owns every pointer-
+	 * based drag in the parent shell — file tiles on the wallpaper,
+	 * entity tiles inside My WordPress, and any plugin surface that
+	 * registers a draggable element via `dragManager.start()`.
+	 *
+	 * Distinct from {@link dragBridge}: that's a payload channel for
+	 * cross-iframe Media Library drags. This is the gesture driver —
+	 * it owns the pointer events, the ghost element, the drop-target
+	 * registry, and the global cancellation paths (Escape / blur /
+	 * visibilitychange / pointercancel).
+	 *
+	 * @since 0.18.0
+	 */
+	dragManager: DragManagerApi;
 	/**
 	 * Register a slash-command that appears in the Cmd+K palette.
 	 *
@@ -1522,6 +1540,10 @@ function init(): void {
 	// (after shell DOM exists) so any iframe loading afterward sees
 	// a parent that's ready to receive messages.
 	const dragBridge = new DragBridge();
+	// In-shell drag-and-drop manager — owns the pointer-based drag
+	// gestures for file tiles, entity tiles, and plugin-registered
+	// draggable surfaces. Drop targets register via the public API.
+	const dragManager: DragManagerApi = new DragManager();
 
 	// Register the AI Assistant as the first (default) Cmd+K palette
 	// and install the single global shortcut. Other plugins can register
@@ -2472,10 +2494,17 @@ function init(): void {
 		openOsSettings,
 		aiAssistant,
 		dragBridge,
+		dragManager,
 		connect: connectionBridge.connect,
 		config,
 	} );
 	installPublicApi( desktopApi );
+
+	// Now that `wp.desktop.dragManager` is on the window, register
+	// the recycle-bin drop targets (dock icon + window body). The
+	// installer is idempotent — it listens for `DOCK_AFTER_RENDER`
+	// and `WINDOW_OPENED` to (re-)attach when the elements appear.
+	installRecycleBinDropTargets( dragManager );
 
 	// Wire the cross-feature Heartbeat bus before any consumer
 	// (presence, recycle bin, third-party plugins) registers a
@@ -2704,21 +2733,50 @@ function init(): void {
 			// Capture the click coordinates so a folder created from
 			// this menu lands where the user clicked, not at (0, 0).
 			const dropClient = { x: clientX, y: clientY };
+			// Snap the click point to the nearest empty grid cell —
+			// shared between every "new" item the menu spawns
+			// (folder, link, embed) so anything created lands on a
+			// clean cell aligned with the grid.
+			const cellAtClick = (): { x: number; y: number } => {
+				const rect = desktopArea.getBoundingClientRect();
+				const rawX = Math.max( 0, dropClient.x - rect.left );
+				const rawY = Math.max( 0, dropClient.y - rect.top );
+				const occupied = buildOccupiedSet(
+					filesApi.store.getState().placementsByFolder.get( 0 ) ?? [],
+				);
+				return snapToEmptyCell( rawX, rawY, occupied, desktopArea );
+			};
+			const createUrlPlacement = (
+				type: 'link' | 'embed',
+				dialogTitle: string,
+				description: string,
+			): void => {
+				openUrlDialog( {
+					title: dialogTitle,
+					description,
+					nameLabel: 'Name',
+					urlLabel: 'URL',
+					submitLabel: 'Create',
+					onSubmit: async ( { name, url } ) => {
+						const cell = cellAtClick();
+						const placement = await filesRest.createPlacement( {
+							type,
+							ref: url,
+							parentId: 0,
+							x: cell.x,
+							y: cell.y,
+							meta: name ? { name } : undefined,
+						} );
+						filesApi.store.upsertPlacement( placement );
+					},
+				} );
+			};
 			const items = buildWallpaperMenuItems( {
 				createFolder: () => {
 					openCreateFolderDialog( {
 						onSubmit: async ( name ) => {
 							const folder = await filesRest.createFolder( { name } );
-							// Translate viewport → desktop-area local
-							// coords, then snap to the nearest empty
-							// grid cell so the new folder lands aligned.
-							const rect = desktopArea.getBoundingClientRect();
-							const rawX = Math.max( 0, dropClient.x - rect.left );
-							const rawY = Math.max( 0, dropClient.y - rect.top );
-							const occupied = buildOccupiedSet(
-								filesApi.store.getState().placementsByFolder.get( 0 ) ?? [],
-							);
-							const cell = snapToEmptyCell( rawX, rawY, occupied, desktopArea );
+							const cell = cellAtClick();
 							const placement = await filesRest.createPlacement( {
 								type: 'folder',
 								ref: String( folder.id ),
@@ -2731,6 +2789,18 @@ function init(): void {
 						},
 					} );
 				},
+				createLink: () =>
+					createUrlPlacement(
+						'link',
+						'New web link',
+						'Opens the URL in a new browser tab.',
+					),
+				createEmbed: () =>
+					createUrlPlacement(
+						'embed',
+						'New embedded web window',
+						'Opens the URL inside a desktop window.',
+					),
 				toggleShowDesktop: () => manager.toggleShowDesktop(),
 				openOsSettings: () => openOsSettings(),
 				openWallpapers: () => openOsSettings(),
@@ -2767,6 +2837,9 @@ function init(): void {
 					sortNameDesc: 'Name (Z → A)',
 					sortDateAsc: 'Date (oldest first)',
 					sortDateDesc: 'Date (newest first)',
+					newHeading: 'New',
+					newLink: 'Web link (open in browser)',
+					newEmbed: 'Embedded window (open in shell)',
 				},
 				serverItems: ( config.serverWallpaperMenuItems as
 				| ServerWallpaperMenuItem[]

--- a/src/drag/drop-target-registry.ts
+++ b/src/drag/drop-target-registry.ts
@@ -1,0 +1,100 @@
+/**
+ * Desktop Mode — Drop target registry.
+ *
+ * Keeps the live list of drop targets and runs the hit-test on each
+ * `pointermove`. Hit-testing is a simple "deepest registered ancestor
+ * of `elementFromPoint`" walk — no z-order accounting, no priority
+ * fields. The DOM nesting IS the priority.
+ *
+ * Claimant semantics: the deepest registered ancestor *claims* the
+ * pointer position even if its `accept()` returns false. The cursor
+ * shows `no-drop` and the drop is rejected, instead of falling
+ * through to a parent target. This is what stops a drop on top of an
+ * iframe window from being silently routed to the wallpaper
+ * underneath.
+ *
+ * @since 0.18.0
+ */
+
+import type { DragPayload, DropTarget } from './types';
+
+export class DropTargetRegistry {
+	private readonly _targets = new Map< string, DropTarget >();
+	private readonly _byElement = new Map< HTMLElement, DropTarget >();
+
+	register( target: DropTarget ): () => void {
+		// Idempotent: re-registering with the same id replaces in
+		// place. Layers that re-mount during a hot reload don't have
+		// to track their previous deregister.
+		const prev = this._targets.get( target.id );
+		if ( prev ) {
+			this._byElement.delete( prev.element );
+		}
+		this._targets.set( target.id, target );
+		this._byElement.set( target.element, target );
+		return () => {
+			const cur = this._targets.get( target.id );
+			if ( cur === target ) {
+				this._targets.delete( target.id );
+				this._byElement.delete( target.element );
+			}
+		};
+	}
+
+	list(): readonly DropTarget[] {
+		return Array.from( this._targets.values() );
+	}
+
+	clear(): void {
+		this._targets.clear();
+		this._byElement.clear();
+	}
+
+	/**
+	 * Find the deepest registered target whose element is `el` or an
+	 * ancestor of `el`. Walks the DOM tree once (O(depth)).
+	 *
+	 * Window claim boundary: if the walk crosses a `.desktop-mode-window`
+	 * element BEFORE finding a registered target, hit-testing stops
+	 * there and returns null. This is the rule that makes "drag over
+	 * a Gutenberg admin window" produce reject feedback instead of
+	 * silently routing the drop to the wallpaper canvas underneath.
+	 *
+	 * A window can opt INTO accepting drops by registering a target
+	 * on its own body (e.g. Recycle Bin's `[data-desktop-mode-recycle-bin-root]`):
+	 * since that element sits inside the window, the walk hits it
+	 * before reaching the window boundary and the body's target wins.
+	 */
+	hitTest( el: Element | null ): DropTarget | null {
+		let cur: Element | null = el;
+		while ( cur ) {
+			if ( cur instanceof HTMLElement ) {
+				const t = this._byElement.get( cur );
+				if ( t ) {
+					return t;
+				}
+				if ( cur.classList.contains( 'desktop-mode-window' ) ) {
+					return null;
+				}
+			}
+			cur = cur.parentElement;
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience: pick the target at viewport `(clientX, clientY)`.
+	 * Caller is responsible for hiding any obscuring ghost element
+	 * before calling — see `GhostHandle.withHidden()`.
+	 */
+	hitTestPoint( clientX: number, clientY: number ): {
+		target: DropTarget | null;
+		element: Element | null;
+		accepted: boolean;
+		payload?: DragPayload;
+	} {
+		const el = document.elementFromPoint( clientX, clientY );
+		const target = this.hitTest( el );
+		return { target, element: el, accepted: false };
+	}
+}

--- a/src/drag/ghost.ts
+++ b/src/drag/ghost.ts
@@ -1,0 +1,134 @@
+/**
+ * Desktop Mode — Drag ghost element.
+ *
+ * The ghost is the visual element the user sees following the
+ * pointer during a drag. By default it's a deep clone of the source
+ * element, positioned `fixed`, with `pointer-events: none` so it
+ * doesn't interfere with `elementFromPoint` hit-testing of the drop
+ * surfaces underneath.
+ *
+ * The clone strategy works because every interactive draggable in
+ * the shell (file tile, entity tile) is a self-contained DOM node
+ * whose visual appearance is captured by class+style at clone time.
+ * If a future caller needs a custom ghost (e.g. a thumbnail-only
+ * card during a Media Library drag) they pass `payload.ghost.element`
+ * and the manager renders that instead.
+ *
+ * @since 0.18.0
+ */
+
+import type { DragPayload } from './types';
+
+const GHOST_CLASS = 'desktop-mode-drag-ghost';
+const GHOST_ACCEPT_CLASS = 'desktop-mode-drag-ghost--accept';
+const GHOST_REJECT_CLASS = 'desktop-mode-drag-ghost--reject';
+
+export interface GhostHandle {
+	readonly element: HTMLElement;
+	/** Position the ghost so its origin sits at (clientX, clientY) minus its offset. */
+	moveTo( clientX: number, clientY: number ): void;
+	/** Toggle visual feedback for over-accepting vs over-rejecting target. */
+	setMode( mode: 'accept' | 'reject' | 'neutral' ): void;
+	/**
+	 * Hide the ghost from `elementFromPoint` without removing it from
+	 * the DOM. Used during hit-testing so the ghost itself isn't
+	 * returned as the topmost element.
+	 */
+	withHidden< T >( fn: () => T ): T;
+	/** Remove from the DOM. Idempotent. */
+	dispose(): void;
+}
+
+/**
+ * Mount a ghost element under the pointer at `(clientX, clientY)`.
+ * The caller should call `moveTo()` on subsequent `pointermove`
+ * events and `dispose()` on cancel/commit.
+ */
+export function mountGhost(
+	payload: DragPayload,
+	clientX: number,
+	clientY: number,
+): GhostHandle {
+	const ghost = buildGhost( payload );
+	const offsetX = payload.ghost?.offsetX ?? defaultOffsetX( payload.source );
+	const offsetY = payload.ghost?.offsetY ?? defaultOffsetY( payload.source );
+
+	ghost.classList.add( GHOST_CLASS );
+	ghost.setAttribute( 'aria-hidden', 'true' );
+	ghost.style.position = 'fixed';
+	ghost.style.left = '0';
+	ghost.style.top = '0';
+	ghost.style.margin = '0';
+	ghost.style.pointerEvents = 'none';
+	// Above every shell layer, including the system dock and any
+	// modal. We want to track the pointer literally.
+	ghost.style.zIndex = '2147483647';
+	ghost.style.willChange = 'transform';
+	// Pointer-events:none on the ghost is sufficient — the manager
+	// also temporarily applies visibility:hidden during elementFromPoint
+	// hit-tests as a belt-and-braces safeguard against engines that
+	// honour pointer-events but still report hidden-by-pointer-events
+	// elements at the top of the stack.
+
+	document.body.appendChild( ghost );
+
+	const handle: GhostHandle = {
+		get element() {
+			return ghost;
+		},
+		moveTo( cx, cy ) {
+			ghost.style.transform = `translate3d(${ cx - offsetX }px, ${ cy - offsetY }px, 0)`;
+		},
+		setMode( mode ) {
+			ghost.classList.remove( GHOST_ACCEPT_CLASS, GHOST_REJECT_CLASS );
+			if ( mode === 'accept' ) {
+				ghost.classList.add( GHOST_ACCEPT_CLASS );
+			} else if ( mode === 'reject' ) {
+				ghost.classList.add( GHOST_REJECT_CLASS );
+			}
+		},
+		withHidden( fn ) {
+			const prev = ghost.style.visibility;
+			ghost.style.visibility = 'hidden';
+			try {
+				return fn();
+			} finally {
+				ghost.style.visibility = prev;
+			}
+		},
+		dispose() {
+			if ( ghost.isConnected ) {
+				ghost.remove();
+			}
+		},
+	};
+
+	handle.moveTo( clientX, clientY );
+	handle.setMode( 'neutral' );
+	return handle;
+}
+
+function buildGhost( payload: DragPayload ): HTMLElement {
+	if ( payload.ghost?.element ) {
+		return payload.ghost.element;
+	}
+	const clone = payload.source.cloneNode( true ) as HTMLElement;
+	// Remove identifiers that could collide with the source — IDs
+	// must be unique, and the clone's `data-placement-id` etc. could
+	// be read by debugging tools that walk the DOM looking for state.
+	clone.removeAttribute( 'id' );
+	// Mirror the source's measured size so layout-sensitive ghosts
+	// (tiles whose width is set by a parent grid) don't collapse.
+	const rect = payload.source.getBoundingClientRect();
+	clone.style.width = `${ rect.width }px`;
+	clone.style.height = `${ rect.height }px`;
+	return clone;
+}
+
+function defaultOffsetX( source: HTMLElement ): number {
+	return source.offsetWidth / 2;
+}
+
+function defaultOffsetY( source: HTMLElement ): number {
+	return source.offsetHeight / 2;
+}

--- a/src/drag/index.ts
+++ b/src/drag/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Desktop Mode — Drag module barrel.
+ *
+ * `wp.desktop.dragManager` is the public surface. Plugin authors
+ * register drop targets via `dragManager.registerDropTarget()` and
+ * (rarely) start sessions via `dragManager.start()` for plugin-defined
+ * draggable surfaces.
+ *
+ * Cross-iframe Media Library drags continue to flow through
+ * `wp.desktop.dragBridge` (`src/drag-bridge.ts`) — that's a payload
+ * channel, separate from this gesture manager.
+ *
+ * @since 0.18.0
+ */
+
+export { DragManager } from './manager';
+export type {
+	CancelReason,
+	DragManagerApi,
+	DragPayload,
+	DragSession,
+	DropTarget,
+	GhostConfig,
+	StartOpts,
+} from './types';
+export { DRAG_EVENTS, DRAG_THRESHOLD_PX } from './types';

--- a/src/drag/manager.ts
+++ b/src/drag/manager.ts
@@ -1,0 +1,413 @@
+/**
+ * Desktop Mode — DragManager.
+ *
+ * Single source of truth for in-shell drag gestures. Sources call
+ * `manager.start()` from a `pointerdown` handler; the manager attaches
+ * its own document-level move/up/cancel listeners and drives the
+ * gesture from there. This deliberately avoids `setPointerCapture` —
+ * pointer capture redirects events to the captured element and breaks
+ * HTML5 drag detection on tiles that are also `draggable=true` (the
+ * long-standing My WordPress entity-tile drag bug).
+ *
+ * Lifecycle:
+ *
+ *   1. `start({ payload, origin, … })` records the origin pointer,
+ *      attaches `pointermove` / `pointerup` / `pointercancel` to
+ *      `document`, and lazily installs the recovery handlers on the
+ *      first call.
+ *   2. On each `pointermove` below `DRAG_THRESHOLD_PX`: nothing
+ *      visible happens. The session is "armed" but not "lifted".
+ *   3. On the first `pointermove` past the threshold: the ghost is
+ *      mounted, `--dragging` is added to the source, the START
+ *      CustomEvent fires.
+ *   4. On further `pointermove`s: the ghost follows; the registry
+ *      hit-tests under the cursor; ENTER/LEAVE events fire on
+ *      transitions; the ghost's accept/reject visual flips.
+ *   5. On `pointerup`: hit-test once more (with the ghost hidden);
+ *      if a target accepts, fire its `onDrop` and the COMMIT event;
+ *      otherwise fire CANCEL with `'no-target'` or `'rejected'`.
+ *   6. Cleanup runs from a single `_finish()` path, idempotently.
+ *
+ * Cancellation paths (Escape, blur, visibilitychange, error,
+ * pointercancel, manual `session.cancel()`) all funnel into the same
+ * `_finish('cancel', reason)` exit.
+ *
+ * @since 0.18.0
+ */
+
+import { DropTargetRegistry } from './drop-target-registry';
+import { mountGhost, type GhostHandle } from './ghost';
+import { installRecovery } from './recovery';
+import {
+	DRAG_EVENTS,
+	DRAG_THRESHOLD_PX,
+	type CancelReason,
+	type DragManagerApi,
+	type DragSession,
+	type DropTarget,
+	type StartOpts,
+} from './types';
+
+const SOURCE_DRAGGING_CLASS = 'desktop-mode-file-tile--dragging';
+const TARGET_DROP_ACTIVE_CLASS = 'desktop-mode-file-tile--drop-target';
+const TRASH_DROP_ACTIVE_ATTR = 'data-desktop-mode-trash-drop-active';
+const FILES_DROP_ACTIVE_ATTR = 'data-files-drop-active';
+
+interface InternalSession extends DragSession {
+	_origin: PointerEvent;
+	_pointerId: number;
+	_lifted: boolean;
+	_finished: boolean;
+	_callbacks: {
+		onClickOnly?: () => void;
+		onCancel?: ( reason: CancelReason ) => void;
+		onCommit?: ( target: DropTarget ) => void;
+	};
+	_ghost: GhostHandle | null;
+	_currentTarget: DropTarget | null;
+	_currentAccepted: boolean;
+}
+
+export class DragManager implements DragManagerApi {
+	private readonly _registry = new DropTargetRegistry();
+	private _active: InternalSession | null = null;
+	private _docListenersAttached = false;
+
+	start( opts: StartOpts ): DragSession | null {
+		// Reject when another session is in flight — at most one drag
+		// at a time. The right behaviour: silently drop the new
+		// pointerdown so it falls through to whatever click/select
+		// handler the source has, rather than commandeering the
+		// pointer and confusing the user.
+		if ( this._active ) {
+			return null;
+		}
+		// Primary button only.
+		if ( opts.origin.button !== 0 ) {
+			return null;
+		}
+
+		const session: InternalSession = {
+			payload: opts.payload,
+			isFinished: () => session._finished,
+			cancel: ( reason ) => this._cancel( session, reason ?? 'caller' ),
+			_origin: opts.origin,
+			_pointerId: opts.origin.pointerId,
+			_lifted: false,
+			_finished: false,
+			_callbacks: {
+				onClickOnly: opts.onClickOnly,
+				onCancel: opts.onCancel,
+				onCommit: opts.onCommit,
+			},
+			_ghost: null,
+			_currentTarget: null,
+			_currentAccepted: false,
+		};
+		this._active = session;
+		this._ensureDocListeners();
+		installRecovery( ( reason ) => {
+			if ( this._active ) {
+				this._cancel( this._active, reason );
+			}
+		} );
+		return session;
+	}
+
+	registerDropTarget( target: DropTarget ): () => void {
+		return this._registry.register( target );
+	}
+
+	isDragging(): boolean {
+		return this._active !== null && this._active._lifted;
+	}
+
+	getActive(): DragSession | null {
+		return this._active;
+	}
+
+	debug(): {
+			findOrphans(): Element[];
+			listTargets(): readonly DropTarget[];
+			} {
+		return {
+			findOrphans: () => findOrphans(),
+			listTargets: () => this._registry.list(),
+		};
+	}
+
+	// -----------------------------------------------------------------
+	// Internals
+	// -----------------------------------------------------------------
+
+	private _ensureDocListeners(): void {
+		if ( this._docListenersAttached ) {
+			return;
+		}
+		this._docListenersAttached = true;
+		document.addEventListener( 'pointermove', this._onPointerMove, true );
+		document.addEventListener( 'pointerup', this._onPointerUp, true );
+		document.addEventListener( 'pointercancel', this._onPointerCancel, true );
+	}
+
+	private readonly _onPointerMove = ( e: PointerEvent ): void => {
+		const session = this._active;
+		if ( ! session || session._pointerId !== e.pointerId ) {
+			return;
+		}
+		const dx = e.clientX - session._origin.clientX;
+		const dy = e.clientY - session._origin.clientY;
+		if ( ! session._lifted ) {
+			if ( Math.abs( dx ) < DRAG_THRESHOLD_PX && Math.abs( dy ) < DRAG_THRESHOLD_PX ) {
+				return;
+			}
+			this._lift( session, e );
+		}
+		if ( ! session._ghost ) {
+			return;
+		}
+		session._ghost.moveTo( e.clientX, e.clientY );
+		this._updateHover( session, e.clientX, e.clientY );
+		dispatchOnDocument( DRAG_EVENTS.MOVE, {
+			payload: session.payload,
+			clientX: e.clientX,
+			clientY: e.clientY,
+		} );
+	};
+
+	private readonly _onPointerUp = ( e: PointerEvent ): void => {
+		const session = this._active;
+		if ( ! session || session._pointerId !== e.pointerId ) {
+			return;
+		}
+		if ( ! session._lifted ) {
+			// Sub-threshold gesture — treat as a click. Do NOT call
+			// onCommit. The source's onClickOnly callback (if any)
+			// owns whatever the click meant.
+			session._finished = true;
+			this._active = null;
+			try {
+				session._callbacks.onClickOnly?.();
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( '[desktop-mode] drag onClickOnly threw:', err );
+			}
+			return;
+		}
+		// Lifted — commit or reject based on hit-test.
+		const hit = this._hitTestNow( session, e.clientX, e.clientY );
+		if ( hit && hit.accepted && hit.target ) {
+			this._commit( session, hit.target, e.clientX, e.clientY );
+			return;
+		}
+		this._cancel( session, hit && hit.target ? 'rejected' : 'no-target' );
+	};
+
+	private readonly _onPointerCancel = ( e: PointerEvent ): void => {
+		const session = this._active;
+		if ( ! session || session._pointerId !== e.pointerId ) {
+			return;
+		}
+		this._cancel( session, 'pointercancel' );
+	};
+
+	private _lift( session: InternalSession, e: PointerEvent ): void {
+		session._lifted = true;
+		session.payload.source.classList.add( SOURCE_DRAGGING_CLASS );
+		session._ghost = mountGhost( session.payload, e.clientX, e.clientY );
+		dispatchOnDocument( DRAG_EVENTS.START, { payload: session.payload } );
+	}
+
+	private _hitTestNow(
+		session: InternalSession,
+		clientX: number,
+		clientY: number,
+	): { target: DropTarget | null; accepted: boolean } {
+		const run = (): { target: DropTarget | null; accepted: boolean } => {
+			const el = document.elementFromPoint( clientX, clientY );
+			const target = this._registry.hitTest( el );
+			if ( ! target ) {
+				return { target: null, accepted: false };
+			}
+			let accepted = false;
+			try {
+				accepted = target.accept( session.payload );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( '[desktop-mode] drop target accept() threw:', target.id, err );
+			}
+			return { target, accepted };
+		};
+		// Hide the ghost so it doesn't show up as the topmost element
+		// at (clientX, clientY).
+		if ( session._ghost ) {
+			return session._ghost.withHidden( run );
+		}
+		return run();
+	}
+
+	private _updateHover( session: InternalSession, clientX: number, clientY: number ): void {
+		const next = this._hitTestNow( session, clientX, clientY );
+		const prevTarget = session._currentTarget;
+		if ( next.target === prevTarget && next.accepted === session._currentAccepted ) {
+			return;
+		}
+		if ( prevTarget ) {
+			fireLeave( prevTarget, session );
+		}
+		session._currentTarget = next.target;
+		session._currentAccepted = next.accepted;
+		if ( next.target ) {
+			if ( next.accepted ) {
+				fireEnter( next.target, session );
+				session._ghost?.setMode( 'accept' );
+			} else {
+				session._ghost?.setMode( 'reject' );
+				dispatchOnDocument( DRAG_EVENTS.REJECTED, {
+					payload: session.payload,
+					targetId: next.target.id,
+				} );
+			}
+		} else {
+			session._ghost?.setMode( 'reject' );
+		}
+	}
+
+	private _commit(
+		session: InternalSession,
+		target: DropTarget,
+		clientX: number,
+		clientY: number,
+	): void {
+		session._finished = true;
+		// Drop the LEAVE on the active target before invoking onDrop
+		// so target callbacks see a clean enter/leave pair.
+		fireLeave( target, session );
+		this._cleanupDom( session );
+		const prevActive = this._active;
+		this._active = null;
+		try {
+			void target.onDrop( session, { clientX, clientY } );
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( '[desktop-mode] drop target onDrop threw:', target.id, err );
+		}
+		try {
+			session._callbacks.onCommit?.( target );
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( '[desktop-mode] drag onCommit threw:', err );
+		}
+		dispatchOnDocument( DRAG_EVENTS.COMMIT, {
+			payload: session.payload,
+			targetId: target.id,
+		} );
+		dispatchOnDocument( DRAG_EVENTS.END, { payload: session.payload, reason: 'commit' } );
+		// Defensive: the assignment above already nulled `_active`,
+		// but if some listener re-entered start() during the callbacks
+		// above, leave that new session in place.
+		if ( this._active === prevActive ) {
+			this._active = null;
+		}
+	}
+
+	private _cancel( session: InternalSession, reason: CancelReason ): void {
+		if ( session._finished ) {
+			return;
+		}
+		session._finished = true;
+		if ( session._currentTarget ) {
+			fireLeave( session._currentTarget, session );
+		}
+		this._cleanupDom( session );
+		this._active = null;
+		try {
+			session._callbacks.onCancel?.( reason );
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( '[desktop-mode] drag onCancel threw:', err );
+		}
+		dispatchOnDocument( DRAG_EVENTS.CANCEL, { payload: session.payload, reason } );
+		dispatchOnDocument( DRAG_EVENTS.END, { payload: session.payload, reason } );
+	}
+
+	private _cleanupDom( session: InternalSession ): void {
+		// Source class. The source may have been removed from the DOM
+		// already (rare — the wallpaper layer rebuilds tiles on store
+		// changes) but classList mutations on detached nodes are a
+		// no-op.
+		try {
+			session.payload.source.classList.remove( SOURCE_DRAGGING_CLASS );
+		} catch {
+			// ignore
+		}
+		session._ghost?.dispose();
+		session._ghost = null;
+		session._currentTarget = null;
+		session._currentAccepted = false;
+		// Belt-and-braces: scrub any stale drop-active markers anywhere
+		// in the document. Targets that misbehave by leaving these on
+		// (e.g. a plugin whose onLeave threw) shouldn't pollute the
+		// next drag.
+		scrubOrphans();
+	}
+}
+
+function dispatchOnDocument( type: string, detail: unknown ): void {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	document.dispatchEvent( new CustomEvent( type, { detail } ) );
+}
+
+function fireEnter( target: DropTarget, session: DragSession ): void {
+	try {
+		target.onEnter?.( session );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( '[desktop-mode] drop target onEnter threw:', target.id, err );
+	}
+	dispatchOnDocument( DRAG_EVENTS.ENTER, {
+		payload: session.payload,
+		targetId: target.id,
+	} );
+}
+
+function fireLeave( target: DropTarget, session: DragSession ): void {
+	try {
+		target.onLeave?.( session );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( '[desktop-mode] drop target onLeave threw:', target.id, err );
+	}
+	dispatchOnDocument( DRAG_EVENTS.LEAVE, {
+		payload: session.payload,
+		targetId: target.id,
+	} );
+}
+
+/** Find any DOM nodes carrying drag-related state classes/attributes. */
+function findOrphans(): Element[] {
+	if ( typeof document === 'undefined' ) {
+		return [];
+	}
+	const out: Element[] = [];
+	for ( const sel of [
+		`.${ SOURCE_DRAGGING_CLASS }`,
+		`.${ TARGET_DROP_ACTIVE_CLASS }`,
+		`[${ TRASH_DROP_ACTIVE_ATTR }]`,
+		`[${ FILES_DROP_ACTIVE_ATTR }]`,
+	] ) {
+		document.querySelectorAll( sel ).forEach( ( el ) => out.push( el ) );
+	}
+	return out;
+}
+
+/** Strip any drag-related state classes/attributes from the document. */
+function scrubOrphans(): void {
+	for ( const el of findOrphans() ) {
+		el.classList.remove( SOURCE_DRAGGING_CLASS, TARGET_DROP_ACTIVE_CLASS );
+		el.removeAttribute( TRASH_DROP_ACTIVE_ATTR );
+		el.removeAttribute( FILES_DROP_ACTIVE_ATTR );
+	}
+}

--- a/src/drag/recovery.ts
+++ b/src/drag/recovery.ts
@@ -1,0 +1,52 @@
+/**
+ * Desktop Mode — Drag-session recovery handlers.
+ *
+ * Wires the global cancel paths the system used to lack:
+ *
+ *   - `Escape` keypress           → user explicitly aborts
+ *   - `window` blur                → tab loses focus mid-drag
+ *   - `document` visibilitychange  → tab hidden mid-drag
+ *
+ * Drop-handler errors are caught locally in the manager via
+ * `try/catch` around each callback invocation — a global
+ * `window.error` listener was tried and rejected because it fires
+ * for too many unrelated events (`<img>` load failures, third-party
+ * script errors, etc.) and would spuriously cancel in-flight drags.
+ *
+ * Listeners are attached lazily on the first session start so cold
+ * boots that never drag pay nothing. They are never removed — keeping
+ * them attached forever costs three idle listeners and avoids race
+ * conditions around session end vs handler removal.
+ *
+ * @since 0.18.0
+ */
+
+let _installed = false;
+
+export function installRecovery( cancelActive: ( reason: 'escape' | 'blur' | 'visibility' ) => void ): void {
+	if ( _installed ) {
+		return;
+	}
+	_installed = true;
+
+	document.addEventListener( 'keydown', ( e ) => {
+		if ( e.key === 'Escape' ) {
+			cancelActive( 'escape' );
+		}
+	} );
+
+	window.addEventListener( 'blur', () => {
+		cancelActive( 'blur' );
+	} );
+
+	document.addEventListener( 'visibilitychange', () => {
+		if ( document.hidden ) {
+			cancelActive( 'visibility' );
+		}
+	} );
+}
+
+/** Test-only — resets the install latch so a new manager can re-arm. */
+export function __resetRecoveryForTests(): void {
+	_installed = false;
+}

--- a/src/drag/types.ts
+++ b/src/drag/types.ts
@@ -1,0 +1,171 @@
+/**
+ * Desktop Mode — Centralized drag-and-drop types.
+ *
+ * The DragManager unifies every in-shell drag gesture (file tiles on
+ * the wallpaper, entity tiles inside My WordPress, future plugin
+ * surfaces) onto a single pointer-event-based pipeline. Native HTML5
+ * drag was abandoned for in-shell gestures because:
+ *
+ *   1. `setPointerCapture` (used by tile rearrange handlers) silently
+ *      breaks HTML5 `dragstart` detection — the browser never fires
+ *      it, so payloads attached to `DataTransfer` never reach a drop
+ *      target. That was the long-standing "I can drag a Posts tile
+ *      but nothing accepts the drop" bug.
+ *   2. HTML5 drag has no programmatic cancel. Pressing Escape, alt-
+ *      tabbing away, or system modals leave drag state stranded; the
+ *      pointer-event model gives us full control over teardown.
+ *   3. The "Lift and Drop" cross-iframe pattern (architecture.md North
+ *      Star) needs a parent-shell-controlled drag anyway. Building
+ *      that on top of native HTML5 means routing drops through
+ *      postMessage shims; building it on pointer events keeps a single
+ *      mental model.
+ *
+ * The legacy `setShortcutDragPayload` / `hasShortcutPayload` /
+ * `readShortcutPayload` helpers in `desktop-files/drag-shortcut.ts`
+ * are kept for backwards compat — third-party plugins that emitted
+ * HTML5 drags with the legacy MIME continue to work, the manager
+ * bridges them into a session at `dragstart` time and `preventDefault`s
+ * the browser's native drag.
+ *
+ * Cross-iframe Media Library drags (`src/drag-bridge.ts`) remain a
+ * separate channel. That bridge is a payload carrier, not a gesture
+ * driver — its lifecycle is owned by the source/destination iframes,
+ * not the parent shell.
+ *
+ * @since 0.18.0
+ */
+
+/**
+ * Payload carried by an in-flight drag. `type` is a free-form slug
+ * that drop targets switch on. The framework knows about
+ * `'desktop-file'` and `'shortcut'`; plugins can introduce their
+ * own.
+ */
+export interface DragPayload {
+	/** Slug. `'desktop-file'`, `'shortcut'`, or plugin-defined. */
+	type: string;
+	/** Originating element. Used for the default ghost + click fallback. */
+	source: HTMLElement;
+	/** Type-specific data. Shape is the consumer's contract. */
+	data: Record< string, unknown >;
+	/** Optional override for the ghost element + offset. */
+	ghost?: GhostConfig;
+}
+
+export interface GhostConfig {
+	/** Element to render under the cursor. Defaults to a clone of `source`. */
+	element?: HTMLElement;
+	/** Pointer-to-ghost-origin offset, in CSS px. */
+	offsetX: number;
+	offsetY: number;
+}
+
+/** Reasons a drag session can end without committing a drop. */
+export type CancelReason =
+	| 'escape' // user pressed Escape
+	| 'blur' // window lost focus
+	| 'visibility' // tab became hidden
+	| 'pointercancel' // browser fired pointercancel (touch interrupted, etc.)
+	| 'no-target' // pointerup over a non-accepting region
+	| 'rejected' // pointerup over a registered target that rejected
+	| 'caller'; // manual `session.cancel()`
+
+/**
+ * The in-flight session. Returned from `manager.start()`. Sources
+ * generally don't keep a reference — drop targets receive it as the
+ * first arg of their callbacks.
+ */
+export interface DragSession {
+	readonly payload: DragPayload;
+	/** Has the session already exited (cancel or commit). */
+	isFinished(): boolean;
+	/** Manually cancel. Idempotent. */
+	cancel( reason?: CancelReason ): void;
+}
+
+/**
+ * A registered drop target. Multiple targets can be live at once;
+ * the manager hit-tests under the cursor and picks the deepest
+ * match in the DOM.
+ *
+ * Accept-vs-reject semantics: `accept(payload)` returns true if
+ * this target wants the payload. If false, the manager still treats
+ * the target as a *claimant* — the cursor shows `no-drop` and the
+ * drop is rejected. This prevents the ghost from "falling through"
+ * a window onto the wallpaper underneath.
+ */
+export interface DropTarget {
+	/** Stable id for diagnostics + idempotent re-registration. */
+	id: string;
+	/** DOM container that defines the hit-test region. */
+	element: HTMLElement;
+	/** Pure predicate. Cheap. Called on every entry transition. */
+	accept( payload: DragPayload ): boolean;
+	/** Fired once when the cursor enters this target. */
+	onEnter?( session: DragSession ): void;
+	/** Fired once when the cursor leaves this target. */
+	onLeave?( session: DragSession ): void;
+	/**
+	 * Fired on pointerup over this target if `accept()` returned
+	 * true. Coordinates are in client (viewport) space.
+	 */
+	onDrop( session: DragSession, ev: { clientX: number; clientY: number } ): void | Promise< void >;
+}
+
+/** Public manager API. Mounted on `wp.desktop.dragManager`. */
+export interface DragManagerApi {
+	/**
+	 * Begin a drag. Returns a session, or `null` when:
+	 *
+	 *   - Another session is already active.
+	 *   - The pointerdown was on a non-primary button.
+	 *
+	 * The manager attaches its own document-level move/up/cancel
+	 * listeners; the source DOES NOT call `setPointerCapture`.
+	 * Pointer capture is incompatible with HTML5 drag detection
+	 * and has no benefit on the document-listener model.
+	 */
+	start( opts: StartOpts ): DragSession | null;
+	/** Register a drop target. Returns a deregister function. */
+	registerDropTarget( target: DropTarget ): () => void;
+	/** Is a session currently active? */
+	isDragging(): boolean;
+	/** Currently active session, or null. */
+	getActive(): DragSession | null;
+	/** Diagnostics — exposed for tests + manual QA. */
+	debug(): {
+		findOrphans(): Element[];
+		listTargets(): readonly DropTarget[];
+	};
+}
+
+export interface StartOpts {
+	payload: DragPayload;
+	/** The pointerdown that initiated the gesture. */
+	origin: PointerEvent;
+	/**
+	 * Called if the gesture never crosses the drag threshold (the
+	 * user clicked rather than dragged). Source code should treat
+	 * this as the click handler.
+	 */
+	onClickOnly?: () => void;
+	/** Called when the session is cancelled (any reason). */
+	onCancel?: ( reason: CancelReason ) => void;
+	/** Called when the session commits to a drop target. */
+	onCommit?: ( target: DropTarget ) => void;
+}
+
+/** Distance the pointer must travel to "lift" the source. */
+export const DRAG_THRESHOLD_PX = 4;
+
+/** CustomEvent names dispatched on `document`. */
+export const DRAG_EVENTS = {
+	START: 'desktop-mode.drag.start',
+	MOVE: 'desktop-mode.drag.move',
+	ENTER: 'desktop-mode.drag.enter',
+	LEAVE: 'desktop-mode.drag.leave',
+	REJECTED: 'desktop-mode.drag.rejected',
+	COMMIT: 'desktop-mode.drag.commit',
+	CANCEL: 'desktop-mode.drag.cancel',
+	END: 'desktop-mode.drag.end',
+} as const;

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -25,7 +25,21 @@ import {
 	renderStatusBarSegments,
 	type StatusBarSegment,
 } from '../desktop-files/folder-status-bar';
-import { setShortcutDragPayload } from '../desktop-files/drag-shortcut';
+import type { DragManagerApi } from '../drag';
+import type { ShortcutDragData } from '../desktop-files/drag-payloads';
+
+/**
+ * Read the runtime DragManager. Boot order guarantees this exists by
+ * the time this module's tile builders run — the My WordPress window
+ * only mounts after `installPublicApi(desktopApi)` has wired the
+ * manager onto `wp.desktop.dragManager`.
+ */
+function getDragManager(): DragManagerApi | null {
+	const api = (
+		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
+	).wp?.desktop?.dragManager;
+	return api ?? null;
+}
 import {
 	renderBreadcrumbs,
 	type BreadcrumbSegment,
@@ -399,14 +413,13 @@ function renderRoot( state: RenderState ): void {
 			name: entity.label,
 			date: synthDate,
 		} );
-		attachTileDrag( tile, layout, {
-			tileKey,
-			// Folder tiles use Finder-style semantics: single click
-			// selects (visual highlight only — no navigation, so a
-			// fast double-click can't race the tile out of the DOM),
-			// double click navigates.
-			onClick: () => select( tile ),
-		} );
+		// Folder tiles use Finder-style semantics: single click
+		// selects (visual highlight only — no navigation, so a fast
+		// double-click can't race the tile out of the DOM), double
+		// click navigates. No drag-out: folder tiles aren't filed as
+		// shortcuts — only entity tiles are.
+		void tileKey;
+		tile.addEventListener( 'click', () => select( tile ) );
 		tile.addEventListener( 'dblclick', ( e ) => {
 			e.preventDefault();
 			navigate( state, { kind: 'list', entityId: entity.id } );
@@ -772,28 +785,55 @@ function buildEntityTile(
 	} );
 	tile.dataset.entryId = String( item.id );
 
-	// Make the tile a native HTML5 drag source so the user can
-	// drag it out of the My WordPress window and drop it on the
-	// wallpaper, on a folder icon, or inside an open folder
-	// window — the desktop FilesLayer reads the payload and files
-	// a `post`-type placement (a shortcut) at the drop target.
-	// Internal rearrange is still disabled (single click selects,
-	// double click opens) — only the cross-window drag-out fires.
-	tile.draggable = true;
-	tile.addEventListener( 'dragstart', ( e: DragEvent ) => {
-		hideTooltip();
-		if ( ! e.dataTransfer ) {
+	// Drag-out: the user picks up an entity tile and drops it on the
+	// wallpaper, a folder icon, or inside an open folder window. The
+	// desktop FilesLayer's drop targets accept the `'shortcut'` payload
+	// and POST a new placement at the drop coordinates.
+	//
+	// We route through the centralized DragManager rather than HTML5
+	// drag because:
+	//   1. HTML5 drag's `dragstart` fails to fire when an ancestor or
+	//      sibling listener has called `setPointerCapture` on the
+	//      tile — the long-standing "I can lift the tile but no drop
+	//      target sees the payload" bug.
+	//   2. We want a single cancellation path (Escape, blur,
+	//      visibilitychange) for every in-shell drag.
+	//   3. Phase 8's "Lift and Drop" cross-iframe pattern needs
+	//      pointer-event control anyway. Building on it now keeps a
+	//      single mental model.
+	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		if ( e.button !== 0 ) {
 			return;
 		}
-		setShortcutDragPayload( e.dataTransfer, {
-			type: 'post',
-			ref: String( item.id ),
-			title: titleText,
-			icon: entity.icon,
+		const dragManager = getDragManager();
+		if ( ! dragManager ) {
+			return;
+		}
+		dragManager.start( {
+			payload: {
+				type: 'shortcut',
+				source: tile,
+				data: {
+					kind: 'post',
+					ref: String( item.id ),
+					title: titleText,
+					icon: entity.icon,
+				} satisfies ShortcutDragData,
+				ghost: {
+					offsetX: e.clientX - tile.getBoundingClientRect().left,
+					offsetY: e.clientY - tile.getBoundingClientRect().top,
+				},
+			},
+			origin: e,
+			onClickOnly: () => {
+				// Sub-threshold gesture — the regular `click` listener
+				// (added below by `attachSelectAndDragHandlers`) handles
+				// selection. Hiding the tooltip here is harmless even
+				// if the click handler also fires; tooltip is gone
+				// either way.
+				hideTooltip();
+			},
 		} );
-		// Browser uses the drag source as the default ghost — that
-		// already looks right (the tile follows the cursor with a
-		// subtle alpha). No setDragImage override needed.
 	} );
 
 	// If another user is editing right now, surface that on the
@@ -848,12 +888,15 @@ function buildEntityTile(
 		name: titleText,
 		date: item.date || new Date( 0 ).toISOString(),
 	} );
-	attachTileDrag( tile, ctx.layout, {
-		tileKey,
-		onClick: () => {
-			selectTile( state, ctx, tile, entity, item.id );
-		},
-		onDragStart: hideTooltip,
+	// Click-to-select. The pointerdown handler above already routes
+	// drags through the DragManager, so a sub-threshold gesture
+	// (pointer-down, no movement, pointer-up) flows naturally:
+	// pointerdown fires manager.start(); manager treats it as a
+	// click on pointerup; the browser dispatches `click`; this
+	// listener selects.
+	void tileKey;
+	tile.addEventListener( 'click', () => {
+		selectTile( state, ctx, tile, entity, item.id );
 	} );
 
 	tile.addEventListener( 'dblclick', ( e ) => {
@@ -1349,16 +1392,13 @@ function renderDetail(
 				name: sub.label,
 				date: sub.synthDate,
 			} );
-			attachTileDrag( tile, layout, {
-				tileKey,
-				// Sub-folder tiles use the same Finder-style
-				// semantics as the root folder tiles: single click
-				// selects (visual only), double click navigates.
-				// Disabled tiles still receive the selection so the
-				// user has a hover/focus affordance, but no dblclick
-				// listener is attached below.
-				onClick: () => select( tile ),
-			} );
+			// Sub-folder tiles use the same Finder-style semantics as
+			// the root folder tiles: single click selects (visual
+			// only), double click navigates. Disabled tiles still
+			// receive the selection so the user has a hover/focus
+			// affordance, but no dblclick listener below.
+			void tileKey;
+			tile.addEventListener( 'click', () => select( tile ) );
 			if ( ! sub.disabled ) {
 				tile.addEventListener( 'dblclick', ( e ) => {
 					e.preventDefault();
@@ -1563,35 +1603,32 @@ function renderSubList(
 				name: item.label,
 				date: item.date,
 			} );
-			attachTileDrag( tile, layout, {
-				tileKey,
-				onClick: () => {
-					if ( selectedTile ) {
-						selectedTile.classList.remove(
-							'desktop-mode-my-wordpress__tile--selected',
-						);
-					}
-					tile.classList.add(
+			tile.addEventListener( 'click', () => {
+				if ( selectedTile ) {
+					selectedTile.classList.remove(
 						'desktop-mode-my-wordpress__tile--selected',
 					);
-					selectedTile = tile;
-					selectedKey = tileKey;
+				}
+				tile.classList.add(
+					'desktop-mode-my-wordpress__tile--selected',
+				);
+				selectedTile = tile;
+				selectedKey = tileKey;
 
-					showPreviewLoading( right );
-					Promise.resolve( item.preview() )
-						.then( ( node ) => {
-							if ( selectedKey !== tileKey ) {
-								return; // Selection moved on.
-							}
-							right.replaceChildren( node );
-						} )
-						.catch( ( err ) => {
-							if ( selectedKey !== tileKey ) {
-								return;
-							}
-							showPreviewError( right, err );
-						} );
-				},
+				showPreviewLoading( right );
+				Promise.resolve( item.preview() )
+					.then( ( node ) => {
+						if ( selectedKey !== tileKey ) {
+							return; // Selection moved on.
+						}
+						right.replaceChildren( node );
+					} )
+					.catch( ( err ) => {
+						if ( selectedKey !== tileKey ) {
+							return;
+						}
+						showPreviewError( right, err );
+					} );
 			} );
 			tiles.appendChild( tile );
 		}
@@ -3215,7 +3252,7 @@ function extractContentMediaIds( html: string ): number[] {
  * applies it to the new one. A second click on the already-selected
  * tile is idempotent.
  *
- * Returns the click handler to wire into `attachTileDrag.onClick`.
+ * Returns the click handler to wire into a tile's `click` listener.
  */
 function createTileSelector(): ( tile: HTMLElement ) => void {
 	let selected: HTMLElement | null = null;
@@ -3623,107 +3660,14 @@ function storageKey( scope: string ): string {
 	return `desktop-mode-my-wordpress:positions:${ scope }`;
 }
 
-interface TileDragOpts {
-	tileKey: string;
-	onClick: () => void;
-	onDragStart?: () => void;
-}
-
-const DRAG_THRESHOLD_PX = 4;
-
-function attachTileDrag(
-	tile: HTMLElement,
-	layout: TileLayout,
-	opts: TileDragOpts,
-): void {
-	let drag: {
-		pointerId: number;
-		startX: number;
-		startY: number;
-		originX: number;
-		originY: number;
-		moved: boolean;
-	} | null = null;
-
-	const onPointerDown = ( e: PointerEvent ) => {
-		if ( e.button !== 0 ) {
-			return;
-		}
-		const originX = parseFloat( tile.style.left || '0' );
-		const originY = parseFloat( tile.style.top || '0' );
-		drag = {
-			pointerId: e.pointerId,
-			startX: e.clientX,
-			startY: e.clientY,
-			originX,
-			originY,
-			moved: false,
-		};
-		try {
-			tile.setPointerCapture( e.pointerId );
-		} catch {
-			// Older browsers / non-pointer-capture-friendly hosts —
-			// drag still works via document-level listeners below.
-		}
-	};
-
-	const onPointerMove = ( e: PointerEvent ) => {
-		if ( ! drag || drag.pointerId !== e.pointerId ) {
-			return;
-		}
-		const dx = e.clientX - drag.startX;
-		const dy = e.clientY - drag.startY;
-		if (
-			! drag.moved &&
-			Math.abs( dx ) < DRAG_THRESHOLD_PX &&
-			Math.abs( dy ) < DRAG_THRESHOLD_PX
-		) {
-			return;
-		}
-		if ( ! drag.moved ) {
-			drag.moved = true;
-			tile.classList.add( 'desktop-mode-file-tile--dragging' );
-			opts.onDragStart?.();
-		}
-		applyTilePosition( tile, drag.originX + dx, drag.originY + dy );
-	};
-
-	const onPointerEnd = ( e: PointerEvent ) => {
-		if ( ! drag || drag.pointerId !== e.pointerId ) {
-			return;
-		}
-		const wasMoved = drag.moved;
-		try {
-			tile.releasePointerCapture( e.pointerId );
-		} catch {
-			// Already released.
-		}
-		tile.classList.remove( 'desktop-mode-file-tile--dragging' );
-		if ( ! wasMoved ) {
-			drag = null;
-			opts.onClick();
-			return;
-		}
-		// Drag is intentionally NON-rearranging inside My WordPress.
-		// The tile lifts during the drag (visual feedback) but snaps
-		// back to its origin on release — internal cell layout is
-		// auto-flow-only and not user-arrangeable. The drag affordance
-		// stays alive so a future cross-window drag-out (e.g. drag a
-		// post tile onto the wallpaper to create a shortcut) has a
-		// gesture to hook into. For now, no external drop target =
-		// snap back.
-		applyTilePosition( tile, drag.originX, drag.originY );
-		drag = null;
-		// `layout` is preserved in scope for future drag-out wiring.
-		void layout;
-		void opts.tileKey;
-	};
-
-	tile.addEventListener( 'pointerdown', onPointerDown );
-	tile.addEventListener( 'pointermove', onPointerMove );
-	tile.addEventListener( 'pointerup', onPointerEnd );
-	tile.addEventListener( 'pointercancel', onPointerEnd );
-}
+// `attachTileDrag` was a snap-back pointer-event drag with no real
+// rearrange or drag-out function. It existed as a placeholder for
+// future cross-window drag-out, but it set `setPointerCapture` on the
+// tile which BROKE HTML5 `dragstart` detection on the `draggable=true`
+// post tiles — the long-standing "I can lift the tile but no drop
+// target sees it" bug. Removed in 0.18.0; entity tiles now use the
+// centralized DragManager (`pointerdown` -> `dragManager.start()`)
+// for drag-out and a plain `click` listener for selection.
 
 /**
  * Live `RenderState` for the currently-mounted My WordPress

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -141,6 +141,19 @@ export type { ConnectOptions, WindowConnection } from './connection';
 
 export type { AskFn, AskOptions, AskResult, AskToolCall } from './ai/ask';
 
+// ----- Drag-and-drop manager (in-shell pointer-event drag) -----
+
+export type {
+	CancelReason as DragCancelReason,
+	DragManagerApi,
+	DragPayload,
+	DragSession,
+	DropTarget as DragDropTarget,
+	GhostConfig as DragGhostConfig,
+	StartOpts as DragStartOpts,
+} from './drag';
+export { DRAG_EVENTS, DRAG_THRESHOLD_PX } from './drag';
+
 // ----- DevTools / cross-plugin instrumentation -----
 
 export type {

--- a/tests/phpunit/tests/desktopFiles.php
+++ b/tests/phpunit/tests/desktopFiles.php
@@ -35,7 +35,7 @@ class Tests_DesktopMode_Files extends WP_UnitTestCase {
 	 */
 	public function test_built_in_types_are_registered() {
 		$types = wp_list_pluck( desktop_mode_get_file_types(), 'type' );
-		foreach ( array( 'post', 'attachment', 'user', 'term', 'comment', 'folder', 'bookmark' ) as $expected ) {
+		foreach ( array( 'post', 'attachment', 'user', 'term', 'comment', 'folder', 'bookmark', 'link', 'embed' ) as $expected ) {
 			$this->assertContains( $expected, $types );
 		}
 	}
@@ -164,6 +164,48 @@ class Tests_DesktopMode_Files extends WP_UnitTestCase {
 	 */
 	public function test_bookmark_file_rejects_javascript_url() {
 		$file = desktop_mode_resolve_file( 'bookmark', 'javascript:alert(1)' );
+		$this->assertFalse( $file->exists() );
+	}
+
+	/**
+	 * @covers Desktop_Mode_Link_File
+	 */
+	public function test_link_file_serializes_url_and_host_title() {
+		$file  = desktop_mode_resolve_file( 'link', 'https://example.com/path' );
+		$shape = $file->serialize();
+		$this->assertSame( 'link', $shape['type'] );
+		$this->assertSame( 'example.com', $shape['title'] );
+		$this->assertSame( 'https://example.com/path', $shape['url'] );
+		$this->assertSame( 'dashicons-admin-links', $shape['icon'] );
+		$this->assertTrue( $shape['exists'] );
+	}
+
+	/**
+	 * @covers Desktop_Mode_Link_File
+	 */
+	public function test_link_file_rejects_javascript_url() {
+		$file = desktop_mode_resolve_file( 'link', 'javascript:alert(1)' );
+		$this->assertFalse( $file->exists() );
+	}
+
+	/**
+	 * @covers Desktop_Mode_Embed_File
+	 */
+	public function test_embed_file_serializes_url_and_host_title() {
+		$file  = desktop_mode_resolve_file( 'embed', 'https://example.com/dashboard' );
+		$shape = $file->serialize();
+		$this->assertSame( 'embed', $shape['type'] );
+		$this->assertSame( 'example.com', $shape['title'] );
+		$this->assertSame( 'https://example.com/dashboard', $shape['url'] );
+		$this->assertSame( 'dashicons-welcome-view-site', $shape['icon'] );
+		$this->assertTrue( $shape['exists'] );
+	}
+
+	/**
+	 * @covers Desktop_Mode_Embed_File
+	 */
+	public function test_embed_file_rejects_empty_ref() {
+		$file = desktop_mode_resolve_file( 'embed', '' );
 		$this->assertFalse( $file->exists() );
 	}
 

--- a/tests/vitest/desktop-files-bin-drop.test.ts
+++ b/tests/vitest/desktop-files-bin-drop.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression test for the recycle-bin DOCK ICON drop flow.
+ *
+ * The user reports: "Still not able to drop anything in the recycle
+ * bin ICON, it reacts, but when releasing the button is not trashed."
+ *
+ * This test installs the bin drop targets the same way `desktop.ts`
+ * does (via `installRecycleBinDropTargets( dragManager )`), simulates
+ * a desktop-file drag onto a faked dock icon element, and verifies
+ * (a) the icon onEnter highlight, (b) the onDrop firing, and (c) the
+ * REST DELETE issued for the placement id.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DragManager } from '../../src/drag/manager';
+import { __resetRecoveryForTests } from '../../src/drag/recovery';
+import { HOOKS } from '../../src/hooks';
+
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+type BinTargetsModule = typeof import( '../../src/desktop-files/recycle-bin-targets' );
+
+// We do NOT call `vi.resetModules()` here because `trash.ts` imports
+// `rest` via `layer-deps`, and a reset would split the module graph
+// (the trash code would see an un-installed REST while the test set
+// up deps on a different `rest` instance). Sharing one module graph
+// keeps the `rest.installRestDeps` call visible to both.
+async function load(): Promise< {
+	store: StoreModule;
+	rest: RestModule;
+	binTargets: BinTargetsModule;
+} > {
+	return {
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+		binTargets: await import( '../../src/desktop-files/recycle-bin-targets' ),
+	};
+}
+
+const placement = ( id: number, type = 'post' ) => ( {
+	id,
+	parentId: 0,
+	x: 100,
+	y: 100,
+	sortOrder: 0,
+	updatedAtMs: 1,
+	meta: null,
+	file: {
+		type,
+		ref: String( id ),
+		title: `Item ${ id }`,
+		icon: 'dashicons-admin-post',
+		previewUrl: '',
+		exists: true,
+	},
+} );
+
+function pointerEvent(
+	type: string,
+	clientX: number,
+	clientY: number,
+	target: HTMLElement | Document = document,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target instanceof HTMLElement ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+function installManagerOnWindow( manager: DragManager ): void {
+	const wp = ( window as unknown as { wp?: { hooks?: unknown; desktop?: Record< string, unknown > } } ).wp ?? {};
+	wp.desktop = ( wp.desktop as Record< string, unknown > | undefined ) ?? {};
+	( wp.desktop as { dragManager: DragManager } ).dragManager = manager;
+	( window as unknown as { wp: typeof wp } ).wp = wp;
+}
+
+describe( 'recycle-bin dock icon drop (user regression)', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		__resetRecoveryForTests();
+		const mod = await import( '../../src/desktop-files/recycle-bin-targets' );
+		mod.__resetRecycleBinDropTargetsForTests();
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'dropping a desktop-file on the bin dock icon issues REST DELETE', async () => {
+		const { store, rest, binTargets } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		const fetchSpy = vi.fn( async () =>
+			new Response(
+				JSON.stringify( { deleted: true } ),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+		);
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		// 1. Mount the manager + install bin drop targets.
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+
+		// 2. Build a fake dock icon BEFORE installing — the installer's
+		//    initial probe should pick it up.
+		const dockTile = document.createElement( 'div' );
+		dockTile.classList.add(
+			'desktop-mode-dock__item',
+			'desktop-mode-dock__item--system',
+		);
+		dockTile.dataset.systemId = 'desktop-mode-recycle-bin';
+		const innerBtn = document.createElement( 'button' );
+		innerBtn.classList.add( 'desktop-mode-dock__item-primary' );
+		dockTile.appendChild( innerBtn );
+		document.body.appendChild( dockTile );
+
+		binTargets.installRecycleBinDropTargets( manager );
+
+		// Verify the bin target is now in the registry.
+		const targets = manager.debug().listTargets();
+		expect( targets.find( ( t ) => t.id === 'recycle-bin-dock' ) ).toBeDefined();
+
+		// 3. Seed a placement in the store. The user's drag-out will
+		//    point at this object via session.payload.data.placement.
+		const p = placement( 7, 'link' );
+		store.setFolderPlacements( 0, [ p ] );
+
+		// 4. Build a desktop file tile to act as the source.
+		const sourceTile = document.createElement( 'div' );
+		sourceTile.className = 'desktop-mode-file-tile';
+		document.body.appendChild( sourceTile );
+
+		// 5. Hit-test stub: returns the bin tile inner element when
+		//    the cursor is at (300, 300).
+		document.elementFromPoint = ( x, y ) => {
+			if ( x >= 280 && x < 340 && y >= 280 && y < 340 ) {
+				return innerBtn;
+			}
+			return null;
+		};
+
+		// 6. Start a desktop-file drag from sourceTile.
+		const onCommit = vi.fn();
+		manager.start( {
+			payload: {
+				type: 'desktop-file',
+				source: sourceTile,
+				data: {
+					placement: p,
+					sourceFolderId: 0,
+				},
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 100, 100, sourceTile ),
+			onCommit,
+		} );
+
+		// 7. Drag past threshold → over bin → release.
+		document.dispatchEvent( pointerEvent( 'pointermove', 110, 100 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 300, 300 ) );
+		// Verify the bin highlight applied via onEnter.
+		expect(
+			dockTile.hasAttribute( 'data-desktop-mode-trash-drop-active' ),
+		).toBe( true );
+		document.dispatchEvent( pointerEvent( 'pointerup', 300, 300 ) );
+
+		// 8. The drop should have committed.
+		expect( onCommit ).toHaveBeenCalledTimes( 1 );
+
+		// 9. Wait for trashByFileType → trashPlacementWithUndo → REST DELETE.
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		// 10. Verify a DELETE was issued for placement id 7.
+		const deletes = fetchSpy.mock.calls.filter( ( call ) => {
+			const init = call[ 1 ] as RequestInit | undefined;
+			return init?.method === 'DELETE' && String( call[ 0 ] ).endsWith( '/placements/7' );
+		} );
+		expect( deletes.length ).toBe( 1 );
+
+		// 11. Optimistic eviction means the placement is gone from the
+		//     store on the local side.
+		expect(
+			store.getFilesState().placementsByFolder.get( 0 )?.length,
+		).toBe( 0 );
+
+		// 12. The bin highlight class should be cleared.
+		expect(
+			dockTile.hasAttribute( 'data-desktop-mode-trash-drop-active' ),
+		).toBe( false );
+	} );
+
+	test( 'bin drop target re-registers after a dock re-render', async () => {
+		const { store, rest, binTargets } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		vi.stubGlobal( 'fetch', vi.fn( async () =>
+			new Response( JSON.stringify( { deleted: true } ), { status: 200 } ),
+		) );
+
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+
+		// First dock render.
+		const tile1 = document.createElement( 'div' );
+		tile1.classList.add( 'desktop-mode-dock__item' );
+		tile1.dataset.systemId = 'desktop-mode-recycle-bin';
+		document.body.appendChild( tile1 );
+
+		binTargets.installRecycleBinDropTargets( manager );
+		expect(
+			manager
+				.debug()
+				.listTargets()
+				.find( ( t ) => t.id === 'recycle-bin-dock' )?.element,
+		).toBe( tile1 );
+
+		// Dock re-renders — old tile detached, new one attached.
+		tile1.remove();
+		const tile2 = document.createElement( 'div' );
+		tile2.classList.add( 'desktop-mode-dock__item' );
+		tile2.dataset.systemId = 'desktop-mode-recycle-bin';
+		document.body.appendChild( tile2 );
+
+		// Fire the dock-after-render hook the same way `dock.ts` does.
+		( window as unknown as { wp: { hooks: { doAction: ( h: string, ...a: unknown[] ) => void } } } )
+			.wp.hooks.doAction( HOOKS.DOCK_AFTER_RENDER, {} );
+
+		// The drop target should now point at the NEW tile.
+		expect(
+			manager
+				.debug()
+				.listTargets()
+				.find( ( t ) => t.id === 'recycle-bin-dock' )?.element,
+		).toBe( tile2 );
+	} );
+} );

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Integration tests for the desktop-files drag flow with the
+ * centralized DragManager. Exercises:
+ *
+ *   - Tile drag → wallpaper canvas (REST PATCH with new x/y).
+ *   - Tile drag → recycle bin window body (trash + REST DELETE).
+ *   - Tile drag → arbitrary admin window (rejected, no REST).
+ *   - Pinned tile pointerdown → bump animation, no drag session.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DragManager } from '../../src/drag/manager';
+import { __resetRecoveryForTests } from '../../src/drag/recovery';
+
+type LayerModule = typeof import( '../../src/desktop-files/layer' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+
+async function load(): Promise< {
+	layer: LayerModule;
+	store: StoreModule;
+	rest: RestModule;
+} > {
+	vi.resetModules();
+	return {
+		layer: await import( '../../src/desktop-files/layer' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+	};
+}
+
+const placement = ( id: number, overrides: Record< string, unknown > = {} ) => ( {
+	id,
+	parentId: 0,
+	x: 100,
+	y: 100,
+	sortOrder: 0,
+	updatedAtMs: 1,
+	meta: null,
+	file: {
+		type: 'post',
+		ref: String( id ),
+		title: `Post ${ id }`,
+		icon: 'dashicons-admin-post',
+		previewUrl: '',
+		exists: true,
+		...( overrides.file as Record< string, unknown > | undefined ),
+	},
+	...overrides,
+} );
+
+function pointerEvent(
+	type: string,
+	clientX: number,
+	clientY: number,
+	target: HTMLElement | Document = document,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target instanceof HTMLElement ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+function installElementFromPointStub( regions: Array< { el: Element; rect: Rect } > ): void {
+	const ordered = [ ...regions ];
+	document.elementFromPoint = ( x: number, y: number ): Element | null => {
+		for ( let i = ordered.length - 1; i >= 0; i -= 1 ) {
+			const { el, rect } = ordered[ i ];
+			if (
+				x >= rect.x &&
+				x < rect.x + rect.w &&
+				y >= rect.y &&
+				y < rect.y + rect.h
+			) {
+				return el;
+			}
+		}
+		return null;
+	};
+}
+
+function setupRestStub() {
+	const fetchSpy = vi.fn( async () =>
+		new Response( JSON.stringify( { placements: [], folderId: 0 } ), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		} ),
+	);
+	vi.stubGlobal( 'fetch', fetchSpy );
+	return fetchSpy;
+}
+
+function installManagerOnWindow(): DragManager {
+	const manager = new DragManager();
+	( window as unknown as { wp: { desktop: { dragManager: DragManager } } } ).wp = (
+		window as unknown as { wp?: { desktop?: unknown } }
+	).wp ?? { hooks: {} };
+	const wp = ( window as unknown as { wp: { desktop?: unknown; hooks?: unknown } } ).wp;
+	wp.desktop = ( wp.desktop as Record< string, unknown > | undefined ) ?? {};
+	( wp.desktop as { dragManager: DragManager } ).dragManager = manager;
+	return manager;
+}
+
+describe( 'desktop-files drag (DragManager-backed)', () => {
+	beforeEach( () => {
+		installHooksStub();
+		__resetRecoveryForTests();
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'super-threshold drag PATCHes the placement with the snapped cell', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		const fetchSpy = setupRestStub();
+		const manager = installManagerOnWindow();
+		void manager;
+
+		store.setFolderPlacements( 0, [ placement( 1 ) ] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		expect( tile ).not.toBeNull();
+		tile!.style.left = '100px';
+		tile!.style.top = '100px';
+		Object.defineProperty( tile!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 100, top: 100, right: 188, bottom: 196,
+				width: 88, height: 96, x: 100, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		// Hit-test stub: cursor at (300, 300) lands on the host (the
+		// canvas drop target). Position relative to host's bbox.
+		Object.defineProperty( host, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		installElementFromPointStub( [ { el: host, rect: { x: 0, y: 0, w: 1024, h: 768 } } ] );
+
+		// Capture the layer container's bbox lookup. Container is
+		// inside host so its bbox is also (0,0,1024,768) in our setup.
+		const container = host.querySelector< HTMLElement >( '.desktop-mode-files-layer' );
+		Object.defineProperty( container!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+
+		// Reset fetch spy so we ignore the boot-time hydrate call.
+		fetchSpy.mockClear();
+
+		// Drag from (140, 140) — center of tile — to (310, 220).
+		tile!.dispatchEvent( pointerEvent( 'pointerdown', 140, 140, tile! ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 310, 220 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 310, 220 ) );
+
+		// Wait a microtask for the optimistic upsert + REST call.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// At least one PATCH /placements/1 call was issued.
+		const patches = fetchSpy.mock.calls.filter( ( call ) => {
+			const init = call[ 1 ] as RequestInit | undefined;
+			return init?.method === 'PATCH' && String( call[ 0 ] ).includes( '/placements/1' );
+		} );
+		expect( patches.length ).toBeGreaterThanOrEqual( 1 );
+
+		handle.dispose();
+	} );
+
+	test( 'pinned tile pointerdown adds bump class without starting a drag', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const manager = installManagerOnWindow();
+
+		store.setFolderPlacements( 0, [
+			placement( 1, { file: { type: 'shortcut', ref: '1', title: 'Pinned', icon: 'dashicons-admin-home', previewUrl: '', exists: true, pinned: true } } ),
+		] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		expect( tile?.classList.contains( 'desktop-mode-file-tile--pinned' ) ).toBe( true );
+
+		tile!.dispatchEvent( pointerEvent( 'pointerdown', 50, 50, tile! ) );
+
+		// Bump class is present briefly; no drag session is active.
+		expect( tile?.classList.contains( 'desktop-mode-file-tile--bump' ) ).toBe( true );
+		expect( manager.getActive() ).toBeNull();
+
+		handle.dispose();
+	} );
+
+	test( 'drag rolls back optimistic store on REST failure', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		// Boot fetch returns OK list; subsequent PATCH fails.
+		let firstCallSeen = false;
+		const fetchSpy = vi.fn( async ( _url: unknown, init: RequestInit | undefined ) => {
+			if ( init?.method === 'PATCH' || firstCallSeen ) {
+				firstCallSeen = true;
+				return new Response( JSON.stringify( { code: 'fail' } ), { status: 500 } );
+			}
+			firstCallSeen = true;
+			return new Response(
+				JSON.stringify( { placements: [], folderId: 0 } ),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		} );
+		vi.stubGlobal( 'fetch', fetchSpy );
+		installManagerOnWindow();
+
+		store.setFolderPlacements( 0, [ placement( 1 ) ] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		Object.defineProperty( host, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		const container = host.querySelector< HTMLElement >( '.desktop-mode-files-layer' );
+		Object.defineProperty( container!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		Object.defineProperty( tile!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 100, top: 100, right: 188, bottom: 196,
+				width: 88, height: 96, x: 100, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		installElementFromPointStub( [ { el: host, rect: { x: 0, y: 0, w: 1024, h: 768 } } ] );
+		tile!.style.left = '100px';
+		tile!.style.top = '100px';
+
+		tile!.dispatchEvent( pointerEvent( 'pointerdown', 140, 140, tile! ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 310, 220 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 310, 220 ) );
+
+		// Let the optimistic upsert + the failing PATCH + the rollback
+		// resolve.
+		await new Promise( ( r ) => setTimeout( r, 10 ) );
+
+		// After rollback, no orphaned `--dragging` class anywhere.
+		expect( document.querySelectorAll( '.desktop-mode-file-tile--dragging' ).length ).toBe( 0 );
+		expect( document.querySelector( '.desktop-mode-drag-ghost' ) ).toBeNull();
+
+		handle.dispose();
+	} );
+} );

--- a/tests/vitest/desktop-files-drop-into-folder.test.ts
+++ b/tests/vitest/desktop-files-drop-into-folder.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Regression test for the user-reported "drop a shortcut onto a
+ * folder tile, then open the folder — tiles don't render" bug.
+ *
+ * Scenario:
+ *   1. A folder layer is mounted on the wallpaper.
+ *   2. A folder tile is rendered (the placement is a folder).
+ *   3. A drag from "outside" (faking a My WordPress entity tile)
+ *      drops a `'shortcut'` payload onto the folder tile.
+ *   4. Open the folder window (mount a SECOND layer keyed at the
+ *      target folder id).
+ *   5. The layer should display the new tile.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DragManager } from '../../src/drag/manager';
+import { __resetRecoveryForTests } from '../../src/drag/recovery';
+
+type LayerModule = typeof import( '../../src/desktop-files/layer' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+
+async function load(): Promise< {
+	layer: LayerModule;
+	store: StoreModule;
+	rest: RestModule;
+} > {
+	vi.resetModules();
+	return {
+		layer: await import( '../../src/desktop-files/layer' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+	};
+}
+
+const folderPlacement = ( id: number, parentId = 0, ref = '5' ) => ( {
+	id,
+	parentId,
+	x: 100,
+	y: 100,
+	sortOrder: 0,
+	updatedAtMs: 1,
+	meta: null,
+	file: {
+		type: 'folder',
+		ref,
+		title: `Folder ${ ref }`,
+		icon: 'dashicons-category',
+		previewUrl: '',
+		exists: true,
+	},
+} );
+
+function pointerEvent(
+	type: string,
+	clientX: number,
+	clientY: number,
+	target: HTMLElement | Document = document,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target instanceof HTMLElement ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+function installManagerOnWindow( manager: DragManager ): void {
+	const wp = ( window as unknown as { wp?: { hooks?: unknown; desktop?: Record< string, unknown > } } ).wp ?? {};
+	wp.desktop = ( wp.desktop as Record< string, unknown > | undefined ) ?? {};
+	( wp.desktop as { dragManager: DragManager } ).dragManager = manager;
+	( window as unknown as { wp: typeof wp } ).wp = wp;
+}
+
+describe( 'drop shortcut on folder tile (user regression)', () => {
+	beforeEach( () => {
+		installHooksStub();
+		__resetRecoveryForTests();
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'drop creates placement that appears when folder is opened', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		// REST fetch behaviour. The server keeps a tiny in-memory
+		// table keyed by parent folder so a POST followed by a GET
+		// reads back what the POST wrote — the realistic flow.
+		const serverByFolder = new Map< number, Array< Record< string, unknown > > >();
+		serverByFolder.set( 0, [ folderPlacement( 1, 0, '5' ) ] );
+		let nextPlacementId = 1000;
+		const fetchSpy = vi.fn( async ( url: unknown, init: RequestInit | undefined ) => {
+			const u = String( url );
+			if ( init?.method === 'POST' && u.endsWith( '/placements' ) ) {
+				const body = JSON.parse( init.body as string );
+				const newPlacement = {
+					id: ++nextPlacementId,
+					parentId: body.parentId,
+					x: body.x,
+					y: body.y,
+					sortOrder: 0,
+					updatedAtMs: Date.now(),
+					meta: null,
+					file: {
+						type: body.type,
+						ref: body.ref,
+						title: `Item ${ body.ref }`,
+						icon: 'dashicons-admin-post',
+						previewUrl: '',
+						exists: true,
+					},
+				};
+				const bucket = serverByFolder.get( body.parentId ) ?? [];
+				bucket.push( newPlacement );
+				serverByFolder.set( body.parentId, bucket );
+				return new Response( JSON.stringify( newPlacement ), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				} );
+			}
+			const folderMatch = u.match( /folder=(\d+)/ );
+			const folderId = folderMatch ? parseInt( folderMatch[ 1 ], 10 ) : 0;
+			const placements = serverByFolder.get( folderId ) ?? [];
+			return new Response(
+				JSON.stringify( { placements, folderId } ),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		} );
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+
+		// Seed the wallpaper with a folder tile.
+		store.setFolderPlacements( 0, [ folderPlacement( 1, 0, '5' ) ] );
+
+		const wallpaper = document.createElement( 'div' );
+		wallpaper.id = 'desktop-mode-area';
+		Object.defineProperty( wallpaper, 'clientWidth', { value: 1200, configurable: true } );
+		Object.defineProperty( wallpaper, 'clientHeight', { value: 800, configurable: true } );
+		Object.defineProperty( wallpaper, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1200, bottom: 800,
+				width: 1200, height: 800, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		document.body.appendChild( wallpaper );
+		const wallpaperLayer = layer.mountFilesLayer( wallpaper, 0 );
+
+		const folderTile = wallpaper.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		expect( folderTile ).not.toBeNull();
+		Object.defineProperty( folderTile!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 100, top: 100, right: 188, bottom: 196,
+				width: 88, height: 96, x: 100, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+
+		// Hit-test stub: cursor at (140, 140) is on folderTile.
+		document.elementFromPoint = ( x, y ) => {
+			if ( x >= 100 && x < 188 && y >= 100 && y < 196 ) {
+				return folderTile;
+			}
+			if ( x >= 0 && x < 1200 && y >= 0 && y < 800 ) {
+				return wallpaper;
+			}
+			return null;
+		};
+
+		// Synthesize a dragstart from a faked My WordPress post tile.
+		const sourceTile = document.createElement( 'div' );
+		sourceTile.className = 'desktop-mode-my-wordpress__tile';
+		document.body.appendChild( sourceTile );
+
+		manager.start( {
+			payload: {
+				type: 'shortcut',
+				source: sourceTile,
+				data: {
+					kind: 'post',
+					ref: '42',
+					title: 'My Post',
+					icon: 'dashicons-admin-post',
+				},
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 200, 200, sourceTile ),
+		} );
+
+		// Cross threshold + move to over folderTile.
+		document.dispatchEvent( pointerEvent( 'pointermove', 250, 250 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 140, 140 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 140, 140 ) );
+
+		// Wait for REST POST + the optimistic upsert to land.
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		// Store should now have a placement under folder 5.
+		const folderBucket = store.getFilesState().placementsByFolder.get( 5 );
+		expect( folderBucket?.length ).toBe( 1 );
+		expect( folderBucket?.[ 0 ].file.type ).toBe( 'post' );
+		expect( folderBucket?.[ 0 ].file.ref ).toBe( '42' );
+
+		// Now open the folder by mounting a layer for folderId=5.
+		const folderHost = document.createElement( 'div' );
+		folderHost.classList.add( 'desktop-mode-window__body' );
+		// Wrap in a fake `.desktop-mode-window` to mirror production.
+		const folderWindow = document.createElement( 'div' );
+		folderWindow.classList.add( 'desktop-mode-window' );
+		folderWindow.appendChild( folderHost );
+		document.body.appendChild( folderWindow );
+		Object.defineProperty( folderHost, 'clientWidth', { value: 600, configurable: true } );
+		Object.defineProperty( folderHost, 'clientHeight', { value: 400, configurable: true } );
+
+		const folderLayer = layer.mountFilesLayer( folderHost, 5 );
+
+		// Wait for any pending REST settles.
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		// The folder layer's container should now hold a tile for the
+		// dropped shortcut.
+		const folderTiles = folderHost.querySelectorAll( '.desktop-mode-file-tile' );
+		expect( folderTiles.length ).toBe( 1 );
+
+		wallpaperLayer.dispose();
+		folderLayer.dispose();
+	} );
+
+	test( 'drop INSIDE an open folder window paints a tile immediately', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		const serverByFolder = new Map< number, Array< Record< string, unknown > > >();
+		let nextPlacementId = 2000;
+		const fetchSpy = vi.fn( async ( url: unknown, init: RequestInit | undefined ) => {
+			const u = String( url );
+			if ( init?.method === 'POST' && u.endsWith( '/placements' ) ) {
+				const body = JSON.parse( init.body as string );
+				const newPlacement = {
+					id: ++nextPlacementId,
+					parentId: body.parentId,
+					x: body.x,
+					y: body.y,
+					sortOrder: 0,
+					updatedAtMs: Date.now(),
+					meta: null,
+					file: {
+						type: body.type,
+						ref: body.ref,
+						title: `Item ${ body.ref }`,
+						icon: 'dashicons-admin-post',
+						previewUrl: '',
+						exists: true,
+					},
+				};
+				const bucket = serverByFolder.get( body.parentId ) ?? [];
+				bucket.push( newPlacement );
+				serverByFolder.set( body.parentId, bucket );
+				return new Response( JSON.stringify( newPlacement ), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				} );
+			}
+			const folderMatch = u.match( /folder=(\d+)/ );
+			const folderId = folderMatch ? parseInt( folderMatch[ 1 ], 10 ) : 0;
+			const placements = serverByFolder.get( folderId ) ?? [];
+			return new Response(
+				JSON.stringify( { placements, folderId } ),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		} );
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+
+		// Mount an open folder window for folder 7 (empty).
+		const folderWindow = document.createElement( 'div' );
+		folderWindow.classList.add( 'desktop-mode-window' );
+		const folderHost = document.createElement( 'div' );
+		folderHost.classList.add( 'desktop-mode-window__body' );
+		folderWindow.appendChild( folderHost );
+		document.body.appendChild( folderWindow );
+		Object.defineProperty( folderHost, 'clientWidth', { value: 600, configurable: true } );
+		Object.defineProperty( folderHost, 'clientHeight', { value: 400, configurable: true } );
+		Object.defineProperty( folderHost, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 200, top: 100, right: 800, bottom: 500,
+				width: 600, height: 400, x: 200, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		const folderLayer = layer.mountFilesLayer( folderHost, 7 );
+
+		// Wait for hydration to complete.
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		// Faked source tile (My WordPress post).
+		const sourceTile = document.createElement( 'div' );
+		document.body.appendChild( sourceTile );
+
+		// Hit-test resolves the cursor over the folder window's body
+		// (i.e. over the open folder canvas).
+		document.elementFromPoint = ( x, y ) => {
+			if ( x >= 200 && x < 800 && y >= 100 && y < 500 ) {
+				return folderHost;
+			}
+			return null;
+		};
+
+		const container = folderHost.querySelector< HTMLElement >( '.desktop-mode-files-layer' );
+		Object.defineProperty( container!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 200, top: 100, right: 800, bottom: 500,
+				width: 600, height: 400, x: 200, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+
+		manager.start( {
+			payload: {
+				type: 'shortcut',
+				source: sourceTile,
+				data: {
+					kind: 'post',
+					ref: '99',
+					title: 'Hello',
+					icon: 'dashicons-admin-post',
+				},
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 0, 0, sourceTile ),
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 50, 50 ) ); // off-target
+		document.dispatchEvent( pointerEvent( 'pointermove', 400, 250 ) ); // over folder host
+		document.dispatchEvent( pointerEvent( 'pointerup', 400, 250 ) );
+
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		// Verify the placement was created with parentId=7.
+		const folderBucket = store.getFilesState().placementsByFolder.get( 7 );
+		expect( folderBucket?.length ).toBe( 1 );
+		expect( folderBucket?.[ 0 ].file.ref ).toBe( '99' );
+
+		// Verify the layer painted a tile.
+		const tilesAfter = folderHost.querySelectorAll( '.desktop-mode-file-tile' );
+		expect( tilesAfter.length ).toBe( 1 );
+
+		folderLayer.dispose();
+	} );
+} );

--- a/tests/vitest/desktop-files-wallpaper-menu.test.ts
+++ b/tests/vitest/desktop-files-wallpaper-menu.test.ts
@@ -13,6 +13,8 @@ async function load(): Promise< MenuModule > {
 
 const stubDeps = ( overrides: Partial< import( '../../src/desktop-files/wallpaper-menu' ).WallpaperMenuDeps > = {} ) => ( {
 	createFolder: vi.fn(),
+	createLink: vi.fn(),
+	createEmbed: vi.fn(),
 	toggleShowDesktop: vi.fn(),
 	openOsSettings: vi.fn(),
 	openWallpapers: vi.fn(),
@@ -27,6 +29,9 @@ const stubDeps = ( overrides: Partial< import( '../../src/desktop-files/wallpape
 		sortNameDesc: 'Name (Z → A)',
 		sortDateAsc: 'Date (oldest first)',
 		sortDateDesc: 'Date (newest first)',
+		newHeading: 'New',
+		newLink: 'Web link (open in browser)',
+		newEmbed: 'Embedded window (open in shell)',
 	},
 	...overrides,
 } );
@@ -41,9 +46,12 @@ describe( 'wallpaper context menu', () => {
 		document.body.innerHTML = '';
 	} );
 
-	test( 'buildMenuItems returns the four built-ins in order', async () => {
+	test( 'buildMenuItems returns the built-ins in order', async () => {
 		const { buildMenuItems } = await load();
 		const items = buildMenuItems( stubDeps() );
+		// The "new" submenu (web link / embedded window) is
+		// temporarily hidden in wallpaper-menu.ts; re-add 'new'
+		// (and the children assertion below) when it ships.
 		expect( items.map( ( i ) => i.id ) ).toEqual( [
 			'create-folder',
 			'sort-by',
@@ -51,6 +59,7 @@ describe( 'wallpaper context menu', () => {
 			'os-settings',
 			'wallpapers',
 		] );
+		expect( items.find( ( i ) => i.id === 'new' ) ).toBeUndefined();
 		const sortBy = items.find( ( i ) => i.id === 'sort-by' );
 		expect( sortBy?.children?.map( ( c ) => c.id ) ).toEqual(
 			expect.arrayContaining( [

--- a/tests/vitest/drag-drop-targets.test.ts
+++ b/tests/vitest/drag-drop-targets.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Drop-target registry behavior — deepest-match wins, the
+ * `.desktop-mode-window` claim boundary, idempotent re-registration.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DropTargetRegistry } from '../../src/drag/drop-target-registry';
+
+describe( 'DropTargetRegistry', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'deepest registered ancestor wins', () => {
+		const reg = new DropTargetRegistry();
+		const outer = document.createElement( 'div' );
+		const middle = document.createElement( 'div' );
+		const inner = document.createElement( 'div' );
+		outer.appendChild( middle );
+		middle.appendChild( inner );
+		document.body.appendChild( outer );
+
+		const outerTarget = {
+			id: 'outer', element: outer, accept: () => true, onDrop: () => undefined,
+		};
+		const middleTarget = {
+			id: 'middle', element: middle, accept: () => true, onDrop: () => undefined,
+		};
+		reg.register( outerTarget );
+		reg.register( middleTarget );
+
+		expect( reg.hitTest( inner ) ).toBe( middleTarget );
+		expect( reg.hitTest( middle ) ).toBe( middleTarget );
+		expect( reg.hitTest( outer ) ).toBe( outerTarget );
+	} );
+
+	test( 'hitTest returns null for an element outside any registered tree', () => {
+		const reg = new DropTargetRegistry();
+		const isolated = document.createElement( 'div' );
+		document.body.appendChild( isolated );
+
+		expect( reg.hitTest( isolated ) ).toBeNull();
+	} );
+
+	test( '.desktop-mode-window stops the walk and returns null', () => {
+		// Layout:
+		//   <div id="wallpaper">
+		//     <div class="desktop-mode-window">
+		//       <iframe />
+		//     </div>
+		//   </div>
+		// Wallpaper is registered, the window is NOT. Hit-testing on
+		// the iframe should NOT find the wallpaper — the window
+		// boundary blocks the walk.
+		const reg = new DropTargetRegistry();
+		const wallpaper = document.createElement( 'div' );
+		wallpaper.id = 'wallpaper';
+		const win = document.createElement( 'div' );
+		win.classList.add( 'desktop-mode-window' );
+		const iframe = document.createElement( 'div' );
+		win.appendChild( iframe );
+		wallpaper.appendChild( win );
+		document.body.appendChild( wallpaper );
+
+		reg.register( {
+			id: 'wallpaper', element: wallpaper, accept: () => true, onDrop: () => undefined,
+		} );
+
+		// Cursor over iframe → hit-test walks up → hits .desktop-mode-window
+		// before reaching wallpaper → returns null.
+		expect( reg.hitTest( iframe ) ).toBeNull();
+		// But hitting the wallpaper itself directly still works.
+		expect( reg.hitTest( wallpaper )?.id ).toBe( 'wallpaper' );
+	} );
+
+	test( 'a target registered INSIDE the window claims its own region', () => {
+		// When a window opts into accepting drops by registering a
+		// target on its body (e.g. recycle bin), hit-testing over that
+		// body returns the bin target — the window class boundary only
+		// kicks in when no inner registration is found.
+		const reg = new DropTargetRegistry();
+		const wallpaper = document.createElement( 'div' );
+		const win = document.createElement( 'div' );
+		win.classList.add( 'desktop-mode-window' );
+		const binBody = document.createElement( 'div' );
+		const innerChild = document.createElement( 'span' );
+		binBody.appendChild( innerChild );
+		win.appendChild( binBody );
+		wallpaper.appendChild( win );
+		document.body.appendChild( wallpaper );
+
+		reg.register( {
+			id: 'wallpaper', element: wallpaper, accept: () => true, onDrop: () => undefined,
+		} );
+		const binTarget = {
+			id: 'bin', element: binBody, accept: () => true, onDrop: () => undefined,
+		};
+		reg.register( binTarget );
+
+		expect( reg.hitTest( innerChild ) ).toBe( binTarget );
+		expect( reg.hitTest( binBody ) ).toBe( binTarget );
+	} );
+
+	test( 'idempotent re-registration replaces the old entry under the same id', () => {
+		const reg = new DropTargetRegistry();
+		const a = document.createElement( 'div' );
+		const b = document.createElement( 'div' );
+		document.body.append( a, b );
+
+		const t1 = { id: 'tgt', element: a, accept: () => true, onDrop: () => undefined };
+		reg.register( t1 );
+		expect( reg.hitTest( a )?.element ).toBe( a );
+
+		const t2 = { id: 'tgt', element: b, accept: () => true, onDrop: () => undefined };
+		reg.register( t2 );
+		expect( reg.hitTest( a ) ).toBeNull();
+		expect( reg.hitTest( b )?.element ).toBe( b );
+	} );
+
+	test( 'deregister returned by register removes the entry', () => {
+		const reg = new DropTargetRegistry();
+		const el = document.createElement( 'div' );
+		document.body.appendChild( el );
+		const deregister = reg.register( {
+			id: 'tgt', element: el, accept: () => true, onDrop: () => undefined,
+		} );
+		expect( reg.list().length ).toBe( 1 );
+		deregister();
+		expect( reg.list().length ).toBe( 0 );
+		// Second deregister is a no-op.
+		expect( () => deregister() ).not.toThrow();
+	} );
+
+	test( 'list returns a snapshot — caller mutations do not affect the registry', () => {
+		const reg = new DropTargetRegistry();
+		const el = document.createElement( 'div' );
+		reg.register( {
+			id: 'x', element: el, accept: () => true, onDrop: () => undefined,
+		} );
+		const snapshot = reg.list() as Array< unknown >;
+		// Snapshot is a frozen array per `Array.from()` — mutations
+		// shouldn't propagate. (Some implementations return a live
+		// view; the registry uses Array.from so this is safe.)
+		expect( snapshot.length ).toBe( 1 );
+		// Adding to snapshot doesn't affect registry.
+		snapshot.push( 'extra' );
+		expect( reg.list().length ).toBe( 1 );
+	} );
+} );

--- a/tests/vitest/drag-manager.test.ts
+++ b/tests/vitest/drag-manager.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Unit tests for the centralized DragManager.
+ *
+ * Exercises the state machine: lift threshold, single-session
+ * invariant, drop-target hit-testing + claim-boundary, ghost
+ * lifecycle, click-only fallback for sub-threshold gestures.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DragManager } from '../../src/drag/manager';
+import { __resetRecoveryForTests } from '../../src/drag/recovery';
+import type { DragPayload, DropTarget } from '../../src/drag/types';
+
+/**
+ * jsdom doesn't construct `PointerEvent`s, so we synthesize a plain
+ * Event with the fields the manager reads. Same trick `drag-unstate.test.ts`
+ * uses for the title-bar drag tests.
+ */
+function pointerEvent(
+	type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+	clientX: number,
+	clientY: number,
+	target: HTMLElement | Document = document,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target instanceof HTMLElement ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+function makeSource( id: string ): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.id = id;
+	el.className = 'desktop-mode-file-tile';
+	el.style.position = 'absolute';
+	el.style.width = '88px';
+	el.style.height = '96px';
+	document.body.appendChild( el );
+	return el;
+}
+
+function makeTargetElement( id: string, rect: { x: number; y: number; w: number; h: number } ): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.id = id;
+	el.style.position = 'absolute';
+	el.style.left = `${ rect.x }px`;
+	el.style.top = `${ rect.y }px`;
+	el.style.width = `${ rect.w }px`;
+	el.style.height = `${ rect.h }px`;
+	document.body.appendChild( el );
+	// jsdom doesn't compute layouts, so `elementFromPoint` returns
+	// nothing useful by default. Stub it on `document` to walk our
+	// targets and return the first whose stored rect contains (x, y).
+	return el;
+}
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+function installElementFromPointStub( regions: Array< { el: Element; rect: Rect } > ): void {
+	const ordered = [ ...regions ];
+	document.elementFromPoint = ( x: number, y: number ): Element | null => {
+		// Search in REVERSE registration order so later registrations
+		// win on overlap (matches "last appended is on top" intuition).
+		for ( let i = ordered.length - 1; i >= 0; i -= 1 ) {
+			const { el, rect } = ordered[ i ];
+			if (
+				x >= rect.x &&
+				x < rect.x + rect.w &&
+				y >= rect.y &&
+				y < rect.y + rect.h
+			) {
+				return el;
+			}
+		}
+		return null;
+	};
+}
+
+describe( 'DragManager', () => {
+	beforeEach( () => {
+		installHooksStub();
+		__resetRecoveryForTests();
+		// jsdom default: no elementFromPoint. Tests that need a
+		// specific hit-test result call `installElementFromPointStub`
+		// to override; everything else gets null (no target found).
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'sub-threshold gesture fires onClickOnly without lifting the ghost', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		const onClickOnly = vi.fn();
+		const onCommit = vi.fn();
+
+		const session = manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 100, 100, source ),
+			onClickOnly,
+			onCommit,
+		} );
+		expect( session ).not.toBeNull();
+		expect( manager.isDragging() ).toBe( false ); // not lifted yet
+
+		// Move 2px — below threshold.
+		document.dispatchEvent( pointerEvent( 'pointermove', 102, 100 ) );
+		expect( manager.isDragging() ).toBe( false );
+		expect( document.querySelector( '.desktop-mode-drag-ghost' ) ).toBeNull();
+
+		// Release.
+		document.dispatchEvent( pointerEvent( 'pointerup', 102, 100 ) );
+		expect( onClickOnly ).toHaveBeenCalledTimes( 1 );
+		expect( onCommit ).not.toHaveBeenCalled();
+		expect( manager.getActive() ).toBeNull();
+	} );
+
+	test( 'super-threshold gesture lifts ghost and applies --dragging to source', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+
+		manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 100, 100, source ),
+		} );
+
+		document.dispatchEvent( pointerEvent( 'pointermove', 110, 100 ) );
+		expect( manager.isDragging() ).toBe( true );
+		expect( source.classList.contains( 'desktop-mode-file-tile--dragging' ) ).toBe( true );
+		const ghost = document.querySelector( '.desktop-mode-drag-ghost' );
+		expect( ghost ).not.toBeNull();
+
+		document.dispatchEvent( pointerEvent( 'pointerup', 110, 100 ) );
+		// Cleanup.
+		expect( source.classList.contains( 'desktop-mode-file-tile--dragging' ) ).toBe( false );
+		expect( document.querySelector( '.desktop-mode-drag-ghost' ) ).toBeNull();
+	} );
+
+	test( 'second start() while dragging returns null', () => {
+		const manager = new DragManager();
+		const a = makeSource( 'a' );
+		const b = makeSource( 'b' );
+
+		manager.start( {
+			payload: { type: 'desktop-file', source: a, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, a ),
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 60, 50 ) );
+		expect( manager.isDragging() ).toBe( true );
+
+		const second = manager.start( {
+			payload: { type: 'desktop-file', source: b, data: {} },
+			origin: pointerEvent( 'pointerdown', 200, 200, b ),
+		} );
+		expect( second ).toBeNull();
+	} );
+
+	test( 'commit fires onDrop on the accepting target and onCommit on the source', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		const targetEl = makeTargetElement( 'tgt', { x: 200, y: 200, w: 100, h: 100 } );
+		installElementFromPointStub( [ { el: targetEl, rect: { x: 200, y: 200, w: 100, h: 100 } } ] );
+
+		const onDrop = vi.fn();
+		const onCommit = vi.fn();
+		const target: DropTarget = {
+			id: 'tgt',
+			element: targetEl,
+			accept: () => true,
+			onDrop,
+		};
+		const deregister = manager.registerDropTarget( target );
+		const payload: DragPayload = { type: 'desktop-file', source, data: { foo: 'bar' } };
+
+		manager.start( {
+			payload,
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+			onCommit,
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 250, 250 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 250, 250 ) );
+
+		expect( onDrop ).toHaveBeenCalledTimes( 1 );
+		expect( onDrop.mock.calls[ 0 ][ 1 ] ).toEqual( { clientX: 250, clientY: 250 } );
+		expect( onCommit ).toHaveBeenCalledTimes( 1 );
+		expect( onCommit.mock.calls[ 0 ][ 0 ] ).toBe( target );
+
+		deregister();
+	} );
+
+	test( 'rejecting target prevents onDrop and reports rejected', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		const targetEl = makeTargetElement( 'tgt', { x: 200, y: 200, w: 100, h: 100 } );
+		installElementFromPointStub( [ { el: targetEl, rect: { x: 200, y: 200, w: 100, h: 100 } } ] );
+
+		const onDrop = vi.fn();
+		const onCommit = vi.fn();
+		const onCancel = vi.fn();
+		manager.registerDropTarget( {
+			id: 'tgt',
+			element: targetEl,
+			accept: () => false, // rejects
+			onDrop,
+		} );
+
+		manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+			onCommit,
+			onCancel,
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 250, 250 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 250, 250 ) );
+
+		expect( onDrop ).not.toHaveBeenCalled();
+		expect( onCommit ).not.toHaveBeenCalled();
+		expect( onCancel ).toHaveBeenCalledWith( 'rejected' );
+	} );
+
+	test( 'no-target drop fires onCancel with no-target reason', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		installElementFromPointStub( [] );
+		const onCancel = vi.fn();
+
+		manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+			onCancel,
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 250, 250 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 250, 250 ) );
+
+		expect( onCancel ).toHaveBeenCalledWith( 'no-target' );
+	} );
+
+	test( 'deregister removes the target from hit-testing', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		const targetEl = makeTargetElement( 'tgt', { x: 200, y: 200, w: 100, h: 100 } );
+		installElementFromPointStub( [ { el: targetEl, rect: { x: 200, y: 200, w: 100, h: 100 } } ] );
+
+		const onDrop = vi.fn();
+		const deregister = manager.registerDropTarget( {
+			id: 'tgt',
+			element: targetEl,
+			accept: () => true,
+			onDrop,
+		} );
+		expect( manager.debug().listTargets().length ).toBe( 1 );
+
+		deregister();
+		expect( manager.debug().listTargets().length ).toBe( 0 );
+
+		manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 250, 250 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 250, 250 ) );
+		expect( onDrop ).not.toHaveBeenCalled();
+	} );
+
+	test( 'cancel() during drag tears down ghost and source class', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+
+		const session = manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 60, 50 ) );
+		expect( source.classList.contains( 'desktop-mode-file-tile--dragging' ) ).toBe( true );
+		expect( document.querySelector( '.desktop-mode-drag-ghost' ) ).not.toBeNull();
+
+		session?.cancel();
+		expect( session?.isFinished() ).toBe( true );
+		expect( source.classList.contains( 'desktop-mode-file-tile--dragging' ) ).toBe( false );
+		expect( document.querySelector( '.desktop-mode-drag-ghost' ) ).toBeNull();
+		expect( manager.getActive() ).toBeNull();
+	} );
+
+	test( 'cleanup is idempotent — double cancel is a no-op', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		const onCancel = vi.fn();
+
+		const session = manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+			onCancel,
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 60, 50 ) );
+		session?.cancel();
+		session?.cancel(); // second call
+		expect( onCancel ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'enter/leave fires once per transition', () => {
+		const manager = new DragManager();
+		const source = makeSource( 'src' );
+		const a = makeTargetElement( 'a', { x: 200, y: 0, w: 100, h: 100 } );
+		const b = makeTargetElement( 'b', { x: 400, y: 0, w: 100, h: 100 } );
+		installElementFromPointStub( [
+			{ el: a, rect: { x: 200, y: 0, w: 100, h: 100 } },
+			{ el: b, rect: { x: 400, y: 0, w: 100, h: 100 } },
+		] );
+
+		const aEnter = vi.fn();
+		const aLeave = vi.fn();
+		const bEnter = vi.fn();
+		manager.registerDropTarget( {
+			id: 'a', element: a, accept: () => true, onDrop: () => undefined, onEnter: aEnter, onLeave: aLeave,
+		} );
+		manager.registerDropTarget( {
+			id: 'b', element: b, accept: () => true, onDrop: () => undefined, onEnter: bEnter,
+		} );
+
+		manager.start( {
+			payload: { type: 'desktop-file', source, data: {} },
+			origin: pointerEvent( 'pointerdown', 50, 50, source ),
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 250, 50 ) ); // over A
+		expect( aEnter ).toHaveBeenCalledTimes( 1 );
+		document.dispatchEvent( pointerEvent( 'pointermove', 260, 50 ) ); // still over A
+		expect( aEnter ).toHaveBeenCalledTimes( 1 );
+		document.dispatchEvent( pointerEvent( 'pointermove', 450, 50 ) ); // over B
+		expect( aLeave ).toHaveBeenCalledTimes( 1 );
+		expect( bEnter ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'findOrphans returns elements with stale drag classes/attrs', () => {
+		const manager = new DragManager();
+		const dirty = makeSource( 'dirty' );
+		dirty.classList.add( 'desktop-mode-file-tile--dragging' );
+		const someBin = document.createElement( 'div' );
+		someBin.setAttribute( 'data-desktop-mode-trash-drop-active', '' );
+		document.body.appendChild( someBin );
+
+		const orphans = manager.debug().findOrphans();
+		expect( orphans ).toContain( dirty );
+		expect( orphans ).toContain( someBin );
+	} );
+} );

--- a/tests/vitest/drag-recovery.test.ts
+++ b/tests/vitest/drag-recovery.test.ts
@@ -1,0 +1,137 @@
+/**
+ * DragManager recovery paths — Escape, blur, visibilitychange,
+ * pointercancel. Each path must:
+ *
+ *   1. Cancel the active session (`onCancel` fires with the right reason).
+ *   2. Strip every drag-state DOM marker so `findOrphans()` returns [].
+ *   3. Be idempotent — a second cancel call (or a second listener
+ *      firing) doesn't double-fire any callback.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DragManager } from '../../src/drag/manager';
+import { __resetRecoveryForTests } from '../../src/drag/recovery';
+
+function pointerEvent(
+	type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+	clientX: number,
+	clientY: number,
+	target: HTMLElement | Document = document,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target instanceof HTMLElement ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+function makeSource(): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.className = 'desktop-mode-file-tile';
+	document.body.appendChild( el );
+	return el;
+}
+
+function startActiveDrag( manager: DragManager, onCancel: () => void ): { source: HTMLElement } {
+	const source = makeSource();
+	manager.start( {
+		payload: { type: 'desktop-file', source, data: {} },
+		origin: pointerEvent( 'pointerdown', 50, 50, source ),
+		onCancel,
+	} );
+	document.dispatchEvent( pointerEvent( 'pointermove', 60, 50 ) );
+	return { source };
+}
+
+describe( 'DragManager recovery', () => {
+	beforeEach( () => {
+		installHooksStub();
+		__resetRecoveryForTests();
+		// jsdom doesn't implement elementFromPoint natively. The
+		// manager's hover update calls it on every pointermove past
+		// threshold; without the stub the tests crash before they
+		// can exercise the recovery paths. Returning null is fine —
+		// recovery doesn't depend on a particular target being found.
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'Escape mid-drag cancels the session and scrubs DOM state', () => {
+		const manager = new DragManager();
+		const onCancel = vi.fn();
+		const { source } = startActiveDrag( manager, onCancel );
+
+		const escape = new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } );
+		document.dispatchEvent( escape );
+
+		expect( onCancel ).toHaveBeenCalledWith( 'escape' );
+		expect( source.classList.contains( 'desktop-mode-file-tile--dragging' ) ).toBe( false );
+		expect( document.querySelector( '.desktop-mode-drag-ghost' ) ).toBeNull();
+		expect( manager.debug().findOrphans() ).toEqual( [] );
+	} );
+
+	test( 'window blur mid-drag cancels with reason=blur', () => {
+		const manager = new DragManager();
+		const onCancel = vi.fn();
+		startActiveDrag( manager, onCancel );
+
+		window.dispatchEvent( new Event( 'blur' ) );
+
+		expect( onCancel ).toHaveBeenCalledWith( 'blur' );
+	} );
+
+	test( 'visibilitychange to hidden cancels with reason=visibility', () => {
+		const manager = new DragManager();
+		const onCancel = vi.fn();
+		startActiveDrag( manager, onCancel );
+
+		Object.defineProperty( document, 'hidden', { value: true, configurable: true } );
+		document.dispatchEvent( new Event( 'visibilitychange' ) );
+
+		expect( onCancel ).toHaveBeenCalledWith( 'visibility' );
+		// Reset for next test.
+		Object.defineProperty( document, 'hidden', { value: false, configurable: true } );
+	} );
+
+	test( 'pointercancel fires CancelReason="pointercancel"', () => {
+		const manager = new DragManager();
+		const onCancel = vi.fn();
+		startActiveDrag( manager, onCancel );
+
+		document.dispatchEvent( pointerEvent( 'pointercancel', 60, 50 ) );
+
+		expect( onCancel ).toHaveBeenCalledWith( 'pointercancel' );
+	} );
+
+	test( 'recovery handlers are idempotent — duplicate cancels do not re-fire onCancel', () => {
+		const manager = new DragManager();
+		const onCancel = vi.fn();
+		startActiveDrag( manager, onCancel );
+
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape' } ) );
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape' } ) );
+		window.dispatchEvent( new Event( 'blur' ) );
+
+		expect( onCancel ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'Escape WITHOUT an active drag is a no-op', () => {
+		const manager = new DragManager();
+		// Don't start a drag — but recovery may have been installed by
+		// an earlier test in the suite. Issue Escape; nothing should
+		// happen.
+		expect( () => {
+			document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape' } ) );
+		} ).not.toThrow();
+		expect( manager.getActive() ).toBeNull();
+	} );
+} );

--- a/tests/vitest/my-wordpress-drag.test.ts
+++ b/tests/vitest/my-wordpress-drag.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Regression test for the My WordPress entity-tile drag-out flow.
+ *
+ * The user-reported bug: "Posts & Pages tiles inside My WordPress are
+ * forbidden — I can lift the tile but no drop target accepts it."
+ *
+ * Root cause was in `attachTileDrag` (deleted in 0.18.0) which called
+ * `setPointerCapture` on a tile that was also `draggable=true`. Pointer
+ * capture redirected pointer events to the tile, which prevented the
+ * browser from firing `dragstart` — so the HTML5 drag never started,
+ * the payload was never set on `DataTransfer`, and no drop target ever
+ * saw it.
+ *
+ * The fix: pointerdown on the tile starts a DragManager session with
+ * a `'shortcut'` payload. The manager owns the gesture; the
+ * wallpaper's drop target accepts the payload and POSTs a placement.
+ *
+ * This test wires the same shape my-wordpress now uses (pointerdown
+ * → dragManager.start) and verifies the drop target receives a typed
+ * shortcut payload after a super-threshold gesture. It does NOT load
+ * the full my-wordpress module — that would require the entire shell
+ * boot. It tests the contract.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { DragManager } from '../../src/drag/manager';
+import { __resetRecoveryForTests } from '../../src/drag/recovery';
+import type { ShortcutDragData } from '../../src/desktop-files/drag-payloads';
+
+function pointerEvent(
+	type: string,
+	clientX: number,
+	clientY: number,
+	target: HTMLElement | Document = document,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target instanceof HTMLElement ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+function installElementFromPointStub( regions: Array< { el: Element; rect: { x: number; y: number; w: number; h: number } } > ): void {
+	const ordered = [ ...regions ];
+	document.elementFromPoint = ( x: number, y: number ): Element | null => {
+		for ( let i = ordered.length - 1; i >= 0; i -= 1 ) {
+			const { el, rect } = ordered[ i ];
+			if ( x >= rect.x && x < rect.x + rect.w && y >= rect.y && y < rect.y + rect.h ) {
+				return el;
+			}
+		}
+		return null;
+	};
+}
+
+/**
+ * Replicates the exact pointerdown handler my-wordpress wires onto
+ * each post / page tile (`buildEntityTile` in
+ * `src/my-wordpress/index.ts`). If this test passes, the pattern in
+ * production is sound.
+ */
+function attachMyWordpressEntityDrag(
+	tile: HTMLElement,
+	postId: number,
+	postTitle: string,
+	manager: DragManager,
+): void {
+	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		if ( e.button !== 0 ) {
+			return;
+		}
+		manager.start( {
+			payload: {
+				type: 'shortcut',
+				source: tile,
+				data: {
+					kind: 'post',
+					ref: String( postId ),
+					title: postTitle,
+					icon: 'dashicons-admin-post',
+				} satisfies ShortcutDragData,
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: e,
+		} );
+	} );
+}
+
+describe( 'My WordPress entity-tile drag (regression)', () => {
+	beforeEach( () => {
+		installHooksStub();
+		__resetRecoveryForTests();
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'super-threshold drag fires onDrop on the wallpaper with a shortcut payload', () => {
+		const manager = new DragManager();
+
+		// Tile sits inside the (faked) My WordPress window.
+		const myWordpressWindow = document.createElement( 'div' );
+		myWordpressWindow.classList.add( 'desktop-mode-window' );
+		const tile = document.createElement( 'div' );
+		tile.className = 'desktop-mode-my-wordpress__tile';
+		myWordpressWindow.appendChild( tile );
+		document.body.appendChild( myWordpressWindow );
+
+		// Wallpaper canvas is registered as a drop target.
+		const wallpaper = document.createElement( 'div' );
+		wallpaper.id = 'desktop-mode-area';
+		document.body.appendChild( wallpaper );
+
+		const onDrop = vi.fn();
+		manager.registerDropTarget( {
+			id: 'wallpaper',
+			element: wallpaper,
+			accept: ( payload ) => payload.type === 'shortcut',
+			onDrop,
+		} );
+
+		attachMyWordpressEntityDrag( tile, 42, 'Hello World', manager );
+
+		// At pointer (50, 50) the cursor is over the tile (inside the
+		// window). At (500, 500) it's over the wallpaper.
+		installElementFromPointStub( [
+			{ el: tile, rect: { x: 0, y: 0, w: 100, h: 100 } },
+			{ el: myWordpressWindow, rect: { x: 0, y: 0, w: 200, h: 200 } },
+			{ el: wallpaper, rect: { x: 400, y: 400, w: 800, h: 600 } },
+		] );
+
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 50, 50, tile ) );
+		// Cross threshold while still over the My WordPress window —
+		// the window claim boundary should reject (no onEnter/onDrop).
+		document.dispatchEvent( pointerEvent( 'pointermove', 80, 50 ) );
+		expect( onDrop ).not.toHaveBeenCalled();
+		// Move out over the wallpaper canvas.
+		document.dispatchEvent( pointerEvent( 'pointermove', 500, 500 ) );
+		// Release on wallpaper.
+		document.dispatchEvent( pointerEvent( 'pointerup', 500, 500 ) );
+
+		expect( onDrop ).toHaveBeenCalledTimes( 1 );
+		const [ session, where ] = onDrop.mock.calls[ 0 ];
+		expect( session.payload.type ).toBe( 'shortcut' );
+		expect( ( session.payload.data as ShortcutDragData ).kind ).toBe( 'post' );
+		expect( ( session.payload.data as ShortcutDragData ).ref ).toBe( '42' );
+		expect( where ).toEqual( { clientX: 500, clientY: 500 } );
+	} );
+
+	test( 'sub-threshold pointer gesture does not fire any drop target', () => {
+		const manager = new DragManager();
+		const tile = document.createElement( 'div' );
+		document.body.appendChild( tile );
+		const wallpaper = document.createElement( 'div' );
+		document.body.appendChild( wallpaper );
+		const onDrop = vi.fn();
+		manager.registerDropTarget( {
+			id: 'wallpaper',
+			element: wallpaper,
+			accept: () => true,
+			onDrop,
+		} );
+		attachMyWordpressEntityDrag( tile, 1, 'x', manager );
+		installElementFromPointStub( [ { el: wallpaper, rect: { x: 0, y: 0, w: 1000, h: 1000 } } ] );
+
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 50, 50, tile ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 51, 50 ) ); // sub-threshold
+		document.dispatchEvent( pointerEvent( 'pointerup', 51, 50 ) );
+
+		expect( onDrop ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Escape mid-drag aborts without firing onDrop', () => {
+		const manager = new DragManager();
+		const tile = document.createElement( 'div' );
+		const wallpaper = document.createElement( 'div' );
+		document.body.append( tile, wallpaper );
+		const onDrop = vi.fn();
+		manager.registerDropTarget( {
+			id: 'wallpaper',
+			element: wallpaper,
+			accept: () => true,
+			onDrop,
+		} );
+		attachMyWordpressEntityDrag( tile, 1, 'x', manager );
+		installElementFromPointStub( [ { el: wallpaper, rect: { x: 0, y: 0, w: 1000, h: 1000 } } ] );
+
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 50, 50, tile ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape' } ) );
+
+		expect( onDrop ).not.toHaveBeenCalled();
+		expect( manager.getActive() ).toBeNull();
+		expect( manager.debug().findOrphans() ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
- Implement tests for DropTargetRegistry to verify deepest-match behavior, idempotent re-registration, and hit-testing across various scenarios.
- Create unit tests for DragManager to cover drag state management, including sub-threshold gestures, drop target interactions, and recovery paths.
- Add regression tests for My WordPress entity-tile drag functionality to ensure proper payload handling and drop target acceptance.
- Introduce tests for drag recovery mechanisms, ensuring idempotency and correct state cleanup on escape, blur, and visibility changes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-130-ad9e7eb6d9d20e5def47b2c0035ca33f0eb6bce8.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->