### PR TITLE
feat(pwa): implement desktop_mode_pwa_force_replace_sw filter to manage service worker conflicts

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2480,11 +2480,27 @@ add_filter( 'desktop_mode_pwa_manifest', static function ( array $manifest ) {
 } );
 ```
 
+### `desktop_mode_pwa_force_replace_sw` — Stable (filter)
+
+Opt desktop-mode in to replace a foreign root-scope service worker on
+this origin. Default `false` — desktop-mode yields to any existing SW
+(Super PWA, Jetpack Boost, etc.) and the install tile shows a toast
+naming this filter as the path forward. Return `true` to take over.
+
+```php
+add_filter( 'desktop_mode_pwa_force_replace_sw', '__return_true' );
+```
+
+Use this to unblock the "Install \<site\> as an app" affordance on sites
+where another PWA plugin's SW is shadowing desktop-mode and Chromium
+therefore won't fire `beforeinstallprompt`.
+
 ### PHP helpers — Stable
 
 ```php
 desktop_mode_pwa_manifest_url();
 desktop_mode_pwa_sw_url();
+desktop_mode_pwa_force_replace_sw();
 desktop_mode_pwa_get_user_state( $user_id = 0 );
 desktop_mode_pwa_update_user_state( array $patch, $user_id = 0 );
 ```

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -35,9 +35,22 @@ So the SW registers at root scope, but the fetch handler returns early
 "narrow scope" without inheriting the technical limitation.
 
 If another plugin already registered a root-scoped SW, the registration
-**bails** with a console warning rather than usurping it. To override,
-return `true` from the `desktop_mode_pwa_force_replace_sw` filter (not
-yet wired — coming as part of v2).
+**bails** with a console warning rather than usurping it. The "Install
+\<site\> as an app" tile then surfaces a focused toast pointing at the
+opt-in filter (rather than the generic "not available" fallback), so
+users on affected sites see the actionable message instead of silently
+broken behaviour.
+
+To opt this install in, return `true` from the
+`desktop_mode_pwa_force_replace_sw` filter:
+
+```php
+add_filter( 'desktop_mode_pwa_force_replace_sw', '__return_true' );
+```
+
+The filter resolves at shell-config build time; effective on the next
+page load. Use this when another PWA plugin's SW is shadowing
+desktop-mode and you want desktop-mode to take over the install path.
 
 ## Caching policy
 

--- a/includes/pwa.php
+++ b/includes/pwa.php
@@ -83,6 +83,38 @@ function desktop_mode_pwa_sw_url() {
 }
 
 /**
+ * Resolves whether desktop-mode should usurp another root-scope SW.
+ *
+ * When `false` (default), `src/pwa/sw-register.ts` bails on registration
+ * if another root-scope service worker is already on the origin — polite
+ * behaviour for sites that intentionally use a different PWA plugin. When
+ * `true`, our registration replaces the existing SW.
+ *
+ * Operators flip this to recover installability on sites where a foreign
+ * SW (Super PWA, Jetpack Boost, etc.) is shadowing the desktop-mode SW
+ * and causing the "Install <site> as an app" tile to surface the
+ * "another app is handling installs" toast.
+ *
+ * @since 0.8.6
+ *
+ * @return bool
+ */
+function desktop_mode_pwa_force_replace_sw() {
+	/**
+	 * Filters whether desktop-mode replaces an existing root-scope SW.
+	 *
+	 * Return `true` to take over from a foreign PWA plugin's service
+	 * worker so desktop-mode's "Install as app" affordance works on
+	 * sites where another plugin's SW is already active.
+	 *
+	 * @since 0.8.6
+	 *
+	 * @param bool $force_replace Defaults to `false` (yield to existing SWs).
+	 */
+	return (bool) apply_filters( 'desktop_mode_pwa_force_replace_sw', false );
+}
+
+/**
  * Detects which PWA endpoint the current request is targeting, if any.
  *
  * Mirrors `desktop_mode_is_portal_request()`'s strategy: read the

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -472,17 +472,24 @@ function desktop_mode_enqueue_assets() {
 			'fromPortal'       => $from_portal,
 			'fromPortalIntent' => $from_portal_intent,
 			'pwa'              => array(
-				'manifestUrl' => esc_url_raw( desktop_mode_pwa_manifest_url() ),
-				'swUrl'       => esc_url_raw( desktop_mode_pwa_sw_url() ),
-				'stateUrl'    => esc_url_raw( rest_url( 'desktop-mode/v1/pwa-state' ) ),
-				'state'       => desktop_mode_pwa_get_user_state( get_current_user_id() ),
+				'manifestUrl'    => esc_url_raw( desktop_mode_pwa_manifest_url() ),
+				'swUrl'          => esc_url_raw( desktop_mode_pwa_sw_url() ),
+				'stateUrl'       => esc_url_raw( rest_url( 'desktop-mode/v1/pwa-state' ) ),
+				'state'          => desktop_mode_pwa_get_user_state( get_current_user_id() ),
 				// Mirrors the manifest's `name` field — used by the
 				// install pill so the button reads "Install <site>"
 				// rather than "Install <current page>" (which would
 				// be misleading: we install the whole site as an
 				// app, not the dashboard window the user happens to
 				// be viewing).
-				'appName'     => get_bloginfo( 'name' ),
+				'appName'        => get_bloginfo( 'name' ),
+				// Operators set the `desktop_mode_pwa_force_replace_sw`
+				// filter to `true` when another root-scope service
+				// worker on the origin is blocking desktop-mode
+				// installability (foreign-SW guard in
+				// `src/pwa/sw-register.ts`). Default `false` preserves
+				// the polite behaviour where we yield to existing PWAs.
+				'forceReplaceSw' => desktop_mode_pwa_force_replace_sw(),
 			),
 		)
 	);

--- a/src/pwa/index.ts
+++ b/src/pwa/index.ts
@@ -39,7 +39,9 @@ export function bootstrapPwa(
 	);
 	// Fire-and-forget — registration is async but the rest of the
 	// shell doesn't gate on it.
-	void registerServiceWorker( config.pwa );
+	void registerServiceWorker( config.pwa, {
+		forceReplace: !! config.pwa.forceReplaceSw,
+	} );
 }
 
 export { promptInstall, undismissInstallHint } from './install';

--- a/src/pwa/install.ts
+++ b/src/pwa/install.ts
@@ -40,6 +40,7 @@
 
 import { __, sprintf } from '../i18n';
 import type { ToastOptions } from '../toast';
+import { getSwRegistrationStatus } from './sw-register';
 
 /** Stable id for the tile — exported so tests can assert against it. */
 export const PWA_INSTALL_TILE_ID = 'desktop-mode-pwa-install';
@@ -239,6 +240,20 @@ async function onTileClick(
 					'%s is already installed. Open it from your apps menu or home screen.',
 				),
 				siteName,
+			),
+		} );
+		return;
+	}
+
+	// Foreign service worker blocked our registration → Chromium will
+	// never fire `beforeinstallprompt` because the installability
+	// criterion requires OUR SW to be controlling. The generic "not
+	// available" fallback leaves the user with no path forward; this
+	// branch names the cause and points at the operator-side knob.
+	if ( getSwRegistrationStatus() === 'foreign-sw' ) {
+		showToast( {
+			message: __(
+				"Install isn't available — another plugin's service worker is active on this site. A site admin can opt in by setting the desktop_mode_pwa_force_replace_sw filter to true.",
 			),
 		} );
 		return;

--- a/src/pwa/sw-register.ts
+++ b/src/pwa/sw-register.ts
@@ -27,10 +27,31 @@
 
 import type { PwaConfig } from '../types';
 
+/**
+ * Outcome of the most recent {@link registerServiceWorker} call.
+ *
+ *   - `'pending'` — registration hasn't been attempted yet (or is still
+ *     in-flight).
+ *   - `'registered'` — our SW is the controller (or activating).
+ *   - `'foreign-sw'` — another root-scope SW is already on this origin
+ *     and we bailed rather than usurp it. Operators can opt in via the
+ *     `desktop_mode_pwa_force_replace_sw` PHP filter.
+ *   - `'unsupported'` — `navigator.serviceWorker` not available, or the
+ *     origin isn't secure.
+ *   - `'failed'` — `register()` threw.
+ */
+export type SwRegistrationStatus =
+	| 'pending'
+	| 'registered'
+	| 'foreign-sw'
+	| 'unsupported'
+	| 'failed';
+
 let _registration: ServiceWorkerRegistration | null = null;
 let _registrationFailed = false;
 let _controllerChangeBound = false;
 let _reloadingForSwUpdate = false;
+let _status: SwRegistrationStatus = 'pending';
 
 /**
  * Wire up the auto-reload on SW takeover. Two scenarios distinguished:
@@ -134,15 +155,18 @@ export async function registerServiceWorker(
 	options: { forceReplace?: boolean } = {},
 ): Promise< ServiceWorkerRegistration | null > {
 	if ( typeof navigator === 'undefined' || ! ( 'serviceWorker' in navigator ) ) {
+		_status = 'unsupported';
 		return null;
 	}
 	if ( ! config?.swUrl ) {
+		_status = 'unsupported';
 		return null;
 	}
 	if ( ! window.isSecureContext ) {
 		// SWs require HTTPS (or `localhost`). On a plain-HTTP staging
 		// install we silently skip — no point alarming the user about
 		// something the operator can't fix from inside the shell.
+		_status = 'unsupported';
 		return null;
 	}
 	if ( _registration || _registrationFailed ) {
@@ -161,6 +185,7 @@ export async function registerServiceWorker(
 			return url !== '' && url !== config.swUrl;
 		} );
 		if ( foreign ) {
+			_status = 'foreign-sw';
 			if ( typeof console !== 'undefined' ) {
 				console.warn(
 					'[desktop-mode] another service worker is already registered (' +
@@ -177,6 +202,7 @@ export async function registerServiceWorker(
 			scope: '/',
 			updateViaCache: 'none',
 		} );
+		_status = 'registered';
 		// Auto-reload when the new SW takes control. Bound only after a
 		// successful registration so we never reload a page that has no
 		// SW relationship in the first place.
@@ -184,11 +210,22 @@ export async function registerServiceWorker(
 		return _registration;
 	} catch ( err ) {
 		_registrationFailed = true;
+		_status = 'failed';
 		if ( typeof console !== 'undefined' ) {
 			console.warn( '[desktop-mode] SW registration failed:', err );
 		}
 		return null;
 	}
+}
+
+/**
+ * Synchronous read of the most recent registration outcome. Drives
+ * UI that needs to differentiate "install isn't available" causes —
+ * e.g. the install tile's click handler surfaces a foreign-SW-specific
+ * toast when the value is `'foreign-sw'`.
+ */
+export function getSwRegistrationStatus(): SwRegistrationStatus {
+	return _status;
 }
 
 /**
@@ -205,4 +242,5 @@ export function _resetSwRegistration(): void {
 	_registrationFailed = false;
 	_controllerChangeBound = false;
 	_reloadingForSwUpdate = false;
+	_status = 'pending';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2012,6 +2012,14 @@ export interface PwaConfig {
 	 * rather than the current page title.
 	 */
 	appName: string;
+	/**
+	 * When `true`, our service-worker registration takes over even if
+	 * another root-scope SW is already on the origin. Sourced from the
+	 * `desktop_mode_pwa_force_replace_sw` PHP filter (default `false`)
+	 * so operators can opt in when a foreign PWA plugin is blocking
+	 * desktop-mode installability.
+	 */
+	forceReplaceSw?: boolean;
 }
 
 /**

--- a/tests/phpunit/tests/desktopModePwaForceReplaceSw.php
+++ b/tests/phpunit/tests/desktopModePwaForceReplaceSw.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for `desktop_mode_pwa_force_replace_sw()` — the resolver behind
+ * the `desktop_mode_pwa_force_replace_sw` filter that lets operators opt
+ * desktop-mode in to replace a foreign root-scope SW.
+ *
+ * Fix for GH #239 — without the filter wired through, sites with another
+ * PWA plugin's SW silently lose installability and the "Install <site>
+ * as an app" tile falls back to a generic "not available" toast.
+ *
+ * @package WPDesktopMode
+ *
+ * @group desktop-mode
+ */
+class Tests_DesktopMode_PwaForceReplaceSw extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'desktop_mode_pwa_force_replace_sw' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::desktop_mode_pwa_force_replace_sw
+	 */
+	public function test_defaults_to_false() {
+		$this->assertFalse( desktop_mode_pwa_force_replace_sw() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_pwa_force_replace_sw
+	 */
+	public function test_filter_can_opt_in() {
+		add_filter( 'desktop_mode_pwa_force_replace_sw', '__return_true' );
+		$this->assertTrue( desktop_mode_pwa_force_replace_sw() );
+	}
+
+	/**
+	 * Non-boolean filter return is coerced to a bool so the JS shell
+	 * config carries a consistent type — without the cast a string like
+	 * `'1'` would surface as `forceReplaceSw: '1'` rather than `true`.
+	 *
+	 * @covers ::desktop_mode_pwa_force_replace_sw
+	 */
+	public function test_non_boolean_return_is_coerced() {
+		add_filter(
+			'desktop_mode_pwa_force_replace_sw',
+			static function () {
+				return 1;
+			}
+		);
+		$this->assertSame( true, desktop_mode_pwa_force_replace_sw() );
+
+		remove_all_filters( 'desktop_mode_pwa_force_replace_sw' );
+
+		add_filter(
+			'desktop_mode_pwa_force_replace_sw',
+			static function () {
+				return '';
+			}
+		);
+		$this->assertSame( false, desktop_mode_pwa_force_replace_sw() );
+	}
+}

--- a/tests/vitest/pwa-install-foreign-sw.test.ts
+++ b/tests/vitest/pwa-install-foreign-sw.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Foreign-SW install affordance — fix for GH #239.
+ *
+ * Covers:
+ *   - `registerServiceWorker` tags `_status = 'foreign-sw'` when another
+ *     root-scope SW is on the origin, leaves `_status = 'registered'`
+ *     when ours wins, and respects `forceReplace: true` to bypass the
+ *     guard.
+ *   - `getInstallTileDef(...).onOpen` surfaces the foreign-SW-specific
+ *     toast (rather than the generic "not available" fallback) once the
+ *     status flips, so users see the actionable message naming the
+ *     `desktop_mode_pwa_force_replace_sw` filter.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	_resetSwRegistration,
+	getSwRegistrationStatus,
+	registerServiceWorker,
+} from '../../src/pwa/sw-register';
+import {
+	_resetInstallAffordance,
+	getInstallTileDef,
+} from '../../src/pwa/install';
+
+type RegistrationLike = Pick<
+	ServiceWorkerRegistration,
+	'scope' | 'active' | 'installing'
+>;
+
+interface SwTestHandle {
+	registrations: RegistrationLike[];
+	register: ReturnType< typeof vi.fn >;
+}
+
+function installSwStub( initial: RegistrationLike[] = [] ): SwTestHandle {
+	const handle: SwTestHandle = {
+		registrations: [ ...initial ],
+		register: vi.fn( async ( url: string ) => {
+			const reg: RegistrationLike = {
+				scope: '/',
+				active: {
+					scriptURL: url,
+					state: 'activated',
+				} as unknown as ServiceWorker,
+				installing: null,
+			};
+			handle.registrations.push( reg );
+			return reg as unknown as ServiceWorkerRegistration;
+		} ),
+	};
+
+	Object.defineProperty( window, 'isSecureContext', {
+		value: true,
+		configurable: true,
+	} );
+
+	const swStub = {
+		register: handle.register,
+		getRegistrations: vi.fn( async () => handle.registrations ),
+		controller: null,
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+	};
+
+	Object.defineProperty( navigator, 'serviceWorker', {
+		value: swStub,
+		configurable: true,
+	} );
+
+	return handle;
+}
+
+function clearSwStub(): void {
+	// `delete` works because we set `configurable: true` above.
+	delete ( navigator as unknown as { serviceWorker?: unknown } )
+		.serviceWorker;
+}
+
+const SW_URL = 'https://example.test/desktop-mode/sw.js';
+const FOREIGN_REG: RegistrationLike = {
+	scope: '/',
+	active: {
+		scriptURL: 'https://example.test/wp-content/plugins/other-pwa/sw.js',
+		state: 'activated',
+	} as unknown as ServiceWorker,
+	installing: null,
+};
+
+beforeEach( () => {
+	_resetSwRegistration();
+	_resetInstallAffordance();
+} );
+
+afterEach( () => {
+	clearSwStub();
+	_resetSwRegistration();
+	_resetInstallAffordance();
+} );
+
+describe( 'registerServiceWorker — foreign SW detection', () => {
+	test( 'status starts at "pending"', () => {
+		expect( getSwRegistrationStatus() ).toBe( 'pending' );
+	} );
+
+	test( 'flips to "foreign-sw" when another root-scope SW is registered', async () => {
+		installSwStub( [ FOREIGN_REG ] );
+		const result = await registerServiceWorker( {
+			manifestUrl: '',
+			swUrl: SW_URL,
+			stateUrl: '',
+			state: {
+				installHintDismissed: false,
+				notificationsEnabled: false,
+			},
+			appName: 'Test',
+		} );
+		expect( result ).toBeNull();
+		expect( getSwRegistrationStatus() ).toBe( 'foreign-sw' );
+	} );
+
+	test( 'flips to "registered" when no foreign SW is present', async () => {
+		const handle = installSwStub( [] );
+		const result = await registerServiceWorker( {
+			manifestUrl: '',
+			swUrl: SW_URL,
+			stateUrl: '',
+			state: {
+				installHintDismissed: false,
+				notificationsEnabled: false,
+			},
+			appName: 'Test',
+		} );
+		expect( result ).not.toBeNull();
+		expect( getSwRegistrationStatus() ).toBe( 'registered' );
+		expect( handle.register ).toHaveBeenCalledWith( SW_URL, {
+			scope: '/',
+			updateViaCache: 'none',
+		} );
+	} );
+
+	test( 'forceReplace bypasses the foreign-SW guard and registers anyway', async () => {
+		const handle = installSwStub( [ FOREIGN_REG ] );
+		const result = await registerServiceWorker(
+			{
+				manifestUrl: '',
+				swUrl: SW_URL,
+				stateUrl: '',
+				state: {
+					installHintDismissed: false,
+					notificationsEnabled: false,
+				},
+				appName: 'Test',
+			},
+			{ forceReplace: true },
+		);
+		expect( result ).not.toBeNull();
+		expect( getSwRegistrationStatus() ).toBe( 'registered' );
+		expect( handle.register ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'install tile — foreign-SW toast surfacing', () => {
+	test( 'fires the foreign-SW-specific toast when status is "foreign-sw"', async () => {
+		installSwStub( [ FOREIGN_REG ] );
+		await registerServiceWorker( {
+			manifestUrl: '',
+			swUrl: SW_URL,
+			stateUrl: '',
+			state: {
+				installHintDismissed: false,
+				notificationsEnabled: false,
+			},
+			appName: 'Test Site',
+		} );
+		expect( getSwRegistrationStatus() ).toBe( 'foreign-sw' );
+
+		const showToast = vi.fn( () => () => {} );
+		const tile = getInstallTileDef( 'Test Site', showToast );
+		tile.onOpen();
+		// onTileClick runs async (isLikelyInstalled is awaited).
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		expect( showToast ).toHaveBeenCalledTimes( 1 );
+		const msg = ( showToast.mock.calls[ 0 ][ 0 ] as { message: string } )
+			.message;
+		expect( msg ).toMatch(
+			/another plugin's service worker|desktop_mode_pwa_force_replace_sw/,
+		);
+	} );
+
+	test( 'falls back to the generic toast when status is not "foreign-sw"', async () => {
+		// No foreign SW registered, no `beforeinstallprompt` fired → the
+		// click handler hits the generic "Install isn't available right
+		// now" branch.
+		installSwStub( [] );
+		// Don't call registerServiceWorker — leave status at 'pending'
+		// so we exercise the non-foreign path.
+
+		const showToast = vi.fn( () => () => {} );
+		const tile = getInstallTileDef( 'Test Site', showToast );
+		tile.onOpen();
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		expect( showToast ).toHaveBeenCalledTimes( 1 );
+		const msg = ( showToast.mock.calls[ 0 ][ 0 ] as { message: string } )
+			.message;
+		expect( msg ).not.toMatch( /desktop_mode_pwa_force_replace_sw/ );
+		expect( msg ).toMatch( /isn't available right now/ );
+	} );
+} );


### PR DESCRIPTION
Might close https://github.com/WordPress/desktop-mode/issues/239 ?

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-242-ee28d9726649a659447dfd10c02119ab67ade6cd.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->