### PR TITLE
Smooth desktop repaint on adds and removes

### DIFF
--- a/assets/css/posts-window.css
+++ b/assets/css/posts-window.css
@@ -1565,7 +1565,14 @@ wpd-user-profile > .desktop-mode-users__edit-layout {
 }
 .desktop-mode-users__edit-main {
 	min-width: 0;
+	width: 100%;
 	max-width: 720px;
+	/* Center within the `minmax(0, 1fr)` grid cell so the form
+	 * stays readable on wide windows instead of leaving a large
+	 * empty band on the right edge. The 720px max preserves the
+	 * intended line length; the auto inline margin pushes the
+	 * unused width equally to both sides. */
+	margin-inline: auto;
 	display: flex;
 	flex-direction: column;
 }

--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -344,17 +344,15 @@
 	font-size: 18px;
 	width: 18px;
 	height: 18px;
-	/* Dashicons inherits `display: inline-block` from core, which
-	 * positions the glyph via text-layout — and the font's
-	 * baseline isn't quite centered in its em-box, so the visible
-	 * character drifts a px or two off the button's geometric
-	 * centre. Make the span itself a flex centerer so the glyph
-	 * sits dead-centre regardless of the font's intrinsic baseline. */
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	line-height: 1;
 }
+/* The flex-centring override for the dashicon glyph lives in
+ * `windows.css` rather than here. `windows.css` is mtime-stamped
+ * (per `desktop_mode_register_assets` in includes/assets.php) so
+ * its URL changes whenever it does, but `@import`-ed sub-sheets
+ * like this one are fetched without a version query and the
+ * browser will serve a stale cached copy across edits to this
+ * file. Co-locating cache-sensitive overrides with the parent
+ * stylesheet is the rule of the road here. */
 
 /* Focused window: meta buttons visible. */
 .desktop-mode-window--focused .desktop-mode-window__meta-btn {

--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -344,6 +344,16 @@
 	font-size: 18px;
 	width: 18px;
 	height: 18px;
+	/* Dashicons inherits `display: inline-block` from core, which
+	 * positions the glyph via text-layout — and the font's
+	 * baseline isn't quite centered in its em-box, so the visible
+	 * character drifts a px or two off the button's geometric
+	 * centre. Make the span itself a flex centerer so the glyph
+	 * sits dead-centre regardless of the font's intrinsic baseline. */
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
 }
 
 /* Focused window: meta buttons visible. */

--- a/assets/css/windows.css
+++ b/assets/css/windows.css
@@ -55,3 +55,30 @@
 	outline-offset: -6px;
 	background: color-mix(in srgb, var(--desktop-mode-accent, #2271b1) 8%, transparent);
 }
+
+/*
+ * Title-bar meta-button dashicon centring — same cache-busting
+ * reason: Dashicons inherits `display: inline-block` from core
+ * which positions the glyph via text-layout, and the font's
+ * baseline isn't the geometric centre of its em-box, so the
+ * visible `?` drifts off-centre inside the 28×28 button.
+ * Re-flexing the dashicon span re-anchors the glyph regardless
+ * of the font's intrinsic metrics. Lives in `windows.css`
+ * rather than `window-chrome.css` so the parent stylesheet's
+ * mtime stamp invalidates it on every edit — sub-sheet @imports
+ * are not version-queried and can be served from cache.
+ */
+.desktop-mode-window__meta-btn .dashicons {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
+	/* Reset any inherited `top` / `left` offset that bleeds in
+	 * from wp-admin or third-party stylesheets that style icons
+	 * by their glyph class (e.g. `.dashicons-editor-help` with
+	 * `top: 5px; left: 6px;` — leftover from contextual-help
+	 * styling that doesn't belong in our title bar). Without this
+	 * the glyph drifts off-centre inside the button. */
+	top: 0 !important;
+	left: 0 !important;
+}

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -66,7 +66,7 @@ Native (non-iframe) windows skip postMessage entirely — `Window.send` and the 
 
 | Type | Direction | Carries | Purpose |
 |---|---|---|---|
-| `desktop-mode-bridge-handshake` | parent → iframe | `{ connectionId, topics }` | Open a new connection. Iframe must ack before parent flushes its message queue. |
+| `desktop-mode-bridge-handshake` | parent → iframe | `{ connectionId, targetWindowId, topics }` | Open a new connection. Iframe must ack before parent flushes its message queue. The `targetWindowId` (since 0.22.0) is the host window's id — the iframe stores it for `wp.desktop.iframe.windowId` / `whenWindowId()`. |
 | `desktop-mode-bridge-handshake-ack` | iframe → parent | `{ connectionId }` | Iframe acknowledges. Parent fires `HOOKS.CONNECTION_OPENED` + flushes. |
 | `desktop-mode-bridge-publish` | both ways | `{ connectionId, topic, payload }` | Pub/sub message. Wildcard subscribers (`'*'`) see every topic. |
 | `desktop-mode-bridge-disconnect` | both ways | `{ connectionId }` | Tear the connection down. Idempotent. |
@@ -95,7 +95,7 @@ The forwarder skips drops landing on in-page receivers that already accept files
 6. Iframe's bridge handler receives the handshake, stores the connection in its own `connections` map, posts `desktop-mode-bridge-handshake-ack` back.
 7. Parent's `routeIncomingFromIframe` receives the ack, dispatches to the connection's `_handleIframeMessage`, which:
    - Sets `isOpen = true`.
-   - Fires `HOOKS.CONNECTION_OPENED` with `{ connectionId, targetWindowId, topics }`.
+   - Fires `HOOKS.CONNECTION_OPENED` with `{ connectionId, targetWindowId, topics, connection }`. The `connection` field (since 0.22.0) is the live `WindowConnection` — plug in `.subscribe()` directly from the hook handler without an extra `wp.desktop.getConnection(id)` round-trip.
    - Calls `opts.onOpen?.()`.
    - Drains the queue with `flushQueue()` — every queued message becomes a real `postMessage`.
 8. Iframe receives the publishes, looks up subscribers in `subs`, calls each in turn.
@@ -160,6 +160,39 @@ When something's not working:
 - **`window.wp.desktop.iframe`** — the iframe-side API. If it's `undefined` inside an iframe, the bridge script wasn't loaded — for chromeless wp-admin pages it's inline; for `iframeContent: { bridge: true }` it's auto-injected after load; for any other same-origin iframe enqueue `desktop-mode-iframe-bridge`.
 - **`window.location.origin`** check — every postMessage in both directions filters on this. A common cause of "messages don't arrive" is a shell mounted on `https://example.test` and an iframe loaded from `http://example.test` (different origin); same domain ≠ same origin.
 - **`event.source === iframe.contentWindow`** check — even same-origin, a foreign caller posting `desktop-mode-bridge-*` messages from somewhere ELSE in the parent will be silently dropped.
+
+## Cross-origin iframes — explicit non-goal
+
+**Every bridge in this repo is same-origin only**. Three independent origin filters enforce this:
+
+- `src/iframe-bridge-standalone.ts:131` — `parentOrigin = window.location.origin`.
+- `src/connection/index.ts:39` — `INITIAL_ORIGIN = window.location.origin`.
+- `src/drag-bridge.ts:207` — `this._origin = window.location.origin`.
+
+Each postMessage's `targetOrigin` is set to its own captured origin, and each `'message'` listener rejects events whose `e.origin` doesn't match. Cross-origin parents silently drop every bridge message — no warn, no fallback. This is **deliberate**: the bridge payloads feed into drop handlers that insert HTML and into hook subscribers that may execute code, so widening the trust boundary would create a clear XSS surface.
+
+Concretely, the bridge will not operate in these contexts:
+
+- **Cross-origin parent** — desktop-mode loaded in an `<iframe>` whose parent is on a different origin (top-level admin opened outside the shell, or shell embedded in a foreign host).
+- **Foreign-origin Gutenberg `srcdoc` canvas** — by default the editor-canvas iframe inherits the parent's origin (works fine), but some plugin / theme combos override `src` to a foreign URL.
+- **Sandboxed iframes** (`<iframe sandbox>` without `allow-same-origin`) — the iframe's origin is `"null"`, which never matches.
+- **PWA wrappers** loading desktop-mode in a foreign service-worker scope.
+
+### Detecting it from inside an iframe
+
+`wp.desktop.iframe.isParentReachable()` returns `true` when the parent is same-origin and addressable, `false` otherwise:
+
+```javascript
+if ( ! wp.desktop.iframe.isParentReachable() ) {
+    // No bridge — fall back to in-iframe UI, skip the feature,
+    // or surface a "this view requires desktop mode" notice.
+    return;
+}
+// Bridge is live; publish away.
+wp.desktop.iframe.publish( 'editor:content', html );
+```
+
+The predicate accesses `window.parent.location.origin` inside a try/catch — cross-origin parents throw on the access. Cheap, no postMessage round-trip. Use it before wiring expensive subscriptions or showing UI that promises cross-window behavior.
 
 ## Cross-window drag bridge — Stable *(since 0.22.0)*
 

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -1,0 +1,122 @@
+# `<wpd-*>` component reference
+
+Canonical mapping of every shipped web component: tag name → exported class → source file → one-line purpose. The runtime missing-component warner (`src/ui/components/missing-import-warner.ts`) points readers here.
+
+All components are **side-effect registered** by `desktop.min.js`. Plugin authors don't need to enqueue any extra script to use the tags — just emit `<wpd-foo>` markup. The class export is only needed for TypeScript types or programmatic instantiation.
+
+## Source of truth
+
+`src/ui/components/index.ts` re-exports every component class AND the `WPD_COMPONENT_TAGS` constant — the array all the dev-time guards iterate. If this doc and the index disagree, the index wins. To add a new component:
+
+1. Create `src/ui/components/<name>/<name>.ts`, `<name>.styles.ts`, `<name>.test.ts`.
+2. Add the class export + tag to `src/ui/components/index.ts`.
+3. Add the tag to `src/ui/components/tags.ts` (sourced by `WPD_COMPONENT_TAGS`).
+4. Add a row to this table.
+5. Document via the `static help = { … }` block on the class — surfaced in OS Settings → Help live.
+
+## Layout & structure
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-body>` | `WpdBody` | `wpd-body/wpd-body.ts` | Page-body scroll container. |
+| `<wpd-panel>` | `WpdPanel` | `wpd-panel/wpd-panel.ts` | Collapsible content section with header. |
+| `<wpd-section>` | `WpdSection` | `wpd-section/wpd-section.ts` | Titled section block within a panel. |
+| `<wpd-row>` | `WpdRow` | `wpd-row/wpd-row.ts` | Horizontal flex row primitive. |
+| `<wpd-stack>` | `WpdStack` | `wpd-stack/wpd-stack.ts` | Vertical flex stack with consistent gap. |
+| `<wpd-cluster>` | `WpdCluster` | `wpd-cluster/wpd-cluster.ts` | Wrapped flex row for chips / tags / actions. |
+| `<wpd-grid>` | `WpdGrid` | `wpd-grid/wpd-grid.ts` | Auto-fit CSS grid primitive. |
+| `<wpd-card>` | `WpdCard` | `wpd-card/wpd-card.ts` | Bordered surface for entity-card UIs. |
+| `<wpd-display>` | `WpdDisplay` | `wpd-display/wpd-display.ts` | Hero / display-typography container. |
+
+## Form controls
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-form>` | `WpdForm` | `wpd-form/wpd-form.ts` | Form host with auto value-collection + validation. |
+| `<wpd-text-field>` | `WpdTextField` | `wpd-text-field/wpd-text-field.ts` | Single-line text input. |
+| `<wpd-textarea>` | `WpdTextarea` | `wpd-textarea/wpd-textarea.ts` | Multi-line text input. |
+| `<wpd-number-field>` | `WpdNumberField` | `wpd-number-field/wpd-number-field.ts` | Numeric input with min/max/step. |
+| `<wpd-color-field>` | `WpdColorField` | `wpd-color-field/wpd-color-field.ts` | Color picker with swatches. |
+| `<wpd-range-field>` | `WpdRangeField` | `wpd-range-field/wpd-range-field.ts` | Slider with live numeric readout. |
+| `<wpd-checkbox>` | `WpdCheckbox` | `wpd-checkbox/wpd-checkbox.ts` | Standalone checkbox. |
+| `<wpd-checkbox-label>` | `WpdCheckboxLabel` | `wpd-checkbox-label/wpd-checkbox-label.ts` | Checkbox + inline label pair. |
+| `<wpd-select>` / `<wpd-option>` | `WpdSelect`, `WpdOption` | `wpd-select/wpd-select.ts` | Native select with custom chrome. |
+| `<wpd-multiselect>` | `WpdMultiselect` | `wpd-multiselect/wpd-multiselect.ts` | Multi-select with chips. |
+| `<wpd-segmented>` / `<wpd-segment>` | `WpdSegmented`, `WpdSegment` | `wpd-segmented/wpd-segmented.ts` | Segmented control (radio group as buttons). |
+| `<wpd-tag-input>` | `WpdTagInput` | `wpd-tag-input/wpd-tag-input.ts` | Free-text tag entry with autocomplete. |
+| `<wpd-category-picker>` | `WpdCategoryPicker` | `wpd-category-picker/wpd-category-picker.ts` | Category tree picker. |
+| `<wpd-role-picker>` | `WpdRolePicker` | `wpd-role-picker/wpd-role-picker.ts` | WP role select. |
+| `<wpd-user-search>` | `WpdUserSearch` | `wpd-user-search/wpd-user-search.ts` | Live user autocomplete (`/users` REST). |
+
+## Buttons & actions
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-button>` | `WpdButton` | `wpd-button/wpd-button.ts` | Primary / secondary / ghost button. |
+| `<wpd-window-button>` | `WpdWindowButton` | `wpd-window-button/wpd-window-button.ts` | Title-bar icon button (minimize / maximize / close / custom). |
+
+## Menus & overlays
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-menu>` / `<wpd-menu-item>` | `WpdMenu`, `WpdMenuItem` | `wpd-menu/wpd-menu.ts` | Dropdown menu surface. |
+| `<wpd-context-menu>` / `<wpd-context-menu-option>` | `WpdContextMenu`, `WpdContextMenuOption` | `wpd-context-menu/wpd-context-menu.ts` | Right-click / long-press menu. |
+| `<wpd-flyout>` | `WpdFlyout` | `wpd-flyout/wpd-flyout.ts` | Anchored popover. Supports placement strategies. |
+| `<wpd-modal>` | `WpdModal` | `wpd-modal/wpd-modal.ts` | Full-overlay modal with focus trap. |
+| `<wpd-confirm-dialog>` | `WpdConfirmDialog`, `wpdConfirm` | `wpd-confirm-dialog/wpd-confirm-dialog.ts` | Confirm prompt — use `await wpdConfirm({...})` (never `window.confirm`). |
+| `<wpd-toast>` / `<wpd-toast-container>` | `WpdToast`, `WpdToastContainer` | `wpd-toast/wpd-toast.ts` | Bottom-edge toast notifications. |
+| `<wpd-notice>` | `WpdNotice` | `wpd-notice/wpd-notice.ts` | Inline informational/warning notice. |
+
+## Display & feedback
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-icon>` | `WpdIcon` | `wpd-icon/wpd-icon.ts` | Icon by dashicon slug or SVG content. |
+| `<wpd-avatar>` | `WpdAvatar` | `wpd-avatar/wpd-avatar.ts` | User avatar with presence dot. |
+| `<wpd-badge>` | `WpdBadge` | `wpd-badge/wpd-badge.ts` | Number badge with tone color. |
+| `<wpd-ribbon>` | `WpdRibbon` | `wpd-ribbon/wpd-ribbon.ts` | Corner ribbon for tiles. |
+| `<wpd-chip>` | `WpdChip` | `wpd-chip/wpd-chip.ts` | Tag/category chip with tone. |
+| `<wpd-key>` | `WpdKey` | `wpd-key/wpd-key.ts` | Keyboard shortcut display. |
+| `<wpd-code>` | `WpdCode` | `wpd-code/wpd-code.ts` | Inline / block monospace code with copy. |
+| `<wpd-spinner>` | `WpdSpinner` | `wpd-spinner/wpd-spinner.ts` | Loading spinner with preset variants. |
+| `<wpd-progress-bar>` | `WpdProgressBar` | `wpd-progress-bar/wpd-progress-bar.ts` | Determinate or indeterminate progress. |
+| `<wpd-save-status>` | `WpdSaveStatus` | `wpd-save-status/wpd-save-status.ts` | Title-bar save indicator (idle / saving / saved / failed). |
+| `<wpd-relative-time>` | `WpdRelativeTime` | `wpd-relative-time/wpd-relative-time.ts` | Auto-updating "2 min ago". |
+| `<wpd-empty-state>` | `WpdEmptyState` | `wpd-empty-state/wpd-empty-state.ts` | Empty-list / no-results placeholder. |
+| `<wpd-rating-summary>` | `WpdRatingSummary` | `wpd-rating-summary/wpd-rating-summary.ts` | Star average + per-star bucket bars. |
+
+## Lists & tables
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-table>` | `WpdTable` | `wpd-table/wpd-table.ts` | Sortable, filterable data table with sub-tables. |
+| `<wpd-log>` | `WpdLog` | `wpd-log/wpd-log.ts` | Virtualized streaming log container. |
+| `<wpd-tile>` | `WpdTile` | `wpd-tile/wpd-tile.ts` | Desktop-style icon tile (used by file layer + dock). |
+
+## Tabs & navigation
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-tabs>` / `<wpd-tab>` / `<wpd-tabpanel>` | `WpdTabs`, `WpdTab`, `WpdTabPanel` | `wpd-tabs/wpd-tabs.ts` | Tab strip with associated panels. |
+| `<wpd-tab-chip>` | `WpdTabChip` | `wpd-tab-chip/wpd-tab-chip.ts` | Single chip tab (e.g. window tabs). |
+| `<wpd-steps>` / `<wpd-step>` | `WpdSteps`, `WpdStep` | `wpd-steps/wpd-steps.ts` | Wizard step indicator. |
+| `<wpd-crumb-chain>` | `WpdCrumbChain` | `wpd-crumb-chain/wpd-crumb-chain.ts` | Breadcrumb trail with chevron separators. |
+
+## Color & theming
+
+| Tag | Class | Source | Purpose |
+| --- | --- | --- | --- |
+| `<wpd-swatch>` | `WpdSwatch` | `wpd-swatch/wpd-swatch.ts` | Single color swatch button. |
+| `<wpd-swatch-grid>` | `WpdSwatchGrid` | `wpd-swatch-grid/wpd-swatch-grid.ts` | Grid of color swatches with selection. |
+
+## Importing the classes (for TypeScript)
+
+```typescript
+import { WpdLog, type WpdLogRowRenderer } from 'desktop-mode';
+```
+
+The runtime tag is already registered (no extra script needed) — the class import is for type-checking, subclassing, or programmatic instantiation. See [`use-from-a-plugin.md`](./use-from-a-plugin.md) for the local-install workflow.
+
+## Per-component help
+
+Every class has a `static help = { … }` block with full props / slots / events / examples / status. The OS Settings → Help tab iterates `WPD_COMPONENT_TAGS` and renders these descriptors live; that's the authoritative per-component reference. The table above is a directory; the `static help` block is the manual.

--- a/docs/examples/iframe-initiated-window.md
+++ b/docs/examples/iframe-initiated-window.md
@@ -68,10 +68,14 @@ function PreviewSidebar() {
     const [ streaming, setStreaming ] = useState( false );
 
     const open = async () => {
-        // We need to know our own window id so we can include it in
-        // diagnostics or sub-topic names. `whenWindowId()` resolves
-        // once the parent has handshaken (always before any user
-        // interaction in practice).
+        // Guard before awaiting the window id. `whenWindowId()` never
+        // rejects — if the parent shell never sends a handshake (e.g.
+        // cross-origin parent, page opened outside Desktop Mode) the
+        // Promise hangs forever. `isParentReachable()` resolves that
+        // ambiguity synchronously.
+        if ( ! wp.desktop.iframe.isParentReachable() ) {
+            return; // Not running inside Desktop Mode — bail silently.
+        }
         const myWindowId = await wp.desktop.iframe.whenWindowId();
 
         // Tell the parent shell to open a Preview window paired with us.

--- a/docs/examples/iframe-initiated-window.md
+++ b/docs/examples/iframe-initiated-window.md
@@ -1,0 +1,155 @@
+# Iframe-initiated window opens
+
+`docs/examples/connect-to-window.md` shows the case where the parent shell drives the conversation — a title-bar button mounted via `registerTitleBarButton` calls `wp.desktop.connect()` and pushes data into a sibling iframe. This recipe covers the **inverse topology**: code running *inside* a chromeless wp-admin iframe (a Gutenberg `PluginSidebar`, a custom meta-box, a settings page) needs to open or talk to a sibling window — without the parent shell having to register anything per-iframe-route.
+
+The classic case: **Live Preview**. The user is editing a post; a sidebar button inside the Gutenberg iframe should open a "Preview" window next to it and stream content changes live.
+
+## Patterns at a glance
+
+| Need | Use | Why |
+| --- | --- | --- |
+| "Open a sibling window from inside this iframe" | `wp.desktop.send( 'request-open-window', { url } )` — parent listens via `Window.on` | Symmetric `Window.send` / `wp.desktop.send` channel, no per-target wiring. |
+| "Connect back to the parent so I can publish updates" | `wp.desktop.iframe.requestConnection({ topics })` | Iframe initiates; parent's `HOOKS.IFRAME_CONNECTION_REQUEST` filter decides accept/reject. |
+| "What window am I living in?" | `wp.desktop.iframe.windowId` / `await wp.desktop.iframe.whenWindowId()` | Resolved after the parent's first handshake. |
+| "Did the parent shell even hear me?" | `wp.desktop.iframe.publish` now `console.warn`s on dropped messages (since 0.22.0) | Watch DevTools. |
+
+## Recipe: PluginSidebar opens a Preview window with live content streaming
+
+### 1. Parent-side bootstrap (shell, once)
+
+```javascript
+// In your plugin's shell-side bundle (the main `desktop.min.js`-loaded entry).
+//
+// We listen on the publish channel for `request-open-preview` from any
+// iframe window (Gutenberg post editor). When it arrives, open a sibling
+// Preview window AND wire the live content forwarder.
+
+import { addAction, HOOKS } from 'desktop-mode';
+
+addAction( HOOKS.WINDOW_OPENED, 'my-plugin/wire-editor', ( e ) => {
+    if ( ! e.windowId.startsWith( 'edit-post' ) ) {
+        return;
+    }
+    const editor = wp.desktop.windowManager.getById( e.windowId );
+    if ( ! editor ) return;
+
+    editor.on( 'request-open-preview', ( payload ) => {
+        const previewId = `preview-of-${ editor.id }`;
+        const preview = wp.desktop.openWindow( 'native:my-plugin-preview', {
+            id: previewId,
+            title: 'Live Preview',
+        } );
+        // Open a connection back to the editor's iframe so we can forward
+        // its content updates to the preview window's native render.
+        const conn = wp.desktop.connect( editor.id, {
+            topics: [ 'editor:content' ],
+        } );
+        conn.subscribe( 'editor:content', ( html ) => {
+            preview.send( 'preview:html', html );
+        } );
+    } );
+} );
+```
+
+### 2. Iframe-side trigger (PluginSidebar, runs inside post.php)
+
+```javascript
+// Loaded by your plugin on post.php / post-new.php (via enqueue_block_editor_assets).
+//
+// Inside Gutenberg, register a sidebar button that:
+//   a) Asks the parent shell to open the Preview window.
+//   b) Starts streaming editor content over the connection.
+
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+import { useSelect, subscribe } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+
+function PreviewSidebar() {
+    const [ streaming, setStreaming ] = useState( false );
+
+    const open = async () => {
+        // We need to know our own window id so we can include it in
+        // diagnostics or sub-topic names. `whenWindowId()` resolves
+        // once the parent has handshaken (always before any user
+        // interaction in practice).
+        const myWindowId = await wp.desktop.iframe.whenWindowId();
+
+        // Tell the parent shell to open a Preview window paired with us.
+        // `wp.desktop.send( channel, payload )` posts a `desktop-mode-window-publish`
+        // message — the parent's `Window.on('request-open-preview')` handler
+        // (wired in step 1) fires.
+        wp.desktop.send( 'request-open-preview', {
+            sourceWindowId: myWindowId,
+        } );
+
+        // Now start publishing editor content. The parent's connection's
+        // subscriber forwards each batch into the preview window.
+        setStreaming( true );
+    };
+
+    useEffect( () => {
+        if ( ! streaming ) return;
+
+        let last = '';
+        const unsub = subscribe( () => {
+            const editor = wp.data.select( 'core/editor' );
+            const html = editor.getEditedPostContent();
+            if ( html === last ) return;
+            last = html;
+            wp.desktop.iframe.publish( 'editor:content', html );
+        } );
+
+        return unsub;
+    }, [ streaming ] );
+
+    return (
+        <PluginSidebar name="my-plugin/preview" title="Preview">
+            <Button isPrimary onClick={ open }>
+                { streaming ? 'Streaming…' : 'Open live preview' }
+            </Button>
+        </PluginSidebar>
+    );
+}
+
+registerPlugin( 'my-plugin-preview', { render: PreviewSidebar } );
+```
+
+### 3. Preview window's native render (also runs in the shell bundle)
+
+```javascript
+wp.desktop.registerWindow( 'native:my-plugin-preview', {
+    native: true,
+    render( body, ctx ) {
+        body.innerHTML = '<iframe id="preview-frame" style="width:100%; height:100%; border:none"></iframe>';
+        const iframe = body.querySelector( '#preview-frame' );
+
+        // Listen for content updates forwarded by the parent from the
+        // editor iframe (step 1 wires the forwarder).
+        ctx.window.on( 'preview:html', ( html ) => {
+            iframe.srcdoc = html;
+        } );
+    },
+} );
+```
+
+## What's happening under the hood
+
+1. **PluginSidebar runs inside the Gutenberg iframe.** That iframe has the standalone iframe-bridge installed (auto-enqueued on every admin page for desktop-mode users), which exposes `wp.desktop.send`, `wp.desktop.iframe.publish`, and `wp.desktop.iframe.windowId`.
+2. **Step 2's `wp.desktop.send`** turns into a `desktop-mode-window-publish` postMessage to the parent. The parent's `Window.on(...)` subscribers for THIS window's id fire — step 1's handler is one of them.
+3. **Step 1 opens the Preview window** and immediately opens a typed connection back to the editor's iframe via `wp.desktop.connect(editor.id, { topics })`. The connection handshakes through `desktop-mode-bridge-handshake` / `…-ack`.
+4. **Step 2's `wp.desktop.iframe.publish`** fans editor content out over every open connection. The parent's `conn.subscribe(...)` fires, and we forward into the preview window's native channel via `preview.send(...)`.
+5. **Step 3 listens** on the preview's own channel via `ctx.window.on(...)` — no postMessage on this side; it's all in-process.
+
+## When the parent silently ignores your message
+
+If `wp.desktop.send(...)` (or `wp.desktop.iframe.publish(...)`) does nothing visible:
+
+- **No connection open** → since 0.22.0 `publish` logs a `console.warn` when there are zero connections. Open DevTools (in the iframe's frame), look for `[desktop-mode] wp.desktop.iframe.publish dropped`.
+- **No subscriber** → no warning by design. Add an `addAction(HOOKS.CONNECTION_OPENED, …)` log on the parent side to confirm the connection actually opened.
+- **Cross-origin iframe** → bridges hard-filter on `window.location.origin`. The Gutenberg editor-canvas (nested iframe inside post.php) uses `srcdoc` which inherits the parent's origin, so it's fine; arbitrary cross-origin iframes silently drop. See [`bridge-protocol.md`](../bridge-protocol.md#cross-origin-iframes) for the explicit non-goal.
+
+## Related
+
+- [`connect-to-window.md`](./connect-to-window.md) — the inverse topology (parent-initiated).
+- [`code-editor-open.md`](./code-editor-open.md) — sibling-window opens via a different protocol (`desktop-mode-code-open` postMessage).
+- [`../bridge-protocol.md`](../bridge-protocol.md) — full message catalog.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -131,6 +131,19 @@ document.addEventListener( 'desktop-mode-window-content-loaded', ( e ) => {
 
 Companion `wp.hooks` action: `HOOKS.WINDOW_CONTENT_LOADED` (`desktop-mode.window.content-loaded`).
 
+#### Programmatic equivalent — `Window.whenContentReady()` *(since 0.22.0)*
+
+For code paths that don't want to wire a CustomEvent listener (e.g. a plugin coordinating with an `iframeContent: { bridge: true }` native window before its first `send`), the `Window` facade exposes a Promise-returning version:
+
+```javascript
+const win = await wp.desktop.openWindow( 'my-plugin/inbox' );
+await win.whenContentReady();
+// Bridge listeners are guaranteed wired here; safe to send / connect.
+win.send( 'init', { … } );
+```
+
+Resolves immediately for windows that are already ready, otherwise on the next matching `desktop-mode-window-content-loaded` for this window's id. Mirrors `HOOKS.WINDOW_CONTENT_LOADED` semantics — works for both iframe and native windows.
+
 ---
 
 ### `desktop-mode-window-focused` — Stable
@@ -2078,13 +2091,31 @@ wp.desktop.iframe.subscribe( 'preview:zoom', ( payload ) => {
 } );
 ```
 
-`publish( topic, payload )` fans the message out to every parent-side connection currently open against this iframe. `onConnection` callbacks are replayed for currently-open connections, so a late registration still sees who's already there.
+`publish( topic, payload )` fans the message out to every parent-side connection currently open against this iframe. **As of 0.22.0, calls with zero open connections log a `console.warn`** — the previous silent drop was a recurring footgun for plugin authors publishing before the parent's `connect()` lands. `onConnection` callbacks are replayed for currently-open connections, so a late registration still sees who's already there.
+
+#### `wp.desktop.iframe.windowId` / `whenWindowId()` — Stable *(since 0.22.0)*
+
+The id of the native window the parent shell opened to host this iframe. Populated automatically once the parent issues the first connection handshake (the handshake carries `targetWindowId`); `null` until then. Removes the cross-origin-fragile `iframe.contentWindow ===` walk that parent-side plugin code used to identify iframes.
+
+```javascript
+// Inside the iframe:
+const id = wp.desktop.iframe.windowId; // string | null
+
+// Or wait for it (Promise resolves once known):
+const id = await wp.desktop.iframe.whenWindowId();
+wp.desktop.iframe.publish( 'sidebar-opened', { windowId: id } );
+```
+
+The id is exactly what `wp.desktop.openWindow(...)` returns parent-side and what `Window.id` exposes — a stable cross-side handle for self-identification.
 
 **Lifecycle hooks** (parent-side, observability):
 
 ```javascript
 wp.desktop.hooks.addAction( 'desktop-mode.connection.opened', 'me', ( e ) => {
-    // e = { connectionId, targetWindowId, topics }
+    // e = { connectionId, targetWindowId, topics, connection }
+    // `connection` is the live WindowConnection (since 0.22.0) —
+    // subscribe to it directly without a `getConnection` round-trip.
+    e.connection.subscribe( 'live-pings', ( payload ) => { … } );
 } );
 wp.desktop.hooks.addAction( 'desktop-mode.connection.closed', 'me', ( e ) => {
     // e = { connectionId, reason }
@@ -2094,6 +2125,17 @@ wp.desktop.hooks.addAction( 'desktop-mode.connection.message', 'me', ( e ) => {
     // High-volume — keep subscribers cheap.
 } );
 ```
+
+For connections opened by the iframe (`requestConnection`), the parent can later look up the live connection by id:
+
+```javascript
+const conn = wp.desktop.getConnection( connectionId );
+if ( conn ) {
+    conn.subscribe( 'topic', cb );
+}
+```
+
+`wp.desktop.getConnection( id )` returns the same `WindowConnection` reference the `connect()` factory produces (or what `CONNECTION_OPENED` ships as `connection`). Returns `null` for unknown / destroyed ids.
 
 See [`docs/examples/connect-to-window.md`](./examples/connect-to-window.md) for the full live-preview recipe.
 

--- a/docs/use-from-a-plugin.md
+++ b/docs/use-from-a-plugin.md
@@ -1,0 +1,95 @@
+# Using `desktop-mode` from your own plugin
+
+This doc explains how a sibling WordPress plugin can use `desktop-mode`'s TypeScript types and component classes (`WpdLog`, `WpdCode`, `WpdTabs`, …) *without* publishing `desktop-mode` to npm and *without* reaching into its `src/` tree via relative paths.
+
+## The short version
+
+`desktop-mode`'s `package.json` is `"private": true` (so it can never be accidentally `npm publish`ed) but exposes its public API via the `exports` map. Any sibling plugin can install it as a local file dependency:
+
+```jsonc
+// my-plugin/package.json
+{
+    "dependencies": {
+        "desktop-mode": "file:../desktop-mode"
+    }
+}
+```
+
+```bash
+cd my-plugin
+npm install
+```
+
+That's it. After install, the import resolves through `desktop-mode`'s `exports`:
+
+```typescript
+import { WpdLog, type WpdLogRowRenderer, HOOKS } from 'desktop-mode';
+```
+
+No relative paths, no monorepo refactor, no npm registry.
+
+## What you get
+
+Everything re-exported from `src/public-api.ts`:
+
+- **TypeScript types** — `WindowConfig`, `WallpaperDef`, `WidgetDef`, `DragManagerApi`, `DragBridgePayload`, `WindowConnection`, …
+- **Component classes** — `WpdLog`, `WpdCode`, `WpdTabs`, `WpdAvatar`, `WpdBadge`, …
+- **Hook constants** — `HOOKS.WINDOW_OPENED`, `HOOKS.CONNECTION_OPENED`, `HOOKS.DRAG_BRIDGE_EVENTS`, …
+- **Public surface helpers** — `DRAG_EVENTS`, `DRAG_BRIDGE_EVENTS`, etc.
+
+Both runtime values AND types — the same file backs both conditions in the `exports` map.
+
+## Runtime use of components — you usually don't need the import at all
+
+The `wpd-*` custom elements are **already registered globally** by `desktop.min.js` when desktop mode is active. Plugin templates can just emit the markup:
+
+```html
+<wpd-log id="agent-trace" max-rows="500"></wpd-log>
+```
+
+```javascript
+const log = document.getElementById( 'agent-trace' );
+log.appendRow( { level: 'info', message: 'Agent started' } );
+```
+
+The class import (`import { WpdLog } from 'desktop-mode'`) is only useful for:
+
+1. **TypeScript type-checking** of the element handle (`document.getElementById('agent-trace') as WpdLog`).
+2. **Subclassing** a component to override behavior.
+3. **Programmatic instantiation** (`new WpdLog()` then `document.body.appendChild(el)`) — rare; the HTML route is preferred.
+
+## Avoiding duplicate bundling
+
+If your plugin bundles its own JS (Vite, esbuild, webpack, …) and imports `WpdLog`, the bundler will include the component's source in your bundle by default. For a single-component import this is ~3 KB gzip; for the full kit it's much more.
+
+If you want to **externalize** — load desktop-mode's classes at runtime from the shell's bundle rather than your own — your bundler config needs:
+
+```javascript
+// vite.config.js
+export default {
+    build: {
+        rollupOptions: {
+            external: [ 'desktop-mode' ],
+        },
+    },
+};
+```
+
+Combined with a small browser shim that resolves the import to a runtime global (e.g. `window.desktopMode`). This is an advanced setup; for most plugins, just letting the bundler include the components is fine.
+
+## Why not just publish to npm?
+
+We could. We deliberately don't, because:
+
+- Bundle distribution within WordPress.org plugin reviews is already covered by the build step in this repo (`assets/js/*.min.js`). Publishing a parallel npm artifact would be a second source of truth that drifts.
+- The TypeScript surface is the contract; type-only consumers don't need an npm fetch — they need a path.
+- `file:` dependencies are stable, version-locked at install time, and don't require a registry.
+
+If you genuinely need a registry-based install (e.g. a CI runner that can't see this repo's filesystem), open an issue and we'll re-evaluate.
+
+## Troubleshooting
+
+- **`Cannot find module 'desktop-mode'`** — confirm the `file:` path is correct relative to your plugin's `package.json` location, then re-run `npm install`.
+- **Types resolve but runtime imports fail** — your bundler is configured to externalize without a runtime shim. Either remove the externalization or wire a global resolver.
+- **Duplicate custom element warning in DevTools** — the `wpd-*` elements register themselves on import; if both your bundle AND `desktop.min.js` define them, browsers log a warning (harmless — the registry is idempotent per tag name).
+- **Editing `desktop-mode/src/*` doesn't reflect in your plugin** — `file:` dependencies on some npm versions copy at install time. Run `npm install` again, or switch to `npm link` for an active symlink while developing both packages in parallel.

--- a/docs/use-from-a-plugin.md
+++ b/docs/use-from-a-plugin.md
@@ -87,6 +87,26 @@ We could. We deliberately don't, because:
 
 If you genuinely need a registry-based install (e.g. a CI runner that can't see this repo's filesystem), open an issue and we'll re-evaluate.
 
+## Iframe bridge gotcha — `whenWindowId()` never rejects
+
+If your plugin code runs inside a chromeless wp-admin iframe and calls
+`wp.desktop.iframe.whenWindowId()`, be aware that the returned Promise
+**never rejects**. When the page is not running inside Desktop Mode (a
+cross-origin parent, a direct admin URL visit, a unit-test harness) the
+Promise simply hangs forever — any `await` after it will never resume.
+
+Always guard with `isParentReachable()` first:
+
+```javascript
+if ( ! wp.desktop.iframe.isParentReachable() ) {
+    return; // Not inside Desktop Mode — skip iframe-bridge code.
+}
+const windowId = await wp.desktop.iframe.whenWindowId();
+```
+
+The same caveat applies to `Window.whenContentReady()` on the shell side —
+it never rejects if the content iframe never signals readiness.
+
 ## Troubleshooting
 
 - **`Cannot find module 'desktop-mode'`** — confirm the `file:` path is correct relative to your plugin's `package.json` location, then re-run `npm install`.

--- a/includes/desktop-files/trash.php
+++ b/includes/desktop-files/trash.php
@@ -762,7 +762,7 @@ function desktop_mode_files_trash_folder( $user_id, $folder_id ) {
 	// IDs; deep folder trees iterate.
 	$child_folder_ids = $wpdb->get_col(
 		$wpdb->prepare(
-			"SELECT id FROM {$tables['folders']} f
+			"SELECT f.id FROM {$tables['folders']} f
 			INNER JOIN {$tables['placements']} p ON p.file_type = 'folder' AND p.file_ref = CAST( f.id AS CHAR )
 			WHERE p.parent_id = %d AND f.trashed_at_ms IS NULL",
 			$folder_id

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -2493,6 +2493,30 @@ function desktop_mode_chromeless_bridge_script() {
 		}
 		window.addEventListener( 'load', attach, { once: true } );
 	} )();
+
+	/*
+	 * Bridge-ready signal. Every listener installed by this script
+	 * is now wired; let the parent shell know so it can fire
+	 * `HOOKS.IFRAME_READY` and re-arm any connection handshakes
+	 * (`src/connection/index.ts#onIframeReady`) that arrived before
+	 * we were listening. Without this, every consumer of
+	 * `HOOKS.IFRAME_READY` (devtools replay, connection rearm)
+	 * stays silent for the lifetime of the iframe — documented
+	 * surface that never actually fires.
+	 *
+	 * Posted to the parent's own origin only. Wrapped in try/catch
+	 * because cross-origin parents (top-level admin opened outside
+	 * the shell) would throw on the postMessage and we don't want a
+	 * single failed dispatch to wedge anything else above.
+	 */
+	try {
+		if ( window.parent && window.parent !== window ) {
+			window.parent.postMessage(
+				{ type: 'desktop-mode-ready' },
+				window.location.origin
+			);
+		}
+	} catch ( _err ) { /* parent gone or cross-origin */ }
 } )();
 JS;
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
 	"types": "src/public-api.ts",
 	"exports": {
 		".": {
-			"types": "./src/public-api.ts"
+			"types": "./src/public-api.ts",
+			"import": "./src/public-api.ts",
+			"default": "./src/public-api.ts"
 		},
 		"./global": {
 			"types": "./src/global.d.ts"

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -226,6 +226,7 @@ export interface BuildPublicApiDeps {
 	dragBridge: DragBridgeApi;
 	dragManager: DragManagerApi;
 	connect: ( targetWindowId: string, opts?: ConnectOptions ) => WindowConnection;
+	getConnection: ( connectionId: string ) => WindowConnection | null;
 	config: DesktopConfig;
 }
 
@@ -260,6 +261,7 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 		dragBridge,
 		dragManager,
 		connect,
+		getConnection,
 		config,
 	} = deps;
 
@@ -543,6 +545,7 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 			win.setAppearanceChrome( chromeId );
 		},
 		connect,
+		getConnection,
 		broadcast,
 		subscribe,
 		registerPalette,

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -318,6 +318,13 @@ export function createConnectionBridge( manager: WindowManager ) {
 						connectionId: id,
 						targetWindowId,
 						topics,
+						// Ship the live Connection alongside the id so
+						// iframe-initiated connections can be subscribed
+						// to directly from the hook handler — without
+						// `wp.desktop.getConnection(id)` plumbing the
+						// payload would carry the id but no way to call
+						// `.subscribe()` against it.
+						connection: conn,
 					} );
 					try {
 						opts.onOpen?.();
@@ -480,6 +487,7 @@ export function createConnectionBridge( manager: WindowManager ) {
 			sendToIframe( iframe, {
 				type: 'desktop-mode-bridge-handshake',
 				connectionId: id,
+				targetWindowId,
 				topics,
 			} );
 		}
@@ -615,6 +623,7 @@ export function createConnectionBridge( manager: WindowManager ) {
 			sendToIframe( iframe, {
 				type: 'desktop-mode-bridge-handshake',
 				connectionId: conn.id,
+				targetWindowId: conn.target,
 				topics: [], // already negotiated client-side; iframe re-uses
 			} );
 		}
@@ -636,5 +645,33 @@ export function createConnectionBridge( manager: WindowManager ) {
 		}
 	};
 
-	return { connect, routeIncomingFromIframe, onIframeReady, onWindowClosed };
+	/**
+	 * Look up a live `WindowConnection` by id. Returns `null` for
+	 * unknown ids and for ids whose connection has been destroyed.
+	 *
+	 * Companion to {@link HOOKS.CONNECTION_OPENED}: shell-side plugin
+	 * code that observes a connection being opened by an iframe (via
+	 * `wp.desktop.iframe.requestConnection`) gets the id in the hook
+	 * payload but had no way to obtain the live Connection object
+	 * before this accessor existed. Now `connection` is also passed
+	 * directly in the hook payload — both paths produce the same
+	 * Connection reference; pick whichever fits the call site.
+	 *
+	 * @public
+	 * @since 0.22.0
+	 */
+	const getConnection = (
+		connectionId: string,
+	): WindowConnection | null => {
+		const conn = _connections.get( connectionId );
+		return conn ?? null;
+	};
+
+	return {
+		connect,
+		getConnection,
+		routeIncomingFromIframe,
+		onIframeReady,
+		onWindowClosed,
+	};
 }

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -244,6 +244,266 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		notifySelection( placement );
 	};
 
+	/**
+	 * Compute pinned-slot map + displaced map for a list. Shared by
+	 * the wholesale rebuild and the incremental path so both end up
+	 * with bit-identical layouts.
+	 */
+	const computeLayout = (
+		list: readonly RestPlacementShape[],
+	): {
+		pinnedSlots: Map< number, { x: number; y: number } >;
+		displaced: Map< number, { x: number; y: number } >;
+	} => {
+		const pinnedSlots = new Map< number, { x: number; y: number } >();
+		const occupiedCells = new Set< string >();
+		let pinnedIdx = 0;
+		for ( const placement of list ) {
+			if ( ! isPinned( placement ) ) {
+				continue;
+			}
+			const slot = cellToPos( 0, pinnedIdx );
+			pinnedSlots.set( placement.id, { x: slot.x, y: slot.y } );
+			occupiedCells.add( cellKey( slot.col, slot.row ) );
+			pinnedIdx += 1;
+		}
+		const displaced = new Map< number, { x: number; y: number } >();
+		for ( const placement of list ) {
+			if ( pinnedSlots.has( placement.id ) ) {
+				continue;
+			}
+			const target = pointToCell( placement.x, placement.y );
+			const key = cellKey( target.col, target.row );
+			if ( ! occupiedCells.has( key ) ) {
+				occupiedCells.add( key );
+				continue;
+			}
+			const free = snapToEmptyCell(
+				placement.x,
+				placement.y,
+				occupiedCells,
+				host,
+			);
+			occupiedCells.add( cellKey( free.col, free.row ) );
+			displaced.set( placement.id, { x: free.x, y: free.y } );
+		}
+		return { pinnedSlots, displaced };
+	};
+
+	/**
+	 * Apply final position to an existing tile based on the pinned /
+	 * displaced / stored coordinates. Pure DOM mutation — no rebuild.
+	 */
+	const applyTilePosition = (
+		tile: HTMLElement,
+		placement: RestPlacementShape,
+		pinnedSlots: Map< number, { x: number; y: number } >,
+		displaced: Map< number, { x: number; y: number } >,
+	): void => {
+		const pinned = pinnedSlots.get( placement.id );
+		const moved = displaced.get( placement.id );
+		if ( pinned ) {
+			setTilePosition( tile, pinned.x, pinned.y );
+		} else if ( moved ) {
+			setTilePosition( tile, moved.x, moved.y );
+		} else {
+			setTilePosition( tile, placement.x, placement.y );
+		}
+	};
+
+	/**
+	 * Build a fully-wired tile DOM node for a placement. Encapsulates
+	 * everything the wholesale rebuild used to do inline per tile:
+	 * position, drag wiring, context menu, click-select, drop-target
+	 * registrations. Used by BOTH the wholesale rebuild and the
+	 * incremental add path so the behaviour stays in lock-step.
+	 *
+	 * Caller is responsible for appending the returned element to
+	 * `container`.
+	 */
+	const wireTile = (
+		placement: RestPlacementShape,
+		pinnedSlots: Map< number, { x: number; y: number } >,
+		displaced: Map< number, { x: number; y: number } >,
+	): HTMLElement => {
+		const tile = buildTile( placement, folderId );
+		const pinnedSlot = pinnedSlots.get( placement.id );
+		if ( pinnedSlot ) {
+			setTilePosition( tile, pinnedSlot.x, pinnedSlot.y );
+			tile.classList.add( `${ TILE_CLASS }--pinned` );
+			attachContextMenu( tile, placement );
+			attachSelectOnClick( tile, placement );
+			if ( shouldRejectTileDrops( placement ) ) {
+				const dragManager = getDragManager();
+				if ( dragManager ) {
+					const deregister = dragManager.registerDropTarget( {
+						id: `desktop-mode-files-tile-${ placement.id }-reject`,
+						element: tile,
+						accept: () => false,
+						onDrop: () => {},
+					} );
+					tileRejectDeregisters.set( placement.id, deregister );
+				}
+			}
+			return tile;
+		}
+		const moved = displaced.get( placement.id );
+		if ( moved ) {
+			setTilePosition( tile, moved.x, moved.y );
+		}
+		attachTileDrag( tile, placement, folderId );
+		attachContextMenu( tile, placement );
+		attachSelectOnClick( tile, placement );
+		if ( placement.file.type === 'folder' ) {
+			const targetFolderId = parseInt( placement.file.ref, 10 );
+			if ( targetFolderId > 0 ) {
+				const dragManager = getDragManager();
+				if ( dragManager ) {
+					const deregister = registerFolderDropTarget(
+						dragManager,
+						tile,
+						targetFolderId,
+						folderId,
+					);
+					folderDropDeregisters.set( placement.id, deregister );
+				}
+			}
+		} else if ( shouldRejectTileDrops( placement ) ) {
+			const dragManager = getDragManager();
+			if ( dragManager ) {
+				const deregister = dragManager.registerDropTarget( {
+					id: `desktop-mode-files-tile-${ placement.id }-reject`,
+					element: tile,
+					accept: () => false,
+					onDrop: () => {},
+				} );
+				tileRejectDeregisters.set( placement.id, deregister );
+			}
+		}
+		return tile;
+	};
+
+	/**
+	 * Incremental repaint path — handles the common "added and/or
+	 * removed one or more placements, otherwise same set" case
+	 * without nuking the entire container's DOM. Preserves DOM
+	 * identity for unchanged tiles so the user doesn't see a
+	 * "desktop reload" flash on file creation, shortcut drop, or
+	 * deletion.
+	 *
+	 * Returns `true` if the patch applied; `false` if the caller
+	 * must fall through to the wholesale rebuild. Bails when ANY
+	 * shared tile has a structural change (file-type, file-ref,
+	 * pinned-flag) — those cases need the wholesale path's full
+	 * re-wiring.
+	 *
+	 * @since 0.22.0
+	 */
+	const tryPatchIncremental = (
+		list: readonly RestPlacementShape[],
+	): boolean => {
+		const existing = new Map< number, HTMLElement >();
+		for ( const tile of container.querySelectorAll< HTMLElement >(
+			'[data-placement-id]',
+		) ) {
+			const raw = tile.dataset.placementId ?? '';
+			const id = parseInt( raw, 10 );
+			if ( raw === '' || ( Number.isNaN( id ) && raw !== '-0' ) ) {
+				return false;
+			}
+			existing.set( id, tile );
+		}
+
+		const wantIds = new Set< number >();
+		for ( const placement of list ) {
+			wantIds.add( placement.id );
+		}
+
+		// Verify every SHARED id has matching structural fields. If
+		// any differ (file-type, file-ref, or pinned flag flipped),
+		// the wholesale path's full re-wiring is needed.
+		for ( const placement of list ) {
+			const tile = existing.get( placement.id );
+			if ( ! tile ) {
+				continue; // added — handled below.
+			}
+			if ( tile.dataset.fileType !== placement.file.type ) {
+				return false;
+			}
+			if ( tile.dataset.fileRef !== placement.file.ref ) {
+				return false;
+			}
+			const wasPinned = tile.classList.contains(
+				`${ TILE_CLASS }--pinned`,
+			);
+			if ( wasPinned !== isPinned( placement ) ) {
+				return false;
+			}
+		}
+
+		// Remove tiles whose placements are gone — deregister their
+		// drop-target claims first so the registry doesn't keep
+		// detached-element references.
+		for ( const [ id, tile ] of existing ) {
+			if ( wantIds.has( id ) ) {
+				continue;
+			}
+			const folderDereg = folderDropDeregisters.get( id );
+			if ( folderDereg ) {
+				try {
+					folderDereg();
+				} catch {
+					// ignore
+				}
+				folderDropDeregisters.delete( id );
+			}
+			const rejectDereg = tileRejectDeregisters.get( id );
+			if ( rejectDereg ) {
+				try {
+					rejectDereg();
+				} catch {
+					// ignore
+				}
+				tileRejectDeregisters.delete( id );
+			}
+			tile.remove();
+		}
+
+		const { pinnedSlots, displaced } = computeLayout( list );
+
+		// Update positions on shared tiles + build new ones for adds.
+		for ( const placement of list ) {
+			const tile = existing.get( placement.id );
+			if ( tile ) {
+				applyTilePosition( tile, placement, pinnedSlots, displaced );
+				continue;
+			}
+			container.appendChild(
+				wireTile( placement, pinnedSlots, displaced ),
+			);
+		}
+
+		// Selection bookkeeping — match the wholesale path so right-
+		// pane consumers stay in sync when the selected tile was the
+		// removed one.
+		if (
+			selectedId !== null &&
+			! container.querySelector(
+				`[data-placement-id="${ selectedId }"]`,
+			)
+		) {
+			selectedId = null;
+			notifySelection( null );
+		}
+
+		doAction( 'desktop-mode.files.grid-rendered', {
+			folderId,
+			count: list.length,
+		} );
+
+		return true;
+	};
+
 	const repaint = ( state: FilesState ): void => {
 		const raw = state.placementsByFolder.get( folderId ) ?? [];
 		// Pinned tiles always render first so their slots are
@@ -259,23 +519,29 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		}
 		lastFingerprint = fp;
 
-		// Fast path: the common case (single tile dragged within the
-		// same folder) changes only `x` / `y` / `sortOrder` for one or
-		// more existing tiles. Nuking the DOM with `replaceChildren`
-		// for that produces a visible flash that reads to users as
-		// "the desktop just reloaded." When the placement set + every
-		// structural field matches what's already in the DOM, patch
-		// positions in place and bail before the wholesale rebuild.
-		// Falls through to the rebuild for adds, removes, renames,
-		// file-type changes, parent moves, or pin-flag flips — any of
-		// which require the full pinned-slot + drop-target
-		// reconciliation below.
+		// Fastest path: position-only changes (intra-folder drag,
+		// auto-arrange). Same set, same structure, no rewiring.
 		if ( tryPatchPositions( list, container, host ) ) {
 			return;
 		}
 
-		// Wholesale rebuild — simplest correct strategy. Plugins that
-		// want stable decorations re-attach via `tile-rendered`.
+		// Incremental path: same set MOSTLY, with adds and/or removes
+		// but no structural mutations on the unchanged tiles. Covers
+		// the file-creation, shortcut-drop, and delete flows — which
+		// otherwise would each visibly flash the wallpaper with a
+		// full `replaceChildren()` rebuild.
+		if ( tryPatchIncremental( list ) ) {
+			return;
+		}
+
+		// Wholesale rebuild — last resort. Pin-flag flips, parent-
+		// folder moves, file-type changes, all land here. Plugins
+		// that want stable decorations re-attach via `tile-rendered`.
+
+		// Wholesale rebuild — last-resort path for transitions the
+		// incremental walker can't handle (pin-flag flips, parent-
+		// folder moves, file-type changes). Plugins that want stable
+		// decorations re-attach via `tile-rendered`.
 		container.replaceChildren();
 		// Folder drop targets are tile-scoped — the previous tile DOM
 		// nodes are detached by `replaceChildren` above. Deregister
@@ -300,161 +566,16 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		}
 		tileRejectDeregisters.clear();
 
-		// Pinned tiles (registered with `pinned: true` —
-		// `desktop_mode_register_icon`) anchor to a fixed slot and
-		// drop the drag wiring entirely. Today the only pinned
-		// surface is the framework "My WordPress" shortcut, but the
-		// flag is generic so anything that should never move can
-		// opt in.
-		// Reserve column 0, top-down, for pinned tiles. Their
-		// server-stored (x, y) is ignored — the visual slot is
-		// purely a function of their pinned-order index.
-		const pinnedSlots = new Map< number, { x: number; y: number } >();
-		const occupiedCells = new Set< string >();
-		let pinnedIdx = 0;
-		for ( const placement of list ) {
-			if ( ! isPinned( placement ) ) {
-				continue;
-			}
-			const slot = cellToPos( 0, pinnedIdx );
-			pinnedSlots.set( placement.id, { x: slot.x, y: slot.y } );
-			occupiedCells.add( cellKey( slot.col, slot.row ) );
-			pinnedIdx += 1;
-		}
+		// Layout passes — pinned-slot allocation then displacement of
+		// non-pinned tiles whose stored coords landed on a pinned
+		// slot. Shared with the incremental + fast paths via
+		// `computeLayout()`.
+		const { pinnedSlots, displaced } = computeLayout( list );
 
-		// Pre-compute display cells for non-pinned tiles, evicting
-		// any whose stored coords land on a pinned slot. Pre-existing
-		// data from before pinned shortcuts existed (e.g. Recycle Bin
-		// already living at (0, 0)) would otherwise overlap visually
-		// with the new anchored "My WordPress" tile. Process in
-		// stored-position order so pre-pinned tiles keep their
-		// relative ordering when displaced.
-		const displaced = new Map<
-			number,
-			{ x: number; y: number }
-		>();
 		for ( const placement of list ) {
-			if ( pinnedSlots.has( placement.id ) ) {
-				continue;
-			}
-			const target = pointToCell( placement.x, placement.y );
-			const key = cellKey( target.col, target.row );
-			if ( ! occupiedCells.has( key ) ) {
-				occupiedCells.add( key );
-				continue;
-			}
-			// Stored cell is taken (by a pinned tile or an already-
-			// displaced peer). Snap to the next free cell.
-			const free = snapToEmptyCell(
-				placement.x,
-				placement.y,
-				occupiedCells,
-				host,
+			container.appendChild(
+				wireTile( placement, pinnedSlots, displaced ),
 			);
-			occupiedCells.add( cellKey( free.col, free.row ) );
-			displaced.set( placement.id, { x: free.x, y: free.y } );
-		}
-
-		for ( const placement of list ) {
-			const tile = buildTile( placement, folderId );
-			const pinnedSlot = pinnedSlots.get( placement.id );
-			if ( pinnedSlot ) {
-				setTilePosition( tile, pinnedSlot.x, pinnedSlot.y );
-				tile.classList.add( `${ TILE_CLASS }--pinned` );
-				// No drag wiring on pinned tiles by design — they
-				// anchor to a fixed slot. We deliberately DO NOT
-				// surface any upfront visual cue (no special cursor,
-				// bump animation, or tooltip): the tile looks +
-				// reacts identically to any other tile, and the
-				// (silent) failure to drag becomes the feedback at
-				// the moment the user attempts it. This was the
-				// 0.9.0 design call — pre-emptive cues read as "this
-				// tile is broken/disabled" even though clicking it
-				// opens the window normally.
-				attachContextMenu( tile, placement );
-				attachSelectOnClick( tile, placement );
-				// Pinned tiles (My WordPress today) are system
-				// shortcuts — never valid drop targets. Without an
-				// explicit reject claimant the hit-test walks past
-				// them to the canvas drop target → green "Drop here
-				// to move" chip on hover, misleading because the
-				// drop snaps elsewhere (the cell is in the visual-
-				// occupied set). The Recycle Bin is excluded — its
-				// own trash-accepting drop target registers from
-				// `recycle-bin-targets.ts` and the registry
-				// overwrites by element.
-				if ( shouldRejectTileDrops( placement ) ) {
-					const dragManager = getDragManager();
-					if ( dragManager ) {
-						const deregister = dragManager.registerDropTarget( {
-							id: `desktop-mode-files-tile-${ placement.id }-reject`,
-							element: tile,
-							accept: () => false,
-							onDrop: () => {},
-						} );
-						tileRejectDeregisters.set( placement.id, deregister );
-					}
-				}
-				container.appendChild( tile );
-				continue;
-			}
-			const moved = displaced.get( placement.id );
-			if ( moved ) {
-				setTilePosition( tile, moved.x, moved.y );
-			}
-			attachTileDrag( tile, placement, folderId );
-			attachContextMenu( tile, placement );
-			attachSelectOnClick( tile, placement );
-			// Folder tiles also accept drag-out drops — dropping a
-			// post (or any shortcut payload) on a folder icon files
-			// the shortcut INTO that folder rather than next to the
-			// folder on the wallpaper.
-			if ( placement.file.type === 'folder' ) {
-				const targetFolderId = parseInt( placement.file.ref, 10 );
-				if ( targetFolderId > 0 ) {
-					const dragManager = getDragManager();
-					if ( dragManager ) {
-						const deregister = registerFolderDropTarget(
-							dragManager,
-							tile,
-							targetFolderId,
-							folderId,
-						);
-						folderDropDeregisters.set( placement.id, deregister );
-					}
-				}
-			} else if ( shouldRejectTileDrops( placement ) ) {
-				// Non-folder shortcut tiles (My WordPress, dock
-				// promotions, plugin-registered icons that don't
-				// claim drops themselves) need an explicit reject
-				// claimant. Without one, the hit-test walks PAST
-				// the tile up to the canvas drop target, which
-				// accepts → the user sees the green "Drop here to
-				// move" chip even though the drop would land in
-				// the next free cell (because pinned/occupied
-				// tiles are in the visual-occupied set).
-				//
-				// The Recycle Bin is excluded — `recycle-bin-targets.ts`
-				// registers its OWN trash-accepting drop target on
-				// the bin tile, and the registry overwrites by
-				// element. Stamping a reject claimant here would
-				// hide the trash gesture.
-				const dragManager = getDragManager();
-				if ( dragManager ) {
-					const deregister = dragManager.registerDropTarget( {
-						id: `desktop-mode-files-tile-${ placement.id }-reject`,
-						element: tile,
-						accept: () => false,
-						onDrop: () => {
-							// Unreachable — `accept: false` short-
-							// circuits commit. Defined for the type
-							// contract.
-						},
-					} );
-					tileRejectDeregisters.set( placement.id, deregister );
-				}
-			}
-			container.appendChild( tile );
 		}
 		// If the previously-selected tile is gone (deleted, moved
 		// folders), drop the selection so the right pane can clear.

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -534,10 +534,6 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			return;
 		}
 
-		// Wholesale rebuild — last resort. Pin-flag flips, parent-
-		// folder moves, file-type changes, all land here. Plugins
-		// that want stable decorations re-attach via `tile-rendered`.
-
 		// Wholesale rebuild — last-resort path for transitions the
 		// incremental walker can't handle (pin-flag flips, parent-
 		// folder moves, file-type changes). Plugins that want stable

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1212,6 +1212,19 @@ export interface WpDesktopPublicApi {
 	 */
 	connect: ( targetWindowId: string, opts?: ConnectOptions ) => WindowConnection;
 	/**
+	 * Look up a live `WindowConnection` by id. Returns `null` for
+	 * unknown ids and for ids whose connection has been destroyed.
+	 *
+	 * Companion to {@link HOOKS.CONNECTION_OPENED}, which now also
+	 * carries a `connection` field in its payload — `getConnection`
+	 * is the explicit accessor for cases where the caller has the
+	 * id (e.g. from a stored snapshot, devtools, or a deferred
+	 * handler) but doesn't have a live reference yet.
+	 *
+	 * @since 0.22.0
+	 */
+	getConnection: ( connectionId: string ) => WindowConnection | null;
+	/**
 	 * Cross-window broadcast. Publishes a payload on a topic to
 	 * every window — native or iframe — that has subscribed. The
 	 * canonical built-in topic is `desktop-mode.data-changed`,
@@ -2937,6 +2950,7 @@ function init(): void {
 		dragBridge,
 		dragManager,
 		connect: connectionBridge.connect,
+		getConnection: connectionBridge.getConnection,
 		config,
 	} );
 	installPublicApi( desktopApi );

--- a/src/drag-bridge.ts
+++ b/src/drag-bridge.ts
@@ -148,6 +148,54 @@ function isPayloadRequest( m: unknown ): m is PayloadRequestMsg {
 		( m as { type?: unknown } ).type === 'desktop-mode-drag-payload-request';
 }
 
+/**
+ * Map the legacy Media Library payload shape (no `kind` field, just
+ * the WP attachment record) into the tagged union receivers expect.
+ * Pass-through for already-tagged payloads.
+ */
+function normalizeLegacyPayload(
+	payload: DragBridgePayload,
+): DragBridgePayload {
+	const obj = payload as unknown as { kind?: unknown } & Record<
+		string,
+		unknown
+	>;
+	if (
+		obj.kind === 'attachment' ||
+		obj.kind === 'post' ||
+		obj.kind === 'user'
+	) {
+		return payload;
+	}
+	// Look-alike test for the legacy Media Library payload — id +
+	// url + mime are the three fields the patch always emits. Any
+	// other shape falls through unchanged and the receivers will
+	// drop it on the typed shape check.
+	if (
+		typeof obj.id === 'number' &&
+		typeof obj.url === 'string' &&
+		typeof obj.mime === 'string'
+	) {
+		return {
+			kind: 'attachment',
+			id: obj.id,
+			url: obj.url,
+			title: typeof obj.title === 'string' ? obj.title : '',
+			alt: typeof obj.alt === 'string' ? obj.alt : '',
+			mime: obj.mime,
+			thumbnailUrl:
+				typeof obj.thumbnailUrl === 'string'
+					? obj.thumbnailUrl
+					: undefined,
+			sizes:
+				obj.sizes && typeof obj.sizes === 'object'
+					? ( obj.sizes as Record< string, unknown > )
+					: undefined,
+		};
+	}
+	return payload;
+}
+
 // -----------------------------------------------------------------------
 
 export class DragBridge implements DragBridgeApi {
@@ -219,9 +267,21 @@ export class DragBridge implements DragBridgeApi {
 	};
 
 	private _startDrag( payload: DragBridgePayload ): void {
-		this._payload = payload;
+		// Legacy Media Library patch (`assets/js/media-library-enhanced.js`,
+		// since 0.14.0) emits payloads without a `kind` field — just
+		// `{ id, url, title, alt, mime, sizes, thumbnailUrl }`. Normalize
+		// to the tagged union here so every downstream consumer
+		// (Gutenberg drop-receiver, future plugin receivers) only
+		// has to handle one shape. The shape check is conservative —
+		// missing or non-matching fields fall through to the typed
+		// branch as-is, preserving forward compatibility for plugins
+		// that emit their own legitimate payload kinds.
+		const normalized = normalizeLegacyPayload( payload );
+		this._payload = normalized;
 		document.dispatchEvent(
-			new CustomEvent( DRAG_BRIDGE_EVENTS.START, { detail: { payload } } ),
+			new CustomEvent( DRAG_BRIDGE_EVENTS.START, {
+				detail: { payload: normalized },
+			} ),
 		);
 	}
 

--- a/src/drag-bridge.ts
+++ b/src/drag-bridge.ts
@@ -160,11 +160,7 @@ function normalizeLegacyPayload(
 		string,
 		unknown
 	>;
-	if (
-		obj.kind === 'attachment' ||
-		obj.kind === 'post' ||
-		obj.kind === 'user'
-	) {
+	if ( obj.kind !== undefined && obj.kind !== null ) {
 		return payload;
 	}
 	// Look-alike test for the legacy Media Library payload — id +

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -56,7 +56,10 @@ import type {
 	DesktopFileDragData,
 	ShortcutDragData,
 } from '../desktop-files/drag-payloads';
-import type { DragBridgePayload } from '../drag-bridge';
+import {
+	DRAG_BRIDGE_EVENTS,
+	type DragBridgePayload,
+} from '../drag-bridge';
 
 const TARGET_ID_PREFIX = 'desktop-mode-iframe-drop-';
 const IFRAME_SELECTOR = 'iframe.desktop-mode-window__iframe';
@@ -272,6 +275,43 @@ export function installIframeDropTargets( dragManager: DragManagerApi ): void {
 	} );
 	document.addEventListener( DRAG_EVENTS.END, () => {
 		onDragEnd();
+	} );
+
+	// Forward cross-frame bridge sessions to every iframe so the
+	// receiver inside (e.g. the Gutenberg drop-receiver) can stash
+	// the payload and use it on its OWN native HTML5 `drop` event.
+	// This is the path that brings the legacy Media Library patch
+	// back to life: media-library-enhanced.js posts
+	// `desktop-mode-drag-start` to the parent, the bridge stores +
+	// normalizes the payload + fires DRAG_BRIDGE_EVENTS.START on
+	// the parent's document, this listener fans the message out to
+	// every iframe, and Gutenberg's receiver inserts the matching
+	// block on drop — without depending on the custom DataTransfer
+	// MIME surviving the cross-iframe hop (which Chromium strips).
+	document.addEventListener( DRAG_BRIDGE_EVENTS.START, ( e ) => {
+		const detail = ( e as CustomEvent ).detail as
+			| { payload?: DragBridgePayload }
+			| undefined;
+		if ( ! detail?.payload ) {
+			return;
+		}
+		const iframes = document.querySelectorAll< HTMLIFrameElement >(
+			IFRAME_SELECTOR,
+		);
+		iframes.forEach( ( iframe ) => {
+			postIntoIframe( iframe, {
+				type: 'desktop-mode-drag-over',
+				payload: detail.payload,
+			} );
+		} );
+	} );
+	document.addEventListener( DRAG_BRIDGE_EVENTS.END, () => {
+		const iframes = document.querySelectorAll< HTMLIFrameElement >(
+			IFRAME_SELECTOR,
+		);
+		iframes.forEach( ( iframe ) => {
+			postIntoIframe( iframe, { type: 'desktop-mode-drag-leave' } );
+		} );
 	} );
 
 	// On WINDOW_CLOSED we don't need to do anything special — if the

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -75,6 +75,138 @@ const _suppressedIframes = new Map< HTMLIFrameElement, string >();
 /** Registered drop-target deregister fns during a drag, keyed by iframe. */
 const _activeRegistrations = new Map< HTMLIFrameElement, DeregisterFn >();
 
+/** Active bridge payload while iframe-to-iframe drag intercept is live. */
+let _bridgeInterceptPayload: DragBridgePayload | null = null;
+let _lastHoveredBridgeIframe: HTMLIFrameElement | null = null;
+
+function suppressIframePointerEventsBridge(): void {
+	const iframes = document.querySelectorAll< HTMLIFrameElement >(
+		IFRAME_SELECTOR,
+	);
+	iframes.forEach( ( iframe ) => {
+		if ( _suppressedIframes.has( iframe ) ) {
+			return;
+		}
+		_suppressedIframes.set( iframe, iframe.style.pointerEvents );
+		iframe.style.pointerEvents = 'none';
+	} );
+}
+
+function restoreIframePointerEvents(): void {
+	_suppressedIframes.forEach( ( prev, iframe ) => {
+		iframe.style.pointerEvents = prev;
+	} );
+	_suppressedIframes.clear();
+}
+
+/**
+ * Find the iframe-window that contains the cursor at the given
+ * client coords. With iframe pointer-events suppressed during a
+ * bridge session, `elementFromPoint` returns the body div *inside*
+ * an iframe-window; walking up to `.desktop-mode-window` and back
+ * down to the iframe child is the reliable resolution path.
+ */
+function findIframeAtCursor(
+	clientX: number,
+	clientY: number,
+): HTMLIFrameElement | null {
+	const el = document.elementFromPoint( clientX, clientY );
+	if ( ! el ) {
+		return null;
+	}
+	const win = el.closest( '.desktop-mode-window' );
+	if ( ! ( win instanceof HTMLElement ) ) {
+		return null;
+	}
+	const iframe = win.querySelector( IFRAME_SELECTOR );
+	return iframe instanceof HTMLIFrameElement ? iframe : null;
+}
+
+const onBridgeDragOver = ( e: DragEvent ): void => {
+	if ( ! _bridgeInterceptPayload ) {
+		return;
+	}
+	e.preventDefault();
+	if ( e.dataTransfer ) {
+		e.dataTransfer.dropEffect = 'copy';
+	}
+	const iframe = findIframeAtCursor( e.clientX, e.clientY );
+	if ( iframe === _lastHoveredBridgeIframe ) {
+		return;
+	}
+	if ( _lastHoveredBridgeIframe ) {
+		postIntoIframe( _lastHoveredBridgeIframe, {
+			type: 'desktop-mode-drag-leave',
+		} );
+	}
+	_lastHoveredBridgeIframe = iframe;
+	if ( iframe ) {
+		postIntoIframe( iframe, {
+			type: 'desktop-mode-drag-over',
+			payload: _bridgeInterceptPayload,
+		} );
+	}
+};
+
+const onBridgeDrop = ( e: DragEvent ): void => {
+	if ( ! _bridgeInterceptPayload ) {
+		return;
+	}
+	e.preventDefault();
+	e.stopPropagation();
+	if ( typeof e.stopImmediatePropagation === 'function' ) {
+		e.stopImmediatePropagation();
+	}
+	const iframe = findIframeAtCursor( e.clientX, e.clientY );
+	const payload = _bridgeInterceptPayload;
+	stopBridgeIntercept();
+	if ( ! iframe ) {
+		return;
+	}
+	const rect = iframe.getBoundingClientRect();
+	postIntoIframe( iframe, {
+		type: 'desktop-mode-drop',
+		payload,
+		position: {
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top,
+		},
+	} );
+};
+
+const onBridgeDragEnd = (): void => {
+	stopBridgeIntercept();
+};
+
+function startBridgeIntercept( payload: DragBridgePayload ): void {
+	if ( _bridgeInterceptPayload ) {
+		_bridgeInterceptPayload = payload;
+		return;
+	}
+	_bridgeInterceptPayload = payload;
+	suppressIframePointerEventsBridge();
+	document.addEventListener( 'dragover', onBridgeDragOver, true );
+	document.addEventListener( 'drop', onBridgeDrop, true );
+	document.addEventListener( 'dragend', onBridgeDragEnd, true );
+}
+
+function stopBridgeIntercept(): void {
+	if ( ! _bridgeInterceptPayload ) {
+		return;
+	}
+	_bridgeInterceptPayload = null;
+	if ( _lastHoveredBridgeIframe ) {
+		postIntoIframe( _lastHoveredBridgeIframe, {
+			type: 'desktop-mode-drag-leave',
+		} );
+		_lastHoveredBridgeIframe = null;
+	}
+	document.removeEventListener( 'dragover', onBridgeDragOver, true );
+	document.removeEventListener( 'drop', onBridgeDrop, true );
+	document.removeEventListener( 'dragend', onBridgeDragEnd, true );
+	restoreIframePointerEvents();
+}
+
 /**
  * Extract the cross-frame `bridgePayload` from a DragManager payload
  * regardless of payload type. Both `'shortcut'` (fresh tile from My
@@ -199,13 +331,19 @@ function onDragStart( payload: unknown ): void {
 		payload,
 	);
 	iframes.forEach( ( iframe ) => {
-		if ( _suppressedIframes.has( iframe ) ) {
-			return;
+		// Suppress pointer-events idempotently. If the bridge
+		// intercept already suppressed this iframe (shell-side
+		// drags fan a bridge-payload through desktop.ts and that
+		// fires DRAG_BRIDGE_EVENTS.START synchronously BEFORE the
+		// DragManager's DRAG_EVENTS.START listener runs here), we
+		// don't want to overwrite the prior-value snapshot — but
+		// we also must NOT early-return: this loop is also the
+		// only place that registers the per-iframe DragManager
+		// drop targets the hit-test needs to land an `onDrop`.
+		if ( ! _suppressedIframes.has( iframe ) ) {
+			_suppressedIframes.set( iframe, iframe.style.pointerEvents );
+			iframe.style.pointerEvents = 'none';
 		}
-		// Snapshot inline pointerEvents so we can restore it on END.
-		// Empty string means "no inline override — use stylesheet".
-		_suppressedIframes.set( iframe, iframe.style.pointerEvents );
-		iframe.style.pointerEvents = 'none';
 
 		// Only register a drop target when the payload is one we know
 		// how to deliver into the iframe (`bridgePayload` present).
@@ -216,6 +354,9 @@ function onDragStart( payload: unknown ): void {
 		// mode (correct UX — the iframe window doesn't want this
 		// payload type).
 		if ( ! isBridgeable ) {
+			return;
+		}
+		if ( _activeRegistrations.has( iframe ) ) {
 			return;
 		}
 		const dropTargetEl = iframe.parentElement;
@@ -277,17 +418,23 @@ export function installIframeDropTargets( dragManager: DragManagerApi ): void {
 		onDragEnd();
 	} );
 
-	// Forward cross-frame bridge sessions to every iframe so the
-	// receiver inside (e.g. the Gutenberg drop-receiver) can stash
-	// the payload and use it on its OWN native HTML5 `drop` event.
-	// This is the path that brings the legacy Media Library patch
-	// back to life: media-library-enhanced.js posts
-	// `desktop-mode-drag-start` to the parent, the bridge stores +
-	// normalizes the payload + fires DRAG_BRIDGE_EVENTS.START on
-	// the parent's document, this listener fans the message out to
-	// every iframe, and Gutenberg's receiver inserts the matching
-	// block on drop — without depending on the custom DataTransfer
-	// MIME surviving the cross-iframe hop (which Chromium strips).
+	// Iframe-to-iframe HTML5 drag intercept. The legacy Media Library
+	// patch (`assets/js/media-library-enhanced.js`) starts a native
+	// HTML5 drag inside `upload.php`, and the user drops on
+	// Gutenberg's nested editor-canvas iframe. Without intervention,
+	// every drag event (dragover / drop) fires INSIDE whichever
+	// iframe the cursor is over and never reaches the parent shell —
+	// the bridge payload is stranded, Gutenberg's own handler
+	// doesn't recognise the drop (Chromium strips the custom MIME
+	// across iframe boundaries), and nothing inserts.
+	//
+	// The fix mirrors the DragManager pattern: while a bridge
+	// session is in flight, suppress `pointer-events` on every
+	// iframe-window. Drag events then fall through to the parent
+	// document, where we can identify which iframe-window the
+	// cursor is over and postMessage `desktop-mode-drop` to its
+	// content window — the same protocol the Gutenberg receiver
+	// already implements for shell-side DragManager drops.
 	document.addEventListener( DRAG_BRIDGE_EVENTS.START, ( e ) => {
 		const detail = ( e as CustomEvent ).detail as
 			| { payload?: DragBridgePayload }
@@ -295,23 +442,10 @@ export function installIframeDropTargets( dragManager: DragManagerApi ): void {
 		if ( ! detail?.payload ) {
 			return;
 		}
-		const iframes = document.querySelectorAll< HTMLIFrameElement >(
-			IFRAME_SELECTOR,
-		);
-		iframes.forEach( ( iframe ) => {
-			postIntoIframe( iframe, {
-				type: 'desktop-mode-drag-over',
-				payload: detail.payload,
-			} );
-		} );
+		startBridgeIntercept( detail.payload );
 	} );
 	document.addEventListener( DRAG_BRIDGE_EVENTS.END, () => {
-		const iframes = document.querySelectorAll< HTMLIFrameElement >(
-			IFRAME_SELECTOR,
-		);
-		iframes.forEach( ( iframe ) => {
-			postIntoIframe( iframe, { type: 'desktop-mode-drag-leave' } );
-		} );
+		stopBridgeIntercept();
 	} );
 
 	// On WINDOW_CLOSED we don't need to do anything special — if the

--- a/src/gutenberg-drop-receiver.ts
+++ b/src/gutenberg-drop-receiver.ts
@@ -293,6 +293,15 @@ function notifyParentOfFailure( reason: string ): void {
 // Message wiring.
 // ---------------------------------------------------------------------
 
+interface DragOverMsg {
+	type: 'desktop-mode-drag-over';
+	payload: DragBridgePayload;
+}
+
+interface DragLeaveMsg {
+	type: 'desktop-mode-drag-leave';
+}
+
 function isDropMsg( m: unknown ): m is DropMsg {
 	if ( ! m || typeof m !== 'object' ) {
 		return false;
@@ -308,15 +317,60 @@ function isDropMsg( m: unknown ): m is DropMsg {
 	return p.kind === 'attachment' || p.kind === 'post' || p.kind === 'user';
 }
 
+function isDragOverMsg( m: unknown ): m is DragOverMsg {
+	if ( ! m || typeof m !== 'object' ) {
+		return false;
+	}
+	const obj = m as { type?: unknown; payload?: unknown };
+	if ( obj.type !== 'desktop-mode-drag-over' ) {
+		return false;
+	}
+	const p = obj.payload as { kind?: unknown } | undefined;
+	if ( ! p || typeof p !== 'object' ) {
+		return false;
+	}
+	return p.kind === 'attachment' || p.kind === 'post' || p.kind === 'user';
+}
+
+function isDragLeaveMsg( m: unknown ): m is DragLeaveMsg {
+	if ( ! m || typeof m !== 'object' ) {
+		return false;
+	}
+	return ( m as { type?: unknown } ).type === 'desktop-mode-drag-leave';
+}
+
+/**
+ * Latest bridge payload broadcast from the parent shell while a
+ * cross-frame drag is in flight. Set on `desktop-mode-drag-over`,
+ * cleared on `-drag-leave` or after a successful insert. Used by
+ * the native HTML5 `drop` handler below to insert the correct
+ * block when Chromium strips the custom `application/x-wp-media-
+ * attachment` MIME on the cross-iframe hop (so Gutenberg's own
+ * drop logic doesn't recognize the payload as a media drop and
+ * silently no-ops).
+ */
+let stashedBridgePayload: DragBridgePayload | null = null;
+
 function install(): void {
 	const expectedOrigin = window.location.origin;
 	window.addEventListener( 'message', ( e: MessageEvent ) => {
 		if ( e.origin !== expectedOrigin ) {
 			return;
 		}
+		if ( isDragOverMsg( e.data ) ) {
+			stashedBridgePayload = e.data.payload;
+			return;
+		}
+		if ( isDragLeaveMsg( e.data ) ) {
+			stashedBridgePayload = null;
+			return;
+		}
 		if ( ! isDropMsg( e.data ) ) {
 			return;
 		}
+		// Explicit `desktop-mode-drop` (DragManager-driven path —
+		// shell-side tile dropped on this iframe's overlay).
+		stashedBridgePayload = null;
 		void performInsert( e.data.payload ).catch( ( err: unknown ) => {
 			const reason = err instanceof Error ? err.message : String( err );
 			// eslint-disable-next-line no-console
@@ -327,6 +381,59 @@ function install(): void {
 			notifyParentOfFailure( reason );
 		} );
 	} );
+
+	// Native HTML5 drop fallback. Fires when an iframe-source drag
+	// (e.g. legacy Media Library patch in `assets/js/media-library-
+	// enhanced.js`) completes inside this Gutenberg iframe. Without
+	// this hook, the cross-iframe DataTransfer loses its custom
+	// `application/x-wp-media-attachment` MIME (Chromium strips
+	// non-standard MIMEs at the iframe boundary) and Gutenberg's
+	// own drop handler can't recognize it as a media drop. We
+	// stash the payload via the bridge START broadcast and use it
+	// here to insert the correct block. Capture phase + stop-
+	// immediate-propagation so we win the race against Gutenberg's
+	// own drop logic and don't double-insert.
+	window.addEventListener(
+		'drop',
+		( e: DragEvent ) => {
+			if ( ! stashedBridgePayload ) {
+				return;
+			}
+			const payload = stashedBridgePayload;
+			stashedBridgePayload = null;
+			e.preventDefault();
+			e.stopPropagation();
+			if ( typeof e.stopImmediatePropagation === 'function' ) {
+				e.stopImmediatePropagation();
+			}
+			void performInsert( payload ).catch( ( err: unknown ) => {
+				const reason = err instanceof Error ? err.message : String( err );
+				// eslint-disable-next-line no-console
+				console.error(
+					'[desktop-mode] Gutenberg drop receiver native-drop insert failed:',
+					err,
+				);
+				notifyParentOfFailure( reason );
+			} );
+		},
+		true, // capture — beat Gutenberg's own drop listeners.
+	);
+	// Allow the drop in the first place. Without preventing dragover,
+	// the browser treats the iframe as a non-drop target and never
+	// fires `drop` at all.
+	window.addEventListener(
+		'dragover',
+		( e: DragEvent ) => {
+			if ( ! stashedBridgePayload ) {
+				return;
+			}
+			e.preventDefault();
+			if ( e.dataTransfer ) {
+				e.dataTransfer.dropEffect = 'copy';
+			}
+		},
+		true,
+	);
 }
 
 install();

--- a/src/gutenberg-drop-receiver.ts
+++ b/src/gutenberg-drop-receiver.ts
@@ -351,6 +351,92 @@ function isDragLeaveMsg( m: unknown ): m is DragLeaveMsg {
  */
 let stashedBridgePayload: DragBridgePayload | null = null;
 
+interface AttachedDocSentinel extends Document {
+	__desktopModeDropReceiverAttached?: boolean;
+}
+
+// Diagnostic counters — surfaced via the debug helper below so we
+// can immediately see at runtime which side of the pipeline is
+// reaching the user and which is silent.
+const _debugCounters = {
+	dragOverMsgs: 0,
+	dragLeaveMsgs: 0,
+	nativeDrops: 0,
+	nativeDropsWithStash: 0,
+	docsAttached: 0,
+};
+
+function onNativeDrop( e: DragEvent ): void {
+	_debugCounters.nativeDrops++;
+	if ( ! stashedBridgePayload ) {
+		return;
+	}
+	_debugCounters.nativeDropsWithStash++;
+	const payload = stashedBridgePayload;
+	stashedBridgePayload = null;
+	e.preventDefault();
+	e.stopPropagation();
+	if ( typeof e.stopImmediatePropagation === 'function' ) {
+		e.stopImmediatePropagation();
+	}
+	void performInsert( payload ).catch( ( err: unknown ) => {
+		const reason = err instanceof Error ? err.message : String( err );
+		// eslint-disable-next-line no-console
+		console.error(
+			'[desktop-mode] Gutenberg drop receiver native-drop insert failed:',
+			err,
+		);
+		notifyParentOfFailure( reason );
+	} );
+}
+
+function onNativeDragOver( e: DragEvent ): void {
+	if ( ! stashedBridgePayload ) {
+		return;
+	}
+	e.preventDefault();
+	if ( e.dataTransfer ) {
+		e.dataTransfer.dropEffect = 'copy';
+	}
+}
+
+/**
+ * Attach native HTML5 `drop` + `dragover` listeners to a Document
+ * (the outer post.php iframe AND every nested same-origin iframe
+ * inside it — Gutenberg's editor canvas runs in a sub-iframe so
+ * drops on the canvas never reach `window` of the outer iframe
+ * where this script runs).
+ *
+ * Idempotent — each document is marked with a sentinel so repeated
+ * walks don't pile up listeners.
+ */
+function attachToDocument( doc: Document ): void {
+	const sentinel = doc as AttachedDocSentinel;
+	if ( sentinel.__desktopModeDropReceiverAttached ) {
+		return;
+	}
+	sentinel.__desktopModeDropReceiverAttached = true;
+	doc.addEventListener( 'drop', onNativeDrop, true );
+	doc.addEventListener( 'dragover', onNativeDragOver, true );
+	_debugCounters.docsAttached++;
+}
+
+function attachToAllFrames(): void {
+	attachToDocument( document );
+	document
+		.querySelectorAll< HTMLIFrameElement >( 'iframe' )
+		.forEach( ( iframe ) => {
+			try {
+				const innerDoc = iframe.contentDocument;
+				if ( innerDoc ) {
+					attachToDocument( innerDoc );
+				}
+			} catch {
+				// Cross-origin sub-iframe — can't access; skip.
+			}
+		} );
+}
+
 function install(): void {
 	const expectedOrigin = window.location.origin;
 	window.addEventListener( 'message', ( e: MessageEvent ) => {
@@ -359,10 +445,12 @@ function install(): void {
 		}
 		if ( isDragOverMsg( e.data ) ) {
 			stashedBridgePayload = e.data.payload;
+			_debugCounters.dragOverMsgs++;
 			return;
 		}
 		if ( isDragLeaveMsg( e.data ) ) {
 			stashedBridgePayload = null;
+			_debugCounters.dragLeaveMsgs++;
 			return;
 		}
 		if ( ! isDropMsg( e.data ) ) {
@@ -382,58 +470,41 @@ function install(): void {
 		} );
 	} );
 
-	// Native HTML5 drop fallback. Fires when an iframe-source drag
-	// (e.g. legacy Media Library patch in `assets/js/media-library-
-	// enhanced.js`) completes inside this Gutenberg iframe. Without
-	// this hook, the cross-iframe DataTransfer loses its custom
-	// `application/x-wp-media-attachment` MIME (Chromium strips
-	// non-standard MIMEs at the iframe boundary) and Gutenberg's
-	// own drop handler can't recognize it as a media drop. We
-	// stash the payload via the bridge START broadcast and use it
-	// here to insert the correct block. Capture phase + stop-
-	// immediate-propagation so we win the race against Gutenberg's
-	// own drop logic and don't double-insert.
-	window.addEventListener(
-		'drop',
-		( e: DragEvent ) => {
-			if ( ! stashedBridgePayload ) {
-				return;
-			}
-			const payload = stashedBridgePayload;
-			stashedBridgePayload = null;
-			e.preventDefault();
-			e.stopPropagation();
-			if ( typeof e.stopImmediatePropagation === 'function' ) {
-				e.stopImmediatePropagation();
-			}
-			void performInsert( payload ).catch( ( err: unknown ) => {
-				const reason = err instanceof Error ? err.message : String( err );
-				// eslint-disable-next-line no-console
-				console.error(
-					'[desktop-mode] Gutenberg drop receiver native-drop insert failed:',
-					err,
-				);
-				notifyParentOfFailure( reason );
-			} );
-		},
-		true, // capture — beat Gutenberg's own drop listeners.
-	);
-	// Allow the drop in the first place. Without preventing dragover,
-	// the browser treats the iframe as a non-drop target and never
-	// fires `drop` at all.
-	window.addEventListener(
-		'dragover',
-		( e: DragEvent ) => {
-			if ( ! stashedBridgePayload ) {
-				return;
-			}
-			e.preventDefault();
-			if ( e.dataTransfer ) {
-				e.dataTransfer.dropEffect = 'copy';
+	// Attach now (covers the outer post.php iframe + any sub-
+	// iframes already in the DOM at script-run time). Then mount a
+	// MutationObserver so any iframe Gutenberg adds later (its
+	// editor-canvas iframe lands on first paint, sometimes after
+	// our boot) is picked up. Also re-walk on iframe `load` since
+	// reloading a nested iframe replaces its document and clears
+	// our sentinel.
+	attachToAllFrames();
+	if ( typeof MutationObserver !== 'undefined' && document.documentElement ) {
+		new MutationObserver( () => attachToAllFrames() ).observe(
+			document.documentElement,
+			{ childList: true, subtree: true },
+		);
+	}
+	document.addEventListener(
+		'load',
+		( e: Event ) => {
+			if ( e.target instanceof HTMLIFrameElement ) {
+				attachToAllFrames();
 			}
 		},
 		true,
 	);
+
+	// Diagnostic surface — paste `window.__desktopModeDropReceiverDebug()`
+	// in DevTools (inside the post.php iframe) to inspect.
+	type DebugWindow = Window & {
+		__desktopModeDropReceiverDebug?: () => Record< string, unknown >;
+	};
+	( window as DebugWindow ).__desktopModeDropReceiverDebug = () => ( {
+		..._debugCounters,
+		hasStash: stashedBridgePayload !== null,
+		stashKind: stashedBridgePayload?.kind ?? null,
+		iframesNow: document.querySelectorAll( 'iframe' ).length,
+	} );
 }
 
 install();

--- a/src/iframe-bridge-standalone.ts
+++ b/src/iframe-bridge-standalone.ts
@@ -79,6 +79,57 @@ interface IframeApi {
 		opts: RequestConnectionOptions,
 	): Promise< ConnectionRecord >;
 	chrome: IframeChromeApi;
+	/**
+	 * The id of the window the parent shell opened to host this
+	 * iframe. Populated after the first connection handshake from
+	 * the parent (the handshake message now carries
+	 * `targetWindowId`). `null` until then.
+	 *
+	 * Replaces the brittle `iframe.contentWindow ===` walk plugins
+	 * had to do parent-side; iframe code can now self-identify
+	 * (e.g. `wp.desktop.iframe.publish('focus-changed', {windowId:
+	 * wp.desktop.iframe.windowId})`).
+	 *
+	 * @since 0.22.0
+	 */
+	readonly windowId: string | null;
+	/**
+	 * Resolve once `windowId` is populated by the first handshake.
+	 * Resolves immediately if already known.
+	 *
+	 * @since 0.22.0
+	 */
+	whenWindowId(): Promise< string >;
+	/**
+	 * Whether the parent frame is same-origin and reachable. All
+	 * bridge messages (handshakes, publishes, drag-bridge, OS-file
+	 * forwarder) hard-filter on `window.location.origin`; a cross-
+	 * origin parent silently drops everything we post. Use this
+	 * predicate to fail fast / degrade gracefully instead of
+	 * debugging vanishing messages:
+	 *
+	 * ```js
+	 * if ( ! wp.desktop.iframe.isParentReachable() ) {
+	 *     // Cross-origin parent — bridge can't operate. Fall back
+	 *     // to in-iframe UI or skip the feature entirely.
+	 *     return;
+	 * }
+	 * ```
+	 *
+	 * Returns `true` when:
+	 *   - There IS a parent (we're in an iframe, not the top frame).
+	 *   - The parent's origin matches ours (same-origin).
+	 *
+	 * Returns `false` when:
+	 *   - Top frame (`window.parent === window`).
+	 *   - Parent is cross-origin (accessing `window.parent.location`
+	 *     throws). Includes most Gutenberg `srcdoc` canvases that
+	 *     inherited a different origin, sandboxed iframes, PWA
+	 *     wrappers loading desktop-mode in a foreign frame.
+	 *
+	 * @since 0.22.0
+	 */
+	isParentReachable(): boolean;
 }
 
 type WindowChannelCb = (
@@ -111,6 +162,29 @@ interface IframeWp {
 	const connections: Record< string, ConnectionRecord > = {};
 	const connectionListeners: ConnectionListenerCb[] = [];
 	const subs: Record< string, SubscriberCb[] > = {};
+
+	/**
+	 * The host window's id, learned from the first
+	 * `desktop-mode-bridge-handshake` the parent sends. `null` until
+	 * the parent connects; resolves through
+	 * {@link IframeApi.whenWindowId} for callers that need a wait.
+	 */
+	let _windowId: string | null = null;
+	const _windowIdWaiters: Array< ( id: string ) => void > = [];
+	const _setWindowId = ( id: string ): void => {
+		if ( ! id || _windowId === id ) {
+			return;
+		}
+		_windowId = id;
+		const waiters = _windowIdWaiters.splice( 0 );
+		for ( const waiter of waiters ) {
+			try {
+				waiter( id );
+			} catch {
+				/* swallow */
+			}
+		}
+	};
 
 	/**
 	 * Per-channel subscribers for the unified window-channel API
@@ -162,6 +236,14 @@ interface IframeWp {
 			data.type === 'desktop-mode-bridge-handshake' &&
 			typeof data.connectionId === 'string'
 		) {
+			// The parent's handshake carries the host window id since
+			// 0.22.0. Stash it so `wp.desktop.iframe.windowId` and
+			// `whenWindowId()` can serve callers that need to know
+			// which native window opened this iframe.
+			const tw = ( data as { targetWindowId?: unknown } ).targetWindowId;
+			if ( typeof tw === 'string' && tw !== '' ) {
+				_setWindowId( tw );
+			}
 			if ( connections[ data.connectionId ] ) {
 				try {
 					window.parent.postMessage(
@@ -277,7 +359,21 @@ interface IframeWp {
 			if ( typeof topic !== 'string' || topic === '' ) {
 				return;
 			}
-			for ( const id of Object.keys( connections ) ) {
+			const ids = Object.keys( connections );
+			if ( ids.length === 0 ) {
+				// Silent no-op was a recurring footgun: plugin authors
+				// publishing before any parent-side `connect()` lands
+				// see nothing happen, no error, no warn. Emit a
+				// console.warn so the missing-handshake case is at
+				// least discoverable in DevTools.
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[desktop-mode] wp.desktop.iframe.publish dropped: no open connection for topic "%s". The parent shell must call `wp.desktop.connect(windowId)` first.',
+					topic,
+				);
+				return;
+			}
+			for ( const id of ids ) {
 				emitToParent( id, topic, payload );
 			}
 		},
@@ -469,6 +565,32 @@ interface IframeWp {
 					settle( false, err as Error );
 				}
 			} );
+		},
+		get windowId() {
+			return _windowId;
+		},
+		whenWindowId(): Promise< string > {
+			if ( _windowId !== null ) {
+				return Promise.resolve( _windowId );
+			}
+			return new Promise< string >( ( resolve ) => {
+				_windowIdWaiters.push( resolve );
+			} );
+		},
+		isParentReachable(): boolean {
+			if ( ! window.parent || window.parent === window ) {
+				return false;
+			}
+			try {
+				// Cross-origin parents throw on `.location.origin`
+				// access. Same-origin parents return a string we can
+				// compare to our own origin to confirm the bridge
+				// will actually accept our messages.
+				const parentOrig = window.parent.location.origin;
+				return parentOrig === parentOrigin;
+			} catch {
+				return false;
+			}
 		},
 	};
 
@@ -674,6 +796,28 @@ interface IframeWp {
 			},
 			true,
 		);
+	}
+
+	/*
+	 * Bridge-ready signal. Every listener installed by this bundle
+	 * is now wired; let the parent shell know so it can fire
+	 * `HOOKS.IFRAME_READY` and re-arm any connection handshakes
+	 * (`src/connection/index.ts#onIframeReady`) that arrived before
+	 * we were listening. Symmetric with the inline chromeless
+	 * bridge in `includes/render/chromeless-bridge.php` — both
+	 * iframe-side entry points emit the same message so the parent
+	 * sees a uniform "iframe wired" signal regardless of which
+	 * bridge is in play.
+	 */
+	try {
+		if ( window.parent && window.parent !== window ) {
+			window.parent.postMessage(
+				{ type: 'desktop-mode-ready' },
+				parentOrigin,
+			);
+		}
+	} catch {
+		/* cross-origin parent; swallow */
 	}
 
 	function installScreenMetaHoist( origin: string ): void {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -2152,6 +2152,52 @@ export class Window {
 	}
 
 	/**
+	 * Resolve when this window's content is ready to receive sends.
+	 * Returns a Promise that resolves immediately for windows that
+	 * are already ready, and otherwise waits for the next
+	 * {@link HOOKS.WINDOW_CONTENT_LOADED} matching this window's id.
+	 *
+	 * Backstop for the iframe bridge handshake race: plugin authors
+	 * coordinating with an `iframeContent: { bridge: true }` native
+	 * window can `await win.whenContentReady()` before issuing the
+	 * first send/connect, instead of wiring iframe.load themselves
+	 * or hoping that {@link HOOKS.IFRAME_READY} has fired by their
+	 * boot.
+	 *
+	 * Resolves regardless of whether the content path was an iframe
+	 * `load`, the chromeless `desktop-mode-ready` postMessage, or a
+	 * native render's synchronous `markContentLoaded()` — all three
+	 * end up calling {@link markWindowContentReady}.
+	 *
+	 * @public
+	 * @since 0.22.0
+	 */
+	public whenContentReady(): Promise< void > {
+		if ( isWindowContentReady( this.id ) ) {
+			return Promise.resolve();
+		}
+		return new Promise< void >( ( resolve ) => {
+			const expectedId = this.id;
+			const onLoaded = ( e: Event ): void => {
+				const detail = ( e as CustomEvent< { windowId?: string } > )
+					.detail;
+				if ( ! detail || detail.windowId !== expectedId ) {
+					return;
+				}
+				document.removeEventListener(
+					'desktop-mode-window-content-loaded',
+					onLoaded,
+				);
+				resolve();
+			};
+			document.addEventListener(
+				'desktop-mode-window-content-loaded',
+				onLoaded,
+			);
+		} );
+	}
+
+	/**
 	 * Set the activity indicator's phase explicitly. Most callers
 	 * should prefer {@link trackActivity} (or `wp.desktop.fetch()`
 	 * which calls it internally) — this is the escape hatch for code


### PR DESCRIPTION
## Summary

Eliminates the visible "desktop just reloaded" flash on file creation, shortcut drop on the wallpaper, and tile deletion. The renderer used to fall through to a wholesale `container.replaceChildren()` rebuild for any structural change, repainting every tile from scratch even when only one had appeared or disappeared.

Adds a middle render path (`tryPatchIncremental`) between the existing position-only fast path and the wholesale rebuild:

1. **`tryPatchPositions`** — same set, only X/Y changed (drag-within-folder, auto-arrange). Unchanged.
2. **`tryPatchIncremental` (new)** — adds and/or removes, no structural changes on shared tiles. Surgically removes gone tiles (with their drop-target deregistrations) and appends new ones (fully wired). DOM identity preserved for everything unchanged.
3. **Wholesale rebuild** — last resort for pin-flag flips, parent-folder moves, file-type changes. Still nukes + rebuilds, since those each need full re-wiring.

## Why this is safe

- Per-tile setup is now in a single `wireTile()` helper, called by both the wholesale rebuild and the incremental path. No risk of drift between paths.
- Pinned-slot allocation + displacement (`computeLayout()`) is the same function feeding all three paths — layouts are bit-identical.
- The incremental path bails (returns `false`, falls through to wholesale) on any shared tile whose `data-file-type`, `data-file-ref`, or pinned flag differs from the new placement. That's the same conservative gate `tryPatchPositions` already uses; it just relaxes the same-set requirement.
- Selection bookkeeping (drop selection when the selected tile is removed) is mirrored from the wholesale path.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test:js` — 1485 passing (no test changes; existing covers the fingerprint + tryPatchPositions surface)
- [x] `npm run build:desktop` clean (~+1KB on desktop.min.js, accounted for by the new helper)
- [ ] Manual: create a folder via the wallpaper context menu — no flash, new folder fades in alone
- [ ] Manual: drag a post tile out of My WordPress onto the wallpaper — no flash, just the new shortcut tile
- [ ] Manual: right-click a tile → Move to Recycle Bin — no flash, only that tile disappears
- [ ] Manual: drag a tile inside the wallpaper — still smooth (position-only fast path still hits)
- [ ] Manual: Sort By / Clean Up — still smooth (still hits tryPatchPositions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-262-e3867b6b7b3d42979b05e57bdc8affb637d97ba7.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->