### PR TITLE
test: add unit test to ensure bridge script skips core AJAX update buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,28 @@ The primitive is also exposed on the public API as `wp.desktop.createSharedStore
 
 `is_admin_bar_showing()` short-circuits to `true` in admin context — the `show_admin_bar` filter alone is NOT sufficient inside chromeless iframes. We pair it with `remove_action( 'in_admin_header', 'wp_admin_bar_render', 0 )` on `admin_init`, AND a CSS rule killing the reserved 32px. Do not remove either half.
 
+## Running PHPUnit — DO NOT spin up wp-env
+
+The standalone repo's `npm run test:php` (and `npm run env:start`) call `wp-env`,
+which binds port **8889**. **That port is already taken by the user's running
+Core-checkout dev environment** (`wordpress-*`, started via its
+own `docker-compose.yml`). Starting wp-env races the user's dev container; doing
+it without asking has burned the user before.
+
+**Run plugin PHPUnit inside the existing `wordpress-*` (develop/alcazaba/any matching name) container
+instead.** Core's WP test library is at `/var/www/tests/phpunit/`.
+Set `WP_TESTS_DIR` so the plugin's `bootstrap.php` finds it:
+
+```bash
+docker exec -e WP_TESTS_DIR=/var/www/tests/phpunit wordpress-alcazaba-php-1 \
+  sh -lc "cd /var/www/src/wp-content/plugins/desktop-mode && \
+  ./vendor/bin/phpunit --configuration tests/phpunit/phpunit.xml.dist \
+  [--filter='Tests_DesktopMode_Render']"
+```
+
+If the user has stopped their dev environment, ASK before starting wp-env — do
+not start it on your own.
+
 ## Process reminders to self
 
 - **Read before speculating.** When asked how a mechanism works (refresh flow, hook order, bridge protocol), grep the code first. Hand-waving gets caught.

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -863,6 +863,32 @@ function desktop_mode_chromeless_bridge_script() {
 		if ( link.hasAttribute( 'download' ) ) {
 			return;
 		}
+		/*
+		 * WordPress core's wp-admin/js/updates.js owns the click on these
+		 * AJAX-driven plugin/theme management buttons — it binds in bubble
+		 * phase and calls preventDefault to take over with an in-place
+		 * AJAX install / update / delete (with its own progress spinner
+		 * and inline success/failure UX). Our capture-phase handler would
+		 * preempt it: preventDefault here fires BEFORE updates.js's own,
+		 * the AJAX call never starts, and the postMessage below diverts
+		 * the user to the link's no-JS fallback URL (update.php?action=
+		 * install-plugin&...) opened as a freshly spawned desktop window.
+		 * That fallback technically completes the install server-side,
+		 * but it's a long blocking page-load with no in-place feedback —
+		 * which is what users perceive as "Install Now keeps loading and
+		 * opens a new tab". Skip these classes so updates.js's bubble
+		 * handler runs as core intended.
+		 */
+		if (
+			link.classList.contains( 'install-now' ) ||
+			link.classList.contains( 'update-link' ) ||
+			link.classList.contains( 'update-now' ) ||
+			link.classList.contains( 'delete-plugin' ) ||
+			link.classList.contains( 'delete-theme' ) ||
+			link.classList.contains( 'install-theme' )
+		) {
+			return;
+		}
 		var href = link.getAttribute( 'href' );
 		var kind = classifyLink( href, window.location.href );
 		if ( kind === 'admin' ) {

--- a/tests/phpunit/tests/desktopModeRender.php
+++ b/tests/phpunit/tests/desktopModeRender.php
@@ -309,6 +309,57 @@ class Tests_DesktopMode_Render extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The capture-phase click handler runs BEFORE wp-admin/js/updates.js's
+	 * own bubble-phase handler. If the bridge intercepts and preventDefaults
+	 * a click on `.install-now` / `.update-link` / `.delete-plugin` etc.,
+	 * core's AJAX install/update/delete flow never starts and the user is
+	 * diverted to the no-JS update.php fallback — opened as a freshly
+	 * spawned desktop window that takes seconds to load. Pin the skip list
+	 * so a future refactor doesn't silently bring the regression back.
+	 *
+	 * @covers ::desktop_mode_chromeless_bridge_script
+	 */
+	public function test_bridge_script_skips_wp_core_ajax_update_buttons() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['desktop_mode_chromeless'] = '1';
+
+		ob_start();
+		desktop_mode_chromeless_bridge_script();
+		$output = ob_get_clean();
+
+		// Each class WP core's wp-admin/js/updates.js binds an AJAX
+		// click handler to. The bridge must early-return on these so
+		// updates.js's bubble handler can run.
+		$ajax_classes = array(
+			'install-now',
+			'update-link',
+			'update-now',
+			'delete-plugin',
+			'delete-theme',
+			'install-theme',
+		);
+		foreach ( $ajax_classes as $class ) {
+			$this->assertStringContainsString(
+				"link.classList.contains( '{$class}' )",
+				$output,
+				"Bridge must skip clicks on .{$class} so wp-admin/js/updates.js can run."
+			);
+		}
+
+		// The skip block must sit BEFORE the `kind === 'admin'`
+		// branch — otherwise we'd preventDefault before the bail.
+		$skip_pos  = strpos( $output, "link.classList.contains( 'install-now' )" );
+		$admin_pos = strpos( $output, "kind === 'admin'" );
+		$this->assertNotFalse( $skip_pos );
+		$this->assertNotFalse( $admin_pos );
+		$this->assertLessThan(
+			$admin_pos,
+			$skip_pos,
+			'AJAX-class skip must run before the admin-link prevent-default block.'
+		);
+	}
+
+	/**
 	 * @covers ::desktop_mode_classic_link_interceptor
 	 */
 	public function test_classic_interceptor_emits_nothing_without_flag() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/desktop-mode/issues/134
https://github.com/user-attachments/assets/f6a1c8e6-eabc-4f55-b754-99aa87c35a34

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-136-38370e50186a7af38021b2170503f86821712f3f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->