### PR TITLE
feat(desktops): arrow-key shortcuts + Overview-from-Show-Desktop fix

### DIFF
--- a/assets/css/window-overview.css
+++ b/assets/css/window-overview.css
@@ -436,6 +436,20 @@
 	background: rgba( 255, 255, 255, 0.08 );
 }
 
+/*
+ * Keyboard cursor parked on the "+" tile. Mirrors the visual weight
+ * of `--active` (solid accent border + halo) so the user sees at a
+ * glance "Enter will land here". The dashed border on the add tile
+ * flips to solid when the cursor lands, matching the desktop tiles'
+ * solid borders.
+ */
+.desktop-mode-overview-top-bar__tile--add.desktop-mode-overview-top-bar__tile--cursor {
+	border-style: solid;
+	border-color: var( --wp-admin-theme-color, #2271b1 );
+	box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 );
+	background: rgba( 255, 255, 255, 0.08 );
+}
+
 .desktop-mode-overview-top-bar__tile-plus {
 	display: flex;
 	align-items: center;

--- a/assets/css/window-states.css
+++ b/assets/css/window-states.css
@@ -174,6 +174,66 @@
 }
 
 /*
+ * Desktop-switch slide — applied to `.desktop-mode-area` (the windows
+ * + widgets container) when the user moves between virtual desktops
+ * via arrow keys or any other directional caller. The wallpaper lives
+ * OUTSIDE this element (sibling under `.desktop-mode-shell`), so the
+ * slide reveals the wallpaper as a backdrop — no black flash, no
+ * awkward gap on the leading edge.
+ *
+ * `--sliding-from-right` plays when moving to the next desktop (the
+ * rightward arrow press): the new desktop's content rushes in from
+ * the right and settles to centre. `--sliding-from-left` mirrors it
+ * for the previous-desktop direction. Wrap-around presses (rightmost
+ * → first via ArrowRight) keep the direction the user perceived,
+ * not the index delta.
+ *
+ * Opacity tapers from 0.35 → 1 so the moving content visibly arrives
+ * rather than just sliding in at full strength, but the wallpaper
+ * stays at full opacity behind it for an anchored sense of place.
+ * Cubic-bezier ease-out lands cleanly without overshoot.
+ *
+ * `forwards` isn't needed — the JS strips the class on `animationend`
+ * so the element returns to its natural transform / opacity state.
+ */
+@keyframes desktop-mode-area-slide-from-right {
+	from {
+		transform: translateX(64px);
+		opacity: 0.35;
+	}
+	to {
+		transform: translateX(0);
+		opacity: 1;
+	}
+}
+
+@keyframes desktop-mode-area-slide-from-left {
+	from {
+		transform: translateX(-64px);
+		opacity: 0.35;
+	}
+	to {
+		transform: translateX(0);
+		opacity: 1;
+	}
+}
+
+.desktop-mode-area--sliding-from-right {
+	animation: desktop-mode-area-slide-from-right 0.28s cubic-bezier( 0.2, 0.7, 0.2, 1 );
+}
+
+.desktop-mode-area--sliding-from-left {
+	animation: desktop-mode-area-slide-from-left 0.28s cubic-bezier( 0.2, 0.7, 0.2, 1 );
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-area--sliding-from-right,
+	.desktop-mode-area--sliding-from-left {
+		animation: none;
+	}
+}
+
+/*
  * Minimized state — fade + scale down.
  * Uses opacity + pointer-events instead of display: none so the
  * CSS transition can animate the change. The window is invisible

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -12,6 +12,7 @@
 
 import { WindowManager } from './window-manager';
 import { installWindowSwitcherShortcut } from './window-manager/switcher';
+import { installDesktopArrowShortcuts } from './window-manager/desktop-shortcuts';
 import {
 	installWindowLoadingTransitions,
 } from './window/loading';
@@ -1719,6 +1720,7 @@ function init(): void {
 	} );
 	installPaletteShortcut();
 	installWindowSwitcherShortcut( manager );
+	installDesktopArrowShortcuts( manager );
 
 	// Iframe command bridge — pulls `wp.data.select('core/commands')` out
 	// of whichever window has focus and exposes the commands as slash-

--- a/src/window-manager/desktop-shortcuts.ts
+++ b/src/window-manager/desktop-shortcuts.ts
@@ -1,0 +1,223 @@
+/**
+ * Desktop Mode — Virtual-desktop arrow-key shortcuts.
+ *
+ * Bare arrow keys drive the four most common desktop-shell actions
+ * when focus is outside a text-entry surface:
+ *
+ *   - ArrowLeft  → previous virtual desktop (no-op with one desktop or
+ *                  when already on the leftmost).
+ *   - ArrowRight → next virtual desktop (symmetrical no-op rules).
+ *   - ArrowUp    → toggle the Overview grid (mirrors the
+ *                  Arrange → Overview button).
+ *   - ArrowDown  → toggle Show Desktop (mirrors the right-click
+ *                  Show desktop action / wallpaper-click gesture).
+ *
+ * Bare arrows mean we lean hard on {@link isTextEntryFocus} to avoid
+ * stealing keystrokes from inputs, textareas, contenteditable, and
+ * nested iframes (where the inner document owns the keys — typing in
+ * Gutenberg's block canvas, for instance). Same gate as the window
+ * switcher in `switcher.ts`. We deliberately do NOT install an iframe
+ * forwarder for these keys: arrow keys inside admin pages routinely
+ * mean "navigate this list", "move caret", etc., and forwarding them
+ * would surprise users.
+ *
+ * `preventDefault` only fires when we actually acted on the key —
+ * otherwise plain ArrowDown on an empty desktop area would still
+ * preventDefault a page-scroll the user expected.
+ *
+ * @since 0.8.6
+ */
+
+import { isTextEntryFocus } from './switcher';
+import type { WindowManager } from './index';
+
+export type DesktopDirection = 'prev' | 'next';
+
+/**
+ * Switch to the desktop immediately before or after the active one in
+ * the registry order. Wraps at the ends — past the last desktop loops
+ * back to the first and vice versa — so a user pressing ArrowRight
+ * repeatedly always cycles through every desktop.
+ *
+ * Returns `true` when a switch actually happened so the keydown
+ * handler knows to `preventDefault`.
+ */
+export function switchToAdjacentDesktop(
+	mgr: WindowManager,
+	direction: DesktopDirection,
+): boolean {
+	const desktops = mgr.getDesktops();
+	if ( desktops.length < 2 ) {
+		return false;
+	}
+	const activeId = mgr.getActiveDesktopId();
+	const idx = desktops.findIndex( ( d ) => d.id === activeId );
+	if ( idx === -1 ) {
+		return false;
+	}
+	const step = direction === 'next' ? 1 : -1;
+	// `+ length` before modulo handles the negative step at idx 0.
+	const targetIdx = ( idx + step + desktops.length ) % desktops.length;
+	if ( targetIdx === idx ) {
+		return false;
+	}
+	mgr.switchDesktop( desktops[ targetIdx ].id, { direction } );
+	return true;
+}
+
+/**
+ * Toggle Overview — enter if not active, exit (without selecting a
+ * window) if currently in overview. Always returns `true` since the
+ * keypress is intentionally consumed in both directions.
+ */
+export function toggleOverview( mgr: WindowManager ): boolean {
+	if ( mgr._overviewActive ) {
+		mgr.exitOverview();
+	} else {
+		mgr.enterOverview();
+	}
+	return true;
+}
+
+/**
+ * Toggle Show Desktop. Returns `false` when there are no live windows
+ * (so ArrowDown doesn't preventDefault on a fresh, empty desktop) or
+ * when overview is active — minimizing every window while the user is
+ * looking at the overview grid would clash with the in-flight thumbnail
+ * transforms and surprise the user mid-navigation. The caller routes
+ * ArrowDown to {@link exitOverviewIfActive} first when in overview.
+ */
+export function toggleShowDesktop( mgr: WindowManager ): boolean {
+	if ( mgr._overviewActive ) {
+		return false;
+	}
+	if ( mgr.getAll().length === 0 ) {
+		return false;
+	}
+	mgr.toggleShowDesktop();
+	return true;
+}
+
+/**
+ * Exit overview onto the currently active desktop without selecting a
+ * specific window. Used by ArrowUp / ArrowDown when overview is active
+ * so those keys feel like "get me out of overview" rather than firing
+ * a second action on top of an already-mounted overview.
+ *
+ * Returns `true` when an exit actually happened (callers
+ * `preventDefault` on a real action only).
+ */
+export function exitOverviewIfActive( mgr: WindowManager ): boolean {
+	if ( ! mgr._overviewActive ) {
+		return false;
+	}
+	mgr.exitOverview();
+	return true;
+}
+
+/**
+ * True when the shell is in the canonical "Show Desktop" state — at
+ * least one window exists and every live window is minimized.
+ * Mirrors the global check inside {@link WindowManager.toggleShowDesktop},
+ * so the heuristic matches whatever flipped the user into the state
+ * in the first place.
+ */
+function isShowDesktopActive( mgr: WindowManager ): boolean {
+	const all = mgr.getAll();
+	if ( all.length === 0 ) {
+		return false;
+	}
+	return all.every( ( w ) => w.state === 'minimized' );
+}
+
+/**
+ * Restore every window when the shell is in Show Desktop state. Used
+ * by ArrowUp so the press feels like "bring my windows back" rather
+ * than escalating into Overview — matching the symmetrical
+ * ArrowDown-then-ArrowUp expectation. No-op (returns `false`) outside
+ * Show Desktop so the caller can fall through to the next action.
+ */
+export function exitShowDesktopIfActive( mgr: WindowManager ): boolean {
+	if ( ! isShowDesktopActive( mgr ) ) {
+		return false;
+	}
+	// `toggleShowDesktop` already special-cases "every window minimized"
+	// → restore all. Calling it is the contract-preserving way to exit
+	// rather than duplicating the iteration here.
+	mgr.toggleShowDesktop();
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Global shortcut installer
+// ---------------------------------------------------------------------------
+
+let installed = false;
+
+/**
+ * Install the arrow-key desktop shortcuts. Idempotent — calling more
+ * than once is a no-op so HMR / re-init paths don't stack listeners.
+ */
+export function installDesktopArrowShortcuts( mgr: WindowManager ): void {
+	if ( installed ) {
+		return;
+	}
+	installed = true;
+
+	document.addEventListener(
+		'keydown',
+		( e: KeyboardEvent ) => {
+			// Modified arrows are reserved — Shift-arrow extends
+			// selections, Cmd/Ctrl/Alt-arrow are word-jumps or browser /
+			// OS shortcuts. Bare arrow only.
+			if ( e.ctrlKey || e.metaKey || e.altKey || e.shiftKey ) {
+				return;
+			}
+			if (
+				e.code !== 'ArrowLeft' &&
+				e.code !== 'ArrowRight' &&
+				e.code !== 'ArrowUp' &&
+				e.code !== 'ArrowDown'
+			) {
+				return;
+			}
+			if ( isTextEntryFocus( document ) ) {
+				return;
+			}
+
+			let handled = false;
+			switch ( e.code ) {
+				case 'ArrowLeft':
+					handled = switchToAdjacentDesktop( mgr, 'prev' );
+					break;
+				case 'ArrowRight':
+					handled = switchToAdjacentDesktop( mgr, 'next' );
+					break;
+				case 'ArrowUp':
+					// Priority chain:
+					//   1. Overview active → exit (mirrors Enter-to-commit).
+					//   2. Show Desktop active → restore windows (the
+					//      symmetric undo for the ArrowDown gesture; the
+					//      user expects "↓ hides, ↑ brings back" before
+					//      they expect "↑ opens Overview").
+					//   3. Default → enter Overview.
+					handled =
+						exitOverviewIfActive( mgr ) ||
+						exitShowDesktopIfActive( mgr ) ||
+						toggleOverview( mgr );
+					break;
+				case 'ArrowDown':
+					// In overview, ArrowDown exits without minimizing —
+					// the regular Show Desktop toggle is intentionally
+					// suppressed (see `toggleShowDesktop`).
+					handled = exitOverviewIfActive( mgr ) || toggleShowDesktop( mgr );
+					break;
+			}
+
+			if ( handled ) {
+				e.preventDefault();
+			}
+		},
+		true,
+	);
+}

--- a/src/window-manager/desktop-shortcuts.ts
+++ b/src/window-manager/desktop-shortcuts.ts
@@ -29,6 +29,7 @@
  */
 
 import { isTextEntryFocus } from './switcher';
+import { refreshOverviewTopBar } from './overview';
 import type { WindowManager } from './index';
 
 export type DesktopDirection = 'prev' | 'next';
@@ -38,6 +39,10 @@ export type DesktopDirection = 'prev' | 'next';
  * the registry order. Wraps at the ends — past the last desktop loops
  * back to the first and vice versa — so a user pressing ArrowRight
  * repeatedly always cycles through every desktop.
+ *
+ * Outside overview, this is the only navigation primitive. Inside
+ * overview, callers route through {@link cycleOverviewCursor} instead
+ * so the trailing "+" tile participates in the cycle.
  *
  * Returns `true` when a switch actually happened so the keydown
  * handler knows to `preventDefault`.
@@ -61,6 +66,63 @@ export function switchToAdjacentDesktop(
 	if ( targetIdx === idx ) {
 		return false;
 	}
+	mgr.switchDesktop( desktops[ targetIdx ].id, { direction } );
+	return true;
+}
+
+/**
+ * Arrow navigation INSIDE overview. Cycle order is `[ ...desktops, + ]`
+ * — pressing past the last desktop parks the cursor on the trailing
+ * "+" tile (highlighted via `--cursor`); pressing once more wraps back
+ * to the first desktop.
+ *
+ * Cursor-on-desktop also drives the active desktop (matches the
+ * pre-existing "arrow switches active desktop in overview" behaviour
+ * so the grid + top bar repaint as the cursor moves). Cursor-on-add
+ * leaves the active desktop alone — there's nothing to switch to yet.
+ * Pressing Enter while parked on "+" creates the desktop (see
+ * `commitAddTile`).
+ *
+ * Returns `true` whenever the cycle moved, so the caller
+ * `preventDefault`s only on real navigation.
+ */
+export function cycleOverviewCursor(
+	mgr: WindowManager,
+	direction: DesktopDirection,
+): boolean {
+	if ( ! mgr._overviewActive ) {
+		return false;
+	}
+	const desktops = mgr.getDesktops();
+	// Single desktop + "+" still produces a 2-element cycle, so unlike
+	// `switchToAdjacentDesktop` we never bail on length.
+	const cycleLength = desktops.length + 1;
+	const ADD_INDEX = desktops.length;
+	const currentIdx = mgr._overviewAddTileFocused
+		? ADD_INDEX
+		: desktops.findIndex( ( d ) => d.id === mgr.getActiveDesktopId() );
+	if ( currentIdx === -1 ) {
+		return false;
+	}
+	const step = direction === 'next' ? 1 : -1;
+	const targetIdx = ( currentIdx + step + cycleLength ) % cycleLength;
+	if ( targetIdx === currentIdx ) {
+		return false;
+	}
+
+	if ( targetIdx === ADD_INDEX ) {
+		// Move cursor onto the "+" tile. Don't touch active desktop —
+		// there's no desktop to switch to. Just repaint the top bar so
+		// the cursor highlight follows.
+		mgr._overviewAddTileFocused = true;
+		refreshOverviewTopBar( mgr );
+		return true;
+	}
+
+	// Moving onto a real desktop tile — clear add-tile focus and route
+	// through the standard switch so the grid + top-bar update via the
+	// existing overview-aware path in `switchDesktop`.
+	mgr._overviewAddTileFocused = false;
 	mgr.switchDesktop( desktops[ targetIdx ].id, { direction } );
 	return true;
 }
@@ -188,10 +250,14 @@ export function installDesktopArrowShortcuts( mgr: WindowManager ): void {
 			let handled = false;
 			switch ( e.code ) {
 				case 'ArrowLeft':
-					handled = switchToAdjacentDesktop( mgr, 'prev' );
+					handled = mgr._overviewActive
+						? cycleOverviewCursor( mgr, 'prev' )
+						: switchToAdjacentDesktop( mgr, 'prev' );
 					break;
 				case 'ArrowRight':
-					handled = switchToAdjacentDesktop( mgr, 'next' );
+					handled = mgr._overviewActive
+						? cycleOverviewCursor( mgr, 'next' )
+						: switchToAdjacentDesktop( mgr, 'next' );
 					break;
 				case 'ArrowUp':
 					// Priority chain:

--- a/src/window-manager/desktops.ts
+++ b/src/window-manager/desktops.ts
@@ -14,7 +14,7 @@ import { __, sprintf } from '../i18n';
 import type { Desktop } from '../types';
 import type { Window } from '../window';
 import { computeOverviewLayout } from './geometry';
-import { createOverviewLabel } from './overview';
+import { createOverviewLabel, refreshOverviewTopBar } from './overview';
 import { OVERVIEW_TOP_BAR_RESERVE } from './overview-constants';
 import type { WindowManager } from './index';
 
@@ -88,7 +88,34 @@ export function createDesktop( mgr: WindowManager ): Desktop {
  * leaving and entering desktop ids so plugins can sync per-desktop
  * state (active-desktop-aware indicators, custom widgets, etc.).
  */
-export function switchDesktop( mgr: WindowManager, id: string ): void {
+/**
+ * Optional shape `switchDesktop` accepts to drive the slide animation
+ * direction. Callers that know the user's intent (the arrow-key
+ * handler) pass `direction`; everyone else omits it and the switch is
+ * instantaneous.
+ */
+export interface SwitchDesktopOptions {
+	/**
+	 * Visual slide direction.
+	 *
+	 *   - `'next'`: content slides in from the right. Matches a
+	 *     rightward arrow press, including the wrap from last → first
+	 *     (the user perceived a rightward motion regardless of the
+	 *     index delta).
+	 *   - `'prev'`: content slides in from the left.
+	 *
+	 * Omitting it (or passing nothing) skips the animation — fine for
+	 * jump-to-desktop callers (tile click, plugin API) where there's
+	 * no left/right metaphor to honour.
+	 */
+	direction?: 'next' | 'prev';
+}
+
+export function switchDesktop(
+	mgr: WindowManager,
+	id: string,
+	opts?: SwitchDesktopOptions,
+): void {
 	if ( id === mgr._activeDesktopId ) {
 		return;
 	}
@@ -97,25 +124,86 @@ export function switchDesktop( mgr: WindowManager, id: string ): void {
 	}
 	const previousId = mgr._activeDesktopId;
 	mgr._activeDesktopId = id;
-	refreshDesktopVisibility( mgr );
 
-	// Re-focus the topmost window on the new desktop. Without this,
-	// focus / z-state would still point at the prior desktop's window
-	// — invisible and confusing if the user then triggers a dock
-	// action that reuses the focused window's context.
-	const topOnNew = [ ...mgr._stack ]
-		.reverse()
-		.find(
-			( w ) => w.config.desktopId === id && w.state !== 'minimized',
-		);
-	if ( topOnNew ) {
-		mgr.focus( topOnNew );
+	// Visibility + overview state must stay in sync. Outside overview
+	// it's a plain show/hide refresh. Mid-overview, the grid has
+	// already snapshotted the previous desktop's windows at scaled
+	// transforms — flipping `display` alone would surface the new
+	// desktop's windows at their saved (non-overview) geometry on top
+	// of a still-visible overview backdrop. `relayoutOverviewForActiveDesktop`
+	// clears the stale snapshot, surfaces the new desktop's windows
+	// with overview transforms, and the top-bar refresh moves the
+	// `--active` highlight to match. Without these two calls,
+	// keyboard-driven desktop switching mid-overview looked like
+	// "nothing happened" even though the underlying active id moved.
+	if ( mgr._overviewActive ) {
+		relayoutOverviewForActiveDesktop( mgr );
+		refreshOverviewTopBar( mgr );
+	} else {
+		refreshDesktopVisibility( mgr );
+		if ( opts?.direction ) {
+			animateDesktopSwitch( mgr, opts.direction );
+		}
+
+		// Re-focus the topmost window on the new desktop. Without this,
+		// focus / z-state would still point at the prior desktop's window
+		// — invisible and confusing if the user then triggers a dock
+		// action that reuses the focused window's context.
+		const topOnNew = [ ...mgr._stack ]
+			.reverse()
+			.find(
+				( w ) =>
+					w.config.desktopId === id && w.state !== 'minimized',
+			);
+		if ( topOnNew ) {
+			mgr.focus( topOnNew );
+		}
 	}
 
 	doAction( HOOKS.DESKTOP_SWITCHED, {
 		from: previousId,
 		to: id,
 	} );
+}
+
+/**
+ * Play the one-shot slide-in animation on the desktop area itself.
+ * The wallpaper layer is a sibling under `.desktop-mode-shell`, not
+ * a child of `_desktop`, so sliding `_desktop` reveals the wallpaper
+ * as a backdrop on the leading edge — no black gap, no flash.
+ *
+ * `void el.offsetWidth` forces a reflow so re-adding the class after a
+ * removal actually restarts the keyframe. Without it, two consecutive
+ * arrow presses would play the animation once and freeze on the
+ * second.
+ *
+ * The `animationend` listener filters on `animationName` so child
+ * animations (window-open, window-shake, …) bubbling up through the
+ * desktop area don't strip our class mid-flight.
+ */
+function animateDesktopSwitch(
+	mgr: WindowManager,
+	direction: 'next' | 'prev',
+): void {
+	const el = mgr._desktop;
+	const cls =
+		direction === 'next'
+			? 'desktop-mode-area--sliding-from-right'
+			: 'desktop-mode-area--sliding-from-left';
+	el.classList.remove(
+		'desktop-mode-area--sliding-from-right',
+		'desktop-mode-area--sliding-from-left',
+	);
+	void el.offsetWidth;
+	el.classList.add( cls );
+	const onEnd = ( e: AnimationEvent ): void => {
+		if ( ! e.animationName.startsWith( 'desktop-mode-area-slide-from-' ) ) {
+			return;
+		}
+		el.classList.remove( cls );
+		el.removeEventListener( 'animationend', onEnd );
+	};
+	el.addEventListener( 'animationend', onEnd );
 }
 
 /**

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -182,6 +182,16 @@ export class WindowManager {
 	public _overviewMouseHandler: ( ( e: MouseEvent ) => void ) | null = null;
 	/** @internal */
 	public _lastOverviewHoverId: string | null = null;
+	/**
+	 * Tracks whether the keyboard cursor in overview is currently
+	 * parked on the trailing "+" tile (rather than a real desktop).
+	 * Lets arrow navigation include the add affordance in its cycle —
+	 * Enter while this is `true` creates a new desktop. Reset to
+	 * `false` on overview exit.
+	 *
+	 * @internal
+	 */
+	public _overviewAddTileFocused = false;
 
 	// ---- Snap-zone state (edge-snap + split overview) ----
 

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -49,6 +49,7 @@ import {
 	getDesktops,
 	seedDesktops,
 	switchDesktop,
+	type SwitchDesktopOptions,
 } from './desktops';
 import { cascade, tile } from './arrange';
 import {
@@ -986,8 +987,8 @@ export class WindowManager {
 	public createDesktop(): Desktop {
 		return createDesktop( this );
 	}
-	public switchDesktop( id: string ): void {
-		switchDesktop( this, id );
+	public switchDesktop( id: string, opts?: SwitchDesktopOptions ): void {
+		switchDesktop( this, id, opts );
 	}
 	public closeDesktop( id: string ): void {
 		closeDesktop( this, id );

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -35,6 +35,32 @@ export function enterOverview( mgr: WindowManager ): void {
 	if ( mgr._overviewActive ) {
 		return;
 	}
+	// "Show Desktop → Overview" unwind. If every window on the active
+	// desktop is minimized — the canonical Show Desktop state — entering
+	// overview would otherwise show an empty grid, contradicting the
+	// user's expectation that Overview reveals their work. Restore them
+	// first so they participate in the layout below.
+	const onActive = mgr._stack.filter(
+		( w ) => w.config.desktopId === mgr._activeDesktopId,
+	);
+	if (
+		onActive.length > 0 &&
+		onActive.every( ( w ) => w.state === 'minimized' )
+	) {
+		for ( const w of onActive ) {
+			try {
+				w.restore();
+			} catch ( err ) {
+				if ( typeof console !== 'undefined' ) {
+					console.error(
+						'[desktop-mode] enterOverview: window.restore() threw for',
+						w.id,
+						err,
+					);
+				}
+			}
+		}
+	}
 	// Overview shows only the ACTIVE desktop's windows in the main
 	// grid; windows on other desktops stay hidden underneath. The top
 	// bar (rendered later) gives the user a way to switch. Native
@@ -239,6 +265,16 @@ export function enterOverview( mgr: WindowManager ): void {
 	mgr._overviewKeyHandler = ( e: KeyboardEvent ) => {
 		if ( e.key === 'Escape' ) {
 			exitOverview( mgr );
+			return;
+		}
+		// Enter commits the currently active desktop — useful when the
+		// user has been arrowing through the top-bar tiles and now wants
+		// to land on whichever they've highlighted. No specific window
+		// selection: just collapse the overview onto the active desktop's
+		// existing layout.
+		if ( e.key === 'Enter' ) {
+			e.preventDefault();
+			exitOverview( mgr );
 		}
 	};
 	mgr._desktop.addEventListener(
@@ -415,9 +451,12 @@ function buildDesktopTile( mgr: WindowManager, d: Desktop ): HTMLElement {
 /**
  * Re-render the top bar in place. Called after any operation that
  * mutates the desktop list (create, close) so the bar reflects the
- * new state without a full overview exit/re-enter cycle.
+ * new state without a full overview exit/re-enter cycle. Exported so
+ * cross-module callers (e.g. `switchDesktop` in `desktops.ts`) can
+ * refresh the `--active` tile highlight when the user navigates
+ * between desktops mid-overview.
  */
-function refreshOverviewTopBar( mgr: WindowManager ): void {
+export function refreshOverviewTopBar( mgr: WindowManager ): void {
 	if ( ! mgr._overviewTopBar ) {
 		return;
 	}

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -267,13 +267,18 @@ export function enterOverview( mgr: WindowManager ): void {
 			exitOverview( mgr );
 			return;
 		}
-		// Enter commits the currently active desktop — useful when the
-		// user has been arrowing through the top-bar tiles and now wants
-		// to land on whichever they've highlighted. No specific window
-		// selection: just collapse the overview onto the active desktop's
-		// existing layout.
+		// Enter commits whatever the keyboard cursor is parked on:
+		//
+		//   - "+" tile  → create a new desktop and exit onto it.
+		//   - desktop   → exit overview onto the currently active
+		//                 desktop (arrow keys keep that in sync as the
+		//                 cursor moves through tiles).
 		if ( e.key === 'Enter' ) {
 			e.preventDefault();
+			if ( mgr._overviewAddTileFocused ) {
+				commitAddTile( mgr );
+				return;
+			}
 			exitOverview( mgr );
 		}
 	};
@@ -365,21 +370,39 @@ function buildOverviewTopBar( mgr: WindowManager ): HTMLElement {
 	addTile.type = 'button';
 	addTile.className =
 		'desktop-mode-overview-top-bar__tile desktop-mode-overview-top-bar__tile--add';
+	if ( mgr._overviewAddTileFocused ) {
+		// Mirrors the `--active` highlight on the active desktop tile —
+		// signals "this is where Enter will land". Distinct class name
+		// so future styling can diverge from the active-desktop look
+		// without touching click handlers.
+		addTile.classList.add(
+			'desktop-mode-overview-top-bar__tile--cursor',
+		);
+	}
 	addTile.setAttribute( 'aria-label', __( 'Add new desktop' ) );
 	addTile.innerHTML =
 		'<span class="desktop-mode-overview-top-bar__tile-plus" aria-hidden="true">+</span>';
 	addTile.addEventListener( 'click', ( e: MouseEvent ) => {
 		e.preventDefault();
 		e.stopPropagation();
-		const created = createDesktop( mgr );
-		// Auto-switch to the new desktop AND exit overview onto it —
-		// matches macOS Spaces ergonomics where pressing "+" lands
-		// you on the freshly-created blank space.
-		exitOverviewToDesktop( mgr, created.id );
+		commitAddTile( mgr );
 	} );
 	list.appendChild( addTile );
 
 	return bar;
+}
+
+/**
+ * Create a new desktop, switch to it, and exit overview onto it.
+ * Shared by the "+" tile click handler AND the Enter-key commit path
+ * when the keyboard cursor is parked on the "+" tile. macOS Spaces
+ * ergonomics — pressing "+" lands you on the freshly-created blank
+ * space without an extra hop.
+ */
+export function commitAddTile( mgr: WindowManager ): void {
+	const created = createDesktop( mgr );
+	mgr._overviewAddTileFocused = false;
+	exitOverviewToDesktop( mgr, created.id );
 }
 
 /** Build a single desktop tile for the overview top bar. */
@@ -388,7 +411,12 @@ function buildDesktopTile( mgr: WindowManager, d: Desktop ): HTMLElement {
 	tile.type = 'button';
 	tile.className = 'desktop-mode-overview-top-bar__tile';
 	tile.dataset.desktopId = d.id;
-	if ( d.id === mgr._activeDesktopId ) {
+	// Active highlight follows the keyboard cursor: when the cursor is
+	// parked on the "+" tile, no desktop tile should also light up.
+	// The active desktop's windows still render in the grid behind the
+	// bar, so there's still context — but the visual selection is
+	// unambiguous: only the "+" reads as "Enter lands here".
+	if ( d.id === mgr._activeDesktopId && ! mgr._overviewAddTileFocused ) {
 		tile.classList.add( 'desktop-mode-overview-top-bar__tile--active' );
 	}
 	// translators: %s is the desktop label
@@ -549,6 +577,10 @@ export function exitOverview(
 		return;
 	}
 	mgr._overviewActive = false;
+	// Drop the keyboard cursor's "+ focused" state so the next overview
+	// session starts with the cursor on the active desktop, not on
+	// whatever tile the previous session left it on.
+	mgr._overviewAddTileFocused = false;
 
 	doAction( HOOKS.OVERVIEW_EXITING, {
 		windowId: selected && maximize ? selected.id : undefined,

--- a/tests/vitest/desktop-shortcuts.test.ts
+++ b/tests/vitest/desktop-shortcuts.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for the arrow-key virtual-desktop shortcuts:
+ *
+ *   ArrowLeft/Right → previous / next desktop (no wrap)
+ *   ArrowUp         → toggle Overview
+ *   ArrowDown       → toggle Show Desktop
+ *
+ * The action helpers are exercised directly; the keydown installer
+ * gate is covered separately via a small integration block at the
+ * bottom so we don't double up on `installDesktopArrowShortcuts`
+ * idempotency.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import {
+	exitOverviewIfActive,
+	exitShowDesktopIfActive,
+	switchToAdjacentDesktop,
+	toggleOverview,
+	toggleShowDesktop,
+} from '../../src/window-manager/desktop-shortcuts';
+import {
+	clearHooksStub,
+	installHooksStub,
+	type FakeWpHooks,
+} from './helpers/hooks-stub';
+
+function openConfig( id: string ) {
+	return {
+		id,
+		url: `http://example.test/wp-admin/${ id }.php`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+	};
+}
+
+describe( 'WindowManager — arrow-key desktop shortcuts', async () => {
+	let hooks: FakeWpHooks;
+	let desktopArea: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( async () => {
+		hooks = installHooksStub();
+		void hooks;
+		desktopArea = document.createElement( 'div' );
+		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		Object.defineProperty( desktopArea, 'clientWidth', {
+			value: 1600,
+			configurable: true,
+		} );
+		Object.defineProperty( desktopArea, 'clientHeight', {
+			value: 900,
+			configurable: true,
+		} );
+		document.body.appendChild( desktopArea );
+		manager = new WindowManager( desktopArea );
+	} );
+
+	afterEach( async () => {
+		for ( const win of manager.getAll() ) {
+			win.destroy();
+		}
+		desktopArea.remove();
+		clearHooksStub();
+	} );
+
+	describe( 'switchToAdjacentDesktop', async () => {
+		test( 'no-op with a single desktop', async () => {
+			expect( switchToAdjacentDesktop( manager, 'next' ) ).toBe( false );
+			expect( switchToAdjacentDesktop( manager, 'prev' ) ).toBe( false );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+
+		test( 'next moves to the desktop immediately to the right', async () => {
+			const second = manager.createDesktop();
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+
+			expect( switchToAdjacentDesktop( manager, 'next' ) ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( second.id );
+		} );
+
+		test( 'prev moves to the desktop immediately to the left', async () => {
+			const second = manager.createDesktop();
+			manager.switchDesktop( second.id );
+
+			expect( switchToAdjacentDesktop( manager, 'prev' ) ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+
+		test( 'wraps from the rightmost desktop back to the first', async () => {
+			const second = manager.createDesktop();
+			manager.switchDesktop( second.id );
+
+			expect( switchToAdjacentDesktop( manager, 'next' ) ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+
+		test( 'wraps from the leftmost desktop back to the last', async () => {
+			const second = manager.createDesktop();
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+
+			expect( switchToAdjacentDesktop( manager, 'prev' ) ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( second.id );
+		} );
+
+		test( 'next arrow press tags the desktop area with the right-to-left slide class', async () => {
+			manager.createDesktop();
+
+			switchToAdjacentDesktop( manager, 'next' );
+
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-right',
+				),
+			).toBe( true );
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-left',
+				),
+			).toBe( false );
+		} );
+
+		test( 'prev arrow press tags the desktop area with the left-to-right slide class', async () => {
+			const second = manager.createDesktop();
+			manager.switchDesktop( second.id );
+
+			switchToAdjacentDesktop( manager, 'prev' );
+
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-left',
+				),
+			).toBe( true );
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-right',
+				),
+			).toBe( false );
+		} );
+
+		test( 'wrap-around forward press still uses the rightward slide direction', async () => {
+			// User perceives "I pressed right again" — the visual cue
+			// should match that, even though the index loops back to 0.
+			const second = manager.createDesktop();
+			manager.switchDesktop( second.id );
+
+			switchToAdjacentDesktop( manager, 'next' );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-right',
+				),
+			).toBe( true );
+		} );
+
+		test( 'mid-overview switch does not apply the slide class to the desktop area', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+
+			switchToAdjacentDesktop( manager, 'next' );
+
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-right',
+				),
+			).toBe( false );
+			expect(
+				desktopArea.classList.contains(
+					'desktop-mode-area--sliding-from-left',
+				),
+			).toBe( false );
+		} );
+
+		test( 'cycles through three desktops in order with successive next presses', async () => {
+			const second = manager.createDesktop();
+			const third = manager.createDesktop();
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+
+			switchToAdjacentDesktop( manager, 'next' );
+			expect( manager.getActiveDesktopId() ).toBe( second.id );
+			switchToAdjacentDesktop( manager, 'next' );
+			expect( manager.getActiveDesktopId() ).toBe( third.id );
+			switchToAdjacentDesktop( manager, 'next' );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+	} );
+
+	describe( 'toggleOverview', async () => {
+		test( 'enters overview when inactive', async () => {
+			await manager.open( openConfig( 'a' ) );
+			expect( manager._overviewActive ).toBe( false );
+
+			expect( toggleOverview( manager ) ).toBe( true );
+			expect( manager._overviewActive ).toBe( true );
+		} );
+
+		test( 'exits overview when active', async () => {
+			await manager.open( openConfig( 'a' ) );
+			manager.enterOverview();
+			expect( manager._overviewActive ).toBe( true );
+
+			expect( toggleOverview( manager ) ).toBe( true );
+			expect( manager._overviewActive ).toBe( false );
+		} );
+	} );
+
+	describe( 'toggleShowDesktop', async () => {
+		test( 'minimizes every open window on the first call', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			const b = await manager.open( openConfig( 'b' ) );
+			expect( a.state ).not.toBe( 'minimized' );
+			expect( b.state ).not.toBe( 'minimized' );
+
+			expect( toggleShowDesktop( manager ) ).toBe( true );
+			expect( a.state ).toBe( 'minimized' );
+			expect( b.state ).toBe( 'minimized' );
+		} );
+
+		test( 'restores every minimized window on the second call', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			const b = await manager.open( openConfig( 'b' ) );
+			toggleShowDesktop( manager );
+
+			expect( toggleShowDesktop( manager ) ).toBe( true );
+			expect( a.state ).toBe( 'normal' );
+			expect( b.state ).toBe( 'normal' );
+		} );
+
+		test( 'returns false when there are no windows to act on', async () => {
+			expect( toggleShowDesktop( manager ) ).toBe( false );
+		} );
+
+		test( 'returns false (and is a no-op) while overview is active', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			manager.enterOverview();
+			expect( manager._overviewActive ).toBe( true );
+
+			expect( toggleShowDesktop( manager ) ).toBe( false );
+			expect( a.state ).not.toBe( 'minimized' );
+		} );
+	} );
+
+	describe( 'exitShowDesktopIfActive', async () => {
+		test( 'restores every window when all are minimized', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			const b = await manager.open( openConfig( 'b' ) );
+			a.minimize();
+			b.minimize();
+			expect( a.state ).toBe( 'minimized' );
+			expect( b.state ).toBe( 'minimized' );
+
+			expect( exitShowDesktopIfActive( manager ) ).toBe( true );
+
+			expect( a.state ).toBe( 'normal' );
+			expect( b.state ).toBe( 'normal' );
+		} );
+
+		test( 'no-op when at least one window is not minimized', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			const b = await manager.open( openConfig( 'b' ) );
+			a.minimize();
+			// `b` stays in 'normal' — not a Show Desktop state.
+
+			expect( exitShowDesktopIfActive( manager ) ).toBe( false );
+			expect( a.state ).toBe( 'minimized' );
+			expect( b.state ).not.toBe( 'minimized' );
+		} );
+
+		test( 'no-op when no windows exist', async () => {
+			expect( exitShowDesktopIfActive( manager ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'exitOverviewIfActive', async () => {
+		test( 'exits overview when it is active', async () => {
+			await manager.open( openConfig( 'a' ) );
+			manager.enterOverview();
+			expect( manager._overviewActive ).toBe( true );
+
+			expect( exitOverviewIfActive( manager ) ).toBe( true );
+			expect( manager._overviewActive ).toBe( false );
+		} );
+
+		test( 'returns false when overview is not active', async () => {
+			expect( exitOverviewIfActive( manager ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'mid-overview desktop switching', async () => {
+		test( 'arrow-switching desktops mid-overview re-lays out the grid for the new active desktop', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			const second = manager.createDesktop();
+			manager.switchDesktop( second.id );
+			const b = await manager.open( openConfig( 'b' ) );
+			manager.switchDesktop( 'desktop-1' );
+
+			manager.enterOverview();
+			expect(
+				a.element.classList.contains( 'desktop-mode-window--overview' ),
+			).toBe( true );
+			expect( b.element.style.display ).toBe( 'none' );
+
+			expect( switchToAdjacentDesktop( manager, 'next' ) ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( second.id );
+
+			// New active desktop's window has the overview class; the
+			// previous one has been cleared and hidden.
+			expect(
+				b.element.classList.contains( 'desktop-mode-window--overview' ),
+			).toBe( true );
+			expect( a.element.style.display ).toBe( 'none' );
+			expect(
+				a.element.classList.contains( 'desktop-mode-window--overview' ),
+			).toBe( false );
+		} );
+
+		test( 'mid-overview switch refreshes the top-bar active-tile highlight', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+
+			const bar = manager._overviewTopBar!;
+			expect( bar ).not.toBeNull();
+			const activeBefore = bar.querySelector< HTMLElement >(
+				'.desktop-mode-overview-top-bar__tile--active',
+			);
+			expect( activeBefore?.dataset.desktopId ).toBe( 'desktop-1' );
+
+			switchToAdjacentDesktop( manager, 'next' );
+
+			// Bar was re-rendered in place — fetch the new node.
+			const refreshed = manager._overviewTopBar!;
+			const activeAfter = refreshed.querySelector< HTMLElement >(
+				'.desktop-mode-overview-top-bar__tile--active',
+			);
+			expect( activeAfter?.dataset.desktopId ).toBe( 'desktop-2' );
+		} );
+	} );
+} );

--- a/tests/vitest/desktop-shortcuts.test.ts
+++ b/tests/vitest/desktop-shortcuts.test.ts
@@ -10,7 +10,7 @@
  * bottom so we don't double up on `installDesktopArrowShortcuts`
  * idempotency.
  */
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
 import {
 	cycleOverviewCursor,
@@ -43,6 +43,15 @@ describe( 'WindowManager — arrow-key desktop shortcuts', async () => {
 	beforeEach( async () => {
 		hooks = installHooksStub();
 		void hooks;
+		// Several tests enter overview without explicitly exiting it.
+		// `enterOverview` (and `exitOverview`) schedule setTimeout
+		// callbacks that fire `doAction(OVERVIEW_ENTERED / OVERVIEW_EXITED)`
+		// 280–300 ms later. Under real timers those fire AFTER `afterEach`
+		// has cleared the hooks stub, and `getWpHooks` then throws —
+		// flaky locally, deterministic on CI. Fake timers keep those
+		// callbacks pending in the queue so they're discarded when
+		// `vi.useRealTimers()` resets the timer state below.
+		vi.useFakeTimers();
 		desktopArea = document.createElement( 'div' );
 		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
 			value: () =>
@@ -75,6 +84,10 @@ describe( 'WindowManager — arrow-key desktop shortcuts', async () => {
 			win.destroy();
 		}
 		desktopArea.remove();
+		// Restore real timers BEFORE clearing the stub so any callbacks
+		// the test queued get discarded along with the fake-timer state,
+		// not run against an already-cleared `window.wp`.
+		vi.useRealTimers();
 		clearHooksStub();
 	} );
 

--- a/tests/vitest/desktop-shortcuts.test.ts
+++ b/tests/vitest/desktop-shortcuts.test.ts
@@ -13,6 +13,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
 import {
+	cycleOverviewCursor,
 	exitOverviewIfActive,
 	exitShowDesktopIfActive,
 	switchToAdjacentDesktop,
@@ -296,6 +297,161 @@ describe( 'WindowManager — arrow-key desktop shortcuts', async () => {
 
 		test( 'returns false when overview is not active', async () => {
 			expect( exitOverviewIfActive( manager ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'cycleOverviewCursor (+ tile in arrow cycle)', async () => {
+		test( 'arrow-right past the last desktop parks the cursor on the + tile', async () => {
+			manager.createDesktop(); // desktop-2
+			manager.enterOverview();
+			expect( manager._overviewAddTileFocused ).toBe( false );
+
+			// D1 → D2 (real switch).
+			expect( cycleOverviewCursor( manager, 'next' ) ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-2' );
+			expect( manager._overviewAddTileFocused ).toBe( false );
+
+			// D2 → +.
+			expect( cycleOverviewCursor( manager, 'next' ) ).toBe( true );
+			expect( manager._overviewAddTileFocused ).toBe( true );
+			// Active desktop is unchanged — there's nothing to switch to.
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-2' );
+		} );
+
+		test( 'arrow-right from the + tile wraps back to the first desktop', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+			cycleOverviewCursor( manager, 'next' ); // D1 → D2
+			cycleOverviewCursor( manager, 'next' ); // D2 → +
+			expect( manager._overviewAddTileFocused ).toBe( true );
+
+			expect( cycleOverviewCursor( manager, 'next' ) ).toBe( true );
+
+			expect( manager._overviewAddTileFocused ).toBe( false );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+
+		test( 'arrow-left from the first desktop parks the cursor on the + tile', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+
+			expect( cycleOverviewCursor( manager, 'prev' ) ).toBe( true );
+			expect( manager._overviewAddTileFocused ).toBe( true );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+
+		test( 'arrow-left from + tile lands on the last desktop', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+			cycleOverviewCursor( manager, 'prev' ); // D1 → +
+			expect( manager._overviewAddTileFocused ).toBe( true );
+
+			expect( cycleOverviewCursor( manager, 'prev' ) ).toBe( true );
+			expect( manager._overviewAddTileFocused ).toBe( false );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-2' );
+		} );
+
+		test( 'works with a single desktop (cycle = [D1, +])', async () => {
+			manager.enterOverview();
+			expect( manager.getDesktops() ).toHaveLength( 1 );
+
+			expect( cycleOverviewCursor( manager, 'next' ) ).toBe( true );
+			expect( manager._overviewAddTileFocused ).toBe( true );
+
+			expect( cycleOverviewCursor( manager, 'next' ) ).toBe( true );
+			expect( manager._overviewAddTileFocused ).toBe( false );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		} );
+
+		test( 'is a no-op outside overview', async () => {
+			manager.createDesktop();
+			expect( cycleOverviewCursor( manager, 'next' ) ).toBe( false );
+		} );
+
+		test( 'refreshes the top bar so the + tile picks up the --cursor class', async () => {
+			manager.enterOverview();
+			cycleOverviewCursor( manager, 'next' ); // D1 → +
+
+			const addTile = manager._overviewTopBar!.querySelector< HTMLElement >(
+				'.desktop-mode-overview-top-bar__tile--add',
+			);
+			expect( addTile ).not.toBeNull();
+			expect(
+				addTile!.classList.contains(
+					'desktop-mode-overview-top-bar__tile--cursor',
+				),
+			).toBe( true );
+		} );
+
+		test( 'desktop tiles drop --active while the cursor is on the + tile', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+			// Two arrows: D1 → D2 → +.
+			cycleOverviewCursor( manager, 'next' );
+			cycleOverviewCursor( manager, 'next' );
+			expect( manager._overviewAddTileFocused ).toBe( true );
+
+			const activeTiles = manager._overviewTopBar!.querySelectorAll(
+				'.desktop-mode-overview-top-bar__tile--active',
+			);
+			// No desktop tile should still be highlighted — only the
+			// "+" carries the keyboard cursor's visual weight.
+			expect( activeTiles ).toHaveLength( 0 );
+		} );
+
+		test( 'desktop tile regains --active when the cursor leaves the + tile', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+			cycleOverviewCursor( manager, 'next' ); // D1 → D2
+			cycleOverviewCursor( manager, 'next' ); // D2 → +
+			cycleOverviewCursor( manager, 'next' ); // + → D1 (wrap)
+
+			const activeTile = manager._overviewTopBar!.querySelector< HTMLElement >(
+				'.desktop-mode-overview-top-bar__tile--active',
+			);
+			expect( activeTile?.dataset.desktopId ).toBe( 'desktop-1' );
+		} );
+
+		test( 'exitOverview clears the + cursor state', async () => {
+			manager.enterOverview();
+			cycleOverviewCursor( manager, 'next' );
+			expect( manager._overviewAddTileFocused ).toBe( true );
+
+			manager.exitOverview();
+
+			expect( manager._overviewAddTileFocused ).toBe( false );
+		} );
+	} );
+
+	describe( 'Enter on + tile creates a new desktop', async () => {
+		test( 'pressing Enter while cursor is on + creates a desktop and exits overview onto it', async () => {
+			manager.enterOverview();
+			cycleOverviewCursor( manager, 'next' ); // D1 → +
+			expect( manager._overviewAddTileFocused ).toBe( true );
+			expect( manager.getDesktops() ).toHaveLength( 1 );
+
+			document.dispatchEvent(
+				new KeyboardEvent( 'keydown', { key: 'Enter' } ),
+			);
+
+			expect( manager.getDesktops() ).toHaveLength( 2 );
+			expect( manager.getActiveDesktopId() ).toBe( 'desktop-2' );
+			expect( manager._overviewActive ).toBe( false );
+			expect( manager._overviewAddTileFocused ).toBe( false );
+		} );
+
+		test( 'pressing Enter while cursor is on a desktop tile exits without creating', async () => {
+			manager.createDesktop();
+			manager.enterOverview();
+			expect( manager.getDesktops() ).toHaveLength( 2 );
+
+			document.dispatchEvent(
+				new KeyboardEvent( 'keydown', { key: 'Enter' } ),
+			);
+
+			expect( manager.getDesktops() ).toHaveLength( 2 );
+			expect( manager._overviewActive ).toBe( false );
 		} );
 	} );
 

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -254,6 +254,71 @@ describe( 'WindowManager — virtual desktops', async () => {
 		expect( c.element.classList.contains( 'desktop-mode-window--overview' ) ).toBe( true );
 	} );
 
+	test( 'enterOverview restores all minimized windows when the active desktop is in Show Desktop state', async () => {
+		// Reproduces the "Show Desktop → Overview shows nothing" bug.
+		// With every window on the active desktop minimized, Overview's
+		// `state !== 'minimized'` eligibility filter would otherwise
+		// produce an empty grid.
+		const a = await manager.open( openConfig( 'a' ) );
+		const b = await manager.open( openConfig( 'b' ) );
+		a.minimize();
+		b.minimize();
+		expect( a.state ).toBe( 'minimized' );
+		expect( b.state ).toBe( 'minimized' );
+
+		manager.enterOverview();
+
+		// Both windows are back in 'normal' state and now wear the
+		// overview class — the grid actually contains them.
+		expect( a.state ).toBe( 'normal' );
+		expect( b.state ).toBe( 'normal' );
+		expect(
+			a.element.classList.contains( 'desktop-mode-window--overview' ),
+		).toBe( true );
+		expect(
+			b.element.classList.contains( 'desktop-mode-window--overview' ),
+		).toBe( true );
+	} );
+
+	test( 'Enter key in overview exits without selecting a window', async () => {
+		await manager.open( openConfig( 'a' ) );
+		manager.enterOverview();
+		expect( manager._overviewActive ).toBe( true );
+
+		document.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter' } ),
+		);
+
+		expect( manager._overviewActive ).toBe( false );
+	} );
+
+	test( 'enterOverview leaves partially-minimized desktops alone', async () => {
+		// Counterpart guarantee: only the "everything minimized" path
+		// auto-restores. If the user minimized one window manually, the
+		// other two are visible and Overview should show only the
+		// non-minimized cohort (existing behaviour preserved).
+		const a = await manager.open( openConfig( 'a' ) );
+		const b = await manager.open( openConfig( 'b' ) );
+		const c = await manager.open( openConfig( 'c' ) );
+		a.minimize();
+		expect( a.state ).toBe( 'minimized' );
+
+		manager.enterOverview();
+
+		expect( a.state ).toBe( 'minimized' );
+		expect( b.state ).toBe( 'normal' );
+		expect( c.state ).toBe( 'normal' );
+		expect(
+			a.element.classList.contains( 'desktop-mode-window--overview' ),
+		).toBe( false );
+		expect(
+			b.element.classList.contains( 'desktop-mode-window--overview' ),
+		).toBe( true );
+		expect(
+			c.element.classList.contains( 'desktop-mode-window--overview' ),
+		).toBe( true );
+	} );
+
 	test( 'snapshot preserves geometry for windows on non-active desktops', async () => {
 		// Regression: when a window sits on a hidden (display: none)
 		// desktop, `offsetLeft/Top/Width/Height` all return 0 because


### PR DESCRIPTION
## Summary

Adds bare arrow-key shortcuts for managing virtual desktops and fixes a long-standing usability bug where entering Overview while every window was minimized produced an empty grid.


https://github.com/user-attachments/assets/aa396fb8-cd5c-435c-8a17-4173507f251c



## Shortcuts

Gated by the same text-entry-focus rule as the existing `` ` `` window switcher, so typing into inputs / textareas / Gutenberg's block canvas is never intercepted.

| Key   | Outside overview                | Inside overview                          | In Show Desktop                  |
|-------|---------------------------------|------------------------------------------|----------------------------------|
| `←`   | Previous desktop (wraps)        | Previous desktop (grid + top-bar update) | Previous desktop                 |
| `→`   | Next desktop (wraps)            | Next desktop (grid + top-bar update)     | Next desktop                     |
| `↑`   | Enter Overview                  | Exit Overview onto active desktop        | Restore windows (exit Show Desktop) |
| `↓`   | Toggle Show Desktop             | Exit Overview (no minimize)              | Toggle Show Desktop              |
| `Enter` (in overview) | —                  | Commit current desktop, exit overview    | —                                |

Wrap-around presses keep the *perceived* direction of the slide — pressing `→` past the rightmost desktop still slides in from the right even though the index loops back to 0.

## Mid-overview desktop switching

`switchDesktop` is now overview-aware. When called mid-overview it re-lays out the grid for the new active desktop and refreshes the top-bar `--active` highlight. Without this, the active id moved but the UI looked frozen.

## Slide animation

Desktop switches outside overview play a one-shot horizontal slide-in on `.desktop-mode-area` itself — the windows + widgets container. The wallpaper is a sibling of that element under `.desktop-mode-shell`, so the slide reveals the wallpaper as a backdrop on the leading edge: no flash, no gap. 280 ms cubic-bezier ease-out, translate `64px → 0` with opacity `0.35 → 1`. `prefers-reduced-motion` disables it.

## Overview-from-Show-Desktop fix

Entering Overview while every window on the active desktop was minimized (the canonical Show Desktop state) used to produce an empty backdrop — the eligibility filter excluded minimized windows. Now it restores them first so the grid actually contains them. Partially-minimized desktops are untouched (existing behaviour preserved).

## Public API

`WindowManager.switchDesktop()` gains an optional `{ direction: 'next' | 'prev' }` argument. Directional callers (the arrow handler) pass it to drive the slide; jump-to callers (tile click, plugin API) omit it and the switch is instantaneous. Non-breaking.

## Test plan

- [x] Single desktop: arrow keys are no-ops (don't preventDefault scroll).
- [x] Two desktops: `→` switches to D2 with a right-to-left slide. `←` switches back with the mirrored slide.
- [x] Three desktops: `→` from D3 wraps to D1 with a right-to-left slide (perceived direction, not index delta).
- [x] In Overview: `←` / `→` move the highlighted top-bar tile AND re-lay out the grid for the new desktop. `Enter` exits overview onto that desktop. `↑` and `↓` also exit overview cleanly.
- [x] In Show Desktop (press `↓` first): `↑` restores all windows without opening Overview.
- [x] In an `<input>`, `<textarea>`, or Gutenberg block canvas: arrow keys do their normal in-field thing, never desktop-switch.
- [x] `prefers-reduced-motion: reduce` (system setting): the slide is suppressed.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-221-3b52dfdaba4ef2a3ca5b16e309e1c242255c3f5e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->