### PR TITLE
Appearance window polish + dock-peek fixes

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -147,11 +147,19 @@ html.wp-toolbar:has( body.desktop-mode-chromeless ) {
  * Exceptions: keep .page-title-action visible where it's the only
  * entry point to a sub-flow:
  *  - plugin-install.php → "Upload Plugin"
- *  - themes.php         → "Add Theme" (link to theme-install.php)
+ *
+ * themes.php's native "Add Theme" page-title-action used to live
+ * here, but the iframe scrolled past it on load (the focus-target
+ * heuristic on the visible theme grid stole the scroll position),
+ * which made the only entry point to theme-install.php disappear.
+ * The Appearance window now ships an "Add Theme" tab in the
+ * submenu strip (see desktop_mode_inject_appearance_tabs in
+ * includes/themes-tabs.php), so the in-page button is redundant
+ * and stays hidden.
+ *
  * See issue #38.
  */
-.desktop-mode-chromeless.plugin-install-php .wrap > .page-title-action,
-.desktop-mode-chromeless.themes-php .wrap > .page-title-action {
+.desktop-mode-chromeless.plugin-install-php .wrap > .page-title-action {
 	display: inline-block;
 	margin-top: 12px;
 }

--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -47,6 +47,7 @@ require_once DESKTOP_MODE_DIR . 'includes/os-settings.php';
 require_once DESKTOP_MODE_DIR . 'includes/seen-intros.php';
 require_once DESKTOP_MODE_DIR . 'includes/portal.php';
 require_once DESKTOP_MODE_DIR . 'includes/default-window.php';
+require_once DESKTOP_MODE_DIR . 'includes/themes-tabs.php';
 require_once DESKTOP_MODE_DIR . 'includes/media-query.php';
 require_once DESKTOP_MODE_DIR . 'includes/accents.php';
 require_once DESKTOP_MODE_DIR . 'includes/toast-types.php';

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -116,6 +116,14 @@ Plugins (notably WooCommerce's `wc-addons` Extensions row) register `menu_title 
 
 **Fix**: `desktop_mode_build_dock_items()` skips submenu entries whose cleaned title is empty / null / whitespace.
 
+### Synthetic "Add Theme" tab on the Appearance window
+
+Core does not register `theme-install.php` as a submenu of `themes.php` — classic admin only surfaces it through the in-page "Add Theme" `.page-title-action` button at the top of `themes.php`. Inside chromeless that button scrolls out of view on first paint (the focus-target heuristic on the visible theme grid steals the scroll position), leaving no entry point to the install flow.
+
+**Fix**: `desktop_mode_inject_appearance_tabs()` (in `includes/themes-tabs.php`) hooks `desktop_mode_dock_item` and prepends `{ title: 'Add Theme', url: theme-install.php }` to the Appearance dock item's submenu when the current user has `install_themes`. The chromeless CSS rule that previously kept the page-title-action visible on `themes.php` has been removed (`assets/css/chromeless.css`) so the in-page button stays hidden — the tab is the canonical entry point.
+
+Resulting tab order: Appearance | Add Theme | Editor | Fonts | …
+
 ## Adding a new fix
 
 Decision tree, in order:

--- a/includes/themes-tabs.php
+++ b/includes/themes-tabs.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Desktop Mode — Appearance window tab adaptations.
+ *
+ * The Appearance dock item opens an iframe of `themes.php` and uses
+ * the in-window submenu strip (built from the WP `$submenu` global)
+ * as its tab bar. WP Core does not register `theme-install.php` as a
+ * submenu of `themes.php`; classic admin instead surfaces it through
+ * the in-page "Add Theme" `.page-title-action` button.
+ *
+ * Inside chromeless we hide that button (it scrolled out of the
+ * iframe's visible area on first paint, leaving no entry point to
+ * the install flow — see assets/css/chromeless.css). This file
+ * compensates by injecting an "Add Theme" tab at the front of the
+ * Appearance window's submenu strip via the `desktop_mode_dock_item`
+ * filter.
+ *
+ * Resulting tab order: Appearance | Add Theme | Editor | Fonts | …
+ *
+ * @package Desktop_Mode
+ * @since   0.8.2
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Prepends an "Add Theme" entry to the Appearance dock item's submenu.
+ *
+ * Called once per dock item via {@see desktop_mode_build_dock_items()}.
+ * Skipped for every menu other than `themes.php` and for users who
+ * lack the `install_themes` capability — matching what classic
+ * admin's "Add Theme" page-title-action enforces.
+ *
+ * @since 0.8.2
+ *
+ * @param array  $dock_item The dock item data (id, title, icon, url,
+ *                          badge, submenu, multi, placement, isCore).
+ * @param string $menu_slug The menu slug — e.g. `themes.php`.
+ * @return array Filtered dock item.
+ */
+function desktop_mode_inject_appearance_tabs( $dock_item, $menu_slug ) {
+	if ( 'themes.php' !== $menu_slug ) {
+		return $dock_item;
+	}
+
+	if ( ! current_user_can( 'install_themes' ) ) {
+		return $dock_item;
+	}
+
+	if ( ! isset( $dock_item['submenu'] ) || ! is_array( $dock_item['submenu'] ) ) {
+		$dock_item['submenu'] = array();
+	}
+
+	// `?browse=popular` lands on the Popular tab (the JS installer
+	// router would default-redirect to this anyway when no sort is
+	// specified — passing it explicitly makes the intent visible
+	// AND avoids the brief flash where WP's Backbone router rewrites
+	// the URL after first paint, which inside the iframe re-arms the
+	// chromeless body class flicker). Other valid values: `new`
+	// (Latest), `block-themes`, `favorites`.
+	$add_theme = array(
+		'title' => __( 'Add Theme', 'desktop-mode' ),
+		'url'   => admin_url( 'theme-install.php?browse=popular' ),
+	);
+
+	// Idempotent: skip if a previous filter pass (or another plugin)
+	// already added an entry pointing at theme-install.php.
+	foreach ( $dock_item['submenu'] as $existing ) {
+		if ( ! empty( $existing['url'] ) && false !== strpos( $existing['url'], 'theme-install.php' ) ) {
+			return $dock_item;
+		}
+	}
+
+	array_unshift( $dock_item['submenu'], $add_theme );
+
+	return $dock_item;
+}
+add_filter( 'desktop_mode_dock_item', 'desktop_mode_inject_appearance_tabs', 10, 2 );
+
+/**
+ * Fixes the visible "active tab" state inside chromeless
+ * theme-install.php iframes.
+ *
+ * Background: WP's installer JS uses a Backbone router whose pattern
+ * `theme-install.php?browse=:sort` greedy-captures everything past
+ * `browse=` ([^/?]+ matches `&` too). Inside chromeless the URL also
+ * carries `desktop_mode_chromeless=1`, so `:sort` ends up as
+ * `popular&desktop_mode_chromeless=1`. WP's `view.sort()` then runs
+ * with that polluted value and the `[data-sort]` selector finds
+ * nothing — leaving every tab in the unselected state even though
+ * the popular themes ARE the rendered listing.
+ *
+ * Reordering query params or re-encoding doesn't help: any URL that
+ * exposes `browse=` to the router matches the route, and any URL
+ * that hides it falls through to a redirect that strips the
+ * chromeless flag (which would re-render the iframe with full admin
+ * chrome on next paint).
+ *
+ * The minimum-viable shim: inline JS that reads the real `browse`
+ * value via URLSearchParams, finds the matching `[data-sort]` tab,
+ * and sets `current` + `aria-current` on it. A MutationObserver on
+ * `.filter-links` keeps the tab synced if WP's router fires again
+ * (e.g. the user picks Latest, then comes back to Popular via the
+ * route's pushState).
+ *
+ * @since 0.8.2
+ */
+function desktop_mode_theme_install_active_tab_script() {
+	if ( ! desktop_mode_is_chromeless_request() ) {
+		return;
+	}
+	if ( ! isset( $GLOBALS['pagenow'] ) || 'theme-install.php' !== $GLOBALS['pagenow'] ) {
+		return;
+	}
+
+	$js = <<<'JS'
+( function () {
+    var browseParam = new URLSearchParams( window.location.search ).get( 'browse' );
+    if ( ! browseParam ) {
+        return;
+    }
+    function applyActiveTab() {
+        var match = document.querySelector(
+            '.filter-links li > a[data-sort="' + browseParam + '"]'
+        );
+        if ( ! match ) {
+            return false;
+        }
+        var tabs = document.querySelectorAll( '.filter-links li > a[data-sort]' );
+        var alreadyCorrect =
+            match.classList.contains( 'current' ) &&
+            Array.prototype.every.call( tabs, function ( a ) {
+                return a === match || ! a.classList.contains( 'current' );
+            } );
+        if ( alreadyCorrect ) {
+            return true;
+        }
+        Array.prototype.forEach.call( tabs, function ( a ) {
+            a.classList.remove( 'current' );
+            a.removeAttribute( 'aria-current' );
+        } );
+        match.classList.add( 'current' );
+        match.setAttribute( 'aria-current', 'page' );
+        return true;
+    }
+    function init() {
+        if ( ! applyActiveTab() ) {
+            window.requestAnimationFrame( init );
+            return;
+        }
+        var container = document.querySelector( '.filter-links' );
+        if ( ! container ) {
+            return;
+        }
+        var pending = false;
+        var observer = new MutationObserver( function () {
+            if ( pending ) {
+                return;
+            }
+            pending = true;
+            window.requestAnimationFrame( function () {
+                pending = false;
+                applyActiveTab();
+            } );
+        } );
+        observer.observe( container, {
+            attributes: true,
+            subtree: true,
+            attributeFilter: [ 'class', 'aria-current' ],
+        } );
+    }
+    if ( document.readyState === 'loading' ) {
+        document.addEventListener( 'DOMContentLoaded', init );
+    } else {
+        init();
+    }
+} )();
+JS;
+
+	wp_print_inline_script_tag( $js );
+}
+add_action( 'admin_footer', 'desktop_mode_theme_install_active_tab_script', 100 );

--- a/src/boot/link-interceptor.ts
+++ b/src/boot/link-interceptor.ts
@@ -157,6 +157,7 @@ export function bindTopWindowLinkInterceptor(
 				baseId: windowId,
 				multi: !! dockEntry?.multi,
 				url: url.href,
+				parentUrl: dockEntry?.url ?? url.href,
 				title: dockEntry?.title || fallbackTitle,
 				icon: dockEntry?.icon || 'dashicons-admin-generic',
 				submenu: dockEntry?.submenu,

--- a/src/boot/session.ts
+++ b/src/boot/session.ts
@@ -64,6 +64,16 @@ export function restoreSession(
 			desktopId: win.desktopId,
 			multi: !! dockEntry?.multi,
 			url: win.url,
+			// `dockEntry?.url` is the parent menu's landing page —
+			// recover it so the synthetic "back to parent" tab in
+			// the in-window strip points at the dock URL even when
+			// the saved `win.url` is a sub-page (e.g. theme-install.php
+			// under Appearance, or a deep wc-admin route under
+			// WooCommerce). Without this the dedup check in
+			// `dom.ts` sees the iframe URL match a submenu entry
+			// and suppresses the parent tab — losing the only
+			// affordance to navigate back.
+			parentUrl: dockEntry?.url ?? win.url,
 			title: win.title,
 			icon: win.icon || 'dashicons-admin-generic',
 			x: clamped.x,
@@ -132,6 +142,7 @@ export function openCurrentPage(
 		baseId: windowId,
 		multi: !! dockEntry?.multi,
 		url: config.currentPage,
+		parentUrl: dockEntry?.url ?? config.currentPage,
 		title: config.currentTitle,
 		icon: config.currentIcon,
 		submenu: dockEntry?.submenu,

--- a/src/desktop-layout.ts
+++ b/src/desktop-layout.ts
@@ -401,6 +401,7 @@ export function createLayoutDispatcher(
 				id: baseId,
 				baseId,
 				url: item.url,
+				parentUrl: item.url,
 				title: item.title,
 				icon: item.icon.startsWith( 'dashicons-' )
 					? item.icon
@@ -414,6 +415,12 @@ export function createLayoutDispatcher(
 				id: deriveWindowId( sub.url, deps.adminUrl ),
 				baseId: deriveWindowId( item.url, deps.adminUrl ),
 				url: sub.url,
+				// Pin the synthetic parent tab to the dock landing
+				// page, not to the sub-page the user picked. Without
+				// this, a submenu-pick (e.g. clicking "Editor" inside
+				// Appearance's submenu popover) would open at
+				// site-editor.php with no way back to themes.php.
+				parentUrl: item.url,
 				title: item.title,
 				icon: item.icon.startsWith( 'dashicons-' )
 					? item.icon

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1700,6 +1700,7 @@ function init(): void {
 				return {
 					title: item.title,
 					icon: item.icon,
+					url: item.url,
 					submenu: item.submenu,
 					multi: item.multi,
 				};
@@ -1715,6 +1716,11 @@ function init(): void {
 						// avoids painting a generic glyph on a window
 						// the user knows by its parent's identity.
 						icon: item.icon,
+						// `url` holds the PARENT tile's landing page, so
+						// the new window's synthetic "back to parent"
+						// tab links to the dock URL (themes.php) rather
+						// than to the sub-page itself.
+						url: item.url,
 						multi: item.multi,
 					};
 				}

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -354,6 +354,25 @@ export class Dock {
 	}
 
 	public replaceItems( items: DockItem[] ): void {
+		// Tear down peek attachments for the OLD menu tiles before
+		// removing them. Without this, `attachDockPeek` listeners stay
+		// armed on detached tiles and (worse) any popover already
+		// appended to `document.body` is orphaned — its `tearDown`
+		// closure becomes unreachable from the dock. A subsequent
+		// peek opening on the freshly-rebuilt tile then renders a
+		// SECOND popover with the same per-window `view-transition-name`
+		// as the leaked one, which Chrome reports as
+		// "Unexpected duplicate view-transition-name". System tile
+		// peeks live in the same map under `system:` keys and aren't
+		// being replaced here, so leave those entries alone.
+		for ( const itemId of this.itemElements.keys() ) {
+			const teardown = this.peekTeardowns.get( itemId );
+			if ( teardown ) {
+				teardown();
+				this.peekTeardowns.delete( itemId );
+			}
+		}
+
 		for ( const el of this.itemElements.values() ) {
 			el.remove();
 		}
@@ -1248,6 +1267,7 @@ export class Dock {
 			id: baseId,
 			baseId,
 			url: item.url,
+			parentUrl: item.url,
 			title: item.title,
 			icon: item.icon.startsWith( 'dashicons-' ) ? item.icon : 'dashicons-admin-generic',
 			submenu: item.submenu,
@@ -1256,27 +1276,24 @@ export class Dock {
 	}
 
 	/**
-	 * Open a brand-new instance of a multi-capable page, even if one is
-	 * already open. Invoked by the "+" chip on the dock icon.
+	 * Open a brand-new instance of a page, even if one is already
+	 * open. Invoked by the "+" ghost card in the dock peek.
+	 *
+	 * The user explicitly asked for "another window of this thing,"
+	 * so we honour the request even when {@link tryNativeUrlRemap}
+	 * would otherwise route the click into a native-window
+	 * singleton. Result: clicking + while a native Posts window is
+	 * open opens a fresh iframe of `edit.php` alongside it. Two
+	 * windows of Posts is the explicit ask — that's what + is for.
 	 */
 	private openNewInstance( item: DockItem ): void {
-		// Honor URL → native-window remaps before spawning a fresh
-		// iframe. Without this, clicking "+ Open new Posts" while
-		// the native Posts opt-in is active would BYPASS the
-		// remap, leaving the user with a phantom edit.php iframe
-		// next to their native Posts window — exactly the kind of
-		// duplicate the remap exists to prevent. For URLs that have
-		// no remap, `tryNativeUrlRemap` returns false and we fall
-		// through to the regular fresh-iframe path.
-		if ( tryNativeUrlRemap( item.url ) ) {
-			return;
-		}
 		const baseId = this.deriveWindowId( item.url );
 
 		this.windowManager.openNew( {
 			id: baseId,
 			baseId,
 			url: item.url,
+			parentUrl: item.url,
 			title: item.title,
 			icon: item.icon.startsWith( 'dashicons-' ) ? item.icon : 'dashicons-admin-generic',
 			submenu: item.submenu,

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,24 @@ export interface WindowConfig {
 	 * something unique.
 	 */
 	url?: string;
+	/**
+	 * The dock landing URL — the URL the dock tile points at, which
+	 * may differ from {@link WindowConfig.url} once the iframe has
+	 * navigated to a sub-page. Used to render the synthetic
+	 * "back to parent" tab in the in-window tab strip so it always
+	 * points at the parent landing page, not at whichever sub-page
+	 * the iframe happens to be on at construction time. Optional —
+	 * callers that don't pass it fall back to `url` (the original
+	 * behaviour).
+	 *
+	 * Critical on session restore: the snapshot saves the iframe's
+	 * current URL, so without this hint a window restored on a
+	 * sub-page (e.g. theme-install.php under Appearance) would lose
+	 * its parent tab — the dedup check would see the saved iframe
+	 * URL match the same submenu entry that already represents that
+	 * sub-page.
+	 */
+	parentUrl?: string;
 	/** Window title displayed in the title bar. */
 	title: string;
 	/** Dashicon class for the window icon (e.g., 'dashicons-admin-post'). */

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -625,15 +625,31 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 			// auto-prepended self-link from `submenu`, so without this
 			// tab the only way back to the parent listing (e.g. All
 			// Posts from inside Categories) would be to close the window
-			// and reopen it. Skip if a caller-supplied submenu entry
-			// already points at the parent URL (avoids two tabs claiming
-			// the active state on the same key).
+			// and reopen it.
+			//
+			// The synthetic uses `parentUrl` (the dock landing page),
+			// falling back to `url` when the caller didn't pass one.
+			// They diverge when the iframe has been navigated to a
+			// sub-page (or restored from a session that captured one),
+			// e.g. Appearance window currently on `theme-install.php`:
+			// `url = theme-install.php`, `parentUrl = themes.php`.
+			//
+			// Dedup: skip the synthetic if a submenu entry already
+			// points at the *parent* URL. That covers the WooCommerce
+			// shape (parent URL gets rewritten to the first submenu
+			// URL like `wc-admin`, so the first submenu entry already
+			// is the back-to-parent affordance) without false-positively
+			// suppressing it on a session-restored Appearance window
+			// (where the iframe URL `theme-install.php` matches the
+			// "Add Theme" entry but `parentUrl = themes.php` doesn't).
+			const synthUrl = config.parentUrl ?? config.url;
+			const synthKey = urlMatchKey( synthUrl );
 			const parentAlreadyInSubmenu = config.submenu.some(
-				( s ) => urlMatchKey( s.url ) === initialKey,
+				( s ) => urlMatchKey( s.url ) === synthKey,
 			);
 			const seedSubmenu: { title: string; url: string }[] = parentAlreadyInSubmenu
 				? [ ...config.submenu ]
-				: [ { title: config.title, url: config.url }, ...config.submenu ];
+				: [ { title: config.title, url: synthUrl }, ...config.submenu ];
 
 			for ( const sub of seedSubmenu ) {
 				const tab = document.createElement( 'button' );

--- a/src/window/iframe-bridge.ts
+++ b/src/window/iframe-bridge.ts
@@ -38,6 +38,16 @@ const INITIAL_ORIGIN = window.location.origin;
 export interface AdminLinkDockEntry {
 	title: string;
 	icon: string;
+	/**
+	 * The parent dock-tile URL — the page the user clicked from. Used
+	 * to seed the new window's `parentUrl` so the in-window
+	 * "back to parent" tab points at the dock landing page even when
+	 * the cross-page link drops the user on a sub-page (e.g. a
+	 * `theme-install.php` link from a Posts editor opens at
+	 * theme-install.php with the parent tab still saying "Appearance").
+	 * Optional — falls back to the destination URL when missing.
+	 */
+	url?: string;
 	submenu?: { title: string; url: string }[];
 	multi?: boolean;
 }
@@ -66,6 +76,7 @@ interface AdminLinkDispatchDeps {
 		id: string;
 		baseId: string;
 		url: string;
+		parentUrl?: string;
 		title: string;
 		icon: string;
 		submenu?: { title: string; url: string }[];
@@ -495,6 +506,7 @@ function handleCrossPageAdminLink(
 		id: targetSlug,
 		baseId: targetSlug,
 		url: absolute,
+		parentUrl: entry?.url ?? absolute,
 		title,
 		icon: entry?.icon ?? 'dashicons-admin-generic',
 		submenu: entry?.submenu,

--- a/tests/phpunit/tests/desktopModeInjectAppearanceTabs.php
+++ b/tests/phpunit/tests/desktopModeInjectAppearanceTabs.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Tests for the `desktop_mode_inject_appearance_tabs()` filter
+ * callback, which prepends an "Add Theme" entry to the Appearance
+ * dock item's submenu so the in-window tab strip exposes
+ * `theme-install.php` directly (the in-page page-title-action
+ * button is hidden in chromeless mode — see
+ * assets/css/chromeless.css).
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ *
+ * @covers ::desktop_mode_inject_appearance_tabs
+ */
+class Tests_DesktopMode_InjectAppearanceTabs extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $subscriber_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Helper: a minimal dock-item shape matching what
+	 * `desktop_mode_build_dock_items()` hands to the filter.
+	 */
+	private function make_dock_item( array $overrides = array() ) {
+		return array_merge(
+			array(
+				'id'        => 'menu-appearance',
+				'title'     => 'Appearance',
+				'icon'      => 'dashicons-admin-appearance',
+				'url'       => admin_url( 'themes.php' ),
+				'badge'     => 0,
+				'submenu'   => array(),
+				'multi'     => false,
+				'placement' => 'dock',
+				'isCore'    => true,
+			),
+			$overrides
+		);
+	}
+
+	public function test_prepends_add_theme_entry_for_themes_php() {
+		$dock_item = $this->make_dock_item(
+			array(
+				'submenu' => array(
+					array( 'title' => 'Editor', 'url' => admin_url( 'site-editor.php' ) ),
+				),
+			)
+		);
+
+		$result = desktop_mode_inject_appearance_tabs( $dock_item, 'themes.php' );
+
+		$this->assertCount( 2, $result['submenu'] );
+		$this->assertSame( 'Add Theme', $result['submenu'][0]['title'] );
+		// `?browse=popular` makes the iframe land on the Popular tab
+		// without relying on WP's JS-router default-redirect.
+		$this->assertSame(
+			admin_url( 'theme-install.php?browse=popular' ),
+			$result['submenu'][0]['url']
+		);
+		// Existing entries stay in place after the prepended one.
+		$this->assertSame( 'Editor', $result['submenu'][1]['title'] );
+	}
+
+	public function test_no_op_for_other_menu_slugs() {
+		$dock_item = $this->make_dock_item(
+			array(
+				'submenu' => array(
+					array( 'title' => 'All Posts', 'url' => admin_url( 'edit.php' ) ),
+				),
+			)
+		);
+
+		$result = desktop_mode_inject_appearance_tabs( $dock_item, 'edit.php' );
+
+		// Unchanged — the filter only fires for themes.php.
+		$this->assertCount( 1, $result['submenu'] );
+		$this->assertSame( 'All Posts', $result['submenu'][0]['title'] );
+	}
+
+	public function test_skipped_for_users_without_install_themes_capability() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$dock_item = $this->make_dock_item(
+			array(
+				'submenu' => array(
+					array( 'title' => 'Editor', 'url' => admin_url( 'site-editor.php' ) ),
+				),
+			)
+		);
+
+		$result = desktop_mode_inject_appearance_tabs( $dock_item, 'themes.php' );
+
+		$titles = wp_list_pluck( $result['submenu'], 'title' );
+		$this->assertNotContains( 'Add Theme', $titles );
+		$this->assertCount( 1, $result['submenu'] );
+	}
+
+	public function test_idempotent_when_theme_install_already_present() {
+		$existing_add_theme = array(
+			'title' => 'Custom Add Theme',
+			'url'   => admin_url( 'theme-install.php' ),
+		);
+		$dock_item          = $this->make_dock_item(
+			array(
+				'submenu' => array( $existing_add_theme ),
+			)
+		);
+
+		$result = desktop_mode_inject_appearance_tabs( $dock_item, 'themes.php' );
+
+		// No duplicate — the existing theme-install entry was detected.
+		$this->assertCount( 1, $result['submenu'] );
+		$this->assertSame( 'Custom Add Theme', $result['submenu'][0]['title'] );
+	}
+
+	public function test_initialises_missing_submenu_array() {
+		$dock_item = $this->make_dock_item();
+		unset( $dock_item['submenu'] );
+
+		$result = desktop_mode_inject_appearance_tabs( $dock_item, 'themes.php' );
+
+		$this->assertIsArray( $result['submenu'] );
+		$this->assertCount( 1, $result['submenu'] );
+		$this->assertSame( 'Add Theme', $result['submenu'][0]['title'] );
+	}
+
+	/**
+	 * Pin the integration via the `desktop_mode_dock_item` filter — the
+	 * production `add_filter()` call in `includes/themes-tabs.php` is
+	 * what actually wires this into the dock builder. Re-register
+	 * defensively because earlier tests in the suite call
+	 * `remove_all_filters( 'desktop_mode_dock_item' )` in their
+	 * tear_down.
+	 */
+	public function test_filter_is_registered_at_priority_10() {
+		// Ensure registration regardless of prior tear_down state.
+		add_filter( 'desktop_mode_dock_item', 'desktop_mode_inject_appearance_tabs', 10, 2 );
+
+		$priority = has_filter(
+			'desktop_mode_dock_item',
+			'desktop_mode_inject_appearance_tabs'
+		);
+
+		$this->assertSame( 10, $priority );
+	}
+}

--- a/tests/vitest/dock-badge.test.ts
+++ b/tests/vitest/dock-badge.test.ts
@@ -117,6 +117,136 @@ describe( 'Dock.setBadge — rail discriminator', () => {
 	} );
 } );
 
+describe( 'Dock.replaceItems tears down peek attachments', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.useFakeTimers();
+	} );
+	afterEach( () => {
+		vi.useRealTimers();
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	function pointerEnter( el: HTMLElement ): void {
+		const evt = new Event( 'pointerenter' );
+		Object.defineProperty( evt, 'pointerType', { value: 'mouse' } );
+		el.dispatchEvent( evt );
+	}
+
+	/**
+	 * Regression: a peek panel (popover attached to `document.body`)
+	 * shown when `replaceItems` runs used to leak — its tile was
+	 * removed but the popover lived on, and a fresh popover for the
+	 * rebuilt tile collided with it on `view-transition-name`. Chrome
+	 * surfaced this as "Unexpected duplicate view-transition-name:
+	 * desktop-mode-peek-card-<id>". `replaceItems` now drains
+	 * `peekTeardowns` for the items being replaced; system tile
+	 * peeks (keyed `system:*`) stay untouched.
+	 */
+	test( 'visible peek popover is removed when replaceItems fires', () => {
+		const win = {
+			id: 'themes-php',
+			config: {
+				title: 'Appearance',
+				icon: 'dashicons-admin-appearance',
+				baseId: 'themes-php',
+			},
+		};
+		const manager = {
+			getFocused: () => null,
+			getAllByBaseId: () => [],
+			getById: ( id: string ) => ( id === 'themes-php' ? win : undefined ),
+			getActiveDesktopId: () => 'default-1',
+		} as unknown as ConstructorParameters< typeof Dock >[ 1 ];
+
+		const container = document.createElement( 'nav' );
+		document.body.appendChild( container );
+		const item: DockItem = {
+			id: 'menu-appearance',
+			title: 'Appearance',
+			icon: 'dashicons-admin-appearance',
+			url: 'http://localhost/wp-admin/themes.php',
+			badge: 0,
+			submenu: [],
+			multi: false,
+		};
+		const dock = new Dock(
+			container,
+			manager,
+			[ item ],
+			'http://localhost/wp-admin/',
+			'left',
+		);
+
+		const tile = container.querySelector< HTMLElement >(
+			'[data-menu-slug="menu-appearance"]',
+		);
+		expect( tile ).not.toBeNull();
+
+		pointerEnter( tile! );
+		vi.advanceTimersByTime( 500 );
+		expect( document.querySelectorAll( '.desktop-mode-dock-peek' ).length ).toBe( 1 );
+
+		// Live menu refresh — would happen on plugin install/activate
+		// or any chromeless `desktop-mode-plugins-changed` postMessage.
+		dock.replaceItems( [ item ] );
+
+		// The orphaned popover must be gone before the rebuilt tile
+		// is allowed to spawn a fresh one. Without the teardown drain
+		// in `replaceItems`, the old popover lingers and a second
+		// peek collides on `view-transition-name`.
+		expect( document.querySelectorAll( '.desktop-mode-dock-peek' ).length ).toBe( 0 );
+	} );
+
+	test( 'after replaceItems, the rebuilt tile shows a fresh peek', () => {
+		const win = {
+			id: 'themes-php',
+			config: {
+				title: 'Appearance',
+				icon: 'dashicons-admin-appearance',
+				baseId: 'themes-php',
+			},
+		};
+		const manager = {
+			getFocused: () => null,
+			getAllByBaseId: () => [],
+			getById: ( id: string ) => ( id === 'themes-php' ? win : undefined ),
+			getActiveDesktopId: () => 'default-1',
+		} as unknown as ConstructorParameters< typeof Dock >[ 1 ];
+
+		const container = document.createElement( 'nav' );
+		document.body.appendChild( container );
+		const item: DockItem = {
+			id: 'menu-appearance',
+			title: 'Appearance',
+			icon: 'dashicons-admin-appearance',
+			url: 'http://localhost/wp-admin/themes.php',
+			badge: 0,
+			submenu: [],
+			multi: false,
+		};
+		const dock = new Dock(
+			container,
+			manager,
+			[ item ],
+			'http://localhost/wp-admin/',
+			'left',
+		);
+
+		dock.replaceItems( [ item ] );
+
+		const tile = container.querySelector< HTMLElement >(
+			'[data-menu-slug="menu-appearance"]',
+		);
+		pointerEnter( tile! );
+		vi.advanceTimersByTime( 500 );
+		// Exactly one peek — not zero (teardown over-drained), not
+		// two (leaked old listener also fired).
+		expect( document.querySelectorAll( '.desktop-mode-dock-peek' ).length ).toBe( 1 );
+	} );
+} );
+
 describe( 'Dock.removeSystemItem fires HOOKS.DOCK_ITEM_REMOVED', () => {
 	beforeEach( () => installHooksStub() );
 	afterEach( () => {

--- a/tests/vitest/window-submenu.test.ts
+++ b/tests/vitest/window-submenu.test.ts
@@ -115,6 +115,95 @@ describe( 'WindowManager — opening a window with a submenu', () => {
 		expect( tabs[ 0 ].classList.contains( 'desktop-mode-window__tab--active' ) ).toBe( true );
 	} );
 
+	test( 'synthetic parent tab uses parentUrl when iframe is on a sub-page', () => {
+		// Reproduces the F5-on-Add-Theme scenario: session save
+		// captured the iframe URL (theme-install.php), so on restore
+		// the new window opens with `url = theme-install.php` even
+		// though the dock landing is themes.php. Without `parentUrl`,
+		// the dedup check sees the iframe URL match the "Add Theme"
+		// submenu entry and suppresses the synthetic — leaving the
+		// user with no way back to themes.php.
+		const win = manager.open( {
+			id: 'themes-php',
+			url: 'http://example.test/wp-admin/theme-install.php?browse=popular',
+			parentUrl: 'http://example.test/wp-admin/themes.php',
+			title: 'Appearance',
+			icon: 'dashicons-admin-appearance',
+			multi: false,
+			submenu: [
+				{ title: 'Add Theme', url: 'http://example.test/wp-admin/theme-install.php?browse=popular' },
+				{ title: 'Editor', url: 'http://example.test/wp-admin/site-editor.php' },
+			],
+		} );
+
+		const tabs = win.element.querySelectorAll< HTMLElement >( '.desktop-mode-window__tab' );
+		// Synthetic Appearance + Add Theme + Editor.
+		expect( tabs.length ).toBe( 3 );
+		expect( tabs[ 0 ].textContent ).toBe( 'Appearance' );
+		expect( tabs[ 0 ].dataset.url ).toBe( 'http://example.test/wp-admin/themes.php' );
+		// Add Theme is the active tab because its URL matches the
+		// iframe's current URL (theme-install.php).
+		expect( tabs[ 1 ].textContent ).toBe( 'Add Theme' );
+		expect( tabs[ 1 ].classList.contains( 'desktop-mode-window__tab--active' ) ).toBe( true );
+		// Synthetic Appearance is NOT active — the iframe isn't on
+		// themes.php right now.
+		expect( tabs[ 0 ].classList.contains( 'desktop-mode-window__tab--active' ) ).toBe( false );
+	} );
+
+	test( 'synthetic parent tab is suppressed when parentUrl already in submenu (WC shape)', () => {
+		// Mirrors WooCommerce: parent dock URL is rewritten to the
+		// first submenu's URL (`wc-admin`) because the top-level slug
+		// has no working callback. The "Home" submenu entry already
+		// IS the back-to-parent affordance — adding a synthetic with
+		// the same URL would render two tabs claiming the same page.
+		const win = manager.open( {
+			id: 'wc-admin',
+			url: 'http://example.test/wp-admin/admin.php?page=wc-orders',
+			parentUrl: 'http://example.test/wp-admin/admin.php?page=wc-admin',
+			title: 'WooCommerce',
+			icon: 'dashicons-cart',
+			multi: false,
+			submenu: [
+				{ title: 'Home', url: 'http://example.test/wp-admin/admin.php?page=wc-admin' },
+				{ title: 'Orders', url: 'http://example.test/wp-admin/admin.php?page=wc-orders' },
+				{ title: 'Products', url: 'http://example.test/wp-admin/edit.php?post_type=product' },
+			],
+		} );
+
+		const tabs = win.element.querySelectorAll< HTMLElement >( '.desktop-mode-window__tab' );
+		// Just the three submenu entries — no synthetic, since
+		// "Home" already serves as the parent affordance.
+		expect( tabs.length ).toBe( 3 );
+		expect( tabs[ 0 ].textContent ).toBe( 'Home' );
+		// "Orders" is active — that's the iframe's current URL.
+		expect( tabs[ 1 ].textContent ).toBe( 'Orders' );
+		expect( tabs[ 1 ].classList.contains( 'desktop-mode-window__tab--active' ) ).toBe( true );
+	} );
+
+	test( 'parentUrl absent — synthetic logic falls back to url (legacy behaviour)', () => {
+		// Callers that haven't been updated to pass `parentUrl` keep
+		// the original behaviour: synthetic uses `url`, dedup compares
+		// against `url`. If a submenu entry shares `url`, the
+		// synthetic is suppressed — same as before this fix.
+		const win = manager.open( {
+			id: 'edit.php',
+			url: 'http://example.test/wp-admin/edit.php',
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			multi: false,
+			submenu: [
+				{ title: 'All Posts', url: 'http://example.test/wp-admin/edit.php' },
+				{ title: 'Add New', url: 'http://example.test/wp-admin/post-new.php' },
+			],
+		} );
+
+		const tabs = win.element.querySelectorAll< HTMLElement >( '.desktop-mode-window__tab' );
+		// Two tabs: "All Posts" (which already covers the parent URL)
+		// and "Add New". No synthetic prepended.
+		expect( tabs.length ).toBe( 2 );
+		expect( tabs[ 0 ].textContent ).toBe( 'All Posts' );
+	} );
+
 	test( 'opens + closes a singleton + re-opens without error', () => {
 		const first = manager.open( {
 			id: 'plugins.php',


### PR DESCRIPTION
## Features

- **"Add Theme" tab in the Appearance window** — prepended to the in-window submenu strip via `desktop_mode_dock_item`, points at `theme-install.php?browse=popular` so the iframe lands on the Popular tab. Capability-gated on `install_themes`.
- **Hide the in-page "Add Theme" button** on chromeless `themes.php` — it scrolled out of view on first paint, leaving no entry point. The new tab replaces it.

## Fixes

- **Popular tab not visually selected** in the Add Theme iframe. WP's installer Backbone router pattern (`theme-install.php?browse=:sort`) greedy-captures the chromeless flag, so `view.sort()` runs with junk and no tab matches `[data-sort=…]`. Fix: tiny inline shim that reads the real `?browse=` and sets `current` / `aria-current`, with a MutationObserver to keep it synced.
- **F5 on a sub-page loses the parent tab** (e.g. reload while on Add Theme dropped the "Appearance" tab). Session saves the iframe URL, so on restore `config.url` was the sub-page and dedup falsely suppressed the synthetic parent. Fix: new `parentUrl` field on `WindowConfig`, plumbed from dock + session-restore + link interceptors. Dedup now compares against the dock landing URL.
- **"Open another" no-op on native-remapped tiles** (e.g. the "+" ghost on Posts when the native Posts opt-in was on). The remap intercepted the click and just focused the existing native singleton. Fix: `openNewInstance` now bypasses the remap — the user explicitly asked for another window, so honour it with a fresh iframe alongside the native.
- **`Unexpected duplicate view-transition-name`** in the console after a menu refresh. `Dock.replaceItems()` rebuilt tiles without tearing down peek attachments, leaking the old popover on `document.body`; a subsequent peek collided on the per-window `view-transition-name`. Fix: drain `peekTeardowns` for the items being replaced.

## Tests

- New PHPUnit class covering `desktop_mode_inject_appearance_tabs()`.
- New Vitest cases for the `parentUrl` synthetic-tab logic (sub-page restore, WC dedup, legacy fallback) and the `replaceItems` peek teardown.
- Existing suites stay green: 633 PHPUnit, 1069 Vitest.

## Docs

- `docs/plugin-compat-layer.md` — added the synthetic Add Theme tab to the menu-data adaptations list.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-138-cde911dc9d5136cf21021e6ba537415d6204f603.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->