### PR TITLE
Cross-page admin-link clicks: state, destructive actions, referer hint

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1570,6 +1570,61 @@ window.wp.desktop.listCommands().forEach( ( c ) => console.log( `/${ c.slug } �
 
 ---
 
+### `registerDestructiveAdminAction( entry )` — Stable  *(since 0.8.4)*
+
+Mark a wp-admin URL pattern as a **destructive (redirect-back) action** so a click on that URL navigates the *source* iframe in place instead of opening a new window. The same UX vanilla wp-admin gives for Trash / Untrash / Delete row actions — the row disappears, the list refreshes with an "Undo" notice on the same screen.
+
+Built-ins are pinned with no opt-in: Core's `trash`, `untrash`, `delete` on posts plus the comment-moderation set (`spamcomment`, `unspamcomment`, `trashcomment`, `untrashcomment`, `deletecomment`, `approvecomment`, `unapprovecomment`). Register a predicate for any plugin-specific equivalent.
+
+```javascript
+const unregister = window.wp.desktop.registerDestructiveAdminAction( {
+    id: 'woocommerce/trash-order',
+    matches: ( _url, parsed ) =>
+        parsed.pathname.endsWith( '/admin.php' ) &&
+        parsed.searchParams.get( 'page' ) === 'wc-orders' &&
+        parsed.searchParams.get( 'action' ) === 'trash' &&
+        parsed.searchParams.has( '_wpnonce' ),
+} );
+```
+
+**Entry shape:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `string` | Globally-unique, recommended `<plugin>/<action-slug>`. Re-registering the same id replaces the prior entry. |
+| `matches` | `( url: string, parsed: URL ) => boolean` | Predicate. Receives the raw URL string + a parsed URL object (the dispatcher parses once and shares). Return `true` to claim the URL. Predicates SHOULD also check for nonce presence — a URL with the action name but no nonce won't perform a side-effect on the server, and the in-place reload would be wasted. |
+
+**Returns:** an unregister function. Calling it removes the entry by id. `unregisterDestructiveAdminAction( id )` does the same.
+
+**When not to register:**
+- Built-ins are already covered — no need for `trash` / `untrash` / `delete` on Core post types.
+- Actions that genuinely *navigate* to a different screen (Edit, Settings deep links) should NOT be marked destructive — let them open a new window.
+- Bulk-action POSTs handled via `<form>` submission are out of scope (forms don't go through this dispatcher).
+
+**Cross-bundle:** the registry routes through `wp.desktop.createSharedStore`. A `register…` call from a plugin's own Vite IIFE is visible to the dispatcher (which runs inside the shell's `window-system` bundle). See `AGENTS.md` § "Cross-bundle state".
+
+---
+
+### `unregisterDestructiveAdminAction( id )` — Stable  *(since 0.8.4)*
+
+Remove a previously registered predicate. Idempotent — no-op when the id is unknown.
+
+```javascript
+window.wp.desktop.unregisterDestructiveAdminAction( 'woocommerce/trash-order' );
+```
+
+---
+
+### `listDestructiveAdminActions()` — Stable  *(since 0.8.4)*
+
+Snapshot (defensive copy) of every plugin-registered destructive-admin-action predicate. Built-in Core whitelist entries are NOT included — they're not registry entries.
+
+```javascript
+window.wp.desktop.listDestructiveAdminActions().forEach( ( e ) => console.log( e.id ) );
+```
+
+---
+
 ### `wp.desktop.ai.ask( query, opts? )` — Experimental  *(since 0.17.0)*
 
 Programmatic access to the AI Copilot — same endpoint the built-in overlay talks to. Resolves to an `AskResult`; rejects on network errors, HTTP failures, or abort.

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -63,6 +63,11 @@ import {
 	unregisterCommand,
 } from '../commands';
 import {
+	listDestructiveAdminActions,
+	registerDestructiveAdminAction,
+	unregisterDestructiveAdminAction,
+} from '../destructive-admin-actions';
+import {
 	listSettingsTabs,
 	registerSettingsTab,
 	unregisterSettingsTab,
@@ -154,7 +159,10 @@ export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'onWindow', 'loadVendorScript', 'getWallpaperSurfaces', 'registerModule',
 	'loadModules', 'whenReady', 'ready', 'isReady', 'setDefaultWindow',
 	'refreshMenu', 'config', 'ai', 'dragBridge', 'dragManager', 'registerCommand',
-	'unregisterCommand', 'listCommands', 'registerSettingsTab',
+	'unregisterCommand', 'listCommands',
+	'registerDestructiveAdminAction', 'unregisterDestructiveAdminAction',
+	'listDestructiveAdminActions',
+	'registerSettingsTab',
 	'unregisterSettingsTab', 'listSettingsTabs',
 	'registerDockRailRenderer', 'unregisterDockRailRenderer', 'listDockRailRenderers',
 	'openOsSettings', 'getOsSettings', 'subscribeOsSettings', 'updateOsSettings',
@@ -306,6 +314,9 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 		registerCommand,
 		unregisterCommand,
 		listCommands,
+		registerDestructiveAdminAction,
+		unregisterDestructiveAdminAction,
+		listDestructiveAdminActions,
 		registerSettingsTab,
 		unregisterSettingsTab,
 		listSettingsTabs,

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -22,6 +22,7 @@ import {
 	tryNativeUrlRemap,
 } from './native-url-remap';
 import { bindAdminLinkDispatch } from './window/iframe-bridge';
+import type { DestructiveAdminActionEntry } from './destructive-admin-actions';
 // Tile-decoration helpers and the dock-selector registry live in
 // `src/dock-helpers.ts` — `src/api/facade.ts` is the only consumer
 // in this bundle since 0.8.1.
@@ -723,6 +724,57 @@ export interface WpDesktopPublicApi {
 	unregisterCommand: ( slug: string ) => void;
 	/** Snapshot of all currently registered commands. @since 0.14.0 */
 	listCommands: () => DesktopCommand[];
+	/**
+	 * Register a predicate that classifies an admin URL as a
+	 * "destructive admin action" — i.e. a click that should navigate
+	 * the SOURCE iframe in place (vanilla wp-admin's "row disappears
+	 * + Undo notice on the same list" UX) instead of opening a new
+	 * window.
+	 *
+	 * Built-ins covered with no opt-in: Core's `trash`, `untrash`,
+	 * `delete` on posts and the comment-moderation set
+	 * (`spamcomment`, `trashcomment`, etc.). Plugin authors with a
+	 * custom redirect-back action register a predicate so their
+	 * URL stays in place too.
+	 *
+	 * ```js
+	 * const unregister = wp.desktop.registerDestructiveAdminAction( {
+	 *     id: 'woocommerce/trash-order',
+	 *     matches: ( _url, parsed ) =>
+	 *         parsed.pathname.endsWith( '/admin.php' ) &&
+	 *         parsed.searchParams.get( 'page' ) === 'wc-orders' &&
+	 *         parsed.searchParams.get( 'action' ) === 'trash' &&
+	 *         parsed.searchParams.has( '_wpnonce' ),
+	 * } );
+	 * ```
+	 *
+	 * Predicates SHOULD assert nonce presence — a URL with the
+	 * action name but no nonce won't perform a side-effect on the
+	 * server, and the in-place nav would just be a wasted reload.
+	 *
+	 * Returns an unregister function. Calling
+	 * `unregisterDestructiveAdminAction( id )` does the same.
+	 *
+	 * @since 0.8.4
+	 */
+	registerDestructiveAdminAction: (
+		entry: DestructiveAdminActionEntry,
+	) => () => void;
+	/**
+	 * Remove a previously registered destructive-admin-action
+	 * predicate. No-op when the id is unknown.
+	 *
+	 * @since 0.8.4
+	 */
+	unregisterDestructiveAdminAction: ( id: string ) => void;
+	/**
+	 * Snapshot of every plugin-registered destructive-admin-action
+	 * predicate. Built-ins (`trash`, `untrash`, `delete`, …) are
+	 * NOT included — they have no `id` and aren't registry entries.
+	 *
+	 * @since 0.8.4
+	 */
+	listDestructiveAdminActions: () => DestructiveAdminActionEntry[];
 	/**
 	 * Register a tab in the OS Settings window.
 	 *

--- a/src/destructive-admin-actions.test.ts
+++ b/src/destructive-admin-actions.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the destructive-admin-action registry.
+ *
+ * Covers register / unregister / replace / list / match plus the
+ * cross-bundle store contract (the registry's whole reason for
+ * existence — see file header).
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import {
+	registerDestructiveAdminAction,
+	unregisterDestructiveAdminAction,
+	listDestructiveAdminActions,
+	matchDestructiveAdminAction,
+	_resetDestructiveAdminActionsForTests,
+	type DestructiveAdminActionEntry,
+} from './destructive-admin-actions';
+
+beforeEach( () => {
+	_resetDestructiveAdminActionsForTests();
+} );
+
+function parse( href: string ): URL {
+	return new URL( href, 'http://example.test' );
+}
+
+describe( 'destructive-admin-actions: register / unregister', () => {
+	test( 'registered predicate matches its URL', () => {
+		registerDestructiveAdminAction( {
+			id: 'plugin/foo',
+			matches: ( _url, parsed ) =>
+				parsed.searchParams.get( 'action' ) === 'foo' &&
+				parsed.searchParams.has( '_wpnonce' ),
+		} );
+
+		const url = 'http://example.test/wp-admin/admin.php?page=p&action=foo&_wpnonce=abc';
+		expect( matchDestructiveAdminAction( url, parse( url ) ) ).toBe(
+			'plugin/foo',
+		);
+	} );
+
+	test( 'predicate that returns false leaves the URL unclaimed', () => {
+		registerDestructiveAdminAction( {
+			id: 'plugin/foo',
+			matches: () => false,
+		} );
+
+		const url = 'http://example.test/wp-admin/admin.php?action=foo&_wpnonce=abc';
+		expect( matchDestructiveAdminAction( url, parse( url ) ) ).toBeNull();
+	} );
+
+	test( 'unregister removes the predicate', () => {
+		registerDestructiveAdminAction( {
+			id: 'plugin/foo',
+			matches: () => true,
+		} );
+		expect( listDestructiveAdminActions() ).toHaveLength( 1 );
+
+		unregisterDestructiveAdminAction( 'plugin/foo' );
+		expect( listDestructiveAdminActions() ).toHaveLength( 0 );
+
+		const url = 'http://example.test/wp-admin/admin.php?action=foo';
+		expect( matchDestructiveAdminAction( url, parse( url ) ) ).toBeNull();
+	} );
+
+	test( 'returned unregister function removes the entry', () => {
+		const unregister = registerDestructiveAdminAction( {
+			id: 'plugin/foo',
+			matches: () => true,
+		} );
+		expect( listDestructiveAdminActions() ).toHaveLength( 1 );
+
+		unregister();
+		expect( listDestructiveAdminActions() ).toHaveLength( 0 );
+	} );
+
+	test( 're-registering the same id replaces the prior entry', () => {
+		const first = vi.fn().mockReturnValue( false );
+		const second = vi.fn().mockReturnValue( true );
+
+		registerDestructiveAdminAction( { id: 'plugin/foo', matches: first } );
+		registerDestructiveAdminAction( { id: 'plugin/foo', matches: second } );
+
+		expect( listDestructiveAdminActions() ).toHaveLength( 1 );
+
+		const url = 'http://example.test/wp-admin/admin.php?action=foo';
+		expect( matchDestructiveAdminAction( url, parse( url ) ) ).toBe(
+			'plugin/foo',
+		);
+		expect( first ).not.toHaveBeenCalled();
+		expect( second ).toHaveBeenCalled();
+	} );
+
+	test( 'first registered predicate that claims the URL wins', () => {
+		registerDestructiveAdminAction( {
+			id: 'plugin/first',
+			matches: () => true,
+		} );
+		registerDestructiveAdminAction( {
+			id: 'plugin/second',
+			matches: () => true,
+		} );
+
+		const url = 'http://example.test/wp-admin/admin.php?action=foo';
+		expect( matchDestructiveAdminAction( url, parse( url ) ) ).toBe(
+			'plugin/first',
+		);
+	} );
+
+	test( 'malformed entry returns a no-op unregister, registry unchanged', () => {
+		// Missing matches.
+		const u1 = registerDestructiveAdminAction(
+			{ id: 'plugin/bad' } as unknown as DestructiveAdminActionEntry,
+		);
+		// Empty id.
+		const u2 = registerDestructiveAdminAction( {
+			id: '   ',
+			matches: () => true,
+		} );
+		// Non-function matches.
+		const u3 = registerDestructiveAdminAction( {
+			id: 'plugin/bad-fn',
+			matches: 'nope' as unknown as DestructiveAdminActionEntry[ 'matches' ],
+		} );
+
+		expect( listDestructiveAdminActions() ).toHaveLength( 0 );
+		expect( () => {
+			u1();
+			u2();
+			u3();
+		} ).not.toThrow();
+	} );
+
+	test( 'throwing predicate is logged but does not abort the walk', () => {
+		const consoleSpy = vi
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+
+		registerDestructiveAdminAction( {
+			id: 'plugin/throws',
+			matches: () => {
+				throw new Error( 'boom' );
+			},
+		} );
+		registerDestructiveAdminAction( {
+			id: 'plugin/good',
+			matches: () => true,
+		} );
+
+		const url = 'http://example.test/wp-admin/admin.php?action=foo';
+		expect( matchDestructiveAdminAction( url, parse( url ) ) ).toBe(
+			'plugin/good',
+		);
+		expect( consoleSpy ).toHaveBeenCalledWith(
+			expect.stringContaining( 'plugin/throws' ),
+			expect.any( Error ),
+		);
+		consoleSpy.mockRestore();
+	} );
+
+	test( 'listDestructiveAdminActions returns a defensive copy', () => {
+		registerDestructiveAdminAction( {
+			id: 'plugin/foo',
+			matches: () => true,
+		} );
+		const snapshot = listDestructiveAdminActions();
+		snapshot.length = 0;
+		expect( listDestructiveAdminActions() ).toHaveLength( 1 );
+	} );
+
+	test( 'walker passes both raw URL string and parsed URL to the predicate', () => {
+		const matches = vi.fn().mockReturnValue( true );
+		registerDestructiveAdminAction( { id: 'plugin/foo', matches } );
+
+		const raw = 'http://example.test/wp-admin/admin.php?action=foo';
+		matchDestructiveAdminAction( raw, parse( raw ) );
+
+		expect( matches ).toHaveBeenCalledTimes( 1 );
+		const [ urlArg, parsedArg ] = matches.mock.calls[ 0 ];
+		expect( urlArg ).toBe( raw );
+		expect( parsedArg ).toBeInstanceOf( URL );
+		expect( parsedArg.searchParams.get( 'action' ) ).toBe( 'foo' );
+	} );
+} );
+
+describe( 'destructive-admin-actions: cross-bundle store', () => {
+	// The registry routes through `createSharedStore` so a write
+	// from bundle A is visible to bundle B. Vitest collapses both
+	// imports into the same module, so we can't simulate the
+	// two-bundle path directly — but we CAN pin the slot key, which
+	// is the runtime contract that makes the cross-bundle sharing
+	// work.
+	test( 'state lives on the shared-stores slot under the documented key', () => {
+		registerDestructiveAdminAction( {
+			id: 'plugin/foo',
+			matches: () => true,
+		} );
+		const slot = (
+			window as unknown as {
+				__desktopModeSharedStores?: Map< string, unknown >;
+			}
+		).__desktopModeSharedStores;
+		expect( slot ).toBeDefined();
+		expect( slot?.has( 'desktop-mode/destructive-admin-actions' ) ).toBe(
+			true,
+		);
+	} );
+} );

--- a/src/destructive-admin-actions.ts
+++ b/src/destructive-admin-actions.ts
@@ -1,0 +1,197 @@
+/**
+ * Destructive-admin-action registry.
+ *
+ * The cross-page admin-link dispatcher (`handleCrossPageAdminLink`
+ * in `src/window/iframe-bridge.ts`) classifies admin-internal clicks
+ * into three buckets:
+ *
+ *   1. Native-window remap — opens a registered native window
+ *      (Posts, Pages, Plugins, …) and closes the source iframe.
+ *   2. Destructive action — navigates the SOURCE iframe in place
+ *      so vanilla wp-admin's "row disappears + Undo notice on the
+ *      same list" behavior is preserved.
+ *   3. Cross-page open — spawns a new window for a genuine
+ *      different-page navigation (Edit screen, deep settings link).
+ *
+ * Bucket 2 is what this registry feeds: a list of predicates +
+ * a built-in whitelist of Core action names (Trash, Untrash, Delete
+ * on posts; the spam / approve / trash / unspam set on comments).
+ * Plugin authors that introduce their own redirect-back actions
+ * (e.g. `admin.php?page=my-plugin&action=my-trash&_wpnonce=…`)
+ * register a predicate here so their action stays in place too,
+ * matching the UX every wp-admin user already has muscle memory for.
+ *
+ * Why a registry instead of "any URL with `_wpnonce`": plenty of
+ * legitimate cross-page navigations also carry nonces (e.g.
+ * `update-core.php?action=upgrade-core&_wpnonce=…`,
+ * `users.php?action=adduser&_wpnonce=…`). Treating every nonce'd URL
+ * as redirect-back would break the windowing UX for them. The
+ * registry keeps the policy explicit and per-plugin.
+ *
+ * Cross-bundle state: the registry routes through
+ * {@link createSharedStore} (key `desktop-mode/destructive-admin-actions`).
+ * The `iframe-bridge.ts` module that walks the predicates lives in
+ * the `window-system` Vite bundle; the main `desktop.ts` bundle is
+ * where plugins typically run their `register*` calls — so a plain
+ * module-level array would give each bundle its own private copy and
+ * silently drop every registration. See `AGENTS.md` §
+ * "Cross-bundle state — `wp.desktop.createSharedStore`".
+ *
+ * @since 0.8.4
+ */
+
+import { createSharedStore } from './shared-store';
+
+/**
+ * Predicate function shape — given the raw URL string + a parsed
+ * URL object (the dispatcher parses once and shares for ergonomics),
+ * return `true` to claim the URL as a destructive action.
+ *
+ * Predicates SHOULD also check for nonce presence — a `?action=foo`
+ * without a nonce won't actually perform a side-effect on the
+ * server (WP / plugin handlers reject it via `check_admin_referer`).
+ * Including the nonce check disambiguates from action names that
+ * plugins might overload for non-destructive flows.
+ */
+export type DestructiveAdminActionPredicate = (
+	url: string,
+	parsed: URL,
+) => boolean;
+
+/**
+ * A single registry entry. The `id` is used to dedupe re-registrations
+ * (same id replaces the prior entry) and to identify the entry on
+ * unregister. Predicate-only access via {@link matches}.
+ */
+export interface DestructiveAdminActionEntry {
+	/**
+	 * Globally-unique id. Recommended format
+	 * `<plugin>/<action-slug>` so two plugins won't collide.
+	 */
+	id: string;
+	/**
+	 * The classifier. The walker stops at the first match in
+	 * registration order, so order across plugins follows
+	 * registration order.
+	 */
+	matches: DestructiveAdminActionPredicate;
+}
+
+interface RegistryState {
+	entries: DestructiveAdminActionEntry[];
+}
+
+const store = createSharedStore< RegistryState >(
+	'desktop-mode/destructive-admin-actions',
+	() => ( { entries: [] } ),
+);
+
+/**
+ * Register (or replace) a destructive-admin-action predicate.
+ *
+ * @example
+ * ```ts
+ * wp.desktop.registerDestructiveAdminAction( {
+ *     id: 'woocommerce/trash-order',
+ *     matches: ( _url, parsed ) =>
+ *         parsed.pathname.endsWith( '/admin.php' ) &&
+ *         parsed.searchParams.get( 'page' ) === 'wc-orders' &&
+ *         parsed.searchParams.get( 'action' ) === 'trash' &&
+ *         parsed.searchParams.has( '_wpnonce' ),
+ * } );
+ * ```
+ *
+ * @since 0.8.4
+ *
+ * @param entry Registry entry. Returns a no-op unregister when the
+ *              entry is malformed (missing id / matches), so callers
+ *              can store the return value unconditionally.
+ * @return Unregister function. Calling it removes the entry by id;
+ *         subsequent calls are no-ops.
+ */
+export function registerDestructiveAdminAction(
+	entry: DestructiveAdminActionEntry,
+): () => void {
+	if ( ! entry || typeof entry.id !== 'string' || entry.id.trim() === '' ) {
+		return () => {};
+	}
+	if ( typeof entry.matches !== 'function' ) {
+		return () => {};
+	}
+
+	const entries = store.state.entries;
+	const idx = entries.findIndex( ( e ) => e.id === entry.id );
+	if ( idx >= 0 ) {
+		entries.splice( idx, 1 );
+	}
+	entries.push( entry );
+
+	return () => unregisterDestructiveAdminAction( entry.id );
+}
+
+/**
+ * Remove a destructive-admin-action entry by id. No-op when no entry
+ * matches.
+ *
+ * @since 0.8.4
+ *
+ * @param id Entry id passed to {@link registerDestructiveAdminAction}.
+ */
+export function unregisterDestructiveAdminAction( id: string ): void {
+	const entries = store.state.entries;
+	const idx = entries.findIndex( ( e ) => e.id === id );
+	if ( idx >= 0 ) {
+		entries.splice( idx, 1 );
+	}
+}
+
+/**
+ * Defensive snapshot of the current registry — mutating the array
+ * does NOT affect the registry. For debugging + the public API's
+ * `list…` reflection method.
+ *
+ * @internal
+ */
+export function listDestructiveAdminActions(): DestructiveAdminActionEntry[] {
+	return store.state.entries.slice();
+}
+
+/**
+ * Walk the registry looking for a matching predicate. Returns the
+ * first matching entry's id, or `null`. Used by the dispatcher only
+ * — callers outside the bridge should generally not need this.
+ *
+ * @internal
+ */
+export function matchDestructiveAdminAction(
+	url: string,
+	parsed: URL,
+): string | null {
+	for ( const entry of store.state.entries ) {
+		try {
+			if ( entry.matches( url, parsed ) ) {
+				return entry.id;
+			}
+		} catch ( err ) {
+			// One bad predicate shouldn't shadow the rest. The
+			// throw is the plugin author's bug; surface it but
+			// keep walking.
+			// eslint-disable-next-line no-console
+			console.warn(
+				`[desktop-mode] destructive-action predicate threw for "${ entry.id }":`,
+				err,
+			);
+		}
+	}
+	return null;
+}
+
+/**
+ * Test-only escape hatch — clears every registered entry. Used by
+ * Vitest setups to keep tests independent.
+ *
+ * @internal
+ */
+export function _resetDestructiveAdminActionsForTests(): void {
+	store.state.entries.length = 0;
+}

--- a/src/native-url-remap.ts
+++ b/src/native-url-remap.ts
@@ -27,6 +27,7 @@
  */
 
 import type { OsSettingsSnapshot } from './settings/registry';
+import { createSharedStore } from './shared-store';
 
 /**
  * A single URL → native-window remap.
@@ -74,8 +75,24 @@ interface RemapDeps {
 	adminUrl: string;
 }
 
-const remaps: NativeUrlRemap[] = [];
-let deps: RemapDeps | null = null;
+// Routed through `createSharedStore` so the registry registered from
+// the MAIN `desktop.ts` bundle is visible to the WINDOW-SYSTEM bundle
+// that owns the `Window` class (`handleWindowMessage` calls
+// `tryNativeUrlRemap` from inside the window-system bundle). A plain
+// module-level array here would give each bundle its own private
+// copy: `registerNativeUrlRemap()` in main would push into one array,
+// `tryNativeUrlRemap()` in window-system would walk a different empty
+// one, and every cross-page admin-link click that should remap to a
+// native window would silently fall through. See `AGENTS.md`
+// § "Cross-bundle state — `wp.desktop.createSharedStore`".
+interface RemapRegistryState {
+	remaps: NativeUrlRemap[];
+	deps: RemapDeps | null;
+}
+const remapStore = createSharedStore< RemapRegistryState >(
+	'desktop-mode/native-url-remap',
+	() => ( { remaps: [], deps: null } ),
+);
 
 /**
  * Wire the registry to the live shell — called once from `desktop.ts`
@@ -84,7 +101,7 @@ let deps: RemapDeps | null = null;
  * @internal
  */
 export function bindNativeUrlRemap( bound: RemapDeps ): void {
-	deps = bound;
+	remapStore.state.deps = bound;
 }
 
 /**
@@ -108,6 +125,7 @@ export function registerNativeUrlRemap( entry: NativeUrlRemap ): () => void {
 
 	// Replace any existing entry with the same id — mirrors WordPress's
 	// `register_*` semantics so a hot-reloaded bundle doesn't double up.
+	const remaps = remapStore.state.remaps;
 	const existingIdx = remaps.findIndex( ( r ) => r.id === entry.id );
 	if ( existingIdx >= 0 ) {
 		remaps.splice( existingIdx, 1 );
@@ -121,6 +139,7 @@ export function registerNativeUrlRemap( entry: NativeUrlRemap ): () => void {
  * Remove a remap by id.
  */
 export function unregisterNativeUrlRemap( id: string ): void {
+	const remaps = remapStore.state.remaps;
 	const i = remaps.findIndex( ( r ) => r.id === id );
 	if ( i >= 0 ) {
 		remaps.splice( i, 1 );
@@ -134,7 +153,7 @@ export function unregisterNativeUrlRemap( id: string ): void {
  * @internal
  */
 export function listNativeUrlRemaps(): NativeUrlRemap[] {
-	return remaps.slice();
+	return remapStore.state.remaps.slice();
 }
 
 /**
@@ -154,6 +173,7 @@ export function listNativeUrlRemaps(): NativeUrlRemap[] {
  * @return Native window id the URL maps to, or `null`.
  */
 export function resolveNativeUrlRemap( url: string ): string | null {
+	const { deps, remaps } = remapStore.state;
 	if ( ! deps || ! url ) {
 		return null;
 	}
@@ -191,6 +211,7 @@ export function resolveNativeUrlRemap( url: string ): string | null {
  * @return Whether the URL was remapped to a native window.
  */
 export function tryNativeUrlRemap( url: string ): boolean {
+	const { deps, remaps } = remapStore.state;
 	if ( ! deps || ! url ) {
 		return false;
 	}
@@ -234,6 +255,6 @@ export function tryNativeUrlRemap( url: string ): boolean {
  * @internal
  */
 export function _resetNativeUrlRemap(): void {
-	remaps.length = 0;
-	deps = null;
+	remapStore.state.remaps.length = 0;
+	remapStore.state.deps = null;
 }

--- a/src/window/iframe-bridge.test.ts
+++ b/src/window/iframe-bridge.test.ts
@@ -7,6 +7,10 @@
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { bindAdminLinkDispatch, handleWindowMessage } from './iframe-bridge';
+import {
+	_resetDestructiveAdminActionsForTests,
+	registerDestructiveAdminAction,
+} from '../destructive-admin-actions';
 import { HOOKS } from '../hooks';
 import type { Window } from './index';
 import {
@@ -379,6 +383,251 @@ describe( 'iframe-bridge: desktop-mode-iframe-admin-link', () => {
 
 		expect( openWindow ).not.toHaveBeenCalled();
 		expect( assignSpy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'destructive action (trash) navigates the source iframe in place, not a new window', () => {
+		// Vanilla wp-admin treats Trash / Untrash / Delete row
+		// actions as in-place: the list refreshes with the
+		// "1 post moved to the Trash. Undo." notice. Reproducing
+		// that here keeps the source list authoritative (avoids
+		// a stale row) AND lets WP's `wp_get_referer()` resolve
+		// to the source page (Referer is the iframe's current
+		// URL during `location.assign`, not the parent shell's).
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( { id: 'edit-php' } );
+
+		const target =
+			window.location.origin +
+			'/wp-admin/post.php?post=42&action=trash&_wpnonce=abc&desktop_mode_chromeless=1';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( assignSpy ).toHaveBeenCalledWith( target );
+		expect( openWindow ).not.toHaveBeenCalled();
+		expect( win.close ).not.toHaveBeenCalled();
+	} );
+
+	test( 'destructive action without a nonce still opens a new window', () => {
+		// `?action=trash` with no `_wpnonce` is meaningless to WP
+		// (`check_admin_referer` would reject it). The action-name
+		// match alone isn't a reliable signal — a plugin could
+		// reuse the word for a non-destructive flow. The nonce
+		// presence is the actual disambiguator.
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( { id: 'edit-php' } );
+
+		const target =
+			window.location.origin +
+			'/wp-admin/post.php?post=42&action=trash';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		expect( assignSpy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Edit row action (no nonce) opens a new window — destructive whitelist does not over-claim', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( { id: 'edit-php' } );
+
+		const target =
+			window.location.origin +
+			'/wp-admin/post.php?post=42&action=edit';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		expect( assignSpy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'plugin-registered destructive predicate keeps cross-page URL in place', () => {
+		// The extension point: an action name OUTSIDE the built-in
+		// whitelist gets in-place behavior because a plugin
+		// registered a predicate for it.
+		_resetDestructiveAdminActionsForTests();
+		registerDestructiveAdminAction( {
+			id: 'test/woo-trash-order',
+			matches: ( _url, parsed ) =>
+				parsed.pathname.endsWith( '/admin.php' ) &&
+				parsed.searchParams.get( 'page' ) === 'wc-orders' &&
+				parsed.searchParams.get( 'action' ) === 'trash' &&
+				parsed.searchParams.has( '_wpnonce' ),
+		} );
+
+		try {
+			const { openWindow } = bindFakeDispatcher();
+			const { win, assignSpy } = mockAdminWindow( {
+				id: 'admin-php-page-wc-orders',
+			} );
+			( win.config as unknown as { url: string } ).url =
+				window.location.origin + '/wp-admin/admin.php?page=wc-orders';
+
+			const target =
+				window.location.origin +
+				'/wp-admin/admin.php?page=wc-orders&action=trash&order=99&_wpnonce=woo';
+			postToWindow( win, {
+				type: 'desktop-mode-iframe-admin-link',
+				url: target,
+			} );
+
+			expect( openWindow ).not.toHaveBeenCalled();
+			expect( assignSpy ).toHaveBeenCalledTimes( 1 );
+			const navigated = new URL( String( assignSpy.mock.calls[ 0 ][ 0 ] ) );
+			// Still goes through `stampSourceReferer` for the same
+			// Referrer-Policy reasons as built-in destructive actions.
+			expect( navigated.searchParams.get( '_wp_http_referer' ) ).toBe(
+				'/wp-admin/admin.php?page=wc-orders',
+			);
+			expect( navigated.searchParams.get( 'action' ) ).toBe( 'trash' );
+		} finally {
+			_resetDestructiveAdminActionsForTests();
+		}
+	} );
+
+	test( 'plugin-registered predicate that returns false leaves the URL on the cross-page path', () => {
+		_resetDestructiveAdminActionsForTests();
+		registerDestructiveAdminAction( {
+			id: 'test/never-matches',
+			matches: () => false,
+		} );
+
+		try {
+			const { openWindow } = bindFakeDispatcher();
+			const { win, assignSpy } = mockAdminWindow( { id: 'edit-php' } );
+
+			const target =
+				window.location.origin +
+				'/wp-admin/admin.php?page=foo&action=export&_wpnonce=zzz';
+			postToWindow( win, {
+				type: 'desktop-mode-iframe-admin-link',
+				url: target,
+			} );
+
+			expect( openWindow ).toHaveBeenCalledTimes( 1 );
+			expect( assignSpy ).not.toHaveBeenCalled();
+		} finally {
+			_resetDestructiveAdminActionsForTests();
+		}
+	} );
+
+	test( 'comment moderation action (spam) navigates in place', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( { id: 'edit-comments-php' } );
+
+		const target =
+			window.location.origin +
+			'/wp-admin/comment.php?action=spamcomment&c=99&_wpnonce=xyz';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( assignSpy ).toHaveBeenCalledWith( target );
+		expect( openWindow ).not.toHaveBeenCalled();
+	} );
+
+	test( 'cross-page open stamps `_wp_http_referer` from the source window URL', () => {
+		// Safety-net regression: even with the destructive-action
+		// short-circuit in place, plugin-specific side-effect URLs
+		// that DON'T match the whitelist will still open a new
+		// window — and there a fresh iframe has no prior in-frame
+		// navigation, so the browser's `Referer` header on the
+		// destination request is the desktop shell's URL. Threading
+		// `_wp_http_referer` makes `wp_get_referer()` resolve to the
+		// page the user clicked from, preventing post-action
+		// redirects from bouncing to whatever URL the shell page
+		// happens to be on.
+		const { openWindow } = bindFakeDispatcher();
+		const { win } = mockAdminWindow( { id: 'edit-php' } );
+		( win.config as unknown as { url: string } ).url =
+			window.location.origin + '/wp-admin/edit.php?desktop_mode_chromeless=1';
+
+		// Cross-page URL with a nonce but an action name OUTSIDE
+		// the destructive whitelist — represents a plugin's custom
+		// side-effect link.
+		const target =
+			window.location.origin +
+			'/wp-admin/admin.php?page=my-plugin&action=custom-export&_wpnonce=abc';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		const openedUrl = String( openWindow.mock.calls[ 0 ][ 0 ].url );
+		const parsed = new URL( openedUrl );
+		// The `desktop_mode_chromeless` flag is stripped from the
+		// referer hint — `wp_get_referer()` consumers pass the
+		// result downstream into further redirects, and a
+		// chromeless-flagged referer would loop the flag into URLs
+		// that shouldn't carry it. The post-redirect preserve
+		// filter (server-side) reattaches it where needed.
+		expect( parsed.searchParams.get( '_wp_http_referer' ) ).toBe(
+			'/wp-admin/edit.php',
+		);
+		// Original action params survive the rewrite.
+		expect( parsed.searchParams.get( 'action' ) ).toBe( 'custom-export' );
+		expect( parsed.searchParams.get( 'page' ) ).toBe( 'my-plugin' );
+	} );
+
+	test( 'destructive action in-place navigation stamps `_wp_http_referer`', () => {
+		// Real-world `Referrer-Policy` headers can downgrade the
+		// browser's `Referer` to just the origin, dropping the path
+		// WP needs to redirect back to the list. The explicit hint
+		// makes the destination resolution deterministic.
+		const { openWindow } = bindFakeDispatcher();
+		const { win, assignSpy } = mockAdminWindow( { id: 'edit-php' } );
+		( win.config as unknown as { url: string } ).url =
+			window.location.origin + '/wp-admin/edit.php?desktop_mode_chromeless=1';
+
+		const target =
+			window.location.origin +
+			'/wp-admin/post.php?post=42&action=trash&_wpnonce=abc&desktop_mode_chromeless=1';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( openWindow ).not.toHaveBeenCalled();
+		expect( assignSpy ).toHaveBeenCalledTimes( 1 );
+		const navigatedTo = String( assignSpy.mock.calls[ 0 ][ 0 ] );
+		const parsed = new URL( navigatedTo );
+		expect( parsed.searchParams.get( '_wp_http_referer' ) ).toBe(
+			'/wp-admin/edit.php',
+		);
+		// Action params survive the rewrite.
+		expect( parsed.searchParams.get( 'action' ) ).toBe( 'trash' );
+		expect( parsed.searchParams.get( 'post' ) ).toBe( '42' );
+		expect( parsed.searchParams.get( '_wpnonce' ) ).toBe( 'abc' );
+	} );
+
+	test( 'cross-page open does not double-stamp an existing `_wp_http_referer`', () => {
+		const { openWindow } = bindFakeDispatcher();
+		const { win } = mockAdminWindow( { id: 'edit-php' } );
+		( win.config as unknown as { url: string } ).url =
+			window.location.origin + '/wp-admin/edit.php';
+
+		const target =
+			window.location.origin +
+			'/wp-admin/post.php?post=42&action=trash&_wp_http_referer=%2Fwp-admin%2Fcustom.php';
+		postToWindow( win, {
+			type: 'desktop-mode-iframe-admin-link',
+			url: target,
+		} );
+
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		const openedUrl = String( openWindow.mock.calls[ 0 ][ 0 ].url );
+		const parsed = new URL( openedUrl );
+		// Caller-supplied referer wins — we don't overwrite.
+		expect( parsed.searchParams.get( '_wp_http_referer' ) ).toBe(
+			'/wp-admin/custom.php',
+		);
 	} );
 
 	test( 'unbound deps drops the click without crashing', () => {

--- a/src/window/iframe-bridge.ts
+++ b/src/window/iframe-bridge.ts
@@ -16,6 +16,8 @@ import { addExternalTab } from './tabs';
 import type { Window } from './index';
 import { dispatchFromWindow, markWindowContentReady } from '../window-channels';
 import { tryNativeUrlRemap } from '../native-url-remap';
+import { createSharedStore } from '../shared-store';
+import { matchDestructiveAdminAction } from '../destructive-admin-actions';
 
 /**
  * Origin snapshot taken once at module load. Any subsequent mutation
@@ -91,7 +93,22 @@ interface AdminLinkDispatchDeps {
 	findDockEntry( url: string ): AdminLinkDockEntry | null;
 }
 
-let adminLinkDeps: AdminLinkDispatchDeps | null = null;
+// Routed through `createSharedStore` so the deps set by the MAIN
+// `desktop.ts` bundle are visible to the WINDOW-SYSTEM bundle that
+// owns the `Window` class (and therefore actually runs
+// `handleWindowMessage`). A plain module-level `let` here would give
+// each bundle its own private copy: `bindAdminLinkDispatch()` would
+// set the main bundle's copy while `handleWindowMessage` reads the
+// window-system bundle's still-null copy, and every cross-page admin-
+// link click would silently no-op. See `AGENTS.md` § "Cross-bundle
+// state — `wp.desktop.createSharedStore`".
+interface AdminLinkDepsState {
+	deps: AdminLinkDispatchDeps | null;
+}
+const adminLinkDepsStore = createSharedStore< AdminLinkDepsState >(
+	'desktop-mode/admin-link-deps',
+	() => ( { deps: null } ),
+);
 
 /**
  * Wire the cross-page admin-link dispatcher. Called once from
@@ -103,7 +120,7 @@ let adminLinkDeps: AdminLinkDispatchDeps | null = null;
 export function bindAdminLinkDispatch(
 	deps: AdminLinkDispatchDeps | null,
 ): void {
-	adminLinkDeps = deps;
+	adminLinkDepsStore.state.deps = deps;
 }
 
 /**
@@ -223,12 +240,13 @@ export function handleWindowMessage( win: Window, event: MessageEvent ): void {
 		typeof data.url === 'string' &&
 		data.url !== ''
 	) {
+		const deps = adminLinkDepsStore.state.deps;
 		if ( tryNativeUrlRemap( data.url ) ) {
 			win.close();
-		} else if ( adminLinkDeps ) {
+		} else if ( deps ) {
 			const linkLabel =
 				typeof data.label === 'string' ? data.label : '';
-			handleCrossPageAdminLink( win, data.url, linkLabel, adminLinkDeps );
+			handleCrossPageAdminLink( win, data.url, linkLabel, deps );
 		}
 	}
 
@@ -443,6 +461,153 @@ function handleDesktopNavigate(
  * readers announce the page change). Setting `iframe.src` from the
  * parent overwrites the current entry instead.
  */
+/**
+ * Core wp-admin URL `action=` values that perform a side-effect on
+ * the server and redirect back to the source list page (Trash,
+ * Untrash, Delete on posts; the equivalents on comments).
+ *
+ * These are intentionally NOT cross-page navigations even when the
+ * URL's slug differs from the source window's: vanilla wp-admin
+ * handles them in the current tab — the user clicks Trash on a row,
+ * the list refreshes with the "1 post moved to the Trash. Undo."
+ * notice. Opening a fresh window would leave the source list stale
+ * AND land the user on the action's redirect target (which depends
+ * on Referer in ways that don't survive a fresh iframe; see the
+ * `_wp_http_referer` shim further down for the safety-net
+ * mitigation).
+ *
+ * Whitelist, not blanket "any `_wpnonce`": URLs like
+ * `update-core.php?action=upgrade-core&_wpnonce=…` carry a nonce
+ * but ARE genuine cross-page navigations the user wants in a window.
+ *
+ * Extension point: plugins register their own predicates via
+ * `wp.desktop.registerDestructiveAdminAction({ id, matches })` —
+ * see `src/destructive-admin-actions.ts`. Built-in Core action
+ * names are pinned in this set for zero-config behavior; the
+ * plugin registry is consulted AFTER the built-in check.
+ */
+const DESTRUCTIVE_ADMIN_ACTIONS: ReadonlySet< string > = new Set( [
+	// wp-admin/post.php
+	'trash',
+	'untrash',
+	'delete',
+	// wp-admin/comment.php
+	'spam',
+	'unspam',
+	'spamcomment',
+	'unspamcomment',
+	'trashcomment',
+	'untrashcomment',
+	'deletecomment',
+	'approvecomment',
+	'unapprovecomment',
+] );
+
+/**
+ * True when a URL is a redirect-back side-effect (Trash, Untrash,
+ * Delete on posts/comments). Used to short-circuit
+ * {@link handleCrossPageAdminLink} into the same-page branch so the
+ * source iframe is the one that performs the action — its natural
+ * Referer header then carries the source URL, and WP redirects
+ * straight back to the list with the success notice.
+ */
+function isDestructiveActionUrl( url: URL ): boolean {
+	const action = url.searchParams.get( 'action' );
+	if ( action && DESTRUCTIVE_ADMIN_ACTIONS.has( action ) ) {
+		// A standalone `?action=trash` with no nonce won't actually
+		// trash anything (WP rejects it with `check_admin_referer`);
+		// the nonce check is also a useful disambiguator from action
+		// names a plugin might overload for non-destructive flows.
+		if (
+			url.searchParams.has( '_wpnonce' ) ||
+			url.searchParams.has( '_wp_nonce' )
+		) {
+			return true;
+		}
+	}
+	// Plugin-registered predicates (the extension point). Walked
+	// AFTER the built-in whitelist so the common case is one map
+	// lookup; predicates only run for URLs Core didn't already
+	// claim. The registry is shared across bundles via
+	// `createSharedStore`, so a plugin's `registerDestructiveAdminAction`
+	// call from its own bundle reaches the dispatcher running in
+	// the `window-system` bundle.
+	return matchDestructiveAdminAction( url.toString(), url ) !== null;
+}
+
+/**
+ * Stamp `_wp_http_referer=<source-page>` onto an admin URL so WP's
+ * referer-driven redirects (`wp_get_referer()` in trash/untrash/
+ * delete handlers, in form-post `redirect_post_location`, in plugin
+ * actions that send the user "back" after a side-effect) resolve to
+ * the page the user clicked FROM, not whatever URL the browser's
+ * `Referer` header happens to carry.
+ *
+ * Why this hint is necessary in both navigation paths:
+ *
+ *   - **New-window opens** — a freshly-created iframe has no prior
+ *     in-frame history, so the browser uses the embedder's URL as
+ *     `Referer`. WP then redirects post-trash to the desktop shell
+ *     URL (often the portal-stamped Dashboard).
+ *
+ *   - **Same-iframe `location.assign`** — the iframe DOES have a
+ *     prior URL, but real-world `Referrer-Policy` headers (WP and
+ *     many hosts set `strict-origin-when-cross-origin` or stricter)
+ *     can downgrade the `Referer` to just the origin, dropping the
+ *     `/wp-admin/edit.php?…` path WP needs. The post-trash redirect
+ *     then falls into the `wp_get_referer()` fallback branches that
+ *     end at Dashboard.
+ *
+ * `_wp_http_referer` is the same hint WP itself threads through
+ * forms via `wp_nonce_field()`; `wp_get_referer()` checks
+ * `$_REQUEST['_wp_http_referer']` BEFORE the raw header, so the
+ * param wins. Harmless on non-action navigations.
+ *
+ * Returns the URL unchanged when the caller already supplied a
+ * referer (we never overwrite), when the source URL is unreadable,
+ * or when the source resolves to a different origin (defensive — a
+ * mis-attributed referer is worse than none).
+ */
+function stampSourceReferer( url: URL, win: Window ): URL {
+	if ( url.searchParams.has( '_wp_http_referer' ) ) {
+		return url;
+	}
+	let sourceHref = '';
+	try {
+		sourceHref = win.iframe?.contentWindow?.location.href ?? '';
+	} catch {
+		// Cross-origin or torn-down iframe — fall through.
+	}
+	if ( ! sourceHref ) {
+		sourceHref = win.config.url || '';
+	}
+	if ( ! sourceHref ) {
+		return url;
+	}
+	try {
+		const sourceUrl = new URL( sourceHref, INITIAL_ORIGIN );
+		if ( sourceUrl.origin !== INITIAL_ORIGIN ) {
+			return url;
+		}
+		const out = new URL( url.href );
+		// Strip the chromeless flag from the hint: `wp_get_referer()`
+		// passes the result downstream to logic that builds the
+		// next redirect, and a chromeless-flagged referer would loop
+		// the flag into places it doesn't belong. The post-redirect
+		// preserve filter (`desktop_mode_chromeless_preserve_redirect`)
+		// reattaches the flag where needed.
+		const cleaned = new URL( sourceUrl.href );
+		cleaned.searchParams.delete( 'desktop_mode_chromeless' );
+		out.searchParams.set(
+			'_wp_http_referer',
+			cleaned.pathname + ( cleaned.search ? cleaned.search : '' ),
+		);
+		return out;
+	} catch {
+		return url;
+	}
+}
+
 function handleCrossPageAdminLink(
 	win: Window,
 	rawUrl: string,
@@ -462,6 +627,42 @@ function handleCrossPageAdminLink(
 
 	const targetSlug = deps.deriveSlug( absolute );
 	const sourceSlug = win.config.baseId || win.id;
+
+	// Destructive row actions (Trash, Untrash, Delete on posts;
+	// spam / approve / trash on comments) navigate the SOURCE iframe
+	// in place regardless of slug, matching vanilla wp-admin's
+	// "click Trash → row disappears + Undo notice on the same list"
+	// behavior. Slug-based cross-page open-a-new-window logic isn't
+	// meaningful here: the URL's slug is whichever
+	// `post.php?post=N&action=trash` it happens to be, but the
+	// landing page after WP's 302 is the list the user already has
+	// open — the in-place branch reaches that exact state.
+	if ( targetSlug !== sourceSlug && isDestructiveActionUrl( url ) ) {
+		// Inject `_wp_http_referer` so WP's trash/untrash/delete
+		// handlers resolve `wp_get_referer()` to the source page
+		// regardless of what the browser's `Referer` header carries
+		// (real-world `Referrer-Policy` headers downgrade the
+		// header to just the origin, dropping the path WP needs).
+		// Without this, the post-action redirect lands wherever WP's
+		// fallback chooses — commonly the Dashboard, since the
+		// origin-only referer matches neither `post.php` nor
+		// `post-new.php` and WP's "back to the list" branch then
+		// substitutes `admin_url('edit.php')` only when the referer
+		// IS empty / IS post.php; everything else passes through
+		// and gets `trashed=1&ids=N` appended to the wrong URL.
+		const trashUrl = stampSourceReferer( url, win );
+		const inner = win.iframe?.contentWindow;
+		if ( inner ) {
+			try {
+				inner.location.assign( trashUrl.href );
+			} catch {
+				if ( win.iframe ) {
+					win.iframe.src = trashUrl.href;
+				}
+			}
+		}
+		return;
+	}
 
 	if ( targetSlug === sourceSlug ) {
 		const inner = win.iframe?.contentWindow;
@@ -502,10 +703,16 @@ function handleCrossPageAdminLink(
 	const trimmedLabel = linkLabel.trim();
 	const title =
 		entry?.title || ( trimmedLabel !== '' ? trimmedLabel : targetSlug );
+
+	// Forward source page as `_wp_http_referer` — see
+	// {@link stampSourceReferer} for the rationale (same shim the
+	// in-place destructive-action branch uses).
+	const urlWithReferer = stampSourceReferer( url, win );
+
 	deps.openWindow( {
 		id: targetSlug,
 		baseId: targetSlug,
-		url: absolute,
+		url: urlWithReferer.toString(),
 		parentUrl: entry?.url ?? absolute,
 		title,
 		icon: entry?.icon ?? 'dashicons-admin-generic',


### PR DESCRIPTION
## What you'll notice

- Clicking **Trash / Untrash / Delete** on a row in the Posts list now does what vanilla WordPress does: the same list refreshes in place with the "1 post moved to the Trash. Undo." banner. No new window. No surprise jump to the Dashboard.
- The same goes for comment moderation row actions — **Approve / Spam / Trash** on the Comments screen all refresh in place.
- Clicking **Edit** (or any genuine "take me to a different screen" link) still opens a new window, exactly as before.
- A new public API lets plugin authors mark their *own* redirect-back action URLs as in-place: `wp.desktop.registerDestructiveAdminAction(...)`.

## Why this needs fixing

Three real bugs were stacked on top of each other. They mask each other; you have to peel them off one at a time.

### 1. Cross-page admin-link clicks weren't being intercepted at all

Click any in-iframe admin link that goes to a different page — say, an Edit link on a Posts row — and the click was silently swallowed. No new window. No navigation. Nothing.

The shell's window code lives in one JavaScript bundle, and the main desktop code lives in another. Both bundles import the same dispatch module — but each bundle ends up with its **own private copy** of that module's state. The main bundle was correctly wiring the dispatcher; the window bundle was reading its own never-populated copy and doing nothing. The fix: stash that state on a single shared object both bundles read from.

### 2. Trash was opening a *new* window… on the Dashboard

Once #1 was fixed and cross-page clicks worked again, Trash had a new problem: it opened a fresh window, and that window showed the Dashboard, not the Posts list.

Why? When you open a brand-new iframe and immediately point it at `post.php?action=trash`, the iframe has no prior page in its history. The browser's `Referer` header falls back to the *embedder's* URL — i.e., whichever page the desktop shell is currently displaying (often the Dashboard after login). WordPress's trash handler reads that `Referer` to decide where to send the user after the deletion. So the post got trashed correctly, then WordPress sent the user "back" to the Dashboard, because that's where it thought they came from.

This isn't a vanilla WordPress problem because in vanilla WP, Trash is a same-tab navigation — the `Referer` is the Posts list URL, exactly what WP needs.

The proper fix is to **stop opening a new window for these actions** entirely. In real WordPress, the Trash row click never opens a new tab — the list just refreshes in place with an Undo notice. We now do the same thing: the destructive action runs against the *source* iframe, so the iframe's existing URL becomes the `Referer`, and WP redirects right back to the list as it should.

### 3. The Referer header itself is unreliable

Even with #2 in place — even when the action runs against the source iframe whose URL is correct — many environments set a `Referrer-Policy` header that strips the path off the `Referer` (sending only `http://your-site.com`, without the `/wp-admin/edit.php` part). That breaks WordPress's "send me back where I came from" logic just as effectively as #2 did.

Belt-and-braces fix: we attach `_wp_http_referer=<source-page>` as a query parameter on the action URL. WordPress checks that parameter *before* falling back to the raw `Referer` header — it's the same hint WordPress itself uses for form posts via `wp_nonce_field()`. So the redirect destination is deterministic regardless of what header the browser ends up sending.

### 4. Plugins should be able to opt in to the same behavior

Built-in WordPress has a fixed set of redirect-back action names: `trash`, `untrash`, `delete`, `spamcomment`, etc. We hard-code those for zero-config coverage. But plenty of plugins introduce their own destructive actions (WooCommerce order trash, for example). Without an extension point, those would keep opening stray windows.

New stable API:

```js
wp.desktop.registerDestructiveAdminAction( {
    id: 'woocommerce/trash-order',
    matches: ( _url, parsed ) =>
        parsed.pathname.endsWith( '/admin.php' ) &&
        parsed.searchParams.get( 'page' ) === 'wc-orders' &&
        parsed.searchParams.get( 'action' ) === 'trash' &&
        parsed.searchParams.has( '_wpnonce' ),
} );
```

Predicate-based (rather than a name list) so plugins can match on whatever combination of path / query / nonce uniquely identifies their action. Symmetric with the existing `registerNativeUrlRemap` so authors recognize the pattern. Returns an unregister function. Companion `unregisterDestructiveAdminAction(id)` and `listDestructiveAdminActions()` for completeness.

## Files

| File | What changed |
|---|---|
| `src/window/iframe-bridge.ts` | The actual dispatch fix: shared state, destructive-action short-circuit, `_wp_http_referer` stamping in both branches. |
| `src/native-url-remap.ts` | Same shared-state fix applied to the URL remap registry, which had the same latent issue. |
| `src/destructive-admin-actions.ts` | New module — the plugin-extensible registry. |
| `src/api/facade.ts` | Wires the new functions onto `wp.desktop`. |
| `src/desktop.ts` | Adds the new methods to the public API's TypeScript interface. |
| `src/window/iframe-bridge.test.ts` | 9 new tests covering each new branch. |
| `src/destructive-admin-actions.test.ts` | New file — 11 unit tests for the registry. |
| `docs/javascript-reference.md` | Reference docs for the new API. |

## Test plan

- [ ] Hard-reload wp-admin with desktop mode on.
- [ ] Click **Trash** on a Posts row → same window refreshes, "1 post moved to the Trash. Undo." banner shows.
- [ ] Click **Edit** on a Posts row → new window opens on the editor (unchanged behavior).
- [ ] Open the Trash view → **Restore** and **Delete Permanently** also refresh in place.
- [ ] On the Comments screen → **Approve / Spam / Trash** row actions refresh in place.
- [ ] Bookmark / admin-bar / "Edit Post" deep links → still open a new window with the correct page.
- [ ] No regressions on dock clicks, dashboard widgets, plugin pages opened from dock.
- [ ] `npm run test:js` — 1153 tests pass.
- [ ] `npm run lint`, `tsc --noEmit`, `npm run build` — clean across all bundles.
