### PR TITLE
Plugins window: real updates, not just a phantom badge

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1953,13 +1953,23 @@ Filter the resolved wp.org icon URL for an installed plugin row. Return `null` t
 apply_filters( 'desktop_mode_plugins_window_icon_url', string|null $url, string $slug, array $row ): string|null
 ```
 
+### `desktop_mode_plugins_window_refresh_updates` — Stable *(filter, since 0.18.0)*
+
+Short-circuit the lazy refresh of the `update_plugins` site transient that runs on the first row of every REST plugins collection. Core only refreshes that transient on `load-plugins.php` / `load-update-core.php` / cron — REST is not on that list — so without this hop the Plugins window can show "no updates" while the dock badge (computed off `$menu`) reports pending updates. The refresh inherits Core's own 12h throttle (`_maybe_update_plugins()`), so the steady-state cost is a single transient read per request.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_refresh_updates', bool $refresh ): bool
+```
+
+Return `false` to skip the refresh — useful for hosts that run their own update orchestration (managed WordPress, internal mirrors) and don't want REST hits to potentially trigger a wp.org HTTPS check.
+
 ### REST-field decorators on `/wp/v2/plugins` — Stable (since 0.9.0)
 
 Server-injected enrichment fields. The JS reads them on every list paint:
 
 | Field | Shape | What it carries |
 |---|---|---|
-| `desktop_mode_update_available` | `{ available: bool, new_version: string\|null }` | Pending wp.org update for this row, derived from `get_site_transient( 'update_plugins' )`. |
+| `desktop_mode_update_available` | `{ available: bool, new_version: string\|null, package: string, slug: string }` | Pending wp.org update for this row, derived from `get_site_transient( 'update_plugins' )`. Since 0.18.0 the transient is lazily refreshed at REST-time (subject to Core's 12h throttle, and the `desktop_mode_plugins_window_refresh_updates` filter) so the window stays in sync with the dock update badge. `package` carries the download URL (empty for plugins without a wp.org zip — the JS surfaces the same "Auto-update unavailable" fallback Core renders); `slug` is what `wp_ajax_update_plugin` echoes back in its event payload. |
 | `desktop_mode_can_manage` | `{ activate, deactivate, delete: bool }` | Per-row capability flags so the JS doesn't re-derive caps. Server still re-validates every mutation. |
 | `desktop_mode_icon_url` | `string\|null` | Best-effort wp.org icon URL derived from the plugin's `textdomain`. Filterable via `desktop_mode_plugins_window_icon_url`. |
 | `desktop_mode_size_kb` | `int\|null` | Disk footprint of the plugin folder in kilobytes. Cached 6h. |

--- a/includes/plugins-window/permissions.php
+++ b/includes/plugins-window/permissions.php
@@ -96,7 +96,7 @@ function desktop_mode_plugins_window_user_can_use( $user_id = null ) {
  * @since 0.9.0
  *
  * @param int|null $user_id Optional.
- * @return array{install:bool,delete:bool,upload:bool,activate:bool}
+ * @return array{install:bool,delete:bool,upload:bool,activate:bool,update:bool}
  */
 function desktop_mode_plugins_window_caps( $user_id = null ) {
 	$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
@@ -106,5 +106,11 @@ function desktop_mode_plugins_window_caps( $user_id = null ) {
 		'install'  => $user_id > 0 && user_can( $user_id, 'install_plugins' ),
 		'delete'   => $user_id > 0 && user_can( $user_id, 'delete_plugins' ),
 		'upload'   => $user_id > 0 && user_can( $user_id, 'upload_plugins' ),
+		// Mirrors Core's `current_user_can( 'update_plugins' )` gate on
+		// the inline "Update now" link in `wp_plugin_update_row()` — the
+		// JS uses it to hide the Update action for editors / non-admin
+		// roles even when `desktop_mode_update_available.available` is
+		// true. Server-side, `wp_ajax_update_plugin` re-checks the cap.
+		'update'   => $user_id > 0 && user_can( $user_id, 'update_plugins' ),
 	);
 }

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -87,20 +87,124 @@ function desktop_mode_plugins_window_register_rest_fields() {
 add_action( 'rest_api_init', 'desktop_mode_plugins_window_register_rest_fields' );
 
 /**
+ * Resolve the plugin file path (relative to `WP_PLUGIN_DIR`, ending in
+ * `.php`) for a Core REST plugin row.
+ *
+ * Core's `WP_REST_Plugins_Controller::prepare_item_for_response` emits
+ * the `plugin` field with the trailing `.php` STRIPPED — e.g.
+ * `"elementor/elementor"` rather than `"elementor/elementor.php"`. But
+ * every internal WordPress data structure that keys off the plugin
+ * file — `update_plugins` site transient, `active_plugins` option,
+ * `plugin_basename()`, `WP_PLUGIN_DIR` paths — uses the full filename.
+ * Mixing the two yields silent lookup misses (the symptom that hid
+ * the "Update available" tab).
+ *
+ * This helper re-appends `.php` when missing so callers can use the
+ * result as a transient/option key or filesystem path directly.
+ *
+ * @since 0.18.0
+ *
+ * @param array $row Core REST plugin row.
+ * @return string Plugin file (e.g. `"elementor/elementor.php"`), or `''`
+ *                when the row has no `plugin` field.
+ */
+function desktop_mode_plugins_window_row_plugin_file( $row ) {
+	$file = isset( $row['plugin'] ) ? (string) $row['plugin'] : '';
+	if ( '' === $file ) {
+		return '';
+	}
+	if ( '.php' !== substr( $file, -4 ) ) {
+		$file .= '.php';
+	}
+	return $file;
+}
+
+/**
+ * Lazily prime the `update_plugins` site transient so REST callers see
+ * the same "updates available" picture as the classic Plugins screen.
+ *
+ * Core only refreshes the transient on `load-plugins.php`,
+ * `load-update-core.php`, and the twice-daily cron — REST is not on
+ * that list, so a fresh page load of the desktop Plugins window can
+ * see an empty/stale transient even when the dock badge (computed
+ * off `$menu`, which Core builds against `wp_get_update_data()`)
+ * reports pending updates. We mirror Core's own throttle
+ * (`wp-admin/includes/update.php::_maybe_update_plugins()` — 12h since
+ * last check) so a hot REST hit is a transient read, not an HTTPS
+ * round-trip to api.wordpress.org.
+ *
+ * Idempotent on its own (Core's 12h throttle); callers that hit this
+ * many times per request should additionally guard with their own
+ * static so they don't pay the transient-read overhead per row.
+ *
+ * @since 0.18.0
+ */
+function desktop_mode_plugins_window_maybe_refresh_update_transient() {
+	/**
+	 * Short-circuit the lazy refresh of the `update_plugins` transient.
+	 *
+	 * Return `false` to skip the refresh — useful for hosts that run
+	 * their own update orchestration (managed WordPress, internal
+	 * mirrors) and don't want every REST hit to the plugins endpoint
+	 * to potentially trigger a wp.org check.
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param bool $refresh Whether to call `wp_update_plugins()`
+	 *                     when the transient is older than 12h.
+	 */
+	if ( ! apply_filters( 'desktop_mode_plugins_window_refresh_updates', true ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'wp_update_plugins' ) ) {
+		// `wp-includes/update.php` is normally autoloaded on every
+		// request; guard anyway so an unusual bootstrap (mu-plugin
+		// CLI harness, stripped-down REST runtime) doesn't fatal.
+		return;
+	}
+
+	$current = get_site_transient( 'update_plugins' );
+	if (
+		is_object( $current ) &&
+		isset( $current->last_checked ) &&
+		12 * HOUR_IN_SECONDS > ( time() - (int) $current->last_checked )
+	) {
+		// Inside Core's standard refresh window — trust the cached
+		// snapshot, identical to `_maybe_update_plugins()`'s posture.
+		return;
+	}
+
+	wp_update_plugins();
+}
+
+/**
  * `desktop_mode_update_available` callback.
  *
  * @since 0.9.0
  *
  * @param array $row Core REST plugin row.
- * @return array{available:bool,new_version:string|null}
+ * @return array{available:bool,new_version:string|null,package:string,slug:string}
  */
 function desktop_mode_plugins_window_field_update_available( $row ) {
-	$plugin_file = isset( $row['plugin'] ) ? (string) $row['plugin'] : '';
+	$plugin_file = desktop_mode_plugins_window_row_plugin_file( $row );
 	if ( '' === $plugin_file ) {
 		return array(
 			'available'   => false,
 			'new_version' => null,
+			'package'     => '',
+			'slug'        => '',
 		);
+	}
+
+	// Prime the transient once per request before reading it —
+	// otherwise REST callers see a stale/empty snapshot relative to
+	// the classic Plugins screen and the dock update badge. Static
+	// guard keeps the transient read off the hot per-row path.
+	static $primed = false;
+	if ( ! $primed ) {
+		$primed = true;
+		desktop_mode_plugins_window_maybe_refresh_update_transient();
 	}
 
 	// `update_plugins` is the canonical site-wide cache of pending
@@ -111,6 +215,8 @@ function desktop_mode_plugins_window_field_update_available( $row ) {
 		return array(
 			'available'   => false,
 			'new_version' => null,
+			'package'     => '',
+			'slug'        => '',
 		);
 	}
 
@@ -118,6 +224,8 @@ function desktop_mode_plugins_window_field_update_available( $row ) {
 		return array(
 			'available'   => false,
 			'new_version' => null,
+			'package'     => '',
+			'slug'        => '',
 		);
 	}
 
@@ -125,10 +233,29 @@ function desktop_mode_plugins_window_field_update_available( $row ) {
 	$ver   = is_object( $entry ) && isset( $entry->new_version )
 		? (string) $entry->new_version
 		: null;
+	// `package` is the download URL Core's upgrader hits to fetch the
+	// new .zip. Empty for plugins that don't ship a wp.org package
+	// (premium / private hosts) — Core renders an "Automatic update is
+	// unavailable for this plugin" notice in that case rather than the
+	// "Update now" link. We surface the URL so JS can apply the same
+	// gating without needing a second round-trip.
+	$package = is_object( $entry ) && ! empty( $entry->package )
+		? (string) $entry->package
+		: '';
+	// `slug` is what Core's `wp_ajax_update_plugin` echoes back in its
+	// success / error envelope. We forward what the transient already
+	// carries; the AJAX handler doesn't require it on the request
+	// side (it derives slug from `plugin`), but having it client-side
+	// keeps event payloads symmetric with Core's own.
+	$slug = is_object( $entry ) && ! empty( $entry->slug )
+		? (string) $entry->slug
+		: '';
 
 	return array(
 		'available'   => true,
 		'new_version' => $ver,
+		'package'     => $package,
+		'slug'        => $slug,
 	);
 }
 
@@ -222,7 +349,7 @@ function desktop_mode_plugins_window_field_icon_url( $row ) {
  * @return int|null Size in kilobytes, or null on failure.
  */
 function desktop_mode_plugins_window_field_size_kb( $row ) {
-	$plugin_file = isset( $row['plugin'] ) ? (string) $row['plugin'] : '';
+	$plugin_file = desktop_mode_plugins_window_row_plugin_file( $row );
 	if ( '' === $plugin_file ) {
 		return null;
 	}

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -16,9 +16,11 @@
 
 import { __, sprintf } from '../i18n';
 import { broadcast, subscribe } from '../broadcast';
+import { enqueueUpdateJob } from './update-queue';
 import {
 	activateInstalledPlugin,
 	deactivateInstalledPlugin,
+	updateInstalledPlugin,
 	deleteInstalledPlugin,
 	fetchInstalledPlugins,
 	getConfig,
@@ -43,7 +45,7 @@ const SOURCE = 'installed-view';
 interface PluginsChangedPayload {
 	source: string;
 	plugin?: string;
-	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'bulk';
+	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'update' | 'bulk';
 }
 import type { InstalledPlugin } from './types';
 import type {
@@ -88,6 +90,13 @@ interface InstalledViewState {
 	search: string;
 	/** Loading flag for the table skeleton. */
 	loading: boolean;
+	/**
+	 * Set of plugin files currently in the update queue (enqueued or
+	 * in-flight). Mirrors Core's `is-enqueued` row class — used to
+	 * disable the Update button so a user can't double-fire while
+	 * the queue is still draining.
+	 */
+	updating: Set< string >;
 }
 
 /**
@@ -102,6 +111,7 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		statusFilter: '',
 		search: '',
 		loading: true,
+		updating: new Set< string >(),
 	};
 
 	// ─── Toolbar ────────────────────────────────────────────────────
@@ -118,10 +128,31 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		{ value: 'inactive', label: __( 'Inactive', 'desktop-mode' ) },
 		{ value: 'update', label: __( 'Update available', 'desktop-mode' ) },
 	];
+	// Track the Update-available segment + its count badge so we can
+	// repaint just the badge when rows change, without rebuilding the
+	// whole segmented control (which would lose focus / selection).
+	let updateCountBadge: HTMLElement | null = null;
 	for ( const opt of statusOptions ) {
 		const seg = document.createElement( 'wpd-segment' );
 		seg.setAttribute( 'value', opt.value );
-		seg.textContent = opt.label;
+		if ( opt.value === 'update' ) {
+			// Compose a labeled wrapper + a `<wpd-badge>` count chip.
+			// `<wpd-segment>` slots its children into the light DOM, so
+			// arbitrary HTML inside is fine — same posture other
+			// segmented controls in the codebase use.
+			const label = document.createElement( 'span' );
+			label.textContent = opt.label;
+			seg.appendChild( label );
+			const badge = document.createElement( 'wpd-badge' );
+			badge.setAttribute( 'tone', 'warning' );
+			badge.setAttribute( 'no-dot', '' );
+			badge.style.cssText = 'margin-inline-start:6px;';
+			badge.hidden = true; // shown only when count > 0
+			seg.appendChild( badge );
+			updateCountBadge = badge;
+		} else {
+			seg.textContent = opt.label;
+		}
 		statusFilter.appendChild( seg );
 	}
 	statusFilter.addEventListener( 'wpd-pick', ( ev: Event ) => {
@@ -391,6 +422,45 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			delete: row.status === 'inactive',
 		};
 
+		// Update action — mirrors Core's `wp_plugin_update_row()` inline
+		// "Update now" link. Gated by the global `update_plugins` cap
+		// (Core's same check) and the presence of a `package` URL on the
+		// transient entry; when `available && ! package` we surface the
+		// disabled "Auto-update unavailable" hint Core renders.
+		const update = row.desktop_mode_update_available;
+		if ( getConfig().caps.update && update?.available ) {
+			if ( update.package ) {
+				const updating = state.updating.has( row.plugin );
+				const label = updating
+					? __( 'Updating…', 'desktop-mode' )
+					: sprintf(
+						/* translators: %s: new plugin version (e.g. "1.4.2") */
+						__( 'Update to %s', 'desktop-mode' ),
+						update.new_version ?? '',
+					);
+				const btn = button( label, 'primary' );
+				if ( updating ) {
+					btn.setAttribute( 'disabled', '' );
+					btn.setAttribute( 'aria-busy', 'true' );
+				}
+				btn.addEventListener( 'click', ( e ) => {
+					e.stopPropagation();
+					void runUpdate( row );
+				} );
+				wrap.appendChild( btn );
+			} else {
+				const hint = document.createElement( 'span' );
+				hint.style.cssText =
+					'font-size:0.78em;color:var(--wp-desktop-text-muted,#666);';
+				hint.textContent = __( 'Auto-update unavailable', 'desktop-mode' );
+				hint.title = __(
+					'This plugin does not ship a wp.org download package. Update it manually from its source.',
+					'desktop-mode',
+				);
+				wrap.appendChild( hint );
+			}
+		}
+
 		if ( can.activate ) {
 			const btn = button( __( 'Activate', 'desktop-mode' ), 'primary' );
 			btn.addEventListener( 'click', ( e ) => {
@@ -446,6 +516,28 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 
 		const cfg = getConfig();
 		const selected = state.rows.filter( ( r ) => ids.includes( r.plugin ) );
+
+		if ( cfg.caps.update ) {
+			const updatable = selected.filter(
+				( r ) =>
+					!! r.desktop_mode_update_available?.available &&
+					!! r.desktop_mode_update_available.package,
+			);
+			if ( updatable.length > 0 ) {
+				const btn = button(
+					sprintf(
+						/* translators: %d: number of plugins with pending updates */
+						__( 'Update %d', 'desktop-mode' ),
+						updatable.length,
+					),
+					'primary',
+				);
+				btn.addEventListener( 'click', () => {
+					void runBulk( updatable, 'update' );
+				} );
+				bulkBar.appendChild( btn );
+			}
+		}
 
 		if ( cfg.caps.activate ) {
 			const activatable = selected.filter( ( r ) => r.status === 'inactive' );
@@ -507,6 +599,29 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			table.removeAttribute( 'loading' );
 		}
 		table.data = filterRows( state.rows );
+		paintUpdateCount();
+	}
+
+	/**
+	 * Refresh the "Update available" segment's count badge to reflect
+	 * how many rows in `state.rows` (the full list, NOT the current
+	 * filtered view) currently have a pending update. Hidden when the
+	 * count is zero so the segment falls back to a plain text label.
+	 */
+	function paintUpdateCount(): void {
+		if ( ! updateCountBadge ) {
+			return;
+		}
+		const count = state.rows.filter(
+			( r ) => !! r.desktop_mode_update_available?.available,
+		).length;
+		if ( count > 0 ) {
+			updateCountBadge.textContent = String( count );
+			updateCountBadge.hidden = false;
+		} else {
+			updateCountBadge.hidden = true;
+			updateCountBadge.textContent = '';
+		}
 	}
 
 	function filterRows( rows: InstalledPlugin[] ): InstalledPlugin[] {
@@ -678,9 +793,66 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		}
 	}
 
+	/**
+	 * Update a single plugin via Core's `wp_ajax_update_plugin`
+	 * handler, serialized through the single-flight queue. The queue
+	 * is critical — concurrent runs corrupt the `update_plugins`
+	 * transient (see comment in Core's ajax handler). Marks the row
+	 * "updating" up-front so the button paints disabled while waiting.
+	 */
+	async function runUpdate( row: InstalledPlugin ): Promise< void > {
+		if ( state.updating.has( row.plugin ) ) {
+			return; // already enqueued / in flight
+		}
+		state.updating.add( row.plugin );
+		paintTable();
+		try {
+			const result = await enqueueUpdateJob( () => updateInstalledPlugin( row ) );
+			// Drop the pending-update marker and bump the version
+			// on the row so the table repaints without a refetch.
+			mergeRow( {
+				...row,
+				version: result.newVersion,
+				desktop_mode_update_available: {
+					available: false,
+					new_version: null,
+					package: '',
+					slug: row.desktop_mode_update_available?.slug ?? '',
+				},
+			} as InstalledPlugin );
+			toast(
+				sprintf(
+					/* translators: 1: plugin name, 2: new version */
+					__( '%1$s updated to %2$s.', 'desktop-mode' ),
+					row.name || row.plugin,
+					result.newVersion,
+				),
+			);
+			broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+				source: SOURCE,
+				plugin: row.plugin,
+				action: 'update',
+			} );
+			void refreshFrameworkMenu();
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: 1: plugin name, 2: error message */
+					__( 'Update of %1$s failed: %2$s', 'desktop-mode' ),
+					row.name || row.plugin,
+					describe( err ),
+				),
+				6000,
+			);
+		} finally {
+			state.updating.delete( row.plugin );
+			paintTable();
+		}
+	}
+
 	async function runBulk(
 		rows: InstalledPlugin[],
-		action: 'activate' | 'deactivate' | 'delete',
+		action: 'activate' | 'deactivate' | 'delete' | 'update',
 	): Promise< void > {
 		if ( rows.length === 0 ) {
 			return;
@@ -715,6 +887,30 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 				} else if ( action === 'delete' ) {
 					await deleteInstalledPlugin( row );
 					state.rows = state.rows.filter( ( r ) => r.plugin !== row.plugin );
+				} else if ( action === 'update' ) {
+					// Route through the single-flight queue so all
+					// rows fan in serially (mirrors Core's behavior;
+					// concurrent `Plugin_Upgrader` runs corrupt the
+					// transient).
+					state.updating.add( row.plugin );
+					paintTable();
+					try {
+						const result = await enqueueUpdateJob( () =>
+							updateInstalledPlugin( row ),
+						);
+						mergeRow( {
+							...row,
+							version: result.newVersion,
+							desktop_mode_update_available: {
+								available: false,
+								new_version: null,
+								package: '',
+								slug: row.desktop_mode_update_available?.slug ?? '',
+							},
+						} as InstalledPlugin );
+					} finally {
+						state.updating.delete( row.plugin );
+					}
 				}
 				if (
 					( action === 'deactivate' || action === 'delete' ) &&
@@ -753,6 +949,8 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			noun = __( 'deleted', 'desktop-mode' );
 		} else if ( action === 'activate' ) {
 			noun = __( 'activated', 'desktop-mode' );
+		} else if ( action === 'update' ) {
+			noun = __( 'updated', 'desktop-mode' );
 		} else {
 			noun = __( 'deactivated', 'desktop-mode' );
 		}

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -53,6 +53,12 @@ export interface PluginsWindowConfig {
 		install: boolean;
 		delete: boolean;
 		upload: boolean;
+		/**
+		 * `current_user_can( 'update_plugins' )`. Mirrors Core's gate on
+		 * the inline "Update now" link — when false the JS hides the
+		 * Update action even for rows with a pending update.
+		 */
+		update: boolean;
 	};
 	currentUserId: number;
 	introSeen: boolean;
@@ -324,6 +330,72 @@ export async function deleteInstalledPlugin(
  */
 function encodePluginPath( plugin: string ): string {
 	return plugin.split( '/' ).map( encodeURIComponent ).join( '/' );
+}
+
+/**
+ * Update success envelope as returned by Core's `wp_ajax_update_plugin`
+ * (see `wp-admin/includes/ajax-actions.php::wp_ajax_update_plugin`).
+ * The handler `wp_send_json_success( $status )` payload is forwarded
+ * verbatim — the version fields are pre-prefixed with "Version ", so
+ * we expose the raw values here and let the caller format.
+ */
+export interface UpdatePluginResult {
+	update: 'plugin';
+	slug: string;
+	oldVersion: string;
+	newVersion: string;
+	plugin: string;
+	pluginName: string;
+	debug?: string[];
+}
+
+/**
+ * Trigger Core's `wp_ajax_update_plugin` handler — the exact same
+ * endpoint the classic Plugins screen's "Update now" link hits via
+ * `wp.updates.updatePlugin()`. We reuse it verbatim rather than
+ * reimplementing `Plugin_Upgrader` (which lives in admin-only
+ * includes and would tank Plugin Check).
+ *
+ * The handler validates `current_user_can( 'update_plugins' )`, calls
+ * `wp_update_plugins()` to refresh the transient, and runs the
+ * upgrader. On success returns `{ update, slug, oldVersion, newVersion,
+ * plugin, pluginName }`; on failure throws with the server's
+ * `errorMessage` and an `errorCode` attached.
+ *
+ * Note: the underlying upgrader holds a transient-level lock, so
+ * concurrent runs can clobber each other's `update_plugins` transient
+ * (see Core's comment in `wp_ajax_update_plugin`). Callers MUST route
+ * through `enqueueUpdateJob` to serialize.
+ *
+ * @public
+ * @since 0.18.0
+ */
+export async function updateInstalledPlugin(
+	plugin: InstalledPlugin,
+): Promise< UpdatePluginResult > {
+	// Core's `update-plugin` handler keys into the `update_plugins`
+	// transient with the FULL filename (`foo/foo.php`), but Core's REST
+	// controller strips the `.php` extension when populating the
+	// `plugin` field — so the value we received from `/wp/v2/plugins`
+	// is one `.php` short of what the upgrader needs. Re-append before
+	// firing, otherwise `Plugin_Upgrader::bulk_upgrade()` falls through
+	// to the "already at latest version" branch (the transient lookup
+	// misses on the stripped key). Mirrors the same fix we apply
+	// server-side in `desktop_mode_plugins_window_row_plugin_file()`.
+	const pluginFile = plugin.plugin.endsWith( '.php' )
+		? plugin.plugin
+		: plugin.plugin + '.php';
+	return ajaxRequest< UpdatePluginResult >(
+		'update-plugin',
+		{
+			plugin: pluginFile,
+			slug:
+				plugin.desktop_mode_update_available?.slug ||
+				plugin.textdomain ||
+				plugin.plugin.split( '/' )[ 0 ],
+		},
+		{ nonceField: '_ajax_nonce', nonceValue: getConfig().updatesNonce },
+	);
 }
 
 // ─── Browse / Info / Reviews (admin-ajax) ─────────────────────────────

--- a/src/plugins-window/types.ts
+++ b/src/plugins-window/types.ts
@@ -45,12 +45,26 @@ export interface InstalledPlugin {
 	// ─── REST-field decorators added in `includes/plugins-window/rest-fields.php` ───
 
 	/**
-	 * `{ available, new_version }` — true if a wp.org update is
-	 * pending. Read from the `update_plugins` site transient.
+	 * Pending wp.org update for this row, derived from the
+	 * `update_plugins` site transient.
+	 *
+	 * - `available` — there's a newer version in the transient.
+	 * - `new_version` — the version the upgrader would install.
+	 * - `package` — download URL for the new .zip. Empty when the
+	 *               plugin doesn't ship a wp.org package (premium /
+	 *               private hosts); JS uses this the same way Core's
+	 *               `wp_plugin_update_row()` does — present means
+	 *               "Update now" link, empty means "Automatic update
+	 *               is unavailable for this plugin" copy.
+	 * - `slug` — the wp.org slug as the transient carries it. Mostly
+	 *            informational; the `update-plugin` AJAX action derives
+	 *            the slug from `plugin` itself.
 	 */
 	desktop_mode_update_available?: {
 		available: boolean;
 		new_version: string | null;
+		package: string;
+		slug: string;
 	};
 	/**
 	 * Per-row capability flags so the JS doesn't re-derive caps. The

--- a/src/plugins-window/update-queue.ts
+++ b/src/plugins-window/update-queue.ts
@@ -1,0 +1,80 @@
+/**
+ * Native Plugins window — single-flight update queue.
+ *
+ * Mirrors Core's `wp.updates.ajaxLocked` + `wp.updates.queue` semantics
+ * (see `wp-admin/js/updates.js`): plugin updates MUST run one at a
+ * time. The `update_plugins` site transient is a single mutable
+ * snapshot — `Plugin_Upgrader` writes to it on completion, so two
+ * concurrent updates can interleave and corrupt each other's view of
+ * pending updates. Core enforces this with a global lock and a FIFO
+ * queue; we do the same, scoped to this window.
+ *
+ * Exposed as a thin Promise wrapper: callers just `await
+ * enqueueUpdateJob( () => updateInstalledPlugin( row ) )` and get the
+ * result. Cancellation is intentionally NOT supported — once an
+ * update is in flight the upgrader is past the point of safe abort.
+ *
+ * @public
+ * @since 0.18.0
+ */
+
+interface Job< T > {
+	run: () => Promise< T >;
+	resolve: ( value: T ) => void;
+	reject: ( error: unknown ) => void;
+}
+
+const queue: Array< Job< unknown > > = [];
+let inFlight = false;
+
+/**
+ * Enqueue a plugin-update job. The returned Promise resolves /
+ * rejects with the result of `run()` once every job ahead of it
+ * has settled. Errors are isolated — one failed update does not
+ * cancel queued jobs (matches Core's behavior; failed updates leave
+ * a `notice-error` on the row and the queue drains the rest).
+ */
+export function enqueueUpdateJob< T >( run: () => Promise< T > ): Promise< T > {
+	return new Promise< T >( ( resolve, reject ) => {
+		queue.push( {
+			run: run as () => Promise< unknown >,
+			resolve: resolve as ( v: unknown ) => void,
+			reject,
+		} );
+		void drain();
+	} );
+}
+
+/** Number of jobs waiting (excludes the one currently running). */
+export function pendingUpdateJobs(): number {
+	return queue.length;
+}
+
+/** True while a job is mid-flight. */
+export function isUpdateInFlight(): boolean {
+	return inFlight;
+}
+
+async function drain(): Promise< void > {
+	if ( inFlight ) {
+		return;
+	}
+	const job = queue.shift();
+	if ( ! job ) {
+		return;
+	}
+	inFlight = true;
+	try {
+		const value = await job.run();
+		job.resolve( value );
+	} catch ( err ) {
+		job.reject( err );
+	} finally {
+		inFlight = false;
+		// Yield to the microtask queue so the resolver's
+		// `.then` handlers run before the next job begins —
+		// keeps the "row finishes, next row spinner appears"
+		// transition crisp in the UI.
+		void Promise.resolve().then( drain );
+	}
+}

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -256,15 +256,161 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 	 */
 	public function test_update_available_field_reports_false_when_no_update() {
 		// Force a clean state — the test bootstrap may have populated
-		// the transient with whatever the install last fetched.
+		// the transient with whatever the install last fetched. Stamp
+		// `last_checked` to now so the lazy refresh helper short-
+		// circuits (we don't want a wp.org HTTP call from the test
+		// suite).
 		set_site_transient(
 			'update_plugins',
-			(object) array( 'response' => array() )
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+			)
 		);
 		$row = array( 'plugin' => 'never/installed.php' );
 		$out = desktop_mode_plugins_window_field_update_available( $row );
 		$this->assertFalse( $out['available'] );
 		$this->assertNull( $out['new_version'] );
+	}
+
+	/**
+	 * Regression: when the `update_plugins` transient HAS an entry
+	 * for the row, the decorator must report `available: true` plus
+	 * the available version — this is what feeds the "Update
+	 * available" filter and the inline Update action.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_update_available
+	 */
+	public function test_update_available_field_reports_true_when_transient_has_entry() {
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(
+					// Transients key plugin files by their FULL path
+					// including the `.php` extension.
+					'hello-dolly/hello.php' => (object) array(
+						'new_version' => '99.0.0',
+						'package'     => 'https://downloads.wordpress.org/plugin/hello-dolly.99.0.0.zip',
+						'slug'        => 'hello-dolly',
+					),
+				),
+			)
+		);
+		// Core's REST controller strips the `.php` extension from the
+		// `plugin` field — this row mirrors what we actually receive.
+		// Asserting on this shape guards against future regressions of
+		// the "transient lookup misses because of the `.php` strip" bug.
+		$row = array( 'plugin' => 'hello-dolly/hello' );
+		$out = desktop_mode_plugins_window_field_update_available( $row );
+		$this->assertTrue( $out['available'] );
+		$this->assertSame( '99.0.0', $out['new_version'] );
+		$this->assertSame(
+			'https://downloads.wordpress.org/plugin/hello-dolly.99.0.0.zip',
+			$out['package'],
+			'`package` is the download URL the JS gates the Update button on.'
+		);
+		$this->assertSame( 'hello-dolly', $out['slug'] );
+	}
+
+	/**
+	 * Plugins without a `package` URL (premium / private hosts) should
+	 * still be flagged `available: true`, but the empty `package`
+	 * signals to the JS to surface the "Auto-update unavailable" hint
+	 * rather than the "Update now" button — mirrors Core's own
+	 * fallback in `wp_plugin_update_row()`.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_update_available
+	 */
+	public function test_update_available_field_handles_missing_package() {
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(
+					'premium/premium.php' => (object) array(
+						'new_version' => '2.0',
+						// no `package` — premium plugin without a wp.org zip.
+					),
+				),
+			)
+		);
+		$row = array( 'plugin' => 'premium/premium' );
+		$out = desktop_mode_plugins_window_field_update_available( $row );
+		$this->assertTrue( $out['available'] );
+		$this->assertSame( '2.0', $out['new_version'] );
+		$this->assertSame( '', $out['package'] );
+	}
+
+	/**
+	 * The Plugins-window caps surface must expose the `update_plugins`
+	 * cap so the JS can hide / show the Update action without
+	 * re-deriving caps client-side. Server still re-validates every
+	 * update through `wp_ajax_update_plugin`.
+	 *
+	 * @covers ::desktop_mode_plugins_window_caps
+	 */
+	public function test_caps_surface_includes_update_for_admins() {
+		wp_set_current_user( $this->admin_id );
+		$caps = desktop_mode_plugins_window_caps();
+		$this->assertArrayHasKey( 'update', $caps );
+		$this->assertTrue( $caps['update'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_caps
+	 */
+	public function test_caps_surface_denies_update_for_editor() {
+		wp_set_current_user( $this->editor_id );
+		$caps = desktop_mode_plugins_window_caps();
+		$this->assertFalse( $caps['update'] );
+	}
+
+	/**
+	 * The lazy refresh helper must respect Core's 12h throttle: when
+	 * the transient was checked under 12h ago, it must NOT clobber
+	 * the cached snapshot (otherwise every REST hit could chain a
+	 * wp.org HTTPS round-trip).
+	 *
+	 * @covers ::desktop_mode_plugins_window_maybe_refresh_update_transient
+	 */
+	public function test_maybe_refresh_respects_12h_throttle() {
+		$snapshot = (object) array(
+			'last_checked' => time() - 60, // 1 minute ago.
+			'response'     => array( 'foo/foo.php' => (object) array( 'new_version' => '2.0' ) ),
+		);
+		set_site_transient( 'update_plugins', $snapshot );
+
+		desktop_mode_plugins_window_maybe_refresh_update_transient();
+
+		$after = get_site_transient( 'update_plugins' );
+		$this->assertEquals( $snapshot, $after, 'Fresh transient should not be refreshed.' );
+	}
+
+	/**
+	 * The `desktop_mode_plugins_window_refresh_updates` filter must
+	 * be able to opt a site out of the lazy refresh entirely — even
+	 * when the cached snapshot is well over 12h old.
+	 *
+	 * @covers ::desktop_mode_plugins_window_maybe_refresh_update_transient
+	 */
+	public function test_maybe_refresh_filter_can_opt_out() {
+		$snapshot = (object) array(
+			'last_checked' => time() - DAY_IN_SECONDS, // way past 12h.
+			'response'     => array(),
+		);
+		set_site_transient( 'update_plugins', $snapshot );
+
+		add_filter( 'desktop_mode_plugins_window_refresh_updates', '__return_false' );
+		desktop_mode_plugins_window_maybe_refresh_update_transient();
+		remove_filter( 'desktop_mode_plugins_window_refresh_updates', '__return_false' );
+
+		$after = get_site_transient( 'update_plugins' );
+		$this->assertEquals(
+			$snapshot,
+			$after,
+			'Filter returning false should skip the refresh and leave the stale snapshot untouched.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes the "Update available" tab showing zero plugins while the dock badge reported pending updates, and adds the per-row + bulk "Update now" UX Core has on `wp-admin/plugins.php`.


https://github.com/user-attachments/assets/6fa8b3c4-8005-41cd-84a6-2b9cac41fc79


## Bugs fixed

### 1. Stale `update_plugins` transient on REST requests
Core only refreshes `update_plugins` on `load-plugins.php` / `load-update-core.php` / cron. REST is not on that list, so a freshly loaded Plugins window saw an empty/stale snapshot while the dock badge (which is rebuilt off `$menu` during the desktop-shell page load) reported real numbers.

**Fix:** `desktop_mode_plugins_window_maybe_refresh_update_transient()` — lazy refresh on the first row of every REST plugins collection, inheriting Core's own 12h throttle (`_maybe_update_plugins()` posture). Guarded by a static so it runs once per request, and by a new `desktop_mode_plugins_window_refresh_updates` filter for hosts that orchestrate updates themselves.

### 2. `.php`-strip mismatch (the real culprit)
Core's `WP_REST_Plugins_Controller` emits the `plugin` field with the `.php` stripped (`elementor/elementor`), but every internal WP data structure — the `update_plugins` transient, `Plugin_Upgrader::bulk_upgrade()`, `wp_ajax_update_plugin` — keys by the full filename (`elementor/elementor.php`). The REST field callback was looking up the stripped key against a fully-keyed transient → miss on every row → all rows reported `available: false`.

**Fix:** `desktop_mode_plugins_window_row_plugin_file()` re-appends `.php` when missing. Routed `desktop_mode_update_available` and `desktop_mode_size_kb` through it (the size callback had the same latent bug for single-file plugins like Hello Dolly). Mirrored on the JS side in `updateInstalledPlugin()` so `wp_ajax_update_plugin` receives the form it actually keys against (otherwise the upgrader fell through to "Plugin is at the latest version").

## Update-now UX (matches `wp-admin/plugins.php`)

- **Per-row Update button** — primary `Update to X.Y.Z` button in the actions cell when the user has `update_plugins` AND the transient entry ships a `package` URL. When `available && ! package` (premium / no-wp.org-zip plugins), surfaces the same "Auto-update unavailable" hint Core renders.
- **Bulk Update** — `Update N` action in the bulk bar; fans through the same single-flight queue.
- **Single-flight queue** (`update-queue.ts`) — mirrors Core's `wp.updates.ajaxLocked` + FIFO `wp.updates.queue` semantics. Concurrent `Plugin_Upgrader` runs corrupt the `update_plugins` transient (documented in Core's own AJAX handler); enforcing single-flight is non-optional, not a polish item.
- **Reuses Core's AJAX endpoint** — `wp_ajax_update_plugin` with the existing `'updates'` nonce. No reimplementation of `Plugin_Upgrader`, which keeps us out of `wp-admin/includes/` and keeps Plugin Check green.
- **Count badge on the "Update available" segment** — `<wpd-badge tone="warning">N</wpd-badge>` that recounts on every row update; hidden when zero.
- **Live cross-view sync** — success broadcasts on `desktop-mode.plugin.changed` with `action: 'update'`, refreshes the framework menu (dock badge), bumps the row version inline.

## Data shape changes

- `desktop_mode_update_available` REST field now `{ available, new_version, package, slug }` (was `{ available, new_version }`). `package` is the gate the JS uses to decide Update-button vs Auto-update-unavailable hint — matches Core's own gating in `wp_plugin_update_row()`.
- `caps` config blob gains `update` (boolean, mirrors `current_user_can( 'update_plugins' )`). Server still re-validates every mutation in the AJAX handler.

## New filter

`desktop_mode_plugins_window_refresh_updates` (bool, default `true`) — opt-out of the lazy transient refresh. For managed hosts that run their own update orchestration.

## Tests

`tests/phpunit/tests/pluginsWindowRegistration.php`: +6 tests covering hit case with REST-stripped row shape (regression test for the `.php` strip), missing-`package` fallback, the 12h throttle, the opt-out filter, and `caps.update` for admin + editor. 27/27 in the class green, 660/660 in the full plugin suite green.

## Files

- `includes/plugins-window/rest-fields.php` — normalization helper + lazy refresh + extended field shape.
- `includes/plugins-window/permissions.php` — `caps.update`.
- `src/plugins-window/rest.ts` — `updateInstalledPlugin()` (re-appends `.php` before hitting `wp_ajax_update_plugin`).
- `src/plugins-window/update-queue.ts` *(new)* — single-flight queue.
- `src/plugins-window/installed-view.ts` — Update button (row + bulk), count badge, optimistic row repaint, broadcast on success.
- `src/plugins-window/types.ts` — extended `desktop_mode_update_available` + `caps.update`.
- `tests/phpunit/tests/pluginsWindowRegistration.php` — new coverage.
- `docs/hooks-reference.md` — new filter + extended field shape.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-185-7bbd5f426a28fbd928fd20b8a90d10ed936fe7f5.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->