### PR TITLE
Trash bin polish: URL badge, live placement badge, no media auto-trash

### DIFF
--- a/docs/examples/recycle-bin.md
+++ b/docs/examples/recycle-bin.md
@@ -54,6 +54,14 @@ wp_delete_attachment( $attachment_id, true );
 
 `wp_delete_attachment( $id, true )` with the force flag skips capture automatically — the filter is the per-call escape hatch when you can't pass `force_delete = true`.
 
+By default media files are NOT auto-routed through Trash: vanilla WordPress permanent-deletes attachments on first click, and the Recycle Bin tracks only posts, pages, and comments. Sites that want media in the bin should define `MEDIA_TRASH` in `wp-config.php`:
+
+```php
+define( 'MEDIA_TRASH', true );
+```
+
+Once set, deleting from the Media library routes the attachment through the WP trash and the Recycle Bin window surfaces it automatically (`attachment` is already in the default `desktop_mode_recycle_bin_capture_post_types` list). The constant has to live in `wp-config.php` because Core locks it before any plugin loads.
+
 ## Add a custom column to the table
 
 The JS layer applies a filter to the column descriptor before assignment:

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1618,7 +1618,7 @@ add_filter( 'desktop_mode_recycle_bin_capture_post_types', function ( $types ) {
 
 ### `desktop_mode_recycle_bin_should_capture` — Experimental (filter)
 
-Per-attachment opt-out. Returning `false` for a specific `WP_Post` lets that single deletion bypass the bin.
+Per-attachment opt-out, applied when something has set `MEDIA_TRASH` (or otherwise routes attachment deletes through `wp_trash_post()`). Returning `false` for a specific `WP_Post` lets that single deletion bypass the bin's metadata stamping.
 
 ```php
 apply_filters( 'desktop_mode_recycle_bin_should_capture', bool $capture, WP_Post $post );

--- a/includes/desktop-files/trash.php
+++ b/includes/desktop-files/trash.php
@@ -1080,7 +1080,13 @@ function desktop_mode_files_list_trashed_for_recycle_bin( $user_id ) {
 				__( '%s on desktop', 'desktop-mode' ),
 				(string) $row['file_type']
 			);
-		$out[] = array(
+		// `type_label` is the short uppercase badge the JS renders
+		// inline before the title. Most placements collapse to the
+		// generic "Placement" badge (the JS humanizes the bucket
+		// slug when no label is set). `link` placements — created
+		// via "New URL" on the desktop — deserve a more specific
+		// label so they read as URL-shortcuts, not generic tiles.
+		$item = array(
 			'id'            => (int) $row['id'],
 			'type'          => $bucket,
 			'title'         => $title,
@@ -1095,6 +1101,10 @@ function desktop_mode_files_list_trashed_for_recycle_bin( $user_id ) {
 			'can_purge'     => desktop_mode_files_user_can_purge_placement( $user_id, $row ),
 			'edit_link'     => '',
 		);
+		if ( 'link' === (string) $row['file_type'] ) {
+			$item['type_label'] = __( 'URL', 'desktop-mode' );
+		}
+		$out[] = $item;
 	}
 
 	// Trashed folders owned by this user.

--- a/includes/recycle-bin/capture.php
+++ b/includes/recycle-bin/capture.php
@@ -2,15 +2,18 @@
 /**
  * Desktop Mode — Recycle Bin: capture.
  *
- * Intercepts media deletion so attachments are routed to the WordPress
- * trash instead of being permanently deleted on first call. Posts and
- * pages already use the trash by default — this file's job is to bring
- * media in line so the Recycle Bin window has something to show.
+ * Stamps "who-deleted-what-when" metadata onto posts, pages, and
+ * comments as they pass through `wp_trash_post()` / `trashed_comment`,
+ * so the Recycle Bin window can show "deleted by Alice, 5 minutes ago"
+ * without a second roundtrip.
  *
- * The interception is filterable end-to-end:
+ * Media attachments are NOT auto-routed through Trash — they follow
+ * vanilla WordPress behavior (permanent-delete on first click). To
+ * enable trash for media, define `MEDIA_TRASH` as `true` in
+ * `wp-config.php`; the Recycle Bin window will surface trashed
+ * attachments automatically because `attachment` is in the default
+ * `desktop_mode_recycle_bin_capture_post_types` list.
  *
- *   - `desktop_mode_recycle_bin_should_capture` decides whether a given
- *     attachment is captured at all (capability gates, plugin opt-out).
  *   - `desktop_mode_recycle_bin_capture_post_types` controls which post
  *     types we listen for in the first place.
  *   - The `desktop_mode_recycle_bin_item_captured` action fires after a
@@ -51,85 +54,6 @@ function desktop_mode_recycle_bin_capture_post_types() {
 	$types = apply_filters( 'desktop_mode_recycle_bin_capture_post_types', $types );
 
 	return array_values( array_filter( array_map( 'strval', (array) $types ) ) );
-}
-
-/**
- * Whether the recycle bin should capture a given attachment.
- *
- * Returning `false` from the `desktop_mode_recycle_bin_should_capture`
- * filter restores vanilla `wp_delete_attachment()` semantics for that
- * single call — useful for "really delete now" admin flows.
- *
- * @since 0.19.0
- *
- * @param WP_Post $post  Attachment post object.
- * @param bool    $force Whether `wp_delete_attachment( $id, true )` was used.
- * @return bool
- */
-function desktop_mode_recycle_bin_should_capture_attachment( $post, $force ) {
-	// Honor explicit force-delete: that's the user (or a plugin) saying
-	// "skip the bin." Same contract as posts.
-	if ( $force ) {
-		return false;
-	}
-
-	if ( ! in_array( 'attachment', desktop_mode_recycle_bin_capture_post_types(), true ) ) {
-		return false;
-	}
-
-	/**
-	 * Filter whether a specific attachment should be soft-deleted into
-	 * the recycle bin instead of being permanently deleted.
-	 *
-	 * @since 0.19.0
-	 *
-	 * @param bool    $capture Default true.
-	 * @param WP_Post $post    Attachment being deleted.
-	 */
-	return (bool) apply_filters( 'desktop_mode_recycle_bin_should_capture', true, $post );
-}
-
-/**
- * Short-circuits `wp_delete_attachment()` to route the attachment
- * through the trash instead.
- *
- * Returning a non-null value from the `pre_delete_attachment` filter
- * tells core to skip its delete codepath and use our return value as
- * the function result. We call `wp_trash_post()`, stash a marker so
- * the bin knows when it was deleted and by whom, and return the
- * trashed post object — same shape `wp_delete_attachment()` would.
- *
- * @since 0.19.0
- *
- * @param mixed   $delete Default null (continue with deletion).
- * @param WP_Post $post   Attachment about to be deleted.
- * @param bool    $force  Whether force-delete was requested.
- * @return mixed Non-null short-circuits core deletion.
- */
-function desktop_mode_recycle_bin_intercept_attachment_delete( $delete, $post, $force ) {
-	if ( null !== $delete ) {
-		// Another plugin already short-circuited — don't double-handle.
-		return $delete;
-	}
-
-	if ( ! ( $post instanceof WP_Post ) || 'attachment' !== $post->post_type ) {
-		return $delete;
-	}
-
-	if ( ! desktop_mode_recycle_bin_should_capture_attachment( $post, $force ) ) {
-		return $delete;
-	}
-
-	$trashed = wp_trash_post( $post->ID );
-	if ( ! $trashed ) {
-		// Trash failed — let core try its normal deletion so we don't
-		// silently drop the user's request on the floor.
-		return $delete;
-	}
-
-	desktop_mode_recycle_bin_record_capture( $post->ID );
-
-	return $trashed;
 }
 
 /**
@@ -189,7 +113,6 @@ function desktop_mode_recycle_bin_record_capture( $post_id ) {
 	do_action( 'desktop_mode_recycle_bin_item_captured', $post_id, $user_id, $now_gmt );
 }
 
-add_filter( 'pre_delete_attachment', 'desktop_mode_recycle_bin_intercept_attachment_delete', 10, 3 );
 add_action( 'wp_trash_post', 'desktop_mode_recycle_bin_on_trash_post', 10, 1 );
 
 /**

--- a/src/desktop-files/trash.ts
+++ b/src/desktop-files/trash.ts
@@ -27,14 +27,28 @@ import type { RestPlacementShape } from './rest';
  * Broadcast a "this kind of thing changed in trash state" event so
  * cross-window listeners (recycle-bin, badge counters, …) can refresh
  * without waiting for the next Heartbeat tick.
+ *
+ * Payload follows the cross-window convention:
+ *   { source, action: 'trashed' | 'untrashed' | 'deleted', ids }
+ * so the badge subscriber can delta-update by `ids.length` and the
+ * Recycle Bin window's own listener can skip its self-emitted events
+ * by checking `source`.
  */
-function broadcastFilesChange( kind: 'placement' | 'shortcut' | 'folder' ): void {
+function broadcastFilesChange(
+	kind: 'placement' | 'shortcut' | 'folder',
+	action: 'trashed' | 'untrashed' | 'deleted',
+	ids: number[],
+): void {
 	const api = (
 		window as {
 			wp?: { desktop?: { broadcast?: ( topic: string, payload: unknown ) => void } };
 		}
 	).wp?.desktop;
-	api?.broadcast?.( `desktop-mode.${ kind }.changed`, { reason: 'trash' } );
+	api?.broadcast?.( `desktop-mode.${ kind }.changed`, {
+		source: 'desktop-files',
+		action,
+		ids,
+	} );
 }
 
 function showTrashedToast( message: string, onUndo: () => void ): void {
@@ -72,13 +86,13 @@ export async function trashPlacementWithUndo(
 	filesStoreApi.removePlacement( placementId );
 	try {
 		await rest.deletePlacement( placementId );
-		broadcastFilesChange( kind );
+		broadcastFilesChange( kind, 'trashed', [ placementId ] );
 		showTrashedToast( `"${ title }" moved to Trash`, async () => {
 			try {
 				await rest.restoreTrashedItem( placementId, 'placement' );
 				const res = await rest.listPlacements( parentId );
 				filesStoreApi.setFolderPlacements( parentId, res.placements );
-				broadcastFilesChange( kind );
+				broadcastFilesChange( kind, 'untrashed', [ placementId ] );
 			} catch ( err ) {
 				// eslint-disable-next-line no-console
 				console.error( '[desktop-mode] restore failed:', err );
@@ -112,13 +126,13 @@ export async function trashFolderWithUndo(
 	filesStoreApi.removeFolder( folderId );
 	try {
 		await rest.deleteFolder( folderId );
-		broadcastFilesChange( 'folder' );
+		broadcastFilesChange( 'folder', 'trashed', [ folderId ] );
 		showTrashedToast( `"${ title }" moved to Trash`, async () => {
 			try {
 				await rest.restoreTrashedItem( folderId, 'folder' );
 				const res = await rest.listPlacements( parentId );
 				filesStoreApi.setFolderPlacements( parentId, res.placements );
-				broadcastFilesChange( 'folder' );
+				broadcastFilesChange( 'folder', 'untrashed', [ folderId ] );
 			} catch ( err ) {
 				// eslint-disable-next-line no-console
 				console.error( '[desktop-mode] restore folder failed:', err );

--- a/src/recycle-bin/badge.ts
+++ b/src/recycle-bin/badge.ts
@@ -382,6 +382,13 @@ function wireBroadcastDeltas(): void {
 	subscribe( 'desktop-mode.page.changed', onDomain );
 	subscribe( 'desktop-mode.attachment.changed', onDomain );
 	subscribe( 'desktop-mode.comment.changed', onDomain );
+	// Files-on-the-desktop trash mutations (URL placements, plugin
+	// shortcuts, user folders). Without these, dragging a URL tile to
+	// the Recycle Bin trashes the placement but the dock badge stays
+	// at its previous value until the next Heartbeat tick.
+	subscribe( 'desktop-mode.placement.changed', onDomain );
+	subscribe( 'desktop-mode.shortcut.changed', onDomain );
+	subscribe( 'desktop-mode.folder.changed', onDomain );
 }
 
 /**

--- a/tests/phpunit/tests/recycleBinTrashView.php
+++ b/tests/phpunit/tests/recycleBinTrashView.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Tests for Trash bin view polish:
+ *
+ *   - URL placements (file_type='link') carry a dedicated 'URL' badge
+ *     label (issue 1).
+ *   - Media attachments follow vanilla WP behavior — they permanent-
+ *     delete on first call and do NOT route through Trash by default
+ *     (issue 2). Sites that want media-in-trash opt in via
+ *     `define( 'MEDIA_TRASH', true )` in `wp-config.php`.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-recycle-bin
+ */
+class Tests_DesktopMode_RecycleBinTrashView extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		desktop_mode_files_install_schema();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		global $wpdb;
+		$tables = desktop_mode_files_table_names();
+		foreach ( $tables as $t ) {
+			$wpdb->query( "TRUNCATE TABLE $t" );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Issue 1: a trashed link placement reports `type_label = 'URL'` so
+	 * the JS badge reads "URL" instead of the generic "Placement".
+	 *
+	 * @covers ::desktop_mode_files_list_trashed_for_recycle_bin
+	 */
+	public function test_link_placement_carries_url_type_label() {
+		$placement_id = $this->create_placement( 'link', 'https://example.com/' );
+		desktop_mode_files_trash_placement( self::$admin_id, $placement_id );
+
+		$items = desktop_mode_files_list_trashed_for_recycle_bin( self::$admin_id );
+
+		$item = $this->find_by_id( $items, $placement_id );
+		$this->assertNotNull( $item, 'Trashed link placement should appear in the list.' );
+		$this->assertSame( 'placement', $item['type'], 'Bucket stays "placement" so filters keep working.' );
+		$this->assertArrayHasKey( 'type_label', $item );
+		$this->assertSame( 'URL', $item['type_label'] );
+	}
+
+	/**
+	 * Issue 1 — counter-test: non-link placements don't get the URL
+	 * label so they fall back to the JS-side humanized bucket.
+	 *
+	 * @covers ::desktop_mode_files_list_trashed_for_recycle_bin
+	 */
+	public function test_non_link_placement_has_no_url_type_label() {
+		$post_id      = self::factory()->post->create();
+		$placement_id = $this->create_placement( 'post', (string) $post_id );
+		desktop_mode_files_trash_placement( self::$admin_id, $placement_id );
+
+		$items = desktop_mode_files_list_trashed_for_recycle_bin( self::$admin_id );
+
+		$item = $this->find_by_id( $items, $placement_id );
+		$this->assertNotNull( $item );
+		$this->assertSame( 'placement', $item['type'] );
+		$this->assertArrayNotHasKey( 'type_label', $item, 'Only link placements opt into the bespoke label.' );
+	}
+
+	/**
+	 * Issue 2: with the `pre_delete_attachment` interception removed,
+	 * deleting an attachment via `wp_delete_attachment()` follows
+	 * vanilla WP — the post is permanently deleted on first call,
+	 * not routed to Trash. The Recycle Bin only surfaces attachments
+	 * that were trashed through some other path (REST, programmatic
+	 * `wp_trash_post`, MEDIA_TRASH enabled).
+	 */
+	public function test_attachment_delete_does_not_route_through_trash_by_default() {
+		$zip_id = self::factory()->attachment->create_object(
+			'/tmp/akismet.zip',
+			0,
+			array(
+				'post_mime_type' => 'application/zip',
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+			)
+		);
+		$image_id = self::factory()->attachment->create_object(
+			'/tmp/photo.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+			)
+		);
+
+		wp_delete_attachment( $zip_id );
+		wp_delete_attachment( $image_id );
+
+		$this->assertNull( get_post( $zip_id ), '.zip should permanent-delete on first call.' );
+		$this->assertNull( get_post( $image_id ), 'Image should permanent-delete on first call.' );
+	}
+
+	/**
+	 * Posts still go through Trash via core's default behavior — the
+	 * removal of the attachment-specific interception must not affect
+	 * the non-attachment trash flow.
+	 */
+	public function test_posts_still_route_through_trash() {
+		$post_id = self::factory()->post->create(
+			array( 'post_status' => 'publish' )
+		);
+
+		wp_delete_post( $post_id );
+
+		$post = get_post( $post_id );
+		$this->assertNotNull( $post );
+		$this->assertSame( 'trash', $post->post_status );
+	}
+
+	private function create_placement( string $file_type, string $file_ref ): int {
+		global $wpdb;
+		$tables = desktop_mode_files_table_names();
+		$now_ms = (int) round( microtime( true ) * 1000 );
+		$wpdb->insert(
+			$tables['placements'],
+			array(
+				'user_id'       => self::$admin_id,
+				'parent_id'     => 0,
+				'file_type'     => $file_type,
+				'file_ref'      => $file_ref,
+				'x'             => 0,
+				'y'             => 0,
+				'sort_order'    => 0,
+				'updated_at_ms' => $now_ms,
+			)
+		);
+		return (int) $wpdb->insert_id;
+	}
+
+	private function find_by_id( array $items, int $id ): ?array {
+		foreach ( $items as $item ) {
+			if ( (int) $item['id'] === $id ) {
+				return $item;
+			}
+		}
+		return null;
+	}
+}

--- a/tests/vitest/recycle-bin-badge-files-delta.test.ts
+++ b/tests/vitest/recycle-bin-badge-files-delta.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression test — files-on-desktop trash broadcast shape.
+ *
+ * Trashing a URL placement (or plugin shortcut / folder) MUST emit
+ * the cross-window convention payload `{ source, action, ids }` so
+ * the dock badge can delta-update synchronously. Before this fix
+ * the helper emitted `{ reason: 'trash' }`, which the badge
+ * subscriber couldn't decode — the badge then waited up to a full
+ * Heartbeat tick (15–60 s) to learn there was a new item in trash.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+async function load(): Promise< {
+	trash: typeof import( '../../src/desktop-files/trash' );
+	store: typeof import( '../../src/desktop-files/store' );
+	rest: typeof import( '../../src/desktop-files/rest' );
+	bc: typeof import( '../../src/broadcast' );
+} > {
+	return {
+		trash: await import( '../../src/desktop-files/trash' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+		bc: await import( '../../src/broadcast' ),
+	};
+}
+
+function makePlacement( id: number, type = 'link' ) {
+	return {
+		id,
+		parentId: 0,
+		x: 0,
+		y: 0,
+		sortOrder: 0,
+		updatedAtMs: 1,
+		meta: null,
+		file: {
+			type,
+			ref: 'https://example.com/',
+			title: 'example.com',
+			icon: 'dashicons-admin-links',
+			previewUrl: '',
+			exists: true,
+		},
+	};
+}
+
+describe( 'desktop-files trash — broadcast shape', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		// Mount a thin `wp.desktop.broadcast` shim that forwards to
+		// the module-level broadcast — production wires this in
+		// `desktop.ts` boot, but our test loads the trash helper in
+		// isolation. Without it the broadcaster silently no-ops and
+		// the bug we're regression-testing is invisible.
+		const { bc } = await load();
+		const w = window as unknown as { wp?: Record< string, unknown > };
+		w.wp = {
+			...( w.wp ?? {} ),
+			desktop: {
+				...( ( w.wp?.desktop as Record< string, unknown > | undefined ) ?? {} ),
+				broadcast: bc.broadcast,
+			},
+		};
+	} );
+
+	afterEach( async () => {
+		const { store } = await load();
+		store.__resetFilesStoreForTests();
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		const w = window as unknown as { wp?: Record< string, unknown > };
+		if ( w.wp ) {
+			delete w.wp.desktop;
+		}
+	} );
+
+	test( 'trashPlacementWithUndo broadcasts { action: "trashed", ids } on placement.changed', async () => {
+		const { trash, store, rest, bc } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		const fetchSpy = vi.fn( async () =>
+			new Response( JSON.stringify( { deleted: true } ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ),
+		);
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		const placementSub = vi.fn();
+		bc.subscribe( 'desktop-mode.placement.changed', placementSub );
+
+		const p = makePlacement( 42, 'link' );
+		store.setFolderPlacements( 0, [ p ] );
+
+		await trash.trashPlacementWithUndo( p );
+
+		expect( placementSub ).toHaveBeenCalledTimes( 1 );
+		expect( placementSub ).toHaveBeenCalledWith(
+			{
+				source: 'desktop-files',
+				action: 'trashed',
+				ids: [ 42 ],
+			},
+			expect.objectContaining( { topic: 'desktop-mode.placement.changed' } ),
+		);
+	} );
+
+	test( 'trashPlacementWithUndo on a shortcut emits on shortcut.changed (not placement.changed)', async () => {
+		const { trash, store, rest, bc } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( async () =>
+				new Response( JSON.stringify( { deleted: true } ), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				} ),
+			),
+		);
+
+		const shortcutSub = vi.fn();
+		const placementSub = vi.fn();
+		bc.subscribe( 'desktop-mode.shortcut.changed', shortcutSub );
+		bc.subscribe( 'desktop-mode.placement.changed', placementSub );
+
+		const p = makePlacement( 17, 'shortcut' );
+		store.setFolderPlacements( 0, [ p ] );
+
+		await trash.trashPlacementWithUndo( p );
+
+		expect( shortcutSub ).toHaveBeenCalledWith(
+			{
+				source: 'desktop-files',
+				action: 'trashed',
+				ids: [ 17 ],
+			},
+			expect.objectContaining( { topic: 'desktop-mode.shortcut.changed' } ),
+		);
+		expect( placementSub ).not.toHaveBeenCalled();
+	} );
+
+	test( 'trashFolderWithUndo emits on folder.changed with the folder id', async () => {
+		const { trash, store, rest, bc } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( async () =>
+				new Response( JSON.stringify( { deleted: true } ), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				} ),
+			),
+		);
+
+		const folderSub = vi.fn();
+		bc.subscribe( 'desktop-mode.folder.changed', folderSub );
+
+		const folderPlacement = {
+			...makePlacement( 9, 'folder' ),
+			file: {
+				...makePlacement( 9, 'folder' ).file,
+				ref: '5',
+				icon: 'dashicons-portfolio',
+				title: 'My Folder',
+			},
+		};
+		store.setFolderPlacements( 0, [ folderPlacement ] );
+
+		await trash.trashFolderWithUndo( folderPlacement );
+
+		expect( folderSub ).toHaveBeenCalledWith(
+			{
+				source: 'desktop-files',
+				action: 'trashed',
+				ids: [ 5 ],
+			},
+			expect.objectContaining( { topic: 'desktop-mode.folder.changed' } ),
+		);
+	} );
+} );


### PR DESCRIPTION
Follow-up to #206. Three small Trash-bin improvements from post-merge feedback.

## Summary

- **URL placements get a dedicated 'URL' badge.** A trashed "New URL" tile now reads `URL` in the inline type badge instead of the generic `Placement`. Other placement kinds keep their existing humanized bucket label.
- **Dock badge updates live when a URL / shortcut / folder is moved to Trash.** The desktop-files trash helper was emitting `{ reason: 'trash' }`, which the badge subscriber couldn't decode — so the dock badge stayed stale until the next Heartbeat tick (15–60s). Now it emits the cross-window convention `{ source, action, ids }` that posts/pages/attachments already use, and the badge subscribes to the `placement.changed` / `shortcut.changed` / `folder.changed` channels.
- **Media files revert to vanilla WordPress behaviour.** The plugin no longer intercepts `pre_delete_attachment`, so Media-library delete actually permanent-deletes on first click. This resolves the "plugin .zip shows up in Trash bin as Media" feedback at the source — nothing auto-trashes those files anymore. Sites that want media-in-trash can opt in by setting `define( 'MEDIA_TRASH', true );` in `wp-config.php`; the Recycle Bin still tracks `attachment` in its default capture list, so trashed media surfaces automatically when any path (REST, programmatic `wp_trash_post`, MEDIA_TRASH-enabled flow) routes it there.

## Test plan

- [x] Create a "New URL" placement on the desktop, drag it to Trash. The Recycle Bin row should display a red-ish `URL` badge instead of `PLACEMENT`.
- [x] While trashing the URL above, watch the Trash dock icon — the badge count should bump +1 immediately, no Heartbeat-tick delay. Restoring via the Undo toast should bump it back −1, also live.
- [x] Same live-badge behavior for trashing a plugin shortcut and trashing a user folder.
- [x] Upload a plugin .zip into the Media library, delete it from the Media library. It should be gone immediately, no Trash entry.
- [x] Trash a post or page — should still route through Trash as before (regression check).
- [ ] Restore a previously-trashed media file from the Recycle Bin (if any pre-existing items are in the bin from before this PR) — should still work.

## Coverage

- 4 new PHPUnit cases for the URL label and the media-permanent-delete default
- 3 new vitest cases for the placement / shortcut / folder broadcast shape
- Full suites green: 1214 JS, 678 PHP

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-214-c8e0c12d6d12a13db47d96286ac0d2f6d792572e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->