### PR TITLE
Hide registered icons from desktop instead of trashing

### DIFF
--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -943,9 +943,13 @@ function attachTileDrag(
 /**
  * Wire right-click → context menu on a tile. Items vary by file
  * type — folders get a "Delete folder" that wipes the underlying
- * folder row plus its placements; non-folders get "Move to
- * Trash" that drops only the placement (the entity stays
+ * folder row plus its placements; non-folder user placements get
+ * "Move to Trash" that drops only the placement (the entity stays
  * intact — that's the file-references-not-copies contract).
+ * Plugin-registered icons (file type `'shortcut'`) and synthetic
+ * dock-promotion shortcuts get "Hide from desktop" instead — they
+ * aren't user data, so they're hidden via the visibility map and
+ * restorable from OS Settings → Apps & Icons rather than trashed.
  */
 function attachContextMenu(
 	tile: HTMLElement,
@@ -1102,21 +1106,36 @@ function attachContextMenu(
 				onClick: () => trashFolderWithUndo( placement ),
 			} );
 		} else {
-			// Synthetic shortcuts (dock items the user promoted to the
-			// desktop via OS Settings → Apps & Icons) aren't real
-			// placements — they're derived from the visibility map and
-			// live only in the in-memory store. Trashing one would
-			// hit a 404 on the REST endpoint. Replace the action with
-			// "Hide from desktop", which updates the visibility back
-			// to 'dock' and the sync module drops the synth tile.
+			// Two cases get "Hide from desktop" instead of "Move to
+			// Trash":
+			//
+			//   1. Synthetic shortcuts the user promoted from a dock
+			//      item via OS Settings → Apps & Icons. They aren't
+			//      real placements — they're derived from the
+			//      visibility map and live only in the in-memory store,
+			//      so trashing them would 404 on the REST endpoint.
+			//
+			//   2. Plugin-registered icons (file type `'shortcut'`) —
+			//      Content Graph, Recycle Bin, My WordPress, and any
+			//      icon registered via `desktop_mode_register_icon()`.
+			//      These are framework/plugin shortcuts, not user
+			//      data, and shouldn't be deletable from the wallpaper.
+			//      The user can hide them here and restore via OS
+			//      Settings → Apps & Icons.
+			//
+			// Both write `itemVisibility[ id ] = 'dock'` — the layout
+			// dispatcher's settings subscription drops the desktop tile
+			// on the next tick.
 			const synthFromDockItem = readSynthSource( placement );
-			if ( synthFromDockItem ) {
+			const isRegisteredIcon = placement.file.type === 'shortcut';
+			if ( synthFromDockItem || isRegisteredIcon ) {
+				const hideId = synthFromDockItem ?? placement.file.ref;
 				items.push( {
 					id: 'hide-from-desktop',
 					label: 'Hide from desktop',
 					icon: 'dashicons-hidden',
 					sort: 90,
-					onClick: () => hidePromotedDockItem( synthFromDockItem ),
+					onClick: () => hidePromotedDockItem( hideId ),
 				} );
 			} else {
 				items.push( {


### PR DESCRIPTION
## Summary

Right-clicking **Content Graph**, **Recycle Bin**, **My WordPress** (or any plugin-registered icon via `desktop_mode_register_icon()`) on the wallpaper used to offer **Move to Trash** — wrong, because these aren't user data: they're framework/plugin shortcuts that the file types REST endpoint can't meaningfully delete.

The tile context menu now offers **Hide from desktop** instead. It writes `itemVisibility[ iconId ] = 'dock'` via the existing `hidePromotedDockItem` writer; the layout dispatcher drops the tile on the next tick. Users restore the icon from **OS Settings → Apps & Icons**, where every registered icon is listed.

User-data placements (posts, pages, folders, user-created shortcuts) keep **Move to Trash** unchanged.

## Change

`src/desktop-files/layer.ts` — `attachContextMenu()` now unifies the synth-from-dock branch with the registered-icon case: any tile whose `placement.file.type === 'shortcut'` (or whose meta carries `__synthFromDockItem`) gets **Hide from desktop**; everything else keeps the trash flow.

## Test plan

- [ ] Right-click the My WordPress icon → menu shows **Hide from desktop**, no **Move to Trash**. Picking it hides the icon; opening OS Settings → Apps & Icons → setting placement back to "On the desktop" restores it.
- [ ] Same for Content Graph and Recycle Bin.
- [ ] Right-click a user-created shortcut (e.g. a post dragged to the wallpaper) → menu still shows **Move to Trash** and trashing works.
- [ ] Right-click a folder → still shows **Move folder to Trash**.
- [ ] Right-click a dock-promoted synthetic shortcut → still shows **Hide from desktop** (no regression on the existing synth path).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-187-714a03ca52e5ce7c46cd83cf8733e9c43fdf2566.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->