### PR TITLE
Fix plugins window stale-nonce 'Cookie check failed' on long-running sessions (#250)

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -43,6 +43,7 @@ require_once DESKTOP_MODE_DIR . 'includes/assets.php';
 require_once DESKTOP_MODE_DIR . 'includes/admin-bar.php';
 require_once DESKTOP_MODE_DIR . 'includes/session.php';
 require_once DESKTOP_MODE_DIR . 'includes/presence.php';
+require_once DESKTOP_MODE_DIR . 'includes/nonce-refresh.php';
 require_once DESKTOP_MODE_DIR . 'includes/os-settings.php';
 require_once DESKTOP_MODE_DIR . 'includes/seen-intros.php';
 require_once DESKTOP_MODE_DIR . 'includes/welcome-dialog.php';

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2545,6 +2545,41 @@ See [`docs/pwa.md`](./pwa.md) for the full architecture and
 
 ---
 
+## Nonce refresh (since 0.8.7)
+
+The desktop shell is a long-running SPA whose nonces would
+otherwise go stale past WordPress's `nonce_life` (24 h). To
+prevent this, `includes/nonce-refresh.php` registers a
+`heartbeat_received` filter that ships fresh values for a fixed
+set of nonce actions on every Heartbeat tick — the client
+overwrites the cached values in `window.desktopModeConfig` and
+the per-window blobs in place.
+
+### `desktop_mode_nonce_refresh_actions` — Stable *(filter, since 0.8.7)*
+
+Filter the list of nonce-action strings the server refreshes on
+every Heartbeat tick.
+
+```php
+add_filter( 'desktop_mode_nonce_refresh_actions', function ( $actions ) {
+    $actions[] = 'my-plugin/admin-ajax';
+    return $actions;
+} );
+```
+
+- **Param** `string[] $actions` — default set: `[ 'wp_rest',
+  'desktop-mode-plugins', 'updates' ]`.
+- **Return** `string[]` — non-string / empty entries are
+  silently dropped.
+
+Each action string is passed verbatim to `wp_create_nonce()`,
+so it MUST match whatever was used to mint the original cached
+nonce. On the client side, register a `registerNonceTarget()`
+updater (`src/nonce-refresh.ts`) keyed by the same action so the
+incoming value is written to wherever your code reads from.
+
+---
+
 ## See also
 
 - [JavaScript Reference](./javascript-reference.md) — the event + postMessage side of the contract.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2574,9 +2574,10 @@ add_filter( 'desktop_mode_nonce_refresh_actions', function ( $actions ) {
 
 Each action string is passed verbatim to `wp_create_nonce()`,
 so it MUST match whatever was used to mint the original cached
-nonce. On the client side, register a `registerNonceTarget()`
-updater (`src/nonce-refresh.ts`) keyed by the same action so the
-incoming value is written to wherever your code reads from.
+nonce. On the client side, subscribe to the `desktop_mode_nonces`
+heartbeat field via
+[`wp.desktop.heartbeat.subscribe`](./javascript-reference.md#nonce-refresh--heartbeat-field-stable-since-087)
+and write the value where your code reads from.
 
 ---
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4200,6 +4200,45 @@ See [Examples — My WordPress media action](./examples/my-wordpress-media-actio
 
 ---
 
+## Nonce refresh — `registerNonceTarget()` *(Stable, since 0.8.7)*
+
+WordPress nonces expire after `nonce_life` (24 h by default). The
+desktop shell is a long-running SPA, so cached nonces stamped
+into `window.desktopModeConfig.restNonce` (auto-injected by
+`injectRestNonce`) and per-window config blobs like
+`window.desktopModeWindowConfig['desktop-mode-plugins']` would
+otherwise go stale after a day. The server's
+`heartbeat_received` filter (see
+[`desktop_mode_nonce_refresh_actions`](./hooks-reference.md#desktop_mode_nonce_refresh_actions--stable-filter-since-087))
+ships a fresh `{ action: nonce }` map on every tick under the
+`desktop_mode_nonces` heartbeat field; the client overwrites the
+cached values in place. Defaults cover `wp_rest`,
+`desktop-mode-plugins`, and `updates`.
+
+Feature modules that stash their own nonces in a per-window
+config blob can subscribe via `registerNonceTarget()`:
+
+```ts
+import { registerNonceTarget } from 'desktop-mode/nonce-refresh';
+
+registerNonceTarget( 'my-plugin/admin-ajax', ( fresh ) => {
+    window.desktopModeWindowConfig[ 'my-plugin' ].ajaxNonce = fresh;
+} );
+```
+
+The updater fires on every Heartbeat tick that carries a value
+for the registered action. Targets compose — multiple updaters
+per action are supported. The shell-wide `restNonce` and every
+per-window blob's `restNonce` are refreshed automatically by the
+framework's built-in `wp_rest` target, so most callers don't
+need to wire anything by hand.
+
+The PHP side must publish the matching action via
+[`desktop_mode_nonce_refresh_actions`](./hooks-reference.md#desktop_mode_nonce_refresh_actions--stable-filter-since-087)
+for the value to actually be shipped over heartbeat.
+
+---
+
 ## See also
 
 - [Hooks Reference](./hooks-reference.md) — the PHP side of the API.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4200,7 +4200,7 @@ See [Examples — My WordPress media action](./examples/my-wordpress-media-actio
 
 ---
 
-## Nonce refresh — `registerNonceTarget()` *(Stable, since 0.8.7)*
+## Nonce refresh — heartbeat field *(Stable, since 0.8.7)*
 
 WordPress nonces expire after `nonce_life` (24 h by default). The
 desktop shell is a long-running SPA, so cached nonces stamped
@@ -4211,31 +4211,40 @@ otherwise go stale after a day. The server's
 `heartbeat_received` filter (see
 [`desktop_mode_nonce_refresh_actions`](./hooks-reference.md#desktop_mode_nonce_refresh_actions--stable-filter-since-087))
 ships a fresh `{ action: nonce }` map on every tick under the
-`desktop_mode_nonces` heartbeat field; the client overwrites the
-cached values in place. Defaults cover `wp_rest`,
+`desktop_mode_nonces` heartbeat field; the framework overwrites
+its own cached values in place. Defaults cover `wp_rest`,
 `desktop-mode-plugins`, and `updates`.
 
-Feature modules that stash their own nonces in a per-window
-config blob can subscribe via `registerNonceTarget()`:
+**Out of the box**: the shell-wide `restNonce` and every
+per-window blob's `restNonce` are refreshed automatically — most
+plugin authors don't need to wire anything by hand.
+
+**For plugins that ship their own cached nonce** (an admin-ajax
+nonce keyed by a custom action, a private REST nonce, …): publish
+the action on PHP via
+[`desktop_mode_nonce_refresh_actions`](./hooks-reference.md#desktop_mode_nonce_refresh_actions--stable-filter-since-087),
+then subscribe to the heartbeat field and read the action key off
+the returned map:
 
 ```ts
-import { registerNonceTarget } from 'desktop-mode/nonce-refresh';
-
-registerNonceTarget( 'my-plugin/admin-ajax', ( fresh ) => {
-    window.desktopModeWindowConfig[ 'my-plugin' ].ajaxNonce = fresh;
+wp.desktop.heartbeat.subscribe( 'desktop_mode_nonces', ( nonces ) => {
+    const fresh = nonces[ 'my-plugin/admin-ajax' ];
+    if ( typeof fresh === 'string' && fresh !== '' ) {
+        window.myPluginConfig.ajaxNonce = fresh;
+    }
 } );
 ```
 
-The updater fires on every Heartbeat tick that carries a value
-for the registered action. Targets compose — multiple updaters
-per action are supported. The shell-wide `restNonce` and every
-per-window blob's `restNonce` are refreshed automatically by the
-framework's built-in `wp_rest` target, so most callers don't
-need to wire anything by hand.
+The same heartbeat surface (`wp.desktop.heartbeat.subscribe` /
+`.contribute`) is already used for presence, recycle-bin badges,
+files realtime, etc. — see the
+[heartbeat bus](#wp-desktop-heartbeat) section for the full
+contract.
 
-The PHP side must publish the matching action via
-[`desktop_mode_nonce_refresh_actions`](./hooks-reference.md#desktop_mode_nonce_refresh_actions--stable-filter-since-087)
-for the value to actually be shipped over heartbeat.
+`src/nonce-refresh.ts` ships an internal `registerNonceTarget()`
+helper used by the framework's built-in updaters, but it's not
+exposed across bundles — third-party plugins should use the
+heartbeat subscription above.
 
 ---
 

--- a/includes/nonce-refresh.php
+++ b/includes/nonce-refresh.php
@@ -89,14 +89,17 @@ function desktop_mode_nonce_refresh_build_payload() {
 
 /**
  * Heartbeat handler — attach the fresh nonce map to every tick
- * from a logged-in user.
+ * from a user who has Desktop Mode enabled.
  *
- * Runs unconditionally for logged-in users, not gated on a
- * client-sent opt-in field. The cost is tiny (three
- * `wp_create_nonce()` calls, all hot-cached inside a single
- * request) and we want EVERY shell tab to receive the refresh,
- * including ones that don't otherwise contribute to the heartbeat
- * payload.
+ * Gated on `desktop_mode_is_enabled()` (not just `is_user_logged_in()`)
+ * so users on classic admin screens — editors on post-edit pages,
+ * subscribers reading the front-end heartbeat — don't carry the
+ * payload around. The shell's nonces only need refreshing for
+ * users who actually run the shell.
+ *
+ * The cost is tiny when fired (three `wp_create_nonce()` calls,
+ * all hot-cached inside a single request) — the gate is about
+ * not shipping irrelevant data to non-shell users on every tick.
  *
  * @since 0.8.7
  *
@@ -109,7 +112,7 @@ function desktop_mode_nonce_refresh_heartbeat_received( $response, $data ) {
 	if ( ! is_array( $response ) ) {
 		$response = array();
 	}
-	if ( ! is_user_logged_in() ) {
+	if ( ! function_exists( 'desktop_mode_is_enabled' ) || ! desktop_mode_is_enabled() ) {
 		return $response;
 	}
 	$response[ DESKTOP_MODE_NONCE_REFRESH_FIELD ] = desktop_mode_nonce_refresh_build_payload();

--- a/includes/nonce-refresh.php
+++ b/includes/nonce-refresh.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Desktop Mode — Heartbeat-driven nonce refresh.
+ *
+ * WordPress nonces are valid for `nonce_life` (24 hours by default).
+ * The desktop shell is a long-running SPA whose per-window config
+ * blobs bake `wp_create_nonce()` values into the page at render
+ * time, so any session that stays open past the 24-hour mark hits
+ * `rest_cookie_invalid_nonce` ("Cookie check failed") on the next
+ * REST call — even though the auth cookie is still valid.
+ *
+ * Fix: on every Heartbeat tick, return a fresh copy of every nonce
+ * action the shell cares about, keyed by action string. The client
+ * subscribes via `src/nonce-refresh.ts` and rewrites the cached
+ * values in place. `wp_create_nonce()` returns the same value
+ * inside a single 12-hour tick window, so the actual nonce string
+ * only changes when the tick rolls — well before the 24-hour hard
+ * expiry catches the cached value.
+ *
+ * Default actions covered:
+ *
+ *   - `wp_rest` — the canonical REST cookie nonce. Used by every
+ *      window that stashes a `restNonce` in its config blob, plus
+ *      the shell-wide auto-injection in `src/inject-rest-nonce.ts`.
+ *   - `desktop-mode-plugins` — admin-ajax nonce for our
+ *      browse/install/upload/reviews handlers.
+ *   - `updates` — Core's wp.updates nonce used by
+ *      `wp_ajax_install_plugin` / `wp_ajax_update_plugin`.
+ *
+ * Plugin authors who need to extend the set can hook
+ * `desktop_mode_nonce_refresh_actions` and add their own nonce
+ * action strings. The client side picks the new fields up
+ * automatically through the same heartbeat field — feature modules
+ * just need to register a target for the field they care about via
+ * the JS-side `registerNonceTarget()` helper.
+ *
+ * @package WPDesktopMode
+ * @since   0.8.7
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Heartbeat field name. Public — `src/nonce-refresh.ts` subscribes
+ * to this string. Keep the value stable across versions or update
+ * both ends.
+ */
+const DESKTOP_MODE_NONCE_REFRESH_FIELD = 'desktop_mode_nonces';
+
+/**
+ * Mint a fresh map of `{ action => nonce }` for every action the
+ * shell needs to keep alive past `nonce_life`. The set is
+ * filterable so other native windows / third-party plugins can
+ * extend it; the only requirement is that the action string match
+ * whatever was passed to `wp_create_nonce()` at registration.
+ *
+ * @since 0.8.7
+ *
+ * @return array<string,string> Map of nonce-action => current nonce value.
+ */
+function desktop_mode_nonce_refresh_build_payload() {
+	$actions = array(
+		'wp_rest',
+		'desktop-mode-plugins',
+		'updates',
+	);
+
+	/**
+	 * Filter the set of nonce actions refreshed on every Heartbeat tick.
+	 *
+	 * Each entry must be a literal nonce action string (the same value
+	 * passed to `wp_create_nonce()` wherever the original was minted).
+	 *
+	 * @since 0.8.7
+	 *
+	 * @param string[] $actions Default nonce actions.
+	 */
+	$actions = (array) apply_filters( 'desktop_mode_nonce_refresh_actions', $actions );
+
+	$payload = array();
+	foreach ( $actions as $action ) {
+		if ( ! is_string( $action ) || $action === '' ) {
+			continue;
+		}
+		$payload[ $action ] = wp_create_nonce( $action );
+	}
+	return $payload;
+}
+
+/**
+ * Heartbeat handler — attach the fresh nonce map to every tick
+ * from a logged-in user.
+ *
+ * Runs unconditionally for logged-in users, not gated on a
+ * client-sent opt-in field. The cost is tiny (three
+ * `wp_create_nonce()` calls, all hot-cached inside a single
+ * request) and we want EVERY shell tab to receive the refresh,
+ * including ones that don't otherwise contribute to the heartbeat
+ * payload.
+ *
+ * @since 0.8.7
+ *
+ * @param array $response Heartbeat response (filter return value).
+ * @param array $data     Client-sent payload. Unused here.
+ * @return array
+ */
+function desktop_mode_nonce_refresh_heartbeat_received( $response, $data ) {
+	unset( $data );
+	if ( ! is_array( $response ) ) {
+		$response = array();
+	}
+	if ( ! is_user_logged_in() ) {
+		return $response;
+	}
+	$response[ DESKTOP_MODE_NONCE_REFRESH_FIELD ] = desktop_mode_nonce_refresh_build_payload();
+	return $response;
+}
+add_filter( 'heartbeat_received', 'desktop_mode_nonce_refresh_heartbeat_received', 5, 2 );

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -146,6 +146,7 @@ import {
 } from './presence';
 import { type ActivityApi } from './activity';
 import { bootHeartbeatBus, type HeartbeatBus } from './heartbeat';
+import { bootNonceRefresh } from './nonce-refresh';
 import { bindTopWindowLinkInterceptor } from './boot/link-interceptor';
 import { bindMenuRefresh } from './boot/menu-refresh';
 import { openCurrentPage, restoreSession } from './boot/session';
@@ -2886,6 +2887,13 @@ function init(): void {
 	// contributor / subscriber. Idempotent — safe to run twice
 	// if init() ever fires again.
 	bootHeartbeatBus();
+
+	// Subscribe to heartbeat-driven nonce refresh so cached
+	// `restNonce` values in `window.desktopModeConfig` and
+	// `window.desktopModeWindowConfig` stay valid past the
+	// 24-hour `nonce_life` boundary. See `src/nonce-refresh.ts`
+	// and `includes/nonce-refresh.php`.
+	bootNonceRefresh();
 
 	// Files-on-the-Desktop: hand the open() dispatcher real
 	// dependencies and seed the per-user associations from the

--- a/src/nonce-refresh.ts
+++ b/src/nonce-refresh.ts
@@ -20,12 +20,22 @@
  * changes when the tick rolls — well before the 24-hour hard
  * expiry catches the cached value.
  *
- * Extending: feature modules that stash their own nonces in a
- * per-window config blob call `registerNonceTarget()` at boot
- * with the nonce action they care about and a tiny updater that
- * writes the fresh value where they read it from. Plain
- * registration is the public extension surface; the heartbeat
- * field name is an internal detail.
+ * Extending from third-party plugins: subscribe to the
+ * heartbeat field directly via the public heartbeat surface —
+ *
+ *     wp.desktop.heartbeat.subscribe( 'desktop_mode_nonces', ( map ) => {
+ *         // map[ 'my-plugin/admin-ajax' ] is the fresh value
+ *     } );
+ *
+ * The matching action must be published from PHP via the
+ * `desktop_mode_nonce_refresh_actions` filter so the server
+ * actually ships it.
+ *
+ * `registerNonceTarget()` below is an internal helper the
+ * framework uses to wire its own built-in targets — third-party
+ * bundles don't ship with the main bundle's module graph, so
+ * importing it directly isn't supported. The public extension
+ * surface is the heartbeat subscription above.
  *
  * @since 0.8.7
  */
@@ -63,7 +73,12 @@ let booted = false;
  * since the initial cached value (from the per-window config
  * blob) is already correct at registration time.
  *
- * @public
+ * Framework-only. Third-party plugins can't import this from a
+ * separate bundle; use
+ * `wp.desktop.heartbeat.subscribe( 'desktop_mode_nonces', cb )`
+ * instead and read the action key off the returned map.
+ *
+ * @internal
  */
 export function registerNonceTarget(
 	action: string,
@@ -88,7 +103,10 @@ export function registerNonceTarget(
  * no-op so the boot order between this and per-window
  * registrations doesn't matter.
  *
- * @public
+ * Called once from `src/desktop.ts` during shell boot. Plugin
+ * authors don't need to call this.
+ *
+ * @internal
  */
 export function bootNonceRefresh(): void {
 	if ( booted ) {

--- a/src/nonce-refresh.ts
+++ b/src/nonce-refresh.ts
@@ -1,0 +1,223 @@
+/**
+ * Heartbeat-driven refresh of the shell's cached nonces.
+ *
+ * WordPress nonces expire after `nonce_life` (24 hours by default).
+ * The desktop shell is a long-running SPA — without periodic
+ * refresh, every nonce stamped into `window.desktopModeConfig` /
+ * `window.desktopModeWindowConfig` at page render goes stale once
+ * the tab has been open longer than a day. Native windows that
+ * carry a cached `restNonce` (Plugins, Posts, Pages, Users, …)
+ * then hit `rest_cookie_invalid_nonce` — surfaced to the user as
+ * the misleading "Cookie check failed" error, GH#250.
+ *
+ * Server side (`includes/nonce-refresh.php`) attaches a fresh map
+ * `{ action: nonce }` to every Heartbeat tick under the field
+ * `desktop_mode_nonces`. This module subscribes via the shared
+ * `heartbeat` bus and rewrites every registered target in place
+ * so consumers that read `getConfig()` per-request automatically
+ * pick the new value up. `wp_create_nonce()` returns the same
+ * string within a 12-hour tick window, so the actual nonce only
+ * changes when the tick rolls — well before the 24-hour hard
+ * expiry catches the cached value.
+ *
+ * Extending: feature modules that stash their own nonces in a
+ * per-window config blob call `registerNonceTarget()` at boot
+ * with the nonce action they care about and a tiny updater that
+ * writes the fresh value where they read it from. Plain
+ * registration is the public extension surface; the heartbeat
+ * field name is an internal detail.
+ *
+ * @since 0.8.7
+ */
+
+import { heartbeat } from './heartbeat';
+
+/**
+ * Heartbeat field name. Matches the server-side constant in
+ * `includes/nonce-refresh.php` — keep both in sync.
+ */
+const HEARTBEAT_FIELD = 'desktop_mode_nonces';
+
+/** Shape of the heartbeat field — `{ nonce-action: fresh-value }`. */
+type NoncePayload = Record< string, string >;
+
+/**
+ * Updater registered against a single nonce action. Called with
+ * the freshly-minted value on every Heartbeat tick that carries
+ * the action.
+ */
+type NonceTargetUpdater = ( freshNonce: string ) => void;
+
+const targets = new Map< string, Set< NonceTargetUpdater > >();
+let booted = false;
+
+/**
+ * Register a target that should receive fresh `wp_create_nonce()`
+ * values for `action` on every Heartbeat tick. Returns an
+ * unsubscribe. Multiple targets per action compose — useful when
+ * the same action backs more than one cached field.
+ *
+ * Call this at boot, before the first heartbeat tick fires. Any
+ * registration that lands after a tick is still picked up on the
+ * next one — no replay of the most recent value is performed,
+ * since the initial cached value (from the per-window config
+ * blob) is already correct at registration time.
+ *
+ * @public
+ */
+export function registerNonceTarget(
+	action: string,
+	updater: NonceTargetUpdater,
+): () => void {
+	if ( typeof action !== 'string' || action === '' ) {
+		return () => {};
+	}
+	let set = targets.get( action );
+	if ( ! set ) {
+		set = new Set();
+		targets.set( action, set );
+	}
+	set.add( updater );
+	return () => {
+		set!.delete( updater );
+	};
+}
+
+/**
+ * Wire the heartbeat subscriber. Idempotent — calling twice is a
+ * no-op so the boot order between this and per-window
+ * registrations doesn't matter.
+ *
+ * @public
+ */
+export function bootNonceRefresh(): void {
+	if ( booted ) {
+		return;
+	}
+	booted = true;
+	heartbeat.subscribe< NoncePayload >( HEARTBEAT_FIELD, ( payload ) => {
+		if ( ! payload || typeof payload !== 'object' ) {
+			return;
+		}
+		for ( const [ action, value ] of Object.entries( payload ) ) {
+			if ( typeof value !== 'string' || value === '' ) {
+				continue;
+			}
+			const set = targets.get( action );
+			if ( ! set ) {
+				continue;
+			}
+			for ( const updater of set ) {
+				try {
+					updater( value );
+				} catch ( err ) {
+					// One bad updater shouldn't strand peers. Log
+					// loudly so plugin authors notice.
+					// eslint-disable-next-line no-console
+					console.error(
+						`[desktop-mode/nonce-refresh] updater for "${ action }" threw:`,
+						err,
+					);
+				}
+			}
+		}
+	} );
+
+	registerShellAndPluginsWindowTargets();
+}
+
+/**
+ * Wire the framework's own cached nonces.
+ *
+ *   - `wp_rest` backs `window.desktopModeConfig.restNonce`
+ *      (used by `injectRestNonce()` shell-wide) and the
+ *      per-window blob for the Plugins window.
+ *   - `desktop-mode-plugins` backs the Plugins window's
+ *      `ajaxNonce` (admin-ajax handlers we own).
+ *   - `updates` backs the Plugins window's `updatesNonce`
+ *      (Core's wp.updates install/update handlers).
+ *
+ * Other native windows that stash a `restNonce` (Posts, Pages,
+ * Users, Comments, …) are picked up by the `wp_rest` target
+ * generically — see `updateAllRestNonces`. New per-window
+ * action strings need their own `registerNonceTarget()` call,
+ * either inline below or from the feature module itself.
+ */
+function registerShellAndPluginsWindowTargets(): void {
+	registerNonceTarget( 'wp_rest', updateAllRestNonces );
+	registerNonceTarget( 'desktop-mode-plugins', ( fresh ) => {
+		writeWindowConfigField( 'desktop-mode-plugins', 'ajaxNonce', fresh );
+	} );
+	registerNonceTarget( 'updates', ( fresh ) => {
+		writeWindowConfigField( 'desktop-mode-plugins', 'updatesNonce', fresh );
+	} );
+}
+
+/**
+ * Push the fresh `wp_rest` nonce into every cached location the
+ * framework knows about: the shell-wide config the auto-injector
+ * reads, plus every per-window config blob that carries a
+ * `restNonce` string. Iterating the whole map is cheap (a handful
+ * of windows) and means new native windows pick up refresh for
+ * free as long as they follow the `restNonce` naming convention.
+ */
+function updateAllRestNonces( fresh: string ): void {
+	const cfg = readShellConfig();
+	if ( cfg && typeof cfg.restNonce === 'string' ) {
+		cfg.restNonce = fresh;
+	}
+	const windowConfigs = readWindowConfigs();
+	if ( ! windowConfigs ) {
+		return;
+	}
+	for ( const blob of Object.values( windowConfigs ) ) {
+		if (
+			blob &&
+			typeof blob === 'object' &&
+			typeof ( blob as { restNonce?: unknown } ).restNonce === 'string'
+		) {
+			( blob as { restNonce: string } ).restNonce = fresh;
+		}
+	}
+}
+
+function writeWindowConfigField(
+	windowId: string,
+	field: string,
+	value: string,
+): void {
+	const blobs = readWindowConfigs();
+	const blob = blobs?.[ windowId ];
+	if ( blob && typeof blob === 'object' ) {
+		( blob as Record< string, unknown > )[ field ] = value;
+	}
+}
+
+function readShellConfig(): { restNonce?: unknown } | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+	return ( window as unknown as {
+		desktopModeConfig?: { restNonce?: unknown };
+	} ).desktopModeConfig;
+}
+
+function readWindowConfigs(): Record< string, unknown > | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+	return ( window as unknown as {
+		desktopModeWindowConfig?: Record< string, unknown >;
+	} ).desktopModeWindowConfig;
+}
+
+/**
+ * Test-only reset. Drops every registered target + the boot
+ * flag so an isolated test can rewire from scratch.
+ *
+ * @internal
+ */
+export function _resetNonceRefreshForTests(): void {
+	targets.clear();
+	booted = false;
+}

--- a/tests/phpunit/tests/nonceRefresh.php
+++ b/tests/phpunit/tests/nonceRefresh.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for the Heartbeat-driven nonce-refresh handler
+ * (`includes/nonce-refresh.php`). Regression target is GH#250 —
+ * the Plugins window's stale cached nonce surfacing as "Cookie
+ * check failed" once the shell tab passed the 24-hour
+ * `nonce_life` boundary.
+ *
+ * @group desktop-mode
+ * @group desktop-mode-nonce-refresh
+ */
+class Tests_DesktopMode_NonceRefresh extends WP_UnitTestCase {
+
+	protected static $user_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_heartbeat_received
+	 */
+	public function test_skips_anonymous_users() {
+		wp_set_current_user( 0 );
+
+		$response = desktop_mode_nonce_refresh_heartbeat_received( array(), array() );
+
+		$this->assertArrayNotHasKey(
+			DESKTOP_MODE_NONCE_REFRESH_FIELD,
+			$response,
+			'Logged-out users must not receive a refreshed nonce payload.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_heartbeat_received
+	 */
+	public function test_logged_in_user_receives_fresh_nonces_for_default_actions() {
+		wp_set_current_user( self::$user_id );
+
+		$response = desktop_mode_nonce_refresh_heartbeat_received( array(), array() );
+
+		$this->assertArrayHasKey( DESKTOP_MODE_NONCE_REFRESH_FIELD, $response );
+		$nonces = $response[ DESKTOP_MODE_NONCE_REFRESH_FIELD ];
+
+		// Default action set — the ones the Plugins window relies on.
+		$this->assertArrayHasKey( 'wp_rest', $nonces );
+		$this->assertArrayHasKey( 'desktop-mode-plugins', $nonces );
+		$this->assertArrayHasKey( 'updates', $nonces );
+
+		// Each value must validate against the action it's keyed by —
+		// catches accidental mis-keying of the payload.
+		$this->assertSame( 1, wp_verify_nonce( $nonces['wp_rest'], 'wp_rest' ) );
+		$this->assertSame(
+			1,
+			wp_verify_nonce( $nonces['desktop-mode-plugins'], 'desktop-mode-plugins' )
+		);
+		$this->assertSame( 1, wp_verify_nonce( $nonces['updates'], 'updates' ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_heartbeat_received
+	 */
+	public function test_preserves_pre_existing_response_keys() {
+		wp_set_current_user( self::$user_id );
+
+		$response = desktop_mode_nonce_refresh_heartbeat_received(
+			array( 'some_other_feature' => 'untouched' ),
+			array()
+		);
+
+		$this->assertSame( 'untouched', $response['some_other_feature'] );
+		$this->assertArrayHasKey( DESKTOP_MODE_NONCE_REFRESH_FIELD, $response );
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_build_payload
+	 */
+	public function test_filter_can_add_custom_actions() {
+		wp_set_current_user( self::$user_id );
+
+		$callback = function ( $actions ) {
+			$actions[] = 'my-plugin/custom';
+			return $actions;
+		};
+		add_filter( 'desktop_mode_nonce_refresh_actions', $callback );
+
+		$payload = desktop_mode_nonce_refresh_build_payload();
+
+		remove_filter( 'desktop_mode_nonce_refresh_actions', $callback );
+
+		$this->assertArrayHasKey( 'my-plugin/custom', $payload );
+		$this->assertSame(
+			1,
+			wp_verify_nonce( $payload['my-plugin/custom'], 'my-plugin/custom' )
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_build_payload
+	 */
+	public function test_filter_can_remove_default_actions() {
+		wp_set_current_user( self::$user_id );
+
+		$callback = function () {
+			return array( 'wp_rest' );
+		};
+		add_filter( 'desktop_mode_nonce_refresh_actions', $callback );
+
+		$payload = desktop_mode_nonce_refresh_build_payload();
+
+		remove_filter( 'desktop_mode_nonce_refresh_actions', $callback );
+
+		$this->assertSame( array( 'wp_rest' ), array_keys( $payload ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_build_payload
+	 */
+	public function test_filter_skips_non_string_and_empty_entries() {
+		wp_set_current_user( self::$user_id );
+
+		$callback = function () {
+			return array( 'wp_rest', '', 0, null, false, 'updates' );
+		};
+		add_filter( 'desktop_mode_nonce_refresh_actions', $callback );
+
+		$payload = desktop_mode_nonce_refresh_build_payload();
+
+		remove_filter( 'desktop_mode_nonce_refresh_actions', $callback );
+
+		$this->assertSame(
+			array( 'wp_rest', 'updates' ),
+			array_keys( $payload ),
+			'Non-string / empty action entries must be discarded.'
+		);
+	}
+
+	/**
+	 * Wired correctly into the `heartbeat_received` filter chain
+	 * so a tick from a logged-in user really does ship the nonces.
+	 */
+	public function test_filter_is_registered_on_heartbeat_received() {
+		$this->assertNotFalse(
+			has_filter(
+				'heartbeat_received',
+				'desktop_mode_nonce_refresh_heartbeat_received'
+			),
+			'desktop_mode_nonce_refresh_heartbeat_received should hook heartbeat_received.'
+		);
+	}
+}

--- a/tests/phpunit/tests/nonceRefresh.php
+++ b/tests/phpunit/tests/nonceRefresh.php
@@ -15,6 +15,9 @@ class Tests_DesktopMode_NonceRefresh extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		// Opt this user into Desktop Mode so the heartbeat gate
+		// (`desktop_mode_is_enabled()`) lets the payload through.
+		update_user_meta( self::$user_id, 'desktop_mode_mode', '1' );
 	}
 
 	public function tear_down() {
@@ -34,6 +37,23 @@ class Tests_DesktopMode_NonceRefresh extends WP_UnitTestCase {
 			DESKTOP_MODE_NONCE_REFRESH_FIELD,
 			$response,
 			'Logged-out users must not receive a refreshed nonce payload.'
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_nonce_refresh_heartbeat_received
+	 */
+	public function test_skips_users_without_desktop_mode_enabled() {
+		$opted_out = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		// No desktop_mode_mode meta -> is_enabled() returns false.
+		wp_set_current_user( $opted_out );
+
+		$response = desktop_mode_nonce_refresh_heartbeat_received( array(), array() );
+
+		$this->assertArrayNotHasKey(
+			DESKTOP_MODE_NONCE_REFRESH_FIELD,
+			$response,
+			'Users who have not opted into Desktop Mode must not receive the payload.'
 		);
 	}
 

--- a/tests/vitest/nonce-refresh.test.ts
+++ b/tests/vitest/nonce-refresh.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for `src/nonce-refresh.ts` — heartbeat-driven refresh of
+ * the cached REST/ajax nonces. Regression target is GH#250
+ * ("Plugins table sometimes won't load — Cookie check failed"),
+ * where a long-running shell session crossed WordPress's 24-hour
+ * `nonce_life` boundary and the per-window blob's `restNonce`
+ * went stale.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	bootHeartbeatBus,
+	_resetHeartbeatBusForTests,
+} from '../../src/heartbeat';
+import {
+	bootNonceRefresh,
+	registerNonceTarget,
+	_resetNonceRefreshForTests,
+} from '../../src/nonce-refresh';
+
+interface JQueryHandlers {
+	'heartbeat-send'?: ( e: unknown, data: Record< string, unknown > ) => void;
+	'heartbeat-tick'?: ( e: unknown, response: Record< string, unknown > ) => void;
+}
+
+function installFakeJQuery(): JQueryHandlers {
+	const handlers: JQueryHandlers = {};
+	( window as unknown as { jQuery: unknown } ).jQuery = (
+		_: Document,
+	): {
+		on: ( ev: string, cb: ( ...args: unknown[] ) => void ) => void;
+	} => ( {
+		on( ev, cb ) {
+			( handlers as Record< string, unknown > )[ ev ] = cb as unknown;
+		},
+	} );
+	return handlers;
+}
+
+interface ShellWindow extends Window {
+	desktopModeConfig?: { restNonce?: string };
+	desktopModeWindowConfig?: Record< string, unknown >;
+	jQuery?: unknown;
+}
+
+function shellWindow(): ShellWindow {
+	return window as unknown as ShellWindow;
+}
+
+describe( 'nonce-refresh', () => {
+	beforeEach( () => {
+		_resetHeartbeatBusForTests();
+		_resetNonceRefreshForTests();
+		delete shellWindow().jQuery;
+		delete shellWindow().desktopModeConfig;
+		delete shellWindow().desktopModeWindowConfig;
+	} );
+
+	afterEach( () => {
+		_resetHeartbeatBusForTests();
+		_resetNonceRefreshForTests();
+		delete shellWindow().jQuery;
+		delete shellWindow().desktopModeConfig;
+		delete shellWindow().desktopModeWindowConfig;
+	} );
+
+	test( 'rewrites the shell-wide restNonce on every tick', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeConfig = { restNonce: 'stale' };
+
+		bootHeartbeatBus();
+		bootNonceRefresh();
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 'fresh-1' } },
+		);
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'fresh-1' );
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 'fresh-2' } },
+		);
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'fresh-2' );
+	} );
+
+	test( 'rewrites the plugins-window restNonce / ajaxNonce / updatesNonce', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeWindowConfig = {
+			'desktop-mode-plugins': {
+				restNonce:    'stale-rest',
+				ajaxNonce:    'stale-ajax',
+				updatesNonce: 'stale-updates',
+			},
+		};
+
+		bootHeartbeatBus();
+		bootNonceRefresh();
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{
+				desktop_mode_nonces: {
+					wp_rest:                'fresh-rest',
+					'desktop-mode-plugins': 'fresh-ajax',
+					updates:                'fresh-updates',
+				},
+			},
+		);
+
+		const cfg = shellWindow().desktopModeWindowConfig?.[
+			'desktop-mode-plugins'
+		] as Record< string, string >;
+		expect( cfg.restNonce ).toBe( 'fresh-rest' );
+		expect( cfg.ajaxNonce ).toBe( 'fresh-ajax' );
+		expect( cfg.updatesNonce ).toBe( 'fresh-updates' );
+	} );
+
+	test( 'refreshes restNonce on EVERY native window blob, not just plugins', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeWindowConfig = {
+			'desktop-mode-plugins': { restNonce: 'stale' },
+			'desktop-mode-posts':   { restNonce: 'stale' },
+			'desktop-mode-users':   { restNonce: 'stale' },
+			// A blob without restNonce — should be left alone.
+			'desktop-mode-other':   { something: 'else' },
+		};
+
+		bootHeartbeatBus();
+		bootNonceRefresh();
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 'fresh' } },
+		);
+
+		const cfgs = shellWindow().desktopModeWindowConfig!;
+		expect(
+			( cfgs[ 'desktop-mode-plugins' ] as { restNonce: string } ).restNonce,
+		).toBe( 'fresh' );
+		expect(
+			( cfgs[ 'desktop-mode-posts' ] as { restNonce: string } ).restNonce,
+		).toBe( 'fresh' );
+		expect(
+			( cfgs[ 'desktop-mode-users' ] as { restNonce: string } ).restNonce,
+		).toBe( 'fresh' );
+		expect(
+			( cfgs[ 'desktop-mode-other' ] as Record< string, unknown > ).restNonce,
+		).toBeUndefined();
+	} );
+
+	test( 'ignores ticks without the desktop_mode_nonces field', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeConfig = { restNonce: 'original' };
+
+		bootHeartbeatBus();
+		bootNonceRefresh();
+
+		handlers[ 'heartbeat-tick' ]?.( {}, { something_else: 'ignored' } );
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'original' );
+	} );
+
+	test( 'tolerates a missing desktopModeConfig and missing window-config blob', () => {
+		const handlers = installFakeJQuery();
+		// Neither global set — must NOT throw.
+		bootHeartbeatBus();
+		bootNonceRefresh();
+
+		expect( () =>
+			handlers[ 'heartbeat-tick' ]?.(
+				{},
+				{
+					desktop_mode_nonces: {
+						wp_rest:                'fresh',
+						'desktop-mode-plugins': 'fresh',
+						updates:                'fresh',
+					},
+				},
+			),
+		).not.toThrow();
+	} );
+
+	test( 'skips a stray non-string value in the payload', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeConfig = { restNonce: 'original' };
+
+		bootHeartbeatBus();
+		bootNonceRefresh();
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 42 } },
+		);
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'original' );
+	} );
+
+	test( 'registerNonceTarget composes with built-in targets', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeConfig = { restNonce: 'stale' };
+
+		const seen: string[] = [];
+		bootHeartbeatBus();
+		bootNonceRefresh();
+		registerNonceTarget( 'wp_rest', ( v ) => seen.push( v ) );
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 'fresh' } },
+		);
+		expect( seen ).toEqual( [ 'fresh' ] );
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'fresh' );
+	} );
+
+	test( 'bootNonceRefresh is idempotent', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeConfig = { restNonce: 'stale' };
+
+		bootHeartbeatBus();
+		bootNonceRefresh();
+		bootNonceRefresh();
+
+		const calls: string[] = [];
+		registerNonceTarget( 'wp_rest', ( v ) => calls.push( v ) );
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 'fresh' } },
+		);
+		// Built-in target + custom target = restNonce updated AND
+		// our spy called exactly once. A double-boot would either
+		// double-fire the spy or re-register the built-in target.
+		expect( calls ).toEqual( [ 'fresh' ] );
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'fresh' );
+	} );
+
+	test( 'a throwing updater does not strand peer updaters', () => {
+		const handlers = installFakeJQuery();
+		shellWindow().desktopModeConfig = { restNonce: 'stale' };
+
+		const errSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		bootHeartbeatBus();
+		bootNonceRefresh();
+		registerNonceTarget( 'wp_rest', () => {
+			throw new Error( 'boom' );
+		} );
+
+		handlers[ 'heartbeat-tick' ]?.(
+			{},
+			{ desktop_mode_nonces: { wp_rest: 'fresh' } },
+		);
+		// Built-in target still ran despite the throwing peer.
+		expect( shellWindow().desktopModeConfig?.restNonce ).toBe( 'fresh' );
+		errSpy.mockRestore();
+	} );
+} );


### PR DESCRIPTION
## Summary

- Refresh shell-cached nonces on every Heartbeat tick so they don't go stale once a tab crosses WordPress's 24h `nonce_life` boundary.
- Server: new `heartbeat_received` filter ships `{ action: nonce }` under `desktop_mode_nonces`. Filter `desktop_mode_nonce_refresh_actions` lets other windows / plugins extend the set.
- Client: subscribes via the existing heartbeat bus, rewrites `desktopModeConfig.restNonce`, every per-window blob's `restNonce`, and the Plugins window's `ajaxNonce` / `updatesNonce` in place. New `registerNonceTarget()` API for plugin authors.

Fixes #250.

## Root cause

`includes/plugins-window/window.php:134` bakes `wp_create_nonce('wp_rest')` into the per-window config blob at page render. The desktop shell is a long-running SPA — once the tab is open past `nonce_life` (24h), the cached `restNonce` is rejected by `rest_cookie_check_errors()` and `/wp/v2/plugins` returns `rest_cookie_invalid_nonce`, surfaced as "Could not load plugins: Cookie check failed". A hard refresh re-mints the nonce, which is exactly what the bug report describes. The same shape exists in every window that stashes a `restNonce` (Posts, Pages, Users, Comments, …); the `wp_rest` target in this fix refreshes all of them generically.

## Why heartbeat refresh

`wp_create_nonce()` returns a stable value within a 12h tick window, so refreshing on every tick (≤60s in the background) means the cached value always reflects the current tick — well before the 24h hard expiry catches it. Same mechanism Gutenberg/Core already use for their own nonces.

## Test plan

- [x] `npm run lint` — clean.
- [x] `tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [x] `npm run test:js` — 1464/1464 pass (9 new tests in `tests/vitest/nonce-refresh.test.ts`).
- [ ] `npm run test:php -- --filter=Tests_DesktopMode_NonceRefresh` — 7 new tests; could not run locally (port collision with another worktree's wp-env). CI will exercise.
- [ ] Browser sanity: in DevTools console, set `window.desktopModeWindowConfig['desktop-mode-plugins'].restNonce = 'broken'`, try opening Plugins → fails with "Cookie check failed". Wait ~15s for one Heartbeat tick. Reopening Plugins succeeds without a page reload.
- [ ] Soak test: leave the shell tab open >24h, open Plugins — table loads. (Slow, optional.)

## Docs updated

- `docs/hooks-reference.md` — new `desktop_mode_nonce_refresh_actions` filter.
- `docs/javascript-reference.md` — `registerNonceTarget()` surface.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-253-b97626412ea77665709c66229b6a0e2fbc28b64c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->