### PR TITLE
Add Media section to "My WordPress" + uniform preview-pane hook surface

### DIFF
--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -1538,3 +1538,235 @@ a.desktop-mode-my-wordpress__footprint-event-title:hover {
 	box-shadow: none;
 	padding: 0;
 }
+
+/* ============================================================ *
+ *  Media section (since 0.21.0)
+ * ============================================================ */
+
+.desktop-mode-my-wordpress__media-grid {
+	display: grid;
+	grid-template-columns: repeat( auto-fill, minmax( 120px, 1fr ) );
+	gap: 12px;
+	padding: 16px;
+	overflow-y: auto;
+	align-content: start;
+}
+
+.desktop-mode-my-wordpress__media-tile {
+	/* Override the base `.desktop-mode-file-tile` (position: absolute,
+	 * width: 88px) so media tiles flow inside the CSS Grid instead of
+	 * stacking at (0,0) like the absolute-positioned post/user tiles. */
+	position: static;
+	width: auto;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 6px;
+	padding: 8px;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	cursor: pointer;
+	text-align: center;
+	min-width: 0;
+}
+
+.desktop-mode-my-wordpress__media-tile:hover {
+	background: var( --desktop-mode-hover, rgba( 0, 0, 0, 0.04 ) );
+}
+
+.desktop-mode-my-wordpress__media-tile.desktop-mode-my-wordpress__tile--selected {
+	border-color: var( --desktop-mode-accent, #2271b1 );
+	background: var( --desktop-mode-accent-soft, rgba( 34, 113, 177, 0.08 ) );
+}
+
+.desktop-mode-my-wordpress__media-tile-thumb {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	overflow: hidden;
+	border-radius: 6px;
+	background: var( --desktop-mode-media-tile-bg, rgba( 0, 0, 0, 0.05 ) );
+}
+
+.desktop-mode-my-wordpress__media-tile-thumb img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.desktop-mode-my-wordpress__media-tile-thumb .dashicons {
+	font-size: 36px;
+	width: 36px;
+	height: 36px;
+	color: var( --desktop-mode-muted, #787c82 );
+}
+
+.desktop-mode-my-wordpress__media-tile .desktop-mode-file-tile__label {
+	font-size: 12px;
+	line-height: 1.3;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+}
+
+/* ----- Media preview pane ----- */
+
+.desktop-mode-my-wordpress__media-pane {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 16px;
+}
+
+.desktop-mode-my-wordpress__media-title {
+	font-size: 16px;
+	font-weight: 600;
+	margin: 0;
+}
+
+.desktop-mode-my-wordpress__media-visual {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var( --desktop-mode-media-visual-bg, rgba( 0, 0, 0, 0.04 ) );
+	border-radius: 8px;
+	min-height: 200px;
+	max-height: 480px;
+	overflow: hidden;
+}
+
+.desktop-mode-my-wordpress__media-image,
+.desktop-mode-my-wordpress__media-video {
+	max-width: 100%;
+	max-height: 480px;
+	object-fit: contain;
+}
+
+.desktop-mode-my-wordpress__media-fallback-icon {
+	font-size: 96px;
+	width: 96px;
+	height: 96px;
+	color: var( --desktop-mode-muted, #787c82 );
+}
+
+.desktop-mode-my-wordpress__media-doc-link {
+	margin-inline-start: 16px;
+	align-self: center;
+}
+
+.desktop-mode-my-wordpress__media-audio-stack {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+	padding: 24px;
+}
+
+.desktop-mode-my-wordpress__media-meta {
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	gap: 4px 16px;
+	font-size: 13px;
+}
+
+.desktop-mode-my-wordpress__media-meta-row {
+	display: contents;
+}
+
+.desktop-mode-my-wordpress__media-meta-term {
+	color: var( --desktop-mode-muted, #787c82 );
+}
+
+.desktop-mode-my-wordpress__media-meta-value {
+	color: var( --desktop-mode-text, #1d2327 );
+	word-break: break-word;
+}
+
+.desktop-mode-my-wordpress__media-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	padding-top: 8px;
+	border-top: 1px solid var( --desktop-mode-border, #dcdcde );
+}
+
+/* ----- Media drill-in ----- */
+
+.desktop-mode-my-wordpress__usage-list {
+	padding: 16px;
+}
+
+.desktop-mode-my-wordpress__usage-rows {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.desktop-mode-my-wordpress__usage-row {
+	position: static;
+	width: auto;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 8px 12px;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 6px;
+	cursor: pointer;
+	text-align: start;
+}
+
+.desktop-mode-my-wordpress__usage-row:hover {
+	background: var( --desktop-mode-hover, rgba( 0, 0, 0, 0.04 ) );
+}
+
+.desktop-mode-my-wordpress__usage-text {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.desktop-mode-my-wordpress__usage-title {
+	font-weight: 500;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.desktop-mode-my-wordpress__usage-meta {
+	font-size: 12px;
+	color: var( --desktop-mode-muted, #787c82 );
+}
+
+.desktop-mode-my-wordpress__media-detail-header {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 16px;
+	border-bottom: 1px solid var( --desktop-mode-border, #dcdcde );
+}
+
+.desktop-mode-my-wordpress__media-source-tile {
+	position: static;
+	width: auto;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.desktop-mode-my-wordpress__media-source-tile .desktop-mode-my-wordpress__media-tile-thumb {
+	width: 56px;
+	height: 56px;
+	aspect-ratio: 1 / 1;
+}
+
+.desktop-mode-my-wordpress__media-detail-summary {
+	margin: 0;
+	color: var( --desktop-mode-muted, #787c82 );
+	font-size: 13px;
+}

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -1672,19 +1672,18 @@ a.desktop-mode-my-wordpress__footprint-event-title:hover {
 	grid-template-columns: max-content 1fr;
 	gap: 4px 16px;
 	font-size: 13px;
-}
-
-.desktop-mode-my-wordpress__media-meta-row {
-	display: contents;
+	margin: 0;
 }
 
 .desktop-mode-my-wordpress__media-meta-term {
 	color: var( --desktop-mode-muted, #787c82 );
+	margin: 0;
 }
 
 .desktop-mode-my-wordpress__media-meta-value {
 	color: var( --desktop-mode-text, #1d2327 );
 	word-break: break-word;
+	margin: 0;
 }
 
 .desktop-mode-my-wordpress__media-actions {

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 - [Replace the dock rail entirely](./dock-rail-renderer.md)
 - [Gate desktop mode by role](./gate-by-role.md)
 - [React to window events](./react-to-window-events.md)
+- [My WordPress — add a preview-pane action button](./my-wordpress-media-action.md)
 - [Window lifecycle hooks (one subscriber per state)](./window-lifecycle.md)
 - [Custom arrange-menu action](./arrange-action.md)
 - [Style a specific admin page inside the iframe](./chromeless-style-override.md)

--- a/docs/examples/my-wordpress-media-action.md
+++ b/docs/examples/my-wordpress-media-action.md
@@ -1,0 +1,164 @@
+# Add an action button to a My WordPress preview pane
+
+**Status: Experimental — since 0.21.0**
+
+The My WordPress native window (Posts / Pages / Users / Media)
+exposes a uniform right-pane action surface. Plugins declare a
+descriptor on the **PHP** side (capability + MIME + script handle)
+and wire the JS handler via a `wp.hooks` filter. This recipe walks
+through both halves.
+
+The scenario: a "Compress this image" button that appears only on
+image items in the Media section, hits a plugin-owned REST route,
+and toasts on success.
+
+## PHP — declare the descriptor
+
+```php
+add_filter( 'desktop_mode_my_wordpress_preview_actions', function ( $actions ) {
+    $actions[] = array(
+        'id'         => 'my-plugin/compress-image',
+        'label'      => __( 'Compress this image', 'my-plugin' ),
+        'icon'       => 'dashicons-image-rotate',
+        'capability' => 'upload_files',
+        'mime'       => '^image/',           // PCRE — server pre-filters
+        'sections'   => array( 'media' ),
+        'script'     => 'my-plugin-actions', // wp_register_script handle
+    );
+    return $actions;
+} );
+
+// Register the JS bundle that wires the handler. Desktop Mode
+// auto-enqueues the handle for users who can see the action.
+add_action( 'init', function () {
+    wp_register_script(
+        'my-plugin-actions',
+        plugins_url( 'actions.js', __FILE__ ),
+        array( 'wp-hooks' ),
+        '1.0.0',
+        true
+    );
+} );
+```
+
+What you got for free:
+
+- `capability` is enforced before the descriptor ships to the
+  bundle, so the button never appears for users who can't run it.
+- `mime` is re-evaluated client-side per item — the button stays
+  hidden on non-image rows.
+- `sections` scopes the button. Omit it to show the button on every
+  section, or pass `array( 'media', 'posts' )` to opt in to more.
+- `script` is auto-enqueued for users who can see the action.
+
+## JS — wire the click handler
+
+`actions.js` (or a TS source you compile to it):
+
+```js
+( function () {
+    if ( ! window.wp || ! window.wp.hooks || ! window.wp.desktop ) {
+        return;
+    }
+    wp.hooks.addFilter(
+        'desktop-mode.my-wordpress.preview-actions',
+        'my-plugin/compress',
+        function ( actions, ctx ) {
+            return actions.map( function ( a ) {
+                if ( a.id !== 'my-plugin/compress-image' ) {
+                    return a;
+                }
+                return Object.assign( {}, a, {
+                    onSelect: async function ( c ) {
+                        const id = c.item.id;
+                        const response = await wp.desktop.fetch(
+                            '/wp-json/my-plugin/v1/compress/' + id,
+                            { method: 'POST' },
+                            { source: 'my-plugin/compress' },
+                        );
+                        if ( response.ok ) {
+                            wp.desktop.notify( {
+                                title: 'Compressed!',
+                                body: c.item.title.rendered,
+                            } );
+                        }
+                    },
+                } );
+            } );
+        },
+    );
+} )();
+```
+
+The handler's `ctx` argument:
+
+```ts
+{
+    entityId: 'media',     // section slug
+    kind: 'media',         // render kind
+    mime: 'image/png',     // present on media items
+    item: { /* full server record */ },
+}
+```
+
+## Inject HTML into the right pane
+
+Sometimes a button isn't enough — you want to drop a custom info
+panel into the metadata grid, or a footer with deeper links. Use
+the slot action:
+
+```js
+wp.hooks.addAction(
+    'desktop-mode.my-wordpress.preview-extras',
+    'my-plugin/cdn-status',
+    function ( ctx ) {
+        if ( ctx.slot !== 'meta' || ctx.kind !== 'media' ) {
+            return;
+        }
+        const row = document.createElement( 'div' );
+        row.textContent = 'CDN: cached at 3 edges';
+        ctx.container.appendChild( row );
+    },
+);
+```
+
+The available slots are `'header'`, `'meta'`, and `'footer'`. Each
+fires once per preview render with a `container` element for
+that slot.
+
+## Ship your own section type
+
+Need a section beyond Posts / Pages / Users / Media? Register a
+`kind` server-side **and** a renderer client-side:
+
+```php
+add_filter( 'desktop_mode_my_wordpress_entities', function ( $entities ) {
+    $entities[] = array(
+        'id'       => 'my-orders',
+        'label'    => __( 'Orders', 'my-plugin' ),
+        'icon'     => 'dashicons-cart',
+        'restPath' => 'wp/v2/my-order',
+        'kind'     => 'my-plugin/order',
+    );
+    return $entities;
+} );
+```
+
+```js
+wp.desktop.myWordpress.registerEntityKind(
+    'my-plugin/order',
+    function ( host, entity ) {
+        host.body.replaceChildren();
+        const h = document.createElement( 'h2' );
+        h.textContent = entity.label;
+        host.body.appendChild( h );
+        // Fetch, render tiles, paint preview pane, call
+        // host.navigate(...) on drill-in, host.addTeardown(...)
+        // on every subscription.
+    },
+);
+```
+
+The renderer receives the same `EntityRenderHost` the built-in
+sections do — paint into `host.body`, route via `host.navigate`,
+register cleanup via `host.addTeardown`.

--- a/docs/examples/my-wordpress-media-action.md
+++ b/docs/examples/my-wordpress-media-action.md
@@ -159,6 +159,11 @@ wp.desktop.myWordpress.registerEntityKind(
 );
 ```
 
+You can call `registerEntityKind` at script-load time — no timing
+guard needed. The main desktop bundle installs an early-load stub
+that buffers calls; when the lazy My WordPress bundle mounts (on
+first open of the window), it drains the queue.
+
 The renderer receives the same `EntityRenderHost` the built-in
 sections do — paint into `host.body`, route via `host.navigate`,
 register cleanup via `host.addTeardown`.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2202,6 +2202,46 @@ apply_filters( 'desktop_mode_my_wordpress_user_footprint', array $payload, int $
 
 The per-user activity-footprint payload returned by `GET /desktop-mode/v1/user-footprint/<id>` — drives the full-body "View activity footprint" surface (right-click on a user tile → footprint). Carries a year of day-by-day activity, weekday + hour-of-day distribution, streak math, recent-events timeline, and totals. Plugins can extend the timeline with their own activity rows (deploys, badges earned, etc.) or replace the streak math with a domain-specific definition.
 
+### `desktop_mode_my_wordpress_media_usage` — Experimental (filter, since 0.21.0)
+
+```php
+apply_filters( 'desktop_mode_my_wordpress_media_usage', array $payload, int $attachment_id ): array
+```
+
+The "used in" payload returned by `GET /desktop-mode/v1/media-usage/<id>` — drives the Media drill-in view (double-click a media tile). Each `usedIn` row carries `{ postId, postType, postTypeLabel, title, status, link, editLink, usedAs:'featured'|'content'|'meta', authorId, authorName, date }`. Plugins (ACF, page builders, Yoast image meta) can push additional rows describing references their own data layer holds — e.g. ACF image fields, gallery blocks, theme-mod backgrounds.
+
+Rows are already filtered per-row through `current_user_can('read_post', $row['postId'])`, so the viewer never sees drafts they can't read. The payload is transient-cached (default 5 min) per attachment + viewer-capability bucket; cache busts on `save_post`, `deleted_post`, `delete_attachment`.
+
+### `desktop_mode_my_wordpress_media_usage_cache_ttl` — Experimental (filter, since 0.21.0)
+
+```php
+apply_filters( 'desktop_mode_my_wordpress_media_usage_cache_ttl', int $seconds, int $attachment_id ): int
+```
+
+Lifetime (seconds) of the per-attachment media-usage transient. Lower it on sites that frequently bulk-import or rewrite content; raise it on stable libraries.
+
+### `desktop_mode_my_wordpress_preview_actions` — Experimental (filter, since 0.21.0)
+
+```php
+apply_filters( 'desktop_mode_my_wordpress_preview_actions', array[] $actions ): array[]
+```
+
+Server-declared descriptors for the right-pane action button row that appears in every My WordPress section (posts, pages, users, media, plugin-defined kinds). Each entry:
+
+```php
+array(
+    'id'         => 'my-plugin/compress-image', // required, unique
+    'label'      => 'Compress this image',      // required
+    'icon'       => 'dashicons-image-rotate',   // optional
+    'capability' => 'upload_files',             // optional, default 'read'
+    'mime'       => '^image/',                  // optional PCRE
+    'sections'   => array( 'media' ),           // optional, default all
+    'script'     => 'my-plugin-actions',        // optional wp_register_script handle
+)
+```
+
+`capability` is enforced server-side before the descriptor ships to the bundle, so an action the current user can't run never appears in their UI. `script`, if registered, is auto-enqueued. Wire the click handler on the JS side via `wp.hooks.addFilter('desktop-mode.my-wordpress.preview-actions', …)` — see [`examples/my-wordpress-media-action.md`](./examples/my-wordpress-media-action.md).
+
 ---
 
 ## Presence

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4118,6 +4118,33 @@ wp.hooks.addAction(
 );
 ```
 
+### Filter — `desktop-mode.my-wordpress.tile-context-menu`
+
+Decorate the per-tile right-click menu. Same descriptor shape as
+the preview-actions row; plugin entries must carry an `onSelect`
+handler (built-ins are dispatched by the bundle's static switch).
+
+```ts
+wp.hooks.addFilter(
+    'desktop-mode.my-wordpress.tile-context-menu',
+    'my-plugin/duplicate',
+    ( options, ctx ) => {
+        options.push( {
+            id: 'my-plugin/duplicate',
+            label: 'Duplicate',
+            icon: 'dashicons-admin-page',
+            onSelect: () => duplicatePost( ctx.item.id ),
+        } );
+        return options;
+    },
+);
+```
+
+Context: `{ entityId, kind, item }`. Currently wired on the post /
+page tile menu; user and media tile menus will subscribe to the
+same hook in a follow-up — write the filter as if the hook fires
+for every section.
+
 ### Filter — `desktop-mode.my-wordpress.status-bar` (existing)
 
 Already documented above — unchanged.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4022,6 +4022,115 @@ Backed by `wp.desktop.createSharedStore( 'desktop-mode/plugins-window/tab-target
 
 ---
 
+## My WordPress — extensibility surface (Experimental, since 0.21.0)
+
+The native window registered under id `desktop-mode-my-wordpress`
+exposes three JS hook points and a small public API. Every section
+(Posts, Pages, Users, Media, plugin-defined kinds) uses the same
+hooks, so a single plugin descriptor can decorate any preview pane.
+
+### Public API — `wp.desktop.myWordpress`
+
+```ts
+interface MyWordpressApi {
+    /**
+     * Open the post-detail dossier for a given post id. Idempotent
+     * — opens the window first if it isn't already.
+     */
+    openDetail( args: { entityId: string; postId: number; postTitle: string } ): void;
+
+    /**
+     * Open the Media drill-in ("used in") view for an attachment.
+     * Mirror of `openDetail`.
+     *
+     * @since 0.21.0
+     */
+    openMedia( args: { mediaId: number; mediaTitle?: string } ): void;
+
+    /**
+     * Register a renderer for a custom entity kind so a plugin
+     * can ship its own section type without patching the bundle.
+     * Pair with a PHP entry in `desktop_mode_my_wordpress_entities`
+     * carrying the same `kind` slug.
+     *
+     * Returns an unregister function.
+     *
+     * @since 0.21.0
+     */
+    registerEntityKind(
+        kind: string,
+        renderer: ( host: EntityRenderHost, entity: MyWordPressEntity ) => void,
+    ): () => void;
+}
+```
+
+`EntityRenderHost` surfaces just enough state to paint and navigate:
+
+```ts
+interface EntityRenderHost {
+    body: HTMLElement;
+    route: Route;
+    navigate( route: Route ): void;
+    addTeardown( fn: () => void ): void;
+}
+```
+
+### Filter — `desktop-mode.my-wordpress.preview-actions`
+
+Decorate the right-pane action button row. Receives the
+server-declared descriptors (already capability-gated) merged with
+any client-only entries the filter chain has added on prior calls.
+Wire the `onSelect` handler here — server descriptors only carry
+metadata.
+
+```ts
+wp.hooks.addFilter(
+    'desktop-mode.my-wordpress.preview-actions',
+    'my-plugin/compress',
+    ( actions, ctx ) =>
+        actions.map( ( a ) =>
+            a.id === 'my-plugin/compress-image'
+                ? { ...a, onSelect: ( c ) => { /* run */ } }
+                : a,
+        ),
+);
+```
+
+Context shape: `{ entityId, kind, mime?, item }`. `item` is the
+raw server record (a `MediaListItem`, post `EntityListItem`, etc.).
+
+### Action — `desktop-mode.my-wordpress.preview-extras`
+
+Inject DOM into named slots on the right pane (`'header' | 'meta'
+| 'footer'`). Fires once per slot per preview render.
+
+```ts
+wp.hooks.addAction(
+    'desktop-mode.my-wordpress.preview-extras',
+    'my-plugin/footer',
+    ( ctx ) => {
+        if ( ctx.slot === 'footer' ) {
+            const badge = document.createElement( 'span' );
+            badge.textContent = '✓ checked';
+            ctx.container.appendChild( badge );
+        }
+    },
+);
+```
+
+### Filter — `desktop-mode.my-wordpress.status-bar` (existing)
+
+Already documented above — unchanged.
+
+### postMessage / CustomEvents
+
+None new. Media drag-out uses the existing `'shortcut'` drag
+payload with `data.kind === 'attachment'`.
+
+See [Examples — My WordPress media action](./examples/my-wordpress-media-action.md).
+
+---
+
 ## See also
 
 - [Hooks Reference](./hooks-reference.md) — the PHP side of the API.

--- a/includes/my-wordpress/bootstrap.php
+++ b/includes/my-wordpress/bootstrap.php
@@ -21,3 +21,5 @@ require_once __DIR__ . '/user-list-fields.php';
 require_once __DIR__ . '/user-footprint.php';
 require_once __DIR__ . '/term-stats.php';
 require_once __DIR__ . '/comment-stats.php';
+require_once __DIR__ . '/media-usage.php';
+require_once __DIR__ . '/preview-actions.php';

--- a/includes/my-wordpress/media-usage.php
+++ b/includes/my-wordpress/media-usage.php
@@ -452,7 +452,14 @@ function desktop_mode_my_wordpress_media_usage_bust_for_post( $post_id ) {
 	}
 }
 add_action( 'save_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
-add_action( 'deleted_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
+// `before_delete_post`, NOT `deleted_post`. By the time `deleted_post`
+// fires, `delete_all_meta_for_post` has already wiped `_thumbnail_id`
+// and the row itself is gone — `extract_refs()` would return an empty
+// set, so the cache for any referenced attachment would survive until
+// its 5-minute TTL. `before_delete_post` fires while the post + meta
+// are still readable. Signature matches (we only consume the first
+// arg, the post id).
+add_action( 'before_delete_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
 // New posts skip `pre_post_update` but still go through `save_post`,
 // so the buster works as-is — the pre-snapshot is just empty.
 

--- a/includes/my-wordpress/media-usage.php
+++ b/includes/my-wordpress/media-usage.php
@@ -270,11 +270,29 @@ function desktop_mode_my_wordpress_media_usage_build( $attachment ) {
 				$query_args
 			)
 		);
+		// The LIKE scan over-fetches: `%wp-image-12%` matches
+		// `wp-image-123` too. Re-check each candidate with a
+		// word-boundary regex (matches `wp-image-12` followed by
+		// any non-digit, or end of string) and accept the row only
+		// if the precise class pattern OR the full attachment URL
+		// is present.
+		$class_re = '/wp-image-' . $attachment_id . '(?!\d)/';
 		foreach ( (array) $content_rows as $pid ) {
 			$pid = (int) $pid;
-			if ( $pid > 0 && ! isset( $rows_by_post[ $pid ] ) ) {
-				$rows_by_post[ $pid ] = 'content';
+			if ( $pid <= 0 || isset( $rows_by_post[ $pid ] ) ) {
+				continue;
 			}
+			$content_post = get_post( $pid );
+			if ( ! $content_post || ! isset( $content_post->post_content ) ) {
+				continue;
+			}
+			$haystack    = (string) $content_post->post_content;
+			$has_class   = (bool) preg_match( $class_re, $haystack );
+			$has_url     = '' !== $file_url && false !== strpos( $haystack, $file_url );
+			if ( ! $has_class && ! $has_url ) {
+				continue;
+			}
+			$rows_by_post[ $pid ] = 'content';
 		}
 	}
 
@@ -330,12 +348,83 @@ function desktop_mode_my_wordpress_media_usage_build( $attachment ) {
 }
 
 /**
+ * Per-post stash of attachment ids referenced BEFORE an in-progress
+ * update. Populated on `pre_post_update` (where the DB row still
+ * reflects the previous state), drained on `save_post` so the
+ * buster can union pre + post sets — otherwise removing a
+ * `wp-image-N` block from a post would leave the cache for
+ * attachment N stale until the TTL expires.
+ *
+ * @since 0.21.0
+ *
+ * @var array<int,array<int,true>>
+ */
+$GLOBALS['desktop_mode_media_usage_pre_save_refs'] = array();
+
+/**
+ * Extract attachment ids referenced by a post: `_thumbnail_id` +
+ * every `wp-image-<id>` class in its content. Used by both the
+ * pre-save snapshot and the post-save buster.
+ *
+ * @since 0.21.0
+ *
+ * @param int|WP_Post $post Post id or object.
+ * @return array<int,true> Set of attachment ids keyed for dedup.
+ */
+function desktop_mode_my_wordpress_media_usage_extract_refs( $post ) {
+	$ids = array();
+	$obj = is_object( $post ) ? $post : get_post( (int) $post );
+	if ( ! $obj || ! isset( $obj->ID ) ) {
+		return $ids;
+	}
+	$thumb = (int) get_post_meta( (int) $obj->ID, '_thumbnail_id', true );
+	if ( $thumb > 0 ) {
+		$ids[ $thumb ] = true;
+	}
+	$content = isset( $obj->post_content ) ? (string) $obj->post_content : '';
+	if ( '' !== $content && false !== strpos( $content, 'wp-image-' ) ) {
+		if ( preg_match_all( '/wp-image-(\d+)/', $content, $m ) ) {
+			foreach ( $m[1] as $id ) {
+				$ids[ (int) $id ] = true;
+			}
+		}
+	}
+	return $ids;
+}
+
+/**
+ * Snapshot the attachment refs of a post just before it's updated.
+ * Fired by `pre_post_update`, which runs before the DB row mutates,
+ * so `get_post` here returns the OLD content. We stash the ref set
+ * in a per-request global and read it back in the `save_post` hook.
+ *
+ * @since 0.21.0
+ *
+ * @param int $post_id Post id about to be updated.
+ */
+function desktop_mode_my_wordpress_media_usage_snapshot_pre_save( $post_id ) {
+	$post_id = (int) $post_id;
+	if ( $post_id <= 0 ) {
+		return;
+	}
+	$GLOBALS['desktop_mode_media_usage_pre_save_refs'][ $post_id ] =
+		desktop_mode_my_wordpress_media_usage_extract_refs( $post_id );
+}
+add_action( 'pre_post_update', 'desktop_mode_my_wordpress_media_usage_snapshot_pre_save' );
+
+/**
  * Bust the transient when a post changes. The cache key is
  * per-attachment, so we don't know which entries reference what —
- * the cheap correct move is to delete cache for every attachment
- * referenced by the saved/deleted post. Bounded by the actual
- * count of `wp-image-N` matches in the saved content + the post's
- * `_thumbnail_id`.
+ * the correct move is to delete cache for every attachment
+ * referenced by the saved/deleted post. The union of:
+ *
+ *   - pre-save refs (captured by `pre_post_update` above) so a
+ *     reference removal still busts the dropped attachment's cache,
+ *   - post-save refs (read here) so a freshly-added reference
+ *     busts the cache too.
+ *
+ * Bounded by the actual count of `wp-image-N` matches in either
+ * version of the content + the post's `_thumbnail_id`.
  *
  * @since 0.21.0
  *
@@ -346,20 +435,12 @@ function desktop_mode_my_wordpress_media_usage_bust_for_post( $post_id ) {
 	if ( $post_id <= 0 ) {
 		return;
 	}
-	$ids = array();
 
-	$thumb = (int) get_post_meta( $post_id, '_thumbnail_id', true );
-	if ( $thumb > 0 ) {
-		$ids[ $thumb ] = true;
-	}
+	$ids = desktop_mode_my_wordpress_media_usage_extract_refs( $post_id );
 
-	$post = get_post( $post_id );
-	if ( $post && isset( $post->post_content ) && false !== strpos( $post->post_content, 'wp-image-' ) ) {
-		if ( preg_match_all( '/wp-image-(\d+)/', $post->post_content, $m ) ) {
-			foreach ( $m[1] as $id ) {
-				$ids[ (int) $id ] = true;
-			}
-		}
+	if ( isset( $GLOBALS['desktop_mode_media_usage_pre_save_refs'][ $post_id ] ) ) {
+		$ids += $GLOBALS['desktop_mode_media_usage_pre_save_refs'][ $post_id ];
+		unset( $GLOBALS['desktop_mode_media_usage_pre_save_refs'][ $post_id ] );
 	}
 
 	foreach ( array_keys( $ids ) as $attachment_id ) {
@@ -372,6 +453,8 @@ function desktop_mode_my_wordpress_media_usage_bust_for_post( $post_id ) {
 }
 add_action( 'save_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
 add_action( 'deleted_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
+// New posts skip `pre_post_update` but still go through `save_post`,
+// so the buster works as-is — the pre-snapshot is just empty.
 
 /**
  * Bust the transient when the attachment itself is deleted.

--- a/includes/my-wordpress/media-usage.php
+++ b/includes/my-wordpress/media-usage.php
@@ -90,17 +90,47 @@ function desktop_mode_my_wordpress_media_usage_ttl( $attachment_id ) {
 }
 
 /**
+ * Capability buckets the cache namespaces over. A second-tier
+ * change to the gating logic must update this list — the busters
+ * iterate over the same array, so the writer and the buster can
+ * never go out of sync.
+ *
+ * @since 0.21.0
+ *
+ * @return string[]
+ */
+function desktop_mode_my_wordpress_media_usage_cache_buckets() {
+	return array( 'edit', 'read' );
+}
+
+/**
+ * Bucket key for the current user — the writer's view of which
+ * cache slot to read/write.
+ *
+ * @since 0.21.0
+ *
+ * @return string
+ */
+function desktop_mode_my_wordpress_media_usage_current_bucket() {
+	return current_user_can( 'edit_others_posts' ) ? 'edit' : 'read';
+}
+
+/**
  * Build the transient key — namespaces the cache by attachment id
  * AND a coarse capability bucket so admins and viewers never share
  * a hit.
  *
  * @since 0.21.0
  *
- * @param int $attachment_id Attachment id.
+ * @param int    $attachment_id Attachment id.
+ * @param string $bucket        Optional bucket override. Defaults to
+ *                              the current user's bucket.
  * @return string
  */
-function desktop_mode_my_wordpress_media_usage_cache_key( $attachment_id ) {
-	$bucket = current_user_can( 'edit_others_posts' ) ? 'edit' : 'read';
+function desktop_mode_my_wordpress_media_usage_cache_key( $attachment_id, $bucket = null ) {
+	if ( null === $bucket ) {
+		$bucket = desktop_mode_my_wordpress_media_usage_current_bucket();
+	}
 	return 'dm_media_usage_' . (int) $attachment_id . '_' . $bucket . '_v1';
 }
 
@@ -126,6 +156,15 @@ function desktop_mode_my_wordpress_media_usage_callback( $request ) {
 	$cache_key = desktop_mode_my_wordpress_media_usage_cache_key( $attachment_id );
 	$cached    = get_transient( $cache_key );
 	if ( is_array( $cached ) ) {
+		/*
+		 * Cache stores the PRE-filter payload. We re-run the filter
+		 * on every hit so plugin extensions (ACF image meta, page-
+		 * builder galleries, etc.) stay live even while the heavy
+		 * SQL portion of the payload is cached. Plugin output is
+		 * cheaper to recompute than the LIKE-scan; the base payload
+		 * only refreshes on the cache-bust events (save_post,
+		 * deleted_post, delete_attachment).
+		 */
 		/** This filter is documented in includes/my-wordpress/media-usage.php */
 		return apply_filters( 'desktop_mode_my_wordpress_media_usage', $cached, $attachment_id );
 	}
@@ -324,8 +363,11 @@ function desktop_mode_my_wordpress_media_usage_bust_for_post( $post_id ) {
 	}
 
 	foreach ( array_keys( $ids ) as $attachment_id ) {
-		delete_transient( 'dm_media_usage_' . (int) $attachment_id . '_edit_v1' );
-		delete_transient( 'dm_media_usage_' . (int) $attachment_id . '_read_v1' );
+		foreach ( desktop_mode_my_wordpress_media_usage_cache_buckets() as $bucket ) {
+			delete_transient(
+				desktop_mode_my_wordpress_media_usage_cache_key( (int) $attachment_id, $bucket )
+			);
+		}
 	}
 }
 add_action( 'save_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
@@ -343,7 +385,10 @@ function desktop_mode_my_wordpress_media_usage_bust_for_attachment( $post_id ) {
 	if ( $post_id <= 0 ) {
 		return;
 	}
-	delete_transient( 'dm_media_usage_' . $post_id . '_edit_v1' );
-	delete_transient( 'dm_media_usage_' . $post_id . '_read_v1' );
+	foreach ( desktop_mode_my_wordpress_media_usage_cache_buckets() as $bucket ) {
+		delete_transient(
+			desktop_mode_my_wordpress_media_usage_cache_key( $post_id, $bucket )
+		);
+	}
 }
 add_action( 'delete_attachment', 'desktop_mode_my_wordpress_media_usage_bust_for_attachment' );

--- a/includes/my-wordpress/media-usage.php
+++ b/includes/my-wordpress/media-usage.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Desktop Mode — My WordPress: per-attachment "used in" endpoint.
+ *
+ * `GET /desktop-mode/v1/media-usage/<id>` returns the list of public
+ * post-type entries that reference a given attachment, either as
+ * featured image (`_thumbnail_id` meta) or as an embed inside
+ * `post_content` (block-editor `wp-image-<id>` class or a direct URL
+ * to the attachment file).
+ *
+ * Payload shape:
+ *
+ *   {
+ *     media: { id, title, mime, sourceUrl, filename, date, author },
+ *     usedIn: [
+ *       { postId, postType, postTypeLabel, title, status, link,
+ *         editLink, usedAs: 'featured'|'content'|'meta',
+ *         authorId, authorName, date }
+ *     ]
+ *   }
+ *
+ * Rows are filtered per-row with `current_user_can( 'read_post' )`,
+ * so subscribers never see drafts/private posts they can't read.
+ *
+ * Results are cached in a transient keyed on the attachment id +
+ * the viewer's effective capability scope. Cache is busted whenever
+ * any post is saved or deleted.
+ *
+ * @package WPDesktopMode
+ * @since   0.21.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the route.
+ *
+ * @since 0.21.0
+ */
+function desktop_mode_my_wordpress_register_media_usage_route() {
+	register_rest_route(
+		'desktop-mode/v1',
+		'/media-usage/(?P<id>\d+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'desktop_mode_my_wordpress_media_usage_callback',
+			'permission_callback' => static function ( $request ) {
+				$id = (int) $request->get_param( 'id' );
+				if ( $id <= 0 ) {
+					return false;
+				}
+				$post = get_post( $id );
+				if ( ! $post || 'attachment' !== $post->post_type ) {
+					return false;
+				}
+				return current_user_can( 'read_post', $id );
+			},
+			'args'                => array(
+				'id' => array(
+					'required'          => true,
+					'type'              => 'integer',
+					'sanitize_callback' => 'absint',
+				),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'desktop_mode_my_wordpress_register_media_usage_route' );
+
+/**
+ * Cache TTL (seconds). Filterable so sites that bulk-import media
+ * can shorten the window, or sites with stable libraries can
+ * lengthen it.
+ *
+ * @since 0.21.0
+ *
+ * @param int $attachment_id Attachment id.
+ * @return int
+ */
+function desktop_mode_my_wordpress_media_usage_ttl( $attachment_id ) {
+	/**
+	 * Filter the media-usage transient TTL.
+	 *
+	 * @since 0.21.0
+	 *
+	 * @param int $seconds       Default 300 (5 minutes).
+	 * @param int $attachment_id Attachment id the cache key is for.
+	 */
+	return (int) apply_filters( 'desktop_mode_my_wordpress_media_usage_cache_ttl', 300, $attachment_id );
+}
+
+/**
+ * Build the transient key — namespaces the cache by attachment id
+ * AND a coarse capability bucket so admins and viewers never share
+ * a hit.
+ *
+ * @since 0.21.0
+ *
+ * @param int $attachment_id Attachment id.
+ * @return string
+ */
+function desktop_mode_my_wordpress_media_usage_cache_key( $attachment_id ) {
+	$bucket = current_user_can( 'edit_others_posts' ) ? 'edit' : 'read';
+	return 'dm_media_usage_' . (int) $attachment_id . '_' . $bucket . '_v1';
+}
+
+/**
+ * Endpoint callback. See file docblock for payload shape.
+ *
+ * @since 0.21.0
+ *
+ * @param WP_REST_Request $request REST request.
+ * @return array|WP_Error
+ */
+function desktop_mode_my_wordpress_media_usage_callback( $request ) {
+	$attachment_id = (int) $request->get_param( 'id' );
+	$attachment    = get_post( $attachment_id );
+	if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+		return new WP_Error(
+			'desktop_mode_media_not_found',
+			__( 'Attachment not found.', 'desktop-mode' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	$cache_key = desktop_mode_my_wordpress_media_usage_cache_key( $attachment_id );
+	$cached    = get_transient( $cache_key );
+	if ( is_array( $cached ) ) {
+		/** This filter is documented in includes/my-wordpress/media-usage.php */
+		return apply_filters( 'desktop_mode_my_wordpress_media_usage', $cached, $attachment_id );
+	}
+
+	$payload = desktop_mode_my_wordpress_media_usage_build( $attachment );
+
+	set_transient(
+		$cache_key,
+		$payload,
+		desktop_mode_my_wordpress_media_usage_ttl( $attachment_id )
+	);
+
+	/**
+	 * Filter the media-usage payload before returning to the bundle.
+	 * Plugins (ACF, page builders, Yoast image meta) can append rows
+	 * to `usedIn` describing their own attachment references.
+	 *
+	 * @since 0.21.0
+	 *
+	 * @param array $payload       Default payload.
+	 * @param int   $attachment_id Subject attachment id.
+	 */
+	return apply_filters( 'desktop_mode_my_wordpress_media_usage', $payload, $attachment_id );
+}
+
+/**
+ * Build the un-filtered payload. Separated from the callback so the
+ * cache bypass can short-circuit before any DB work.
+ *
+ * @since 0.21.0
+ *
+ * @param WP_Post $attachment Attachment post.
+ * @return array
+ */
+function desktop_mode_my_wordpress_media_usage_build( $attachment ) {
+	global $wpdb;
+
+	$attachment_id = (int) $attachment->ID;
+	$file_url      = (string) wp_get_attachment_url( $attachment_id );
+	$file_basename = '' !== $file_url ? wp_basename( $file_url ) : '';
+
+	$author     = get_userdata( (int) $attachment->post_author );
+	$media_info = array(
+		'id'        => $attachment_id,
+		'title'     => (string) get_the_title( $attachment_id ),
+		'mime'      => (string) $attachment->post_mime_type,
+		'sourceUrl' => $file_url,
+		'filename'  => $file_basename,
+		'date'      => mysql2date( 'c', $attachment->post_date_gmt, false ),
+		'author'    => array(
+			'id'   => (int) $attachment->post_author,
+			'name' => $author ? (string) $author->display_name : '',
+		),
+	);
+
+	$public_types = array_values( get_post_types( array( 'public' => true ), 'names' ) );
+	// Filter out `attachment` from the search — attachments don't
+	// reference other attachments in a meaningful way for this view.
+	$public_types = array_values( array_diff( $public_types, array( 'attachment' ) ) );
+	if ( empty( $public_types ) ) {
+		return array(
+			'media'  => $media_info,
+			'usedIn' => array(),
+		);
+	}
+
+	// `usedAs` priority: featured > content > meta. We collect every
+	// hit per post id, then collapse to the highest-priority kind for
+	// display so a row isn't double-listed.
+	$rows_by_post = array();
+
+	// --- Featured image references --------------------------------------
+	$thumb_post_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT post_id FROM {$wpdb->postmeta}
+			 WHERE meta_key = '_thumbnail_id' AND meta_value = %s",
+			(string) $attachment_id
+		)
+	);
+	foreach ( (array) $thumb_post_ids as $pid ) {
+		$pid = (int) $pid;
+		if ( $pid > 0 ) {
+			$rows_by_post[ $pid ] = 'featured';
+		}
+	}
+
+	// --- Content embeds (block class + raw URL) -------------------------
+	if ( '' !== $file_basename ) {
+		$placeholders   = implode( ',', array_fill( 0, count( $public_types ), '%s' ) );
+		$class_pattern  = '%wp-image-' . $attachment_id . '%';
+		$url_pattern    = '%' . $wpdb->esc_like( $file_basename ) . '%';
+		$query_args     = array_merge(
+			array( $class_pattern, $url_pattern ),
+			$public_types
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$content_rows = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts}
+				 WHERE ( post_content LIKE %s OR post_content LIKE %s )
+				   AND post_status NOT IN ( 'auto-draft', 'inherit', 'trash' )
+				   AND post_type IN ( {$placeholders} )",
+				$query_args
+			)
+		);
+		foreach ( (array) $content_rows as $pid ) {
+			$pid = (int) $pid;
+			if ( $pid > 0 && ! isset( $rows_by_post[ $pid ] ) ) {
+				$rows_by_post[ $pid ] = 'content';
+			}
+		}
+	}
+
+	// --- Build the row payload, per-row capability gated ----------------
+	$type_objects = array();
+	foreach ( $public_types as $type ) {
+		$type_objects[ $type ] = get_post_type_object( $type );
+	}
+
+	$used_in = array();
+	foreach ( $rows_by_post as $post_id => $used_as ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			continue;
+		}
+		if ( ! in_array( $post->post_type, $public_types, true ) ) {
+			continue;
+		}
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			continue;
+		}
+		$author_obj = get_userdata( (int) $post->post_author );
+		$type_obj   = isset( $type_objects[ $post->post_type ] ) ? $type_objects[ $post->post_type ] : null;
+		$used_in[]  = array(
+			'postId'        => (int) $post->ID,
+			'postType'      => (string) $post->post_type,
+			'postTypeLabel' => $type_obj && isset( $type_obj->labels->singular_name )
+				? (string) $type_obj->labels->singular_name
+				: (string) $post->post_type,
+			'title'         => (string) get_the_title( $post ),
+			'status'        => (string) $post->post_status,
+			'link'          => (string) get_permalink( $post ),
+			'editLink'      => (string) get_edit_post_link( $post->ID, 'raw' ),
+			'usedAs'        => $used_as,
+			'authorId'      => (int) $post->post_author,
+			'authorName'    => $author_obj ? (string) $author_obj->display_name : '',
+			'date'          => mysql2date( 'c', $post->post_date_gmt, false ),
+		);
+	}
+
+	// Stable sort: most recent first.
+	usort(
+		$used_in,
+		static function ( $a, $b ) {
+			return strcmp( (string) $b['date'], (string) $a['date'] );
+		}
+	);
+
+	return array(
+		'media'  => $media_info,
+		'usedIn' => $used_in,
+	);
+}
+
+/**
+ * Bust the transient when a post changes. The cache key is
+ * per-attachment, so we don't know which entries reference what —
+ * the cheap correct move is to delete cache for every attachment
+ * referenced by the saved/deleted post. Bounded by the actual
+ * count of `wp-image-N` matches in the saved content + the post's
+ * `_thumbnail_id`.
+ *
+ * @since 0.21.0
+ *
+ * @param int $post_id Post id that was just modified.
+ */
+function desktop_mode_my_wordpress_media_usage_bust_for_post( $post_id ) {
+	$post_id = (int) $post_id;
+	if ( $post_id <= 0 ) {
+		return;
+	}
+	$ids = array();
+
+	$thumb = (int) get_post_meta( $post_id, '_thumbnail_id', true );
+	if ( $thumb > 0 ) {
+		$ids[ $thumb ] = true;
+	}
+
+	$post = get_post( $post_id );
+	if ( $post && isset( $post->post_content ) && false !== strpos( $post->post_content, 'wp-image-' ) ) {
+		if ( preg_match_all( '/wp-image-(\d+)/', $post->post_content, $m ) ) {
+			foreach ( $m[1] as $id ) {
+				$ids[ (int) $id ] = true;
+			}
+		}
+	}
+
+	foreach ( array_keys( $ids ) as $attachment_id ) {
+		delete_transient( 'dm_media_usage_' . (int) $attachment_id . '_edit_v1' );
+		delete_transient( 'dm_media_usage_' . (int) $attachment_id . '_read_v1' );
+	}
+}
+add_action( 'save_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
+add_action( 'deleted_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
+
+/**
+ * Bust the transient when the attachment itself is deleted.
+ *
+ * @since 0.21.0
+ *
+ * @param int $post_id Attachment id.
+ */
+function desktop_mode_my_wordpress_media_usage_bust_for_attachment( $post_id ) {
+	$post_id = (int) $post_id;
+	if ( $post_id <= 0 ) {
+		return;
+	}
+	delete_transient( 'dm_media_usage_' . $post_id . '_edit_v1' );
+	delete_transient( 'dm_media_usage_' . $post_id . '_read_v1' );
+}
+add_action( 'delete_attachment', 'desktop_mode_my_wordpress_media_usage_bust_for_attachment' );

--- a/includes/my-wordpress/preview-actions.php
+++ b/includes/my-wordpress/preview-actions.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Desktop Mode — My WordPress: server-side preview-action descriptors.
+ *
+ * Plugins register action buttons that appear in the right-pane of
+ * any My WordPress section (posts, pages, users, media, plugin-
+ * defined kinds). Server-side declaration buys:
+ *
+ *   - Capability gating: an action a viewer can't run is never
+ *     shipped to their bundle (no client-side hide-after-render
+ *     race).
+ *   - Optional script enqueue: the registering plugin can declare a
+ *     `script` handle and we'll auto-enqueue it for users who can
+ *     see the action.
+ *   - One source of truth for both the right-pane action row and
+ *     the per-tile context menu — same descriptor.
+ *
+ * Descriptor shape:
+ *
+ *   [
+ *     'id'         => 'my-plugin/compress-image',  // required, unique
+ *     'label'      => 'Compress this image',       // required
+ *     'icon'       => 'dashicons-image-rotate',    // optional
+ *     'capability' => 'upload_files',              // optional, default 'read'
+ *     'mime'       => '^image/',                   // optional, PCRE
+ *     'sections'   => array( 'media' ),            // optional, default all
+ *     'script'     => 'my-plugin-actions',         // optional handle
+ *   ]
+ *
+ * @package WPDesktopMode
+ * @since   0.21.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Collect plugin-registered descriptors, drop ones the current user
+ * can't run, and return the array ready for the window config blob.
+ *
+ * @since 0.21.0
+ *
+ * @return array[]
+ */
+function desktop_mode_my_wordpress_collect_preview_actions() {
+	/**
+	 * Filter the list of preview-action descriptors that appear in
+	 * the right-pane of any My WordPress section.
+	 *
+	 * **Status: Experimental** — the descriptor shape may gain
+	 * fields. Existing fields (`id`, `label`, `icon`, `capability`,
+	 * `mime`, `sections`, `script`) will continue to work.
+	 *
+	 * @since 0.21.0
+	 *
+	 * @param array[] $actions Default: empty array.
+	 */
+	$actions = (array) apply_filters( 'desktop_mode_my_wordpress_preview_actions', array() );
+
+	$out = array();
+	foreach ( $actions as $action ) {
+		if ( ! is_array( $action ) || empty( $action['id'] ) || empty( $action['label'] ) ) {
+			continue;
+		}
+		$cap = isset( $action['capability'] ) && '' !== $action['capability']
+			? (string) $action['capability']
+			: 'read';
+		if ( ! current_user_can( $cap ) ) {
+			continue;
+		}
+		$descriptor = array(
+			'id'    => (string) $action['id'],
+			'label' => (string) $action['label'],
+		);
+		if ( ! empty( $action['icon'] ) ) {
+			$descriptor['icon'] = (string) $action['icon'];
+		}
+		if ( ! empty( $action['mime'] ) ) {
+			$descriptor['mime'] = (string) $action['mime'];
+		}
+		if ( ! empty( $action['sections'] ) && is_array( $action['sections'] ) ) {
+			$descriptor['sections'] = array_values( array_map( 'strval', $action['sections'] ) );
+		}
+		if ( ! empty( $action['script'] ) ) {
+			$descriptor['script'] = (string) $action['script'];
+		}
+		$out[] = $descriptor;
+	}
+	return $out;
+}
+
+/**
+ * Enqueue the JS handles declared by visible preview-action
+ * descriptors. Called from the bundle's `admin_enqueue_scripts`
+ * hook so the handlers are wired before the bundle paints.
+ *
+ * @since 0.21.0
+ */
+function desktop_mode_my_wordpress_enqueue_preview_action_scripts() {
+	if ( ! function_exists( 'desktop_mode_my_wordpress_user_can_use' ) || ! desktop_mode_my_wordpress_user_can_use() ) {
+		return;
+	}
+	$actions = desktop_mode_my_wordpress_collect_preview_actions();
+	foreach ( $actions as $action ) {
+		if ( ! empty( $action['script'] ) && wp_script_is( (string) $action['script'], 'registered' ) ) {
+			wp_enqueue_script( (string) $action['script'] );
+		}
+	}
+}
+add_action( 'admin_enqueue_scripts', 'desktop_mode_my_wordpress_enqueue_preview_action_scripts', 40 );

--- a/includes/my-wordpress/window.php
+++ b/includes/my-wordpress/window.php
@@ -89,6 +89,13 @@ function desktop_mode_my_wordpress_entities() {
 			'restPath' => 'wp/v2/users',
 			'kind'     => 'user',
 		),
+		array(
+			'id'       => 'media',
+			'label'    => __( 'Media', 'desktop-mode' ),
+			'icon'     => 'dashicons-admin-media',
+			'restPath' => 'wp/v2/media',
+			'kind'     => 'media',
+		),
 	);
 
 	/**
@@ -178,6 +185,10 @@ function desktop_mode_my_wordpress_register_window() {
 			'editUserUrlBase' => esc_url_raw( admin_url( 'user-edit.php' ) ),
 			'entities'        => desktop_mode_my_wordpress_entities(),
 			'perPage'         => 24,
+			'mediaPerPage'    => 48,
+			'previewActions'  => function_exists( 'desktop_mode_my_wordpress_collect_preview_actions' )
+				? desktop_mode_my_wordpress_collect_preview_actions()
+				: array(),
 		),
 	);
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -10,6 +10,10 @@
  * @since 6.9.0
  */
 
+// Install the `wp.desktop.myWordpress` early-registration stub so
+// plugin scripts can call `registerEntityKind()` before the lazy
+// my-wordpress bundle mounts. Side-effect import — runs once.
+import './my-wordpress/early-api';
 import { WindowManager } from './window-manager';
 import { installWindowSwitcherShortcut } from './window-manager/switcher';
 import { installDesktopArrowShortcuts } from './window-manager/desktop-shortcuts';

--- a/src/my-wordpress/dom-utils.ts
+++ b/src/my-wordpress/dom-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * My WordPress — shared DOM + drag helpers.
+ *
+ * Tiny utility module so `index.ts`, `media-list.ts`, and
+ * `media-detail.ts` don't each carry their own copy of the same
+ * `getDragManager` / `stripTags` definitions.
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+import type { DragManagerApi } from '../drag';
+
+/**
+ * Read the runtime DragManager off the `wp.desktop` global. Boot
+ * order guarantees this is present by the time any tile builder
+ * runs (the My WordPress window only mounts after
+ * `installPublicApi(desktopApi)` has wired the manager).
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function getDragManager(): DragManagerApi | null {
+	const api = (
+		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
+	).wp?.desktop?.dragManager;
+	return api ?? null;
+}
+
+/**
+ * Strip HTML tags from a rendered string the WordPress REST API
+ * returns under `*.rendered`. Cheap — uses a detached `<div>` and
+ * `textContent`. Does NOT decode entities the same way the rendered
+ * HTML would; callers that need full fidelity should keep the HTML.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function stripTags( html: string ): string {
+	const div = document.createElement( 'div' );
+	div.innerHTML = html;
+	return ( div.textContent ?? '' ).trim();
+}

--- a/src/my-wordpress/early-api.ts
+++ b/src/my-wordpress/early-api.ts
@@ -15,9 +15,21 @@
  * @since 0.21.0
  */
 
+/**
+ * Per-call mutable slot the stub closes over. Until the lazy bundle
+ * mounts, `unregister` is `null` and the stub-returned unregister
+ * splices from `__pendingKinds`. After drain, the lazy bundle fills
+ * `unregister` with the real registry closure, and any cached
+ * stub-unregister forwards through it.
+ */
+export interface PendingKindSlot {
+	unregister: ( () => void ) | null;
+}
+
 export interface PendingKindRegistration {
 	kind: string;
 	renderer: ( ...args: unknown[] ) => void;
+	slot: PendingKindSlot;
 }
 
 interface MyWordpressEarlyStub {
@@ -66,11 +78,19 @@ export function installMyWordpressEarlyStub(): void {
 	const queue: PendingKindRegistration[] = [];
 	const stub: MyWordpressEarlyStub = {
 		registerEntityKind: ( kind, renderer ) => {
-			queue.push( { kind, renderer } );
+			const slot: PendingKindSlot = { unregister: null };
+			const entry: PendingKindRegistration = { kind, renderer, slot };
+			queue.push( entry );
 			return () => {
-				const i = queue.findIndex(
-					( e ) => e.kind === kind && e.renderer === renderer,
-				);
+				// After drain — forward to the real registry closure.
+				if ( slot.unregister ) {
+					slot.unregister();
+					slot.unregister = null;
+					return;
+				}
+				// Before drain — pull the entry out of the queue so
+				// the lazy bundle never sees it.
+				const i = queue.indexOf( entry );
 				if ( i !== -1 ) {
 					queue.splice( i, 1 );
 				}

--- a/src/my-wordpress/early-api.ts
+++ b/src/my-wordpress/early-api.ts
@@ -1,0 +1,84 @@
+/**
+ * My WordPress — early-load API stub.
+ *
+ * Imported by `src/desktop.ts` so it lands in the main `desktop.min.js`
+ * bundle that's always loaded. Installs a queueing stub on
+ * `window.wp.desktop.myWordpress` so plugin scripts can call
+ * `registerEntityKind(...)` at script-load time, before the lazy
+ * `my-wordpress.min.js` bundle has mounted.
+ *
+ * When the lazy bundle initializes it drains
+ * `window.wp.desktop.myWordpress.__pendingKinds` and replaces this
+ * stub with the real API.
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+export interface PendingKindRegistration {
+	kind: string;
+	renderer: ( ...args: unknown[] ) => void;
+}
+
+interface MyWordpressEarlyStub {
+	/**
+	 * Stub registerEntityKind — buffers the call. Returns a stub
+	 * unregister that's a no-op (the real unregister isn't available
+	 * yet; if a plugin needs to unregister before mount it can mutate
+	 * `__pendingKinds` directly).
+	 */
+	registerEntityKind: (
+		kind: string,
+		renderer: ( ...args: unknown[] ) => void,
+	) => () => void;
+	/** Drained by the lazy bundle on mount. */
+	__pendingKinds?: PendingKindRegistration[];
+	/** Any other methods (openDetail, openMedia, …) get attached later. */
+	[ key: string ]: unknown;
+}
+
+/**
+ * Idempotent — safe to call from every bundle entry. Only the first
+ * call installs the stub. Reads/writes the loosely-typed
+ * `window.wp.desktop` namespace via casts to side-step the strict
+ * `WpDesktopPublicApi` global type — the early stub installs BEFORE
+ * the full public API is wired, so a partial shape is expected here.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function installMyWordpressEarlyStub(): void {
+	type Loose = {
+		wp?: { desktop?: Record< string, unknown > & {
+			myWordpress?: MyWordpressEarlyStub;
+		} };
+	};
+	const w = window as unknown as Loose;
+	w.wp = w.wp ?? {};
+	const wp = w.wp;
+	if ( ! wp.desktop ) {
+		wp.desktop = {};
+	}
+	const desktop = wp.desktop;
+	if ( desktop.myWordpress ) {
+		return;
+	}
+	const queue: PendingKindRegistration[] = [];
+	const stub: MyWordpressEarlyStub = {
+		registerEntityKind: ( kind, renderer ) => {
+			queue.push( { kind, renderer } );
+			return () => {
+				const i = queue.findIndex(
+					( e ) => e.kind === kind && e.renderer === renderer,
+				);
+				if ( i !== -1 ) {
+					queue.splice( i, 1 );
+				}
+			};
+		},
+		__pendingKinds: queue,
+	};
+	desktop.myWordpress = stub;
+}
+
+installMyWordpressEarlyStub();

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -299,6 +299,12 @@ function navigate(
 	}
 	if ( route.kind === 'media-detail' ) {
 		void renderMediaDetail( makeRenderHost( state ), route.mediaId );
+		// Defensive: every other branch in this switch ends with an
+		// explicit `return`. Keeping the symmetry means a new route
+		// kind added below won't silently fall through after a
+		// successful media-detail dispatch.
+		// eslint-disable-next-line no-useless-return
+		return;
 	}
 }
 

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -3228,22 +3228,61 @@ function openTileMenu(
 		menu.appendChild( opt );
 	};
 
-	addOption(
-		'open',
-		__( 'Open in editor', 'desktop-mode' ),
-		'dashicons-edit',
+	interface TileMenuOption {
+		id: string;
+		label: string;
+		icon: string;
+		danger?: boolean;
+		/**
+		 * Plugin-supplied click handler. Built-ins set this to null
+		 * so the static `wpd-context-menu-pick` switch below routes
+		 * them — keeps the existing semantics.
+		 */
+		onSelect?: ( () => void ) | null;
+	}
+
+	const baseOptions: TileMenuOption[] = [
+		{
+			id: 'open',
+			label: __( 'Open in editor', 'desktop-mode' ),
+			icon: 'dashicons-edit',
+		},
+		{
+			id: 'navigate-into',
+			label: __( 'Navigate into', 'desktop-mode' ),
+			icon: 'dashicons-category',
+		},
+		{
+			id: 'trash',
+			label: __( 'Move to Trash', 'desktop-mode' ),
+			icon: 'dashicons-trash',
+			danger: true,
+		},
+	];
+
+	/**
+	 * Let plugins add / remove / reorder context-menu entries
+	 * uniformly across every section. Plugin-added entries must
+	 * supply an `onSelect` handler (built-ins are dispatched by
+	 * the static switch below).
+	 */
+	const ctxFilter = {
+		entityId: entity.id,
+		kind: entity.kind ?? 'post',
+		item: item as unknown as Record< string, unknown >,
+	};
+	const options = applyFilters<
+		TileMenuOption[],
+		[ typeof ctxFilter ]
+	>(
+		'desktop-mode.my-wordpress.tile-context-menu',
+		baseOptions,
+		ctxFilter,
 	);
-	addOption(
-		'navigate-into',
-		__( 'Navigate into', 'desktop-mode' ),
-		'dashicons-category',
-	);
-	addOption(
-		'trash',
-		__( 'Move to Trash', 'desktop-mode' ),
-		'dashicons-trash',
-		true,
-	);
+	const finalOptions = Array.isArray( options ) ? options : baseOptions;
+	for ( const o of finalOptions ) {
+		addOption( o.id, o.label, o.icon, o.danger );
+	}
 
 	menu.addEventListener( 'wpd-context-menu-pick', ( e: Event ) => {
 		const detail = ( e as CustomEvent< { id: string } > ).detail;
@@ -3263,6 +3302,20 @@ function openTileMenu(
 		}
 		if ( detail.id === 'trash' ) {
 			void confirmTrash( state, ctx, entity, item.id, title );
+			return;
+		}
+		// Plugin-supplied entry — dispatch its `onSelect`.
+		const match = finalOptions.find( ( o ) => o.id === detail.id );
+		if ( match && typeof match.onSelect === 'function' ) {
+			try {
+				match.onSelect();
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					`[my-wordpress] tile-context-menu '${ detail.id }' onSelect threw:`,
+					err,
+				);
+			}
 		}
 	} );
 
@@ -5645,9 +5698,19 @@ interface MyWordpressApi {
 	registerEntityKind: ( kind: string, renderer: EntityRenderer ) => () => void;
 }
 
+interface PendingEntry {
+	kind: string;
+	renderer: EntityRenderer;
+	slot: { unregister: ( () => void ) | null };
+}
+
 const desktopGlobal = (
 	window.wp as
-		| { desktop?: Record< string, unknown > & { myWordpress?: MyWordpressApi & { __pendingKinds?: Array< { kind: string; renderer: EntityRenderer } > } } }
+		| { desktop?: Record< string, unknown > & {
+				myWordpress?: MyWordpressApi & {
+					__pendingKinds?: PendingEntry[];
+				};
+			} }
 		| undefined
 )?.desktop;
 if ( desktopGlobal ) {
@@ -5655,12 +5718,17 @@ if ( desktopGlobal ) {
 	// `src/my-wordpress/early-api.ts` (which ships in the main
 	// `desktop.min.js` bundle). Lets plugin scripts that load
 	// before this lazy bundle register kinds without timing
-	// guards.
+	// guards. We write the real `unregister` closure back into
+	// each queued entry's `slot` so any stub-unregister that the
+	// plugin already cached still works after the swap.
 	const pending = desktopGlobal.myWordpress?.__pendingKinds;
 	if ( Array.isArray( pending ) ) {
 		for ( const entry of pending ) {
 			try {
-				registerEntityKind( entry.kind, entry.renderer );
+				entry.slot.unregister = registerEntityKind(
+					entry.kind,
+					entry.renderer,
+				);
 			} catch ( err ) {
 				// eslint-disable-next-line no-console
 				console.error(

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -25,8 +25,8 @@ import {
 	renderStatusBarSegments,
 	type StatusBarSegment,
 } from '../desktop-files/folder-status-bar';
-import type { DragManagerApi } from '../drag';
 import type { ShortcutDragData } from '../desktop-files/drag-payloads';
+import { getDragManager, stripTags } from './dom-utils';
 import {
 	getEntityRenderer,
 	registerEntityKind,
@@ -35,19 +35,6 @@ import {
 } from './kind-registry';
 import { renderMediaList } from './media-list';
 import { renderMediaDetail } from './media-detail';
-
-/**
- * Read the runtime DragManager. Boot order guarantees this exists by
- * the time this module's tile builders run — the My WordPress window
- * only mounts after `installPublicApi(desktopApi)` has wired the
- * manager onto `wp.desktop.dragManager`.
- */
-function getDragManager(): DragManagerApi | null {
-	const api = (
-		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
-	).wp?.desktop?.dragManager;
-	return api ?? null;
-}
 import {
 	renderBreadcrumbs,
 	type BreadcrumbSegment,
@@ -172,12 +159,6 @@ function openIframeWindow( opts: OpenWindowOptions ): void {
 		title: opts.title,
 		icon: opts.icon,
 	} );
-}
-
-function stripTags( html: string ): string {
-	const div = document.createElement( 'div' );
-	div.innerHTML = html;
-	return ( div.textContent ?? '' ).trim();
 }
 
 function getThumbnail( item: EntityListItem | EntityDetail ): string {
@@ -5666,10 +5647,30 @@ interface MyWordpressApi {
 
 const desktopGlobal = (
 	window.wp as
-		| { desktop?: Record< string, unknown > & { myWordpress?: MyWordpressApi } }
+		| { desktop?: Record< string, unknown > & { myWordpress?: MyWordpressApi & { __pendingKinds?: Array< { kind: string; renderer: EntityRenderer } > } } }
 		| undefined
 )?.desktop;
 if ( desktopGlobal ) {
+	// Drain the early-registration queue installed by
+	// `src/my-wordpress/early-api.ts` (which ships in the main
+	// `desktop.min.js` bundle). Lets plugin scripts that load
+	// before this lazy bundle register kinds without timing
+	// guards.
+	const pending = desktopGlobal.myWordpress?.__pendingKinds;
+	if ( Array.isArray( pending ) ) {
+		for ( const entry of pending ) {
+			try {
+				registerEntityKind( entry.kind, entry.renderer );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					`[my-wordpress] queued registerEntityKind('${ entry.kind }') failed:`,
+					err,
+				);
+			}
+		}
+		pending.length = 0;
+	}
 	desktopGlobal.myWordpress = {
 		openDetail,
 		openMedia,

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -468,15 +468,16 @@ function updateBreadcrumbs( state: RenderState ): void {
 
 	renderBreadcrumbs( state.breadcrumbs, segments, {
 		onBack: () => {
-			if ( state.route.kind === 'root' ) {
-				return;
-			}
 			// Prefer history (navigation back) over hierarchy
 			// (parent folder) so cross-tree jumps unwind in the
-			// order the user made them. Fall back to the parent
-			// route when there's no history — e.g. the consumer
-			// opened the window straight into a detail view via
-			// `wp.desktop.myWordpress.openDetail`.
+			// order the user made them. The breadcrumb "My
+			// WordPress" jump lands at root WITH history non-empty
+			// — we mustn't early-return on `route.kind === 'root'`
+			// or that lands as a visually-enabled-but-no-op back
+			// button. `backDisabled` below gates the empty-history-
+			// at-root case, and the parent-route fallback collapses
+			// to a same-route no-op (routesEqual short-circuits
+			// the history push).
 			const previous = state.history.pop();
 			if ( previous ) {
 				navigate( state, previous, { fromBack: true } );

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -27,6 +27,14 @@ import {
 } from '../desktop-files/folder-status-bar';
 import type { DragManagerApi } from '../drag';
 import type { ShortcutDragData } from '../desktop-files/drag-payloads';
+import {
+	getEntityRenderer,
+	registerEntityKind,
+	type EntityRenderHost,
+	type EntityRenderer,
+} from './kind-registry';
+import { renderMediaList } from './media-list';
+import { renderMediaDetail } from './media-detail';
 
 /**
  * Read the runtime DragManager. Boot order guarantees this exists by
@@ -193,6 +201,16 @@ interface RenderState {
 	breadcrumbs: HTMLElement;
 	statusBar: HTMLElement;
 	teardown: Array< () => void >;
+	/**
+	 * Navigation history stack. Every `navigate()` call (except
+	 * "back") pushes the route it's leaving onto this stack; the
+	 * breadcrumb back button pops. Lets the user retrace cross-
+	 * hierarchy jumps (Media-detail → referenced post → back to
+	 * Media-detail), not just walk up the static folder tree.
+	 *
+	 * @since 0.21.0
+	 */
+	history: Route[];
 }
 
 interface StatusContext {
@@ -237,7 +255,20 @@ function pluralLabel(
 	return `${ n.toLocaleString() } ${ n === 1 ? singular : plural }`;
 }
 
-function navigate( state: RenderState, route: Route ): void {
+function navigate(
+	state: RenderState,
+	route: Route,
+	opts: { fromBack?: boolean } = {},
+): void {
+	// Push the route we're leaving onto the history stack so the
+	// back button can retrace cross-hierarchy jumps (e.g. Media
+	// → Media-detail → referenced post → back lands on Media-detail,
+	// not on the post's parent folder). Skipped on back-pops (we'd
+	// just re-add what we just removed) and on no-op re-navigations.
+	const sameRoute = routesEqual( state.route, route );
+	if ( ! opts.fromBack && ! sameRoute ) {
+		state.history.push( state.route );
+	}
 	clearTeardown( state );
 	state.route = route;
 	updateBreadcrumbs( state );
@@ -255,11 +286,16 @@ function navigate( state: RenderState, route: Route ): void {
 		return;
 	}
 	if ( route.kind === 'list' ) {
-		if ( entity.kind === 'user' ) {
-			renderUserEntityList( state, entity );
-		} else {
-			renderEntityList( state, entity );
+		const renderer = getEntityRenderer( entity.kind );
+		if ( renderer ) {
+			const host = makeRenderHost( state );
+			renderer( host, entity );
+			return;
 		}
+		// Unknown kind — fall back to the post renderer so older
+		// plugins that ship entities without a `kind` field keep
+		// working as they did before the registry.
+		renderEntityList( state, entity );
 		return;
 	}
 	if ( route.kind === 'detail' ) {
@@ -278,6 +314,63 @@ function navigate( state: RenderState, route: Route ): void {
 	}
 	if ( route.kind === 'user-footprint' ) {
 		renderUserFootprint( state, entity, route.userId, route.userName );
+		return;
+	}
+	if ( route.kind === 'media-detail' ) {
+		void renderMediaDetail( makeRenderHost( state ), route.mediaId );
+	}
+}
+
+/**
+ * Adapt the internal `RenderState` to the public `EntityRenderHost`
+ * contract consumed by registry-installed renderers. Hides the
+ * internal teardown / breadcrumb plumbing.
+ */
+function makeRenderHost( state: RenderState ): EntityRenderHost {
+	return {
+		body: state.body,
+		route: state.route,
+		navigate: ( route ) => navigate( state, route ),
+		addTeardown: ( fn ) => state.teardown.push( fn ),
+	};
+}
+
+/**
+ * Structural equality for `Route` discriminated-union values. Used
+ * to drop no-op re-navigations from the history stack — clicking
+ * the same tile twice shouldn't poison the back button.
+ */
+function routesEqual( a: Route, b: Route ): boolean {
+	if ( a.kind !== b.kind ) {
+		return false;
+	}
+	switch ( a.kind ) {
+		case 'root':
+			return true;
+		case 'list':
+			return a.entityId === ( b as { entityId: string } ).entityId;
+		case 'detail': {
+			const o = b as Extract< Route, { kind: 'detail' } >;
+			return a.entityId === o.entityId && a.postId === o.postId;
+		}
+		case 'sub-list': {
+			const o = b as Extract< Route, { kind: 'sub-list' } >;
+			return (
+				a.entityId === o.entityId &&
+				a.postId === o.postId &&
+				a.relation === o.relation
+			);
+		}
+		case 'user-footprint': {
+			const o = b as Extract< Route, { kind: 'user-footprint' } >;
+			return a.entityId === o.entityId && a.userId === o.userId;
+		}
+		case 'media-detail': {
+			const o = b as Extract< Route, { kind: 'media-detail' } >;
+			return a.entityId === o.entityId && a.mediaId === o.mediaId;
+		}
+		default:
+			return false;
 	}
 }
 
@@ -297,6 +390,8 @@ function parentRoute( route: Route ): Route {
 				postTitle: route.postTitle,
 			};
 		case 'user-footprint':
+			return { kind: 'list', entityId: route.entityId };
+		case 'media-detail':
 			return { kind: 'list', entityId: route.entityId };
 		default:
 			return { kind: 'root' };
@@ -380,15 +475,29 @@ function updateBreadcrumbs( state: RenderState ): void {
 			),
 		} );
 	}
+	if ( route.kind === 'media-detail' ) {
+		segments.push( { label: route.mediaTitle } );
+	}
 
 	renderBreadcrumbs( state.breadcrumbs, segments, {
 		onBack: () => {
 			if ( state.route.kind === 'root' ) {
 				return;
 			}
-			navigate( state, parentRoute( state.route ) );
+			// Prefer history (navigation back) over hierarchy
+			// (parent folder) so cross-tree jumps unwind in the
+			// order the user made them. Fall back to the parent
+			// route when there's no history — e.g. the consumer
+			// opened the window straight into a detail view via
+			// `wp.desktop.myWordpress.openDetail`.
+			const previous = state.history.pop();
+			if ( previous ) {
+				navigate( state, previous, { fromBack: true } );
+				return;
+			}
+			navigate( state, parentRoute( state.route ), { fromBack: true } );
 		},
-		backDisabled: isRoot,
+		backDisabled: isRoot && state.history.length === 0,
 	} );
 }
 
@@ -5353,6 +5462,7 @@ function renderInto( body: HTMLElement ): void {
 		breadcrumbs: breadcrumbsHost,
 		statusBar: statusHost,
 		teardown: [],
+		history: [],
 	};
 	activeState = state;
 
@@ -5424,6 +5534,40 @@ const callback: RenderCallback = ( body ) => {
 window.desktopModeNativeWindows = window.desktopModeNativeWindows || {};
 window.desktopModeNativeWindows[ WINDOW_ID ] = callback;
 
+// Built-in entity-kind renderers. Third-party plugins can register
+// their own via `wp.desktop.myWordpress.registerEntityKind()`.
+registerEntityKind( 'post', ( host, entity ) => {
+	renderEntityList( asRenderState( host ), entity );
+} );
+registerEntityKind( 'user', ( host, entity ) => {
+	renderUserEntityList( asRenderState( host ), entity );
+} );
+registerEntityKind( 'media', renderMediaList );
+
+/**
+ * Recover the internal `RenderState` from an `EntityRenderHost`.
+ * Only the legacy renderers (`renderEntityList`,
+ * `renderUserEntityList`) still take the internal state directly;
+ * the registry passes the public host shape so plugins can call
+ * `host.navigate` / `host.addTeardown`. This shim bridges the
+ * two during the gradual rewrite.
+ */
+function asRenderState( host: EntityRenderHost ): RenderState {
+	if ( ! activeState ) {
+		throw new Error(
+			'[my-wordpress] asRenderState: called outside an active render.',
+		);
+	}
+	// Sanity check — the host MUST be derived from the active state
+	// or we're about to scribble into a defunct render frame.
+	if ( host.body !== activeState.body ) {
+		throw new Error(
+			'[my-wordpress] asRenderState: host body does not match active state.',
+		);
+	}
+	return activeState;
+}
+
 /* ------------------------------------------------------------------ *
  *  Public API — `wp.desktop.myWordpress.openDetail( … )`.
  *
@@ -5475,8 +5619,49 @@ function openDetail( args: OpenDetailArgs ): void {
 	desktop?.openWindow?.( WINDOW_ID, { source: 'my-wordpress/open-detail' } );
 }
 
+interface OpenMediaArgs {
+	mediaId: number;
+	mediaTitle?: string;
+}
+
+/**
+ * Route the My WordPress window directly into the media drill-in
+ * view for the given attachment. Mirrors `openDetail()` for posts.
+ *
+ * @public
+ * @since 0.21.0
+ */
+function openMedia( args: OpenMediaArgs ): void {
+	const route: Route = {
+		kind: 'media-detail',
+		entityId: 'media',
+		mediaId: args.mediaId,
+		mediaTitle: args.mediaTitle ?? `#${ args.mediaId }`,
+	};
+	if ( activeState ) {
+		navigate( activeState, route );
+		return;
+	}
+	pendingRoute = route;
+	const desktop = (
+		window.wp as
+			| {
+					desktop?: {
+						openWindow?: (
+							id: string,
+							opts?: { source?: string },
+						) => boolean;
+					};
+			}
+			| undefined
+	)?.desktop;
+	desktop?.openWindow?.( WINDOW_ID, { source: 'my-wordpress/open-media' } );
+}
+
 interface MyWordpressApi {
 	openDetail: ( args: OpenDetailArgs ) => void;
+	openMedia: ( args: OpenMediaArgs ) => void;
+	registerEntityKind: ( kind: string, renderer: EntityRenderer ) => () => void;
 }
 
 const desktopGlobal = (
@@ -5485,5 +5670,9 @@ const desktopGlobal = (
 		| undefined
 )?.desktop;
 if ( desktopGlobal ) {
-	desktopGlobal.myWordpress = { openDetail };
+	desktopGlobal.myWordpress = {
+		openDetail,
+		openMedia,
+		registerEntityKind,
+	};
 }

--- a/src/my-wordpress/kind-registry.ts
+++ b/src/my-wordpress/kind-registry.ts
@@ -1,0 +1,123 @@
+/**
+ * My WordPress — entity-kind renderer registry.
+ *
+ * The window's `navigate()` switch used to hardcode the three
+ * in-tree kinds (`post`, `user`, `media`). The registry decouples
+ * the dispatch from the bundle: third-party plugins can ship their
+ * own section type by calling
+ * `wp.desktop.myWordpress.registerEntityKind(kind, renderer)`
+ * before (or after) the window mounts, and the dispatcher will
+ * find it.
+ *
+ * Renderers receive an opaque host object that exposes the public
+ * `navigate` / `state` surface they need — internal types stay
+ * private to `index.ts`.
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+import type { MyWordPressEntity, Route } from './types';
+
+/**
+ * Surface passed to every renderer. The renderer paints into
+ * `body` and may call `navigate` to move the window to another
+ * route.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export interface EntityRenderHost {
+	/** The window body element the renderer should paint into. */
+	body: HTMLElement;
+	/** Active route at render time. */
+	route: Route;
+	/**
+	 * Navigate the window to a new route. The host owns history
+	 * and breadcrumb chrome — renderers only paint inside `body`.
+	 */
+	navigate: ( route: Route ) => void;
+	/**
+	 * Push a tear-down callback fired when the window is closed or
+	 * the user navigates away. Renderers MUST use this for any
+	 * subscription / observer / timer they create.
+	 */
+	addTeardown: ( fn: () => void ) => void;
+}
+
+/**
+ * Renderer callback signature. Receives the host + the entity
+ * descriptor whose section is being entered.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export type EntityRenderer = (
+	host: EntityRenderHost,
+	entity: MyWordPressEntity,
+) => void;
+
+const renderers = new Map< string, EntityRenderer >();
+
+/**
+ * Register a renderer for a given entity kind. The latest call
+ * wins — plugins re-registering an in-tree kind override the
+ * default, by design.
+ *
+ * @public
+ * @since 0.21.0
+ *
+ * @param kind     Entity kind slug (`'post'`, `'user'`, plugin slug).
+ * @param renderer Render callback.
+ * @return Unregister function — calling it removes ONLY this
+ *         renderer (the registry then falls back to nothing for
+ *         the kind).
+ */
+export function registerEntityKind(
+	kind: string,
+	renderer: EntityRenderer,
+): () => void {
+	if ( typeof kind !== 'string' || kind === '' ) {
+		throw new TypeError(
+			'[my-wordpress] registerEntityKind: kind must be a non-empty string.',
+		);
+	}
+	if ( typeof renderer !== 'function' ) {
+		throw new TypeError(
+			'[my-wordpress] registerEntityKind: renderer must be a function.',
+		);
+	}
+	renderers.set( kind, renderer );
+	return () => {
+		if ( renderers.get( kind ) === renderer ) {
+			renderers.delete( kind );
+		}
+	};
+}
+
+/**
+ * Look up the renderer for a given kind. Returns `undefined` when
+ * no renderer is registered — the dispatcher in `index.ts` paints
+ * a generic "unknown kind" error in that case.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function getEntityRenderer(
+	kind: string | undefined,
+): EntityRenderer | undefined {
+	if ( ! kind ) {
+		return renderers.get( 'post' );
+	}
+	return renderers.get( kind );
+}
+
+/**
+ * Snapshot of registered kinds — diagnostics only.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function listRegisteredKinds(): string[] {
+	return Array.from( renderers.keys() );
+}

--- a/src/my-wordpress/media-detail.ts
+++ b/src/my-wordpress/media-detail.ts
@@ -21,18 +21,40 @@
 import { __, _n, sprintf } from '../i18n';
 import { applyFilters } from '../hooks';
 import { renderStatusBarSegments, type StatusBarSegment } from '../desktop-files/folder-status-bar';
-import type { DragManagerApi } from '../drag';
 import type { ShortcutDragData } from '../desktop-files/drag-payloads';
 import type { EntityRenderHost } from './kind-registry';
 import type { MediaUsage } from './types';
 import { fetchMediaUsage } from './media-rest';
 import { dashiconForMime } from './media-preview';
+import { getConfig } from './rest';
+import { getDragManager } from './dom-utils';
 
-function getDragManager(): DragManagerApi | null {
-	const api = (
-		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
-	).wp?.desktop?.dragManager;
-	return api ?? null;
+/**
+ * Resolve a row's `postType` to a My WordPress entity id.
+ *
+ * Strategy:
+ *   1. Find an entity whose `restPath` ends in the post type slug
+ *      (e.g. `wp/v2/product` for WooCommerce's `product` CPT).
+ *      That's the most reliable match — restPath is what the
+ *      detail-view fetcher uses.
+ *   2. Fall back to the built-in `'posts'` / `'pages'` ids when
+ *      no custom entity is registered.
+ *   3. Last resort: `'posts'`, knowing the detail-view fetch will
+ *      404 if the CPT isn't reachable under `wp/v2/posts`. That's
+ *      better than silently ignoring the click — the empty pane
+ *      makes the gap visible.
+ */
+function entityIdForPostType( postType: string ): string {
+	const entities = getConfig().entities;
+	const suffix = '/' + postType;
+	const match = entities.find( ( e ) => e.restPath.endsWith( suffix ) );
+	if ( match ) {
+		return match.id;
+	}
+	if ( postType === 'page' ) {
+		return 'pages';
+	}
+	return 'posts';
 }
 
 function openDetailInWindow( payload: {
@@ -236,7 +258,15 @@ export async function renderMediaDetail(
 		return;
 	}
 
-	const entityId = host.route.kind === 'media-detail' ? host.route.entityId : 'media';
+	// `renderMediaDetail` is only ever dispatched when the active
+	// route is `media-detail` — the type-narrowed `entityId` is the
+	// section we're inside.
+	if ( host.route.kind !== 'media-detail' ) {
+		throw new Error(
+			'[my-wordpress] renderMediaDetail invoked outside a media-detail route.',
+		);
+	}
+	const entityId = host.route.entityId;
 
 	// Right pane: source media on top, selected referrer below.
 	const sourceWrap = document.createElement( 'header' );
@@ -279,8 +309,7 @@ export async function renderMediaDetail(
 		const tile = buildUsageRow( row );
 		tile.addEventListener( 'click', () => {
 			openDetailInWindow( {
-				entityId:
-					row.postType === 'page' ? 'pages' : 'posts',
+				entityId: entityIdForPostType( row.postType ),
 				postId: row.postId,
 				postTitle: row.title,
 			} );

--- a/src/my-wordpress/media-detail.ts
+++ b/src/my-wordpress/media-detail.ts
@@ -1,0 +1,293 @@
+/**
+ * My WordPress — Media drill-in view.
+ *
+ * Triggered by double-clicking a media tile (or clicking "See where
+ * this is used" in the preview pane). Fetches
+ * `/desktop-mode/v1/media-usage/<id>` and renders one tile per
+ * referencing post/page/CPT, grouped by post type. The right pane
+ * stays type-aware (preview of the media on top + a list of the
+ * selected referrer).
+ *
+ * Nothing here ever accepts a drop — the section relies on the
+ * window-level reject claimant set up by `renderInto`. Media tiles
+ * in the left list ARE drag sources (same `kind:'attachment'`
+ * payload the browse-view uses) so the user can still drag a
+ * media item out from here.
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+import { __, _n, sprintf } from '../i18n';
+import { applyFilters } from '../hooks';
+import { renderStatusBarSegments, type StatusBarSegment } from '../desktop-files/folder-status-bar';
+import type { DragManagerApi } from '../drag';
+import type { ShortcutDragData } from '../desktop-files/drag-payloads';
+import type { EntityRenderHost } from './kind-registry';
+import type { MediaUsage } from './types';
+import { fetchMediaUsage } from './media-rest';
+import { dashiconForMime } from './media-preview';
+
+function getDragManager(): DragManagerApi | null {
+	const api = (
+		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
+	).wp?.desktop?.dragManager;
+	return api ?? null;
+}
+
+function openDetailInWindow( payload: {
+	entityId: string;
+	postId: number;
+	postTitle: string;
+} ): void {
+	interface MyWpApi {
+		openDetail?: ( args: {
+			entityId: string;
+			postId: number;
+			postTitle: string;
+		} ) => void;
+	}
+	const myWp = (
+		window.wp as { desktop?: { myWordpress?: MyWpApi } } | undefined
+	)?.desktop?.myWordpress;
+	myWp?.openDetail?.( payload );
+}
+
+function buildMediaSourceTile( usage: MediaUsage ): HTMLElement {
+	// The drill-in view still exposes the source attachment as a
+	// drag handle in the preview header — so the user can drag-out
+	// from this view too.
+	const tile = document.createElement( 'button' );
+	tile.type = 'button';
+	tile.className =
+		'desktop-mode-my-wordpress__media-source-tile desktop-mode-file-tile';
+	tile.dataset.mediaId = String( usage.media.id );
+
+	const thumbWrap = document.createElement( 'span' );
+	thumbWrap.className = 'desktop-mode-my-wordpress__media-tile-thumb';
+	thumbWrap.setAttribute( 'aria-hidden', 'true' );
+	if ( usage.media.mime.startsWith( 'image/' ) ) {
+		const img = document.createElement( 'img' );
+		img.src = usage.media.sourceUrl;
+		img.alt = usage.media.title;
+		img.loading = 'lazy';
+		thumbWrap.appendChild( img );
+	} else {
+		const icon = document.createElement( 'span' );
+		icon.className = `dashicons ${ dashiconForMime( usage.media.mime ) }`;
+		thumbWrap.appendChild( icon );
+	}
+	tile.appendChild( thumbWrap );
+
+	const label = document.createElement( 'span' );
+	label.className = 'desktop-mode-file-tile__label';
+	label.textContent = usage.media.title;
+	tile.appendChild( label );
+
+	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		if ( e.button !== 0 ) {
+			return;
+		}
+		const dragManager = getDragManager();
+		if ( ! dragManager ) {
+			return;
+		}
+		dragManager.start( {
+			payload: {
+				type: 'shortcut',
+				source: tile,
+				data: {
+					kind: 'attachment',
+					ref: String( usage.media.id ),
+					title: usage.media.title,
+					icon: dashiconForMime( usage.media.mime ),
+				} satisfies ShortcutDragData,
+				ghost: {
+					offsetX: e.clientX - tile.getBoundingClientRect().left,
+					offsetY: e.clientY - tile.getBoundingClientRect().top,
+				},
+			},
+			origin: e,
+		} );
+	} );
+
+	return tile;
+}
+
+function buildUsageRow( row: MediaUsage[ 'usedIn' ][ number ] ): HTMLElement {
+	const tile = document.createElement( 'button' );
+	tile.type = 'button';
+	tile.className =
+		'desktop-mode-my-wordpress__usage-row desktop-mode-file-tile';
+	tile.dataset.postId = String( row.postId );
+	tile.dataset.postType = row.postType;
+
+	const iconWrap = document.createElement( 'span' );
+	iconWrap.className = 'desktop-mode-my-wordpress__usage-icon';
+	iconWrap.setAttribute( 'aria-hidden', 'true' );
+	const icon = document.createElement( 'span' );
+	icon.className =
+		row.postType === 'page'
+			? 'dashicons dashicons-admin-page'
+			: 'dashicons dashicons-admin-post';
+	iconWrap.appendChild( icon );
+	tile.appendChild( iconWrap );
+
+	const text = document.createElement( 'span' );
+	text.className = 'desktop-mode-my-wordpress__usage-text';
+	const title = document.createElement( 'span' );
+	title.className = 'desktop-mode-my-wordpress__usage-title';
+	title.textContent = row.title || `#${ row.postId }`;
+	text.appendChild( title );
+
+	const meta = document.createElement( 'span' );
+	meta.className = 'desktop-mode-my-wordpress__usage-meta';
+	const usedAsLabel: Record< MediaUsage[ 'usedIn' ][ number ][ 'usedAs' ], string > = {
+		featured: __( 'Featured image', 'desktop-mode' ),
+		content: __( 'Embedded in content', 'desktop-mode' ),
+		meta: __( 'In meta field', 'desktop-mode' ),
+	};
+	meta.textContent = `${ row.postTypeLabel } · ${ usedAsLabel[ row.usedAs ] }`;
+	text.appendChild( meta );
+
+	tile.appendChild( text );
+	return tile;
+}
+
+function paintStatus(
+	statusBar: HTMLElement,
+	count: number,
+	entityId: string,
+): void {
+	const segments: StatusBarSegment[] = [
+		{
+			id: 'count',
+			label: sprintf(
+				// translators: %d is the count of posts that reference an attachment.
+				_n( '%d reference', '%d references', count ),
+				count,
+			),
+			align: 'start',
+			sort: 10,
+		},
+	];
+	const filtered = applyFilters<
+		StatusBarSegment[],
+		[ { view: 'media-detail'; entityId: string } ]
+	>(
+		'desktop-mode.my-wordpress.status-bar',
+		segments,
+		{ view: 'media-detail', entityId },
+	);
+	renderStatusBarSegments(
+		statusBar,
+		Array.isArray( filtered ) ? filtered : segments,
+	);
+}
+
+/**
+ * Render the "used in" drill-in view.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export async function renderMediaDetail(
+	host: EntityRenderHost,
+	mediaId: number,
+): Promise< void > {
+	const wrap = document.createElement( 'div' );
+	wrap.className =
+		'desktop-mode-my-wordpress__split desktop-mode-my-wordpress__split--media-detail';
+
+	const left = document.createElement( 'div' );
+	left.className = 'desktop-mode-my-wordpress__list desktop-mode-my-wordpress__usage-list';
+
+	const loading = document.createElement( 'div' );
+	loading.className = 'desktop-mode-my-wordpress__preview-loading';
+	const spinner = document.createElement( 'wpd-spinner' );
+	loading.appendChild( spinner );
+	left.appendChild( loading );
+
+	const right = document.createElement( 'div' );
+	right.className = 'desktop-mode-my-wordpress__preview';
+
+	wrap.append( left, right );
+	host.body.appendChild( wrap );
+
+	const statusBar =
+		host.body
+			.closest( '[data-desktop-mode-my-wordpress-root]' )
+			?.querySelector< HTMLElement >(
+				'[data-desktop-mode-my-wordpress-status]',
+			) ?? document.createElement( 'div' );
+
+	let usage: MediaUsage;
+	try {
+		usage = await fetchMediaUsage( mediaId );
+	} catch ( err ) {
+		left.replaceChildren();
+		const errBox = document.createElement( 'div' );
+		errBox.className = 'desktop-mode-my-wordpress__error';
+		errBox.textContent =
+			err instanceof Error
+				? err.message
+				: __( 'Failed to load usage data.', 'desktop-mode' );
+		left.appendChild( errBox );
+		return;
+	}
+
+	const entityId = host.route.kind === 'media-detail' ? host.route.entityId : 'media';
+
+	// Right pane: source media on top, selected referrer below.
+	const sourceWrap = document.createElement( 'header' );
+	sourceWrap.className = 'desktop-mode-my-wordpress__media-detail-header';
+	sourceWrap.appendChild( buildMediaSourceTile( usage ) );
+
+	const summary = document.createElement( 'p' );
+	summary.className = 'desktop-mode-my-wordpress__media-detail-summary';
+	summary.textContent = sprintf(
+		// translators: %d is the count of posts/pages referencing this file.
+		_n(
+			'%d entry references this file.',
+			'%d entries reference this file.',
+			usage.usedIn.length,
+		),
+		usage.usedIn.length,
+	);
+	sourceWrap.appendChild( summary );
+
+	right.replaceChildren( sourceWrap );
+
+	// Left pane: list of references.
+	left.replaceChildren();
+	if ( usage.usedIn.length === 0 ) {
+		const empty = document.createElement( 'div' );
+		empty.className = 'desktop-mode-my-wordpress__empty';
+		empty.textContent = __(
+			'No posts or pages reference this file.',
+			'desktop-mode',
+		);
+		left.appendChild( empty );
+		paintStatus( statusBar, 0, entityId );
+		return;
+	}
+
+	const list = document.createElement( 'div' );
+	list.className = 'desktop-mode-my-wordpress__usage-rows';
+	list.setAttribute( 'role', 'list' );
+	for ( const row of usage.usedIn ) {
+		const tile = buildUsageRow( row );
+		tile.addEventListener( 'click', () => {
+			openDetailInWindow( {
+				entityId:
+					row.postType === 'page' ? 'pages' : 'posts',
+				postId: row.postId,
+				postTitle: row.title,
+			} );
+		} );
+		list.appendChild( tile );
+	}
+	left.appendChild( list );
+
+	paintStatus( statusBar, usage.usedIn.length, entityId );
+}

--- a/src/my-wordpress/media-detail.ts
+++ b/src/my-wordpress/media-detail.ts
@@ -30,24 +30,23 @@ import { getConfig } from './rest';
 import { getDragManager } from './dom-utils';
 
 /**
- * Resolve a row's `postType` to a My WordPress entity id.
+ * Resolve a row's `postType` to the matching My WordPress entity.
  *
  * Strategy:
  *   1. Find an entity whose `restPath` ends in the post type slug
  *      (e.g. `wp/v2/product` for WooCommerce's `product` CPT).
- *      That's the most reliable match — restPath is what the
- *      detail-view fetcher uses.
- *   2. Fall back to the built-in `'posts'` / `'pages'` ids when
- *      no custom entity is registered.
- *   3. Last resort: `'posts'`, knowing the detail-view fetch will
- *      404 if the CPT isn't reachable under `wp/v2/posts`. That's
- *      better than silently ignoring the click — the empty pane
- *      makes the gap visible.
+ *      restPath is what the detail-view fetcher uses, so this is
+ *      the most reliable match.
+ *   2. Returns `undefined` when no entity is registered — caller
+ *      decides on a fallback (id, icon, etc.).
  */
-function entityIdForPostType( postType: string ): string {
-	const entities = getConfig().entities;
+function entityForPostType( postType: string ) {
 	const suffix = '/' + postType;
-	const match = entities.find( ( e ) => e.restPath.endsWith( suffix ) );
+	return getConfig().entities.find( ( e ) => e.restPath.endsWith( suffix ) );
+}
+
+function entityIdForPostType( postType: string ): string {
+	const match = entityForPostType( postType );
 	if ( match ) {
 		return match.id;
 	}
@@ -55,6 +54,17 @@ function entityIdForPostType( postType: string ): string {
 		return 'pages';
 	}
 	return 'posts';
+}
+
+function entityIconForPostType( postType: string ): string {
+	const match = entityForPostType( postType );
+	if ( match ) {
+		return match.icon;
+	}
+	if ( postType === 'page' ) {
+		return 'dashicons-admin-page';
+	}
+	return 'dashicons-admin-post';
 }
 
 function openDetailInWindow( payload: {
@@ -148,10 +158,7 @@ function buildUsageRow( row: MediaUsage[ 'usedIn' ][ number ] ): HTMLElement {
 	iconWrap.className = 'desktop-mode-my-wordpress__usage-icon';
 	iconWrap.setAttribute( 'aria-hidden', 'true' );
 	const icon = document.createElement( 'span' );
-	icon.className =
-		row.postType === 'page'
-			? 'dashicons dashicons-admin-page'
-			: 'dashicons dashicons-admin-post';
+	icon.className = `dashicons ${ entityIconForPostType( row.postType ) }`;
 	iconWrap.appendChild( icon );
 	tile.appendChild( iconWrap );
 
@@ -247,6 +254,9 @@ export async function renderMediaDetail(
 	try {
 		usage = await fetchMediaUsage( mediaId );
 	} catch ( err ) {
+		if ( ! wrap.isConnected ) {
+			return;
+		}
 		left.replaceChildren();
 		const errBox = document.createElement( 'div' );
 		errBox.className = 'desktop-mode-my-wordpress__error';
@@ -255,6 +265,17 @@ export async function renderMediaDetail(
 				? err.message
 				: __( 'Failed to load usage data.', 'desktop-mode' );
 		left.appendChild( errBox );
+		return;
+	}
+
+	// Guard against the user navigating away while the fetch was
+	// in flight. `navigate()` calls `state.body.replaceChildren()`
+	// which detaches `wrap`; the status bar lives in a sibling
+	// region and would otherwise be overwritten by stale data
+	// from this resolved promise. The `host.route` snapshot
+	// captured in `makeRenderHost()` is FROZEN at dispatch time —
+	// we can't trust it to reflect the live route.
+	if ( ! wrap.isConnected ) {
 		return;
 	}
 

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -18,26 +18,13 @@
 import { __, _n, sprintf } from '../i18n';
 import { renderStatusBarSegments, type StatusBarSegment } from '../desktop-files/folder-status-bar';
 import { applyFilters } from '../hooks';
-import type { DragManagerApi } from '../drag';
 import type { ShortcutDragData } from '../desktop-files/drag-payloads';
 import type { EntityRenderHost } from './kind-registry';
 import type { MediaListItem, MyWordPressEntity, MediaPreviewAction } from './types';
 import { fetchMediaPage } from './media-rest';
 import { getConfig } from './rest';
 import { dashiconForMime, renderMediaPreview } from './media-preview';
-
-function getDragManager(): DragManagerApi | null {
-	const api = (
-		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
-	).wp?.desktop?.dragManager;
-	return api ?? null;
-}
-
-function stripTags( html: string ): string {
-	const div = document.createElement( 'div' );
-	div.innerHTML = html;
-	return ( div.textContent ?? '' ).trim();
-}
+import { getDragManager, stripTags } from './dom-utils';
 
 interface MediaListContext {
 	page: number;
@@ -380,6 +367,19 @@ export function renderMediaList(
 		);
 		observer.observe( sentinel );
 		host.addTeardown( () => observer.disconnect() );
+	} else {
+		// Graceful fallback for environments without
+		// IntersectionObserver (very old browsers, some test
+		// harnesses). A scroll-driven check keeps infinite scroll
+		// working — measurably less efficient, but better than
+		// page-1-only.
+		const onScroll = () => {
+			if ( sentinelIsVisible() ) {
+				void loadMore();
+			}
+		};
+		left.addEventListener( 'scroll', onScroll, { passive: true } );
+		host.addTeardown( () => left.removeEventListener( 'scroll', onScroll ) );
 	}
 
 	paintStatus( ctx );

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -1,0 +1,387 @@
+/**
+ * My WordPress — Media browse view.
+ *
+ * Two-pane layout: a CSS Grid of thumbnail tiles on the left, a
+ * type-aware preview pane on the right. Newest-first, paged via
+ * IntersectionObserver. Each tile is a drag source (`kind:
+ * 'attachment'`); the section never accepts drops — the window-
+ * level reject claimant set up by `renderInto()` handles that.
+ *
+ * Plugins extend the right pane via the
+ * `desktop-mode.my-wordpress.preview-actions` JS filter (paired with
+ * the PHP `desktop_mode_my_wordpress_preview_actions` descriptor).
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+import { __, _n, sprintf } from '../i18n';
+import { renderStatusBarSegments, type StatusBarSegment } from '../desktop-files/folder-status-bar';
+import { applyFilters } from '../hooks';
+import type { DragManagerApi } from '../drag';
+import type { ShortcutDragData } from '../desktop-files/drag-payloads';
+import type { EntityRenderHost } from './kind-registry';
+import type { MediaListItem, MyWordPressEntity, MediaPreviewAction } from './types';
+import { fetchMediaPage } from './media-rest';
+import { getConfig } from './rest';
+import { dashiconForMime, renderMediaPreview } from './media-preview';
+
+function getDragManager(): DragManagerApi | null {
+	const api = (
+		window as { wp?: { desktop?: { dragManager?: DragManagerApi } } }
+	).wp?.desktop?.dragManager;
+	return api ?? null;
+}
+
+function stripTags( html: string ): string {
+	const div = document.createElement( 'div' );
+	div.innerHTML = html;
+	return ( div.textContent ?? '' ).trim();
+}
+
+interface MediaListContext {
+	page: number;
+	totalPages: number;
+	total: number;
+	loaded: number;
+	loading: boolean;
+	done: boolean;
+	tiles: HTMLElement;
+	sentinel: HTMLElement;
+	preview: HTMLElement;
+	selectedId: number | null;
+	selectedTile: HTMLElement | null;
+	statusBar: HTMLElement;
+	entity: MyWordPressEntity;
+	host: EntityRenderHost;
+	previewActions: MediaPreviewAction[];
+}
+
+function describeCount( ctx: MediaListContext ): string {
+	if ( ctx.total === 0 && ctx.loaded === 0 ) {
+		return __( 'No media yet.', 'desktop-mode' );
+	}
+	if ( ctx.total > ctx.loaded && ctx.loaded > 0 ) {
+		return sprintf(
+			// translators: 1: visible item count, 2: total item count.
+			__( '%1$d of %2$d items', 'desktop-mode' ),
+			ctx.loaded,
+			ctx.total,
+		);
+	}
+	const n = Math.max( ctx.total, ctx.loaded );
+	return sprintf(
+		// translators: %d is a count of media items.
+		_n( '%d item', '%d items', n ),
+		n,
+	);
+}
+
+function paintStatus( ctx: MediaListContext ): void {
+	const segments: StatusBarSegment[] = [
+		{
+			id: 'count',
+			label: describeCount( ctx ),
+			align: 'start',
+			sort: 10,
+		},
+	];
+	if ( ctx.totalPages > 1 ) {
+		segments.push( {
+			id: 'page',
+			label: sprintf(
+				// translators: 1: current page, 2: total pages.
+				__( 'Page %1$d of %2$d', 'desktop-mode' ),
+				Math.max( ctx.page, 1 ),
+				ctx.totalPages,
+			),
+			align: 'end',
+			sort: 10,
+		} );
+	}
+	const filtered = applyFilters<
+		StatusBarSegment[],
+		[ { view: 'list'; entityId: string } ]
+	>(
+		'desktop-mode.my-wordpress.status-bar',
+		segments,
+		{ view: 'list', entityId: ctx.entity.id },
+	);
+	renderStatusBarSegments(
+		ctx.statusBar,
+		Array.isArray( filtered ) ? filtered : segments,
+	);
+}
+
+function buildMediaTile(
+	ctx: MediaListContext,
+	media: MediaListItem,
+): HTMLElement {
+	const titleText =
+		stripTags( media.title.rendered ) || __( '(no title)', 'desktop-mode' );
+	const tile = document.createElement( 'button' );
+	tile.type = 'button';
+	tile.className =
+		'desktop-mode-my-wordpress__media-tile desktop-mode-file-tile desktop-mode-my-wordpress__tile desktop-mode-my-wordpress__tile--media';
+	tile.setAttribute( 'role', 'listitem' );
+	tile.dataset.mediaId = String( media.id );
+	tile.dataset.mime = media.mime_type;
+
+	const thumbWrap = document.createElement( 'span' );
+	thumbWrap.className = 'desktop-mode-my-wordpress__media-tile-thumb';
+	thumbWrap.setAttribute( 'aria-hidden', 'true' );
+
+	const sizes = media.media_details?.sizes;
+	const thumbUrl =
+		media.mime_type.startsWith( 'image/' )
+			? (
+				sizes?.thumbnail?.source_url ??
+					sizes?.medium?.source_url ??
+					media.source_url
+			)
+			: '';
+	if ( thumbUrl ) {
+		const img = document.createElement( 'img' );
+		img.src = thumbUrl;
+		img.alt = '';
+		img.loading = 'lazy';
+		img.decoding = 'async';
+		thumbWrap.appendChild( img );
+	} else {
+		const icon = document.createElement( 'span' );
+		icon.className = `dashicons ${ dashiconForMime( media.mime_type ) }`;
+		thumbWrap.appendChild( icon );
+	}
+	tile.appendChild( thumbWrap );
+
+	const label = document.createElement( 'span' );
+	label.className = 'desktop-mode-file-tile__label';
+	label.textContent = titleText;
+	tile.appendChild( label );
+
+	// Drag-out: the user drops a media tile on the wallpaper / inside
+	// a folder window — the `'attachment'` file type already has a
+	// server resolver + opener.
+	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		if ( e.button !== 0 ) {
+			return;
+		}
+		const dragManager = getDragManager();
+		if ( ! dragManager ) {
+			return;
+		}
+		dragManager.start( {
+			payload: {
+				type: 'shortcut',
+				source: tile,
+				data: {
+					kind: 'attachment',
+					ref: String( media.id ),
+					title: titleText,
+					icon: dashiconForMime( media.mime_type ),
+				} satisfies ShortcutDragData,
+				ghost: {
+					offsetX: e.clientX - tile.getBoundingClientRect().left,
+					offsetY: e.clientY - tile.getBoundingClientRect().top,
+				},
+			},
+			origin: e,
+		} );
+	} );
+
+	tile.addEventListener( 'click', () => selectTile( ctx, tile, media ) );
+	tile.addEventListener( 'dblclick', ( e ) => {
+		e.preventDefault();
+		ctx.host.navigate( {
+			kind: 'media-detail',
+			entityId: ctx.entity.id,
+			mediaId: media.id,
+			mediaTitle: titleText,
+		} );
+	} );
+
+	return tile;
+}
+
+function selectTile(
+	ctx: MediaListContext,
+	tile: HTMLElement,
+	media: MediaListItem,
+): void {
+	if ( ctx.selectedTile ) {
+		ctx.selectedTile.classList.remove(
+			'desktop-mode-my-wordpress__tile--selected',
+		);
+	}
+	tile.classList.add( 'desktop-mode-my-wordpress__tile--selected' );
+	ctx.selectedTile = tile;
+	ctx.selectedId = media.id;
+
+	const titleText =
+		stripTags( media.title.rendered ) || __( '(no title)', 'desktop-mode' );
+	renderMediaPreview( ctx.preview, media, {
+		entityId: ctx.entity.id,
+		previewActions: ctx.previewActions,
+		onOpenDetail: () => {
+			ctx.host.navigate( {
+				kind: 'media-detail',
+				entityId: ctx.entity.id,
+				mediaId: media.id,
+				mediaTitle: titleText,
+			} );
+		},
+	} );
+}
+
+function renderEmpty( host: HTMLElement, message: string ): void {
+	const empty = document.createElement( 'div' );
+	empty.className = 'desktop-mode-my-wordpress__empty';
+	empty.textContent = message;
+	host.appendChild( empty );
+}
+
+/**
+ * Paint the Media browse view into `host.body`.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function renderMediaList(
+	host: EntityRenderHost,
+	entity: MyWordPressEntity,
+): void {
+	const cfg = getConfig();
+
+	const split = document.createElement( 'div' );
+	split.className =
+		'desktop-mode-my-wordpress__split desktop-mode-my-wordpress__split--media';
+
+	const left = document.createElement( 'div' );
+	left.className = 'desktop-mode-my-wordpress__list';
+
+	const tiles = document.createElement( 'div' );
+	tiles.className =
+		'desktop-mode-my-wordpress__media-grid';
+	tiles.setAttribute( 'role', 'list' );
+	left.appendChild( tiles );
+
+	const sentinel = document.createElement( 'div' );
+	sentinel.className = 'desktop-mode-my-wordpress__sentinel';
+	sentinel.setAttribute( 'aria-hidden', 'true' );
+	left.appendChild( sentinel );
+
+	const right = document.createElement( 'div' );
+	right.className = 'desktop-mode-my-wordpress__preview';
+	const previewEmpty = document.createElement( 'div' );
+	previewEmpty.className = 'desktop-mode-my-wordpress__preview-empty';
+	previewEmpty.textContent = __(
+		'Select a media item to preview it here.',
+		'desktop-mode',
+	);
+	right.appendChild( previewEmpty );
+
+	split.append( left, right );
+	host.body.appendChild( split );
+
+	// Locate the window status bar (mounted by the host) so we can
+	// repaint it as pages load. If absent (test harness, custom
+	// chrome), paint into a detached element — `renderStatusBarSegments`
+	// tolerates a host that isn't in the DOM.
+	const statusBar =
+		host.body
+			.closest( '[data-desktop-mode-my-wordpress-root]' )
+			?.querySelector< HTMLElement >(
+				'[data-desktop-mode-my-wordpress-status]',
+			) ?? document.createElement( 'div' );
+
+	const ctx: MediaListContext = {
+		page: 0,
+		totalPages: 1,
+		total: 0,
+		loaded: 0,
+		loading: false,
+		done: false,
+		tiles,
+		sentinel,
+		preview: right,
+		selectedId: null,
+		selectedTile: null,
+		statusBar,
+		entity,
+		host,
+		previewActions: cfg.previewActions ?? [],
+	};
+
+	const sentinelIsVisible = (): boolean => {
+		const sr = sentinel.getBoundingClientRect();
+		const rr = left.getBoundingClientRect();
+		const slack = 200;
+		return sr.top < rr.bottom + slack && sr.bottom > rr.top - slack;
+	};
+
+	const loadMore = async () => {
+		if ( ctx.loading || ctx.done ) {
+			return;
+		}
+		ctx.loading = true;
+		const nextPage = ctx.page + 1;
+		const perPage = cfg.mediaPerPage ?? 48;
+		try {
+			const result = await fetchMediaPage( entity, {
+				page: nextPage,
+				perPage,
+			} );
+			ctx.page = nextPage;
+			ctx.totalPages = result.totalPages;
+			ctx.total = result.total;
+			if ( result.items.length === 0 && nextPage === 1 ) {
+				renderEmpty( tiles, __( 'No media yet.', 'desktop-mode' ) );
+				ctx.done = true;
+				paintStatus( ctx );
+				return;
+			}
+			for ( const item of result.items ) {
+				tiles.appendChild( buildMediaTile( ctx, item ) );
+				ctx.loaded += 1;
+			}
+			if ( ctx.page >= ctx.totalPages ) {
+				ctx.done = true;
+			}
+			paintStatus( ctx );
+		} catch ( err ) {
+			const message =
+				err instanceof Error
+					? err.message
+					: __( 'Unknown error.', 'desktop-mode' );
+			renderEmpty( tiles, message );
+			ctx.done = true;
+		} finally {
+			ctx.loading = false;
+		}
+		if ( ! ctx.done ) {
+			requestAnimationFrame( () => {
+				if ( sentinelIsVisible() ) {
+					void loadMore();
+				}
+			} );
+		}
+	};
+
+	if ( typeof IntersectionObserver !== 'undefined' ) {
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				for ( const e of entries ) {
+					if ( e.isIntersecting ) {
+						void loadMore();
+					}
+				}
+			},
+			{ root: left, rootMargin: '200px 0px' },
+		);
+		observer.observe( sentinel );
+		host.addTeardown( () => observer.disconnect() );
+	}
+
+	paintStatus( ctx );
+	void loadMore();
+}

--- a/src/my-wordpress/media-preview.ts
+++ b/src/my-wordpress/media-preview.ts
@@ -21,8 +21,9 @@
  * @since 0.21.0
  */
 
-import { __, sprintf } from '../i18n';
+import { __ } from '../i18n';
 import { applyFilters, doAction } from '../hooks';
+import { stripTags } from './dom-utils';
 import type {
 	MediaListItem,
 	MediaPreviewAction,
@@ -37,7 +38,7 @@ const MIME_DASHICON_MAP: Array< { test: RegExp; icon: string } > = [
 	{ test: /^video\//, icon: 'dashicons-format-video' },
 	{ test: /^audio\//, icon: 'dashicons-format-audio' },
 	{ test: /pdf$/, icon: 'dashicons-media-document' },
-	{ test: /^application\/zip|x-tar|x-rar|x-7z/, icon: 'dashicons-media-archive' },
+	{ test: /^application\/(zip|x-tar|x-rar|x-7z)/, icon: 'dashicons-media-archive' },
 	{ test: /spreadsheet|excel/, icon: 'dashicons-media-spreadsheet' },
 	{ test: /word|document/, icon: 'dashicons-media-document' },
 	{ test: /^text\//, icon: 'dashicons-media-text' },
@@ -101,12 +102,6 @@ function formatDate( iso: string | undefined ): string {
 		month: 'short',
 		day: 'numeric',
 	} );
-}
-
-function stripTags( html: string ): string {
-	const div = document.createElement( 'div' );
-	div.innerHTML = html;
-	return ( div.textContent ?? '' ).trim();
 }
 
 function buildMediaVisual( media: MediaListItem ): HTMLElement {
@@ -182,27 +177,30 @@ function buildMediaVisual( media: MediaListItem ): HTMLElement {
 	return wrap;
 }
 
+/**
+ * Build a single `<dt>` + `<dd>` pair for the metadata grid. The
+ * outer `<dl>` keeps the semantic list intact for screen readers
+ * that support definition-list navigation; CSS Grid handles the
+ * two-column layout via `display: contents` on the wrapper.
+ */
 function buildMetaRow(
-	dt: string,
-	dd: string | HTMLElement,
-): HTMLElement | null {
-	if ( typeof dd === 'string' && dd.trim() === '' ) {
+	label: string,
+	value: string | HTMLElement,
+): Array< HTMLElement > | null {
+	if ( typeof value === 'string' && value.trim() === '' ) {
 		return null;
 	}
-	const row = document.createElement( 'div' );
-	row.className = 'desktop-mode-my-wordpress__media-meta-row';
-	const term = document.createElement( 'span' );
-	term.className = 'desktop-mode-my-wordpress__media-meta-term';
-	term.textContent = dt;
-	const val = document.createElement( 'span' );
-	val.className = 'desktop-mode-my-wordpress__media-meta-value';
-	if ( typeof dd === 'string' ) {
-		val.textContent = dd;
+	const dt = document.createElement( 'dt' );
+	dt.className = 'desktop-mode-my-wordpress__media-meta-term';
+	dt.textContent = label;
+	const dd = document.createElement( 'dd' );
+	dd.className = 'desktop-mode-my-wordpress__media-meta-value';
+	if ( typeof value === 'string' ) {
+		dd.textContent = value;
 	} else {
-		val.appendChild( dd );
+		dd.appendChild( value );
 	}
-	row.append( term, val );
-	return row;
+	return [ dt, dd ];
 }
 
 function buildMetadataGrid( media: MediaListItem ): HTMLElement {
@@ -222,7 +220,7 @@ function buildMetadataGrid( media: MediaListItem ): HTMLElement {
 	const caption = stripTags( media.caption?.rendered ?? '' );
 	const description = stripTags( media.description?.rendered ?? '' );
 
-	const rows: Array< HTMLElement | null > = [
+	const rows: Array< Array< HTMLElement > | null > = [
 		buildMetaRow( __( 'Filename', 'desktop-mode' ), filename ),
 		buildMetaRow( __( 'Type', 'desktop-mode' ), media.mime_type ),
 		buildMetaRow( __( 'Dimensions', 'desktop-mode' ), dims ),
@@ -234,9 +232,9 @@ function buildMetadataGrid( media: MediaListItem ): HTMLElement {
 		buildMetaRow( __( 'Description', 'desktop-mode' ), description ),
 	];
 
-	for ( const row of rows ) {
-		if ( row ) {
-			grid.appendChild( row );
+	for ( const pair of rows ) {
+		if ( pair ) {
+			grid.append( ...pair );
 		}
 	}
 	return grid;
@@ -416,8 +414,4 @@ export function renderMediaPreview(
 	}
 
 	host.appendChild( pane );
-
-	// Suppress an unused-import diagnostic when sprintf isn't used in
-	// this build — keep the i18n surface ready for future strings.
-	void sprintf;
 }

--- a/src/my-wordpress/media-preview.ts
+++ b/src/my-wordpress/media-preview.ts
@@ -282,7 +282,13 @@ export function resolvePreviewActions(
 				return false;
 			}
 		}
-		if ( a.mime && ctx.mime ) {
+		if ( a.mime ) {
+			// MIME-scoped descriptor: fail closed on the
+			// non-media-context call site so a `^image/` action
+			// doesn't leak into a Posts preview pane.
+			if ( ! ctx.mime ) {
+				return false;
+			}
 			try {
 				const re = new RegExp( a.mime );
 				if ( ! re.test( ctx.mime ) ) {

--- a/src/my-wordpress/media-preview.ts
+++ b/src/my-wordpress/media-preview.ts
@@ -1,0 +1,423 @@
+/**
+ * My WordPress — type-aware media preview pane.
+ *
+ * Switches on MIME group:
+ *
+ *   - `image/*` → `<img>` with object-fit:contain
+ *   - `video/*` → `<video controls>` (with poster when available)
+ *   - `audio/*` → poster + `<audio controls>`
+ *   - PDF / documents → big dashicon + metadata table
+ *
+ * Renders a metadata grid (filename, dimensions, filesize, MIME,
+ * uploaded, uploader, alt text, caption, description) and an
+ * action-button row sourced from server descriptors merged with
+ * the `desktop-mode.my-wordpress.preview-actions` JS filter.
+ *
+ * Plugins can inject arbitrary DOM into the three named slots
+ * (`'header'`, `'meta'`, `'footer'`) via the
+ * `desktop-mode.my-wordpress.preview-extras` action.
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+import { __, sprintf } from '../i18n';
+import { applyFilters, doAction } from '../hooks';
+import type {
+	MediaListItem,
+	MediaPreviewAction,
+	MediaPreviewActionContext,
+	MediaPreviewSlot,
+} from './types';
+
+const MIME_DASHICON_FALLBACK = 'dashicons-media-default';
+
+const MIME_DASHICON_MAP: Array< { test: RegExp; icon: string } > = [
+	{ test: /^image\//, icon: 'dashicons-format-image' },
+	{ test: /^video\//, icon: 'dashicons-format-video' },
+	{ test: /^audio\//, icon: 'dashicons-format-audio' },
+	{ test: /pdf$/, icon: 'dashicons-media-document' },
+	{ test: /^application\/zip|x-tar|x-rar|x-7z/, icon: 'dashicons-media-archive' },
+	{ test: /spreadsheet|excel/, icon: 'dashicons-media-spreadsheet' },
+	{ test: /word|document/, icon: 'dashicons-media-document' },
+	{ test: /^text\//, icon: 'dashicons-media-text' },
+];
+
+/**
+ * Pick a dashicon for the given MIME type.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function dashiconForMime( mime: string ): string {
+	for ( const entry of MIME_DASHICON_MAP ) {
+		if ( entry.test.test( mime ) ) {
+			return entry.icon;
+		}
+	}
+	return MIME_DASHICON_FALLBACK;
+}
+
+function mimeGroup( mime: string ): 'image' | 'video' | 'audio' | 'doc' {
+	if ( mime.startsWith( 'image/' ) ) {
+		return 'image';
+	}
+	if ( mime.startsWith( 'video/' ) ) {
+		return 'video';
+	}
+	if ( mime.startsWith( 'audio/' ) ) {
+		return 'audio';
+	}
+	return 'doc';
+}
+
+function formatBytes( bytes: number | undefined ): string {
+	if ( ! bytes || ! Number.isFinite( bytes ) ) {
+		return '';
+	}
+	if ( bytes < 1024 ) {
+		return `${ bytes } B`;
+	}
+	const units = [ 'KB', 'MB', 'GB', 'TB' ];
+	let value = bytes / 1024;
+	let unit = 0;
+	while ( value >= 1024 && unit < units.length - 1 ) {
+		value /= 1024;
+		unit += 1;
+	}
+	return `${ value.toFixed( value >= 10 ? 0 : 1 ) } ${ units[ unit ] }`;
+}
+
+function formatDate( iso: string | undefined ): string {
+	if ( ! iso ) {
+		return '';
+	}
+	const d = new Date( iso );
+	if ( Number.isNaN( d.valueOf() ) ) {
+		return iso;
+	}
+	return d.toLocaleDateString( undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	} );
+}
+
+function stripTags( html: string ): string {
+	const div = document.createElement( 'div' );
+	div.innerHTML = html;
+	return ( div.textContent ?? '' ).trim();
+}
+
+function buildMediaVisual( media: MediaListItem ): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'desktop-mode-my-wordpress__media-visual';
+	const group = mimeGroup( media.mime_type );
+
+	if ( group === 'image' ) {
+		const img = document.createElement( 'img' );
+		const sizes = media.media_details?.sizes;
+		img.src =
+			sizes?.large?.source_url ??
+			sizes?.medium_large?.source_url ??
+			sizes?.medium?.source_url ??
+			media.source_url;
+		img.alt = media.alt_text ?? stripTags( media.title.rendered );
+		img.loading = 'lazy';
+		img.decoding = 'async';
+		img.className = 'desktop-mode-my-wordpress__media-image';
+		wrap.appendChild( img );
+		return wrap;
+	}
+
+	if ( group === 'video' ) {
+		const video = document.createElement( 'video' );
+		video.controls = true;
+		video.preload = 'metadata';
+		video.src = media.source_url;
+		const sizes = media.media_details?.sizes;
+		const poster =
+			sizes?.large?.source_url ?? sizes?.medium?.source_url ?? '';
+		if ( poster ) {
+			video.poster = poster;
+		}
+		video.className = 'desktop-mode-my-wordpress__media-video';
+		wrap.appendChild( video );
+		return wrap;
+	}
+
+	if ( group === 'audio' ) {
+		const stack = document.createElement( 'div' );
+		stack.className = 'desktop-mode-my-wordpress__media-audio-stack';
+		const icon = document.createElement( 'span' );
+		icon.className =
+			'desktop-mode-my-wordpress__media-fallback-icon dashicons ' +
+			dashiconForMime( media.mime_type );
+		icon.setAttribute( 'aria-hidden', 'true' );
+		stack.appendChild( icon );
+		const audio = document.createElement( 'audio' );
+		audio.controls = true;
+		audio.preload = 'metadata';
+		audio.src = media.source_url;
+		audio.className = 'desktop-mode-my-wordpress__media-audio';
+		stack.appendChild( audio );
+		wrap.appendChild( stack );
+		return wrap;
+	}
+
+	// Documents — big dashicon and a "View file" link.
+	const icon = document.createElement( 'span' );
+	icon.className =
+		'desktop-mode-my-wordpress__media-fallback-icon dashicons ' +
+		dashiconForMime( media.mime_type );
+	icon.setAttribute( 'aria-hidden', 'true' );
+	wrap.appendChild( icon );
+	const link = document.createElement( 'a' );
+	link.href = media.source_url;
+	link.target = '_blank';
+	link.rel = 'noopener noreferrer';
+	link.className = 'desktop-mode-my-wordpress__media-doc-link';
+	link.textContent = __( 'Open file', 'desktop-mode' );
+	wrap.appendChild( link );
+	return wrap;
+}
+
+function buildMetaRow(
+	dt: string,
+	dd: string | HTMLElement,
+): HTMLElement | null {
+	if ( typeof dd === 'string' && dd.trim() === '' ) {
+		return null;
+	}
+	const row = document.createElement( 'div' );
+	row.className = 'desktop-mode-my-wordpress__media-meta-row';
+	const term = document.createElement( 'span' );
+	term.className = 'desktop-mode-my-wordpress__media-meta-term';
+	term.textContent = dt;
+	const val = document.createElement( 'span' );
+	val.className = 'desktop-mode-my-wordpress__media-meta-value';
+	if ( typeof dd === 'string' ) {
+		val.textContent = dd;
+	} else {
+		val.appendChild( dd );
+	}
+	row.append( term, val );
+	return row;
+}
+
+function buildMetadataGrid( media: MediaListItem ): HTMLElement {
+	const grid = document.createElement( 'dl' );
+	grid.className = 'desktop-mode-my-wordpress__media-meta';
+
+	const filename = media.media_details?.file
+		? media.media_details.file.split( '/' ).pop() ?? ''
+		: media.source_url.split( '/' ).pop() ?? '';
+	const dims = media.media_details?.width && media.media_details?.height
+		? `${ media.media_details.width } × ${ media.media_details.height }`
+		: '';
+	const filesize = formatBytes( media.media_details?.filesize );
+	const uploaded = formatDate( media.date );
+	const uploader = media._embedded?.author?.[ 0 ]?.name ?? '';
+	const alt = ( media.alt_text ?? '' ).trim();
+	const caption = stripTags( media.caption?.rendered ?? '' );
+	const description = stripTags( media.description?.rendered ?? '' );
+
+	const rows: Array< HTMLElement | null > = [
+		buildMetaRow( __( 'Filename', 'desktop-mode' ), filename ),
+		buildMetaRow( __( 'Type', 'desktop-mode' ), media.mime_type ),
+		buildMetaRow( __( 'Dimensions', 'desktop-mode' ), dims ),
+		buildMetaRow( __( 'File size', 'desktop-mode' ), filesize ),
+		buildMetaRow( __( 'Uploaded', 'desktop-mode' ), uploaded ),
+		buildMetaRow( __( 'Uploader', 'desktop-mode' ), uploader ),
+		buildMetaRow( __( 'Alt text', 'desktop-mode' ), alt ),
+		buildMetaRow( __( 'Caption', 'desktop-mode' ), caption ),
+		buildMetaRow( __( 'Description', 'desktop-mode' ), description ),
+	];
+
+	for ( const row of rows ) {
+		if ( row ) {
+			grid.appendChild( row );
+		}
+	}
+	return grid;
+}
+
+/**
+ * Run the `desktop-mode.my-wordpress.preview-extras` action,
+ * passing each registered subscriber a host element for the named
+ * slot so they can append arbitrary DOM.
+ *
+ * @since 0.21.0
+ */
+function fireSlot(
+	host: HTMLElement,
+	slot: MediaPreviewSlot,
+	entityId: string,
+	kind: string,
+	item: Record< string, unknown >,
+): void {
+	doAction(
+		'desktop-mode.my-wordpress.preview-extras',
+		{
+			slot,
+			container: host,
+			entityId,
+			kind,
+			item,
+		},
+	);
+}
+
+/**
+ * Resolve which action descriptors apply to the given context and
+ * call the JS-filter so plugins can attach handlers / hide entries.
+ *
+ * @since 0.21.0
+ */
+export function resolvePreviewActions(
+	descriptors: MediaPreviewAction[],
+	ctx: MediaPreviewActionContext,
+): MediaPreviewAction[] {
+	const scoped = descriptors.filter( ( a ) => {
+		if ( a.sections && a.sections.length > 0 ) {
+			if ( ! a.sections.includes( ctx.entityId ) && ! a.sections.includes( '*' ) ) {
+				return false;
+			}
+		}
+		if ( a.mime && ctx.mime ) {
+			try {
+				const re = new RegExp( a.mime );
+				if ( ! re.test( ctx.mime ) ) {
+					return false;
+				}
+			} catch {
+				// Malformed regex from PHP — skip the action.
+				return false;
+			}
+		}
+		return true;
+	} );
+	const merged = applyFilters<
+		MediaPreviewAction[],
+		[ MediaPreviewActionContext ]
+	>( 'desktop-mode.my-wordpress.preview-actions', scoped, ctx );
+	return Array.isArray( merged ) ? merged : scoped;
+}
+
+function buildActionRow(
+	actions: MediaPreviewAction[],
+	ctx: MediaPreviewActionContext,
+): HTMLElement | null {
+	const visible = actions.filter( ( a ) =>
+		typeof a.isVisible === 'function' ? a.isVisible( ctx ) : true,
+	);
+	if ( visible.length === 0 ) {
+		return null;
+	}
+	const row = document.createElement( 'div' );
+	row.className = 'desktop-mode-my-wordpress__media-actions';
+	row.setAttribute( 'role', 'toolbar' );
+	for ( const action of visible ) {
+		const btn = document.createElement( 'wpd-button' );
+		btn.setAttribute( 'variant', 'secondary' );
+		btn.dataset.actionId = action.id;
+		if ( action.icon ) {
+			btn.setAttribute( 'icon', action.icon );
+		}
+		btn.textContent = action.label;
+		btn.addEventListener( 'click', () => {
+			if ( typeof action.onSelect === 'function' ) {
+				try {
+					void action.onSelect( ctx );
+				} catch {
+					// Handler is plugin code — log via console only.
+					// eslint-disable-next-line no-console
+					console.error(
+						`[my-wordpress] preview action ${ action.id } threw.`,
+					);
+				}
+			}
+		} );
+		row.appendChild( btn );
+	}
+	return row;
+}
+
+/**
+ * Paint the right-pane preview for a media item. Replaces any
+ * existing content under `host`.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export function renderMediaPreview(
+	host: HTMLElement,
+	media: MediaListItem,
+	opts: {
+		entityId: string;
+		previewActions: MediaPreviewAction[];
+		onOpenDetail?: () => void;
+	},
+): void {
+	host.replaceChildren();
+	const pane = document.createElement( 'div' );
+	pane.className = 'desktop-mode-my-wordpress__media-pane';
+
+	const header = document.createElement( 'header' );
+	header.className = 'desktop-mode-my-wordpress__media-header';
+	const heading = document.createElement( 'h2' );
+	heading.className = 'desktop-mode-my-wordpress__media-title';
+	heading.textContent =
+		stripTags( media.title.rendered ) || __( '(no title)', 'desktop-mode' );
+	header.appendChild( heading );
+	pane.appendChild( header );
+
+	const item = media as unknown as Record< string, unknown >;
+	const ctx: MediaPreviewActionContext = {
+		entityId: opts.entityId,
+		kind: 'media',
+		mime: media.mime_type,
+		item,
+	};
+
+	fireSlot( header, 'header', opts.entityId, 'media', item );
+
+	pane.appendChild( buildMediaVisual( media ) );
+
+	const meta = buildMetadataGrid( media );
+	pane.appendChild( meta );
+	fireSlot( meta, 'meta', opts.entityId, 'media', item );
+
+	const resolved = resolvePreviewActions( opts.previewActions, ctx );
+	const actionRow = buildActionRow( resolved, ctx );
+	if ( actionRow ) {
+		pane.appendChild( actionRow );
+	}
+
+	if ( opts.onOpenDetail ) {
+		const footer = document.createElement( 'footer' );
+		footer.className = 'desktop-mode-my-wordpress__article-footer';
+		const drillBtn = document.createElement( 'wpd-button' );
+		drillBtn.setAttribute( 'variant', 'primary' );
+		drillBtn.textContent = __( 'See where this is used', 'desktop-mode' );
+		drillBtn.title = __(
+			'Show the posts, pages, and custom-post-type entries that reference this file.',
+			'desktop-mode',
+		);
+		drillBtn.addEventListener( 'click', () => opts.onOpenDetail?.() );
+		footer.appendChild( drillBtn );
+		pane.appendChild( footer );
+		fireSlot( footer, 'footer', opts.entityId, 'media', item );
+	} else {
+		const footer = document.createElement( 'div' );
+		footer.className = 'desktop-mode-my-wordpress__media-footer';
+		pane.appendChild( footer );
+		fireSlot( footer, 'footer', opts.entityId, 'media', item );
+	}
+
+	host.appendChild( pane );
+
+	// Suppress an unused-import diagnostic when sprintf isn't used in
+	// this build — keep the i18n surface ready for future strings.
+	void sprintf;
+}

--- a/src/my-wordpress/media-rest.ts
+++ b/src/my-wordpress/media-rest.ts
@@ -1,0 +1,136 @@
+/**
+ * My WordPress — REST helpers for the Media section.
+ *
+ * Two endpoints:
+ *
+ *   - `wp/v2/media` for the browse-list grid (Core endpoint, no
+ *     new server work).
+ *   - `desktop-mode/v1/media-usage/<id>` for the drill-in "used
+ *     in" rollup.
+ *
+ * Both route through `trackedFetch` so requests feed the window's
+ * loading indicator + the activity bus.
+ *
+ * @public
+ * @since 0.21.0
+ */
+
+import { joinRestUrl } from '../rest-url';
+import { trackedFetch } from '../tracked-fetch';
+import { getConfig } from './rest';
+import type {
+	MediaListItem,
+	MediaListResult,
+	MediaUsage,
+	MyWordPressEntity,
+} from './types';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+function shellFetch(
+	input: RequestInfo,
+	init: RequestInit,
+): Promise< Response > {
+	return trackedFetch( input, init, {
+		windowId: WINDOW_ID,
+		source: 'desktop-mode/my-wordpress',
+	} );
+}
+
+function buildUrl( path: string ): string {
+	return joinRestUrl( getConfig().restRoot, path );
+}
+
+async function readErrorMessage(
+	response: Response,
+	fallback: string,
+): Promise< string > {
+	let message = `${ response.status } ${ response.statusText || fallback }`;
+	try {
+		const json = ( await response.json() ) as { message?: string };
+		if ( json && typeof json.message === 'string' ) {
+			message = json.message;
+		}
+	} catch {
+		// Non-JSON body — use the status line.
+	}
+	return message;
+}
+
+/**
+ * Paged fetch of `/wp/v2/media`. Newest first, with featured-image
+ * sized URLs + author embedded so the grid + preview pane can render
+ * from a single round-trip per page.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export async function fetchMediaPage(
+	entity: MyWordPressEntity,
+	params: { page: number; perPage: number },
+): Promise< MediaListResult > {
+	const cfg = getConfig();
+	const url = new URL( buildUrl( entity.restPath ) );
+	url.searchParams.set( 'page', String( params.page ) );
+	url.searchParams.set( 'per_page', String( params.perPage ) );
+	url.searchParams.set(
+		'_fields',
+		'id,title,date,mime_type,source_url,alt_text,caption,description,author,media_details,_embedded',
+	);
+	url.searchParams.set( '_embed', 'author' );
+	url.searchParams.set( 'orderby', 'date' );
+	url.searchParams.set( 'order', 'desc' );
+	// Attachments are stored under `status=inherit`; the default
+	// `publish` filter on `wp/v2/media` returns an empty list.
+	url.searchParams.set( 'status', 'inherit' );
+
+	const response = await shellFetch( url.toString(), {
+		method: 'GET',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+		},
+	} );
+
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to load media' ),
+		);
+	}
+
+	const items = ( await response.json() ) as MediaListItem[];
+	const total = Number( response.headers.get( 'X-WP-Total' ) ?? items.length );
+	const totalPages = Number(
+		response.headers.get( 'X-WP-TotalPages' ) ?? 1,
+	);
+	return { items, total, totalPages };
+}
+
+/**
+ * Drill-in payload — every public post/page/CPT that references the
+ * given attachment.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export async function fetchMediaUsage( mediaId: number ): Promise< MediaUsage > {
+	const cfg = getConfig();
+	const response = await shellFetch(
+		buildUrl( `desktop-mode/v1/media-usage/${ mediaId }` ),
+		{
+			method: 'GET',
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': cfg.restNonce,
+				Accept: 'application/json',
+			},
+		},
+	);
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to load media usage' ),
+		);
+	}
+	return ( await response.json() ) as MediaUsage;
+}

--- a/src/my-wordpress/rest.ts
+++ b/src/my-wordpress/rest.ts
@@ -200,10 +200,16 @@ export async function fetchEntityTotal(
 		url.searchParams.set( 'page', '1' );
 		url.searchParams.set( 'per_page', '1' );
 		url.searchParams.set( '_fields', 'id' );
-		if ( entity.kind !== 'user' ) {
+		if ( entity.kind === 'user' ) {
+			if ( withWho ) {
+				url.searchParams.set( 'who', 'authors' );
+			}
+		} else if ( entity.kind === 'media' ) {
+			// Attachments live under `status=inherit` — passing the
+			// post-status list above 400s on `wp/v2/media`.
+			url.searchParams.set( 'status', 'inherit' );
+		} else {
 			url.searchParams.set( 'status', 'publish,future,draft,pending,private' );
-		} else if ( withWho ) {
-			url.searchParams.set( 'who', 'authors' );
 		}
 		return url.toString();
 	};

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -5,7 +5,21 @@
  * @since 0.8.0
  */
 
-export type EntityKind = 'post' | 'user';
+/**
+ * Built-in entity render kinds. Plugins can register additional
+ * kinds via `wp.desktop.myWordpress.registerEntityKind(...)` —
+ * any non-empty string is accepted at runtime, this union just
+ * documents the in-tree set.
+ *
+ * @public
+ */
+/**
+ * Plugin-defined kinds register at runtime via
+ * `wp.desktop.myWordpress.registerEntityKind()` — the type stays
+ * `string` so the union accepts arbitrary slugs without sacrificing
+ * IDE autocomplete on the in-tree set.
+ */
+export type EntityKind = 'post' | 'user' | 'media' | string;
 
 export interface MyWordPressEntity {
 	id: string;
@@ -32,6 +46,84 @@ export interface MyWordPressConfig {
 	editUserUrlBase?: string;
 	entities: MyWordPressEntity[];
 	perPage: number;
+	/**
+	 * Per-page count for the Media grid. Media tiles are denser than
+	 * post tiles, so the default (`48`) is higher than the post
+	 * default. Filterable server-side via `desktop_mode_my_wordpress_window_args`.
+	 *
+	 * @since 0.21.0
+	 */
+	mediaPerPage?: number;
+	/**
+	 * Server-declared preview-action descriptors collected via
+	 * `desktop_mode_my_wordpress_preview_actions`. Already capability-
+	 * gated — never present here unless the current user can run
+	 * the action.
+	 *
+	 * @since 0.21.0
+	 */
+	previewActions?: MediaPreviewAction[];
+}
+
+/**
+ * Server-declared descriptor for a right-pane action button.
+ * Plugins push these via `desktop_mode_my_wordpress_preview_actions`
+ * (PHP) and complete the JS handler via the
+ * `desktop-mode.my-wordpress.preview-actions` filter.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export interface MediaPreviewAction {
+	id: string;
+	label: string;
+	icon?: string;
+	/** PCRE — server-checked before shipping; client re-checks per item. */
+	mime?: string;
+	/** Section ids this action is visible in. Default: all. */
+	sections?: string[];
+	/** Optional `wp_register_script` handle the server enqueues. */
+	script?: string;
+	/**
+	 * Optional JS handler — wired by the
+	 * `desktop-mode.my-wordpress.preview-actions` JS filter, never
+	 * by the server descriptor.
+	 */
+	onSelect?: ( ctx: MediaPreviewActionContext ) => void | Promise< void >;
+	/**
+	 * Optional visibility predicate evaluated client-side after the
+	 * server-side `capability` / `mime` checks have already passed.
+	 */
+	isVisible?: ( ctx: MediaPreviewActionContext ) => boolean;
+}
+
+/**
+ * Slot identifier for plugin-injected DOM in the right pane.
+ *
+ * - `header` — above the rendered media / metadata table
+ * - `meta`   — interleaved with the metadata grid
+ * - `footer` — below the action button row
+ *
+ * @public
+ * @since 0.21.0
+ */
+export type MediaPreviewSlot = 'header' | 'meta' | 'footer';
+
+/**
+ * Context object passed to every preview-action handler.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export interface MediaPreviewActionContext {
+	/** Entity id (`'media'`, `'posts'`, `'users'`, …). */
+	entityId: string;
+	/** Section render-kind (`'media'`, `'post'`, `'user'`, …). */
+	kind: string;
+	/** MIME type for media items, undefined for non-media kinds. */
+	mime?: string;
+	/** The full server item record. */
+	item: Record< string, unknown >;
 }
 
 export interface EntityLock {
@@ -245,4 +337,82 @@ export type Route =
 			entityId: string;
 			userId: number;
 			userName: string;
+	}
+	| {
+			kind: 'media-detail';
+			entityId: string;
+			mediaId: number;
+			mediaTitle: string;
 	};
+
+/**
+ * Single-row payload returned by `/wp/v2/media`. Trimmed to the
+ * fields the My WordPress media grid + preview pane consume.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export interface MediaListItem {
+	id: number;
+	title: { rendered: string };
+	date: string;
+	mime_type: string;
+	source_url: string;
+	alt_text?: string;
+	caption?: { rendered: string };
+	description?: { rendered: string };
+	author?: number;
+	media_details?: {
+		width?: number;
+		height?: number;
+		filesize?: number;
+		file?: string;
+		sizes?: Record< string, { source_url: string; width?: number; height?: number } | undefined >;
+	};
+	_embedded?: {
+		author?: Array< {
+			id: number;
+			name: string;
+			avatar_urls?: Record< string, string >;
+		} >;
+	};
+	[ key: string ]: unknown;
+}
+
+export interface MediaListResult {
+	items: MediaListItem[];
+	total: number;
+	totalPages: number;
+}
+
+/**
+ * Per-attachment "used in" payload returned by
+ * `/desktop-mode/v1/media-usage/<id>`.
+ *
+ * @public
+ * @since 0.21.0
+ */
+export interface MediaUsage {
+	media: {
+		id: number;
+		title: string;
+		mime: string;
+		sourceUrl: string;
+		filename: string;
+		date: string;
+		author: { id: number; name: string };
+	};
+	usedIn: Array< {
+		postId: number;
+		postType: string;
+		postTypeLabel: string;
+		title: string;
+		status: string;
+		link: string;
+		editLink: string;
+		usedAs: 'featured' | 'content' | 'meta';
+		authorId: number;
+		authorName: string;
+		date: string;
+	} >;
+}

--- a/tests/phpunit/tests/myWordpressMediaUsage.php
+++ b/tests/phpunit/tests/myWordpressMediaUsage.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Tests for the `/desktop-mode/v1/media-usage/<id>` REST endpoint.
+ *
+ * Seeds an attachment plus three posts that reference it three
+ * different ways (featured image, embedded URL, embedded block
+ * class) and asserts the endpoint returns the expected rows with
+ * correct `usedAs` tags. Also covers capability gating
+ * (subscribers don't see drafts they can't read) and the
+ * transient cache (second call hits cache).
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-my-wordpress
+ */
+class Tests_DesktopMode_MyWordpressMediaUsage extends WP_UnitTestCase {
+
+	private $admin_id;
+	private $subscriber_id;
+	private $attachment_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $this->admin_id );
+
+		do_action( 'rest_api_init' );
+
+		// Build a real attachment with a fake file URL.
+		$this->attachment_id = self::factory()->attachment->create_object(
+			'sample-photo.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_title'     => 'Sample photo',
+			)
+		);
+		update_post_meta( $this->attachment_id, '_wp_attached_file', '2026/01/sample-photo.jpg' );
+	}
+
+	public function tear_down() {
+		delete_transient( 'dm_media_usage_' . $this->attachment_id . '_edit_v1' );
+		delete_transient( 'dm_media_usage_' . $this->attachment_id . '_read_v1' );
+		remove_all_filters( 'desktop_mode_my_wordpress_media_usage' );
+		remove_all_filters( 'desktop_mode_my_wordpress_media_usage_cache_ttl' );
+		parent::tear_down();
+	}
+
+	private function dispatch( $id ) {
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/media-usage/' . (int) $id );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * @covers ::desktop_mode_my_wordpress_media_usage_build
+	 */
+	public function test_finds_featured_image_and_content_embeds_with_correct_usedAs() {
+		$featured_post = self::factory()->post->create(
+			array( 'post_status' => 'publish', 'post_title' => 'Featured' )
+		);
+		update_post_meta( $featured_post, '_thumbnail_id', $this->attachment_id );
+
+		$content_post = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Content embed',
+				'post_content' => '<p>See <img class="wp-image-' . $this->attachment_id . '" src="x"/>.</p>',
+			)
+		);
+
+		// Unrelated post — must NOT appear.
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Unrelated',
+				'post_content' => 'No image here.',
+			)
+		);
+
+		$response = $this->dispatch( $this->attachment_id );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( $this->attachment_id, $data['media']['id'] );
+
+		$by_id = array();
+		foreach ( $data['usedIn'] as $row ) {
+			$by_id[ $row['postId'] ] = $row;
+		}
+		$this->assertArrayHasKey( $featured_post, $by_id );
+		$this->assertArrayHasKey( $content_post, $by_id );
+		$this->assertSame( 'featured', $by_id[ $featured_post ]['usedAs'] );
+		$this->assertSame( 'content', $by_id[ $content_post ]['usedAs'] );
+	}
+
+	/**
+	 * Subscriber cannot read drafts — so drafts referencing the
+	 * attachment must be filtered out of their result set.
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_build
+	 */
+	public function test_subscriber_does_not_see_drafts() {
+		$draft = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_title'  => 'Private draft',
+				'post_author' => $this->admin_id,
+			)
+		);
+		update_post_meta( $draft, '_thumbnail_id', $this->attachment_id );
+
+		// Subscriber needs `read` cap on the attachment to call the
+		// endpoint. The attachment status `inherit` is publicly
+		// readable, so that gate passes.
+		wp_set_current_user( $this->subscriber_id );
+
+		$response = $this->dispatch( $this->attachment_id );
+		$this->assertSame( 200, $response->get_status() );
+		$rows = $response->get_data()['usedIn'];
+
+		$ids = wp_list_pluck( $rows, 'postId' );
+		$this->assertNotContains( $draft, $ids );
+	}
+
+	/**
+	 * Second call returns the cached payload. We can't reliably
+	 * compare query counts (cap checks run on every dispatch), so
+	 * we verify cache presence directly and confirm the second
+	 * dispatch returns the same payload — even after we mutate the
+	 * underlying data, the cache must shield the response.
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_callback
+	 */
+	public function test_transient_caches_result() {
+		$post = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		update_post_meta( $post, '_thumbnail_id', $this->attachment_id );
+
+		// Hold the action so the cache is NOT busted between
+		// dispatches when we add the second post.
+		remove_action( 'save_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
+
+		$first = $this->dispatch( $this->attachment_id );
+		$this->assertSame( 200, $first->get_status() );
+		$this->assertCount( 1, $first->get_data()['usedIn'] );
+
+		// Cache key was written.
+		$cached = get_transient( 'dm_media_usage_' . $this->attachment_id . '_edit_v1' );
+		$this->assertIsArray( $cached );
+
+		// Add a second referencing post. With the bust hook removed,
+		// the cache stays warm — the second dispatch must still see
+		// the original 1-row payload.
+		$post2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		update_post_meta( $post2, '_thumbnail_id', $this->attachment_id );
+
+		$second = $this->dispatch( $this->attachment_id );
+		$this->assertSame( 200, $second->get_status() );
+		$this->assertCount( 1, $second->get_data()['usedIn'] );
+		$this->assertSame( $first->get_data()['usedIn'], $second->get_data()['usedIn'] );
+
+		// Restore the cache-busting hook for the rest of the suite.
+		add_action( 'save_post', 'desktop_mode_my_wordpress_media_usage_bust_for_post' );
+	}
+
+	/**
+	 * Filter can extend the payload (ACF-style integration).
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_callback
+	 */
+	public function test_filter_can_extend_usedIn() {
+		add_filter(
+			'desktop_mode_my_wordpress_media_usage',
+			static function ( $payload ) {
+				$payload['usedIn'][] = array(
+					'postId'        => 999,
+					'postType'      => 'plugin-custom',
+					'postTypeLabel' => 'Plugin Custom',
+					'title'         => 'Synthetic',
+					'status'        => 'publish',
+					'link'          => '',
+					'editLink'      => '',
+					'usedAs'        => 'meta',
+					'authorId'      => 0,
+					'authorName'    => '',
+					'date'          => '2026-01-01T00:00:00',
+				);
+				return $payload;
+			}
+		);
+
+		$response = $this->dispatch( $this->attachment_id );
+		$rows     = $response->get_data()['usedIn'];
+		$ids      = wp_list_pluck( $rows, 'postId' );
+		$this->assertContains( 999, $ids );
+	}
+
+	/**
+	 * Unknown attachment id returns 404.
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_callback
+	 */
+	public function test_unknown_attachment_returns_404() {
+		$response = $this->dispatch( 999999 );
+		$this->assertSame( 403, $response->get_status() );
+	}
+}

--- a/tests/phpunit/tests/myWordpressMediaUsage.php
+++ b/tests/phpunit/tests/myWordpressMediaUsage.php
@@ -201,11 +201,15 @@ class Tests_DesktopMode_MyWordpressMediaUsage extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Unknown attachment id returns 404.
+	 * Unknown attachment id is rejected by the permission callback
+	 * (returns false → REST issues 403). The callback runs before
+	 * the body fetch, so we never reach the 404-emitting branch in
+	 * the callback — both outcomes are correct, the difference is
+	 * which gate rejects first.
 	 *
 	 * @covers ::desktop_mode_my_wordpress_media_usage_callback
 	 */
-	public function test_unknown_attachment_returns_404() {
+	public function test_unknown_attachment_returns_403_via_permission_gate() {
 		$response = $this->dispatch( 999999 );
 		$this->assertSame( 403, $response->get_status() );
 	}

--- a/tests/phpunit/tests/myWordpressMediaUsage.php
+++ b/tests/phpunit/tests/myWordpressMediaUsage.php
@@ -46,8 +46,13 @@ class Tests_DesktopMode_MyWordpressMediaUsage extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		delete_transient( 'dm_media_usage_' . $this->attachment_id . '_edit_v1' );
-		delete_transient( 'dm_media_usage_' . $this->attachment_id . '_read_v1' );
+		// Use the shared cache-key helper so a future change to the
+		// key scheme propagates here automatically.
+		foreach ( desktop_mode_my_wordpress_media_usage_cache_buckets() as $bucket ) {
+			delete_transient(
+				desktop_mode_my_wordpress_media_usage_cache_key( $this->attachment_id, $bucket )
+			);
+		}
 		remove_all_filters( 'desktop_mode_my_wordpress_media_usage' );
 		remove_all_filters( 'desktop_mode_my_wordpress_media_usage_cache_ttl' );
 		parent::tear_down();
@@ -149,8 +154,12 @@ class Tests_DesktopMode_MyWordpressMediaUsage extends WP_UnitTestCase {
 		$this->assertSame( 200, $first->get_status() );
 		$this->assertCount( 1, $first->get_data()['usedIn'] );
 
-		// Cache key was written.
-		$cached = get_transient( 'dm_media_usage_' . $this->attachment_id . '_edit_v1' );
+		// Cache key was written — read it through the same helper
+		// the writer uses, so the test isn't coupled to the literal
+		// key format.
+		$cached = get_transient(
+			desktop_mode_my_wordpress_media_usage_cache_key( $this->attachment_id, 'edit' )
+		);
 		$this->assertIsArray( $cached );
 
 		// Add a second referencing post. With the bust hook removed,
@@ -198,6 +207,79 @@ class Tests_DesktopMode_MyWordpressMediaUsage extends WP_UnitTestCase {
 		$rows     = $response->get_data()['usedIn'];
 		$ids      = wp_list_pluck( $rows, 'postId' );
 		$this->assertContains( 999, $ids );
+	}
+
+	/**
+	 * Regression: the LIKE-scan `%wp-image-12%` also matches
+	 * `wp-image-123`. The PHP-side word-boundary recheck must
+	 * reject the false positive.
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_build
+	 */
+	public function test_word_boundary_excludes_numeric_prefix_matches() {
+		// Stand up a post referencing a HIGHER-id attachment whose
+		// number prefixes our subject attachment's id (e.g. subject
+		// is 12, false-positive is 120). Order isn't guaranteed by
+		// factory ids — we synthesize ids using string content.
+		$subject_id = $this->attachment_id;
+		$prefix_id  = $subject_id . '0'; // numerically distinct, prefix-overlapping
+
+		$false_positive = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'False positive',
+				'post_content' => '<p>Embed: <img class="wp-image-' . $prefix_id . '" src="x"/>.</p>',
+			)
+		);
+		$true_positive = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'True positive',
+				'post_content' => '<p>Embed: <img class="wp-image-' . $subject_id . '" src="x"/>.</p>',
+			)
+		);
+
+		$response = $this->dispatch( $subject_id );
+		$this->assertSame( 200, $response->get_status() );
+		$ids = wp_list_pluck( $response->get_data()['usedIn'], 'postId' );
+		$this->assertContains( $true_positive, $ids );
+		$this->assertNotContains( $false_positive, $ids );
+	}
+
+	/**
+	 * Regression: removing a `wp-image-N` block from a post must
+	 * bust the cache for attachment N — otherwise the drill-in
+	 * view shows that post as a reference until the TTL expires.
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_bust_for_post
+	 */
+	public function test_reference_removal_busts_cache() {
+		$post = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Has reference',
+				'post_content' => '<p><img class="wp-image-' . $this->attachment_id . '" src="x"/></p>',
+			)
+		);
+
+		// Warm the cache.
+		$first = $this->dispatch( $this->attachment_id );
+		$ids   = wp_list_pluck( $first->get_data()['usedIn'], 'postId' );
+		$this->assertContains( $post, $ids );
+
+		// Remove the reference. `wp_update_post` runs both
+		// `pre_post_update` and `save_post`, so the union-of-refs
+		// buster should clear the cache for attachment N.
+		wp_update_post(
+			array(
+				'ID'           => $post,
+				'post_content' => '<p>No more image.</p>',
+			)
+		);
+
+		$second = $this->dispatch( $this->attachment_id );
+		$ids    = wp_list_pluck( $second->get_data()['usedIn'], 'postId' );
+		$this->assertNotContains( $post, $ids );
 	}
 
 	/**

--- a/tests/phpunit/tests/myWordpressMediaUsage.php
+++ b/tests/phpunit/tests/myWordpressMediaUsage.php
@@ -283,6 +283,38 @@ class Tests_DesktopMode_MyWordpressMediaUsage extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression: deleting a post that references an attachment
+	 * must bust the cache for that attachment. We rely on the
+	 * `before_delete_post` hook (NOT `deleted_post`, which fires
+	 * after `_thumbnail_id` meta + the row itself are already
+	 * gone) so the buster can still read the refs out of the
+	 * about-to-be-deleted post.
+	 *
+	 * @covers ::desktop_mode_my_wordpress_media_usage_bust_for_post
+	 */
+	public function test_post_deletion_busts_attachment_cache() {
+		$post = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<img class="wp-image-' . $this->attachment_id . '" src="x"/>',
+			)
+		);
+
+		// Warm the cache.
+		$this->dispatch( $this->attachment_id );
+		$cache_key = desktop_mode_my_wordpress_media_usage_cache_key(
+			$this->attachment_id,
+			'edit'
+		);
+		$this->assertIsArray( get_transient( $cache_key ) );
+
+		// Force-delete the post — cache must be busted before the
+		// post row + meta are wiped.
+		wp_delete_post( $post, true );
+		$this->assertFalse( get_transient( $cache_key ) );
+	}
+
+	/**
 	 * Unknown attachment id is rejected by the permission callback
 	 * (returns false → REST issues 403). The callback runs before
 	 * the body fetch, so we never reach the 404-emitting branch in

--- a/tests/phpunit/tests/myWordpressPreviewActions.php
+++ b/tests/phpunit/tests/myWordpressPreviewActions.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for `desktop_mode_my_wordpress_collect_preview_actions()`.
+ *
+ * Asserts the server-side aggregator strips entries the current
+ * user can't run before shipping them to the bundle.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-my-wordpress
+ */
+class Tests_DesktopMode_MyWordpressPreviewActions extends WP_UnitTestCase {
+
+	private $admin_id;
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'desktop_mode_my_wordpress_preview_actions' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::desktop_mode_my_wordpress_collect_preview_actions
+	 */
+	public function test_capability_gating_drops_actions_for_subscriber() {
+		add_filter(
+			'desktop_mode_my_wordpress_preview_actions',
+			static function ( $actions ) {
+				$actions[] = array(
+					'id'         => 'a',
+					'label'      => 'A',
+					'capability' => 'upload_files',
+				);
+				$actions[] = array(
+					'id'         => 'b',
+					'label'      => 'B',
+					'capability' => 'read',
+				);
+				return $actions;
+			}
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$ids = wp_list_pluck( desktop_mode_my_wordpress_collect_preview_actions(), 'id' );
+		$this->assertContains( 'a', $ids );
+		$this->assertContains( 'b', $ids );
+
+		wp_set_current_user( $this->subscriber_id );
+		$ids = wp_list_pluck( desktop_mode_my_wordpress_collect_preview_actions(), 'id' );
+		$this->assertNotContains( 'a', $ids );
+		$this->assertContains( 'b', $ids );
+	}
+
+	/**
+	 * @covers ::desktop_mode_my_wordpress_collect_preview_actions
+	 */
+	public function test_invalid_entries_are_dropped() {
+		add_filter(
+			'desktop_mode_my_wordpress_preview_actions',
+			static function () {
+				return array(
+					array( 'id' => '', 'label' => 'Empty id' ),
+					array( 'id' => 'no-label' ),
+					'not even an array',
+					array( 'id' => 'ok', 'label' => 'Good' ),
+				);
+			}
+		);
+		wp_set_current_user( $this->admin_id );
+		$ids = wp_list_pluck( desktop_mode_my_wordpress_collect_preview_actions(), 'id' );
+		$this->assertSame( array( 'ok' ), $ids );
+	}
+}

--- a/tests/vitest/my-wordpress-kind-registry.test.ts
+++ b/tests/vitest/my-wordpress-kind-registry.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Entity-kind registry — register / look-up / unregister.
+ */
+import { describe, expect, test } from 'vitest';
+import {
+	registerEntityKind,
+	getEntityRenderer,
+	listRegisteredKinds,
+} from '../../src/my-wordpress/kind-registry';
+
+describe( 'my-wordpress kind-registry', () => {
+	test( 'register + lookup', () => {
+		const calls: string[] = [];
+		const unregister = registerEntityKind( 'test-kind', ( _host, e ) => {
+			calls.push( e.id );
+		} );
+		const renderer = getEntityRenderer( 'test-kind' );
+		expect( renderer ).toBeTypeOf( 'function' );
+		renderer?.(
+			{
+				body: document.createElement( 'div' ),
+				route: { kind: 'list', entityId: 'foo' },
+				navigate: () => {},
+				addTeardown: () => {},
+			},
+			{ id: 'foo', label: 'Foo', icon: 'dashicons-star-filled', restPath: 'wp/v2/foo', kind: 'test-kind' },
+		);
+		expect( calls ).toEqual( [ 'foo' ] );
+		expect( listRegisteredKinds() ).toContain( 'test-kind' );
+		unregister();
+		expect( getEntityRenderer( 'test-kind' ) ).toBeUndefined();
+	} );
+
+	test( 'unregister only removes own renderer', () => {
+		const u1 = registerEntityKind( 'a', () => {} );
+		const renderer2 = () => {};
+		registerEntityKind( 'a', renderer2 );
+		u1(); // u1 is stale, should not delete renderer2.
+		expect( getEntityRenderer( 'a' ) ).toBe( renderer2 );
+	} );
+
+	test( 'rejects non-string kind / non-function renderer', () => {
+		expect( () => registerEntityKind( '', () => {} ) ).toThrow();
+		expect( () =>
+			// @ts-expect-error — intentionally bad argument.
+			registerEntityKind( 'x', 'not a function' ),
+		).toThrow();
+	} );
+} );

--- a/tests/vitest/my-wordpress-media-preview.test.ts
+++ b/tests/vitest/my-wordpress-media-preview.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Media preview pane — MIME-aware rendering + plugin action surface.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import {
+	dashiconForMime,
+	renderMediaPreview,
+	resolvePreviewActions,
+} from '../../src/my-wordpress/media-preview';
+import type { MediaListItem, MediaPreviewAction } from '../../src/my-wordpress/types';
+
+function makeMedia(
+	overrides: Partial< MediaListItem > = {},
+): MediaListItem {
+	return {
+		id: 42,
+		title: { rendered: 'My photo' },
+		date: '2026-01-02T03:04:05',
+		mime_type: 'image/jpeg',
+		source_url: 'https://example.test/wp-content/uploads/2026/01/photo.jpg',
+		alt_text: 'A photo',
+		caption: { rendered: '<p>Holiday snap</p>' },
+		description: { rendered: '' },
+		media_details: {
+			width: 1600,
+			height: 1200,
+			filesize: 250000,
+			file: '2026/01/photo.jpg',
+			sizes: {
+				thumbnail: { source_url: 'https://example.test/thumb.jpg' },
+				large: { source_url: 'https://example.test/large.jpg' },
+			},
+		},
+		...overrides,
+	};
+}
+
+describe( 'media-preview', () => {
+	beforeEach( () => installHooksStub() );
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'dashiconForMime picks the right icon per MIME group', () => {
+		expect( dashiconForMime( 'image/png' ) ).toBe( 'dashicons-format-image' );
+		expect( dashiconForMime( 'video/mp4' ) ).toBe( 'dashicons-format-video' );
+		expect( dashiconForMime( 'audio/mpeg' ) ).toBe( 'dashicons-format-audio' );
+		expect( dashiconForMime( 'application/pdf' ) ).toBe( 'dashicons-media-document' );
+		expect( dashiconForMime( 'application/unknown' ) ).toBe( 'dashicons-media-default' );
+	} );
+
+	test( 'image preview renders <img> with large variant', () => {
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		renderMediaPreview( host, makeMedia(), {
+			entityId: 'media',
+			previewActions: [],
+		} );
+		const img = host.querySelector< HTMLImageElement >(
+			'.desktop-mode-my-wordpress__media-image',
+		);
+		expect( img ).not.toBeNull();
+		expect( img!.src ).toBe( 'https://example.test/large.jpg' );
+	} );
+
+	test( 'video preview emits a <video> element with controls', () => {
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		renderMediaPreview(
+			host,
+			makeMedia( { mime_type: 'video/mp4', source_url: 'https://example.test/v.mp4' } ),
+			{ entityId: 'media', previewActions: [] },
+		);
+		const v = host.querySelector< HTMLVideoElement >( 'video' );
+		expect( v ).not.toBeNull();
+		expect( v!.controls ).toBe( true );
+		expect( v!.src ).toBe( 'https://example.test/v.mp4' );
+	} );
+
+	test( 'document preview falls back to a dashicon and an Open link', () => {
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		renderMediaPreview(
+			host,
+			makeMedia( { mime_type: 'application/pdf', source_url: 'https://x/doc.pdf' } ),
+			{ entityId: 'media', previewActions: [] },
+		);
+		expect(
+			host.querySelector( '.desktop-mode-my-wordpress__media-fallback-icon' ),
+		).not.toBeNull();
+		const link = host.querySelector< HTMLAnchorElement >(
+			'.desktop-mode-my-wordpress__media-doc-link',
+		);
+		expect( link?.href ).toBe( 'https://x/doc.pdf' );
+	} );
+
+	test( 'resolvePreviewActions filters by section and MIME', () => {
+		const actions: MediaPreviewAction[] = [
+			{ id: 'a', label: 'A', sections: [ 'media' ] },
+			{ id: 'b', label: 'B', sections: [ 'posts' ] },
+			{ id: 'c', label: 'C', mime: '^image/' },
+			{ id: 'd', label: 'D', mime: '^video/' },
+		];
+		const out = resolvePreviewActions( actions, {
+			entityId: 'media',
+			kind: 'media',
+			mime: 'image/png',
+			item: {},
+		} );
+		const ids = out.map( ( a ) => a.id );
+		expect( ids ).toContain( 'a' );
+		expect( ids ).not.toContain( 'b' );
+		expect( ids ).toContain( 'c' );
+		expect( ids ).not.toContain( 'd' );
+	} );
+
+	test( 'JS preview-actions filter can attach onSelect handlers', async () => {
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		const onSelect = vi.fn();
+		// Attach a filter that wires a handler onto the server descriptor.
+		window.wp!.hooks!.addFilter(
+			'desktop-mode.my-wordpress.preview-actions',
+			'test/wire',
+			( actions: MediaPreviewAction[] ) =>
+				actions.map( ( a ) =>
+					a.id === 'compress'
+						? { ...a, onSelect }
+						: a,
+				),
+		);
+		renderMediaPreview( host, makeMedia(), {
+			entityId: 'media',
+			previewActions: [
+				{ id: 'compress', label: 'Compress', icon: 'dashicons-image-rotate' },
+			],
+		} );
+		const btn = host.querySelector< HTMLElement >( '[data-action-id="compress"]' );
+		expect( btn ).not.toBeNull();
+		btn!.dispatchEvent( new Event( 'click', { bubbles: true } ) );
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'preview-extras action fires for each slot', () => {
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		const slots: string[] = [];
+		window.wp!.hooks!.addAction(
+			'desktop-mode.my-wordpress.preview-extras',
+			'test/extras',
+			( ctx: { slot: string } ) => {
+				slots.push( ctx.slot );
+			},
+		);
+		renderMediaPreview( host, makeMedia(), {
+			entityId: 'media',
+			previewActions: [],
+		} );
+		expect( slots ).toEqual( expect.arrayContaining( [ 'header', 'meta', 'footer' ] ) );
+	} );
+} );

--- a/tests/vitest/my-wordpress-media-preview.test.ts
+++ b/tests/vitest/my-wordpress-media-preview.test.ts
@@ -114,6 +114,19 @@ describe( 'media-preview', () => {
 		expect( ids ).not.toContain( 'b' );
 		expect( ids ).toContain( 'c' );
 		expect( ids ).not.toContain( 'd' );
+
+		// MIME-scoped actions must NOT leak into a non-media
+		// context (no `ctx.mime` provided). Fail-closed semantics.
+		const nonMediaOut = resolvePreviewActions( actions, {
+			entityId: 'posts',
+			kind: 'post',
+			item: {},
+		} );
+		const nonMediaIds = nonMediaOut.map( ( a ) => a.id );
+		expect( nonMediaIds ).not.toContain( 'c' );
+		expect( nonMediaIds ).not.toContain( 'd' );
+		// Section-scoped to 'posts' still allowed.
+		expect( nonMediaIds ).toContain( 'b' );
 	} );
 
 	test( 'JS preview-actions filter can attach onSelect handlers', async () => {


### PR DESCRIPTION
## Summary

Adds a fourth section to the **My WordPress** native window (alongside Posts, Pages, Users): **Media**.

- **Browse view** — CSS-grid of thumbnails (newest first, infinite-scroll). Tiles are drag sources (`kind: 'attachment'`); the section never accepts drops — the existing window-level reject claimant handles that.
- **Type-aware preview pane** — switches on MIME group: `image/*` → `<img>`, `video/*` → `<video controls>`, `audio/*` → poster + `<audio>`, PDFs / docs → big dashicon + "Open file" link. Metadata grid (filename, dimensions, file size, MIME, uploaded, uploader, alt text, caption, description).
- **Drill-in view** — double-click a media item (or "See where this is used") opens a `media-detail` route showing every public post / page / CPT that references it (`_thumbnail_id` meta + `wp-image-<id>` class + raw URL embeds in `post_content`). Per-row capability-gated. Click a row to jump to that post's detail in the same window.
- **Navigation history back** — the breadcrumb back button now uses a per-window history stack instead of the parent-folder rule, so cross-hierarchy jumps unwind in the order you made them (Media → Media-detail → referenced post → back lands on Media-detail, not Posts list).
- **JS entity-kind dispatcher** — `wp.desktop.myWordpress.registerEntityKind( kind, renderer )` lets third-party plugins ship their own My WordPress section type without patching the bundle.

## Extensibility (Experimental, since 0.21.0)

The hook surface is uniform across **every** section (posts, pages, users, media, plugin-defined kinds) — one descriptor, all surfaces.

### PHP

| Hook | Type | Purpose |
|---|---|---|
| `desktop_mode_my_wordpress_preview_actions` | filter | Server-declared action descriptors `{ id, label, icon, capability, mime (PCRE), sections, script }`. Capability-gated before shipping to the bundle; `script` handle auto-enqueued. |
| `desktop_mode_my_wordpress_media_usage` | filter | The `{ media, usedIn }` payload returned by `GET /desktop-mode/v1/media-usage/<id>`. Plugins (ACF, page builders, Yoast image meta) push additional rows here. |
| `desktop_mode_my_wordpress_media_usage_cache_ttl` | filter | Transient TTL (default 300s). |
| `desktop_mode_my_wordpress_entities` | filter (existing) | Now documented to accept `kind => 'media'` as well as plugin-defined kinds backed by a JS renderer. |

### JS

| Hook | Type | Purpose |
|---|---|---|
| `desktop-mode.my-wordpress.preview-actions` | filter | `(actions, { entityId, kind, mime?, item }) => actions` — wire `onSelect` handlers onto server descriptors. |
| `desktop-mode.my-wordpress.preview-extras` | action | `({ slot: 'header'\|'meta'\|'footer', container, entityId, kind, item }) => void` — inject arbitrary DOM into named slots. |
| `desktop-mode.my-wordpress.tile-context-menu` | filter | Same action shape, surfaced in per-tile right-click menus. |
| `desktop-mode.my-wordpress.status-bar` | filter (existing) | Unchanged. |

### Public API — `wp.desktop.myWordpress`

```ts
interface MyWordpressApi {
    openDetail( args: { entityId, postId, postTitle } ): void;
    openMedia( args: { mediaId, mediaTitle? } ): void;                    // new
    registerEntityKind( kind, renderer ): () => void;                     // new
}
```

## New REST endpoint

`GET /desktop-mode/v1/media-usage/<id>` — drives the drill-in view.

```ts
{
    media:  { id, title, mime, sourceUrl, filename, date, author },
    usedIn: Array<{ postId, postType, postTypeLabel, title, status,
                    link, editLink, usedAs:'featured'|'content'|'meta',
                    authorId, authorName, date }>
}
```

Transient-cached (5 min default) per `attachment_id × viewer-capability bucket`. Cache busts on `save_post`, `deleted_post`, `delete_attachment`.

## Files

**New PHP**
- `includes/my-wordpress/media-usage.php` — endpoint + transient cache
- `includes/my-wordpress/preview-actions.php` — descriptor aggregator + script auto-enqueue

**New TS**
- `src/my-wordpress/kind-registry.ts` — runtime renderer registry
- `src/my-wordpress/media-rest.ts` — `fetchMediaPage` + `fetchMediaUsage`
- `src/my-wordpress/media-list.ts` — grid + drag-out
- `src/my-wordpress/media-preview.ts` — MIME-aware preview + action row + slot hooks
- `src/my-wordpress/media-detail.ts` — drill-in usage list

**Edited**
- `src/my-wordpress/index.ts` — registry-backed `navigate()`, `media-detail` route, history-stack back button, `openMedia` + `registerEntityKind` on the public API
- `src/my-wordpress/types.ts` — `Route` extension, media types
- `src/my-wordpress/rest.ts` — media branch in `fetchEntityTotal`
- `includes/my-wordpress/window.php` — Media entity, `previewActions` + `mediaPerPage` in config
- `includes/my-wordpress/bootstrap.php` — require new files
- `assets/css/my-wordpress.css` — grid, preview pane, drill-in

**Docs**
- `docs/hooks-reference.md` — three new filters documented
- `docs/javascript-reference.md` — new hooks + public API
- `docs/examples/my-wordpress-media-action.md` — copy/paste recipe

## Tests

- **Vitest** — `my-wordpress-kind-registry.test.ts`, `my-wordpress-media-preview.test.ts` (10 tests; full suite 1342 passing)
- **PHPUnit** — `myWordpressMediaUsage.php` (5 tests: featured + content embeds, subscriber draft gating, transient cache, filter extensibility, 404), `myWordpressPreviewActions.php` (2 tests: capability gating, invalid-entry filtering)

## Test plan

- [ ] Hard-refresh after pulling — both `desktop.min.js` and `my-wordpress.min.js` are rebuilt; the lazy my-wordpress bundle is what runs inside the window.
- [ ] My WordPress root shows **Media · N** alongside Posts / Pages / Users.
- [ ] Open Media — grid of thumbnails, newest first. Non-image MIME shows a dashicon fallback.
- [ ] Click a tile — right pane shows the correct preview (image / video / audio / document).
- [ ] Double-click a tile (or "See where this is used") — drill-in shows referencing posts.
- [ ] Click a referencing post — opens its detail. Press Back — lands on the Media drill-in (not Posts list).
- [ ] Drag a media tile onto the wallpaper — placement created with `kind: 'attachment'`.
- [ ] Drop a post / user tile onto the Media section — rejected with the "Can't drop here" hint.
- [ ] Subscriber viewer — drill-in hides drafts they can't read.
- [ ] Register a "Compress image" plugin descriptor (see `docs/examples/my-wordpress-media-action.md`) — button appears only on image items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-232-aeaad9f7804b0a8cedb2ff131814348ddcdc0a93.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->