### PR TITLE
fix(preview): pass id to windowManager.open from Open in editor button

### DIFF
--- a/src/desktop-files/preview.ts
+++ b/src/desktop-files/preview.ts
@@ -269,7 +269,13 @@ async function renderPostPreview(
 				}
 				| undefined
 		)?.desktop?.windowManager;
+		const postType =
+			typeof file.postType === 'string'
+				? ( file.postType as string )
+				: 'post';
+		const entityId = postType === 'page' ? 'pages' : 'posts';
 		wm?.open( {
+			id: `${ entityId }-edit-${ id }`,
 			url: editUrl,
 			title: stripTags( data.title.rendered ),
 			icon: file.icon,


### PR DESCRIPTION
## Summary

- Clicking **Open in editor** in the folder preview pane (right side of a folder window, for a shortcut to a post/page) threw `TypeError: windowManager.open(): config.id must be a non-empty string` and did nothing.
- Root cause: `renderPostPreview()` in `src/desktop-files/preview.ts` called `wm.open()` without an `id`. `WindowManager.open()` requires `config.id` to be a non-empty string (`src/window-manager/index.ts:384`) and throws otherwise.
- Fix: derive `entityId` from `file.postType` (the same shape the **Explore details** button just above already uses) and pass `id: \`${entityId}-edit-${postId}\``. This matches `openEditor()` in `src/my-wordpress/index.ts`, so reopening the same shortcut focuses the existing editor window instead of stacking duplicates.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `./node_modules/.bin/tsc --noEmit` clean
- [x] `npm run test:js` (1214/1214 passing)
- [x] Manual: open a folder containing a post shortcut, select it, click **Open in editor** → post editor opens in a new window. Click it again → existing window refocuses (no duplicates, no console error).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-219-708c0f566a56d658be85066fa864f36877a9a8ee.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->