### PR TITLE
Pre demo polishment

### DIFF
--- a/includes/my-wordpress/user-footprint.php
+++ b/includes/my-wordpress/user-footprint.php
@@ -25,10 +25,18 @@
  *     hour:    [ 0..23 ],                                      // post counts, server-local hour
  *     streak:  { longest, current, longestRange:{ from, to } },
  *     timeline:[                                               // 30 most recent activity rows
- *       { kind:'post'|'comment'|'post-update', date, title, link, status, postId? }
+ *       { kind:'post'|'comment'|'post-update', date, title, link, status, postId?, type? }
  *     ],
  *     totals:  { posts, pages, comments, updates, mostProlificMonth?:{ ym, n } }
  *   }
+ *
+ * Timeline row fields:
+ * - `kind`   — discriminator: `'post'` (publish), `'comment'`, or
+ *              `'post-update'` (revision rollup).
+ * - `type`   — only set when `kind` is `'post'` or `'post-update'`.
+ *              Carries the post's CPT slug (`'post'`, `'page'`, custom
+ *              types) so the renderer can pick a Post-vs-Page icon
+ *              without a second REST lookup.
  *
  * "Updates" are revisions saved by the user AFTER a post's original
  * creation — i.e. the user opened an existing post and saved it

--- a/includes/my-wordpress/user-footprint.php
+++ b/includes/my-wordpress/user-footprint.php
@@ -19,16 +19,22 @@
  *
  *   {
  *     profile: { id, name, avatarUrl, link, roleLabels?, registered? },
- *     range:   { from, to, days },             // YYYY-MM-DD bookends + day count
- *     daily:   [ { date, posts, comments } ], // length = range.days; missing days = 0/0
- *     weekday: [ 0..6 ],                      // post counts, Sunday-indexed
- *     hour:    [ 0..23 ],                     // post counts, server-local hour
+ *     range:   { from, to, days },                              // YYYY-MM-DD bookends + day count
+ *     daily:   [ { date, posts, comments, updates } ],         // length = range.days; missing days = 0
+ *     weekday: [ 0..6 ],                                       // post counts, Sunday-indexed
+ *     hour:    [ 0..23 ],                                      // post counts, server-local hour
  *     streak:  { longest, current, longestRange:{ from, to } },
- *     timeline:[                              // 30 most recent activity rows
- *       { kind:'post'|'comment', date, title, link, status, postId? }
+ *     timeline:[                                               // 30 most recent activity rows
+ *       { kind:'post'|'comment'|'post-update', date, title, link, status, postId? }
  *     ],
- *     totals:  { posts, pages, comments, mostProlificMonth?:{ ym, n } }
+ *     totals:  { posts, pages, comments, updates, mostProlificMonth?:{ ym, n } }
  *   }
+ *
+ * "Updates" are revisions saved by the user AFTER a post's original
+ * creation — i.e. the user opened an existing post and saved it
+ * again. The initial save (which WordPress also writes as a revision)
+ * is excluded so the per-day "updates" count doesn't double up with
+ * the per-day "posts" count.
  *
  * @package WPDesktopMode
  * @since   0.20.0
@@ -165,6 +171,35 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 		$comment_by_day[ (string) $row['d'] ] = (int) $row['n'];
 	}
 
+	// Updates = revisions saved by this user, joined back to the
+	// parent post so we can skip the initial-save revision (where the
+	// revision's `post_date_gmt` equals the parent's `post_date_gmt`).
+	// `r.post_author` (not the parent's) tracks who hit Save, so
+	// updates an editor makes to someone else's post show up on the
+	// editor's footprint — same shape GitHub's contribution graph
+	// uses for commits across repos you don't own.
+	$update_rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT DATE(r.post_date_gmt) AS d, COUNT(*) AS n
+			FROM {$wpdb->posts} r
+			INNER JOIN {$wpdb->posts} p ON r.post_parent = p.ID
+			WHERE r.post_author = %d
+				AND r.post_type = 'revision'
+				AND r.post_status = 'inherit'
+				AND r.post_date_gmt > p.post_date_gmt
+				AND r.post_date_gmt >= %s
+			GROUP BY d
+			ORDER BY d ASC",
+			$user_id,
+			gmdate( 'Y-m-d 00:00:00', $from_ts )
+		),
+		ARRAY_A
+	);
+	$update_by_day = array();
+	foreach ( (array) $update_rows as $row ) {
+		$update_by_day[ (string) $row['d'] ] = (int) $row['n'];
+	}
+
 	$daily = array();
 	for ( $i = 0; $i < $days; $i += 1 ) {
 		$ts   = strtotime( '+' . $i . ' days', $from_ts );
@@ -173,6 +208,7 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 			'date'     => $date,
 			'posts'    => isset( $post_by_day[ $date ] ) ? $post_by_day[ $date ] : 0,
 			'comments' => isset( $comment_by_day[ $date ] ) ? $comment_by_day[ $date ] : 0,
+			'updates'  => isset( $update_by_day[ $date ] ) ? $update_by_day[ $date ] : 0,
 		);
 	}
 
@@ -233,8 +269,17 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 	$today_str       = $range['to'];
 	$prev_day_active = false;
 
+	// "Active" = published a post, left a comment, or saved a revision.
+	// Pre-0.8.7 this only counted publish days, so an editor doing
+	// daily updates without new posts had a "0 day" streak — wrong
+	// flavour of GitHub-style for a CMS where most work is editing.
+	$is_active = static function ( $entry ) {
+		return $entry['posts'] > 0
+			|| ( isset( $entry['updates'] ) && $entry['updates'] > 0 )
+			|| ( isset( $entry['comments'] ) && $entry['comments'] > 0 );
+	};
 	foreach ( $daily as $entry ) {
-		if ( $entry['posts'] > 0 ) {
+		if ( $is_active( $entry ) ) {
 			if ( ! $prev_day_active ) {
 				$run_start = $entry['date'];
 			}
@@ -252,7 +297,7 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 	}
 	// Current streak — walk backward from today.
 	for ( $i = count( $daily ) - 1; $i >= 0; $i -= 1 ) {
-		if ( $daily[ $i ]['posts'] > 0 ) {
+		if ( $is_active( $daily[ $i ] ) ) {
 			$current += 1;
 		} else {
 			break;
@@ -298,6 +343,29 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 		),
 		ARRAY_A
 	);
+	// Recent updates — newest revision per parent post saved by this
+	// user. We collapse per-parent (`GROUP BY r.post_parent`) so a
+	// burst of saves on one post reads as one row in the activity
+	// list (otherwise an editor polishing a single article would push
+	// every other event off the screen). The MAX(r.post_date_gmt)
+	// surfaces the most recent save as the row's timestamp.
+	$timeline_updates = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT r.post_parent AS parent_id, MAX(r.post_date_gmt) AS last_save, p.post_title, p.post_status, p.post_type
+			FROM {$wpdb->posts} r
+			INNER JOIN {$wpdb->posts} p ON r.post_parent = p.ID
+			WHERE r.post_author = %d
+				AND r.post_type = 'revision'
+				AND r.post_status = 'inherit'
+				AND r.post_date_gmt > p.post_date_gmt
+				AND p.post_status NOT IN ( 'auto-draft', 'inherit', 'trash' )
+			GROUP BY r.post_parent
+			ORDER BY last_save DESC
+			LIMIT 30",
+			$user_id
+		),
+		ARRAY_A
+	);
 	$timeline = array();
 	foreach ( (array) $timeline_posts as $p ) {
 		$pid = (int) $p['ID'];
@@ -320,6 +388,18 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 			'status' => 'approved',
 			'postId' => $pid,
 			'link'   => $pid ? (string) get_permalink( $pid ) : '',
+		);
+	}
+	foreach ( (array) $timeline_updates as $u ) {
+		$pid = (int) $u['parent_id'];
+		$timeline[] = array(
+			'kind'   => 'post-update',
+			'date'   => mysql2date( 'c', $u['last_save'], false ),
+			'title'  => (string) $u['post_title'],
+			'status' => (string) $u['post_status'],
+			'postId' => $pid,
+			'link'   => $pid ? (string) get_permalink( $pid ) : '',
+			'type'   => (string) $u['post_type'],
 		);
 	}
 	usort(
@@ -356,6 +436,20 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 			$user_id
 		)
 	);
+	// Lifetime updates = revisions this user saved after the initial
+	// creation of the parent post. Matches the per-day `updates`
+	// definition so the hero stat and heatmap rollups agree.
+	$totals_updates = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM {$wpdb->posts} r
+			INNER JOIN {$wpdb->posts} p ON r.post_parent = p.ID
+			WHERE r.post_author = %d
+				AND r.post_type = 'revision'
+				AND r.post_status = 'inherit'
+				AND r.post_date_gmt > p.post_date_gmt",
+			$user_id
+		)
+	);
 	$month_row = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT DATE_FORMAT(post_date_gmt, '%%Y-%%m') AS ym, COUNT(*) AS n
@@ -374,6 +468,7 @@ function desktop_mode_my_wordpress_user_footprint_callback( $request ) {
 		'posts'    => $totals_posts,
 		'pages'    => $totals_pages,
 		'comments' => $totals_comments,
+		'updates'  => $totals_updates,
 	);
 	if ( $month_row && isset( $month_row['ym'] ) ) {
 		$totals['mostProlificMonth'] = array(

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -1809,6 +1809,13 @@ export class Dock {
 			return;
 		}
 
+		// Resolved through the public-API global typed in `global.d.ts`
+		// (WpDesktopPublicApi), so a future signature change to
+		// `openNewWindow` shows up at THIS call site instead of being
+		// hidden behind an inline `as unknown as { wp?: … }` cast that
+		// pinned a stale local shape.
+		const openNewWindow = window.wp?.desktop?.openNewWindow;
+
 		// Dock-promoted desktop icons whose target is a native window
 		// (My WordPress, Jorvy, plugin-registered launchers) carry the
 		// registry id on `item.windowId` and ship with an empty `url`.
@@ -1818,10 +1825,7 @@ export class Dock {
 		// iframe whose `src=''` never loads (user-visible symptom: the
 		// duplicate window appears with just the title bar).
 		if ( item.windowId && ! item.url ) {
-			const api = ( window as unknown as {
-				wp?: { desktop?: { openNewWindow?: ( id: string, opts?: { source?: string } ) => boolean } };
-			} ).wp?.desktop;
-			if ( api?.openNewWindow?.( item.windowId, { source: 'dock-peek' } ) ) {
+			if ( openNewWindow?.( item.windowId, { source: 'dock-peek' } ) ) {
 				return;
 			}
 		}
@@ -1837,10 +1841,7 @@ export class Dock {
 		// the URL instead of a duplicate of the native window.
 		const remappedId = resolveNativeUrlRemap( item.url );
 		if ( remappedId ) {
-			const api = ( window as unknown as {
-				wp?: { desktop?: { openNewWindow?: ( id: string, opts?: { source?: string } ) => boolean } };
-			} ).wp?.desktop;
-			if ( api?.openNewWindow?.( remappedId, { source: 'dock-peek' } ) ) {
+			if ( openNewWindow?.( remappedId, { source: 'dock-peek' } ) ) {
 				return;
 			}
 		}

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -1809,6 +1809,23 @@ export class Dock {
 			return;
 		}
 
+		// Dock-promoted desktop icons whose target is a native window
+		// (My WordPress, Jorvy, plugin-registered launchers) carry the
+		// registry id on `item.windowId` and ship with an empty `url`.
+		// Route those directly through the native opener so the +
+		// spawns a fresh native instance — without this branch the
+		// `deriveWindowId('')` fallthrough below opens a chrome-only
+		// iframe whose `src=''` never loads (user-visible symptom: the
+		// duplicate window appears with just the title bar).
+		if ( item.windowId && ! item.url ) {
+			const api = ( window as unknown as {
+				wp?: { desktop?: { openNewWindow?: ( id: string, opts?: { source?: string } ) => boolean } };
+			} ).wp?.desktop;
+			if ( api?.openNewWindow?.( item.windowId, { source: 'dock-peek' } ) ) {
+				return;
+			}
+		}
+
 		// If the item's URL is claimed by a native-window remap (Posts,
 		// Pages, Users, Comments, Plugins, …), spawn a fresh native
 		// instance via the registry — same path as the regular dock

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -4360,6 +4360,19 @@ function buildFootprintHeadlineStats(
 			'',
 		),
 	);
+	// Lifetime saves on existing content — the editor counterpart to
+	// "Total content" / "Comments left". Skipped when zero so a
+	// brand-new author doesn't see an empty card.
+	const updateCount = payload.totals.updates ?? 0;
+	if ( updateCount > 0 ) {
+		wrap.appendChild(
+			buildStatCard(
+				updateCount.toLocaleString(),
+				__( 'Updates', 'desktop-mode' ),
+				__( 'Saves on existing posts', 'desktop-mode' ),
+			),
+		);
+	}
 
 	const longestRange = payload.streak.longestRange;
 	const longestCaption =
@@ -4428,8 +4441,13 @@ function buildFootprintCalendar(
 
 	// Bucket each day by intensity. Max intensity in the window
 	// drives the scale so a sparse poster's pattern still reads.
+	// Update saves count toward the intensity alongside fresh posts
+	// and comments — same shape as GitHub, where edits to existing
+	// content paint the calendar just as boldly as net-new work.
+	const dayIntensity = ( d: UserFootprint[ 'daily' ][ number ] ): number =>
+		d.posts + d.comments + ( d.updates ?? 0 );
 	const maxIntensity = payload.daily.reduce( ( m, d ) => {
-		const v = d.posts + d.comments;
+		const v = dayIntensity( d );
 		return v > m ? v : m;
 	}, 0 );
 	const bucketize = ( v: number ): number => {
@@ -4550,18 +4568,19 @@ function buildFootprintCalendar(
 	}
 	for ( let i = 0; i < payload.daily.length; i += 1 ) {
 		const d = payload.daily[ i ];
-		const intensity = bucketize( d.posts + d.comments );
+		const intensity = bucketize( dayIntensity( d ) );
 		const cell = document.createElement( 'span' );
 		cell.className = `desktop-mode-my-wordpress__footprint-cell desktop-mode-my-wordpress__footprint-cell--l${ intensity }`;
 		cell.title = sprintf(
-			// translators: 1: date, 2: post count, 3: comment count.
+			// translators: 1: date, 2: post count, 3: comment count, 4: update (re-save) count.
 			__(
-				'%1$s — %2$d posts, %3$d comments',
+				'%1$s — %2$d posts, %3$d comments, %4$d updates',
 				'desktop-mode',
 			),
 			formatLongDate( d.date ),
 			d.posts,
 			d.comments,
+			d.updates ?? 0,
 		);
 		cell.dataset.date = d.date;
 		placeCell( cell, firstDow + i );
@@ -4786,11 +4805,13 @@ function buildFootprintTimeline(
 		const dot = document.createElement( 'span' );
 		dot.className = 'desktop-mode-my-wordpress__footprint-dot';
 		const icon = document.createElement( 'span' );
-		icon.className =
-			'dashicons ' +
-			( ev.kind === 'comment'
-				? 'dashicons-admin-comments'
-				: 'dashicons-admin-post' );
+		let iconClass = 'dashicons-admin-post';
+		if ( ev.kind === 'comment' ) {
+			iconClass = 'dashicons-admin-comments';
+		} else if ( ev.kind === 'post-update' ) {
+			iconClass = 'dashicons-edit';
+		}
+		icon.className = 'dashicons ' + iconClass;
 		icon.setAttribute( 'aria-hidden', 'true' );
 		dot.appendChild( icon );
 		li.appendChild( dot );
@@ -4804,14 +4825,21 @@ function buildFootprintTimeline(
 			: document.createElement( 'span' );
 		titleNode.className =
 			'desktop-mode-my-wordpress__footprint-event-title';
-		titleNode.textContent =
-			ev.kind === 'comment'
-				? sprintf(
-					// translators: %s is a post title the user commented on.
-					__( 'Commented on “%s”', 'desktop-mode' ),
-					title,
-				)
-				: title;
+		if ( ev.kind === 'comment' ) {
+			titleNode.textContent = sprintf(
+				// translators: %s is a post title the user commented on.
+				__( 'Commented on “%s”', 'desktop-mode' ),
+				title,
+			);
+		} else if ( ev.kind === 'post-update' ) {
+			titleNode.textContent = sprintf(
+				// translators: %s is the post title the user re-saved.
+				__( 'Updated “%s”', 'desktop-mode' ),
+				title,
+			);
+		} else {
+			titleNode.textContent = title;
+		}
 		if ( ev.link && titleNode instanceof HTMLAnchorElement ) {
 			titleNode.href = ev.link;
 			titleNode.target = '_blank';

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -5432,15 +5432,30 @@ function storageKey( scope: string ): string {
 // for drag-out and a plain `click` listener for selection.
 
 /**
- * Live `RenderState` for the currently-mounted My WordPress
- * window, or `null` when it isn't open. Captured in `renderInto`
- * and cleared on close — used by the public
+ * The most-recently-mounted My WordPress window's `RenderState`, or
+ * `null` when none is open. Used by the public
  * `wp.desktop.myWordpress.openDetail()` API so any other shell
  * surface (folder window CMO, plugin code) can route the My
  * WordPress window directly into a post's detail dossier without
- * duplicating the per-relation rendering.
+ * duplicating the per-relation rendering. When multiple instances
+ * are open (a duplicate spawned via `wp.desktop.openNewWindow`, or a
+ * second copy on another virtual desktop) this points at the
+ * latest mount — that's the one the user just acted on, so a
+ * fresh `openDetail()` navigates it in place rather than spawning
+ * another window.
  */
 let activeState: RenderState | null = null;
+/**
+ * Every currently-mounted `RenderState`, keyed by its body host
+ * element. Multi-instance support: the kind-registry renderers
+ * receive an opaque `EntityRenderHost` derived from a specific
+ * window's state, and we need to recover the matching state even
+ * when it isn't the most recently focused one. Without this map,
+ * navigating inside a NON-latest instance threw — `asRenderState`
+ * fell back to the singleton `activeState` and rejected the call
+ * because the bodies didn't match.
+ */
+const liveStates = new Map< HTMLElement, RenderState >();
 /**
  * Pending route applied on next `renderInto`. When the My WordPress
  * window isn't open yet, `openDetail()` opens it AND queues a
@@ -5448,17 +5463,26 @@ let activeState: RenderState | null = null;
  * queue.
  */
 let pendingRoute: Route | null = null;
+/**
+ * Monotonic counter for the per-instance drop-target id. Multiple
+ * My WordPress windows can coexist (duplicate via the dock peek,
+ * a second copy on another virtual desktop), so the claimant id
+ * has to be unique per render — otherwise the second registration
+ * silently replaces the first's element binding in the drag
+ * registry and instance 1's body stops rejecting drops.
+ */
+let rejectIdCounter = 0;
 
-function renderInto( body: HTMLElement ): void {
+function renderInto( body: HTMLElement ): ( () => void ) | undefined {
 	const root = body.querySelector< HTMLElement >( ROOT_SEL );
 	if ( ! root ) {
-		return;
+		return undefined;
 	}
 	const breadcrumbsHost = root.querySelector< HTMLElement >( BREADCRUMBS_SEL );
 	const bodyHost = root.querySelector< HTMLElement >( BODY_SEL );
 	const statusHost = root.querySelector< HTMLElement >( STATUS_SEL );
 	if ( ! breadcrumbsHost || ! bodyHost || ! statusHost ) {
-		return;
+		return undefined;
 	}
 
 	const state: RenderState = {
@@ -5471,6 +5495,17 @@ function renderInto( body: HTMLElement ): void {
 		history: [],
 	};
 	activeState = state;
+	liveStates.set( bodyHost, state );
+
+	// Window-lifetime teardowns — tracked OUTSIDE `state.teardown`
+	// because `navigate()` flushes the latter on every route change.
+	// Putting drop-target deregistration and tile-menu cleanup in
+	// `state.teardown` (the previous shape) meant the first
+	// `navigate( state, root )` call below ran them immediately, so
+	// the window's drop-rejection claimant never survived past the
+	// initial paint. These run exclusively from the returned
+	// teardown.
+	const windowTeardowns: Array< () => void > = [];
 
 	// Register a CLAIMANT drop target on the window body that rejects
 	// every payload. My WordPress is a read-only directory listing
@@ -5490,8 +5525,9 @@ function renderInto( body: HTMLElement ): void {
 	// @since 0.20.0
 	const dragManager = getDragManager();
 	if ( dragManager ) {
+		rejectIdCounter += 1;
 		const deregister = dragManager.registerDropTarget( {
-			id: `${ WINDOW_ID }-reject`,
+			id: `${ WINDOW_ID }-reject-${ rejectIdCounter }`,
 			element: body,
 			accept: () => false,
 			onDrop: () => {
@@ -5499,41 +5535,58 @@ function renderInto( body: HTMLElement ): void {
 				// commit path. Defined for the type contract.
 			},
 		} );
-		state.teardown.push( deregister );
+		windowTeardowns.push( deregister );
 	}
 
 	// Back button + crumb-click handlers are wired by the shared
 	// breadcrumb helper inside `updateBreadcrumbs` — no per-element
 	// listener wiring here anymore.
 
-	// Tear down on close.
-	const closeHandler = ( e: Event ) => {
-		const detail = ( e as CustomEvent< { windowId?: string } > ).detail;
-		if ( detail?.windowId === WINDOW_ID ) {
-			clearTeardown( state );
-			closeAnyTileMenu();
-			if ( activeState === state ) {
-				activeState = null;
-			}
-			document.removeEventListener( 'desktop-mode-window-closed', closeHandler );
-		}
-	};
-	document.addEventListener( 'desktop-mode-window-closed', closeHandler );
-	state.teardown.push( () => closeAnyTileMenu() );
+	windowTeardowns.push( () => closeAnyTileMenu() );
 
 	// If the consumer opened the window via `openDetail` while it
 	// was closed, the queued route is the actual destination.
 	const initialRoute = pendingRoute ?? { kind: 'root' };
 	pendingRoute = null;
 	navigate( state, initialRoute );
+
+	// Return a teardown the framework invokes when THIS specific
+	// window closes. The framework wires it to the per-window
+	// lifecycle (see `Window.hydrateNative`), so a duplicate
+	// instance closing only tears down its OWN state — the previous
+	// implementation listened for `desktop-mode-window-closed`
+	// globally and matched on the base WINDOW_ID, which fired for
+	// every sibling's close event and clobbered live instances.
+	return () => {
+		clearTeardown( state );
+		for ( const fn of windowTeardowns ) {
+			try {
+				fn();
+			} catch {
+				/* swallow — teardown best-effort */
+			}
+		}
+		windowTeardowns.length = 0;
+		liveStates.delete( bodyHost );
+		if ( activeState === state ) {
+			// Promote whichever sibling is still alive to active so
+			// `openDetail` / `openMedia` keep routing to an open
+			// instance instead of spawning a fresh window.
+			const next = liveStates.size > 0
+				? Array.from( liveStates.values() ).pop()!
+				: null;
+			activeState = next;
+		}
+	};
 }
 
 const callback: RenderCallback = ( body ) => {
 	try {
-		renderInto( body );
+		return renderInto( body );
 	} catch ( err ) {
 		// eslint-disable-next-line no-console
 		console.error( '[my-wordpress] render failed:', err );
+		return undefined;
 	}
 };
 
@@ -5557,21 +5610,27 @@ registerEntityKind( 'media', renderMediaList );
  * the registry passes the public host shape so plugins can call
  * `host.navigate` / `host.addTeardown`. This shim bridges the
  * two during the gradual rewrite.
+ *
+ * Looks up `host.body` in the live-states map (instead of
+ * comparing against the singleton `activeState`) so navigating
+ * inside a NON-latest instance still resolves to the correct
+ * state. Without the map lookup, every kind-registry render
+ * (Posts list, Users list, …) in a backgrounded duplicate threw
+ * with "host body does not match active state" — the symptom the
+ * user saw as "the second window won't load" once they tried to
+ * drill in.
  */
 function asRenderState( host: EntityRenderHost ): RenderState {
-	if ( ! activeState ) {
-		throw new Error(
-			'[my-wordpress] asRenderState: called outside an active render.',
-		);
+	const found = liveStates.get( host.body );
+	if ( found ) {
+		return found;
 	}
-	// Sanity check — the host MUST be derived from the active state
-	// or we're about to scribble into a defunct render frame.
-	if ( host.body !== activeState.body ) {
-		throw new Error(
-			'[my-wordpress] asRenderState: host body does not match active state.',
-		);
+	if ( activeState && host.body === activeState.body ) {
+		return activeState;
 	}
-	return activeState;
+	throw new Error(
+		'[my-wordpress] asRenderState: host body does not match any live render state.',
+	);
 }
 
 /* ------------------------------------------------------------------ *

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -273,6 +273,13 @@ export interface UserFootprint {
 		date: string;
 		posts: number;
 		comments: number;
+		/**
+		 * Revisions saved by the user that day, excluding the initial
+		 * save of brand-new posts (those count under `posts`). Added
+		 * in 0.8.7 so the heatmap registers update activity, not just
+		 * publications and comments.
+		 */
+		updates: number;
 	} >;
 	/** Sunday-indexed weekday distribution; length 7. */
 	weekday: number[];
@@ -284,7 +291,8 @@ export interface UserFootprint {
 		longestRange: { from: string; to: string };
 	};
 	timeline: Array< {
-		kind: 'post' | 'comment';
+		/** `'post-update'` rows are most-recent-save-per-parent rollups (since 0.8.7). */
+		kind: 'post' | 'comment' | 'post-update';
 		date: string;
 		title: string;
 		link: string;
@@ -296,6 +304,8 @@ export interface UserFootprint {
 		posts: number;
 		pages: number;
 		comments: number;
+		/** Lifetime revision count, excluding the initial save. Since 0.8.7. */
+		updates: number;
 		mostProlificMonth?: { ym: string; n: number };
 	};
 }

--- a/src/ui/components/wpd-crumb-chain/wpd-crumb-chain.ts
+++ b/src/ui/components/wpd-crumb-chain/wpd-crumb-chain.ts
@@ -357,7 +357,13 @@ function pickForegroundColor( bg: string ): string {
 		_readbackCanvas.width = 1;
 		_readbackCanvas.height = 1;
 	}
-	const ctx = _readbackCanvas.getContext( '2d' );
+	// `willReadFrequently: true` tells Chrome to back the canvas with
+	// a CPU buffer instead of the default GPU texture — `getImageData`
+	// below would otherwise trigger a GPU-to-CPU sync on every crumb
+	// render. The breadcrumb chain re-paints on every navigation in
+	// My WordPress / folder windows, so this fires often enough that
+	// Chrome surfaces the "willReadFrequently" perf warning.
+	const ctx = _readbackCanvas.getContext( '2d', { willReadFrequently: true } );
 	if ( ! ctx ) {
 		return '#1d2327';
 	}

--- a/src/ui/util/avatar-resolve.ts
+++ b/src/ui/util/avatar-resolve.ts
@@ -84,7 +84,12 @@ export async function resolveAvatarUrl(
 				const canvas = document.createElement( 'canvas' );
 				canvas.width = 1;
 				canvas.height = 1;
-				const ctx = canvas.getContext( '2d' );
+				// `willReadFrequently: true` keeps the canvas CPU-backed so
+				// the `getImageData` call below doesn't pay a GPU sync. The
+				// probe runs once per distinct avatar URL; per-canvas the
+				// readback is one-shot, but Chrome's heuristic still flags
+				// the pattern across the page-wide chorus of avatar resolves.
+				const ctx = canvas.getContext( '2d', { willReadFrequently: true } );
 				if ( ! ctx ) {
 					// No 2D context — fall back to the original URL so
 					// real avatars still render. Worst case: the

--- a/tests/vitest/dock-peek-native-icon-spawn.test.ts
+++ b/tests/vitest/dock-peek-native-icon-spawn.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression: clicking the dock-peek "+" (Ghost Card) on a synthesized
+ * dock tile for a wallpaper-icon-promoted-to-dock that targets a
+ * native window (e.g. My WordPress when the user moves its icon to
+ * the dock via OS Settings) used to call `manager.openNew()` with an
+ * empty `url` and no `native`/`render` config — opening a chrome-
+ * only iframe whose `src=''` never loaded. The fix routes that case
+ * through the native opener so the duplicate spawns as a real
+ * native instance.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { Dock, type DockItem } from '../../src/dock';
+import type { WindowManager } from '../../src/window-manager';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+function makeManagerStub() {
+	return {
+		getFocused: () => null,
+		getAllByBaseId: () => [],
+		getById: () => undefined,
+		getActiveDesktopId: () => 'default-1',
+		openNew: vi.fn(),
+	} as unknown as WindowManager & { openNew: ReturnType< typeof vi.fn > };
+}
+
+function synthIconDockItem( overrides: Partial< DockItem > = {} ): DockItem {
+	// Same shape `applyDockPlacement` produces for a wallpaper icon
+	// promoted to the dock that targets a native window (My WordPress,
+	// Jorvy, plugin-registered launchers).
+	return {
+		id: 'desktop:desktop-mode-my-wordpress',
+		title: 'My WordPress',
+		icon: 'dashicons-wordpress',
+		url: '',
+		windowId: 'desktop-mode-my-wordpress',
+		badge: 0,
+		submenu: [],
+		multi: false,
+		isCore: false,
+		...overrides,
+	};
+}
+
+describe( 'Dock — dock-peek "+" on native-window-targeted icon', () => {
+	beforeEach( () => installHooksStub() );
+	afterEach( () => {
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	test( '"+" routes through wp.desktop.openNewWindow when item has windowId + empty url', () => {
+		const openNewWindow = vi.fn().mockReturnValue( true );
+		// `installHooksStub` populated `window.wp.hooks` — extend it
+		// with the public-API `desktop` namespace instead of replacing
+		// `window.wp` (which would clobber the hooks stub).
+		( window as unknown as { wp: { hooks: unknown; desktop?: { openNewWindow: typeof openNewWindow } } } )
+			.wp.desktop = { openNewWindow };
+
+		const manager = makeManagerStub();
+		const item = synthIconDockItem();
+		const container = document.createElement( 'nav' );
+		document.body.appendChild( container );
+		const dock = new Dock( container, manager, [ item ], 'http://localhost/wp-admin/', 'left' );
+
+		// Reach the private spawner — same call the dock-peek "+" makes.
+		( dock as unknown as { openNewInstance: ( i: DockItem ) => void } )
+			.openNewInstance( item );
+
+		expect( openNewWindow ).toHaveBeenCalledWith(
+			'desktop-mode-my-wordpress',
+			{ source: 'dock-peek' },
+		);
+		// And — critically — `manager.openNew` MUST NOT have been
+		// called. Pre-fix it WAS called with `url: ''` / no render
+		// callback, which is what produced the chrome-only second
+		// window the user reported.
+		expect( manager.openNew ).not.toHaveBeenCalled();
+	} );
+
+	test( '"+" still falls through to iframe openNew for regular menu items', () => {
+		const manager = makeManagerStub();
+		// Same-origin URL so the off-site short-circuit doesn't try to
+		// `window.open()` (not implemented in jsdom).
+		const item: DockItem = {
+			id: 'plugin-x',
+			title: 'Plugin X',
+			icon: 'dashicons-admin-plugins',
+			url: '/wp-admin/admin.php?page=plugin-x',
+			badge: 0,
+			submenu: [],
+			multi: false,
+		};
+		const container = document.createElement( 'nav' );
+		document.body.appendChild( container );
+		const dock = new Dock( container, manager, [ item ], '/wp-admin/', 'left' );
+
+		( dock as unknown as { openNewInstance: ( i: DockItem ) => void } )
+			.openNewInstance( item );
+
+		expect( manager.openNew ).toHaveBeenCalledTimes( 1 );
+		const call = manager.openNew.mock.calls[ 0 ][ 0 ] as {
+			url: string;
+			multi: boolean;
+		};
+		expect( call.url ).toBe( '/wp-admin/admin.php?page=plugin-x' );
+		expect( call.multi ).toBe( true );
+	} );
+} );

--- a/tests/vitest/my-wordpress-multi-instance.test.ts
+++ b/tests/vitest/my-wordpress-multi-instance.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Regression: opening a second My WordPress window while the first
+ * is still open should still load. Pre-fix the module-level
+ * `closeHandler` matched on the base `WINDOW_ID`, so closing instance 1
+ * tore down instance 2's state mid-render; `asRenderState` then
+ * rejected any kind-registry navigation in the still-alive instance
+ * because the singleton `activeState` no longer pointed at it.
+ *
+ * Test pattern: load the my-wordpress module (it registers a callback
+ * on `window.desktopModeNativeWindows[WINDOW_ID]`), call that callback
+ * against two distinct bodies, and confirm both ended up with the
+ * root tile grid painted.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { cloneTemplate } from '../../src/native-windows';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+interface NativeWindowsGlobal {
+	desktopModeNativeWindows?: Record<
+		string,
+		( ( body: HTMLElement ) => void | ( () => void ) ) | undefined
+	>;
+	desktopModeWindowConfig?: Record< string, unknown >;
+}
+
+function installTemplateMarkup( host: HTMLElement ): void {
+	host.innerHTML = `
+		<div class="desktop-mode-my-wordpress" data-desktop-mode-my-wordpress-root>
+			<header data-desktop-mode-my-wordpress-breadcrumbs></header>
+			<div class="desktop-mode-my-wordpress__body" data-desktop-mode-my-wordpress-body>
+				<div class="desktop-mode-my-wordpress__loading" data-desktop-mode-my-wordpress-loading hidden></div>
+			</div>
+			<div class="desktop-mode-folder-status-bar" data-desktop-mode-my-wordpress-status></div>
+		</div>
+	`;
+}
+
+describe( 'my-wordpress — multi-instance render', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		// Stub the shell config the bundle reads via `getConfig()`.
+		( window as unknown as NativeWindowsGlobal ).desktopModeWindowConfig = {
+			[ WINDOW_ID ]: {
+				restRoot: 'http://example.test/wp-json/',
+				restNonce: 'nonce',
+				editPostUrlBase: 'http://example.test/wp-admin/post.php',
+				editUserUrlBase: 'http://example.test/wp-admin/user-edit.php',
+				entities: [
+					{
+						id: 'posts',
+						label: 'Posts',
+						icon: 'dashicons-admin-post',
+						restPath: 'wp/v2/posts',
+						kind: 'post',
+					},
+				],
+				perPage: 24,
+				mediaPerPage: 48,
+				previewActions: [],
+			},
+		};
+		// `fetchEntityTotal` runs as soon as the root view paints — stub
+		// fetch so the test doesn't hit the network.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () =>
+				Promise.resolve(
+					new Response( '[]', {
+						status: 200,
+						headers: { 'X-WP-Total': '0' },
+					} ),
+				),
+			),
+		);
+		// Side-effect import installs the render callback.
+		await import( '../../src/my-wordpress/index' );
+	} );
+
+	afterEach( () => {
+		// Don't wipe `desktopModeNativeWindows` — Vitest caches the
+		// side-effect import, so the bundle's registration only runs
+		// once across the whole file. Clearing the global between
+		// tests strands every subsequent test without a callback.
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'callback paints content into a single body', async () => {
+		const cb = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		expect( typeof cb ).toBe( 'function' );
+
+		const body = document.createElement( 'div' );
+		body.className = 'desktop-mode-window__body';
+		installTemplateMarkup( body );
+		document.body.appendChild( body );
+
+		cb!( body );
+
+		const grid = body.querySelector( '.desktop-mode-my-wordpress__grid' );
+		expect( grid ).not.toBeNull();
+		expect( grid!.children.length ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'callback paints content into BOTH bodies when invoked twice', async () => {
+		const cb = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		expect( typeof cb ).toBe( 'function' );
+
+		const body1 = document.createElement( 'div' );
+		body1.className = 'desktop-mode-window__body';
+		body1.dataset.instance = '1';
+		installTemplateMarkup( body1 );
+		document.body.appendChild( body1 );
+
+		const body2 = document.createElement( 'div' );
+		body2.className = 'desktop-mode-window__body';
+		body2.dataset.instance = '2';
+		installTemplateMarkup( body2 );
+		document.body.appendChild( body2 );
+
+		const teardown1 = cb!( body1 );
+		const teardown2 = cb!( body2 );
+
+		const grid1 = body1.querySelector( '.desktop-mode-my-wordpress__grid' );
+		const grid2 = body2.querySelector( '.desktop-mode-my-wordpress__grid' );
+		expect( grid1, 'first body grid' ).not.toBeNull();
+		expect( grid2, 'second body grid' ).not.toBeNull();
+
+		// Pre-fix regression: tearing down instance 1 also fired
+		// instance 2's `closeHandler` (both compared the closed event's
+		// `windowId` against the base `WINDOW_ID` constant), so instance
+		// 2's teardown ran while it was still alive — content stayed,
+		// but the drop-target registration leaked AND the singleton
+		// `activeState` flipped to `null`, leaving every kind-registry
+		// render in instance 2 to throw "host body does not match
+		// active state."
+		if ( typeof teardown1 === 'function' ) {
+			teardown1();
+		}
+		const grid2After = body2.querySelector(
+			'.desktop-mode-my-wordpress__grid',
+		);
+		expect( grid2After, 'instance 2 grid after instance 1 teardown' )
+			.not.toBeNull();
+
+		if ( typeof teardown2 === 'function' ) {
+			teardown2();
+		}
+	} );
+
+	test( 'callback returns a per-instance teardown function', async () => {
+		const cb = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		expect( typeof cb ).toBe( 'function' );
+
+		const body = document.createElement( 'div' );
+		body.className = 'desktop-mode-window__body';
+		installTemplateMarkup( body );
+		document.body.appendChild( body );
+
+		const teardown = cb!( body );
+		// The framework's `Window.hydrateNative` captures this teardown
+		// and invokes it on `close()`. Without a function here the per-
+		// instance close cleanup would be missing entirely.
+		expect( typeof teardown ).toBe( 'function' );
+
+		// Idempotent: teardown shouldn't throw if invoked.
+		( teardown as () => void )();
+	} );
+
+	test( 'opening a second window via manager.openNew with the my-wordpress finalRender shape renders content in the second window', async () => {
+		// This mirrors what `openNewFromEntry` does for native windows
+		// — the user-reported scenario: an open My WordPress window,
+		// then `wp.desktop.openNewWindow( 'desktop-mode-my-wordpress' )`
+		// (or any path that routes through `manager.openNew`).
+		const TEMPLATE_ID = `desktop-mode-native-window-${ WINDOW_ID }`;
+		const tpl = document.createElement( 'template' );
+		tpl.id = TEMPLATE_ID;
+		tpl.innerHTML = `
+			<div class="desktop-mode-my-wordpress" data-desktop-mode-my-wordpress-root>
+				<header data-desktop-mode-my-wordpress-breadcrumbs></header>
+				<div class="desktop-mode-my-wordpress__body" data-desktop-mode-my-wordpress-body>
+					<div class="desktop-mode-my-wordpress__loading" data-desktop-mode-my-wordpress-loading hidden></div>
+				</div>
+				<div class="desktop-mode-folder-status-bar" data-desktop-mode-my-wordpress-status></div>
+			</div>
+		`;
+		document.body.appendChild( tpl );
+
+		const desktop = document.createElement( 'div' );
+		Object.defineProperty( desktop, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		Object.defineProperty( desktop, 'clientWidth', { value: 1600, configurable: true } );
+		Object.defineProperty( desktop, 'clientHeight', { value: 900, configurable: true } );
+		document.body.appendChild( desktop );
+		const manager = new WindowManager( desktop );
+
+		const render = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		expect( typeof render ).toBe( 'function' );
+
+		// Same shape as `openNewFromEntry`'s `finalRender`.
+		const finalRender = ( body: HTMLElement, ctx?: unknown ): unknown => {
+			body.appendChild( cloneTemplate( TEMPLATE_ID ) );
+			return ( render as ( b: HTMLElement, c?: unknown ) => unknown )( body, ctx );
+		};
+
+		await manager.open( {
+			id: WINDOW_ID,
+			baseId: WINDOW_ID,
+			url: `#${ WINDOW_ID }`,
+			title: 'MW',
+			native: true,
+			render: finalRender as never,
+		} );
+
+		await manager.openNew( {
+			id: WINDOW_ID,
+			baseId: WINDOW_ID,
+			url: `#${ WINDOW_ID }`,
+			title: 'MW',
+			native: true,
+			render: finalRender as never,
+		} );
+
+		const wins = manager.getAll();
+		expect( wins.length ).toBe( 2 );
+
+		for ( const win of wins ) {
+			const body = win.element.querySelector< HTMLElement >(
+				'.desktop-mode-window__body',
+			);
+			expect( body, `body for ${ win.id }` ).not.toBeNull();
+			const grid = body!.querySelector( '.desktop-mode-my-wordpress__grid' );
+			expect(
+				grid,
+				`grid for ${ win.id } — pre-fix only the FIRST window had a grid; the second one's renderInto silently bailed because module-level state was stale`,
+			).not.toBeNull();
+		}
+
+		for ( const win of wins ) {
+			win.destroy();
+		}
+		desktop.remove();
+		document.getElementById( TEMPLATE_ID )?.remove();
+	} );
+} );


### PR DESCRIPTION
A set of targeted bug fixes and a feature extension to the user activity footprint. No architectural changes; each fix is self-contained and regression-tested.

---

### Fixes

#### Dock-peek: native-window icons now open correctly ([`src/dock.ts`](https://github.com/WordPress/desktop-mode/blob/pre-demo-polishment/src/dock.ts))

Dock items whose target is a native window (My WordPress, Jorvy, plugin-registered launchers) carry a `windowId` but no `url`. Clicking them in dock-peek was falling through to the generic URL-based iframe path, which opened a chrome-only window with `src=""` — the user saw a title bar with no content.

The fix adds an early guard: if `item.windowId && !item.url`, the click is routed directly through `wp.desktop.openNewWindow()`, spawning a proper native instance. If `openNewWindow` returns falsy (old API, feature flag off) the existing fallback logic handles it transparently.

#### My WordPress: multiple instances no longer interfere with each other ([`src/my-wordpress/index.ts`](https://github.com/WordPress/desktop-mode/blob/pre-demo-polishment/src/my-wordpress/index.ts))

Three related issues when two My WordPress windows were open at the same time:

1. **Close clobbered live siblings.** The previous teardown used a `desktop-mode-window-closed` document listener matched on the base `WINDOW_ID`. Every sibling's close event fired the same handler — closing instance B cleared instance A's state and left it broken. Fixed by having `renderInto` return a per-instance teardown that the framework calls only for *that* specific window.

2. **Navigation in a non-foreground instance threw.** `asRenderState` compared against the singleton `activeState`. Drilling into a posts list inside a backgrounded duplicate triggered *"host body does not match active state"*. Fixed by introducing a `liveStates: Map<HTMLElement, RenderState>` that lets `asRenderState` resolve the correct state for any live instance.

3. **Drag-rejection drop targets overwrote each other.** Both instances registered a claimant with the same id (`my-wordpress-reject`), so the second registration silently replaced the first's element binding. Fixed by appending a per-mount monotonic counter (`rejectIdCounter`) to the id.

#### UI: `willReadFrequently: true` on pixel-readback canvas contexts ([`src/ui/components/wpd-crumb-chain/wpd-crumb-chain.ts`](https://github.com/WordPress/desktop-mode/blob/pre-demo-polishment/src/ui/components/wpd-crumb-chain/wpd-crumb-chain.ts), [`src/ui/util/avatar-resolve.ts`](https://github.com/WordPress/desktop-mode/blob/pre-demo-polishment/src/ui/util/avatar-resolve.ts))

Both `wpd-crumb-chain` (foreground-color picker) and `avatar-resolve` (transparent-pixel probe) create a 1×1 canvas and immediately call `getImageData`. Without the `willReadFrequently` hint Chrome backs the canvas with a GPU texture, so each `getImageData` triggers a GPU→CPU sync. The breadcrumb chain re-paints on every navigation; the avatar resolver fires once per unique URL across the page — often enough that Chrome was surfacing the "willReadFrequently" performance warning in both cases.

---

### Feature: User activity footprint now tracks post updates / revisions

**`includes/my-wordpress/user-footprint.php` · `src/my-wordpress/index.ts` · `src/my-wordpress/types.ts`**

The activity heatmap and stats previously only counted published posts and comments. Editors who spend most of their time updating existing content (the typical CMS workflow) appeared to have no activity. This brings the footprint model in line with how GitHub counts contributions — edits to existing content are first-class activity.

**What counts as an "update":** a WordPress revision saved by the user *after* the parent post's initial creation (`r.post_date_gmt > p.post_date_gmt`). The initial save is excluded so it doesn't double-count with the "posts" column. Updates are attributed to whoever hit Save (via `r.post_author`), not the post owner — consistent with tracking editorial work across a team.

**Changes in detail:**

- **`daily[].updates`** — per-day update count, added alongside the existing `posts` and `comments` fields (zero-filled for days with no saves).
- **`totals.updates`** — lifetime revision count, excluding the initial save.
- **`timeline` `post-update` kind** — revisions are collapsed per parent post (`GROUP BY r.post_parent, MAX(post_date_gmt)`) so a burst of saves on one article reads as a single row rather than flooding the timeline. Displayed with a pencil icon and "Updated `"…"`" label.
- **`timeline[].type`** — CPT slug (`'post'`, `'page'`, custom type) added to `post` and `post-update` rows so the renderer can pick a Post-vs-Page icon without a second REST lookup.
- **Streak logic** — "active day" now includes update and comment activity, not only publish days.
- **UI "Updates" stat card** — shown in the My WordPress stats panel when the lifetime count is > 0. Heatmap intensity now sums `posts + comments + updates`.

---

### Tests

- **`tests/vitest/dock-peek-native-icon-spawn.test.ts`** — verifies that a `windowId`-only dock item spawns a native window and does not fall through to the iframe path.
- **`tests/vitest/my-wordpress-multi-instance.test.ts`** — covers the three multi-instance regressions above: close isolation, independent navigation, and unique drop-target ids.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-255-ad7f93ecce0e00ba1be4064a8f8346ffdda3de5f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->