### PR TITLE
fix: open each post as its own window from the Posts window

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,10 +9,13 @@
  *
  * `post_type` separates Posts from Pages (both are edit.php). `page` is
  * the plugin-routed admin.php entry point. `taxonomy` distinguishes
- * Categories from Tags (both are edit-tags.php). Everything else —
- * pagination, nonces, action-feedback flags, our internal desktop_mode_chromeless
- * marker — is considered transient and stripped, so a direct-URL land
- * and a dock click resolve to the same window ID.
+ * Categories from Tags (both are edit-tags.php). `post` is the post ID
+ * on post.php — different posts must resolve to different windows so
+ * opening a second post from the Posts list doesn't just refocus the
+ * first. Everything else — pagination, nonces, action-feedback flags,
+ * our internal desktop_mode_chromeless marker — is considered transient
+ * and stripped, so a direct-URL land and a dock click resolve to the
+ * same window ID.
  */
 const IDENTITY_PARAMS: readonly string[] = [
 	'post_type',
@@ -28,6 +31,11 @@ const IDENTITY_PARAMS: readonly string[] = [
 	// plugins that route inside `admin.php?page=` via a custom param
 	// can either piggyback on `path` or grow this list.
 	'path',
+	// The post ID on `post.php?post=X&action=edit`. Without this, every
+	// individual post edit URL collapses to `post-php`, so clicking a
+	// second row in the Posts window just refocuses the first post's
+	// window instead of opening the new one.
+	'post',
 ];
 
 /**

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -59,6 +59,23 @@ describe( 'utils/deriveWindowId', () => {
 		expect( cats ).not.toBe( tags );
 	} );
 
+	test( 'separates individual post edit URLs by the `post` query arg', () => {
+		// Regression: without `post` in the identity set, every
+		// post.php?post=X&action=edit URL collapses to `post-php`, so
+		// clicking a second post in the Posts window just refocuses
+		// the first post's window.
+		const first = deriveWindowId(
+			`${ ADMIN }post.php?post=123&action=edit`,
+			ADMIN,
+		);
+		const second = deriveWindowId(
+			`${ ADMIN }post.php?post=456&action=edit`,
+			ADMIN,
+		);
+		expect( first ).not.toBe( second );
+		expect( first ).toBe( 'post-php-post-123' );
+	} );
+
 	test( 'separates plugin-routed pages by the `page` query arg', () => {
 		const one = deriveWindowId(
 			`${ ADMIN }admin.php?page=my-plugin`,


### PR DESCRIPTION
## Summary

Clicking a second post in the Posts window refocused the first post's window instead of opening a new one.

`deriveWindowId()` collapsed every `post.php?post=X&action=edit` URL to the same ID (`post-php`) because `post` wasn't in `IDENTITY_PARAMS` — only `post_type`, `page`, `taxonomy`, and `path` were significant. So every post-edit URL produced the same window ID, and `windowManager.open()` saw a matching window and refocused it.

## Fix

Add `post` to `IDENTITY_PARAMS` so `post.php?post=123&action=edit` → `post-php-post-123` and `post.php?post=456&action=edit` → `post-php-post-456`. Every code path that derives a window ID (Posts-window row click via `openAdminUrl`, in-shell `<a href>` clicks via the link interceptor, dock-icon clicks, session restore, geometry lookups) benefits automatically since they all funnel through `deriveWindowId`.

## Test plan

- [x] `npm run lint`, `tsc --noEmit`, full `vitest` (1116 tests) green
- [x] New regression test in `tests/vitest/utils.test.ts` locks in distinct IDs for two post URLs
- [x] Manual: open the Posts window, click Post A → opens Post A window; click Post B → opens Post B as a separate window; click Post A again → refocuses the existing Post A window

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-176-7d089ff11514552400fe7fb7d22b66b66e1533c9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->