### PR TITLE
feat: add "Automatic Updates" column and related functionality to Plugins window

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2017,6 +2017,16 @@ apply_filters( 'desktop_mode_plugins_window_refresh_updates', bool $refresh, boo
 
 Return `false` to skip the refresh — useful for hosts that run their own update orchestration (managed WordPress, internal mirrors) and don't want REST hits to potentially trigger a wp.org HTTPS check. The filter is also called on the explicit force-refresh path (when the in-window Refresh button passes `?desktop_mode_force_refresh=1`); returning `false` there keeps the no-network posture even on user-initiated refreshes. Inspect `$force` to apply different policies for opportunistic vs. user-initiated refreshes.
 
+### `desktop_mode_plugins_window_auto_updates_enabled` — Experimental *(filter, since 0.21.0)*
+
+Whether the Plugins window's "Automatic Updates" column should be shown to the current user. Mirrors Core's `WP_Plugins_List_Table::$show_autoupdates` gate (`wp_is_auto_update_enabled_for_type( 'plugin' )` + `update_plugins` cap + network-admin on multisite). Return `false` to suppress the column entirely — useful for managed-hosting environments that orchestrate auto-updates externally and don't want users toggling per-plugin state from within the shell.
+
+```php
+apply_filters( 'desktop_mode_plugins_window_auto_updates_enabled', bool $enabled, int $user_id ): bool
+```
+
+The flag is surfaced to the JS bundle on the window's `config` blob as `autoUpdatesEnabled` and consumed at column-build time — flipping it via the filter takes effect on the next reload of the window.
+
 ### REST-field decorators on `/wp/v2/plugins` — Stable (since 0.9.0)
 
 Server-injected enrichment fields. The JS reads them on every list paint:
@@ -2027,6 +2037,7 @@ Server-injected enrichment fields. The JS reads them on every list paint:
 | `desktop_mode_can_manage` | `{ activate, deactivate, delete: bool }` | Per-row capability flags so the JS doesn't re-derive caps. Server still re-validates every mutation. |
 | `desktop_mode_icon_url` | `string\|null` | Best-effort wp.org icon URL derived from the plugin's `textdomain`. Filterable via `desktop_mode_plugins_window_icon_url`. |
 | `desktop_mode_size_kb` | `int\|null` | Disk footprint of the plugin folder in kilobytes. Cached 6h. |
+| `desktop_mode_auto_update` | `{ enabled: bool, forced: bool\|null, supported: bool }` | (Since 0.21.0) Per-row auto-update state, mirroring Core's "Automatic Updates" column on `plugins.php`. `enabled` reflects the `auto_update_plugins` site option (overridden by `forced` when a filter pins it). `forced` is `null` for user-toggleable rows, `true`/`false` when the `auto_update_plugin` filter has pinned the state. `supported` is true when the `update_plugins` transient has an entry for the plugin (either `response` or `no_update`); when false the JS hides the toggle — premium / private plugins that never check in with wp.org. The toggle itself routes through Core's `wp_ajax_toggle_auto_updates` handler (action `toggle-auto-updates`, `'updates'` nonce). |
 
 ### Actions — Stable (since 0.9.0)
 

--- a/includes/plugins-window/permissions.php
+++ b/includes/plugins-window/permissions.php
@@ -114,3 +114,74 @@ function desktop_mode_plugins_window_caps( $user_id = null ) {
 		'update'   => $user_id > 0 && user_can( $user_id, 'update_plugins' ),
 	);
 }
+
+/**
+ * Whether the Plugins window should surface an "Automatic Updates"
+ * column at all.
+ *
+ * Mirrors Core's `WP_Plugins_List_Table::__construct()` gate:
+ *
+ *   $this->show_autoupdates = wp_is_auto_update_enabled_for_type( 'plugin' )
+ *       && current_user_can( 'update_plugins' )
+ *       && ( ! is_multisite() || $this->screen->in_admin( 'network' ) );
+ *
+ * `wp_is_auto_update_enabled_for_type()` lives in
+ * `wp-admin/includes/update.php`. On admin requests `init` fires
+ * INSIDE `wp-load.php`, BEFORE `wp-admin/admin.php` requires its
+ * includes — so by the time native windows register their config on
+ * `init` priority 20, the helper isn't loaded yet. We lazy-require
+ * it from this gate so the config blob always reflects the true
+ * state. (The check is gated by `is_admin()` so REST / front-end
+ * requests don't pay the cost.)
+ *
+ * On multisite, only network admins can toggle plugin auto-updates —
+ * Core gates the column on the network screen specifically, but we
+ * use the `manage_network_plugins` capability as the user-facing
+ * equivalent (true for super admins, false for everyone else).
+ *
+ * @since 0.21.0
+ *
+ * @param int|null $user_id Optional. Defaults to `get_current_user_id()`.
+ * @return bool
+ */
+function desktop_mode_plugins_window_auto_updates_enabled( $user_id = null ) {
+	$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
+
+	$enabled = false;
+	if ( $user_id > 0 && user_can( $user_id, 'update_plugins' ) ) {
+		// Lazy-require Core's admin update helper if it hasn't been
+		// loaded yet. Same posture `wp_ajax_install_plugin` uses for
+		// `plugins_api()` — admin-side files are safe to load when
+		// we're in admin context. We guard with `is_admin()` so REST
+		// / front-end requests don't pull in admin includes.
+		if ( ! function_exists( 'wp_is_auto_update_enabled_for_type' ) && is_admin() ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+		if (
+			function_exists( 'wp_is_auto_update_enabled_for_type' )
+			&& wp_is_auto_update_enabled_for_type( 'plugin' )
+		) {
+			if ( is_multisite() ) {
+				// Network-only — match Core's `screen->in_admin( 'network' )`
+				// gate as closely as we can outside a screen context.
+				$enabled = user_can( $user_id, 'manage_network_plugins' );
+			} else {
+				$enabled = true;
+			}
+		}
+	}
+
+	/**
+	 * Filter whether the Plugins window's "Automatic Updates" column
+	 * should be shown to the current user. Return `false` to hide the
+	 * column entirely (Core hides it when the auto-update subsystem is
+	 * disabled or when the viewer isn't on a network admin screen on
+	 * multisite).
+	 *
+	 * @since 0.21.0
+	 *
+	 * @param bool $enabled Default gate result.
+	 * @param int  $user_id User being checked.
+	 */
+	return (bool) apply_filters( 'desktop_mode_plugins_window_auto_updates_enabled', $enabled, $user_id );
+}

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -24,9 +24,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Register the four enrichment fields on the `plugin` REST resource.
+ * Register the five enrichment fields on the `plugin` REST resource.
  *
  * @since 0.9.0
+ * @since 0.21.0 Added `desktop_mode_auto_update`.
  */
 function desktop_mode_plugins_window_register_rest_fields() {
 	register_rest_field(

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -9,6 +9,7 @@
  *   - desktop_mode_can_manage       — `{ activate, deactivate, delete }`
  *   - desktop_mode_icon_url         — best-effort wp.org icon URL
  *   - desktop_mode_size_kb          — disk size of plugin folder
+ *   - desktop_mode_auto_update      — `{ enabled, forced, supported }`
  *
  * Plugin Check posture: every callback below uses ONLY functions
  * available in `wp-includes/` (current_user_can, get_site_transient,
@@ -78,6 +79,20 @@ function desktop_mode_plugins_window_register_rest_fields() {
 			'schema'       => array(
 				'description' => __( 'Approximate disk footprint of the plugin folder, in kilobytes (cached 6h).', 'desktop-mode' ),
 				'type'        => array( 'integer', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+
+	register_rest_field(
+		'plugin',
+		'desktop_mode_auto_update',
+		array(
+			'get_callback' => 'desktop_mode_plugins_window_field_auto_update',
+			'schema'       => array(
+				'description' => __( 'Auto-update state for this plugin (enabled / forced / supported), mirroring Core\'s plugins.php column.', 'desktop-mode' ),
+				'type'        => 'object',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
@@ -523,4 +538,109 @@ function desktop_mode_plugins_window_compute_dir_size_kb( $dir ) {
 	}
 
 	return $total_bytes > 0 ? max( 1, (int) round( $total_bytes / 1024 ) ) : 0;
+}
+
+/**
+ * `desktop_mode_auto_update` callback.
+ *
+ * Mirrors the per-row state Core derives in
+ * `WP_Plugins_List_Table::prepare_items()` for its "Automatic Updates"
+ * column. Shape:
+ *
+ *   - `enabled`   bool  — the plugin file is currently in the
+ *                          `auto_update_plugins` site option, OR a
+ *                          filter has forced auto-updates on.
+ *   - `forced`    bool|null — `true`/`false` when the
+ *                          `auto_update_plugin` filter pinned the state,
+ *                          `null` when the user is free to toggle.
+ *   - `supported` bool  — whether the `update_plugins` transient has an
+ *                          entry for this plugin (either in `response` or
+ *                          `no_update`). Core hides the toggle entirely
+ *                          when this is false — premium / private plugins
+ *                          that never check in with wp.org.
+ *
+ * NOT included here (lives on the window config instead): the global
+ * `wp_is_auto_update_enabled_for_type( 'plugin' )` flag, which depends
+ * on admin-only includes — see `desktop_mode_plugins_window_auto_updates_enabled()`.
+ *
+ * @since 0.21.0
+ *
+ * @param array $row Core REST plugin row.
+ * @return array{enabled:bool,forced:bool|null,supported:bool}
+ */
+function desktop_mode_plugins_window_field_auto_update( $row ) {
+	$plugin_file = desktop_mode_plugins_window_row_plugin_file( $row );
+	if ( '' === $plugin_file ) {
+		return array(
+			'enabled'   => false,
+			'forced'    => null,
+			'supported' => false,
+		);
+	}
+
+	$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
+	$enabled      = in_array( $plugin_file, $auto_updates, true );
+
+	// `update-supported` mirrors Core's logic: a plugin is "supported"
+	// for auto-update toggling when wp.org has either a pending update
+	// row OR an explicit no-update row in the `update_plugins` transient.
+	// Premium / private plugins that never call home land in neither
+	// bucket — Core hides the toggle so the user doesn't enable an
+	// auto-update that can't ever fire.
+	$supported = false;
+	$updates   = get_site_transient( 'update_plugins' );
+	if ( is_object( $updates ) ) {
+		if ( isset( $updates->response[ $plugin_file ] ) || isset( $updates->no_update[ $plugin_file ] ) ) {
+			$supported = true;
+		}
+	}
+
+	// Build the payload Core's filter expects (mirrors
+	// `WP_Plugins_List_Table::prepare_items()`'s `$filter_payload`).
+	// `wp_is_auto_update_forced_for_item()` itself is in
+	// `wp-admin/includes/update.php` — we can't include that from a REST
+	// callback (Plugin Check), so we run the filter directly. It's a
+	// single `apply_filters()` call under the hood.
+	//
+	// Important: `wp_parse_args( $row, $defaults )` lets `$row` keys
+	// override `$defaults`. Core's REST controller strips `.php` from
+	// the `plugin` field, but every filter that hooks `auto_update_plugin`
+	// (including Core's own) reads `$item->plugin` expecting the FULL
+	// filename. We layer the normalized `$plugin_file` AFTER the parse
+	// so it always wins.
+	$filter_payload = wp_parse_args(
+		$row,
+		array(
+			'id'            => $plugin_file,
+			'slug'          => isset( $row['textdomain'] ) ? (string) $row['textdomain'] : '',
+			'plugin'        => $plugin_file,
+			'new_version'   => '',
+			'url'           => '',
+			'package'       => '',
+			'icons'         => array(),
+			'banners'       => array(),
+			'banners_rtl'   => array(),
+			'tested'        => '',
+			'requires_php'  => '',
+			'compatibility' => new stdClass(),
+		)
+	);
+	$filter_payload['plugin'] = $plugin_file;
+	$filter_payload['id']     = $plugin_file;
+	$filter_payload           = (object) $filter_payload;
+	/** This filter is documented in wp-admin/includes/class-wp-automatic-updater.php */
+	$forced = apply_filters( 'auto_update_plugin', null, $filter_payload );
+	if ( null !== $forced ) {
+		$forced = (bool) $forced;
+		// When a filter forces the state, that's the effective state
+		// regardless of the `auto_update_plugins` option — match Core's
+		// rendering in `single_row_columns()`.
+		$enabled = $forced;
+	}
+
+	return array(
+		'enabled'   => (bool) $enabled,
+		'forced'    => $forced,
+		'supported' => $supported,
+	);
 }

--- a/includes/plugins-window/window.php
+++ b/includes/plugins-window/window.php
@@ -145,6 +145,13 @@ function desktop_mode_plugins_window_register_window() {
 			// through Core's existing handler, no reimplementation.
 			'updatesNonce'    => wp_create_nonce( 'updates' ),
 			'caps'            => $caps,
+			// Global "Automatic Updates" column gate — same shape Core's
+			// `WP_Plugins_List_Table::$show_autoupdates` uses (true only
+			// when the auto-update subsystem is enabled AND the viewer
+			// can update plugins). Per-row state still lives on the REST
+			// field `desktop_mode_auto_update` so the JS knows whether
+			// each individual row is enabled / forced / supported.
+			'autoUpdatesEnabled' => desktop_mode_plugins_window_auto_updates_enabled(),
 			'currentUserId'   => (int) get_current_user_id(),
 			'introSeen'       => function_exists( 'desktop_mode_has_seen_intro' )
 				? desktop_mode_has_seen_intro( get_current_user_id(), 'plugins' )

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -29,6 +29,7 @@ import {
 	isDesktopModeSelf,
 	refreshFrameworkMenu,
 	reloadOutOfDesktopMode,
+	toggleAutoUpdate,
 } from './rest';
 
 /**
@@ -47,7 +48,14 @@ const SOURCE = 'installed-view';
 interface PluginsChangedPayload {
 	source: string;
 	plugin?: string;
-	action?: 'activate' | 'deactivate' | 'delete' | 'install' | 'update' | 'bulk';
+	action?:
+		| 'activate'
+		| 'deactivate'
+		| 'delete'
+		| 'install'
+		| 'update'
+		| 'auto-update'
+		| 'bulk';
 }
 import type { InstalledPlugin } from './types';
 import type {
@@ -104,6 +112,13 @@ interface InstalledViewState {
 	 * the queue is still draining.
 	 */
 	updating: Set< string >;
+	/**
+	 * Set of plugin files whose auto-update toggle is currently in
+	 * flight. Mirrors Core's spinning `.dashicons-update.spin` overlay
+	 * — used to swap the toggle text/spinner while the AJAX call is
+	 * pending so the user can't double-fire.
+	 */
+	autoUpdating: Set< string >;
 }
 
 /**
@@ -119,6 +134,7 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		search: '',
 		loading: true,
 		updating: new Set< string >(),
+		autoUpdating: new Set< string >(),
 	};
 
 	// ─── Toolbar ────────────────────────────────────────────────────
@@ -315,13 +331,27 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 				sortValue: ( row: InstalledPlugin ) => row.desktop_mode_size_kb ?? 0,
 				render: ( _value, row ) => formatSize( row.desktop_mode_size_kb ?? null ),
 			},
-			{
-				key: '_actions',
-				label: '',
-				align: 'end',
-				render: ( _value, row ) => renderActionsCell( row ),
-			},
 		];
+		// "Automatic Updates" column — only shown when the global
+		// auto-update subsystem is enabled AND the viewer can update
+		// plugins. Mirrors Core's `WP_Plugins_List_Table::$show_autoupdates`
+		// gate on `plugins.php`.
+		if ( cfg.autoUpdatesEnabled ) {
+			cols.push( {
+				key: 'auto_updates',
+				label: __( 'Automatic Updates', 'desktop-mode' ),
+				sortable: true,
+				sortValue: ( row: InstalledPlugin ) =>
+					row.desktop_mode_auto_update?.enabled ? 1 : 0,
+				render: ( _value, row ) => renderAutoUpdateCell( row ),
+			} );
+		}
+		cols.push( {
+			key: '_actions',
+			label: '',
+			align: 'end',
+			render: ( _value, row ) => renderActionsCell( row ),
+		} );
 		return cfg.caps.activate || cfg.caps.delete ? cols : cols.slice( 0, -1 );
 	}
 
@@ -442,6 +472,94 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block;';
 		const text = stripHtml( row.author ?? '' );
 		wrap.textContent = text || __( 'Unknown', 'desktop-mode' );
+		return wrap;
+	}
+
+	/**
+	 * Render the "Automatic Updates" cell. Mirrors Core's three-state
+	 * rendering on `plugins.php`:
+	 *
+	 *   1. Forced (filter pinned)  → static "Auto-updates enabled" /
+	 *                                "Auto-updates disabled" label.
+	 *   2. Not update-supported    → em-dash placeholder; the plugin
+	 *                                doesn't check in with wp.org so
+	 *                                an auto-update could never fire.
+	 *   3. User-toggleable         → clickable link that flips state.
+	 *                                Shows a spinner while in flight.
+	 */
+	function renderAutoUpdateCell( row: InstalledPlugin ): HTMLElement {
+		const wrap = document.createElement( 'div' );
+		// `data-noclick` so wpd-table doesn't fire row-click (which
+		// expands the detail panel) when the user clicks the toggle.
+		wrap.setAttribute( 'data-noclick', '' );
+		wrap.style.cssText =
+			'display:inline-flex;align-items:center;gap:6px;white-space:nowrap;';
+
+		const meta = row.desktop_mode_auto_update;
+		const forced = meta?.forced ?? null;
+
+		if ( forced !== null ) {
+			// Filter-pinned — render a read-only label, no toggle.
+			const label = document.createElement( 'span' );
+			label.style.cssText = 'color:var(--wp-desktop-text-muted,#666);';
+			label.textContent = forced
+				? __( 'Auto-updates enabled', 'desktop-mode' )
+				: __( 'Auto-updates disabled', 'desktop-mode' );
+			wrap.appendChild( label );
+			return wrap;
+		}
+
+		const supported = !! meta?.supported;
+		if ( ! supported ) {
+			// Premium / private plugin that never checks in with wp.org —
+			// Core hides the toggle entirely. Render an em-dash so the
+			// cell isn't blank.
+			const placeholder = document.createElement( 'span' );
+			placeholder.style.cssText = 'color:var(--wp-desktop-text-muted,#9ca3af);';
+			placeholder.textContent = '—';
+			placeholder.title = __(
+				'This plugin does not check in with WordPress.org, so automatic updates can\'t be scheduled.',
+				'desktop-mode',
+			);
+			wrap.appendChild( placeholder );
+			return wrap;
+		}
+
+		const enabled = !! meta?.enabled;
+		const busy = state.autoUpdating.has( row.plugin );
+		const link = document.createElement( 'a' );
+		link.href = '#';
+		link.setAttribute( 'role', 'button' );
+		link.setAttribute( 'data-wp-action', enabled ? 'disable' : 'enable' );
+		link.style.cssText =
+			'display:inline-flex;align-items:center;gap:6px;' +
+			'color:var(--wp-desktop-accent,#2271b1);text-decoration:none;' +
+			'cursor:pointer;font-size:0.9em;';
+		if ( busy ) {
+			link.style.opacity = '0.6';
+			link.style.pointerEvents = 'none';
+			link.setAttribute( 'aria-busy', 'true' );
+		}
+
+		const label = document.createElement( 'span' );
+		if ( busy ) {
+			label.textContent = enabled
+				? __( 'Disabling…', 'desktop-mode' )
+				: __( 'Enabling…', 'desktop-mode' );
+		} else {
+			label.textContent = enabled
+				? __( 'Disable auto-updates', 'desktop-mode' )
+				: __( 'Enable auto-updates', 'desktop-mode' );
+		}
+		link.appendChild( label );
+
+		link.addEventListener( 'click', ( e: MouseEvent ) => {
+			e.preventDefault();
+			e.stopPropagation();
+			void runToggleAutoUpdate( row );
+		} );
+
+		wrap.appendChild( link );
 		return wrap;
 	}
 
@@ -955,6 +1073,73 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 			void refreshFrameworkMenu();
 		} finally {
 			state.updating.delete( row.plugin );
+			paintTable();
+		}
+	}
+
+	/**
+	 * Flip the per-plugin auto-update state via Core's
+	 * `toggle-auto-updates` AJAX action. Optimistic: paint the new
+	 * state immediately, revert on failure. Tracks in-flight rows in
+	 * `state.autoUpdating` so the cell can paint a spinner.
+	 */
+	async function runToggleAutoUpdate( row: InstalledPlugin ): Promise< void > {
+		if ( state.autoUpdating.has( row.plugin ) ) {
+			return; // already in flight
+		}
+		const meta = row.desktop_mode_auto_update;
+		if ( ! meta || meta.forced !== null || ! meta.supported ) {
+			// Forced or unsupported rows shouldn't surface a toggle — guard
+			// in case a stale click slips through during a state transition.
+			return;
+		}
+		const wasEnabled = meta.enabled;
+		const nextState: 'enable' | 'disable' = wasEnabled ? 'disable' : 'enable';
+
+		state.autoUpdating.add( row.plugin );
+		paintTable();
+		try {
+			await toggleAutoUpdate( row, nextState );
+			mergeRow( {
+				...row,
+				desktop_mode_auto_update: {
+					...meta,
+					enabled: ! wasEnabled,
+				},
+			} as InstalledPlugin );
+			toast(
+				wasEnabled
+					? sprintf(
+						/* translators: %s: plugin name */
+						__( 'Auto-updates disabled for %s.', 'desktop-mode' ),
+						row.name || row.plugin,
+					)
+					: sprintf(
+						/* translators: %s: plugin name */
+						__( 'Auto-updates enabled for %s.', 'desktop-mode' ),
+						row.name || row.plugin,
+					),
+			);
+			broadcast< PluginsChangedPayload >( PLUGINS_CHANGED_TOPIC, {
+				source: SOURCE,
+				plugin: row.plugin,
+				action: 'auto-update',
+			} );
+		} catch ( err ) {
+			toast(
+				sprintf(
+					/* translators: 1: plugin name, 2: error message */
+					__(
+						'Could not toggle auto-updates for %1$s: %2$s',
+						'desktop-mode',
+					),
+					row.name || row.plugin,
+					describe( err ),
+				),
+				6000,
+			);
+		} finally {
+			state.autoUpdating.delete( row.plugin );
 			paintTable();
 		}
 	}

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -61,6 +61,14 @@ export interface PluginsWindowConfig {
 		 */
 		update: boolean;
 	};
+	/**
+	 * Mirrors Core's `WP_Plugins_List_Table::$show_autoupdates`. True
+	 * when `wp_is_auto_update_enabled_for_type( 'plugin' )` is on AND
+	 * the viewer can update plugins (and, on multisite, holds the
+	 * network-admin cap). When false the JS hides the column entirely
+	 * — identical to Core's posture on the classic Plugins screen.
+	 */
+	autoUpdatesEnabled: boolean;
 	currentUserId: number;
 	introSeen: boolean;
 	introUrl: string;
@@ -431,6 +439,50 @@ export async function updateInstalledPlugin(
 				plugin.desktop_mode_update_available?.slug ||
 				plugin.textdomain ||
 				plugin.plugin.split( '/' )[ 0 ],
+		},
+		{ nonceField: '_ajax_nonce', nonceValue: getConfig().updatesNonce },
+	);
+}
+
+/**
+ * Toggle the per-plugin auto-update state. Calls Core's existing
+ * `wp_ajax_toggle_auto_updates` handler (registered on the
+ * `toggle-auto-updates` action) — the exact same endpoint Core's
+ * own "Enable / Disable auto-updates" links hit via
+ * `wp.updates.toggleAutoUpdate()`. We reuse it verbatim rather than
+ * reimplementing the option mutation (which lives in `wp-admin/includes/`
+ * and would mean carrying the deleted-plugin cleanup logic ourselves).
+ *
+ * The handler validates `current_user_can( 'update_plugins' )`, the
+ * `'updates'` nonce, checks the plugin file against `get_plugins()`,
+ * and atomically updates the `auto_update_plugins` site option. On
+ * success Core returns an empty `wp_send_json_success()` envelope —
+ * the caller is expected to update local row state from the requested
+ * new value.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export async function toggleAutoUpdate(
+	plugin: InstalledPlugin,
+	state: 'enable' | 'disable',
+): Promise< void > {
+	// Core's handler keys into `get_plugins()` with the FULL filename
+	// (`foo/foo.php`), but Core's REST controller strips the `.php`
+	// extension when populating the `plugin` field — so the value we
+	// received from `/wp/v2/plugins` is one `.php` short of what the
+	// handler needs. Re-append before firing, otherwise the asset
+	// won't match any installed plugin and Core returns "the item does
+	// not exist". Mirrors the same fix we apply for `updateInstalledPlugin`.
+	const pluginFile = plugin.plugin.endsWith( '.php' )
+		? plugin.plugin
+		: plugin.plugin + '.php';
+	await ajaxRequest< unknown >(
+		'toggle-auto-updates',
+		{
+			type: 'plugin',
+			asset: pluginFile,
+			state,
 		},
 		{ nonceField: '_ajax_nonce', nonceValue: getConfig().updatesNonce },
 	);

--- a/src/plugins-window/types.ts
+++ b/src/plugins-window/types.ts
@@ -79,6 +79,28 @@ export interface InstalledPlugin {
 	desktop_mode_icon_url?: string | null;
 	/** Disk size of the plugin folder in kilobytes (null when unreadable). */
 	desktop_mode_size_kb?: number | null;
+	/**
+	 * Auto-update state for this plugin, mirroring Core's
+	 * "Automatic Updates" column on `plugins.php`.
+	 *
+	 * - `enabled`   — plugin is in the `auto_update_plugins` site option
+	 *                 OR `forced === true` (Core treats a filter-pinned
+	 *                 state as the effective state, regardless of option).
+	 * - `forced`    — `true`/`false` when the `auto_update_plugin` filter
+	 *                 has pinned the state; `null` when the user is free
+	 *                 to toggle. JS renders a static label (no toggle)
+	 *                 when forced.
+	 * - `supported` — the plugin shows up in the `update_plugins`
+	 *                 transient (either `response` or `no_update`).
+	 *                 Premium / private plugins that never check in with
+	 *                 wp.org land in neither bucket — Core hides the
+	 *                 toggle entirely for those rows.
+	 */
+	desktop_mode_auto_update?: {
+		enabled: boolean;
+		forced: boolean | null;
+		supported: boolean;
+	};
 
 	/**
 	 * Index signature so `InstalledPlugin` satisfies the

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -33,6 +33,10 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 		// Make sure no test leaks an opt-in state into the next.
 		remove_all_filters( 'desktop_mode_plugins_window_user_can_register' );
 		remove_all_filters( 'desktop_mode_plugins_window_user_can_use' );
+		remove_all_filters( 'desktop_mode_plugins_window_auto_updates_enabled' );
+		remove_all_filters( 'desktop_mode_plugins_window_refresh_updates' );
+		remove_all_filters( 'desktop_mode_plugins_window_icon_url' );
+		remove_all_filters( 'auto_update_plugin' );
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -557,6 +557,205 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 		}
 	}
 
+	// ----------------------------------------------------------------
+	// `desktop_mode_auto_update` REST field — per-row auto-update state.
+	// ----------------------------------------------------------------
+
+	/**
+	 * Plugin whose file is in the `auto_update_plugins` site option and
+	 * has an entry in the `update_plugins` transient should report
+	 * `enabled: true, supported: true, forced: null` — the most common
+	 * happy-path shape.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_auto_update
+	 */
+	public function test_auto_update_field_reports_enabled_when_in_option_and_supported() {
+		update_site_option( 'auto_update_plugins', array( 'akismet/akismet.php' ) );
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+				// `no_update` rows mean "checked in, no update right now" —
+				// Core treats that as `update-supported`.
+				'no_update'    => array(
+					'akismet/akismet.php' => (object) array( 'slug' => 'akismet' ),
+				),
+			)
+		);
+		// REST controller strips `.php`.
+		$row = array(
+			'plugin'     => 'akismet/akismet',
+			'textdomain' => 'akismet',
+		);
+		$out = desktop_mode_plugins_window_field_auto_update( $row );
+		$this->assertTrue( $out['enabled'] );
+		$this->assertTrue( $out['supported'] );
+		$this->assertNull( $out['forced'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_plugins_window_field_auto_update
+	 */
+	public function test_auto_update_field_reports_disabled_when_not_in_option() {
+		update_site_option( 'auto_update_plugins', array() );
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+				'no_update'    => array(
+					'akismet/akismet.php' => (object) array( 'slug' => 'akismet' ),
+				),
+			)
+		);
+		$row = array(
+			'plugin'     => 'akismet/akismet',
+			'textdomain' => 'akismet',
+		);
+		$out = desktop_mode_plugins_window_field_auto_update( $row );
+		$this->assertFalse( $out['enabled'] );
+		$this->assertTrue( $out['supported'] );
+		$this->assertNull( $out['forced'] );
+	}
+
+	/**
+	 * Plugins missing from both the `response` and `no_update` maps in
+	 * the transient have `supported: false` — Core hides the toggle
+	 * entirely in that case so users don't enable an auto-update that
+	 * can never fire (premium / private plugins).
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_auto_update
+	 */
+	public function test_auto_update_field_reports_unsupported_when_not_in_transient() {
+		update_site_option( 'auto_update_plugins', array() );
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+				'no_update'    => array(),
+			)
+		);
+		$row = array( 'plugin' => 'premium/premium' );
+		$out = desktop_mode_plugins_window_field_auto_update( $row );
+		$this->assertFalse( $out['enabled'] );
+		$this->assertFalse( $out['supported'] );
+		$this->assertNull( $out['forced'] );
+	}
+
+	/**
+	 * The `auto_update_plugin` filter forces the state irrespective of
+	 * the site option. Mirrors Core's rendering where a forced row
+	 * shows a read-only "Auto-updates enabled" label.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_auto_update
+	 */
+	public function test_auto_update_field_respects_filter_forcing_enabled() {
+		update_site_option( 'auto_update_plugins', array() );
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+				'no_update'    => array(
+					'forced/forced.php' => (object) array( 'slug' => 'forced' ),
+				),
+			)
+		);
+		$callback = static function ( $update, $item ) {
+			if ( isset( $item->plugin ) && 'forced/forced.php' === $item->plugin ) {
+				return true;
+			}
+			return $update;
+		};
+		add_filter( 'auto_update_plugin', $callback, 10, 2 );
+		try {
+			$row = array( 'plugin' => 'forced/forced' );
+			$out = desktop_mode_plugins_window_field_auto_update( $row );
+			$this->assertTrue( $out['forced'] );
+			$this->assertTrue(
+				$out['enabled'],
+				'A filter that pins forced=true must yield enabled=true even when the option is empty.'
+			);
+		} finally {
+			remove_filter( 'auto_update_plugin', $callback, 10 );
+		}
+	}
+
+	/**
+	 * Filter pinning the state to disabled must yield
+	 * `enabled: false, forced: false` so the JS can render the
+	 * read-only "Auto-updates disabled" label and skip the toggle.
+	 *
+	 * @covers ::desktop_mode_plugins_window_field_auto_update
+	 */
+	public function test_auto_update_field_respects_filter_forcing_disabled() {
+		// Plugin IS in the option, but filter says disabled — filter wins.
+		update_site_option( 'auto_update_plugins', array( 'forced/forced.php' ) );
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(),
+				'no_update'    => array(
+					'forced/forced.php' => (object) array( 'slug' => 'forced' ),
+				),
+			)
+		);
+		$callback = static function ( $update, $item ) {
+			if ( isset( $item->plugin ) && 'forced/forced.php' === $item->plugin ) {
+				return false;
+			}
+			return $update;
+		};
+		add_filter( 'auto_update_plugin', $callback, 10, 2 );
+		try {
+			$row = array( 'plugin' => 'forced/forced' );
+			$out = desktop_mode_plugins_window_field_auto_update( $row );
+			$this->assertFalse( $out['forced'] );
+			$this->assertFalse( $out['enabled'] );
+		} finally {
+			remove_filter( 'auto_update_plugin', $callback, 10 );
+		}
+	}
+
+	// ----------------------------------------------------------------
+	// `desktop_mode_plugins_window_auto_updates_enabled` — global gate.
+	// ----------------------------------------------------------------
+
+	/**
+	 * Filter must be able to flip the column off even when the
+	 * underlying gate would say yes — hosts that manage auto-updates
+	 * externally (managed WordPress, internal mirrors) can suppress
+	 * the in-window toggle and rely on the existing channel instead.
+	 *
+	 * @covers ::desktop_mode_plugins_window_auto_updates_enabled
+	 */
+	public function test_auto_updates_enabled_filter_can_force_off() {
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'desktop_mode_plugins_window_auto_updates_enabled', '__return_false' );
+		try {
+			$this->assertFalse( desktop_mode_plugins_window_auto_updates_enabled() );
+		} finally {
+			remove_all_filters( 'desktop_mode_plugins_window_auto_updates_enabled' );
+		}
+	}
+
+	/**
+	 * Logged-out users (or users without `update_plugins`) must not see
+	 * the column. Multisite admins on a single-site context likewise
+	 * are gated by the `manage_network_plugins` check.
+	 *
+	 * @covers ::desktop_mode_plugins_window_auto_updates_enabled
+	 */
+	public function test_auto_updates_enabled_closed_for_users_without_update_cap() {
+		wp_set_current_user( $this->editor_id );
+		$this->assertFalse( desktop_mode_plugins_window_auto_updates_enabled() );
+		wp_set_current_user( 0 );
+		$this->assertFalse( desktop_mode_plugins_window_auto_updates_enabled() );
+	}
+
 	/**
 	 * The opportunistic prime path respects the 12h `last_checked`
 	 * throttle (mirrors `_maybe_update_plugins()`), but the explicit


### PR DESCRIPTION
closes https://github.com/WordPress/desktop-mode/issues/226

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-227-756ba28c25fcf548e87e8ece08112b014235c174.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->