### PR TITLE
fix(content-graph): open each post in its own window (#150)

### DIFF
--- a/src/content-graph/panel.ts
+++ b/src/content-graph/panel.ts
@@ -50,9 +50,15 @@ interface OpenWindowArgs {
 	icon?: string;
 }
 
+interface DesktopWindow {
+	isFullscreen?: () => boolean;
+	toggleFullscreen?: () => void;
+}
+
 interface DesktopApi {
 	windowManager?: {
 		open: ( args: OpenWindowArgs ) => unknown;
+		getFocused?: () => DesktopWindow | null;
 	};
 	deriveWindowId?: ( url: string ) => string;
 	myWordpress?: {
@@ -266,6 +272,15 @@ export function renderPanel(
 		href: string,
 		labelText: string,
 		icon: string,
+		// Per-entity disambiguator. The framework's `deriveWindowId()`
+		// strips the `post` / `user_id` / `tag_ID` / `item` query
+		// params from the URL when computing the id (they're not in
+		// IDENTITY_PARAMS), so every post-edit url collapses to a
+		// single window id and clicking "Open" on a second post just
+		// focuses the first one's editor. Pass an entity-specific
+		// suffix (e.g. `post-42`, `user-7`) to keep each entity on
+		// its own window. See issue #150.
+		windowKey?: string,
 	): void => {
 		const api = desktopApi();
 		if ( ! api.windowManager || ! api.deriveWindowId || ! href ) {
@@ -274,7 +289,21 @@ export function renderPanel(
 			}
 			return;
 		}
-		const id = api.deriveWindowId( href );
+		// If the currently-focused window is in fullscreen, exit
+		// fullscreen first so the freshly opened window is actually
+		// visible. The framework pins fullscreen windows to
+		// `z-index: 99999 !important`, which overrides the normal
+		// inline z-index the new window receives — without this, the
+		// new window opens "underneath" the fullscreen one and the
+		// user only sees the click do nothing.
+		const focused = api.windowManager.getFocused?.();
+		if ( focused?.isFullscreen?.() ) {
+			focused.toggleFullscreen?.();
+		}
+		let id = api.deriveWindowId( href );
+		if ( windowKey ) {
+			id = `${ id }-${ windowKey }`;
+		}
 		api.windowManager.open( {
 			id,
 			baseId: id,
@@ -506,6 +535,7 @@ export function renderPanel(
 					detail.post.edit_url,
 					detail.post.title,
 					'dashicons-admin-post',
+					`post-${ detail.post.id }`,
 				),
 			);
 			wrap.appendChild( edit );
@@ -520,6 +550,7 @@ export function renderPanel(
 					detail.post.view_url,
 					detail.post.title,
 					'dashicons-admin-post',
+					`post-${ detail.post.id }`,
 				),
 			);
 			wrap.appendChild( view );
@@ -637,6 +668,7 @@ export function renderPanel(
 				href: user.edit_url,
 				title: user.name,
 				primary: true,
+				windowKey: `user-${ user.id }`,
 			} ),
 		);
 	};
@@ -740,6 +772,7 @@ export function renderPanel(
 				href: term.edit_url,
 				title: term.name,
 				primary: true,
+				windowKey: `term-${ term.taxonomy }-${ term.id }`,
 			} ),
 		);
 	};
@@ -836,6 +869,7 @@ export function renderPanel(
 				href: comment.edit_url,
 				title: authorName || __( 'Comment' ),
 				primary: true,
+				windowKey: `comment-${ comment.id }`,
 			} ),
 		);
 	};
@@ -867,6 +901,7 @@ export function renderPanel(
 				href: media.edit_url,
 				title: media.title,
 				primary: true,
+				windowKey: `media-${ media.id }`,
 			} ),
 		);
 	};
@@ -909,6 +944,7 @@ export function renderPanel(
 				href: revision.edit_url,
 				title: __( 'Revision' ),
 				primary: true,
+				windowKey: `revision-${ revision.id }`,
 			} ),
 		);
 	};
@@ -1158,6 +1194,7 @@ export function renderPanel(
 		href: string;
 		title: string;
 		primary?: boolean;
+		windowKey?: string;
 	} ): HTMLElement => {
 		const wrap = document.createElement( 'div' );
 		wrap.className = 'desktop-mode-content-graph__panel-actions';
@@ -1171,7 +1208,7 @@ export function renderPanel(
 			primary: opts.primary,
 		} );
 		btn.addEventListener( 'click', () =>
-			openAdminUrl( opts.href, opts.title, opts.icon ),
+			openAdminUrl( opts.href, opts.title, opts.icon, opts.windowKey ),
 		);
 		wrap.appendChild( btn );
 		return wrap;


### PR DESCRIPTION
## Summary

Two related fixes for the "Open in WordPress" buttons in the Content Graph side panel.

### Per-entity window disambiguator

`deriveWindowId()` doesn't count `post`, `user_id`, `tag_ID`, `item` as identity params (they're not in `IDENTITY_PARAMS`), so every post-edit URL collapsed to the single id `post-php` and clicking **Edit** on a second post just focused the first one's editor.

Each call site now passes an entity-specific suffix that's appended to the derived id:

| Entity   | Suffix                     |
|----------|----------------------------|
| Post     | `post-${id}`               |
| User     | `user-${id}`               |
| Term     | `term-${taxonomy}-${id}`   |
| Comment  | `comment-${id}`            |
| Media    | `media-${id}`              |
| Revision | `revision-${id}`           |

Result: each entity opens in its own window. Clicking the same entity twice still focuses the existing window (correct dedup behavior).

### Exit fullscreen on source before opening

The framework pins fullscreen windows to `z-index: 99999 !important`, which overrides the normal inline z-index a freshly opened window receives. With Content Graph in fullscreen, clicking **Edit** opened a new window underneath the fullscreen one — the user saw the click do nothing.

If `getFocused()` returns a fullscreen window at open time, `toggleFullscreen()` it first so the new window is actually visible. The previously-fullscreen window restores to whichever state it was in before (normal or maximized), keeping its place in the z-stack.

### Why a content-graph-local fix instead of patching the framework

- Adding `post`, `user_id`, `tag_ID`, `item` to `IDENTITY_PARAMS` would change dedup semantics for every consumer of `deriveWindowId`, including the dock and the URL-to-window matcher. Too broad for a focused bug fix.
- Auto-exiting fullscreen inside `windowManager.focus()` would change behavior for every consumer that uses fullscreen + opens new windows. Could surprise existing plugins.

Both fixes are contained inside `panel.ts` so this PR doesn't move framework-level contracts.

Closes #150

## Test plan

- [x] Open Content Graph, focus a post (graph A), click **Edit** — A's editor opens.
- [x] Keep A's editor open, focus a different post (graph B) in Content Graph, click **Edit** — a separate window B opens.
- [x] Repeat with **Open in WordPress** on a user, a term, a comment, a media item, a revision — each entity opens its own window the first time, focuses the existing window on repeat clicks.
- [x] Maximize Content Graph (middle button), open a post — new editor appears on top of the maximized graph.
- [x] Fullscreen Content Graph (focus button), open a post — Content Graph exits fullscreen and the new editor appears on top.
- [x] `prefers-reduced-motion` honored (no animation regressions).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-153-9488b951c356c1bde98fa33de01593b35cf50ea6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->