### PR TITLE
OS-file drop — progress UI, live refresh, cancel cleanup, CMO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,8 @@ docs/
     │                            or wpd-table-{filter-change,row-click,expand-change} event details.
     ├── spinner.md               UPDATE/READ WHEN: <wpd-spinner> contract changes — preset list,
     │                            attribute names, CSS-variable surface, or accessibility defaults.
+    ├── progress-bar.md          UPDATE/READ WHEN: <wpd-progress-bar> contract changes — value/max,
+    │                            indeterminate, tone list, label/show-percent header, or CSS-variable surface.
     ├── register-icon.md        UPDATE/READ WHEN: desktop_mode_register_icon() contract changes.
     ├── register-wallpaper.md   UPDATE/READ WHEN: WallpaperDef or desktop_mode_register_wallpaper() changes.
     ├── shared-store.md          UPDATE/READ WHEN: wp.desktop.createSharedStore() contract,

--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -1002,3 +1002,124 @@ button.desktop-mode-folder-status-bar__segment:hover {
 .desktop-mode-drag-ghost--reject {
 	cursor: no-drop;
 }
+
+/* ============================================================ *
+ *  Upload progress HUD (since 0.31.0)
+ *
+ *  Pinned floating panel that surfaces the OS-file-drop manager's
+ *  in-flight uploads. One row per file with a `<wpd-progress-bar>`,
+ *  a filename + status, and a Cancel/Dismiss action. The panel
+ *  hides itself when there are no rows; it's purely reactive to
+ *  the four upload-lifecycle hooks.
+ * ============================================================ */
+
+.desktop-mode-upload-hud {
+	position: fixed;
+	inset-block-end: 16px;
+	inset-inline-end: 16px;
+	width: 320px;
+	max-width: calc( 100vw - 32px );
+	background: var( --desktop-mode-panel-bg, #fff );
+	color: var( --desktop-mode-fg-on-light, #1d2327 );
+	border: 1px solid var( --desktop-mode-border, #dcdcde );
+	border-radius: 10px;
+	box-shadow: 0 8px 28px rgba( 0, 0, 0, 0.18 );
+	z-index: 99998;
+	font: inherit;
+	pointer-events: auto;
+	overflow: hidden;
+}
+
+.desktop-mode-upload-hud[ hidden ] {
+	display: none;
+}
+
+.desktop-mode-upload-hud__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 12px;
+	background: var( --desktop-mode-panel-header-bg, rgba( 0, 0, 0, 0.04 ) );
+	border-block-end: 1px solid var( --desktop-mode-border, #dcdcde );
+	font-weight: 600;
+	font-size: 12px;
+}
+
+.desktop-mode-upload-hud__title {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.desktop-mode-upload-hud__close {
+	border: 0;
+	background: transparent;
+	color: inherit;
+	font-size: 16px;
+	line-height: 1;
+	width: 22px;
+	height: 22px;
+	border-radius: 4px;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.desktop-mode-upload-hud__close:hover,
+.desktop-mode-upload-hud__close:focus-visible {
+	background: rgba( 0, 0, 0, 0.08 );
+	outline: none;
+}
+
+.desktop-mode-upload-hud__list {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	padding: 10px 12px;
+	max-height: 50vh;
+	overflow-y: auto;
+}
+
+.desktop-mode-upload-hud__row {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	grid-template-areas:
+		'meta actions'
+		'bar bar';
+	gap: 6px 8px;
+	align-items: center;
+	font-size: 12px;
+}
+
+.desktop-mode-upload-hud__meta {
+	grid-area: meta;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.desktop-mode-upload-hud__name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: 500;
+}
+
+.desktop-mode-upload-hud__status {
+	font-size: 11px;
+	opacity: 0.75;
+	font-variant-numeric: tabular-nums;
+}
+
+.desktop-mode-upload-hud__row wpd-progress-bar {
+	grid-area: bar;
+}
+
+.desktop-mode-upload-hud__actions {
+	grid-area: actions;
+	display: inline-flex;
+	gap: 4px;
+}

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -37,6 +37,7 @@ defined( 'ABSPATH' ) || exit;
 - [`<wpd-flyout>` — sliding edge-anchored panel](./wpd-flyout.md)
 - [Render a data table — filters, sticky columns, sub-tables](./data-table.md)
 - [Loading spinner — presets and color overrides](./spinner.md)
+- [Progress bar — determinate, indeterminate, tones](./progress-bar.md)
 - [Window loading state — spinner overlay + ready signal](./window-loading.md)
 - [Native windows — overview + render-callback contract](./native-windows.md)
 - [Native window with bundle-bound config (REST URLs, nonces)](./window-with-config.md)

--- a/docs/examples/os-file-drop.md
+++ b/docs/examples/os-file-drop.md
@@ -40,7 +40,7 @@ on `window.wp.hooks`). All hook names live on
 | `desktop-mode.drop.before-upload` | filter | `({ file, mime, fields }, ctx) => payload \| null` — last chance to swap the file or cancel (returning `null`). |
 | `desktop-mode.drop.upload-started` | action | _Since 0.31.0._ `{ file, fields, context, abort: () => void }` — XHR is open and about to `send()`. Call `abort()` to cancel mid-flight; the manager will reject with `UploadAbortedError`. |
 | `desktop-mode.drop.upload-progress` | action | _Since 0.31.0._ `{ file, fields, context, loaded, total, indeterminate }` — per `XMLHttpRequestUpload.progress` tick. A synthetic 100% event is fired on `upload.load`. |
-| `desktop-mode.drop.after-upload` | action | `{ result: DropUploadResult, fields, context }` |
+| `desktop-mode.drop.after-upload` | action | `{ file: File, result: DropUploadResult, fields, context }` — `file` (since 0.31.0) carries the same `File` ref as `upload-started`, so per-file UI can match by identity. |
 | `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `error.name === 'UploadAbortedError'` for a caller-cancelled upload. |
 
 `DropContext.surface` is one of `'wallpaper' | 'window' |
@@ -182,13 +182,14 @@ wp.hooks.addAction(
 wp.hooks.addAction(
     FILE_DROP_HOOKS.AFTER_UPLOAD,
     'my-plugin/progress',
-    ( { fields } ) => {
-        for ( const [ file, bar ] of bars ) {
-            if ( file.name === fields.filename ) {
-                bar.setAttribute( 'tone', 'success' );
-                bars.delete( file );
-            }
-        }
+    ( { file } ) => {
+        // Match on the `File` reference itself — two drops of
+        // `photo.jpg` from different folders would otherwise route
+        // each other's success event to the wrong row.
+        const bar = bars.get( file );
+        if ( ! bar ) return;
+        bar.setAttribute( 'tone', 'success' );
+        bars.delete( file );
     }
 );
 ```

--- a/docs/examples/os-file-drop.md
+++ b/docs/examples/os-file-drop.md
@@ -38,8 +38,10 @@ on `window.wp.hooks`). All hook names live on
 | `desktop-mode.drop.files-rejected` | action | `{ rejections: DropRejection[], context: DropContext }` — files that failed the allow-list. |
 | `desktop-mode.drop.dialog-fields` | filter | `(entry: DropFileEntry, ctx) => DropFileEntry` — mutate the per-file defaults the dialog shows. |
 | `desktop-mode.drop.before-upload` | filter | `({ file, mime, fields }, ctx) => payload \| null` — last chance to swap the file or cancel (returning `null`). |
+| `desktop-mode.drop.upload-started` | action | _Since 0.31.0._ `{ file, fields, context, abort: () => void }` — XHR is open and about to `send()`. Call `abort()` to cancel mid-flight; the manager will reject with `UploadAbortedError`. |
+| `desktop-mode.drop.upload-progress` | action | _Since 0.31.0._ `{ file, fields, context, loaded, total, indeterminate }` — per `XMLHttpRequestUpload.progress` tick. A synthetic 100% event is fired on `upload.load`. |
 | `desktop-mode.drop.after-upload` | action | `{ result: DropUploadResult, fields, context }` |
-| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` |
+| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `error.name === 'UploadAbortedError'` for a caller-cancelled upload. |
 
 `DropContext.surface` is one of `'wallpaper' | 'window' |
 'folder' | 'iframe' | 'unknown'`. `windowId` is populated when
@@ -127,6 +129,71 @@ wp.hooks.addFilter(
     }
 );
 ```
+
+## Showing upload progress
+
+A floating HUD ships with the shell — bottom-right, one row per
+in-flight upload, each row carrying a `<wpd-progress-bar>` plus a
+Cancel button that calls the `abort()` handle from
+`upload-started`. The HUD subscribes to the four hooks above and is
+the canonical consumer; plugins that want a different UI can:
+
+1. Set `data-desktop-mode-suppress-upload-hud` on `<body>` before
+   the shell boots to disable the default panel.
+2. Subscribe to `upload-started` / `upload-progress` /
+   `after-upload` / `upload-failed` to drive a custom UI.
+
+Minimal example — a per-window in-iframe progress bar:
+
+```js
+import { FILE_DROP_HOOKS } from '@wp-desktop-mode/os-file-drop';
+
+const bars = new Map(); // file → <wpd-progress-bar>
+
+wp.hooks.addAction(
+    FILE_DROP_HOOKS.UPLOAD_STARTED,
+    'my-plugin/progress',
+    ( { file, fields } ) => {
+        const bar = document.createElement( 'wpd-progress-bar' );
+        bar.setAttribute( 'label', fields.filename );
+        bar.setAttribute( 'show-percent', '' );
+        bar.setAttribute( 'indeterminate', '' );
+        document.querySelector( '#uploads' ).appendChild( bar );
+        bars.set( file, bar );
+    }
+);
+
+wp.hooks.addAction(
+    FILE_DROP_HOOKS.UPLOAD_PROGRESS,
+    'my-plugin/progress',
+    ( { file, loaded, total, indeterminate } ) => {
+        const bar = bars.get( file );
+        if ( ! bar ) return;
+        if ( indeterminate || total <= 0 ) {
+            bar.setAttribute( 'indeterminate', '' );
+        } else {
+            bar.removeAttribute( 'indeterminate' );
+            bar.setAttribute( 'max', String( total ) );
+            bar.setAttribute( 'value', String( loaded ) );
+        }
+    }
+);
+
+wp.hooks.addAction(
+    FILE_DROP_HOOKS.AFTER_UPLOAD,
+    'my-plugin/progress',
+    ( { fields } ) => {
+        for ( const [ file, bar ] of bars ) {
+            if ( file.name === fields.filename ) {
+                bar.setAttribute( 'tone', 'success' );
+                bars.delete( file );
+            }
+        }
+    }
+);
+```
+
+`<wpd-progress-bar>` is documented in `docs/examples/progress-bar.md`.
 
 ## Hooks reference
 

--- a/docs/examples/os-file-drop.md
+++ b/docs/examples/os-file-drop.md
@@ -41,7 +41,7 @@ on `window.wp.hooks`). All hook names live on
 | `desktop-mode.drop.upload-started` | action | _Since 0.31.0._ `{ file, fields, context, abort: () => void }` — XHR is open and about to `send()`. Call `abort()` to cancel mid-flight; the manager will reject with `UploadAbortedError`. |
 | `desktop-mode.drop.upload-progress` | action | _Since 0.31.0._ `{ file, fields, context, loaded, total, indeterminate }` — per `XMLHttpRequestUpload.progress` tick. A synthetic 100% event is fired on `upload.load`. |
 | `desktop-mode.drop.after-upload` | action | `{ file: File, result: DropUploadResult, fields, context }` — `file` (since 0.31.0) carries the same `File` ref as `upload-started`, so per-file UI can match by identity. |
-| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `error.name === 'UploadAbortedError'` for a caller-cancelled upload. |
+| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `file` is the post-`before-upload` identity, same as the other lifecycle hooks. `error.name === 'UploadAbortedError'` for a caller-cancelled upload. |
 
 `DropContext.surface` is one of `'wallpaper' | 'window' |
 'folder' | 'iframe' | 'unknown'`. `windowId` is populated when

--- a/docs/examples/progress-bar.md
+++ b/docs/examples/progress-bar.md
@@ -1,0 +1,109 @@
+# Example: progress bar
+
+`<wpd-progress-bar>` is a linear progress indicator with two modes
+(determinate, indeterminate), four tones, and a built-in label /
+percent header. Used by the OS-file-drop upload HUD and available
+to any feature that needs a value-driven bar.
+
+> Status: **Experimental** since 0.31.0.
+
+## Drop-in
+
+```html
+<wpd-progress-bar value="42"></wpd-progress-bar>
+
+<wpd-progress-bar indeterminate label="Uploading…"></wpd-progress-bar>
+
+<wpd-progress-bar
+    value="280"
+    max="320"
+    tone="success"
+    label="hero.jpg"
+    show-percent
+></wpd-progress-bar>
+```
+
+## Modes
+
+| Mode | When to use | How |
+|---|---|---|
+| Determinate | You have a running `loaded / total`. | Set `value` (and optionally `max`, default `100`). The fill width animates between updates. |
+| Indeterminate | You don't know the total, or the work is open-ended. | Set the boolean `indeterminate` attribute. A 33%-wide bar sweeps across the track on a 1.1s linear loop. |
+
+Switch modes live by toggling the `indeterminate` attribute — the
+component repaints on every attribute change.
+
+## Tones
+
+Tints the fill via the shared `--desktop-mode-status-*` palette so
+the bar reads the same as toasts, ribbons, and notices.
+
+```html
+<wpd-progress-bar value="80" tone="success"></wpd-progress-bar>
+<wpd-progress-bar value="80" tone="warning"></wpd-progress-bar>
+<wpd-progress-bar value="80" tone="danger"></wpd-progress-bar>
+```
+
+## Inline label + percent
+
+```html
+<wpd-progress-bar
+    value="42"
+    label="Uploading hero.jpg"
+    show-percent
+></wpd-progress-bar>
+```
+
+Renders the label on the left of a small header row and a
+right-aligned `42%` readout. The label is also wired into the
+track's `aria-label`. `show-percent` is a boolean attribute.
+
+## Driving it from JS
+
+```js
+const bar = document.createElement( 'wpd-progress-bar' );
+bar.setAttribute( 'indeterminate', '' );
+bar.setAttribute( 'show-percent', '' );
+host.appendChild( bar );
+
+// …a moment later, real progress arrives:
+bar.removeAttribute( 'indeterminate' );
+bar.setAttribute( 'max', String( total ) );
+bar.setAttribute( 'value', String( loaded ) );
+```
+
+## Theming
+
+Every surface is overridable via CSS variables on the host:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `--wpd-progress-track-bg` | `var(--desktop-mode-control-bg, rgba(0,0,0,0.08))` | Track background. |
+| `--wpd-progress-fill` | `var(--wp-admin-theme-color, #2271b1)` | Fill color (overridden by the `tone` attribute). |
+| `--wpd-progress-height` | `6px` | Track height. |
+| `--wpd-progress-radius` | `999px` | Track + fill border-radius. |
+| `--wpd-progress-label-color` | `inherit` | Header text color. |
+| `--wpd-progress-label-size` | `12px` | Header font size. |
+| `--wpd-progress-label-gap` | `4px` | Space between header and track. |
+
+```css
+my-feature {
+    --wpd-progress-height: 10px;
+    --wpd-progress-radius: 4px;
+    --wpd-progress-fill: #5e3aee;
+}
+```
+
+## Accessibility
+
+Determinate mode wires `role="progressbar"` with
+`aria-valuemin / aria-valuemax / aria-valuenow`. Indeterminate
+mode drops the `aria-valuenow / aria-valuemax` attributes (which
+is the spec's signal for indeterminate state). `label` is mirrored
+onto `aria-label`. `prefers-reduced-motion: reduce` disables the
+indeterminate sweep and the fill-width transition.
+
+## Where it's used in the shell
+
+- OS-file-drop upload HUD — `src/os-file-drop/progress-hud.ts`
+  (see [`docs/examples/os-file-drop.md`](os-file-drop.md)).

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1535,7 +1535,7 @@ apply_filters( 'desktop_mode_drop_enabled', bool $enabled, int $user_id );
 | `desktop-mode.drop.upload-started` | action | _Since 0.31.0._ `{ file, fields, context, abort }` — fires once the XHR is `open()`ed and immediately before `send()`. Call `abort()` to cancel the in-flight upload; the manager rejects with `UploadAbortedError` and emits `upload-failed`. If `abort()` is called after the request body has been fully sent, the manager lets the server respond and then DELETEs the resulting attachment so the user's Media Library never shows a "cancelled" file. |
 | `desktop-mode.drop.upload-progress` | action | _Since 0.31.0._ `{ file, fields, context, loaded, total, indeterminate }` — per `XMLHttpRequestUpload.progress` event. `total === 0` / `indeterminate === true` when the request length isn't known. A synthetic 100% event is dispatched on `upload.load` so a HUD can show "wrapping up" while the server finishes the response. |
 | `desktop-mode.drop.after-upload` | action | `{ file, result, fields, context }` — `file` (since 0.31.0) is the same `File` reference exposed by `upload-started` / `upload-progress`, so per-file state can be looked up by identity rather than filename. |
-| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `error.name === 'UploadAbortedError'` when the failure came from a `upload-started` `abort()` call. |
+| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `file` carries the same identity as `upload-started` / `upload-progress` / `after-upload` (the post-`before-upload` `File`, in case a plugin swapped it). Match by reference, not filename. `error.name === 'UploadAbortedError'` when the failure came from a `upload-started` `abort()` call. |
 
 ---
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1532,8 +1532,10 @@ apply_filters( 'desktop_mode_drop_enabled', bool $enabled, int $user_id );
 | `desktop-mode.drop.files-rejected` | action | `{ rejections, context }` — files that failed the allow-list. |
 | `desktop-mode.drop.dialog-fields` | filter | `(entry, ctx) => entry` — mutate the per-file defaults. |
 | `desktop-mode.drop.before-upload` | filter | `(payload, ctx) => payload \| null` — return `null` to cancel. |
+| `desktop-mode.drop.upload-started` | action | _Since 0.31.0._ `{ file, fields, context, abort }` — fires once the XHR is `open()`ed and immediately before `send()`. Call `abort()` to cancel the in-flight upload; the manager rejects with `UploadAbortedError` and emits `upload-failed`. If `abort()` is called after the request body has been fully sent, the manager lets the server respond and then DELETEs the resulting attachment so the user's Media Library never shows a "cancelled" file. |
+| `desktop-mode.drop.upload-progress` | action | _Since 0.31.0._ `{ file, fields, context, loaded, total, indeterminate }` — per `XMLHttpRequestUpload.progress` event. `total === 0` / `indeterminate === true` when the request length isn't known. A synthetic 100% event is dispatched on `upload.load` so a HUD can show "wrapping up" while the server finishes the response. |
 | `desktop-mode.drop.after-upload` | action | `{ result, fields, context }` |
-| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` |
+| `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `error.name === 'UploadAbortedError'` when the failure came from a `upload-started` `abort()` call. |
 
 ---
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1534,7 +1534,7 @@ apply_filters( 'desktop_mode_drop_enabled', bool $enabled, int $user_id );
 | `desktop-mode.drop.before-upload` | filter | `(payload, ctx) => payload \| null` — return `null` to cancel. |
 | `desktop-mode.drop.upload-started` | action | _Since 0.31.0._ `{ file, fields, context, abort }` — fires once the XHR is `open()`ed and immediately before `send()`. Call `abort()` to cancel the in-flight upload; the manager rejects with `UploadAbortedError` and emits `upload-failed`. If `abort()` is called after the request body has been fully sent, the manager lets the server respond and then DELETEs the resulting attachment so the user's Media Library never shows a "cancelled" file. |
 | `desktop-mode.drop.upload-progress` | action | _Since 0.31.0._ `{ file, fields, context, loaded, total, indeterminate }` — per `XMLHttpRequestUpload.progress` event. `total === 0` / `indeterminate === true` when the request length isn't known. A synthetic 100% event is dispatched on `upload.load` so a HUD can show "wrapping up" while the server finishes the response. |
-| `desktop-mode.drop.after-upload` | action | `{ result, fields, context }` |
+| `desktop-mode.drop.after-upload` | action | `{ file, result, fields, context }` — `file` (since 0.31.0) is the same `File` reference exposed by `upload-started` / `upload-progress`, so per-file state can be looked up by identity rather than filename. |
 | `desktop-mode.drop.upload-failed` | action | `{ file, error, context }` — `error.name === 'UploadAbortedError'` when the failure came from a `upload-started` `abort()` call. |
 
 ---

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1129,6 +1129,10 @@ export const HOOKS = {
 	FILE_DROP_DIALOG_FIELDS: 'desktop-mode.drop.dialog-fields',
 	/** Filter — `(payload, ctx) => payload | null`, last call before POST. */
 	FILE_DROP_BEFORE_UPLOAD: 'desktop-mode.drop.before-upload',
+	/** Action — `{ file, fields, context, abort }` once XHR is open and about to send. @since 0.31.0 */
+	FILE_DROP_UPLOAD_STARTED: 'desktop-mode.drop.upload-started',
+	/** Action — `{ file, fields, context, loaded, total, indeterminate }` per progress tick. @since 0.31.0 */
+	FILE_DROP_UPLOAD_PROGRESS: 'desktop-mode.drop.upload-progress',
 	/** Action — `{ result, fields, context }` after successful upload. */
 	FILE_DROP_AFTER_UPLOAD: 'desktop-mode.drop.after-upload',
 	/** Action — `{ file, error, context }` on upload failure. */

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1133,7 +1133,7 @@ export const HOOKS = {
 	FILE_DROP_UPLOAD_STARTED: 'desktop-mode.drop.upload-started',
 	/** Action — `{ file, fields, context, loaded, total, indeterminate }` per progress tick. @since 0.31.0 */
 	FILE_DROP_UPLOAD_PROGRESS: 'desktop-mode.drop.upload-progress',
-	/** Action — `{ result, fields, context }` after successful upload. */
+	/** Action — `{ file, result, fields, context }` after successful upload. `file` since 0.31.0. */
 	FILE_DROP_AFTER_UPLOAD: 'desktop-mode.drop.after-upload',
 	/** Action — `{ file, error, context }` on upload failure. */
 	FILE_DROP_UPLOAD_FAILED: 'desktop-mode.drop.upload-failed',

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -4983,8 +4983,19 @@ function createTileSelector(): ( tile: HTMLElement ) => void {
  *  click-vs-drag threshold, `--dragging` class).
  * ------------------------------------------------------------------ */
 
-const TILE_W = 96;
-const TILE_H = 92;
+// Cell pitch for the in-window absolute-positioned tile canvas used
+// by Posts / Pages / users / plugin sections. Tile visual is 88px
+// wide; the previous 96×92 cell pitch left only ~4px per side
+// between neighbours, so the selected tile's background ring abutted
+// adjacent corner ribbons and read as "spillover" (regression
+// surfaced once `<wpd-ribbon>` started rendering DRAFT/PENDING
+// banners in 0.21.0). Widen the cell so the selection ring has
+// breathing room — and so wrapped 2-line labels don't push the next
+// row's tile into the cell above. Tile label is clamped to 2 lines
+// via CSS in `my-wordpress.css`; if you change that clamp, raise
+// `TILE_H` to match.
+const TILE_W = 108;
+const TILE_H = 112;
 const TILE_PAD = 16;
 
 export interface TileSortable {

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -583,6 +583,7 @@ export function renderMediaList(
 	addAction<
 		[
 			{
+				file: File;
 				result: DropUploadResult;
 				fields: { filename: string };
 				context: unknown;

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -17,11 +17,15 @@
 
 import { __, _n, sprintf } from '../i18n';
 import { renderStatusBarSegments, type StatusBarSegment } from '../desktop-files/folder-status-bar';
-import { applyFilters } from '../hooks';
+import { addAction, applyFilters, removeAction } from '../hooks';
+import { FILE_DROP_HOOKS } from '../os-file-drop/hooks';
+import type { DropUploadResult } from '../os-file-drop/types';
 import { attachTileDragOut, buildTileFromSpec } from '../desktop-files/tile-spec';
+import { wpdConfirm } from '../ui/components/wpd-confirm-dialog/wpd-confirm-dialog';
+import { showToast } from '../toast';
 import type { EntityRenderHost } from './kind-registry';
 import type { MediaListItem, MyWordPressEntity, MediaPreviewAction } from './types';
-import { fetchMediaPage } from './media-rest';
+import { deleteMediaItem, fetchMediaItem, fetchMediaPage } from './media-rest';
 import { getConfig } from './rest';
 import { dashiconForMime, renderMediaPreview } from './media-preview';
 import { stripTags } from './dom-utils';
@@ -147,7 +151,231 @@ function buildMediaTile(
 		} );
 	} );
 
+	tile.addEventListener( 'contextmenu', ( e ) => {
+		e.preventDefault();
+		openMediaTileMenu( ctx, tile, media, titleText, {
+			x: ( e as MouseEvent ).clientX,
+			y: ( e as MouseEvent ).clientY,
+		} );
+	} );
+
 	return tile;
+}
+
+interface MediaTileMenuOption {
+	id: string;
+	label: string;
+	icon: string;
+	danger?: boolean;
+	onSelect?: ( () => void ) | null;
+}
+
+/**
+ * Build + position the right-click menu for a media tile. Mirrors
+ * `openTileMenu()` in `my-wordpress/index.ts` — same `<wpd-context-menu>`
+ * shape, same dismiss handling — so plugin authors only have to learn
+ * one pattern.
+ */
+function openMediaTileMenu(
+	ctx: MediaListContext,
+	tile: HTMLElement,
+	media: MediaListItem,
+	titleText: string,
+	pos: { x: number; y: number },
+): void {
+	closeAnyMediaTileMenu();
+	selectTile( ctx, tile, media );
+
+	const menu = document.createElement( 'wpd-context-menu' );
+	menu.setAttribute( 'open', '' );
+	menu.classList.add( 'desktop-mode-my-wordpress__menu' );
+	( menu as HTMLElement ).style.left = `${ pos.x }px`;
+	( menu as HTMLElement ).style.top = `${ pos.y }px`;
+
+	const base: MediaTileMenuOption[] = [
+		{
+			id: 'navigate-into',
+			label: __( 'Navigate into', 'desktop-mode' ),
+			icon: 'dashicons-category',
+		},
+		{
+			id: 'open-source',
+			label: __( 'Open file in new tab', 'desktop-mode' ),
+			icon: 'dashicons-external',
+		},
+		{
+			id: 'delete',
+			label: __( 'Delete permanently', 'desktop-mode' ),
+			icon: 'dashicons-trash',
+			danger: true,
+		},
+	];
+
+	const filterCtx = {
+		entityId: ctx.entity.id,
+		kind: 'attachment' as const,
+		item: media as unknown as Record< string, unknown >,
+	};
+	const options = applyFilters<
+		MediaTileMenuOption[],
+		[ typeof filterCtx ]
+	>(
+		'desktop-mode.my-wordpress.tile-context-menu',
+		base,
+		filterCtx,
+	);
+	const finalOptions = Array.isArray( options ) ? options : base;
+
+	for ( const o of finalOptions ) {
+		const opt = document.createElement( 'wpd-context-menu-option' );
+		( opt as HTMLElement ).dataset.menuItemId = o.id;
+		opt.setAttribute( 'value', o.id );
+		opt.setAttribute( 'icon', o.icon );
+		if ( o.danger ) {
+			opt.setAttribute( 'danger', '' );
+		}
+		opt.textContent = o.label;
+		menu.appendChild( opt );
+	}
+
+	menu.addEventListener( 'wpd-context-menu-pick', ( e: Event ) => {
+		const detail = ( e as CustomEvent< { id: string } > ).detail;
+		closeAnyMediaTileMenu();
+		if ( detail.id === 'navigate-into' ) {
+			ctx.host.navigate( {
+				kind: 'media-detail',
+				entityId: ctx.entity.id,
+				mediaId: media.id,
+				mediaTitle: titleText,
+			} );
+			return;
+		}
+		if ( detail.id === 'open-source' ) {
+			window.open( media.source_url, '_blank', 'noopener,noreferrer' );
+			return;
+		}
+		if ( detail.id === 'delete' ) {
+			void confirmDeleteMedia( ctx, tile, media, titleText );
+			return;
+		}
+		const match = finalOptions.find( ( o ) => o.id === detail.id );
+		if ( match && typeof match.onSelect === 'function' ) {
+			try {
+				match.onSelect();
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					`[my-wordpress/media] tile-context-menu '${ detail.id }' onSelect threw:`,
+					err,
+				);
+			}
+		}
+	} );
+
+	document.body.appendChild( menu );
+	const rect = menu.getBoundingClientRect();
+	if ( rect.right > window.innerWidth ) {
+		( menu as HTMLElement ).style.left = `${ Math.max(
+			0,
+			window.innerWidth - rect.width - 8,
+		) }px`;
+	}
+	if ( rect.bottom > window.innerHeight ) {
+		( menu as HTMLElement ).style.top = `${ Math.max(
+			0,
+			window.innerHeight - rect.height - 8,
+		) }px`;
+	}
+
+	queueMicrotask( () => {
+		const onDocPointerDown = ( ev: PointerEvent ) => {
+			if ( ev.target instanceof Node && menu.contains( ev.target ) ) {
+				return;
+			}
+			closeAnyMediaTileMenu();
+		};
+		const onDocKey = ( ev: KeyboardEvent ) => {
+			if ( ev.key === 'Escape' ) {
+				closeAnyMediaTileMenu();
+			}
+		};
+		document.addEventListener( 'pointerdown', onDocPointerDown, true );
+		document.addEventListener( 'keydown', onDocKey );
+		menu.addEventListener( 'tile-menu-closed', () => {
+			document.removeEventListener(
+				'pointerdown',
+				onDocPointerDown,
+				true,
+			);
+			document.removeEventListener( 'keydown', onDocKey );
+		} );
+	} );
+}
+
+function closeAnyMediaTileMenu(): void {
+	document
+		.querySelectorAll( 'wpd-context-menu.desktop-mode-my-wordpress__menu' )
+		.forEach( ( n ) => {
+			n.dispatchEvent( new CustomEvent( 'tile-menu-closed' ) );
+			n.remove();
+		} );
+}
+
+async function confirmDeleteMedia(
+	ctx: MediaListContext,
+	tile: HTMLElement,
+	media: MediaListItem,
+	titleText: string,
+): Promise< void > {
+	const ok = await wpdConfirm( {
+		title: __( 'Delete media?', 'desktop-mode' ),
+		message: sprintf(
+			// translators: %s is a media item title.
+			__( '“%s” will be permanently deleted. This cannot be undone.', 'desktop-mode' ),
+			titleText,
+		),
+		confirmLabel: __( 'Delete', 'desktop-mode' ),
+		cancelLabel: __( 'Cancel', 'desktop-mode' ),
+		danger: true,
+	} );
+	if ( ! ok ) {
+		return;
+	}
+	try {
+		await deleteMediaItem( media.id );
+		removeMediaFromList( ctx, tile, media.id );
+		showToast( { message: __( 'Media deleted.', 'desktop-mode' ) } );
+	} catch ( err ) {
+		const message =
+			err instanceof Error
+				? err.message
+				: __( 'Couldn’t delete that file.', 'desktop-mode' );
+		showToast( { message } );
+	}
+}
+
+function removeMediaFromList(
+	ctx: MediaListContext,
+	tile: HTMLElement,
+	mediaId: number,
+): void {
+	tile.remove();
+	if ( ctx.selectedId === mediaId ) {
+		ctx.selectedId = null;
+		ctx.selectedTile = null;
+		// Restore the "select a media item" placeholder.
+		ctx.preview.replaceChildren();
+		const placeholder = document.createElement( 'div' );
+		placeholder.className = 'desktop-mode-my-wordpress__preview-empty';
+		placeholder.textContent = __(
+			'Select a media item to preview it here.',
+			'desktop-mode',
+		);
+		ctx.preview.appendChild( placeholder );
+	}
+	ctx.loaded = Math.max( 0, ctx.loaded - 1 );
+	ctx.total = Math.max( 0, ctx.total - 1 );
+	paintStatus( ctx );
 }
 
 function selectTile(
@@ -344,6 +572,66 @@ export function renderMediaList(
 		host.addTeardown( () => left.removeEventListener( 'scroll', onScroll ) );
 	}
 
+	// Live-refresh — fold freshly-uploaded attachments into the grid
+	// as the OS-drop manager finishes them. We do this by id (single
+	// REST GET) so the visible page-1 set + scroll position are kept
+	// intact. Subscribers added per renderMediaList() call are torn
+	// down when the host unmounts so a closed window stops listening.
+	const liveNs = `desktop-mode/my-wordpress-media-live-${ Math.random()
+		.toString( 36 )
+		.slice( 2, 8 ) }`;
+	addAction<
+		[
+			{
+				result: DropUploadResult;
+				fields: { filename: string };
+				context: unknown;
+			},
+		]
+	>( FILE_DROP_HOOKS.AFTER_UPLOAD, liveNs, ( payload ) => {
+		void spliceNewMedia( ctx, payload.result.id );
+	} );
+	host.addTeardown( () =>
+		removeAction( FILE_DROP_HOOKS.AFTER_UPLOAD, liveNs ),
+	);
+	host.addTeardown( () => closeAnyMediaTileMenu() );
+
 	paintStatus( ctx );
 	void loadMore();
+}
+
+/**
+ * Fetch and prepend a freshly-uploaded attachment. If we already
+ * have a tile for that id (rare — e.g. a second AFTER_UPLOAD fires
+ * for the same item via a plugin), the duplicate is ignored.
+ */
+async function spliceNewMedia(
+	ctx: MediaListContext,
+	mediaId: number,
+): Promise< void > {
+	if ( ! ctx.tiles.isConnected ) {
+		return;
+	}
+	if (
+		ctx.tiles.querySelector(
+			`wpd-tile[data-media-id="${ mediaId }"]`,
+		)
+	) {
+		return;
+	}
+	try {
+		const item = await fetchMediaItem( mediaId );
+		// The newest item belongs at the top of the grid; insertBefore
+		// against `firstChild` is the cheap way to prepend.
+		ctx.tiles.insertBefore( buildMediaTile( ctx, item ), ctx.tiles.firstChild );
+		ctx.loaded += 1;
+		ctx.total += 1;
+		paintStatus( ctx );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'[my-wordpress/media] live-refresh fetch failed:',
+			err,
+		);
+	}
 }

--- a/src/my-wordpress/media-rest.ts
+++ b/src/my-wordpress/media-rest.ts
@@ -108,6 +108,68 @@ export async function fetchMediaPage(
 }
 
 /**
+ * Fetch one attachment by id. Used after an OS-drop upload to splice
+ * the new item into the visible grid without reloading the whole
+ * page (which would lose the user's scroll position).
+ *
+ * @public
+ * @since 0.31.0
+ */
+export async function fetchMediaItem(
+	mediaId: number,
+): Promise< MediaListItem > {
+	const cfg = getConfig();
+	const url = new URL( buildUrl( `wp/v2/media/${ mediaId }` ) );
+	url.searchParams.set(
+		'_fields',
+		'id,title,date,mime_type,source_url,alt_text,caption,description,author,media_details,_embedded',
+	);
+	url.searchParams.set( '_embed', 'author' );
+	const response = await shellFetch( url.toString(), {
+		method: 'GET',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+		},
+	} );
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to load media item' ),
+		);
+	}
+	return ( await response.json() ) as MediaListItem;
+}
+
+/**
+ * Permanently delete an attachment. `force=true` because attachments
+ * don't go through the trash flow the way posts do — leaving them in
+ * a soft-deleted limbo state isn't what users expect from a "Delete"
+ * affordance in the media grid.
+ *
+ * @public
+ * @since 0.31.0
+ */
+export async function deleteMediaItem( mediaId: number ): Promise< void > {
+	const cfg = getConfig();
+	const url = new URL( buildUrl( `wp/v2/media/${ mediaId }` ) );
+	url.searchParams.set( 'force', 'true' );
+	const response = await shellFetch( url.toString(), {
+		method: 'DELETE',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+		},
+	} );
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to delete media item' ),
+		);
+	}
+}
+
+/**
  * Drill-in payload — every public post/page/CPT that references the
  * given attachment.
  *

--- a/src/os-file-drop/dialog.ts
+++ b/src/os-file-drop/dialog.ts
@@ -18,6 +18,7 @@ import '../ui/components/wpd-text-field/wpd-text-field';
 import '../ui/components/wpd-textarea/wpd-textarea';
 import '../ui/components/wpd-button/wpd-button';
 import { showToast } from '../toast';
+import { formatBytes } from './format-bytes';
 import {
 	uploadFile,
 	UploadAbortedError,
@@ -145,6 +146,15 @@ export async function openUploadDialog( args: OpenDialogArgs ): Promise< void > 
 		// Per-file failure messages — kept for single-file batches
 		// where the summary toast doesn't carry the error detail.
 		const failureDetails: string[] = [];
+		// NOTE: sequential `await` — uploads run one at a time on
+		// purpose. The HUD assumes one active progress bar per
+		// `UPLOAD_STARTED` and won't reconcile concurrent streams
+		// (the per-file state is keyed by `File`, but the panel's
+		// "Uploading N of M…" header reads from a single counter).
+		// Parallelising here would also let a 10-file batch swamp
+		// the WordPress process pool / fpm workers on shared hosts.
+		// If a future change introduces a concurrency knob, the HUD
+		// header logic and the rate-limit story both need a look.
 		for ( let i = 0; i < total; i++ ) {
 			const entry = args.entries[ i ];
 			try {
@@ -236,16 +246,6 @@ function textareaField(
 		}
 	} );
 	return el;
-}
-
-function formatBytes( bytes: number ): string {
-	if ( bytes >= 1024 * 1024 ) {
-		return `${ ( bytes / ( 1024 * 1024 ) ).toFixed( 1 ) } MB`;
-	}
-	if ( bytes >= 1024 ) {
-		return `${ ( bytes / 1024 ).toFixed( 0 ) } KB`;
-	}
-	return `${ bytes } B`;
 }
 
 interface BatchSummaryArgs {

--- a/src/os-file-drop/dialog.ts
+++ b/src/os-file-drop/dialog.ts
@@ -18,7 +18,11 @@ import '../ui/components/wpd-text-field/wpd-text-field';
 import '../ui/components/wpd-textarea/wpd-textarea';
 import '../ui/components/wpd-button/wpd-button';
 import { showToast } from '../toast';
-import { uploadFile, UploadCancelledError } from './upload';
+import {
+	uploadFile,
+	UploadAbortedError,
+	UploadCancelledError,
+} from './upload';
 import type {
 	DropContext,
 	DropFileEntry,
@@ -134,9 +138,14 @@ export async function openUploadDialog( args: OpenDialogArgs ): Promise< void > 
 		( uploadBtn as unknown as { disabled: boolean } ).disabled = true;
 		( cancelBtn as unknown as { disabled: boolean } ).disabled = true;
 		uploadBtn.textContent = 'Uploading…';
+		const total = args.entries.length;
 		let successes = 0;
 		let failures = 0;
-		for ( let i = 0; i < args.entries.length; i++ ) {
+		let cancelled = 0;
+		// Per-file failure messages — kept for single-file batches
+		// where the summary toast doesn't carry the error detail.
+		const failureDetails: string[] = [];
+		for ( let i = 0; i < total; i++ ) {
 			const entry = args.entries[ i ];
 			try {
 				await uploadFile( {
@@ -150,26 +159,31 @@ export async function openUploadDialog( args: OpenDialogArgs ): Promise< void > 
 				successes++;
 			} catch ( err ) {
 				if ( err instanceof UploadCancelledError ) {
-					// Filter chose to cancel — treat as a soft win.
+					// Plugin filter blocked it — count as a soft skip
+					// alongside user cancellations so the summary
+					// reads consistently.
+					cancelled++;
+					continue;
+				}
+				if ( err instanceof UploadAbortedError ) {
+					// User cancelled mid-flight via the HUD button.
+					cancelled++;
 					continue;
 				}
 				failures++;
 				const message =
 					err instanceof Error ? err.message : 'Upload failed.';
-				showToast( {
-					message: `“${ entry.file.name }” — ${ message }`,
-				} );
+				failureDetails.push( `“${ entry.file.name }” — ${ message }` );
 			}
 		}
 		modal.remove();
-		if ( successes > 0 && failures === 0 ) {
-			showToast( {
-				message:
-					successes === 1
-						? 'Uploaded to Media Library.'
-						: `Uploaded ${ successes } files to Media Library.`,
-			} );
-		}
+		showBatchSummaryToast( {
+			total,
+			successes,
+			failures,
+			cancelled,
+			failureDetails,
+		} );
 	};
 
 	renderBody();
@@ -232,4 +246,84 @@ function formatBytes( bytes: number ): string {
 		return `${ ( bytes / 1024 ).toFixed( 0 ) } KB`;
 	}
 	return `${ bytes } B`;
+}
+
+interface BatchSummaryArgs {
+	total: number;
+	successes: number;
+	failures: number;
+	cancelled: number;
+	failureDetails: string[];
+}
+
+/**
+ * One-line summary toast for the end of a batch. The phrasing
+ * adapts to what actually happened:
+ *
+ *   - All succeeded → "Uploaded N files to Media Library."
+ *   - All cancelled → "All uploads cancelled."
+ *   - All failed → either the lone error or "N uploads failed."
+ *   - Mixed → "Uploaded N. Cancelled X. Failed Y." (only the
+ *     non-zero clauses appear, so two-state batches stay short).
+ *
+ * Single-file batches keep the existing "<file> — <error>" toast
+ * for failures because there's no other way to surface the
+ * server's message.
+ */
+function showBatchSummaryToast( args: BatchSummaryArgs ): void {
+	const { total, successes, failures, cancelled, failureDetails } = args;
+
+	// Empty batch — defensive; runUploads is only called with entries.
+	if ( total === 0 ) {
+		return;
+	}
+
+	// Single-file batch — preserve the original tight feedback:
+	// one toast that either confirms or carries the server error.
+	if ( total === 1 ) {
+		if ( successes === 1 ) {
+			showToast( { message: 'Uploaded to Media Library.' } );
+		} else if ( failures === 1 && failureDetails[ 0 ] ) {
+			showToast( { message: failureDetails[ 0 ] } );
+		} else if ( cancelled === 1 ) {
+			showToast( { message: 'Upload cancelled.' } );
+		}
+		return;
+	}
+
+	// Single-state shortcuts.
+	if ( successes === total ) {
+		showToast( {
+			message: `Uploaded ${ successes } files to Media Library.`,
+		} );
+		return;
+	}
+	if ( cancelled === total ) {
+		showToast( { message: 'All uploads cancelled.' } );
+		return;
+	}
+	if ( failures === total ) {
+		showToast( {
+			message:
+				failures === 1 && failureDetails[ 0 ]
+					? failureDetails[ 0 ]
+					: `${ failures } uploads failed.`,
+		} );
+		return;
+	}
+
+	// Mixed result — assemble the non-zero clauses.
+	const parts: string[] = [];
+	if ( successes > 0 ) {
+		parts.push(
+			`Uploaded ${ successes } file${ successes === 1 ? '' : 's' }.`,
+		);
+	}
+	if ( cancelled > 0 ) {
+		parts.push( `Cancelled ${ cancelled }.` );
+	}
+	if ( failures > 0 ) {
+		parts.push( `Failed ${ failures }.` );
+	}
+	showToast( { message: parts.join( ' ' ) } );
 }

--- a/src/os-file-drop/format-bytes.ts
+++ b/src/os-file-drop/format-bytes.ts
@@ -1,0 +1,35 @@
+/**
+ * OS-file drop manager — shared byte-size formatter.
+ *
+ * Renders a number of bytes as a short human-readable string:
+ * `0 B` / `844 B` / `12 KB` / `1.4 MB` / `2.0 GB`. Used by the
+ * upload dialog (file-size column) and the floating HUD
+ * (per-tick `loaded / total`).
+ *
+ * Decimals:
+ *   - bytes → no decimal (`844 B`).
+ *   - everything else → one decimal unless the rounded value
+ *     would render `≥ 100` (in which case the decimal is dropped
+ *     so labels don't get noisier as the unit gets bigger:
+ *     `12.4 MB` but `123 MB`).
+ *
+ * The previous two ad-hoc implementations (dialog + HUD) used
+ * subtly different rounding rules — keep this one as the single
+ * source of truth.
+ *
+ * @since 0.31.0
+ */
+export function formatBytes( bytes: number ): string {
+	if ( ! Number.isFinite( bytes ) || bytes <= 0 ) {
+		return '0 B';
+	}
+	const units = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
+	let v = bytes;
+	let i = 0;
+	while ( v >= 1024 && i < units.length - 1 ) {
+		v /= 1024;
+		i++;
+	}
+	const decimals = v >= 100 || i === 0 ? 0 : 1;
+	return `${ v.toFixed( decimals ) } ${ units[ i ] }`;
+}

--- a/src/os-file-drop/hooks.ts
+++ b/src/os-file-drop/hooks.ts
@@ -85,8 +85,20 @@ export const FILE_DROP_HOOKS = {
 
 	/**
 	 * Action — fires after a successful upload. Payload:
-	 * `{ result: DropUploadResult, fields: DropDialogFields,
-	 * context: DropContext }`.
+	 * `{ file: File, result: DropUploadResult, fields:
+	 * DropDialogFields, context: DropContext }`.
+	 *
+	 * The `file` field carries the same `File` reference that
+	 * `UPLOAD_STARTED` / `UPLOAD_PROGRESS` exposed (i.e. the
+	 * payload returned by the `BEFORE_UPLOAD` filter, in case a
+	 * plugin swapped the file). Subscribers tracking per-file
+	 * state — progress HUDs, sequence counters — should match on
+	 * this identity rather than the filename: two drops of
+	 * `photo.jpg` from different folders would otherwise route
+	 * each other's success event to the wrong row.
+	 *
+	 * @since 0.31.0 the `file` field was added; pre-0.31.0 code
+	 * that destructured `{ result, fields, context }` keeps working.
 	 */
 	AFTER_UPLOAD: 'desktop-mode.drop.after-upload',
 

--- a/src/os-file-drop/hooks.ts
+++ b/src/os-file-drop/hooks.ts
@@ -108,6 +108,14 @@ export const FILE_DROP_HOOKS = {
 	 * `error` is an `UploadAbortedError` when the failure came
 	 * from the caller invoking the `abort()` handle on
 	 * `UPLOAD_STARTED`.
+	 *
+	 * `file` carries the same identity as `UPLOAD_STARTED` /
+	 * `UPLOAD_PROGRESS` / `AFTER_UPLOAD` — the post-`BEFORE_UPLOAD`
+	 * `File`, in case a plugin swapped it. Match by reference, not
+	 * filename: a HUD that keys its row map on the started-File
+	 * needs the same key here, otherwise the row stays stuck in
+	 * "running" after a failure when a `BEFORE_UPLOAD` filter
+	 * replaced the file.
 	 */
 	UPLOAD_FAILED: 'desktop-mode.drop.upload-failed',
 } as const;

--- a/src/os-file-drop/hooks.ts
+++ b/src/os-file-drop/hooks.ts
@@ -52,6 +52,38 @@ export const FILE_DROP_HOOKS = {
 	BEFORE_UPLOAD: 'desktop-mode.drop.before-upload',
 
 	/**
+	 * Action — fires once `BEFORE_UPLOAD` has cleared and the XHR
+	 * is `open()`ed, immediately before `send()`. Payload:
+	 * `{ file: File, fields: DropDialogFields, context: DropContext,
+	 * abort: () => void }`. The `abort` handle aborts the in-flight
+	 * request; the manager rejects with `UploadAbortedError` and
+	 * fires `UPLOAD_FAILED` with that error.
+	 *
+	 * Pair with `UPLOAD_PROGRESS` to drive a progress UI; pair with
+	 * `AFTER_UPLOAD` / `UPLOAD_FAILED` to know when the upload ends.
+	 *
+	 * @since 0.31.0
+	 */
+	UPLOAD_STARTED: 'desktop-mode.drop.upload-started',
+
+	/**
+	 * Action — fires for every `XMLHttpRequestUpload.progress` event.
+	 * Payload: `{ file: File, fields: DropDialogFields, context:
+	 * DropContext, loaded: number, total: number, indeterminate:
+	 * boolean }`. `total` is `0` and `indeterminate` is `true` when
+	 * the request body length isn't known (rare for multipart, but
+	 * possible on transcoding proxies); subscribers should treat
+	 * that as an indeterminate state.
+	 *
+	 * A synthetic 100%-loaded event is dispatched once the `upload`
+	 * stream emits `load` so a HUD can show a definite "wrapping up"
+	 * state while the server finishes the response.
+	 *
+	 * @since 0.31.0
+	 */
+	UPLOAD_PROGRESS: 'desktop-mode.drop.upload-progress',
+
+	/**
 	 * Action — fires after a successful upload. Payload:
 	 * `{ result: DropUploadResult, fields: DropDialogFields,
 	 * context: DropContext }`.
@@ -61,6 +93,9 @@ export const FILE_DROP_HOOKS = {
 	/**
 	 * Action — fires after an upload fails. Payload:
 	 * `{ file: File, error: Error, context: DropContext }`.
+	 * `error` is an `UploadAbortedError` when the failure came
+	 * from the caller invoking the `abort()` handle on
+	 * `UPLOAD_STARTED`.
 	 */
 	UPLOAD_FAILED: 'desktop-mode.drop.upload-failed',
 } as const;

--- a/src/os-file-drop/index.ts
+++ b/src/os-file-drop/index.ts
@@ -8,6 +8,8 @@
  */
 
 import { mountOsFileDropManager } from './manager';
+import { mountUploadProgressHud } from './progress-hud';
+import { mountMediaLibraryRefresher } from './library-refresher';
 import type { DropConfig, DropContext, DropFileEntry } from './types';
 
 interface BootArgs {
@@ -22,6 +24,8 @@ export function bootOsFileDrop( args: BootArgs ): void {
 		allowedMimes: [],
 		maxSize: 0,
 	};
+	mountUploadProgressHud();
+	mountMediaLibraryRefresher();
 	mountOsFileDropManager( {
 		config,
 		mediaUrl: args.mediaUrl,

--- a/src/os-file-drop/library-refresher.ts
+++ b/src/os-file-drop/library-refresher.ts
@@ -82,11 +82,14 @@ function refreshOpenLibraries(): void {
 			frame.contentWindow?.location.reload();
 		} catch {
 			// Cross-origin (shouldn't happen for an admin iframe, but
-			// guard anyway) — `src` reassignment is the cross-origin-
-			// safe fallback. Always-same-origin in practice.
-			const src = frame.getAttribute( 'src' );
-			if ( src ) {
-				frame.setAttribute( 'src', src );
+			// guard anyway). Re-assigning the current `href` — not
+			// the initial `src` attribute — preserves any in-iframe
+			// navigation (filter, pagination) the user has done.
+			// `resolveIframeUrl` already fell back to `src` when it
+			// couldn't read `contentWindow.location.href`.
+			const reloadHref = resolveIframeUrl( frame );
+			if ( reloadHref ) {
+				frame.setAttribute( 'src', reloadHref );
 			}
 		}
 	}

--- a/src/os-file-drop/library-refresher.ts
+++ b/src/os-file-drop/library-refresher.ts
@@ -1,0 +1,111 @@
+/**
+ * OS-file drop manager — live-refresh open Media Library windows.
+ *
+ * When the user drops a file anywhere in the shell and the upload
+ * completes, any open iframe window pointing at `upload.php` (the
+ * classic Media Library) should reflect the new attachment without
+ * the user pressing F5. We do this from the parent shell — the
+ * iframe is same-origin, so we can call `contentWindow.location.
+ * reload()` directly. For URLs we can't classify we leave the
+ * iframe alone; this is purely additive.
+ *
+ * The My WordPress Media section has its own live-refresh path
+ * (single REST GET → prepend) in `src/my-wordpress/media-list.ts`
+ * — that's better UX (no scroll jump) and is the preferred surface
+ * for plugins. This module covers the classic admin page that
+ * doesn't yet have an in-place refresh affordance.
+ *
+ * Plugins that want to suppress this behavior can set
+ * `data-desktop-mode-suppress-media-library-refresh` on `<body>`
+ * before the shell boots.
+ *
+ * @since 0.31.0
+ */
+
+import { addAction } from '../hooks';
+import { FILE_DROP_HOOKS } from './hooks';
+import type { DropContext, DropDialogFields, DropUploadResult } from './types';
+
+interface AfterUploadPayload {
+	result: DropUploadResult;
+	fields: DropDialogFields;
+	context: DropContext;
+}
+
+/**
+ * Subscribe once to `after-upload`. Idempotent — repeated calls are
+ * no-ops, matching how `mountUploadProgressHud()` mounts.
+ */
+export function mountMediaLibraryRefresher(): void {
+	if (
+		document.body.hasAttribute(
+			'data-desktop-mode-suppress-media-library-refresh',
+		)
+	) {
+		return;
+	}
+	const sentinel = window as unknown as {
+		__wpdMediaLibraryRefresher?: boolean;
+	};
+	if ( sentinel.__wpdMediaLibraryRefresher ) {
+		return;
+	}
+	sentinel.__wpdMediaLibraryRefresher = true;
+
+	addAction< [ AfterUploadPayload ] >(
+		FILE_DROP_HOOKS.AFTER_UPLOAD,
+		'desktop-mode/os-file-drop-library-refresh',
+		() => refreshOpenLibraries(),
+	);
+}
+
+/**
+ * Walk every shell iframe; reload the ones whose URL points at the
+ * classic Media Library. We classify on `upload.php` (the canonical
+ * library page) — that catches both the default grid view and the
+ * list view. We deliberately don't try to reload modal media
+ * pickers (`media-upload.php`, `wp.media` overlays): they own a
+ * different lifecycle and reloading them mid-pick would lose user
+ * state.
+ */
+function refreshOpenLibraries(): void {
+	const iframes = document.querySelectorAll< HTMLIFrameElement >( 'iframe' );
+	for ( const frame of Array.from( iframes ) ) {
+		if ( ! isMediaLibraryUrl( resolveIframeUrl( frame ) ) ) {
+			continue;
+		}
+		try {
+			// `location.reload()` is the simplest path that respects
+			// the page's own initialization order; the classic
+			// uploader has no public JS hook for "rescan attachments"
+			// that we could call without poking at internals.
+			frame.contentWindow?.location.reload();
+		} catch {
+			// Cross-origin (shouldn't happen for an admin iframe, but
+			// guard anyway) — `src` reassignment is the cross-origin-
+			// safe fallback. Always-same-origin in practice.
+			const src = frame.getAttribute( 'src' );
+			if ( src ) {
+				frame.setAttribute( 'src', src );
+			}
+		}
+	}
+}
+
+function resolveIframeUrl( frame: HTMLIFrameElement ): string {
+	try {
+		return frame.contentWindow?.location.href ?? frame.src ?? '';
+	} catch {
+		return frame.src ?? '';
+	}
+}
+
+function isMediaLibraryUrl( url: string ): boolean {
+	if ( ! url ) {
+		return false;
+	}
+	// Match both the bare admin path and absolute URLs. We don't
+	// care about the query string — the user may have navigated
+	// to a filter or to page 2; the reload preserves that URL.
+	return /\/wp-admin\/upload\.php(?:[?#]|$)/.test( url );
+}

--- a/src/os-file-drop/progress-hud.ts
+++ b/src/os-file-drop/progress-hud.ts
@@ -1,0 +1,373 @@
+/**
+ * OS-file drop manager — floating upload-progress HUD.
+ *
+ * A pinned bottom-right panel that shows one row per in-flight
+ * upload. Each row is a `<wpd-progress-bar>` plus a filename and a
+ * Cancel / Dismiss action. The HUD subscribes to the four upload-
+ * lifecycle hooks and owns nothing else — its lifecycle is purely
+ * reactive:
+ *
+ *   - `upload-started`  → add row, store `abort` handle, indeterminate.
+ *   - `upload-progress` → update value / max on the matching row.
+ *   - `after-upload`    → mark success, auto-dismiss after a short
+ *                         linger so the user sees the green state.
+ *   - `upload-failed`   → mark failed, keep visible until dismissed.
+ *
+ * The panel renders into `document.body`, ignores window stacking,
+ * and uses `pointer-events: auto` on the panel only so drops still
+ * land on the wallpaper / windows behind it.
+ *
+ * Plugins can take this UI over entirely:
+ *   - Set `data-desktop-mode-suppress-upload-hud` on `document.body`
+ *     before the shell boots to prevent the default panel from
+ *     mounting — useful when a plugin wants to handle the same
+ *     hook surface with its own UI.
+ *
+ * @since 0.31.0
+ */
+
+import { addAction } from '../hooks';
+import { activity } from '../activity';
+import { FILE_DROP_HOOKS } from './hooks';
+import type { DropContext, DropDialogFields, DropUploadResult } from './types';
+
+import '../ui/components/wpd-progress-bar/wpd-progress-bar';
+import '../ui/components/wpd-button/wpd-button';
+
+interface HudRow {
+	file: File;
+	abort: () => void;
+	root: HTMLElement;
+	bar: HTMLElement;
+	statusEl: HTMLElement;
+	cancelBtn: HTMLElement;
+	state: 'running' | 'success' | 'failed' | 'aborted';
+	lingerTimer: ReturnType< typeof setTimeout > | null;
+}
+
+const ROWS = new Map< File, HudRow >();
+let panel: HTMLElement | null = null;
+
+/**
+ * Mount the HUD once. Idempotent — subsequent calls are no-ops.
+ *
+ * Called from `bootOsFileDrop`. Subscribers are attached lazily on
+ * the very first started event so the cost is zero when no one ever
+ * drops a file.
+ */
+export function mountUploadProgressHud(): void {
+	if ( document.body.hasAttribute( 'data-desktop-mode-suppress-upload-hud' ) ) {
+		return;
+	}
+	if ( ( window as unknown as { __wpdUploadHud?: boolean } ).__wpdUploadHud ) {
+		return;
+	}
+	( window as unknown as { __wpdUploadHud?: boolean } ).__wpdUploadHud = true;
+
+	const ns = 'desktop-mode/os-file-drop-hud';
+
+	type StartedPayload = {
+		file: File;
+		fields: DropDialogFields;
+		context: DropContext;
+		abort: () => void;
+	};
+	addAction< [ StartedPayload ] >(
+		FILE_DROP_HOOKS.UPLOAD_STARTED,
+		ns,
+		( payload ) =>
+			onStarted( payload.file, payload.fields, payload.abort ),
+	);
+
+	addAction<
+		[
+			{
+				file: File;
+				fields: DropDialogFields;
+				context: DropContext;
+				loaded: number;
+				total: number;
+				indeterminate: boolean;
+			},
+		]
+	>( FILE_DROP_HOOKS.UPLOAD_PROGRESS, ns, ( payload ) =>
+		onProgress(
+			payload.file,
+			payload.loaded,
+			payload.total,
+			payload.indeterminate,
+		),
+	);
+
+	addAction<
+		[
+			{
+				result: DropUploadResult;
+				fields: DropDialogFields;
+				context: DropContext;
+			},
+		]
+	>( FILE_DROP_HOOKS.AFTER_UPLOAD, ns, ( payload ) =>
+		onComplete( payload.fields, payload.result ),
+	);
+
+	addAction<
+		[
+			{
+				file: File;
+				error: Error;
+				context: DropContext;
+			},
+		]
+	>( FILE_DROP_HOOKS.UPLOAD_FAILED, ns, ( payload ) =>
+		onFailed( payload.file, payload.error ),
+	);
+}
+
+function onStarted(
+	file: File,
+	fields: DropDialogFields,
+	abort: () => void,
+): void {
+	const p = ensurePanel();
+	const row = document.createElement( 'div' );
+	row.className = 'desktop-mode-upload-hud__row';
+
+	const meta = document.createElement( 'div' );
+	meta.className = 'desktop-mode-upload-hud__meta';
+
+	const name = document.createElement( 'div' );
+	name.className = 'desktop-mode-upload-hud__name';
+	name.textContent = fields.filename || file.name;
+	name.title = fields.filename || file.name;
+
+	const statusEl = document.createElement( 'div' );
+	statusEl.className = 'desktop-mode-upload-hud__status';
+	statusEl.textContent = 'Uploading…';
+
+	meta.append( name, statusEl );
+
+	const bar = document.createElement( 'wpd-progress-bar' );
+	bar.setAttribute( 'indeterminate', '' );
+	bar.setAttribute( 'show-percent', '' );
+
+	const actions = document.createElement( 'div' );
+	actions.className = 'desktop-mode-upload-hud__actions';
+
+	const cancelBtn = document.createElement( 'wpd-button' );
+	cancelBtn.setAttribute( 'variant', 'tertiary' );
+	cancelBtn.setAttribute( 'size', 'small' );
+	cancelBtn.textContent = 'Cancel';
+	cancelBtn.addEventListener( 'click', () => {
+		const r = ROWS.get( file );
+		if ( ! r ) {
+			return;
+		}
+		if ( r.state === 'running' ) {
+			// Mark the row immediately so the user gets feedback even
+			// when we're in the "late cancel" path (server already
+			// received the body; we have to wait for its response so
+			// we know the attachment id to delete). The actual state
+			// flip to `aborted` happens when UPLOAD_FAILED fires.
+			r.statusEl.textContent = 'Cancelling…';
+			( r.cancelBtn as unknown as { disabled: boolean } ).disabled = true;
+			r.abort();
+		} else {
+			dismissRow( r );
+		}
+	} );
+	actions.appendChild( cancelBtn );
+
+	row.append( meta, bar, actions );
+	p.querySelector( '.desktop-mode-upload-hud__list' )!.appendChild( row );
+
+	ROWS.set( file, {
+		file,
+		abort,
+		root: row,
+		bar,
+		statusEl,
+		cancelBtn,
+		state: 'running',
+		lingerTimer: null,
+	} );
+	updateHeader();
+}
+
+function onProgress(
+	file: File,
+	loaded: number,
+	total: number,
+	indeterminate: boolean,
+): void {
+	const r = ROWS.get( file );
+	if ( ! r || r.state !== 'running' ) {
+		return;
+	}
+	if ( indeterminate || total <= 0 ) {
+		r.bar.setAttribute( 'indeterminate', '' );
+		r.statusEl.textContent = `${ formatBytes( loaded ) } sent`;
+	} else {
+		r.bar.removeAttribute( 'indeterminate' );
+		r.bar.setAttribute( 'max', String( total ) );
+		r.bar.setAttribute( 'value', String( loaded ) );
+		r.statusEl.textContent = `${ formatBytes( loaded ) } / ${ formatBytes( total ) }`;
+	}
+}
+
+function onComplete(
+	fields: DropDialogFields,
+	result: DropUploadResult,
+): void {
+	// We track by File object; the after-upload payload doesn't carry
+	// it, so fall back to filename matching.
+	const r = findRowByFilename( fields.filename || result.filename );
+	if ( ! r ) {
+		return;
+	}
+	r.state = 'success';
+	r.bar.removeAttribute( 'indeterminate' );
+	r.bar.setAttribute( 'value', '100' );
+	r.bar.setAttribute( 'max', '100' );
+	r.bar.setAttribute( 'tone', 'success' );
+	r.statusEl.textContent = 'Uploaded';
+	r.cancelBtn.textContent = 'Dismiss';
+	r.lingerTimer = setTimeout( () => dismissRow( r ), 2500 );
+	updateHeader();
+
+	activity.publish( 'desktop-mode/upload-hud-complete', {
+		filename: fields.filename || result.filename,
+		attachmentId: result.id,
+	} );
+}
+
+function onFailed( file: File, error: Error ): void {
+	const r = ROWS.get( file );
+	if ( ! r ) {
+		return;
+	}
+	r.bar.removeAttribute( 'indeterminate' );
+	r.bar.setAttribute( 'tone', 'danger' );
+	r.cancelBtn.textContent = 'Dismiss';
+	( r.cancelBtn as unknown as { disabled: boolean } ).disabled = false;
+	if ( error.name === 'UploadAbortedError' ) {
+		r.state = 'aborted';
+		r.statusEl.textContent = 'Cancelled';
+	} else {
+		r.state = 'failed';
+		r.statusEl.textContent = error.message || 'Upload failed';
+	}
+	updateHeader();
+}
+
+function dismissRow( r: HudRow ): void {
+	if ( r.lingerTimer ) {
+		clearTimeout( r.lingerTimer );
+	}
+	ROWS.delete( r.file );
+	r.root.remove();
+	updateHeader();
+	if ( ROWS.size === 0 && panel ) {
+		panel.hidden = true;
+	}
+}
+
+function findRowByFilename( filename: string ): HudRow | null {
+	for ( const r of ROWS.values() ) {
+		if ( ( r.file.name === filename || nameMatches( r, filename ) ) ) {
+			return r;
+		}
+	}
+	return null;
+}
+
+function nameMatches( r: HudRow, filename: string ): boolean {
+	const labelEl = r.root.querySelector( '.desktop-mode-upload-hud__name' );
+	return ( labelEl?.textContent ?? '' ) === filename;
+}
+
+function ensurePanel(): HTMLElement {
+	if ( panel && panel.isConnected ) {
+		panel.hidden = false;
+		return panel;
+	}
+	const p = document.createElement( 'div' );
+	p.className = 'desktop-mode-upload-hud';
+	p.setAttribute( 'role', 'region' );
+	p.setAttribute( 'aria-label', 'Uploads' );
+
+	const header = document.createElement( 'div' );
+	header.className = 'desktop-mode-upload-hud__header';
+
+	const title = document.createElement( 'div' );
+	title.className = 'desktop-mode-upload-hud__title';
+	title.textContent = 'Uploads';
+
+	const closeBtn = document.createElement( 'button' );
+	closeBtn.type = 'button';
+	closeBtn.className = 'desktop-mode-upload-hud__close';
+	closeBtn.setAttribute( 'aria-label', 'Hide upload panel' );
+	closeBtn.textContent = '×';
+	closeBtn.addEventListener( 'click', () => {
+		// Dismiss every finished row, hide the panel. In-flight uploads
+		// stay running — the user must click each row's Cancel to abort.
+		for ( const r of [ ...ROWS.values() ] ) {
+			if ( r.state !== 'running' ) {
+				dismissRow( r );
+			}
+		}
+		if ( ROWS.size === 0 ) {
+			p.hidden = true;
+		}
+	} );
+
+	header.append( title, closeBtn );
+
+	const list = document.createElement( 'div' );
+	list.className = 'desktop-mode-upload-hud__list';
+
+	p.append( header, list );
+	document.body.appendChild( p );
+	panel = p;
+	return p;
+}
+
+function updateHeader(): void {
+	if ( ! panel ) {
+		return;
+	}
+	const title = panel.querySelector(
+		'.desktop-mode-upload-hud__title',
+	) as HTMLElement | null;
+	if ( ! title ) {
+		return;
+	}
+	const total = ROWS.size;
+	const running = [ ...ROWS.values() ].filter( ( r ) => r.state === 'running' )
+		.length;
+	if ( running > 0 ) {
+		title.textContent =
+			running === total
+				? `Uploading ${ running } file${ running === 1 ? '' : 's' }…`
+				: `${ running } of ${ total } uploading…`;
+	} else if ( total > 0 ) {
+		title.textContent = `Uploads (${ total })`;
+	} else {
+		title.textContent = 'Uploads';
+	}
+}
+
+function formatBytes( n: number ): string {
+	if ( ! Number.isFinite( n ) || n <= 0 ) {
+		return '0 B';
+	}
+	const units = [ 'B', 'KB', 'MB', 'GB' ];
+	let v = n;
+	let i = 0;
+	while ( v >= 1024 && i < units.length - 1 ) {
+		v /= 1024;
+		i++;
+	}
+	const decimals = v >= 100 || i === 0 ? 0 : 1;
+	return `${ v.toFixed( decimals ) } ${ units[ i ] }`;
+}

--- a/src/os-file-drop/progress-hud.ts
+++ b/src/os-file-drop/progress-hud.ts
@@ -28,6 +28,7 @@
 
 import { addAction } from '../hooks';
 import { activity } from '../activity';
+import { formatBytes } from './format-bytes';
 import { FILE_DROP_HOOKS } from './hooks';
 import type { DropContext, DropDialogFields, DropUploadResult } from './types';
 
@@ -102,13 +103,14 @@ export function mountUploadProgressHud(): void {
 	addAction<
 		[
 			{
+				file: File;
 				result: DropUploadResult;
 				fields: DropDialogFields;
 				context: DropContext;
 			},
 		]
 	>( FILE_DROP_HOOKS.AFTER_UPLOAD, ns, ( payload ) =>
-		onComplete( payload.fields, payload.result ),
+		onComplete( payload.file, payload.fields, payload.result ),
 	);
 
 	addAction<
@@ -216,12 +218,15 @@ function onProgress(
 }
 
 function onComplete(
+	file: File,
 	fields: DropDialogFields,
 	result: DropUploadResult,
 ): void {
-	// We track by File object; the after-upload payload doesn't carry
-	// it, so fall back to filename matching.
-	const r = findRowByFilename( fields.filename || result.filename );
+	// Match by File identity — two drops of `photo.jpg` from
+	// different folders would otherwise route each other's success
+	// event to the wrong row and leave one stuck in "running"
+	// forever.
+	const r = ROWS.get( file );
 	if ( ! r ) {
 		return;
 	}
@@ -270,20 +275,6 @@ function dismissRow( r: HudRow ): void {
 	if ( ROWS.size === 0 && panel ) {
 		panel.hidden = true;
 	}
-}
-
-function findRowByFilename( filename: string ): HudRow | null {
-	for ( const r of ROWS.values() ) {
-		if ( ( r.file.name === filename || nameMatches( r, filename ) ) ) {
-			return r;
-		}
-	}
-	return null;
-}
-
-function nameMatches( r: HudRow, filename: string ): boolean {
-	const labelEl = r.root.querySelector( '.desktop-mode-upload-hud__name' );
-	return ( labelEl?.textContent ?? '' ) === filename;
 }
 
 function ensurePanel(): HTMLElement {
@@ -357,17 +348,3 @@ function updateHeader(): void {
 	}
 }
 
-function formatBytes( n: number ): string {
-	if ( ! Number.isFinite( n ) || n <= 0 ) {
-		return '0 B';
-	}
-	const units = [ 'B', 'KB', 'MB', 'GB' ];
-	let v = n;
-	let i = 0;
-	while ( v >= 1024 && i < units.length - 1 ) {
-		v /= 1024;
-		i++;
-	}
-	const decimals = v >= 100 || i === 0 ? 0 : 1;
-	return `${ v.toFixed( decimals ) } ${ units[ i ] }`;
-}

--- a/src/os-file-drop/upload.ts
+++ b/src/os-file-drop/upload.ts
@@ -156,7 +156,12 @@ export async function uploadFile(
 			}
 			const error = new Error( 'Network error during upload.' );
 			doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-				file: args.file,
+				// `filtered.file` — same identity as UPLOAD_STARTED /
+				// _PROGRESS / AFTER_UPLOAD. A BEFORE_UPLOAD filter
+				// that swapped the File would otherwise route this
+				// failure to a row keyed by the original (pre-swap)
+				// File, leaving the HUD row stuck in "running".
+				file: filtered.file,
 				error,
 				context: args.context,
 			} );
@@ -166,7 +171,12 @@ export async function uploadFile(
 		xhr.addEventListener( 'abort', () => {
 			const error = new UploadAbortedError();
 			doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-				file: args.file,
+				// `filtered.file` — same identity as UPLOAD_STARTED /
+				// _PROGRESS / AFTER_UPLOAD. A BEFORE_UPLOAD filter
+				// that swapped the File would otherwise route this
+				// failure to a row keyed by the original (pre-swap)
+				// File, leaving the HUD row stuck in "running".
+				file: filtered.file,
 				error,
 				context: args.context,
 			} );
@@ -181,7 +191,7 @@ export async function uploadFile(
 				const message = extractXhrMessage( xhr );
 				const error = new Error( message );
 				doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-					file: args.file,
+					file: filtered.file,
 					error,
 					context: args.context,
 				} );
@@ -203,7 +213,7 @@ export async function uploadFile(
 						? err
 						: new Error( 'Could not parse server response.' );
 				doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-					file: args.file,
+					file: filtered.file,
 					error,
 					context: args.context,
 				} );
@@ -225,7 +235,7 @@ export async function uploadFile(
 				);
 				const error = new UploadAbortedError();
 				doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-					file: args.file,
+					file: filtered.file,
 					error,
 					context: args.context,
 				} );

--- a/src/os-file-drop/upload.ts
+++ b/src/os-file-drop/upload.ts
@@ -5,19 +5,29 @@
  *
  *   1. Runs the `desktop-mode.drop.before-upload` filter (a
  *      plugin can return `null` to cancel or swap the file out).
- *   2. POSTs a `multipart/form-data` body so the dialog's
- *      pre-filled `title`, `alt_text`, `caption`, and
- *      `description` are persisted alongside the binary in a
- *      single round-trip (the alternative — raw body + a
- *      follow-up PATCH — leaks half-attached media on failure).
- *   3. Fires `desktop-mode.drop.after-upload` /
+ *   2. POSTs a `multipart/form-data` body via `XMLHttpRequest` so
+ *      the `upload.progress` event surface is observable. The
+ *      single-shot multipart write keeps the dialog's pre-filled
+ *      `title`, `alt_text`, `caption`, and `description` attached
+ *      to the binary in one round-trip (the alternative — raw body
+ *      + a follow-up PATCH — leaks half-attached media on failure).
+ *   3. Emits `desktop-mode.drop.upload-started` at send time with an
+ *      `abort()` handle, `desktop-mode.drop.upload-progress` on every
+ *      progress event, and `desktop-mode.drop.after-upload` /
  *      `desktop-mode.drop.upload-failed` on the way out.
+ *
+ * `fetch` cannot be substituted here — the spec exposes upload
+ * progress only via XHR's `upload.onprogress` callback (the Streams-
+ * based fetch upload-progress proposal isn't yet broadly supported,
+ * and our floating HUD needs determinate bars). Activity-bus
+ * attribution for the request lives in the manager's surrounding
+ * `wp.desktop.activity.publish` calls — XHR doesn't route through
+ * `wp.desktop.fetch` by design.
  *
  * @since 0.30.0
  */
 
 import { applyFilters, doAction } from '../hooks';
-import { trackedFetch } from '../tracked-fetch';
 import { FILE_DROP_HOOKS } from './hooks';
 import type {
 	DropContext,
@@ -70,61 +80,175 @@ export async function uploadFile(
 	body.append( 'caption', filtered.fields.caption );
 	body.append( 'description', filtered.fields.description );
 
-	let response: Response;
-	try {
-		response = await trackedFetch(
-			args.mediaUrl,
-			{
-				method: 'POST',
-				credentials: 'same-origin',
-				headers: { 'X-WP-Nonce': args.restNonce },
-				body,
-			},
-			{ source: 'desktop-mode/os-file-drop' },
-		);
-	} catch ( err ) {
-		const error = err instanceof Error ? err : new Error( String( err ) );
-		doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-			file: args.file,
-			error,
+	return new Promise< DropUploadResult >( ( resolve, reject ) => {
+		const xhr = new XMLHttpRequest();
+		xhr.open( 'POST', args.mediaUrl, true );
+		xhr.withCredentials = true;
+		xhr.setRequestHeader( 'X-WP-Nonce', args.restNonce );
+		xhr.responseType = 'text';
+
+		let aborted = false;
+		// Body-fully-sent flag — set when `upload.load` fires. After
+		// this point the server may have already stored the attachment,
+		// so an `xhr.abort()` won't actually undo the upload. We deal
+		// with that by letting the request finish and DELETE-ing the
+		// resulting attachment in the load handler below.
+		let bodyFullySent = false;
+		let cancelRequested = false;
+		const abort = (): void => {
+			cancelRequested = true;
+			if ( bodyFullySent ) {
+				// Too late to bin the request on the wire — wait for
+				// the server's response so we know the attachment id,
+				// then delete it. The xhr's `load` handler below sees
+				// `cancelRequested` and routes accordingly.
+				return;
+			}
+			aborted = true;
+			try {
+				xhr.abort();
+			} catch {
+				/* already done */
+			}
+		};
+
+		// `upload-started` lands AFTER `open()` but BEFORE `send()` so
+		// subscribers can attach their own onprogress observers via the
+		// hook bus and get a working `abort()` handle in the same tick.
+		doAction( FILE_DROP_HOOKS.UPLOAD_STARTED, {
+			file: filtered.file,
+			fields: filtered.fields,
 			context: args.context,
+			abort,
 		} );
-		throw error;
-	}
 
-	if ( ! response.ok ) {
-		const message = await extractMessage( response );
-		const error = new Error( message );
-		doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
-			file: args.file,
-			error,
-			context: args.context,
+		xhr.upload.addEventListener( 'progress', ( e: ProgressEvent ) => {
+			doAction( FILE_DROP_HOOKS.UPLOAD_PROGRESS, {
+				file: filtered.file,
+				fields: filtered.fields,
+				context: args.context,
+				loaded: e.loaded,
+				total: e.lengthComputable ? e.total : 0,
+				indeterminate: ! e.lengthComputable,
+			} );
 		} );
-		throw error;
-	}
 
-	const data = ( await response.json() ) as {
-		id: number;
-		source_url: string;
-		mime_type?: string;
-		title?: { rendered?: string };
-		media_details?: { file?: string };
-	};
-	const result: DropUploadResult = {
-		id: data.id,
-		url: data.source_url,
-		mime: data.mime_type || filtered.mime,
-		title: data.title?.rendered || filtered.fields.title,
-		filename: data.media_details?.file || filtered.fields.filename,
-	};
+		// Some browsers fire `load` on the upload stream slightly before
+		// the response body arrives — surface a synthetic 100% there so
+		// the HUD doesn't sit at 99% during server-side processing.
+		// We also use this to flip `bodyFullySent` so a late `abort()`
+		// switches to the "wait + delete" path.
+		xhr.upload.addEventListener( 'load', () => {
+			bodyFullySent = true;
+			doAction( FILE_DROP_HOOKS.UPLOAD_PROGRESS, {
+				file: filtered.file,
+				fields: filtered.fields,
+				context: args.context,
+				loaded: filtered.file.size,
+				total: filtered.file.size,
+				indeterminate: false,
+			} );
+		} );
 
-	doAction( FILE_DROP_HOOKS.AFTER_UPLOAD, {
-		result,
-		fields: filtered.fields,
-		context: args.context,
+		xhr.addEventListener( 'error', () => {
+			if ( aborted ) {
+				return;
+			}
+			const error = new Error( 'Network error during upload.' );
+			doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
+				file: args.file,
+				error,
+				context: args.context,
+			} );
+			reject( error );
+		} );
+
+		xhr.addEventListener( 'abort', () => {
+			const error = new UploadAbortedError();
+			doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
+				file: args.file,
+				error,
+				context: args.context,
+			} );
+			reject( error );
+		} );
+
+		xhr.addEventListener( 'load', () => {
+			if ( aborted ) {
+				return;
+			}
+			if ( xhr.status < 200 || xhr.status >= 300 ) {
+				const message = extractXhrMessage( xhr );
+				const error = new Error( message );
+				doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
+					file: args.file,
+					error,
+					context: args.context,
+				} );
+				reject( error );
+				return;
+			}
+			let data: {
+				id: number;
+				source_url: string;
+				mime_type?: string;
+				title?: { rendered?: string };
+				media_details?: { file?: string };
+			};
+			try {
+				data = JSON.parse( xhr.responseText );
+			} catch ( err ) {
+				const error =
+					err instanceof Error
+						? err
+						: new Error( 'Could not parse server response.' );
+				doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
+					file: args.file,
+					error,
+					context: args.context,
+				} );
+				reject( error );
+				return;
+			}
+			// Late-cancel cleanup. The user clicked Cancel after the
+			// body had been fully sent — the server still went on to
+			// create the attachment. DELETE it before we surface
+			// success / fire AFTER_UPLOAD, so live-refresh subscribers
+			// (My WordPress media-list, classic Media Library iframe)
+			// never see a "cancelled" file. Force=true skips trash so
+			// the cleanup is final.
+			if ( cancelRequested && data.id ) {
+				void deleteAttachment(
+					args.mediaUrl,
+					args.restNonce,
+					data.id,
+				);
+				const error = new UploadAbortedError();
+				doAction( FILE_DROP_HOOKS.UPLOAD_FAILED, {
+					file: args.file,
+					error,
+					context: args.context,
+				} );
+				reject( error );
+				return;
+			}
+			const result: DropUploadResult = {
+				id: data.id,
+				url: data.source_url,
+				mime: data.mime_type || filtered.mime,
+				title: data.title?.rendered || filtered.fields.title,
+				filename: data.media_details?.file || filtered.fields.filename,
+			};
+			doAction( FILE_DROP_HOOKS.AFTER_UPLOAD, {
+				result,
+				fields: filtered.fields,
+				context: args.context,
+			} );
+			resolve( result );
+		} );
+
+		xhr.send( body );
 	} );
-
-	return result;
 }
 
 /**
@@ -140,10 +264,60 @@ export class UploadCancelledError extends Error {
 	}
 }
 
-async function extractMessage( response: Response ): Promise< string > {
-	const fallback = `Upload failed (HTTP ${ response.status }).`;
+/**
+ * Marker thrown by `uploadFile` when the caller invoked the
+ * `abort()` handle exposed via the `upload-started` action (e.g.
+ * a HUD "Cancel" button). Distinct from `UploadCancelledError` so
+ * subscribers can tell "the filter blocked this" apart from "the
+ * user cancelled mid-flight".
+ *
+ * @since 0.31.0
+ */
+export class UploadAbortedError extends Error {
+	constructor() {
+		super( 'Upload aborted by the caller.' );
+		this.name = 'UploadAbortedError';
+	}
+}
+
+/**
+ * Best-effort cleanup for a "late cancel" — the upload's body had
+ * already been received by the server when the user pressed Cancel,
+ * so we DELETE the attachment that was created. Force=true so the
+ * file is removed outright instead of sitting in trash (which would
+ * itself surface in the user's Media Library). Failures here are
+ * silent; the attachment will eventually be visible to the user and
+ * they can delete it manually. We deliberately don't route through
+ * `trackedFetch` — this is invisible cleanup, not user activity.
+ */
+function deleteAttachment(
+	mediaUrl: string,
+	restNonce: string,
+	id: number,
+): Promise< void > {
+	const url = `${ mediaUrl.replace( /\/$/, '' ) }/${ id }?force=true`;
+	const cleanup = new XMLHttpRequest();
+	cleanup.open( 'DELETE', url, true );
+	cleanup.withCredentials = true;
+	cleanup.setRequestHeader( 'X-WP-Nonce', restNonce );
+	return new Promise( ( resolve ) => {
+		cleanup.addEventListener( 'loadend', () => resolve() );
+		try {
+			cleanup.send();
+		} catch {
+			resolve();
+		}
+	} );
+}
+
+function extractXhrMessage( xhr: XMLHttpRequest ): string {
+	const fallback = `Upload failed (HTTP ${ xhr.status }).`;
+	const text = xhr.responseText;
+	if ( ! text ) {
+		return fallback;
+	}
 	try {
-		const data = ( await response.json() ) as { message?: string };
+		const data = JSON.parse( text ) as { message?: string };
 		if ( data && typeof data.message === 'string' ) {
 			return data.message;
 		}

--- a/src/os-file-drop/upload.ts
+++ b/src/os-file-drop/upload.ts
@@ -240,6 +240,7 @@ export async function uploadFile(
 				filename: data.media_details?.file || filtered.fields.filename,
 			};
 			doAction( FILE_DROP_HOOKS.AFTER_UPLOAD, {
+				file: filtered.file,
 				result,
 				fields: filtered.fields,
 				context: args.context,
@@ -301,10 +302,35 @@ function deleteAttachment(
 	cleanup.withCredentials = true;
 	cleanup.setRequestHeader( 'X-WP-Nonce', restNonce );
 	return new Promise( ( resolve ) => {
-		cleanup.addEventListener( 'loadend', () => resolve() );
+		cleanup.addEventListener( 'loadend', () => {
+			// Cleanup failures are recoverable from the user's
+			// perspective (they can delete the file manually), so
+			// we don't reject — but a warning makes the "phantom
+			// attachment" class of bug discoverable instead of
+			// silent for plugin authors investigating.
+			if ( cleanup.status < 200 || cleanup.status >= 300 ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`[os-file-drop] late-cancel cleanup failed for attachment ${ id } (HTTP ${ cleanup.status }). The attachment remains in the Media Library; delete it manually.`,
+				);
+			}
+			resolve();
+		} );
+		cleanup.addEventListener( 'error', () => {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`[os-file-drop] late-cancel cleanup network error for attachment ${ id }. The attachment remains in the Media Library; delete it manually.`,
+			);
+			resolve();
+		} );
 		try {
 			cleanup.send();
-		} catch {
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`[os-file-drop] late-cancel cleanup could not be dispatched for attachment ${ id }:`,
+				err,
+			);
 			resolve();
 		}
 	} );

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -94,6 +94,8 @@ export { WpdRatingSummary } from './wpd-rating-summary/wpd-rating-summary';
 export type { WpdRatingBuckets } from './wpd-rating-summary/wpd-rating-summary';
 export { WpdNotice } from './wpd-notice/wpd-notice';
 export type { WpdNoticeTone } from './wpd-notice/wpd-notice';
+export { WpdProgressBar } from './wpd-progress-bar/wpd-progress-bar';
+export type { WpdProgressTone } from './wpd-progress-bar/wpd-progress-bar';
 
 // List of tags registered by this barrel. `doAction(
 // COMPONENTS_REGISTERED, { tags } )` fires once from
@@ -161,4 +163,5 @@ export const WPD_COMPONENT_TAGS = [
 	'wpd-card',
 	'wpd-rating-summary',
 	'wpd-notice',
+	'wpd-progress-bar',
 ] as const;

--- a/src/ui/components/wpd-progress-bar/wpd-progress-bar.styles.ts
+++ b/src/ui/components/wpd-progress-bar/wpd-progress-bar.styles.ts
@@ -1,0 +1,113 @@
+import { css } from '../../core';
+
+export const styles = css`
+	:host {
+		display: block;
+		--wpd-progress-track-bg: var(
+			--desktop-mode-control-bg,
+			rgba( 0, 0, 0, 0.08 )
+		);
+		--wpd-progress-fill: var(
+			--wp-admin-theme-color,
+			#2271b1
+		);
+		--wpd-progress-height: 6px;
+		--wpd-progress-radius: 999px;
+		--wpd-progress-label-color: inherit;
+		--wpd-progress-label-size: 12px;
+		--wpd-progress-label-gap: 4px;
+		width: 100%;
+		font: inherit;
+		color: var( --wpd-progress-label-color );
+	}
+	:host( [ hidden ] ) {
+		display: none;
+	}
+
+	.header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+		margin-bottom: var( --wpd-progress-label-gap );
+		font-size: var( --wpd-progress-label-size );
+		line-height: 1.3;
+	}
+	.label {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.percent {
+		font-variant-numeric: tabular-nums;
+		opacity: 0.75;
+		flex-shrink: 0;
+	}
+
+	.track {
+		position: relative;
+		width: 100%;
+		height: var( --wpd-progress-height );
+		background: var( --wpd-progress-track-bg );
+		border-radius: var( --wpd-progress-radius );
+		overflow: hidden;
+	}
+
+	.fill {
+		position: absolute;
+		inset-block: 0;
+		inset-inline-start: 0;
+		width: 0;
+		background: var( --wpd-progress-fill );
+		border-radius: inherit;
+		transition: width 0.18s ease-out;
+	}
+
+	/* Tone modifiers — same custom-property surface. */
+	:host( [ tone='success' ] ) {
+		--wpd-progress-fill: var(
+			--desktop-mode-status-success,
+			#3a8a3a
+		);
+	}
+	:host( [ tone='warning' ] ) {
+		--wpd-progress-fill: var(
+			--desktop-mode-status-warning,
+			#dba617
+		);
+	}
+	:host( [ tone='danger' ] ) {
+		--wpd-progress-fill: var(
+			--desktop-mode-status-danger,
+			#d63638
+		);
+	}
+
+	/* Indeterminate — sweeping bar across the track. */
+	:host( [ indeterminate ] ) .fill {
+		width: 33%;
+		animation: wpd-progress-sweep 1.1s linear infinite;
+		transition: none;
+	}
+
+	@keyframes wpd-progress-sweep {
+		0% {
+			transform: translateX( -120% );
+		}
+		100% {
+			transform: translateX( 320% );
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.fill {
+			transition: none;
+		}
+		:host( [ indeterminate ] ) .fill {
+			animation: none;
+			width: 100%;
+			opacity: 0.6;
+		}
+	}
+`;

--- a/src/ui/components/wpd-progress-bar/wpd-progress-bar.test.ts
+++ b/src/ui/components/wpd-progress-bar/wpd-progress-bar.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `<wpd-progress-bar>` — smoke tests covering determinate value
+ * rendering, max-clamping, indeterminate mode, the label + percent
+ * header, ARIA wiring, and live attribute updates.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import './wpd-progress-bar';
+
+const tick = (): Promise< void > =>
+	new Promise( ( r ) => queueMicrotask( () => queueMicrotask( () => r() ) ) );
+
+describe( '<wpd-progress-bar>', () => {
+	let host: HTMLElement;
+	beforeEach( () => {
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+	} );
+	afterEach( () => host.remove() );
+
+	test( 'renders a progressbar track with default ARIA values', async () => {
+		host.innerHTML = `<wpd-progress-bar value="0"></wpd-progress-bar>`;
+		await tick();
+		const track = host
+			.querySelector( 'wpd-progress-bar' )!
+			.shadowRoot!.querySelector( '.track' )!;
+		expect( track.getAttribute( 'role' ) ).toBe( 'progressbar' );
+		expect( track.getAttribute( 'aria-valuemin' ) ).toBe( '0' );
+		expect( track.getAttribute( 'aria-valuemax' ) ).toBe( '100' );
+		expect( track.getAttribute( 'aria-valuenow' ) ).toBe( '0' );
+	} );
+
+	test( 'fill width matches value/max in determinate mode', async () => {
+		host.innerHTML = `<wpd-progress-bar value="42"></wpd-progress-bar>`;
+		await tick();
+		const fill = host
+			.querySelector( 'wpd-progress-bar' )!
+			.shadowRoot!.querySelector( '.fill' ) as HTMLElement;
+		expect( parseFloat( fill.style.width ) ).toBeCloseTo( 42, 5 );
+	} );
+
+	test( 'value over max is clamped', async () => {
+		host.innerHTML = `<wpd-progress-bar value="999" max="200"></wpd-progress-bar>`;
+		await tick();
+		const fill = host
+			.querySelector( 'wpd-progress-bar' )!
+			.shadowRoot!.querySelector( '.fill' ) as HTMLElement;
+		// 200 / 200 → 100%
+		// jsdom normalizes `100.00%` → `100%`; assert numerically.
+		expect( parseFloat( fill.style.width ) ).toBeCloseTo( 100, 5 );
+		const track = host
+			.querySelector( 'wpd-progress-bar' )!
+			.shadowRoot!.querySelector( '.track' )!;
+		expect( track.getAttribute( 'aria-valuenow' ) ).toBe( '200' );
+	} );
+
+	test( 'indeterminate drops aria-valuenow/max and clears inline width', async () => {
+		host.innerHTML = `<wpd-progress-bar value="50" indeterminate></wpd-progress-bar>`;
+		await tick();
+		const bar = host.querySelector( 'wpd-progress-bar' )!;
+		const track = bar.shadowRoot!.querySelector( '.track' )!;
+		const fill = bar.shadowRoot!.querySelector( '.fill' ) as HTMLElement;
+		expect( track.hasAttribute( 'aria-valuenow' ) ).toBe( false );
+		expect( track.hasAttribute( 'aria-valuemax' ) ).toBe( false );
+		// The CSS animation keeps the bar sweeping; we clear the
+		// inline width so the stylesheet's 33% rule wins.
+		expect( fill.style.width ).toBe( '' );
+	} );
+
+	test( 'label populates the header text and aria-label on the track', async () => {
+		host.innerHTML = `<wpd-progress-bar value="10" label="hero.jpg"></wpd-progress-bar>`;
+		await tick();
+		const bar = host.querySelector( 'wpd-progress-bar' )!;
+		const header = bar.shadowRoot!.querySelector( '.header' ) as HTMLElement;
+		const labelEl = bar.shadowRoot!.querySelector( '.label' ) as HTMLElement;
+		const track = bar.shadowRoot!.querySelector( '.track' )!;
+		expect( header.hidden ).toBe( false );
+		expect( labelEl.textContent ).toBe( 'hero.jpg' );
+		expect( track.getAttribute( 'aria-label' ) ).toBe( 'hero.jpg' );
+	} );
+
+	test( 'show-percent renders the integer percent next to the label', async () => {
+		host.innerHTML = `<wpd-progress-bar value="33" label="x" show-percent></wpd-progress-bar>`;
+		await tick();
+		const percent = host
+			.querySelector( 'wpd-progress-bar' )!
+			.shadowRoot!.querySelector( '.percent' ) as HTMLElement;
+		expect( percent.hidden ).toBe( false );
+		expect( percent.textContent ).toBe( '33%' );
+	} );
+
+	test( 'changing value live re-paints the fill width', async () => {
+		host.innerHTML = `<wpd-progress-bar value="10"></wpd-progress-bar>`;
+		await tick();
+		const bar = host.querySelector( 'wpd-progress-bar' )!;
+		const fill = bar.shadowRoot!.querySelector( '.fill' ) as HTMLElement;
+		expect( parseFloat( fill.style.width ) ).toBeCloseTo( 10, 5 );
+		bar.setAttribute( 'value', '75' );
+		await tick();
+		expect( parseFloat( fill.style.width ) ).toBeCloseTo( 75, 5 );
+	} );
+
+	test( 'max <= 0 falls back to indeterminate behavior', async () => {
+		host.innerHTML = `<wpd-progress-bar value="5" max="0"></wpd-progress-bar>`;
+		await tick();
+		const track = host
+			.querySelector( 'wpd-progress-bar' )!
+			.shadowRoot!.querySelector( '.track' )!;
+		expect( track.hasAttribute( 'aria-valuenow' ) ).toBe( false );
+	} );
+} );

--- a/src/ui/components/wpd-progress-bar/wpd-progress-bar.test.ts
+++ b/src/ui/components/wpd-progress-bar/wpd-progress-bar.test.ts
@@ -99,6 +99,36 @@ describe( '<wpd-progress-bar>', () => {
 		expect( parseFloat( fill.style.width ) ).toBeCloseTo( 75, 5 );
 	} );
 
+	test( 'progressbar role + aria-value* live on the host element, not just the shadow track', async () => {
+		// AT / browser combos that don't surface shadow-DOM roles
+		// rely on the host carrying the canonical semantics, the
+		// same way native <progress> exposes itself.
+		host.innerHTML = `<wpd-progress-bar value="60" max="200" label="Saving"></wpd-progress-bar>`;
+		await tick();
+		const bar = host.querySelector( 'wpd-progress-bar' )!;
+		expect( bar.getAttribute( 'role' ) ).toBe( 'progressbar' );
+		expect( bar.getAttribute( 'aria-valuemin' ) ).toBe( '0' );
+		expect( bar.getAttribute( 'aria-valuemax' ) ).toBe( '200' );
+		expect( bar.getAttribute( 'aria-valuenow' ) ).toBe( '60' );
+		expect( bar.getAttribute( 'aria-label' ) ).toBe( 'Saving' );
+	} );
+
+	test( 'indeterminate drops the host aria-valuenow / aria-valuemax', async () => {
+		host.innerHTML = `<wpd-progress-bar value="60" indeterminate></wpd-progress-bar>`;
+		await tick();
+		const bar = host.querySelector( 'wpd-progress-bar' )!;
+		expect( bar.getAttribute( 'role' ) ).toBe( 'progressbar' );
+		expect( bar.hasAttribute( 'aria-valuenow' ) ).toBe( false );
+		expect( bar.hasAttribute( 'aria-valuemax' ) ).toBe( false );
+	} );
+
+	test( 'author-provided aria-label on the host wins over `label`', async () => {
+		host.innerHTML = `<wpd-progress-bar value="10" label="Saving" aria-label="Custom"></wpd-progress-bar>`;
+		await tick();
+		const bar = host.querySelector( 'wpd-progress-bar' )!;
+		expect( bar.getAttribute( 'aria-label' ) ).toBe( 'Custom' );
+	} );
+
 	test( 'max <= 0 falls back to indeterminate behavior', async () => {
 		host.innerHTML = `<wpd-progress-bar value="5" max="0"></wpd-progress-bar>`;
 		await tick();

--- a/src/ui/components/wpd-progress-bar/wpd-progress-bar.ts
+++ b/src/ui/components/wpd-progress-bar/wpd-progress-bar.ts
@@ -1,0 +1,206 @@
+/**
+ * `<wpd-progress-bar>` — determinate or indeterminate progress indicator.
+ *
+ * Drop-in:
+ *
+ * ```html
+ * <wpd-progress-bar value="42"></wpd-progress-bar>
+ * <wpd-progress-bar indeterminate label="Uploading…"></wpd-progress-bar>
+ * <wpd-progress-bar value="280" max="320" tone="success"
+ *     label="hero.jpg" show-percent></wpd-progress-bar>
+ * ```
+ *
+ * Determinate: set `value` (and optionally `max`, default `100`). The
+ * fill width animates between updates. Indeterminate: set the boolean
+ * `indeterminate` attribute — a 33% bar sweeps across the track on a
+ * 1.1s linear loop.
+ *
+ * Tone (`default | success | warning | danger`) tints the fill via the
+ * shared `--desktop-mode-status-*` palette so the bar reads the same as
+ * the rest of the shell. Every visual surface — track, fill, height,
+ * radius, label color/size — is overridable via CSS custom properties.
+ *
+ * @since 0.31.0
+ */
+
+import { Component, defineComponent, html, type TemplateResult } from '../../core';
+import { styles } from './wpd-progress-bar.styles';
+
+export type WpdProgressTone = 'default' | 'success' | 'warning' | 'danger';
+
+export class WpdProgressBar extends Component {
+	static props = [
+		'value',
+		'max',
+		'indeterminate',
+		'tone',
+		'label',
+		'showPercent',
+	] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Progress bar',
+		summary:
+			'Linear progress indicator. Determinate mode shows `value/max` as a fill width; indeterminate mode sweeps across the track. Supports tone tinting, an optional inline label + percent header, and full CSS-variable theming.',
+		status: 'experimental',
+		since: '0.31.0',
+		props: [
+			{
+				name: 'value',
+				type: 'number',
+				default: '0',
+				description: 'Current progress. Clamped to `[0, max]`.',
+			},
+			{
+				name: 'max',
+				type: 'number',
+				default: '100',
+				description: 'Maximum value. Setting `max <= 0` forces indeterminate.',
+			},
+			{
+				name: 'indeterminate',
+				type: 'boolean',
+				description:
+					'Show the sweeping indeterminate animation instead of a value-driven fill. The `value` attribute is ignored while this is set.',
+			},
+			{
+				name: 'tone',
+				type: '"default" | "success" | "warning" | "danger"',
+				default: 'default',
+				description: 'Tints the fill from the shared status palette.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description:
+					'Optional inline label rendered above the track. Also wired into `aria-label` when set.',
+			},
+			{
+				name: 'show-percent',
+				type: 'boolean',
+				description:
+					'Render a right-aligned percent readout next to the label. Only meaningful in determinate mode.',
+			},
+		],
+		cssProps: [
+			{
+				name: '--wpd-progress-track-bg',
+				default: 'var(--desktop-mode-control-bg, rgba(0,0,0,0.08))',
+			},
+			{
+				name: '--wpd-progress-fill',
+				default: 'var(--wp-admin-theme-color, #2271b1)',
+			},
+			{ name: '--wpd-progress-height', default: '6px' },
+			{ name: '--wpd-progress-radius', default: '999px' },
+			{ name: '--wpd-progress-label-color', default: 'inherit' },
+			{ name: '--wpd-progress-label-size', default: '12px' },
+			{ name: '--wpd-progress-label-gap', default: '4px' },
+		],
+		example: html`<wpd-progress-bar
+			value="42"
+			label="Uploading hero.jpg"
+			show-percent
+		></wpd-progress-bar>`,
+	} as const;
+
+	protected render(): TemplateResult {
+		return html`<div class="root" part="root">
+			<div class="header" part="header" hidden>
+				<span class="label" part="label"></span>
+				<span class="percent" part="percent"></span>
+			</div>
+			<div class="track" part="track">
+				<div class="fill" part="fill"></div>
+			</div>
+		</div>`;
+	}
+
+	protected requestUpdate(): void {
+		super.requestUpdate();
+		queueMicrotask( () => this._paint() );
+	}
+
+	connectedCallback(): void {
+		super.connectedCallback();
+		queueMicrotask( () => this._paint() );
+	}
+
+	private _paint(): void {
+		const root = this.shadowRoot;
+		if ( ! root ) {
+			return;
+		}
+		const max = this._readMax();
+		const indeterminate = this.hasAttribute( 'indeterminate' ) || max <= 0;
+		const value = indeterminate ? 0 : this._readValue( max );
+		const ratio = indeterminate ? 0 : value / max;
+		const percent = Math.round( ratio * 100 );
+		const label = this.getAttribute( 'label' ) ?? '';
+		const showPercent = this.hasAttribute( 'show-percent' );
+
+		const fill = root.querySelector( '.fill' ) as HTMLElement | null;
+		if ( fill && ! indeterminate ) {
+			fill.style.width = `${ ( ratio * 100 ).toFixed( 2 ) }%`;
+		} else if ( fill && indeterminate ) {
+			fill.style.removeProperty( 'width' );
+		}
+
+		const header = root.querySelector( '.header' ) as HTMLElement | null;
+		const labelEl = root.querySelector( '.label' ) as HTMLElement | null;
+		const percentEl = root.querySelector( '.percent' ) as HTMLElement | null;
+		if ( header && labelEl && percentEl ) {
+			const visible = label || ( showPercent && ! indeterminate );
+			header.hidden = ! visible;
+			labelEl.textContent = label;
+			percentEl.hidden = ! ( showPercent && ! indeterminate );
+			percentEl.textContent = `${ percent }%`;
+		}
+
+		const track = root.querySelector( '.track' ) as HTMLElement | null;
+		if ( track ) {
+			track.setAttribute( 'role', 'progressbar' );
+			track.setAttribute( 'aria-valuemin', '0' );
+			if ( indeterminate ) {
+				track.removeAttribute( 'aria-valuenow' );
+				track.removeAttribute( 'aria-valuemax' );
+			} else {
+				track.setAttribute( 'aria-valuemax', String( max ) );
+				track.setAttribute( 'aria-valuenow', String( value ) );
+			}
+			if ( label ) {
+				track.setAttribute( 'aria-label', label );
+			} else {
+				track.removeAttribute( 'aria-label' );
+			}
+		}
+	}
+
+	private _readMax(): number {
+		const attr = this.getAttribute( 'max' );
+		if ( attr === null ) {
+			return 100;
+		}
+		const raw = parseFloat( attr );
+		// Keep non-positive values verbatim so the indeterminate
+		// fallback can see them; clamp only `NaN` to the default.
+		return Number.isFinite( raw ) ? raw : 100;
+	}
+
+	private _readValue( max: number ): number {
+		const raw = parseFloat( this.getAttribute( 'value' ) ?? '0' );
+		if ( ! Number.isFinite( raw ) ) {
+			return 0;
+		}
+		if ( raw < 0 ) {
+			return 0;
+		}
+		if ( raw > max ) {
+			return max;
+		}
+		return raw;
+	}
+}
+
+defineComponent( 'wpd-progress-bar', WpdProgressBar );

--- a/src/ui/components/wpd-progress-bar/wpd-progress-bar.ts
+++ b/src/ui/components/wpd-progress-bar/wpd-progress-bar.ts
@@ -158,6 +158,14 @@ export class WpdProgressBar extends Component {
 			percentEl.textContent = `${ percent }%`;
 		}
 
+		// Mirror ARIA onto BOTH the host AND the inner track. Some
+		// browser / AT combos don't surface shadow-DOM `role` to
+		// the accessibility tree, so the host carries the canonical
+		// progressbar semantics (matching how native `<progress>`
+		// exposes itself). The inner track keeps a copy so authors
+		// inspecting the shadow root for styling tests still see
+		// the role they expect.
+		this._syncAria( max, value, indeterminate, label );
 		const track = root.querySelector( '.track' ) as HTMLElement | null;
 		if ( track ) {
 			track.setAttribute( 'role', 'progressbar' );
@@ -174,6 +182,44 @@ export class WpdProgressBar extends Component {
 			} else {
 				track.removeAttribute( 'aria-label' );
 			}
+		}
+	}
+
+	/**
+	 * Track which `aria-label` values we wrote ourselves so an
+	 * author-provided `aria-label` is never clobbered by a `label`
+	 * change. Without this we'd overwrite on every paint.
+	 */
+	private _ownedAriaLabel: string | null = null;
+
+	private _syncAria(
+		max: number,
+		value: number,
+		indeterminate: boolean,
+		label: string,
+	): void {
+		this.setAttribute( 'role', 'progressbar' );
+		this.setAttribute( 'aria-valuemin', '0' );
+		if ( indeterminate ) {
+			this.removeAttribute( 'aria-valuenow' );
+			this.removeAttribute( 'aria-valuemax' );
+		} else {
+			this.setAttribute( 'aria-valuemax', String( max ) );
+			this.setAttribute( 'aria-valuenow', String( value ) );
+		}
+		// Mirror `label` → `aria-label` on the host so AT reads it
+		// even when the visible header is hidden by `show-percent`
+		// off + no label space. If the author wrote their own
+		// `aria-label`, leave it alone.
+		const existing = this.getAttribute( 'aria-label' );
+		if ( label ) {
+			if ( existing === null || existing === this._ownedAriaLabel ) {
+				this.setAttribute( 'aria-label', label );
+				this._ownedAriaLabel = label;
+			}
+		} else if ( existing !== null && existing === this._ownedAriaLabel ) {
+			this.removeAttribute( 'aria-label' );
+			this._ownedAriaLabel = null;
 		}
 	}
 

--- a/tests/vitest/os-file-drop-upload.test.ts
+++ b/tests/vitest/os-file-drop-upload.test.ts
@@ -1,9 +1,10 @@
 /**
  * Unit tests for `src/os-file-drop/upload.ts`.
  *
- * Verifies the wp/v2/media multipart POST shape and the
- * `before-upload` / `after-upload` / `upload-failed` hook
- * surface.
+ * Verifies the wp/v2/media multipart POST shape, the
+ * `before-upload` / `upload-started` / `upload-progress` /
+ * `after-upload` / `upload-failed` hook surface, and the
+ * `abort()` handle wired through `upload-started`.
  *
  * @since 0.30.0
  */
@@ -12,7 +13,11 @@ import {
 	clearHooksStub,
 	installHooksStub,
 } from './helpers/hooks-stub';
-import { uploadFile, UploadCancelledError } from '../../src/os-file-drop/upload';
+import {
+	uploadFile,
+	UploadAbortedError,
+	UploadCancelledError,
+} from '../../src/os-file-drop/upload';
 import { FILE_DROP_HOOKS } from '../../src/os-file-drop/hooks';
 import type { DropContext } from '../../src/os-file-drop/types';
 
@@ -38,38 +43,134 @@ function defaultArgs( file: File, mime: string ) {
 	};
 }
 
+/**
+ * Minimal XHR stub that mimics the order browsers fire events in:
+ * `upload.progress*` → `upload.load` → `load` (with the configured
+ * status + body). The instance is exposed via `lastXhr` so tests
+ * can call `.simulateProgress()` / `.simulateError()` from outside.
+ */
+class FakeXhrUpload {
+	private listeners = new Map< string, Array< ( e: ProgressEvent ) => void > >();
+	addEventListener(
+		name: string,
+		handler: ( e: ProgressEvent ) => void,
+	): void {
+		const arr = this.listeners.get( name ) ?? [];
+		arr.push( handler );
+		this.listeners.set( name, arr );
+	}
+	emit( name: string, event: ProgressEvent ): void {
+		for ( const fn of this.listeners.get( name ) ?? [] ) {
+			fn( event );
+		}
+	}
+}
+
+interface FakeXhrConfig {
+	status: number;
+	responseText: string;
+	failMode?: 'network' | 'none';
+}
+
+class FakeXhr {
+	static lastInstance: FakeXhr | null = null;
+	static nextConfig: FakeXhrConfig = {
+		status: 201,
+		responseText: '',
+	};
+
+	upload = new FakeXhrUpload();
+	private listeners = new Map< string, Array< ( e: Event ) => void > >();
+	status = 0;
+	responseText = '';
+	responseType = '';
+	withCredentials = false;
+	method = '';
+	url = '';
+	private headers: Record< string, string > = {};
+
+	constructor() {
+		FakeXhr.lastInstance = this;
+	}
+
+	open( method: string, url: string ): void {
+		this.method = method;
+		this.url = url;
+	}
+	setRequestHeader( key: string, value: string ): void {
+		this.headers[ key ] = value;
+	}
+	addEventListener( name: string, handler: ( e: Event ) => void ): void {
+		const arr = this.listeners.get( name ) ?? [];
+		arr.push( handler );
+		this.listeners.set( name, arr );
+	}
+	abort(): void {
+		queueMicrotask( () => this.emit( 'abort', new Event( 'abort' ) ) );
+	}
+	send( _body: unknown ): void {
+		const cfg = FakeXhr.nextConfig;
+		queueMicrotask( () => {
+			// Simulate one upload progress tick + the synthetic
+			// `upload.load` the production code listens for.
+			this.upload.emit(
+				'progress',
+				new ProgressEvent( 'progress', {
+					lengthComputable: true,
+					loaded: 8,
+					total: 16,
+				} ),
+			);
+			this.upload.emit(
+				'load',
+				new ProgressEvent( 'load', {
+					lengthComputable: true,
+					loaded: 16,
+					total: 16,
+				} ),
+			);
+			if ( cfg.failMode === 'network' ) {
+				this.emit( 'error', new Event( 'error' ) );
+				return;
+			}
+			this.status = cfg.status;
+			this.responseText = cfg.responseText;
+			this.emit( 'load', new Event( 'load' ) );
+		} );
+	}
+	private emit( name: string, e: Event ): void {
+		for ( const fn of this.listeners.get( name ) ?? [] ) {
+			fn( e );
+		}
+	}
+}
+
 describe( 'os-file-drop/upload', () => {
+	let realXhr: typeof XMLHttpRequest;
 	beforeEach( () => {
 		installHooksStub();
-		( window as unknown as { wp?: { desktop?: { fetch?: unknown } } } ).wp = {
-			...( window as unknown as { wp?: unknown } ).wp ?? {},
-			hooks: window.wp!.hooks,
-			desktop: {
-				fetch: ( _input: RequestInfo, init?: RequestInit ) => {
-					// Capture the multipart body in a closure via the test.
-					return Promise.resolve(
-						new Response(
-							JSON.stringify( {
-								id: 42,
-								source_url: 'https://example.test/uploads/test.png',
-								mime_type: 'image/png',
-								title: { rendered: 'Test' },
-								media_details: { file: 'test.png' },
-							} ),
-							{
-								status: 201,
-								headers: { 'content-type': 'application/json' },
-							},
-						),
-					);
-				},
-			},
-		} as unknown as typeof window.wp;
+		realXhr = ( globalThis as { XMLHttpRequest: typeof XMLHttpRequest } )
+			.XMLHttpRequest;
+		( globalThis as unknown as { XMLHttpRequest: unknown } ).XMLHttpRequest =
+			FakeXhr;
+		FakeXhr.lastInstance = null;
+		FakeXhr.nextConfig = {
+			status: 201,
+			responseText: JSON.stringify( {
+				id: 42,
+				source_url: 'https://example.test/uploads/test.png',
+				mime_type: 'image/png',
+				title: { rendered: 'Test' },
+				media_details: { file: 'test.png' },
+			} ),
+		};
 	} );
 
 	afterEach( () => {
 		clearHooksStub();
 		vi.restoreAllMocks();
+		( globalThis as unknown as { XMLHttpRequest: unknown } ).XMLHttpRequest =
+			realXhr;
 	} );
 
 	test( 'POSTs multipart form-data and emits after-upload', async () => {
@@ -84,6 +185,36 @@ describe( 'os-file-drop/upload', () => {
 		expect( result.id ).toBe( 42 );
 		expect( result.url ).toContain( '/uploads/' );
 		expect( seen ).toHaveLength( 1 );
+		expect( FakeXhr.lastInstance?.method ).toBe( 'POST' );
+	} );
+
+	test( 'emits upload-started before send with an abort handle', async () => {
+		const file = makeFile( 'test.png', 'image/png' );
+		const startedPayloads: Array< { abort: () => void } > = [];
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_STARTED,
+			'test/started',
+			( p: { abort: () => void } ) => startedPayloads.push( p ),
+		);
+		await uploadFile( defaultArgs( file, 'image/png' ) );
+		expect( startedPayloads ).toHaveLength( 1 );
+		expect( typeof startedPayloads[ 0 ].abort ).toBe( 'function' );
+	} );
+
+	test( 'emits upload-progress as bytes flow + synthetic 100% on stream load', async () => {
+		const file = makeFile( 'test.png', 'image/png' );
+		const ticks: Array< { loaded: number; total: number } > = [];
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_PROGRESS,
+			'test/progress',
+			( p: { loaded: number; total: number } ) => ticks.push( p ),
+		);
+		await uploadFile( defaultArgs( file, 'image/png' ) );
+		// One real progress tick (8/16) + the synthetic full event
+		// the production code dispatches on `upload.load`.
+		expect( ticks.length ).toBeGreaterThanOrEqual( 2 );
+		expect( ticks[ 0 ].loaded ).toBe( 8 );
+		expect( ticks[ 1 ].loaded ).toBe( ticks[ 1 ].total );
 	} );
 
 	test( 'before-upload returning null cancels the upload', async () => {
@@ -99,14 +230,10 @@ describe( 'os-file-drop/upload', () => {
 	} );
 
 	test( 'a non-OK response fires upload-failed', async () => {
-		( window as unknown as { wp: { desktop: { fetch: unknown } } } ).wp.desktop.fetch =
-			() =>
-				Promise.resolve(
-					new Response( JSON.stringify( { message: 'Forbidden' } ), {
-						status: 403,
-						headers: { 'content-type': 'application/json' },
-					} ),
-				);
+		FakeXhr.nextConfig = {
+			status: 403,
+			responseText: JSON.stringify( { message: 'Forbidden' } ),
+		};
 		const failures: unknown[] = [];
 		window.wp!.hooks!.addAction(
 			FILE_DROP_HOOKS.UPLOAD_FAILED,
@@ -118,5 +245,25 @@ describe( 'os-file-drop/upload', () => {
 			uploadFile( defaultArgs( file, 'image/png' ) ),
 		).rejects.toThrow( /Forbidden/ );
 		expect( failures ).toHaveLength( 1 );
+	} );
+
+	test( 'network error fires upload-failed with a generic message', async () => {
+		FakeXhr.nextConfig = { status: 0, responseText: '', failMode: 'network' };
+		const file = makeFile( 'test.png', 'image/png' );
+		await expect(
+			uploadFile( defaultArgs( file, 'image/png' ) ),
+		).rejects.toThrow( /Network error/i );
+	} );
+
+	test( 'abort() from the started payload rejects with UploadAbortedError', async () => {
+		const file = makeFile( 'test.png', 'image/png' );
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_STARTED,
+			'test/abort',
+			( p: { abort: () => void } ) => p.abort(),
+		);
+		await expect(
+			uploadFile( defaultArgs( file, 'image/png' ) ),
+		).rejects.toBeInstanceOf( UploadAbortedError );
 	} );
 } );

--- a/tests/vitest/os-file-drop-upload.test.ts
+++ b/tests/vitest/os-file-drop-upload.test.ts
@@ -73,6 +73,7 @@ interface FakeXhrConfig {
 }
 
 class FakeXhr {
+	static instances: FakeXhr[] = [];
 	static lastInstance: FakeXhr | null = null;
 	static nextConfig: FakeXhrConfig = {
 		status: 201,
@@ -87,10 +88,12 @@ class FakeXhr {
 	withCredentials = false;
 	method = '';
 	url = '';
+	aborted = false;
 	private headers: Record< string, string > = {};
 
 	constructor() {
 		FakeXhr.lastInstance = this;
+		FakeXhr.instances.push( this );
 	}
 
 	open( method: string, url: string ): void {
@@ -106,10 +109,21 @@ class FakeXhr {
 		this.listeners.set( name, arr );
 	}
 	abort(): void {
+		this.aborted = true;
 		queueMicrotask( () => this.emit( 'abort', new Event( 'abort' ) ) );
 	}
 	send( _body: unknown ): void {
 		const cfg = FakeXhr.nextConfig;
+		// DELETE requests (the late-cancel cleanup path) don't drive
+		// the upload-progress event stream and respond with 200 OK.
+		if ( this.method === 'DELETE' ) {
+			queueMicrotask( () => {
+				this.status = 200;
+				this.responseText = '{}';
+				this.emit( 'loadend', new Event( 'loadend' ) );
+			} );
+			return;
+		}
 		queueMicrotask( () => {
 			// Simulate one upload progress tick + the synthetic
 			// `upload.load` the production code listens for.
@@ -154,6 +168,7 @@ describe( 'os-file-drop/upload', () => {
 		( globalThis as unknown as { XMLHttpRequest: unknown } ).XMLHttpRequest =
 			FakeXhr;
 		FakeXhr.lastInstance = null;
+		FakeXhr.instances = [];
 		FakeXhr.nextConfig = {
 			status: 201,
 			responseText: JSON.stringify( {
@@ -175,16 +190,21 @@ describe( 'os-file-drop/upload', () => {
 
 	test( 'POSTs multipart form-data and emits after-upload', async () => {
 		const file = makeFile( 'test.png', 'image/png' );
-		const seen: unknown[] = [];
+		const seen: Array< { file: File; result: { id: number } } > = [];
 		window.wp!.hooks!.addAction(
 			FILE_DROP_HOOKS.AFTER_UPLOAD,
 			'test/after',
-			( p: unknown ) => seen.push( p ),
+			( p: { file: File; result: { id: number } } ) => seen.push( p ),
 		);
 		const result = await uploadFile( defaultArgs( file, 'image/png' ) );
 		expect( result.id ).toBe( 42 );
 		expect( result.url ).toContain( '/uploads/' );
 		expect( seen ).toHaveLength( 1 );
+		// The File ref must travel through so per-file UIs (HUD,
+		// My WordPress live-refresh) can match by identity rather
+		// than filename — two `photo.jpg` drops from different
+		// folders would otherwise collide.
+		expect( seen[ 0 ].file ).toBe( file );
 		expect( FakeXhr.lastInstance?.method ).toBe( 'POST' );
 	} );
 
@@ -265,5 +285,72 @@ describe( 'os-file-drop/upload', () => {
 		await expect(
 			uploadFile( defaultArgs( file, 'image/png' ) ),
 		).rejects.toBeInstanceOf( UploadAbortedError );
+		// Body never made it to the server → no cleanup DELETE.
+		expect( FakeXhr.instances.some( ( i ) => i.method === 'DELETE' ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'late abort() — after body is fully sent — DELETEs the created attachment', async () => {
+		const file = makeFile( 'test.png', 'image/png' );
+		// Defer the abort to `UPLOAD_PROGRESS` at 100% so it fires
+		// AFTER `xhr.upload.load` has flipped `bodyFullySent`. By
+		// that point `xhr.abort()` would be too late — the server
+		// will respond 201 with the new attachment, and the
+		// production code is supposed to DELETE it before
+		// surfacing the failure.
+		let abortHandle: ( () => void ) | null = null;
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_STARTED,
+			'test/late-abort/capture',
+			( p: { abort: () => void } ) => {
+				abortHandle = p.abort;
+			},
+		);
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_PROGRESS,
+			'test/late-abort/trigger',
+			( p: { loaded: number; total: number } ) => {
+				if ( p.loaded === p.total && abortHandle ) {
+					abortHandle();
+					abortHandle = null;
+				}
+			},
+		);
+		const failures: Array< { error: Error } > = [];
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_FAILED,
+			'test/late-abort/fail',
+			( p: { error: Error } ) => failures.push( p ),
+		);
+
+		await expect(
+			uploadFile( defaultArgs( file, 'image/png' ) ),
+		).rejects.toBeInstanceOf( UploadAbortedError );
+
+		// The upload XHR must NOT have been wire-aborted — the
+		// production code lets it complete so it knows the
+		// attachment id to clean up.
+		const uploadXhr = FakeXhr.instances.find(
+			( i ) => i.method === 'POST',
+		);
+		expect( uploadXhr ).toBeDefined();
+		expect( uploadXhr!.aborted ).toBe( false );
+
+		// A DELETE must follow, pointing at the attachment the
+		// server reported (id=42 in the default fixture) with
+		// `force=true` so it skips trash.
+		const deleteXhr = FakeXhr.instances.find(
+			( i ) => i.method === 'DELETE',
+		);
+		expect( deleteXhr ).toBeDefined();
+		expect( deleteXhr!.url ).toContain( '/wp/v2/media/42' );
+		expect( deleteXhr!.url ).toContain( 'force=true' );
+
+		// And the failure surface must report an abort (not a
+		// generic failure) so HUDs can distinguish cancellation
+		// from a real error.
+		expect( failures ).toHaveLength( 1 );
+		expect( failures[ 0 ].error ).toBeInstanceOf( UploadAbortedError );
 	} );
 } );

--- a/tests/vitest/os-file-drop-upload.test.ts
+++ b/tests/vitest/os-file-drop-upload.test.ts
@@ -275,6 +275,41 @@ describe( 'os-file-drop/upload', () => {
 		).rejects.toThrow( /Network error/i );
 	} );
 
+	test( 'upload-failed carries the filtered File identity (post-BEFORE_UPLOAD swap)', async () => {
+		// Regression: every UPLOAD_FAILED branch (network, HTTP,
+		// JSON parse, early abort, late cancel) used to pass
+		// `args.file` (the pre-filter File) while UPLOAD_STARTED /
+		// _PROGRESS / AFTER_UPLOAD passed `filtered.file`. A HUD
+		// keyed on the started-File would then drop the failure
+		// event and leave the row stuck in "running".
+		const original = makeFile( 'original.png', 'image/png' );
+		const swapped = makeFile( 'swapped.png', 'image/png' );
+		window.wp!.hooks!.addFilter(
+			FILE_DROP_HOOKS.BEFORE_UPLOAD,
+			'test/swap-file',
+			( payload: { file: File; mime: string; fields: unknown } ) => ( {
+				...payload,
+				file: swapped,
+			} ),
+		);
+		FakeXhr.nextConfig = {
+			status: 500,
+			responseText: JSON.stringify( { message: 'Server error' } ),
+		};
+		const failures: Array< { file: File } > = [];
+		window.wp!.hooks!.addAction(
+			FILE_DROP_HOOKS.UPLOAD_FAILED,
+			'test/failed-identity',
+			( p: { file: File } ) => failures.push( p ),
+		);
+		await expect(
+			uploadFile( defaultArgs( original, 'image/png' ) ),
+		).rejects.toThrow( /Server error/ );
+		expect( failures ).toHaveLength( 1 );
+		expect( failures[ 0 ].file ).toBe( swapped );
+		expect( failures[ 0 ].file ).not.toBe( original );
+	} );
+
 	test( 'abort() from the started payload rejects with UploadAbortedError', async () => {
 		const file = makeFile( 'test.png', 'image/png' );
 		window.wp!.hooks!.addAction(


### PR DESCRIPTION
Builds on the drag-and-drop-from-desktop feature (#236) so the
upload flow has a real progress UI, refreshes the views the user is
looking at, and cleans up after itself when a user cancels.

## Summary

1. **`<wpd-progress-bar>` component** — determinate / indeterminate
   linear bar with tones, label + percent header, full CSS-variable
   theming, ARIA wiring. Documented in
   `docs/examples/progress-bar.md`.
2. **XHR-based uploader + new hooks** — the OS-file-drop uploader
   now uses `XMLHttpRequest` so `upload.progress` is observable.
   Two new hooks ride alongside the existing ones:
   - `desktop-mode.drop.upload-started` — `{ file, fields, context,
     abort: () => void }` fires once the request is `open()`ed.
   - `desktop-mode.drop.upload-progress` — per-tick
     `{ loaded, total, indeterminate }`, plus a synthetic 100%
     event on `upload.load` so a HUD can show "wrapping up".
   `BEFORE_UPLOAD` / `AFTER_UPLOAD` / `UPLOAD_FAILED` semantics are
   unchanged. New `UploadAbortedError` distinguishes user-cancel
   from filter-cancel.
3. **Floating upload-progress HUD** — pinned bottom-right panel,
   one row per file, with a `<wpd-progress-bar>` and a
   Cancel / Dismiss action. Auto-clears successful uploads after
   2.5s, keeps failures around until dismissed. Suppressable via
   `data-desktop-mode-suppress-upload-hud` on `<body>` so plugins
   can take the same hook surface over with their own UI.
4. **Live-refresh My WordPress → Media** — `media-list.ts`
   subscribes to `after-upload` and prepends the new attachment to
   the visible grid via a single `wp/v2/media/{id}` GET. Scroll
   position and current selection are preserved.
5. **Live-refresh classic Media Library** — any open iframe window
   pointing at `/wp-admin/upload.php` reloads when an upload
   finishes (URL preserved, so filters / pagination survive).
   Suppressable via
   `data-desktop-mode-suppress-media-library-refresh`.
6. **Context menu on Media tiles** — right-click a tile in My
   WordPress → Media for **Navigate into**, **Open file in new tab**,
   **Delete permanently**. Delete confirms via `wpdConfirm` and
   issues `DELETE wp/v2/media/{id}?force=true`. Filterable via the
   existing `desktop-mode.my-wordpress.tile-context-menu` hook.
7. **Per-batch summary toast** — multi-file uploads now end with a
   single toast that summarises only the non-zero buckets:
   `Uploaded 2 files. Cancelled 1. Failed 1.` Single-file batches
   keep their tight original toast (or the server error verbatim).
8. **Cancel-leaves-corrupted-media fix** — if the user pressed
   Cancel after the body had been fully sent, the server still
   created the attachment. The uploader now detects that case
   (via `xhr.upload.load`) and `DELETE`s the attachment after the
   server responds, so a cancelled upload never appears in the
   Media Library, My WordPress, or anywhere else. The HUD shows
   "Cancelling…" while it waits for the server.
9. **Tile selection clipping fix** — My WordPress post/page tile
   cells were `96 × 92` px around an `88` px-wide tile, leaving
   the selected tile's background ring abutting adjacent ribbons.
   Cell pitch bumped to `108 × 112` so the inset selection has
   breathing room and 2-line labels don't bleed into the next
   row.

## Already-implemented (clarification)

Drops onto Gutenberg's drop zone, the classic media uploader, and
any `[data-drop-zone]` are passed through to those handlers by the
chromeless bridge (`includes/render/chromeless-bridge.php:1197`).
Gutenberg's own uploader handles upload + block insertion — the
OS-file-drop manager intentionally doesn't intercept those
surfaces. Only drops onto non-drop-zone areas escalate to the
shell's confirmation dialog.

## Public API additions

### JS hooks (`src/os-file-drop/hooks.ts`)

| Hook | Kind | Payload |
| --- | --- | --- |
| `desktop-mode.drop.upload-started` | action | `{ file, fields, context, abort }` |
| `desktop-mode.drop.upload-progress` | action | `{ file, fields, context, loaded, total, indeterminate }` |

Also exposed via `wp.desktop.HOOKS.FILE_DROP_UPLOAD_STARTED` /
`FILE_DROP_UPLOAD_PROGRESS`.

### Exports

- `UploadAbortedError` from `src/os-file-drop/upload.ts`.
- `WpdProgressBar`, `WpdProgressTone` from
  `src/ui/components/wpd-progress-bar/`.
- `fetchMediaItem`, `deleteMediaItem` from
  `src/my-wordpress/media-rest.ts`.

### Body-attribute toggles (opt-out for plugins that want to own
the UI):

- `data-desktop-mode-suppress-upload-hud`
- `data-desktop-mode-suppress-media-library-refresh`

## Files

| Area | Files |
| --- | --- |
| New component | `src/ui/components/wpd-progress-bar/{ts,styles,test}` |
| New modules | `src/os-file-drop/progress-hud.ts`, `src/os-file-drop/library-refresher.ts` |
| Uploader | `src/os-file-drop/{upload,hooks,dialog,index}.ts` |
| Media view | `src/my-wordpress/{media-list,media-rest}.ts`, `src/my-wordpress/index.ts` |
| Styles | `assets/css/desktop-files.css` (HUD) |
| Hook index | `src/hooks.ts`, `src/ui/components/index.ts` |
| Docs | `docs/examples/progress-bar.md` (new), `docs/examples/os-file-drop.md`, `docs/examples/README.md`, `docs/hooks-reference.md`, `AGENTS.md` |
| Tests | `tests/vitest/os-file-drop-upload.test.ts` (XHR fake), `src/ui/components/wpd-progress-bar/wpd-progress-bar.test.ts` (new) |

## Test plan

- [x] `npm run test:js` — 1401/1401 pass.
- [x] `npm run lint` — clean.
- [x] `./node_modules/.bin/tsc --noEmit` — clean.
- [x] `npm run build` — both bundles emit cleanly.
- [ ] Manual: drop a single image on the wallpaper → dialog →
      upload → HUD shows 0–100% → toast "Uploaded to Media
      Library." → file appears in My WordPress → Media without F5.
- [ ] Manual: drop 3 files → HUD shows three rows → Cancel one
      mid-flight → HUD row goes "Cancelling…" → "Cancelled" →
      summary toast reads "Uploaded 2 files. Cancelled 1." →
      cancelled file is **not** present in Media Library.
- [ ] Manual: open `upload.php` in a window, drop a file on the
      wallpaper → after upload, the Media Library iframe reloads
      with the new attachment visible.
- [ ] Manual: right-click a media tile in My WordPress → Media →
      Delete permanently → confirm → tile disappears, count
      decrements, no F5 needed.
- [ ] Manual: right-click → Navigate into → drills into the media
      detail view.
- [ ] Manual: drop a file on the Gutenberg post editor — Gutenberg
      uploads and inserts the block (unchanged behavior).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-237-3b79c3c6ec1f9ba131b5eb950016e7e08b4305ba.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->