### PR TITLE
Draft readme.txt changelog from GitHub auto-notes during release

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -89,10 +89,38 @@ generate_changelog_draft() {
 		echo "warning: GitHub generate-notes API returned nothing — skipping draft." >&2
 		return 1
 	fi
+	# Transformation pipeline (one awk pass):
+	#  1. Keep only bullet lines, drop "first contribution" boilerplate.
+	#  2. Strip the trailing "by @user in <PR-URL>" suffix.
+	#  3. Strip trailing " (#NNN)" PR refs.
+	#  4. Strip leading "Fix #NNN:" / "Closes #NNN:" / "Resolves #NNN:".
+	#  5. Strip conventional-commit prefixes (type or type(scope) + colon)
+	#     case-insensitively, using a tolower() mirror for matching
+	#     because POSIX awk regex has no case-insensitive flag.
+	#  6. Capitalize the first letter of what remains.
 	local draft
 	draft=$(printf '%s\n' "$raw" | awk '
 		/^\* / && !/made their first contribution/ {
 			sub(/ by @[^ ]+ in https:\/\/[^ ]+$/, "")
+			sub(/[[:space:]]*\(#[0-9]+\)[[:space:]]*$/, "")
+
+			lower = tolower($0)
+			if (match(lower, /^\* (fix(es)?|close[sd]?|resolve[sd]?)[[:space:]]+#[0-9]+:[[:space:]]*/)) {
+				$0 = "* " substr($0, RSTART + RLENGTH)
+				lower = tolower($0)
+			}
+			if (match(lower, /^\* (feat|fix|chore|docs|refactor|perf|test|style|build|ci|revert)(\([^)]+\))?:[[:space:]]+/)) {
+				$0 = "* " substr($0, RSTART + RLENGTH)
+			}
+
+			if (length($0) >= 3) {
+				first = substr($0, 3, 1)
+				upper = toupper(first)
+				if (first != upper) {
+					$0 = substr($0, 1, 2) upper substr($0, 4)
+				}
+			}
+
 			print
 		}
 	')

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -146,7 +146,9 @@ if [[ "$dry_run_changelog" == "1" ]]; then
 		echo "=========================================================="
 		echo ""
 		echo "At this point the real release script would pause with:"
-		echo "  Press Enter to continue, or Ctrl-C to abort..."
+		echo "  Please update readme.txt if needed, save, and press Enter when done."
+		echo "  (Ctrl-C to abort, then 'git checkout readme.txt' to undo.)"
+		echo "  Press Enter when done..."
 		echo ""
 		echo "Dry run complete. No files changed."
 	fi
@@ -253,10 +255,10 @@ else
 				printf '%s\n' "$draft"
 				echo "=========================================================="
 				echo ""
-				echo "Review/edit readme.txt now (WordPress.org users see this)."
-				echo "Keep it user-facing: short, plain language, no PR refs."
-				echo "To abort: Ctrl-C, then 'git checkout readme.txt' to undo."
-				read -r -p "Press Enter to continue... " _
+				echo "Please update readme.txt if needed, save, and press Enter when done."
+				echo "(WordPress.org users see this — keep it user-facing.)"
+				echo "(Ctrl-C to abort, then 'git checkout readme.txt' to undo.)"
+				read -r -p "Press Enter when done... " _
 			fi
 		fi
 	else

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -3,32 +3,48 @@
 # Idempotent — safe to re-run if a previous attempt failed mid-flow.
 #
 # Flags:
-#   --skip-i18n   Skip the translation-file refresh (extract + build).
-#                 Use for hotfix releases where you do not want
-#                 .pot/.po/.json churn in the bump commit.
+#   --skip-i18n             Skip the translation-file refresh (extract + build).
+#                           Use for hotfix releases where you do not want
+#                           .pot/.po/.json churn in the bump commit.
+#   --skip-changelog        Skip drafting the readme.txt changelog from
+#                           GitHub's auto-generated release notes. Use when
+#                           you've already hand-written the changelog block,
+#                           or for hotfixes with nothing notable to log.
+#   --dry-run-changelog     Print the changelog draft that would be inserted
+#                           into readme.txt, then exit without modifying any
+#                           files or pushing. Useful for previewing the
+#                           draft and the editor pause before a real release.
 
 set -euo pipefail
 
 skip_i18n=0
+skip_changelog=0
+dry_run_changelog=0
 new=""
 for arg in "$@"; do
 	case "$arg" in
 		--skip-i18n)
 			skip_i18n=1
 			;;
+		--skip-changelog)
+			skip_changelog=1
+			;;
+		--dry-run-changelog)
+			dry_run_changelog=1
+			;;
 		-h|--help)
-			echo "usage: $0 <version> [--skip-i18n]  (e.g., 0.5.0 or 0.5.0-rc1)"
+			echo "usage: $0 <version> [--skip-i18n] [--skip-changelog] [--dry-run-changelog]  (e.g., 0.5.0 or 0.5.0-rc1)"
 			exit 0
 			;;
 		-*)
 			echo "error: unknown flag '$arg'" >&2
-			echo "usage: $0 <version> [--skip-i18n]" >&2
+			echo "usage: $0 <version> [--skip-i18n] [--skip-changelog] [--dry-run-changelog]" >&2
 			exit 1
 			;;
 		*)
 			if [[ -n "$new" ]]; then
 				echo "error: unexpected extra positional argument '$arg'" >&2
-				echo "usage: $0 <version> [--skip-i18n]" >&2
+				echo "usage: $0 <version> [--skip-i18n] [--skip-changelog] [--dry-run-changelog]" >&2
 				exit 1
 			fi
 			new="$arg"
@@ -37,7 +53,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$new" ]]; then
-	echo "usage: $0 <version> [--skip-i18n]  (e.g., 0.5.0 or 0.5.0-rc1)" >&2
+	echo "usage: $0 <version> [--skip-i18n] [--skip-changelog] [--dry-run-changelog]  (e.g., 0.5.0 or 0.5.0-rc1)" >&2
 	exit 1
 fi
 
@@ -47,6 +63,66 @@ command -v gh >/dev/null || { echo "error: 'gh' CLI required (for CI polling)" >
 if ! gh auth status >/dev/null 2>&1; then
 	echo "error: gh CLI is not authenticated. Run:  gh auth login" >&2
 	exit 1
+fi
+
+# Fetches GitHub's auto-generated release notes for the next tag, keeps
+# only bullet lines, strips the trailing "by @user in <PR-URL>" suffix,
+# and drops "first contribution" boilerplate. Echoes the transformed
+# bullets on stdout; echoes a diagnostic on stderr and returns non-zero
+# if there is nothing usable to write.
+generate_changelog_draft() {
+	local target_tag="$1"
+	local prev
+	prev=$(git describe --tags --abbrev=0 2>/dev/null || true)
+	if [[ -z "$prev" ]]; then
+		echo "warning: no previous tag found — skipping changelog draft." >&2
+		return 1
+	fi
+	local repo raw
+	repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+	raw=$(gh api -X POST "repos/$repo/releases/generate-notes" \
+		-f tag_name="$target_tag" \
+		-f previous_tag_name="$prev" \
+		-f target_commitish=trunk \
+		--jq '.body' 2>/dev/null || true)
+	if [[ -z "$raw" ]]; then
+		echo "warning: GitHub generate-notes API returned nothing — skipping draft." >&2
+		return 1
+	fi
+	local draft
+	draft=$(printf '%s\n' "$raw" | awk '
+		/^\* / && !/made their first contribution/ {
+			sub(/ by @[^ ]+ in https:\/\/[^ ]+$/, "")
+			print
+		}
+	')
+	if [[ -z "$draft" ]]; then
+		echo "warning: no bullet items in generated notes — skipping draft." >&2
+		return 1
+	fi
+	printf '%s\n' "$draft"
+}
+
+# --dry-run-changelog short-circuits before any preflight checks so it
+# works from any branch and any working-tree state. Use it to preview
+# the draft + interaction without mutating anything.
+if [[ "$dry_run_changelog" == "1" ]]; then
+	echo "Dry run: previewing changelog draft for $tag (no files will be modified)."
+	echo ""
+	if draft=$(generate_changelog_draft "$tag"); then
+		echo "=========================================================="
+		echo "Would prepend this '= $new =' block to readme.txt:"
+		echo "----------------------------------------------------------"
+		echo "= $new ="
+		printf '%s\n' "$draft"
+		echo "=========================================================="
+		echo ""
+		echo "At this point the real release script would pause with:"
+		echo "  Press Enter to continue, or Ctrl-C to abort..."
+		echo ""
+		echo "Dry run complete. No files changed."
+	fi
+	exit 0
 fi
 
 branch=$(git rev-parse --abbrev-ref HEAD)
@@ -111,6 +187,52 @@ else
 		fi
 	else
 		echo "Skipping i18n refresh (--skip-i18n)."
+	fi
+
+	# Draft the readme.txt changelog block from GitHub's auto-generated
+	# release notes, then pause so the releaser can curate before the
+	# bump commit. Resume-safe: skips if readme.txt already has a
+	# "= $new =" block (from a prior aborted attempt). If the editor
+	# pause is aborted with Ctrl-C, readme.txt will be left modified;
+	# undo with: git checkout readme.txt
+	if [[ "$skip_changelog" == "0" ]]; then
+		if grep -q "^= $new =$" readme.txt; then
+			echo "readme.txt already has a '= $new =' block — skipping changelog draft."
+		else
+			echo "Drafting readme.txt changelog from GitHub notes for $tag..."
+			if draft=$(generate_changelog_draft "$tag"); then
+				draft_file=$(mktemp)
+				printf '%s\n' "$draft" > "$draft_file"
+				tmp=$(mktemp)
+				awk -v ver="$new" -v draft_file="$draft_file" '
+					{ print }
+					!inserted && $0 == "== Changelog ==" {
+						print ""
+						print "= " ver " ="
+						while ((getline line < draft_file) > 0) print line
+						close(draft_file)
+						inserted = 1
+					}
+				' readme.txt > "$tmp"
+				mv "$tmp" readme.txt
+				rm -f "$draft_file"
+
+				echo ""
+				echo "=========================================================="
+				echo "Drafted '= $new =' block in readme.txt:"
+				echo "----------------------------------------------------------"
+				echo "= $new ="
+				printf '%s\n' "$draft"
+				echo "=========================================================="
+				echo ""
+				echo "Review/edit readme.txt now (WordPress.org users see this)."
+				echo "Keep it user-facing: short, plain language, no PR refs."
+				echo "To abort: Ctrl-C, then 'git checkout readme.txt' to undo."
+				read -r -p "Press Enter to continue... " _
+			fi
+		fi
+	else
+		echo "Skipping changelog draft (--skip-changelog)."
 	fi
 
 	./bin/bump-version.sh "$new"


### PR DESCRIPTION
## Summary

- `bin/release.sh` now fetches GitHub's auto-generated release notes for the upcoming tag, transforms them into WP.org-friendly bullets, prepends a `= X.Y.Z =` block to `readme.txt`, and pauses so the releaser can curate the wording before the bump commit lands.
- The GitHub Release itself remains fully auto-generated by `release.yml` (`gh release create --generate-notes`). `readme.txt` is now its curated WP.org-facing twin.
- Two new flags:
  - `--skip-changelog` — opt out (hotfixes, or when you've hand-written the block already).
  - `--dry-run-changelog` — print the draft and exit without modifying any files. Works from any branch and any working-tree state.

## Transformation pipeline

Applied in one `awk` pass after the API response comes back:

1. Keep only bullet lines, drop "first contribution" boilerplate.
2. Strip the trailing `by @user in <PR-URL>` suffix.
3. Strip trailing ` (#NNN)` PR refs.
4. Strip leading `Fix #NNN:` / `Closes #NNN:` / `Resolves #NNN:`.
5. Strip conventional-commit prefixes (`feat:`, `fix:`, `fix(scope):`, etc.) case-insensitively. Uses a `tolower()` mirror for matching since POSIX awk regex has no case-insensitive flag.
6. Capitalize the first letter of what remains.

Titles without an explicit colon prefix (e.g. `Feat comments as native windows`, `Plugins window: real updates...`) are left untouched, since detecting those needs guesswork that could damage real text. They go through the human pass.

## Example draft (v0.8.2 → v0.8.3)

```
= 0.8.3 =
* Add npm run extract:i18n script for PHP + TypeScript string extraction
* Feat comments as native windows
* Chrome <111 titlebars + duplicate-placement REST 500s
* SW navigation interception caused window-in-window after core update
* Open each post as its own window from the Posts window
* Fix Users window data + live-refresh, plus per-window REST clients
* Session-expiry cascade + Plugins window sync
* Narrow scope to /wp-admin/ and throttle SW reloads
* Plugins window: real updates, not just a phantom badge
* Debounce fswatch bursts so one save = one rebuild
* Support plain permalinks for REST URL construction
* Hide registered icons from desktop instead of trashing
```

## Pause UX

After the draft is written to `readme.txt`, the script prints:

```
Please update readme.txt if needed, save, and press Enter when done.
(WordPress.org users see this — keep it user-facing.)
(Ctrl-C to abort, then 'git checkout readme.txt' to undo.)
Press Enter when done...
```

The releaser opens `readme.txt` in their editor, edits the bullets, saves, returns to the terminal, and hits Enter. `bump-version.sh` and the bump commit then pick up the curated edits.

## Resume / abort behavior

- If `readme.txt` already has a `= X.Y.Z =` block (e.g. from a prior aborted attempt), the draft step is skipped — the human's edits are never clobbered.
- If aborted mid-pause with Ctrl-C, the file is left modified on disk; `git checkout readme.txt` undoes it.

## Test plan

- [x] `bash -n bin/release.sh` — script syntax is valid.
- [x] `bin/release.sh 0.8.3 --dry-run-changelog` — prints the example draft above and exits without modifying files.
- [x] Transformation verified against the full v0.8.2 → v0.8.3 PR list (12 bullets, mix of `fix:`, `fix(scope):`, `Fix:`, `Fix #NNN:`, plain titles, and edge cases).
- [ ] First live release using the new flow — verify pause works, edits are picked up by the bump commit, GH Release notes remain unchanged.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-188-ae39e36ea1197fdee6158e3580a1b381722856dd.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->