### PR TITLE
fix(dock): light indicators for native-window-target dock icons (#235)

### DIFF
--- a/src/dock.ts
+++ b/src/dock.ts
@@ -95,6 +95,19 @@ export interface DockItem {
 	icon: string;
 	/** Admin page URL to open. */
 	url: string;
+	/**
+	 * Native-window id this tile targets, when known up front.
+	 * Populated for synthesized tiles built from a
+	 * `desktop_mode_register_icon()` entry whose `window` field points
+	 * at a registered native window (no `url`). The dock prefers this
+	 * over deriving an id from `url` for indicator + hover-peek
+	 * lookups — without it those synth tiles fall back to
+	 * `deriveWindowId('')` and never match the open window, so the
+	 * active/focused dot stays dark.
+	 *
+	 * @since 0.8.6
+	 */
+	windowId?: string;
 	/** Number badge (update count, comment count, etc.). 0 = no badge. */
 	badge: number;
 	/** Submenu items. */
@@ -948,8 +961,7 @@ export class Dock {
 		// lookup, hovering the Posts tile finds no instances and
 		// the peek card never appears even when the native window
 		// is open.
-		const remappedId = resolveNativeUrlRemap( item.url );
-		const baseId = remappedId ?? this.deriveWindowId( item.url );
+		const baseId = this.resolveItemBaseId( item );
 		const teardown = attachDockPeek( {
 			tile,
 			item: {
@@ -1816,6 +1828,32 @@ export class Dock {
 	}
 
 	/**
+	 * Resolve the window-manager key for a dock tile, in this order:
+	 *
+	 * 1. `item.windowId` — set by `applyDockPlacement` when the tile
+	 *    is synthesized from a `desktop_mode_register_icon()` entry
+	 *    whose target is a native window. Native-window ids never
+	 *    pass through the URL → native-window remap layer, so we
+	 *    short-circuit before touching it.
+	 * 2. {@link resolveNativeUrlRemap} on `item.url` — captures the
+	 *    `nativePostsEnabled` / `nativePagesEnabled` opt-ins that
+	 *    repoint a URL-based tile at a native window.
+	 * 3. {@link deriveWindowId} on `item.url` — the URL-based
+	 *    fallback for ordinary admin-menu tiles.
+	 *
+	 * Shared by the hover-peek card and the active/focused-dot
+	 * indicator; the two stayed in lockstep before this method existed
+	 * by hand-rolling the same chain at each call site.
+	 */
+	private resolveItemBaseId( item: DockItem ): string {
+		if ( item.windowId ) {
+			return item.windowId;
+		}
+		const remapped = resolveNativeUrlRemap( item.url );
+		return remapped ?? this.deriveWindowId( item.url );
+	}
+
+	/**
 	 * Listen to window events to update active/focused indicators on dock items.
 	 *
 	 * The event detail isn't used — we just need to re-query the
@@ -1920,16 +1958,7 @@ export class Dock {
 				continue;
 			}
 
-			// When a URL → native-window remap is currently active for
-			// this tile (e.g. the Posts dock tile under the
-			// `nativePostsEnabled` opt-in), the dock should track the
-			// native window's id, NOT the iframe slug derived from the
-			// URL. Otherwise the user opens "Posts" via the dock, the
-			// remap routes to `desktop-mode-posts`, and the dock keeps
-			// looking up `wp-window-edit-php` — finds nothing — and
-			// the tile never lights up.
-			const remappedId = resolveNativeUrlRemap( item.url );
-			const baseId = remappedId ?? this.deriveWindowId( item.url );
+			const baseId = this.resolveItemBaseId( item );
 			const instances = item.multi
 				? this.windowManager
 					.getAllByBaseId( baseId )

--- a/src/settings/item-placement.ts
+++ b/src/settings/item-placement.ts
@@ -161,6 +161,13 @@ export function applyDockPlacement(
 			title: icon.title,
 			icon: icon.icon,
 			url: icon.url || '',
+			// Carry the native-window id forward so the dock can light
+			// the active-dot indicator + show the hover-peek card when
+			// the target window is open. Without this, window-target
+			// icons (no `url`) synthesize a tile whose only id-bearing
+			// field is an empty string — deriveWindowId('') matches
+			// nothing the window manager has stored.
+			windowId: icon.window || undefined,
 			badge: 0,
 			submenu: [],
 			isCore: false,

--- a/tests/vitest/item-visibility-flow.test.ts
+++ b/tests/vitest/item-visibility-flow.test.ts
@@ -68,4 +68,55 @@ describe( 'item visibility — hide from dock', () => {
 	test( 'resolvePlacement falls back to nativeRail when no override', () => {
 		expect( resolvePlacement( 'woocommerce', 'dock', {} ) ).toBe( 'dock' );
 	} );
+
+	test( 'window-target icon promoted to dock carries windowId for indicator lookups', () => {
+		const out = applyDockPlacement(
+			[],
+			[
+				{
+					id: 'desktop-mode-my-wordpress',
+					title: 'My WordPress',
+					icon: 'dashicons-wordpress',
+					window: 'desktop-mode-my-wordpress',
+					url: '',
+					position: -1,
+				},
+			],
+			{
+				itemVisibility: { 'desktop-mode-my-wordpress': 'dock' },
+				dockOrder: [],
+			},
+		);
+		const synth = out.find(
+			( i ) => i.id === 'dock:desktop-mode-my-wordpress',
+		);
+		expect( synth ).toBeDefined();
+		expect( synth?.url ).toBe( '' );
+		expect( synth?.windowId ).toBe( 'desktop-mode-my-wordpress' );
+	} );
+
+	test( 'url-target icon promoted to dock leaves windowId unset', () => {
+		const out = applyDockPlacement(
+			[],
+			[
+				{
+					id: 'external-shortcut',
+					title: 'Docs',
+					icon: 'dashicons-book',
+					window: '',
+					url: 'https://example.com/docs',
+					position: 1,
+				},
+			],
+			{
+				itemVisibility: { 'external-shortcut': 'dock' },
+				dockOrder: [],
+			},
+		);
+		const synth = out.find(
+			( i ) => i.id === 'dock:external-shortcut',
+		);
+		expect( synth ).toBeDefined();
+		expect( synth?.windowId ).toBeUndefined();
+	} );
 } );


### PR DESCRIPTION
## Summary

Closes #235.

When a desktop icon registered with `'window' => '<native-id>'` (no `url`) is promoted to the dock via `itemVisibility` (`'dock'` or `'both'`), `applyDockPlacement` synthesized a `DockItem` with `url: ''`. The dock's active/focused indicator and hover-peek both keyed off `deriveWindowId(item.url)` — on an empty URL that produces a baseId that never matches the open native window's id (e.g. `desktop-mode-my-wordpress`). Result: the dot stayed dark and the peek card never appeared, both for fresh opens and after session restore.

<img width="3200" height="2364" alt="CleanShot 2026-05-19 at 12 28 16@2x" src="https://github.com/user-attachments/assets/0361440d-cc2c-4bd4-9a83-d610247a272f" />



## Fix

- `src/dock.ts` — added optional `windowId?: string` on `DockItem`; introduced `resolveItemBaseId()` which prefers `windowId`, then `resolveNativeUrlRemap(item.url)`, then `deriveWindowId(item.url)`. The active-state pass and the hover-peek baseId now both route through it, so they stay in lockstep.
- `src/settings/item-placement.ts` — synthesized dock tiles carry `windowId: icon.window || undefined` so the dock has a direct key into the window manager for native-window targets.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:js` — 1441 passing (+2 new cases in `item-visibility-flow.test.ts`: synth-from-window-icon carries `windowId`; synth-from-url-icon leaves it undefined)
- [x] `npm run build` — clean
- [x] Manually verified in local wordpress-develop: My WordPress (placed on dock) now lights its active dot when open + focused indicator when frontmost; same behavior after session restore.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-245-4ac321ad2e0eb9e780eead0d488f43588c3d53f5.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->