### PR TITLE
Restore "Show desktop on wallpaper click" as an opt-in setting

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -867,6 +867,23 @@
 	min-height: 22px;
 }
 
+/* One toggle + hint pair. Stacking these without separators reads as
+ * a wall of checkboxes; a hairline above each item (after the first)
+ * groups the label with its description and gives the eye a stopping
+ * point between unrelated settings. The first item sits flush so the
+ * section heading already serves as its top boundary. */
+.desktop-mode-features__item {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.desktop-mode-features__item + .desktop-mode-features__item {
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
+}
+
 /* "Reset what's-new dialogs" row — separates the action from the
  * native-Posts toggle above and gives breathing room around the
  * button. `align-items: flex-start` keeps the inline-flex

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -109,6 +109,12 @@ function desktop_mode_default_os_settings() {
 		// the server-side cap gate (`edit_posts`) means the toggle only
 		// matters for users who could see the Comments tile anyway.
 		'nativeCommentsEnabled'    => true,
+		// When true, left-clicking the empty wallpaper triggers the
+		// "Show desktop" toggle (macOS-style) and the matching entry is
+		// hidden from the wallpaper context menu. When false (default),
+		// the entry stays in the menu and left clicks on the wallpaper
+		// do nothing. Per-user.
+		'showDesktopOnWallpaperClick' => false,
 		// Per-item placement preferences. Map of item id (dock-item
 		// slug or registered desktop-icon id) → one of:
 		//   'both'    — show on both dock and desktop.
@@ -354,6 +360,10 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		? (bool) $raw['nativeCommentsEnabled']
 		: $defaults['nativeCommentsEnabled'];
 
+	$show_desktop_on_wallpaper_click = isset( $raw['showDesktopOnWallpaperClick'] )
+		? (bool) $raw['showDesktopOnWallpaperClick']
+		: $defaults['showDesktopOnWallpaperClick'];
+
 	// itemVisibility — map<sanitize_key, enum>. Unknown ids are kept
 	// (a deactivated plugin's setting should survive reactivation);
 	// invalid placement values are dropped.
@@ -416,6 +426,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'nativeUsersEnabled'       => $native_users_enabled,
 		'nativePluginsEnabled'     => $native_plugins_enabled,
 		'nativeCommentsEnabled'    => $native_comments_enabled,
+		'showDesktopOnWallpaperClick' => $show_desktop_on_wallpaper_click,
 		'itemVisibility'           => $item_visibility,
 		'dockOrder'                => $dock_order,
 	);

--- a/src/desktop-files/wallpaper-menu.ts
+++ b/src/desktop-files/wallpaper-menu.ts
@@ -363,13 +363,17 @@ export function buildMenuItems( deps: WallpaperMenuDeps ): WallpaperMenuItem[] {
 				},
 			],
 		},
-		{
-			id: 'show-desktop',
-			label: deps.labels.showDesktop,
-			icon: 'dashicons-desktop',
-			sort: 20,
-			onClick: () => deps.toggleShowDesktop(),
-		},
+		...( deps.includeShowDesktop === false
+			? []
+			: [
+					{
+						id: 'show-desktop',
+						label: deps.labels.showDesktop,
+						icon: 'dashicons-desktop',
+						sort: 20,
+						onClick: () => deps.toggleShowDesktop(),
+					} as WallpaperMenuItem,
+			] ),
 		{
 			id: 'os-settings',
 			label: deps.labels.osSettings,
@@ -441,6 +445,13 @@ export interface WallpaperMenuDeps {
 	 * so users see at a glance which order is auto-arranging.
 	 */
 	currentSortMode?: SortMode | null;
+	/**
+	 * Whether to render the built-in "Show desktop" entry. When `false`,
+	 * the caller has wired the wallpaper's left-click to drive the same
+	 * toggle (macOS-style) and the menu entry would be redundant.
+	 * Default `true`.
+	 */
+	includeShowDesktop?: boolean;
 	labels: {
 		createFolder: string;
 		showDesktop: string;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -3162,6 +3162,35 @@ function init(): void {
 		ro.observe( desktopArea );
 	}
 
+	// Wallpaper LEFT-click → "Show desktop" toggle, gated behind the
+	// per-user OS Setting (Features tab → "Show desktop when clicking
+	// the wallpaper"). Off by default — the toggle lives in the
+	// wallpaper context menu instead. When on, we mirror the macOS
+	// gesture and the matching menu entry is suppressed (see the
+	// `includeShowDesktop` flag passed to the menu builder below).
+	desktopArea.addEventListener( 'click', ( e: MouseEvent ) => {
+		if ( ! osSettings.state.showDesktopOnWallpaperClick ) {
+			return;
+		}
+		// Only the bare wallpaper — clicks on a tile, widget, or any
+		// inner surface bubble up but shouldn't trigger the toggle.
+		if ( e.target !== desktopArea ) {
+			return;
+		}
+		// Suppress while overview is active — overview has its own
+		// pointer surface and would mis-fire on the synthesized click.
+		if ( desktopArea.classList.contains( 'desktop-mode-area--overview' ) ) {
+			return;
+		}
+		// If the context menu is currently open, swallow this click so
+		// it just dismisses the menu (handled by the menu's own
+		// outside-click listener) without also toggling Show Desktop.
+		if ( isWallpaperMenuOpen() ) {
+			return;
+		}
+		manager.toggleShowDesktop();
+	} );
+
 	// Wallpaper context menu — RIGHT-click only. `contextmenu` is
 	// the only opener; left-clicks on the bg either dismiss the
 	// menu (handled inside `openWallpaperMenu`) or do nothing.
@@ -3258,6 +3287,8 @@ function init(): void {
 					relayoutRoot( rootSortTransform( mode ) );
 				},
 				currentSortMode: rootSortMode,
+				includeShowDesktop:
+					! osSettings.state.showDesktopOnWallpaperClick,
 				labels: {
 					createFolder: 'New folder',
 					showDesktop: 'Show desktop',

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -187,6 +187,7 @@ export const DEFAULTS: OsSettingsState = {
 	// Native Comments window — replaces `edit-comments.php`. Same
 	// opt-out posture; cap-gated on `edit_posts` server-side.
 	nativeCommentsEnabled: true,
+	showDesktopOnWallpaperClick: false,
 	itemVisibility: {},
 	dockOrder: [],
 };

--- a/src/settings/sections/features.ts
+++ b/src/settings/sections/features.ts
@@ -71,6 +71,13 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 		paint();
 	};
 
+	const onShowDesktopOnClickToggle = ( e: Event ): void => {
+		const checked = ( e as CustomEvent ).detail?.checked === true;
+		ctx.state.showDesktopOnWallpaperClick = checked;
+		ctx.save();
+		paint();
+	};
+
 	// AI moderation toggle — admin-only, persisted as a SITE option
 	// (not user meta) via the dedicated REST endpoint. Local mirror of
 	// the shell snapshot so paint() reflects the new value
@@ -189,75 +196,101 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 						'Tune individual Desktop Mode behaviors. Each toggle affects only your account and takes effect immediately — no reload required. Watch the dot in the OS Settings title bar to see when a change has been saved.',
 					) }
 				>
-					<wpd-checkbox-label
-						label=${ __( 'Use the native Posts window' ) }
-						?checked=${ ctx.state.nativePostsEnabled }
-						@wpd-checkbox-change=${ onNativePostsToggle }
-					></wpd-checkbox-label>
-					<p class="desktop-mode-features__hint">
-						${ __(
-							'Replaces the classic Posts list iframe with a native, table-driven window: sticky header, server-paginated rows, multi-select bulk actions, and a sub-row preview. On by default. Toggle off to return to the classic experience.',
-						) }
-					</p>
-					<wpd-checkbox-label
-						label=${ __( 'Use the native Pages window' ) }
-						?checked=${ ctx.state.nativePagesEnabled }
-						@wpd-checkbox-change=${ onNativePagesToggle }
-					></wpd-checkbox-label>
-					<p class="desktop-mode-features__hint">
-						${ __(
-							'Same table-driven experience as the Posts window, tailored for Pages: a Parent column, hierarchical sort, and the same lock indicator when another user is editing a page. On by default. Toggle off to return to the classic experience.',
-						) }
-					</p>
-					<wpd-checkbox-label
-						label=${ __( 'Use the native Users window' ) }
-						?checked=${ ctx.state.nativeUsersEnabled }
-						@wpd-checkbox-change=${ onNativeUsersToggle }
-					></wpd-checkbox-label>
-					<p class="desktop-mode-features__hint">
-						${ __(
-							'A native Users list with bulk role change, last-login tracking, live online indicators, click-to-copy email, and one-click password resets. Capability-gated — readers see a read-only view, role assignment respects WordPress role permissions. On by default.',
-						) }
-					</p>
-					<wpd-checkbox-label
-						label=${ __( 'Use the native Plugins window' ) }
-						?checked=${ ctx.state.nativePluginsEnabled }
-						@wpd-checkbox-change=${ onNativePluginsToggle }
-					></wpd-checkbox-label>
-					<p class="desktop-mode-features__hint">
-						${ __(
-							'A native two-tab Plugins window: an Installed list with bulk activate / deactivate / delete, and a Browse gallery powered by the WordPress.org repository — rich detail flyout with screenshots, ratings histogram, and recent reviews. Drag a .zip onto the window to install, or drag a card from Browse to the dock to pin it. On by default.',
-						) }
-					</p>
-					<wpd-checkbox-label
-						label=${ __( 'Use the native Comments window' ) }
-						?checked=${ ctx.state.nativeCommentsEnabled }
-						@wpd-checkbox-change=${ onNativeCommentsToggle }
-					></wpd-checkbox-label>
-					<p class="desktop-mode-features__hint">
-						${ __(
-							'A redesigned moderation queue with Pending / All / Spam / Trash / Mine tabs, bulk approve/spam/trash plus an 8-second undo, inline reply right in the row, an author insights drawer, a per-row spam confidence score (Akismet + heuristics), and full keyboard moderation (j/k navigate, a approve, s spam, d trash, r reply, e edit, u undo). On by default.',
-						) }
-					</p>
+					<div class="desktop-mode-features__item">
+						<wpd-checkbox-label
+							label=${ __( 'Use the native Posts window' ) }
+							?checked=${ ctx.state.nativePostsEnabled }
+							@wpd-checkbox-change=${ onNativePostsToggle }
+						></wpd-checkbox-label>
+						<p class="desktop-mode-features__hint">
+							${ __(
+								'Replaces the classic Posts list iframe with a native, table-driven window: sticky header, server-paginated rows, multi-select bulk actions, and a sub-row preview. On by default. Toggle off to return to the classic experience.',
+							) }
+						</p>
+					</div>
+					<div class="desktop-mode-features__item">
+						<wpd-checkbox-label
+							label=${ __( 'Use the native Pages window' ) }
+							?checked=${ ctx.state.nativePagesEnabled }
+							@wpd-checkbox-change=${ onNativePagesToggle }
+						></wpd-checkbox-label>
+						<p class="desktop-mode-features__hint">
+							${ __(
+								'Same table-driven experience as the Posts window, tailored for Pages: a Parent column, hierarchical sort, and the same lock indicator when another user is editing a page. On by default. Toggle off to return to the classic experience.',
+							) }
+						</p>
+					</div>
+					<div class="desktop-mode-features__item">
+						<wpd-checkbox-label
+							label=${ __( 'Use the native Users window' ) }
+							?checked=${ ctx.state.nativeUsersEnabled }
+							@wpd-checkbox-change=${ onNativeUsersToggle }
+						></wpd-checkbox-label>
+						<p class="desktop-mode-features__hint">
+							${ __(
+								'A native Users list with bulk role change, last-login tracking, live online indicators, click-to-copy email, and one-click password resets. Capability-gated — readers see a read-only view, role assignment respects WordPress role permissions. On by default.',
+							) }
+						</p>
+					</div>
+					<div class="desktop-mode-features__item">
+						<wpd-checkbox-label
+							label=${ __( 'Use the native Plugins window' ) }
+							?checked=${ ctx.state.nativePluginsEnabled }
+							@wpd-checkbox-change=${ onNativePluginsToggle }
+						></wpd-checkbox-label>
+						<p class="desktop-mode-features__hint">
+							${ __(
+								'A native two-tab Plugins window: an Installed list with bulk activate / deactivate / delete, and a Browse gallery powered by the WordPress.org repository — rich detail flyout with screenshots, ratings histogram, and recent reviews. Drag a .zip onto the window to install, or drag a card from Browse to the dock to pin it. On by default.',
+							) }
+						</p>
+					</div>
+					<div class="desktop-mode-features__item">
+						<wpd-checkbox-label
+							label=${ __( 'Use the native Comments window' ) }
+							?checked=${ ctx.state.nativeCommentsEnabled }
+							@wpd-checkbox-change=${ onNativeCommentsToggle }
+						></wpd-checkbox-label>
+						<p class="desktop-mode-features__hint">
+							${ __(
+								'A redesigned moderation queue with Pending / All / Spam / Trash / Mine tabs, bulk approve/spam/trash plus an 8-second undo, inline reply right in the row, an author insights drawer, a per-row spam confidence score (Akismet + heuristics), and full keyboard moderation (j/k navigate, a approve, s spam, d trash, r reply, e edit, u undo). On by default.',
+							) }
+						</p>
+					</div>
 					${ shellCfg?.commentsAi
 						? html`
-							<wpd-checkbox-label
-								label=${ __( 'Score new comments with AI' ) }
-								?checked=${ aiState.enabled }
-								?disabled=${ aiState.saving || ! aiState.providerConfigured }
-								@wpd-checkbox-change=${ onCommentsAiToggle }
-							></wpd-checkbox-label>
-							<p class="desktop-mode-features__hint">
-								${ aiState.providerConfigured
-									? __(
-										'When a new comment lands, your configured AI provider scores it for spam and hostility. The verdict appears in the per-row chip and is folded into the spam confidence score. Token usage applies — admin-only site setting.',
-									)
-									: __(
-										'Configure an AI provider in OS Settings → AI first. Once a provider is set up, this toggle becomes available and every new comment is scored on arrival.',
-									) }
-							</p>
+							<div class="desktop-mode-features__item">
+								<wpd-checkbox-label
+									label=${ __( 'Score new comments with AI' ) }
+									?checked=${ aiState.enabled }
+									?disabled=${ aiState.saving || ! aiState.providerConfigured }
+									@wpd-checkbox-change=${ onCommentsAiToggle }
+								></wpd-checkbox-label>
+								<p class="desktop-mode-features__hint">
+									${ aiState.providerConfigured
+										? __(
+											'When a new comment lands, your configured AI provider scores it for spam and hostility. The verdict appears in the per-row chip and is folded into the spam confidence score. Token usage applies — admin-only site setting.',
+										)
+										: __(
+											'Configure an AI provider in OS Settings → AI first. Once a provider is set up, this toggle becomes available and every new comment is scored on arrival.',
+										) }
+								</p>
+							</div>
 						`
 						: '' }
+					<div class="desktop-mode-features__item">
+						<wpd-checkbox-label
+							label=${ __(
+								'Show desktop when clicking the wallpaper',
+							) }
+							?checked=${ ctx.state.showDesktopOnWallpaperClick }
+							@wpd-checkbox-change=${ onShowDesktopOnClickToggle }
+						></wpd-checkbox-label>
+						<p class="desktop-mode-features__hint">
+							${ __(
+								'macOS-style gesture: a left click on the empty desktop minimizes every window, and a second click restores them. When on, the matching "Show desktop" entry is removed from the wallpaper context menu — the click gesture replaces it. Off by default.',
+							) }
+						</p>
+					</div>
 					<div class="desktop-mode-features__row">
 						<wpd-button
 							variant="secondary"

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -156,6 +156,10 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 			typeof parsed.nativeCommentsEnabled === 'boolean'
 				? parsed.nativeCommentsEnabled
 				: DEFAULTS.nativeCommentsEnabled,
+		showDesktopOnWallpaperClick:
+			typeof parsed.showDesktopOnWallpaperClick === 'boolean'
+				? parsed.showDesktopOnWallpaperClick
+				: DEFAULTS.showDesktopOnWallpaperClick,
 		itemVisibility: sanitizeItemVisibility( parsed.itemVisibility ),
 		dockOrder: sanitizeDockOrder( parsed.dockOrder ),
 	};

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -186,6 +186,14 @@ export interface OsSettingsState {
 	 */
 	nativeCommentsEnabled: boolean;
 	/**
+	 * When true, left-clicking the empty wallpaper triggers the
+	 * "Show desktop" toggle (macOS-style) and the matching entry is
+	 * hidden from the wallpaper context menu. When false (default),
+	 * the entry stays in the context menu and left clicks on the
+	 * wallpaper do nothing. Per-user.
+	 */
+	showDesktopOnWallpaperClick: boolean;
+	/**
 	 * Per-item placement preference. Maps an item id (dock-item slug or
 	 * registered desktop-icon id) to one of:
 	 *   - `'both'`    — show on both dock and desktop.

--- a/tests/vitest/desktop-files-wallpaper-menu.test.ts
+++ b/tests/vitest/desktop-files-wallpaper-menu.test.ts
@@ -69,6 +69,20 @@ describe( 'wallpaper context menu', () => {
 		);
 	} );
 
+	test( 'buildMenuItems omits show-desktop when includeShowDesktop is false', async () => {
+		const { buildMenuItems } = await load();
+		const items = buildMenuItems(
+			stubDeps( { includeShowDesktop: false } ),
+		);
+		expect( items.map( ( i ) => i.id ) ).toEqual( [
+			'create-folder',
+			'new-url',
+			'sort-by',
+			'os-settings',
+			'wallpapers',
+		] );
+	} );
+
 	test( 'clicking New URL invokes deps.createUrl', async () => {
 		const { openWallpaperMenu, buildMenuItems } = await load();
 		const deps = stubDeps();


### PR DESCRIPTION
## Summary

Adds a new per-user toggle in **OS Settings → Features**:
**"Show desktop when clicking the wallpaper"** (off by default).

The macOS-style left-click-the-wallpaper gesture used to be the only
way to trigger Show Desktop. It was moved into the wallpaper context
menu (CMO) so left-clicks on the desktop wouldn't surprise users who
weren't expecting that affordance. This brings the gesture back as an
opt-in, with the two surfaces kept mutually exclusive so there's
never a redundant entry on screen:

- **Off (default)** — wallpaper left-clicks do nothing; the
  `Show desktop` entry appears in the wallpaper CMO.
- **On** — left-clicking the empty wallpaper toggles Show Desktop;
  the matching CMO entry is suppressed.

Also tidies up the Features tab: each toggle + hint pair now has a
hairline separator above it (matching the existing `__row` separator
at the bottom of the section), so the wall of checkboxes reads as
grouped settings rather than one continuous list.

## Tab placement

The toggle lives in **Features**, not **Appearance**: Features is
where per-user behavior flags live (native Posts/Pages/Users/Plugins/
Comments windows, AI comment scoring, reset what's-new dialogs).
Appearance is reserved for look-and-feel (wallpaper, accent, dock
size, layout). This is interaction behavior, so Features is the
right home.

## State plumbing

New persisted field `showDesktopOnWallpaperClick: boolean`
(default `false`) wired end-to-end:

- **PHP** — `desktop_mode_default_os_settings()` and
  `desktop_mode_sanitize_os_settings()` in `includes/os-settings.php`
  add the field with a `(bool)` coercion matching the surrounding
  `native*Enabled` flags.
- **TypeScript state** — added to `OsSettingsState`
  (`src/settings/types.ts`), `DEFAULTS` (`src/settings/constants.ts`),
  and the `_parseRaw` sanitizer in `src/settings/state.ts`.

The field is intentionally **not** added to
`OsSettingsSnapshot` — it's a shell-level preference; no plugin
needs to read it. The shell reads `osSettings.state.*` directly at
click time.

## Wallpaper menu wiring

`src/desktop-files/wallpaper-menu.ts` gains an optional
`includeShowDesktop?: boolean` field on `WallpaperMenuDeps`
(default `true`). When `false`, the built-in `show-desktop` item is
omitted from the menu's items list.

`src/desktop.ts` passes
`includeShowDesktop: ! osSettings.state.showDesktopOnWallpaperClick`
into the menu builder.

## Left-click handler

`src/desktop.ts` registers a `click` listener on `desktopArea`,
gated on the setting:

```ts
desktopArea.addEventListener( 'click', ( e: MouseEvent ) => {
    if ( ! osSettings.state.showDesktopOnWallpaperClick ) return;
    if ( e.target !== desktopArea ) return;
    if ( desktopArea.classList.contains( 'desktop-mode-area--overview' ) ) return;
    if ( isWallpaperMenuOpen() ) return;
    manager.toggleShowDesktop();
} );
```

Guards in plain English:

- `target !== desktopArea` — only the bare wallpaper. Clicks on a
  tile, widget, or any inner surface bubble up but mustn't trigger
  the toggle.
- Overview check — overview owns its own pointer surface; a
  synthesized trailing click would otherwise minimize every window
  the moment the overview animation starts (this guard mirrors the
  one already in the contextmenu handler above).
- `isWallpaperMenuOpen()` — if the CMO is currently open, the click
  should just dismiss it (handled by the menu's own outside-click
  listener) without also triggering Show Desktop.

## Features section grouping

Each toggle + hint in `src/settings/sections/features.ts` is now
wrapped in `<div class="desktop-mode-features__item">`. A new rule
in `assets/css/os-settings.css` adds a hairline border + padding
above every item after the first:

```css
.desktop-mode-features__item {
    display: flex;
    flex-direction: column;
    gap: 6px;
}

.desktop-mode-features__item + .desktop-mode-features__item {
    margin-top: 16px;
    padding-top: 16px;
    border-top: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
}
```

This matches the `border-top` style already used by
`.desktop-mode-features__row` at the bottom of the section
("Reset what's-new dialogs").

## Files changed

- `includes/os-settings.php` — default + sanitize.
- `src/settings/types.ts` — `OsSettingsState.showDesktopOnWallpaperClick`.
- `src/settings/constants.ts` — `DEFAULTS.showDesktopOnWallpaperClick`.
- `src/settings/state.ts` — `_parseRaw` coercion.
- `src/settings/sections/features.ts` — new checkbox; each toggle
  wrapped in `__item` divs.
- `src/desktop-files/wallpaper-menu.ts` — `includeShowDesktop` deps flag.
- `src/desktop.ts` — passes flag into menu builder; left-click handler.
- `assets/css/os-settings.css` — `__item` separators.
- `tests/vitest/desktop-files-wallpaper-menu.test.ts` — new test
  asserting the `show-desktop` item is omitted when
  `includeShowDesktop: false`.

## Test plan

- [x] `npm run build` — green.
- [x] `./node_modules/.bin/tsc --noEmit` — green.
- [x] `npm run lint` — green.
- [x] `npm run test:js` — 1209 / 1209 passing.
- [ ] `npm run test:php` — couldn't run locally (wp-env tests-mysql
  service won't start in this environment). PHP change is the same
  default-+-sanitize pattern the surrounding fields use; `php -l`
  on `includes/os-settings.php` passes.
- [ ] Manual QA:
    - [ ] Default state: wallpaper left-click does nothing; CMO
          shows "Show desktop".
    - [ ] Toggle on: wallpaper left-click minimizes all windows;
          second click restores; CMO no longer shows "Show desktop".
    - [ ] Toggle persists across reload.
    - [ ] Right-click + dismiss-by-left-click still works.
    - [ ] Overview is unaffected (clicks on overview thumbnails
          don't trigger Show Desktop).
    - [ ] Features tab visually separates each toggle group.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-210-fb86be1ef62f9768929ba9ef25b0b42980f722d3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->