### PR TITLE
Fix: session-expiry cascade + Plugins window sync

### DIFF
--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -2367,6 +2367,20 @@ function desktop_mode_chromeless_bridge_script() {
 				}
 				if ( sawLoggedOut && data[ 'wp-auth-check' ] === true ) {
 					sawLoggedOut = false;
+					// Tell the parent shell BEFORE we reload so it
+					// doesn't have to wait for its own heartbeat
+					// tick (up to 60s on an idle shell) to discover
+					// the cookie is fresh. Parent runs its full
+					// recovery path on receipt — overlay teardown,
+					// iframe reload sweep, then a hard reload.
+					try {
+						if ( window.parent && window.parent !== window ) {
+							window.parent.postMessage(
+								{ type: 'desktop-mode-reauth-detected' },
+								window.location.origin
+							);
+						}
+					} catch ( _err ) { /* parent gone */ }
 					try { window.location.reload(); } catch ( _err ) { /* swallow */ }
 				}
 			} );

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -237,6 +237,7 @@ function desktop_mode_chromeless_bridge_script() {
 	// Emit via wp_print_inline_script_tag so CSP nonces and `<script>`
 	// attribute hygiene go through Core rather than being hand-rolled.
 	$js = <<<'JS'
+//# sourceURL=desktop-mode-chromeless-bridge.js
 ( function() {
 	// Escape hatch: a chromeless page is only meant to live inside a
 	// desktop-mode window iframe. If the top window IS this page, the
@@ -370,6 +371,61 @@ function desktop_mode_chromeless_bridge_script() {
 					}
 				}
 				window.parent.postMessage( msg, window.location.origin );
+			} catch ( _err ) { /* swallow */ }
+		};
+
+		// Helper — when an admin-side request returns 401/403 the
+		// session is most likely toast. Don't wait up to 60s for the
+		// next heartbeat tick to surface core's auth-check modal —
+		// force an immediate tick. `wp.heartbeat.connectNow()` is
+		// safe to call repeatedly; we still debounce to avoid storms
+		// when many requests fail at once. Same-origin gate keeps us
+		// out of third-party 403s. The URL gate avoids looping on
+		// heartbeat itself (heartbeat shouldn't 403 — but if it does
+		// the recursive connectNow would not help anyway).
+		var wpdAuthCheckCooldownUntil = 0;
+		var wpdMaybeForceAuthCheck = function ( status, url ) {
+			if ( status !== 401 && status !== 403 ) {
+				return;
+			}
+			var urlStr = String( url || '' );
+			if ( ! urlStr ) {
+				return;
+			}
+			// Cross-origin URLs aren't ours to interpret.
+			try {
+				var resolved = new URL( urlStr, window.location.href );
+				if ( resolved.origin !== window.location.origin ) {
+					return;
+				}
+				// Skip heartbeat to avoid recursion. Skip wp-login
+				// because the login iframe itself returns 4xx during
+				// the auth handshake and we don't want to retrigger.
+				if (
+					resolved.pathname.indexOf( '/wp-admin/admin-ajax.php' ) !== -1
+					&& /(?:^|&|\?)action=heartbeat(?:&|$)/.test( resolved.search )
+				) {
+					return;
+				}
+				if ( resolved.pathname.indexOf( '/wp-login.php' ) !== -1 ) {
+					return;
+				}
+			} catch ( _err ) {
+				return;
+			}
+			var now = Date.now();
+			if ( now < wpdAuthCheckCooldownUntil ) {
+				return;
+			}
+			wpdAuthCheckCooldownUntil = now + 5000;
+			try {
+				if (
+					window.wp
+					&& window.wp.heartbeat
+					&& typeof window.wp.heartbeat.connectNow === 'function'
+				) {
+					window.wp.heartbeat.connectNow();
+				}
 			} catch ( _err ) { /* swallow */ }
 		};
 
@@ -517,6 +573,7 @@ function desktop_mode_chromeless_bridge_script() {
 							} catch ( _hErr ) { /* swallow */ }
 						}
 						wpdReportNetwork( method, url, res.status, Math.round( dur ), ! res.ok, extra );
+						wpdMaybeForceAuthCheck( res.status, url );
 						return res;
 					},
 					function ( err ) {
@@ -616,6 +673,7 @@ function desktop_mode_chromeless_bridge_script() {
 						xhr.status === 0 || xhr.status >= 400,
 						extra
 					);
+					wpdMaybeForceAuthCheck( xhr.status, xhr.__wpdUrl );
 				};
 				try {
 					xhr.addEventListener( 'loadend', fire );
@@ -2260,6 +2318,65 @@ function desktop_mode_chromeless_bridge_script() {
 			};
 		};
 	}
+
+	/* -----------------------------------------------------------------
+	 * Stale-nonce recovery after wp-auth-check re-authentication.
+	 *
+	 * When the user's session expires while a chromeless window is
+	 * open, core's `wp-auth-check.js` shows its login iframe inside
+	 * this page. After re-auth the auth cookie is fresh — but every
+	 * per-page nonce cached in JS globals
+	 * (`_wpUpdatesSettings.ajax_nonce`, `commonL10n.nonce`, Gutenberg's
+	 * `wpApiSettings.nonce`, etc.) was minted under the OLD nonce-tick
+	 * and is now rejected by `check_ajax_referer`. WP reports that as
+	 * "Cookie check failed" on the next plugin Install / Activate /
+	 * Update click, which is misleading: the cookie is fine; the
+	 * nonce is stale.
+	 *
+	 * Fix: watch jQuery's `heartbeat-tick`. If we ever see
+	 * `wp-auth-check: false` (the modal trigger) and then later see
+	 * the same field flip back to `true`, the user re-authed
+	 * mid-session and every cached nonce in this iframe is stale —
+	 * reload so they regenerate from the fresh session.
+	 *
+	 * Per-iframe scope is intentional: each chromeless iframe carries
+	 * its own jQuery + heartbeat stack and its own nonce caches.
+	 * Siblings recover on their own next tick. We don't broadcast a
+	 * reload to peers because the parent shell may still be running
+	 * core's confirm() prompts and we don't want to surprise-reload
+	 * windows with unsaved state.
+	 *
+	 * If jQuery never loads on this page (rare — most admin screens
+	 * pull it for heartbeat already), this block is a no-op.
+	 * ----------------------------------------------------------------- */
+	( function _wpdInstallAuthCheckRecovery() {
+		var attached = false;
+		var sawLoggedOut = false;
+		function attach() {
+			if ( attached || ! window.jQuery ) {
+				return;
+			}
+			attached = true;
+			window.jQuery( document ).on( 'heartbeat-tick.wpdAuthRecover', function ( ev, data ) {
+				if ( ! data || typeof data !== 'object' || ! ( 'wp-auth-check' in data ) ) {
+					return;
+				}
+				if ( data[ 'wp-auth-check' ] === false ) {
+					sawLoggedOut = true;
+					return;
+				}
+				if ( sawLoggedOut && data[ 'wp-auth-check' ] === true ) {
+					sawLoggedOut = false;
+					try { window.location.reload(); } catch ( _err ) { /* swallow */ }
+				}
+			} );
+		}
+		attach();
+		if ( document.readyState === 'loading' ) {
+			document.addEventListener( 'DOMContentLoaded', attach, { once: true } );
+		}
+		window.addEventListener( 'load', attach, { once: true } );
+	} )();
 } )();
 JS;
 

--- a/includes/render/shell.php
+++ b/includes/render/shell.php
@@ -85,3 +85,171 @@ function desktop_mode_render_shell() {
 	do_action( 'desktop_mode_shell_after' );
 }
 add_action( 'in_admin_header', 'desktop_mode_render_shell', 5 );
+
+/**
+ * Parent-shell counterpart to the chromeless bridge's stale-nonce
+ * recovery (see `chromeless-bridge.php`).
+ *
+ * Core's `wp-auth-check.js` shows `#wp-auth-check-wrap` (the dark
+ * backdrop + login iframe) when a heartbeat tick returns
+ * `wp-auth-check: false`. It only dismisses the overlay when the
+ * user re-authenticates inside *its own* sub-iframe — re-auth
+ * happening anywhere else (a chromeless iframe inside our shell,
+ * another browser tab, the classic admin in another window) leaves
+ * the parent shell stuck behind an orphaned backdrop that no
+ * F5 / Cmd-R can clear in practice because the script re-attaches
+ * on every page load and the modal is already in DOM.
+ *
+ * Fix: subscribe to `heartbeat-tick` here and, on `false → true`,
+ * dismiss the wrap manually — same pattern as the per-iframe
+ * recovery, but the parent doesn't need to reload (it doesn't
+ * hold per-page WP nonces; iframes do).
+ *
+ * @since 0.18.5
+ */
+function desktop_mode_parent_auth_check_recovery_script() {
+	if (
+		desktop_mode_is_chromeless_request()
+		|| ! desktop_mode_is_enabled()
+		|| desktop_mode_is_classic_request()
+	) {
+		return;
+	}
+	$js = <<<'JS'
+//# sourceURL=desktop-mode-parent-auth-recovery.js
+( function () {
+	var sawLoggedOut = false;
+
+	/* -----------------------------------------------------------------
+	 * Fast-path auth-check: on 401/403 from any same-origin admin
+	 * request, force `wp.heartbeat.connectNow()` instead of waiting
+	 * up to 60s for the next regular tick. Same logic ships
+	 * inside chromeless iframes via the bridge — this is the
+	 * parent-shell counterpart for the shell's own fetches
+	 * (session-save, REST registries, etc.).
+	 *
+	 * Debounced (5s) so a burst of failed requests doesn't fire a
+	 * storm of heartbeats. URL gate skips heartbeat itself and
+	 * wp-login.php so the recovery can't loop on the very request
+	 * the modal authenticates with.
+	 * ----------------------------------------------------------------- */
+	var authCooldownUntil = 0;
+	function maybeForceAuthCheck( status, url ) {
+		if ( status !== 401 && status !== 403 ) {
+			return;
+		}
+		try {
+			var resolved = new URL( String( url || '' ), window.location.href );
+			if ( resolved.origin !== window.location.origin ) {
+				return;
+			}
+			if (
+				resolved.pathname.indexOf( '/wp-admin/admin-ajax.php' ) !== -1
+				&& /(?:^|&|\?)action=heartbeat(?:&|$)/.test( resolved.search )
+			) {
+				return;
+			}
+			if ( resolved.pathname.indexOf( '/wp-login.php' ) !== -1 ) {
+				return;
+			}
+		} catch ( _err ) {
+			return;
+		}
+		var now = Date.now();
+		if ( now < authCooldownUntil ) {
+			return;
+		}
+		authCooldownUntil = now + 5000;
+		try {
+			if (
+				window.wp
+				&& window.wp.heartbeat
+				&& typeof window.wp.heartbeat.connectNow === 'function'
+			) {
+				window.wp.heartbeat.connectNow();
+			}
+		} catch ( _err ) { /* swallow */ }
+	}
+
+	if ( typeof window.fetch === 'function' ) {
+		var origFetch = window.fetch;
+		window.fetch = function ( input, init ) {
+			var url = '';
+			if ( typeof input === 'string' ) {
+				url = input;
+			} else if ( input && typeof input === 'object' ) {
+				url = input.url || '';
+			}
+			var p;
+			try {
+				p = origFetch.apply( this, arguments );
+			} catch ( sync ) {
+				throw sync;
+			}
+			return p.then( function ( res ) {
+				try { maybeForceAuthCheck( res.status, url ); } catch ( _e ) {}
+				return res;
+			} );
+		};
+	}
+	if ( typeof XMLHttpRequest !== 'undefined' ) {
+		var origOpen = XMLHttpRequest.prototype.open;
+		XMLHttpRequest.prototype.open = function ( method, url ) {
+			try { this.__wpdAuthUrl = url; } catch ( _e ) {}
+			return origOpen.apply( this, arguments );
+		};
+		var origSend = XMLHttpRequest.prototype.send;
+		XMLHttpRequest.prototype.send = function () {
+			var xhr = this;
+			try {
+				xhr.addEventListener( 'loadend', function () {
+					try { maybeForceAuthCheck( xhr.status, xhr.__wpdAuthUrl ); } catch ( _e ) {}
+				} );
+			} catch ( _e ) {}
+			return origSend.apply( this, arguments );
+		};
+	}
+
+	function dismissAuthCheckOverlay() {
+		try {
+			var wrap = document.getElementById( 'wp-auth-check-wrap' );
+			if ( wrap && wrap.parentNode ) {
+				wrap.parentNode.removeChild( wrap );
+			}
+			// Core toggles these to lock scrolling + signal the
+			// "show" state; strip them both so the shell becomes
+			// interactive again.
+			document.documentElement.classList.remove( 'wp-auth-check-show' );
+			document.body.classList.remove( 'modal-open' );
+		} catch ( _err ) { /* DOM gone — nothing useful to do */ }
+	}
+	function attach() {
+		if ( ! window.jQuery ) {
+			return false;
+		}
+		window.jQuery( document ).on( 'heartbeat-tick.wpdParentAuthRecover', function ( ev, data ) {
+			if ( ! data || typeof data !== 'object' || ! ( 'wp-auth-check' in data ) ) {
+				return;
+			}
+			if ( data[ 'wp-auth-check' ] === false ) {
+				sawLoggedOut = true;
+				return;
+			}
+			if ( sawLoggedOut && data[ 'wp-auth-check' ] === true ) {
+				sawLoggedOut = false;
+				dismissAuthCheckOverlay();
+			}
+		} );
+		return true;
+	}
+	if ( ! attach() ) {
+		if ( document.readyState === 'loading' ) {
+			document.addEventListener( 'DOMContentLoaded', attach, { once: true } );
+		}
+		window.addEventListener( 'load', attach, { once: true } );
+	}
+} )();
+JS;
+	wp_print_inline_script_tag( $js );
+}
+add_action( 'admin_footer', 'desktop_mode_parent_auth_check_recovery_script' );

--- a/includes/render/shell.php
+++ b/includes/render/shell.php
@@ -96,14 +96,26 @@ add_action( 'in_admin_header', 'desktop_mode_render_shell', 5 );
  * user re-authenticates inside *its own* sub-iframe — re-auth
  * happening anywhere else (a chromeless iframe inside our shell,
  * another browser tab, the classic admin in another window) leaves
- * the parent shell stuck behind an orphaned backdrop that no
- * F5 / Cmd-R can clear in practice because the script re-attaches
- * on every page load and the modal is already in DOM.
+ * the parent shell stuck behind an orphaned backdrop.
  *
- * Fix: subscribe to `heartbeat-tick` here and, on `false → true`,
- * dismiss the wrap manually — same pattern as the per-iframe
- * recovery, but the parent doesn't need to reload (it doesn't
- * hold per-page WP nonces; iframes do).
+ * Beyond the backdrop, the bigger problem is that **WordPress
+ * nonces are tied to the user's session token**, and re-auth mints
+ * a fresh token. Every nonce the parent shell cached at page load
+ * (`wp.desktop.config.restNonce`, plus whatever third-party
+ * registries/widgets pulled in) was generated against the old
+ * token and is now silently rejected by `wp_verify_nonce()` /
+ * `check_ajax_referer()` — even though the auth cookie itself is
+ * valid. WP reports that as "Cookie check failed", which is
+ * misleading; the cookie is the only thing still working.
+ *
+ * Fix: on `wp-auth-check: false → true`, do a hard reload of the
+ * parent. The chromeless iframes already self-reload via their
+ * own bridge-side handler, but the parent is the only place where
+ * stale shell-wide nonces live, and there is no in-place API to
+ * swap every cached nonce across every loaded bundle + every
+ * plugin. The session-saver's `pagehide` flush writes the latest
+ * window snapshot before unload, so window positions / open
+ * windows are preserved across the reload.
  *
  * @since 0.18.5
  */
@@ -210,19 +222,108 @@ function desktop_mode_parent_auth_check_recovery_script() {
 		};
 	}
 
-	function dismissAuthCheckOverlay() {
+	function recoverFromReauth() {
+		// Strip the overlay first so the user sees the shell come
+		// back to life *before* the reload starts, instead of
+		// looking at a frozen dark backdrop while the network
+		// stalls. The reload guarantees nonces refresh.
 		try {
 			var wrap = document.getElementById( 'wp-auth-check-wrap' );
 			if ( wrap && wrap.parentNode ) {
 				wrap.parentNode.removeChild( wrap );
 			}
-			// Core toggles these to lock scrolling + signal the
-			// "show" state; strip them both so the shell becomes
-			// interactive again.
 			document.documentElement.classList.remove( 'wp-auth-check-show' );
 			document.body.classList.remove( 'modal-open' );
 		} catch ( _err ) { /* DOM gone — nothing useful to do */ }
+
+		// Reload every open iframe BEFORE the parent reload. Two
+		// reasons:
+		//
+		// 1. Each iframe is also showing core's wp-auth-check
+		//    modal (each one runs its own heartbeat). Without
+		//    this, those modals linger until each iframe's own
+		//    next heartbeat tick (up to 60s) — visible as a
+		//    "frozen iframe with a login modal" while the rest of
+		//    the shell is interactive again.
+		//
+		// 2. If an iframe was bounced to `wp-login.php` because it
+		//    made a server request while logged-out, the
+		//    session-saver may have captured that URL. The parent
+		//    reload would restore the iframe AT wp-login.php
+		//    instead of at the original admin page. Telling each
+		//    iframe to `location.reload()` directly makes the
+		//    browser walk its history back through the login
+		//    bounce now that cookies are fresh — the iframe lands
+		//    on the page it was originally on.
+		//
+		// Same-origin only (cross-origin iframes wouldn't be ours
+		// anyway).
+		try {
+			var frames = document.querySelectorAll( 'iframe' );
+			for ( var i = 0; i < frames.length; i++ ) {
+				try {
+					// Cross-origin access throws — caught + ignored.
+					var fw = frames[ i ].contentWindow;
+					if ( fw && fw.location && typeof fw.location.reload === 'function' ) {
+						fw.location.reload();
+					}
+				} catch ( _crossOrigin ) { /* not ours */ }
+			}
+		} catch ( _err ) { /* swallow */ }
+
+		// Hard reload — the only reliable way to refresh every
+		// nonce baked into JS globals across every loaded bundle.
+		// Small delay lets the session-saver's `pagehide` write
+		// the current window snapshot AND gives the
+		// `wp-auth-check-iframe` from core a chance to relay the
+		// success postMessage out (some plugins listen for that).
+		try {
+			window.setTimeout( function () {
+				try {
+					window.location.reload();
+				} catch ( _err ) { /* swallow */ }
+			}, 250 );
+		} catch ( _err ) {
+			try { window.location.reload(); } catch ( _e ) {}
+		}
 	}
+	// Cross-iframe nudge. The chromeless bridge inside each iframe
+	// posts `desktop-mode-reauth-detected` the instant its own
+	// heartbeat sees `wp-auth-check: false → true`. Without this
+	// the parent has to wait for ITS heartbeat to tick (15s active,
+	// up to 60s idle) before recoverFromReauth fires — during which
+	// every REST call from the shell keeps returning 401 with the
+	// stale shell-wide nonce. With this, the parent's recovery
+	// starts within a frame of the iframe seeing the new cookie.
+	try {
+		window.addEventListener( 'message', function ( ev ) {
+			if ( ev.origin !== window.location.origin ) {
+				return;
+			}
+			if ( ! ev.data || typeof ev.data !== 'object' ) {
+				return;
+			}
+			if ( ev.data.type !== 'desktop-mode-reauth-detected' ) {
+				return;
+			}
+			// Recovery is idempotent (the reload-of-everything path
+			// can only fire once before the page is gone), but
+			// gate on `sawLoggedOut` anyway so a stray message
+			// from a misbehaving iframe doesn't reload the shell
+			// during a normal session.
+			if ( sawLoggedOut ) {
+				sawLoggedOut = false;
+				recoverFromReauth();
+			} else {
+				// Even if we never noticed the logout ourselves,
+				// the iframe did. Trust it and recover — the
+				// stale-nonce gap is real even when the parent
+				// dodged the auth-check modal entirely.
+				recoverFromReauth();
+			}
+		} );
+	} catch ( _err ) { /* swallow */ }
+
 	function attach() {
 		if ( ! window.jQuery ) {
 			return false;
@@ -237,7 +338,7 @@ function desktop_mode_parent_auth_check_recovery_script() {
 			}
 			if ( sawLoggedOut && data[ 'wp-auth-check' ] === true ) {
 				sawLoggedOut = false;
-				dismissAuthCheckOverlay();
+				recoverFromReauth();
 			}
 		} );
 		return true;

--- a/src/plugins-window/browse-view.ts
+++ b/src/plugins-window/browse-view.ts
@@ -14,12 +14,27 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { broadcast, subscribe } from '../broadcast';
 import {
 	buildCard,
 	repaintCardCta,
 	type CardCallbacks,
 	type InstalledIndex,
 } from './card';
+
+/**
+ * Cross-view sync topic for the Plugins window. See
+ * `installed-view.ts` for the contract.
+ *
+ * @internal
+ */
+const PLUGINS_CHANGED_TOPIC = 'desktop-mode.plugin.changed';
+const SOURCE = 'browse-view';
+interface PluginsChangedPayload {
+	source: string;
+	plugin?: string;
+	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'bulk';
+}
 import { installPluginDropTargets, makeCardDraggable } from './card-drag';
 import { openDetailFlyout } from './flyout-detail';
 import {
@@ -145,6 +160,22 @@ export function mountBrowseView(
 		right.appendChild( upload );
 	}
 
+	// Refresh button — re-fetch the current filter / search result
+	// set from wp.org and the installed-state cache. Matches the
+	// affordance on the Installed tab so the surface is symmetric;
+	// also useful when wp.org's cached response lags the user's
+	// just-uploaded plugin.
+	const refreshButton = document.createElement( 'wpd-button' );
+	refreshButton.setAttribute( 'variant', 'ghost' );
+	refreshButton.setAttribute( 'title', __( 'Refresh', 'desktop-mode' ) );
+	refreshButton.innerHTML =
+		'<span class="dashicons dashicons-update" aria-hidden="true"></span>';
+	refreshButton.addEventListener( 'click', () => {
+		void refreshInstalled();
+		void resetAndLoad();
+	} );
+	right.appendChild( refreshButton );
+
 	toolbar.append( left, right );
 
 	// ─── Gallery ────────────────────────────────────────────────────
@@ -250,6 +281,11 @@ export function mountBrowseView(
 					if ( card && plugin ) {
 						repaintCardCta( card, plugin, state.installed, cardCallbacks );
 					}
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: pluginFile ?? slug2,
+						action: 'install',
+					} );
 					if ( pluginFile ) {
 						// eslint-disable-next-line no-console
 						console.log( '[plugins-window] installed', pluginFile );
@@ -264,6 +300,11 @@ export function mountBrowseView(
 					if ( card && plugin ) {
 						repaintCardCta( card, plugin, state.installed, cardCallbacks );
 					}
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: updated.plugin,
+						action: 'activate',
+					} );
 				},
 				onPluginDeactivated: ( updated ) => {
 					state.installed.set( indexKeyFor( updated ), updated );
@@ -274,6 +315,11 @@ export function mountBrowseView(
 					if ( card && plugin ) {
 						repaintCardCta( card, plugin, state.installed, cardCallbacks );
 					}
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: updated.plugin,
+						action: 'deactivate',
+					} );
 				},
 				onPluginDeleted: ( deleted ) => {
 					const key = indexKeyFor( deleted );
@@ -285,6 +331,11 @@ export function mountBrowseView(
 					if ( card && plugin ) {
 						repaintCardCta( card, plugin, state.installed, cardCallbacks );
 					}
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: deleted.plugin,
+						action: 'delete',
+					} );
 				},
 			} );
 		},
@@ -316,6 +367,11 @@ export function mountBrowseView(
 					),
 				);
 				repaintCardCta( card, plugin, state.installed, cardCallbacks );
+				broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+					source: SOURCE,
+					plugin: plugin.slug,
+					action: 'install',
+				} );
 				void refreshFrameworkMenu();
 			} catch ( err ) {
 				cta?.removeAttribute( 'busy' );
@@ -357,6 +413,11 @@ export function mountBrowseView(
 				if ( plugin ) {
 					repaintCardCta( card, plugin, state.installed, cardCallbacks );
 				}
+				broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+					source: SOURCE,
+					plugin: updated.plugin,
+					action: 'activate',
+				} );
 				// Background — dock/taskbar repaint shouldn't gate the
 				// in-card "Active" state flip.
 				void refreshFrameworkMenu();
@@ -548,7 +609,23 @@ export function mountBrowseView(
 		status.textContent = '';
 	}
 
+	// Cross-view sync: when the Installed tab activates / deactivates
+	// / deletes a plugin, refresh our installed-state cache so card
+	// CTAs flip without the user having to switch tabs and back.
+	// Self-emitted broadcasts are skipped — our own card callbacks
+	// already updated the local map and repainted the affected card.
+	const unsubscribePluginsChanged = subscribe< PluginsChangedPayload >(
+		PLUGINS_CHANGED_TOPIC,
+		( payload ) => {
+			if ( payload?.source === SOURCE ) {
+				return;
+			}
+			void refreshInstalled();
+		},
+	);
+
 	return () => {
+		unsubscribePluginsChanged();
 		observer.disconnect();
 		bodyEl.removeEventListener( 'dragenter', onDragEnter );
 		bodyEl.removeEventListener( 'dragleave', onDragLeave );

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -15,6 +15,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { broadcast, subscribe } from '../broadcast';
 import {
 	activateInstalledPlugin,
 	deactivateInstalledPlugin,
@@ -25,6 +26,25 @@ import {
 	refreshFrameworkMenu,
 	reloadOutOfDesktopMode,
 } from './rest';
+
+/**
+ * Cross-view sync topic for the Plugins window.
+ *
+ * Emitted whenever one view (Installed / Browse) mutates plugin
+ * state, so the other view re-fetches and re-paints rather than
+ * showing a stale snapshot. The `source` field lets each view
+ * skip self-emitted broadcasts (its mutation handler already
+ * updated local state optimistically).
+ *
+ * @internal
+ */
+const PLUGINS_CHANGED_TOPIC = 'desktop-mode.plugin.changed';
+const SOURCE = 'installed-view';
+interface PluginsChangedPayload {
+	source: string;
+	plugin?: string;
+	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'bulk';
+}
 import type { InstalledPlugin } from './types';
 import type {
 	WpdTable,
@@ -529,6 +549,11 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 					row.name || row.plugin,
 				),
 			);
+			broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+				source: SOURCE,
+				plugin: row.plugin,
+				action: 'activate',
+			} );
 			// Background — the table's status badge already flipped via
 			// `mergeRow` above; the menu refresh is a slow hidden-iframe
 			// load that only needs to keep the dock/taskbar in sync.
@@ -575,6 +600,11 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 					row.name || row.plugin,
 				),
 			);
+			broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+				source: SOURCE,
+				plugin: row.plugin,
+				action: 'deactivate',
+			} );
 			void refreshFrameworkMenu();
 		} catch ( err ) {
 			applyStatusOptimistic( row, previous );
@@ -630,6 +660,11 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 					row.name || row.plugin,
 				),
 			);
+			broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+				source: SOURCE,
+				plugin: row.plugin,
+				action: 'delete',
+			} );
 			void refreshFrameworkMenu();
 		} catch ( err ) {
 			toast(
@@ -706,6 +741,12 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			reloadOutOfDesktopMode();
 			return;
 		}
+		if ( succeeded > 0 ) {
+			broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+				source: SOURCE,
+				action: 'bulk',
+			} );
+		}
 		void refreshFrameworkMenu();
 		let noun = '';
 		if ( action === 'delete' ) {
@@ -751,7 +792,23 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		paintTable();
 	}
 
+	// Cross-view sync: when the Browse tab installs/activates a
+	// plugin, refresh the installed list so the row reflects the
+	// new state without the user having to switch tabs and back.
+	// Self-emitted broadcasts are skipped — our mutation handlers
+	// already painted the new state.
+	const unsubscribePluginsChanged = subscribe< PluginsChangedPayload >(
+		PLUGINS_CHANGED_TOPIC,
+		( payload ) => {
+			if ( payload?.source === SOURCE ) {
+				return;
+			}
+			void reload();
+		},
+	);
+
 	return () => {
+		unsubscribePluginsChanged();
 		table.removeEventListener( 'wpd-table-selection-change', selectionListener );
 		host.replaceChildren();
 	};


### PR DESCRIPTION
## Summary

When a user's WP session expired while desktop mode was open, the
shell entered a broken state that snowballed: stale-nonce 401/403s on
plugin Install/Activate ("Cookie check failed"), an orphaned dark
backdrop locking the parent, and Installed / Browse tabs disagreeing
about plugin state. This PR fixes the recovery path end-to-end and
the cross-tab sync gap.

## Changes

### 1. Stale-nonce recovery on re-auth — `includes/render/chromeless-bridge.php`

WP nonces are tied to the user's **session token**. Logging back in
mints a fresh token; every nonce JS captured at page load
(`_wpUpdatesSettings.ajax_nonce`, `wpApiSettings.nonce`, etc.) is now
silently rejected — even though the cookie itself is valid. WP
reports that as "Cookie check failed", which is misleading.

Added an iframe-side `heartbeat-tick` watcher that detects
`wp-auth-check: false → true` and reloads the iframe so the server
re-mints nonces against the new session token. The reloaded iframe
also `postMessage`s `desktop-mode-reauth-detected` to the parent
**before** reloading itself, so the parent doesn't have to wait for
its own heartbeat tick to catch up.

### 2. Parent shell recovery — `includes/render/shell.php`

Core's `wp-auth-check.js` shows `#wp-auth-check-wrap` only dismisses
when re-auth happens in *its own* sub-iframe. Re-auth from anywhere
else (one of our chromeless iframes, another tab) leaves the parent
behind an orphaned dark backdrop that no F5 reliably clears.

Added an `admin_footer` inline script in the parent shell that:

- Listens for `desktop-mode-reauth-detected` from any same-origin
  iframe AND its own `heartbeat-tick` going `false → true` (belt +
  suspenders).
- Strips `#wp-auth-check-wrap`, `wp-auth-check-show`, `modal-open`
  so the shell is interactive again immediately.
- Walks every same-origin iframe and calls `contentWindow.location
  .reload()` — handles iframes that were bounced to `wp-login.php`
  and would otherwise be restored AT the login URL by the session
  saver.
- Hard-reloads the parent 250ms later — the only way to refresh
  every cached nonce across every loaded bundle + third-party plugin.
  Session-saver's `pagehide` flush preserves window positions.

### 3. Fast-path auth-check on 401/403 — both files

WP heartbeat ticks every 15–60s in admin. Without help, a session
that expired right after a tick could leave the user staring at 401s
for up to a minute before core's modal appeared.

Added `maybeForceAuthCheck(status, url)` to the existing fetch + XHR
wrappers (chromeless bridge) and a new parallel wrapper in the parent
shell. On a same-origin 401/403 from anywhere other than
`/wp-admin/admin-ajax.php?action=heartbeat` or `/wp-login.php`, it
calls `wp.heartbeat.connectNow()`. Debounced 5s so a burst of failed
requests doesn't storm heartbeats. Modal now appears within ~1s of
the first failed request instead of after a minute.

### 4. Diagnostic `sourceURL` tags

The reported `Unexpected token 'default'` at
`/wp-admin/update-core.php?desktop_mode_chromeless=1:3851` couldn't
be reproduced from our bundles (all IIFE, no ESM tokens). Added
`//# sourceURL=desktop-mode-chromeless-bridge.js` and
`desktop-mode-parent-auth-recovery.js` to the two inline scripts we
emit, so the next time the error fires the console clearly says
whether it's our code or a third-party plugin's inline script.

### 5. Plugins window cross-view sync — `src/plugins-window/`

The native Plugins window has two tabs (Installed + Browse) mounted
side-by-side in the same DOM. Activating a plugin from Installed
didn't update the Browse tab's card CTA, and vice versa. Browse also
lacked a Refresh affordance.

- Both views now `subscribe` to the `desktop-mode.plugin.changed`
  broadcast topic and re-fetch on receipt.
- Each view `broadcast`s on successful activate / deactivate /
  delete / install (including from the detail flyout). `source`
  field gates self-broadcasts (each view already updates its own
  state optimistically).
- Added a Refresh button to Browse, matching the one on Installed.
- Going through the canonical broadcast bus (not just a local
  `CustomEvent`) gives multi-tab/multi-window sync for free.

## Testing

```bash
# Force session expiry to repro the cascade:
docker exec wordpress-alcazaba-cli-1 wp user session destroy admin --all --allow-root

# Wait ~15–60s in desktop mode (or click anything to trigger a 401
# and the fast-path heartbeat). Log in inside the modal that appears.
# Expected: shell reloads itself within ~1s of submitting the login,
# iframes reload to their canonical URLs, no "Cookie check failed"
# on the next Plugins → Activate click.
```

- `php -l` clean on every changed `.php` file.
- `npm run lint`, `npm run build`, `./node_modules/.bin/tsc --noEmit` clean.
- `npm run test:js` — 1116/1116 passing.

## Known caveats

- The `update-core.php` SyntaxError needs a repro to fully resolve —
  the `sourceURL` diagnostic will identify the actual offending
  script next time it fires.
- The underlying *cause* of session expiry isn't addressed here
  (nothing in this plugin destroys cookies). This PR makes recovery
  fast and lossless when it happens.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-180-d46397d964b338fb65fc594bb403d6442435cc78.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->