### PR TITLE
fix(plugins-window): align dock badge with in-window update count (#258)

### DIFF
--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -68,6 +68,24 @@ function desktop_mode_build_dock_items() {
 			$badge = (int) $matches[1];
 		}
 
+		// The Plugins menu badge in `wp-admin/menu.php` is built from
+		// `count( $update_plugins->response )` — a raw transient count
+		// that can include orphan rows (deleted plugin files, entries
+		// injected by third-party update servers for plugins that
+		// aren't installed locally). Our Plugins window's "Update
+		// available" filter only counts updates whose key intersects
+		// `get_plugins()`, because every row in the window comes from
+		// REST `/wp/v2/plugins` which iterates `get_plugins()`.
+		// Recompute the dock badge from the same intersection so the
+		// dock count always agrees with what the window shows (GH#258).
+		if (
+			'plugins.php' === $item[2] &&
+			! is_multisite() &&
+			function_exists( 'desktop_mode_plugins_window_count_visible_updates' )
+		) {
+			$badge = desktop_mode_plugins_window_count_visible_updates();
+		}
+
 		// Determine the icon. Menu entries can set `$item[6]` to anything
 		// — a dashicon class, a remote URL, a data:URI, 'none', or 'div'
 		// — so normalize before we serialize it for the shell JS.

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -355,9 +355,8 @@ function desktop_mode_plugins_window_field_update_available( $row ) {
  * menu title (the source the dock-builder regex captures). That raw
  * count can drift above the in-window "Update available" filter when
  * the transient holds orphan entries — rows for plugin files that no
- * longer exist on disk, or rows injected by third-party update servers
- * (`update_plugins_{hostname}` filter, custom `site_transient_update_plugins`
- * filters) that key on a file `get_plugins()` doesn't return.
+ * longer exist on disk, or rows injected via the standard `Update URI`
+ * mechanism that key on a file `get_plugins()` doesn't return.
  *
  * The Plugins window iterates `get_plugins()` via REST and shows each
  * row as updatable iff `update_plugins->response[ $plugin_file ]` is

--- a/includes/plugins-window/rest-fields.php
+++ b/includes/plugins-window/rest-fields.php
@@ -346,6 +346,53 @@ function desktop_mode_plugins_window_field_update_available( $row ) {
 }
 
 /**
+ * Count plugin updates visible to the Plugins window — i.e. updates in
+ * the `update_plugins` site transient whose key corresponds to an
+ * actually-installed plugin file (`get_plugins()`).
+ *
+ * Core's `wp_get_update_data()` reports `count( $update_plugins->response )`
+ * verbatim, which is what `wp-admin/menu.php` embeds in the Plugins
+ * menu title (the source the dock-builder regex captures). That raw
+ * count can drift above the in-window "Update available" filter when
+ * the transient holds orphan entries — rows for plugin files that no
+ * longer exist on disk, or rows injected by third-party update servers
+ * (`update_plugins_{hostname}` filter, custom `site_transient_update_plugins`
+ * filters) that key on a file `get_plugins()` doesn't return.
+ *
+ * The Plugins window iterates `get_plugins()` via REST and shows each
+ * row as updatable iff `update_plugins->response[ $plugin_file ]` is
+ * set — exactly the intersection we compute here. Using this count for
+ * the dock badge guarantees the two surfaces agree (GH#258).
+ *
+ * @since 0.8.8
+ *
+ * @return int Number of installed plugins with a pending update.
+ */
+function desktop_mode_plugins_window_count_visible_updates() {
+	$updates = get_site_transient( 'update_plugins' );
+	if ( ! is_object( $updates ) || empty( $updates->response ) || ! is_array( $updates->response ) ) {
+		return 0;
+	}
+
+	// `get_plugins()` lives in `wp-admin/includes/plugin.php`. Loaded by
+	// default on every admin request (which is where `$menu` is built),
+	// but require it explicitly so REST + cron + WP-CLI callers can use
+	// this helper without depending on the admin runtime.
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$installed = get_plugins();
+
+	$count = 0;
+	foreach ( array_keys( $updates->response ) as $plugin_file ) {
+		if ( isset( $installed[ $plugin_file ] ) ) {
+			++$count;
+		}
+	}
+	return $count;
+}
+
+/**
  * `desktop_mode_can_manage` callback.
  *
  * Per-row cap surface so the JS UI can hide actions the viewer can't

--- a/tests/phpunit/tests/desktopModeBuildDockItems.php
+++ b/tests/phpunit/tests/desktopModeBuildDockItems.php
@@ -114,9 +114,54 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 	 * Update badges live inside <span class="update-plugins count-N"> in
 	 * the title HTML. The builder must extract the count and strip the
 	 * span from the visible title.
+	 *
+	 * Uses the Themes menu rather than Plugins because the Plugins entry
+	 * gets a recomputed-from-transient override (see
+	 * `test_plugins_dock_badge_recomputed_from_installed_plugin_intersection`)
+	 * — `themes.php` exercises the plain regex path.
 	 */
 	public function test_extracts_update_badge_and_strips_span_from_title() {
 		global $menu;
+		$menu = array(
+			array(
+				'Appearance <span class="update-plugins count-3"><span class="theme-count">3</span></span>',
+				'switch_themes',
+				'themes.php',
+				'',
+				'',
+				'menu-appearance',
+				'dashicons-admin-appearance',
+			),
+		);
+
+		$items = desktop_mode_build_dock_items();
+
+		$this->assertSame( 'Appearance', $items[0]['title'] );
+		$this->assertSame( 3, $items[0]['badge'] );
+	}
+
+	/**
+	 * The Plugins menu badge is built by Core from
+	 * `count( $update_plugins->response )` — a raw transient count that
+	 * can drift above the in-window "Update available" filter when the
+	 * transient holds orphan entries (deleted plugin files, rows
+	 * injected by third-party update servers that key on a file
+	 * `get_plugins()` doesn't return).
+	 *
+	 * The dock builder must recompute the badge for `plugins.php` as
+	 * the intersection of the transient with `get_plugins()` so the
+	 * dock count agrees with the Plugins window — fixes GH#258.
+	 */
+	public function test_plugins_dock_badge_recomputed_from_installed_plugin_intersection() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Plugins menu badge is suppressed on multisite by Core.' );
+		}
+
+		global $menu;
+		// Title carries `count-3` even though only one of the three
+		// transient rows corresponds to an installed plugin
+		// (`desktop-mode/desktop-mode.php`). The other two are orphans
+		// — exactly the shape that produced GH#258.
 		$menu = array(
 			array(
 				'Plugins <span class="update-plugins count-3"><span class="plugin-count">3</span></span>',
@@ -129,10 +174,70 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 			),
 		);
 
-		$items = desktop_mode_build_dock_items();
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$installed = get_plugins();
+		// Sanity check: the test environment includes desktop-mode itself.
+		$this->assertArrayHasKey( 'desktop-mode/desktop-mode.php', $installed );
 
-		$this->assertSame( 'Plugins', $items[0]['title'] );
-		$this->assertSame( 3, $items[0]['badge'] );
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'last_checked' => time(),
+				'response'     => array(
+					'desktop-mode/desktop-mode.php'   => (object) array(
+						'new_version' => '999.0.0',
+						'package'     => '',
+						'slug'        => 'desktop-mode',
+					),
+					'orphan-one/orphan-one.php'       => (object) array(
+						'new_version' => '1.0.0',
+						'package'     => '',
+						'slug'        => 'orphan-one',
+					),
+					'orphan-two/orphan-two.php'       => (object) array(
+						'new_version' => '1.0.0',
+						'package'     => '',
+						'slug'        => 'orphan-two',
+					),
+				),
+			)
+		);
+
+		try {
+			$items = desktop_mode_build_dock_items();
+			$this->assertSame( 1, $items[0]['badge'] );
+		} finally {
+			delete_site_transient( 'update_plugins' );
+		}
+	}
+
+	/**
+	 * When the `update_plugins` transient is unset / empty, the Plugins
+	 * dock badge falls through to zero — the regex-captured value is
+	 * ignored because the override is authoritative.
+	 */
+	public function test_plugins_dock_badge_is_zero_when_transient_is_empty() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Plugins menu badge is suppressed on multisite by Core.' );
+		}
+
+		global $menu;
+		$menu = array(
+			array(
+				'Plugins <span class="update-plugins count-2"><span class="plugin-count">2</span></span>',
+				'activate_plugins',
+				'plugins.php',
+				'',
+				'',
+				'menu-plugins',
+				'dashicons-admin-plugins',
+			),
+		);
+
+		delete_site_transient( 'update_plugins' );
+
+		$items = desktop_mode_build_dock_items();
+		$this->assertSame( 0, $items[0]['badge'] );
 	}
 
 	public function test_no_badge_when_count_class_missing() {


### PR DESCRIPTION
## Summary

Closes #258.

The Plugins dock badge could show a higher count than the "Update available" filter inside the Plugins window (reporter saw badge=3, filter=2, persistent across hard reload).

**Root cause.** The dock badge is regex-extracted from `$menu['plugins.php']` title HTML, which Core builds from `count( $update_plugins->response )` — the raw transient count. The in-window filter counts REST `/wp/v2/plugins` rows where `desktop_mode_update_available.available === true`, which is set only when the transient entry maps to a plugin file `get_plugins()` returns. They drift when the transient holds orphan rows — entries for deleted plugin files, or rows injected by third-party update servers that key on a file `get_plugins()` doesn't return. The reporter's site runs Bricks + Admin Columns Pro, both of which use that pattern.

**Fix.** Override the badge for `plugins.php` with the intersection of `update_plugins->response` and `get_plugins()` — the same intersection the REST endpoint already applies.

- New helper `desktop_mode_plugins_window_count_visible_updates()` in `rest-fields.php` next to the related transient logic.
- `desktop_mode_build_dock_items()` calls it for the `plugins.php` slug after the regex extraction (the regex stays as a fallback for the generic case).
- Two new PHPUnit tests: orphan-stripping and empty-transient → 0. Existing regex-extraction test moved to `themes.php` so it still exercises the generic path.

## Reproduction (verified live)

Seeded `update_plugins` with 3 rows where only one (`crowdsignal-forms/crowdsignal-forms.php`) matched `get_plugins()`. Without the override the dock badge rendered `3` while the window filter showed `Update available 1`. With the override the badge correctly rendered `1`.

```
WP menu badge would render: 3
Plugins window filter would render: 1
```

## Test plan

- [x] `npm run test:php -- --filter='Tests_DesktopMode_BuildDockItems'` passes (new + existing).
- [x] On an install with at least one plugin updating: dock badge equals the count in the Plugins window's "Update available" filter.
- [x] Plant an orphan in `update_plugins` (`docker exec ... wp eval 'set_site_transient("update_plugins", …);'`), hard reload → badge does not over-count.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-263-ce055b10584e42bc565768178ef1f83b33455f3b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->