### PR TITLE
Allow deactivating plugins in CMO desktop & dock

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2998,6 +2998,14 @@ interface DockItem {
     submenu:  { title: string; url: string }[];
     multi:    boolean;       // hover-peek + Ghost Card eligibility
     isCore:   boolean;       // true for WP-shipped menus, false for plugin-contributed
+    pluginFile: string | null; // owning plugin file (e.g. `woocommerce/woocommerce.php`)
+                               // when the menu was registered by an active,
+                               // deactivatable plugin; null for core menus,
+                               // mu-plugins, drop-ins, and Desktop Mode itself.
+                               // Drives the dock right-click "Deactivate …" action.
+                               // Resolved server-side by reflecting on the
+                               // menu page hook's registered callbacks.
+                               // Stable since 0.27.0.
 }
 ```
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3003,8 +3003,16 @@ interface DockItem {
                                // deactivatable plugin; null for core menus,
                                // mu-plugins, drop-ins, and Desktop Mode itself.
                                // Drives the dock right-click "Deactivate …" action.
-                               // Resolved server-side by reflecting on the
-                               // menu page hook's registered callbacks.
+                               // Resolved server-side by snapshotting $menu/$submenu
+                               // around every admin_menu callback (registration-time
+                               // attribution), with page-hook reflection + a CPT/
+                               // taxonomy registration tracker as fallbacks.
+                               // Stable since 0.27.0.
+    pluginName: string | null; // owning plugin's display name (the `Name:` field
+                               // from its plugin header). Used in the right-click
+                               // "Deactivate <pluginName>…" label so sub-page tiles
+                               // (e.g. WC's Analytics) read as the parent plugin.
+                               // Always null when pluginFile is null.
                                // Stable since 0.27.0.
 }
 ```

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -170,7 +170,11 @@ function desktop_mode_build_dock_items() {
 			'placement'  => desktop_mode_dock_placement( $item[2] ),
 			'isCore'     => desktop_mode_is_core_menu_slug( $item[2] ),
 			'pluginFile' => desktop_mode_resolve_menu_plugin_file( $item[2] ),
+			'pluginName' => null,
 		);
+		if ( $dock_item['pluginFile'] ) {
+			$dock_item['pluginName'] = desktop_mode_plugin_display_name( $dock_item['pluginFile'] );
+		}
 
 		/**
 		 * Filters a single dock item's data.
@@ -453,67 +457,538 @@ function desktop_mode_is_core_menu_slug( $menu_slug ) {
  *                     when the slug isn't owned by a deactivatable plugin.
  */
 function desktop_mode_resolve_menu_plugin_file( $menu_slug ) {
-	if ( desktop_mode_is_core_menu_slug( $menu_slug ) ) {
+	$slug = (string) $menu_slug;
+
+	// `get_plugin_page_hookname` + `get_plugins` come from
+	// `wp-admin/includes/plugin.php`, which Core loads itself on
+	// every admin request. The resolver only runs in admin context
+	// (called during `admin_enqueue_scripts` and the `_admin_menu`
+	// tracker), so the symbols are always available. Bail rather
+	// than `require_once` something that's Core's job to load.
+	if ( ! function_exists( 'get_plugin_page_hookname' ) || ! function_exists( 'get_plugins' ) ) {
 		return null;
 	}
 
+	$self_basename = defined( 'DESKTOP_MODE_FILE' ) ? plugin_basename( DESKTOP_MODE_FILE ) : '';
+
+	// Strategy 1 — registration-time attribution. The admin_menu hook
+	// wrapper (see `desktop_mode_install_menu_attribution_tracker`) snapshots
+	// `$menu`/`$submenu` around every admin_menu callback and records
+	// "this plugin file added this slug". This is the authoritative
+	// source — it captures menus whose page hook isn't predictable from
+	// the slug (e.g. WC's `wc-admin&path=/marketing`) and handles
+	// callbacks that simply forward to a shared renderer (which
+	// reflection would mis-attribute).
+	$map = desktop_mode_menu_attribution_map();
+	if ( isset( $map[ $slug ] ) ) {
+		$plugin_file = $map[ $slug ];
+		if ( $self_basename && $plugin_file === $self_basename ) {
+			return null;
+		}
+		return $plugin_file;
+	}
+
+	// Strategy 2 — CPT / taxonomy registration tracker. Core's `edit.php`
+	// / `edit-tags.php` handle the render, so the page hook would never
+	// point at the registering plugin. We caught the plugin at
+	// `register_post_type()` / `register_taxonomy()` time via
+	// `debug_backtrace()`.
+	$tracked = desktop_mode_lookup_taxonomy_or_post_type_plugin_file( $slug );
+	if ( null !== $tracked ) {
+		if ( $self_basename && $tracked === $self_basename ) {
+			return null;
+		}
+		return $tracked;
+	}
+
+	$base = strtok( $slug, '?' );
+
+	// Cheap reject: literal core PHP files with no `?page=` parameter
+	// (the universal "a plugin registered an admin route" signal). We
+	// can't reuse `desktop_mode_is_core_menu_slug()` here — that
+	// classifier strtok's the query string and treats `admin.php?page=foo`
+	// as core, which would hide every plugin-registered top-level tile.
+	if ( desktop_mode_is_pure_core_file( $base ) && false === strpos( $slug, '?page=' ) ) {
+		return null;
+	}
+
+	// Strategy 3 — page-hook reflection fallback. The earlier strategies
+	// can miss when a plugin is loaded after admin_menu has fired (rare),
+	// or when the menu was injected by a non-admin_menu pathway. Reflect
+	// on `$wp_filter[$hookname]` to find the callback's declaring file
+	// and map it back to an active plugin.
 	global $wp_filter;
-
-	if ( ! function_exists( 'get_plugin_page_hookname' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-	if ( ! function_exists( 'get_plugins' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-
-	$hookname = get_plugin_page_hookname( (string) $menu_slug, '' );
+	$hookname = get_plugin_page_hookname( $slug, '' );
 	if ( empty( $hookname ) || empty( $wp_filter[ $hookname ] ) ) {
 		return null;
 	}
 
-	$plugins_dir   = wp_normalize_path( WP_PLUGIN_DIR );
-	$installed     = get_plugins();
-	$self_basename = defined( 'DESKTOP_MODE_FILE' ) ? plugin_basename( DESKTOP_MODE_FILE ) : '';
-
 	$hook = $wp_filter[ $hookname ];
-	// `WP_Hook::$callbacks` is keyed by priority; iterate in WP's order.
 	foreach ( $hook->callbacks as $cbs ) {
 		foreach ( $cbs as $cb ) {
-			$file = desktop_mode_callback_source_file( $cb['function'] ?? null );
-			if ( ! $file ) {
+			$plugin_file = desktop_mode_plugin_file_for_callback( $cb['function'] ?? null );
+			if ( ! $plugin_file ) {
 				continue;
 			}
-			$file = wp_normalize_path( $file );
-			if ( 0 !== strpos( $file, $plugins_dir . '/' ) ) {
-				continue;
+			if ( $self_basename && $plugin_file === $self_basename ) {
+				return null;
 			}
-
-			// Derive `<folder>` from `<plugins_dir>/<folder>/…`. Plugins
-			// can ship in a folder or as a single-file plugin at the
-			// plugin-dir root — handle both.
-			$rel = ltrim( substr( $file, strlen( $plugins_dir ) ), '/' );
-			$folder = ( false !== strpos( $rel, '/' ) ) ? strtok( $rel, '/' ) : '';
-
-			foreach ( $installed as $plugin_file => $_data ) {
-				$match = false;
-				if ( '' !== $folder && 0 === strpos( $plugin_file, $folder . '/' ) ) {
-					$match = true;
-				} elseif ( '' === $folder && $plugin_file === $rel ) {
-					$match = true;
-				}
-				if ( ! $match ) {
-					continue;
-				}
-				if ( $self_basename && $plugin_file === $self_basename ) {
-					return null;
-				}
-				return $plugin_file;
-			}
+			return $plugin_file;
 		}
 	}
 
 	return null;
 }
+
+/**
+ * Map an arbitrary filesystem path inside `WP_PLUGIN_DIR` to the
+ * corresponding plugin file in `get_plugins()`. Returns null when the
+ * path isn't under the plugins directory, or doesn't match any active
+ * plugin folder.
+ *
+ * @since 0.27.0
+ *
+ * @param string $file Absolute filesystem path.
+ * @return string|null Plugin file (`<folder>/<file>.php`) or null.
+ */
+/**
+ * Look up the human-readable display name for a plugin file. Returns
+ * the plugin folder name as a last-resort fallback if `get_plugins()`
+ * has no entry (extremely rare — would mean the plugin file isn't
+ * installed but somehow registered a menu).
+ *
+ * @since 0.27.0
+ *
+ * @param string $plugin_file Plugin file relative to `WP_PLUGIN_DIR`.
+ * @return string Display name.
+ */
+function desktop_mode_plugin_display_name( $plugin_file ) {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		return strtok( $plugin_file, '/' ) ?: $plugin_file;
+	}
+	$installed = get_plugins();
+	if ( isset( $installed[ $plugin_file ]['Name'] ) && '' !== $installed[ $plugin_file ]['Name'] ) {
+		return (string) $installed[ $plugin_file ]['Name'];
+	}
+	$folder = strtok( $plugin_file, '/' );
+	return $folder ? $folder : $plugin_file;
+}
+
+function desktop_mode_plugin_file_for_path( $file ) {
+	if ( ! is_string( $file ) || '' === $file ) {
+		return null;
+	}
+	$plugins_dir = wp_normalize_path( WP_PLUGIN_DIR );
+	$norm        = wp_normalize_path( $file );
+	if ( 0 !== strpos( $norm, $plugins_dir . '/' ) ) {
+		return null;
+	}
+	if ( ! function_exists( 'get_plugins' ) ) {
+		return null;
+	}
+	$installed = get_plugins();
+
+	$rel    = ltrim( substr( $norm, strlen( $plugins_dir ) ), '/' );
+	$folder = ( false !== strpos( $rel, '/' ) ) ? strtok( $rel, '/' ) : '';
+
+	foreach ( $installed as $plugin_file => $_data ) {
+		if ( '' !== $folder && 0 === strpos( $plugin_file, $folder . '/' ) ) {
+			return $plugin_file;
+		}
+		if ( '' === $folder && $plugin_file === $rel ) {
+			return $plugin_file;
+		}
+	}
+	return null;
+}
+
+/**
+ * Convenience wrapper: reflect on a callback to find its declaring
+ * file, then map that file to an active plugin via
+ * {@see desktop_mode_plugin_file_for_path()}.
+ *
+ * @since 0.27.0
+ *
+ * @param mixed $callback A WP-style callback.
+ * @return string|null Plugin file or null.
+ */
+function desktop_mode_plugin_file_for_callback( $callback ) {
+	$file = desktop_mode_callback_source_file( $callback );
+	return $file ? desktop_mode_plugin_file_for_path( $file ) : null;
+}
+
+/**
+ * Lazy accessor + lazy initializer for the registration-time menu
+ * attribution map: `slug → plugin_file`. The map is populated by the
+ * wrapped admin_menu callbacks installed by
+ * {@see desktop_mode_install_menu_attribution_tracker()}.
+ *
+ * @since 0.27.0
+ *
+ * @return array<string,string>
+ */
+function &desktop_mode_menu_attribution_map() {
+	static $map = null;
+	if ( null === $map ) {
+		$map = array();
+	}
+	return $map;
+}
+
+/**
+ * Install admin_menu callback wrappers that record which plugin file
+ * registered each `$menu` / `$submenu` slug.
+ *
+ * Approach:
+ *
+ *   1. Hooked on `_admin_menu` priority `-PHP_INT_MAX`, just before
+ *      `admin_menu` fires.
+ *   2. Walk `$wp_filter['admin_menu']->callbacks`. For each callback,
+ *      reflect on the function to find its declaring file → plugin
+ *      file. If the callback doesn't live in `WP_PLUGIN_DIR`, leave it
+ *      alone (Core's own callbacks).
+ *   3. Replace the callback in-place with a closure that snapshots
+ *      `$menu` and `$submenu` keys, invokes the original, then diffs
+ *      the globals. Every new top-level slug and every new submenu
+ *      entry gets attributed to that plugin file.
+ *
+ * This is the source of truth for plugin → menu ownership because it
+ * captures menus regardless of slug shape, hook name predictability,
+ * or whether the plugin shares a render callback. Reflection on the
+ * page hook (in `desktop_mode_resolve_menu_plugin_file`) is now a
+ * fallback for the rare cases where the tracker wasn't able to install
+ * in time.
+ *
+ * Idempotent — runs at most once per request via a static `$installed`
+ * flag.
+ *
+ * @since 0.27.0
+ *
+ * @return void
+ */
+function desktop_mode_install_menu_attribution_tracker() {
+	static $installed = false;
+	if ( $installed ) {
+		return;
+	}
+	$installed = true;
+
+	global $wp_filter;
+	if ( empty( $wp_filter['admin_menu'] ) ) {
+		return;
+	}
+	$hook = $wp_filter['admin_menu'];
+
+	foreach ( $hook->callbacks as $priority => $cbs ) {
+		foreach ( $cbs as $id => $cb ) {
+			$orig        = $cb['function'] ?? null;
+			$plugin_file = desktop_mode_plugin_file_for_callback( $orig );
+			if ( ! $plugin_file || ! is_callable( $orig ) ) {
+				continue;
+			}
+			$accepted_args = (int) ( $cb['accepted_args'] ?? 1 );
+
+			$wrapper = static function () use ( $orig, $plugin_file ) {
+				global $menu, $submenu;
+
+				$before_top_slugs = array();
+				if ( is_array( $menu ) ) {
+					foreach ( $menu as $entry ) {
+						if ( isset( $entry[2] ) ) {
+							$before_top_slugs[ (string) $entry[2] ] = true;
+						}
+					}
+				}
+				$before_submenu_keys = is_array( $submenu ) ? array_keys( $submenu ) : array();
+				$before_submenu_sigs = array();
+				if ( is_array( $submenu ) ) {
+					foreach ( $submenu as $parent => $children ) {
+						$sigs = array();
+						foreach ( (array) $children as $child ) {
+							if ( isset( $child[2] ) ) {
+								$sigs[ (string) $child[2] ] = true;
+							}
+						}
+						$before_submenu_sigs[ $parent ] = $sigs;
+					}
+				}
+
+				$args   = func_get_args();
+				$return = call_user_func_array( $orig, $args );
+
+				$map = &desktop_mode_menu_attribution_map();
+
+				if ( is_array( $menu ) ) {
+					foreach ( $menu as $entry ) {
+						if ( ! isset( $entry[2] ) ) {
+							continue;
+						}
+						$slug = (string) $entry[2];
+						if ( ! isset( $before_top_slugs[ $slug ] ) && ! isset( $map[ $slug ] ) ) {
+							$map[ $slug ] = $plugin_file;
+						}
+					}
+				}
+
+				if ( is_array( $submenu ) ) {
+					foreach ( $submenu as $parent => $children ) {
+						$prev_sigs = $before_submenu_sigs[ $parent ] ?? array();
+						foreach ( (array) $children as $child ) {
+							if ( ! isset( $child[2] ) ) {
+								continue;
+							}
+							$slug = (string) $child[2];
+							if ( isset( $prev_sigs[ $slug ] ) ) {
+								continue;
+							}
+							if ( ! isset( $map[ $slug ] ) ) {
+								$map[ $slug ] = $plugin_file;
+							}
+							// Also attribute the parent if it isn't
+							// already attributed and Core doesn't own it.
+							// Lets a submenu-only plugin (registered
+							// under a Core parent like `tools.php`) be
+							// resolvable too.
+						}
+						if (
+							! in_array( $parent, $before_submenu_keys, true )
+							&& ! isset( $map[ $parent ] )
+						) {
+							$map[ $parent ] = $plugin_file;
+						}
+					}
+				}
+
+				return $return;
+			};
+
+			// Preserve the `accepted_args` metadata so callbacks
+			// expecting parameters from `do_action_ref_array()` still
+			// receive them. The wrapper uses `func_get_args()` so it
+			// forwards everything.
+			$wp_filter['admin_menu']->callbacks[ $priority ][ $id ] = array(
+				'function'      => $wrapper,
+				'accepted_args' => $accepted_args,
+			);
+		}
+	}
+}
+
+add_action( '_admin_menu', 'desktop_mode_install_menu_attribution_tracker', -PHP_INT_MAX );
+add_action( '_network_admin_menu', 'desktop_mode_install_menu_attribution_tracker', -PHP_INT_MAX );
+add_action( '_user_admin_menu', 'desktop_mode_install_menu_attribution_tracker', -PHP_INT_MAX );
+
+/**
+ * The subset of `desktop_mode_is_core_menu_slug`'s "core files" that's
+ * actually owned by Core regardless of any query string — this is what
+ * we use inside the plugin-file resolver to reject Posts / Pages / etc.
+ * without rejecting `admin.php?page=…` (a universal plugin signal that
+ * the public is_core classifier also incorrectly treats as core for
+ * legacy reasons we don't want to disturb).
+ *
+ * The list intentionally drops `admin.php` so plugin-registered
+ * top-level pages can still be resolved.
+ *
+ * @since 0.27.0
+ *
+ * @param string $base Slug with query string already stripped.
+ * @return bool True when the base filename is a Core admin handler.
+ */
+function desktop_mode_is_pure_core_file( $base ) {
+	$core_files = array(
+		'index.php',
+		'edit-comments.php',
+		'upload.php',
+		'term.php',
+		'post-new.php',
+		'post.php',
+		'themes.php',
+		'nav-menus.php',
+		'widgets.php',
+		'customize.php',
+		'plugins.php',
+		'plugin-install.php',
+		'plugin-editor.php',
+		'users.php',
+		'user-new.php',
+		'profile.php',
+		'user-edit.php',
+		'tools.php',
+		'import.php',
+		'export.php',
+		'site-health.php',
+		'export-personal-data.php',
+		'erase-personal-data.php',
+		'options-general.php',
+		'options-writing.php',
+		'options-reading.php',
+		'options-discussion.php',
+		'options-media.php',
+		'options-permalink.php',
+		'options-privacy.php',
+		'link-manager.php',
+		'update-core.php',
+	);
+	return in_array( $base, $core_files, true );
+}
+
+/**
+ * Resolve a CPT / taxonomy URL slug (`edit.php?post_type=X` or
+ * `edit-tags.php?taxonomy=Y`) to the plugin file that registered the
+ * type. The mapping is built lazily on `init` by capturing the
+ * filename of whichever code called `register_post_type()` /
+ * `register_taxonomy()` for non-builtin types.
+ *
+ * Returns null when the slug isn't a CPT / taxonomy URL, when the
+ * registered type is builtin, or when the registrant lives outside
+ * `WP_PLUGIN_DIR` (theme-registered or mu-plugin).
+ *
+ * @since 0.27.0
+ *
+ * @param string $slug Menu slug.
+ * @return string|null Plugin file or null.
+ */
+function desktop_mode_lookup_taxonomy_or_post_type_plugin_file( $slug ) {
+	if ( false !== strpos( $slug, 'edit.php?' ) && false !== strpos( $slug, 'post_type=' ) ) {
+		$qs = parse_url( 'http://x/' . ltrim( $slug, '/' ), PHP_URL_QUERY );
+		parse_str( (string) $qs, $args );
+		$pt = isset( $args['post_type'] ) ? (string) $args['post_type'] : '';
+		if ( '' === $pt ) {
+			return null;
+		}
+		$map = desktop_mode_get_typed_plugin_map();
+		return $map['post_type'][ $pt ] ?? null;
+	}
+	if ( false !== strpos( $slug, 'edit-tags.php?' ) && false !== strpos( $slug, 'taxonomy=' ) ) {
+		$qs = parse_url( 'http://x/' . ltrim( $slug, '/' ), PHP_URL_QUERY );
+		parse_str( (string) $qs, $args );
+		$tx = isset( $args['taxonomy'] ) ? (string) $args['taxonomy'] : '';
+		if ( '' === $tx ) {
+			return null;
+		}
+		$map = desktop_mode_get_typed_plugin_map();
+		return $map['taxonomy'][ $tx ] ?? null;
+	}
+	return null;
+}
+
+/**
+ * Lazy accessor for the CPT/taxonomy → plugin file map. The map is
+ * populated by `desktop_mode_record_type_registrant()` (hooked early on
+ * `init`), so by the time the dock payload is built — on
+ * `admin_enqueue_scripts`, well after `init` — every plugin-registered
+ * non-builtin type has an entry. Stored in a static so repeated
+ * lookups during a single request don't trigger the populator twice.
+ *
+ * @since 0.27.0
+ *
+ * @return array{post_type: array<string,string>, taxonomy: array<string,string>}
+ */
+function &desktop_mode_get_typed_plugin_map() {
+	static $map = null;
+	if ( null === $map ) {
+		$map = array(
+			'post_type' => array(),
+			'taxonomy'  => array(),
+		);
+	}
+	return $map;
+}
+
+/**
+ * Record the registering plugin file for a CPT or taxonomy. Hooked at
+ * `registered_post_type` / `registered_taxonomy` priority 9999 so we
+ * fire after every other listener has run (lets a plugin re-register
+ * its own type on top of someone else's — last writer wins, which
+ * matches WP's runtime semantics).
+ *
+ * Resolution is via `debug_backtrace()`: walk frames until we hit one
+ * whose `file` lives under `WP_PLUGIN_DIR`, then map the folder back
+ * to a `get_plugins()` entry. Cheap — the backtrace is bounded to 12
+ * frames and runs once per type registration, all during `init`.
+ *
+ * @since 0.27.0
+ *
+ * @param string $type_or_post_type Type name (CPT or taxonomy).
+ * @param string $kind              Either `'post_type'` or `'taxonomy'`.
+ * @return void
+ */
+function desktop_mode_record_type_registrant( $type_or_post_type, $kind ) {
+	if ( '' === (string) $type_or_post_type ) {
+		return;
+	}
+	// Skip Core builtin types — they're registered from Core itself
+	// (Posts, Pages, Categories, …) and the backtrace would never land
+	// inside WP_PLUGIN_DIR anyway. Cheap pre-filter.
+	if ( 'post_type' === $kind ) {
+		$obj = get_post_type_object( $type_or_post_type );
+		if ( $obj && ! empty( $obj->_builtin ) ) {
+			return;
+		}
+	} elseif ( 'taxonomy' === $kind ) {
+		$obj = get_taxonomy( $type_or_post_type );
+		if ( $obj && ! empty( $obj->_builtin ) ) {
+			return;
+		}
+	}
+
+	$plugin_file = desktop_mode_plugin_file_for_callback_backtrace();
+	if ( null === $plugin_file ) {
+		return;
+	}
+	$map = &desktop_mode_get_typed_plugin_map();
+	$map[ $kind ][ $type_or_post_type ] = $plugin_file;
+}
+
+/**
+ * Walk the current PHP backtrace and return the plugin file owning
+ * the closest frame inside `WP_PLUGIN_DIR`. Returns null when no
+ * frame qualifies or when `get_plugins()` isn't available (Core
+ * hasn't loaded `wp-admin/includes/plugin.php` yet — true on
+ * non-admin requests and very early admin bootstrap).
+ *
+ * Used by the CPT / taxonomy registration tracker to attribute
+ * `register_post_type()` / `register_taxonomy()` calls without
+ * forcing Core to load its admin include earlier than it would.
+ *
+ * @since 0.27.0
+ *
+ * @return string|null Plugin file or null.
+ */
+function desktop_mode_plugin_file_for_callback_backtrace() {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		return null;
+	}
+	$bt = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 12 );
+	foreach ( $bt as $frame ) {
+		if ( empty( $frame['file'] ) ) {
+			continue;
+		}
+		$plugin_file = desktop_mode_plugin_file_for_path( (string) $frame['file'] );
+		if ( null !== $plugin_file ) {
+			return $plugin_file;
+		}
+	}
+	return null;
+}
+
+add_action(
+	'registered_post_type',
+	static function ( $post_type ) {
+		desktop_mode_record_type_registrant( $post_type, 'post_type' );
+	},
+	9999,
+	1
+);
+
+add_action(
+	'registered_taxonomy',
+	static function ( $taxonomy ) {
+		desktop_mode_record_type_registrant( $taxonomy, 'taxonomy' );
+	},
+	9999,
+	1
+);
 
 /**
  * Resolve the declaring file of a hook callback. Handles closures,

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -850,7 +850,7 @@ function desktop_mode_is_pure_core_file( $base ) {
  */
 function desktop_mode_lookup_taxonomy_or_post_type_plugin_file( $slug ) {
 	if ( false !== strpos( $slug, 'edit.php?' ) && false !== strpos( $slug, 'post_type=' ) ) {
-		$qs = parse_url( 'http://x/' . ltrim( $slug, '/' ), PHP_URL_QUERY );
+		$qs = wp_parse_url( 'http://x/' . ltrim( $slug, '/' ), PHP_URL_QUERY );
 		parse_str( (string) $qs, $args );
 		$pt = isset( $args['post_type'] ) ? (string) $args['post_type'] : '';
 		if ( '' === $pt ) {
@@ -860,7 +860,7 @@ function desktop_mode_lookup_taxonomy_or_post_type_plugin_file( $slug ) {
 		return $map['post_type'][ $pt ] ?? null;
 	}
 	if ( false !== strpos( $slug, 'edit-tags.php?' ) && false !== strpos( $slug, 'taxonomy=' ) ) {
-		$qs = parse_url( 'http://x/' . ltrim( $slug, '/' ), PHP_URL_QUERY );
+		$qs = wp_parse_url( 'http://x/' . ltrim( $slug, '/' ), PHP_URL_QUERY );
 		parse_str( (string) $qs, $args );
 		$tx = isset( $args['taxonomy'] ) ? (string) $args['taxonomy'] : '';
 		if ( '' === $tx ) {

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -166,9 +166,10 @@ function desktop_mode_build_dock_items() {
 			'url'       => $url,
 			'badge'     => $badge,
 			'submenu'   => $sub_items,
-			'multi'     => desktop_mode_dock_item_is_multi( $item[2] ),
-			'placement' => desktop_mode_dock_placement( $item[2] ),
-			'isCore'    => desktop_mode_is_core_menu_slug( $item[2] ),
+			'multi'      => desktop_mode_dock_item_is_multi( $item[2] ),
+			'placement'  => desktop_mode_dock_placement( $item[2] ),
+			'isCore'     => desktop_mode_is_core_menu_slug( $item[2] ),
+			'pluginFile' => desktop_mode_resolve_menu_plugin_file( $item[2] ),
 		);
 
 		/**
@@ -416,6 +417,138 @@ function desktop_mode_is_core_menu_slug( $menu_slug ) {
 	);
 
 	return in_array( $base, $core_files, true );
+}
+
+/**
+ * Resolve the plugin file (e.g. `woocommerce/woocommerce.php`) that owns
+ * a given top-level admin menu slug, by reflecting on the callbacks
+ * registered for the menu's page hook.
+ *
+ * Returns the plugin's main file path (relative to `WP_PLUGIN_DIR`) when
+ * the menu was registered by a regular plugin, `null` otherwise. Core
+ * menus, mu-plugins, drop-ins, theme-registered menus, and Desktop Mode
+ * itself all return `null` — none of these are deactivatable through the
+ * `wp/v2/plugins` REST route, so the dock right-click menu should not
+ * offer a deactivate action for them.
+ *
+ * Resolution algorithm:
+ *
+ *   1. Skip core menu slugs outright — `plugins.php`, `edit.php?post_type=…`,
+ *      etc. are never owned by a deactivatable plugin.
+ *   2. Compute the page hookname via `get_plugin_page_hookname()` and read
+ *      `$wp_filter[ $hookname ]->callbacks`. This is the action list WP
+ *      walks to render the menu's body — the plugin's own render callback
+ *      lives here.
+ *   3. Reflect each callback to find its declaring file. Match the file
+ *      path against `WP_PLUGIN_DIR/<folder>/…` and use `<folder>` to look
+ *      up an entry in `get_plugins()`. Return the matching `<folder>/<file>.php`.
+ *   4. Exclude Desktop Mode itself — deactivating from inside the shell
+ *      is handled by the plugins-window's self-deactivate path.
+ *
+ * @since 0.27.0
+ *
+ * @param string $menu_slug The menu slug from `$menu[$i][2]` (e.g. `woocommerce`,
+ *                          `admin.php?page=jetpack`, `edit.php?post_type=foo`).
+ * @return string|null Plugin file path relative to `WP_PLUGIN_DIR`, or null
+ *                     when the slug isn't owned by a deactivatable plugin.
+ */
+function desktop_mode_resolve_menu_plugin_file( $menu_slug ) {
+	if ( desktop_mode_is_core_menu_slug( $menu_slug ) ) {
+		return null;
+	}
+
+	global $wp_filter;
+
+	if ( ! function_exists( 'get_plugin_page_hookname' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$hookname = get_plugin_page_hookname( (string) $menu_slug, '' );
+	if ( empty( $hookname ) || empty( $wp_filter[ $hookname ] ) ) {
+		return null;
+	}
+
+	$plugins_dir   = wp_normalize_path( WP_PLUGIN_DIR );
+	$installed     = get_plugins();
+	$self_basename = defined( 'DESKTOP_MODE_FILE' ) ? plugin_basename( DESKTOP_MODE_FILE ) : '';
+
+	$hook = $wp_filter[ $hookname ];
+	// `WP_Hook::$callbacks` is keyed by priority; iterate in WP's order.
+	foreach ( $hook->callbacks as $cbs ) {
+		foreach ( $cbs as $cb ) {
+			$file = desktop_mode_callback_source_file( $cb['function'] ?? null );
+			if ( ! $file ) {
+				continue;
+			}
+			$file = wp_normalize_path( $file );
+			if ( 0 !== strpos( $file, $plugins_dir . '/' ) ) {
+				continue;
+			}
+
+			// Derive `<folder>` from `<plugins_dir>/<folder>/…`. Plugins
+			// can ship in a folder or as a single-file plugin at the
+			// plugin-dir root — handle both.
+			$rel = ltrim( substr( $file, strlen( $plugins_dir ) ), '/' );
+			$folder = ( false !== strpos( $rel, '/' ) ) ? strtok( $rel, '/' ) : '';
+
+			foreach ( $installed as $plugin_file => $_data ) {
+				$match = false;
+				if ( '' !== $folder && 0 === strpos( $plugin_file, $folder . '/' ) ) {
+					$match = true;
+				} elseif ( '' === $folder && $plugin_file === $rel ) {
+					$match = true;
+				}
+				if ( ! $match ) {
+					continue;
+				}
+				if ( $self_basename && $plugin_file === $self_basename ) {
+					return null;
+				}
+				return $plugin_file;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Resolve the declaring file of a hook callback. Handles closures,
+ * `[ $object, 'method' ]`, `[ 'Class', 'method' ]`, plain function names,
+ * and `'Class::method'` strings. Returns null when reflection fails or
+ * the callback shape isn't reflectable (rare — e.g. an invocable object
+ * whose `__invoke` lives in PHP core).
+ *
+ * @since 0.27.0
+ *
+ * @param mixed $callback A callback as stored in `WP_Hook::$callbacks[$prio][$id]['function']`.
+ * @return string|null Absolute filesystem path of the declaring file, or null.
+ */
+function desktop_mode_callback_source_file( $callback ) {
+	if ( empty( $callback ) ) {
+		return null;
+	}
+	try {
+		if ( is_string( $callback ) && false !== strpos( $callback, '::' ) ) {
+			list( $class, $method ) = explode( '::', $callback, 2 );
+			$ref = new ReflectionMethod( $class, $method );
+		} elseif ( is_array( $callback ) && isset( $callback[0], $callback[1] ) ) {
+			$ref = new ReflectionMethod( $callback[0], (string) $callback[1] );
+		} elseif ( is_object( $callback ) && ! ( $callback instanceof Closure ) && method_exists( $callback, '__invoke' ) ) {
+			$ref = new ReflectionMethod( $callback, '__invoke' );
+		} elseif ( is_callable( $callback ) ) {
+			$ref = new ReflectionFunction( $callback );
+		} else {
+			return null;
+		}
+		$file = $ref->getFileName();
+		return $file ? $file : null;
+	} catch ( ReflectionException $e ) {
+		return null;
+	}
 }
 
 /**

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -541,17 +541,6 @@ function desktop_mode_resolve_menu_plugin_file( $menu_slug ) {
 }
 
 /**
- * Map an arbitrary filesystem path inside `WP_PLUGIN_DIR` to the
- * corresponding plugin file in `get_plugins()`. Returns null when the
- * path isn't under the plugins directory, or doesn't match any active
- * plugin folder.
- *
- * @since 0.27.0
- *
- * @param string $file Absolute filesystem path.
- * @return string|null Plugin file (`<folder>/<file>.php`) or null.
- */
-/**
  * Look up the human-readable display name for a plugin file. Returns
  * the plugin folder name as a last-resort fallback if `get_plugins()`
  * has no entry (extremely rare — would mean the plugin file isn't
@@ -574,6 +563,17 @@ function desktop_mode_plugin_display_name( $plugin_file ) {
 	return $folder ? $folder : $plugin_file;
 }
 
+/**
+ * Map an arbitrary filesystem path inside `WP_PLUGIN_DIR` to the
+ * corresponding plugin file in `get_plugins()`. Returns null when the
+ * path isn't under the plugins directory, or doesn't match any active
+ * plugin folder.
+ *
+ * @since 0.27.0
+ *
+ * @param string $file Absolute filesystem path.
+ * @return string|null Plugin file (`<folder>/<file>.php`) or null.
+ */
 function desktop_mode_plugin_file_for_path( $file ) {
 	if ( ! is_string( $file ) || '' === $file ) {
 		return null;

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -109,6 +109,15 @@ export interface DockItem {
 	 * in `desktop_mode_is_core_menu_slug`.
 	 */
 	isCore?: boolean;
+	/**
+	 * Plugin file (e.g. `woocommerce/woocommerce.php`) that owns this
+	 * menu, when resolvable. Set server-side by
+	 * `desktop_mode_resolve_menu_plugin_file()`. Used by the dock
+	 * right-click menu to surface a "Deactivate plugin" action. Always
+	 * `null` for core menus, mu-plugins, drop-ins, and Desktop Mode
+	 * itself — none of those are deactivatable via `wp/v2/plugins`.
+	 */
+	pluginFile?: string | null;
 }
 
 /** Which edge of the screen the rail hugs. Drives tooltip anchoring + modifier CSS. */
@@ -905,6 +914,7 @@ export class Dock {
 				id: item.id,
 				title: item.title,
 				surface: 'dock',
+				pluginFile: item.pluginFile ?? null,
 			} );
 		} );
 

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -118,6 +118,15 @@ export interface DockItem {
 	 * itself — none of those are deactivatable via `wp/v2/plugins`.
 	 */
 	pluginFile?: string | null;
+	/**
+	 * Human-readable display name of the owning plugin (e.g.
+	 * `"WooCommerce"`), as read from the plugin header's `Name:` field
+	 * via `get_plugins()`. Used in the right-click "Deactivate …"
+	 * label so a sub-page tile (e.g. WC's "Analytics") still presents
+	 * the parent plugin's identity in the destructive action. Null
+	 * when `pluginFile` is null.
+	 */
+	pluginName?: string | null;
 }
 
 /** Which edge of the screen the rail hugs. Drives tooltip anchoring + modifier CSS. */
@@ -915,6 +924,7 @@ export class Dock {
 				title: item.title,
 				surface: 'dock',
 				pluginFile: item.pluginFile ?? null,
+				pluginName: item.pluginName ?? null,
 			} );
 		} );
 

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -22,9 +22,13 @@
  * @since 0.25.0
  */
 
-import { __ } from './i18n';
+import { __, sprintf } from './i18n';
 import { openWithShellOverlays } from './shell-overlays/loader';
 import { canonicalItemId } from './settings/item-placement';
+import { wpdConfirm } from './ui/components/wpd-confirm-dialog/wpd-confirm-dialog';
+import { trackedFetch } from './tracked-fetch';
+import { showToast } from './toast';
+import { joinRestUrl } from './rest-url';
 import type { ItemVisibility } from './settings/types';
 import type { OsSettingsSnapshot } from './settings/registry';
 
@@ -80,6 +84,15 @@ export interface OpenItemVisibilityMenuOpts {
 	title: string;
 	/** Which surface the user right-clicked on. */
 	surface: 'dock' | 'desktop';
+	/**
+	 * Plugin file (e.g. `woocommerce/woocommerce.php`) when the item is
+	 * owned by an active, deactivatable plugin. When non-null the menu
+	 * surfaces a "Deactivate <title>" action that calls
+	 * `PUT /wp/v2/plugins/<file>` with `{ status: 'inactive' }`.
+	 *
+	 * @since 0.27.0
+	 */
+	pluginFile?: string | null;
 }
 
 /**
@@ -120,13 +133,16 @@ function openItemVisibilityMenuImmediate(
 
 	const canonical = canonicalItemId( opts.id );
 
-	type MenuOption = {
-		id: string;
-		label: string;
-		icon?: string;
-		danger?: boolean;
-		onPick: () => void;
-	};
+	type MenuOption =
+		| {
+				kind?: 'option';
+				id: string;
+				label: string;
+				icon?: string;
+				danger?: boolean;
+				onPick: () => void;
+			}
+		| { kind: 'separator' };
 
 	const options: MenuOption[] = [];
 
@@ -175,6 +191,25 @@ function openItemVisibilityMenuImmediate(
 		},
 	} );
 
+	// When the tile is owned by an active, deactivatable plugin, surface
+	// a danger action at the bottom. `pluginFile` is `null` for core
+	// menus, mu-plugins, drop-ins, and Desktop Mode itself — see
+	// `desktop_mode_resolve_menu_plugin_file()`.
+	if ( opts.pluginFile ) {
+		const pluginFile = opts.pluginFile;
+		options.push( { kind: 'separator' } );
+		options.push( {
+			id: 'deactivate-plugin',
+			// translators: %s is the dock tile's display title.
+			label: sprintf( __( 'Deactivate %s…' ), opts.title ),
+			icon: 'dashicons-trash',
+			danger: true,
+			onPick: () => {
+				void confirmAndDeactivatePlugin( pluginFile, opts.title );
+			},
+		} );
+	}
+
 	const menu = document.createElement( 'wpd-context-menu' );
 	menu.setAttribute( 'open', '' );
 	menu.classList.add( 'desktop-mode-item-visibility-menu' );
@@ -186,8 +221,16 @@ function openItemVisibilityMenuImmediate(
 	menu.style.visibility = 'hidden';
 	menu.style.zIndex = '10000';
 
-	const byKey = new Map< string, MenuOption >();
+	type PickableOption = Exclude< MenuOption, { kind: 'separator' } >;
+	const byKey = new Map< string, PickableOption >();
 	for ( const opt of options ) {
+		if ( opt.kind === 'separator' ) {
+			const hr = document.createElement( 'hr' );
+			hr.style.cssText =
+				'border: 0; border-top: 1px solid rgba(255,255,255,0.12); margin: 4px 6px;';
+			menu.appendChild( hr );
+			continue;
+		}
 		byKey.set( opt.id, opt );
 		const node = document.createElement( 'wpd-context-menu-option' );
 		// `<wpd-context-menu-option>` emits `detail.id` from
@@ -285,4 +328,112 @@ function openItemVisibilityMenuImmediate(
 	};
 	document.addEventListener( 'mousedown', onOutside, true );
 	document.addEventListener( 'keydown', onKey, true );
+}
+
+/**
+ * Confirm + deactivate a plugin by file path. On success the dock
+ * auto-refreshes via the existing `desktop-mode-plugins-changed`
+ * postMessage path that the chromeless bridge fires when WP repaints
+ * the admin menu — but the user right-clicked from the shell, not
+ * from `plugins.php`, so we additionally call `wp.desktop.refreshMenu()`
+ * (when available) to trigger the hidden-iframe probe.
+ *
+ * @since 0.27.0
+ */
+async function confirmAndDeactivatePlugin(
+	pluginFile: string,
+	title: string,
+): Promise< void > {
+	const confirmed = await wpdConfirm( {
+		/* translators: %s: plugin title. */
+		title: sprintf( __( 'Deactivate %s?' ), title ),
+		message: __(
+			'This plugin will stop running on the site. You can re-activate it later from the Plugins screen.',
+		),
+		confirmLabel: __( 'Deactivate' ),
+		cancelLabel: __( 'Cancel' ),
+		danger: true,
+	} );
+	if ( ! confirmed ) {
+		return;
+	}
+
+	type ConfigShape = { restRoot?: string; restNonce?: string };
+	const cfg =
+		( window as unknown as { desktopModeConfig?: ConfigShape } )
+			.desktopModeConfig ?? {};
+	const restRoot =
+		typeof cfg.restRoot === 'string' && cfg.restRoot
+			? cfg.restRoot
+			: `${ window.location.origin }/wp-json/`;
+	const restNonce =
+		typeof cfg.restNonce === 'string' && cfg.restNonce ? cfg.restNonce : '';
+
+	// Core's REST route is registered with regex
+	// `(?P<plugin>[^.\/]+(?:\/[^.\/]+)?)` — segments may not contain
+	// dots, which means the `.php` extension on the plugin file MUST
+	// be stripped before it goes into the URL (Core's REST controller
+	// already returns the stripped form on read). And literal slashes
+	// must be preserved (Apache's `AllowEncodedSlashes Off` default
+	// rejects `%2F`), so we encode each segment individually and
+	// rejoin with `/`. Same pattern as the plugins-window's
+	// `encodePluginPath()`.
+	const stripped = pluginFile.endsWith( '.php' )
+		? pluginFile.slice( 0, -4 )
+		: pluginFile;
+	const encoded = stripped
+		.split( '/' )
+		.map( encodeURIComponent )
+		.join( '/' );
+	const url = joinRestUrl( restRoot, `wp/v2/plugins/${ encoded }` );
+
+	try {
+		const res = await trackedFetch(
+			url,
+			{
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': restNonce,
+				},
+				body: JSON.stringify( { status: 'inactive' } ),
+				credentials: 'same-origin',
+			},
+			{ source: 'desktop-mode/dock-deactivate-plugin' },
+		);
+		if ( ! res.ok ) {
+			throw new Error( `HTTP ${ res.status }` );
+		}
+	} catch ( err ) {
+		showToast( {
+			message: sprintf(
+				/* translators: %s: plugin title. */
+				__( 'Could not deactivate %s.' ),
+				title,
+			),
+			duration: 4000,
+		} );
+		// Surface for debugging — the activity-bus already logged the
+		// failed fetch through trackedFetch.
+		// eslint-disable-next-line no-console
+		console.error( '[desktop-mode] deactivate plugin failed', err );
+		return;
+	}
+
+	showToast( {
+		message: sprintf(
+			/* translators: %s: plugin title. */
+			__( '%s deactivated.' ),
+			title,
+		),
+		duration: 3000,
+	} );
+
+	// Ask the shell to repaint the dock from a fresh menu probe. The
+	// dock's own `desktop-mode-plugins-changed` listener will pick up
+	// the new $menu shape and remove the now-inactive plugin's tile.
+	const w = window as unknown as {
+		wp?: { desktop?: { refreshMenu?: () => void } };
+	};
+	w.wp?.desktop?.refreshMenu?.();
 }

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -93,6 +93,15 @@ export interface OpenItemVisibilityMenuOpts {
 	 * @since 0.27.0
 	 */
 	pluginFile?: string | null;
+	/**
+	 * Owning plugin's display name (e.g. `"WooCommerce"`). When the
+	 * dock tile is a sub-page (Analytics, Marketing, …) this is the
+	 * label we show in the destructive action — the user is
+	 * deactivating the plugin, not the tile.
+	 *
+	 * @since 0.27.0
+	 */
+	pluginName?: string | null;
 }
 
 /**
@@ -197,15 +206,20 @@ function openItemVisibilityMenuImmediate(
 	// `desktop_mode_resolve_menu_plugin_file()`.
 	if ( opts.pluginFile ) {
 		const pluginFile = opts.pluginFile;
+		// Prefer the owning plugin's display name so a sub-page tile
+		// (e.g. WC's "Analytics") reads as "Deactivate WooCommerce…".
+		// Falls back to the tile title for plugins whose `Name:` header
+		// is missing — extremely rare, but cheaper than throwing.
+		const pluginLabel = opts.pluginName || opts.title;
 		options.push( { kind: 'separator' } );
 		options.push( {
 			id: 'deactivate-plugin',
-			// translators: %s is the dock tile's display title.
-			label: sprintf( __( 'Deactivate %s…' ), opts.title ),
+			// translators: %s is the owning plugin's display name.
+			label: sprintf( __( 'Deactivate %s…' ), pluginLabel ),
 			icon: 'dashicons-trash',
 			danger: true,
 			onPick: () => {
-				void confirmAndDeactivatePlugin( pluginFile, opts.title );
+				void confirmAndDeactivatePlugin( pluginFile, pluginLabel );
 			},
 		} );
 	}
@@ -219,15 +233,23 @@ function openItemVisibilityMenuImmediate(
 	menu.style.left = '-9999px';
 	menu.style.top = '-9999px';
 	menu.style.visibility = 'hidden';
-	menu.style.zIndex = '10000';
+	// Must sit above the dock-peek popover (z-index: 999999 in
+	// assets/css/dock-peek.css). The peek is still visible when the
+	// user right-clicks a tile, so without this the menu opens
+	// underneath the thumbnail strip.
+	menu.style.zIndex = '1000000';
 
 	type PickableOption = Exclude< MenuOption, { kind: 'separator' } >;
 	const byKey = new Map< string, PickableOption >();
 	for ( const opt of options ) {
 		if ( opt.kind === 'separator' ) {
 			const hr = document.createElement( 'hr' );
+			// Pull the separator color from a CSS variable so light-mode
+			// docks and theme overrides can re-color it without touching
+			// JS. Fallback matches the dark dock chrome the rest of
+			// `<wpd-context-menu>` is built against.
 			hr.style.cssText =
-				'border: 0; border-top: 1px solid rgba(255,255,255,0.12); margin: 4px 6px;';
+				'border: 0; border-top: 1px solid var( --wpd-context-menu-separator-color, rgba(255,255,255,0.12) ); margin: 4px 6px;';
 			menu.appendChild( hr );
 			continue;
 		}
@@ -420,14 +442,28 @@ async function confirmAndDeactivatePlugin(
 		return;
 	}
 
-	showToast( {
-		message: sprintf(
-			/* translators: %s: plugin title. */
-			__( '%s deactivated.' ),
-			title,
-		),
-		duration: 3000,
-	} );
+	// Close every open window that belongs to the deactivated plugin —
+	// otherwise the user is left with an iframe pointing at a now-403
+	// admin route (or a native window whose render bundle just stopped
+	// loading). Walk the current menu, find dock items whose
+	// `pluginFile` matches the target, then close every instance
+	// keyed by that item's derived window id.
+	const closedTitles = closeWindowsForPlugin( pluginFile );
+
+	const deactivatedMsg =
+		closedTitles.length > 0
+			? sprintf(
+				/* translators: 1: plugin title. 2: number of windows that were closed. */
+				__( '%1$s deactivated. Closed %2$d window(s).' ),
+				title,
+				closedTitles.length,
+			)
+			: sprintf(
+				/* translators: %s: plugin title. */
+				__( '%s deactivated.' ),
+				title,
+			);
+	showToast( { message: deactivatedMsg, duration: 3000 } );
 
 	// Ask the shell to repaint the dock from a fresh menu probe. The
 	// dock's own `desktop-mode-plugins-changed` listener will pick up
@@ -436,4 +472,124 @@ async function confirmAndDeactivatePlugin(
 		wp?: { desktop?: { refreshMenu?: () => void } };
 	};
 	w.wp?.desktop?.refreshMenu?.();
+}
+
+/**
+ * Close every open window owned by `pluginFile`. Returns the titles
+ * of windows that were closed (used by the deactivation toast).
+ *
+ * Lookup pathway:
+ *
+ *   1. Read the current dock items via `wp.desktop.getMenuItems()`.
+ *      Each item carries the `pluginFile` resolved server-side.
+ *   2. For each matching item, derive the window `baseId` from its
+ *      url and close every instance under that base (`getAllByBaseId`)
+ *      plus any singleton keyed under the dock item id itself
+ *      (`getById( item.id )`).
+ *   3. Also walk every open window once more by url substring — covers
+ *      `admin.php?page=<plugin-slug>…` instances that diverged from the
+ *      registered dock url (deep links, custom navigations).
+ *
+ * @since 0.27.0
+ */
+function closeWindowsForPlugin( pluginFile: string ): string[] {
+	interface DockItemLike {
+		id: string;
+		title: string;
+		url: string;
+		pluginFile?: string | null;
+	}
+	interface WindowLike {
+		id: string;
+		iframe?: HTMLIFrameElement | null;
+		config?: { title?: string; baseId?: string; url?: string };
+		close: () => void;
+	}
+	interface ShellShim {
+		getMenuItems?: () => DockItemLike[];
+		deriveWindowId?: ( url: string ) => string;
+		windowManager?: {
+			getAll?: () => WindowLike[];
+		};
+	}
+	const api = ( window as unknown as { wp?: { desktop?: ShellShim } } )
+		.wp?.desktop;
+	if ( ! api?.windowManager?.getAll ) {
+		return [];
+	}
+
+	const items = api.getMenuItems?.() ?? [];
+	const owned = items.filter( ( i ) => i.pluginFile === pluginFile );
+	if ( owned.length === 0 ) {
+		return [];
+	}
+
+	// Build the set of identity keys that any owned tile could
+	// produce: the slug-derived dock id AND the URL-derived window
+	// baseId (they typically agree, but session-restored or
+	// cross-rail tiles can diverge).
+	const ownedKeys = new Set< string >();
+	for ( const item of owned ) {
+		ownedKeys.add( item.id );
+		if ( api.deriveWindowId ) {
+			ownedKeys.add( api.deriveWindowId( item.url ) );
+		}
+	}
+
+	// Walk every open window once and check ownership four ways. Each
+	// path independently catches a real-world case the others miss:
+	// matching by `id` covers freshly opened singletons; matching by
+	// `config.baseId` covers multi-instance windows whose `id` is
+	// suffixed (`<baseId>-2`); deriving from `config.url` covers
+	// windows opened with a URL that differs from the dock item's
+	// landing URL (deep links); deriving from the live iframe URL
+	// covers windows that navigated away from where they started.
+	const toClose = new Map< string, WindowLike >();
+	const windows = api.windowManager.getAll() ?? [];
+	const derive = api.deriveWindowId;
+	for ( const w of windows ) {
+		if ( ownedKeys.has( w.id ) ) {
+			toClose.set( w.id, w );
+			continue;
+		}
+		if ( w.config?.baseId && ownedKeys.has( w.config.baseId ) ) {
+			toClose.set( w.id, w );
+			continue;
+		}
+		if ( derive && w.config?.url ) {
+			const derivedFromConfig = derive( w.config.url );
+			if ( ownedKeys.has( derivedFromConfig ) ) {
+				toClose.set( w.id, w );
+				continue;
+			}
+		}
+		if ( derive && w.iframe ) {
+			// `iframe.src` reflects the iframe's CURRENT location, not
+			// just its initial URL — covers the case where the user
+			// navigated a single window through several WC subpages.
+			let liveUrl = '';
+			try {
+				liveUrl = w.iframe.src || '';
+			} catch {
+				/* cross-origin iframe — leave liveUrl empty */
+			}
+			if ( liveUrl ) {
+				const derivedFromLive = derive( liveUrl );
+				if ( ownedKeys.has( derivedFromLive ) ) {
+					toClose.set( w.id, w );
+				}
+			}
+		}
+	}
+
+	const titles: string[] = [];
+	for ( const w of toClose.values() ) {
+		titles.push( w.config?.title ?? w.id );
+		try {
+			w.close();
+		} catch {
+			/* swallow — one bad close shouldn't block the rest */
+		}
+	}
+	return titles;
 }

--- a/tests/phpunit/tests/desktopModeBuildDockItems.php
+++ b/tests/phpunit/tests/desktopModeBuildDockItems.php
@@ -739,10 +739,10 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 	 * @covers ::desktop_mode_plugin_file_for_path
 	 */
 	public function test_resolve_plugin_file_returns_plugin_basename_when_callback_lives_in_plugin_dir() {
-		$fake_folder = 'dm-positive-resolver-fixture';
-		$fake_dir    = WP_PLUGIN_DIR . '/' . $fake_folder;
+		$fake_folder   = 'dm-positive-resolver-fixture';
+		$fake_dir      = WP_PLUGIN_DIR . '/' . $fake_folder;
 		$fake_basename = $fake_folder . '/' . $fake_folder . '.php';
-		$fake_file   = WP_PLUGIN_DIR . '/' . $fake_basename;
+		$fake_file     = WP_PLUGIN_DIR . '/' . $fake_basename;
 
 		if ( ! is_dir( $fake_dir ) ) {
 			mkdir( $fake_dir, 0755, true );
@@ -775,37 +775,71 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 		$hookname = get_plugin_page_hookname( $slug, '' );
 		add_action( $hookname, 'dm_positive_resolver_fixture_render' );
 
-		$resolved = desktop_mode_resolve_menu_plugin_file( $slug );
-
-		remove_action( $hookname, 'dm_positive_resolver_fixture_render' );
-		remove_filter( 'all_plugins', $inject );
-		wp_cache_delete( 'plugins', 'plugins' );
-		// Best-effort cleanup; harmless if the file is already gone.
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
-		@unlink( $fake_file );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.rmdir_rmdir
-		@rmdir( $fake_dir );
-
-		$this->assertSame( $fake_basename, $resolved );
+		// `try`/`finally` so an assertion failure can't leave the
+		// fixture directory + plugin-cache override behind for the
+		// next test run. Without this, `get_plugins()` would
+		// permanently pick up `dm-positive-resolver-fixture` as an
+		// installed plugin on subsequent runs.
+		try {
+			$resolved = desktop_mode_resolve_menu_plugin_file( $slug );
+			$this->assertSame( $fake_basename, $resolved );
+		} finally {
+			remove_action( $hookname, 'dm_positive_resolver_fixture_render' );
+			remove_filter( 'all_plugins', $inject );
+			wp_cache_delete( 'plugins', 'plugins' );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			@unlink( $fake_file );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rmdir_rmdir
+			@rmdir( $fake_dir );
+		}
 	}
 
+	/**
+	 * The self-exclusion guard fires when the page-hook reflection
+	 * lands on a callback that lives inside Desktop Mode's own folder
+	 * — the dock right-click should never offer the "Deactivate
+	 * Desktop Mode" action (that's the plugins-window's
+	 * self-deactivate path's job, which knows how to handle the
+	 * shell-shutdown side effects).
+	 *
+	 * To exercise the guard specifically (not the "no callback in
+	 * WP_PLUGIN_DIR" early return), we register a real Desktop Mode
+	 * function — `desktop_mode_is_pure_core_file()` — as the callback
+	 * on a fake page hook. Reflection on that function returns a
+	 * filename inside `WP_PLUGIN_DIR/desktop-mode/…`, so the resolver
+	 * walks through the page-hook reflection branch, matches the
+	 * desktop-mode plugin file, then hits the `$self_basename` guard
+	 * and returns null.
+	 *
+	 * @covers ::desktop_mode_resolve_menu_plugin_file
+	 */
 	public function test_resolve_plugin_file_excludes_desktop_mode_itself() {
-		$slug     = 'desktop-mode-self-test';
+		$slug     = 'desktop-mode-self-exclusion-test';
 		$hookname = get_plugin_page_hookname( $slug, '' );
-		$callback = static function () {
-			return null;
-		};
-		add_action( $hookname, $callback );
 
-		$resolved = desktop_mode_resolve_menu_plugin_file( $slug );
+		// Sanity-check the precondition the test depends on. If this
+		// fails, the test is exercising the wrong branch and should be
+		// re-thought rather than silently regress to the old "outside
+		// WP_PLUGIN_DIR" path.
+		$callback_file = ( new ReflectionFunction( 'desktop_mode_is_pure_core_file' ) )
+			->getFileName();
+		$this->assertNotFalse(
+			$callback_file,
+			'Cannot reflect on desktop_mode_is_pure_core_file — test cannot exercise self-exclusion.'
+		);
+		$this->assertStringStartsWith(
+			wp_normalize_path( WP_PLUGIN_DIR ) . '/',
+			wp_normalize_path( $callback_file ),
+			'Desktop Mode must live under WP_PLUGIN_DIR for the self-exclusion branch to trigger.'
+		);
 
-		remove_action( $hookname, $callback );
+		add_action( $hookname, 'desktop_mode_is_pure_core_file' );
+		try {
+			$resolved = desktop_mode_resolve_menu_plugin_file( $slug );
+		} finally {
+			remove_action( $hookname, 'desktop_mode_is_pure_core_file' );
+		}
 
-		// The closure is declared in this test file, which lives under
-		// `tests/phpunit/tests/` — outside `WP_PLUGIN_DIR` — so the
-		// resolver must return null. (If a future change ever placed
-		// the test harness inside the plugin dir, the self-exclusion
-		// guard below would still catch the desktop-mode case.)
 		$this->assertNull( $resolved );
 	}
 }

--- a/tests/phpunit/tests/desktopModeBuildDockItems.php
+++ b/tests/phpunit/tests/desktopModeBuildDockItems.php
@@ -685,4 +685,63 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 		$this->assertNotContains( 'menu-background-tool', $dock_ids );
 		$this->assertContains( 'menu-other-plugin', $dock_ids );
 	}
+
+	/**
+	 * Core menu slugs never resolve to a plugin file — even if some
+	 * callback happens to be registered on the page hook. The classifier
+	 * short-circuits before reflecting on $wp_filter, so the dock never
+	 * shows a "Deactivate" action for Dashboard, Posts, Plugins, etc.
+	 *
+	 * @covers ::desktop_mode_resolve_menu_plugin_file
+	 */
+	public function test_resolve_plugin_file_returns_null_for_core_slugs() {
+		$this->assertNull( desktop_mode_resolve_menu_plugin_file( 'index.php' ) );
+		$this->assertNull( desktop_mode_resolve_menu_plugin_file( 'plugins.php' ) );
+		$this->assertNull( desktop_mode_resolve_menu_plugin_file( 'edit.php' ) );
+		$this->assertNull( desktop_mode_resolve_menu_plugin_file( 'edit.php?post_type=page' ) );
+	}
+
+	/**
+	 * Unknown slugs with no registered page hook (or no plugin-owned
+	 * callbacks on it) resolve to null. The right-click menu then skips
+	 * the deactivate option entirely — better than a false positive
+	 * that would 404 on the REST mutation.
+	 *
+	 * @covers ::desktop_mode_resolve_menu_plugin_file
+	 */
+	public function test_resolve_plugin_file_returns_null_for_unknown_slug() {
+		$this->assertNull(
+			desktop_mode_resolve_menu_plugin_file( 'nonexistent-menu-slug-xyz' )
+		);
+	}
+
+	/**
+	 * Desktop Mode is always its own special case — even when its own
+	 * code registers a callback for a menu page hook, we MUST return
+	 * null so the dock right-click can never offer to deactivate the
+	 * very plugin rendering the dock. The plugins-window's
+	 * self-deactivate path handles that scenario with the right
+	 * confirmation + reload affordances.
+	 *
+	 * @covers ::desktop_mode_resolve_menu_plugin_file
+	 */
+	public function test_resolve_plugin_file_excludes_desktop_mode_itself() {
+		$slug     = 'desktop-mode-self-test';
+		$hookname = get_plugin_page_hookname( $slug, '' );
+		$callback = static function () {
+			return null;
+		};
+		add_action( $hookname, $callback );
+
+		$resolved = desktop_mode_resolve_menu_plugin_file( $slug );
+
+		remove_action( $hookname, $callback );
+
+		// The closure is declared in this test file, which lives under
+		// `tests/phpunit/tests/` — outside `WP_PLUGIN_DIR` — so the
+		// resolver must return null. (If a future change ever placed
+		// the test harness inside the plugin dir, the self-exclusion
+		// guard below would still catch the desktop-mode case.)
+		$this->assertNull( $resolved );
+	}
 }

--- a/tests/phpunit/tests/desktopModeBuildDockItems.php
+++ b/tests/phpunit/tests/desktopModeBuildDockItems.php
@@ -725,6 +725,70 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 	 *
 	 * @covers ::desktop_mode_resolve_menu_plugin_file
 	 */
+	/**
+	 * Positive path: a callback whose declaring file lives under
+	 * `WP_PLUGIN_DIR/<folder>/…` resolves to the plugin file
+	 * `get_plugins()` has under that folder.
+	 *
+	 * Setup is messy on purpose — we need a real on-disk PHP file
+	 * inside the plugins directory (Reflection reads the absolute
+	 * path) and a matching entry in `get_plugins()`. The fixture is
+	 * written, included, used, and torn down within a single test.
+	 *
+	 * @covers ::desktop_mode_resolve_menu_plugin_file
+	 * @covers ::desktop_mode_plugin_file_for_path
+	 */
+	public function test_resolve_plugin_file_returns_plugin_basename_when_callback_lives_in_plugin_dir() {
+		$fake_folder = 'dm-positive-resolver-fixture';
+		$fake_dir    = WP_PLUGIN_DIR . '/' . $fake_folder;
+		$fake_basename = $fake_folder . '/' . $fake_folder . '.php';
+		$fake_file   = WP_PLUGIN_DIR . '/' . $fake_basename;
+
+		if ( ! is_dir( $fake_dir ) ) {
+			mkdir( $fake_dir, 0755, true );
+		}
+		// Write a real plugin header so `get_plugins()` discovers the
+		// fixture on its filesystem scan after we bust the plugin cache.
+		// Without a `Plugin Name:` header WP skips the file entirely.
+		file_put_contents(
+			$fake_file,
+			"<?php\n/**\n * Plugin Name: DM Positive Resolver Fixture\n * Version: 0.0.0\n */\nfunction dm_positive_resolver_fixture_render() {}\n"
+		);
+		require_once $fake_file;
+
+		$inject = static function ( $plugins ) use ( $fake_basename ) {
+			$plugins[ $fake_basename ] = array(
+				'Name'        => 'DM Positive Resolver Fixture',
+				'Version'     => '0.0.0',
+				'Description' => 'Fixture for desktop-mode resolver test.',
+			);
+			return $plugins;
+		};
+		add_filter( 'all_plugins', $inject );
+		// `get_plugins()` caches results per request and only runs the
+		// `all_plugins` filter on a cache miss. The bootstrap has
+		// almost certainly populated that cache already, so we must
+		// invalidate it for our injected entry to be visible.
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		$slug     = 'dm-positive-resolver-fixture-page';
+		$hookname = get_plugin_page_hookname( $slug, '' );
+		add_action( $hookname, 'dm_positive_resolver_fixture_render' );
+
+		$resolved = desktop_mode_resolve_menu_plugin_file( $slug );
+
+		remove_action( $hookname, 'dm_positive_resolver_fixture_render' );
+		remove_filter( 'all_plugins', $inject );
+		wp_cache_delete( 'plugins', 'plugins' );
+		// Best-effort cleanup; harmless if the file is already gone.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		@unlink( $fake_file );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rmdir_rmdir
+		@rmdir( $fake_dir );
+
+		$this->assertSame( $fake_basename, $resolved );
+	}
+
 	public function test_resolve_plugin_file_excludes_desktop_mode_itself() {
 		$slug     = 'desktop-mode-self-test';
 		$hookname = get_plugin_page_hookname( $slug, '' );


### PR DESCRIPTION
<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-234-2743a202ae601aa364de5d43afc07ebe24b5b1af.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->