### PR TITLE
fix(plugins-window): rename Browse tab to Add Plugin

### DIFF
--- a/includes/plugins-window/window.php
+++ b/includes/plugins-window/window.php
@@ -35,7 +35,7 @@ function desktop_mode_plugins_window_render_template() {
 		<wpd-tabs value="installed" class="desktop-mode-plugins__tabs" data-desktop-mode-plugins-tabs>
 			<wpd-tab value="installed"><?php esc_html_e( 'Installed', 'desktop-mode' ); ?></wpd-tab>
 			<?php if ( ! empty( $caps['install'] ) ) : ?>
-				<wpd-tab value="browse"><?php esc_html_e( 'Browse', 'desktop-mode' ); ?></wpd-tab>
+				<wpd-tab value="browse"><?php esc_html_e( 'Add Plugin', 'desktop-mode' ); ?></wpd-tab>
 				<wpd-tab value="featured"><?php esc_html_e( 'Desktop Mode plugins', 'desktop-mode' ); ?></wpd-tab>
 			<?php endif; ?>
 		</wpd-tabs>


### PR DESCRIPTION
## Summary

- Renames the second tab in the native Plugins window from **Browse** to **Add Plugin** so the label matches what the tab actually does (search wp.org + upload a `.zip` to install).
- Internal tab `value="browse"` and JS code paths are unchanged; only the user-visible string moves.

## Test plan

- [x] Open the Plugins native window as an admin (with `install_plugins`).
- [x] Confirm the tab row reads: **Installed | Add Plugin | Desktop Mode plugins**.
- [x] Switching to **Add Plugin** still loads the wp.org search + segmented filters.
- [x] Installing or uploading a plugin from that tab still works.
- [x] Open as a Subscriber: only **Installed** is visible (Add Plugin still hidden behind the `install_plugins` cap).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-259-f31671b2aa749319b673bf33c312fbc360bcb003.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->