### PR TITLE
fix(boot): sequence openCurrentPage after restoreSession to avoid duplicate windows

### DIFF
--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2242,20 +2242,26 @@ function init(): void {
 	//      IS the default window — open it. The desktop is populated
 	//      with the user's chosen startup.
 	const hasSession = !! ( config.session && config.session.windows && config.session.windows.length > 0 );
-	if ( hasSession ) {
-		// Fire-and-forget: the boot path doesn't need to wait for
-		// session restore to complete before proceeding with the
-		// rest of setup. Windows appear asynchronously as the lazy
-		// `window-system[.min].js` bundle resolves and each
-		// `manager.open(...)` finishes. Restore errors are logged
-		// rather than surfaced — a broken session shouldn't strand
-		// the desktop.
-		void restoreSession( manager, config, desktopArea ).catch( ( err ) => {
+	// Session restore runs fire-and-forget so the rest of boot
+	// (manager wiring, settings, server-sync) doesn't block on the
+	// lazy `window-system[.min].js` bundle. openCurrentPage chains
+	// off the SAME promise though — running it concurrently with
+	// restore races on `manager.open()`'s existing-check: both calls
+	// pass the check while the first window's `createWindow()` is
+	// still awaiting `ensureWindowSystemLoaded`, so the dedupe by
+	// baseId misses and the user gets two copies of the same window
+	// (e.g. portal-intent + saved Dashboard → two Dashboards, second
+	// one's iframe never finishes because the chromeless bridge
+	// only handshakes with one instance per id). The comment on
+	// case 2 already says "the page they asked for opens on top of
+	// the restored stack" — sequencing this is what makes that true.
+	const sessionRestore = hasSession
+		? restoreSession( manager, config, desktopArea ).catch( ( err ) => {
 			if ( typeof console !== 'undefined' ) {
 				console.error( '[desktop-mode] session restore failed:', err );
 			}
-		} );
-	}
+		} )
+		: Promise.resolve();
 	const defaultEnabled = config.defaultWindow?.enabled !== false;
 	const defaultUrlEarly = config.defaultWindow?.url ?? '';
 	const isNativeDefault =
@@ -2268,11 +2274,13 @@ function init(): void {
 		defaultEnabled,
 		isNativeDefault,
 	} ) ) {
-		void openCurrentPage( manager, config ).catch( ( err ) => {
-			if ( typeof console !== 'undefined' ) {
-				console.error( '[desktop-mode] openCurrentPage failed:', err );
-			}
-		} );
+		void sessionRestore.then( () =>
+			openCurrentPage( manager, config ).catch( ( err ) => {
+				if ( typeof console !== 'undefined' ) {
+					console.error( '[desktop-mode] openCurrentPage failed:', err );
+				}
+			} ),
+		);
 	}
 
 	// Persistence.


### PR DESCRIPTION
## Summary

Reported by Roberto: in Incognito with a portal-intent URL (`?desktop_mode_portal=1&desktop_mode_portal_intent=1`) and a saved session, two Dashboard windows opened; the second one's spinner never resolved.

Root cause is a boot-time race in `src/desktop.ts`:

- `restoreSession` and `openCurrentPage` were fired concurrently (both `void …`).
- `manager.open()`'s dedupe-by-baseId check (`src/window-manager/index.ts:406`) runs synchronously, **before** `createWindow()` awaits `ensureWindowSystemLoaded`. So both calls pass the existing-check while the first window is still mid-await on the lazy bundle.
- Result: two Window instances constructed with the same `id`/`baseId`. The chromeless bridge handshakes by id and only finishes one of them; the other hangs on the spinner forever.

## Fix

Sequence them. `openCurrentPage` chains off the same promise `restoreSession` resolves. If the page the user asked for is already in the restored stack, `manager.open()` finds and focuses it; otherwise a fresh window opens on top — exactly what the existing case-2 comment already promised ("the page they asked for opens on top of the restored stack").

No new manager-level state. The change is one block in `init()`.

## Test plan

- [x] Incognito, log in, hit `…/wp-admin/index.php?desktop_mode_portal=1&desktop_mode_portal_intent=1` with Dashboard in the saved session → exactly one Dashboard window opens, spinner resolves.
- [x] Fresh user with no saved session, direct admin URL (`fromPortal=false`) → window opens normally.
- [x] Bare `/desktop-mode/` visit (`fromPortal=true`, `fromPortalIntent=false`, session exists) → session restores, no extra window.
- [x] `npm run lint`, `tsc --noEmit`, `npm run test:js` (1214 tests) all pass.