### PR TITLE
Support plain permalinks for REST URL construction

### DIFF
--- a/src/content-graph/rest.ts
+++ b/src/content-graph/rest.ts
@@ -10,6 +10,7 @@
  * @since 0.8.2
  */
 
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import type {
 	CommentStats,
@@ -108,7 +109,7 @@ export async function fetchUserStats(
 	userId: number,
 ): Promise< UserStats > {
 	const res = await trackedFetch(
-		`${ cfg.restRoot }desktop-mode/v1/user-stats/${ userId }`,
+		joinRestUrl( cfg.restRoot, `desktop-mode/v1/user-stats/${ userId }` ),
 		{ headers: authHeaders( cfg ) },
 		{ source: SOURCE, windowId: WINDOW_ID },
 	);
@@ -124,9 +125,10 @@ export async function fetchTermStats(
 	termId: number,
 ): Promise< TermStats > {
 	const res = await trackedFetch(
-		`${ cfg.restRoot }desktop-mode/v1/term-stats/${ encodeURIComponent(
-			taxonomy,
-		) }/${ termId }`,
+		joinRestUrl(
+			cfg.restRoot,
+			`desktop-mode/v1/term-stats/${ encodeURIComponent( taxonomy ) }/${ termId }`,
+		),
 		{ headers: authHeaders( cfg ) },
 		{ source: SOURCE, windowId: WINDOW_ID },
 	);
@@ -143,7 +145,7 @@ export async function fetchCommentStats(
 	commentId: number,
 ): Promise< CommentStats > {
 	const res = await trackedFetch(
-		`${ cfg.restRoot }desktop-mode/v1/comment-stats/${ commentId }`,
+		joinRestUrl( cfg.restRoot, `desktop-mode/v1/comment-stats/${ commentId }` ),
 		{ headers: authHeaders( cfg ) },
 		{ source: SOURCE, windowId: WINDOW_ID },
 	);

--- a/src/desktop-files/preview.ts
+++ b/src/desktop-files/preview.ts
@@ -20,6 +20,7 @@
 
 import { applyFilters } from '../hooks';
 import { __, sprintf } from '../i18n';
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import type { RestPlacementShape } from './rest';
 
@@ -61,20 +62,16 @@ function readRestRoot(): string {
 	if ( cfg?.restUrl ) {
 		return cfg.restUrl.endsWith( '/' ) ? cfg.restUrl : cfg.restUrl + '/';
 	}
-	if ( cfg?.adminUrl ) {
-		// Fall back to the admin root + the stable wp-json segment.
-		try {
-			const u = new URL( cfg.adminUrl, window.location.origin );
-			return `${ u.origin }/wp-json/`;
-		} catch {
-			// Pass through.
-		}
-	}
+	// Last-ditch fallback used only when the shell config never lands
+	// (e.g., the file-tile renders before `wp.desktop` boots). Assumes
+	// pretty permalinks; plain-permalink sites that hit this path would
+	// 404, but in practice the shell config is always present by the
+	// time a preview is requested.
 	return `${ window.location.origin }/wp-json/`;
 }
 
 function restUrl( path: string ): string {
-	return readRestRoot() + path.replace( /^\/+/, '' );
+	return joinRestUrl( readRestRoot(), path );
 }
 
 /* ------------------------------------------------------------------ *

--- a/src/desktop-files/rest.ts
+++ b/src/desktop-files/rest.ts
@@ -9,6 +9,7 @@
  */
 
 import { trackedFetch } from '../tracked-fetch';
+import { joinRestUrl } from '../rest-url';
 
 export interface RestPlacementShape {
 	id: number;
@@ -89,7 +90,7 @@ function ensureDeps(): FilesRestDeps {
 
 async function call< T >( path: string, init: RequestInit ): Promise< T > {
 	const { baseUrl, nonce } = ensureDeps();
-	const url = `${ baseUrl.replace( /\/$/, '' ) }${ path }`;
+	const url = joinRestUrl( baseUrl, path );
 	const headers = new Headers( init.headers ?? {} );
 	headers.set( 'X-WP-Nonce', nonce );
 	if ( init.body && ! headers.has( 'Content-Type' ) ) {

--- a/src/my-wordpress/rest.ts
+++ b/src/my-wordpress/rest.ts
@@ -9,6 +9,7 @@
  * @since 0.8.0
  */
 
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import type {
 	EntityDetail,
@@ -47,11 +48,7 @@ export function getEntity( id: string ): MyWordPressEntity | undefined {
 }
 
 function buildUrl( path: string ): string {
-	const cfg = getConfig();
-	const base = cfg.restRoot.endsWith( '/' )
-		? cfg.restRoot
-		: cfg.restRoot + '/';
-	return base + path.replace( /^\/+/, '' );
+	return joinRestUrl( getConfig().restRoot, path );
 }
 
 async function shellFetch(

--- a/src/oauth-relay.ts
+++ b/src/oauth-relay.ts
@@ -23,6 +23,7 @@
  * @since 0.8.2
  */
 
+import { joinRestUrl } from './rest-url';
 import { trackedFetch } from './tracked-fetch';
 
 export interface StartOAuthOptions {
@@ -74,7 +75,7 @@ export function startOAuth(
 	const restNonce = readRestNonce();
 
 	return trackedFetch(
-		restRoot + 'desktop-mode/v1/oauth/start',
+		joinRestUrl( restRoot, 'desktop-mode/v1/oauth/start' ),
 		{
 			method: 'POST',
 			headers: {

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -20,6 +20,7 @@
  */
 
 import { trackedFetch } from '../tracked-fetch';
+import { joinRestUrl } from '../rest-url';
 import type {
 	BrowseFilter,
 	InstalledPlugin,
@@ -266,7 +267,7 @@ async function unpackErrorResponse( response: Response ): Promise< Error > {
  */
 export async function fetchInstalledPlugins(): Promise< InstalledPlugin[] > {
 	const cfg = getConfig();
-	const url = cfg.pluginsUrl + '?context=view&per_page=100';
+	const url = joinRestUrl( cfg.restRoot, 'wp/v2/plugins?context=view&per_page=100' );
 	return restRequest< InstalledPlugin[] >( url, { method: 'GET' } );
 }
 
@@ -290,7 +291,7 @@ async function mutateInstalledPlugin(
 ): Promise< InstalledPlugin > {
 	const cfg = getConfig();
 	return restRequest< InstalledPlugin >(
-		cfg.pluginsUrl + '/' + encodePluginPath( plugin.plugin ),
+		joinRestUrl( cfg.restRoot, `wp/v2/plugins/${ encodePluginPath( plugin.plugin ) }` ),
 		{
 			method: 'PUT',
 			body: JSON.stringify( body ),
@@ -304,7 +305,10 @@ export async function deleteInstalledPlugin(
 ): Promise< void > {
 	const cfg = getConfig();
 	await restRequest< void >(
-		cfg.pluginsUrl + '/' + encodePluginPath( plugin.plugin ) + '?force=true',
+		joinRestUrl(
+			cfg.restRoot,
+			`wp/v2/plugins/${ encodePluginPath( plugin.plugin ) }?force=true`,
+		),
 		{
 			method: 'DELETE',
 			expectJson: false,

--- a/src/posts-window/categories-mindmap.ts
+++ b/src/posts-window/categories-mindmap.ts
@@ -25,6 +25,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import { type PostsWindowClient, type TermRow } from './rest';
 
@@ -2819,7 +2820,7 @@ export async function mountCategoriesMindmap(
 		}
 		const cfg = client.getConfig();
 		const url = new URL(
-			`${ cfg.restRoot.replace( /\/$/, '' ) }/desktop-mode/v1/term-counts`,
+			joinRestUrl( cfg.restRoot, 'desktop-mode/v1/term-counts' ),
 		);
 		url.searchParams.set( 'taxonomy', 'category' );
 		url.searchParams.set(

--- a/src/posts-window/rest.ts
+++ b/src/posts-window/rest.ts
@@ -26,6 +26,7 @@
  * @since 0.8.0
  */
 
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 
 declare global {
@@ -606,7 +607,7 @@ export function createPostsWindowClient(
 		signal?: AbortSignal,
 	): Promise< TagTerm[] > => {
 		const cfg = getConfig();
-		const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags` );
+		const url = new URL( joinRestUrl( cfg.restRoot, 'wp/v2/tags' ) );
 		url.searchParams.set( 'per_page', '20' );
 		url.searchParams.set( '_fields', 'id,name,slug,count' );
 		url.searchParams.set( 'orderby', 'count' );
@@ -625,7 +626,7 @@ export function createPostsWindowClient(
 
 	const createTag = async ( name: string ): Promise< TagTerm > => {
 		const cfg = getConfig();
-		const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags`;
+		const url = joinRestUrl( cfg.restRoot, 'wp/v2/tags' );
 		try {
 			const { data } = await request< TagTerm >( url, {
 				method: 'POST',
@@ -668,9 +669,7 @@ export function createPostsWindowClient(
 		signal?: AbortSignal,
 	): Promise< CategoryTerm[] > => {
 		const cfg = getConfig();
-		const url = new URL(
-			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/categories`,
-		);
+		const url = new URL( joinRestUrl( cfg.restRoot, 'wp/v2/categories' ) );
 		url.searchParams.set( 'per_page', '100' );
 		url.searchParams.set( '_fields', 'id,name,slug,parent' );
 		url.searchParams.set( 'orderby', 'name' );
@@ -686,9 +685,7 @@ export function createPostsWindowClient(
 		signal?: AbortSignal,
 	): Promise< AuthorOption[] > => {
 		const cfg = getConfig();
-		const url = new URL(
-			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/users`,
-		);
+		const url = new URL( joinRestUrl( cfg.restRoot, 'wp/v2/users' ) );
 		url.searchParams.set( 'per_page', '100' );
 		url.searchParams.set( 'who', 'authors' );
 		url.searchParams.set( '_fields', 'id,name' );
@@ -713,7 +710,7 @@ export function createPostsWindowClient(
 		signal?: AbortSignal,
 	): Promise< TagOptionsPage > => {
 		const cfg = getConfig();
-		const url = new URL( `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/tags` );
+		const url = new URL( joinRestUrl( cfg.restRoot, 'wp/v2/tags' ) );
 		url.searchParams.set( 'per_page', String( Math.max( 1, perPage ) ) );
 		url.searchParams.set( 'page', String( Math.max( 1, page ) ) );
 		url.searchParams.set( '_fields', 'id,name,count' );
@@ -740,7 +737,7 @@ export function createPostsWindowClient(
 		opts: { slug?: string; description?: string } = {},
 	): Promise< CategoryTerm > => {
 		const cfg = getConfig();
-		const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/categories`;
+		const url = joinRestUrl( cfg.restRoot, 'wp/v2/categories' );
 		const body: Record< string, unknown > = { name, parent };
 		if ( opts.slug ) {
 			body.slug = opts.slug;
@@ -796,9 +793,7 @@ export function createPostsWindowClient(
 		params: TermsListParams = {},
 	): Promise< TermsListPage > => {
 		const cfg = getConfig();
-		const url = new URL(
-			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }`,
-		);
+		const url = new URL( joinRestUrl( cfg.restRoot, `wp/v2/${ taxonomy }` ) );
 		url.searchParams.set( 'per_page', String( params.perPage ?? 50 ) );
 		url.searchParams.set( 'page', String( params.page ?? 1 ) );
 		url.searchParams.set(
@@ -857,7 +852,7 @@ export function createPostsWindowClient(
 		>,
 	): Promise< TermRow > => {
 		const cfg = getConfig();
-		const url = `${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }/${ id }`;
+		const url = joinRestUrl( cfg.restRoot, `wp/v2/${ taxonomy }/${ id }` );
 		const { data } = await request< Partial< TermRow > >( url, {
 			method: 'POST',
 			body: JSON.stringify( patch ),
@@ -884,7 +879,7 @@ export function createPostsWindowClient(
 	): Promise< void > => {
 		const cfg = getConfig();
 		const url = new URL(
-			`${ cfg.restRoot.replace( /\/$/, '' ) }/wp/v2/${ taxonomy }/${ id }`,
+			joinRestUrl( cfg.restRoot, `wp/v2/${ taxonomy }/${ id }` ),
 		);
 		url.searchParams.set( 'force', 'true' );
 		await request( url.toString(), { method: 'DELETE' } );

--- a/src/posts-window/tags-cloud.ts
+++ b/src/posts-window/tags-cloud.ts
@@ -30,6 +30,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import { type PostsWindowClient, type TermRow } from './rest';
 
@@ -1969,7 +1970,7 @@ export async function mountTagsCloud(
 		}
 		const cfg = client.getConfig();
 		const url = new URL(
-			`${ cfg.restRoot.replace( /\/$/, '' ) }/desktop-mode/v1/term-counts`,
+			joinRestUrl( cfg.restRoot, 'desktop-mode/v1/term-counts' ),
 		);
 		// Server expects the WP internal taxonomy slug (`post_tag`),
 		// not the REST endpoint base (`tags`) — `get_taxonomy()`

--- a/src/posts-window/user-edit-render.ts
+++ b/src/posts-window/user-edit-render.ts
@@ -22,6 +22,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import { applyAvatarSrc } from '../ui/util/avatar-resolve';
 import { type PostsWindowConfig } from './rest';
@@ -1792,9 +1793,9 @@ function buildSessionsRow( userId: number, isSelfEdit: boolean ): HTMLElement {
 			const base =
 				( cfg as unknown as { insightsUrlBase?: string } )
 					.insightsUrlBase ??
-				`${ cfg.restRoot }desktop-mode/v1/users/`;
+				joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/' );
 			const res = await trackedFetch(
-				`${ base }${ userId }/destroy-sessions`,
+				joinRestUrl( base, `${ userId }/destroy-sessions` ),
 				{
 					method: 'POST',
 					credentials: 'same-origin',
@@ -1858,7 +1859,7 @@ function buildAppPasswordsRow( userId: number ): HTMLElement {
 	const cfg = resolveUserEditClient().getConfig();
 	const base =
 		( cfg as unknown as { insightsUrlBase?: string } ).insightsUrlBase ??
-		`${ cfg.restRoot }desktop-mode/v1/users/`;
+		joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/' );
 	const list = document.createElement( 'ul' );
 	list.style.cssText =
 		'list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px;';
@@ -1921,13 +1922,13 @@ function buildAppPasswordsRow( userId: number ): HTMLElement {
 				e.preventDefault();
 				try {
 					const res = await trackedFetch(
-					`${ base }${ userId }/application-passwords/${ item.uuid }`,
-					{
-						method: 'DELETE',
-						credentials: 'same-origin',
-						headers: { 'X-WP-Nonce': cfg.restNonce },
-					},
-					{ source: 'user-edit-window/app-pw-revoke' },
+						joinRestUrl( base, `${ userId }/application-passwords/${ item.uuid }` ),
+						{
+							method: 'DELETE',
+							credentials: 'same-origin',
+							headers: { 'X-WP-Nonce': cfg.restNonce },
+						},
+						{ source: 'user-edit-window/app-pw-revoke' },
 					);
 					if ( ! res.ok ) {
 						throw new Error( `http_${ res.status }` );
@@ -1949,7 +1950,7 @@ function buildAppPasswordsRow( userId: number ): HTMLElement {
 	const refresh = async (): Promise< void > => {
 		try {
 			const res = await trackedFetch(
-				`${ base }${ userId }/application-passwords`,
+				joinRestUrl( base, `${ userId }/application-passwords` ),
 				{
 					credentials: 'same-origin',
 					headers: { 'X-WP-Nonce': cfg.restNonce },
@@ -1976,7 +1977,7 @@ function buildAppPasswordsRow( userId: number ): HTMLElement {
 		}
 		try {
 			const res = await trackedFetch(
-				`${ base }${ userId }/application-passwords`,
+				joinRestUrl( base, `${ userId }/application-passwords` ),
 				{
 					method: 'POST',
 					credentials: 'same-origin',

--- a/src/posts-window/user-edit-rest.ts
+++ b/src/posts-window/user-edit-rest.ts
@@ -9,6 +9,7 @@
  * @since 0.18.0
  */
 
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import type { PostsWindowConfig } from './rest';
 
@@ -167,8 +168,8 @@ export function createUserEditClient(
 		const cfg = getConfig();
 		const base =
 			( cfg as unknown as { usersUrl?: string } ).usersUrl ??
-			`${ cfg.restRoot }wp/v2/users`;
-		const url = `${ base }/${ id }?context=edit`;
+			joinRestUrl( cfg.restRoot, 'wp/v2/users' );
+		const url = joinRestUrl( base, `${ id }?context=edit` );
 		const res = await shellFetch(
 			url,
 			{
@@ -194,9 +195,9 @@ export function createUserEditClient(
 		const cfg = getConfig();
 		const base =
 			( cfg as unknown as { usersUrl?: string } ).usersUrl ??
-			`${ cfg.restRoot }wp/v2/users`;
+			joinRestUrl( cfg.restRoot, 'wp/v2/users' );
 		const res = await shellFetch(
-			`${ base }/${ id }?context=edit`,
+			joinRestUrl( base, `${ id }?context=edit` ),
 			{
 				method: 'POST', // PUT == POST for WP REST when X-HTTP-Method-Override is unsupported.
 				credentials: 'same-origin',
@@ -240,8 +241,8 @@ export function createUserEditClient(
 		const cfg = getConfig();
 		const base =
 			( cfg as unknown as { insightsUrlBase?: string } )
-				.insightsUrlBase ?? `${ cfg.restRoot }desktop-mode/v1/users/`;
-		const url = new URL( `${ base }${ id }/insights` );
+				.insightsUrlBase ?? joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/' );
+		const url = new URL( joinRestUrl( base, `${ id }/insights` ) );
 		if ( opts.fresh ) {
 			url.searchParams.set( 'fresh', '1' );
 		}

--- a/src/posts-window/users-rest.ts
+++ b/src/posts-window/users-rest.ts
@@ -10,6 +10,7 @@
  * @since 0.18.0
  */
 
+import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import type { PostsWindowConfig } from './rest';
 
@@ -276,7 +277,7 @@ export function createUsersWindowClient(
 		const cfg = getConfig();
 		const url =
 			( cfg as unknown as { bulkRoleUrl?: string } ).bulkRoleUrl ??
-			`${ cfg.restRoot }desktop-mode/v1/users/bulk-role`;
+			joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/bulk-role' );
 		const res = await shellFetch(
 			url,
 			{
@@ -304,9 +305,9 @@ export function createUsersWindowClient(
 		const cfg = getConfig();
 		const base =
 			( cfg as unknown as { sendResetUrlBase?: string } )
-				.sendResetUrlBase ?? `${ cfg.restRoot }desktop-mode/v1/users/`;
+				.sendResetUrlBase ?? joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/' );
 		const res = await shellFetch(
-			`${ base }${ id }/send-password-reset`,
+			joinRestUrl( base, `${ id }/send-password-reset` ),
 			{
 				method: 'POST',
 				credentials: 'same-origin',
@@ -335,9 +336,9 @@ export function createUsersWindowClient(
 		const cfg = getConfig();
 		const base =
 			( cfg as unknown as { sendResetUrlBase?: string } )
-				.sendResetUrlBase ?? `${ cfg.restRoot }desktop-mode/v1/users/`;
+				.sendResetUrlBase ?? joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/' );
 		const res = await shellFetch(
-			`${ base }${ id }/resend-welcome`,
+			joinRestUrl( base, `${ id }/resend-welcome` ),
 			{
 				method: 'POST',
 				credentials: 'same-origin',
@@ -368,7 +369,7 @@ export function createUsersWindowClient(
 		const cfg = getConfig();
 		const url =
 			( cfg as unknown as { createUserUrl?: string } ).createUserUrl ??
-			`${ cfg.restRoot }desktop-mode/v1/users`;
+			joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users' );
 		const res = await shellFetch(
 			url,
 			{
@@ -411,7 +412,7 @@ export function createUsersWindowClient(
 		const cfg = getConfig();
 		const url =
 			( cfg as unknown as { bulkDeleteUrl?: string } ).bulkDeleteUrl ??
-			`${ cfg.restRoot }desktop-mode/v1/users/bulk-delete`;
+			joinRestUrl( cfg.restRoot, 'desktop-mode/v1/users/bulk-delete' );
 		const body: Record< string, unknown > = { ids };
 		if ( typeof reassign === 'number' && reassign > 0 ) {
 			body.reassign = reassign;

--- a/src/rest-url.ts
+++ b/src/rest-url.ts
@@ -1,0 +1,60 @@
+/**
+ * Build a WordPress REST URL that works on every permalink structure.
+ *
+ * Why this exists: `rest_url()` server-side returns one of two shapes
+ * depending on the site's Settings -> Permalinks choice:
+ *
+ *   - Pretty (Post name, Day and name, Custom, ...):
+ *       `https://site.example/wp-json/`
+ *   - Plain (the WordPress default on fresh installs):
+ *       `https://site.example/index.php?rest_route=/`
+ *
+ * Naive `restRoot + 'wp/v2/posts?per_page=10'` concatenation works for
+ * the first shape and silently breaks for the second (produces a URL
+ * with two `?` separators; WordPress routes the request to the
+ * homepage and returns HTML, JSON.parse throws). This helper takes a
+ * REST root (either shape) plus a relative REST path and produces a
+ * well-formed URL string that the WP router will accept.
+ *
+ * Path semantics:
+ *   - Leading slashes on `path` are ignored.
+ *   - A `?key=value` query string embedded in `path` is preserved and
+ *     merged into the final URL.
+ *
+ * @since 0.21.0
+ */
+
+const FALLBACK_BASE = 'http://localhost/';
+
+export function joinRestUrl( restRoot: string, path: string ): string {
+	const base =
+		typeof window !== 'undefined' && window.location
+			? window.location.href
+			: FALLBACK_BASE;
+	const url = new URL( restRoot, base );
+
+	const trimmed = path.replace( /^\/+/, '' );
+	const queryAt = trimmed.indexOf( '?' );
+	const route = queryAt === -1 ? trimmed : trimmed.slice( 0, queryAt );
+	const extraQuery = queryAt === -1 ? '' : trimmed.slice( queryAt + 1 );
+
+	if ( url.searchParams.has( 'rest_route' ) ) {
+		const existing = url.searchParams.get( 'rest_route' ) ?? '/';
+		const prefix = existing.endsWith( '/' ) ? existing : existing + '/';
+		url.searchParams.set( 'rest_route', prefix + route );
+	} else {
+		const pathname = url.pathname.endsWith( '/' )
+			? url.pathname
+			: url.pathname + '/';
+		url.pathname = pathname + route;
+	}
+
+	if ( extraQuery ) {
+		const extras = new URLSearchParams( extraQuery );
+		extras.forEach( ( value, key ) => {
+			url.searchParams.append( key, value );
+		} );
+	}
+
+	return url.toString();
+}

--- a/tests/vitest/rest-url.test.ts
+++ b/tests/vitest/rest-url.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Pins the contract for `joinRestUrl`.
+ *
+ * Both permalink shapes must round-trip through the helper without
+ * dropping or doubling query separators.
+ *
+ * @since 0.21.0
+ */
+import { describe, expect, test } from 'vitest';
+import { joinRestUrl } from '../../src/rest-url';
+
+describe( 'joinRestUrl', () => {
+	describe( 'pretty permalinks', () => {
+		const root = 'https://site.example/wp-json/';
+
+		test( 'appends a plain path', () => {
+			expect( joinRestUrl( root, 'wp/v2/posts' ) ).toBe(
+				'https://site.example/wp-json/wp/v2/posts',
+			);
+		} );
+
+		test( 'strips a leading slash on the path', () => {
+			expect( joinRestUrl( root, '/wp/v2/posts' ) ).toBe(
+				'https://site.example/wp-json/wp/v2/posts',
+			);
+		} );
+
+		test( 'preserves a query string on the path', () => {
+			expect(
+				joinRestUrl( root, 'wp/v2/posts?per_page=10&page=2' ),
+			).toBe(
+				'https://site.example/wp-json/wp/v2/posts?per_page=10&page=2',
+			);
+		} );
+
+		test( 'tolerates a missing trailing slash on the root', () => {
+			expect(
+				joinRestUrl( 'https://site.example/wp-json', 'wp/v2/tags' ),
+			).toBe( 'https://site.example/wp-json/wp/v2/tags' );
+		} );
+	} );
+
+	describe( 'plain permalinks', () => {
+		const root = 'https://site.example/index.php?rest_route=/';
+
+		test( 'appends the route to the rest_route query parameter', () => {
+			expect( joinRestUrl( root, 'wp/v2/posts' ) ).toBe(
+				'https://site.example/index.php?rest_route=%2Fwp%2Fv2%2Fposts',
+			);
+		} );
+
+		test( 'strips a leading slash on the path', () => {
+			expect( joinRestUrl( root, '/wp/v2/posts' ) ).toBe(
+				'https://site.example/index.php?rest_route=%2Fwp%2Fv2%2Fposts',
+			);
+		} );
+
+		test( 'merges a path query string with rest_route', () => {
+			const result = joinRestUrl( root, 'wp/v2/posts?per_page=10&page=2' );
+			const url = new URL( result );
+			expect( url.searchParams.get( 'rest_route' ) ).toBe( '/wp/v2/posts' );
+			expect( url.searchParams.get( 'per_page' ) ).toBe( '10' );
+			expect( url.searchParams.get( 'page' ) ).toBe( '2' );
+		} );
+
+		test( 'handles a rest_route prefix without trailing slash', () => {
+			const result = joinRestUrl(
+				'https://site.example/index.php?rest_route=/wp',
+				'v2/users',
+			);
+			expect( new URL( result ).searchParams.get( 'rest_route' ) ).toBe(
+				'/wp/v2/users',
+			);
+		} );
+	} );
+
+	test( 'resolves a same-origin relative root against window.location', () => {
+		const result = joinRestUrl( '/wp-json/', 'wp/v2/posts' );
+		const url = new URL( result );
+		expect( url.pathname ).toBe( '/wp-json/wp/v2/posts' );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes #183. Several REST call sites built URLs by concatenating a path onto the injected `restRoot` (or a sibling `usersUrl` / `insightsUrlBase` / `pluginsUrl` / `baseUrl` key) and assumed the pretty-permalink shape (`/wp-json/...`). On sites configured with Settings -> Permalinks -> **Plain** (the WordPress default for fresh installs), `rest_url()` emits the query-string shape (`?rest_route=/...`); concatenating `?context=edit` or `?per_page=10` onto that produced two `?` separators, and the URL parser collapsed the whole path into the `rest_route` value, dropping the trailing query params and causing 404s.

## What changed

- New `src/rest-url.ts` exports `joinRestUrl(restRoot, path)`, which handles both shapes:
  - **Pretty:** appends the path to the URL pathname.
  - **Plain:** appends the path to the existing `rest_route` query value and merges any query params from the path as separate searchParams.
- Migrated every unsafe call site to use the helper:
  - `src/posts-window/{rest,users-rest,user-edit-rest,user-edit-render,tags-cloud,categories-mindmap}.ts`
  - `src/content-graph/rest.ts`
  - `src/oauth-relay.ts`
  - `src/my-wordpress/rest.ts`
  - `src/desktop-files/preview.ts`
  - `src/desktop-files/rest.ts` (the `call()` helper, so every placements / folders / associations endpoint inherits the fix; the visible symptom on Plain was desktop icons taking several seconds to appear because the files layer 404'd on `/desktop-mode/v1/files/placements?folder=0` and fell back to a slower path).
  - `src/plugins-window/rest.ts` (list / activate / deactivate / delete; visible symptom was the Plugins window showing "Could not load plugins: No route was found matching the URL and request method.").
- 9 new unit tests pinning the helper's behavior on both permalink shapes (route-only, route+query, with/without trailing slashes, etc.).

PHP side already adapted to permalink structure via `rest_url()`, so no PHP changes were needed.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:js` green (1125/1125, +9 new)
- [x] `npm run build` produces all bundles
- [x] Manual on local dev with Settings -> Permalinks -> **Plain**:
  - [x] Posts window paginates, filters by tag / category / author
  - [x] Users window opens, User Edit window loads with `?context=edit`, save round-trips
  - [x] My WordPress window opens and lists entities
  - [x] Content Graph loads user / term / comment stats
  - [x] Desktop icons render immediately on boot (no slow fallback)
  - [x] Plugins window lists installed plugins (no "No route was found" toast)
- [x] Same flows still work on **Post name** permalinks (no regression).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-184-57fadb79b80774997e4870c3354c86f50da9a63b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->