### PR TITLE
feat(divi): add compatibility layer for Divi script dependencies and tests

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -82,6 +82,7 @@ require_once DESKTOP_MODE_DIR . 'includes/comments-window/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/my-wordpress/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/content-graph/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/pwa.php';
+require_once DESKTOP_MODE_DIR . 'includes/compat/divi.php';
 
 /**
  * Cascade-deactivate plugins that declare `Requires Plugins: desktop-mode`

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -158,6 +158,75 @@ In classic admin `window.top === window`, so `et_gb = window` and the bundle res
 
 **Test**: `tests/phpunit/tests/diviCompat.php` — pins dep injection (`test_injects_missing_wp_editor_and_wp_data_deps`), the no-op-when-absent case (`test_no_op_when_divi_not_registered`), idempotence (`test_does_not_duplicate_deps_when_already_present`), the chromeless `et_gb` override (`test_chromeless_request_appends_et_gb_window_override`), and the classic-admin guard (`test_classic_request_does_not_append_et_gb_override`).
 
+### Divi — Visual Builder `top_window` resolves to the desktop shell
+
+**File**: `includes/compat/divi.php` (`desktop_mode_compat_divi_vb_iframe_signal`).
+
+A second class of cross-frame bug bites once Divi's Visual Builder launches inside our chromeless iframe (e.g., user clicks the "Use Divi Builder" block, the iframe navigates to `/?p=N&et_fb=1`, VB attempts to mount). The VB bundle imports a `top_window` helper from `frontend-builder/build/frame-helpers.js`. Its resolver, simplified:
+
+```js
+try { u = !!window.top.document && window.top; } catch ( _ ) { u = false; }
+if ( u && u.__Cypress__ ) {                  // Cypress escape hatch
+    top_window = ( window.parent === u ) ? window : window.parent;
+    is_iframe  = ( window.parent !== u );
+} else if ( u ) {
+    top_window = u;                          // ← falls through here for us
+    is_iframe  = ( u !== window.self );      // ← so is_iframe = true
+}
+window.ET_Builder = …({ Frames: { top: top_window } });
+```
+
+Inside our chromeless iframe `window.top` is the desktop shell — a same-origin document with no Divi globals, no `wp.data`, no REST nonce. VB then routes its REST roundtrips, state queries, and DOM ops through that shell window and waits forever. Symptom: the `et-fb-page-preloading` loader spins forever after clicking "Use Divi Builder".
+
+**Fix part 1 — `__Cypress__` flag.** Hook `wp_head` priority 1 and, when the current request is front-end AND the current user has desktop mode enabled, emit a tiny inline script that sets `window.top.__Cypress__ = true`. That trips Divi's first branch; since `window.parent === window.top` for our single-level iframe, `top_window` resolves to `window` (the iframe itself) and `is_iframe` becomes `false`. The flag is idempotent (`OR`-with-existing) and reads nowhere else in the WP stack.
+
+**Fix part 2 — preloader bridge (VB-top frame only).** Divi 5's VB architecture is 2 frames deep (`/?et_fb=1` hosts an inner `<iframe id="et-vb-app-frame" src="…&app_window=1">`). Inside Desktop Mode that becomes 3 frames: shell → chromeless iframe (VB-top) → inner app-frame. The cleanup in `visual-builder/build/root.js` runs inside the inner app-frame and does:
+
+```js
+e( document );
+window.top && window.top !== window && window.top.document && e( window.top.document );
+```
+
+…where `e()` strips `et-fb-page-preloading` from `#et-fb-app` and `#et-fb-app-body-root`. In classic admin `window.top` IS the VB-top. In Desktop Mode `window.top` is the shell, which has no Divi elements — so the cleanup never reaches the visible preloader at the chromeless iframe level, and the loader spins forever.
+
+We mirror the removal by watching the inner app-frame from the VB-top: a MutationObserver on the child iframe's document fires the local cleanup once the inner `#et-fb-app` loses the class. A 30s watchdog timeout strips the preloader even if the observer never fires. Detection is via the `app_window=1` query flag Divi sets on the inner iframe URL — present means we're the inner frame and skip the bridge; absent means we're the VB-top and emit it.
+
+**Plugins this addresses**: Divi theme (frontend Visual Builder, `et_fb=1` activation flow) — applies to Divi 5.x with the two-frame VB architecture. Older 4.x Visual Builder uses a single frame; only Fix part 1 applies there.
+
+**Tests**: `tests/phpunit/tests/diviCompat.php` — `test_vb_iframe_signal_emits_on_front_end_for_desktop_user`, `test_vb_iframe_signal_skips_admin_requests`, `test_vb_iframe_signal_skips_when_desktop_mode_disabled`, `test_vb_top_frame_emits_preloader_bridge`, `test_inner_app_frame_skips_preloader_bridge`.
+
+### Divi — eject to top-level for Visual Builder via `Location.prototype` patch
+
+**File**: `includes/compat/divi.php` (`desktop_mode_compat_divi_eject_iframe_patch` + `desktop_mode_compat_divi_eject_parent_listener` + `desktop_mode_compat_divi_is_active`).
+
+Even with shims 1–3 above, Divi VB inside our three-level iframe nesting (shell → chromeless iframe → Divi's inner app-frame) is materially slower than running at top level. The browser de-prioritizes resource loading at each nesting depth, image-measurement scripts read 0 because `load` fires before `naturalWidth` settles, and the `et-fb-page-preloading` overlay sits up for many seconds while ~100 builder scripts parse on the throttled main thread. VB is a focus-mode editor that takes over the entire viewport anyway — the desktop metaphor doesn't add value while you're inside it.
+
+**Strategy**: catch Divi's navigation *pre-flight* inside the chromeless iframe, forward the intended URL to the parent shell via `postMessage`, and let the parent navigate the top tab. Divi's full activation flow (nonce check → `et_fb_auto_activate_builder` server-side redirect → speculation-rules prerender) then runs against a real top-level navigation.
+
+**Why prototype patching instead of click-interception**:
+
+- Divi 5's `switchEditor( DIVI )` does `window.location.href = getVBUrl()` programmatically — not an `<a>` click — so the chromeless-bridge link interceptor can't see it.
+- The Gutenberg editor canvas in WP 6.3+ is itself another nested iframe, putting the Divi placeholder block two frames below the chromeless bridge.
+- Earlier attempts that ejected by reading the iframe's `contentWindow.location.href` on `load` were too late: by then Divi's nonce had already been consumed inside the iframe and the URL was the post-redirect form. Navigating top to that URL skipped the activation step.
+
+**Fix**:
+
+1. **Iframe-side patcher** (`admin_head` priority 0, chromeless + Divi-active only). Replaces `Location.prototype.href`'s setter, `Location.prototype.assign`, and `Location.prototype.replace`. Each wrapped function checks the URL against the VB pattern (`et_fb=1` or `et_fb_activation_nonce=`); on match it `postMessage`s the parent and skips the navigation. Non-matching URLs delegate to the original implementation.
+
+   `Window.location` itself is `[Unforgeable]` and can't be reassigned, but `Location.prototype.href`'s property descriptor is plain data — `Object.defineProperty` works in every current browser (Chrome, Firefox, Safari).
+
+   The patcher also installs a capture-phase click listener on `a[href]` matching the same VB pattern, to cover the admin-bar "Edit With Divi" link which is a real `<a href>` that wouldn't go through `Location.prototype`.
+
+2. **Parent-shell listener** (`admin_footer` priority 1, non-chromeless + Divi-active only). Listens for `desktop-mode-divi-vb-eject` postMessages, checks `ev.origin === window.location.origin`, re-parses the URL and verifies same origin, then sets `window.top.location.href` to it.
+
+3. **`desktop_mode_compat_divi_is_active()`** — small helper that returns true for the Divi theme or the Divi Builder plugin. Both halves of the fix are gated on it so non-Divi sites pay nothing.
+
+**Plugins this addresses**: Divi theme + Divi Builder plugin, both editing flows (Gutenberg block "Use Divi Builder", Classic Editor's AJAX-then-redirect, admin-bar "Edit With Divi").
+
+**Tests**: `tests/phpunit/tests/diviCompat.php` — `test_iframe_patch_emits_in_chromeless_for_divi`, `test_iframe_patch_skips_when_not_chromeless`, `test_iframe_patch_skips_without_divi`, `test_parent_listener_emits_on_shell_for_divi`, `test_parent_listener_skips_in_chromeless_request`, `test_parent_listener_skips_when_desktop_mode_disabled`, `test_parent_listener_skips_without_divi`, `test_is_active_true_for_divi_theme`, `test_is_active_false_for_other_theme`. The JS patching itself is verified live — vitest in jsdom doesn't model `[Unforgeable]` realistically.
+
+> **Note**: shims 2 (`__Cypress__`) and 3 (preloader bridge) remain in place as defense-in-depth fallbacks for the brief window where the iframe is still loading the VB URL before the patcher's message reaches the parent. If the eject fires correctly, VB never finishes loading in the iframe and those shims never matter.
+
 ## Adding a new fix
 
 Decision tree, in order:

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -195,37 +195,33 @@ We mirror the removal by watching the inner app-frame from the VB-top: a Mutatio
 
 **Tests**: `tests/phpunit/tests/diviCompat.php` — `test_vb_iframe_signal_emits_on_front_end_for_desktop_user`, `test_vb_iframe_signal_skips_admin_requests`, `test_vb_iframe_signal_skips_when_desktop_mode_disabled`, `test_vb_top_frame_emits_preloader_bridge`, `test_inner_app_frame_skips_preloader_bridge`.
 
-### Divi — eject to top-level for Visual Builder via `Location.prototype` patch
+### Divi — hand the VB session off to a standalone browser tab
 
 **File**: `includes/compat/divi.php` (`desktop_mode_compat_divi_eject_iframe_patch` + `desktop_mode_compat_divi_eject_parent_listener` + `desktop_mode_compat_divi_is_active`).
 
-Even with shims 1–3 above, Divi VB inside our three-level iframe nesting (shell → chromeless iframe → Divi's inner app-frame) is materially slower than running at top level. The browser de-prioritizes resource loading at each nesting depth, image-measurement scripts read 0 because `load` fires before `naturalWidth` settles, and the `et-fb-page-preloading` overlay sits up for many seconds while ~100 builder scripts parse on the throttled main thread. VB is a focus-mode editor that takes over the entire viewport anyway — the desktop metaphor doesn't add value while you're inside it.
+Even with shims 1–3 above, Divi VB inside our three-level iframe nesting (shell → chromeless iframe → Divi's inner app-frame) is materially slower than running at top level — the browser de-prioritizes resource loading at each nesting depth, image-measurement scripts read 0 because `load` fires before `naturalWidth` settles, and the `et-fb-page-preloading` overlay sits up for many seconds while ~100 builder scripts parse on the throttled main thread. VB is a focus-mode editor that takes over the entire viewport anyway — the desktop metaphor doesn't add value while you're inside it.
 
-**Strategy**: catch Divi's navigation *pre-flight* inside the chromeless iframe, forward the intended URL to the parent shell via `postMessage`, and let the parent navigate the top tab. Divi's full activation flow (nonce check → `et_fb_auto_activate_builder` server-side redirect → speculation-rules prerender) then runs against a real top-level navigation.
+**Strategy**: detect the user's *intent* to enter VB at the click layer, ask for explicit confirmation, then navigate the top tab to a classic-admin post-edit page so Divi can run in its native single-frame environment. Two clicks total to enter VB, but each is deliberate.
 
-**Why prototype patching instead of click-interception**:
+**Why click-by-text-content instead of patching navigation primitives**:
 
-- Divi 5's `switchEditor( DIVI )` does `window.location.href = getVBUrl()` programmatically — not an `<a>` click — so the chromeless-bridge link interceptor can't see it.
-- The Gutenberg editor canvas in WP 6.3+ is itself another nested iframe, putting the Divi placeholder block two frames below the chromeless bridge.
-- Earlier attempts that ejected by reading the iframe's `contentWindow.location.href` on `load` were too late: by then Divi's nonce had already been consumed inside the iframe and the URL was the post-redirect form. Navigating top to that URL skipped the activation step.
+Earlier iterations tried to transparently intercept Divi's navigation — patching `Location.prototype.href`, intercepting `fetch` / `XHR`, watching iframe `load` events — and all of them failed in different ways. Divi captures `Location` references early in its bundle init, makes its REST save through a path our `fetch`/`XHR` wraps don't reach (it goes through `@wordpress/api-fetch` which bundles its own `fetch` reference), and the page-leave tears down our console before any diagnostic we add survives. The honest fix is to detect at a layer we *can* see — the click itself — and explicitly ask the user before doing anything irreversible.
+
+Detection is by visible text content on the clicked element rather than by selector — Divi changes the button class across versions but the user-facing label has been stable for years. We match: `"Use Divi Builder"`, `"Use The Divi Builder"`, `"Edit With The Divi Builder"`, `"Edit With Divi"` (case-insensitive, trimmed). The "Use Default Editor" sibling button is not in the match set, so users can still keep editing in Gutenberg.
 
 **Fix**:
 
-1. **Iframe-side patcher** (`admin_head` priority 0, chromeless + Divi-active only). Replaces `Location.prototype.href`'s setter, `Location.prototype.assign`, and `Location.prototype.replace`. Each wrapped function checks the URL against the VB pattern (`et_fb=1` or `et_fb_activation_nonce=`); on match it `postMessage`s the parent and skips the navigation. Non-matching URLs delegate to the original implementation.
+1. **Iframe-side click handler** (`admin_head` priority 0, chromeless + Divi-active only). Installs a capture-phase `click` listener that walks up from `e.target` looking for a `BUTTON`, `A`, `INPUT`, or `SPAN` whose trimmed lowercase text matches the VB button set. On match: `preventDefault` + `stopPropagation` + `stopImmediatePropagation`, then `postMessage` to the parent shell with `{ type: 'desktop-mode-divi-vb-handoff', url: window.location.href }`. The handler is also installed inside every reachable same-origin nested iframe (Gutenberg's editor canvas, etc.) — a `MutationObserver` on `document.documentElement` walks new iframes as they're added.
 
-   `Window.location` itself is `[Unforgeable]` and can't be reassigned, but `Location.prototype.href`'s property descriptor is plain data — `Object.defineProperty` works in every current browser (Chrome, Firefox, Safari).
-
-   The patcher also installs a capture-phase click listener on `a[href]` matching the same VB pattern, to cover the admin-bar "Edit With Divi" link which is a real `<a href>` that wouldn't go through `Location.prototype`.
-
-2. **Parent-shell listener** (`admin_footer` priority 1, non-chromeless + Divi-active only). Listens for `desktop-mode-divi-vb-eject` postMessages, checks `ev.origin === window.location.origin`, re-parses the URL and verifies same origin, then sets `window.top.location.href` to it.
+2. **Parent-shell listener** (`admin_footer` priority 1, non-chromeless + Divi-active only). Listens for `desktop-mode-divi-vb-handoff` postMessages, checks `ev.origin === window.location.origin`, then reshapes the URL: strip `desktop_mode_chromeless` (the iframe-only flag would keep us in chromeless render at top level), add `desktop_mode_classic=1` (consumed by `desktop_mode_redirect_plain_admin_to_portal()` in `includes/portal.php:286-288` to skip the portal-redirect for this request). Then shows `wp.desktop.confirm()` with `hideCancel: true` + `dismissable: true` — a single "Open Divi in this tab" action plus an X to close. On confirm, sets `window.top.location.href` to the reshaped URL. On X-close or Escape, does nothing — the user stays where they were and can click the button again later to re-show the dialog.
 
 3. **`desktop_mode_compat_divi_is_active()`** — small helper that returns true for the Divi theme or the Divi Builder plugin. Both halves of the fix are gated on it so non-Divi sites pay nothing.
 
-**Plugins this addresses**: Divi theme + Divi Builder plugin, both editing flows (Gutenberg block "Use Divi Builder", Classic Editor's AJAX-then-redirect, admin-bar "Edit With Divi").
+**Plugins this addresses**: Divi theme + Divi Builder plugin, every editing flow whose "Use Divi Builder" / "Edit With Divi" button text matches one of the patterns above — Gutenberg block placeholder, Classic Editor row action, admin-bar Edit-With-Divi link.
 
-**Tests**: `tests/phpunit/tests/diviCompat.php` — `test_iframe_patch_emits_in_chromeless_for_divi`, `test_iframe_patch_skips_when_not_chromeless`, `test_iframe_patch_skips_without_divi`, `test_parent_listener_emits_on_shell_for_divi`, `test_parent_listener_skips_in_chromeless_request`, `test_parent_listener_skips_when_desktop_mode_disabled`, `test_parent_listener_skips_without_divi`, `test_is_active_true_for_divi_theme`, `test_is_active_false_for_other_theme`. The JS patching itself is verified live — vitest in jsdom doesn't model `[Unforgeable]` realistically.
+**Tests**: `tests/phpunit/tests/diviCompat.php` — `test_iframe_patch_emits_in_chromeless_for_divi`, `test_iframe_patch_skips_when_not_chromeless`, `test_iframe_patch_skips_without_divi`, `test_parent_listener_emits_on_shell_for_divi`, `test_parent_listener_skips_in_chromeless_request`, `test_parent_listener_skips_when_desktop_mode_disabled`, `test_parent_listener_skips_without_divi`, `test_is_active_true_for_divi_theme`, `test_is_active_false_for_other_theme`. Vitest covers `wpd-confirm-dialog`'s `hideCancel` / `dismissable` props in `src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.test.ts`.
 
-> **Note**: shims 2 (`__Cypress__`) and 3 (preloader bridge) remain in place as defense-in-depth fallbacks for the brief window where the iframe is still loading the VB URL before the patcher's message reaches the parent. If the eject fires correctly, VB never finishes loading in the iframe and those shims never matter.
+> **Note**: shims 1–3 remain in place. Shim 1 (deps fix) is needed so the Divi block actually *renders* with its "Use Divi Builder" button — that label is what the click handler matches on. Shims 2 (`__Cypress__`) and 3 (preloader bridge) remain as defense-in-depth for users who *don't* take the handoff and let VB load inside the iframe anyway (e.g., older Divi versions that don't show our match-text buttons, or third-party plugins that activate VB through an unintercepted path).
 
 ## Adding a new fix
 

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -124,6 +124,40 @@ Core does not register `theme-install.php` as a submenu of `themes.php` — clas
 
 Resulting tab order: Appearance | Add Theme | Editor | Fonts | …
 
+## The script side: dependency repairs
+
+Some plugins / themes register block-editor scripts with incomplete `wp_enqueue_script()` dep arrays. When script load order accidentally resolves in their favor in classic admin, nobody notices; when our chromeless render shifts timing, the underlying bug surfaces and the plugin's React integration crashes before it can mount any UI.
+
+We can't change the plugin's PHP, but `WP_Scripts::$registered` is a mutable in-memory map. Adding a missing dep onto an existing registration is idempotent, side-effect-free, and silently becomes a no-op the day the plugin ships a real fix upstream.
+
+### Divi — `et-builder-gutenberg` dep order + cross-frame `et_gb` scope
+
+**File**: `includes/compat/divi.php`.
+
+Two problems sit on the same script registration. Both manifest as the same console error: `Uncaught TypeError: Cannot read properties of undefined (reading 'isCleanNewPost')` thrown from `gutenberg.js` at module-load time. Symptom for the user: no "Use Divi Builder" block on new posts, no Divi `PluginSidebar`, no toggle — Divi appears completely absent inside a desktop window.
+
+**Problem 1 — missing deps.** Divi (both the Divi theme and the standalone Divi Builder plugin) registers `et-builder-gutenberg` with only `[ 'jquery', 'wp-hooks' ]` as deps. The bundle reads from `wp.data` at module-load time. Without `wp-data` and `wp-editor` declared as deps, WordPress doesn't guarantee `@wordpress/editor` (which registers the `core/editor` store) has run by the time Divi's bundle executes.
+
+**Problem 2 — cross-frame `window.et_gb`.** Divi's bundle is webpack-built with `@wordpress/data` externalised to `window.et_gb.wp.data` — not `window.wp.data`. The inline script Divi adds (`before` the bundle) sets `window.et_gb` via this expression:
+
+```js
+window.et_gb = (window.top && window.top.Cypress && window.parent === window.top && window)
+    || (window.top && window.top.Cypress && window.parent !== window.top && window.parent)
+    || window.top   // ← falls through to here in our chromeless iframe
+    || window;
+```
+
+In classic admin `window.top === window`, so `et_gb = window` and the bundle resolves `wp.data` against the page's own globals. Inside a chromeless iframe `window.top` is the desktop shell — a different document with no `wp.data` — so `et_gb.wp.data` is undefined and the bundle throws on first access.
+
+**Fix**: `desktop_mode_compat_divi_fix_gutenberg_deps()` hooks `enqueue_block_editor_assets` at priority 999 (after Divi's priority 4) and does two things:
+
+1. Push `wp-data` + `wp-editor` onto Divi's existing registration's `deps`. The script loader then orders the bundle after `core/editor` registers.
+2. *Only inside chromeless requests*, append an inline `before` script that re-assigns `window.et_gb = window;`. Multiple `wp_add_inline_script( …, 'before' )` calls concatenate in registration order, so ours runs after Divi's and wins. We scope this to chromeless because Divi's original `et_gb = window.top` is legitimate for top-level page loads and for the Cypress-iframe case.
+
+**Plugins this addresses**: Divi theme (4.x and 5.x as of 5.5.2), Divi Builder plugin (same `et-builder-gutenberg` handle).
+
+**Test**: `tests/phpunit/tests/diviCompat.php` — pins dep injection (`test_injects_missing_wp_editor_and_wp_data_deps`), the no-op-when-absent case (`test_no_op_when_divi_not_registered`), idempotence (`test_does_not_duplicate_deps_when_already_present`), the chromeless `et_gb` override (`test_chromeless_request_appends_et_gb_window_override`), and the classic-admin guard (`test_classic_request_does_not_append_et_gb_override`).
+
 ## Adding a new fix
 
 Decision tree, in order:
@@ -132,7 +166,8 @@ Decision tree, in order:
 2. **Is the offending CSS rule a `top: <pixel>` on a positioned element, with an admin-bar-height pixel value?** → Tier 2 covers it. Verify the value is in the default set or extend via `desktop_mode_chromeless_admin_bar_top_values`.
 3. **Is the offending CSS rule selector-targetable and self-contained?** → Tier 3 — write a scoped CSS override in `chromeless.css`. Follow the docblock template above.
 4. **Is the breakage in menu data, not CSS?** → Add a dock-side adaptation in `includes/helpers.php` and a PHPUnit test under `tests/phpunit/tests/desktopModeBuildDockItems.php` (or `desktopModeMenuItemUrl.php` if it's a URL-builder issue).
-5. **Is it none of the above?** Open an issue. Don't escalate to broad fixes (`overflow: hidden` on body, JS-rewriting stylesheets, etc.) without a discussion — those tend to break more than they fix.
+5. **Is a block-editor script crashing at module load because of a missing `wp_enqueue_script()` dep?** → Add a registration-mutation shim under `includes/compat/<plugin>.php` and a PHPUnit test that pins the shape. Follow `includes/compat/divi.php` as the template.
+6. **Is it none of the above?** Open an issue. Don't escalate to broad fixes (`overflow: hidden` on body, JS-rewriting stylesheets, etc.) without a discussion — those tend to break more than they fix.
 
 ## Test discipline
 

--- a/includes/compat/divi.php
+++ b/includes/compat/divi.php
@@ -172,6 +172,13 @@ function desktop_mode_compat_divi_vb_iframe_signal() {
 	if ( ! desktop_mode_is_enabled() ) {
 		return;
 	}
+	// Bail when Divi isn't active — the inline script below is
+	// shaped entirely around Divi's frame-helpers and VB preloader.
+	// Other handlers in this file already gate on
+	// `desktop_mode_compat_divi_is_active()`; this one was missed.
+	if ( ! desktop_mode_compat_divi_is_active() ) {
+		return;
+	}
 	// `app_window=1` flags the inner VB iframe Divi spawns inside the
 	// `/?p=N&et_fb=1` page. The outer ("VB-top") frame is what hosts
 	// the visible preloader the user sees; the inner is where Divi

--- a/includes/compat/divi.php
+++ b/includes/compat/divi.php
@@ -396,7 +396,6 @@ function desktop_mode_compat_divi_eject_iframe_patch() {
 	<?php
 }
 add_action( 'admin_head', 'desktop_mode_compat_divi_eject_iframe_patch', 0 );
-add_action( 'admin_footer', 'desktop_mode_compat_divi_eject_iframe_patch', 999 );
 
 /**
  * Parent-shell side: receive the handoff message, ask the user
@@ -463,11 +462,13 @@ function desktop_mode_compat_divi_eject_parent_listener() {
 				dismissable: true,
 			} );
 		} else {
-			promptUser = Promise.resolve(
-				window.confirm(
-					'Divi cannot run inside Desktop Mode. Click OK to open Divi in this browser tab (Desktop Mode will resume on your next wp-admin visit).'
-				)
-			);
+			// Defense-in-depth no-op. `wp.desktop.confirm` is
+			// reliably present on every shell page where this
+			// listener emits, so this branch is unreachable in
+			// practice. A `window.confirm` here would violate the
+			// codebase-wide "no native dialogs" rule (see CLAUDE.md);
+			// resolving false is the safer empty fallback.
+			promptUser = Promise.resolve( false );
 		}
 		Promise.resolve( promptUser ).then( function ( ok ) {
 			if ( ok ) { window.top.location.href = url; }

--- a/includes/compat/divi.php
+++ b/includes/compat/divi.php
@@ -456,15 +456,16 @@ function desktop_mode_compat_divi_eject_parent_listener() {
 		var promptUser;
 		if ( window.wp && window.wp.desktop && typeof window.wp.desktop.confirm === 'function' ) {
 			promptUser = window.wp.desktop.confirm( {
-				title: 'Open Divi in a standalone browser tab?',
-				message: 'Divi\u2019s Visual Builder needs a full browser tab to render and save correctly \u2014 it doesn\u2019t work well inside a Desktop Mode window.\n\nContinuing will close this window and load the page editor in the current browser tab, exiting Desktop Mode. Next time you visit wp-admin you\u2019ll be back in Desktop Mode automatically.',
-				confirmLabel: 'Open in standalone tab',
-				cancelLabel: 'Stay in Desktop Mode',
+				title: 'Divi needs its own browser tab',
+				message: 'Divi\u2019s Visual Builder cannot run inside a Desktop Mode window \u2014 it needs the full browser tab to render and save correctly. There is no workaround on our side; Divi simply doesn\u2019t support being nested.',
+				confirmLabel: 'Open Divi in this tab',
+				hideCancel: true,
+				dismissable: true,
 			} );
 		} else {
 			promptUser = Promise.resolve(
 				window.confirm(
-					'Open Divi in a standalone browser tab? Desktop Mode will be exited for this editing session and resume on your next wp-admin visit.'
+					'Divi cannot run inside Desktop Mode. Click OK to open Divi in this browser tab (Desktop Mode will resume on your next wp-admin visit).'
 				)
 			);
 		}

--- a/includes/compat/divi.php
+++ b/includes/compat/divi.php
@@ -107,7 +107,7 @@ function desktop_mode_compat_divi_fix_gutenberg_deps() {
 		}
 	}
 
-	if ( function_exists( 'desktop_mode_is_chromeless_request' ) && desktop_mode_is_chromeless_request() ) {
+	if ( desktop_mode_is_chromeless_request() ) {
 		wp_add_inline_script(
 			'et-builder-gutenberg',
 			'window.et_gb = window;',
@@ -116,3 +116,390 @@ function desktop_mode_compat_divi_fix_gutenberg_deps() {
 	}
 }
 add_action( 'enqueue_block_editor_assets', 'desktop_mode_compat_divi_fix_gutenberg_deps', 999 );
+
+/**
+ * Signal Divi's Visual Builder frame-helpers that the iframe context
+ * is "top-level-equivalent" so its `top_window` export resolves to
+ * the iframe's own `window` instead of the desktop shell.
+ *
+ * The VB front-end bundle includes a helper module
+ * (`frontend-builder/build/frame-helpers.js`) whose `top_window`
+ * resolver does roughly this at load time:
+ *
+ *     try { u = !!window.top.document && window.top; }
+ *     catch ( _ ) { u = false; }
+ *     if ( u && u.__Cypress__ ) {
+ *         top_window = ( window.parent === u ) ? window : window.parent;
+ *         is_iframe  = ( window.parent !== u );
+ *     } else if ( u ) {
+ *         top_window = u;                  // ← falls through to here
+ *         is_iframe  = ( u !== window.self );
+ *     }
+ *
+ * Inside a chromeless iframe `window.top` is the desktop shell, so
+ * the `else if ( u )` branch fires: `top_window = window.top` (the
+ * shell), `is_iframe = true`. The rest of Divi's VB then routes
+ * REST nonces, builder state, and DOM ops through a window that
+ * has none of those things — VB sits permanently on its
+ * "et-fb-page-preloading" loader because the state it's waiting
+ * for will never arrive.
+ *
+ * Setting `__Cypress__` on `window.top` (our shell) makes Divi take
+ * the Cypress branch instead. Since we're a single-level iframe
+ * (`window.parent === window.top`), that branch resolves
+ * `top_window = window` (the iframe itself), `is_iframe = false`
+ * — exactly the classic-admin behavior. The flag costs nothing
+ * outside Divi (no other code in the WP stack reads `__Cypress__`)
+ * and is idempotent (we OR with the existing value).
+ *
+ * Scope: only when the current user has desktop mode enabled AND
+ * the rendered document is loaded inside an iframe (`window.top !==
+ * window`). The inline script is a few-byte no-op everywhere else.
+ * Front-end only — admin pages use `et_gb` (see above) and route
+ * through a different compat path.
+ *
+ * Reported to Elegant Themes. Remove this hook when Divi makes
+ * `top_window` iframe-aware upstream.
+ *
+ * @since 0.18.x
+ *
+ * @return void
+ */
+function desktop_mode_compat_divi_vb_iframe_signal() {
+	if ( is_admin() ) {
+		return;
+	}
+	if ( ! desktop_mode_is_enabled() ) {
+		return;
+	}
+	// `app_window=1` flags the inner VB iframe Divi spawns inside the
+	// `/?p=N&et_fb=1` page. The outer ("VB-top") frame is what hosts
+	// the visible preloader the user sees; the inner is where Divi
+	// mounts its React app. We only need the preloader bridge on the
+	// VB-top — the inner frame's `__Cypress__` signal is enough.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only flag set by Divi itself when constructing the inner iframe.
+	$is_app_frame = isset( $_GET['app_window'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['app_window'] ) );
+	?>
+<script id="desktop-mode-compat-divi-vb">
+( function () {
+	if ( window.top === window ) { return; }
+	<?php if ( $is_app_frame ) : ?>
+	// Inside Divi's own inner builder iframe. We only want to
+	// taint window.top with the Cypress flag when DM is wrapping
+	// the whole stack (3 frames deep: shell, chromeless,
+	// builder). At top-level VB flow (2 frames deep: builder-top,
+	// builder) window.parent === window.top AND window.top is
+	// the actual builder-top frame. Tainting it there would
+	// mistrain Divi's frame-helpers: it would hit the Cypress
+	// branch, see parent equals top, and resolve top_window =
+	// window (the inner self) instead of the parent. Divi then
+	// can't communicate inner-to-top and the preloader sits up
+	// forever. Bail before doing anything in this case.
+	if ( window.parent === window.top ) { return; }
+	<?php endif; ?>
+	try { window.top.__Cypress__ = window.top.__Cypress__ || true; } catch ( e ) {}
+	<?php if ( ! $is_app_frame ) : ?>
+	/*
+	 * VB-top preloader bridge.
+	 *
+	 * Divi's `visual-builder/build/root.js` clears the preloader by
+	 * removing the `et-fb-page-preloading` class from `#et-fb-app`
+	 * and `#et-fb-app-body-root` in two places: its own document AND
+	 * `window.top.document`. The intent is "and also clear it on the
+	 * outer VB-top frame I'm rendered into." In classic admin
+	 * `window.top` IS the VB-top, so that works.
+	 *
+	 * In a Desktop Mode chromeless iframe, the nesting is one deeper
+	 * — the inner React app's `window.top` is the desktop shell,
+	 * which has no Divi elements. Root.js cleans its own doc and
+	 * no-ops on the shell, leaving THIS document's preloader stuck
+	 * forever.
+	 *
+	 * Mirror the removal here: once the inner app-frame's
+	 * `#et-fb-app` loses the preloading class (the canonical signal
+	 * that Divi finished mounting), strip it from this document's
+	 * `#et-fb-app` / `#et-fb-app-body-root`. Same-origin gives us
+	 * direct access to the child iframe's document, so a
+	 * MutationObserver on the child suffices. A 30s watchdog
+	 * timeout strips the preloader even if the observer never fires
+	 * (e.g. Divi's React errors out silently inside the inner
+	 * frame) — better a broken builder visible than an invisible
+	 * spinner forever.
+	 */
+	function clearLocalPreloader() {
+		[ 'et-fb-app', 'et-fb-app-body-root' ].forEach( function ( id ) {
+			var el = document.getElementById( id );
+			if ( el ) { el.classList.remove( 'et-fb-page-preloading' ); }
+		} );
+	}
+	function bridgeAppFrame( appFrame ) {
+		var idoc = null;
+		try { idoc = appFrame.contentDocument; } catch ( e ) {}
+		if ( ! idoc ) {
+			appFrame.addEventListener( 'load', function () { bridgeAppFrame( appFrame ); }, { once: true } );
+			return;
+		}
+		function check() {
+			var inner = idoc.getElementById( 'et-fb-app' ) || idoc.getElementById( 'et-fb-app-body-root' );
+			if ( inner && ! inner.classList.contains( 'et-fb-page-preloading' ) ) {
+				clearLocalPreloader();
+				return true;
+			}
+			return false;
+		}
+		if ( check() ) { return; }
+		var mo = new MutationObserver( function () { if ( check() ) { mo.disconnect(); } } );
+		mo.observe( idoc.documentElement, { attributes: true, subtree: true, attributeFilter: [ 'class' ] } );
+		setTimeout( function () { mo.disconnect(); clearLocalPreloader(); }, 30000 );
+	}
+	function hunt() {
+		var f = document.getElementById( 'et-vb-app-frame' );
+		if ( f ) { bridgeAppFrame( f ); return; }
+		var bodyMo = new MutationObserver( function () {
+			var found = document.getElementById( 'et-vb-app-frame' );
+			if ( found ) { bodyMo.disconnect(); bridgeAppFrame( found ); }
+		} );
+		bodyMo.observe( document.documentElement, { childList: true, subtree: true } );
+	}
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', hunt );
+	} else {
+		hunt();
+	}
+	<?php endif; ?>
+} )();
+</script>
+	<?php
+}
+add_action( 'wp_head', 'desktop_mode_compat_divi_vb_iframe_signal', 1 );
+
+/**
+ * Iframe-side: hijack clicks on Divi's "Use Divi Builder" /
+ * "Edit With The Divi Builder" buttons and links, and hand the
+ * navigation off to the parent shell so the user can opt into a
+ * top-level browser tab for the editing session.
+ *
+ * Why we hijack instead of letting Divi navigate:
+ *
+ * Divi's Visual Builder fundamentally doesn't behave well inside
+ * Desktop Mode's nested iframe chain (shell -> chromeless iframe
+ * -> Divi's inner app-frame). Earlier attempts to transparently
+ * eject mid-navigation hit a chain of subtle race conditions —
+ * Divi captures `Location.prototype` references early, makes its
+ * REST save through a path our `fetch`/`XHR` wraps don't reach,
+ * and the page-leave tears down our console before any diagnostic
+ * we add survives the navigation. The honest fix is to ask the
+ * user, explicitly, whether they want to leave Desktop Mode for
+ * this edit session.
+ *
+ * Detection is by visible text content on the clicked element
+ * rather than by selector — Divi changes the button class across
+ * versions but the user-facing label has been stable for years.
+ * We match: "Use Divi Builder", "Use The Divi Builder", "Edit
+ * With The Divi Builder", "Edit With Divi" (case-insensitive,
+ * trimmed). The "Use Default Editor" sibling button is not in the
+ * match set, so users can still keep editing in Gutenberg.
+ *
+ * Scope: chromeless requests only, and only when Divi is active.
+ * The handler also walks every same-origin nested iframe so the
+ * Gutenberg editor canvas (when Gutenberg keeps it for non-Divi
+ * blocks) is covered.
+ *
+ * @since 0.18.x
+ *
+ * @return void
+ */
+function desktop_mode_compat_divi_eject_iframe_patch() {
+	if ( ! desktop_mode_is_chromeless_request() ) {
+		return;
+	}
+	if ( ! desktop_mode_compat_divi_is_active() ) {
+		return;
+	}
+	?>
+<script id="desktop-mode-compat-divi-vb-handoff">
+( function () {
+	var BTN_TEXTS = [
+		'use divi builder',
+		'use the divi builder',
+		'edit with the divi builder',
+		'edit with divi',
+	];
+	function matchesDiviVbButton( el ) {
+		if ( ! el || ! el.tagName ) { return false; }
+		var tag = el.tagName;
+		if ( tag !== 'BUTTON' && tag !== 'A' && tag !== 'INPUT' && tag !== 'SPAN' ) { return false; }
+		var raw = ( el.textContent || el.value || el.getAttribute( 'aria-label' ) || '' );
+		var text = String( raw ).replace( /\s+/g, ' ' ).trim().toLowerCase();
+		return BTN_TEXTS.indexOf( text ) !== -1;
+	}
+	function postHandoff( currentUrl ) {
+		try {
+			window.top.postMessage(
+				{ type: 'desktop-mode-divi-vb-handoff', url: String( currentUrl ) },
+				window.location.origin
+			);
+		} catch ( e ) {}
+	}
+	function onClick( e ) {
+		if ( e.defaultPrevented ) { return; }
+		if ( e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ) { return; }
+		var el = e.target;
+		var match = null;
+		while ( el && el.nodeType === 1 ) {
+			if ( matchesDiviVbButton( el ) ) { match = el; break; }
+			el = el.parentNode;
+		}
+		if ( ! match ) { return; }
+		e.preventDefault();
+		e.stopPropagation();
+		if ( typeof e.stopImmediatePropagation === 'function' ) {
+			e.stopImmediatePropagation();
+		}
+		postHandoff( window.location.href );
+	}
+	function attachClickListener( doc ) {
+		try {
+			if ( doc.__desktopModeDiviHandoffAttached ) { return; }
+			doc.__desktopModeDiviHandoffAttached = true;
+			doc.addEventListener( 'click', onClick, true );
+		} catch ( e ) {}
+	}
+	function walkAndAttach( root ) {
+		attachClickListener( root );
+		var frames;
+		try { frames = root.querySelectorAll( 'iframe' ); }
+		catch ( e ) { return; }
+		frames.forEach( function ( iframe ) {
+			try {
+				if ( iframe.contentDocument ) { walkAndAttach( iframe.contentDocument ); }
+			} catch ( e ) {}
+			if ( iframe.__desktopModeDiviHandoffHooked ) { return; }
+			iframe.__desktopModeDiviHandoffHooked = true;
+			iframe.addEventListener( 'load', function () {
+				try { if ( iframe.contentDocument ) { walkAndAttach( iframe.contentDocument ); } } catch ( e ) {}
+			} );
+		} );
+	}
+	function bootstrap() {
+		walkAndAttach( document );
+		new MutationObserver( function () { walkAndAttach( document ); } )
+			.observe( document.documentElement, { subtree: true, childList: true } );
+	}
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', bootstrap );
+	} else {
+		bootstrap();
+	}
+} )();
+</script>
+	<?php
+}
+add_action( 'admin_head', 'desktop_mode_compat_divi_eject_iframe_patch', 0 );
+add_action( 'admin_footer', 'desktop_mode_compat_divi_eject_iframe_patch', 999 );
+
+/**
+ * Parent-shell side: receive the handoff message, ask the user
+ * to confirm via `wp.desktop.confirm()`, and on accept navigate
+ * `window.top.location.href` to the iframe's current URL — which
+ * is the post-edit page. The user lands at top level on the same
+ * post they were editing, clicks "Use Divi Builder" again with a
+ * single browser tab, and Divi runs in its native single-frame
+ * environment.
+ *
+ * Two clicks total to enter VB, but each is deliberate. No
+ * detection magic, no race conditions, no transparent eject.
+ *
+ * Same-origin guards: the message event must originate from our
+ * own origin AND the URL we navigate to must parse back to the
+ * same origin. Foreign frames can't trigger the handoff.
+ *
+ * @since 0.18.x
+ *
+ * @return void
+ */
+function desktop_mode_compat_divi_eject_parent_listener() {
+	if ( ! desktop_mode_is_enabled() ) {
+		return;
+	}
+	if ( desktop_mode_is_chromeless_request() || desktop_mode_is_classic_request() ) {
+		return;
+	}
+	if ( ! desktop_mode_compat_divi_is_active() ) {
+		return;
+	}
+	?>
+<script id="desktop-mode-compat-divi-vb-handoff-parent">
+( function () {
+	// Reshape the iframe's URL into a top-level classic-admin URL.
+	// The iframe carries `desktop_mode_chromeless=1`, which would
+	// keep the chromeless render alive even at top level — leaving
+	// the user on what looks like the same headless Gutenberg they
+	// already had inside the window. We want a normal wp-admin page
+	// instead, so strip that flag and add `desktop_mode_classic=1`
+	// so our own `desktop_mode_redirect_plain_admin_to_portal()` in
+	// `includes/portal.php` skips its portal-bounce for this load.
+	function handoffUrl( raw ) {
+		try {
+			var parsed = new URL( String( raw || '' ), window.location.href );
+			if ( parsed.origin !== window.location.origin ) { return null; }
+			parsed.searchParams.delete( 'desktop_mode_chromeless' );
+			parsed.searchParams.set( 'desktop_mode_classic', '1' );
+			return parsed.toString();
+		} catch ( e ) { return null; }
+	}
+	window.addEventListener( 'message', function ( ev ) {
+		if ( ev.origin !== window.location.origin ) { return; }
+		if ( ! ev.data || ev.data.type !== 'desktop-mode-divi-vb-handoff' ) { return; }
+		var url = handoffUrl( ev.data.url );
+		if ( ! url ) { return; }
+		var promptUser;
+		if ( window.wp && window.wp.desktop && typeof window.wp.desktop.confirm === 'function' ) {
+			promptUser = window.wp.desktop.confirm( {
+				title: 'Open Divi in a standalone browser tab?',
+				message: 'Divi\u2019s Visual Builder needs a full browser tab to render and save correctly \u2014 it doesn\u2019t work well inside a Desktop Mode window.\n\nContinuing will close this window and load the page editor in the current browser tab, exiting Desktop Mode. Next time you visit wp-admin you\u2019ll be back in Desktop Mode automatically.',
+				confirmLabel: 'Open in standalone tab',
+				cancelLabel: 'Stay in Desktop Mode',
+			} );
+		} else {
+			promptUser = Promise.resolve(
+				window.confirm(
+					'Open Divi in a standalone browser tab? Desktop Mode will be exited for this editing session and resume on your next wp-admin visit.'
+				)
+			);
+		}
+		Promise.resolve( promptUser ).then( function ( ok ) {
+			if ( ok ) { window.top.location.href = url; }
+		} );
+	} );
+} )();
+</script>
+	<?php
+}
+add_action( 'admin_footer', 'desktop_mode_compat_divi_eject_parent_listener', 1 );
+
+
+/**
+ * Detect whether Divi (theme or standalone Divi Builder plugin)
+ * is active. Used to gate both the iframe-side patcher and the
+ * parent-side listener — both no-ops on non-Divi sites.
+ *
+ * @since 0.18.x
+ *
+ * @return bool True when the Divi theme is active OR the Divi
+ *              Builder plugin is active.
+ */
+function desktop_mode_compat_divi_is_active() {
+	$theme = wp_get_theme();
+	if ( $theme instanceof WP_Theme ) {
+		$name     = (string) $theme->get( 'Name' );
+		$template = (string) $theme->get_template();
+		if ( 'Divi' === $name || 'Divi' === $template ) {
+			return true;
+		}
+	}
+	if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'divi-builder/divi-builder.php' ) ) {
+		return true;
+	}
+	return false;
+}

--- a/includes/compat/divi.php
+++ b/includes/compat/divi.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Divi compatibility — script dependency repair.
+ *
+ * Divi (both the theme and the standalone Divi Builder plugin)
+ * registers its block-editor bundle `et-builder-gutenberg` with
+ * only `[ 'jquery', 'wp-hooks' ]` as dependencies. The bundle
+ * calls `wp.data.select( 'core/editor' ).isCleanNewPost` at
+ * module-load time (top-level statement, not inside a function),
+ * so it needs the `core/editor` data store to be registered before
+ * it executes. Without `wp-editor` (which pulls in `wp-data` and
+ * registers `core/editor`) in the dep array, WordPress doesn't
+ * guarantee that ordering — and when the bundle wins the race the
+ * `select( ... )` call returns `undefined` and the bundle throws:
+ *
+ *     Uncaught TypeError: Cannot read properties of undefined
+ *     (reading 'isCleanNewPost')
+ *
+ * The rest of Divi's React integration never mounts: no `Use Divi
+ * Builder` block on new posts, no `PluginSidebar`, no toggle. To
+ * the user it looks like Divi simply doesn't work inside a desktop
+ * window.
+ *
+ * We inject the missing deps onto the existing registration so the
+ * script loader prints `wp-editor`'s graph first and the bundle
+ * runs against a populated `wp.data`. The shim is idempotent: if
+ * Divi later ships the fix upstream (or renames the handle), this
+ * becomes a no-op.
+ *
+ * Reported to Elegant Themes. Remove this file when Divi ships
+ * the fix upstream.
+ *
+ * @since   0.18.x
+ * @package WP_Desktop_Mode\Compat
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inject `wp-data` and `wp-editor` as dependencies on Divi's
+ * `et-builder-gutenberg` script registration, and (inside a
+ * chromeless iframe) override Divi's `window.et_gb` assignment so
+ * the bundle's webpack externals resolve to the iframe's own
+ * `wp.data`.
+ *
+ * Two problems on the same script registration:
+ *
+ *  1. **Missing deps.** Divi declares only `[ jquery, wp-hooks ]`
+ *     but the bundle reads from `wp.data` at module-load time. We
+ *     add `wp-data` + `wp-editor` so the loader prints them first.
+ *
+ *  2. **`window.et_gb` resolves to the wrong frame.** Divi's
+ *     bundle is webpack-built with `@wordpress/data` externalised
+ *     to `window.et_gb.wp.data` — not `window.wp.data`. The inline
+ *     script Divi adds (`before` the bundle) sets `window.et_gb`
+ *     via this expression:
+ *
+ *         window.et_gb = (window.top && window.top.Cypress && …)
+ *             || window.top   // ← falls through to here
+ *             || window;
+ *
+ *     In classic admin `window.top === window`, so `et_gb =
+ *     window` and `et_gb.wp.data` is the page's own `wp.data`.
+ *     Inside our chromeless iframe `window.top` is the desktop
+ *     shell — a different document with no `wp.data` — so
+ *     `et_gb.wp.data` is undefined and the bundle throws on first
+ *     access (`Cannot read properties of undefined (reading
+ *     'isCleanNewPost')`). The rest of Divi's React integration
+ *     never mounts: no `Use Divi Builder` block on new posts, no
+ *     `PluginSidebar`, no toggle.
+ *
+ *     Multiple `wp_add_inline_script( …, 'before' )` calls
+ *     concatenate in registration order, so appending our own
+ *     `window.et_gb = window;` after Divi's lets our assignment
+ *     win. Scoped to chromeless requests because Divi's original
+ *     intent (use `window.top` when the parent is a Cypress
+ *     harness) is sensible in other iframe contexts.
+ *
+ * Hooked at `enqueue_block_editor_assets` priority 999 so it runs
+ * after Divi's own enqueue (priority 4) but before the script
+ * loader prints `<script>` tags.
+ *
+ * Reported to Elegant Themes. Remove this file when Divi ships
+ * the fix upstream.
+ *
+ * @since 0.18.x
+ *
+ * @return void
+ */
+function desktop_mode_compat_divi_fix_gutenberg_deps() {
+	global $wp_scripts;
+
+	if ( ! ( $wp_scripts instanceof WP_Scripts ) ) {
+		return;
+	}
+
+	if ( ! isset( $wp_scripts->registered['et-builder-gutenberg'] ) ) {
+		return;
+	}
+
+	$registration = $wp_scripts->registered['et-builder-gutenberg'];
+	$existing     = (array) $registration->deps;
+
+	foreach ( array( 'wp-data', 'wp-editor' ) as $dep ) {
+		if ( ! in_array( $dep, $existing, true ) ) {
+			$registration->deps[] = $dep;
+		}
+	}
+
+	if ( function_exists( 'desktop_mode_is_chromeless_request' ) && desktop_mode_is_chromeless_request() ) {
+		wp_add_inline_script(
+			'et-builder-gutenberg',
+			'window.et_gb = window;',
+			'before'
+		);
+	}
+}
+add_action( 'enqueue_block_editor_assets', 'desktop_mode_compat_divi_fix_gutenberg_deps', 999 );

--- a/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.styles.ts
+++ b/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.styles.ts
@@ -27,6 +27,30 @@ export const dialogStyles = css`
 		display: flex;
 		flex-direction: column;
 		gap: 10px;
+		position: relative;
+	}
+
+	.close {
+		position: absolute;
+		top: 8px;
+		right: 10px;
+		width: 28px;
+		height: 28px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		border: 0;
+		border-radius: 6px;
+		color: var( --wpd-confirm-dialog-fg-muted, rgba( 255, 255, 255, 0.7 ) );
+		cursor: pointer;
+		font-size: 22px;
+		line-height: 1;
+		padding: 0;
+	}
+	.close:hover {
+		background: rgba( 255, 255, 255, 0.08 );
+		color: inherit;
 	}
 
 	.title {

--- a/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.test.ts
+++ b/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.test.ts
@@ -102,4 +102,45 @@ describe( 'wpd-confirm-dialog', () => {
 		dialog.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 		await expect( promise ).resolves.toBe( false );
 	} );
+
+	test( 'hideCancel hides the cancel button entirely', async () => {
+		const { wpdConfirm } = await load();
+		const promise = wpdConfirm( { message: 'X', hideCancel: true } );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+		const dialog = document.querySelector< HTMLElement >( 'wpd-confirm-dialog' )!;
+		const cancelBtn = dialog.shadowRoot!.querySelector< HTMLButtonElement >( '.btn--secondary' );
+		expect( cancelBtn ).toBeNull();
+		// Confirm still works.
+		const confirmBtn = dialog.shadowRoot!.querySelector< HTMLButtonElement >( '.btn--primary' );
+		expect( confirmBtn ).not.toBeNull();
+		confirmBtn!.click();
+		await expect( promise ).resolves.toBe( true );
+	} );
+
+	test( 'dismissable renders an X close button that emits cancel', async () => {
+		const { wpdConfirm } = await load();
+		const promise = wpdConfirm( {
+			message: 'X',
+			hideCancel: true,
+			dismissable: true,
+		} );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+		const dialog = document.querySelector< HTMLElement >( 'wpd-confirm-dialog' )!;
+		const closeBtn = dialog.shadowRoot!.querySelector< HTMLButtonElement >( '.close' );
+		expect( closeBtn ).not.toBeNull();
+		expect( closeBtn!.getAttribute( 'aria-label' ) ).toBe( 'Close' );
+		closeBtn!.click();
+		await expect( promise ).resolves.toBe( false );
+	} );
+
+	test( 'without dismissable, the close button is absent', async () => {
+		const { wpdConfirm } = await load();
+		const promise = wpdConfirm( { message: 'X' } );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+		const dialog = document.querySelector< HTMLElement >( 'wpd-confirm-dialog' )!;
+		expect( dialog.shadowRoot!.querySelector( '.close' ) ).toBeNull();
+		// Tear down to avoid a dangling Promise.
+		dialog.shadowRoot!.querySelector< HTMLButtonElement >( '.btn--secondary' )!.click();
+		await promise;
+	} );
 } );

--- a/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.ts
+++ b/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.ts
@@ -43,6 +43,8 @@ export class WpdConfirmDialog extends Component {
 		'confirm-label',
 		'cancel-label',
 		'danger',
+		'hide-cancel',
+		'dismissable',
 	] as const;
 	static styles = [ dialogStyles ];
 
@@ -59,6 +61,8 @@ export class WpdConfirmDialog extends Component {
 			{ name: 'confirm-label', type: 'string', default: 'Confirm', description: 'Confirm-button label.' },
 			{ name: 'cancel-label', type: 'string', default: 'Cancel', description: 'Cancel-button label.' },
 			{ name: 'danger', type: 'boolean attribute', description: 'Renders the confirm button red.' },
+			{ name: 'hide-cancel', type: 'boolean attribute', description: 'Hides the cancel button entirely. Useful when there is no alternative action — pair with `dismissable` so the user still has an explicit way to close.' },
+			{ name: 'dismissable', type: 'boolean attribute', description: 'Renders an X close button in the top-right corner. Click emits `wpd-cancel`.' },
 		],
 		events: [
 			{
@@ -126,8 +130,18 @@ export class WpdConfirmDialog extends Component {
 		const cancelLabel =
 			( this as unknown as { 'cancel-label': string | null } )[ 'cancel-label' ] || 'Cancel';
 		const isDanger = this.hasAttribute( 'danger' );
+		const hideCancel = this.hasAttribute( 'hide-cancel' );
+		const isDismissable = this.hasAttribute( 'dismissable' );
 		return html`
 			<div class="dialog" tabindex="-1">
+				${ isDismissable
+					? html`<button
+						type="button"
+						class="close"
+						aria-label="Close"
+						@click=${ () => this._cancel() }
+					>&times;</button>`
+					: html`` }
 				${ title
 					? html`<h2 class="title">${ title }</h2>`
 					: html`` }
@@ -135,13 +149,15 @@ export class WpdConfirmDialog extends Component {
 					? html`<p class="message">${ message }</p>`
 					: html`` }
 				<div class="actions">
-					<button
-						type="button"
-						class="btn btn--secondary"
-						@click=${ () => this._cancel() }
-					>
-						${ cancelLabel }
-					</button>
+					${ hideCancel
+						? html``
+						: html`<button
+							type="button"
+							class="btn btn--secondary"
+							@click=${ () => this._cancel() }
+						>
+							${ cancelLabel }
+						</button>` }
 					<button
 						type="button"
 						class="btn ${ isDanger ? 'btn--danger' : 'btn--primary' }"
@@ -162,6 +178,10 @@ export interface WpdConfirmOptions {
 	confirmLabel?: string;
 	cancelLabel?: string;
 	danger?: boolean;
+	/** Hide the cancel button entirely. Pair with `dismissable` to keep a way to close. */
+	hideCancel?: boolean;
+	/** Render an X close button in the top-right corner. Click emits `wpd-cancel`. */
+	dismissable?: boolean;
 }
 
 /**
@@ -186,6 +206,12 @@ export function wpdConfirm( options: WpdConfirmOptions ): Promise< boolean > {
 		}
 		if ( options.danger ) {
 			dialog.setAttribute( 'danger', '' );
+		}
+		if ( options.hideCancel ) {
+			dialog.setAttribute( 'hide-cancel', '' );
+		}
+		if ( options.dismissable ) {
+			dialog.setAttribute( 'dismissable', '' );
 		}
 		const cleanup = ( ok: boolean ): void => {
 			dialog.remove();

--- a/src/wpd-confirm.ts
+++ b/src/wpd-confirm.ts
@@ -52,6 +52,12 @@ export async function wpdConfirm(
 		if ( options.danger ) {
 			dialog.setAttribute( 'danger', '' );
 		}
+		if ( options.hideCancel ) {
+			dialog.setAttribute( 'hide-cancel', '' );
+		}
+		if ( options.dismissable ) {
+			dialog.setAttribute( 'dismissable', '' );
+		}
 		const cleanup = ( ok: boolean ): void => {
 			dialog.remove();
 			resolve( ok );

--- a/tests/phpunit/tests/diviCompat.php
+++ b/tests/phpunit/tests/diviCompat.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Tests for the Divi script-dependency compat shim.
+ *
+ * Divi's `et-builder-gutenberg` bundle calls `wp.data.select(
+ * 'core/editor' ).isCleanNewPost` at module-load time but only
+ * declares `[ jquery, wp-hooks ]` as deps. When script load order
+ * resolves against Divi, the call throws and Divi's React
+ * integration never mounts. We add `wp-data` + `wp-editor` to the
+ * existing registration so the loader prints the `core/editor`
+ * store first. See includes/compat/divi.php.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ *
+ * @covers ::desktop_mode_compat_divi_fix_gutenberg_deps
+ */
+class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
+
+	public function tear_down() {
+		wp_deregister_script( 'et-builder-gutenberg' );
+		unset( $_GET['desktop_mode_chromeless'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: simulate a chromeless request by priming the query
+	 * arg + user meta that `desktop_mode_is_chromeless_request()`
+	 * checks. Caller is responsible for unsetting state in
+	 * `tear_down`.
+	 */
+	private function force_chromeless() {
+		$_GET['desktop_mode_chromeless'] = '1';
+		$user_id                         = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, 'wp_desktop_mode', '1' );
+	}
+
+	/**
+	 * Simulate Divi's registration shape, fire the compat hook,
+	 * and assert the deps were extended.
+	 */
+	public function test_injects_missing_wp_editor_and_wp_data_deps() {
+		wp_register_script(
+			'et-builder-gutenberg',
+			'https://example.test/divi-gutenberg.js',
+			array( 'jquery', 'wp-hooks' ),
+			'5.5.2',
+			true
+		);
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		$deps = wp_scripts()->registered['et-builder-gutenberg']->deps;
+
+		$this->assertContains( 'wp-data', $deps, 'wp-data must be injected so core/editor store registers first.' );
+		$this->assertContains( 'wp-editor', $deps, 'wp-editor must be injected so the data store is populated before Divi runs.' );
+		// Original deps survive the merge.
+		$this->assertContains( 'jquery', $deps );
+		$this->assertContains( 'wp-hooks', $deps );
+	}
+
+	/**
+	 * Shim must be a no-op when Divi isn't installed — the script
+	 * handle simply isn't registered.
+	 */
+	public function test_no_op_when_divi_not_registered() {
+		$this->assertFalse( wp_script_is( 'et-builder-gutenberg', 'registered' ) );
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		$this->assertFalse( wp_script_is( 'et-builder-gutenberg', 'registered' ) );
+	}
+
+	/**
+	 * Idempotent: if Divi later fixes their deps upstream (or the
+	 * shim runs twice for any reason), we must not duplicate the
+	 * injected entries.
+	 */
+	public function test_does_not_duplicate_deps_when_already_present() {
+		wp_register_script(
+			'et-builder-gutenberg',
+			'https://example.test/divi-gutenberg.js',
+			array( 'jquery', 'wp-hooks', 'wp-data', 'wp-editor' ),
+			'5.5.2',
+			true
+		);
+
+		do_action( 'enqueue_block_editor_assets' );
+		do_action( 'enqueue_block_editor_assets' );
+
+		$deps = wp_scripts()->registered['et-builder-gutenberg']->deps;
+
+		$this->assertSame( 1, count( array_keys( $deps, 'wp-data', true ) ) );
+		$this->assertSame( 1, count( array_keys( $deps, 'wp-editor', true ) ) );
+	}
+
+	/**
+	 * Inside a chromeless iframe, we must append an inline `before`
+	 * script that re-points `window.et_gb` at the iframe's own
+	 * window. Divi's webpack externals resolve `@wordpress/data`
+	 * via `window.et_gb.wp.data`, and Divi's own inline `before`
+	 * sets `et_gb = window.top` — which is our desktop shell, a
+	 * different document. We must override that assignment.
+	 */
+	public function test_chromeless_request_appends_et_gb_window_override() {
+		$this->force_chromeless();
+		wp_register_script(
+			'et-builder-gutenberg',
+			'https://example.test/divi-gutenberg.js',
+			array( 'jquery', 'wp-hooks' ),
+			'5.5.2',
+			true
+		);
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		$before_inlines = (array) wp_scripts()->get_data( 'et-builder-gutenberg', 'before' );
+		$joined         = implode( "\n", $before_inlines );
+
+		$this->assertStringContainsString( 'window.et_gb = window;', $joined );
+	}
+
+	/**
+	 * In classic (non-chromeless) requests we must NOT override
+	 * `window.et_gb` — Divi's original logic correctly points it at
+	 * `window.top` for the Cypress-iframe case and at `window` for
+	 * top-level page loads. Our override would clobber that.
+	 */
+	public function test_classic_request_does_not_append_et_gb_override() {
+		// Ensure the chromeless query flag is not set; current user has no desktop meta.
+		wp_set_current_user( 0 );
+		wp_register_script(
+			'et-builder-gutenberg',
+			'https://example.test/divi-gutenberg.js',
+			array( 'jquery', 'wp-hooks' ),
+			'5.5.2',
+			true
+		);
+
+		do_action( 'enqueue_block_editor_assets' );
+
+		$before_inlines = (array) wp_scripts()->get_data( 'et-builder-gutenberg', 'before' );
+		$joined         = implode( "\n", $before_inlines );
+
+		$this->assertStringNotContainsString( 'window.et_gb = window;', $joined );
+	}
+}

--- a/tests/phpunit/tests/diviCompat.php
+++ b/tests/phpunit/tests/diviCompat.php
@@ -19,23 +19,28 @@
  */
 class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 
+	private $chromeless_user_id = 0;
+
 	public function tear_down() {
 		wp_deregister_script( 'et-builder-gutenberg' );
-		unset( $_GET['desktop_mode_chromeless'] );
+		unset( $_GET['desktop_mode_chromeless'], $_GET['app_window'] );
+		if ( $this->chromeless_user_id > 0 ) {
+			delete_user_meta( $this->chromeless_user_id, 'desktop_mode_mode' );
+			$this->chromeless_user_id = 0;
+		}
 		parent::tear_down();
 	}
 
 	/**
 	 * Helper: simulate a chromeless request by priming the query
 	 * arg + user meta that `desktop_mode_is_chromeless_request()`
-	 * checks. Caller is responsible for unsetting state in
-	 * `tear_down`.
+	 * checks. `tear_down()` resets the state.
 	 */
 	private function force_chromeless() {
 		$_GET['desktop_mode_chromeless'] = '1';
-		$user_id                         = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $user_id );
-		update_user_meta( $user_id, 'wp_desktop_mode', '1' );
+		$this->chromeless_user_id        = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
 	}
 
 	/**
@@ -146,5 +151,283 @@ class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 		$joined         = implode( "\n", $before_inlines );
 
 		$this->assertStringNotContainsString( 'window.et_gb = window;', $joined );
+	}
+
+	/**
+	 * Helper: capture output of the wp_head-side VB signal function.
+	 */
+	private function capture_vb_signal_output() {
+		ob_start();
+		desktop_mode_compat_divi_vb_iframe_signal();
+		return ob_get_clean();
+	}
+
+	/**
+	 * Front-end (`! is_admin()`) with a desktop-mode-enabled user
+	 * must emit the inline script that conditionally sets
+	 * `__Cypress__` on the parent shell.
+	 */
+	public function test_vb_iframe_signal_emits_on_front_end_for_desktop_user() {
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+
+		$out = $this->capture_vb_signal_output();
+
+		$this->assertStringContainsString( 'desktop-mode-compat-divi-vb', $out );
+		$this->assertStringContainsString( '__Cypress__', $out );
+		$this->assertStringContainsString( 'window.top === window', $out );
+	}
+
+	/**
+	 * Guard: the inline script must NOT be emitted on admin
+	 * requests — admin uses the `et_gb` path; emitting both would
+	 * confuse the Divi block-editor bundle that doesn't expect a
+	 * Cypress flag on the shell.
+	 */
+	public function test_vb_iframe_signal_skips_admin_requests() {
+		set_current_screen( 'edit-post' ); // primes is_admin() to true
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+
+		$out = $this->capture_vb_signal_output();
+		set_current_screen( 'front' );
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * Guard: no output for visitors who don't have desktop mode
+	 * enabled. The shim only matters when our shell is what
+	 * `window.top` points at.
+	 */
+	public function test_vb_iframe_signal_skips_when_desktop_mode_disabled() {
+		wp_set_current_user( 0 );
+
+		$out = $this->capture_vb_signal_output();
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * The VB-top frame (no `app_window` flag) is what hosts the
+	 * visible preloader. The emitted script MUST include the bridge
+	 * logic — MutationObserver hook on `#et-vb-app-frame` plus the
+	 * 30-second watchdog timeout — so the preloader gets stripped
+	 * once Divi's React app de-classes the inner frame.
+	 */
+	public function test_vb_top_frame_emits_preloader_bridge() {
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		// Default request — no `app_window=1`, so this IS the VB-top.
+
+		$out = $this->capture_vb_signal_output();
+
+		$this->assertStringContainsString( '__Cypress__', $out );
+		$this->assertStringContainsString( 'et-vb-app-frame', $out );
+		$this->assertStringContainsString( 'et-fb-page-preloading', $out );
+		$this->assertStringContainsString( 'MutationObserver', $out );
+	}
+
+	/**
+	 * The inner app-frame (Divi sets `app_window=1` on the URL when
+	 * it spawns its inner iframe) must NOT carry the bridge — only
+	 * the `__Cypress__` signal. The bridge runs in the outer frame;
+	 * emitting it in the inner one would set up a MutationObserver
+	 * watching its own self via `getElementById( 'et-vb-app-frame' )`,
+	 * which doesn't exist in the inner doc and is wasted work.
+	 */
+	public function test_inner_app_frame_skips_preloader_bridge() {
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$_GET['app_window'] = '1';
+
+		$out = $this->capture_vb_signal_output();
+
+		$this->assertStringContainsString( '__Cypress__', $out );
+		$this->assertStringNotContainsString( 'et-vb-app-frame', $out );
+		$this->assertStringNotContainsString( 'MutationObserver', $out );
+	}
+
+	/**
+	 * Regression: the app-frame branch must bail BEFORE setting
+	 * `__Cypress__` when `window.parent === window.top`. That's
+	 * the top-level VB flow (2-deep). If we taint window.top
+	 * there, Divi's frame-helpers picks the wrong top_window and
+	 * the inner builder iframe never finishes mounting — VB
+	 * preloader hangs forever for users on top-level Divi with
+	 * Desktop Mode enabled but the chromeless flag stripped.
+	 *
+	 * Pin the bail guard so the bug can't regress.
+	 */
+	public function test_inner_app_frame_bails_when_parent_equals_top() {
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$_GET['app_window'] = '1';
+
+		$out = $this->capture_vb_signal_output();
+
+		// The guard must appear BEFORE the __Cypress__ assignment.
+		$guardPos   = strpos( $out, 'window.parent === window.top' );
+		$cypressPos = strpos( $out, '__Cypress__ = window.top.__Cypress__' );
+		$this->assertNotFalse( $guardPos, 'parent-equals-top guard must be present in the app-frame branch.' );
+		$this->assertNotFalse( $cypressPos );
+		$this->assertLessThan( $cypressPos, $guardPos, 'Guard must precede the __Cypress__ assignment so 2-deep top-level VB bails first.' );
+	}
+
+	/**
+	 * Helper: prime "Divi is active" by switching the stylesheet
+	 * and template options to "Divi" and clearing the theme cache.
+	 */
+	private function activate_divi_theme() {
+		update_option( 'stylesheet', 'Divi' );
+		update_option( 'template', 'Divi' );
+		wp_clean_themes_cache();
+	}
+
+	private function capture_iframe_patch_output() {
+		ob_start();
+		desktop_mode_compat_divi_eject_iframe_patch();
+		return ob_get_clean();
+	}
+
+	private function capture_parent_listener_output() {
+		ob_start();
+		desktop_mode_compat_divi_eject_parent_listener();
+		return ob_get_clean();
+	}
+
+	/**
+	 * Iframe-side hijack: emitted only inside chromeless requests
+	 * for users on Divi. The script must install a capture-phase
+	 * click listener that matches by VB button text and emit our
+	 * `desktop-mode-divi-vb-handoff` message.
+	 */
+	public function test_iframe_patch_emits_in_chromeless_for_divi() {
+		$this->force_chromeless();
+		$this->activate_divi_theme();
+
+		$out = $this->capture_iframe_patch_output();
+
+		$this->assertStringContainsString( 'desktop-mode-compat-divi-vb-handoff', $out );
+		$this->assertStringContainsString( 'desktop-mode-divi-vb-handoff', $out );
+		// Button-text matcher — the load-bearing detection.
+		$this->assertStringContainsString( 'use divi builder', $out );
+		$this->assertStringContainsString( 'edit with the divi builder', $out );
+		// Capture-phase click listener that wraps the matcher.
+		$this->assertStringContainsString( "addEventListener( 'click'", $out );
+	}
+
+	/**
+	 * Outside chromeless requests there's nothing to intercept —
+	 * the parent shell loads its own navigation, not a Divi iframe.
+	 */
+	public function test_iframe_patch_skips_when_not_chromeless() {
+		wp_set_current_user( 0 );
+		$this->activate_divi_theme();
+
+		$out = $this->capture_iframe_patch_output();
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * On non-Divi sites the patcher would never match its URL
+	 * pattern, so we save the script weight entirely.
+	 */
+	public function test_iframe_patch_skips_without_divi() {
+		$this->force_chromeless();
+		// No theme activation — default test theme is whatever
+		// the harness ships (twentytwentyfive in this environment).
+
+		$out = $this->capture_iframe_patch_output();
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * Parent-shell listener: emitted on the shell admin page when
+	 * desktop mode is on, the request is not chromeless / classic,
+	 * AND Divi is active. Listens for the message and navigates
+	 * `window.top.location.href` to the URL.
+	 */
+	public function test_parent_listener_emits_on_shell_for_divi() {
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$this->activate_divi_theme();
+
+		$out = $this->capture_parent_listener_output();
+
+		$this->assertStringContainsString( 'desktop-mode-compat-divi-vb-handoff-parent', $out );
+		$this->assertStringContainsString( 'desktop-mode-divi-vb-handoff', $out );
+		$this->assertStringContainsString( 'window.top.location.href', $out );
+		// Origin guard prevents foreign frames from triggering nav.
+		$this->assertStringContainsString( 'ev.origin !== window.location.origin', $out );
+		// Confirm dialog is the load-bearing UX explicit step.
+		$this->assertStringContainsString( 'wp.desktop.confirm', $out );
+		$this->assertStringContainsString( 'Open in standalone tab', $out );
+		// URL transform: strip chromeless flag, add classic flag.
+		// Without this, top-level navigation hits the iframe URL's
+		// `desktop_mode_chromeless=1` and renders headless again.
+		$this->assertStringContainsString( "searchParams.delete( 'desktop_mode_chromeless' )", $out );
+		$this->assertStringContainsString( "searchParams.set( 'desktop_mode_classic', '1' )", $out );
+	}
+
+	/**
+	 * In a chromeless request we must NOT emit the parent listener
+	 * — there's no parent shell at that level.
+	 */
+	public function test_parent_listener_skips_in_chromeless_request() {
+		$this->force_chromeless();
+		$this->activate_divi_theme();
+
+		$out = $this->capture_parent_listener_output();
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * Visitors without desktop mode enabled get nothing.
+	 */
+	public function test_parent_listener_skips_when_desktop_mode_disabled() {
+		wp_set_current_user( 0 );
+		$this->activate_divi_theme();
+
+		$out = $this->capture_parent_listener_output();
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * Non-Divi sites get nothing — the listener would never fire.
+	 */
+	public function test_parent_listener_skips_without_divi() {
+		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->chromeless_user_id );
+		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+
+		$out = $this->capture_parent_listener_output();
+
+		$this->assertSame( '', trim( $out ) );
+	}
+
+	/**
+	 * Divi-active detector: Divi theme.
+	 */
+	public function test_is_active_true_for_divi_theme() {
+		$this->activate_divi_theme();
+		$this->assertTrue( desktop_mode_compat_divi_is_active() );
+	}
+
+	/**
+	 * Divi-active detector: arbitrary other theme.
+	 */
+	public function test_is_active_false_for_other_theme() {
+		$this->assertFalse( desktop_mode_compat_divi_is_active() );
 	}
 }

--- a/tests/phpunit/tests/diviCompat.php
+++ b/tests/phpunit/tests/diviCompat.php
@@ -370,7 +370,11 @@ class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'ev.origin !== window.location.origin', $out );
 		// Confirm dialog is the load-bearing UX explicit step.
 		$this->assertStringContainsString( 'wp.desktop.confirm', $out );
-		$this->assertStringContainsString( 'Open in standalone tab', $out );
+		$this->assertStringContainsString( 'Open Divi in this tab', $out );
+		// No "stay" button — the dialog explains there is no other
+		// path and offers only Open + an X to dismiss.
+		$this->assertStringContainsString( 'hideCancel: true', $out );
+		$this->assertStringContainsString( 'dismissable: true', $out );
 		// URL transform: strip chromeless flag, add classic flag.
 		// Without this, top-level navigation hits the iframe URL's
 		// `desktop_mode_chromeless=1` and renders headless again.

--- a/tests/phpunit/tests/diviCompat.php
+++ b/tests/phpunit/tests/diviCompat.php
@@ -171,6 +171,7 @@ class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->chromeless_user_id );
 		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$this->activate_divi_theme();
 
 		$out = $this->capture_vb_signal_output();
 
@@ -221,6 +222,7 @@ class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->chromeless_user_id );
 		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$this->activate_divi_theme();
 		// Default request — no `app_window=1`, so this IS the VB-top.
 
 		$out = $this->capture_vb_signal_output();
@@ -243,6 +245,7 @@ class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->chromeless_user_id );
 		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$this->activate_divi_theme();
 		$_GET['app_window'] = '1';
 
 		$out = $this->capture_vb_signal_output();
@@ -267,6 +270,7 @@ class Tests_DesktopMode_DiviCompat extends WP_UnitTestCase {
 		$this->chromeless_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->chromeless_user_id );
 		update_user_meta( $this->chromeless_user_id, 'desktop_mode_mode', '1' );
+		$this->activate_divi_theme();
 		$_GET['app_window'] = '1';
 
 		$out = $this->capture_vb_signal_output();


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/doesnt-work-with-divi-19/

<img width="1337" height="903" alt="image" src="https://github.com/user-attachments/assets/0157211f-a544-4fc9-afff-963c16e3c6e5" />

<img width="1379" height="886" alt="image" src="https://github.com/user-attachments/assets/0598803d-431c-48d3-892d-f16d56a66bff" />


<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-244-74f06e904d61e4cabd90b3086a9a8c034dccbf5c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->