### PR TITLE
Fix rearrange icons out of desktop

### DIFF
--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -365,6 +365,14 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 					parentId: folderId,
 				};
 				filesStoreApi.upsertPlacement( next );
+				// Notify the shell that a tile was placed by the user
+				// (not by Sort By / Clean Up). The desktop root listens
+				// to drop out of auto-arrange mode so the user's manual
+				// position survives the next desktop resize.
+				doAction( 'desktop-mode.files.tile-manually-placed', {
+					folderId,
+					placementId: data.placement.id,
+				} );
 				void rest
 					.updatePlacement( data.placement.id, {
 						x: cell.x,

--- a/src/desktop-files/wallpaper-menu.ts
+++ b/src/desktop-files/wallpaper-menu.ts
@@ -45,6 +45,12 @@ export interface WallpaperMenuItem {
 	 * when `children` is non-empty — the flyout takes over.
 	 */
 	children?: WallpaperMenuItem[];
+	/**
+	 * Render a leading check mark on the option (radio-style — used
+	 * for the active Sort By order). Cosmetic; doesn't change the
+	 * click path.
+	 */
+	checked?: boolean;
 	/** Click handler. Receives the event for `preventDefault` etc. */
 	onClick: ( e: MouseEvent ) => void | Promise< void >;
 }
@@ -206,6 +212,9 @@ export function openWallpaperMenu(
 			if ( child.disabled ) {
 				kopt.setAttribute( 'disabled', '' );
 			}
+			if ( child.checked ) {
+				kopt.setAttribute( 'checked', '' );
+			}
 			kopt.textContent = child.label;
 			kopt.addEventListener( 'wpd-context-menu-pick', ( e: Event ) => {
 				e.stopPropagation();
@@ -305,24 +314,28 @@ export function buildMenuItems( deps: WallpaperMenuDeps ): WallpaperMenuItem[] {
 					id: 'sort-name-asc',
 					label: deps.labels.sortNameAsc,
 					sort: 10,
+					checked: deps.currentSortMode === 'name-asc',
 					onClick: () => deps.sortIcons( 'name-asc' ),
 				},
 				{
 					id: 'sort-name-desc',
 					label: deps.labels.sortNameDesc,
 					sort: 20,
+					checked: deps.currentSortMode === 'name-desc',
 					onClick: () => deps.sortIcons( 'name-desc' ),
 				},
 				{
 					id: 'sort-date-desc',
 					label: deps.labels.sortDateDesc,
 					sort: 30,
+					checked: deps.currentSortMode === 'date-desc',
 					onClick: () => deps.sortIcons( 'date-desc' ),
 				},
 				{
 					id: 'sort-date-asc',
 					label: deps.labels.sortDateAsc,
 					sort: 40,
+					checked: deps.currentSortMode === 'date-asc',
 					onClick: () => deps.sortIcons( 'date-asc' ),
 				},
 			],
@@ -398,6 +411,13 @@ export interface WallpaperMenuDeps {
 	openOsSettings: () => void;
 	openWallpapers: () => void;
 	sortIcons: ( mode: SortMode ) => void;
+	/**
+	 * Currently-active sort mode, or `null` when the desktop is in
+	 * free-placement mode (the user has dragged tiles manually). The
+	 * matching Sort By submenu entry renders with a leading check
+	 * so users see at a glance which order is auto-arranging.
+	 */
+	currentSortMode?: SortMode | null;
 	labels: {
 		createFolder: string;
 		showDesktop: string;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -181,6 +181,7 @@ import {
 	isWallpaperMenuOpen,
 	openWallpaperMenu,
 	type ServerWallpaperMenuItem,
+	type SortMode as RootSortMode,
 } from './desktop-files/wallpaper-menu';
 import { openCreateFolderDialog } from './desktop-files/create-folder-dialog';
 import { openUrlDialog } from './desktop-files/url-dialog';
@@ -2777,13 +2778,20 @@ function init(): void {
 	// boolean snapshot would go stale.
 	/**
 	 * Re-tile every placement at the desktop root in the order
-	 * returned by `transform`. Used by both Clean up (identity
-	 * transform) and Sort by * (sort transforms).
+	 * returned by `transform`. Used by Clean up (identity transform),
+	 * Sort by * (sort transforms, persisted), and the auto-arrange
+	 * ResizeObserver (current sort transform, NOT persisted — see
+	 * `rootSortMode` below).
+	 *
+	 * When `persist` is `false` we only mutate the store + DOM (via
+	 * the layer's repaint subscription); REST is left alone so a
+	 * resize storm doesn't fire dozens of writes per tile.
 	 */
 	const relayoutRoot = (
 		transform: (
 			arr: import( './desktop-files/rest' ).RestPlacementShape[],
 		) => import( './desktop-files/rest' ).RestPlacementShape[],
+		persist = true,
 	): void => {
 		const root = filesApi.store.getState().placementsByFolder.get( 0 ) ?? [];
 		const ordered = transform( root );
@@ -2814,6 +2822,9 @@ function init(): void {
 				y: cell.y,
 				sortOrder: i,
 			} );
+			if ( ! persist ) {
+				continue;
+			}
 			void filesRest
 				.updatePlacement( p.id, {
 					x: cell.x,
@@ -2826,6 +2837,111 @@ function init(): void {
 				} );
 		}
 	};
+
+	/**
+	 * Build the placement-list transform for a given sort mode. Same
+	 * sort keys the wallpaper menu offers; extracted so the resize
+	 * observer can re-apply the user's last pick without duplicating
+	 * the comparator logic.
+	 */
+	const rootSortTransform = ( mode: RootSortMode ) => (
+		arr: import( './desktop-files/rest' ).RestPlacementShape[],
+	): import( './desktop-files/rest' ).RestPlacementShape[] => {
+		const sorted = arr.slice();
+		switch ( mode ) {
+			case 'name-asc':
+				sorted.sort( ( a, b ) =>
+					a.file.title.localeCompare( b.file.title ),
+				);
+				break;
+			case 'name-desc':
+				sorted.sort( ( a, b ) =>
+					b.file.title.localeCompare( a.file.title ),
+				);
+				break;
+			case 'date-asc':
+				sorted.sort( ( a, b ) => a.updatedAtMs - b.updatedAtMs );
+				break;
+			case 'date-desc':
+				sorted.sort( ( a, b ) => b.updatedAtMs - a.updatedAtMs );
+				break;
+		}
+		return sorted;
+	};
+
+	// Auto-arrange / "sort by" sticky state. When a user picks Sort
+	// By from the wallpaper menu we remember the mode so subsequent
+	// desktop resizes re-pack the icons into the new column count
+	// (overflowing icons would otherwise stay where they were and
+	// fall off the right/bottom edges as the window shrinks). Cleared
+	// when the user manually drags a tile — manual placement wins,
+	// macOS Finder convention.
+	const ROOT_SORT_MODE_KEY = 'desktop-mode:root-sort-mode';
+	const isRootSortMode = ( v: unknown ): v is RootSortMode =>
+		v === 'name-asc' ||
+		v === 'name-desc' ||
+		v === 'date-asc' ||
+		v === 'date-desc';
+	let rootSortMode: RootSortMode | null = ( () => {
+		try {
+			const raw = window.localStorage.getItem( ROOT_SORT_MODE_KEY );
+			return isRootSortMode( raw ) ? raw : null;
+		} catch {
+			return null;
+		}
+	} )();
+	const setRootSortMode = ( mode: RootSortMode | null ): void => {
+		rootSortMode = mode;
+		try {
+			if ( mode ) {
+				window.localStorage.setItem( ROOT_SORT_MODE_KEY, mode );
+			} else {
+				window.localStorage.removeItem( ROOT_SORT_MODE_KEY );
+			}
+		} catch {
+			// localStorage unavailable (private mode, quota) — keep
+			// the in-memory state and move on.
+		}
+	};
+
+	// Clear auto-arrange when the user manually drags a root tile.
+	// Emitted by `desktop-files/layer.ts` from the canvas drop
+	// handler; folderId 0 = the desktop root.
+	addAction(
+		'desktop-mode.files.tile-manually-placed',
+		'desktop-mode/root-sort-clear',
+		( payload: unknown ) => {
+			const folderId = ( payload as { folderId?: number } | undefined )
+				?.folderId;
+			if ( folderId === 0 ) {
+				setRootSortMode( null );
+			}
+		},
+	);
+
+	// Re-pack icons when the desktop area resizes — but ONLY while
+	// auto-arrange is active. Manual layouts stay untouched. The
+	// non-persisting relayout mutates the store so the layer's
+	// subscription repaints, and avoids a REST writeback storm
+	// during a continuous drag-resize of the browser window.
+	if ( typeof ResizeObserver !== 'undefined' ) {
+		let lastW = desktopArea.clientWidth;
+		let lastH = desktopArea.clientHeight;
+		const ro = new ResizeObserver( () => {
+			if ( ! rootSortMode ) {
+				return;
+			}
+			const w = desktopArea.clientWidth;
+			const h = desktopArea.clientHeight;
+			if ( w === lastW && h === lastH ) {
+				return;
+			}
+			lastW = w;
+			lastH = h;
+			relayoutRoot( rootSortTransform( rootSortMode ), false );
+		} );
+		ro.observe( desktopArea );
+	}
 
 	// Wallpaper context menu — RIGHT-click only. `contextmenu` is
 	// the only opener; left-clicks on the bg either dismiss the
@@ -2918,29 +3034,11 @@ function init(): void {
 				toggleShowDesktop: () => manager.toggleShowDesktop(),
 				openOsSettings: () => openOsSettings(),
 				openWallpapers: () => openOsSettings(),
-				sortIcons: ( mode ) =>
-					relayoutRoot( ( arr ) => {
-						const sorted = arr.slice();
-						switch ( mode ) {
-							case 'name-asc':
-								sorted.sort( ( a, b ) =>
-									a.file.title.localeCompare( b.file.title ),
-								);
-								break;
-							case 'name-desc':
-								sorted.sort( ( a, b ) =>
-									b.file.title.localeCompare( a.file.title ),
-								);
-								break;
-							case 'date-asc':
-								sorted.sort( ( a, b ) => a.updatedAtMs - b.updatedAtMs );
-								break;
-							case 'date-desc':
-								sorted.sort( ( a, b ) => b.updatedAtMs - a.updatedAtMs );
-								break;
-						}
-						return sorted;
-					} ),
+				sortIcons: ( mode ) => {
+					setRootSortMode( mode );
+					relayoutRoot( rootSortTransform( mode ) );
+				},
+				currentSortMode: rootSortMode,
 				labels: {
 					createFolder: 'New folder',
 					showDesktop: 'Show desktop',

--- a/src/ui/components/wpd-context-menu/wpd-context-menu.styles.ts
+++ b/src/ui/components/wpd-context-menu/wpd-context-menu.styles.ts
@@ -88,7 +88,19 @@ export const optionStyles = css`
 
 	.chevron {
 		margin-inline-start: auto;
-		font-size: 14px;
+		padding-inline-start: 8px;
+		font-size: 16px;
+		line-height: 1;
 		opacity: 0.7;
+	}
+
+	.check {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		font-size: 13px;
+		line-height: 1;
+		opacity: 0.95;
 	}
 `;

--- a/src/ui/components/wpd-context-menu/wpd-context-menu.ts
+++ b/src/ui/components/wpd-context-menu/wpd-context-menu.ts
@@ -92,6 +92,7 @@ export class WpdContextMenuOption extends Component {
 		'danger',
 		'heading',
 		'has-children',
+		'checked',
 	] as const;
 	static styles = [ optionStyles ];
 
@@ -131,6 +132,11 @@ export class WpdContextMenuOption extends Component {
 				name: 'has-children',
 				type: 'boolean attribute',
 				description: 'Renders a trailing chevron to suggest a submenu.',
+			},
+			{
+				name: 'checked',
+				type: 'boolean attribute',
+				description: 'Renders a leading check mark — for radio-style picks inside a submenu (e.g. the active Sort By order).',
 			},
 		],
 		slots: [
@@ -193,13 +199,22 @@ export class WpdContextMenuOption extends Component {
 	protected render() {
 		const icon = this.getAttribute( 'icon' );
 		const hasChildren = this.hasAttribute( 'has-children' );
+		const checked = this.hasAttribute( 'checked' );
+		// Chevron + check are rendered as plain unicode glyphs rather
+		// than dashicons because the dashicons font's `:before` content
+		// rules live in the parent document and don't pierce the
+		// component's shadow root — so a `class="dashicons …"` span
+		// renders empty in this context.
 		return html`
+			${ checked
+				? html`<span class="check" aria-hidden="true">✓</span>`
+				: html`` }
 			${ icon
 				? html`<span class="icon dashicons ${ icon }" aria-hidden="true"></span>`
 				: html`` }
 			<span class="label"><slot></slot></span>
 			${ hasChildren
-				? html`<span class="chevron dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>`
+				? html`<span class="chevron" aria-hidden="true">›</span>`
 				: html`` }
 		`;
 	}


### PR DESCRIPTION
<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-151-ad348a6a7c03fd66ee1025194989468229aa1dc9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->