### PR TITLE
Add window notices feature with persistent dismissal and server sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,10 +312,15 @@ docs/
     ├── pwa-install.md           UPDATE/READ WHEN: wp.desktop.pwa.promptInstall(),
     │                            install-pill UX, or desktop_mode_pwa_manifest filter
     │                            contract changes.
-    └── notify.md                UPDATE/READ WHEN: wp.desktop.notify() options shape,
-                                 fallback semantics, or
-                                 desktop-mode/notification-{requested,shown}
-                                 channel payloads change.
+    ├── notify.md                UPDATE/READ WHEN: wp.desktop.notify() options shape,
+    │                            fallback semantics, or
+    │                            desktop-mode/notification-{requested,shown}
+    │                            channel payloads change.
+    └── window-notice.md         UPDATE/READ WHEN: desktop_mode_register_window_notice()
+                                 contract, wp.desktop.registerWindowNotice() shape,
+                                 <wpd-notice> attributes, or the persistence-key
+                                 scheme (desktop-mode-notice-dismissed:<userId>)
+                                 changes.
 ```
 
 **Rules of thumb:**

--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -63,6 +63,7 @@ require_once DESKTOP_MODE_DIR . 'includes/settings-tabs.php';
 require_once DESKTOP_MODE_DIR . 'includes/dock-rail-renderer.php';
 require_once DESKTOP_MODE_DIR . 'includes/title-bar-buttons.php';
 require_once DESKTOP_MODE_DIR . 'includes/window-chrome.php';
+require_once DESKTOP_MODE_DIR . 'includes/window-notices.php';
 require_once DESKTOP_MODE_DIR . 'includes/wallpapers.php';
 require_once DESKTOP_MODE_DIR . 'includes/widgets/heartbeat.php';
 require_once DESKTOP_MODE_DIR . 'includes/render.php';

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -54,5 +54,6 @@ defined( 'ABSPATH' ) || exit;
 - [Track who's around — `wp.desktop.presence`](./presence.md)
 - [Surface a custom "Install as App" button](./pwa-install.md)
 - [Send a notification — `wp.desktop.notify()`](./notify.md)
+- [Show a banner at the top of a window — `desktop_mode_register_window_notice()`](./window-notice.md)
 
 If your use case isn't here, check [Hooks Reference](../hooks-reference.md) and [JavaScript Reference](../javascript-reference.md) — everything we fire is documented there.

--- a/docs/examples/window-notice.md
+++ b/docs/examples/window-notice.md
@@ -63,6 +63,34 @@ desktop_mode_register_window_notice( array(
 ) );
 ```
 
+## How `match` selectors combine
+
+Three selector types are accepted: `window` (single id), `windows`
+(list of ids), and `urlContains`. Their combination rules:
+
+- **Within `windows`**, ids are **OR**'d — the window matches if its
+  id is any of the entries.
+- **Across selector types**, the semantics is **AND** — the window
+  must satisfy every selector that was set. For example, this notice
+  appears only on the Posts window *whose URL also contains
+  `wc-admin`*:
+
+  ```php
+  desktop_mode_register_window_notice( array(
+      'id'    => 'my-plugin/wc-posts',
+      // …
+      'match' => array(
+          'windows'     => array( 'edit-php' ),
+          'urlContains' => 'wc-admin',
+      ),
+  ) );
+  ```
+
+  It does **not** mean "every Posts window OR every wc-admin URL." To
+  get OR across selector types, register two separate notices (they
+  can share the same `id` only if you want one to replace the other —
+  use different ids otherwise).
+
 ## JavaScript — register from a plugin bundle
 
 The same API is exposed on `wp.desktop` with a fully-flexible `match`

--- a/docs/examples/window-notice.md
+++ b/docs/examples/window-notice.md
@@ -1,0 +1,160 @@
+# Show a banner at the top of a window
+
+A **window notice** is a tone-coded banner pinned to the top of one
+or more windows — between the title bar and the content area, full
+width. The user can dismiss it (default), and the dismissal is
+remembered per-user in `localStorage` so the same banner never
+re-appears for them.
+
+Notices are pure declarative data: tone, message (HTML), an optional
+dashicons glyph, and an optional `match` selector. The shell renders
+each entry as a `<wpd-notice>` web component inside the matching
+window's `after-titlebar` slot.
+
+## PHP — register a banner on a single window
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'init', function () {
+    desktop_mode_register_window_notice( array(
+        'id'      => 'my-plugin/welcome-posts',
+        'tone'    => 'info',
+        'message' => __(
+            '<strong>Welcome to My Plugin.</strong> Try the new <a href="…">bulk-edit overlay</a>.',
+            'my-plugin'
+        ),
+        'icon'    => 'dashicons-info',
+        'match'   => array( 'window' => 'edit-php' ), // Posts window
+    ) );
+} );
+```
+
+## PHP — banner that applies to several "kinds" of window
+
+```php
+desktop_mode_register_window_notice( array(
+    'id'      => 'my-plugin/holiday-banner',
+    'tone'    => 'warning',
+    'message' => __( 'Holiday freeze in effect — content edits are read-only.', 'my-plugin' ),
+    'match'   => array(
+        'windows' => array(
+            'edit-php',          // Posts
+            'edit-php-page',     // Pages
+            'upload-php',        // Media
+        ),
+    ),
+) );
+```
+
+## PHP — match by URL substring
+
+For plugin pages whose window id is derived from a long URL (e.g.
+`admin.php?page=wc-admin&path=/analytics`), match by URL substring
+instead of trying to predict the slug:
+
+```php
+desktop_mode_register_window_notice( array(
+    'id'      => 'my-plugin/wc-promo',
+    'tone'    => 'success',
+    'message' => __( 'Black Friday rate now available on the API.', 'my-plugin' ),
+    'match'   => array( 'urlContains' => 'wc-admin' ),
+) );
+```
+
+## JavaScript — register from a plugin bundle
+
+The same API is exposed on `wp.desktop` with a fully-flexible `match`
+predicate (any synchronous function of the `Window` instance):
+
+```js
+const unregister = wp.desktop.registerWindowNotice( {
+    id: 'my-plugin/welcome',
+    tone: 'info',
+    message: 'Welcome! <a href="/wp-admin/">Open admin home</a>.',
+    match: ( win ) => win.id === 'edit-php',
+} );
+
+// Later — remove the notice declaratively:
+unregister();
+```
+
+### Imperative dismissal / un-dismissal
+
+```js
+// Mark a notice as dismissed for the current user.
+wp.desktop.dismissWindowNotice( 'my-plugin/welcome' );
+
+// Clear the dismissal so it shows again on next mount.
+wp.desktop.undismissWindowNotice( 'my-plugin/welcome' );
+
+// Snapshot for debugging:
+console.log( wp.desktop.listWindowNotices() );
+```
+
+## Allowed tones
+
+`info` (default), `success`, `warning`, `error` (alias `danger`),
+`neutral`. Plugins that need a brand color can override the
+underlying CSS variables on the `<wpd-notice>` host:
+
+```css
+wpd-notice[ tone='info' ] {
+    --wpd-notice-info: #6a4af5;
+    --wpd-notice-info-bg: rgba( 106, 74, 245, 0.08 );
+}
+```
+
+## What HTML is allowed in `message`
+
+PHP-registered messages pass through `wp_kses_post()` — links,
+inline formatting (`<strong>`, `<em>`, `<br>`, `<code>`), and
+`<span>`s with class names survive; `<script>` and other unsafe
+markup are stripped.
+
+JS-registered messages are written via `innerHTML` as-is. Treat the
+field as a trusted string: include only content you author, and run
+any user-supplied data through an HTML sanitizer first.
+
+## Hiding the close button
+
+Pass `dismissible: false` (PHP) or the `not-dismissible` attribute
+(component-level) for a banner the user can't dismiss — useful for
+hard-coded state messages like "Read-only mode."
+
+```php
+desktop_mode_register_window_notice( array(
+    'id'          => 'my-plugin/read-only',
+    'tone'        => 'warning',
+    'dismissible' => false,
+    'message'     => __( 'This window is in read-only mode.', 'my-plugin' ),
+) );
+```
+
+## Stacking multiple notices
+
+Each call to `desktop_mode_register_window_notice()` /
+`wp.desktop.registerWindowNotice()` registers an independent slot
+renderer. When multiple notices match the same window, they stack in
+`order` ascending (default 100). Set `order` explicitly to control
+the visual hierarchy.
+
+## Server-side filter
+
+Plugins can mutate the final list right before it ships to the
+shell — handy for request-time banners (e.g. "your trial expires
+today"):
+
+```php
+add_filter( 'desktop_mode_window_notices', function ( $entries ) {
+    if ( my_plugin_trial_expires_today() ) {
+        $entries[] = array(
+            'id'      => 'my-plugin/trial-expires',
+            'tone'    => 'warning',
+            'message' => __( 'Your trial expires today.', 'my-plugin' ),
+        );
+    }
+    return $entries;
+} );
+```

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2332,7 +2332,7 @@ Actions:
 - `desktop_mode_window_chrome_script_registered( $handle )`
 - `desktop_mode_window_chrome_registered( $id, $entry )`
 
-### Window notices (since 0.22.0)
+### Window notices — Experimental  *(since 0.22.0)*
 
 ```php
 desktop_mode_register_window_notice( $args );

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2332,6 +2332,31 @@ Actions:
 - `desktop_mode_window_chrome_script_registered( $handle )`
 - `desktop_mode_window_chrome_registered( $id, $entry )`
 
+### Window notices (since 0.22.0)
+
+```php
+desktop_mode_register_window_notice( $args );
+```
+
+`$args`:
+- `id` *(required)* — persistence + dedupe key.
+- `message` *(required)* — HTML body. Passed through `wp_kses_post()`.
+- `tone` — `info` (default) | `success` | `warning` | `error` | `danger` | `neutral`.
+- `dismissible` — show a close button. Default `true`.
+- `icon` — optional Dashicons class.
+- `match` — optional selector: `{ window?: 'edit-php' }`, `{ windows?: [ 'edit-php', 'edit-php-page' ] }`, or `{ urlContains?: 'wc-admin' }`. Combine freely; omit for "every window."
+- `order` — sort order. Lower renders higher in a stack. Default 100.
+
+Notices render as `<wpd-notice>` inside the matching window's
+`after-titlebar` slot. Each user's dismissal is persisted in
+`localStorage` so the same banner never reappears for them.
+
+Actions / filters:
+- `desktop_mode_window_notice_registered( $id, $entry )` — action.
+- `desktop_mode_window_notices( $entries )` — filter the final list right before it ships to the shell (request-time banners).
+
+See [`docs/examples/window-notice.md`](examples/window-notice.md).
+
 ---
 
 ## Progressive Web App (since 0.8.0)

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3572,7 +3572,60 @@ wp.desktop.registerWindowChrome( def );
 wp.desktop.unregisterWindowChrome( id );
 wp.desktop.listWindowChromes();
 wp.desktop.applyWindowChrome( windowId, chromeId );
+
+// Window notices — Experimental (since 0.22.0). See subsection below.
+wp.desktop.registerWindowNotice( entry );
+wp.desktop.unregisterWindowNotice( id );
+wp.desktop.listWindowNotices();
+wp.desktop.dismissWindowNotice( id );
+wp.desktop.undismissWindowNotice( id );
 ```
+
+### Window notices — Experimental *(since 0.22.0)*
+
+Tone-coded banners pinned to the top of any matching window. The
+shell renders each entry as a `<wpd-notice>` web component inside
+the matching window's `after-titlebar` slot host, and each user's
+dismissal of a given `id` is persisted in `localStorage` under
+`desktop-mode-notice-dismissed:<userId>` so the banner never
+reappears for them.
+
+```ts
+type WindowNoticeTone =
+    | 'info' | 'success' | 'warning' | 'error' | 'danger' | 'neutral';
+
+interface WindowNoticeEntry {
+    id: string;                              // persistence + dedupe key — recommend `<plugin>/<slug>`
+    message: string;                         // HTML; links + inline formatting allowed. Treat as trusted.
+    tone?: WindowNoticeTone;                 // default 'info'
+    dismissible?: boolean;                   // default true
+    icon?: string;                           // dashicons class (e.g. 'dashicons-info')
+    match?: ( win: Window ) => boolean;      // default: every window
+    order?: number;                          // default 100. Lower renders higher in a stack.
+    owner?: string;                          // tag for bulk teardown
+}
+
+wp.desktop.registerWindowNotice( entry );   // returns an unregister fn
+wp.desktop.unregisterWindowNotice( id );
+wp.desktop.listWindowNotices();              // snapshot, sorted by (order, id)
+wp.desktop.dismissWindowNotice( id );        // imperative dismiss (writes localStorage)
+wp.desktop.undismissWindowNotice( id );      // clear a prior dismissal
+```
+
+`message` is written via `innerHTML` on the client. Include only
+content you author; if you must include user-supplied data, run it
+through an HTML sanitizer first. PHP-registered notices are passed
+through `wp_kses_post()` automatically — see
+[`docs/examples/window-notice.md`](examples/window-notice.md).
+
+`match` runs once per window-paint and any throw is treated as
+"don't render this notice on this window."
+
+Persistence key layout:
+
+| Key | Shape | Notes |
+|-----|-------|-------|
+| `desktop-mode-notice-dismissed:<userId>` | `Record< noticeId, true >` (JSON) | Falls back to `…:anon` for logged-out / pre-hydration. |
 
 ### JS hooks (under `wp.hooks` / `addFilter`-`addAction`)
 

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -555,6 +555,9 @@ function desktop_mode_build_menu_payload() {
 		'serverWindowChromes'       => function_exists( 'desktop_mode_build_window_chromes_payload' )
 			? desktop_mode_build_window_chromes_payload()
 			: array(),
+		'serverWindowNotices'       => function_exists( 'desktop_mode_build_window_notices_payload' )
+			? desktop_mode_build_window_notices_payload()
+			: array(),
 		'desktopIcons'     => function_exists( 'desktop_mode_build_desktop_icons_payload' )
 			? desktop_mode_build_desktop_icons_payload()
 			: array(),
@@ -842,6 +845,9 @@ function desktop_mode_flush_script_handle_registries() {
 	}
 	if ( function_exists( 'desktop_mode_flush_window_chrome_registry' ) ) {
 		desktop_mode_flush_window_chrome_registry();
+	}
+	if ( function_exists( 'desktop_mode_flush_window_notice_registry' ) ) {
+		desktop_mode_flush_window_notice_registry();
 	}
 	desktop_mode_warn_unresolvable_script_handle( '', '', '__flush__' );
 }

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -197,6 +197,9 @@ function desktop_mode_enqueue_assets() {
 	$server_window_chromes         = isset( $menu_payload['serverWindowChromes'] )
 		? $menu_payload['serverWindowChromes']
 		: array();
+	$server_window_notices         = isset( $menu_payload['serverWindowNotices'] )
+		? $menu_payload['serverWindowNotices']
+		: array();
 	$desktop_icons     = isset( $menu_payload['desktopIcons'] )
 		? $menu_payload['desktopIcons']
 		: array();
@@ -320,6 +323,7 @@ function desktop_mode_enqueue_assets() {
 			'serverWindowSlots'         => $server_window_slots,
 			'serverWindowChromeScripts' => $server_window_chrome_scripts,
 			'serverWindowChromes'       => $server_window_chromes,
+			'serverWindowNotices'       => $server_window_notices,
 			'desktopIcons'     => $desktop_icons,
 			'serverFileTypes'        => $server_file_types,
 			'serverFileOpeners'      => $server_file_openers,

--- a/includes/window-notices.php
+++ b/includes/window-notices.php
@@ -59,8 +59,12 @@ function desktop_mode_window_notice_tones() {
  *                               Default `true`.
  *     @type string $icon        Optional. Dashicons class for a
  *                               leading glyph (e.g.
- *                               `dashicons-info`).
- *     @type array  $match       Optional. Per-window selector. Combine
+ *                               `dashicons-info`). Must match
+ *                               `/^dashicons-[a-z0-9-]+$/`; values
+ *                               that don't are silently dropped to
+ *                               `''` rather than failing the
+ *                               registration.
+ *     @type array  $match       Optional. Per-window selector. Pick
  *                               any of:
  *                                 - `'window' => 'edit-php'` — single
  *                                   window id (e.g. `edit-php` for
@@ -69,12 +73,26 @@ function desktop_mode_window_notice_tones() {
  *                                 - `'windows' => array( 'edit-php',
  *                                   'edit-php-pagename' )` — multiple
  *                                   window ids ("all windows of kind
- *                                   X / Y / Z").
+ *                                   X / Y / Z"). Within the array the
+ *                                   semantics is OR (any id matches).
  *                                 - `'urlContains' => 'wc-admin'` —
  *                                   case-insensitive URL substring
  *                                   match. Useful for plugin pages
  *                                   whose id is derived from a long
  *                                   URL.
+ *
+ *                               When more than one selector type is
+ *                               present, all of them must match
+ *                               (AND). E.g. `array( 'windows' =>
+ *                               array( 'edit-php' ), 'urlContains'
+ *                               => 'wc-admin' )` shows the notice
+ *                               only on the Posts window when its
+ *                               URL also contains `wc-admin` — not
+ *                               on every Posts window AND every
+ *                               wc-admin-URL window. Use two
+ *                               separate `desktop_mode_register_window_notice()`
+ *                               calls for OR-across-selector-types.
+ *
  *                               When omitted, the notice paints on
  *                               every window.
  *     @type int    $order       Optional. Sort order — lower
@@ -131,12 +149,20 @@ function desktop_mode_register_window_notice( $args = array() ) {
 		);
 	}
 
+	// Icon validation. Dashicons class names are alphanumeric with
+	// hyphens and always start with `dashicons-`. Anything else is
+	// either a typo or attempted styling-injection; drop silently
+	// rather than reject the whole registration so a minor mistake
+	// in one field doesn't kill the banner entirely.
+	$icon_raw = (string) $args['icon'];
+	$icon     = preg_match( '/^dashicons-[a-z0-9-]+$/', $icon_raw ) ? $icon_raw : '';
+
 	$entry = array(
 		'id'          => strtolower( $id ),
 		'message'     => wp_kses_post( (string) $args['message'] ),
 		'tone'        => $tone,
 		'dismissible' => (bool) $args['dismissible'],
-		'icon'        => (string) $args['icon'],
+		'icon'        => $icon,
 		'match'       => is_array( $args['match'] ) ? $args['match'] : array(),
 		'order'       => (int) $args['order'],
 	);
@@ -183,9 +209,15 @@ function desktop_mode_window_notice_registry( $id = '', $entry = null ) {
 }
 
 /**
- * Test-only flush. Used by PHPUnit setUp() to keep tests independent.
+ * Drop every registered window notice. Intended for PHPUnit `set_up()`
+ * so a previous test's notices can't leak into the next test's
+ * payload-build assertions. **Not** a public API — production code
+ * that calls this would wipe every plugin's registered notice on the
+ * current request. Mirrors the same `flush_*` shape the
+ * commands / settings-tabs / window-chrome registries expose.
  *
  * @since 0.22.0
+ * @internal
  */
 function desktop_mode_flush_window_notice_registry() {
 	desktop_mode_window_notice_registry( '__flush__' );

--- a/includes/window-notices.php
+++ b/includes/window-notices.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Window notices — declarative top-of-window banners.
+ *
+ * Plugins call `desktop_mode_register_window_notice()` to surface a
+ * tone-coded banner at the top of every window matching a `match`
+ * predicate (or every window by default). The shell renders the
+ * notice via the `<wpd-notice>` web component inside the window's
+ * `after-titlebar` slot, and records the user's dismissal in
+ * `localStorage` so the same notice never reappears.
+ *
+ * Notices are pure declarative data — no JS handle is needed.
+ *
+ * Example:
+ *
+ * ```php
+ * desktop_mode_register_window_notice( array(
+ *     'id'      => 'my-plugin/welcome',
+ *     'tone'    => 'info',
+ *     'message' => '<strong>Welcome!</strong> Read the <a href="…">docs</a>.',
+ *     'match'   => array( 'window' => 'edit-php' ), // optional
+ * ) );
+ * ```
+ *
+ * @since 0.22.0
+ * @package DesktopMode
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Allowed tones — mirror the `<wpd-notice>` component's `tone`
+ * attribute.
+ *
+ * @since 0.22.0
+ * @return string[]
+ */
+function desktop_mode_window_notice_tones() {
+	return array( 'info', 'success', 'warning', 'error', 'danger', 'neutral' );
+}
+
+/**
+ * Register (or replace) a declarative window notice.
+ *
+ * @since 0.22.0
+ *
+ * @param array $args {
+ *     @type string $id          Required. Persistence + dedupe key.
+ *                               Recommended format `<plugin>/<slug>`.
+ *     @type string $message     Required. HTML body. Passed through
+ *                               `wp_kses_post()` before shipping, so
+ *                               links + basic formatting are allowed
+ *                               but `<script>` and other unsafe
+ *                               markup are stripped.
+ *     @type string $tone        Optional. One of
+ *                               {@see desktop_mode_window_notice_tones()}.
+ *                               Default `info`.
+ *     @type bool   $dismissible Optional. Show a close button.
+ *                               Default `true`.
+ *     @type string $icon        Optional. Dashicons class for a
+ *                               leading glyph (e.g.
+ *                               `dashicons-info`).
+ *     @type array  $match       Optional. Per-window selector. Combine
+ *                               any of:
+ *                                 - `'window' => 'edit-php'` — single
+ *                                   window id (e.g. `edit-php` for
+ *                                   Posts, `plugins` for the native
+ *                                   Plugins window).
+ *                                 - `'windows' => array( 'edit-php',
+ *                                   'edit-php-pagename' )` — multiple
+ *                                   window ids ("all windows of kind
+ *                                   X / Y / Z").
+ *                                 - `'urlContains' => 'wc-admin'` —
+ *                                   case-insensitive URL substring
+ *                                   match. Useful for plugin pages
+ *                                   whose id is derived from a long
+ *                                   URL.
+ *                               When omitted, the notice paints on
+ *                               every window.
+ *     @type int    $order       Optional. Sort order — lower
+ *                               renders higher in a stack of
+ *                               notices. Default 100.
+ * }
+ * @return true|WP_Error `true` on success; `WP_Error` on validation
+ *                       failure.
+ */
+function desktop_mode_register_window_notice( $args = array() ) {
+	$defaults = array(
+		'id'          => '',
+		'message'     => '',
+		'tone'        => 'info',
+		'dismissible' => true,
+		'icon'        => '',
+		'match'       => array(),
+		'order'       => 100,
+	);
+	$args = wp_parse_args( $args, $defaults );
+
+	$id = (string) $args['id'];
+	if ( '' === $id ) {
+		return desktop_mode_registration_error(
+			'desktop_mode_missing_id',
+			__( 'Window notice registration requires a non-empty `id`.', 'desktop-mode' )
+		);
+	}
+	if ( ! preg_match( '/^[a-z0-9_\\/-]+$/i', $id ) ) {
+		return desktop_mode_registration_error(
+			'desktop_mode_invalid_id',
+			__( 'Window notice `id` must be alphanumeric with hyphens, underscores, or slashes.', 'desktop-mode' ),
+			array( 'id' => $id )
+		);
+	}
+
+	if ( '' === (string) $args['message'] ) {
+		return desktop_mode_registration_error(
+			'desktop_mode_missing_message',
+			__( 'Window notice registration requires a non-empty `message`.', 'desktop-mode' ),
+			array( 'id' => $id )
+		);
+	}
+
+	$tone = (string) $args['tone'];
+	if ( ! in_array( $tone, desktop_mode_window_notice_tones(), true ) ) {
+		return desktop_mode_registration_error(
+			'desktop_mode_invalid_tone',
+			__( 'Window notice `tone` must be one of the documented values.', 'desktop-mode' ),
+			array(
+				'id'   => $id,
+				'tone' => $tone,
+			)
+		);
+	}
+
+	$entry = array(
+		'id'          => strtolower( $id ),
+		'message'     => wp_kses_post( (string) $args['message'] ),
+		'tone'        => $tone,
+		'dismissible' => (bool) $args['dismissible'],
+		'icon'        => (string) $args['icon'],
+		'match'       => is_array( $args['match'] ) ? $args['match'] : array(),
+		'order'       => (int) $args['order'],
+	);
+
+	desktop_mode_window_notice_registry( $entry['id'], $entry );
+
+	/**
+	 * Fires after a window notice is successfully registered.
+	 *
+	 * @since 0.22.0
+	 *
+	 * @param string $id    The notice id.
+	 * @param array  $entry The stored registry entry.
+	 */
+	do_action( 'desktop_mode_window_notice_registered', $entry['id'], $entry );
+
+	return true;
+}
+
+/**
+ * Internal module-level registry for window notices.
+ *
+ * @since 0.22.0
+ * @internal
+ *
+ * @param string     $id    Id to read or write.
+ * @param array|null $entry Entry to store, or `null` to read.
+ * @return array|null
+ */
+function desktop_mode_window_notice_registry( $id = '', $entry = null ) {
+	static $store = array();
+
+	if ( '__flush__' === (string) $id ) {
+		$store = array();
+		return array();
+	}
+	if ( '' === (string) $id ) {
+		return $store;
+	}
+	if ( null !== $entry ) {
+		$store[ (string) $id ] = $entry;
+	}
+	return isset( $store[ (string) $id ] ) ? $store[ (string) $id ] : null;
+}
+
+/**
+ * Test-only flush. Used by PHPUnit setUp() to keep tests independent.
+ *
+ * @since 0.22.0
+ */
+function desktop_mode_flush_window_notice_registry() {
+	desktop_mode_window_notice_registry( '__flush__' );
+}
+
+/**
+ * Build the payload shipped to the shell. Each entry is the stored
+ * registry record, runnable through the
+ * `desktop_mode_window_notices` filter so plugins can mutate the
+ * final list (e.g. add a dynamic notice computed at request time).
+ *
+ * @since 0.22.0
+ *
+ * @return array[]
+ */
+function desktop_mode_build_window_notices_payload() {
+	$registry = desktop_mode_window_notice_registry();
+	$entries  = is_array( $registry ) ? array_values( $registry ) : array();
+
+	/**
+	 * Filter the assembled list of window notices before it ships to
+	 * the shell. Plugins can append/remove/mutate notices here for
+	 * request-dependent banners (e.g. "your trial expires today")
+	 * without registering them statically.
+	 *
+	 * @since 0.22.0
+	 *
+	 * @param array[] $entries List of notice entries.
+	 */
+	$entries = apply_filters( 'desktop_mode_window_notices', $entries );
+
+	// Re-sort by order for deterministic emission, then by id.
+	usort(
+		$entries,
+		static function ( $a, $b ) {
+			$oa = isset( $a['order'] ) ? (int) $a['order'] : 100;
+			$ob = isset( $b['order'] ) ? (int) $b['order'] : 100;
+			if ( $oa !== $ob ) {
+				return $oa - $ob;
+			}
+			return strcmp( (string) $a['id'], (string) $b['id'] );
+		}
+	);
+
+	return $entries;
+}

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -99,6 +99,13 @@ import {
 	unregisterWindowSlot,
 } from '../window-chrome/slots/registry';
 import {
+	dismissWindowNotice,
+	listWindowNotices,
+	registerWindowNotice,
+	undismissWindowNotice,
+	unregisterWindowNotice,
+} from '../window-notices';
+import {
 	listWindowChromes,
 	registerWindowChrome,
 	unregisterWindowChrome,
@@ -180,6 +187,8 @@ export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'applyWindowControls',
 	'registerWindowSlot', 'unregisterWindowSlot', 'listWindowSlots',
 	'applyWindowSlot',
+	'registerWindowNotice', 'unregisterWindowNotice', 'listWindowNotices',
+	'dismissWindowNotice', 'undismissWindowNotice',
 	'registerWindowChrome', 'unregisterWindowChrome', 'listWindowChromes',
 	'applyWindowChrome',
 	'connect',
@@ -513,6 +522,11 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 			}
 			win.setAppearanceSlot( slot, slotConfig );
 		},
+		registerWindowNotice,
+		unregisterWindowNotice,
+		listWindowNotices,
+		dismissWindowNotice,
+		undismissWindowNotice,
 		registerWindowChrome,
 		unregisterWindowChrome,
 		listWindowChromes,

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -72,6 +72,7 @@ import {
 	type WindowSlotDef,
 } from './window-chrome/slots/registry';
 import { createWindowSlotRegistrySync } from './window-chrome/slots/server-sync';
+import { applyServerWindowNotices } from './window-notices-server-sync';
 import {
 	type WindowChromeDef,
 } from './window-chrome/chrome/registry';
@@ -1089,6 +1090,42 @@ export interface WpDesktopPublicApi {
 		slot: import( './types' ).WindowSlotName,
 		config: import( './types' ).WindowSlotConfig | undefined,
 	) => void;
+	/**
+	 * Register (or replace) a window notice — a tone-coded banner
+	 * rendered at the top of every matching window (inside the
+	 * `after-titlebar` slot). The notice carries an `id`, an HTML
+	 * `message`, an optional `tone` (`info` | `success` | `warning`
+	 * | `error` | `danger` | `neutral`), and an optional `match`
+	 * predicate (defaults to every window). The user's dismissal of
+	 * a given `id` persists in `localStorage` so the same banner
+	 * never reappears for that user.
+	 *
+	 * Returns an unregister function for symmetry with
+	 * {@link registerCommand}.
+	 *
+	 * @since 0.22.0
+	 */
+	registerWindowNotice: (
+		entry: import( './window-notices' ).WindowNoticeEntry,
+	) => () => void;
+	/** Remove a previously registered notice by id. @since 0.22.0 */
+	unregisterWindowNotice: ( id: string ) => void;
+	/** Snapshot of registered window notices. @since 0.22.0 */
+	listWindowNotices: () => import( './window-notices' ).WindowNoticeEntry[];
+	/**
+	 * Imperatively mark a notice id as dismissed for the current
+	 * user. Future window paints will start in the hidden state.
+	 *
+	 * @since 0.22.0
+	 */
+	dismissWindowNotice: ( id: string ) => void;
+	/**
+	 * Clear a previous dismissal so the notice will paint again on
+	 * the next mount.
+	 *
+	 * @since 0.22.0
+	 */
+	undismissWindowNotice: ( id: string ) => void;
 	/**
 	 * **Experimental** — register (or replace) a custom chrome
 	 * implementation. A chrome owns the title-bar DOM tree of any
@@ -2534,6 +2571,16 @@ function init(): void {
 			: [],
 		Array.isArray( config.serverWindowSlots )
 			? config.serverWindowSlots
+			: [],
+	);
+
+	// Window notices — declarative top-of-window banners shipped
+	// straight from PHP (no JS handle, pure data). Each entry is
+	// translated to a Layer-3 slot renderer targeting the
+	// `after-titlebar` slot.
+	applyServerWindowNotices(
+		Array.isArray( config.serverWindowNotices )
+			? config.serverWindowNotices
 			: [],
 	);
 

--- a/src/menu-refresh-apply.ts
+++ b/src/menu-refresh-apply.ts
@@ -27,8 +27,10 @@ import type {
 	DesktopTitleBarButtonScriptServerEntry,
 	DesktopWallpaperServerEntry,
 	DesktopWidgetServerEntry,
+	DesktopWindowNoticeServerEntry,
 	NativeWindowServerEntry,
 } from './types';
+import { applyServerWindowNotices } from './window-notices-server-sync';
 
 /** Shape of every payload key the bridge may carry. */
 export interface MenuRefreshPayload {
@@ -42,6 +44,7 @@ export interface MenuRefreshPayload {
 	serverSettingsTabs?: unknown;
 	serverDockRailRendererScripts?: unknown;
 	serverTitleBarButtonScripts?: unknown;
+	serverWindowNotices?: unknown;
 	desktopIcons?: unknown;
 }
 
@@ -186,6 +189,7 @@ export function createApplyPayload(
 		const serverSettingsTabs = payload.serverSettingsTabs;
 		const serverDockRailRendererScripts = payload.serverDockRailRendererScripts;
 		const serverTitleBarButtonScripts = payload.serverTitleBarButtonScripts;
+		const serverWindowNotices = payload.serverWindowNotices;
 		const desktopIcons = payload.desktopIcons;
 
 		// Guard: an empty `dockItems` list is NEVER legitimate —
@@ -310,6 +314,17 @@ export function createApplyPayload(
 			);
 			config.serverDockRailRendererScripts =
 				serverDockRailRendererScripts as DesktopConfig[ 'serverDockRailRendererScripts' ];
+		}
+
+		// Window-notice sync — reconcile declarative notices against
+		// the latest server snapshot. Plugin activation adds entries;
+		// deactivation removes them (server-owned entries only).
+		if ( Array.isArray( serverWindowNotices ) ) {
+			applyServerWindowNotices(
+				serverWindowNotices as DesktopWindowNoticeServerEntry[],
+			);
+			config.serverWindowNotices =
+				serverWindowNotices as DesktopConfig[ 'serverWindowNotices' ];
 		}
 
 		// Desktop-icon sync — re-render the wallpaper shortcut grid

--- a/src/types.ts
+++ b/src/types.ts
@@ -1205,6 +1205,40 @@ export interface DesktopWindowSlotServerEntry {
 }
 
 /**
+ * Server-declared window-notice metadata entry — emitted by
+ * `desktop_mode_register_window_notice()`. Notices are pure
+ * declarative data so there is no script handle.
+ *
+ * `match` is optional and supports three selectors (combine freely):
+ *   - `window: <windowId>` — render only on the window with this id
+ *     (e.g. `'edit-php'` for Posts, `'plugins'` for the native
+ *     Plugins window).
+ *   - `windows: string[]` — render on any window whose id is in the
+ *     list (the "all windows of kind X / Y / Z" shape).
+ *   - `urlContains: <substring>` — render on any window whose URL
+ *     contains the substring (case-insensitive). Useful for plugin
+ *     pages where the id is derived from a long admin URL.
+ *
+ * When `match` is omitted, the notice renders on every window.
+ *
+ * @public
+ * @since 0.22.0
+ */
+export interface DesktopWindowNoticeServerEntry {
+	id: string;
+	message: string;
+	tone: 'info' | 'success' | 'warning' | 'error' | 'danger' | 'neutral';
+	dismissible: boolean;
+	icon?: string;
+	match?: {
+		window?: string;
+		windows?: string[];
+		urlContains?: string;
+	};
+	order?: number;
+}
+
+/**
  * Server-declared custom-chrome script entry. One per
  * `desktop_mode_register_window_chrome_script()` call.
  *
@@ -1599,6 +1633,16 @@ export interface DesktopConfig {
 	 * @since 0.6.0
 	 */
 	serverWindowChromes?: DesktopWindowChromeServerEntry[];
+	/**
+	 * Server-declared window notices (from
+	 * `desktop_mode_register_window_notice()`). Each entry is rendered
+	 * as a `<wpd-notice>` inside the matching window's
+	 * `after-titlebar` slot. Pure declarative data — no script handle
+	 * required.
+	 *
+	 * @since 0.22.0
+	 */
+	serverWindowNotices?: DesktopWindowNoticeServerEntry[];
 	/**
 	 * Server-declared desktop icons (from `desktop_mode_register_icon()`).
 	 * The shell renders these as shortcut tiles on the wallpaper;

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -91,6 +91,8 @@ export type { WpdCrumbSegment } from './wpd-crumb-chain/wpd-crumb-chain';
 export { WpdCard } from './wpd-card/wpd-card';
 export { WpdRatingSummary } from './wpd-rating-summary/wpd-rating-summary';
 export type { WpdRatingBuckets } from './wpd-rating-summary/wpd-rating-summary';
+export { WpdNotice } from './wpd-notice/wpd-notice';
+export type { WpdNoticeTone } from './wpd-notice/wpd-notice';
 
 // List of tags registered by this barrel. `doAction(
 // COMPONENTS_REGISTERED, { tags } )` fires once from
@@ -157,4 +159,5 @@ export const WPD_COMPONENT_TAGS = [
 	'wpd-crumb-chain',
 	'wpd-card',
 	'wpd-rating-summary',
+	'wpd-notice',
 ] as const;

--- a/src/ui/components/tags.ts
+++ b/src/ui/components/tags.ts
@@ -70,4 +70,5 @@ export const WPD_COMPONENT_TAGS = [
 	'wpd-category-picker',
 	'wpd-crumb-chain',
 	'wpd-card',
+	'wpd-notice',
 ] as const;

--- a/src/ui/components/wpd-notice/storage.ts
+++ b/src/ui/components/wpd-notice/storage.ts
@@ -1,0 +1,100 @@
+/**
+ * Per-user dismissal storage for `<wpd-notice>`.
+ *
+ * Notices that carry a `notice-id` record their dismissal in
+ * `localStorage` under a per-user key so the same user never sees the
+ * same dismissed banner twice across reloads. The key includes the
+ * current user id (read from `wp.desktop.config.currentUserId` on
+ * first read) so a shared browser doesn't carry one user's
+ * dismissals into another's session. When the id is unavailable
+ * (logged-out, pre-hydration) we fall back to `anon`.
+ *
+ * @since 0.22.0
+ */
+
+const KEY_PREFIX = 'desktop-mode-notice-dismissed';
+
+interface MaybeWpDesktop {
+	desktop?: { config?: { currentUserId?: number } };
+}
+
+function currentUserSuffix(): string {
+	const w = ( window as unknown as { wp?: MaybeWpDesktop } ).wp;
+	const uid = w?.desktop?.config?.currentUserId;
+	if ( typeof uid === 'number' && uid > 0 ) {
+		return String( uid );
+	}
+	return 'anon';
+}
+
+function storageKey(): string {
+	return `${ KEY_PREFIX }:${ currentUserSuffix() }`;
+}
+
+function readMap(): Record< string, true > {
+	try {
+		const raw = window.localStorage.getItem( storageKey() );
+		if ( ! raw ) {
+			return {};
+		}
+		const parsed = JSON.parse( raw ) as unknown;
+		if ( parsed && typeof parsed === 'object' && ! Array.isArray( parsed ) ) {
+			return parsed as Record< string, true >;
+		}
+	} catch {
+		// localStorage may be disabled (Safari private mode, quota
+		// exceeded, etc.) — fall through to the empty map. A notice
+		// that can't persist still shows once per page load.
+	}
+	return {};
+}
+
+function writeMap( map: Record< string, true > ): void {
+	try {
+		window.localStorage.setItem( storageKey(), JSON.stringify( map ) );
+	} catch {
+		// Same rationale as readMap — silently no-op when storage
+		// isn't writable.
+	}
+}
+
+export function isNoticeDismissed( id: string ): boolean {
+	if ( ! id ) {
+		return false;
+	}
+	return readMap()[ id ] === true;
+}
+
+export function markNoticeDismissed( id: string ): void {
+	if ( ! id ) {
+		return;
+	}
+	const map = readMap();
+	map[ id ] = true;
+	writeMap( map );
+}
+
+export function clearNoticeDismissed( id: string ): void {
+	if ( ! id ) {
+		return;
+	}
+	const map = readMap();
+	if ( map[ id ] ) {
+		delete map[ id ];
+		writeMap( map );
+	}
+}
+
+/**
+ * Test-only escape hatch — drops every dismissal record for the
+ * current user.
+ *
+ * @internal
+ */
+export function _resetNoticeDismissalsForTests(): void {
+	try {
+		window.localStorage.removeItem( storageKey() );
+	} catch {
+		// no-op
+	}
+}

--- a/src/ui/components/wpd-notice/wpd-notice.styles.ts
+++ b/src/ui/components/wpd-notice/wpd-notice.styles.ts
@@ -1,0 +1,142 @@
+/**
+ * `<wpd-notice>` — full-width banner styles.
+ *
+ * The host stretches edge-to-edge of its container (intended for the
+ * window's `after-titlebar` slot host, which itself spans the window
+ * width). Tone variants colorize the left accent stripe + background;
+ * the label inherits the surrounding text color so links inside slot
+ * content still pick up the admin theme link color.
+ */
+import { css } from '../../core';
+
+export const styles = css`
+	:host {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		width: 100%;
+		box-sizing: border-box;
+		padding: 10px 14px;
+		font: var(
+			--wpd-notice-font,
+			13px/1.5 var( --desktop-mode-font, system-ui )
+		);
+		color: var( --wpd-notice-color, var( --desktop-mode-text, #1d2327 ) );
+		background: var( --wpd-notice-bg, rgba( 0, 0, 0, 0.04 ) );
+		border-block-end: 1px solid
+			var( --wpd-notice-border, rgba( 0, 0, 0, 0.08 ) );
+		border-inline-start: 4px solid
+			var( --wpd-notice-accent, #646970 );
+	}
+	:host( [ hidden ] ) {
+		display: none;
+	}
+
+	.wpd-notice__icon {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
+		color: var( --wpd-notice-accent, #646970 );
+	}
+	.wpd-notice__icon[ hidden ] {
+		display: none;
+	}
+
+	.wpd-notice__label {
+		flex: 1;
+		min-width: 0;
+		word-wrap: break-word;
+	}
+	::slotted( a ) {
+		color: var( --wpd-notice-link, var( --wp-admin-theme-color, #2271b1 ) );
+	}
+	::slotted( p:first-child ) {
+		margin-block-start: 0;
+	}
+	::slotted( p:last-child ) {
+		margin-block-end: 0;
+	}
+
+	.wpd-notice__close {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: inherit;
+		opacity: 0.6;
+		cursor: pointer;
+		border-radius: 4px;
+		transition: opacity 0.12s ease, background-color 0.12s ease;
+	}
+	.wpd-notice__close:hover {
+		opacity: 1;
+		background: rgba( 0, 0, 0, 0.06 );
+	}
+	.wpd-notice__close:focus-visible {
+		opacity: 1;
+		outline: 2px solid
+			var( --wp-admin-theme-color, #2271b1 );
+		outline-offset: 1px;
+	}
+	.wpd-notice__close[ hidden ] {
+		display: none;
+	}
+	.wpd-notice__close svg {
+		width: 14px;
+		height: 14px;
+	}
+
+	/* ─── Tones ──────────────────────────────────────────────────────
+	   Same palette as <wpd-badge> so the two surfaces feel like a set.
+	   Plugins can override any single tone via the variables below
+	   without redefining the rest. */
+	:host( [ tone='info' ] ) {
+		--wpd-notice-accent: var( --wpd-notice-info, #0969da );
+		--wpd-notice-bg: var( --wpd-notice-info-bg, rgba( 9, 105, 218, 0.08 ) );
+		--wpd-notice-border: var(
+			--wpd-notice-info-border,
+			rgba( 9, 105, 218, 0.16 )
+		);
+	}
+	:host( [ tone='success' ] ) {
+		--wpd-notice-accent: var( --wpd-notice-success, #1a7f37 );
+		--wpd-notice-bg: var( --wpd-notice-success-bg, rgba( 26, 127, 55, 0.08 ) );
+		--wpd-notice-border: var(
+			--wpd-notice-success-border,
+			rgba( 26, 127, 55, 0.16 )
+		);
+	}
+	:host( [ tone='warning' ] ) {
+		--wpd-notice-accent: var( --wpd-notice-warning, #9a6700 );
+		--wpd-notice-bg: var( --wpd-notice-warning-bg, rgba( 154, 103, 0, 0.08 ) );
+		--wpd-notice-border: var(
+			--wpd-notice-warning-border,
+			rgba( 154, 103, 0, 0.16 )
+		);
+	}
+	:host( [ tone='error' ] ),
+	:host( [ tone='danger' ] ) {
+		--wpd-notice-accent: var( --wpd-notice-error, #cf222e );
+		--wpd-notice-bg: var( --wpd-notice-error-bg, rgba( 207, 34, 46, 0.08 ) );
+		--wpd-notice-border: var(
+			--wpd-notice-error-border,
+			rgba( 207, 34, 46, 0.16 )
+		);
+	}
+	:host( [ tone='neutral' ] ) {
+		--wpd-notice-accent: var( --wpd-notice-neutral, #57606a );
+		--wpd-notice-bg: var( --wpd-notice-neutral-bg, rgba( 87, 96, 106, 0.08 ) );
+		--wpd-notice-border: var(
+			--wpd-notice-neutral-border,
+			rgba( 87, 96, 106, 0.16 )
+		);
+	}
+`;

--- a/src/ui/components/wpd-notice/wpd-notice.test.ts
+++ b/src/ui/components/wpd-notice/wpd-notice.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import './wpd-notice';
+import { _resetNoticeDismissalsForTests } from './storage';
+
+const tick = (): Promise< void > => Promise.resolve();
+
+describe( '<wpd-notice>', () => {
+	let host: HTMLElement;
+	beforeEach( () => {
+		_resetNoticeDismissalsForTests();
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+	} );
+	afterEach( () => {
+		host.remove();
+		_resetNoticeDismissalsForTests();
+	} );
+
+	test( 'role=status set on connection', async () => {
+		host.innerHTML = `<wpd-notice>Hi</wpd-notice>`;
+		await tick();
+		expect( host.querySelector( 'wpd-notice' )!.getAttribute( 'role' ) ).toBe(
+			'status',
+		);
+	} );
+
+	test( 'defaults tone to info when no tone attribute set', async () => {
+		host.innerHTML = `<wpd-notice>Hello</wpd-notice>`;
+		await tick();
+		expect( host.querySelector( 'wpd-notice' )!.getAttribute( 'tone' ) ).toBe(
+			'info',
+		);
+	} );
+
+	test( 'dismissible by default — close button visible', async () => {
+		host.innerHTML = `<wpd-notice>Hello</wpd-notice>`;
+		await tick();
+		const btn = host
+			.querySelector( 'wpd-notice' )!
+			.shadowRoot!.querySelector( '.wpd-notice__close' ) as HTMLButtonElement;
+		expect( btn.hasAttribute( 'hidden' ) ).toBe( false );
+	} );
+
+	test( 'not-dismissible attribute hides the close button', async () => {
+		host.innerHTML = `<wpd-notice not-dismissible>Hello</wpd-notice>`;
+		await tick();
+		const btn = host
+			.querySelector( 'wpd-notice' )!
+			.shadowRoot!.querySelector( '.wpd-notice__close' ) as HTMLButtonElement;
+		expect( btn.hasAttribute( 'hidden' ) ).toBe( true );
+	} );
+
+	test( 'icon attribute renders dashicons span', async () => {
+		host.innerHTML = `<wpd-notice icon="dashicons-info">x</wpd-notice>`;
+		await tick();
+		const iconEl = host
+			.querySelector( 'wpd-notice' )!
+			.shadowRoot!.querySelector( '.wpd-notice__icon' ) as HTMLElement;
+		expect( iconEl.hasAttribute( 'hidden' ) ).toBe( false );
+		expect( iconEl.classList.contains( 'dashicons-info' ) ).toBe( true );
+	} );
+
+	test( 'no icon attribute → icon span hidden', async () => {
+		host.innerHTML = `<wpd-notice>x</wpd-notice>`;
+		await tick();
+		const iconEl = host
+			.querySelector( 'wpd-notice' )!
+			.shadowRoot!.querySelector( '.wpd-notice__icon' ) as HTMLElement;
+		expect( iconEl.hasAttribute( 'hidden' ) ).toBe( true );
+	} );
+
+	test( 'clicking close hides host and fires wpd-notice-dismiss', async () => {
+		host.innerHTML = `<wpd-notice notice-id="t/click">Hi</wpd-notice>`;
+		await tick();
+		const el = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		let detail: unknown = null;
+		el.addEventListener( 'wpd-notice-dismiss', ( e ) => {
+			detail = ( e as CustomEvent ).detail;
+		} );
+		const btn = el.shadowRoot!.querySelector(
+			'.wpd-notice__close',
+		) as HTMLButtonElement;
+		btn.click();
+		expect( el.hidden ).toBe( true );
+		expect( ( detail as { noticeId?: string } )?.noticeId ).toBe( 't/click' );
+	} );
+
+	test( 'dismissal persists per notice-id — second mount stays hidden', async () => {
+		host.innerHTML = `<wpd-notice notice-id="t/persist">Hi</wpd-notice>`;
+		await tick();
+		const el1 = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		( el1 as unknown as { dismiss(): void } ).dismiss();
+		expect( el1.hidden ).toBe( true );
+
+		// Re-mount a fresh instance with the same id.
+		host.innerHTML = '';
+		host.innerHTML = `<wpd-notice notice-id="t/persist">Hi again</wpd-notice>`;
+		await tick();
+		const el2 = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		expect( el2.hidden ).toBe( true );
+	} );
+
+	test( 'undismiss clears persistence — new mount shows again', async () => {
+		host.innerHTML = `<wpd-notice notice-id="t/undismiss">Hi</wpd-notice>`;
+		await tick();
+		const el1 = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		( el1 as unknown as { dismiss(): void } ).dismiss();
+		( el1 as unknown as { undismiss(): void } ).undismiss();
+
+		host.innerHTML = '';
+		host.innerHTML = `<wpd-notice notice-id="t/undismiss">Hi</wpd-notice>`;
+		await tick();
+		const el2 = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		expect( el2.hidden ).toBe( false );
+	} );
+
+	test( 'notice-id absent → dismissal does not write to localStorage', async () => {
+		host.innerHTML = `<wpd-notice>No id</wpd-notice>`;
+		await tick();
+		const el = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		( el as unknown as { dismiss(): void } ).dismiss();
+		expect( el.hidden ).toBe( true );
+		// No record stored; a second instance with no id always shows.
+		host.innerHTML = '';
+		host.innerHTML = `<wpd-notice>Again</wpd-notice>`;
+		await tick();
+		const el2 = host.querySelector( 'wpd-notice' )! as HTMLElement;
+		expect( el2.hidden ).toBe( false );
+	} );
+
+	test( 'slotted HTML (links) is preserved', async () => {
+		host.innerHTML =
+			`<wpd-notice>Hi <a href="#" id="lnk">link</a></wpd-notice>`;
+		await tick();
+		const el = host.querySelector( 'wpd-notice' )!;
+		expect( el.querySelector( '#lnk' ) ).not.toBeNull();
+	} );
+} );

--- a/src/ui/components/wpd-notice/wpd-notice.ts
+++ b/src/ui/components/wpd-notice/wpd-notice.ts
@@ -1,0 +1,197 @@
+/**
+ * `<wpd-notice>` — full-width banner.
+ *
+ * The canonical place to surface a non-blocking, contextual message
+ * inside a window — release notes, a setup nudge, a deprecation
+ * warning, a "your trial expires in 3 days" reminder, etc. Five
+ * built-in tones map to common UI semantics (`info`, `success`,
+ * `warning`, `error`, `neutral`) and a close button is rendered by
+ * default. Slotted content is HTML so plugins can include links and
+ * basic formatting.
+ *
+ * Usage:
+ *
+ *   <wpd-notice tone="info" notice-id="my-plugin/welcome">
+ *     Welcome to the plugin! <a href="…">Read the docs</a>.
+ *   </wpd-notice>
+ *
+ *   <wpd-notice tone="warning" not-dismissible>
+ *     Maintenance window in 10 minutes.
+ *   </wpd-notice>
+ *
+ * Persistence: when `notice-id` is set, the dismissed state is stored
+ * in `localStorage` under the key
+ * `desktop-mode-notice-dismissed:<userId>` (a JSON map of
+ * `{ noticeId: true }`). On connection the component reads the map
+ * and self-hides if already dismissed. Clearing the dismissal is the
+ * `<wpd-notice>.undismiss()` instance method, or
+ * `wp.desktop.undismissWindowNotice( id )` for code-registered notices.
+ *
+ * @since 0.22.0
+ */
+
+import { Component, defineComponent, html } from '../../core';
+import { styles } from './wpd-notice.styles';
+import { __ } from '../../../i18n';
+import {
+	isNoticeDismissed,
+	markNoticeDismissed,
+	clearNoticeDismissed,
+} from './storage';
+
+export type WpdNoticeTone =
+	| 'info'
+	| 'success'
+	| 'warning'
+	| 'error'
+	| 'danger'
+	| 'neutral';
+
+export class WpdNotice extends Component {
+	static props = [ 'tone', 'dismissible', 'notDismissible', 'icon', 'noticeId' ] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Notice',
+		summary:
+			'Full-width banner placed inside a window (typically the after-titlebar slot). Tone-coded background + accent stripe, optional close button, optional dashicons leading glyph. Slotted content is HTML — links and basic formatting are supported.',
+		status: 'experimental',
+		since: '0.22.0',
+		props: [
+			{
+				name: 'tone',
+				type: '"info" | "success" | "warning" | "error" | "danger" | "neutral"',
+				description:
+					'Color palette. Defaults to `info`. `error` and `danger` are aliases.',
+			},
+			{
+				name: 'not-dismissible',
+				type: 'boolean',
+				description:
+					'Suppress the trailing close button. Defaults to dismissible.',
+			},
+			{
+				name: 'icon',
+				type: 'string',
+				description:
+					'Optional Dashicons class for a leading glyph (e.g. `dashicons-info`).',
+			},
+			{
+				name: 'notice-id',
+				type: 'string',
+				description:
+					'Persistence key. When set, the notice records its dismissed state in localStorage so it stays closed across reloads for the same user.',
+			},
+		],
+		slots: [
+			{
+				name: '(default)',
+				description:
+					'Message HTML. Links, `<strong>`, `<em>`, and other inline formatting are allowed.',
+			},
+		],
+		events: [
+			{
+				name: 'wpd-notice-dismiss',
+				description: 'Fires after the user clicks the close button.',
+				detail: '{ noticeId?: string }',
+			},
+		],
+		cssProps: [
+			{ name: '--wpd-notice-bg', description: 'Background color.' },
+			{ name: '--wpd-notice-accent', description: 'Left-edge stripe + icon color.' },
+			{ name: '--wpd-notice-color', description: 'Text color.' },
+			{ name: '--wpd-notice-border', description: 'Bottom border color.' },
+			{ name: '--wpd-notice-link', description: 'Color for slotted <a> elements.' },
+		],
+		example: html`
+			<wpd-notice tone="warning" notice-id="docs/example">
+				Heads up — this is a demo notice.
+				<a href="#">Learn more</a>.
+			</wpd-notice>
+		`,
+	} as const;
+
+	connectedCallback(): void {
+		super.connectedCallback();
+		if ( ! this.hasAttribute( 'role' ) ) {
+			this.setAttribute( 'role', 'status' );
+		}
+		if ( ! this.hasAttribute( 'tone' ) ) {
+			this.setAttribute( 'tone', 'info' );
+		}
+		const id = this.getAttribute( 'notice-id' );
+		if ( id && isNoticeDismissed( id ) ) {
+			this.hidden = true;
+		}
+	}
+
+	/**
+	 * Imperatively dismiss the notice — hides the host and records
+	 * the dismissal in localStorage when `notice-id` is set.
+	 */
+	dismiss(): void {
+		this.hidden = true;
+		const id = this.getAttribute( 'notice-id' );
+		if ( id ) {
+			markNoticeDismissed( id );
+		}
+		this.emit( 'wpd-notice-dismiss', { noticeId: id ?? undefined } );
+	}
+
+	/**
+	 * Clear a previously recorded dismissal and re-show the notice.
+	 * Useful in tests and for "Show again" affordances.
+	 */
+	undismiss(): void {
+		const id = this.getAttribute( 'notice-id' );
+		if ( id ) {
+			clearNoticeDismissed( id );
+		}
+		this.hidden = false;
+	}
+
+	protected render() {
+		const icon = this.getAttribute( 'icon' );
+		// Treat any explicit `not-dismissible` attr as suppressive.
+		// A legacy `dismissible="false"` string also works.
+		const notDismissibleAttr = this.hasAttribute( 'not-dismissible' );
+		const dismissibleAttr = this.getAttribute( 'dismissible' );
+		const dismissible = ! (
+			notDismissibleAttr || dismissibleAttr === 'false'
+		);
+
+		return html`
+			<span
+				class="wpd-notice__icon dashicons ${ icon ?? '' }"
+				?hidden=${ ! icon }
+				aria-hidden="true"
+			></span>
+			<span class="wpd-notice__label"><slot></slot></span>
+			<button
+				type="button"
+				class="wpd-notice__close"
+				?hidden=${ ! dismissible }
+				aria-label=${ __( 'Dismiss notice' ) }
+				@click=${ ( e: Event ) => this._onDismiss( e ) }
+			>
+				<svg viewBox="0 0 14 14" aria-hidden="true">
+					<path
+						d="M3 3 L11 11 M11 3 L3 11"
+						stroke="currentColor"
+						stroke-width="1.6"
+						stroke-linecap="round"
+						fill="none"
+					></path>
+				</svg>
+			</button>
+		`;
+	}
+
+	private _onDismiss( e: Event ): void {
+		e.preventDefault();
+		e.stopPropagation();
+		this.dismiss();
+	}
+}
+defineComponent( 'wpd-notice', WpdNotice );

--- a/src/ui/components/wpd-notice/wpd-notice.ts
+++ b/src/ui/components/wpd-notice/wpd-notice.ts
@@ -48,7 +48,7 @@ export type WpdNoticeTone =
 	| 'neutral';
 
 export class WpdNotice extends Component {
-	static props = [ 'tone', 'dismissible', 'notDismissible', 'icon', 'noticeId' ] as const;
+	static props = [ 'tone', 'notDismissible', 'icon', 'noticeId' ] as const;
 	static styles = [ styles ];
 
 	static help = {
@@ -153,13 +153,7 @@ export class WpdNotice extends Component {
 
 	protected render() {
 		const icon = this.getAttribute( 'icon' );
-		// Treat any explicit `not-dismissible` attr as suppressive.
-		// A legacy `dismissible="false"` string also works.
-		const notDismissibleAttr = this.hasAttribute( 'not-dismissible' );
-		const dismissibleAttr = this.getAttribute( 'dismissible' );
-		const dismissible = ! (
-			notDismissibleAttr || dismissibleAttr === 'false'
-		);
+		const dismissible = ! this.hasAttribute( 'not-dismissible' );
 
 		return html`
 			<span

--- a/src/window-notices-server-sync.test.ts
+++ b/src/window-notices-server-sync.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for `window-notices-server-sync.ts`.
+ *
+ * Two behaviors under test:
+ *
+ *   1. `buildMatcher` — the private predicate factory that translates
+ *      the declarative `match` shape (`window`, `windows`, `urlContains`)
+ *      into a `(win) => boolean`. We test it indirectly: register a
+ *      notice with each shape, then assert that the resulting slot
+ *      renderer's `match` predicate reports the right boolean for a
+ *      handful of fake windows.
+ *
+ *   2. `applyServerWindowNotices` — the reconciler that adds, updates,
+ *      and removes server-owned entries. We verify that:
+ *        - new entries land in the registry,
+ *        - subsequent calls with a different list remove dropped
+ *          server entries,
+ *        - JS-registered entries (no `__server__` owner) survive a
+ *          server sync that doesn't mention them.
+ *
+ * The slot-painter pipeline is exercised in
+ * `window-chrome/slots/render.ts` — its tests live there; we only
+ * need the slot-registry's `slotsForWindow()` lookup here, which
+ * returns the entries our calls registered.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+	listWindowNotices,
+	registerWindowNotice,
+	_resetWindowNoticesForTests,
+} from './window-notices';
+import { applyServerWindowNotices } from './window-notices-server-sync';
+import { slotsForWindow } from './window-chrome/slots/registry';
+import type { Window as DesktopWindow } from './window';
+import type { DesktopWindowNoticeServerEntry } from './types';
+
+function fakeWindow(
+	id: string,
+	url: string = '',
+): DesktopWindow {
+	return {
+		id,
+		config: { id, url, title: id, icon: 'dashicons-admin-generic' },
+	} as unknown as DesktopWindow;
+}
+
+function matcherFor( noticeId: string ) {
+	const slotId = `desktop-mode-notice/${ noticeId }`;
+	// `slotsForWindow` filters by `match(win)`, so to read the
+	// predicate we ask the slot-registry whether a given fake window
+	// matches the entry. We use that as our predicate-under-test.
+	return ( win: DesktopWindow ) =>
+		slotsForWindow( win, 'after-titlebar' ).some( ( def ) => def.id === slotId );
+}
+
+describe( 'window-notices-server-sync — buildMatcher', () => {
+	beforeEach( () => {
+		_resetWindowNoticesForTests();
+	} );
+	afterEach( () => {
+		_resetWindowNoticesForTests();
+	} );
+
+	test( 'no match → renders on every window', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/everywhere',
+				message: 'Hello',
+				tone: 'info',
+				dismissible: true,
+			},
+		] );
+		const matches = matcherFor( 'plugin/everywhere' );
+		expect( matches( fakeWindow( 'edit-php' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'plugins' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'whatever' ) ) ).toBe( true );
+	} );
+
+	test( 'window selector matches only the named id', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/posts-only',
+				message: 'Hi',
+				tone: 'info',
+				dismissible: true,
+				match: { window: 'edit-php' },
+			},
+		] );
+		const matches = matcherFor( 'plugin/posts-only' );
+		expect( matches( fakeWindow( 'edit-php' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'plugins' ) ) ).toBe( false );
+	} );
+
+	test( 'windows array selector matches any of the listed ids (OR)', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/content',
+				message: 'Hi',
+				tone: 'info',
+				dismissible: true,
+				match: { windows: [ 'edit-php', 'edit-php-page', 'upload-php' ] },
+			},
+		] );
+		const matches = matcherFor( 'plugin/content' );
+		expect( matches( fakeWindow( 'edit-php' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'edit-php-page' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'upload-php' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'plugins' ) ) ).toBe( false );
+	} );
+
+	test( 'window + windows are unioned into a single OR set', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/union',
+				message: 'Hi',
+				tone: 'info',
+				dismissible: true,
+				match: { window: 'edit-php', windows: [ 'plugins' ] },
+			},
+		] );
+		const matches = matcherFor( 'plugin/union' );
+		expect( matches( fakeWindow( 'edit-php' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'plugins' ) ) ).toBe( true );
+		expect( matches( fakeWindow( 'upload-php' ) ) ).toBe( false );
+	} );
+
+	test( 'urlContains selector matches case-insensitively', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/wc',
+				message: 'Hi',
+				tone: 'info',
+				dismissible: true,
+				match: { urlContains: 'WC-ADMIN' },
+			},
+		] );
+		const matches = matcherFor( 'plugin/wc' );
+		expect(
+			matches(
+				fakeWindow( 'whatever', 'http://example.com/wp-admin/admin.php?page=wc-admin' ),
+			),
+		).toBe( true );
+		expect(
+			matches(
+				fakeWindow( 'whatever', 'http://example.com/wp-admin/edit.php' ),
+			),
+		).toBe( false );
+	} );
+
+	test( 'urlContains tolerates an empty config.url', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/wc-strict',
+				message: 'Hi',
+				tone: 'info',
+				dismissible: true,
+				match: { urlContains: 'wc-admin' },
+			},
+		] );
+		const matches = matcherFor( 'plugin/wc-strict' );
+		expect( matches( fakeWindow( 'no-url' ) ) ).toBe( false );
+	} );
+
+	test( 'id selector + urlContains are AND-ed', () => {
+		applyServerWindowNotices( [
+			{
+				id: 'plugin/wc-posts',
+				message: 'Hi',
+				tone: 'info',
+				dismissible: true,
+				match: { window: 'edit-php', urlContains: 'wc-admin' },
+			},
+		] );
+		const matches = matcherFor( 'plugin/wc-posts' );
+		// Both match → render.
+		expect(
+			matches(
+				fakeWindow( 'edit-php', 'http://example.com/wp-admin/edit.php?page=wc-admin' ),
+			),
+		).toBe( true );
+		// id mismatch → skip even if URL matches.
+		expect(
+			matches(
+				fakeWindow( 'plugins', 'http://example.com/wp-admin/plugins.php?page=wc-admin' ),
+			),
+		).toBe( false );
+		// URL mismatch → skip even if id matches.
+		expect(
+			matches(
+				fakeWindow( 'edit-php', 'http://example.com/wp-admin/edit.php' ),
+			),
+		).toBe( false );
+	} );
+} );
+
+describe( 'window-notices-server-sync — applyServerWindowNotices', () => {
+	beforeEach( () => {
+		_resetWindowNoticesForTests();
+	} );
+	afterEach( () => {
+		_resetWindowNoticesForTests();
+	} );
+
+	test( 'adds entries on first call', () => {
+		const initial: DesktopWindowNoticeServerEntry[] = [
+			{
+				id: 'plugin/a',
+				message: 'A',
+				tone: 'info',
+				dismissible: true,
+			},
+			{
+				id: 'plugin/b',
+				message: 'B',
+				tone: 'warning',
+				dismissible: false,
+			},
+		];
+		applyServerWindowNotices( initial );
+
+		const list = listWindowNotices().map( ( e ) => e.id );
+		expect( list ).toContain( 'plugin/a' );
+		expect( list ).toContain( 'plugin/b' );
+	} );
+
+	test( 'updates an existing entry when the message changes', () => {
+		applyServerWindowNotices( [
+			{ id: 'plugin/c', message: 'old', tone: 'info', dismissible: true },
+		] );
+		applyServerWindowNotices( [
+			{ id: 'plugin/c', message: 'new', tone: 'warning', dismissible: false },
+		] );
+
+		const entry = listWindowNotices().find( ( e ) => e.id === 'plugin/c' );
+		expect( entry ).toBeDefined();
+		expect( entry!.message ).toBe( 'new' );
+		expect( entry!.tone ).toBe( 'warning' );
+		expect( entry!.dismissible ).toBe( false );
+	} );
+
+	test( 'drops server entries no longer in the payload', () => {
+		applyServerWindowNotices( [
+			{ id: 'plugin/keep', message: 'K', tone: 'info', dismissible: true },
+			{ id: 'plugin/drop', message: 'D', tone: 'info', dismissible: true },
+		] );
+		applyServerWindowNotices( [
+			{ id: 'plugin/keep', message: 'K', tone: 'info', dismissible: true },
+		] );
+
+		const ids = listWindowNotices().map( ( e ) => e.id );
+		expect( ids ).toContain( 'plugin/keep' );
+		expect( ids ).not.toContain( 'plugin/drop' );
+	} );
+
+	test( 'JS-registered (non-server) entries survive a server sync', () => {
+		// One JS-side caller; no owner tag.
+		registerWindowNotice( {
+			id: 'plugin/js',
+			message: 'JS',
+			tone: 'info',
+		} );
+		// Server ships one entry, then in a follow-up ships none.
+		applyServerWindowNotices( [
+			{ id: 'plugin/server', message: 'S', tone: 'info', dismissible: true },
+		] );
+		applyServerWindowNotices( [] );
+
+		const ids = listWindowNotices().map( ( e ) => e.id );
+		expect( ids ).toContain( 'plugin/js' );
+		expect( ids ).not.toContain( 'plugin/server' );
+	} );
+
+	test( 'ignores entries with missing or non-string id', () => {
+		applyServerWindowNotices( [
+			// Empty id — schema-valid string, but the runtime guard
+			// in applyServerWindowNotices skips it.
+			{ id: '', message: 'x', tone: 'info', dismissible: true },
+			// Missing id entirely — type-level malformed.
+			// @ts-expect-error — deliberately malformed for the test
+			{ message: 'x', tone: 'info', dismissible: true },
+			{ id: 'plugin/ok', message: 'ok', tone: 'info', dismissible: true },
+		] );
+
+		const ids = listWindowNotices().map( ( e ) => e.id );
+		expect( ids ).toEqual( [ 'plugin/ok' ] );
+	} );
+} );

--- a/src/window-notices-server-sync.ts
+++ b/src/window-notices-server-sync.ts
@@ -1,0 +1,110 @@
+/**
+ * Server-driven window-notices sync.
+ *
+ * Notices are pure declarative data — the PHP side ships the full
+ * entry through the payload (id, message, tone, dismissibility,
+ * match), and this module mirrors the list onto the live registry by
+ * calling {@link registerWindowNotice} for each. Re-runs on every
+ * `desktop-mode-plugins-changed` payload so plugin activation /
+ * deactivation reflects without an F5.
+ *
+ * @since 0.22.0
+ */
+
+import {
+	registerWindowNotice,
+	unregisterWindowNotice,
+	listWindowNotices,
+	type WindowNoticeMatch,
+} from './window-notices';
+import type { DesktopWindowNoticeServerEntry } from './types';
+import type { Window as DesktopWindow } from './window';
+
+function buildMatcher(
+	match: DesktopWindowNoticeServerEntry[ 'match' ],
+): WindowNoticeMatch | undefined {
+	if ( ! match ) {
+		return undefined;
+	}
+	const ids = new Set< string >();
+	if ( typeof match.window === 'string' && match.window !== '' ) {
+		ids.add( match.window );
+	}
+	if ( Array.isArray( match.windows ) ) {
+		for ( const id of match.windows ) {
+			if ( typeof id === 'string' && id !== '' ) {
+				ids.add( id );
+			}
+		}
+	}
+	const needle =
+		typeof match.urlContains === 'string' && match.urlContains !== ''
+			? match.urlContains.toLowerCase()
+			: null;
+
+	if ( ids.size === 0 && needle === null ) {
+		return undefined;
+	}
+
+	return ( w: DesktopWindow ) => {
+		if ( ids.size > 0 && ! ids.has( w.id ) ) {
+			return false;
+		}
+		if ( needle !== null ) {
+			const url =
+				typeof w.config.url === 'string' ? w.config.url.toLowerCase() : '';
+			if ( ! url.includes( needle ) ) {
+				return false;
+			}
+		}
+		return true;
+	};
+}
+
+/**
+ * Reconcile the live `registerWindowNotice()` registry against a
+ * fresh server-shipped list. Adds any newly-declared entries,
+ * updates changed ones, removes entries the server no longer ships.
+ */
+export function applyServerWindowNotices(
+	entries: DesktopWindowNoticeServerEntry[],
+): void {
+	const wanted = new Set< string >();
+
+	for ( const entry of entries ) {
+		if ( ! entry || typeof entry.id !== 'string' || ! entry.id ) {
+			continue;
+		}
+		wanted.add( entry.id.toLowerCase() );
+		// register* replaces an existing entry with the same id, so
+		// it doubles as an update path.
+		registerWindowNotice( {
+			id: entry.id,
+			message: entry.message,
+			tone: entry.tone,
+			dismissible: entry.dismissible !== false,
+			icon: entry.icon,
+			match: buildMatcher( entry.match ),
+			order: typeof entry.order === 'number' ? entry.order : undefined,
+			// `owner` tag marks every server-shipped notice so a
+			// targeted cleanup is trivial if/when we surface a sweep
+			// helper later. Matches the convention used by the
+			// command / settings-tab sync modules.
+			owner: '__server__',
+		} );
+	}
+
+	// Drop entries the server no longer ships (plugin deactivated
+	// mid-session). Only sweep entries we recognise as
+	// server-shipped via the owner tag — JS-registered notices
+	// (`wp.desktop.registerWindowNotice` from a non-server caller)
+	// keep their lifecycle.
+	for ( const existing of listWindowNotices() ) {
+		if ( existing.owner !== '__server__' ) {
+			continue;
+		}
+		if ( ! wanted.has( existing.id ) ) {
+			unregisterWindowNotice( existing.id );
+		}
+	}
+}

--- a/src/window-notices.ts
+++ b/src/window-notices.ts
@@ -1,0 +1,263 @@
+/**
+ * Window-notice registry — top-of-window banners.
+ *
+ * Plugins call {@link registerWindowNotice} to surface a banner at the
+ * top of any window matching the registration's `match` predicate.
+ * The banner is rendered as a `<wpd-notice>` element appended to the
+ * window's `after-titlebar` slot — the slot host the window-chrome
+ * framework already exposes for "below the title bar, above the body,
+ * full window width" affordances.
+ *
+ * Why a dedicated registry on top of `registerWindowSlot()`: notices
+ * are pure declarative data (tone, message, dismissibility,
+ * persistence id) that every plugin describes the same way. Forcing
+ * each author to write the slot's render callback by hand bloats
+ * plugin code, fragments the close-button affordance, and breaks the
+ * "dismissal persisted per user" promise. Wrapping the slot system
+ * lets the framework own the rendering rules and gives plugin authors
+ * a one-line API.
+ *
+ * Cross-bundle state: the registry routes through
+ * {@link createSharedStore} (key `desktop-mode/window-notices`) so the
+ * lazy `window-system[.min].js` bundle and the main `desktop.ts`
+ * bundle share the same `Map` of entries.
+ *
+ * @since 0.22.0
+ */
+
+import { createSharedStore } from './shared-store';
+import {
+	registerWindowSlot,
+	unregisterWindowSlot,
+} from './window-chrome/slots/registry';
+import type { Window as DesktopWindow } from './window';
+import {
+	clearNoticeDismissed,
+	markNoticeDismissed,
+} from './ui/components/wpd-notice/storage';
+// Side-effect import — registers the `<wpd-notice>` custom element so
+// the element we synthesize in `buildNoticeElement` upgrades
+// synchronously. Idempotent: harmless if another bundle (or the
+// barrel) already loaded the module.
+import './ui/components/wpd-notice/wpd-notice';
+
+/**
+ * Tone palette accepted by {@link WindowNoticeEntry}. Mirrors
+ * `<wpd-notice>`'s `tone` attribute.
+ */
+export type WindowNoticeTone =
+	| 'info'
+	| 'success'
+	| 'warning'
+	| 'error'
+	| 'danger'
+	| 'neutral';
+
+/**
+ * Predicate handed `(window)`; return `true` to render the notice on
+ * that window.
+ */
+export type WindowNoticeMatch = ( win: DesktopWindow ) => boolean;
+
+/**
+ * One declarative window-notice. The `id` is also the persistence key
+ * — when the user dismisses the notice we record `id → true` in
+ * localStorage and the `<wpd-notice>` self-hides on subsequent mounts.
+ */
+export interface WindowNoticeEntry {
+	/**
+	 * Persistence + dedupe key. Recommended format
+	 * `<plugin>/<notice-slug>` so two plugins won't collide.
+	 */
+	id: string;
+	/**
+	 * HTML message body. Allowed: `<a>`, `<strong>`, `<em>`, `<br>`,
+	 * and other inline formatting. The string is written via
+	 * `innerHTML` — callers MUST sanitize untrusted input themselves
+	 * (PHP authors: pass it through `wp_kses_post()`).
+	 */
+	message: string;
+	/** Color palette. Default `info`. */
+	tone?: WindowNoticeTone;
+	/** Show a close button. Default `true`. */
+	dismissible?: boolean;
+	/** Optional Dashicons class for a leading glyph (e.g. `dashicons-info`). */
+	icon?: string;
+	/**
+	 * Window-match predicate. Return `true` to render the notice on a
+	 * given window. Defaults to "every window".
+	 */
+	match?: WindowNoticeMatch;
+	/** Sort order — lower renders higher. Default 100. */
+	order?: number;
+	/**
+	 * Owner tag — typically the WordPress script handle that
+	 * registered the notice. Set to live-unregister on plugin
+	 * deactivation.
+	 */
+	owner?: string;
+}
+
+interface RegistryState {
+	entries: Map< string, WindowNoticeEntry >;
+}
+
+const store = createSharedStore< RegistryState >(
+	'desktop-mode/window-notices',
+	() => ( { entries: new Map() } ),
+);
+
+const ID_PATTERN = /^[a-z0-9_/-]+$/;
+
+function slotIdFor( id: string ): string {
+	return `desktop-mode-notice/${ id.toLowerCase() }`;
+}
+
+function buildNoticeElement( entry: WindowNoticeEntry ): HTMLElement {
+	const el = document.createElement( 'wpd-notice' );
+	el.setAttribute( 'tone', entry.tone ?? 'info' );
+	el.setAttribute( 'notice-id', entry.id );
+	if ( entry.dismissible === false ) {
+		el.setAttribute( 'not-dismissible', '' );
+	}
+	if ( entry.icon ) {
+		el.setAttribute( 'icon', entry.icon );
+	}
+	// `innerHTML` is intentional — `message` is HTML so plugins can
+	// include links and formatting. The contract is documented on the
+	// entry's `message` field; PHP callers should use
+	// `wp_kses_post()`.
+	el.innerHTML = entry.message;
+	return el;
+}
+
+/**
+ * Register (or replace) a window notice. Returns an unregister
+ * function for convenience.
+ *
+ * @example
+ * ```ts
+ * wp.desktop.registerWindowNotice( {
+ *     id: 'my-plugin/welcome',
+ *     tone: 'info',
+ *     message: 'Welcome! <a href="…">Read the docs</a>.',
+ *     match: ( w ) => w.id === 'edit-php',
+ * } );
+ * ```
+ */
+export function registerWindowNotice(
+	entry: WindowNoticeEntry,
+): () => void {
+	if ( ! entry || typeof entry !== 'object' ) {
+		return () => {};
+	}
+	const id = String( entry.id ?? '' ).trim().toLowerCase();
+	if ( ! id || ! ID_PATTERN.test( id ) ) {
+		return () => {};
+	}
+	if ( typeof entry.message !== 'string' || entry.message === '' ) {
+		return () => {};
+	}
+
+	const normalised: WindowNoticeEntry = { ...entry, id };
+	store.state.entries.set( id, normalised );
+
+	const slotId = slotIdFor( id );
+	registerWindowSlot( {
+		id: slotId,
+		slot: 'after-titlebar',
+		order: normalised.order ?? 100,
+		// Append rather than clear — every notice slot entry appends
+		// its own `<wpd-notice>` so multiple notices stack.
+		replace: false,
+		owner: normalised.owner,
+		match: ( win ) => {
+			const def = store.state.entries.get( id );
+			if ( ! def ) {
+				return false;
+			}
+			if ( typeof def.match !== 'function' ) {
+				return true;
+			}
+			try {
+				return def.match( win ) === true;
+			} catch {
+				return false;
+			}
+		},
+		render: ( host ) => {
+			const def = store.state.entries.get( id );
+			if ( ! def ) {
+				return;
+			}
+			host.appendChild( buildNoticeElement( def ) );
+		},
+	} );
+
+	return () => unregisterWindowNotice( id );
+}
+
+/**
+ * Remove a window notice by id. Idempotent.
+ */
+export function unregisterWindowNotice( id: string ): void {
+	const key = String( id ?? '' ).trim().toLowerCase();
+	if ( ! key ) {
+		return;
+	}
+	if ( store.state.entries.delete( key ) ) {
+		unregisterWindowSlot( slotIdFor( key ) );
+	}
+}
+
+/**
+ * Defensive snapshot of every registered notice. Sorted by `(order,
+ * id)` so iteration is deterministic.
+ */
+export function listWindowNotices(): WindowNoticeEntry[] {
+	return Array.from( store.state.entries.values() ).sort( ( a, b ) => {
+		const oa = a.order ?? 100;
+		const ob = b.order ?? 100;
+		if ( oa !== ob ) {
+			return oa - ob;
+		}
+		return a.id.localeCompare( b.id );
+	} );
+}
+
+/**
+ * Imperatively mark a notice as dismissed for the current user.
+ * Future mounts will start in the hidden state.
+ */
+export function dismissWindowNotice( id: string ): void {
+	const key = String( id ?? '' ).trim().toLowerCase();
+	if ( ! key ) {
+		return;
+	}
+	markNoticeDismissed( key );
+}
+
+/**
+ * Clear a previous dismissal so the notice shows again on next
+ * mount.
+ */
+export function undismissWindowNotice( id: string ): void {
+	const key = String( id ?? '' ).trim().toLowerCase();
+	if ( ! key ) {
+		return;
+	}
+	clearNoticeDismissed( key );
+}
+
+/**
+ * Test-only escape hatch — drops every registered notice + every
+ * dismissal record so tests start from a clean slate.
+ *
+ * @internal
+ */
+export function _resetWindowNoticesForTests(): void {
+	for ( const id of Array.from( store.state.entries.keys() ) ) {
+		unregisterWindowSlot( slotIdFor( id ) );
+	}
+	store.state.entries.clear();
+}

--- a/tests/phpunit/tests/windowNotices.php
+++ b/tests/phpunit/tests/windowNotices.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Tests for the window-notice registry — declarative top-of-window
+ * banners shipped from PHP and rendered as `<wpd-notice>` inside the
+ * `after-titlebar` slot. Coverage:
+ *
+ *   - storage + validation of `desktop_mode_register_window_notice()`
+ *   - payload shape + ordering of
+ *     `desktop_mode_build_window_notices_payload()`
+ *   - the `desktop_mode_window_notices` request-time filter
+ *   - that the notices land in the menu payload under
+ *     `serverWindowNotices`
+ *
+ * Module-level state is flushed in `set_up` so cross-test pollution
+ * stays bounded.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-window-notices
+ */
+class Tests_DesktopMode_WindowNotices extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		desktop_mode_flush_window_notice_registry();
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_register_stores_entry() {
+		$result = desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/welcome',
+				'message' => 'Hello',
+			)
+		);
+		$this->assertTrue( $result );
+
+		$registry = desktop_mode_window_notice_registry();
+		$this->assertArrayHasKey( 'plugin/welcome', $registry );
+		$this->assertSame( 'Hello', $registry['plugin/welcome']['message'] );
+		$this->assertSame( 'info', $registry['plugin/welcome']['tone'] );
+		$this->assertTrue( $registry['plugin/welcome']['dismissible'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_register_rejects_empty_id() {
+		$result = desktop_mode_register_window_notice(
+			array(
+				'id'      => '',
+				'message' => 'Hello',
+			)
+		);
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'desktop_mode_missing_id', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_register_rejects_empty_message() {
+		$result = desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/blank',
+				'message' => '',
+			)
+		);
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'desktop_mode_missing_message', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_register_rejects_invalid_tone() {
+		$result = desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/bad-tone',
+				'message' => 'Hello',
+				'tone'    => 'flashy',
+			)
+		);
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'desktop_mode_invalid_tone', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_register_rejects_invalid_id_chars() {
+		$result = desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/Bad Id!',
+				'message' => 'Hello',
+			)
+		);
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'desktop_mode_invalid_id', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_message_passes_through_wp_kses_post() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/safe',
+				'message' => 'Hi <a href="https://example.com">link</a><script>alert(1)</script>',
+			)
+		);
+		$entry = desktop_mode_window_notice_registry( 'plugin/safe' );
+		$this->assertStringContainsString( '<a href="https://example.com">link</a>', $entry['message'] );
+		$this->assertStringNotContainsString( '<script>', $entry['message'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_build_window_notices_payload
+	 */
+	public function test_payload_returns_entries_in_order() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/b',
+				'message' => 'B',
+				'order'   => 200,
+			)
+		);
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/a',
+				'message' => 'A',
+				'order'   => 50,
+			)
+		);
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/c',
+				'message' => 'C',
+				'order'   => 100,
+			)
+		);
+
+		$payload = desktop_mode_build_window_notices_payload();
+		$this->assertCount( 3, $payload );
+		$this->assertSame( 'plugin/a', $payload[0]['id'] );
+		$this->assertSame( 'plugin/c', $payload[1]['id'] );
+		$this->assertSame( 'plugin/b', $payload[2]['id'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_build_window_notices_payload
+	 */
+	public function test_filter_can_append_request_time_notices() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/static',
+				'message' => 'Static',
+			)
+		);
+		add_filter(
+			'desktop_mode_window_notices',
+			static function ( $entries ) {
+				$entries[] = array(
+					'id'      => 'plugin/dynamic',
+					'message' => 'Dynamic',
+					'tone'    => 'warning',
+					'order'   => 10,
+				);
+				return $entries;
+			}
+		);
+		$payload = desktop_mode_build_window_notices_payload();
+		$this->assertSame( 'plugin/dynamic', $payload[0]['id'] );
+		$this->assertSame( 'plugin/static', $payload[1]['id'] );
+
+		remove_all_filters( 'desktop_mode_window_notices' );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_register_fires_action() {
+		$captured = null;
+		add_action(
+			'desktop_mode_window_notice_registered',
+			static function ( $id, $entry ) use ( &$captured ) {
+				$captured = array(
+					'id'    => $id,
+					'entry' => $entry,
+				);
+			},
+			10,
+			2
+		);
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/action-test',
+				'message' => 'Hi',
+			)
+		);
+		$this->assertNotNull( $captured );
+		$this->assertSame( 'plugin/action-test', $captured['id'] );
+		$this->assertSame( 'Hi', $captured['entry']['message'] );
+
+		remove_all_actions( 'desktop_mode_window_notice_registered' );
+	}
+
+	/**
+	 * @covers ::desktop_mode_build_menu_payload
+	 */
+	public function test_menu_payload_includes_server_window_notices() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/menu-payload',
+				'message' => 'Menu',
+			)
+		);
+		$payload = desktop_mode_build_menu_payload();
+		$this->assertArrayHasKey( 'serverWindowNotices', $payload );
+		$ids = array_column( $payload['serverWindowNotices'], 'id' );
+		$this->assertContains( 'plugin/menu-payload', $ids );
+	}
+}

--- a/tests/phpunit/tests/windowNotices.php
+++ b/tests/phpunit/tests/windowNotices.php
@@ -224,4 +224,84 @@ class Tests_DesktopMode_WindowNotices extends WP_UnitTestCase {
 		$ids = array_column( $payload['serverWindowNotices'], 'id' );
 		$this->assertContains( 'plugin/menu-payload', $ids );
 	}
+
+	/**
+	 * @covers ::desktop_mode_build_window_notices_payload
+	 */
+	public function test_payload_round_trips_match_icon_and_order() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/round-trip',
+				'message' => 'Round trip',
+				'icon'    => 'dashicons-info',
+				'order'   => 42,
+				'match'   => array(
+					'windows'     => array( 'edit-php', 'edit-php-page' ),
+					'urlContains' => 'wc-admin',
+				),
+			)
+		);
+		$payload = desktop_mode_build_window_notices_payload();
+		$entry   = null;
+		foreach ( $payload as $candidate ) {
+			if ( 'plugin/round-trip' === $candidate['id'] ) {
+				$entry = $candidate;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry, 'expected entry in payload' );
+		$this->assertSame( 'dashicons-info', $entry['icon'] );
+		$this->assertSame( 42, $entry['order'] );
+		$this->assertIsArray( $entry['match'] );
+		$this->assertSame(
+			array( 'edit-php', 'edit-php-page' ),
+			$entry['match']['windows']
+		);
+		$this->assertSame( 'wc-admin', $entry['match']['urlContains'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_icon_must_match_dashicons_pattern() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/icon-valid',
+				'message' => 'Valid icon',
+				'icon'    => 'dashicons-info',
+			)
+		);
+		$entry = desktop_mode_window_notice_registry( 'plugin/icon-valid' );
+		$this->assertSame( 'dashicons-info', $entry['icon'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_icon_drops_garbage_silently() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/icon-junk',
+				'message' => 'Junk icon',
+				'icon'    => 'evil class injection',
+			)
+		);
+		$entry = desktop_mode_window_notice_registry( 'plugin/icon-junk' );
+		$this->assertSame( '', $entry['icon'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_window_notice
+	 */
+	public function test_icon_drops_non_dashicons_prefix() {
+		desktop_mode_register_window_notice(
+			array(
+				'id'      => 'plugin/icon-no-prefix',
+				'message' => 'Other class',
+				'icon'    => 'fa-info',
+			)
+		);
+		$entry = desktop_mode_window_notice_registry( 'plugin/icon-no-prefix' );
+		$this->assertSame( '', $entry['icon'] );
+	}
 }


### PR DESCRIPTION
- Introduced `desktop_mode_register_window_notice()` for registering declarative window notices.
- Created `<wpd-notice>` web component for rendering notices with customizable tones, messages, and dismissibility.
- Implemented localStorage management for user-specific notice dismissal.
- Added server-side synchronization for window notices to reflect plugin changes without page reloads.
- Developed comprehensive tests for the `<wpd-notice>` component and its functionality.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-228-0255cf16740b1f95016df299bbd3ae8808c55035.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->