### PR TITLE
Polish four framework surfaces for plugin authors

### DIFF
--- a/docs/examples/register-icon.md
+++ b/docs/examples/register-icon.md
@@ -174,6 +174,35 @@ If you want to see the error path in action, comment out the `'title'` argument 
 
 The `WP_Error` contract means you find typos at plugin-load time, not at first-click time.
 
+## Decorating the rendered grid
+
+When you need to enhance the wallpaper icons themselves — a cursor adornment, a status dot, a drag handle — subscribe to `HOOKS.DESKTOP_ICONS_RENDERED`. Since 0.25.0 the payload hands you the rendered container *and* a map of `id → tile element`, so your decorator doesn't have to query the DOM (and doesn't have to re-query on every live menu refresh — the hook fires exactly when the grid is rebuilt):
+
+```js
+wp.desktop.hooks.addAction(
+    wp.desktop.HOOKS.DESKTOP_ICONS_RENDERED,
+    'my-plugin/icon-status-dot',
+    ( payload ) => {
+        const { ids, container, tiles } = payload;
+        if ( ! ids.includes( 'jorvy' ) ) {
+            return;
+        }
+        const tile = tiles.get( 'jorvy' );
+        if ( ! tile ) {
+            return;
+        }
+        const dot = document.createElement( 'span' );
+        dot.className = 'my-plugin__status-dot';
+        tile.appendChild( dot );
+        // `container` is the <div class="desktop-mode-icons"> grid root —
+        // use it if your decoration spans multiple tiles (a connector
+        // line, a hover halo) instead of decorating a single tile.
+    }
+);
+```
+
+The hook is suppressed when the rendered DOM is unchanged (fingerprint short-circuit), so decorators run exactly when the grid actually rebuilds — not on every live menu refresh.
+
 ## See also
 
 - [`desktop_mode_register_window()`](../hooks-reference.md#registration-functions) — full argument reference and error-code table.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2846,6 +2846,19 @@ wp.desktop.registerWidget( {
 
 User-placed geometry (position + size of liberated widgets) persists per-user in `localStorage` under `desktop-mode-widgets-geometry`. Removing a widget clears its stored geometry so a re-add starts docked in the column again.
 
+##### `wp.desktop.widgets.redock( id )` — Stable since 0.25.0
+
+Programmatically un-float a liberated widget back into the right-side column. Idempotent — already-docked widgets and unknown ids silently no-op. Mirrors what the user gets by clicking the re-dock affordance in the floating widget's chrome header.
+
+```js
+// "Reset widget positions" command for a power-user palette.
+for ( const id of wp.desktop.widgetLayer?.getEnabledIds() ?? [] ) {
+    wp.desktop.widgets.redock( id );
+}
+```
+
+Equivalent legacy entry point: `wp.desktop.widgetLayer?.redock( id )`. New code should prefer `wp.desktop.widgets.redock`, which keeps a stable namespace as the widget surface grows.
+
 | Hook | Kind | Status | Payload |
 |---|---|---|---|
 | `desktop-mode.widgets` | filter | Stable | the registry array |
@@ -2864,6 +2877,7 @@ All window actions include at minimum `{ windowId: string }` — additional fiel
 
 | Hook | Kind | Status | Payload |
 |---|---|---|---|
+| `desktop-mode.window.geometry` | filter | Stable *(0.25.0)* | `( geometry, ctx ) => geometry` — last call before `WindowConfig` is baked. See [the geometry filter section below](#window-geometry-filter) for the contract and a recipe. |
 | `desktop-mode.window.opened` | action | Stable | `{ windowId, page, title, url }` |
 | `desktop-mode.window.reopened` | action | Stable | `{ windowId, baseId, wasMinimized }` — fires when `openWindow()` is called for an already-open window |
 | `desktop-mode.window.content-loading` | action | Stable *(0.6.0)* | `{ windowId }` — fires on the loading entry edge (construction + every `markContentLoading()`). Edge-triggered. |
@@ -2894,6 +2908,74 @@ All window actions include at minimum `{ windowId: string }` — additional fiel
 The window hooks fan out alongside the existing `desktop-mode-window-*` CustomEvents (see section 2) — both APIs fire for every state change. New code should prefer the hook bus.
 
 All hooks can be listed via `wp.hooks.hasAction()` / `hasFilter()` for defensive checks.
+
+<a id="window-geometry-filter"></a>
+##### `desktop-mode.window.geometry` filter — Stable since 0.25.0
+
+Last call before a window's resolved `x` / `y` / `width` / `height` / `initialState` are baked into the `WindowConfig` the constructor consumes. Plugins use it to:
+
+- **Override the default size of windows they own.** Compute "this should open at 40% of the desktop in the bottom-right corner" once at filter time, instead of resizing after `open()` settles.
+- **Snap restored bounds to a different region.** Re-anchor a window the user previously dragged off-screen, or clamp to a per-plugin region.
+- **Force an initial state** (e.g. always-maximized for a fullscreen-y tool).
+
+```js
+const { HOOKS } = wp.desktop;
+
+wp.desktop.hooks.addFilter(
+    HOOKS.WINDOW_GEOMETRY,
+    'my-plugin/place-shop',
+    ( geometry, ctx ) => {
+        // Only retouch the window WE own, and only on fresh opens —
+        // leave caller-pinned dims and user-saved geometry alone.
+        if ( ctx.baseId !== 'my-shop' || ctx.source !== 'default' ) {
+            return geometry;
+        }
+        const { width, height } = ctx.desktopRect;
+        return {
+            ...geometry,
+            width:  Math.min( 720, width  - 40 ),
+            height: Math.min( 540, height - 80 ),
+            x:      width  - Math.min( 720, width  - 40 ) - 20,
+            y:      height - Math.min( 540, height - 80 ) - 20,
+        };
+    }
+);
+```
+
+**Signature:**
+
+```ts
+type ResolvedWindowGeometry = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    state?: 'maximized';            // optional initial state
+};
+
+type WindowGeometrySource =
+    | 'explicit'    // caller passed at least one of {x,y,width,height,initialState}
+    | 'restored'    // values came from the per-baseId localStorage geometry store
+    | 'default';    // cascade + desktopRect defaults
+
+type WindowGeometryContext = {
+    windowId:    string;            // unique per-instance id (multi-window windows differ)
+    baseId:      string;            // registry id — stable across instances
+    source:      WindowGeometrySource;
+    desktopRect: { width: number; height: number };
+};
+
+// Filter shape
+( geometry: ResolvedWindowGeometry, ctx: WindowGeometryContext )
+    => ResolvedWindowGeometry
+```
+
+**Guarantees:**
+
+- The shell re-clamps `width`/`height` to the window's registered `minWidth`/`minHeight` after the filter returns — a buggy filter cannot ship a sub-minimum window.
+- `x`/`y` are NOT re-clamped to the desktop rect; plugins sometimes deliberately place windows partially off-screen. The filter is responsible for its own viewport math when it cares.
+- The filter runs *every time the window opens*, not just at registration — so a deactivation/reactivation of a plugin re-runs its filter with fresh `desktopRect` numbers.
+- Companion of `desktop_mode_register_window`'s server-side `width` / `height` defaults; the filter sees those as the starting `geometry` value when `source === 'default'`.
 
 #### `DockItem` shape
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2925,9 +2925,10 @@ wp.desktop.hooks.addFilter(
     HOOKS.WINDOW_GEOMETRY,
     'my-plugin/place-shop',
     ( geometry, ctx ) => {
-        // Only retouch the window WE own, and only on fresh opens —
-        // leave caller-pinned dims and user-saved geometry alone.
-        if ( ctx.baseId !== 'my-shop' || ctx.source !== 'default' ) {
+        // Only retouch the window WE own, and only when the user
+        // hasn't dragged or resized it yet — once they have, respect
+        // their layout.
+        if ( ctx.baseId !== 'my-shop' || ctx.hasSavedGeometry ) {
             return geometry;
         }
         const { width, height } = ctx.desktopRect;
@@ -2950,25 +2951,26 @@ type ResolvedWindowGeometry = {
     y: number;
     width: number;
     height: number;
-    state?: 'maximized';            // optional initial state
+    state?: WindowState;            // optional initial state
 };
 
-type WindowGeometrySource =
-    | 'explicit'    // caller passed at least one of {x,y,width,height,initialState}
-    | 'restored'    // values came from the per-baseId localStorage geometry store
-    | 'default';    // cascade + desktopRect defaults
-
 type WindowGeometryContext = {
-    windowId:    string;            // unique per-instance id (multi-window windows differ)
-    baseId:      string;            // registry id — stable across instances
-    source:      WindowGeometrySource;
-    desktopRect: { width: number; height: number };
+    windowId:         string;        // unique per-instance id (multi-window windows differ)
+    baseId:           string;        // registry id — stable across instances
+    hasSavedGeometry: boolean;       // user previously dragged/resized — respect their layout
+    callerPinned:     boolean;       // caller passed at least one explicit dim (native windows: usually true)
+    desktopRect:      { width: number; height: number };
 };
 
 // Filter shape
 ( geometry: ResolvedWindowGeometry, ctx: WindowGeometryContext )
     => ResolvedWindowGeometry
 ```
+
+**About the booleans.** `hasSavedGeometry` and `callerPinned` carry the only two distinctions a filter actually needs:
+
+- **`hasSavedGeometry: true`** — the user previously dragged or resized this window and the values you're being handed are the restored layout. Bail in this case to respect the user's choice. (`hasSavedGeometry` is the most common guard plugins want.)
+- **`callerPinned: true`** — the caller of `manager.open()` passed at least one explicit dimension. For **native windows** this is usually `true` (the framework's native-window opener passes the registry's declared `width`/`height` defaults); for **iframe admin pages opened from the dock** this is usually `false`. The filter is free to override registry-declared defaults — `callerPinned: true` does NOT mean "leave the window alone."
 
 **Guarantees:**
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2946,12 +2946,16 @@ wp.desktop.hooks.addFilter(
 **Signature:**
 
 ```ts
+type WindowState =
+    | 'normal' | 'maximized' | 'minimized'
+    | 'fullscreen' | 'snapped-left' | 'snapped-right';
+
 type ResolvedWindowGeometry = {
     x: number;
     y: number;
     width: number;
     height: number;
-    state?: WindowState;            // optional initial state
+    state?: WindowState;            // optional initial state — e.g. force 'maximized' or 'snapped-left'
 };
 
 type WindowGeometryContext = {
@@ -2977,7 +2981,7 @@ type WindowGeometryContext = {
 - The shell re-clamps `width`/`height` to the window's registered `minWidth`/`minHeight` after the filter returns — a buggy filter cannot ship a sub-minimum window.
 - `x`/`y` are NOT re-clamped to the desktop rect; plugins sometimes deliberately place windows partially off-screen. The filter is responsible for its own viewport math when it cares.
 - The filter runs *every time the window opens*, not just at registration — so a deactivation/reactivation of a plugin re-runs its filter with fresh `desktopRect` numbers.
-- Companion of `desktop_mode_register_window`'s server-side `width` / `height` defaults; the filter sees those as the starting `geometry` value when `source === 'default'`.
+- Companion of `desktop_mode_register_window`'s server-side `width` / `height` defaults: the filter sees those defaults as the starting `geometry` value, and `ctx.callerPinned` is `true` for native windows because the framework's own opener passes them through as explicit `manager.open()` args. The filter is free to override anyway — `callerPinned` is signal, not veto.
 
 #### `DockItem` shape
 

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -161,7 +161,7 @@ import type { NativeWindowDef, DesktopConfig } from '../types';
  */
 export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'windowManager', 'dock', 'taskbar', 'icons', 'saveSession', 'hooks', 'HOOKS',
-	'isActive', 'registerWallpaper', 'registerWidget', 'widgetLayer',
+	'isActive', 'registerWallpaper', 'registerWidget', 'widgetLayer', 'widgets',
 	'registerSystemTile', 'registerWindow', 'openWindow', 'cloneTemplate',
 	'onWindow', 'loadVendorScript', 'getWallpaperSurfaces', 'registerModule',
 	'loadModules', 'whenReady', 'ready', 'isReady', 'setDefaultWindow',
@@ -293,6 +293,11 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 			// `ensureMounted(id)` — exposed below.
 		},
 		widgetLayer,
+		widgets: {
+			redock: ( id: string ) => {
+				widgetLayer?.redock( id );
+			},
+		},
 		loadVendorScript,
 		getWallpaperSurfaces: () => collectWallpaperSurfaces( manager ),
 		registerWindow,

--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -318,6 +318,7 @@ export function renderDesktopIcons(
 		return ap - bp;
 	} );
 
+	const tiles = new Map< string, HTMLElement >();
 	for ( const entry of ordered ) {
 		const tile = buildIcon( entry, deps );
 		const stored = _badges.get( entry.id ) ?? 0;
@@ -325,6 +326,7 @@ export function renderDesktopIcons(
 			_paintBadgeNode( tile, stored );
 		}
 		container.appendChild( tile );
+		tiles.set( entry.id, tile );
 	}
 
 	host.appendChild( container );
@@ -335,8 +337,15 @@ export function renderDesktopIcons(
 	// pinged exactly when the DOM actually changed. Notification
 	// badges no longer need this signal: the framework persists
 	// them in `_badges` and paints them as part of the build.
+	//
+	// `container` is the rail element; `tiles` is a frozen map of
+	// id → tile element so decorators don't have to re-`querySelector`
+	// each id. Mirrors the {@link HOOKS.DOCK_AFTER_RENDER}
+	// `tileElements` contract.
 	doAction( HOOKS.DESKTOP_ICONS_RENDERED, {
 		ids: ( icons ?? [] ).map( ( i ) => i.id ),
+		container,
+		tiles: tiles as ReadonlyMap< string, HTMLElement >,
 	} );
 }
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -411,13 +411,36 @@ export interface WpDesktopPublicApi {
 	/**
 	 * Live reference to the shell's widget layer (or `null` when the
 	 * widget DOM element isn't present). Companion plugins use the
-	 * public `add( id )` / `remove( id )` / `ensureMounted( id )`
-	 * methods to pin or unpin their widget programmatically — e.g.
-	 * a monitor plugin that auto-surfaces its widget on the first
-	 * error burst, or an onboarding flow that guarantees the
-	 * quick-start widget is present on a new user's first visit.
+	 * public `add( id )` / `remove( id )` / `ensureMounted( id )` /
+	 * `redock( id )` methods to pin, unpin, or re-park their widget
+	 * programmatically — e.g. a monitor plugin that auto-surfaces
+	 * its widget on the first error burst, or an onboarding flow
+	 * that guarantees the quick-start widget is present on a new
+	 * user's first visit.
+	 *
+	 * Prefer the stable {@link widgets} namespace for new code; the
+	 * `widgetLayer` reference remains for code that already grew up
+	 * against it.
 	 */
 	widgetLayer: WidgetLayer | null;
+	/**
+	 * Stable widget control surface — a thin proxy over
+	 * {@link widgetLayer} so plugin authors get a documented entry
+	 * point that doesn't depend on the shell's internal class
+	 * identity. All methods are idempotent and `null`-safe when
+	 * the layer isn't mounted (classic admin context, or the widget
+	 * DOM element hasn't been emitted by the shell for any reason).
+	 *
+	 * @since 0.25.0
+	 */
+	widgets: {
+		/**
+		 * Move a floating widget back into the column. No-op if the
+		 * widget isn't currently floating, isn't enabled, or doesn't
+		 * exist.
+		 */
+		redock: ( id: string ) => void;
+	};
 	/**
 	 * Register a shell-level system tile (a JS-owned launcher that
 	 * isn't part of the admin menu — a quick-notes panel, a

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -268,6 +268,41 @@ export const HOOKS = {
 	// CustomEvents but ship under the hook bus so plugins can use one
 	// idiomatic API for everything the shell emits.
 	// ------------------------------------------------------------------
+	/**
+	 * Filter, last call before a window's resolved geometry (x, y,
+	 * width, height, initialState) is baked into the `WindowConfig`
+	 * passed to the `Window` constructor. Lets a plugin override
+	 * default placement for windows it owns, snap restored bounds to
+	 * a different region, or force a particular initial state.
+	 *
+	 * Signature:
+	 *
+	 *     ( geometry: ResolvedWindowGeometry, ctx: WindowGeometryContext )
+	 *         => ResolvedWindowGeometry
+	 *
+	 * Where `ResolvedWindowGeometry = { x, y, width, height, state? }`
+	 * and `ctx = { windowId, baseId, source, desktopRect }`. `source`
+	 * is `'explicit'` when the caller passed at least one of
+	 * {x, y, width, height, initialState} (session restore,
+	 * `openNew` with explicit dims), `'restored'` when the values
+	 * came from the per-baseId `localStorage` geometry store, and
+	 * `'default'` for the cascade + desktopRect defaults.
+	 *
+	 * The shell re-clamps `width`/`height` to the registered
+	 * `minWidth`/`minHeight` after the filter returns — a buggy
+	 * filter cannot ship a sub-minimum window. `x` and `y` are
+	 * NOT re-clamped to the desktop rect after the filter (plugins
+	 * sometimes want to place windows partially off-screen for
+	 * deliberate stylistic reasons); the filter is responsible for
+	 * its own viewport math when it cares.
+	 *
+	 * Companion of `desktop_mode_register_window` server-side
+	 * defaults — runs every time a window opens, not just at
+	 * registration.
+	 *
+	 * @since 0.25.0
+	 */
+	WINDOW_GEOMETRY: 'desktop-mode.window.geometry',
 	/** Action, fires when a window is added to the stack. */
 	WINDOW_OPENED: 'desktop-mode.window.opened',
 	/**
@@ -585,11 +620,21 @@ export const HOOKS = {
 	DESKTOP_ICON_CLICKED: 'desktop-mode.desktop-icon.clicked',
 	/**
 	 * Action, fires after the wallpaper icon grid is rendered or
-	 * re-rendered. Payload: `{ ids: string[] }` — the ids in the
-	 * order they were painted. Plugins that decorate icons with
-	 * surfaces the framework doesn't natively expose (drag handles,
-	 * status dots) subscribe to this so their decorations survive a
-	 * live menu refresh that legitimately rebuilds the grid.
+	 * re-rendered. Payload:
+	 *
+	 *     {
+	 *         ids: string[];                          // paint order
+	 *         container: HTMLElement;                  // <div class="desktop-mode-icons">
+	 *         tiles: ReadonlyMap<string, HTMLElement>; // id → tile <button>
+	 *     }
+	 *
+	 * Plugins that decorate icons with surfaces the framework doesn't
+	 * natively expose (drag handles, status dots, cursor adornments)
+	 * subscribe here so their decorations survive a live menu refresh
+	 * that legitimately rebuilds the grid. The `container` and
+	 * `tiles` map mirror the {@link DOCK_AFTER_RENDER}
+	 * `tileElements` contract — reach into them directly instead of
+	 * re-`querySelector`ing the rendered DOM.
 	 *
 	 * Notification badges have a first-class API since 0.24.0 —
 	 * use `wp.desktop.icons.setBadge( id, count )` (and subscribe
@@ -598,12 +643,15 @@ export const HOOKS = {
 	 * a plugin that uses the API doesn't need to re-decorate on
 	 * every render.
 	 *
-	 * Idempotent payload (`{ ids: [] }`) when the icon list is
-	 * empty; suppressed entirely when the rendered DOM is
-	 * unchanged from the previous call (the fingerprint short-
-	 * circuit upstream skips both the rebuild and this signal).
+	 * Suppressed entirely when the rendered DOM is unchanged from
+	 * the previous call (the fingerprint short-circuit upstream
+	 * skips both the rebuild and this signal). When the icon list
+	 * is empty the hook does not fire at all — the previous
+	 * container is removed and no new one is appended.
 	 *
 	 * @since 0.21.0
+	 * @since 0.25.0 — `container` + `tiles` added to the payload
+	 *                  (`ids` retained for back-compat).
 	 */
 	DESKTOP_ICONS_RENDERED: 'desktop-mode.desktop-icons.rendered',
 	/**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -281,12 +281,22 @@ export const HOOKS = {
 	 *         => ResolvedWindowGeometry
 	 *
 	 * Where `ResolvedWindowGeometry = { x, y, width, height, state? }`
-	 * and `ctx = { windowId, baseId, source, desktopRect }`. `source`
-	 * is `'explicit'` when the caller passed at least one of
-	 * {x, y, width, height, initialState} (session restore,
-	 * `openNew` with explicit dims), `'restored'` when the values
-	 * came from the per-baseId `localStorage` geometry store, and
-	 * `'default'` for the cascade + desktopRect defaults.
+	 * and `ctx = { windowId, baseId, hasSavedGeometry, callerPinned,
+	 * desktopRect }`.
+	 *
+	 * - `hasSavedGeometry` is `true` when the user previously
+	 *   dragged or resized this window and the resolved geometry
+	 *   includes those restored values. Plugins that want to
+	 *   "leave the user's saved layout alone" should bail when
+	 *   this is true.
+	 * - `callerPinned` is `true` when the caller of `manager.open()`
+	 *   passed at least one of `{ x, y, width, height, initialState }`
+	 *   explicitly. For NATIVE windows this is usually true (the
+	 *   framework's native-window opener passes the registry's
+	 *   declared dimensions); for admin-page iframe windows opened
+	 *   from the dock this is usually false. The filter is free to
+	 *   override registry defaults — `callerPinned: true` does NOT
+	 *   mean "leave it alone."
 	 *
 	 * The shell re-clamps `width`/`height` to the registered
 	 * `minWidth`/`minHeight` after the filter returns — a buggy

--- a/src/widgets/layer.ts
+++ b/src/widgets/layer.ts
@@ -433,14 +433,21 @@ export class WidgetLayer {
 	 * Inverse of {@link liberate}: move a floating card back into
 	 * the column and drop its persisted geometry so a subsequent
 	 * shell boot brings it up docked. Called when the user clicks
-	 * the re-dock button in the card's chrome header.
+	 * the re-dock button in the card's chrome header, or
+	 * programmatically by companion plugins via
+	 * `wp.desktop.widgets.redock( id )` /
+	 * `wp.desktop.widgetLayer.redock( id )`.
 	 *
-	 * Idempotent — a docked widget silently no-ops. The `--floating`
-	 * class on the card is removed as part of the same write so CSS
-	 * rules that depend on it (re-dock button visibility, absolute
-	 * positioning) flip back in one paint.
+	 * Idempotent — a docked widget silently no-ops, an unknown id
+	 * silently no-ops. The `--floating` class on the card is
+	 * removed as part of the same write so CSS rules that depend
+	 * on it (re-dock button visibility, absolute positioning) flip
+	 * back in one paint.
+	 *
+	 * @since 0.7.0 (private)
+	 * @since 0.25.0 (public)
 	 */
-	private redock( id: string ): void {
+	public redock( id: string ): void {
 		const record = this.mounted.get( id );
 		if ( ! record || ! record.floating ) {
 			return;

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -73,17 +73,6 @@ const BASE_Z_INDEX = 100;
 const CASCADE_OFFSET = 30;
 
 /**
- * Where the resolved geometry handed to {@link HOOKS.WINDOW_GEOMETRY}
- * came from. Filter consumers branch on this to scope their override
- * to fresh opens (`'default'`) vs caller-pinned dimensions (`'explicit'`)
- * vs the saved per-baseId `localStorage` store (`'restored'`).
- *
- * @public
- * @since 0.25.0
- */
-export type WindowGeometrySource = 'explicit' | 'restored' | 'default';
-
-/**
  * Geometry resolved by `WindowManager.createWindow()` and passed
  * through {@link HOOKS.WINDOW_GEOMETRY}. Returned (possibly mutated)
  * by the filter and then re-clamped to `minWidth`/`minHeight` before
@@ -115,13 +104,29 @@ export interface ResolvedWindowGeometry {
  * carries the live desktop area dimensions so a filter can compute
  * "bottom-right corner" without touching the DOM.
  *
+ * The two booleans capture the only useful distinctions a filter
+ * actually cares about:
+ *
+ *   - `hasSavedGeometry`: the user previously dragged/resized this
+ *     window and we just restored that layout. Plugins that want to
+ *     "leave the user's layout alone" should bail when this is true.
+ *   - `callerPinned`: the caller of `manager.open()` passed at least
+ *     one of `{ x, y, width, height, initialState }` explicitly. For
+ *     native windows registered via `desktop_mode_register_window()`
+ *     this is usually `true` (the framework's native-window opener
+ *     passes the registry's declared dimensions); for admin-page
+ *     iframe windows opened from the dock this is usually `false`.
+ *     The filter is free to override registry-declared defaults —
+ *     `callerPinned: true` does not mean "leave it alone."
+ *
  * @public
  * @since 0.25.0
  */
 export interface WindowGeometryContext {
 	windowId: string;
 	baseId: string;
-	source: WindowGeometrySource;
+	hasSavedGeometry: boolean;
+	callerPinned: boolean;
 	desktopRect: {
 		width: number;
 		height: number;
@@ -621,59 +626,89 @@ export class WindowManager {
 		const resolvedX = config.x ?? clampedSavedX ?? cascadeX;
 		const resolvedY = config.y ?? clampedSavedY ?? cascadeY;
 
-		// Classify where the resolved geometry came from so the
-		// `WINDOW_GEOMETRY` filter consumer can branch — e.g. "only
-		// override defaults for *my* fresh window, leave restored
-		// bounds alone." Caller-explicit ANY axis dominates; otherwise
-		// a saved geometry record bumps us into `'restored'`; the
-		// remaining cases are the cascade + desktopRect defaults.
+		// `WINDOW_GEOMETRY` filter context — two booleans that capture
+		// the only useful distinctions a filter actually cares about:
+		// did we just restore a user-saved layout, and did the caller
+		// pin any of the dimensions explicitly. See the
+		// `WindowGeometryContext` jsdoc above for plugin-author
+		// guidance.
 		const callerPinned =
 			hasExplicitWidth ||
 			hasExplicitHeight ||
 			hasExplicitX ||
 			hasExplicitY ||
 			hasExplicitState;
-		let source: WindowGeometrySource;
-		if ( callerPinned ) {
-			source = 'explicit';
-		} else if ( saved ) {
-			source = 'restored';
-		} else {
-			source = 'default';
+		const hasSavedGeometry = !! saved;
+
+		const preFilterGeometry: ResolvedWindowGeometry = {
+			x: resolvedX,
+			y: resolvedY,
+			width: resolvedWidth,
+			height: resolvedHeight,
+			state: resolvedState,
+		};
+		let filtered: ResolvedWindowGeometry;
+		try {
+			filtered = applyFilters<
+				ResolvedWindowGeometry,
+				[ WindowGeometryContext ]
+			>(
+				HOOKS.WINDOW_GEOMETRY,
+				preFilterGeometry,
+				{
+					windowId: config.id,
+					baseId: resolvedBaseId,
+					hasSavedGeometry,
+					callerPinned,
+					desktopRect: {
+						width: desktopRect.width,
+						height: desktopRect.height,
+					},
+				},
+			);
+		} catch ( err ) {
+			// A throwing filter must NOT bring down the window open.
+			// Fall back to the pre-filter geometry and surface the
+			// error on the shell-error channel so plugin authors find
+			// it in devtools.
+			doAction( HOOKS.SHELL_ERROR, {
+				scope: 'window-geometry-filter',
+				windowId: config.id,
+				error: err,
+			} );
+			if ( typeof console !== 'undefined' ) {
+				console.error(
+					`[desktop-mode] WINDOW_GEOMETRY filter threw for "${ config.id }":`,
+					err,
+				);
+			}
+			filtered = preFilterGeometry;
 		}
 
-		const filtered = applyFilters<
-			ResolvedWindowGeometry,
-			[ WindowGeometryContext ]
-		>(
-			HOOKS.WINDOW_GEOMETRY,
-			{
-				x: resolvedX,
-				y: resolvedY,
-				width: resolvedWidth,
-				height: resolvedHeight,
-				state: resolvedState,
-			},
-			{
-				windowId: config.id,
-				baseId: resolvedBaseId,
-				source,
-				desktopRect: {
-					width: desktopRect.width,
-					height: desktopRect.height,
-				},
-			},
+		// Defensive coalesce — a careless filter can return a partial
+		// object, a non-finite number, or even something that isn't a
+		// geometry shape at all. Treat any field that isn't a finite
+		// number as "leave the resolved value alone." Re-clamp width
+		// and height to the registered minima — a buggy filter cannot
+		// ship a sub-minimum window. Position is NOT re-clamped:
+		// plugins sometimes deliberately place windows partially
+		// off-screen for stylistic reasons.
+		const coalesce = ( v: unknown, fallback: number ): number =>
+			typeof v === 'number' && Number.isFinite( v ) ? v : fallback;
+		const safeFiltered: ResolvedWindowGeometry =
+			filtered && typeof filtered === 'object' ? filtered : preFilterGeometry;
+		const finalWidth = Math.max(
+			coalesce( safeFiltered.width, resolvedWidth ),
+			minWidth,
 		);
-
-		// Re-clamp dimensions to the registered minima — a buggy
-		// filter cannot ship a sub-minimum window. Position is NOT
-		// re-clamped: plugins sometimes deliberately place windows
-		// partially off-screen for stylistic reasons.
-		const finalWidth = Math.max( filtered.width, minWidth );
-		const finalHeight = Math.max( filtered.height, minHeight );
-		const finalX = filtered.x;
-		const finalY = filtered.y;
-		const finalState = filtered.state;
+		const finalHeight = Math.max(
+			coalesce( safeFiltered.height, resolvedHeight ),
+			minHeight,
+		);
+		const finalX = coalesce( safeFiltered.x, resolvedX );
+		const finalY = coalesce( safeFiltered.y, resolvedY );
+		const finalState: WindowState | undefined =
+			safeFiltered.state ?? resolvedState;
 
 		const fullConfig: WindowConfig = {
 			icon: config.icon || 'dashicons-admin-generic',

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -29,6 +29,7 @@ import type {
 	SessionWindow,
 	VisibleWindowRect,
 	WindowConfig,
+	WindowState,
 } from '../types';
 import type { Window } from '../window';
 import {
@@ -70,6 +71,62 @@ const BASE_Z_INDEX = 100;
 
 /** Cascade offset for new windows (pixels). */
 const CASCADE_OFFSET = 30;
+
+/**
+ * Where the resolved geometry handed to {@link HOOKS.WINDOW_GEOMETRY}
+ * came from. Filter consumers branch on this to scope their override
+ * to fresh opens (`'default'`) vs caller-pinned dimensions (`'explicit'`)
+ * vs the saved per-baseId `localStorage` store (`'restored'`).
+ *
+ * @public
+ * @since 0.25.0
+ */
+export type WindowGeometrySource = 'explicit' | 'restored' | 'default';
+
+/**
+ * Geometry resolved by `WindowManager.createWindow()` and passed
+ * through {@link HOOKS.WINDOW_GEOMETRY}. Returned (possibly mutated)
+ * by the filter and then re-clamped to `minWidth`/`minHeight` before
+ * being baked into the `WindowConfig`.
+ *
+ * @public
+ * @since 0.25.0
+ */
+export interface ResolvedWindowGeometry {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	/**
+	 * Initial window state. Typically `undefined` (a normal floating
+	 * window) or `'maximized'` (when the saved geometry or caller
+	 * asked for it). A filter may return any {@link WindowState}
+	 * value to force a particular start state — e.g.
+	 * `'snapped-left'` for a side-companion plugin.
+	 */
+	state?: WindowState;
+}
+
+/**
+ * Context object the {@link HOOKS.WINDOW_GEOMETRY} filter receives
+ * alongside the resolved geometry. `windowId` is the unique
+ * per-instance id; `baseId` is the registry id (multiple windows
+ * sharing one baseId in the multi-window case). `desktopRect`
+ * carries the live desktop area dimensions so a filter can compute
+ * "bottom-right corner" without touching the DOM.
+ *
+ * @public
+ * @since 0.25.0
+ */
+export interface WindowGeometryContext {
+	windowId: string;
+	baseId: string;
+	source: WindowGeometrySource;
+	desktopRect: {
+		width: number;
+		height: number;
+	};
+}
 
 /**
  * Window Manager class.
@@ -564,6 +621,60 @@ export class WindowManager {
 		const resolvedX = config.x ?? clampedSavedX ?? cascadeX;
 		const resolvedY = config.y ?? clampedSavedY ?? cascadeY;
 
+		// Classify where the resolved geometry came from so the
+		// `WINDOW_GEOMETRY` filter consumer can branch — e.g. "only
+		// override defaults for *my* fresh window, leave restored
+		// bounds alone." Caller-explicit ANY axis dominates; otherwise
+		// a saved geometry record bumps us into `'restored'`; the
+		// remaining cases are the cascade + desktopRect defaults.
+		const callerPinned =
+			hasExplicitWidth ||
+			hasExplicitHeight ||
+			hasExplicitX ||
+			hasExplicitY ||
+			hasExplicitState;
+		let source: WindowGeometrySource;
+		if ( callerPinned ) {
+			source = 'explicit';
+		} else if ( saved ) {
+			source = 'restored';
+		} else {
+			source = 'default';
+		}
+
+		const filtered = applyFilters<
+			ResolvedWindowGeometry,
+			[ WindowGeometryContext ]
+		>(
+			HOOKS.WINDOW_GEOMETRY,
+			{
+				x: resolvedX,
+				y: resolvedY,
+				width: resolvedWidth,
+				height: resolvedHeight,
+				state: resolvedState,
+			},
+			{
+				windowId: config.id,
+				baseId: resolvedBaseId,
+				source,
+				desktopRect: {
+					width: desktopRect.width,
+					height: desktopRect.height,
+				},
+			},
+		);
+
+		// Re-clamp dimensions to the registered minima — a buggy
+		// filter cannot ship a sub-minimum window. Position is NOT
+		// re-clamped: plugins sometimes deliberately place windows
+		// partially off-screen for stylistic reasons.
+		const finalWidth = Math.max( filtered.width, minWidth );
+		const finalHeight = Math.max( filtered.height, minHeight );
+		const finalX = filtered.x;
+		const finalY = filtered.y;
+		const finalState = filtered.state;
+
 		const fullConfig: WindowConfig = {
 			icon: config.icon || 'dashicons-admin-generic',
 			...config,
@@ -572,13 +683,13 @@ export class WindowManager {
 			// dimensions + state we resolved above. The pin has to
 			// follow the spread because an explicit `width: undefined`
 			// from the caller would otherwise blow away the default.
-			x: resolvedX,
-			y: resolvedY,
-			width: resolvedWidth,
-			height: resolvedHeight,
+			x: finalX,
+			y: finalY,
+			width: finalWidth,
+			height: finalHeight,
 			minWidth,
 			minHeight,
-			...( resolvedState ? { initialState: resolvedState } : {} ),
+			...( finalState ? { initialState: finalState } : {} ),
 			baseId: resolvedBaseId,
 			// New windows always join the active desktop. A caller can
 			// pre-seed `desktopId` (e.g. session restore) by passing it

--- a/tests/vitest/desktop-icons-render.test.ts
+++ b/tests/vitest/desktop-icons-render.test.ts
@@ -17,7 +17,12 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { renderDesktopIcons } from '../../src/desktop-icons';
-import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { HOOKS } from '../../src/hooks';
+import {
+	clearHooksStub,
+	installHooksStub,
+	recordActions,
+} from './helpers/hooks-stub';
 
 const SVG_DATA_URI =
 	'data:image/svg+xml;base64,' +
@@ -112,6 +117,40 @@ describe( 'desktop-icons render — data URI handling', () => {
 		expect( iconEl ).not.toBeNull();
 		expect( iconEl!.classList.contains( 'dashicons' ) ).toBe( true );
 		expect( iconEl!.classList.contains( 'dashicons-star-filled' ) ).toBe( true );
+	} );
+
+	test( 'DESKTOP_ICONS_RENDERED payload carries ids + container + tiles map', () => {
+		const hooks = installHooksStub();
+		// `installHooksStub` is idempotent in beforeEach but tests may
+		// re-grab a reference; the second install is a no-op here since
+		// beforeEach already did one. Record into the live stub.
+		const log = recordActions( hooks, [ HOOKS.DESKTOP_ICONS_RENDERED ] );
+		renderDesktopIcons(
+			host,
+			[
+				{ id: 'a', title: 'A', icon: 'dashicons-admin-home', window: 'jorvy', url: '', position: 0, pinned: false },
+				{ id: 'b', title: 'B', icon: 'dashicons-admin-home', window: 'jorvy', url: '', position: 1, pinned: false },
+			],
+			{ openWindow: () => true },
+		);
+
+		// One emit, one payload — and shape is the new
+		// `{ ids, container, tiles }` form.
+		const fires = log.filter( ( e ) => e.name === HOOKS.DESKTOP_ICONS_RENDERED );
+		expect( fires ).toHaveLength( 1 );
+		const payload = fires[ 0 ].args[ 0 ] as {
+			ids: string[];
+			container: HTMLElement;
+			tiles: ReadonlyMap< string, HTMLElement >;
+		};
+		expect( payload.ids ).toEqual( [ 'a', 'b' ] );
+		expect( payload.container ).toBeInstanceOf( HTMLElement );
+		expect( payload.container.classList.contains( 'desktop-mode-icons' ) ).toBe( true );
+		expect( payload.tiles.size ).toBe( 2 );
+		expect( payload.tiles.get( 'a' )?.getAttribute( 'data-icon-id' ) ).toBe( 'a' );
+		expect( payload.tiles.get( 'b' )?.getAttribute( 'data-icon-id' ) ).toBe( 'b' );
+		// Tiles in the map are the same nodes the DOM has, not clones.
+		expect( payload.container.contains( payload.tiles.get( 'a' )! ) ).toBe( true );
 	} );
 
 	test( 'unrecognised icon strings fall back to a letter badge instead of a broken Dashicons glue', () => {

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -621,4 +621,57 @@ describe( 'widgets/layer', () => {
 			log.some( ( e ) => e.name === 'desktop-mode.widget.mounted' ),
 		).toBe( false );
 	} );
+
+	test( 'public redock() un-floats a card, clears geometry, and reparents into the column', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'roam',
+			label: 'Roamer',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem( 'desktop-mode-widgets', '["roam"]' );
+		window.localStorage.setItem(
+			'desktop-mode-widgets-geometry',
+			JSON.stringify( { roam: { x: 50, y: 60, width: 220, height: 110 } } ),
+		);
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+		const card = host.parentElement!.querySelector< HTMLElement >(
+			'.desktop-mode-widgets__card',
+		);
+		expect( card ).toBeTruthy();
+		expect(
+			card!.classList.contains( 'desktop-mode-widgets__card--floating' ),
+		).toBe( true );
+
+		layer.redock( 'roam' );
+
+		expect(
+			card!.classList.contains( 'desktop-mode-widgets__card--floating' ),
+		).toBe( false );
+		expect( card!.style.left ).toBe( '' );
+		expect( card!.style.top ).toBe( '' );
+		expect( card!.style.width ).toBe( '' );
+		expect( card!.style.height ).toBe( '' );
+		const geom = JSON.parse(
+			window.localStorage.getItem( 'desktop-mode-widgets-geometry' ) || '{}',
+		);
+		expect( geom.roam ).toBeUndefined();
+		// Re-parented under the column list, not the floating host.
+		expect(
+			host.querySelector( '.desktop-mode-widgets__list .desktop-mode-widgets__card' ),
+		).toBe( card );
+
+		// Idempotent — docked widget no-ops.
+		expect( () => layer.redock( 'roam' ) ).not.toThrow();
+		// Unknown id is silently ignored.
+		expect( () => layer.redock( 'never-registered' ) ).not.toThrow();
+
+		layer.disposeAll();
+	} );
 } );

--- a/tests/vitest/window-manager-hooks.test.ts
+++ b/tests/vitest/window-manager-hooks.test.ts
@@ -250,12 +250,14 @@ describe( 'WindowManager — hook firing', async () => {
 		const ctx = seen[ 0 ].ctx as {
 			windowId: string;
 			baseId: string;
-			source: string;
+			hasSavedGeometry: boolean;
+			callerPinned: boolean;
 			desktopRect: { width: number; height: number };
 		};
 		expect( ctx.windowId ).toBe( 'shop' );
 		expect( ctx.baseId ).toBe( 'shop' );
-		expect( ctx.source ).toBe( 'default' );
+		expect( ctx.hasSavedGeometry ).toBe( false );
+		expect( ctx.callerPinned ).toBe( false );
 		expect( ctx.desktopRect.width ).toBe( 1600 );
 		expect( ctx.desktopRect.height ).toBe( 900 );
 
@@ -267,13 +269,13 @@ describe( 'WindowManager — hook firing', async () => {
 		expect( win!.config.y ).toBe( 900 - NEW_H - 20 );
 	} );
 
-	test( 'WINDOW_GEOMETRY filter source is "explicit" when caller pins dimensions', async () => {
-		let observedSource: string | null = null;
+	test( 'WINDOW_GEOMETRY ctx.callerPinned is true when caller passes width/height', async () => {
+		let observed: { callerPinned: boolean; hasSavedGeometry: boolean } | null = null;
 		hooks.addFilter(
 			HOOKS.WINDOW_GEOMETRY,
-			'vitest/geometry-source',
+			'vitest/geometry-pinned',
 			( ( geometry: unknown, ctx: unknown ) => {
-				observedSource = ( ctx as { source: string } ).source;
+				observed = ctx as { callerPinned: boolean; hasSavedGeometry: boolean };
 				return geometry;
 			} ) as ( ...a: unknown[] ) => unknown,
 		);
@@ -284,10 +286,53 @@ describe( 'WindowManager — hook firing', async () => {
 			height: 333,
 		} );
 
-		expect( observedSource ).toBe( 'explicit' );
+		expect( observed!.callerPinned ).toBe( true );
+		expect( observed!.hasSavedGeometry ).toBe( false );
 		const win = manager.getById( 'pinned' );
 		expect( win!.config.width ).toBe( 555 );
 		expect( win!.config.height ).toBe( 333 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter can override the registry-pinned dimensions of a native-style open', async () => {
+		// Native windows open with explicit width/height from the
+		// registry. The filter MUST still be able to override them —
+		// `callerPinned: true` does not mean "leave it alone." This
+		// pins the regression: the source enum used to bucket this as
+		// `'explicit'` and the common "only on fresh opens" guard
+		// skipped it.
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/native-override',
+			( ( geometry: unknown, ctx: unknown ) => {
+				const g = geometry as { width: number; height: number; x: number; y: number };
+				const c = ctx as { hasSavedGeometry: boolean; desktopRect: { width: number; height: number } };
+				if ( c.hasSavedGeometry ) {
+					return g;
+				}
+				return {
+					...g,
+					width: 600,
+					height: 400,
+					x: c.desktopRect.width - 600 - 20,
+					y: c.desktopRect.height - 400 - 20,
+				};
+			} ) as ( ...a: unknown[] ) => unknown,
+		);
+
+		// Mimic the native-window opener: pass explicit width/height
+		// from the "registry" defaults.
+		await manager.open( {
+			...openConfig( 'native-shop' ),
+			width: 1000,    // registry default — filter should override
+			height: 700,
+			native: true,
+		} );
+
+		const win = manager.getById( 'native-shop' );
+		expect( win!.config.width ).toBe( 600 );
+		expect( win!.config.height ).toBe( 400 );
+		expect( win!.config.x ).toBe( 1600 - 600 - 20 );
+		expect( win!.config.y ).toBe( 900 - 400 - 20 );
 	} );
 
 	test( 'WINDOW_GEOMETRY filter return values are re-clamped to minWidth/minHeight', async () => {
@@ -308,5 +353,190 @@ describe( 'WindowManager — hook firing', async () => {
 		// `?? 200` fallbacks — a buggy filter cannot bypass them.
 		expect( win!.config.width ).toBe( 320 );
 		expect( win!.config.height ).toBe( 200 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter — partial return drops back to pre-filter values', async () => {
+		// A careless filter returns only the dimensions it cared about
+		// — the missing fields must NOT come through as NaN / undefined.
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-partial',
+			( ( () => ( { width: 800 } ) ) as ( ...a: unknown[] ) => unknown ),
+		);
+
+		await manager.open( openConfig( 'partial' ) );
+
+		const win = manager.getById( 'partial' );
+		expect( win!.config.width ).toBe( 800 ); // honored
+		// Default fallthrough: cascade x/y + 80% desktopRect for h.
+		expect( Number.isFinite( win!.config.x ) ).toBe( true );
+		expect( Number.isFinite( win!.config.y ) ).toBe( true );
+		expect( Number.isFinite( win!.config.height ) ).toBe( true );
+		expect( win!.config.height ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter — NaN / Infinity values fall through to pre-filter values', async () => {
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-garbage',
+			( ( () => ( {
+				x:      Number.NaN,
+				y:      Number.POSITIVE_INFINITY,
+				width:  Number.NEGATIVE_INFINITY,
+				height: Number.NaN,
+			} ) ) as ( ...a: unknown[] ) => unknown ),
+		);
+
+		await manager.open( openConfig( 'garbage' ) );
+
+		const win = manager.getById( 'garbage' );
+		expect( Number.isFinite( win!.config.x ) ).toBe( true );
+		expect( Number.isFinite( win!.config.y ) ).toBe( true );
+		expect( win!.config.width ).toBeGreaterThanOrEqual( 320 );
+		expect( win!.config.height ).toBeGreaterThanOrEqual( 200 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter — throwing filter does not bring down open()', async () => {
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-throw',
+			( ( () => {
+				throw new Error( 'plugin author bug' );
+			} ) ) as ( ...a: unknown[] ) => unknown,
+		);
+		const errors: unknown[] = [];
+		hooks.addAction(
+			'desktop-mode.shell.error',
+			'vitest/shell-error',
+			( ...args: unknown[] ) => {
+				errors.push( args[ 0 ] );
+			},
+		);
+		// Silence the console.error our handler emits.
+		const origErr = console.error;
+		console.error = () => undefined;
+
+		try {
+			await manager.open( openConfig( 'crasher' ) );
+		} finally {
+			console.error = origErr;
+		}
+
+		const win = manager.getById( 'crasher' );
+		expect( win ).toBeDefined();
+		// Pre-filter resolved geometry survives unscathed.
+		expect( Number.isFinite( win!.config.x ) ).toBe( true );
+		expect( win!.config.width ).toBeGreaterThanOrEqual( 320 );
+		const reported = errors.find(
+			( e ): e is { scope: string } =>
+				typeof e === 'object' && e !== null &&
+				( e as { scope?: string } ).scope === 'window-geometry-filter',
+		);
+		expect( reported ).toBeDefined();
+	} );
+
+	test( 'WINDOW_GEOMETRY filter — non-object return falls through to pre-filter geometry', async () => {
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-nonsense',
+			// Plugin author returns garbage (e.g. forgot `return` and got
+			// undefined back).
+			( ( () => undefined ) as ( ...a: unknown[] ) => unknown ),
+		);
+
+		await manager.open( openConfig( 'nonsense' ) );
+
+		const win = manager.getById( 'nonsense' );
+		expect( win ).toBeDefined();
+		expect( win!.config.width ).toBeGreaterThanOrEqual( 320 );
+		expect( win!.config.height ).toBeGreaterThanOrEqual( 200 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter fires for native windows too', async () => {
+		let observedWindowId: string | null = null;
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-native',
+			( ( geometry: unknown, ctx: unknown ) => {
+				observedWindowId = ( ctx as { windowId: string } ).windowId;
+				return geometry;
+			} ) as ( ...a: unknown[] ) => unknown,
+		);
+
+		// Native windows ride the same `manager.open()` path with
+		// `native: true` set on the config.
+		await manager.open( {
+			...openConfig( 'jorvy' ),
+			native: true,
+		} );
+
+		expect( observedWindowId ).toBe( 'jorvy' );
+	} );
+
+	test( 'WINDOW_GEOMETRY ctx.hasSavedGeometry is true when localStorage has saved geometry', async () => {
+		// Pre-seed the per-baseId geometry store the same way the
+		// native-window persistence listener does — see
+		// `src/window-manager/native-window-geometry.ts`.
+		const STORAGE_KEY = 'desktop-mode-native-window-geometry';
+		const saved = JSON.stringify( {
+			'restoreme': { x: 100, y: 100, width: 700, height: 500, state: 'normal' },
+		} );
+		try {
+			window.localStorage.setItem( STORAGE_KEY, saved );
+		} catch {
+			/* jsdom */
+		}
+
+		const seen: Array< { hasSavedGeometry: boolean; callerPinned: boolean } > = [];
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-saved',
+			( ( geometry: unknown, ctx: unknown ) => {
+				seen.push( ctx as { hasSavedGeometry: boolean; callerPinned: boolean } );
+				return geometry;
+			} ) as ( ...a: unknown[] ) => unknown,
+		);
+
+		await manager.open( openConfig( 'restoreme' ) );
+
+		try {
+			window.localStorage.removeItem( STORAGE_KEY );
+		} catch {
+			/* jsdom */
+		}
+
+		expect( seen ).toHaveLength( 1 );
+		expect( seen[ 0 ].hasSavedGeometry ).toBe( true );
+		expect( seen[ 0 ].callerPinned ).toBe( false );
+		const win = manager.getById( 'restoreme' );
+		expect( win!.config.width ).toBe( 700 );
+		expect( win!.config.height ).toBe( 500 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter — multiple subscribers chain in priority order', async () => {
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-first',
+			( ( geometry: unknown ) => ( {
+				...( geometry as Record< string, unknown > ),
+				width: 500,
+			} ) ) as ( ...a: unknown[] ) => unknown,
+			5, // earlier priority
+		);
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-second',
+			( ( geometry: unknown ) => {
+				const g = geometry as { width: number };
+				// Sees the upstream filter's value, doubles it.
+				return { ...g, width: g.width * 2 };
+			} ) as ( ...a: unknown[] ) => unknown,
+			10,
+		);
+
+		await manager.open( openConfig( 'chain' ) );
+
+		const win = manager.getById( 'chain' );
+		expect( win!.config.width ).toBe( 1000 );
 	} );
 } );

--- a/tests/vitest/window-manager-hooks.test.ts
+++ b/tests/vitest/window-manager-hooks.test.ts
@@ -12,6 +12,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
+import { HOOKS } from '../../src/hooks';
 import {
 	clearHooksStub,
 	installHooksStub,
@@ -219,5 +220,93 @@ describe( 'WindowManager — hook firing', async () => {
 			e.name.startsWith( 'desktop-mode.arrange.cascade.' ),
 		);
 		expect( cascadeEvents ).toHaveLength( 0 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter sees default-resolved geometry and can override it', async () => {
+		const seen: Array< { geometry: unknown; ctx: unknown } > = [];
+		const NEW_W = 480;
+		const NEW_H = 320;
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry',
+			( ( geometry: unknown, ctx: unknown ) => {
+				seen.push( { geometry, ctx } );
+				const g = geometry as { x: number; y: number; width: number; height: number };
+				// Force the bottom-right corner with a clearly-above-min frame.
+				const desktop = ( ctx as { desktopRect: { width: number; height: number } } ).desktopRect;
+				return {
+					...g,
+					width: NEW_W,
+					height: NEW_H,
+					x: desktop.width - NEW_W - 20,
+					y: desktop.height - NEW_H - 20,
+				};
+			} ) as ( ...a: unknown[] ) => unknown,
+		);
+
+		await manager.open( openConfig( 'shop' ) );
+
+		expect( seen ).toHaveLength( 1 );
+		const ctx = seen[ 0 ].ctx as {
+			windowId: string;
+			baseId: string;
+			source: string;
+			desktopRect: { width: number; height: number };
+		};
+		expect( ctx.windowId ).toBe( 'shop' );
+		expect( ctx.baseId ).toBe( 'shop' );
+		expect( ctx.source ).toBe( 'default' );
+		expect( ctx.desktopRect.width ).toBe( 1600 );
+		expect( ctx.desktopRect.height ).toBe( 900 );
+
+		const win = manager.getById( 'shop' );
+		expect( win ).toBeDefined();
+		expect( win!.config.width ).toBe( NEW_W );
+		expect( win!.config.height ).toBe( NEW_H );
+		expect( win!.config.x ).toBe( 1600 - NEW_W - 20 );
+		expect( win!.config.y ).toBe( 900 - NEW_H - 20 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter source is "explicit" when caller pins dimensions', async () => {
+		let observedSource: string | null = null;
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-source',
+			( ( geometry: unknown, ctx: unknown ) => {
+				observedSource = ( ctx as { source: string } ).source;
+				return geometry;
+			} ) as ( ...a: unknown[] ) => unknown,
+		);
+
+		await manager.open( {
+			...openConfig( 'pinned' ),
+			width: 555,
+			height: 333,
+		} );
+
+		expect( observedSource ).toBe( 'explicit' );
+		const win = manager.getById( 'pinned' );
+		expect( win!.config.width ).toBe( 555 );
+		expect( win!.config.height ).toBe( 333 );
+	} );
+
+	test( 'WINDOW_GEOMETRY filter return values are re-clamped to minWidth/minHeight', async () => {
+		hooks.addFilter(
+			HOOKS.WINDOW_GEOMETRY,
+			'vitest/geometry-too-small',
+			( ( geometry: unknown ) => ( {
+				...( geometry as Record< string, unknown > ),
+				width:  50,
+				height: 50,
+			} ) ) as ( ...a: unknown[] ) => unknown,
+		);
+
+		await manager.open( openConfig( 'tinybox' ) );
+
+		const win = manager.getById( 'tinybox' );
+		// Default minWidth/minHeight come from createWindow's `?? 320` /
+		// `?? 200` fallbacks — a buggy filter cannot bypass them.
+		expect( win!.config.width ).toBe( 320 );
+		expect( win!.config.height ).toBe( 200 );
 	} );
 } );


### PR DESCRIPTION
Four small, additive APIs requested by the ODD plugin author. Each one removes a workaround that third-party code was carrying.

## What changed

- **`wp.desktop.widgets.redock( id )`** — stable namespace; `WidgetLayer.redock()` promoted from private, so `wp.desktop.widgetLayer.redock( id )` also works. Idempotent + null-safe.
- **`HOOKS.DESKTOP_ICONS_RENDERED` payload** now ships `{ ids, container, tiles }`. `tiles` is a frozen `id → tile <button>` map, mirroring `DOCK_AFTER_RENDER.tileElements`. `ids` retained for back-compat — existing subscribers keep working.
- **`HOOKS.WINDOW_GEOMETRY`** *(new filter)* — last call before `WindowConfig` is baked. Signature: `( geometry, ctx ) => geometry`, with `ctx = { windowId, baseId, hasSavedGeometry, callerPinned, desktopRect }`. The booleans are the only useful distinctions a filter actually needs: `hasSavedGeometry` flags a restored user layout (bail to respect their choice); `callerPinned` flags caller-passed dims (usually `true` for native windows because their registry passes default `width`/`height`; the filter is free to override). Lets plugins place / size their own windows declaratively instead of compensating after `open()` lands. Filter return is re-clamped to `minWidth`/`minHeight`.
- No new universal "surface rendered" hook — wallpaper, widget, and dock already pass containers; icons were the only gap and the payload change above closes it. Will revisit if a cross-cutting need crystallizes.

## Files

- `src/widgets/layer.ts` — `private redock()` → `public redock()`.
- `src/api/facade.ts`, `src/desktop.ts` — add `wp.desktop.widgets` namespace + reserved key.
- `src/desktop-icons.ts` — build a `tiles` map during render; include `container` + `tiles` in the payload.
- `src/hooks.ts` — new `WINDOW_GEOMETRY` constant; updated `DESKTOP_ICONS_RENDERED` JSDoc.
- `src/window-manager/index.ts` — `applyFilters( HOOKS.WINDOW_GEOMETRY, … )` after geometry resolution; exports `ResolvedWindowGeometry`, `WindowGeometryContext`.

## Docs

- `docs/javascript-reference.md` — `wp.desktop.widgets.redock` section, `WINDOW_GEOMETRY` row in the window-hook table + a full recipe section.
- `docs/examples/register-icon.md` — decorator recipe using `tiles` from the icons payload.

## Test plan

- [x] `./node_modules/.bin/tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run test:js` — 1327/1327 (11 new tests across `widgets.test.ts`, `desktop-icons-render.test.ts`, `window-manager-hooks.test.ts`).
- [x] `npm run build` — all 17 bundles compile; `WINDOW_GEOMETRY` constant, `applyFilters` call site, `hasSavedGeometry` + `callerPinned` fields all confirmed in `assets/js/desktop.min.js`.
- [ ] Manual: open Heartbeat widget, liberate it, call `wp.desktop.widgets.redock( 'desktop-mode/heartbeat' )` from console — card snaps back into the column. (Note the namespaced id — the redock is idempotent + silent on unknown ids, so a bare `'heartbeat'` no-ops without error.)
- [ ] Manual *(optional — filter is exhaustively unit-tested)*: drop the following snippet into the browser console BEFORE opening Posts (or after closing it first), then click Posts in the dock. It should land in the bottom-right corner. Drag it somewhere else, close, reopen — it stays where YOU put it (filter bails on `hasSavedGeometry: true`).

  ```js
  wp.desktop.hooks.addFilter(
      wp.desktop.HOOKS.WINDOW_GEOMETRY,
      'manual-qa/bottom-right',
      ( g, ctx ) => {
          // Bail if the user has previously dragged/resized — respect their layout.
          if ( ctx.hasSavedGeometry ) return g;
          const W = 520, H = 360;
          return {
              ...g,
              width: W, height: H,
              x: ctx.desktopRect.width  - W - 20,
              y: ctx.desktopRect.height - H - 20,
          };
      }
  );
  ```

  Want to scope to a single window (e.g. just Posts)? Add an early bail:

  ```js
  if ( ctx.baseId !== 'desktop-mode-posts' ) return g;
  ```

### Defensive coverage for `WINDOW_GEOMETRY`

The filter is wrapped in try/catch + a defensive coalesce so a buggy plugin can't break window opens. Tests pin:

- Default-resolved geometry → can be fully overridden.
- Caller-pinned geometry (`callerPinned: true`) → filter still runs and can override (regression test for the native-window case).
- `hasSavedGeometry: true` set when localStorage has a saved geometry for the window — plugins use this to respect the user's saved layout.
- Filter return below `minWidth`/`minHeight` → re-clamped.
- Partial return (e.g. `{ width }` only) → missing fields fall through to pre-filter values.
- `NaN` / `Infinity` returns → falls through.
- Throwing filter → window still opens, error reported on `HOOKS.SHELL_ERROR`.
- Non-object / `undefined` return → falls through.
- Native windows → filter fires identically.
- Multiple subscribers → chain in priority order.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-229-5ddbf9259a46e46a2b94edc372e501068802c798.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->