### PR TITLE
fix(dock): make every dock scrollable, keep system tiles pinned

### DIFF
--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -575,7 +575,12 @@
 	max-width: calc( 100% - 32px );
 	flex-direction: row;
 	justify-content: center;
-	padding: 8px 12px;
+	/* Top padding is 4px instead of 8px so that the inner `__scroll`
+	 * wrapper can claim its own 4px padding-top for badge clearance
+	 * (the tile's badge sits at top: -3px). Net vertical chrome stays
+	 * symmetric: 4px pill padding + 4px wrapper padding above the
+	 * tile, 8px pill padding below — tile is 8px from both edges. */
+	padding: 4px 12px 8px;
 	gap: 6px;
 	border-radius: 18px;
 
@@ -629,12 +634,53 @@
 	transform: scale( 1.1 );
 }
 
-/* Separator — vertical hairline between menu tiles and system tiles,
- * with margin-inline-start: auto pushing system items to the end.
- * The `--group` variant keeps the hairline styling for the inline
- * core→plugin boundary but drops the auto margin so it sits where
- * inserted. Tighter margin than the auto variant so the two groups
- * read as related rather than completely isolated. */
+/*
+ * Bottom-dock inner wrappers — `__scroll` carries the menu tiles and
+ * absorbs horizontal overflow; `__pinned` carries the system tiles and
+ * stays anchored to the trailing edge. Padding-top on `__scroll` gives
+ * the badge (top: -3px on the tile) room so `overflow-y: hidden`
+ * doesn't crop it. `min-width: 0` lets the wrapper shrink below its
+ * content's natural width, so the dock pill's `max-width` is what
+ * decides when scroll kicks in instead of the content forcing the
+ * pill wider. `justify-content: center` keeps tiles balanced inside
+ * the pill when content fits; when it overflows, scroll engages and
+ * items extend past the visible area.
+ */
+.desktop-mode-dock[ data-desktop-mode-dock-placement="bottom" ] .desktop-mode-dock__scroll {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	flex: 1 1 auto;
+	min-width: 0;
+	padding-top: 4px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: none;
+}
+
+.desktop-mode-dock[ data-desktop-mode-dock-placement="bottom" ] .desktop-mode-dock__scroll::-webkit-scrollbar {
+	display: none;
+}
+
+.desktop-mode-dock[ data-desktop-mode-dock-placement="bottom" ] .desktop-mode-dock__pinned {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	/* Match the scroll wrapper's badge clearance so system tiles sit
+	 * on the same vertical baseline as the menu tiles. */
+	padding-top: 4px;
+}
+
+/* Separator — vertical hairline between menu tiles and system tiles.
+ * Lives at the leading edge of `__pinned`; flex flow handles the
+ * "pinned at the trailing edge" placement, no margin-inline-start:
+ * auto needed. The `--group` variant keeps the hairline styling for
+ * the inline core→plugin boundary inside `__scroll` and sits where
+ * inserted. */
 .desktop-mode-dock[ data-desktop-mode-dock-placement="bottom" ]
 	.desktop-mode-dock__separator {
 	width: 1px;
@@ -643,7 +689,6 @@
 	   28px matches the dock tile inner glyph area. */
 	height: 28px;
 	margin: auto 4px auto 8px;
-	margin-inline-start: auto;
 	background: var( --desktop-mode-dock-border );
 	flex-shrink: 0;
 }

--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -27,9 +27,10 @@
 	flex-shrink: 0;
 	/*
 	 * overflow: visible so the per-tile "Open another" chip can float
-	 * past the dock's outer edge. Real-world menus fit the viewport
-	 * without a scrollbar; if this ever needs to scroll, wrap tiles
-	 * in a scroll container rather than clipping here.
+	 * past the dock's outer edge. Real-world bottom-dock menus fit
+	 * the viewport without a scrollbar; vertical placements route
+	 * their overflow through the inner `__scroll` wrapper, leaving
+	 * the dock itself non-scrolling.
 	 */
 	overflow: visible;
 }
@@ -335,6 +336,68 @@
 	flex-direction: column;
 	padding: 16px 0 12px;
 	gap: 6px;
+	/*
+	 * Vertical docks split into two inner wrappers:
+	 *   - `__scroll`  — flex: 1, scrollable, hosts menu tiles + the
+	 *                   inline core/plugin separator. When the menu
+	 *                   exceeds the dock's height, this is what
+	 *                   scrolls; the outer dock stays a fixed pillar.
+	 *   - `__pinned`  — sized to content, hosts system tiles
+	 *                   (Recycle Bin, OS Settings, …) + their hairline
+	 *                   separator. Always visible at the bottom edge
+	 *                   regardless of scroll position.
+	 *
+	 * `min-height: 0` on the dock is defensive: even though `__scroll`
+	 * absorbs the overflow, the dock is a flex item inside the shell
+	 * body (a flex row), and the default `min-height: auto` would let
+	 * a tall `__pinned` push the dock past the parent's height.
+	 */
+	min-height: 0;
+}
+
+/*
+ * Scrollable menu-tile area inside vertical docks. `flex: 1 1 0` plus
+ * `min-height: 0` lets it shrink below its content's natural height so
+ * `overflow-y: auto` actually engages. `overflow-x: clip` keeps the
+ * active-dot / focused-pill indicators visible (they sit at x≈2px
+ * inside the wrapper's content box) while preventing `overflow-y: auto`
+ * from coercing horizontal scroll. Scrollbar is hidden visually —
+ * Firefox via `scrollbar-width: none`, WebKit via the pseudo-element
+ * rule below — so the rail keeps its clean macOS look. Mouse wheel,
+ * touchpad, touch, and keyboard focus-into-view all still work.
+ */
+.desktop-mode-dock[ data-desktop-mode-dock-placement="left" ] .desktop-mode-dock__scroll,
+.desktop-mode-dock[ data-desktop-mode-dock-placement="right" ] .desktop-mode-dock__scroll {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	flex: 1 1 0;
+	min-height: 0;
+	width: 100%;
+	overflow-y: auto;
+	overflow-x: clip;
+	scrollbar-width: none;
+}
+
+.desktop-mode-dock[ data-desktop-mode-dock-placement="left" ] .desktop-mode-dock__scroll::-webkit-scrollbar,
+.desktop-mode-dock[ data-desktop-mode-dock-placement="right" ] .desktop-mode-dock__scroll::-webkit-scrollbar {
+	display: none;
+}
+
+/*
+ * Pinned area below `__scroll` — system tiles stay reachable here
+ * regardless of how the menu list scrolls. `flex-shrink: 0` so it's
+ * never compressed; sized to its content's natural height.
+ */
+.desktop-mode-dock[ data-desktop-mode-dock-placement="left" ] .desktop-mode-dock__pinned,
+.desktop-mode-dock[ data-desktop-mode-dock-placement="right" ] .desktop-mode-dock__pinned {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	width: 100%;
 }
 
 /* Left: dock is the first flex item in __body (row layout). */
@@ -417,10 +480,12 @@
 }
 
 /* Separator — horizontal hairline between menu tiles and system
- * tiles, with margin-top: auto pushing system items to the bottom.
- * The `--group` variant is used inline between core and plugin
- * menu tiles; it keeps the hairline styling but drops the auto
- * margin so it sits exactly where it's inserted. */
+ * tiles. With the `__scroll` / `__pinned` split the system separator
+ * lives at the top of `__pinned`; flex-flow handles the "system
+ * tiles at the bottom" placement, no margin-top: auto needed. The
+ * `--group` variant is used inline between core and plugin menu
+ * tiles in `__scroll`; it keeps the hairline styling and sits
+ * exactly where it's inserted. */
 .desktop-mode-dock[ data-desktop-mode-dock-placement="left" ]
 	.desktop-mode-dock__separator,
 .desktop-mode-dock[ data-desktop-mode-dock-placement="right" ]
@@ -430,7 +495,6 @@
 	margin: 8px auto 4px;
 	background: var( --desktop-mode-dock-border );
 	flex-shrink: 0;
-	margin-top: auto;
 }
 
 .desktop-mode-dock[ data-desktop-mode-dock-placement="left" ]
@@ -442,13 +506,23 @@
 }
 
 /*
- * Hide the separator when nothing precedes it. The TS code creates
- * a system / pinned separator before its first cluster item — on a
- * clean install with only system items and no menu items, the
- * separator becomes the dock's first child and would render as a
- * stray hairline with nothing to divide.
+ * Hide the system separator when nothing precedes it — on a clean
+ * install (or a low-cap user with zero menu items) the separator
+ * would render as a stray hairline with nothing to divide.
+ *
+ * Two cases:
+ *   1. Bottom dock — separator is a direct child of the dock; hide
+ *      when it's the first such child.
+ *   2. Vertical docks — separator lives inside `__pinned`; hide when
+ *      `__scroll` (its sibling above) is empty of menu tiles.
  */
-.desktop-mode-dock__separator:first-child {
+.desktop-mode-dock > .desktop-mode-dock__separator:first-child {
+	display: none;
+}
+
+.desktop-mode-dock__scroll:not(:has( .desktop-mode-dock__item ))
+	+ .desktop-mode-dock__pinned
+	.desktop-mode-dock__separator {
 	display: none;
 }
 

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -340,24 +340,21 @@ export class Dock {
 			orientation,
 		);
 
-		// Vertical placements get two inner wrappers so menu tiles can
-		// scroll independently of the system tiles at the bottom. The
-		// outer dock keeps the placement attribute + orientation chrome;
-		// the wrappers carry the actual flow. For the bottom dock no
-		// wrappers — the flat row works as-is.
-		if ( orientation === 'bottom' ) {
-			this.itemHost = container;
-			this.systemHost = container;
-		} else {
-			const scroll = document.createElement( 'div' );
-			scroll.className = 'desktop-mode-dock__scroll';
-			const pinned = document.createElement( 'div' );
-			pinned.className = 'desktop-mode-dock__pinned';
-			container.appendChild( scroll );
-			container.appendChild( pinned );
-			this.itemHost = scroll;
-			this.systemHost = pinned;
-		}
+		// Every dock gets two inner wrappers so menu tiles can scroll
+		// independently of the system tiles. Vertical placements scroll
+		// the menu area vertically with system tiles pinned at the
+		// bottom edge; the bottom dock scrolls horizontally with system
+		// tiles pinned at the trailing edge. The outer dock keeps the
+		// placement attribute + orientation chrome; the wrappers carry
+		// the actual flow.
+		const scroll = document.createElement( 'div' );
+		scroll.className = 'desktop-mode-dock__scroll';
+		const pinned = document.createElement( 'div' );
+		pinned.className = 'desktop-mode-dock__pinned';
+		container.appendChild( scroll );
+		container.appendChild( pinned );
+		this.itemHost = scroll;
+		this.systemHost = pinned;
 
 		// Tooltip — shared across all items. Anchor class flips per
 		// orientation so the tooltip sits outside the dock regardless
@@ -474,23 +471,6 @@ export class Dock {
 			tileElements: this.itemElements as ReadonlyMap<string, HTMLElement>,
 		} );
 
-		// When `itemHost === systemHost` (the bottom dock), the system
-		// separator + tiles live in the same container as menu tiles,
-		// and new menu tiles need to be inserted BEFORE them to keep
-		// the menu → separator → system DOM order. For vertical docks
-		// they're in different hosts, so a simple appendChild is right.
-		const insertMenuChild = ( node: Node ): void => {
-			if (
-				this.itemHost === this.systemHost &&
-				this.systemSeparator &&
-				this.systemSeparator.parentNode === this.itemHost
-			) {
-				this.itemHost.insertBefore( node, this.systemSeparator );
-			} else {
-				this.itemHost.appendChild( node );
-			}
-		};
-
 		let insertedGroupSeparator = false;
 		let tilesInsertedThisPass = 0;
 		for ( const item of items ) {
@@ -500,13 +480,13 @@ export class Dock {
 					sep.className =
 						'desktop-mode-dock__separator desktop-mode-dock__separator--group';
 					sep.setAttribute( 'aria-hidden', 'true' );
-					insertMenuChild( sep );
+					this.itemHost.appendChild( sep );
 				}
 				insertedGroupSeparator = true;
 			}
 			const btn = this.createItemButton( item );
 			this.itemElements.set( item.id, btn );
-			insertMenuChild( btn );
+			this.itemHost.appendChild( btn );
 			tilesInsertedThisPass++;
 			// Re-apply any client-side badge override that was set
 			// before the refresh. Without this, the live menu

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -222,6 +222,24 @@ export interface DockAttentionOptions {
  */
 export class Dock {
 	private container: HTMLElement;
+	/**
+	 * Where menu tiles + the inline group separator live. For vertical
+	 * placements this is the inner `.desktop-mode-dock__scroll` wrapper
+	 * (a scrollable flex column) so a long admin menu doesn't push the
+	 * system tiles off-screen; the wrapper takes the scroll while the
+	 * outer dock stays the height of the shell body. For the bottom
+	 * placement it's the dock itself — the horizontal pill has its own
+	 * width constraints and doesn't benefit from inner scrolling.
+	 */
+	private itemHost: HTMLElement;
+	/**
+	 * Where system tiles + their hairline separator live. For vertical
+	 * placements this is the `.desktop-mode-dock__pinned` wrapper sat
+	 * below `itemHost`, so OS Settings / Recycle Bin / etc. stay visible
+	 * at the bottom regardless of scroll position. For the bottom
+	 * placement it's the dock itself.
+	 */
+	private systemHost: HTMLElement;
 	private windowManager: WindowManager;
 	private items: DockItem[];
 	private tooltip: HTMLElement;
@@ -322,6 +340,25 @@ export class Dock {
 			orientation,
 		);
 
+		// Vertical placements get two inner wrappers so menu tiles can
+		// scroll independently of the system tiles at the bottom. The
+		// outer dock keeps the placement attribute + orientation chrome;
+		// the wrappers carry the actual flow. For the bottom dock no
+		// wrappers — the flat row works as-is.
+		if ( orientation === 'bottom' ) {
+			this.itemHost = container;
+			this.systemHost = container;
+		} else {
+			const scroll = document.createElement( 'div' );
+			scroll.className = 'desktop-mode-dock__scroll';
+			const pinned = document.createElement( 'div' );
+			pinned.className = 'desktop-mode-dock__pinned';
+			container.appendChild( scroll );
+			container.appendChild( pinned );
+			this.itemHost = scroll;
+			this.systemHost = pinned;
+		}
+
 		// Tooltip — shared across all items. Anchor class flips per
 		// orientation so the tooltip sits outside the dock regardless
 		// of which edge it hugs.
@@ -421,7 +458,7 @@ export class Dock {
 			el.remove();
 		}
 		// Also remove any stale group separator from a previous render.
-		this.container
+		this.itemHost
 			.querySelectorAll(
 				'.desktop-mode-dock__separator--group',
 			)
@@ -437,6 +474,23 @@ export class Dock {
 			tileElements: this.itemElements as ReadonlyMap<string, HTMLElement>,
 		} );
 
+		// When `itemHost === systemHost` (the bottom dock), the system
+		// separator + tiles live in the same container as menu tiles,
+		// and new menu tiles need to be inserted BEFORE them to keep
+		// the menu → separator → system DOM order. For vertical docks
+		// they're in different hosts, so a simple appendChild is right.
+		const insertMenuChild = ( node: Node ): void => {
+			if (
+				this.itemHost === this.systemHost &&
+				this.systemSeparator &&
+				this.systemSeparator.parentNode === this.itemHost
+			) {
+				this.itemHost.insertBefore( node, this.systemSeparator );
+			} else {
+				this.itemHost.appendChild( node );
+			}
+		};
+
 		let insertedGroupSeparator = false;
 		let tilesInsertedThisPass = 0;
 		for ( const item of items ) {
@@ -446,21 +500,13 @@ export class Dock {
 					sep.className =
 						'desktop-mode-dock__separator desktop-mode-dock__separator--group';
 					sep.setAttribute( 'aria-hidden', 'true' );
-					if ( this.systemSeparator ) {
-						this.container.insertBefore( sep, this.systemSeparator );
-					} else {
-						this.container.appendChild( sep );
-					}
+					insertMenuChild( sep );
 				}
 				insertedGroupSeparator = true;
 			}
 			const btn = this.createItemButton( item );
 			this.itemElements.set( item.id, btn );
-			if ( this.systemSeparator ) {
-				this.container.insertBefore( btn, this.systemSeparator );
-			} else {
-				this.container.appendChild( btn );
-			}
+			insertMenuChild( btn );
 			tilesInsertedThisPass++;
 			// Re-apply any client-side badge override that was set
 			// before the refresh. Without this, the live menu
@@ -696,12 +742,12 @@ export class Dock {
 			this.systemSeparator = document.createElement( 'div' );
 			this.systemSeparator.className = 'desktop-mode-dock__separator';
 			this.systemSeparator.setAttribute( 'aria-hidden', 'true' );
-			this.container.appendChild( this.systemSeparator );
+			this.systemHost.appendChild( this.systemSeparator );
 		}
 
 		const tile = this.createSystemItemButton( item );
 		this.systemItemElements.set( item.id, tile );
-		this.container.appendChild( tile );
+		this.systemHost.appendChild( tile );
 		this.updateActiveStates();
 
 		doAction( HOOKS.DOCK_TILE_RENDERED, {
@@ -741,7 +787,12 @@ export class Dock {
 		}
 		this.peekTeardowns.clear();
 
-		this.container.innerHTML = '';
+		// Clear menu host only — system tiles live in their own host
+		// and survive a re-render. For the bottom dock both hosts are
+		// the same element; in that case the system tiles haven't been
+		// appended yet at constructor time so clearing here is still
+		// safe (`render()` only runs from the constructor).
+		this.itemHost.innerHTML = '';
 
 		const base = this.buildHookContextBase();
 		doAction( HOOKS.DOCK_BEFORE_RENDER, {
@@ -756,18 +807,18 @@ export class Dock {
 				// Only insert if there's at least one core tile before
 				// us — otherwise a plugin-only dock would lead with a
 				// lonely separator.
-				if ( this.container.childElementCount > 0 ) {
+				if ( this.itemHost.childElementCount > 0 ) {
 					const sep = document.createElement( 'div' );
 					sep.className =
 						'desktop-mode-dock__separator desktop-mode-dock__separator--group';
 					sep.setAttribute( 'aria-hidden', 'true' );
-					this.container.appendChild( sep );
+					this.itemHost.appendChild( sep );
 				}
 				insertedGroupSeparator = true;
 			}
 			const btn = this.createItemButton( item );
 			this.itemElements.set( item.id, btn );
-			this.container.appendChild( btn );
+			this.itemHost.appendChild( btn );
 			doAction( HOOKS.DOCK_TILE_RENDERED, {
 				...base,
 				item,
@@ -1079,7 +1130,7 @@ export class Dock {
 		};
 
 		const eachSiblingTile = ( fn: ( el: HTMLElement ) => void ): void => {
-			for ( const child of Array.from( this.container.children ) ) {
+			for ( const child of Array.from( this.itemHost.children ) ) {
 				if ( child instanceof HTMLElement && child !== tile && isMenuTile( child ) ) {
 					fn( child );
 				}
@@ -1088,7 +1139,7 @@ export class Dock {
 
 		const snapshotMenuOrder = (): string[] => {
 			const ids: string[] = [];
-			for ( const child of Array.from( this.container.children ) ) {
+			for ( const child of Array.from( this.itemHost.children ) ) {
 				if ( isMenuTile( child ) ) {
 					ids.push( child.dataset.menuSlug as string );
 				}
@@ -1201,11 +1252,11 @@ export class Dock {
 			let reordered = false;
 			if ( insertBefore ) {
 				if ( targetTile !== tile.nextSibling ) {
-					this.container.insertBefore( tile, targetTile );
+					this.itemHost.insertBefore( tile, targetTile );
 					reordered = true;
 				}
 			} else if ( targetTile.nextSibling !== tile ) {
-				this.container.insertBefore( tile, targetTile.nextSibling );
+				this.itemHost.insertBefore( tile, targetTile.nextSibling );
 				reordered = true;
 			}
 
@@ -1330,7 +1381,7 @@ export class Dock {
 				eachSiblingTile( ( sib ) => {
 					prevRects.set( sib, sib.getBoundingClientRect() );
 				} );
-				this.container.insertBefore( tile, originalNext );
+				this.itemHost.insertBefore( tile, originalNext );
 				flipSiblings( prevRects );
 			}
 			animateHome();

--- a/tests/vitest/dock-decoration-hooks.test.ts
+++ b/tests/vitest/dock-decoration-hooks.test.ts
@@ -115,8 +115,11 @@ describe( 'dock decoration hooks', () => {
 		);
 
 		const { container } = mount( [ makeItem() ] );
-		// Wrapper is the direct child; the original tile lives inside.
-		const wrap = container.querySelector( ':scope > .plugin-wrap' );
+		// Wrapper sits inside the dock's `__scroll` host; the original
+		// tile lives inside the wrapper. Plugin contract: the returned
+		// element is what gets painted as the tile; the shell still
+		// finds `[data-menu-slug]` descendants for active state.
+		const wrap = container.querySelector( '.desktop-mode-dock__scroll > .plugin-wrap' );
 		expect( wrap ).not.toBeNull();
 		expect( wrap?.querySelector( '[data-menu-slug="edit.php"]' ) ).not.toBeNull();
 	} );


### PR DESCRIPTION
## Summary

Sites with many CPTs + plugins routinely produce more menu tiles than fit the viewport. With a vertical dock (Classic layout's left side bar) the bottom tiles + system cluster get clipped off the bottom of the screen; with a horizontal dock (Unified / Spatial layouts) the trailing tiles get clipped off the right edge. Either way the user can't reach them.

This PR introduces an inner `__scroll` / `__pinned` wrapper pair on every dock so the menu area can scroll while the system tiles stay pinned at the trailing edge.

- `.desktop-mode-dock__scroll` — scrollable; hosts menu tiles + the inline core/plugin separator. Scrollbar is hidden visually (`scrollbar-width: none` + WebKit pseudo) so the rail keeps its macOS look. Mouse wheel, touchpad, touch, and keyboard focus-into-view all work.
- `.desktop-mode-dock__pinned` — sized to content; hosts the system separator + system tiles. Always visible at the trailing edge, regardless of scroll position.

Vertical placements (left / right) flow the wrappers as columns: `__scroll` takes the available height and scrolls vertically, `__pinned` sits at the bottom edge. The bottom placement flows them as rows: `__scroll` takes the available width and scrolls horizontally, `__pinned` sits at the trailing edge. The bottom pill's padding shifts from `8px 12px` to `4px 12px 8px` so `__scroll` has 4px internal top padding for badge clearance (the tile's badge sits at `top: -3px`); net vertical chrome is unchanged.

Drag-to-reorder, `replaceItems`, `appendSystemItem`, and `removeSystemItem` route through new `itemHost` / `systemHost` fields so the same code paths serve both shapes.

https://github.com/user-attachments/assets/c0953c97-7a8f-4caa-8785-e04f0d325130

Fixes #251.

> Re: the second part of the issue (\"optionally display the label next to the icon\"). Intentionally not implemented. The dock is designed as a macOS-style icon strip; adding labels turns it into a sidebar (i.e. the native WP admin menu) and roughly quadruples its width, undoing the \"more room for content\" benefit of the desktop chrome. It also doesn't fit the bottom dock. If we want this it should ship as a separate \`DockRailRenderer\` (the extensibility point already exists in \`src/dock-rail/\`), not as a toggle on the default renderer.

## Test plan

To reproduce overflow: a site with 25+ CPTs / plugin menus. Each layout exposes a different rail shape.

- [ ] **Left dock (Classic layout)** — OS Settings → Desktop layout → Classic. Mouse-wheel / trackpad scroll over the side bar; menu area scrolls vertically, system tiles (Recycle Bin / OS Settings / Bug Report / Exit) stay pinned at the bottom of the rail.
- [ ] **Right dock** — no built-in UI for this; from the console after switching to Classic, run \`wp.desktop.sideDock?.setOrientation('right')\` to flip the side bar to the right edge. Same behaviour, mirrored.
- [ ] **Bottom dock (Unified layout)** — OS Settings → Desktop layout → Unified. Mouse-wheel / trackpad-horizontal-scroll over the dock pill; menu tiles scroll horizontally, system tiles stay pinned at the trailing edge. Badges on tiles are not clipped.
- [ ] **Bottom dock (Spatial layout)** — same as Unified but with core menu items emitted as wallpaper icons; the bottom pill hosts only plugin menus. Horizontal scroll + pinned trailing cluster still behave correctly.
- [ ] **Classic with overflow on BOTH rails** — left dock has many CPTs and bottom dock has many plugin menus; both rails scroll independently, both keep their pinned clusters.
- [ ] **Drag-to-reorder a menu tile** inside the scrollable area on each layout.
- [ ] **Plugin activate / deactivate while the dock is scrolled** — live refresh repaints menu tiles, system tiles unaffected, no stale separators.
- [ ] **Low-cap user** (Subscriber role: no menu items, only system tiles) — no stray separator hairline next to the system cluster.
- [x] **No visible scrollbar** on any dock at any time.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-264-d062d94388d3b4f2acab539e7c70f0759807597e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->