### PR TITLE
fix(sync): debounce fswatch bursts so one save = one rebuild

### DIFF
--- a/bin/sync-to-wp-develop.sh
+++ b/bin/sync-to-wp-develop.sh
@@ -174,13 +174,40 @@ build_and_sync
 
 echo "[sync] watching ${#watch_paths[@]} paths under $src — Ctrl-C to stop"
 
-# fswatch excludes (regex against full path):
-# - .DS_Store: Finder noise
-# - /node_modules/: huge + chatty
-fswatch -o \
+# Quiet-period debounce: wait WPDM_SYNC_DEBOUNCE seconds with no
+# further events before rebuilding. Editor atomic-saves emit several
+# FSEvents in a burst, and `npm run build` runs ~14 vite invocations
+# back-to-back (~30-60s), so any edit during the build queues another
+# rebuild even when nothing actually changed. Draining events first
+# coalesces both cases into a single build.
+debounce_secs="${WPDM_SYNC_DEBOUNCE:-2}"
+
+# Path-mode fswatch (no -o) so we can log what changed. Each event is
+# one absolute path per line. The exclude flags below remain in effect.
+fswatch \
 	--exclude='\.DS_Store$' \
 	--exclude='/node_modules/' \
 	--latency 1 \
-	"${watch_paths[@]}" | while read -r _; do
+	"${watch_paths[@]}" | while read -r first_path; do
+	# Drain any follow-on events that arrive within $debounce_secs of
+	# the last one. `read -t` returns non-zero on timeout, which ends
+	# the inner loop. Counter is informational only.
+	changed=( "$first_path" )
+	while IFS= read -r -t "$debounce_secs" extra_path; do
+		changed+=( "$extra_path" )
+	done
+
+	# Strip $src/ prefix for legibility, dedupe, keep the first few.
+	preview=()
+	for p in "${changed[@]}"; do
+		short="${p#$src/}"
+		preview+=( "$short" )
+	done
+	# Bash 3 (macOS default) has no associative arrays — sort | uniq instead.
+	unique_preview=$(printf '%s\n' "${preview[@]}" | sort -u)
+	count=$(printf '%s\n' "$unique_preview" | wc -l | tr -d ' ')
+	first_three=$(printf '%s\n' "$unique_preview" | head -3 | paste -sd, -)
+	echo "[sync] $(date '+%H:%M:%S') ${count} path(s) changed: ${first_three}$([ "$count" -gt 3 ] && echo ', …')"
+
 	build_and_sync || echo "[sync] build/sync failed — waiting for next change"
 done


### PR DESCRIPTION
## Summary

- `bin/sync-to-wp-develop.sh --watch` was running a full `npm run build` 2-3 times in a row for a single save: editor atomic-saves emit several FSEvents in a burst, and edits that arrive during the build (which fires ~14 vite invocations back-to-back) queue another rebuild even when nothing actually changed.
- Switch fswatch to path-mode and drain follow-on events for a configurable quiet period (default 2s via `WPDM_SYNC_DEBOUNCE`) before invoking `build_and_sync`, so one save reliably produces one rebuild.
- Log which paths triggered each rebuild so the cause is visible at a glance.

## Test plan

- [ ] Start `bin/sync-to-wp-develop.sh --watch` and save a single TS file: only one `npm run build` should run, with a `N path(s) changed: …` line naming the file.
- [ ] Save the same file repeatedly within a couple of seconds: still coalesces into a single rebuild after the burst settles.
- [ ] Save a file while a build is in progress: queued events are drained and the rebuild fires exactly once after the quiet period.
- [ ] `WPDM_SYNC_DEBOUNCE=4 bin/sync-to-wp-develop.sh --watch` respects the override.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-186-4262c23bbd0612dee70e2069792ce2a5cfc9ea2f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->