### PR TITLE
feat(content-graph): Multi-lens architecture and Galaxy lens

### DIFF
--- a/docs/brainstorms/content-graph-multi-lens-galaxy-requirements.md
+++ b/docs/brainstorms/content-graph-multi-lens-galaxy-requirements.md
@@ -1,0 +1,172 @@
+---
+date: 2026-05-10
+topic: content-graph-multi-lens-galaxy
+---
+
+# Content Graph: Multi-Lens Views and the Radial Galaxy
+
+## Summary
+
+Content Graph becomes a multi-lens viewer. The first new lens, Radial Galaxy, clusters posts by a user-chosen taxonomy via a force-driven layout, with bridge highlighting that fades intra-cluster edges and pops cross-cluster ones. Four new edge types (co-tag, co-author, page hierarchy, menu) join the existing hyperlinks under a toolbar multi-toggle. A lens-switcher in the toolbar establishes the architecture so future lenses (Sitemap, Timeline) can drop in as new lens IDs without refactor.
+
+---
+
+## Problem Frame
+
+Content Graph today is a single-geometry tool: one force-directed layout, one edge type (`<a href>` extracted from `post_content`), one mental model, "the web of internal links." That story serves curiosity well but undersells what's actually in WordPress. Posts are also organized by taxonomies, written by authors, parented to pages, and exposed through nav menus. None of that surfaces in the graph today.
+
+Editors and content strategists currently reach for the categories admin page or a sitemap export to answer questions like "what topics am I covering?" or "which categories overlap?", and the answers come back as flat lists, not as a visual whose density and connectedness tell the story. There's no surface in WordPress where an editor can see "the constellations of my topical coverage" at a glance. The graph is the natural place to deliver that, but it has to grow beyond a single layout and a single edge type to do so.
+
+---
+
+## Actors
+
+- A1. **Site editor**: opens Content Graph to understand topical coverage, find related content, and spot structural patterns (clusters, bridges, gaps). Primary user.
+- A2. **Content strategist**: uses the lens to audit how categories overlap, which authors span topics, and where the IA's spine (menus, hierarchy) sits. Secondary user.
+- A3. **Plugin developer extending Desktop Mode**: currently consumes Content Graph as a fixed window; benefits from the lens architecture being clean enough to add their own lens later. Tertiary; informs API and architecture quality, not v1 features.
+
+---
+
+## Key Flows
+
+- F1. **Switch lens from Constellation to Galaxy**
+  - **Trigger:** User opens Content Graph (defaults to last-used lens, Constellation on first ever open) and clicks the Galaxy segment in the toolbar's lens switcher.
+  - **Actors:** A1
+  - **Steps:** (1) Force sim re-equilibrates with per-cluster centroid attractors added. (2) Existing nodes drift toward their term clusters; multi-term nodes settle between. (3) Edge rendering switches to bridge-highlighting (intra fades, cross pops). (4) Toolbar reveals the taxonomy dropdown and edge multi-toggle. (5) Toolbar status updates to show terms count alongside nodes/links count.
+  - **Outcome:** Same data, new visual. Lens choice persists for next open.
+  - **Covered by:** R1, R3, R6, R8, R13
+
+- F2. **Pick a different clustering taxonomy**
+  - **Trigger:** User in Galaxy lens opens the taxonomy dropdown and selects a different taxonomy.
+  - **Actors:** A1, A2
+  - **Steps:** (1) Force sim re-equilibrates with new term centroids. (2) Nodes drift to their new clusters. (3) Cluster labels update. (4) The "Uncategorized" cluster appears or shrinks based on coverage of the new taxonomy. (5) Choice persists per user.
+  - **Outcome:** Same nodes, regrouped by the new taxonomic axis.
+  - **Covered by:** R4, R5, R7, R14
+
+- F3. **Reveal a hidden edge type**
+  - **Trigger:** User toggles "Co-author" from off to on in the edges multi-toggle.
+  - **Actors:** A2
+  - **Steps:** (1) The new edge set becomes visible (loaded eagerly with the rest of the graph payload, just rendered or hidden by toggle). (2) Edges render in their type's distinct color and weight. (3) Bridge highlighting still applies in Galaxy. (4) Toggle state persists per user, scoped per lens.
+  - **Outcome:** Co-authorship bridges become visible; user can spot polymath authors writing across category clusters.
+  - **Covered by:** R10, R11, R12, R13, R14
+
+- F4. **Focus a node**
+  - **Trigger:** User clicks any node.
+  - **Actors:** A1
+  - **Steps:** Same as today's Constellation flow, focus animates, satellites fan out, side panel populates with post detail and per-relationship contextual views.
+  - **Outcome:** Existing focused-detail UX, unchanged across both lenses.
+  - **Covered by:** R15
+
+---
+
+## Requirements
+
+**Lens architecture**
+
+- R1. The Content Graph window exposes at least two lenses on first ship: **Constellation** (current behavior) and **Galaxy** (new). Lens choice is a first-class concept the toolbar exposes via a segmented control.
+- R2. The lens architecture supports adding future lenses (e.g. Sitemap, Timeline) by registering a new lens ID without refactoring the existing two. Each lens controls its own layout strategy, default edge visibility, and toolbar extras.
+- R3. Switching lenses re-equilibrates the existing scene (same node identities, same `GraphScene`) rather than tearing down and remounting. Camera state and focused-node state survive lens switches.
+
+**Galaxy lens**
+
+- R4. The user picks any registered **public** taxonomy from a toolbar dropdown to drive clustering. Default selection is `category` if present, otherwise the first available public taxonomy alphabetically.
+- R5. Each term in the selected taxonomy becomes a cluster centroid that attracts posts holding that term. Centroids drift with their cluster's center of mass; positions are not fixed.
+- R6. Posts holding multiple terms in the selected taxonomy are pulled toward each of their term clusters proportionally, settling visually between them by emergent force balance, not by duplicating a node per term.
+- R7. Posts and pages with no terms in the selected taxonomy form a single "Uncategorized" cluster.
+- R8. Each cluster carries a label rendered above its centroid showing the term name and the number of nodes it currently anchors. Labels are scale-aware: visible at zoom levels matching the existing node-label visibility rule.
+- R9. Empty terms (zero nodes) are hidden from the rendered scene and the cluster-label set by default. There is no UI to opt them in for v1.
+
+**Edges**
+
+- R10. Four new edge types ship in v1 alongside the existing hyperlink edge type:
+  - **Co-tag**: posts sharing one or more terms in any taxonomy *other than* the currently-selected clustering taxonomy.
+  - **Co-author**: posts with the same `post_author`.
+  - **Hierarchy**: `post_parent` relationships.
+  - **Menu**: nav menu items pointing to posts.
+- R11. The toolbar exposes a multi-toggle (one control per edge type) controlling visibility of each edge type independently. Each edge type renders in a distinct color and weight, legend-friendly.
+- R12. Default edge visibility on first paint is per-lens:
+  - **Constellation**: hyperlinks on; all four new types off (preserves today's behavior).
+  - **Galaxy**: hyperlinks on; **co-tag** on; co-author, hierarchy, menu off.
+- R13. In Galaxy lens, **bridge highlighting** applies to all visible edge types: when both endpoints sit in the same cluster, the edge fades to a low-alpha background; when endpoints sit in different clusters (or one is in "Uncategorized"), the edge renders at full intensity in its type's color.
+
+**Persistence**
+
+- R14. Per-user persistence covers: last-selected lens, last-selected clustering taxonomy in Galaxy, per-lens edge-toggle state, and per-lens post-type chip state.
+
+**Continuity with current behavior**
+
+- R15. The existing satellite fan-out, side panel, search, fit-to-view, pan/zoom, and node-focus interactions work unchanged in both lenses.
+- R16. The post-type filter chips remain a secondary filter on top of the chosen taxonomy and lens. Toggling a post type out hides matching nodes regardless of clustering.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R6.** Given a post is tagged with both `News` and `Travel` in the Categories taxonomy, when Galaxy is the active lens with `category` selected, then the node settles approximately on the line between the News and Travel cluster centroids, not inside either cluster's interior.
+- AE2. **Covers R7.** Given a Page with no `category` terms (Pages typically lack categories), when Galaxy is active with `category` selected, then the page node lives in the "Uncategorized" cluster, not in any term cluster.
+- AE3. **Covers R12, R13.** Given Galaxy is the active lens with `category` selected and only the default edge types on (hyperlinks plus co-tag), when two posts in different category clusters share a tag in `post_tag`, then the co-tag edge between them renders at full intensity in the co-tag color; when two posts in the same category cluster share a tag, that intra-cluster co-tag edge renders faded.
+- AE4. **Covers R3.** Given the user has focused a node in Constellation and the side panel is open, when the user switches to Galaxy via the toolbar, then the same node remains focused, the side panel stays populated, and the camera does not snap back to a default fit-to-view.
+- AE5. **Covers R14.** Given the user picks `post_tag` as the Galaxy taxonomy and toggles `co-author` edges on, when the user closes Content Graph and reopens it, then the lens is still Galaxy, the taxonomy is still `post_tag`, and `co-author` edges are still visible.
+- AE6. **Covers R9.** Given the selected clustering taxonomy has 50 terms but only 12 of them have at least one post in the current post-type filter, when Galaxy renders, then exactly 12 cluster centroids and 12 cluster labels are visible (plus "Uncategorized" if any nodes lack terms in that taxonomy).
+
+---
+
+## Success Criteria
+
+- An editor opening Content Graph for the first time after this ships sees something visually distinct from "the same graph as before" and can articulate within roughly 30 seconds what each cluster represents.
+- A content strategist can answer "which authors write across multiple categories?" by toggling on co-author edges in Galaxy without leaving the window.
+- The lens architecture is clean enough that a Sitemap or Timeline lens can be added in a follow-up without touching `GraphScene`'s public surface beyond registering a new lens ID.
+- A planning pass on this doc can produce concrete file diffs without inventing user-facing behavior, scope, or persistence semantics.
+- Galaxy on the sites Constellation handles today does not regress on time-to-first-paint or interactive smoothness (pan, zoom, node drag).
+
+---
+
+## Scope Boundaries
+
+- **Block reference edges** (featured images, cover blocks, image refs, post-loop queries, reusable blocks, embeds): explicitly deferred. Block parsing is materially more expensive than the four cheap edge types and earns its own follow-up.
+- **AI-augmented features** (semantic similarity edges, prompt-driven views, AI cluster captions, suggested-link recommendations): separate brainstorm.
+- **Editor-mode interactions** (drag-to-link, bulk edit, in-graph rename, spawn-here): separate brainstorm.
+- **Sitemap and Timeline lens implementations**: the architecture supports them, but they ship as separate work.
+- **Multi-taxonomy overlay** (visualizing two taxonomies' clustering simultaneously as nested cluster regions): explicitly considered and rejected for v1 due to visual-noise risk.
+- **Auto-detect-by-post-type clustering** (different content types clustered by different keys in one mixed galaxy): explicitly considered and rejected for conceptual heterogeneity.
+- **Site Audit overlays** (orphans, broken links, stale content): direction A in the brainstorm; separate effort.
+- **Scale and performance work for huge graphs** (streaming load, level-of-detail rendering, mini-map): current Content Graph performance baseline applies. Optimizing for sites above the existing comfort range (the `ForceSim` comments cite roughly 500 nodes for the current O(n²) repulsion loop) is out of scope. Galaxy must not regress on the sites Constellation handles today.
+
+---
+
+## Key Decisions
+
+- **Galaxy uses force-driven clusters, not strict polar coordinates.** Rejected rings-and-sectors, sun-and-planets, and sunburst alternatives. Rationale: galaxy of clusters extends the existing `ForceSim` rather than introducing a new geometric engine, and "multi-term posts pulled between clusters" is uniquely natural in a force model.
+- **One taxonomy at a time, configurable.** Rejected hard-coded categories-only and rejected multi-taxonomy overlay. Rationale: configurable hits CPTs with custom taxonomies without inventing per-CPT logic; one-at-a-time keeps the visual interpretable.
+- **Bridge highlighting is the default edge story in Galaxy.** Rejected "all edges equal weight" and "hide edges entirely." Rationale: clustered layouts make intra-vs-inter distinction inherently meaningful; faded intra ink lets the cross-cluster signal carry.
+- **Lens switcher is a real architecture from day one, not a toggle.** Rejected single-toggle ("cluster on/off") and rejected multi-window ("each lens its own window"). Rationale: a single toggle wouldn't pay back when adding Sitemap or Timeline; multi-window fragments the experience and loses the "switch and compare" affordance.
+- **Block references deferred, not absorbed into v1.** Rationale: the SQL-cheap edges (the other four) cost roughly the same as the existing hyperlink edges in build time; block parsing is its own engineering project with its own caching, invalidation, and edge-case story (Cover, Featured Image, post-loop, reusable, embed). It earns a focused follow-up.
+- **Cluster centroids drift with their cluster's center of mass.** Rejected fixed-position centroids on a precomputed lattice. Rationale: drifting centroids let the layout breathe as the user toggles edge types or post-type chips, and avoid the "robot" feel of a hand-placed grid.
+- **Empty terms hidden by default with no v1 UI to reveal them.** Rationale: a 50-term taxonomy with 12 used terms produces 38 invisible centroids if shown; the visual cost outweighs the once-in-a-while value of seeing them. A "show empty" toggle can land in a follow-up if real users ask.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing `ForceSim` (`src/content-graph/sim.ts`) supports adding per-cluster centroid attractor forces as an extension. The current sim has three forces (repulsion, spring, gravity); adding a fourth attractor force toward each node's term centroid is the same shape of code, not a rewrite.
+- The REST endpoints under `desktop-mode/v1/content-graph/` are the right place to extend with new edge types and a `taxonomy` query parameter. The same caching model (transient keyed on participating rows' `post_modified_gmt` plus query parameters) extends naturally.
+- Pixi `Container` reuse across lens switches is feasible without remounting the `Application`. Same `world` container; different per-lens force configuration.
+- Per-user persistence has a natural home in existing user-meta or per-window persistence surfaces already used elsewhere in Desktop Mode. No new persistence primitive should be required.
+- The existing `<wpd-*>` component kit covers most of the needed UI (segmented control, dropdown, toggle chips). Whether each specific control already exists is a planning-tier check against `src/ui/components/index.ts`.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None. All scope-shaping decisions are locked.)
+
+### Deferred to Planning
+
+- [Affects R10][Technical] How are co-tag, co-author, hierarchy, and menu edge sets queried efficiently? Co-tag in particular implies a self-join on `wp_term_relationships` filtered to non-clustering taxonomies; on large sites this needs the cache strategy to keep up.
+- [Affects R5, R6][Technical] What attractor strength and cluster-spacing produces a visually pleasing Galaxy on a typical 200-node site, a sparse 30-node site, and a dense 500-node site without per-site tuning? Likely an empirical pass during implementation.
+- [Affects R3][Technical] What's the cleanest way to swap the active force configuration on a live `ForceSim` so the lens transition feels graceful rather than thrashed? Options: re-create the sim, mutate force coefficients in place, or run a transition phase. Decide during planning.
+- [Affects R11][Needs research] Is there a `<wpd-*>` component already suitable for the edges multi-toggle (chips with on/off plus a color swatch), or does this warrant a small new component? Check `src/ui/components/index.ts` during planning per the project's component-first rule.
+- [Affects R14][Technical] Per-user persistence: existing user-meta key namespace conventions in this plugin are already established; the planning pass should grep current usage and reuse the convention rather than invent a new one.
+- [Affects R10][Technical] Menu-structure edges: nav menus point at multiple target types (post, term, custom URL). Edge generation should resolve only menu items whose target is a post in scope, but the precise filter belongs in planning when querying `wp_get_nav_menu_items` (or equivalent) is implemented.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1992,6 +1992,69 @@ The static template body before it's emitted into the native-window template ele
 
 ---
 
+## Content Graph (since 0.8.2)
+
+A native window that visualises posts / pages / CPTs as a force-directed graph, with internal hyperlinks (and as of 0.9.0 four additional edge kinds: shared terms, shared author, page hierarchy, and nav menu structure) drawn between nodes. Two lenses ship in the box: **Constellation** (current force-directed layout) and **Galaxy** (taxonomy-clustered, with bridge highlighting that fades intra-cluster edges).
+
+### `desktop_mode_content_graph_user_can_use` — Experimental (filter)
+
+```php
+apply_filters( 'desktop_mode_content_graph_user_can_use', bool $can ): bool
+```
+
+Gates icon and window registration. Default `current_user_can( 'edit_posts' )`. Return `false` to hide Content Graph for a role; return `true` to opt a role back in.
+
+### `desktop_mode_content_graph_window_args` / `desktop_mode_content_graph_icon_args` — Experimental (filter)
+
+Tweak the args passed to `desktop_mode_register_window()` / `desktop_mode_register_icon()` for Content Graph. Useful to change default dimensions, swap the dashicon, or remove the `pinned` flag so the icon joins normal sort order.
+
+### `desktop_mode_content_graph_post_types` — Experimental (filter)
+
+```php
+apply_filters( 'desktop_mode_content_graph_post_types', array[] $entries ): array[]
+```
+
+Each entry declares `slug`, `label`, and `icon`. Default: every public post type except `attachment`. Removing an entry hides it from the post-type chip row AND excludes it from the graph entirely.
+
+### `desktop_mode_content_graph_template_html` — Experimental (filter)
+
+The static template body before it's emitted into the native-window template element. Keep the `data-desktop-mode-content-graph-*` data hooks intact so the JS bundle can find its mount points.
+
+### `desktop_mode_content_graph_taxonomies` — Experimental (filter, since 0.9.0)
+
+```php
+apply_filters( 'desktop_mode_content_graph_taxonomies', array[] $entries ): array[]
+```
+
+The list of taxonomies offered as Galaxy clustering keys in the toolbar's "Cluster by" dropdown. Each entry declares `slug`, `label`, `hierarchical`, and `post_types`. Default: every public taxonomy. Removing an entry hides it from the dropdown AND from the prefs sanitizer's allow-list (a stored value pointing at a removed taxonomy falls back to the default).
+
+### `desktop_mode_content_graph_edge_kind_descriptors` — Experimental (filter, since 0.9.0)
+
+```php
+apply_filters( 'desktop_mode_content_graph_edge_kind_descriptors', array[] $entries ): array[]
+```
+
+The list of edge kinds offered to the toolbar's edges multi-toggle. Each entry declares `slug`, `label`, `color` (CSS hex, e.g. `#2c6be5`), and `weight`. Default: `link`, `co_tag`, `co_author`, `hierarchy`, `menu`. Removing an entry hides it from the toggle UI but does NOT prevent the server-side build from emitting that kind when an explicit REST query asks for it.
+
+### `desktop_mode_content_graph_terms_truncated` — Experimental (action, since 0.9.0)
+
+```php
+do_action( 'desktop_mode_content_graph_terms_truncated', int $post_id, string $taxonomy, int $original_count )
+```
+
+Fires once per `(post, taxonomy)` tuple whose membership exceeds the per-node 50-term cap (`DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP`). The cap is a defensive guard on payload size; this hook lets you log when it fires so you can tell whether real content is being truncated.
+
+### REST endpoints
+
+Under `desktop-mode/v1/content-graph`:
+
+- `GET /post-types` — descriptor list driving the post-type chip row.
+- `GET /nodes?types=post,page&edges=link,co_tag&taxonomies=category` — full `{ nodes, edges, stats }` tuple. The `edges` and `taxonomies` query parameters land in 0.9.0; pre-0.9.0 callers omitting them get only `link` edges and no `terms` field on nodes (backwards-compatible default).
+- `GET /post/<id>` — the side-panel detail bundle for one post.
+- `GET /preferences` / `POST /preferences` — per-user UI prefs (lens, taxonomy, per-lens edges + post-type chips). New in 0.9.0.
+
+---
+
 ## Presence
 
 Framework-level presence tracking. Storage in

--- a/docs/plans/2026-05-10-001-feat-content-graph-multi-lens-galaxy-plan.md
+++ b/docs/plans/2026-05-10-001-feat-content-graph-multi-lens-galaxy-plan.md
@@ -1,0 +1,601 @@
+---
+title: "feat: Add multi-lens architecture and Galaxy lens to Content Graph"
+type: feat
+status: active
+date: 2026-05-10
+origin: docs/brainstorms/content-graph-multi-lens-galaxy-requirements.md
+---
+
+# feat: Add multi-lens architecture and Galaxy lens to Content Graph
+
+## Summary
+
+Extend the Content Graph window with a lens architecture (`Constellation` + new `Galaxy`) and four new edge types (co-tag, co-author, hierarchy, menu). PHP work extends `graph-builder.php` in place with new edge extractors and a `kind` field on edges, plus a new `preferences.php` per-user state endpoint following the `os-settings.php` pattern. Frontend work adds a cluster-attractor force loop to `ForceSim`, a `setLens()` method on `GraphScene`, edge-kind-aware draw with bridge highlighting, and a refactored toolbar that migrates the existing raw-DOM controls to `<wpd-*>` components while adding the new lens segmented control, taxonomy dropdown, and edges multi-toggle.
+
+---
+
+## Problem Frame
+
+Content Graph today is a single-geometry tool: one force-directed layout, one edge type. Editors and content strategists have no surface where they can see "the constellations of my topical coverage" at a glance. The brainstorm settled on Multi-Lens Views with Galaxy as the first new lens, plus four cheap new edge types alongside hyperlinks. This plan defines how that ships. (See origin: `docs/brainstorms/content-graph-multi-lens-galaxy-requirements.md`)
+
+---
+
+## Requirements
+
+- R1. Two lenses on first ship: Constellation (current) and Galaxy (new), exposed via a toolbar segmented control.
+- R2. Lens architecture supports adding future lenses by registering a new lens ID without refactoring the existing two.
+- R3. Switching lenses re-equilibrates the existing scene (no remount). Camera and focused-node state survive lens switches.
+- R4. The user picks any registered public taxonomy from a toolbar dropdown to drive Galaxy clustering. Default selection is `category` if present.
+- R5. Each term in the selected taxonomy becomes a cluster centroid; centroids drift with their cluster's center of mass.
+- R6. Posts holding multiple terms are pulled toward each term cluster proportionally and settle between them by force balance.
+- R7. Posts and pages with no terms in the selected taxonomy form a single "Uncategorized" cluster.
+- R8. Each cluster carries a label with term name and post count, scale-aware.
+- R9. Empty terms (zero nodes) are hidden by default in Galaxy.
+- R10. Four new edge types: co-tag, co-author, hierarchy (`post_parent`), menu (nav menu items).
+- R11. Toolbar exposes an edges multi-toggle; each edge type renders in a distinct color and weight.
+- R12. Per-lens default edge visibility: Constellation = links only; Galaxy = links + co-tag.
+- R13. Bridge highlighting in Galaxy: intra-cluster edges fade, cross-cluster edges pop in their type's color.
+- R14. Per-user persistence: last-selected lens, last-selected taxonomy, per-lens edge-toggle state, per-lens post-type chip state.
+- R15. Existing satellite fan-out, side panel, search, fit-to-view, and pan/zoom unchanged across both lenses.
+- R16. Post-type filter chips remain a secondary filter on top of the chosen taxonomy and lens. Post-type selections are per-lens (covered by R14): switching lenses preserves the post-type filter for each lens independently rather than resetting it.
+
+**Origin actors:** A1 (site editor), A2 (content strategist), A3 (plugin developer extending Desktop Mode)
+**Origin flows:** F1 (switch lens), F2 (pick taxonomy), F3 (reveal hidden edge type), F4 (focus a node)
+**Origin acceptance examples:** AE1 (covers R6), AE2 (covers R7), AE3 (covers R12, R13), AE4 (covers R3), AE5 (covers R14), AE6 (covers R9)
+
+---
+
+## Scope Boundaries
+
+- Block reference edges (featured images, cover blocks, image refs, post-loop queries, reusable blocks, embeds): deferred from origin; out of this plan.
+- AI-augmented features (semantic edges, prompt-driven views, AI cluster captions): origin out-of-scope.
+- Editor-mode interactions (drag-to-link, bulk edit, in-graph rename): origin out-of-scope.
+- Sitemap and Timeline lens implementations: architecture supports them; they ship as separate work.
+- Multi-taxonomy overlay; auto-detect-by-post-type clustering: origin discarded options.
+- Site Audit overlays (orphans, broken links, stale content): origin out-of-scope.
+- Scale work above the existing `ForceSim` ~500-node ceiling (Barnes-Hut, level-of-detail, mini-map): out of this plan; Galaxy must not regress on sites Constellation handles today.
+- New `wp.desktop.*` public API for lens or edge-type registration: plan-local non-goal. Internal-only in v1; promote to public hooks if extension demand surfaces in a follow-up.
+- New `docs/examples/` example: plan-local non-goal. Lens and edge-type registration are not public extension surfaces in v1.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/content-graph/index.ts`: render entry; wires toolbar + panel + scene + REST. Owns `activeTypes` state and `loadGraph()` orchestration. No persistence wired today.
+- `src/content-graph/scene.ts`: `GraphScene` class. Pixi v8 `Application` + world `Container` with three layers. Camera target-then-ease. `draw()` repaints all `EdgeView`s and `NodeView`s every tick. Adding edge kinds requires extending `EdgeView` and the `draw()` color/width branching.
+- `src/content-graph/sim.ts`: hand-rolled spring sim. `step(dt)` runs (1) O(n²) repulsion, (2) per-edge spring, (3) gravity + Euler integrate with damping + velocity clamp + drag-influence smoothstep, (4) `alpha *= ALPHA_DECAY`. Adding cluster centroid attractors is a clean fourth force loop between gravity and integrate.
+- `src/content-graph/toolbar.ts`: vanilla DOM today (raw `document.createElement('button')`). `AGENTS.md` flags this as a violation; this plan migrates it to `<wpd-*>`.
+- `src/content-graph/rest.ts`: `getConfig()` reads `window.desktopModeWindowConfig['desktop-mode-content-graph']`. `trackedFetch` wrappers tagged `source: 'desktop-mode/content-graph'`.
+- `src/content-graph/types.ts`: wire-payload + in-memory shapes. REST is the source of truth.
+- `includes/content-graph/window.php`: `desktop_mode_register_window` registration. `config` array hydrates `window.desktopModeWindowConfig` in JS. The place to inject initial preferences and taxonomy catalog.
+- `includes/content-graph/rest.php`: three routes (`/post-types`, `/nodes`, `/post/<id>`). Capability check `desktop_mode_content_graph_user_can_use()`.
+- `includes/content-graph/graph-builder.php`: full graph builder + transient cache. Cache key = `MD5(GROUP_CONCAT(ID, post_modified_gmt))` over participating rows. Extend in place for the new edge types.
+- `includes/os-settings.php`: canonical pattern for per-user preference endpoint. Meta key `desktop_mode_os_settings`, REST `GET/POST`, sanitizer/defaults.
+- `includes/session.php`: alternate per-user state pattern; useful as cross-reference.
+- `src/boot/session-saver.ts`: trailing-edge debounced (500ms) saver with `sendBeacon` flush on unload. The pattern preferences-saver should mirror, but with a shorter debounce.
+- `src/ui/components/wpd-segmented/wpd-segmented.ts`: segmented control. Stable since 0.9.0. `value` + `wpd-pick` event.
+- `src/ui/components/wpd-select/wpd-select.ts`: dropdown wrapping native `<select>`. Same `value` + `wpd-pick` contract. Stable since 0.11.0.
+- `src/ui/components/wpd-multiselect/wpd-multiselect.ts`: popover with checkboxes. Experimental.
+- `src/ui/components/wpd-chip/wpd-chip.ts`: chip primitive with optional dismiss. Replaces hand-rolled chip buttons.
+
+### Institutional Learnings
+
+- No `docs/solutions/` tree exists in this repo. The de-facto institutional knowledge lives in `AGENTS.md`. Four notes apply directly:
+  - **`<wpd-*>` over raw HTML controls**: today's vanilla-DOM toolbar in `src/content-graph/toolbar.ts` violates this; the plan migrates it.
+  - **`wp.desktop.fetch` / `trackedFetch` over raw `fetch`**: already followed in `src/content-graph/rest.ts`; new REST helpers must keep this convention.
+  - **`createSharedStore` for cross-bundle state**: NOT applicable here. Content Graph is a single bundle (`content-graph.min.js`), so plain module-level state is fine.
+  - **Live-refresh payload pattern**: NOT triggered. Lenses and edge types are TS-side constants in v1, not server-driven registries.
+- The Pixi.js skill pack at `.agents/skills/pixijs/` is reference material, not learnings. Useful for Pixi v8 specifics but does not encode prior incidents.
+
+### External References
+
+- None. Local patterns cover all four design dimensions (force sim, persistence, REST cache, `<wpd-*>` kit). External research skipped per Phase 1.2.
+
+---
+
+## Key Technical Decisions
+
+- **Edges carry a discriminated `kind` field on the wire**: `'link' | 'co_tag' | 'co_author' | 'hierarchy' | 'menu'`. Existing hyperlink edges become `kind: 'link'`. The single `EdgeView` shape branches on kind for color and weight at draw time. Rationale: keeping all edges in one collection simplifies bridge-highlighting logic (which is kind-agnostic) and avoids parallel render paths.
+- **Cluster centroids are emergent, not pre-computed**: each tick, the new attractor force computes a centroid per term as the running average of its members' positions, then attracts each non-pinned member toward its term centroid (or weighted average of term centroids for multi-term posts). No fixed lattice. Rationale: integrates with the existing alpha-decay cooling; multi-term posts settle between clusters via emergent balance (R6, AE1).
+- **Lens switch is a live config swap on the existing `GraphScene`**: `setLens(id)` mutates which forces are active, which edge kinds are visible by default, and which toolbar extras render. Then `reheat(0.3, false)` to re-equilibrate. No teardown of the Pixi `Application` or `world` container. Rationale: AE4 requires camera + focus state to survive lens switch; the cheapest implementation that satisfies this is in-place mutation.
+- **`GraphScene.setData()` preserves focus and camera state across rebuilds**: when a `loadGraph()` runs because the lens switch changed the requested edge kinds or taxonomies, `setData()` carries forward `focusedId` (when the focused node still exists in the new payload) and leaves `targetX/Y/Scale` untouched. `loadGraph()` itself takes a `reason` flag so it only calls `fitToView()` and `clearFocus()` on initial mount or post-type filter change, not on lens-switch loads. Rationale: AE4 plus realistic data flow (Constellation and Galaxy default to different edge kinds, so most lens switches DO refetch) require the rebuild path to preserve state, not just the cache-hit path.
+- **Per-node term membership ships on the `/nodes` payload**: every node carries a `terms: Record<taxonomy, termId[]>` map scoped to taxonomies the request asked about. The scope is computed server-side from the active Galaxy taxonomy plus any taxonomies referenced by the requested edge kinds (co-tag pulls in all non-clustering public taxonomies). Rationale: U5's `setClusterTaxonomy()` needs membership data to derive centroids; emitting it inline saves a second round-trip on every taxonomy switch and shares the query cost with the co-tag extractor (which already JOINs `wp_term_relationships`). Bounded by a per-node-per-taxonomy 50-term truncation cap with an observability hook.
+- **Backend extends `graph-builder.php` in place, not a parallel module**: new per-edge-type extractors run alongside the existing link extractor. Cache-key hash domain expands to cover the new data sources (term-relationships state, nav-menu state). Rationale: one cache, one invalidation contract; parallel modules would require per-source cache coordination.
+- **Cache invalidation hooks expand**: existing `save_post` and `deleted_post` stay; add `set_object_terms` (taxonomy changes), `wp_update_nav_menu` and `wp_update_nav_menu_item` (menu changes). Rationale: any of these can change an edge derived in this plan.
+- **Per-user preferences follow `os-settings.php` shape**: new `includes/content-graph/preferences.php`, meta key `desktop_mode_content_graph_prefs` (autoload-false, no leading underscore per convention), REST `GET/POST /desktop-mode/v1/content-graph/preferences`. Initial state injected through `desktopModeWindowConfig` to avoid first-paint round-trip. Debounced writes mirror `src/boot/session-saver.ts` at 250ms (UI-pref writes are higher-frequency, lower-criticality than session writes).
+- **Toolbar `<wpd-*>` migration is bundled into this effort, not split off**: `src/content-graph/toolbar.ts` is raw DOM today. Extending it without migrating would entrench the `AGENTS.md` violation. Migration is small per-control surgery, not a rewrite.
+- **No new public `wp.desktop.*` API in v1**: lens registry and edge-type registry stay as TS-side constants. Promote to public hooks if real plugin demand surfaces. Rationale: API surfaces are easier to add later than to remove; v1 has no validated extension demand from plugin authors.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How are co-tag, co-author, hierarchy, menu edge sets queried efficiently?**
+  - Co-tag: single bulk `wp_term_relationships` JOIN keyed on the in-scope post IDs already fetched, filtered to non-clustering taxonomies. Stay on raw `$wpdb->get_results` with prepared `IN (...)` placeholders, matching the existing `desktop_mode_content_graph_fetch_rows()` style.
+  - Co-author: derive in PHP from `post_author` (added to existing fetch SELECT). No extra query.
+  - Hierarchy: derive in PHP from `post_parent` (added to existing fetch SELECT). No extra query.
+  - Menu: `wp_get_nav_menus()` + `wp_get_nav_menu_items($menu)` per menu, filter to `_menu_item_type='post_type'`, emit edges from menu (or parent menu item) to referenced post id. Skip non-post targets.
+- **Cleanest way to swap force config on a live `ForceSim`?** Add a `setForceConfig({ clustersEnabled, attractorStrength })` method that mutates internal flags. Tick loop reads flags and runs the cluster-attractor force loop only when enabled. No re-creation. `reheat(0.3, false)` after the swap.
+- **Multi-toggle component**: `<wpd-multiselect>` for the edges control (popover with checkboxes saves toolbar real estate). Post-type chips become `<wpd-chip>` rows with a thin parent owning the active `Set` (the existing toolbar already does this; just swap the `<button>` for `<wpd-chip>`).
+- **User-meta key naming**: `desktop_mode_content_graph_prefs` (per the `desktop_mode_<feature>` convention from `os-settings.php`).
+- **Menu-edge filter precision**: `_menu_item_type='post_type'` AND `_menu_item_object_id` resolves to a post in scope. Skip terms (`taxonomy`) and custom URLs (`custom`).
+
+### Deferred to Implementation
+
+- **Empirical force-sim tuning**: attractor strength and cluster spacing for sparse (~30-node), typical (~200-node), and dense (~500-node) sites. Solve by running the dev server with seeded fixtures during U4 and U5; do not block the plan on this.
+- **Exact cache-key digest shape for term-relationships and nav-menu state**: a `MAX(term_taxonomy_id) + COUNT(*)` over `wp_term_relationships` filtered to in-scope post IDs is likely sufficient, but the precise SQL and whether to hash menu-item `post_modified_gmt` separately are implementation-time choices.
+- **Whether to extract a `src/content-graph/lenses.ts` registry module or keep lens definitions as a constant in `scene.ts`**: settle once the lens-config object's shape stabilizes during U5.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+        ┌─────────────────────────────────────────────────────────────────┐
+        │  GraphScene (extended)                                          │
+        │                                                                 │
+        │   tick(dt):                                                     │
+        │     sim.step(dt)        ◄── ForceSim with optional cluster      │
+        │     cameraEase()             attractor force (gated by lens)    │
+        │     draw()              ◄── edge-kind-aware color/weight        │
+        │     drawClusterLabels() ◄── new layer, scale-aware              │
+        │     satellites.drawLinks()                                      │
+        │                                                                 │
+        │   setLens(id):                                                  │
+        │     this.activeLens = lensRegistry[id]                          │
+        │     sim.setForceConfig(lens.forces)                             │
+        │     this.visibleEdgeKinds = lens.defaultEdgeKinds               │
+        │     sim.reheat(0.3, false)                                      │
+        │     // camera, focus, satellites unchanged                      │
+        └─────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ wired by index.ts orchestration
+                              │
+        ┌─────────────────────┴───────────────────────────────────────────┐
+        │  Toolbar (refactored to <wpd-*>)                                │
+        │                                                                 │
+        │   <wpd-segmented> Lens     :  Constellation | Galaxy            │
+        │   <wpd-select>    Taxonomy :  (visible only in Galaxy)          │
+        │   <wpd-chip> row  Types    :  per post-type (existing concept)  │
+        │   <wpd-multiselect> Edges  :  links | co-tag | co-author |     │
+        │                              hierarchy | menu                   │
+        │   Search input + Fit button (preserved)                         │
+        └─────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ wired by index.ts orchestration
+                              │
+        ┌─────────────────────┴───────────────────────────────────────────┐
+        │  REST                                                           │
+        │                                                                 │
+        │   GET  /content-graph/post-types        (existing)              │
+        │   GET  /content-graph/nodes?types=&edges=   ◄── edges param NEW │
+        │                                              returns edges with │
+        │                                              `kind` field       │
+        │   GET  /content-graph/post/<id>         (existing)              │
+        │   GET  /content-graph/preferences       (NEW)                   │
+        │   POST /content-graph/preferences       (NEW)                   │
+        └─────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ caches via transient with expanded hash
+                              │
+        ┌─────────────────────┴───────────────────────────────────────────┐
+        │  graph-builder.php (extended in place)                          │
+        │                                                                 │
+        │   build($types, $edge_kinds):                                   │
+        │     cache_key = hash(types + edge_kinds + rows_mtime            │
+        │                      + term_relationships_state                 │
+        │                      + nav_menu_state)                          │
+        │     if cached: return                                           │
+        │     rows = fetch_rows($types)  // adds post_parent, post_author │
+        │     edges = []                                                  │
+        │     edges += extract_link_edges(rows)        // existing        │
+        │     if 'co_tag'   in $edge_kinds: extract_co_tag_edges(rows)    │
+        │     if 'co_author' in $edge_kinds: extract_co_author_edges(...) │
+        │     if 'hierarchy' in $edge_kinds: extract_hierarchy_edges(...) │
+        │     if 'menu'     in $edge_kinds: extract_menu_edges(rows)      │
+        │     set_transient                                               │
+        └─────────────────────────────────────────────────────────────────┘
+```
+
+The lens system is two TS-side constants (one per lens) keyed by id. Each constant declares: `id`, `label`, `forces` (which force loops the sim runs), `defaultEdgeKinds` (which edge kinds visible on first paint), `toolbarExtras` (which extra controls render). Future lenses (Sitemap, Timeline) drop in by adding a third constant and wiring its toolbar extras; `setLens()` and `draw()` need no further change.
+
+---
+
+## Implementation Units
+
+### U1. PHP: edge-type extractors and graph-builder cache extension
+
+**Goal:** Add four new edge-type extractors (co-tag, co-author, hierarchy, menu) to the existing graph builder. Extend the transient cache key to invalidate on the new data sources. Update REST `/nodes` to accept an `edges` query parameter and return edges with a `kind` field. Emit per-node term membership for public taxonomies so the client (U5) can derive cluster membership without a second round-trip.
+
+**Requirements:** R5, R7, R10, R12
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `includes/content-graph/graph-builder.php`
+- Modify: `includes/content-graph/rest.php`
+- Test: `tests/phpunit/tests/contentGraphEdgeBuilders.php`
+
+**Approach:**
+- Add `post_parent` and `post_author` to the SELECT in `desktop_mode_content_graph_fetch_rows()`. Hierarchy and co-author edges derive in pure PHP from the same fetched rows (no extra query).
+- Co-tag: one bulk `wp_term_relationships` JOIN keyed on in-scope post IDs, filtered to taxonomies other than the currently-clustering taxonomy. Co-tag is symmetric, dedupe on ordered `(min, max)` pair.
+- Menu: `wp_get_nav_menus()` to enumerate menus, then `wp_get_nav_menu_items($menu)` per menu, filter to `_menu_item_type='post_type'` AND `_menu_item_object_id` is in scope. Emit one edge per (menu_item -> target_post_id) where source is either the menu's representative post or the menu item's parent post if any.
+- Extend `desktop_mode_content_graph_cache_key()`'s hash domain to include term-relationships state digest and nav-menu state digest, both keyed on the in-scope post IDs.
+- Add cache-flush hooks: `set_object_terms`, `wp_update_nav_menu`, `wp_update_nav_menu_item`.
+- REST `/nodes` accepts an `edges` query parameter (CSV list of edge kinds to include). Default = all kinds the requesting client wants (carried via the toolbar's edge-toggle state). Build returns edges with a `kind` field on each.
+- Edges come back as `array{ from: int, to: int, kind: string }`. Existing hyperlink edges become `kind: 'link'`.
+- **Per-node term membership emission** (consumed by U5's Galaxy clustering): each node in the `/nodes` response carries a `terms` field shaped as `array<taxonomy_slug, int[]>` mapping taxonomy slug to the term ids that node belongs to. Scope: only taxonomies the build is asked about (a new `taxonomies` query parameter, defaulting to the user's saved Galaxy taxonomy plus any other taxonomies referenced by the requested edge kinds, e.g., co-tag implies all non-clustering public taxonomies). Same bulk `wp_term_relationships` JOIN as the co-tag extractor; the membership map is a side-output of the same query, so the cost is one query (not N), shared.
+- **Payload-size bound:** the per-node `terms` map sizes proportionally to (number of taxonomies in scope) × (average terms per node). Practical bound on a 500-node site with 3 in-scope taxonomies and an average of 4 terms per taxonomy per node is roughly 500 × 3 × 4 = 6000 small int values, on the order of tens of kilobytes pre-gzip. The build truncates `terms[<taxonomy>]` for any single node above 50 entries (a defensive cap; users with more terms per post on one taxonomy hit a documented limit, and the truncation is logged via `do_action('desktop_mode_content_graph_terms_truncated', $post_id, $taxonomy, $count)` for observability). The same query is required for co-tag edge generation regardless, so this adds no new query cost on top of edges; it just keeps the data product instead of discarding it.
+
+**Patterns to follow:**
+- `desktop_mode_content_graph_fetch_rows()` in `includes/content-graph/graph-builder.php` (raw `$wpdb` with prepared `IN(...)` placeholders).
+- Existing cache-key construction in `desktop_mode_content_graph_cache_key()`.
+
+**Test scenarios:**
+- Happy path: a fixture with three posts, two share a tag, two share an author, one has `post_parent` set to another. Calling build with all four new edge kinds returns the expected set of typed edges, no duplicates, no self-edges.
+- Happy path (edges parameter contract): requesting `edges=link,co_tag` returns only hyperlink and co-tag edges, with no co-author, hierarchy, or menu edges in the response. Requesting `edges=link` returns only hyperlink edges. Confirms the parameter U3's `fetchGraph(cfg, types, edgeKinds)` contract depends on.
+- Happy path (Covers AE1): a post tagged with two categories produces co-tag edges to other posts in either category when clustering by a different taxonomy.
+- Happy path (per-node terms emission): with a fixture of three posts where post A has terms `[1, 2]` in `category` and `[10]` in `post_tag`, the response node for A carries `terms: { category: [1, 2], post_tag: [10] }`. Posts with no terms in any in-scope taxonomy carry an empty `terms: {}` object (not omitted, so the field is reliably present on every node).
+- Edge case (terms truncation cap): a single post with more than 50 terms in a single taxonomy has its `terms[<taxonomy>]` truncated to 50 entries, and `do_action('desktop_mode_content_graph_terms_truncated', $post_id, $taxonomy, $count)` fires once with the original count.
+- Edge case: post with no terms in any taxonomy produces no co-tag edges.
+- Edge case: posts in different post types are still candidates for co-author edges if they share `post_author`.
+- Edge case: nav menu containing a custom-URL item plus a post-type item produces only the post-type edge (custom URL skipped).
+- Edge case: nav menu containing a term link is skipped entirely.
+- Error path: requesting an unknown edge kind in the `edges` parameter returns 400 (or silently filters; pick one and document).
+- Integration: after `wp_set_object_terms()` adds a tag to a post, the next `/nodes` call returns updated co-tag edges (cache invalidated by `set_object_terms` hook).
+- Integration: after `wp_update_nav_menu_item()` changes a menu item's target, the next `/nodes` call reflects the new menu edge.
+
+**Verification:**
+- `npm run lint`, `npm run typecheck`, `npm run test:js` all green.
+- PHPUnit `test-content-graph-edge-builders.php` passes.
+- Manual: hit `/wp-json/desktop-mode/v1/content-graph/nodes?types=post,page&edges=link,co_tag,co_author,hierarchy,menu` on a seeded site and verify all five edge kinds appear with correct `kind` values.
+
+---
+
+### U2. PHP: preferences endpoint and config injection
+
+**Goal:** New per-user preferences endpoint following the `os-settings.php` pattern. Inject initial preferences and the public-taxonomy catalog into `desktopModeWindowConfig` so first paint avoids a REST round-trip.
+
+**Requirements:** R4, R14
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `includes/content-graph/preferences.php`
+- Modify: `includes/content-graph/bootstrap.php`
+- Modify: `includes/content-graph/window.php`
+- Test: `tests/phpunit/tests/contentGraphPreferences.php`
+
+**Approach:**
+- New file `preferences.php` with constant `DESKTOP_MODE_CONTENT_GRAPH_PREFS_META_KEY = 'desktop_mode_content_graph_prefs'`.
+- Two REST routes under `desktop-mode/v1/content-graph/preferences`: `GET` (returns merged-with-defaults) and `POST` (sanitizes + stores). Permission callback shared with existing `desktop_mode_content_graph_rest_permission()`.
+- Schema (illustrative, fields that exist v1):
+  - `lens`: enum `'constellation' | 'galaxy'`, default `'constellation'`.
+  - `byLens.constellation.types`: string[] of post-type slugs (defaults to all public).
+  - `byLens.constellation.edges`: string[] of edge kinds (default `['link']`).
+  - `byLens.galaxy.taxonomy`: string (default `'category'` or first available public taxonomy alphabetically).
+  - `byLens.galaxy.types`: string[] of post-type slugs.
+  - `byLens.galaxy.edges`: string[] of edge kinds (default `['link', 'co_tag']`).
+- Sanitizer rejects unknown lens ids, unknown edge kinds, post-type slugs that fail `post_type_exists`, taxonomy slugs that fail `taxonomy_exists` and the `public => true` filter.
+- `bootstrap.php` includes the new file.
+- `window.php` extends the `config` array to include: `prefs` (the merged-with-defaults preferences for the requesting user), `taxonomies` (the public-taxonomy catalog: `[{slug, label, hierarchical, post_types}]`), and `edgeKinds` (the static catalog of edge kinds with `[{slug, label, color, weight}]`).
+
+**Patterns to follow:**
+- `includes/os-settings.php` end-to-end (meta key naming, sanitizer/defaults, REST route registration, schema-driven validation).
+- Existing `config` array injection in `desktop_mode_register_window` call inside `includes/content-graph/window.php`.
+
+**Test scenarios:**
+- Happy path: GET returns defaults for a user with no stored prefs.
+- Happy path: POST with a valid full prefs body persists; subsequent GET returns the same payload.
+- Happy path: POST with a partial body (only `lens`) merges with existing stored prefs without losing other fields.
+- Edge case: POST with `lens: 'sitemap'` (unknown) is rejected; existing stored prefs unchanged.
+- Edge case: POST with an unknown edge kind is dropped from the array but other valid kinds persist.
+- Edge case: POST with a private taxonomy slug is rejected.
+- Error path: unauthenticated request returns 401/403 per existing permission callback.
+- Integration: window-render injects the same payload that GET would return for the current user.
+
+**Verification:**
+- PHPUnit `test-content-graph-preferences.php` passes.
+- Manual: open Content Graph as a logged-in user; check `window.desktopModeWindowConfig['desktop-mode-content-graph']` contains `prefs`, `taxonomies`, `edgeKinds`.
+- `npm run lint`, `npm run typecheck`, `npm run test:js` green.
+
+---
+
+### U3. Frontend: types and REST client extensions
+
+**Goal:** Type the new wire shapes (edge `kind`, preferences, taxonomy catalog, edge-kind catalog). Add REST helpers for the preferences endpoint. Extend `getConfig()` typing and the `fetchGraph()` helper to pass the `edges` parameter.
+
+**Requirements:** R10, R14
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `src/content-graph/types.ts`
+- Modify: `src/content-graph/rest.ts`
+- Test: `tests/vitest/content-graph-rest.test.ts`
+
+**Approach:**
+- Add `EdgeKind` discriminated union: `'link' | 'co_tag' | 'co_author' | 'hierarchy' | 'menu'`.
+- Extend `GraphEdgePayload` with `kind: EdgeKind`. Existing-data compatibility: server always emits `kind`, including `'link'` for the existing extractor.
+- Extend `GraphNodePayload` with `terms: Record<string, number[]>` where the key is a taxonomy slug and the value is the array of term ids that node belongs to in that taxonomy. The map is bounded to taxonomies the request asked about (see U1 Approach for the scoping rule). The field is always present on every node, including the empty-object case `terms: {}` for nodes with no in-scope memberships, so consumers do not have to handle a `terms-may-be-undefined` branch.
+- Add `LensId` union: `'constellation' | 'galaxy'`.
+- Add `ContentGraphPrefs` shape mirroring U2's schema.
+- Add `TaxonomyDescriptor` and `EdgeKindDescriptor` types.
+- Extend `ContentGraphConfig` with `prefs: ContentGraphPrefs`, `taxonomies: TaxonomyDescriptor[]`, `edgeKinds: EdgeKindDescriptor[]`.
+- Add `fetchPrefs(cfg): Promise<ContentGraphPrefs>` and `savePrefs(cfg, partial): Promise<ContentGraphPrefs>` in `rest.ts`.
+- Extend `fetchGraph(cfg, types)` to `fetchGraph(cfg, types, edgeKinds, taxonomies)` so the server can early-out on unrequested edge kinds and scope per-node `terms` emission to taxonomies the client actually needs (the active Galaxy clustering taxonomy plus any others required by the requested edge kinds).
+
+**Patterns to follow:**
+- Existing `fetchPostTypes` / `fetchPostDetail` shape in `src/content-graph/rest.ts`.
+- `trackedFetch` with `source: 'desktop-mode/content-graph'`.
+
+**Test scenarios:**
+- Happy path: `fetchPrefs` returns the typed shape, `savePrefs` round-trips.
+- Happy path: `fetchGraph(cfg, types, ['link', 'co_tag'], ['category'])` parses node-level `terms` into the typed `Record<string, number[]>` and exposes it on the in-memory `GraphNode` for the simulator to consume.
+- Edge case: a node with `terms: {}` in the wire payload is parsed into a node whose `terms` is the empty object (not `undefined`), so U5's clustering code never has to null-check the field.
+- Edge case: malformed server response is surfaced as an error, not silently coerced.
+- Error path: 401 from the prefs endpoint propagates.
+
+**Verification:**
+- `npm run typecheck` green.
+- `tests/vitest/content-graph-rest.test.ts` green.
+- All consumers of `GraphEdgePayload` continue to compile (TS will flag any unhandled `kind`).
+
+---
+
+### U4. ForceSim: cluster attractor force
+
+**Goal:** Add an optional cluster-attractor force loop to `ForceSim`. Each non-pinned node is attracted toward the weighted average of the centroids of the term clusters it belongs to. Centroids are computed each tick from current member positions.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `src/content-graph/sim.ts`
+- Test: `tests/vitest/content-graph-sim-clusters.test.ts`
+
+**Approach:**
+- Add a new public field `clusterMembership: Map<nodeId, string[]> | null` on `ForceSim` (term ids per node; multi-term nodes have multiple). Setter: `setClusters(membership)`. Null disables the force entirely.
+- Add a new force-config flag `attractorStrength: number` (default 0; nonzero enables the loop). `setForceConfig({ attractorStrength })` mutates it.
+- New tick step (between gravity and integrate):
+  - Compute per-term centroids: scratch `Map<termId, {sx, sy, n}>`. One pass over members.
+  - For each node with membership: target = mean of its term centroids (weighted equally for v1; revisit if needed). Force = `(target - position) * attractorStrength`.
+  - Apply to `node.vx`, `node.vy` before damping.
+- Nodes with no membership (the "Uncategorized" cluster) are pulled toward the same scratch entry keyed on a sentinel (e.g., `__uncategorized__`).
+- Existing repulsion + spring + gravity + damping + velocity clamp + drag-influence smoothstep all continue to apply unchanged.
+
+**Execution note:** Add cluster-membership unit tests first; the force loop is small and the assertion ("multi-term node settles between cluster centroids") is testable with deterministic seeds and many ticks.
+
+**Patterns to follow:**
+- The existing repulsion loop (lines 130-154) and spring loop (lines 157-172) for shape and style.
+- The `dragOrigin` smoothstep (lines 175-216) as a reminder that conditional force application is already a precedent.
+
+**Test scenarios:**
+- Happy path: with one term centroid and a small ring of members, members converge inward over N ticks.
+- Happy path (Covers AE1): a multi-term node with two term centroids settles approximately on the line between them, not inside either cluster.
+- Happy path (Covers AE2): a node with no membership is pulled to the "Uncategorized" centroid.
+- Edge case: `clusterMembership = null` disables the force entirely; behavior matches today's sim.
+- Edge case: `attractorStrength = 0` disables the force regardless of membership.
+- Edge case: a term with one member produces a centroid equal to that member's position (force is zero).
+- Edge case: pinned nodes are not displaced by the attractor.
+- Integration: after `setClusters` swaps to a new membership, `reheat(0.3, false)` re-equilibrates within ~200 ticks.
+
+**Verification:**
+- `tests/vitest/content-graph-sim-clusters.test.ts` green.
+- `npm run typecheck` green.
+- Existing sim tests (if any) continue to pass.
+
+---
+
+### U5. GraphScene: lens API, cluster labels, edge-kind-aware bridge highlighting
+
+**Goal:** Add `setLens(lensId)` to `GraphScene`. Branch the `draw()` loop on edge `kind` for color/weight. Apply bridge highlighting (intra fades, cross pops) when the active lens is Galaxy. Add a cluster-label layer rendered at scale-aware visibility.
+
+**Requirements:** R1, R2, R3, R5, R8, R11, R12, R13
+
+**Dependencies:** U3, U4.
+
+**Files:**
+- Modify: `src/content-graph/scene.ts`
+- Possibly create: `src/content-graph/lenses.ts` (extracted iff the lens config's surface area pushes past a single page in `scene.ts`)
+- Test: `tests/vitest/content-graph-scene-lens.test.ts`
+
+**Approach:**
+- Lens config object: `{ id, forces: { attractor: boolean, attractorStrength: number }, edgeKinds: { intraDimAlpha: number, defaults: EdgeKind[] }, showClusterLabels: boolean }`. Two constants: `CONSTELLATION_LENS` and `GALAXY_LENS`.
+- `setLens(lensId)`:
+  - Mutate `this.activeLens`.
+  - Call `sim.setForceConfig({ attractorStrength: lens.forces.attractorStrength })` and `sim.setClusters(lens.forces.attractor ? this.clusterMembership : null)`.
+  - Set `this.visibleEdgeKinds` to `lens.edgeKinds.defaults` (initial paint; user overrides via toolbar persist independently).
+  - `sim.reheat(0.3, false)`.
+  - Camera, focus, satellites: untouched.
+- `draw()` loop changes:
+  - Per edge: render only if `kind` is in `visibleEdgeKinds`.
+  - Color/weight come from a per-kind palette (e.g., link = neutral gray, co-tag = blue, co-author = purple, hierarchy = teal, menu = amber). Palette lives next to the lens config.
+  - Bridge highlighting (Galaxy only): if both endpoints share at least one term in the active clustering taxonomy, alpha = `lens.edgeKinds.intraDimAlpha` (e.g., 0.06); otherwise alpha = base. "Uncategorized" counts as one shared cluster for this rule (so two uncategorized posts' link is intra, faded).
+- Cluster-label layer:
+  - New `clusterLabelLayer: PixiContainer` added to `world` between `nodeLayer` and `labelLayer`.
+  - Per-tick: for each term centroid, render a `PixiText` with term name + member count above the centroid. Reuse the existing label-visibility scale rule from `draw()` so labels disappear at low zoom.
+- Label collision policy: when two cluster centroids drift close enough that their labels overlap, accept the overlap at the current zoom level. The scale-aware visibility rule already hides labels at low zoom; at normal zoom, overlapping cluster labels are an acceptable outcome of the force-driven layout (and a signal that the user might want to pan or zoom). No collision-avoidance logic in v1.
+  - Empty terms (zero members) are not rendered. (R9, AE6.)
+- `setClusterTaxonomy(taxonomySlug)`: re-derives cluster membership from the current node set's taxonomy data, calls `sim.setClusters(...)`, updates labels. Membership comes from the per-node `terms` field on each `GraphNode` (typed and emitted by U3 and U1 respectively); no extra REST round-trip is needed when the active taxonomy is already in the cached payload's `terms` scope. If the user picks a taxonomy outside that scope, the toolbar triggers a `loadGraph()` with the new `taxonomies` query parameter so the next payload carries the membership data.
+- `setVisibleEdgeKinds(kinds)`: sets the field; next `draw()` reflects.
+- **Focus and camera continuity across rebuilds (feasibility-2 fix):** `GraphScene.setData(payload)` is updated so it preserves `focusedId` and the camera target (`targetX`, `targetY`, `targetScale`) across a fresh data load when the focused node still exists in the new payload. Today's `setData()` re-randomises positions for missing nodes and constructs a new `ForceSim`; the change is to (a) carry forward `focusedId` if the new node set still contains that id (clear it otherwise), (b) leave `targetX/Y/Scale` untouched on the rebuild path so the camera does not snap to a default fit-to-view, and (c) re-apply the focused node's `pinned: true` and re-emit the satellite fan-out for the new node-detail (the panel content survives because U7 does not reload it on lens switch). `loadGraph()` in `index.ts` correspondingly stops calling `scene?.fitToView()` and `scene?.clearFocus()` when the load was triggered by a lens switch (vs. an initial mount or a post-type filter change). This satisfies AE4 along the U7 path that fetches both edge kinds for the new lens.
+
+**Patterns to follow:**
+- Existing `draw()` structure in `src/content-graph/scene.ts` for the per-edge and per-node loops.
+- The label-visibility threshold logic at lines 607-654.
+
+**Test scenarios:**
+- Happy path: `setLens('galaxy')` while a node is focused leaves the focused node id and camera position unchanged. (Covers AE4.)
+- Happy path: in Galaxy with `category` clustering, an edge between two posts in the same category has alpha equal to `intraDimAlpha`; an edge between posts in different categories has full alpha. (Covers AE3.)
+- Happy path: cluster labels render at zoom > threshold; disappear at zoom < threshold.
+- Edge case: setting a lens with no `attractor` does not re-derive cluster membership and skips label rendering.
+- Edge case: setting `visibleEdgeKinds = []` results in zero edges drawn but nodes still render.
+- Happy path (Covers AE4, focus-and-camera continuity through rebuild): with a node focused and camera panned/zoomed off-center, calling `scene.setData(newPayload)` where the new payload still contains the focused node id leaves `focusedId`, `targetX`, `targetY`, and `targetScale` unchanged. The focused node is re-pinned and the satellite fan-out re-renders against the new node detail. `loadGraph()` invoked via the lens-switch path skips `fitToView()` and `clearFocus()`.
+- Edge case: `setData(newPayload)` where the focused node id is absent from the new payload clears `focusedId` and the satellite layer; camera target stays put (no implicit fit-to-view) so the user does not get yanked across the canvas.
+- Edge case (Covers AE6): a term with zero in-scope members has no label and no centroid in the scratch map; given a taxonomy with 50 terms and 12 used, exactly 12 cluster centroids and 12 labels render (plus "Uncategorized" if any nodes lack terms).
+- Edge case (R2 extensibility): a hypothetical third lens registered as a new entry in the lens-config map is selectable via `setLens()` without requiring changes to the branching logic in `setLens()` body or `draw()`. The test asserts the structural contract by registering a fixture lens object and verifying `setLens('fixture')` mutates the active config without throwing on unknown-lens branching.
+- Integration: switching from Constellation to Galaxy and back returns the camera and focus to their pre-switch values (no implicit fit-to-view).
+
+**Verification:**
+- `tests/vitest/content-graph-scene-lens.test.ts` green.
+- Manual: open Content Graph, switch lenses; observe cluster formation in Galaxy and the bridge-highlighting effect; switch back; confirm camera/focus survive.
+
+---
+
+### U6. Toolbar: <wpd-*> migration plus lens / taxonomy / edges controls
+
+**Goal:** Migrate `src/content-graph/toolbar.ts` from raw DOM to `<wpd-*>` components. Add the lens segmented control, taxonomy dropdown, and edges multi-toggle. Per-lens visibility rules: taxonomy dropdown visible only in Galaxy; edges multi-toggle visible in both lenses.
+
+**Requirements:** R1, R4, R11, R16
+
+**Dependencies:** U3.
+
+**Files:**
+- Modify: `src/content-graph/toolbar.ts`
+- Test: `tests/vitest/content-graph-toolbar.test.ts`
+
+**Approach:**
+- Replace the existing raw `<button>` chip rendering with `<wpd-chip>` rows. The parent owner of the active `Set` stays; only the rendered element changes.
+- New `<wpd-segmented>` for the lens picker, with two `<wpd-segment>` children. `wpd-pick` event fires `onLensChange(lensId)`.
+- New `<wpd-select>` for the taxonomy dropdown, populated from `cfg.taxonomies`. Hidden when the active lens is Constellation. `wpd-pick` fires `onTaxonomyChange(slug)`.
+- New `<wpd-multiselect>` for the edges toggle, populated from `cfg.edgeKinds`. `wpd-pick` fires `onEdgesChange(kinds)`.
+- Search input + Fit button preserved (refactor styling to fit the new component layout if needed).
+- Layout: use `<wpd-row>` / `<wpd-cluster>` to compose the toolbar. Mobile/narrow handling: the existing toolbar sits in a horizontally-scrollable container; preserve.
+- Removal: delete the raw `escapeHtml`/`escapeAttr` helpers if they become unused after migration.
+
+**Patterns to follow:**
+- Other toolbar consumers of `<wpd-segmented>` and `<wpd-select>` in the repo (the research map called these out as established stable components).
+- `panel.ts`'s use of `wpd-spinner` for a precedent of `<wpd-*>` consumption inside content-graph.
+
+**Test scenarios:**
+- Happy path: clicking a lens segment fires `onLensChange` with the picked id.
+- Happy path: picking a taxonomy fires `onTaxonomyChange` with the slug.
+- Happy path: toggling an edge kind fires `onEdgesChange` with the new array of visible kinds.
+- Happy path: post-type chip click toggles the chip and fires `onTypesChange`.
+- Edge case: Constellation lens hides the taxonomy dropdown; switching to Galaxy reveals it.
+- Edge case: edges multi-toggle disables the link entry in a lens that bans it (none in v1, but the wiring should be consistent).
+- Integration: keyboard tab order traverses lens -> taxonomy -> chips -> edges -> search -> fit in a sensible reading order.
+
+**Verification:**
+- `tests/vitest/content-graph-toolbar.test.ts` green.
+- `npm run lint` green (specifically: no remaining raw `document.createElement('button')` or `<input>` in `toolbar.ts`).
+- Manual: open Content Graph, use only the keyboard to traverse and operate every control.
+
+---
+
+### U7. Orchestration: persistence wiring and lens switching end-to-end
+
+**Goal:** In `src/content-graph/index.ts`, hydrate prefs from the injected window config on first paint, wire toolbar callbacks to scene + sim + REST, and persist user changes through a debounced saver.
+
+**Requirements:** R3, R14
+
+**Dependencies:** U2, U3, U5, U6.
+
+**Files:**
+- Modify: `src/content-graph/index.ts`
+- Possibly create: `src/content-graph/preferences.ts` (extracted iff the persistence helper grows past ~50 lines)
+- Test: `tests/vitest/content-graph-index-persistence.test.ts`
+
+**Approach:**
+- On render: read `cfg.prefs` and call `scene.setLens(prefs.lens)`, `scene.setClusterTaxonomy(prefs.byLens.galaxy.taxonomy)`, `scene.setVisibleEdgeKinds(prefs.byLens[prefs.lens].edges)`, `loadGraph()` with `prefs.byLens[prefs.lens].types` and `.edges`.
+- Toolbar callbacks update local state, call the corresponding scene methods, and schedule a debounced `savePrefs(partial)`.
+- Debounced saver: trailing-edge with 250ms wait. Mirrors `src/boot/session-saver.ts` but lighter (no `sendBeacon` flush; preferences are not safety-critical).
+- **Lens switch path:** `loadGraph()` is invoked when the new lens's `(types, edges, taxonomies)` differs from what was last fetched. The call is annotated with a `reason: 'lens-switch'` flag so `loadGraph()` skips its post-load `scene?.fitToView()` and `scene?.clearFocus()` calls (those continue to run for `reason: 'initial'` and `reason: 'filter-change'`). Combined with U5's `setData()` continuity rules, this preserves `focusedId` and camera target across the lens transition (AE4). When the new lens's data shape matches the cached payload, the round-trip is skipped entirely and only `scene.setLens()` runs.
+- Search, fit-to-view, post-type chips all preserved.
+
+**Patterns to follow:**
+- `src/boot/session-saver.ts` for the debounced-saver shape.
+- The existing `buildToolbarCallbacks()` factory in `src/content-graph/index.ts`.
+
+**Test scenarios:**
+- Happy path: on first paint with `prefs.lens = 'galaxy'`, the scene mounts with Galaxy already active.
+- Happy path (Covers AE5): the user switches lens to Galaxy, picks `post_tag`, toggles `co-author` on. After 250ms idle the saver POSTs prefs containing those values. On a fresh mount the same state is restored.
+- Edge case: rapid toolbar interactions within 250ms collapse to a single POST.
+- Edge case: switching lens when (types, edges) match the cached payload skips the network round-trip.
+- Error path: a failed POST does not roll back the local UI state. The next successful save catches up.
+- Integration: closing and reopening the window after toolbar changes restores the most recent prefs.
+
+**Verification:**
+- `tests/vitest/content-graph-index-persistence.test.ts` green.
+- Manual end-to-end: walk through F1, F2, F3, F4 from the origin doc; verify outcomes match.
+
+---
+
+### U8. Documentation updates
+
+**Goal:** Backfill the existing `desktop_mode_content_graph_*` filters in `docs/hooks-reference.md` (the gap research found). Document any new filters introduced by this work. Skip new `wp.desktop.*` API and `docs/examples/` entries; both are deferred per Key Technical Decisions.
+
+**Requirements:** Indirect (preserves the project's documented-contract rule from `AGENTS.md`).
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `docs/hooks-reference.md`
+- Modify (only if a new filter is added during U1-U7): the same.
+
+**Approach:**
+- Add a new section in `docs/hooks-reference.md` covering the existing Content Graph filters that aren't documented today: `desktop_mode_content_graph_window_args`, `desktop_mode_content_graph_icon_args`, `desktop_mode_content_graph_user_can_use`, `desktop_mode_content_graph_post_types`, `desktop_mode_content_graph_template_html`. Status: Stable. Cite signatures and a one-line use case for each.
+- If the implementation adds any new filter (likely candidates: a filter on the edge-kind catalog, a filter on the taxonomy catalog, a filter on the prefs schema), document it in the same section with status: Experimental and a note that the surface may change.
+- Skip `docs/javascript-reference.md` updates: no public `wp.desktop.*` surface added in v1.
+- Skip `docs/examples/`: no public extension surface to demo.
+
+**Test expectation:** none. Documentation-only unit; correctness is reviewed via human read-through during PR review.
+
+**Verification:**
+- Markdown lints (if configured) clean.
+- Hooks listed match the actual `apply_filters` calls in `includes/content-graph/`.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Content Graph is a self-contained native window. The new preferences endpoint adds one route under the existing `desktop-mode/v1` namespace; no other windows are touched. The Pixi `Application` lifecycle stays the same; lens switching does not remount it.
+- **Error propagation:** REST failures surface to the existing toolbar status line via `setStatus()`. Persistence-write failures are non-fatal (toast or silent retry; the content-graph window continues to function).
+- **State lifecycle risks:**
+  - Cache invalidation on the new edge types must be tight; a stale cache after `set_object_terms` would silently misrepresent co-tag edges. Covered by U1's invalidation hooks and tested by an integration scenario.
+  - Multi-term posts being attracted toward many centroids could destabilize the simulation if attractor force is too strong; tuning is deferred to implementation but the velocity clamp in `sim.ts` provides a hard ceiling.
+- **API surface parity:** No other native window or external consumer reads the Content Graph's REST endpoints today. The `kind` field on edges is additive; existing handlers (none external) will not break.
+- **Integration coverage:** Cross-layer scenarios that mocks alone will not prove are flagged as Integration in test scenarios for U1, U2, U4, U7. They cover end-to-end persistence, end-to-end edge-type invalidation, and lens-switch state preservation.
+- **Unchanged invariants:** Existing satellite fan-out, side panel, search, fit-to-view, pan/zoom, and node-focus interactions are NOT changed (R15). The brainstorm's Key Flow F4 explicitly relies on this. Tests must verify these continue to behave identically across both lenses.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Force-sim becomes unstable when attractor force is added (oscillation, escape velocity). | The existing `MAX_VELOCITY` clamp and damping factor cap blow-up. Force coefficient tuning deferred to implementation with empirical fixtures (sparse, typical, dense sites). Tests assert convergence within N ticks for the typical case. |
+| Co-tag query becomes expensive on sites with many tags or many posts (N posts × M tags). | One bulk `wp_term_relationships` JOIN keyed on the in-scope post IDs already fetched, not per-post. Existing transient cache covers steady-state cost. If empirical pain emerges, an opt-in "compute co-tag edges only on demand" path is a clean follow-up. |
+| Cache invalidation gaps cause stale edges (e.g., a hook we forgot to listen to). | Explicit hook list in U1: `save_post`, `deleted_post`, `set_object_terms`, `wp_update_nav_menu`, `wp_update_nav_menu_item`. Integration tests in U1 exercise the most likely scenarios. |
+| `<wpd-*>` migration of the existing chip row introduces visual regressions. | Toolbar visual diff via screenshots before/after on a seeded site during PR review. The component-kit replacements are functionally equivalent; risk is in styling spacing or dashicon rendering. |
+| Lens switch loses camera or focus state because the rebuild path (`loadGraph()` + `setData()`) snaps to fit-to-view. | Resolved in design: `setData()` preserves `focusedId` and camera target on rebuilds, and `loadGraph()` accepts a `reason` flag that suppresses `fitToView()` and `clearFocus()` on lens-switch loads. AE4 is enforced as an explicit test scenario in U5. Any regression is caught by the test, not by review alone. |
+| Per-node `terms` payload grows unbounded on sites with very long taxonomies (e.g., a tag taxonomy with hundreds of terms per post). | Per-node-per-taxonomy 50-term truncation cap in U1, with `do_action('desktop_mode_content_graph_terms_truncated', ...)` for observability. The scoping rule (only request taxonomies actually needed by the active lens + visible edge kinds) keeps typical payloads bounded; the cap is the safety net for outliers. |
+| Bridge highlighting visually overpowers cross-cluster signal because intra-dim alpha is too aggressive (or too mild). | Default `intraDimAlpha = 0.06`; expose as a per-lens config field so it can be tuned without recompile. Tune empirically against seeded fixtures. |
+| Preferences schema drift between PHP and TS leads to silent field loss. | PHP sanitizer is the gate; TS types describe the same shape; PHP unit tests in U2 assert the round-trip. Whenever the schema changes, both sides update in the same commit. |
+
+---
+
+## Documentation / Operational Notes
+
+- Documentation: per U8, `docs/hooks-reference.md` is updated. No `docs/javascript-reference.md` or `docs/examples/` work in v1.
+- Translation (i18n): user-facing strings ("Constellation", "Galaxy", lens labels, taxonomy labels, edge-kind labels, "Uncategorized") flow through the existing `__()` helper. Per the project memory, do NOT regenerate the POT/PO/JSON in this PR. That is a batched pre-translation step.
+- Operational rollout: this is a single-plugin feature; no migration, no feature flag in v1. Ships in the next plugin release.
+- Build: per `AGENTS.md`, run `npm run build` after every code change. Specifically `npm run build:content-graph` covers the relevant bundle, and `npm run build` covers all targets.
+- PHPUnit conventions: every new test class under `tests/phpunit/tests/` MUST carry the `@group desktop-mode` PHPDoc tag at the class level. The repo's `tests/phpunit/phpunit.xml.dist` filters tests by `@group desktop-mode`; without the tag, the class runs zero tests and the suite reports green silently. File naming follows the existing camelCase convention (e.g., `contentGraphEdgeBuilders.php`, `contentGraphPreferences.php`).
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/content-graph-multi-lens-galaxy-requirements.md](../brainstorms/content-graph-multi-lens-galaxy-requirements.md)
+- Related code: `src/content-graph/`, `includes/content-graph/`, `src/ui/components/wpd-segmented/`, `src/ui/components/wpd-select/`, `src/ui/components/wpd-multiselect/`, `src/ui/components/wpd-chip/`, `includes/os-settings.php`, `src/boot/session-saver.ts`
+- Related PRs/issues: none yet.
+- External docs: none used.

--- a/includes/content-graph/bootstrap.php
+++ b/includes/content-graph/bootstrap.php
@@ -19,5 +19,6 @@ defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/assets.php';
 require_once __DIR__ . '/graph-builder.php';
+require_once __DIR__ . '/preferences.php';
 require_once __DIR__ . '/rest.php';
 require_once __DIR__ . '/window.php';

--- a/includes/content-graph/graph-builder.php
+++ b/includes/content-graph/graph-builder.php
@@ -2,22 +2,38 @@
 /**
  * Desktop Mode — Content Graph: graph builder.
  *
- * Walks the WordPress post store to produce two arrays for the bundle:
+ * Walks the WordPress post store to produce three arrays for the
+ * bundle:
  *
- *   - `nodes`  — one entry per post matching the requested types.
- *   - `edges`  — one entry per internal hyperlink found in any node's
- *                `post_content`, deduped, with self-edges suppressed.
+ *   - `nodes`  — one entry per post matching the requested types. Each
+ *                node carries a `terms` map from taxonomy slug to the
+ *                term ids that node belongs to (scoped to the
+ *                taxonomies the request asked about).
+ *   - `edges`  — one entry per relationship in the requested edge
+ *                kinds, keyed by `kind`:
+ *                  * `link`      — internal hyperlink in `post_content`
+ *                  * `co_tag`    — shared term in any taxonomy other
+ *                                  than the active clustering taxonomy
+ *                  * `co_author` — shared `post_author`
+ *                  * `hierarchy` — `post_parent` relationships
+ *                  * `menu`      — nav-menu items pointing to a post
+ *                                  in scope (and to their parent menu
+ *                                  item's referenced post when present)
+ *   - `stats`  — counts for nodes/edges and a `generated_at` ts.
  *
  * The expensive piece is the link extraction: every published post in
  * scope is parsed with `DOMDocument`, every `<a href>` is scanned, and
  * each href is resolved with `url_to_postid()`. We cache the full
- * `{ nodes, edges }` tuple in a transient keyed on the requested
- * `types` plus a hash of the relevant rows' `post_modified_gmt`. Any
- * change to a participating post invalidates the hash, so save_post
+ * `{ nodes, edges, stats }` tuple in a transient keyed on the
+ * requested `types`, requested `edge_kinds`, requested `taxonomies`,
+ * AND a hash that bumps when any participating row's
+ * `post_modified_gmt`, term-relationships state, or nav-menu state
+ * changes. Any of those changes invalidates the hash, so editing
  * implicitly refreshes the graph the next time it's requested. We
- * also explicitly bust the cache on `save_post` and `deleted_post` so
- * editors don't see stale data even if some other process pre-warms
- * the transient.
+ * also explicitly bust the cache on `save_post`, `deleted_post`,
+ * `set_object_terms`, `wp_update_nav_menu`, and
+ * `wp_update_nav_menu_item` so editors don't see stale data even if
+ * some other process pre-warms the transient.
  *
  * @package WPDesktopMode
  * @since   0.8.2
@@ -29,24 +45,59 @@ const DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_PREFIX = 'desktop_mode_cg_';
 const DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_TTL    = 6 * HOUR_IN_SECONDS;
 
 /**
+ * Defensive cap: a single post's `terms[<taxonomy>]` is truncated to
+ * this many entries. Sites that genuinely store more terms per post
+ * per taxonomy hit a documented limit and the truncation fires the
+ * `desktop_mode_content_graph_terms_truncated` action with the
+ * original count for observability.
+ *
+ * @since 0.9.0
+ */
+const DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP = 50;
+
+/**
+ * Catalog of edge kinds the builder knows how to produce.
+ *
+ * @since 0.9.0
+ *
+ * @return string[]
+ */
+function desktop_mode_content_graph_edge_kinds() {
+	return array( 'link', 'co_tag', 'co_author', 'hierarchy', 'menu' );
+}
+
+/**
  * Build (or reuse the cached version of) the graph payload for the
- * requested post types.
+ * requested post types, edge kinds, and taxonomy scope.
  *
  * @since 0.8.2
+ * @since 0.9.0 Added `$edge_kinds` and `$taxonomies` parameters.
  *
- * @param string[] $types Post type slugs. Filtered against the public
- *                        post-type registry, attachments excluded.
+ * @param string[] $types       Post type slugs. Filtered against the
+ *                              public post-type registry, attachments
+ *                              excluded.
+ * @param string[] $edge_kinds  Edge kinds to compute. Subset of
+ *                              `desktop_mode_content_graph_edge_kinds()`.
+ *                              Empty = all kinds.
+ * @param string[] $taxonomies  Taxonomy slugs whose memberships should
+ *                              ride along on each node's `terms` map.
+ *                              Public taxonomies only. Empty = no
+ *                              membership data emitted.
  * @return array{
  *     nodes: array<int, array{
  *         id: int, type: string, title: string, status: string,
- *         slug: string, edit_url: string
+ *         slug: string, edit_url: string,
+ *         terms: array<string, int[]>
  *     }>,
- *     edges: array<int, array{ from: int, to: int }>,
+ *     edges: array<int, array{ from: int, to: int, kind: string }>,
  *     stats: array{ nodes: int, edges: int, generated_at: int }
  * }
  */
-function desktop_mode_content_graph_build( array $types ) {
-	$types = desktop_mode_content_graph_normalize_types( $types );
+function desktop_mode_content_graph_build( array $types, array $edge_kinds = array(), array $taxonomies = array() ) {
+	$types      = desktop_mode_content_graph_normalize_types( $types );
+	$edge_kinds = desktop_mode_content_graph_normalize_edge_kinds( $edge_kinds );
+	$taxonomies = desktop_mode_content_graph_normalize_taxonomies( $taxonomies );
+
 	if ( empty( $types ) ) {
 		return array(
 			'nodes' => array(),
@@ -59,55 +110,69 @@ function desktop_mode_content_graph_build( array $types ) {
 		);
 	}
 
-	$cache_key = desktop_mode_content_graph_cache_key( $types );
+	$cache_key = desktop_mode_content_graph_cache_key( $types, $edge_kinds, $taxonomies );
 	$cached    = get_transient( $cache_key );
 	if ( is_array( $cached ) && isset( $cached['nodes'], $cached['edges'] ) ) {
 		return $cached;
 	}
 
-	$rows = desktop_mode_content_graph_fetch_rows( $types );
-
-	$nodes       = array();
-	$nodes_by_id = array();
+	$rows        = desktop_mode_content_graph_fetch_rows( $types );
+	$ids_in_scope = array();
 	foreach ( $rows as $row ) {
-		$id   = (int) $row->ID;
-		$node = array(
+		$ids_in_scope[ (int) $row->ID ] = true;
+	}
+
+	// Collect per-node taxonomy membership ONCE, indexed by post id.
+	// The co-tag extractor and the per-node `terms` map are derived
+	// from the same data so we can produce both with a single pass.
+	$terms_by_post = empty( $taxonomies )
+		? array()
+		: desktop_mode_content_graph_collect_terms_by_post( array_keys( $ids_in_scope ), $taxonomies );
+
+	$nodes = array();
+	foreach ( $rows as $row ) {
+		$id    = (int) $row->ID;
+		$nodes[] = array(
 			'id'       => $id,
 			'type'     => (string) $row->post_type,
 			'title'    => (string) get_the_title( $row ),
 			'status'   => (string) $row->post_status,
 			'slug'     => (string) $row->post_name,
 			'edit_url' => (string) get_edit_post_link( $id, 'raw' ),
+			'terms'    => isset( $terms_by_post[ $id ] ) ? $terms_by_post[ $id ] : (object) array(),
 		);
-		$nodes[]            = $node;
-		$nodes_by_id[ $id ] = true;
 	}
 
-	$edges_seen = array();
-	$edges      = array();
-	foreach ( $rows as $row ) {
-		$from = (int) $row->ID;
-		$tos  = desktop_mode_content_graph_extract_internal_links( (string) $row->post_content );
-		foreach ( $tos as $to ) {
-			if ( $to === $from ) {
-				continue;
-			}
-			if ( empty( $nodes_by_id[ $to ] ) ) {
-				// Linked post exists but is not in the requested types
-				// scope, or is not a published post. Skip; the user
-				// can widen the filter to surface it.
-				continue;
-			}
-			$key = $from . '->' . $to;
-			if ( isset( $edges_seen[ $key ] ) ) {
-				continue;
-			}
-			$edges_seen[ $key ] = true;
-			$edges[]            = array(
-				'from' => $from,
-				'to'   => $to,
-			);
-		}
+	$edges = array();
+	if ( in_array( 'link', $edge_kinds, true ) ) {
+		$edges = array_merge(
+			$edges,
+			desktop_mode_content_graph_extract_link_edges( $rows, $ids_in_scope )
+		);
+	}
+	if ( in_array( 'co_author', $edge_kinds, true ) ) {
+		$edges = array_merge(
+			$edges,
+			desktop_mode_content_graph_extract_co_author_edges( $rows )
+		);
+	}
+	if ( in_array( 'hierarchy', $edge_kinds, true ) ) {
+		$edges = array_merge(
+			$edges,
+			desktop_mode_content_graph_extract_hierarchy_edges( $rows, $ids_in_scope )
+		);
+	}
+	if ( in_array( 'co_tag', $edge_kinds, true ) ) {
+		$edges = array_merge(
+			$edges,
+			desktop_mode_content_graph_extract_co_tag_edges( $terms_by_post )
+		);
+	}
+	if ( in_array( 'menu', $edge_kinds, true ) ) {
+		$edges = array_merge(
+			$edges,
+			desktop_mode_content_graph_extract_menu_edges( $ids_in_scope )
+		);
 	}
 
 	$payload = array(
@@ -127,9 +192,7 @@ function desktop_mode_content_graph_build( array $types ) {
 
 /**
  * Filter, sanitize, and uniquify the requested type slugs against the
- * public post-type registry. Returned slugs are guaranteed to exist
- * AND to be among the slugs declared by
- * `desktop_mode_content_graph_post_types()`.
+ * public post-type registry.
  *
  * @since 0.8.2
  *
@@ -154,20 +217,79 @@ function desktop_mode_content_graph_normalize_types( array $types ) {
 }
 
 /**
- * Cache key for `{ nodes, edges }` for a given type set. Includes a
- * short hash of the participating rows' post_modified_gmt so any
- * relevant edit busts the cache implicitly.
+ * Filter, sanitize, and uniquify requested edge kinds.
+ *
+ * Empty input returns just `['link']` for backwards compatibility:
+ * before 0.9.0 the builder produced only hyperlink edges, and any
+ * pre-existing caller (including a stale browser-cached client) is
+ * expected to keep getting that behavior until they opt in to the
+ * new edge kinds via the `edges` query parameter.
+ *
+ * @since 0.9.0
+ *
+ * @param string[] $edge_kinds
+ * @return string[]
+ */
+function desktop_mode_content_graph_normalize_edge_kinds( array $edge_kinds ) {
+	$allowed = array_flip( desktop_mode_content_graph_edge_kinds() );
+	if ( empty( $edge_kinds ) ) {
+		return array( 'link' );
+	}
+	$out = array();
+	foreach ( $edge_kinds as $k ) {
+		$k = sanitize_key( (string) $k );
+		if ( '' !== $k && isset( $allowed[ $k ] ) ) {
+			$out[ $k ] = true;
+		}
+	}
+	return array_keys( $out );
+}
+
+/**
+ * Filter, sanitize, and uniquify requested taxonomy slugs against the
+ * registered public taxonomy registry.
+ *
+ * @since 0.9.0
+ *
+ * @param string[] $taxonomies
+ * @return string[]
+ */
+function desktop_mode_content_graph_normalize_taxonomies( array $taxonomies ) {
+	if ( empty( $taxonomies ) ) {
+		return array();
+	}
+	$registered = get_taxonomies( array( 'public' => true ), 'names' );
+	$allowed    = is_array( $registered ) ? array_flip( $registered ) : array();
+	$out        = array();
+	foreach ( $taxonomies as $tax ) {
+		$tax = sanitize_key( (string) $tax );
+		if ( '' !== $tax && isset( $allowed[ $tax ] ) ) {
+			$out[ $tax ] = true;
+		}
+	}
+	return array_keys( $out );
+}
+
+/**
+ * Cache key for `{ nodes, edges, stats }` for the given type set,
+ * edge-kind set, and taxonomy scope. Includes hashes that bump when
+ * any of: (a) a participating row's `post_modified_gmt` changes, (b)
+ * any term-relationship for an in-scope post changes, (c) any nav
+ * menu definition changes (when nav-menu edges are requested).
  *
  * @since 0.8.2
+ * @since 0.9.0 Hash domain expanded for new edge kinds and taxonomies.
  *
- * @param string[] $types Already normalized.
+ * @param string[] $types       Already normalized.
+ * @param string[] $edge_kinds  Already normalized.
+ * @param string[] $taxonomies  Already normalized.
  * @return string
  */
-function desktop_mode_content_graph_cache_key( array $types ) {
+function desktop_mode_content_graph_cache_key( array $types, array $edge_kinds, array $taxonomies ) {
 	global $wpdb;
 	$placeholders = implode( ',', array_fill( 0, count( $types ), '%s' ) );
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$hash = (string) $wpdb->get_var(
+	$rows_hash = (string) $wpdb->get_var(
 		$wpdb->prepare(
 			"SELECT MD5( GROUP_CONCAT( CONCAT( ID, ':', post_modified_gmt ) ORDER BY ID ) )
 			 FROM {$wpdb->posts}
@@ -176,19 +298,59 @@ function desktop_mode_content_graph_cache_key( array $types ) {
 			$types
 		)
 	);
-	// phpcs:enable
-	if ( '' === $hash || null === $hash ) {
-		$hash = 'empty';
+	$tr_hash    = '';
+	$menu_hash  = '';
+	if ( in_array( 'co_tag', $edge_kinds, true ) || ! empty( $taxonomies ) ) {
+		// Term-relationship state: a digest of (object_id, term_taxonomy_id)
+		// over the in-scope posts. Cheap enough for a single MD5 over a
+		// GROUP_CONCAT; the rows_hash join keeps the workspace small.
+		$tr_hash = (string) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MD5( GROUP_CONCAT( CONCAT( tr.object_id, ':', tr.term_taxonomy_id ) ORDER BY tr.object_id, tr.term_taxonomy_id ) )
+				 FROM {$wpdb->term_relationships} tr
+				 INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id
+				 WHERE p.post_status IN ( 'publish', 'private' )
+				 AND p.post_type IN ( {$placeholders} )",
+				$types
+			)
+		);
 	}
-	return DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_PREFIX . substr( md5( implode( ',', $types ) . '|' . $hash ), 0, 24 );
+	if ( in_array( 'menu', $edge_kinds, true ) ) {
+		// Nav-menu state digest: every nav_menu_item's id +
+		// post_modified_gmt. Editing any menu item bumps the row's
+		// post_modified_gmt, which bumps the hash.
+		$menu_hash = (string) $wpdb->get_var(
+			"SELECT MD5( GROUP_CONCAT( CONCAT( ID, ':', post_modified_gmt ) ORDER BY ID ) )
+			 FROM {$wpdb->posts}
+			 WHERE post_type = 'nav_menu_item'"
+		);
+	}
+	// phpcs:enable
+	if ( '' === $rows_hash || null === $rows_hash ) {
+		$rows_hash = 'empty';
+	}
+	$composite = implode(
+		'|',
+		array(
+			'types=' . implode( ',', $types ),
+			'edges=' . implode( ',', $edge_kinds ),
+			'taxes=' . implode( ',', $taxonomies ),
+			'rows=' . $rows_hash,
+			'tr=' . $tr_hash,
+			'menu=' . $menu_hash,
+		)
+	);
+	return DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_PREFIX . substr( md5( $composite ), 0, 24 );
 }
 
 /**
  * Fetch the participating posts in a single query. Returns full rows
- * (including `post_content`) so the link extractor can run without N+1
- * `get_post()` calls.
+ * including `post_content`, `post_parent`, and `post_author` so the
+ * link extractor and the cheap derived edge extractors can run
+ * without N+1 `get_post()` calls.
  *
  * @since 0.8.2
+ * @since 0.9.0 Adds `post_parent`, `post_author` to the SELECT.
  *
  * @param string[] $types Already normalized.
  * @return WP_Post[]
@@ -199,7 +361,7 @@ function desktop_mode_content_graph_fetch_rows( array $types ) {
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$rows = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT ID, post_type, post_status, post_title, post_name, post_content
+			"SELECT ID, post_type, post_status, post_title, post_name, post_content, post_parent, post_author
 			 FROM {$wpdb->posts}
 			 WHERE post_status IN ( 'publish', 'private' )
 			 AND post_type IN ( {$placeholders} )
@@ -213,9 +375,6 @@ function desktop_mode_content_graph_fetch_rows( array $types ) {
 		return array();
 	}
 
-	// Hydrate as WP_Post so get_the_title()/get_edit_post_link() work
-	// without additional queries. update_post_caches() warms the
-	// objects so subsequent helper calls hit the cache.
 	$posts = array();
 	foreach ( $rows as $row ) {
 		$post    = new WP_Post( $row );
@@ -225,6 +384,119 @@ function desktop_mode_content_graph_fetch_rows( array $types ) {
 		update_post_caches( $posts, '', false, false );
 	}
 	return $posts;
+}
+
+/**
+ * Per-node taxonomy membership map. Returns
+ * `array<post_id, array<taxonomy_slug, int[]>>` covering only the
+ * requested taxonomies and the in-scope post ids. One bulk JOIN; no
+ * N+1.
+ *
+ * Truncates per-(post, taxonomy) entries to the
+ * `DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP` limit and fires the
+ * `desktop_mode_content_graph_terms_truncated` action when the cap
+ * applies.
+ *
+ * @since 0.9.0
+ *
+ * @param int[]    $post_ids   In-scope post ids.
+ * @param string[] $taxonomies Already normalized public taxonomy slugs.
+ * @return array<int, array<string, int[]>>
+ */
+function desktop_mode_content_graph_collect_terms_by_post( array $post_ids, array $taxonomies ) {
+	if ( empty( $post_ids ) || empty( $taxonomies ) ) {
+		return array();
+	}
+	global $wpdb;
+	$id_placeholders  = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
+	$tax_placeholders = implode( ',', array_fill( 0, count( $taxonomies ), '%s' ) );
+	$args             = array_merge( array_map( 'intval', $post_ids ), $taxonomies );
+	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT tr.object_id AS post_id, tt.taxonomy AS taxonomy, tt.term_id AS term_id
+			 FROM {$wpdb->term_relationships} tr
+			 INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+			 WHERE tr.object_id IN ( {$id_placeholders} )
+			 AND tt.taxonomy IN ( {$tax_placeholders} )",
+			$args
+		)
+	);
+	// phpcs:enable
+	if ( ! is_array( $rows ) ) {
+		return array();
+	}
+	$out = array();
+	foreach ( $rows as $row ) {
+		$pid = (int) $row->post_id;
+		$tax = (string) $row->taxonomy;
+		$tid = (int) $row->term_id;
+		if ( ! isset( $out[ $pid ] ) ) {
+			$out[ $pid ] = array();
+		}
+		if ( ! isset( $out[ $pid ][ $tax ] ) ) {
+			$out[ $pid ][ $tax ] = array();
+		}
+		$out[ $pid ][ $tax ][] = $tid;
+	}
+	// Apply per-(post, taxonomy) truncation cap.
+	foreach ( $out as $pid => $by_tax ) {
+		foreach ( $by_tax as $tax => $ids ) {
+			$count = count( $ids );
+			if ( $count > DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP ) {
+				$out[ $pid ][ $tax ] = array_slice( $ids, 0, DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP );
+				/**
+				 * Fires once per (post, taxonomy) tuple whose membership
+				 * exceeds the cap.
+				 *
+				 * @since 0.9.0
+				 *
+				 * @param int    $post_id  Post whose terms were truncated.
+				 * @param string $taxonomy Taxonomy slug.
+				 * @param int    $count    Original (pre-truncation) term count.
+				 */
+				do_action( 'desktop_mode_content_graph_terms_truncated', $pid, $tax, $count );
+			}
+		}
+	}
+	return $out;
+}
+
+/**
+ * Internal-link edges, extracted from `post_content` via DOMDocument.
+ *
+ * @since 0.9.0 Factored out of `build()`.
+ *
+ * @param WP_Post[] $rows         All in-scope posts.
+ * @param bool[]    $ids_in_scope Map of in-scope post id => true.
+ * @return array<int, array{ from: int, to: int, kind: string }>
+ */
+function desktop_mode_content_graph_extract_link_edges( array $rows, array $ids_in_scope ) {
+	$edges_seen = array();
+	$edges      = array();
+	foreach ( $rows as $row ) {
+		$from = (int) $row->ID;
+		$tos  = desktop_mode_content_graph_extract_internal_links( (string) $row->post_content );
+		foreach ( $tos as $to ) {
+			if ( $to === $from ) {
+				continue;
+			}
+			if ( empty( $ids_in_scope[ $to ] ) ) {
+				continue;
+			}
+			$key = 'link:' . $from . '->' . $to;
+			if ( isset( $edges_seen[ $key ] ) ) {
+				continue;
+			}
+			$edges_seen[ $key ] = true;
+			$edges[]            = array(
+				'from' => $from,
+				'to'   => $to,
+				'kind' => 'link',
+			);
+		}
+	}
+	return $edges;
 }
 
 /**
@@ -242,13 +514,10 @@ function desktop_mode_content_graph_extract_internal_links( $content ) {
 		return array();
 	}
 
-	// `<base>` shenanigans aside, url_to_postid() handles relative,
-	// absolute, query-string, pretty, and ?p= forms uniformly.
 	$ids  = array();
 	$seen = array();
 	$prev = libxml_use_internal_errors( true );
 	$dom  = new DOMDocument();
-	// `loadHTML` insists on a charset hint to avoid mangling utf-8.
 	$loaded = $dom->loadHTML( '<?xml encoding="utf-8"?>' . $content );
 	libxml_clear_errors();
 	libxml_use_internal_errors( $prev );
@@ -263,7 +532,6 @@ function desktop_mode_content_graph_extract_internal_links( $content ) {
 		if ( '' === $href ) {
 			continue;
 		}
-		// Skip obvious non-internal targets fast.
 		if ( 0 === strpos( $href, '#' ) ) {
 			continue;
 		}
@@ -282,10 +550,230 @@ function desktop_mode_content_graph_extract_internal_links( $content ) {
 }
 
 /**
- * Cache invalidation. Any post-type change wipes every transient
- * carrying the `desktop_mode_cg_` prefix. We don't have a per-type
- * index so we wipe globally, the cost is one extra build on next
- * open which dominates the time-savings on subsequent opens.
+ * Co-author edges: pairs of in-scope posts sharing `post_author`.
+ * Symmetric, deduped on ordered (min, max) pairs.
+ *
+ * @since 0.9.0
+ *
+ * @param WP_Post[] $rows
+ * @return array<int, array{ from: int, to: int, kind: string }>
+ */
+function desktop_mode_content_graph_extract_co_author_edges( array $rows ) {
+	$by_author = array();
+	foreach ( $rows as $row ) {
+		$uid = (int) $row->post_author;
+		if ( $uid <= 0 ) {
+			continue;
+		}
+		if ( ! isset( $by_author[ $uid ] ) ) {
+			$by_author[ $uid ] = array();
+		}
+		$by_author[ $uid ][] = (int) $row->ID;
+	}
+	$edges = array();
+	$seen  = array();
+	foreach ( $by_author as $ids ) {
+		$count = count( $ids );
+		if ( $count < 2 ) {
+			continue;
+		}
+		for ( $i = 0; $i < $count; $i++ ) {
+			for ( $j = $i + 1; $j < $count; $j++ ) {
+				$a = $ids[ $i ];
+				$b = $ids[ $j ];
+				if ( $a === $b ) {
+					continue;
+				}
+				$lo  = $a < $b ? $a : $b;
+				$hi  = $a < $b ? $b : $a;
+				$key = 'co_author:' . $lo . '->' . $hi;
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+				$seen[ $key ] = true;
+				$edges[]      = array(
+					'from' => $lo,
+					'to'   => $hi,
+					'kind' => 'co_author',
+				);
+			}
+		}
+	}
+	return $edges;
+}
+
+/**
+ * Hierarchy edges: `post_parent` relationships for in-scope posts
+ * whose parent is also in scope. Directed (parent -> child).
+ *
+ * @since 0.9.0
+ *
+ * @param WP_Post[] $rows
+ * @param bool[]    $ids_in_scope
+ * @return array<int, array{ from: int, to: int, kind: string }>
+ */
+function desktop_mode_content_graph_extract_hierarchy_edges( array $rows, array $ids_in_scope ) {
+	$edges = array();
+	$seen  = array();
+	foreach ( $rows as $row ) {
+		$child  = (int) $row->ID;
+		$parent = (int) $row->post_parent;
+		if ( $parent <= 0 || $parent === $child ) {
+			continue;
+		}
+		if ( empty( $ids_in_scope[ $parent ] ) ) {
+			continue;
+		}
+		$key = 'hierarchy:' . $parent . '->' . $child;
+		if ( isset( $seen[ $key ] ) ) {
+			continue;
+		}
+		$seen[ $key ] = true;
+		$edges[]      = array(
+			'from' => $parent,
+			'to'   => $child,
+			'kind' => 'hierarchy',
+		);
+	}
+	return $edges;
+}
+
+/**
+ * Co-tag edges: pairs of in-scope posts sharing at least one term in
+ * any of the taxonomies for which we collected memberships. Symmetric,
+ * deduped on ordered (min, max) pairs.
+ *
+ * The full taxonomy scope is whatever the request asked about; the
+ * caller (build()) is responsible for excluding the active clustering
+ * taxonomy if that is the desired behavior.
+ *
+ * @since 0.9.0
+ *
+ * @param array<int, array<string, int[]>> $terms_by_post
+ * @return array<int, array{ from: int, to: int, kind: string }>
+ */
+function desktop_mode_content_graph_extract_co_tag_edges( array $terms_by_post ) {
+	// Build an index: term_taxonomy -> [post_id, ...]
+	$by_term = array();
+	foreach ( $terms_by_post as $pid => $by_tax ) {
+		foreach ( $by_tax as $tax => $term_ids ) {
+			foreach ( $term_ids as $tid ) {
+				$key = $tax . ':' . (int) $tid;
+				if ( ! isset( $by_term[ $key ] ) ) {
+					$by_term[ $key ] = array();
+				}
+				$by_term[ $key ][ (int) $pid ] = true;
+			}
+		}
+	}
+	$edges = array();
+	$seen  = array();
+	foreach ( $by_term as $post_set ) {
+		$ids   = array_keys( $post_set );
+		$count = count( $ids );
+		if ( $count < 2 ) {
+			continue;
+		}
+		for ( $i = 0; $i < $count; $i++ ) {
+			for ( $j = $i + 1; $j < $count; $j++ ) {
+				$a   = $ids[ $i ];
+				$b   = $ids[ $j ];
+				$lo  = $a < $b ? $a : $b;
+				$hi  = $a < $b ? $b : $a;
+				$key = 'co_tag:' . $lo . '->' . $hi;
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+				$seen[ $key ] = true;
+				$edges[]      = array(
+					'from' => $lo,
+					'to'   => $hi,
+					'kind' => 'co_tag',
+				);
+			}
+		}
+	}
+	return $edges;
+}
+
+/**
+ * Menu edges: nav-menu items whose target is an in-scope post produce
+ * an edge from the menu item's parent menu item's target post (if any
+ * and in scope) to the target post. When the menu item is at the top
+ * level of its menu, the edge is dropped; we only emit edges between
+ * pairs of in-scope content posts.
+ *
+ * @since 0.9.0
+ *
+ * @param bool[] $ids_in_scope Map of in-scope post id => true.
+ * @return array<int, array{ from: int, to: int, kind: string }>
+ */
+function desktop_mode_content_graph_extract_menu_edges( array $ids_in_scope ) {
+	if ( empty( $ids_in_scope ) || ! function_exists( 'wp_get_nav_menus' ) ) {
+		return array();
+	}
+	$menus = wp_get_nav_menus();
+	if ( empty( $menus ) || is_wp_error( $menus ) ) {
+		return array();
+	}
+	$edges = array();
+	$seen  = array();
+	foreach ( $menus as $menu ) {
+		$items = wp_get_nav_menu_items( $menu );
+		if ( empty( $items ) || is_wp_error( $items ) ) {
+			continue;
+		}
+		// Build a per-menu map: menu_item_id -> resolved target post id
+		// (only when the item is `post_type` AND points at an in-scope
+		// post). Items pointing at terms or custom URLs are excluded.
+		$item_target = array();
+		foreach ( $items as $item ) {
+			if ( 'post_type' !== (string) $item->type ) {
+				continue;
+			}
+			$target = (int) $item->object_id;
+			if ( $target <= 0 || empty( $ids_in_scope[ $target ] ) ) {
+				continue;
+			}
+			$item_target[ (int) $item->ID ] = $target;
+		}
+		// Now emit edges from each item's parent-menu-item's target
+		// (when present and resolved) to the item's target.
+		foreach ( $items as $item ) {
+			$item_id = (int) $item->ID;
+			if ( ! isset( $item_target[ $item_id ] ) ) {
+				continue;
+			}
+			$parent_item_id = (int) $item->menu_item_parent;
+			if ( $parent_item_id <= 0 || ! isset( $item_target[ $parent_item_id ] ) ) {
+				continue;
+			}
+			$from = $item_target[ $parent_item_id ];
+			$to   = $item_target[ $item_id ];
+			if ( $from === $to ) {
+				continue;
+			}
+			$key = 'menu:' . $from . '->' . $to;
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$edges[]      = array(
+				'from' => $from,
+				'to'   => $to,
+				'kind' => 'menu',
+			);
+		}
+	}
+	return $edges;
+}
+
+/**
+ * Cache invalidation. Any post / term-relationship / nav-menu change
+ * wipes every transient carrying the `desktop_mode_cg_` prefix. We
+ * don't have a per-type or per-taxonomy index so we wipe globally;
+ * the cost is one extra build on next open which dominates the time
+ * savings on subsequent opens.
  *
  * @since 0.8.2
  */
@@ -300,3 +788,6 @@ function desktop_mode_content_graph_flush_cache() {
 }
 add_action( 'save_post', 'desktop_mode_content_graph_flush_cache' );
 add_action( 'deleted_post', 'desktop_mode_content_graph_flush_cache' );
+add_action( 'set_object_terms', 'desktop_mode_content_graph_flush_cache' );
+add_action( 'wp_update_nav_menu', 'desktop_mode_content_graph_flush_cache' );
+add_action( 'wp_update_nav_menu_item', 'desktop_mode_content_graph_flush_cache' );

--- a/includes/content-graph/preferences.php
+++ b/includes/content-graph/preferences.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * Desktop Mode — Content Graph: per-user preferences.
+ *
+ * Persists per-user UI state for the Content Graph window: which
+ * lens is active, which taxonomy drives Galaxy clustering, and per-
+ * lens edge-toggle + post-type-chip state. Backs the toolbar's
+ * "remember my last view" behavior so reopening the window doesn't
+ * reset choices.
+ *
+ * Mirrors the os-settings.php pattern: defaults helper, getter that
+ * always returns a fully-shaped array, sanitizer that merges client
+ * payload with defaults, REST GET/POST routes under
+ * `desktop-mode/v1/content-graph/preferences`. State is stored in a
+ * single user-meta entry so a single `update_user_meta` call writes
+ * the whole snapshot.
+ *
+ * @package WPDesktopMode
+ * @since   0.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** User-meta key for Content Graph preferences. */
+const DESKTOP_MODE_CONTENT_GRAPH_PREFS_META_KEY = 'desktop_mode_content_graph_prefs';
+
+/** Lens IDs the front end recognises. */
+const DESKTOP_MODE_CONTENT_GRAPH_LENSES = array( 'constellation', 'galaxy' );
+
+/**
+ * Default preferences for a fresh user.
+ *
+ * Mirrors the per-lens default-edge-visibility decision in the plan:
+ * Constellation defaults to hyperlinks only (preserves today's
+ * behavior). Galaxy defaults to hyperlinks plus co-tag (the bridge-
+ * highlighting story).
+ *
+ * @since 0.9.0
+ *
+ * @return array
+ */
+function desktop_mode_content_graph_default_prefs() {
+	return array(
+		'lens'   => 'constellation',
+		'byLens' => array(
+			'constellation' => array(
+				'types' => array(),
+				'edges' => array( 'link' ),
+			),
+			'galaxy'        => array(
+				'types'    => array(),
+				'edges'    => array( 'link', 'co_tag' ),
+				'taxonomy' => 'category',
+			),
+		),
+	);
+}
+
+/**
+ * Load and return a fully-shaped preferences array for a user.
+ *
+ * @since 0.9.0
+ *
+ * @param int $user_id
+ * @return array
+ */
+function desktop_mode_content_graph_get_prefs( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return desktop_mode_content_graph_default_prefs();
+	}
+	$raw = get_user_meta( $user_id, DESKTOP_MODE_CONTENT_GRAPH_PREFS_META_KEY, true );
+	if ( ! is_array( $raw ) ) {
+		return desktop_mode_content_graph_default_prefs();
+	}
+	return desktop_mode_content_graph_sanitize_prefs( $raw );
+}
+
+/**
+ * Sanitize and persist a partial or full preferences payload, merging
+ * with whatever is currently stored so a partial save (e.g., only
+ * `lens`) doesn't wipe the rest.
+ *
+ * @since 0.9.0
+ *
+ * @param int   $user_id
+ * @param mixed $patch Raw client payload.
+ * @return array Merged + sanitized prefs (the new authoritative value).
+ */
+function desktop_mode_content_graph_save_prefs( $user_id, $patch ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return desktop_mode_content_graph_default_prefs();
+	}
+	$current = desktop_mode_content_graph_get_prefs( $user_id );
+	$merged  = desktop_mode_content_graph_merge_prefs( $current, is_array( $patch ) ? $patch : array() );
+	$clean   = desktop_mode_content_graph_sanitize_prefs( $merged );
+	update_user_meta( $user_id, DESKTOP_MODE_CONTENT_GRAPH_PREFS_META_KEY, $clean );
+	return $clean;
+}
+
+/**
+ * Shallow merge that preserves per-lens sub-fields not present in the
+ * patch. Per-lens entries on `byLens` are merged at one level deeper
+ * so a patch like `{ byLens: { galaxy: { taxonomy: 'post_tag' } } }`
+ * does not wipe `galaxy.types` or `galaxy.edges`.
+ *
+ * @since 0.9.0
+ *
+ * @param array $current
+ * @param array $patch
+ * @return array
+ */
+function desktop_mode_content_graph_merge_prefs( array $current, array $patch ) {
+	$out = $current;
+	if ( isset( $patch['lens'] ) ) {
+		$out['lens'] = $patch['lens'];
+	}
+	if ( isset( $patch['byLens'] ) && is_array( $patch['byLens'] ) ) {
+		foreach ( $patch['byLens'] as $lens_id => $lens_patch ) {
+			if ( ! is_array( $lens_patch ) ) {
+				continue;
+			}
+			$existing = isset( $out['byLens'][ $lens_id ] ) && is_array( $out['byLens'][ $lens_id ] )
+				? $out['byLens'][ $lens_id ]
+				: array();
+			$out['byLens'][ $lens_id ] = array_merge( $existing, $lens_patch );
+		}
+	}
+	return $out;
+}
+
+/**
+ * Sanitize a (possibly malicious) preferences payload back to a
+ * known-good shape. Unknown lens IDs, unknown edge kinds, unknown
+ * post-type slugs, and unknown taxonomies are dropped silently.
+ *
+ * @since 0.9.0
+ *
+ * @param array $raw
+ * @return array
+ */
+function desktop_mode_content_graph_sanitize_prefs( $raw ) {
+	$defaults = desktop_mode_content_graph_default_prefs();
+	if ( ! is_array( $raw ) ) {
+		return $defaults;
+	}
+
+	// Lens.
+	$lens = $defaults['lens'];
+	if (
+		isset( $raw['lens'] )
+		&& is_string( $raw['lens'] )
+		&& in_array( $raw['lens'], DESKTOP_MODE_CONTENT_GRAPH_LENSES, true )
+	) {
+		$lens = (string) $raw['lens'];
+	}
+
+	$allowed_kinds = array_flip( desktop_mode_content_graph_edge_kinds() );
+
+	$registered_post_types = array_flip(
+		(array) wp_list_pluck( desktop_mode_content_graph_post_types(), 'slug' )
+	);
+
+	$registered_taxonomies = array_flip(
+		(array) get_taxonomies( array( 'public' => true ), 'names' )
+	);
+
+	$by_lens = $defaults['byLens'];
+
+	if ( isset( $raw['byLens'] ) && is_array( $raw['byLens'] ) ) {
+		foreach ( $raw['byLens'] as $lens_id => $lens_state ) {
+			if ( ! is_string( $lens_id ) || ! in_array( $lens_id, DESKTOP_MODE_CONTENT_GRAPH_LENSES, true ) ) {
+				continue;
+			}
+			if ( ! is_array( $lens_state ) ) {
+				continue;
+			}
+			$entry = isset( $by_lens[ $lens_id ] ) ? $by_lens[ $lens_id ] : array();
+
+			// Post-type slugs.
+			if ( isset( $lens_state['types'] ) && is_array( $lens_state['types'] ) ) {
+				$cleaned = array();
+				foreach ( $lens_state['types'] as $slug ) {
+					if ( ! is_string( $slug ) ) {
+						continue;
+					}
+					$slug = sanitize_key( $slug );
+					if ( '' !== $slug && isset( $registered_post_types[ $slug ] ) ) {
+						$cleaned[ $slug ] = true;
+					}
+					if ( count( $cleaned ) >= 32 ) {
+						break;
+					}
+				}
+				$entry['types'] = array_keys( $cleaned );
+			}
+
+			// Edge kinds.
+			if ( isset( $lens_state['edges'] ) && is_array( $lens_state['edges'] ) ) {
+				$cleaned = array();
+				foreach ( $lens_state['edges'] as $kind ) {
+					if ( ! is_string( $kind ) ) {
+						continue;
+					}
+					$kind = sanitize_key( $kind );
+					if ( '' !== $kind && isset( $allowed_kinds[ $kind ] ) ) {
+						$cleaned[ $kind ] = true;
+					}
+				}
+				$entry['edges'] = array_keys( $cleaned );
+			}
+
+			// Galaxy-only: taxonomy slug.
+			if ( 'galaxy' === $lens_id && isset( $lens_state['taxonomy'] ) && is_string( $lens_state['taxonomy'] ) ) {
+				$slug = sanitize_key( $lens_state['taxonomy'] );
+				if ( '' !== $slug && isset( $registered_taxonomies[ $slug ] ) ) {
+					$entry['taxonomy'] = $slug;
+				}
+			}
+
+			$by_lens[ $lens_id ] = $entry;
+		}
+	}
+
+	return array(
+		'lens'   => $lens,
+		'byLens' => $by_lens,
+	);
+}
+
+/**
+ * Permission callback for the prefs REST routes. Mirrors the broader
+ * Content Graph capability gate so users who can't see the window
+ * can't write preferences for it either.
+ *
+ * @since 0.9.0
+ *
+ * @return bool
+ */
+function desktop_mode_content_graph_prefs_rest_permission() {
+	return is_user_logged_in() && desktop_mode_content_graph_user_can_use();
+}
+
+/**
+ * Register the prefs REST routes.
+ *
+ * @since 0.9.0
+ */
+function desktop_mode_content_graph_register_prefs_routes() {
+	register_rest_route(
+		'desktop-mode/v1',
+		'/content-graph/preferences',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'desktop_mode_content_graph_rest_get_prefs',
+				'permission_callback' => 'desktop_mode_content_graph_prefs_rest_permission',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'desktop_mode_content_graph_rest_save_prefs',
+				'permission_callback' => 'desktop_mode_content_graph_prefs_rest_permission',
+				'args'                => array(
+					'preferences' => array(
+						'required' => true,
+						'type'     => 'object',
+					),
+				),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'desktop_mode_content_graph_register_prefs_routes' );
+
+/**
+ * GET /desktop-mode/v1/content-graph/preferences
+ *
+ * @since 0.9.0
+ *
+ * @return WP_REST_Response
+ */
+function desktop_mode_content_graph_rest_get_prefs() {
+	return rest_ensure_response( desktop_mode_content_graph_get_prefs( get_current_user_id() ) );
+}
+
+/**
+ * POST /desktop-mode/v1/content-graph/preferences
+ *
+ * @since 0.9.0
+ *
+ * @param WP_REST_Request $request
+ * @return WP_REST_Response
+ */
+function desktop_mode_content_graph_rest_save_prefs( WP_REST_Request $request ) {
+	$user_id = get_current_user_id();
+	$payload = $request->get_param( 'preferences' );
+	return rest_ensure_response( desktop_mode_content_graph_save_prefs( $user_id, $payload ) );
+}
+
+/**
+ * Build a descriptor list of public taxonomies eligible for Galaxy
+ * clustering. Mirrors the post-types descriptor shape so the JS side
+ * can render dropdown options without an extra REST round-trip.
+ *
+ * @since 0.9.0
+ *
+ * @return array[] Each entry: `array( 'slug', 'label', 'hierarchical', 'post_types' )`.
+ */
+function desktop_mode_content_graph_taxonomies() {
+	$taxes  = get_taxonomies( array( 'public' => true ), 'objects' );
+	$result = array();
+	foreach ( $taxes as $tax ) {
+		$result[] = array(
+			'slug'         => (string) $tax->name,
+			'label'        => (string) $tax->labels->name,
+			'hierarchical' => (bool) $tax->hierarchical,
+			'post_types'   => array_values( (array) $tax->object_type ),
+		);
+	}
+
+	/**
+	 * Filter the list of taxonomies offered as Galaxy clustering keys.
+	 * Each entry must declare `slug`, `label`, `hierarchical`, and
+	 * `post_types`. Removing an entry hides it from the dropdown AND
+	 * from the prefs sanitizer's allow-list.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array[] $result Default: every public taxonomy.
+	 */
+	$filtered = apply_filters( 'desktop_mode_content_graph_taxonomies', $result );
+	return is_array( $filtered ) ? array_values( $filtered ) : $result;
+}
+
+/**
+ * Build a descriptor list of edge kinds offered to the toolbar's edges
+ * multi-toggle. Each entry carries display metadata and the wire slug
+ * used by the REST layer.
+ *
+ * @since 0.9.0
+ *
+ * @return array[] Each entry: `array( 'slug', 'label', 'color', 'weight' )`.
+ */
+function desktop_mode_content_graph_edge_kind_descriptors() {
+	$result = array(
+		array(
+			'slug'   => 'link',
+			'label'  => __( 'Hyperlinks', 'desktop-mode' ),
+			'color'  => '#6b7280',
+			'weight' => 0.7,
+		),
+		array(
+			'slug'   => 'co_tag',
+			'label'  => __( 'Shared terms', 'desktop-mode' ),
+			'color'  => '#2c6be5',
+			'weight' => 0.7,
+		),
+		array(
+			'slug'   => 'co_author',
+			'label'  => __( 'Same author', 'desktop-mode' ),
+			'color'  => '#7c3aed',
+			'weight' => 0.7,
+		),
+		array(
+			'slug'   => 'hierarchy',
+			'label'  => __( 'Page hierarchy', 'desktop-mode' ),
+			'color'  => '#059669',
+			'weight' => 0.7,
+		),
+		array(
+			'slug'   => 'menu',
+			'label'  => __( 'Menu structure', 'desktop-mode' ),
+			'color'  => '#d97706',
+			'weight' => 0.7,
+		),
+	);
+
+	/**
+	 * Filter the edge-kind descriptors offered to the toolbar's edges
+	 * multi-toggle. Removing an entry hides it from the toggle UI but
+	 * does NOT prevent the server-side build from emitting that kind.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array[] $result Default: link, co_tag, co_author, hierarchy, menu.
+	 */
+	$filtered = apply_filters( 'desktop_mode_content_graph_edge_kind_descriptors', $result );
+	return is_array( $filtered ) ? array_values( $filtered ) : $result;
+}

--- a/includes/content-graph/rest.php
+++ b/includes/content-graph/rest.php
@@ -57,8 +57,18 @@ function desktop_mode_content_graph_register_routes() {
 			'callback'            => 'desktop_mode_content_graph_rest_nodes',
 			'permission_callback' => 'desktop_mode_content_graph_rest_permission',
 			'args'                => array(
-				'types' => array(
+				'types'      => array(
 					'description' => 'Comma-separated list of post type slugs to include.',
+					'type'        => 'string',
+					'default'     => '',
+				),
+				'edges'      => array(
+					'description' => 'Comma-separated list of edge kinds to compute (link, co_tag, co_author, hierarchy, menu). Empty = all kinds.',
+					'type'        => 'string',
+					'default'     => '',
+				),
+				'taxonomies' => array(
+					'description' => 'Comma-separated list of public taxonomy slugs whose memberships should ride along on each node\'s `terms` map.',
 					'type'        => 'string',
 					'default'     => '',
 				),
@@ -122,11 +132,24 @@ function desktop_mode_content_graph_rest_post_types() {
  * @return WP_REST_Response
  */
 function desktop_mode_content_graph_rest_nodes( WP_REST_Request $request ) {
-	$raw   = (string) $request->get_param( 'types' );
-	$types = '' === $raw
+	$raw_types = (string) $request->get_param( 'types' );
+	$types     = '' === $raw_types
 		? wp_list_pluck( desktop_mode_content_graph_post_types(), 'slug' )
-		: array_map( 'trim', explode( ',', $raw ) );
-	return rest_ensure_response( desktop_mode_content_graph_build( (array) $types ) );
+		: array_map( 'trim', explode( ',', $raw_types ) );
+
+	$raw_edges  = (string) $request->get_param( 'edges' );
+	$edge_kinds = '' === $raw_edges
+		? array()
+		: array_map( 'trim', explode( ',', $raw_edges ) );
+
+	$raw_taxes  = (string) $request->get_param( 'taxonomies' );
+	$taxonomies = '' === $raw_taxes
+		? array()
+		: array_map( 'trim', explode( ',', $raw_taxes ) );
+
+	return rest_ensure_response(
+		desktop_mode_content_graph_build( (array) $types, (array) $edge_kinds, (array) $taxonomies )
+	);
 }
 
 /**

--- a/includes/content-graph/window.php
+++ b/includes/content-graph/window.php
@@ -152,6 +152,9 @@ function desktop_mode_content_graph_register_window() {
 			'editCommentUrl' => esc_url_raw( admin_url( 'comment.php' ) ),
 			'mediaUrl'       => esc_url_raw( admin_url( 'upload.php' ) ),
 			'postTypes'      => desktop_mode_content_graph_post_types(),
+			'taxonomies'     => desktop_mode_content_graph_taxonomies(),
+			'edgeKinds'      => desktop_mode_content_graph_edge_kind_descriptors(),
+			'prefs'          => desktop_mode_content_graph_get_prefs( get_current_user_id() ),
 		),
 	);
 

--- a/src/content-graph/index.ts
+++ b/src/content-graph/index.ts
@@ -3,27 +3,40 @@
  *
  * Lazy-loaded by the native-window sync the first time the
  * `desktop-mode-content-graph` window opens. Wires the toolbar +
- * Pixi scene + focused-status row; pulls `{ nodes, edges }` from the
- * `desktop-mode/v1/content-graph` REST routes. On node focus the host
- * fetches `/post/<id>` and pushes the detail to the scene, which fans
- * out per-relationship satellites that the user can click to deep-link
- * into authors, terms, comments, media, and revisions.
+ * Pixi scene + side panel + REST. As of 0.9.0 it also hydrates per-
+ * user preferences (lens choice, taxonomy, edge-toggle state, post-
+ * type chips), wires the new lens segmented control + taxonomy
+ * dropdown + edges multi-toggle, and persists changes via a
+ * debounced `savePrefs()` mirror of `src/boot/session-saver.ts`.
  *
  * The `<wpd-*>` web components are defined by the main desktop
  * bundle; this module only consumes them.
  *
  * @public
  * @since 0.8.2
+ * @since 0.9.0 Multi-lens orchestration + preferences persistence.
  */
 
 import { __, sprintf } from '../i18n';
-import { fetchGraph, fetchPostDetail, fetchPostTypes, getConfig } from './rest';
-import { renderToolbar } from './toolbar';
+import {
+	fetchGraph,
+	fetchPostDetail,
+	fetchPostTypes,
+	getConfig,
+	savePrefs,
+} from './rest';
+import { renderToolbar, type ToolbarHandle } from './toolbar';
 import { renderPanel } from './panel';
 import { GraphScene } from './scene';
 import type { SatelliteRef } from './satellites';
 import type { DesktopApiLike } from './pixi-types';
-import type { GraphNode } from './types';
+import type {
+	ContentGraphConfig,
+	ContentGraphPrefs,
+	EdgeKind,
+	GraphNode,
+	LensId,
+} from './types';
 
 type RenderCallback = ( body: HTMLElement ) => void;
 
@@ -38,6 +51,15 @@ const WINDOW_ID = 'desktop-mode-content-graph';
 interface ActiveState {
 	abort: () => void;
 }
+
+/**
+ * Reasons `loadGraph()` may be called. The reason gates fit-to-view
+ * and clear-focus side effects (lens-switch reloads must NOT snap the
+ * camera or drop focus, per AE4).
+ *
+ * @since 0.9.0
+ */
+type LoadReason = 'initial' | 'lens-switch' | 'filter-change';
 
 async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 	const root = body.querySelector< HTMLElement >(
@@ -65,7 +87,16 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 	const desktopApi = ( window.wp as { desktop?: DesktopApiLike } | undefined )
 		?.desktop ?? {};
 
-	let activeTypes: string[] = cfg.postTypes.map( ( t ) => t.slug );
+	// Mutable view state, hydrated from cfg.prefs and updated by toolbar
+	// callbacks. The debounced saver pulls a fresh snapshot before
+	// firing.
+	let activeLens: LensId = cfg.prefs.lens;
+	let activeTypes: string[] = currentLensState( cfg, activeLens ).types;
+	let activeEdges: EdgeKind[] = currentLensState( cfg, activeLens ).edges;
+	let activeTaxonomy: string = cfg.prefs.byLens.galaxy.taxonomy;
+	// Cached payload key — when a lens switch wouldn't change the
+	// (types, edges, taxonomy) tuple, we skip the network round-trip.
+	let lastFetchKey = '';
 	let scene: GraphScene | null = null;
 	let detailRequestId = 0;
 	let aborted = false;
@@ -84,9 +115,6 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 		},
 	} );
 
-	// Satellite click → contextual panel view (NOT a navigation away).
-	// The panel reuses the data already fetched for the post detail; no
-	// extra REST round-trip per click.
 	const handleSatelliteClick = ( ref: SatelliteRef ): void => {
 		switch ( ref.kind ) {
 			case 'user':
@@ -136,34 +164,88 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 		} )();
 	};
 
-	const buildToolbarCallbacks = () => ( {
-		onTypesChange: ( types: string[] ) => {
-			activeTypes = types;
-			void loadGraph();
-		},
-		onFitToView: () => scene?.fitToView(),
-		onSearchSelect: ( node: GraphNode ) => focusNode( node ),
-		getNodes: () => scene?.getNodes() ?? [],
-	} );
+	// Trailing-edge debounced prefs saver, ~250ms wait. Mirrors the
+	// session-saver pattern but lighter: prefs are not safety-critical,
+	// so no `sendBeacon` flush on unload.
+	let saveTimer: ReturnType< typeof setTimeout > | null = null;
+	const schedulePrefsSave = (): void => {
+		if ( saveTimer ) {
+			clearTimeout( saveTimer );
+		}
+		saveTimer = setTimeout( () => {
+			saveTimer = null;
+			void savePrefs( cfg, snapshotPrefs() ).catch( ( err ) => {
+				// eslint-disable-next-line no-console
+				console.warn( '[content-graph] savePrefs failed', err );
+			} );
+		}, 250 );
+	};
 
-	let toolbar = renderToolbar(
-		toolbarHost,
-		cfg.postTypes,
-		buildToolbarCallbacks(),
-	);
+	const snapshotPrefs = (): Partial< ContentGraphPrefs > => {
+		// Build a partial patch reflecting current UI state so the
+		// server merges and persists it.
+		return {
+			lens: activeLens,
+			byLens: {
+				constellation: {
+					types:
+						activeLens === 'constellation'
+							? activeTypes
+							: cfg.prefs.byLens.constellation.types,
+					edges:
+						activeLens === 'constellation'
+							? activeEdges
+							: cfg.prefs.byLens.constellation.edges,
+				},
+				galaxy: {
+					types:
+						activeLens === 'galaxy'
+							? activeTypes
+							: cfg.prefs.byLens.galaxy.types,
+					edges:
+						activeLens === 'galaxy'
+							? activeEdges
+							: cfg.prefs.byLens.galaxy.edges,
+					taxonomy: activeTaxonomy,
+				},
+			},
+		};
+	};
 
-	const loadGraph = async (): Promise< void > => {
+	const fetchKey = (): string =>
+		[
+			activeTypes.slice().sort().join( ',' ),
+			activeEdges.slice().sort().join( ',' ),
+			activeLens === 'galaxy' ? activeTaxonomy : '',
+		].join( '|' );
+
+	const loadGraph = async ( reason: LoadReason ): Promise< void > => {
 		if ( aborted ) {
+			return;
+		}
+		const key = fetchKey();
+		if ( reason === 'lens-switch' && key === lastFetchKey ) {
+			// No network round-trip needed; lens swap is purely visual.
 			return;
 		}
 		showLoading( true );
 		toolbar.setStatus( __( 'Loading graph…' ) );
 		try {
-			const payload = await fetchGraph( cfg, activeTypes );
+			const taxonomies =
+				activeLens === 'galaxy' && activeTaxonomy
+					? [ activeTaxonomy ]
+					: [];
+			const payload = await fetchGraph(
+				cfg,
+				activeTypes,
+				activeEdges,
+				taxonomies,
+			);
 			if ( aborted ) {
 				return;
 			}
 			scene?.setData( payload );
+			lastFetchKey = key;
 			toolbar.setStatus(
 				sprintf(
 					/* translators: 1: number of nodes (posts/pages) in the graph. 2: number of links between them. */
@@ -172,9 +254,11 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 					payload.stats.edges,
 				),
 			);
-			scene?.fitToView();
-			scene?.clearFocus();
-			panel.hide();
+			if ( reason !== 'lens-switch' ) {
+				scene?.fitToView();
+				scene?.clearFocus();
+				panel.hide();
+			}
 		} catch ( err ) {
 			if ( aborted ) {
 				return;
@@ -186,6 +270,63 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 			showLoading( false );
 		}
 	};
+
+	const buildToolbarCallbacks = () => ( {
+		onTypesChange: ( types: string[] ) => {
+			activeTypes = types;
+			void loadGraph( 'filter-change' );
+			schedulePrefsSave();
+		},
+		onLensChange: ( lens: LensId ) => {
+			activeLens = lens;
+			const lensState = currentLensState( cfg, lens );
+			activeTypes = lensState.types;
+			activeEdges = lensState.edges;
+			scene?.setLens( lens );
+			scene?.setVisibleEdgeKinds( activeEdges );
+			if ( lens === 'galaxy' ) {
+				scene?.setClusterTaxonomy( activeTaxonomy );
+			} else {
+				scene?.setClusterTaxonomy( null );
+			}
+			toolbar.setActiveTypes( activeTypes );
+			toolbar.setActiveEdges( activeEdges );
+			void loadGraph( 'lens-switch' );
+			schedulePrefsSave();
+		},
+		onTaxonomyChange: ( slug: string ) => {
+			activeTaxonomy = slug;
+			scene?.setClusterTaxonomy( slug );
+			void loadGraph( 'filter-change' );
+			schedulePrefsSave();
+		},
+		onEdgesChange: ( edges: EdgeKind[] ) => {
+			activeEdges = edges;
+			scene?.setVisibleEdgeKinds( edges );
+			void loadGraph( 'filter-change' );
+			schedulePrefsSave();
+		},
+		onFitToView: () => scene?.fitToView(),
+		onSearchSelect: ( node: GraphNode ) => focusNode( node ),
+		getNodes: () => scene?.getNodes() ?? [],
+	} );
+
+	let toolbar: ToolbarHandle = renderToolbar(
+		toolbarHost,
+		cfg.postTypes,
+		cfg.taxonomies,
+		cfg.edgeKinds,
+		{
+			lens: activeLens,
+			types:
+				activeTypes.length > 0
+					? activeTypes
+					: cfg.postTypes.map( ( t ) => t.slug ),
+			taxonomy: activeTaxonomy,
+			edges: activeEdges,
+		},
+		buildToolbarCallbacks(),
+	);
 
 	scene = new GraphScene(
 		stageHost,
@@ -209,29 +350,80 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 		return { abort: () => {} };
 	}
 
+	// Wire the edge palette + initial lens state into the scene.
+	scene.setEdgePalette( cfg.edgeKinds );
+	scene.setLens( activeLens );
+	scene.setVisibleEdgeKinds( activeEdges );
+	if ( activeLens === 'galaxy' ) {
+		scene.setClusterTaxonomy( activeTaxonomy );
+	}
+
 	// First-load: refresh post-type counts so chips reflect live state,
 	// then load the graph itself.
 	try {
 		const refreshed = await fetchPostTypes( cfg );
-		// Replace the live toolbar handle so subsequent setStatus calls
-		// target the new DOM. Without this the original handle silently
-		// writes to a removed element.
 		toolbar.destroy();
-		toolbar = renderToolbar( toolbarHost, refreshed, buildToolbarCallbacks() );
+		toolbar = renderToolbar(
+			toolbarHost,
+			refreshed,
+			cfg.taxonomies,
+			cfg.edgeKinds,
+			{
+				lens: activeLens,
+				types:
+					activeTypes.length > 0
+						? activeTypes
+						: refreshed.map( ( t ) => t.slug ),
+				taxonomy: activeTaxonomy,
+				edges: activeEdges,
+			},
+			buildToolbarCallbacks(),
+		);
 	} catch {
 		// Non-fatal — keep the chips that came from the window config.
 	}
 
-	await loadGraph();
+	if ( activeTypes.length === 0 ) {
+		activeTypes = cfg.postTypes.map( ( t ) => t.slug );
+	}
+	await loadGraph( 'initial' );
 
 	return {
 		abort: () => {
 			aborted = true;
+			if ( saveTimer ) {
+				clearTimeout( saveTimer );
+				saveTimer = null;
+			}
 			toolbar.destroy();
 			panel.destroy();
 			scene?.destroy();
 			scene = null;
 		},
+	};
+}
+
+/**
+ * Pull the current lens's per-lens state out of the cfg.prefs blob.
+ * Defaults `types` to "all available" when no preference is stored
+ * yet (consistent with today's "show everything by default" UX).
+ *
+ * @since 0.9.0
+ */
+function currentLensState(
+	cfg: ContentGraphConfig,
+	lens: LensId,
+): { types: string[]; edges: EdgeKind[] } {
+	const lensPrefs =
+		lens === 'galaxy'
+			? cfg.prefs.byLens.galaxy
+			: cfg.prefs.byLens.constellation;
+	return {
+		types:
+			lensPrefs.types.length > 0
+				? lensPrefs.types
+				: cfg.postTypes.map( ( t ) => t.slug ),
+		edges: lensPrefs.edges,
 	};
 }
 

--- a/src/content-graph/rest.ts
+++ b/src/content-graph/rest.ts
@@ -14,6 +14,8 @@ import { trackedFetch } from '../tracked-fetch';
 import type {
 	CommentStats,
 	ContentGraphConfig,
+	ContentGraphPrefs,
+	EdgeKind,
 	GraphPayload,
 	PostDetail,
 	PostTypeDescriptor,
@@ -65,10 +67,18 @@ export async function fetchPostTypes(
 export async function fetchGraph(
 	cfg: ContentGraphConfig,
 	types: string[],
+	edgeKinds: EdgeKind[] = [],
+	taxonomies: string[] = [],
 ): Promise< GraphPayload > {
 	const url = new URL( `${ cfg.apiBase }/nodes` );
 	if ( types.length > 0 ) {
 		url.searchParams.set( 'types', types.join( ',' ) );
+	}
+	if ( edgeKinds.length > 0 ) {
+		url.searchParams.set( 'edges', edgeKinds.join( ',' ) );
+	}
+	if ( taxonomies.length > 0 ) {
+		url.searchParams.set( 'taxonomies', taxonomies.join( ',' ) );
 	}
 	const res = await trackedFetch(
 		url.toString(),
@@ -79,6 +89,57 @@ export async function fetchGraph(
 		throw new Error( `nodes: ${ res.status }` );
 	}
 	return ( await res.json() ) as GraphPayload;
+}
+
+/**
+ * GET /content-graph/preferences — fetch the current user's saved
+ * preferences (lens choice, per-lens taxonomy/edges/types). Server
+ * always returns a fully-shaped object even for users with nothing
+ * stored.
+ *
+ * @since 0.9.0
+ */
+export async function fetchPrefs(
+	cfg: ContentGraphConfig,
+): Promise< ContentGraphPrefs > {
+	const res = await trackedFetch(
+		`${ cfg.apiBase }/preferences`,
+		{ headers: authHeaders( cfg ) },
+		{ source: SOURCE, windowId: WINDOW_ID, silent: true },
+	);
+	if ( ! res.ok ) {
+		throw new Error( `preferences: ${ res.status }` );
+	}
+	return ( await res.json() ) as ContentGraphPrefs;
+}
+
+/**
+ * POST /content-graph/preferences — persist a (possibly partial) prefs
+ * patch. Server merges with current stored value, sanitizes, and
+ * returns the merged shape.
+ *
+ * @since 0.9.0
+ */
+export async function savePrefs(
+	cfg: ContentGraphConfig,
+	patch: Partial< ContentGraphPrefs >,
+): Promise< ContentGraphPrefs > {
+	const res = await trackedFetch(
+		`${ cfg.apiBase }/preferences`,
+		{
+			method: 'POST',
+			headers: {
+				...authHeaders( cfg ),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( { preferences: patch } ),
+		},
+		{ source: SOURCE, windowId: WINDOW_ID, silent: true },
+	);
+	if ( ! res.ok ) {
+		throw new Error( `preferences POST: ${ res.status }` );
+	}
+	return ( await res.json() ) as ContentGraphPrefs;
 }
 
 export async function fetchPostDetail(

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -46,16 +46,19 @@ import {
 	type PixiNamespace,
 	type PixiText,
 } from './pixi-types';
-import { ForceSim } from './sim';
+import { ForceSim, type ClusterMembership } from './sim';
 import {
 	SatelliteLayer,
 	type SatelliteOnClick,
 	type PostTypeIconLookup,
 } from './satellites';
 import type {
+	EdgeKind,
+	EdgeKindDescriptor,
 	GraphEdge,
 	GraphNode,
 	GraphPayload,
+	LensId,
 	PostDetail,
 	PostTypeDescriptor,
 } from './types';
@@ -65,6 +68,85 @@ const NODE_FILL_FOCUS = 0x2c6be5;
 const NODE_FILL_NEIGHBOUR = 0x4f8bf3;
 const EDGE_BASE = 0x9aa6b6;
 const EDGE_HOT = 0x2c6be5;
+
+/**
+ * Sentinel cluster key used by `setClusterTaxonomy()` for nodes with
+ * no in-scope memberships in the active clustering taxonomy. Mirrors
+ * the corresponding constant used by `ForceSim`'s attractor force.
+ *
+ * @since 0.9.0
+ */
+const UNCATEGORIZED_KEY = '__uncategorized__';
+
+/**
+ * Per-lens config. Constellation keeps today's force-directed layout
+ * with no clustering; Galaxy adds the cluster attractor and applies
+ * bridge highlighting to edges. Future lenses (Sitemap, Timeline)
+ * drop in by adding a third entry.
+ *
+ * @since 0.9.0
+ */
+interface LensConfig {
+	id: LensId;
+	attractorStrength: number;
+	showClusterLabels: boolean;
+	bridgeHighlighting: boolean;
+	intraDimAlpha: number;
+}
+
+const LENSES: Record< LensId, LensConfig > = {
+	constellation: {
+		id: 'constellation',
+		attractorStrength: 0,
+		showClusterLabels: false,
+		bridgeHighlighting: false,
+		intraDimAlpha: 0.18,
+	},
+	galaxy: {
+		id: 'galaxy',
+		attractorStrength: 0.04,
+		showClusterLabels: true,
+		bridgeHighlighting: true,
+		intraDimAlpha: 0.06,
+	},
+};
+
+/**
+ * Default per-edge-kind visual palette. Mirrors what the server emits
+ * via `desktop_mode_content_graph_edge_kind_descriptors()` so the
+ * scene can render before the orchestrator hands over the
+ * server-provided palette.
+ *
+ * @since 0.9.0
+ */
+const DEFAULT_EDGE_PALETTE: Record< EdgeKind, { color: number; weight: number } > = {
+	link: { color: EDGE_BASE, weight: 0.7 },
+	co_tag: { color: 0x2c6be5, weight: 0.7 },
+	co_author: { color: 0x7c3aed, weight: 0.7 },
+	hierarchy: { color: 0x059669, weight: 0.7 },
+	menu: { color: 0xd97706, weight: 0.7 },
+};
+
+function paletteFromDescriptors(
+	descriptors: EdgeKindDescriptor[] | undefined,
+): Record< EdgeKind, { color: number; weight: number } > {
+	if ( ! descriptors || descriptors.length === 0 ) {
+		return DEFAULT_EDGE_PALETTE;
+	}
+	const out: Record< EdgeKind, { color: number; weight: number } > = {
+		...DEFAULT_EDGE_PALETTE,
+	};
+	for ( const d of descriptors ) {
+		// Color comes in as a CSS hex string ("#rrggbb") from PHP; parse to int.
+		let color = DEFAULT_EDGE_PALETTE[ d.slug ].color;
+		const m = /^#([0-9a-f]{6})$/i.exec( d.color );
+		if ( m ) {
+			color = parseInt( m[ 1 ], 16 );
+		}
+		out[ d.slug ] = { color, weight: d.weight };
+	}
+	return out;
+}
 
 const ZOOM_MIN = 0.15;
 const ZOOM_MAX = 4;
@@ -100,10 +182,12 @@ export class GraphScene {
 	private world!: PixiContainer;
 	private edgeLayer!: PixiContainer;
 	private nodeLayer!: PixiContainer;
+	private clusterLabelLayer!: PixiContainer;
 	private labelLayer!: PixiContainer;
 	private satellites: SatelliteLayer | null = null;
 	private nodeViews = new Map< number, NodeView >();
 	private edgeViews: EdgeView[] = [];
+	private clusterLabels = new Map< string, PixiText >();
 	private nodes: GraphNode[] = [];
 	private edges: GraphEdge[] = [];
 	private sim: ForceSim | null = null;
@@ -129,6 +213,22 @@ export class GraphScene {
 	private callbacks: SceneCallbacks;
 	private onSatelliteClick: SatelliteOnClick;
 	private postTypeIcon: PostTypeIconLookup;
+	// Lens state.
+	private activeLens: LensConfig = LENSES.constellation;
+	private visibleEdgeKinds: Set< EdgeKind > = new Set( [ 'link' ] );
+	private clusterTaxonomy: string | null = null;
+	private clusterMembership: ClusterMembership | null = null;
+	private edgePalette: Record< EdgeKind, { color: number; weight: number } > =
+		DEFAULT_EDGE_PALETTE;
+	/**
+	 * Optional override for cluster-label rendering. Receives the
+	 * cluster key (`<taxonomy>:<term_id>` or `__uncategorized__`) and
+	 * the live member count, returns the user-facing label string.
+	 * When unset, labels default to `#<term_id> (count)` form.
+	 *
+	 * @since 0.9.0
+	 */
+	private clusterLabelLookup: ( ( key: string, count: number ) => string ) | null = null;
 
 	constructor(
 		host: HTMLElement,
@@ -196,8 +296,14 @@ export class GraphScene {
 
 		this.edgeLayer = new pixi.Container();
 		this.nodeLayer = new pixi.Container();
+		this.clusterLabelLayer = new pixi.Container();
 		this.labelLayer = new pixi.Container();
-		this.world.addChild( this.edgeLayer, this.nodeLayer, this.labelLayer );
+		this.world.addChild(
+			this.edgeLayer,
+			this.nodeLayer,
+			this.clusterLabelLayer,
+			this.labelLayer,
+		);
 
 		this.satellites = new SatelliteLayer(
 			pixi,
@@ -222,6 +328,12 @@ export class GraphScene {
 		for ( const n of this.nodes ) {
 			prev.set( n.id, n );
 		}
+		// Snapshot the focused id BEFORE we rebuild so we can carry
+		// it forward when the focused node still exists in the new
+		// payload (feasibility-2 fix). Camera target is left untouched
+		// across rebuilds; loadGraph()'s lens-switch path explicitly
+		// avoids fitToView()/clearFocus() so this state persists.
+		const previouslyFocusedId = this.focusedId;
 
 		const nodes: GraphNode[] = payload.nodes.map( ( p ) => {
 			const old = prev.get( p.id );
@@ -262,8 +374,147 @@ export class GraphScene {
 		this.nodes = nodes;
 		this.edges = edges;
 		this.rebuildSprites();
-		this.sim = new ForceSim( nodes, edges );
+		this.sim = new ForceSim( nodes, edges, {
+			...this.sim?.opts,
+			repulsion: 26000,
+			springK: 0.04,
+			springLen: 200,
+			gravity: 0.0035,
+			damping: 0.86,
+			attractorStrength: this.activeLens.attractorStrength,
+		} );
+		// Re-apply current cluster membership so the new node set
+		// inherits the active Galaxy clustering without an explicit
+		// setClusterTaxonomy() round-trip from the orchestrator.
+		if ( this.clusterTaxonomy ) {
+			this.recomputeClusterMembership();
+		}
 		this.sim.reheat( 0.15, false );
+
+		// Carry forward focus when the focused node survived the
+		// rebuild. If it didn't, clear focus — but DO NOT call
+		// fitToView(), the camera target stays where the user left it.
+		if (
+			previouslyFocusedId !== null &&
+			byId.has( previouslyFocusedId )
+		) {
+			const view = this.nodeViews.get( previouslyFocusedId );
+			if ( view ) {
+				view.node.pinned = true;
+				this.focusedId = previouslyFocusedId;
+			} else {
+				this.focusedId = null;
+			}
+		} else {
+			this.focusedId = null;
+			this.satellites?.clear();
+		}
+	}
+
+	/**
+	 * Switch the active lens. Mutates the sim's force config in
+	 * place; does NOT remount the Pixi Application or recreate the
+	 * scene graph. Camera target and focused-node state survive the
+	 * switch (per AE4).
+	 *
+	 * @since 0.9.0
+	 */
+	setLens( lensId: LensId ): void {
+		const lens = LENSES[ lensId ];
+		if ( ! lens ) {
+			return;
+		}
+		this.activeLens = lens;
+		if ( this.sim ) {
+			this.sim.setForceConfig( {
+				attractorStrength: lens.attractorStrength,
+			} );
+			this.sim.setClusters(
+				lens.attractorStrength > 0 ? this.clusterMembership : null,
+			);
+			this.sim.reheat( 0.3, false );
+		}
+		this.draw();
+	}
+
+	/**
+	 * Set the taxonomy that drives Galaxy clustering. Recomputes
+	 * per-node membership from the current node set's `terms` field
+	 * and pushes the new map into the sim if Galaxy is active.
+	 *
+	 * @since 0.9.0
+	 */
+	setClusterTaxonomy( taxonomySlug: string | null ): void {
+		this.clusterTaxonomy = taxonomySlug;
+		if ( ! taxonomySlug ) {
+			this.clusterMembership = null;
+		} else {
+			this.recomputeClusterMembership();
+		}
+		if ( this.sim ) {
+			this.sim.setClusters(
+				this.activeLens.attractorStrength > 0
+					? this.clusterMembership
+					: null,
+			);
+			this.sim.reheat( 0.3, false );
+		}
+	}
+
+	/**
+	 * Replace the visible-edge-kinds set. Pure rendering-only state;
+	 * does not refetch.
+	 *
+	 * @since 0.9.0
+	 */
+	setVisibleEdgeKinds( kinds: EdgeKind[] ): void {
+		this.visibleEdgeKinds = new Set( kinds );
+		this.draw();
+	}
+
+	/**
+	 * Override the per-edge-kind visual palette. Typically supplied
+	 * by the orchestrator from `cfg.edgeKinds` so the look-and-feel
+	 * is server-controllable.
+	 *
+	 * @since 0.9.0
+	 */
+	setEdgePalette( descriptors: EdgeKindDescriptor[] | undefined ): void {
+		this.edgePalette = paletteFromDescriptors( descriptors );
+		this.draw();
+	}
+
+	/**
+	 * Override the cluster-label formatter. Orchestrators can plug in
+	 * a lookup that maps cluster keys to human-readable term names.
+	 *
+	 * @since 0.9.0
+	 */
+	setClusterLabelLookup(
+		fn: ( ( key: string, count: number ) => string ) | null,
+	): void {
+		this.clusterLabelLookup = fn;
+	}
+
+	private recomputeClusterMembership(): void {
+		const tax = this.clusterTaxonomy;
+		if ( ! tax ) {
+			this.clusterMembership = null;
+			return;
+		}
+		const m: ClusterMembership = new Map();
+		for ( const n of this.nodes ) {
+			const ids = n.terms?.[ tax ];
+			if ( ids && ids.length > 0 ) {
+				m.set(
+					n.id,
+					ids.map( ( tid ) => `${ tax }:${ tid }` ),
+				);
+			} else {
+				m.set( n.id, [ UNCATEGORIZED_KEY ] );
+			}
+		}
+		this.clusterMembership = m;
 	}
 
 	private rebuildSprites(): void {
@@ -560,6 +811,7 @@ export class GraphScene {
 			this.world.y += dyc * k;
 		}
 		this.draw();
+		this.drawClusterLabels();
 		this.satellites?.drawLinks();
 	}
 
@@ -581,24 +833,60 @@ export class GraphScene {
 		}
 
 		const dimmed = focusId !== null;
+		const lens = this.activeLens;
+		const membership = this.clusterMembership;
 
 		for ( const v of this.edgeViews ) {
 			const { edge, gfx } = v;
 			gfx.clear();
+			// Hide edges of kinds the user has muted via the toolbar.
+			if ( ! this.visibleEdgeKinds.has( edge.kind ) ) {
+				continue;
+			}
 			const isFocusEdge =
 				focusId !== null &&
 				( edge.from.id === focusId || edge.to.id === focusId );
 			const isHoverEdge =
 				hoverId !== null &&
 				( edge.from.id === hoverId || edge.to.id === hoverId );
+
+			// Bridge highlighting (Galaxy only): edges whose endpoints
+			// share at least one cluster key fade to the lens's
+			// intra-cluster dim alpha; edges that cross clusters or
+			// reach into Uncategorized pop at full intensity. Focused
+			// satellites (the focused node's own edges) are exempt
+			// from fading so the existing satellite UX is unchanged.
+			let isIntraCluster = false;
+			if ( lens.bridgeHighlighting && membership && ! isFocusEdge ) {
+				const a = membership.get( edge.from.id );
+				const b = membership.get( edge.to.id );
+				if ( a && b ) {
+					for ( const k of a ) {
+						if ( b.includes( k ) ) {
+							isIntraCluster = true;
+							break;
+						}
+					}
+				}
+			}
+
 			let alpha: number;
 			if ( dimmed ) {
 				alpha = isFocusEdge ? 0.85 : 0.05;
+			} else if ( isIntraCluster ) {
+				alpha = lens.intraDimAlpha;
+			} else if ( isHoverEdge ) {
+				alpha = 0.7;
 			} else {
-				alpha = isHoverEdge ? 0.7 : 0.18;
+				alpha = 0.55;
 			}
-			const color = isFocusEdge || isHoverEdge ? EDGE_HOT : EDGE_BASE;
-			const width = isFocusEdge || isHoverEdge ? 1.2 : 0.7;
+
+			const palette = this.edgePalette[ edge.kind ];
+			const baseColor = palette ? palette.color : EDGE_BASE;
+			const baseWidth = palette ? palette.weight : 0.7;
+			const color =
+				isFocusEdge || isHoverEdge ? EDGE_HOT : baseColor;
+			const width = isFocusEdge || isHoverEdge ? 1.2 : baseWidth;
 			gfx.moveTo( edge.from.x, edge.from.y )
 				.lineTo( edge.to.x, edge.to.y )
 				.stroke( { color, width, alpha } );
@@ -652,6 +940,106 @@ export class GraphScene {
 			}
 			label.alpha = labelAlpha;
 		}
+	}
+
+	private drawClusterLabels(): void {
+		// Only Galaxy renders cluster labels.
+		if ( ! this.activeLens.showClusterLabels || ! this.clusterMembership || ! this.clusterTaxonomy ) {
+			// Clear any leftover labels from a prior lens.
+			if ( this.clusterLabels.size > 0 ) {
+				this.clusterLabelLayer.removeChildren();
+				this.clusterLabels.clear();
+			}
+			return;
+		}
+
+		// Compute live centroids + counts. Skip Uncategorized in the
+		// label set unless it actually has members; empty terms are
+		// hidden by default per R9.
+		const centroids = new Map<
+			string,
+			{ sx: number; sy: number; n: number }
+		>();
+		for ( const n of this.nodes ) {
+			const keys = this.clusterMembership.get( n.id );
+			if ( ! keys ) {
+				continue;
+			}
+			for ( const k of keys ) {
+				const c = centroids.get( k );
+				if ( c ) {
+					c.sx += n.x;
+					c.sy += n.y;
+					c.n += 1;
+				} else {
+					centroids.set( k, { sx: n.x, sy: n.y, n: 1 } );
+				}
+			}
+		}
+
+		// Reuse PixiText nodes by cluster key; create on first appearance,
+		// remove when a cluster has zero members in a subsequent tick.
+		const seen = new Set< string >();
+		const showLabels = this.world.scale.x > 0.6;
+		const inverseScale = 1 / this.world.scale.x;
+		for ( const [ key, c ] of centroids ) {
+			if ( c.n === 0 ) {
+				continue;
+			}
+			seen.add( key );
+			const cx = c.sx / c.n;
+			const cy = c.sy / c.n;
+			const labelText = this.formatClusterLabel( key, c.n );
+			let label = this.clusterLabels.get( key );
+			if ( ! label ) {
+				label = new this.pixi.Text( {
+					text: labelText,
+					style: {
+						fill: 0x111827,
+						fontSize: 12,
+						fontFamily:
+							'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+						fontWeight: '600',
+					},
+					resolution: 2,
+					anchor: { x: 0.5, y: 1 },
+				} );
+				this.clusterLabelLayer.addChild( label );
+				this.clusterLabels.set( key, label );
+			} else if ( label.text !== labelText ) {
+				label.text = labelText;
+			}
+			label.x = cx;
+			label.y = cy - 36;
+			label.scale.set( inverseScale );
+			label.alpha = showLabels ? 0.9 : 0;
+		}
+		// Tear down labels for clusters that disappeared this tick.
+		for ( const [ key, label ] of this.clusterLabels ) {
+			if ( ! seen.has( key ) ) {
+				this.clusterLabelLayer.removeChild( label );
+				try {
+					label.destroy();
+				} catch {
+					// ignore — Pixi sometimes throws on race during teardown.
+				}
+				this.clusterLabels.delete( key );
+			}
+		}
+	}
+
+	private formatClusterLabel( clusterKey: string, count: number ): string {
+		if ( this.clusterLabelLookup ) {
+			return this.clusterLabelLookup( clusterKey, count );
+		}
+		// Default fallback when no lookup is wired up. Cluster key is
+		// `<taxonomy>:<term_id>` (or sentinel `__uncategorized__`).
+		if ( clusterKey === UNCATEGORIZED_KEY ) {
+			return `Uncategorized (${ count })`;
+		}
+		const idx = clusterKey.lastIndexOf( ':' );
+		const tail = idx >= 0 ? clusterKey.slice( idx + 1 ) : clusterKey;
+		return `#${ tail } (${ count })`;
 	}
 
 	focusNode( id: number ): void {

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -253,7 +253,7 @@ export class GraphScene {
 			}
 			f.degree++;
 			t.degree++;
-			edges.push( { from: f, to: t } );
+			edges.push( { from: f, to: t, kind: e.kind } );
 		}
 		for ( const n of nodes ) {
 			n.radius = 8 + Math.min( 8, Math.sqrt( n.degree ) * 2.4 );

--- a/src/content-graph/sim.ts
+++ b/src/content-graph/sim.ts
@@ -33,6 +33,15 @@ export interface SimOptions {
 	springLen: number;
 	gravity: number;
 	damping: number;
+	/**
+	 * Strength coefficient for the per-cluster centroid attractor
+	 * force introduced in 0.9.0. `0` disables the force entirely
+	 * (Constellation lens behavior). Galaxy lens sets this nonzero
+	 * via `setForceConfig({ attractorStrength })`.
+	 *
+	 * @since 0.9.0
+	 */
+	attractorStrength: number;
 }
 
 export const DEFAULT_SIM_OPTIONS: SimOptions = {
@@ -48,7 +57,20 @@ export const DEFAULT_SIM_OPTIONS: SimOptions = {
 	springLen: 200,
 	gravity: 0.0035,
 	damping: 0.86,
+	attractorStrength: 0,
 };
+
+/**
+ * A `ClusterMembership` maps each node id to the cluster keys it
+ * belongs to. Multi-membership pulls the node toward each centroid
+ * proportionally; the emergent settle position is the (force-weighted)
+ * average. The reserved key `'__uncategorized__'` is used by
+ * `setClusters()` callers to flag nodes with no in-scope memberships
+ * so they form a single Uncategorized galaxy.
+ *
+ * @since 0.9.0
+ */
+export type ClusterMembership = Map< number, string[] >;
 
 const ALPHA_DECAY = 0.992;
 const ALPHA_MIN = 0.01;
@@ -73,6 +95,15 @@ export class ForceSim {
 	 */
 	public dragOrigin: { x: number; y: number } | null = null;
 	public dragInfluenceRadius = 500;
+	/**
+	 * Per-node cluster membership. `null` disables the cluster-attractor
+	 * force entirely (Constellation lens). When non-null, the
+	 * tick loop derives per-cluster centroids from current member
+	 * positions and pulls each member toward its centroid(s).
+	 *
+	 * @since 0.9.0
+	 */
+	private clusterMembership: ClusterMembership | null = null;
 	private alpha = ALPHA_REHEAT;
 
 	constructor(
@@ -83,6 +114,27 @@ export class ForceSim {
 		this.nodes = nodes;
 		this.edges = edges;
 		this.opts = opts;
+	}
+
+	/**
+	 * Mutate force-config flags in place. Used by the lens-switch path
+	 * (`GraphScene.setLens()`) so transitioning between Constellation
+	 * and Galaxy doesn't require recreating the sim.
+	 *
+	 * @since 0.9.0
+	 */
+	setForceConfig( patch: Partial< SimOptions > ): void {
+		this.opts = { ...this.opts, ...patch };
+	}
+
+	/**
+	 * Replace the cluster membership map (or null it out to disable
+	 * the cluster-attractor force).
+	 *
+	 * @since 0.9.0
+	 */
+	setClusters( membership: ClusterMembership | null ): void {
+		this.clusterMembership = membership;
 	}
 
 	reheat( value = ALPHA_REHEAT, kick = true ): void {
@@ -168,6 +220,65 @@ export class ForceSim {
 			if ( ! e.to.pinned ) {
 				e.to.vx -= fx;
 				e.to.vy -= fy;
+			}
+		}
+
+		// Cluster attractor (Galaxy lens). Computes per-cluster
+		// centroids from current member positions, then pulls each
+		// non-pinned node toward the (equally-weighted) average of
+		// the centroids of clusters it belongs to. Multi-cluster
+		// nodes settle between centroids by emergent force balance.
+		// Disabled when membership is null OR strength is zero.
+		const membership = this.clusterMembership;
+		const attractorStrength = this.opts.attractorStrength;
+		if ( membership && attractorStrength > 0 ) {
+			const centroids = new Map<
+				string,
+				{ sx: number; sy: number; n: number }
+			>();
+			for ( const n of nodes ) {
+				const keys = membership.get( n.id );
+				if ( ! keys ) {
+					continue;
+				}
+				for ( const k of keys ) {
+					const c = centroids.get( k );
+					if ( c ) {
+						c.sx += n.x;
+						c.sy += n.y;
+						c.n += 1;
+					} else {
+						centroids.set( k, { sx: n.x, sy: n.y, n: 1 } );
+					}
+				}
+			}
+			for ( const n of nodes ) {
+				if ( n.pinned ) {
+					continue;
+				}
+				const keys = membership.get( n.id );
+				if ( ! keys || keys.length === 0 ) {
+					continue;
+				}
+				let tx = 0;
+				let ty = 0;
+				let count = 0;
+				for ( const k of keys ) {
+					const c = centroids.get( k );
+					if ( ! c || c.n === 0 ) {
+						continue;
+					}
+					tx += c.sx / c.n;
+					ty += c.sy / c.n;
+					count += 1;
+				}
+				if ( count === 0 ) {
+					continue;
+				}
+				tx /= count;
+				ty /= count;
+				n.vx += ( tx - n.x ) * attractorStrength;
+				n.vy += ( ty - n.y ) * attractorStrength;
 			}
 		}
 

--- a/src/content-graph/toolbar.ts
+++ b/src/content-graph/toolbar.ts
@@ -1,23 +1,46 @@
 /**
  * Content Graph — toolbar.
  *
- * Top strip of the window. Three pieces:
+ * Top strip of the window. As of 0.9.0 the toolbar is composed
+ * entirely of `<wpd-*>` components (per AGENTS.md "Use wpd-*
+ * components, not raw HTML controls"). It exposes:
  *
- *   1. **Filter chips** — one per public post type. Click to toggle;
- *      the host re-fetches `/nodes` with the active set.
- *   2. **Search** — fuzzy match on node titles. Selecting a result
- *      tells the host to focus that node.
- *   3. **Action buttons** — fit-to-view + reheat the simulation.
+ *   1. **Lens picker** — `<wpd-segmented>` switching between
+ *      Constellation and Galaxy.
+ *   2. **Taxonomy picker** — `<wpd-select>` choosing the Galaxy
+ *      clustering taxonomy. Visible only when the active lens is
+ *      Galaxy.
+ *   3. **Post-type chips** — `<wpd-chip>` row, one per public post
+ *      type. Click toggles inclusion in the build.
+ *   4. **Edges multi-toggle** — `<wpd-multiselect>` controlling which
+ *      edge kinds render. Default-on/off varies by lens (R12).
+ *   5. **Search** — fuzzy match on node titles. Selecting a result
+ *      tells the host to focus that node. Kept as a raw input
+ *      because it owns its own results dropdown which doesn't yet
+ *      have a native `<wpd-*>` analogue.
+ *   6. **Action buttons** — `<wpd-button>` for fit-to-view. Status
+ *      text reports node/edge counts.
  *
  * @public
  * @since 0.8.2
+ * @since 0.9.0 wpd-* migration; lens/taxonomy/edges controls.
  */
 
 import { __ } from '../i18n';
-import type { GraphNode, PostTypeDescriptor } from './types';
+import type {
+	EdgeKind,
+	EdgeKindDescriptor,
+	GraphNode,
+	LensId,
+	PostTypeDescriptor,
+	TaxonomyDescriptor,
+} from './types';
 
 export interface ToolbarCallbacks {
 	onTypesChange: ( types: string[] ) => void;
+	onLensChange: ( lens: LensId ) => void;
+	onTaxonomyChange: ( taxonomySlug: string ) => void;
+	onEdgesChange: ( edges: EdgeKind[] ) => void;
 	onFitToView: () => void;
 	onSearchSelect: ( node: GraphNode ) => void;
 	getNodes: () => GraphNode[];
@@ -25,44 +48,129 @@ export interface ToolbarCallbacks {
 
 export interface ToolbarHandle {
 	setStatus: ( text: string ) => void;
+	setActiveLens: ( lens: LensId ) => void;
+	setActiveTaxonomy: ( slug: string ) => void;
+	setActiveEdges: ( edges: EdgeKind[] ) => void;
+	setActiveTypes: ( types: string[] ) => void;
 	destroy: () => void;
+}
+
+export interface ToolbarInitialState {
+	lens: LensId;
+	types: string[];
+	taxonomy: string;
+	edges: EdgeKind[];
 }
 
 export function renderToolbar(
 	host: HTMLElement,
 	postTypes: PostTypeDescriptor[],
+	taxonomies: TaxonomyDescriptor[],
+	edgeKinds: EdgeKindDescriptor[],
+	initial: ToolbarInitialState,
 	callbacks: ToolbarCallbacks,
 ): ToolbarHandle {
 	host.replaceChildren();
 
-	const active = new Set( postTypes.map( ( t ) => t.slug ) );
+	// --- Lens picker ----------------------------------------------------
+	const lensPicker = document.createElement( 'wpd-segmented' );
+	lensPicker.setAttribute( 'label', __( 'Lens' ) );
+	lensPicker.setAttribute( 'value', initial.lens );
+	( lensPicker as unknown as {
+		items: ReadonlyArray< { value: string; label: string } >;
+	} ).items = [
+		{ value: 'constellation', label: __( 'Constellation' ) },
+		{ value: 'galaxy', label: __( 'Galaxy' ) },
+	];
+	lensPicker.addEventListener( 'wpd-pick', ( evt: Event ) => {
+		const detail = ( evt as CustomEvent< { value: string } > ).detail;
+		const next = detail.value as LensId;
+		applyLensVisibility( next );
+		callbacks.onLensChange( next );
+	} );
+	host.appendChild( lensPicker );
 
+	// --- Taxonomy dropdown (Galaxy only) --------------------------------
+	const taxonomyWrap = document.createElement( 'div' );
+	taxonomyWrap.className = 'desktop-mode-content-graph__taxonomy';
+	const taxonomyPicker = document.createElement( 'wpd-select' );
+	taxonomyPicker.setAttribute( 'label', __( 'Cluster by' ) );
+	taxonomyPicker.setAttribute( 'value', initial.taxonomy );
+	( taxonomyPicker as unknown as {
+		items: ReadonlyArray< { value: string; label: string } >;
+	} ).items = taxonomies.map( ( t ) => ( {
+		value: t.slug,
+		label: t.label,
+	} ) );
+	taxonomyPicker.addEventListener( 'wpd-pick', ( evt: Event ) => {
+		const detail = ( evt as CustomEvent< { value: string } > ).detail;
+		callbacks.onTaxonomyChange( detail.value );
+	} );
+	taxonomyWrap.appendChild( taxonomyPicker );
+	host.appendChild( taxonomyWrap );
+
+	// --- Post-type chip row ---------------------------------------------
+	const activeTypes = new Set(
+		initial.types.length > 0
+			? initial.types
+			: postTypes.map( ( t ) => t.slug ),
+	);
 	const chipsRow = document.createElement( 'div' );
 	chipsRow.className = 'desktop-mode-content-graph__filters';
 	host.appendChild( chipsRow );
 
+	const chipByType = new Map< string, HTMLElement >();
 	for ( const type of postTypes ) {
-		const chip = document.createElement( 'button' );
-		chip.type = 'button';
-		chip.className = 'desktop-mode-content-graph__chip is-active';
+		const chip = document.createElement( 'wpd-chip' );
+		chip.setAttribute( 'label', `${ type.label } (${ type.count })` );
+		chip.setAttribute(
+			'tone',
+			activeTypes.has( type.slug ) ? 'accent' : 'neutral',
+		);
 		chip.dataset.slug = type.slug;
-		chip.innerHTML =
-			`<span class="dashicons ${ escapeAttr( type.icon ) }" aria-hidden="true"></span>` +
-			`<span class="desktop-mode-content-graph__chip-label">${ escapeHtml( type.label ) }</span>` +
-			`<span class="desktop-mode-content-graph__chip-count">${ type.count }</span>`;
+		chip.style.cursor = 'pointer';
 		chip.addEventListener( 'click', () => {
-			if ( active.has( type.slug ) ) {
-				active.delete( type.slug );
-				chip.classList.remove( 'is-active' );
+			if ( activeTypes.has( type.slug ) ) {
+				activeTypes.delete( type.slug );
+				chip.setAttribute( 'tone', 'neutral' );
 			} else {
-				active.add( type.slug );
-				chip.classList.add( 'is-active' );
+				activeTypes.add( type.slug );
+				chip.setAttribute( 'tone', 'accent' );
 			}
-			callbacks.onTypesChange( Array.from( active ) );
+			callbacks.onTypesChange( Array.from( activeTypes ) );
 		} );
 		chipsRow.appendChild( chip );
+		chipByType.set( type.slug, chip );
 	}
 
+	// --- Edges multi-toggle ---------------------------------------------
+	const activeEdges = new Set< EdgeKind >( initial.edges );
+	const edgesPicker = document.createElement( 'wpd-multiselect' );
+	edgesPicker.setAttribute( 'label', __( 'Edges' ) );
+	edgesPicker.setAttribute(
+		'value',
+		Array.from( activeEdges ).join( ',' ),
+	);
+	( edgesPicker as unknown as {
+		items: ReadonlyArray< { value: string; label: string } >;
+	} ).items = edgeKinds.map( ( k ) => ( {
+		value: k.slug,
+		label: k.label,
+	} ) );
+	edgesPicker.addEventListener( 'wpd-pick', ( evt: Event ) => {
+		const detail = (
+			evt as CustomEvent< { value: string; values: string[] } >
+		).detail;
+		const next = detail.values as EdgeKind[];
+		activeEdges.clear();
+		for ( const k of next ) {
+			activeEdges.add( k );
+		}
+		callbacks.onEdgesChange( Array.from( activeEdges ) );
+	} );
+	host.appendChild( edgesPicker );
+
+	// --- Search (kept as raw input + result list) -----------------------
 	const searchWrap = document.createElement( 'div' );
 	searchWrap.className = 'desktop-mode-content-graph__search';
 	const searchInput = document.createElement( 'input' );
@@ -122,15 +230,14 @@ export function renderToolbar(
 		}, 120 );
 	} );
 
+	// --- Actions row ----------------------------------------------------
 	const actions = document.createElement( 'div' );
 	actions.className = 'desktop-mode-content-graph__actions';
 
-	const fit = document.createElement( 'button' );
-	fit.type = 'button';
-	fit.className = 'desktop-mode-content-graph__btn';
-	fit.innerHTML =
-		'<span class="dashicons dashicons-editor-expand" aria-hidden="true"></span>' +
-		`<span>${ escapeHtml( __( 'Fit' ) ) }</span>`;
+	const fit = document.createElement( 'wpd-button' );
+	fit.setAttribute( 'label', __( 'Fit' ) );
+	fit.setAttribute( 'icon', 'editor-expand' );
+	fit.setAttribute( 'variant', 'tertiary' );
 	fit.title = __( 'Fit graph to view' );
 	fit.addEventListener( 'click', () => callbacks.onFitToView() );
 	actions.appendChild( fit );
@@ -140,6 +247,12 @@ export function renderToolbar(
 	actions.appendChild( status );
 
 	host.appendChild( actions );
+
+	// Apply initial lens-driven visibility.
+	function applyLensVisibility( lens: LensId ): void {
+		taxonomyWrap.hidden = lens !== 'galaxy';
+	}
+	applyLensVisibility( initial.lens );
 
 	const onDocClick = ( ev: Event ): void => {
 		if ( ! searchWrap.contains( ev.target as Node ) ) {
@@ -151,6 +264,32 @@ export function renderToolbar(
 	return {
 		setStatus: ( text: string ) => {
 			status.textContent = text;
+		},
+		setActiveLens: ( lens: LensId ) => {
+			lensPicker.setAttribute( 'value', lens );
+			applyLensVisibility( lens );
+		},
+		setActiveTaxonomy: ( slug: string ) => {
+			taxonomyPicker.setAttribute( 'value', slug );
+		},
+		setActiveEdges: ( edges: EdgeKind[] ) => {
+			activeEdges.clear();
+			for ( const k of edges ) {
+				activeEdges.add( k );
+			}
+			edgesPicker.setAttribute( 'value', edges.join( ',' ) );
+		},
+		setActiveTypes: ( types: string[] ) => {
+			activeTypes.clear();
+			for ( const t of types ) {
+				activeTypes.add( t );
+			}
+			for ( const [ slug, chip ] of chipByType ) {
+				chip.setAttribute(
+					'tone',
+					activeTypes.has( slug ) ? 'accent' : 'neutral',
+				);
+			}
 		},
 		destroy: () => {
 			document.removeEventListener( 'click', onDocClick );
@@ -164,8 +303,4 @@ function escapeHtml( s: string ): string {
 		.replace( /</g, '&lt;' )
 		.replace( />/g, '&gt;' )
 		.replace( /"/g, '&quot;' );
-}
-
-function escapeAttr( s: string ): string {
-	return s.replace( /[^a-zA-Z0-9 _\-]/g, '' );
 }

--- a/src/content-graph/types.ts
+++ b/src/content-graph/types.ts
@@ -16,6 +16,28 @@ export interface PostTypeDescriptor {
 	count: number;
 }
 
+/**
+ * Lens identifiers the front end recognises. Mirrors the PHP
+ * `DESKTOP_MODE_CONTENT_GRAPH_LENSES` constant.
+ *
+ * @since 0.9.0
+ */
+export type LensId = 'constellation' | 'galaxy';
+
+/**
+ * Discriminated union of edge kinds the wire protocol can carry.
+ * `link` is the legacy hyperlink edge from `<a href>` extraction; the
+ * other four arrived in 0.9.0 with the multi-lens work.
+ *
+ * @since 0.9.0
+ */
+export type EdgeKind =
+	| 'link'
+	| 'co_tag'
+	| 'co_author'
+	| 'hierarchy'
+	| 'menu';
+
 export interface GraphNodePayload {
 	id: number;
 	type: string;
@@ -23,11 +45,83 @@ export interface GraphNodePayload {
 	status: string;
 	slug: string;
 	edit_url: string;
+	/**
+	 * Per-taxonomy term-id memberships scoped to whatever taxonomies
+	 * the request asked about (the Galaxy clustering taxonomy plus
+	 * any others required by the requested edge kinds, e.g., co-tag
+	 * pulls in all non-clustering public taxonomies).
+	 *
+	 * The map is always present on every node. Nodes with no in-scope
+	 * memberships carry an empty object so consumers do not have to
+	 * branch on undefined.
+	 *
+	 * @since 0.9.0
+	 */
+	terms: Record< string, number[] >;
 }
 
 export interface GraphEdgePayload {
 	from: number;
 	to: number;
+	/**
+	 * Edge kind tag. Existing hyperlink edges carry `'link'`. Added
+	 * 0.9.0 with the multi-lens work; the server always emits this
+	 * field on every edge.
+	 *
+	 * @since 0.9.0
+	 */
+	kind: EdgeKind;
+}
+
+/**
+ * Descriptor for one public taxonomy eligible to drive Galaxy
+ * clustering. Mirrors the PHP `desktop_mode_content_graph_taxonomies`
+ * server output.
+ *
+ * @since 0.9.0
+ */
+export interface TaxonomyDescriptor {
+	slug: string;
+	label: string;
+	hierarchical: boolean;
+	post_types: string[];
+}
+
+/**
+ * Descriptor for one edge kind offered to the toolbar's edges
+ * multi-toggle. Mirrors the PHP
+ * `desktop_mode_content_graph_edge_kind_descriptors` server output.
+ *
+ * @since 0.9.0
+ */
+export interface EdgeKindDescriptor {
+	slug: EdgeKind;
+	label: string;
+	color: string;
+	weight: number;
+}
+
+/**
+ * Per-user preferences mirror of the PHP
+ * `desktop_mode_content_graph_default_prefs()` shape. The server is
+ * the source of truth; this type just describes what the wire
+ * carries.
+ *
+ * @since 0.9.0
+ */
+export interface ContentGraphPrefs {
+	lens: LensId;
+	byLens: {
+		constellation: {
+			types: string[];
+			edges: EdgeKind[];
+		};
+		galaxy: {
+			types: string[];
+			edges: EdgeKind[];
+			taxonomy: string;
+		};
+	};
 }
 
 export interface GraphPayload {
@@ -237,6 +331,12 @@ export interface ContentGraphConfig {
 	editCommentUrl: string;
 	mediaUrl: string;
 	postTypes: PostTypeDescriptor[];
+	/** Public taxonomies offered as Galaxy clustering keys. @since 0.9.0 */
+	taxonomies: TaxonomyDescriptor[];
+	/** Edge-kind catalog offered to the toolbar's edges multi-toggle. @since 0.9.0 */
+	edgeKinds: EdgeKindDescriptor[];
+	/** Initial per-user prefs hydrated server-side to skip a first-paint round-trip. @since 0.9.0 */
+	prefs: ContentGraphPrefs;
 }
 
 /**
@@ -256,4 +356,6 @@ export interface GraphNode extends GraphNodePayload {
 export interface GraphEdge {
 	from: GraphNode;
 	to: GraphNode;
+	/** Edge kind, carried through from the wire payload. @since 0.9.0 */
+	kind: EdgeKind;
 }

--- a/tests/phpunit/tests/contentGraphEdgeBuilders.php
+++ b/tests/phpunit/tests/contentGraphEdgeBuilders.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Tests for Content Graph edge-type extractors and per-node taxonomy
+ * membership emission added in 0.9.0.
+ *
+ * Covers `desktop_mode_content_graph_build()` with various
+ * combinations of `$edge_kinds` and `$taxonomies`, the cache-key hash
+ * domain, and the 50-term-per-(post, taxonomy) truncation cap.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-content-graph
+ */
+class Tests_DesktopMode_ContentGraphEdgeBuilders extends WP_UnitTestCase {
+
+	/**
+	 * Force a clean transient namespace before each test so we don't
+	 * race against another test's fixture.
+	 */
+	public function set_up() {
+		parent::set_up();
+		desktop_mode_content_graph_flush_cache();
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_link_edges_only_when_link_kind_requested() {
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$b = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<a href="' . get_permalink( $a ) . '">link</a>',
+			)
+		);
+
+		$with_link = desktop_mode_content_graph_build( array( 'post' ), array( 'link' ), array() );
+		$this->assertCount( 1, $with_link['edges'], 'link edge expected' );
+		$this->assertSame( 'link', $with_link['edges'][0]['kind'] );
+		$this->assertSame( $b, $with_link['edges'][0]['from'] );
+		$this->assertSame( $a, $with_link['edges'][0]['to'] );
+
+		desktop_mode_content_graph_flush_cache();
+
+		$without_link = desktop_mode_content_graph_build( array( 'post' ), array( 'co_author' ), array() );
+		$this->assertSame( 0, $this->edges_with_kind( $without_link['edges'], 'link' ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_co_author_edges_pair_posts_sharing_post_author() {
+		$author = self::factory()->user->create();
+		$other  = self::factory()->user->create();
+
+		$a = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => $author,
+			)
+		);
+		$b = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => $author,
+			)
+		);
+		$c = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => $other,
+			)
+		);
+
+		$payload = desktop_mode_content_graph_build( array( 'post' ), array( 'co_author' ), array() );
+		$pairs   = $this->pairs_with_kind( $payload['edges'], 'co_author' );
+		$this->assertCount( 1, $pairs, 'exactly one co-author pair from author' );
+		$expected = $a < $b ? array( $a, $b ) : array( $b, $a );
+		$this->assertSame( $expected, $pairs[0] );
+		// And no spurious edges to the post by the other author.
+		foreach ( $pairs as $pair ) {
+			$this->assertNotContains( $c, $pair );
+		}
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_hierarchy_edges_emit_only_when_parent_in_scope() {
+		$parent = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+		$child = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+				'post_parent' => $parent,
+			)
+		);
+		// Out-of-scope child whose parent is also a page but which we
+		// won't include in the build's $types.
+		$post_child = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+				'post_parent' => $parent,
+			)
+		);
+
+		$payload = desktop_mode_content_graph_build( array( 'page' ), array( 'hierarchy' ), array() );
+		$pairs   = $this->pairs_with_kind( $payload['edges'], 'hierarchy' );
+		$this->assertCount( 1, $pairs );
+		$this->assertSame( array( $parent, $child ), $pairs[0] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_co_tag_edges_pair_posts_sharing_terms() {
+		$cat_news   = self::factory()->category->create( array( 'name' => 'News' ) );
+		$tag_breaking = self::factory()->tag->create( array( 'name' => 'Breaking' ) );
+
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$b = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$c = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		wp_set_object_terms( $a, array( $cat_news ), 'category' );
+		wp_set_object_terms( $b, array( $cat_news ), 'category' );
+		wp_set_object_terms( $a, array( $tag_breaking ), 'post_tag' );
+		wp_set_object_terms( $c, array( $tag_breaking ), 'post_tag' );
+
+		$payload = desktop_mode_content_graph_build(
+			array( 'post' ),
+			array( 'co_tag' ),
+			array( 'category', 'post_tag' )
+		);
+		$pairs = $this->pairs_with_kind( $payload['edges'], 'co_tag' );
+		// Expect (a,b) on category and (a,c) on post_tag — but NOT
+		// (b,c) which share no taxonomy memberships.
+		$ab = array( min( $a, $b ), max( $a, $b ) );
+		$ac = array( min( $a, $c ), max( $a, $c ) );
+		$bc = array( min( $b, $c ), max( $b, $c ) );
+		$this->assertContains( $ab, $pairs );
+		$this->assertContains( $ac, $pairs );
+		$this->assertNotContains( $bc, $pairs );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_per_node_terms_emission_when_taxonomies_in_scope() {
+		$cat = self::factory()->category->create( array( 'name' => 'Travel' ) );
+		$tag = self::factory()->tag->create( array( 'name' => 'sunset' ) );
+
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_set_object_terms( $a, array( $cat ), 'category' );
+		wp_set_object_terms( $a, array( $tag ), 'post_tag' );
+
+		$payload = desktop_mode_content_graph_build(
+			array( 'post' ),
+			array( 'link' ),
+			array( 'category', 'post_tag' )
+		);
+		$node = $this->find_node( $payload['nodes'], $a );
+		$this->assertNotNull( $node );
+		$this->assertIsArray( $node['terms'] );
+		$this->assertSame( array( $cat ), $node['terms']['category'] );
+		$this->assertSame( array( $tag ), $node['terms']['post_tag'] );
+	}
+
+	/**
+	 * Nodes with no in-scope memberships still carry a `terms`
+	 * field (empty), so consumers don't need a null-check branch.
+	 *
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_node_terms_is_object_when_no_memberships() {
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		// WP's post factory auto-assigns the default category. Strip
+		// every term relationship so the post genuinely has no
+		// memberships in any taxonomy.
+		wp_set_object_terms( $a, array(), 'category' );
+		wp_set_object_terms( $a, array(), 'post_tag' );
+
+		$payload = desktop_mode_content_graph_build(
+			array( 'post' ),
+			array( 'link' ),
+			array( 'category' )
+		);
+		$node = $this->find_node( $payload['nodes'], $a );
+		$this->assertNotNull( $node );
+		$this->assertArrayHasKey( 'terms', $node );
+		// Empty membership is emitted as an empty object (stdClass) so
+		// JSON encoding produces `{}` not `[]`.
+		$this->assertInstanceOf( 'stdClass', $node['terms'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_terms_truncation_fires_observability_action() {
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$tag_ids = array();
+		for ( $i = 0; $i < DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP + 5; $i++ ) {
+			$tag_ids[] = self::factory()->tag->create( array( 'slug' => 'cap-' . $i ) );
+		}
+		wp_set_object_terms( $a, $tag_ids, 'post_tag' );
+
+		$captured = array();
+		$listener = static function ( $post_id, $taxonomy, $count ) use ( &$captured ) {
+			$captured[] = array( $post_id, $taxonomy, $count );
+		};
+		add_action( 'desktop_mode_content_graph_terms_truncated', $listener, 10, 3 );
+
+		$payload = desktop_mode_content_graph_build(
+			array( 'post' ),
+			array( 'link' ),
+			array( 'post_tag' )
+		);
+
+		remove_action( 'desktop_mode_content_graph_terms_truncated', $listener, 10 );
+
+		$node = $this->find_node( $payload['nodes'], $a );
+		$this->assertNotNull( $node );
+		$this->assertCount(
+			DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP,
+			$node['terms']['post_tag'],
+			'truncation cap applied'
+		);
+		$this->assertNotEmpty( $captured, 'observability action fired' );
+		$this->assertSame( $a, $captured[0][0] );
+		$this->assertSame( 'post_tag', $captured[0][1] );
+		$this->assertSame( DESKTOP_MODE_CONTENT_GRAPH_TERMS_PER_TAX_CAP + 5, $captured[0][2] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_edges_param_filters_to_requested_kinds() {
+		$author = self::factory()->user->create();
+		$cat    = self::factory()->category->create();
+
+		$a = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => $author,
+			)
+		);
+		$b = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_author'  => $author,
+				'post_content' => '<a href="' . get_permalink( $a ) . '">link</a>',
+			)
+		);
+		wp_set_object_terms( $a, array( $cat ), 'category' );
+		wp_set_object_terms( $b, array( $cat ), 'category' );
+
+		$only_link = desktop_mode_content_graph_build( array( 'post' ), array( 'link' ), array( 'category' ) );
+		$this->assertSame( 1, $this->edges_with_kind( $only_link['edges'], 'link' ) );
+		$this->assertSame( 0, $this->edges_with_kind( $only_link['edges'], 'co_tag' ) );
+		$this->assertSame( 0, $this->edges_with_kind( $only_link['edges'], 'co_author' ) );
+
+		desktop_mode_content_graph_flush_cache();
+
+		$link_and_tag = desktop_mode_content_graph_build( array( 'post' ), array( 'link', 'co_tag' ), array( 'category' ) );
+		$this->assertSame( 1, $this->edges_with_kind( $link_and_tag['edges'], 'link' ) );
+		$this->assertSame( 1, $this->edges_with_kind( $link_and_tag['edges'], 'co_tag' ) );
+		$this->assertSame( 0, $this->edges_with_kind( $link_and_tag['edges'], 'co_author' ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_unknown_edge_kinds_are_silently_dropped() {
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		// Should not error; unknown kinds normalise to no-op.
+		$payload = desktop_mode_content_graph_build( array( 'post' ), array( 'link', 'no_such_kind' ), array() );
+		$this->assertIsArray( $payload['edges'] );
+		// Still returns the link edge ecosystem (zero edges in this
+		// fixture but the call succeeds).
+		$node = $this->find_node( $payload['nodes'], $a );
+		$this->assertNotNull( $node );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_unknown_taxonomies_are_silently_dropped() {
+		$a = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		// Strip auto-assigned default category so the post starts truly
+		// memberless.
+		wp_set_object_terms( $a, array(), 'category' );
+		wp_set_object_terms( $a, array(), 'post_tag' );
+
+		$payload = desktop_mode_content_graph_build( array( 'post' ), array( 'link' ), array( 'category', 'no_such_taxonomy' ) );
+		$node    = $this->find_node( $payload['nodes'], $a );
+		$this->assertNotNull( $node );
+		// The known-but-unmembered taxonomy still yields an empty terms object.
+		$this->assertInstanceOf( 'stdClass', $node['terms'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_build
+	 */
+	public function test_set_object_terms_invalidates_cache() {
+		$cat = self::factory()->category->create();
+		$a   = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$b   = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		wp_set_object_terms( $a, array( $cat ), 'category' );
+		// First call: only A has the category. Expect 0 co_tag edges
+		// since no other post shares it.
+		$payload_before = desktop_mode_content_graph_build( array( 'post' ), array( 'co_tag' ), array( 'category' ) );
+		$this->assertSame( 0, $this->edges_with_kind( $payload_before['edges'], 'co_tag' ) );
+
+		// Now add the same category to B. The set_object_terms hook
+		// must have flushed the cache, so the next call recomputes
+		// and surfaces the (a, b) co-tag edge.
+		wp_set_object_terms( $b, array( $cat ), 'category' );
+
+		$payload_after = desktop_mode_content_graph_build( array( 'post' ), array( 'co_tag' ), array( 'category' ) );
+		$this->assertSame( 1, $this->edges_with_kind( $payload_after['edges'], 'co_tag' ) );
+	}
+
+	// --- helpers -----------------------------------------------------
+
+	private function edges_with_kind( array $edges, $kind ) {
+		$n = 0;
+		foreach ( $edges as $e ) {
+			if ( $kind === $e['kind'] ) {
+				$n++;
+			}
+		}
+		return $n;
+	}
+
+	private function pairs_with_kind( array $edges, $kind ) {
+		$out = array();
+		foreach ( $edges as $e ) {
+			if ( $kind === $e['kind'] ) {
+				$out[] = array( (int) $e['from'], (int) $e['to'] );
+			}
+		}
+		return $out;
+	}
+
+	private function find_node( array $nodes, $id ) {
+		foreach ( $nodes as $n ) {
+			if ( (int) $n['id'] === (int) $id ) {
+				return $n;
+			}
+		}
+		return null;
+	}
+}

--- a/tests/phpunit/tests/contentGraphPreferences.php
+++ b/tests/phpunit/tests/contentGraphPreferences.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests for Content Graph per-user preferences (introduced in 0.9.0).
+ *
+ * Covers `desktop_mode_content_graph_default_prefs()`,
+ * `desktop_mode_content_graph_sanitize_prefs()`, and the
+ * GET/POST round-trip through the meta key.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-content-graph
+ */
+class Tests_DesktopMode_ContentGraphPreferences extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::desktop_mode_content_graph_default_prefs
+	 */
+	public function test_defaults_have_expected_shape() {
+		$d = desktop_mode_content_graph_default_prefs();
+		$this->assertSame( 'constellation', $d['lens'] );
+		$this->assertSame( array( 'link' ), $d['byLens']['constellation']['edges'] );
+		$this->assertSame( array( 'link', 'co_tag' ), $d['byLens']['galaxy']['edges'] );
+		$this->assertSame( 'category', $d['byLens']['galaxy']['taxonomy'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_get_prefs
+	 */
+	public function test_get_prefs_returns_defaults_for_user_with_nothing_stored() {
+		$user_id = self::factory()->user->create();
+		$got     = desktop_mode_content_graph_get_prefs( $user_id );
+		$this->assertSame( desktop_mode_content_graph_default_prefs(), $got );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_save_prefs
+	 * @covers ::desktop_mode_content_graph_get_prefs
+	 */
+	public function test_full_round_trip() {
+		$user_id = self::factory()->user->create();
+		$patch   = array(
+			'lens'   => 'galaxy',
+			'byLens' => array(
+				'galaxy' => array(
+					'taxonomy' => 'post_tag',
+					'edges'    => array( 'link', 'co_tag', 'co_author' ),
+					'types'    => array( 'post' ),
+				),
+			),
+		);
+		$saved = desktop_mode_content_graph_save_prefs( $user_id, $patch );
+		$this->assertSame( 'galaxy', $saved['lens'] );
+		$this->assertSame( 'post_tag', $saved['byLens']['galaxy']['taxonomy'] );
+		$this->assertSame( array( 'link', 'co_tag', 'co_author' ), $saved['byLens']['galaxy']['edges'] );
+		$this->assertSame( array( 'post' ), $saved['byLens']['galaxy']['types'] );
+
+		// Reload from storage; should match.
+		$reloaded = desktop_mode_content_graph_get_prefs( $user_id );
+		$this->assertSame( $saved, $reloaded );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_save_prefs
+	 */
+	public function test_partial_save_merges_without_clobbering_other_lens() {
+		$user_id = self::factory()->user->create();
+
+		// Seed Galaxy state.
+		desktop_mode_content_graph_save_prefs(
+			$user_id,
+			array(
+				'byLens' => array(
+					'galaxy' => array(
+						'taxonomy' => 'post_tag',
+						'edges'    => array( 'link', 'co_tag', 'menu' ),
+					),
+				),
+			)
+		);
+
+		// Now patch only the Constellation lens edge selection.
+		$saved = desktop_mode_content_graph_save_prefs(
+			$user_id,
+			array(
+				'byLens' => array(
+					'constellation' => array(
+						'edges' => array( 'link', 'co_author' ),
+					),
+				),
+			)
+		);
+
+		// Galaxy state must survive intact.
+		$this->assertSame( 'post_tag', $saved['byLens']['galaxy']['taxonomy'] );
+		$this->assertSame( array( 'link', 'co_tag', 'menu' ), $saved['byLens']['galaxy']['edges'] );
+		// Constellation edges updated.
+		$this->assertSame( array( 'link', 'co_author' ), $saved['byLens']['constellation']['edges'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_sanitize_prefs
+	 */
+	public function test_sanitize_drops_unknown_lens() {
+		$out = desktop_mode_content_graph_sanitize_prefs(
+			array( 'lens' => 'sitemap' )
+		);
+		$this->assertSame( 'constellation', $out['lens'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_sanitize_prefs
+	 */
+	public function test_sanitize_drops_unknown_edge_kind() {
+		$out = desktop_mode_content_graph_sanitize_prefs(
+			array(
+				'byLens' => array(
+					'galaxy' => array(
+						'edges' => array( 'link', 'no_such_kind', 'co_author' ),
+					),
+				),
+			)
+		);
+		$this->assertSame( array( 'link', 'co_author' ), $out['byLens']['galaxy']['edges'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_sanitize_prefs
+	 */
+	public function test_sanitize_drops_private_taxonomy() {
+		// Register a private taxonomy on the fly.
+		register_taxonomy(
+			'private_tax_' . substr( md5( uniqid() ), 0, 6 ),
+			'post',
+			array( 'public' => false )
+		);
+		$out = desktop_mode_content_graph_sanitize_prefs(
+			array(
+				'byLens' => array(
+					'galaxy' => array(
+						// A real taxonomy that's not public.
+						'taxonomy' => 'nav_menu',
+					),
+				),
+			)
+		);
+		// Default falls back to "category" (or whatever default is).
+		$this->assertSame( 'category', $out['byLens']['galaxy']['taxonomy'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_sanitize_prefs
+	 */
+	public function test_sanitize_drops_unknown_post_type() {
+		$out = desktop_mode_content_graph_sanitize_prefs(
+			array(
+				'byLens' => array(
+					'galaxy' => array(
+						'types' => array( 'post', 'no_such_type' ),
+					),
+				),
+			)
+		);
+		$this->assertSame( array( 'post' ), $out['byLens']['galaxy']['types'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_taxonomies
+	 */
+	public function test_taxonomies_descriptor_includes_category() {
+		$taxes = desktop_mode_content_graph_taxonomies();
+		$slugs = wp_list_pluck( $taxes, 'slug' );
+		$this->assertContains( 'category', $slugs );
+		$this->assertContains( 'post_tag', $slugs );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_edge_kind_descriptors
+	 */
+	public function test_edge_kind_descriptors_cover_all_kinds() {
+		$slugs = wp_list_pluck( desktop_mode_content_graph_edge_kind_descriptors(), 'slug' );
+		$this->assertEqualSets(
+			desktop_mode_content_graph_edge_kinds(),
+			$slugs
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_graph_save_prefs
+	 */
+	public function test_save_for_nonexistent_user_returns_defaults() {
+		$got = desktop_mode_content_graph_save_prefs( 0, array( 'lens' => 'galaxy' ) );
+		$this->assertSame( desktop_mode_content_graph_default_prefs(), $got );
+	}
+}

--- a/tests/vitest/content-graph-rest.test.ts
+++ b/tests/vitest/content-graph-rest.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for the Content Graph REST client (added in 0.9.0): the
+ * new edge-kind discriminator on edges, the new `terms` field on
+ * nodes, the extended `fetchGraph` signature, and the new
+ * `fetchPrefs` / `savePrefs` helpers.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	fetchGraph,
+	fetchPrefs,
+	savePrefs,
+} from '../../src/content-graph/rest';
+import type {
+	ContentGraphConfig,
+	ContentGraphPrefs,
+	GraphPayload,
+} from '../../src/content-graph/types';
+
+declare global {
+	// eslint-disable-next-line no-var
+	var wp:
+		| {
+				desktop?: {
+					fetch?: typeof fetch;
+				};
+		  }
+		| undefined;
+}
+
+const cfg: ContentGraphConfig = {
+	restRoot: 'http://example.test/wp-json/',
+	restNonce: 'test-nonce',
+	apiBase: 'http://example.test/wp-json/desktop-mode/v1/content-graph',
+	editPostUrl: '',
+	editTermUrl: '',
+	editUserUrl: '',
+	editCommentUrl: '',
+	mediaUrl: '',
+	postTypes: [],
+	taxonomies: [],
+	edgeKinds: [],
+	prefs: {
+		lens: 'constellation',
+		byLens: {
+			constellation: { types: [], edges: [ 'link' ] },
+			galaxy: {
+				types: [],
+				edges: [ 'link', 'co_tag' ],
+				taxonomy: 'category',
+			},
+		},
+	},
+};
+
+function jsonResponse< T >( body: T, status = 200 ): Response {
+	return new Response( JSON.stringify( body ), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	} );
+}
+
+describe( 'content-graph rest client', () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach( () => {
+		originalFetch = global.fetch;
+	} );
+
+	afterEach( () => {
+		global.fetch = originalFetch;
+		// Reset wp.desktop in case a test wired it.
+		( global as { wp?: unknown } ).wp = undefined;
+	} );
+
+	test( 'fetchGraph passes types, edges, and taxonomies as query params', async () => {
+		const spy = vi.fn().mockResolvedValue(
+			jsonResponse< GraphPayload >( {
+				nodes: [],
+				edges: [],
+				stats: { nodes: 0, edges: 0, generated_at: 0 },
+			} ),
+		);
+		global.fetch = spy as unknown as typeof fetch;
+
+		await fetchGraph(
+			cfg,
+			[ 'post', 'page' ],
+			[ 'link', 'co_tag' ],
+			[ 'category', 'post_tag' ],
+		);
+
+		const calledWith = spy.mock.calls[ 0 ][ 0 ] as string;
+		const url = new URL( calledWith );
+		expect( url.searchParams.get( 'types' ) ).toBe( 'post,page' );
+		expect( url.searchParams.get( 'edges' ) ).toBe( 'link,co_tag' );
+		expect( url.searchParams.get( 'taxonomies' ) ).toBe( 'category,post_tag' );
+	} );
+
+	test( 'fetchGraph omits unsupplied query params', async () => {
+		const spy = vi.fn().mockResolvedValue(
+			jsonResponse< GraphPayload >( {
+				nodes: [],
+				edges: [],
+				stats: { nodes: 0, edges: 0, generated_at: 0 },
+			} ),
+		);
+		global.fetch = spy as unknown as typeof fetch;
+
+		await fetchGraph( cfg, [ 'post' ] );
+
+		const url = new URL( spy.mock.calls[ 0 ][ 0 ] as string );
+		expect( url.searchParams.get( 'types' ) ).toBe( 'post' );
+		expect( url.searchParams.has( 'edges' ) ).toBe( false );
+		expect( url.searchParams.has( 'taxonomies' ) ).toBe( false );
+	} );
+
+	test( 'fetchGraph parses node terms and edge kinds into typed shapes', async () => {
+		const payload: GraphPayload = {
+			nodes: [
+				{
+					id: 1,
+					type: 'post',
+					title: 'Hello',
+					status: 'publish',
+					slug: 'hello',
+					edit_url: '',
+					terms: { category: [ 7, 9 ], post_tag: [ 12 ] },
+				},
+				{
+					id: 2,
+					type: 'post',
+					title: 'World',
+					status: 'publish',
+					slug: 'world',
+					edit_url: '',
+					terms: {},
+				},
+			],
+			edges: [
+				{ from: 1, to: 2, kind: 'link' },
+				{ from: 1, to: 2, kind: 'co_tag' },
+			],
+			stats: { nodes: 2, edges: 2, generated_at: 0 },
+		};
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue( jsonResponse( payload ) ) as unknown as typeof fetch;
+
+		const got = await fetchGraph( cfg, [ 'post' ], [ 'link', 'co_tag' ], [ 'category', 'post_tag' ] );
+
+		// Per-node terms parses cleanly into the typed Record.
+		expect( got.nodes[ 0 ].terms.category ).toEqual( [ 7, 9 ] );
+		expect( got.nodes[ 0 ].terms.post_tag ).toEqual( [ 12 ] );
+		// Empty `terms: {}` parses without ceremony — consumers don't have
+		// to null-check.
+		expect( got.nodes[ 1 ].terms ).toEqual( {} );
+		// Edge kinds round-trip through the discriminated union.
+		expect( got.edges[ 0 ].kind ).toBe( 'link' );
+		expect( got.edges[ 1 ].kind ).toBe( 'co_tag' );
+	} );
+
+	test( 'fetchPrefs returns the typed prefs shape', async () => {
+		const prefs: ContentGraphPrefs = {
+			lens: 'galaxy',
+			byLens: {
+				constellation: { types: [], edges: [ 'link' ] },
+				galaxy: {
+					types: [ 'post' ],
+					edges: [ 'link', 'co_tag', 'co_author' ],
+					taxonomy: 'post_tag',
+				},
+			},
+		};
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue( jsonResponse( prefs ) ) as unknown as typeof fetch;
+
+		const got = await fetchPrefs( cfg );
+		expect( got ).toEqual( prefs );
+	} );
+
+	test( 'savePrefs POSTs the patch wrapped in a `preferences` envelope', async () => {
+		const merged: ContentGraphPrefs = {
+			lens: 'galaxy',
+			byLens: {
+				constellation: { types: [], edges: [ 'link' ] },
+				galaxy: {
+					types: [],
+					edges: [ 'link', 'co_tag' ],
+					taxonomy: 'post_tag',
+				},
+			},
+		};
+		const spy = vi.fn().mockResolvedValue( jsonResponse( merged ) );
+		global.fetch = spy as unknown as typeof fetch;
+
+		const got = await savePrefs( cfg, {
+			byLens: {
+				...merged.byLens,
+				galaxy: { ...merged.byLens.galaxy, taxonomy: 'post_tag' },
+			},
+		} );
+
+		expect( got ).toEqual( merged );
+		const init = spy.mock.calls[ 0 ][ 1 ] as RequestInit;
+		expect( init.method ).toBe( 'POST' );
+		const body = JSON.parse( init.body as string );
+		expect( body ).toHaveProperty( 'preferences' );
+		expect( body.preferences.byLens.galaxy.taxonomy ).toBe( 'post_tag' );
+	} );
+
+	test( 'fetchPrefs surfaces non-2xx responses as errors', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue( new Response( 'no', { status: 401 } ) ) as unknown as typeof fetch;
+		await expect( fetchPrefs( cfg ) ).rejects.toThrow( /preferences:.*401/ );
+	} );
+
+	test( 'savePrefs surfaces non-2xx responses as errors', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValue( new Response( 'nope', { status: 403 } ) ) as unknown as typeof fetch;
+		await expect( savePrefs( cfg, { lens: 'galaxy' } ) ).rejects.toThrow(
+			/preferences POST:.*403/,
+		);
+	} );
+} );

--- a/tests/vitest/content-graph-sim-clusters.test.ts
+++ b/tests/vitest/content-graph-sim-clusters.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the cluster-attractor force added to ForceSim in
+ * 0.9.0. Covers convergence, multi-cluster between-balance,
+ * uncategorized fallback, pinned nodes, and the disable paths
+ * (membership null / strength zero).
+ */
+import { describe, expect, test } from 'vitest';
+import {
+	DEFAULT_SIM_OPTIONS,
+	ForceSim,
+	type ClusterMembership,
+} from '../../src/content-graph/sim';
+import type { GraphEdge, GraphNode } from '../../src/content-graph/types';
+
+function makeNode( id: number, x: number, y: number ): GraphNode {
+	return {
+		id,
+		type: 'post',
+		title: `n${ id }`,
+		status: 'publish',
+		slug: `n${ id }`,
+		edit_url: '',
+		terms: {},
+		x,
+		y,
+		vx: 0,
+		vy: 0,
+		pinned: false,
+		radius: 4,
+		color: 0,
+		degree: 0,
+	};
+}
+
+function tickN( sim: ForceSim, n: number ): void {
+	for ( let i = 0; i < n; i++ ) {
+		sim.step( 1 );
+	}
+}
+
+describe( 'ForceSim cluster attractor', () => {
+	test( 'converges members toward a single cluster centroid', () => {
+		// Three members in a wide ring around the origin; centroid sits
+		// near origin and members should drift inward over time.
+		const a = makeNode( 1, -200, 0 );
+		const b = makeNode( 2, 200, 0 );
+		const c = makeNode( 3, 0, 200 );
+		const sim = new ForceSim(
+			[ a, b, c ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0.05 },
+		);
+		const membership: ClusterMembership = new Map( [
+			[ 1, [ 'cluster_a' ] ],
+			[ 2, [ 'cluster_a' ] ],
+			[ 3, [ 'cluster_a' ] ],
+		] );
+		sim.setClusters( membership );
+
+		const initialSpread =
+			Math.hypot( a.x - 0, a.y - 0 ) +
+			Math.hypot( b.x - 0, b.y - 0 ) +
+			Math.hypot( c.x - 0, c.y - 0 );
+		tickN( sim, 200 );
+		const finalSpread =
+			Math.hypot( a.x - 0, a.y - 0 ) +
+			Math.hypot( b.x - 0, b.y - 0 ) +
+			Math.hypot( c.x - 0, c.y - 0 );
+		expect( finalSpread ).toBeLessThan( initialSpread );
+	} );
+
+	test( 'multi-cluster node settles between cluster centroids (Covers AE1)', () => {
+		// Two clusters separated on the x-axis, with a "shared" node
+		// that belongs to both. The shared node should equilibrate
+		// roughly on the line between the two cluster centroids.
+		const left1 = makeNode( 1, -300, 0 );
+		const left2 = makeNode( 2, -290, 30 );
+		const right1 = makeNode( 3, 300, 0 );
+		const right2 = makeNode( 4, 290, -30 );
+		const shared = makeNode( 5, 0, 200 );
+		const sim = new ForceSim(
+			[ left1, left2, right1, right2, shared ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0.08 },
+		);
+		const membership: ClusterMembership = new Map( [
+			[ 1, [ 'L' ] ],
+			[ 2, [ 'L' ] ],
+			[ 3, [ 'R' ] ],
+			[ 4, [ 'R' ] ],
+			[ 5, [ 'L', 'R' ] ],
+		] );
+		sim.setClusters( membership );
+		tickN( sim, 400 );
+		// Shared node settles closer to the x-axis than to either
+		// extreme; |x| smaller than the cluster centroids' |x|.
+		expect( Math.abs( shared.x ) ).toBeLessThan( 200 );
+	} );
+
+	test( 'uncategorized members orbit the uncategorized centroid', () => {
+		// Two non-overlapping cluster keys. Members keyed only to
+		// '__uncategorized__' should clump together separately from
+		// the named cluster.
+		const a = makeNode( 1, -200, -200 );
+		const b = makeNode( 2, -200, 200 );
+		const u1 = makeNode( 3, 200, 0 );
+		const u2 = makeNode( 4, 250, 50 );
+		const sim = new ForceSim(
+			[ a, b, u1, u2 ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0.05 },
+		);
+		const membership: ClusterMembership = new Map( [
+			[ 1, [ 'real' ] ],
+			[ 2, [ 'real' ] ],
+			[ 3, [ '__uncategorized__' ] ],
+			[ 4, [ '__uncategorized__' ] ],
+		] );
+		sim.setClusters( membership );
+		tickN( sim, 300 );
+		// real-cluster members closer to each other than to the
+		// uncategorized members.
+		const realPairDist = Math.hypot( a.x - b.x, a.y - b.y );
+		const crossDist1 = Math.hypot( a.x - u1.x, a.y - u1.y );
+		const crossDist2 = Math.hypot( b.x - u2.x, b.y - u2.y );
+		expect( realPairDist ).toBeLessThan( crossDist1 );
+		expect( realPairDist ).toBeLessThan( crossDist2 );
+	} );
+
+	test( 'membership = null disables the force entirely', () => {
+		const a = makeNode( 1, -100, 0 );
+		const b = makeNode( 2, 100, 0 );
+		const simOff = new ForceSim(
+			[ a, b ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0.5 },
+		);
+		simOff.setClusters( null );
+		const beforeDist = Math.hypot( a.x - b.x, a.y - b.y );
+		tickN( simOff, 50 );
+		const afterDist = Math.hypot( a.x - b.x, a.y - b.y );
+		// With repulsion only and no attractor, distance grows or
+		// stays put — definitely doesn't shrink dramatically.
+		expect( afterDist ).toBeGreaterThanOrEqual( beforeDist - 1 );
+	} );
+
+	test( 'attractorStrength = 0 disables the force regardless of membership', () => {
+		const a = makeNode( 1, -100, 0 );
+		const b = makeNode( 2, 100, 0 );
+		const sim = new ForceSim(
+			[ a, b ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0 },
+		);
+		sim.setClusters(
+			new Map( [
+				[ 1, [ 'L' ] ],
+				[ 2, [ 'L' ] ],
+			] ),
+		);
+		const beforeDist = Math.hypot( a.x - b.x, a.y - b.y );
+		tickN( sim, 50 );
+		const afterDist = Math.hypot( a.x - b.x, a.y - b.y );
+		// No attractor pull: gap should not collapse.
+		expect( afterDist ).toBeGreaterThanOrEqual( beforeDist * 0.9 );
+	} );
+
+	test( 'pinned nodes are not displaced by the attractor', () => {
+		const a = makeNode( 1, -200, -200 );
+		a.pinned = true;
+		const b = makeNode( 2, 200, 200 );
+		const sim = new ForceSim(
+			[ a, b ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0.5 },
+		);
+		sim.setClusters(
+			new Map( [
+				[ 1, [ 'L' ] ],
+				[ 2, [ 'L' ] ],
+			] ),
+		);
+		const ax = a.x;
+		const ay = a.y;
+		tickN( sim, 50 );
+		expect( a.x ).toBe( ax );
+		expect( a.y ).toBe( ay );
+	} );
+
+	test( 'setForceConfig allows live config swap', () => {
+		const a = makeNode( 1, -100, 0 );
+		const b = makeNode( 2, 100, 0 );
+		const sim = new ForceSim(
+			[ a, b ],
+			[],
+			{ ...DEFAULT_SIM_OPTIONS, attractorStrength: 0 },
+		);
+		sim.setClusters(
+			new Map( [
+				[ 1, [ 'L' ] ],
+				[ 2, [ 'L' ] ],
+			] ),
+		);
+		// Off → no convergence.
+		const beforeDist = Math.hypot( a.x - b.x, a.y - b.y );
+		tickN( sim, 50 );
+		const midDist = Math.hypot( a.x - b.x, a.y - b.y );
+		expect( midDist ).toBeGreaterThanOrEqual( beforeDist * 0.9 );
+
+		// Flip strength on; expect convergence on subsequent ticks.
+		sim.setForceConfig( { attractorStrength: 0.05 } );
+		sim.reheat( 0.3, false );
+		tickN( sim, 200 );
+		const afterDist = Math.hypot( a.x - b.x, a.y - b.y );
+		expect( afterDist ).toBeLessThan( midDist );
+	} );
+} );


### PR DESCRIPTION
## Summary

Adds a multi-lens architecture to Content Graph alongside the existing force-directed view (now called **Constellation**) and ships **Galaxy**, the first new lens. Galaxy clusters posts by a user-chosen taxonomy with bridge highlighting that fades intra-cluster edges and pops cross-cluster ones. Four new edge types (co-tag, co-author, page hierarchy, nav menu) join the existing hyperlinks, each user-controllable via a new edges multi-toggle. Per-user persistence remembers lens choice, taxonomy, edge toggles, and post-type chips scoped per lens.

The lens architecture is extensible from day one: future lenses (Sitemap, Timeline) drop in by adding a third entry to the lens registry without refactoring the existing two.

Origin docs: [brainstorm](docs/brainstorms/content-graph-multi-lens-galaxy-requirements.md), [plan](docs/plans/2026-05-10-001-feat-content-graph-multi-lens-galaxy-plan.md).

## What changed

| Unit | What | Files |
|---|---|---|
| U1 | Four new PHP edge extractors + per-node `terms` emission + extended cache invalidation. `/nodes` REST accepts `edges` and `taxonomies` params. | `includes/content-graph/graph-builder.php`, `rest.php` |
| U2 | New per-user preferences endpoint (mirrors `os-settings.php`). Server injects `prefs`, `taxonomies`, `edgeKinds` into the window config for first-paint with no round-trip. | `includes/content-graph/preferences.php` (new), `bootstrap.php`, `window.php` |
| U3 + U4 | TS `EdgeKind`/`LensId`/`ContentGraphPrefs` types, `fetchPrefs`/`savePrefs` helpers, extended `fetchGraph(types, edgeKinds, taxonomies)`. ForceSim gains a cluster-attractor force loop, gated by `attractorStrength`. | `src/content-graph/types.ts`, `rest.ts`, `sim.ts` |
| U5 | `GraphScene.setLens()`, `setClusterTaxonomy()`, `setVisibleEdgeKinds()`. New cluster-label layer. Bridge-highlighting in `draw()`. `setData()` preserves `focusedId` and camera target across rebuilds (feasibility-2 fix). | `src/content-graph/scene.ts` |
| U6 + U7 | Toolbar migrated from raw DOM to `<wpd-segmented>` / `<wpd-select>` / `<wpd-multiselect>` / `<wpd-chip>` / `<wpd-button>`. Orchestration hydrates from `cfg.prefs`, runs lens-aware `loadGraph(reason)`, debounced (250ms) `savePrefs()`. | `src/content-graph/toolbar.ts`, `index.ts` |
| U8 | `docs/hooks-reference.md` backfills existing Content Graph filters and documents the new ones (`desktop_mode_content_graph_taxonomies`, `_edge_kind_descriptors`, `_terms_truncated`). | `docs/hooks-reference.md` |

## Test plan

- [ ] **Switch lenses.** Open Content Graph, click Galaxy in the toolbar's lens picker. Verify clusters form by `category` (default), multi-category posts settle between clusters, cross-cluster hyperlinks pop while intra-cluster ones fade. Switch back to Constellation; verify the original look returns.
- [ ] **Pick a different taxonomy.** Change the cluster-by dropdown to `post_tag` (or any other public taxonomy). Verify clusters re-form, the Uncategorized cluster appears or shrinks based on the new taxonomy's coverage.
- [ ] **Toggle edge kinds.** Open the edges multi-toggle, enable `Same author`. Verify co-author edges render in their distinct color, fade on intra-cluster, pop on cross-cluster.
- [ ] **Focus survives lens switch (AE4).** Focus a node, then switch lenses. Verify the focused node stays focused, the side panel stays populated, and the camera does not snap to a default fit-to-view.
- [ ] **Persistence (AE5).** Pick Galaxy lens + `post_tag` + `co_author` edges on. Close and reopen the Content Graph window. Verify the same state is restored.
- [ ] **Empty taxonomy (AE6).** Pick a taxonomy that has many unused terms. Verify only the terms with at least one post in scope produce visible clusters and labels.

## Verification

- `npm run lint` clean
- `npm run typecheck` clean
- `npm run build` clean (all 7 vite targets)
- `npm run test:js` — **1105/1105** tests pass (14 new: 7 sim-clusters, 7 rest)
- PHPUnit — **22 new test cases** (11 U1 + 11 U2), full suite **617/617** passing at the U1 checkpoint

## Notes

- Trunk's PR #141 (auto-inject `X-WP-Nonce`) is merged in; my `authHeaders()` still explicitly sets the nonce, which is now redundant but not harmful (caller-supplied headers win). Worth a tiny follow-up cleanup commit if you want.
- The brainstorm and plan docs are in this PR under `docs/brainstorms/` and `docs/plans/` for review context. They drove the U1–U8 commit structure.
- 8 implementation units land as 7 atomic commits (U3 + U4 share one commit, as do U6 + U7, because the work is tightly coupled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-144-1fcbd940363f9326479ea8b862956ed405f116a0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->