### PR TITLE
Drag-and-drop follow-up: review fixes

### DIFF
--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -45,19 +45,18 @@ function desktop_mode_enqueue_assets() {
 
 		// Block Editor cross-window drop receiver. Listens for
 		// `desktop-mode-drop` postMessages from the parent shell and
-		// inserts the matching block. Only enqueue inside the Block
-		// Editor screens — every other admin page would be paying for
-		// a bundle it never uses. `$hook_suffix` is supplied by the
-		// `admin_enqueue_scripts` action; `post.php` / `post-new.php`
-		// cover both edit + new-post flows. Gutenberg also drives
-		// `site-editor.php` (full-site editing) — included so dropping
-		// onto a template / template-part window also works.
+		// inserts the matching block. Only enqueue inside the
+		// post-edit Block Editor screens — every other admin page
+		// would be paying for a bundle it never uses.
+		//
+		// `site-editor.php` (full-site editor) deliberately omitted:
+		// the FSE doesn't expose `wp.data.dispatch('core/block-editor')`
+		// until the user opens a template in the canvas iframe, so
+		// drops arriving before that point would silently time out
+		// after the receiver's 5 s `waitForEditor()` poll. Re-enable
+		// once we have a reliable readiness signal in that context.
 		global $hook_suffix;
-		if (
-			'post.php' === $hook_suffix
-			|| 'post-new.php' === $hook_suffix
-			|| 'site-editor.php' === $hook_suffix
-		) {
+		if ( 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) {
 			wp_enqueue_script( 'desktop-mode-gutenberg-drop-receiver' );
 		}
 	}

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -43,6 +43,13 @@ import {
 import type { RestPlacementShape } from './rest';
 import type { FilesState } from './store';
 import type { DragBridgePayload } from '../drag-bridge';
+import { isConflict, showConflictToast } from './conflict-toast';
+import type { DragManagerApi, DragSession, DropTarget } from '../drag';
+import { trashFolderWithUndo, trashPlacementWithUndo } from './trash';
+import type {
+	DesktopFileDragData,
+	ShortcutDragData,
+} from './drag-payloads';
 
 /**
  * Build a cross-frame bridge payload from a placement, or return
@@ -101,13 +108,6 @@ function buildBridgePayloadFromPlacement(
 	}
 	return undefined;
 }
-import { isConflict, showConflictToast } from './conflict-toast';
-import type { DragManagerApi, DragSession, DropTarget } from '../drag';
-import { trashFolderWithUndo, trashPlacementWithUndo } from './trash';
-import type {
-	DesktopFileDragData,
-	ShortcutDragData,
-} from './drag-payloads';
 
 /**
  * Read the runtime DragManager. Boot order guarantees this exists by

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1819,6 +1819,24 @@ function init(): void {
 	// `desktop-mode-drop` postMessages. Idempotent.
 	installIframeDropTargets( dragManager );
 
+	// Surface a toast when an iframe receiver (Gutenberg drop-
+	// receiver today) reports a failed insert — most commonly a
+	// timeout waiting for `wp.data` in a window where the editor
+	// never finished booting. Without this the user would see no
+	// feedback and silently lose the drop.
+	window.addEventListener( 'message', ( e: MessageEvent ) => {
+		if ( e.origin !== window.location.origin ) {
+			return;
+		}
+		const data = e.data as { type?: unknown; reason?: unknown } | null;
+		if ( ! data || data.type !== 'desktop-mode-drop-failed' ) {
+			return;
+		}
+		showToast( {
+			message: 'Could not insert into the editor.',
+		} );
+	} );
+
 	// Register the AI Assistant as the first (default) Cmd+K palette
 	// and install the single global shortcut. Other plugins can register
 	// more palettes via wp.desktop.registerPalette and Cmd+K cycles

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -187,10 +187,9 @@ function onDragStart( payload: unknown ): void {
 	const isBridgeable = !! extractBridgePayload( payload );
 	// Diagnostic — visible in DevTools console at every drag start.
 	// Helps narrow down which side of the wiring is breaking when a
-	// regression bubbles up. Cheap (one log per drag, no inner loop
-	// noise) so it's fine to leave in shipped code.
-	// eslint-disable-next-line no-console
-	console.log(
+	// regression bubbles up. `console.info` is in the lint
+	// allowlist; `console.log` would need an inline disable.
+	console.info(
 		'[desktop-mode] drag-start: suppressing %d iframe(s); bridgeable=%s',
 		iframes.length,
 		isBridgeable,
@@ -285,13 +284,15 @@ export function installIframeDropTargets( dragManager: DragManagerApi ): void {
 		'desktop-mode/drag/iframe-drop-targets-window-close',
 		() => {
 			// Re-walk to drop any iframes that disappeared from the
-			// DOM mid-drag.
-			_suppressedIframes.forEach( ( _prev, iframe ) => {
+			// DOM mid-drag. Iterate over a snapshot — mutating the
+			// Map inside `forEach` is spec-safe but reads as a
+			// hazard at the call site.
+			for ( const [ iframe ] of Array.from( _suppressedIframes ) ) {
 				if ( ! iframe.isConnected ) {
 					_suppressedIframes.delete( iframe );
 				}
-			} );
-			_activeRegistrations.forEach( ( deregister, iframe ) => {
+			}
+			for ( const [ iframe, deregister ] of Array.from( _activeRegistrations ) ) {
 				if ( ! iframe.isConnected ) {
 					try {
 						deregister();
@@ -300,7 +301,7 @@ export function installIframeDropTargets( dragManager: DragManagerApi ): void {
 					}
 					_activeRegistrations.delete( iframe );
 				}
-			} );
+			}
 		},
 	);
 

--- a/src/gutenberg-drop-receiver.ts
+++ b/src/gutenberg-drop-receiver.ts
@@ -98,6 +98,27 @@ function escapeHtml( s: string ): string {
 }
 
 /**
+ * Reject `javascript:` and `data:` URLs before they land in an
+ * inserted anchor's href. The bridge's same-origin postMessage check
+ * is the first line of defence, but defence-in-depth here is cheap.
+ * Accepts http(s), absolute paths, hash + query fragments, and any
+ * other scheme that isn't on the deny list.
+ */
+function isSafeUrl( raw: string ): boolean {
+	const lower = raw.trimStart().toLowerCase();
+	if ( lower.startsWith( 'javascript:' ) ) {
+		return false;
+	}
+	if ( lower.startsWith( 'data:' ) ) {
+		return false;
+	}
+	if ( lower.startsWith( 'vbscript:' ) ) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Build a Gutenberg block spec for the given payload. Returns `null`
  * for empty post/user URLs (the receiver no-ops in that case rather
  * than inserting a dead `<a href="">`).
@@ -108,6 +129,13 @@ export function buildBlockSpec(
 	payload: DragBridgePayload,
 ): BlockSpec | null {
 	if ( payload.kind === 'attachment' ) {
+		// Attachment URLs feed `core/image[.url]` / `core/video[.src]`
+		// etc. as raw attributes, never as HTML — but a hostile
+		// `javascript:` URL surviving into a `core/file` href would
+		// still be a click-to-XSS. Reject up front.
+		if ( ! payload.url || ! isSafeUrl( payload.url ) ) {
+			return null;
+		}
 		const mime = payload.mime || '';
 		if ( mime.startsWith( 'image/' ) ) {
 			return {
@@ -150,8 +178,9 @@ export function buildBlockSpec(
 	// `post` and `user` both render as a paragraph wrapping an
 	// anchor. Skip when the bridge couldn't resolve a URL — empty
 	// hrefs aren't useful and the drop should snap back instead of
-	// silently inserting a dead link.
-	if ( ! payload.url ) {
+	// silently inserting a dead link. Same scheme gate as
+	// attachments: a `javascript:` URL would be a one-click XSS.
+	if ( ! payload.url || ! isSafeUrl( payload.url ) ) {
 		return null;
 	}
 	const safeTitle = escapeHtml( payload.title || payload.url );
@@ -240,6 +269,26 @@ async function performInsert( payload: DragBridgePayload ): Promise< void > {
 	data.dispatch( 'core/block-editor' ).insertBlocks( [ block ] );
 }
 
+/**
+ * Notify the parent shell that an insert failed (timeout, throw,
+ * unknown payload). The parent listens for this message and surfaces
+ * a toast — without it the user would see no feedback when the
+ * editor wasn't ready and silently swallow the drop.
+ */
+function notifyParentOfFailure( reason: string ): void {
+	if ( window.parent === window ) {
+		return;
+	}
+	try {
+		window.parent.postMessage(
+			{ type: 'desktop-mode-drop-failed', reason },
+			window.location.origin,
+		);
+	} catch {
+		// Cross-origin parent — nothing we can do.
+	}
+}
+
 // ---------------------------------------------------------------------
 // Message wiring.
 // ---------------------------------------------------------------------
@@ -268,12 +317,14 @@ function install(): void {
 		if ( ! isDropMsg( e.data ) ) {
 			return;
 		}
-		void performInsert( e.data.payload ).catch( ( err ) => {
+		void performInsert( e.data.payload ).catch( ( err: unknown ) => {
+			const reason = err instanceof Error ? err.message : String( err );
 			// eslint-disable-next-line no-console
 			console.error(
 				'[desktop-mode] Gutenberg drop receiver insert failed:',
 				err,
 			);
+			notifyParentOfFailure( reason );
 		} );
 	} );
 }

--- a/tests/vitest/gutenberg-drop-receiver.test.ts
+++ b/tests/vitest/gutenberg-drop-receiver.test.ts
@@ -158,6 +158,40 @@ describe( 'buildBlockSpec — post / user', () => {
 		expect( spec ).toBeNull();
 	} );
 
+	test( 'rejects javascript: URL on a post payload (XSS gate)', () => {
+		const spec = buildBlockSpec( {
+			kind: 'post',
+			id: 1,
+			postType: 'post',
+			// eslint-disable-next-line no-script-url
+			url: 'javascript:alert(1)',
+			title: 'Bad',
+		} );
+		expect( spec ).toBeNull();
+	} );
+
+	test( 'rejects javascript: URL with leading whitespace + uppercase', () => {
+		const spec = buildBlockSpec( {
+			kind: 'user',
+			id: 1,
+			url: '  JavaScript:alert(1)',
+			title: 'Bad',
+		} );
+		expect( spec ).toBeNull();
+	} );
+
+	test( 'rejects data: URL on an attachment payload', () => {
+		const spec = buildBlockSpec( {
+			kind: 'attachment',
+			id: 1,
+			url: 'data:text/html,<script>alert(1)</script>',
+			title: 'Bad',
+			alt: '',
+			mime: 'text/html',
+		} );
+		expect( spec ).toBeNull();
+	} );
+
 	test( 'falls back to the URL as anchor text when title is empty', () => {
 		const spec = buildBlockSpec( {
 			kind: 'post',


### PR DESCRIPTION
## Summary

Follow-up to #260 (Drag and drop improvements). Five code-review items from a post-merge audit:

1. **`console.log` → `console.info`** in `src/drag/iframe-drop-targets.ts`. `no-console` ESLint config allows `info`/`warn`/`error` only; this drops the inline `eslint-disable` and uses the more semantically accurate level for the drag-start diagnostic.

2. **Mid-file imports in `src/desktop-files/layer.ts`**. `buildBridgePayloadFromPlacement` had been inserted between two groups of imports, which would have tripped `import/first`. Moved the function below all imports.

3. **Block `javascript:` / `data:` / `vbscript:` URLs in the Gutenberg drop-receiver** (`src/gutenberg-drop-receiver.ts`). Same-origin postMessage is the first line of defence; this is defence-in-depth so a hostile URL surviving into a `core/file` href or `core/paragraph` anchor can't become click-to-XSS. Returns `null` (silent no-op) for hostile URLs — same shape as "empty URL → no insert".

4. **Drop `site-editor.php` enqueue** in `includes/render/assets.php`. The FSE's `core/block-editor` store isn't reliably available without an opened template in the canvas, so drops would silently time out at the receiver's 5 s `waitForEditor` poll. Also added a `desktop-mode-drop-failed` postMessage from the receiver → parent toast pipeline so any future "editor not ready" failure surfaces as user-visible feedback instead of just a `console.error`.

5. **`Map` mutation during `forEach`** in the `WINDOW_CLOSED` cleanup of `iframe-drop-targets.ts`. Spec-safe but reads as a hazard; switched to `for…of` over `Array.from()` snapshots for both `_suppressedIframes` and `_activeRegistrations`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test:js` — 1485 passing (3 new vitests cover `javascript:` / `data:` URL rejection across post / user / attachment payloads, plus the leading-whitespace + uppercase variants)
- [x] `npm run build:desktop` + `npm run build:gutenberg-drop-receiver` — clean
- [ ] Manual: drag a media tile / post shortcut / wallpaper shortcut into an open Gutenberg post window; confirm block insertion
- [ ] Manual: open Gutenberg, wait, then drag in; confirm no spurious "Could not insert" toast (receiver still works after editor finished booting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-261-7d69aef6613868440334bb1f789a4cf8b7c1e200.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->