### PR TITLE
feat(recycle-bin): hide Media filter tab when MEDIA_TRASH is off

### DIFF
--- a/docs/examples/recycle-bin.md
+++ b/docs/examples/recycle-bin.md
@@ -62,6 +62,8 @@ define( 'MEDIA_TRASH', true );
 
 Once set, deleting from the Media library routes the attachment through the WP trash and the Recycle Bin window surfaces it automatically (`attachment` is already in the default `desktop_mode_recycle_bin_capture_post_types` list). The constant has to live in `wp-config.php` because Core locks it before any plugin loads.
 
+The Recycle Bin toolbar reflects this gate visually: the **Media** filter segment is hidden unless `MEDIA_TRASH` is on, so users on the default WP setup don't see a tab that can never have rows under it.
+
 ## Add a custom column to the table
 
 The JS layer applies a filter to the column descriptor before assignment:

--- a/includes/recycle-bin/window.php
+++ b/includes/recycle-bin/window.php
@@ -39,7 +39,20 @@ function desktop_mode_recycle_bin_render_template() {
 					<wpd-segment value="" selected><?php esc_html_e( 'All', 'desktop-mode' ); ?></wpd-segment>
 					<wpd-segment value="post"><?php esc_html_e( 'Posts', 'desktop-mode' ); ?></wpd-segment>
 					<wpd-segment value="page"><?php esc_html_e( 'Pages', 'desktop-mode' ); ?></wpd-segment>
-					<wpd-segment value="attachment"><?php esc_html_e( 'Media', 'desktop-mode' ); ?></wpd-segment>
+					<?php
+					// The Media segment is only useful when WP itself routes
+					// attachment deletions through Trash. That gate is the
+					// `MEDIA_TRASH` constant — defaults to false in core, can
+					// be flipped to true from `wp-config.php`. Without it,
+					// attachments permanent-delete on first click and the
+					// Trash bin will never have anything in this bucket, so
+					// the tab would always read "0" and confuse users.
+					if ( defined( 'MEDIA_TRASH' ) && MEDIA_TRASH ) :
+						?>
+						<wpd-segment value="attachment"><?php esc_html_e( 'Media', 'desktop-mode' ); ?></wpd-segment>
+						<?php
+					endif;
+					?>
 					<wpd-segment value="comment"><?php esc_html_e( 'Comments', 'desktop-mode' ); ?></wpd-segment>
 					<wpd-segment value="desktop"><?php esc_html_e( 'Desktop', 'desktop-mode' ); ?></wpd-segment>
 				</wpd-segmented>

--- a/tests/phpunit/tests/recycleBinMediaTab.php
+++ b/tests/phpunit/tests/recycleBinMediaTab.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Test that the Recycle Bin's Media filter tab only renders when
+ * `MEDIA_TRASH` is enabled.
+ *
+ * Without MEDIA_TRASH, WP routes every attachment delete straight to
+ * permanent-delete, so the Trash bin will never have anything in the
+ * Media bucket — surfacing an empty tab there just confuses users.
+ *
+ * Note on environment: the test suite's WP install defines
+ * `MEDIA_TRASH = false` inside `wp_initial_constants()` very early in
+ * the boot, before plugins (or this test file) load. PHP constants
+ * are immutable, so we can't flip it at runtime. Test asserts only
+ * the "false / undefined → tab hidden" branch — flipping MEDIA_TRASH
+ * to true requires a wp-config.php change and is covered by manual
+ * QA.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-recycle-bin
+ */
+class Tests_DesktopMode_RecycleBinMediaTab extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * @covers ::desktop_mode_recycle_bin_render_template
+	 */
+	public function test_media_segment_hidden_when_media_trash_is_off() {
+		// Guard: this test only makes sense in the default MEDIA_TRASH=false
+		// environment. If a future tests-env starts defining it true, the
+		// branch we care about is no longer reachable here and we can skip
+		// rather than emit a misleading pass.
+		if ( defined( 'MEDIA_TRASH' ) && MEDIA_TRASH ) {
+			$this->markTestSkipped(
+				'Environment has MEDIA_TRASH enabled; this branch is exercised by manual QA.'
+			);
+		}
+
+		ob_start();
+		desktop_mode_recycle_bin_render_template();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'value="attachment"',
+			$html,
+			'The Media segment must not render when MEDIA_TRASH is off.'
+		);
+		// Sibling segments stay so a regression on the conditional
+		// doesn't silently chop the rest of the toolbar.
+		$this->assertStringContainsString( 'value="post"', $html );
+		$this->assertStringContainsString( 'value="page"', $html );
+		$this->assertStringContainsString( 'value="comment"', $html );
+		$this->assertStringContainsString( 'value="desktop"', $html );
+	}
+}


### PR DESCRIPTION
## Summary

- The Recycle Bin toolbar was showing a **Media** type-filter segment on every install. On the default WP setup `MEDIA_TRASH` is `false`, so the Media library permanent-deletes attachments on first click and the bucket can never have rows — the tab always read empty and confused users.
- Render the **Media** segment only when `defined( 'MEDIA_TRASH' ) && MEDIA_TRASH`. Sites that opt in via `define( 'MEDIA_TRASH', true );` in `wp-config.php` get the tab back without any additional configuration.
- Sibling segments (Posts, Pages, Comments, Desktop) are unaffected.

The constant is the right gate because attachments only ever end up in trash when WordPress itself routes them there — which only happens when `MEDIA_TRASH` is truthy.

## Test plan

- [x] PHPUnit: new \`Tests_DesktopMode_RecycleBinMediaTab\` case verifies the Media segment is absent on the default \`MEDIA_TRASH=false\` env, and that the four sibling segments stay rendered. Self-skips if a future tests-env flips the constant on (PHP constants can't be flipped at runtime).
- [x] Manual: open the Recycle Bin without \`MEDIA_TRASH\` defined → toolbar reads "All | Posts | Pages | Comments | Desktop", no Media tab.
- [x] Manual: add \`define( 'MEDIA_TRASH', true );\` to \`wp-config.php\`, reload → Media tab appears between Pages and Comments and filters correctly.
- [x] Full PHP suite: 679 / 679 green.
- [x] Full JS suite: 1214 / 1214 green.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-216-5ca3ad129e74bc7f4722abbeec2149d6c8f5a0bf.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->