### PR TITLE
ci: test against PHP 8.3 and 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Updates the PHPUnit job matrix in `.github/workflows/ci.yml` from `['8.1', '8.2']` to `['8.3', '8.4']`.
- Plugin's `Requires PHP: 7.4` floor is unchanged; this only affects what versions CI exercises.

## Test plan
- [x] CI passes on both PHP 8.3 and PHP 8.4 matrix legs.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-238-ec7808f750b75aea63ea8589c14b77c225a1e74e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->