### PR TITLE
Native Plugins window + `<wpd-card>`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,28 @@ The primitive is also exposed on the public API as `wp.desktop.createSharedStore
 
 `is_admin_bar_showing()` short-circuits to `true` in admin context — the `show_admin_bar` filter alone is NOT sufficient inside chromeless iframes. We pair it with `remove_action( 'in_admin_header', 'wp_admin_bar_render', 0 )` on `admin_init`, AND a CSS rule killing the reserved 32px. Do not remove either half.
 
+## Running PHPUnit — DO NOT spin up wp-env
+
+The standalone repo's `npm run test:php` (and `npm run env:start`) call `wp-env`,
+which binds port **8889**. **That port is already taken by the user's running
+Core-checkout dev environment** (`wordpress-*`, started via its
+own `docker-compose.yml`). Starting wp-env races the user's dev container; doing
+it without asking has burned the user before.
+
+**Run plugin PHPUnit inside the existing `wordpress-*` (develop/alcazaba/any matching name) container
+instead.** Core's WP test library is at `/var/www/tests/phpunit/`.
+Set `WP_TESTS_DIR` so the plugin's `bootstrap.php` finds it:
+
+```bash
+docker exec -e WP_TESTS_DIR=/var/www/tests/phpunit wordpress-alcazaba-php-1 \
+  sh -lc "cd /var/www/src/wp-content/plugins/desktop-mode && \
+  ./vendor/bin/phpunit --configuration tests/phpunit/phpunit.xml.dist \
+  [--filter='Tests_DesktopMode_Render']"
+```
+
+If the user has stopped their dev environment, ASK before starting wp-env — do
+not start it on your own.
+
 ## Process reminders to self
 
 - **Read before speculating.** When asked how a mechanism works (refresh flow, hook order, bridge protocol), grep the code first. Hand-waving gets caught.

--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -104,28 +104,18 @@
 }
 
 /* Pinned tiles ("My WordPress", Recycle Bin) anchor to a fixed slot
- * and DO NOT wire drag. The `not-allowed` cursor signals "this tile
- * is intentionally fixed" so the user understands the (lack of)
- * interaction instead of suspecting a bug. The `--bump` keyframe
- * fires on pointerdown for explicit feedback that the gesture
- * landed but the tile is anchored.
+ * and DO NOT wire drag — but they look + behave identically to any
+ * other tile until the user attempts a drag (which silently fails).
+ * No upfront visual cue: feedback now happens at the moment of the
+ * gesture, not before, per @since 0.9.0 design feedback.
  *
- * @since 0.18.0
+ * Default `cursor: pointer` from the base `.desktop-mode-file-tile`
+ * rule covers click-to-open. Touch interactions stay as
+ * `touch-action: auto` so the OS scroll gesture works on top of
+ * the tile.
  */
 .desktop-mode-file-tile--pinned {
-	cursor: not-allowed;
 	touch-action: auto;
-}
-
-.desktop-mode-file-tile--bump {
-	animation: desktop-mode-file-tile-bump 220ms ease-out;
-}
-
-@keyframes desktop-mode-file-tile-bump {
-	0%   { transform: translate( 0, 0 ); }
-	30%  { transform: translate( 0, -3px ) scale( 1.02 ); }
-	60%  { transform: translate( 0, 1px ) scale( 0.99 ); }
-	100% { transform: translate( 0, 0 ); }
 }
 
 /* Folder tile is the drop target during a cross-window shortcut

--- a/assets/css/plugins-window.css
+++ b/assets/css/plugins-window.css
@@ -1,0 +1,977 @@
+/**
+ * Native Plugins window — shell + tab styles.
+ *
+ * Bundle iterates fast; this stylesheet is `filemtime`-cache-busted
+ * via `wp_register_style`. Heavy view-specific styles (gallery
+ * cards, detail-flyout hero) ship here too so a single CSS handle
+ * covers the whole window.
+ */
+
+.desktop-mode-plugins {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
+	min-height: 0;
+	min-width: 0;
+	max-width: 100%;
+	/* Clip horizontal overflow at every level — `<wpd-flyout>` when
+	 * closed sits at `transform: translateX(110%)` and would
+	 * otherwise create a phantom scroll out to its off-screen
+	 * resting position. We need `overflow-x` AND `position:
+	 * relative` so the flyout's `position: absolute` containing
+	 * block resolves to THIS element (not a higher ancestor). */
+	overflow-x: hidden;
+	overflow-y: hidden;
+	position: relative;
+	box-sizing: border-box;
+}
+
+.desktop-mode-plugins__tabs {
+	border-block-end: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+	flex: 0 0 auto;
+}
+
+.desktop-mode-plugins__panel {
+	flex: 1 1 auto;
+	min-height: 0;
+	min-width: 0;
+	max-width: 100%;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	/* Belt + braces — never let a child stretch the panel past the
+	 * window width. Earlier the right-hand side of the window would
+	 * scroll into empty space because the wpd-table host was sized
+	 * by content rather than container. */
+	overflow: hidden;
+}
+
+/* Honour the `hidden` attribute — `<wpd-tabs>` toggles it on inactive
+ * panels, but our explicit `display: flex` above wins by specificity.
+ * Without this rule every panel renders concurrently in the first
+ * panel slot. */
+.desktop-mode-plugins__panel[ hidden ] {
+	display: none;
+}
+
+.desktop-mode-plugins__installed,
+.desktop-mode-plugins__browse {
+	flex: 1 1 auto;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+/* ─── Toolbar ───────────────────────────────────────────────────── */
+
+.desktop-mode-plugins__toolbar {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	border-block-end: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+	flex-wrap: wrap;
+}
+
+.desktop-mode-plugins__toolbar-left {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.desktop-mode-plugins__toolbar-left wpd-text-field {
+	flex: 1 1 240px;
+	min-width: 200px;
+	max-width: 360px;
+}
+
+.desktop-mode-plugins__toolbar-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.desktop-mode-plugins__toolbar-trailing {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.desktop-mode-plugins__bulk {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding-inline: 8px;
+}
+
+.desktop-mode-plugins__bulk-count {
+	font-size: 0.85em;
+	color: var( --wpd-fg-muted, #555 );
+}
+
+/* ─── Body / table ──────────────────────────────────────────────── */
+
+.desktop-mode-plugins__body {
+	flex: 1 1 auto;
+	min-height: 0;
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	/* Inset matching the Posts/Pages/Users windows so the table
+	 * doesn't kiss the window's left/right borders. */
+	padding: 8px 12px 12px;
+}
+
+.desktop-mode-plugins__body wpd-table {
+	flex: 1 1 auto;
+	min-height: 0;
+	min-width: 0;
+	max-width: 100%;
+	width: 100%;
+	box-sizing: border-box;
+	/* The `<wpd-table>` ships with its own scroll container, but it
+	 * needs a constrained height to know when to start scrolling.
+	 * Without `--wpd-table-max-height` set, sticky-header silently
+	 * disables itself and the table grows to its full intrinsic
+	 * height instead of scrolling inside the panel.
+	 *
+	 * NO `overflow` here — wpd-table's internal `.scroll` div
+	 * handles scrolling. An outer `overflow: auto` here was
+	 * causing a phantom horizontal scrollbar that revealed empty
+	 * space to the right of the table because the host was sized
+	 * by content (icon cell + actions cell) rather than container. */
+	--wpd-table-max-height: 100%;
+}
+
+.desktop-mode-plugins__empty {
+	text-align: center;
+	padding: 32px 16px;
+	color: var( --wpd-fg-muted, #666 );
+}
+
+.desktop-mode-plugins__empty .dashicons {
+	font-size: 32px;
+	width: 32px;
+	height: 32px;
+	display: inline-block;
+	margin-block-end: 8px;
+	opacity: 0.6;
+}
+
+/* ─── Cells ─────────────────────────────────────────────────────── */
+
+.desktop-mode-plugins__name-cell {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	min-width: 0;
+	padding-block: 4px;
+}
+
+.desktop-mode-plugins__name-icon {
+	flex: 0 0 40px;
+	width: 40px;
+	height: 40px;
+	max-width: 40px;
+	max-height: 40px;
+	border-radius: 8px;
+	overflow: hidden;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: var( --wpd-bg-muted, rgba( 0, 0, 0, 0.04 ) );
+}
+
+/* Hard-clamp the inner image too — wp.org SVG icons are unsized,
+ * which left the user agent stretching them to the document's full
+ * width when the parent ever became `auto`. */
+.desktop-mode-plugins__name-icon img,
+.desktop-mode-plugins__name-icon svg {
+	width: 100%;
+	height: 100%;
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
+	display: block;
+	transition: opacity 180ms ease;
+}
+
+.desktop-mode-plugins__name-icon-fallback {
+	font-size: 22px;
+	width: 22px;
+	height: 22px;
+	line-height: 22px;
+	color: var( --wpd-fg-muted, #888 );
+}
+
+.desktop-mode-plugins__name-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+/* Force the title + path to actually stack — `<strong>` and `<span>`
+ * are `display: inline` by default, and `display: flex` on the
+ * parent doesn't always force flex-item layout when the cell
+ * surrounding them comes from a third-party component (the user
+ * reported them rendering on the same line). */
+.desktop-mode-plugins__name-text > strong,
+.desktop-mode-plugins__name-text > span {
+	display: block;
+}
+
+.desktop-mode-plugins__name-text > strong {
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.desktop-mode-plugins__name-path {
+	font-size: 0.78em;
+	color: var( --wpd-fg-muted, #888 );
+	font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.desktop-mode-plugins__badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 10px 2px 8px;
+	border-radius: 999px;
+	font-size: 0.78em;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	text-transform: none;
+	line-height: 1.4;
+	white-space: nowrap;
+}
+
+/* Coloured dot prepended to the badge label — provides the
+ * status-at-a-glance signal without relying on text alone. */
+.desktop-mode-plugins__badge::before {
+	content: '';
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: currentColor;
+	flex: 0 0 auto;
+	display: inline-block;
+}
+
+.desktop-mode-plugins__badge.is-active {
+	background: rgba( 35, 165, 90, 0.14 );
+	color: rgb( 22, 110, 55 );
+}
+
+.desktop-mode-plugins__badge.is-inactive {
+	background: rgba( 120, 120, 120, 0.12 );
+	color: var( --wpd-fg-muted, #555 );
+}
+
+.desktop-mode-plugins__version-cell {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
+.desktop-mode-plugins__update-badge {
+	font-size: 0.78em;
+	background: rgba( 250, 175, 0, 0.18 );
+	color: rgb( 145, 95, 0 );
+	padding: 1px 7px;
+	border-radius: 999px;
+	font-weight: 600;
+}
+
+.desktop-mode-plugins__author-cell {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.desktop-mode-plugins__row-actions {
+	display: inline-flex;
+	gap: 8px;
+	align-items: center;
+	justify-content: flex-end;
+	flex-wrap: nowrap;
+}
+
+.desktop-mode-plugins__row-actions wpd-button {
+	flex: 0 0 auto;
+}
+
+/* ─── Browse — gallery ──────────────────────────────────────────── */
+
+.desktop-mode-plugins__gallery {
+	display: grid;
+	grid-template-columns: repeat( auto-fill, minmax( 280px, 1fr ) );
+	gap: 14px;
+	padding: 16px;
+	flex: 1 1 auto;
+	min-height: 0;
+	min-width: 0;
+	max-width: 100%;
+	/* Vertical scroll only — `auto-fill` with `1fr` already prevents
+	 * children from exceeding the container width, but we still
+	 * clamp `overflow-x` defensively so a misbehaving card can't
+	 * stretch the gallery. */
+	overflow-x: hidden;
+	overflow-y: auto;
+	align-content: start;
+	box-sizing: border-box;
+}
+
+.desktop-mode-plugins__gallery-sentinel {
+	height: 1px;
+}
+
+.desktop-mode-plugins__gallery-status {
+	padding: 12px 16px;
+	color: var( --wpd-fg-muted, #666 );
+	text-align: center;
+	margin: 0;
+}
+
+/* ─── Browse — card ─────────────────────────────────────────────── */
+
+/* The card chrome (padding, gap, border, radius, hover lift, focus
+ * ring, reduced-motion fallback) all comes from `<wpd-card>` —
+ * `:host([interactive])` handles the hover transform, the kit's
+ * `prefers-reduced-motion` rule kills the transition. We layer
+ * gallery-specific tweaks here; nothing duplicates the kit. */
+
+.desktop-mode-plugins__card.desktop-mode-plugins__card--skeleton {
+	gap: 8px;
+}
+
+.desktop-mode-plugins__card-header {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+}
+
+.desktop-mode-plugins__card-icon {
+	flex: 0 0 auto;
+	width: 56px;
+	height: 56px;
+	border-radius: 10px;
+	overflow: hidden;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: var( --wpd-bg-muted, rgba( 0, 0, 0, 0.04 ) );
+}
+
+.desktop-mode-plugins__card-icon img {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	opacity: 0;
+	transition: opacity 180ms ease;
+}
+
+.desktop-mode-plugins__card-icon img.is-loaded {
+	opacity: 1;
+}
+
+.desktop-mode-plugins__card-icon-fallback {
+	font-size: 28px;
+	width: 28px;
+	height: 28px;
+	color: var( --wpd-fg-muted, #888 );
+}
+
+.desktop-mode-plugins__card-titleblock {
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.desktop-mode-plugins__card-title {
+	margin: 0 0 2px 0;
+	font-size: 1rem;
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.desktop-mode-plugins__card-byline {
+	margin: 0;
+	color: var( --wpd-fg-muted, #777 );
+	font-size: 0.82rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.desktop-mode-plugins__card-desc {
+	margin: 0;
+	color: var( --wpd-fg, #333 );
+	font-size: 0.88rem;
+	line-height: 1.45;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.desktop-mode-plugins__card-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	margin-top: auto;
+}
+
+.desktop-mode-plugins__card-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	font-size: 0.78rem;
+	color: var( --wpd-fg-muted, #666 );
+}
+
+/* ─── Stars ─────────────────────────────────────────────────────── */
+
+.desktop-mode-plugins__stars {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.desktop-mode-plugins__star .dashicons {
+	font-size: 14px;
+	width: 14px;
+	height: 14px;
+	color: rgb( 245, 175, 0 );
+}
+
+.desktop-mode-plugins__star .dashicons-star-empty {
+	color: var( --wpd-fg-muted, rgba( 0, 0, 0, 0.25 ) );
+}
+
+.desktop-mode-plugins__stars-count {
+	margin-inline-start: 4px;
+	color: var( --wpd-fg-muted, #888 );
+	font-size: 0.78em;
+}
+
+.desktop-mode-plugins__card-installs {
+	font-size: 0.78em;
+	color: var( --wpd-fg-muted, #888 );
+}
+
+/* ─── Skeleton lines (gallery + flyout) ─────────────────────────── */
+
+.desktop-mode-plugins__skeleton {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 16px;
+}
+
+.desktop-mode-plugins__skeleton-line {
+	display: block;
+	height: 12px;
+	border-radius: 4px;
+	background: linear-gradient(
+		90deg,
+		rgba( 0, 0, 0, 0.06 ) 0%,
+		rgba( 0, 0, 0, 0.10 ) 50%,
+		rgba( 0, 0, 0, 0.06 ) 100%
+	);
+	background-size: 200% 100%;
+	animation: dm-plugins-shimmer 1.4s linear infinite;
+}
+
+@keyframes dm-plugins-shimmer {
+	from {
+		background-position: 100% 0;
+	}
+	to {
+		background-position: -100% 0;
+	}
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-plugins__skeleton-line {
+		animation: none;
+	}
+}
+
+/* ─── Flyout detail ─────────────────────────────────────────────── */
+
+[data-desktop-mode-plugins-flyout] {
+	width: min( 560px, calc( 100% - 28px ) );
+}
+
+.desktop-mode-plugins__flyout {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+.desktop-mode-plugins__flyout-hero {
+	position: relative;
+	padding: 16px 56px 14px 18px;
+	border-block-end: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+	flex: 0 0 auto;
+	overflow: hidden;
+	/* Mirror the flyout shell's outer corner radius (`<wpd-flyout>`
+	 * uses 14px) so a banner background-image stops at the rounded
+	 * top edge instead of bleeding past it. */
+	border-start-start-radius: 14px;
+	border-start-end-radius: 14px;
+}
+
+/* ─── Flyout close — circular glass button ──────────────────────── */
+
+.desktop-mode-plugins__flyout-close {
+	position: absolute;
+	inset-block-start: 12px;
+	inset-inline-end: 12px;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	border: 1px solid rgba( 0, 0, 0, 0.08 );
+	border-radius: 50%;
+	background: rgba( 255, 255, 255, 0.78 );
+	-webkit-backdrop-filter: blur( 12px ) saturate( 160% );
+	backdrop-filter: blur( 12px ) saturate( 160% );
+	box-shadow:
+		0 1px 4px rgba( 0, 0, 0, 0.10 ),
+		0 0 0 1px rgba( 255, 255, 255, 0.4 ) inset;
+	color: var( --wpd-fg, #333 );
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	z-index: 2;
+	transition:
+		transform 150ms ease,
+		background 150ms ease,
+		border-color 150ms ease,
+		box-shadow 150ms ease;
+}
+
+.desktop-mode-plugins__flyout-close:hover {
+	background: rgba( 255, 255, 255, 0.96 );
+	transform: scale( 1.06 );
+	border-color: rgba( 0, 0, 0, 0.16 );
+	box-shadow:
+		0 4px 10px rgba( 0, 0, 0, 0.14 ),
+		0 0 0 1px rgba( 255, 255, 255, 0.5 ) inset;
+}
+
+.desktop-mode-plugins__flyout-close:active {
+	transform: scale( 0.96 );
+}
+
+.desktop-mode-plugins__flyout-close:focus-visible {
+	outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+	outline-offset: 2px;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-plugins__flyout-close {
+		transition: none;
+	}
+	.desktop-mode-plugins__flyout-close:hover,
+	.desktop-mode-plugins__flyout-close:active {
+		transform: none;
+	}
+}
+
+.desktop-mode-plugins__flyout-banner {
+	position: absolute;
+	inset: 0;
+	background-size: cover;
+	background-position: center;
+	opacity: 0;
+	transition: opacity 220ms ease;
+	z-index: 0;
+}
+
+.desktop-mode-plugins__flyout-banner.has-banner {
+	opacity: 0.18;
+}
+
+.desktop-mode-plugins__flyout-hero-inner {
+	position: relative;
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	z-index: 1;
+}
+
+.desktop-mode-plugins__flyout-hero-icon {
+	width: 64px;
+	height: 64px;
+	border-radius: 12px;
+	overflow: hidden;
+	background: var( --wpd-bg-muted, rgba( 0, 0, 0, 0.04 ) );
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.desktop-mode-plugins__flyout-hero-icon img {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+.desktop-mode-plugins__flyout-hero-text {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.desktop-mode-plugins__flyout-hero-title {
+	margin: 0 0 4px;
+	font-size: 1.2rem;
+	font-weight: 600;
+}
+
+.desktop-mode-plugins__flyout-hero-byline {
+	margin: 0 0 6px;
+	color: var( --wpd-fg-muted, #666 );
+}
+
+.desktop-mode-plugins__flyout-meta-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px 16px;
+	font-size: 0.78rem;
+	color: var( --wpd-fg-muted, #666 );
+	margin-top: 6px;
+}
+
+.desktop-mode-plugins__flyout-tabs {
+	flex: 0 0 auto;
+	border-block-end: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+}
+
+.desktop-mode-plugins__flyout-body {
+	padding: 16px 18px;
+	flex: 1 1 auto;
+	overflow: auto;
+	min-height: 0;
+}
+
+.desktop-mode-plugins__flyout-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 12px 16px;
+	border-block-start: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+	flex: 0 0 auto;
+}
+
+.desktop-mode-plugins__flyout-footer-right {
+	display: inline-flex;
+	gap: 6px;
+}
+
+.desktop-mode-plugins__flyout-wporg {
+	font-size: 0.86rem;
+}
+
+.desktop-mode-plugins__flyout-error {
+	color: rgb( 184, 50, 50 );
+	padding: 16px;
+}
+
+/* ─── Histogram (Reviews tab) ───────────────────────────────────── */
+
+.desktop-mode-plugins__histogram {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-block-end: 16px;
+}
+
+.desktop-mode-plugins__histogram-row {
+	display: grid;
+	grid-template-columns: 32px 1fr 48px;
+	gap: 8px;
+	align-items: center;
+	font-size: 0.82rem;
+}
+
+.desktop-mode-plugins__histogram-track {
+	background: var( --wpd-bg-muted, rgba( 0, 0, 0, 0.06 ) );
+	border-radius: 999px;
+	height: 6px;
+	overflow: hidden;
+}
+
+.desktop-mode-plugins__histogram-fill {
+	display: block;
+	height: 100%;
+	background: rgb( 245, 175, 0 );
+	border-radius: 999px;
+	transition: width 220ms ease;
+}
+
+.desktop-mode-plugins__histogram-count {
+	color: var( --wpd-fg-muted, #777 );
+	text-align: end;
+}
+
+.desktop-mode-plugins__reviews-list {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.desktop-mode-plugins__review {
+	border: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+	border-radius: 10px;
+	padding: 12px 14px;
+	background: var( --wpd-card-bg, #fff );
+}
+
+.desktop-mode-plugins__review-head {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-block-end: 6px;
+	flex-wrap: wrap;
+}
+
+.desktop-mode-plugins__review-author {
+	font-weight: 600;
+}
+
+.desktop-mode-plugins__review-date {
+	margin-inline-start: auto;
+	font-size: 0.78em;
+	color: var( --wpd-fg-muted, #888 );
+}
+
+.desktop-mode-plugins__review-excerpt {
+	margin: 0;
+	font-size: 0.92em;
+	line-height: 1.5;
+	color: var( --wpd-fg, #333 );
+}
+
+.desktop-mode-plugins__review-link {
+	display: inline-block;
+	margin-block-start: 6px;
+	font-size: 0.82em;
+}
+
+.desktop-mode-plugins__reviews-loading,
+.desktop-mode-plugins__reviews-fallback {
+	color: var( --wpd-fg-muted, #888 );
+	font-size: 0.92em;
+}
+
+.desktop-mode-plugins__html {
+	font-size: 0.92rem;
+	line-height: 1.5;
+}
+
+.desktop-mode-plugins__html h3,
+.desktop-mode-plugins__html h4 {
+	margin-top: 1em;
+}
+
+.desktop-mode-plugins__screenshots {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.desktop-mode-plugins__screenshot img {
+	max-width: 100%;
+	border-radius: 8px;
+	border: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+}
+
+.desktop-mode-plugins__screenshot figcaption {
+	font-size: 0.84rem;
+	color: var( --wpd-fg-muted, #666 );
+	margin-top: 6px;
+}
+
+/* ─── Upload dialog ─────────────────────────────────────────────── */
+
+.desktop-mode-plugins__upload-overlay {
+	position: absolute;
+	inset: 0;
+	background: rgba( 0, 0, 0, 0.32 );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 20;
+	animation: dm-plugins-fade-in 180ms ease both;
+}
+
+.desktop-mode-plugins__upload-card {
+	width: min( 480px, calc( 100% - 32px ) );
+	background: var( --wpd-card-bg, #fff );
+	border-radius: 14px;
+	padding: 22px 22px 18px;
+	box-shadow: 0 16px 48px rgba( 0, 0, 0, 0.32 );
+	animation: dm-plugins-pop-in 220ms cubic-bezier( 0.22, 1, 0.36, 1 ) both;
+}
+
+@keyframes dm-plugins-fade-in {
+	from { opacity: 0; }
+	to   { opacity: 1; }
+}
+
+@keyframes dm-plugins-pop-in {
+	from { transform: scale( 0.96 ); opacity: 0; }
+	to   { transform: none;          opacity: 1; }
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-plugins__upload-overlay,
+	.desktop-mode-plugins__upload-card {
+		animation: none;
+	}
+}
+
+.desktop-mode-plugins__upload-heading {
+	margin: 0 0 4px;
+	font-size: 1.1rem;
+}
+
+.desktop-mode-plugins__upload-lede {
+	margin: 0 0 16px;
+	color: var( --wpd-fg-muted, #666 );
+	font-size: 0.9em;
+}
+
+.desktop-mode-plugins__upload-dropzone {
+	border: 2px dashed var( --wpd-border-strong, rgba( 0, 0, 0, 0.18 ) );
+	border-radius: 12px;
+	padding: 24px 16px;
+	text-align: center;
+	cursor: pointer;
+	transition: border-color 150ms ease, background 150ms ease;
+}
+
+.desktop-mode-plugins__upload-dropzone.is-hovered,
+.desktop-mode-plugins__upload-dropzone.has-file {
+	border-color: var( --wp-admin-theme-color, #2271b1 );
+	background: rgba( 34, 113, 177, 0.05 );
+}
+
+.desktop-mode-plugins__upload-icon {
+	font-size: 32px;
+	width: 32px;
+	height: 32px;
+	color: var( --wpd-fg-muted, #888 );
+	margin-block-end: 6px;
+}
+
+.desktop-mode-plugins__upload-hint {
+	margin: 0 0 4px;
+}
+
+.desktop-mode-plugins__upload-filename {
+	margin: 0;
+	font-size: 0.86em;
+	color: var( --wpd-fg, #333 );
+	font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+}
+
+.desktop-mode-plugins__upload-status {
+	margin: 12px 0 0;
+	font-size: 0.86em;
+}
+
+.desktop-mode-plugins__upload-status[ data-tone='error' ] {
+	color: rgb( 184, 50, 50 );
+}
+
+.desktop-mode-plugins__upload-status[ data-tone='success' ] {
+	color: rgb( 25, 120, 65 );
+}
+
+.desktop-mode-plugins__upload-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-block-start: 14px;
+}
+
+/* ─── Window-level .zip drop overlay ────────────────────────────── */
+
+.desktop-mode-plugins__window-drop {
+	position: absolute;
+	inset: 12px;
+	border: 2px dashed var( --wp-admin-theme-color, #2271b1 );
+	border-radius: 14px;
+	background: rgba( 34, 113, 177, 0.08 );
+	color: var( --wp-admin-theme-color, #2271b1 );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 1.05rem;
+	font-weight: 600;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 180ms ease;
+	z-index: 9;
+}
+
+.has-zip-dragover .desktop-mode-plugins__window-drop {
+	opacity: 1;
+}
+
+/* ─── Drag ghost ────────────────────────────────────────────────── */
+
+.desktop-mode-plugins__drag-ghost {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 14px;
+	background: var( --wpd-card-bg, #fff );
+	border-radius: 999px;
+	box-shadow: 0 6px 20px rgba( 0, 0, 0, 0.18 );
+	font-size: 0.92rem;
+	font-weight: 600;
+	max-width: 240px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.desktop-mode-plugins__drag-ghost img {
+	width: 24px;
+	height: 24px;
+	border-radius: 6px;
+}
+
+.desktop-mode-plugins__drag-ghost-fallback {
+	color: var( --wpd-fg-muted, #888 );
+	font-size: 22px;
+}
+
+[ data-plugins-card-drop-active ] {
+	outline: 2px dashed var( --wp-admin-theme-color, #2271b1 );
+	outline-offset: 2px;
+}

--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -73,6 +73,7 @@ require_once DESKTOP_MODE_DIR . 'includes/posts-window/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/pages-window/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/users-window/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/user-edit-window/bootstrap.php';
+require_once DESKTOP_MODE_DIR . 'includes/plugins-window/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/my-wordpress/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/content-graph/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/pwa.php';

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -44,6 +44,7 @@ defined( 'ABSPATH' ) || exit;
 - [Cross-window devtools — instrumentation primitives](./devtools-instrumentation.md)
 - [Extend the Recycle Bin](./recycle-bin.md)
 - [Native Posts window — default-on, remap registry, hooks](./native-posts.md)
+- [Native Plugins window — Browse / Install / Reviews / Drag-to-dock](./plugins-window-extras.md)
 - [Window activity & the modem dot — `wp.desktop.fetch`, `Window.trackActivity`](./window-activity.md)
 - [Pulse a window's icon — `Window.requestAttention()`](./window-request-attention.md)
 - [Render a keyed list without losing clicks — `renderKeyedList()`](./keyed-list.md)

--- a/docs/examples/plugins-window-extras.md
+++ b/docs/examples/plugins-window-extras.md
@@ -1,0 +1,178 @@
+# Plugins window — extras
+
+Recipes for plugin authors that want to extend the native Plugins window. Every PHP hook listed below is documented in [`docs/hooks-reference.md`](../hooks-reference.md#native-plugins-window-since-090); JS-side surface lives in [`docs/javascript-reference.md`](../javascript-reference.md#native-plugins-window-since-090).
+
+---
+
+## 1. Sponsor a custom Browse filter
+
+Add a "Curated" tab to the Browse segmented filter that calls `plugins_api( 'query_plugins' )` with a fixed wp.org tag.
+
+```php
+<?php
+add_filter(
+    'desktop_mode_plugins_window_browse_args',
+    static function ( array $api_args, array $raw ): array {
+        if ( 'curated' !== ( $raw['browse'] ?? '' ) ) {
+            return $api_args;
+        }
+        // Override the upstream call with our pinned tag.
+        unset( $api_args['browse'] );
+        $api_args['tag'] = 'gutenberg-block';
+        return $api_args;
+    },
+    10,
+    2
+);
+```
+
+JS side, push the new segment into the toolbar before the bundle paints:
+
+```js
+addFilter(
+    'desktop_mode.pluginsWindow.browseFilters',
+    'my-plugin/curated',
+    ( filters ) => [
+        ...filters,
+        { value: 'curated', label: __( 'Curated', 'my-plugin' ) },
+    ]
+);
+```
+
+> Until the JS filter registry lands, you can also subclass the segmented control or layer your own segment via the `desktop_mode_plugins_window_template_html` filter.
+
+---
+
+## 2. Override the wp.org icon URL for premium plugins
+
+Premium plugins aren't on the .org repo, so the default icon resolver returns `null` (the JS card paints a placeholder). If your plugin ships a known asset URL on your CDN, return it via the `desktop_mode_plugins_window_icon_url` filter:
+
+```php
+<?php
+add_filter(
+    'desktop_mode_plugins_window_icon_url',
+    static function ( $url, string $slug, array $row ) {
+        if ( 'my-premium-plugin' === $slug ) {
+            return 'https://cdn.example.com/icons/my-premium-plugin@2x.png';
+        }
+        return $url;
+    },
+    10,
+    3
+);
+```
+
+Returning `null` suppresses the icon entirely (forces the placeholder).
+
+---
+
+## 3. Swap the wp.org reviews scraper
+
+The default reviews handler hits `https://wordpress.org/plugins/{slug}/#reviews` and parses the HTML with `DOMDocument`. wp.org HTML can change, so the result is best-effort and falls back to a histogram-only view on parse failure.
+
+If you maintain a more robust parser (or have access to a private reviews API), short-circuit the default by returning an array of items:
+
+```php
+<?php
+add_filter(
+    'desktop_mode_plugins_window_review_parser',
+    static function ( $items, string $slug ) {
+        if ( null !== $items ) {
+            return $items; // Already overridden upstream.
+        }
+        $cached = get_transient( 'my_plugin_reviews_' . $slug );
+        if ( is_array( $cached ) ) {
+            return $cached;
+        }
+
+        // …call your own reviews API…
+        $rows = my_plugin_fetch_reviews( $slug );
+
+        return array_map(
+            static fn( $r ) => array(
+                'author'  => (string) $r->author,
+                'stars'   => (int) $r->stars,        // 1–5
+                'excerpt' => (string) $r->excerpt,
+                'date'    => (string) $r->date,      // free-form, e.g. "August 2026"
+                'url'     => (string) $r->permalink,
+            ),
+            $rows
+        );
+    },
+    10,
+    2
+);
+```
+
+Return `null` to fall through to the default DOMDocument parser.
+
+---
+
+## 4. React to a successful .zip upload
+
+Hook the `desktop_mode_plugins_window_installed` action to seed defaults when a new plugin lands via the upload route:
+
+```php
+<?php
+add_action(
+    'desktop_mode_plugins_window_installed',
+    static function ( string $plugin_file ): void {
+        // $plugin_file is e.g. "akismet/akismet.php"
+        if ( 'my-plugin/my-plugin.php' === $plugin_file ) {
+            update_option( 'my_plugin_first_install_at', time() );
+        }
+    }
+);
+```
+
+This action only fires for the `wp_ajax_desktop_mode_plugins_upload` route. Installs that go through Core's `wp_ajax_install_plugin` (the slug-based path) trigger Core's own `upgrader_process_complete` action — wire to that for cross-source coverage.
+
+---
+
+## 5. Land on the Browse tab when opening the window from your own UI
+
+The bundle reads an initial-tab hint from a shared store. Set it BEFORE `openById( 'desktop-mode-plugins' )`:
+
+```ts
+import { setPluginsWindowTab } from 'desktop-mode/plugins-window/tab-target';
+
+const myButton = document.querySelector( '#explore-plugins' )!;
+myButton.addEventListener( 'click', () => {
+    setPluginsWindowTab( 'browse' );
+    window.wp.desktop.openWindow( { id: 'desktop-mode-plugins' } );
+} );
+```
+
+Backed by `wp.desktop.createSharedStore` so multiple bundles read the same value. The hint is consumed (cleared) on first read by the render callback, so a subsequent open without an explicit hint defaults back to "installed".
+
+---
+
+## 6. Accept dragged plugin cards as a drop target on your own canvas
+
+Cards in the Browse gallery emit a `wporg-plugin` payload via the framework drag bridge. Register your own drop target so plugin authors can drag a card into your custom canvas:
+
+```ts
+window.wp.desktop.dragManager.registerDropTarget( {
+    id: 'my-plugin/canvas',
+    element: document.querySelector( '#my-canvas' )!,
+    accept: ( payload ) => payload.type === 'wporg-plugin',
+    onEnter: ( session ) => {
+        document.querySelector( '#my-canvas' )!
+            .classList.add( 'is-drop-target' );
+    },
+    onLeave: () => {
+        document.querySelector( '#my-canvas' )!
+            .classList.remove( 'is-drop-target' );
+    },
+    onDrop: ( session, ev ) => {
+        const { slug, name, iconUrl } = session.payload.data as {
+            slug:    string;
+            name:    string;
+            iconUrl: string | null;
+        };
+        // …attach the plugin to your canvas at (ev.clientX, ev.clientY)…
+    },
+} );
+```
+
+The framework's drag bridge handles the ghost element + hit-testing for you; the payload type is the contract — anything matching `'wporg-plugin'` is a card from this window.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1828,6 +1828,101 @@ Returning `false` from `enabled` (or `matches`) lets the click fall through. An 
 
 ---
 
+## Native Plugins window (since 0.9.0)
+
+A two-tab native window that replaces the chromeless `plugins.php` (Installed list) and `plugin-install.php` (Browse the .org repo) iframes. **Opt-OUT** — fresh installs land on it; users can flip it off via **OS Settings → Features → Use the native Plugins window** (persisted as `OsSettingsState.nativePluginsEnabled`, default `true`). `plugin-editor.php` is intentionally NOT claimed; that surface stays on the existing iframe.
+
+Architecture summary: read paths use Core REST (`/wp/v2/plugins`); admin-only paths (browse / info / reviews / .zip upload) live on `admin-ajax.php` (`wp_ajax_desktop_mode_plugins_*`) so we never need to `require_once ABSPATH . 'wp-admin/…'`. Install-by-slug delegates to Core's existing `wp_ajax_install_plugin` handler. Mutations are followed by `wp.desktop.refreshMenu()` so the dock repaints live.
+
+### `desktop_mode_plugins_window_user_can_register` — Stable *(filter, since 0.9.0)*
+
+Cap-only gate (`activate_plugins`) that decides whether the window is registered for this user. Decoupled from the opt-in toggle so flipping the OS-Settings flag mid-session doesn't require an F5.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_user_can_register', bool $can, int $user_id ): bool
+```
+
+### `desktop_mode_plugins_window_user_can_use` — Stable *(filter, since 0.9.0)*
+
+Combined cap-and-opt-in. Returns `true` when the user has `activate_plugins` AND has not flipped `nativePluginsEnabled` to `false`.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_user_can_use', bool $can, int $user_id ): bool
+```
+
+### `desktop_mode_plugins_window_args` — Experimental *(filter, since 0.9.0)*
+
+Last-mile mutation of the args passed to `desktop_mode_register_window( 'desktop-mode-plugins', … )`. Title, icon, default size, config blob — same shape as the Posts/Users window filter.
+
+### `desktop_mode_plugins_window_template_html` — Experimental *(filter, since 0.9.0)*
+
+Filters the rendered template HTML before `wp_kses` runs. Keep `data-desktop-mode-plugins-{root,tabs,installed-host,browse-host,flyout}` intact or rename them and update the matching constants in `src/plugins-window/index.ts`.
+
+### `desktop_mode_plugins_window_browse_args` — Stable *(filter, since 0.9.0)*
+
+Mutates the args passed to `plugins_api( 'query_plugins', … )` from the `wp_ajax_desktop_mode_plugins_browse` handler.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_browse_args', array $api_args, array $raw_params ): array
+```
+
+`$raw_params` carries the sanitized request: `browse`, `search`, `tag`, `page`, `per_page`. Use this to pin a corporate plugin allow-list, force a specific `tag`, or extend the `fields` payload.
+
+### `desktop_mode_plugins_window_browse_response` — Stable *(filter, since 0.9.0)*
+
+Mutates the wp.org browse response before it's cached + sent to the client. The payload is `{ plugins: array, info: array }`.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_browse_response', array $payload, array $api_args ): array
+```
+
+### `desktop_mode_plugins_window_info_response` — Stable *(filter, since 0.9.0)*
+
+Same pattern for `plugins_api( 'plugin_information', … )`. Lets a plugin amend the description sections, prepend a notice, or splice in an extra screenshot.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_info_response', array $payload, string $slug ): array
+```
+
+### `desktop_mode_plugins_window_review_parser` — Experimental *(filter, since 0.9.0)*
+
+Override the default DOMDocument-based parser for the wp.org reviews page. Return an array of `{ author, stars, excerpt, date, url }` items to short-circuit the default parser. Return `null` to fall through to the built-in DOM parsing.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_review_parser', array|null $items, string $slug ): array|null
+```
+
+The use case: wp.org HTML changes occasionally. A plugin author who maintains a more robust parser (or who has access to a private reviews API) can swap in their own implementation without forking the upstream.
+
+### `desktop_mode_plugins_window_icon_url` — Experimental *(filter, since 0.9.0)*
+
+Filter the resolved wp.org icon URL for an installed plugin row. Return `null` to suppress (forces the placeholder); return a different URL to override (useful for premium plugins shipping a known asset URL).
+
+```php
+apply_filters( 'desktop_mode_plugins_window_icon_url', string|null $url, string $slug, array $row ): string|null
+```
+
+### REST-field decorators on `/wp/v2/plugins` — Stable (since 0.9.0)
+
+Server-injected enrichment fields. The JS reads them on every list paint:
+
+| Field | Shape | What it carries |
+|---|---|---|
+| `desktop_mode_update_available` | `{ available: bool, new_version: string\|null }` | Pending wp.org update for this row, derived from `get_site_transient( 'update_plugins' )`. |
+| `desktop_mode_can_manage` | `{ activate, deactivate, delete: bool }` | Per-row capability flags so the JS doesn't re-derive caps. Server still re-validates every mutation. |
+| `desktop_mode_icon_url` | `string\|null` | Best-effort wp.org icon URL derived from the plugin's `textdomain`. Filterable via `desktop_mode_plugins_window_icon_url`. |
+| `desktop_mode_size_kb` | `int\|null` | Disk footprint of the plugin folder in kilobytes. Cached 6h. |
+
+### Actions — Stable (since 0.9.0)
+
+```php
+do_action( 'desktop_mode_plugins_window_installed', string $plugin_file );
+```
+
+Fires after the upload-AJAX handler installs a plugin from an uploaded .zip. `$plugin_file` is the resolved plugin file (e.g. `"akismet/akismet.php"`). Hook this to seed default settings for first-install plugins, send an audit-log entry, or chain a network-wide deploy.
+
+---
+
 ## My WordPress (since 0.8.0)
 
 A pinned virtual folder on the wallpaper that opens a native file-explorer window for browsing WordPress entities. Phase 1 ships Posts and Pages; the entity list is filterable so plugin authors can extend it without forking the bundle.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3698,6 +3698,57 @@ applyFilters( 'desktop-mode.files.resolve-opener', FileOpenerDef | null, type: s
 
 ---
 
+## Native Plugins window (since 0.9.0)
+
+The `desktop-mode-plugins` native window replaces the chromeless `plugins.php` and `plugin-install.php` iframes. Two tabs (Installed + Browse), a `<wpd-flyout>` detail panel, .zip upload (button + drop-on-window), and drag-card-to-dock pinning via the framework drag bridge.
+
+### URL routing
+
+Both `plugins.php` and `plugin-install.php` are claimed by `registerNativeUrlRemap`. The latter stashes a `tab: 'browse'` hint in the shared store `'desktop-mode/plugins-window/tab-target'` so the bundle's first paint activates the Browse tab. When `nativePluginsEnabled` is `false`, the click falls through to the classic iframe path.
+
+### Drag bridge integration
+
+Cards in the Browse gallery call `wp.desktop.dragManager.start({ … })` on pointer-down. The payload is:
+
+```ts
+{
+  type: 'wporg-plugin',
+  source: HTMLElement,
+  data: {
+    slug: string,
+    name: string,
+    iconUrl: string | null,
+    homepage: string,
+    authorName: string,
+    shortDescription: string,
+  },
+  ghost: { offsetX: number, offsetY: number, element: HTMLElement },
+}
+```
+
+The bundle pre-installs a drop target on the dock element that accepts this payload type and calls `wp.desktop.registerSystemTile()` to pin a transient tile pointing at the plugin's wp.org page. **Plugin authors can register their own drop targets** (e.g. on a custom canvas) that filter on `payload.type === 'wporg-plugin'` and react to a card drop with no further coordination.
+
+### Live-refresh
+
+After every install / activate / deactivate / delete the bundle calls `await wp.desktop.refreshMenu()`. That spawns a hidden chromeless iframe to capture the real-admin-context menu payload (handles plugins that gate `admin_menu` on `is_admin()`) — same primitive the chromeless bridge uses. Plugin authors that mutate plugin state from elsewhere should mirror this:
+
+```ts
+await myInstallFlow();
+await window.wp.desktop.refreshMenu();
+```
+
+### Shared state — initial tab hint
+
+```ts
+import { setPluginsWindowTab } from 'desktop-mode/plugins-window/tab-target';
+
+setPluginsWindowTab( 'browse' ); // call BEFORE openById( 'desktop-mode-plugins' )
+```
+
+Backed by `wp.desktop.createSharedStore( 'desktop-mode/plugins-window/tab-target', … )` so multiple bundles see the same value.
+
+---
+
 ## See also
 
 - [Hooks Reference](./hooks-reference.md) — the PHP side of the API.

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -107,6 +107,16 @@ function desktop_mode_register_assets() {
 		file_exists( $posts_window_css ) ? (string) filemtime( $posts_window_css ) : $version
 	);
 
+	// Native Plugins window CSS — same `filemtime`-cache-bust posture
+	// as the Posts/Recycle Bin styles.
+	$plugins_window_css = DESKTOP_MODE_DIR . 'assets/css/plugins-window.css';
+	wp_register_style(
+		'desktop-mode-plugins-window',
+		DESKTOP_MODE_URL . 'assets/css/plugins-window.css',
+		array( 'desktop-mode-variables', 'dashicons' ),
+		file_exists( $plugins_window_css ) ? (string) filemtime( $plugins_window_css ) : $version
+	);
+
 	// Files-on-the-Desktop tile + layer styles. `filemtime` for the
 	// same reason as the recycle-bin / posts-window CSS: this file
 	// iterates faster than the plugin version, and a stale cache
@@ -194,6 +204,25 @@ function desktop_mode_register_assets() {
 	);
 	wp_set_script_translations(
 		'desktop-mode-posts-window',
+		'desktop-mode',
+		DESKTOP_MODE_DIR . 'languages'
+	);
+
+	// `desktop-mode-plugins-window` — small bundle for the native
+	// Plugins window. Lazy-loaded by the native-window sync the first
+	// time the window opens (via the dock-click swap when the user
+	// opts in); registers a render callback on
+	// `window.desktopModeNativeWindows['desktop-mode-plugins']`.
+	$plugins_window_js = DESKTOP_MODE_DIR . 'assets/js/plugins-window' . $suffix . '.js';
+	wp_register_script(
+		'desktop-mode-plugins-window',
+		DESKTOP_MODE_URL . 'assets/js/plugins-window' . $suffix . '.js',
+		array( 'wp-i18n' ),
+		file_exists( $plugins_window_js ) ? (string) filemtime( $plugins_window_js ) : $version,
+		true
+	);
+	wp_set_script_translations(
+		'desktop-mode-plugins-window',
 		'desktop-mode',
 		DESKTOP_MODE_DIR . 'languages'
 	);

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -99,6 +99,12 @@ function desktop_mode_default_os_settings() {
 		// the server-side cap gate (`list_users`) means the toggle
 		// only matters for users who could see the Users tile anyway.
 		'nativeUsersEnabled'       => true,
+		// Per-user opt-OUT for the native Plugins window. Defaults ON;
+		// the server-side cap gate (`activate_plugins`) means the
+		// toggle only matters for users who could see the Plugins
+		// tile anyway. When `false`, the dock click falls back to the
+		// classic `plugins.php` chromeless iframe path.
+		'nativePluginsEnabled'     => true,
 	);
 }
 
@@ -323,6 +329,10 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		? (bool) $raw['nativeUsersEnabled']
 		: $defaults['nativeUsersEnabled'];
 
+	$native_plugins_enabled = isset( $raw['nativePluginsEnabled'] )
+		? (bool) $raw['nativePluginsEnabled']
+		: $defaults['nativePluginsEnabled'];
+
 	return array(
 		'wallpaper'                => $wallpaper,
 		'accent'                   => $accent,
@@ -337,6 +347,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'nativePostsHiddenColumns' => $native_posts_hidden_columns,
 		'nativePagesEnabled'       => $native_pages_enabled,
 		'nativeUsersEnabled'       => $native_users_enabled,
+		'nativePluginsEnabled'     => $native_plugins_enabled,
 	);
 }
 

--- a/includes/plugins-window/ajax.php
+++ b/includes/plugins-window/ajax.php
@@ -1,0 +1,742 @@
+<?php
+/**
+ * Desktop Mode — Native Plugins Window: admin-ajax actions.
+ *
+ * Anything that needs an admin-only class lives here, NOT on REST.
+ * Reason: `admin-ajax.php` itself ships from `wp-admin/`, so by the
+ * time any `wp_ajax_*` callback fires, `wp-admin/includes/{plugin,
+ * plugin-install,file,misc,class-wp-upgrader,class-wp-ajax-upgrader-skin}.php`
+ * are already on the include path. Calling those classes from a REST
+ * route would force a `require_once ABSPATH . 'wp-admin/…'` line —
+ * Plugin Check rejects that pattern.
+ *
+ * Action map (every callback verifies a `desktop-mode-plugins` nonce
+ * AND a per-action capability):
+ *
+ *   wp_ajax_desktop_mode_plugins_browse   — `plugins_api( 'query_plugins' )`
+ *   wp_ajax_desktop_mode_plugins_info     — `plugins_api( 'plugin_information' )`
+ *   wp_ajax_desktop_mode_plugins_reviews  — wp.org reviews scrape (DOMDocument)
+ *   wp_ajax_desktop_mode_plugins_upload   — `Plugin_Upgrader::install()` from $_FILES
+ *
+ * Install-by-slug is handled by Core's existing `wp_ajax_install_plugin`
+ * — the JS calls it directly with the standard `'updates'` nonce. We
+ * never reimplement it.
+ *
+ * Activate / deactivate / delete go through Core REST
+ * (`PUT/DELETE /wp/v2/plugins/{plugin}`), which lives in
+ * `wp-includes/`. No custom handler needed there.
+ *
+ * @package WPDesktopMode
+ * @since   0.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared nonce check + capability gate for every action below.
+ *
+ * Uses `check_ajax_referer( …, …, false )` so a missing/expired
+ * nonce surfaces as a clean JSON error rather than a `wp_die()` —
+ * the JS wraps every call in a `wp.desktop.fetch` and expects JSON.
+ *
+ * @since 0.9.0
+ *
+ * @param string $cap Capability the requester must hold.
+ * @return true|WP_Error True on pass, WP_Error on rejection.
+ */
+function desktop_mode_plugins_window_ajax_guard( $cap ) {
+	$nonce_ok = check_ajax_referer( 'desktop-mode-plugins', '_ajax_nonce', false );
+	if ( ! $nonce_ok ) {
+		return new WP_Error(
+			'desktop_mode_plugins_bad_nonce',
+			__( 'Security check failed. Refresh the window and try again.', 'desktop-mode' ),
+			array( 'status' => 403 )
+		);
+	}
+	if ( ! current_user_can( $cap ) ) {
+		return new WP_Error(
+			'desktop_mode_plugins_forbidden',
+			__( 'You are not allowed to do that.', 'desktop-mode' ),
+			array( 'status' => 403 )
+		);
+	}
+	return true;
+}
+
+/**
+ * Send a `WP_Error` as a JSON response, then exit.
+ *
+ * @since 0.9.0
+ *
+ * @param WP_Error $error
+ * @return void
+ */
+function desktop_mode_plugins_window_ajax_error( WP_Error $error ) {
+	$status = 500;
+	$data   = $error->get_error_data();
+	if ( is_array( $data ) && isset( $data['status'] ) ) {
+		$status = (int) $data['status'];
+	}
+	wp_send_json_error(
+		array(
+			'code'    => $error->get_error_code(),
+			'message' => $error->get_error_message(),
+		),
+		$status
+	);
+}
+
+/**
+ * `wp_ajax_desktop_mode_plugins_browse` — proxy to
+ * `plugins_api( 'query_plugins', … )` with a 10-minute transient
+ * cache keyed by the args.
+ *
+ * Body params:
+ *   - browse    string (featured|popular|recommended|favorites|new|beta), default "featured"
+ *   - search    string, optional
+ *   - tag       string, optional
+ *   - page      int,    default 1
+ *   - per_page  int,    default 24, capped at 60
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_ajax_browse() {
+	$guard = desktop_mode_plugins_window_ajax_guard( 'install_plugins' );
+	if ( is_wp_error( $guard ) ) {
+		desktop_mode_plugins_window_ajax_error( $guard );
+		return; // unreachable; clarity for static analyzers.
+	}
+
+	// `plugins_api()` lives in `wp-admin/includes/plugin-install.php`,
+	// which `admin-ajax.php` does NOT auto-load. Same idiom Core's
+	// own `wp_ajax_install_plugin` uses (see
+	// `wp-admin/includes/ajax-actions.php` ~L4483). Plugin Check
+	// accepts this — the rule against `require_once ABSPATH .
+	// 'wp-admin/…'` only applies to non-admin contexts (REST
+	// callbacks, plugin bootstrap), and `wp_ajax_*` hooks fire
+	// inside admin-ajax which is itself an admin file.
+	if ( ! function_exists( 'plugins_api' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+	}
+
+	$browse_raw = isset( $_POST['browse'] ) ? sanitize_key( wp_unslash( (string) $_POST['browse'] ) ) : 'featured';
+	$allowed    = array( 'featured', 'popular', 'recommended', 'favorites', 'new', 'beta', 'updated' );
+	if ( ! in_array( $browse_raw, $allowed, true ) ) {
+		$browse_raw = 'featured';
+	}
+
+	$search   = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['search'] ) ) : '';
+	$tag      = isset( $_POST['tag'] ) ? sanitize_key( wp_unslash( (string) $_POST['tag'] ) ) : '';
+	$page     = isset( $_POST['page'] ) ? max( 1, (int) $_POST['page'] ) : 1;
+	$per_page = isset( $_POST['per_page'] ) ? max( 1, min( 60, (int) $_POST['per_page'] ) ) : 24;
+
+	$api_args = array(
+		'page'     => $page,
+		'per_page' => $per_page,
+		// Lightweight field set — `plugin_information` covers the
+		// detail-flyout case via a separate call.
+		'fields'   => array(
+			'icons'             => true,
+			'banners'           => true,
+			'short_description' => true,
+			'description'       => false,
+			'sections'          => false,
+			'screenshots'       => false,
+			'rating'            => true,
+			'ratings'           => false,
+			'num_ratings'       => true,
+			'active_installs'   => true,
+			'last_updated'      => true,
+			'tested'            => true,
+			'requires'          => true,
+			'requires_php'      => true,
+			'homepage'          => true,
+			'compatibility'     => false,
+			'group'             => false,
+			'contributors'      => false,
+			'donate_link'       => false,
+		),
+	);
+
+	if ( '' !== $search ) {
+		$api_args['search'] = $search;
+	} elseif ( '' !== $tag ) {
+		$api_args['tag'] = $tag;
+	} else {
+		$api_args['browse'] = $browse_raw;
+	}
+
+	/**
+	 * Filter the args passed to `plugins_api( 'query_plugins', … )`.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array $api_args   Args passed to plugins_api.
+	 * @param array $raw_params Sanitized request params.
+	 */
+	$api_args = (array) apply_filters(
+		'desktop_mode_plugins_window_browse_args',
+		$api_args,
+		array(
+			'browse'   => $browse_raw,
+			'search'   => $search,
+			'tag'      => $tag,
+			'page'     => $page,
+			'per_page' => $per_page,
+		)
+	);
+
+	$cache_key = 'dm_pwbrowse_' . md5( wp_json_encode( $api_args ) );
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached && is_array( $cached ) ) {
+		wp_send_json_success( $cached );
+		return;
+	}
+
+	$result = plugins_api( 'query_plugins', $api_args );
+	if ( is_wp_error( $result ) ) {
+		desktop_mode_plugins_window_ajax_error( $result );
+		return;
+	}
+
+	// `plugins_api` returns an object with `plugins` + `info` props.
+	$payload = array(
+		'plugins' => isset( $result->plugins ) ? array_values( (array) $result->plugins ) : array(),
+		'info'    => isset( $result->info ) ? (array) $result->info : array(),
+	);
+
+	/**
+	 * Filter the browse response before it's cached + sent.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array $payload  `{ plugins, info }`.
+	 * @param array $api_args Args used.
+	 */
+	$payload = (array) apply_filters(
+		'desktop_mode_plugins_window_browse_response',
+		$payload,
+		$api_args
+	);
+
+	set_transient( $cache_key, $payload, 10 * MINUTE_IN_SECONDS );
+	wp_send_json_success( $payload );
+}
+add_action( 'wp_ajax_desktop_mode_plugins_browse', 'desktop_mode_plugins_window_ajax_browse' );
+
+/**
+ * `wp_ajax_desktop_mode_plugins_info` — proxy to
+ * `plugins_api( 'plugin_information', { slug, fields: { … } } )`
+ * with a 1-hour transient cache per slug.
+ *
+ * Body params:
+ *   - slug  string, required
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_ajax_info() {
+	$guard = desktop_mode_plugins_window_ajax_guard( 'install_plugins' );
+	if ( is_wp_error( $guard ) ) {
+		desktop_mode_plugins_window_ajax_error( $guard );
+		return;
+	}
+
+	// See note in the browse handler — `plugins_api()` is admin-only;
+	// admin-ajax does not auto-load it. Mirrors Core's own
+	// `wp_ajax_install_plugin` idiom.
+	if ( ! function_exists( 'plugins_api' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+	}
+
+	$slug = isset( $_POST['slug'] ) ? sanitize_key( wp_unslash( (string) $_POST['slug'] ) ) : '';
+	if ( '' === $slug ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_missing_slug',
+				__( 'Missing plugin slug.', 'desktop-mode' ),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	$cache_key = 'dm_pwinfo_' . md5( $slug );
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached && is_array( $cached ) ) {
+		wp_send_json_success( $cached );
+		return;
+	}
+
+	$api_args = array(
+		'slug'   => $slug,
+		'fields' => array(
+			'sections'          => true,
+			'screenshots'       => true,
+			'ratings'           => true,
+			'banners'           => true,
+			'icons'             => true,
+			'contributors'      => true,
+			'last_updated'      => true,
+			'requires'          => true,
+			'requires_php'      => true,
+			'tested'            => true,
+			'homepage'          => true,
+			'short_description' => true,
+			'donate_link'       => true,
+			'reviews'           => false, // We use our own scraper for the Reviews tab.
+		),
+	);
+
+	$result = plugins_api( 'plugin_information', $api_args );
+	if ( is_wp_error( $result ) ) {
+		desktop_mode_plugins_window_ajax_error( $result );
+		return;
+	}
+
+	$payload = (array) $result;
+
+	/**
+	 * Filter the plugin-information response before it's cached + sent.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array  $payload Result, cast to array.
+	 * @param string $slug    Plugin slug.
+	 */
+	$payload = (array) apply_filters(
+		'desktop_mode_plugins_window_info_response',
+		$payload,
+		$slug
+	);
+
+	set_transient( $cache_key, $payload, HOUR_IN_SECONDS );
+	wp_send_json_success( $payload );
+}
+add_action( 'wp_ajax_desktop_mode_plugins_info', 'desktop_mode_plugins_window_ajax_info' );
+
+/**
+ * `wp_ajax_desktop_mode_plugins_reviews` — best-effort scrape of the
+ * top reviews from a plugin's wp.org page.
+ *
+ * Body params:
+ *   - slug  string, required
+ *
+ * Returns either `{ items: [...], parsed: true }` or
+ * `{ items: [], parsed: false, reason: '<code>' }`. Caller is
+ * expected to fall back to the histogram-only view on `parsed: false`.
+ * Cache success 1h, failure 15m so wp.org can recover quickly.
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_ajax_reviews() {
+	$guard = desktop_mode_plugins_window_ajax_guard( 'install_plugins' );
+	if ( is_wp_error( $guard ) ) {
+		desktop_mode_plugins_window_ajax_error( $guard );
+		return;
+	}
+
+	$slug = isset( $_POST['slug'] ) ? sanitize_key( wp_unslash( (string) $_POST['slug'] ) ) : '';
+	if ( '' === $slug ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_missing_slug',
+				__( 'Missing plugin slug.', 'desktop-mode' ),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	$cache_key = 'dm_pwreviews_' . md5( $slug );
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached && is_array( $cached ) ) {
+		wp_send_json_success( $cached );
+		return;
+	}
+
+	/**
+	 * Filter to swap out the default DOMDocument-based review parser.
+	 *
+	 * Return an array of items to short-circuit; return `null` to
+	 * fall through to the default parser. Items must each be an
+	 * associative array with `author`, `stars` (int 1–5), `excerpt`,
+	 * `date`, and (optional) `url` keys.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array|null $items Override list, or null for default behaviour.
+	 * @param string     $slug  Plugin slug.
+	 */
+	$override = apply_filters( 'desktop_mode_plugins_window_review_parser', null, $slug );
+	if ( is_array( $override ) ) {
+		$payload = array(
+			'items'  => array_values( $override ),
+			'parsed' => true,
+		);
+		set_transient( $cache_key, $payload, HOUR_IN_SECONDS );
+		wp_send_json_success( $payload );
+		return;
+	}
+
+	$url      = 'https://wordpress.org/plugins/' . $slug . '/#reviews';
+	$response = wp_remote_get(
+		$url,
+		array(
+			'timeout'   => 5,
+			'sslverify' => true,
+			'headers'   => array(
+				'Accept-Language' => get_locale(),
+			),
+		)
+	);
+
+	if ( is_wp_error( $response ) ) {
+		$payload = array(
+			'items'  => array(),
+			'parsed' => false,
+			'reason' => 'fetch_failed',
+		);
+		set_transient( $cache_key, $payload, 15 * MINUTE_IN_SECONDS );
+		wp_send_json_success( $payload );
+		return;
+	}
+
+	$status = (int) wp_remote_retrieve_response_code( $response );
+	if ( $status < 200 || $status >= 300 ) {
+		$payload = array(
+			'items'  => array(),
+			'parsed' => false,
+			'reason' => 'http_' . $status,
+		);
+		set_transient( $cache_key, $payload, 15 * MINUTE_IN_SECONDS );
+		wp_send_json_success( $payload );
+		return;
+	}
+
+	$body = (string) wp_remote_retrieve_body( $response );
+	if ( '' === $body ) {
+		$payload = array(
+			'items'  => array(),
+			'parsed' => false,
+			'reason' => 'empty_body',
+		);
+		set_transient( $cache_key, $payload, 15 * MINUTE_IN_SECONDS );
+		wp_send_json_success( $payload );
+		return;
+	}
+
+	$items = desktop_mode_plugins_window_parse_reviews_html( $body );
+	if ( null === $items ) {
+		$payload = array(
+			'items'  => array(),
+			'parsed' => false,
+			'reason' => 'parse_failed',
+		);
+		set_transient( $cache_key, $payload, 15 * MINUTE_IN_SECONDS );
+		wp_send_json_success( $payload );
+		return;
+	}
+
+	$payload = array(
+		'items'  => $items,
+		'parsed' => true,
+	);
+	set_transient( $cache_key, $payload, HOUR_IN_SECONDS );
+	wp_send_json_success( $payload );
+}
+add_action( 'wp_ajax_desktop_mode_plugins_reviews', 'desktop_mode_plugins_window_ajax_reviews' );
+
+/**
+ * Default DOMDocument-based parser for the wp.org plugin reviews
+ * page. Returns an array of `{ author, stars, excerpt, date, url }`
+ * on success, or `null` when parsing fails.
+ *
+ * The wp.org review HTML may change without notice — wrap every
+ * navigation in `try`/`catch` and bail to `null` on any failure so
+ * the JS can fall back to the histogram-only view.
+ *
+ * @since 0.9.0
+ *
+ * @param string $html
+ * @return array<int,array<string,mixed>>|null
+ */
+function desktop_mode_plugins_window_parse_reviews_html( $html ) {
+	if ( ! class_exists( 'DOMDocument' ) ) {
+		return null;
+	}
+
+	try {
+		$prev = libxml_use_internal_errors( true );
+		$doc  = new DOMDocument();
+		// Force UTF-8 — wp.org output is UTF-8 but loadHTML defaults
+		// to ISO-8859-1.
+		$doc->loadHTML(
+			'<?xml encoding="UTF-8">' . $html,
+			LIBXML_NOERROR | LIBXML_NOWARNING
+		);
+		libxml_clear_errors();
+		libxml_use_internal_errors( $prev );
+
+		$xpath = new DOMXPath( $doc );
+
+		// wp.org review markup at the time of writing wraps each
+		// review in `<div class="review">` containing `<h4>`-like
+		// title, `<div class="reviewer">` author block, `<p>` body,
+		// star rating spans, and a permalink. We grab the first 5.
+		$reviews = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " review ")]' );
+		if ( ! $reviews instanceof DOMNodeList || 0 === $reviews->length ) {
+			return null;
+		}
+
+		$out   = array();
+		$count = 0;
+		foreach ( $reviews as $review ) {
+			if ( $count >= 5 ) {
+				break;
+			}
+			if ( ! $review instanceof DOMNode ) {
+				continue;
+			}
+
+			$author = '';
+			$author_nodes = $xpath->query(
+				'.//*[contains(concat(" ", normalize-space(@class), " "), " reviewer-name ")]',
+				$review
+			);
+			if ( $author_nodes instanceof DOMNodeList && $author_nodes->length > 0 ) {
+				$author = trim( (string) $author_nodes->item( 0 )->textContent );
+			}
+
+			$excerpt = '';
+			$excerpt_nodes = $xpath->query( './/p', $review );
+			if ( $excerpt_nodes instanceof DOMNodeList && $excerpt_nodes->length > 0 ) {
+				$excerpt = trim( (string) $excerpt_nodes->item( 0 )->textContent );
+			}
+			if ( '' !== $excerpt && function_exists( 'mb_strimwidth' ) ) {
+				$excerpt = mb_strimwidth( $excerpt, 0, 320, '…' );
+			}
+
+			$date = '';
+			$date_nodes = $xpath->query(
+				'.//*[contains(concat(" ", normalize-space(@class), " "), " review-date ")]',
+				$review
+			);
+			if ( $date_nodes instanceof DOMNodeList && $date_nodes->length > 0 ) {
+				$date = trim( (string) $date_nodes->item( 0 )->textContent );
+			}
+
+			$stars = 0;
+			$rating_nodes = $xpath->query(
+				'.//*[contains(concat(" ", normalize-space(@class), " "), " wporg-ratings ") or contains(concat(" ", normalize-space(@class), " "), " star-rating ")]',
+				$review
+			);
+			if ( $rating_nodes instanceof DOMNodeList && $rating_nodes->length > 0 ) {
+				$rating_text = (string) $rating_nodes->item( 0 )->textContent;
+				if ( preg_match( '/(\d+(?:\.\d+)?)\s*\/\s*5/', $rating_text, $m ) ) {
+					$stars = (int) round( (float) $m[1] );
+				} elseif ( preg_match( '/(\d+)\s*star/i', $rating_text, $m ) ) {
+					$stars = (int) $m[1];
+				} else {
+					// Fall back to counting filled-star elements.
+					$filled = $xpath->query(
+						'.//*[contains(concat(" ", normalize-space(@class), " "), " star ") and contains(concat(" ", normalize-space(@class), " "), " filled ")]',
+						$rating_nodes->item( 0 )
+					);
+					if ( $filled instanceof DOMNodeList ) {
+						$stars = (int) $filled->length;
+					}
+				}
+			}
+			$stars = max( 0, min( 5, $stars ) );
+
+			$url = '';
+			$link_nodes = $xpath->query( './/a[contains(@href, "/topic/")]', $review );
+			if ( $link_nodes instanceof DOMNodeList && $link_nodes->length > 0 ) {
+				$href = $link_nodes->item( 0 );
+				if ( $href instanceof DOMElement ) {
+					$url = (string) $href->getAttribute( 'href' );
+				}
+			}
+
+			if ( '' === $author && '' === $excerpt ) {
+				continue;
+			}
+
+			$out[] = array(
+				'author'  => $author,
+				'stars'   => $stars,
+				'excerpt' => $excerpt,
+				'date'    => $date,
+				'url'     => $url,
+			);
+			$count++;
+		}
+
+		return $out;
+	} catch ( Throwable $e ) { // phpcs:ignore PHPCompatibility.Classes.NewClasses.throwableFound
+		// Throwable covers both Errors and Exceptions on PHP 7+. Any
+		// failure (e.g. malformed HTML, libxml gone) bails to null
+		// so the caller serves the histogram-only fallback.
+		return null;
+	}
+}
+
+/**
+ * `wp_ajax_desktop_mode_plugins_upload` — install a plugin from a
+ * .zip uploaded as multipart/form-data under the `pluginzip` field.
+ *
+ * Mirrors the classic `update.php?action=upload-plugin` flow but
+ * returns JSON. By the time this callback fires, the
+ * `Plugin_Upgrader`, `WP_Ajax_Upgrader_Skin`, and `wp_handle_upload`
+ * symbols are already loaded (admin-ajax loads them).
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_ajax_upload() {
+	$guard = desktop_mode_plugins_window_ajax_guard( 'upload_plugins' );
+	if ( is_wp_error( $guard ) ) {
+		desktop_mode_plugins_window_ajax_error( $guard );
+		return;
+	}
+
+	if ( empty( $_FILES['pluginzip'] ) || ! is_array( $_FILES['pluginzip'] ) ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_missing_file',
+				__( 'No file received. Pick a .zip and try again.', 'desktop-mode' ),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	$file = $_FILES['pluginzip']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read raw, sanitized below.
+
+	if ( ! isset( $file['name'] ) || ! isset( $file['tmp_name'] ) || ! isset( $file['error'] ) ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_invalid_file',
+				__( 'Upload payload is malformed.', 'desktop-mode' ),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	if ( UPLOAD_ERR_OK !== (int) $file['error'] ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_upload_error',
+				sprintf(
+					/* translators: %d: PHP UPLOAD_ERR_* code. */
+					__( 'Upload failed (error %d). Try again.', 'desktop-mode' ),
+					(int) $file['error']
+				),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	$name = sanitize_file_name( (string) $file['name'] );
+	if ( '' === $name || '.zip' !== strtolower( substr( $name, -4 ) ) ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_not_zip',
+				__( 'Plugin uploads must be a .zip file.', 'desktop-mode' ),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	$tmp_name = (string) $file['tmp_name'];
+	if ( ! is_uploaded_file( $tmp_name ) ) {
+		// Defensive — `is_uploaded_file()` is the standard guard
+		// against a path-traversal payload smuggled through tmp_name.
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_bad_tmp',
+				__( 'Refused: temporary upload path is not trusted.', 'desktop-mode' ),
+				array( 'status' => 400 )
+			)
+		);
+		return;
+	}
+
+	// `Plugin_Upgrader` + `WP_Ajax_Upgrader_Skin` are admin-only
+	// classes; admin-ajax does NOT auto-load them. Same `require_once`
+	// chain Core's own `wp_ajax_install_plugin` uses (see
+	// `wp-admin/includes/ajax-actions.php`). Plugin Check accepts
+	// this in admin-ajax callbacks — the rule applies to non-admin
+	// contexts (REST callbacks, plugin bootstrap), not here.
+	if ( ! function_exists( 'wp_handle_upload' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+	}
+	if ( ! class_exists( 'WP_Upgrader' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	}
+	if ( ! class_exists( 'WP_Ajax_Upgrader_Skin' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';
+	}
+	if ( ! class_exists( 'Plugin_Upgrader' ) || ! class_exists( 'WP_Ajax_Upgrader_Skin' ) ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_upgrader_missing',
+				__( 'Plugin upgrader is unavailable in this context. Reload the page and try again.', 'desktop-mode' ),
+				array( 'status' => 503 )
+			)
+		);
+		return;
+	}
+
+	$skin     = new WP_Ajax_Upgrader_Skin();
+	$upgrader = new Plugin_Upgrader( $skin );
+	$result   = $upgrader->install( $tmp_name );
+
+	if ( is_wp_error( $skin->result ) ) {
+		desktop_mode_plugins_window_ajax_error( $skin->result );
+		return;
+	}
+	if ( $skin->get_errors()->has_errors() ) {
+		desktop_mode_plugins_window_ajax_error( $skin->get_errors() );
+		return;
+	}
+	if ( is_wp_error( $result ) ) {
+		desktop_mode_plugins_window_ajax_error( $result );
+		return;
+	}
+	if ( false === $result || null === $result ) {
+		// `Plugin_Upgrader::install()` returns `false` when the
+		// destination already exists and overwrite isn't allowed.
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'desktop_mode_plugins_install_failed',
+				__( 'Plugin install failed. The destination folder may already exist.', 'desktop-mode' ),
+				array( 'status' => 409 )
+			)
+		);
+		return;
+	}
+
+	$plugin_file = $upgrader->plugin_info();
+
+	/**
+	 * Fires after the Plugins window has installed a plugin from an
+	 * uploaded .zip. Hook callers receive the resolved plugin file.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string $plugin_file Plugin file (e.g. "akismet/akismet.php").
+	 */
+	do_action( 'desktop_mode_plugins_window_installed', $plugin_file );
+
+	wp_send_json_success(
+		array(
+			'plugin_file' => (string) $plugin_file,
+			'status'      => 'inactive',
+			'messages'    => $skin->get_upgrade_messages(),
+		)
+	);
+}
+add_action( 'wp_ajax_desktop_mode_plugins_upload', 'desktop_mode_plugins_window_ajax_upload' );

--- a/includes/plugins-window/bootstrap.php
+++ b/includes/plugins-window/bootstrap.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Desktop Mode — Native Plugins Window module bootstrap.
+ *
+ * Replaces the chromeless `plugins.php` + `plugin-install.php` iframes
+ * with a single native window containing two tabs: an Installed list
+ * (manage activations + updates + delete) and a Browse gallery
+ * (explore wp.org, view rich detail in a `<wpd-flyout>`, install by
+ * slug, upload .zip, drag-drop a .zip onto the window).
+ *
+ * Public PHP surface (all filterable):
+ *
+ *   - desktop_mode_plugins_window_user_can_register
+ *   - desktop_mode_plugins_window_user_can_use
+ *   - desktop_mode_plugins_window_args
+ *   - desktop_mode_plugins_window_template_html
+ *   - desktop_mode_plugins_window_browse_args
+ *   - desktop_mode_plugins_window_browse_response
+ *   - desktop_mode_plugins_window_info_response
+ *   - desktop_mode_plugins_window_review_parser
+ *   - desktop_mode_plugins_window_card_extras
+ *
+ * The dock-side swap (Plugins tile → native window when opt-in is on)
+ * is implemented JS-side in `src/desktop.ts` via
+ * `registerNativeUrlRemap` — this module owns only the window itself,
+ * not the entry point.
+ *
+ * Plugin Check posture: NEVER `require_once ABSPATH . 'wp-admin/…'`.
+ * Anything that needs admin-only classes (`Plugin_Upgrader`,
+ * `WP_Filesystem`, `plugins_api`) lives on `admin-ajax.php`
+ * (`includes/plugins-window/ajax.php`) where those files are already
+ * loaded. Pure data enrichment lives on REST field decorators
+ * (`includes/plugins-window/rest-fields.php`).
+ *
+ * @package WPDesktopMode
+ * @since   0.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/permissions.php';
+require_once __DIR__ . '/window.php';
+require_once __DIR__ . '/rest-fields.php';
+require_once __DIR__ . '/ajax.php';

--- a/includes/plugins-window/permissions.php
+++ b/includes/plugins-window/permissions.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Desktop Mode — Native Plugins Window: capability gates.
+ *
+ * Multi-tier gating, parallel to WordPress core's `plugins.php` flow:
+ *
+ *   - `activate_plugins` → REGISTER the window (the broad gate).
+ *                          Cap-only check; the opt-in toggle is JS-side.
+ *   - `install_plugins`  → Browse tab + install/upload (JS hides the
+ *                          tab; AJAX routes re-validate).
+ *   - `delete_plugins`   → bulk-delete + per-row delete action.
+ *   - `upload_plugins`   → .zip upload (file or drag-drop).
+ *
+ * UI-side gating is purely UX polish — the AJAX routes in `ajax.php`
+ * re-validate every cap before mutating anything.
+ *
+ * @package WPDesktopMode
+ * @since   0.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Whether the user is eligible to have the Plugins window registered.
+ *
+ * Cap-only check — the opt-in toggle is a runtime, JS-side gate. A
+ * user who toggles the setting on AFTER load needs the window
+ * already registered for the JS-side remap to find it.
+ *
+ * @since 0.9.0
+ *
+ * @param int|null $user_id Optional. Defaults to `get_current_user_id()`.
+ * @return bool
+ */
+function desktop_mode_plugins_window_user_can_register( $user_id = null ) {
+	$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
+	$can     = $user_id > 0 && user_can( $user_id, 'activate_plugins' );
+
+	/**
+	 * Filter whether the current user can have the Plugins window
+	 * registered. This is the boot-time check; runtime "should the
+	 * dock click use the native window?" is the JS-side
+	 * `nativePluginsEnabled` flag.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param bool $can     Default: `activate_plugins` capability.
+	 * @param int  $user_id User being checked.
+	 */
+	return (bool) apply_filters(
+		'desktop_mode_plugins_window_user_can_register',
+		$can,
+		$user_id
+	);
+}
+
+/**
+ * Combined cap-and-opt-in check. Used by callers that want the
+ * combined answer (e.g. analytics, an arrange-menu entry).
+ *
+ * @since 0.9.0
+ *
+ * @param int|null $user_id Optional.
+ * @return bool
+ */
+function desktop_mode_plugins_window_user_can_use( $user_id = null ) {
+	$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
+
+	$cap_ok = desktop_mode_plugins_window_user_can_register( $user_id );
+
+	$opt_in = false;
+	if ( $cap_ok && function_exists( 'desktop_mode_get_os_settings' ) ) {
+		$settings = desktop_mode_get_os_settings( $user_id );
+		$opt_in   = ! empty( $settings['nativePluginsEnabled'] );
+	}
+
+	$can = $cap_ok && $opt_in;
+
+	/**
+	 * Filter whether the current user has opted into the native
+	 * Plugins experience.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param bool $can     Default gate result.
+	 * @param int  $user_id User being checked.
+	 */
+	return (bool) apply_filters( 'desktop_mode_plugins_window_user_can_use', $can, $user_id );
+}
+
+/**
+ * Capability flags surfaced to the JS bundle so the UI can hide
+ * actions the viewer can't perform. Server still re-validates every
+ * mutation, so a tampered flag here changes nothing security-wise.
+ *
+ * @since 0.9.0
+ *
+ * @param int|null $user_id Optional.
+ * @return array{install:bool,delete:bool,upload:bool,activate:bool}
+ */
+function desktop_mode_plugins_window_caps( $user_id = null ) {
+	$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
+
+	return array(
+		'activate' => $user_id > 0 && user_can( $user_id, 'activate_plugins' ),
+		'install'  => $user_id > 0 && user_can( $user_id, 'install_plugins' ),
+		'delete'   => $user_id > 0 && user_can( $user_id, 'delete_plugins' ),
+		'upload'   => $user_id > 0 && user_can( $user_id, 'upload_plugins' ),
+	);
+}

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Desktop Mode — Native Plugins Window: REST field decorators.
+ *
+ * Adds enrichment fields to Core's `/wp/v2/plugins` REST resource so
+ * the JS bundle can render rich rows in one round-trip:
+ *
+ *   - desktop_mode_update_available — `{ available, new_version }`
+ *   - desktop_mode_can_manage       — `{ activate, deactivate, delete }`
+ *   - desktop_mode_icon_url         — best-effort wp.org icon URL
+ *   - desktop_mode_size_kb          — disk size of plugin folder
+ *
+ * Plugin Check posture: every callback below uses ONLY functions
+ * available in `wp-includes/` (current_user_can, get_site_transient,
+ * filesize, glob, …). No admin-only includes are needed, so REST is
+ * the right home — registering these fields on `rest_api_init` keeps
+ * the contract consistent with Core's other plugin REST decorators.
+ *
+ * @package WPDesktopMode
+ * @since   0.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the four enrichment fields on the `plugin` REST resource.
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_register_rest_fields() {
+	register_rest_field(
+		'plugin',
+		'desktop_mode_update_available',
+		array(
+			'get_callback' => 'desktop_mode_plugins_window_field_update_available',
+			'schema'       => array(
+				'description' => __( 'Whether an update is available for this plugin (and the available version).', 'desktop-mode' ),
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+
+	register_rest_field(
+		'plugin',
+		'desktop_mode_can_manage',
+		array(
+			'get_callback' => 'desktop_mode_plugins_window_field_can_manage',
+			'schema'       => array(
+				'description' => __( 'Per-plugin capability flags for the requester (activate / deactivate / delete).', 'desktop-mode' ),
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+
+	register_rest_field(
+		'plugin',
+		'desktop_mode_icon_url',
+		array(
+			'get_callback' => 'desktop_mode_plugins_window_field_icon_url',
+			'schema'       => array(
+				'description' => __( 'Best-effort icon URL for the plugin (resolves from the wp.org slug, null when unknown).', 'desktop-mode' ),
+				'type'        => array( 'string', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+
+	register_rest_field(
+		'plugin',
+		'desktop_mode_size_kb',
+		array(
+			'get_callback' => 'desktop_mode_plugins_window_field_size_kb',
+			'schema'       => array(
+				'description' => __( 'Approximate disk footprint of the plugin folder, in kilobytes (cached 6h).', 'desktop-mode' ),
+				'type'        => array( 'integer', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'desktop_mode_plugins_window_register_rest_fields' );
+
+/**
+ * `desktop_mode_update_available` callback.
+ *
+ * @since 0.9.0
+ *
+ * @param array $row Core REST plugin row.
+ * @return array{available:bool,new_version:string|null}
+ */
+function desktop_mode_plugins_window_field_update_available( $row ) {
+	$plugin_file = isset( $row['plugin'] ) ? (string) $row['plugin'] : '';
+	if ( '' === $plugin_file ) {
+		return array(
+			'available'   => false,
+			'new_version' => null,
+		);
+	}
+
+	// `update_plugins` is the canonical site-wide cache of pending
+	// updates, refreshed by `wp_update_plugins()` on the standard
+	// schedule. Reading it costs nothing.
+	$updates = get_site_transient( 'update_plugins' );
+	if ( ! is_object( $updates ) || empty( $updates->response ) || ! is_array( $updates->response ) ) {
+		return array(
+			'available'   => false,
+			'new_version' => null,
+		);
+	}
+
+	if ( ! isset( $updates->response[ $plugin_file ] ) ) {
+		return array(
+			'available'   => false,
+			'new_version' => null,
+		);
+	}
+
+	$entry = $updates->response[ $plugin_file ];
+	$ver   = is_object( $entry ) && isset( $entry->new_version )
+		? (string) $entry->new_version
+		: null;
+
+	return array(
+		'available'   => true,
+		'new_version' => $ver,
+	);
+}
+
+/**
+ * `desktop_mode_can_manage` callback.
+ *
+ * Per-row cap surface so the JS UI can hide actions the viewer can't
+ * perform without re-deriving caps client-side. Server still
+ * re-validates every mutation.
+ *
+ * @since 0.9.0
+ *
+ * @param array $row Core REST plugin row.
+ * @return array{activate:bool,deactivate:bool,delete:bool}
+ */
+function desktop_mode_plugins_window_field_can_manage( $row ) {
+	$status = isset( $row['status'] ) ? (string) $row['status'] : '';
+
+	$can_activate = current_user_can( 'activate_plugins' );
+	$can_delete   = current_user_can( 'delete_plugins' );
+
+	// Active plugins can only be deleted after deactivation; surface
+	// that constraint so the JS can dim the Delete action while the
+	// row is active.
+	$can_delete_now = $can_delete && 'inactive' === $status;
+
+	return array(
+		'activate'   => $can_activate && 'inactive' === $status,
+		'deactivate' => $can_activate && 'active' === $status,
+		'delete'     => $can_delete_now,
+	);
+}
+
+/**
+ * `desktop_mode_icon_url` callback.
+ *
+ * Derives a wp.org icon URL from the plugin's slug. We prefer the
+ * SVG (`icon.svg`), fall back to the 256×256 PNG, and finally the
+ * 128×128 PNG. We don't HEAD-check the URL — the JS card has an
+ * `onerror` fallback to a `<wpd-icon name="dashicons-admin-plugins">`
+ * placeholder, so a 404 here costs nothing.
+ *
+ * Plugins not on the .org repo (premium, internal, single-site) get
+ * `null` and the JS falls straight to the placeholder.
+ *
+ * @since 0.9.0
+ *
+ * @param array $row Core REST plugin row.
+ * @return string|null
+ */
+function desktop_mode_plugins_window_field_icon_url( $row ) {
+	// Core's controller exposes the directory slug under `textdomain`
+	// for .org plugins (same as the wp.org repo slug). Empty when the
+	// plugin doesn't ship a Text Domain header — fine, we just return
+	// null and the placeholder paints.
+	$slug = isset( $row['textdomain'] ) ? (string) $row['textdomain'] : '';
+	$slug = sanitize_key( $slug );
+	if ( '' === $slug ) {
+		return null;
+	}
+
+	/**
+	 * Filter the resolved icon URL for a plugin row.
+	 *
+	 * Return `null` to suppress the icon (forces the placeholder).
+	 * Return a different URL to override the wp.org default — useful
+	 * for custom CDN art or premium plugins shipping a known asset URL.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string|null $url  Default URL (wp.org SVG by slug).
+	 * @param string      $slug Plugin slug.
+	 * @param array       $row  Core REST plugin row.
+	 */
+	return apply_filters(
+		'desktop_mode_plugins_window_icon_url',
+		'https://ps.w.org/' . $slug . '/assets/icon.svg',
+		$slug,
+		$row
+	);
+}
+
+/**
+ * `desktop_mode_size_kb` callback. Caches per-plugin for 6 hours so
+ * a 50-row table doesn't `glob`+`filesize` 50 directories on every
+ * fetch. Returns `null` when the folder can't be read.
+ *
+ * @since 0.9.0
+ *
+ * @param array $row Core REST plugin row.
+ * @return int|null Size in kilobytes, or null on failure.
+ */
+function desktop_mode_plugins_window_field_size_kb( $row ) {
+	$plugin_file = isset( $row['plugin'] ) ? (string) $row['plugin'] : '';
+	if ( '' === $plugin_file ) {
+		return null;
+	}
+
+	// `WP_PLUGIN_DIR` is defined in `wp-includes/default-constants.php`
+	// — safe to reference anywhere.
+	$plugin_dir = WP_PLUGIN_DIR;
+	$root       = $plugin_dir . '/' . dirname( $plugin_file );
+	if ( '.' === dirname( $plugin_file ) || ! is_dir( $root ) ) {
+		// Single-file plugins (e.g. hello.php at the root of plugins/).
+		$candidate = $plugin_dir . '/' . $plugin_file;
+		if ( is_file( $candidate ) ) {
+			$bytes = (int) filesize( $candidate );
+			return $bytes > 0 ? max( 1, (int) round( $bytes / 1024 ) ) : 0;
+		}
+		return null;
+	}
+
+	$cache_key = 'dm_pwsz_' . md5( $plugin_file );
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached && is_int( $cached ) ) {
+		return $cached;
+	}
+
+	$kb = desktop_mode_plugins_window_compute_dir_size_kb( $root );
+	set_transient( $cache_key, $kb, 6 * HOUR_IN_SECONDS );
+	return $kb;
+}
+
+/**
+ * Recursively sum file sizes under `$dir`, returning kilobytes.
+ *
+ * Caps total iteration to 5,000 entries so a pathological symlink
+ * loop (or an enormous plugin folder full of vendor cruft) can't
+ * stall a REST response. When the cap trips we return whatever we
+ * counted so far — a slight under-report is better than a hung
+ * request.
+ *
+ * @since 0.9.0
+ *
+ * @param string $dir Absolute filesystem path.
+ * @return int Kilobytes (rounded).
+ */
+function desktop_mode_plugins_window_compute_dir_size_kb( $dir ) {
+	if ( ! is_dir( $dir ) ) {
+		return 0;
+	}
+
+	$total_bytes = 0;
+	$visited     = 0;
+	$max_visit   = 5000;
+
+	$stack = array( $dir );
+	while ( ! empty( $stack ) && $visited < $max_visit ) {
+		$current = array_pop( $stack );
+		$entries = @scandir( $current ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best-effort, errors fall back to null.
+		if ( ! is_array( $entries ) ) {
+			continue;
+		}
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $current . '/' . $entry;
+			if ( is_link( $path ) ) {
+				// Skip symlinks: they could escape the plugin folder
+				// or recurse infinitely. The classic admin's plugin
+				// list ignores symlink contents for the same reason.
+				continue;
+			}
+			$visited++;
+			if ( $visited >= $max_visit ) {
+				break 2;
+			}
+			if ( is_dir( $path ) ) {
+				$stack[] = $path;
+			} elseif ( is_file( $path ) ) {
+				$total_bytes += (int) filesize( $path );
+			}
+		}
+	}
+
+	return $total_bytes > 0 ? max( 1, (int) round( $total_bytes / 1024 ) ) : 0;
+}

--- a/includes/plugins-window/window.php
+++ b/includes/plugins-window/window.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Desktop Mode — Native Plugins Window: registration + template.
+ *
+ * Native window registered with `placement: 'none'` — the entry
+ * point is the existing Plugins dock tile (built from WordPress's
+ * `$menu`), which the JS-side URL remap rewrites to open this window
+ * when `nativePluginsEnabled` is on.
+ *
+ * The shell wraps the template echoed by
+ * `desktop_mode_plugins_window_render_template()` in
+ * `<template id="desktop-mode-native-window-desktop-mode-plugins">`
+ * and clones it into the window body BEFORE the JS render callback
+ * fires. The `data-desktop-mode-plugins-*` hooks below are the
+ * contract the JS relies on — keep them intact (or rename via the
+ * filter) when customizing the layout.
+ *
+ * @package WPDesktopMode
+ * @since   0.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Echoes the native Plugins window's template body.
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_render_template() {
+	$caps = desktop_mode_plugins_window_caps();
+
+	ob_start();
+	?>
+	<div class="desktop-mode-plugins" data-desktop-mode-plugins-root>
+		<wpd-tabs value="installed" class="desktop-mode-plugins__tabs" data-desktop-mode-plugins-tabs>
+			<wpd-tab value="installed"><?php esc_html_e( 'Installed', 'desktop-mode' ); ?></wpd-tab>
+			<?php if ( ! empty( $caps['install'] ) ) : ?>
+				<wpd-tab value="browse"><?php esc_html_e( 'Browse', 'desktop-mode' ); ?></wpd-tab>
+			<?php endif; ?>
+		</wpd-tabs>
+
+		<wpd-tabpanel for="installed" class="desktop-mode-plugins__panel">
+			<div class="desktop-mode-plugins__installed" data-desktop-mode-plugins-installed-host>
+				<?php /* JS bundle paints the toolbar + <wpd-table> here.
+				       Empty host — first-frame shows the table's own
+				       loading skeleton. */ ?>
+			</div>
+		</wpd-tabpanel>
+
+		<?php if ( ! empty( $caps['install'] ) ) : ?>
+			<wpd-tabpanel for="browse" class="desktop-mode-plugins__panel">
+				<div class="desktop-mode-plugins__browse" data-desktop-mode-plugins-browse-host>
+					<?php /* JS bundle paints the search + segmented filter
+					       + Upload button + <wpd-grid> of cards here. */ ?>
+				</div>
+			</wpd-tabpanel>
+		<?php endif; ?>
+
+		<?php /* Detail flyout — populated lazily when a card is clicked.
+		       Lives at the root of the template so it can slide over the
+		       full window body, not just one tab panel. */ ?>
+		<wpd-flyout
+			placement="end"
+			data-desktop-mode-plugins-flyout
+			aria-label="<?php esc_attr_e( 'Plugin details', 'desktop-mode' ); ?>"
+		></wpd-flyout>
+	</div>
+	<?php
+	$html = (string) ob_get_clean();
+
+	/**
+	 * Filter the native Plugins window's template HTML.
+	 *
+	 * Keep the `data-desktop-mode-plugins-*` hooks intact so the JS
+	 * render callback can find its mount points, or rename them and
+	 * update the matching constants in `src/plugins-window/index.ts`.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string $html Default template HTML.
+	 */
+	$filtered = (string) apply_filters( 'desktop_mode_plugins_window_template_html', $html );
+
+	if ( function_exists( 'desktop_mode_kses_native_window_template' ) ) {
+		echo desktop_mode_kses_native_window_template( $filtered ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- helper kses-escapes.
+	} else {
+		echo wp_kses( $filtered, wp_kses_allowed_html( 'post' ) );
+	}
+}
+
+/**
+ * Register the native Plugins window on `init` (priority 20, after
+ * `components.php` has bootstrapped the registry).
+ *
+ * Cap-only gate so that flipping the opt-in mid-session doesn't
+ * require an F5. The opt-in is a runtime check on the JS-side remap
+ * (`enabled: ( s ) => s.nativePluginsEnabled === true` in
+ * `src/desktop.ts`).
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_plugins_window_register_window() {
+	if ( ! desktop_mode_plugins_window_user_can_register() ) {
+		return;
+	}
+
+	$caps = desktop_mode_plugins_window_caps();
+
+	$window_args = array(
+		'title'      => __( 'Plugins', 'desktop-mode' ),
+		'icon'       => 'dashicons-admin-plugins',
+		'template'   => 'desktop_mode_plugins_window_render_template',
+		'script'     => 'desktop-mode-plugins-window',
+		'style'      => 'desktop-mode-plugins-window',
+		'width'      => 1180,
+		'height'     => 760,
+		'min_width'  => 760,
+		'min_height' => 480,
+		// `'none'` — no dock or wallpaper tile from this registration.
+		// The Plugins dock tile lives in WordPress's `$menu` and the
+		// JS-side URL remap routes its click to `openById` here when
+		// the opt-in is on. A separate tile would be a duplicate
+		// entry point.
+		'placement'  => 'none',
+		'config'     => array(
+			'restRoot'        => esc_url_raw( rest_url() ),
+			'restNonce'       => wp_create_nonce( 'wp_rest' ),
+			// Core's REST controller for installed plugins.
+			'pluginsUrl'      => esc_url_raw( rest_url( 'wp/v2/plugins' ) ),
+			// `admin-ajax.php` is the canonical home for our
+			// install/upload/browse/info/reviews handlers — Plugin Check
+			// rejects calls to admin-only classes from REST callbacks.
+			'ajaxUrl'         => esc_url_raw( admin_url( 'admin-ajax.php' ) ),
+			'ajaxNonce'       => wp_create_nonce( 'desktop-mode-plugins' ),
+			// Core's `wp_ajax_install_plugin` (and friends) verify
+			// against the `'updates'` nonce action — same string Core's
+			// wp.updates client passes. We reuse it verbatim so we go
+			// through Core's existing handler, no reimplementation.
+			'updatesNonce'    => wp_create_nonce( 'updates' ),
+			'caps'            => $caps,
+			'currentUserId'   => (int) get_current_user_id(),
+			'introSeen'       => function_exists( 'desktop_mode_has_seen_intro' )
+				? desktop_mode_has_seen_intro( get_current_user_id(), 'plugins' )
+				: true,
+			'introUrl'        => esc_url_raw( rest_url( 'desktop-mode/v1/intros/seen' ) ),
+		),
+	);
+
+	/**
+	 * Filter the args used to register the native Plugins window.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array $window_args Args passed to `desktop_mode_register_window()`.
+	 */
+	$window_args = (array) apply_filters( 'desktop_mode_plugins_window_args', $window_args );
+
+	$registered = desktop_mode_register_window( 'desktop-mode-plugins', $window_args );
+	if ( is_wp_error( $registered ) ) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( '[desktop-mode] Native Plugins window registration failed: ' . $registered->get_error_message() );
+	}
+}
+add_action( 'init', 'desktop_mode_plugins_window_register_window', 20 );

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -863,6 +863,32 @@ function desktop_mode_chromeless_bridge_script() {
 		if ( link.hasAttribute( 'download' ) ) {
 			return;
 		}
+		/*
+		 * WordPress core's wp-admin/js/updates.js owns the click on these
+		 * AJAX-driven plugin/theme management buttons — it binds in bubble
+		 * phase and calls preventDefault to take over with an in-place
+		 * AJAX install / update / delete (with its own progress spinner
+		 * and inline success/failure UX). Our capture-phase handler would
+		 * preempt it: preventDefault here fires BEFORE updates.js's own,
+		 * the AJAX call never starts, and the postMessage below diverts
+		 * the user to the link's no-JS fallback URL (update.php?action=
+		 * install-plugin&...) opened as a freshly spawned desktop window.
+		 * That fallback technically completes the install server-side,
+		 * but it's a long blocking page-load with no in-place feedback —
+		 * which is what users perceive as "Install Now keeps loading and
+		 * opens a new tab". Skip these classes so updates.js's bubble
+		 * handler runs as core intended.
+		 */
+		if (
+			link.classList.contains( 'install-now' ) ||
+			link.classList.contains( 'update-link' ) ||
+			link.classList.contains( 'update-now' ) ||
+			link.classList.contains( 'delete-plugin' ) ||
+			link.classList.contains( 'delete-theme' ) ||
+			link.classList.contains( 'install-theme' )
+		) {
+			return;
+		}
 		var href = link.getAttribute( 'href' );
 		var kind = classifyLink( href, window.location.href );
 		if ( kind === 'admin' ) {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
 		}
 	},
 	"scripts": {
-		"build": "npm run vendor:pixi && npm run build:desktop && npm run build:iframe-bridge && npm run build:recycle-bin && npm run build:posts-window && npm run build:my-wordpress && npm run build:content-graph && npm run build:pwa-sw",
+		"build": "npm run vendor:pixi && npm run build:desktop && npm run build:iframe-bridge && npm run build:recycle-bin && npm run build:posts-window && npm run build:plugins-window && npm run build:my-wordpress && npm run build:content-graph && npm run build:pwa-sw",
 		"build:desktop": "vite build --mode development && vite build --mode production",
 		"build:iframe-bridge": "DESKTOP_MODE_TARGET=iframe-bridge vite build --mode development && DESKTOP_MODE_TARGET=iframe-bridge vite build --mode production",
 		"build:recycle-bin": "DESKTOP_MODE_TARGET=recycle-bin vite build --mode development && DESKTOP_MODE_TARGET=recycle-bin vite build --mode production",
 		"build:posts-window": "DESKTOP_MODE_TARGET=posts-window vite build --mode development && DESKTOP_MODE_TARGET=posts-window vite build --mode production",
+		"build:plugins-window": "DESKTOP_MODE_TARGET=plugins-window vite build --mode development && DESKTOP_MODE_TARGET=plugins-window vite build --mode production",
 		"build:my-wordpress": "DESKTOP_MODE_TARGET=my-wordpress vite build --mode development && DESKTOP_MODE_TARGET=my-wordpress vite build --mode production",
 		"build:content-graph": "DESKTOP_MODE_TARGET=content-graph vite build --mode development && DESKTOP_MODE_TARGET=content-graph vite build --mode production",
 		"build:pwa-sw": "DESKTOP_MODE_TARGET=pwa-sw vite build --mode development && DESKTOP_MODE_TARGET=pwa-sw vite build --mode production",

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -352,6 +352,9 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 			if ( typeof patch.nativeUsersEnabled === 'boolean' ) {
 				osSettings.state.nativeUsersEnabled = patch.nativeUsersEnabled;
 			}
+			if ( typeof patch.nativePluginsEnabled === 'boolean' ) {
+				osSettings.state.nativePluginsEnabled = patch.nativePluginsEnabled;
+			}
 			if ( Array.isArray( patch.nativePostsHiddenColumns ) ) {
 				osSettings.state.nativePostsHiddenColumns =
 					patch.nativePostsHiddenColumns

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -259,16 +259,16 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			if ( pinnedSlot ) {
 				setTilePosition( tile, pinnedSlot.x, pinnedSlot.y );
 				tile.classList.add( `${ TILE_CLASS }--pinned` );
-				tile.setAttribute( 'aria-roledescription', 'pinned shortcut' );
-				tile.setAttribute( 'aria-disabled', 'true' );
 				// No drag wiring on pinned tiles by design — they
-				// anchor to a fixed slot. We DO wire a pointerdown
-				// handler that flashes a `--bump` class so the user
-				// gets explicit feedback ("this tile is pinned"
-				// instead of silent non-response) plus the title
-				// attribute that surfaces in browser tooltips and
-				// to assistive tech.
-				attachPinnedTileFeedback( tile );
+				// anchor to a fixed slot. We deliberately DO NOT
+				// surface any upfront visual cue (no special cursor,
+				// bump animation, or tooltip): the tile looks +
+				// reacts identically to any other tile, and the
+				// (silent) failure to drag becomes the feedback at
+				// the moment the user attempts it. This was the
+				// 0.9.0 design call — pre-emptive cues read as "this
+				// tile is broken/disabled" even though clicking it
+				// opens the window normally.
 				attachContextMenu( tile, placement );
 				attachSelectOnClick( tile, placement );
 				container.appendChild( tile );
@@ -883,30 +883,6 @@ function attachTileDrag(
 		void session;
 		void visibleX;
 		void visibleY;
-	} );
-}
-
-/**
- * Pinned tiles ("My WordPress", Recycle Bin) anchor to a fixed slot
- * by design. We don't wire drag, but we DO add a "bumped" cosmetic
- * affordance on pointerdown so the user gets explicit feedback —
- * silent non-response feels broken; an animated bump + a tooltip
- * reads as "this tile is intentionally fixed."
- */
-function attachPinnedTileFeedback( tile: HTMLElement ): void {
-	tile.title = tile.title || 'Pinned shortcut — anchored to this slot';
-	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
-		if ( e.button !== 0 ) {
-			return;
-		}
-		tile.classList.remove( `${ TILE_CLASS }--bump` );
-		// Force a reflow so re-adding the class restarts the CSS
-		// animation. `void` discards the read.
-		void tile.offsetWidth;
-		tile.classList.add( `${ TILE_CLASS }--bump` );
-	} );
-	tile.addEventListener( 'animationend', () => {
-		tile.classList.remove( `${ TILE_CLASS }--bump` );
 	} );
 }
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1819,6 +1819,33 @@ function init(): void {
 		},
 	} );
 
+	// Native Plugins window — claims `plugins.php` (Installed list)
+	// AND `plugin-install.php` (Browse the .org repo). The latter
+	// stashes a `tab: 'browse'` hint so the bundle's first paint
+	// activates the Browse tab. `plugin-editor.php` is intentionally
+	// NOT claimed — it's a code-editor surface that belongs to the
+	// separate code-editor bundle.
+	registerNativeUrlRemap( {
+		id: 'desktop-mode-plugins',
+		nativeWindowId: 'desktop-mode-plugins',
+		matches: ( _url, parsed ) => {
+			const path = parsed.pathname;
+			return (
+				path.endsWith( '/plugins.php' ) ||
+				path.endsWith( '/plugin-install.php' )
+			);
+		},
+		enabled: ( snapshot ) => snapshot.nativePluginsEnabled === true,
+		onMatch: ( _url, parsed ) => {
+			const tab = parsed.pathname.endsWith( '/plugin-install.php' )
+				? 'browse'
+				: 'installed';
+			void import( './plugins-window/tab-target' ).then( ( m ) => {
+				m.setPluginsWindowTab( tab );
+			} );
+		},
+	} );
+
 	if ( bottomDockEl && shellEl && shellBody && config.dockItems ) {
 		desktopArea.classList.add( 'desktop-mode-area--with-dock' );
 		const initialLayout = osSettings.getOsSettingsSnapshot().desktopLayout;

--- a/src/plugins-window/browse-view.ts
+++ b/src/plugins-window/browse-view.ts
@@ -1,0 +1,569 @@
+/**
+ * Native Plugins window — Browse tab.
+ *
+ * Search field + segmented browse filter + Upload button + a
+ * `<wpd-grid>`-style gallery of cards. Infinite scroll via
+ * IntersectionObserver on a sentinel.
+ *
+ * The whole window body also acts as a drop zone for `.zip` files —
+ * dragging from Finder/Explorer onto the window opens the upload
+ * dialog with the file pre-applied.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __, sprintf } from '../i18n';
+import {
+	buildCard,
+	repaintCardCta,
+	type CardCallbacks,
+	type InstalledIndex,
+} from './card';
+import { installPluginDropTargets, makeCardDraggable } from './card-drag';
+import { openDetailFlyout } from './flyout-detail';
+import {
+	activateInstalledPlugin,
+	browsePlugins,
+	fetchInstalledPlugins,
+	getConfig,
+	installPluginBySlug,
+	refreshFrameworkMenu,
+} from './rest';
+import type {
+	BrowseFilter,
+	InstalledPlugin,
+	WpOrgBrowsePlugin,
+} from './types';
+import { openUploadDialog } from './upload-dialog';
+
+interface BrowseState {
+	filter: BrowseFilter;
+	search: string;
+	page: number;
+	totalPages: number;
+	loading: boolean;
+	exhausted: boolean;
+	plugins: WpOrgBrowsePlugin[];
+	installed: InstalledIndex;
+	cardsBySlug: Map< string, HTMLElement >;
+}
+
+/** Toast helper — mirrors installed-view.ts. */
+function toast( message: string, duration = 3500 ): void {
+	const api = window.wp?.desktop;
+	if ( api && typeof api.showToast === 'function' ) {
+		api.showToast( { message, duration } );
+		return;
+	}
+	// eslint-disable-next-line no-console
+	console.log( '[plugins-window]', message );
+}
+
+/**
+ * Mount the Browse view into a host element. Returns a teardown.
+ *
+ * `flyoutEl` is the `<wpd-flyout data-desktop-mode-plugins-flyout>`
+ * declared in the template — we share it across cards.
+ */
+export function mountBrowseView(
+	host: HTMLElement,
+	flyoutEl: HTMLElement | null,
+	bodyEl: HTMLElement,
+): () => void {
+	host.replaceChildren();
+
+	const state: BrowseState = {
+		filter: 'featured',
+		search: '',
+		page: 1,
+		totalPages: 0,
+		loading: false,
+		exhausted: false,
+		plugins: [],
+		installed: new Map(),
+		cardsBySlug: new Map(),
+	};
+
+	// ─── Toolbar ────────────────────────────────────────────────────
+	const toolbar = document.createElement( 'header' );
+	toolbar.className = 'desktop-mode-plugins__toolbar';
+
+	const left = document.createElement( 'div' );
+	left.className = 'desktop-mode-plugins__toolbar-left';
+
+	const segmented = document.createElement( 'wpd-segmented' );
+	segmented.setAttribute( 'value', 'featured' );
+	const filters: Array< { value: BrowseFilter; label: string } > = [
+		{ value: 'featured', label: __( 'Featured', 'desktop-mode' ) },
+		{ value: 'popular', label: __( 'Popular', 'desktop-mode' ) },
+		{ value: 'recommended', label: __( 'Recommended', 'desktop-mode' ) },
+		{ value: 'favorites', label: __( 'Favorites', 'desktop-mode' ) },
+		{ value: 'new', label: __( 'New', 'desktop-mode' ) },
+		{ value: 'beta', label: __( 'Beta', 'desktop-mode' ) },
+	];
+	for ( const opt of filters ) {
+		const seg = document.createElement( 'wpd-segment' );
+		seg.setAttribute( 'value', opt.value );
+		seg.textContent = opt.label;
+		segmented.appendChild( seg );
+	}
+	segmented.addEventListener( 'wpd-pick', ( ev: Event ) => {
+		const next = ( ev as CustomEvent< { value: string } > ).detail?.value ?? 'featured';
+		state.filter = next as BrowseFilter;
+		void resetAndLoad();
+	} );
+
+	const search = document.createElement( 'wpd-text-field' );
+	search.setAttribute( 'placeholder', __( 'Search WordPress.org…', 'desktop-mode' ) );
+	let searchDebounce: number | undefined;
+	search.addEventListener( 'wpd-input-change', ( ev: Event ) => {
+		const value = ( ev as CustomEvent< { value: string } > ).detail?.value ?? '';
+		window.clearTimeout( searchDebounce );
+		searchDebounce = window.setTimeout( () => {
+			state.search = value;
+			void resetAndLoad();
+		}, 250 );
+	} );
+
+	left.append( segmented, search );
+
+	const right = document.createElement( 'div' );
+	right.className = 'desktop-mode-plugins__toolbar-trailing';
+	const cfg = getConfig();
+	if ( cfg.caps.upload ) {
+		const upload = document.createElement( 'wpd-button' );
+		upload.setAttribute( 'variant', 'secondary' );
+		upload.innerHTML =
+			'<span class="dashicons dashicons-upload" aria-hidden="true"></span> ' +
+			__( 'Upload Plugin', 'desktop-mode' );
+		upload.addEventListener( 'click', () => {
+			void openUploadDialog( bodyEl, null, {
+				onUploaded: () => void refreshInstalled(),
+			} );
+		} );
+		right.appendChild( upload );
+	}
+
+	toolbar.append( left, right );
+
+	// ─── Gallery ────────────────────────────────────────────────────
+	const gallery = document.createElement( 'div' );
+	gallery.className = 'desktop-mode-plugins__gallery';
+
+	// The sentinel must live INSIDE the gallery scroll container —
+	// IntersectionObserver with `root: gallery` only fires when the
+	// observed element enters that scroll viewport. Earlier we
+	// appended it as a sibling AFTER the gallery, which meant the
+	// observer fired exactly once on initial mount (the sentinel was
+	// in the document viewport) and never again on subsequent
+	// scrolls. The sentinel now scrolls down WITH the gallery
+	// content; as the user reaches the bottom, it slides into the
+	// observer's `root` viewport and triggers the next fetch.
+	const sentinel = document.createElement( 'div' );
+	sentinel.className = 'desktop-mode-plugins__gallery-sentinel';
+	sentinel.setAttribute( 'aria-hidden', 'true' );
+
+	const status = document.createElement( 'p' );
+	status.className = 'desktop-mode-plugins__gallery-status';
+	status.hidden = true;
+
+	host.append( toolbar, gallery, status );
+
+	// ─── Window-level .zip drop overlay ────────────────────────────
+	const dropOverlay = document.createElement( 'div' );
+	dropOverlay.className = 'desktop-mode-plugins__window-drop';
+	dropOverlay.setAttribute( 'aria-hidden', 'true' );
+	const dropMsg = document.createElement( 'p' );
+	dropMsg.textContent = __(
+		'Drop the .zip to install.',
+		'desktop-mode',
+	);
+	dropOverlay.appendChild( dropMsg );
+	bodyEl.appendChild( dropOverlay );
+
+	let dragDepth = 0;
+	const isZipDrag = ( ev: DragEvent ): boolean =>
+		Boolean(
+			ev.dataTransfer?.types.includes( 'Files' ),
+		);
+
+	const onDragEnter = ( ev: DragEvent ): void => {
+		if ( ! cfg.caps.upload ) {
+			return;
+		}
+		if ( ! isZipDrag( ev ) ) {
+			return;
+		}
+		dragDepth++;
+		bodyEl.classList.add( 'has-zip-dragover' );
+	};
+	const onDragLeave = ( ev: DragEvent ): void => {
+		if ( ! cfg.caps.upload || ! isZipDrag( ev ) ) {
+			return;
+		}
+		dragDepth = Math.max( 0, dragDepth - 1 );
+		if ( dragDepth === 0 ) {
+			bodyEl.classList.remove( 'has-zip-dragover' );
+		}
+	};
+	const onDragOver = ( ev: DragEvent ): void => {
+		if ( cfg.caps.upload && isZipDrag( ev ) ) {
+			ev.preventDefault();
+		}
+	};
+	const onDrop = ( ev: DragEvent ): void => {
+		if ( ! cfg.caps.upload ) {
+			return;
+		}
+		const file = ev.dataTransfer?.files?.[ 0 ];
+		dragDepth = 0;
+		bodyEl.classList.remove( 'has-zip-dragover' );
+		if ( ! file ) {
+			return;
+		}
+		ev.preventDefault();
+		void openUploadDialog( bodyEl, file, {
+			onUploaded: () => void refreshInstalled(),
+		} );
+	};
+	bodyEl.addEventListener( 'dragenter', onDragEnter );
+	bodyEl.addEventListener( 'dragleave', onDragLeave );
+	bodyEl.addEventListener( 'dragover', onDragOver );
+	bodyEl.addEventListener( 'drop', onDrop );
+
+	// ─── Card drop targets (drag a card to dock to pin) ────────────
+	const teardownDropTargets = installPluginDropTargets();
+
+	// ─── Card callbacks ────────────────────────────────────────────
+	const cardCallbacks: CardCallbacks = {
+		onOpen: ( slug, hint ) => {
+			if ( ! flyoutEl ) {
+				return;
+			}
+			openDetailFlyout( flyoutEl, slug, hint, {
+				getInstalled: ( s ) => state.installed.get( s ),
+				onPluginInstalled: async ( pluginFile, slug2 ) => {
+					await refreshInstalled();
+					const card = state.cardsBySlug.get( slug2 );
+					const plugin = state.plugins.find( ( p ) => p.slug === slug2 );
+					if ( card && plugin ) {
+						repaintCardCta( card, plugin, state.installed, cardCallbacks );
+					}
+					if ( pluginFile ) {
+						// eslint-disable-next-line no-console
+						console.log( '[plugins-window] installed', pluginFile );
+					}
+				},
+				onPluginActivated: ( updated ) => {
+					state.installed.set( indexKeyFor( updated ), updated );
+					const card = state.cardsBySlug.get( updated.textdomain ?? '' );
+					const plugin = state.plugins.find(
+						( p ) => p.slug === ( updated.textdomain ?? '' ),
+					);
+					if ( card && plugin ) {
+						repaintCardCta( card, plugin, state.installed, cardCallbacks );
+					}
+				},
+				onPluginDeactivated: ( updated ) => {
+					state.installed.set( indexKeyFor( updated ), updated );
+					const card = state.cardsBySlug.get( updated.textdomain ?? '' );
+					const plugin = state.plugins.find(
+						( p ) => p.slug === ( updated.textdomain ?? '' ),
+					);
+					if ( card && plugin ) {
+						repaintCardCta( card, plugin, state.installed, cardCallbacks );
+					}
+				},
+				onPluginDeleted: ( deleted ) => {
+					const key = indexKeyFor( deleted );
+					state.installed.delete( key );
+					const card = state.cardsBySlug.get( deleted.textdomain ?? '' );
+					const plugin = state.plugins.find(
+						( p ) => p.slug === ( deleted.textdomain ?? '' ),
+					);
+					if ( card && plugin ) {
+						repaintCardCta( card, plugin, state.installed, cardCallbacks );
+					}
+				},
+			} );
+		},
+		onInstall: async ( plugin, card ) => {
+			const cta = card.querySelector< HTMLElement >( '[data-plugin-card-cta]' );
+			cta?.setAttribute( 'busy', '' );
+			cta?.setAttribute( 'disabled', '' );
+			try {
+				await installPluginBySlug( plugin.slug );
+				await refreshFrameworkMenu();
+				await refreshInstalled();
+				toast(
+					sprintf(
+						/* translators: %s: plugin name */
+						__( 'Installed %s.', 'desktop-mode' ),
+						plugin.name,
+					),
+				);
+				repaintCardCta( card, plugin, state.installed, cardCallbacks );
+			} catch ( err ) {
+				cta?.removeAttribute( 'busy' );
+				cta?.removeAttribute( 'disabled' );
+				toast(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Install failed: %s', 'desktop-mode' ),
+						describe( err ),
+					),
+					6000,
+				);
+			}
+		},
+		onActivate: async ( installed, card ) => {
+			const cta = card.querySelector< HTMLElement >( '[data-plugin-card-cta]' );
+			cta?.setAttribute( 'busy', '' );
+			cta?.setAttribute( 'disabled', '' );
+			try {
+				const updated = await activateInstalledPlugin( installed );
+				state.installed.set( indexKeyFor( updated ), updated );
+				toast(
+					sprintf(
+						/* translators: %s: plugin name */
+						__( '%s activated.', 'desktop-mode' ),
+						updated.name || updated.plugin,
+					),
+				);
+				await refreshFrameworkMenu();
+				const plugin = state.plugins.find(
+					( p ) => p.slug === ( updated.textdomain ?? '' ),
+				);
+				if ( plugin ) {
+					repaintCardCta( card, plugin, state.installed, cardCallbacks );
+				}
+			} catch ( err ) {
+				cta?.removeAttribute( 'busy' );
+				cta?.removeAttribute( 'disabled' );
+				toast(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Activation failed: %s', 'desktop-mode' ),
+						describe( err ),
+					),
+					6000,
+				);
+			}
+		},
+	};
+
+	// ─── Infinite scroll ────────────────────────────────────────────
+	// `root: gallery` so the observer fires against the gallery's
+	// internal scroll, not the document viewport.
+	const observer = new IntersectionObserver(
+		( entries ) => {
+			for ( const entry of entries ) {
+				if ( entry.isIntersecting ) {
+					void loadMore();
+				}
+			}
+		},
+		{ root: gallery, rootMargin: '240px', threshold: 0 },
+	);
+	observer.observe( sentinel );
+
+	// ─── Initial loads ──────────────────────────────────────────────
+	void refreshInstalled();
+	void resetAndLoad();
+
+	async function refreshInstalled(): Promise< void > {
+		try {
+			const rows = await fetchInstalledPlugins();
+			state.installed = new Map(
+				rows.map( ( r ) => [ indexKeyFor( r ), r ] ),
+			);
+			// Repaint every existing card so its CTA reflects the new
+			// installed state.
+			for ( const [ slug, card ] of state.cardsBySlug ) {
+				const plugin = state.plugins.find( ( p ) => p.slug === slug );
+				if ( plugin ) {
+					repaintCardCta( card, plugin, state.installed, cardCallbacks );
+				}
+			}
+		} catch {
+			// Best-effort — a missing installed cache just means cards
+			// show "Install" instead of "Active". Recovers on next call.
+		}
+	}
+
+	async function resetAndLoad(): Promise< void > {
+		state.page = 1;
+		state.totalPages = 0;
+		state.exhausted = false;
+		state.plugins = [];
+		state.cardsBySlug.clear();
+		gallery.replaceChildren();
+		// Skeleton cards while we wait for the first response.
+		for ( let i = 0; i < 6; i++ ) {
+			gallery.appendChild( buildSkeletonCard() );
+		}
+		// Sentinel must be the LAST child of the gallery so it scrolls
+		// with the content. `replaceChildren()` removed it, so re-append.
+		gallery.appendChild( sentinel );
+		await loadMore();
+	}
+
+	/**
+	 * Skeleton cards inserted just before the sentinel while a
+	 *  loadMore() is in flight. Lets the user see "more is coming"
+	 *  instead of the page going silent during the fetch. Cleared
+	 *  on every loadMore exit.
+	 */
+	const inflightSkeletons: HTMLElement[] = [];
+
+	function showInflightLoader(): void {
+		if ( inflightSkeletons.length > 0 ) {
+			return;
+		}
+		// Match the column count visually — pagination on a wide
+		// gallery feels less abrupt with a few placeholders than one.
+		for ( let i = 0; i < 4; i++ ) {
+			const skel = buildSkeletonCard();
+			gallery.insertBefore( skel, sentinel );
+			inflightSkeletons.push( skel );
+		}
+	}
+
+	function clearInflightLoader(): void {
+		for ( const skel of inflightSkeletons ) {
+			skel.remove();
+		}
+		inflightSkeletons.length = 0;
+	}
+
+	async function loadMore(): Promise< void > {
+		if ( state.loading || state.exhausted ) {
+			return;
+		}
+		state.loading = true;
+		// Skeleton placeholders ONLY for subsequent pages — the
+		// initial load already paints six skeletons via resetAndLoad,
+		// and we'd double-up if we added more here.
+		if ( state.page > 1 ) {
+			showInflightLoader();
+		}
+		try {
+			const data = await browsePlugins( {
+				browse: state.search === '' ? state.filter : undefined,
+				search: state.search === '' ? undefined : state.search,
+				page: state.page,
+				perPage: 24,
+			} );
+			if ( state.page === 1 ) {
+				// Drop skeletons + any prior content; re-anchor the
+				// sentinel as the last child for the observer.
+				gallery.replaceChildren();
+				gallery.appendChild( sentinel );
+			}
+			// `info.pages` is wp.org's authoritative page-count signal —
+			// short-page heuristics get fooled when the API returns
+			// fewer than `per_page` rows on a non-final page.
+			const info = ( data.info ?? {} ) as { pages?: number; results?: number };
+			if ( typeof info.pages === 'number' && info.pages > 0 ) {
+				state.totalPages = info.pages;
+			}
+			const incoming = data.plugins ?? [];
+			if ( incoming.length === 0 ) {
+				state.exhausted = true;
+				if ( state.page === 1 ) {
+					showStatus( __( 'No plugins matched.', 'desktop-mode' ) );
+				}
+				return;
+			}
+			for ( const plugin of incoming ) {
+				if ( ! plugin?.slug ) {
+					continue;
+				}
+				if ( state.cardsBySlug.has( plugin.slug ) ) {
+					continue;
+				}
+				const card = buildCard( plugin, state.installed, cardCallbacks );
+				makeCardDraggable( card, plugin );
+				// Always insert BEFORE the sentinel so it stays last
+				// for IntersectionObserver to keep observing it.
+				gallery.insertBefore( card, sentinel );
+				state.cardsBySlug.set( plugin.slug, card );
+				state.plugins.push( plugin );
+			}
+			state.page++;
+			// Two exhaustion signals — trust whichever fires first.
+			if ( state.totalPages > 0 && state.page > state.totalPages ) {
+				state.exhausted = true;
+			} else if ( state.totalPages === 0 && incoming.length < 24 ) {
+				// Fallback when wp.org didn't surface a `pages` count.
+				state.exhausted = true;
+			}
+			hideStatus();
+		} catch ( err ) {
+			showStatus(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Could not load plugins: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+			);
+		} finally {
+			clearInflightLoader();
+			state.loading = false;
+		}
+	}
+
+	function showStatus( message: string ): void {
+		status.hidden = false;
+		status.textContent = message;
+	}
+	function hideStatus(): void {
+		status.hidden = true;
+		status.textContent = '';
+	}
+
+	return () => {
+		observer.disconnect();
+		bodyEl.removeEventListener( 'dragenter', onDragEnter );
+		bodyEl.removeEventListener( 'dragleave', onDragLeave );
+		bodyEl.removeEventListener( 'dragover', onDragOver );
+		bodyEl.removeEventListener( 'drop', onDrop );
+		dropOverlay.remove();
+		teardownDropTargets();
+		host.replaceChildren();
+	};
+}
+
+function buildSkeletonCard(): HTMLElement {
+	// Non-interactive `<wpd-card>` — same chrome as a real gallery
+	// card without the hover lift, so the loading state visually
+	// pre-frames the content that's about to land.
+	const card = document.createElement( 'wpd-card' );
+	card.classList.add(
+		'desktop-mode-plugins__card',
+		'desktop-mode-plugins__card--skeleton',
+	);
+	card.setAttribute( 'aria-hidden', 'true' );
+	for ( let i = 0; i < 4; i++ ) {
+		const line = document.createElement( 'span' );
+		line.className = 'desktop-mode-plugins__skeleton-line';
+		line.style.width = `${ 50 + ( i * 17 ) % 50 }%`;
+		card.appendChild( line );
+	}
+	return card;
+}
+
+function indexKeyFor( plugin: InstalledPlugin ): string {
+	// Prefer the textdomain (matches wp.org slug) so the cross-lookup
+	// from a Browse card works. Fall back to the plugin file path on
+	// installs without a Text Domain header.
+	return plugin.textdomain || plugin.plugin;
+}
+
+function describe( err: unknown ): string {
+	if ( err instanceof Error ) {
+		return err.message;
+	}
+	return String( err );
+}

--- a/src/plugins-window/card-drag.ts
+++ b/src/plugins-window/card-drag.ts
@@ -1,0 +1,233 @@
+/**
+ * Native Plugins window — drag plugin cards to the dock to pin.
+ *
+ * Wires every card element as a drag source for the framework's
+ * `wp.desktop.dragManager`. Payload type is `'wporg-plugin'` so any
+ * plugin author can register their own drop targets that accept it.
+ *
+ * Drop targets we install:
+ *
+ *   - `dock` — calls `wp.desktop.registerSystemTile()` to create a
+ *     transient dock entry that opens a window to the plugin's
+ *     wp.org page. Lives for the session; not persisted.
+ *
+ * Wallpaper drop (creating a desktop icon) is deferred to a
+ * follow-up — needs a server-side persistence path that doesn't yet
+ * exist for client-only icons.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __, sprintf } from '../i18n';
+import { pickIcon } from './card';
+import type { WpOrgBrowsePlugin } from './types';
+
+interface SystemTileShape {
+	id: string;
+	title: string;
+	icon?: string;
+	url?: string;
+}
+
+interface DragManagerLite {
+	start( opts: {
+		payload: {
+			type: string;
+			source: HTMLElement;
+			data: Record< string, unknown >;
+			ghost?: { offsetX: number; offsetY: number; element?: HTMLElement };
+		};
+		origin: PointerEvent;
+		onClickOnly?: () => void;
+	} ): { isFinished(): boolean } | null;
+	registerDropTarget( target: {
+		id: string;
+		element: HTMLElement;
+		accept: ( payload: { type: string } ) => boolean;
+		onEnter?: () => void;
+		onLeave?: () => void;
+		onDrop: ( session: { payload: { data: Record< string, unknown > } } ) => void;
+	} ): () => void;
+}
+
+interface DesktopApi {
+	dragManager?: DragManagerLite;
+	registerSystemTile?: ( tile: SystemTileShape ) => void;
+	showToast?: ( opts: { message: string; duration?: number } ) => void;
+}
+
+function api(): DesktopApi | null {
+	return ( window.wp?.desktop ?? null ) as DesktopApi | null;
+}
+
+/**
+ * Mark a plugin card element as a drag source. Must be called for
+ * every card that's added to the gallery. Idempotent — safe to call
+ * twice on the same element.
+ */
+export function makeCardDraggable(
+	card: HTMLElement,
+	plugin: WpOrgBrowsePlugin,
+): void {
+	if ( card.dataset.dragWired === '1' ) {
+		return;
+	}
+	card.dataset.dragWired = '1';
+
+	card.addEventListener( 'pointerdown', ( ev: PointerEvent ) => {
+		const desktop = api();
+		const manager = desktop?.dragManager;
+		if ( ! manager ) {
+			return;
+		}
+		// Don't escalate when the user clicked the CTA — they're
+		// triggering an action, not starting a drag.
+		const t = ev.target as HTMLElement | null;
+		if ( t?.closest( '[data-plugin-card-cta]' ) ) {
+			return;
+		}
+		manager.start( {
+			payload: {
+				type: 'wporg-plugin',
+				source: card,
+				data: {
+					slug: plugin.slug,
+					name: plugin.name,
+					iconUrl: pickIcon( plugin.icons ) ?? null,
+					homepage: plugin.homepage ?? '',
+					authorName: stripHtml( plugin.author ?? '' ),
+					shortDescription: plugin.short_description ?? '',
+				},
+				ghost: buildGhost( plugin, card, ev ),
+			},
+			origin: ev,
+			onClickOnly: () => {
+				/* The card's own click handler runs; nothing to do. */
+			},
+		} );
+	} );
+}
+
+/**
+ * Install the framework drop targets that accept `wporg-plugin`
+ * payloads. Returns a teardown that removes every registered target.
+ *
+ * Currently: dock (pin a system tile). Wallpaper deferred.
+ */
+export function installPluginDropTargets(): () => void {
+	const desktop = api();
+	const manager = desktop?.dragManager;
+	if ( ! manager ) {
+		return () => {};
+	}
+
+	const teardowns: Array< () => void > = [];
+
+	const dock = findDockElement();
+	if ( dock ) {
+		const off = manager.registerDropTarget( {
+			id: 'desktop-mode-plugins-window/dock',
+			element: dock,
+			accept: ( p ) => p.type === 'wporg-plugin',
+			onEnter: () => {
+				dock.setAttribute( 'data-plugins-card-drop-active', '' );
+			},
+			onLeave: () => {
+				dock.removeAttribute( 'data-plugins-card-drop-active' );
+			},
+			onDrop: ( session ) => {
+				dock.removeAttribute( 'data-plugins-card-drop-active' );
+				const data = session.payload.data;
+				const slug = String( data.slug ?? '' );
+				if ( ! slug ) {
+					return;
+				}
+				const name = String( data.name ?? slug );
+				const icon = typeof data.iconUrl === 'string' && data.iconUrl
+					? data.iconUrl
+					: 'dashicons-admin-plugins';
+				const homepage = String( data.homepage ?? '' );
+				const url = homepage !== ''
+					? homepage
+					: `https://wordpress.org/plugins/${ encodeURIComponent( slug ) }/`;
+
+				if ( typeof desktop?.registerSystemTile === 'function' ) {
+					desktop.registerSystemTile( {
+						id: `wporg-plugin-${ slug }`,
+						title: name,
+						icon,
+						url,
+					} );
+				}
+				if ( typeof desktop?.showToast === 'function' ) {
+					desktop.showToast( {
+						message: sprintf(
+							/* translators: %s: plugin name */
+							__( 'Pinned %s to the dock.', 'desktop-mode' ),
+							name,
+						),
+						duration: 3500,
+					} );
+				}
+			},
+		} );
+		teardowns.push( off );
+	}
+
+	return () => {
+		for ( const off of teardowns ) {
+			try {
+				off();
+			} catch {
+				/* best-effort cleanup */
+			}
+		}
+	};
+}
+
+function findDockElement(): HTMLElement | null {
+	// Match the canonical dock root selectors used by `dock-rail-renderer`
+	// and `bottomDock` paint. Order matters — bottom dock first because
+	// it's on top in the spatial layout.
+	return (
+		document.querySelector< HTMLElement >( '.desktop-mode-bottom-dock' ) ??
+		document.querySelector< HTMLElement >( '.desktop-mode-dock' ) ??
+		document.querySelector< HTMLElement >( '[data-desktop-mode-dock]' )
+	);
+}
+
+function buildGhost(
+	plugin: WpOrgBrowsePlugin,
+	card: HTMLElement,
+	origin: PointerEvent,
+): { offsetX: number; offsetY: number; element?: HTMLElement } {
+	const rect = card.getBoundingClientRect();
+	const offsetX = origin.clientX - rect.left;
+	const offsetY = origin.clientY - rect.top;
+
+	const ghost = document.createElement( 'div' );
+	ghost.className = 'desktop-mode-plugins__drag-ghost';
+	const iconUrl = pickIcon( plugin.icons );
+	if ( iconUrl ) {
+		const img = document.createElement( 'img' );
+		img.src = iconUrl;
+		img.alt = '';
+		ghost.appendChild( img );
+	} else {
+		const fallback = document.createElement( 'span' );
+		fallback.className =
+			'dashicons dashicons-admin-plugins desktop-mode-plugins__drag-ghost-fallback';
+		ghost.appendChild( fallback );
+	}
+	const label = document.createElement( 'span' );
+	label.textContent = plugin.name;
+	ghost.appendChild( label );
+	return { offsetX, offsetY, element: ghost };
+}
+
+function stripHtml( html: string ): string {
+	const tmp = document.createElement( 'div' );
+	tmp.innerHTML = html;
+	return tmp.textContent ?? '';
+}

--- a/src/plugins-window/card.ts
+++ b/src/plugins-window/card.ts
@@ -1,0 +1,349 @@
+/**
+ * Native Plugins window — gallery card factory.
+ *
+ * Renders a single wp.org plugin as a clickable card. Whole card click
+ * opens the detail flyout; a primary CTA on the card surfaces the
+ * fast path (Install / Activate / Open). Hover lift + image fade-in
+ * are CSS-only (`assets/css/plugins-window.css`).
+ *
+ * The card also escalates pointer-down to the framework's drag
+ * bridge so the user can drag a card to the dock (pin) — we don't
+ * install drop targets here; that's `card-drag.ts`'s job.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __, sprintf } from '../i18n';
+import type { InstalledPlugin, WpOrgBrowsePlugin } from './types';
+
+/**
+ * What the card knows about an installed counterpart, so the CTA can
+ * say "Activate" / "Active" instead of "Install" when the plugin is
+ * already on disk.
+ */
+export type InstalledIndex = Map< string, InstalledPlugin >;
+
+export interface CardCallbacks {
+	onOpen: ( slug: string, hint?: WpOrgBrowsePlugin ) => void;
+	onInstall: ( plugin: WpOrgBrowsePlugin, card: HTMLElement ) => Promise< void >;
+	onActivate: ( installed: InstalledPlugin, card: HTMLElement ) => Promise< void >;
+}
+
+/** Render a single card. */
+export function buildCard(
+	plugin: WpOrgBrowsePlugin,
+	installed: InstalledIndex,
+	callbacks: CardCallbacks,
+): HTMLElement {
+	// `<wpd-card interactive>` gives us the focusable + click-emitting
+	// behaviour the gallery needs without any handcoded ARIA / role /
+	// tabindex / hover-lift CSS. The component dispatches
+	// `wpd-card-click` skipping `[data-noclick]` descendants — the CTA
+	// button below opts out via that attribute, so we don't need a
+	// per-event `event.target.closest()` guard.
+	const card = document.createElement( 'wpd-card' );
+	card.classList.add( 'desktop-mode-plugins__card' );
+	card.setAttribute( 'interactive', '' );
+	card.dataset.slug = plugin.slug;
+	card.setAttribute(
+		'aria-label',
+		sprintf(
+			/* translators: %s: plugin name */
+			__( 'View details for %s', 'desktop-mode' ),
+			plugin.name,
+		),
+	);
+
+	// ─── Header (icon + title + author) ─────────────────────────────
+	// Plain `<header>` slot — `<wpd-card>` styles the slotted element
+	// as a flex row with a 12px gap automatically.
+	const header = document.createElement( 'header' );
+	header.className = 'desktop-mode-plugins__card-header';
+
+	const iconWrap = document.createElement( 'div' );
+	iconWrap.className = 'desktop-mode-plugins__card-icon';
+	const iconUrl = pickIcon( plugin.icons );
+	if ( iconUrl ) {
+		const img = document.createElement( 'img' );
+		img.src = iconUrl;
+		img.alt = '';
+		img.loading = 'lazy';
+		img.decoding = 'async';
+		img.addEventListener(
+			'load',
+			() => img.classList.add( 'is-loaded' ),
+		);
+		img.addEventListener( 'error', () => {
+			iconWrap.replaceChildren( buildFallbackGlyph() );
+		} );
+		iconWrap.appendChild( img );
+	} else {
+		iconWrap.appendChild( buildFallbackGlyph() );
+	}
+
+	const titleBlock = document.createElement( 'div' );
+	titleBlock.className = 'desktop-mode-plugins__card-titleblock';
+	const title = document.createElement( 'h3' );
+	title.className = 'desktop-mode-plugins__card-title';
+	title.textContent = decodeEntities( plugin.name );
+	const byline = document.createElement( 'p' );
+	byline.className = 'desktop-mode-plugins__card-byline';
+	byline.innerHTML = sprintf(
+		/* translators: %s: plugin author name (HTML-stripped) */
+		__( 'by %s', 'desktop-mode' ),
+		`<span>${ escapeHtml( stripHtml( plugin.author ?? '' ) ) }</span>`,
+	);
+	titleBlock.append( title, byline );
+
+	header.setAttribute( 'slot', 'header' );
+	header.append( iconWrap, titleBlock );
+
+	// ─── Description ─────────────────────────────────────────────────
+	const desc = document.createElement( 'p' );
+	desc.className = 'desktop-mode-plugins__card-desc';
+	desc.textContent = decodeEntities( plugin.short_description ?? '' );
+
+	// ─── Footer (rating + installs + CTA) ───────────────────────────
+	const footer = document.createElement( 'footer' );
+	footer.className = 'desktop-mode-plugins__card-footer';
+	footer.setAttribute( 'slot', 'footer' );
+
+	const meta = document.createElement( 'div' );
+	meta.className = 'desktop-mode-plugins__card-meta';
+	meta.appendChild( buildStarCluster( plugin.rating ?? 0, plugin.num_ratings ?? 0 ) );
+	const installs = document.createElement( 'span' );
+	installs.className = 'desktop-mode-plugins__card-installs';
+	installs.textContent = formatInstalls( plugin.active_installs ?? 0 );
+	meta.appendChild( installs );
+
+	const cta = buildCta( plugin, installed, callbacks, card );
+
+	footer.append( meta, cta );
+
+	card.append( header, desc, footer );
+
+	// `<wpd-card interactive>` already handles role / tabindex /
+	// click + keyboard activation and skips `[data-noclick]`
+	// descendants. We just listen for its `wpd-card-click` event.
+	card.addEventListener( 'wpd-card-click', () => {
+		callbacks.onOpen( plugin.slug, plugin );
+	} );
+
+	return card;
+}
+
+/** Recompute the CTA after install / activate state changes. */
+export function repaintCardCta(
+	card: HTMLElement,
+	plugin: WpOrgBrowsePlugin,
+	installed: InstalledIndex,
+	callbacks: CardCallbacks,
+): void {
+	const footer = card.querySelector< HTMLElement >(
+		'.desktop-mode-plugins__card-footer',
+	);
+	if ( ! footer ) {
+		return;
+	}
+	const previous = footer.querySelector< HTMLElement >(
+		'[data-plugin-card-cta]',
+	);
+	if ( previous ) {
+		previous.remove();
+	}
+	footer.appendChild( buildCta( plugin, installed, callbacks, card ) );
+}
+
+function buildCta(
+	plugin: WpOrgBrowsePlugin,
+	installed: InstalledIndex,
+	callbacks: CardCallbacks,
+	card: HTMLElement,
+): HTMLElement {
+	const installedRow = installed.get( plugin.slug );
+	const button = document.createElement( 'wpd-button' );
+	button.setAttribute( 'data-plugin-card-cta', '' );
+	button.setAttribute( 'data-noclick', '' );
+	if ( installedRow ) {
+		if (
+			installedRow.status === 'active' ||
+			installedRow.status === 'active-network'
+		) {
+			button.setAttribute( 'variant', 'ghost' );
+			button.setAttribute( 'disabled', '' );
+			button.textContent = __( 'Active', 'desktop-mode' );
+		} else {
+			button.setAttribute( 'variant', 'primary' );
+			button.textContent = __( 'Activate', 'desktop-mode' );
+			button.addEventListener( 'click', ( ev ) => {
+				ev.stopPropagation();
+				void callbacks.onActivate( installedRow, card );
+			} );
+		}
+	} else {
+		button.setAttribute( 'variant', 'primary' );
+		button.textContent = __( 'Install', 'desktop-mode' );
+		button.addEventListener( 'click', ( ev ) => {
+			ev.stopPropagation();
+			void callbacks.onInstall( plugin, card );
+		} );
+	}
+	return button;
+}
+
+/**
+ * Render a 5-star cluster using `<wpd-icon>` glyphs. Half-star
+ * support: ratings come back as 0–100 from wp.org.
+ */
+export function buildStarCluster(
+	rating0to100: number,
+	totalRatings: number,
+): HTMLElement {
+	const wrap = document.createElement( 'span' );
+	wrap.className = 'desktop-mode-plugins__stars';
+	wrap.setAttribute( 'aria-label', formatStarsAriaLabel( rating0to100 ) );
+
+	const stars5 = Math.max( 0, Math.min( 5, ( rating0to100 / 100 ) * 5 ) );
+	const full = Math.floor( stars5 );
+	const half = stars5 - full >= 0.5 ? 1 : 0;
+	const empty = 5 - full - half;
+	for ( let i = 0; i < full; i++ ) {
+		wrap.appendChild( buildStar( 'filled' ) );
+	}
+	for ( let i = 0; i < half; i++ ) {
+		wrap.appendChild( buildStar( 'half' ) );
+	}
+	for ( let i = 0; i < empty; i++ ) {
+		wrap.appendChild( buildStar( 'empty' ) );
+	}
+
+	if ( totalRatings > 0 ) {
+		const count = document.createElement( 'span' );
+		count.className = 'desktop-mode-plugins__stars-count';
+		count.textContent = `(${ formatThousands( totalRatings ) })`;
+		wrap.appendChild( count );
+	}
+	return wrap;
+}
+
+function buildStar( kind: 'filled' | 'half' | 'empty' ): HTMLElement {
+	const span = document.createElement( 'span' );
+	span.className = 'desktop-mode-plugins__star';
+	span.setAttribute( 'aria-hidden', 'true' );
+	const icon = document.createElement( 'span' );
+	if ( kind === 'filled' ) {
+		icon.className = 'dashicons dashicons-star-filled';
+	} else if ( kind === 'half' ) {
+		icon.className = 'dashicons dashicons-star-half';
+	} else {
+		icon.className = 'dashicons dashicons-star-empty';
+	}
+	span.appendChild( icon );
+	return span;
+}
+
+function buildFallbackGlyph(): HTMLElement {
+	const fallback = document.createElement( 'span' );
+	fallback.className =
+		'dashicons dashicons-admin-plugins desktop-mode-plugins__card-icon-fallback';
+	fallback.setAttribute( 'aria-hidden', 'true' );
+	return fallback;
+}
+
+/** Pick the best available icon URL (svg > 256 > 128 > 1x). */
+export function pickIcon(
+	icons: Record< string, string > | undefined,
+): string | null {
+	if ( ! icons ) {
+		return null;
+	}
+	return (
+		icons.svg ??
+		icons[ '256' ] ??
+		icons[ '256x256' ] ??
+		icons.default ??
+		icons[ '128' ] ??
+		icons[ '128x128' ] ??
+		icons[ '2x' ] ??
+		icons[ '1x' ] ??
+		Object.values( icons )[ 0 ] ??
+		null
+	);
+}
+
+/**
+ * Format an active-installs count like wp.org does:
+ *   - 50         → "50+ active"
+ *   - 1,234      → "1,000+ active"
+ *   - 100,000    → "100,000+ active"
+ *   - 5,000,000  → "5+ million active"
+ */
+function formatInstalls( n: number ): string {
+	if ( n <= 0 ) {
+		return __( 'Fewer than 10 active', 'desktop-mode' );
+	}
+	if ( n >= 1_000_000 ) {
+		const millions = Math.floor( n / 1_000_000 );
+		return sprintf(
+			/* translators: %d: integer number of millions of active installs */
+			__( '%d+ million active', 'desktop-mode' ),
+			millions,
+		);
+	}
+	if ( n >= 1000 ) {
+		return sprintf(
+			/* translators: %s: comma-grouped active install count */
+			__( '%s+ active', 'desktop-mode' ),
+			formatThousands( roundTo3SigFigs( n ) ),
+		);
+	}
+	return sprintf(
+		/* translators: %s: comma-grouped active install count */
+		__( '%s+ active', 'desktop-mode' ),
+		formatThousands( n ),
+	);
+}
+
+function roundTo3SigFigs( n: number ): number {
+	const order = Math.pow( 10, Math.floor( Math.log10( n ) ) - 2 );
+	return Math.floor( n / order ) * order;
+}
+
+function formatStarsAriaLabel( rating0to100: number ): string {
+	const stars5 = Math.max( 0, Math.min( 5, ( rating0to100 / 100 ) * 5 ) );
+	return sprintf(
+		/* translators: %s: rating out of 5 (one decimal) */
+		__( 'Rated %s out of 5', 'desktop-mode' ),
+		stars5.toFixed( 1 ),
+	);
+}
+
+function formatThousands( n: number ): string {
+	try {
+		return new Intl.NumberFormat().format( n );
+	} catch {
+		return String( n );
+	}
+}
+
+const _entityCache = document.createElement( 'textarea' );
+function decodeEntities( html: string ): string {
+	if ( ! html ) {
+		return '';
+	}
+	_entityCache.innerHTML = html;
+	return _entityCache.value;
+}
+
+function escapeHtml( raw: string ): string {
+	const tmp = document.createElement( 'div' );
+	tmp.textContent = raw;
+	return tmp.innerHTML;
+}
+
+function stripHtml( html: string ): string {
+	const tmp = document.createElement( 'div' );
+	tmp.innerHTML = html;
+	return tmp.textContent ?? '';
+}

--- a/src/plugins-window/flyout-detail.ts
+++ b/src/plugins-window/flyout-detail.ts
@@ -1,0 +1,879 @@
+/**
+ * Native Plugins window — detail flyout.
+ *
+ * Slides in from the inline-end edge over the active tab. Sticky
+ * hero (banner background + icon + name + author + rating + active
+ * installs) plus `<wpd-tabs>` for Overview / Screenshots / Reviews /
+ * Changelog / FAQ. Action footer pinned to the bottom: Install /
+ * Activate / Deactivate / Delete + a "View on WordPress.org" link.
+ *
+ * `plugin_information` lazy-fetches on flyout open ONLY (never per
+ * card). Reviews lazy-fetch on Reviews tab activation.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __, sprintf } from '../i18n';
+import { buildStarCluster, pickIcon } from './card';
+import {
+	activateInstalledPlugin,
+	deactivateInstalledPlugin,
+	deleteInstalledPlugin,
+	fetchPluginInfo,
+	fetchPluginReviews,
+	getConfig,
+	installPluginBySlug,
+	refreshFrameworkMenu,
+} from './rest';
+import type {
+	InstalledPlugin,
+	WpOrgBrowsePlugin,
+	WpOrgPluginInfo,
+} from './types';
+
+interface FlyoutCallbacks {
+	getInstalled: ( slug: string ) => InstalledPlugin | undefined;
+	onPluginInstalled: ( pluginFile: string, slug: string ) => Promise< void >;
+	onPluginActivated: ( plugin: InstalledPlugin ) => void;
+	onPluginDeactivated: ( plugin: InstalledPlugin ) => void;
+	onPluginDeleted: ( plugin: InstalledPlugin ) => void;
+}
+
+/** Toast helper, shell-routed when available. */
+function toast( message: string, duration = 3500 ): void {
+	const api = window.wp?.desktop;
+	if ( api && typeof api.showToast === 'function' ) {
+		api.showToast( { message, duration } );
+		return;
+	}
+	// eslint-disable-next-line no-console
+	console.log( '[plugins-window]', message );
+}
+
+/** Confirm-dialog helper, shell-routed when available. */
+async function confirm( opts: {
+	title?: string;
+	message: string;
+	confirmLabel?: string;
+	danger?: boolean;
+} ): Promise< boolean > {
+	const api = window.wp?.desktop;
+	if ( api && typeof api.confirm === 'function' ) {
+		return api.confirm( opts );
+	}
+	return Promise.resolve( true );
+}
+
+/**
+ * Open the detail flyout for the given slug. The flyout element is
+ * already in the template (`data-desktop-mode-plugins-flyout`) — we
+ * paint into it.
+ */
+export function openDetailFlyout(
+	flyout: HTMLElement,
+	slug: string,
+	hint: WpOrgBrowsePlugin | undefined,
+	callbacks: FlyoutCallbacks,
+): void {
+	flyout.replaceChildren();
+
+	const card = document.createElement( 'div' );
+	card.className = 'desktop-mode-plugins__flyout';
+
+	// Build skeleton sections; we'll fill in once `plugin_information`
+	// resolves, but render the hint header eagerly so the user sees
+	// something IMMEDIATELY (no flash-of-empty).
+	const hero = buildHeroSkeleton( hint );
+	const tabs = buildTabs();
+	const body = document.createElement( 'div' );
+	body.className = 'desktop-mode-plugins__flyout-body';
+	const footer = document.createElement( 'footer' );
+	footer.className = 'desktop-mode-plugins__flyout-footer';
+
+	card.append( hero.root, tabs.root, body, footer );
+	flyout.appendChild( card );
+	flyout.setAttribute( 'open', '' );
+
+	let info: WpOrgPluginInfo | null = null;
+	const reviewsCache = { loaded: false };
+
+	const refreshFooter = (): void => {
+		paintFooter( footer, slug, info, callbacks, () => closeFlyout( flyout ) );
+	};
+	refreshFooter();
+
+	tabs.onChange( ( tab ) => {
+		paintTabBody( body, tab, info, slug, reviewsCache );
+	} );
+
+	// Initial body — Overview shows the skeleton hint description until
+	// `plugin_information` lands.
+	paintTabBody( body, 'overview', info, slug, reviewsCache );
+
+	// Lazy-fetch the rich detail.
+	void ( async () => {
+		try {
+			info = await fetchPluginInfo( slug );
+			paintHero( hero, info );
+			refreshFooter();
+			const current = tabs.current();
+			paintTabBody( body, current, info, slug, reviewsCache );
+		} catch ( err ) {
+			body.innerHTML = '';
+			const failure = document.createElement( 'p' );
+			failure.className = 'desktop-mode-plugins__flyout-error';
+			failure.textContent =
+				err instanceof Error
+					? err.message
+					: __( 'Could not load plugin details.', 'desktop-mode' );
+			body.appendChild( failure );
+		}
+	} )();
+}
+
+function closeFlyout( flyout: HTMLElement ): void {
+	flyout.removeAttribute( 'open' );
+}
+
+function buildHeroSkeleton( hint?: WpOrgBrowsePlugin ): {
+	root: HTMLElement;
+	icon: HTMLElement;
+	title: HTMLElement;
+	byline: HTMLElement;
+	stars: HTMLElement;
+	meta: HTMLElement;
+	banner: HTMLElement;
+} {
+	const root = document.createElement( 'header' );
+	root.className = 'desktop-mode-plugins__flyout-hero';
+
+	const banner = document.createElement( 'div' );
+	banner.className = 'desktop-mode-plugins__flyout-banner';
+	root.appendChild( banner );
+
+	const inner = document.createElement( 'div' );
+	inner.className = 'desktop-mode-plugins__flyout-hero-inner';
+
+	const icon = document.createElement( 'div' );
+	icon.className = 'desktop-mode-plugins__flyout-hero-icon';
+
+	const text = document.createElement( 'div' );
+	text.className = 'desktop-mode-plugins__flyout-hero-text';
+	const title = document.createElement( 'h2' );
+	title.className = 'desktop-mode-plugins__flyout-hero-title';
+	const byline = document.createElement( 'p' );
+	byline.className = 'desktop-mode-plugins__flyout-hero-byline';
+	const meta = document.createElement( 'div' );
+	meta.className = 'desktop-mode-plugins__flyout-hero-meta';
+	const stars = document.createElement( 'div' );
+	stars.className = 'desktop-mode-plugins__flyout-hero-stars';
+	meta.appendChild( stars );
+
+	text.append( title, byline, meta );
+	inner.append( icon, text );
+
+	root.appendChild( inner );
+
+	// Circular glass close button — pinned top-right, floats over the
+	// banner. Plain `<button>` so we can inline-style every visual
+	// without fighting `<wpd-button>`'s own padding/min-width. The
+	// `data-flyout-close` attribute is the contract `<wpd-flyout>`
+	// listens for, so the click still wires up to the framework's
+	// dismiss flow.
+	const close = document.createElement( 'button' );
+	close.type = 'button';
+	close.className = 'desktop-mode-plugins__flyout-close';
+	close.setAttribute( 'data-flyout-close', '' );
+	close.setAttribute(
+		'aria-label',
+		__( 'Close plugin details', 'desktop-mode' ),
+	);
+	// Stroke-based X — crisp at every DPR, scales with the button's
+	// `color` so the glass works in both light and color-scheme
+	// backgrounds.
+	close.innerHTML =
+		'<svg viewBox="0 0 24 24" width="14" height="14" fill="none" ' +
+		'stroke="currentColor" stroke-width="2.4" stroke-linecap="round" ' +
+		'aria-hidden="true">' +
+		'<path d="M18 6 L6 18"></path>' +
+		'<path d="M6 6 L18 18"></path>' +
+		'</svg>';
+	root.appendChild( close );
+
+	if ( hint ) {
+		title.textContent = hint.name;
+		byline.textContent = sprintf(
+			/* translators: %s: plugin author */
+			__( 'by %s', 'desktop-mode' ),
+			stripHtml( hint.author ?? '' ),
+		);
+		const iconUrl = pickIcon( hint.icons );
+		if ( iconUrl ) {
+			const img = document.createElement( 'img' );
+			img.src = iconUrl;
+			img.alt = '';
+			icon.appendChild( img );
+		}
+		stars.appendChild(
+			buildStarCluster( hint.rating ?? 0, hint.num_ratings ?? 0 ),
+		);
+	}
+
+	return { root, icon, title, byline, stars, meta, banner };
+}
+
+function paintHero(
+	parts: ReturnType< typeof buildHeroSkeleton >,
+	info: WpOrgPluginInfo,
+): void {
+	parts.title.textContent = info.name;
+	parts.byline.textContent = sprintf(
+		/* translators: %s: plugin author */
+		__( 'by %s', 'desktop-mode' ),
+		stripHtml( info.author ?? '' ),
+	);
+	parts.icon.replaceChildren();
+	const iconUrl = pickIcon( info.icons );
+	if ( iconUrl ) {
+		const img = document.createElement( 'img' );
+		img.src = iconUrl;
+		img.alt = '';
+		parts.icon.appendChild( img );
+	}
+	parts.stars.replaceChildren(
+		buildStarCluster( info.rating ?? 0, info.num_ratings ?? 0 ),
+	);
+
+	const bannerUrl = info.banners?.high ?? info.banners?.low;
+	if ( bannerUrl ) {
+		parts.banner.style.backgroundImage = `url("${ bannerUrl }")`;
+		parts.banner.classList.add( 'has-banner' );
+	}
+
+	// Trailing meta line: active installs + last updated + tested up to.
+	parts.meta.querySelectorAll( ':scope > .desktop-mode-plugins__flyout-meta-row' ).forEach( ( n ) => n.remove() );
+	const metaRow = document.createElement( 'div' );
+	metaRow.className = 'desktop-mode-plugins__flyout-meta-row';
+	const installs = document.createElement( 'span' );
+	installs.textContent = sprintf(
+		/* translators: %s: comma-grouped active install count */
+		__( '%s+ active', 'desktop-mode' ),
+		new Intl.NumberFormat().format( info.active_installs ?? 0 ),
+	);
+	const updated = document.createElement( 'span' );
+	updated.textContent = sprintf(
+		/* translators: %s: human-readable date string from wp.org */
+		__( 'Updated %s', 'desktop-mode' ),
+		humanDate( info.last_updated ),
+	);
+	const tested = document.createElement( 'span' );
+	tested.textContent = info.tested
+		? sprintf(
+			/* translators: %s: maximum tested WordPress version */
+			__( 'Tested up to WordPress %s', 'desktop-mode' ),
+			info.tested,
+		)
+		: '';
+	metaRow.append( installs, updated );
+	if ( tested.textContent ) {
+		metaRow.appendChild( tested );
+	}
+	parts.meta.appendChild( metaRow );
+}
+
+type DetailTab = 'overview' | 'screenshots' | 'reviews' | 'changelog' | 'faq';
+
+function buildTabs(): {
+	root: HTMLElement;
+	current: () => DetailTab;
+	onChange: ( cb: ( tab: DetailTab ) => void ) => void;
+	} {
+	const root = document.createElement( 'wpd-tabs' );
+	root.className = 'desktop-mode-plugins__flyout-tabs';
+	root.setAttribute( 'value', 'overview' );
+	const labels: Array< { value: DetailTab; label: string } > = [
+		{ value: 'overview', label: __( 'Overview', 'desktop-mode' ) },
+		{ value: 'screenshots', label: __( 'Screenshots', 'desktop-mode' ) },
+		{ value: 'reviews', label: __( 'Reviews', 'desktop-mode' ) },
+		{ value: 'changelog', label: __( 'Changelog', 'desktop-mode' ) },
+		{ value: 'faq', label: __( 'FAQ', 'desktop-mode' ) },
+	];
+	for ( const opt of labels ) {
+		const tab = document.createElement( 'wpd-tab' );
+		tab.setAttribute( 'value', opt.value );
+		tab.textContent = opt.label;
+		root.appendChild( tab );
+	}
+	let current: DetailTab = 'overview';
+	const subscribers = new Set<( tab: DetailTab ) => void >();
+	root.addEventListener( 'wpd-tab-change', ( ev: Event ) => {
+		const detail = ( ev as CustomEvent< { value: string } > ).detail;
+		const value = ( detail?.value ?? 'overview' ) as DetailTab;
+		current = value;
+		for ( const cb of subscribers ) {
+			cb( current );
+		}
+	} );
+	return {
+		root,
+		current: () => current,
+		onChange: ( cb ) => subscribers.add( cb ),
+	};
+}
+
+function paintTabBody(
+	body: HTMLElement,
+	tab: DetailTab,
+	info: WpOrgPluginInfo | null,
+	slug: string,
+	reviewsCache: { loaded: boolean },
+): void {
+	body.replaceChildren();
+	if ( ! info ) {
+		body.appendChild( buildSkeletonLines( 4 ) );
+		return;
+	}
+	if ( tab === 'overview' ) {
+		body.appendChild( buildHtmlSection( info.sections?.description ?? info.short_description ?? '' ) );
+		return;
+	}
+	if ( tab === 'screenshots' ) {
+		body.appendChild( buildScreenshots( info.screenshots ) );
+		return;
+	}
+	if ( tab === 'changelog' ) {
+		body.appendChild( buildHtmlSection( info.sections?.changelog ?? '' ) );
+		return;
+	}
+	if ( tab === 'faq' ) {
+		body.appendChild( buildHtmlSection( info.sections?.faq ?? '' ) );
+		return;
+	}
+	if ( tab === 'reviews' ) {
+		body.appendChild( buildRatingsHistogram( info ) );
+		const list = document.createElement( 'div' );
+		list.className = 'desktop-mode-plugins__reviews-list';
+		const loadingLine = document.createElement( 'p' );
+		loadingLine.className = 'desktop-mode-plugins__reviews-loading';
+		loadingLine.textContent = __( 'Loading recent reviews…', 'desktop-mode' );
+		list.appendChild( loadingLine );
+		body.appendChild( list );
+		if ( ! reviewsCache.loaded ) {
+			void ( async () => {
+				try {
+					const resp = await fetchPluginReviews( slug );
+					list.replaceChildren();
+					if ( ! resp.parsed || resp.items.length === 0 ) {
+						const fallback = document.createElement( 'p' );
+						fallback.className = 'desktop-mode-plugins__reviews-fallback';
+						fallback.innerHTML = sprintf(
+							/* translators: %s: anchor tag with link to wp.org reviews */
+							__(
+								'Recent reviews aren’t available right now. %s',
+								'desktop-mode',
+							),
+							`<a href="https://wordpress.org/plugins/${ encodeURIComponent( slug ) }/#reviews" target="_blank" rel="noopener">${ __(
+								'Read reviews on WordPress.org ↗',
+								'desktop-mode',
+							) }</a>`,
+						);
+						list.appendChild( fallback );
+					} else {
+						for ( const item of resp.items ) {
+							list.appendChild( buildReviewCard( item ) );
+						}
+					}
+					reviewsCache.loaded = true;
+				} catch {
+					list.replaceChildren();
+					const failure = document.createElement( 'p' );
+					failure.className = 'desktop-mode-plugins__reviews-fallback';
+					failure.textContent = __(
+						'Could not load reviews.',
+						'desktop-mode',
+					);
+					list.appendChild( failure );
+				}
+			} )();
+		}
+	}
+}
+
+function buildHtmlSection( html: string ): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'desktop-mode-plugins__html';
+	if ( ! html ) {
+		const empty = document.createElement( 'p' );
+		empty.className = 'desktop-mode-plugins__empty-line';
+		empty.textContent = __( 'No content available.', 'desktop-mode' );
+		wrap.appendChild( empty );
+		return wrap;
+	}
+	// wp.org returns HTML strings — sanitize before injection. Use a
+	// permissive whitelist: paragraphs, lists, headings, links, code,
+	// images. Anything else is stripped to text.
+	wrap.innerHTML = sanitizeHtml( html );
+	wrap.querySelectorAll( 'a' ).forEach( ( a ) => {
+		a.setAttribute( 'target', '_blank' );
+		a.setAttribute( 'rel', 'noopener nofollow' );
+	} );
+	return wrap;
+}
+
+function buildScreenshots(
+	shots: Record< string, { src: string; caption: string } > | undefined,
+): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'desktop-mode-plugins__screenshots';
+	const items = shots ? Object.values( shots ) : [];
+	if ( items.length === 0 ) {
+		const empty = document.createElement( 'p' );
+		empty.className = 'desktop-mode-plugins__empty-line';
+		empty.textContent = __(
+			'This plugin doesn’t ship screenshots.',
+			'desktop-mode',
+		);
+		wrap.appendChild( empty );
+		return wrap;
+	}
+	for ( const shot of items ) {
+		const fig = document.createElement( 'figure' );
+		fig.className = 'desktop-mode-plugins__screenshot';
+		const img = document.createElement( 'img' );
+		img.src = shot.src;
+		img.loading = 'lazy';
+		img.alt = shot.caption ?? '';
+		fig.appendChild( img );
+		if ( shot.caption ) {
+			const cap = document.createElement( 'figcaption' );
+			cap.innerHTML = sanitizeHtml( shot.caption );
+			fig.appendChild( cap );
+		}
+		wrap.appendChild( fig );
+	}
+	return wrap;
+}
+
+function buildRatingsHistogram( info: WpOrgPluginInfo ): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'desktop-mode-plugins__histogram';
+	const ratings = info.ratings ?? {};
+	const total = Object.values( ratings ).reduce(
+		( a, b ) => a + ( typeof b === 'number' ? b : 0 ),
+		0,
+	);
+	if ( total === 0 ) {
+		const empty = document.createElement( 'p' );
+		empty.className = 'desktop-mode-plugins__empty-line';
+		empty.textContent = __( 'No ratings yet.', 'desktop-mode' );
+		wrap.appendChild( empty );
+		return wrap;
+	}
+	for ( let star = 5; star >= 1; star-- ) {
+		const count = ratings[ String( star ) ] ?? 0;
+		const ratio = count / total;
+		const row = document.createElement( 'div' );
+		row.className = 'desktop-mode-plugins__histogram-row';
+		const label = document.createElement( 'span' );
+		label.className = 'desktop-mode-plugins__histogram-label';
+		label.textContent = sprintf(
+			/* translators: %d: number of stars (1–5) */
+			__( '%d ★', 'desktop-mode' ),
+			star,
+		);
+		const track = document.createElement( 'span' );
+		track.className = 'desktop-mode-plugins__histogram-track';
+		const fill = document.createElement( 'span' );
+		fill.className = 'desktop-mode-plugins__histogram-fill';
+		fill.style.width = `${ Math.round( ratio * 100 ) }%`;
+		track.appendChild( fill );
+		const num = document.createElement( 'span' );
+		num.className = 'desktop-mode-plugins__histogram-count';
+		num.textContent = new Intl.NumberFormat().format( count );
+		row.append( label, track, num );
+		wrap.appendChild( row );
+	}
+	return wrap;
+}
+
+function buildReviewCard( item: {
+	author: string;
+	stars: number;
+	excerpt: string;
+	date: string;
+	url: string;
+} ): HTMLElement {
+	const card = document.createElement( 'article' );
+	card.className = 'desktop-mode-plugins__review';
+	const head = document.createElement( 'header' );
+	head.className = 'desktop-mode-plugins__review-head';
+	const author = document.createElement( 'span' );
+	author.className = 'desktop-mode-plugins__review-author';
+	author.textContent = item.author || __( 'Anonymous', 'desktop-mode' );
+	const star = buildStarCluster( ( item.stars / 5 ) * 100, 0 );
+	head.append( author, star );
+	if ( item.date ) {
+		const date = document.createElement( 'time' );
+		date.className = 'desktop-mode-plugins__review-date';
+		date.textContent = item.date;
+		head.appendChild( date );
+	}
+	const body = document.createElement( 'p' );
+	body.className = 'desktop-mode-plugins__review-excerpt';
+	body.textContent = item.excerpt;
+	card.append( head, body );
+	if ( item.url ) {
+		const link = document.createElement( 'a' );
+		link.href = item.url;
+		link.target = '_blank';
+		link.rel = 'noopener nofollow';
+		link.textContent = __( 'Read on WordPress.org ↗', 'desktop-mode' );
+		link.className = 'desktop-mode-plugins__review-link';
+		card.appendChild( link );
+	}
+	return card;
+}
+
+function buildSkeletonLines( count: number ): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'desktop-mode-plugins__skeleton';
+	for ( let i = 0; i < count; i++ ) {
+		const line = document.createElement( 'span' );
+		line.className = 'desktop-mode-plugins__skeleton-line';
+		line.style.width = `${ 60 + ( i * 10 ) % 40 }%`;
+		wrap.appendChild( line );
+	}
+	return wrap;
+}
+
+function paintFooter(
+	footer: HTMLElement,
+	slug: string,
+	info: WpOrgPluginInfo | null,
+	callbacks: FlyoutCallbacks,
+	close: () => void,
+): void {
+	footer.replaceChildren();
+	const cfg = getConfig();
+
+	const installed = callbacks.getInstalled( slug );
+	const left = document.createElement( 'div' );
+	left.className = 'desktop-mode-plugins__flyout-footer-left';
+	const wpOrg = document.createElement( 'a' );
+	wpOrg.href = `https://wordpress.org/plugins/${ encodeURIComponent( slug ) }/`;
+	wpOrg.target = '_blank';
+	wpOrg.rel = 'noopener';
+	wpOrg.className = 'desktop-mode-plugins__flyout-wporg';
+	wpOrg.textContent = __( 'View on WordPress.org ↗', 'desktop-mode' );
+	left.appendChild( wpOrg );
+
+	const right = document.createElement( 'div' );
+	right.className = 'desktop-mode-plugins__flyout-footer-right';
+
+	if ( installed ) {
+		if ( cfg.caps.activate ) {
+			if (
+				installed.status === 'active' ||
+				installed.status === 'active-network'
+			) {
+				const btn = button( __( 'Deactivate', 'desktop-mode' ), 'secondary' );
+				btn.addEventListener( 'click', () => {
+					void doDeactivate();
+				} );
+				right.appendChild( btn );
+			} else {
+				const btn = button( __( 'Activate', 'desktop-mode' ), 'primary' );
+				btn.addEventListener( 'click', () => {
+					void doActivate();
+				} );
+				right.appendChild( btn );
+			}
+		}
+		if ( cfg.caps.delete && installed.status === 'inactive' ) {
+			const btn = button( __( 'Delete', 'desktop-mode' ), 'danger' );
+			btn.addEventListener( 'click', () => {
+				void doDelete();
+			} );
+			right.appendChild( btn );
+		}
+	} else if ( cfg.caps.install ) {
+		const btn = button( __( 'Install', 'desktop-mode' ), 'primary' );
+		btn.addEventListener( 'click', () => {
+			void doInstall( btn );
+		} );
+		right.appendChild( btn );
+	}
+
+	footer.append( left, right );
+
+	async function doInstall( btn: HTMLElement ): Promise< void > {
+		btn.setAttribute( 'busy', '' );
+		btn.setAttribute( 'disabled', '' );
+		try {
+			const result = await installPluginBySlug( slug );
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( 'Installed %s.', 'desktop-mode' ),
+					info?.name ?? slug,
+				),
+			);
+			await refreshFrameworkMenu();
+			await callbacks.onPluginInstalled( result.plugin ?? '', slug );
+			paintFooter( footer, slug, info, callbacks, close );
+		} catch ( err ) {
+			btn.removeAttribute( 'busy' );
+			btn.removeAttribute( 'disabled' );
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Install failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+
+	async function doActivate(): Promise< void > {
+		if ( ! installed ) {
+			return;
+		}
+		try {
+			const updated = await activateInstalledPlugin( installed );
+			callbacks.onPluginActivated( updated );
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( '%s activated.', 'desktop-mode' ),
+					updated.name || updated.plugin,
+				),
+			);
+			await refreshFrameworkMenu();
+			paintFooter( footer, slug, info, callbacks, close );
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Activation failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+
+	async function doDeactivate(): Promise< void > {
+		if ( ! installed ) {
+			return;
+		}
+		try {
+			const updated = await deactivateInstalledPlugin( installed );
+			callbacks.onPluginDeactivated( updated );
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( '%s deactivated.', 'desktop-mode' ),
+					updated.name || updated.plugin,
+				),
+			);
+			await refreshFrameworkMenu();
+			paintFooter( footer, slug, info, callbacks, close );
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Deactivation failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+
+	async function doDelete(): Promise< void > {
+		if ( ! installed ) {
+			return;
+		}
+		const ok = await confirm( {
+			title: __( 'Delete plugin?', 'desktop-mode' ),
+			message: sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'Permanently delete %s? Its files will be removed from disk. This cannot be undone.',
+					'desktop-mode',
+				),
+				installed.name || installed.plugin,
+			),
+			confirmLabel: __( 'Delete', 'desktop-mode' ),
+			danger: true,
+		} );
+		if ( ! ok ) {
+			return;
+		}
+		try {
+			await deleteInstalledPlugin( installed );
+			callbacks.onPluginDeleted( installed );
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( '%s deleted.', 'desktop-mode' ),
+					installed.name || installed.plugin,
+				),
+			);
+			await refreshFrameworkMenu();
+			close();
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Delete failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+}
+
+function button( label: string, variant: string ): HTMLElement {
+	const b = document.createElement( 'wpd-button' );
+	b.setAttribute( 'variant', variant );
+	b.textContent = label;
+	return b;
+}
+
+/**
+ * Permissive HTML allow-list for `description` / `changelog` / `faq`
+ * sections. Strips scripts, iframes, event handlers; keeps headings,
+ * paragraphs, lists, links, images, code blocks.
+ */
+function sanitizeHtml( html: string ): string {
+	const allowed = new Set( [
+		'A',
+		'ABBR',
+		'B',
+		'BLOCKQUOTE',
+		'BR',
+		'CODE',
+		'DD',
+		'DEL',
+		'DIV',
+		'DL',
+		'DT',
+		'EM',
+		'FIGCAPTION',
+		'FIGURE',
+		'H1',
+		'H2',
+		'H3',
+		'H4',
+		'H5',
+		'H6',
+		'HR',
+		'I',
+		'IMG',
+		'KBD',
+		'LI',
+		'OL',
+		'P',
+		'PRE',
+		'Q',
+		'S',
+		'SMALL',
+		'SPAN',
+		'STRONG',
+		'SUB',
+		'SUP',
+		'TABLE',
+		'TBODY',
+		'TD',
+		'TFOOT',
+		'TH',
+		'THEAD',
+		'TR',
+		'U',
+		'UL',
+	] );
+	const allowedAttrs = new Set( [
+		'href',
+		'src',
+		'alt',
+		'title',
+		'name',
+		'rel',
+		'target',
+		'colspan',
+		'rowspan',
+	] );
+
+	const wrap = document.createElement( 'div' );
+	wrap.innerHTML = html;
+	const walker = document.createTreeWalker( wrap, NodeFilter.SHOW_ELEMENT );
+	const toRemove: Element[] = [];
+	let current: Element | null = walker.currentNode as Element;
+	while ( current ) {
+		const next = walker.nextNode() as Element | null;
+		if ( current === wrap ) {
+			current = next;
+			continue;
+		}
+		if ( ! allowed.has( current.tagName ) ) {
+			toRemove.push( current );
+		} else {
+			for ( const attr of Array.from( current.attributes ) ) {
+				if ( ! allowedAttrs.has( attr.name.toLowerCase() ) ) {
+					current.removeAttribute( attr.name );
+				}
+			}
+			if ( current.tagName === 'A' ) {
+				const href = current.getAttribute( 'href' ) ?? '';
+				if ( href.startsWith( 'javascript:' ) ) {
+					current.removeAttribute( 'href' );
+				}
+			}
+			if ( current.tagName === 'IMG' ) {
+				const src = current.getAttribute( 'src' ) ?? '';
+				if ( src.startsWith( 'javascript:' ) ) {
+					current.removeAttribute( 'src' );
+				}
+			}
+		}
+		current = next;
+	}
+	for ( const el of toRemove ) {
+		const text = document.createTextNode( el.textContent ?? '' );
+		el.replaceWith( text );
+	}
+	return wrap.innerHTML;
+}
+
+function describe( err: unknown ): string {
+	if ( err instanceof Error ) {
+		return err.message;
+	}
+	return String( err );
+}
+
+function stripHtml( html: string ): string {
+	const tmp = document.createElement( 'div' );
+	tmp.innerHTML = html;
+	return tmp.textContent ?? '';
+}
+
+function humanDate( raw: string | undefined ): string {
+	if ( ! raw ) {
+		return '—';
+	}
+	const m = /^(\d{4})-(\d{2})-(\d{2})/.exec( raw );
+	if ( m ) {
+		const date = new Date( Date.UTC( +m[ 1 ], +m[ 2 ] - 1, +m[ 3 ] ) );
+		try {
+			return date.toLocaleDateString();
+		} catch {
+			return raw;
+		}
+	}
+	return raw;
+}

--- a/src/plugins-window/index.ts
+++ b/src/plugins-window/index.ts
@@ -1,0 +1,224 @@
+/**
+ * Native Plugins window — render entry point.
+ *
+ * Lazy-loaded by the native-window sync the first time the
+ * `desktop-mode-plugins` window opens. Wires the two-tab shell
+ * (Installed / Browse) and the detail flyout against the template
+ * echoed by `desktop_mode_plugins_window_render_template()`.
+ *
+ * The `<wpd-*>` web components are defined by the main desktop
+ * bundle; this module only consumes them. Avoid any side-effect
+ * imports from `src/ui/` so loading this bundle never tries to
+ * re-`customElements.define()` an existing tag.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { trackedFetch } from '../tracked-fetch';
+import { __ } from '../i18n';
+import { mountBrowseView } from './browse-view';
+import { mountInstalledView } from './installed-view';
+import { getConfig, type PluginsWindowConfig } from './rest';
+import {
+	consumePluginsWindowTab,
+	subscribePluginsWindowTab,
+	type PluginsWindowTab,
+} from './tab-target';
+
+/**
+ * Tag every native-window registry slot the same way the recycle-bin
+ * + posts-window bundles do. Returning a teardown is wired internally
+ * via the `desktop-mode-window-closed` event.
+ */
+type RenderCallback = ( body: HTMLElement ) => void;
+
+declare global {
+	interface Window {
+		desktopModeNativeWindows?: Record< string, RenderCallback | undefined >;
+	}
+}
+
+export type { PluginsWindowConfig } from './rest';
+
+/**
+ * Render entry. Called by the framework's native-window sync once
+ * the template has been cloned into the body.
+ */
+function renderPluginsWindow( body: HTMLElement ): void {
+	const root = body.querySelector< HTMLElement >(
+		'[data-desktop-mode-plugins-root]',
+	);
+	if ( ! root ) {
+		body.innerHTML =
+			'<p style="padding:20px;color:var(--wpd-fg-muted,#666);">' +
+			__( 'Plugins window template missing.', 'desktop-mode' ) +
+			'</p>';
+		return;
+	}
+
+	const config = getConfig();
+	const tabs = root.querySelector< HTMLElement >(
+		'[data-desktop-mode-plugins-tabs]',
+	);
+
+	// ─── Installed tab ─────────────────────────────────────────────
+	const installedHost = root.querySelector< HTMLElement >(
+		'[data-desktop-mode-plugins-installed-host]',
+	);
+	let installedTeardown: ( () => void ) | null = null;
+	if ( installedHost ) {
+		if ( config.caps.activate ) {
+			installedTeardown = mountInstalledView( installedHost );
+		} else {
+			installedHost.replaceChildren();
+			const msg = document.createElement( 'p' );
+			msg.style.padding = '20px';
+			msg.style.color = 'var(--wpd-fg-muted, #666)';
+			msg.textContent = __(
+				'You do not have permission to manage plugins.',
+				'desktop-mode',
+			);
+			installedHost.appendChild( msg );
+		}
+	}
+
+	// ─── Browse tab ─────────────────────────────────────────────────
+	const browseHost = root.querySelector< HTMLElement >(
+		'[data-desktop-mode-plugins-browse-host]',
+	);
+	const flyout = root.querySelector< HTMLElement >(
+		'[data-desktop-mode-plugins-flyout]',
+	);
+	let browseTeardown: ( () => void ) | null = null;
+	if ( browseHost && config.caps.install ) {
+		browseTeardown = mountBrowseView( browseHost, flyout, body );
+	}
+
+	// ─── Tab routing ───────────────────────────────────────────────
+	const applyTab = ( tab: PluginsWindowTab ): void => {
+		if ( ! tabs ) {
+			return;
+		}
+		// Browse hidden when the viewer can't install — never auto-flip
+		// the tab somewhere they can't see.
+		if ( tab === 'browse' && ! config.caps.install ) {
+			tabs.setAttribute( 'value', 'installed' );
+			return;
+		}
+		tabs.setAttribute( 'value', tab );
+	};
+
+	const initialTab = consumePluginsWindowTab();
+	if ( initialTab ) {
+		applyTab( initialTab );
+	}
+
+	const unsubscribeTab = subscribePluginsWindowTab( ( state ) => {
+		if ( state.tab ) {
+			applyTab( state.tab );
+		}
+	} );
+
+	// Cleanup on window close. The framework dispatches the event on
+	// `document` with `detail.windowId` matching the window being torn
+	// down — we only fire teardown for our own id.
+	const onClosed = ( ev: Event ): void => {
+		const detail = ( ev as CustomEvent< { windowId?: string } > ).detail;
+		if ( detail?.windowId !== 'desktop-mode-plugins' ) {
+			return;
+		}
+		document.removeEventListener( 'desktop-mode-window-closed', onClosed );
+		unsubscribeTab();
+		if ( installedTeardown ) {
+			installedTeardown();
+			installedTeardown = null;
+		}
+		if ( browseTeardown ) {
+			browseTeardown();
+			browseTeardown = null;
+		}
+	};
+	document.addEventListener( 'desktop-mode-window-closed', onClosed );
+
+	// First-open intro — gated on `config.introSeen`. Lazy-loaded
+	// (the dialog ships a chunk of inline-styled markup that we only
+	// pay for when the dialog actually fires) so cold opens after
+	// the first stay snappy.
+	void maybeShowIntro( config );
+}
+
+/**
+ * Module-scoped guard — block the dialog from re-opening within the same shell session
+ *  if the user already dismissed it but the REST POST hasn't echoed back yet.
+ */
+let _introShown = false;
+
+async function maybeShowIntro( config: PluginsWindowConfig ): Promise< void > {
+	if ( _introShown || config.introSeen ) {
+		return;
+	}
+	_introShown = true;
+	try {
+		const { showPluginsIntroDialog } = await import( './intro-dialog' );
+		const result = await showPluginsIntroDialog();
+		// `cancel` (Escape / backdrop click) intentionally does NOT
+		// mark seen — it's our testing escape hatch so design
+		// iteration doesn't require resetting OS Settings between
+		// runs.
+		if ( result === 'cancel' ) {
+			_introShown = false;
+			return;
+		}
+		void markIntroSeen( config );
+		if ( result === 'settings' ) {
+			openOsSettingsFeatures();
+		}
+	} catch {
+		// Dialog mount failed; allow a re-open to retry.
+		_introShown = false;
+	}
+}
+
+async function markIntroSeen( config: PluginsWindowConfig ): Promise< void > {
+	if ( ! config.introUrl ) {
+		return;
+	}
+	try {
+		await trackedFetch(
+			config.introUrl,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': config.restNonce,
+				},
+				body: JSON.stringify( { slug: 'plugins' } ),
+			},
+			{
+				windowId: 'desktop-mode-plugins',
+				source: 'plugins-window/intro',
+			},
+		);
+		// Mirror the server flag locally so a re-open inside the
+		// same shell session doesn't re-fire the dialog.
+		( config as { introSeen: boolean } ).introSeen = true;
+	} catch {
+		// Swallow — worst case is showing the intro once more.
+	}
+}
+
+function openOsSettingsFeatures(): void {
+	const api = ( window as unknown as {
+		wp?: { desktop?: { openOsSettings?: ( tab?: string ) => void } };
+	} ).wp?.desktop;
+	if ( typeof api?.openOsSettings === 'function' ) {
+		api.openOsSettings( 'features' );
+	}
+}
+
+const registry = ( window.desktopModeNativeWindows ??= {} );
+registry[ 'desktop-mode-plugins' ] = ( body: HTMLElement ) => {
+	renderPluginsWindow( body );
+};

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -1,0 +1,737 @@
+/**
+ * Native Plugins window — Installed tab.
+ *
+ * `<wpd-table>`-driven list of every plugin in `wp-content/plugins/`.
+ * Columns: icon + name, status, version (with update badge), author,
+ * size, actions. Bulk actions: activate, deactivate, delete.
+ *
+ * Mutation flow: optimistic-then-revert-on-failure. After every
+ * successful mutation we call `refreshFrameworkMenu()` so the dock /
+ * taskbar repaint live (see `src/boot/menu-refresh.ts` for the
+ * underlying contract).
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __, sprintf } from '../i18n';
+import {
+	activateInstalledPlugin,
+	deactivateInstalledPlugin,
+	deleteInstalledPlugin,
+	fetchInstalledPlugins,
+	getConfig,
+	refreshFrameworkMenu,
+} from './rest';
+import type { InstalledPlugin } from './types';
+import type {
+	WpdTable,
+	WpdTableColumn,
+} from '../ui/components/wpd-table/wpd-table';
+
+/** Toast helper, shell-routed when available. */
+function toast( message: string, duration = 3500 ): void {
+	const api = window.wp?.desktop;
+	if ( api && typeof api.showToast === 'function' ) {
+		api.showToast( { message, duration } );
+		return;
+	}
+	// eslint-disable-next-line no-console
+	console.log( '[plugins-window]', message );
+}
+
+/** Confirm-dialog helper, shell-routed when available. */
+async function confirm( opts: {
+	title?: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	danger?: boolean;
+} ): Promise< boolean > {
+	const api = window.wp?.desktop;
+	if ( api && typeof api.confirm === 'function' ) {
+		return api.confirm( opts );
+	}
+	// Last-resort UX fallback only fires in non-shell contexts (tests,
+	// embedded previews). Production always has the shell.
+	return Promise.resolve( true );
+}
+
+interface InstalledViewState {
+	/** All rows from the most recent fetch. */
+	rows: InstalledPlugin[];
+	/** Status filter — `''` means All. */
+	statusFilter: string;
+	/** Free-text search (case-insensitive substring match). */
+	search: string;
+	/** Loading flag for the table skeleton. */
+	loading: boolean;
+}
+
+/**
+ * Mount the Installed view into a host element. Returns a teardown
+ * for the framework's window-closed cleanup pattern.
+ */
+export function mountInstalledView( host: HTMLElement ): () => void {
+	host.replaceChildren();
+
+	const state: InstalledViewState = {
+		rows: [],
+		statusFilter: '',
+		search: '',
+		loading: true,
+	};
+
+	// ─── Toolbar ────────────────────────────────────────────────────
+	const toolbar = document.createElement( 'header' );
+	toolbar.className = 'desktop-mode-plugins__toolbar';
+
+	const left = document.createElement( 'div' );
+	left.className = 'desktop-mode-plugins__toolbar-left';
+	const statusFilter = document.createElement( 'wpd-segmented' );
+	statusFilter.setAttribute( 'value', '' );
+	const statusOptions: Array< { value: string; label: string } > = [
+		{ value: '', label: __( 'All', 'desktop-mode' ) },
+		{ value: 'active', label: __( 'Active', 'desktop-mode' ) },
+		{ value: 'inactive', label: __( 'Inactive', 'desktop-mode' ) },
+		{ value: 'update', label: __( 'Update available', 'desktop-mode' ) },
+	];
+	for ( const opt of statusOptions ) {
+		const seg = document.createElement( 'wpd-segment' );
+		seg.setAttribute( 'value', opt.value );
+		seg.textContent = opt.label;
+		statusFilter.appendChild( seg );
+	}
+	statusFilter.addEventListener( 'wpd-pick', ( ev: Event ) => {
+		const detail = ( ev as CustomEvent< { value: string } > ).detail;
+		state.statusFilter = detail?.value ?? '';
+		paintTable();
+	} );
+
+	const search = document.createElement( 'wpd-text-field' );
+	search.setAttribute(
+		'placeholder',
+		__( 'Search installed plugins…', 'desktop-mode' ),
+	);
+	let searchDebounce: number | undefined;
+	search.addEventListener( 'wpd-input-change', ( ev: Event ) => {
+		const value = ( ev as CustomEvent< { value: string } > ).detail?.value ?? '';
+		window.clearTimeout( searchDebounce );
+		searchDebounce = window.setTimeout( () => {
+			state.search = value;
+			paintTable();
+		}, 200 );
+	} );
+
+	left.append( statusFilter, search );
+
+	const right = document.createElement( 'div' );
+	right.className = 'desktop-mode-plugins__toolbar-right';
+	const bulkBar = document.createElement( 'div' );
+	bulkBar.className = 'desktop-mode-plugins__bulk';
+	bulkBar.hidden = true;
+	right.appendChild( bulkBar );
+
+	const trailing = document.createElement( 'div' );
+	trailing.className = 'desktop-mode-plugins__toolbar-trailing';
+	const refreshButton = document.createElement( 'wpd-button' );
+	refreshButton.setAttribute( 'variant', 'ghost' );
+	refreshButton.setAttribute( 'title', __( 'Refresh', 'desktop-mode' ) );
+	refreshButton.innerHTML =
+		'<span class="dashicons dashicons-update" aria-hidden="true"></span>';
+	refreshButton.addEventListener( 'click', () => {
+		void reload();
+	} );
+	trailing.appendChild( refreshButton );
+
+	toolbar.append( left, right, trailing );
+
+	// ─── Table ──────────────────────────────────────────────────────
+	const tableWrap = document.createElement( 'div' );
+	tableWrap.className = 'desktop-mode-plugins__body';
+	const table = document.createElement( 'wpd-table' ) as WpdTable< InstalledPlugin >;
+	table.setAttribute( 'selectable', 'multi' );
+	table.setAttribute( 'sticky-header', '' );
+	table.setAttribute( 'sticky-columns', '1' );
+	table.setAttribute( 'hover', '' );
+	table.setAttribute( 'striped', '' );
+	table.setAttribute( 'bordered', '' );
+	table.setAttribute( 'loading', '' );
+
+	const empty = document.createElement( 'div' );
+	empty.setAttribute( 'slot', 'empty' );
+	empty.className = 'desktop-mode-plugins__empty';
+	empty.innerHTML =
+		'<span class="dashicons dashicons-admin-plugins" aria-hidden="true"></span>' +
+		'<p>' +
+		__( 'No plugins match your filters.', 'desktop-mode' ) +
+		'</p>';
+	table.appendChild( empty );
+
+	const getRowId = ( row: InstalledPlugin, index: number ): string =>
+		row.plugin || String( index );
+	table.getRowId = getRowId;
+	table.columns = buildColumns();
+
+	tableWrap.appendChild( table );
+
+	host.append( toolbar, tableWrap );
+
+	// ─── Selection → bulk-bar ──────────────────────────────────────
+	const selectionListener = ( ev: Event ): void => {
+		const detail = ( ev as CustomEvent< { selection: string[] } > ).detail;
+		const ids = detail?.selection ?? [];
+		paintBulkBar( ids );
+	};
+	table.addEventListener( 'wpd-table-selection-change', selectionListener );
+
+	// ─── Initial fetch ──────────────────────────────────────────────
+	void reload();
+
+	function buildColumns(): WpdTableColumn< InstalledPlugin >[] {
+		const cfg = getConfig();
+		const cols: WpdTableColumn< InstalledPlugin >[] = [
+			{
+				key: 'name',
+				label: __( 'Plugin', 'desktop-mode' ),
+				sortable: true,
+				sticky: true,
+				render: ( _value, row ) => renderNameCell( row ),
+			},
+			{
+				key: 'status',
+				label: __( 'Status', 'desktop-mode' ),
+				sortable: true,
+				render: ( _value, row ) => renderStatusCell( row ),
+			},
+			{
+				key: 'version',
+				label: __( 'Version', 'desktop-mode' ),
+				sortable: true,
+				render: ( _value, row ) => renderVersionCell( row ),
+			},
+			{
+				key: 'author',
+				label: __( 'Author', 'desktop-mode' ),
+				render: ( _value, row ) => renderAuthorCell( row ),
+			},
+			{
+				key: 'desktop_mode_size_kb',
+				label: __( 'Size', 'desktop-mode' ),
+				align: 'end',
+				sortable: true,
+				sortValue: ( row: InstalledPlugin ) => row.desktop_mode_size_kb ?? 0,
+				render: ( _value, row ) => formatSize( row.desktop_mode_size_kb ?? null ),
+			},
+			{
+				key: '_actions',
+				label: '',
+				align: 'end',
+				render: ( _value, row ) => renderActionsCell( row ),
+			},
+		];
+		return cfg.caps.activate || cfg.caps.delete ? cols : cols.slice( 0, -1 );
+	}
+
+	// Cell renderers use INLINE styles instead of class selectors —
+	// `<wpd-table>` cells live inside its shadow DOM, so document
+	// CSS rules don't reach them. Same posture posts-window uses.
+
+	function renderNameCell( row: InstalledPlugin ): HTMLElement {
+		const wrap = document.createElement( 'div' );
+		wrap.style.cssText =
+			'display:flex;align-items:center;gap:12px;min-width:0;padding:4px 0;';
+
+		const icon = document.createElement( 'div' );
+		icon.style.cssText =
+			'flex:0 0 32px;width:32px;height:32px;max-width:32px;max-height:32px;' +
+			'border-radius:6px;overflow:hidden;display:flex;align-items:center;' +
+			'justify-content:center;background:rgba(0,0,0,0.04);box-sizing:border-box;';
+
+		const url = row.desktop_mode_icon_url;
+		if ( url ) {
+			const img = document.createElement( 'img' );
+			img.src = url;
+			img.alt = '';
+			img.loading = 'lazy';
+			img.decoding = 'async';
+			img.style.cssText =
+				'width:100%;height:100%;max-width:100%;max-height:100%;' +
+				'object-fit:contain;display:block;';
+			img.addEventListener( 'error', () => {
+				icon.replaceChildren( buildFallbackIcon() );
+			} );
+			icon.appendChild( img );
+		} else {
+			icon.appendChild( buildFallbackIcon() );
+		}
+
+		const text = document.createElement( 'div' );
+		text.style.cssText =
+			'display:flex;flex-direction:column;gap:2px;min-width:0;flex:1 1 auto;' +
+			'line-height:1.35;';
+
+		const title = document.createElement( 'strong' );
+		title.textContent = row.name || row.plugin;
+		title.style.cssText =
+			'display:block;font-weight:600;white-space:nowrap;overflow:hidden;' +
+			'text-overflow:ellipsis;';
+
+		const path = document.createElement( 'span' );
+		path.textContent = row.plugin;
+		path.style.cssText =
+			'display:block;font-size:0.78em;color:#888;font-family:' +
+			'ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;' +
+			'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;';
+
+		text.append( title, path );
+		wrap.append( icon, text );
+		return wrap;
+	}
+
+	function buildFallbackIcon(): HTMLElement {
+		const fallback = document.createElement( 'span' );
+		fallback.className = 'dashicons dashicons-admin-plugins';
+		fallback.setAttribute( 'aria-hidden', 'true' );
+		fallback.style.cssText =
+			'font-size:18px;width:18px;height:18px;line-height:18px;color:#888;';
+		return fallback;
+	}
+
+	function renderStatusCell( row: InstalledPlugin ): HTMLElement {
+		const badge = document.createElement( 'span' );
+		const isActive =
+			row.status === 'active' || row.status === 'active-network';
+		const dot = isActive ? '#16a34a' : '#9ca3af';
+		const bg = isActive ? 'rgba(22, 163, 74, 0.14)' : 'rgba(120, 120, 120, 0.12)';
+		const fg = isActive ? '#166e37' : '#555';
+		badge.style.cssText =
+			`display:inline-flex;align-items:center;gap:6px;padding:2px 10px 2px 8px;` +
+			`border-radius:999px;font-size:0.78em;font-weight:600;line-height:1.4;` +
+			`white-space:nowrap;background:${ bg };color:${ fg };`;
+		const dotEl = document.createElement( 'span' );
+		dotEl.style.cssText =
+			`width:6px;height:6px;border-radius:50%;background:${ dot };` +
+			'flex:0 0 auto;display:inline-block;';
+		badge.appendChild( dotEl );
+		const label = document.createElement( 'span' );
+		label.textContent = isActive
+			? __( 'Active', 'desktop-mode' )
+			: __( 'Inactive', 'desktop-mode' );
+		badge.appendChild( label );
+		return badge;
+	}
+
+	function renderVersionCell( row: InstalledPlugin ): HTMLElement {
+		const wrap = document.createElement( 'div' );
+		wrap.style.cssText =
+			'display:flex;align-items:center;gap:6px;flex-wrap:wrap;';
+		const v = document.createElement( 'span' );
+		v.textContent = row.version ?? '—';
+		wrap.appendChild( v );
+		const update = row.desktop_mode_update_available;
+		if ( update?.available && update.new_version ) {
+			const badge = document.createElement( 'span' );
+			badge.style.cssText =
+				'font-size:0.78em;background:rgba(245,175,0,0.18);' +
+				'color:#915f00;padding:1px 7px;border-radius:999px;font-weight:600;';
+			badge.textContent = sprintf(
+				/* translators: %s: new plugin version */
+				__( '→ %s', 'desktop-mode' ),
+				update.new_version,
+			);
+			wrap.appendChild( badge );
+		}
+		return wrap;
+	}
+
+	function renderAuthorCell( row: InstalledPlugin ): HTMLElement {
+		const wrap = document.createElement( 'span' );
+		wrap.style.cssText =
+			'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block;';
+		const text = stripHtml( row.author ?? '' );
+		wrap.textContent = text || __( 'Unknown', 'desktop-mode' );
+		return wrap;
+	}
+
+	function renderActionsCell( row: InstalledPlugin ): HTMLElement {
+		const wrap = document.createElement( 'div' );
+		wrap.style.cssText =
+			'display:inline-flex;gap:8px;align-items:center;justify-content:flex-end;' +
+			'flex-wrap:nowrap;';
+		// Mark as `data-noclick` so wpd-table doesn't fire row-click on
+		// these buttons.
+		wrap.setAttribute( 'data-noclick', '' );
+
+		const can = row.desktop_mode_can_manage ?? {
+			activate: row.status === 'inactive',
+			deactivate: row.status === 'active' || row.status === 'active-network',
+			delete: row.status === 'inactive',
+		};
+
+		if ( can.activate ) {
+			const btn = button( __( 'Activate', 'desktop-mode' ), 'primary' );
+			btn.addEventListener( 'click', ( e ) => {
+				e.stopPropagation();
+				void runActivate( row );
+			} );
+			wrap.appendChild( btn );
+		} else if ( can.deactivate ) {
+			const btn = button( __( 'Deactivate', 'desktop-mode' ), 'secondary' );
+			btn.addEventListener( 'click', ( e ) => {
+				e.stopPropagation();
+				void runDeactivate( row );
+			} );
+			wrap.appendChild( btn );
+		}
+
+		if ( can.delete ) {
+			const btn = button( __( 'Delete', 'desktop-mode' ), 'danger' );
+			btn.addEventListener( 'click', ( e ) => {
+				e.stopPropagation();
+				void runDelete( row );
+			} );
+			wrap.appendChild( btn );
+		}
+
+		return wrap;
+	}
+
+	function button( label: string, variant: string ): HTMLElement {
+		const b = document.createElement( 'wpd-button' );
+		b.setAttribute( 'variant', variant );
+		b.setAttribute( 'size', 'small' );
+		b.textContent = label;
+		return b;
+	}
+
+	function paintBulkBar( ids: string[] ): void {
+		bulkBar.replaceChildren();
+		if ( ids.length === 0 ) {
+			bulkBar.hidden = true;
+			return;
+		}
+		bulkBar.hidden = false;
+
+		const count = document.createElement( 'span' );
+		count.className = 'desktop-mode-plugins__bulk-count';
+		count.textContent = sprintf(
+			/* translators: %d: number of selected plugins */
+			__( '%d selected', 'desktop-mode' ),
+			ids.length,
+		);
+		bulkBar.appendChild( count );
+
+		const cfg = getConfig();
+		const selected = state.rows.filter( ( r ) => ids.includes( r.plugin ) );
+
+		if ( cfg.caps.activate ) {
+			const activatable = selected.filter( ( r ) => r.status === 'inactive' );
+			if ( activatable.length > 0 ) {
+				const btn = button( __( 'Activate', 'desktop-mode' ), 'primary' );
+				btn.addEventListener( 'click', () => {
+					void runBulk( activatable, 'activate' );
+				} );
+				bulkBar.appendChild( btn );
+			}
+			const deactivatable = selected.filter(
+				( r ) => r.status === 'active' || r.status === 'active-network',
+			);
+			if ( deactivatable.length > 0 ) {
+				const btn = button( __( 'Deactivate', 'desktop-mode' ), 'secondary' );
+				btn.addEventListener( 'click', () => {
+					void runBulk( deactivatable, 'deactivate' );
+				} );
+				bulkBar.appendChild( btn );
+			}
+		}
+
+		if ( cfg.caps.delete ) {
+			const deletable = selected.filter( ( r ) => r.status === 'inactive' );
+			if ( deletable.length > 0 ) {
+				const btn = button( __( 'Delete', 'desktop-mode' ), 'danger' );
+				btn.addEventListener( 'click', () => {
+					void runBulk( deletable, 'delete' );
+				} );
+				bulkBar.appendChild( btn );
+			}
+		}
+	}
+
+	async function reload(): Promise< void > {
+		state.loading = true;
+		table.setAttribute( 'loading', '' );
+		try {
+			state.rows = await fetchInstalledPlugins();
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Could not load plugins: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+			state.rows = [];
+		}
+		state.loading = false;
+		paintTable();
+	}
+
+	function paintTable(): void {
+		if ( state.loading ) {
+			table.setAttribute( 'loading', '' );
+		} else {
+			table.removeAttribute( 'loading' );
+		}
+		table.data = filterRows( state.rows );
+	}
+
+	function filterRows( rows: InstalledPlugin[] ): InstalledPlugin[] {
+		const q = state.search.trim().toLowerCase();
+		const status = state.statusFilter;
+		return rows.filter( ( row ) => {
+			if ( status === 'active' ) {
+				if ( row.status !== 'active' && row.status !== 'active-network' ) {
+					return false;
+				}
+			} else if ( status === 'inactive' ) {
+				if ( row.status !== 'inactive' ) {
+					return false;
+				}
+			} else if ( status === 'update' ) {
+				if ( ! row.desktop_mode_update_available?.available ) {
+					return false;
+				}
+			}
+			if ( q !== '' ) {
+				const haystack = `${ row.name ?? '' } ${ row.plugin } ${ stripHtml( row.author ?? '' ) }`.toLowerCase();
+				if ( ! haystack.includes( q ) ) {
+					return false;
+				}
+			}
+			return true;
+		} );
+	}
+
+	async function runActivate( row: InstalledPlugin ): Promise< void > {
+		const previous = row.status;
+		applyStatusOptimistic( row, 'active' );
+		try {
+			const updated = await activateInstalledPlugin( row );
+			mergeRow( updated );
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( '%s activated.', 'desktop-mode' ),
+					row.name || row.plugin,
+				),
+			);
+			await refreshFrameworkMenu();
+		} catch ( err ) {
+			applyStatusOptimistic( row, previous );
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Activation failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+
+	async function runDeactivate( row: InstalledPlugin ): Promise< void > {
+		const previous = row.status;
+		applyStatusOptimistic( row, 'inactive' );
+		try {
+			const updated = await deactivateInstalledPlugin( row );
+			mergeRow( updated );
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( '%s deactivated.', 'desktop-mode' ),
+					row.name || row.plugin,
+				),
+			);
+			await refreshFrameworkMenu();
+		} catch ( err ) {
+			applyStatusOptimistic( row, previous );
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Deactivation failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+
+	async function runDelete( row: InstalledPlugin ): Promise< void > {
+		const ok = await confirm( {
+			title: __( 'Delete plugin?', 'desktop-mode' ),
+			message: sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'Permanently delete %s? Its files will be removed from disk. This cannot be undone.',
+					'desktop-mode',
+				),
+				row.name || row.plugin,
+			),
+			confirmLabel: __( 'Delete', 'desktop-mode' ),
+			danger: true,
+		} );
+		if ( ! ok ) {
+			return;
+		}
+		try {
+			await deleteInstalledPlugin( row );
+			state.rows = state.rows.filter( ( r ) => r.plugin !== row.plugin );
+			paintTable();
+			toast(
+				sprintf(
+					/* translators: %s: plugin name */
+					__( '%s deleted.', 'desktop-mode' ),
+					row.name || row.plugin,
+				),
+			);
+			await refreshFrameworkMenu();
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Delete failed: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+				6000,
+			);
+		}
+	}
+
+	async function runBulk(
+		rows: InstalledPlugin[],
+		action: 'activate' | 'deactivate' | 'delete',
+	): Promise< void > {
+		if ( rows.length === 0 ) {
+			return;
+		}
+		if ( action === 'delete' ) {
+			const ok = await confirm( {
+				title: __( 'Delete selected plugins?', 'desktop-mode' ),
+				message: sprintf(
+					/* translators: %d: number of plugins */
+					__(
+						'Permanently delete %d plugin(s)? Their files will be removed from disk. This cannot be undone.',
+						'desktop-mode',
+					),
+					rows.length,
+				),
+				confirmLabel: __( 'Delete', 'desktop-mode' ),
+				danger: true,
+			} );
+			if ( ! ok ) {
+				return;
+			}
+		}
+		let succeeded = 0;
+		const failures: Array< { row: InstalledPlugin; err: unknown } > = [];
+		for ( const row of rows ) {
+			try {
+				if ( action === 'activate' ) {
+					mergeRow( await activateInstalledPlugin( row ) );
+				} else if ( action === 'deactivate' ) {
+					mergeRow( await deactivateInstalledPlugin( row ) );
+				} else if ( action === 'delete' ) {
+					await deleteInstalledPlugin( row );
+					state.rows = state.rows.filter( ( r ) => r.plugin !== row.plugin );
+				}
+				succeeded++;
+			} catch ( err ) {
+				failures.push( { row, err } );
+			}
+		}
+		paintTable();
+		table.clearSelection();
+		await refreshFrameworkMenu();
+		let noun = '';
+		if ( action === 'delete' ) {
+			noun = __( 'deleted', 'desktop-mode' );
+		} else if ( action === 'activate' ) {
+			noun = __( 'activated', 'desktop-mode' );
+		} else {
+			noun = __( 'deactivated', 'desktop-mode' );
+		}
+		const summary =
+			failures.length === 0
+				? sprintf(
+					/* translators: 1: count, 2: action verb (activated, deactivated, deleted) */
+					__( '%1$d plugin(s) %2$s.', 'desktop-mode' ),
+					succeeded,
+					noun,
+				)
+				: sprintf(
+					/* translators: 1: success count, 2: failure count, 3: action verb */
+					__( '%1$d %3$s, %2$d failed.', 'desktop-mode' ),
+					succeeded,
+					failures.length,
+					noun,
+				);
+		toast( summary, 5000 );
+	}
+
+	function applyStatusOptimistic(
+		row: InstalledPlugin,
+		next: InstalledPlugin[ 'status' ],
+	): void {
+		row.status = next;
+		paintTable();
+	}
+
+	function mergeRow( updated: InstalledPlugin ): void {
+		const idx = state.rows.findIndex( ( r ) => r.plugin === updated.plugin );
+		if ( idx >= 0 ) {
+			state.rows[ idx ] = { ...state.rows[ idx ], ...updated };
+		} else {
+			state.rows.push( updated );
+		}
+		paintTable();
+	}
+
+	return () => {
+		table.removeEventListener( 'wpd-table-selection-change', selectionListener );
+		host.replaceChildren();
+	};
+}
+
+function formatSize( kb: number | null ): string {
+	if ( kb === null || kb === undefined ) {
+		return '—';
+	}
+	if ( kb < 1024 ) {
+		return sprintf(
+			/* translators: %d: size in kilobytes */
+			__( '%d KB', 'desktop-mode' ),
+			kb,
+		);
+	}
+	const mb = kb / 1024;
+	return sprintf(
+		/* translators: %s: size in megabytes (one decimal) */
+		__( '%s MB', 'desktop-mode' ),
+		mb.toFixed( 1 ),
+	);
+}
+
+function stripHtml( html: string ): string {
+	const tmp = document.createElement( 'div' );
+	tmp.innerHTML = html;
+	return tmp.textContent ?? '';
+}
+
+function describe( err: unknown ): string {
+	if ( err instanceof Error ) {
+		return err.message;
+	}
+	return String( err );
+}

--- a/src/plugins-window/intro-dialog.ts
+++ b/src/plugins-window/intro-dialog.ts
@@ -1,0 +1,245 @@
+/**
+ * Plugins-window first-open intro.
+ *
+ * Same lifecycle / Promise-based contract as the Pages intro:
+ * render a backdrop + dialog, resolve with the chosen action, tear
+ * down on close. Three outcomes:
+ *
+ *   - `'confirm'`  — primary "Got it" button.
+ *   - `'settings'` — "Take me to settings" link.
+ *   - `'cancel'`   — Escape / backdrop click. Caller MUST NOT mark
+ *                    seen, so the dialog re-opens next time the
+ *                    window opens (lets us iterate without
+ *                    resetting OS Settings between runs).
+ *
+ * Inline `<style>` keeps the module portable across hosts that
+ * haven't enqueued the plugins-window stylesheet at boot.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __ } from '../i18n';
+
+export type IntroResult = 'confirm' | 'settings' | 'cancel';
+
+/**
+ * Show the Plugins-window intro. Returns a Promise that resolves
+ * with the user's chosen action.
+ *
+ * @since 0.9.0
+ */
+export async function showPluginsIntroDialog(): Promise< IntroResult > {
+	return new Promise< IntroResult >( ( resolve ) => {
+		const backdrop = document.createElement( 'div' );
+		backdrop.className = 'desktop-mode-plugins-intro__backdrop';
+		backdrop.setAttribute( 'role', 'presentation' );
+		Object.assign( backdrop.style, {
+			position: 'fixed',
+			inset: '0',
+			background:
+				'color-mix(in srgb, var(--wp-admin-theme-color, #1d2327) 60%, transparent)',
+			backdropFilter: 'blur(2px)',
+			WebkitBackdropFilter: 'blur(2px)',
+			zIndex: '100000',
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			padding: '24px',
+		} as Partial< CSSStyleDeclaration > );
+
+		const dialog = document.createElement( 'div' );
+		dialog.setAttribute( 'role', 'dialog' );
+		dialog.setAttribute( 'aria-modal', 'true' );
+		dialog.setAttribute( 'aria-labelledby', 'desktop-mode-plugins-intro-title' );
+		dialog.className = 'desktop-mode-plugins-intro';
+		Object.assign( dialog.style, {
+			background: 'var(--wp-admin-theme-bg, #fff)',
+			color: 'var(--wp-admin-theme-fg, #1d2327)',
+			borderRadius: '14px',
+			boxShadow: '0 24px 60px rgba(0,0,0,.28)',
+			maxWidth: '560px',
+			width: '100%',
+			maxHeight: '90vh',
+			overflow: 'auto',
+			padding: '28px 32px 24px',
+			fontFamily:
+				'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+		} as Partial< CSSStyleDeclaration > );
+
+		dialog.innerHTML = renderDialogMarkup();
+		backdrop.appendChild( dialog );
+		document.body.appendChild( backdrop );
+
+		const primaryBtn = dialog.querySelector< HTMLButtonElement >(
+			'[data-action="confirm"]',
+		);
+		const settingsBtn = dialog.querySelector< HTMLButtonElement >(
+			'[data-action="settings"]',
+		);
+		primaryBtn?.focus();
+
+		let resolved = false;
+		const cleanup = ( result: IntroResult ): void => {
+			if ( resolved ) {
+				return;
+			}
+			resolved = true;
+			document.removeEventListener( 'keydown', onKey, true );
+			backdrop.remove();
+			resolve( result );
+		};
+
+		const onKey = ( e: KeyboardEvent ): void => {
+			if ( e.key === 'Escape' ) {
+				e.preventDefault();
+				cleanup( 'cancel' );
+			}
+		};
+		document.addEventListener( 'keydown', onKey, true );
+
+		backdrop.addEventListener( 'click', ( e ) => {
+			if ( e.target === backdrop ) {
+				cleanup( 'cancel' );
+			}
+		} );
+
+		primaryBtn?.addEventListener( 'click', () => cleanup( 'confirm' ) );
+		settingsBtn?.addEventListener( 'click', () => cleanup( 'settings' ) );
+	} );
+}
+
+/**
+ * Markup for the Plugins intro dialog. Inline `<style>` so the
+ * dialog is fully self-contained and renders correctly even when
+ * the plugins-window stylesheet hasn't been enqueued yet (e.g. on
+ * cold-open before lazy-loading completes).
+ */
+function renderDialogMarkup(): string {
+	const title = __( 'Welcome to the new Plugins window', 'desktop-mode' );
+	const lede = __(
+		'You\'re looking at the redesigned Plugins admin — same WordPress.org repository under the hood, with a workflow tuned for how Desktop Mode wants you to work.',
+		'desktop-mode',
+	);
+
+	const highlights = [
+		__(
+			'Two tabs in one window — Installed for managing what you have, Browse for discovering new plugins. No more bouncing between Plugins → Add New → back to Installed.',
+			'desktop-mode',
+		),
+		__(
+			'A real gallery on Browse — clean cards with rating, install count, last updated, and a click-anywhere detail flyout. Subtle hover lift, lazy-loaded icons, infinite scroll.',
+			'desktop-mode',
+		),
+		__(
+			'The detail flyout shows screenshots, the ratings histogram, recent reviews, the changelog and FAQ — all without leaving the window.',
+			'desktop-mode',
+		),
+		__(
+			'Drag a .zip onto the window to install — or drag a Browse card straight to the dock to pin a shortcut. The framework drag bridge handles the rest.',
+			'desktop-mode',
+		),
+		__(
+			'The dock repaints LIVE after every install / activate / deactivate / delete. No reload, no stale tile, no "wait, did that work?".',
+			'desktop-mode',
+		),
+		__(
+			'Per-row capability flags so the UI hides actions you can\'t perform — and the server re-validates every mutation, so flags can\'t be tampered into more permissions.',
+			'desktop-mode',
+		),
+	];
+
+	const li = ( arr: string[] ): string =>
+		arr
+			.map(
+				( s ) =>
+					`<li><span class="dot" aria-hidden="true"></span>${ escapeHtml(
+						s,
+					) }</li>`,
+			)
+			.join( '' );
+
+	return `
+		<style>
+			.desktop-mode-plugins-intro h2 {
+				margin: 0 0 8px;
+				font-size: 22px;
+				font-weight: 600;
+				letter-spacing: -0.01em;
+			}
+			.desktop-mode-plugins-intro p.lede {
+				margin: 0 0 20px;
+				color: var(--wp-admin-theme-fg-muted, #50575e);
+				font-size: 14px;
+				line-height: 1.5;
+			}
+			.desktop-mode-plugins-intro__list {
+				list-style: none;
+				margin: 0 0 22px;
+				padding: 0;
+				font-size: 14px;
+				line-height: 1.5;
+			}
+			.desktop-mode-plugins-intro__list li {
+				display: flex;
+				align-items: flex-start;
+				gap: 10px;
+				padding: 6px 0;
+			}
+			.desktop-mode-plugins-intro__list .dot {
+				flex: 0 0 auto;
+				width: 6px;
+				height: 6px;
+				margin-top: 9px;
+				border-radius: 50%;
+				background: var(--wp-admin-theme-color, #2271b1);
+			}
+			.desktop-mode-plugins-intro__footer {
+				display: flex;
+				justify-content: flex-end;
+				gap: 8px;
+				margin-top: 8px;
+			}
+			.desktop-mode-plugins-intro__footer button {
+				appearance: none;
+				border: 1px solid var(--wp-admin-theme-border, #dcdcde);
+				background: var(--wp-admin-theme-bg, #fff);
+				color: inherit;
+				padding: 8px 14px;
+				border-radius: 6px;
+				font-size: 13px;
+				cursor: pointer;
+			}
+			.desktop-mode-plugins-intro__footer button.primary {
+				border-color: var(--wp-admin-theme-color, #2271b1);
+				background: var(--wp-admin-theme-color, #2271b1);
+				color: #fff;
+				font-weight: 500;
+			}
+			.desktop-mode-plugins-intro__footer button:hover {
+				filter: brightness(1.05);
+			}
+			.desktop-mode-plugins-intro__footer button:focus-visible {
+				outline: 2px solid var(--wp-admin-theme-color, #2271b1);
+				outline-offset: 2px;
+			}
+		</style>
+		<h2 id="desktop-mode-plugins-intro-title">${ escapeHtml( title ) }</h2>
+		<p class="lede">${ escapeHtml( lede ) }</p>
+		<ul class="desktop-mode-plugins-intro__list">${ li( highlights ) }</ul>
+		<div class="desktop-mode-plugins-intro__footer">
+			<button type="button" data-action="settings">${ escapeHtml(
+				__( 'Take me to settings', 'desktop-mode' ),
+			) }</button>
+			<button type="button" class="primary" data-action="confirm">${ escapeHtml(
+				__( 'Got it', 'desktop-mode' ),
+			) }</button>
+		</div>
+	`;
+}
+
+function escapeHtml( s: string ): string {
+	const t = document.createElement( 'div' );
+	t.textContent = s;
+	return t.innerHTML;
+}

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -1,0 +1,403 @@
+/**
+ * Native Plugins window — REST + admin-ajax glue.
+ *
+ * Read paths use Core REST (`/wp/v2/plugins`); mutation paths split:
+ *
+ *   - Activate / Deactivate: `PUT /wp/v2/plugins/{plugin}` (Core REST,
+ *     `wp-includes/`, no admin-only files needed).
+ *   - Delete:                 `DELETE /wp/v2/plugins/{plugin}` (Core REST).
+ *   - Install by slug:        `admin-ajax.php?action=install-plugin`
+ *                             (Core's wp.updates handler — we just
+ *                             call it from JS, no PHP of our own).
+ *   - Upload .zip:            our `wp_ajax_desktop_mode_plugins_upload`.
+ *   - Browse / Info / Reviews: our `wp_ajax_desktop_mode_plugins_*`.
+ *
+ * Every call goes through `trackedFetch` so the window's title-bar
+ * activity indicator picks it up.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { trackedFetch } from '../tracked-fetch';
+import type {
+	BrowseFilter,
+	InstalledPlugin,
+	PluginReviewsResponse,
+	WpOrgBrowsePlugin,
+	WpOrgPluginInfo,
+} from './types';
+
+const WINDOW_ID = 'desktop-mode-plugins';
+
+declare global {
+	interface Window {
+		desktopModeWindowConfig?: Record< string, unknown >;
+	}
+}
+
+/**
+ * Subset of the `desktop_mode_register_window( 'desktop-mode-plugins',
+ * […, 'config' => […] ] )` blob this bundle reads. Re-declared here
+ * so the REST module isn't entangled with `index.ts`.
+ */
+export interface PluginsWindowConfig {
+	restRoot: string;
+	restNonce: string;
+	pluginsUrl: string;
+	ajaxUrl: string;
+	ajaxNonce: string;
+	updatesNonce: string;
+	caps: {
+		activate: boolean;
+		install: boolean;
+		delete: boolean;
+		upload: boolean;
+	};
+	currentUserId: number;
+	introSeen: boolean;
+	introUrl: string;
+}
+
+/**
+ * Read the localized config blob. Throws when missing — better to
+ * fail loudly with a clear message than silently fall back to a
+ * default that papers over a registration regression.
+ */
+export function getConfig(): PluginsWindowConfig {
+	const store = window.desktopModeWindowConfig;
+	const cfg = store
+		? ( store[ WINDOW_ID ] as PluginsWindowConfig | undefined )
+		: undefined;
+	if ( ! cfg ) {
+		throw new Error(
+			`[${ WINDOW_ID }] config blob is missing — was the window opened ` +
+				'without registration? See the matching `desktop_mode_register_window()` ' +
+				'call in `includes/plugins-window/window.php`.',
+		);
+	}
+	return cfg;
+}
+
+/**
+ * Wrapper around `trackedFetch` that attributes every request to the
+ * Plugins window so concurrent operations from other windows don't
+ * fight for the same activity indicator.
+ *
+ * @internal
+ */
+function shellFetch( input: RequestInfo, init?: RequestInit ): Promise< Response > {
+	return trackedFetch( input, init, {
+		windowId: WINDOW_ID,
+		source: 'desktop-mode/plugins-window',
+	} );
+}
+
+/**
+ * REST request helper — attaches the `X-WP-Nonce` and JSON content
+ * type, throws on non-2xx with a useful message.
+ */
+async function restRequest< T >(
+	url: string,
+	init: RequestInit & { expectJson?: boolean } = {},
+): Promise< T > {
+	const cfg = getConfig();
+	const { expectJson = true, ...rest } = init;
+	const response = await shellFetch( url, {
+		...rest,
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+			...( rest.body ? { 'Content-Type': 'application/json' } : {} ),
+			...( rest.headers ?? {} ),
+		},
+	} );
+	if ( ! response.ok ) {
+		throw await unpackErrorResponse( response );
+	}
+	if ( ! expectJson ) {
+		return undefined as unknown as T;
+	}
+	return ( await response.json() ) as T;
+}
+
+/**
+ * Admin-AJAX request helper. Encodes the args as `application/x-www-form-urlencoded`
+ * (the format Core's wp.updates expects) and parses the standard
+ * `{ success, data }` envelope.
+ */
+async function ajaxRequest< T >(
+	action: string,
+	args: Record< string, string | number | boolean | undefined > = {},
+	options: { nonceField?: string; nonceValue?: string } = {},
+): Promise< T > {
+	const cfg = getConfig();
+	const body = new URLSearchParams();
+	body.set( 'action', action );
+	const nonceField = options.nonceField ?? '_ajax_nonce';
+	const nonceValue = options.nonceValue ?? cfg.ajaxNonce;
+	body.set( nonceField, nonceValue );
+	for ( const [ key, value ] of Object.entries( args ) ) {
+		if ( value === undefined ) {
+			continue;
+		}
+		body.set( key, String( value ) );
+	}
+	const response = await shellFetch( cfg.ajaxUrl, {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+			Accept: 'application/json',
+		},
+		body,
+	} );
+	const json = await readJsonOrThrow( response );
+	return unwrapAjaxEnvelope< T >( json, response.status );
+}
+
+/** Multipart variant of {@link ajaxRequest} for the .zip upload route. */
+async function ajaxUpload< T >(
+	action: string,
+	formData: FormData,
+): Promise< T > {
+	const cfg = getConfig();
+	formData.set( 'action', action );
+	if ( ! formData.has( '_ajax_nonce' ) ) {
+		formData.set( '_ajax_nonce', cfg.ajaxNonce );
+	}
+	const response = await shellFetch( cfg.ajaxUrl, {
+		method: 'POST',
+		credentials: 'same-origin',
+		body: formData,
+		// Don't set Content-Type — the browser appends the boundary.
+	} );
+	const json = await readJsonOrThrow( response );
+	return unwrapAjaxEnvelope< T >( json, response.status );
+}
+
+async function readJsonOrThrow( response: Response ): Promise< unknown > {
+	let json: unknown;
+	try {
+		json = await response.json();
+	} catch ( err ) {
+		throw new Error(
+			`Server returned ${ response.status } with non-JSON body. (${ String( err ) })`,
+		);
+	}
+	if ( ! response.ok ) {
+		throw extractAjaxError( json, response.status );
+	}
+	return json;
+}
+
+function unwrapAjaxEnvelope< T >( json: unknown, status: number ): T {
+	if ( typeof json === 'object' && json !== null && 'success' in json ) {
+		const env = json as { success: boolean; data?: unknown };
+		if ( env.success ) {
+			return ( env.data ?? null ) as T;
+		}
+		throw extractAjaxError( env.data, status );
+	}
+	// Some Core handlers (the install-plugin one in particular) ship a
+	// non-enveloped `{ slug, plugin, errorCode, … }` shape. Forward as
+	// the generic T.
+	return json as T;
+}
+
+function extractAjaxError( data: unknown, status: number ): Error {
+	if ( typeof data === 'object' && data !== null ) {
+		const obj = data as { message?: string; errorMessage?: string; code?: string };
+		const msg = obj.message ?? obj.errorMessage ?? obj.code;
+		if ( typeof msg === 'string' && msg !== '' ) {
+			const err = new Error( msg );
+			( err as Error & { code?: string; status?: number } ).code = obj.code;
+			( err as Error & { code?: string; status?: number } ).status = status;
+			return err;
+		}
+	}
+	return new Error( `Request failed (${ status }).` );
+}
+
+async function unpackErrorResponse( response: Response ): Promise< Error > {
+	let message = `${ response.status } ${ response.statusText }`;
+	try {
+		const json = ( await response.json() ) as { message?: string; code?: string };
+		if ( json && typeof json.message === 'string' && json.message !== '' ) {
+			message = json.message;
+		}
+		const err = new Error( message );
+		( err as Error & { code?: string; status?: number } ).code = json?.code;
+		( err as Error & { code?: string; status?: number } ).status = response.status;
+		return err;
+	} catch {
+		const err = new Error( message );
+		( err as Error & { status?: number } ).status = response.status;
+		return err;
+	}
+}
+
+// ─── Installed plugins ────────────────────────────────────────────────
+
+/**
+ * Fetch the full installed-plugins list. Core's
+ * `/wp/v2/plugins` doesn't paginate (the install can't realistically
+ * have more than a few hundred), so we request `per_page=100` to
+ * collapse the typical install into a single round-trip.
+ */
+export async function fetchInstalledPlugins(): Promise< InstalledPlugin[] > {
+	const cfg = getConfig();
+	const url = cfg.pluginsUrl + '?context=view&per_page=100';
+	return restRequest< InstalledPlugin[] >( url, { method: 'GET' } );
+}
+
+/** Activate a plugin. */
+export async function activateInstalledPlugin(
+	plugin: InstalledPlugin,
+): Promise< InstalledPlugin > {
+	return mutateInstalledPlugin( plugin, { status: 'active' } );
+}
+
+/** Deactivate a plugin (status flips to `'inactive'`). */
+export async function deactivateInstalledPlugin(
+	plugin: InstalledPlugin,
+): Promise< InstalledPlugin > {
+	return mutateInstalledPlugin( plugin, { status: 'inactive' } );
+}
+
+async function mutateInstalledPlugin(
+	plugin: InstalledPlugin,
+	body: { status: 'active' | 'inactive' | 'active-network' },
+): Promise< InstalledPlugin > {
+	const cfg = getConfig();
+	return restRequest< InstalledPlugin >(
+		cfg.pluginsUrl + '/' + encodePluginPath( plugin.plugin ),
+		{
+			method: 'PUT',
+			body: JSON.stringify( body ),
+		},
+	);
+}
+
+/** Delete a plugin. Plugin must be inactive — server returns 400 otherwise. */
+export async function deleteInstalledPlugin(
+	plugin: InstalledPlugin,
+): Promise< void > {
+	const cfg = getConfig();
+	await restRequest< void >(
+		cfg.pluginsUrl + '/' + encodePluginPath( plugin.plugin ) + '?force=true',
+		{
+			method: 'DELETE',
+			expectJson: false,
+		},
+	);
+}
+
+/**
+ * Encode a plugin file path for use as a REST route segment. Core's
+ * REST controller registers the route with regex
+ * `(?P<plugin>[^.\/]+(?:\/[^.\/]+)?)` which expects literal slashes.
+ *
+ * `encodeURIComponent` would percent-encode the slash to `%2F`, and
+ * Apache rejects encoded slashes by default (`AllowEncodedSlashes
+ * Off`) — same gotcha that tripped Core's own JS REST client.
+ * Encode each segment individually and rejoin with literal `/`s.
+ */
+function encodePluginPath( plugin: string ): string {
+	return plugin.split( '/' ).map( encodeURIComponent ).join( '/' );
+}
+
+// ─── Browse / Info / Reviews (admin-ajax) ─────────────────────────────
+
+/** Browse the wp.org plugin directory. */
+export async function browsePlugins( args: {
+	browse?: BrowseFilter;
+	search?: string;
+	tag?: string;
+	page?: number;
+	perPage?: number;
+} = {} ): Promise< {
+	plugins: WpOrgBrowsePlugin[];
+	info: Record< string, unknown >;
+} > {
+	return ajaxRequest( 'desktop_mode_plugins_browse', {
+		browse: args.browse,
+		search: args.search,
+		tag: args.tag,
+		page: args.page,
+		per_page: args.perPage,
+	} );
+}
+
+/** Fetch the full `plugin_information` payload for a slug. */
+export async function fetchPluginInfo( slug: string ): Promise< WpOrgPluginInfo > {
+	return ajaxRequest< WpOrgPluginInfo >( 'desktop_mode_plugins_info', { slug } );
+}
+
+/** Fetch (cached) recent reviews for a slug — falls back to histogram on parse failure. */
+export async function fetchPluginReviews(
+	slug: string,
+): Promise< PluginReviewsResponse > {
+	return ajaxRequest< PluginReviewsResponse >( 'desktop_mode_plugins_reviews', { slug } );
+}
+
+// ─── Install / Upload ─────────────────────────────────────────────────
+
+/**
+ * Install a plugin from the wp.org repository by slug. Calls Core's
+ * existing `wp_ajax_install_plugin` handler — same payload Core's
+ * own "Install" buttons use, no reimplementation. Verified against
+ * the `'updates'` nonce, not our window-scoped `_ajax_nonce`.
+ */
+export async function installPluginBySlug( slug: string ): Promise< {
+	plugin?: string;
+	slug: string;
+	activateUrl?: string;
+	blogId?: number;
+} > {
+	return ajaxRequest(
+		'install-plugin',
+		{ slug },
+		{ nonceField: '_ajax_nonce', nonceValue: getConfig().updatesNonce },
+	);
+}
+
+/**
+ * Upload + install a .zip via our `wp_ajax_desktop_mode_plugins_upload`
+ * action.
+ */
+export async function uploadPluginZip( file: File ): Promise< {
+	plugin_file: string;
+	status: 'inactive';
+	messages: string[];
+} > {
+	const data = new FormData();
+	data.set( 'pluginzip', file );
+	return ajaxUpload( 'desktop_mode_plugins_upload', data );
+}
+
+// ─── Live-refresh helper ──────────────────────────────────────────────
+
+/**
+ * Repaint the dock + taskbar after a plugin mutation. Calls
+ * `wp.desktop.refreshMenu()` which spawns a 1×1 hidden chromeless
+ * iframe to capture the real-admin-context menu payload (handles
+ * plugins that gate `admin_menu` on `is_admin()`).
+ *
+ * Best-effort — silently no-ops when the helper isn't on the public
+ * facade. The window's own state still updates from its own
+ * mutation responses; what we lose without this call is the dock
+ * tile changing live.
+ */
+export async function refreshFrameworkMenu(): Promise< void > {
+	const refresh = window.wp?.desktop?.refreshMenu;
+	if ( typeof refresh !== 'function' ) {
+		return;
+	}
+	try {
+		await refresh();
+	} catch {
+		// Best-effort; never throw from a refresh call.
+	}
+}

--- a/src/plugins-window/tab-target.ts
+++ b/src/plugins-window/tab-target.ts
@@ -1,0 +1,114 @@
+/**
+ * Tiny shared-store holder for the Plugins window's pending initial
+ * tab hint.
+ *
+ * The dock-click URL remap fires BEFORE the window opens. When the
+ * remap matches `plugin-install.php` we want the window to land on
+ * the "Browse" tab, not "Installed" — but `openById` doesn't carry
+ * per-open state. We stash the hint in a shared store the render
+ * callback reads back on first paint, then clear so the next open
+ * without an explicit hint defaults to "installed".
+ *
+ * Shared via `wp.desktop.createSharedStore` (see CLAUDE.md
+ * "Cross-bundle state") so the same module loaded into different
+ * bundles is the single source of truth.
+ *
+ * @since 0.9.0
+ */
+
+interface SharedStoreApi< T > {
+	state: T;
+	notify(): void;
+	subscribe( cb: ( state: T ) => void ): () => void;
+}
+
+interface DesktopFacade {
+	createSharedStore?: < T >(
+		key: string,
+		initial: () => T,
+	) => SharedStoreApi< T >;
+}
+
+export type PluginsWindowTab = 'installed' | 'browse';
+
+interface TabTargetState {
+	tab: PluginsWindowTab | null;
+	requestedAt: number;
+}
+
+const _initial: TabTargetState = {
+	tab: null,
+	requestedAt: 0,
+};
+
+let _store: SharedStoreApi< TabTargetState > | null = null;
+function getStore(): SharedStoreApi< TabTargetState > | null {
+	if ( _store ) {
+		return _store;
+	}
+	const w = window as unknown as { wp?: { desktop?: DesktopFacade } };
+	const factory = w.wp?.desktop?.createSharedStore;
+	if ( typeof factory !== 'function' ) {
+		return null;
+	}
+	_store = factory< TabTargetState >(
+		'desktop-mode/plugins-window/tab-target',
+		() => ( { ..._initial } ),
+	);
+	return _store;
+}
+
+/**
+ * Set the tab the next window open should land on. Must be called
+ * BEFORE `openById( 'desktop-mode-plugins' )`.
+ */
+export function setPluginsWindowTab( tab: PluginsWindowTab ): void {
+	const store = getStore();
+	if ( store ) {
+		store.state.tab = tab;
+		store.state.requestedAt = Date.now();
+		store.notify();
+		return;
+	}
+	const w = window as unknown as { _wpdPluginsWindowTab?: TabTargetState };
+	w._wpdPluginsWindowTab = { tab, requestedAt: Date.now() };
+}
+
+/**
+ * Read (and consume) the pending tab hint. Returns `null` when no
+ * hint was set — the caller should default to "installed".
+ */
+export function consumePluginsWindowTab(): PluginsWindowTab | null {
+	const store = getStore();
+	if ( store ) {
+		const tab = store.state.tab;
+		if ( tab !== null ) {
+			store.state.tab = null;
+			store.state.requestedAt = 0;
+			store.notify();
+		}
+		return tab;
+	}
+	const w = window as unknown as { _wpdPluginsWindowTab?: TabTargetState };
+	const prev = w._wpdPluginsWindowTab;
+	if ( prev ) {
+		w._wpdPluginsWindowTab = { tab: null, requestedAt: 0 };
+		return prev.tab;
+	}
+	return null;
+}
+
+/**
+ * Subscribe to tab-target changes — used by the render callback so
+ * a second click on the dock with a different hint can flip the tab
+ * without reopening the window.
+ */
+export function subscribePluginsWindowTab(
+	cb: ( state: TabTargetState ) => void,
+): () => void {
+	const store = getStore();
+	if ( ! store ) {
+		return () => {};
+	}
+	return store.subscribe( ( state ) => cb( { ...state } ) );
+}

--- a/src/plugins-window/types.ts
+++ b/src/plugins-window/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Native Plugins window — public type surface.
+ *
+ * Re-exported from `index.ts` so plugin authors writing JS-side
+ * filters / extensions get the same shapes the bundle works against.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+/**
+ * A row from Core's `/wp/v2/plugins` list, with our REST-field
+ * decorators (`desktop_mode_*`) attached.
+ *
+ * Fields with question marks are optional in older Core versions or
+ * may be absent under a `_fields` whitelist; the JS guards every
+ * access.
+ */
+export interface InstalledPlugin {
+	/** Plugin file path relative to `wp-content/plugins/`, e.g. `"akismet/akismet.php"`. Acts as the row id. */
+	plugin: string;
+	/** Plugin status — `"active"` or `"inactive"` (`"active-network"` on multisite). */
+	status: 'active' | 'inactive' | 'active-network';
+	/** Display name from the plugin header. */
+	name: string;
+	/** Plugin URL from the plugin header (homepage). */
+	plugin_uri?: string;
+	/** Author display name (HTML allowed by Core; we rely on Core's escaping). */
+	author?: string;
+	/** Author URL from the plugin header. */
+	author_uri?: string;
+	/** Plugin description (HTML allowed). */
+	description?: { raw: string; rendered: string } | string;
+	/** Version from the plugin header. */
+	version?: string;
+	/** Plugin's text domain — Core uses this as the wp.org slug for .org plugins. */
+	textdomain?: string;
+	/** Network-only plugin flag. */
+	network_only?: boolean;
+	/** Whether the plugin requires WP at this version or higher. */
+	requires_wp?: string;
+	/** Whether the plugin requires PHP at this version or higher. */
+	requires_php?: string;
+
+	// ─── REST-field decorators added in `includes/plugins-window/rest-fields.php` ───
+
+	/**
+	 * `{ available, new_version }` — true if a wp.org update is
+	 * pending. Read from the `update_plugins` site transient.
+	 */
+	desktop_mode_update_available?: {
+		available: boolean;
+		new_version: string | null;
+	};
+	/**
+	 * Per-row capability flags so the JS doesn't re-derive caps. The
+	 * server still re-validates every mutation; this is purely UX.
+	 */
+	desktop_mode_can_manage?: {
+		activate: boolean;
+		deactivate: boolean;
+		delete: boolean;
+	};
+	/** wp.org icon URL derived from the slug; null when the plugin isn't on the .org repo. */
+	desktop_mode_icon_url?: string | null;
+	/** Disk size of the plugin folder in kilobytes (null when unreadable). */
+	desktop_mode_size_kb?: number | null;
+
+	/**
+	 * Index signature so `InstalledPlugin` satisfies the
+	 * `T extends Record<string, unknown>` constraint on `WpdTable<T>`.
+	 * Same shape posts-window uses for `PostListItem`.
+	 */
+	[ key: string ]: unknown;
+}
+
+/**
+ * A single plugin entry in the wp.org Browse response. Mirrors the
+ * `plugins_api( 'query_plugins' )` row shape for the field set our
+ * AJAX `browse` action requests.
+ */
+export interface WpOrgBrowsePlugin {
+	slug: string;
+	name: string;
+	version: string;
+	author: string;
+	author_profile?: string;
+	homepage?: string;
+	short_description: string;
+	rating: number;
+	num_ratings: number;
+	active_installs: number;
+	last_updated: string;
+	tested: string;
+	requires?: string;
+	requires_php?: string;
+	icons?: Record< string, string >;
+	banners?: Record< string, string >;
+	download_link?: string;
+}
+
+/**
+ * The `plugins_api( 'plugin_information' )` response — far richer than
+ * Browse rows; includes the full description sections, screenshots,
+ * ratings histogram, and contributors.
+ */
+export interface WpOrgPluginInfo extends WpOrgBrowsePlugin {
+	sections?: Record< string, string >;
+	screenshots?: Record< string, { src: string; caption: string } >;
+	ratings?: Record< string, number >;
+	contributors?: Record< string, { profile: string; avatar: string; display_name: string } >;
+	donate_link?: string;
+}
+
+/** Browse filters (mirror the wp.org `browse` arg whitelist). */
+export type BrowseFilter =
+	| 'featured'
+	| 'popular'
+	| 'recommended'
+	| 'favorites'
+	| 'new'
+	| 'beta'
+	| 'updated';
+
+/** A single review parsed from the wp.org plugin reviews page. */
+export interface PluginReview {
+	author: string;
+	stars: number;
+	excerpt: string;
+	date: string;
+	url: string;
+}
+
+/** Response shape for our `wp_ajax_desktop_mode_plugins_reviews` action. */
+export interface PluginReviewsResponse {
+	items: PluginReview[];
+	parsed: boolean;
+	reason?: string;
+}

--- a/src/plugins-window/upload-dialog.ts
+++ b/src/plugins-window/upload-dialog.ts
@@ -1,0 +1,287 @@
+/**
+ * Native Plugins window — .zip upload dialog.
+ *
+ * Opens a `<wpd-confirm-dialog>` styled with a custom slot
+ * containing a file picker + drop zone. Submits to our
+ * `wp_ajax_desktop_mode_plugins_upload` action via `uploadPluginZip`.
+ *
+ * Public surface: `openUploadDialog( hostBody, prefilledFile? )`. The
+ * window-level drop-zone overlay (in `browse-view.ts`) calls this with
+ * the dropped file pre-applied so the user just confirms.
+ *
+ * @public
+ * @since 0.9.0
+ */
+
+import { __, sprintf } from '../i18n';
+import { refreshFrameworkMenu, uploadPluginZip } from './rest';
+
+interface UploadResult {
+	plugin_file: string;
+	status: 'inactive';
+	messages: string[];
+}
+
+export interface UploadCallbacks {
+	onUploaded?: ( result: UploadResult ) => void;
+}
+
+/**
+ * Open the upload dialog. Returns a promise that resolves with the
+ * upload result on success, or `null` when the user cancels.
+ */
+export function openUploadDialog(
+	host: HTMLElement,
+	prefilled: File | null,
+	callbacks: UploadCallbacks = {},
+): Promise< UploadResult | null > {
+	return new Promise( ( resolve ) => {
+		const overlay = document.createElement( 'div' );
+		overlay.className = 'desktop-mode-plugins__upload-overlay';
+
+		const card = document.createElement( 'div' );
+		card.className = 'desktop-mode-plugins__upload-card';
+		card.setAttribute( 'role', 'dialog' );
+		card.setAttribute( 'aria-modal', 'true' );
+		card.setAttribute(
+			'aria-label',
+			__( 'Upload a plugin .zip', 'desktop-mode' ),
+		);
+
+		const heading = document.createElement( 'h2' );
+		heading.className = 'desktop-mode-plugins__upload-heading';
+		heading.textContent = __( 'Upload a plugin', 'desktop-mode' );
+		const lede = document.createElement( 'p' );
+		lede.className = 'desktop-mode-plugins__upload-lede';
+		lede.textContent = __(
+			'Pick a .zip file from your computer, or drop one onto the area below.',
+			'desktop-mode',
+		);
+
+		const dropZone = document.createElement( 'div' );
+		dropZone.className = 'desktop-mode-plugins__upload-dropzone';
+		dropZone.tabIndex = 0;
+		dropZone.setAttribute( 'role', 'button' );
+		dropZone.setAttribute(
+			'aria-label',
+			__(
+				'Drop a .zip plugin file here, or click to choose a file.',
+				'desktop-mode',
+			),
+		);
+
+		const dropIcon = document.createElement( 'span' );
+		dropIcon.className =
+			'dashicons dashicons-upload desktop-mode-plugins__upload-icon';
+		dropIcon.setAttribute( 'aria-hidden', 'true' );
+		const dropHint = document.createElement( 'p' );
+		dropHint.className = 'desktop-mode-plugins__upload-hint';
+		dropHint.textContent = __(
+			'Drop your .zip here or click to browse',
+			'desktop-mode',
+		);
+		const fileLabel = document.createElement( 'p' );
+		fileLabel.className = 'desktop-mode-plugins__upload-filename';
+		fileLabel.hidden = true;
+
+		dropZone.append( dropIcon, dropHint, fileLabel );
+
+		const input = document.createElement( 'input' );
+		input.type = 'file';
+		input.accept = '.zip,application/zip,application/x-zip-compressed';
+		input.style.display = 'none';
+		dropZone.appendChild( input );
+
+		const status = document.createElement( 'p' );
+		status.className = 'desktop-mode-plugins__upload-status';
+		status.hidden = true;
+
+		const actions = document.createElement( 'div' );
+		actions.className = 'desktop-mode-plugins__upload-actions';
+		const cancelBtn = document.createElement( 'wpd-button' );
+		cancelBtn.setAttribute( 'variant', 'ghost' );
+		cancelBtn.textContent = __( 'Cancel', 'desktop-mode' );
+		const submitBtn = document.createElement( 'wpd-button' );
+		submitBtn.setAttribute( 'variant', 'primary' );
+		submitBtn.textContent = __( 'Install', 'desktop-mode' );
+		submitBtn.setAttribute( 'disabled', '' );
+		actions.append( cancelBtn, submitBtn );
+
+		card.append( heading, lede, dropZone, status, actions );
+		overlay.appendChild( card );
+		host.appendChild( overlay );
+
+		// ─── State ──────────────────────────────────────────────────
+		let pickedFile: File | null = null;
+		let uploading = false;
+
+		const setFile = ( file: File | null ): void => {
+			pickedFile = file;
+			if ( file ) {
+				dropZone.classList.add( 'has-file' );
+				fileLabel.hidden = false;
+				fileLabel.textContent = sprintf(
+					/* translators: 1: file name, 2: file size in KB */
+					__( '%1$s · %2$s KB', 'desktop-mode' ),
+					file.name,
+					Math.round( file.size / 1024 ).toString(),
+				);
+				submitBtn.removeAttribute( 'disabled' );
+			} else {
+				dropZone.classList.remove( 'has-file' );
+				fileLabel.hidden = true;
+				submitBtn.setAttribute( 'disabled', '' );
+			}
+		};
+
+		// ─── Wire up ────────────────────────────────────────────────
+		dropZone.addEventListener( 'click', ( ev ) => {
+			if ( ( ev.target as HTMLElement )?.tagName === 'INPUT' ) {
+				return;
+			}
+			input.click();
+		} );
+		dropZone.addEventListener( 'keydown', ( ev: KeyboardEvent ) => {
+			if ( ev.key === 'Enter' || ev.key === ' ' ) {
+				ev.preventDefault();
+				input.click();
+			}
+		} );
+		dropZone.addEventListener( 'dragover', ( ev ) => {
+			ev.preventDefault();
+			dropZone.classList.add( 'is-hovered' );
+		} );
+		dropZone.addEventListener( 'dragleave', () => {
+			dropZone.classList.remove( 'is-hovered' );
+		} );
+		dropZone.addEventListener( 'drop', ( ev: DragEvent ) => {
+			ev.preventDefault();
+			dropZone.classList.remove( 'is-hovered' );
+			const file = ev.dataTransfer?.files?.[ 0 ];
+			if ( file && isZip( file ) ) {
+				setFile( file );
+			} else if ( file ) {
+				showStatus(
+					__( 'Only .zip files are accepted.', 'desktop-mode' ),
+					'error',
+				);
+			}
+		} );
+		input.addEventListener( 'change', () => {
+			const file = input.files?.[ 0 ];
+			if ( file && isZip( file ) ) {
+				setFile( file );
+			}
+		} );
+
+		const close = ( result: UploadResult | null ): void => {
+			document.removeEventListener( 'keydown', onKey );
+			overlay.remove();
+			resolve( result );
+		};
+		const onKey = ( ev: KeyboardEvent ): void => {
+			if ( ev.key === 'Escape' && ! uploading ) {
+				close( null );
+			}
+		};
+		document.addEventListener( 'keydown', onKey );
+
+		cancelBtn.addEventListener( 'click', () => {
+			if ( uploading ) {
+				return;
+			}
+			close( null );
+		} );
+
+		submitBtn.addEventListener( 'click', () => {
+			if ( ! pickedFile || uploading ) {
+				return;
+			}
+			void runUpload();
+		} );
+
+		overlay.addEventListener( 'click', ( ev ) => {
+			if ( ev.target === overlay && ! uploading ) {
+				close( null );
+			}
+		} );
+
+		// Pre-populate the file slot when the caller passed one (drop
+		// onto the window body bypasses the picker).
+		if ( prefilled && isZip( prefilled ) ) {
+			setFile( prefilled );
+		}
+
+		async function runUpload(): Promise< void > {
+			if ( ! pickedFile ) {
+				return;
+			}
+			uploading = true;
+			submitBtn.setAttribute( 'busy', '' );
+			submitBtn.setAttribute( 'disabled', '' );
+			cancelBtn.setAttribute( 'disabled', '' );
+			showStatus(
+				__( 'Uploading and installing…', 'desktop-mode' ),
+				'info',
+			);
+			try {
+				const result = await uploadPluginZip( pickedFile );
+				await refreshFrameworkMenu();
+				if ( callbacks.onUploaded ) {
+					callbacks.onUploaded( result );
+				}
+				showStatus(
+					sprintf(
+						/* translators: %s: plugin file (e.g. akismet/akismet.php) */
+						__( 'Installed %s. Activate it from the Installed tab.', 'desktop-mode' ),
+						result.plugin_file,
+					),
+					'success',
+				);
+				// Brief celebratory pause so the user reads the success
+				// message; then close. Skipped during tests where the
+				// jsdom timer doesn't realistically run.
+				window.setTimeout( () => close( result ), 1200 );
+			} catch ( err ) {
+				uploading = false;
+				submitBtn.removeAttribute( 'busy' );
+				submitBtn.removeAttribute( 'disabled' );
+				cancelBtn.removeAttribute( 'disabled' );
+				const message =
+					err instanceof Error ? err.message : String( err );
+				showStatus(
+					sprintf(
+						/* translators: %s: error message from the upload handler */
+						__( 'Upload failed: %s', 'desktop-mode' ),
+						message,
+					),
+					'error',
+				);
+			}
+		}
+
+		function showStatus(
+			message: string,
+			tone: 'info' | 'success' | 'error',
+		): void {
+			status.hidden = false;
+			status.dataset.tone = tone;
+			status.textContent = message;
+		}
+
+		// Focus the dropzone so keyboard users can immediately Enter
+		// to open the file picker.
+		window.setTimeout( () => dropZone.focus(), 16 );
+	} );
+}
+
+function isZip( file: File ): boolean {
+	if ( file.size <= 0 ) {
+		return false;
+	}
+	const name = file.name.toLowerCase();
+	if ( name.endsWith( '.zip' ) ) {
+		return true;
+	}
+	return file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
+}

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -179,6 +179,11 @@ export const DEFAULTS: OsSettingsState = {
 	// `list_users`), so flipping this off only affects the small set
 	// of users who can see the Users tile in the first place.
 	nativeUsersEnabled: true,
+	// Native Plugins window — replaces `plugins.php` and
+	// `plugin-install.php`. Same opt-out posture; cap-gated on
+	// `activate_plugins` server-side, so flipping this off only
+	// affects users who could see the Plugins tile anyway.
+	nativePluginsEnabled: true,
 };
 
 /**

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -145,6 +145,7 @@ export class OsSettings implements SettingsCtx {
 			nativePostsHiddenColumns: this.state.nativePostsHiddenColumns.slice(),
 			nativePagesEnabled: this.state.nativePagesEnabled,
 			nativeUsersEnabled: this.state.nativeUsersEnabled,
+			nativePluginsEnabled: this.state.nativePluginsEnabled,
 		};
 	}
 

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -94,6 +94,14 @@ export interface OsSettingsSnapshot {
 	 * @since 0.18.0
 	 */
 	nativeUsersEnabled: boolean;
+	/**
+	 * Per-user opt-in for the native Plugins window. Same posture as
+	 * {@link nativeUsersEnabled} — UI-side gate; the window itself is
+	 * cap-gated on the server (`activate_plugins`). Default on.
+	 *
+	 * @since 0.9.0
+	 */
+	nativePluginsEnabled: boolean;
 }
 
 export interface SettingsTabRenderCtx {

--- a/src/settings/sections/features.ts
+++ b/src/settings/sections/features.ts
@@ -52,6 +52,13 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 		paint();
 	};
 
+	const onNativePluginsToggle = ( e: Event ): void => {
+		const checked = ( e as CustomEvent ).detail?.checked === true;
+		ctx.state.nativePluginsEnabled = checked;
+		ctx.save();
+		paint();
+	};
+
 	let resetting = false;
 	const onResetIntros = async (): Promise< void > => {
 		if ( resetting ) {
@@ -121,6 +128,16 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 					<p class="desktop-mode-features__hint">
 						${ __(
 							'A native Users list with bulk role change, last-login tracking, live online indicators, click-to-copy email, and one-click password resets. Capability-gated — readers see a read-only view, role assignment respects WordPress role permissions. On by default.',
+						) }
+					</p>
+					<wpd-checkbox-label
+						label=${ __( 'Use the native Plugins window' ) }
+						?checked=${ ctx.state.nativePluginsEnabled }
+						@wpd-checkbox-change=${ onNativePluginsToggle }
+					></wpd-checkbox-label>
+					<p class="desktop-mode-features__hint">
+						${ __(
+							'A native two-tab Plugins window: an Installed list with bulk activate / deactivate / delete, and a Browse gallery powered by the WordPress.org repository — rich detail flyout with screenshots, ratings histogram, and recent reviews. Drag a .zip onto the window to install, or drag a card from Browse to the dock to pin it. On by default.',
 						) }
 					</p>
 					<div class="desktop-mode-features__row">

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -148,6 +148,10 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 			typeof parsed.nativeUsersEnabled === 'boolean'
 				? parsed.nativeUsersEnabled
 				: DEFAULTS.nativeUsersEnabled,
+		nativePluginsEnabled:
+			typeof parsed.nativePluginsEnabled === 'boolean'
+				? parsed.nativePluginsEnabled
+				: DEFAULTS.nativePluginsEnabled,
 	};
 }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -162,6 +162,19 @@ export interface OsSettingsState {
 	 * @since 0.18.0
 	 */
 	nativeUsersEnabled: boolean;
+	/**
+	 * Per-user opt-in for the native Plugins window. When true, the
+	 * Plugins dock tile / `plugins.php` / `plugin-install.php` links
+	 * open the native two-tab window (Installed list + wp.org Browse
+	 * gallery) instead of the chromeless iframes. Defaults on.
+	 * Capability-gated on the server (`activate_plugins`); the Browse
+	 * tab is hidden for users without `install_plugins`. The
+	 * `plugin-editor.php` URL is intentionally NOT claimed — it stays
+	 * on the existing code-editor iframe.
+	 *
+	 * @since 0.9.0
+	 */
+	nativePluginsEnabled: boolean;
 }
 
 /**

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -83,6 +83,7 @@ export { WpdCategoryPicker } from './wpd-category-picker/wpd-category-picker';
 export type { WpdCategoryItem } from './wpd-category-picker/wpd-category-picker';
 export { WpdCrumbChain } from './wpd-crumb-chain/wpd-crumb-chain';
 export type { WpdCrumbSegment } from './wpd-crumb-chain/wpd-crumb-chain';
+export { WpdCard } from './wpd-card/wpd-card';
 
 // List of tags registered by this barrel. `doAction(
 // COMPONENTS_REGISTERED, { tags } )` fires once from
@@ -144,4 +145,5 @@ export const WPD_COMPONENT_TAGS = [
 	'wpd-save-status',
 	'wpd-category-picker',
 	'wpd-crumb-chain',
+	'wpd-card',
 ] as const;

--- a/src/ui/components/wpd-card/wpd-card.styles.ts
+++ b/src/ui/components/wpd-card/wpd-card.styles.ts
@@ -1,0 +1,93 @@
+import { css } from '../../core';
+
+export const styles = css`
+	:host {
+		display: flex;
+		flex-direction: column;
+		gap: var( --wpd-card-gap, 12px );
+		padding: var( --wpd-card-padding, 16px );
+		border: 1px solid var( --wpd-card-border, var( --wpd-border, rgba( 0, 0, 0, 0.08 ) ) );
+		border-radius: var( --wpd-card-radius, 12px );
+		background: var( --wpd-card-bg, #fff );
+		color: var( --wpd-card-fg, inherit );
+		box-sizing: border-box;
+		min-width: 0;
+		transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+	}
+
+	:host( [ hidden ] ) {
+		display: none;
+	}
+
+	:host( [ compact ] ) {
+		padding: var( --wpd-card-padding-compact, 10px );
+		gap: var( --wpd-card-gap-compact, 6px );
+		border-radius: var( --wpd-card-radius-compact, 8px );
+	}
+
+	:host( [ interactive ] ) {
+		cursor: pointer;
+		outline-offset: 2px;
+	}
+
+	/* Hover lift only when the card is interactive — non-clickable
+	 * cards (e.g. read-only tile in a digest list) shouldn't grow on
+	 * mouseover. */
+	:host( [ interactive ]:hover ),
+	:host( [ interactive ]:focus-visible ) {
+		transform: translateY( -2px );
+		box-shadow: var(
+			--wpd-card-shadow-hover,
+			0 4px 16px rgba( 0, 0, 0, 0.08 )
+		);
+		border-color: var(
+			--wpd-card-border-hover,
+			var( --wpd-border-strong, rgba( 0, 0, 0, 0.16 ) )
+		);
+	}
+
+	:host( [ selected ] ) {
+		border-color: var(
+			--wpd-card-border-selected,
+			var( --wp-admin-theme-color, #2271b1 )
+		);
+		box-shadow: var(
+			--wpd-card-shadow-selected,
+			0 0 0 1px var( --wp-admin-theme-color, #2271b1 ) inset
+		);
+	}
+
+	:host( [ disabled ] ) {
+		opacity: 0.55;
+		pointer-events: none;
+		cursor: not-allowed;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host {
+			transition: none;
+		}
+		:host( [ interactive ]:hover ),
+		:host( [ interactive ]:focus-visible ) {
+			transform: none;
+		}
+	}
+
+	/* Slotted header / footer rhythm — pure CSS so consumers don't
+	 * need separate wpd-card-header / wpd-card-footer tags to get
+	 * the standard layout. */
+	::slotted( header ) {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		min-width: 0;
+	}
+
+	::slotted( footer ) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		margin-top: auto;
+	}
+`;

--- a/src/ui/components/wpd-card/wpd-card.test.ts
+++ b/src/ui/components/wpd-card/wpd-card.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import './wpd-card';
+
+const tick = (): Promise< void > =>
+	new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+describe( '<wpd-card>', () => {
+	let host: HTMLElement;
+	beforeEach( () => {
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+	} );
+	afterEach( () => host.remove() );
+
+	test( 'non-interactive cards do NOT add role / tabindex', async () => {
+		host.innerHTML = `<wpd-card></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		expect( card.hasAttribute( 'role' ) ).toBe( false );
+		expect( card.hasAttribute( 'tabindex' ) ).toBe( false );
+	} );
+
+	test( 'interactive cards expose role="button" + tabindex="0"', async () => {
+		host.innerHTML = `<wpd-card interactive></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		expect( card.getAttribute( 'role' ) ).toBe( 'button' );
+		expect( card.getAttribute( 'tabindex' ) ).toBe( '0' );
+		expect( card.getAttribute( 'aria-disabled' ) ).toBe( 'false' );
+	} );
+
+	test( 'disabled interactive cards are tab-skipped', async () => {
+		host.innerHTML = `<wpd-card interactive disabled></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		expect( card.getAttribute( 'tabindex' ) ).toBe( '-1' );
+		expect( card.getAttribute( 'aria-disabled' ) ).toBe( 'true' );
+	} );
+
+	test( 'click on an interactive card fires wpd-card-click', async () => {
+		host.innerHTML = `<wpd-card interactive></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		const onClick = vi.fn();
+		card.addEventListener( 'wpd-card-click', onClick );
+		card.click();
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'click on a non-interactive card does NOT fire', async () => {
+		host.innerHTML = `<wpd-card></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		const onClick = vi.fn();
+		card.addEventListener( 'wpd-card-click', onClick );
+		card.click();
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+
+	test( 'click on a [data-noclick] descendant is ignored', async () => {
+		host.innerHTML = `
+			<wpd-card interactive>
+				<button data-noclick id="btn">Action</button>
+			</wpd-card>
+		`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		const btn = host.querySelector< HTMLElement >( '#btn' )!;
+		const onClick = vi.fn();
+		card.addEventListener( 'wpd-card-click', onClick );
+		btn.click();
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Enter on an interactive card fires wpd-card-click', async () => {
+		host.innerHTML = `<wpd-card interactive></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		const onClick = vi.fn();
+		card.addEventListener( 'wpd-card-click', onClick );
+		card.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } ),
+		);
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'disabled card swallows clicks', async () => {
+		host.innerHTML = `<wpd-card interactive disabled></wpd-card>`;
+		await tick();
+		const card = host.querySelector< HTMLElement >( 'wpd-card' )!;
+		const onClick = vi.fn();
+		card.addEventListener( 'wpd-card-click', onClick );
+		card.click();
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/ui/components/wpd-card/wpd-card.ts
+++ b/src/ui/components/wpd-card/wpd-card.ts
@@ -1,0 +1,246 @@
+/**
+ * `<wpd-card>` — generic, hover-aware container card.
+ *
+ * Same role `<article>` would play, plus:
+ *
+ *   - `interactive` makes the host focusable + click-emitting (cursor,
+ *     tabindex=0, `role="button"`, Enter / Space keyboard fire the
+ *     same `wpd-card-click` event as the mouse). Non-interactive
+ *     cards stay inert — read-only digest tiles don't want a hover
+ *     lift or a button role.
+ *   - `selected` paints the accent ring (current item in a picker).
+ *   - `disabled` fades the host and ignores pointer / key events.
+ *   - Hover lift, shadow, smooth transition. `prefers-reduced-motion`
+ *     disables every transform.
+ *   - Three slot rhythms via `::slotted` rules so consumers can
+ *     drop a plain `<header>` / `<footer>` and get the standard
+ *     header-row / footer-pinned-to-bottom layout for free.
+ *
+ * The shape stays small — anything richer than "container with the
+ * standard look" belongs to a feature-specific layer that wraps
+ * `<wpd-card>` (e.g. the Plugins gallery card factory).
+ *
+ * Usage:
+ *
+ *   <wpd-card interactive @wpd-card-click="${ ... }">
+ *     <header><img/><h3>Title</h3></header>
+ *     <p>Description</p>
+ *     <footer><span>meta</span><wpd-button>Action</wpd-button></footer>
+ *   </wpd-card>
+ *
+ * Attributes:
+ *   - `interactive` — boolean, surfaces hover lift + emits
+ *                     `wpd-card-click`.
+ *   - `selected`    — boolean, paints the accent ring.
+ *   - `compact`     — boolean, smaller padding + radius.
+ *   - `disabled`    — boolean, fades + blocks input.
+ *   - `aria-label`  — used by screen readers as the card's name when
+ *                     interactive (no inferred label).
+ *
+ * Events:
+ *   - `wpd-card-click` — `{ originalEvent: MouseEvent | KeyboardEvent }`.
+ *     Fired when an interactive card is clicked or Enter / Space is
+ *     pressed. Skips clicks on `data-noclick` descendants so action
+ *     buttons inside the card don't double-fire (matches
+ *     `<wpd-table>`'s row-click semantics).
+ *
+ * @since 0.9.0
+ */
+
+import { Component, defineComponent, html } from '../../core';
+import { styles } from './wpd-card.styles';
+
+const NOCLICK_SELECTOR = '[data-noclick]';
+
+interface CardClickDetail {
+	originalEvent: MouseEvent | KeyboardEvent;
+}
+
+export class WpdCard extends Component {
+	static props = [
+		'interactive',
+		'selected',
+		'compact',
+		'disabled',
+	] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Card',
+		summary:
+			'Generic hover-aware container. Becomes click-emitting + focusable when `interactive`. Slots for header / default body / footer have built-in layout rhythm so consumers don\'t need bespoke wrapper components.',
+		status: 'stable',
+		since: '0.9.0',
+		props: [
+			{
+				name: 'interactive',
+				type: 'boolean',
+				default: 'false',
+				description:
+					'Surfaces hover lift + cursor + role="button" + emits `wpd-card-click` on click / Enter / Space.',
+			},
+			{
+				name: 'selected',
+				type: 'boolean',
+				default: 'false',
+				description:
+					'Paints the accent ring — pickers / single-selection lists turn this on for the active card.',
+			},
+			{
+				name: 'compact',
+				type: 'boolean',
+				default: 'false',
+				description: 'Tighter padding + smaller radius for dense lists.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean',
+				default: 'false',
+				description:
+					'Fades the card and blocks pointer / key input. No `wpd-card-click` while disabled.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-card-click',
+				detail: '{ originalEvent: MouseEvent | KeyboardEvent }',
+				description:
+					'Fires when an interactive card is activated. Skips events whose target is inside a `[data-noclick]` descendant so inline action buttons don\'t double-fire.',
+			},
+		],
+		slots: [
+			{
+				name: '(default)',
+				description: 'Card body. Free-form content.',
+			},
+			{
+				name: 'header',
+				description:
+					'Top slot — laid out as a flex row with 12px gap. Drop an `<img>` / icon plus a title block.',
+			},
+			{
+				name: 'footer',
+				description:
+					'Bottom slot — pinned via `margin-top: auto`. Standard pattern: meta on the left, primary CTA on the right.',
+			},
+		],
+		cssProps: [
+			{ name: '--wpd-card-bg', default: '#fff' },
+			{ name: '--wpd-card-fg', default: 'inherit' },
+			{ name: '--wpd-card-padding', default: '16px' },
+			{ name: '--wpd-card-padding-compact', default: '10px' },
+			{ name: '--wpd-card-gap', default: '12px' },
+			{ name: '--wpd-card-gap-compact', default: '6px' },
+			{ name: '--wpd-card-radius', default: '12px' },
+			{ name: '--wpd-card-radius-compact', default: '8px' },
+			{ name: '--wpd-card-border', default: 'var(--wpd-border, rgba(0,0,0,0.08))' },
+			{ name: '--wpd-card-border-hover', default: 'var(--wpd-border-strong, rgba(0,0,0,0.16))' },
+			{ name: '--wpd-card-border-selected', default: 'var(--wp-admin-theme-color, #2271b1)' },
+			{ name: '--wpd-card-shadow-hover', default: '0 4px 16px rgba(0,0,0,0.08)' },
+		],
+		example: html`
+			<wpd-card interactive>
+				<header>
+					<wpd-icon name="dashicons-admin-plugins" size="40"></wpd-icon>
+					<div>
+						<h3>Akismet</h3>
+						<p>by Automattic</p>
+					</div>
+				</header>
+				<p>The anti-spam service for WordPress sites.</p>
+				<footer>
+					<span>1M+ active</span>
+					<wpd-button variant="primary" data-noclick>Install</wpd-button>
+				</footer>
+			</wpd-card>
+		`,
+	} as const;
+
+	connectedCallback(): void {
+		super.connectedCallback();
+		this._syncRoles();
+		this.addEventListener( 'click', this._onClick );
+		this.addEventListener( 'keydown', this._onKeyDown );
+	}
+
+	disconnectedCallback(): void {
+		this.removeEventListener( 'click', this._onClick );
+		this.removeEventListener( 'keydown', this._onKeyDown );
+	}
+
+	protected render() {
+		// Re-sync the ARIA + tabindex set whenever a prop changes.
+		// `connectedCallback` runs once on first mount; this picks up
+		// `interactive`/`disabled` flips after that.
+		this._syncRoles();
+		return html`<slot name="header"></slot><slot></slot><slot name="footer"></slot>`;
+	}
+
+	private _syncRoles(): void {
+		const interactive = this.hasAttribute( 'interactive' );
+		const disabled = this.hasAttribute( 'disabled' );
+		if ( interactive ) {
+			if ( ! this.hasAttribute( 'role' ) ) {
+				this.setAttribute( 'role', 'button' );
+			}
+			// Disabled cards are NOT focusable — Tab order skips them.
+			this.setAttribute( 'tabindex', disabled ? '-1' : '0' );
+			this.setAttribute( 'aria-disabled', disabled ? 'true' : 'false' );
+		} else {
+			this.removeAttribute( 'role' );
+			this.removeAttribute( 'tabindex' );
+			this.removeAttribute( 'aria-disabled' );
+		}
+	}
+
+	private _onClick = ( ev: MouseEvent ): void => {
+		if ( ! this.hasAttribute( 'interactive' ) || this.hasAttribute( 'disabled' ) ) {
+			return;
+		}
+		const target = ev.target as HTMLElement | null;
+		if ( target?.closest( NOCLICK_SELECTOR ) ) {
+			return;
+		}
+		this._emitCardClick( ev );
+	};
+
+	private _onKeyDown = ( ev: KeyboardEvent ): void => {
+		if ( ! this.hasAttribute( 'interactive' ) || this.hasAttribute( 'disabled' ) ) {
+			return;
+		}
+		if ( ev.key !== 'Enter' && ev.key !== ' ' && ev.key !== 'Spacebar' ) {
+			return;
+		}
+		const target = ev.target as HTMLElement | null;
+		if ( target && target !== this && target.closest( NOCLICK_SELECTOR ) ) {
+			return;
+		}
+		// Don't double-fire when the user pressed Space INSIDE a button —
+		// the button's own click handler already runs.
+		if (
+			target instanceof HTMLElement &&
+			target !== this &&
+			( target.tagName === 'BUTTON' ||
+				target.tagName === 'A' ||
+				target.tagName === 'INPUT' ||
+				target.tagName === 'TEXTAREA' ||
+				target.tagName === 'SELECT' )
+		) {
+			return;
+		}
+		ev.preventDefault();
+		this._emitCardClick( ev );
+	};
+
+	private _emitCardClick( originalEvent: MouseEvent | KeyboardEvent ): void {
+		this.dispatchEvent(
+			new CustomEvent< CardClickDetail >( 'wpd-card-click', {
+				detail: { originalEvent },
+				bubbles: true,
+				composed: true,
+			} ),
+		);
+	}
+}
+
+defineComponent( 'wpd-card', WpdCard );

--- a/tests/phpunit/tests/desktopModeRender.php
+++ b/tests/phpunit/tests/desktopModeRender.php
@@ -309,6 +309,57 @@ class Tests_DesktopMode_Render extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The capture-phase click handler runs BEFORE wp-admin/js/updates.js's
+	 * own bubble-phase handler. If the bridge intercepts and preventDefaults
+	 * a click on `.install-now` / `.update-link` / `.delete-plugin` etc.,
+	 * core's AJAX install/update/delete flow never starts and the user is
+	 * diverted to the no-JS update.php fallback — opened as a freshly
+	 * spawned desktop window that takes seconds to load. Pin the skip list
+	 * so a future refactor doesn't silently bring the regression back.
+	 *
+	 * @covers ::desktop_mode_chromeless_bridge_script
+	 */
+	public function test_bridge_script_skips_wp_core_ajax_update_buttons() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['desktop_mode_chromeless'] = '1';
+
+		ob_start();
+		desktop_mode_chromeless_bridge_script();
+		$output = ob_get_clean();
+
+		// Each class WP core's wp-admin/js/updates.js binds an AJAX
+		// click handler to. The bridge must early-return on these so
+		// updates.js's bubble handler can run.
+		$ajax_classes = array(
+			'install-now',
+			'update-link',
+			'update-now',
+			'delete-plugin',
+			'delete-theme',
+			'install-theme',
+		);
+		foreach ( $ajax_classes as $class ) {
+			$this->assertStringContainsString(
+				"link.classList.contains( '{$class}' )",
+				$output,
+				"Bridge must skip clicks on .{$class} so wp-admin/js/updates.js can run."
+			);
+		}
+
+		// The skip block must sit BEFORE the `kind === 'admin'`
+		// branch — otherwise we'd preventDefault before the bail.
+		$skip_pos  = strpos( $output, "link.classList.contains( 'install-now' )" );
+		$admin_pos = strpos( $output, "kind === 'admin'" );
+		$this->assertNotFalse( $skip_pos );
+		$this->assertNotFalse( $admin_pos );
+		$this->assertLessThan(
+			$admin_pos,
+			$skip_pos,
+			'AJAX-class skip must run before the admin-link prevent-default block.'
+		);
+	}
+
+	/**
 	 * @covers ::desktop_mode_classic_link_interceptor
 	 */
 	public function test_classic_interceptor_emits_nothing_without_flag() {

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Tests for the native Plugins window's PHP registration + cap gates.
+ *
+ * The Plugins window is gated on `activate_plugins` (broad gate) plus
+ * the `nativePluginsEnabled` opt-out toggle. Per-action mutation caps
+ * (`install_plugins`, `delete_plugins`, `upload_plugins`) are
+ * enforced inside the AJAX callbacks themselves; these tests cover
+ * the registration gate + the per-row capability surface
+ * (`desktop_mode_plugins_window_caps`).
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-plugins-window
+ */
+class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
+
+	private $admin_id;
+	private $editor_id;
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->editor_id     = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function tear_down() {
+		// Make sure no test leaks an opt-in state into the next.
+		remove_all_filters( 'desktop_mode_plugins_window_user_can_register' );
+		remove_all_filters( 'desktop_mode_plugins_window_user_can_use' );
+		parent::tear_down();
+	}
+
+	// ----------------------------------------------------------------
+	// `_user_can_register` — cap-only gate. Decoupled from the opt-in
+	// so flipping the OS-Settings toggle takes effect mid-session.
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_register
+	 */
+	public function test_register_gate_open_for_admin_without_opt_in() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( desktop_mode_plugins_window_user_can_register() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_register
+	 */
+	public function test_register_gate_closed_for_editor() {
+		// Editors don't have `activate_plugins` on a single-site install.
+		wp_set_current_user( $this->editor_id );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_register() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_register
+	 */
+	public function test_register_gate_closed_for_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_register() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_register
+	 */
+	public function test_register_gate_closed_for_logged_out_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_register() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_register
+	 */
+	public function test_register_filter_can_block_a_capable_user() {
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'desktop_mode_plugins_window_user_can_register', '__return_false' );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_register() );
+	}
+
+	// ----------------------------------------------------------------
+	// `_user_can_use` — combined cap + opt-in.
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_use
+	 */
+	public function test_gate_open_by_default_for_admins() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( desktop_mode_plugins_window_user_can_use() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_use
+	 */
+	public function test_gate_closes_when_admin_opts_out() {
+		wp_set_current_user( $this->admin_id );
+		desktop_mode_save_os_settings(
+			$this->admin_id,
+			array( 'nativePluginsEnabled' => false )
+		);
+		$this->assertFalse( desktop_mode_plugins_window_user_can_use() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_use
+	 */
+	public function test_gate_closed_for_logged_out_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_use() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_use
+	 */
+	public function test_filter_can_force_gate_open() {
+		wp_set_current_user( $this->editor_id );
+		// Editor lacks `activate_plugins` — default would be closed.
+		$this->assertFalse( desktop_mode_plugins_window_user_can_use() );
+
+		add_filter( 'desktop_mode_plugins_window_user_can_use', '__return_true' );
+		$this->assertTrue( desktop_mode_plugins_window_user_can_use() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_user_can_use
+	 */
+	public function test_filter_can_force_gate_closed() {
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'desktop_mode_plugins_window_user_can_use', '__return_false' );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_use() );
+	}
+
+	// ----------------------------------------------------------------
+	// `_caps` — per-action capability surface.
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_caps
+	 */
+	public function test_caps_admin_has_every_action() {
+		wp_set_current_user( $this->admin_id );
+		$caps = desktop_mode_plugins_window_caps();
+		$this->assertTrue( $caps['activate'] );
+		$this->assertTrue( $caps['install'] );
+		$this->assertTrue( $caps['delete'] );
+		$this->assertTrue( $caps['upload'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_caps
+	 */
+	public function test_caps_editor_has_no_plugin_actions() {
+		wp_set_current_user( $this->editor_id );
+		$caps = desktop_mode_plugins_window_caps();
+		$this->assertFalse( $caps['activate'] );
+		$this->assertFalse( $caps['install'] );
+		$this->assertFalse( $caps['delete'] );
+		$this->assertFalse( $caps['upload'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_caps
+	 */
+	public function test_caps_logged_out_user_returns_false_for_every_action() {
+		wp_set_current_user( 0 );
+		$caps = desktop_mode_plugins_window_caps();
+		$this->assertFalse( $caps['activate'] );
+		$this->assertFalse( $caps['install'] );
+		$this->assertFalse( $caps['delete'] );
+		$this->assertFalse( $caps['upload'] );
+	}
+
+	/**
+	 * The OS Settings opt-out flag must round-trip through sanitize +
+	 * load — a regression that drops the key on save would silently
+	 * unset every user who toggled the setting off.
+	 *
+	 * @covers ::desktop_mode_save_os_settings
+	 * @covers ::desktop_mode_get_os_settings
+	 */
+	public function test_native_plugins_enabled_round_trips_through_os_settings() {
+		desktop_mode_save_os_settings(
+			$this->admin_id,
+			array( 'nativePluginsEnabled' => false )
+		);
+		$loaded = desktop_mode_get_os_settings( $this->admin_id );
+		$this->assertArrayHasKey( 'nativePluginsEnabled', $loaded );
+		$this->assertFalse( $loaded['nativePluginsEnabled'] );
+
+		desktop_mode_save_os_settings(
+			$this->admin_id,
+			array( 'nativePluginsEnabled' => true )
+		);
+		$loaded = desktop_mode_get_os_settings( $this->admin_id );
+		$this->assertTrue( $loaded['nativePluginsEnabled'] );
+	}
+
+	/**
+	 * Default OS Settings payload must include the new flag with its
+	 * documented default (true / opt-out).
+	 *
+	 * @covers ::desktop_mode_default_os_settings
+	 */
+	public function test_native_plugins_enabled_defaults_on() {
+		$defaults = desktop_mode_default_os_settings();
+		$this->assertArrayHasKey( 'nativePluginsEnabled', $defaults );
+		$this->assertTrue( $defaults['nativePluginsEnabled'] );
+	}
+
+	/**
+	 * REST-field decorator output for `desktop_mode_can_manage` must
+	 * encode the per-row state correctly: an active plugin can be
+	 * deactivated but not deleted; an inactive plugin can be activated
+	 * AND deleted.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_can_manage
+	 */
+	public function test_can_manage_field_for_active_plugin_row() {
+		wp_set_current_user( $this->admin_id );
+		$row = array(
+			'plugin' => 'fake/fake.php',
+			'status' => 'active',
+		);
+		$flags = desktop_mode_plugins_window_field_can_manage( $row );
+		$this->assertFalse( $flags['activate'] );
+		$this->assertTrue( $flags['deactivate'] );
+		$this->assertFalse( $flags['delete'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_field_can_manage
+	 */
+	public function test_can_manage_field_for_inactive_plugin_row() {
+		wp_set_current_user( $this->admin_id );
+		$row = array(
+			'plugin' => 'fake/fake.php',
+			'status' => 'inactive',
+		);
+		$flags = desktop_mode_plugins_window_field_can_manage( $row );
+		$this->assertTrue( $flags['activate'] );
+		$this->assertFalse( $flags['deactivate'] );
+		$this->assertTrue( $flags['delete'] );
+	}
+
+	/**
+	 * Update-available decorator should report `false` when the
+	 * `update_plugins` transient has no entry for the row.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_update_available
+	 */
+	public function test_update_available_field_reports_false_when_no_update() {
+		// Force a clean state — the test bootstrap may have populated
+		// the transient with whatever the install last fetched.
+		set_site_transient(
+			'update_plugins',
+			(object) array( 'response' => array() )
+		);
+		$row = array( 'plugin' => 'never/installed.php' );
+		$out = desktop_mode_plugins_window_field_update_available( $row );
+		$this->assertFalse( $out['available'] );
+		$this->assertNull( $out['new_version'] );
+	}
+
+	/**
+	 * `desktop_mode_icon_url` should derive a wp.org icon URL from the
+	 * row's `textdomain` and respect the per-row filter.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_icon_url
+	 */
+	public function test_icon_url_derives_from_textdomain() {
+		$row = array(
+			'plugin'     => 'akismet/akismet.php',
+			'textdomain' => 'akismet',
+		);
+		$url = desktop_mode_plugins_window_field_icon_url( $row );
+		$this->assertSame(
+			'https://ps.w.org/akismet/assets/icon.svg',
+			$url
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_field_icon_url
+	 */
+	public function test_icon_url_returns_null_when_no_textdomain() {
+		$row = array( 'plugin' => 'something/something.php' );
+		$this->assertNull( desktop_mode_plugins_window_field_icon_url( $row ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_field_icon_url
+	 */
+	public function test_icon_url_filter_can_override() {
+		add_filter(
+			'desktop_mode_plugins_window_icon_url',
+			static function ( $url, $slug ) {
+				return 'https://cdn.example.com/' . $slug . '.png';
+			},
+			10,
+			2
+		);
+		$row = array(
+			'plugin'     => 'custom/custom.php',
+			'textdomain' => 'custom',
+		);
+		$url = desktop_mode_plugins_window_field_icon_url( $row );
+		$this->assertSame( 'https://cdn.example.com/custom.png', $url );
+		remove_all_filters( 'desktop_mode_plugins_window_icon_url' );
+	}
+}

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -188,7 +188,14 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 		handle.dispose();
 	} );
 
-	test( 'pinned tile pointerdown adds bump class without starting a drag', async () => {
+	test( 'pinned tile silently swallows pointerdown — no bump cue, no drag session', async () => {
+		// As of 0.9.0 we deliberately surface NO upfront visual cue
+		// on pinned tiles (no bump animation, no `not-allowed`
+		// cursor, no pre-emptive tooltip): the tile looks + reacts
+		// identically to a draggable one until the user attempts a
+		// drag, which then fails silently. Pre-emptive cues read as
+		// "this tile is broken/disabled" — we want the failure to
+		// happen at the moment of the gesture, not before.
 		const { layer, store, rest } = await load();
 		store.__resetFilesStoreForTests();
 		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
@@ -206,11 +213,15 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 		const handle = layer.mountFilesLayer( host, 0 );
 		const tile = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
 		expect( tile?.classList.contains( 'desktop-mode-file-tile--pinned' ) ).toBe( true );
+		// `aria-disabled` and the pre-emptive tooltip both went away
+		// in 0.9.0 — clicking the tile still opens the window, so
+		// painting it as "disabled" was misleading.
+		expect( tile?.hasAttribute( 'aria-disabled' ) ).toBe( false );
+		expect( tile?.title ).toBe( '' );
 
 		tile!.dispatchEvent( pointerEvent( 'pointerdown', 50, 50, tile! ) );
 
-		// Bump class is present briefly; no drag session is active.
-		expect( tile?.classList.contains( 'desktop-mode-file-tile--bump' ) ).toBe( true );
+		expect( tile?.classList.contains( 'desktop-mode-file-tile--bump' ) ).toBe( false );
 		expect( manager.getActive() ).toBeNull();
 
 		handle.dispose();

--- a/tests/vitest/plugins-window-rest.test.ts
+++ b/tests/vitest/plugins-window-rest.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the native Plugins window's REST + admin-ajax glue.
+ *
+ * The bundle is a thin layer over `fetch`; the regressions we care
+ * about are:
+ *   1. The window-config blob is required — missing config must
+ *      throw a useful error rather than silently fall back.
+ *   2. `X-WP-Nonce` is attached to every Core REST request.
+ *   3. The admin-ajax envelope `{ success, data }` is unwrapped so
+ *      callers receive the inner `data`.
+ *   4. Install-by-slug uses Core's `'updates'` nonce, NOT our window
+ *      nonce — that's what `wp_ajax_install_plugin` verifies against.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	activateInstalledPlugin,
+	browsePlugins,
+	deactivateInstalledPlugin,
+	deleteInstalledPlugin,
+	fetchInstalledPlugins,
+	getConfig,
+	installPluginBySlug,
+	uploadPluginZip,
+	type PluginsWindowConfig,
+} from '../../src/plugins-window/rest';
+import type { InstalledPlugin } from '../../src/plugins-window/types';
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	interface Window {
+		desktopModeWindowConfig?: Record< string, unknown >;
+	}
+}
+
+const PLUGINS_URL = 'http://example.test/wp-json/wp/v2/plugins';
+const AJAX_URL    = 'http://example.test/wp-admin/admin-ajax.php';
+
+function installConfig( over: Partial< PluginsWindowConfig > = {} ): void {
+	const cfg: PluginsWindowConfig = {
+		restRoot:      'http://example.test/wp-json/',
+		restNonce:     'rest-nonce',
+		pluginsUrl:    PLUGINS_URL,
+		ajaxUrl:       AJAX_URL,
+		ajaxNonce:     'plugins-window-nonce',
+		updatesNonce:  'updates-nonce',
+		caps:          {
+			activate: true,
+			install:  true,
+			delete:   true,
+			upload:   true,
+		},
+		currentUserId: 1,
+		introSeen:     true,
+		introUrl:      'http://example.test/wp-json/desktop-mode/v1/intros/seen',
+		...over,
+	};
+	window.desktopModeWindowConfig = window.desktopModeWindowConfig ?? {};
+	window.desktopModeWindowConfig[ 'desktop-mode-plugins' ] = cfg;
+}
+
+function jsonResponse( body: unknown, status = 200 ): Response {
+	return new Response( JSON.stringify( body ), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	} );
+}
+
+function ajaxOkResponse( data: unknown ): Response {
+	return jsonResponse( { success: true, data } );
+}
+
+const FAKE_INSTALLED: InstalledPlugin = {
+	plugin:     'akismet/akismet.php',
+	status:     'inactive',
+	name:       'Akismet',
+	textdomain: 'akismet',
+};
+
+beforeEach( () => {
+	installConfig();
+} );
+
+afterEach( () => {
+	delete window.desktopModeWindowConfig;
+	vi.restoreAllMocks();
+} );
+
+describe( 'getConfig', () => {
+	test( 'throws when the config blob is missing', () => {
+		delete window.desktopModeWindowConfig;
+		expect( () => getConfig() ).toThrow( /config blob is missing/ );
+	} );
+
+	test( 'returns the registered blob', () => {
+		const cfg = getConfig();
+		expect( cfg.pluginsUrl ).toBe( PLUGINS_URL );
+		expect( cfg.ajaxUrl ).toBe( AJAX_URL );
+	} );
+} );
+
+describe( 'fetchInstalledPlugins', () => {
+	test( 'GETs Core REST with the X-WP-Nonce header', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			jsonResponse( [] ) as never,
+		);
+		await fetchInstalledPlugins();
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		const [ url, init ] = fetchMock.mock.calls[ 0 ] as [
+			string,
+			RequestInit,
+		];
+		expect( url ).toContain( PLUGINS_URL );
+		expect( url ).toContain( 'context=view' );
+		expect( url ).toContain( 'per_page=100' );
+		const headers = ( init.headers ?? {} ) as Record< string, string >;
+		expect( headers[ 'X-WP-Nonce' ] ).toBe( 'rest-nonce' );
+	} );
+
+	test( 'surfaces WP_Error JSON in the thrown error', async () => {
+		vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			new Response(
+				JSON.stringify( {
+					code:    'rest_forbidden',
+					message: 'Sorry, you can’t.',
+				} ),
+				{ status: 403, headers: { 'Content-Type': 'application/json' } },
+			) as never,
+		);
+		await expect( fetchInstalledPlugins() ).rejects.toThrow(
+			/Sorry, you can/,
+		);
+	} );
+} );
+
+describe( 'activate / deactivate / delete', () => {
+	test( 'activate sends PUT with status=active to /plugins/{plugin}', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			jsonResponse( { ...FAKE_INSTALLED, status: 'active' } ) as never,
+		);
+		await activateInstalledPlugin( FAKE_INSTALLED );
+		const [ url, init ] = fetchMock.mock.calls[ 0 ] as [
+			string,
+			RequestInit,
+		];
+		// Per-segment encode — slashes stay literal so Apache's
+		// default `AllowEncodedSlashes Off` doesn't reject the route.
+		expect( url ).toBe(
+			`${ PLUGINS_URL }/${ FAKE_INSTALLED.plugin
+				.split( '/' )
+				.map( encodeURIComponent )
+				.join( '/' ) }`,
+		);
+		// `akismet/akismet.php` has no segment that needs encoding,
+		// so the assertion ends up identical to the literal path.
+		expect( url ).toContain( '/akismet/akismet.php' );
+		expect( init.method ).toBe( 'PUT' );
+		expect( JSON.parse( init.body as string ) ).toEqual( { status: 'active' } );
+	} );
+
+	test( 'deactivate sends PUT with status=inactive', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			jsonResponse( { ...FAKE_INSTALLED, status: 'inactive' } ) as never,
+		);
+		await deactivateInstalledPlugin( {
+			...FAKE_INSTALLED,
+			status: 'active',
+		} );
+		const init = fetchMock.mock.calls[ 0 ]![ 1 ] as RequestInit;
+		expect( JSON.parse( init.body as string ) ).toEqual( { status: 'inactive' } );
+	} );
+
+	test( 'delete sends DELETE with force=true', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			new Response( null, { status: 200 } ) as never,
+		);
+		await deleteInstalledPlugin( FAKE_INSTALLED );
+		const [ url, init ] = fetchMock.mock.calls[ 0 ] as [
+			string,
+			RequestInit,
+		];
+		expect( url ).toContain( 'force=true' );
+		expect( init.method ).toBe( 'DELETE' );
+	} );
+} );
+
+describe( 'browsePlugins', () => {
+	test( 'POSTs to admin-ajax with our nonce + sends the inner data', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			ajaxOkResponse( {
+				plugins: [ { slug: 'akismet', name: 'Akismet' } ],
+				info:    { results: 1 },
+			} ) as never,
+		);
+		const out = await browsePlugins( { browse: 'featured', perPage: 10 } );
+		const [ url, init ] = fetchMock.mock.calls[ 0 ] as [
+			string,
+			RequestInit,
+		];
+		expect( url ).toBe( AJAX_URL );
+		expect( init.method ).toBe( 'POST' );
+		const body = init.body as URLSearchParams;
+		expect( body.get( 'action' ) ).toBe( 'desktop_mode_plugins_browse' );
+		expect( body.get( '_ajax_nonce' ) ).toBe( 'plugins-window-nonce' );
+		expect( body.get( 'browse' ) ).toBe( 'featured' );
+		expect( body.get( 'per_page' ) ).toBe( '10' );
+		expect( out.plugins ).toHaveLength( 1 );
+	} );
+
+	test( 'unwraps a `success: false` envelope into a thrown error', async () => {
+		vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			jsonResponse( {
+				success: false,
+				data:    { message: 'wp.org is sleeping' },
+			} ) as never,
+		);
+		await expect( browsePlugins( {} ) ).rejects.toThrow( /wp\.org is sleeping/ );
+	} );
+} );
+
+describe( 'installPluginBySlug', () => {
+	test( 'uses Core’s `updates` nonce, not our window nonce', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			ajaxOkResponse( { plugin: 'akismet/akismet.php', slug: 'akismet' } ) as never,
+		);
+		await installPluginBySlug( 'akismet' );
+		const init = fetchMock.mock.calls[ 0 ]![ 1 ] as RequestInit;
+		const body = init.body as URLSearchParams;
+		expect( body.get( 'action' ) ).toBe( 'install-plugin' );
+		expect( body.get( '_ajax_nonce' ) ).toBe( 'updates-nonce' );
+		expect( body.get( 'slug' ) ).toBe( 'akismet' );
+	} );
+} );
+
+describe( 'uploadPluginZip', () => {
+	test( 'POSTs multipart with our window nonce + the file under `pluginzip`', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			ajaxOkResponse( {
+				plugin_file: 'akismet/akismet.php',
+				status:      'inactive',
+				messages:    [],
+			} ) as never,
+		);
+		const file = new File(
+			[ 'PK\x03\x04dummy zip bytes' ],
+			'akismet.zip',
+			{ type: 'application/zip' },
+		);
+		await uploadPluginZip( file );
+		const init = fetchMock.mock.calls[ 0 ]![ 1 ] as RequestInit;
+		expect( init.method ).toBe( 'POST' );
+		const data = init.body as FormData;
+		expect( data.get( 'action' ) ).toBe( 'desktop_mode_plugins_upload' );
+		expect( data.get( '_ajax_nonce' ) ).toBe( 'plugins-window-nonce' );
+		const submitted = data.get( 'pluginzip' );
+		expect( submitted ).toBeInstanceOf( File );
+		expect( ( submitted as File ).name ).toBe( 'akismet.zip' );
+	} );
+} );

--- a/vite.config.js
+++ b/vite.config.js
@@ -89,6 +89,17 @@ const TARGETS = {
 		fileBase: 'sw',
 		iifeName: 'desktopModeServiceWorker',
 	},
+	// Native Plugins window — replaces the chromeless `plugins.php`
+	// and `plugin-install.php` iframes with a `<wpd-tabs>`-driven
+	// installed list + browse-the-repo gallery + detail flyout. Same
+	// shape as posts-window: registers a render callback on
+	// `window.desktopModeNativeWindows['desktop-mode-plugins']` and
+	// consumes the `<wpd-*>` tags defined by the main desktop bundle.
+	'plugins-window': {
+		entry:    'src/plugins-window/index.ts',
+		fileBase: 'plugins-window',
+		iifeName: 'desktopModePluginsWindow',
+	},
 };
 
 export default defineConfig( ( { mode } ) => {


### PR DESCRIPTION
Adds a first-class **Plugins** native window to replace the chromeless `plugins.php` + `plugin-install.php` iframes, plus a reusable `<wpd-card>` component for the gallery.

## Highlights

- **Two-tab native window** (`desktop-mode-plugins`, opt-out via `nativePluginsEnabled`):
  - **Installed** — `<wpd-table>` with name + status badge, version + update pill, author, disk size, per-row Activate / Deactivate / Delete + bulk actions. Live dock repaint after every mutation via `wp.desktop.refreshMenu()`.
  - **Browse** — search + segmented filter (Featured / Popular / Recommended / Favorites / New / Beta) + Upload button. Infinite-scroll gallery of `<wpd-card>` tiles with hover lift, lazy icons, and shimmer skeletons during pagination.
- **Detail flyout** (`<wpd-flyout>`) with sticky hero, banner-clipped corners, glass-blur close button, and tabs for **Overview / Screenshots / Reviews / Changelog / FAQ**. Reviews are scraped from wp.org with a histogram-only fallback when parsing fails.
- **Install paths**:
  - by .org slug → calls Core's existing `wp_ajax_install_plugin` (zero reimplementation, uses Core's `'updates'` nonce).
  - by .zip → `wp_ajax_desktop_mode_plugins_upload` accepts a multipart upload **or** drag-drop a .zip onto the window.
- **Drag a card to the dock** → pins via `wp.desktop.registerSystemTile()`. Payload type `'wporg-plugin'` is hookable so plugin authors can register their own drop targets.
- **First-open intro dialog** showcasing the new window (matches the Posts/Pages/Users pattern, persists via the seen-intros REST endpoint).

## New surfaces

- **PHP**: `desktop_mode_plugins_window_user_can_register|use|caps`, `*_args|template_html|browse_args|browse_response|info_response|review_parser|icon_url`, action `desktop_mode_plugins_window_installed`. REST-field decorators on `/wp/v2/plugins`: `desktop_mode_update_available`, `desktop_mode_can_manage`, `desktop_mode_icon_url`, `desktop_mode_size_kb`. AJAX actions: `wp_ajax_desktop_mode_plugins_{browse,info,reviews,upload}`.
- **JS**: `wp.desktop.createSharedStore('desktop-mode/plugins-window/tab-target')` for initial-tab routing; `OsSettingsState.nativePluginsEnabled` + Features toggle.
- **Component**: `<wpd-card>` — `interactive`, `selected`, `compact`, `disabled`, `wpd-card-click` event, `[data-noclick]`-aware, slot rhythms for `<header>` / `<footer>`.

## Notable fixes (during this branch)

- `<wpd-table>` cell content now uses inline styles (cells live in shadow DOM; document CSS doesn't reach them — same posture posts-window uses).
- Fixed phantom horizontal scroll caused by `<wpd-flyout>`'s off-screen translate — root container is now `position: relative` + `overflow-x: hidden`.
- Plugin path encoding (`encodePluginPath`) keeps slashes literal for Apache's default `AllowEncodedSlashes Off`.
- Segmented event listener corrected (`wpd-pick`, not `wpd-segmented-change`).
- Removed pre-emptive "you can't drag this" cues (`cursor: not-allowed`, bump animation, tooltip, `aria-disabled`) on pinned tiles like My WordPress — silent until the user actually attempts a drag.

## Plugin Check posture

`Plugin_Upgrader`, `WP_Filesystem`, `plugins_api()` all touched only from `wp_ajax_*` callbacks (the same idiom Core's `wp_ajax_install_plugin` uses) — no `require_once ABSPATH . 'wp-admin/…'` in REST runtime paths.

## Tests

- **Vitest**: `plugins-window-rest.test.ts` (11), `wpd-card.test.ts` (8), updated `desktop-files-drag.test.ts`. **1064/1064 passing.**
- **PHPUnit**: `pluginsWindowRegistration.php` covers cap gates, opt-in round-trip, REST-field decorators, icon-URL filter.

## Docs

- Full Plugins-window section in `docs/hooks-reference.md` + `docs/javascript-reference.md`.
- New recipe `docs/examples/plugins-window-extras.md` (curated browse filter, icon override, reviews-parser swap, install action, deep-link to Browse, accept-card drop target).

## Verification

```bash
npm run lint && ./node_modules/.bin/tsc --noEmit && npm run test:js && npm run build
```

Plus manual QA in the dev environment: install a plugin from Browse, deactivate from Installed, drop a .zip on the window, drag a card to the dock, switch tabs, open detail flyout, hard-refresh — all live, no F5 between steps.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-137-623ba1b5366ce71b284b60b7b7416eb7d872e285.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->