### PR TITLE
fix(plugins-window): support re-uploading existing plugins, add post-install Activate panel

### DIFF
--- a/assets/css/plugins-window.css
+++ b/assets/css/plugins-window.css
@@ -918,6 +918,19 @@
 	margin-block-start: 14px;
 }
 
+.desktop-mode-plugins__upload-success-heading {
+	margin: 4px 0 6px;
+	font-size: 1rem;
+	color: rgb( 25, 120, 65 );
+}
+
+.desktop-mode-plugins__upload-success-detail {
+	margin: 0 0 6px;
+	color: var( --wpd-fg, #333 );
+	font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+	font-size: 0.9em;
+}
+
 /* ─── Window-level .zip drop overlay ────────────────────────────── */
 
 .desktop-mode-plugins__window-drop {

--- a/includes/plugins-window/ajax.php
+++ b/includes/plugins-window/ajax.php
@@ -690,9 +690,55 @@ function desktop_mode_plugins_window_ajax_upload() {
 		return;
 	}
 
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce verified above via desktop_mode_plugins_window_ajax_guard().
+	$overwrite = ! empty( $_POST['overwrite'] );
+
 	$skin     = new WP_Ajax_Upgrader_Skin();
 	$upgrader = new Plugin_Upgrader( $skin );
-	$result   = $upgrader->install( $tmp_name );
+	$result   = $upgrader->install(
+		$tmp_name,
+		array( 'overwrite_package' => $overwrite )
+	);
+
+	// Treat "destination folder exists" specially when the caller did
+	// NOT explicitly ask to overwrite — return a 409 with enough
+	// context for the client to prompt the user and re-submit with
+	// `overwrite=1`. WP_Ajax_Upgrader_Skin parks the error on
+	// `$skin->result`; older paths and `Plugin_Upgrader::install()`
+	// itself can also surface it via `$result` directly or by
+	// returning `false`, so check all three. Mirrors Core's classic
+	// `update.php?action=upload-plugin` confirm flow without the
+	// full upload-and-rerun-from-disk dance.
+	$folder_exists = false;
+	if ( ! $overwrite ) {
+		if ( is_wp_error( $skin->result ) && 'folder_exists' === $skin->result->get_error_code() ) {
+			$folder_exists = true;
+		} elseif ( is_wp_error( $result ) && 'folder_exists' === $result->get_error_code() ) {
+			$folder_exists = true;
+		} elseif ( false === $result || null === $result ) {
+			// `Plugin_Upgrader::install()` returns `false` when the
+			// destination already exists and overwrite isn't allowed.
+			// We can't get the destination path from the result, but
+			// the upgrader emitted the same `folder_exists` skin
+			// error en route (caught above) — this branch is a
+			// belt-and-braces fallback.
+			$folder_exists = true;
+		}
+	}
+
+	if ( $folder_exists ) {
+		desktop_mode_plugins_window_ajax_error(
+			new WP_Error(
+				'folder_exists',
+				__(
+					'A plugin with the same folder name is already installed. Replace it to continue.',
+					'desktop-mode'
+				),
+				array( 'status' => 409 )
+			)
+		);
+		return;
+	}
 
 	if ( is_wp_error( $skin->result ) ) {
 		desktop_mode_plugins_window_ajax_error( $skin->result );
@@ -707,13 +753,11 @@ function desktop_mode_plugins_window_ajax_upload() {
 		return;
 	}
 	if ( false === $result || null === $result ) {
-		// `Plugin_Upgrader::install()` returns `false` when the
-		// destination already exists and overwrite isn't allowed.
 		desktop_mode_plugins_window_ajax_error(
 			new WP_Error(
 				'desktop_mode_plugins_install_failed',
-				__( 'Plugin install failed. The destination folder may already exist.', 'desktop-mode' ),
-				array( 'status' => 409 )
+				__( 'Plugin install failed.', 'desktop-mode' ),
+				array( 'status' => 500 )
 			)
 		);
 		return;
@@ -731,11 +775,32 @@ function desktop_mode_plugins_window_ajax_upload() {
 	 */
 	do_action( 'desktop_mode_plugins_window_installed', $plugin_file );
 
+	// Read the just-installed plugin's headers so the client can show
+	// a name / version on the post-install Activate panel without a
+	// follow-up round-trip. `get_plugin_data()` reads the file
+	// directly — cheap, and the file is already warm in disk cache
+	// from the upgrader.
+	$plugin_name    = '';
+	$plugin_version = '';
+	if ( '' !== $plugin_file ) {
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$abs_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
+		if ( file_exists( $abs_plugin_file ) ) {
+			$data           = get_plugin_data( $abs_plugin_file, false, false );
+			$plugin_name    = isset( $data['Name'] ) ? (string) $data['Name'] : '';
+			$plugin_version = isset( $data['Version'] ) ? (string) $data['Version'] : '';
+		}
+	}
+
 	wp_send_json_success(
 		array(
-			'plugin_file' => (string) $plugin_file,
-			'status'      => 'inactive',
-			'messages'    => $skin->get_upgrade_messages(),
+			'plugin_file'    => (string) $plugin_file,
+			'plugin_name'    => $plugin_name,
+			'plugin_version' => $plugin_version,
+			'status'         => 'inactive',
+			'messages'       => $skin->get_upgrade_messages(),
 		)
 	);
 }

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -212,7 +212,18 @@ async function readJsonOrThrow( response: Response ): Promise< unknown > {
 		);
 	}
 	if ( ! response.ok ) {
-		throw extractAjaxError( json, response.status );
+		// admin-ajax handlers wrap errors as `wp_send_json_error( $err )`
+		// → `{ success: false, data: { code, message, … } }`. The inner
+		// `data` is what carries the code/message — pass it through so
+		// `extractAjaxError()` actually finds them on a non-OK response.
+		const errPayload =
+			typeof json === 'object' &&
+			json !== null &&
+			'success' in json &&
+			( json as { success?: unknown } ).success === false
+				? ( json as { data?: unknown } ).data
+				: json;
+		throw extractAjaxError( errPayload, response.status );
 	}
 	return json;
 }
@@ -457,17 +468,29 @@ export async function installPluginBySlug( slug: string ): Promise< {
 	);
 }
 
-/**
- * Upload + install a .zip via our `wp_ajax_desktop_mode_plugins_upload`
- * action.
- */
-export async function uploadPluginZip( file: File ): Promise< {
+export interface UploadPluginResult {
 	plugin_file: string;
+	plugin_name: string;
+	plugin_version: string;
 	status: 'inactive';
 	messages: string[];
-} > {
+}
+
+/**
+ * Upload + install a .zip via our `wp_ajax_desktop_mode_plugins_upload`
+ * action. Pass `overwrite: true` to instruct the upgrader to replace
+ * an existing plugin directory — used by the dialog's confirm flow
+ * after the server has returned a `folder_exists` 409.
+ */
+export async function uploadPluginZip(
+	file: File,
+	options: { overwrite?: boolean } = {},
+): Promise< UploadPluginResult > {
 	const data = new FormData();
 	data.set( 'pluginzip', file );
+	if ( options.overwrite ) {
+		data.set( 'overwrite', '1' );
+	}
 	return ajaxUpload( 'desktop_mode_plugins_upload', data );
 }
 

--- a/src/plugins-window/upload-dialog.ts
+++ b/src/plugins-window/upload-dialog.ts
@@ -14,17 +14,48 @@
  */
 
 import { __, sprintf } from '../i18n';
-import { refreshFrameworkMenu, uploadPluginZip } from './rest';
+import {
+	activateInstalledPlugin,
+	refreshFrameworkMenu,
+	uploadPluginZip,
+	type UploadPluginResult,
+} from './rest';
+// `wpdConfirm` and `showToast` here MUST come from the main-bundle-safe
+// shims (`../wpd-confirm`, `../toast`) — they construct the elements via
+// `document.createElement()` after lazy-loading the shell-overlays
+// bundle. Importing the component module directly
+// (`../ui/components/wpd-confirm-dialog/wpd-confirm-dialog`) would
+// inline `wpd-confirm-dialog`'s `defineComponent()` into the main
+// bundle. That's the canary tag the shell-overlays loader uses to
+// detect whether the bundle is loaded — registering it from the main
+// bundle short-circuits the loader, and the OTHER components in
+// shell-overlays (notably `wpd-window-button`, which renders the
+// titlebar Minimize / Maximize / Close icons) never get defined. The
+// result is visually intact-looking window controls with zero icons.
+import { wpdConfirm } from '../wpd-confirm';
+import { showToast } from '../toast';
+import { broadcast } from '../broadcast';
 import '../ui/components/wpd-button/wpd-button';
 
-interface UploadResult {
-	plugin_file: string;
-	status: 'inactive';
-	messages: string[];
+/**
+ * Cross-view sync topic for the Plugins window. The Installed +
+ * Browse views subscribe and re-fetch on every payload so they
+ * never show a stale snapshot — see `installed-view.ts` and
+ * `browse-view.ts`. The upload dialog publishes here too so a
+ * fresh install / activate from the dialog is reflected on both
+ * tabs without the user needing to hit Refresh.
+ */
+const PLUGINS_CHANGED_TOPIC = 'desktop-mode.plugin.changed';
+const PLUGINS_CHANGED_SOURCE = 'upload-dialog';
+interface PluginsChangedPayload {
+	source: string;
+	plugin?: string;
+	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'bulk';
 }
 
 export interface UploadCallbacks {
-	onUploaded?: ( result: UploadResult ) => void;
+	onUploaded?: ( result: UploadPluginResult ) => void;
+	onActivated?: ( pluginFile: string ) => void;
 }
 
 /**
@@ -35,7 +66,7 @@ export function openUploadDialog(
 	host: HTMLElement,
 	prefilled: File | null,
 	callbacks: UploadCallbacks = {},
-): Promise< UploadResult | null > {
+): Promise< UploadPluginResult | null > {
 	return new Promise( ( resolve ) => {
 		const overlay = document.createElement( 'div' );
 		overlay.className = 'desktop-mode-plugins__upload-overlay';
@@ -175,7 +206,7 @@ export function openUploadDialog(
 			}
 		} );
 
-		const close = ( result: UploadResult | null ): void => {
+		const close = ( result: UploadPluginResult | null ): void => {
 			document.removeEventListener( 'keydown', onKey );
 			overlay.remove();
 			resolve( result );
@@ -213,7 +244,7 @@ export function openUploadDialog(
 			setFile( prefilled );
 		}
 
-		async function runUpload(): Promise< void > {
+		async function runUpload( overwrite = false ): Promise< void > {
 			if ( ! pickedFile ) {
 				return;
 			}
@@ -222,32 +253,67 @@ export function openUploadDialog(
 			submitBtn.setAttribute( 'disabled', '' );
 			cancelBtn.setAttribute( 'disabled', '' );
 			showStatus(
-				__( 'Uploading and installing…', 'desktop-mode' ),
+				overwrite
+					? __( 'Replacing existing plugin…', 'desktop-mode' )
+					: __( 'Uploading and installing…', 'desktop-mode' ),
 				'info',
 			);
 			try {
-				const result = await uploadPluginZip( pickedFile );
+				const result = await uploadPluginZip( pickedFile, { overwrite } );
 				if ( callbacks.onUploaded ) {
 					callbacks.onUploaded( result );
 				}
-				// Background — the upload UX shows its own success state
-				// and closes itself shortly after; the hidden-iframe menu
-				// refresh is for dock/taskbar sync and doesn't need to
-				// gate that handoff.
+				// Tell every other view (Installed tab, anything else
+				// listening) that the plugin set just changed — they
+				// re-fetch and re-render, so the new row appears
+				// without the user needing to hit Refresh.
+				broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+					source: PLUGINS_CHANGED_SOURCE,
+					plugin: result.plugin_file,
+					action: 'install',
+				} );
+				// Hidden-iframe menu refresh keeps the dock/taskbar in
+				// sync if the new plugin registered an admin menu (the
+				// activate path also triggers one; firing here too is
+				// idempotent and lets the user see new tiles even if
+				// they Close without activating).
 				void refreshFrameworkMenu();
-				showStatus(
-					sprintf(
-						/* translators: %s: plugin file (e.g. akismet/akismet.php) */
-						__( 'Installed %s. Activate it from the Installed tab.', 'desktop-mode' ),
-						result.plugin_file,
-					),
-					'success',
-				);
-				// Brief celebratory pause so the user reads the success
-				// message; then close. Skipped during tests where the
-				// jsdom timer doesn't realistically run.
-				window.setTimeout( () => close( result ), 1200 );
+				showSuccessPanel( result );
 			} catch ( err ) {
+				const errStatus = ( err as Error & { status?: number } ).status;
+				const errCode = ( err as Error & { code?: string } ).code;
+				if (
+					! overwrite &&
+					( errStatus === 409 || errCode === 'folder_exists' )
+				) {
+					// Server refused because the destination folder
+					// exists. Ask the user, then retry with overwrite.
+					uploading = false;
+					submitBtn.removeAttribute( 'busy' );
+					submitBtn.removeAttribute( 'disabled' );
+					cancelBtn.removeAttribute( 'disabled' );
+					showStatus(
+						__(
+							'A plugin with the same folder name is already installed.',
+							'desktop-mode',
+						),
+						'info',
+					);
+					const ok = await wpdConfirm( {
+						title: __( 'Replace existing plugin?', 'desktop-mode' ),
+						message: __(
+							'A plugin with the same folder name is already installed. Replacing it overwrites the installed files. Any local edits to the plugin will be lost. The plugin will keep its activation state.',
+							'desktop-mode',
+						),
+						confirmLabel: __( 'Replace', 'desktop-mode' ),
+						cancelLabel: __( 'Cancel', 'desktop-mode' ),
+						danger: true,
+					} );
+					if ( ok ) {
+						await runUpload( true );
+					}
+					return;
+				}
 				uploading = false;
 				submitBtn.removeAttribute( 'busy' );
 				submitBtn.removeAttribute( 'disabled' );
@@ -263,6 +329,146 @@ export function openUploadDialog(
 					'error',
 				);
 			}
+		}
+
+		/**
+		 * Replace the picker + Install/Cancel footer with a post-install
+		 * action panel — plugin name + version, an Activate button, and
+		 * a Close button. Mirrors WP Core's classic
+		 * `update.php?action=upload-plugin` "Plugin installed
+		 * successfully → Activate Plugin" UX, scoped to this dialog so
+		 * no window navigation is required.
+		 */
+		function showSuccessPanel( result: UploadPluginResult ): void {
+			// The upload itself is settled; clear the in-flight guard so
+			// the new Activate / Close buttons aren't immediately
+			// short-circuited by it.
+			uploading = false;
+			// Tear down the picker so it can't be re-fired and the
+			// success state is unambiguous.
+			dropZone.remove();
+			input.remove();
+			actions.remove();
+			status.hidden = true;
+
+			const successHeading = document.createElement( 'h3' );
+			successHeading.className = 'desktop-mode-plugins__upload-success-heading';
+			successHeading.textContent = __(
+				'Plugin installed successfully.',
+				'desktop-mode',
+			);
+
+			const detail = document.createElement( 'p' );
+			detail.className = 'desktop-mode-plugins__upload-success-detail';
+			const name = result.plugin_name || result.plugin_file;
+			detail.textContent = result.plugin_version
+				? sprintf(
+					/* translators: 1: plugin name 2: plugin version */
+					__( '%1$s %2$s', 'desktop-mode' ),
+					name,
+					result.plugin_version,
+				)
+				: name;
+
+			const successActions = document.createElement( 'div' );
+			successActions.className = 'desktop-mode-plugins__upload-actions';
+			const closeBtn = document.createElement( 'wpd-button' );
+			closeBtn.setAttribute( 'variant', 'ghost' );
+			closeBtn.textContent = __( 'Close', 'desktop-mode' );
+			const activateBtn = document.createElement( 'wpd-button' );
+			activateBtn.setAttribute( 'variant', 'primary' );
+			activateBtn.textContent = __( 'Activate Plugin', 'desktop-mode' );
+			successActions.append( closeBtn, activateBtn );
+
+			card.append( successHeading, detail, successActions );
+
+			closeBtn.addEventListener( 'click', () => {
+				if ( uploading ) {
+					return;
+				}
+				close( result );
+			} );
+
+			activateBtn.addEventListener( 'click', () => {
+				if ( uploading ) {
+					return;
+				}
+				void runActivate();
+			} );
+
+			async function runActivate(): Promise< void > {
+				uploading = true;
+				activateBtn.setAttribute( 'busy', '' );
+				activateBtn.setAttribute( 'disabled', '' );
+				closeBtn.setAttribute( 'disabled', '' );
+				try {
+					// `/wp/v2/plugins/{plugin}` keys off the
+					// extensionless plugin slug. The upload handler
+					// returns the full `foo/foo.php`; strip the `.php`
+					// to match Core's REST shape.
+					const pluginFile = result.plugin_file.endsWith( '.php' )
+						? result.plugin_file.slice( 0, -4 )
+						: result.plugin_file;
+					const updated = await activateInstalledPlugin( {
+						plugin: pluginFile,
+						status: 'inactive',
+					} as Parameters< typeof activateInstalledPlugin >[ 0 ] );
+					if ( callbacks.onActivated ) {
+						callbacks.onActivated( result.plugin_file );
+					}
+					void refreshFrameworkMenu();
+					// Notify both tabs so the row flips to "Active" and
+					// any cached state on either side refetches.
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: PLUGINS_CHANGED_SOURCE,
+						plugin: updated.plugin,
+						action: 'activate',
+					} );
+					// Toast is best-effort, in case the user has
+					// dragged the dialog out of view; the in-dialog
+					// "activated" panel below is the primary signal.
+					showToast( {
+						message: sprintf(
+							/* translators: %s: plugin name */
+							__( '%s activated.', 'desktop-mode' ),
+							name,
+						),
+					} );
+					// Swap the post-install panel for an explicit
+					// activated state. Lets the user read confirmation
+					// and dismiss on their own schedule — matching the
+					// post-install panel's interaction model.
+					uploading = false;
+					successHeading.textContent = __(
+						'Plugin activated.',
+						'desktop-mode',
+					);
+					activateBtn.remove();
+					closeBtn.removeAttribute( 'disabled' );
+					closeBtn.setAttribute( 'variant', 'primary' );
+					closeBtn.textContent = __( 'Done', 'desktop-mode' );
+					closeBtn.focus?.();
+				} catch ( err ) {
+					uploading = false;
+					activateBtn.removeAttribute( 'busy' );
+					activateBtn.removeAttribute( 'disabled' );
+					closeBtn.removeAttribute( 'disabled' );
+					const message =
+						err instanceof Error ? err.message : String( err );
+					status.hidden = false;
+					status.dataset.tone = 'error';
+					status.textContent = sprintf(
+						/* translators: %s: error message from the activate handler */
+						__( 'Activate failed: %s', 'desktop-mode' ),
+						message,
+					);
+					card.appendChild( status );
+				}
+			}
+
+			// Move keyboard focus to the primary action so the user
+			// can confirm with Enter.
+			window.setTimeout( () => activateBtn.focus?.(), 16 );
 		}
 
 		function showStatus(

--- a/tests/vitest/plugins-window-rest.test.ts
+++ b/tests/vitest/plugins-window-rest.test.ts
@@ -236,9 +236,11 @@ describe( 'uploadPluginZip', () => {
 	test( 'POSTs multipart with our window nonce + the file under `pluginzip`', async () => {
 		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
 			ajaxOkResponse( {
-				plugin_file: 'akismet/akismet.php',
-				status:      'inactive',
-				messages:    [],
+				plugin_file:    'akismet/akismet.php',
+				plugin_name:    'Akismet',
+				plugin_version: '5.7',
+				status:         'inactive',
+				messages:       [],
 			} ) as never,
 		);
 		const file = new File(
@@ -255,5 +257,56 @@ describe( 'uploadPluginZip', () => {
 		const submitted = data.get( 'pluginzip' );
 		expect( submitted ).toBeInstanceOf( File );
 		expect( ( submitted as File ).name ).toBe( 'akismet.zip' );
+		// `overwrite` is omitted on the initial attempt — only set
+		// after the user confirms the overwrite prompt.
+		expect( data.get( 'overwrite' ) ).toBeNull();
+	} );
+
+	test( 'passes `overwrite=1` when called with { overwrite: true }', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			ajaxOkResponse( {
+				plugin_file:    'akismet/akismet.php',
+				plugin_name:    'Akismet',
+				plugin_version: '5.7',
+				status:         'inactive',
+				messages:       [],
+			} ) as never,
+		);
+		const file = new File(
+			[ 'PK\x03\x04dummy zip bytes' ],
+			'akismet.zip',
+			{ type: 'application/zip' },
+		);
+		await uploadPluginZip( file, { overwrite: true } );
+		const init = fetchMock.mock.calls[ 0 ]![ 1 ] as RequestInit;
+		const data = init.body as FormData;
+		expect( data.get( 'overwrite' ) ).toBe( '1' );
+	} );
+
+	test( 'surfaces server `folder_exists` error with status code', async () => {
+		vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			new Response(
+				JSON.stringify( {
+					success: false,
+					data:    {
+						code:    'folder_exists',
+						message: 'A plugin with the same folder name is already installed. Replace it to continue.',
+					},
+				} ),
+				{
+					status:  409,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			) as never,
+		);
+		const file = new File(
+			[ 'PK\x03\x04dummy zip bytes' ],
+			'akismet.zip',
+			{ type: 'application/zip' },
+		);
+		await expect( uploadPluginZip( file ) ).rejects.toMatchObject( {
+			code:    'folder_exists',
+			status:  409,
+		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Fixes two issues reported on issue #178 with the native Plugins window's .zip upload flow:

1. **Re-uploading a plugin returned a 500** — the AJAX handler hit Core's `Plugin_Upgrader::install()` without `overwrite_package`, so a second upload of the same plugin (e.g. updating from .zip) failed with `folder_exists`.
2. **No post-install feedback** — the dialog auto-closed after 1.2 s with no indication that the install succeeded, the Installed tab kept showing stale state until Refresh was pressed, and there was no in-place way to activate the freshly-installed plugin.

Mirrors WP Core's classic `update.php?action=upload-plugin` UX inside the native window, without leaving the dialog.

## What changed

**Server (`includes/plugins-window/ajax.php`)**
- Accepts `overwrite=1` and forwards `overwrite_package=true` to the upgrader.
- When the install fails with `folder_exists` and the client didn't ask for overwrite, returns a structured **409** with `code: folder_exists` so the client can prompt.
- On success, returns the just-installed plugin's `plugin_name` + `plugin_version` so the client doesn't need a follow-up round-trip.

**Dialog (`src/plugins-window/upload-dialog.ts`)**
- Catches the 409, shows a `<wpd-confirm-dialog>` "Replace existing plugin?" (red Replace), retries with `overwrite=1` on confirm.
- Replaces the auto-close with an in-dialog success panel: **plugin name + version**, **Activate Plugin** (primary), **Close** (ghost).
- Clicking Activate calls Core REST `PUT /wp/v2/plugins/{plugin}` and swaps the panel to a final "Plugin activated." state with a single **Done** button. User dismisses on their own schedule; no auto-close at any step.
- Publishes `desktop-mode.plugin.changed` (`action: 'install'` then `'activate'`) on the shared cross-view topic so the Installed + Browse tabs repaint without the user hitting Refresh.

**REST client (`src/plugins-window/rest.ts`)**
- `uploadPluginZip( file, { overwrite } )` — passes the flag through as multipart `overwrite=1`.
- Enriched `UploadPluginResult` (`plugin_name`, `plugin_version`).
- `readJsonOrThrow` now unwraps `wp_send_json_error` envelopes before calling `extractAjaxError`, so the `code` and `status` fields land on the thrown error. This was a latent bug for any non-2xx response with a `{ success: false, data: { code, message } }` envelope — only this PR's 409 path exercises it today, but it's a strict improvement for every other admin-ajax call routed through the same helper.

**Window-chrome regression guard (same file)**
While iterating I introduced a regression: importing from `../ui/components/wpd-confirm-dialog/wpd-confirm-dialog` (and `../toast` momentarily) inlined `defineComponent('wpd-confirm-dialog', …)` into `desktop.min.js`. That tag is the canary `src/shell-overlays/loader.ts` uses to detect "bundle already loaded," so the loader short-circuited and `wpd-window-button` never registered — every window's Minimize / Maximize / Fullscreen / Close icons disappeared. The fix is to import from `../wpd-confirm` (the main-bundle-safe shim that lazy-loads the bundle before constructing the element). An inline comment now explains the trap so this doesn't regress.

## Tests

- New vitest cases for `uploadPluginZip` covering the `overwrite=1` passthrough and the surfaced `code: folder_exists` / `status: 409` on the rejected promise.
- Existing test updated to assert the enriched success payload shape.
- `npm run lint`, `tsc --noEmit`, and the full `npm run test:js` suite (1135 tests) pass.
- End-to-end manual verification via Chrome DevTools MCP against the wordpress-develop checkout:
  - First upload → 200, in-dialog "Plugin installed successfully. / `<name> <version>`" → click **Activate Plugin** → REST PUT 200 → "Plugin activated." → click **Done** → dialog closes, plugin shows as Active on the Installed tab without pressing Refresh.
  - Same plugin uploaded again → server returns 409 with `code: folder_exists` → "Replace existing plugin?" prompt → Replace re-uploads with `overwrite=1` → 200 with Core's "Removing the current plugin… Plugin installed successfully." messages → success panel reappears.

## Test plan

- [x] Pull, `npm install && npm run build`
- [x] Upload a fresh plugin .zip from the Plugins window → see the in-dialog success panel
- [x] Click **Activate Plugin** → see the "Plugin activated." confirmation state, then **Done**
- [x] Open the Installed tab → freshly-installed plugin is present and active (no Refresh required)
- [x] Re-upload the same plugin → "Replace existing plugin?" prompt appears; confirm → success panel reappears
- [x] Cancel the prompt → dialog returns to the pre-upload state
- [x] Verify Minimize / Maximize / Fullscreen / Close icons still render on every window

Refs: #178

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-197-a0519942607bb7e8c07a6558341ee26e33f7e28c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->