### PR TITLE
Drag and drop improvements

### DIFF
--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -512,6 +512,13 @@ wpd-tab-chip + wpd-tab-chip {
 	transition: opacity 0.25s ease;
 }
 
+/* Cross-window drag drop-overlay rules live in windows.css, NOT here.
+ * Putting them in this @import'd sub-sheet means browsers can serve a
+ * stale cached copy even when the parent windows.css has been cache-
+ * busted by mtime, leaving the drag stuck at the iframe boundary
+ * until the user manually clears their stylesheet cache. Keep them
+ * co-located with the @import declarations themselves. */
+
 /*
  * Loading-state overlay — painted by `src/window/dom.ts` into
  * every window's body and removed once the body's content reports

--- a/assets/css/windows.css
+++ b/assets/css/windows.css
@@ -31,3 +31,27 @@
 @import url( "window-states.css" );
 @import url( "window-overview.css" );
 @import url( "os-settings.css" );
+
+/*
+ * Cross-window drag drop highlight — kept INLINE in this file
+ * (not in any of the @import'd sub-sheets) so the mtime-stamped
+ * `?ver=…` on `windows.css` reliably invalidates the rules along
+ * with the parent stylesheet. Sub-sheets are fetched without an
+ * explicit version query and can be served from the browser's
+ * heuristic cache even after a hard reload.
+ *
+ * The cross-window pointer routing itself is driven from
+ * JavaScript by `src/drag/iframe-drop-targets.ts` — on drag
+ * START with a shortcut payload, every iframe element gets an
+ * inline `style.pointerEvents = 'none'` so pointer events fall
+ * through to the iframe's parent (`.desktop-mode-window__body`),
+ * which is registered as the drop target. No CSS rule is needed
+ * to make the routing work — this stylesheet only paints the
+ * visual feedback for whichever window is currently the active
+ * drop target.
+ */
+.desktop-mode-window__body[data-desktop-mode-iframe-drop-active] {
+	outline: 2px dashed var(--desktop-mode-accent, #2271b1);
+	outline-offset: -6px;
+	background: color-mix(in srgb, var(--desktop-mode-accent, #2271b1) 8%, transparent);
+}

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -161,6 +161,51 @@ When something's not working:
 - **`window.location.origin`** check — every postMessage in both directions filters on this. A common cause of "messages don't arrive" is a shell mounted on `https://example.test` and an iframe loaded from `http://example.test` (different origin); same domain ≠ same origin.
 - **`event.source === iframe.contentWindow`** check — even same-origin, a foreign caller posting `desktop-mode-bridge-*` messages from somewhere ELSE in the parent will be silently dropped.
 
+## Cross-window drag bridge — Stable *(since 0.22.0)*
+
+A separate channel from the connection bridge. Where the connection bridge carries app-level pub/sub between a window and its iframe, the **drag bridge** carries an in-flight drag payload between the parent shell and ALL same-origin iframes — receivers don't need to be "connected" to receive it.
+
+### When it fires
+
+The drag bridge stores a single `DragBridgePayload` at any given time. Two ways the payload gets in:
+
+- **Shell-side drag source** — a DragManager `'shortcut'` session starts on a shell-rendered tile (My WordPress media / post / user). The shell's `DRAG_EVENTS.START` listener (`src/desktop.ts`) reads `payload.data.bridgePayload` and calls `dragBridge.start(payload)`. Cleared on `DRAG_EVENTS.END`.
+- **Iframe-side drag source** — an iframe postMessages `{ type: 'desktop-mode-drag-start', payload }` to the parent. The bridge stores the payload and broadcasts `DRAG_BRIDGE_EVENTS.START` as a `CustomEvent` on `document` so other shell modules can react.
+
+### Receiver protocol
+
+Drop-receiver iframes have two ways to consume the payload:
+
+1. **Push** — `src/drag/iframe-drop-targets.ts` registers an overlay drop target on every iframe window. When the pointer is over an iframe and the gesture is a shortcut drag, the shell postMessages:
+
+   | Message | Direction | Payload |
+   |---|---|---|
+   | `desktop-mode-drag-over` | parent → iframe | `{ type, payload: DragBridgePayload }` |
+   | `desktop-mode-drag-leave` | parent → iframe | `{ type }` |
+   | `desktop-mode-drop` | parent → iframe | `{ type, payload: DragBridgePayload, position: { x, y } }` |
+
+   Receivers listen on `window.message`, check `event.origin === window.location.origin`, and switch on `data.payload.kind`. The built-in Gutenberg receiver (`src/gutenberg-drop-receiver.ts`) is the canonical example.
+
+2. **Pull** — any iframe can postMessage `{ type: 'desktop-mode-drag-payload-request' }` and the parent replies (directly to `event.source`) with `{ type: 'desktop-mode-drag-payload', payload }`. Useful for iframes that bind their own native `drop` handler and need the rich payload after the browser has stripped the custom MIME from DataTransfer.
+
+### Payload union
+
+```ts
+type DragBridgePayload =
+  | { kind: 'attachment'; id: number; url: string; title: string;
+      alt: string; mime: string; thumbnailUrl?: string;
+      sizes?: Record<string, unknown> }
+  | { kind: 'post'; id: number; postType: string; url: string;
+      title: string }
+  | { kind: 'user'; id: number; url: string; title: string };
+```
+
+### Sniff points
+
+- **`document.body[data-desktop-mode-dragging]`** — set by the DragManager while ANY drag is in flight. Pair with `[data-desktop-mode-drag-type="shortcut"]` to gate iframe-overlay CSS.
+- **`window.wp.desktop.dragBridge.getPayload()`** — read the current cross-frame payload from anywhere in the parent shell.
+- **`desktop-mode-cross-frame-drag-start` / `-end` CustomEvents** — dispatched on `document` each time the bridge transitions. Plugins layer drop-zone highlights on these without polling.
+
 ## Don't reinvent the wiring
 
 If you find yourself writing `window.parent.postMessage` or hand-rolling a handshake, check first:

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -297,6 +297,67 @@ The cross-iframe `wp-desktop-drag-*` events from `wp.desktop.dragBridge`
 (Media Library payload channel) are a separate, lower-level surface
 and remain Stable since 0.14.0.
 
+### `wp.desktop.dragBridge` — cross-iframe drag — Stable *(since 0.22.0)*
+
+The bridge is the postMessage channel that lets shell-side drags
+(My WordPress media tiles, post tiles, user tiles) land inside iframe
+windows (the Gutenberg editor, the site editor). When a DragManager
+session begins on a shell tile carrying a `bridgePayload`, the shell
+fans the payload into `dragBridge.start(payload)`. While the gesture
+is in flight, the shell routes pointer events through a per-window
+overlay (`src/drag/iframe-drop-targets.ts`) and posts the following
+messages into the iframe under the cursor:
+
+| postMessage type | Direction | When | Payload shape |
+| --- | --- | --- | --- |
+| `desktop-mode-drag-over` | parent → iframe | cursor entered the iframe | `{ type, payload: DragBridgePayload }` |
+| `desktop-mode-drag-leave` | parent → iframe | cursor left the iframe | `{ type }` |
+| `desktop-mode-drop` | parent → iframe | pointerup over the iframe | `{ type, payload: DragBridgePayload, position: { x, y } }` |
+| `desktop-mode-drag-start` | iframe → parent | iframe initiated its own drag | `{ type, payload: DragBridgePayload }` |
+| `desktop-mode-drag-end` | iframe → parent | iframe-initiated drag ended | `{ type }` |
+| `desktop-mode-drag-payload-request` | iframe → parent | iframe wants the current payload | reply: `{ type: 'desktop-mode-drag-payload', payload }` |
+
+`DragBridgePayload` is a discriminated union keyed on `kind`:
+
+```ts
+type DragBridgePayload =
+  | { kind: 'attachment'; id: number; url: string; title: string;
+      alt: string; mime: string; thumbnailUrl?: string;
+      sizes?: Record<string, unknown> }
+  | { kind: 'post'; id: number; postType: string; url: string;
+      title: string }
+  | { kind: 'user'; id: number; url: string; title: string };
+```
+
+Public `DragBridgeApi` surface:
+
+```ts
+interface DragBridgeApi {
+  getPayload(): DragBridgePayload | null;
+  isDragging(): boolean;
+  start( payload: DragBridgePayload ): void;
+  end(): void;
+}
+```
+
+`start` / `end` let in-process code (e.g. a plugin's own drag source)
+drive the bridge directly without postMessage round-trips. The shell
+calls these automatically when a `'shortcut'` DragManager session
+starts/ends with a `bridgePayload` attached.
+
+Same-origin messages only — the bridge checks `e.origin` against the
+parent's own origin before storing payloads or responding.
+
+The built-in Gutenberg drop receiver (`assets/js/gutenberg-drop-receiver.min.js`,
+enqueued on `post.php` / `post-new.php` / `site-editor.php`)
+listens for `desktop-mode-drop` and inserts a block:
+
+- `attachment` `image/*` → `core/image`
+- `attachment` `video/*` → `core/video`
+- `attachment` `audio/*` → `core/audio`
+- `attachment` other → `core/file`
+- `post` / `user` → `core/paragraph` with `<a href="URL">title</a>`
+
 ### OS-file drop hooks — Experimental *(since 0.30.0)*
 
 When the user drags a file in from the host operating system

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -46,11 +46,20 @@ function desktop_mode_register_assets() {
 		array( 'desktop-mode-variables' ),
 		$version
 	);
+	// `filemtime`-stamped — window-chrome iteration (drop overlays,
+	// new drag affordances, third-party-plugin compat) lands faster
+	// than plugin version bumps. Without an mtime stamp the browser
+	// keeps `?ver=<plugin-version>` valid for the whole release cycle
+	// and the user keeps seeing yesterday's CSS even after a hard
+	// reload. Stamps the parent `windows.css` only; the @imports inside
+	// (`window-chrome.css`, `window-states.css`, …) inherit the cache
+	// directive from the parent fetch, so a busted `windows.css` busts
+	// the whole subtree.
 	wp_register_style(
 		'desktop-mode-windows',
 		DESKTOP_MODE_URL . 'assets/css/windows.css',
 		array( 'desktop-mode-variables', 'dashicons' ),
-		$version
+		$built_version( 'assets/css/windows.css' )
 	);
 	wp_register_style(
 		'desktop-mode-dock',
@@ -178,6 +187,23 @@ function desktop_mode_register_assets() {
 		DESKTOP_MODE_URL . 'assets/js/iframe-bridge' . $suffix . '.js',
 		array(),
 		$built_version( 'assets/js/iframe-bridge' . $suffix . '.js' ),
+		true
+	);
+
+	// `desktop-mode-gutenberg-drop-receiver` — iframe-side bundle
+	// enqueued only on the Block Editor screens (`post.php` /
+	// `post-new.php`) for desktop-mode users. Listens for
+	// `desktop-mode-drop` postMessages from the parent shell (see
+	// `src/drag/iframe-drop-targets.ts`) and inserts the matching
+	// Gutenberg block via `wp.data.dispatch('core/block-editor')`.
+	// Depends on `wp-blocks` + `wp-data` so the editor stores are
+	// guaranteed enqueued before the receiver runs its first message
+	// handler.
+	wp_register_script(
+		'desktop-mode-gutenberg-drop-receiver',
+		DESKTOP_MODE_URL . 'assets/js/gutenberg-drop-receiver' . $suffix . '.js',
+		array( 'wp-blocks', 'wp-data' ),
+		$built_version( 'assets/js/gutenberg-drop-receiver' . $suffix . '.js' ),
 		true
 	);
 

--- a/includes/desktop-files/types/class-desktop-mode-attachment-file.php
+++ b/includes/desktop-files/types/class-desktop-mode-attachment-file.php
@@ -66,9 +66,16 @@ class Desktop_Mode_Attachment_File extends Desktop_Mode_File {
 	}
 
 	public function serialize(): array {
-		$shape          = parent::serialize();
-		$post           = $this->attachment();
-		$shape['mime']  = $post ? (string) $post->post_mime_type : '';
+		$shape         = parent::serialize();
+		$post          = $this->attachment();
+		$shape['mime'] = $post ? (string) $post->post_mime_type : '';
+		// Full-size source URL + alt text — surfaced so cross-frame
+		// drag handlers can build `core/image` / `core/video` /
+		// `core/audio` / `core/file` blocks on drop into Gutenberg
+		// without a REST roundtrip. `previewUrl` is a thumbnail and
+		// not the right attribute for the inserted block.
+		$shape['sourceUrl'] = $post ? (string) wp_get_attachment_url( $post->ID ) : '';
+		$shape['alt']       = $post ? (string) get_post_meta( $post->ID, '_wp_attachment_image_alt', true ) : '';
 		return $shape;
 	}
 

--- a/includes/desktop-files/types/class-desktop-mode-post-file.php
+++ b/includes/desktop-files/types/class-desktop-mode-post-file.php
@@ -72,10 +72,15 @@ class Desktop_Mode_Post_File extends Desktop_Mode_File {
 	}
 
 	public function serialize(): array {
-		$shape         = parent::serialize();
-		$post          = $this->post();
+		$shape             = parent::serialize();
+		$post              = $this->post();
 		$shape['postType'] = $post ? (string) $post->post_type : '';
 		$shape['status']   = $post ? (string) $post->post_status : '';
+		// Permalink — surfaced on the serialized shape so cross-frame
+		// drag handlers can build a `<a href>` block on drop without
+		// a synchronous REST roundtrip. Empty string when the post is
+		// gone or has no permalink (drafts of certain post types).
+		$shape['link']     = $post ? (string) get_permalink( $post ) : '';
 		return $shape;
 	}
 

--- a/includes/desktop-files/types/class-desktop-mode-user-file.php
+++ b/includes/desktop-files/types/class-desktop-mode-user-file.php
@@ -51,9 +51,13 @@ class Desktop_Mode_User_File extends Desktop_Mode_File {
 	}
 
 	public function serialize(): array {
-		$shape       = parent::serialize();
-		$user        = $this->user();
+		$shape          = parent::serialize();
+		$user           = $this->user();
 		$shape['roles'] = $user ? array_values( (array) $user->roles ) : array();
+		// Author archive URL — surfaced so cross-frame drag handlers
+		// can build a `<a href>` to the author's posts on drop into
+		// Gutenberg without a REST roundtrip.
+		$shape['link']  = $user ? (string) get_author_posts_url( (int) $user->ID ) : '';
 		return $shape;
 	}
 

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -42,6 +42,24 @@ function desktop_mode_enqueue_assets() {
 	// accidentally classic.
 	if ( desktop_mode_is_enabled() ) {
 		wp_enqueue_script( 'desktop-mode-iframe-bridge' );
+
+		// Block Editor cross-window drop receiver. Listens for
+		// `desktop-mode-drop` postMessages from the parent shell and
+		// inserts the matching block. Only enqueue inside the Block
+		// Editor screens — every other admin page would be paying for
+		// a bundle it never uses. `$hook_suffix` is supplied by the
+		// `admin_enqueue_scripts` action; `post.php` / `post-new.php`
+		// cover both edit + new-post flows. Gutenberg also drives
+		// `site-editor.php` (full-site editing) — included so dropping
+		// onto a template / template-part window also works.
+		global $hook_suffix;
+		if (
+			'post.php' === $hook_suffix
+			|| 'post-new.php' === $hook_suffix
+			|| 'site-editor.php' === $hook_suffix
+		) {
+			wp_enqueue_script( 'desktop-mode-gutenberg-drop-receiver' );
+		}
 	}
 
 	// Chromeless requests (iframes) need chromeless styles and overrides.

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
 		}
 	},
 	"scripts": {
-		"build": "npm run vendor:pixi && npm run build:desktop && npm run build:iframe-bridge && npm run build:recycle-bin && npm run build:posts-window && npm run build:plugins-window && npm run build:comments-window && npm run build:my-wordpress && npm run build:content-graph && npm run build:ai-assistant && npm run build:animated-logo-wallpaper && npm run build:about-scene && npm run build:os-settings-panel && npm run build:shell-overlays && npm run build:window-system && npm run build:widget-heartbeat && npm run build:pwa-sw",
+		"build": "npm run vendor:pixi && npm run build:desktop && npm run build:iframe-bridge && npm run build:gutenberg-drop-receiver && npm run build:recycle-bin && npm run build:posts-window && npm run build:plugins-window && npm run build:comments-window && npm run build:my-wordpress && npm run build:content-graph && npm run build:ai-assistant && npm run build:animated-logo-wallpaper && npm run build:about-scene && npm run build:os-settings-panel && npm run build:shell-overlays && npm run build:window-system && npm run build:widget-heartbeat && npm run build:pwa-sw",
 		"build:desktop": "vite build --mode development && vite build --mode production",
 		"build:iframe-bridge": "DESKTOP_MODE_TARGET=iframe-bridge vite build --mode development && DESKTOP_MODE_TARGET=iframe-bridge vite build --mode production",
+		"build:gutenberg-drop-receiver": "DESKTOP_MODE_TARGET=gutenberg-drop-receiver vite build --mode development && DESKTOP_MODE_TARGET=gutenberg-drop-receiver vite build --mode production",
 		"build:recycle-bin": "DESKTOP_MODE_TARGET=recycle-bin vite build --mode development && DESKTOP_MODE_TARGET=recycle-bin vite build --mode production",
 		"build:posts-window": "DESKTOP_MODE_TARGET=posts-window vite build --mode development && DESKTOP_MODE_TARGET=posts-window vite build --mode production",
 		"build:plugins-window": "DESKTOP_MODE_TARGET=plugins-window vite build --mode development && DESKTOP_MODE_TARGET=plugins-window vite build --mode production",

--- a/src/desktop-files/drag-payloads.ts
+++ b/src/desktop-files/drag-payloads.ts
@@ -22,12 +22,26 @@
  */
 
 import type { RestPlacementShape } from './rest';
+import type { DragBridgePayload } from '../drag-bridge';
 
 export interface DesktopFileDragData {
 	/** The placement being dragged (full record). */
 	placement: RestPlacementShape;
 	/** Folder the source tile lives in, BEFORE the drop. */
 	sourceFolderId: number;
+	/**
+	 * Optional cross-frame bridge payload, synthesized from the
+	 * placement's file shape at drag start when the file type is
+	 * bridgeable (attachment / post / user). Lets iframe receivers
+	 * (Gutenberg drop-receiver) react to a desktop-file drop the
+	 * same way they would a fresh shortcut drag — the user dragging
+	 * an existing post shortcut from the wallpaper into Gutenberg
+	 * gets the same `<a href>` insertion as dragging from My
+	 * WordPress.
+	 *
+	 * @since 0.22.0
+	 */
+	bridgePayload?: DragBridgePayload;
 }
 
 export interface ShortcutDragData {
@@ -39,6 +53,18 @@ export interface ShortcutDragData {
 	title?: string;
 	/** Optional dashicon class for diagnostics + ghost. */
 	icon?: string;
+	/**
+	 * Optional cross-frame bridge payload. When present the shell
+	 * fans this into `wp.desktop.dragBridge` at lift time so iframe
+	 * receivers (e.g. the Gutenberg drop-receiver) can react to the
+	 * drag — the receiver inserts a block built from this payload on
+	 * `desktop-mode-drop`. Tiles that omit it still drag-out for
+	 * placement purposes; they just don't trigger any iframe-side
+	 * drop behavior.
+	 *
+	 * @since 0.22.0
+	 */
+	bridgePayload?: DragBridgePayload;
 }
 
 /** Concrete payload shapes consumed by drop targets. */

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -42,6 +42,65 @@ import {
 } from './grid';
 import type { RestPlacementShape } from './rest';
 import type { FilesState } from './store';
+import type { DragBridgePayload } from '../drag-bridge';
+
+/**
+ * Build a cross-frame bridge payload from a placement, or return
+ * `undefined` when the placement's file type isn't one we know how
+ * to deliver into an iframe (anything outside attachment/post/user).
+ *
+ * The placement's `file` shape carries everything we need because
+ * the PHP `Desktop_Mode_*_File::serialize()` methods surface `link`
+ * / `sourceUrl` / `alt` / `mime` / `postType` on every list
+ * response.
+ *
+ * @since 0.22.0
+ */
+function buildBridgePayloadFromPlacement(
+	placement: RestPlacementShape,
+): DragBridgePayload | undefined {
+	const file = placement.file;
+	if ( ! file ) {
+		return undefined;
+	}
+	const id = parseInt( String( file.ref ?? '' ), 10 );
+	if ( ! Number.isFinite( id ) || id <= 0 ) {
+		return undefined;
+	}
+	const title = String( file.title ?? '' );
+	if ( file.type === 'attachment' ) {
+		const url = String( file.sourceUrl ?? file.previewUrl ?? '' );
+		return {
+			kind: 'attachment',
+			id,
+			url,
+			title,
+			alt: String( file.alt ?? '' ),
+			mime: String( file.mime ?? '' ),
+			thumbnailUrl: file.previewUrl
+				? String( file.previewUrl )
+				: undefined,
+		};
+	}
+	if ( file.type === 'post' ) {
+		return {
+			kind: 'post',
+			id,
+			postType: String( file.postType ?? 'post' ),
+			url: String( file.link ?? '' ),
+			title,
+		};
+	}
+	if ( file.type === 'user' ) {
+		return {
+			kind: 'user',
+			id,
+			url: String( file.link ?? '' ),
+			title,
+		};
+	}
+	return undefined;
+}
 import { isConflict, showConflictToast } from './conflict-toast';
 import type { DragManagerApi, DragSession, DropTarget } from '../drag';
 import { trashFolderWithUndo, trashPlacementWithUndo } from './trash';
@@ -1606,6 +1665,14 @@ function attachTileDrag(
 				data: {
 					placement: livePlacement,
 					sourceFolderId: folderId,
+					// Synthesize a cross-frame bridge payload from the
+					// placement's file shape so a wallpaper-placed
+					// shortcut can be dropped into an open Gutenberg
+					// iframe and inserted as the matching block. The
+					// PHP serialize() methods (`Desktop_Mode_Post_File`,
+					// `Desktop_Mode_User_File`, `Desktop_Mode_Attachment_File`)
+					// surface the URL fields this needs.
+					bridgePayload: buildBridgePayloadFromPlacement( livePlacement ),
 				} satisfies DesktopFileDragData,
 				ghost: {
 					offsetX: e.clientX - tile.getBoundingClientRect().left,

--- a/src/desktop-files/tile-spec.ts
+++ b/src/desktop-files/tile-spec.ts
@@ -219,6 +219,16 @@ export interface TileDragOutPayload {
 	title?: string;
 	/** Optional dashicon class for the ghost. */
 	icon?: string;
+	/**
+	 * Optional cross-frame bridge payload. When set the shell fans
+	 * this into `wp.desktop.dragBridge` while the gesture is live so
+	 * iframe receivers (Gutenberg drop-receiver, future Media Library
+	 * receiver) can insert a block on `desktop-mode-drop`. See
+	 * `ShortcutDragData.bridgePayload`.
+	 *
+	 * @since 0.22.0
+	 */
+	bridgePayload?: import( '../drag-bridge' ).DragBridgePayload;
 }
 
 /**
@@ -258,6 +268,7 @@ export function attachTileDragOut(
 					ref: payload.ref,
 					title: payload.title,
 					icon: payload.icon,
+					bridgePayload: payload.bridgePayload,
 				} satisfies ShortcutDragData,
 				ghost: {
 					offsetX: e.clientX - rect.left,

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -128,7 +128,8 @@ import {
 } from './pwa/install';
 import { type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
-import { DragManager, type DragManagerApi } from './drag';
+import { DragManager, type DragManagerApi, DRAG_EVENTS } from './drag';
+import { installIframeDropTargets } from './drag/iframe-drop-targets';
 import {
 	type DesktopCommand,
 } from './commands';
@@ -1771,6 +1772,52 @@ function init(): void {
 	// gestures for file tiles, entity tiles, and plugin-registered
 	// draggable surfaces. Drop targets register via the public API.
 	const dragManager: DragManagerApi = new DragManager();
+
+	// Fan shell-side shortcut drags into the cross-frame bridge so
+	// iframe receivers (Gutenberg drop-receiver, future Media Library
+	// receiver) participate via the same `desktop-mode-drop`
+	// protocol used by iframe-source drags. Only `'shortcut'`
+	// payloads carrying a `bridgePayload` opt in — every other drag
+	// (desktop-file repositions, plugin payloads) stays purely
+	// shell-side.
+	document.addEventListener( DRAG_EVENTS.START, ( e ) => {
+		const detail = ( e as CustomEvent ).detail as
+			| {
+					payload?: {
+						type?: string;
+						data?: { bridgePayload?: unknown };
+					};
+				}
+			| undefined;
+		const payload = detail?.payload;
+		// Both `'shortcut'` (fresh tile from My WordPress) AND
+		// `'desktop-file'` (existing placement dragged off the
+		// wallpaper) drags can carry a `bridgePayload`. Either way
+		// we feed it into the bridge so iframe receivers participate
+		// via the same `desktop-mode-drop` protocol.
+		if ( ! payload ) {
+			return;
+		}
+		if ( payload.type !== 'shortcut' && payload.type !== 'desktop-file' ) {
+			return;
+		}
+		const bridgePayload = payload.data?.bridgePayload as
+			| import( './drag-bridge' ).DragBridgePayload
+			| undefined;
+		if ( bridgePayload ) {
+			dragBridge.start( bridgePayload );
+		}
+	} );
+	document.addEventListener( DRAG_EVENTS.END, () => {
+		// `end()` is idempotent — safe to fire on every session end
+		// whether or not we started one for it.
+		dragBridge.end();
+	} );
+
+	// Cross-iframe drop targets — installs an overlay per iframe
+	// window that catches shortcut drags and forwards them as
+	// `desktop-mode-drop` postMessages. Idempotent.
+	installIframeDropTargets( dragManager );
 
 	// Register the AI Assistant as the first (default) Cmd+K palette
 	// and install the single global shortcut. Other plugins can register

--- a/src/drag-bridge.ts
+++ b/src/drag-bridge.ts
@@ -6,52 +6,108 @@
  * DataTransfer) — but custom MIME types like `application/x-wp-media-
  * attachment` can be stripped during the cross-frame hop, depending on
  * the browser. This bridge is the authoritative channel for the full
- * attachment payload: source iframes postMessage us when a drag starts,
- * we hold the payload in memory, and any receiver iframe can request it
- * back via postMessage during its own `drop` handler.
+ * payload: source iframes postMessage us when a drag starts, the shell
+ * can also push a payload in-process when a DragManager session begins
+ * over a shell-rendered tile (My WordPress, desktop shortcut), and any
+ * receiver iframe can read it back via `desktop-mode-drag-over` /
+ * `desktop-mode-drop` messages routed by the shell, or pull it on
+ * demand via `desktop-mode-drag-payload-request`.
  *
  * Architecture:
  *
- *   Source iframe (Media Library)
- *     │  window.parent.postMessage( desktop-mode-drag-start, payload )
+ *   Shell-rendered drag source (My WordPress tile)
+ *     │  dragManager fires `desktop-mode.drag.start`
+ *     │  desktop.ts bridges that into `bridge.start(payload)`
  *     ▼
  *   Parent shell (this module)
  *     │  stores `currentPayload`
- *     │  dispatches `desktop-mode.drag.start` / `.end` CustomEvents on
- *     │  document so other shell modules can react (highlight drop
- *     │  zones, dim non-target windows, etc.)
+ *     │  dispatches `desktop-mode-cross-frame-drag-start` /
+ *     │  `-end` CustomEvents on document so other shell modules
+ *     │  can react (highlight drop zones, dim non-target windows).
+ *     │  When the pointer enters an iframe drop target, the shell
+ *     │  postMessages `desktop-mode-drag-over` into that iframe.
+ *     │  On pointerup over an iframe, postMessages `desktop-mode-drop`.
  *     ▲
- *     │  any iframe can postMessage:
- *     │    desktop-mode-drag-payload-request → we reply with the payload
+ *     │  source iframe (Media Library) can ALSO drive the bridge
+ *     │  via `window.parent.postMessage(desktop-mode-drag-start, ...)`.
  *     ▼
- *   Receiver iframe (e.g. post editor)
- *     uses the payload in its drop handler to insert the media.
+ *   Receiver iframe (Gutenberg post editor)
+ *     listens for `desktop-mode-drop`, inserts the appropriate block.
  *
- * This module is intentionally minimal — it does NOT render a ghost or
- * draw drop indicators. Those are future iterations. The foundation
- * here is the payload plumbing plus the shell-level events so other
- * modules can layer visual polish on top without duplicating the
- * source-of-truth.
+ * Payload type is a discriminated union keyed on `kind`. The receiver
+ * switches on `kind` to decide what block to create.
  *
  * @since 0.14.0
  */
 
-export interface DragPayload {
+/**
+ * Attachment payload — media item dragged from a media surface
+ * (My WordPress media view, future Media Library iframe).
+ */
+export interface AttachmentDragPayload {
+	kind: 'attachment';
 	id: number;
+	/** Full-size file URL. */
 	url: string;
 	title: string;
 	alt: string;
+	/** `image/png`, `video/mp4`, `audio/mpeg`, application MIME, etc. */
 	mime: string;
 	thumbnailUrl?: string;
-	sizes?: Record<string, unknown>;
+	sizes?: Record< string, unknown >;
 }
+
+/**
+ * Post / page / CPT payload — dragged from a post-type list tile
+ * (My WordPress posts/pages view).
+ */
+export interface PostDragPayload {
+	kind: 'post';
+	id: number;
+	/** `'post'`, `'page'`, or any CPT slug. */
+	postType: string;
+	/** Permalink (frontend URL). Receivers use this for the anchor href. */
+	url: string;
+	title: string;
+}
+
+/**
+ * User payload — dragged from a user tile (My WordPress users view).
+ * Receivers turn this into an anchor pointing at the author archive.
+ */
+export interface UserDragPayload {
+	kind: 'user';
+	id: number;
+	/** Author archive URL (or profile URL fallback). */
+	url: string;
+	title: string;
+}
+
+/** Discriminated union of all bridge payload shapes. */
+export type DragBridgePayload =
+	| AttachmentDragPayload
+	| PostDragPayload
+	| UserDragPayload;
 
 /** Public surface — mounted on `wp.desktop.dragBridge`. */
 export interface DragBridgeApi {
 	/** Current payload while a cross-frame drag is in flight, or null. */
-	getPayload(): DragPayload | null;
+	getPayload(): DragBridgePayload | null;
 	/** True when a cross-frame drag is in progress. */
 	isDragging(): boolean;
+	/**
+	 * Start a bridge session from in-process (the shell). Used when a
+	 * DragManager pointer session begins over a shell-rendered tile —
+	 * fanning the payload here lets iframe receivers participate via
+	 * the same message protocol used by iframe-source drags.
+	 *
+	 * Idempotent: calling `start` while a session is active overwrites
+	 * the payload. Calling it with the same identity payload is a
+	 * no-op.
+	 */
+	start( payload: DragBridgePayload ): void;
+	/** End the current session. Idempotent. */
+	end(): void;
 }
 
 /** Event names we dispatch on `document`. */
@@ -66,7 +122,7 @@ export const DRAG_BRIDGE_EVENTS = {
 
 interface StartMsg {
 	type: 'desktop-mode-drag-start';
-	payload: DragPayload;
+	payload: DragBridgePayload;
 }
 interface EndMsg {
 	type: 'desktop-mode-drag-end';
@@ -95,7 +151,7 @@ function isPayloadRequest( m: unknown ): m is PayloadRequestMsg {
 // -----------------------------------------------------------------------
 
 export class DragBridge implements DragBridgeApi {
-	private _payload: DragPayload | null = null;
+	private _payload: DragBridgePayload | null = null;
 	/** Snapshot of the origin at boot so later mutations can't widen trust. */
 	private readonly _origin: string;
 
@@ -104,12 +160,23 @@ export class DragBridge implements DragBridgeApi {
 		window.addEventListener( 'message', this._onMessage );
 	}
 
-	getPayload(): DragPayload | null {
+	getPayload(): DragBridgePayload | null {
 		return this._payload;
 	}
 
 	isDragging(): boolean {
 		return this._payload !== null;
+	}
+
+	start( payload: DragBridgePayload ): void {
+		if ( this._payload === payload ) {
+			return;
+		}
+		this._startDrag( payload );
+	}
+
+	end(): void {
+		this._endDrag();
 	}
 
 	// -----------------------------------------------------------
@@ -129,7 +196,7 @@ export class DragBridge implements DragBridgeApi {
 		const msg = e.data as InboundMsg | unknown;
 
 		if ( isStart( msg ) ) {
-			this._startDrag( msg.payload, e.source ?? null );
+			this._startDrag( msg.payload );
 			return;
 		}
 		if ( isEnd( msg ) ) {
@@ -151,7 +218,7 @@ export class DragBridge implements DragBridgeApi {
 		}
 	};
 
-	private _startDrag( payload: DragPayload, _source: MessageEventSource | null ): void {
+	private _startDrag( payload: DragBridgePayload ): void {
 		this._payload = payload;
 		document.dispatchEvent(
 			new CustomEvent( DRAG_BRIDGE_EVENTS.START, { detail: { payload } } ),

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -1,0 +1,332 @@
+/**
+ * Desktop Mode — Iframe-window drop targets.
+ *
+ * Cross-iframe pointer routing for shell-side shortcut drags. The
+ * problem: when a DragManager session runs in the parent shell and
+ * the cursor moves over an iframe-window's iframe, the iframe's
+ * `pointer-events: auto` (default) captures the move and the
+ * parent's `pointermove` handler stops firing — the ghost "freezes"
+ * at the iframe boundary.
+ *
+ * The fix has to be bulletproof across browsers and stacking
+ * variations, so it's driven entirely from JavaScript via the
+ * DragManager lifecycle events (no CSS rules to cache, no overlay
+ * stacking-context puzzles):
+ *
+ *   - On `DRAG_EVENTS.START` with a `'shortcut'` payload that
+ *     carries a `bridgePayload`:
+ *       1. Walk every `iframe.desktop-mode-window__iframe` in the
+ *          document, save its current inline `pointer-events`, and
+ *          set it to `'none'`. The iframe stops capturing pointer
+ *          events. The browser routes the move to whatever is
+ *          behind it — typically the iframe's parent
+ *          (`.desktop-mode-window__body`).
+ *       2. Register that parent as a drop target via the
+ *          DragManager. `elementFromPoint` returns the parent, the
+ *          registry's deepest-ancestor walk finds the registered
+ *          target, and `onEnter` / `onDrop` post the cross-window
+ *          message into the iframe.
+ *
+ *   - On `DRAG_EVENTS.END`:
+ *       1. Restore every iframe's `pointer-events` to its prior
+ *          value.
+ *       2. Deregister the drop targets.
+ *
+ * Why this design beats the previous overlay-based attempt:
+ *
+ *   - The overlay required body attributes to flip in time AND its
+ *     CSS rule to be applied AND the overlay to be appended to the
+ *     right element AND the overlay's stacking context to win
+ *     against the iframe — any one breaking left the ghost stuck.
+ *   - Driving the iframe's `pointer-events` from JS at the START
+ *     event is a single observable side effect (visible in
+ *     DevTools' inline styles) with no caching or specificity
+ *     surface.
+ *
+ * @since 0.22.0
+ */
+
+import { addAction, HOOKS } from '../hooks';
+import {
+	DRAG_EVENTS,
+	type DragManagerApi,
+	type DragSession,
+} from './types';
+import type {
+	DesktopFileDragData,
+	ShortcutDragData,
+} from '../desktop-files/drag-payloads';
+import type { DragBridgePayload } from '../drag-bridge';
+
+const TARGET_ID_PREFIX = 'desktop-mode-iframe-drop-';
+const IFRAME_SELECTOR = 'iframe.desktop-mode-window__iframe';
+const DROP_ACTIVE_ATTR = 'data-desktop-mode-iframe-drop-active';
+
+let _installed = false;
+let _dragManager: DragManagerApi | null = null;
+
+type DeregisterFn = () => void;
+
+/** Snapshot of iframe inline `pointerEvents` values during a drag. */
+const _suppressedIframes = new Map< HTMLIFrameElement, string >();
+/** Registered drop-target deregister fns during a drag, keyed by iframe. */
+const _activeRegistrations = new Map< HTMLIFrameElement, DeregisterFn >();
+
+/**
+ * Extract the cross-frame `bridgePayload` from a DragManager payload
+ * regardless of payload type. Both `'shortcut'` (fresh tile from My
+ * WordPress) and `'desktop-file'` (existing wallpaper placement) data
+ * shapes optionally carry the same `bridgePayload` field. Returns
+ * `undefined` when the payload either isn't a known shape or doesn't
+ * carry a bridge payload.
+ */
+function extractBridgePayload(
+	payload: unknown,
+): DragBridgePayload | undefined {
+	if ( ! payload || typeof payload !== 'object' ) {
+		return undefined;
+	}
+	const obj = payload as { type?: unknown; data?: unknown };
+	if ( obj.type !== 'shortcut' && obj.type !== 'desktop-file' ) {
+		return undefined;
+	}
+	const data = obj.data as
+		| ShortcutDragData
+		| DesktopFileDragData
+		| undefined;
+	return data?.bridgePayload;
+}
+
+function postIntoIframe(
+	iframe: HTMLIFrameElement,
+	msg: unknown,
+): void {
+	const w = iframe.contentWindow;
+	if ( ! w ) {
+		return;
+	}
+	try {
+		w.postMessage( msg, window.location.origin );
+	} catch {
+		// Cross-origin or detached frame — no receiver to talk to.
+	}
+}
+
+function registerDropTargetFor(
+	dragManager: DragManagerApi,
+	iframe: HTMLIFrameElement,
+	target: HTMLElement,
+	windowId: string,
+): () => void {
+	return dragManager.registerDropTarget( {
+		id: `${ TARGET_ID_PREFIX }${ windowId }`,
+		element: target,
+		accept: ( payload ) => !! extractBridgePayload( payload ),
+		onEnter: ( session: DragSession ) => {
+			const bridge = extractBridgePayload( session.payload );
+			if ( ! bridge ) {
+				return;
+			}
+			target.setAttribute( DROP_ACTIVE_ATTR, '' );
+			postIntoIframe( iframe, {
+				type: 'desktop-mode-drag-over',
+				payload: bridge,
+			} );
+		},
+		onLeave: () => {
+			target.removeAttribute( DROP_ACTIVE_ATTR );
+			postIntoIframe( iframe, { type: 'desktop-mode-drag-leave' } );
+		},
+		onDrop: ( session, ev ) => {
+			target.removeAttribute( DROP_ACTIVE_ATTR );
+			const bridge = extractBridgePayload( session.payload );
+			if ( ! bridge ) {
+				return;
+			}
+			const rect = iframe.getBoundingClientRect();
+			postIntoIframe( iframe, {
+				type: 'desktop-mode-drop',
+				payload: bridge,
+				position: {
+					x: ev.clientX - rect.left,
+					y: ev.clientY - rect.top,
+				},
+			} );
+		},
+	} );
+}
+
+function deriveWindowIdFromIframe( iframe: HTMLIFrameElement ): string {
+	// Each iframe-window stamps its outer root with `id="wp-window-<id>"`.
+	// Walk up to find that root so the drop target's id is stable +
+	// debuggable.
+	let cur: HTMLElement | null = iframe.parentElement;
+	while ( cur ) {
+		if ( cur.id.startsWith( 'wp-window-' ) ) {
+			return cur.id.slice( 'wp-window-'.length );
+		}
+		cur = cur.parentElement;
+	}
+	// Fallback — unique-enough id so the registry doesn't collide.
+	return `unknown-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
+}
+
+function onDragStart( payload: unknown ): void {
+	const dragManager = _dragManager;
+	if ( ! dragManager ) {
+		return;
+	}
+	// Always suppress iframe pointer-events for the duration of ANY
+	// drag — including desktop-file repositions and plugin payloads
+	// that don't carry a `bridgePayload`. This is the only way the
+	// ghost can track the cursor across iframe boundaries; without it
+	// the iframe captures the move and the ghost freezes the moment
+	// the cursor crosses the edge. The drop side still gates on
+	// payload kind via the registered DropTarget's `accept()`.
+	const iframes = document.querySelectorAll< HTMLIFrameElement >( IFRAME_SELECTOR );
+	const isBridgeable = !! extractBridgePayload( payload );
+	// Diagnostic — visible in DevTools console at every drag start.
+	// Helps narrow down which side of the wiring is breaking when a
+	// regression bubbles up. Cheap (one log per drag, no inner loop
+	// noise) so it's fine to leave in shipped code.
+	// eslint-disable-next-line no-console
+	console.log(
+		'[desktop-mode] drag-start: suppressing %d iframe(s); bridgeable=%s',
+		iframes.length,
+		isBridgeable,
+		payload,
+	);
+	iframes.forEach( ( iframe ) => {
+		if ( _suppressedIframes.has( iframe ) ) {
+			return;
+		}
+		// Snapshot inline pointerEvents so we can restore it on END.
+		// Empty string means "no inline override — use stylesheet".
+		_suppressedIframes.set( iframe, iframe.style.pointerEvents );
+		iframe.style.pointerEvents = 'none';
+
+		// Only register a drop target when the payload is one we know
+		// how to deliver into the iframe (`bridgePayload` present).
+		// For other drag types the suppression alone is enough to
+		// keep the ghost tracking — `elementFromPoint` returns the
+		// iframe's parent body div, which the registry's deepest-
+		// ancestor walk fails to match and the ghost stays in reject
+		// mode (correct UX — the iframe window doesn't want this
+		// payload type).
+		if ( ! isBridgeable ) {
+			return;
+		}
+		const dropTargetEl = iframe.parentElement;
+		if ( ! dropTargetEl ) {
+			return;
+		}
+		const windowId = deriveWindowIdFromIframe( iframe );
+		const deregister = registerDropTargetFor(
+			dragManager,
+			iframe,
+			dropTargetEl,
+			windowId,
+		);
+		_activeRegistrations.set( iframe, deregister );
+	} );
+}
+
+function onDragEnd(): void {
+	_suppressedIframes.forEach( ( prev, iframe ) => {
+		iframe.style.pointerEvents = prev;
+	} );
+	_suppressedIframes.clear();
+	_activeRegistrations.forEach( ( deregister ) => {
+		try {
+			deregister();
+		} catch {
+			// Registry already cleaned up; ignore.
+		}
+	} );
+	_activeRegistrations.clear();
+}
+
+/**
+ * Install the cross-window iframe drop-target machinery. Idempotent.
+ * Bind ONCE at shell boot; the rest is driven by drag events.
+ *
+ * Also exposes `window.__desktopModeIframeDropDebug` returning the
+ * live state of the registration map, so users hitting a regression
+ * can paste that into DevTools and report exactly which side of the
+ * wiring is broken.
+ *
+ * @public
+ * @since 0.22.0
+ */
+export function installIframeDropTargets( dragManager: DragManagerApi ): void {
+	if ( _installed ) {
+		return;
+	}
+	_installed = true;
+	_dragManager = dragManager;
+
+	document.addEventListener( DRAG_EVENTS.START, ( e ) => {
+		const detail = ( e as CustomEvent ).detail as
+			| { payload?: unknown }
+			| undefined;
+		onDragStart( detail?.payload );
+	} );
+	document.addEventListener( DRAG_EVENTS.END, () => {
+		onDragEnd();
+	} );
+
+	// On WINDOW_CLOSED we don't need to do anything special — if the
+	// drag is in flight when a window closes, the closing window's
+	// iframe is gone from the DOM and the registry's element-keyed
+	// store silently drops the orphan reference. The deregister fn we
+	// stored becomes a harmless no-op.
+	addAction(
+		HOOKS.WINDOW_CLOSED,
+		'desktop-mode/drag/iframe-drop-targets-window-close',
+		() => {
+			// Re-walk to drop any iframes that disappeared from the
+			// DOM mid-drag.
+			_suppressedIframes.forEach( ( _prev, iframe ) => {
+				if ( ! iframe.isConnected ) {
+					_suppressedIframes.delete( iframe );
+				}
+			} );
+			_activeRegistrations.forEach( ( deregister, iframe ) => {
+				if ( ! iframe.isConnected ) {
+					try {
+						deregister();
+					} catch {
+						// already cleaned up
+					}
+					_activeRegistrations.delete( iframe );
+				}
+			} );
+		},
+	);
+
+	type DesktopModeIframeDropDebugWindow = Window & {
+		__desktopModeIframeDropDebug?: () => {
+			installed: boolean;
+			iframesInDom: number;
+			suppressedCount: number;
+			registeredCount: number;
+			suppressedIframeIds: string[];
+		};
+	};
+	( window as DesktopModeIframeDropDebugWindow ).__desktopModeIframeDropDebug = () => ( {
+		installed: _installed,
+		iframesInDom: document.querySelectorAll( IFRAME_SELECTOR ).length,
+		suppressedCount: _suppressedIframes.size,
+		registeredCount: _activeRegistrations.size,
+		suppressedIframeIds: Array.from( _suppressedIframes.keys() ).map(
+			deriveWindowIdFromIframe,
+		),
+	} );
+}
+
+/** Test-only. Drops the install latch + clears any in-flight state. */
+export function __resetIframeDropTargetsForTests(): void {
+	onDragEnd();
+	_installed = false;
+	_dragManager = null;
+}

--- a/src/gutenberg-drop-receiver.ts
+++ b/src/gutenberg-drop-receiver.ts
@@ -1,0 +1,281 @@
+/**
+ * Desktop Mode — Gutenberg drop receiver (iframe-side bundle).
+ *
+ * Loaded only inside `post.php` / `post-new.php` chromeless iframes
+ * (PHP enqueue keyed on `current_screen()->base`). Listens for
+ * `desktop-mode-drop` postMessages from the parent shell —
+ * dispatched by `src/drag/iframe-drop-targets.ts` when the user
+ * releases a shell-side drag (My WordPress media / post / user tile)
+ * over a Gutenberg window's drop overlay.
+ *
+ * The receiver maps the bridge payload's `kind` (+ media `mime`) to
+ * a Gutenberg block and inserts it via the Block Editor's data store:
+ *
+ *   - `attachment` `image/*`  → `core/image`
+ *   - `attachment` `video/*`  → `core/video`
+ *   - `attachment` `audio/*`  → `core/audio`
+ *   - `attachment` other      → `core/file`
+ *   - `post` / `user`         → `core/paragraph` with `<a href>title</a>`
+ *
+ * The block factory + dispatch are pure functions of the payload —
+ * unit-tested in `gutenberg-drop-receiver.test.ts` against synthetic
+ * `wp.blocks` / `wp.data` shims. The bundle itself never touches the
+ * DOM; insertion happens entirely through Gutenberg's store.
+ *
+ * Origin trust: messages whose `e.origin !== window.location.origin`
+ * are dropped. Same-origin admin scripts can still forge messages,
+ * but the browser's same-origin boundary is the real defence.
+ *
+ * @since 0.22.0
+ */
+
+// ---------------------------------------------------------------------
+// Payload shapes — mirror the discriminated union in `src/drag-bridge.ts`.
+// Duplicated here (instead of imported) because this is a standalone
+// iframe-side bundle with no shell dependencies.
+// ---------------------------------------------------------------------
+
+interface AttachmentDragPayload {
+	kind: 'attachment';
+	id: number;
+	url: string;
+	title: string;
+	alt: string;
+	mime: string;
+	thumbnailUrl?: string;
+	sizes?: Record< string, unknown >;
+}
+
+interface PostDragPayload {
+	kind: 'post';
+	id: number;
+	postType: string;
+	url: string;
+	title: string;
+}
+
+interface UserDragPayload {
+	kind: 'user';
+	id: number;
+	url: string;
+	title: string;
+}
+
+type DragBridgePayload =
+	| AttachmentDragPayload
+	| PostDragPayload
+	| UserDragPayload;
+
+interface DropMsg {
+	type: 'desktop-mode-drop';
+	payload: DragBridgePayload;
+	position?: { x: number; y: number };
+}
+
+// ---------------------------------------------------------------------
+// Block factory — pure. Tested via vitest.
+// ---------------------------------------------------------------------
+
+interface BlockSpec {
+	/** Block slug (`core/image`, `core/paragraph`, …). */
+	name: string;
+	/** Block attributes. */
+	attributes: Record< string, unknown >;
+}
+
+/**
+ * Escape a string for inclusion in HTML attributes / text. Used when
+ * constructing `<a>` markup for post/user payloads. Same allowlist
+ * `wp_specialchars()` covers.
+ */
+function escapeHtml( s: string ): string {
+	return s
+		.replace( /&/g, '&amp;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' )
+		.replace( /"/g, '&quot;' )
+		.replace( /'/g, '&#039;' );
+}
+
+/**
+ * Build a Gutenberg block spec for the given payload. Returns `null`
+ * for empty post/user URLs (the receiver no-ops in that case rather
+ * than inserting a dead `<a href="">`).
+ *
+ * @public
+ */
+export function buildBlockSpec(
+	payload: DragBridgePayload,
+): BlockSpec | null {
+	if ( payload.kind === 'attachment' ) {
+		const mime = payload.mime || '';
+		if ( mime.startsWith( 'image/' ) ) {
+			return {
+				name: 'core/image',
+				attributes: {
+					id: payload.id,
+					url: payload.url,
+					alt: payload.alt || '',
+					caption: '',
+				},
+			};
+		}
+		if ( mime.startsWith( 'video/' ) ) {
+			return {
+				name: 'core/video',
+				attributes: {
+					id: payload.id,
+					src: payload.url,
+				},
+			};
+		}
+		if ( mime.startsWith( 'audio/' ) ) {
+			return {
+				name: 'core/audio',
+				attributes: {
+					id: payload.id,
+					src: payload.url,
+				},
+			};
+		}
+		return {
+			name: 'core/file',
+			attributes: {
+				id: payload.id,
+				href: payload.url,
+				fileName: payload.title,
+			},
+		};
+	}
+	// `post` and `user` both render as a paragraph wrapping an
+	// anchor. Skip when the bridge couldn't resolve a URL — empty
+	// hrefs aren't useful and the drop should snap back instead of
+	// silently inserting a dead link.
+	if ( ! payload.url ) {
+		return null;
+	}
+	const safeTitle = escapeHtml( payload.title || payload.url );
+	const safeHref = escapeHtml( payload.url );
+	return {
+		name: 'core/paragraph',
+		attributes: {
+			content: `<a href="${ safeHref }">${ safeTitle }</a>`,
+		},
+	};
+}
+
+// ---------------------------------------------------------------------
+// Gutenberg integration — minimally typed shim.
+// ---------------------------------------------------------------------
+
+interface WpBlocks {
+	createBlock( name: string, attributes?: Record< string, unknown > ): unknown;
+}
+
+interface WpDataDispatch {
+	insertBlocks( blocks: unknown[] ): void;
+}
+
+interface WpDataSelect {
+	getBlockCount(): number;
+}
+
+interface WpData {
+	dispatch( store: 'core/block-editor' ): WpDataDispatch;
+	select( store: 'core/block-editor' ): WpDataSelect;
+}
+
+interface WpGlobal {
+	blocks?: WpBlocks;
+	data?: WpData;
+	domReady?: ( cb: () => void ) => void;
+}
+
+declare const window: Window & { wp?: WpGlobal };
+
+/**
+ * Resolve `wp.blocks` + `wp.data` once they're both available. Polls
+ * with `requestAnimationFrame` instead of `wp.domReady` because the
+ * editor stores can boot AFTER DOMContentLoaded in some flows (e.g.
+ * `post-new.php?post_type=page` with a slow REST preload).
+ *
+ * Gives up after ~5s (300 rAF ticks at 60Hz) and rejects so the drop
+ * surfaces an error in the console rather than hanging forever.
+ */
+async function waitForEditor(): Promise< {
+	blocks: WpBlocks;
+	data: WpData;
+} > {
+	return new Promise( ( resolve, reject ) => {
+		let ticks = 0;
+		const MAX_TICKS = 300;
+		const tick = (): void => {
+			const wp = window.wp;
+			if ( wp?.blocks && wp.data ) {
+				resolve( { blocks: wp.blocks, data: wp.data } );
+				return;
+			}
+			ticks++;
+			if ( ticks > MAX_TICKS ) {
+				reject(
+					new Error(
+						'desktop-mode/gutenberg-drop-receiver: timed out waiting for wp.blocks + wp.data',
+					),
+				);
+				return;
+			}
+			requestAnimationFrame( tick );
+		};
+		tick();
+	} );
+}
+
+async function performInsert( payload: DragBridgePayload ): Promise< void > {
+	const spec = buildBlockSpec( payload );
+	if ( ! spec ) {
+		return;
+	}
+	const { blocks, data } = await waitForEditor();
+	const block = blocks.createBlock( spec.name, spec.attributes );
+	data.dispatch( 'core/block-editor' ).insertBlocks( [ block ] );
+}
+
+// ---------------------------------------------------------------------
+// Message wiring.
+// ---------------------------------------------------------------------
+
+function isDropMsg( m: unknown ): m is DropMsg {
+	if ( ! m || typeof m !== 'object' ) {
+		return false;
+	}
+	const obj = m as { type?: unknown; payload?: unknown };
+	if ( obj.type !== 'desktop-mode-drop' ) {
+		return false;
+	}
+	const p = obj.payload as { kind?: unknown } | undefined;
+	if ( ! p || typeof p !== 'object' ) {
+		return false;
+	}
+	return p.kind === 'attachment' || p.kind === 'post' || p.kind === 'user';
+}
+
+function install(): void {
+	const expectedOrigin = window.location.origin;
+	window.addEventListener( 'message', ( e: MessageEvent ) => {
+		if ( e.origin !== expectedOrigin ) {
+			return;
+		}
+		if ( ! isDropMsg( e.data ) ) {
+			return;
+		}
+		void performInsert( e.data.payload ).catch( ( err ) => {
+			// eslint-disable-next-line no-console
+			console.error(
+				'[desktop-mode] Gutenberg drop receiver insert failed:',
+				err,
+			);
+		} );
+	} );
+}
+
+install();

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -988,6 +988,18 @@ function buildEntityTile(
 			ref: String( item.id ),
 			title: titleText,
 			icon: entity.icon,
+			// Cross-frame bridge payload — the Gutenberg drop-receiver
+			// turns this into a `core/paragraph` with an `<a href>` to
+			// the permalink. Tiles without a `link` (very old REST
+			// shapes / private posts) still drag-out for placement
+			// purposes; the receiver no-ops on an empty url.
+			bridgePayload: {
+				kind: 'post',
+				id: item.id,
+				postType: entity.id,
+				url: item.link ?? '',
+				title: titleText,
+			},
 		},
 		() => hideTooltip(),
 	);
@@ -3745,6 +3757,17 @@ function buildUserTile(
 			ref: String( item.id ),
 			title: displayName,
 			icon: 'dashicons-admin-users',
+			// Cross-frame bridge payload — receiver inserts a
+			// `core/paragraph` with `<a href>` pointing at the
+			// author archive (`item.link`). Falls back to empty
+			// string when the REST shape omitted the link; the
+			// receiver gates on a truthy URL.
+			bridgePayload: {
+				kind: 'user',
+				id: item.id,
+				url: item.link ?? '',
+				title: displayName,
+			},
 		},
 		() => hideTooltip(),
 	);

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -138,6 +138,22 @@ function buildMediaTile(
 		ref: String( media.id ),
 		title: titleText,
 		icon: dashiconForMime( media.mime_type ),
+		// Cross-frame bridge payload — lets the Gutenberg drop-
+		// receiver build a `core/image` / `core/video` / `core/audio`
+		// / `core/file` block when this tile is dropped on an open
+		// editor iframe. The full-size source URL is the right block
+		// attribute regardless of mime; the receiver picks the
+		// concrete block from the MIME prefix.
+		bridgePayload: {
+			kind: 'attachment',
+			id: media.id,
+			url: media.source_url,
+			title: titleText,
+			alt: stripTags( media.alt_text ?? '' ),
+			mime: media.mime_type,
+			thumbnailUrl: thumbUrl || undefined,
+			sizes: media.media_details?.sizes,
+		},
 	} );
 
 	tile.addEventListener( 'click', () => selectTile( ctx, tile, media ) );

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -154,6 +154,17 @@ export type {
 } from './drag';
 export { DRAG_EVENTS, DRAG_THRESHOLD_PX } from './drag';
 
+// ----- Cross-iframe drag bridge -----
+
+export type {
+	AttachmentDragPayload,
+	DragBridgeApi,
+	DragBridgePayload,
+	PostDragPayload,
+	UserDragPayload,
+} from './drag-bridge';
+export { DRAG_BRIDGE_EVENTS } from './drag-bridge';
+
 // ----- DevTools / cross-plugin instrumentation -----
 
 export type {

--- a/tests/vitest/gutenberg-drop-receiver.test.ts
+++ b/tests/vitest/gutenberg-drop-receiver.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the Gutenberg drop-receiver's payload → block
+ * mapping. The receiver itself is a side-effect bundle that listens
+ * on `window.message`, but the block-spec factory is a pure function
+ * exported for test access.
+ */
+import { describe, expect, test } from 'vitest';
+import { buildBlockSpec } from '../../src/gutenberg-drop-receiver';
+
+describe( 'buildBlockSpec — attachment', () => {
+	test( 'maps an image attachment to core/image with id + url + alt', () => {
+		const spec = buildBlockSpec( {
+			kind: 'attachment',
+			id: 42,
+			url: 'https://example.test/wp-content/uploads/cat.png',
+			title: 'Cat',
+			alt: 'A grey cat',
+			mime: 'image/png',
+		} );
+		expect( spec ).toEqual( {
+			name: 'core/image',
+			attributes: {
+				id: 42,
+				url: 'https://example.test/wp-content/uploads/cat.png',
+				alt: 'A grey cat',
+				caption: '',
+			},
+		} );
+	} );
+
+	test( 'falls back to empty alt when source omitted it', () => {
+		const spec = buildBlockSpec( {
+			kind: 'attachment',
+			id: 7,
+			url: 'https://example.test/x.jpg',
+			title: 'X',
+			alt: '',
+			mime: 'image/jpeg',
+		} );
+		expect( spec?.attributes.alt ).toBe( '' );
+	} );
+
+	test( 'maps a video attachment to core/video', () => {
+		const spec = buildBlockSpec( {
+			kind: 'attachment',
+			id: 99,
+			url: 'https://example.test/clip.mp4',
+			title: 'Clip',
+			alt: '',
+			mime: 'video/mp4',
+		} );
+		expect( spec ).toEqual( {
+			name: 'core/video',
+			attributes: { id: 99, src: 'https://example.test/clip.mp4' },
+		} );
+	} );
+
+	test( 'maps an audio attachment to core/audio', () => {
+		const spec = buildBlockSpec( {
+			kind: 'attachment',
+			id: 100,
+			url: 'https://example.test/song.mp3',
+			title: 'Song',
+			alt: '',
+			mime: 'audio/mpeg',
+		} );
+		expect( spec ).toEqual( {
+			name: 'core/audio',
+			attributes: { id: 100, src: 'https://example.test/song.mp3' },
+		} );
+	} );
+
+	test( 'maps a generic file attachment to core/file', () => {
+		const spec = buildBlockSpec( {
+			kind: 'attachment',
+			id: 200,
+			url: 'https://example.test/doc.pdf',
+			title: 'doc.pdf',
+			alt: '',
+			mime: 'application/pdf',
+		} );
+		expect( spec ).toEqual( {
+			name: 'core/file',
+			attributes: {
+				id: 200,
+				href: 'https://example.test/doc.pdf',
+				fileName: 'doc.pdf',
+			},
+		} );
+	} );
+} );
+
+describe( 'buildBlockSpec — post / user', () => {
+	test( 'maps a post payload to a paragraph anchor', () => {
+		const spec = buildBlockSpec( {
+			kind: 'post',
+			id: 5,
+			postType: 'post',
+			url: 'https://example.test/hello-world/',
+			title: 'Hello World',
+		} );
+		expect( spec ).toEqual( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'<a href="https://example.test/hello-world/">Hello World</a>',
+			},
+		} );
+	} );
+
+	test( 'maps a user payload to a paragraph anchor', () => {
+		const spec = buildBlockSpec( {
+			kind: 'user',
+			id: 1,
+			url: 'https://example.test/author/admin/',
+			title: 'Admin',
+		} );
+		expect( spec ).toEqual( {
+			name: 'core/paragraph',
+			attributes: {
+				content: '<a href="https://example.test/author/admin/">Admin</a>',
+			},
+		} );
+	} );
+
+	test( 'escapes HTML in title + href to neutralize hostile content', () => {
+		const spec = buildBlockSpec( {
+			kind: 'post',
+			id: 9,
+			postType: 'post',
+			url: 'https://example.test/x?a=1&b=<script>',
+			title: 'Mean & "quoted" <script>',
+		} );
+		// All five sensitive chars must be escaped in BOTH href and text.
+		expect( spec?.attributes.content ).toBe(
+			'<a href="https://example.test/x?a=1&amp;b=&lt;script&gt;">Mean &amp; &quot;quoted&quot; &lt;script&gt;</a>',
+		);
+	} );
+
+	test( 'returns null when the post payload has no URL (silent no-op)', () => {
+		const spec = buildBlockSpec( {
+			kind: 'post',
+			id: 1,
+			postType: 'post',
+			url: '',
+			title: 'Untitled',
+		} );
+		expect( spec ).toBeNull();
+	} );
+
+	test( 'returns null when the user payload has no URL', () => {
+		const spec = buildBlockSpec( {
+			kind: 'user',
+			id: 1,
+			url: '',
+			title: 'Admin',
+		} );
+		expect( spec ).toBeNull();
+	} );
+
+	test( 'falls back to the URL as anchor text when title is empty', () => {
+		const spec = buildBlockSpec( {
+			kind: 'post',
+			id: 10,
+			postType: 'post',
+			url: 'https://example.test/post-10/',
+			title: '',
+		} );
+		expect( spec?.attributes.content ).toBe(
+			'<a href="https://example.test/post-10/">https://example.test/post-10/</a>',
+		);
+	} );
+} );

--- a/vite.config.js
+++ b/vite.config.js
@@ -281,6 +281,16 @@ const TARGETS = {
 		fileBase: 'iframe-bridge',
 		iifeName: 'desktopModeIframeBridge',
 	},
+	// Gutenberg drop-receiver — tiny iframe-side bundle enqueued only
+	// on post.php / post-new.php. Listens for `desktop-mode-drop`
+	// messages from the shell and inserts the corresponding block via
+	// `wp.data.dispatch('core/block-editor').insertBlocks(...)`. See
+	// `src/drag/iframe-drop-targets.ts` for the shell side.
+	'gutenberg-drop-receiver': {
+		entry:    'src/gutenberg-drop-receiver.ts',
+		fileBase: 'gutenberg-drop-receiver',
+		iifeName: 'desktopModeGutenbergDropReceiver',
+	},
 	// Recycle Bin app — a thin bundle that registers a render
 	// callback on `window.desktopModeNativeWindows['desktop-mode-recycle-bin']`
 	// and renders a `<wpd-table>` populated from the REST list. The


### PR DESCRIPTION
Now everything (almost everything) is drag and drop enabled. Including iframes as destinations.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-260-45e8d8b1ea58609a41427431f168b47f4c55fa6f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->