### PR TITLE
fix(pwa): narrow scope to /wp-admin/ and throttle SW reloads

### DIFF
--- a/includes/pwa.php
+++ b/includes/pwa.php
@@ -202,8 +202,34 @@ function desktop_mode_pwa_build_manifest() {
 		$short_name = $site_name;
 	}
 
-	$start_url = desktop_mode_portal_url();
-	$scope     = '/';
+	// `start_url` is the actual landing URL after the `/desktop-mode/`
+	// portal redirect — pointing the PWA directly at it lets us narrow
+	// `scope` to `/wp-admin/` without breaking the launch path. The
+	// portal redirect still exists for typed / bookmarked
+	// `/desktop-mode/` visits in regular browser tabs.
+	//
+	// `scope` is `/wp-admin/`, not `/`. The wider `/` scope had two
+	// failure modes that this fixes:
+	//
+	//   - Front-end URLs (e.g. `/2026/05/post-123/`) were considered
+	//     in-scope, so Chrome's "Open in app" link-capturing redirected
+	//     external-link clicks (Comments "In response to" column, etc.)
+	//     into the installed PWA window instead of opening a real
+	//     browser tab. Excluding the front-end from scope makes those
+	//     clicks open in a browser tab as users expect.
+	//   - Every same-origin `<a target="_blank">` from inside the PWA
+	//     opened a NEW standalone PWA window for the same reason. With
+	//     scope narrowed, only `/wp-admin/*` links capture into the
+	//     PWA; everything else escapes to the system browser.
+	//
+	// `id` is held at the previous `/desktop-mode/` value so existing
+	// installs aren't treated as a different app and reset by Chrome
+	// after this change ships.
+	$start_url = admin_url( 'index.php?desktop_mode_portal=1' );
+	$scope     = admin_url( '/', 'relative' );
+	if ( '' === $scope ) {
+		$scope = '/wp-admin/';
+	}
 
 	$manifest_url = desktop_mode_pwa_manifest_url();
 
@@ -217,7 +243,7 @@ function desktop_mode_pwa_build_manifest() {
 		),
 		'start_url'            => $start_url,
 		'scope'                => $scope,
-		'id'                   => $start_url,
+		'id'                   => desktop_mode_portal_url(),
 		'display'              => 'standalone',
 		'display_override'     => array( 'standalone', 'minimal-ui' ),
 		'orientation'          => 'any',
@@ -242,7 +268,7 @@ function desktop_mode_pwa_build_manifest() {
 			array(
 				'platform' => 'webapp',
 				'url'      => $manifest_url,
-				'id'       => $start_url,
+				'id'       => desktop_mode_portal_url(),
 			),
 		),
 		'prefer_related_applications' => false,

--- a/src/pwa/sw-register.ts
+++ b/src/pwa/sw-register.ts
@@ -72,12 +72,55 @@ function bindControllerChangeReload(): void {
 		if ( _reloadingForSwUpdate ) {
 			return;
 		}
+		// Throttle reloads to prevent infinite cycles under DevTools'
+		// "Application → Service Workers → Update on reload". That flag
+		// forces an install + activate on every page load even when the
+		// SW bytes are byte-identical, so every reload we trigger here
+		// causes ANOTHER `controllerchange` on the next load, which
+		// triggers another reload, ad infinitum.
+		//
+		// Window: 30s. Real-deploy reloads coalesce across rapid
+		// successive activations; the user picks up the new bundle on
+		// the next reload past the window.
+		if ( wasRecentlyReloadedForSwUpdate() ) {
+			return;
+		}
+		markReloadedForSwUpdate();
 		_reloadingForSwUpdate = true;
 		// One-frame delay so any in-flight UI work has a chance to
 		// settle before the navigation. Not strictly required, but
 		// avoids a class of "click → reload races input" surprises.
 		setTimeout( () => window.location.reload(), 0 );
 	} );
+}
+
+const SW_RELOAD_THROTTLE_KEY = 'wpd-sw-reload-ts';
+const SW_RELOAD_THROTTLE_MS = 30_000;
+
+function wasRecentlyReloadedForSwUpdate(): boolean {
+	try {
+		const raw = sessionStorage.getItem( SW_RELOAD_THROTTLE_KEY );
+		const last = raw ? Number.parseInt( raw, 10 ) : 0;
+		if ( ! Number.isFinite( last ) || last <= 0 ) {
+			return false;
+		}
+		return Date.now() - last < SW_RELOAD_THROTTLE_MS;
+	} catch {
+		// sessionStorage may be unavailable (private mode, blocked
+		// storage). Without it we can't throttle, so default to
+		// "no recent reload" and let the reload fire. The infinite-
+		// loop scenario it guards against requires DevTools, which is
+		// itself unlikely to coincide with storage being blocked.
+		return false;
+	}
+}
+
+function markReloadedForSwUpdate(): void {
+	try {
+		sessionStorage.setItem( SW_RELOAD_THROTTLE_KEY, String( Date.now() ) );
+	} catch {
+		// See `wasRecentlyReloadedForSwUpdate` — swallow.
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related PWA bugs:

1. **External links captured into the PWA.** Manifest declared `scope: '/'`, so every same-origin URL was in-scope of the installed app. Chrome's link-capturing routed clicks like the Comments "In response to" links (which point at front-end posts) into a standalone PWA window instead of opening a browser tab.
2. **Infinite reload loop with DevTools "Update on reload."** Chrome's "Application → Service Workers → Update on reload" forces a SW install + activate on every navigation even when the SW bytes are byte-identical. The `controllerchange` handler reloaded the page on every activation, driving an infinite cycle inside the PWA.

## What changed

- **Narrowed `scope` to `/wp-admin/`** (`includes/pwa.php`). Front-end URLs are now out of scope, so Chrome lets them open in a regular browser tab. Internal `/wp-admin/*` navigation still stays inside the PWA.
- **Moved `start_url` to `/wp-admin/index.php?desktop_mode_portal=1`** so the launch path lands inside the new scope without relying on the `/desktop-mode/` redirect.
- **Held `id` at the previous `/desktop-mode/` value** so Chrome treats existing installs as the same app and doesn't reset them.
- **Throttled SW-update reloads** (`src/pwa/sw-register.ts`): if we already reloaded for a controllerchange within the last 30s, skip the next one. Phantom updates from DevTools can't cycle anymore. Real deploys keep working: the next reload past the throttle window picks up the new bundle.

## Test plan

- [x] Reinstall the PWA after deploy so Chrome picks up the new manifest.
- [x] In the PWA: open Comments, click an "In response to" link. Expect it to open in a browser tab.
- [x] In a regular browser tab with Desktop Mode enabled: same click, same expectation.
- [x] Inside the PWA with DevTools "Update on reload" enabled: reload the window. Expect one auto-reload at most, then a steady state. No infinite "Service Worker was updated…" flood.
- [x] Verify the manifest at `/desktop-mode/manifest.webmanifest` shows `"scope":"/wp-admin/"`, `"start_url":".../wp-admin/index.php?desktop_mode_portal=1"`, `"id":".../desktop-mode/"`.
- [x] Existing PWA installs continue to launch and report `display-mode: standalone` after the manifest change.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-181-aa5935602d717384d5d2e6b415eaa4e772cfbd20.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->