### PR TITLE
feat: add item visibility and dock order settings

### DIFF
--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -604,3 +604,32 @@
 }
 
 
+
+/* Drag-to-reorder (since 0.25.0).
+ *
+ * The dragged tile follows the cursor via inline `transform:
+ * translate()` written from JS. It stays IN flow so flex doesn't
+ * collapse the row — the visual lift is a z-index bump and
+ * `pointer-events: none` so `elementFromPoint` finds siblings
+ * underneath the cursor. Sibling tiles animate via FLIP — the JS
+ * writes inline `transform` + `transition` per leg, so no CSS
+ * transition is declared here (it would race with the per-leg
+ * inline transition). */
+.desktop-mode-dock__item--dragging {
+	pointer-events: none;
+	z-index: 50;
+	opacity: 0.92;
+	cursor: grabbing;
+	will-change: transform;
+	/* Subtle shadow so the dragged tile reads as "lifted" against
+	 * the dock surface it floats above. */
+	filter: drop-shadow( 0 6px 12px rgba( 0, 0, 0, 0.35 ) );
+}
+
+.desktop-mode-dock__item:not( .desktop-mode-dock__item--system ) {
+	cursor: grab;
+}
+
+.desktop-mode-dock__item:not( .desktop-mode-dock__item--system ):active {
+	cursor: grabbing;
+}

--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -1037,3 +1037,53 @@
 	height: 100%;
 }
 
+
+/* Apps & Icons section (since 0.25.0) — per-item placement chooser. */
+.desktop-mode-apps-icons__list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.desktop-mode-apps-icons__row {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 8px 4px;
+	border-bottom: 1px solid var( --desktop-mode-border, rgba( 0, 0, 0, 0.08 ) );
+}
+
+.desktop-mode-apps-icons__row:last-child {
+	border-bottom: 0;
+}
+
+.desktop-mode-apps-icons__identity {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex: 1;
+	min-width: 0;
+}
+
+.desktop-mode-apps-icons__icon {
+	width: 24px;
+	height: 24px;
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.desktop-mode-apps-icons__icon.dashicons {
+	font-size: 20px;
+}
+
+.desktop-mode-apps-icons__title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.desktop-mode-apps-icons__row wpd-select {
+	min-width: 180px;
+}

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -105,6 +105,19 @@ function desktop_mode_default_os_settings() {
 		// tile anyway. When `false`, the dock click falls back to the
 		// classic `plugins.php` chromeless iframe path.
 		'nativePluginsEnabled'     => true,
+		// Per-item placement preferences. Map of item id (dock-item
+		// slug or registered desktop-icon id) → one of:
+		//   'both'    — show on both dock and desktop.
+		//   'dock'    — show only on the dock; hide from desktop.
+		//   'desktop' — show only on the wallpaper; hide from dock.
+		//   'hidden'  — hide from every shell surface.
+		// Missing keys mean "no override" — items use their native rail.
+		// Sanitized as map<sanitize_key, enum>. Capped at 256 entries.
+		'itemVisibility'           => array(),
+		// Per-user dock ordering. Ordered list of item ids; ids not in
+		// the list keep their server-supplied position appended after
+		// the listed ones. Unknown ids are tolerated.
+		'dockOrder'                => array(),
 	);
 }
 
@@ -333,6 +346,52 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		? (bool) $raw['nativePluginsEnabled']
 		: $defaults['nativePluginsEnabled'];
 
+	// itemVisibility — map<sanitize_key, enum>. Unknown ids are kept
+	// (a deactivated plugin's setting should survive reactivation);
+	// invalid placement values are dropped.
+	$item_visibility = array();
+	if ( isset( $raw['itemVisibility'] ) && is_array( $raw['itemVisibility'] ) ) {
+		$allowed_placements = array( 'both', 'dock', 'desktop', 'hidden' );
+		$count              = 0;
+		foreach ( $raw['itemVisibility'] as $key => $val ) {
+			if ( $count >= 256 ) {
+				break;
+			}
+			if ( ! is_string( $key ) || '' === $key || ! is_string( $val ) ) {
+				continue;
+			}
+			$slug = sanitize_key( $key );
+			if ( '' === $slug ) {
+				continue;
+			}
+			if ( ! in_array( $val, $allowed_placements, true ) ) {
+				continue;
+			}
+			$item_visibility[ $slug ] = $val;
+			++$count;
+		}
+	}
+
+	// dockOrder — ordered list of sanitize_key()-clean ids.
+	$dock_order = array();
+	if ( isset( $raw['dockOrder'] ) && is_array( $raw['dockOrder'] ) ) {
+		$seen = array();
+		foreach ( $raw['dockOrder'] as $id ) {
+			if ( ! is_string( $id ) || '' === $id ) {
+				continue;
+			}
+			$slug = sanitize_key( $id );
+			if ( '' === $slug || isset( $seen[ $slug ] ) ) {
+				continue;
+			}
+			$seen[ $slug ]  = true;
+			$dock_order[]    = $slug;
+			if ( count( $dock_order ) >= 256 ) {
+				break;
+			}
+		}
+	}
+
 	return array(
 		'wallpaper'                => $wallpaper,
 		'accent'                   => $accent,
@@ -348,6 +407,8 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'nativePagesEnabled'       => $native_pages_enabled,
 		'nativeUsersEnabled'       => $native_users_enabled,
 		'nativePluginsEnabled'     => $native_plugins_enabled,
+		'itemVisibility'           => $item_visibility,
+		'dockOrder'                => $dock_order,
 	);
 }
 

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -364,6 +364,40 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 						)
 						.slice( 0, 32 );
 			}
+			if (
+				patch.itemVisibility &&
+				typeof patch.itemVisibility === 'object'
+			) {
+				const allowed = [ 'both', 'dock', 'desktop', 'hidden' ];
+				const next: Record<
+					string,
+					'both' | 'dock' | 'desktop' | 'hidden'
+				> = {};
+				for ( const [ k, v ] of Object.entries(
+					patch.itemVisibility as Record< string, unknown >,
+				) ) {
+					if ( typeof k !== 'string' || k === '' ) {
+						continue;
+					}
+					if ( typeof v !== 'string' || ! allowed.includes( v ) ) {
+						continue;
+					}
+					next[ k ] = v as
+						| 'both'
+						| 'dock'
+						| 'desktop'
+						| 'hidden';
+				}
+				osSettings.state.itemVisibility = next;
+			}
+			if ( Array.isArray( patch.dockOrder ) ) {
+				osSettings.state.dockOrder = patch.dockOrder
+					.filter(
+						( v ): v is string =>
+							typeof v === 'string' && v !== '',
+					)
+					.slice( 0, 256 );
+			}
 			osSettings.save( opts );
 		},
 		deriveWindowId: ( url: string, overrideAdminUrl?: string ) =>

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -712,6 +712,52 @@ function isPinned( placement: RestPlacementShape ): boolean {
 }
 
 /**
+ * If `placement` is a synthesized shortcut from a dock-item the user
+ * promoted to the desktop (via OS Settings → Apps & Icons), return
+ * the source dock-item id. Returns `null` for real placements.
+ *
+ * Marker key matches the one written by
+ * `settings/desktop-shortcuts-sync.ts`.
+ */
+function readSynthSource( placement: RestPlacementShape ): string | null {
+	const meta = placement.meta;
+	if ( ! meta || typeof meta !== 'object' ) {
+		return null;
+	}
+	const v = ( meta as Record< string, unknown > ).__synthFromDockItem;
+	return typeof v === 'string' && v !== '' ? v : null;
+}
+
+/**
+ * Hide a dock item the user previously promoted onto the desktop.
+ * Mutates `OsSettingsState.itemVisibility[ dockItemId ]` to `'dock'`
+ * via the public API; the shortcuts-sync subscription removes the
+ * synthetic placement on the next tick.
+ */
+function hidePromotedDockItem( dockItemId: string ): void {
+	const api = (
+		window as unknown as {
+			wp?: {
+				desktop?: {
+					getOsSettings?: () => {
+						itemVisibility: Record< string, string >;
+					};
+					updateOsSettings?: ( patch: {
+						itemVisibility?: Record< string, string >;
+					} ) => void;
+				};
+			};
+		}
+	).wp?.desktop;
+	if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
+		return;
+	}
+	const current = api.getOsSettings().itemVisibility ?? {};
+	const next = { ...current, [ dockItemId ]: 'dock' };
+	api.updateOsSettings( { itemVisibility: next } );
+}
+
+/**
  * Register a folder tile as a drop target. Folder tiles claim their
  * own hit-test region; the DragManager routes the drop here when the
  * cursor releases over a folder (the registry's deepest-match wins
@@ -1056,14 +1102,32 @@ function attachContextMenu(
 				onClick: () => trashFolderWithUndo( placement ),
 			} );
 		} else {
-			items.push( {
-				id: 'remove',
-				label: 'Move to Trash',
-				icon: 'dashicons-trash',
-				sort: 90,
-				danger: true,
-				onClick: () => trashPlacementWithUndo( placement ),
-			} );
+			// Synthetic shortcuts (dock items the user promoted to the
+			// desktop via OS Settings → Apps & Icons) aren't real
+			// placements — they're derived from the visibility map and
+			// live only in the in-memory store. Trashing one would
+			// hit a 404 on the REST endpoint. Replace the action with
+			// "Hide from desktop", which updates the visibility back
+			// to 'dock' and the sync module drops the synth tile.
+			const synthFromDockItem = readSynthSource( placement );
+			if ( synthFromDockItem ) {
+				items.push( {
+					id: 'hide-from-desktop',
+					label: 'Hide from desktop',
+					icon: 'dashicons-hidden',
+					sort: 90,
+					onClick: () => hidePromotedDockItem( synthFromDockItem ),
+				} );
+			} else {
+				items.push( {
+					id: 'remove',
+					label: 'Move to Trash',
+					icon: 'dashicons-trash',
+					sort: 90,
+					danger: true,
+					onClick: () => trashPlacementWithUndo( placement ),
+				} );
+			}
 		}
 		openTileMenu( { x: e.clientX, y: e.clientY }, { placement, items } );
 	} );

--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -38,6 +38,7 @@ import { activity } from './activity';
 import { __, _n, sprintf } from './i18n';
 import { doAction, HOOKS } from './hooks';
 import { renderIcon } from './icon';
+import { openItemVisibilityMenu } from './item-visibility-menu';
 import type { DesktopIconServerEntry } from './types';
 import type { WindowManager } from './window-manager';
 
@@ -461,6 +462,24 @@ function buildIcon(
 			target: entry.window ? 'window' : 'url',
 		} );
 		openTarget( entry, deps );
+	} );
+
+	// Right-click → visibility menu. Skips pinned system icons (e.g.
+	// "My WordPress") which are framework-owned and shouldn't be
+	// user-hideable from the wallpaper.
+	tile.addEventListener( 'contextmenu', ( e: MouseEvent ) => {
+		if ( entry.pinned ) {
+			return;
+		}
+		e.preventDefault();
+		e.stopPropagation();
+		openItemVisibilityMenu( {
+			x: e.clientX,
+			y: e.clientY,
+			id: entry.id,
+			title: entry.title,
+			surface: 'desktop',
+		} );
 	} );
 
 	return tile;

--- a/src/desktop-layout.ts
+++ b/src/desktop-layout.ts
@@ -45,7 +45,11 @@ import {
 } from './dock-rail';
 import type { WindowManager } from './window-manager';
 import { deriveWindowId } from './utils';
-import type { DesktopLayoutId } from './settings/types';
+import type { DesktopLayoutId, OsSettingsState } from './settings/types';
+import {
+	applyDesktopPlacement,
+	applyDockPlacement,
+} from './settings/item-placement';
 import { doAction, HOOKS } from './hooks';
 
 /**
@@ -78,6 +82,16 @@ export interface LayoutDispatcherDeps {
 	 * synthesized core menu icons (Spatial only).
 	 */
 	renderIcons: ( icons: DesktopIconServerEntry[] | undefined ) => void;
+	/**
+	 * Read the current OS-settings snapshot. The dispatcher consults
+	 * this on every partition / repaint so the user's
+	 * `itemVisibility` + `dockOrder` overrides take effect without
+	 * the call site having to thread settings through.
+	 */
+	getSettings?: () => Pick<
+		OsSettingsState,
+		'itemVisibility' | 'dockOrder'
+	>;
 }
 
 /**
@@ -169,6 +183,14 @@ export interface LayoutDispatcher {
 	 * @since 0.18.0
 	 */
 	getMenuItems(): DockItem[];
+	/**
+	 * Re-apply the current OS-settings placement preferences to every
+	 * rail. Called when `itemVisibility` or `dockOrder` changes — both
+	 * the dock contents and the desktop-icons grid may shift.
+	 *
+	 * @since 0.25.0
+	 */
+	refresh(): void;
 	/** Tear down all docks. Called on shell unload (or in tests). */
 	destroy(): void;
 }
@@ -264,10 +286,40 @@ export function createLayoutDispatcher(
 		sideDockEl = null;
 	};
 
+	/**
+	 * Effective dock-item list after applying the user's visibility +
+	 * ordering preferences. Reads server icons so desktop-only items
+	 * the user has promoted to the dock get synthesized into tiles.
+	 */
+	const readSettings = (): Pick<
+		OsSettingsState,
+		'itemVisibility' | 'dockOrder'
+	> => deps.getSettings?.() ?? { itemVisibility: {}, dockOrder: [] };
+
+	const effectiveDockItems = (): DockItem[] => {
+		// System tile ids match the native-window ids the framework
+		// has already mounted on the dock (Recycle Bin's
+		// `placement: 'taskbar'` registration is the canonical
+		// example). Pass them through so applyDockPlacement skips
+		// synthesizing a duplicate when the user picks "Both" for
+		// an icon whose native window is already on the dock.
+		const dockedNativeWindows = new Set< string >();
+		for ( const entry of systemTiles.values() ) {
+			dockedNativeWindows.add( entry.item.id );
+		}
+		return applyDockPlacement(
+			items,
+			serverIcons,
+			readSettings(),
+			dockedNativeWindows,
+		);
+	};
+
 	const partition = (): { core: DockItem[]; plugin: DockItem[] } => {
+		const effective = effectiveDockItems();
 		const core: DockItem[] = [];
 		const plugin: DockItem[] = [];
-		for ( const item of items ) {
+		for ( const item of effective ) {
 			if ( item.isCore ) {
 				core.push( item );
 			} else {
@@ -278,20 +330,42 @@ export function createLayoutDispatcher(
 	};
 
 	const repaintIcons = (): void => {
+		const settings = readSettings();
 		if ( layout !== 'spatial' ) {
-			deps.renderIcons( serverIcons );
+			// Apply visibility to the wallpaper grid — items the user
+			// promoted to the desktop get synthesized; native desktop
+			// icons hidden / dock-only are filtered out.
+			deps.renderIcons(
+				applyDesktopPlacement( serverIcons, items, settings.itemVisibility ),
+			);
 			return;
 		}
-		// Spatial owns the wallpaper as the "core surface": only
-		// synthesized core menu icons render here. Plugin admin
-		// menus already live in the bottom dock; rendering plugin-
-		// registered desktop icons on top would duplicate every
-		// plugin that ships both a top-level menu and a desktop
-		// shortcut. Plugin authors who want a Spatial-mode wallpaper
-		// presence can hook a filter in a follow-up if it comes up.
+		// Spatial owns the wallpaper as the "core surface": synthesized
+		// core menu icons render here. Server-registered plugin
+		// desktop icons are deliberately suppressed — plugin admin
+		// menus live in the bottom dock, and duplicating them on the
+		// wallpaper would create two paths to the same screen. The
+		// only Spatial-mode wallpaper additions beyond core synthesis
+		// are items the user EXPLICITLY promoted via OS Settings (an
+		// `itemVisibility` override on a dock-native item).
 		const { core } = partition();
 		const synthesized = core.map( coreItemToIconEntry );
-		deps.renderIcons( synthesized );
+		const explicitlyPromoted: DesktopIconServerEntry[] = [];
+		let synthIndex = 0;
+		for ( const item of items ) {
+			const placement = settings.itemVisibility[ item.id ];
+			if ( placement === 'desktop' || placement === 'both' ) {
+				explicitlyPromoted.push( {
+					id: `dock:${ item.id }`,
+					title: item.title,
+					icon: item.icon,
+					window: '',
+					url: item.url || '',
+					position: 2000 + synthIndex++,
+				} );
+			}
+		}
+		deps.renderIcons( [ ...synthesized, ...explicitlyPromoted ] );
 	};
 
 	const tearDownDocks = (): void => {
@@ -449,7 +523,7 @@ export function createLayoutDispatcher(
 		} else if ( layout === 'unified' ) {
 			removeSideDockEl();
 			primary = mountRail(
-				buildMountDeps( deps.bottomDockEl, items, 'bottom' ),
+				buildMountDeps( deps.bottomDockEl, effectiveDockItems(), 'bottom' ),
 			);
 			primaryDock = unwrapDefaultDock( primary );
 		} else {
@@ -499,7 +573,7 @@ export function createLayoutDispatcher(
 				side?.replaceItems( core );
 				primary?.replaceItems( plugin );
 			} else if ( layout === 'unified' ) {
-				primary?.replaceItems( items );
+				primary?.replaceItems( effectiveDockItems() );
 			} else {
 				primary?.replaceItems( plugin );
 			}
@@ -539,6 +613,18 @@ export function createLayoutDispatcher(
 		getSystemTile: ( id: string ): SystemDockItem | null =>
 			systemTiles.get( id )?.item ?? null,
 		getMenuItems: () => items.slice(),
+		refresh: (): void => {
+			const { core, plugin } = partition();
+			if ( layout === 'classic' ) {
+				side?.replaceItems( core );
+				primary?.replaceItems( plugin );
+			} else if ( layout === 'unified' ) {
+				primary?.replaceItems( effectiveDockItems() );
+			} else {
+				primary?.replaceItems( plugin );
+			}
+			repaintIcons();
+		},
 		destroy: (): void => {
 			tearDownDocks();
 			removeSideDockEl();

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -146,6 +146,10 @@ import { bindShellLifecycle, wireSessionEvents } from './boot/shell-lifecycle';
 import { trackedFetch } from './boot/tracked-fetch';
 import { buildPublicApi, installPublicApi } from './api/facade';
 import { setCurrentLayout } from './layout';
+import {
+	installShortcutsSync,
+	syncShortcutsWithVisibility,
+} from './settings/desktop-shortcuts-sync';
 
 // `INITIAL_ORIGIN` lives in `src/boot/origin.ts` since 0.8.1 so every
 // boot-time consumer reaches the same captured value — see the import
@@ -1886,6 +1890,13 @@ function init(): void {
 				windowManager: manager,
 				adminUrl: config.adminUrl,
 				renderIcons,
+				getSettings: () => {
+					const snap = osSettings.getOsSettingsSnapshot();
+					return {
+						itemVisibility: snap.itemVisibility,
+						dockOrder: snap.dockOrder,
+					};
+				},
 			},
 			initialLayout,
 			config.dockItems,
@@ -2565,15 +2576,39 @@ function init(): void {
 		if ( ! layoutDispatcher ) {
 			return;
 		}
+		const prevLayout = layoutDispatcher.getLayout();
 		layoutDispatcher.setLayout( snapshot.desktopLayout );
 		desktopApi.dock = layoutDispatcher.getPrimary();
 		desktopApi.sideDock = layoutDispatcher.getSide();
 		desktopApi.desktopLayout = snapshot.desktopLayout;
+		// Always re-apply per-item placement on every settings save.
+		// `setLayout` already rebuilt from scratch when the layout
+		// itself changed (and reads the latest settings while doing
+		// so), so we skip the explicit refresh in that case to avoid
+		// double-rendering. Otherwise, refresh unconditionally — the
+		// snapshot may carry an item-visibility or dock-order change
+		// that callers (settings tab, context menu, drag-to-reorder)
+		// rely on landing live.
+		if ( prevLayout === snapshot.desktopLayout ) {
+			layoutDispatcher.refresh();
+		}
+		// Bring the files-layer placements in line with the new
+		// visibility map — promotes dock items onto the wallpaper
+		// and removes hidden server icons from the grid.
+		syncShortcutsWithVisibility( snapshot.itemVisibility );
 		// Cross-bundle SSOT publish — feature bundles + third-party
 		// plugins that imported `@layout` see the change without
 		// having to thread the OsSettings snapshot through.
 		setCurrentLayout( snapshot.desktopLayout );
 	} );
+
+	// Install the files-layer reconciler. Runs an initial sync on a
+	// microtask AND on every files-store change so the server's
+	// page-load hydration of registered icons gets filtered through
+	// the visibility map immediately.
+	installShortcutsSync(
+		() => osSettings.getOsSettingsSnapshot().itemVisibility,
+	);
 
 	// Initial publish so any consumer that reads `getCurrentLayout()`
 	// before the first OS Settings change sees the right value.

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -16,6 +16,7 @@ import { deriveWindowId } from './utils';
 import { __, _n, sprintf } from './i18n';
 import { hashTitleToHue } from './ui/util/hash-hue';
 import { attachDockPeek } from './dock-peek';
+import { openItemVisibilityMenu } from './item-visibility-menu';
 import {
 	resolveNativeUrlRemap,
 	tryNativeUrlRemap,
@@ -239,6 +240,17 @@ export class Dock {
 	private hooksNamespace: string;
 
 	private static instanceCounter = 0;
+
+	/**
+	 * Module-wide "currently-running drag reset" handle. A drag attaches
+	 * its escape hatches (pointermove/up/cancel/blur/visibility) to
+	 * `document`. If the rail re-renders mid-drag (live menu refresh,
+	 * dispatcher refresh after a settings save), the dragged tile is
+	 * destroyed but its document listeners keep firing on detached DOM —
+	 * blocking the next drag. Every new tile's drag setup calls this
+	 * before attaching its own, guaranteeing only one drag is ever live.
+	 */
+	private static activeDragReset: ( () => void ) | null = null;
 
 	/**
 	 * Build the base context object every dock decoration hook
@@ -680,6 +692,15 @@ export class Dock {
 	 * reordered everything into one class).
 	 */
 	private render(): void {
+		// Cancel any in-flight drag — the dragged tile is about to be
+		// destroyed below. Without this its document-level listeners
+		// keep firing on detached DOM and block the next drag.
+		if ( Dock.activeDragReset ) {
+			const prev = Dock.activeDragReset;
+			Dock.activeDragReset = null;
+			prev();
+		}
+
 		// Tear down peeks from the previous render — each tile is about
 		// to be discarded, so its hover listeners would dangle on a
 		// detached node. Idempotent.
@@ -873,6 +894,20 @@ export class Dock {
 			this.openPage( item );
 		} );
 
+		// Right-click → visibility menu. Mounted on the tile (not the
+		// primary button) so a contextmenu inside the badge or the
+		// future submenu chevron still triggers it.
+		tile.addEventListener( 'contextmenu', ( ev: MouseEvent ) => {
+			ev.preventDefault();
+			openItemVisibilityMenu( {
+				x: ev.clientX,
+				y: ev.clientY,
+				id: item.id,
+				title: item.title,
+				surface: 'dock',
+			} );
+		} );
+
 		tile.appendChild( primary );
 
 		this.bindTooltipFiltered( tile, item.title, ctx );
@@ -939,10 +974,399 @@ export class Dock {
 		} );
 		this.peekTeardowns.set( item.id, teardown );
 
+		this.attachDragReorder( tile, item.id );
+
 		return applyFilters< HTMLElement >(
 			HOOKS.DOCK_TILE_ELEMENT,
 			tile,
 			ctx,
+		);
+	}
+
+	/**
+	 * Drag-to-reorder for menu tiles. Fixed slots — no interpolated
+	 * positioning. While dragging:
+	 *
+	 * 1. Pointer down on the primary button starts a tentative drag.
+	 *    Click handling is preserved by requiring movement past a
+	 *    small threshold before we claim the gesture.
+	 * 2. Once claimed, the tile gets a `--dragging` modifier so CSS
+	 *    can lift it visually. Every `pointermove` checks which other
+	 *    menu tile the cursor is currently over; if it's a different
+	 *    tile, we splice the dragged tile in front of it (so adjacent
+	 *    tiles slide into the vacated slot).
+	 * 3. On `pointerup` we read the resulting DOM order, persist the
+	 *    new id list to `dockOrder` via the public settings writer,
+	 *    and the layout-dispatcher subscriber re-applies. Cancellation
+	 *    (Escape, pointercancel) reverts to the original order.
+	 *
+	 * @since 0.25.0
+	 */
+	private attachDragReorder( tile: HTMLElement, itemId: string ): void {
+		const THRESHOLD = 5; // px the pointer must move before claiming.
+		const FLIP_MS = 200;
+		let active = false;
+		let startX = 0;
+		let startY = 0;
+		let originalOrder: string[] = [];
+		let originalNext: ChildNode | null = null;
+		let pointerId = -1;
+		let originRect: DOMRect | null = null;
+		let justDragged = false;
+		// Defensive guard: belt-and-braces cleanup if listeners are
+		// somehow detached without the gesture completing (browser
+		// hands the pointer to another consumer, devtools pause,
+		// a third-party event swallowed our pointerup). Without
+		// this, the tile stays stuck in `--dragging` and the user
+		// can't grab it again because subsequent pointerdowns think
+		// a gesture is already running.
+		const hardReset = (): void => {
+			active = false;
+			tile.classList.remove( 'desktop-mode-dock__item--dragging' );
+			tile.style.transform = '';
+			tile.style.transition = '';
+			document.removeEventListener( 'pointermove', onMove );
+			document.removeEventListener( 'pointerup', onUp );
+			document.removeEventListener( 'pointercancel', onCancel );
+			document.removeEventListener( 'keydown', onKey, true );
+			window.removeEventListener( 'blur', onBlur );
+			document.removeEventListener( 'visibilitychange', onVisibility );
+			pointerId = -1;
+			originRect = null;
+		};
+
+		const isMenuTile = ( el: Element | null ): el is HTMLElement => {
+			return (
+				!! el &&
+				el instanceof HTMLElement &&
+				el.classList.contains( 'desktop-mode-dock__item' ) &&
+				! el.classList.contains( 'desktop-mode-dock__item--system' ) &&
+				!! el.dataset.menuSlug
+			);
+		};
+
+		const eachSiblingTile = ( fn: ( el: HTMLElement ) => void ): void => {
+			for ( const child of Array.from( this.container.children ) ) {
+				if ( child instanceof HTMLElement && child !== tile && isMenuTile( child ) ) {
+					fn( child );
+				}
+			}
+		};
+
+		const snapshotMenuOrder = (): string[] => {
+			const ids: string[] = [];
+			for ( const child of Array.from( this.container.children ) ) {
+				if ( isMenuTile( child ) ) {
+					ids.push( child.dataset.menuSlug as string );
+				}
+			}
+			return ids;
+		};
+
+		/**
+		 * FLIP — animate siblings from their previous rect to their
+		 * new rect. Snapshot deltas, apply inverse transform with no
+		 * transition, then in the next frame remove the transform so
+		 * the transition CSS carries them home.
+		 */
+		const flipSiblings = (
+			prevRects: Map< Element, DOMRect >,
+		): void => {
+			eachSiblingTile( ( sib ) => {
+				const prev = prevRects.get( sib );
+				if ( ! prev ) {
+					return;
+				}
+				const now = sib.getBoundingClientRect();
+				const dx = prev.left - now.left;
+				const dy = prev.top - now.top;
+				if ( Math.abs( dx ) < 0.5 && Math.abs( dy ) < 0.5 ) {
+					return;
+				}
+				sib.style.transition = 'none';
+				sib.style.transform = `translate(${ dx }px, ${ dy }px)`;
+				// Force layout flush so the transform sticks before
+				// we remove it.
+				void sib.offsetHeight;
+				sib.style.transition = `transform ${ FLIP_MS }ms cubic-bezier(0.2, 0.7, 0.3, 1)`;
+				sib.style.transform = '';
+				const onEnd = (): void => {
+					sib.style.transition = '';
+					sib.style.transform = '';
+					sib.removeEventListener( 'transitionend', onEnd );
+				};
+				sib.addEventListener( 'transitionend', onEnd );
+			} );
+		};
+
+		const onMove = ( ev: PointerEvent ): void => {
+			// Filter to the pointer that initiated this gesture so a
+			// second touch / mouse doesn't accidentally drive it.
+			if ( pointerId !== -1 && ev.pointerId !== pointerId ) {
+				return;
+			}
+			if ( ! active ) {
+				const dx = ev.clientX - startX;
+				const dy = ev.clientY - startY;
+				if ( dx * dx + dy * dy < THRESHOLD * THRESHOLD ) {
+					return;
+				}
+				// Claim the gesture.
+				active = true;
+				originalOrder = snapshotMenuOrder();
+				originalNext = tile.nextSibling;
+				originRect = tile.getBoundingClientRect();
+				tile.classList.add( 'desktop-mode-dock__item--dragging' );
+				// Suppress the hover tooltip & peek for the duration.
+				this.tooltip.classList.remove(
+					'desktop-mode-dock__tooltip--visible',
+				);
+			}
+
+			if ( ! originRect ) {
+				return;
+			}
+
+			// Translate the dragged tile by the cursor delta from its
+			// initial press position so it follows the cursor.
+			const dx = ev.clientX - startX;
+			const dy = ev.clientY - startY;
+			tile.style.transform = `translate(${ dx }px, ${ dy }px)`;
+
+			// Hit-test for a sibling under the cursor. The dragged
+			// tile has CSS `pointer-events: none` so it never returns
+			// itself — the deepest non-dragged element wins.
+			const under = document.elementFromPoint( ev.clientX, ev.clientY );
+			const targetTile = under?.closest(
+				'.desktop-mode-dock__item',
+			) as HTMLElement | null;
+			if ( ! targetTile || targetTile === tile ) {
+				return;
+			}
+			if ( ! isMenuTile( targetTile ) ) {
+				return;
+			}
+
+			// Determine which half of the target the cursor is in.
+			// Bottom (horizontal) docks compare X; side (vertical) docks
+			// compare Y.
+			const rect = targetTile.getBoundingClientRect();
+			let insertBefore: boolean;
+			if ( this.orientation === 'bottom' ) {
+				insertBefore = ev.clientX < rect.left + rect.width / 2;
+			} else {
+				insertBefore = ev.clientY < rect.top + rect.height / 2;
+			}
+
+			// Snapshot the BEFORE rects of every non-dragged sibling so
+			// we can FLIP them once the DOM has been reordered.
+			const prevRects = new Map< Element, DOMRect >();
+			eachSiblingTile( ( sib ) => {
+				prevRects.set( sib, sib.getBoundingClientRect() );
+			} );
+
+			let reordered = false;
+			if ( insertBefore ) {
+				if ( targetTile !== tile.nextSibling ) {
+					this.container.insertBefore( tile, targetTile );
+					reordered = true;
+				}
+			} else if ( targetTile.nextSibling !== tile ) {
+				this.container.insertBefore( tile, targetTile.nextSibling );
+				reordered = true;
+			}
+
+			if ( reordered ) {
+				// The dragged tile's in-flow slot moved. Re-base the
+				// cursor anchor to the centre of the new slot so
+				// subsequent translates stay smooth — without this,
+				// the tile would jump by the slot-width on every
+				// swap. We measure with no transform applied so the
+				// rect reflects the true in-flow position.
+				tile.style.transform = '';
+				const fresh = tile.getBoundingClientRect();
+				startX = fresh.left + fresh.width / 2;
+				startY = fresh.top + fresh.height / 2;
+				tile.style.transform = `translate(${
+					ev.clientX - startX
+				}px, ${ ev.clientY - startY }px)`;
+				flipSiblings( prevRects );
+			}
+		};
+
+		const cleanup = (): void => {
+			tile.classList.remove( 'desktop-mode-dock__item--dragging' );
+			tile.style.transform = '';
+			tile.style.transition = '';
+			document.removeEventListener( 'pointermove', onMove );
+			document.removeEventListener( 'pointerup', onUp );
+			document.removeEventListener( 'pointercancel', onCancel );
+			document.removeEventListener( 'keydown', onKey, true );
+			window.removeEventListener( 'blur', onBlur );
+			document.removeEventListener( 'visibilitychange', onVisibility );
+			pointerId = -1;
+			originRect = null;
+			active = false;
+			if ( Dock.activeDragReset === hardReset ) {
+				Dock.activeDragReset = null;
+			}
+		};
+
+		const animateHome = (): void => {
+			// Snap the dragged tile back to its slot with the same
+			// curve the siblings used — covers the "no swap, user
+			// released" case AND the cancellation case.
+			tile.style.transition = `transform ${ FLIP_MS }ms cubic-bezier(0.2, 0.7, 0.3, 1)`;
+			tile.style.transform = '';
+			const onEnd = (): void => {
+				tile.style.transition = '';
+				tile.removeEventListener( 'transitionend', onEnd );
+			};
+			tile.addEventListener( 'transitionend', onEnd );
+		};
+
+		const persistDockOrder = ( finalOrder: string[] ): void => {
+			void itemId;
+			const api = (
+				window as unknown as {
+					wp?: {
+						desktop?: {
+							getOsSettings?: () => {
+								dockOrder: string[];
+							};
+							updateOsSettings?: ( patch: {
+								dockOrder?: string[];
+							} ) => void;
+						};
+					};
+				}
+			).wp?.desktop;
+			if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
+				return;
+			}
+			const existing = api.getOsSettings().dockOrder;
+			const finalSet = new Set( finalOrder );
+			const merged: string[] = [];
+			let injected = false;
+			for ( const id of existing ) {
+				if ( finalSet.has( id ) ) {
+					if ( ! injected ) {
+						merged.push( ...finalOrder );
+						injected = true;
+					}
+					continue;
+				}
+				merged.push( id );
+			}
+			if ( ! injected ) {
+				merged.push( ...finalOrder );
+			}
+			api.updateOsSettings( { dockOrder: merged } );
+		};
+
+		const onUp = ( ev: PointerEvent ): void => {
+			if ( pointerId !== -1 && ev.pointerId !== pointerId ) {
+				return;
+			}
+			if ( ! active ) {
+				cleanup();
+				return;
+			}
+			justDragged = true;
+			const finalOrder = snapshotMenuOrder();
+			animateHome();
+			cleanup();
+
+			const same =
+				finalOrder.length === originalOrder.length &&
+				finalOrder.every( ( id, i ) => id === originalOrder[ i ] );
+			if ( ! same ) {
+				persistDockOrder( finalOrder );
+			}
+			setTimeout( () => {
+				justDragged = false;
+			}, 200 );
+		};
+
+		const onCancel = ( ev?: PointerEvent ): void => {
+			if ( ev && pointerId !== -1 && ev.pointerId !== pointerId ) {
+				return;
+			}
+			if ( active && originalNext !== undefined ) {
+				const prevRects = new Map< Element, DOMRect >();
+				eachSiblingTile( ( sib ) => {
+					prevRects.set( sib, sib.getBoundingClientRect() );
+				} );
+				this.container.insertBefore( tile, originalNext );
+				flipSiblings( prevRects );
+			}
+			animateHome();
+			cleanup();
+		};
+
+		const onKey = ( ev: KeyboardEvent ): void => {
+			if ( ev.key === 'Escape' ) {
+				onCancel();
+			}
+		};
+
+		// Window/tab losing focus or visibility while a drag is in
+		// flight: cancel cleanly so the tile doesn't get stuck in
+		// `--dragging` when the user comes back. The browser may also
+		// silently drop the pointer capture in these cases.
+		const onBlur = (): void => onCancel();
+		const onVisibility = (): void => {
+			if ( document.visibilityState !== 'visible' ) {
+				onCancel();
+			}
+		};
+
+		tile.addEventListener( 'pointerdown', ( ev: PointerEvent ) => {
+			if ( ev.button !== 0 ) {
+				return;
+			}
+			// Cancel any in-flight drag from a previous tile that may
+			// have been orphaned by a rail rebuild. The module-wide
+			// handle calls the OWNER's hardReset, detaching its
+			// document-level listeners — without this, the orphan's
+			// listeners would race ours and the new gesture would
+			// look "stuck" because two parallel drags fight for the
+			// same pointer.
+			if ( Dock.activeDragReset ) {
+				const prev = Dock.activeDragReset;
+				Dock.activeDragReset = null;
+				prev();
+			}
+			// Also reset our own state in case this same tile's
+			// previous gesture didn't clean up.
+			if ( active || pointerId !== -1 ) {
+				hardReset();
+			}
+			startX = ev.clientX;
+			startY = ev.clientY;
+			pointerId = ev.pointerId;
+			active = false;
+			Dock.activeDragReset = hardReset;
+			document.addEventListener( 'pointermove', onMove );
+			document.addEventListener( 'pointerup', onUp );
+			document.addEventListener( 'pointercancel', onCancel );
+			document.addEventListener( 'keydown', onKey, true );
+			window.addEventListener( 'blur', onBlur );
+			document.addEventListener( 'visibilitychange', onVisibility );
+		} );
+
+		// Block the click that immediately follows a drag — without
+		// this, releasing the pointer on the dragged tile (or any
+		// tile, after a reorder) triggers the open-or-focus handler.
+		tile.addEventListener(
+			'click',
+			( ev: MouseEvent ) => {
+				if ( justDragged ) {
+					ev.preventDefault();
+					ev.stopImmediatePropagation();
+				}
+			},
+			true,
 		);
 	}
 
@@ -1257,6 +1681,51 @@ export class Dock {
 	 * only the destination changes.
 	 */
 	private openPage( item: DockItem ): void {
+		// Synthesized dock tiles (created from desktop icons promoted
+		// to the dock via the user's `itemVisibility` settings)
+		// carry id prefix `dock:<icon-id>`. Their native opener
+		// lives on the original `desktop_mode_register_icon` entry —
+		// `window` for a native-window target, `url` otherwise.
+		// Without this branch the click would derive a window id
+		// from an empty URL and silently no-op.
+		if ( item.id.startsWith( 'dock:' ) ) {
+			const iconId = item.id.slice( 5 );
+			const cfg = ( window as unknown as {
+				desktopModeConfig?: { desktopIcons?: Array< {
+					id: string;
+					window?: string;
+					url?: string;
+					title: string;
+					icon: string;
+				} > };
+			} ).desktopModeConfig;
+			const icon = cfg?.desktopIcons?.find( ( i ) => i.id === iconId );
+			if ( icon?.window ) {
+				const wp = ( window as unknown as {
+					wp?: { desktop?: { openWindow?: ( id: string ) => unknown } };
+				} ).wp?.desktop;
+				wp?.openWindow?.( icon.window );
+				return;
+			}
+			if ( icon?.url ) {
+				const baseId = this.deriveWindowId( icon.url );
+				this.windowManager.open( {
+					id: baseId,
+					baseId,
+					url: icon.url,
+					parentUrl: icon.url,
+					title: icon.title,
+					icon: icon.icon.startsWith( 'dashicons-' )
+						? icon.icon
+						: 'dashicons-admin-generic',
+					submenu: [],
+					multi: false,
+				} );
+				return;
+			}
+			return;
+		}
+
 		if ( tryNativeUrlRemap( item.url ) ) {
 			return;
 		}

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -1,0 +1,238 @@
+/**
+ * Right-click context menu for hiding / moving a dock tile or
+ * desktop icon. Mutates the user's `itemVisibility` map via the
+ * public `wp.desktop.updateOsSettings` writer; the layout dispatcher's
+ * settings subscription handles the live re-paint.
+ *
+ * Two callers:
+ *
+ * - `Dock` — attaches a `contextmenu` listener per tile, passes
+ *   `surface: 'dock'`. Menu options: "Hide from dock", "Show on
+ *   desktop instead", "Hide everywhere".
+ * - `renderDesktopIcons` — attaches per icon, passes
+ *   `surface: 'desktop'`. Menu options: "Hide from desktop", "Move
+ *   to dock", "Hide everywhere".
+ *
+ * The `id` passed in is the **rail-prefixed** id as it appears in
+ * the DOM (`'dock:<x>'` / `'desktop:<x>'` for synthesized tiles).
+ * The handler reduces it to the canonical id via
+ * {@link canonicalItemId} before writing the override, so the
+ * visibility map is always keyed by the registered item id.
+ *
+ * @since 0.25.0
+ */
+
+import { __ } from './i18n';
+import './ui/components/wpd-context-menu/wpd-context-menu';
+import { canonicalItemId } from './settings/item-placement';
+import type { ItemVisibility } from './settings/types';
+import type { OsSettingsSnapshot } from './settings/registry';
+
+interface WpDesktopShim {
+	getOsSettings?: () => OsSettingsSnapshot;
+	updateOsSettings?: (
+		patch: Partial< OsSettingsSnapshot >,
+		opts?: { windowId?: string },
+	) => void;
+	openOsSettings?: ( opts?: { tabId?: string } ) => void;
+}
+
+function getApi(): WpDesktopShim | null {
+	const w = window as unknown as { wp?: { desktop?: WpDesktopShim } };
+	return w.wp?.desktop ?? null;
+}
+
+let activeMenu: HTMLElement | null = null;
+
+function closeMenu(): void {
+	if ( activeMenu ) {
+		activeMenu.remove();
+		activeMenu = null;
+	}
+}
+
+function writeVisibility(
+	canonicalId: string,
+	placement: ItemVisibility,
+): void {
+	const api = getApi();
+	if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
+		return;
+	}
+	const snap = api.getOsSettings();
+	const next = { ...snap.itemVisibility };
+	if ( placement === 'both' ) {
+		delete next[ canonicalId ];
+	} else {
+		next[ canonicalId ] = placement;
+	}
+	api.updateOsSettings( { itemVisibility: next } );
+}
+
+export interface OpenItemVisibilityMenuOpts {
+	/** Viewport coordinates the user right-clicked at. */
+	x: number;
+	y: number;
+	/** Item id as it appears in the DOM (may be rail-prefixed). */
+	id: string;
+	/** Display title — used in the OS Settings shortcut option. */
+	title: string;
+	/** Which surface the user right-clicked on. */
+	surface: 'dock' | 'desktop';
+}
+
+/**
+ * Open the visibility menu next to the user's cursor. Idempotent —
+ * a second call closes the previous menu before opening a fresh one.
+ */
+export function openItemVisibilityMenu(
+	opts: OpenItemVisibilityMenuOpts,
+): void {
+	closeMenu();
+
+	const canonical = canonicalItemId( opts.id );
+
+	type MenuOption = {
+		id: string;
+		label: string;
+		icon?: string;
+		danger?: boolean;
+		onPick: () => void;
+	};
+
+	const options: MenuOption[] = [];
+
+	if ( opts.surface === 'dock' ) {
+		options.push( {
+			id: 'hide-from-dock',
+			label: __( 'Hide from dock' ),
+			icon: 'dashicons-hidden',
+			onPick: () => writeVisibility( canonical, 'desktop' ),
+		} );
+		options.push( {
+			id: 'show-on-desktop-too',
+			label: __( 'Also show on desktop' ),
+			icon: 'dashicons-desktop',
+			onPick: () => writeVisibility( canonical, 'both' ),
+		} );
+	} else {
+		options.push( {
+			id: 'hide-from-desktop',
+			label: __( 'Hide from desktop' ),
+			icon: 'dashicons-hidden',
+			onPick: () => writeVisibility( canonical, 'dock' ),
+		} );
+		options.push( {
+			id: 'show-on-dock-too',
+			label: __( 'Also show on dock' ),
+			icon: 'dashicons-menu',
+			onPick: () => writeVisibility( canonical, 'both' ),
+		} );
+	}
+	options.push( {
+		id: 'hide-everywhere',
+		label: __( 'Hide everywhere' ),
+		icon: 'dashicons-no',
+		danger: true,
+		onPick: () => writeVisibility( canonical, 'hidden' ),
+	} );
+
+	options.push( {
+		id: 'open-settings',
+		label: __( 'Apps & Icons settings…' ),
+		icon: 'dashicons-admin-generic',
+		onPick: () => {
+			const api = getApi();
+			api?.openOsSettings?.( { tabId: 'apps-icons' } );
+		},
+	} );
+
+	const menu = document.createElement( 'wpd-context-menu' );
+	menu.setAttribute( 'open', '' );
+	menu.classList.add( 'desktop-mode-item-visibility-menu' );
+	( menu as HTMLElement ).dataset.itemId = opts.id;
+	menu.style.position = 'fixed';
+	// Off-screen first so we can measure size before placement.
+	menu.style.left = '-9999px';
+	menu.style.top = '-9999px';
+	menu.style.visibility = 'hidden';
+	menu.style.zIndex = '10000';
+
+	const byId = new Map< string, MenuOption >();
+	for ( const opt of options ) {
+		byId.set( opt.id, opt );
+		const node = document.createElement( 'wpd-context-menu-option' );
+		node.setAttribute( 'value', opt.id );
+		if ( opt.icon ) {
+			node.setAttribute( 'icon', opt.icon );
+		}
+		if ( opt.danger ) {
+			node.setAttribute( 'danger', '' );
+		}
+		node.textContent = opt.label;
+		menu.appendChild( node );
+	}
+
+	menu.addEventListener( 'wpd-context-menu-pick', ( e: Event ) => {
+		const detail = ( e as CustomEvent< { id: string; value: string } > ).detail;
+		const opt = byId.get( detail?.id );
+		closeMenu();
+		try {
+			opt?.onPick();
+		} catch {
+			/* swallow — bad opener shouldn't crash the shell */
+		}
+	} );
+
+	document.body.appendChild( menu );
+	activeMenu = menu;
+
+	// Measure now that the menu is in the DOM, then position it.
+	//
+	// Dock right-clicks ALWAYS anchor the menu's bottom edge at the
+	// cursor (i.e., the menu opens upward). The dock hugs a viewport
+	// edge — bottom for the taskbar, left/right for side docks — so
+	// anchoring below the cursor reliably pushes the menu off-
+	// screen. Desktop-icon right-clicks default to opening below
+	// the cursor (natural OS-style menu) and only flip up when
+	// they would overflow the viewport.
+	const rect = menu.getBoundingClientRect();
+	const margin = 8;
+	let left = opts.x;
+	let top: number;
+	if ( opts.surface === 'dock' ) {
+		top = Math.max( margin, opts.y - rect.height - margin );
+	} else {
+		top = opts.y;
+		if ( top + rect.height + margin > window.innerHeight ) {
+			top = Math.max( margin, opts.y - rect.height );
+		}
+	}
+	if ( left + rect.width + margin > window.innerWidth ) {
+		left = Math.max( margin, opts.x - rect.width );
+	}
+	menu.style.left = `${ left }px`;
+	menu.style.top = `${ top }px`;
+	menu.style.visibility = '';
+
+	// Outside-click + Escape dismisser.
+	const onOutside = ( ev: MouseEvent ): void => {
+		if ( ! activeMenu ) {
+			return;
+		}
+		if ( ! activeMenu.contains( ev.target as Node ) ) {
+			closeMenu();
+			document.removeEventListener( 'mousedown', onOutside, true );
+			document.removeEventListener( 'keydown', onKey, true );
+		}
+	};
+	const onKey = ( ev: KeyboardEvent ): void => {
+		if ( ev.key === 'Escape' ) {
+			closeMenu();
+			document.removeEventListener( 'mousedown', onOutside, true );
+			document.removeEventListener( 'keydown', onKey, true );
+		}
+	};
+	document.addEventListener( 'mousedown', onOutside, true );
+	document.addEventListener( 'keydown', onKey, true );
+}

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -184,6 +184,8 @@ export const DEFAULTS: OsSettingsState = {
 	// `activate_plugins` server-side, so flipping this off only
 	// affects users who could see the Plugins tile anyway.
 	nativePluginsEnabled: true,
+	itemVisibility: {},
+	dockOrder: [],
 };
 
 /**

--- a/src/settings/desktop-shortcuts-sync.ts
+++ b/src/settings/desktop-shortcuts-sync.ts
@@ -1,0 +1,238 @@
+/**
+ * Reconcile the user's `itemVisibility` map with the modern
+ * files-layer placements store so dock-only items can be promoted
+ * onto the wallpaper grid and server-registered desktop icons can
+ * be hidden from it.
+ *
+ * Two flows:
+ *
+ * 1. **Promote a dock item to the desktop.** For every admin-menu
+ *    item whose visibility is `'desktop'` or `'both'`, upsert a
+ *    synthetic `shortcut` placement into the files store. The
+ *    placement carries a deterministic negative id (hashed from the
+ *    dock-item id) so re-syncs are idempotent. Position defaults
+ *    to (0, 0) — the layer's `snapToEmptyCell` finds an open slot
+ *    on first paint.
+ *
+ * 2. **Hide a server-registered icon.** For every icon in
+ *    `config.desktopIcons` whose visibility is `'dock'` or
+ *    `'hidden'`, remove the corresponding placement from the files
+ *    store. The server still hydrates it on the next page load —
+ *    this module re-applies on every change, so the icon disappears
+ *    again immediately.
+ *
+ * Synthetic placements aren't persisted via REST; they live only
+ * in the JS store. The source of truth is `itemVisibility`, so
+ * promotion survives reloads even though placement positions don't.
+ * If/when we want true position persistence for promoted items, a
+ * follow-up can swap the in-memory upsert for `createPlacement` +
+ * track the assigned real id in a side-map on the user meta.
+ *
+ * @since 0.25.0
+ */
+
+import { filesApi } from '../desktop-files';
+import type { RestPlacementShape } from '../desktop-files/rest';
+import type { DesktopConfig, DesktopIconServerEntry, DockItemConfig } from '../types';
+import type { ItemVisibility, OsSettingsState } from './types';
+
+/** Marker on `placement.meta` for shortcuts we synthesized. */
+const SYNTH_META_KEY = '__synthFromDockItem';
+
+/** Deterministic negative id from a string. */
+function hashToNegativeId( s: string ): number {
+	// Plain multiplicative hash — no bitwise ops so the result stays
+	// safely within JS's number range without needing >>> coercion.
+	// `Math.abs` + modulo into a positive range, then negate so we
+	// never collide with the REST layer's positive ids.
+	let h = 0;
+	for ( let i = 0; i < s.length; i++ ) {
+		h = ( h * 31 + s.charCodeAt( i ) ) % 0x7fffffff;
+	}
+	return -( h + 1 );
+}
+
+/** Build a synthetic placement representing a promoted dock item. */
+function buildSyntheticPlacement(
+	item: DockItemConfig,
+): RestPlacementShape {
+	return {
+		id: hashToNegativeId( item.id ),
+		parentId: 0,
+		x: 0,
+		y: 0,
+		sortOrder: 9999,
+		updatedAtMs: Date.now(),
+		meta: { [ SYNTH_META_KEY ]: item.id },
+		file: {
+			type: 'shortcut',
+			ref: `dock-promoted:${ item.id }`,
+			title: item.title,
+			icon: item.icon,
+			previewUrl: '',
+			exists: true,
+			// The shortcut opener (built-in-openers.ts) reads these
+			// off the file shape — `shortcutUrl` is what a dock-item
+			// promotion naturally has.
+			shortcutUrl: item.url,
+		},
+	};
+}
+
+/** Read the live dock items (from the dispatcher when available). */
+function readDockItems(): DockItemConfig[] {
+	const api = ( window as unknown as {
+		wp?: {
+			desktop?: {
+				getMenuItems?: () => Array< {
+					id: string;
+					title: string;
+					icon: string;
+					url: string;
+					badge?: number;
+					submenu?: { title: string; url: string }[];
+				} >;
+			};
+		};
+	} ).wp?.desktop;
+	if ( api?.getMenuItems ) {
+		const items = api.getMenuItems();
+		return items.map( ( i ) => ( {
+			id: i.id,
+			title: i.title,
+			icon: i.icon,
+			url: i.url,
+			badge: i.badge ?? 0,
+			submenu: i.submenu ?? [],
+		} ) );
+	}
+	const cfg = ( window as unknown as { desktopModeConfig?: DesktopConfig } )
+		.desktopModeConfig;
+	return cfg?.dockItems ?? [];
+}
+
+function readServerIcons(): DesktopIconServerEntry[] {
+	const cfg = ( window as unknown as { desktopModeConfig?: DesktopConfig } )
+		.desktopModeConfig;
+	return cfg?.desktopIcons ?? [];
+}
+
+/** Reentrancy guard so our own store writes don't trigger re-sync. */
+let reentrant = false;
+
+/**
+ * Bring the files store in line with the current
+ * {@link OsSettingsState.itemVisibility} map.
+ */
+export function syncShortcutsWithVisibility(
+	visibility: Record< string, ItemVisibility >,
+): void {
+	if ( reentrant ) {
+		return;
+	}
+	reentrant = true;
+	try {
+		const dockItems = readDockItems();
+		const serverIcons = readServerIcons();
+
+		const state = filesApi.store.getState();
+		const root = state.placementsByFolder.get( 0 ) ?? [];
+
+		// Index current synthetic placements by the source dock-item id.
+		const currentSynth = new Map< string, RestPlacementShape >();
+		for ( const p of root ) {
+			const sourceId = ( p.meta ?? null ) &&
+				typeof p.meta === 'object'
+				? ( p.meta as Record< string, unknown > )[ SYNTH_META_KEY ]
+				: null;
+			if ( typeof sourceId === 'string' ) {
+				currentSynth.set( sourceId, p );
+			}
+		}
+
+		// Index real placements by icon-id ref. Server-registered
+		// shortcuts have `file.ref` equal to the registered icon id
+		// (PHP's serializer writes the icon's own id into the ref
+		// field). Plugin authors creating their own shortcuts via
+		// REST may use other refs — those are ignored here.
+		const realByRef = new Map< string, RestPlacementShape >();
+		const registeredIconIds = new Set< string >(
+			serverIcons.map( ( i ) => i.id ),
+		);
+		for ( const p of root ) {
+			const ref = p?.file?.ref;
+			if ( typeof ref === 'string' && registeredIconIds.has( ref ) ) {
+				realByRef.set( ref, p );
+			}
+		}
+
+		// 1. Promote dock items.
+		const desiredSynth = new Set< string >();
+		for ( const item of dockItems ) {
+			const placement = visibility[ item.id ];
+			if ( placement === 'desktop' || placement === 'both' ) {
+				desiredSynth.add( item.id );
+				if ( ! currentSynth.has( item.id ) ) {
+					filesApi.store.upsertPlacement(
+						buildSyntheticPlacement( item ),
+					);
+				}
+			}
+		}
+		// Remove synthetic placements that are no longer wanted.
+		for ( const [ sourceId, p ] of currentSynth ) {
+			if ( ! desiredSynth.has( sourceId ) ) {
+				filesApi.store.removePlacement( p.id );
+			}
+		}
+
+		// 2. Hide server-registered shortcuts that the user has
+		//    suppressed (placement = 'dock' or 'hidden').
+		for ( const icon of serverIcons ) {
+			const placement = visibility[ icon.id ];
+			if ( placement === 'dock' || placement === 'hidden' ) {
+				const p = realByRef.get( icon.id );
+				if ( p ) {
+					filesApi.store.removePlacement( p.id );
+				}
+			}
+		}
+	} finally {
+		reentrant = false;
+	}
+}
+
+/**
+ * Wire up the live reconciliation. Called once during shell boot.
+ * Re-syncs whenever:
+ *
+ * - The files store changes (server hydration re-injects a hidden
+ *   icon — we drop it again).
+ * - The user updates visibility via OS Settings or the right-click
+ *   menu (handled by an external caller passing the new snapshot).
+ *
+ * Returns a teardown function for tests / hot-reload.
+ */
+export function installShortcutsSync(
+	getVisibility: () => Record< string, ItemVisibility >,
+): () => void {
+	// Initial reconciliation — runs on a microtask so any
+	// just-mounted desktop icons from the server hydration are in
+	// the store before we filter.
+	queueMicrotask( () => syncShortcutsWithVisibility( getVisibility() ) );
+
+	// Re-run on every store change so server-driven hydration
+	// (e.g. a refresh fetching the full placements list) gets
+	// filtered. The reentrancy guard prevents our own writes from
+	// triggering an infinite loop.
+	const off = filesApi.store.subscribe( () => {
+		syncShortcutsWithVisibility( getVisibility() );
+	} );
+
+	return off;
+}
+
+export type OsSettingsVisibility = Pick<
+	OsSettingsState,
+	'itemVisibility'
+>;

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -70,6 +70,7 @@ import type {
 import { buildAboutSection } from './sections/about';
 import { buildAccentSection } from './sections/accent';
 import { buildAiSection } from './sections/ai';
+import { buildAppsIconsSection } from './sections/apps-icons';
 import { buildDesktopLayoutSection } from './sections/desktop-layout';
 import { buildDockSizeSection } from './sections/dock-size';
 import { buildExtendedSection } from './sections/extended';
@@ -146,6 +147,8 @@ export class OsSettings implements SettingsCtx {
 			nativePagesEnabled: this.state.nativePagesEnabled,
 			nativeUsersEnabled: this.state.nativeUsersEnabled,
 			nativePluginsEnabled: this.state.nativePluginsEnabled,
+			itemVisibility: { ...this.state.itemVisibility },
+			dockOrder: this.state.dockOrder.slice(),
 		};
 	}
 
@@ -385,6 +388,16 @@ export class OsSettings implements SettingsCtx {
 				>`,
 				panel: html`<wpd-tabpanel for="features">
 					<wpd-panel>${ buildFeaturesSection( this ) }</wpd-panel>
+				</wpd-tabpanel>`,
+			},
+			{
+				id: 'apps-icons',
+				order: 22,
+				tab: html`<wpd-tab value="apps-icons"
+					>${ __( 'Apps & Icons' ) }</wpd-tab
+				>`,
+				panel: html`<wpd-tabpanel for="apps-icons">
+					<wpd-panel>${ buildAppsIconsSection( this ) }</wpd-panel>
 				</wpd-tabpanel>`,
 			},
 		];

--- a/src/settings/item-placement.ts
+++ b/src/settings/item-placement.ts
@@ -1,0 +1,308 @@
+/**
+ * Item-placement helpers — apply the user's per-item visibility
+ * preferences and dock ordering to the raw dock + desktop-icon lists
+ * the layout dispatcher receives.
+ *
+ * Visibility model (matches OsSettingsState.itemVisibility):
+ *
+ * - `'both'`    — item appears on both dock and desktop. Synthesized
+ *                 across rails when only one carries native metadata.
+ * - `'dock'`    — only on the dock. Synthesized when natively desktop-
+ *                 only. Suppressed from the desktop grid.
+ * - `'desktop'` — only on the wallpaper. Synthesized when natively
+ *                 dock-only. Suppressed from the dock.
+ * - `'hidden'`  — suppressed from every shell surface.
+ *
+ * Missing key in the visibility map means "no override" — item appears
+ * on its native rail and nowhere else.
+ *
+ * @since 0.25.0
+ */
+
+import type { DockItem } from '../dock';
+import type { DesktopIconServerEntry } from '../types';
+import type { ItemVisibility, OsSettingsState } from './types';
+
+/**
+ * The two rails a placeable item can live on. Items registered through
+ * the admin menu pipeline default to `'dock'`; items registered via
+ * `desktop_mode_register_icon()` default to `'desktop'`.
+ */
+export type NativeRail = 'dock' | 'desktop';
+
+/**
+ * Union view of a single shell-surface item. Used by the OS Settings
+ * "Apps & Icons" tab to list every placeable thing in one table
+ * regardless of which rail registered it.
+ */
+export interface PlaceableItem {
+	id: string;
+	title: string;
+	icon: string;
+	/** Where the item was originally registered. Drives the effective default. */
+	nativeRail: NativeRail;
+	/** Resolved placement after applying the user's override (defaults if absent). */
+	placement: ItemVisibility;
+}
+
+/**
+ * The id used for an item synthesized into the OPPOSITE rail. Kept
+ * deterministic so re-renders address the same DOM node — the dock
+ * uses `desktop:<id>` for a tile synthesized from a desktop icon, and
+ * the desktop icon grid uses `dock:<id>` for an icon synthesized from
+ * a dock item. The originating rail keeps the bare id.
+ */
+function synthDockId( desktopIconId: string ): string {
+	return `desktop:${ desktopIconId }`;
+}
+function synthIconId( dockItemId: string ): string {
+	return `dock:${ dockItemId }`;
+}
+
+/**
+ * Strip the synthesis prefix to recover the user-facing id used as
+ * the key in the visibility map. Right-click handlers on either rail
+ * call this before reading or writing the override.
+ */
+export function canonicalItemId( id: string ): string {
+	if ( id.startsWith( 'dock:' ) ) {
+		return id.slice( 5 );
+	}
+	if ( id.startsWith( 'desktop:' ) ) {
+		return id.slice( 8 );
+	}
+	return id;
+}
+
+/**
+ * Resolve the effective placement for an item id given its native
+ * rail. Returns the user override when present, otherwise the
+ * implicit default ('dock' for dock-native, 'desktop' for desktop-
+ * native) — never 'both' as a fallback, since an unconfigured item
+ * does not auto-duplicate across rails.
+ */
+export function resolvePlacement(
+	id: string,
+	nativeRail: NativeRail,
+	visibility: Record< string, ItemVisibility >,
+): ItemVisibility {
+	const override = visibility[ id ];
+	if ( override ) {
+		return override;
+	}
+	return nativeRail;
+}
+
+function shouldShowOnDock( placement: ItemVisibility ): boolean {
+	return placement === 'dock' || placement === 'both';
+}
+
+function shouldShowOnDesktop( placement: ItemVisibility ): boolean {
+	return placement === 'desktop' || placement === 'both';
+}
+
+/**
+ * Apply visibility + ordering to a raw `DockItem[]` list. The result:
+ *
+ * 1. Items whose effective placement excludes the dock are filtered
+ *    out.
+ * 2. Desktop-native icons whose effective placement includes the dock
+ *    are synthesized into placeholder `DockItem`s and appended (with
+ *    `id: 'desktop:<icon-id>'` so live re-renders keep their DOM
+ *    handle stable).
+ * 3. The combined list is reordered to match `dockOrder`. Ids not in
+ *    the order list keep their relative position and render after the
+ *    explicitly-ordered ones, preserving the server-supplied order.
+ */
+export function applyDockPlacement(
+	dockItems: DockItem[],
+	desktopIcons: DesktopIconServerEntry[],
+	settings: Pick< OsSettingsState, 'itemVisibility' | 'dockOrder' >,
+	/**
+	 * Native-window ids ALREADY mounted on the dock as framework
+	 * system tiles (e.g. Recycle Bin's taskbar-placement window
+	 * registration, plugin-owned native-window launchers). When an
+	 * icon's `window` field is in this set, skip the synthesis —
+	 * the dock would otherwise paint the same target twice.
+	 *
+	 * @since 0.25.0
+	 */
+	dockedNativeWindows?: ReadonlySet< string >,
+): DockItem[] {
+	const visibility = settings.itemVisibility;
+	const order = settings.dockOrder;
+
+	// 1. Filter native dock items by placement.
+	const kept: DockItem[] = [];
+	for ( const item of dockItems ) {
+		const placement = resolvePlacement( item.id, 'dock', visibility );
+		if ( shouldShowOnDock( placement ) ) {
+			kept.push( item );
+		}
+	}
+
+	// 2. Synthesize dock tiles for desktop icons promoted to the
+	//    dock, EXCEPT those whose target native window is already
+	//    on the dock as a framework system tile (Recycle Bin et al).
+	for ( const icon of desktopIcons ) {
+		const placement = resolvePlacement( icon.id, 'desktop', visibility );
+		if ( ! shouldShowOnDock( placement ) ) {
+			continue;
+		}
+		if (
+			icon.window &&
+			dockedNativeWindows &&
+			dockedNativeWindows.has( icon.window )
+		) {
+			continue;
+		}
+		kept.push( {
+			id: synthIconId( icon.id ),
+			title: icon.title,
+			icon: icon.icon,
+			url: icon.url || '',
+			badge: 0,
+			submenu: [],
+			isCore: false,
+		} );
+	}
+
+	// 3. Reorder.
+	return applyOrder( kept, order );
+}
+
+/**
+ * Apply visibility to a raw desktop-icon list. Filters out icons
+ * suppressed from the desktop, then synthesizes new icons for any
+ * dock-native items promoted to the wallpaper.
+ *
+ * The synthesized id prefix (`'dock:'`) lets right-click handlers on
+ * the wallpaper recover the original dock-item id via
+ * {@link canonicalItemId} when writing the visibility override.
+ */
+export function applyDesktopPlacement(
+	desktopIcons: DesktopIconServerEntry[],
+	dockItems: DockItem[],
+	visibility: Record< string, ItemVisibility >,
+): DesktopIconServerEntry[] {
+	const out: DesktopIconServerEntry[] = [];
+
+	for ( const icon of desktopIcons ) {
+		const placement = resolvePlacement( icon.id, 'desktop', visibility );
+		if ( shouldShowOnDesktop( placement ) ) {
+			out.push( icon );
+		}
+	}
+
+	let synthIndex = 0;
+	for ( const item of dockItems ) {
+		const placement = resolvePlacement( item.id, 'dock', visibility );
+		if ( ! shouldShowOnDesktop( placement ) ) {
+			continue;
+		}
+		out.push( {
+			id: synthDockId( item.id ),
+			title: item.title,
+			icon: item.icon,
+			window: '',
+			url: item.url || '',
+			// Place synthesized dock-promoted icons after server-registered
+			// ones. Stable ordering by source-list index inside the bucket.
+			position: 2000 + synthIndex++,
+		} );
+	}
+
+	return out;
+}
+
+/**
+ * Reorder a flat item list to match an explicit id order. Ids not in
+ * `order` keep their relative source position and render after the
+ * explicitly-ordered slice.
+ *
+ * Exported for the dock drag-to-reorder handler: it splices an id to
+ * a new index and pipes the result through `applyOrder` to render the
+ * intermediate state during a drag without committing to state until
+ * drop.
+ */
+export function applyOrder< T extends { id: string } >(
+	items: T[],
+	order: ReadonlyArray< string >,
+): T[] {
+	if ( order.length === 0 || items.length <= 1 ) {
+		return items;
+	}
+	const byId = new Map< string, T >();
+	for ( const item of items ) {
+		byId.set( item.id, item );
+	}
+	const out: T[] = [];
+	const placed = new Set< string >();
+	for ( const id of order ) {
+		const item = byId.get( id );
+		if ( item ) {
+			out.push( item );
+			placed.add( id );
+		}
+	}
+	for ( const item of items ) {
+		if ( ! placed.has( item.id ) ) {
+			out.push( item );
+		}
+	}
+	return out;
+}
+
+/**
+ * Build the union list shown in the OS Settings → Apps & Icons tab.
+ * Dock items first (preserving server order), then desktop icons that
+ * don't share an id with a dock item. The resolved `placement` on
+ * each entry is what the picker pre-selects.
+ */
+export function listPlaceableItems(
+	dockItems: DockItem[],
+	desktopIcons: DesktopIconServerEntry[],
+	visibility: Record< string, ItemVisibility >,
+): PlaceableItem[] {
+	const out: PlaceableItem[] = [];
+	const seen = new Set< string >();
+
+	for ( const item of dockItems ) {
+		if ( seen.has( item.id ) ) {
+			continue;
+		}
+		seen.add( item.id );
+		out.push( {
+			id: item.id,
+			title: item.title,
+			icon: item.icon,
+			nativeRail: 'dock',
+			placement: resolvePlacement( item.id, 'dock', visibility ),
+		} );
+	}
+
+	for ( const icon of desktopIcons ) {
+		if ( seen.has( icon.id ) ) {
+			continue;
+		}
+		seen.add( icon.id );
+		out.push( {
+			id: icon.id,
+			title: icon.title,
+			icon: icon.icon,
+			nativeRail: 'desktop',
+			placement: resolvePlacement( icon.id, 'desktop', visibility ),
+		} );
+	}
+
+	// Alphabetical by display title — the OS Settings → Apps & Icons
+	// list is a flat picker, so the user's reading order is the
+	// natural sort. `localeCompare` with the `'base'` sensitivity
+	// folds case + accents so "WooCommerce" and "woocommerce" land
+	// adjacently regardless of how the plugin registered its label.
+	out.sort( ( a, b ) =>
+		a.title.localeCompare( b.title, undefined, { sensitivity: 'base' } ),
+	);
+
+	return out;
+}

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -102,6 +102,23 @@ export interface OsSettingsSnapshot {
 	 * @since 0.9.0
 	 */
 	nativePluginsEnabled: boolean;
+	/**
+	 * Per-item placement preferences. Map of item id → one of
+	 * `'both' | 'dock' | 'desktop' | 'hidden'`. Missing keys mean
+	 * "use the item's native rail." See
+	 * {@link OsSettingsState.itemVisibility} for full semantics.
+	 *
+	 * @since 0.25.0
+	 */
+	itemVisibility: Record< string, 'both' | 'dock' | 'desktop' | 'hidden' >;
+	/**
+	 * User-defined dock ordering. Ordered list of item ids; ids absent
+	 * from the list render after the listed ones in server-supplied
+	 * order.
+	 *
+	 * @since 0.25.0
+	 */
+	dockOrder: string[];
 }
 
 export interface SettingsTabRenderCtx {

--- a/src/settings/sections/apps-icons.ts
+++ b/src/settings/sections/apps-icons.ts
@@ -1,0 +1,164 @@
+/**
+ * Apps & Icons section — per-item placement preferences.
+ *
+ * Lists every dock item + desktop icon registered in this admin (the
+ * dispatcher's view via `getMenuItems()` and `desktopModeConfig.
+ * desktopIcons`). For each row the user picks where the item should
+ * appear: on the dock, on the wallpaper, on both surfaces, or
+ * nowhere. The choice writes to `state.itemVisibility` and the layout
+ * dispatcher's settings subscription refreshes the rails live.
+ *
+ * @since 0.25.0
+ */
+
+import { __ } from '../../i18n';
+import { html, render } from '../../ui/core';
+import { renderIcon } from '../../icon';
+import type { ItemVisibility, SettingsCtx } from '../types';
+import { listPlaceableItems } from '../item-placement';
+import type { DesktopConfig } from '../../types';
+import type { DockItem } from '../../dock';
+
+/** Read the live dock item list — prefer the live shell API when present. */
+function readDockItems(): DockItem[] {
+	const api = ( window as unknown as {
+		wp?: { desktop?: { getMenuItems?: () => DockItem[] } };
+	} ).wp?.desktop;
+	if ( api && typeof api.getMenuItems === 'function' ) {
+		return api.getMenuItems();
+	}
+	// Fallback: the server-shipped list from the boot payload.
+	const cfg = ( window as unknown as { desktopModeConfig?: DesktopConfig } )
+		.desktopModeConfig;
+	const raw = cfg?.dockItems ?? [];
+	return raw.map( ( i ) => ( {
+		id: i.id,
+		title: i.title,
+		icon: i.icon,
+		url: i.url,
+		badge: i.badge,
+		submenu: i.submenu,
+		multi: i.multi,
+		isCore: i.isCore,
+	} ) );
+}
+
+function readDesktopIcons(): import( '../../types' ).DesktopIconServerEntry[] {
+	const cfg = ( window as unknown as { desktopModeConfig?: DesktopConfig } )
+		.desktopModeConfig;
+	return cfg?.desktopIcons ?? [];
+}
+
+interface PlacementOption {
+	id: ItemVisibility;
+	label: string;
+}
+
+/**
+ * Available placement options. Same set for every row — both rails
+ * support synthesis now: dock-native items are projected onto the
+ * wallpaper as synthetic shortcut placements via the files-layer
+ * sync, and desktop-native icons are synthesized as dock tiles by
+ * the layout dispatcher.
+ */
+function getPlacementOptions(): PlacementOption[] {
+	return [
+		{ id: 'desktop', label: __( 'On the desktop' ) },
+		{ id: 'dock', label: __( 'On the dock' ) },
+		{ id: 'both', label: __( 'On both' ) },
+		{ id: 'hidden', label: __( 'Hidden' ) },
+	];
+}
+
+export function buildAppsIconsSection( ctx: SettingsCtx ): HTMLElement {
+	const wrapper = document.createElement( 'div' );
+
+	const setPlacement = ( id: string, placement: ItemVisibility ): void => {
+		const next = { ...ctx.state.itemVisibility };
+		next[ id ] = placement;
+		ctx.state.itemVisibility = next;
+		ctx.save();
+		paint();
+	};
+
+	const onPlacementChange =
+		( id: string ) =>
+			( e: Event ): void => {
+				const detail = ( e as CustomEvent ).detail as { value?: string };
+				const next = detail?.value;
+				if (
+					next === 'both' ||
+					next === 'dock' ||
+					next === 'desktop' ||
+					next === 'hidden'
+				) {
+					setPlacement( id, next );
+				}
+			};
+
+	const paint = (): void => {
+		const dockItems = readDockItems();
+		const desktopIcons = readDesktopIcons();
+		const rows = listPlaceableItems(
+			dockItems,
+			desktopIcons,
+			ctx.state.itemVisibility,
+		);
+
+		render(
+			html`
+				<wpd-section
+					heading=${ __( 'Apps & Icons' ) }
+					description=${ __(
+						'Choose where each app shortcut shows up — on the dock, on the desktop wallpaper, both, or hidden entirely. Changes apply instantly to the running shell.',
+					) }
+				>
+					${ rows.length === 0
+						? html`<wpd-empty-state
+								heading=${ __( 'No apps registered yet' ) }
+								description=${ __(
+									'Plugins and the admin menu will appear here once they’re registered.',
+								) }
+							></wpd-empty-state>`
+						: html`<div class="desktop-mode-apps-icons__list">
+								${ rows.map(
+									( row ) =>
+										html`<div
+											class="desktop-mode-apps-icons__row"
+											data-item-id=${ row.id }
+										>
+											<div class="desktop-mode-apps-icons__identity">
+												${ renderIcon( row.icon, {
+													title: row.title,
+													className:
+														'desktop-mode-apps-icons__icon',
+												} ) }
+												<div class="desktop-mode-apps-icons__title">
+													${ row.title }
+												</div>
+											</div>
+											<wpd-select
+												label=${ __( 'Show in' ) }
+												value=${ row.placement }
+												@wpd-pick=${ onPlacementChange( row.id ) }
+											>
+												${ getPlacementOptions().map(
+													( o ) =>
+														html`<wpd-option
+															value=${ o.id }
+															>${ o.label }</wpd-option
+														>`,
+												) }
+											</wpd-select>
+										</div>`,
+								) }
+							</div>` }
+				</wpd-section>
+			`,
+			wrapper,
+		);
+	};
+
+	paint();
+	return wrapper;
+}

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -152,7 +152,62 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 			typeof parsed.nativePluginsEnabled === 'boolean'
 				? parsed.nativePluginsEnabled
 				: DEFAULTS.nativePluginsEnabled,
+		itemVisibility: sanitizeItemVisibility( parsed.itemVisibility ),
+		dockOrder: sanitizeDockOrder( parsed.dockOrder ),
 	};
+}
+
+function sanitizeItemVisibility(
+	raw: unknown,
+): Record< string, import( './types' ).ItemVisibility > {
+	if ( ! raw || typeof raw !== 'object' || Array.isArray( raw ) ) {
+		return {};
+	}
+	const allowed: ReadonlyArray< import( './types' ).ItemVisibility > = [
+		'both',
+		'dock',
+		'desktop',
+		'hidden',
+	];
+	const out: Record< string, import( './types' ).ItemVisibility > = {};
+	let count = 0;
+	for ( const [ k, v ] of Object.entries( raw as Record< string, unknown > ) ) {
+		if ( count >= 256 ) {
+			break;
+		}
+		if ( typeof k !== 'string' || k === '' ) {
+			continue;
+		}
+		if ( typeof v !== 'string' ) {
+			continue;
+		}
+		const placement = v as import( './types' ).ItemVisibility;
+		if ( ! allowed.includes( placement ) ) {
+			continue;
+		}
+		out[ k ] = placement;
+		count++;
+	}
+	return out;
+}
+
+function sanitizeDockOrder( raw: unknown ): string[] {
+	if ( ! Array.isArray( raw ) ) {
+		return [];
+	}
+	const out: string[] = [];
+	const seen = new Set< string >();
+	for ( const id of raw ) {
+		if ( typeof id !== 'string' || id === '' || seen.has( id ) ) {
+			continue;
+		}
+		seen.add( id );
+		out.push( id );
+		if ( out.length >= 256 ) {
+			break;
+		}
+	}
+	return out;
 }
 
 // -----------------------------------------------------------------------
@@ -206,6 +261,8 @@ function _cloneState( state: OsSettingsState ): OsSettingsState {
 		customImage: state.customImage ? { ...state.customImage } : null,
 		ai: { ...state.ai, apiKeys: { ...state.ai.apiKeys } },
 		nativePostsHiddenColumns: state.nativePostsHiddenColumns.slice(),
+		itemVisibility: { ...state.itemVisibility },
+		dockOrder: state.dockOrder.slice(),
 	};
 }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -175,7 +175,39 @@ export interface OsSettingsState {
 	 * @since 0.9.0
 	 */
 	nativePluginsEnabled: boolean;
+	/**
+	 * Per-item placement preference. Maps an item id (dock-item slug or
+	 * registered desktop-icon id) to one of:
+	 *   - `'both'`    — show on both dock and desktop.
+	 *   - `'dock'`    — show only on the dock.
+	 *   - `'desktop'` — show only on the wallpaper.
+	 *   - `'hidden'`  — hide from every shell surface.
+	 *
+	 * Missing keys mean "no override" — items use whichever rail they
+	 * natively live on. The `'both'` value is never persisted (the
+	 * server drops it on save) so the map stays compact.
+	 *
+	 * @since 0.25.0
+	 */
+	itemVisibility: Record< string, ItemVisibility >;
+	/**
+	 * User-defined dock ordering. Ordered list of item ids. Ids not in
+	 * the list keep their server-supplied position and render appended
+	 * after the listed ones. Unknown ids (deactivated plugin) survive
+	 * the round-trip in case the plugin comes back.
+	 *
+	 * @since 0.25.0
+	 */
+	dockOrder: string[];
 }
+
+/**
+ * Allowed values for {@link OsSettingsState.itemVisibility}. See the
+ * field docblock for semantics.
+ *
+ * @since 0.25.0
+ */
+export type ItemVisibility = 'both' | 'dock' | 'desktop' | 'hidden';
 
 /**
  * Subset of the REST media item we actually use. `_fields` on the


### PR DESCRIPTION
- Introduced `itemVisibility` and `dockOrder` properties to `OsSettingsState` for managing user preferences on app placements.
- Implemented sanitization functions for `itemVisibility` and `dockOrder` to ensure valid data is stored.
- Created a new "Apps & Icons" settings section allowing users to configure where each app shortcut appears (dock, desktop, both, or hidden).
- Added context menu for right-click actions on dock tiles and desktop icons to modify visibility settings.
- Developed synchronization logic to reconcile user visibility preferences with the files-layer placements store.
- Enhanced item placement helpers to apply user-defined visibility and ordering to dock and desktop items.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-154-c02fa3fe19879b5a9c1591f2615c9c292b7960a7.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->