### PR TITLE
feat(my-wordpress): add server-side search to entity list views

### DIFF
--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -67,6 +67,69 @@
 	min-height: 0;
 	overflow: hidden;
 	position: relative;
+	display: flex;
+	flex-direction: column;
+}
+
+/* List-view toolbar — sits between the breadcrumb header and the
+ * split pane in every entity list view (Posts, Pages, Users, Media).
+ * Holds the server-side search input today; reserved for future
+ * filter / sort controls. Visual treatment mirrors the Content
+ * Graph toolbar's search row so the two surfaces read as the same
+ * control. */
+.desktop-mode-my-wordpress__list-toolbar {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	border-bottom: 1px solid var( --desktop-mode-border, #dcdcde );
+	background: transparent;
+}
+
+.desktop-mode-my-wordpress__list-toolbar-search {
+	position: relative;
+	flex: 1 1 auto;
+	min-width: 0;
+	max-width: 360px;
+}
+
+.desktop-mode-my-wordpress__list-toolbar-search-input {
+	width: 100%;
+	padding: 6px 10px;
+	border: 1px solid var( --wpd-border, #d8dde4 );
+	border-radius: 6px;
+	background: var( --wpd-surface, #fff );
+	color: inherit;
+	font-size: 13px;
+	box-sizing: border-box;
+}
+
+.desktop-mode-my-wordpress__list-toolbar-search-input:focus {
+	outline: none;
+	border-color: var( --wpd-accent, #2c6be5 );
+	box-shadow: 0 0 0 3px var( --wpd-accent-soft, rgba( 44, 107, 229, 0.18 ) );
+}
+
+/* When the list-toolbar mounts, the split pane needs to claim the
+ * remaining vertical space inside the flex column body — without
+ * this rule it would size to its content (which, for an empty list,
+ * is zero) and the tile canvas would collapse. */
+.desktop-mode-my-wordpress__body > .desktop-mode-my-wordpress__split {
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+/* Search-in-progress dimming. The previous result set stays in place
+ * (no skeleton flash, no empty intermediate page) but reads as
+ * "stale" until the new page lands and the renderer atomically swaps
+ * the tiles. `pointer-events: none` blocks the user from clicking
+ * a tile that's about to disappear. */
+.desktop-mode-my-wordpress__tiles--searching,
+.desktop-mode-my-wordpress__media-grid--searching {
+	opacity: 0.45;
+	pointer-events: none;
+	transition: opacity 0.12s ease-out;
 }
 
 /* Reuse the file-system folder window's status-bar element

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -33,6 +33,7 @@ import {
 	type EntityRenderHost,
 	type EntityRenderer,
 } from './kind-registry';
+import { renderListToolbar } from './list-toolbar';
 import { renderMediaList } from './media-list';
 import { renderMediaDetail } from './media-detail';
 import {
@@ -653,13 +654,62 @@ interface ListContext {
 	selectedTile: HTMLElement | null;
 	observer: IntersectionObserver | null;
 	layout: TileLayout;
+	/**
+	 * Current debounced search query — empty string means no filter.
+	 * Threaded into `fetchEntityList` as the `search` param.
+	 *
+	 * @since 0.22.0
+	 */
+	query: string;
+	/**
+	 * Aborts the in-flight page fetch when a new search query
+	 * supersedes it. Replaced on every `loadMore()` call so the
+	 * latest in-flight request is the only one that can paint.
+	 *
+	 * @since 0.22.0
+	 */
+	abort: AbortController | null;
 }
+
+/**
+ * Per-entity remembered search query. Survives a click-into-post-
+ * and-back round-trip (renderEntityList re-mounts on every list
+ * navigation; reading from this map at the top restores the prior
+ * query without baking it into the Route schema). Keyed by
+ * `entity.id` so switching Posts → Pages clears the field — see
+ * the user-facing rationale for that in the plan.
+ *
+ * @since 0.22.0
+ */
+const lastQueryByEntity = new Map< string, string >();
 
 function renderEntityList(
 	state: RenderState,
 	entity: MyWordPressEntity,
 ): void {
 	const cfg = getConfig();
+	const initialQuery = lastQueryByEntity.get( entity.id ) ?? '';
+
+	const toolbar = renderListToolbar( {
+		placeholder: sprintf(
+			// translators: %s is a lowercased entity-type label (e.g. "posts", "pages").
+			__( 'Search %s…', 'desktop-mode' ),
+			entity.label.toLowerCase(),
+		),
+		ariaLabel: sprintf(
+			// translators: %s is an entity-type label (e.g. "Posts", "Pages").
+			__( 'Search %s', 'desktop-mode' ),
+			entity.label,
+		),
+		initialValue: initialQuery,
+		onSearchChange: ( q ) => {
+			lastQueryByEntity.set( entity.id, q );
+			void resetForSearch( q );
+		},
+	} );
+	state.body.appendChild( toolbar.host );
+	state.teardown.push( () => toolbar.destroy() );
+
 	const split = document.createElement( 'div' );
 	split.className = 'desktop-mode-my-wordpress__split';
 
@@ -711,8 +761,14 @@ function renderEntityList(
 		selectedTile: null,
 		observer: null,
 		layout: tileLayout,
+		query: initialQuery,
+		abort: null,
 	};
 	state.teardown.push( () => tileLayout.dispose() );
+	// Cancel any in-flight page fetch on teardown — keeps the
+	// activity bus / loading spinner from showing a never-resolving
+	// pulse after the user navigates away.
+	state.teardown.push( () => ctx.abort?.abort() );
 
 	const repaintListStatus = () => {
 		// Show "X of Y items" while infinite scroll still has more
@@ -782,18 +838,31 @@ function renderEntityList(
 		ctx.loading = true;
 		const nextPage = ctx.page + 1;
 		const isFirst = nextPage === 1;
+		const queryAtFetchTime = ctx.query;
 		showLoadingSkeleton( tiles, ctx.layout, isFirst );
+		const controller = new AbortController();
+		ctx.abort = controller;
 		try {
 			const result = await fetchEntityList( entity, {
 				page: nextPage,
 				perPage: cfg.perPage,
+				search: queryAtFetchTime || undefined,
+				signal: controller.signal,
 			} );
+			// Race guard: a fresh search may have started while this
+			// page was in flight. The new request resets ctx.query
+			// AND aborts this controller — but if the abort lost the
+			// race (response already buffered) we'd paint stale
+			// tiles into a freshly-cleared grid.
+			if ( ctx.query !== queryAtFetchTime ) {
+				return;
+			}
 			ctx.page = nextPage;
 			ctx.totalPages = result.totalPages;
 			ctx.total = result.total;
 			hideLoadingSkeleton( tiles );
 			if ( result.items.length === 0 && isFirst ) {
-				renderListEmpty( tiles, entity );
+				renderListEmpty( tiles, entity, queryAtFetchTime );
 				ctx.done = true;
 				repaintListStatus();
 				return;
@@ -807,6 +876,12 @@ function renderEntityList(
 			}
 			repaintListStatus();
 		} catch ( err ) {
+			if ( isAbortError( err ) ) {
+				// Search query changed mid-flight. The new query's
+				// loadMore() will repaint; nothing to do here, and
+				// we explicitly avoid painting an error message.
+				return;
+			}
 			hideLoadingSkeleton( tiles );
 			const msg =
 				err instanceof Error ? err.message : __( 'Unknown error.', 'desktop-mode' );
@@ -814,12 +889,123 @@ function renderEntityList(
 			ctx.done = true;
 		} finally {
 			ctx.loading = false;
+			if ( ctx.abort === controller ) {
+				ctx.abort = null;
+			}
 		}
 		// Chain — keep pulling pages while the sentinel is still
 		// within the rootMargin slack and there's more to load.
 		// Wrapped in `requestAnimationFrame` so the layout has
 		// settled with the freshly-appended tiles before we
 		// measure the sentinel's position.
+		if ( ! ctx.done ) {
+			requestAnimationFrame( () => {
+				if ( sentinelIsVisible() ) {
+					void loadMore();
+				}
+			} );
+		}
+	};
+
+	const resetForSearch = async ( q: string ): Promise< void > => {
+		// Cancel any in-flight page so the prior query can't paint
+		// after the swap.
+		ctx.abort?.abort();
+		ctx.abort = null;
+		ctx.query = q;
+
+		// Critical UX: do NOT clear tiles + paint a skeleton up front.
+		// Search runs on every debounced keystroke; ripping the grid
+		// down to placeholders before the response lands shows the
+		// user an "intermediate page" that flashes between every
+		// refinement. Instead keep the previous results visible (the
+		// `--searching` class dims them so the change-in-progress is
+		// visible), do the fetch, then atomically swap when the new
+		// page lands.
+		tiles.classList.add(
+			'desktop-mode-my-wordpress__tiles--searching',
+		);
+		hideLoadingSkeleton( tiles );
+
+		const controller = new AbortController();
+		ctx.abort = controller;
+		ctx.loading = true;
+
+		try {
+			const result = await fetchEntityList( entity, {
+				page: 1,
+				perPage: cfg.perPage,
+				search: q || undefined,
+				signal: controller.signal,
+			} );
+			// Stale guard — a later query may have superseded us.
+			if ( ctx.query !== q ) {
+				return;
+			}
+
+			// Atomic swap. Up to this point the user has been looking
+			// at the prior result set (dimmed); the next few lines
+			// replace it with the new one in one frame.
+			tiles.replaceChildren();
+			ctx.layout.clear();
+			tiles.classList.remove(
+				'desktop-mode-my-wordpress__tiles--searching',
+			);
+
+			ctx.page = 1;
+			ctx.totalPages = result.totalPages;
+			ctx.total = result.total;
+			ctx.loaded = 0;
+			ctx.done = ctx.page >= ctx.totalPages;
+			ctx.selectedId = null;
+			ctx.selectedTile = null;
+			ctx.preview.replaceChildren();
+			const emptyPreview = document.createElement( 'div' );
+			emptyPreview.className =
+				'desktop-mode-my-wordpress__preview-empty';
+			emptyPreview.textContent = __(
+				'Select an entry to preview it here.',
+				'desktop-mode',
+			);
+			ctx.preview.appendChild( emptyPreview );
+
+			if ( result.items.length === 0 ) {
+				renderListEmpty( tiles, entity, q );
+				ctx.done = true;
+			} else {
+				for ( const item of result.items ) {
+					tiles.appendChild(
+						buildEntityTile( state, ctx, entity, item ),
+					);
+					ctx.loaded += 1;
+				}
+			}
+			repaintListStatus();
+		} catch ( err ) {
+			if ( isAbortError( err ) ) {
+				return;
+			}
+			tiles.classList.remove(
+				'desktop-mode-my-wordpress__tiles--searching',
+			);
+			tiles.replaceChildren();
+			ctx.layout.clear();
+			const msg =
+				err instanceof Error
+					? err.message
+					: __( 'Unknown error.', 'desktop-mode' );
+			renderListError( tiles, msg );
+			ctx.done = true;
+		} finally {
+			ctx.loading = false;
+			if ( ctx.abort === controller ) {
+				ctx.abort = null;
+			}
+		}
+
+		// Chain — keep pulling pages while the sentinel is still
+		// within the rootMargin slack. The first page is in; let
+		// the regular `loadMore` pipeline drive any follow-ups.
 		if ( ! ctx.done ) {
 			requestAnimationFrame( () => {
 				if ( sentinelIsVisible() ) {
@@ -847,17 +1033,31 @@ function renderEntityList(
 	void loadMore();
 }
 
+function isAbortError( err: unknown ): boolean {
+	return err instanceof DOMException && err.name === 'AbortError';
+}
+
 function renderListEmpty(
 	host: HTMLElement,
 	entity: MyWordPressEntity,
+	query?: string,
 ): void {
 	const empty = document.createElement( 'div' );
 	empty.className = 'desktop-mode-my-wordpress__empty';
-	empty.textContent = sprintf(
-		// translators: %s is an entity-type label (e.g. "Posts", "Pages").
-		__( 'No %s yet.', 'desktop-mode' ),
-		entity.label.toLowerCase(),
-	);
+	if ( query ) {
+		empty.textContent = sprintf(
+			// translators: 1: search query, 2: lowercased entity-type label.
+			__( 'No %2$s match "%1$s".', 'desktop-mode' ),
+			query,
+			entity.label.toLowerCase(),
+		);
+	} else {
+		empty.textContent = sprintf(
+			// translators: %s is an entity-type label (e.g. "Posts", "Pages").
+			__( 'No %s yet.', 'desktop-mode' ),
+			entity.label.toLowerCase(),
+		);
+	}
 	host.appendChild( empty );
 }
 
@@ -3455,6 +3655,10 @@ interface UserListContext {
 	selectedTile: HTMLElement | null;
 	observer: IntersectionObserver | null;
 	layout: TileLayout;
+	/** @since 0.22.0 */
+	query: string;
+	/** @since 0.22.0 */
+	abort: AbortController | null;
 }
 
 function renderUserEntityList(
@@ -3462,6 +3666,20 @@ function renderUserEntityList(
 	entity: MyWordPressEntity,
 ): void {
 	const cfg = getConfig();
+	const initialQuery = lastQueryByEntity.get( entity.id ) ?? '';
+
+	const toolbar = renderListToolbar( {
+		placeholder: __( 'Search users…', 'desktop-mode' ),
+		ariaLabel: __( 'Search users', 'desktop-mode' ),
+		initialValue: initialQuery,
+		onSearchChange: ( q ) => {
+			lastQueryByEntity.set( entity.id, q );
+			void resetForSearch( q );
+		},
+	} );
+	state.body.appendChild( toolbar.host );
+	state.teardown.push( () => toolbar.destroy() );
+
 	const split = document.createElement( 'div' );
 	split.className = 'desktop-mode-my-wordpress__split';
 
@@ -3513,8 +3731,11 @@ function renderUserEntityList(
 		selectedTile: null,
 		observer: null,
 		layout: tileLayout,
+		query: initialQuery,
+		abort: null,
 	};
 	state.teardown.push( () => tileLayout.dispose() );
+	state.teardown.push( () => ctx.abort?.abort() );
 
 	const repaintListStatus = () => {
 		let itemLabel: string;
@@ -3571,12 +3792,20 @@ function renderUserEntityList(
 		ctx.loading = true;
 		const nextPage = ctx.page + 1;
 		const isFirst = nextPage === 1;
+		const queryAtFetchTime = ctx.query;
 		showLoadingSkeleton( tiles, ctx.layout, isFirst );
+		const controller = new AbortController();
+		ctx.abort = controller;
 		try {
 			const result = await fetchUserList( entity, {
 				page: nextPage,
 				perPage: cfg.perPage,
+				search: queryAtFetchTime || undefined,
+				signal: controller.signal,
 			} );
+			if ( ctx.query !== queryAtFetchTime ) {
+				return;
+			}
 			ctx.page = nextPage;
 			ctx.totalPages = result.totalPages;
 			ctx.total = result.total;
@@ -3584,7 +3813,13 @@ function renderUserEntityList(
 			if ( result.items.length === 0 && isFirst ) {
 				renderListEmptyMessage(
 					tiles,
-					__( 'No users to show.', 'desktop-mode' ),
+					queryAtFetchTime
+						? sprintf(
+							// translators: %s is the user-entered search query.
+							__( 'No users match "%s".', 'desktop-mode' ),
+							queryAtFetchTime,
+						)
+						: __( 'No users to show.', 'desktop-mode' ),
 				);
 				ctx.done = true;
 				repaintListStatus();
@@ -3601,6 +3836,9 @@ function renderUserEntityList(
 			}
 			repaintListStatus();
 		} catch ( err ) {
+			if ( isAbortError( err ) ) {
+				return;
+			}
 			hideLoadingSkeleton( tiles );
 			const msg =
 				err instanceof Error
@@ -3610,7 +3848,114 @@ function renderUserEntityList(
 			ctx.done = true;
 		} finally {
 			ctx.loading = false;
+			if ( ctx.abort === controller ) {
+				ctx.abort = null;
+			}
 		}
+		if ( ! ctx.done ) {
+			requestAnimationFrame( () => {
+				if ( sentinelIsVisible() ) {
+					void loadMore();
+				}
+			} );
+		}
+	};
+
+	const resetForSearch = async ( q: string ): Promise< void > => {
+		// See `renderEntityList`'s `resetForSearch` for the full
+		// rationale — short version: don't rip the grid down to a
+		// skeleton on every keystroke; keep the old tiles visible
+		// (dimmed via the `--searching` class), fetch, then swap.
+		ctx.abort?.abort();
+		ctx.abort = null;
+		ctx.query = q;
+
+		tiles.classList.add(
+			'desktop-mode-my-wordpress__tiles--searching',
+		);
+		hideLoadingSkeleton( tiles );
+
+		const controller = new AbortController();
+		ctx.abort = controller;
+		ctx.loading = true;
+
+		try {
+			const result = await fetchUserList( entity, {
+				page: 1,
+				perPage: cfg.perPage,
+				search: q || undefined,
+				signal: controller.signal,
+			} );
+			if ( ctx.query !== q ) {
+				return;
+			}
+
+			tiles.replaceChildren();
+			ctx.layout.clear();
+			tiles.classList.remove(
+				'desktop-mode-my-wordpress__tiles--searching',
+			);
+
+			ctx.page = 1;
+			ctx.totalPages = result.totalPages;
+			ctx.total = result.total;
+			ctx.loaded = 0;
+			ctx.done = ctx.page >= ctx.totalPages;
+			ctx.selectedId = null;
+			ctx.selectedTile = null;
+			ctx.preview.replaceChildren();
+			const emptyPreview = document.createElement( 'div' );
+			emptyPreview.className =
+				'desktop-mode-my-wordpress__preview-empty';
+			emptyPreview.textContent = __(
+				'Select a user to see their profile here.',
+				'desktop-mode',
+			);
+			ctx.preview.appendChild( emptyPreview );
+
+			if ( result.items.length === 0 ) {
+				renderListEmptyMessage(
+					tiles,
+					q
+						? sprintf(
+							// translators: %s is the user-entered search query.
+							__( 'No users match "%s".', 'desktop-mode' ),
+							q,
+						)
+						: __( 'No users to show.', 'desktop-mode' ),
+				);
+				ctx.done = true;
+			} else {
+				for ( const item of result.items ) {
+					tiles.appendChild(
+						buildUserTile( state, ctx, entity, item ),
+					);
+					ctx.loaded += 1;
+				}
+			}
+			repaintListStatus();
+		} catch ( err ) {
+			if ( isAbortError( err ) ) {
+				return;
+			}
+			tiles.classList.remove(
+				'desktop-mode-my-wordpress__tiles--searching',
+			);
+			tiles.replaceChildren();
+			ctx.layout.clear();
+			const msg =
+				err instanceof Error
+					? err.message
+					: __( 'Unknown error.', 'desktop-mode' );
+			renderListError( tiles, msg );
+			ctx.done = true;
+		} finally {
+			ctx.loading = false;
+			if ( ctx.abort === controller ) {
+				ctx.abort = null;
+			}
+		}
+
 		if ( ! ctx.done ) {
 			requestAnimationFrame( () => {
 				if ( sentinelIsVisible() ) {
@@ -5038,6 +5383,16 @@ interface TileLayout {
 	 * "where the next icons go" promise honest.
 	 */
 	peekNextCells: ( count: number ) => Array< { x: number; y: number } >;
+	/**
+	 * Drop every tracked tile entry and clear the occupied set so the
+	 * same layout instance can be reused for a fresh result set. The
+	 * persisted-positions map on disk stays intact — when a previously-
+	 * placed tile's key reappears (e.g. user clears the search field),
+	 * its remembered position is restored.
+	 *
+	 * @since 0.22.0
+	 */
+	clear: () => void;
 	dispose: () => void;
 }
 
@@ -5364,6 +5719,12 @@ function createTileLayout( host: HTMLElement, scope: string ): TileLayout {
 		return out;
 	};
 
+	const clear = (): void => {
+		entries.length = 0;
+		occupied.clear();
+		host.style.minHeight = '';
+	};
+
 	return {
 		host,
 		scope,
@@ -5372,6 +5733,7 @@ function createTileLayout( host: HTMLElement, scope: string ): TileLayout {
 		sort,
 		reflow,
 		peekNextCells,
+		clear,
 		dispose: () => {
 			resizeObserver?.disconnect();
 			resizeObserver = null;

--- a/src/my-wordpress/list-toolbar.ts
+++ b/src/my-wordpress/list-toolbar.ts
@@ -1,0 +1,147 @@
+/**
+ * My WordPress — list-view toolbar.
+ *
+ * Thin chrome that sits between the breadcrumb header and the tile
+ * grid in every entity list view (Posts, Pages, Users, Media, plus
+ * any plugin-registered kind that mounts the helper). Owns the
+ * search input + a 300ms debounce + native-X clearing.
+ *
+ * Mirrors the visual shape of the Content Graph toolbar's search
+ * input so the two surfaces read as the same control. Server-side
+ * search via `?search=<q>` on each WP REST collection — see
+ * `fetchEntityList`, `fetchUserList`, `fetchMediaPage` for the
+ * pass-through.
+ *
+ * @public
+ * @since 0.22.0
+ */
+
+import { __ } from '../i18n';
+
+const DEBOUNCE_MS = 300;
+
+export interface ListToolbarOptions {
+	/**
+	 * Fires when the debounced search query changes. Empty string
+	 * means "clear the search". Callers reset pagination state and
+	 * refetch page 1 with the new query.
+	 */
+	onSearchChange: ( query: string ) => void;
+	/** Placeholder shown when the input is empty. */
+	placeholder?: string;
+	/** ARIA label for the input. */
+	ariaLabel?: string;
+	/** Initial query value. Empty by default. */
+	initialValue?: string;
+}
+
+export interface ListToolbarHandle {
+	/** Outer DOM element — caller mounts this into the window body. */
+	host: HTMLElement;
+	/** Current debounced query. */
+	getQuery: () => string;
+	/** Tear down the input, debounce timer, and event listeners. */
+	destroy: () => void;
+}
+
+/**
+ * Build a list-view toolbar with a search input. Single piece of
+ * chrome today; the helper exists so future controls (filter chips,
+ * sort, group-by) can be plumbed in one place rather than added to
+ * every list renderer.
+ *
+ * @public
+ * @since 0.22.0
+ */
+export function renderListToolbar(
+	options: ListToolbarOptions,
+): ListToolbarHandle {
+	const host = document.createElement( 'div' );
+	host.className = 'desktop-mode-my-wordpress__list-toolbar';
+
+	const search = document.createElement( 'div' );
+	search.className = 'desktop-mode-my-wordpress__list-toolbar-search';
+
+	const input = document.createElement( 'input' );
+	input.type = 'search';
+	input.className = 'desktop-mode-my-wordpress__list-toolbar-search-input';
+	input.placeholder =
+		options.placeholder ?? __( 'Search…', 'desktop-mode' );
+	input.setAttribute(
+		'aria-label',
+		options.ariaLabel ?? options.placeholder ?? __( 'Search', 'desktop-mode' ),
+	);
+	input.autocomplete = 'off';
+	input.spellcheck = false;
+	if ( options.initialValue ) {
+		input.value = options.initialValue;
+	}
+	search.appendChild( input );
+	host.appendChild( search );
+
+	let debounceId: ReturnType< typeof setTimeout > | null = null;
+	let lastEmitted = options.initialValue ?? '';
+
+	const emit = ( raw: string ) => {
+		const normalized = raw.trim();
+		if ( normalized === lastEmitted ) {
+			return;
+		}
+		lastEmitted = normalized;
+		options.onSearchChange( normalized );
+	};
+
+	const onInput = () => {
+		if ( debounceId !== null ) {
+			clearTimeout( debounceId );
+		}
+		debounceId = setTimeout( () => {
+			debounceId = null;
+			emit( input.value );
+		}, DEBOUNCE_MS );
+	};
+	input.addEventListener( 'input', onInput );
+
+	// Native `type="search"` ships a clear-X in WebKit/Chrome. Clicking
+	// it fires `input` with an empty value AND a `search` event — pin
+	// to the latter as a belt-and-braces so the debounce doesn't add
+	// 300ms of lag to an explicit clear.
+	const onSearchEvent = () => {
+		if ( input.value === '' ) {
+			if ( debounceId !== null ) {
+				clearTimeout( debounceId );
+				debounceId = null;
+			}
+			emit( '' );
+		}
+	};
+	input.addEventListener( 'search', onSearchEvent );
+
+	// Enter commits immediately too — saves the debounce wait for
+	// users who type then press Enter.
+	const onKeydown = ( ev: KeyboardEvent ) => {
+		if ( ev.key === 'Enter' ) {
+			ev.preventDefault();
+			if ( debounceId !== null ) {
+				clearTimeout( debounceId );
+				debounceId = null;
+			}
+			emit( input.value );
+		}
+	};
+	input.addEventListener( 'keydown', onKeydown );
+
+	return {
+		host,
+		getQuery: () => lastEmitted,
+		destroy: () => {
+			if ( debounceId !== null ) {
+				clearTimeout( debounceId );
+				debounceId = null;
+			}
+			input.removeEventListener( 'input', onInput );
+			input.removeEventListener( 'search', onSearchEvent );
+			input.removeEventListener( 'keydown', onKeydown );
+		},
+	};
+}

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -24,11 +24,23 @@ import { attachTileDragOut, buildTileFromSpec } from '../desktop-files/tile-spec
 import { wpdConfirm } from '../ui/components/wpd-confirm-dialog/wpd-confirm-dialog';
 import { showToast } from '../toast';
 import type { EntityRenderHost } from './kind-registry';
+import { renderListToolbar } from './list-toolbar';
 import type { MediaListItem, MyWordPressEntity, MediaPreviewAction } from './types';
 import { deleteMediaItem, fetchMediaItem, fetchMediaPage } from './media-rest';
 import { getConfig } from './rest';
 import { dashiconForMime, renderMediaPreview } from './media-preview';
 import { stripTags } from './dom-utils';
+
+/**
+ * Per-window media search query memory. Survives a media-detail
+ * drill-and-back round-trip so the user doesn't lose their filter.
+ * Lives in module scope but is keyed by entity id — switching from
+ * Media to a different entity clears the field, which is the
+ * intentional UX for "fresh field per entity".
+ *
+ * @since 0.22.0
+ */
+const lastQueryByMediaEntity = new Map< string, string >();
 
 interface MediaListContext {
 	page: number;
@@ -46,6 +58,10 @@ interface MediaListContext {
 	entity: MyWordPressEntity;
 	host: EntityRenderHost;
 	previewActions: MediaPreviewAction[];
+	/** @since 0.22.0 */
+	query: string;
+	/** @since 0.22.0 */
+	abort: AbortController | null;
 }
 
 function describeCount( ctx: MediaListContext ): string {
@@ -428,6 +444,19 @@ export function renderMediaList(
 	entity: MyWordPressEntity,
 ): void {
 	const cfg = getConfig();
+	const initialQuery = lastQueryByMediaEntity.get( entity.id ) ?? '';
+
+	const toolbar = renderListToolbar( {
+		placeholder: __( 'Search media…', 'desktop-mode' ),
+		ariaLabel: __( 'Search media', 'desktop-mode' ),
+		initialValue: initialQuery,
+		onSearchChange: ( q ) => {
+			lastQueryByMediaEntity.set( entity.id, q );
+			void resetForSearch( q );
+		},
+	} );
+	host.body.appendChild( toolbar.host );
+	host.addTeardown( () => toolbar.destroy() );
 
 	const split = document.createElement( 'div' );
 	split.className =
@@ -487,7 +516,10 @@ export function renderMediaList(
 		entity,
 		host,
 		previewActions: cfg.previewActions ?? [],
+		query: initialQuery,
+		abort: null,
 	};
+	host.addTeardown( () => ctx.abort?.abort() );
 
 	const sentinelIsVisible = (): boolean => {
 		const sr = sentinel.getBoundingClientRect();
@@ -503,16 +535,33 @@ export function renderMediaList(
 		ctx.loading = true;
 		const nextPage = ctx.page + 1;
 		const perPage = cfg.mediaPerPage ?? 48;
+		const queryAtFetchTime = ctx.query;
+		const controller = new AbortController();
+		ctx.abort = controller;
 		try {
 			const result = await fetchMediaPage( entity, {
 				page: nextPage,
 				perPage,
+				search: queryAtFetchTime || undefined,
+				signal: controller.signal,
 			} );
+			if ( ctx.query !== queryAtFetchTime ) {
+				return;
+			}
 			ctx.page = nextPage;
 			ctx.totalPages = result.totalPages;
 			ctx.total = result.total;
 			if ( result.items.length === 0 && nextPage === 1 ) {
-				renderEmpty( tiles, __( 'No media yet.', 'desktop-mode' ) );
+				renderEmpty(
+					tiles,
+					queryAtFetchTime
+						? sprintf(
+							// translators: %s is the user-entered search query.
+							__( 'No media match "%s".', 'desktop-mode' ),
+							queryAtFetchTime,
+						)
+						: __( 'No media yet.', 'desktop-mode' ),
+				);
 				ctx.done = true;
 				paintStatus( ctx );
 				return;
@@ -526,6 +575,9 @@ export function renderMediaList(
 			}
 			paintStatus( ctx );
 		} catch ( err ) {
+			if ( err instanceof DOMException && err.name === 'AbortError' ) {
+				return;
+			}
 			const message =
 				err instanceof Error
 					? err.message
@@ -534,7 +586,110 @@ export function renderMediaList(
 			ctx.done = true;
 		} finally {
 			ctx.loading = false;
+			if ( ctx.abort === controller ) {
+				ctx.abort = null;
+			}
 		}
+		if ( ! ctx.done ) {
+			requestAnimationFrame( () => {
+				if ( sentinelIsVisible() ) {
+					void loadMore();
+				}
+			} );
+		}
+	};
+
+	const resetForSearch = async ( q: string ): Promise< void > => {
+		// Keep the previous results visible (dimmed via the
+		// `--searching` class) until the new page lands, then swap
+		// atomically. See `renderEntityList.resetForSearch` for the
+		// full rationale — same fix shape applied here.
+		ctx.abort?.abort();
+		ctx.abort = null;
+		ctx.query = q;
+
+		tiles.classList.add(
+			'desktop-mode-my-wordpress__media-grid--searching',
+		);
+
+		const controller = new AbortController();
+		ctx.abort = controller;
+		ctx.loading = true;
+		const perPage = cfg.mediaPerPage ?? 48;
+
+		try {
+			const result = await fetchMediaPage( entity, {
+				page: 1,
+				perPage,
+				search: q || undefined,
+				signal: controller.signal,
+			} );
+			if ( ctx.query !== q ) {
+				return;
+			}
+
+			tiles.replaceChildren();
+			tiles.classList.remove(
+				'desktop-mode-my-wordpress__media-grid--searching',
+			);
+
+			ctx.page = 1;
+			ctx.totalPages = result.totalPages;
+			ctx.total = result.total;
+			ctx.loaded = 0;
+			ctx.done = ctx.page >= ctx.totalPages;
+			ctx.selectedId = null;
+			ctx.selectedTile = null;
+			ctx.preview.replaceChildren();
+			const emptyPreview = document.createElement( 'div' );
+			emptyPreview.className =
+				'desktop-mode-my-wordpress__preview-empty';
+			emptyPreview.textContent = __(
+				'Select a media item to preview it here.',
+				'desktop-mode',
+			);
+			ctx.preview.appendChild( emptyPreview );
+
+			if ( result.items.length === 0 ) {
+				renderEmpty(
+					tiles,
+					q
+						? sprintf(
+							// translators: %s is the user-entered search query.
+							__( 'No media match "%s".', 'desktop-mode' ),
+							q,
+						)
+						: __( 'No media yet.', 'desktop-mode' ),
+				);
+				ctx.done = true;
+			} else {
+				for ( const item of result.items ) {
+					tiles.appendChild( buildMediaTile( ctx, item ) );
+					ctx.loaded += 1;
+				}
+			}
+			paintStatus( ctx );
+		} catch ( err ) {
+			if ( err instanceof DOMException && err.name === 'AbortError' ) {
+				return;
+			}
+			tiles.classList.remove(
+				'desktop-mode-my-wordpress__media-grid--searching',
+			);
+			tiles.replaceChildren();
+			const message =
+				err instanceof Error
+					? err.message
+					: __( 'Unknown error.', 'desktop-mode' );
+			renderEmpty( tiles, message );
+			ctx.done = true;
+		} finally {
+			ctx.loading = false;
+			if ( ctx.abort === controller ) {
+				ctx.abort = null;
+			}
+		}
+
 		if ( ! ctx.done ) {
 			requestAnimationFrame( () => {
 				if ( sentinelIsVisible() ) {

--- a/src/my-wordpress/media-rest.ts
+++ b/src/my-wordpress/media-rest.ts
@@ -67,7 +67,18 @@ async function readErrorMessage(
  */
 export async function fetchMediaPage(
 	entity: MyWordPressEntity,
-	params: { page: number; perPage: number },
+	params: {
+		page: number;
+		perPage: number;
+		/**
+		 * Optional search query. Passed verbatim to `/wp/v2/media` as
+		 * `?search=…`, which matches attachment titles + filenames.
+		 *
+		 * @since 0.22.0
+		 */
+		search?: string;
+		signal?: AbortSignal;
+	},
 ): Promise< MediaListResult > {
 	const cfg = getConfig();
 	const url = new URL( buildUrl( entity.restPath ) );
@@ -83,6 +94,9 @@ export async function fetchMediaPage(
 	// Attachments are stored under `status=inherit`; the default
 	// `publish` filter on `wp/v2/media` returns an empty list.
 	url.searchParams.set( 'status', 'inherit' );
+	if ( params.search ) {
+		url.searchParams.set( 'search', params.search );
+	}
 
 	const response = await shellFetch( url.toString(), {
 		method: 'GET',
@@ -91,6 +105,7 @@ export async function fetchMediaPage(
 			'X-WP-Nonce': cfg.restNonce,
 			Accept: 'application/json',
 		},
+		signal: params.signal,
 	} );
 
 	if ( ! response.ok ) {

--- a/src/my-wordpress/rest.ts
+++ b/src/my-wordpress/rest.ts
@@ -64,6 +64,23 @@ async function shellFetch(
 interface ListParams {
 	page: number;
 	perPage: number;
+	/**
+	 * Optional server-side search query. Passed verbatim to the WP
+	 * REST endpoint via `?search=…`, which runs a LIKE against the
+	 * collection's indexed columns (`post_title` + `post_content` for
+	 * posts; see the per-fetcher comments below for the others).
+	 *
+	 * @since 0.22.0
+	 */
+	search?: string;
+	/**
+	 * Optional `AbortSignal` so callers can cancel a stale page-fetch
+	 * when the user types a new search query before the previous
+	 * round-trip lands.
+	 *
+	 * @since 0.22.0
+	 */
+	signal?: AbortSignal;
 }
 
 export async function fetchEntityList(
@@ -84,6 +101,9 @@ export async function fetchEntityList(
 	// statuses, so unauthorized users still only see what they can
 	// read.
 	url.searchParams.set( 'status', 'publish,future,draft,pending,private' );
+	if ( params.search ) {
+		url.searchParams.set( 'search', params.search );
+	}
 
 	const response = await shellFetch( url.toString(), {
 		method: 'GET',
@@ -92,6 +112,7 @@ export async function fetchEntityList(
 			'X-WP-Nonce': cfg.restNonce,
 			Accept: 'application/json',
 		},
+		signal: params.signal,
 	} );
 
 	if ( ! response.ok ) {
@@ -261,7 +282,19 @@ export async function fetchEntityTotal(
  */
 export async function fetchUserList(
 	entity: MyWordPressEntity,
-	params: { page: number; perPage: number },
+	params: {
+		page: number;
+		perPage: number;
+		/**
+		 * Optional search query. Passed verbatim to `/wp/v2/users` as
+		 * `?search=…`, which matches against user_login, user_nicename,
+		 * user_email, user_url, and display_name.
+		 *
+		 * @since 0.22.0
+		 */
+		search?: string;
+		signal?: AbortSignal;
+	},
 ): Promise< UserListResult > {
 	const cfg = getConfig();
 	const buildRequestUrl = ( mode: 'edit' | 'authors' ): string => {
@@ -279,6 +312,9 @@ export async function fetchUserList(
 		} else {
 			url.searchParams.set( 'who', 'authors' );
 		}
+		if ( params.search ) {
+			url.searchParams.set( 'search', params.search );
+		}
 		return url.toString();
 	};
 
@@ -290,6 +326,7 @@ export async function fetchUserList(
 				'X-WP-Nonce': cfg.restNonce,
 				Accept: 'application/json',
 			},
+			signal: params.signal,
 		} );
 
 	let response = await send( buildRequestUrl( 'edit' ) );


### PR DESCRIPTION
## Summary

Adds a search input above the Posts / Pages / Users / Media (and any plugin-registered) entity list views in the My WordPress window. Mirrors the visual treatment of the Content Graph search input so the two surfaces read as the same control — but the implementation diverges:

- **Server-side, not client-side.** Every WP REST collection supports `?search=…` natively against indexed columns (`post_title` + `post_content`, user_login/email/nicename/display_name, attachment title/filename). Client-side filtering would only match the ~24–48 tiles in memory at any moment, which would be useless for paginated infinite-scroll lists.
- **Atomic swap, not skeleton flash.** Previous results stay visible (dimmed) while the new page resolves, then replace in a single frame. No "intermediate page" between keystrokes.

## What's in here

- **`renderListToolbar`** — shared helper (300ms debounce, native-X clear, Enter-to-commit) consumed by all three built-in list renderers.
- **REST plumbing** — `fetchEntityList`, `fetchUserList`, `fetchMediaPage` gain optional `search` + `signal` params. No new endpoints, no PHP changes.
- **Race guards** — `AbortController` per page fetch + a stale-query check so fast typing can't paint a previous query's tiles into the current grid.
- **Per-entity remembered query** — survives a click-into-detail-and-back round-trip; resets when switching entities (e.g. Posts → Pages).
- **Empty-state copy** — \`No <entity> match \"<query>\".\` for zero-result searches.
- **`TileLayout.clear()`** — small new method so the canvas can be reused for a fresh result set without disposing and rebuilding the layout instance.

## UX notes

- Placement: own row below the breadcrumb header (full width, predictable space, room for future filter / sort controls). The Content Graph toolbar lives in the same spot for the same reasons.
- Dimming during in-flight searches uses `opacity: 0.45` + 120ms ease-out on `--searching`. The title-bar activity pulse (free from `trackedFetch`) carries the rest of the "work in progress" feedback.
- Search query persistence is per-entity, in-memory only. Closing and reopening the window resets it.

## Performance

- One REST round-trip per debounced keystroke, payload shape identical to a normal list fetch.
- No client-side index, no bundle-size hit beyond the helper (~80 LOC).
- Caveat: `/wp/v2/posts?search=foo` searches title + content. `post_title` is indexed, `post_content` is not (no FULLTEXT). Fine at typical site sizes; can get slow on very large content. Out of scope for v1.

## Test plan

- [ ] Type in the search field on Posts — results refine without skeleton flash.
- [ ] Type fast (race scenario) — only the final query's results paint.
- [ ] Native search-input X clears immediately, no 300ms debounce wait.
- [ ] Empty result — shows \`No posts match \"xyz\".\`.
- [ ] Click into a post, back out — search query persists.
- [ ] Switch Posts → Pages — search field resets.
- [ ] Same flow on Users.
- [ ] Same flow on Media.
- [ ] Reorder / dock collapse / window resize while a search is in flight — no stale paints.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-254-88d90d0de29986b5c64f8f7eb9c69555bd64f993.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->