### PR TITLE
Tag cloud & category mindmap: search, clustering, server cache

### DIFF
--- a/assets/css/posts-window.css
+++ b/assets/css/posts-window.css
@@ -510,6 +510,13 @@
 	border-bottom: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
 	background: rgba( 255, 255, 255, 0.6 );
 	backdrop-filter: blur( 8px );
+	/* New stacking context so the search dropdown (z-index inside)
+	 * paints above the pixi canvas in the layout sibling below. Without
+	 * this, the canvas (later in DOM, no z-index) wins the paint order
+	 * and the dropdown renders BEHIND the chips/nodes — clicks then land
+	 * on the canvas instead of the dropdown items. */
+	position: relative;
+	z-index: 2;
 }
 
 .wpd-mindmap__btn {
@@ -575,6 +582,82 @@
 	text-align: end;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-mindmap__search {
+	position: relative;
+	flex: 0 1 280px;
+	min-width: 180px;
+}
+
+.wpd-mindmap__search-input {
+	width: 100%;
+	padding: 6px 10px;
+	border: 1px solid var( --wpd-border, #d8dde4 );
+	border-radius: 6px;
+	background: var( --wpd-surface, #fff );
+	color: inherit;
+	font: inherit;
+	font-size: 13px;
+}
+
+.wpd-mindmap__search-input:focus {
+	outline: none;
+	border-color: var( --wpd-accent, var( --wp-admin-theme-color, #2271b1 ) );
+	box-shadow: 0 0 0 3px
+		var( --wpd-accent-soft, rgba( 34, 113, 177, 0.18 ) );
+}
+
+.wpd-mindmap__search-results {
+	position: absolute;
+	top: calc( 100% + 4px );
+	inset-inline-start: 0;
+	inset-inline-end: 0;
+	margin: 0;
+	padding: 4px;
+	list-style: none;
+	background: var( --wpd-surface-2, #fff );
+	border: 1px solid var( --wpd-border, #d8dde4 );
+	border-radius: 8px;
+	box-shadow: 0 6px 18px rgba( 17, 24, 39, 0.08 );
+	z-index: 100;
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.wpd-mindmap__search-result {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	width: 100%;
+	padding: 6px 10px;
+	background: transparent;
+	border: 0;
+	border-radius: 6px;
+	color: inherit;
+	cursor: pointer;
+	text-align: start;
+	font: inherit;
+	font-size: 13px;
+}
+
+.wpd-mindmap__search-result:hover,
+.wpd-mindmap__search-result.is-active {
+	background: var( --wpd-hover, rgba( 79, 139, 243, 0.08 ) );
+}
+
+.wpd-mindmap__search-title {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-mindmap__search-meta {
+	font-size: 11px;
+	color: var( --wpd-text-muted, #6b7280 );
 	white-space: nowrap;
 }
 
@@ -819,6 +902,10 @@
 	border-bottom: 1px solid var( --wpd-border, rgba( 0, 0, 0, 0.08 ) );
 	background: rgba( 255, 255, 255, 0.6 );
 	backdrop-filter: blur( 8px );
+	/* Stacking context for the search dropdown — see the matching
+	 * comment on `.wpd-mindmap__toolbar`. */
+	position: relative;
+	z-index: 2;
 }
 
 .wpd-tagcloud__btn {
@@ -880,6 +967,82 @@
 	text-align: end;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-tagcloud__search {
+	position: relative;
+	flex: 0 1 280px;
+	min-width: 180px;
+}
+
+.wpd-tagcloud__search-input {
+	width: 100%;
+	padding: 6px 10px;
+	border: 1px solid var( --wpd-border, #d8dde4 );
+	border-radius: 6px;
+	background: var( --wpd-surface, #fff );
+	color: inherit;
+	font: inherit;
+	font-size: 13px;
+}
+
+.wpd-tagcloud__search-input:focus {
+	outline: none;
+	border-color: var( --wpd-accent, var( --wp-admin-theme-color, #2271b1 ) );
+	box-shadow: 0 0 0 3px
+		var( --wpd-accent-soft, rgba( 34, 113, 177, 0.18 ) );
+}
+
+.wpd-tagcloud__search-results {
+	position: absolute;
+	top: calc( 100% + 4px );
+	inset-inline-start: 0;
+	inset-inline-end: 0;
+	margin: 0;
+	padding: 4px;
+	list-style: none;
+	background: var( --wpd-surface-2, #fff );
+	border: 1px solid var( --wpd-border, #d8dde4 );
+	border-radius: 8px;
+	box-shadow: 0 6px 18px rgba( 17, 24, 39, 0.08 );
+	z-index: 100;
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.wpd-tagcloud__search-result {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	width: 100%;
+	padding: 6px 10px;
+	background: transparent;
+	border: 0;
+	border-radius: 6px;
+	color: inherit;
+	cursor: pointer;
+	text-align: start;
+	font: inherit;
+	font-size: 13px;
+}
+
+.wpd-tagcloud__search-result:hover,
+.wpd-tagcloud__search-result.is-active {
+	background: var( --wpd-hover, rgba( 79, 139, 243, 0.08 ) );
+}
+
+.wpd-tagcloud__search-title {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-tagcloud__search-meta {
+	font-size: 11px;
+	color: var( --wpd-text-muted, #6b7280 );
 	white-space: nowrap;
 }
 

--- a/includes/posts-window/window.php
+++ b/includes/posts-window/window.php
@@ -361,12 +361,85 @@ function desktop_mode_posts_window_register_count_field() {
 add_action( 'rest_api_init', 'desktop_mode_posts_window_register_count_field' );
 
 /**
+ * Shared site-wide cache version for any term-derived endpoint
+ * payload (bulk counts, tag cooccurrence, …). Stored in a non-
+ * autoloaded option and bumped by
+ * `desktop_mode_posts_window_terms_cache_invalidate()` whenever a
+ * post/term change could move the derived data. The version is
+ * baked into every transient cache key, so a single
+ * `update_option()` retires the entire family of cached payloads
+ * in one stroke — no enumerating keys, no race window where an
+ * old entry might still be served. Stale entries fall out of the
+ * DB naturally via the transient TTL.
+ *
+ * @since 0.8.5
+ */
+function desktop_mode_posts_window_terms_cache_version() {
+	$v = (int) get_option( 'desktop_mode_terms_cache_version', 0 );
+	if ( $v <= 0 ) {
+		$v = 1;
+		// autoload = false so this doesn't ride on every page load.
+		update_option( 'desktop_mode_terms_cache_version', $v, false );
+	}
+	return $v;
+}
+
+/**
+ * Invalidate every cached terms-derived payload by incrementing
+ * the shared version. The next call to any cached endpoint will
+ * miss its transient lookup, recompute, and store under the new
+ * key.
+ *
+ * Hooked to a handful of "post→term graph changed" actions below.
+ * The signature is intentionally argument-tolerant — each hook
+ * passes different positional args (object_id, term_id, taxonomy,
+ * …) and PHP just ignores extras for a no-param target.
+ *
+ * @since 0.8.5
+ */
+function desktop_mode_posts_window_terms_cache_invalidate() {
+	$v = desktop_mode_posts_window_terms_cache_version();
+	update_option(
+		'desktop_mode_terms_cache_version',
+		$v + 1,
+		false
+	);
+}
+// Direct post→term graph changes. `set_object_terms` fires whenever
+// `wp_set_object_terms()` runs — covers post saves that change
+// terms, term-delete cleanup, REST PATCH on a post's tags array,
+// classic-editor flows, the lot. It's the ground truth.
+add_action( 'set_object_terms', 'desktop_mode_posts_window_terms_cache_invalidate' );
+// Term identity changes — a renamed term doesn't shift pair counts
+// but a deleted term does (its relationships go away). Invalidating
+// on every term mutation costs one option write per edit, which is
+// fine for the typical category/tag edit cadence.
+add_action( 'created_term', 'desktop_mode_posts_window_terms_cache_invalidate' );
+add_action( 'edited_term', 'desktop_mode_posts_window_terms_cache_invalidate' );
+add_action( 'delete_term', 'desktop_mode_posts_window_terms_cache_invalidate' );
+// Status flips that change what the SQL counts. Both endpoints
+// exclude 'trash', 'auto-draft', and 'inherit'; trashing or
+// restoring a post adds and removes counts/pairs from the graph.
+add_action( 'wp_trash_post', 'desktop_mode_posts_window_terms_cache_invalidate' );
+add_action( 'untrashed_post', 'desktop_mode_posts_window_terms_cache_invalidate' );
+// Pre-delete fires while term_relationships still exist; the row
+// will be gone by the time the next query runs. Belt-and-braces
+// alongside set_object_terms (which fires during delete cleanup
+// on most modern WP versions).
+add_action( 'before_delete_post', 'desktop_mode_posts_window_terms_cache_invalidate' );
+
+/**
  * Bulk count endpoint — returns `{ term_id: count }` for every
  * requested term in one query. The `desktop_mode_count` REST field
  * (per-term) is the canonical source, but on installs where the
  * field isn't reaching the response (caching, REST middleware,
  * stale `_fields` whitelist) the JS calls this endpoint as a
  * defensive fallback so node labels never silently show 0.
+ *
+ * Cached: a single transient holds `{ term_id: count }` for EVERY
+ * term in the taxonomy. Each call projects the caller's requested
+ * IDs out of that map, so all clients hit the same cache entry
+ * regardless of which subset they ask for.
  *
  * GET `/desktop-mode/v1/term-counts?taxonomy=category&ids=1,4,7`
  *
@@ -419,50 +492,64 @@ function desktop_mode_posts_window_term_counts_callback( $request ) {
 	// the param. 500 is far above any plausible category/tag count.
 	$ids = array_slice( $ids, 0, 500 );
 
-	// Mirror WP core's `_update_post_term_count` filtering — limit to
-	// the taxonomy's `object_type` (e.g. `post` for category) and
-	// exclude statuses core treats as non-counting:
-	//   - 'trash' + 'auto-draft' → user-not-published-and-never-will-be
-	//   - 'inherit' → attachment-only status; excluded so attachments
-	//                 aren't double-counted via parent inheritance
-	// Everything else (publish, draft, pending, future, private) is
-	// included so the user sees a "real" post count, not WP's
-	// publish-only term_taxonomy.count.
-	$object_types = array_map(
-		'sanitize_key',
-		(array) $tax_obj->object_type
-	);
-	$object_types = array_filter( $object_types, 'post_type_exists' );
-	if ( empty( $object_types ) ) {
-		$object_types = array( 'post' );
-	}
-	$id_placeholders   = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
-	$type_placeholders = implode( ',', array_fill( 0, count( $object_types ), '%s' ) );
-	$rows = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT tt.term_id, COUNT(p.ID) AS cnt
-			 FROM {$wpdb->term_taxonomy} tt
-			 LEFT JOIN {$wpdb->term_relationships} tr
-			   ON tr.term_taxonomy_id = tt.term_taxonomy_id
-			 LEFT JOIN {$wpdb->posts} p
-			   ON p.ID = tr.object_id
-			   AND p.post_status NOT IN ( 'trash', 'auto-draft', 'inherit' )
-			   AND p.post_type IN ( $type_placeholders )
-			 WHERE tt.taxonomy = %s
-			 AND tt.term_id IN ( $id_placeholders )
-			 GROUP BY tt.term_id",
-			array_merge( $object_types, array( $taxonomy ), $ids )
-		),
-		ARRAY_A
-	);
-	$out  = array();
-	foreach ( (array) $rows as $row ) {
-		$out[ (string) (int) $row['term_id'] ] = (int) $row['cnt'];
-	}
-	foreach ( $ids as $id ) {
-		if ( ! isset( $out[ (string) $id ] ) ) {
-			$out[ (string) $id ] = 0;
+	// Cache strategy: one transient holds the FULL taxonomy's
+	// { term_id => count } map. All clients project their requested
+	// ID subset out of the same cached map, so a window that asks
+	// for IDs [1, 4, 7] and one that asks for [4, 11, 22] share the
+	// same cache hit. Key shape: `dmtcnt_v<version>_<taxonomy>`.
+	$cache_version = desktop_mode_posts_window_terms_cache_version();
+	$cache_key     = sprintf( 'dmtcnt_v%d_%s', $cache_version, $taxonomy );
+	$counts        = get_transient( $cache_key );
+	if ( ! is_array( $counts ) ) {
+		// Mirror WP core's `_update_post_term_count` filtering —
+		// limit to the taxonomy's `object_type` (e.g. `post` for
+		// category) and exclude statuses core treats as non-counting:
+		//   - 'trash' + 'auto-draft' → user-not-published-and-never-will-be
+		//   - 'inherit' → attachment-only status; excluded so attachments
+		//                 aren't double-counted via parent inheritance
+		// Everything else (publish, draft, pending, future, private)
+		// is included so the user sees a "real" post count, not
+		// WP's publish-only term_taxonomy.count.
+		$object_types = array_map(
+			'sanitize_key',
+			(array) $tax_obj->object_type
+		);
+		$object_types = array_filter( $object_types, 'post_type_exists' );
+		if ( empty( $object_types ) ) {
+			$object_types = array( 'post' );
 		}
+		$type_placeholders = implode( ',', array_fill( 0, count( $object_types ), '%s' ) );
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT tt.term_id, COUNT(p.ID) AS cnt
+				 FROM {$wpdb->term_taxonomy} tt
+				 LEFT JOIN {$wpdb->term_relationships} tr
+				   ON tr.term_taxonomy_id = tt.term_taxonomy_id
+				 LEFT JOIN {$wpdb->posts} p
+				   ON p.ID = tr.object_id
+				   AND p.post_status NOT IN ( 'trash', 'auto-draft', 'inherit' )
+				   AND p.post_type IN ( $type_placeholders )
+				 WHERE tt.taxonomy = %s
+				 GROUP BY tt.term_id",
+				array_merge( $object_types, array( $taxonomy ) )
+			),
+			ARRAY_A
+		);
+		$counts = array();
+		foreach ( (array) $rows as $row ) {
+			$counts[ (string) (int) $row['term_id'] ] = (int) $row['cnt'];
+		}
+		set_transient( $cache_key, $counts, DAY_IN_SECONDS );
+	}
+
+	// Project the caller's requested IDs out of the (cached or
+	// fresh) full map. Missing IDs return 0 to match the legacy
+	// shape — a caller looking up a term that no longer exists or
+	// has no associated posts still gets a zero, not a missing key.
+	$out = array();
+	foreach ( $ids as $id ) {
+		$key         = (string) $id;
+		$out[ $key ] = isset( $counts[ $key ] ) ? (int) $counts[ $key ] : 0;
 	}
 	return $out;
 }
@@ -514,73 +601,6 @@ function desktop_mode_posts_window_register_tag_cooccurrence_route() {
 }
 add_action( 'rest_api_init', 'desktop_mode_posts_window_register_tag_cooccurrence_route' );
 
-/**
- * Current site-wide cache version for the tag-cooccurrence response.
- *
- * The version sits in a non-autoloaded option and is bumped by
- * `desktop_mode_posts_window_tag_cooccurrence_invalidate()` whenever
- * a post/term change could have moved the cooccurrence graph. The
- * version is baked into the transient cache key so an invalidation
- * has the effect of making every previously-cached payload
- * unreachable in a single `update_option()` call — far cheaper than
- * enumerating + deleting individual transients. Stale entries age
- * out naturally via the transient's TTL.
- *
- * @since 0.8.5
- */
-function desktop_mode_posts_window_tag_cooccurrence_cache_version() {
-	$v = (int) get_option( 'desktop_mode_tag_cooccurrence_cache_version', 0 );
-	if ( $v <= 0 ) {
-		$v = 1;
-		// autoload = false so this doesn't ride on every page load.
-		update_option( 'desktop_mode_tag_cooccurrence_cache_version', $v, false );
-	}
-	return $v;
-}
-
-/**
- * Invalidate every cached tag-cooccurrence payload by incrementing
- * the cache version. The next call to the endpoint will miss its
- * transient lookup, recompute, and store under the new key.
- *
- * Hooked to a handful of "post-term graph changed" actions below.
- * The signature is intentionally variadic-tolerant — the hooks all
- * pass different args (object_id, term_id, taxonomy, …) and PHP
- * 7+ ignores extras for a no-param target.
- *
- * @since 0.8.5
- */
-function desktop_mode_posts_window_tag_cooccurrence_invalidate() {
-	$v = desktop_mode_posts_window_tag_cooccurrence_cache_version();
-	update_option(
-		'desktop_mode_tag_cooccurrence_cache_version',
-		$v + 1,
-		false
-	);
-}
-// Direct post→term graph changes. `set_object_terms` fires whenever
-// `wp_set_object_terms()` runs — covers post saves that change
-// terms, term-delete cleanup, REST PATCH on a post's tags array,
-// classic-editor flows, the lot. It's the ground truth.
-add_action( 'set_object_terms', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-// Term identity changes — a renamed term doesn't shift pair counts
-// but a deleted term does (its relationships go away). Invalidating
-// on every term mutation costs one option write per edit, which is
-// fine for the typical category/tag edit cadence.
-add_action( 'created_term', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-add_action( 'edited_term', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-add_action( 'delete_term', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-// Status flips that change what the SQL counts. The endpoint
-// excludes 'trash', 'auto-draft', and 'inherit'; trashing or
-// restoring a post can both add and remove pairs from the graph.
-add_action( 'wp_trash_post', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-add_action( 'untrashed_post', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-// Pre-delete fires while term_relationships still exist; the row
-// will be gone by the time the next query runs. Belt-and-braces
-// alongside set_object_terms (which fires during delete cleanup
-// on most modern WP versions).
-add_action( 'before_delete_post', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
-
 function desktop_mode_posts_window_tag_cooccurrence_callback( $request ) {
 	global $wpdb;
 
@@ -606,7 +626,7 @@ function desktop_mode_posts_window_tag_cooccurrence_callback( $request ) {
 	// option bump makes every old entry unreachable without us
 	// having to enumerate keys. Taxonomy + limit are part of the key
 	// because they change the response shape.
-	$cache_version = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+	$cache_version = desktop_mode_posts_window_terms_cache_version();
 	$cache_key     = sprintf(
 		'dmwco_v%d_%s_l%d',
 		$cache_version,

--- a/includes/posts-window/window.php
+++ b/includes/posts-window/window.php
@@ -468,6 +468,254 @@ function desktop_mode_posts_window_term_counts_callback( $request ) {
 }
 
 /**
+ * REST: tag co-occurrence aggregator. Returns, for each tag, its
+ * top-N most frequently co-occurring sibling tags + the shared
+ * post count. Used by the Tags window to precluster the pixi
+ * cloud — tags that appear together on the same post get pulled
+ * toward each other after the spiral pack.
+ *
+ * GET `/desktop-mode/v1/tag-cooccurrence?taxonomy=post_tag&limit=8`
+ *
+ * Response:
+ *   { "pairs": { "<tagId>": [ { "id": <neighborId>, "shared": N }, … ] } }
+ *
+ * Status filtering mirrors `_update_post_term_count` (exclude
+ * trash, auto-draft, inherit). Post type is bounded to the
+ * taxonomy's declared `object_type` so e.g. page-attached terms
+ * don't bleed into the post-tag graph.
+ *
+ * @since 0.8.5
+ */
+function desktop_mode_posts_window_register_tag_cooccurrence_route() {
+	register_rest_route(
+		'desktop-mode/v1',
+		'/tag-cooccurrence',
+		array(
+			'methods'             => 'GET',
+			'callback'            => 'desktop_mode_posts_window_tag_cooccurrence_callback',
+			'permission_callback' => function () {
+				return current_user_can( 'edit_posts' );
+			},
+			'args'                => array(
+				'taxonomy' => array(
+					'required'          => false,
+					'type'              => 'string',
+					'default'           => 'post_tag',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'limit'    => array(
+					'required' => false,
+					'type'     => 'integer',
+					'default'  => 8,
+				),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'desktop_mode_posts_window_register_tag_cooccurrence_route' );
+
+/**
+ * Current site-wide cache version for the tag-cooccurrence response.
+ *
+ * The version sits in a non-autoloaded option and is bumped by
+ * `desktop_mode_posts_window_tag_cooccurrence_invalidate()` whenever
+ * a post/term change could have moved the cooccurrence graph. The
+ * version is baked into the transient cache key so an invalidation
+ * has the effect of making every previously-cached payload
+ * unreachable in a single `update_option()` call — far cheaper than
+ * enumerating + deleting individual transients. Stale entries age
+ * out naturally via the transient's TTL.
+ *
+ * @since 0.8.5
+ */
+function desktop_mode_posts_window_tag_cooccurrence_cache_version() {
+	$v = (int) get_option( 'desktop_mode_tag_cooccurrence_cache_version', 0 );
+	if ( $v <= 0 ) {
+		$v = 1;
+		// autoload = false so this doesn't ride on every page load.
+		update_option( 'desktop_mode_tag_cooccurrence_cache_version', $v, false );
+	}
+	return $v;
+}
+
+/**
+ * Invalidate every cached tag-cooccurrence payload by incrementing
+ * the cache version. The next call to the endpoint will miss its
+ * transient lookup, recompute, and store under the new key.
+ *
+ * Hooked to a handful of "post-term graph changed" actions below.
+ * The signature is intentionally variadic-tolerant — the hooks all
+ * pass different args (object_id, term_id, taxonomy, …) and PHP
+ * 7+ ignores extras for a no-param target.
+ *
+ * @since 0.8.5
+ */
+function desktop_mode_posts_window_tag_cooccurrence_invalidate() {
+	$v = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+	update_option(
+		'desktop_mode_tag_cooccurrence_cache_version',
+		$v + 1,
+		false
+	);
+}
+// Direct post→term graph changes. `set_object_terms` fires whenever
+// `wp_set_object_terms()` runs — covers post saves that change
+// terms, term-delete cleanup, REST PATCH on a post's tags array,
+// classic-editor flows, the lot. It's the ground truth.
+add_action( 'set_object_terms', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+// Term identity changes — a renamed term doesn't shift pair counts
+// but a deleted term does (its relationships go away). Invalidating
+// on every term mutation costs one option write per edit, which is
+// fine for the typical category/tag edit cadence.
+add_action( 'created_term', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+add_action( 'edited_term', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+add_action( 'delete_term', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+// Status flips that change what the SQL counts. The endpoint
+// excludes 'trash', 'auto-draft', and 'inherit'; trashing or
+// restoring a post can both add and remove pairs from the graph.
+add_action( 'wp_trash_post', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+add_action( 'untrashed_post', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+// Pre-delete fires while term_relationships still exist; the row
+// will be gone by the time the next query runs. Belt-and-braces
+// alongside set_object_terms (which fires during delete cleanup
+// on most modern WP versions).
+add_action( 'before_delete_post', 'desktop_mode_posts_window_tag_cooccurrence_invalidate' );
+
+function desktop_mode_posts_window_tag_cooccurrence_callback( $request ) {
+	global $wpdb;
+
+	$taxonomy = sanitize_key( (string) $request->get_param( 'taxonomy' ) );
+	$tax_obj  = get_taxonomy( $taxonomy );
+	if ( ! $tax_obj ) {
+		return new WP_Error(
+			'desktop_mode_invalid_taxonomy',
+			__( 'Unknown taxonomy.', 'desktop-mode' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$limit = (int) $request->get_param( 'limit' );
+	if ( $limit <= 0 ) {
+		$limit = 8;
+	}
+	// Cap so a malicious caller can't fan out the response. 24 is
+	// far more neighbors than any layout pass actually consumes.
+	$limit = min( 24, $limit );
+
+	// Cache lookup. The key bakes in the current version so a single
+	// option bump makes every old entry unreachable without us
+	// having to enumerate keys. Taxonomy + limit are part of the key
+	// because they change the response shape.
+	$cache_version = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+	$cache_key     = sprintf(
+		'dmwco_v%d_%s_l%d',
+		$cache_version,
+		$taxonomy,
+		$limit
+	);
+	$cached = get_transient( $cache_key );
+	if ( is_array( $cached ) && isset( $cached['pairs'] ) ) {
+		return rest_ensure_response( $cached );
+	}
+
+	$object_types = array_map(
+		'sanitize_key',
+		(array) $tax_obj->object_type
+	);
+	$object_types = array_filter( $object_types, 'post_type_exists' );
+	if ( empty( $object_types ) ) {
+		$object_types = array( 'post' );
+	}
+	$type_placeholders = implode( ',', array_fill( 0, count( $object_types ), '%s' ) );
+
+	// One scan: every (post, term) row in the taxonomy on a
+	// non-trashed, non-attachment-inherited post of the right type.
+	// Sorted by post so we can walk in O(n) and emit pairs per post.
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT tr.object_id, tt.term_id
+			 FROM {$wpdb->term_relationships} tr
+			 INNER JOIN {$wpdb->term_taxonomy} tt
+			   ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			 INNER JOIN {$wpdb->posts} p
+			   ON p.ID = tr.object_id
+			   AND p.post_status NOT IN ( 'trash', 'auto-draft', 'inherit' )
+			   AND p.post_type IN ( $type_placeholders )
+			 WHERE tt.taxonomy = %s
+			 ORDER BY tr.object_id",
+			array_merge( $object_types, array( $taxonomy ) )
+		),
+		ARRAY_A
+	);
+
+	// Group term ids per post, then emit pair counts. Sort each
+	// post's term list so we can walk i<j and double-write into the
+	// symmetric pair map (a→b and b→a both get incremented).
+	$pairs       = array(); // term_id => array( neighbor_id => shared_count )
+	$current_id  = 0;
+	$current_set = array();
+	$flush = function () use ( &$current_set, &$pairs ) {
+		$ids = array_values( array_unique( $current_set ) );
+		$n   = count( $ids );
+		if ( $n < 2 ) {
+			return;
+		}
+		sort( $ids, SORT_NUMERIC );
+		for ( $i = 0; $i < $n; $i++ ) {
+			$a = $ids[ $i ];
+			for ( $j = $i + 1; $j < $n; $j++ ) {
+				$b = $ids[ $j ];
+				if ( ! isset( $pairs[ $a ][ $b ] ) ) {
+					$pairs[ $a ][ $b ] = 0;
+				}
+				if ( ! isset( $pairs[ $b ][ $a ] ) ) {
+					$pairs[ $b ][ $a ] = 0;
+				}
+				$pairs[ $a ][ $b ]++;
+				$pairs[ $b ][ $a ]++;
+			}
+		}
+	};
+	foreach ( (array) $rows as $row ) {
+		$post_id = (int) $row['object_id'];
+		$term_id = (int) $row['term_id'];
+		if ( $post_id !== $current_id ) {
+			$flush();
+			$current_id  = $post_id;
+			$current_set = array();
+		}
+		$current_set[] = $term_id;
+	}
+	$flush();
+
+	// Trim each tag's neighbor list to top-N by shared count, then
+	// reshape into the response payload. Keep string keys so JSON
+	// preserves them as numeric-looking object properties.
+	$result = array();
+	foreach ( $pairs as $tag_id => $neighbors ) {
+		arsort( $neighbors, SORT_NUMERIC );
+		$top  = array_slice( $neighbors, 0, $limit, true );
+		$list = array();
+		foreach ( $top as $neighbor_id => $shared ) {
+			$list[] = array(
+				'id'     => (int) $neighbor_id,
+				'shared' => (int) $shared,
+			);
+		}
+		$result[ (string) (int) $tag_id ] = $list;
+	}
+
+	$payload = array( 'pairs' => $result );
+	// Store under the version-stamped key. TTL is a day; an
+	// invalidation hook bump retires the key sooner. The DAY ceiling
+	// is the floor on cache staleness if every invalidation hook
+	// somehow missed firing.
+	set_transient( $cache_key, $payload, DAY_IN_SECONDS );
+
+	return rest_ensure_response( $payload );
+}
+
+/**
  * REST get_callback for `desktop_mode_is_default`. Reads the
  * taxonomy's default-term option (e.g. `default_category`) and
  * compares against the current term's id.

--- a/src/posts-window/categories-mindmap.ts
+++ b/src/posts-window/categories-mindmap.ts
@@ -228,6 +228,24 @@ export async function mountCategoriesMindmap(
 	recenterBtn.innerHTML =
 		'<span class="dashicons dashicons-image-rotate" aria-hidden="true"></span>' +
 		__( 'Recenter' );
+	// Fuzzy-search input. Wired below, after `nodes` + `focusNode`
+	// exist; the DOM lives here so the toolbar paints with the box in
+	// place from the first frame.
+	const searchWrap = document.createElement( 'div' );
+	searchWrap.className = 'wpd-mindmap__search';
+	const searchInput = document.createElement( 'input' );
+	searchInput.type = 'search';
+	searchInput.className = 'wpd-mindmap__search-input';
+	searchInput.placeholder = __( 'Search categories…' );
+	searchInput.setAttribute(
+		'aria-label',
+		__( 'Search categories in the mindmap' ),
+	);
+	searchWrap.appendChild( searchInput );
+	const searchResults = document.createElement( 'ul' );
+	searchResults.className = 'wpd-mindmap__search-results';
+	searchResults.hidden = true;
+	searchWrap.appendChild( searchResults );
 	const hint = document.createElement( 'span' );
 	hint.className = 'wpd-mindmap__hint';
 	hint.textContent = __(
@@ -235,6 +253,7 @@ export async function mountCategoriesMindmap(
 	);
 	toolbar.appendChild( addRootBtn );
 	toolbar.appendChild( recenterBtn );
+	toolbar.appendChild( searchWrap );
 	toolbar.appendChild( hint );
 	host.appendChild( toolbar );
 
@@ -2886,6 +2905,142 @@ export async function mountCategoriesMindmap(
 	// only Uncategorized exists AND removes it the moment a new
 	// root category is created (no F5 needed).
 
+	// --- Search wiring ------------------------------------------------
+	// Case-insensitive substring match on node name, top 10 by post
+	// count. Selecting a result (mouse OR keyboard) delegates to the
+	// existing `focusNode` (pan + zoom + sidebar). DOM was created
+	// with the toolbar above so the input is visible from the first
+	// frame.
+	//
+	// Keyboard nav: ArrowDown/ArrowUp move the highlight, Enter
+	// activates it, Escape clears. Mouse hover also moves the
+	// highlight so keyboard + mouse don't fight.
+	//
+	// Mousedown (not click) on the result + preventDefault keeps focus
+	// on the input — otherwise the button steals focus and the input's
+	// own blur fires, which used to race with the click and sometimes
+	// hide the dropdown before the click handler ran.
+	let currentMatches: MindNode[] = [];
+	let selectedIndex = 0;
+	const repaintHighlight = (): void => {
+		const items = searchResults.querySelectorAll< HTMLButtonElement >(
+			'.wpd-mindmap__search-result',
+		);
+		items.forEach( ( el, i ) => {
+			const active = i === selectedIndex;
+			el.classList.toggle( 'is-active', active );
+			if ( active ) {
+				el.scrollIntoView( { block: 'nearest' } );
+			}
+		} );
+	};
+	const selectMatch = ( n: MindNode ): void => {
+		searchInput.value = '';
+		searchResults.hidden = true;
+		searchResults.replaceChildren();
+		currentMatches = [];
+		selectedIndex = 0;
+		void focusNode( n.id );
+	};
+	const renderSearchResults = (): void => {
+		const q = searchInput.value.trim().toLowerCase();
+		if ( q.length === 0 ) {
+			searchResults.hidden = true;
+			searchResults.replaceChildren();
+			currentMatches = [];
+			selectedIndex = 0;
+			return;
+		}
+		currentMatches = Array.from( nodes.values() )
+			.filter( ( n ) => n.name.toLowerCase().includes( q ) )
+			.sort( ( a, b ) => b.count - a.count )
+			.slice( 0, 10 );
+		selectedIndex = 0;
+		searchResults.replaceChildren();
+		currentMatches.forEach( ( n, i ) => {
+			const li = document.createElement( 'li' );
+			const btn = document.createElement( 'button' );
+			btn.type = 'button';
+			btn.className = 'wpd-mindmap__search-result';
+			if ( i === 0 ) {
+				btn.classList.add( 'is-active' );
+			}
+			const nameEl = document.createElement( 'span' );
+			nameEl.className = 'wpd-mindmap__search-title';
+			nameEl.textContent = n.name || `#${ n.id }`;
+			const countEl = document.createElement( 'span' );
+			countEl.className = 'wpd-mindmap__search-meta';
+			countEl.textContent = sprintf(
+				/* translators: %d: number of posts assigned to a category. */
+				__( '%d posts' ),
+				n.count,
+			);
+			btn.appendChild( nameEl );
+			btn.appendChild( countEl );
+			btn.addEventListener( 'mousedown', ( ev ) => {
+				ev.preventDefault();
+				selectMatch( n );
+			} );
+			btn.addEventListener( 'mouseenter', () => {
+				selectedIndex = i;
+				repaintHighlight();
+			} );
+			li.appendChild( btn );
+			searchResults.appendChild( li );
+		} );
+		searchResults.hidden = currentMatches.length === 0;
+	};
+	searchInput.addEventListener( 'input', renderSearchResults );
+	searchInput.addEventListener( 'focus', renderSearchResults );
+	searchInput.addEventListener( 'keydown', ( ev ) => {
+		if ( ev.key === 'ArrowDown' ) {
+			if ( currentMatches.length === 0 ) {
+				return;
+			}
+			ev.preventDefault();
+			selectedIndex = Math.min(
+				selectedIndex + 1,
+				currentMatches.length - 1,
+			);
+			repaintHighlight();
+		} else if ( ev.key === 'ArrowUp' ) {
+			if ( currentMatches.length === 0 ) {
+				return;
+			}
+			ev.preventDefault();
+			selectedIndex = Math.max( selectedIndex - 1, 0 );
+			repaintHighlight();
+		} else if ( ev.key === 'Enter' ) {
+			if ( currentMatches.length === 0 ) {
+				return;
+			}
+			ev.preventDefault();
+			selectMatch( currentMatches[ selectedIndex ] );
+		} else if ( ev.key === 'Escape' ) {
+			searchInput.value = '';
+			searchResults.hidden = true;
+			searchResults.replaceChildren();
+			currentMatches = [];
+			selectedIndex = 0;
+		}
+	} );
+	searchInput.addEventListener( 'blur', () => {
+		// Delayed so any mousedown on a result still fires its handler
+		// before the dropdown vanishes. Mousedown+preventDefault keeps
+		// focus on the input so this blur normally won't even fire on
+		// result clicks, but this remains the dismiss path for "click
+		// somewhere else / tab away".
+		setTimeout( () => {
+			searchResults.hidden = true;
+		}, 120 );
+	} );
+	const onDocClickSearch = ( ev: Event ): void => {
+		if ( ! searchWrap.contains( ev.target as Node ) ) {
+			searchResults.hidden = true;
+		}
+	};
+	document.addEventListener( 'click', onDocClickSearch );
+
 	// --- Teardown -----------------------------------------------------
 	return () => {
 		if ( raf !== null ) {
@@ -2898,6 +3053,7 @@ export async function mountCategoriesMindmap(
 		}
 		ro.disconnect();
 		stage.removeEventListener( 'wheel', onWheel );
+		document.removeEventListener( 'click', onDocClickSearch );
 		try {
 			app.destroy( true, { children: true, texture: true } );
 		} catch {

--- a/src/posts-window/rest.ts
+++ b/src/posts-window/rest.ts
@@ -383,12 +383,29 @@ export interface PostsWindowClient {
 		taxonomy: 'categories' | 'tags',
 		params?: TermsListParams,
 	): Promise< TermsListPage >;
+	fetchTagCooccurrence(
+		taxonomy?: 'tags' | 'categories',
+		limit?: number,
+	): Promise< Map< number, TermNeighbor[] > >;
 	updateTerm(
 		taxonomy: 'categories' | 'tags',
 		id: number,
 		patch: Partial< Pick< TermRow, 'name' | 'slug' | 'description' | 'parent' > >,
 	): Promise< TermRow >;
 	deleteTerm( taxonomy: 'categories' | 'tags', id: number ): Promise< void >;
+}
+
+/**
+ * One co-occurring sibling term as reported by
+ * `/desktop-mode/v1/tag-cooccurrence`. `shared` is the number of
+ * posts the two terms share.
+ *
+ * @public
+ * @since 0.8.5
+ */
+export interface TermNeighbor {
+	id: number;
+	shared: number;
 }
 
 /**
@@ -844,6 +861,59 @@ export function createPostsWindowClient(
 		};
 	};
 
+	const fetchTagCooccurrence = async (
+		taxonomy: 'tags' | 'categories' = 'tags',
+		limit = 8,
+	): Promise< Map< number, TermNeighbor[] > > => {
+		const cfg = getConfig();
+		const url = new URL(
+			joinRestUrl(
+				cfg.restRoot,
+				'desktop-mode/v1/tag-cooccurrence',
+			),
+		);
+		// Server speaks WP taxonomy slugs, not the wp/v2 plural form.
+		url.searchParams.set(
+			'taxonomy',
+			taxonomy === 'tags' ? 'post_tag' : 'category',
+		);
+		url.searchParams.set( 'limit', String( limit ) );
+		const { data } = await request<
+			{ pairs?: Record< string, TermNeighbor[] > } | TermNeighbor[]
+		>( url.toString(), { method: 'GET' } );
+		const out = new Map< number, TermNeighbor[] >();
+		const pairs =
+			data && typeof data === 'object' && ! Array.isArray( data )
+				? data.pairs
+				: undefined;
+		if ( ! pairs ) {
+			return out;
+		}
+		for ( const [ key, neighbors ] of Object.entries( pairs ) ) {
+			const id = parseInt( key, 10 );
+			if ( ! Number.isFinite( id ) || id <= 0 ) {
+				continue;
+			}
+			const clean: TermNeighbor[] = [];
+			for ( const raw of neighbors ) {
+				const nid = Number( raw?.id );
+				const sh = Number( raw?.shared );
+				if (
+					Number.isFinite( nid ) &&
+					nid > 0 &&
+					Number.isFinite( sh ) &&
+					sh > 0
+				) {
+					clean.push( { id: nid, shared: sh } );
+				}
+			}
+			if ( clean.length > 0 ) {
+				out.set( id, clean );
+			}
+		}
+		return out;
+	};
+
 	const updateTerm = async (
 		taxonomy: 'categories' | 'tags',
 		id: number,
@@ -905,6 +975,7 @@ export function createPostsWindowClient(
 		createCategory,
 		updatePostCategories,
 		fetchTerms,
+		fetchTagCooccurrence,
 		updateTerm,
 		deleteTerm,
 	};

--- a/src/posts-window/tags-cloud.ts
+++ b/src/posts-window/tags-cloud.ts
@@ -32,7 +32,11 @@
 import { __, sprintf } from '../i18n';
 import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
-import { type PostsWindowClient, type TermRow } from './rest';
+import {
+	type PostsWindowClient,
+	type TermNeighbor,
+	type TermRow,
+} from './rest';
 
 interface PixiPoint {
 	x: number;
@@ -258,6 +262,24 @@ export async function mountTagsCloud(
 	reflowBtn.title = __(
 		'Recompute the chip layout from scratch — discards manual repositioning.',
 	);
+	// Fuzzy-search input. Wired below, after `tags` + `focusTag` exist;
+	// the DOM lives here so the toolbar paints with the box in place
+	// from the first frame.
+	const searchWrap = document.createElement( 'div' );
+	searchWrap.className = 'wpd-tagcloud__search';
+	const searchInput = document.createElement( 'input' );
+	searchInput.type = 'search';
+	searchInput.className = 'wpd-tagcloud__search-input';
+	searchInput.placeholder = __( 'Search tags…' );
+	searchInput.setAttribute(
+		'aria-label',
+		__( 'Search tags in the cloud' ),
+	);
+	searchWrap.appendChild( searchInput );
+	const searchResults = document.createElement( 'ul' );
+	searchResults.className = 'wpd-tagcloud__search-results';
+	searchResults.hidden = true;
+	searchWrap.appendChild( searchResults );
 	const hint = document.createElement( 'span' );
 	hint.className = 'wpd-tagcloud__hint';
 	hint.textContent = __(
@@ -266,6 +288,7 @@ export async function mountTagsCloud(
 	toolbar.appendChild( addTagBtn );
 	toolbar.appendChild( recenterBtn );
 	toolbar.appendChild( reflowBtn );
+	toolbar.appendChild( searchWrap );
 	toolbar.appendChild( hint );
 	host.appendChild( toolbar );
 
@@ -412,6 +435,15 @@ export async function mountTagsCloud(
 	const positionsKey = computePositionsKey();
 	const persistedPositions = readPersistedPositions( positionsKey );
 
+	// Co-occurrence map: tag id → list of co-occurring sibling tags
+	// (with `shared` post counts). Populated from
+	// `/desktop-mode/v1/tag-cooccurrence` on mount and on Reflow;
+	// empty until the fetch resolves. When non-empty, the spiral pack
+	// switches to cluster-aware mode — tags that share posts sit
+	// near each other on the canvas instead of being placed in pure
+	// popularity-only order.
+	let cooccurrenceMap: Map< number, TermNeighbor[] > = new Map();
+
 	const themeHue = readAdminThemeHue();
 
 	// --- Data fetch + initial layout ---------------------------------
@@ -498,8 +530,13 @@ export async function mountTagsCloud(
 
 		// Spiral-pack any boxes that don't have a manually-set or
 		// previously-computed position. Sort by count desc so popular
-		// tags get prime real estate near the centre.
+		// tags get prime real estate near the centre. When the
+		// cooccurrence map is non-empty, `packBoxesWithClusters`
+		// anchors each fresh chip near its placed neighbours; with an
+		// empty map it falls back to the original origin-anchored
+		// spiral.
 		const placed: Array< { x: number; y: number; w: number; h: number } > = [];
+		const placedById = new Map< number, { x: number; y: number } >();
 		for ( const box of tags.values() ) {
 			if ( ! fresh.includes( box ) ) {
 				placed.push( {
@@ -508,21 +545,17 @@ export async function mountTagsCloud(
 					w: box.width,
 					h: box.height,
 				} );
+				placedById.set( box.id, { x: box.tx, y: box.ty } );
 			}
 		}
 		fresh.sort( ( a, b ) => b.count - a.count );
+		packBoxesWithClusters( fresh, placed, placedById, cooccurrenceMap );
 		for ( const box of fresh ) {
-			const slot = findSpiralSlot( box.width, box.height, placed );
-			box.tx = slot.x;
-			box.ty = slot.y;
-			box.x = slot.x;
-			box.y = slot.y;
-			placed.push( {
-				x: slot.x - box.width / 2,
-				y: slot.y - box.height / 2,
-				w: box.width,
-				h: box.height,
-			} );
+			// `packBoxesWithClusters` wrote tx/ty; mirror onto x/y so
+			// fresh chips paint at their final position instead of
+			// easing from (0,0).
+			box.x = box.tx;
+			box.y = box.ty;
 		}
 	}
 
@@ -703,21 +736,50 @@ export async function mountTagsCloud(
 	}
 
 	// --- Spiral packer ------------------------------------------------
-	// Walk an Archimedean spiral outward from (0,0) in fine angular
-	// steps, picking the first slot whose AABB doesn't intersect any
-	// already-placed AABB (with SPIRAL_PADDING breathing room). Order
-	// matters — boxes are sorted by count desc before this runs, so
-	// popular tags claim centre first. The slight Y stretch (0.7×)
-	// gives the cloud a wider, more newspaper-like aspect ratio.
+	// Walk an Archimedean spiral outward from (anchorX, anchorY) in
+	// fine angular steps, picking the first slot whose AABB doesn't
+	// intersect any already-placed AABB (with SPIRAL_PADDING breathing
+	// room). Order matters — boxes are sorted by count desc before
+	// this runs, so popular tags claim their anchor's centre first.
+	// The slight Y stretch (0.7×) gives the cloud a wider,
+	// newspaper-like aspect ratio.
+	//
+	// `anchorX`/`anchorY` default to the origin (backwards-compatible
+	// with the pre-clustering call sites that always packed at 0,0).
+	// The cooccurrence-aware path passes a non-zero anchor — the
+	// weighted centroid of already-placed co-occurring siblings — so
+	// related tags pack next to each other.
 	function findSpiralSlot(
 		w: number,
 		h: number,
 		placed: Array< { x: number; y: number; w: number; h: number } >,
+		anchorX = 0,
+		anchorY = 0,
 	): { x: number; y: number } {
 		if ( placed.length === 0 ) {
-			return { x: 0, y: 0 };
+			return { x: anchorX, y: anchorY };
 		}
 		const padding = SPIRAL_PADDING;
+		// Try the anchor itself first — if free, we want the spiral to
+		// place this chip exactly at its centroid, not one tick out.
+		{
+			const aabb = {
+				x: anchorX - w / 2 - padding,
+				y: anchorY - h / 2 - padding,
+				w: w + padding * 2,
+				h: h + padding * 2,
+			};
+			let overlap = false;
+			for ( const p of placed ) {
+				if ( aabbIntersect( aabb, p ) ) {
+					overlap = true;
+					break;
+				}
+			}
+			if ( ! overlap ) {
+				return { x: anchorX, y: anchorY };
+			}
+		}
 		// Step the spiral so the angular increment shrinks at higher
 		// radii (more candidate slots per ring further out, where they
 		// matter); inner steps stay coarse so the centre packs tight.
@@ -726,8 +788,8 @@ export async function mountTagsCloud(
 		for ( let i = 0; i < maxIter; i++ ) {
 			theta += 0.18;
 			const r = theta * 5;
-			const cx = r * Math.cos( theta );
-			const cy = r * Math.sin( theta ) * 0.7;
+			const cx = anchorX + r * Math.cos( theta );
+			const cy = anchorY + r * Math.sin( theta ) * 0.7;
 			const aabb = {
 				x: cx - w / 2 - padding,
 				y: cy - h / 2 - padding,
@@ -746,8 +808,96 @@ export async function mountTagsCloud(
 			}
 		}
 		// Should never hit — the spiral is unbounded — but a safe
-		// fallback (place far below) keeps the function total.
-		return { x: 0, y: ( placed.length + 1 ) * ( h + padding ) };
+		// fallback (place far below the anchor) keeps the function
+		// total.
+		return {
+			x: anchorX,
+			y: anchorY + ( placed.length + 1 ) * ( h + padding ),
+		};
+	}
+
+	// Cluster-aware spiral pack. For each box in `boxesInOrder`,
+	// computes an anchor as the weighted centroid of its already-
+	// placed co-occurring siblings (read from `placedById`); falls
+	// back to a freshly-allocated "new cluster" anchor on a coarse
+	// meta-spiral when the box has no placed neighbour yet. Then
+	// calls `findSpiralSlot` from that anchor and writes
+	// `box.tx`/`box.ty`. Mutates `placed` + `placedById` so later
+	// boxes see this one.
+	//
+	// When `cooccurrence` is empty the math collapses to the original
+	// origin-anchored spiral pack (every box gets the cluster-0
+	// anchor at (0,0)), so the no-cooccurrence-data path stays
+	// identical to before clustering existed.
+	function packBoxesWithClusters(
+		boxesInOrder: TagBox[],
+		placed: Array< { x: number; y: number; w: number; h: number } >,
+		placedById: Map< number, { x: number; y: number } >,
+		cooccurrence: Map< number, TermNeighbor[] >,
+	): void {
+		let clusterCounter = 0;
+		const allocateClusterAnchor = (): { x: number; y: number } => {
+			const idx = clusterCounter++;
+			if ( idx === 0 ) {
+				return { x: 0, y: 0 };
+			}
+			// Phyllotaxis-ish meta-spiral: each new cluster centre
+			// sits at golden-angle θ ≈ 137° from the previous, on a
+			// ring whose radius grows linearly. The slight Y stretch
+			// (0.8) matches the inner spiral's newspaper aspect.
+			const theta = idx * 2.4;
+			const radius = 120 + idx * 70;
+			return {
+				x: radius * Math.cos( theta ),
+				y: radius * Math.sin( theta ) * 0.8,
+			};
+		};
+		for ( const box of boxesInOrder ) {
+			let anchorX = 0;
+			let anchorY = 0;
+			let usedCentroid = false;
+			const neighbors = cooccurrence.get( box.id );
+			if ( neighbors && neighbors.length > 0 ) {
+				let sumX = 0;
+				let sumY = 0;
+				let sumW = 0;
+				for ( const n of neighbors ) {
+					const pos = placedById.get( n.id );
+					if ( ! pos ) {
+						continue;
+					}
+					sumX += pos.x * n.shared;
+					sumY += pos.y * n.shared;
+					sumW += n.shared;
+				}
+				if ( sumW > 0 ) {
+					anchorX = sumX / sumW;
+					anchorY = sumY / sumW;
+					usedCentroid = true;
+				}
+			}
+			if ( ! usedCentroid ) {
+				const anchor = allocateClusterAnchor();
+				anchorX = anchor.x;
+				anchorY = anchor.y;
+			}
+			const slot = findSpiralSlot(
+				box.width,
+				box.height,
+				placed,
+				anchorX,
+				anchorY,
+			);
+			box.tx = slot.x;
+			box.ty = slot.y;
+			placedById.set( box.id, { x: slot.x, y: slot.y } );
+			placed.push( {
+				x: slot.x - box.width / 2,
+				y: slot.y - box.height / 2,
+				w: box.width,
+				h: box.height,
+			} );
+		}
 	}
 
 	// --- Per-frame pass ----------------------------------------------
@@ -1901,7 +2051,7 @@ export async function mountTagsCloud(
 	reflowBtn.addEventListener( 'click', () => {
 		// Wipe persisted positions and rebuild the layout from
 		// scratch. Useful if the user dragged things into chaos and
-		// wants the popularity-sorted spiral back.
+		// wants the popularity-sorted clustered cloud back.
 		persistedPositions.clear();
 		writePersistedPositions( positionsKey, persistedPositions );
 		// Reset every box's target to "needs spiral placement".
@@ -1909,26 +2059,25 @@ export async function mountTagsCloud(
 			box.tx = 0;
 			box.ty = 0;
 		}
-		// Force the spiral packer to consider every chip "fresh".
+		// Re-pack every chip from scratch, using the latest
+		// cooccurrence map (if any). Background-refresh below picks
+		// up any new co-occurrence data so a future Reflow click
+		// reflects the live tag graph.
 		const allBoxes = Array.from( tags.values() );
-		const placed: Array< { x: number; y: number; w: number; h: number } > =
-			[];
 		allBoxes.sort( ( a, b ) => b.count - a.count );
-		for ( const box of allBoxes ) {
-			const slot = findSpiralSlot( box.width, box.height, placed );
-			box.tx = slot.x;
-			box.ty = slot.y;
-			placed.push( {
-				x: slot.x - box.width / 2,
-				y: slot.y - box.height / 2,
-				w: box.width,
-				h: box.height,
-			} );
-		}
+		packBoxesWithClusters(
+			allBoxes,
+			[],
+			new Map< number, { x: number; y: number } >(),
+			cooccurrenceMap,
+		);
 		// Smooth zoom-out as the cloud rearranges. Chips ease into
-		// their new spiral positions in tick(); the camera animates
-		// to the new framing in lockstep.
+		// their new positions in tick(); the camera animates to the
+		// new framing in lockstep.
 		fitToView( { animate: true } );
+		// Background: re-fetch cooccurrence so the next Reflow uses
+		// fresh data without blocking this click.
+		void refreshCooccurrence();
 	} );
 
 	// Click empty canvas → close focus. Pixi paints into the canvas,
@@ -2033,6 +2182,49 @@ export async function mountTagsCloud(
 		}
 	}
 
+	// Re-pack every non-persisted chip using the current cooccurrence
+	// map. Persisted (user-dragged) chips stay where the user put
+	// them and double as anchors that the rest packs around. Called
+	// when fresh cooccurrence data arrives — the pixi tick eases x/y
+	// toward the new tx/ty so chips smoothly drift to their cluster
+	// positions without a hard jump.
+	function relayoutWithCooccurrence(): void {
+		const placed: Array<
+			{ x: number; y: number; w: number; h: number }
+		> = [];
+		const placedById = new Map< number, { x: number; y: number } >();
+		const toRepack: TagBox[] = [];
+		for ( const box of tags.values() ) {
+			if ( persistedPositions.has( box.id ) ) {
+				placed.push( {
+					x: box.tx - box.width / 2,
+					y: box.ty - box.height / 2,
+					w: box.width,
+					h: box.height,
+				} );
+				placedById.set( box.id, { x: box.tx, y: box.ty } );
+			} else {
+				toRepack.push( box );
+			}
+		}
+		toRepack.sort( ( a, b ) => b.count - a.count );
+		packBoxesWithClusters( toRepack, placed, placedById, cooccurrenceMap );
+	}
+
+	async function refreshCooccurrence(): Promise< void > {
+		// Background fetch — empty map on failure leaves the layout
+		// in pure-spiral mode (no regression vs. pre-clustering).
+		try {
+			const fetched = await client.fetchTagCooccurrence( 'tags', 8 );
+			cooccurrenceMap = fetched;
+			if ( cooccurrenceMap.size > 0 ) {
+				relayoutWithCooccurrence();
+			}
+		} catch {
+			// Non-fatal — keep the current layout.
+		}
+	}
+
 	// --- Bootstrap ---------------------------------------------------
 	buildCloud();
 	paintSidebar();
@@ -2042,6 +2234,11 @@ export async function mountTagsCloud(
 	// counts + font sizes settle to the any-status values once the
 	// response lands.
 	void refreshCountsViaBulk();
+	// Cooccurrence is fetched async too. The initial paint uses the
+	// pure popularity spiral; when the response lands, non-persisted
+	// chips are re-packed into clusters and the pixi tick eases them
+	// from their spiral positions to the new cluster positions.
+	void refreshCooccurrence();
 
 	// Empty-state hint when no tags exist.
 	if ( terms.length === 0 ) {
@@ -2052,6 +2249,145 @@ export async function mountTagsCloud(
 		);
 		stage.appendChild( empty );
 	}
+
+	// --- Search wiring ------------------------------------------------
+	// Case-insensitive substring match on tag name + slug, top 10 by
+	// post count. Selecting a result (mouse OR keyboard) delegates to
+	// `focusTag` (pan + zoom + sidebar). DOM was created with the
+	// toolbar above.
+	//
+	// Keyboard nav: ArrowDown/ArrowUp move the highlight, Enter
+	// activates it, Escape clears. Mouse hover also moves the
+	// highlight so keyboard + mouse don't fight.
+	//
+	// Mousedown (not click) on the result + preventDefault keeps focus
+	// on the input — otherwise the button steals focus and the input's
+	// own blur fires, which used to race with the click and sometimes
+	// hide the dropdown before the click handler ran.
+	let currentMatches: TagBox[] = [];
+	let selectedIndex = 0;
+	const repaintHighlight = (): void => {
+		const items = searchResults.querySelectorAll< HTMLButtonElement >(
+			'.wpd-tagcloud__search-result',
+		);
+		items.forEach( ( el, i ) => {
+			const active = i === selectedIndex;
+			el.classList.toggle( 'is-active', active );
+			if ( active ) {
+				el.scrollIntoView( { block: 'nearest' } );
+			}
+		} );
+	};
+	const selectMatch = ( t: TagBox ): void => {
+		searchInput.value = '';
+		searchResults.hidden = true;
+		searchResults.replaceChildren();
+		currentMatches = [];
+		selectedIndex = 0;
+		void focusTag( t.id );
+	};
+	const renderSearchResults = (): void => {
+		const q = searchInput.value.trim().toLowerCase();
+		if ( q.length === 0 ) {
+			searchResults.hidden = true;
+			searchResults.replaceChildren();
+			currentMatches = [];
+			selectedIndex = 0;
+			return;
+		}
+		currentMatches = Array.from( tags.values() )
+			.filter(
+				( t ) =>
+					t.name.toLowerCase().includes( q ) ||
+					t.slug.toLowerCase().includes( q ),
+			)
+			.sort( ( a, b ) => b.count - a.count )
+			.slice( 0, 10 );
+		selectedIndex = 0;
+		searchResults.replaceChildren();
+		currentMatches.forEach( ( t, i ) => {
+			const li = document.createElement( 'li' );
+			const btn = document.createElement( 'button' );
+			btn.type = 'button';
+			btn.className = 'wpd-tagcloud__search-result';
+			if ( i === 0 ) {
+				btn.classList.add( 'is-active' );
+			}
+			const nameEl = document.createElement( 'span' );
+			nameEl.className = 'wpd-tagcloud__search-title';
+			nameEl.textContent = t.name || `#${ t.id }`;
+			const countEl = document.createElement( 'span' );
+			countEl.className = 'wpd-tagcloud__search-meta';
+			countEl.textContent = sprintf(
+				/* translators: %d: number of posts assigned to a tag. */
+				__( '%d posts' ),
+				t.count,
+			);
+			btn.appendChild( nameEl );
+			btn.appendChild( countEl );
+			btn.addEventListener( 'mousedown', ( ev ) => {
+				ev.preventDefault();
+				selectMatch( t );
+			} );
+			btn.addEventListener( 'mouseenter', () => {
+				selectedIndex = i;
+				repaintHighlight();
+			} );
+			li.appendChild( btn );
+			searchResults.appendChild( li );
+		} );
+		searchResults.hidden = currentMatches.length === 0;
+	};
+	searchInput.addEventListener( 'input', renderSearchResults );
+	searchInput.addEventListener( 'focus', renderSearchResults );
+	searchInput.addEventListener( 'keydown', ( ev ) => {
+		if ( ev.key === 'ArrowDown' ) {
+			if ( currentMatches.length === 0 ) {
+				return;
+			}
+			ev.preventDefault();
+			selectedIndex = Math.min(
+				selectedIndex + 1,
+				currentMatches.length - 1,
+			);
+			repaintHighlight();
+		} else if ( ev.key === 'ArrowUp' ) {
+			if ( currentMatches.length === 0 ) {
+				return;
+			}
+			ev.preventDefault();
+			selectedIndex = Math.max( selectedIndex - 1, 0 );
+			repaintHighlight();
+		} else if ( ev.key === 'Enter' ) {
+			if ( currentMatches.length === 0 ) {
+				return;
+			}
+			ev.preventDefault();
+			selectMatch( currentMatches[ selectedIndex ] );
+		} else if ( ev.key === 'Escape' ) {
+			searchInput.value = '';
+			searchResults.hidden = true;
+			searchResults.replaceChildren();
+			currentMatches = [];
+			selectedIndex = 0;
+		}
+	} );
+	searchInput.addEventListener( 'blur', () => {
+		// Delayed so any mousedown on a result still fires its handler
+		// before the dropdown vanishes. Mousedown+preventDefault keeps
+		// focus on the input so this blur normally won't even fire on
+		// result clicks, but this remains the dismiss path for "click
+		// somewhere else / tab away".
+		setTimeout( () => {
+			searchResults.hidden = true;
+		}, 120 );
+	} );
+	const onDocClickSearch = ( ev: Event ): void => {
+		if ( ! searchWrap.contains( ev.target as Node ) ) {
+			searchResults.hidden = true;
+		}
+	};
+	document.addEventListener( 'click', onDocClickSearch );
 
 	// --- Teardown -----------------------------------------------------
 	return () => {
@@ -2065,6 +2401,7 @@ export async function mountTagsCloud(
 		}
 		ro.disconnect();
 		stage.removeEventListener( 'wheel', onWheel );
+		document.removeEventListener( 'click', onDocClickSearch );
 		try {
 			app.destroy( true, { children: true, texture: true } );
 		} catch {

--- a/tests/phpunit/tests/postsWindowTagCooccurrence.php
+++ b/tests/phpunit/tests/postsWindowTagCooccurrence.php
@@ -35,7 +35,7 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 		// Reset the cache version so each test starts from a clean
 		// state — otherwise an earlier test's invalidation leaks
 		// into the cache-hit checks here.
-		delete_option( 'desktop_mode_tag_cooccurrence_cache_version' );
+		delete_option( 'desktop_mode_terms_cache_version' );
 	}
 
 	// ----------------------------------------------------------------
@@ -307,27 +307,27 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 	// ----------------------------------------------------------------
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_cache_version
+	 * @covers ::desktop_mode_posts_window_terms_cache_version
 	 */
 	public function test_cache_version_starts_at_one_when_unset() {
 		$this->assertSame(
 			1,
-			desktop_mode_posts_window_tag_cooccurrence_cache_version()
+			desktop_mode_posts_window_terms_cache_version()
 		);
 		$this->assertSame(
 			1,
-			(int) get_option( 'desktop_mode_tag_cooccurrence_cache_version' ),
+			(int) get_option( 'desktop_mode_terms_cache_version' ),
 			'First read must persist the version so concurrent readers see the same value.'
 		);
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_invalidate_bumps_the_version() {
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
-		desktop_mode_posts_window_tag_cooccurrence_invalidate();
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
+		desktop_mode_posts_window_terms_cache_invalidate();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertSame( $before + 1, $after );
 	}
 
@@ -350,7 +350,7 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 		// `wp_set_object_terms` above already triggered an invalidation,
 		// so the cache version is no longer 1. Read it AFTER the
 		// fixture is set up.
-		$version = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$version = desktop_mode_posts_window_terms_cache_version();
 
 		$response = rest_get_server()->dispatch(
 			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
@@ -373,7 +373,7 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 	public function test_second_call_returns_cached_payload_without_recomputing() {
 		wp_set_current_user( $this->admin_id );
 
-		$version   = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$version   = desktop_mode_posts_window_terms_cache_version();
 		$cache_key = sprintf( 'dmwco_v%d_%s_l%d', $version, 'post_tag', 8 );
 
 		// Stuff a sentinel payload into the cache; if the endpoint
@@ -396,7 +396,7 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 *
 	 * After invalidation, the previous cached payload must be
 	 * unreachable (different version → different key) and the
@@ -405,7 +405,7 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 	public function test_invalidation_makes_old_cache_unreachable() {
 		wp_set_current_user( $this->admin_id );
 
-		$version_a = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$version_a = desktop_mode_posts_window_terms_cache_version();
 		$key_a     = sprintf( 'dmwco_v%d_%s_l%d', $version_a, 'post_tag', 8 );
 
 		// Plant a sentinel under the current version's key.
@@ -419,8 +419,8 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 		set_transient( $key_a, $sentinel, DAY_IN_SECONDS );
 
 		// Bump the version.
-		desktop_mode_posts_window_tag_cooccurrence_invalidate();
-		$version_b = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		desktop_mode_posts_window_terms_cache_invalidate();
+		$version_b = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $version_a, $version_b );
 
 		// Endpoint must miss (different key) and return the live
@@ -432,7 +432,7 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 *
 	 * The hook surface — every action below should bump the
 	 * version. If one of these regresses, users would see stale
@@ -441,77 +441,77 @@ class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
 	public function test_set_object_terms_invalidates_cache() {
 		$post = self::factory()->post->create();
 		$tag  = self::factory()->tag->create();
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		wp_set_object_terms( $post, array( $tag ), 'post_tag' );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_created_term_invalidates_cache() {
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		self::factory()->tag->create( array( 'name' => 'fresh' ) );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_edited_term_invalidates_cache() {
 		$tag = self::factory()->tag->create( array( 'name' => 'before' ) );
 		// Setup fired created_term + set_object_terms; snapshot the
 		// version AFTER setup so the assertion is about the edit.
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		wp_update_term( $tag, 'post_tag', array( 'name' => 'after' ) );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_delete_term_invalidates_cache() {
 		$tag    = self::factory()->tag->create();
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		wp_delete_term( $tag, 'post_tag' );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_wp_trash_post_invalidates_cache() {
 		$post   = self::factory()->post->create();
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		wp_trash_post( $post );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_untrash_post_invalidates_cache() {
 		$post = self::factory()->post->create();
 		wp_trash_post( $post );
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		wp_untrash_post( $post );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 
 	/**
-	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 * @covers ::desktop_mode_posts_window_terms_cache_invalidate
 	 */
 	public function test_before_delete_post_invalidates_cache() {
 		$post   = self::factory()->post->create();
-		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$before = desktop_mode_posts_window_terms_cache_version();
 		wp_delete_post( $post, true );
-		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$after = desktop_mode_posts_window_terms_cache_version();
 		$this->assertGreaterThan( $before, $after );
 	}
 }

--- a/tests/phpunit/tests/postsWindowTagCooccurrence.php
+++ b/tests/phpunit/tests/postsWindowTagCooccurrence.php
@@ -1,0 +1,517 @@
+<?php
+/**
+ * Tests for the `/desktop-mode/v1/tag-cooccurrence` REST endpoint.
+ *
+ * Powers the Tags window's cluster-aware spiral pack — tags that
+ * share posts get pulled toward each other on the canvas. The
+ * endpoint scans `term_relationships` once, groups by post, and
+ * emits weighted neighbor lists per tag. A regression that miscounts
+ * pairs, leaks trashed posts into the graph, or fans out unbounded
+ * neighbor lists would visibly corrupt the cloud layout — these
+ * tests pin the math + the safety guards.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-posts-window
+ */
+class Tests_DesktopMode_PostsWindowTagCooccurrence extends WP_UnitTestCase {
+
+	private $admin_id;
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// The REST route is registered on `rest_api_init`; trigger
+		// the action so the route is live for the dispatcher under
+		// test. (WP_UnitTestCase doesn't fire it for every test.)
+		do_action( 'rest_api_init' );
+
+		// Reset the cache version so each test starts from a clean
+		// state — otherwise an earlier test's invalidation leaks
+		// into the cache-hit checks here.
+		delete_option( 'desktop_mode_tag_cooccurrence_cache_version' );
+	}
+
+	// ----------------------------------------------------------------
+	// Auth
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_posts_window_register_tag_cooccurrence_route
+	 */
+	public function test_endpoint_requires_edit_posts_cap() {
+		wp_set_current_user( $this->subscriber_id );
+		$request  = new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame(
+			403,
+			$response->get_status(),
+			'Subscriber must not be able to read the cooccurrence aggregator.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_register_tag_cooccurrence_route
+	 */
+	public function test_endpoint_allows_administrator() {
+		wp_set_current_user( $this->admin_id );
+		$request  = new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			'Admin must be able to read the cooccurrence aggregator.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 */
+	public function test_unknown_taxonomy_returns_400() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' );
+		$request->set_param( 'taxonomy', 'definitely_not_a_taxonomy' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 400, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'desktop_mode_invalid_taxonomy', $data['code'] );
+	}
+
+	// ----------------------------------------------------------------
+	// Empty + happy paths
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 */
+	public function test_returns_empty_pairs_when_no_shared_posts() {
+		wp_set_current_user( $this->admin_id );
+
+		// Two tags but no post links them.
+		$t1 = self::factory()->tag->create( array( 'name' => 'alpha' ) );
+		$t2 = self::factory()->tag->create( array( 'name' => 'beta' ) );
+
+		$post_a = self::factory()->post->create();
+		$post_b = self::factory()->post->create();
+		wp_set_object_terms( $post_a, array( $t1 ), 'post_tag' );
+		wp_set_object_terms( $post_b, array( $t2 ), 'post_tag' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'pairs', $data );
+		$this->assertSame( array(), $data['pairs'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 */
+	public function test_single_post_with_three_tags_yields_three_pairs() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create( array( 'name' => 'one' ) );
+		$t2 = self::factory()->tag->create( array( 'name' => 'two' ) );
+		$t3 = self::factory()->tag->create( array( 'name' => 'three' ) );
+
+		$post = self::factory()->post->create();
+		wp_set_object_terms( $post, array( $t1, $t2, $t3 ), 'post_tag' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$data  = $response->get_data();
+		$pairs = $data['pairs'];
+
+		// Each tag should see the other two as neighbors with shared=1.
+		foreach ( array( $t1, $t2, $t3 ) as $tid ) {
+			$this->assertArrayHasKey( (string) $tid, $pairs );
+			$this->assertCount( 2, $pairs[ (string) $tid ] );
+			foreach ( $pairs[ (string) $tid ] as $neighbor ) {
+				$this->assertSame( 1, $neighbor['shared'] );
+				$this->assertNotSame( $tid, $neighbor['id'] );
+			}
+		}
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 *
+	 * Two posts share both tags → shared count = 2. A third post
+	 * pairs only the first tag with a third tag → shared(t1,t3) = 1.
+	 * Verifies the per-pair accumulation across distinct posts AND
+	 * that the response sorts neighbors by shared count desc.
+	 */
+	public function test_accumulates_shared_counts_across_posts_and_sorts_desc() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create( array( 'name' => 'apple' ) );
+		$t2 = self::factory()->tag->create( array( 'name' => 'banana' ) );
+		$t3 = self::factory()->tag->create( array( 'name' => 'cherry' ) );
+
+		// Two posts pair t1+t2.
+		foreach ( range( 0, 1 ) as $i ) {
+			$p = self::factory()->post->create();
+			wp_set_object_terms( $p, array( $t1, $t2 ), 'post_tag' );
+		}
+		// One post pairs t1+t3.
+		$p = self::factory()->post->create();
+		wp_set_object_terms( $p, array( $t1, $t3 ), 'post_tag' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$pairs = $response->get_data()['pairs'];
+
+		// t1 sees t2 (2 shared) and t3 (1 shared) — t2 first (sorted desc).
+		$this->assertArrayHasKey( (string) $t1, $pairs );
+		$this->assertSame( $t2, $pairs[ (string) $t1 ][0]['id'] );
+		$this->assertSame( 2, $pairs[ (string) $t1 ][0]['shared'] );
+		$this->assertSame( $t3, $pairs[ (string) $t1 ][1]['id'] );
+		$this->assertSame( 1, $pairs[ (string) $t1 ][1]['shared'] );
+
+		// t2 sees only t1, with shared=2.
+		$this->assertArrayHasKey( (string) $t2, $pairs );
+		$this->assertCount( 1, $pairs[ (string) $t2 ] );
+		$this->assertSame( $t1, $pairs[ (string) $t2 ][0]['id'] );
+		$this->assertSame( 2, $pairs[ (string) $t2 ][0]['shared'] );
+	}
+
+	// ----------------------------------------------------------------
+	// Status / type filtering — must mirror core's
+	// `_update_post_term_count` exclusions so the cluster graph
+	// matches what the user actually sees in the cloud.
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 */
+	public function test_excludes_trash_posts_from_cooccurrence() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create( array( 'name' => 'live' ) );
+		$t2 = self::factory()->tag->create( array( 'name' => 'live2' ) );
+
+		// One trashed post links t1+t2 — should NOT count.
+		$trashed = self::factory()->post->create( array( 'post_status' => 'trash' ) );
+		wp_set_object_terms( $trashed, array( $t1, $t2 ), 'post_tag' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$pairs = $response->get_data()['pairs'];
+		$this->assertArrayNotHasKey( (string) $t1, $pairs );
+		$this->assertArrayNotHasKey( (string) $t2, $pairs );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 */
+	public function test_includes_drafts_pending_and_future_statuses() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create( array( 'name' => 'draft1' ) );
+		$t2 = self::factory()->tag->create( array( 'name' => 'draft2' ) );
+
+		// Drafts are non-trash and aren't auto-draft/inherit, so they
+		// should contribute to the graph — matches how the rest of
+		// the cloud counts terms.
+		$draft = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		wp_set_object_terms( $draft, array( $t1, $t2 ), 'post_tag' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$pairs = $response->get_data()['pairs'];
+		$this->assertArrayHasKey( (string) $t1, $pairs );
+		$this->assertSame( $t2, $pairs[ (string) $t1 ][0]['id'] );
+	}
+
+	// ----------------------------------------------------------------
+	// Top-N limit + cap
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 */
+	public function test_limit_param_trims_neighbor_list() {
+		wp_set_current_user( $this->admin_id );
+
+		// One hub tag connected to five sibling tags via one shared post.
+		$hub      = self::factory()->tag->create( array( 'name' => 'hub' ) );
+		$siblings = array();
+		for ( $i = 0; $i < 5; $i++ ) {
+			$siblings[] = self::factory()->tag->create( array( 'name' => "s$i" ) );
+		}
+		$post = self::factory()->post->create();
+		wp_set_object_terms( $post, array_merge( array( $hub ), $siblings ), 'post_tag' );
+
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' );
+		$request->set_param( 'limit', 2 );
+		$response = rest_get_server()->dispatch( $request );
+		$pairs    = $response->get_data()['pairs'];
+
+		$this->assertArrayHasKey( (string) $hub, $pairs );
+		$this->assertCount(
+			2,
+			$pairs[ (string) $hub ],
+			'limit=2 must trim the hub tag to its top 2 neighbors.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 *
+	 * The callback caps `limit` at 24 — a hostile or sloppy caller
+	 * passing limit=9999 must not be able to balloon every tag's
+	 * neighbor array.
+	 */
+	public function test_limit_param_is_capped_to_24() {
+		wp_set_current_user( $this->admin_id );
+
+		$hub      = self::factory()->tag->create( array( 'name' => 'hub' ) );
+		$siblings = array();
+		for ( $i = 0; $i < 30; $i++ ) {
+			$siblings[] = self::factory()->tag->create( array( 'name' => "s$i" ) );
+		}
+		$post = self::factory()->post->create();
+		wp_set_object_terms( $post, array_merge( array( $hub ), $siblings ), 'post_tag' );
+
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' );
+		$request->set_param( 'limit', 9999 );
+		$response = rest_get_server()->dispatch( $request );
+		$pairs    = $response->get_data()['pairs'];
+
+		$this->assertCount(
+			24,
+			$pairs[ (string) $hub ],
+			'limit must be clamped to 24 regardless of the caller-supplied value.'
+		);
+	}
+
+	// ----------------------------------------------------------------
+	// Cache layer
+	//
+	// The endpoint memoises its result into a transient keyed by the
+	// site-wide cache version + taxonomy + limit. Invalidation hooks
+	// bump the version, which makes every previously-cached payload
+	// unreachable in a single option write. Tests below pin the
+	// version helpers + verify the canonical invalidation triggers.
+	// ----------------------------------------------------------------
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_cache_version
+	 */
+	public function test_cache_version_starts_at_one_when_unset() {
+		$this->assertSame(
+			1,
+			desktop_mode_posts_window_tag_cooccurrence_cache_version()
+		);
+		$this->assertSame(
+			1,
+			(int) get_option( 'desktop_mode_tag_cooccurrence_cache_version' ),
+			'First read must persist the version so concurrent readers see the same value.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_invalidate_bumps_the_version() {
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		desktop_mode_posts_window_tag_cooccurrence_invalidate();
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertSame( $before + 1, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 *
+	 * First call must populate the transient under
+	 * `dmwco_v<version>_<taxonomy>_l<limit>`. We verify by reading
+	 * the transient directly — equality with the response payload
+	 * proves the cache write fired.
+	 */
+	public function test_first_call_writes_payload_to_transient() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create( array( 'name' => 'cache-a' ) );
+		$t2 = self::factory()->tag->create( array( 'name' => 'cache-b' ) );
+		$p  = self::factory()->post->create();
+		wp_set_object_terms( $p, array( $t1, $t2 ), 'post_tag' );
+
+		// `wp_set_object_terms` above already triggered an invalidation,
+		// so the cache version is no longer 1. Read it AFTER the
+		// fixture is set up.
+		$version = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$payload = $response->get_data();
+
+		$cache_key = sprintf( 'dmwco_v%d_%s_l%d', $version, 'post_tag', 8 );
+		$cached    = get_transient( $cache_key );
+		$this->assertIsArray( $cached );
+		$this->assertSame( $payload, $cached );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_callback
+	 *
+	 * A pre-warmed transient under the active version must be
+	 * returned verbatim — proves the dispatcher short-circuits on
+	 * cache hit instead of re-running the SQL aggregation.
+	 */
+	public function test_second_call_returns_cached_payload_without_recomputing() {
+		wp_set_current_user( $this->admin_id );
+
+		$version   = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$cache_key = sprintf( 'dmwco_v%d_%s_l%d', $version, 'post_tag', 8 );
+
+		// Stuff a sentinel payload into the cache; if the endpoint
+		// short-circuits on hit we should see this verbatim instead
+		// of the empty-pairs response the real SQL would produce.
+		$sentinel = array(
+			'pairs' => array(
+				'9999' => array(
+					array( 'id' => 8888, 'shared' => 42 ),
+				),
+			),
+		);
+		set_transient( $cache_key, $sentinel, DAY_IN_SECONDS );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $sentinel, $response->get_data() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 *
+	 * After invalidation, the previous cached payload must be
+	 * unreachable (different version → different key) and the
+	 * endpoint must recompute from the live DB.
+	 */
+	public function test_invalidation_makes_old_cache_unreachable() {
+		wp_set_current_user( $this->admin_id );
+
+		$version_a = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$key_a     = sprintf( 'dmwco_v%d_%s_l%d', $version_a, 'post_tag', 8 );
+
+		// Plant a sentinel under the current version's key.
+		$sentinel = array(
+			'pairs' => array(
+				'1234' => array(
+					array( 'id' => 5678, 'shared' => 99 ),
+				),
+			),
+		);
+		set_transient( $key_a, $sentinel, DAY_IN_SECONDS );
+
+		// Bump the version.
+		desktop_mode_posts_window_tag_cooccurrence_invalidate();
+		$version_b = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $version_a, $version_b );
+
+		// Endpoint must miss (different key) and return the live
+		// empty-pairs response.
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/desktop-mode/v1/tag-cooccurrence' )
+		);
+		$this->assertSame( array( 'pairs' => array() ), $response->get_data() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 *
+	 * The hook surface — every action below should bump the
+	 * version. If one of these regresses, users would see stale
+	 * cluster layouts after edits without an F5.
+	 */
+	public function test_set_object_terms_invalidates_cache() {
+		$post = self::factory()->post->create();
+		$tag  = self::factory()->tag->create();
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		wp_set_object_terms( $post, array( $tag ), 'post_tag' );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_created_term_invalidates_cache() {
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		self::factory()->tag->create( array( 'name' => 'fresh' ) );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_edited_term_invalidates_cache() {
+		$tag = self::factory()->tag->create( array( 'name' => 'before' ) );
+		// Setup fired created_term + set_object_terms; snapshot the
+		// version AFTER setup so the assertion is about the edit.
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		wp_update_term( $tag, 'post_tag', array( 'name' => 'after' ) );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_delete_term_invalidates_cache() {
+		$tag    = self::factory()->tag->create();
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		wp_delete_term( $tag, 'post_tag' );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_wp_trash_post_invalidates_cache() {
+		$post   = self::factory()->post->create();
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		wp_trash_post( $post );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_untrash_post_invalidates_cache() {
+		$post = self::factory()->post->create();
+		wp_trash_post( $post );
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		wp_untrash_post( $post );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+
+	/**
+	 * @covers ::desktop_mode_posts_window_tag_cooccurrence_invalidate
+	 */
+	public function test_before_delete_post_invalidates_cache() {
+		$post   = self::factory()->post->create();
+		$before = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		wp_delete_post( $post, true );
+		$after = desktop_mode_posts_window_tag_cooccurrence_cache_version();
+		$this->assertGreaterThan( $before, $after );
+	}
+}

--- a/tests/phpunit/tests/postsWindowTermCounts.php
+++ b/tests/phpunit/tests/postsWindowTermCounts.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Tests for the `/desktop-mode/v1/term-counts` REST endpoint.
+ *
+ * Bulk count endpoint that returns `{ term_id: count }` for every
+ * requested term, mirroring core's `_update_post_term_count` status
+ * filtering (trash + auto-draft + inherit excluded; drafts, pending,
+ * future, private all included). Since 0.8.5 the endpoint caches
+ * the WHOLE taxonomy's count map under one transient — clients with
+ * different ID subsets all project out of the same cached map.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-posts-window
+ */
+class Tests_DesktopMode_PostsWindowTermCounts extends WP_UnitTestCase {
+
+	private $admin_id;
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		do_action( 'rest_api_init' );
+
+		// Clear the shared cache version so each test starts clean.
+		delete_option( 'desktop_mode_terms_cache_version' );
+	}
+
+	private function dispatch_with_ids( array $ids, $taxonomy = 'post_tag' ) {
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/term-counts' );
+		$request->set_param( 'taxonomy', $taxonomy );
+		$request->set_param( 'ids', implode( ',', $ids ) );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	// ----------------------------------------------------------------
+	// Auth
+	// ----------------------------------------------------------------
+
+	public function test_endpoint_requires_edit_posts_cap() {
+		wp_set_current_user( $this->subscriber_id );
+		$tag      = self::factory()->tag->create();
+		$response = $this->dispatch_with_ids( array( $tag ) );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_endpoint_allows_administrator() {
+		wp_set_current_user( $this->admin_id );
+		$tag      = self::factory()->tag->create();
+		$response = $this->dispatch_with_ids( array( $tag ) );
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_unknown_taxonomy_returns_400() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/term-counts' );
+		$request->set_param( 'taxonomy', 'definitely_not_a_taxonomy' );
+		$request->set_param( 'ids', '1,2,3' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame(
+			'desktop_mode_invalid_taxonomy',
+			$response->get_data()['code']
+		);
+	}
+
+	// ----------------------------------------------------------------
+	// Happy path + projection
+	// ----------------------------------------------------------------
+
+	public function test_returns_zero_for_unknown_or_unused_ids() {
+		wp_set_current_user( $this->admin_id );
+		$response = $this->dispatch_with_ids( array( 9999, 8888 ) );
+		$data     = $response->get_data();
+		$this->assertSame( 0, $data['9999'] );
+		$this->assertSame( 0, $data['8888'] );
+	}
+
+	public function test_returns_correct_counts_for_tagged_posts() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create();
+		$t2 = self::factory()->tag->create();
+
+		// 3 posts tagged with t1, 1 post tagged with t2.
+		foreach ( range( 0, 2 ) as $i ) {
+			$p = self::factory()->post->create();
+			wp_set_object_terms( $p, array( $t1 ), 'post_tag' );
+		}
+		$p = self::factory()->post->create();
+		wp_set_object_terms( $p, array( $t2 ), 'post_tag' );
+
+		$data = $this->dispatch_with_ids( array( $t1, $t2 ) )->get_data();
+		$this->assertSame( 3, $data[ (string) $t1 ] );
+		$this->assertSame( 1, $data[ (string) $t2 ] );
+	}
+
+	/**
+	 * Different callers with different ID subsets must all share
+	 * the same cached map and get the right projection. This is
+	 * the central benefit of caching the whole taxonomy under one
+	 * key — without it, the cache hit rate would collapse on a
+	 * window that re-requests a subset on every reload.
+	 */
+	public function test_different_id_subsets_project_from_shared_cache() {
+		wp_set_current_user( $this->admin_id );
+
+		$tags = array();
+		for ( $i = 0; $i < 5; $i++ ) {
+			$tag = self::factory()->tag->create();
+			// i posts → i counts (0, 1, 2, 3, 4).
+			for ( $j = 0; $j < $i; $j++ ) {
+				$p = self::factory()->post->create();
+				wp_set_object_terms( $p, array( $tag ), 'post_tag' );
+			}
+			$tags[] = $tag;
+		}
+
+		// First call asks for the first three IDs.
+		$first  = $this->dispatch_with_ids( array_slice( $tags, 0, 3 ) )->get_data();
+		$this->assertSame( 0, $first[ (string) $tags[0] ] );
+		$this->assertSame( 1, $first[ (string) $tags[1] ] );
+		$this->assertSame( 2, $first[ (string) $tags[2] ] );
+
+		// Second call asks for the last three IDs — must hit the
+		// same cache entry and still return the right projection.
+		$second = $this->dispatch_with_ids( array_slice( $tags, 2, 3 ) )->get_data();
+		$this->assertSame( 2, $second[ (string) $tags[2] ] );
+		$this->assertSame( 3, $second[ (string) $tags[3] ] );
+		$this->assertSame( 4, $second[ (string) $tags[4] ] );
+	}
+
+	// ----------------------------------------------------------------
+	// Status filtering — mirrors core's `_update_post_term_count`
+	// ----------------------------------------------------------------
+
+	public function test_trash_posts_excluded_from_count() {
+		wp_set_current_user( $this->admin_id );
+
+		$tag      = self::factory()->tag->create();
+		$published = self::factory()->post->create();
+		wp_set_object_terms( $published, array( $tag ), 'post_tag' );
+
+		$trashed = self::factory()->post->create( array( 'post_status' => 'trash' ) );
+		wp_set_object_terms( $trashed, array( $tag ), 'post_tag' );
+
+		$data = $this->dispatch_with_ids( array( $tag ) )->get_data();
+		$this->assertSame(
+			1,
+			$data[ (string) $tag ],
+			'Trashed posts must not contribute to bulk count.'
+		);
+	}
+
+	public function test_drafts_included_in_count() {
+		wp_set_current_user( $this->admin_id );
+
+		$tag   = self::factory()->tag->create();
+		$draft = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		wp_set_object_terms( $draft, array( $tag ), 'post_tag' );
+
+		$data = $this->dispatch_with_ids( array( $tag ) )->get_data();
+		$this->assertSame(
+			1,
+			$data[ (string) $tag ],
+			'Drafts must contribute to bulk count.'
+		);
+	}
+
+	// ----------------------------------------------------------------
+	// Caching
+	// ----------------------------------------------------------------
+
+	public function test_first_call_writes_full_taxonomy_map_to_transient() {
+		wp_set_current_user( $this->admin_id );
+
+		$t1 = self::factory()->tag->create();
+		$t2 = self::factory()->tag->create();
+		$p  = self::factory()->post->create();
+		wp_set_object_terms( $p, array( $t1, $t2 ), 'post_tag' );
+
+		// Cache version moves on every fixture call; read it AFTER
+		// fixtures are set up.
+		$version   = desktop_mode_posts_window_terms_cache_version();
+		$cache_key = sprintf( 'dmtcnt_v%d_%s', $version, 'post_tag' );
+
+		// Caller only asks for t1, but the cache should still
+		// contain BOTH terms (the endpoint computes the whole
+		// taxonomy on a miss).
+		$this->dispatch_with_ids( array( $t1 ) );
+
+		$cached = get_transient( $cache_key );
+		$this->assertIsArray( $cached );
+		$this->assertArrayHasKey( (string) $t1, $cached );
+		$this->assertArrayHasKey(
+			(string) $t2,
+			$cached,
+			'Cache must contain every term in the taxonomy, not just the ones the first caller requested.'
+		);
+		$this->assertSame( 1, $cached[ (string) $t1 ] );
+		$this->assertSame( 1, $cached[ (string) $t2 ] );
+	}
+
+	public function test_second_call_short_circuits_on_cache_hit() {
+		wp_set_current_user( $this->admin_id );
+
+		$version   = desktop_mode_posts_window_terms_cache_version();
+		$cache_key = sprintf( 'dmtcnt_v%d_%s', $version, 'post_tag' );
+
+		// Plant a sentinel map; the dispatcher must read this
+		// instead of running the SQL aggregation.
+		$sentinel = array(
+			'42'   => 999,
+			'1337' => 7,
+		);
+		set_transient( $cache_key, $sentinel, DAY_IN_SECONDS );
+
+		$data = $this->dispatch_with_ids( array( 42, 1337 ) )->get_data();
+		$this->assertSame( 999, $data['42'] );
+		$this->assertSame( 7, $data['1337'] );
+	}
+
+	public function test_set_object_terms_invalidates_term_counts_cache() {
+		wp_set_current_user( $this->admin_id );
+
+		$version_a = desktop_mode_posts_window_terms_cache_version();
+		$key_a     = sprintf( 'dmtcnt_v%d_%s', $version_a, 'post_tag' );
+
+		// Plant a sentinel under the current version's key.
+		$sentinel = array( '4242' => 1234 );
+		set_transient( $key_a, $sentinel, DAY_IN_SECONDS );
+
+		// `wp_set_object_terms` triggers the shared invalidator.
+		$tag  = self::factory()->tag->create();
+		$post = self::factory()->post->create();
+		wp_set_object_terms( $post, array( $tag ), 'post_tag' );
+
+		// New version → new cache key → sentinel no longer reachable.
+		$version_b = desktop_mode_posts_window_terms_cache_version();
+		$this->assertGreaterThan( $version_a, $version_b );
+
+		$data = $this->dispatch_with_ids( array( $tag, 4242 ) )->get_data();
+		$this->assertSame(
+			1,
+			$data[ (string) $tag ],
+			'Live SQL must replace the stale sentinel after invalidation.'
+		);
+		$this->assertSame(
+			0,
+			$data['4242'],
+			'Stale sentinel entry must not leak through after invalidation.'
+		);
+	}
+
+	// ----------------------------------------------------------------
+	// Safety guards
+	// ----------------------------------------------------------------
+
+	public function test_empty_ids_param_returns_empty() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/term-counts' );
+		$request->set_param( 'taxonomy', 'post_tag' );
+		$request->set_param( 'ids', '' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data() );
+	}
+
+	public function test_ids_param_capped_at_500_caller_ids() {
+		wp_set_current_user( $this->admin_id );
+
+		// Pass 750 IDs; the endpoint must trim to the first 500.
+		// We don't need real tags here — we just want to prove the
+		// callable returns a 200 with up to 500 keys, not error out
+		// or balloon the response.
+		$big = range( 1, 750 );
+		$response = $this->dispatch_with_ids( $big );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertLessThanOrEqual( 500, count( $response->get_data() ) );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Content Graph–style search bar to the pixi tag cloud and category mindmap, pre-clusters the tag cloud by co-occurrence (tags that share posts sit near each other), and introduces a shared server cache with version-bump invalidation for the two terms-derived REST endpoints.

## Search

- New search input in both `wpd-mindmap__toolbar` and `wpd-tagcloud__toolbar`.
- Substring match on name (plus slug for tags), top-10 by post count.
- Mouse + keyboard: ArrowUp/Down, Enter, Escape; click delegates to existing `focusNode` / `focusTag`.
- Fixes a stacking-context bug where the dropdown rendered behind the pixi canvas (toolbar now creates its own stacking context).

## Co-occurrence clustering for tags

- New `GET /desktop-mode/v1/tag-cooccurrence` — one SQL scan over `term_relationships`, returns top-N co-occurring siblings per tag with shared-post counts. Status filter mirrors core's `_update_post_term_count`.
- `findSpiralSlot` extended with an optional anchor; new `packBoxesWithClusters` pulls each chip toward the centroid of its already-placed neighbors and seeds new clusters on a golden-angle meta-spiral when nothing co-occurs yet.
- First paint = popularity spiral; when the cooccurrence fetch lands, non-persisted chips ease into their cluster positions via the existing pixi tick. User-dragged positions stay put.
- Reflow re-packs with the current map and refreshes cooccurrence in the background.

## Server cache

- Shared transient cache for `/tag-cooccurrence` and `/term-counts`. One version option (`desktop_mode_terms_cache_version`) keyed into both caches.
- `/term-counts` caches the **whole taxonomy** under one key (`dmtcnt_v{N}_{taxonomy}`) and projects the caller's requested ID subset out of it — every client variant shares the same entry.
- Invalidation: 7 actions bump the version (`set_object_terms`, `created_term`, `edited_term`, `delete_term`, `wp_trash_post`, `untrashed_post`, `before_delete_post`). One option write retires every cached payload across both endpoints.
- TTL `DAY_IN_SECONDS` as a floor on staleness if a hook ever fails to fire.

## Tests

- New PHPUnit:
  - `Tests_DesktopMode_PostsWindowTagCooccurrence` — 22 tests covering math, status filtering, `limit` cap, cache hit/miss, and per-hook invalidation.
  - `Tests_DesktopMode_PostsWindowTermCounts` — 13 tests covering auth, ID projection, shared-cache projection across subsets, status filtering, cache hit/miss, invalidation, caps.
- `npm run lint`, `tsc --noEmit`, `npm run test:js` (1237 / 1237) — green.
- Full `@group desktop-mode` PHPUnit: 780 / 781. The single failure is the pre-existing `pluginsWindowRegistration` test that tries to contact wordpress.org from the test container.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-220-b620ba9ace9cb33ab338ca2870e00825393ef8c4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->