### PR TITLE
refactor(dock): clarify comments on `hide-if-no-customize` behavior a…

### DIFF
--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -108,14 +108,12 @@ function desktop_mode_build_dock_items() {
 				if ( ! empty( $sub_item[1] ) && ! current_user_can( $sub_item[1] ) ) {
 					continue;
 				}
-				// Note on `hide-if-no-customize` (issue #241): WordPress
-				// tags Appearance → Customize / Header / Background with
-				// this class. The semantics are "shown by default; hide
-				// only when `<body class="no-customize-support">`." The
+				// No `hide-if-no-customize` filter here. WordPress tags
+				// Appearance → Customize / Header / Background with that
+				// class; the semantics are "shown by default; hide only
+				// when `<body class=\"no-customize-support\">`". The
 				// Customizer is supported inside chromeless iframes, so
-				// these entries belong in the dock. (Earlier revisions
-				// stripped them — that read the class as "always hide"
-				// and dropped the only entry point to Additional CSS.)
+				// these entries belong in the dock.
 				$sub_url = desktop_mode_menu_item_url( $sub_item[2] );
 				// Capture the first capability-passing submenu URL so
 				// we can use it as the parent's effective URL below

--- a/src/ui/components/wpd-table/wpd-table.test.ts
+++ b/src/ui/components/wpd-table/wpd-table.test.ts
@@ -402,11 +402,6 @@ describe( '<wpd-table>', () => {
 	} );
 
 	test( 'toggling a row checkbox does NOT rebuild tbody children', async () => {
-		// Repro: in the native Plugins window, clicking a row checkbox
-		// rebuilt the whole tbody, dropping focus from the just-clicked
-		// checkbox and (with scroll-anchoring giving up on the transient
-		// empty body) snapping the scroll back to the top. Pin the new
-		// behavior: row identity is preserved across a selection toggle.
 		host.innerHTML = `<wpd-table selectable="multi"></wpd-table>`;
 		await tick();
 		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;

--- a/src/ui/components/wpd-table/wpd-table.ts
+++ b/src/ui/components/wpd-table/wpd-table.ts
@@ -545,10 +545,9 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 	 * Selection mutators (`select` / `deselect` / `selectAll` /
 	 * `clearSelection`) update the affected row in place via
 	 * {@link _syncSelectionDom} rather than re-rendering the whole
-	 * tbody. The rebuild path destroyed the focused checkbox the user
-	 * just clicked — focus fell to `<body>` and, when paint coincided
-	 * with the transient empty-tbody window, scroll-anchoring gave up
-	 * and snapped the table back to the top (GH#164).
+	 * tbody — a rebuild would tear down the focused checkbox and
+	 * (because scroll-anchoring abandons a momentarily empty container)
+	 * could snap scroll back to the top.
 	 */
 	select( id: WpdTableRowId ): void {
 		if ( this._selection.has( id ) ) {
@@ -601,12 +600,6 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 	 * rebuilding it. Updates each affected row's `is-selected` class
 	 * and `select-row-checkbox` `checked` state, then re-syncs the
 	 * header select-all checkbox (checked / indeterminate / empty).
-	 *
-	 * Called from {@link select}, {@link deselect}, {@link selectAll},
-	 * and {@link clearSelection}. The rebuild path used to flow
-	 * through `_schedulePaint` → `_paintBody` → `tbody.replaceChildren`,
-	 * which tore down the focused checkbox + transiently emptied the
-	 * scroll container; both symptoms in GH#164.
 	 *
 	 * @param ids `'all'` to walk every row, or an iterable of row ids
 	 *            whose rows need updating. Unknown ids are silently
@@ -1313,10 +1306,6 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 		tr.setAttribute( 'part', 'row' );
 		tr.dataset.rowIndex = String( rowIndex );
 		const id = this._getRowId( row, rowIndex );
-		// Stamp the row id so {@link _syncSelectionDom} can find this
-		// row without rebuilding the body. `String(id)` matches the
-		// dataset round-trip; the original id type (number | string)
-		// is recovered at lookup time from the live data array.
 		tr.dataset.rowId = String( id );
 		if ( this._selection.has( id ) ) {
 			tr.classList.add( 'is-selected' );

--- a/tests/phpunit/tests/desktopModeBuildDockItems.php
+++ b/tests/phpunit/tests/desktopModeBuildDockItems.php
@@ -228,13 +228,11 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Issue #241 regression — entries tagged `hide-if-no-customize`
-	 * must remain in the dock.
+	 * Entries tagged `hide-if-no-customize` must remain in the dock.
 	 *
 	 * Core stamps Appearance → Customize / Header / Background with
 	 * that class. It means "shown by default; hide only on
-	 * `<body class=\"no-customize-support\">`" — the inverse of what
-	 * an earlier revision of this builder assumed. The Customizer is
+	 * `<body class=\"no-customize-support\">`". The Customizer is
 	 * supported inside chromeless iframes, so the entry must stay in
 	 * the submenu; without it the user has no path from the dock to
 	 * the Additional CSS editor.
@@ -252,7 +250,7 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 
 		$titles = wp_list_pluck( $items[0]['submenu'], 'title' );
 		$this->assertNotContains( 'Themes', $titles ); // self-link strip
-		$this->assertContains( 'Customize', $titles ); // the regression — must be present
+		$this->assertContains( 'Customize', $titles );
 		$this->assertContains( 'Menus', $titles );
 	}
 


### PR DESCRIPTION
This commit felt through the cracks...

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-248-e269b890304257190ca00f7ea76cfabae30abcdb.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->