### PR TITLE
Restore the full WordPress command palette inside Cmd+K

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -942,3 +942,20 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
  * Chromeless #wpbody-content, #adminmenuwrap, #wpfooter overrides are in
  * chromeless.css to keep all legacy page tweaks in one place.
  */
+
+/*
+ * Hide WordPress core's built-in command palette (`@wordpress/commands`).
+ * Desktop mode force-enqueues `wp_enqueue_command_palette_assets()` so
+ * the `core/commands` data store is populated for our shell harvester
+ * (see `src/commands/shell-harvester.ts`); the side effect is that WP
+ * also mounts its own `<CommandPalette>` to the document body. We
+ * already block its Cmd+K handler in `src/palette-registry.ts`, but if
+ * a third-party script opens it programmatically (`wp.data.dispatch(
+ * 'core/commands' ).open()`), the dialog would float over the desktop
+ * with admin-menu navigation callbacks whose `document.location = url`
+ * would unload the shell. Keep it permanently hidden.
+ */
+.commands-command-menu,
+.commands-command-menu__overlay {
+	display: none !important;
+}

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -78,6 +78,53 @@ function desktop_mode_enqueue_assets() {
 	// JS.
 	wp_enqueue_script( 'desktop-mode' );
 
+	// `wp_enqueue_command_palette_assets()` (WP 6.9+) enqueues the
+	// `wp-commands` store package, the `wp-core-commands` script that
+	// registers the WordPress-wide baseline (Add new post, Manage
+	// plugins, Switch theme, Browse patterns, …) AND — critically —
+	// the inline `wp.coreCommands.initializeCommandPalette( … )` call
+	// that actually populates the `core/commands` data store with the
+	// admin-menu commands. Without that inline init, the script loads
+	// but the store stays empty and `src/commands/shell-harvester.ts`
+	// finds nothing to publish.
+	//
+	// WP normally only calls this on screens that opt in to the native
+	// palette; the shell needs it on every admin URL it might wrap.
+	// `function_exists` guard for pre-6.9 sites — the harvester gracefully
+	// no-ops when the store is missing.
+	if ( function_exists( 'wp_enqueue_command_palette_assets' ) ) {
+		// `wp_enqueue_command_palette_assets()` calls
+		// `array_key_exists( $menu_slug, $submenu )` without guarding
+		// the global, so an unset `$submenu` (test contexts, edge-case
+		// admin requests where the menu wasn't built yet) blows up
+		// with a TypeError. Initialize defensively before calling.
+		global $menu, $submenu;
+		if ( ! isset( $submenu ) || ! is_array( $submenu ) ) {
+			$submenu = array();
+		}
+		if ( ! isset( $menu ) || ! is_array( $menu ) ) {
+			$menu = array();
+		}
+		wp_enqueue_command_palette_assets();
+
+		// Expose the same menu-commands array WP serializes into
+		// `wp.coreCommands.initializeCommandPalette(...)` on a window
+		// slot the shell harvester can read. Built in PHP from `$menu`
+		// / `$submenu` here (we already guarded that they're arrays
+		// above), then injected as a `before` inline on our own bundle
+		// — that runs synchronously before `desktop.min.js` boots the
+		// shell harvester, so the lookup is guaranteed populated by
+		// the time `src/commands/shell-harvester.ts` classifies any
+		// command. Decoupled from WP's command-palette mount timing
+		// (which fires from a core-registered hook we can't reorder).
+		$menu_map = desktop_mode_build_command_menu_map();
+		wp_add_inline_script(
+			'desktop-mode',
+			'window.__desktopModeMenuCommands = ' . wp_json_encode( $menu_map ) . ';',
+			'before'
+		);
+	}
+
 	// Pass configuration to JavaScript.
 	global $title, $pagenow, $parent_file, $menu;
 
@@ -381,3 +428,123 @@ function desktop_mode_enqueue_assets() {
 	do_action( 'desktop_mode_mode_init' );
 }
 add_action( 'admin_enqueue_scripts', 'desktop_mode_enqueue_assets' );
+
+/**
+ * Build the admin-menu command map (name → URL) and expose it on
+ * `window.__desktopModeMenuCommands`. The shell command harvester
+ * (`src/commands/shell-harvester.ts`) reads this slot to resolve URLs
+ * for "Go to: …" commands whose JS callbacks
+ * (`document.location = menuCommand.url`) close over a variable URL
+ * we can't extract from source. Without this map those commands
+ * either get skipped (no URL recoverable) or — if the location
+ * shadow misses — navigate the SHELL out of desktop mode.
+ *
+ * Mirrors what WordPress core's `wp_enqueue_command_palette_assets()`
+ * builds for `wp.coreCommands.initializeCommandPalette(...)`. We
+ * duplicate the logic here (instead of monkey-patching the JS init
+ * which is timing-sensitive — WP registers its hook during core load,
+ * so it always emits its inline before any plugin-added inline on the
+ * same handle) and ship the result through `wp_add_inline_script` on
+ * our own bundle handle. That decouples us entirely from WP's command-
+ * palette mount timing.
+ *
+ * @since 0.8.4
+ *
+ * @global array $menu
+ * @global array $submenu
+ * @return array<int, array{label:string, url:string, name:string}>
+ */
+function desktop_mode_build_command_menu_map() {
+	global $menu, $submenu;
+	if ( ! is_array( $menu ) ) {
+		return array();
+	}
+	$out = array();
+
+	$extract_root_text = static function ( $label ) {
+		if ( '' === $label || ! is_string( $label ) ) {
+			return '';
+		}
+		if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
+			$processor = new WP_HTML_Tag_Processor( $label );
+			$text      = '';
+			$depth     = 0;
+			while ( $processor->next_token() ) {
+				$token_type = $processor->get_token_type();
+				if ( '#text' === $token_type && 0 === $depth ) {
+					$text .= $processor->get_modifiable_text();
+				}
+				if ( '#tag' === $token_type ) {
+					if ( $processor->is_tag_closer() ) {
+						if ( $depth > 0 ) {
+							--$depth;
+						}
+						continue;
+					}
+					$name = $processor->get_tag();
+					if ( $name && ! ( class_exists( 'WP_HTML_Processor' ) && WP_HTML_Processor::is_void( $name ) ) ) {
+						++$depth;
+					}
+				}
+			}
+			return trim( $text );
+		}
+		return trim( wp_strip_all_tags( $label ) );
+	};
+
+	foreach ( $menu as $menu_item ) {
+		if ( empty( $menu_item[0] ) || ! is_string( $menu_item[0] ) ) {
+			continue;
+		}
+		if ( ! empty( $menu_item[1] ) && ! current_user_can( $menu_item[1] ) ) {
+			continue;
+		}
+		$menu_label = $extract_root_text( $menu_item[0] );
+		$menu_slug  = $menu_item[2];
+		$menu_url   = '';
+		if ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) {
+			$menu_url = $menu_slug;
+		} elseif ( ! empty( menu_page_url( $menu_slug, false ) ) ) {
+			$menu_url = menu_page_url( $menu_slug, false );
+		}
+		if ( '' !== $menu_url ) {
+			$out[] = array(
+				'label' => $menu_label,
+				'url'   => $menu_url,
+				'name'  => $menu_slug,
+			);
+		}
+		if ( ! empty( $submenu ) && is_array( $submenu ) && array_key_exists( $menu_slug, $submenu ) ) {
+			foreach ( $submenu[ $menu_slug ] as $submenu_item ) {
+				if ( empty( $submenu_item[0] ) ) {
+					continue;
+				}
+				if ( ! empty( $submenu_item[1] ) && ! current_user_can( $submenu_item[1] ) ) {
+					continue;
+				}
+				$submenu_label = $extract_root_text( $submenu_item[0] );
+				$submenu_slug  = $submenu_item[2];
+				$submenu_url   = '';
+				if ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) {
+					$submenu_url = $submenu_slug;
+				} elseif ( ! empty( menu_page_url( $submenu_slug, false ) ) ) {
+					$submenu_url = menu_page_url( $submenu_slug, false );
+				}
+				if ( '' === $submenu_url ) {
+					continue;
+				}
+				$out[] = array(
+					'label' => sprintf(
+						/* translators: 1: parent menu label, 2: submenu label */
+						__( '%1$s > %2$s' ),
+						$menu_label,
+						$submenu_label
+					),
+					'url'   => $submenu_url,
+					'name'  => $menu_slug . '-' . $submenu_item[2],
+				);
+			}
+		}
+	}
+	return $out;
+}

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -536,7 +536,7 @@ function desktop_mode_build_command_menu_map() {
 				$out[] = array(
 					'label' => sprintf(
 						/* translators: 1: parent menu label, 2: submenu label */
-						__( '%1$s > %2$s' ),
+						__( '%1$s > %2$s', 'desktop-mode' ),
 						$menu_label,
 						$submenu_label
 					),

--- a/src/ai-assistant/impl.ts
+++ b/src/ai-assistant/impl.ts
@@ -343,12 +343,15 @@ export class AiAssistant implements AiAssistantApi {
 		this._input.value = '';
 		this._selectedCommand = 0;
 		this._submitBtn.classList.remove( 'has-value' );
-		// Show any commands flagged `eager` immediately — today that's
-		// everything harvested from the focused window's
-		// `core/commands` store via the iframe bridge (block editor
-		// actions, pattern commands, feature toggles). Slash-only
-		// commands stay hidden until the user types `/`. If nothing
-		// eager is registered, fall back to the AI suggestions surface.
+		// Empty input on open: surface the *contextual* commands
+		// (Gutenberg's Duplicate / Add before / pattern actions,
+		// editor toggles harvested from the focused iframe). Those
+		// are what the user is most likely reaching for in the
+		// current context. If nothing contextual is available
+		// (native window focused, or no iframe at all), fall back
+		// to the AI suggestions surface so plain typing submits to
+		// the AI. The shell baseline ("Go to: Posts" etc.) is
+		// intentionally NOT here — it's reachable via `/<query>`.
 		if ( listEagerCommands().length > 0 ) {
 			this._renderCommandMode();
 		} else {
@@ -598,7 +601,7 @@ export class AiAssistant implements AiAssistantApi {
 			if ( this._input.value.startsWith( '/' ) ) {
 				this._renderCommandMode();
 			} else if ( ! hasValue ) {
-				// Empty input: eager command list if any are
+				// Empty input: eager (contextual) commands if any are
 				// registered, otherwise the AI suggestions surface.
 				if ( listEagerCommands().length > 0 ) {
 					this._renderCommandMode();
@@ -692,7 +695,21 @@ export class AiAssistant implements AiAssistantApi {
 		this._showThinking( `Running /${ cmd.slug }…` );
 
 		const ctx: CommandContext = {
-			close: () => this.close(),
+			// Command-initiated close: skip the previousFocus restore.
+			// The command is responsible for any focus management
+			// (e.g. iframe-bridge.runProxy calls `manager.focus(target)`
+			// immediately after `ctx.close()`). The default restore
+			// fires on the close-transition's `transitionend` ~300ms
+			// later, which would otherwise yank focus back to whatever
+			// element was active before the palette opened — typically
+			// an element inside a sibling window's iframe — dragging
+			// that sibling window to the front and undoing the
+			// command's focus choice. User-initiated closes (Escape,
+			// click outside) still restore previousFocus as before.
+			close: () => {
+				this._previousFocus = null;
+				this.close();
+			},
 			openInWindow: ( url, title, icon ) => this._openInLegacyWindow( url, title, icon ),
 			confirm: ( msg, details ) => this._confirm( msg, details ),
 		};
@@ -999,15 +1016,16 @@ export class AiAssistant implements AiAssistantApi {
 			// Fall through to picking mode when the slug doesn't match.
 		}
 
-		// Picking mode. The `eager` flag splits the registry into two
-		// disjoint surfaces:
-		//   - Empty input (not even `/` typed): eager commands only
-		//     (contextual block actions / editor toggles harvested
-		//     from the focused iframe).
-		//   - `/` typed (or `/<query>`): slash-only commands. Eager
-		//     commands are intentionally hidden here — the user has
-		//     announced "I'm looking for a tool to invoke" and mixing
-		//     context-dependent actions into that list is noise.
+		// Picking mode splits the registry into two disjoint surfaces:
+		//   - Empty input: eager (contextual) commands only — Gutenberg
+		//     block actions, pattern shortcuts, editor toggles, etc.
+		//     The non-eager baseline ("Go to: Posts") is intentionally
+		//     hidden here so the empty palette stays a small,
+		//     context-relevant list.
+		//   - `/<query>`: slash-only commands (non-eager). Eager
+		//     commands are excluded here — the user has announced
+		//     "I'm looking for a tool to invoke" and mixing in
+		//     contextual actions is noise.
 		const eagerPicking = parsed.isCommand === false && this._input.value === '';
 		const filtered = eagerPicking
 			? listEagerCommands()

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -245,8 +245,36 @@ export interface DesktopCommand {
  */
 const COMMAND_SLUG = /^[a-z0-9_/-]+$/;
 
-const registry = new Map< string, DesktopCommand >();
-const listeners = new Set<() => void >();
+// Cross-bundle shared state — see `docs/examples/shared-store.md`.
+// Each Desktop Mode feature ships as its own Vite IIFE bundle; without
+// the shared store, the `desktop` bundle and the `ai-assistant` bundle
+// each get their own compiled copy of this module and therefore their
+// own `registry` Map. The shell harvester registers commands into the
+// desktop bundle's registry, the AI Assistant palette reads from its
+// own registry — and finds nothing. Routing through `createSharedStore`
+// guarantees both bundles operate on the same Map / listener set.
+//
+// We capture `state.registry` / `state.listeners` once at module init.
+// Those references never change after the first call (the shared store
+// only re-creates state on explicit `reset()`), so the rest of this
+// file keeps using plain `registry.set/get/delete` and `listeners.add/
+// delete` as before.
+import { createSharedStore } from './shared-store';
+
+interface CommandRegistryState {
+	registry: Map< string, DesktopCommand >;
+	listeners: Set<() => void >;
+}
+
+const commandRegistryStore = createSharedStore< CommandRegistryState >(
+	'desktop-mode/commands-registry',
+	() => ( {
+		registry: new Map< string, DesktopCommand >(),
+		listeners: new Set<() => void >(),
+	} ),
+);
+const registry = commandRegistryStore.state.registry;
+const listeners = commandRegistryStore.state.listeners;
 
 /**
  * Register (or replace) a command. Slug matching is case-insensitive;

--- a/src/commands/iframe-bridge.ts
+++ b/src/commands/iframe-bridge.ts
@@ -28,6 +28,7 @@ import {
 	unregisterByOwner,
 	type DesktopCommand,
 } from './../commands';
+import { tryNativeUrlRemap } from './../native-url-remap';
 import type { HarvestedCommand } from './../types';
 import type { WindowManager } from './../window-manager';
 import { deriveWindowId, sanitizeIconSvg } from './../utils';
@@ -281,6 +282,12 @@ export class IframeCommandBridge {
 	): DesktopCommand[ 'run' ] {
 		return ( _args, ctx ) => {
 			ctx.close();
+			// Honor native URL remaps (e.g. Posts → native Posts
+			// window) the same way the shell harvester does — see
+			// `src/commands/shell-harvester.ts` for the rationale.
+			if ( tryNativeUrlRemap( url ) ) {
+				return;
+			}
 			const id = deriveWindowId( url, this.adminUrl );
 			this.manager.open( { id, baseId: id, url, title, icon } );
 		};

--- a/src/commands/shell-harvester.ts
+++ b/src/commands/shell-harvester.ts
@@ -1,0 +1,745 @@
+/**
+ * Shell-side harvester for `wp.data.select('core/commands')`.
+ *
+ * The chromeless iframe bridge already harvests the focused iframe's
+ * command registry and re-publishes it to the parent palette under
+ * `owner: 'iframe:<windowId>'`. That covers per-window extras (Gutenberg
+ * "Duplicate block", pattern commands, etc.), but it leaves the shell
+ * empty whenever the focused window is a native window — Posts, Files,
+ * Comments, Plugins — because native windows have no iframe and no
+ * `core/commands` runtime to subscribe to.
+ *
+ * This module fixes that by registering the *baseline* WordPress command
+ * set (Add new post, Manage plugins, Switch theme, Browse patterns, …)
+ * directly from the shell's own runtime. `includes/render/assets.php`
+ * force-enqueues `wp-core-commands` on the shell page, which seeds the
+ * `core/commands` store with the same baseline a real admin user would
+ * see. We mount a hidden React harvester here, classify each command
+ * (navigation → opens a desktop window; action → invokes the callback
+ * in-place), and register the result with `owner: 'global'` so the
+ * commands are visible in the palette regardless of which window has
+ * focus.
+ *
+ * Note on plugin install/activate: the React harvester re-runs on every
+ * `core/commands` store tick automatically, so any command added to the
+ * store after boot (rare, but happens) shows up without intervention.
+ * A freshly *activated* plugin's commands won't appear until the shell
+ * page is reloaded — the plugin's JS isn't injected into the live shell.
+ * The per-window iframe harvester (`iframe-bridge.ts`) covers that gap
+ * for any screen the user navigates into.
+ *
+ * @since 0.8.4
+ */
+
+import {
+	registerCommand,
+	unregisterByOwner,
+	type DesktopCommand,
+} from './../commands';
+import { tryNativeUrlRemap } from './../native-url-remap';
+import type { WindowManager } from './../window-manager';
+import { deriveWindowId, sanitizeIconSvg } from './../utils';
+
+const OWNER = 'global';
+
+// `core/commands` callbacks for navigation are written as direct
+// assignments to `document.location` (with `.href` or without). We
+// classify by reading the callback source — never by execution.
+// `document.location` and `Location.prototype` members are
+// `[LegacyUnforgeable]` in WebIDL, so a runtime intercept via
+// `Object.defineProperty` is silently rejected by the browser; an
+// undetected nav callback would therefore navigate the SHELL and
+// trigger the "leave site?" dialog on every iframe under it.
+const NAV_HREF_LITERAL_RE =
+	/(?:document\.location\.href|window\.location\.href|location\.href)\s*=\s*['"]([^'"$]+?)['"]/;
+const NAV_ASSIGN_LITERAL_RE =
+	/(?:document\.location|window\.location|location)\s*=\s*['"]([^'"$]+?)['"]/;
+const NAV_CALL_LITERAL_RE =
+	/location\.(?:assign|replace)\s*\(\s*['"]([^'"$]+?)['"]\s*\)/;
+// Broad "this callback writes to location somehow" detector. Used to
+// flag callbacks whose URL we couldn't extract statically — they're
+// either safely re-routable (site-editor special case below) or unsafe
+// to register at all.
+const NAV_INTENT_RE =
+	/(?:document\.location|window\.location|location)\s*(?:\.href\s*)?=|location\.(?:assign|replace)\s*\(/;
+// Site-editor navigation pattern — the callback references the WP
+// helpers that build a site-editor URL. We can't read the captured
+// `templateType` / `record.id` from the closure, but the command
+// `name` encodes both as `<type>-<id>` (e.g. `wp_template_part-
+// twentytwentyfive//footer-columns`). When this matches, we synthesize
+// the URL ourselves and treat the command as a safe navigate.
+const SITE_EDITOR_INTENT_RE = /getSiteEditorPage\s*\(|site-editor\.php/;
+const SITE_EDITOR_NAME_RE = /^(wp_template_part|wp_template|wp_navigation|wp_block)-(.+)$/;
+
+/**
+ * Look up a command name in the stashed `menu_commands` array (set by
+ * `includes/render/assets.php` as an inline script before our bundle).
+ * Each entry has shape `{ label, url, name }`. Returns the full entry
+ * (so callers can also adopt the clean label — "Posts" — instead of
+ * the harvested "Go to: Posts" used in the palette row).
+ */
+function lookupMenuCommand(
+	name: string,
+): { label: string; url: string } | null {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const list = ( window as any ).__desktopModeMenuCommands;
+	if ( ! Array.isArray( list ) ) {
+		return null;
+	}
+	for ( const entry of list ) {
+		if (
+			entry &&
+			typeof entry === 'object' &&
+			entry.name === name &&
+			typeof entry.url === 'string' &&
+			entry.url !== ''
+		) {
+			return {
+				label: typeof entry.label === 'string' ? entry.label : '',
+				url: entry.url,
+			};
+		}
+	}
+	return null;
+}
+
+interface RawCommand {
+	name: string;
+	label: string;
+	icon?: unknown;
+	context?: string;
+	disabled?: boolean;
+	callback?: ( ...args: unknown[] ) => void;
+}
+
+interface Classified {
+	name: string;
+	label: string;
+	icon?: string;
+	iconSvg?: string;
+	// `navigate` — safe to open as a desktop window (URL was extracted).
+	// `action` — pure JS callback that doesn't touch `location`; safe to
+	//   run inline in the shell.
+	// `skip` — callback navigates dynamically and we couldn't recover a
+	//   URL; registering would risk navigating the shell. Excluded from
+	//   the registry.
+	kind: 'navigate' | 'action' | 'skip';
+	url?: string;
+	// Title for the desktop window the command opens. Distinct from
+	// the palette row's `label` (which keeps the "Go to: Posts" form
+	// the user types). For admin-menu navigation we adopt the clean
+	// menu label ("Posts") so the window's title bar matches what
+	// the user clicked in the menu, not the palette phrasing.
+	windowTitle?: string;
+	callback?: ( ...args: unknown[] ) => void;
+}
+
+export interface ShellCommandHarvesterOptions {
+	manager: WindowManager;
+	adminUrl: string;
+}
+
+export class ShellCommandHarvester {
+	private readonly manager: WindowManager;
+	private readonly adminUrl: string;
+
+	private mounted = false;
+	private host: HTMLDivElement | null = null;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	private root: any = null;
+	private kindCache: Record< string, { kind: 'navigate' | 'action' | 'skip'; url?: string; iconSvg?: string } > =
+		Object.create( null );
+	private callbackCache: Record< string, ( ...args: unknown[] ) => void > =
+		Object.create( null );
+	private lastFingerprint = '';
+
+	constructor( opts: ShellCommandHarvesterOptions ) {
+		this.manager = opts.manager;
+		this.adminUrl = opts.adminUrl;
+	}
+
+	/** Mount the harvester. Idempotent. Safe to call before `wp.data` loads. */
+	public install(): void {
+		this.tryMount( 0 );
+	}
+
+	private tryMount( attempt: number ): void {
+		if ( this.mounted ) {
+			return;
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const wp = ( window as any ).wp;
+		if ( ! wp || ! wp.data || ! wp.element || typeof wp.data.subscribe !== 'function' ) {
+			if ( attempt < 40 ) {
+				window.setTimeout( () => this.tryMount( attempt + 1 ), 150 );
+			}
+			return;
+		}
+		this.mount();
+	}
+
+	private mount(): void {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const wp = ( window as any ).wp;
+		const el = wp.element;
+		const data = wp.data;
+		const createEl = el.createElement;
+		const useEffect = el.useEffect;
+		const useRef = el.useRef;
+		const useMemo = el.useMemo;
+		const useSelect = data.useSelect;
+		if (
+			typeof createEl !== 'function' ||
+			typeof useEffect !== 'function' ||
+			typeof useRef !== 'function' ||
+			typeof useMemo !== 'function' ||
+			typeof useSelect !== 'function' ||
+			typeof el.createRoot !== 'function'
+		) {
+			return;
+		}
+		this.mounted = true;
+
+		const host = document.createElement( 'div' );
+		host.setAttribute( 'aria-hidden', 'true' );
+		host.style.cssText =
+			'position:absolute;width:0;height:0;overflow:hidden;pointer-events:none;left:-9999px;top:-9999px;';
+		( document.body || document.documentElement ).appendChild( host );
+		this.host = host;
+
+		// Ref-based aggregation bucket — see the chromeless bridge's
+		// `__wpdMountReactHarvester` for the full rationale. A
+		// `setState` inside the effect would loop with the hook's
+		// fresh-reference renders. Refs don't re-render, so the loop
+		// is broken even when hooks churn references.
+		const bucket: {
+			perLoader: Record< string, RawCommand[] >;
+			statics: RawCommand[];
+			loadersList: string[];
+		} = {
+			perLoader: {},
+			statics: [],
+			loadersList: [],
+		};
+
+		const fingerprint = ( cmds: RawCommand[] ): string => {
+			if ( ! Array.isArray( cmds ) || cmds.length === 0 ) {
+				return '';
+			}
+			const keys = new Array( cmds.length );
+			for ( let i = 0; i < cmds.length; i++ ) {
+				const c = cmds[ i ];
+				keys[ i ] = c && c.name ? c.name : '';
+			}
+			return keys.join( '|' );
+		};
+
+		const mergeAndPublish = (): void => {
+			let merged: RawCommand[] = [];
+			for ( const name of bucket.loadersList ) {
+				const slice = bucket.perLoader[ name ];
+				if ( Array.isArray( slice ) ) {
+					merged = merged.concat( slice );
+				}
+			}
+			if ( Array.isArray( bucket.statics ) ) {
+				merged = merged.concat( bucket.statics );
+			}
+			// Refresh the callback cache off the same snapshot we're
+			// about to publish — loader-returned commands close over
+			// React state that's only valid this render pass.
+			this.callbackCache = Object.create( null );
+			for ( const cc of merged ) {
+				if ( cc && cc.name && typeof cc.callback === 'function' ) {
+					this.callbackCache[ cc.name ] = cc.callback;
+				}
+			}
+			this.publish( merged );
+		};
+
+		/* eslint-disable react-hooks/exhaustive-deps --
+		   Dependency arrays intentionally key off the fingerprint
+		   (or are deliberately empty) rather than tracking the raw
+		   arrays / props that hooks return fresh on every render. A
+		   "complete" dependency list would re-fire the effects every
+		   render → re-publish → infinite loop. Same trick as the
+		   chromeless bridge's harvester. */
+		const LoaderSlot = ( props: { loader: { name: string; hook: ( a: { search: string } ) => { commands?: RawCommand[] } } } ) => {
+			const loader = props.loader;
+			let result: { commands?: RawCommand[] } | null = null;
+			try {
+				result = loader.hook( { search: '' } );
+			} catch {
+				/* a buggy loader shouldn't take the harvester down */
+			}
+			const cmds: RawCommand[] =
+				result && Array.isArray( result.commands ) ? result.commands : [];
+			const key = useMemo( () => fingerprint( cmds ), [ cmds ] );
+
+			useEffect( () => {
+				bucket.perLoader[ loader.name ] = cmds;
+				mergeAndPublish();
+			}, [ key ] );
+
+			useEffect( () => {
+				return () => {
+					delete bucket.perLoader[ loader.name ];
+					mergeAndPublish();
+				};
+			}, [] );
+
+			return null;
+		};
+
+		const Harvester = () => {
+			// `core/commands` `getCommands( contextual )` partitions the
+			// store: `true` returns commands whose `command.context`
+			// matches the current `state.context`, `false` returns the
+			// non-contextual rest. The WP-wide baseline registered by
+			// `wp.coreCommands.initializeCommandPalette()` (Add new
+			// post, Manage plugins, …) carries no `context`, so it
+			// sits in the non-contextual bucket. The shell has no
+			// context set, so we want both buckets concatenated:
+			// non-contextual covers the baseline; contextual covers
+			// the rare case where a plugin sets a global context.
+			const loaders = useSelect( ( s: ( store: string ) => unknown ) => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const ss = s( 'core/commands' ) as any;
+				if ( ! ss || typeof ss.getCommandLoaders !== 'function' ) {
+					return [];
+				}
+				return [
+					...( ss.getCommandLoaders( false ) || [] ),
+					...( ss.getCommandLoaders( true ) || [] ),
+				];
+			}, [] );
+			const staticCmds = useSelect( ( s: ( store: string ) => unknown ) => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const ss = s( 'core/commands' ) as any;
+				if ( ! ss || typeof ss.getCommands !== 'function' ) {
+					return [];
+				}
+				return [
+					...( ss.getCommands( false ) || [] ),
+					...( ss.getCommands( true ) || [] ),
+				];
+			}, [] );
+
+			const loadersNames = useMemo( () => {
+				return Array.isArray( loaders )
+					? loaders.map( ( l: { name?: string } ) => ( l ? l.name || '' : '' ) )
+					: [];
+			}, [ loaders ] );
+			const loadersKey = loadersNames.join( '|' );
+			useEffect( () => {
+				bucket.loadersList = loadersNames;
+				mergeAndPublish();
+			}, [ loadersKey ] );
+
+			const staticKey = useMemo(
+				() => fingerprint( Array.isArray( staticCmds ) ? staticCmds : [] ),
+				[ staticCmds ],
+			);
+			useEffect( () => {
+				bucket.statics = Array.isArray( staticCmds ) ? staticCmds : [];
+				mergeAndPublish();
+			}, [ staticKey ] );
+
+			if ( ! Array.isArray( loaders ) || loaders.length === 0 ) {
+				return null;
+			}
+			const children: unknown[] = [];
+			for ( const loader of loaders ) {
+				if ( ! loader || typeof loader.hook !== 'function' ) {
+					continue;
+				}
+				children.push(
+					createEl( LoaderSlot, { key: loader.name, loader } ),
+				);
+			}
+			return createEl( el.Fragment || 'div', null, children );
+		};
+		/* eslint-enable react-hooks/exhaustive-deps */
+
+		try {
+			this.root = el.createRoot( host );
+			this.root.render( createEl( Harvester ) );
+		} catch {
+			this.mounted = false;
+			this.root = null;
+			if ( this.host && this.host.parentNode ) {
+				this.host.parentNode.removeChild( this.host );
+			}
+			this.host = null;
+		}
+	}
+
+	private publish( raw: RawCommand[] ): void {
+		// Dedupe + finalize. Same shape as the chromeless harvester's
+		// `__wpdFinalizeCommands` — drop disabled, drop duplicates,
+		// drop entries missing name/label.
+		const seen: Record< string, boolean > = Object.create( null );
+		const classified: Classified[] = [];
+		for ( const cmd of raw ) {
+			if ( ! cmd || ! cmd.name || ! cmd.label ) {
+				continue;
+			}
+			if ( cmd.disabled ) {
+				continue;
+			}
+			if ( seen[ cmd.name ] ) {
+				continue;
+			}
+			seen[ cmd.name ] = true;
+			classified.push( this.classify( cmd ) );
+		}
+
+		// Cheap fingerprint dedupe — `core/commands` ticks on every
+		// unrelated preference change. Re-registering an identical
+		// list every tick would notify subscribers for no reason.
+		let key = '';
+		for ( const c of classified ) {
+			key += `${ c.name }|${ c.kind }|${ c.url || '' }\n`;
+		}
+		if ( key === this.lastFingerprint ) {
+			return;
+		}
+		this.lastFingerprint = key;
+
+		unregisterByOwner( OWNER );
+
+		for ( const c of classified ) {
+			// `skip` commands navigate dynamically and we couldn't
+			// recover the URL — registering them would let a /search
+			// pick navigate the shell out of desktop mode. Drop.
+			if ( c.kind === 'skip' ) {
+				continue;
+			}
+			const slug = `global-${ c.name.toLowerCase().replace( /[^a-z0-9_-]+/g, '-' ) }`;
+			const icon = this.iconFor( c );
+			const def: DesktopCommand = {
+				slug,
+				label: c.label,
+				icon,
+				iconSvg: c.iconSvg && c.iconSvg !== '' ? sanitizeIconSvg( c.iconSvg ) : undefined,
+				owner: OWNER,
+				// NOT eager. The palette splits the registry into two
+				// disjoint surfaces: `eager` commands show on empty
+				// input (and are excluded from slash search at
+				// `src/ai-assistant/impl.ts:494`); non-eager commands
+				// show when the user types `/<query>`. The WP baseline
+				// is large (~150 entries) and meant to be searched —
+				// surfacing it eagerly would drown the iframe-harvested
+				// contextual shortcuts on every open. Slash-search is
+				// the right surface for it, matching the native WP
+				// palette UX (open, type, find).
+				run: c.kind === 'navigate' && c.url
+					? this.runNavigate( c.url, c.windowTitle || c.label, icon )
+					: this.runInvoke( c.name, c.label, icon ),
+			};
+			try {
+				registerCommand( def );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					'[desktop-mode] shell-harvester: dropping bad command',
+					def,
+					err,
+				);
+			}
+		}
+	}
+
+	private classify( cmd: RawCommand ): Classified {
+		const out: Classified = {
+			name: String( cmd.name ),
+			label: String( cmd.label ),
+			icon: typeof cmd.icon === 'string' ? cmd.icon : undefined,
+			iconSvg: undefined,
+			kind: 'action',
+			url: undefined,
+			callback: typeof cmd.callback === 'function' ? cmd.callback : undefined,
+		};
+
+		const cached = this.kindCache[ out.name ];
+		if ( cached ) {
+			out.kind = cached.kind;
+			out.url = cached.url;
+			out.iconSvg = cached.iconSvg;
+			return out;
+		}
+
+		// Flatten React-element icons to a static SVG string once per
+		// command name — Gutenberg ships icons as `@wordpress/icons`
+		// React elements that the palette can't render directly.
+		if ( cmd.icon && typeof cmd.icon !== 'string' ) {
+			out.iconSvg = this.renderIcon( cmd.icon );
+		}
+
+		// Tier 0 — known admin-menu navigation.
+		// (See class doc-block above.)
+		//
+		// WP's `useCommands` wraps every command's `callback` in a stable
+		// ref before exposing it through the store; the source we read
+		// via `Function.prototype.toString` is the wrapper, not the
+		// real handler that does `document.location = menuCommand.url`.
+		// Source-regex classification therefore can never identify
+		// these commands. Instead, check the PHP-built menu map
+		// (`window.__desktopModeMenuCommands`, injected by
+		// `includes/render/assets.php` from the live `$menu`/
+		// `$submenu` globals). If the command name matches an entry,
+		// we know the URL and can safely route it through the window
+		// manager. Skip source inspection for these — the URL is the
+		// source of truth, the callback would just navigate the shell.
+		const menuEntry = lookupMenuCommand( out.name );
+		if ( menuEntry ) {
+			try {
+				out.url = new URL( menuEntry.url, this.adminUrl ).toString();
+				out.kind = 'navigate';
+				if ( menuEntry.label !== '' ) {
+					out.windowTitle = menuEntry.label;
+				}
+			} catch {
+				out.kind = 'skip';
+			}
+			this.kindCache[ out.name ] = {
+				kind: out.kind,
+				url: out.url,
+				iconSvg: out.iconSvg,
+			};
+			return out;
+		}
+
+		if ( typeof cmd.callback === 'function' ) {
+			let src = '';
+			try {
+				src = Function.prototype.toString.call( cmd.callback );
+			} catch {
+				src = '';
+			}
+
+			// Tier 1 — literal URL extractable from the callback source.
+			const literal =
+				src.match( NAV_HREF_LITERAL_RE ) ||
+				src.match( NAV_ASSIGN_LITERAL_RE ) ||
+				src.match( NAV_CALL_LITERAL_RE );
+			if ( literal && literal[ 1 ] ) {
+				try {
+					out.url = new URL( literal[ 1 ], window.location.href ).toString();
+					out.kind = 'navigate';
+				} catch {
+					out.kind = 'action';
+				}
+			} else if ( NAV_INTENT_RE.test( src ) ) {
+				// Callback writes to `location` but the URL isn't a
+				// string literal — could be `addQueryArgs(...)`,
+				// template literal, captured closure, etc. We can't
+				// safely execute (shell would navigate). Admin-menu
+				// nav was already handled above via Tier 0; the
+				// remaining recoverable case is site-editor template
+				// navigation.
+
+				// Site-editor template navigation. The callback uses
+				// `getSiteEditorPage()` / `site-editor.php`, and the
+				// command name encodes `<entityType>-<entityId>`
+				// (e.g. `wp_template_part-twentytwentyfive//footer-
+				// columns`). Rebuild the URL from the name.
+				const isSiteEditorIntent = SITE_EDITOR_INTENT_RE.test( src );
+				const nameMatch = isSiteEditorIntent
+					? out.name.match( SITE_EDITOR_NAME_RE )
+					: null;
+				if ( nameMatch ) {
+					const entityType = nameMatch[ 1 ];
+					const entityId = nameMatch[ 2 ];
+					const p = `/${ entityType }/${ entityId }`;
+					try {
+						const siteEditor = new URL( 'site-editor.php', this.adminUrl );
+						siteEditor.searchParams.set( 'p', p );
+						siteEditor.searchParams.set( 'canvas', 'edit' );
+						out.url = siteEditor.toString();
+						out.kind = 'navigate';
+					} catch {
+						out.kind = 'skip';
+					}
+				} else {
+					// Unrecoverable nav. Skip rather than register
+					// a command that would unload the shell.
+					out.kind = 'skip';
+				}
+			}
+			// else: pure JS action (no `location` writes detected).
+			// Keep `kind: 'action'` — `runInvoke` will execute the
+			// callback in the shell with the location shadow as a
+			// belt-and-braces guard. Toggles, dispatches, modal opens
+			// all land here and work fine.
+		}
+
+		this.kindCache[ out.name ] = {
+			kind: out.kind,
+			url: out.url,
+			iconSvg: out.iconSvg,
+		};
+		return out;
+	}
+
+	private renderIcon( icon: unknown ): string {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const wp = ( window as any ).wp;
+		if ( ! wp || ! wp.element || typeof wp.element.renderToString !== 'function' ) {
+			return '';
+		}
+		try {
+			const rendered = wp.element.renderToString( icon );
+			if (
+				typeof rendered === 'string' &&
+				rendered.toLowerCase().startsWith( '<svg' )
+			) {
+				return rendered;
+			}
+		} catch {
+			/* swallow */
+		}
+		return '';
+	}
+
+	private iconFor( c: Classified ): string {
+		if ( c.icon && c.icon.startsWith( 'dashicons-' ) ) {
+			return c.icon;
+		}
+		return c.kind === 'navigate' ? 'dashicons-external' : 'dashicons-arrow-right-alt';
+	}
+
+	private runNavigate(
+		url: string,
+		title: string,
+		icon: string,
+	): DesktopCommand[ 'run' ] {
+		return ( _args, ctx ) => {
+			ctx.close();
+			// Consult the native URL remap registry first — if a
+			// native window claims this URL (e.g. the Posts window
+			// for `edit.php`, the Plugins window for `plugins.php`),
+			// open that instead of spawning an iframe. Falls through
+			// to plain iframe-window opening when no remap matches
+			// or the remap's gate refuses the current user.
+			if ( tryNativeUrlRemap( url ) ) {
+				return;
+			}
+			const id = deriveWindowId( url, this.adminUrl );
+			this.manager.open( { id, baseId: id, url, title, icon } );
+		};
+	}
+
+	private runInvoke( name: string, title: string, icon: string ): DesktopCommand[ 'run' ] {
+		return ( _args, ctx ) => {
+			ctx.close();
+			const cb = this.callbackCache[ name ];
+			if ( typeof cb !== 'function' ) {
+				return;
+			}
+			// Many "action"-classified commands are actually navigation
+			// in disguise — `useAdminNavigationCommands` writes
+			// `document.location = menuCommand.url` (variable URL), so
+			// our static regex can't catch them at classify time and
+			// they fall into this branch. Running them as-is would
+			// navigate the SHELL window, unloading every iframe
+			// (including an editor with unsaved changes → Chrome's
+			// "leave site?" dialog). Shadow the navigation sinks so
+			// any `document.location = ...` / `window.location = ...`
+			// / `location.assign(...)` / `location.replace(...)`
+			// inside the callback is captured instead of executed.
+			// If we capture a URL, open it as a new desktop window;
+			// otherwise treat the command as a pure JS action and run
+			// the callback for real.
+			const captured = this.runWithNavCapture( cb );
+			if ( captured ) {
+				const id = deriveWindowId( captured, this.adminUrl );
+				this.manager.open( { id, baseId: id, url: captured, title, icon } );
+			}
+		};
+	}
+
+	/**
+	 * Invoke `cb` with navigation sinks (`document.location`,
+	 * `window.location`, `location.assign`, `location.replace`)
+	 * shadowed so any assignment is captured instead of navigating
+	 * the shell. Returns the captured URL or `null` if the callback
+	 * was a pure JS action.
+	 *
+	 * The shadow uses `Object.defineProperty` on the document /
+	 * window instance to override the prototype's accessor for the
+	 * duration of the call. `delete` afterwards unshadows so the
+	 * native setter is restored.
+	 */
+	private runWithNavCapture(
+		cb: ( ...args: unknown[] ) => void,
+	): string | null {
+		let captured: string | null = null;
+		const setCaptured = ( v: unknown ) => {
+			if ( captured === null && typeof v === 'string' && v !== '' ) {
+				captured = v;
+			}
+		};
+
+		const realLocation = window.location;
+		// Read-through descriptor: any property access on the shadow
+		// proxy reads through to the real location. Writes to `href`
+		// / `pathname` / `search` are captured.
+		const locationProxy = new Proxy( realLocation, {
+			get( target, prop ) {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const value = ( target as any )[ prop ];
+				if ( prop === 'assign' || prop === 'replace' ) {
+					return ( url: string ) => setCaptured( url );
+				}
+				if ( typeof value === 'function' ) {
+					return value.bind( target );
+				}
+				return value;
+			},
+			set( _target, prop, value ) {
+				if ( prop === 'href' ) {
+					setCaptured( value );
+					return true;
+				}
+				return true;
+			},
+		} );
+
+		const shadowed: Array< { obj: object; key: 'location' } > = [];
+		const installShadow = ( obj: object ) => {
+			try {
+				Object.defineProperty( obj, 'location', {
+					configurable: true,
+					get: () => locationProxy,
+					set: ( v: unknown ) => setCaptured( v ),
+				} );
+				shadowed.push( { obj, key: 'location' } );
+			} catch {
+				/* the platform refused to shadow — fall through and
+				 * accept that this callback will navigate for real if
+				 * it writes to this particular sink */
+			}
+		};
+
+		installShadow( document );
+		installShadow( window );
+
+		try {
+			cb( { close: () => {} } );
+		} catch {
+			/* a callback that throws shouldn't break the palette */
+		} finally {
+			for ( const s of shadowed ) {
+				try {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					delete ( s.obj as any )[ s.key ];
+				} catch {
+					/* swallow — best-effort unshadow */
+				}
+			}
+		}
+
+		return captured;
+	}
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -81,6 +81,7 @@ import {
 	type ConnectOptions,
 } from './connection';
 import { IframeCommandBridge } from './commands/iframe-bridge';
+import { ShellCommandHarvester } from './commands/shell-harvester';
 import { type ScriptExtras } from './wallpapers/vendor-loader';
 import {
 	type WallpaperSurface,
@@ -1724,6 +1725,19 @@ function init(): void {
 	// commands in the shell palette. Navigation commands rewrite to open
 	// a new desktop window; actions proxy back into the iframe.
 	new IframeCommandBridge( {
+		manager,
+		adminUrl: config.adminUrl,
+	} ).install();
+
+	// Shell-side baseline harvester — pulls the WordPress-wide command
+	// set (Add new post, Manage plugins, Switch theme, Browse patterns,
+	// …) from `core/commands` running in the shell's own runtime and
+	// registers them under `owner: 'global'`. Without this the palette
+	// only shows commands from the focused iframe — native windows
+	// (Posts, Files, Plugins, Comments) contribute none, so the user
+	// would never see the WP baseline while one of those is focused.
+	// Re-harvests automatically on `desktop-mode-plugins-changed`.
+	new ShellCommandHarvester( {
 		manager,
 		adminUrl: config.adminUrl,
 	} ).install();

--- a/src/palette-registry.ts
+++ b/src/palette-registry.ts
@@ -212,6 +212,17 @@ export function installPaletteShortcut(): void {
 
 	// Parent-document keydown — catches Cmd+K when focus is on the shell
 	// itself (admin bar, dock, wallpaper, anywhere outside an iframe).
+	//
+	// `stopImmediatePropagation` is critical: WP's
+	// `wp_enqueue_command_palette_assets` (force-enqueued in
+	// `includes/render/assets.php` so the `core/commands` data store
+	// is populated for our harvester) also mounts `<CommandMenu>` on
+	// the shell and binds its own global Cmd+K shortcut via Mousetrap.
+	// Without stopping immediate propagation, BOTH palettes open and
+	// the user can pick from WP's — whose admin-nav callbacks do
+	// `document.location = url` and unload the shell out of desktop
+	// mode. Kill WP's listener at the capture stage so only ours
+	// ever sees the keystroke.
 	document.addEventListener(
 		'keydown',
 		( e: KeyboardEvent ) => {
@@ -222,6 +233,7 @@ export function installPaletteShortcut(): void {
 				return;
 			}
 			e.preventDefault();
+			e.stopImmediatePropagation();
 			cyclePalettes();
 		},
 		true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,14 @@ const IDENTITY_PARAMS: readonly string[] = [
 	// second row in the Posts window just refocuses the first post's
 	// window instead of opening the new one.
 	'post',
+	// Site-editor entity path: `site-editor.php?p=/wp_template_part/
+	// twentytwentyfive//footer-columns`. Each template / template
+	// part / pattern / navigation entity is a distinct "page" from
+	// the user's perspective — picking "Header" after "Footer column"
+	// should open a new window, not refocus the existing footer one.
+	// Without `p` in identity, every site-editor URL collapses to
+	// `site-editor-php` and the second pick is a no-op.
+	'p',
 ];
 
 /**

--- a/tests/vitest/commands-registry.test.ts
+++ b/tests/vitest/commands-registry.test.ts
@@ -21,7 +21,16 @@ type CommandsModule = typeof import( '../../src/commands' );
 
 async function load(): Promise< CommandsModule > {
 	vi.resetModules();
-	return await import( '../../src/commands' );
+	const mod = await import( '../../src/commands' );
+	// The registry now lives in a `createSharedStore` slot on `window`
+	// so the desktop + ai-assistant bundles share it at runtime.
+	// `vi.resetModules()` clears the module graph but not the global
+	// slot, so without this loop commands from a previous test leak
+	// into the next. Drain the registry between loads.
+	for ( const cmd of mod.listCommands() ) {
+		mod.unregisterCommand( cmd.slug );
+	}
+	return mod;
 }
 
 describe( 'commands.ts — 0.16.0 additions', () => {


### PR DESCRIPTION
## What this fixes

Pressing Cmd+K used to show only the slash-commands we register ourselves
plus whatever the focused iframe happened to harvest. Everything the
native WordPress palette surfaces — "Add new post", "Manage plugins",
"Switch theme", every admin-menu destination, every Gutenberg pattern
and template part — was missing from the shell. Typing `/posts`
returned "No commands matching /posts" even though Posts is the most
obvious thing in the admin.

After this change, `/<anything>` searches the full WordPress command
catalogue. Picks open a desktop window (or native window, when one is
registered for that URL) instead of unloading the shell.

## Why it was broken

Four separate bugs, layered.

1. **`wp-core-commands` wasn't enqueued on the shell page.** WordPress
   only loads its command-palette baseline on screens that opt in.
   The shell wraps every admin URL; on most of them, the
   `core/commands` data store was simply empty.

2. **We queried the store with the wrong contextual flag.**
   `getCommands(true)` returns commands whose `context` matches the
   current `state.context`. The shell has no context, the WP baseline
   carries no context, so `true` matched nothing. The non-contextual
   bucket — every admin-menu destination — lives behind
   `getCommands(false)`.

3. **The command registry was a module-local `Map`.** The shell and
   the AI Assistant compile to separate Vite bundles. Each bundle
   imported `src/commands.ts` and got its own compiled copy with its
   own `Map`. The harvester wrote 156 commands into one Map; the
   palette UI read from the other (empty) Map. `wp.desktop.listCommands()`
   in the console returned 156, but the palette filter returned 0.

4. **The runtime classifier couldn't see WP's real callbacks.**
   `useCommands` wraps every callback in a stable React ref before
   exposing it through the store. `Function.prototype.toString` on
   that wrapper returns
   `(...args) => { const callback = currentCallbacksRef.current[command.name]; ... }`
   — the destination URL lives inside `currentCallbacksRef.current`,
   a closure variable nothing can read from outside. Source-regex
   classification was always going to miss this. Picking the command
   ran the wrapper, the wrapper called the real handler, the real
   handler did `document.location = menuCommand.url`, and the shell
   navigated out of desktop mode (which then redirected through the
   portal handler and stamped `desktop_mode_portal=1` flags on the
   URL).

## How it works now

**Enqueue.** The shell calls `wp_enqueue_command_palette_assets()`
(WP 6.9+) which loads `wp-commands`, `wp-core-commands`, and the inline
init that seeds the data store. WordPress's `<CommandPalette>` UI is
hidden via CSS and its Cmd+K shortcut is intercepted in capture phase
so only the desktop palette can ever open. WP's data is reused; WP's
UI is not.

**Cross-bundle state.** `src/commands.ts` now routes the registry and
listener set through `createSharedStore('desktop-mode/commands-registry', …)`.
Every bundle that imports `commands.ts` operates on the same Map.
This is the pattern `docs/event-driven-framework.md` documents for
exactly this kind of split — the command registry now follows it.

**Classification.** A new shell harvester (`src/commands/shell-harvester.ts`)
mounts a hidden React tree that subscribes to both buckets of
`core/commands` (`getCommands(false)` + `getCommands(true)`) plus every
loader's contextual hook output. For each command it decides one of
three things:

- **Navigate** — the URL is known. The command name lives in
  `window.__desktopModeMenuCommands`, an array of
  `{label, url, name}` entries that `includes/render/assets.php`
  builds in PHP from the live `$menu`/`$submenu` globals and ships
  via `wp_add_inline_script` before our bundle boots. Same data
  WordPress passes to `initializeCommandPalette()`, computed on the
  server, delivered synchronously, no monkey-patch race. The window
  title comes from this map ("Posts"), not the harvested row label
  ("Go to: Posts"). Picks open in a new desktop window, or in a
  registered native window when `tryNativeUrlRemap()` claims the URL.

- **Site-editor entity** — the command name encodes
  `<entityType>-<entityId>` (`wp_template_part-twentytwentyfive//footer-columns`).
  The URL is synthesized from the name and passed to `manager.open()`.
  `p` was added to `IDENTITY_PARAMS` in `src/utils.ts` so each entity
  gets its own window — picking "Header" after "Footer column" opens
  a second window instead of refocusing the first.

- **Pure JS action** — the callback doesn't touch `location`.
  Toggles, dispatches, modal opens. Runs in the shell with a
  `document.location` shadow as a belt-and-braces guard.

Anything else — dynamically-navigating callbacks we can't safely
recover a URL for — is skipped rather than registered. Better a
missing command than a command that unloads the shell.

**Palette UX.** Cmd+K with nothing typed surfaces the eager
(context-dependent) commands the focused iframe harvested — Duplicate,
Add after, pattern actions. Empty palette without an iframe in focus
falls through to the AI suggestions surface so plain typing still
submits to the AI. Typing `/` switches to the slash-search palette,
where the WordPress baseline lives. Picking a command no longer drags
the previously-focused window to the front: when `ctx.close()` is
called from inside a command's `run`, the palette's transitionend
focus-restore is suppressed so the command's own focus management
(`manager.focus(target)`) is the last word.

## Why it's awesome

- **Everything's reachable from Cmd+K.** Every admin-menu destination,
  every submenu, every plugin's commands. The user's mental model
  ("WordPress has a Cmd+K palette") finally matches reality inside
  desktop mode.
- **Nothing unloads the shell.** Variable-URL callbacks, site-editor
  navigation, action commands that close over closures — all of them
  open in new windows or run in place. No more "leave site?" dialog
  while editing a post, no more portal-redirect reloads.
- **Native windows are honored.** `/posts` opens the native Posts
  window, not a raw `edit.php` iframe. Same code path the dock uses,
  so the experience is consistent.
- **Contextual commands stay contextual.** Gutenberg's per-block
  commands appear eagerly when the editor is focused and disappear
  when it isn't, instead of leaking into every palette session.
- **Stable across bundle splits.** The shared registry means future
  feature bundles can register and read commands without rediscovering
  the cross-bundle trap.

## Files touched

- `includes/render/assets.php` — enqueue `wp_enqueue_command_palette_assets`
  on the shell, build and inject the menu-commands map from
  `$menu`/`$submenu`.
- `src/commands.ts` — registry + listeners moved into a shared store.
- `src/commands/shell-harvester.ts` (new) — React-based harvester for
  the shell's own `core/commands` store; three-tier classifier with
  the menu-commands map as Tier 0.
- `src/commands/iframe-bridge.ts` — navigate path now consults
  `tryNativeUrlRemap()` before falling back to iframe windows.
- `src/ai-assistant/impl.ts` — empty-input falls back to AI
  suggestions when no eager commands are registered; command-initiated
  closes skip the previousFocus restore so focus stays where the
  command put it.
- `src/palette-registry.ts` — Cmd+K handler `stopImmediatePropagation`s
  so WP's own shortcut never fires.
- `src/utils.ts` — `IDENTITY_PARAMS` includes `p` so site-editor
  entities each get their own window.
- `src/desktop.ts` — installs the shell harvester at boot alongside
  the iframe bridge.
- `assets/css/desktop.css` — hides the WP `<CommandPalette>` dialog
  in case anything opens it programmatically.
- `tests/vitest/commands-registry.test.ts` — drains the now-shared
  registry between tests since `vi.resetModules()` doesn't clear
  globals.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-199-7441516eafcafa1f8d8b5e9b2dd6a6be7fabd30d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->