### PR TITLE
fix(files): throw on empty REST body to avoid TypeError after self-replace

### DIFF
--- a/src/desktop-files/rest.ts
+++ b/src/desktop-files/rest.ts
@@ -116,6 +116,19 @@ async function call< T >( path: string, init: RequestInit ): Promise< T > {
 			`[desktop-mode] files REST ${ res.status }: ${ err?.code ?? '' } ${ err?.message ?? '' }`.trim(),
 		);
 	}
+	// A 2xx with an empty or unparseable body is something the
+	// consumers can't usefully do anything with (every route in
+	// this module returns a shaped object). It happens transiently
+	// when desktop-mode replaces itself live — REST routes briefly
+	// re-register, a redirect to wp-login HTML can sneak through,
+	// etc. — and crashes the consumer with a cryptic
+	// `Cannot read properties of null` if we forward it. Throw
+	// here so the caller's `.catch` logs a meaningful line.
+	if ( null === body ) {
+		throw new Error(
+			`[desktop-mode] files REST ${ res.status }: empty or unparseable body.`,
+		);
+	}
 	return body as T;
 }
 


### PR DESCRIPTION
## Summary

When desktop-mode replaces itself live (Plugins window → Upload .zip → Replace), REST routes briefly re-register and a 2xx response can land with an empty or unparseable body. The files REST client previously returned `null as T`, which crashed the folder-hydration consumer in `src/desktop-files/layer.ts` with:

```
[desktop-mode] files: failed to hydrate folder 0 TypeError: Cannot read properties of null (reading 'placements')
```

Fix at the boundary: in `src/desktop-files/rest.ts`'s `call()`, throw when the body is `null` on a 2xx. Every consumer in the files module expects a shaped object, so a null body is never legitimate. The existing `.catch` handlers now log a single meaningful line:

```
[desktop-mode] files: failed to hydrate folder 0 Error: [desktop-mode] files REST 200: empty or unparseable body.
```

Boundary fix > per-consumer guard: one change covers `listPlacements`, `listFolders`, `restoreTrashedItem`, etc., and produces a clearer signal than silently no-op'ing.

The `409 (Conflict)` console line that also appears in the issue is expected — it's the server's "this plugin folder already exists, replace?" signal that `upload-dialog.ts` handles correctly. Out of scope for this PR.

Refs WordPress/desktop-mode#212.

## Test plan

- [x] On a site with desktop-mode active, open the Plugins window and upload the desktop-mode .zip.
- [x] Confirm the "Replace existing plugin?" dialog appears (409 path still works).
- [x] Click Replace; upload completes.
- [x] CTRL+R the page; the TypeError on folder hydration no longer fires.
- [x] If the transient empty-body race still hits, the console shows the new clear message instead of the TypeError, and the desktop layer keeps working.
- [x] `npm run lint`, `tsc --noEmit`, `npm run test:js` all pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-215-476078728cd601660f21da91d806c94d0638ca4c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->