### PR TITLE
feat(admin-bar): shortcuts popover, dock-style tooltips, reorder

### DIFF
--- a/assets/js/admin-bar.js
+++ b/assets/js/admin-bar.js
@@ -248,4 +248,214 @@
 			document.dispatchEvent( new CustomEvent( 'desktop-mode-open-bug-report' ) );
 		} );
 	}
+
+	// Keyboard Shortcuts button — toggles a floating popover anchored
+	// under the button, styled like the Arrange submenu. Content is
+	// passed in via `cfg.shortcuts` (translated server-side in PHP).
+	wireShortcutsPopover( document.getElementById( 'wp-admin-bar-desktop-help' ), cfg.shortcuts );
+
+	// Custom tooltips for the icon-only admin-bar buttons. The native
+	// `title` attribute renders a slow, OS-styled tooltip that conflicts
+	// with our dock-style custom tooltip; we swap each `title` to
+	// `data-desktop-tooltip` + `aria-label` so screen readers still see
+	// the label but the visual tooltip is fully ours.
+	wireTooltipsFor( [
+		'wp-admin-bar-desktop-fullscreen',
+		'wp-admin-bar-desktop-help',
+		'wp-admin-bar-desktop-bug-report',
+		'wp-admin-bar-desktop-layout-menu',
+	] );
+
+	/**
+	 * Re-anchors a native `title` attribute to a `data-desktop-tooltip`
+	 * data attribute on the same node, plus mirrors it to `aria-label`
+	 * so assistive tech keeps the description. Pure-CSS tooltip then
+	 * renders from the data attribute via the `[data-desktop-tooltip]
+	 * .ab-item::after` rule in admin-bar.php.
+	 */
+	function wireTooltipsFor( ids ) {
+		for ( var i = 0; i < ids.length; i++ ) {
+			var node = document.getElementById( ids[ i ] );
+			if ( ! node ) continue;
+			var link = node.querySelector( '.ab-item' );
+			if ( ! link ) continue;
+			var label = link.getAttribute( 'title' );
+			if ( ! label ) continue;
+			link.removeAttribute( 'title' );
+			link.setAttribute( 'data-desktop-tooltip', label );
+			if ( ! link.hasAttribute( 'aria-label' ) ) {
+				link.setAttribute( 'aria-label', label );
+			}
+		}
+	}
+
+	function wireShortcutsPopover( btn, data ) {
+		if ( ! btn || ! data ) {
+			return;
+		}
+		var anchor = btn.querySelector( '.ab-item' ) || btn;
+		var popover = buildShortcutsPopover( data );
+		btn.appendChild( popover );
+
+		var isOpen = false;
+		function open() {
+			if ( isOpen ) return;
+			isOpen = true;
+			popover.classList.add( 'is-open' );
+			btn.classList.add( 'is-open' );
+			document.addEventListener( 'mousedown', onDocMouseDown, true );
+			document.addEventListener( 'keydown', onKey, true );
+		}
+		function close() {
+			if ( ! isOpen ) return;
+			isOpen = false;
+			popover.classList.remove( 'is-open' );
+			btn.classList.remove( 'is-open' );
+			document.removeEventListener( 'mousedown', onDocMouseDown, true );
+			document.removeEventListener( 'keydown', onKey, true );
+		}
+		function onDocMouseDown( e ) {
+			if ( btn.contains( e.target ) ) return;
+			close();
+		}
+		function onKey( e ) {
+			if ( e.key === 'Escape' ) {
+				e.stopPropagation();
+				close();
+			}
+		}
+
+		anchor.addEventListener( 'click', function( e ) {
+			e.preventDefault();
+			e.stopPropagation();
+			isOpen ? close() : open();
+		} );
+		// Swallow stray clicks inside the popover so they don't bubble
+		// up to admin-bar handlers (and so the popover stays open while
+		// the user reads it).
+		popover.addEventListener( 'mousedown', function( e ) {
+			e.stopPropagation();
+		} );
+		popover.addEventListener( 'click', function( e ) {
+			e.stopPropagation();
+		} );
+	}
+
+	function buildShortcutsPopover( data ) {
+		var root = document.createElement( 'div' );
+		root.className = 'desktop-mode-shortcuts-popover';
+		root.setAttribute( 'role', 'dialog' );
+		if ( data.title ) {
+			root.setAttribute( 'aria-label', data.title );
+		}
+
+		if ( data.contextual ) {
+			root.appendChild( buildShortcutsTable( data.contextual ) );
+		}
+		if ( data.general ) {
+			root.appendChild( buildShortcutsList( data.general ) );
+		}
+		return root;
+	}
+
+	function buildShortcutsTable( section ) {
+		var wrap = document.createElement( 'section' );
+		wrap.className = 'desktop-mode-shortcuts-popover__section';
+
+		if ( section.heading ) {
+			var h = document.createElement( 'h3' );
+			h.className = 'desktop-mode-shortcuts-popover__heading';
+			h.textContent = section.heading;
+			wrap.appendChild( h );
+		}
+
+		var table = document.createElement( 'table' );
+		table.className = 'desktop-mode-shortcuts-popover__table';
+
+		var thead = document.createElement( 'thead' );
+		var headRow = document.createElement( 'tr' );
+		[ 'key', 'outside', 'inside', 'showDesktop' ].forEach( function( col ) {
+			var th = document.createElement( 'th' );
+			th.scope = 'col';
+			th.textContent = section.headers && section.headers[ col ] ? section.headers[ col ] : '';
+			headRow.appendChild( th );
+		} );
+		thead.appendChild( headRow );
+		table.appendChild( thead );
+
+		var tbody = document.createElement( 'tbody' );
+		( section.rows || [] ).forEach( function( row ) {
+			var tr = document.createElement( 'tr' );
+
+			var keyCell = document.createElement( 'td' );
+			keyCell.className = 'desktop-mode-shortcuts-popover__key-cell';
+			keyCell.appendChild( renderKeys( row.keys || [] ) );
+			if ( row.note ) {
+				var note = document.createElement( 'span' );
+				note.className = 'desktop-mode-shortcuts-popover__note';
+				note.textContent = ' ' + row.note;
+				keyCell.appendChild( note );
+			}
+			tr.appendChild( keyCell );
+
+			[ 'outside', 'inside', 'showDesktop' ].forEach( function( col ) {
+				var td = document.createElement( 'td' );
+				td.textContent = row[ col ] || '—';
+				tr.appendChild( td );
+			} );
+
+			tbody.appendChild( tr );
+		} );
+		table.appendChild( tbody );
+		wrap.appendChild( table );
+
+		return wrap;
+	}
+
+	function buildShortcutsList( section ) {
+		var wrap = document.createElement( 'section' );
+		wrap.className = 'desktop-mode-shortcuts-popover__section';
+
+		if ( section.heading ) {
+			var h = document.createElement( 'h3' );
+			h.className = 'desktop-mode-shortcuts-popover__heading';
+			h.textContent = section.heading;
+			wrap.appendChild( h );
+		}
+
+		var list = document.createElement( 'ul' );
+		list.className = 'desktop-mode-shortcuts-popover__list';
+		( section.items || [] ).forEach( function( item ) {
+			var li = document.createElement( 'li' );
+			li.className = 'desktop-mode-shortcuts-popover__item';
+			li.appendChild( renderKeys( item.keys || [] ) );
+			var desc = document.createElement( 'span' );
+			desc.className = 'desktop-mode-shortcuts-popover__description';
+			desc.textContent = item.description || '';
+			li.appendChild( desc );
+			list.appendChild( li );
+		} );
+		wrap.appendChild( list );
+
+		return wrap;
+	}
+
+	function renderKeys( keys ) {
+		var span = document.createElement( 'span' );
+		span.className = 'desktop-mode-shortcuts-popover__keys';
+		keys.forEach( function( key, idx ) {
+			if ( idx > 0 ) {
+				var plus = document.createElement( 'span' );
+				plus.className = 'desktop-mode-shortcuts-popover__plus';
+				plus.textContent = '+';
+				plus.setAttribute( 'aria-hidden', 'true' );
+				span.appendChild( plus );
+			}
+			var kbd = document.createElement( 'kbd' );
+			kbd.className = 'desktop-mode-shortcuts-popover__kbd';
+			kbd.textContent = key;
+			span.appendChild( kbd );
+		} );
+		return span;
+	}
 } )();

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -64,59 +64,11 @@ function desktop_mode_admin_bar_toggle( $wp_admin_bar ) {
 			array(
 				'parent' => 'top-secondary',
 				'id'     => 'desktop-fullscreen',
-				'title'  => '<span class="ab-icon dashicons dashicons-fullscreen-alt" aria-hidden="true"></span>'
-					. '<span class="ab-label">' . esc_html__( 'Fullscreen', 'desktop-mode' ) . '</span>',
+				'title'  => '<span class="ab-icon dashicons dashicons-fullscreen-alt" aria-hidden="true"></span>',
 				'href'   => '#',
 				'meta'   => array(
 					'class'    => 'desktop-fullscreen-btn',
 					'title'    => __( 'Enter fullscreen', 'desktop-mode' ),
-					'tabindex' => 0,
-				),
-			)
-		);
-	}
-
-	// "Report a bug" trigger — shown only when desktop mode is active.
-	// Clicking dispatches a `desktop-mode-open-bug-report` document
-	// CustomEvent that the shell listens for and answers by opening the
-	// Bug Report native window. PHP doesn't know the JS side exists; the
-	// event lets us add the button without coupling to any specific
-	// shell module.
-	if ( $is_active ) {
-		$wp_admin_bar->add_node(
-			array(
-				'parent' => 'top-secondary',
-				'id'     => 'desktop-bug-report',
-				'title'  => '<span class="ab-icon dashicons dashicons-buddicons-replies" aria-hidden="true"></span>'
-					. '<span class="ab-label">' . esc_html__( 'Report a bug', 'desktop-mode' ) . '</span>',
-				'href'   => '#',
-				'meta'   => array(
-					'class'    => 'desktop-bug-report-btn',
-					'title'    => __( 'Open the Bug Report window', 'desktop-mode' ),
-					'tabindex' => 0,
-				),
-			)
-		);
-	}
-
-	// AI Assistant trigger — shown when desktop mode is active AND the
-	// current user has AI features configured. Clicking (or pressing
-	// Cmd+K anywhere) opens the spotlight-style AI overlay.
-	if ( $is_active && function_exists( 'desktop_mode_ai_is_enabled' ) && desktop_mode_ai_is_enabled( get_current_user_id() ) ) {
-		// Use dashicons-admin-comments (speech bubble) — same rendering
-		// path as the toggle + arrange buttons, no SVG / HTML parsing
-		// issues in the admin-bar context. The ⌘K badge is added via
-		// a CSS ::after on the label so it never touches the DOM.
-		$wp_admin_bar->add_node(
-			array(
-				'parent' => 'top-secondary',
-				'id'     => 'desktop-ai-assistant',
-				'title'  => '<span class="ab-icon dashicons dashicons-admin-comments" aria-hidden="true"></span>'
-					. '<span class="ab-label">' . esc_html__( 'Ask AI', 'desktop-mode' ) . '</span>',
-				'href'   => '#',
-				'meta'   => array(
-					'class'    => 'desktop-ai-btn',
-					'title'    => __( 'Open AI Assistant (Cmd+K)', 'desktop-mode' ),
 					'tabindex' => 0,
 				),
 			)
@@ -128,13 +80,17 @@ function desktop_mode_admin_bar_toggle( $wp_admin_bar ) {
 	// admin, which has no windows to arrange). Parent renders as a
 	// dashicon with a hover-opened submenu; each child is routed to
 	// `wp.desktop.windowManager.*` by the inline JS.
+	//
+	// Sits next to Fullscreen so the two shell-state actions group
+	// visually. Ask AI, then the help/meta cluster (Keyboard shortcuts
+	// + Report a bug) follow, with the help/meta pair anchored to the
+	// far right of the secondary bar next to the user identity menu.
 	if ( $is_active ) {
 		$wp_admin_bar->add_node(
 			array(
 				'parent' => 'top-secondary',
 				'id'     => 'desktop-layout-menu',
-				'title'  => '<span class="ab-icon dashicons dashicons-grid-view" aria-hidden="true"></span>'
-					. '<span class="ab-label">' . esc_html__( 'Arrange', 'desktop-mode' ) . '</span>',
+				'title'  => '<span class="ab-icon dashicons dashicons-grid-view" aria-hidden="true"></span>',
 				'href'   => '#',
 				'meta'   => array(
 					'title'    => __( 'Arrange windows', 'desktop-mode' ),
@@ -275,6 +231,74 @@ function desktop_mode_admin_bar_toggle( $wp_admin_bar ) {
 			}
 		}
 	}
+
+	// AI Assistant trigger — shown when desktop mode is active AND the
+	// current user has AI features configured. Clicking (or pressing
+	// Cmd+K anywhere) opens the spotlight-style AI overlay.
+	if ( $is_active && function_exists( 'desktop_mode_ai_is_enabled' ) && desktop_mode_ai_is_enabled( get_current_user_id() ) ) {
+		// Use dashicons-admin-comments (speech bubble) — same rendering
+		// path as the toggle + arrange buttons, no SVG / HTML parsing
+		// issues in the admin-bar context. The ⌘K badge is added via
+		// a CSS ::after on the label so it never touches the DOM.
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'top-secondary',
+				'id'     => 'desktop-ai-assistant',
+				'title'  => '<span class="ab-icon dashicons dashicons-admin-comments" aria-hidden="true"></span>'
+					. '<span class="ab-label">' . esc_html__( 'Ask AI', 'desktop-mode' ) . '</span>',
+				'href'   => '#',
+				'meta'   => array(
+					'class'    => 'desktop-ai-btn',
+					'title'    => __( 'Open AI Assistant (Cmd+K)', 'desktop-mode' ),
+					'tabindex' => 0,
+				),
+			)
+		);
+	}
+
+	// "Keyboard shortcuts" trigger — shown only when desktop mode is
+	// active. Dispatches `desktop-mode-open-help` on click; the shell
+	// answers by opening the Keyboard Shortcuts reference window.
+	if ( $is_active ) {
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'top-secondary',
+				'id'     => 'desktop-help',
+				'title'  => '<span class="ab-icon desktop-mode-keyboard-icon" aria-hidden="true"></span>',
+				'href'   => '#',
+				'meta'   => array(
+					'class'    => 'desktop-help-btn',
+					'title'    => __( 'Keyboard shortcuts', 'desktop-mode' ),
+					'tabindex' => 0,
+				),
+			)
+		);
+	}
+
+	// "Report a bug" trigger — shown only when desktop mode is active.
+	// Clicking dispatches a `desktop-mode-open-bug-report` document
+	// CustomEvent that the shell listens for and answers by opening the
+	// Bug Report native window. PHP doesn't know the JS side exists; the
+	// event lets us add the button without coupling to any specific
+	// shell module. Anchored to the far right of the secondary bar so
+	// the meta/help cluster (Keyboard shortcuts + Report a bug) sits
+	// next to the user identity menu — matches the convention used by
+	// most SaaS products (Help / "?" at the user-menu corner).
+	if ( $is_active ) {
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'top-secondary',
+				'id'     => 'desktop-bug-report',
+				'title'  => '<span class="ab-icon dashicons dashicons-buddicons-replies" aria-hidden="true"></span>',
+				'href'   => '#',
+				'meta'   => array(
+					'class'    => 'desktop-bug-report-btn',
+					'title'    => __( 'Open the Bug Report window', 'desktop-mode' ),
+					'tabindex' => 0,
+				),
+			)
+		);
+	}
 }
 add_action( 'admin_bar_menu', 'desktop_mode_admin_bar_toggle', 190 );
 
@@ -296,7 +320,8 @@ function desktop_mode_enqueue_toggle_assets() {
 		#wpadminbar #wp-admin-bar-desktop-layout-menu > .ab-item,
 		#wpadminbar #wp-admin-bar-desktop-ai-assistant > .ab-item,
 		#wpadminbar #wp-admin-bar-desktop-fullscreen > .ab-item,
-		#wpadminbar #wp-admin-bar-desktop-bug-report > .ab-item {
+		#wpadminbar #wp-admin-bar-desktop-bug-report > .ab-item,
+		#wpadminbar #wp-admin-bar-desktop-help > .ab-item {
 			display: inline-flex;
 			align-items: center;
 			gap: 6px;
@@ -305,7 +330,8 @@ function desktop_mode_enqueue_toggle_assets() {
 		#wpadminbar #wp-admin-bar-desktop-layout-menu .ab-icon,
 		#wpadminbar #wp-admin-bar-desktop-ai-assistant .ab-icon,
 		#wpadminbar #wp-admin-bar-desktop-fullscreen .ab-icon,
-		#wpadminbar #wp-admin-bar-desktop-bug-report .ab-icon {
+		#wpadminbar #wp-admin-bar-desktop-bug-report .ab-icon,
+		#wpadminbar #wp-admin-bar-desktop-help .ab-icon {
 			float: none;
 			margin: 0;
 			padding: 0;
@@ -341,8 +367,7 @@ function desktop_mode_enqueue_toggle_assets() {
 			color: inherit;
 		}
 		@media screen and (max-width: 782px) {
-			#wp-admin-bar-desktop-mode-toggle .ab-label,
-			#wp-admin-bar-desktop-layout-menu .ab-label {
+			#wp-admin-bar-desktop-mode-toggle .ab-label {
 				display: none;
 			}
 		}
@@ -439,11 +464,6 @@ function desktop_mode_enqueue_toggle_assets() {
 		body.desktop-mode-browser-fs #wp-admin-bar-desktop-bug-report {
 			display: none;
 		}
-		@media screen and (max-width: 782px) {
-			#wp-admin-bar-desktop-fullscreen .ab-label {
-				display: none;
-			}
-		}
 
 		/* Bug Report admin-bar button — same dashicons rendering pattern
 		   as the toggle. dashicons-buddicons-replies is a speech bubble
@@ -455,15 +475,187 @@ function desktop_mode_enqueue_toggle_assets() {
 			-moz-osx-font-smoothing: grayscale;
 		}
 		#wp-admin-bar-desktop-bug-report .ab-icon.dashicons::before {
-			/* dashicons-buddicons-replies */
-			content: "\f465";
+			/* dashicons-buddicons-replies — same glyph as the dock tile so
+			   the two surfaces (admin-bar + dock) match. */
+			content: "\f451";
 			top: 0;
 			position: static;
 		}
-		@media screen and (max-width: 782px) {
-			#wp-admin-bar-desktop-bug-report .ab-label {
-				display: none;
-			}
+
+		/* Keyboard shortcuts admin-bar button. Dashicons has no keyboard
+		   glyph, so we paint a small inline SVG via CSS `mask` with
+		   `background-color: currentColor` — that way the icon inherits
+		   the admin-bar text color across every WP profile scheme
+		   without us hardcoding a fill. */
+		#wp-admin-bar-desktop-help .ab-icon.desktop-mode-keyboard-icon {
+			background-color: currentColor;
+			-webkit-mask: url( "data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'black\' stroke-width=\'1.6\' stroke-linecap=\'round\' stroke-linejoin=\'round\'><rect x=\'2.5\' y=\'6\' width=\'19\' height=\'12\' rx=\'2.2\'/><path d=\'M6 10h0M10 10h0M14 10h0M18 10h0M6 14h0M10 14h4M18 14h0\'/></svg>" ) no-repeat center / 20px 20px;
+			        mask: url( "data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'black\' stroke-width=\'1.6\' stroke-linecap=\'round\' stroke-linejoin=\'round\'><rect x=\'2.5\' y=\'6\' width=\'19\' height=\'12\' rx=\'2.2\'/><path d=\'M6 10h0M10 10h0M14 10h0M18 10h0M6 14h0M10 14h4M18 14h0\'/></svg>" ) no-repeat center / 20px 20px;
+		}
+
+		/* Keyboard-shortcuts floating popover — anchored under the
+		   keyboard button. Styled to match the Arrange submenu (light
+		   bg on the otherwise-dark admin bar, soft shadow, rounded
+		   corners). Built dynamically in admin-bar.js from translated
+		   content shipped via `desktopModeAdminBar.shortcuts`. */
+		#wpadminbar #wp-admin-bar-desktop-help {
+			position: relative;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover {
+			display: none;
+			position: absolute;
+			top: 100%;
+			right: 0;
+			margin-top: 0;
+			padding: 12px 14px;
+			min-width: 460px;
+			max-width: min( 90vw, 720px );
+			background: var( --desktop-mode-window-bg, #fff );
+			color: var( --desktop-mode-text, #1d2327 );
+			border: 1px solid var( --desktop-mode-window-border, #c3c4c7 );
+			border-radius: 8px;
+			box-shadow: 0 8px 24px rgba( 0, 0, 0, 0.18 ),
+				0 2px 6px rgba( 0, 0, 0, 0.08 );
+			z-index: 99999;
+			font-size: 12px;
+			line-height: 1.4;
+			text-align: left;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover.is-open {
+			display: block;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__section + .desktop-mode-shortcuts-popover__section {
+			margin-top: 12px;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__heading {
+			margin: 0 0 6px;
+			padding: 0;
+			font-size: 11px;
+			font-weight: 600;
+			letter-spacing: 0.04em;
+			text-transform: uppercase;
+			color: var( --desktop-mode-muted-fg, #50575e );
+			line-height: 1.2;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__table {
+			width: 100%;
+			border-collapse: collapse;
+			color: inherit;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__table th,
+		#wpadminbar .desktop-mode-shortcuts-popover__table td {
+			padding: 6px 8px;
+			vertical-align: middle;
+			text-align: left;
+			border-bottom: 1px solid rgba( 0, 0, 0, 0.06 );
+			color: inherit;
+			font-weight: 400;
+			font-size: 12px;
+			line-height: 1.4;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__table th {
+			font-weight: 600;
+			font-size: 11px;
+			color: var( --desktop-mode-muted-fg, #50575e );
+			letter-spacing: 0.02em;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__table tbody tr:last-child td {
+			border-bottom: none;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__key-cell {
+			white-space: nowrap;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__note {
+			color: var( --desktop-mode-muted-fg, #50575e );
+			font-size: 11px;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__list {
+			margin: 0;
+			padding: 0;
+			list-style: none;
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__item {
+			display: grid;
+			grid-template-columns: 120px 1fr;
+			align-items: center;
+			gap: 12px;
+			padding: 4px 8px;
+			border-radius: 4px;
+			background: rgba( 0, 0, 0, 0.03 );
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__keys {
+			display: inline-flex;
+			align-items: center;
+			gap: 4px;
+			flex-wrap: wrap;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__kbd {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			min-width: 22px;
+			height: 20px;
+			padding: 0 5px;
+			border: 1px solid rgba( 0, 0, 0, 0.18 );
+			border-bottom-width: 2px;
+			border-radius: 4px;
+			background: #fff;
+			color: var( --desktop-mode-text, #1d2327 );
+			font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+			font-size: 11px;
+			font-weight: 600;
+			line-height: 1;
+			white-space: nowrap;
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__plus {
+			font-size: 10px;
+			color: var( --desktop-mode-muted-fg, #50575e );
+		}
+		#wpadminbar .desktop-mode-shortcuts-popover__description {
+			color: inherit;
+		}
+
+		/* Dock-style custom tooltip for icon-only admin-bar buttons.
+		   admin-bar.js moves the native `title` to `data-desktop-tooltip`
+		   so the OS delayed tooltip never competes with this one. Floats
+		   below the button, dark pill with white text — visually
+		   identical to the dock tooltip pattern. */
+		#wpadminbar .ab-item[ data-desktop-tooltip ] {
+			position: relative;
+		}
+		#wpadminbar .ab-item[ data-desktop-tooltip ]::after {
+			content: attr( data-desktop-tooltip );
+			position: absolute;
+			top: 100%;
+			left: 50%;
+			margin-top: 4px;
+			transform: translateX( -50% ) translateY( 4px );
+			padding: 6px 12px;
+			background: rgba( 0, 0, 0, 0.85 );
+			color: #fff;
+			font-size: 12px;
+			font-weight: 400;
+			line-height: 1.4;
+			white-space: nowrap;
+			border-radius: 6px;
+			pointer-events: none;
+			opacity: 0;
+			transition: opacity 0.15s ease, transform 0.15s ease;
+			z-index: 100000;
+		}
+		#wpadminbar .ab-item[ data-desktop-tooltip ]:hover::after,
+		#wpadminbar .ab-item[ data-desktop-tooltip ]:focus-visible::after {
+			opacity: 1;
+			transform: translateX( -50% ) translateY( 0 );
+		}
+		/* When the keyboard-shortcuts popover is open, suppress the
+		   tooltip on its own anchor so the two never stack on top of
+		   each other. */
+		#wpadminbar #wp-admin-bar-desktop-help.is-open .ab-item[ data-desktop-tooltip ]::after {
+			opacity: 0;
 		}
 
 		/* Arrange submenu — aligned visually with the <wpd-menu> component
@@ -564,6 +756,83 @@ function desktop_mode_enqueue_toggle_assets() {
 					'exitFullscreen'  => __( 'Exit fullscreen', 'desktop-mode' ),
 					'enterTitle'      => __( 'Enter fullscreen', 'desktop-mode' ),
 					'exitTitle'       => __( 'Exit fullscreen', 'desktop-mode' ),
+				),
+				/*
+				 * Keyboard-shortcuts popover content. Translated once on
+				 * the server and shipped to admin-bar.js, which renders
+				 * the popover anchored under the keyboard button.
+				 *
+				 * `contextual` is a small table that distinguishes the
+				 * three modes the shortcuts operate in (Outside Overview,
+				 * Inside Overview, Show Desktop). `general` is a flat
+				 * list for shortcuts whose behaviour doesn't shift by
+				 * mode.
+				 */
+				'shortcuts'  => array(
+					'title'      => __( 'Keyboard shortcuts', 'desktop-mode' ),
+					'contextual' => array(
+						'heading' => __( 'Desktops & Overview', 'desktop-mode' ),
+						'headers' => array(
+							'key'         => __( 'Key', 'desktop-mode' ),
+							'outside'     => __( 'Outside overview', 'desktop-mode' ),
+							'inside'      => __( 'Inside overview', 'desktop-mode' ),
+							'showDesktop' => __( 'In Show Desktop', 'desktop-mode' ),
+						),
+						'rows'    => array(
+							array(
+								'keys'        => array( '←' ),
+								'outside'     => __( 'Previous desktop (wraps)', 'desktop-mode' ),
+								'inside'      => __( 'Previous desktop (grid + top-bar update)', 'desktop-mode' ),
+								'showDesktop' => __( 'Previous desktop', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( '→' ),
+								'outside'     => __( 'Next desktop (wraps)', 'desktop-mode' ),
+								'inside'      => __( 'Next desktop (grid + top-bar update)', 'desktop-mode' ),
+								'showDesktop' => __( 'Next desktop', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( '↑' ),
+								'outside'     => __( 'Enter Overview', 'desktop-mode' ),
+								'inside'      => __( 'Exit Overview onto active desktop', 'desktop-mode' ),
+								'showDesktop' => __( 'Restore windows (exit Show Desktop)', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( '↓' ),
+								'outside'     => __( 'Toggle Show Desktop', 'desktop-mode' ),
+								'inside'      => __( 'Exit Overview (no minimize)', 'desktop-mode' ),
+								'showDesktop' => __( 'Toggle Show Desktop', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( 'Enter' ),
+								'note'        => __( '(in overview)', 'desktop-mode' ),
+								'outside'     => '—',
+								'inside'      => __( 'Commit current desktop, exit overview', 'desktop-mode' ),
+								'showDesktop' => '—',
+							),
+						),
+					),
+					'general'    => array(
+						'heading' => __( 'Windows & palette', 'desktop-mode' ),
+						'items'   => array(
+							array(
+								'keys'        => array( '`' ),
+								'description' => __( 'Cycle to the next window on the active desktop.', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( 'Shift', '`' ),
+								'description' => __( 'Cycle to the previous window on the active desktop.', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( '⌘/Ctrl', 'K' ),
+								'description' => __( 'Open the command palette / Ask AI overlay.', 'desktop-mode' ),
+							),
+							array(
+								'keys'        => array( 'Esc' ),
+								'description' => __( 'Exit Overview (or Snap Overview) without changing window state.', 'desktop-mode' ),
+							),
+						),
+					),
 				),
 			)
 		) . ';',

--- a/src/window-manager/switcher.ts
+++ b/src/window-manager/switcher.ts
@@ -106,9 +106,22 @@ let installed = false;
  * SELECT, checkbox / radio / button INPUTs are treated as non-text:
  * they don't accept character input, so stealing `` ` `` from them
  * is fine.
+ *
+ * Shadow-DOM gotcha: when focus lands on an input INSIDE an open
+ * shadow root (every `<wpd-*>` component does this — `Component`
+ * defaults `static shadow = true`), `doc.activeElement` returns the
+ * host element, not the inner input. A naïve `instanceof
+ * HTMLInputElement` check would miss it and the gate would say "not
+ * text" while the user is typing — bare arrow / `` ` `` then fires.
+ * We walk through each open shadow root's own `activeElement` until
+ * we land on the real focused leaf. Closed shadow roots stop the
+ * loop on their own (their `activeElement` is `null` from outside).
  */
 export function isTextEntryFocus( doc: Document ): boolean {
-	const el = doc.activeElement as HTMLElement | null;
+	let el: Element | null = doc.activeElement;
+	while ( el && el.shadowRoot && el.shadowRoot.activeElement ) {
+		el = el.shadowRoot.activeElement;
+	}
 	if ( ! el ) {
 		return false;
 	}
@@ -138,7 +151,7 @@ export function isTextEntryFocus( doc: Document ): boolean {
 		] );
 		return textTypes.has( el.type );
 	}
-	if ( el.isContentEditable === true ) {
+	if ( el instanceof HTMLElement && el.isContentEditable === true ) {
 		return true;
 	}
 	// Fallback for environments (jsdom) that don't implement

--- a/tests/vitest/switcher.test.ts
+++ b/tests/vitest/switcher.test.ts
@@ -177,5 +177,48 @@ describe( 'WindowManager — window switcher (cycleFocus)', async () => {
 			btn.focus();
 			expect( isTextEntryFocus( document ) ).toBe( false );
 		} );
+
+		test( 'returns true when a text INPUT inside an open shadow root is focused (wpd-* host)', async () => {
+			// All <wpd-*> components attach an open shadow root, so when
+			// the inner <input> takes focus, `document.activeElement`
+			// reports the HOST, not the input. The gate must walk into
+			// the shadow root so it still classifies the focus as text.
+			const host = mount( document.createElement( 'div' ) );
+			const shadow = host.attachShadow( { mode: 'open' } );
+			const input = document.createElement( 'input' );
+			input.type = 'text';
+			shadow.appendChild( input );
+			input.focus();
+			expect( document.activeElement ).toBe( host );
+			expect( isTextEntryFocus( document ) ).toBe( true );
+		} );
+
+		test( 'returns true when a TEXTAREA is focused two shadow roots deep', async () => {
+			// Components occasionally nest a child component inside their
+			// own shadow root. The walk must follow the chain, not stop
+			// after the first hop.
+			const outer = mount( document.createElement( 'div' ) );
+			const outerShadow = outer.attachShadow( { mode: 'open' } );
+			const innerHost = document.createElement( 'div' );
+			outerShadow.appendChild( innerHost );
+			const innerShadow = innerHost.attachShadow( { mode: 'open' } );
+			const textarea = document.createElement( 'textarea' );
+			innerShadow.appendChild( textarea );
+			textarea.focus();
+			expect( document.activeElement ).toBe( outer );
+			expect( isTextEntryFocus( document ) ).toBe( true );
+		} );
+
+		test( 'returns false when a non-text element (button) inside a shadow root is focused', async () => {
+			// Walking into the shadow root must still respect element
+			// type — a button there is a button, not a text-entry.
+			const host = mount( document.createElement( 'div' ) );
+			const shadow = host.attachShadow( { mode: 'open' } );
+			const btn = document.createElement( 'button' );
+			shadow.appendChild( btn );
+			btn.focus();
+			expect( document.activeElement ).toBe( host );
+			expect( isTextEntryFocus( document ) ).toBe( false );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Admin bar now reads as a row of icons matching the dock, with a keyboard-shortcuts popover, dock-style tooltips on every icon, and a purpose-grouped reorder. Bundled fix: the text-entry gate now walks shadow roots, so typing into `<wpd-*>` inputs no longer triggers the new arrow-key desktop shortcuts.

<img width="3206" height="2432" alt="CleanShot 2026-05-15 at 17 51 39@2x" src="https://github.com/user-attachments/assets/725f645d-2729-4be6-8752-f321f17671b0" />


## What changed in the admin bar

**Icon-only buttons.** Fullscreen, Report a bug, and Arrange drop their text labels. Hover surfaces the new dock-style tooltip instead.

**Bug-report glyph fix.** The inline CSS was forcing `\f465` (dashicons-email, an envelope) under a `dashicons-buddicons-replies` class. The admin bar therefore showed a different icon than the dock tile. Use the real `\f451` so the two surfaces match.

**Keyboard shortcuts popover.** New admin-bar entry with a custom inline-SVG keyboard icon (dashicons has no keyboard glyph). Clicking toggles a floating popover anchored under the button, styled like the Arrange submenu: white background, soft shadow, rounded corners. Closes on click-outside or `Esc`. Content is translated server-side via `desktopModeAdminBar.shortcuts` and covers:

- The desktop / overview arrow-key table (`←` / `→` / `↑` / `↓` / `Enter`) with the three columns from the spec: Outside overview, Inside overview, In Show Desktop.
- Cross-mode shortcuts: backtick, Shift+backtick, `⌘/Ctrl+K`, `Esc`.

**Dock-style tooltips.** admin-bar.js rewrites each icon button's native `title` to `data-desktop-tooltip` and mirrors it to `aria-label`. A CSS `::after` pseudo-element renders the dark pill below the button, identical visual to the dock. The tooltip on the keyboard-shortcuts anchor is suppressed while its popover is open so the two never stack.

**Reorder by purpose.** Left to right in the secondary admin bar:

| Group | Items |
|---|---|
| Mode toggle (escape hatch) | Switch to Classic Admin |
| Shell state | Fullscreen, Arrange |
| Primary action | Ask AI |
| Help / meta (anchored next to user identity) | Keyboard shortcuts, Report a bug |

This matches the convention most SaaS products use for Help / "?" near the user-menu corner.

## Bundled fix: `isTextEntryFocus` and shadow DOM

Every `<wpd-*>` component attaches an open shadow root. When focus lands on an inner `<input>` or `<textarea>`, `document.activeElement` returns the host element, not the leaf, so `instanceof HTMLInputElement` returned `false` and the gate classified the host as non-text. Bare backtick (window switcher) and the new arrow-key desktop shortcuts (PR #221) therefore fired while the user was typing into shell-side inputs: OS Settings AI tab API-key input, Plugins window search box, the Open URL dialog, posts-window filters, etc.

`isTextEntryFocus` now walks through each open shadow root's own `activeElement` before the existing INPUT / TEXTAREA / contenteditable checks. Closed shadow roots stop the walk on their own (their `activeElement` is `null` from outside). The iframe / Gutenberg case is unaffected — focus is the `<iframe>` element itself, caught by the existing `HTMLIFrameElement` branch.

## Test plan

- 3 new vitest cases in `tests/vitest/switcher.test.ts`: single-level shadow input (positive), two-level nested shadow textarea (positive, walks the chain), button-in-shadow negative.
- Full vitest suite: 1278 tests pass (1275 before, plus the 3 above).
- Manual: in the desktop shell, open OS Settings → AI, focus the API-key input, press arrow keys — desktops should NOT switch. Repeat in Plugins search, Open URL dialog. Gutenberg / Dashboard iframes were already covered by the iframe branch.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-223-7f691423dbffd852bef97a6e9c0363225d1366ec.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->