### PR TITLE
Remember native window size across opens (fixes #203)

### DIFF
--- a/docs/native-windows-proposal.md
+++ b/docs/native-windows-proposal.md
@@ -60,15 +60,25 @@ desktop_mode_register_window( 'jorvy', array(
     'styles'         => array( 'jorvy-panel' ),
 
     // Optional window defaults. Overridable per-open via the JS API.
-    // `width` / `height` are the size used the very first time a user
-    // opens this window. From then on, the shell remembers the last
-    // size the user dragged the window to (per baseId, in
-    // localStorage under `desktop-mode-native-window-geometry`) and
-    // reopens at that size — clamped to `min_width` / `min_height`
-    // so raising the minimum in a plugin update never reopens at the
-    // older smaller size. Snapped / maximized / fullscreen sizes are
-    // not persisted; only sizes the user picks by dragging the resize
-    // handle in the normal floating state.
+    // `width` / `height` are the size used the very first time a
+    // user opens this window. From then on, the shell remembers
+    // the last size, position, AND maximize state the user left
+    // the window in (per baseId, in localStorage under
+    // `desktop-mode-native-window-geometry`) and replays them on
+    // the next fresh open. The same persistence covers classic
+    // iframe-backed windows opened from a dock click or desktop
+    // icon. Size is clamped to `min_width` / `min_height` so
+    // raising the minimum in a plugin update never reopens at the
+    // older smaller size. Position is clamped to the current
+    // desktop area so a window remembered at x=2800 on a 3440px
+    // display doesn't open off-screen on a laptop. Snap-zone tiles
+    // are not persisted; only geometry the user picks while the
+    // window is in the normal floating state. Width / height /
+    // position ALWAYS represent the floating values, even when
+    // state=maximized; they are what un-maximize restores to.
+    // Duplicate instances opened via `openNewWindow` or the "+"
+    // dock-peek affordance always cascade off the primary's
+    // remembered position into a fresh floating slot.
     'width'          => 420,
     'height'         => 320,
     'min_width'      => 320,

--- a/docs/native-windows-proposal.md
+++ b/docs/native-windows-proposal.md
@@ -60,6 +60,15 @@ desktop_mode_register_window( 'jorvy', array(
     'styles'         => array( 'jorvy-panel' ),
 
     // Optional window defaults. Overridable per-open via the JS API.
+    // `width` / `height` are the size used the very first time a user
+    // opens this window. From then on, the shell remembers the last
+    // size the user dragged the window to (per baseId, in
+    // localStorage under `desktop-mode-native-window-geometry`) and
+    // reopens at that size — clamped to `min_width` / `min_height`
+    // so raising the minimum in a plugin update never reopens at the
+    // older smaller size. Snapped / maximized / fullscreen sizes are
+    // not persisted; only sizes the user picks by dragging the resize
+    // handle in the normal floating state.
     'width'          => 420,
     'height'         => 320,
     'min_width'      => 320,

--- a/src/native-windows.ts
+++ b/src/native-windows.ts
@@ -29,6 +29,10 @@ import { activity } from './activity';
 import { HOOKS, addAction, doAction, removeAction } from './hooks';
 import { loadVendorScript } from './wallpapers/vendor-loader';
 import { registerSyntheticIframe } from './connection';
+import {
+	loadNativeWindowGeometry,
+	saveNativeWindowGeometry,
+} from './window-manager/native-window-geometry';
 import type { SystemDockItem } from './dock';
 import type {
 	NativeRenderContext,
@@ -866,6 +870,28 @@ export function createNativeWindowSync(
 	// Always reflects the most recent sync.
 	const entriesById = new Map< string, NativeWindowServerEntry >();
 
+	/**
+	 * Resolve the size to open a native window at, preferring the
+	 * user's last manually-resized dimensions over the registered
+	 * defaults. Clamps to the registered `minWidth` / `minHeight` so
+	 * a stale entry from a wider-minimum version of a plugin can't
+	 * open the window smaller than the plugin currently allows.
+	 *
+	 * @since 0.8.5
+	 */
+	const resolveSizeForEntry = (
+		entry: NativeWindowServerEntry,
+	): { width: number; height: number } => {
+		const saved = loadNativeWindowGeometry( entry.id );
+		if ( ! saved ) {
+			return { width: entry.width, height: entry.height };
+		}
+		return {
+			width: Math.max( saved.width, entry.minWidth ),
+			height: Math.max( saved.height, entry.minHeight ),
+		};
+	};
+
 	const ensureTemplate = ( entry: NativeWindowServerEntry ): void => {
 		if ( injectedTemplates.has( entry.templateId ) ) {
 			return;
@@ -996,6 +1022,8 @@ export function createNativeWindowSync(
 			return render?.( body, ctx );
 		};
 
+		const size = resolveSizeForEntry( entry );
+
 		void manager.open( {
 			id: entry.id,
 			baseId: entry.id,
@@ -1005,8 +1033,8 @@ export function createNativeWindowSync(
 			icon: entry.icon,
 			x: 0,
 			y: 0,
-			width: entry.width,
-			height: entry.height,
+			width: size.width,
+			height: size.height,
 			minWidth: entry.minWidth,
 			minHeight: entry.minHeight,
 			render: finalRender,
@@ -1032,6 +1060,8 @@ export function createNativeWindowSync(
 			return render?.( body, ctx );
 		};
 
+		const size = resolveSizeForEntry( entry );
+
 		void manager.openNew( {
 			id: entry.id,
 			baseId: entry.id,
@@ -1039,8 +1069,8 @@ export function createNativeWindowSync(
 			url: `#${ entry.id }`,
 			title: entry.title,
 			icon: entry.icon,
-			width: entry.width,
-			height: entry.height,
+			width: size.width,
+			height: size.height,
 			minWidth: entry.minWidth,
 			minHeight: entry.minHeight,
 			render: finalRender,
@@ -1161,6 +1191,45 @@ export function createNativeWindowSync(
 		openNewFromEntry( entry );
 		return true;
 	};
+
+	// Persist the user's manually-resized size for native windows so
+	// the next open lands at the same dimensions instead of the
+	// plugin-author defaults. WINDOW_RESIZE_END only fires from the
+	// pointer-drag resize handler, so programmatic re-tiles
+	// (arrange.ts / snap-zones.ts) don't poison the persisted size.
+	//
+	// Skipped for non-normal states: a snap-zone tile (left half,
+	// quarter, …) isn't the user saying "this is my preferred size",
+	// it's a temporary layout intent. Restoring those on next open
+	// would defeat the purpose.
+	addAction(
+		HOOKS.WINDOW_RESIZE_END,
+		'desktop-mode-native-window-geometry',
+		( payload: unknown ) => {
+			const p = payload as
+				| { windowId?: string; width?: number; height?: number }
+				| null;
+			const windowId = p?.windowId;
+			const width = p?.width;
+			const height = p?.height;
+			if (
+				! windowId ||
+				typeof width !== 'number' ||
+				typeof height !== 'number'
+			) {
+				return;
+			}
+			const win = manager.getById( windowId );
+			if ( ! win || ! win.config.native ) {
+				return;
+			}
+			if ( win.state !== 'normal' ) {
+				return;
+			}
+			const baseId = win.config.baseId || win.id;
+			saveNativeWindowGeometry( baseId, { width, height } );
+		},
+	);
 
 	return { sync, openById, openNewById };
 }

--- a/src/native-windows.ts
+++ b/src/native-windows.ts
@@ -32,6 +32,8 @@ import { registerSyntheticIframe } from './connection';
 import {
 	loadNativeWindowGeometry,
 	saveNativeWindowGeometry,
+	saveNativeWindowPosition,
+	setNativeWindowSavedState,
 } from './window-manager/native-window-geometry';
 import type { SystemDockItem } from './dock';
 import type {
@@ -877,6 +879,12 @@ export function createNativeWindowSync(
 	 * a stale entry from a wider-minimum version of a plugin can't
 	 * open the window smaller than the plugin currently allows.
 	 *
+	 * Maximized state is replayed in `WindowManager.createWindow`
+	 * (via `initialState: 'maximized'`) — not here. That keeps the
+	 * replay path uniform between native and classic windows. The
+	 * caller can suppress it by passing an explicit `initialState`
+	 * on the `manager.open` call.
+	 *
 	 * @since 0.8.5
 	 */
 	const resolveSizeForEntry = (
@@ -1024,6 +1032,9 @@ export function createNativeWindowSync(
 
 		const size = resolveSizeForEntry( entry );
 
+		// Leave `x` / `y` unset so `WindowManager.createWindow` can
+		// apply the user's last saved position (or cascade on first
+		// open). An explicit `0, 0` would short-circuit that.
 		void manager.open( {
 			id: entry.id,
 			baseId: entry.id,
@@ -1031,8 +1042,6 @@ export function createNativeWindowSync(
 			url: `#${ entry.id }`,
 			title: entry.title,
 			icon: entry.icon,
-			x: 0,
-			y: 0,
 			width: size.width,
 			height: size.height,
 			minWidth: entry.minWidth,
@@ -1060,6 +1069,12 @@ export function createNativeWindowSync(
 			return render?.( body, ctx );
 		};
 
+		// Duplicate instances always open floating — the remembered
+		// maximize preference applies to the primary window only.
+		// Passing an explicit `initialState: 'normal'` suppresses the
+		// `WindowManager.createWindow` saved-state replay (which
+		// would otherwise spawn the duplicate in the maximized state
+		// the user set on the primary).
 		const size = resolveSizeForEntry( entry );
 
 		void manager.openNew( {
@@ -1073,6 +1088,7 @@ export function createNativeWindowSync(
 			height: size.height,
 			minWidth: entry.minWidth,
 			minHeight: entry.minHeight,
+			initialState: 'normal',
 			render: finalRender,
 			autofocus: entry.autofocus,
 			ownerHandle: entry.ownerHandle || entry.scriptHandle,
@@ -1192,16 +1208,19 @@ export function createNativeWindowSync(
 		return true;
 	};
 
-	// Persist the user's manually-resized size for native windows so
-	// the next open lands at the same dimensions instead of the
-	// plugin-author defaults. WINDOW_RESIZE_END only fires from the
-	// pointer-drag resize handler, so programmatic re-tiles
-	// (arrange.ts / snap-zones.ts) don't poison the persisted size.
+	// Persist the user's manually-resized size for EVERY window
+	// (native and classic iframe-backed alike) so the next fresh
+	// open lands at the same dimensions instead of the defaults.
+	// WINDOW_RESIZE_END only fires from the pointer-drag resize
+	// handler, so programmatic re-tiles (arrange.ts / snap-zones.ts)
+	// don't poison the persisted size.
 	//
 	// Skipped for non-normal states: a snap-zone tile (left half,
 	// quarter, …) isn't the user saying "this is my preferred size",
 	// it's a temporary layout intent. Restoring those on next open
-	// would defeat the purpose.
+	// would defeat the purpose. Maximized + fullscreen resizes are
+	// also skipped here; the WINDOW_MAXIMIZED listener below records
+	// the maximize *intent* separately from the floating size.
 	addAction(
 		HOOKS.WINDOW_RESIZE_END,
 		'desktop-mode-native-window-geometry',
@@ -1220,7 +1239,7 @@ export function createNativeWindowSync(
 				return;
 			}
 			const win = manager.getById( windowId );
-			if ( ! win || ! win.config.native ) {
+			if ( ! win ) {
 				return;
 			}
 			if ( win.state !== 'normal' ) {
@@ -1228,6 +1247,107 @@ export function createNativeWindowSync(
 			}
 			const baseId = win.config.baseId || win.id;
 			saveNativeWindowGeometry( baseId, { width, height } );
+			// A top-left / top / left handle drag also moves the
+			// window, so capture the post-resize x/y too. The
+			// resize-end payload only carries width / height; read
+			// position directly off the element. Defensive guard
+			// for tests that mock the Window without a real element.
+			if ( win.element ) {
+				saveNativeWindowPosition( baseId, {
+					x: win.element.offsetLeft,
+					y: win.element.offsetTop,
+				} );
+			}
+		},
+	);
+
+	// Persist the user's drag position so the window reopens where
+	// they last left it. WINDOW_DRAG_END fires once per pointer-up
+	// at the end of a title-bar drag — same gating as resize-end:
+	// only the normal floating state counts, so an in-progress snap
+	// (state=snapped-left, dragged to commit the half-screen tile)
+	// doesn't poison the stored position.
+	//
+	// We write BOTH size + position here. The size is the window's
+	// current floating dimensions even if the user never manually
+	// resized; without this seed call, `saveNativeWindowPosition`
+	// would have no prior entry to layer position onto for users
+	// who open-drag-close without ever resizing.
+	addAction(
+		HOOKS.WINDOW_DRAG_END,
+		'desktop-mode-native-window-geometry',
+		( payload: unknown ) => {
+			const windowId = ( payload as { windowId?: string } | null )?.windowId;
+			if ( ! windowId ) {
+				return;
+			}
+			const win = manager.getById( windowId );
+			if ( ! win ) {
+				return;
+			}
+			if ( win.state !== 'normal' ) {
+				return;
+			}
+			if ( ! win.element ) {
+				return;
+			}
+			const baseId = win.config.baseId || win.id;
+			saveNativeWindowGeometry( baseId, {
+				width: win.element.offsetWidth,
+				height: win.element.offsetHeight,
+			} );
+			saveNativeWindowPosition( baseId, {
+				x: win.element.offsetLeft,
+				y: win.element.offsetTop,
+			} );
+		},
+	);
+
+	// Persist the user's maximized intent for every window. The
+	// floating width / height stored separately by the resize-end
+	// handler stays untouched — it's still what un-maximize restores
+	// to.
+	//
+	// When the user maximizes a window they never resized, seed the
+	// floating size from the entry defaults (for native windows in
+	// the registry) or the current window snapshot's pre-maximize
+	// geometry — whichever is available. Without a seed the
+	// store has no width/height to anchor the maximize-on-reopen.
+	addAction(
+		HOOKS.WINDOW_MAXIMIZED,
+		'desktop-mode-native-window-geometry',
+		( payload: unknown ) => {
+			const windowId = ( payload as { windowId?: string } | null )?.windowId;
+			if ( ! windowId ) {
+				return;
+			}
+			const win = manager.getById( windowId );
+			if ( ! win ) {
+				return;
+			}
+			const baseId = win.config.baseId || win.id;
+			const entry = entriesById.get( baseId );
+			const defaults = entry
+				? { width: entry.width, height: entry.height }
+				: { width: win.config.width, height: win.config.height };
+			setNativeWindowSavedState( baseId, 'maximized', defaults );
+		},
+	);
+
+	addAction(
+		HOOKS.WINDOW_UNMAXIMIZED,
+		'desktop-mode-native-window-geometry',
+		( payload: unknown ) => {
+			const windowId = ( payload as { windowId?: string } | null )?.windowId;
+			if ( ! windowId ) {
+				return;
+			}
+			const win = manager.getById( windowId );
+			if ( ! win ) {
+				return;
+			}
+			const baseId = win.config.baseId || win.id;
+			setNativeWindowSavedState( baseId, null );
 		},
 	);
 

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -62,6 +62,7 @@ import {
 	updateSnapZoneForDrag,
 } from './snap-zones';
 import { enterOverview, exitOverview } from './overview';
+import { loadNativeWindowGeometry } from './native-window-geometry';
 
 /** Base z-index for desktop windows. */
 const BASE_Z_INDEX = 100;
@@ -452,13 +453,30 @@ export class WindowManager {
 	/**
 	 * Open a brand-new window even if one is already open for this
 	 * page. Only makes sense for pages flagged `multi`.
+	 *
+	 * Duplicates always open in the floating ('normal') state and at
+	 * a fresh cascade slot — the per-baseId saved size / state /
+	 * position preferences apply to the primary instance only.
+	 * Spawning a maximized twin alongside the maximized primary
+	 * would hide the primary; landing a twin on top of the primary's
+	 * remembered position would hide it too. Callers can override
+	 * either default by passing `initialState` / `x` / `y` explicitly.
 	 */
 	public async openNew(
 		config: Partial<WindowConfig> & { id: string; url: string; title: string },
 	): Promise< Window > {
 		const baseId = config.baseId || config.id;
 		const nextId = this.nextInstanceId( baseId );
-		return this.createWindow( { ...config, id: nextId, baseId } );
+		const cascadeX = 40 + ( this.cascadeIndex % 8 ) * CASCADE_OFFSET;
+		const cascadeY = 40 + ( this.cascadeIndex % 8 ) * CASCADE_OFFSET;
+		return this.createWindow( {
+			initialState: 'normal',
+			x: cascadeX,
+			y: cascadeY,
+			...config,
+			id: nextId,
+			baseId,
+		} );
 	}
 
 	/**
@@ -474,16 +492,83 @@ export class WindowManager {
 		const cascadeX = 40 + ( this.cascadeIndex % 8 ) * CASCADE_OFFSET;
 		const cascadeY = 40 + ( this.cascadeIndex % 8 ) * CASCADE_OFFSET;
 
+		// When the caller didn't pin geometry (a fresh dock click or
+		// desktop-icon open, not a session restore which passes
+		// everything, not an `openNew` duplicate which passes its own
+		// cascade), fall back to the per-baseId localStorage geometry
+		// store before the desktopRect-based defaults. Same store as
+		// native windows — keyed by baseId, lets a user's "this is
+		// the size and place I want this window" preference survive
+		// close/reopen even when the window wasn't open at the last
+		// session save.
+		const resolvedBaseId = config.baseId || config.id;
+		const minWidth = config.minWidth ?? 320;
+		const minHeight = config.minHeight ?? 200;
+		const hasExplicitWidth = typeof config.width === 'number';
+		const hasExplicitHeight = typeof config.height === 'number';
+		const hasExplicitX = typeof config.x === 'number';
+		const hasExplicitY = typeof config.y === 'number';
+		const hasExplicitState = typeof config.initialState === 'string';
+		const saved =
+			! hasExplicitWidth ||
+			! hasExplicitHeight ||
+			! hasExplicitState ||
+			! hasExplicitX ||
+			! hasExplicitY
+				? loadNativeWindowGeometry( resolvedBaseId )
+				: null;
+		const resolvedWidth =
+			config.width ??
+			( saved ? Math.max( saved.width, minWidth ) : defaultWidth );
+		const resolvedHeight =
+			config.height ??
+			( saved ? Math.max( saved.height, minHeight ) : defaultHeight );
+		const resolvedState =
+			config.initialState ??
+			( saved?.state === 'maximized' ? 'maximized' : undefined );
+
+		// Clamp saved x / y to the current desktop area so a window
+		// remembered at x=2800 on a 3440px display doesn't open
+		// off-screen on a laptop. Mirrors the clamp the session-restore
+		// path applies via `clampGeometryToViewport`.
+		let clampedSavedX: number | undefined;
+		let clampedSavedY: number | undefined;
+		if (
+			saved &&
+			typeof saved.x === 'number' &&
+			typeof saved.y === 'number'
+		) {
+			const margin = 12;
+			const maxX = Math.max(
+				0,
+				desktopRect.width - resolvedWidth - margin,
+			);
+			const maxY = Math.max(
+				0,
+				desktopRect.height - resolvedHeight - margin,
+			);
+			clampedSavedX = Math.max( margin, Math.min( saved.x, maxX ) );
+			clampedSavedY = Math.max( margin, Math.min( saved.y, maxY ) );
+		}
+		const resolvedX = config.x ?? clampedSavedX ?? cascadeX;
+		const resolvedY = config.y ?? clampedSavedY ?? cascadeY;
+
 		const fullConfig: WindowConfig = {
 			icon: config.icon || 'dashicons-admin-generic',
-			x: config.x ?? cascadeX,
-			y: config.y ?? cascadeY,
-			width: config.width ?? defaultWidth,
-			height: config.height ?? defaultHeight,
-			minWidth: config.minWidth ?? 320,
-			minHeight: config.minHeight ?? 200,
 			...config,
-			baseId: config.baseId || config.id,
+			// Spread `config` first so callers can pass through any
+			// extras (render, ownerHandle, parentUrl, …), then pin the
+			// dimensions + state we resolved above. The pin has to
+			// follow the spread because an explicit `width: undefined`
+			// from the caller would otherwise blow away the default.
+			x: resolvedX,
+			y: resolvedY,
+			width: resolvedWidth,
+			height: resolvedHeight,
+			minWidth,
+			minHeight,
+			...( resolvedState ? { initialState: resolvedState } : {} ),
+			baseId: resolvedBaseId,
 			// New windows always join the active desktop. A caller can
 			// pre-seed `desktopId` (e.g. session restore) by passing it
 			// in `config`, which the spread above preserves.

--- a/src/window-manager/native-window-geometry.ts
+++ b/src/window-manager/native-window-geometry.ts
@@ -4,14 +4,19 @@
  * Native windows are excluded from the session-restore snapshot
  * (their `render` callback is a JS closure, not something we can
  * serialize and rehydrate server-side). But "the size I picked last
- * time" survives a reload without needing server state — just store
- * `{ width, height }` per baseId in localStorage and read it back on
- * open.
+ * time" and "I left this maximized" survive a reload without needing
+ * server state — just store `{ width, height, state? }` per baseId
+ * in localStorage and read it back on open.
  *
  * Position is intentionally NOT persisted. Cascade-on-open keeps
  * stacked native windows visible on every viewport size; restoring a
  * remembered position would happily place a window off-screen after
  * the user switches between monitors of different sizes.
+ *
+ * Width and height ALWAYS represent the floating ("normal") size,
+ * even when `state === 'maximized'` — they're the size the window
+ * un-maximizes back to. The maximize state is layered on top of that
+ * size, not a replacement for it.
  *
  * @since 0.8.5
  */
@@ -25,7 +30,16 @@ const MAX_ENTRIES = 64;
 /** Sanity ceiling for a single stored dimension (px). */
 const MAX_DIMENSION = 8192;
 
-type SavedGeometry = { width: number; height: number };
+/** Persisted window state. Only states worth restoring are listed. */
+export type SavedWindowState = 'maximized';
+
+type SavedGeometry = {
+	width: number;
+	height: number;
+	x?: number;
+	y?: number;
+	state?: SavedWindowState;
+};
 
 type StoredMap = Record< string, SavedGeometry >;
 
@@ -59,11 +73,13 @@ function writeMap( map: StoredMap ): void {
 }
 
 /**
- * Look up the remembered size for a native window.
+ * Look up the remembered geometry + state for a window.
  *
  * Returns `null` when nothing is stored or the stored value is
  * malformed. Caller is responsible for clamping to a registered
- * `minWidth` / `minHeight`.
+ * `minWidth` / `minHeight` and for clamping `x` / `y` to the
+ * current viewport (so a window remembered at x=2800 on a 3440px
+ * desktop doesn't open off-screen on a smaller monitor).
  */
 export function loadNativeWindowGeometry(
 	baseId: string,
@@ -88,20 +104,40 @@ export function loadNativeWindowGeometry(
 	) {
 		return null;
 	}
-	return { width: Math.round( width ), height: Math.round( height ) };
+	const state: SavedWindowState | undefined =
+		entry.state === 'maximized' ? 'maximized' : undefined;
+	const x = Number( entry.x );
+	const y = Number( entry.y );
+	const hasPosition =
+		Number.isFinite( x ) &&
+		Number.isFinite( y ) &&
+		x >= 0 &&
+		y >= 0 &&
+		x <= MAX_DIMENSION &&
+		y <= MAX_DIMENSION;
+	return {
+		width: Math.round( width ),
+		height: Math.round( height ),
+		...( hasPosition ? { x: Math.round( x ), y: Math.round( y ) } : {} ),
+		...( state ? { state } : {} ),
+	};
 }
 
 /**
- * Persist a new size for a native window. No-ops when the new size
- * matches what's already stored — saves an unnecessary write +
- * `storage` event on every micro-resize.
+ * Persist a new floating size for a native window. Preserves any
+ * previously-saved `state` (e.g. 'maximized') so writing the size
+ * after a manual resize doesn't drop the maximize preference.
+ *
+ * No-ops when both size and the (preserved) state already match what's
+ * stored — saves an unnecessary write + `storage` event on every
+ * micro-resize.
  *
  * Trims the map to {@link MAX_ENTRIES} oldest-out so a long-running
  * shell doesn't accumulate stale entries from removed plugins.
  */
 export function saveNativeWindowGeometry(
 	baseId: string,
-	geometry: SavedGeometry,
+	geometry: { width: number; height: number },
 ): void {
 	if ( ! baseId ) {
 		return;
@@ -120,14 +156,155 @@ export function saveNativeWindowGeometry(
 	}
 	const map = readMap();
 	const prev = map[ baseId ];
-	if ( prev && prev.width === width && prev.height === height ) {
+	const state =
+		prev && prev.state === 'maximized'
+			? ( 'maximized' as const )
+			: undefined;
+	const carriedX = typeof prev?.x === 'number' ? prev.x : undefined;
+	const carriedY = typeof prev?.y === 'number' ? prev.y : undefined;
+	if (
+		prev &&
+		prev.width === width &&
+		prev.height === height &&
+		prev.state === state &&
+		prev.x === carriedX &&
+		prev.y === carriedY
+	) {
 		return;
 	}
-	// Move-to-end (delete + re-insert) so recently-used ids survive
-	// the trim. JS object insertion order on string keys is preserved
-	// per ES2015+ which all browsers we ship to honor.
+	upsertEntry( map, baseId, {
+		width,
+		height,
+		...( typeof carriedX === 'number' && typeof carriedY === 'number'
+			? { x: carriedX, y: carriedY }
+			: {} ),
+		...( state ? { state } : {} ),
+	} );
+	writeMapTrimmed( map );
+}
+
+/**
+ * Persist the user's last drag position for a window. Preserves
+ * width / height / state on the existing entry.
+ *
+ * Skipped when no prior entry exists — there's nothing to seed the
+ * width / height from on the position-only path. The next resize-end
+ * or maximize event will land the first entry, and subsequent drags
+ * will accumulate position on top of it. In practice the first
+ * resize-end / drag-end happens within microseconds of opening
+ * (cascade defaults aren't user-intentional sizes), so the gap is
+ * a one-frame edge case.
+ */
+export function saveNativeWindowPosition(
+	baseId: string,
+	position: { x: number; y: number },
+): void {
+	if ( ! baseId ) {
+		return;
+	}
+	const x = Math.round( Number( position.x ) );
+	const y = Math.round( Number( position.y ) );
+	if (
+		! Number.isFinite( x ) ||
+		! Number.isFinite( y ) ||
+		x < 0 ||
+		y < 0 ||
+		x > MAX_DIMENSION ||
+		y > MAX_DIMENSION
+	) {
+		return;
+	}
+	const map = readMap();
+	const prev = map[ baseId ];
+	if ( ! prev ) {
+		return;
+	}
+	if ( prev.x === x && prev.y === y ) {
+		return;
+	}
+	upsertEntry( map, baseId, {
+		...prev,
+		x,
+		y,
+	} );
+	writeMapTrimmed( map );
+}
+
+/**
+ * Persist (or clear) the saved window state. Width/height are left
+ * untouched if a previous entry exists — they represent the floating
+ * size to restore to on un-maximize and shouldn't be perturbed.
+ *
+ * When the store has no prior entry for this baseId and the caller
+ * passes `defaults`, we seed the entry with those defaults so a user
+ * who maximizes a never-resized window still gets the "open
+ * maximized next time" behavior.
+ */
+export function setNativeWindowSavedState(
+	baseId: string,
+	state: SavedWindowState | null,
+	defaults?: { width: number; height: number },
+): void {
+	if ( ! baseId ) {
+		return;
+	}
+	const map = readMap();
+	const prev = map[ baseId ];
+	if ( ! prev ) {
+		if ( state === null || ! defaults ) {
+			return;
+		}
+		const width = Math.round( Number( defaults.width ) );
+		const height = Math.round( Number( defaults.height ) );
+		if (
+			! Number.isFinite( width ) ||
+			! Number.isFinite( height ) ||
+			width <= 0 ||
+			height <= 0 ||
+			width > MAX_DIMENSION ||
+			height > MAX_DIMENSION
+		) {
+			return;
+		}
+		upsertEntry( map, baseId, { width, height, state } );
+		writeMapTrimmed( map );
+		return;
+	}
+	if ( state === null ) {
+		if ( ! prev.state ) {
+			return;
+		}
+		const { state: _state, ...rest } = prev;
+		upsertEntry( map, baseId, rest );
+		writeMapTrimmed( map );
+		return;
+	}
+	if ( prev.state === state ) {
+		return;
+	}
+	upsertEntry( map, baseId, {
+		...prev,
+		state,
+	} );
+	writeMapTrimmed( map );
+}
+
+/**
+ * Move-to-end insert into the map so recently-used ids survive the
+ * trim. JS object insertion order on string keys is preserved per
+ * ES2015+ which all browsers we ship to honor.
+ */
+function upsertEntry(
+	map: StoredMap,
+	baseId: string,
+	entry: SavedGeometry,
+): void {
 	delete map[ baseId ];
-	map[ baseId ] = { width, height };
+	map[ baseId ] = entry;
+}
+
+/** Write the map after evicting oldest entries past {@link MAX_ENTRIES}. */
+function writeMapTrimmed( map: StoredMap ): void {
 	const keys = Object.keys( map );
 	if ( keys.length > MAX_ENTRIES ) {
 		const trimmed: StoredMap = {};

--- a/src/window-manager/native-window-geometry.ts
+++ b/src/window-manager/native-window-geometry.ts
@@ -1,0 +1,150 @@
+/**
+ * Per-baseId geometry persistence for native windows.
+ *
+ * Native windows are excluded from the session-restore snapshot
+ * (their `render` callback is a JS closure, not something we can
+ * serialize and rehydrate server-side). But "the size I picked last
+ * time" survives a reload without needing server state — just store
+ * `{ width, height }` per baseId in localStorage and read it back on
+ * open.
+ *
+ * Position is intentionally NOT persisted. Cascade-on-open keeps
+ * stacked native windows visible on every viewport size; restoring a
+ * remembered position would happily place a window off-screen after
+ * the user switches between monitors of different sizes.
+ *
+ * @since 0.8.5
+ */
+
+/** Storage key for the per-baseId geometry map. */
+export const NATIVE_GEOMETRY_STORAGE_KEY = 'desktop-mode-native-window-geometry';
+
+/** Cap on remembered entries — protects against unbounded growth. */
+const MAX_ENTRIES = 64;
+
+/** Sanity ceiling for a single stored dimension (px). */
+const MAX_DIMENSION = 8192;
+
+type SavedGeometry = { width: number; height: number };
+
+type StoredMap = Record< string, SavedGeometry >;
+
+/** Read the persisted map; tolerates missing / corrupt storage. */
+function readMap(): StoredMap {
+	try {
+		const raw = window.localStorage.getItem( NATIVE_GEOMETRY_STORAGE_KEY );
+		if ( ! raw ) {
+			return {};
+		}
+		const parsed = JSON.parse( raw );
+		if ( ! parsed || typeof parsed !== 'object' ) {
+			return {};
+		}
+		return parsed as StoredMap;
+	} catch {
+		return {};
+	}
+}
+
+/** Write the persisted map; silent failure under private mode. */
+function writeMap( map: StoredMap ): void {
+	try {
+		window.localStorage.setItem(
+			NATIVE_GEOMETRY_STORAGE_KEY,
+			JSON.stringify( map ),
+		);
+	} catch {
+		/* storage unavailable — silently degrade */
+	}
+}
+
+/**
+ * Look up the remembered size for a native window.
+ *
+ * Returns `null` when nothing is stored or the stored value is
+ * malformed. Caller is responsible for clamping to a registered
+ * `minWidth` / `minHeight`.
+ */
+export function loadNativeWindowGeometry(
+	baseId: string,
+): SavedGeometry | null {
+	if ( ! baseId ) {
+		return null;
+	}
+	const map = readMap();
+	const entry = map[ baseId ];
+	if ( ! entry ) {
+		return null;
+	}
+	const width = Number( entry.width );
+	const height = Number( entry.height );
+	if (
+		! Number.isFinite( width ) ||
+		! Number.isFinite( height ) ||
+		width <= 0 ||
+		height <= 0 ||
+		width > MAX_DIMENSION ||
+		height > MAX_DIMENSION
+	) {
+		return null;
+	}
+	return { width: Math.round( width ), height: Math.round( height ) };
+}
+
+/**
+ * Persist a new size for a native window. No-ops when the new size
+ * matches what's already stored — saves an unnecessary write +
+ * `storage` event on every micro-resize.
+ *
+ * Trims the map to {@link MAX_ENTRIES} oldest-out so a long-running
+ * shell doesn't accumulate stale entries from removed plugins.
+ */
+export function saveNativeWindowGeometry(
+	baseId: string,
+	geometry: SavedGeometry,
+): void {
+	if ( ! baseId ) {
+		return;
+	}
+	const width = Math.round( Number( geometry.width ) );
+	const height = Math.round( Number( geometry.height ) );
+	if (
+		! Number.isFinite( width ) ||
+		! Number.isFinite( height ) ||
+		width <= 0 ||
+		height <= 0 ||
+		width > MAX_DIMENSION ||
+		height > MAX_DIMENSION
+	) {
+		return;
+	}
+	const map = readMap();
+	const prev = map[ baseId ];
+	if ( prev && prev.width === width && prev.height === height ) {
+		return;
+	}
+	// Move-to-end (delete + re-insert) so recently-used ids survive
+	// the trim. JS object insertion order on string keys is preserved
+	// per ES2015+ which all browsers we ship to honor.
+	delete map[ baseId ];
+	map[ baseId ] = { width, height };
+	const keys = Object.keys( map );
+	if ( keys.length > MAX_ENTRIES ) {
+		const trimmed: StoredMap = {};
+		for ( const key of keys.slice( -MAX_ENTRIES ) ) {
+			trimmed[ key ] = map[ key ];
+		}
+		writeMap( trimmed );
+		return;
+	}
+	writeMap( map );
+}
+
+/** Test-only — reset persisted state between cases. */
+export function __resetNativeWindowGeometryForTests(): void {
+	try {
+		window.localStorage.removeItem( NATIVE_GEOMETRY_STORAGE_KEY );
+	} catch {
+		/* nothing to reset */
+	}
+}

--- a/tests/vitest/native-window-geometry.test.ts
+++ b/tests/vitest/native-window-geometry.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the per-baseId native-window geometry store.
+ *
+ * Native windows are excluded from the server-side session snapshot
+ * because their `render` callback is a JS closure. This module keeps
+ * "the size I picked last time" on the client in localStorage —
+ * orthogonal from the session restore but reads in the same
+ * `openFromEntry` path so a user's resize survives a reload.
+ *
+ * @see https://github.com/Automattic/wp-desktop-mode/issues/203
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+	__resetNativeWindowGeometryForTests,
+	NATIVE_GEOMETRY_STORAGE_KEY,
+	loadNativeWindowGeometry,
+	saveNativeWindowGeometry,
+} from '../../src/window-manager/native-window-geometry';
+
+describe( 'native-window-geometry', () => {
+	beforeEach( () => {
+		__resetNativeWindowGeometryForTests();
+	} );
+	afterEach( () => {
+		__resetNativeWindowGeometryForTests();
+	} );
+
+	test( 'load returns null when nothing is stored', () => {
+		expect( loadNativeWindowGeometry( 'desktop-mode-plugins' ) ).toBeNull();
+	} );
+
+	test( 'save then load round-trips width and height', () => {
+		saveNativeWindowGeometry( 'desktop-mode-plugins', {
+			width: 1500,
+			height: 900,
+		} );
+
+		expect( loadNativeWindowGeometry( 'desktop-mode-plugins' ) ).toEqual( {
+			width: 1500,
+			height: 900,
+		} );
+	} );
+
+	test( 'save rounds non-integer dimensions to whole pixels', () => {
+		saveNativeWindowGeometry( 'demo', { width: 1280.6, height: 720.4 } );
+
+		expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+			width: 1281,
+			height: 720,
+		} );
+	} );
+
+	test( 'save ignores non-positive or non-finite dimensions', () => {
+		saveNativeWindowGeometry( 'a', { width: 0, height: 600 } );
+		saveNativeWindowGeometry( 'b', { width: 800, height: -1 } );
+		saveNativeWindowGeometry( 'c', { width: NaN, height: 600 } );
+		saveNativeWindowGeometry( 'd', { width: Infinity, height: 600 } );
+
+		expect( loadNativeWindowGeometry( 'a' ) ).toBeNull();
+		expect( loadNativeWindowGeometry( 'b' ) ).toBeNull();
+		expect( loadNativeWindowGeometry( 'c' ) ).toBeNull();
+		expect( loadNativeWindowGeometry( 'd' ) ).toBeNull();
+	} );
+
+	test( 'save ignores entries past the sanity ceiling', () => {
+		saveNativeWindowGeometry( 'huge', { width: 9000, height: 600 } );
+
+		expect( loadNativeWindowGeometry( 'huge' ) ).toBeNull();
+	} );
+
+	test( 'save with empty baseId is a no-op', () => {
+		saveNativeWindowGeometry( '', { width: 800, height: 600 } );
+
+		// No key would be created — the next call returns the
+		// default-empty store.
+		expect(
+			window.localStorage.getItem( NATIVE_GEOMETRY_STORAGE_KEY ),
+		).toBeNull();
+	} );
+
+	test( 'load tolerates corrupt JSON', () => {
+		window.localStorage.setItem(
+			NATIVE_GEOMETRY_STORAGE_KEY,
+			'{not-json',
+		);
+
+		expect( loadNativeWindowGeometry( 'anything' ) ).toBeNull();
+	} );
+
+	test( 'load tolerates a non-object payload', () => {
+		window.localStorage.setItem( NATIVE_GEOMETRY_STORAGE_KEY, '"oops"' );
+
+		expect( loadNativeWindowGeometry( 'anything' ) ).toBeNull();
+	} );
+
+	test( 'load returns null for entries with malformed dimensions', () => {
+		window.localStorage.setItem(
+			NATIVE_GEOMETRY_STORAGE_KEY,
+			JSON.stringify( {
+				bad: { width: 'wide', height: 600 },
+			} ),
+		);
+
+		expect( loadNativeWindowGeometry( 'bad' ) ).toBeNull();
+	} );
+
+	test( 'save overwrites the previous size for the same baseId', () => {
+		saveNativeWindowGeometry( 'demo', { width: 800, height: 600 } );
+		saveNativeWindowGeometry( 'demo', { width: 1400, height: 900 } );
+
+		expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+			width: 1400,
+			height: 900,
+		} );
+	} );
+
+	test( 'trims the store to a bounded size, evicting the oldest', () => {
+		// Save 70 distinct ids — exceeds the 64-entry cap. The first
+		// few should be evicted to make room for the latest.
+		for ( let i = 0; i < 70; i++ ) {
+			saveNativeWindowGeometry( `app-${ i }`, {
+				width: 800 + i,
+				height: 600,
+			} );
+		}
+
+		// The earliest entries are gone; recent ones survive.
+		expect( loadNativeWindowGeometry( 'app-0' ) ).toBeNull();
+		expect( loadNativeWindowGeometry( 'app-5' ) ).toBeNull();
+		expect( loadNativeWindowGeometry( 'app-69' ) ).toEqual( {
+			width: 869,
+			height: 600,
+		} );
+	} );
+
+	test( 'a recently-touched id moves to the front of the eviction queue', () => {
+		for ( let i = 0; i < 64; i++ ) {
+			saveNativeWindowGeometry( `app-${ i }`, {
+				width: 800,
+				height: 600,
+			} );
+		}
+
+		// Touch app-0 — should now be the youngest, not the oldest.
+		saveNativeWindowGeometry( 'app-0', { width: 1500, height: 900 } );
+
+		// One more save pushes the store back past the cap. With the
+		// move-to-end behavior, app-1 (the next oldest) gets evicted,
+		// not app-0.
+		saveNativeWindowGeometry( 'app-99', { width: 800, height: 600 } );
+
+		expect( loadNativeWindowGeometry( 'app-0' ) ).toEqual( {
+			width: 1500,
+			height: 900,
+		} );
+		expect( loadNativeWindowGeometry( 'app-1' ) ).toBeNull();
+		expect( loadNativeWindowGeometry( 'app-99' ) ).toEqual( {
+			width: 800,
+			height: 600,
+		} );
+	} );
+} );

--- a/tests/vitest/native-window-geometry.test.ts
+++ b/tests/vitest/native-window-geometry.test.ts
@@ -15,6 +15,8 @@ import {
 	NATIVE_GEOMETRY_STORAGE_KEY,
 	loadNativeWindowGeometry,
 	saveNativeWindowGeometry,
+	saveNativeWindowPosition,
+	setNativeWindowSavedState,
 } from '../../src/window-manager/native-window-geometry';
 
 describe( 'native-window-geometry', () => {
@@ -130,6 +132,180 @@ describe( 'native-window-geometry', () => {
 		expect( loadNativeWindowGeometry( 'app-69' ) ).toEqual( {
 			width: 869,
 			height: 600,
+		} );
+	} );
+
+	describe( 'saved window position', () => {
+		test( 'save then load round-trips x and y alongside size', () => {
+			saveNativeWindowGeometry( 'demo', { width: 800, height: 600 } );
+			saveNativeWindowPosition( 'demo', { x: 240, y: 120 } );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 800,
+				height: 600,
+				x: 240,
+				y: 120,
+			} );
+		} );
+
+		test( 'saveNativeWindowPosition is a no-op when no prior entry exists', () => {
+			saveNativeWindowPosition( 'demo', { x: 240, y: 120 } );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toBeNull();
+		} );
+
+		test( 'saveNativeWindowPosition rounds to whole pixels', () => {
+			saveNativeWindowGeometry( 'demo', { width: 800, height: 600 } );
+			saveNativeWindowPosition( 'demo', { x: 240.7, y: 120.2 } );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 800,
+				height: 600,
+				x: 241,
+				y: 120,
+			} );
+		} );
+
+		test( 'saveNativeWindowPosition rejects negative or non-finite values', () => {
+			saveNativeWindowGeometry( 'demo', { width: 800, height: 600 } );
+
+			saveNativeWindowPosition( 'demo', { x: -10, y: 120 } );
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 800,
+				height: 600,
+			} );
+
+			saveNativeWindowPosition( 'demo', { x: NaN, y: 0 } );
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 800,
+				height: 600,
+			} );
+		} );
+
+		test( 'saveNativeWindowGeometry preserves a previously-saved position', () => {
+			saveNativeWindowGeometry( 'demo', { width: 800, height: 600 } );
+			saveNativeWindowPosition( 'demo', { x: 240, y: 120 } );
+
+			saveNativeWindowGeometry( 'demo', { width: 1500, height: 900 } );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+				x: 240,
+				y: 120,
+			} );
+		} );
+
+		test( 'setNativeWindowSavedState preserves a previously-saved position', () => {
+			saveNativeWindowGeometry( 'demo', { width: 800, height: 600 } );
+			saveNativeWindowPosition( 'demo', { x: 240, y: 120 } );
+
+			setNativeWindowSavedState( 'demo', 'maximized' );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 800,
+				height: 600,
+				x: 240,
+				y: 120,
+				state: 'maximized',
+			} );
+		} );
+
+		test( 'loadNativeWindowGeometry drops malformed position values', () => {
+			window.localStorage.setItem(
+				NATIVE_GEOMETRY_STORAGE_KEY,
+				JSON.stringify( {
+					demo: {
+						width: 800,
+						height: 600,
+						x: 'left',
+						y: 120,
+					},
+				} ),
+			);
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 800,
+				height: 600,
+			} );
+		} );
+	} );
+
+	describe( 'saved window state', () => {
+		test( 'setNativeWindowSavedState seeds a new entry from defaults', () => {
+			setNativeWindowSavedState( 'demo', 'maximized', {
+				width: 520,
+				height: 400,
+			} );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 520,
+				height: 400,
+				state: 'maximized',
+			} );
+		} );
+
+		test( 'setNativeWindowSavedState without defaults is a no-op when nothing is stored yet', () => {
+			setNativeWindowSavedState( 'demo', 'maximized' );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toBeNull();
+		} );
+
+		test( 'setNativeWindowSavedState layers state on an existing size without changing it', () => {
+			saveNativeWindowGeometry( 'demo', { width: 1500, height: 900 } );
+
+			setNativeWindowSavedState( 'demo', 'maximized' );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+				state: 'maximized',
+			} );
+		} );
+
+		test( 'setNativeWindowSavedState(null) clears the state but keeps the size', () => {
+			saveNativeWindowGeometry( 'demo', { width: 1500, height: 900 } );
+			setNativeWindowSavedState( 'demo', 'maximized' );
+
+			setNativeWindowSavedState( 'demo', null );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+			} );
+		} );
+
+		test( 'saveNativeWindowGeometry preserves the previously-saved state', () => {
+			setNativeWindowSavedState( 'demo', 'maximized', {
+				width: 520,
+				height: 400,
+			} );
+
+			saveNativeWindowGeometry( 'demo', { width: 1500, height: 900 } );
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+				state: 'maximized',
+			} );
+		} );
+
+		test( 'loadNativeWindowGeometry drops unknown state values', () => {
+			window.localStorage.setItem(
+				NATIVE_GEOMETRY_STORAGE_KEY,
+				JSON.stringify( {
+					demo: {
+						width: 1500,
+						height: 900,
+						state: 'rotated-3d', // unsupported
+					},
+				} ),
+			);
+
+			expect( loadNativeWindowGeometry( 'demo' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+			} );
 		} );
 	} );
 

--- a/tests/vitest/native-windows-sync.test.ts
+++ b/tests/vitest/native-windows-sync.test.ts
@@ -24,6 +24,7 @@ import {
 	__resetNativeWindowGeometryForTests,
 	loadNativeWindowGeometry,
 	saveNativeWindowGeometry,
+	setNativeWindowSavedState,
 } from '../../src/window-manager/native-window-geometry';
 import { HOOKS } from '../../src/hooks';
 import type { WindowManager } from '../../src/window-manager';
@@ -49,6 +50,7 @@ function setupHarness(): Harness {
 	const manager = {
 		open: managerOpen,
 		getById: () => null,
+		getByBaseIdOnActiveDesktop: () => undefined,
 		getFocused: () => null,
 		getAll: () => [],
 		getCount: () => 0,
@@ -358,6 +360,30 @@ describe( 'native-windows.createNativeWindowSync — live activation / deactivat
 			expect( call.height ).toBe( 900 );
 		} );
 
+		test( 'openById does not pin x / y, so createWindow can apply the saved position', async () => {
+			// Regression: native open path used to hard-code
+			// `x: 0, y: 0`, which short-circuited the saved-position
+			// replay in `WindowManager.createWindow`. After dragging
+			// a native window like Posts to the bottom-right, closing
+			// it, and reopening from the dock, it would land back at
+			// (0, 0) instead of the user's last position.
+			const h = setupHarness();
+			const { sync, openById } = createNativeWindowSync(
+				depsFromHarness( h ),
+			);
+
+			await sync( [ entry( 'calculator' ) ] );
+
+			openById( 'calculator' );
+
+			const call = h.managerOpen.mock.calls[ 0 ]?.[ 0 ] as {
+				x?: number;
+				y?: number;
+			};
+			expect( call.x ).toBeUndefined();
+			expect( call.y ).toBeUndefined();
+		} );
+
 		test( 'a stored size smaller than the current minimum is clamped up', async () => {
 			// A previous version registered a smaller minimum and the
 			// user resized down. After the plugin update raises
@@ -415,7 +441,7 @@ describe( 'native-windows.createNativeWindowSync — live activation / deactivat
 			} );
 		} );
 
-		test( 'WINDOW_RESIZE_END is ignored when the resized window is not native', async () => {
+		test( 'WINDOW_RESIZE_END persists the new size for classic (non-native) windows too', async () => {
 			const h = setupHarness();
 			h.manager.getById = ( () => ( {
 				id: 'edit-php',
@@ -431,10 +457,13 @@ describe( 'native-windows.createNativeWindowSync — live activation / deactivat
 				height: 900,
 			} );
 
-			expect( loadNativeWindowGeometry( 'edit-php' ) ).toBeNull();
+			expect( loadNativeWindowGeometry( 'edit-php' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+			} );
 		} );
 
-		test( 'WINDOW_RESIZE_END is ignored when the native window is not in normal state', async () => {
+		test( 'WINDOW_RESIZE_END is ignored when the window is not in normal state', async () => {
 			const h = setupHarness();
 			h.manager.getById = ( () => ( {
 				id: 'calculator',
@@ -452,5 +481,121 @@ describe( 'native-windows.createNativeWindowSync — live activation / deactivat
 
 			expect( loadNativeWindowGeometry( 'calculator' ) ).toBeNull();
 		} );
+
+		test( 'WINDOW_MAXIMIZED records the maximize preference, preserving the floating size', async () => {
+			saveNativeWindowGeometry( 'calculator', {
+				width: 1500,
+				height: 900,
+			} );
+
+			const h = setupHarness();
+			h.manager.getById = ( () => ( {
+				id: 'calculator',
+				state: 'maximized' as const,
+				config: { native: true, baseId: 'calculator' },
+			} ) ) as WindowManager[ 'getById' ];
+
+			const { sync } = createNativeWindowSync( depsFromHarness( h ) );
+			await sync( [
+				entry( 'calculator', { width: 520, height: 400 } ),
+			] );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_MAXIMIZED, {
+				windowId: 'calculator',
+			} );
+
+			expect( loadNativeWindowGeometry( 'calculator' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+				state: 'maximized',
+			} );
+		} );
+
+		test( 'WINDOW_MAXIMIZED seeds floating size from entry defaults when nothing was stored', async () => {
+			const h = setupHarness();
+			h.manager.getById = ( () => ( {
+				id: 'calculator',
+				state: 'maximized' as const,
+				config: { native: true, baseId: 'calculator' },
+			} ) ) as WindowManager[ 'getById' ];
+
+			const { sync } = createNativeWindowSync( depsFromHarness( h ) );
+			await sync( [
+				entry( 'calculator', { width: 520, height: 400 } ),
+			] );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_MAXIMIZED, {
+				windowId: 'calculator',
+			} );
+
+			expect( loadNativeWindowGeometry( 'calculator' ) ).toEqual( {
+				width: 520,
+				height: 400,
+				state: 'maximized',
+			} );
+		} );
+
+		test( 'WINDOW_DRAG_END seeds size + position even when nothing was previously stored', async () => {
+			// Regression: open-drag-close (no manual resize) was
+			// dropping the position because `saveNativeWindowPosition`
+			// requires a prior entry to layer onto.
+			const h = setupHarness();
+			const element = document.createElement( 'div' );
+			Object.defineProperty( element, 'offsetLeft', { value: 1200, configurable: true } );
+			Object.defineProperty( element, 'offsetTop', { value: 700, configurable: true } );
+			Object.defineProperty( element, 'offsetWidth', { value: 820, configurable: true } );
+			Object.defineProperty( element, 'offsetHeight', { value: 540, configurable: true } );
+			h.manager.getById = ( () => ( {
+				id: 'edit-php',
+				state: 'normal' as const,
+				config: { native: false, baseId: 'edit-php' },
+				element,
+			} ) ) as WindowManager[ 'getById' ];
+
+			createNativeWindowSync( depsFromHarness( h ) );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_DRAG_END, {
+				windowId: 'edit-php',
+				x: 1200,
+				y: 700,
+			} );
+
+			expect( loadNativeWindowGeometry( 'edit-php' ) ).toEqual( {
+				width: 820,
+				height: 540,
+				x: 1200,
+				y: 700,
+			} );
+		} );
+
+		test( 'WINDOW_UNMAXIMIZED clears the maximize preference, preserving the floating size', async () => {
+			setNativeWindowSavedState( 'calculator', 'maximized', {
+				width: 520,
+				height: 400,
+			} );
+			saveNativeWindowGeometry( 'calculator', {
+				width: 1500,
+				height: 900,
+			} );
+
+			const h = setupHarness();
+			h.manager.getById = ( () => ( {
+				id: 'calculator',
+				state: 'normal' as const,
+				config: { native: true, baseId: 'calculator' },
+			} ) ) as WindowManager[ 'getById' ];
+
+			createNativeWindowSync( depsFromHarness( h ) );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_UNMAXIMIZED, {
+				windowId: 'calculator',
+			} );
+
+			expect( loadNativeWindowGeometry( 'calculator' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+			} );
+		} );
+
 	} );
 } );

--- a/tests/vitest/native-windows-sync.test.ts
+++ b/tests/vitest/native-windows-sync.test.ts
@@ -20,6 +20,12 @@ import { Dock } from '../../src/dock';
 import { createNativeWindowSync } from '../../src/native-windows';
 import * as vendorLoader from '../../src/wallpapers/vendor-loader';
 import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import {
+	__resetNativeWindowGeometryForTests,
+	loadNativeWindowGeometry,
+	saveNativeWindowGeometry,
+} from '../../src/window-manager/native-window-geometry';
+import { HOOKS } from '../../src/hooks';
 import type { WindowManager } from '../../src/window-manager';
 import type { NativeWindowServerEntry } from '../../src/types';
 
@@ -101,6 +107,7 @@ function tilesIn( el: HTMLElement ): string[] {
 describe( 'native-windows.createNativeWindowSync — live activation / deactivation', () => {
 	beforeEach( () => {
 		installHooksStub();
+		__resetNativeWindowGeometryForTests();
 		// `loadVendorScript` is exercised when an entry has a non-empty
 		// scriptUrl. We stub it so tests don't try to inject real
 		// `<script>` tags. Most tests use scriptUrl='' and bypass it.
@@ -108,6 +115,7 @@ describe( 'native-windows.createNativeWindowSync — live activation / deactivat
 	} );
 	afterEach( () => {
 		clearHooksStub();
+		__resetNativeWindowGeometryForTests();
 		vi.restoreAllMocks();
 		document.body.innerHTML = '';
 	} );
@@ -291,5 +299,158 @@ describe( 'native-windows.createNativeWindowSync — live activation / deactivat
 
 		await sync( [] );
 		expect( openById( 'calculator' ) ).toBe( false );
+	} );
+
+	describe( 'remembered window size (issue #203)', () => {
+		test( 'openById uses the registered defaults when nothing is remembered', async () => {
+			const h = setupHarness();
+			const { sync, openById } = createNativeWindowSync(
+				depsFromHarness( h ),
+			);
+
+			await sync( [
+				entry( 'calculator', {
+					width: 520,
+					height: 400,
+					minWidth: 280,
+					minHeight: 220,
+				} ),
+			] );
+
+			openById( 'calculator' );
+
+			expect( h.managerOpen ).toHaveBeenCalledTimes( 1 );
+			const call = h.managerOpen.mock.calls[ 0 ]?.[ 0 ] as {
+				width: number;
+				height: number;
+			};
+			expect( call.width ).toBe( 520 );
+			expect( call.height ).toBe( 400 );
+		} );
+
+		test( 'openById prefers a previously-saved size over the registered defaults', async () => {
+			saveNativeWindowGeometry( 'calculator', {
+				width: 1500,
+				height: 900,
+			} );
+
+			const h = setupHarness();
+			const { sync, openById } = createNativeWindowSync(
+				depsFromHarness( h ),
+			);
+
+			await sync( [
+				entry( 'calculator', {
+					width: 520,
+					height: 400,
+					minWidth: 280,
+					minHeight: 220,
+				} ),
+			] );
+
+			openById( 'calculator' );
+
+			const call = h.managerOpen.mock.calls[ 0 ]?.[ 0 ] as {
+				width: number;
+				height: number;
+			};
+			expect( call.width ).toBe( 1500 );
+			expect( call.height ).toBe( 900 );
+		} );
+
+		test( 'a stored size smaller than the current minimum is clamped up', async () => {
+			// A previous version registered a smaller minimum and the
+			// user resized down. After the plugin update raises
+			// minWidth, the next open must respect the new floor.
+			saveNativeWindowGeometry( 'calculator', {
+				width: 320,
+				height: 240,
+			} );
+
+			const h = setupHarness();
+			const { sync, openById } = createNativeWindowSync(
+				depsFromHarness( h ),
+			);
+
+			await sync( [
+				entry( 'calculator', {
+					width: 520,
+					height: 400,
+					minWidth: 500,
+					minHeight: 350,
+				} ),
+			] );
+
+			openById( 'calculator' );
+
+			const call = h.managerOpen.mock.calls[ 0 ]?.[ 0 ] as {
+				width: number;
+				height: number;
+			};
+			expect( call.width ).toBe( 500 );
+			expect( call.height ).toBe( 350 );
+		} );
+
+		test( 'WINDOW_RESIZE_END persists the new size for a native window in normal state', async () => {
+			const h = setupHarness();
+			const fakeWin = {
+				id: 'calculator',
+				state: 'normal' as const,
+				config: { native: true, baseId: 'calculator' },
+			};
+			h.manager.getById = ( ( id: string ) =>
+				id === 'calculator' ? fakeWin : null ) as WindowManager[ 'getById' ];
+
+			createNativeWindowSync( depsFromHarness( h ) );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_RESIZE_END, {
+				windowId: 'calculator',
+				width: 1500,
+				height: 900,
+			} );
+
+			expect( loadNativeWindowGeometry( 'calculator' ) ).toEqual( {
+				width: 1500,
+				height: 900,
+			} );
+		} );
+
+		test( 'WINDOW_RESIZE_END is ignored when the resized window is not native', async () => {
+			const h = setupHarness();
+			h.manager.getById = ( () => ( {
+				id: 'edit-php',
+				state: 'normal' as const,
+				config: { native: false, baseId: 'edit-php' },
+			} ) ) as WindowManager[ 'getById' ];
+
+			createNativeWindowSync( depsFromHarness( h ) );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_RESIZE_END, {
+				windowId: 'edit-php',
+				width: 1500,
+				height: 900,
+			} );
+
+			expect( loadNativeWindowGeometry( 'edit-php' ) ).toBeNull();
+		} );
+
+		test( 'WINDOW_RESIZE_END is ignored when the native window is not in normal state', async () => {
+			const h = setupHarness();
+			h.manager.getById = ( () => ( {
+				id: 'calculator',
+				state: 'maximized' as const,
+				config: { native: true, baseId: 'calculator' },
+			} ) ) as WindowManager[ 'getById' ];
+
+			createNativeWindowSync( depsFromHarness( h ) );
+
+			window.wp!.hooks.doAction( HOOKS.WINDOW_RESIZE_END, {
+				windowId: 'calculator',
+				width: 1500,
+				height: 900,
+			} );
+
+			expect( loadNativeWindowGeometry( 'calculator' ) ).toBeNull();
+		} );
 	} );
 } );

--- a/tests/vitest/window-manager-geometry-replay.test.ts
+++ b/tests/vitest/window-manager-geometry-replay.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests that `WindowManager.createWindow` consults the per-baseId
+ * geometry store as a fallback when the caller doesn't pin
+ * dimensions or state.
+ *
+ * This covers the path used by classic (iframe-backed) windows
+ * opened from a dock-icon click or a desktop icon, where no
+ * width / height is provided and the default cascade-from-rect math
+ * would otherwise win.
+ *
+ * @see https://github.com/Automattic/wp-desktop-mode/issues/203
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import {
+	__resetNativeWindowGeometryForTests,
+	saveNativeWindowGeometry,
+	saveNativeWindowPosition,
+	setNativeWindowSavedState,
+} from '../../src/window-manager/native-window-geometry';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+function openConfig( id: string, extras: Record< string, unknown > = {} ) {
+	return {
+		id,
+		baseId: id,
+		url: `http://example.test/wp-admin/${ id }.php`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+		...extras,
+	};
+}
+
+describe( 'WindowManager geometry replay (issue #203)', () => {
+	let desktopArea: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		__resetNativeWindowGeometryForTests();
+		desktopArea = document.createElement( 'div' );
+		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		Object.defineProperty( desktopArea, 'clientWidth', {
+			value: 1600,
+			configurable: true,
+		} );
+		Object.defineProperty( desktopArea, 'clientHeight', {
+			value: 900,
+			configurable: true,
+		} );
+		document.body.appendChild( desktopArea );
+		manager = new WindowManager( desktopArea );
+	} );
+
+	afterEach( () => {
+		for ( const win of manager.getAll() ) {
+			win.destroy();
+		}
+		desktopArea.remove();
+		clearHooksStub();
+		__resetNativeWindowGeometryForTests();
+	} );
+
+	test( 'no saved entry: falls back to the desktopRect-based default size', async () => {
+		const win = await manager.open( openConfig( 'edit-php' ) );
+
+		// Default is min(rect.width * 0.8, 1200) = min(1280, 1200) = 1200.
+		expect( win.config.width ).toBe( 1200 );
+		// Default is min(rect.height * 0.8, 800) = min(720, 800) = 720.
+		expect( win.config.height ).toBe( 720 );
+	} );
+
+	test( 'saved size: a fresh open lands at the persisted dimensions', async () => {
+		saveNativeWindowGeometry( 'edit-php', {
+			width: 1400,
+			height: 880,
+		} );
+
+		const win = await manager.open( openConfig( 'edit-php' ) );
+
+		expect( win.config.width ).toBe( 1400 );
+		expect( win.config.height ).toBe( 880 );
+	} );
+
+	test( 'explicit width / height from the caller wins over the saved entry', async () => {
+		// Session restore passes explicit dimensions. The saved
+		// localStorage value must not override.
+		saveNativeWindowGeometry( 'edit-php', {
+			width: 1400,
+			height: 880,
+		} );
+
+		const win = await manager.open(
+			openConfig( 'edit-php', { width: 700, height: 500 } ),
+		);
+
+		expect( win.config.width ).toBe( 700 );
+		expect( win.config.height ).toBe( 500 );
+	} );
+
+	test( 'saved size is clamped up to the registered minimum', async () => {
+		saveNativeWindowGeometry( 'desktop-mode-plugins', {
+			width: 320,
+			height: 240,
+		} );
+
+		const win = await manager.open(
+			openConfig( 'desktop-mode-plugins', {
+				minWidth: 760,
+				minHeight: 480,
+			} ),
+		);
+
+		expect( win.config.width ).toBe( 760 );
+		expect( win.config.height ).toBe( 480 );
+	} );
+
+	test( 'saved state="maximized" replays as initialState on a fresh open', async () => {
+		setNativeWindowSavedState( 'edit-php', 'maximized', {
+			width: 1400,
+			height: 880,
+		} );
+
+		const win = await manager.open( openConfig( 'edit-php' ) );
+
+		expect( win.config.initialState ).toBe( 'maximized' );
+	} );
+
+	test( 'openNew always opens floating regardless of the saved state', async () => {
+		setNativeWindowSavedState( 'edit-php', 'maximized', {
+			width: 1400,
+			height: 880,
+		} );
+
+		const win = await manager.openNew(
+			openConfig( 'edit-php', { multi: true } ),
+		);
+
+		expect( win.config.initialState ).toBe( 'normal' );
+	} );
+
+	test( 'session-restore initialState wins over the saved state', async () => {
+		setNativeWindowSavedState( 'edit-php', 'maximized', {
+			width: 1400,
+			height: 880,
+		} );
+
+		const win = await manager.open(
+			openConfig( 'edit-php', { initialState: 'minimized' } ),
+		);
+
+		expect( win.config.initialState ).toBe( 'minimized' );
+	} );
+
+	describe( 'position replay', () => {
+		test( 'saved x / y are applied on a fresh primary open', async () => {
+			saveNativeWindowGeometry( 'edit-php', {
+				width: 800,
+				height: 600,
+			} );
+			saveNativeWindowPosition( 'edit-php', { x: 240, y: 160 } );
+
+			const win = await manager.open( openConfig( 'edit-php' ) );
+
+			expect( win.config.x ).toBe( 240 );
+			expect( win.config.y ).toBe( 160 );
+		} );
+
+		test( 'no saved position falls back to the cascade-from-rect default', async () => {
+			saveNativeWindowGeometry( 'edit-php', {
+				width: 800,
+				height: 600,
+			} );
+
+			const win = await manager.open( openConfig( 'edit-php' ) );
+
+			// Default cascade is `40 + (0 % 8) * CASCADE_OFFSET = 40`.
+			expect( win.config.x ).toBe( 40 );
+			expect( win.config.y ).toBe( 40 );
+		} );
+
+		test( 'a saved position outside the current viewport is clamped back inside', async () => {
+			// Simulates an ultrawide-to-laptop transition. The
+			// 1600x900 desktop in this harness can't honour a saved
+			// x=2800.
+			saveNativeWindowGeometry( 'edit-php', {
+				width: 800,
+				height: 600,
+			} );
+			saveNativeWindowPosition( 'edit-php', { x: 2800, y: 2000 } );
+
+			const win = await manager.open( openConfig( 'edit-php' ) );
+
+			// max-x = desktopWidth - winWidth - margin = 1600 - 800 - 12 = 788.
+			expect( win.config.x ).toBe( 788 );
+			// max-y = 900 - 600 - 12 = 288.
+			expect( win.config.y ).toBe( 288 );
+		} );
+
+		test( 'explicit caller x / y wins over a saved position', async () => {
+			saveNativeWindowGeometry( 'edit-php', {
+				width: 800,
+				height: 600,
+			} );
+			saveNativeWindowPosition( 'edit-php', { x: 240, y: 160 } );
+
+			const win = await manager.open(
+				openConfig( 'edit-php', { x: 600, y: 400 } ),
+			);
+
+			expect( win.config.x ).toBe( 600 );
+			expect( win.config.y ).toBe( 400 );
+		} );
+
+		test( 'openNew (duplicate) cascades, not replays the primary position', async () => {
+			saveNativeWindowGeometry( 'edit-php', {
+				width: 800,
+				height: 600,
+			} );
+			saveNativeWindowPosition( 'edit-php', { x: 240, y: 160 } );
+
+			const win = await manager.openNew(
+				openConfig( 'edit-php', { multi: true } ),
+			);
+
+			// Duplicate gets a cascade slot, not the saved primary
+			// position. The cascade index for the first window is 0,
+			// so cascade x = 40.
+			expect( win.config.x ).toBe( 40 );
+			expect( win.config.y ).toBe( 40 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Native windows (Plugins, Posts, Users, Comments, Settings, …) reopened at the plugin-author defaults on every open, forcing the user to resize them every time. The Plugins window in particular ships at 1180×760 which is too narrow for the installed-plugins table on many setups.

This adds per-`baseId` `{ width, height }` persistence in localStorage so each native window reopens at the size the user last resized it to.


https://github.com/user-attachments/assets/060d40fd-28a0-4fea-b6e3-f461d2f66c64




## How it works

- New module `src/window-manager/native-window-geometry.ts` — read/write a single localStorage map (`desktop-mode-native-window-geometry`), bounded at 64 entries with LRU eviction, with sanity checks on dimensions.
- `src/native-windows.ts`:
  - `openFromEntry` / `openNewFromEntry` now resolve `{ width, height }` from the saved map when present, falling back to the registered defaults. The stored size is clamped up to the registered `min_width` / `min_height` so raising the minimum in a plugin update never reopens at a no-longer-allowed smaller size.
  - A single `WINDOW_RESIZE_END` listener writes the new size back, but only when the resized window is native AND in `state === 'normal'`. That keeps snap-zone halves, maximized geometry, and fullscreen geometry from poisoning the stored "preferred" size. Programmatic tiles in `arrange.ts` / `snap-zones.ts` go through their own hooks and never fire resize-end, so they don't write either.

Position is intentionally NOT persisted. Cascade-on-open keeps stacked native windows visible across viewport size changes (different monitors, different zoom levels); restoring a remembered position would happily place a window off-screen.

## Why not server-side session restore

Native windows are already skipped from the session snapshot because their `render` callback is a JS closure we can't serialize and rehydrate server-side. Persisting just `{ width, height }` client-side is orthogonal to that constraint and needs no PHP wiring.

## Tests

- `tests/vitest/native-window-geometry.test.ts` (12 cases): round-trip, rounding, invalid input rejection, ceiling, corrupt-JSON tolerance, overwrite, trim, LRU move-to-end.
- `tests/vitest/native-windows-sync.test.ts` (6 new cases under "remembered window size"): default fallback, stored size honored, clamp-up to current minimum, persist-on-resize-end happy path, native-only filter, normal-state-only filter.

## Test plan

- [x] Open the Plugins window from the dock. First time: opens at the default 1180×760.
- [x] Drag the right edge wider so all plugin-table columns fit. Close it.
- [x] Open Plugins again. It opens at the new size.
- [x] Reload the page. Open Plugins. Still at the size you picked.
- [x] Try the same for any other native window (Posts, Users, Comments, Settings).
- [x] Snap the window to a half-screen, then close. Reopen: size should NOT be the snapped half, it should be the last floating size you picked.

Fixes #203

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-207-ce2de89a078a1f896c21797d57f7e1a0e4cecc5f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->