### PR TITLE
Fix plugin .zip drop routing to Media Library uploader

### DIFF
--- a/src/os-file-drop/manager.ts
+++ b/src/os-file-drop/manager.ts
@@ -191,6 +191,15 @@ export function mountOsFileDropManager( opts: MountOptions ): MountedManager {
 		if ( ! dragHasFiles( ev ) ) {
 			return;
 		}
+		// A closer handler already called `preventDefault()` —
+		// meaning some nested drop target (the Plugins upload
+		// dropzone, a future feature, …) is willing to accept the
+		// file. Yield to it so our overlay doesn't paint over its
+		// own hover state.
+		if ( ev.defaultPrevented ) {
+			resetOverlay();
+			return;
+		}
 		ev.preventDefault();
 		if ( ev.dataTransfer ) {
 			ev.dataTransfer.dropEffect = 'copy';
@@ -210,6 +219,14 @@ export function mountOsFileDropManager( opts: MountOptions ): MountedManager {
 
 	const onDrop = ( ev: DragEvent ): void => {
 		if ( ! dragHasFiles( ev ) ) {
+			return;
+		}
+		// A closer handler already called `preventDefault()` and
+		// took responsibility for this file (e.g. the Plugins
+		// `.zip` upload dropzone). Don't double-handle it through
+		// the Media Library pipeline.
+		if ( ev.defaultPrevented ) {
+			resetOverlay();
 			return;
 		}
 		ev.preventDefault();

--- a/src/plugins-window/upload-dialog.ts
+++ b/src/plugins-window/upload-dialog.ts
@@ -143,6 +143,19 @@ export function openUploadDialog(
 		overlay.appendChild( card );
 		host.appendChild( overlay );
 
+		// The modal overlay swallows stray drag/drop events so a
+		// .zip dropped on the dimmed area (outside the dropzone)
+		// can't bubble through to the Plugins window body — that
+		// would open a duplicate upload dialog — or to the
+		// shell-wide OS-file-drop manager.
+		const swallowDrag = ( ev: DragEvent ): void => {
+			ev.preventDefault();
+			ev.stopPropagation();
+		};
+		overlay.addEventListener( 'dragenter', swallowDrag );
+		overlay.addEventListener( 'dragover', swallowDrag );
+		overlay.addEventListener( 'drop', swallowDrag );
+
 		// ─── State ──────────────────────────────────────────────────
 		let pickedFile: File | null = null;
 		let uploading = false;
@@ -179,15 +192,23 @@ export function openUploadDialog(
 				input.click();
 			}
 		} );
+		// Drag/drop events are stopped at the dropzone so they
+		// don't bubble to the Plugins window body handler (which
+		// would open a second upload dialog) or to the shell-wide
+		// OS-file-drop manager (which would route the .zip to the
+		// Media Library).
 		dropZone.addEventListener( 'dragover', ( ev ) => {
 			ev.preventDefault();
+			ev.stopPropagation();
 			dropZone.classList.add( 'is-hovered' );
 		} );
-		dropZone.addEventListener( 'dragleave', () => {
+		dropZone.addEventListener( 'dragleave', ( ev ) => {
+			ev.stopPropagation();
 			dropZone.classList.remove( 'is-hovered' );
 		} );
 		dropZone.addEventListener( 'drop', ( ev: DragEvent ) => {
 			ev.preventDefault();
+			ev.stopPropagation();
 			dropZone.classList.remove( 'is-hovered' );
 			const file = ev.dataTransfer?.files?.[ 0 ];
 			if ( file && isZip( file ) ) {

--- a/tests/vitest/os-file-drop-manager.test.ts
+++ b/tests/vitest/os-file-drop-manager.test.ts
@@ -25,6 +25,7 @@ import {
 	defaultFields,
 	handleFiles,
 	humanize,
+	mountOsFileDropManager,
 	partitionByPolicy,
 	resolveAllowedMime,
 	sanitizeFilename,
@@ -55,6 +56,13 @@ describe( 'os-file-drop/manager', () => {
 	afterEach( () => {
 		clearHooksStub();
 		document.body.innerHTML = '';
+		// Tear down any manager mounted during a test so the
+		// window-level sentinel + listeners don't leak across
+		// tests.
+		const host = window as unknown as {
+			__desktopModeOsFileDropMounted?: { dispose: () => void };
+		};
+		host.__desktopModeOsFileDropMounted?.dispose();
 	} );
 
 	describe( 'partitionByPolicy', () => {
@@ -284,6 +292,47 @@ describe( 'os-file-drop/manager', () => {
 					openDialog,
 				},
 			);
+			expect( openDialog ).not.toHaveBeenCalled();
+		} );
+
+		test( 'window-level drop bails when a nested handler already preventDefault-ed', async () => {
+			// Inner drop target (e.g. the Plugins .zip upload
+			// dropzone) is a child of the body and calls
+			// preventDefault on the drop. The window-level
+			// manager must NOT also process the file — that's
+			// what was opening the Media Library uploader on top
+			// of the Plugins upload dialog.
+			const openDialog = vi.fn().mockResolvedValue( undefined );
+			mountOsFileDropManager( {
+				config: {
+					enabled: true,
+					allowedMimes: IMAGE_MIMES,
+					maxSize: 0,
+				},
+				mediaUrl: '',
+				restNonce: '',
+				openDialog,
+			} );
+
+			const inner = document.createElement( 'div' );
+			document.body.appendChild( inner );
+			inner.addEventListener( 'drop', ( ev ) => ev.preventDefault() );
+
+			const file = makeFile( 'photo.png', 'image/png' );
+			const dataTransfer = {
+				types: [ 'Files' ],
+				files: [ file ],
+				dropEffect: 'copy',
+			};
+			const drop = new Event( 'drop', {
+				bubbles: true,
+				cancelable: true,
+			} );
+			Object.defineProperty( drop, 'dataTransfer', {
+				value: dataTransfer,
+			} );
+			inner.dispatchEvent( drop );
+
 			expect( openDialog ).not.toHaveBeenCalled();
 		} );
 


### PR DESCRIPTION
## Summary

Dropping a `.zip` onto the Plugins → Upload Plugin dropzone opened the Media Library uploader on top of the install dialog instead of installing the plugin. The OS-file-drop manager (added in 0.30.0) listens at the window level; the dropzone's `preventDefault` call wasn't enough to stop the event from bubbling and being re-processed as a media upload.

## What changed

- **`src/os-file-drop/manager.ts`** — `onDrop` and `onDragOver` bail out when `ev.defaultPrevented` is true. That's the standard signal that a closer handler has taken ownership of the file, so the window-level manager yields. This generalises to any nested drop zone, current or future.
- **`src/plugins-window/upload-dialog.ts`** — the dropzone's drag/drop listeners call `stopPropagation()` so the drop doesn't bubble to the Plugins browse-view body handler (which would otherwise open a second install dialog under the modal). The dialog's overlay also swallows stray drops outside the dropzone, matching modal semantics.
- **`tests/vitest/os-file-drop-manager.test.ts`** — new test for the `defaultPrevented` skip path; `afterEach` now disposes any mounted manager so the window-level sentinel doesn't leak across tests.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `./node_modules/.bin/tsc --noEmit` clean
- [x] `npm run test:js` — 1465 tests pass (one new)
- [x] Manual: drop a `.zip` onto the Upload Plugin dropzone → installs the plugin, no Media Library dialog
- [x] Manual: drop a `.zip` onto the dimmed overlay area outside the dropzone → nothing happens (modal swallows it)
- [x] Manual: drop an image on the desktop wallpaper → Media Library uploader still appears (no regression)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-256-98559bf2d235d5fbb4860d3e1943505d6674548c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->