### PR TITLE
Fix Users window data + live-refresh, plus per-window REST clients

### DIFF
--- a/includes/users-window/window.php
+++ b/includes/users-window/window.php
@@ -375,9 +375,14 @@ function desktop_mode_users_window_default_query_args() {
 			. 'desktop_mode_user_stats,desktop_mode_last_login,desktop_mode_presence,'
 			. 'desktop_mode_can_edit,desktop_mode_assignable_roles',
 		// `who=authors` would hide subscribers — we want the full
-		// list. Default core context is `view`, which is what we
-		// rely on for cap-gated fields.
-		'context'  => 'view',
+		// list. `context=edit` is required because `email`, `roles`,
+		// and `registered_date` are edit-context-only on
+		// `/wp/v2/users`; in `view` they're omitted from the response
+		// entirely (independent of `_fields`), which paints the
+		// table as "No role" / empty email / empty registered date.
+		// The window is already gated on `list_users`, the cap
+		// `context=edit` requires, so this is safe.
+		'context'  => 'edit',
 		'per_page' => 20,
 	);
 
@@ -487,7 +492,7 @@ function desktop_mode_users_window_register_rest_fields() {
 			'schema'       => array(
 				'description' => __( 'Per-user content stats: published post / page / comment counts.', 'desktop-mode' ),
 				'type'        => 'object',
-				'context'     => array( 'view' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
 				'readonly'    => true,
 			),
 		)
@@ -508,7 +513,7 @@ function desktop_mode_users_window_register_rest_fields() {
 			'schema'       => array(
 				'description' => __( 'UTC unix timestamp of this user’s last successful login, or null when never recorded.', 'desktop-mode' ),
 				'type'        => array( 'integer', 'null' ),
-				'context'     => array( 'view' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
 				'readonly'    => true,
 			),
 		)
@@ -529,7 +534,7 @@ function desktop_mode_users_window_register_rest_fields() {
 				'description' => __( 'Live presence status: online / inactive / offline.', 'desktop-mode' ),
 				'type'        => 'string',
 				'enum'        => array( 'online', 'inactive', 'offline' ),
-				'context'     => array( 'view' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
 				'readonly'    => true,
 			),
 		)
@@ -550,7 +555,7 @@ function desktop_mode_users_window_register_rest_fields() {
 			'schema'       => array(
 				'description' => __( 'Whether the requester can edit this user.', 'desktop-mode' ),
 				'type'        => 'boolean',
-				'context'     => array( 'view' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
 				'readonly'    => true,
 			),
 		)
@@ -572,7 +577,7 @@ function desktop_mode_users_window_register_rest_fields() {
 				'description' => __( 'Role slugs the requester can assign to this user.', 'desktop-mode' ),
 				'type'        => 'array',
 				'items'       => array( 'type' => 'string' ),
-				'context'     => array( 'view' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
 				'readonly'    => true,
 			),
 		)

--- a/src/posts-window/categories-mindmap.ts
+++ b/src/posts-window/categories-mindmap.ts
@@ -26,14 +26,7 @@
 
 import { __, sprintf } from '../i18n';
 import { trackedFetch } from '../tracked-fetch';
-import {
-	createCategory,
-	deleteTerm,
-	fetchTerms,
-	updateTerm,
-	getConfig,
-	type TermRow,
-} from './rest';
+import { type PostsWindowClient, type TermRow } from './rest';
 
 interface PixiPoint {
 	x: number;
@@ -192,6 +185,7 @@ const POST_RING_RADIUS = 170;
  */
 export async function mountCategoriesMindmap(
 	host: HTMLElement,
+	client: PostsWindowClient,
 ): Promise< () => void > {
 	const api = window.wp?.desktop;
 	if ( ! api || typeof api.loadModules !== 'function' ) {
@@ -477,7 +471,7 @@ export async function mountCategoriesMindmap(
 		const all: TermRow[] = [];
 		let page = 1;
 		while ( page <= 5 ) {
-			const res = await fetchTerms( 'categories', { page, perPage: 100 } );
+			const res = await client.fetchTerms( 'categories', { page, perPage: 100 } );
 			all.push( ...res.items );
 			if ( page >= res.totalPages ) {
 				break;
@@ -1546,7 +1540,7 @@ export async function mountCategoriesMindmap(
 				! isAncestor( node.id, target.id )
 			) {
 				try {
-					await updateTerm( 'categories', node.id, {
+					await client.updateTerm( 'categories', node.id, {
 						parent: target.id,
 					} );
 					node.parent = target.id;
@@ -2050,7 +2044,7 @@ export async function mountCategoriesMindmap(
 			applyPostsResult( cached, myFocusId );
 			return;
 		}
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		const url = new URL( cfg.postsUrl );
 		url.searchParams.set( 'categories', String( focusId ) );
 		url.searchParams.set( 'per_page', String( POST_PER_PAGE ) );
@@ -2058,7 +2052,7 @@ export async function mountCategoriesMindmap(
 		url.searchParams.set( 'status', 'any' );
 		url.searchParams.set( '_fields', 'id,title,status' );
 		try {
-			const response = await fetchShellJson( url.toString() );
+			const response = await fetchShellJson( client, url.toString() );
 			if ( mySeq !== loadSeq || focusId !== myFocusId ) {
 				return;
 			}
@@ -2356,7 +2350,7 @@ export async function mountCategoriesMindmap(
 			}
 			createBtn.disabled = true;
 			try {
-				const created = await createCategory( name, d.parent, {
+				const created = await client.createCategory( name, d.parent, {
 					slug: slugInput.value.trim() || undefined,
 					description: descInput.value || undefined,
 				} );
@@ -2555,7 +2549,7 @@ export async function mountCategoriesMindmap(
 			);
 			makeRootBtn.addEventListener( 'click', async () => {
 				try {
-					await updateTerm( 'categories', node.id, { parent: 0 } );
+					await client.updateTerm( 'categories', node.id, { parent: 0 } );
 					node.parent = 0;
 					terms = terms.map( ( t ) =>
 						t.id === node.id ? { ...t, parent: 0 } : t,
@@ -2599,7 +2593,7 @@ export async function mountCategoriesMindmap(
 				patch.slug = slugRaw;
 			}
 			try {
-				const updated = await updateTerm(
+				const updated = await client.updateTerm(
 					'categories',
 					node.id,
 					patch,
@@ -2650,7 +2644,7 @@ export async function mountCategoriesMindmap(
 				armResetTimer = null;
 			}
 			try {
-				await deleteTerm( 'categories', node.id );
+				await client.deleteTerm( 'categories', node.id );
 				terms = terms.filter( ( t ) => t.id !== node.id );
 				focusId = null;
 				clearPosts();
@@ -2823,7 +2817,7 @@ export async function mountCategoriesMindmap(
 		if ( terms.length === 0 ) {
 			return;
 		}
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		const url = new URL(
 			`${ cfg.restRoot.replace( /\/$/, '' ) }/desktop-mode/v1/term-counts`,
 		);
@@ -2833,7 +2827,7 @@ export async function mountCategoriesMindmap(
 			terms.map( ( t ) => t.id ).join( ',' ),
 		);
 		try {
-			const response = await fetchShellJson( url.toString() );
+			const response = await fetchShellJson( client, url.toString() );
 			const map = response.json as Record< string, number >;
 			let dirty = false;
 			terms = terms.map( ( t ) => {
@@ -3058,8 +3052,11 @@ interface ShellJsonResponse {
 	headers: Headers;
 }
 
-async function fetchShellJson( url: string ): Promise< ShellJsonResponse > {
-	const cfg = getConfig();
+async function fetchShellJson(
+	client: PostsWindowClient,
+	url: string,
+): Promise< ShellJsonResponse > {
+	const cfg = client.getConfig();
 	const init: RequestInit = {
 		method: 'GET',
 		credentials: 'same-origin',

--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -26,28 +26,17 @@ import { showPostsIntroDialog } from './intro-dialog';
 // profile UI mounted automatically.
 import './wpd-user-profile';
 import {
-	buildEditPostUrl,
-	createCategory,
-	createTag,
-	deleteTerm,
-	fetchAllCategories,
-	fetchAuthorOptions,
-	fetchPosts,
-	fetchTagOptions,
-	getActiveWindowId,
-	getConfig,
-	searchTags,
-	setActiveWindowId,
-	trashPost,
-	updatePostCategories,
-	updatePostTags,
+	createPostsWindowClient,
 	type AuthorOption,
 	type CategoryTerm,
 	type PostListItem,
 	type PostsListParams,
+	type PostsWindowClient,
+	type PostsWindowConfig,
 	type TagOption,
 	type TagTerm,
 } from './rest';
+import { createUsersWindowClient } from './users-rest';
 import type {
 	BulkAction,
 	PostsWindowContext,
@@ -135,10 +124,10 @@ document.addEventListener( 'desktop-mode-intros-reset', () => {
 	}
 } );
 
-function maybeShowIntro(): void {
-	let cfg: ReturnType< typeof getConfig >;
+function maybeShowIntro( client: PostsWindowClient ): void {
+	let cfg: PostsWindowConfig;
 	try {
-		cfg = getConfig();
+		cfg = client.getConfig();
 	} catch {
 		return;
 	}
@@ -168,7 +157,7 @@ function maybeShowIntro(): void {
 				_introShown[ slug ] = false;
 				return;
 			}
-			void markIntroSeen( cfg, slug );
+			void markIntroSeen( cfg, slug, client );
 			if ( result === 'settings' ) {
 				openOsSettingsFeatures();
 			}
@@ -180,8 +169,9 @@ function maybeShowIntro(): void {
 }
 
 async function markIntroSeen(
-	cfg: ReturnType< typeof getConfig >,
+	cfg: PostsWindowConfig,
 	slug: string,
+	client: PostsWindowClient,
 ): Promise< void > {
 	if ( ! cfg.introUrl ) {
 		return;
@@ -199,7 +189,7 @@ async function markIntroSeen(
 				body: JSON.stringify( { slug } ),
 			},
 			{
-				windowId: getActiveWindowId(),
+				windowId: client.windowId,
 				source: `${ slug }-window/intro`,
 			},
 		);
@@ -441,9 +431,10 @@ const EMPTY_FILTER_DATA: ColumnFilterData = { authors: [], tags: [] };
  */
 function buildAllColumns(
 	cache: CellCache,
+	client: PostsWindowClient,
 	filterData: ColumnFilterData = EMPTY_FILTER_DATA,
 ): WpdTableColumn< PostListItem >[] {
-	const cols = _buildBaseColumns( cache, filterData );
+	const cols = _buildBaseColumns( cache, filterData, client );
 	const hooks = window.wp?.hooks;
 	return hooks && typeof hooks.applyFilters === 'function'
 		? ( hooks.applyFilters(
@@ -461,9 +452,10 @@ function buildAllColumns(
  */
 function buildColumns(
 	cache: CellCache,
+	client: PostsWindowClient,
 	filterData: ColumnFilterData = EMPTY_FILTER_DATA,
 ): WpdTableColumn< PostListItem >[] {
-	const all = buildAllColumns( cache, filterData );
+	const all = buildAllColumns( cache, client, filterData );
 	const hidden = getHiddenColumns();
 	if ( hidden.size === 0 ) {
 		return all;
@@ -479,6 +471,7 @@ function buildColumns(
 function _buildBaseColumns(
 	cache: CellCache,
 	filterData: ColumnFilterData,
+	client: PostsWindowClient,
 ): WpdTableColumn< PostListItem >[] {
 	// `mode` lets us swap the taxonomy columns out for hierarchical
 	// pages without the column hook bus knowing the difference.
@@ -486,7 +479,7 @@ function _buildBaseColumns(
 	// already-mode-appropriate base list and append/replace from there.
 	let mode: 'posts' | 'pages' = 'posts';
 	try {
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		if ( cfg.mode === 'pages' ) {
 			mode = 'pages';
 		}
@@ -502,7 +495,7 @@ function _buildBaseColumns(
 		sortable: true,
 		sticky: true,
 		render: ( _v, row ) =>
-			memoCell( cache, row.id, 'title', () => buildTitleCell( row ) ),
+			memoCell( cache, row.id, 'title', () => buildTitleCell( row, client ) ),
 	};
 	const authorCol: WpdTableColumn< PostListItem > = {
 		key: 'author',
@@ -540,7 +533,7 @@ function _buildBaseColumns(
 			label: __( 'Template' ),
 			width: '180px',
 			render: ( _v, row ) =>
-				memoCell( cache, row.id, 'template', () => buildTemplateCell( row ) ),
+				memoCell( cache, row.id, 'template', () => buildTemplateCell( row, client ) ),
 		};
 		const slugCol: WpdTableColumn< PostListItem > = {
 			key: 'slug',
@@ -582,7 +575,7 @@ function _buildBaseColumns(
 			width: '260px',
 			render: ( _v, row ) =>
 				memoCell( cache, row.id, 'categories', () =>
-					buildCategoriesCell( row ),
+					buildCategoriesCell( row, client ),
 				),
 		},
 		{
@@ -607,7 +600,7 @@ function _buildBaseColumns(
 					},
 				),
 			render: ( _v, row ) =>
-				memoCell( cache, row.id, 'tags', () => buildTagsCell( row ) ),
+				memoCell( cache, row.id, 'tags', () => buildTagsCell( row, client ) ),
 		},
 		dateCol,
 	];
@@ -678,13 +671,13 @@ function refreshParentTitleRoster( rows: PostListItem[] ): void {
  *
  * @since 0.18.0
  */
-function buildTemplateCell( row: PostListItem ): HTMLElement {
+function buildTemplateCell( row: PostListItem, client: PostsWindowClient ): HTMLElement {
 	const cell = document.createElement( 'span' );
 	cell.className = 'desktop-mode-posts__template';
 	const slug = typeof row.template === 'string' ? row.template : '';
 	let label = slug;
 	try {
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		const map = cfg.pageTemplates ?? {};
 		label = map[ slug ] ?? ( slug === '' ? __( 'Default template' ) : slug );
 	} catch {
@@ -948,6 +941,7 @@ function mountKebabColumnToggles(
 	body: HTMLElement,
 	cache: CellCache,
 	repaintColumns: () => void,
+	client: PostsWindowClient,
 ): { refresh: () => void; dispose: () => void } | null {
 	const winEl = body.closest( '.desktop-mode-window' ) as HTMLElement | null;
 	const panel = winEl?.querySelector(
@@ -967,7 +961,7 @@ function mountKebabColumnToggles(
 		.querySelectorAll( `.${ SECTION_CLASS }, .${ ITEM_CLASS }` )
 		.forEach( ( n ) => n.remove() );
 
-	const allCols = buildAllColumns( cache );
+	const allCols = buildAllColumns( cache, client );
 	const togglable = allCols.filter(
 		( c ) => ! REQUIRED_COLUMN_KEYS.has( c.key ),
 	);
@@ -1074,7 +1068,7 @@ function defaultStatusSegments(): StatusSegment[] {
  * "Move to trash"; remove it (return an empty array, or filter it
  * out by id) for read-only views.
  */
-function defaultBulkActions(): BulkAction[] {
+function defaultBulkActions( client: PostsWindowClient ): BulkAction[] {
 	return [
 		{
 			id: 'trash',
@@ -1095,7 +1089,7 @@ function defaultBulkActions(): BulkAction[] {
 					return;
 				}
 				const results = await Promise.all(
-					trashable.map( ( id ) => trashPost( id ) ),
+					trashable.map( ( id ) => client.trashPost( id ) ),
 				);
 				const errors = results.filter( ( r ) => ! r.ok );
 				if ( errors.length > 0 ) {
@@ -1121,9 +1115,9 @@ function defaultBulkActions(): BulkAction[] {
  * misbehaving filter (returning `null`, throwing) doesn't strand the
  * bulk bar.
  */
-function resolveBulkActions(): BulkAction[] {
+function resolveBulkActions( client: PostsWindowClient ): BulkAction[] {
 	const hooks = window.wp?.hooks;
-	const defaults = defaultBulkActions();
+	const defaults = defaultBulkActions( client );
 	if ( ! hooks || typeof hooks.applyFilters !== 'function' ) {
 		return defaults;
 	}
@@ -1182,7 +1176,7 @@ function resolveToolbarTrailing( ctx: PostsWindowContext ): HTMLElement[] {
 	}
 }
 
-function buildTitleCell( row: PostListItem ): HTMLElement {
+function buildTitleCell( row: PostListItem, client: PostsWindowClient ): HTMLElement {
 	const cell = document.createElement( 'span' );
 	cell.style.cssText =
 		'display:flex;flex-direction:column;gap:4px;min-width:0;';
@@ -1192,7 +1186,7 @@ function buildTitleCell( row: PostListItem ): HTMLElement {
 		'display:flex;align-items:center;gap:8px;min-width:0;';
 
 	const link = document.createElement( 'a' );
-	link.href = buildEditPostUrl( row.id );
+	link.href = client.buildEditPostUrl( row.id );
 	link.setAttribute( 'data-noclick', '' );
 	const title = decodeTitle( row.title.rendered ) || __( '(no title)' );
 	link.textContent = title;
@@ -1273,9 +1267,9 @@ function buildTitleCell( row: PostListItem ): HTMLElement {
 	// row matches the reading-page assignments. Answers the most-asked
 	// classic-list pain — "which page is set as the homepage?" —
 	// without making the user crack open Settings → Reading.
-	let cfgForBadges: ReturnType< typeof getConfig > | null = null;
+	let cfgForBadges: PostsWindowConfig | null = null;
 	try {
-		cfgForBadges = getConfig();
+		cfgForBadges = client.getConfig();
 	} catch {
 		cfgForBadges = null;
 	}
@@ -1456,7 +1450,7 @@ function buildAuthorCell( row: PostListItem ): HTMLElement {
  *     same `<wpd-tag-input>` instance across selection-only
  *     repaints, so its open state and pending chips don't reset.
  */
-function buildTagsCell( row: PostListItem ): HTMLElement {
+function buildTagsCell( row: PostListItem, client: PostsWindowClient ): HTMLElement {
 	const wrap = document.createElement( 'span' );
 	wrap.style.cssText =
 		'display:inline-flex;align-items:center;width:100%;min-width:0;';
@@ -1513,7 +1507,7 @@ function buildTagsCell( row: PostListItem ): HTMLElement {
 			const ac = new AbortController();
 			cellState.suggestAbort = ac;
 			try {
-				const matches = await searchTags( query, ac.signal );
+				const matches = await client.searchTags( query, ac.signal );
 				if ( cellState.lastQuery !== query ) {
 					return;
 				}
@@ -1557,7 +1551,7 @@ function buildTagsCell( row: PostListItem ): HTMLElement {
 		try {
 			let resolvedTag: TagTerm | null = null;
 			if ( detail.isNew || typeof detail.tag.id !== 'number' ) {
-				resolvedTag = await createTag( detail.tag.label );
+				resolvedTag = await client.createTag( detail.tag.label );
 			} else {
 				resolvedTag = {
 					id: Number( detail.tag.id ),
@@ -1572,7 +1566,7 @@ function buildTagsCell( row: PostListItem ): HTMLElement {
 					.map( ( t ) => Number( t.id ) ),
 				resolvedTag.id,
 			];
-			await updatePostTags( row.id, desiredIds );
+			await client.updatePostTags( row.id, desiredIds );
 
 			// Reconcile: replace the pending placeholder with the
 			// canonical term, drop the pulse.
@@ -1639,7 +1633,7 @@ function buildTagsCell( row: PostListItem ): HTMLElement {
 				.filter( ( t ) => t.label !== removed.label )
 				.map( ( t ) => Number( t.id ) )
 				.filter( ( n ) => Number.isFinite( n ) );
-			await updatePostTags( row.id, desiredIds );
+			await client.updatePostTags( row.id, desiredIds );
 			setValue(
 				previous.filter( ( t ) => t.label !== removed.label ),
 			);
@@ -1703,7 +1697,7 @@ function showTagError( title: string, err: unknown ): void {
  *   - Errors roll the chip set back to its prior state and surface
  *     a toast via the shell.
  */
-function buildCategoriesCell( row: PostListItem ): HTMLElement {
+function buildCategoriesCell( row: PostListItem, client: PostsWindowClient ): HTMLElement {
 	const wrap = document.createElement( 'span' );
 	wrap.className = 'wpd-cat-cell-dropzone';
 	wrap.style.cssText =
@@ -1749,7 +1743,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 	// real ancestors. The shared `getCategoriesTree()` promise
 	// dedupes across every row's cell, so 50 rows = ONE round-trip
 	// per window-open.
-	void getCategoriesTree()
+	void getCategoriesTree( client )
 		.then( ( tree ) => {
 			if ( ! picker.isConnected ) {
 				return; // window closed / row scrolled away
@@ -1781,7 +1775,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 				return;
 			}
 			try {
-				const created = await createCategory( detail.name, parent );
+				const created = await client.createCategory( detail.name, parent );
 				// Drop the cache so any future picker open re-fetches
 				// the tree (won't include the new term until that
 				// happens, but each picker that's already loaded
@@ -1808,7 +1802,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 				picker.endCreating( parent );
 				// Persist the post's new category set.
 				try {
-					await updatePostCategories( row.id, nextValue );
+					await client.updatePostCategories( row.id, nextValue );
 					const api = window.wp?.desktop;
 					if ( api && typeof api.broadcast === 'function' ) {
 						api.broadcast( 'desktop-mode.post.changed', {
@@ -1841,7 +1835,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 		setValue( next );
 
 		try {
-			await updatePostCategories( row.id, next );
+			await client.updatePostCategories( row.id, next );
 
 			const api = window.wp?.desktop;
 			if ( api && typeof api.broadcast === 'function' ) {
@@ -1891,7 +1885,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 			return;
 		}
 		try {
-			await deleteTerm( 'categories', detail.id );
+			await client.deleteTerm( 'categories', detail.id );
 			// `deleteTerm` already broadcasts desktop-mode.term.changed,
 			// which clears the cache and pushes the fresh tree to
 			// every live picker. We just need to drop the deleted
@@ -1902,7 +1896,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 				);
 				setValue( next );
 				try {
-					await updatePostCategories( row.id, next );
+					await client.updatePostCategories( row.id, next );
 				} catch ( err ) {
 					// The term IS gone server-side; failing to write
 					// back the post's now-shorter list is recoverable
@@ -2056,7 +2050,7 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
 		const previous = cellState.categoryIds.slice();
 		setValue( merged );
 		try {
-			await updatePostCategories( row.id, merged );
+			await client.updatePostCategories( row.id, merged );
 			const api = window.wp?.desktop;
 			if ( api && typeof api.broadcast === 'function' ) {
 				api.broadcast( 'desktop-mode.post.changed', {
@@ -2084,9 +2078,9 @@ function buildCategoriesCell( row: PostListItem ): HTMLElement {
  */
 let _categoryTreePromise: Promise< WpdCategoryItem[] > | null = null;
 
-function getCategoriesTree(): Promise< WpdCategoryItem[] > {
+function getCategoriesTree( client: PostsWindowClient ): Promise< WpdCategoryItem[] > {
 	if ( ! _categoryTreePromise ) {
-		_categoryTreePromise = fetchAllCategories().then(
+		_categoryTreePromise = client.fetchAllCategories().then(
 			( terms: CategoryTerm[] ) =>
 				terms.map( ( t ) => ( {
 					id: t.id,
@@ -2127,8 +2121,8 @@ const _activePickers = new Set< WpdCategoryPicker >();
  * `picker.items` doesn't know about, so freshly-created
  * categories silently couldn't be dragged.
  */
-function broadcastFreshCategoryTreeToPickers(): void {
-	void getCategoriesTree()
+function broadcastFreshCategoryTreeToPickers( client: PostsWindowClient ): void {
+	void getCategoriesTree( client )
 		.then( ( tree ) => {
 			for ( const picker of _activePickers ) {
 				if ( picker.isConnected ) {
@@ -2237,14 +2231,17 @@ function buildSubRow( row: PostListItem ): Node {
  * `Window.desktopModeNativeWindows` global type cleanly across both
  * modules.
  */
-export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
+export async function renderPostsWindow(
+	body: HTMLElement,
+	client: PostsWindowClient,
+): Promise< void > {
 	const root = body.querySelector< HTMLElement >( ROOT );
 	const table = body.querySelector< WpdTable< PostListItem > >( TABLE );
 	if ( ! root || ! table ) {
 		return;
 	}
 
-	maybeShowIntro();
+	maybeShowIntro( client );
 
 	// Term-management tabs (Categories + Tags) — lazy-mounted on first
 	// activation so cold-load of the Posts window never pays for them
@@ -2267,7 +2264,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 			if ( value === 'categories' && catsHost && ! catsTeardown ) {
 				void import( './categories-mindmap' ).then(
 					async ( { mountCategoriesMindmap } ) => {
-						catsTeardown = await mountCategoriesMindmap( catsHost );
+						catsTeardown = await mountCategoriesMindmap( catsHost, client );
 					},
 				);
 			}
@@ -2279,14 +2276,14 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 				// table fallback. Loads its own term list internally.
 				void import( './tags-cloud' ).then(
 					async ( { mountTagsCloud } ) => {
-						tagsTeardown = await mountTagsCloud( tagsHost );
+						tagsTeardown = await mountTagsCloud( tagsHost, client );
 					},
 				);
 			}
 		} );
 	}
 
-	const cfg = getConfig();
+	const cfg = client.getConfig();
 	const view: ViewState = {
 		page: 1,
 		perPage: Math.max( 1, cfg.defaultPerPage || 20 ),
@@ -2313,7 +2310,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 	// tree priming pattern below.
 	const filterData: ColumnFilterData = { authors: [], tags: [] };
 
-	table.columns = buildColumns( cellCache, filterData );
+	table.columns = buildColumns( cellCache, client, filterData );
 	table.getRowId = ( row ) => row.id;
 	table.subTable = ( row ) => buildSubRow( row );
 	table.sort = { key: 'date', direction: 'desc' };
@@ -2429,7 +2426,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 		const mySeq = ++refreshSeq;
 		table.toggleAttribute( 'loading', true );
 		try {
-			const result = await fetchPosts( buildParams() );
+			const result = await client.fetchPosts( buildParams() );
 			if ( mySeq !== refreshSeq ) {
 				return;
 			}
@@ -2567,7 +2564,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 
 	// --- Bulk actions registry ---------------------------------------
 
-	const bulkActions = resolveBulkActions();
+	const bulkActions = resolveBulkActions( client );
 	if ( bulkActionsHost ) {
 		bulkActionsHost.replaceChildren();
 		for ( const action of bulkActions ) {
@@ -2718,7 +2715,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 			const detail = payload as { taxonomy?: string } | null;
 			if ( detail?.taxonomy === 'category' ) {
 				clearCategoryTreeCache();
-				broadcastFreshCategoryTreeToPickers();
+				broadcastFreshCategoryTreeToPickers( client );
 			}
 		};
 		broadcastUnsubs.push(
@@ -2738,12 +2735,12 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 		// reassign `table.columns` (the table component's own setter
 		// triggers a re-render).
 		cellCache.clear();
-		table.columns = buildColumns( cellCache, filterData );
+		table.columns = buildColumns( cellCache, client, filterData );
 	};
 
 	// Authors load once — sites with >100 active authors are rare
 	// enough that a single REST call covers the dropdown.
-	void fetchAuthorOptions().then( ( authors ) => {
+	void client.fetchAuthorOptions().then( ( authors ) => {
 		filterData.authors = authors;
 		repaintColumns();
 	} );
@@ -2764,7 +2761,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 		tagFetching = true;
 		try {
 			const next = tagPage + 1;
-			const res = await fetchTagOptions( next, TAG_PAGE_SIZE );
+			const res = await client.fetchTagOptions( next, TAG_PAGE_SIZE );
 			tagPage = next;
 			tagTotalPages = Math.max( tagTotalPages, res.totalPages || next );
 			const seen = new Set( filterData.tags.map( ( t ) => t.id ) );
@@ -2790,6 +2787,7 @@ export async function renderPostsWindow( body: HTMLElement ): Promise< void > {
 		body,
 		cellCache,
 		repaintColumns,
+		client,
 	);
 
 	// Repaint when any OS Settings change lands — covers the user
@@ -2984,23 +2982,23 @@ const registry = ( window.desktopModeNativeWindows ??
 // `(body) => void`, but TypeScript allows void-typed callbacks to
 // return any value; the runtime contract is what matters here.
 registry[ 'desktop-mode-posts' ] = ( body: HTMLElement ) => {
-	setActiveWindowId( 'desktop-mode-posts' );
+	const client = createPostsWindowClient( 'desktop-mode-posts' );
 	// Cast through `unknown` so the Record's `void`-returning member
 	// type still accepts the Promise without forcing every consumer
 	// (recycle-bin et al.) to widen their declaration.
-	return renderPostsWindow( body ).catch( ( err ) => {
+	return renderPostsWindow( body, client ).catch( ( err ) => {
 		// eslint-disable-next-line no-console
 		console.error( '[posts-window] render failed:', err );
 	} ) as unknown as void;
 };
 
-// Pages window — same render path with the active window id swapped
-// so `getConfig()` reads the Pages config blob. Mode-driven branches
-// inside `renderPostsWindow` (column set, intro slug, taxonomy-tab
-// binding) gate the post-type-specific behavior.
+// Pages window — same render path with a Pages-scoped client so
+// `client.getConfig()` reads the Pages config blob. Mode-driven
+// branches inside `renderPostsWindow` (column set, intro slug,
+// taxonomy-tab binding) gate the post-type-specific behavior.
 registry[ 'desktop-mode-pages' ] = ( body: HTMLElement ) => {
-	setActiveWindowId( 'desktop-mode-pages' );
-	return renderPostsWindow( body ).catch( ( err ) => {
+	const client = createPostsWindowClient( 'desktop-mode-pages' );
+	return renderPostsWindow( body, client ).catch( ( err ) => {
 		// eslint-disable-next-line no-console
 		console.error( '[pages-window] render failed:', err );
 	} ) as unknown as void;
@@ -3011,9 +3009,9 @@ registry[ 'desktop-mode-pages' ] = ( body: HTMLElement ) => {
 // (`./users-render`) rather than wedging a third branch into
 // `renderPostsWindow` — keeps the post-row code path untouched.
 registry[ 'desktop-mode-users' ] = ( body: HTMLElement ) => {
-	setActiveWindowId( 'desktop-mode-users' );
+	const client = createUsersWindowClient( 'desktop-mode-users' );
 	return import( './users-render' )
-		.then( ( m ) => m.renderUsersWindow( body ) )
+		.then( ( m ) => m.renderUsersWindow( body, client ) )
 		.catch( ( err ) => {
 			// eslint-disable-next-line no-console
 			console.error( '[users-window] render failed:', err );
@@ -3029,7 +3027,6 @@ registry[ 'desktop-mode-users' ] = ( body: HTMLElement ) => {
 // component. Subsequent target changes flip the same attribute,
 // triggering an in-place re-mount.
 registry[ 'desktop-mode-user-edit' ] = ( body: HTMLElement ) => {
-	setActiveWindowId( 'desktop-mode-user-edit' );
 	const profile = body.querySelector(
 		'wpd-user-profile[data-wpd-user-profile-host]',
 	) as HTMLElement | null;
@@ -3058,29 +3055,6 @@ registry[ 'desktop-mode-user-edit' ] = ( body: HTMLElement ) => {
 		}
 		target.clearUserEditTarget();
 
-		// Already-open window + new target → swap user-id; the
-		// component handles the in-place re-mount. Re-pin the
-		// active window id back to `desktop-mode-user-edit` before
-		// the re-mount runs, because focusing another window in the
-		// meantime (Posts, Pages, …) may have moved it. Without this
-		// pin, the form's `getConfig()` reads a sibling window's
-		// config blob that lacks `allRoles` / `assignableRoles` and
-		// the role select renders with zero options.
-		//
-		// `profile.isConnected` guard — when the user-edit window is
-		// closed and reopened, the previous open's subscription is
-		// still alive in memory (the shared-store subscriber list
-		// holds the closure). Without the guard, that stale
-		// subscription would fire on the NEXT `setUserEditTarget`
-		// (clicking another row), uselessly `setAttribute` on the
-		// detached profile element AND — fatally — call
-		// `clearUserEditTarget`. The clear ran SYNCHRONOUSLY before
-		// the fresh window's render callback got its async read,
-		// so the read saw `null`, fell back to `cfg.currentUserId`,
-		// and the form mounted for the viewer instead of the
-		// clicked user. Skipping when the profile is no longer in
-		// the document leaves the target intact for the fresh
-		// render to pick up.
 		target.subscribeUserEditTarget( ( next ) => {
 			if ( ! profile.isConnected ) {
 				return;
@@ -3091,7 +3065,6 @@ registry[ 'desktop-mode-user-edit' ] = ( body: HTMLElement ) => {
 				next.userId !== userId
 			) {
 				userId = next.userId;
-				setActiveWindowId( 'desktop-mode-user-edit' );
 				profile.setAttribute( 'user-id', String( userId ) );
 				target.clearUserEditTarget();
 			}

--- a/src/posts-window/rest.ts
+++ b/src/posts-window/rest.ts
@@ -8,6 +8,20 @@
  * total row count and last page number without a separate count
  * query.
  *
+ * # Per-window client
+ *
+ * `createPostsWindowClient(windowId)` returns a {@link PostsWindowClient}
+ * bound to one window's localized config blob. Each registry entry
+ * in `./index.ts` builds its own client at mount time and threads
+ * it into render code through closures. This replaces the
+ * pre-0.18.x module-level `_activeWindowId` singleton, which
+ * silently drifted whenever a sibling window opened (notably the
+ * Users window opening User-edit) and caused REST calls to read
+ * the wrong window's config — observed as
+ * "Failed to construct 'URL': Invalid URL" on the Users window's
+ * Refresh button. A per-window client makes the wrong-id call
+ * structurally impossible.
+ *
  * @public
  * @since 0.8.0
  */
@@ -226,17 +240,7 @@ export interface PostsListParams {
 	status?: string;
 	orderby?: string;
 	order?: 'asc' | 'desc';
-	/**
-	 * One or more author user ids. Multiple values are sent comma-
-	 * joined (`?author=1,2`) — core's REST endpoint treats the list
-	 * as a union (posts whose author is ANY of the listed users).
-	 */
 	author?: number | number[];
-	/**
-	 * One or more tag term ids. Multiple values are sent comma-
-	 * joined (`?tags=1,2`) — core's REST endpoint treats the list
-	 * as an intersection (posts that carry EVERY listed tag).
-	 */
 	tag?: number | number[];
 }
 
@@ -246,254 +250,6 @@ export interface TrashResult {
 	error?: string;
 }
 
-/**
- * Default window id this module reads its config from. Mutated by
- * {@link setActiveWindowId} when the shared bundle is rendering for a
- * sibling list window (Pages, future CPTs).
- *
- * Module-level mutation is acceptable here: each list window's
- * render-and-fetch flow is short-lived and the registry entries at
- * the bottom of `index.ts` set the id BEFORE handing control to the
- * shared render function. The pattern intentionally avoids threading
- * a windowId argument through every helper at the cost of being
- * non-reentrant for two list windows opened in the same animation
- * frame — an edge case that, on closing-and-reopening, is harmless.
- *
- * @since 0.18.0
- */
-let _activeWindowId = 'desktop-mode-posts';
-
-/**
- * Override the window id `getConfig()` reads. Call before invoking
- * the render function for a non-Posts list window.
- *
- * @since 0.18.0
- */
-export function setActiveWindowId( id: string ): void {
-	_activeWindowId = id;
-}
-
-/** The window id `getConfig()` is currently bound to. */
-export function getActiveWindowId(): string {
-	return _activeWindowId;
-}
-
-/**
- * Read the localized config blob. The window registers via PHP's
- * `desktop_mode_register_window( …, [ 'config' => [ … ] ] )` which
- * lands the data on `window.desktopModeWindowConfig[ <id> ]`. We
- * read it lazily so consumers don't fail at import time when the
- * bundle is loaded outside the window's lifecycle (tests, etc.).
- */
-export function getConfig(): PostsWindowConfig {
-	const store = window.desktopModeWindowConfig;
-	const cfg = store ? ( store[ _activeWindowId ] as PostsWindowConfig | undefined ) : undefined;
-	if ( ! cfg ) {
-		throw new Error(
-			`[${ _activeWindowId }] config blob is missing — was the window opened ` +
-				'without registration? See the matching `desktop_mode_register_window()` ' +
-				'call in `includes/{posts,pages}-window/window.php`.',
-		);
-	}
-	return cfg;
-}
-
-interface RequestOptions extends RequestInit {
-	/** Set to `false` to skip `response.json()` (e.g. `DELETE` 200 with no body). */
-	expectJson?: boolean;
-}
-
-interface RequestResult< T > {
-	data: T;
-	headers: Headers;
-}
-
-/**
- * Resolve the fetch implementation. Prefers `wp.desktop.fetch` when
- * the shell exposes it (so every Posts-window REST call lights up
- * the window's title-bar activity indicator); falls back to native
- * `fetch` for tests / non-shell hosts. The third arg attributes the
- * request to the Posts native window so concurrent operations from
- * other windows don't fight for the same indicator.
- *
- * @internal
- */
-function shellFetch( input: RequestInfo, init?: RequestInit ): Promise< Response > {
-	return trackedFetch( input, init, { windowId: 'desktop-mode-posts' } );
-}
-
-async function request< T >(
-	url: string,
-	init: RequestOptions = {},
-): Promise< RequestResult< T > > {
-	const cfg = getConfig();
-	const response = await shellFetch( url, {
-		...init,
-		credentials: 'same-origin',
-		headers: {
-			'X-WP-Nonce': cfg.restNonce,
-			Accept: 'application/json',
-			...( init.body ? { 'Content-Type': 'application/json' } : {} ),
-			...( init.headers ?? {} ),
-		},
-	} );
-
-	if ( ! response.ok ) {
-		// Surface WP_Error JSON when present; fall back to the status
-		// line otherwise. Either way callers get a thrown Error they
-		// can show inline.
-		let message = `${ response.status } ${ response.statusText }`;
-		try {
-			const json = ( await response.json() ) as { message?: string };
-			if ( json && typeof json.message === 'string' ) {
-				message = json.message;
-			}
-		} catch {
-			// Ignore — non-JSON body, use the status line.
-		}
-		throw new Error( message );
-	}
-
-	const data =
-		init.expectJson === false
-			? ( null as unknown as T )
-			: ( ( await response.json() ) as T );
-	return { data, headers: response.headers };
-}
-
-/**
- * Fetch a page of posts.
- *
- * Pagination headers (`X-WP-Total`, `X-WP-TotalPages`) are surfaced on
- * the response so the table footer can show "Page N of M · T posts"
- * without a second count query.
- *
- * @since 0.8.0
- */
-export async function fetchPosts(
-	params: PostsListParams = {},
-): Promise< PostsListResponse > {
-	const cfg = getConfig();
-	const url = new URL( cfg.postsUrl );
-
-	// Merge the PHP-declared default query args first (so `_fields`,
-	// `_embed`, and a custom `post_type` from the filter all flow through).
-	for ( const [ key, value ] of Object.entries( cfg.queryArgs ?? {} ) ) {
-		if ( typeof value === 'string' && value !== '' ) {
-			url.searchParams.set( key, value );
-		}
-	}
-
-	if ( params.page ) {
-		url.searchParams.set( 'page', String( params.page ) );
-	}
-	if ( params.perPage ) {
-		url.searchParams.set( 'per_page', String( params.perPage ) );
-	}
-	if ( params.search ) {
-		url.searchParams.set( 'search', params.search );
-	}
-	// `status` quirk: when the param is omitted, core's REST handler
-	// defaults to `publish` only — drafts / pending / scheduled /
-	// private silently disappear from "All". Send `status=any` for
-	// the empty-segment case so the "All" tab actually means *all*
-	// the statuses the current user can see (excluding `trash`,
-	// which has its own segment).
-	if ( params.status ) {
-		url.searchParams.set( 'status', params.status );
-	} else {
-		url.searchParams.set( 'status', 'any' );
-	}
-	if ( params.orderby ) {
-		url.searchParams.set( 'orderby', params.orderby );
-	}
-	if ( params.order ) {
-		url.searchParams.set( 'order', params.order );
-	}
-	// Both `author` and `tags` REST params are registered as arrays
-	// of integers. We send them as `author[]=1&author[]=2` (and
-	// `tags[]=...`) — PHP's `parse_str` handles bracketed array
-	// notation unambiguously, whereas comma-separated values can be
-	// interpreted as a single string by some hosts / security
-	// modules / REST middleware that don't run the schema-aware
-	// `rest_sanitize_value_from_schema` splitter. Result: WP_Query
-	// gets `author__in` / `tag__in` arrays, which are union (OR)
-	// semantics — "posts whose author / tag is ANY of these".
-	const appendIds = ( key: string, v: number | number[] ): void => {
-		const list = Array.isArray( v ) ? v : [ v ];
-		for ( const id of list ) {
-			if ( Number.isFinite( id ) && id > 0 ) {
-				url.searchParams.append( `${ key }[]`, String( id ) );
-			}
-		}
-	};
-	if ( params.author ) {
-		appendIds( 'author', params.author );
-	}
-	if ( params.tag ) {
-		appendIds( 'tags', params.tag );
-	}
-
-	const { data, headers } = await request< PostListItem[] >( url.toString(), {
-		method: 'GET',
-	} );
-
-	return {
-		items: Array.isArray( data ) ? data : [],
-		total: parseInt( headers.get( 'X-WP-Total' ) ?? '0', 10 ) || 0,
-		totalPages: parseInt( headers.get( 'X-WP-TotalPages' ) ?? '0', 10 ) || 0,
-	};
-}
-
-/**
- * Move a single post to the trash. Errors are caught and returned in
- * the result so a bulk caller can keep going on partial failures.
- *
- * Posts that are already in the trash status `DELETE` *without* `force`
- * would be hard-deleted by core. Callers should gate trash actions on
- * `row.status !== 'trash'` to avoid accidental hard deletes.
- *
- * @since 0.8.0
- */
-export async function trashPost( id: number ): Promise< TrashResult > {
-	const cfg = getConfig();
-	try {
-		await request< unknown >( `${ cfg.postsUrl }/${ id }`, {
-			method: 'DELETE',
-		} );
-		return { id, ok: true };
-	} catch ( err ) {
-		return {
-			id,
-			ok: false,
-			error: err instanceof Error ? err.message : String( err ),
-		};
-	}
-}
-
-/**
- * Build the editor URL for a given post id.
- */
-export function buildEditPostUrl( id: number ): string {
-	const cfg = getConfig();
-	const sep = cfg.editPostUrlBase.includes( '?' ) ? '&' : '?';
-	return `${ cfg.editPostUrlBase }${ sep }post=${ id }&action=edit`;
-}
-
-// ---------------------------------------------------------------------------
-// Tag (post_tag taxonomy) CRUD — drives the inline `<wpd-tag-input>` in
-// the Tags column. Three building blocks:
-//
-//   1. searchTags( query )    → autocomplete the popover
-//   2. createTag( name )      → produce a fresh term server-side
-//   3. updatePostTags( id, ids ) → persist the new set of tag ids on a post
-//
-// The bundle calls them in sequence: when the user picks an existing
-// suggestion → updatePostTags. When the user picks "Create '…'" →
-// createTag → updatePostTags. Errors flow back to the column render
-// closure, which rolls back the optimistic UI and surfaces a toast.
-// ---------------------------------------------------------------------------
-
 /** REST shape of a tag (`/wp/v2/tags`). */
 export interface TagTerm {
 	id: number;
@@ -502,107 +258,6 @@ export interface TagTerm {
 	count?: number;
 	link?: string;
 }
-
-/**
- * Fetch tag suggestions matching `query`. Empty `query` returns the
- * 20 most-popular tags (core's default order is `count desc`), which
- * is the "what should I add?" affordance the user gets when they
- * click + with an empty input.
- *
- * @since 0.8.0
- */
-export async function searchTags(
-	query: string,
-	signal?: AbortSignal,
-): Promise< TagTerm[] > {
-	const cfg = getConfig();
-	const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags` );
-	url.searchParams.set( 'per_page', '20' );
-	url.searchParams.set( '_fields', 'id,name,slug,count' );
-	url.searchParams.set( 'orderby', 'count' );
-	url.searchParams.set( 'order', 'desc' );
-	if ( query ) {
-		url.searchParams.set( 'search', query );
-		url.searchParams.set( 'orderby', 'name' );
-		url.searchParams.set( 'order', 'asc' );
-	}
-	const { data } = await request< TagTerm[] >( url.toString(), {
-		method: 'GET',
-		signal,
-	} );
-	return Array.isArray( data ) ? data : [];
-}
-
-/**
- * Create a new tag with the given name. Idempotent against duplicate
- * names — core returns the existing term's id with a `term_exists`
- * code, which we recover from rather than treating as an error so
- * the user can keep typing.
- *
- * Requires `manage_categories` (or filterable `assign_terms`) for
- * the tag taxonomy. Callers should gate the `creatable` flag on the
- * window-config side; we don't second-guess here.
- *
- * @since 0.8.0
- */
-export async function createTag( name: string ): Promise< TagTerm > {
-	const cfg = getConfig();
-	const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags`;
-	try {
-		const { data } = await request< TagTerm >( url, {
-			method: 'POST',
-			body: JSON.stringify( { name } ),
-		} );
-		broadcastTermChange( 'post_tag', 'created', data.id );
-		return data;
-	} catch ( err ) {
-		// Core returns a `term_exists` error with the existing id in
-		// `data.term_id` — recover by fetching that term and pretending
-		// we just created it. Otherwise re-throw.
-		const message = err instanceof Error ? err.message : String( err );
-		// `request<T>` only throws the message; for the recovery we
-		// need to round-trip the JSON body. Fall back to a fresh
-		// search when we can't tell what id WordPress would have
-		// returned — the user gets the existing term either way.
-		if ( /term[\s_]?exists/i.test( message ) ) {
-			const matches = await searchTags( name );
-			const exact = matches.find(
-				( t ) => t.name.toLowerCase() === name.toLowerCase(),
-			);
-			if ( exact ) {
-				return exact;
-			}
-		}
-		throw err;
-	}
-}
-
-/**
- * Replace a post's tag set. The REST `tags` field on `/wp/v2/posts`
- * accepts an array of term ids, so `[]` clears all tags. Returns the
- * persisted post (subset) so callers can reconcile the embedded
- * term list against what the server actually saved.
- *
- * @since 0.8.0
- */
-export async function updatePostTags(
-	postId: number,
-	tagIds: number[],
-): Promise< { id: number; tags: number[] } > {
-	const cfg = getConfig();
-	const url = `${ cfg.postsUrl }/${ postId }`;
-	const { data } = await request< { id: number; tags: number[] } >( url, {
-		method: 'POST',
-		body: JSON.stringify( { tags: tagIds } ),
-	} );
-	return data;
-}
-
-// ---------------------------------------------------------------------------
-// Categories — hierarchical taxonomy. Same shape as tags
-// (`/wp/v2/categories`) but the picker UI walks the `parent` field
-// to render a tree.
-// ---------------------------------------------------------------------------
 
 /** REST shape of a category (`/wp/v2/categories`). */
 export interface CategoryTerm {
@@ -614,71 +269,9 @@ export interface CategoryTerm {
 	link?: string;
 }
 
-/**
- * Fetch the full categories tree. Used once when the user first
- * opens a category picker; the result is cached at the bundle level
- * (see `getCategoryCache` in `src/posts-window/index.ts`) so every
- * row's picker share one round-trip per window-open. Capped at 100
- * — most sites have far fewer; sites with thousands need a separate
- * server-search-driven flow we can layer later.
- *
- * @since 0.8.0
- */
-export async function fetchAllCategories(
-	signal?: AbortSignal,
-): Promise< CategoryTerm[] > {
-	const cfg = getConfig();
-	const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/categories` );
-	url.searchParams.set( 'per_page', '100' );
-	url.searchParams.set( '_fields', 'id,name,slug,parent' );
-	url.searchParams.set( 'orderby', 'name' );
-	url.searchParams.set( 'order', 'asc' );
-	const { data } = await request< CategoryTerm[] >( url.toString(), {
-		method: 'GET',
-		signal,
-	} );
-	return Array.isArray( data ) ? data : [];
-}
-
 export interface AuthorOption {
 	id: number;
 	name: string;
-}
-
-/**
- * List the authors who can write posts. Used to populate the Author
- * column's filter dropdown. Capped at 100 — sites with more authors
- * than that should ship a typeahead instead of a select; v1 trades
- * that off for simplicity.
- *
- * `who=authors` filters down to users with `edit_posts`-style caps
- * (matches the same scoping core uses for the classic Posts list's
- * Author select), so a site with hundreds of subscriber accounts
- * won't drown the dropdown in non-author users.
- *
- * @since 0.8.0
- */
-export async function fetchAuthorOptions(
-	signal?: AbortSignal,
-): Promise< AuthorOption[] > {
-	const cfg = getConfig();
-	const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/users` );
-	url.searchParams.set( 'per_page', '100' );
-	url.searchParams.set( 'who', 'authors' );
-	url.searchParams.set( '_fields', 'id,name' );
-	url.searchParams.set( 'orderby', 'name' );
-	url.searchParams.set( 'order', 'asc' );
-	try {
-		const { data } = await request< AuthorOption[] >( url.toString(), {
-			method: 'GET',
-			signal,
-		} );
-		return Array.isArray( data ) ? data : [];
-	} catch {
-		// Capabilities-gated 401/403 fall through to "no filter
-		// dropdown" rather than killing the table render.
-		return [];
-	}
 }
 
 export interface TagOption {
@@ -691,162 +284,6 @@ export interface TagOptionsPage {
 	items: TagOption[];
 	totalPages: number;
 }
-
-/**
- * Fetch a single page of tag options for the Tag-column filter.
- * Ordered by post count (descending) so the dropdown leads with
- * the tags the user is most likely to filter by; falls back to
- * name-ordered for tags that don't have a count (fresh install).
- *
- * Server pagination — the consumer polls page=2, page=3, … as
- * the user scrolls the popover. `hide_empty` is intentionally OFF
- * so the dropdown lists every tag the user can pick, not just the
- * ones already assigned to a post.
- *
- * @since 0.8.0
- */
-export async function fetchTagOptions(
-	page: number = 1,
-	perPage: number = 50,
-	signal?: AbortSignal,
-): Promise< TagOptionsPage > {
-	const cfg = getConfig();
-	const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags` );
-	url.searchParams.set( 'per_page', String( Math.max( 1, perPage ) ) );
-	url.searchParams.set( 'page', String( Math.max( 1, page ) ) );
-	url.searchParams.set( '_fields', 'id,name,count' );
-	url.searchParams.set( 'orderby', 'count' );
-	url.searchParams.set( 'order', 'desc' );
-	try {
-		const { data, headers } = await request< TagOption[] >(
-			url.toString(),
-			{ method: 'GET', signal },
-		);
-		return {
-			items: Array.isArray( data ) ? data : [],
-			totalPages:
-				parseInt( headers.get( 'X-WP-TotalPages' ) ?? '0', 10 ) || 0,
-		};
-	} catch {
-		return { items: [], totalPages: 0 };
-	}
-}
-
-/**
- * Create a new category, optionally as a child of another. Idempotent
- * against duplicate names *under the same parent* — core returns a
- * `term_exists` error with the existing term's id, which we recover
- * from by re-searching for the name and returning the existing
- * record (so the user can keep typing without bumping into a
- * confusing error).
- *
- * Requires `manage_categories`. Callers should gate the inline
- * create button on their own capability check; we don't second-
- * guess here.
- *
- * @since 0.8.0
- */
-export async function createCategory(
-	name: string,
-	parent: number = 0,
-	opts: { slug?: string; description?: string } = {},
-): Promise< CategoryTerm > {
-	const cfg = getConfig();
-	const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/categories`;
-	const body: Record< string, unknown > = { name, parent };
-	if ( opts.slug ) {
-		body.slug = opts.slug;
-	}
-	if ( opts.description ) {
-		body.description = opts.description;
-	}
-	try {
-		const { data } = await request< CategoryTerm >( url, {
-			method: 'POST',
-			body: JSON.stringify( body ),
-		} );
-		broadcastTermChange( 'category', 'created', data.id );
-		return data;
-	} catch ( err ) {
-		const message = err instanceof Error ? err.message : String( err );
-		if ( /term[\s_]?exists/i.test( message ) ) {
-			// Recover by searching for the name and returning the
-			// matching existing term — nicer UX than surfacing the
-			// raw "term exists" error to the user.
-			const matches = await fetchAllCategories();
-			const exact = matches.find(
-				( t ) =>
-					t.name.toLowerCase() === name.toLowerCase() &&
-					t.parent === parent,
-			);
-			if ( exact ) {
-				return exact;
-			}
-		}
-		throw err;
-	}
-}
-
-/**
- * Notify other parts of the shell that a term was created, updated
- * or deleted. Subscribers (e.g. the post-row category picker, which
- * caches the full tree per window-open) clear their caches so they
- * pick up the change without needing F5.
- *
- * Channel: `desktop-mode.term.changed`. Payload:
- * `{ taxonomy: 'category' | 'post_tag', action, id }`.
- */
-function broadcastTermChange(
-	taxonomy: 'category' | 'post_tag',
-	action: 'created' | 'updated' | 'deleted',
-	id: number,
-): void {
-	const api = (
-		window as unknown as {
-			wp?: {
-				desktop?: {
-					broadcast?: (
-						channel: string,
-						payload: unknown,
-					) => void;
-				};
-			};
-		}
-	).wp?.desktop;
-	if ( api && typeof api.broadcast === 'function' ) {
-		api.broadcast( 'desktop-mode.term.changed', {
-			source: 'posts-window',
-			taxonomy,
-			action,
-			id,
-		} );
-	}
-}
-
-/**
- * Replace a post's category set. WordPress auto-applies
- * "Uncategorized" server-side when the array is empty, so we don't
- * need to send the term explicitly — passing `[]` is the canonical
- * way to "clear all categories" and inherit the fallback.
- *
- * @since 0.8.0
- */
-export async function updatePostCategories(
-	postId: number,
-	categoryIds: number[],
-): Promise< { id: number; categories: number[] } > {
-	const cfg = getConfig();
-	const url = `${ cfg.postsUrl }/${ postId }`;
-	const { data } = await request< { id: number; categories: number[] } >( url, {
-		method: 'POST',
-		body: JSON.stringify( { categories: categoryIds } ),
-	} );
-	return data;
-}
-
-// ---------------------------------------------------------------------------
-// Term management (Categories + Tags tabs)
-// ---------------------------------------------------------------------------
 
 /**
  * Common shape for both categories and tags as displayed in the term-
@@ -891,125 +328,589 @@ export interface TermsListParams {
 	parent?: number;
 }
 
+interface RequestOptions extends RequestInit {
+	/** Set to `false` to skip `response.json()` (e.g. `DELETE` 200 with no body). */
+	expectJson?: boolean;
+}
+
+interface RequestResult< T > {
+	data: T;
+	headers: Headers;
+}
+
 /**
- * Page fetcher for either categories or tags. Returns the bare term
- * shape we render in the table (id/name/slug/parent/count/description)
- * plus the X-WP-Total / X-WP-TotalPages totals so the pager + stats
- * strip can show real numbers without re-counting.
+ * Per-window REST client. Returned by {@link createPostsWindowClient}
+ * and threaded through render code instead of imported as free
+ * functions.
  *
- * @since 0.8.0
+ * Every method reads config and attributes its `trackedFetch` call
+ * to the client's bound `windowId`, so two windows of the same
+ * bundle (Posts + Pages, Users + User-edit) cannot read each
+ * other's config or steal each other's title-bar spinner.
+ *
+ * @since 0.18.x
  */
-export async function fetchTerms(
-	taxonomy: 'categories' | 'tags',
-	params: TermsListParams = {},
-): Promise< TermsListPage > {
-	const cfg = getConfig();
-	const url = new URL(
-		`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }`,
-	);
-	url.searchParams.set( 'per_page', String( params.perPage ?? 50 ) );
-	url.searchParams.set( 'page', String( params.page ?? 1 ) );
-	url.searchParams.set(
-		'_fields',
-		'id,name,slug,parent,count,description,desktop_mode_count,desktop_mode_is_default',
-	);
-	url.searchParams.set( 'orderby', params.orderby ?? 'name' );
-	url.searchParams.set( 'order', params.order ?? 'asc' );
-	if ( params.search ) {
-		url.searchParams.set( 'search', params.search );
-	}
-	if ( typeof params.parent === 'number' && params.parent >= 0 ) {
-		url.searchParams.set( 'parent', String( params.parent ) );
-	}
-	const { data, headers } = await request< Array< Partial< TermRow > > >(
-		url.toString(),
-		{ method: 'GET' },
-	);
-	const items: TermRow[] = Array.isArray( data )
-		? data.map( ( t ) => {
-			// Prefer the any-status count (includes drafts + pending)
-			// when the server emits it; fall back to core's `count`
-			// for older PHP builds that predate the custom field.
-			const anyCount = ( t as { desktop_mode_count?: number } )
-				.desktop_mode_count;
-			const isDefault = ( t as { desktop_mode_is_default?: boolean } )
-				.desktop_mode_is_default === true;
-			return {
-				id: ( t.id as number ) ?? 0,
-				name: ( t.name as string ) ?? '',
-				slug: ( t.slug as string ) ?? '',
-				parent: ( t.parent as number ) ?? 0,
-				count:
-					typeof anyCount === 'number'
-						? anyCount
-						: ( t.count as number ) ?? 0,
-				description: ( t.description as string ) ?? '',
-				isDefault,
+export interface PostsWindowClient {
+	readonly windowId: string;
+	getConfig(): PostsWindowConfig;
+	fetchPosts( params?: PostsListParams ): Promise< PostsListResponse >;
+	trashPost( id: number ): Promise< TrashResult >;
+	buildEditPostUrl( id: number ): string;
+	searchTags( query: string, signal?: AbortSignal ): Promise< TagTerm[] >;
+	createTag( name: string ): Promise< TagTerm >;
+	updatePostTags(
+		postId: number,
+		tagIds: number[],
+	): Promise< { id: number; tags: number[] } >;
+	fetchAllCategories( signal?: AbortSignal ): Promise< CategoryTerm[] >;
+	fetchAuthorOptions( signal?: AbortSignal ): Promise< AuthorOption[] >;
+	fetchTagOptions(
+		page?: number,
+		perPage?: number,
+		signal?: AbortSignal,
+	): Promise< TagOptionsPage >;
+	createCategory(
+		name: string,
+		parent?: number,
+		opts?: { slug?: string; description?: string },
+	): Promise< CategoryTerm >;
+	updatePostCategories(
+		postId: number,
+		categoryIds: number[],
+	): Promise< { id: number; categories: number[] } >;
+	fetchTerms(
+		taxonomy: 'categories' | 'tags',
+		params?: TermsListParams,
+	): Promise< TermsListPage >;
+	updateTerm(
+		taxonomy: 'categories' | 'tags',
+		id: number,
+		patch: Partial< Pick< TermRow, 'name' | 'slug' | 'description' | 'parent' > >,
+	): Promise< TermRow >;
+	deleteTerm( taxonomy: 'categories' | 'tags', id: number ): Promise< void >;
+}
+
+/**
+ * Notify other parts of the shell that a term was created, updated
+ * or deleted. Subscribers (e.g. the post-row category picker, which
+ * caches the full tree per window-open) clear their caches so they
+ * pick up the change without needing F5.
+ *
+ * Channel: `desktop-mode.term.changed`. Payload:
+ * `{ taxonomy: 'category' | 'post_tag', action, id }`.
+ *
+ * @internal
+ */
+function broadcastTermChange(
+	taxonomy: 'category' | 'post_tag',
+	action: 'created' | 'updated' | 'deleted',
+	id: number,
+): void {
+	const api = (
+		window as unknown as {
+			wp?: {
+				desktop?: {
+					broadcast?: (
+						channel: string,
+						payload: unknown,
+					) => void;
+				};
 			};
-		} )
-		: [];
-	return {
-		items,
-		total: parseInt( headers.get( 'X-WP-Total' ) ?? '0', 10 ) || 0,
-		totalPages: parseInt( headers.get( 'X-WP-TotalPages' ) ?? '0', 10 ) || 0,
-	};
+		}
+	).wp?.desktop;
+	if ( api && typeof api.broadcast === 'function' ) {
+		api.broadcast( 'desktop-mode.term.changed', {
+			source: 'posts-window',
+			taxonomy,
+			action,
+			id,
+		} );
+	}
 }
 
 /**
- * Update a term — rename, change slug, change parent (categories only),
- * or rewrite description. Pass only the fields the user changed; core
- * preserves untouched fields.
+ * Build a Posts/Pages REST client bound to a single window id.
  *
- * @since 0.8.0
+ * @param windowId The native-window id this client is attached to
+ *                 (`'desktop-mode-posts'`, `'desktop-mode-pages'`, …). All
+ *                 `getConfig()` reads key off this id, and every fetch is
+ *                 attributed to it via `trackedFetch`'s `windowId` option.
+ *
+ * @since 0.18.x
  */
-export async function updateTerm(
-	taxonomy: 'categories' | 'tags',
-	id: number,
-	patch: Partial< Pick< TermRow, 'name' | 'slug' | 'description' | 'parent' > >,
-): Promise< TermRow > {
-	const cfg = getConfig();
-	const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }/${ id }`;
-	const { data } = await request< Partial< TermRow > >( url, {
-		method: 'POST',
-		body: JSON.stringify( patch ),
-	} );
-	broadcastTermChange(
-		taxonomy === 'categories' ? 'category' : 'post_tag',
-		'updated',
-		id,
-	);
-	return {
-		id: data.id ?? id,
-		name: data.name ?? '',
-		slug: data.slug ?? '',
-		parent: data.parent ?? 0,
-		count: data.count ?? 0,
-		description: data.description ?? '',
-		isDefault: ( data.isDefault as boolean | undefined ) ?? false,
+export function createPostsWindowClient(
+	windowId: string,
+): PostsWindowClient {
+	const getConfig = (): PostsWindowConfig => {
+		const store = window.desktopModeWindowConfig;
+		const cfg = store
+			? ( store[ windowId ] as PostsWindowConfig | undefined )
+			: undefined;
+		if ( ! cfg ) {
+			throw new Error(
+				`[${ windowId }] config blob is missing — was the window opened ` +
+					'without registration? See the matching `desktop_mode_register_window()` ' +
+					'call in `includes/{posts,pages}-window/window.php`.',
+			);
+		}
+		return cfg;
 	};
-}
 
-/**
- * Force-delete a term. Matches WP core behavior: posts assigned to a
- * deleted category fall through to the "Uncategorized" default
- * automatically (taxonomy default term wiring); tags just disappear
- * from their assigned posts.
- *
- * @since 0.8.0
- */
-export async function deleteTerm(
-	taxonomy: 'categories' | 'tags',
-	id: number,
-): Promise< void > {
-	const cfg = getConfig();
-	const url = new URL(
-		`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }/${ id }`,
-	);
-	url.searchParams.set( 'force', 'true' );
-	await request( url.toString(), { method: 'DELETE' } );
-	broadcastTermChange(
-		taxonomy === 'categories' ? 'category' : 'post_tag',
-		'deleted',
-		id,
-	);
+	const shellFetch = (
+		input: RequestInfo,
+		init?: RequestInit,
+	): Promise< Response > => {
+		return trackedFetch( input, init, { windowId } );
+	};
+
+	const request = async < T >(
+		url: string,
+		init: RequestOptions = {},
+	): Promise< RequestResult< T > > => {
+		const cfg = getConfig();
+		const response = await shellFetch( url, {
+			...init,
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': cfg.restNonce,
+				Accept: 'application/json',
+				...( init.body ? { 'Content-Type': 'application/json' } : {} ),
+				...( init.headers ?? {} ),
+			},
+		} );
+
+		if ( ! response.ok ) {
+			// Surface WP_Error JSON when present; fall back to the status
+			// line otherwise. Either way callers get a thrown Error they
+			// can show inline.
+			let message = `${ response.status } ${ response.statusText }`;
+			try {
+				const json = ( await response.json() ) as { message?: string };
+				if ( json && typeof json.message === 'string' ) {
+					message = json.message;
+				}
+			} catch {
+				// Ignore — non-JSON body, use the status line.
+			}
+			throw new Error( message );
+		}
+
+		const data =
+			init.expectJson === false
+				? ( null as unknown as T )
+				: ( ( await response.json() ) as T );
+		return { data, headers: response.headers };
+	};
+
+	const fetchPosts = async (
+		params: PostsListParams = {},
+	): Promise< PostsListResponse > => {
+		const cfg = getConfig();
+		const url = new URL( cfg.postsUrl );
+
+		// Merge the PHP-declared default query args first (so `_fields`,
+		// `_embed`, and a custom `post_type` from the filter all flow through).
+		for ( const [ key, value ] of Object.entries( cfg.queryArgs ?? {} ) ) {
+			if ( typeof value === 'string' && value !== '' ) {
+				url.searchParams.set( key, value );
+			}
+		}
+
+		if ( params.page ) {
+			url.searchParams.set( 'page', String( params.page ) );
+		}
+		if ( params.perPage ) {
+			url.searchParams.set( 'per_page', String( params.perPage ) );
+		}
+		if ( params.search ) {
+			url.searchParams.set( 'search', params.search );
+		}
+		// `status` quirk: when the param is omitted, core's REST handler
+		// defaults to `publish` only — drafts / pending / scheduled /
+		// private silently disappear from "All". Send `status=any` for
+		// the empty-segment case so the "All" tab actually means *all*
+		// the statuses the current user can see (excluding `trash`,
+		// which has its own segment).
+		if ( params.status ) {
+			url.searchParams.set( 'status', params.status );
+		} else {
+			url.searchParams.set( 'status', 'any' );
+		}
+		if ( params.orderby ) {
+			url.searchParams.set( 'orderby', params.orderby );
+		}
+		if ( params.order ) {
+			url.searchParams.set( 'order', params.order );
+		}
+		// Both `author` and `tags` REST params are registered as arrays
+		// of integers. We send them as `author[]=1&author[]=2` (and
+		// `tags[]=...`) — PHP's `parse_str` handles bracketed array
+		// notation unambiguously, whereas comma-separated values can be
+		// interpreted as a single string by some hosts / security
+		// modules / REST middleware that don't run the schema-aware
+		// `rest_sanitize_value_from_schema` splitter. Result: WP_Query
+		// gets `author__in` / `tag__in` arrays, which are union (OR)
+		// semantics — "posts whose author / tag is ANY of these".
+		const appendIds = ( key: string, v: number | number[] ): void => {
+			const list = Array.isArray( v ) ? v : [ v ];
+			for ( const id of list ) {
+				if ( Number.isFinite( id ) && id > 0 ) {
+					url.searchParams.append( `${ key }[]`, String( id ) );
+				}
+			}
+		};
+		if ( params.author ) {
+			appendIds( 'author', params.author );
+		}
+		if ( params.tag ) {
+			appendIds( 'tags', params.tag );
+		}
+
+		const { data, headers } = await request< PostListItem[] >(
+			url.toString(),
+			{ method: 'GET' },
+		);
+
+		return {
+			items: Array.isArray( data ) ? data : [],
+			total: parseInt( headers.get( 'X-WP-Total' ) ?? '0', 10 ) || 0,
+			totalPages:
+				parseInt( headers.get( 'X-WP-TotalPages' ) ?? '0', 10 ) || 0,
+		};
+	};
+
+	const trashPost = async ( id: number ): Promise< TrashResult > => {
+		const cfg = getConfig();
+		try {
+			await request< unknown >( `${ cfg.postsUrl }/${ id }`, {
+				method: 'DELETE',
+			} );
+			return { id, ok: true };
+		} catch ( err ) {
+			return {
+				id,
+				ok: false,
+				error: err instanceof Error ? err.message : String( err ),
+			};
+		}
+	};
+
+	const buildEditPostUrl = ( id: number ): string => {
+		const cfg = getConfig();
+		const sep = cfg.editPostUrlBase.includes( '?' ) ? '&' : '?';
+		return `${ cfg.editPostUrlBase }${ sep }post=${ id }&action=edit`;
+	};
+
+	const searchTags = async (
+		query: string,
+		signal?: AbortSignal,
+	): Promise< TagTerm[] > => {
+		const cfg = getConfig();
+		const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags` );
+		url.searchParams.set( 'per_page', '20' );
+		url.searchParams.set( '_fields', 'id,name,slug,count' );
+		url.searchParams.set( 'orderby', 'count' );
+		url.searchParams.set( 'order', 'desc' );
+		if ( query ) {
+			url.searchParams.set( 'search', query );
+			url.searchParams.set( 'orderby', 'name' );
+			url.searchParams.set( 'order', 'asc' );
+		}
+		const { data } = await request< TagTerm[] >( url.toString(), {
+			method: 'GET',
+			signal,
+		} );
+		return Array.isArray( data ) ? data : [];
+	};
+
+	const createTag = async ( name: string ): Promise< TagTerm > => {
+		const cfg = getConfig();
+		const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags`;
+		try {
+			const { data } = await request< TagTerm >( url, {
+				method: 'POST',
+				body: JSON.stringify( { name } ),
+			} );
+			broadcastTermChange( 'post_tag', 'created', data.id );
+			return data;
+		} catch ( err ) {
+			// Core returns a `term_exists` error with the existing id in
+			// `data.term_id` — recover by fetching that term and pretending
+			// we just created it. Otherwise re-throw.
+			const message = err instanceof Error ? err.message : String( err );
+			if ( /term[\s_]?exists/i.test( message ) ) {
+				const matches = await searchTags( name );
+				const exact = matches.find(
+					( t ) => t.name.toLowerCase() === name.toLowerCase(),
+				);
+				if ( exact ) {
+					return exact;
+				}
+			}
+			throw err;
+		}
+	};
+
+	const updatePostTags = async (
+		postId: number,
+		tagIds: number[],
+	): Promise< { id: number; tags: number[] } > => {
+		const cfg = getConfig();
+		const url = `${ cfg.postsUrl }/${ postId }`;
+		const { data } = await request< { id: number; tags: number[] } >( url, {
+			method: 'POST',
+			body: JSON.stringify( { tags: tagIds } ),
+		} );
+		return data;
+	};
+
+	const fetchAllCategories = async (
+		signal?: AbortSignal,
+	): Promise< CategoryTerm[] > => {
+		const cfg = getConfig();
+		const url = new URL(
+			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/categories`,
+		);
+		url.searchParams.set( 'per_page', '100' );
+		url.searchParams.set( '_fields', 'id,name,slug,parent' );
+		url.searchParams.set( 'orderby', 'name' );
+		url.searchParams.set( 'order', 'asc' );
+		const { data } = await request< CategoryTerm[] >( url.toString(), {
+			method: 'GET',
+			signal,
+		} );
+		return Array.isArray( data ) ? data : [];
+	};
+
+	const fetchAuthorOptions = async (
+		signal?: AbortSignal,
+	): Promise< AuthorOption[] > => {
+		const cfg = getConfig();
+		const url = new URL(
+			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/users`,
+		);
+		url.searchParams.set( 'per_page', '100' );
+		url.searchParams.set( 'who', 'authors' );
+		url.searchParams.set( '_fields', 'id,name' );
+		url.searchParams.set( 'orderby', 'name' );
+		url.searchParams.set( 'order', 'asc' );
+		try {
+			const { data } = await request< AuthorOption[] >( url.toString(), {
+				method: 'GET',
+				signal,
+			} );
+			return Array.isArray( data ) ? data : [];
+		} catch {
+			// Capabilities-gated 401/403 fall through to "no filter
+			// dropdown" rather than killing the table render.
+			return [];
+		}
+	};
+
+	const fetchTagOptions = async (
+		page: number = 1,
+		perPage: number = 50,
+		signal?: AbortSignal,
+	): Promise< TagOptionsPage > => {
+		const cfg = getConfig();
+		const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags` );
+		url.searchParams.set( 'per_page', String( Math.max( 1, perPage ) ) );
+		url.searchParams.set( 'page', String( Math.max( 1, page ) ) );
+		url.searchParams.set( '_fields', 'id,name,count' );
+		url.searchParams.set( 'orderby', 'count' );
+		url.searchParams.set( 'order', 'desc' );
+		try {
+			const { data, headers } = await request< TagOption[] >(
+				url.toString(),
+				{ method: 'GET', signal },
+			);
+			return {
+				items: Array.isArray( data ) ? data : [],
+				totalPages:
+					parseInt( headers.get( 'X-WP-TotalPages' ) ?? '0', 10 ) || 0,
+			};
+		} catch {
+			return { items: [], totalPages: 0 };
+		}
+	};
+
+	const createCategory = async (
+		name: string,
+		parent: number = 0,
+		opts: { slug?: string; description?: string } = {},
+	): Promise< CategoryTerm > => {
+		const cfg = getConfig();
+		const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/categories`;
+		const body: Record< string, unknown > = { name, parent };
+		if ( opts.slug ) {
+			body.slug = opts.slug;
+		}
+		if ( opts.description ) {
+			body.description = opts.description;
+		}
+		try {
+			const { data } = await request< CategoryTerm >( url, {
+				method: 'POST',
+				body: JSON.stringify( body ),
+			} );
+			broadcastTermChange( 'category', 'created', data.id );
+			return data;
+		} catch ( err ) {
+			const message = err instanceof Error ? err.message : String( err );
+			if ( /term[\s_]?exists/i.test( message ) ) {
+				// Recover by searching for the name and returning the
+				// matching existing term — nicer UX than surfacing the
+				// raw "term exists" error to the user.
+				const matches = await fetchAllCategories();
+				const exact = matches.find(
+					( t ) =>
+						t.name.toLowerCase() === name.toLowerCase() &&
+						t.parent === parent,
+				);
+				if ( exact ) {
+					return exact;
+				}
+			}
+			throw err;
+		}
+	};
+
+	const updatePostCategories = async (
+		postId: number,
+		categoryIds: number[],
+	): Promise< { id: number; categories: number[] } > => {
+		const cfg = getConfig();
+		const url = `${ cfg.postsUrl }/${ postId }`;
+		const { data } = await request< { id: number; categories: number[] } >(
+			url,
+			{
+				method: 'POST',
+				body: JSON.stringify( { categories: categoryIds } ),
+			},
+		);
+		return data;
+	};
+
+	const fetchTerms = async (
+		taxonomy: 'categories' | 'tags',
+		params: TermsListParams = {},
+	): Promise< TermsListPage > => {
+		const cfg = getConfig();
+		const url = new URL(
+			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }`,
+		);
+		url.searchParams.set( 'per_page', String( params.perPage ?? 50 ) );
+		url.searchParams.set( 'page', String( params.page ?? 1 ) );
+		url.searchParams.set(
+			'_fields',
+			'id,name,slug,parent,count,description,desktop_mode_count,desktop_mode_is_default',
+		);
+		url.searchParams.set( 'orderby', params.orderby ?? 'name' );
+		url.searchParams.set( 'order', params.order ?? 'asc' );
+		if ( params.search ) {
+			url.searchParams.set( 'search', params.search );
+		}
+		if ( typeof params.parent === 'number' && params.parent >= 0 ) {
+			url.searchParams.set( 'parent', String( params.parent ) );
+		}
+		const { data, headers } = await request< Array< Partial< TermRow > > >(
+			url.toString(),
+			{ method: 'GET' },
+		);
+		const items: TermRow[] = Array.isArray( data )
+			? data.map( ( t ) => {
+				// Prefer the any-status count (includes drafts + pending)
+				// when the server emits it; fall back to core's `count`
+				// for older PHP builds that predate the custom field.
+				const anyCount = ( t as { desktop_mode_count?: number } )
+					.desktop_mode_count;
+				const isDefault =
+					( t as { desktop_mode_is_default?: boolean } )
+						.desktop_mode_is_default === true;
+				return {
+					id: ( t.id as number ) ?? 0,
+					name: ( t.name as string ) ?? '',
+					slug: ( t.slug as string ) ?? '',
+					parent: ( t.parent as number ) ?? 0,
+					count:
+						typeof anyCount === 'number'
+							? anyCount
+							: ( t.count as number ) ?? 0,
+					description: ( t.description as string ) ?? '',
+					isDefault,
+				};
+			} )
+			: [];
+		return {
+			items,
+			total: parseInt( headers.get( 'X-WP-Total' ) ?? '0', 10 ) || 0,
+			totalPages:
+				parseInt( headers.get( 'X-WP-TotalPages' ) ?? '0', 10 ) || 0,
+		};
+	};
+
+	const updateTerm = async (
+		taxonomy: 'categories' | 'tags',
+		id: number,
+		patch: Partial<
+			Pick< TermRow, 'name' | 'slug' | 'description' | 'parent' >
+		>,
+	): Promise< TermRow > => {
+		const cfg = getConfig();
+		const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }/${ id }`;
+		const { data } = await request< Partial< TermRow > >( url, {
+			method: 'POST',
+			body: JSON.stringify( patch ),
+		} );
+		broadcastTermChange(
+			taxonomy === 'categories' ? 'category' : 'post_tag',
+			'updated',
+			id,
+		);
+		return {
+			id: data.id ?? id,
+			name: data.name ?? '',
+			slug: data.slug ?? '',
+			parent: data.parent ?? 0,
+			count: data.count ?? 0,
+			description: data.description ?? '',
+			isDefault: ( data.isDefault as boolean | undefined ) ?? false,
+		};
+	};
+
+	const deleteTerm = async (
+		taxonomy: 'categories' | 'tags',
+		id: number,
+	): Promise< void > => {
+		const cfg = getConfig();
+		const url = new URL(
+			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }/${ id }`,
+		);
+		url.searchParams.set( 'force', 'true' );
+		await request( url.toString(), { method: 'DELETE' } );
+		broadcastTermChange(
+			taxonomy === 'categories' ? 'category' : 'post_tag',
+			'deleted',
+			id,
+		);
+	};
+
+	return {
+		windowId,
+		getConfig,
+		fetchPosts,
+		trashPost,
+		buildEditPostUrl,
+		searchTags,
+		createTag,
+		updatePostTags,
+		fetchAllCategories,
+		fetchAuthorOptions,
+		fetchTagOptions,
+		createCategory,
+		updatePostCategories,
+		fetchTerms,
+		updateTerm,
+		deleteTerm,
+	};
 }

--- a/src/posts-window/tags-cloud.ts
+++ b/src/posts-window/tags-cloud.ts
@@ -31,14 +31,7 @@
 
 import { __, sprintf } from '../i18n';
 import { trackedFetch } from '../tracked-fetch';
-import {
-	createTag,
-	deleteTerm,
-	fetchTerms,
-	updateTerm,
-	getConfig,
-	type TermRow,
-} from './rest';
+import { type PostsWindowClient, type TermRow } from './rest';
 
 interface PixiPoint {
 	x: number;
@@ -217,6 +210,7 @@ const SPOTLIGHT_RADIUS = POST_RING_RADIUS + 130;
  */
 export async function mountTagsCloud(
 	host: HTMLElement,
+	client: PostsWindowClient,
 ): Promise< () => void > {
 	const api = window.wp?.desktop;
 	if ( ! api || typeof api.loadModules !== 'function' ) {
@@ -424,7 +418,7 @@ export async function mountTagsCloud(
 		const all: TermRow[] = [];
 		let page = 1;
 		while ( page <= 5 ) {
-			const res = await fetchTerms( 'tags', { page, perPage: 100 } );
+			const res = await client.fetchTerms( 'tags', { page, perPage: 100 } );
 			all.push( ...res.items );
 			if ( page >= res.totalPages ) {
 				break;
@@ -1282,7 +1276,7 @@ export async function mountTagsCloud(
 			applyPostsResult( cached, myFocusId );
 			return;
 		}
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		const url = new URL( cfg.postsUrl );
 		url.searchParams.set( 'tags', String( focusId ) );
 		url.searchParams.set( 'per_page', String( POST_PER_PAGE ) );
@@ -1290,7 +1284,7 @@ export async function mountTagsCloud(
 		url.searchParams.set( 'status', 'any' );
 		url.searchParams.set( '_fields', 'id,title,status' );
 		try {
-			const response = await fetchShellJson( url.toString() );
+			const response = await fetchShellJson( client, url.toString() );
 			if ( mySeq !== loadSeq || focusId !== myFocusId ) {
 				return;
 			}
@@ -1534,7 +1528,7 @@ export async function mountTagsCloud(
 			}
 			createBtn.disabled = true;
 			try {
-				const created = await createTag( name );
+				const created = await client.createTag( name );
 				const next: TermRow = {
 					id: created.id,
 					name: created.name,
@@ -1558,7 +1552,7 @@ export async function mountTagsCloud(
 				const desc = descInput.value.trim();
 				if ( desc ) {
 					try {
-						const updated = await updateTerm(
+						const updated = await client.updateTerm(
 							'tags',
 							created.id,
 							{ description: desc },
@@ -1745,7 +1739,7 @@ export async function mountTagsCloud(
 				patch.slug = slugRaw;
 			}
 			try {
-				const updated = await updateTerm( 'tags', box.id, patch );
+				const updated = await client.updateTerm( 'tags', box.id, patch );
 				box.name = updated.name;
 				box.description = updated.description;
 				box.slug = updated.slug ?? box.slug;
@@ -1797,7 +1791,7 @@ export async function mountTagsCloud(
 				armResetTimer = null;
 			}
 			try {
-				await deleteTerm( 'tags', box.id );
+				await client.deleteTerm( 'tags', box.id );
 				terms = terms.filter( ( t ) => t.id !== box.id );
 				persistedPositions.delete( box.id );
 				writePersistedPositions( positionsKey, persistedPositions );
@@ -1973,7 +1967,7 @@ export async function mountTagsCloud(
 		if ( terms.length === 0 ) {
 			return;
 		}
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		const url = new URL(
 			`${ cfg.restRoot.replace( /\/$/, '' ) }/desktop-mode/v1/term-counts`,
 		);
@@ -1986,7 +1980,7 @@ export async function mountTagsCloud(
 			terms.map( ( t ) => t.id ).join( ',' ),
 		);
 		try {
-			const response = await fetchShellJson( url.toString() );
+			const response = await fetchShellJson( client, url.toString() );
 			const map = response.json as Record< string, number >;
 			let dirty = false;
 			terms = terms.map( ( t ) => {
@@ -2261,8 +2255,11 @@ interface ShellJsonResponse {
 	headers: Headers;
 }
 
-async function fetchShellJson( url: string ): Promise< ShellJsonResponse > {
-	const cfg = getConfig();
+async function fetchShellJson(
+	client: PostsWindowClient,
+	url: string,
+): Promise< ShellJsonResponse > {
+	const cfg = client.getConfig();
 	const init: RequestInit = {
 		method: 'GET',
 		credentials: 'same-origin',

--- a/src/posts-window/user-edit-render.ts
+++ b/src/posts-window/user-edit-render.ts
@@ -24,14 +24,44 @@
 import { __, sprintf } from '../i18n';
 import { trackedFetch } from '../tracked-fetch';
 import { applyAvatarSrc } from '../ui/util/avatar-resolve';
-import { getActiveWindowId, getConfig, type PostsWindowConfig } from './rest';
+import { type PostsWindowConfig } from './rest';
 import {
-	fetchInsights,
-	fetchUser,
-	saveUser,
+	createUserEditClient,
+	type UserEditClient,
 	type UserEditRecord,
 	type UserInsightsPayload,
 } from './user-edit-rest';
+
+/**
+ * Resolve a {@link UserEditClient} from whichever window happens to
+ * host the user-edit surface right now.
+ *
+ * `<wpd-user-profile>` mounts in two contexts: the dedicated
+ * `desktop-mode-user-edit` window AND the Users window's Profile
+ * sub-tab (viewer's own profile). Both windows ship a compatible
+ * config blob (`restRoot` / `restNonce` / `usersUrl` /
+ * `insightsUrlBase`), so a fallback chain works without each
+ * caller knowing which window it's running in.
+ *
+ * Prefer the user-edit window's own blob when present so the
+ * spinner attribution lights up the right title bar.
+ */
+function resolveUserEditClient(): UserEditClient {
+	const store = (
+		window as unknown as {
+			desktopModeWindowConfig?: Record< string, unknown >;
+		}
+	).desktopModeWindowConfig;
+	if ( store?.[ 'desktop-mode-user-edit' ] ) {
+		return createUserEditClient( 'desktop-mode-user-edit' );
+	}
+	if ( store?.[ 'desktop-mode-users' ] ) {
+		return createUserEditClient( 'desktop-mode-users' );
+	}
+	// Last-resort — let the client itself throw with the canonical
+	// error message so the call site doesn't have to invent one.
+	return createUserEditClient( 'desktop-mode-user-edit' );
+}
 // `./user-edit-target` is read by the Users-window render shell
 // (`users-render.ts:wireProfileSubTab`); this module exposes
 // mount points only.
@@ -166,7 +196,7 @@ async function loadAndMountProfile(
 
 	let user: UserEditRecord;
 	try {
-		user = await fetchUser( userId );
+		user = await resolveUserEditClient().fetchUser( userId );
 	} catch ( err ) {
 		host.replaceChildren();
 		const msg = document.createElement( 'p' );
@@ -189,22 +219,16 @@ async function loadAndMountProfile(
 /**
  * Merged config bag for the user-edit form.
  *
- * `getConfig()` keys on the globally-active window id, which can
- * have drifted to a sibling window (Posts, Pages, …) by the time
- * the form re-mounts. Sibling configs carry restRoot / restNonce
- * but lack profile-specific keys: `allRoles`, `assignableRoles`,
- * `colorSchemes`, `locales`, `contactMethods`, `canPromote`. Without
- * the fallback, the form renders with empty role + colour-scheme
- * pickers, no locale options, etc.
- *
- * We layer the user-edit window's own blob underneath the live
- * `getConfig()` so every key has a backstop, and prefer
- * `desktop-mode-users` when user-edit isn't in the store (which
- * shouldn't happen in practice but keeps the Users window's
- * Profile sub-tab self-sufficient).
+ * `<wpd-user-profile>` mounts in either the user-edit window or
+ * the Users window's Profile sub-tab. Sibling-window configs
+ * (Posts, Pages, …) carry `restRoot` / `restNonce` but lack
+ * profile-specific keys (`allRoles`, `assignableRoles`,
+ * `colorSchemes`, `locales`, `contactMethods`, `canPromote`).
+ * Merge user-edit on top of users on top of the resolved client
+ * config so every key has a backstop without depending on which
+ * window the component happens to live in.
  */
 function resolveProfileConfig(): Record< string, unknown > {
-	const current = getConfig() as unknown as Record< string, unknown >;
 	const store = ( window as unknown as {
 		desktopModeWindowConfig?: Record<
 			string,
@@ -216,7 +240,6 @@ function resolveProfileConfig(): Record< string, unknown > {
 	return {
 		...( users ?? {} ),
 		...( userEdit ?? {} ),
-		...current,
 	};
 }
 
@@ -633,7 +656,7 @@ function mountProfileForm(
 			patch.meta = meta;
 		}
 
-		const result = await saveUser( userId, patch );
+		const result = await resolveUserEditClient().saveUser( userId, patch );
 
 		pending = false;
 		form.setBusy( false );
@@ -657,6 +680,27 @@ function mountProfileForm(
 		}
 
 		notifyToast( __( 'Profile saved.' ), 'success' );
+
+		// Broadcast so the Users window (and any other live listener)
+		// can refresh its row for this user without an F5. Mirrors the
+		// `desktop-mode.post.changed` pattern used by Posts.
+		const broadcastApi = (
+			window as unknown as {
+				wp?: {
+					desktop?: {
+						broadcast?: (
+							channel: string,
+							payload: unknown,
+						) => void;
+					};
+				};
+			}
+		).wp?.desktop;
+		broadcastApi?.broadcast?.( 'desktop-mode.user.changed', {
+			source: 'user-edit-window',
+			action: 'updated',
+			ids: [ userId ],
+		} );
 		// Clear password fields after a successful change so a Save
 		// after another edit doesn't accidentally re-submit them.
 		pwd.value = '';
@@ -762,7 +806,7 @@ async function loadInsightsInto(
 	skeleton.textContent = __( 'Loading insights…' );
 	host.appendChild( skeleton );
 	try {
-		return await fetchInsights( userId, { fresh } );
+		return await resolveUserEditClient().fetchInsights( userId, { fresh } );
 	} catch ( err ) {
 		host.replaceChildren();
 		const msg = document.createElement( 'p' );
@@ -1482,11 +1526,6 @@ function mapErrorCode( code: string | undefined ): string | null {
 			return null;
 	}
 }
-// `getActiveWindowId` is read inside `shellFetch` upstream; importing
-// it keeps the bundle's tree-shaken graph stable when the user-edit
-// module loads in isolation.
-void getActiveWindowId;
-
 // ─── Admin colour scheme picker ─────────────────────────────────────
 
 interface ColorSchemeInfo {
@@ -1749,7 +1788,7 @@ function buildSessionsRow( userId: number, isSelfEdit: boolean ): HTMLElement {
 	btn.addEventListener( 'click', async ( e ) => {
 		e.preventDefault();
 		try {
-			const cfg = getConfig();
+			const cfg = resolveUserEditClient().getConfig();
 			const base =
 				( cfg as unknown as { insightsUrlBase?: string } )
 					.insightsUrlBase ??
@@ -1816,7 +1855,7 @@ function buildAppPasswordsRow( userId: number ): HTMLElement {
 	heading.appendChild( headLabel );
 	wrap.appendChild( heading );
 
-	const cfg = getConfig();
+	const cfg = resolveUserEditClient().getConfig();
 	const base =
 		( cfg as unknown as { insightsUrlBase?: string } ).insightsUrlBase ??
 		`${ cfg.restRoot }desktop-mode/v1/users/`;

--- a/src/posts-window/user-edit-rest.ts
+++ b/src/posts-window/user-edit-rest.ts
@@ -10,7 +10,7 @@
  */
 
 import { trackedFetch } from '../tracked-fetch';
-import { getActiveWindowId, getConfig } from './rest';
+import type { PostsWindowConfig } from './rest';
 
 export interface UserEditRecord {
 	id: number;
@@ -84,46 +84,6 @@ export interface UserInsightsPayload {
 	};
 }
 
-function shellFetch(
-	input: RequestInfo,
-	init?: RequestInit,
-	source?: string,
-): Promise< Response > {
-	return trackedFetch( input, init, {
-		windowId: getActiveWindowId(),
-		source: source ?? 'user-edit-window/rest',
-	} );
-}
-
-/**
- * Load the editable user record. `?context=edit` widens the
- * response to include private fields (email, capabilities, locale,
- * meta) that view-context strips.
- */
-export async function fetchUser( id: number ): Promise< UserEditRecord > {
-	const cfg = getConfig();
-	const base =
-		( cfg as unknown as { usersUrl?: string } ).usersUrl ??
-		`${ cfg.restRoot }wp/v2/users`;
-	const url = `${ base }/${ id }?context=edit`;
-	const res = await shellFetch(
-		url,
-		{
-			method: 'GET',
-			credentials: 'same-origin',
-			headers: {
-				Accept: 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
-			},
-		},
-		'user-edit-window/load',
-	);
-	if ( ! res.ok ) {
-		throw new Error( `[user-edit] load failed: ${ res.status }` );
-	}
-	return ( await res.json() ) as UserEditRecord;
-}
-
 export interface UserEditPatch {
 	first_name?: string;
 	last_name?: string;
@@ -148,87 +108,166 @@ export interface UserEditSaveResult {
 }
 
 /**
- * Save edits via `PUT /wp/v2/users/<id>`. Maps common server
- * error codes (`invalid_username`, `existing_user_email`, …) into
- * a `fieldErrors` map keyed by form field name so the form can
- * highlight the offending input.
+ * Per-window User-edit REST client. Returned by
+ * {@link createUserEditClient}.
+ *
+ * @since 0.18.x
  */
-export async function saveUser(
-	id: number,
-	patch: UserEditPatch,
-): Promise< UserEditSaveResult > {
-	const cfg = getConfig();
-	const base =
-		( cfg as unknown as { usersUrl?: string } ).usersUrl ??
-		`${ cfg.restRoot }wp/v2/users`;
-	const res = await shellFetch(
-		`${ base }/${ id }?context=edit`,
-		{
-			method: 'POST', // PUT == POST for WP REST when X-HTTP-Method-Override is unsupported.
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
-				'X-HTTP-Method-Override': 'PUT',
-			},
-			body: JSON.stringify( patch ),
-		},
-		'user-edit-window/save',
-	);
-	if ( ! res.ok ) {
-		const data = ( await res.json().catch( () => ( {} ) ) ) as {
-			code?: string;
-			message?: string;
-			data?: { params?: Record< string, string > };
-		};
-		const fieldErrors: Record< string, string > = {};
-		const params = data.data?.params;
-		if ( params && typeof params === 'object' ) {
-			for ( const [ k, v ] of Object.entries( params ) ) {
-				fieldErrors[ k ] = String( v );
-			}
-		}
-		return {
-			ok: false,
-			error: data.code ?? `http_${ res.status }`,
-			message: data.message,
-			fieldErrors,
-		};
-	}
-	const user = ( await res.json() ) as UserEditRecord;
-	return { ok: true, user };
+export interface UserEditClient {
+	readonly windowId: string;
+	getConfig(): PostsWindowConfig;
+	fetchUser( id: number ): Promise< UserEditRecord >;
+	saveUser(
+		id: number,
+		patch: UserEditPatch,
+	): Promise< UserEditSaveResult >;
+	fetchInsights(
+		id: number,
+		opts?: { fresh?: boolean },
+	): Promise< UserInsightsPayload >;
 }
 
 /**
- * Fetch the insights payload (stats + activity + sessions). When
- * `fresh` is true, bypasses the per-minute server-side cache.
+ * Build a User-edit REST client bound to a single window id.
+ *
+ * @since 0.18.x
  */
-export async function fetchInsights(
-	id: number,
-	opts: { fresh?: boolean } = {},
-): Promise< UserInsightsPayload > {
-	const cfg = getConfig();
-	const base =
-		( cfg as unknown as { insightsUrlBase?: string } ).insightsUrlBase ??
-		`${ cfg.restRoot }desktop-mode/v1/users/`;
-	const url = new URL( `${ base }${ id }/insights` );
-	if ( opts.fresh ) {
-		url.searchParams.set( 'fresh', '1' );
-	}
-	const res = await shellFetch(
-		url.toString(),
-		{
-			method: 'GET',
-			credentials: 'same-origin',
-			headers: {
-				Accept: 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
+export function createUserEditClient(
+	windowId: string = 'desktop-mode-user-edit',
+): UserEditClient {
+	const getConfig = (): PostsWindowConfig => {
+		const store = (
+			window as unknown as {
+				desktopModeWindowConfig?: Record< string, PostsWindowConfig >;
+			}
+		).desktopModeWindowConfig;
+		const cfg = store?.[ windowId ];
+		if ( ! cfg ) {
+			throw new Error(
+				`[${ windowId }] config blob is missing — was the window opened ` +
+					'without registration? See ' +
+					'`includes/user-edit-window/window.php`.',
+			);
+		}
+		return cfg;
+	};
+
+	const shellFetch = (
+		input: RequestInfo,
+		init?: RequestInit,
+		source?: string,
+	): Promise< Response > => {
+		return trackedFetch( input, init, {
+			windowId,
+			source: source ?? 'user-edit-window/rest',
+		} );
+	};
+
+	const fetchUser = async ( id: number ): Promise< UserEditRecord > => {
+		const cfg = getConfig();
+		const base =
+			( cfg as unknown as { usersUrl?: string } ).usersUrl ??
+			`${ cfg.restRoot }wp/v2/users`;
+		const url = `${ base }/${ id }?context=edit`;
+		const res = await shellFetch(
+			url,
+			{
+				method: 'GET',
+				credentials: 'same-origin',
+				headers: {
+					Accept: 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
 			},
-		},
-		'user-edit-window/insights',
-	);
-	if ( ! res.ok ) {
-		throw new Error( `[user-edit] insights failed: ${ res.status }` );
-	}
-	return ( await res.json() ) as UserInsightsPayload;
+			'user-edit-window/load',
+		);
+		if ( ! res.ok ) {
+			throw new Error( `[user-edit] load failed: ${ res.status }` );
+		}
+		return ( await res.json() ) as UserEditRecord;
+	};
+
+	const saveUser = async (
+		id: number,
+		patch: UserEditPatch,
+	): Promise< UserEditSaveResult > => {
+		const cfg = getConfig();
+		const base =
+			( cfg as unknown as { usersUrl?: string } ).usersUrl ??
+			`${ cfg.restRoot }wp/v2/users`;
+		const res = await shellFetch(
+			`${ base }/${ id }?context=edit`,
+			{
+				method: 'POST', // PUT == POST for WP REST when X-HTTP-Method-Override is unsupported.
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+					'X-HTTP-Method-Override': 'PUT',
+				},
+				body: JSON.stringify( patch ),
+			},
+			'user-edit-window/save',
+		);
+		if ( ! res.ok ) {
+			const data = ( await res.json().catch( () => ( {} ) ) ) as {
+				code?: string;
+				message?: string;
+				data?: { params?: Record< string, string > };
+			};
+			const fieldErrors: Record< string, string > = {};
+			const params = data.data?.params;
+			if ( params && typeof params === 'object' ) {
+				for ( const [ k, v ] of Object.entries( params ) ) {
+					fieldErrors[ k ] = String( v );
+				}
+			}
+			return {
+				ok: false,
+				error: data.code ?? `http_${ res.status }`,
+				message: data.message,
+				fieldErrors,
+			};
+		}
+		const user = ( await res.json() ) as UserEditRecord;
+		return { ok: true, user };
+	};
+
+	const fetchInsights = async (
+		id: number,
+		opts: { fresh?: boolean } = {},
+	): Promise< UserInsightsPayload > => {
+		const cfg = getConfig();
+		const base =
+			( cfg as unknown as { insightsUrlBase?: string } )
+				.insightsUrlBase ?? `${ cfg.restRoot }desktop-mode/v1/users/`;
+		const url = new URL( `${ base }${ id }/insights` );
+		if ( opts.fresh ) {
+			url.searchParams.set( 'fresh', '1' );
+		}
+		const res = await shellFetch(
+			url.toString(),
+			{
+				method: 'GET',
+				credentials: 'same-origin',
+				headers: {
+					Accept: 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+			},
+			'user-edit-window/insights',
+		);
+		if ( ! res.ok ) {
+			throw new Error( `[user-edit] insights failed: ${ res.status }` );
+		}
+		return ( await res.json() ) as UserInsightsPayload;
+	};
+
+	return {
+		windowId,
+		getConfig,
+		fetchUser,
+		saveUser,
+		fetchInsights,
+	};
 }

--- a/src/posts-window/users-render.ts
+++ b/src/posts-window/users-render.ts
@@ -24,16 +24,12 @@
 import { __, sprintf } from '../i18n';
 import { trackedFetch } from '../tracked-fetch';
 import { applyAvatarSrc } from '../ui/util/avatar-resolve';
-import { getActiveWindowId, getConfig } from './rest';
+import type { PostsWindowConfig } from './rest';
 import {
-	bulkSetRole,
-	createUser,
-	fetchUsers,
-	resendWelcome,
-	sendPasswordReset,
 	type CreateUserBody,
 	type UserListItem,
 	type UsersListParams,
+	type UsersWindowClient,
 } from './users-rest';
 import { showUsersIntroDialog } from './users-intro-dialog';
 // Static import — see `desktop.ts`'s onMatch comment for why this
@@ -213,13 +209,13 @@ function memoUserCell(
 }
 
 const _usersIntroShown = { v: false };
-function maybeShowUsersIntro(): void {
+function maybeShowUsersIntro( client: UsersWindowClient ): void {
 	if ( _usersIntroShown.v ) {
 		return;
 	}
-	let cfg: ReturnType< typeof getConfig >;
+	let cfg: PostsWindowConfig;
 	try {
-		cfg = getConfig();
+		cfg = client.getConfig();
 	} catch {
 		return;
 	}
@@ -233,7 +229,7 @@ function maybeShowUsersIntro(): void {
 				_usersIntroShown.v = false;
 				return;
 			}
-			void markUsersIntroSeen( cfg );
+			void markUsersIntroSeen( client, cfg );
 			if ( result === 'settings' ) {
 				const w = window as unknown as {
 					wp?: { desktop?: { openOsSettings?: () => void } };
@@ -247,7 +243,8 @@ function maybeShowUsersIntro(): void {
 }
 
 async function markUsersIntroSeen(
-	cfg: ReturnType< typeof getConfig >,
+	client: UsersWindowClient,
+	cfg: PostsWindowConfig,
 ): Promise< void > {
 	if ( ! cfg.introUrl ) {
 		return;
@@ -265,7 +262,7 @@ async function markUsersIntroSeen(
 				body: JSON.stringify( { slug: 'users' } ),
 			},
 			{
-				windowId: getActiveWindowId(),
+				windowId: client.windowId,
 				source: 'users-window/intro',
 			},
 		);
@@ -277,7 +274,10 @@ async function markUsersIntroSeen(
 
 // ─── Cell builders ───────────────────────────────────────────────────
 
-function buildIdentityCell( row: UserListItem ): HTMLElement {
+function buildIdentityCell(
+	row: UserListItem,
+	cfg: PostsWindowConfig,
+): HTMLElement {
 	const cell = document.createElement( 'span' );
 	cell.style.cssText =
 		'display:flex;align-items:center;gap:10px;min-width:0;';
@@ -311,7 +311,6 @@ function buildIdentityCell( row: UserListItem ): HTMLElement {
 
 	const nameRow = document.createElement( 'span' );
 	const name = document.createElement( 'a' );
-	const cfg = getConfig();
 	name.href = `${ cfg.editPostUrlBase }?user_id=${ row.id }`;
 	name.textContent = row.name || `#${ row.id }`;
 	name.title = name.textContent;
@@ -391,17 +390,15 @@ function buildEmailCell( row: UserListItem ): HTMLElement {
 	return cell;
 }
 
-function buildRoleCell( row: UserListItem ): HTMLElement {
+function buildRoleCell(
+	row: UserListItem,
+	cfg: PostsWindowConfig,
+): HTMLElement {
 	const cell = document.createElement( 'span' );
 	cell.style.cssText =
 		'display:inline-flex;flex-wrap:wrap;gap:4px;min-width:0;';
 	const roles = Array.isArray( row.roles ) ? row.roles : [];
-	let labels: Record< string, string > = {};
-	try {
-		labels = getConfig().allRoles ?? {};
-	} catch {
-		labels = {};
-	}
+	const labels: Record< string, string > = cfg.allRoles ?? {};
 	if ( roles.length === 0 ) {
 		const none = document.createElement( 'span' );
 		none.textContent = __( 'No role' );
@@ -528,7 +525,13 @@ function buildRegisteredCell( row: UserListItem ): HTMLElement {
 		cell.style.color = 'var(--wp-admin-theme-fg-muted, #8c8f94)';
 		return cell;
 	}
-	const ts = Math.floor( Date.parse( raw + 'Z' ) / 1000 );
+	// `_fields=registered_date` returns the bare WP format
+	// (`YYYY-MM-DDTHH:MM:SS`) in `view` context and an ISO-8601 string
+	// with offset (`…+00:00`) in `edit` context. Only append `Z` when
+	// no timezone suffix is present — otherwise `Date.parse` chokes on
+	// the doubled tz and we'd fall through to the raw string.
+	const hasTz = /[Zz]|[+-]\d{2}:?\d{2}$/.test( raw );
+	const ts = Math.floor( Date.parse( hasTz ? raw : raw + 'Z' ) / 1000 );
 	if ( ! Number.isFinite( ts ) ) {
 		cell.textContent = raw;
 		return cell;
@@ -538,17 +541,16 @@ function buildRegisteredCell( row: UserListItem ): HTMLElement {
 	return cell;
 }
 
-function buildActionsCell( row: UserListItem ): HTMLElement {
+function buildActionsCell(
+	row: UserListItem,
+	cfg: PostsWindowConfig,
+	client: UsersWindowClient,
+): HTMLElement {
 	const cell = document.createElement( 'span' );
 	cell.style.cssText =
 		'display:inline-flex;gap:4px;align-items:center;';
 
-	let canEditViewer = false;
-	try {
-		canEditViewer = getConfig().canEdit === true;
-	} catch {
-		canEditViewer = false;
-	}
+	const canEditViewer = cfg.canEdit === true;
 	const canEditRow = row.desktop_mode_can_edit === true;
 	if ( ! canEditViewer || ! canEditRow ) {
 		cell.textContent = '—';
@@ -599,7 +601,7 @@ function buildActionsCell( row: UserListItem ): HTMLElement {
 				if ( ! ok ) {
 					return;
 				}
-				const result = await sendPasswordReset( row.id );
+				const result = await client.sendPasswordReset( row.id );
 				if ( result.ok ) {
 					notifyToast(
 						sprintf(
@@ -641,7 +643,7 @@ function buildActionsCell( row: UserListItem ): HTMLElement {
 				if ( ! ok ) {
 					return;
 				}
-				const result = await resendWelcome( row.id );
+				const result = await client.resendWelcome( row.id );
 				if ( result.ok ) {
 					notifyToast(
 						sprintf(
@@ -669,6 +671,8 @@ function buildActionsCell( row: UserListItem ): HTMLElement {
 
 function buildColumns(
 	cache: UserCellCache,
+	cfg: PostsWindowConfig,
+	client: UsersWindowClient,
 ): WpdTableColumn< UserListItem >[] {
 	const cols: WpdTableColumn< UserListItem >[] = [
 		{
@@ -679,7 +683,7 @@ function buildColumns(
 			minWidth: '260px',
 			render: ( _v, row ) =>
 				memoUserCell( cache, row.id, 'identity', () =>
-					buildIdentityCell( row ),
+					buildIdentityCell( row, cfg ),
 				),
 		},
 		{
@@ -694,7 +698,9 @@ function buildColumns(
 			label: __( 'Role' ),
 			width: '180px',
 			render: ( _v, row ) =>
-				memoUserCell( cache, row.id, 'role', () => buildRoleCell( row ) ),
+				memoUserCell( cache, row.id, 'role', () =>
+					buildRoleCell( row, cfg ),
+				),
 		},
 		{
 			key: 'stats',
@@ -737,13 +743,7 @@ function buildColumns(
 	// edit cap; cell falls back to "—" per-row when the row's
 	// `desktop_mode_can_edit` is false (e.g. self-row, or a higher-
 	// privileged user).
-	let canEdit = false;
-	try {
-		canEdit = getConfig().canEdit === true;
-	} catch {
-		canEdit = false;
-	}
-	if ( canEdit ) {
+	if ( cfg.canEdit === true ) {
 		cols.push( {
 			key: 'actions',
 			label: __( 'Actions' ),
@@ -753,7 +753,7 @@ function buildColumns(
 				// Actions cell is intentionally NOT memoized — its closure
 				// captures `row` and the row payload changes between
 				// fetches. Cheap to rebuild, fewer surprises.
-				buildActionsCell( row ),
+				buildActionsCell( row, cfg, client ),
 		} );
 	}
 
@@ -800,7 +800,10 @@ function applyClientStatusFilter(
 
 // ─── Render entry point ─────────────────────────────────────────────
 
-export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
+export async function renderUsersWindow(
+	body: HTMLElement,
+	client: UsersWindowClient,
+): Promise< void > {
 	const root = body.querySelector< HTMLElement >( ROOT );
 	const table = body.querySelector< WpdTable< UserListItem > >( TABLE );
 	if ( ! root || ! table ) {
@@ -823,9 +826,9 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
 		void openUserEditWindow( id );
 	} );
 
-	maybeShowUsersIntro();
+	maybeShowUsersIntro( client );
 
-	const cfg = getConfig();
+	const cfg = client.getConfig();
 	const view: ViewState = {
 		page: 1,
 		perPage: Math.max( 1, cfg.defaultPerPage || 20 ),
@@ -839,7 +842,7 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
 
 	const cellCache: UserCellCache = new Map();
 
-	table.columns = buildColumns( cellCache );
+	table.columns = buildColumns( cellCache, cfg, client );
 	table.getRowId = ( row ) => row.id;
 	table.sort = { key: 'name', direction: 'asc' };
 
@@ -1011,7 +1014,7 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
 				if ( ! ok ) {
 					return;
 				}
-				const out = await bulkSetRole( ids, role ).catch( ( err ) => {
+				const out = await client.bulkSetRole( ids, role ).catch( ( err ) => {
 					notifyToast(
 						String( ( err as Error ).message ?? err ),
 						{ kind: 'error' },
@@ -1095,7 +1098,7 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
 		const mySeq = ++refreshSeq;
 		table.toggleAttribute( 'loading', true );
 		try {
-			const result = await fetchUsers( buildParams() );
+			const result = await client.fetchUsers( buildParams() );
 			if ( mySeq !== refreshSeq ) {
 				return;
 			}
@@ -1133,7 +1136,7 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
 	// Add User form — mounted when the user activates the "add-new"
 	// tab. The form lives in the PHP template; we wire submit /
 	// reset / generate-password / role+locale dropdowns here.
-	mountAddUserForm( body, {
+	mountAddUserForm( body, client, cfg, {
 		afterCreate: () => {
 			// Reset the create form and bounce back to the all-users
 			// tab so the new user shows up in the list.
@@ -1153,7 +1156,96 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
 	// switch tab → mount edit form flow lives in the same module
 	// as the table itself. Lazy-imports the edit module the first
 	// time a profile is requested.
-	wireProfileSubTab( body );
+	wireProfileSubTab( body, cfg );
+
+	// Live refresh on `desktop-mode.user.changed` — fires when the
+	// User-edit window saves a profile. We patch ONLY the affected
+	// rows in place via `fetchOneUser`; a full `refresh()` would
+	// clear the cell cache, reset scroll, and flicker the table for
+	// every other row that didn't change.
+	const patchUserRow = async ( id: number ): Promise< void > => {
+		try {
+			const updated = await client.fetchOneUser( id );
+			const list = table.data as readonly UserListItem[];
+			const idx = list.findIndex( ( r ) => r.id === id );
+			if ( idx < 0 ) {
+				// User isn't on the current page (filtered/paged out) —
+				// nothing to repaint.
+				return;
+			}
+			if ( ! updated ) {
+				// Row went away (deleted). Drop it locally; a full
+				// pager update would need totalRows decrement, but a
+				// stale missing row is more disruptive than a slightly
+				// off count until the next list fetch.
+				const next = list.slice();
+				next.splice( idx, 1 );
+				table.data = next;
+				return;
+			}
+			// Invalidate cached cells for this id so the table rebuilds
+			// them from the new payload (role chip, email, registered
+			// date, last-login dot, …).
+			for ( const k of Array.from( cellCache.keys() ) ) {
+				if ( k.startsWith( `${ id }::` ) ) {
+					cellCache.delete( k );
+				}
+			}
+			const next = list.slice();
+			next[ idx ] = updated;
+			// Re-apply the active status filter so a row that no longer
+			// matches (e.g. presence flipped offline while "Online" is
+			// selected) doesn't linger.
+			table.data = applyClientStatusFilter( next, view.status );
+		} catch ( err ) {
+			// Non-fatal — log and fall back to a full refresh so the
+			// user doesn't end up looking at a stale row.
+			// eslint-disable-next-line no-console
+			console.warn( '[users-window] row patch failed, falling back to refresh', err );
+			void refresh();
+		}
+	};
+
+	const subscribeApi = (
+		window as unknown as {
+			wp?: {
+				desktop?: {
+					subscribe?: (
+						channel: string,
+						handler: ( payload: unknown ) => void,
+					) => () => void;
+				};
+			};
+		}
+	).wp?.desktop;
+	const unsubscribe = subscribeApi?.subscribe?.(
+		'desktop-mode.user.changed',
+		( payload: unknown ) => {
+			const ids = ( payload as { ids?: unknown } )?.ids;
+			if ( ! Array.isArray( ids ) ) {
+				return;
+			}
+			for ( const raw of ids ) {
+				const id = typeof raw === 'number' ? raw : Number( raw );
+				if ( Number.isFinite( id ) && id > 0 ) {
+					void patchUserRow( id );
+				}
+			}
+		},
+	);
+	if ( unsubscribe ) {
+		document.addEventListener(
+			'desktop-mode-window-closed',
+			( e: Event ) => {
+				const detail = ( e as CustomEvent< { windowId?: string } > )
+					.detail;
+				if ( detail?.windowId === 'desktop-mode-users' ) {
+					unsubscribe();
+				}
+			},
+			{ once: false },
+		);
+	}
 
 	// Initial fetch.
 	void refresh();
@@ -1168,14 +1260,16 @@ export async function renderUsersWindow( body: HTMLElement ): Promise< void > {
  * users opens a separate `desktop-mode-user-edit` window via
  * row click.
  */
-function wireProfileSubTab( body: HTMLElement ): void {
+function wireProfileSubTab(
+	body: HTMLElement,
+	cfg: PostsWindowConfig,
+): void {
 	const profile = body.querySelector(
 		'wpd-user-profile[data-wpd-user-profile-self]',
 	) as HTMLElement | null;
 	if ( ! profile ) {
 		return;
 	}
-	const cfg = getConfig();
 	const viewerId = ( cfg as unknown as { currentUserId?: number } )
 		.currentUserId;
 	if ( typeof viewerId === 'number' && viewerId > 0 ) {
@@ -1223,7 +1317,12 @@ interface WpdFormElement extends HTMLElement {
  *
  * @since 0.18.0
  */
-function mountAddUserForm( body: HTMLElement, opts: AddUserFormOpts ): void {
+function mountAddUserForm(
+	body: HTMLElement,
+	client: UsersWindowClient,
+	cfg: PostsWindowConfig,
+	opts: AddUserFormOpts,
+): void {
 	const formNullable = body.querySelector(
 		'[data-desktop-mode-users-add-form]',
 	) as WpdFormElement | null;
@@ -1235,7 +1334,6 @@ function mountAddUserForm( body: HTMLElement, opts: AddUserFormOpts ): void {
 	// TS losing it across nested function declarations.
 	const form: WpdFormElement = formNullable;
 
-	const cfg = getConfig();
 	const defaultRole = cfg.defaultRole ?? 'subscriber';
 
 	// ── Mount the role + locale `<wpd-select>`s. They're built JS-side
@@ -1306,7 +1404,7 @@ function mountAddUserForm( body: HTMLElement, opts: AddUserFormOpts ): void {
 			send_notification: Boolean( values.send_notification ),
 		};
 
-		const result = await createUser( payload );
+		const result = await client.createUser( payload );
 		pending = false;
 		form.setBusy( false );
 

--- a/src/posts-window/users-rest.ts
+++ b/src/posts-window/users-rest.ts
@@ -4,15 +4,14 @@
  * Thin wrapper around `trackedFetch` for `/wp/v2/users` and the
  * three Users-window mutation endpoints (`bulk-role`,
  * `send-password-reset`, `resend-welcome`, `bulk-delete`). Mirrors
- * the shape of `./rest.ts` for Posts; kept separate so Users can
- * grow its own helpers without bloating the Posts surface.
+ * the per-window-client shape of `./rest.ts`.
  *
  * @public
  * @since 0.18.0
  */
 
 import { trackedFetch } from '../tracked-fetch';
-import { getActiveWindowId, getConfig } from './rest';
+import type { PostsWindowConfig } from './rest';
 
 export type UserPresence = 'online' | 'inactive' | 'offline';
 
@@ -59,84 +58,6 @@ export interface UsersListParams {
 	order?: 'asc' | 'desc';
 }
 
-interface RequestOptions extends RequestInit {
-	source?: string;
-	silent?: boolean;
-}
-
-function shellFetch(
-	input: RequestInfo,
-	init?: RequestInit,
-	options?: { source?: string; silent?: boolean },
-): Promise< Response > {
-	return trackedFetch( input, init, {
-		windowId: getActiveWindowId(),
-		source: options?.source ?? 'users-window/rest',
-		silent: options?.silent,
-	} );
-}
-
-/**
- * Fetch a page of users from `/wp/v2/users`. Reads `total` /
- * `totalPages` from the response headers, same pattern as
- * `./rest.ts:fetchPosts`.
- *
- * @since 0.18.0
- */
-export async function fetchUsers(
-	params: UsersListParams,
-): Promise< UsersListResponse > {
-	const cfg = getConfig();
-	const url = new URL( cfg.postsUrl );
-
-	for ( const [ key, value ] of Object.entries( cfg.queryArgs ?? {} ) ) {
-		if ( typeof value === 'string' && value !== '' ) {
-			url.searchParams.set( key, value );
-		}
-	}
-
-	url.searchParams.set( 'page', String( Math.max( 1, params.page ) ) );
-	url.searchParams.set( 'per_page', String( Math.max( 1, params.perPage ) ) );
-	if ( params.search ) {
-		url.searchParams.set( 'search', params.search );
-	}
-	if ( params.roles && params.roles.length > 0 ) {
-		// Core's `/wp/v2/users` accepts `roles[]=editor&roles[]=author`.
-		for ( const r of params.roles ) {
-			url.searchParams.append( 'roles', r );
-		}
-	}
-	if ( params.orderby ) {
-		url.searchParams.set( 'orderby', params.orderby );
-	}
-	if ( params.order ) {
-		url.searchParams.set( 'order', params.order );
-	}
-
-	const init: RequestOptions = {
-		method: 'GET',
-		credentials: 'same-origin',
-		headers: {
-			Accept: 'application/json',
-			'X-WP-Nonce': cfg.restNonce,
-		},
-	};
-
-	const res = await shellFetch( url.toString(), init, {
-		source: 'users-window/list',
-	} );
-	if ( ! res.ok ) {
-		throw new Error( `[users-window] list fetch failed: ${ res.status }` );
-	}
-	const items = ( await res.json() ) as UserListItem[];
-	const total = parseInt( res.headers.get( 'X-WP-Total' ) ?? '0', 10 );
-	const totalPages = parseInt(
-		res.headers.get( 'X-WP-TotalPages' ) ?? '0',
-		10,
-	);
-	return { items, total, totalPages };
-}
-
 export interface BulkRoleResultRow {
 	ok: boolean;
 	error?: string;
@@ -147,117 +68,10 @@ export interface BulkRoleResponse {
 	results: Record< string, BulkRoleResultRow >;
 }
 
-/**
- * `POST /desktop-mode/v1/users/bulk-role`. Server enforces
- * per-target permission via `editable_roles` — the response
- * always carries a per-id outcome map so partial success is
- * representable. Pass an empty `ids` array to short-circuit.
- *
- * @since 0.18.0
- */
-export async function bulkSetRole(
-	ids: number[],
-	role: string,
-): Promise< BulkRoleResponse > {
-	const cfg = getConfig();
-	const url =
-		( cfg as unknown as { bulkRoleUrl?: string } ).bulkRoleUrl ??
-		`${ cfg.restRoot }desktop-mode/v1/users/bulk-role`;
-	const res = await shellFetch(
-		url,
-		{
-			method: 'POST',
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
-			},
-			body: JSON.stringify( { ids, role } ),
-		},
-		{ source: 'users-window/bulk-role' },
-	);
-	if ( ! res.ok ) {
-		throw new Error( `[users-window] bulk-role failed: ${ res.status }` );
-	}
-	return ( await res.json() ) as BulkRoleResponse;
-}
-
 export interface SimpleResult {
 	ok: boolean;
 	email?: string;
 	error?: string;
-}
-
-/**
- * `POST /desktop-mode/v1/users/<id>/send-password-reset`.
- *
- * @since 0.18.0
- */
-export async function sendPasswordReset( id: number ): Promise< SimpleResult > {
-	const cfg = getConfig();
-	const base =
-		( cfg as unknown as { sendResetUrlBase?: string } ).sendResetUrlBase ??
-		`${ cfg.restRoot }desktop-mode/v1/users/`;
-	const res = await shellFetch(
-		`${ base }${ id }/send-password-reset`,
-		{
-			method: 'POST',
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
-			},
-		},
-		{ source: 'users-window/send-password-reset' },
-	);
-	if ( ! res.ok ) {
-		const body = await res.json().catch( () => ( {} ) );
-		return {
-			ok: false,
-			error:
-				typeof ( body as { code?: string } ).code === 'string'
-					? ( body as { code: string } ).code
-					: `http_${ res.status }`,
-		};
-	}
-	const data = ( await res.json() ) as { ok: boolean; email?: string };
-	return { ok: data.ok === true, email: data.email };
-}
-
-/**
- * `POST /desktop-mode/v1/users/<id>/resend-welcome`.
- *
- * @since 0.18.0
- */
-export async function resendWelcome( id: number ): Promise< SimpleResult > {
-	const cfg = getConfig();
-	const base =
-		( cfg as unknown as { sendResetUrlBase?: string } ).sendResetUrlBase ??
-		`${ cfg.restRoot }desktop-mode/v1/users/`;
-	const res = await shellFetch(
-		`${ base }${ id }/resend-welcome`,
-		{
-			method: 'POST',
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
-			},
-		},
-		{ source: 'users-window/resend-welcome' },
-	);
-	if ( ! res.ok ) {
-		const body = await res.json().catch( () => ( {} ) );
-		return {
-			ok: false,
-			error:
-				typeof ( body as { code?: string } ).code === 'string'
-					? ( body as { code: string } ).code
-					: `http_${ res.status }`,
-		};
-	}
-	const data = ( await res.json() ) as { ok: boolean; email?: string };
-	return { ok: data.ok === true, email: data.email };
 }
 
 export interface CreateUserBody {
@@ -280,94 +94,358 @@ export interface CreateUserResult {
 	message?: string;
 }
 
-/**
- * `POST /desktop-mode/v1/users`. Creates a new WordPress user with
- * the supplied fields. Server-side enforces `create_users` cap +
- * `editable_roles` per role choice.
- *
- * @since 0.18.0
- */
-export async function createUser(
-	body: CreateUserBody,
-): Promise< CreateUserResult > {
-	const cfg = getConfig();
-	const url =
-		( cfg as unknown as { createUserUrl?: string } ).createUserUrl ??
-		`${ cfg.restRoot }desktop-mode/v1/users`;
-	const res = await shellFetch(
-		url,
-		{
-			method: 'POST',
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
-			},
-			body: JSON.stringify( body ),
-		},
-		{ source: 'users-window/create' },
-	);
-	if ( ! res.ok ) {
-		const data = await res.json().catch( () => ( {} ) );
-		const code = ( data as { code?: string } ).code;
-		const message = ( data as { message?: string } ).message;
-		return {
-			ok: false,
-			error: typeof code === 'string' ? code : `http_${ res.status }`,
-			message: typeof message === 'string' ? message : undefined,
-		};
-	}
-	const data = ( await res.json() ) as {
-		ok: boolean;
-		user_id?: number;
-		email?: string;
-	};
-	return {
-		ok: data.ok === true,
-		user_id: data.user_id,
-		email: data.email,
-	};
-}
-
 export interface BulkDeleteResponse {
 	results: Record< string, { ok: boolean; error?: string } >;
 }
 
 /**
- * `POST /desktop-mode/v1/users/bulk-delete`. On single-site this
- * hard-deletes; on multisite it removes from the current blog only.
- * Optional `reassign` reassigns the deleted users' content to the
- * given user id.
+ * Per-window Users REST client. Returned by {@link createUsersWindowClient}
+ * and threaded through render code instead of imported as free
+ * functions.
  *
- * @since 0.18.0
+ * @since 0.18.x
  */
-export async function bulkDeleteUsers(
-	ids: number[],
-	reassign?: number,
-): Promise< BulkDeleteResponse > {
-	const cfg = getConfig();
-	const url =
-		( cfg as unknown as { bulkDeleteUrl?: string } ).bulkDeleteUrl ??
-		`${ cfg.restRoot }desktop-mode/v1/users/bulk-delete`;
-	const body: Record< string, unknown > = { ids };
-	if ( typeof reassign === 'number' && reassign > 0 ) {
-		body.reassign = reassign;
-	}
-	const res = await shellFetch(
-		url,
-		{
-			method: 'POST',
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': cfg.restNonce,
+export interface UsersWindowClient {
+	readonly windowId: string;
+	getConfig(): PostsWindowConfig;
+	fetchUsers( params: UsersListParams ): Promise< UsersListResponse >;
+	/**
+	 * Fetch a single user row using the same `_fields` whitelist as
+	 * {@link fetchUsers}. Returns `null` when the row is gone (e.g.
+	 * the user was deleted between events). Used by the
+	 * `desktop-mode.user.changed` live-refresh path to patch one row
+	 * in place instead of re-fetching the whole page.
+	 */
+	fetchOneUser( id: number ): Promise< UserListItem | null >;
+	bulkSetRole( ids: number[], role: string ): Promise< BulkRoleResponse >;
+	sendPasswordReset( id: number ): Promise< SimpleResult >;
+	resendWelcome( id: number ): Promise< SimpleResult >;
+	createUser( body: CreateUserBody ): Promise< CreateUserResult >;
+	bulkDeleteUsers(
+		ids: number[],
+		reassign?: number,
+	): Promise< BulkDeleteResponse >;
+}
+
+/**
+ * Build a Users REST client bound to a single window id.
+ *
+ * Defaults to `'desktop-mode-users'` to keep callers that don't yet
+ * thread an explicit id working unchanged. Pass a different id for
+ * any sibling window registered by a plugin that wants the same
+ * Users surface (e.g. a per-blog users window on multisite).
+ *
+ * @since 0.18.x
+ */
+export function createUsersWindowClient(
+	windowId: string = 'desktop-mode-users',
+): UsersWindowClient {
+	const getConfig = (): PostsWindowConfig => {
+		const store = (
+			window as unknown as {
+				desktopModeWindowConfig?: Record< string, PostsWindowConfig >;
+			}
+		).desktopModeWindowConfig;
+		const cfg = store?.[ windowId ];
+		if ( ! cfg ) {
+			throw new Error(
+				`[${ windowId }] config blob is missing — was the window opened ` +
+					'without registration? See ' +
+					'`includes/users-window/window.php`.',
+			);
+		}
+		return cfg;
+	};
+
+	const shellFetch = (
+		input: RequestInfo,
+		init?: RequestInit,
+		options?: { source?: string; silent?: boolean },
+	): Promise< Response > => {
+		return trackedFetch( input, init, {
+			windowId,
+			source: options?.source ?? 'users-window/rest',
+			silent: options?.silent,
+		} );
+	};
+
+	const fetchUsers = async (
+		params: UsersListParams,
+	): Promise< UsersListResponse > => {
+		const cfg = getConfig();
+		// `usersUrl` is the semantically correct source for the Users
+		// window; `postsUrl` is also set to `/wp/v2/users` in this
+		// window's config but reading `usersUrl` makes the intent
+		// obvious and is robust against future config-shape drift.
+		const baseUrl = cfg.usersUrl || cfg.postsUrl;
+		const url = new URL( baseUrl );
+
+		for ( const [ key, value ] of Object.entries( cfg.queryArgs ?? {} ) ) {
+			if ( typeof value === 'string' && value !== '' ) {
+				url.searchParams.set( key, value );
+			}
+		}
+
+		url.searchParams.set( 'page', String( Math.max( 1, params.page ) ) );
+		url.searchParams.set(
+			'per_page',
+			String( Math.max( 1, params.perPage ) ),
+		);
+		if ( params.search ) {
+			url.searchParams.set( 'search', params.search );
+		}
+		if ( params.roles && params.roles.length > 0 ) {
+			// Core's `/wp/v2/users` accepts `roles[]=editor&roles[]=author`.
+			for ( const r of params.roles ) {
+				url.searchParams.append( 'roles', r );
+			}
+		}
+		if ( params.orderby ) {
+			url.searchParams.set( 'orderby', params.orderby );
+		}
+		if ( params.order ) {
+			url.searchParams.set( 'order', params.order );
+		}
+
+		const res = await shellFetch(
+			url.toString(),
+			{
+				method: 'GET',
+				credentials: 'same-origin',
+				headers: {
+					Accept: 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
 			},
-			body: JSON.stringify( body ),
-		},
-		{ source: 'users-window/bulk-delete' },
-	);
-	if ( ! res.ok ) {
-		throw new Error( `[users-window] bulk-delete failed: ${ res.status }` );
-	}
-	return ( await res.json() ) as BulkDeleteResponse;
+			{ source: 'users-window/list' },
+		);
+		if ( ! res.ok ) {
+			throw new Error(
+				`[users-window] list fetch failed: ${ res.status }`,
+			);
+		}
+		const items = ( await res.json() ) as UserListItem[];
+		const total = parseInt( res.headers.get( 'X-WP-Total' ) ?? '0', 10 );
+		const totalPages = parseInt(
+			res.headers.get( 'X-WP-TotalPages' ) ?? '0',
+			10,
+		);
+		return { items, total, totalPages };
+	};
+
+	const fetchOneUser = async (
+		id: number,
+	): Promise< UserListItem | null > => {
+		const cfg = getConfig();
+		const baseUrl = cfg.usersUrl || cfg.postsUrl;
+		const url = new URL( `${ baseUrl.replace( /\/$/, '' ) }/${ id }` );
+		// Carry the same `_fields` + `context` the list endpoint uses so
+		// the patched row shape matches what `fetchUsers` produced.
+		for ( const [ key, value ] of Object.entries( cfg.queryArgs ?? {} ) ) {
+			if ( typeof value === 'string' && value !== '' ) {
+				url.searchParams.set( key, value );
+			}
+		}
+		const res = await shellFetch(
+			url.toString(),
+			{
+				method: 'GET',
+				credentials: 'same-origin',
+				headers: {
+					Accept: 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+			},
+			{ source: 'users-window/one', silent: true },
+		);
+		if ( res.status === 404 ) {
+			return null;
+		}
+		if ( ! res.ok ) {
+			throw new Error(
+				`[users-window] one fetch failed: ${ res.status }`,
+			);
+		}
+		return ( await res.json() ) as UserListItem;
+	};
+
+	const bulkSetRole = async (
+		ids: number[],
+		role: string,
+	): Promise< BulkRoleResponse > => {
+		const cfg = getConfig();
+		const url =
+			( cfg as unknown as { bulkRoleUrl?: string } ).bulkRoleUrl ??
+			`${ cfg.restRoot }desktop-mode/v1/users/bulk-role`;
+		const res = await shellFetch(
+			url,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+				body: JSON.stringify( { ids, role } ),
+			},
+			{ source: 'users-window/bulk-role' },
+		);
+		if ( ! res.ok ) {
+			throw new Error(
+				`[users-window] bulk-role failed: ${ res.status }`,
+			);
+		}
+		return ( await res.json() ) as BulkRoleResponse;
+	};
+
+	const sendPasswordReset = async (
+		id: number,
+	): Promise< SimpleResult > => {
+		const cfg = getConfig();
+		const base =
+			( cfg as unknown as { sendResetUrlBase?: string } )
+				.sendResetUrlBase ?? `${ cfg.restRoot }desktop-mode/v1/users/`;
+		const res = await shellFetch(
+			`${ base }${ id }/send-password-reset`,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+			},
+			{ source: 'users-window/send-password-reset' },
+		);
+		if ( ! res.ok ) {
+			const body = await res.json().catch( () => ( {} ) );
+			return {
+				ok: false,
+				error:
+					typeof ( body as { code?: string } ).code === 'string'
+						? ( body as { code: string } ).code
+						: `http_${ res.status }`,
+			};
+		}
+		const data = ( await res.json() ) as { ok: boolean; email?: string };
+		return { ok: data.ok === true, email: data.email };
+	};
+
+	const resendWelcome = async ( id: number ): Promise< SimpleResult > => {
+		const cfg = getConfig();
+		const base =
+			( cfg as unknown as { sendResetUrlBase?: string } )
+				.sendResetUrlBase ?? `${ cfg.restRoot }desktop-mode/v1/users/`;
+		const res = await shellFetch(
+			`${ base }${ id }/resend-welcome`,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+			},
+			{ source: 'users-window/resend-welcome' },
+		);
+		if ( ! res.ok ) {
+			const body = await res.json().catch( () => ( {} ) );
+			return {
+				ok: false,
+				error:
+					typeof ( body as { code?: string } ).code === 'string'
+						? ( body as { code: string } ).code
+						: `http_${ res.status }`,
+			};
+		}
+		const data = ( await res.json() ) as { ok: boolean; email?: string };
+		return { ok: data.ok === true, email: data.email };
+	};
+
+	const createUser = async (
+		body: CreateUserBody,
+	): Promise< CreateUserResult > => {
+		const cfg = getConfig();
+		const url =
+			( cfg as unknown as { createUserUrl?: string } ).createUserUrl ??
+			`${ cfg.restRoot }desktop-mode/v1/users`;
+		const res = await shellFetch(
+			url,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+				body: JSON.stringify( body ),
+			},
+			{ source: 'users-window/create' },
+		);
+		if ( ! res.ok ) {
+			const data = await res.json().catch( () => ( {} ) );
+			const code = ( data as { code?: string } ).code;
+			const message = ( data as { message?: string } ).message;
+			return {
+				ok: false,
+				error: typeof code === 'string' ? code : `http_${ res.status }`,
+				message: typeof message === 'string' ? message : undefined,
+			};
+		}
+		const data = ( await res.json() ) as {
+			ok: boolean;
+			user_id?: number;
+			email?: string;
+		};
+		return {
+			ok: data.ok === true,
+			user_id: data.user_id,
+			email: data.email,
+		};
+	};
+
+	const bulkDeleteUsers = async (
+		ids: number[],
+		reassign?: number,
+	): Promise< BulkDeleteResponse > => {
+		const cfg = getConfig();
+		const url =
+			( cfg as unknown as { bulkDeleteUrl?: string } ).bulkDeleteUrl ??
+			`${ cfg.restRoot }desktop-mode/v1/users/bulk-delete`;
+		const body: Record< string, unknown > = { ids };
+		if ( typeof reassign === 'number' && reassign > 0 ) {
+			body.reassign = reassign;
+		}
+		const res = await shellFetch(
+			url,
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': cfg.restNonce,
+				},
+				body: JSON.stringify( body ),
+			},
+			{ source: 'users-window/bulk-delete' },
+		);
+		if ( ! res.ok ) {
+			throw new Error(
+				`[users-window] bulk-delete failed: ${ res.status }`,
+			);
+		}
+		return ( await res.json() ) as BulkDeleteResponse;
+	};
+
+	return {
+		windowId,
+		getConfig,
+		fetchUsers,
+		fetchOneUser,
+		bulkSetRole,
+		sendPasswordReset,
+		resendWelcome,
+		createUser,
+		bulkDeleteUsers,
+	};
 }

--- a/tests/vitest/posts-window-rest.test.ts
+++ b/tests/vitest/posts-window-rest.test.ts
@@ -13,12 +13,10 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
-	buildEditPostUrl,
-	fetchPosts,
-	getConfig,
-	trashPost,
+	createPostsWindowClient,
+	type PostsWindowClient,
+	type PostsWindowConfig,
 } from '../../src/posts-window/rest';
-import type { PostsWindowConfig } from '../../src/posts-window/rest';
 
 declare global {
 	// eslint-disable-next-line @typescript-eslint/no-namespace
@@ -59,8 +57,11 @@ function jsonResponse(
 	} );
 }
 
+let client: PostsWindowClient;
+
 beforeEach( () => {
 	installConfig();
+	client = createPostsWindowClient( 'desktop-mode-posts' );
 } );
 
 afterEach( () => {
@@ -71,11 +72,11 @@ afterEach( () => {
 describe( 'getConfig', () => {
 	test( 'throws a useful error when the config blob is missing', () => {
 		delete window.desktopModeWindowConfig;
-		expect( () => getConfig() ).toThrow( /config blob is missing/ );
+		expect( () => client.getConfig() ).toThrow( /config blob is missing/ );
 	} );
 
 	test( 'returns the config blob for the posts window id', () => {
-		const cfg = getConfig();
+		const cfg = client.getConfig();
 		expect( cfg.postsUrl ).toBe( POSTS_URL );
 		expect( cfg.queryArgs._embed ).toContain( 'author' );
 	} );
@@ -90,7 +91,7 @@ describe( 'fetchPosts', () => {
 			} ) as never,
 		);
 
-		await fetchPosts( {
+		await client.fetchPosts( {
 			page: 2,
 			perPage: 50,
 			search: 'hello',
@@ -127,7 +128,7 @@ describe( 'fetchPosts', () => {
 				'X-WP-TotalPages': '0',
 			} ) as never,
 		);
-		await fetchPosts();
+		await client.fetchPosts();
 		const init = ( fetchMock.mock.calls[ 0 ] as unknown as [ string, RequestInit ] )[ 1 ];
 		const headers = init.headers as Record< string, string >;
 		expect( headers[ 'X-WP-Nonce' ] ).toBe( 'nonce-1' );
@@ -142,7 +143,7 @@ describe( 'fetchPosts', () => {
 			} ) as never,
 		);
 
-		const result = await fetchPosts();
+		const result = await client.fetchPosts();
 		expect( result.items ).toHaveLength( 1 );
 		expect( result.total ).toBe( 237 );
 		expect( result.totalPages ).toBe( 12 );
@@ -152,7 +153,7 @@ describe( 'fetchPosts', () => {
 		vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
 			jsonResponse( [] ) as never,
 		);
-		const result = await fetchPosts();
+		const result = await client.fetchPosts();
 		expect( result.total ).toBe( 0 );
 		expect( result.totalPages ).toBe( 0 );
 	} );
@@ -171,7 +172,7 @@ describe( 'fetchPosts', () => {
 				},
 			) as never,
 		);
-		await expect( fetchPosts() ).rejects.toThrow( /Invalid post status/ );
+		await expect( client.fetchPosts() ).rejects.toThrow( /Invalid post status/ );
 	} );
 
 	test( 'falls back to status line on non-JSON error body', async () => {
@@ -181,14 +182,14 @@ describe( 'fetchPosts', () => {
 				statusText: 'Internal Server Error',
 			} ) as never,
 		);
-		await expect( fetchPosts() ).rejects.toThrow( /500/ );
+		await expect( client.fetchPosts() ).rejects.toThrow( /500/ );
 	} );
 
 	test( 'omits caller params that are falsy (other than status)', async () => {
 		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
 			jsonResponse( [] ) as never,
 		);
-		await fetchPosts( { search: '', status: '' } );
+		await client.fetchPosts( { search: '', status: '' } );
 		const calledUrl = String(
 			( fetchMock.mock.calls[ 0 ] as unknown as [ string ] )[ 0 ],
 		);
@@ -202,7 +203,7 @@ describe( 'fetchPosts', () => {
 		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
 			jsonResponse( [] ) as never,
 		);
-		await fetchPosts();
+		await client.fetchPosts();
 		const calledUrl = String(
 			( fetchMock.mock.calls[ 0 ] as unknown as [ string ] )[ 0 ],
 		);
@@ -213,7 +214,7 @@ describe( 'fetchPosts', () => {
 		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
 			jsonResponse( [] ) as never,
 		);
-		await fetchPosts( { status: 'trash' } );
+		await client.fetchPosts( { status: 'trash' } );
 		const calledUrl = String(
 			( fetchMock.mock.calls[ 0 ] as unknown as [ string ] )[ 0 ],
 		);
@@ -226,7 +227,7 @@ describe( 'trashPost', () => {
 		vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
 			jsonResponse( { id: 42, status: 'trash' } ) as never,
 		);
-		const result = await trashPost( 42 );
+		const result = await client.trashPost( 42 );
 		expect( result.ok ).toBe( true );
 		expect( result.id ).toBe( 42 );
 	} );
@@ -242,7 +243,7 @@ describe( 'trashPost', () => {
 				},
 			) as never,
 		);
-		const result = await trashPost( 42 );
+		const result = await client.trashPost( 42 );
 		expect( result.ok ).toBe( false );
 		expect( result.error ).toMatch( /cannot delete/ );
 	} );
@@ -250,7 +251,7 @@ describe( 'trashPost', () => {
 
 describe( 'buildEditPostUrl', () => {
 	test( 'appends ?post=<id>&action=edit when the base has no query string', () => {
-		expect( buildEditPostUrl( 7 ) ).toBe(
+		expect( client.buildEditPostUrl( 7 ) ).toBe(
 			'http://example.test/wp-admin/post.php?post=7&action=edit',
 		);
 	} );
@@ -259,7 +260,7 @@ describe( 'buildEditPostUrl', () => {
 		installConfig( {
 			editPostUrlBase: 'http://example.test/wp-admin/post.php?lang=en',
 		} );
-		expect( buildEditPostUrl( 7 ) ).toBe(
+		expect( client.buildEditPostUrl( 7 ) ).toBe(
 			'http://example.test/wp-admin/post.php?lang=en&post=7&action=edit',
 		);
 	} );

--- a/tests/vitest/user-edit-role-save.test.ts
+++ b/tests/vitest/user-edit-role-save.test.ts
@@ -162,11 +162,7 @@ describe( 'User Edit window — role save flow', () => {
 		( globalThis as unknown as { fetch: typeof fetch } ).fetch =
 			fetchSpy as unknown as typeof fetch;
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
-		setActiveWindowId( 'desktop-mode-user-edit' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		await render.mountProfileFormAt( host, 2 );
 
@@ -274,11 +270,7 @@ describe( 'User Edit window — role save flow', () => {
 				},
 			) ) as unknown as typeof fetch;
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
-		setActiveWindowId( 'desktop-mode-user-edit' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		await render.mountProfileFormAt( host, 2 );
 		await tick();
@@ -364,13 +356,9 @@ describe( 'User Edit window — role save flow', () => {
 				},
 			) ) as unknown as typeof fetch;
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
 		// Active window id is the wrong sibling — the scenario the
 		// user hit when bouncing between Edit User and Posts.
-		setActiveWindowId( 'desktop-mode-posts' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		await render.mountProfileFormAt( host, 2 );
 		await tick();
@@ -451,11 +439,7 @@ describe( 'User Edit window — role save flow', () => {
 				},
 			) ) as unknown as typeof fetch;
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
-		setActiveWindowId( 'desktop-mode-user-edit' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		// Admin id is 1, target is 2 — editing someone else.
 		await render.mountProfileFormAt( host, 2 );
@@ -662,11 +646,7 @@ describe( 'User Edit window — role save flow', () => {
 		( globalThis as unknown as { fetch: typeof fetch } ).fetch =
 			fetchSpy as unknown as typeof fetch;
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
-		setActiveWindowId( 'desktop-mode-user-edit' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		await render.mountProfileFormAt( host, 2 );
 		await tick();
@@ -787,11 +767,7 @@ describe( 'User Edit window — role save flow', () => {
 			desktop: { showToast: showToastSpy },
 		};
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
-		setActiveWindowId( 'desktop-mode-user-edit' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		await render.mountProfileFormAt( host, 2 );
 		await tick();
@@ -848,11 +824,7 @@ describe( 'User Edit window — role save flow', () => {
 				},
 			) ) as unknown as typeof fetch;
 
-		const { setActiveWindowId } = await import(
-			'../../src/posts-window/rest'
-		);
-		setActiveWindowId( 'desktop-mode-user-edit' );
-
+		
 		const render = await import( '../../src/posts-window/user-edit-render' );
 		// userId === cfg.currentUserId (1) — admin editing themselves.
 		await render.mountProfileFormAt( host, 1 );


### PR DESCRIPTION
## Why

Two visible bugs in the Users window:

1. Clicking **Edit user** → opening the User-edit window broke the Users window's **Refresh** button (`TypeError: Failed to construct 'URL': Invalid URL`).
2. The All-users table was missing **Email**, **Role**, and **Registered date** for every row.

Both trace to one root cause: `src/posts-window/rest.ts` had a module-level `_activeWindowId` singleton that every renderer in the bundle wrote to. Opening User-edit repointed it to `'desktop-mode-user-edit'`, so any later Users-window REST call read the user-edit config blob — which has no `postsUrl`. Same class of bug already had a `resolveProfileConfig()` band-aid in `user-edit-render.ts`; this PR removes the singleton instead.

## What changed

### Per-window REST client factory

- `rest.ts`, `users-rest.ts`, `user-edit-rest.ts` — free function exports replaced with `createPostsWindowClient(windowId)` / `createUsersWindowClient(windowId)` / `createUserEditClient(windowId)`. Each returns a client whose methods close over the bound `windowId`. Reading the wrong window's config is now structurally impossible.
- `index.ts` registry callbacks build a client per `desktop-mode-{posts,pages,users,user-edit}` mount and thread it into the renderer. `setActiveWindowId` / `getActiveWindowId` / `_activeWindowId` deleted.
- `users-render.ts`, `user-edit-render.ts`, `index.ts`, `tags-cloud.ts`, `categories-mindmap.ts` — `client` threaded through helpers and column-render closures.

### Users window data fixes

- `includes/users-window/window.php` — switched the list query from `context=view` to `context=edit`. WP core only emits `email`, `roles`, and `registered_date` on `/wp/v2/users` in edit context.
- Same file — widened the schema `context` on all five custom REST fields (`desktop_mode_user_stats`, `desktop_mode_last_login`, `desktop_mode_presence`, `desktop_mode_can_edit`, `desktop_mode_assignable_roles`) to `['view','edit','embed']` so they survive the context switch. Without this the Actions column and stats went blank.
- `users-render.ts` — `buildRegisteredCell` no longer appends a stray `Z` to ISO strings that already carry a `+00:00` offset (the registered_date format in edit context). It now relative-formats correctly instead of falling through to the raw ISO.

### Live refresh after profile save

- `user-edit-render.ts` — after `saveUser` succeeds, broadcasts `desktop-mode.user.changed` with `{ source, action: 'updated', ids: [userId] }`. Mirrors the existing `desktop-mode.post.changed` pattern.
- `users-render.ts` — subscribes to the channel and patches **only the affected row** via a new `client.fetchOneUser(id)` (no full list re-fetch, no scroll reset, no flicker). Unsubscribes on window-closed.
- `users-rest.ts` — added `fetchOneUser(id)` that hits `/wp/v2/users/<id>` with the same `_fields` and `context` whitelist as the list endpoint.

## Test plan

- [ ] Open Users window. Verify Email, Role, Registered date, Actions, Content, and Last login dots all populate for every row.
- [ ] Click a row → User-edit window opens. Switch back to Users window and click **Refresh** — no console error, list reloads.
- [ ] In the User-edit window, change a user's role and save. Switch to the Users window — that row's role chip updates in place; other rows don't flicker.
- [ ] Change the email field too. Save. Verify the Users window row updates.
- [ ] `npm run build`, `npm run lint`, `./node_modules/.bin/tsc --noEmit`, `npm run test:js` — all green (1115/1115 vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-177-516fb7bd1e773a8e9381edc830f3594cc440d85f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->