### PR TITLE
Fix blank plugin icons in the Plugins window

### DIFF
--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -292,14 +292,23 @@ function desktop_mode_plugins_window_field_can_manage( $row ) {
 /**
  * `desktop_mode_icon_url` callback.
  *
- * Derives a wp.org icon URL from the plugin's slug. We prefer the
- * SVG (`icon.svg`), fall back to the 256×256 PNG, and finally the
- * 128×128 PNG. We don't HEAD-check the URL — the JS card has an
- * `onerror` fallback to a `<wpd-icon name="dashicons-admin-plugins">`
- * placeholder, so a 404 here costs nothing.
+ * Derives a wp.org icon URL from the plugin's repo slug, which is the
+ * plugin's **folder name** (`dirname( plugin_file )`) — not its text
+ * domain. The two coincide for some plugins, but most ship a textdomain
+ * shorter or differently-suffixed than their .org slug (`woocommerce`
+ * vs textdomain `woo`, `wordpress-seo` vs `yoast-seo`, …). Keying off
+ * the folder is what wp.org's own /assets/ URLs use, so it matches
+ * the broadest set of plugins. Falls back to `textdomain` for
+ * single-file plugins (where `dirname()` returns `.`).
  *
- * Plugins not on the .org repo (premium, internal, single-site) get
- * `null` and the JS falls straight to the placeholder.
+ * We don't HEAD-check the URL — the JS card walks a candidate chain
+ * (SVG → 256 PNG → 128 PNG) on `<img>` error, then drops to a
+ * `<wpd-icon name="dashicons-admin-plugins">` placeholder. A 404 here
+ * costs nothing.
+ *
+ * Plugins not on the .org repo (premium, internal, single-site) will
+ * still produce a URL (we can't tell from REST data alone), and the JS
+ * onerror chain reaches the placeholder after the candidates 404.
  *
  * @since 0.9.0
  *
@@ -307,11 +316,16 @@ function desktop_mode_plugins_window_field_can_manage( $row ) {
  * @return string|null
  */
 function desktop_mode_plugins_window_field_icon_url( $row ) {
-	// Core's controller exposes the directory slug under `textdomain`
-	// for .org plugins (same as the wp.org repo slug). Empty when the
-	// plugin doesn't ship a Text Domain header — fine, we just return
-	// null and the placeholder paints.
-	$slug = isset( $row['textdomain'] ) ? (string) $row['textdomain'] : '';
+	$plugin_file = desktop_mode_plugins_window_row_plugin_file( $row );
+	$folder      = '' !== $plugin_file ? dirname( $plugin_file ) : '';
+	$slug        = ( '' !== $folder && '.' !== $folder ) ? $folder : '';
+
+	if ( '' === $slug ) {
+		// Single-file plugin (e.g. hello.php at the plugins root) —
+		// no folder slug, so fall back to the text domain.
+		$slug = isset( $row['textdomain'] ) ? (string) $row['textdomain'] : '';
+	}
+
 	$slug = sanitize_key( $slug );
 	if ( '' === $slug ) {
 		return null;
@@ -324,10 +338,16 @@ function desktop_mode_plugins_window_field_icon_url( $row ) {
 	 * Return a different URL to override the wp.org default — useful
 	 * for custom CDN art or premium plugins shipping a known asset URL.
 	 *
+	 * The JS receiver walks a candidate chain on `<img>` error,
+	 * swapping `icon.svg` → `icon-256x256.png` → `icon-128x128.png`
+	 * when the returned URL is the wp.org `ps.w.org` default. Custom
+	 * URLs bypass the chain (one shot, then placeholder).
+	 *
 	 * @since 0.9.0
 	 *
-	 * @param string|null $url  Default URL (wp.org SVG by slug).
-	 * @param string      $slug Plugin slug.
+	 * @param string|null $url  Default URL (wp.org SVG by folder slug).
+	 * @param string      $slug Plugin slug (folder name, or textdomain
+	 *                          for single-file plugins).
 	 * @param array       $row  Core REST plugin row.
 	 */
 	return apply_filters(

--- a/src/plugins-window/icon-fallback.ts
+++ b/src/plugins-window/icon-fallback.ts
@@ -1,0 +1,71 @@
+/**
+ * Plugins window — icon URL fallback chain.
+ *
+ * The PHP `desktop_mode_icon_url` REST field returns the wp.org SVG by
+ * default (`https://ps.w.org/<slug>/assets/icon.svg`). Many plugins on
+ * the wp.org repo only ship PNG variants — `icon-256x256.png` or
+ * `icon-128x128.png` — so a one-shot `<img src>` on the SVG 404s and
+ * the row looks iconless even though art exists. This helper attaches
+ * an `error` handler that walks SVG → 256 PNG → 128 PNG before giving
+ * up and calling `onExhausted`, at which point the caller paints its
+ * placeholder.
+ *
+ * Custom URLs (not under `ps.w.org/<slug>/assets/`) bypass the chain —
+ * one shot, then placeholder. That matches what the
+ * `desktop_mode_plugins_window_icon_url` filter docblock promises.
+ *
+ * @public
+ * @since 0.18.0
+ */
+
+const WP_ORG_ASSET_RE =
+	/^(https:\/\/ps\.w\.org\/[a-z0-9-]+\/assets\/)icon\.svg$/i;
+
+/**
+ * Given the URL the PHP field returned, derive the ordered list of
+ * candidates to try. The first entry is always the input URL so the
+ * caller can use the array as a single source of truth.
+ */
+function buildCandidates( initialUrl: string ): string[] {
+	const match = initialUrl.match( WP_ORG_ASSET_RE );
+	if ( ! match ) {
+		return [ initialUrl ];
+	}
+	const base = match[ 1 ];
+	return [
+		initialUrl,
+		base + 'icon-256x256.png',
+		base + 'icon-128x128.png',
+	];
+}
+
+/**
+ * Wire an `<img>` element to walk the wp.org icon candidate chain on
+ * load failure. Returns the first URL it should start with (which the
+ * caller assigns to `img.src`).
+ *
+ * @param img         The `<img>` to monitor.
+ * @param initialUrl  The URL returned by `desktop_mode_icon_url`.
+ * @param onExhausted Invoked when every candidate has 404'd — the
+ *                    caller should paint its placeholder.
+ * @return The URL to assign to `img.src`.
+ */
+export function attachIconFallback(
+	img: HTMLImageElement,
+	initialUrl: string,
+	onExhausted: () => void,
+): string {
+	const candidates = buildCandidates( initialUrl );
+	let index = 0;
+
+	img.addEventListener( 'error', () => {
+		index += 1;
+		if ( index < candidates.length ) {
+			img.src = candidates[ index ];
+			return;
+		}
+		onExhausted();
+	} );
+
+	return candidates[ 0 ];
+}

--- a/src/plugins-window/installed-detail.ts
+++ b/src/plugins-window/installed-detail.ts
@@ -17,6 +17,7 @@
 import { __, sprintf } from '../i18n';
 import { buildStarCluster } from './card';
 import { fetchPluginInfo, fetchPluginReviews } from './rest';
+import { attachIconFallback } from './icon-fallback';
 import type {
 	InstalledPlugin,
 	PluginReview,
@@ -174,11 +175,10 @@ function buildHero( row: InstalledPlugin, _slug: string ): HTMLElement {
 	const iconUrl = row.desktop_mode_icon_url;
 	if ( iconUrl ) {
 		const img = document.createElement( 'img' );
-		img.src = iconUrl;
 		img.alt = '';
 		img.loading = 'lazy';
 		img.decoding = 'async';
-		img.addEventListener( 'error', () => {
+		img.src = attachIconFallback( img, iconUrl, () => {
 			iconTile.replaceChildren( buildFallbackGlyph() );
 		} );
 		iconTile.appendChild( img );
@@ -1203,9 +1203,22 @@ function deriveSlug( row: InstalledPlugin ): string {
 	if ( ! row.desktop_mode_icon_url ) {
 		return '';
 	}
+	// `update_plugins` transient carries the canonical wp.org slug
+	// when the plugin has a pending update — prefer it.
 	const fromUpdate = row.desktop_mode_update_available?.slug;
 	if ( fromUpdate ) {
 		return fromUpdate;
+	}
+	// Folder name is the wp.org repo slug for nearly every installed
+	// plugin on the directory. Textdomain only matches for a minority,
+	// so it's the last-resort fallback (single-file plugins where the
+	// folder is `.`).
+	const file = typeof row.plugin === 'string' ? row.plugin : '';
+	if ( file ) {
+		const slash = file.indexOf( '/' );
+		if ( slash > 0 ) {
+			return file.slice( 0, slash );
+		}
 	}
 	if ( row.textdomain ) {
 		return String( row.textdomain );

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -18,6 +18,7 @@ import { __, sprintf } from '../i18n';
 import { broadcast, subscribe } from '../broadcast';
 import { enqueueUpdateJob } from './update-queue';
 import { buildInstalledDetail } from './installed-detail';
+import { attachIconFallback } from './icon-fallback';
 import {
 	activateInstalledPlugin,
 	deactivateInstalledPlugin,
@@ -333,14 +334,13 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		const url = row.desktop_mode_icon_url;
 		if ( url ) {
 			const img = document.createElement( 'img' );
-			img.src = url;
 			img.alt = '';
 			img.loading = 'lazy';
 			img.decoding = 'async';
 			img.style.cssText =
 				'width:100%;height:100%;max-width:100%;max-height:100%;' +
 				'object-fit:contain;display:block;';
-			img.addEventListener( 'error', () => {
+			img.src = attachIconFallback( img, url, () => {
 				icon.replaceChildren( buildFallbackIcon() );
 			} );
 			icon.appendChild( img );

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -415,11 +415,12 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 
 	/**
 	 * `desktop_mode_icon_url` should derive a wp.org icon URL from the
-	 * row's `textdomain` and respect the per-row filter.
+	 * plugin's folder name — the wp.org repo slug. Textdomain is a
+	 * fallback only for single-file plugins.
 	 *
 	 * @covers ::desktop_mode_plugins_window_field_icon_url
 	 */
-	public function test_icon_url_derives_from_textdomain() {
+	public function test_icon_url_derives_from_folder_slug() {
 		$row = array(
 			'plugin'     => 'akismet/akismet.php',
 			'textdomain' => 'akismet',
@@ -432,11 +433,59 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Folder name and textdomain often diverge (e.g. WooCommerce ships
+	 * folder `woocommerce` but text domain `woo`). The .org repo URL
+	 * is keyed on the folder, so that's what we must use.
+	 *
 	 * @covers ::desktop_mode_plugins_window_field_icon_url
 	 */
-	public function test_icon_url_returns_null_when_no_textdomain() {
+	public function test_icon_url_prefers_folder_over_mismatched_textdomain() {
+		$row = array(
+			'plugin'     => 'woocommerce/woocommerce.php',
+			'textdomain' => 'woo',
+		);
+		$url = desktop_mode_plugins_window_field_icon_url( $row );
+		$this->assertSame(
+			'https://ps.w.org/woocommerce/assets/icon.svg',
+			$url
+		);
+	}
+
+	/**
+	 * Plugins with no `Text Domain:` header still resolve via folder
+	 * name — the dominant cause of the "blank icon" regression that
+	 * the textdomain-only resolver produced.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_icon_url
+	 */
+	public function test_icon_url_works_without_textdomain() {
 		$row = array( 'plugin' => 'something/something.php' );
-		$this->assertNull( desktop_mode_plugins_window_field_icon_url( $row ) );
+		$this->assertSame(
+			'https://ps.w.org/something/assets/icon.svg',
+			desktop_mode_plugins_window_field_icon_url( $row )
+		);
+	}
+
+	/**
+	 * Single-file plugins (no folder) fall back to textdomain. With
+	 * neither folder nor textdomain available, the field is null and
+	 * JS paints the placeholder.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_icon_url
+	 */
+	public function test_icon_url_single_file_uses_textdomain_fallback() {
+		$row = array(
+			'plugin'     => 'hello.php',
+			'textdomain' => 'hello-dolly',
+		);
+		$this->assertSame(
+			'https://ps.w.org/hello-dolly/assets/icon.svg',
+			desktop_mode_plugins_window_field_icon_url( $row )
+		);
+
+		$this->assertNull(
+			desktop_mode_plugins_window_field_icon_url( array( 'plugin' => 'hello.php' ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes #201 

## Problem

In the Installed tab of the native Plugins window, only ~6 of 34 plugin
rows showed an icon — the rest rendered a blank grey square (the empty
container before the dashicon fallback painted, or the dashicon
itself).

## Root cause

`desktop_mode_plugins_window_field_icon_url` derived the wp.org icon
URL from `$row['textdomain']`:

```php
$slug = sanitize_key( $row['textdomain'] ?? '' );
return 'https://ps.w.org/' . $slug . '/assets/icon.svg';
```

But the wp.org asset directory at `ps.w.org/<slug>/assets/` is keyed on
the plugin's **folder name** (the .org repo slug), not its text
domain. These coincide only by accident:

- `woocommerce/woocommerce.php` has text domain `woo` → 404
- `wordpress-seo/wp-seo.php` has text domain `yoast-seo` → 404
- Plugins with no `Text Domain:` header at all → `null` → no icon attempted

A secondary issue: the URL always pointed at `icon.svg`, but many
wp.org plugins ship only `icon-128x128.png` / `icon-256x256.png`. Even
when the slug was right, an SVG-only URL would 404 for those plugins.

There was no race condition, no transient, no fetch error — just a
wrong slug source plus a single-format URL.

## Fix

### PHP — `includes/plugins-window/rest-fields.php`

Resolve the slug from `dirname( $plugin_file )` (the folder name).
Fall back to `textdomain` for single-file plugins like `hello.php`
where the folder is `.`.

### JS — new helper `src/plugins-window/icon-fallback.ts`

`attachIconFallback( img, url, onExhausted )` wires an `<img>` to walk
a candidate chain on load failure:

```
icon.svg → icon-256x256.png → icon-128x128.png → onExhausted()
```

Only applied when the URL matches the `ps.w.org/<slug>/assets/`
shape — custom URLs (set via the `desktop_mode_plugins_window_icon_url`
filter) are still one-shot. Wired into both consumers:

- `src/plugins-window/installed-view.ts` (table icon)
- `src/plugins-window/installed-detail.ts` (expanded-row hero icon)

Also corrected `deriveSlug()` in `installed-detail.ts`, which fed the
wp.org detail panel (`fetchPluginInfo`, reviews tab, etc.) and had the
same textdomain-first bug.

## Tests

Updated `tests/phpunit/tests/pluginsWindowRegistration.php` to cover
the new behaviour:

- Derives from folder name (was: from textdomain — only coincidentally passing for `akismet`).
- Folder wins over a mismatched textdomain (`woocommerce` vs `woo`).
- Works when no textdomain is declared (the dominant cause of the regression).
- Single-file plugins fall back to textdomain; null when neither is available.

## Verification

- `npm run build` — clean
- `npm run lint` — clean
- `./node_modules/.bin/tsc --noEmit` — clean
- `npm run test:js` — 137 files / 1208 tests pass
- PHPUnit `--filter='PluginsWindowRegistration'` — 29 tests / 54 assertions pass (incl. 5 icon-url cases)

## Files changed

- `includes/plugins-window/rest-fields.php`
- `src/plugins-window/icon-fallback.ts` (new)
- `src/plugins-window/installed-view.ts`
- `src/plugins-window/installed-detail.ts`
- `tests/phpunit/tests/pluginsWindowRegistration.php`
- `assets/js/desktop[.min].js` (build output)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-209-c2543a904dfcc775c3fcd4c4b06ac00f62101a9a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->