### PR TITLE
fix(dock): open off-site menu items in a new browser tab

### DIFF
--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -35,6 +35,7 @@
  */
 
 import { activity } from './activity';
+import { tryOpenExternalUrl } from './external-url';
 import { __, _n, sprintf } from './i18n';
 import { doAction, HOOKS } from './hooks';
 import { renderIcon } from './icon';
@@ -510,15 +511,11 @@ function openTarget(
 		return;
 	}
 	if ( entry.url ) {
+		if ( tryOpenExternalUrl( entry.url ) ) {
+			return;
+		}
 		try {
 			const parsed = new URL( entry.url, window.location.origin );
-			if ( parsed.origin !== window.location.origin ) {
-				// Off-site URL — open in a fresh tab with
-				// noopener/noreferrer.
-				window.open( parsed.toString(), '_blank', 'noopener,noreferrer' );
-				return;
-			}
-			// Same-origin admin URL — open as an iframe window.
 			void deps.manager.open( {
 				id: `desktop-icon-${ entry.id }`,
 				url: parsed.toString(),

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -16,6 +16,7 @@ import { deriveWindowId } from './utils';
 import { __, _n, sprintf } from './i18n';
 import { hashTitleToHue } from './ui/util/hash-hue';
 import { attachDockPeek } from './dock-peek';
+import { tryOpenExternalUrl } from './external-url';
 import { openItemVisibilityMenu } from './item-visibility-menu';
 import {
 	resolveNativeUrlRemap,
@@ -1728,6 +1729,9 @@ export class Dock {
 				return;
 			}
 			if ( icon?.url ) {
+				if ( tryOpenExternalUrl( icon.url ) ) {
+					return;
+				}
 				const baseId = this.deriveWindowId( icon.url );
 				this.windowManager.open( {
 					id: baseId,
@@ -1743,6 +1747,16 @@ export class Dock {
 				} );
 				return;
 			}
+			return;
+		}
+
+		// Off-site admin menu entries (e.g. WordPress.com's "Hosting"
+		// link, which points at `wordpress.com/hosting/<site>` from a
+		// wpcomstaging.com wp-admin) can't be iframed — the chromeless
+		// guard returns null for cross-origin URLs and the iframe lands
+		// on `about:blank`. Send those to a new browser tab instead,
+		// mirroring what classic admin does for the same item.
+		if ( tryOpenExternalUrl( item.url ) ) {
 			return;
 		}
 
@@ -1776,6 +1790,13 @@ export class Dock {
 	 * windows of Posts is the explicit ask — that's what + is for.
 	 */
 	private openNewInstance( item: DockItem ): void {
+		// "+" on an off-site tile means the same thing the primary
+		// click does — open a fresh browser tab. Iframing a cross-
+		// origin URL would land on `about:blank` (see openPage).
+		if ( tryOpenExternalUrl( item.url ) ) {
+			return;
+		}
+
 		// If the item's URL is claimed by a native-window remap (Posts,
 		// Pages, Users, Comments, Plugins, …), spawn a fresh native
 		// instance via the registry — same path as the regular dock

--- a/src/external-url.test.ts
+++ b/src/external-url.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the cross-origin URL opener helper. Covers the dock-click
+ * / desktop-icon failure mode that surfaced on WordPress.com — admin
+ * menu entries like "Hosting" and "Upgrades" point at
+ * `wordpress.com/...` URLs cross-origin to the wp-admin host, and used
+ * to land the iframe on `about:blank`.
+ *
+ * The helper compares against `window.location.origin`, so the tests
+ * run with jsdom's default origin (`http://localhost`) and use that
+ * value where they need a same-origin URL.
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { tryOpenExternalUrl } from './external-url';
+
+const originalOpen = window.open;
+const SAME_ORIGIN = window.location.origin;
+
+afterEach( () => {
+	window.open = originalOpen;
+	vi.restoreAllMocks();
+} );
+
+describe( 'tryOpenExternalUrl', () => {
+	test( 'returns false for same-origin absolute URLs', () => {
+		const spy = vi.fn();
+		window.open = spy as unknown as typeof window.open;
+		expect(
+			tryOpenExternalUrl( `${ SAME_ORIGIN }/wp-admin/edit.php` ),
+		).toBe( false );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'returns false for relative URLs', () => {
+		const spy = vi.fn();
+		window.open = spy as unknown as typeof window.open;
+		expect( tryOpenExternalUrl( 'edit.php' ) ).toBe( false );
+		expect( tryOpenExternalUrl( '/wp-admin/upload.php' ) ).toBe(
+			false,
+		);
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'opens cross-origin URLs in a new tab and returns true', () => {
+		const spy = vi.fn();
+		window.open = spy as unknown as typeof window.open;
+		expect(
+			tryOpenExternalUrl( 'https://wordpress.com/hosting/foo' ),
+		).toBe( true );
+		expect( spy ).toHaveBeenCalledWith(
+			'https://wordpress.com/hosting/foo',
+			'_blank',
+			'noopener,noreferrer',
+		);
+	} );
+
+	test( 'opens different-host URLs in a new tab (regression for WP.com)', () => {
+		const spy = vi.fn();
+		window.open = spy as unknown as typeof window.open;
+		// The bug shipped on every wpcomstaging.com wp-admin: the
+		// admin menu items WP.com injects ("Hosting", "Upgrades") point
+		// at `https://wordpress.com/...` URLs, which are cross-origin to
+		// the wp-admin host. The dock's iframe path's same-origin
+		// guard (`withChromelessParam`) returned null, and the iframe
+		// fell through to `about:blank`. Helper now intercepts.
+		expect(
+			tryOpenExternalUrl( 'https://wordpress.com/plans/foo' ),
+		).toBe( true );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'returns false for unparseable URLs', () => {
+		const spy = vi.fn();
+		window.open = spy as unknown as typeof window.open;
+		// `new URL('://broken', base)` throws — the helper swallows
+		// the error and lets the caller fall through to its own
+		// error path (the iframe opener) rather than silently
+		// short-circuiting.
+		expect( tryOpenExternalUrl( '://broken' ) ).toBe( false );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/external-url.ts
+++ b/src/external-url.ts
@@ -1,0 +1,45 @@
+/**
+ * If `url` points off-site relative to the current shell origin, open
+ * it in a fresh browser tab with `noopener,noreferrer` and return
+ * `true`. Returns `false` for same-origin URLs (the caller falls
+ * through to its iframe / native-window opener) and for unparseable
+ * URLs (the caller's own error path handles those).
+ *
+ * Used by every opener the user can trigger from the desktop shell —
+ * dock click, dock peek "+" card, desktop icon double-click — because
+ * an off-site URL routed into the iframe path would either:
+ *
+ *   1. Get rejected by `withChromelessParam()` (same-origin gate) and
+ *      land the iframe on `about:blank` with no affordance for the user
+ *      to recover. This is the failure mode that surfaced on
+ *      WordPress.com, where the admin menu's "Hosting" entry points at
+ *      `https://wordpress.com/hosting/<site>` — a different origin from
+ *      the wp-admin host — and the user saw a blank window.
+ *
+ *   2. Load successfully but be refused by the remote origin's
+ *      `X-Frame-Options` / CSP `frame-ancestors` header (every modern
+ *      first-party portal sets one). The user would see a load error
+ *      inside the iframe with no native browser UI for retry / open-
+ *      in-new-tab.
+ *
+ * Routing off-site URLs straight to a new browser tab matches what
+ * classic admin does when the same menu item is clicked (the WP.com
+ * admin bar uses `target="_blank"` for `wordpress.com` links).
+ *
+ * @since 0.8.7
+ *
+ * @param url Candidate URL — may be a bare path, a slug, or a full URL.
+ * @return true if a new tab was opened, false otherwise.
+ */
+export function tryOpenExternalUrl( url: string ): boolean {
+	try {
+		const parsed = new URL( url, window.location.origin );
+		if ( parsed.origin === window.location.origin ) {
+			return false;
+		}
+		window.open( parsed.toString(), '_blank', 'noopener,noreferrer' );
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

- WordPress.com injects admin menu items (**Hosting**, **Upgrades**, …) that point at `https://wordpress.com/...` URLs — cross-origin to the wpcomstaging.com wp-admin host. Clicking those dock tiles produced a blank window.
- Root cause: `withChromelessParam()` (`src/window/dom.ts:76-83`) returns `null` for cross-origin URLs, and the iframe at `src/window/dom.ts:548` then falls back to `about:blank`. The dock click path never filtered for off-site URLs.
- Fix: add a shared `tryOpenExternalUrl()` helper and call it from every opener path the user can reach from the shell. Cross-origin URLs open in a new browser tab (`_blank`, `noopener,noreferrer`); same-origin URLs are unchanged.

## What changed

- `src/external-url.ts` — new shared helper.
- `src/external-url.test.ts` — 5 unit tests covering same-origin / relative / cross-origin / unparseable URLs.
- `src/dock.ts` — call helper from `openPage` (primary click), `openNewInstance` (peek `+` card), and the `dock:` desktop-icon branch.
- `src/desktop-icons.ts` — refactor the inline cross-origin check to use the shared helper (no behavior change here, just dedup).

The check is generic — no WP.com-specific patterns — so any plugin that registers an off-site admin link (Jetpack Cloud, Akismet portals, etc.) gets the same handling.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:js` — 1444/1444 passing (5 new tests for `tryOpenExternalUrl`)
- [x] `npm run build` — clean
- [x] Reproduced on local dev with a fake WP.com-style menu item (`add_menu_page( …, 'https://example.com/foo', … )`) — tile opens the URL in a new tab; same-origin tiles still open as iframe windows.
- [x] Verified by reporter on a WP.com staging site (Hosting + Upgrades) — both open in a new tab.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-247-660de59eeb33273989a60f01f7f9c181bb614b03.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->