### PR TITLE
Fix: "Edit Post" from the front-end admin bar opens nothing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,16 +80,17 @@ Key server-side entry points:
 
 ## Browser flow
 
-1. `/wp-admin/` loads → portal redirect sends the user to `/desktop-mode/`.
-2. `/desktop-mode/` serves a real admin page (Dashboard by default) with the shell wrapped around it.
-3. The shell's Vite-built TypeScript bundle (`desktop.js` in dev, `desktop.min.js` in prod) initializes:
+1. `/wp-admin/...` loads → the portal redirect on `admin_init` bounces the request through `/desktop-mode/?target=<original-url>`.
+2. `/desktop-mode/` (with or without `target`) forwards back into wp-admin tagged with `desktop_mode_portal=1`. When the redirect resolved from a `target` (user-supplied intent — admin-bar link, bookmark, etc.) the URL also carries `desktop_mode_portal_intent=1`. Both flags are stripped from `currentPage` before the shell sees it; the booleans `fromPortal` / `fromPortalIntent` ride along in the shell config so the boot flow can distinguish "portal stamped this URL" from "user actually asked for it."
+3. The landing page renders with the shell wrapped around it (Dashboard by default; the user's saved focused window, the default-window preference, or the `target` URL otherwise).
+4. The shell's Vite-built TypeScript bundle (`desktop.js` in dev, `desktop.min.js` in prod) initializes:
    - Creates the `WindowManager`.
    - Creates the **layout dispatcher** which owns the dock(s) for the active `desktopLayout` (see [Desktop layout modes](#desktop-layout-modes)).
-   - Either restores the saved session (if one exists) **or** opens the current page in a new window.
+   - Restores the saved session (if one exists). Then `shouldAutoOpenCurrentPage()` (see `src/boot/auto-open.ts`) decides whether to ALSO open `currentPage`. The decision: open when `fromPortal=false` (direct nav) **or** `fromPortalIntent=true` (portal redirected here from a user-clicked link). Suppress on bare portal entries that landed via the default-window / session-focused fallback so a restored stack isn't disturbed.
    - Wires persistence — debounced `POST /wp-json/desktop-mode/v1/session`.
-4. When a dock icon is clicked, the manager opens a window whose iframe `src` is the admin URL with `?desktop_mode_chromeless=1` appended.
-5. The iframe renders WordPress normally, but the chromeless stylesheet hides the admin bar, side menu, and wp-footer.
-6. The iframe `postMessage`s its title, navigation, and screen-meta state up to the parent.
+5. When a dock icon is clicked, the manager opens a window whose iframe `src` is the admin URL with `?desktop_mode_chromeless=1` appended.
+6. The iframe renders WordPress normally, but the chromeless stylesheet hides the admin bar, side menu, and wp-footer.
+7. The iframe `postMessage`s its title, navigation, and screen-meta state up to the parent.
 
 ## Desktop layout modes
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -652,15 +652,17 @@ apply_filters( 'desktop_mode_shell_config', array $config );
 
 ```php
 array(
-    'currentPage'    => string,   // e.g. 'http://localhost:8889/wp-admin/'
-    'currentTitle'   => string,   // human title of the current page
-    'currentIcon'    => string,   // dashicons-* class
-    'adminUrl'       => string,   // admin_url()
-    'portalUrl'      => string,   // desktop_mode_portal_url()
-    'sessionUrl'     => string,   // REST session URL
-    'restNonce'      => string,   // X-WP-Nonce
-    'dockItems'      => array[],  // see desktop_mode_dock_items
-    'session'        => array,    // prior session snapshot or empty
+    'currentPage'      => string,   // e.g. 'http://localhost:8889/wp-admin/'
+    'currentTitle'     => string,   // human title of the current page
+    'currentIcon'      => string,   // dashicons-* class
+    'adminUrl'         => string,   // admin_url()
+    'portalUrl'        => string,   // desktop_mode_portal_url()
+    'sessionUrl'       => string,   // REST session URL
+    'restNonce'        => string,   // X-WP-Nonce
+    'dockItems'        => array[],  // see desktop_mode_dock_items
+    'session'          => array,    // prior session snapshot or empty
+    'fromPortal'       => bool,     // request was forwarded by the /desktop-mode/ portal
+    'fromPortalIntent' => bool,     // portal forward resolved from a user-supplied `target` URL — the user expressed navigation intent toward `currentPage`, not just a bare `/desktop-mode/` visit. Since 0.8.4.
 )
 ```
 

--- a/includes/portal.php
+++ b/includes/portal.php
@@ -28,6 +28,18 @@ const DESKTOP_MODE_PORTAL_PATH = 'desktop-mode';
 const DESKTOP_MODE_PORTAL_FLAG = 'desktop_mode_portal';
 
 /**
+ * Query var set on portal redirects whose landing page came from an
+ * explicit `?target=…` URL the user (or a redirect chain originating
+ * from a click) provided — as opposed to the portal picking the
+ * session's focused window or the default-window fallback.
+ *
+ * The shell uses this to distinguish "user expressed navigation intent
+ * toward this URL" (open it) from "portal had to forward somewhere"
+ * (don't disturb the restored session).
+ */
+const DESKTOP_MODE_PORTAL_INTENT_FLAG = 'desktop_mode_portal_intent';
+
+/**
  * Query var set by the window-title-bar "Detach" action. Tells the
  * admin_init redirect to skip portal forwarding for this request so the
  * user can view the page as classic wp-admin in a new tab even when
@@ -113,7 +125,8 @@ function desktop_mode_handle_portal_request( $wp ) {
 	//      specific admin page (e.g. profile.php).
 	//   2. Last-focused window from the saved session.
 	//   3. Dashboard fallback.
-	$target = '';
+	$target      = '';
+	$has_intent  = false;
 	if ( ! empty( $_GET['target'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		// `esc_url_raw`, NOT `sanitize_text_field`: the latter strips
 		// every `%XX` percent-encoded sequence from its input as an XSS
@@ -124,6 +137,9 @@ function desktop_mode_handle_portal_request( $wp ) {
 		// scheme rejection, file_exists gate) so we don't lose any
 		// real safety by skipping `sanitize_text_field` here.
 		$target = desktop_mode_sanitize_portal_target( esc_url_raw( wp_unslash( $_GET['target'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( '' !== $target ) {
+			$has_intent = true;
+		}
 	}
 	if ( '' === $target ) {
 		$target = desktop_mode_portal_entry_url( $user_id );
@@ -132,6 +148,15 @@ function desktop_mode_handle_portal_request( $wp ) {
 	// Flag the forward so the shell can stamp the address bar back to
 	// /desktop-mode/ via history.replaceState once it has loaded.
 	$target = add_query_arg( DESKTOP_MODE_PORTAL_FLAG, '1', $target );
+
+	// Second flag: the redirect resolved from an explicit `target`, so
+	// the shell should treat the resulting `currentPage` as user
+	// intent and auto-open it on top of the restored session. Without
+	// this, a bare `/desktop-mode/` visit and a portal-redirected
+	// admin-bar click would be indistinguishable downstream.
+	if ( $has_intent ) {
+		$target = add_query_arg( DESKTOP_MODE_PORTAL_INTENT_FLAG, '1', $target );
+	}
 
 	wp_safe_redirect( $target );
 	exit;
@@ -427,7 +452,7 @@ function desktop_mode_sanitize_portal_target( $raw ) {
 
 	if ( is_string( $query ) && '' !== $query ) {
 		parse_str( $query, $args );
-		unset( $args['desktop_mode_chromeless'], $args[ DESKTOP_MODE_PORTAL_FLAG ], $args['target'] );
+		unset( $args['desktop_mode_chromeless'], $args[ DESKTOP_MODE_PORTAL_FLAG ], $args[ DESKTOP_MODE_PORTAL_INTENT_FLAG ], $args['target'] );
 		if ( ! empty( $args ) ) {
 			$target = add_query_arg( $args, $target );
 		}

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -196,14 +196,15 @@ function desktop_mode_enqueue_assets() {
 	};
 
 	// Build the current page URL from $pagenow + $_GET. Strip the portal
-	// marker so the derived window ID matches what the dock would produce
+	// markers so the derived window ID matches what the dock would produce
 	// for the same page — otherwise auto-opening the entry window and
 	// clicking the same dock icon would create a duplicate.
 	$current_query = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	unset( $current_query[ DESKTOP_MODE_PORTAL_FLAG ] );
+	unset( $current_query[ DESKTOP_MODE_PORTAL_FLAG ], $current_query[ DESKTOP_MODE_PORTAL_INTENT_FLAG ] );
 	$current_page = admin_url( $pagenow ) . ( ! empty( $current_query ) ? '?' . http_build_query( $current_query ) : '' );
 
-	$from_portal = ! empty( $_GET[ DESKTOP_MODE_PORTAL_FLAG ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$from_portal        = ! empty( $_GET[ DESKTOP_MODE_PORTAL_FLAG ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$from_portal_intent = ! empty( $_GET[ DESKTOP_MODE_PORTAL_INTENT_FLAG ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	/**
 	 * Filters the desktop shell configuration passed to JavaScript.
@@ -241,6 +242,7 @@ function desktop_mode_enqueue_assets() {
 	 *     @type string $restNonce        Nonce for the session REST endpoint.
 	 *     @type string $portalUrl    Canonical `/desktop-mode/` URL.
 	 *     @type bool   $fromPortal   Whether the shell was reached via the portal.
+	 *     @type bool   $fromPortalIntent Whether the portal redirect resolved from an explicit `?target=…` (user navigation intent) rather than the session's focused window or the default-window fallback. Distinguishes a bare `/desktop-mode/` visit from a portal-redirected admin-bar click so the shell can honour the URL the user actually asked for.
 	 *     @type array  $seenIntros   Slugs of one-time intro dialogs the user has dismissed (e.g. `['posts']`). Native windows gate their first-open intro on this list.
 	 *     @type string $seenIntrosUrl REST endpoint for the seen-intros surface — POST `/seen` to mark, DELETE the base to reset.
 	 * }
@@ -352,6 +354,7 @@ function desktop_mode_enqueue_assets() {
 			'currentUserIsAdmin'    => current_user_can( 'manage_options' ),
 			'portalUrl'        => esc_url( desktop_mode_portal_url() ),
 			'fromPortal'       => $from_portal,
+			'fromPortalIntent' => $from_portal_intent,
 			'pwa'              => array(
 				'manifestUrl' => esc_url_raw( desktop_mode_pwa_manifest_url() ),
 				'swUrl'       => esc_url_raw( desktop_mode_pwa_sw_url() ),

--- a/src/boot/auto-open.ts
+++ b/src/boot/auto-open.ts
@@ -1,0 +1,61 @@
+/**
+ * Auto-open decision matrix for the shell boot flow.
+ *
+ * Extracted so the rules below can be exercised directly by Vitest
+ * instead of through the full `init()` happy path. Keep the predicate
+ * pure — no DOM, no manager, no side effects.
+ *
+ * The five-case truth table (mirrors the comment block in
+ * `desktop.ts`):
+ *
+ *   1. `fromPortal=false`
+ *        → user navigated to a specific admin URL directly. Open it.
+ *
+ *   2. `fromPortal=true` + `fromPortalIntent=true`
+ *        → portal redirected here BECAUSE the user followed a link
+ *          to a specific admin page (admin-bar "Edit Post", a
+ *          bookmark, etc.). The intent flag was added by
+ *          `desktop_mode_handle_portal_request` only when the
+ *          redirect resolved from `?target=…`. Open the URL — it's
+ *          user intent, not a default the portal had to pick.
+ *
+ *   3. `fromPortal=true` + `fromPortalIntent=false` + session exists
+ *        → bare `/desktop-mode/` visit. Portal landed on the
+ *          session's focused window or the default. Session restore
+ *          already covers it; don't double-open.
+ *
+ *   4. `fromPortal=true` + `fromPortalIntent=false` + session empty
+ *      + default disabled
+ *        → user turned the default window off. Show an empty desk.
+ *
+ *   5. `fromPortal=true` + `fromPortalIntent=false` + session empty
+ *      + default enabled
+ *        → clean slate, default window set. The portal already
+ *          forwarded to its URL, so opening `currentPage` populates
+ *          the desktop with the user's chosen startup.
+ *
+ * @since 0.8.4
+ */
+
+export interface AutoOpenInputs {
+	fromPortal: boolean;
+	fromPortalIntent?: boolean;
+	hasSession: boolean;
+	defaultEnabled: boolean;
+	isNativeDefault: boolean;
+}
+
+/**
+ * Whether the boot flow should call `openCurrentPage`.
+ *
+ * Inverse of the `suppressAutoOpen` expression that used to live
+ * inline in `desktop.ts` — kept positive here because tests read
+ * "should open" more cleanly than "should suppress."
+ */
+export function shouldAutoOpenCurrentPage( inputs: AutoOpenInputs ): boolean {
+	const suppress =
+		inputs.fromPortal &&
+		! inputs.fromPortalIntent &&
+		( inputs.hasSession || ! inputs.defaultEnabled || inputs.isNativeDefault );
+	return ! suppress;
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -141,6 +141,7 @@ import { bootHeartbeatBus, type HeartbeatBus } from './heartbeat';
 import { bindTopWindowLinkInterceptor } from './boot/link-interceptor';
 import { bindMenuRefresh } from './boot/menu-refresh';
 import { openCurrentPage, restoreSession } from './boot/session';
+import { shouldAutoOpenCurrentPage } from './boot/auto-open';
 import { createSessionSaver } from './boot/session-saver';
 import { bindShellLifecycle, wireSessionEvents } from './boot/shell-lifecycle';
 import { trackedFetch } from './boot/tracked-fetch';
@@ -2135,24 +2136,37 @@ function init(): void {
 	);
 
 	// Bootstrap: restore session (if any), then decide whether to also
-	// auto-open the current admin URL. The rules compose three signals:
+	// auto-open the current admin URL. The rules compose four signals:
 	//
 	//   1. `fromPortal=false`     → user navigated to a specific admin
-	//      URL (e.g. /wp-admin/edit.php). Always honor that navigation
-	//      by opening the page; direct URLs are intent.
+	//      URL directly (no portal redirect). Always honor — direct
+	//      URLs are intent.
 	//
 	//   2. `fromPortal=true`
-	//      + session exists       → user is returning to their saved
-	//      stack. Respect the stack verbatim — don't force Dashboard
-	//      (or any other default) back in. Matches their last state.
+	//      + `fromPortalIntent=true`
+	//                              → the portal redirected here, but it
+	//      did so because the user followed a link to a specific
+	//      admin page (the `desktop_mode_redirect_plain_admin_to_portal`
+	//      → `?target=…` round-trip). Honor the URL regardless of
+	//      saved-session state; the page they asked for opens on top
+	//      of the restored stack.
 	//
 	//   3. `fromPortal=true`
+	//      + `fromPortalIntent=false`
+	//      + session exists       → bare `/desktop-mode/` visit with a
+	//      saved stack. Portal picked the last-focused window or the
+	//      default; session restore already covers it. Don't double-
+	//      open and don't force a default back into a custom stack.
+	//
+	//   4. `fromPortal=true`
+	//      + `fromPortalIntent=false`
 	//      + session empty
 	//      + defaultWindow.enabled=false
 	//                              → user explicitly turned off the
 	//      default window. Show them an empty desktop. No auto-open.
 	//
-	//   4. `fromPortal=true`
+	//   5. `fromPortal=true`
+	//      + `fromPortalIntent=false`
 	//      + session empty
 	//      + defaultWindow.enabled=true
 	//                              → first visit or clean slate, and
@@ -2180,10 +2194,13 @@ function init(): void {
 	const isNativeDefault =
 		typeof defaultUrlEarly === 'string' &&
 		defaultUrlEarly.startsWith( 'native:' );
-	const suppressAutoOpen =
-		config.fromPortal &&
-		( hasSession || ! defaultEnabled || isNativeDefault );
-	if ( ! suppressAutoOpen ) {
+	if ( shouldAutoOpenCurrentPage( {
+		fromPortal: config.fromPortal,
+		fromPortalIntent: config.fromPortalIntent,
+		hasSession,
+		defaultEnabled,
+		isNativeDefault,
+	} ) ) {
 		void openCurrentPage( manager, config ).catch( ( err ) => {
 			if ( typeof console !== 'undefined' ) {
 				console.error( '[desktop-mode] openCurrentPage failed:', err );
@@ -2277,6 +2294,7 @@ function init(): void {
 	if (
 		config.defaultWindow?.enabled &&
 		config.fromPortal &&
+		! config.fromPortalIntent &&
 		! hasSession &&
 		isNativeDefault
 	) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1729,6 +1729,25 @@ export interface DesktopConfig {
 	/** True when the shell was reached via the portal redirect. */
 	fromPortal: boolean;
 	/**
+	 * True when the portal redirect resolved from an explicit `?target=…`
+	 * URL — i.e. the user expressed navigation intent toward the current
+	 * page (clicked an admin-bar "Edit Post" link, followed a bookmark
+	 * to `/wp-admin/plugins.php`, etc.) rather than landing on
+	 * `/desktop-mode/` bare.
+	 *
+	 * The boot flow uses this to decide whether to honour
+	 * `currentPage` as a window to auto-open: `fromPortal` alone says
+	 * "the portal stamped the URL," only `fromPortalIntent` says "the
+	 * user actually asked for this page."
+	 *
+	 * Optional in the type so older payloads (pre-bug-fix shells) fail
+	 * soft to `undefined` / falsy — keeping the previous (session-
+	 * suppress) behaviour for callers that never see the new flag.
+	 *
+	 * @since 0.8.4
+	 */
+	fromPortalIntent?: boolean;
+	/**
 	 * Progressive-web-app config — endpoint URLs and the per-user
 	 * installable-pill state. Always present in shell-mode requests.
 	 * Optional in the type so older payloads (or chromeless contexts

--- a/tests/phpunit/tests/desktopModeHooks.php
+++ b/tests/phpunit/tests/desktopModeHooks.php
@@ -34,7 +34,7 @@ class Tests_DesktopMode_DesktopModeHooks extends WP_UnitTestCase {
 		remove_all_filters( 'desktop_mode_mode_enabled' );
 		remove_all_actions( 'desktop_mode_mode_init' );
 		remove_all_actions( 'desktop_mode_chromeless_styles' );
-		unset( $_GET['desktop_mode_chromeless'] );
+		unset( $_GET['desktop_mode_chromeless'], $_GET[ DESKTOP_MODE_PORTAL_FLAG ], $_GET[ DESKTOP_MODE_PORTAL_INTENT_FLAG ] );
 		parent::tear_down();
 	}
 
@@ -108,9 +108,72 @@ class Tests_DesktopMode_DesktopModeHooks extends WP_UnitTestCase {
 		desktop_mode_enqueue_assets();
 
 		$this->assertIsArray( $received );
-		foreach ( array( 'currentPage', 'currentTitle', 'currentIcon', 'adminUrl', 'colorScheme', 'dockItems' ) as $key ) {
+		foreach ( array( 'currentPage', 'currentTitle', 'currentIcon', 'adminUrl', 'colorScheme', 'dockItems', 'fromPortal', 'fromPortalIntent' ) as $key ) {
 			$this->assertArrayHasKey( $key, $received, "Config missing key: $key" );
 		}
+	}
+
+	/**
+	 * The shell config surfaces `fromPortalIntent` mirroring the
+	 * `desktop_mode_portal_intent` query flag, and strips it out of
+	 * `currentPage` so the URL-derived window id matches the dock's.
+	 *
+	 * @covers ::desktop_mode_enqueue_assets
+	 */
+	public function test_desktop_mode_shell_config_surfaces_portal_intent_flag() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET[ DESKTOP_MODE_PORTAL_FLAG ]        = '1';
+		$_GET[ DESKTOP_MODE_PORTAL_INTENT_FLAG ] = '1';
+		$_GET['post']                            = '104';
+		$_GET['action']                          = 'edit';
+
+		$received = null;
+		add_filter(
+			'desktop_mode_shell_config',
+			function ( $config ) use ( &$received ) {
+				$received = $config;
+				return $config;
+			}
+		);
+
+		try {
+			desktop_mode_enqueue_assets();
+		} finally {
+			unset( $_GET['post'], $_GET['action'] );
+		}
+
+		$this->assertIsArray( $received );
+		$this->assertTrue( $received['fromPortal'] );
+		$this->assertTrue( $received['fromPortalIntent'] );
+		$this->assertStringNotContainsString( DESKTOP_MODE_PORTAL_FLAG, $received['currentPage'] );
+		$this->assertStringNotContainsString( DESKTOP_MODE_PORTAL_INTENT_FLAG, $received['currentPage'] );
+	}
+
+	/**
+	 * Bare portal entry — `fromPortal=true`, but no intent flag — must
+	 * surface `fromPortalIntent=false` so the boot flow leaves the
+	 * restored session alone.
+	 *
+	 * @covers ::desktop_mode_enqueue_assets
+	 */
+	public function test_desktop_mode_shell_config_intent_flag_defaults_false() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET[ DESKTOP_MODE_PORTAL_FLAG ] = '1';
+
+		$received = null;
+		add_filter(
+			'desktop_mode_shell_config',
+			function ( $config ) use ( &$received ) {
+				$received = $config;
+				return $config;
+			}
+		);
+
+		desktop_mode_enqueue_assets();
+
+		$this->assertIsArray( $received );
+		$this->assertTrue( $received['fromPortal'] );
+		$this->assertFalse( $received['fromPortalIntent'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/desktopModePortal.php
+++ b/tests/phpunit/tests/desktopModePortal.php
@@ -31,6 +31,7 @@ class Tests_DesktopMode_Portal extends WP_UnitTestCase {
 			$_SERVER['REQUEST_URI'],
 			$_SERVER['REQUEST_METHOD'],
 			$_GET[ DESKTOP_MODE_PORTAL_FLAG ],
+			$_GET[ DESKTOP_MODE_PORTAL_INTENT_FLAG ],
 			$_GET[ DESKTOP_MODE_CLASSIC_FLAG ],
 			$_GET['desktop_mode_chromeless']
 		);
@@ -552,5 +553,109 @@ class Tests_DesktopMode_Portal extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'post_type=page', $redirect );
 		$this->assertStringContainsString( DESKTOP_MODE_PORTAL_FLAG . '=1', $redirect );
+	}
+
+	/**
+	 * Bare `/desktop-mode/` visits — no `?target=` — must NOT carry the
+	 * portal-intent flag. The shell uses its absence as the signal that
+	 * the portal picked the landing page itself (default window /
+	 * session-focused), so a restored session shouldn't be disturbed.
+	 *
+	 * @covers ::desktop_mode_handle_portal_request
+	 */
+	public function test_portal_bare_visit_omits_intent_flag() {
+		wp_set_current_user( self::$admin_id );
+
+		$redirect = $this->capture_redirect( '/desktop-mode/' );
+
+		$this->assertNotNull( $redirect );
+		$this->assertStringContainsString( DESKTOP_MODE_PORTAL_FLAG . '=1', $redirect );
+		$this->assertStringNotContainsString( DESKTOP_MODE_PORTAL_INTENT_FLAG . '=1', $redirect );
+	}
+
+	/**
+	 * Regression for the "Edit Post" admin-bar click from the front end:
+	 * `/wp-admin/post.php?post=…&action=edit` → portal redirect →
+	 * `/wp-admin/post.php?…&desktop_mode_portal=1&desktop_mode_portal_intent=1`.
+	 * Without the intent flag the shell would suppress the auto-open
+	 * whenever the user has a saved session, swallowing their click.
+	 *
+	 * @covers ::desktop_mode_handle_portal_request
+	 */
+	public function test_portal_target_redirect_carries_intent_flag() {
+		wp_set_current_user( self::$admin_id );
+		$raw_uri                = '/wp-admin/post.php?post=104&action=edit';
+		$_GET['target']         = $raw_uri;
+		$_SERVER['REQUEST_URI'] = '/desktop-mode/?target=' . rawurlencode( $raw_uri );
+
+		try {
+			$redirect = $this->capture_with( 'desktop_mode_handle_portal_request', null );
+		} finally {
+			unset( $_GET['target'] );
+		}
+
+		$this->assertNotNull( $redirect );
+		$this->assertStringContainsString( 'post.php', $redirect );
+		$this->assertStringContainsString( 'post=104', $redirect );
+		$this->assertStringContainsString( 'action=edit', $redirect );
+		$this->assertStringContainsString( DESKTOP_MODE_PORTAL_FLAG . '=1', $redirect );
+		$this->assertStringContainsString( DESKTOP_MODE_PORTAL_INTENT_FLAG . '=1', $redirect );
+	}
+
+	/**
+	 * If `?target=` is supplied but the URL fails the wp-admin
+	 * whitelist (off-site, missing file, etc.), the portal falls back
+	 * to the session/default landing — which is portal-picked, not
+	 * user intent. The intent flag must NOT survive that fallback.
+	 *
+	 * @covers ::desktop_mode_handle_portal_request
+	 */
+	public function test_portal_invalid_target_does_not_set_intent_flag() {
+		wp_set_current_user( self::$admin_id );
+		$_GET['target']         = '/somewhere-not-admin/foo.php';
+		$_SERVER['REQUEST_URI'] = '/desktop-mode/?target=' . rawurlencode( '/somewhere-not-admin/foo.php' );
+
+		try {
+			$redirect = $this->capture_with( 'desktop_mode_handle_portal_request', null );
+		} finally {
+			unset( $_GET['target'] );
+		}
+
+		$this->assertNotNull( $redirect );
+		$this->assertStringContainsString( DESKTOP_MODE_PORTAL_FLAG . '=1', $redirect );
+		$this->assertStringNotContainsString( DESKTOP_MODE_PORTAL_INTENT_FLAG . '=1', $redirect );
+	}
+
+	/**
+	 * The intent flag must not leak into the derived `currentPage`
+	 * passed to the shell. Otherwise the window id derived from the URL
+	 * would diverge from the dock's id for the same admin page, and
+	 * clicking the dock icon for an already-auto-opened page would
+	 * spawn a duplicate window.
+	 *
+	 * @covers ::desktop_mode_handle_portal_request
+	 * @covers ::desktop_mode_sanitize_portal_target
+	 */
+	public function test_portal_target_with_existing_intent_flag_is_normalised() {
+		wp_set_current_user( self::$admin_id );
+		// User crafts (or a bookmark embeds) a target whose query string
+		// already carries the intent marker. The sanitizer drops the
+		// duplicate so we don't end up with `…intent=1&…intent=1`.
+		$raw_uri                = '/wp-admin/edit.php?post_type=page&' . DESKTOP_MODE_PORTAL_INTENT_FLAG . '=1';
+		$_GET['target']         = $raw_uri;
+		$_SERVER['REQUEST_URI'] = '/desktop-mode/?target=' . rawurlencode( $raw_uri );
+
+		try {
+			$redirect = $this->capture_with( 'desktop_mode_handle_portal_request', null );
+		} finally {
+			unset( $_GET['target'] );
+		}
+
+		$this->assertNotNull( $redirect );
+		// Exactly one occurrence of the intent flag in the final URL.
+		$this->assertSame(
+			1,
+			substr_count( $redirect, DESKTOP_MODE_PORTAL_INTENT_FLAG . '=1' )
+		);
 	}
 }

--- a/tests/vitest/boot-auto-open.test.ts
+++ b/tests/vitest/boot-auto-open.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Boot flow: should-auto-open decision matrix.
+ *
+ * Regression for the "Edit Post in admin bar opens nothing" bug — the
+ * portal-redirect-with-target case used to be indistinguishable from
+ * a bare `/desktop-mode/` visit, so users with a saved session lost
+ * the URL they clicked. The intent flag splits the two; this test
+ * locks the matrix in place.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { shouldAutoOpenCurrentPage } from '../../src/boot/auto-open';
+
+describe( 'shouldAutoOpenCurrentPage', () => {
+	it( 'opens when not from the portal (direct admin URL)', () => {
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: false,
+				hasSession: true,
+				defaultEnabled: true,
+				isNativeDefault: false,
+			} ),
+		).toBe( true );
+	} );
+
+	it( 'opens when portal redirect carried user intent, even with a saved session', () => {
+		// The bug. Without `fromPortalIntent`, this would suppress.
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				fromPortalIntent: true,
+				hasSession: true,
+				defaultEnabled: true,
+				isNativeDefault: false,
+			} ),
+		).toBe( true );
+	} );
+
+	it( 'opens when portal redirect carried intent and the default is native', () => {
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				fromPortalIntent: true,
+				hasSession: false,
+				defaultEnabled: true,
+				isNativeDefault: true,
+			} ),
+		).toBe( true );
+	} );
+
+	it( 'suppresses on a bare portal visit when a session is already saved', () => {
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				fromPortalIntent: false,
+				hasSession: true,
+				defaultEnabled: true,
+				isNativeDefault: false,
+			} ),
+		).toBe( false );
+	} );
+
+	it( 'suppresses on a bare portal visit when the default window is disabled', () => {
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				fromPortalIntent: false,
+				hasSession: false,
+				defaultEnabled: false,
+				isNativeDefault: false,
+			} ),
+		).toBe( false );
+	} );
+
+	it( 'suppresses on a bare portal visit when the default is a native window', () => {
+		// The shell opens the native default through `nativeWindows.openById`
+		// after the manager/registry are wired — auto-open would race it
+		// to an admin URL that isn't the user's choice.
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				fromPortalIntent: false,
+				hasSession: false,
+				defaultEnabled: true,
+				isNativeDefault: true,
+			} ),
+		).toBe( false );
+	} );
+
+	it( 'opens on a bare portal visit when there is no session and the default is a normal URL', () => {
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				fromPortalIntent: false,
+				hasSession: false,
+				defaultEnabled: true,
+				isNativeDefault: false,
+			} ),
+		).toBe( true );
+	} );
+
+	it( 'treats an undefined intent flag as falsy (older payloads)', () => {
+		// Pre-0.8.4 payloads omit `fromPortalIntent` entirely; behaviour
+		// must match the previous "suppress on session" rule so an
+		// upgrade-in-flight doesn't regress.
+		expect(
+			shouldAutoOpenCurrentPage( {
+				fromPortal: true,
+				hasSession: true,
+				defaultEnabled: true,
+				isNativeDefault: false,
+			} ),
+		).toBe( false );
+	} );
+} );


### PR DESCRIPTION
### What's broken

You're reading a post on the front end with Desktop Mode turned on. You click **Edit Post** in the admin bar (or any other deep link into wp-admin — a bookmark to Plugins, a notification email, anything).

Instead of the desktop opening a window with Gutenberg, you get *just* the desktop — your saved windows are restored, the URL bar shows the post-edit link as a teaser, but the page you actually asked for never appears.

## Why it happens

Desktop Mode treats `/desktop-mode/` as the canonical address. To keep that promise, any plain `/wp-admin/...` URL is bounced through the portal first, then forwarded back into the admin with a `desktop_mode_portal=1` flag. The shell sees that flag and knows "this request came through the portal."

The problem: the boot logic used the same flag to mean two different things at once:

1. "The portal stamped this URL" (a technicality — happens on every entry).
2. "Don't disturb the user's restored windows by auto-opening anything."

Those overlap most of the time — but they're not the same thing. When you click *Edit Post*, the portal still forwards you, *but it forwards you to the page you asked for*. The shell couldn't tell the difference between "user typed `/desktop-mode/` and the portal picked a default landing page" and "user clicked a specific link and the portal preserved it." Anyone with a saved session got the former behaviour for every navigation, so the click was silently swallowed.

## The fix

Split the one signal into two:

- **`fromPortal`** — same as before. "This request went through the portal." Used for stamping the address bar back to `/desktop-mode/`.
- **`fromPortalIntent`** — new. "The portal forwarded here *because* the user supplied a specific URL." Set only when a `?target=` survived the redirect chain (admin-bar clicks, bookmarks, notification links, etc.).

The boot flow now opens the requested page whenever intent is present, regardless of whether there's a saved session. Bare `/desktop-mode/` visits keep the old behaviour — your stack is restored exactly as you left it, nothing is forced on top.

## Knock-on effects

- Bookmarks to specific admin pages work again. Activate, edit, settings deep links — anything you'd reach via a URL — opens in a window even if you already had other windows saved.
- Email notifications that link into wp-admin work again for the same reason.
- A plain visit to `/desktop-mode/` still does what it did: restore your last session, leave it alone.
- Older builds of the shell don't break — the new flag is optional, and when it's missing the previous behaviour kicks in.

## Where to look in the code

- `includes/portal.php` — adds the new flag to the redirect when a `target` was supplied.
- `includes/render/assets.php` — strips both portal flags from `currentPage`, surfaces `fromPortalIntent` in the shell config.
- `src/boot/auto-open.ts` — small extracted helper that decides whether to auto-open. Lives on its own so the five-case decision matrix can be tested directly.
- `src/desktop.ts` — calls the helper; the comment block above the call documents the matrix in plain English.

## Tests

- **PHPUnit**: bare-visit redirects omit the intent flag; target-driven redirects carry it; invalid targets fall back without the intent flag; an already-tagged target doesn't double-stamp. The shell-config filter exposes the new boolean in both `true` and `false` shapes.
- **Vitest**: the eight rows of the auto-open decision matrix are pinned, including the regression case (portal + intent + session ⇒ open).
- Full suites green: 666 PHPUnit, 1133 Vitest.

Closes #170

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-193-80867bf4ddc55c5225c21d3e4be4848aa0a80b79.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->