### PR TITLE
Refetch desktop placements on Recycle Bin restore

### DIFF
--- a/src/desktop-files/restore-sync.ts
+++ b/src/desktop-files/restore-sync.ts
@@ -1,0 +1,117 @@
+/**
+ * Desktop Mode — Files restore-from-bin sync.
+ *
+ * Symmetric counterpart to `trash.ts`. Trash optimistically evicts
+ * the placement (and folder, for folder placements) on its way INTO
+ * the bin and emits `desktop-mode.{placement,shortcut,folder}.changed`
+ * so cross-window listeners can react. The reverse path — restoring
+ * an item from the Recycle Bin window — emits the same topics with
+ * `action: 'untrashed'`, but nothing on the desktop-files side was
+ * subscribed: the store learned about the restore only on the next
+ * Heartbeat tick (15–60 s), or, when the heartbeat delta missed it
+ * for any reason, not at all until F5.
+ *
+ * This module fixes that asymmetry by listening for those topics and
+ * issuing an authoritative REST resync the moment a restore is
+ * broadcast. The resync shape mirrors the `truncated: true` fallback
+ * in `heartbeat.ts` — refetch `listFolders()` to repopulate the
+ * folders map (the trash eviction cleared it) and `listPlacements()`
+ * for every still-hydrated folder so the on-screen tiles match the
+ * server.
+ *
+ * Robustness: doesn't depend on the heartbeat machinery at all.
+ * `listPlacements` / `listFolders` always return the authoritative
+ * current state, so a restore lands in the store within one round-
+ * trip regardless of whether heartbeat deltas are working.
+ *
+ * @since 0.7.3
+ */
+
+import { subscribe } from '../broadcast';
+import { listFolders, listPlacements } from './rest';
+import {
+	getFilesState,
+	setFolderPlacements,
+	setFolders,
+} from './store';
+
+interface ChangedPayload {
+	action?: string;
+	source?: string;
+	ids?: unknown;
+}
+
+let started = false;
+const unsubscribers: Array< () => void > = [];
+
+/**
+ * Wire the subscriber. Idempotent — calling twice is safe (the
+ * second call is a no-op).
+ */
+export function startFilesRestoreSync(): void {
+	if ( started ) {
+		return;
+	}
+	started = true;
+
+	const onChange = ( payload: unknown ): void => {
+		const detail = payload as ChangedPayload | null | undefined;
+		if ( ! detail || detail.action !== 'untrashed' ) {
+			return;
+		}
+		resyncFromServer();
+	};
+
+	unsubscribers.push(
+		subscribe( 'desktop-mode.placement.changed', onChange ),
+		subscribe( 'desktop-mode.shortcut.changed', onChange ),
+		subscribe( 'desktop-mode.folder.changed', onChange ),
+	);
+}
+
+/**
+ * Refetch the folders map + every hydrated folder's placements in
+ * parallel. Errors are logged but never thrown — a transient REST
+ * blip leaves the store on its previous state and the next
+ * Heartbeat tick will reconcile.
+ */
+function resyncFromServer(): void {
+	void listFolders()
+		.then( ( res ) => {
+			setFolders( res.folders );
+		} )
+		.catch( ( err ) => {
+			// eslint-disable-next-line no-console
+			console.error(
+				'[desktop-mode] files restore-sync: listFolders failed',
+				err,
+			);
+		} );
+
+	// Snapshot the hydrated set up front because `setFolderPlacements`
+	// re-adds entries during iteration.
+	const hydrated = Array.from( getFilesState().hydratedFolders );
+	for ( const folderId of hydrated ) {
+		void listPlacements( folderId )
+			.then( ( res ) => {
+				setFolderPlacements( folderId, res.placements );
+			} )
+			.catch( ( err ) => {
+				// eslint-disable-next-line no-console
+				console.error(
+					'[desktop-mode] files restore-sync: listPlacements failed for',
+					folderId,
+					err,
+				);
+			} );
+	}
+}
+
+/** Test-only — unsubscribes every listener and resets the install latch. */
+export function __resetFilesRestoreSyncForTests(): void {
+	for ( const off of unsubscribers ) {
+		off();
+	}
+	unsubscribers.length = 0;
+	started = false;
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -178,6 +178,7 @@ import {
 import { mountFilesLayer } from './desktop-files/layer';
 import { installRecycleBinDropTargets } from './desktop-files/recycle-bin-targets';
 import { startFilesHeartbeat } from './desktop-files/heartbeat';
+import { startFilesRestoreSync } from './desktop-files/restore-sync';
 import { buildOccupiedSet, snapToEmptyCell } from './desktop-files/grid';
 import {
 	buildMenuItems as buildWallpaperMenuItems,
@@ -2701,6 +2702,12 @@ function init(): void {
 	// Wire the Files-on-the-Desktop Heartbeat sync. Idempotent —
 	// safe to call again on a re-init.
 	startFilesHeartbeat();
+
+	// Restore-from-bin sync: refetches hydrated folders the moment the
+	// Recycle Bin broadcasts `action: 'untrashed'` so a restored
+	// folder/placement lands back on the desktop without waiting for
+	// the next Heartbeat tick.
+	startFilesRestoreSync();
 
 	// Boot the framework presence probe — always runs in desktop
 	// mode, regardless of whether the chat feature is enabled. The

--- a/tests/vitest/desktop-files-restore-sync.test.ts
+++ b/tests/vitest/desktop-files-restore-sync.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Restore-from-bin sync tests.
+ *
+ * The recycle-bin window emits
+ * `desktop-mode.{placement,shortcut,folder}.changed` with
+ * `action: 'untrashed'` after a successful restore. This module's
+ * subscriber must refetch `listFolders()` once and `listPlacements()`
+ * for every still-hydrated folder so the local store catches up
+ * without waiting for the next Heartbeat tick.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+/**
+ * One shared module graph across tests. We deliberately DON'T call
+ * `vi.resetModules()` between tests: the broadcast bus attaches
+ * listeners to `document`, and `vi.resetModules` would orphan the
+ * previous test's listeners (they'd keep firing on every broadcast).
+ * `afterEach` calls `__resetFilesRestoreSyncForTests` which
+ * unregisters them properly.
+ */
+async function load(): Promise< {
+	rs: typeof import( '../../src/desktop-files/restore-sync' );
+	store: typeof import( '../../src/desktop-files/store' );
+	rest: typeof import( '../../src/desktop-files/rest' );
+	bc: typeof import( '../../src/broadcast' );
+} > {
+	return {
+		rs: await import( '../../src/desktop-files/restore-sync' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+		bc: await import( '../../src/broadcast' ),
+	};
+}
+
+interface MockResponse {
+	body: unknown;
+}
+
+async function flushMicrotasks(): Promise< void > {
+	// `fetch` mock resolves through a JSON parsing chain that needs
+	// a few microtask hops to settle. Five drains is plenty for our
+	// 2-3-step pipeline (response → .json() → store mutator).
+	for ( let i = 0; i < 5; i += 1 ) {
+		// eslint-disable-next-line no-await-in-loop
+		await Promise.resolve();
+	}
+}
+
+function fetchSpy( responses: MockResponse[] ): ReturnType< typeof vi.fn > {
+	let i = 0;
+	return vi.fn( async () => {
+		const next = responses[ i ] ?? { body: {} };
+		i += 1;
+		return new Response( JSON.stringify( next.body ), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		} );
+	} );
+}
+
+describe( 'files restore-sync', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+
+	afterEach( async () => {
+		const { rs, store } = await load();
+		rs.__resetFilesRestoreSyncForTests();
+		store.__resetFilesStoreForTests();
+		clearHooksStub();
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'untrashed broadcast refetches folders + every hydrated placement folder', async () => {
+		const { rs, store, rest, bc } = await load();
+		rs.__resetFilesRestoreSyncForTests();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		// Two hydrated folders: root + an open sub-folder.
+		store.setFolderPlacements( 0, [] );
+		store.setFolderPlacements( 5, [] );
+
+		const spy = fetchSpy( [
+			{ body: { folders: [] } }, // listFolders
+			{ body: { placements: [], folderId: 0 } }, // listPlacements(0)
+			{ body: { placements: [], folderId: 5 } }, // listPlacements(5)
+		] );
+		vi.stubGlobal( 'fetch', spy );
+
+		rs.startFilesRestoreSync();
+		bc.broadcast( 'desktop-mode.folder.changed', {
+			source: 'recycle-bin',
+			action: 'untrashed',
+			ids: [ 5 ],
+		} );
+
+		await flushMicrotasks();
+
+		// 1 listFolders + 2 listPlacements.
+		expect( spy ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	test( 'non-untrash actions are ignored', async () => {
+		const { rs, store, rest, bc } = await load();
+		rs.__resetFilesRestoreSyncForTests();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		store.setFolderPlacements( 0, [] );
+		const spy = fetchSpy( [] );
+		vi.stubGlobal( 'fetch', spy );
+
+		rs.startFilesRestoreSync();
+		bc.broadcast( 'desktop-mode.placement.changed', {
+			source: 'recycle-bin',
+			action: 'trashed',
+			ids: [ 1 ],
+		} );
+		bc.broadcast( 'desktop-mode.placement.changed', {
+			source: 'recycle-bin',
+			action: 'deleted',
+			ids: [ 1 ],
+		} );
+
+		await flushMicrotasks();
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'restored placement upserts populate the store', async () => {
+		const { rs, store, rest, bc } = await load();
+		rs.__resetFilesRestoreSyncForTests();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		store.setFolderPlacements( 0, [] );
+
+		const restored = {
+			id: 42,
+			parentId: 0,
+			x: 0,
+			y: 0,
+			sortOrder: 0,
+			updatedAtMs: 1000,
+			meta: null,
+			file: {
+				type: 'folder',
+				ref: '7',
+				title: 'My folder',
+				icon: 'dashicons-portfolio',
+				previewUrl: '',
+				exists: true,
+			},
+		};
+		const folderRow = {
+			id: 7,
+			ownerId: 1,
+			name: 'My folder',
+			shareMode: 'private' as const,
+			shareMeta: null,
+			updatedAtMs: 1000,
+		};
+		const spy = fetchSpy( [
+			{ body: { folders: [ folderRow ] } },
+			{ body: { placements: [ restored ], folderId: 0 } },
+		] );
+		vi.stubGlobal( 'fetch', spy );
+
+		rs.startFilesRestoreSync();
+		bc.broadcast( 'desktop-mode.folder.changed', {
+			source: 'recycle-bin',
+			action: 'untrashed',
+			ids: [ 7 ],
+		} );
+
+		await flushMicrotasks();
+
+		const state = store.getFilesState();
+		expect( state.folders.get( 7 )?.name ).toBe( 'My folder' );
+		expect(
+			state.placementsByFolder.get( 0 )?.map( ( p ) => p.id ),
+		).toEqual( [ 42 ] );
+	} );
+
+	test( 'subscribes to placement/shortcut/folder topics', async () => {
+		const { rs, store, rest, bc } = await load();
+		rs.__resetFilesRestoreSyncForTests();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		store.setFolderPlacements( 0, [] );
+
+		const spy = fetchSpy( [
+			{ body: { folders: [] } },
+			{ body: { placements: [], folderId: 0 } },
+			{ body: { folders: [] } },
+			{ body: { placements: [], folderId: 0 } },
+			{ body: { folders: [] } },
+			{ body: { placements: [], folderId: 0 } },
+		] );
+		vi.stubGlobal( 'fetch', spy );
+
+		rs.startFilesRestoreSync();
+		bc.broadcast( 'desktop-mode.placement.changed', {
+			source: 'recycle-bin',
+			action: 'untrashed',
+			ids: [ 1 ],
+		} );
+		bc.broadcast( 'desktop-mode.shortcut.changed', {
+			source: 'recycle-bin',
+			action: 'untrashed',
+			ids: [ 2 ],
+		} );
+		bc.broadcast( 'desktop-mode.folder.changed', {
+			source: 'recycle-bin',
+			action: 'untrashed',
+			ids: [ 3 ],
+		} );
+
+		await flushMicrotasks();
+
+		// Each broadcast triggers 1 listFolders + 1 listPlacements(0).
+		expect( spy ).toHaveBeenCalledTimes( 6 );
+	} );
+} );


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/d413cdd7-a7ef-4f13-a1d0-6a25061e556b


Restoring a folder or placement from the Recycle Bin window did not bring it back onto the desktop until a hard reload. The desktop-files trash flow optimistically evicts (and broadcasts) on its way IN, but the symmetric path OUT — the recycle-bin's `desktop-mode.{placement,shortcut,folder}.changed` broadcast with `action: 'untrashed'` — had no subscriber inside `src/desktop-files/`. The Heartbeat upsert query looks correct on paper (filters `trashed_at_ms IS NULL` so restored rows should re-flow), but in practice the row was not arriving in the delta either — so the user's folder/file did not return within 15 s, ever.

## Approach

New small subscriber module `src/desktop-files/restore-sync.ts`. Listens for the three broadcast topics and, on an `untrashed` action, issues an authoritative REST resync — `listFolders()` to repopulate the folders map (the trash eviction cleared it) and `listPlacements()` for every still-hydrated folder so on-screen tiles match the server. Same shape `heartbeat.ts`'s `truncated: true` fallback uses.

Robustness: the resync does not depend on Heartbeat at all. `listFolders` / `listPlacements` always return the authoritative current state, so a restore lands in the store within one round-trip even if the heartbeat delta is misbehaving.

## Changes

- `src/desktop-files/restore-sync.ts` (new) — the subscriber + REST resync.
- `src/desktop.ts` — wire `startFilesRestoreSync()` next to `startFilesHeartbeat()`.
- `tests/vitest/desktop-files-restore-sync.test.ts` (new) — 4 cases: refetch on untrashed, ignore non-untrash actions, restored placements populate the store, all three topics are subscribed.

## Not a regression

This was missing from the original Files-Folders feature in #109; restore-to-desktop has never worked synchronously since the feature shipped.

## Verified

- `npm run build` clean
- `npm run lint` clean
- `npm run test:js`: 1105 tests pass (4 new)
- `tsc --noEmit` clean
- Manually reproduced + verified the fix against `wordpress-develop` at `localhost:8889`

## Open follow-up

The Heartbeat-delta-after-restore observation (server-side query looks correct but the row is not actually delivered) is worth investigating separately. Not blocking this fix because the subscriber bypasses the heartbeat path entirely.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-157-46ba0313b1dbf66f206eea6586e86cc8d2e21330.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->