### PR TITLE
docs: refresh AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,56 @@
-# desktop-mode — local gotchas
+# desktop-mode — agent + contributor guide
 
-Short file. Things I've forgotten or hand-waved before. If it's obvious from reading the code, don't add it here.
+The imperative rules for working in this repo, plus the contributor-only gotchas that aren't obvious from reading the code. Public APIs and their contracts live in `docs/`; this file is the rulebook and cheatsheet for working *inside* the codebase.
 
-## 🧱 Use `wpd-*` components, not raw HTML controls
+## Contents
 
-**Default to the `<wpd-*>` web component for any UI element that has one.** They live in `src/ui/components/<name>/` and are tag-listed in `src/ui/components/index.ts` — that file is the index of what already exists. Pick from there before reaching for raw `<button>`, `<input>`, `<select>`, dialogs, menus, toasts, etc. The components carry the framework's keyboard-nav, focus-management, theming-token, and accessibility plumbing for free; raw HTML doesn't.
+- [Hard rules](#hard-rules)
+  - [Never hand-edit JS in `assets/js/`](#never-hand-edit-js-in-assetsjs)
+  - [Use `wp.desktop.fetch` (or `trackedFetch`), never raw `fetch()`](#use-wpdesktopfetch-or-trackedfetch-never-raw-fetch)
+  - [Use `wp.desktop.confirm` (or `wpdConfirm`), never `window.confirm`/`alert`/`prompt`](#use-wpdesktopconfirm-or-wpdconfirm-never-windowconfirmalertprompt)
+  - [Use `wpd-*` components, not raw HTML controls](#use-wpd--components-not-raw-html-controls)
+- [Workflow](#workflow)
+  - [Always run `npm run build` after all the changes](#always-run-npm-run-build-after-all-the-changes)
+  - [Always branch + PR, never commit to trunk](#always-branch--pr-never-commit-to-trunk)
+  - [Use `bin/sync-to-wp-develop.sh` for local sync, not raw rsync](#use-binsync-to-wp-developsh-for-local-sync-not-raw-rsync)
+  - [Don't regenerate POT/PO/JSON in feature PRs](#dont-regenerate-potpojson-in-feature-prs)
+- [Process reminders](#process-reminders)
+- [Contributor gotchas](#contributor-gotchas)
+  - [Live-refresh on plugin install/activate — how it actually works](#live-refresh-on-plugin-installactivate--how-it-actually-works)
+  - [Event-driven framework](#event-driven-framework)
+  - [Presence — framework-level](#presence--framework-level)
+  - [Cross-bundle state — `wp.desktop.createSharedStore`](#cross-bundle-state--wpdesktopcreatesharedstore)
+  - [Chromeless admin-bar suppression](#chromeless-admin-bar-suppression)
+  - [Running PHPUnit](#running-phpunit)
+- [Developer docs — read before, update after](#developer-docs--read-before-update-after)
 
-Concrete checklist when adding UI:
+---
 
-1. Look at `src/ui/components/index.ts`. If the component you need is there, use it.
-2. If it isn't but the shape is generic (a kind of dialog, picker, menu, status indicator that any future feature could reuse), **build it as a new `<wpd-*>` component** — folder under `src/ui/components/<name>/` with `<name>.ts` (Web Component class), `<name>.styles.ts` (shadow-DOM CSS), and `<name>.test.ts`. Register it in `src/ui/components/index.ts`. Document it via the `static help` block on the class. Reference it in `docs/components-reference.md` if it's user-facing.
-3. Only fall back to bespoke DOM construction when the surface is feature-specific (a tile renderer that knows about placement metadata, a menu-flyout positioning rig).
+## Hard rules
 
-The `<wpd-context-menu>` / `<wpd-context-menu-option>` and `<wpd-confirm-dialog>` pair are good examples — they replaced ~200 LOC of duplicated DOM construction across the wallpaper menu, the tile context menu, the create-folder dialog, and the recycle-bin/posts-window confirm prompts.
+### Never hand-edit JS in `assets/js/`
 
-## 🌐 Use `wp.desktop.fetch` (or `trackedFetch`), never raw `fetch()`
+**`assets/js/*.js` is build output. Treat it as if it were `dist/`.**
+
+Every shipped JS bundle has a TypeScript source under `src/`. The active build targets (and their TS entries) are listed in `package.json` under the `build:*` scripts; `npm run build` runs them all. The actual entry file for each target is in `vite.config.js`, selected by the `DESKTOP_MODE_TARGET` env var.
+
+Process for any JS change:
+
+1. Edit only TS files under `src/` (and CSS under `assets/css/` if styling, that's not built).
+2. Run `npm run build` (or the per-target script).
+3. Run `npm run lint` (or `lint:fix`), must pass on EVERYTHING you touched.
+4. Run `npm run test:js`, must stay green.
+5. Run `npm run typecheck`, must stay green.
+
+If you ever find yourself reaching for `assets/js/*.js` directly, stop and write the TS instead. Hand-edited JS is overwritten by the next `npm run build` and produces no TS-checked types, a silent class of bug.
+
+**Lint scope:** `npm run lint` runs on `src/**/*.ts` only. Test files under `tests/vitest/` aren't in the lint config (typescript-eslint project doesn't include them); rely on `npm run typecheck` + `npm run test:js` to catch issues there.
+
+### Use `wp.desktop.fetch` (or `trackedFetch`), never raw `fetch()`
 
 **Every HTTP call from the shell must route through the framework helper** so the request feeds the active window's loading spinner + the activity bus. Two equivalent entry points:
 
-- **In-bundle** (any `src/**/*.ts` that ends up in the main `desktop.min.js` or any feature bundle): `import { trackedFetch } from '<…>/tracked-fetch'`. The helper finds `wp.desktop.fetch` at runtime.
+- **In-bundle** (any `src/**/*.ts` that ends up in any built bundle): `import { trackedFetch } from '<…>/tracked-fetch'`. The helper finds `wp.desktop.fetch` at runtime.
 - **Plugin-side / external scripts**: `await window.wp.desktop.fetch( url, init, { source: 'my-plugin/foo' } )`.
 
 Shape:
@@ -39,7 +71,7 @@ ESLint enforces this — raw `fetch( … )` and `window.fetch( … )` calls fail
 - The PWA service worker (`src/pwa/sw.ts` — different context, no `wp.desktop` global).
 - Genuinely silent background pollers where attribution would mis-render as user activity (`src/devtools/index.ts`, `src/recycle-bin/badge.ts`).
 
-## 💬 Use `wp.desktop.confirm` (or `wpdConfirm`), never `window.confirm`/`alert`/`prompt`
+### Use `wp.desktop.confirm` (or `wpdConfirm`), never `window.confirm`/`alert`/`prompt`
 
 The framework ships a `<wpd-confirm-dialog>` component and a Promise-returning wrapper:
 
@@ -58,40 +90,52 @@ if ( await wpdConfirm( {
 
 External bundles call `window.wp.desktop.confirm(...)` (same shape). ESLint rejects `window.confirm`, `window.alert`, `window.prompt` — see the rule message for the suggested replacement (a toast, a `<wpd-confirm-dialog>`, or a custom modal built with `<wpd-text-field>`).
 
-## ⛔ Source-of-truth rule: NEVER hand-edit JS in `assets/js/`
+### Use `wpd-*` components, not raw HTML controls
 
-**`assets/js/*.js` is build output. Treat it as if it were `dist/`.**
+**Default to the `<wpd-*>` web component for any UI element that has one.** They live in `src/ui/components/<name>/` and are tag-listed in `src/ui/components/index.ts`, that file is the index of what already exists. Pick from there before reaching for raw `<button>`, `<input>`, `<select>`, dialogs, menus, toasts, etc. The components carry the framework's keyboard-nav, focus-management, theming-token, and accessibility plumbing for free; raw HTML doesn't.
 
-Every shipped JS bundle has a TypeScript source under `src/`. The two
-bundles today are:
+Concrete checklist when adding UI:
 
-| Built file | TS source | Built by |
-|---|---|---|
-| `assets/js/desktop[.min].js` | `src/desktop.ts` | `npm run build:desktop` |
-| `assets/js/iframe-bridge[.min].js` | `src/iframe-bridge-standalone.ts` | `npm run build:iframe-bridge` |
+1. Look at `src/ui/components/index.ts`. If the component you need is there, use it.
+2. If it isn't but the shape is generic (a kind of dialog, picker, menu, status indicator that any future feature could reuse), **build it as a new `<wpd-*>` component**, folder under `src/ui/components/<name>/` with `<name>.ts` (Web Component class), `<name>.styles.ts` (shadow-DOM CSS), and `<name>.test.ts`. Register it in `src/ui/components/index.ts`. Document it via the `static help` block on the class (universal convention across the kit).
+3. Only fall back to bespoke DOM construction when the surface is feature-specific (a tile renderer that knows about placement metadata, a menu-flyout positioning rig).
 
-`npm run build` runs both. Vite's `DESKTOP_MODE_TARGET` env var (`desktop` /
-`iframe-bridge`) selects the entry — see `vite.config.js`.
+The `<wpd-context-menu>` / `<wpd-context-menu-option>` and `<wpd-confirm-dialog>` pair are good examples, they replaced ~200 LOC of duplicated DOM construction across the wallpaper menu, the tile context menu, the create-folder dialog, and the recycle-bin/posts-window confirm prompts.
 
-Process:
+---
 
-1. Edit only TS files under `src/` (and CSS under `assets/css/` if
-   styling — that's not built).
-2. Run `npm run build` (or the per-target script).
-3. Run `npm run lint` (or `:fix`) — must pass on EVERYTHING you touched.
-4. Run `npm run test:js` — must stay green.
-5. Run `./node_modules/.bin/tsc --noEmit` — must stay green.
+## Workflow
 
-If you ever find yourself reaching for `assets/js/*.js` directly, stop
-and write the TS instead. Hand-edited JS is overwritten by the next
-`npm run build` and produces no TS-checked types — silent class of bug.
+### Always run `npm run build` after all the changes
 
-**Lint scope:** `npm run lint` runs on `src/**/*.ts` only. Test files
-under `tests/vitest/` aren't in the lint config (typescript-eslint
-project doesn't include them); rely on `tsc --noEmit` + `vitest` to
-catch issues there.
+Uniform workflow across the repo. Once you're done with a batch of edits (don't bother running it between individual changes), run `npm run build` even if the batch was PHP-only, the build is a cheap correctness gate (it touches Vite + the vendor copy step) and keeps `assets/js/` in sync with `src/`. If you don't, the next person to run `npm run build` will see spurious diffs.
 
-## Live-refresh on plugin install/activate — how it actually works
+### Always branch + PR, never commit to trunk
+
+Even small chores (typos, doc tweaks, one-line fixes) go on a feature branch. Open a PR for every change. Wait for the user's green light before running `gh pr create`; once given, run it yourself.
+
+### Use `bin/sync-to-wp-develop.sh` for local sync, not raw rsync
+
+The script is the single source of truth for the include list and runs `npm run build` first. Only fall back to raw `rsync` for files that are genuinely outside the script's scope (and then question why they're outside it).
+
+### Don't regenerate POT/PO/JSON in feature PRs
+
+i18n re-extraction is a batched pre-translation step, not a per-PR chore. Don't run `npm run build:i18n` as part of a feature branch unless the PR is specifically a translation refresh; the noise dilutes the diff and creates churn with other in-flight branches.
+
+---
+
+## Process reminders
+
+- **Read before speculating.** When asked how a mechanism works (refresh flow, hook order, bridge protocol), grep the code first. Hand-waving gets caught.
+- **Don't implement architectural changes unilaterally.** PHP API additions, payload shape changes, and new registry-sync modules are all load-bearing for plugin authors. Propose, get the green light, then code.
+- **Let the user test before committing.** Sync to local dev, wait for verification, then commit. Avoid the eager-push trail of partial fixes.
+- **Plugin Check** runs in CI as the `plugin-check` job (uses `wordpress/plugin-check-action@v1`, currently `ignore-warnings: true` while we baseline). For local runs: `npm run env:start` then `npm run check:plugin`. Don't add it to a pre-commit hook, it needs a live WP/WP-CLI and is too slow per-commit.
+
+---
+
+## Contributor gotchas
+
+### Live-refresh on plugin install/activate — how it actually works
 
 When the user installs or activates a plugin, the **chromeless bridge** inside the `plugins.php` iframe postMessages `desktop-mode-plugins-changed` to the parent shell with a **payload captured in real admin context** (plugins that gate `admin_menu` on `is_admin()` at load time register correctly there; a REST roundtrip from the shell cannot replicate that, so don't try).
 
@@ -107,40 +151,40 @@ Payload shape (`includes/render.php` builds it, `src/desktop.ts` consumes it):
 
 - **PHP-declared** things are in the payload: dock, taskbar, native windows, widgets, wallpapers. The shell diffs them and fires `registry.subscribe` listeners → UI repaints. No F5.
 - For widgets and wallpapers, the pattern is: PHP payload carries metadata + `scriptUrl`; the `server-sync` module (`src/{widgets,wallpapers}/server-sync.ts`) dynamically loads the plugin's JS, which then publishes a full def on a global (`window.desktopModeWallpapers[id]` / `window.desktopModeWidgets[id]`). The sync reads the def and registers it.
-- **Commands use the same pattern since 0.15.0** via `desktop_mode_register_command_script( $handle )` (primary, minimum-ceremony) or `desktop_mode_register_command( $args )` (optional, declares metadata server-side). Sync module: `src/commands/server-sync.ts`. Live unregistration on deactivation works for commands that either (a) declare `script` in PHP metadata, or (b) set `owner` on their JS `registerCommand` call. Plugins that do neither still require F5 on deactivate — graceful backwards-compat.
-- **OS Settings tabs use the same pattern since 0.17.0** via `desktop_mode_register_settings_tab_script( $handle )` (primary) or `desktop_mode_register_settings_tab( $args )` (optional — id/label/capability/order/script). Sync module: `src/settings/server-sync.ts`; registry: `src/settings/registry.ts`; built-in tabs (appearance=10, ai=20, extended=30, help=40) are interleaved with the registry in `src/settings/index.ts` `renderPanel()` and re-painted live via `subscribeSettingsTabs`. Same (a)/(b) live-unregister rules as commands.
-- **AI Copilot extensibility (since 0.17.0)** lives on a different axis from the live-refresh payloads — it's all per-request wiring inside `/ai/search` (`includes/ai-copilot/search.php`) plus a persistent server-tool registry in `includes/ai-copilot/tools-registry.php`. Two distinct registration surfaces: `desktop_mode_register_ai_tool( $args )` for PHP-dispatched tools (handler runs server-side, capability-gated, never visible to users who lack the cap), and client-side `registerCommand({ aiCallable: true })` for JS-dispatched slash-commands the AI can pick via `/ai/search`'s `command_tools` param. The full filter/action surface is `desktop_mode_ai_{system_prompt,system_prompt_appendix,system_prompt_replace_capability,request,tools,command_tools,command_allowed,tool_result,answer}` + observability actions `desktop_mode_ai_{search_started,tool_called,search_completed,search_error,tool_registered}` — every call carries a shared `request_id` UUID for trace correlation. `wp.desktop.ai.ask()` (`src/ai/ask.ts`) is the client-side programmatic entry point; it harvests `aiCallable: true` commands into `command_tools` and handles the server's `answer_type: 'tool_call'` short-circuit by running `run()` locally. The command's `run` function always lives JS-side — the server only emits a slug+args intent; the client invokes.
+- **Commands** use the same pattern via `desktop_mode_register_command_script( $handle )` (primary, minimum-ceremony) or `desktop_mode_register_command( $args )` (optional, declares metadata server-side). Sync module: `src/commands/server-sync.ts`. Live unregistration on deactivation works for commands that either (a) declare `script` in PHP metadata, or (b) set `owner` on their JS `registerCommand` call. Plugins that do neither still require F5 on deactivate, graceful backwards-compat.
+- **OS Settings tabs** use the same pattern via `desktop_mode_register_settings_tab_script( $handle )` (primary) or `desktop_mode_register_settings_tab( $args )` (optional, id/label/capability/order/script). Sync module: `src/settings/server-sync.ts`; registry: `src/settings/registry.ts`; built-in tabs (appearance=10, ai=20, extended=30, help=40) are interleaved with the registry in `src/settings/index.ts` `renderPanel()` and re-painted live via `subscribeSettingsTabs`. Same (a)/(b) live-unregister rules as commands.
+- **AI Copilot extensibility** lives on a different axis from the live-refresh payloads, it's all per-request wiring inside `/ai/search` (`includes/ai-copilot/search.php`) plus a persistent server-tool registry in `includes/ai-copilot/tools-registry.php`. Two distinct registration surfaces: `desktop_mode_register_ai_tool( $args )` for PHP-dispatched tools (handler runs server-side, capability-gated, never visible to users who lack the cap), and client-side `registerCommand({ aiCallable: true })` for JS-dispatched slash-commands the AI can pick via `/ai/search`'s `command_tools` param. The full filter/action surface is `desktop_mode_ai_{system_prompt,system_prompt_appendix,system_prompt_replace_capability,request,tools,command_tools,command_allowed,tool_result,answer}` + observability actions `desktop_mode_ai_{search_started,tool_called,search_completed,search_error,tool_registered}`, every call carries a shared `request_id` UUID for trace correlation. `wp.desktop.ai.ask()` (`src/ai/ask.ts`) is the client-side programmatic entry point; it harvests `aiCallable: true` commands into `command_tools` and handles the server's `answer_type: 'tool_call'` short-circuit by running `run()` locally. The command's `run` function always lives JS-side, the server only emits a slug+args intent; the client invokes.
 - **Palettes** (`registerPalette`) are the remaining JS-registered-only gap. No server-side opt-in yet; a new plugin's palette won't appear until F5. Same fix shape as commands if/when needed: `desktop_mode_register_palette_script( $handle )` + payload key + clone the sync module.
 
 **When fixing this kind of "why doesn't X update live?" gap**, match the existing pattern: add server-side registration API (`desktop_mode_register_*`), extend the payload with a `server*` array including `scriptUrl`, add a `src/*/server-sync.ts` module modeled on the wallpaper one, wire it into `applyPayload()` in `desktop.ts`. Don't invent a different mechanism.
 
-## Event-driven framework (since 0.5.5)
+### Event-driven framework
 
-The framework is a **transport + state provider**, not a UX policy maker. Apps subscribe to OS events, query window state synchronously, decide for themselves what to do. The framework MUST NOT auto-render based on heuristics it can't generalize across all apps. We learned this when the Dock briefly auto-suppressed badges while their window was focused — convenient for an unread-counter pattern, wrong for any plugin whose badge meant something else (deploy failures, queued items, etc.).
+The framework is a **transport + state provider**, not a UX policy maker. Apps subscribe to OS events, query window state synchronously, decide for themselves what to do. The framework MUST NOT auto-render based on heuristics it can't generalize across all apps. We learned this when the Dock briefly auto-suppressed badges while their window was focused, convenient for an unread-counter pattern, wrong for any plugin whose badge meant something else (deploy failures, queued items, etc.).
 
 Three layers:
 
 1. **State queries.** `windowManager.getById/isActive`, `presence.getStatus`, `createSharedStore`.
 2. **Window lifecycle events.** Document CustomEvents (`desktop-mode-window-*`) AND hook actions (`HOOKS.WINDOW_*`) for every transition: opened, reopened, focused, blurred, minimized, restored, maximized, unmaximized, fullscreen-entered/exited, closing, closed. Per-window facade: `wp.desktop.onWindow(id, handlers)`.
-3. **Activity channels.** `wp.desktop.activity.publish/subscribe/filter` with channel naming `<plugin>/<event>` — peer-to-peer state-change broadcasts on the hook bus.
+3. **Activity channels.** `wp.desktop.activity.publish/subscribe/filter` with channel naming `<plugin>/<event>`, peer-to-peer state-change broadcasts on the hook bus.
 
-When you're tempted to add a heuristic inside the framework — "do X automatically when Y" — stop and turn it into a hook the app can subscribe to. App owns the policy.
+When you're tempted to add a heuristic inside the framework, "do X automatically when Y", stop and turn it into a hook the app can subscribe to. App owns the policy.
 
 Canonical example in-tree: `src/recycle-bin/badge.ts`. Full doc: `docs/event-driven-framework.md`.
 
-## Presence — framework-level (since 0.5.5)
+### Presence — framework-level
 
 Presence tracking (`online | inactive | offline`) lives in `includes/presence.php` and `src/presence/index.ts`. Any plugin can read `wp.desktop.presence.*` or `desktop_mode_presence_*()` without depending on a particular feature plugin being installed (chat, collaboration, …).
 
 Storage: `_desktop_mode_presence` option (autoload=false). The WordPress Heartbeat handler in `includes/presence.php` records bumps at priority 5; the framework client (`src/presence/index.ts`) sends `desktop_mode_presence_active: true` + `desktop_mode_user_active: <bool>` on every tick and ingests the snapshot from the response.
 
-Public surface — see `docs/javascript-reference.md` (`wp.desktop.presence`), `docs/hooks-reference.md` (filters / actions), and `docs/examples/presence.md` (recipe). Plugins with a faster delivery channel (an SSE stream, a WebSocket) can push updates straight into the framework store via `wp.desktop.presence.applyBatch()`.
+Public surface, see `docs/javascript-reference.md` (`wp.desktop.presence`), `docs/hooks-reference.md` (filters / actions), and `docs/examples/presence.md` (recipe). Plugins with a faster delivery channel (an SSE stream, a WebSocket) can push updates straight into the framework store via `wp.desktop.presence.applyBatch()`.
 
-## Cross-bundle state — `wp.desktop.createSharedStore` (since 0.5.5)
+### Cross-bundle state — `wp.desktop.createSharedStore`
 
-Each Desktop Mode feature compiles to its own Vite IIFE bundle (`desktop`, `code-editor`, `recycle-bin`, …, plus any third-party plugin bundles). Module-level state (a top-level `const state = ...` or `class Foo { …singleton… }`) defined in one bundle is **invisible** to another bundle even when both `import './state'` from the same source — each bundle has its own compiled copy. Mutations don't propagate; subscribers don't fire.
+Each Desktop Mode feature compiles to its own Vite IIFE bundle (one per `build:*` script in `package.json`, plus any third-party plugin bundles). Module-level state (a top-level `const state = ...` or `class Foo { …singleton… }`) defined in one bundle is **invisible** to another bundle even when both `import './state'` from the same source, each bundle has its own compiled copy. Mutations don't propagate; subscribers don't fire.
 
-**This was the bug that ate days of debugging on a multi-bundle feature.** Symptom: an always-on shell bundle called a setter that mutated module-level state; a lazy window-bundle read the same state, found the initial value, and rendered the placeholder — because the two bundles each had their own copy of the state module. The fix that's now standard:
+**This was the bug that ate days of debugging on a multi-bundle feature.** Symptom: an always-on shell bundle called a setter that mutated module-level state; a lazy window-bundle read the same state, found the initial value, and rendered the placeholder, because the two bundles each had their own copy of the state module. The fix that's now standard:
 
 ```ts
 import { createSharedStore } from '../shared-store';
@@ -150,21 +194,19 @@ const store = createSharedStore< MyState >( 'my-plugin/state', () => initial() )
 // createSharedStore with the same key.
 ```
 
-The primitive is also exposed on the public API as `wp.desktop.createSharedStore`. See [`docs/javascript-reference.md`](docs/javascript-reference.md#createsharedstore-key-initialstate--stable-since-055) and [`docs/examples/shared-store.md`](docs/examples/shared-store.md).
+The primitive is also exposed on the public API as `wp.desktop.createSharedStore`. See [`docs/javascript-reference.md`](docs/javascript-reference.md) and [`docs/examples/shared-store.md`](docs/examples/shared-store.md).
 
 **When you ARE writing module-level state in a feature with multiple bundles, route it through `createSharedStore`.** This is non-negotiable.
 
 **Before importing from one bundle's entry into another bundle's tree**, double-check that you aren't dragging in heavy code as a side-effect. Pulling a single symbol from a bundle entry that side-effect-imports the whole feature (poller, SSE, leader, heartbeat, …) inflates the consumer bundle. Pull the symbol from the leaf module that defines it instead.
 
-## Chromeless admin-bar suppression
+### Chromeless admin-bar suppression
 
-`is_admin_bar_showing()` short-circuits to `true` in admin context — the `show_admin_bar` filter alone is NOT sufficient inside chromeless iframes. We pair it with `remove_action( 'in_admin_header', 'wp_admin_bar_render', 0 )` on `admin_init`, AND a CSS rule killing the reserved 32px. Do not remove either half.
+`is_admin_bar_showing()` short-circuits to `true` in admin context, the `show_admin_bar` filter alone is NOT sufficient inside chromeless iframes. We pair it with `remove_action( 'in_admin_header', 'wp_admin_bar_render', 0 )` on `admin_init`, AND a CSS rule killing the reserved 32px. Do not remove either half.
 
-## Running PHPUnit
+### Running PHPUnit
 
-`npm run test:php` runs the suite inside wp-env. `.wp-env.json` remaps the
-dev/tests WP ports to **8890 / 8891** so it coexists with the user's
-Core-checkout dev environment on 8889. CI uses the same script.
+`npm run test:php` runs the suite inside wp-env. `.wp-env.json` remaps the dev/tests WP ports to **8890 / 8891** so it coexists with the user's Core-checkout dev environment on 8889. CI uses the same script.
 
 ```bash
 npm run env:start    # idempotent; brings the wp-env stack up if needed
@@ -172,161 +214,46 @@ npm run test:php     # full suite
 npm run test:php -- --filter='Tests_DesktopMode_Render'   # one class
 ```
 
-History: an earlier port collision against `wordpress-develop-wordpress-develop-1`
-(8889) made starting wp-env destructive. The remapped ports remove that
-hazard — wp-env and the Core checkout can both be up at the same time.
+History: an earlier port collision against `wordpress-develop-wordpress-develop-1` (8889) made starting wp-env destructive. The remapped ports remove that hazard, wp-env and the Core checkout can both be up at the same time.
 
-## Process reminders to self
-
-- **Read before speculating.** When asked how a mechanism works (refresh flow, hook order, bridge protocol), grep the code first. Hand-waving gets caught.
-- **Don't implement architectural changes unilaterally.** PHP API additions, payload shape changes, and new registry-sync modules are all load-bearing for plugin authors. Propose, get the green light, then code.
-- **Plugin Check** runs in CI as the `plugin-check` job (uses `wordpress/plugin-check-action@v1`, currently `ignore-warnings: true` while we baseline). For local runs: `npm run env:start` then `npm run check:plugin`. Don't add it to a pre-commit hook — needs a live WP/WP-CLI and is too slow per-commit.
+---
 
 ## Developer docs — read before, update after
 
 `docs/` is the public contract with third-party plugin authors. Two rules, no exceptions:
 
-1. **Before any task that touches a documented surface, read the relevant doc first.** It's the ground truth for what plugins depend on — reading it tells you whether a change is a bug fix, a backwards-compatible extension, or a breaking change that needs a different approach.
+1. **Before any task that touches a documented surface, read the relevant doc first.** It's the ground truth for what plugins depend on, reading it tells you whether a change is a bug fix, a backwards-compatible extension, or a breaking change that needs a different approach.
 2. **Update the relevant doc in the same change.** A hook change without a doc update ships a lie. A new example code path without an example entry is invisible to the people who need it.
 
-### Doc tree — what lives where
+### Doc map
 
-```
-docs/
-├── README.md                   Index + status legend (Stable / Experimental / Planned).
-│                               UPDATE WHEN: adding a new top-level doc, changing status labels.
-│                               READ BEFORE: getting oriented for any doc change.
-│
-├── getting-started.md          5-minute quickstart: dock icon + native window.
-│                               UPDATE WHEN: the minimum viable plugin skeleton changes,
-│                                            or the bootstrap hook names / timings change.
-│                               READ BEFORE: onboarding-related changes, first-run flows.
-│
-├── architecture.md             High-level design: shell vs iframe, bridge, lifecycle.
-│                               UPDATE WHEN: a new rendering path, persistence layer, REST
-│                                            route, or payload shape lands; build tooling shifts.
-│                               READ BEFORE: changes to render.php, desktop.ts bootstrap,
-│                                            bridge, session, or payload plumbing.
-│
-├── hooks-reference.md          Every PHP action + filter, with Stable/Experimental/Planned
-│                               status + signatures + examples.
-│                               UPDATE WHEN: adding/renaming/removing any apply_filters() or
-│                                            do_action(), or changing a signature/default,
-│                                            or changing a hook's status label.
-│                               READ BEFORE: any PHP hook work — this is the contract.
-│
-├── javascript-reference.md     CustomEvents, window.wp.desktop API, postMessage bridge.
-│                               UPDATE WHEN: adding/changing a CustomEvent detail shape, a
-│                                            postMessage bridge message, any wp.desktop.*
-│                                            method/property, user meta keys, query flags.
-│                               READ BEFORE: any shell-JS or bridge change.
-│
-├── bridge-protocol.md          End-to-end wiring of the connection bridge — postMessage
-│                               types, lifecycle walkthrough, sniff points for debugging.
-│                               UPDATE WHEN: bridge protocol message catalog changes,
-│                                            new lifecycle steps, new internal sniff points.
-│                               READ BEFORE: changes to src/connection/, src/window/iframe-bridge.ts,
-│                                            assets/js/iframe-bridge.js, the chromeless inline
-│                                            bridge in includes/render.php, or
-│                                            src/native-windows.ts buildIframeContentRender.
-│
-├── native-windows-proposal.md  Contract for native windows + framework interop.
-│                               UPDATE WHEN: the native-window API, tab system, or framework
-│                                            integration story changes.
-│                               READ BEFORE: changes under src/native-windows/ or
-│                                            desktop_mode_register_window* / window-tab APIs.
-│
-├── pwa.md                      Architecture: web-app manifest, root-scope service
-│                               worker (narrow fetch handler), install affordance,
-│                               wp.desktop.notify() local notifications. v2 push
-│                               wiring lands later without breaking v1 call sites.
-│                               UPDATE WHEN: caching policy changes, new manifest
-│                                            fields are auto-emitted, the SW scope/
-│                                            registration strategy changes, or the
-│                                            wp.desktop.notify / pwa.* surface gains
-│                                            or loses methods.
-│                               READ BEFORE: any change under includes/pwa.php or
-│                                            src/pwa/, or before bumping the SW
-│                                            cache version key.
-│
-├── plugin-compat-layer.md      Internals: how Desktop Mode adapts third-party plugins
-│                               (WC, Yoast, …) whose CSS/menu shapes assume classic
-│                               admin chrome. Three-tier model — CSS variable rebinds
-│                               → runtime offset scanner → targeted CSS overrides —
-│                               plus dock-side adaptations (URL builder, parent
-│                               fallthrough, empty-title skip).
-│                               UPDATE WHEN: adding/removing a compat shim in
-│                                            chromeless.css, the offset neutralizer in
-│                                            render.php, or a dock-builder adaptation
-│                                            in helpers.php for plugin-specific shapes.
-│                               READ BEFORE: any change to chromeless.css scoped to a
-│                                            specific plugin selector, any addition to
-│                                            desktop_mode_chromeless_offset_neutralizer_script,
-│                                            or any tweak to desktop_mode_menu_item_url
-│                                            / desktop_mode_build_dock_items aimed at
-│                                            handling a third-party menu-registration
-│                                            quirk.
-│
-└── examples/                   Copy-paste recipes — ONE per surface.
-    ├── README.md               Index of examples.
-    ├── arrange-action.md       UPDATE/READ WHEN: window-arrange behavior or hook changes.
-    ├── chromeless-style-override.md
-    │                            UPDATE/READ WHEN: chromeless.css contract or desktop_mode_chromeless_*
-    │                            hooks change.
-    ├── dock-badge.md           UPDATE/READ WHEN: dock item shape / badge rendering changes.
-    ├── gate-by-role.md         UPDATE/READ WHEN: desktop_mode_mode_enabled semantics change.
-    ├── inject-shell-config.md  UPDATE/READ WHEN: desktop_mode_shell_config keys change.
-    ├── layout-primitives.md    UPDATE/READ WHEN: <wpd-*> component kit contract changes.
-    ├── native-windows.md       UPDATE/READ WHEN: desktop_mode_register_window() contract changes.
-    ├── native-window-with-tabs.md
-    │                            UPDATE/READ WHEN: desktop_mode_register_window_tab() changes.
-    ├── react-to-window-events.md
-    │                            UPDATE/READ WHEN: window-lifecycle CustomEvent shape changes.
-    ├── register-command.md     UPDATE/READ WHEN: command registry API (JS or PHP) changes.
-    ├── register-ai-provider.md  UPDATE/READ WHEN: desktop_mode_register_ai_provider() contract,
-    │                            provider callback shapes, or active-provider resolution rules change.
-    ├── ai-ask.md                UPDATE/READ WHEN: wp.desktop.ai.ask() contract, AI-tool-calling
-    │                            protocol, or desktop_mode_register_ai_tool() signature changes.
-    ├── code-editor-open.md      UPDATE/READ WHEN: desktop-mode-code-open postMessage protocol,
-    │                            wp.desktop.openWindow contract, or Cmd/Ctrl+Shift+E shortcut changes.
-    ├── connect-to-window.md     UPDATE/READ WHEN: registerTitleBarButton, Window.setHighlight,
-    │                            wp.desktop.connect, or wp.desktop.iframe.* contract changes;
-    │                            desktop-mode-bridge-* postMessage protocol changes.
-    ├── data-table.md            UPDATE/READ WHEN: <wpd-table> contract changes — column descriptor
-    │                            shape, filter kinds, sticky-columns/header behavior, sub-table API,
-    │                            or wpd-table-{filter-change,row-click,expand-change} event details.
-    ├── spinner.md               UPDATE/READ WHEN: <wpd-spinner> contract changes — preset list,
-    │                            attribute names, CSS-variable surface, or accessibility defaults.
-    ├── progress-bar.md          UPDATE/READ WHEN: <wpd-progress-bar> contract changes — value/max,
-    │                            indeterminate, tone list, label/show-percent header, or CSS-variable surface.
-    ├── register-icon.md        UPDATE/READ WHEN: desktop_mode_register_icon() contract changes.
-    ├── register-wallpaper.md   UPDATE/READ WHEN: WallpaperDef or desktop_mode_register_wallpaper() changes.
-    ├── shared-store.md          UPDATE/READ WHEN: wp.desktop.createSharedStore() contract,
-    │                            slot key naming convention, or reset semantics change.
-    ├── presence.md              UPDATE/READ WHEN: wp.desktop.presence.* contract,
-    │                            desktop_mode_presence_* filters/actions, or the Heartbeat
-    │                            payload for `desktop_mode_presence` changes.
-    ├── window-with-config.md    UPDATE/READ WHEN: the 'config' arg on
-    │                            desktop_mode_register_window(), wp.desktop.getWindowConfig(),
-    │                            wp.desktop.debug.window(), or the lazy-load extras
-    │                            harvest contract changes.
-    ├── window-lifecycle.md     UPDATE/READ WHEN: window state machine / lifecycle hooks change.
-    ├── pwa-install.md           UPDATE/READ WHEN: wp.desktop.pwa.promptInstall(),
-    │                            install-pill UX, or desktop_mode_pwa_manifest filter
-    │                            contract changes.
-    ├── notify.md                UPDATE/READ WHEN: wp.desktop.notify() options shape,
-    │                            fallback semantics, or
-    │                            desktop-mode/notification-{requested,shown}
-    │                            channel payloads change.
-    └── window-notice.md         UPDATE/READ WHEN: desktop_mode_register_window_notice()
-                                 contract, wp.desktop.registerWindowNotice() shape,
-                                 <wpd-notice> attributes, or the persistence-key
-                                 scheme (desktop-mode-notice-dismissed:<userId>)
-                                 changes.
-```
+The full index lives in [`docs/README.md`](docs/README.md). Quick reference:
+
+| Path | Read before / update when |
+|---|---|
+| `docs/README.md` | Top-level index + status legend. |
+| `docs/getting-started.md` | The minimum-viable plugin skeleton or bootstrap hook names change. |
+| `docs/architecture.md` | A new rendering path, persistence layer, REST route, or payload shape lands; build tooling shifts. |
+| `docs/api-index.md` | Any public API surface changes (PHP, JS, or events). |
+| `docs/hooks-reference.md` | Any `apply_filters()` / `do_action()` change: add, rename, remove, signature, default, or status. **The PHP hook contract.** |
+| `docs/javascript-reference.md` | Any CustomEvent shape, postMessage bridge message, `wp.desktop.*` method/property, user meta key, or query flag changes. **The JS contract.** |
+| `docs/bridge-protocol.md` | The postMessage bridge protocol, lifecycle steps, or internal sniff points change. |
+| `docs/native-windows-proposal.md` | The native-window API, tab system, or framework integration story changes. |
+| `docs/event-driven-framework.md` | The event-bus model, activity channels, or window lifecycle events change. |
+| `docs/pwa.md` | Caching policy, manifest emission, SW scope/registration, or `wp.desktop.notify` / `pwa.*` surface changes. |
+| `docs/plugin-compat-layer.md` | A chromeless-CSS shim, offset neutralizer, or dock-builder adaptation for a third-party plugin shape is added/changed. |
+| `docs/dock-customization.md` | Dock rendering, ordering, or decoration hooks change. |
+| `docs/files-on-desktop.md` | Desktop file/folder behavior, tile metadata, or placement changes. |
+| `docs/folder-sharing.md` | Folder-sharing API, ACL model, or REST routes change. |
+| `docs/migration-*.md` | A breaking change ships, write a migration note here in the same PR. |
+| `docs/DEVELOPMENT.md` | Local-dev setup, build, or test workflow changes. |
+| `docs/RELEASE.md` | The release process changes. |
+| `docs/examples/*.md` | The hook, API, or component the example uses changes. **One example per surface.** |
+| `docs/examples/README.md` | A new example is added or an existing one is renamed. |
 
 **Rules of thumb:**
+
 - If an example stops working because the hook it uses changed, update the example in the same PR. Never leave a broken example.
-- A documented "Stable" signature changing in a backwards-incompatible way is a breaking change — surface it to the user before shipping.
+- A documented "Stable" signature changing in a backwards-incompatible way is a breaking change, surface it to the user before shipping.
 - If a change spans a surface that doesn't yet have an example (new public API), add one under `docs/examples/` and index it in `examples/README.md`.
 - If a change adds a whole new surface with no doc yet, ask whether it deserves its own `docs/*.md` or fits as an example. Default to an example unless the surface has meaningful architectural weight.


### PR DESCRIPTION
## Summary

Refresh `AGENTS.md` to fix stale claims, surface workflow rules, and restructure for findability.

### Factual fixes
- Replace the stale "two bundles today" table with a pointer to `package.json` `build:*` scripts + `vite.config.js`. The repo now has ~17 build targets, not two.
- Drop the "since 0.15.0" / "since 0.17.0" markers (referenced versions that don't exist; plugin is at 0.8.6) and the now-redundant "since 0.5.5" tags.
- Replace the 134-line ASCII Doc Tree with a 19-row table that matches the actual `docs/` contents. The old tree was missing roughly half the top-level docs and ~21 example pages.
- Switch typecheck guidance from `./node_modules/.bin/tsc --noEmit` to `npm run typecheck`.
- Remove the dangling reference to `docs/components-reference.md` (does not exist; the `static help` block on each `<wpd-*>` class is the actual convention, verified across all 55 components).

### Promoted workflow rules

Moved four standing rules from personal notes into the shared doc:
- Run `npm run build` once at the end of a batch (not between intermediate edits).
- Always branch + PR, never commit to trunk.
- Use `bin/sync-to-wp-develop.sh` over raw `rsync`.
- Don't regenerate POT/PO/JSON in feature PRs.

### Structure
- Reorder into **Hard rules → Workflow → Process reminders → Contributor gotchas → Developer docs map**, so the highest-bite rules (`assets/js/` is build output, `trackedFetch`, `wpdConfirm`, `wpd-*`) come first.
- Add a `## Contents` TOC.
- Reframe the opening (the "Short file" claim was broken at 333 lines). New framing: rulebook + cheatsheet for working *inside* the codebase, with `docs/` as the public contract for plugin authors.

Net result: 327 lines → 327 lines (similar length), but with substantive content corrected and the high-frequency rules surfaced.

## Test plan
- [x] Read through `AGENTS.md` and confirm the Doc map table matches your mental model of `docs/`.
- [x] Spot-check that the "Hard rules" surface the things you actually want to land first when an agent reads the file.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-257-641a4f061a934114ee2b9a6bf2d99af35354120d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->