### PR TITLE
Add Featured Plugins View and Ribbon Component

### DIFF
--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -97,6 +97,53 @@
 	pointer-events: none;
 }
 
+/*
+ * Live drop-cell preview. A soft outline that hovers at the cell
+ * the dropped tile will land in, so the user can predict where the
+ * grid snap will place it before releasing. Positioned absolutely
+ * inside the files layer; `translate3d` updated from JS on every
+ * pointermove while a desktop-file drag hovers the canvas.
+ *
+ * The tile dimensions are baked into `grid.ts` (88 × 96 visual,
+ * 96 × 110 cell pitch). The outline matches the cell pitch — slightly
+ * larger than the tile — so the highlight reads as "this slot" rather
+ * than "this tile."
+ *
+ * @since 0.20.0
+ */
+.desktop-mode-files-drop-preview {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 88px;
+	height: 96px;
+	pointer-events: none;
+	box-sizing: border-box;
+	border-radius: 12px;
+	background: var(
+		--desktop-mode-drop-preview-bg,
+		rgba( 34, 113, 177, 0.08 )
+	);
+	border: 2px dashed
+		var(
+			--desktop-mode-drop-preview-border,
+			rgba( 34, 113, 177, 0.55 )
+		);
+	transition: transform 90ms ease-out;
+	will-change: transform;
+	/* Sit BELOW tiles so a tile being dragged over the cell isn't
+	 * visually clipped by the dashed outline; the outline still reads
+	 * because the tile is semi-transparent during drag (`--dragging`
+	 * sets `opacity: 0.4`). */
+	z-index: 0;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.desktop-mode-files-drop-preview {
+		transition: none;
+	}
+}
+
 .desktop-mode-file-tile {
 	pointer-events: auto;
 	position: absolute;

--- a/assets/css/plugins-window.css
+++ b/assets/css/plugins-window.css
@@ -995,3 +995,43 @@
 wpd-table[ data-installed-rows ]::part( row ) {
 	cursor: pointer;
 }
+
+/* ─── Featured tab ─────────────────────────────────────────────── */
+
+.desktop-mode-plugins__featured {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	flex: 1 1 auto;
+}
+
+.desktop-mode-plugins__featured-intro {
+	padding: 20px 20px 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.desktop-mode-plugins__featured-heading {
+	margin: 0;
+	font-size: 1.15em;
+	font-weight: 600;
+}
+
+.desktop-mode-plugins__featured-blurb {
+	margin: 0;
+	color: var( --wpd-fg-muted, #666 );
+	font-size: 0.9em;
+	line-height: 1.45;
+}
+
+/* Curated cards get a soft inset border + a `<wpd-ribbon>` stamped
+ * onto the top-end corner. The card host carries `position: relative`
+ * so the ribbon's `position: absolute` anchors to the card itself,
+ * not to whatever positioned ancestor lives further out. The ribbon
+ * owns its own clipping geometry; nothing else here needs to know
+ * about the diagonal. */
+.desktop-mode-plugins__card--featured {
+	position: relative;
+	box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 ) inset;
+}

--- a/docs/examples/layout-primitives.md
+++ b/docs/examples/layout-primitives.md
@@ -275,6 +275,64 @@ The host keeps `id="my-brand-picker"`, the inner `<select>` gets `id="my-brand-p
 - `<wpd-row>` uses CSS grid under the hood — standard browser behaviour for keyboard navigation and screen readers applies to its children.
 - Auto-id guarantees that input controls have a stable `id` and a real `<label for>` pairing inside the shadow root — both silence Chrome's "form field needs an id or name" warning and give screen readers a proper accessible name.
 
+## `<wpd-ribbon>` — corner ribbon decoration *(experimental, since 0.20.0)*
+
+A 45° banner that wraps a corner of its parent — the classic "FEATURED / NEW / BETA / SALE" stamp on a card. The component owns its own clipping geometry; consumers only need to make the parent a positioned containing block.
+
+```html
+<article class="my-card" style="position: relative;">
+    <wpd-ribbon>Featured</wpd-ribbon>
+    <h3>Card title</h3>
+    <p>Card body…</p>
+</article>
+```
+
+> ⚠️ **Parent must be positioned.** `<wpd-ribbon>` uses `position: absolute` on its host. Without `position: relative` (or `absolute` / `fixed` / `sticky`) on the parent, the ribbon anchors to the next positioned ancestor up the tree — usually the window body — and floats over the wrong thing entirely.
+
+### Attribute matrix
+
+| Attribute | Values | Default | Notes |
+|---|---|---|---|
+| `placement` | `top-end` · `top-start` · `bottom-end` · `bottom-start` | `top-end` | Logical end/start, so LTR/RTL flip for free. The 45° rotation sign also flips under `[dir='rtl']`. |
+| `tone` | `primary` · `success` · `warning` · `danger` · `info` · `neutral` | `primary` | Background tint. `primary` uses `--wp-admin-theme-color` so the ribbon picks up the active color scheme automatically. Matches `<wpd-badge>`'s palette so the two surfaces feel like a set. |
+
+```html
+<wpd-ribbon placement="bottom-start" tone="success">New</wpd-ribbon>
+<wpd-ribbon placement="top-start" tone="warning">Beta</wpd-ribbon>
+```
+
+### CSS-variable surface
+
+The host honours these custom properties for per-instance tuning without touching the component source. Set them on the host (or on any ancestor) to retheme:
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `--wpd-ribbon-size` | `90px` | Square clipping window edge. Smaller cards usually want `60px–70px`. |
+| `--wpd-ribbon-banner-width` | `140px` | Width of the rotated strip (before clipping). |
+| `--wpd-ribbon-banner-offset` | `20px` | Distance from the corner to the strip's perpendicular centerline. |
+| `--wpd-ribbon-banner-pull` | `-36px` | How far the strip overhangs the clip edge along the inline axis. |
+| `--wpd-ribbon-bg` | `var(--wp-admin-theme-color, #2271b1)` | Banner background — overrides `tone` when set. |
+| `--wpd-ribbon-fg` | `#fff` | Banner text color. |
+| `--wpd-ribbon-shadow` | `0 2px 4px rgba(0,0,0,0.2)` | Drop shadow under the banner. |
+| `--wpd-ribbon-padding` | `4px 0` | Vertical padding of the strip. |
+| `--wpd-ribbon-font` | `700 10px/1.4 system-ui` | Banner text typography shorthand. |
+| `--wpd-ribbon-tracking` | `0.06em` | Letter-spacing. |
+| `--wpd-ribbon-z` | `2` | Stacking order relative to other absolutely-positioned children of the parent. |
+
+### Styling the banner externally with `::part(banner)`
+
+The rotated strip is exposed as the `banner` shadow part, so consumers can apply CSS that shadow-DOM `--wpd-ribbon-*` variables don't cover (e.g. a gradient background, a custom font face):
+
+```css
+my-card wpd-ribbon::part(banner) {
+    background: linear-gradient(135deg, #ff6a00, #ee0979);
+}
+```
+
+### Accessibility
+
+The ribbon is decorative — there is no implicit `role` and `pointer-events: none` is set on the host, so it never steals clicks. If the label carries meaningful information that screen readers shouldn't miss, surface it elsewhere in the card body (e.g. a visually-hidden span repeating the status), since rotated text inside a decorative shadow boundary isn't a reliable a11y surface.
+
 ## Related docs
 
 - [`<wpd-stack>`, `<wpd-cluster>`, `<wpd-grid>`](../javascript-reference.md) — other layout primitives.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2053,6 +2053,8 @@ add_filter( 'desktop_mode_plugins_featured_slugs', static function ( $slugs ) {
 } );
 ```
 
+**Cache scope caveat.** The Featured tab response is cached in a single site-wide transient (`dm_pwfeatured_v1`, 1h TTL) — the cache key does not vary by user or role. If your filter returns role-specific or capability-specific slugs (e.g. surfacing a premium plugin only to administrators), the first viewer's payload will be served to every viewer for the cache window. Either keep the curated list cap-agnostic, or use `desktop_mode_plugins_featured_response` to drop disallowed rows for the current viewer *after* the shared payload is composed (you'd lose the cache hit benefit per user, but no leak).
+
 ### `desktop_mode_plugins_featured_response` — Experimental *(filter, since 0.20.0)*
 
 Last hop before the Featured tab payload is cached (1h transient) and sent to the client. Inject premium / private rows that aren't on wp.org, or enforce a hard cap on the response.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1961,7 +1961,7 @@ Last-mile mutation of the args passed to `desktop_mode_register_window( 'desktop
 
 ### `desktop_mode_plugins_window_template_html` — Experimental *(filter, since 0.9.0)*
 
-Filters the rendered template HTML before `wp_kses` runs. Keep `data-desktop-mode-plugins-{root,tabs,installed-host,browse-host,flyout}` intact or rename them and update the matching constants in `src/plugins-window/index.ts`.
+Filters the rendered template HTML before `wp_kses` runs. Keep `data-desktop-mode-plugins-{root,tabs,installed-host,browse-host,featured-host,flyout}` intact or rename them and update the matching constants in `src/plugins-window/index.ts`.
 
 ### `desktop_mode_plugins_window_browse_args` — Stable *(filter, since 0.9.0)*
 
@@ -2035,6 +2035,33 @@ do_action( 'desktop_mode_plugins_window_installed', string $plugin_file );
 ```
 
 Fires after the upload-AJAX handler installs a plugin from an uploaded .zip. `$plugin_file` is the resolved plugin file (e.g. `"akismet/akismet.php"`). Hook this to seed default settings for first-install plugins, send an audit-log entry, or chain a network-wide deploy.
+
+### `desktop_mode_plugins_featured_slugs` — Experimental *(filter, since 0.20.0)*
+
+The Plugins window's third tab — "Desktop Mode plugins" — leads with a hand-curated list because wp.org's `plugins_api` does not yet expose a usable `requires_plugins` filter. The handler hydrates each curated slug through `plugins_api( 'plugin_information' )` so card metadata stays fresh; it then scans the wp.org popular feed for rows whose `requires_plugins` array contains `desktop-mode` and appends them after the curated entries.
+
+Use this filter to append your own companion plugins (or remove the default seed). Order is preserved — the first slug renders first in the gallery. Output is run through `sanitize_key()` and deduplicated.
+
+```php
+apply_filters( 'desktop_mode_plugins_featured_slugs', string[] $slugs ): string[]
+```
+
+```php
+add_filter( 'desktop_mode_plugins_featured_slugs', static function ( $slugs ) {
+    $slugs[] = 'my-companion-plugin';
+    return $slugs;
+} );
+```
+
+### `desktop_mode_plugins_featured_response` — Experimental *(filter, since 0.20.0)*
+
+Last hop before the Featured tab payload is cached (1h transient) and sent to the client. Inject premium / private rows that aren't on wp.org, or enforce a hard cap on the response.
+
+```php
+apply_filters( 'desktop_mode_plugins_featured_response', array $payload, array $curated ): array
+```
+
+`$payload` shape: `{ plugins: [ … ], info: { curated: int, discovered: int, results: int } }`. Each entry in `plugins` matches the `plugins_api( 'query_plugins' )` row shape plus a boolean `featured` (true for curated, false for auto-discovered).
 
 ---
 

--- a/includes/desktop-files/store.php
+++ b/includes/desktop-files/store.php
@@ -283,6 +283,32 @@ function desktop_mode_files_move( $placement_id, $user_id, $changes = array() ) 
 				}
 			}
 		}
+		// Folder-cycle guard. When the row being moved is itself a
+		// folder placement, the new parent must not be the folder
+		// itself OR any of the folder's descendants — otherwise we
+		// commit `X.parent_id = Y` while `Y.parent_id` still leads
+		// back through `X`, producing an unreachable cycle that
+		// strands every descendant outside the desktop root. Walk
+		// the ancestry of `$target_parent` upward; bail if we hit
+		// the moving folder's id or detect a pre-existing cycle.
+		if ( 'folder' === (string) $row['file_type'] && $target_parent > 0 ) {
+			$moving_folder_id = (int) $row['file_ref'];
+			if ( $moving_folder_id > 0 ) {
+				if (
+					desktop_mode_files_would_create_folder_cycle(
+						$user_id,
+						$moving_folder_id,
+						$target_parent
+					)
+				) {
+					return new WP_Error(
+						'desktop_mode_files_folder_cycle',
+						__( 'A folder cannot be placed inside itself or one of its descendants.', 'desktop-mode' ),
+						array( 'status' => 409 )
+					);
+				}
+			}
+		}
 	}
 
 	$tables = desktop_mode_files_table_names();
@@ -857,3 +883,81 @@ function desktop_mode_files_schedule_prune() {
 	}
 }
 add_action( 'init', 'desktop_mode_files_schedule_prune' );
+
+/**
+ * Walk the folder-parentage chain upward from `$target_parent_id` and
+ * return `true` when `$moving_folder_id` appears anywhere in it —
+ * meaning a move that sets `moving_folder.parent_id = target_parent`
+ * would produce an unreachable cycle (folder placed inside itself or
+ * inside one of its own descendants).
+ *
+ * Folder-parentage is determined by the parent_id of the folder's
+ * placement row, not by anything on the `folders` table. We look up
+ * one live placement per cursor (`LIMIT 1`) — folders with multiple
+ * placements (rare; shared semantics) are still safely covered
+ * because any one upward chain hitting the moving folder is enough
+ * to flag the cycle.
+ *
+ * Defends against pre-existing cycles in the data: if we re-visit a
+ * cursor we've already seen, we treat it as a cycle and reject, so a
+ * corrupted history can't drive this function into an infinite loop.
+ *
+ * @since 0.20.0
+ *
+ * @param int $user_id          Acting user.
+ * @param int $moving_folder_id Folder being moved (its `folders.id`).
+ * @param int $target_parent_id New container folder id (0 = desktop root).
+ * @return bool True when the move would create a cycle.
+ */
+function desktop_mode_files_would_create_folder_cycle( $user_id, $moving_folder_id, $target_parent_id ) {
+	$moving_folder_id = (int) $moving_folder_id;
+	$target_parent_id = (int) $target_parent_id;
+	$user_id          = (int) $user_id;
+	if ( $moving_folder_id <= 0 || $target_parent_id <= 0 || $user_id <= 0 ) {
+		return false;
+	}
+	if ( $moving_folder_id === $target_parent_id ) {
+		return true;
+	}
+	global $wpdb;
+	$tables  = desktop_mode_files_table_names();
+	$visited = array();
+	$cursor  = $target_parent_id;
+	// Hard cap to defend against catastrophically deep trees too —
+	// real installs won't approach 256.
+	$max_depth = 256;
+	while ( $cursor > 0 && $max_depth-- > 0 ) {
+		if ( $cursor === $moving_folder_id ) {
+			return true;
+		}
+		if ( isset( $visited[ $cursor ] ) ) {
+			// Pre-existing cycle in the data — bail safe by treating
+			// the move as cycle-creating too. Better to refuse a
+			// suspicious move than to deepen the damage.
+			return true;
+		}
+		$visited[ $cursor ] = true;
+		// `LIMIT 1` is enough — any upward chain that reaches the
+		// moving folder flags the cycle. Trashed rows excluded so a
+		// recycled-then-recovered ancestor doesn't poison the check.
+		$parent_of_cursor = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT parent_id FROM {$tables['placements']}
+				WHERE user_id = %d
+					AND file_type = 'folder'
+					AND file_ref = %s
+					AND trashed_at_ms IS NULL
+				LIMIT 1",
+				$user_id,
+				(string) $cursor
+			)
+		);
+		if ( null === $parent_of_cursor ) {
+			// Folder has no live placement under this user — chain
+			// ends here. No cycle.
+			return false;
+		}
+		$cursor = (int) $parent_of_cursor;
+	}
+	return false;
+}

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -149,6 +149,13 @@ function desktop_mode_default_os_settings() {
 		// the list keep their server-supplied position appended after
 		// the listed ones. Unknown ids are tolerated.
 		'dockOrder'                => array(),
+		// Persisted desktop position for every dock item the user has
+		// promoted to the wallpaper via `itemVisibility[id]=desktop|both`.
+		// Keyed by item id, value is `{ x: int, y: int }`. The JS
+		// synthesizer reads this when building a synthetic placement so
+		// the icon lands where the user last dragged it instead of
+		// resetting to (0, 0) on every reload. Capped at 256 entries.
+		'dockPromotedPositions'    => array(),
 	);
 }
 
@@ -452,6 +459,44 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		}
 	}
 
+	// dockPromotedPositions — map<sanitize_key, {x: int, y: int}>.
+	// Persisted positions for synthetic dock-promoted placements, so
+	// the JS synthesizer can restore the user's manual placement on
+	// next reload. Capped at 256; absurd coordinates are dropped.
+	$dock_promoted_positions = array();
+	if ( isset( $raw['dockPromotedPositions'] ) && is_array( $raw['dockPromotedPositions'] ) ) {
+		$count     = 0;
+		$max_coord = 100000; // generous; real screens stop in the thousands.
+		foreach ( $raw['dockPromotedPositions'] as $key => $val ) {
+			if ( $count >= 256 ) {
+				break;
+			}
+			if ( ! is_string( $key ) || '' === $key ) {
+				continue;
+			}
+			$slug = sanitize_key( $key );
+			if ( '' === $slug ) {
+				continue;
+			}
+			if ( ! is_array( $val ) ) {
+				continue;
+			}
+			if ( ! isset( $val['x'] ) || ! isset( $val['y'] ) ) {
+				continue;
+			}
+			$x = is_numeric( $val['x'] ) ? (int) $val['x'] : null;
+			$y = is_numeric( $val['y'] ) ? (int) $val['y'] : null;
+			if ( null === $x || null === $y ) {
+				continue;
+			}
+			if ( abs( $x ) > $max_coord || abs( $y ) > $max_coord ) {
+				continue;
+			}
+			$dock_promoted_positions[ $slug ] = array( 'x' => $x, 'y' => $y );
+			++$count;
+		}
+	}
+
 	return array(
 		'wallpaper'                => $wallpaper,
 		'accent'                   => $accent,
@@ -473,6 +518,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'foldersSharingEnabled'    => $folders_sharing_enabled,
 		'itemVisibility'           => $item_visibility,
 		'dockOrder'                => $dock_order,
+		'dockPromotedPositions'    => $dock_promoted_positions,
 	);
 }
 

--- a/includes/plugins-window/ajax.php
+++ b/includes/plugins-window/ajax.php
@@ -805,3 +805,209 @@ function desktop_mode_plugins_window_ajax_upload() {
 	);
 }
 add_action( 'wp_ajax_desktop_mode_plugins_upload', 'desktop_mode_plugins_window_ajax_upload' );
+
+/**
+ * Curated list of slugs that lead the Featured tab.
+ *
+ * Hand-picked because wp.org's `plugins_api` does not surface a real
+ * "filter by `requires_plugins`" query — passing `requires_plugins` to
+ * `query_plugins` is silently ignored and returns the unfiltered repo.
+ * Until the directory grows a usable filter, we maintain the seed list
+ * here and let downstream plugins amend it via the filter below.
+ *
+ * Slug-only — the AJAX handler hydrates each entry through
+ * `plugins_api( 'plugin_information' )` so the card has up-to-date
+ * icons, descriptions, and install counts without us caching them.
+ *
+ * @since 0.20.0
+ *
+ * @return string[] List of wp.org plugin slugs.
+ */
+function desktop_mode_plugins_window_featured_slugs() {
+	$slugs = array(
+		// The author of this plugin forgot to declare Desktop Mode as a
+		// dependency — surfacing it here makes sure desktop-mode users
+		// discover it anyway. Once the `requires_plugins` query lands on
+		// wp.org we can remove the manual seed.
+		'odd-outlandish-desktop-decorator',
+	);
+
+	/**
+	 * Filter the curated list of featured-plugin slugs.
+	 *
+	 * Plugin authors can prepend (or remove) entries to recommend their
+	 * own Desktop-Mode-aware add-ons. Order is preserved — the first
+	 * slug renders first in the gallery.
+	 *
+	 * @since 0.20.0
+	 *
+	 * @param string[] $slugs Plugin slugs.
+	 */
+	$slugs = (array) apply_filters( 'desktop_mode_plugins_featured_slugs', $slugs );
+	$slugs = array_values(
+		array_unique(
+			array_filter(
+				array_map(
+					static function ( $s ) {
+						return sanitize_key( (string) $s );
+					},
+					$slugs
+				)
+			)
+		)
+	);
+	return $slugs;
+}
+
+/**
+ * `wp_ajax_desktop_mode_plugins_featured` — return the Featured tab's
+ * curated + auto-discovered list of plugins that integrate with Desktop
+ * Mode.
+ *
+ * Composition:
+ *   1. Curated slugs from `desktop_mode_plugins_window_featured_slugs()`,
+ *      hydrated via `plugins_api( 'plugin_information' )` so the card
+ *      payload is always fresh.
+ *   2. Auto-discovered slugs from `plugins_api( 'query_plugins' )` whose
+ *      `requires_plugins` array contains `desktop-mode`. wp.org has no
+ *      server-side filter for this today, so we run a broad query and
+ *      filter client-side server-side. Deduped against the curated set.
+ *
+ * Body params: (none)
+ *
+ * Cached for 1h. Failures cached for 15m so a flaky wp.org doesn't
+ * hammer the API on every tab open.
+ *
+ * @since 0.20.0
+ */
+function desktop_mode_plugins_window_ajax_featured() {
+	$guard = desktop_mode_plugins_window_ajax_guard( 'install_plugins' );
+	if ( is_wp_error( $guard ) ) {
+		desktop_mode_plugins_window_ajax_error( $guard );
+		return;
+	}
+
+	if ( ! function_exists( 'plugins_api' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+	}
+
+	$cache_key = 'dm_pwfeatured_v1';
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached && is_array( $cached ) ) {
+		wp_send_json_success( $cached );
+		return;
+	}
+
+	$plugins      = array();
+	$seen_slugs   = array();
+	$fields       = array(
+		'icons'             => true,
+		'banners'           => true,
+		'short_description' => true,
+		'description'       => false,
+		'sections'          => false,
+		'screenshots'       => false,
+		'rating'            => true,
+		'ratings'           => false,
+		'num_ratings'       => true,
+		'active_installs'   => true,
+		'last_updated'      => true,
+		'tested'            => true,
+		'requires'          => true,
+		'requires_php'      => true,
+		'requires_plugins'  => true,
+		'homepage'          => true,
+		'compatibility'     => false,
+		'group'             => false,
+		'contributors'      => false,
+		'donate_link'       => false,
+	);
+
+	// ─── 1. Curated slugs ─────────────────────────────────────────────
+	$curated = desktop_mode_plugins_window_featured_slugs();
+	foreach ( $curated as $slug ) {
+		if ( isset( $seen_slugs[ $slug ] ) ) {
+			continue;
+		}
+		$info = plugins_api(
+			'plugin_information',
+			array(
+				'slug'   => $slug,
+				'fields' => $fields,
+			)
+		);
+		if ( is_wp_error( $info ) || ! is_object( $info ) ) {
+			// Skip — a curated slug that 404s shouldn't tank the whole
+			// tab. Logged via WP_Error so debug builds can spot it.
+			continue;
+		}
+		$row             = (array) $info;
+		$row['featured'] = true;
+		$plugins[]       = $row;
+		$seen_slugs[ $slug ] = true;
+	}
+
+	// ─── 2. Auto-discover via `requires_plugins` ──────────────────────
+	// Best-effort scan: pull the top of the directory and keep rows that
+	// declare desktop-mode as a dependency. The wp.org `query_plugins`
+	// API ignores `requires_plugins` as a filter, so we have to fetch +
+	// sift locally. Scope is intentionally small (100 most-popular rows)
+	// to keep the request bounded; as the ecosystem grows we'll widen
+	// or replace with a real dependency query when wp.org ships one.
+	$discovered = plugins_api(
+		'query_plugins',
+		array(
+			'browse'   => 'popular',
+			'page'     => 1,
+			'per_page' => 100,
+			'fields'   => $fields,
+		)
+	);
+	if ( ! is_wp_error( $discovered ) && isset( $discovered->plugins ) && is_array( $discovered->plugins ) ) {
+		foreach ( $discovered->plugins as $candidate ) {
+			$candidate = (array) $candidate;
+			$slug      = isset( $candidate['slug'] ) ? sanitize_key( (string) $candidate['slug'] ) : '';
+			if ( '' === $slug || isset( $seen_slugs[ $slug ] ) ) {
+				continue;
+			}
+			$requires = isset( $candidate['requires_plugins'] ) ? (array) $candidate['requires_plugins'] : array();
+			if ( ! in_array( 'desktop-mode', $requires, true ) ) {
+				continue;
+			}
+			$candidate['featured'] = false;
+			$plugins[]             = $candidate;
+			$seen_slugs[ $slug ]   = true;
+		}
+	}
+
+	$payload = array(
+		'plugins' => array_values( $plugins ),
+		'info'    => array(
+			'curated'    => count( $curated ),
+			'discovered' => count( $plugins ) - count( $curated ),
+			'results'    => count( $plugins ),
+		),
+	);
+
+	/**
+	 * Filter the Featured tab payload before it's cached + sent.
+	 *
+	 * Use this to inject server-side curated rows (e.g. premium /
+	 * private plugins not on wp.org), or to enforce a hard cap on the
+	 * response.
+	 *
+	 * @since 0.20.0
+	 *
+	 * @param array $payload  `{ plugins: [...], info: {...} }`.
+	 * @param array $curated  Curated slug list.
+	 */
+	$payload = (array) apply_filters(
+		'desktop_mode_plugins_featured_response',
+		$payload,
+		$curated
+	);
+
+	set_transient( $cache_key, $payload, HOUR_IN_SECONDS );
+	wp_send_json_success( $payload );
+}
+add_action( 'wp_ajax_desktop_mode_plugins_featured', 'desktop_mode_plugins_window_ajax_featured' );

--- a/includes/plugins-window/ajax.php
+++ b/includes/plugins-window/ajax.php
@@ -980,11 +980,18 @@ function desktop_mode_plugins_window_ajax_featured() {
 		}
 	}
 
+	// `count( $plugins ) - count( $curated )` can underflow when a
+	// curated slug fails hydration (slug typo, plugin temporarily
+	// delisted from wp.org, plugins_api returning WP_Error). The JS
+	// only uses `discovered` for informational headers, so a negative
+	// number wouldn't crash anything, but it does read as a bug.
+	// Clamp at zero so the count remains a defensible "non-curated rows
+	// in the payload."
 	$payload = array(
 		'plugins' => array_values( $plugins ),
 		'info'    => array(
 			'curated'    => count( $curated ),
-			'discovered' => count( $plugins ) - count( $curated ),
+			'discovered' => max( 0, count( $plugins ) - count( $curated ) ),
 			'results'    => count( $plugins ),
 		),
 	);

--- a/includes/plugins-window/window.php
+++ b/includes/plugins-window/window.php
@@ -36,6 +36,7 @@ function desktop_mode_plugins_window_render_template() {
 			<wpd-tab value="installed"><?php esc_html_e( 'Installed', 'desktop-mode' ); ?></wpd-tab>
 			<?php if ( ! empty( $caps['install'] ) ) : ?>
 				<wpd-tab value="browse"><?php esc_html_e( 'Browse', 'desktop-mode' ); ?></wpd-tab>
+				<wpd-tab value="featured"><?php esc_html_e( 'Desktop Mode plugins', 'desktop-mode' ); ?></wpd-tab>
 			<?php endif; ?>
 		</wpd-tabs>
 
@@ -52,6 +53,12 @@ function desktop_mode_plugins_window_render_template() {
 				<div class="desktop-mode-plugins__browse" data-desktop-mode-plugins-browse-host>
 					<?php /* JS bundle paints the search + segmented filter
 					       + Upload button + <wpd-grid> of cards here. */ ?>
+				</div>
+			</wpd-tabpanel>
+			<wpd-tabpanel for="featured" class="desktop-mode-plugins__panel">
+				<div class="desktop-mode-plugins__featured" data-desktop-mode-plugins-featured-host>
+					<?php /* JS bundle paints an intro blurb + gallery of
+					       plugins that integrate with Desktop Mode here. */ ?>
 				</div>
 			</wpd-tabpanel>
 		<?php endif; ?>

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -418,6 +418,39 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 					)
 					.slice( 0, 256 );
 			}
+			if (
+				patch.dockPromotedPositions &&
+				typeof patch.dockPromotedPositions === 'object'
+			) {
+				const MAX_COORD = 100_000;
+				const next: Record< string, { x: number; y: number } > = {};
+				for ( const [ k, v ] of Object.entries(
+					patch.dockPromotedPositions as Record< string, unknown >,
+				) ) {
+					if ( typeof k !== 'string' || k === '' ) {
+						continue;
+					}
+					if ( ! v || typeof v !== 'object' ) {
+						continue;
+					}
+					const pos = v as { x?: unknown; y?: unknown };
+					if (
+						typeof pos.x !== 'number' ||
+						typeof pos.y !== 'number' ||
+						! Number.isFinite( pos.x ) ||
+						! Number.isFinite( pos.y ) ||
+						Math.abs( pos.x ) > MAX_COORD ||
+						Math.abs( pos.y ) > MAX_COORD
+					) {
+						continue;
+					}
+					next[ k ] = { x: pos.x, y: pos.y };
+					if ( Object.keys( next ).length >= 256 ) {
+						break;
+					}
+				}
+				osSettings.state.dockPromotedPositions = next;
+			}
 			osSettings.save( opts );
 			// Belt-and-suspenders live repaint for visibility / order
 			// changes. The `subscribeOsSettings` listener installed in

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -31,7 +31,6 @@ import { openCreateFolderDialog } from './create-folder-dialog';
 import { openFile } from './open';
 import { resolve as resolveFileType } from './registry';
 import {
-	buildOccupiedSet,
 	cellKey,
 	cellToPos,
 	GRID_CELL_H,
@@ -416,7 +415,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				filesStoreApi
 					.getState()
 					.placementsByFolder.get( folderId ) ?? [];
-			const occupied = buildOccupiedSet( peers, movingId );
+			const occupied = buildVisualOccupiedSet( peers, movingId );
 			const cell = snapToEmptyCell( rawX, rawY, occupied, host );
 			previewEl.style.transform = `translate3d(${ cell.x }px, ${ cell.y }px, 0)`;
 		};
@@ -504,7 +503,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 
 			if ( session.payload.type === 'desktop-file' ) {
 				const data = session.payload.data as unknown as DesktopFileDragData;
-				const occupied = buildOccupiedSet( peers, data.placement.id );
+				const occupied = buildVisualOccupiedSet( peers, data.placement.id );
 				const cell = snapToEmptyCell( rawX, rawY, occupied, host );
 				const next: RestPlacementShape = {
 					...data.placement,
@@ -576,7 +575,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				// where the user released the cursor. Cursor-position
 				// snap is wrong for shortcut creates because users
 				// rarely aim precisely; row-major is the "tidy" outcome.
-				const occupied = buildOccupiedSet( peers );
+				const occupied = buildVisualOccupiedSet( peers );
 				const cell = nextRowMajorCell( occupied, host );
 				void rest
 					.createPlacement( {
@@ -942,6 +941,58 @@ function readSynthSource( placement: RestPlacementShape ): string | null {
  */
 function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
 	return placement.id <= 0 || readSynthSource( placement ) !== null;
+}
+
+/**
+ * Build an occupied-cells set that reflects what's actually painted
+ * on the grid — including pinned tiles' assigned visual slots.
+ *
+ * `grid.ts`'s `buildOccupiedSet` only consults each placement's
+ * stored `(x, y)`, but the repaint deliberately IGNORES those for
+ * pinned tiles (`desktop_mode_register_icon( …, [ 'pinned' => true ] )`),
+ * anchoring them to column 0, rows 0..N-1 in the order they appear.
+ * So a tile pinned at the top of the column has stored coords that
+ * could be anywhere — and the plain occupied set would miss it
+ * entirely, letting drop snaps land on top of the pinned slot.
+ *
+ * Symptom this fixes: in a column rendered as
+ * `My WordPress | empty | Icon A | Icon B`, dragging Icon B at the
+ * empty cell used to highlight My WordPress's slot because
+ * `snapToEmptyCell` thought (0, 0) was free.
+ *
+ * @since 0.20.0
+ */
+function buildVisualOccupiedSet(
+	placements: ReadonlyArray< RestPlacementShape >,
+	excludeId?: number,
+): Set< string > {
+	// Sort pinned-first to mirror the repaint's iteration order, so
+	// pinned-slot indices match what's on screen. `Array.sort` is
+	// stable across all engines we support — within the pinned
+	// group, original placement order is preserved.
+	const sorted = placements.slice().sort( ( a, b ) => {
+		const ap = isPinned( a ) ? 0 : 1;
+		const bp = isPinned( b ) ? 0 : 1;
+		return ap - bp;
+	} );
+
+	const set = new Set< string >();
+	let pinnedIdx = 0;
+	for ( const p of sorted ) {
+		if ( excludeId !== undefined && p.id === excludeId ) {
+			continue;
+		}
+		if ( isPinned( p ) ) {
+			// Visual slot: column 0, row = position in the pinned
+			// sequence. Stored coords ignored, same as the repaint.
+			set.add( cellKey( 0, pinnedIdx ) );
+			pinnedIdx += 1;
+		} else {
+			const cell = pointToCell( p.x, p.y );
+			set.add( cellKey( cell.col, cell.row ) );
+		}
+	}
+	return set;
 }
 
 /**
@@ -1337,7 +1388,7 @@ function registerFolderDropTarget(
 				// We can't read the destination folder window's host
 				// width from here, so default to 4 cols inside
 				// `nextRowMajorCell` — sensible for any folder window.
-				const cell = nextRowMajorCell( buildOccupiedSet( peers ) );
+				const cell = nextRowMajorCell( buildVisualOccupiedSet( peers ) );
 				void rest
 					.createPlacement( {
 						parentId: targetFolderId,

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -1037,10 +1037,18 @@ const RECYCLE_BIN_REF = 'desktop-mode-recycle-bin';
  * WordPress), dock-item promotions, plugin-registered icons,
  * post / page references — gets the rejection.
  *
- * Plugins that register icons via `desktop_mode_register_icon` and
- * WANT to accept drops can register their own drop target on the
- * tile element from a `desktop-mode.files.tile-rendered` listener;
- * the registry overwrites by element, so their target wins.
+ * No plugin escape hatch yet. `desktop-mode.files.tile-rendered`
+ * fires from inside `buildTile` BEFORE the layer registers the
+ * reject claimant on the returned element. Since
+ * `registerDropTarget` overwrites by element and the reject
+ * claimant runs last, any plugin target installed during
+ * `tile-rendered` is immediately overwritten — the claimant wins,
+ * not the plugin. If a real plugin needs to accept drops on its
+ * own icon, the right fix is a new action fired AFTER the layer's
+ * registration (e.g. `desktop-mode.files.tile-drop-registered`)
+ * so plugins can install their own target last. Not adding that
+ * action speculatively — the feature is 0.20.0 / Experimental and
+ * no in-tree caller needs it today.
  *
  * @since 0.20.0
  */

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -198,6 +198,21 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		}
 		lastFingerprint = fp;
 
+		// Fast path: the common case (single tile dragged within the
+		// same folder) changes only `x` / `y` / `sortOrder` for one or
+		// more existing tiles. Nuking the DOM with `replaceChildren`
+		// for that produces a visible flash that reads to users as
+		// "the desktop just reloaded." When the placement set + every
+		// structural field matches what's already in the DOM, patch
+		// positions in place and bail before the wholesale rebuild.
+		// Falls through to the rebuild for adds, removes, renames,
+		// file-type changes, parent moves, or pin-flag flips — any of
+		// which require the full pinned-slot + drop-target
+		// reconciliation below.
+		if ( tryPatchPositions( list, container, host ) ) {
+			return;
+		}
+
 		// Wholesale rebuild — simplest correct strategy. Plugins that
 		// want stable decorations re-attach via `tile-rendered`.
 		container.replaceChildren();
@@ -391,6 +406,26 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 					folderId,
 					placementId: data.placement.id,
 				} );
+				if ( isSyntheticPlacement( data.placement ) ) {
+					// Synthetic placements (dock-item promotions —
+					// negative ids minted by
+					// `settings/desktop-shortcuts-sync.ts`) have no DB
+					// row, so the REST `/files/placements/(?P<id>\d+)`
+					// route can't accept the PATCH. Persist the new
+					// position into `OsSettingsState.dockPromotedPositions`
+					// instead so the synthesizer can restore it on the
+					// next page load — without this write the icon
+					// snaps back to (0, 0) every reload.
+					const dockItemId = readSynthSource( data.placement );
+					if ( dockItemId ) {
+						persistDockPromotedPosition(
+							dockItemId,
+							cell.x,
+							cell.y,
+						);
+					}
+					return;
+				}
 				void rest
 					.updatePlacement(
 						data.placement.id,
@@ -602,6 +637,12 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				sortOrder: i,
 			};
 			filesStoreApi.upsertPlacement( next );
+			if ( isSyntheticPlacement( p ) ) {
+				// No DB row — see the drop-on-canvas note below for the
+				// `\d+`-vs-negative-id reason. Store update above is
+				// enough for the visible sort outcome.
+				return;
+			}
 			void rest
 				.updatePlacement( p.id, { x, y, sortOrder: i } )
 				.catch( ( err: unknown ) => {
@@ -771,6 +812,197 @@ function readSynthSource( placement: RestPlacementShape ): string | null {
 }
 
 /**
+ * Whether `placement` is a synthetic (no DB row) one. Two signals:
+ *   - The `__synthFromDockItem` meta marker — definitive when present.
+ *   - A non-positive id — `settings/desktop-shortcuts-sync.ts` mints
+ *     deterministic negative ids for these, and Core's REST regex on
+ *     `/files/placements/(?P<id>\d+)` only matches positive integers,
+ *     so any non-positive id would 404 anyway. Treating the two as
+ *     equivalent keeps the gate robust against future synth sources
+ *     that forget to stamp the marker.
+ *
+ * Used to gate the three REST PATCH callsites in this module — synth
+ * placements live JS-only, so persisting their (x, y) / parentId
+ * would 404 with `rest_no_route`.
+ */
+function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
+	return placement.id <= 0 || readSynthSource( placement ) !== null;
+}
+
+/**
+ * Persist the new (x, y) of a synthetic dock-promoted placement
+ * into `OsSettingsState.dockPromotedPositions`. The synthesizer
+ * (`settings/desktop-shortcuts-sync.ts`) reads this map on every
+ * sync, so the next reload restores the icon at the saved coords
+ * instead of resetting to (0, 0).
+ *
+ * Silent no-op when the public OS Settings facade isn't available
+ * (tests, embedded previews, or a host that disabled the facade).
+ *
+ * @since 0.20.0
+ */
+function persistDockPromotedPosition(
+	dockItemId: string,
+	x: number,
+	y: number,
+): void {
+	const api = (
+		window as unknown as {
+			wp?: {
+				desktop?: {
+					getOsSettings?: () => {
+						dockPromotedPositions?: Record<
+							string,
+							{ x: number; y: number }
+						>;
+					};
+					updateOsSettings?: ( patch: {
+						dockPromotedPositions?: Record<
+							string,
+							{ x: number; y: number }
+						>;
+					} ) => void;
+				};
+			};
+		}
+	).wp?.desktop;
+	if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
+		return;
+	}
+	const current = api.getOsSettings().dockPromotedPositions ?? {};
+	api.updateOsSettings( {
+		dockPromotedPositions: {
+			...current,
+			[ dockItemId ]: { x, y },
+		},
+	} );
+}
+
+/**
+ * Try to apply a repaint as an in-place position update — no
+ * `replaceChildren()`, no tile rebuild. Returns `true` if the patch
+ * applied; `false` if the caller must fall back to the wholesale
+ * rebuild path.
+ *
+ * The fast path is correct when the ONLY thing that changed is one
+ * or more tiles' `x` / `y` / `sortOrder` / `updatedAtMs`. We can
+ * detect that without keeping a previous-snapshot map by reading
+ * the structural fields the renderer already encodes onto tile data
+ * attributes (`data-placement-id`, `data-file-type`, `data-file-ref`)
+ * plus the `--pinned` class. Anything else — adds, removes, renames,
+ * file-type changes, parent moves, pin-flag flips — falls back so
+ * the renderer can re-run pinned-slot allocation, drop-target
+ * registration, drag wiring, etc.
+ *
+ * Why the fast path matters: after a drag-and-drop the wholesale
+ * rebuild paints to users as "the whole desktop just reloaded" —
+ * every tile vanishes for one frame and re-appears. Patching
+ * positions in place keeps DOM identity for unchanged tiles so the
+ * grid feels continuous.
+ *
+ * @since 0.20.0
+ */
+function tryPatchPositions(
+	list: readonly RestPlacementShape[],
+	container: HTMLElement,
+	host: HTMLElement,
+): boolean {
+	const tiles = Array.from(
+		container.querySelectorAll< HTMLElement >( '[data-placement-id]' ),
+	);
+	if ( tiles.length !== list.length ) {
+		return false;
+	}
+
+	const byId = new Map< number, HTMLElement >();
+	for ( const tile of tiles ) {
+		const raw = tile.dataset.placementId ?? '';
+		const id = parseInt( raw, 10 );
+		// `parseInt` on a negative-id synth placement still returns
+		// the negative number, so synth tiles roundtrip cleanly. Only
+		// genuinely unparseable values short-circuit.
+		if ( raw === '' || ( Number.isNaN( id ) && raw !== '-0' ) ) {
+			return false;
+		}
+		byId.set( id, tile );
+	}
+
+	for ( const placement of list ) {
+		const tile = byId.get( placement.id );
+		if ( ! tile ) {
+			return false;
+		}
+		if ( tile.dataset.fileType !== placement.file.type ) {
+			return false;
+		}
+		if ( tile.dataset.fileRef !== placement.file.ref ) {
+			return false;
+		}
+		// Pin flag is encoded as a class on the wholesale rebuild —
+		// disagreement means the pin state changed and the drag
+		// wiring needs to be added or removed, which only the full
+		// rebuild does.
+		const wasPinned = tile.classList.contains( `${ TILE_CLASS }--pinned` );
+		if ( wasPinned !== isPinned( placement ) ) {
+			return false;
+		}
+	}
+
+	// All checks passed — recompute pinned slots + displacement
+	// exactly as the wholesale path would, then apply positions.
+	const pinnedSlots = new Map< number, { x: number; y: number } >();
+	const occupiedCells = new Set< string >();
+	let pinnedIdx = 0;
+	for ( const placement of list ) {
+		if ( ! isPinned( placement ) ) {
+			continue;
+		}
+		const slot = cellToPos( 0, pinnedIdx );
+		pinnedSlots.set( placement.id, { x: slot.x, y: slot.y } );
+		occupiedCells.add( cellKey( slot.col, slot.row ) );
+		pinnedIdx += 1;
+	}
+	const displaced = new Map< number, { x: number; y: number } >();
+	for ( const placement of list ) {
+		if ( pinnedSlots.has( placement.id ) ) {
+			continue;
+		}
+		const target = pointToCell( placement.x, placement.y );
+		const key = cellKey( target.col, target.row );
+		if ( ! occupiedCells.has( key ) ) {
+			occupiedCells.add( key );
+			continue;
+		}
+		const free = snapToEmptyCell(
+			placement.x,
+			placement.y,
+			occupiedCells,
+			host,
+		);
+		occupiedCells.add( cellKey( free.col, free.row ) );
+		displaced.set( placement.id, { x: free.x, y: free.y } );
+	}
+
+	for ( const placement of list ) {
+		const tile = byId.get( placement.id );
+		if ( ! tile ) {
+			continue; // unreachable — guarded above; keeps the typechecker happy.
+		}
+		const pinned = pinnedSlots.get( placement.id );
+		const disp = displaced.get( placement.id );
+		if ( pinned ) {
+			setTilePosition( tile, pinned.x, pinned.y );
+		} else if ( disp ) {
+			setTilePosition( tile, disp.x, disp.y );
+		} else {
+			setTilePosition( tile, placement.x, placement.y );
+		}
+	}
+
+	return true;
+}
+
+/**
  * Hide a dock item the user previously promoted onto the desktop.
  * Mutates `OsSettingsState.itemVisibility[ dockItemId ]` to `'dock'`
  * via the public API; the shortcuts-sync subscription removes the
@@ -834,6 +1066,15 @@ function registerFolderDropTarget(
 				// so the user gets reject feedback instead of a silent
 				// no-op.
 				if ( data.placement.parentId === targetFolderId ) {
+					return false;
+				}
+				// Synthetic placements (dock-item promotions) have no
+				// DB row, so "move into folder" can't be persisted
+				// today — the REST PATCH would 404 on its negative
+				// id. Reject the drop so the user gets a clear "this
+				// can't go there" cue instead of an apparent move that
+				// silently snaps back on the next sync.
+				if ( isSyntheticPlacement( data.placement ) ) {
 					return false;
 				}
 			}

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -229,6 +229,14 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			}
 		}
 		folderDropDeregisters.clear();
+		for ( const [ , deregister ] of tileRejectDeregisters ) {
+			try {
+				deregister();
+			} catch {
+				// ignore
+			}
+		}
+		tileRejectDeregisters.clear();
 
 		// Pinned tiles (registered with `pinned: true` —
 		// `desktop_mode_register_icon`) anchor to a fixed slot and
@@ -303,6 +311,28 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				// opens the window normally.
 				attachContextMenu( tile, placement );
 				attachSelectOnClick( tile, placement );
+				// Pinned tiles (My WordPress today) are system
+				// shortcuts — never valid drop targets. Without an
+				// explicit reject claimant the hit-test walks past
+				// them to the canvas drop target → green "Drop here
+				// to move" chip on hover, misleading because the
+				// drop snaps elsewhere (the cell is in the visual-
+				// occupied set). The Recycle Bin is excluded — its
+				// own trash-accepting drop target registers from
+				// `recycle-bin-targets.ts` and the registry
+				// overwrites by element.
+				if ( shouldRejectTileDrops( placement ) ) {
+					const dragManager = getDragManager();
+					if ( dragManager ) {
+						const deregister = dragManager.registerDropTarget( {
+							id: `desktop-mode-files-tile-${ placement.id }-reject`,
+							element: tile,
+							accept: () => false,
+							onDrop: () => {},
+						} );
+						tileRejectDeregisters.set( placement.id, deregister );
+					}
+				}
 				container.appendChild( tile );
 				continue;
 			}
@@ -330,6 +360,36 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 						);
 						folderDropDeregisters.set( placement.id, deregister );
 					}
+				}
+			} else if ( shouldRejectTileDrops( placement ) ) {
+				// Non-folder shortcut tiles (My WordPress, dock
+				// promotions, plugin-registered icons that don't
+				// claim drops themselves) need an explicit reject
+				// claimant. Without one, the hit-test walks PAST
+				// the tile up to the canvas drop target, which
+				// accepts → the user sees the green "Drop here to
+				// move" chip even though the drop would land in
+				// the next free cell (because pinned/occupied
+				// tiles are in the visual-occupied set).
+				//
+				// The Recycle Bin is excluded — `recycle-bin-targets.ts`
+				// registers its OWN trash-accepting drop target on
+				// the bin tile, and the registry overwrites by
+				// element. Stamping a reject claimant here would
+				// hide the trash gesture.
+				const dragManager = getDragManager();
+				if ( dragManager ) {
+					const deregister = dragManager.registerDropTarget( {
+						id: `desktop-mode-files-tile-${ placement.id }-reject`,
+						element: tile,
+						accept: () => false,
+						onDrop: () => {
+							// Unreachable — `accept: false` short-
+							// circuits commit. Defined for the type
+							// contract.
+						},
+					} );
+					tileRejectDeregisters.set( placement.id, deregister );
 				}
 			}
 			container.appendChild( tile );
@@ -367,6 +427,15 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	// repaint can deregister stale entries before rebuilding the
 	// container's children.
 	const folderDropDeregisters: Map< number, () => void > = new Map();
+	// Per-tile REJECT claimants for non-folder, non-bin shortcut
+	// tiles. Without these, dragging onto e.g. the My WordPress tile
+	// walks past it to the canvas drop target → green "Drop here to
+	// move" chip, but the drop snaps to the next free cell (since
+	// pinned/occupied tiles are in the visual-occupied set). The
+	// chip text and the actual outcome disagreed. Claiming with
+	// `accept: false` paints the red "Can't drop here" chip
+	// + reject snap-back instead.
+	const tileRejectDeregisters: Map< number, () => void > = new Map();
 
 	// ── Live drop-cell preview ─────────────────────────────────────────
 	// A soft outline that hovers at the cell the drop will land in.
@@ -873,6 +942,14 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				}
 			}
 			folderDropDeregisters.clear();
+			for ( const deregister of tileRejectDeregisters.values() ) {
+				try {
+					deregister();
+				} catch {
+					// ignore
+				}
+			}
+			tileRejectDeregisters.clear();
 			host.removeEventListener( 'click', onCanvasClick );
 			selectionListeners.clear();
 			container.remove();
@@ -941,6 +1018,40 @@ function readSynthSource( placement: RestPlacementShape ): string | null {
  */
 function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
 	return placement.id <= 0 || readSynthSource( placement ) !== null;
+}
+
+/** Recycle-bin tile id; matched on the shortcut tile's `file.ref`. */
+const RECYCLE_BIN_REF = 'desktop-mode-recycle-bin';
+
+/**
+ * Whether a tile should claim drops with `accept: false` — i.e.
+ * surface the red "Can't drop here" chip when the user drags
+ * another tile over it.
+ *
+ * Folders are excluded because `registerFolderDropTarget` already
+ * claims them with `accept: true` for matching payloads. The
+ * Recycle Bin is excluded because `recycle-bin-targets.ts` claims
+ * it as a TRASH target (the registry overwrites by element, so
+ * adding a reject claimant on the bin tile would silently break
+ * trash-by-drop). Everything else — system shortcuts (My
+ * WordPress), dock-item promotions, plugin-registered icons,
+ * post / page references — gets the rejection.
+ *
+ * Plugins that register icons via `desktop_mode_register_icon` and
+ * WANT to accept drops can register their own drop target on the
+ * tile element from a `desktop-mode.files.tile-rendered` listener;
+ * the registry overwrites by element, so their target wins.
+ *
+ * @since 0.20.0
+ */
+function shouldRejectTileDrops( placement: RestPlacementShape ): boolean {
+	if ( placement.file?.type === 'folder' ) {
+		return false;
+	}
+	if ( placement.file?.ref === RECYCLE_BIN_REF ) {
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -371,8 +371,30 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	const canvasDropTarget: DropTarget = {
 		id: `desktop-mode-files-canvas-${ folderId }`,
 		element: host,
-		accept: ( payload ) =>
-			payload.type === 'desktop-file' || payload.type === 'shortcut',
+		accept: ( payload ) => {
+			if ( payload.type !== 'desktop-file' && payload.type !== 'shortcut' ) {
+				return false;
+			}
+			// Folder-cycle preflight for drops onto a folder
+			// window's canvas. The wallpaper root (`folderId === 0`)
+			// can never be a descendant of any folder, so this only
+			// kicks in when a folder window has the canvas. Mirror
+			// of the server-side check; the only difference here is
+			// instant snap-back vs. a 409 toast after the REST hit.
+			if ( folderId > 0 && payload.type === 'desktop-file' ) {
+				const data = payload.data as unknown as DesktopFileDragData;
+				if ( data.placement.file?.type === 'folder' ) {
+					const movingFolderId = parseInt( data.placement.file.ref, 10 );
+					if (
+						! Number.isNaN( movingFolderId ) &&
+						wouldCreateFolderCycle( movingFolderId, folderId )
+					) {
+						return false;
+					}
+				}
+			}
+			return true;
+		},
 		onEnter: () => {
 			host.setAttribute( 'data-files-drop-active', '' );
 		},
@@ -830,6 +852,84 @@ function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
 }
 
 /**
+ * Would moving folder `movingFolderId` into folder `targetParentId`
+ * create a cycle? A move is cyclic when the target parent is the
+ * moving folder itself OR any of its descendants — committing
+ * `moving.parent_id = target` would leave the chain looping back
+ * through the moving folder, stranding every descendant outside the
+ * root.
+ *
+ * Walks the parent chain by reading the live store. Treats a
+ * pre-existing visit as a cycle so a corrupted client state can't
+ * drive the loop forever. Returns `false` when the target sits at
+ * root (`<= 0`) — that case is always safe.
+ *
+ * Authoritative gate lives server-side in
+ * `desktop_mode_files_would_create_folder_cycle()`; this is a
+ * client-side preflight so the `accept` callbacks can reject the
+ * drop up-front (no REST round-trip, no 409 in the console, visible
+ * snap-back at the drop site).
+ *
+ * @since 0.20.0
+ */
+function wouldCreateFolderCycle(
+	movingFolderId: number,
+	targetParentId: number,
+): boolean {
+	if ( targetParentId <= 0 || movingFolderId <= 0 ) {
+		return false;
+	}
+	if ( movingFolderId === targetParentId ) {
+		return true;
+	}
+	// Build a folder-id → containing-folder-id map from every live
+	// placement we know about. Folder identity is `file.ref` parsed
+	// as an int; the containing folder is the placement's parentId.
+	const parentByFolderId = new Map< number, number >();
+	const state = filesStoreApi.getState();
+	for ( const bucket of state.placementsByFolder.values() ) {
+		for ( const p of bucket ) {
+			if ( p.file?.type !== 'folder' ) {
+				continue;
+			}
+			const fid = parseInt( p.file.ref, 10 );
+			if ( Number.isNaN( fid ) || fid <= 0 ) {
+				continue;
+			}
+			// First-seen wins. Folders with multiple placements
+			// (rare; shared semantics) only need one upward chain to
+			// flag a cycle.
+			if ( ! parentByFolderId.has( fid ) ) {
+				parentByFolderId.set( fid, p.parentId );
+			}
+		}
+	}
+
+	const visited = new Set< number >();
+	let cursor = targetParentId;
+	let maxDepth = 256;
+	while ( cursor > 0 && maxDepth-- > 0 ) {
+		if ( cursor === movingFolderId ) {
+			return true;
+		}
+		if ( visited.has( cursor ) ) {
+			return true; // pre-existing cycle — bail safe
+		}
+		visited.add( cursor );
+		const next = parentByFolderId.get( cursor );
+		if ( next === undefined ) {
+			// Unknown ancestry. Let the server's authoritative check
+			// decide — defaulting to "allow" here keeps shared
+			// folders the viewer can't fully see from being falsely
+			// blocked.
+			return false;
+		}
+		cursor = next;
+	}
+	return false;
+}
+
+/**
  * Persist the new (x, y) of a synthetic dock-promoted placement
  * into `OsSettingsState.dockPromotedPositions`. The synthesizer
  * (`settings/desktop-shortcuts-sync.ts`) reads this map on every
@@ -1076,6 +1176,21 @@ function registerFolderDropTarget(
 				// silently snaps back on the next sync.
 				if ( isSyntheticPlacement( data.placement ) ) {
 					return false;
+				}
+				// Folder cycle: dropping folder X onto folder Y
+				// when Y is somewhere inside X creates an
+				// unreachable loop. The server's authoritative
+				// check rejects it too, but doing the preflight
+				// here gives the user a clean "this can't go
+				// there" snap-back instead of a 409 toast.
+				if ( data.placement.file.type === 'folder' ) {
+					const movingFolderId = parseInt( data.placement.file.ref, 10 );
+					if (
+						! Number.isNaN( movingFolderId ) &&
+						wouldCreateFolderCycle( movingFolderId, targetFolderId )
+					) {
+						return false;
+					}
 				}
 			}
 			return true;

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -44,7 +44,7 @@ import {
 import type { RestPlacementShape } from './rest';
 import type { FilesState } from './store';
 import { isConflict, showConflictToast } from './conflict-toast';
-import type { DragManagerApi, DropTarget } from '../drag';
+import type { DragManagerApi, DragSession, DropTarget } from '../drag';
 import { trashFolderWithUndo, trashPlacementWithUndo } from './trash';
 import type {
 	DesktopFileDragData,
@@ -368,6 +368,87 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	// repaint can deregister stale entries before rebuilding the
 	// container's children.
 	const folderDropDeregisters: Map< number, () => void > = new Map();
+
+	// ── Live drop-cell preview ─────────────────────────────────────────
+	// A soft outline that hovers at the cell the drop will land in.
+	// The user reported drops drifting "down-and-right of where I
+	// aimed"; the math fix (subtracting the ghost grab offset) does
+	// most of the work, but a visible target helps the gap between
+	// "where the cursor is" and "where the snapped cell is" stop
+	// being surprising — especially at the edges of the grid where
+	// the snap can skip a column.
+	//
+	// One outline per layer; we install a `pointermove` listener
+	// while the canvas is the active hover target, and tear it down
+	// the instant we leave / drop. The handlers live in this closure
+	// so they can reach `container`, `host`, `folderId`, and the
+	// store.
+	let dropPreviewEl: HTMLElement | null = null;
+	let dropPreviewMoveHandler: ( ( ev: PointerEvent ) => void ) | null = null;
+	const installCanvasDropPreview = ( session: DragSession ): void => {
+		if ( dropPreviewEl ) {
+			return;
+		}
+		// Only worth previewing for desktop-file payloads — for
+		// shortcut creates the layer packs row-major into the next
+		// free cell rather than snapping to the cursor, so a
+		// cursor-tracking preview would lie about the landing slot.
+		if ( session.payload.type !== 'desktop-file' ) {
+			return;
+		}
+		const previewEl = document.createElement( 'div' );
+		previewEl.className = 'desktop-mode-files-drop-preview';
+		previewEl.setAttribute( 'aria-hidden', 'true' );
+		container.appendChild( previewEl );
+		dropPreviewEl = previewEl;
+
+		const ghost = session.payload.ghost;
+		const offsetX = ghost?.offsetX ?? 0;
+		const offsetY = ghost?.offsetY ?? 0;
+		const data = session.payload.data as unknown as DesktopFileDragData;
+		const movingId = data?.placement?.id;
+
+		const updatePreview = ( clientX: number, clientY: number ): void => {
+			const rect = container.getBoundingClientRect();
+			const rawX = Math.max( 0, clientX - rect.left - offsetX );
+			const rawY = Math.max( 0, clientY - rect.top - offsetY );
+			const peers =
+				filesStoreApi
+					.getState()
+					.placementsByFolder.get( folderId ) ?? [];
+			const occupied = buildOccupiedSet( peers, movingId );
+			const cell = snapToEmptyCell( rawX, rawY, occupied, host );
+			previewEl.style.transform = `translate3d(${ cell.x }px, ${ cell.y }px, 0)`;
+		};
+
+		// Prime the preview position before the first `pointermove`
+		// fires (~16 ms gap). The drag manager hides the source tile
+		// via the `--dragging` class but doesn't move it, so its
+		// `getBoundingClientRect()` still reads the spot the user
+		// grabbed from — we synthesize a cursor at the tile center +
+		// offset and feed that into `updatePreview`.
+		const sourceRect = session.payload.source.getBoundingClientRect();
+		updatePreview(
+			sourceRect.left + offsetX,
+			sourceRect.top + offsetY,
+		);
+
+		const moveHandler = ( ev: PointerEvent ): void => {
+			updatePreview( ev.clientX, ev.clientY );
+		};
+		document.addEventListener( 'pointermove', moveHandler );
+		dropPreviewMoveHandler = moveHandler;
+	};
+	const teardownCanvasDropPreview = (): void => {
+		if ( dropPreviewMoveHandler ) {
+			document.removeEventListener( 'pointermove', dropPreviewMoveHandler );
+			dropPreviewMoveHandler = null;
+		}
+		if ( dropPreviewEl ) {
+			dropPreviewEl.remove();
+			dropPreviewEl = null;
+		}
+	};
 	const canvasDropTarget: DropTarget = {
 		id: `desktop-mode-files-canvas-${ folderId }`,
 		element: host,
@@ -395,17 +476,29 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			}
 			return true;
 		},
-		onEnter: () => {
+		onEnter: ( session ) => {
 			host.setAttribute( 'data-files-drop-active', '' );
+			installCanvasDropPreview( session );
 		},
 		onLeave: () => {
 			host.removeAttribute( 'data-files-drop-active' );
+			teardownCanvasDropPreview();
 		},
 		onDrop: ( session, ev ) => {
 			host.removeAttribute( 'data-files-drop-active' );
+			teardownCanvasDropPreview();
 			const rect = container.getBoundingClientRect();
-			const rawX = Math.max( 0, ev.clientX - rect.left );
-			const rawY = Math.max( 0, ev.clientY - rect.top );
+			// Subtract the grab offset so we snap based on where the
+			// tile's TOP-LEFT would land, not where the cursor is. The
+			// drag manager renders the ghost at
+			// `(cursor − ghost.offsetX, cursor − ghost.offsetY)` —
+			// without mirroring that here, the drop site would always
+			// drift down-and-right of where the user sees the ghost.
+			const ghost = session.payload.ghost;
+			const offsetX = ghost?.offsetX ?? 0;
+			const offsetY = ghost?.offsetY ?? 0;
+			const rawX = Math.max( 0, ev.clientX - rect.left - offsetX );
+			const rawY = Math.max( 0, ev.clientY - rect.top - offsetY );
 			const peers =
 				filesStoreApi.getState().placementsByFolder.get( folderId ) ?? [];
 

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -1401,20 +1401,36 @@ function attachTileDrag(
 			// least selectable.
 			return;
 		}
+		// IMPORTANT: re-read the placement from the live store. The
+		// closure-captured `placement` is the value as of the LAST
+		// wholesale repaint — the fast-path repaint
+		// (`tryPatchPositions`) reuses tile DOM and never re-attaches
+		// the drag handler, so without this lookup the closure holds
+		// stale `updatedAtMs` indefinitely after the first move. The
+		// REST PATCH that the canvas drop fires uses that field as
+		// the `If-Match` header; a stale value lands a 409 with
+		// `reason: 'parent_changed'`, surfaced to the user as
+		// "<their own name> moved this to 'another folder'." Shared
+		// folders see this most often because the heartbeat bumps
+		// `updatedAtMs` on every tick a peer is active.
+		const liveBucket =
+			filesStoreApi.getState().placementsByFolder.get( folderId );
+		const livePlacement =
+			liveBucket?.find( ( p ) => p.id === placement.id ) ?? placement;
 		// Read the tile's CURRENT visible position from the inline
 		// styles, not the placement's server-stored (x, y). They
 		// diverge when the layer has displaced this tile to dodge
 		// a pinned slot — using `placement.x` would snap the tile
 		// back to its stored coords on the first pointermove (the
 		// "drag jumps to the pinned slot" bug).
-		const visibleX = parseFloat( tile.style.left ) || placement.x;
-		const visibleY = parseFloat( tile.style.top ) || placement.y;
+		const visibleX = parseFloat( tile.style.left ) || livePlacement.x;
+		const visibleY = parseFloat( tile.style.top ) || livePlacement.y;
 		const session = dragManager.start( {
 			payload: {
 				type: 'desktop-file',
 				source: tile,
 				data: {
-					placement,
+					placement: livePlacement,
 					sourceFolderId: folderId,
 				} satisfies DesktopFileDragData,
 				ghost: {

--- a/src/desktop-files/recycle-bin-targets.ts
+++ b/src/desktop-files/recycle-bin-targets.ts
@@ -107,6 +107,18 @@ function registerOn(
 			if ( ! placement ) {
 				return false;
 			}
+			// Never trash the recycle bin into itself. Both drop
+			// surfaces (the bin's wallpaper tile + the bin window
+			// body) share this `accept`, so dragging the bin onto
+			// either one used to land on `trashByFileType` →
+			// `trashPlacementWithUndo` and the bin's own placement
+			// got soft-trashed. Visible result: the bin vanished
+			// from the desktop, with no obvious way back short of a
+			// reload (which re-auto-placed it because the orphan
+			// backfill only counts non-trashed placements).
+			if ( placement.file?.ref === RECYCLE_BIN_WINDOW_ID ) {
+				return false;
+			}
 			// `canTrash === false` is an explicit veto from the
 			// server. `undefined` (legacy clients / older payloads
 			// that pre-date the flag) defaults to "let it through"

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2746,7 +2746,10 @@ function init(): void {
 		// Bring the files-layer placements in line with the new
 		// visibility map — promotes dock items onto the wallpaper
 		// and removes hidden server icons from the grid.
-		syncShortcutsWithVisibility( snapshot.itemVisibility );
+		syncShortcutsWithVisibility(
+			snapshot.itemVisibility,
+			snapshot.dockPromotedPositions,
+		);
 		// Cross-bundle SSOT publish — feature bundles + third-party
 		// plugins that imported `@layout` see the change without
 		// having to thread the OsSettings snapshot through.
@@ -2759,6 +2762,7 @@ function init(): void {
 	// the visibility map immediately.
 	installShortcutsSync(
 		() => osSettings.getOsSettingsSnapshot().itemVisibility,
+		() => osSettings.getOsSettingsSnapshot().dockPromotedPositions,
 	);
 
 	// Initial publish so any consumer that reads `getCurrentLayout()`

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -5356,6 +5356,36 @@ function renderInto( body: HTMLElement ): void {
 	};
 	activeState = state;
 
+	// Register a CLAIMANT drop target on the window body that rejects
+	// every payload. My WordPress is a read-only directory listing
+	// over the WP REST API — dropping a desktop tile, a placement,
+	// or a shortcut onto it has no defined semantic. Without this
+	// claimant, the drag manager's hit-test walks past the window
+	// boundary and silently `cancel('no-target')`s — from the user's
+	// perspective the ghost just disappears with no feedback.
+	//
+	// Returning `accept: false` paints the no-drop cursor + reject
+	// snap-back animation, so users get visible "this surface
+	// doesn't take drops" feedback instead of guessing. The
+	// claimant ALSO blocks the drag from falling through to the
+	// wallpaper canvas under the window (registry.hitTest stops at
+	// the first registered target it finds in the walk-up).
+	//
+	// @since 0.20.0
+	const dragManager = getDragManager();
+	if ( dragManager ) {
+		const deregister = dragManager.registerDropTarget( {
+			id: `${ WINDOW_ID }-reject`,
+			element: body,
+			accept: () => false,
+			onDrop: () => {
+				// Unreachable — `accept: false` short-circuits the
+				// commit path. Defined for the type contract.
+			},
+		} );
+		state.teardown.push( deregister );
+	}
+
 	// Back button + crumb-click handlers are wired by the shared
 	// breadcrumb helper inside `updateBreadcrumbs` — no per-element
 	// listener wiring here anymore.

--- a/src/plugins-window/featured-view.ts
+++ b/src/plugins-window/featured-view.ts
@@ -1,0 +1,403 @@
+/**
+ * Native Plugins window — "Desktop Mode plugins" tab.
+ *
+ * A curated + auto-discovered gallery of plugins that integrate with
+ * Desktop Mode. Curated entries (hand-picked because wp.org has no
+ * real `requires_plugins` filter) lead the list; rows whose wp.org
+ * `requires_plugins` array contains the `desktop-mode` slug are
+ * appended after.
+ *
+ * Single server fetch per mount — the AJAX endpoint owns the curated
+ * list + discovery + transient caching. No infinite scroll, no
+ * search, no filter: the surface is small by design.
+ *
+ * @public
+ * @since 0.20.0
+ */
+
+import { __, sprintf } from '../i18n';
+import { broadcast, subscribe } from '../broadcast';
+import {
+	buildCard,
+	repaintCardCta,
+	type CardCallbacks,
+	type InstalledIndex,
+} from './card';
+import { makeCardDraggable } from './card-drag';
+import { openDetailFlyout } from './flyout-detail';
+import {
+	activateInstalledPlugin,
+	fetchFeaturedPlugins,
+	fetchInstalledPlugins,
+	installPluginBySlug,
+	refreshFrameworkMenu,
+	type FeaturedPlugin,
+} from './rest';
+import type { InstalledPlugin } from './types';
+import '../ui/components/wpd-button/wpd-button';
+import '../ui/components/wpd-card/wpd-card';
+import '../ui/components/wpd-ribbon/wpd-ribbon';
+
+/**
+ * Cross-view sync topic. Mirrors the contract in `browse-view.ts` /
+ * `installed-view.ts` so the Featured tab also gets repainted when
+ * another tab mutates a plugin's installed state.
+ *
+ * @internal
+ */
+const PLUGINS_CHANGED_TOPIC = 'desktop-mode.plugin.changed';
+const SOURCE = 'featured-view';
+interface PluginsChangedPayload {
+	source: string;
+	plugin?: string;
+	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'bulk';
+}
+
+interface FeaturedState {
+	plugins: FeaturedPlugin[];
+	installed: InstalledIndex;
+	cardsBySlug: Map< string, HTMLElement >;
+	loading: boolean;
+}
+
+/** Toast helper — mirrors the other views. */
+function toast( message: string, duration = 3500 ): void {
+	const api = window.wp?.desktop;
+	if ( api && typeof api.showToast === 'function' ) {
+		api.showToast( { message, duration } );
+		return;
+	}
+	// eslint-disable-next-line no-console
+	console.log( '[plugins-window]', message );
+}
+
+/**
+ * Mount the Featured view into a host element. Returns a teardown
+ * for the framework's window-closed cleanup pattern.
+ */
+export function mountFeaturedView(
+	host: HTMLElement,
+	flyoutEl: HTMLElement | null,
+): () => void {
+	host.replaceChildren();
+
+	const state: FeaturedState = {
+		plugins: [],
+		installed: new Map(),
+		cardsBySlug: new Map(),
+		loading: true,
+	};
+
+	// ─── Intro blurb ───────────────────────────────────────────────────
+	const intro = document.createElement( 'header' );
+	intro.className = 'desktop-mode-plugins__featured-intro';
+	const heading = document.createElement( 'h2' );
+	heading.className = 'desktop-mode-plugins__featured-heading';
+	heading.textContent = __( 'Made for Desktop Mode', 'desktop-mode' );
+	const description = document.createElement( 'p' );
+	description.className = 'desktop-mode-plugins__featured-blurb';
+	description.textContent = __(
+		'Plugins that extend Desktop Mode — desktop decorations, native windows, widgets, and other companions.',
+		'desktop-mode',
+	);
+	intro.append( heading, description );
+
+	// ─── Gallery ───────────────────────────────────────────────────────
+	const gallery = document.createElement( 'div' );
+	gallery.className = 'desktop-mode-plugins__gallery';
+
+	const status = document.createElement( 'p' );
+	status.className = 'desktop-mode-plugins__gallery-status';
+	status.hidden = true;
+
+	host.append( intro, gallery, status );
+
+	// ─── Card callbacks ────────────────────────────────────────────────
+	const cardCallbacks: CardCallbacks = {
+		onOpen: ( slug, hint ) => {
+			if ( ! flyoutEl ) {
+				return;
+			}
+			openDetailFlyout( flyoutEl, slug, hint, {
+				getInstalled: ( s ) => state.installed.get( s ),
+				onPluginInstalled: async ( pluginFile, slug2 ) => {
+					await refreshInstalled();
+					repaintSlugCard( slug2 );
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: pluginFile ?? slug2,
+						action: 'install',
+					} );
+				},
+				onPluginActivated: ( updated ) => {
+					state.installed.set( indexKeyFor( updated ), updated );
+					repaintSlugCard( updated.textdomain ?? '' );
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: updated.plugin,
+						action: 'activate',
+					} );
+				},
+				onPluginDeactivated: ( updated ) => {
+					state.installed.set( indexKeyFor( updated ), updated );
+					repaintSlugCard( updated.textdomain ?? '' );
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: updated.plugin,
+						action: 'deactivate',
+					} );
+				},
+				onPluginDeleted: ( deleted ) => {
+					state.installed.delete( indexKeyFor( deleted ) );
+					repaintSlugCard( deleted.textdomain ?? '' );
+					broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+						source: SOURCE,
+						plugin: deleted.plugin,
+						action: 'delete',
+					} );
+				},
+			} );
+		},
+		onInstall: async ( plugin, card ) => {
+			const cta = card.querySelector< HTMLElement >( '[data-plugin-card-cta]' );
+			const originalText = cta?.textContent ?? '';
+			cta?.setAttribute( 'busy', '' );
+			cta?.setAttribute( 'disabled', '' );
+			if ( cta ) {
+				cta.textContent = __( 'Installing…', 'desktop-mode' );
+			}
+			try {
+				await installPluginBySlug( plugin.slug );
+				await refreshInstalled();
+				toast(
+					sprintf(
+						/* translators: %s: plugin name */
+						__( 'Installed %s.', 'desktop-mode' ),
+						plugin.name,
+					),
+				);
+				repaintCardCta( card, plugin, state.installed, cardCallbacks );
+				broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+					source: SOURCE,
+					plugin: plugin.slug,
+					action: 'install',
+				} );
+				void refreshFrameworkMenu();
+			} catch ( err ) {
+				cta?.removeAttribute( 'busy' );
+				cta?.removeAttribute( 'disabled' );
+				if ( cta ) {
+					cta.textContent = originalText;
+				}
+				toast(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Install failed: %s', 'desktop-mode' ),
+						describe( err ),
+					),
+					6000,
+				);
+			}
+		},
+		onActivate: async ( installed, card ) => {
+			const cta = card.querySelector< HTMLElement >( '[data-plugin-card-cta]' );
+			const originalText = cta?.textContent ?? '';
+			cta?.setAttribute( 'busy', '' );
+			cta?.setAttribute( 'disabled', '' );
+			if ( cta ) {
+				cta.textContent = __( 'Activating…', 'desktop-mode' );
+			}
+			try {
+				const updated = await activateInstalledPlugin( installed );
+				state.installed.set( indexKeyFor( updated ), updated );
+				toast(
+					sprintf(
+						/* translators: %s: plugin name */
+						__( '%s activated.', 'desktop-mode' ),
+						updated.name || updated.plugin,
+					),
+				);
+				const plugin = state.plugins.find(
+					( p ) => p.slug === ( updated.textdomain ?? '' ),
+				);
+				if ( plugin ) {
+					repaintCardCta( card, plugin, state.installed, cardCallbacks );
+				}
+				broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+					source: SOURCE,
+					plugin: updated.plugin,
+					action: 'activate',
+				} );
+				void refreshFrameworkMenu();
+			} catch ( err ) {
+				cta?.removeAttribute( 'busy' );
+				cta?.removeAttribute( 'disabled' );
+				if ( cta ) {
+					cta.textContent = originalText;
+				}
+				toast(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Activation failed: %s', 'desktop-mode' ),
+						describe( err ),
+					),
+					6000,
+				);
+			}
+		},
+	};
+
+	// ─── Initial loads ─────────────────────────────────────────────────
+	void load();
+
+	async function load(): Promise< void > {
+		state.loading = true;
+		paintSkeletons();
+		try {
+			// Run both fetches in parallel — the installed cache is what
+			// flips the card CTA from "Install" to "Active", and we want
+			// the first frame to land in its final state instead of a
+			// brief "Install" flash for a plugin the user already has.
+			const [ featured, installed ] = await Promise.all( [
+				fetchFeaturedPlugins(),
+				fetchInstalledPlugins().catch( () => [] as InstalledPlugin[] ),
+			] );
+			state.installed = new Map(
+				installed.map( ( r ) => [ indexKeyFor( r ), r ] ),
+			);
+			state.plugins = featured.plugins ?? [];
+			renderGallery();
+			if ( state.plugins.length === 0 ) {
+				showStatus( __( 'No featured plugins yet.', 'desktop-mode' ) );
+			} else {
+				hideStatus();
+			}
+		} catch ( err ) {
+			gallery.replaceChildren();
+			showStatus(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Could not load featured plugins: %s', 'desktop-mode' ),
+					describe( err ),
+				),
+			);
+		} finally {
+			state.loading = false;
+		}
+	}
+
+	function paintSkeletons(): void {
+		gallery.replaceChildren();
+		state.cardsBySlug.clear();
+		for ( let i = 0; i < 3; i++ ) {
+			gallery.appendChild( buildSkeletonCard() );
+		}
+	}
+
+	function renderGallery(): void {
+		gallery.replaceChildren();
+		state.cardsBySlug.clear();
+		for ( const plugin of state.plugins ) {
+			if ( ! plugin?.slug ) {
+				continue;
+			}
+			const card = buildCard( plugin, state.installed, cardCallbacks );
+			if ( plugin.featured ) {
+				card.classList.add( 'desktop-mode-plugins__card--featured' );
+				// `<wpd-ribbon>` self-positions absolutely on its parent's
+				// top-end corner (its host has `position: absolute`). The
+				// card host carries `position: relative` via the
+				// `__card--featured` class below so the ribbon anchors to
+				// the card boundary and not whatever ancestor the gallery
+				// inherits.
+				const ribbon = document.createElement( 'wpd-ribbon' );
+				ribbon.textContent = __( 'Featured', 'desktop-mode' );
+				card.prepend( ribbon );
+			}
+			makeCardDraggable( card, plugin );
+			gallery.appendChild( card );
+			state.cardsBySlug.set( plugin.slug, card );
+		}
+	}
+
+	function repaintSlugCard( slug: string ): void {
+		if ( ! slug ) {
+			return;
+		}
+		const card = state.cardsBySlug.get( slug );
+		const plugin = state.plugins.find( ( p ) => p.slug === slug );
+		if ( card && plugin ) {
+			repaintCardCta( card, plugin, state.installed, cardCallbacks );
+		}
+	}
+
+	async function refreshInstalled(): Promise< void > {
+		try {
+			const rows = await fetchInstalledPlugins();
+			state.installed = new Map(
+				rows.map( ( r ) => [ indexKeyFor( r ), r ] ),
+			);
+			for ( const [ slug, card ] of state.cardsBySlug ) {
+				const plugin = state.plugins.find( ( p ) => p.slug === slug );
+				if ( plugin ) {
+					repaintCardCta( card, plugin, state.installed, cardCallbacks );
+				}
+			}
+		} catch {
+			// Best-effort.
+		}
+	}
+
+	function showStatus( message: string ): void {
+		status.hidden = false;
+		status.textContent = message;
+	}
+	function hideStatus(): void {
+		status.hidden = true;
+		status.textContent = '';
+	}
+
+	// Cross-view sync — when Installed or Browse mutates a plugin we
+	// might be showing, refresh the installed cache so the CTA flips.
+	const unsubscribePluginsChanged = subscribe< PluginsChangedPayload >(
+		PLUGINS_CHANGED_TOPIC,
+		( payload ) => {
+			if ( payload?.source === SOURCE ) {
+				return;
+			}
+			void refreshInstalled();
+		},
+	);
+
+	return () => {
+		unsubscribePluginsChanged();
+		host.replaceChildren();
+	};
+}
+
+function buildSkeletonCard(): HTMLElement {
+	const card = document.createElement( 'wpd-card' );
+	card.classList.add(
+		'desktop-mode-plugins__card',
+		'desktop-mode-plugins__card--skeleton',
+	);
+	card.setAttribute( 'aria-hidden', 'true' );
+	for ( let i = 0; i < 4; i++ ) {
+		const line = document.createElement( 'span' );
+		line.className = 'desktop-mode-plugins__skeleton-line';
+		line.style.width = `${ 50 + ( i * 17 ) % 50 }%`;
+		card.appendChild( line );
+	}
+	return card;
+}
+
+function indexKeyFor( plugin: InstalledPlugin ): string {
+	return plugin.textdomain || plugin.plugin;
+}
+
+function describe( err: unknown ): string {
+	if ( err instanceof Error ) {
+		return err.message;
+	}
+	return String( err );
+}

--- a/src/plugins-window/featured-view.ts
+++ b/src/plugins-window/featured-view.ts
@@ -193,7 +193,7 @@ export function mountFeaturedView(
 					sprintf(
 						/* translators: %s: error message */
 						__( 'Install failed: %s', 'desktop-mode' ),
-						describe( err ),
+						formatError( err ),
 					),
 					6000,
 				);
@@ -239,7 +239,7 @@ export function mountFeaturedView(
 					sprintf(
 						/* translators: %s: error message */
 						__( 'Activation failed: %s', 'desktop-mode' ),
-						describe( err ),
+						formatError( err ),
 					),
 					6000,
 				);
@@ -278,7 +278,7 @@ export function mountFeaturedView(
 				sprintf(
 					/* translators: %s: error message */
 					__( 'Could not load featured plugins: %s', 'desktop-mode' ),
-					describe( err ),
+					formatError( err ),
 				),
 			);
 		} finally {
@@ -303,13 +303,16 @@ export function mountFeaturedView(
 			}
 			const card = buildCard( plugin, state.installed, cardCallbacks );
 			if ( plugin.featured ) {
-				card.classList.add( 'desktop-mode-plugins__card--featured' );
 				// `<wpd-ribbon>` self-positions absolutely on its parent's
 				// top-end corner (its host has `position: absolute`). The
-				// card host carries `position: relative` via the
-				// `__card--featured` class below so the ribbon anchors to
-				// the card boundary and not whatever ancestor the gallery
-				// inherits.
+				// `__card--featured` class below carries the matching
+				// `position: relative` on the card host — these two lines
+				// MUST stay paired. Removing the class while keeping the
+				// `prepend` would re-anchor the ribbon to whatever
+				// positioned ancestor the gallery happens to inherit
+				// (usually the window body), so it would float over the
+				// wrong thing entirely.
+				card.classList.add( 'desktop-mode-plugins__card--featured' );
 				const ribbon = document.createElement( 'wpd-ribbon' );
 				ribbon.textContent = __( 'Featured', 'desktop-mode' );
 				card.prepend( ribbon );
@@ -395,7 +398,7 @@ function indexKeyFor( plugin: InstalledPlugin ): string {
 	return plugin.textdomain || plugin.plugin;
 }
 
-function describe( err: unknown ): string {
+function formatError( err: unknown ): string {
 	if ( err instanceof Error ) {
 		return err.message;
 	}

--- a/src/plugins-window/index.ts
+++ b/src/plugins-window/index.ts
@@ -30,6 +30,7 @@ import '../ui/components/wpd-badge/wpd-badge';
 // the class explicitly so the server-rendered element upgrades.
 import '../ui/components/wpd-flyout/wpd-flyout';
 import { mountBrowseView } from './browse-view';
+import { mountFeaturedView } from './featured-view';
 import { mountInstalledView } from './installed-view';
 import { getConfig, type PluginsWindowConfig } from './rest';
 import {
@@ -107,14 +108,26 @@ function renderPluginsWindow( body: HTMLElement ): void {
 		browseTeardown = mountBrowseView( browseHost, flyout, body );
 	}
 
+	// ─── Featured tab ───────────────────────────────────────────────
+	const featuredHost = root.querySelector< HTMLElement >(
+		'[data-desktop-mode-plugins-featured-host]',
+	);
+	let featuredTeardown: ( () => void ) | null = null;
+	if ( featuredHost && config.caps.install ) {
+		featuredTeardown = mountFeaturedView( featuredHost, flyout );
+	}
+
 	// ─── Tab routing ───────────────────────────────────────────────
 	const applyTab = ( tab: PluginsWindowTab ): void => {
 		if ( ! tabs ) {
 			return;
 		}
-		// Browse hidden when the viewer can't install — never auto-flip
-		// the tab somewhere they can't see.
-		if ( tab === 'browse' && ! config.caps.install ) {
+		// Browse + Featured share the `caps.install` gate — never auto-
+		// flip the tab somewhere the viewer can't see.
+		if (
+			( tab === 'browse' || tab === 'featured' ) &&
+			! config.caps.install
+		) {
 			tabs.setAttribute( 'value', 'installed' );
 			return;
 		}
@@ -149,6 +162,10 @@ function renderPluginsWindow( body: HTMLElement ): void {
 		if ( browseTeardown ) {
 			browseTeardown();
 			browseTeardown = null;
+		}
+		if ( featuredTeardown ) {
+			featuredTeardown();
+			featuredTeardown = null;
 		}
 	};
 	document.addEventListener( 'desktop-mode-window-closed', onClosed );

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -463,6 +463,28 @@ export async function fetchPluginInfo( slug: string ): Promise< WpOrgPluginInfo 
 	return ajaxRequest< WpOrgPluginInfo >( 'desktop_mode_plugins_info', { slug } );
 }
 
+/**
+ * Card payload for the Featured tab. Same shape as a Browse card plus
+ * a `featured` boolean — true when the row came from the curated seed
+ * list, false when auto-discovered from wp.org's `requires_plugins`.
+ */
+export interface FeaturedPlugin extends WpOrgBrowsePlugin {
+	featured?: boolean;
+	requires_plugins?: string[];
+}
+
+/**
+ * Fetch the curated + auto-discovered list of plugins that integrate
+ * with Desktop Mode. Backed by a 1h server-side transient — repeat
+ * calls within that window return the same payload.
+ */
+export async function fetchFeaturedPlugins(): Promise< {
+	plugins: FeaturedPlugin[];
+	info: { curated?: number; discovered?: number; results?: number };
+} > {
+	return ajaxRequest( 'desktop_mode_plugins_featured' );
+}
+
 /** Fetch (cached) recent reviews for a slug — falls back to histogram on parse failure. */
 export async function fetchPluginReviews(
 	slug: string,

--- a/src/plugins-window/tab-target.ts
+++ b/src/plugins-window/tab-target.ts
@@ -29,7 +29,7 @@ interface DesktopFacade {
 	) => SharedStoreApi< T >;
 }
 
-export type PluginsWindowTab = 'installed' | 'browse';
+export type PluginsWindowTab = 'installed' | 'browse' | 'featured';
 
 interface TabTargetState {
 	tab: PluginsWindowTab | null;

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -192,6 +192,7 @@ export const DEFAULTS: OsSettingsState = {
 	foldersSharingEnabled: true,
 	itemVisibility: {},
 	dockOrder: [],
+	dockPromotedPositions: {},
 };
 
 /**

--- a/src/settings/desktop-shortcuts-sync.ts
+++ b/src/settings/desktop-shortcuts-sync.ts
@@ -55,12 +55,17 @@ function hashToNegativeId( s: string ): number {
 /** Build a synthetic placement representing a promoted dock item. */
 function buildSyntheticPlacement(
 	item: DockItemConfig,
+	persistedPositions: Record< string, { x: number; y: number } >,
 ): RestPlacementShape {
+	// Restore the user's last-dragged position if we have one. Falls
+	// through to (0, 0) so the layer's `snapToEmptyCell` can find a
+	// free grid slot on first promote.
+	const saved = persistedPositions[ item.id ];
 	return {
 		id: hashToNegativeId( item.id ),
 		parentId: 0,
-		x: 0,
-		y: 0,
+		x: saved ? saved.x : 0,
+		y: saved ? saved.y : 0,
 		sortOrder: 9999,
 		updatedAtMs: Date.now(),
 		meta: { [ SYNTH_META_KEY ]: item.id },
@@ -139,10 +144,14 @@ const removedServerPlacementsByRef = new Map< string, RestPlacementShape >();
 
 /**
  * Bring the files store in line with the current
- * {@link OsSettingsState.itemVisibility} map.
+ * {@link OsSettingsState.itemVisibility} map. The `positions`
+ * argument is the matching `dockPromotedPositions` map — synth
+ * placements built from a previously-dragged dock item land at the
+ * stored coords instead of (0, 0).
  */
 export function syncShortcutsWithVisibility(
 	visibility: Record< string, ItemVisibility >,
+	positions: Record< string, { x: number; y: number } > = {},
 ): void {
 	if ( reentrant ) {
 		return;
@@ -191,7 +200,7 @@ export function syncShortcutsWithVisibility(
 				desiredSynth.add( item.id );
 				if ( ! currentSynth.has( item.id ) ) {
 					filesApi.store.upsertPlacement(
-						buildSyntheticPlacement( item ),
+						buildSyntheticPlacement( item, positions ),
 					);
 				}
 			}
@@ -253,22 +262,30 @@ export function syncShortcutsWithVisibility(
  * - The user updates visibility via OS Settings or the right-click
  *   menu (handled by an external caller passing the new snapshot).
  *
+ * `getPositions` returns the persisted `dockPromotedPositions` map
+ * (defaults to an empty record when the caller doesn't supply one,
+ * for backwards-compat with older boot paths that didn't know about
+ * the field yet).
+ *
  * Returns a teardown function for tests / hot-reload.
  */
 export function installShortcutsSync(
 	getVisibility: () => Record< string, ItemVisibility >,
+	getPositions: () => Record< string, { x: number; y: number } > = () => ( {} ),
 ): () => void {
 	// Initial reconciliation — runs on a microtask so any
 	// just-mounted desktop icons from the server hydration are in
 	// the store before we filter.
-	queueMicrotask( () => syncShortcutsWithVisibility( getVisibility() ) );
+	queueMicrotask( () =>
+		syncShortcutsWithVisibility( getVisibility(), getPositions() ),
+	);
 
 	// Re-run on every store change so server-driven hydration
 	// (e.g. a refresh fetching the full placements list) gets
 	// filtered. The reentrancy guard prevents our own writes from
 	// triggering an infinite loop.
 	const off = filesApi.store.subscribe( () => {
-		syncShortcutsWithVisibility( getVisibility() );
+		syncShortcutsWithVisibility( getVisibility(), getPositions() );
 	} );
 
 	return off;

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -194,6 +194,11 @@ export class OsSettings implements SettingsCtx {
 			foldersSharingEnabled: this.state.foldersSharingEnabled,
 			itemVisibility: { ...this.state.itemVisibility },
 			dockOrder: this.state.dockOrder.slice(),
+			dockPromotedPositions: Object.fromEntries(
+				Object.entries( this.state.dockPromotedPositions ).map(
+					( [ k, v ] ) => [ k, { ...v } ],
+				),
+			),
 		};
 	}
 

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -140,6 +140,17 @@ export interface OsSettingsSnapshot {
 	 * @since 0.25.0
 	 */
 	dockOrder: string[];
+	/**
+	 * Persisted desktop position (in CSS px) for every dock item the
+	 * user has promoted onto the wallpaper. Keyed by dock-item id.
+	 * Missing keys mean "no override" — the synth placement falls
+	 * back to the default grid slot. See
+	 * {@link OsSettingsState.dockPromotedPositions} for the source
+	 * field.
+	 *
+	 * @since 0.20.0
+	 */
+	dockPromotedPositions: Record< string, { x: number; y: number } >;
 }
 
 export interface SettingsTabRenderCtx {

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -173,6 +173,9 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 				: DEFAULTS.foldersSharingEnabled,
 		itemVisibility: sanitizeItemVisibility( parsed.itemVisibility ),
 		dockOrder: sanitizeDockOrder( parsed.dockOrder ),
+		dockPromotedPositions: sanitizeDockPromotedPositions(
+			parsed.dockPromotedPositions,
+		),
 	};
 }
 
@@ -225,6 +228,48 @@ function sanitizeDockOrder( raw: unknown ): string[] {
 		if ( out.length >= 256 ) {
 			break;
 		}
+	}
+	return out;
+}
+
+/**
+ * Coerce an untrusted `dockPromotedPositions` value into the shape
+ * the rest of the bundle expects. Caps at 256 entries; rejects any
+ * non-finite or absurdly large coordinate so a corrupted blob can't
+ * make the synth-placement positioner blow up.
+ */
+function sanitizeDockPromotedPositions(
+	raw: unknown,
+): Record< string, { x: number; y: number } > {
+	if ( ! raw || typeof raw !== 'object' || Array.isArray( raw ) ) {
+		return {};
+	}
+	const out: Record< string, { x: number; y: number } > = {};
+	let count = 0;
+	const MAX_COORD = 100_000; // generous; real screens stop in the thousands
+	for ( const [ k, v ] of Object.entries( raw as Record< string, unknown > ) ) {
+		if ( count >= 256 ) {
+			break;
+		}
+		if ( typeof k !== 'string' || k === '' ) {
+			continue;
+		}
+		if ( ! v || typeof v !== 'object' || Array.isArray( v ) ) {
+			continue;
+		}
+		const pos = v as { x?: unknown; y?: unknown };
+		if (
+			typeof pos.x !== 'number' ||
+			typeof pos.y !== 'number' ||
+			! Number.isFinite( pos.x ) ||
+			! Number.isFinite( pos.y ) ||
+			Math.abs( pos.x ) > MAX_COORD ||
+			Math.abs( pos.y ) > MAX_COORD
+		) {
+			continue;
+		}
+		out[ k ] = { x: pos.x, y: pos.y };
+		count++;
 	}
 	return out;
 }
@@ -282,6 +327,12 @@ function _cloneState( state: OsSettingsState ): OsSettingsState {
 		nativePostsHiddenColumns: state.nativePostsHiddenColumns.slice(),
 		itemVisibility: { ...state.itemVisibility },
 		dockOrder: state.dockOrder.slice(),
+		dockPromotedPositions: Object.fromEntries(
+			Object.entries( state.dockPromotedPositions ).map( ( [ k, v ] ) => [
+				k,
+				{ ...v },
+			] ),
+		),
 	};
 }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -251,6 +251,22 @@ export interface OsSettingsState {
 	 * @since 0.25.0
 	 */
 	dockOrder: string[];
+	/**
+	 * Persisted desktop position (in CSS px) for every dock item the
+	 * user has promoted onto the wallpaper via
+	 * `itemVisibility[ id ] = 'desktop' | 'both'`. The synthesizer in
+	 * `settings/desktop-shortcuts-sync.ts` reads this when building
+	 * a synthetic placement so the icon lands where the user last
+	 * dragged it instead of resetting to (0, 0).
+	 *
+	 * Missing keys mean "no override" — the synth placement falls back
+	 * to the default top-left grid slot. Unknown ids (a plugin whose
+	 * dock item is no longer registered) survive the round-trip in
+	 * case the plugin reactivates. Capped at 256 entries.
+	 *
+	 * @since 0.20.0
+	 */
+	dockPromotedPositions: Record< string, { x: number; y: number } >;
 }
 
 /**

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -48,6 +48,8 @@ export { WpdKey } from './wpd-key/wpd-key';
 export { WpdCode } from './wpd-code/wpd-code';
 export { WpdBadge } from './wpd-badge/wpd-badge';
 export type { WpdBadgeTone } from './wpd-badge/wpd-badge';
+export { WpdRibbon } from './wpd-ribbon/wpd-ribbon';
+export type { WpdRibbonPlacement, WpdRibbonTone } from './wpd-ribbon/wpd-ribbon';
 export { WpdLog } from './wpd-log/wpd-log';
 export type { WpdLogRowRenderer } from './wpd-log/wpd-log';
 export { WpdSteps, WpdStep } from './wpd-steps/wpd-steps';

--- a/src/ui/components/wpd-ribbon/wpd-ribbon.styles.ts
+++ b/src/ui/components/wpd-ribbon/wpd-ribbon.styles.ts
@@ -1,0 +1,145 @@
+/**
+ * `<wpd-ribbon>` — diagonal corner banner.
+ *
+ * The host is a square `overflow: hidden` window pinned to the chosen
+ * corner of its (positioned) parent. Inside, a wider `.banner` strip
+ * is rotated 45° so the visible slice reads as a ribbon wrapping the
+ * corner. The wrapper geometry — width, banner offset — is sized via
+ * CSS custom properties so plugin authors can tune sizes without
+ * forking the styles.
+ *
+ * Why a separate wrapper + banner element rather than a single
+ * rotated element: clipping. The `overflow: hidden` on the host is
+ * what cuts the strip's overhang into a triangular outline. Rotating
+ * the host directly leaves a rectangle floating off the corner.
+ *
+ * Logical-property positioning (`inset-inline-*`, `inset-block-*`)
+ * does the LTR/RTL flip on the wrapper for free. The 45° rotation,
+ * however, has no inline-aware variant — we explicitly flip the
+ * rotation sign under `[dir='rtl']` so the visual band still leans
+ * "downward-into-the-card" rather than backward.
+ */
+import { css } from '../../core';
+
+export const styles = css`
+	:host {
+		position: absolute;
+		width: var( --wpd-ribbon-size, 90px );
+		height: var( --wpd-ribbon-size, 90px );
+		overflow: hidden;
+		pointer-events: none;
+		z-index: var( --wpd-ribbon-z, 2 );
+	}
+	:host( [ hidden ] ) {
+		display: none;
+	}
+
+	.banner {
+		position: absolute;
+		display: block;
+		width: var( --wpd-ribbon-banner-width, 140px );
+		padding: var( --wpd-ribbon-padding, 4px 0 );
+		text-align: center;
+		font: var(
+			--wpd-ribbon-font,
+			700 10px/1.4 var( --desktop-mode-font, system-ui )
+		);
+		letter-spacing: var( --wpd-ribbon-tracking, 0.06em );
+		text-transform: uppercase;
+		color: var( --wpd-ribbon-fg, #fff );
+		background: var(
+			--wpd-ribbon-bg,
+			var( --wp-admin-theme-color, #2271b1 )
+		);
+		box-shadow: var(
+			--wpd-ribbon-shadow,
+			0 2px 4px rgba( 0, 0, 0, 0.2 )
+		);
+	}
+
+	/* ─── Placement: top-end (default) ───────────────────────────────
+	   Wrapper pinned to the top-inline-end corner. Banner translates
+	   into the wrapper diagonally so its visible slice reads
+	   left-to-right going upward in LTR. */
+	:host( :not( [ placement ] ) ),
+	:host( [ placement='top-end' ] ) {
+		inset-block-start: 0;
+		inset-inline-end: 0;
+	}
+	:host( :not( [ placement ] ) ) .banner,
+	:host( [ placement='top-end' ] ) .banner {
+		inset-block-start: var( --wpd-ribbon-banner-offset, 20px );
+		inset-inline-end: var( --wpd-ribbon-banner-pull, -36px );
+		transform: rotate( 45deg );
+	}
+
+	/* ─── Placement: top-start ───────────────────────────────────── */
+	:host( [ placement='top-start' ] ) {
+		inset-block-start: 0;
+		inset-inline-start: 0;
+	}
+	:host( [ placement='top-start' ] ) .banner {
+		inset-block-start: var( --wpd-ribbon-banner-offset, 20px );
+		inset-inline-start: var( --wpd-ribbon-banner-pull, -36px );
+		transform: rotate( -45deg );
+	}
+
+	/* ─── Placement: bottom-end ──────────────────────────────────── */
+	:host( [ placement='bottom-end' ] ) {
+		inset-block-end: 0;
+		inset-inline-end: 0;
+	}
+	:host( [ placement='bottom-end' ] ) .banner {
+		inset-block-end: var( --wpd-ribbon-banner-offset, 20px );
+		inset-inline-end: var( --wpd-ribbon-banner-pull, -36px );
+		transform: rotate( -45deg );
+	}
+
+	/* ─── Placement: bottom-start ────────────────────────────────── */
+	:host( [ placement='bottom-start' ] ) {
+		inset-block-end: 0;
+		inset-inline-start: 0;
+	}
+	:host( [ placement='bottom-start' ] ) .banner {
+		inset-block-end: var( --wpd-ribbon-banner-offset, 20px );
+		inset-inline-start: var( --wpd-ribbon-banner-pull, -36px );
+		transform: rotate( 45deg );
+	}
+
+	/* RTL: flip the rotation sign so the diagonal still hugs the
+	   physical corner the user sees. \`inset-inline-*\` already takes
+	   care of the wrapper position itself. */
+	:host-context( [ dir='rtl' ] ):host( :not( [ placement ] ) ) .banner,
+	:host-context( [ dir='rtl' ] ):host( [ placement='top-end' ] ) .banner {
+		transform: rotate( -45deg );
+	}
+	:host-context( [ dir='rtl' ] ):host( [ placement='top-start' ] ) .banner {
+		transform: rotate( 45deg );
+	}
+	:host-context( [ dir='rtl' ] ):host( [ placement='bottom-end' ] ) .banner {
+		transform: rotate( 45deg );
+	}
+	:host-context( [ dir='rtl' ] ):host( [ placement='bottom-start' ] ) .banner {
+		transform: rotate( -45deg );
+	}
+
+	/* ─── Tones ──────────────────────────────────────────────────────
+	   Match \`<wpd-badge>\`'s palette so the two surfaces feel like a
+	   set. Default (no tone, or \`primary\`) uses the admin theme
+	   accent so the ribbon picks up per-scheme tints automatically. */
+	:host( [ tone='success' ] ) .banner {
+		background: var( --wpd-ribbon-success, #1a7f37 );
+	}
+	:host( [ tone='warning' ] ) .banner {
+		background: var( --wpd-ribbon-warning, #9a6700 );
+	}
+	:host( [ tone='danger' ] ) .banner {
+		background: var( --wpd-ribbon-danger, #cf222e );
+	}
+	:host( [ tone='info' ] ) .banner {
+		background: var( --wpd-ribbon-info, #0969da );
+	}
+	:host( [ tone='neutral' ] ) .banner {
+		background: var( --wpd-ribbon-neutral, #57606a );
+	}
+`;

--- a/src/ui/components/wpd-ribbon/wpd-ribbon.test.ts
+++ b/src/ui/components/wpd-ribbon/wpd-ribbon.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `<wpd-ribbon>` — smoke tests. Confirms the wrapper + rotated banner
+ * render, slot projection works, and the `placement` / `tone`
+ * attributes survive on the host so the shadow-DOM stylesheet's
+ * `[placement='…']` / `[tone='…']` selectors can match.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import './wpd-ribbon';
+
+const tick = (): Promise< void > => Promise.resolve();
+
+describe( '<wpd-ribbon>', () => {
+	let host: HTMLElement;
+	beforeEach( () => {
+		host = document.createElement( 'div' );
+		host.style.position = 'relative';
+		document.body.appendChild( host );
+	} );
+	afterEach( () => host.remove() );
+
+	test( 'renders a banner span + default slot for the label', async () => {
+		host.innerHTML = `<wpd-ribbon>Featured</wpd-ribbon>`;
+		await tick();
+		const ribbon = host.querySelector( 'wpd-ribbon' )!;
+		expect( ribbon.shadowRoot ).not.toBeNull();
+		expect( ribbon.shadowRoot!.querySelector( '.banner' ) ).not.toBeNull();
+		expect( ribbon.shadowRoot!.querySelector( 'slot' ) ).not.toBeNull();
+		expect( ribbon.textContent ).toBe( 'Featured' );
+	} );
+
+	test( 'default has no placement attribute — styles target :not([placement])', async () => {
+		host.innerHTML = `<wpd-ribbon>X</wpd-ribbon>`;
+		await tick();
+		const ribbon = host.querySelector( 'wpd-ribbon' )!;
+		expect( ribbon.hasAttribute( 'placement' ) ).toBe( false );
+	} );
+
+	test( 'placement attribute survives on host for CSS targeting', async () => {
+		host.innerHTML = `<wpd-ribbon placement="bottom-start">X</wpd-ribbon>`;
+		await tick();
+		const ribbon = host.querySelector( 'wpd-ribbon' )!;
+		expect( ribbon.getAttribute( 'placement' ) ).toBe( 'bottom-start' );
+	} );
+
+	test( 'tone attribute survives on host', async () => {
+		host.innerHTML = `<wpd-ribbon tone="success">X</wpd-ribbon>`;
+		await tick();
+		const ribbon = host.querySelector( 'wpd-ribbon' )!;
+		expect( ribbon.getAttribute( 'tone' ) ).toBe( 'success' );
+	} );
+
+	test( 'banner part is exposed so consumers can ::part() override', async () => {
+		host.innerHTML = `<wpd-ribbon>X</wpd-ribbon>`;
+		await tick();
+		const ribbon = host.querySelector( 'wpd-ribbon' )!;
+		const banner = ribbon.shadowRoot!.querySelector( '.banner' )!;
+		expect( banner.getAttribute( 'part' ) ).toBe( 'banner' );
+	} );
+} );

--- a/src/ui/components/wpd-ribbon/wpd-ribbon.ts
+++ b/src/ui/components/wpd-ribbon/wpd-ribbon.ts
@@ -1,0 +1,101 @@
+/**
+ * `<wpd-ribbon>` — diagonal corner ribbon.
+ *
+ * A small, decorative "wrap-around-the-corner" banner — the kind that
+ * stamps a card with FEATURED, NEW, BETA, SALE, etc. The component
+ * auto-positions itself at one of the four corners of its (positioned)
+ * parent, so consumers only need to drop it inside a `position:
+ * relative` container.
+ *
+ * Usage:
+ *
+ *   <article style="position: relative;">
+ *     <wpd-ribbon>Featured</wpd-ribbon>
+ *     …card content…
+ *   </article>
+ *
+ *   <wpd-ribbon placement="bottom-start" tone="success">NEW</wpd-ribbon>
+ *
+ * The parent MUST be a positioned ancestor (relative / absolute /
+ * fixed / sticky). Without that, the ribbon anchors to the next
+ * positioned element up the tree — usually the viewport — which is
+ * never what you want.
+ *
+ * Slot contents flow through to the rotated banner. Keep the label
+ * short — the visible slice is ~80px wide and tightly cropped.
+ *
+ * @since 0.20.0
+ */
+
+import { Component, defineComponent, html } from '../../core';
+import { styles } from './wpd-ribbon.styles';
+
+export type WpdRibbonPlacement =
+	| 'top-end'
+	| 'top-start'
+	| 'bottom-end'
+	| 'bottom-start';
+
+export type WpdRibbonTone =
+	| 'primary'
+	| 'success'
+	| 'warning'
+	| 'danger'
+	| 'info'
+	| 'neutral';
+
+export class WpdRibbon extends Component {
+	static props = [ 'placement', 'tone' ] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Ribbon',
+		summary:
+			'45° corner ribbon. Wraps the top-end (default), top-start, bottom-end, or bottom-start corner of its positioned parent. The host owns clipping + rotation; consumers only set position-relative on the parent and drop a label inside.',
+		status: 'experimental',
+		since: '0.20.0',
+		props: [
+			{
+				name: 'placement',
+				type: '"top-end" | "top-start" | "bottom-end" | "bottom-start"',
+				description:
+					'Which corner of the parent the ribbon hugs. Defaults to `top-end` (logical right in LTR, left in RTL).',
+			},
+			{
+				name: 'tone',
+				type: '"primary" | "success" | "warning" | "danger" | "info" | "neutral"',
+				description:
+					'Background color tone. Defaults to `primary` (the admin theme accent).',
+			},
+		],
+		slots: [ { name: '(default)', description: 'Ribbon label text. Keep short.' } ],
+		cssProps: [
+			{ name: '--wpd-ribbon-size', default: '90px', description: 'Square clipping window edge.' },
+			{ name: '--wpd-ribbon-banner-width', default: '140px', description: 'Width of the rotated strip.' },
+			{ name: '--wpd-ribbon-banner-offset', default: '20px', description: 'Distance from corner to strip center.' },
+			{ name: '--wpd-ribbon-banner-pull', default: '-36px', description: 'How far the strip overhangs the clip edge.' },
+			{ name: '--wpd-ribbon-bg', default: 'var(--wp-admin-theme-color, #2271b1)' },
+			{ name: '--wpd-ribbon-fg', default: '#fff' },
+			{ name: '--wpd-ribbon-shadow', default: '0 2px 4px rgba(0,0,0,0.2)' },
+			{ name: '--wpd-ribbon-padding', default: '4px 0' },
+			{ name: '--wpd-ribbon-font', default: '700 10px/1.4 system-ui' },
+			{ name: '--wpd-ribbon-tracking', default: '0.06em' },
+			{ name: '--wpd-ribbon-z', default: '2' },
+		],
+		example: html`
+			<div
+				style="position: relative; width: 240px; height: 120px;
+				       border: 1px solid #ccc; border-radius: 8px;
+				       padding: 16px; box-sizing: border-box;"
+			>
+				<wpd-ribbon>Featured</wpd-ribbon>
+				Card body…
+			</div>
+		`,
+	} as const;
+
+	protected render() {
+		return html`<span class="banner" part="banner"><slot></slot></span>`;
+	}
+}
+defineComponent( 'wpd-ribbon', WpdRibbon );

--- a/tests/phpunit/tests/desktopFilesStore.php
+++ b/tests/phpunit/tests/desktopFilesStore.php
@@ -341,4 +341,136 @@ class Tests_DesktopMode_FilesStore extends WP_UnitTestCase {
 		$this->assertCount( 1, $rows );
 		$this->assertSame( 'A', $rows[0]['name'] );
 	}
+
+	// ───────────────────────────────────────────────────────────────
+	// Folder-cycle prevention. A folder must not be movable into
+	// itself or into any of its descendants — committing such a
+	// move would leave the chain looping back, stranding every
+	// descendant outside the desktop root.
+	// ───────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::desktop_mode_files_would_create_folder_cycle
+	 */
+	public function test_cycle_detector_flags_self_target() {
+		$folder = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'X' ) );
+		$this->assertTrue(
+			desktop_mode_files_would_create_folder_cycle(
+				self::$admin_id,
+				$folder,
+				$folder
+			)
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_would_create_folder_cycle
+	 */
+	public function test_cycle_detector_flags_descendant_target() {
+		// X (root) → Y → Z
+		$x = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'X' ) );
+		$y = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'Y' ) );
+		// Y's placement under X.
+		desktop_mode_files_place( self::$admin_id, $x, 'folder', (string) $y );
+		$z = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'Z' ) );
+		desktop_mode_files_place( self::$admin_id, $y, 'folder', (string) $z );
+
+		// Moving X into Z (a descendant of X) would form X → Z → Y → X.
+		$this->assertTrue(
+			desktop_mode_files_would_create_folder_cycle(
+				self::$admin_id,
+				$x,
+				$z
+			),
+			'Target inside the moving folder\'s subtree must flag a cycle.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_would_create_folder_cycle
+	 */
+	public function test_cycle_detector_allows_unrelated_target() {
+		// Two parallel trees — moving one folder under the other is fine.
+		$x = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'X' ) );
+		$y = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'Y' ) );
+
+		$this->assertFalse(
+			desktop_mode_files_would_create_folder_cycle(
+				self::$admin_id,
+				$x,
+				$y
+			)
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_would_create_folder_cycle
+	 */
+	public function test_cycle_detector_allows_move_to_root() {
+		$x = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'X' ) );
+		// Target parent 0 = desktop root, can never form a cycle.
+		$this->assertFalse(
+			desktop_mode_files_would_create_folder_cycle(
+				self::$admin_id,
+				$x,
+				0
+			)
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_move
+	 */
+	public function test_move_rejects_folder_cycle_into_descendant() {
+		// X → Y. Now try to move X into Y.
+		$x = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'X' ) );
+		$y = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'Y' ) );
+		// X has an auto-placed row at root; Y has a placement under X.
+		$x_placement = desktop_mode_files_place(
+			self::$admin_id,
+			0,
+			'folder',
+			(string) $x
+		);
+		desktop_mode_files_place( self::$admin_id, $x, 'folder', (string) $y );
+
+		$result = desktop_mode_files_move(
+			$x_placement,
+			self::$admin_id,
+			array( 'parent_id' => $y )
+		);
+		$this->assertWPError( $result );
+		$this->assertSame(
+			'desktop_mode_files_folder_cycle',
+			$result->get_error_code()
+		);
+
+		// And the row was not actually moved.
+		$row = desktop_mode_files_get_placement( $x_placement );
+		$this->assertSame( 0, (int) $row['parent_id'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_move
+	 */
+	public function test_move_rejects_folder_into_itself() {
+		$x = desktop_mode_files_create_folder( self::$admin_id, array( 'name' => 'X' ) );
+		$x_placement = desktop_mode_files_place(
+			self::$admin_id,
+			0,
+			'folder',
+			(string) $x
+		);
+
+		$result = desktop_mode_files_move(
+			$x_placement,
+			self::$admin_id,
+			array( 'parent_id' => $x )
+		);
+		$this->assertWPError( $result );
+		$this->assertSame(
+			'desktop_mode_files_folder_cycle',
+			$result->get_error_code()
+		);
+	}
 }

--- a/tests/phpunit/tests/osSettings.php
+++ b/tests/phpunit/tests/osSettings.php
@@ -139,4 +139,119 @@ class Tests_DesktopMode_OsSettings extends WP_UnitTestCase {
 		);
 		$this->assertSame( 'off', $clean['ai']['transport'] );
 	}
+
+	// ────────────────────────────────────────────────────────────────
+	// dockPromotedPositions — persisted x/y for dock-item icons the
+	// user promoted to the desktop wallpaper.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::desktop_mode_default_os_settings
+	 */
+	public function test_default_includes_empty_dock_promoted_positions() {
+		$defaults = desktop_mode_default_os_settings();
+		$this->assertArrayHasKey( 'dockPromotedPositions', $defaults );
+		$this->assertSame( array(), $defaults['dockPromotedPositions'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_keeps_well_formed_dock_promoted_positions() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'dockPromotedPositions' => array(
+					'edit-php'    => array( 'x' => 200, 'y' => 150 ),
+					'upload-php'  => array( 'x' => 320, 'y' => 240 ),
+				),
+			)
+		);
+		$this->assertArrayHasKey( 'dockPromotedPositions', $clean );
+		$this->assertCount( 2, $clean['dockPromotedPositions'] );
+		$this->assertSame(
+			array( 'x' => 200, 'y' => 150 ),
+			$clean['dockPromotedPositions']['edit-php']
+		);
+	}
+
+	/**
+	 * Slugs go through `sanitize_key()`, so values from an evil JSON
+	 * blob with spaces / uppercase get normalized rather than passed
+	 * through verbatim.
+	 *
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_normalizes_dock_promoted_position_keys() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'dockPromotedPositions' => array(
+					'Edit Php' => array( 'x' => 10, 'y' => 20 ),
+				),
+			)
+		);
+		$this->assertArrayNotHasKey( 'Edit Php', $clean['dockPromotedPositions'] );
+		$this->assertArrayHasKey( 'editphp', $clean['dockPromotedPositions'] );
+	}
+
+	/**
+	 * Non-numeric / missing coords are dropped — the JS shouldn't
+	 * receive a half-shaped position that would crash the synthesizer.
+	 *
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_drops_malformed_dock_promoted_position_values() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'dockPromotedPositions' => array(
+					'a' => array( 'x' => 'not-a-number', 'y' => 0 ),
+					'b' => array( 'x' => 0 ), // missing y
+					'c' => 'not-an-array',
+					'd' => array( 'x' => 50, 'y' => 60 ),
+				),
+			)
+		);
+		$this->assertSame(
+			array( 'd' => array( 'x' => 50, 'y' => 60 ) ),
+			$clean['dockPromotedPositions']
+		);
+	}
+
+	/**
+	 * Out-of-range coordinates are dropped. A corrupted JSON blob with
+	 * coords of ±10^9 shouldn't make it into user meta where it could
+	 * later inflate a screen-position math expression.
+	 *
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_drops_absurd_dock_promoted_position_coords() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'dockPromotedPositions' => array(
+					'huge'    => array( 'x' => 999999999, 'y' => 0 ),
+					'neg'     => array( 'x' => -999999999, 'y' => 0 ),
+					'normal'  => array( 'x' => 100, 'y' => 100 ),
+				),
+			)
+		);
+		$this->assertSame(
+			array( 'normal' => array( 'x' => 100, 'y' => 100 ) ),
+			$clean['dockPromotedPositions']
+		);
+	}
+
+	/**
+	 * Cap-at-256 prevents an evil blob from ballooning user meta.
+	 *
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_caps_dock_promoted_positions_at_256() {
+		$input = array();
+		for ( $i = 0; $i < 300; $i++ ) {
+			$input[ 'item-' . $i ] = array( 'x' => $i, 'y' => $i );
+		}
+		$clean = desktop_mode_sanitize_os_settings(
+			array( 'dockPromotedPositions' => $input )
+		);
+		$this->assertCount( 256, $clean['dockPromotedPositions'] );
+	}
 }

--- a/tests/phpunit/tests/pluginsWindowFeaturedAjax.php
+++ b/tests/phpunit/tests/pluginsWindowFeaturedAjax.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Tests for the Plugins window's Featured tab AJAX endpoint + curated
+ * slug helper.
+ *
+ * The Featured tab is the third tab in the native Plugins window. It
+ * surfaces plugins that depend on Desktop Mode — manually curated for
+ * now (wp.org's plugins_api has no usable `requires_plugins` filter)
+ * and topped up at runtime by scanning the popular-plugins feed for
+ * rows whose `requires_plugins` array contains `desktop-mode`.
+ *
+ * Tests stub `plugins_api` via the `plugins_api` filter so we don't
+ * make real wp.org HTTPS calls from the suite.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-plugins-window
+ * @group ajax
+ */
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
+class Tests_DesktopMode_PluginsWindowFeaturedAjax extends WP_Ajax_UnitTestCase {
+
+	private $admin_id;
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		delete_transient( 'dm_pwfeatured_v1' );
+	}
+
+	public function tear_down() {
+		delete_transient( 'dm_pwfeatured_v1' );
+		remove_all_filters( 'desktop_mode_plugins_featured_slugs' );
+		remove_all_filters( 'desktop_mode_plugins_featured_response' );
+		remove_all_filters( 'plugins_api' );
+		parent::tear_down();
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Curated slugs helper.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * The seed list must include the manually curated entry — the wp.org
+	 * author of the plugin omitted the `Requires Plugins` header, so
+	 * without this seed users would never discover it from the tab.
+	 *
+	 * @covers ::desktop_mode_plugins_window_featured_slugs
+	 */
+	public function test_curated_slugs_contains_default_seed() {
+		$slugs = desktop_mode_plugins_window_featured_slugs();
+		$this->assertContains(
+			'odd-outlandish-desktop-decorator',
+			$slugs,
+			'Curated list must include the hand-picked seed plugin.'
+		);
+	}
+
+	/**
+	 * `desktop_mode_plugins_featured_slugs` must be filterable so
+	 * downstream plugins can append their own recommendations.
+	 *
+	 * @covers ::desktop_mode_plugins_window_featured_slugs
+	 */
+	public function test_curated_slugs_filter_can_append() {
+		add_filter(
+			'desktop_mode_plugins_featured_slugs',
+			static function ( $slugs ) {
+				$slugs[] = 'my-companion-plugin';
+				return $slugs;
+			}
+		);
+		$slugs = desktop_mode_plugins_window_featured_slugs();
+		$this->assertContains( 'my-companion-plugin', $slugs );
+	}
+
+	/**
+	 * Filter output is sanitized + deduped. A garbled or repeated entry
+	 * mustn't leak into the AJAX payload (and the slug must be safe to
+	 * concatenate into a wp.org URL).
+	 *
+	 * @covers ::desktop_mode_plugins_window_featured_slugs
+	 */
+	public function test_curated_slugs_filter_output_is_sanitized_and_deduped() {
+		add_filter(
+			'desktop_mode_plugins_featured_slugs',
+			static function () {
+				return array(
+					'odd-outlandish-desktop-decorator',
+					'odd-outlandish-desktop-decorator', // duplicate
+					'BAD SLUG WITH SPACES',             // sanitize_key strips spaces/uppercase
+					'',                                 // empty filtered out
+					'fine-plugin',
+				);
+			}
+		);
+		$slugs = desktop_mode_plugins_window_featured_slugs();
+		$this->assertSame(
+			array( 'odd-outlandish-desktop-decorator', 'badslugwithspaces', 'fine-plugin' ),
+			array_values( $slugs )
+		);
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// AJAX endpoint.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * Helper: dispatch the featured AJAX action and return decoded body.
+	 */
+	private function dispatch_featured( $with_nonce = true ) {
+		$_POST = array();
+		if ( $with_nonce ) {
+			$_POST['_ajax_nonce'] = wp_create_nonce( 'desktop-mode-plugins' );
+		}
+		try {
+			$this->_handleAjax( 'desktop_mode_plugins_featured' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected — wp_send_json_* throws this in tests.
+		} catch ( WPAjaxDieStopException $e ) {
+			// Some Core paths throw this variant instead.
+		}
+		return json_decode( $this->_last_response, true );
+	}
+
+	/**
+	 * Subscribers (no `install_plugins`) must be rejected — the AJAX
+	 * guard re-validates the cap server-side.
+	 *
+	 * @covers ::desktop_mode_plugins_window_ajax_featured
+	 */
+	public function test_subscriber_rejected_with_403() {
+		wp_set_current_user( $this->subscriber_id );
+		$response = $this->dispatch_featured();
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'desktop_mode_plugins_forbidden', $response['data']['code'] );
+	}
+
+	/**
+	 * Missing nonce is a 403, not a 200. Plugin Check + WordPress
+	 * security guidance both expect every admin-ajax handler to refuse
+	 * unauthenticated callers.
+	 *
+	 * @covers ::desktop_mode_plugins_window_ajax_featured
+	 */
+	public function test_missing_nonce_rejected() {
+		wp_set_current_user( $this->admin_id );
+		$response = $this->dispatch_featured( false );
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'desktop_mode_plugins_bad_nonce', $response['data']['code'] );
+	}
+
+	/**
+	 * Happy path: an admin gets the curated rows in the response, with
+	 * `featured: true`, and the discovery feed's row that declares
+	 * `requires_plugins => [desktop-mode]` is appended.
+	 *
+	 * @covers ::desktop_mode_plugins_window_ajax_featured
+	 */
+	public function test_admin_receives_curated_plus_discovered_payload() {
+		wp_set_current_user( $this->admin_id );
+		$this->mock_plugins_api();
+
+		$response = $this->dispatch_featured();
+		$this->assertTrue( $response['success'] );
+
+		$plugins = $response['data']['plugins'];
+		$this->assertNotEmpty( $plugins );
+
+		// First row must be the curated seed, flagged featured: true.
+		$this->assertSame( 'odd-outlandish-desktop-decorator', $plugins[0]['slug'] );
+		$this->assertTrue( $plugins[0]['featured'] );
+
+		// The discovery feed includes one row that declares the
+		// desktop-mode dependency — it should land in the payload too,
+		// with featured: false. Unrelated rows must be filtered out.
+		$slugs = array_column( $plugins, 'slug' );
+		$this->assertContains( 'fake-dependent-plugin', $slugs );
+		$this->assertNotContains( 'unrelated-plugin', $slugs );
+
+		$dependent = null;
+		foreach ( $plugins as $row ) {
+			if ( 'fake-dependent-plugin' === $row['slug'] ) {
+				$dependent = $row;
+				break;
+			}
+		}
+		$this->assertNotNull( $dependent );
+		$this->assertFalse( $dependent['featured'] );
+
+		// Info block carries counts the JS uses for headers / empty states.
+		$this->assertSame( count( $plugins ), $response['data']['info']['results'] );
+	}
+
+	/**
+	 * Discovery dedupes against curated slugs. If wp.org's popular feed
+	 * happens to return a curated entry too, we must not emit it twice
+	 * (and the curated `featured: true` flag wins).
+	 *
+	 * @covers ::desktop_mode_plugins_window_ajax_featured
+	 */
+	public function test_discovery_dedupes_against_curated() {
+		wp_set_current_user( $this->admin_id );
+		$this->mock_plugins_api( array(
+			// Same slug appears in both the discovery feed AND the
+			// curated list — the AJAX must only emit it once.
+			'discovery' => array(
+				array(
+					'slug'             => 'odd-outlandish-desktop-decorator',
+					'name'             => 'Outlandish Desktop Decorator',
+					'requires_plugins' => array( 'desktop-mode' ),
+				),
+			),
+		) );
+
+		$response = $this->dispatch_featured();
+		$slugs    = array_column( $response['data']['plugins'], 'slug' );
+		$this->assertSame(
+			1,
+			count( array_filter( $slugs, static fn( $s ) => 'odd-outlandish-desktop-decorator' === $s ) ),
+			'Curated + discovery overlap must collapse to a single row.'
+		);
+	}
+
+	/**
+	 * Second call within the cache window returns the same payload —
+	 * proves the transient stuck, and that the helper isn't re-hitting
+	 * `plugins_api` on every tab open. Important because each call is
+	 * an outbound wp.org HTTPS round-trip when uncached.
+	 *
+	 * @covers ::desktop_mode_plugins_window_ajax_featured
+	 */
+	public function test_response_is_cached_for_subsequent_calls() {
+		wp_set_current_user( $this->admin_id );
+		$this->mock_plugins_api();
+
+		$first = $this->dispatch_featured();
+
+		// Reset the response buffer + swap the mock so a fresh call
+		// would surface different data — if the cache works, we get the
+		// FIRST response back unchanged.
+		$this->_last_response = '';
+		remove_all_filters( 'plugins_api' );
+		$this->mock_plugins_api( array( 'curated_name' => 'DIFFERENT' ) );
+
+		$second = $this->dispatch_featured();
+
+		$this->assertSame(
+			$first['data']['plugins'][0]['name'],
+			$second['data']['plugins'][0]['name'],
+			'Second dispatch must read from the transient, not re-call plugins_api.'
+		);
+	}
+
+	/**
+	 * `desktop_mode_plugins_featured_response` filter must run before
+	 * the payload is cached + sent. Lets host plugins inject premium
+	 * rows or enforce a cap.
+	 *
+	 * @covers ::desktop_mode_plugins_window_ajax_featured
+	 */
+	public function test_response_filter_can_inject_extra_rows() {
+		wp_set_current_user( $this->admin_id );
+		$this->mock_plugins_api();
+
+		add_filter(
+			'desktop_mode_plugins_featured_response',
+			static function ( $payload ) {
+				$payload['plugins'][] = array(
+					'slug'     => 'private-premium-companion',
+					'name'     => 'Private Premium',
+					'featured' => true,
+				);
+				return $payload;
+			}
+		);
+
+		$response = $this->dispatch_featured();
+		$slugs    = array_column( $response['data']['plugins'], 'slug' );
+		$this->assertContains( 'private-premium-companion', $slugs );
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Test helpers.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * Stub `plugins_api` so the test never makes a real wp.org call.
+	 * Returns a curated info object for the `plugin_information` action
+	 * and a small discovery feed for `query_plugins`.
+	 */
+	private function mock_plugins_api( array $overrides = array() ) {
+		$curated_name = $overrides['curated_name'] ?? 'ODD — Outlandish Desktop Decorator';
+		$discovery    = $overrides['discovery'] ?? array(
+			// Row that explicitly depends on desktop-mode — should appear.
+			array(
+				'slug'             => 'fake-dependent-plugin',
+				'name'             => 'Fake Dependent',
+				'requires_plugins' => array( 'desktop-mode' ),
+				'rating'           => 80,
+				'short_description' => 'Depends on desktop-mode.',
+			),
+			// Row without the dependency — must be filtered out.
+			array(
+				'slug'             => 'unrelated-plugin',
+				'name'             => 'Unrelated',
+				'requires_plugins' => array(),
+				'rating'           => 60,
+				'short_description' => 'Has nothing to do with desktop mode.',
+			),
+		);
+
+		add_filter(
+			'plugins_api',
+			static function ( $value, $action, $args ) use ( $curated_name, $discovery ) {
+				if ( 'plugin_information' === $action ) {
+					return (object) array(
+						'slug'              => $args->slug,
+						'name'              => $curated_name,
+						'short_description' => 'Curated companion plugin.',
+						'rating'            => 0,
+						'requires_plugins'  => array(),
+					);
+				}
+				if ( 'query_plugins' === $action ) {
+					$plugins = array_map(
+						static fn( $row ) => (object) $row,
+						$discovery
+					);
+					return (object) array(
+						'plugins' => $plugins,
+						'info'    => array( 'page' => 1, 'pages' => 1, 'results' => count( $plugins ) ),
+					);
+				}
+				return $value;
+			},
+			10,
+			3
+		);
+	}
+}

--- a/tests/vitest/desktop-files-bin-drop.test.ts
+++ b/tests/vitest/desktop-files-bin-drop.test.ts
@@ -198,6 +198,114 @@ describe( 'recycle-bin dock icon drop (user regression)', () => {
 		).toBe( false );
 	} );
 
+	test( 'dragging the recycle bin onto itself is rejected — no self-trash', async () => {
+		// Regression: the bin tile (a `'shortcut'` placement with
+		// `file.ref === 'desktop-mode-recycle-bin'`) is registered as
+		// BOTH a drag source (every files-layer tile is) AND a drop
+		// target (this module wires the bin icon up as one). Without
+		// a guard in `accept()`, dragging the bin onto itself fires
+		// `trashByFileType( binPlacement )` → the bin's own placement
+		// gets soft-trashed and vanishes from the desktop.
+		const { store, rest, binTargets } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+
+		const fetchSpy = vi.fn( async () =>
+			new Response(
+				JSON.stringify( { deleted: true } ),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+		);
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+
+		// Build the bin tile in the same DOM shape the files layer
+		// produces — `.desktop-mode-file-tile[data-file-ref="…"]` is
+		// the first selector `findBinTile()` checks.
+		const binTile = document.createElement( 'div' );
+		binTile.classList.add( 'desktop-mode-file-tile' );
+		binTile.dataset.fileRef = 'desktop-mode-recycle-bin';
+		document.body.appendChild( binTile );
+
+		binTargets.installRecycleBinDropTargets( manager );
+		expect(
+			manager.debug().listTargets().find( ( t ) => t.id === 'recycle-bin-dock' ),
+		).toBeDefined();
+
+		// The bin's placement: positive id (it's a real DB row) +
+		// the `shortcut` file shape with the system ref.
+		const binPlacement = {
+			id: 99,
+			parentId: 0,
+			x: 0,
+			y: 0,
+			sortOrder: 0,
+			updatedAtMs: 1,
+			meta: null,
+			file: {
+				type: 'shortcut',
+				ref: 'desktop-mode-recycle-bin',
+				title: 'Recycle Bin',
+				icon: 'dashicons-trash',
+				previewUrl: '',
+				exists: true,
+			},
+		};
+		store.setFolderPlacements( 0, [ binPlacement ] );
+
+		document.elementFromPoint = ( x, y ) => {
+			if ( x >= 280 && x < 340 && y >= 280 && y < 340 ) {
+				return binTile;
+			}
+			return null;
+		};
+
+		const onCommit = vi.fn();
+		manager.start( {
+			payload: {
+				type: 'desktop-file',
+				source: binTile,
+				data: {
+					placement: binPlacement,
+					sourceFolderId: 0,
+				},
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 100, 100, binTile ),
+			onCommit,
+		} );
+
+		document.dispatchEvent( pointerEvent( 'pointermove', 110, 100 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 300, 300 ) );
+
+		// Hover highlight must NOT fire — `accept` returns false up
+		// front so the drop target never lights up.
+		expect(
+			binTile.hasAttribute( 'data-desktop-mode-trash-drop-active' ),
+		).toBe( false );
+
+		document.dispatchEvent( pointerEvent( 'pointerup', 300, 300 ) );
+
+		// `onCommit` from the drag source side fires only on accepted
+		// drops; rejected drops route through `_cancel`.
+		expect( onCommit ).not.toHaveBeenCalled();
+
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		// No REST DELETE issued — the bin's placement survives.
+		const deletes = fetchSpy.mock.calls.filter( ( call ) => {
+			const init = call[ 1 ] as RequestInit | undefined;
+			return init?.method === 'DELETE';
+		} );
+		expect( deletes.length ).toBe( 0 );
+
+		// Bin still in the store at the same id.
+		const remaining = store.getFilesState().placementsByFolder.get( 0 ) ?? [];
+		expect( remaining.find( ( p ) => p.id === 99 ) ).toBeDefined();
+	} );
+
 	test( 'bin drop target re-registers after a dock re-render', async () => {
 		const { store, rest, binTargets } = await load();
 		store.__resetFilesStoreForTests();

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -293,4 +293,181 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 
 		handle.dispose();
 	} );
+
+	test( 'drag-to-reposition keeps tile DOM identity — no full grid rebuild', async () => {
+		// Regression: on every drop the repaint did `container.replaceChildren()`
+		// — every tile was destroyed and re-created. To users that visible
+		// flash reads as "the whole desktop just reloaded." The fast path
+		// in `tryPatchPositions` patches positions in place; the tile
+		// element the user was just holding has to survive the store update.
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		installManagerOnWindow();
+
+		store.setFolderPlacements( 0, [ placement( 1 ), placement( 2 ) ] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		Object.defineProperty( host, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		const handle = layer.mountFilesLayer( host, 0 );
+
+		// Capture initial DOM identity. If the fast path works the
+		// same `<button>` element holds the placement after the drag.
+		const tileBefore = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		const peerBefore = host.querySelector< HTMLElement >( '[data-placement-id="2"]' );
+		expect( tileBefore ).not.toBeNull();
+		expect( peerBefore ).not.toBeNull();
+
+		const container = host.querySelector< HTMLElement >( '.desktop-mode-files-layer' );
+		Object.defineProperty( container!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		Object.defineProperty( tileBefore!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 100, top: 100, right: 188, bottom: 196,
+				width: 88, height: 96, x: 100, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		installElementFromPointStub( [ { el: host, rect: { x: 0, y: 0, w: 1024, h: 768 } } ] );
+		tileBefore!.style.left = '100px';
+		tileBefore!.style.top = '100px';
+
+		tileBefore!.dispatchEvent( pointerEvent( 'pointerdown', 140, 140, tileBefore! ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 410, 320 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 410, 320 ) );
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Same DOM node — no wholesale rebuild.
+		const tileAfter = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		const peerAfter = host.querySelector< HTMLElement >( '[data-placement-id="2"]' );
+		expect( tileAfter ).toBe( tileBefore );
+		expect( peerAfter ).toBe( peerBefore );
+		// But the position did update.
+		expect( tileAfter!.style.left ).not.toBe( '100px' );
+
+		handle.dispose();
+	} );
+
+	test( 'synthetic dock-promoted placement: drag updates store but issues no PATCH', async () => {
+		// Regression: dragging an icon the user promoted from the dock
+		// (OS Settings → Apps & Icons) used to fire a PATCH against a
+		// negative id, which the REST regex `(?P<id>\d+)` rejects → WP
+		// returns `rest_no_route` 404 → the user sees a scary
+		// `[desktop-mode] files: drag persist failed` in the console
+		// every time they nudge a promoted icon.
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		const fetchSpy = setupRestStub();
+		installManagerOnWindow();
+
+		// Spy on the OS-Settings persistence facade — the layer should
+		// route the new position through here for synth placements.
+		const updateOsSettings = vi.fn();
+		const wp = ( window as unknown as { wp: { desktop: Record< string, unknown > } } ).wp;
+		wp.desktop.getOsSettings = () => ( { dockPromotedPositions: {} } );
+		wp.desktop.updateOsSettings = updateOsSettings;
+
+		// Synthetic placement: negative id + `__synthFromDockItem`
+		// meta marker (the shape `settings/desktop-shortcuts-sync.ts`
+		// produces for a dock-item promoted to the desktop).
+		store.setFolderPlacements( 0, [
+			placement( -42, {
+				meta: { __synthFromDockItem: 'edit-php' },
+				file: {
+					type: 'shortcut',
+					ref: 'dock-promoted:edit-php',
+					title: 'Posts',
+					icon: 'dashicons-admin-post',
+					previewUrl: '',
+					exists: true,
+				},
+			} ),
+		] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		Object.defineProperty( host, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '[data-placement-id="-42"]' );
+		expect( tile ).not.toBeNull();
+		tile!.style.left = '100px';
+		tile!.style.top = '100px';
+		Object.defineProperty( tile!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 100, top: 100, right: 188, bottom: 196,
+				width: 88, height: 96, x: 100, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		const container = host.querySelector< HTMLElement >( '.desktop-mode-files-layer' );
+		Object.defineProperty( container!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		installElementFromPointStub( [ { el: host, rect: { x: 0, y: 0, w: 1024, h: 768 } } ] );
+
+		// Boot-time hydrate call is the only PATCH-able thing we
+		// want to ignore here.
+		fetchSpy.mockClear();
+
+		tile!.dispatchEvent( pointerEvent( 'pointerdown', 140, 140, tile! ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 310, 220 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 310, 220 ) );
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// No PATCH attempted — synth placements live JS-only.
+		const patches = fetchSpy.mock.calls.filter( ( call ) => {
+			const init = call[ 1 ] as RequestInit | undefined;
+			return init?.method === 'PATCH';
+		} );
+		expect( patches.length ).toBe( 0 );
+
+		// Store should still reflect the drop position (the optimistic
+		// upsert runs before the gate), so the tile visually moved.
+		const updated = store
+			.getFilesState()
+			.placementsByFolder.get( 0 )
+			?.find( ( p ) => p.id === -42 );
+		expect( updated ).toBeDefined();
+		expect( updated!.x ).not.toBe( 100 );
+
+		// Position persisted into OS Settings keyed by the source
+		// dock-item id, so the synthesizer can restore it on reload.
+		expect( updateOsSettings ).toHaveBeenCalledTimes( 1 );
+		const patch = updateOsSettings.mock.calls[ 0 ][ 0 ] as {
+			dockPromotedPositions: Record< string, { x: number; y: number } >;
+		};
+		expect( patch.dockPromotedPositions ).toBeDefined();
+		expect( patch.dockPromotedPositions[ 'edit-php' ] ).toEqual( {
+			x: updated!.x,
+			y: updated!.y,
+		} );
+
+		handle.dispose();
+	} );
 } );

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -294,6 +294,105 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 		handle.dispose();
 	} );
 
+	test( 'drop into a column with a pinned tile (My WordPress) skips the pinned cell', async () => {
+		// Regression: a column rendered as
+		//   My WordPress (pinned) | empty | Icon A | Icon B
+		// — dragging Icon B at the empty cell used to highlight + drop
+		// onto the My WordPress slot. Cause: the layer's repaint
+		// reserves pinned slots (column 0, row 0..N-1) ignoring stored
+		// (x, y), but `buildOccupiedSet` only read stored coords —
+		// so the pinned cell was missing from `occupied` and
+		// `snapToEmptyCell`'s column-major scan picked (0, 0) as
+		// "empty" first.
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		const fetchSpy = setupRestStub();
+		installManagerOnWindow();
+
+		// My WordPress: pinned via the `file.pinned` flag. Stored
+		// coords intentionally NOT (0, 0) — proves the test actually
+		// exercises the bug (the layer ignores them and slots it at
+		// (0, 0) regardless).
+		const myWp = placement( 100, {
+			x: 9999,
+			y: 9999,
+			file: {
+				type: 'shortcut',
+				ref: 'desktop-mode-my-wordpress',
+				title: 'My WordPress',
+				icon: 'dashicons-wordpress',
+				previewUrl: '',
+				exists: true,
+				pinned: true,
+			},
+		} );
+		// Icon A at (0, 2), Icon B at (0, 3). Cell pitch is
+		// `GRID_PADDING + row * GRID_CELL_H` = 16 + row*110.
+		const iconA = placement( 200, { x: 16, y: 236 } ); // (col 0, row 2)
+		const iconB = placement( 201, { x: 16, y: 346 } ); // (col 0, row 3)
+		store.setFolderPlacements( 0, [ myWp, iconA, iconB ] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		Object.defineProperty( host, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tileB = host.querySelector< HTMLElement >( '[data-placement-id="201"]' );
+		expect( tileB ).not.toBeNull();
+		const container = host.querySelector< HTMLElement >( '.desktop-mode-files-layer' );
+		Object.defineProperty( container!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 0, top: 0, right: 1024, bottom: 768,
+				width: 1024, height: 768, x: 0, y: 0, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		Object.defineProperty( tileB!, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 16, top: 346, right: 104, bottom: 442,
+				width: 88, height: 96, x: 16, y: 346, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+		installElementFromPointStub( [ { el: host, rect: { x: 0, y: 0, w: 1024, h: 768 } } ] );
+
+		fetchSpy.mockClear();
+
+		// Drag Icon B from its (16, 346) toward the empty cell at
+		// (16, 126) — that's (col 0, row 1) on screen.
+		// Pointerdown roughly at the tile's center so the ghost
+		// offset is (44, 48) — same offset the user has when
+		// grabbing a tile naturally.
+		tileB!.dispatchEvent( pointerEvent( 'pointerdown', 60, 394, tileB! ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 60, 220 ) );
+		// Release with cursor at (60, 174) → tile top-left lands at
+		// (60-44, 174-48) = (16, 126) → cell (0, 1).
+		document.dispatchEvent( pointerEvent( 'pointerup', 60, 174 ) );
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const patch = fetchSpy.mock.calls.find( ( call ) => {
+			const init = call[ 1 ] as RequestInit | undefined;
+			return init?.method === 'PATCH' && String( call[ 0 ] ).includes( '/placements/201' );
+		} );
+		expect( patch ).toBeDefined();
+		const body = JSON.parse(
+			( patch![ 1 ] as RequestInit ).body as string,
+		) as { x: number; y: number; parentId: number };
+		// Critical assertion: the snapped cell is (0, 1) — NOT (0, 0)
+		// which is My WordPress's pinned slot.
+		expect( body.x ).toBe( 16 );
+		expect( body.y ).toBe( 126 );
+
+		handle.dispose();
+	} );
+
 	test( 'tile drag reads live placement from store, not closure — heartbeat-bumped updatedAtMs is honored', async () => {
 		// Regression: with the fast-path repaint preserving tile DOM
 		// identity, `attachTileDrag` is only attached once — the

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -294,6 +294,67 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 		handle.dispose();
 	} );
 
+	test( 'tile drag reads live placement from store, not closure — heartbeat-bumped updatedAtMs is honored', async () => {
+		// Regression: with the fast-path repaint preserving tile DOM
+		// identity, `attachTileDrag` is only attached once — the
+		// closure-captured `placement` would otherwise hold a stale
+		// `updatedAtMs` forever after the first heartbeat bump.
+		// Server then rejected the PATCH with `If-Match` mismatch →
+		// 409 surfaced as "admin moved this to 'another folder'."
+		// Shared folders saw this most because peers bump
+		// `updatedAtMs` on every heartbeat tick.
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const manager = installManagerOnWindow();
+
+		// Mount the layer with one placement at updatedAtMs=100.
+		store.setFolderPlacements( 0, [
+			placement( 1 ),
+		] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '[data-placement-id="1"]' );
+		expect( tile ).not.toBeNull();
+
+		// Simulate the server-side bump that would happen after a
+		// peer-driven heartbeat tick — `upsertPlacement` from
+		// `applyDelta` in `heartbeat.ts` does exactly this.
+		store.upsertPlacement(
+			{ ...placement( 1 ), updatedAtMs: 9999 },
+			'remote',
+		);
+
+		// Fast-path took the repaint — same DOM node still in place.
+		expect(
+			host.querySelector< HTMLElement >( '[data-placement-id="1"]' ),
+		).toBe( tile );
+
+		// Capture the session payload by spying on `dragManager.start`.
+		// (The drag never actually has to threshold-lift for this
+		// test — what matters is what `start()` receives.)
+		const startSpy = vi.spyOn( manager, 'start' );
+
+		// Fire pointerdown to trigger the drag handler's `start` call.
+		tile!.dispatchEvent( pointerEvent( 'pointerdown', 50, 50, tile! ) );
+
+		expect( startSpy ).toHaveBeenCalledTimes( 1 );
+		const opts = startSpy.mock.calls[ 0 ][ 0 ];
+		const data = opts.payload.data as { placement: { updatedAtMs: number } };
+		expect( data.placement.updatedAtMs ).toBe( 9999 );
+
+		// Tear down before any pending drag manager state leaks into
+		// the next test.
+		document.dispatchEvent( pointerEvent( 'pointerup', 50, 50 ) );
+		startSpy.mockRestore();
+		handle.dispose();
+	} );
+
 	test( 'drag-to-reposition keeps tile DOM identity — no full grid rebuild', async () => {
 		// Regression: on every drop the repaint did `container.replaceChildren()`
 		// — every tile was destroyed and re-created. To users that visible

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -294,6 +294,111 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 		handle.dispose();
 	} );
 
+	test( 'hovering a non-folder tile during a drag flips the chip to reject', async () => {
+		// Regression: dragging onto a non-folder, non-bin tile
+		// (My WordPress, dock-promotion, plugin-registered icon,
+		// post / page shortcut) used to leave the chip green —
+		// "Drop here to move." The drop would silently snap to the
+		// next free cell, never landing INTO the tile, so the green
+		// affordance lied. Fix: tile-level reject claimant with
+		// `accept: () => false` so the chip turns red on hover.
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const manager = installManagerOnWindow();
+
+		// My WordPress as a pinned shortcut at slot (0, 0); Icon B
+		// as a regular post placement at (0, 2). We drag B onto
+		// My WordPress's tile.
+		const myWp = placement( 100, {
+			file: {
+				type: 'shortcut',
+				ref: 'desktop-mode-my-wordpress',
+				title: 'My WordPress',
+				icon: 'dashicons-wordpress',
+				previewUrl: '',
+				exists: true,
+				pinned: true,
+			},
+		} );
+		const iconB = placement( 200, { x: 16, y: 236 } );
+		store.setFolderPlacements( 0, [ myWp, iconB ] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const myWpTile = host.querySelector< HTMLElement >(
+			'[data-placement-id="100"]',
+		);
+		expect( myWpTile ).not.toBeNull();
+
+		// Verify the reject claimant is in the registry, keyed on the
+		// My WordPress tile element. Confirms the tile owns the
+		// drop-target slot, so a hit-test on the tile resolves to
+		// `accept: false` and the framework chip flips to "Can't
+		// drop here."
+		const target = manager
+			.debug()
+			.listTargets()
+			.find( ( t ) => t.id === 'desktop-mode-files-tile-100-reject' );
+		expect( target ).toBeDefined();
+		expect( target!.element ).toBe( myWpTile );
+		expect(
+			target!.accept( {
+				type: 'desktop-file',
+				source: host,
+				data: { placement: iconB, sourceFolderId: 0 },
+			} ),
+		).toBe( false );
+
+		handle.dispose();
+	} );
+
+	test( 'recycle-bin tile is NOT reject-claimed — its trash target survives', async () => {
+		// Mirror of the above for the bin exclusion. The bin tile is
+		// claimed by `recycle-bin-targets.ts` as a TRASH-accepting
+		// drop target — if `shouldRejectTileDrops` accidentally
+		// returned true for the bin, the layer's reject claimant
+		// would overwrite the bin's trash target (the registry keys
+		// by element).
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const manager = installManagerOnWindow();
+
+		const bin = placement( 99, {
+			file: {
+				type: 'shortcut',
+				ref: 'desktop-mode-recycle-bin',
+				title: 'Recycle Bin',
+				icon: 'dashicons-trash',
+				previewUrl: '',
+				exists: true,
+				pinned: true,
+			},
+		} );
+		store.setFolderPlacements( 0, [ bin ] );
+
+		const host = document.createElement( 'div' );
+		Object.defineProperty( host, 'clientWidth', { value: 1024, configurable: true } );
+		Object.defineProperty( host, 'clientHeight', { value: 768, configurable: true } );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+
+		// The layer-level reject claimant must NOT exist for the bin.
+		const rejected = manager
+			.debug()
+			.listTargets()
+			.find( ( t ) => t.id === 'desktop-mode-files-tile-99-reject' );
+		expect( rejected ).toBeUndefined();
+
+		handle.dispose();
+	} );
+
 	test( 'drop into a column with a pinned tile (My WordPress) skips the pinned cell', async () => {
 		// Regression: a column rendered as
 		//   My WordPress (pinned) | empty | Icon A | Icon B

--- a/tests/vitest/my-wordpress-drag.test.ts
+++ b/tests/vitest/my-wordpress-drag.test.ts
@@ -178,6 +178,73 @@ describe( 'My WordPress entity-tile drag (regression)', () => {
 		expect( onDrop ).not.toHaveBeenCalled();
 	} );
 
+	test( 'reject-claimant on the window body flips the hint chip to "Can\'t drop here"', () => {
+		// Regression: the user reported "we can't drop anything into
+		// MY WordPress app …" — and then "show the label CANT DROP
+		// HERE as we show in other cases." This proves the
+		// `accept: () => false` claimant on the window body is found
+		// by the registry's walk-up, drives the ghost into reject
+		// mode, and surfaces the hint chip with the framework's
+		// default reject label.
+		const manager = new DragManager();
+
+		// Faked My WordPress window: outer `.desktop-mode-window`
+		// wraps a `.desktop-mode-window__body` (the element our render
+		// callback receives). The claimant registers on the body.
+		const myWordpressWindow = document.createElement( 'div' );
+		myWordpressWindow.classList.add( 'desktop-mode-window' );
+		const bodyEl = document.createElement( 'div' );
+		bodyEl.classList.add( 'desktop-mode-window__body' );
+		myWordpressWindow.appendChild( bodyEl );
+		document.body.appendChild( myWordpressWindow );
+
+		// Mirror exactly what `renderInto` does in
+		// `src/my-wordpress/index.ts` — the only thing that matters
+		// for the chip text contract.
+		manager.registerDropTarget( {
+			id: 'desktop-mode-my-wordpress-reject',
+			element: bodyEl,
+			accept: () => false,
+			onDrop: () => {},
+		} );
+
+		// Source tile lives outside the window — typical scenario is a
+		// desktop tile dragged onto My WordPress.
+		const tile = document.createElement( 'div' );
+		document.body.appendChild( tile );
+
+		// Drag a desktop-file payload past the threshold. We DON'T
+		// need a successful drop — what we're asserting is the hover
+		// state mid-drag.
+		manager.start( {
+			payload: {
+				type: 'desktop-file',
+				source: tile,
+				data: {
+					placement: { id: 1 },
+					sourceFolderId: 0,
+				} as unknown as Record< string, unknown >,
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 50, 50, tile ),
+		} );
+
+		installElementFromPointStub( [
+			{ el: bodyEl, rect: { x: 0, y: 0, w: 500, h: 500 } },
+		] );
+
+		// Cross the lift threshold + hover the body — `_updateHover`
+		// runs against the claimant and should flip the ghost.
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+
+		const hint = document.querySelector( '.desktop-mode-drag-hint' );
+		expect( hint ).not.toBeNull();
+		expect( hint!.classList.contains( 'desktop-mode-drag-hint--reject' ) ).toBe( true );
+		expect( hint!.textContent ).toBe( "Can’t drop here" );
+
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 200 ) );
+	} );
+
 	test( 'Escape mid-drag aborts without firing onDrop', () => {
 		const manager = new DragManager();
 		const tile = document.createElement( 'div' );


### PR DESCRIPTION
- Implemented the Featured Plugins view in `featured-view.ts`, providing a curated gallery of plugins for Desktop Mode.
- Introduced a new `<wpd-ribbon>` component for displaying diagonal corner banners, with customizable placement and tone.
- Added styles for the `<wpd-ribbon>` component in `wpd-ribbon.styles.ts`.
- Created tests for the `<wpd-ribbon>` component to ensure proper rendering and attribute handling.
- Developed PHPUnit tests for the AJAX endpoint of the Featured tab, including caching and response validation.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-225-4a5b75836d37c3714782a178db17d81b6e3d9773.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->