### PR TITLE
Fix plugin update refresh, dock badge, and stuck-row failures (#202)

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1955,15 +1955,15 @@ Filter the resolved wp.org icon URL for an installed plugin row. Return `null` t
 apply_filters( 'desktop_mode_plugins_window_icon_url', string|null $url, string $slug, array $row ): string|null
 ```
 
-### `desktop_mode_plugins_window_refresh_updates` — Stable *(filter, since 0.18.0)*
+### `desktop_mode_plugins_window_refresh_updates` — Stable *(filter, since 0.18.0; `$force` argument added 0.8.5)*
 
 Short-circuit the lazy refresh of the `update_plugins` site transient that runs on the first row of every REST plugins collection. Core only refreshes that transient on `load-plugins.php` / `load-update-core.php` / cron — REST is not on that list — so without this hop the Plugins window can show "no updates" while the dock badge (computed off `$menu`) reports pending updates. The refresh inherits Core's own 12h throttle (`_maybe_update_plugins()`), so the steady-state cost is a single transient read per request.
 
 ```php
-apply_filters( 'desktop_mode_plugins_window_refresh_updates', bool $refresh ): bool
+apply_filters( 'desktop_mode_plugins_window_refresh_updates', bool $refresh, bool $force ): bool
 ```
 
-Return `false` to skip the refresh — useful for hosts that run their own update orchestration (managed WordPress, internal mirrors) and don't want REST hits to potentially trigger a wp.org HTTPS check.
+Return `false` to skip the refresh — useful for hosts that run their own update orchestration (managed WordPress, internal mirrors) and don't want REST hits to potentially trigger a wp.org HTTPS check. The filter is also called on the explicit force-refresh path (when the in-window Refresh button passes `?desktop_mode_force_refresh=1`); returning `false` there keeps the no-network posture even on user-initiated refreshes. Inspect `$force` to apply different policies for opportunistic vs. user-initiated refreshes.
 
 ### REST-field decorators on `/wp/v2/plugins` — Stable (since 0.9.0)
 
@@ -1971,7 +1971,7 @@ Server-injected enrichment fields. The JS reads them on every list paint:
 
 | Field | Shape | What it carries |
 |---|---|---|
-| `desktop_mode_update_available` | `{ available: bool, new_version: string\|null, package: string, slug: string }` | Pending wp.org update for this row, derived from `get_site_transient( 'update_plugins' )`. Since 0.18.0 the transient is lazily refreshed at REST-time (subject to Core's 12h throttle, and the `desktop_mode_plugins_window_refresh_updates` filter) so the window stays in sync with the dock update badge. `package` carries the download URL (empty for plugins without a wp.org zip — the JS surfaces the same "Auto-update unavailable" fallback Core renders); `slug` is what `wp_ajax_update_plugin` echoes back in its event payload. |
+| `desktop_mode_update_available` | `{ available: bool, new_version: string\|null, package: string, slug: string }` | Pending wp.org update for this row, derived from `get_site_transient( 'update_plugins' )`. Since 0.18.0 the transient is lazily refreshed at REST-time (subject to Core's 12h throttle, and the `desktop_mode_plugins_window_refresh_updates` filter) so the window stays in sync with the dock update badge. Since 0.8.5 the in-window Refresh button can bypass the 12h throttle by adding `?desktop_mode_force_refresh=1` to the REST request — Core's `wp_clean_plugins_cache( true )` then deletes the transient and fans out to api.wordpress.org, mirroring what classic `plugins.php` does on load. `package` carries the download URL (empty for plugins without a wp.org zip — the JS surfaces the same "Auto-update unavailable" fallback Core renders); `slug` is what `wp_ajax_update_plugin` echoes back in its event payload. |
 | `desktop_mode_can_manage` | `{ activate, deactivate, delete: bool }` | Per-row capability flags so the JS doesn't re-derive caps. Server still re-validates every mutation. |
 | `desktop_mode_icon_url` | `string\|null` | Best-effort wp.org icon URL derived from the plugin's `textdomain`. Filterable via `desktop_mode_plugins_window_icon_url`. |
 | `desktop_mode_size_kb` | `int\|null` | Disk footprint of the plugin folder in kilobytes. Cached 6h. |

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -138,22 +138,39 @@ function desktop_mode_plugins_window_row_plugin_file( $row ) {
  * static so they don't pay the transient-read overhead per row.
  *
  * @since 0.18.0
+ * @since 0.8.5 Accepts a `$force` flag — set by the in-window Refresh
+ *               button via `?desktop_mode_force_refresh=1`. Bypasses
+ *               the 12h throttle and runs `wp_clean_plugins_cache( true )`
+ *               so the next read sees a fresh wp.org snapshot. Without
+ *               this escape hatch the Refresh button was misleading:
+ *               within 12h of the last check it returned the same
+ *               cached "no updates" result Core had stored, while
+ *               classic admin's `plugins.php` (which always calls
+ *               `wp_clean_plugins_cache( true )`) showed pending updates.
+ *
+ * @param bool $force When true, delete the transient and force a fresh
+ *                    wp.org check regardless of the 12h throttle.
  */
-function desktop_mode_plugins_window_maybe_refresh_update_transient() {
+function desktop_mode_plugins_window_maybe_refresh_update_transient( $force = false ) {
 	/**
 	 * Short-circuit the lazy refresh of the `update_plugins` transient.
 	 *
 	 * Return `false` to skip the refresh — useful for hosts that run
 	 * their own update orchestration (managed WordPress, internal
 	 * mirrors) and don't want every REST hit to the plugins endpoint
-	 * to potentially trigger a wp.org check.
+	 * to potentially trigger a wp.org check. The filter also gates the
+	 * explicit force-refresh path so hosts that block wp.org calls
+	 * outright keep that posture even when the user clicks Refresh.
 	 *
 	 * @since 0.18.0
+	 * @since 0.8.5 `$force` parameter added so filter callbacks can
+	 *               distinguish opportunistic refreshes from explicit
+	 *               user-initiated ones.
 	 *
-	 * @param bool $refresh Whether to call `wp_update_plugins()`
-	 *                     when the transient is older than 12h.
+	 * @param bool $refresh Whether to call `wp_update_plugins()`.
+	 * @param bool $force   Whether the caller asked to bypass the throttle.
 	 */
-	if ( ! apply_filters( 'desktop_mode_plugins_window_refresh_updates', true ) ) {
+	if ( ! apply_filters( 'desktop_mode_plugins_window_refresh_updates', true, $force ) ) {
 		return;
 	}
 
@@ -161,6 +178,27 @@ function desktop_mode_plugins_window_maybe_refresh_update_transient() {
 		// `wp-includes/update.php` is normally autoloaded on every
 		// request; guard anyway so an unusual bootstrap (mu-plugin
 		// CLI harness, stripped-down REST runtime) doesn't fatal.
+		return;
+	}
+
+	if ( $force ) {
+		// Explicit user-initiated refresh — bypass the throttle.
+		// Two steps:
+		//   1. Delete the `update_plugins` site transient (and the
+		//      `plugins` cache group) via `wp_clean_plugins_cache()`,
+		//      OR fall back to `delete_site_transient()` directly when
+		//      the admin-side helper isn't loaded.
+		//   2. Call `wp_update_plugins()` to repopulate the transient
+		//      with a fresh wp.org snapshot. Without step 2 the field
+		//      callback reads `false` for the rest of this request and
+		//      every row reports "no updates" — that's the exact
+		//      regression from the first cut of this fix (GH#202).
+		if ( function_exists( 'wp_clean_plugins_cache' ) ) {
+			wp_clean_plugins_cache( true );
+		} else {
+			delete_site_transient( 'update_plugins' );
+		}
+		wp_update_plugins();
 		return;
 	}
 
@@ -176,6 +214,32 @@ function desktop_mode_plugins_window_maybe_refresh_update_transient() {
 	}
 
 	wp_update_plugins();
+}
+
+/**
+ * Detect whether the current REST request asked for an explicit
+ * `update_plugins` refresh via `?desktop_mode_force_refresh=1`.
+ *
+ * The flag is set by the in-window Refresh button (see
+ * `fetchInstalledPlugins({ force: true })` in `src/plugins-window/rest.ts`)
+ * and read from the query string on the way through Core's REST
+ * dispatcher. Querystring is the canonical channel — the value is an
+ * idempotent "use the slow path" hint, not a state-changing action,
+ * so no additional nonce is required beyond REST's standard
+ * `X-WP-Nonce` cookie-auth check.
+ *
+ * @since 0.8.5
+ *
+ * @return bool True when the request asked for a force-refresh.
+ */
+function desktop_mode_plugins_window_force_refresh_requested() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only hint flag; REST auth is enforced separately.
+	if ( ! isset( $_GET['desktop_mode_force_refresh'] ) ) {
+		return false;
+	}
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only hint flag; REST auth is enforced separately.
+	$value = sanitize_text_field( wp_unslash( (string) $_GET['desktop_mode_force_refresh'] ) );
+	return '1' === $value || 'true' === $value;
 }
 
 /**
@@ -200,11 +264,17 @@ function desktop_mode_plugins_window_field_update_available( $row ) {
 	// Prime the transient once per request before reading it —
 	// otherwise REST callers see a stale/empty snapshot relative to
 	// the classic Plugins screen and the dock update badge. Static
-	// guard keeps the transient read off the hot per-row path.
+	// guard keeps the transient read off the hot per-row path. When
+	// the request carries `?desktop_mode_force_refresh=1` we always
+	// take the slow path so the in-window Refresh button can actually
+	// pull a fresh wp.org snapshot (the original throttle made it a
+	// no-op within 12h of the last check — see GH#202).
 	static $primed = false;
 	if ( ! $primed ) {
 		$primed = true;
-		desktop_mode_plugins_window_maybe_refresh_update_transient();
+		desktop_mode_plugins_window_maybe_refresh_update_transient(
+			desktop_mode_plugins_window_force_refresh_requested()
+		);
 	}
 
 	// `update_plugins` is the canonical site-wide cache of pending

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -198,7 +198,16 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 	refreshButton.innerHTML =
 		'<span class="dashicons dashicons-update" aria-hidden="true"></span>';
 	refreshButton.addEventListener( 'click', () => {
-		void reload();
+		// User-initiated refresh — force a fresh wp.org check
+		// server-side (bypass the 12h `update_plugins` throttle) and
+		// also kick the framework menu refresh so the Plugins dock
+		// badge re-paints from the same fresh snapshot. Without the
+		// dock refresh, the in-window list and the dock-icon count
+		// could drift apart after a manual click — see GH#202.
+		void ( async () => {
+			await reload( { force: true } );
+			void refreshFrameworkMenu();
+		} )();
 	} );
 	trailing.appendChild( refreshButton );
 
@@ -577,11 +586,11 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		}
 	}
 
-	async function reload(): Promise< void > {
+	async function reload( opts: { force?: boolean } = {} ): Promise< void > {
 		state.loading = true;
 		table.setAttribute( 'loading', '' );
 		try {
-			state.rows = await fetchInstalledPlugins();
+			state.rows = await fetchInstalledPlugins( opts );
 		} catch ( err ) {
 			toast(
 				sprintf(
@@ -840,15 +849,86 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			} );
 			void refreshFrameworkMenu();
 		} catch ( err ) {
-			toast(
-				sprintf(
-					/* translators: 1: plugin name, 2: error message */
-					__( 'Update of %1$s failed: %2$s', 'desktop-mode' ),
-					row.name || row.plugin,
-					describe( err ),
-				),
-				6000,
-			);
+			// Detect Core's "plugin is already at the latest version"
+			// signal. Core's `wp_ajax_update_plugin` only emits
+			// `errorCode` for `WP_Error`-shaped failures — the
+			// up-to-date branch (line 4685 of ajax-actions.php) sets
+			// only `errorMessage`, the translated string
+			// `__( 'The plugin is at the latest version.' )` from the
+			// `default` textdomain. So we detect on either signal:
+			//   1. `errorCode === 'up_to_date'` (future-proof — if Core
+			//      ever ships the code, we already match).
+			//   2. The translated `errorMessage` equals Core's own
+			//      string in the user's locale (the current shipping
+			//      behavior). `wp.i18n.__` against the `default`
+			//      textdomain returns the same translation Core used
+			//      server-side, so the comparison is locale-correct.
+			// This happens in two real-world scenarios:
+			//   - A prior update succeeded server-side but the client
+			//     didn't see the success envelope (network hiccup, the
+			//     iframe-bridge / shellFetch race the user hit in
+			//     GH#202). The next click reaches Core's transient
+			//     check, which now says "nothing to do".
+			//   - Benign double-clicks within the same window.
+			// Either way the truth is "the row IS up to date" — so
+			// converge the UI to that reality instead of leaving the
+			// stale "Update available" button + scary "failed" toast.
+			const errCode = ( err as { code?: string } )?.code;
+			const errMessage = ( err as { message?: string } )?.message;
+			const coreUpToDateMessage =
+				window.wp?.i18n?.__?.( 'The plugin is at the latest version.' );
+			const isUpToDate =
+				errCode === 'up_to_date' ||
+				( !! coreUpToDateMessage && errMessage === coreUpToDateMessage );
+
+			if ( isUpToDate ) {
+				mergeRow( {
+					...row,
+					desktop_mode_update_available: {
+						available: false,
+						new_version: null,
+						package: '',
+						slug: row.desktop_mode_update_available?.slug ?? '',
+					},
+				} as InstalledPlugin );
+				toast(
+					sprintf(
+						/* translators: %s: plugin name */
+						__( '%s is already up to date.', 'desktop-mode' ),
+						row.name || row.plugin,
+					),
+				);
+				broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+					source: SOURCE,
+					plugin: row.plugin,
+					action: 'update',
+				} );
+			} else {
+				toast(
+					sprintf(
+						/* translators: 1: plugin name, 2: error message */
+						__( 'Update of %1$s failed: %2$s', 'desktop-mode' ),
+						row.name || row.plugin,
+						describe( err ),
+					),
+					6000,
+				);
+				// Reconcile from the server — covers the case where the
+				// upgrader committed the install on disk but the client
+				// promise rejected (timeout, dropped connection, parse
+				// error). Without this, the row stays stuck on "Update
+				// available" even though the on-disk version is fresh,
+				// which is the exact GH#202 symptom.
+				void reload();
+			}
+			// Always refresh the dock badge after an update attempt,
+			// regardless of branch. Core's `wp_ajax_update_plugin` calls
+			// `wp_update_plugins()` up front, which may mutate the
+			// `update_plugins` transient even when the upgrade itself
+			// errors out — so the badge count can change even on
+			// failure. Without this, the badge could lag behind the
+			// in-window state until the user manually clicked Refresh.
+			void refreshFrameworkMenu();
 		} finally {
 			state.updating.delete( row.plugin );
 			paintTable();

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -244,11 +244,23 @@ function unwrapAjaxEnvelope< T >( json: unknown, status: number ): T {
 
 function extractAjaxError( data: unknown, status: number ): Error {
 	if ( typeof data === 'object' && data !== null ) {
-		const obj = data as { message?: string; errorMessage?: string; code?: string };
-		const msg = obj.message ?? obj.errorMessage ?? obj.code;
+		const obj = data as {
+			message?: string;
+			errorMessage?: string;
+			code?: string;
+			errorCode?: string;
+		};
+		const msg = obj.message ?? obj.errorMessage ?? obj.code ?? obj.errorCode;
 		if ( typeof msg === 'string' && msg !== '' ) {
 			const err = new Error( msg );
-			( err as Error & { code?: string; status?: number } ).code = obj.code;
+			// Core's ajax handlers split on the field name: `WP_Error`-wrapped
+			// errors come through as `code`, but `wp_ajax_update_plugin` (and
+			// friends) hand-rolls the envelope and ships `errorCode`. Fall
+			// back to either so callers like `runUpdate()` can detect the
+			// `'up_to_date'` soft-success signal without caring which
+			// handler produced it.
+			( err as Error & { code?: string; status?: number } ).code =
+				obj.code ?? obj.errorCode;
 			( err as Error & { code?: string; status?: number } ).status = status;
 			return err;
 		}
@@ -281,10 +293,21 @@ async function unpackErrorResponse( response: Response ): Promise< Error > {
  * `/wp/v2/plugins` doesn't paginate (the install can't realistically
  * have more than a few hundred), so we request `per_page=100` to
  * collapse the typical install into a single round-trip.
+ *
+ * Pass `{ force: true }` to bypass the server-side 12h `update_plugins`
+ * throttle. The Refresh button uses this — without the flag, repeated
+ * clicks within 12h of Core's last check return the same cached
+ * "no updates" snapshot (GH#202).
  */
-export async function fetchInstalledPlugins(): Promise< InstalledPlugin[] > {
+export async function fetchInstalledPlugins( opts: {
+	force?: boolean;
+} = {} ): Promise< InstalledPlugin[] > {
 	const cfg = getConfig();
-	const url = joinRestUrl( cfg.restRoot, 'wp/v2/plugins?context=view&per_page=100' );
+	const params = new URLSearchParams( { context: 'view', per_page: '100' } );
+	if ( opts.force ) {
+		params.set( 'desktop_mode_force_refresh', '1' );
+	}
+	const url = joinRestUrl( cfg.restRoot, `wp/v2/plugins?${ params.toString() }` );
 	return restRequest< InstalledPlugin[] >( url, { method: 'GET' } );
 }
 

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -459,4 +459,154 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 		$this->assertSame( 'https://cdn.example.com/custom.png', $url );
 		remove_all_filters( 'desktop_mode_plugins_window_icon_url' );
 	}
+
+	// ----------------------------------------------------------------
+	// Force-refresh query-string detector — GH#202.
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_force_refresh_requested
+	 */
+	public function test_force_refresh_detector_returns_false_when_param_absent() {
+		unset( $_GET['desktop_mode_force_refresh'] );
+		$this->assertFalse( desktop_mode_plugins_window_force_refresh_requested() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_force_refresh_requested
+	 */
+	public function test_force_refresh_detector_accepts_one() {
+		$_GET['desktop_mode_force_refresh'] = '1';
+		try {
+			$this->assertTrue( desktop_mode_plugins_window_force_refresh_requested() );
+		} finally {
+			unset( $_GET['desktop_mode_force_refresh'] );
+		}
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_force_refresh_requested
+	 */
+	public function test_force_refresh_detector_accepts_true() {
+		$_GET['desktop_mode_force_refresh'] = 'true';
+		try {
+			$this->assertTrue( desktop_mode_plugins_window_force_refresh_requested() );
+		} finally {
+			unset( $_GET['desktop_mode_force_refresh'] );
+		}
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_force_refresh_requested
+	 */
+	public function test_force_refresh_detector_rejects_other_values() {
+		$_GET['desktop_mode_force_refresh'] = '0';
+		try {
+			$this->assertFalse( desktop_mode_plugins_window_force_refresh_requested() );
+		} finally {
+			unset( $_GET['desktop_mode_force_refresh'] );
+		}
+	}
+
+	/**
+	 * The opportunistic prime path respects the 12h `last_checked`
+	 * throttle (mirrors `_maybe_update_plugins()`), but the explicit
+	 * force path must always invalidate the transient so the next
+	 * read fans out to api.wordpress.org.
+	 *
+	 * @covers ::desktop_mode_plugins_window_maybe_refresh_update_transient
+	 */
+	public function test_force_refresh_deletes_the_update_plugins_transient_and_calls_wp_update_plugins() {
+		// Seed a fresh-looking transient — under normal posture the
+		// throttle would skip the refresh entirely.
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+				'checked'      => array(),
+			)
+		);
+
+		// Block real wp.org calls during the force path so the test
+		// doesn't depend on outbound HTTP. Counting hits to
+		// `pre_http_request` is also how we assert that
+		// `wp_update_plugins()` actually ran (it's the only path
+		// inside the force branch that issues an outbound request).
+		$http_attempts = 0;
+		$blocker       = static function () use ( &$http_attempts ) {
+			++$http_attempts;
+			// Returning a WP_Error keeps wp_update_plugins from writing
+			// the transient back, so we can prove the delete step ran.
+			return new WP_Error( 'http_blocked', 'blocked in tests' );
+		};
+		add_filter( 'pre_http_request', $blocker );
+		try {
+			desktop_mode_plugins_window_maybe_refresh_update_transient( true );
+		} finally {
+			remove_filter( 'pre_http_request', $blocker );
+		}
+
+		$this->assertGreaterThan(
+			0,
+			$http_attempts,
+			'Force path must call wp_update_plugins() (an outbound api.wordpress.org request).'
+		);
+
+		// The cached "no updates" snapshot must be gone. Core may write
+		// back a minimal `{ last_checked }` stub after a failed wp.org
+		// call to throttle retries — that's fine; what matters is that
+		// the stale `response` map is no longer there for the field
+		// callback to read.
+		$after = get_site_transient( 'update_plugins' );
+		if ( is_object( $after ) ) {
+			$this->assertEmpty(
+				(array) ( $after->response ?? array() ),
+				'Force path must clear the cached `response` map.'
+			);
+		} else {
+			$this->assertFalse( $after );
+		}
+	}
+
+	/**
+	 * Hosts that opt out of wp.org checks via the filter must stay
+	 * opted out even on the explicit force path.
+	 *
+	 * @covers ::desktop_mode_plugins_window_maybe_refresh_update_transient
+	 */
+	public function test_force_refresh_respects_short_circuit_filter() {
+		$initial = (object) array(
+			'last_checked' => time() - DAY_IN_SECONDS, // would normally trigger refresh
+			'response'     => array(),
+			'checked'      => array(),
+		);
+		set_site_transient( 'update_plugins', $initial );
+
+		$saw_force = null;
+		add_filter(
+			'desktop_mode_plugins_window_refresh_updates',
+			static function ( $refresh, $force ) use ( &$saw_force ) {
+				$saw_force = $force;
+				return false;
+			},
+			10,
+			2
+		);
+
+		try {
+			desktop_mode_plugins_window_maybe_refresh_update_transient( true );
+		} finally {
+			remove_all_filters( 'desktop_mode_plugins_window_refresh_updates' );
+		}
+
+		$this->assertTrue( $saw_force, 'Filter must receive the force flag.' );
+		// Compare by value — `get_site_transient` re-hydrates the option
+		// into a new stdClass instance, so identity comparison is wrong.
+		$this->assertEquals(
+			$initial,
+			get_site_transient( 'update_plugins' ),
+			'Filter must be able to suppress even the force-refresh path.'
+		);
+	}
 }

--- a/tests/vitest/plugins-window-rest.test.ts
+++ b/tests/vitest/plugins-window-rest.test.ts
@@ -131,6 +131,24 @@ describe( 'fetchInstalledPlugins', () => {
 			/Sorry, you can/,
 		);
 	} );
+
+	test( 'appends ?desktop_mode_force_refresh=1 when force is true', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			jsonResponse( [] ) as never,
+		);
+		await fetchInstalledPlugins( { force: true } );
+		const [ url ] = fetchMock.mock.calls[ 0 ] as [ string, RequestInit ];
+		expect( url ).toContain( 'desktop_mode_force_refresh=1' );
+	} );
+
+	test( 'omits the force flag by default', async () => {
+		const fetchMock = vi.spyOn( global, 'fetch' as never ).mockResolvedValue(
+			jsonResponse( [] ) as never,
+		);
+		await fetchInstalledPlugins();
+		const [ url ] = fetchMock.mock.calls[ 0 ] as [ string, RequestInit ];
+		expect( url ).not.toContain( 'desktop_mode_force_refresh' );
+	} );
 } );
 
 describe( 'activate / deactivate / delete', () => {


### PR DESCRIPTION
Closes #202.

Three real bugs the reporter described, fixed surgically:

## What was broken

1. **Refresh button was a no-op within 12h.** The in-window Refresh button hit `/wp/v2/plugins` with no special signal, so the server-side prime helper honoured Core's 12h `update_plugins` throttle and returned the same stale "no updates" snapshot it had already cached. The classic Plugins screen fixes this with `wp_clean_plugins_cache( true )` on every load — we had no equivalent escape hatch.

2. **Dock badge drifted out of sync with the window.** The Refresh handler only re-fetched row data; it never called `refreshFrameworkMenu()`. After any successful update, the row cleared but the dock-icon "1" badge could persist.

3. **Failed / silent-success updates left the row stuck on "Update available."** Two sub-cases:
   - When Core's `wp_ajax_update_plugin` returns the up-to-date branch (line 4685 of `ajax-actions.php`), it only ships `errorMessage` — not `errorCode`. Our previous code only matched on `errorCode === 'up_to_date'`, so we always fell through to the failure path.
   - The failure path never re-fetched the row, so a server-success / client-error race (timeout, parse failure) left the UI showing "Update available" even though disk was already at the new version.

## What changed

### Server (`includes/plugins-window/rest-fields.php`)
- `desktop_mode_plugins_window_maybe_refresh_update_transient( $force = false )` — new `$force` flag. On force, calls `wp_clean_plugins_cache( true )` (or `delete_site_transient` on the fallback path) and then `wp_update_plugins()` so the transient is repopulated with a fresh wp.org snapshot before the field callback reads it.
- New helper `desktop_mode_plugins_window_force_refresh_requested()` reads `?desktop_mode_force_refresh=1` from the REST request's query string.
- The `desktop_mode_plugins_window_refresh_updates` filter gains a second `$force` argument so hosts that block wp.org calls outright can stay opted out even on user-initiated refreshes.

### Client (`src/plugins-window/`)
- `fetchInstalledPlugins({ force?: boolean })` appends the new query arg when force is set.
- The Refresh button handler now awaits `reload({ force: true })` and then calls `refreshFrameworkMenu()` so the dock badge repaints from the same fresh state.
- `runUpdate()` catch path:
  - Detects Core's up-to-date signal via either `errorCode === 'up_to_date'` (future-proof) or `errorMessage === wp.i18n.__('The plugin is at the latest version.')` (the actual current shape). On match, clears the row's update marker and shows a calm "X is already up to date." toast instead of "Update of X failed: …".
  - Other failures: shows the failure toast and kicks `void reload()` to reconcile from the server.
  - Both branches now always call `refreshFrameworkMenu()` at the end so the dock badge stays consistent.
- `extractAjaxError` reads either `code` or `errorCode` from the response (Core uses both depending on the handler).

## Tests

- New JS tests covering `fetchInstalledPlugins({ force })` URL building.
- New PHPUnit tests for the force-refresh query-string detector, the throttle-bypass behaviour, and the `$force` filter contract.
- 1211 JS tests + 674 PHP tests pass post-merge with trunk.

## Manual test coverage

Verified end-to-end against the reporter's exact sequence: empty cache → Refresh → Update succeeds, dock badge clears. Also covered: non-force path still throttles (regression coverage); up-to-date silent-success path; hard-failure path (download 404) leaves row + badge intact and surfaces a clear error toast.

## Test plan

- [x] Pull this branch, run `npm run build && npm run test:js && npm run test:php`.
- [x] In the desktop Plugins window, click Refresh on a stale state — pending update should appear.
- [x] Update a plugin that's already at latest version externally — calm "already up to date" toast, no scary "failed" wording.
- [x] Simulate a download failure (bad package URL) — clear failure toast, row stays on "Update available", dock badge stays correct.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-211-e0aa291be1e4c52d6ff9357bb5dc2fdf9c20055c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->