### PR TITLE
feat: implement loading skeletons and staggered animations for file tiles

### DIFF
--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -120,6 +120,37 @@
 	-webkit-user-select: none;
 	user-select: none;
 	touch-action: none;
+	/* Soft fade-in on mount — each tile carries its own randomised
+	 * `--enter-delay` / `--enter-duration` (set inline by the
+	 * tile builder), so a freshly-painted grid reads as a cascade
+	 * rather than a synchronised pop-in. Both values land in the
+	 * decimal-of-a-second range — perceivable, never sluggish.
+	 *
+	 * `backwards` keeps the tile invisible during its delay so the
+	 * cascade is honest; the animation runs once, leaves the tile
+	 * at its static `opacity: 1`, and never re-fires from later
+	 * state changes (drag, hover, drop-target).
+	 */
+	animation: desktop-mode-file-tile-enter
+		var( --desktop-mode-file-tile-enter-duration, 0.4s )
+		ease-out
+		var( --desktop-mode-file-tile-enter-delay, 0s )
+		backwards;
+}
+
+@keyframes desktop-mode-file-tile-enter {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-file-tile {
+		animation: none;
+	}
 }
 
 .desktop-mode-file-tile:hover,

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -259,14 +259,76 @@
 	height: 1px;
 }
 
-.desktop-mode-my-wordpress__spinner {
+/* Tile-grid loading skeleton — placeholder tiles that mimic the
+ * icon + label shape of what's about to load. We dropped the
+ * spinning WordPress mark here because it read as an alien
+ * affordance inside the file-explorer surface; a skeleton signals
+ * "tiles are landing in these slots" instead of "the system is
+ * busy doing something opaque."
+ *
+ * Each placeholder is parented directly to the positioned canvas
+ * (`__canvas--positioned`) and `position: absolute` at the
+ * (left, top) the next real tile will occupy — see
+ * `layout.peekNextCells()` and `showLoadingSkeleton()` in
+ * `src/my-wordpress/index.ts`. Per-tile shimmer delay and label
+ * width are inlined so a row of placeholders reads as a cascade,
+ * not a uniform pulse.
+ *
+ * Tile dimensions mirror the real `.desktop-mode-file-tile` width
+ * so a placeholder sits cleanly in the cell its successor will
+ * inherit.
+ */
+.desktop-mode-my-wordpress__skeleton-tile {
+	position: absolute;
 	display: flex;
-	justify-content: center;
-	padding: 16px;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	width: 88px;
+	padding: 8px 4px;
+	box-sizing: border-box;
+	pointer-events: none;
 }
 
-.desktop-mode-my-wordpress__spinner--first {
-	padding: 32px;
+.desktop-mode-my-wordpress__skeleton-icon,
+.desktop-mode-my-wordpress__skeleton-label {
+	background: linear-gradient(
+		90deg,
+		var( --desktop-mode-skeleton-low, rgba( 0, 0, 0, 0.05 ) ) 0%,
+		var( --desktop-mode-skeleton-high, rgba( 0, 0, 0, 0.13 ) ) 50%,
+		var( --desktop-mode-skeleton-low, rgba( 0, 0, 0, 0.05 ) ) 100%
+	);
+	background-size: 200% 100%;
+	animation: desktop-mode-my-wordpress-skeleton-shimmer 1.4s ease-in-out
+		var( --desktop-mode-skeleton-delay, 0s ) infinite;
+}
+
+.desktop-mode-my-wordpress__skeleton-icon {
+	width: 44px;
+	height: 44px;
+	border-radius: 10px;
+}
+
+.desktop-mode-my-wordpress__skeleton-label {
+	width: 72%;
+	height: 10px;
+	border-radius: 4px;
+}
+
+@keyframes desktop-mode-my-wordpress-skeleton-shimmer {
+	from {
+		background-position: 200% 0;
+	}
+	to {
+		background-position: -200% 0;
+	}
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-my-wordpress__skeleton-icon,
+	.desktop-mode-my-wordpress__skeleton-label {
+		animation: none;
+	}
 }
 
 /* ----- Right pane: preview ----- */
@@ -296,6 +358,18 @@
 	min-height: 320px;
 	padding: 32px;
 	box-sizing: border-box;
+}
+
+/* Preview-pane loader — same scale curve as the tile-grid first
+ * spinner and the window-loading overlay. The JS used to hard-code
+ * `size="128"`, which set an inline `--wpd-spinner-size` that
+ * overrode any CSS knob; the size attribute is now omitted so this
+ * rule is the single source of truth for both the My WordPress
+ * preview and the wallpaper file-preview pane (which reuses this
+ * class deliberately).
+ */
+.desktop-mode-my-wordpress__preview-loading wpd-spinner {
+	--wpd-spinner-size: clamp( 96px, 14vw, 192px );
 }
 
 .desktop-mode-my-wordpress__article {

--- a/src/desktop-files/file-tile.ts
+++ b/src/desktop-files/file-tile.ts
@@ -23,6 +23,7 @@ import { renderIcon } from '../icon';
 import { resolve as resolveFileType } from './registry';
 import { openFile } from './open';
 import { showToast } from '../toast';
+import { applyTileEntryStagger } from '../utils';
 import type { RestPlacementShape } from './rest';
 
 /** CSS class on every tile. */
@@ -161,6 +162,8 @@ export function buildTile( placement: RestPlacementShape, folderId: number ): HT
 		lock.setAttribute( 'aria-hidden', 'true' );
 		tile.appendChild( lock );
 	}
+
+	applyTileEntryStagger( tile );
 
 	doAction( 'desktop-mode.files.tile-rendered', { tile, placement } );
 	return tile;

--- a/src/desktop-files/preview.ts
+++ b/src/desktop-files/preview.ts
@@ -732,7 +732,10 @@ function renderLoading(): HTMLElement {
 	const wrap = document.createElement( 'div' );
 	wrap.className = 'desktop-mode-my-wordpress__preview-loading';
 	const spinner = document.createElement( 'wpd-spinner' );
-	spinner.setAttribute( 'size', '128' );
+	// Size driven by the shared
+	// `.desktop-mode-my-wordpress__preview-loading wpd-spinner` rule
+	// in `assets/css/my-wordpress.css` so the wallpaper-preview loader
+	// stays in lockstep with the My WordPress one.
 	wrap.appendChild( spinner );
 	return wrap;
 }

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -85,6 +85,7 @@ import type {
 	UserFootprint,
 	UserListItem,
 } from './types';
+import { applyTileEntryStagger } from '../utils';
 import '../ui/components/wpd-button/wpd-button';
 import '../ui/components/wpd-context-menu/wpd-context-menu';
 import '../ui/components/wpd-spinner/wpd-spinner';
@@ -537,6 +538,8 @@ function buildIconTile( spec: {
 	label.textContent = spec.label;
 	tile.appendChild( label );
 
+	applyTileEntryStagger( tile );
+
 	return tile;
 }
 
@@ -690,7 +693,7 @@ function renderEntityList(
 		ctx.loading = true;
 		const nextPage = ctx.page + 1;
 		const isFirst = nextPage === 1;
-		showSpinner( tiles, isFirst );
+		showLoadingSkeleton( tiles, ctx.layout, isFirst );
 		try {
 			const result = await fetchEntityList( entity, {
 				page: nextPage,
@@ -699,7 +702,7 @@ function renderEntityList(
 			ctx.page = nextPage;
 			ctx.totalPages = result.totalPages;
 			ctx.total = result.total;
-			hideSpinner( tiles );
+			hideLoadingSkeleton( tiles );
 			if ( result.items.length === 0 && isFirst ) {
 				renderListEmpty( tiles, entity );
 				ctx.done = true;
@@ -715,7 +718,7 @@ function renderEntityList(
 			}
 			repaintListStatus();
 		} catch ( err ) {
-			hideSpinner( tiles );
+			hideLoadingSkeleton( tiles );
 			const msg =
 				err instanceof Error ? err.message : __( 'Unknown error.', 'desktop-mode' );
 			renderListError( tiles, msg );
@@ -776,25 +779,91 @@ function renderListError( host: HTMLElement, message: string ): void {
 	host.appendChild( err );
 }
 
-function showSpinner( host: HTMLElement, isFirst: boolean ): void {
-	const id = isFirst
-		? 'desktop-mode-my-wordpress__spinner--first'
-		: 'desktop-mode-my-wordpress__spinner--more';
-	if ( host.querySelector( `[data-spinner="${ id }"]` ) ) {
-		return;
-	}
-	const wrap = document.createElement( 'div' );
-	wrap.dataset.spinner = id;
-	wrap.className = isFirst
-		? 'desktop-mode-my-wordpress__spinner desktop-mode-my-wordpress__spinner--first'
-		: 'desktop-mode-my-wordpress__spinner';
-	const spinner = document.createElement( 'wpd-spinner' );
-	wrap.appendChild( spinner );
-	host.appendChild( wrap );
+/**
+ * Build a single placeholder tile that mirrors the real
+ * `.desktop-mode-file-tile` silhouette (icon block + label rect).
+ * The icon and label fill animate as a shimmering gradient — see
+ * `desktop-mode-my-wordpress-skeleton-shimmer` in
+ * `assets/css/my-wordpress.css`.
+ */
+function buildSkeletonTile( variant: 'first' | 'more' ): HTMLElement {
+	const tile = document.createElement( 'div' );
+	tile.className = 'desktop-mode-my-wordpress__skeleton-tile';
+	tile.dataset.loadingSkeleton = variant;
+	tile.setAttribute( 'aria-hidden', 'true' );
+	const icon = document.createElement( 'div' );
+	icon.className = 'desktop-mode-my-wordpress__skeleton-icon';
+	tile.appendChild( icon );
+	const label = document.createElement( 'div' );
+	label.className = 'desktop-mode-my-wordpress__skeleton-label';
+	tile.appendChild( label );
+	return tile;
 }
 
-function hideSpinner( host: HTMLElement ): void {
-	host.querySelectorAll( '[data-spinner]' ).forEach( ( n ) => n.remove() );
+/**
+ * Paint placeholder tiles into the same column-major slots the next
+ * batch of real tiles will fill. Two contexts share the helper:
+ *
+ *   - `first` — empty canvas, first page about to land. Eight
+ *     placeholders cover the top rows of the pane so the user sees
+ *     a partial grid forming rather than a single floating mark.
+ *   - `more` — infinite-scroll, a few more pages coming. Four
+ *     placeholders extend the existing grid from the next free
+ *     cell, so the user can scroll past the real tiles and see
+ *     exactly where the next ones will arrive.
+ *
+ * Each placeholder is `position: absolute` at the layout-derived
+ * (x, y) and carries `data-loading-skeleton="<variant>"`, both for
+ * dedup-on-show and bulk removal in `hideLoadingSkeleton`. We also
+ * bump the canvas's `min-height` so any skeleton placed past the
+ * last real tile is reachable by the scroll container — without
+ * this, "more"-variant skeletons painted into the next row sit in
+ * unscrollable territory and the user never sees them.
+ *
+ * Label widths and shimmer delays vary across a small palette so a
+ * row of placeholders reads as a soft cascade, not a uniform pulse.
+ */
+const SKELETON_LABEL_WIDTHS = [ 72, 60, 82, 48, 70 ];
+const SKELETON_DELAY_STEPS = [ 0, 0.18, 0.36, 0.54, 0.12 ];
+
+function showLoadingSkeleton(
+	host: HTMLElement,
+	layout: TileLayout,
+	isFirst: boolean,
+): void {
+	const variant: 'first' | 'more' = isFirst ? 'first' : 'more';
+	if ( host.querySelector( `[data-loading-skeleton="${ variant }"]` ) ) {
+		return;
+	}
+	const count = isFirst ? 8 : 4;
+	const cells = layout.peekNextCells( count );
+	let maxBottom = parseFloat( host.style.minHeight || '0' );
+	cells.forEach( ( cell, i ) => {
+		const tile = buildSkeletonTile( variant );
+		tile.style.left = `${ cell.x }px`;
+		tile.style.top = `${ cell.y }px`;
+		tile.style.setProperty(
+			'--desktop-mode-skeleton-delay',
+			`${ SKELETON_DELAY_STEPS[ i % SKELETON_DELAY_STEPS.length ] }s`,
+		);
+		const label = tile.querySelector< HTMLElement >(
+			'.desktop-mode-my-wordpress__skeleton-label',
+		);
+		if ( label ) {
+			label.style.width = `${
+				SKELETON_LABEL_WIDTHS[ i % SKELETON_LABEL_WIDTHS.length ]
+			}%`;
+		}
+		host.appendChild( tile );
+		maxBottom = Math.max( maxBottom, cell.y + TILE_H );
+	} );
+	host.style.minHeight = `${ maxBottom + TILE_PAD }px`;
+}
+
+function hideLoadingSkeleton( host: HTMLElement ): void {
+	host.querySelectorAll( '[data-loading-skeleton]' ).forEach( ( n ) =>
+		n.remove(),
+	);
 }
 
 function buildEntityTile(
@@ -1067,13 +1136,17 @@ async function renderPreview(
  * Replace the preview pane content with a centered, large spinner.
  * Reused by every code path that fetches preview data
  * (post select, sub-list selection, detail-view post hydration).
+ *
+ * Size is driven by the `--wpd-spinner-size` custom property on
+ * `.desktop-mode-my-wordpress__preview-loading wpd-spinner` (see
+ * `assets/css/my-wordpress.css`) so a single CSS knob retunes
+ * every preview spinner without rebuilding the JS bundle.
  */
 function showPreviewLoading( host: HTMLElement ): void {
 	host.replaceChildren();
 	const loading = document.createElement( 'div' );
 	loading.className = 'desktop-mode-my-wordpress__preview-loading';
 	const spinner = document.createElement( 'wpd-spinner' );
-	spinner.setAttribute( 'size', '128' );
 	loading.appendChild( spinner );
 	host.appendChild( loading );
 }
@@ -1242,18 +1315,19 @@ function renderDetail(
 	state.teardown.push( () => menu.dispose() );
 	state.teardown.push( () => layout.dispose() );
 
-	// Show a placeholder tile-grid spinner while we load the post.
-	const spinnerWrap = document.createElement( 'div' );
-	spinnerWrap.className = 'desktop-mode-my-wordpress__spinner';
-	spinnerWrap.appendChild( document.createElement( 'wpd-spinner' ) );
-	tiles.appendChild( spinnerWrap );
+	// Tile-grid skeleton while we load the post. Same `first`
+	// treatment the entity-list view uses for its first page load:
+	// placeholder tiles fill the slots the related-entity folder
+	// tiles are about to land in, so the user sees the spatial
+	// shape of what's coming instead of a disembodied spinner mark.
+	showLoadingSkeleton( tiles, layout, true );
 
 	void ( async () => {
 		let detail: EntityDetail;
 		try {
 			detail = await fetchEntityDetail( entity, postId );
 		} catch ( err ) {
-			tiles.removeChild( spinnerWrap );
+			hideLoadingSkeleton( tiles );
 			renderListError(
 				tiles,
 				err instanceof Error
@@ -1272,7 +1346,7 @@ function renderDetail(
 			return;
 		}
 
-		tiles.removeChild( spinnerWrap );
+		hideLoadingSkeleton( tiles );
 
 		const select = createTileSelector();
 
@@ -1546,10 +1620,10 @@ function renderSubList(
 	state.teardown.push( () => menu.dispose() );
 	state.teardown.push( () => layout.dispose() );
 
-	const spinnerWrap = document.createElement( 'div' );
-	spinnerWrap.className = 'desktop-mode-my-wordpress__spinner';
-	spinnerWrap.appendChild( document.createElement( 'wpd-spinner' ) );
-	tiles.appendChild( spinnerWrap );
+	// Empty-canvas skeleton for the sub-list pane — same `first`
+	// treatment the entity-list and detail views use, so every
+	// "tiles are about to appear" state reads with the same shape.
+	showLoadingSkeleton( tiles, layout, true );
 
 	paintStatus(
 		state,
@@ -1569,7 +1643,7 @@ function renderSubList(
 		try {
 			items = await loadSubItems( entity, postId, relation );
 		} catch ( err ) {
-			tiles.removeChild( spinnerWrap );
+			hideLoadingSkeleton( tiles );
 			renderListError(
 				tiles,
 				err instanceof Error
@@ -1587,7 +1661,7 @@ function renderSubList(
 			return;
 		}
 
-		tiles.removeChild( spinnerWrap );
+		hideLoadingSkeleton( tiles );
 
 		paintStatus(
 			state,
@@ -3370,7 +3444,7 @@ function renderUserEntityList(
 		ctx.loading = true;
 		const nextPage = ctx.page + 1;
 		const isFirst = nextPage === 1;
-		showSpinner( tiles, isFirst );
+		showLoadingSkeleton( tiles, ctx.layout, isFirst );
 		try {
 			const result = await fetchUserList( entity, {
 				page: nextPage,
@@ -3379,7 +3453,7 @@ function renderUserEntityList(
 			ctx.page = nextPage;
 			ctx.totalPages = result.totalPages;
 			ctx.total = result.total;
-			hideSpinner( tiles );
+			hideLoadingSkeleton( tiles );
 			if ( result.items.length === 0 && isFirst ) {
 				renderListEmptyMessage(
 					tiles,
@@ -3400,7 +3474,7 @@ function renderUserEntityList(
 			}
 			repaintListStatus();
 		} catch ( err ) {
-			hideSpinner( tiles );
+			hideLoadingSkeleton( tiles );
 			const msg =
 				err instanceof Error
 					? err.message
@@ -4841,6 +4915,14 @@ interface TileLayout {
 	sort: ( mode: SortMode ) => void;
 	/** Re-flow auto-placed tiles to the current canvas width. */
 	reflow: () => void;
+	/**
+	 * Compute the next N column-major free cells in canvas-pixel
+	 * coords WITHOUT claiming them in the layout's occupied set.
+	 * Used by the loading skeleton so placeholders land in the same
+	 * slots the next batch of real tiles will fill — keeping the
+	 * "where the next icons go" promise honest.
+	 */
+	peekNextCells: ( count: number ) => Array< { x: number; y: number } >;
 	dispose: () => void;
 }
 
@@ -5126,6 +5208,47 @@ function createTileLayout( host: HTMLElement, scope: string ): TileLayout {
 		resizeObserver.observe( host );
 	}
 
+	/**
+	 * Walk the same column-major auto-flow `place()` uses, starting
+	 * from the cells the layout already considers occupied, and
+	 * return the next `count` (x, y) coordinates without recording
+	 * a claim. The loading-skeleton helper uses this so a 4-page
+	 * "load more" run paints 4 placeholders into the four cells the
+	 * next four real tiles will actually fill — wrapping to the
+	 * next row when the current one runs out.
+	 */
+	const peekNextCells = (
+		count: number,
+	): Array< { x: number; y: number } > => {
+		const width =
+			host.clientWidth > 0
+				? host.clientWidth
+				: TILE_PAD + 5 * TILE_W;
+		const cols = Math.max(
+			1,
+			Math.floor( ( width - TILE_PAD ) / TILE_W ),
+		);
+		const taken = new Set< string >( occupied );
+		const out: Array< { x: number; y: number } > = [];
+		for ( let i = 0; i < count; i += 1 ) {
+			for ( let n = 0; ; n += 1 ) {
+				const col = n % cols;
+				const row = Math.floor( n / cols );
+				const key = `${ col },${ row }`;
+				if ( taken.has( key ) ) {
+					continue;
+				}
+				taken.add( key );
+				out.push( {
+					x: TILE_PAD + col * TILE_W,
+					y: TILE_PAD + row * TILE_H,
+				} );
+				break;
+			}
+		}
+		return out;
+	};
+
 	return {
 		host,
 		scope,
@@ -5133,6 +5256,7 @@ function createTileLayout( host: HTMLElement, scope: string ): TileLayout {
 		commit,
 		sort,
 		reflow,
+		peekNextCells,
 		dispose: () => {
 			resizeObserver?.disconnect();
 			resizeObserver = null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,6 +117,33 @@ export function sanitizeClassName( value: string ): string {
 }
 
 /**
+ * Apply a randomized fade-in cadence to a freshly-built file/icon
+ * tile. The animation itself is declared in CSS on
+ * `.desktop-mode-file-tile`; this helper writes the two CSS
+ * custom properties that drive the per-tile stagger:
+ *
+ *   - `--desktop-mode-file-tile-enter-delay`: 0 → 0.25s
+ *   - `--desktop-mode-file-tile-enter-duration`: 0.3 → 0.55s
+ *
+ * Both ranges sit in the decimal-of-a-second window, so a grid of
+ * tiles reads as a soft cascade rather than a uniform pop-in.
+ *
+ * Call once per tile, immediately after creating the element.
+ *
+ * @public
+ */
+export function applyTileEntryStagger( tile: HTMLElement ): void {
+	tile.style.setProperty(
+		'--desktop-mode-file-tile-enter-delay',
+		`${ ( Math.random() * 0.25 ).toFixed( 3 ) }s`,
+	);
+	tile.style.setProperty(
+		'--desktop-mode-file-tile-enter-duration',
+		`${ ( 0.3 + Math.random() * 0.25 ).toFixed( 3 ) }s`,
+	);
+}
+
+/**
  * Returns a comparable key for two admin URLs so equality checks work
  * regardless of the chromeless flag, the portal flag, or trailing
  * slashes. Used by the window class to match submenu tabs against


### PR DESCRIPTION
Improved loading indicator in My WordPress and added some randomness to it :)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-222-1c82dc3660b3412834d7108f243a4b9bf842d0bc.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->