### PR TITLE
Recycle Bin: show item type badges inline next to title

### DIFF
--- a/docs/examples/recycle-bin.md
+++ b/docs/examples/recycle-bin.md
@@ -85,6 +85,17 @@ add_filter( 'desktop_mode_recycle_bin_item', function ( $item, $post ) {
 }, 10, 2 );
 ```
 
+The `type_label` field on every row carries a human-readable label for the entity kind (`Post`, `Page`, `Media`, `Comment`, or the CPT's singular label). The bin renders it as a small inline badge next to the title; column-filter authors can also reuse it for their own cells. Override it from the same filter if your CPT needs a custom label:
+
+```php
+add_filter( 'desktop_mode_recycle_bin_item', function ( $item, $post ) {
+    if ( 'product' === $post->post_type ) {
+        $item[ 'type_label' ] = __( 'Catalog item', 'myplugin' );
+    }
+    return $item;
+}, 10, 2 );
+```
+
 ## Push your own real-time channel
 
 If you run a websocket or SSE service alongside WordPress, hook the unified signal so you don't have to subscribe to every delete action individually:

--- a/includes/recycle-bin/store.php
+++ b/includes/recycle-bin/store.php
@@ -475,6 +475,7 @@ function desktop_mode_recycle_bin_shape_comment_item( $comment ) {
 	$item = array(
 		'id'            => (int) $comment->comment_ID,
 		'type'          => 'comment',
+		'type_label'    => __( 'Comment', 'desktop-mode' ),
 		'title'         => $title,
 		'subtitle'      => $subtitle,
 		'mime'          => '',
@@ -547,9 +548,26 @@ function desktop_mode_recycle_bin_shape_item( $post ) {
 	$user      = $user_id ? get_userdata( $user_id ) : false;
 	$user_name = $user ? $user->display_name : '';
 
+	// Resolve a human label for the type badge. `attachment` collapses
+	// to "Media" to match the toolbar filter; every other registered
+	// post type uses its singular label so CPTs read correctly (e.g.
+	// "Product" for WooCommerce). Unknown types fall back to a
+	// title-cased slug.
+	if ( 'attachment' === $type ) {
+		$type_label = __( 'Media', 'desktop-mode' );
+	} else {
+		$post_type_obj = get_post_type_object( $type );
+		if ( $post_type_obj && isset( $post_type_obj->labels->singular_name ) && '' !== (string) $post_type_obj->labels->singular_name ) {
+			$type_label = (string) $post_type_obj->labels->singular_name;
+		} else {
+			$type_label = ucwords( str_replace( array( '_', '-' ), ' ', $type ) );
+		}
+	}
+
 	$item = array(
 		'id'            => (int) $post->ID,
 		'type'          => $type,
+		'type_label'    => $type_label,
 		'title'         => '' !== $title ? $title : sprintf( '#%d', $post->ID ),
 		'subtitle'      => $subtitle,
 		'mime'          => $mime,

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -97,6 +97,59 @@ export function mapRecycleTypeToFileType( recycleType: string ): string {
 	return 'post';
 }
 
+/**
+ * Inline-styled background tints for the type badge. Lives in JS
+ * because `<wpd-table>` renders its body into a shadow DOM that
+ * blocks document stylesheets — every visual property has to come
+ * from inline `style.*` assignments. The palette is intentionally
+ * desaturated so badges read as metadata, not as primary content.
+ * Unknown types fall through to `_default`.
+ */
+const TYPE_BADGE_COLORS: Record< string, { bg: string; fg: string } > = {
+	post: { bg: '#dbe9fe', fg: '#1d4ed8' },
+	page: { bg: '#e0f2fe', fg: '#075985' },
+	attachment: { bg: '#fef3c7', fg: '#92400e' },
+	comment: { bg: '#dcfce7', fg: '#166534' },
+	_default: { bg: '#e5e7eb', fg: '#374151' },
+};
+
+function humanizeType( slug: string ): string {
+	if ( ! slug ) {
+		return '';
+	}
+	return slug
+		.replace( /[_-]+/g, ' ' )
+		.replace( /\b\w/g, ( c ) => c.toUpperCase() );
+}
+
+function makeTypeBadge( row: RecycleBinItem ): HTMLElement {
+	const label =
+		row.type_label && row.type_label.length > 0
+			? row.type_label
+			: humanizeType( row.type );
+	const colors =
+		TYPE_BADGE_COLORS[ row.type ] ?? TYPE_BADGE_COLORS._default;
+	const badge = document.createElement( 'span' );
+	badge.setAttribute( 'data-desktop-mode-recycle-bin-type-badge', row.type );
+	badge.textContent = label;
+	badge.style.cssText = [
+		'display: inline-flex',
+		'align-items: center',
+		'flex-shrink: 0',
+		'padding: 2px 8px',
+		'border-radius: 999px',
+		'font-size: 11px',
+		'font-weight: 600',
+		'line-height: 1.4',
+		'letter-spacing: 0.2px',
+		'text-transform: uppercase',
+		'white-space: nowrap',
+		'background: ' + colors.bg,
+		'color: ' + colors.fg,
+	].join( ';' );
+	return badge;
+}
+
 const ROOT = '[data-desktop-mode-recycle-bin-root]';
 const FILTER = '[data-desktop-mode-recycle-bin-filter]';
 const SEARCH = '[data-desktop-mode-recycle-bin-search]';
@@ -181,9 +234,12 @@ function buildColumns(): WpdTableColumn< RecycleBinItem >[] {
 			render: ( _v, row ) => {
 				// One-cell layout: optional thumbnail (image
 				// attachments only) sits inline at the start, then
-				// the two-line title/subtitle stack. Posts, pages,
-				// comments get the full title width since they have
-				// nothing to show on the left — no reserved gap.
+				// the two-line title/subtitle stack. A small type
+				// badge sits inline before the title so each row
+				// answers "what kind of thing is this?" without a
+				// dedicated column. Posts, pages, comments get the
+				// full title width since they have nothing to show
+				// on the left — no reserved gap.
 				const wrap = document.createElement( 'span' );
 				wrap.style.cssText =
 					'display:flex;align-items:center;gap:10px;min-width:0;';
@@ -205,12 +261,17 @@ function buildColumns(): WpdTableColumn< RecycleBinItem >[] {
 				const stack = document.createElement( 'span' );
 				stack.style.cssText =
 					'display:flex;flex-direction:column;gap:2px;min-width:0;';
+				const titleRow = document.createElement( 'span' );
+				titleRow.style.cssText =
+					'display:flex;align-items:center;gap:8px;min-width:0;';
+				titleRow.appendChild( makeTypeBadge( row ) );
 				const title = document.createElement( 'span' );
 				title.style.cssText =
 					'font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:320px;';
 				title.textContent = row.title;
 				title.title = row.title;
-				stack.appendChild( title );
+				titleRow.appendChild( title );
+				stack.appendChild( titleRow );
 				if ( row.subtitle ) {
 					const sub = document.createElement( 'span' );
 					sub.style.cssText =
@@ -223,9 +284,10 @@ function buildColumns(): WpdTableColumn< RecycleBinItem >[] {
 				return wrap;
 			},
 		},
-		// No explicit Type column — the title + the toolbar's type
-		// filter tabs already convey the entity kind, and an extra
-		// column inflates the row visually for no signal gain.
+		// No explicit Type column — the inline type badge in the
+		// title cell and the toolbar's type filter tabs already
+		// convey the entity kind, and an extra column inflates the
+		// row visually for no signal gain.
 		{
 			key: 'deleted_at',
 			label: __( 'Deleted' ),

--- a/src/recycle-bin/rest.ts
+++ b/src/recycle-bin/rest.ts
@@ -26,6 +26,14 @@ declare global {
 export interface RecycleBinItem {
 	id: number;
 	type: string;
+	/**
+	 * Human-friendly singular label for the item's type. Populated
+	 * server-side from the post-type-object label (or "Comment" /
+	 * "Media") so CPTs render correctly. May be empty for legacy or
+	 * filter-extended rows — the JS renderer falls back to a
+	 * title-cased version of `type`.
+	 */
+	type_label?: string;
 	title: string;
 	subtitle: string;
 	mime: string;


### PR DESCRIPTION
Closes #205.

## Summary
- Adds a small uppercase type badge inline before each row's title in the Recycle Bin window — `POST`, `PAGE`, `MEDIA`, `COMMENT`, or the CPT's singular label.
- Avoids a dedicated Type column so row height stays compact; the badge sits with the title, between the optional thumbnail and the title text.
- CPT-aware: server-side resolves `type_label` from the post-type object so e.g. a trashed WooCommerce product reads as "Product".

<img width="2334" height="1566" alt="CleanShot 2026-05-14 at 09 40 14@2x" src="https://github.com/user-attachments/assets/f5d10b39-9978-4a7b-845a-ded8b3566fda" />


## Implementation notes
- PHP: `desktop_mode_recycle_bin_shape_item()` and `..._shape_comment_item()` now emit a `type_label` field. Attachments collapse to "Media" to match the toolbar filter; unknown slugs fall back to a title-cased version of the slug.
- TS: new `makeTypeBadge()` helper renders the badge with inline styles (the `<wpd-table>` body lives in a shadow DOM that blocks document stylesheets, so all visual properties have to come from inline `style.*` assignments). A small desaturated palette keeps the badges readable as metadata, not primary content.
- The TS renderer also falls back to a JS-side humanization of `row.type` if `type_label` is missing, so the badge still shows for rows from a plugin that doesn't populate the new field.
- Plugins can override the label per row from the existing `desktop_mode_recycle_bin_item` filter — documented in `docs/examples/recycle-bin.md`.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:js` — 1155 tests pass
- [x] `npm run build` succeeds
- [x] Verified in local dev (wp-develop): badges render for posts, pages, media, comments, and folder/desktop entries

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-206-5784a33e39e0e326eb09939bca8e874af3b8b576.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->