### PR TITLE
Fix #171: SW navigation interception caused window-in-window after core update

### DIFF
--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -172,7 +172,21 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
 		return;
 	}
 
-	if ( req.mode === 'navigate' ) {
+	if ( req.mode === 'navigate' && req.destination === 'document' ) {
+		// Only intercept TOP-LEVEL navigations. Iframe navigations
+		// (`req.destination === 'iframe'`) pass through directly to
+		// the browser. If the SW called `fetch( req )` for an iframe
+		// load, Chrome would forward the request with
+		// `Sec-Fetch-Dest: empty` instead of `iframe`, and the
+		// server-side Sec-Fetch fallback in
+		// `desktop_mode_is_chromeless_request()` would fail to
+		// detect the chromeless context. The plain-admin → portal
+		// redirect would then fire inside a chromeless iframe,
+		// rendering the entire desktop shell inside an existing
+		// window (the "screen on screen" bug from issue #171).
+		// Iframe-targeted offline fallback is not useful anyway —
+		// the user-facing offline page is the desktop shell, which
+		// is the top-level navigation.
 		event.respondWith( networkFirstWithOfflineFallback( req ) );
 	}
 


### PR DESCRIPTION
## Summary

- Service worker stops intercepting iframe navigations, fixing the window-in-window symptom from #171.
- Root cause: when the SW called `event.respondWith( fetch( req ) )` for an iframe load, Chrome forwarded the request with `Sec-Fetch-Dest: empty` instead of `iframe`. The Sec-Fetch fallback in `desktop_mode_is_chromeless_request()` only matches `iframe`, so the plain-admin to portal redirect fired inside the iframe and rendered the desktop shell on top of itself.
- The user-visible trigger is Dashboard, Updates, Update to latest 7.1 nightly: WP core finishes the upgrade with `window.location = about.php?updated` from inside the iframe, exercising exactly that path. Any same-origin iframe navigation that lost the `desktop_mode_chromeless=1` flag would hit the same bug.
- Fix: limit the SW navigation handler to top-level navigations (`req.destination === 'document'`). The offline fallback is meaningful only for the top-level desktop shell page, so iframe-targeted offline support was not lost.

## Before

After clicking Update to latest 7.1 nightly:

```
top:    /wp-admin/update-core.php?desktop_mode_portal=1
  iframe[1]:  src=update-core.php?desktop_mode_chromeless=1
              actual=about.php?desktop_mode_portal=1   <-- portal nested in chromeless iframe
    iframe[2]: update-core.php?action=do-core-upgrade&desktop_mode_chromeless=1
```

Visible result: a second WP admin chrome bar and a second WP Updates window rendered inside the original window.

## After

```
top:    /wp-admin/update-core.php?desktop_mode_portal=1
  iframe[1]:  /wp-admin/about.php   <-- chromeless, no portal redirect, no nested shell
```

The About WordPress page loads cleanly inside the existing WP Updates window.

## How to verify

1. Open `wp-admin/update-core.php` inside Desktop Mode (running against a dev/nightly WP install).
2. Click Update to latest 7.x nightly.
3. Wait for completion.
4. Confirm the iframe lands on the About page with no second admin chrome and no nested desktop shell.

## Test plan

- [ ] Manual: nightly core update flow no longer renders the desktop shell inside the chromeless iframe
- [ ] Manual: PWA install + offline fallback still works for the top-level desktop shell page (visit `/desktop-mode/` offline)
- [x] `npm run lint`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `npm run test:js` (131 files, 1115 tests pass)

Fixes #171

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-175-3043a6914431c0da753bd82677f394a72a5ebc07.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->