### PR TITLE
Sticky notes powered by WP Guidelines

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,14 @@
 {
 	"core": null,
+	"plugins": [
+		".",
+		"https://downloads.wordpress.org/plugin/gutenberg.zip"
+	],
 	"mappings": {
 		"wp-content/plugins/desktop-mode": "."
+	},
+	"lifecycleScripts": {
+		"afterStart": "./bin/setup-wp-env.sh"
 	},
 	"port": 8890,
 	"testsPort": 8891

--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -457,6 +457,146 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 }
 
 /* ---------------------------------------------------------------
+ * Sticky notes — Gutenberg `wp_guideline` artifacts tagged with the
+ * sticky guideline type. Notes sit above wallpaper icons/widgets and
+ * below windows, so they behave like desktop objects rather than app
+ * chrome.
+ * --------------------------------------------------------------- */
+
+.desktop-mode-sticky-notes {
+	position: absolute;
+	inset: 0;
+	z-index: 2;
+	pointer-events: none;
+	transition:
+		opacity 0.22s ease,
+		transform 0.28s cubic-bezier( 0.2, 0, 0.2, 1 );
+}
+
+.desktop-mode-area--overview .desktop-mode-sticky-notes {
+	opacity: 0;
+	transform: translateY( 12px );
+	pointer-events: none;
+}
+
+.desktop-mode-sticky-note {
+	position: absolute;
+	display: flex;
+	flex-direction: column;
+	pointer-events: auto;
+	background: #fff09a;
+	color: #2a2513;
+	border: 1px solid rgba( 84, 67, 0, 0.24 );
+	border-radius: 4px;
+	box-shadow:
+		0 12px 28px rgba( 0, 0, 0, 0.22 ),
+		0 2px 5px rgba( 0, 0, 0, 0.16 ),
+		inset 0 1px 0 rgba( 255, 255, 255, 0.55 );
+	overflow: hidden;
+	resize: both;
+}
+
+.desktop-mode-sticky-note--dragging {
+	opacity: 0.92;
+	resize: none;
+	user-select: none;
+}
+
+.desktop-mode-sticky-note__header {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	min-height: 30px;
+	padding: 4px 6px 4px 8px;
+	background: rgba( 82, 64, 0, 0.06 );
+	border-bottom: 1px solid rgba( 82, 64, 0, 0.14 );
+	cursor: grab;
+	touch-action: none;
+	user-select: none;
+}
+
+.desktop-mode-sticky-note--dragging .desktop-mode-sticky-note__header {
+	cursor: grabbing;
+}
+
+.desktop-mode-sticky-note__grip {
+	flex: 0 0 auto;
+	width: 8px;
+	height: 14px;
+	background-image: radial-gradient(
+		circle,
+		rgba( 60, 48, 0, 0.5 ) 1.2px,
+		transparent 1.5px
+	);
+	background-size: 4px 4px;
+	background-position: 0 1px;
+	background-repeat: space;
+	opacity: 0.42;
+}
+
+.desktop-mode-sticky-note__title {
+	flex: 1;
+	min-width: 0;
+	font-size: 11px;
+	font-weight: 650;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.desktop-mode-sticky-note__status {
+	flex: 0 0 auto;
+}
+
+.desktop-mode-sticky-note wpd-window-button {
+	--wpd-btn-color: rgba( 42, 37, 19, 0.7 );
+	--wpd-btn-color-hover: #2a2513;
+	--wpd-btn-bg-hover: rgba( 42, 37, 19, 0.1 );
+	--wpd-btn-bg-active: rgba( 42, 37, 19, 0.16 );
+	--wpd-btn-danger-hover: rgba( 214, 54, 56, 0.18 );
+	--wpd-btn-outline: var( --wp-admin-theme-color, #2271b1 );
+}
+
+.desktop-mode-sticky-note__open.is-disabled {
+	opacity: 0.34;
+	pointer-events: none;
+}
+
+.desktop-mode-sticky-note__editor {
+	flex: 1;
+	min-height: 0;
+	--desktop-mode-window-bg: transparent;
+	--desktop-mode-border: transparent;
+	--desktop-mode-text: #2a2513;
+	--desktop-mode-muted: rgba( 42, 37, 19, 0.62 );
+	font-family:
+		-apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		sans-serif;
+}
+
+.desktop-mode-sticky-note__editor::part(textarea) {
+	height: 100%;
+	min-height: 100%;
+	padding: 10px 12px 12px;
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	color: #2a2513;
+	font-size: 13px;
+	line-height: 1.4;
+	resize: none;
+}
+
+.desktop-mode-sticky-note__editor::part(textarea):hover,
+.desktop-mode-sticky-note__editor::part(textarea):focus-visible {
+	border-color: transparent;
+	box-shadow: none;
+}
+
+/* ---------------------------------------------------------------
  * Widgets column — right-edge glass strip that paints above the
  * wallpaper but beneath windows. Hosts stacked widget cards and a
  * trailing "Add widget" tile. Interactive only on its own cards +

--- a/bin/setup-wp-env.sh
+++ b/bin/setup-wp-env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WP_ENV_BIN="${WP_ENV_BIN:-./node_modules/.bin/wp-env}"
+
+enable_guidelines_experiment() {
+	local target="$1"
+
+	if ! "${WP_ENV_BIN}" run "${target}" wp plugin is-installed gutenberg; then
+		"${WP_ENV_BIN}" run "${target}" wp plugin install gutenberg
+	fi
+	"${WP_ENV_BIN}" run "${target}" wp plugin activate desktop-mode gutenberg
+	"${WP_ENV_BIN}" run "${target}" wp eval '
+		$experiments = get_option( "gutenberg-experiments", array() );
+		if ( ! is_array( $experiments ) ) {
+			$experiments = array();
+		}
+		$experiments["gutenberg-guidelines"] = true;
+		update_option( "gutenberg-experiments", $experiments );
+	'
+}
+
+enable_guidelines_experiment cli
+enable_guidelines_experiment tests-cli

--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -44,6 +44,7 @@ require_once DESKTOP_MODE_DIR . 'includes/admin-bar.php';
 require_once DESKTOP_MODE_DIR . 'includes/session.php';
 require_once DESKTOP_MODE_DIR . 'includes/presence.php';
 require_once DESKTOP_MODE_DIR . 'includes/nonce-refresh.php';
+require_once DESKTOP_MODE_DIR . 'includes/sticky-notes/heartbeat.php';
 require_once DESKTOP_MODE_DIR . 'includes/os-settings.php';
 require_once DESKTOP_MODE_DIR . 'includes/seen-intros.php';
 require_once DESKTOP_MODE_DIR . 'includes/welcome-dialog.php';

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,12 +161,12 @@ The `'config'` arg on `desktop_mode_register_window()` (also 0.6.0) ships throug
 
 ## Session persistence
 
-Every window lifecycle event — open, close, focus, move, resize, state change — is pushed into a debounced writer that `POST`s the full stack to a REST endpoint. On next load, the shell reads the session and rebuilds the stack before the user sees anything (no "flash of default layout"). Clamping logic adapts window coordinates when the viewport shrinks.
+Every window lifecycle event — open, close, focus, move, resize, state change — plus virtual-desktop create / switch / close is pushed into a debounced writer that `POST`s the full stack to a REST endpoint. On next load, the shell reads the session and rebuilds the stack before the user sees anything (no "flash of default layout"). Clamping logic adapts window coordinates when the viewport shrinks. Desktop-only state still counts: if the user has multiple Spaces but no open windows, the desktop registry and active desktop are restored.
 
 REST surface:
 
 - `GET  /wp-json/desktop-mode/v1/session` — current user's saved session.
-- `POST /wp-json/desktop-mode/v1/session` — overwrite the session. Body: `{ session: { windows: [...], focused, updated } }`.
+- `POST /wp-json/desktop-mode/v1/session` — overwrite the session. Body: `{ session: { windows: [...], desktops: [...], activeDesktop, focused, updated } }`.
 - `DELETE /wp-json/desktop-mode/v1/session` — clear it.
 
 All session routes require a valid `X-WP-Nonce` (the standard REST nonce) and the current user to be logged in with capability `read`.
@@ -216,7 +216,7 @@ Never edit Core's `common.css` or color scheme files. Everything we need is expo
 
 ## What's shipped vs. what comes next
 
-**Shipped** — unified dock with left / right / bottom placement (user preference in OS Settings; default bottom), multi-window orchestration + session restore, virtual desktops / Spaces (0.6), wallpaper registry (0.6), widget registry (0.7), overview + arrange + snap (0.8–0.9), native windows and tabs (0.10–0.11), AI assistant + slash commands + palette registry (0.13–0.14), cross-frame drag bridge for Media Library (0.14), OS Settings native window, accent + custom-gradient editor, toast notifications, iframe observability (`iframe-ready` / `iframe-error` / `iframe-network-completed`), letter-badge icon fallback, batch `closeAll()` with protection filter, primary-desktop filter, iframe command-palette bridge (0.16 — harvests `@wordpress/commands` from the focused window into the shell palette; see "Command palette bridge" above).
+**Shipped** — unified dock with left / right / bottom placement (user preference in OS Settings; default bottom), multi-window orchestration + session restore, virtual desktops / Spaces (0.6), wallpaper registry (0.6), widget registry (0.7), overview + arrange + snap (0.8–0.9), native windows and tabs (0.10–0.11), AI assistant + slash commands + palette registry (0.13–0.14), cross-frame drag bridge for Media Library (0.14), OS Settings native window, accent + custom-gradient editor, toast notifications, iframe observability (`iframe-ready` / `iframe-error` / `iframe-network-completed`), letter-badge icon fallback, batch `closeAll()` with protection filter, primary-desktop filter, iframe command-palette bridge (0.16 — harvests `@wordpress/commands` from the focused window into the shell palette; see "Command palette bridge" above), Gutenberg `wp_guideline` sticky artifacts as draggable per-desktop sticky notes when the `wp_guideline_type` taxonomy exposes an `artifact`/`artifacts` → `sticky` term, with REST boot hydration plus Heartbeat deltas for cross-tab updates.
 
 **Coming up**
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -710,6 +710,7 @@ array(
     'adminUrl'         => string,   // admin_url()
     'portalUrl'        => string,   // desktop_mode_portal_url()
     'sessionUrl'       => string,   // REST session URL
+    'restUrl'          => string,   // REST API root from rest_url(); compose with joinRestUrl() for pretty/plain permalink safety
     'restNonce'        => string,   // X-WP-Nonce
     'dockItems'        => array[],  // see desktop_mode_dock_items
     'session'          => array,    // prior session snapshot or empty

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -776,6 +776,10 @@ That's the whole pattern. The dot blinks for the duration of the round-trip, fla
 
 `wp.desktop.fetch` automatically attaches `X-WP-Nonce: desktopModeConfig.restNonce` to **same-origin** requests whose URL targets a WordPress REST endpoint — either pretty-permalink (`/wp-json/...`) or plain-permalink (`?rest_route=...`). Without the header, WordPress's `rest_cookie_check_errors()` demotes the cookie session to anonymous and any capability-gated route returns `401`. You no longer need to remember to attach it by hand.
 
+When composing REST URLs inside the shell, prefer the server-provided
+`desktopModeConfig.restUrl` root over hard-coded `/wp-json/` paths so
+plain-permalink installs route correctly too.
+
 Rules:
 - **Same-origin only.** Cross-origin requests never receive the header — the nonce is a credential for this site.
 - **Caller wins.** If you pass `headers: { 'X-WP-Nonce': '...' }` (or the input `Request` already carries the header), the framework does not overwrite it.
@@ -1064,7 +1068,7 @@ Server-declared icons (registered via `desktop_mode_register_icon( $id, [ 'pinne
 ---
 
 ### `saveSession` — Stable
-A debounced function that schedules a session write. Call it after mutating window state from your own code.
+A debounced function that schedules a session write. The shell calls it automatically for window lifecycle and virtual-desktop lifecycle changes; call it after mutating session-backed state from your own code.
 
 ```javascript
 window.wp.desktop.windowManager.focus( someWindow );

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -365,6 +365,7 @@ function desktop_mode_enqueue_assets() {
 	 *     @type array  $session      Saved session (windows, focused, updated).
 	 *     @type string $sessionUrl       REST endpoint for saving the session.
 	 *     @type string $mediaUrl         REST endpoint for media uploads (wp/v2/media).
+	 *     @type string $restUrl          REST API root from rest_url(), safe for pretty and plain permalink installs.
 	 *     @type string $defaultWindowUrl REST endpoint for saving the default-window preference.
 	 *     @type array  $defaultWindow    { enabled: bool, url: string } — current default-window preference.
 	 *     @type bool   $canUpload        Whether the user holds the `upload_files` capability.
@@ -416,6 +417,7 @@ function desktop_mode_enqueue_assets() {
 			'defaultWallpaper' => desktop_mode_get_default_wallpaper(),
 			'session'          => desktop_mode_get_session( get_current_user_id() ),
 			'sessionUrl'       => esc_url_raw( rest_url( 'desktop-mode/v1/session' ) ),
+			'restUrl'          => esc_url_raw( rest_url() ),
 			'mediaUrl'         => esc_url_raw( rest_url( 'wp/v2/media' ) ),
 			'dropConfig'       => $drop_config,
 			'defaultWindowUrl' => esc_url_raw( rest_url( 'desktop-mode/v1/default-window' ) ),

--- a/includes/sticky-notes/heartbeat.php
+++ b/includes/sticky-notes/heartbeat.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Desktop Mode — Sticky notes Heartbeat sync.
+ *
+ * Gutenberg's Guidelines experiment owns the `wp_guideline` CPT and
+ * `wp_guideline_type` taxonomy. Desktop Mode only mirrors sticky
+ * artifacts into the shell: the client subscribes with the sticky term
+ * id, known guideline ids, and a high-water modified timestamp; the
+ * server responds with changed sticky guidelines plus removals.
+ *
+ * @package WPDesktopMode
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const DESKTOP_MODE_STICKY_NOTES_POST_TYPE = 'wp_guideline';
+const DESKTOP_MODE_STICKY_NOTES_TAXONOMY  = 'wp_guideline_type';
+
+/**
+ * Add sticky-note deltas to the Heartbeat response.
+ *
+ * @since 0.21.0
+ *
+ * @param array $response Pre-filtered response.
+ * @param array $data     Client-sent payload.
+ * @return array
+ */
+function desktop_mode_sticky_notes_heartbeat_received( $response, $data ) {
+	if ( ! is_array( $response ) ) {
+		$response = array();
+	}
+	if ( empty( $data['desktop_mode_sticky_notes_subscribe'] ) || ! is_array( $data['desktop_mode_sticky_notes_subscribe'] ) ) {
+		return $response;
+	}
+	if ( ! function_exists( 'desktop_mode_is_enabled' ) || ! desktop_mode_is_enabled() ) {
+		return $response;
+	}
+	if (
+		! post_type_exists( DESKTOP_MODE_STICKY_NOTES_POST_TYPE ) ||
+		! taxonomy_exists( DESKTOP_MODE_STICKY_NOTES_TAXONOMY )
+	) {
+		return $response;
+	}
+
+	$sub            = $data['desktop_mode_sticky_notes_subscribe'];
+	$sticky_term_id = isset( $sub['stickyTermId'] ) ? absint( $sub['stickyTermId'] ) : 0;
+	if ( $sticky_term_id <= 0 || ! term_exists( $sticky_term_id, DESKTOP_MODE_STICKY_NOTES_TAXONOMY ) ) {
+		return $response;
+	}
+
+	$known_ids = isset( $sub['knownIds'] ) && is_array( $sub['knownIds'] )
+		? array_values( array_unique( array_filter( array_map( 'absint', $sub['knownIds'] ) ) ) )
+		: array();
+	$known_ids = array_slice( $known_ids, 0, 500 );
+
+	$version = isset( $sub['version'] ) ? max( 0, (int) $sub['version'] ) : 0;
+
+	$response['desktop_mode_sticky_notes'] = desktop_mode_sticky_notes_compute_heartbeat_delta(
+		$sticky_term_id,
+		$known_ids,
+		$version,
+		100
+	);
+
+	return $response;
+}
+add_filter( 'heartbeat_received', 'desktop_mode_sticky_notes_heartbeat_received', 5, 2 );
+
+/**
+ * Compute sticky-note Heartbeat deltas.
+ *
+ * @since 0.21.0
+ *
+ * @param int   $sticky_term_id Sticky term id.
+ * @param int[] $known_ids      Guideline ids currently known by the client.
+ * @param int   $version        Last-seen modified timestamp in milliseconds.
+ * @param int   $cap            Maximum notes to send in one tick.
+ * @return array
+ */
+function desktop_mode_sticky_notes_compute_heartbeat_delta( $sticky_term_id, $known_ids, $version, $cap ) {
+	$cap       = max( 1, (int) $cap );
+	$query_ids = desktop_mode_sticky_notes_query_changed_ids( $sticky_term_id, $version, $cap + 1 );
+	$truncated = count( $query_ids ) > $cap;
+	if ( $truncated ) {
+		$query_ids = array_slice( $query_ids, 0, $cap );
+	}
+
+	$notes = array();
+	foreach ( $query_ids as $post_id ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			continue;
+		}
+		$post = get_post( $post_id );
+		if ( $post instanceof WP_Post ) {
+			$notes[] = desktop_mode_sticky_notes_shape_guideline( $post );
+		}
+	}
+
+	$alive_ids = desktop_mode_sticky_notes_alive_known_ids( $sticky_term_id, $known_ids );
+	$removed   = array_values( array_diff( array_map( 'intval', $known_ids ), $alive_ids ) );
+
+	return array(
+		'notes'        => $notes,
+		'removed'      => $removed,
+		'serverTimeMs' => (int) floor( microtime( true ) * 1000 ),
+		'truncated'    => $truncated,
+	);
+}
+
+/**
+ * Query sticky guideline ids modified since the client's high-water mark.
+ *
+ * @since 0.21.0
+ *
+ * @param int $sticky_term_id Sticky term id.
+ * @param int $version        Last-seen modified timestamp in milliseconds.
+ * @param int $limit          Max ids to return.
+ * @return int[]
+ */
+function desktop_mode_sticky_notes_query_changed_ids( $sticky_term_id, $version, $limit ) {
+	$args = array(
+		'post_type'      => DESKTOP_MODE_STICKY_NOTES_POST_TYPE,
+		'post_status'    => 'private',
+		'posts_per_page' => max( 1, (int) $limit ),
+		'fields'         => 'ids',
+		'orderby'        => 'modified',
+		'order'          => 'ASC',
+		'no_found_rows'  => true,
+		'tax_query'      => array(
+			array(
+				'taxonomy' => DESKTOP_MODE_STICKY_NOTES_TAXONOMY,
+				'field'    => 'term_id',
+				'terms'    => array( (int) $sticky_term_id ),
+			),
+		),
+	);
+	if ( $version > 0 ) {
+		$args['date_query'] = array(
+			array(
+				'column'    => 'post_modified_gmt',
+				'after'     => gmdate( 'Y-m-d H:i:s', (int) floor( $version / 1000 ) ),
+				'inclusive' => true,
+			),
+		);
+	}
+
+	$query = new WP_Query( $args );
+	$ids   = array_map( 'intval', (array) $query->posts );
+	wp_reset_postdata();
+
+	return $ids;
+}
+
+/**
+ * Return the subset of known ids that still point at visible sticky notes.
+ *
+ * @since 0.21.0
+ *
+ * @param int   $sticky_term_id Sticky term id.
+ * @param int[] $known_ids      Client-known guideline ids.
+ * @return int[]
+ */
+function desktop_mode_sticky_notes_alive_known_ids( $sticky_term_id, $known_ids ) {
+	$known_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) $known_ids ) ) ) );
+	if ( empty( $known_ids ) ) {
+		return array();
+	}
+
+	$query = new WP_Query(
+		array(
+			'post_type'      => DESKTOP_MODE_STICKY_NOTES_POST_TYPE,
+			'post_status'    => 'private',
+			'post__in'       => $known_ids,
+			'posts_per_page' => count( $known_ids ),
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => DESKTOP_MODE_STICKY_NOTES_TAXONOMY,
+					'field'    => 'term_id',
+					'terms'    => array( (int) $sticky_term_id ),
+				),
+			),
+		)
+	);
+	$ids = array();
+	foreach ( (array) $query->posts as $post_id ) {
+		$post_id = (int) $post_id;
+		if ( current_user_can( 'edit_post', $post_id ) ) {
+			$ids[] = $post_id;
+		}
+	}
+	wp_reset_postdata();
+
+	return $ids;
+}
+
+/**
+ * Shape a guideline like the Gutenberg REST endpoint's edit context.
+ *
+ * @since 0.21.0
+ *
+ * @param WP_Post $post Guideline post.
+ * @return array
+ */
+function desktop_mode_sticky_notes_shape_guideline( $post ) {
+	$term_ids = wp_get_object_terms(
+		$post->ID,
+		DESKTOP_MODE_STICKY_NOTES_TAXONOMY,
+		array( 'fields' => 'ids' )
+	);
+	if ( is_wp_error( $term_ids ) ) {
+		$term_ids = array();
+	}
+
+	return array(
+		'id'                       => (int) $post->ID,
+		'slug'                     => (string) $post->post_name,
+		'status'                   => (string) get_post_status( $post ),
+		'title'                    => array(
+			'raw' => (string) get_post_field( 'post_title', $post, 'raw' ),
+		),
+		'content'                  => array(
+			'raw' => (string) get_post_field( 'post_content', $post, 'raw' ),
+		),
+		'excerpt'                  => array(
+			'raw' => (string) get_post_field( 'post_excerpt', $post, 'raw' ),
+		),
+		'modified'                 => mysql_to_rfc3339( $post->post_modified ),
+		'desktop_mode_modified_ms' => desktop_mode_sticky_notes_modified_ms( $post ),
+		'link'                     => (string) get_permalink( $post ),
+		'wp_guideline_type'        => array_values( array_map( 'intval', (array) $term_ids ) ),
+	);
+}
+
+/**
+ * Modified timestamp in milliseconds, derived from GMT post time.
+ *
+ * @since 0.21.0
+ *
+ * @param WP_Post $post Post.
+ * @return int
+ */
+function desktop_mode_sticky_notes_modified_ms( $post ) {
+	return (int) get_post_modified_time( 'U', true, $post ) * 1000;
+}

--- a/src/boot/session.ts
+++ b/src/boot/session.ts
@@ -18,7 +18,43 @@ import { tryNativeUrlRemap } from '../native-url-remap';
 import { deriveWindowId } from '../utils';
 import { clampGeometryToViewport, findDockEntryForUrl } from './geometry';
 import type { WindowManager } from '../window-manager';
-import type { DesktopConfig } from '../types';
+import type { DesktopConfig, Session } from '../types';
+
+/**
+ * Whether the saved payload carries meaningful shell state to restore.
+ *
+ * A session can be worth restoring even when it has no windows: virtual
+ * desktops live in the same payload, and sticky notes / desktop files can
+ * make an otherwise empty workspace meaningful. The server always sends a
+ * default one-desktop shape, so keep that as "empty" until the user has
+ * actually saved a customized desktop registry.
+ */
+export function hasRestorableSession(
+	session: Session | undefined,
+): boolean {
+	if ( ! session ) {
+		return false;
+	}
+	if ( Array.isArray( session.windows ) && session.windows.length > 0 ) {
+		return true;
+	}
+	if (
+		typeof session.updated !== 'number' ||
+		session.updated <= 0 ||
+		! Array.isArray( session.desktops ) ||
+		session.desktops.length === 0
+	) {
+		return false;
+	}
+	if ( session.desktops.length > 1 ) {
+		return true;
+	}
+	const onlyDesktop = session.desktops[ 0 ];
+	if ( onlyDesktop?.id && onlyDesktop.id !== 'desktop-1' ) {
+		return true;
+	}
+	return !! session.activeDesktop && session.activeDesktop !== 'desktop-1';
+}
 
 /**
  * Restores windows from a saved session into the manager.

--- a/src/boot/shell-lifecycle.ts
+++ b/src/boot/shell-lifecycle.ts
@@ -12,7 +12,7 @@
  * @since 0.8.1
  */
 
-import { HOOKS, doAction } from '../hooks';
+import { HOOKS, addAction, doAction } from '../hooks';
 
 /** Debounce window for the shell-resized action. Trailing-edge only. */
 const SHELL_RESIZE_DEBOUNCE_MS = 120;
@@ -30,6 +30,9 @@ export function wireSessionEvents( save: () => void ): void {
 	document.addEventListener( 'desktop-mode-window-closed', save );
 	document.addEventListener( 'desktop-mode-window-focused', save );
 	document.addEventListener( 'desktop-mode-window-changed', save );
+	addAction( HOOKS.DESKTOP_CREATED, 'desktop-mode/session-save', save );
+	addAction( HOOKS.DESKTOP_CLOSED, 'desktop-mode/session-save', save );
+	addAction( HOOKS.DESKTOP_SWITCHED, 'desktop-mode/session-save', save );
 }
 
 /**

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -150,7 +150,7 @@ import { bootHeartbeatBus, type HeartbeatBus } from './heartbeat';
 import { bootNonceRefresh } from './nonce-refresh';
 import { bindTopWindowLinkInterceptor } from './boot/link-interceptor';
 import { bindMenuRefresh } from './boot/menu-refresh';
-import { openCurrentPage, restoreSession } from './boot/session';
+import { hasRestorableSession, openCurrentPage, restoreSession } from './boot/session';
 import { shouldAutoOpenCurrentPage } from './boot/auto-open';
 import { createSessionSaver } from './boot/session-saver';
 import { bindShellLifecycle, wireSessionEvents } from './boot/shell-lifecycle';
@@ -161,6 +161,7 @@ import {
 	installShortcutsSync,
 	syncShortcutsWithVisibility,
 } from './settings/desktop-shortcuts-sync';
+import { bootStickyNotes } from './sticky-notes';
 
 // `INITIAL_ORIGIN` lives in `src/boot/origin.ts` since 0.8.1 so every
 // boot-time consumer reaches the same captured value — see the import
@@ -2373,7 +2374,7 @@ function init(): void {
 	//      portal already redirected to its URL, so the current page
 	//      IS the default window — open it. The desktop is populated
 	//      with the user's chosen startup.
-	const hasSession = !! ( config.session && config.session.windows && config.session.windows.length > 0 );
+	const hasSession = hasRestorableSession( config.session );
 	// Session restore runs fire-and-forget so the rest of boot
 	// (manager wiring, settings, server-sync) doesn't block on the
 	// lazy `window-system[.min].js` bundle. openCurrentPage chains
@@ -2959,6 +2960,25 @@ function init(): void {
 	// 24-hour `nonce_life` boundary. See `src/nonce-refresh.ts`
 	// and `includes/nonce-refresh.php`.
 	bootNonceRefresh();
+
+	bootStickyNotes( {
+		host: desktopArea,
+		config,
+		getActiveDesktopId: () => manager.getActiveDesktopId(),
+		openArtifact: ( url, title ) => {
+			const id = deriveWindowId( url, config.adminUrl );
+			void manager.open( {
+				id,
+				baseId: id,
+				url,
+				title,
+				icon: 'dashicons-edit-page',
+			} );
+		},
+		onError: ( message ) => {
+			showToast( { message } );
+		},
+	} );
 
 	// Files-on-the-Desktop: hand the open() dispatcher real
 	// dependencies and seed the per-user associations from the

--- a/src/sticky-notes/heartbeat.ts
+++ b/src/sticky-notes/heartbeat.ts
@@ -1,0 +1,41 @@
+import { heartbeat } from '../heartbeat';
+import type {
+	StickyNotesHeartbeatPayload,
+	StickyNotesHeartbeatSubscribe,
+} from './types';
+
+const SUBSCRIBE_FIELD = 'desktop_mode_sticky_notes_subscribe';
+const RESPONSE_FIELD = 'desktop_mode_sticky_notes';
+
+export interface StickyNotesHeartbeatTarget {
+	getHeartbeatSubscription: () => StickyNotesHeartbeatSubscribe | undefined;
+	applyHeartbeatPayload: ( payload: StickyNotesHeartbeatPayload ) => void;
+}
+
+let started = false;
+let target: StickyNotesHeartbeatTarget | null = null;
+
+export function startStickyNotesHeartbeat(
+	nextTarget: StickyNotesHeartbeatTarget,
+): void {
+	target = nextTarget;
+	if ( started ) {
+		return;
+	}
+	started = true;
+
+	heartbeat.contribute( SUBSCRIBE_FIELD, () =>
+		target?.getHeartbeatSubscription(),
+	);
+	heartbeat.subscribe< StickyNotesHeartbeatPayload >(
+		RESPONSE_FIELD,
+		( payload ) => {
+			target?.applyHeartbeatPayload( payload );
+		},
+	);
+}
+
+export function __resetStickyNotesHeartbeatForTests(): void {
+	started = false;
+	target = null;
+}

--- a/src/sticky-notes/index.ts
+++ b/src/sticky-notes/index.ts
@@ -1,0 +1,2 @@
+export { bootStickyNotes, StickyNotesLayer } from './layer';
+export type { StickyNote, StickyTerms } from './types';

--- a/src/sticky-notes/layer.ts
+++ b/src/sticky-notes/layer.ts
@@ -1,0 +1,947 @@
+import { addAction, addFilter, HOOKS } from '../hooks';
+import { __ } from '../i18n';
+import '../ui/components/wpd-save-status/wpd-save-status';
+import '../ui/components/wpd-textarea/wpd-textarea';
+import '../ui/components/wpd-window-button/wpd-window-button';
+import {
+	buildGuidelineEditUrl,
+	fetchStickyNotes,
+	resolveStickyTerms,
+	saveStickyNote,
+	type StickyNotesRestConfig,
+} from './rest';
+import { startStickyNotesHeartbeat } from './heartbeat';
+import {
+	DEFAULT_STICKY_TITLE,
+	generatedTitle,
+	noteFromGuideline,
+	titleForBody,
+} from './text';
+import type {
+	StickyNotesHeartbeatPayload,
+	StickyNotesHeartbeatSubscribe,
+	StickyGeometry,
+	StickyNote,
+	StickyTerms,
+} from './types';
+
+type SavePhase = 'idle' | 'pending' | 'saving' | 'saved' | 'failed';
+
+interface StickyNotesLayerOptions {
+	host: HTMLElement;
+	config: StickyNotesRestConfig;
+	openArtifact: ( url: string, title: string, guidelineId: number ) => void;
+	getActiveDesktopId?: () => string;
+	onError?: ( message: string ) => void;
+}
+
+type WpdTextareaElement = HTMLElement & {
+	focusInput?: () => void;
+};
+
+const GEOMETRY_KEY = 'desktop-mode-sticky-notes-geometry';
+const DEFAULT_WIDTH = 264;
+const DEFAULT_HEIGHT = 176;
+const MIN_WIDTH = 180;
+const MIN_HEIGHT = 128;
+const EDGE_PADDING = 16;
+const SAVE_DEBOUNCE_MS = 1000;
+
+export class StickyNotesLayer {
+	private host: HTMLElement;
+	private config: StickyNotesRestConfig;
+	private openArtifact: ( url: string, title: string, guidelineId: number ) => void;
+	private getActiveDesktopId: () => string;
+	private onError?: ( message: string ) => void;
+	private root: HTMLElement | null = null;
+	private terms: StickyTerms | null = null;
+	private controllers = new Map< string, StickyNoteController >();
+	private contextMenuInstalled = false;
+	private desktopHooksInstalled = false;
+	private highWaterMs = 0;
+	private zIndexCounter = 0;
+
+	constructor( options: StickyNotesLayerOptions ) {
+		this.host = options.host;
+		this.config = options.config;
+		this.openArtifact = options.openArtifact;
+		this.getActiveDesktopId = options.getActiveDesktopId ?? ( () => 'desktop-1' );
+		this.onError = options.onError;
+	}
+
+	async boot(): Promise< void > {
+		try {
+			this.terms = await resolveStickyTerms( this.config );
+			if ( ! this.terms ) {
+				return;
+			}
+			this.installContextMenu();
+			this.installDesktopHooks();
+			const notes = await fetchStickyNotes(
+				this.config,
+				this.terms.stickyTermId,
+			);
+			this.bumpHighWaterFromNotes( notes );
+			startStickyNotesHeartbeat( this );
+			if ( notes.length === 0 ) {
+				return;
+			}
+			this.ensureRoot();
+			sortNotesByModified( notes ).forEach( ( note, index ) =>
+				this.upsert( note, index ),
+			);
+		} catch ( error ) {
+			// Sticky guidelines are an optional Gutenberg-side surface.
+			// Missing endpoints or denied private guidelines should not
+			// make the desktop noisy on boot.
+			if ( error instanceof Error ) {
+				// eslint-disable-next-line no-console
+				console.debug( '[desktop-mode] Sticky notes unavailable:', error.message );
+			}
+		}
+	}
+
+	createNote( body = '' ): void {
+		if ( ! this.terms ) {
+			return;
+		}
+		const note: StickyNote = {
+			localId: `local:${ Date.now() }:${ Math.random().toString( 36 ).slice( 2 ) }`,
+			guidelineId: null,
+			title: body.trim() ? generatedTitle( body ) : DEFAULT_STICKY_TITLE,
+			body,
+			termIds: this.terms.termIds,
+		};
+		const controller = this.upsert( note, this.controllers.size, {
+			activate: true,
+		} );
+		controller.focus();
+	}
+
+	private upsert(
+		note: StickyNote,
+		index: number,
+		options: { activate?: boolean } = {},
+	): StickyNoteController {
+		this.ensureRoot();
+		const key = noteKey( note );
+		const existing = this.controllers.get( key );
+		if ( existing ) {
+			existing.replace( note );
+			if ( options.activate ) {
+				this.bringToFront( existing );
+			}
+			return existing;
+		}
+		const controller = new StickyNoteController( {
+			layer: this,
+			note,
+			index,
+		} );
+		this.controllers.set( key, controller );
+		this.root?.appendChild( controller.element );
+		this.assignZIndex( controller );
+		this.applyDesktopVisibility( controller );
+		if ( options.activate ) {
+			this.bringToFront( controller );
+		}
+		return controller;
+	}
+
+	private ensureRoot(): HTMLElement {
+		if ( this.root ) {
+			return this.root;
+		}
+		const root = document.createElement( 'section' );
+		root.className = 'desktop-mode-sticky-notes';
+		root.setAttribute( 'aria-label', __( 'Sticky notes' ) );
+		this.host.appendChild( root );
+		this.root = root;
+		return root;
+	}
+
+	private installContextMenu(): void {
+		if ( this.contextMenuInstalled ) {
+			return;
+		}
+		this.contextMenuInstalled = true;
+		addFilter(
+			'desktop-mode.wallpaper-context-menu',
+			'desktop-mode/sticky-notes',
+			( items: unknown ) => {
+				if ( ! Array.isArray( items ) || ! this.terms ) {
+					return items;
+				}
+				if (
+					items.some( ( item ) =>
+						( item as { id?: unknown } ).id === 'new-sticky-note',
+					)
+				) {
+					return items;
+				}
+				return [
+					...items,
+					{
+						id: 'new-sticky-note',
+						label: __( 'New sticky note' ),
+						icon: 'dashicons-edit-page',
+						sort: 14,
+						onClick: () => this.createNote(),
+					},
+				];
+			},
+		);
+	}
+
+	private installDesktopHooks(): void {
+		if ( this.desktopHooksInstalled ) {
+			return;
+		}
+		this.desktopHooksInstalled = true;
+		addAction(
+			HOOKS.DESKTOP_SWITCHED,
+			'desktop-mode/sticky-notes',
+			() => this.refreshDesktopVisibility(),
+		);
+		addAction< [ { desktopId?: string; migratedTo?: string } ] >(
+			HOOKS.DESKTOP_CLOSED,
+			'desktop-mode/sticky-notes',
+			( detail ) => {
+				this.migrateDesktopAssignments( detail?.desktopId, detail?.migratedTo );
+				this.refreshDesktopVisibility();
+			},
+		);
+	}
+
+	save( note: StickyNote ): Promise< StickyNote > {
+		if ( ! this.terms ) {
+			return Promise.reject( new Error( __( 'Sticky term is unavailable.' ) ) );
+		}
+		return saveStickyNote( this.config, note, this.terms );
+	}
+
+	getHeartbeatSubscription(): StickyNotesHeartbeatSubscribe | undefined {
+		if ( ! this.terms ) {
+			return undefined;
+		}
+		return {
+			stickyTermId: this.terms.stickyTermId,
+			knownIds: this.knownGuidelineIds(),
+			version: this.highWaterMs,
+		};
+	}
+
+	applyHeartbeatPayload( payload: StickyNotesHeartbeatPayload ): void {
+		for ( const guideline of payload.notes ?? [] ) {
+			const note = noteFromGuideline( guideline );
+			this.upsertRemote( note );
+		}
+		for ( const id of payload.removed ?? [] ) {
+			this.forgetGuidelineId( id );
+		}
+		if (
+			typeof payload.serverTimeMs === 'number' &&
+			Number.isFinite( payload.serverTimeMs ) &&
+			payload.serverTimeMs > this.highWaterMs
+		) {
+			this.highWaterMs = payload.serverTimeMs;
+		}
+		if ( payload.truncated ) {
+			void this.reloadFromServer();
+		}
+	}
+
+	openNoteArtifact( note: StickyNote ): void {
+		if ( note.guidelineId === null ) {
+			return;
+		}
+		this.openArtifact(
+			buildGuidelineEditUrl( this.config.adminUrl, note.guidelineId ),
+			note.title,
+			note.guidelineId,
+		);
+	}
+
+	notifyError( message: string ): void {
+		this.onError?.( message );
+	}
+
+	hostSize(): { width: number; height: number } {
+		return {
+			width: Math.max( 1, this.host.clientWidth ),
+			height: Math.max( 1, this.host.clientHeight ),
+		};
+	}
+
+	defaultGeometry( index: number ): StickyGeometry {
+		const { width: hostWidth, height: hostHeight } = this.hostSize();
+		const width = Math.min(
+			DEFAULT_WIDTH,
+			Math.max( MIN_WIDTH, hostWidth - EDGE_PADDING * 2 ),
+		);
+		const height = Math.min(
+			DEFAULT_HEIGHT,
+			Math.max( MIN_HEIGHT, hostHeight - EDGE_PADDING * 2 ),
+		);
+		const offset = ( index % 8 ) * 28;
+		const left = clamp(
+			hostWidth - width - 32 - offset,
+			EDGE_PADDING,
+			Math.max( EDGE_PADDING, hostWidth - width - EDGE_PADDING ),
+		);
+		const top = clamp(
+			32 + offset,
+			EDGE_PADDING,
+			Math.max( EDGE_PADDING, hostHeight - height - EDGE_PADDING ),
+		);
+		return {
+			x: left / hostWidth,
+			y: top / hostHeight,
+			width,
+			height,
+		};
+	}
+
+	forget( controller: StickyNoteController ): void {
+		this.controllers.delete( noteKey( controller.note ) );
+		controller.dispose();
+		controller.element.remove();
+		if ( this.controllers.size === 0 ) {
+			this.root?.remove();
+			this.root = null;
+		}
+	}
+
+	replaceControllerKey( oldKey: string, controller: StickyNoteController ): void {
+		const newKey = noteKey( controller.note );
+		this.controllers.delete( oldKey );
+		this.controllers.set( newKey, controller );
+		moveStoredGeometry( oldKey, newKey );
+		this.applyDesktopVisibility( controller );
+	}
+
+	bumpHighWaterFromNote( note: StickyNote ): void {
+		const modifiedMs = noteModifiedMs( note );
+		if ( modifiedMs > this.highWaterMs ) {
+			this.highWaterMs = modifiedMs;
+		}
+	}
+
+	bringToFront( controller: StickyNoteController ): void {
+		controller.setZIndex( this.nextZIndex() );
+	}
+
+	geometryForNote( note: StickyNote, index: number ): StickyGeometry {
+		const key = noteKey( note );
+		const loaded = loadGeometry( key );
+		const desktopId = this.normalizeDesktopId( loaded?.desktopId );
+		const geometry = loaded
+			? { ...loaded, desktopId }
+			: { ...this.defaultGeometry( index ), desktopId };
+		if (
+			! loaded ||
+			loaded.desktopId !== geometry.desktopId
+		) {
+			saveGeometry( key, geometry );
+		}
+		return geometry;
+	}
+
+	private upsertRemote( note: StickyNote ): StickyNoteController {
+		const key = noteKey( note );
+		const existing = this.controllers.get( key );
+		if ( existing ) {
+			if ( ! existing.shouldReplaceFromRemote( note ) ) {
+				this.bumpHighWaterFromNote( note );
+				return existing;
+			}
+			existing.replace( note );
+			this.bumpHighWaterFromNote( note );
+			return existing;
+		}
+		const controller = this.upsert( note, this.controllers.size );
+		this.bumpHighWaterFromNote( note );
+		return controller;
+	}
+
+	private forgetGuidelineId( guidelineId: number ): void {
+		for ( const controller of this.controllers.values() ) {
+			if ( controller.note.guidelineId === guidelineId ) {
+				this.forget( controller );
+				return;
+			}
+		}
+	}
+
+	private knownGuidelineIds(): number[] {
+		const ids: number[] = [];
+		for ( const controller of this.controllers.values() ) {
+			if ( controller.note.guidelineId !== null ) {
+				ids.push( controller.note.guidelineId );
+			}
+		}
+		return ids;
+	}
+
+	private bumpHighWaterFromNotes( notes: StickyNote[] ): void {
+		notes.forEach( ( note ) => this.bumpHighWaterFromNote( note ) );
+	}
+
+	private assignZIndex( controller: StickyNoteController ): void {
+		controller.setZIndex( this.nextZIndex() );
+	}
+
+	private nextZIndex(): number {
+		this.zIndexCounter += 1;
+		return this.zIndexCounter;
+	}
+
+	private applyDesktopVisibility( controller: StickyNoteController ): void {
+		controller.setVisible( this.isNoteOnActiveDesktop( controller.note ) );
+	}
+
+	private refreshDesktopVisibility(): void {
+		for ( const controller of this.controllers.values() ) {
+			this.applyDesktopVisibility( controller );
+		}
+	}
+
+	private isNoteOnActiveDesktop( note: StickyNote ): boolean {
+		const key = noteKey( note );
+		const geometry = loadGeometry( key );
+		const desktopId = this.normalizeDesktopId( geometry?.desktopId );
+		if ( geometry && geometry.desktopId !== desktopId ) {
+			saveGeometry( key, { ...geometry, desktopId } );
+		}
+		return desktopId === this.activeDesktopId();
+	}
+
+	private migrateDesktopAssignments(
+		desktopId: string | undefined,
+		migratedTo: string | undefined,
+	): void {
+		if ( ! desktopId || ! migratedTo || desktopId === migratedTo ) {
+			return;
+		}
+		const map = readGeometryMap();
+		let changed = false;
+		Object.entries( map ).forEach( ( [ key, geometry ] ) => {
+			if ( geometry.desktopId === desktopId ) {
+				map[ key ] = {
+					...geometry,
+					desktopId: this.normalizeDesktopId( migratedTo ),
+				};
+				changed = true;
+			}
+		} );
+		if ( changed ) {
+			writeGeometryMap( map );
+		}
+	}
+
+	private activeDesktopId(): string {
+		try {
+			const id = this.getActiveDesktopId();
+			return typeof id === 'string' && id ? id : 'desktop-1';
+		} catch {
+			return 'desktop-1';
+		}
+	}
+
+	private normalizeDesktopId( desktopId: string | undefined ): string {
+		if ( ! desktopId ) {
+			return this.activeDesktopId();
+		}
+		return desktopId;
+	}
+
+	private async reloadFromServer(): Promise< void > {
+		if ( ! this.terms ) {
+			return;
+		}
+		try {
+			const notes = await fetchStickyNotes(
+				this.config,
+				this.terms.stickyTermId,
+			);
+			const ids = new Set< number >();
+			sortNotesByModified( notes ).forEach( ( note ) => {
+				if ( note.guidelineId !== null ) {
+					ids.add( note.guidelineId );
+				}
+				this.upsertRemote( note );
+			} );
+			this.knownGuidelineIds().forEach( ( id ) => {
+				if ( ! ids.has( id ) ) {
+					this.forgetGuidelineId( id );
+				}
+			} );
+		} catch {
+			// Quiet — the next heartbeat tick can try again.
+		}
+	}
+}
+
+class StickyNoteController {
+	element: HTMLElement;
+	note: StickyNote;
+	private layer: StickyNotesLayer;
+	private index: number;
+	private titleEl: HTMLElement;
+	private editor: WpdTextareaElement;
+	private statusEl: HTMLElement;
+	private openButton: HTMLElement;
+	private saveTimer: number | null = null;
+	private geometryTimer: number | null = null;
+	private saving = false;
+	private saveAgain = false;
+	private resizeObserver: ResizeObserver | null = null;
+	private disposed = false;
+
+	constructor( options: {
+		layer: StickyNotesLayer;
+		note: StickyNote;
+		index: number;
+	} ) {
+		this.layer = options.layer;
+		this.note = options.note;
+		this.index = options.index;
+		this.element = document.createElement( 'article' );
+		this.element.className = 'desktop-mode-sticky-note';
+		this.element.dataset.stickyNoteId = noteKey( this.note );
+		this.titleEl = document.createElement( 'span' );
+		this.editor = document.createElement( 'wpd-textarea' ) as WpdTextareaElement;
+		this.statusEl = document.createElement( 'wpd-save-status' );
+		this.openButton = document.createElement( 'wpd-window-button' );
+		this.paint();
+		this.applyGeometry( this.layer.geometryForNote( this.note, this.index ) );
+		this.element.addEventListener(
+			'pointerdown',
+			() => this.layer.bringToFront( this ),
+			{ capture: true },
+		);
+		this.element.addEventListener( 'focusin', () => this.layer.bringToFront( this ) );
+		this.watchResize();
+	}
+
+	focus(): void {
+		window.setTimeout( () => this.editor.focusInput?.(), 0 );
+	}
+
+	replace( note: StickyNote ): void {
+		this.note = note;
+		this.element.dataset.stickyNoteId = noteKey( this.note );
+		this.titleEl.textContent = this.note.title;
+		this.editor.setAttribute( 'value', this.note.body );
+		this.refreshOpenButton();
+	}
+
+	shouldReplaceFromRemote( note: StickyNote ): boolean {
+		if ( this.hasLocalChanges() ) {
+			return false;
+		}
+		const currentMs = noteModifiedMs( this.note );
+		const incomingMs = noteModifiedMs( note );
+		if (
+			currentMs > 0 &&
+			incomingMs > 0 &&
+			incomingMs <= currentMs &&
+			this.note.title === note.title &&
+			this.note.body === note.body
+		) {
+			return false;
+		}
+		return true;
+	}
+
+	setZIndex( zIndex: number ): void {
+		this.element.style.zIndex = String( zIndex );
+	}
+
+	setVisible( visible: boolean ): void {
+		this.element.style.display = visible ? '' : 'none';
+	}
+
+	dispose(): void {
+		this.disposed = true;
+		if ( this.saveTimer !== null ) {
+			window.clearTimeout( this.saveTimer );
+			this.saveTimer = null;
+		}
+		if ( this.geometryTimer !== null ) {
+			window.clearTimeout( this.geometryTimer );
+			this.geometryTimer = null;
+		}
+		this.resizeObserver?.disconnect();
+		this.resizeObserver = null;
+	}
+
+	private paint(): void {
+		this.element.innerHTML = '';
+		this.element.style.minWidth = `${ MIN_WIDTH }px`;
+		this.element.style.minHeight = `${ MIN_HEIGHT }px`;
+
+		const header = document.createElement( 'div' );
+		header.className = 'desktop-mode-sticky-note__header';
+
+		const grip = document.createElement( 'span' );
+		grip.className = 'desktop-mode-sticky-note__grip';
+		grip.setAttribute( 'aria-hidden', 'true' );
+
+		this.titleEl.className = 'desktop-mode-sticky-note__title';
+		this.titleEl.textContent = this.note.title;
+
+		this.statusEl.setAttribute( 'mode', 'icon' );
+		this.statusEl.setAttribute( 'phase', 'idle' );
+		this.statusEl.className = 'desktop-mode-sticky-note__status';
+
+		this.openButton.setAttribute( 'icon', 'detach' );
+		this.openButton.setAttribute( 'title', __( 'Open artifact' ) );
+		this.openButton.className = 'desktop-mode-sticky-note__open';
+		this.openButton.addEventListener( 'wpd-button-activate', () => {
+			this.layer.openNoteArtifact( this.note );
+		} );
+
+		const close = document.createElement( 'wpd-window-button' );
+		close.setAttribute( 'icon', 'close' );
+		close.setAttribute( 'danger', '' );
+		close.setAttribute( 'title', __( 'Hide sticky note' ) );
+		close.className = 'desktop-mode-sticky-note__close';
+		close.addEventListener( 'wpd-button-activate', () => this.close() );
+
+		header.append( grip, this.titleEl, this.statusEl, this.openButton, close );
+		header.addEventListener( 'pointerdown', ( event ) => this.startDrag( event ) );
+
+		this.editor.className = 'desktop-mode-sticky-note__editor';
+		this.editor.setAttribute( 'aria-label', __( 'Sticky note text' ) );
+		this.editor.setAttribute( 'rows', '8' );
+		this.editor.setAttribute( 'value', this.note.body );
+		this.installEditorKeyboardGuard();
+		this.editor.addEventListener( 'wpd-input-change', ( event ) => {
+			const detail = ( event as CustomEvent< { value: string } > ).detail;
+			this.note.body = detail.value;
+			this.note.title = titleForBody( detail.value );
+			this.titleEl.textContent = this.note.title;
+			this.setPhase( 'pending' );
+			this.scheduleSave();
+		} );
+		this.editor.addEventListener( 'wpd-input-commit', () => this.flushSave() );
+
+		this.element.append( header, this.editor );
+		this.refreshOpenButton();
+	}
+
+	private installEditorKeyboardGuard(): void {
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			this.editor.addEventListener( eventName, ( event ) => {
+				event.stopPropagation();
+			} );
+		} );
+	}
+
+	private refreshOpenButton(): void {
+		const disabled = this.note.guidelineId === null;
+		this.openButton.classList.toggle( 'is-disabled', disabled );
+		this.openButton.setAttribute( 'aria-disabled', disabled ? 'true' : 'false' );
+	}
+
+	private close(): void {
+		if (
+			this.note.guidelineId === null &&
+			this.note.body.trim().length === 0
+		) {
+			this.layer.forget( this );
+			return;
+		}
+		this.flushSave();
+		this.layer.forget( this );
+	}
+
+	private scheduleSave(): void {
+		if (
+			this.note.guidelineId === null &&
+			this.note.body.trim().length === 0
+		) {
+			this.setPhase( 'idle' );
+			return;
+		}
+		if ( this.saveTimer !== null ) {
+			window.clearTimeout( this.saveTimer );
+		}
+		this.saveTimer = window.setTimeout( () => {
+			this.saveTimer = null;
+			void this.save();
+		}, SAVE_DEBOUNCE_MS );
+	}
+
+	private flushSave(): void {
+		if ( this.saveTimer !== null ) {
+			window.clearTimeout( this.saveTimer );
+			this.saveTimer = null;
+		}
+		if (
+			this.note.guidelineId !== null ||
+			this.note.body.trim().length > 0
+		) {
+			void this.save();
+		}
+	}
+
+	private async save(): Promise< void > {
+		if ( this.saving ) {
+			this.saveAgain = true;
+			this.setPhase( 'pending' );
+			return;
+		}
+		this.saving = true;
+		this.setPhase( 'saving' );
+		const bodyAtSave = this.note.body;
+		try {
+			const saved = await this.layer.save( {
+				...this.note,
+				body: bodyAtSave,
+			} );
+			if ( this.disposed ) {
+				return;
+			}
+			const oldKey = noteKey( this.note );
+			this.note.guidelineId = saved.guidelineId;
+			this.note.modified = saved.modified;
+			this.note.link = saved.link;
+			this.note.termIds = saved.termIds.length > 0 ? saved.termIds : this.note.termIds;
+			if ( this.note.body === bodyAtSave ) {
+				this.note.title = saved.title;
+				this.titleEl.textContent = saved.title;
+			}
+			if ( oldKey !== noteKey( this.note ) ) {
+				this.element.dataset.stickyNoteId = noteKey( this.note );
+				this.layer.replaceControllerKey( oldKey, this );
+			}
+			this.layer.bumpHighWaterFromNote( this.note );
+			this.refreshOpenButton();
+			this.setPhase( 'saved' );
+		} catch ( error ) {
+			if ( this.disposed ) {
+				return;
+			}
+			const message = error instanceof Error
+				? error.message
+				: __( 'Could not save sticky note.' );
+			this.setPhase( 'failed', message );
+			this.layer.notifyError( message );
+		} finally {
+			this.saving = false;
+			if ( ! this.disposed && this.saveAgain ) {
+				this.saveAgain = false;
+				this.scheduleSave();
+			}
+		}
+	}
+
+	private setPhase( phase: SavePhase, error?: string ): void {
+		this.statusEl.setAttribute( 'phase', phase );
+		if ( error ) {
+			this.statusEl.setAttribute( 'error', error );
+			this.statusEl.setAttribute( 'title', error );
+		} else {
+			this.statusEl.removeAttribute( 'error' );
+			this.statusEl.removeAttribute( 'title' );
+		}
+	}
+
+	private hasLocalChanges(): boolean {
+		const phase = this.statusEl.getAttribute( 'phase' );
+		return (
+			this.saveTimer !== null ||
+			this.saving ||
+			this.saveAgain ||
+			phase === 'pending' ||
+			phase === 'failed'
+		);
+	}
+
+	private startDrag( event: PointerEvent ): void {
+		if ( event.button !== 0 ) {
+			return;
+		}
+		const target = event.target as HTMLElement | null;
+		if ( target?.closest( 'wpd-window-button, wpd-save-status' ) ) {
+			return;
+		}
+		event.preventDefault();
+		const startRect = this.element.getBoundingClientRect();
+		const hostRect = this.layerHostRect();
+		const startLeft = startRect.left - hostRect.left;
+		const startTop = startRect.top - hostRect.top;
+		const startX = event.clientX;
+		const startY = event.clientY;
+		this.element.classList.add( 'desktop-mode-sticky-note--dragging' );
+		this.element.setPointerCapture?.( event.pointerId );
+
+		const move = ( moveEvent: PointerEvent ): void => {
+			const width = this.element.offsetWidth;
+			const height = this.element.offsetHeight;
+			const { width: hostWidth, height: hostHeight } = this.layer.hostSize();
+			const left = clamp(
+				startLeft + moveEvent.clientX - startX,
+				EDGE_PADDING,
+				Math.max( EDGE_PADDING, hostWidth - width - EDGE_PADDING ),
+			);
+			const top = clamp(
+				startTop + moveEvent.clientY - startY,
+				EDGE_PADDING,
+				Math.max( EDGE_PADDING, hostHeight - height - EDGE_PADDING ),
+			);
+			this.element.style.left = `${ left }px`;
+			this.element.style.top = `${ top }px`;
+		};
+		const up = ( upEvent: PointerEvent ): void => {
+			this.element.classList.remove( 'desktop-mode-sticky-note--dragging' );
+			this.element.releasePointerCapture?.( upEvent.pointerId );
+			document.removeEventListener( 'pointermove', move );
+			document.removeEventListener( 'pointerup', up );
+			this.persistGeometry();
+		};
+		document.addEventListener( 'pointermove', move );
+		document.addEventListener( 'pointerup', up );
+	}
+
+	private applyGeometry( geometry: StickyGeometry ): void {
+		const { width: hostWidth, height: hostHeight } = this.layer.hostSize();
+		const width = clamp( geometry.width, MIN_WIDTH, hostWidth - EDGE_PADDING * 2 );
+		const height = clamp( geometry.height, MIN_HEIGHT, hostHeight - EDGE_PADDING * 2 );
+		const left = clamp(
+			geometry.x * hostWidth,
+			EDGE_PADDING,
+			Math.max( EDGE_PADDING, hostWidth - width - EDGE_PADDING ),
+		);
+		const top = clamp(
+			geometry.y * hostHeight,
+			EDGE_PADDING,
+			Math.max( EDGE_PADDING, hostHeight - height - EDGE_PADDING ),
+		);
+		this.element.style.left = `${ left }px`;
+		this.element.style.top = `${ top }px`;
+		this.element.style.width = `${ width }px`;
+		this.element.style.height = `${ height }px`;
+	}
+
+	private watchResize(): void {
+		if ( typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+		this.resizeObserver = new ResizeObserver( () => {
+			if ( this.geometryTimer !== null ) {
+				window.clearTimeout( this.geometryTimer );
+			}
+			this.geometryTimer = window.setTimeout( () => {
+				this.geometryTimer = null;
+				this.persistGeometry();
+			}, 150 );
+		} );
+		this.resizeObserver.observe( this.element );
+	}
+
+	private persistGeometry(): void {
+		const { width: hostWidth, height: hostHeight } = this.layer.hostSize();
+		const left = parseFloat( this.element.style.left ) || 0;
+		const top = parseFloat( this.element.style.top ) || 0;
+		const existing = loadGeometry( noteKey( this.note ) );
+		saveGeometry( noteKey( this.note ), {
+			...( existing ?? {} ),
+			x: clamp( left / hostWidth, 0, 1 ),
+			y: clamp( top / hostHeight, 0, 1 ),
+			width: this.element.offsetWidth,
+			height: this.element.offsetHeight,
+		} );
+	}
+
+	private layerHostRect(): DOMRect {
+		const parent = this.element.parentElement?.parentElement;
+		return ( parent ?? document.body ).getBoundingClientRect();
+	}
+}
+
+export function bootStickyNotes( options: StickyNotesLayerOptions ): StickyNotesLayer {
+	const layer = new StickyNotesLayer( options );
+	void layer.boot();
+	return layer;
+}
+
+function noteKey( note: StickyNote ): string {
+	return note.guidelineId === null
+		? note.localId
+		: `guideline:${ note.guidelineId }`;
+}
+
+function noteModifiedMs( note: StickyNote ): number {
+	if ( typeof note.modifiedMs === 'number' && Number.isFinite( note.modifiedMs ) ) {
+		return note.modifiedMs;
+	}
+	if ( ! note.modified ) {
+		return 0;
+	}
+	const parsed = Date.parse( note.modified );
+	return Number.isFinite( parsed ) ? parsed : 0;
+}
+
+function sortNotesByModified( notes: StickyNote[] ): StickyNote[] {
+	return [ ...notes ].sort( ( a, b ) => noteModifiedMs( a ) - noteModifiedMs( b ) );
+}
+
+function loadGeometry( key: string ): StickyGeometry | null {
+	const map = readGeometryMap();
+	const value = map[ key ];
+	if (
+		! value ||
+		! Number.isFinite( value.x ) ||
+		! Number.isFinite( value.y ) ||
+		! Number.isFinite( value.width ) ||
+		! Number.isFinite( value.height )
+	) {
+		return null;
+	}
+	return value;
+}
+
+function saveGeometry( key: string, geometry: StickyGeometry ): void {
+	const map = readGeometryMap();
+	map[ key ] = geometry;
+	writeGeometryMap( map );
+}
+
+function moveStoredGeometry( oldKey: string, newKey: string ): void {
+	if ( oldKey === newKey ) {
+		return;
+	}
+	const map = readGeometryMap();
+	if ( map[ oldKey ] ) {
+		map[ newKey ] = map[ oldKey ];
+		delete map[ oldKey ];
+		writeGeometryMap( map );
+	}
+}
+
+function readGeometryMap(): Record< string, StickyGeometry > {
+	try {
+		const raw = window.localStorage.getItem( GEOMETRY_KEY );
+		return raw ? JSON.parse( raw ) as Record< string, StickyGeometry > : {};
+	} catch {
+		return {};
+	}
+}
+
+function writeGeometryMap( map: Record< string, StickyGeometry > ): void {
+	try {
+		window.localStorage.setItem( GEOMETRY_KEY, JSON.stringify( map ) );
+	} catch {
+		// Geometry is a convenience; storage may be unavailable.
+	}
+}
+
+function clamp( value: number, min: number, max: number ): number {
+	if ( max < min ) {
+		return min;
+	}
+	return Math.min( max, Math.max( min, value ) );
+}

--- a/src/sticky-notes/rest.ts
+++ b/src/sticky-notes/rest.ts
@@ -1,0 +1,303 @@
+import { joinRestUrl } from '../rest-url';
+import { trackedFetch } from '../tracked-fetch';
+import {
+	DEFAULT_STICKY_TITLE,
+	noteComponentsForBody,
+	noteFromGuideline,
+} from './text';
+import type {
+	RestGuidelineTerm,
+	RestStickyGuideline,
+	StickyNote,
+	StickyTerms,
+} from './types';
+
+export interface StickyNotesRestConfig {
+	restUrl?: string;
+	adminUrl: string;
+}
+
+export class StickyNotesRestError extends Error {
+	status: number;
+
+	constructor( message: string, status: number ) {
+		super( message );
+		this.name = 'StickyNotesRestError';
+		this.status = status;
+	}
+}
+
+export async function resolveStickyTerms(
+	config: StickyNotesRestConfig,
+): Promise< StickyTerms | null > {
+	const terms = await fetchStickyTermCandidates( config );
+	const picked = pickStickyTerms(
+		[ ...terms.artifactTerms, ...terms.artifactsTerms ],
+		terms.noteTerms,
+		terms.stickyTerms,
+	);
+	if ( picked ) {
+		return picked;
+	}
+
+	const artifact = await ensureTerm( config, {
+		slug: 'artifact',
+		name: 'Artifact',
+		parent: 0,
+	} );
+	const note = await ensureTerm( config, {
+		slug: 'note',
+		name: 'Note',
+		parent: artifact.id,
+	} );
+	const sticky = await ensureTerm( config, {
+		slug: 'sticky',
+		name: 'Sticky',
+		parent: artifact.id,
+	} );
+	return {
+		stickyTermId: sticky.id,
+		termIds: uniqueNumbers( [ artifact.id, note.id, sticky.id ] ),
+	};
+}
+
+async function fetchStickyTermCandidates(
+	config: StickyNotesRestConfig,
+): Promise< {
+	artifactTerms: RestGuidelineTerm[];
+	artifactsTerms: RestGuidelineTerm[];
+	noteTerms: RestGuidelineTerm[];
+	stickyTerms: RestGuidelineTerm[];
+} > {
+	const [ artifactTerms, artifactsTerms, noteTerms, stickyTerms ] =
+		await Promise.all( [
+			fetchTermsBySlug( config, 'artifact' ),
+			fetchTermsBySlug( config, 'artifacts' ),
+			fetchTermsBySlug( config, 'note' ),
+			fetchTermsBySlug( config, 'sticky' ),
+		] );
+	return {
+		artifactTerms,
+		artifactsTerms,
+		noteTerms,
+		stickyTerms,
+	};
+}
+
+export function pickStickyTerms(
+	artifactTerms: RestGuidelineTerm[],
+	noteTerms: RestGuidelineTerm[],
+	stickyTerms: RestGuidelineTerm[],
+): StickyTerms | null {
+	if ( stickyTerms.length === 0 ) {
+		return null;
+	}
+	const artifact = artifactTerms.find( ( term ) =>
+		[ 'artifact', 'artifacts' ].includes( term.slug ),
+	) ?? artifactTerms[ 0 ] ?? null;
+	const sticky = artifact
+		? stickyTerms.find( ( term ) => Number( term.parent ) === artifact.id ) ??
+			stickyTerms[ 0 ]
+		: stickyTerms[ 0 ];
+	if ( ! sticky ) {
+		return null;
+	}
+	const note = artifact
+		? noteTerms.find( ( term ) => Number( term.parent ) === artifact.id ) ??
+			null
+		: null;
+	return {
+		stickyTermId: sticky.id,
+		termIds: uniqueNumbers( [
+			artifact?.id,
+			note?.id,
+			sticky.id,
+		] ),
+	};
+}
+
+export async function fetchStickyNotes(
+	config: StickyNotesRestConfig,
+	stickyTermId: number,
+): Promise< StickyNote[] > {
+	const guidelines = await requestJson< RestStickyGuideline[] >(
+		config,
+		pathWithQuery( 'wp/v2/guidelines', {
+			context: 'edit',
+			status: 'private',
+			per_page: '100',
+			orderby: 'modified',
+			order: 'desc',
+			wp_guideline_type: String( stickyTermId ),
+		} ),
+		undefined,
+		true,
+	);
+	return guidelines
+		.filter( ( guideline ) =>
+			Array.isArray( guideline.wp_guideline_type )
+				? guideline.wp_guideline_type.includes( stickyTermId )
+				: true,
+		)
+		.map( noteFromGuideline );
+}
+
+export async function saveStickyNote(
+	config: StickyNotesRestConfig,
+	note: StickyNote,
+	terms: StickyTerms,
+): Promise< StickyNote > {
+	const components = noteComponentsForBody( note.body, note.title );
+	const payload: Record< string, unknown > = {
+		status: 'private',
+		title: components.title,
+		content: components.content,
+		excerpt: components.excerpt,
+	};
+	if ( note.guidelineId === null ) {
+		payload.wp_guideline_type = terms.termIds;
+	}
+	const path = note.guidelineId === null
+		? 'wp/v2/guidelines'
+		: `wp/v2/guidelines/${ note.guidelineId }`;
+	const guideline = await requestJson< RestStickyGuideline >(
+		config,
+		path,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( payload ),
+		},
+		false,
+	);
+	return noteFromGuideline( guideline );
+}
+
+export function buildGuidelineEditUrl(
+	adminUrl: string,
+	guidelineId: number,
+): string {
+	const url = new URL( 'post.php', adminUrl );
+	url.searchParams.set( 'post', String( guidelineId ) );
+	url.searchParams.set( 'action', 'edit' );
+	return url.toString();
+}
+
+async function fetchTermsBySlug(
+	config: StickyNotesRestConfig,
+	slug: string,
+): Promise< RestGuidelineTerm[] > {
+	try {
+		return await requestJson< RestGuidelineTerm[] >(
+			config,
+			pathWithQuery( 'wp/v2/wp_guideline_type', {
+				context: 'edit',
+				slug,
+				per_page: '100',
+			} ),
+			undefined,
+			true,
+		);
+	} catch ( error ) {
+		if (
+			error instanceof StickyNotesRestError &&
+			( error.status === 404 || error.status === 400 )
+		) {
+			return [];
+		}
+		throw error;
+	}
+}
+
+async function ensureTerm(
+	config: StickyNotesRestConfig,
+	term: { slug: string; name: string; parent: number },
+): Promise< RestGuidelineTerm > {
+	const existing = await fetchTermsBySlug( config, term.slug );
+	const byParent = existing.find(
+		( item ) => Number( item.parent ?? 0 ) === term.parent,
+	);
+	if ( byParent ) {
+		return byParent;
+	}
+	if ( existing[ 0 ] ) {
+		return existing[ 0 ];
+	}
+	try {
+		return await requestJson< RestGuidelineTerm >(
+			config,
+			'wp/v2/wp_guideline_type',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify( term ),
+			},
+			true,
+		);
+	} catch ( error ) {
+		const fallback = await fetchTermsBySlug( config, term.slug );
+		if ( fallback[ 0 ] ) {
+			return fallback[ 0 ];
+		}
+		throw error;
+	}
+}
+
+async function requestJson< T >(
+	config: StickyNotesRestConfig,
+	path: string,
+	init?: RequestInit,
+	silent = true,
+): Promise< T > {
+	const response = await trackedFetch(
+		joinRestUrl( restRoot( config ), path ),
+		init,
+		{
+			source: 'desktop-mode/sticky-notes',
+			silent,
+		},
+	);
+	if ( ! response.ok ) {
+		throw new StickyNotesRestError(
+			response.statusText || `${ DEFAULT_STICKY_TITLE } request failed`,
+			response.status,
+		);
+	}
+	return await response.json() as T;
+}
+
+function restRoot( config: StickyNotesRestConfig ): string {
+	if ( config.restUrl ) {
+		return config.restUrl;
+	}
+	return `${ window.location.origin }/wp-json/`;
+}
+
+function pathWithQuery(
+	path: string,
+	query: Record< string, string >,
+): string {
+	const params = new URLSearchParams();
+	Object.entries( query ).forEach( ( [ key, value ] ) => {
+		params.set( key, value );
+	} );
+	return `${ path }?${ params.toString() }`;
+}
+
+function uniqueNumbers( values: Array< number | undefined > ): number[] {
+	const out: number[] = [];
+	values.forEach( ( value ) => {
+		if (
+			typeof value === 'number' &&
+			Number.isFinite( value ) &&
+			! out.includes( value )
+		) {
+			out.push( value );
+		}
+	} );
+	return out;
+}

--- a/src/sticky-notes/text.ts
+++ b/src/sticky-notes/text.ts
@@ -1,0 +1,193 @@
+import type {
+	RestStickyGuideline,
+	RestTextField,
+	StickyNote,
+} from './types';
+
+export const DEFAULT_STICKY_TITLE = 'Sticky Note';
+
+const LEGACY_METADATA_PREFIX = '<!-- wpworkspace-sticky:';
+const LEGACY_METADATA_SUFFIX = '-->';
+const TITLE_MAX = 64;
+const GENERATED_TITLE_MAX = 48;
+const EXCERPT_MAX = 180;
+
+export function noteFromGuideline(
+	guideline: RestStickyGuideline,
+): StickyNote {
+	const title = titleField( guideline.title );
+	const content = removeLegacyMetadataComment(
+		textFieldValue( guideline.content, { stripHtmlForRendered: true } ),
+	);
+	const modifiedMs = modifiedTimeMs( guideline );
+	return {
+		localId: `guideline:${ guideline.id }`,
+		guidelineId: guideline.id,
+		title,
+		body: editorBody( title, content ),
+		modified: guideline.modified,
+		...( modifiedMs > 0 ? { modifiedMs } : {} ),
+		link: guideline.link,
+		termIds: Array.isArray( guideline.wp_guideline_type )
+			? guideline.wp_guideline_type.filter( isFiniteNumber )
+			: [],
+	};
+}
+
+export function titleField( field: RestTextField ): string {
+	const candidates: string[] = [];
+	if ( typeof field === 'string' ) {
+		candidates.push( field );
+	} else if ( field && typeof field === 'object' ) {
+		if ( typeof field.raw === 'string' ) {
+			candidates.push( field.raw );
+		}
+		if ( typeof field.rendered === 'string' ) {
+			candidates.push( stripHtml( field.rendered ) );
+		}
+	}
+	for ( const candidate of candidates ) {
+		const trimmed = stripHtml( candidate ).trim();
+		if ( trimmed ) {
+			return trimmed;
+		}
+	}
+	return DEFAULT_STICKY_TITLE;
+}
+
+export function textFieldValue(
+	field: RestTextField,
+	options: { stripHtmlForRendered?: boolean } = {},
+): string {
+	if ( typeof field === 'string' ) {
+		return field;
+	}
+	if ( ! field || typeof field !== 'object' ) {
+		return '';
+	}
+	if ( typeof field.raw === 'string' && field.raw.length > 0 ) {
+		return field.raw;
+	}
+	if ( typeof field.rendered === 'string' ) {
+		return options.stripHtmlForRendered
+			? stripHtml( field.rendered )
+			: field.rendered;
+	}
+	return '';
+}
+
+export function titleForBody( body: string ): string {
+	const line = body
+		.split( /\r?\n/ )
+		.find( ( item ) => item.trim().length > 0 )
+		?.trim();
+	const title = line && line.length > 0 ? line : DEFAULT_STICKY_TITLE;
+	return truncate( title, TITLE_MAX );
+}
+
+export function generatedTitle( body: string ): string {
+	const collapsed = body.replace( /\s+/g, ' ' ).trim();
+	const title = collapsed || DEFAULT_STICKY_TITLE;
+	return truncate( title, GENERATED_TITLE_MAX );
+}
+
+export function editorBody( title: string, content: string ): string {
+	const trimmedTitle = title.trim();
+	if ( ! trimmedTitle ) {
+		return content;
+	}
+	const firstLine = content.split( /\r?\n/ )[ 0 ]?.trim();
+	if ( firstLine === trimmedTitle ) {
+		return content;
+	}
+	if ( ! content ) {
+		return trimmedTitle;
+	}
+	return `${ trimmedTitle }\n${ content }`;
+}
+
+export interface StickyNoteComponents {
+	title: string;
+	content: string;
+	excerpt: string;
+}
+
+export function noteComponentsForBody(
+	editorValue: string,
+	fallbackTitle: string = DEFAULT_STICKY_TITLE,
+): StickyNoteComponents {
+	const fallback = fallbackTitle.trim() || DEFAULT_STICKY_TITLE;
+	const title = titleForBody( editorValue );
+	const firstNewline = editorValue.search( /\r?\n/ );
+	if ( firstNewline === -1 ) {
+		const resolvedTitle = title === DEFAULT_STICKY_TITLE ? fallback : title;
+		return {
+			title: resolvedTitle,
+			content: '',
+			excerpt: excerptFor( resolvedTitle ),
+		};
+	}
+	let content = editorValue.slice( firstNewline );
+	content = content.replace( /^\r?\n/, '' );
+	if ( content.startsWith( '\n' ) ) {
+		content = content.slice( 1 );
+	}
+	return {
+		title,
+		content,
+		excerpt: excerptFor( content.trim() ? content : title ),
+	};
+}
+
+export function excerptFor( body: string ): string {
+	const collapsed = body.replace( /[\n\t]+/g, ' ' ).trim();
+	return truncate( collapsed, EXCERPT_MAX );
+}
+
+export function removeLegacyMetadataComment( content: string ): string {
+	if (
+		! content.startsWith( LEGACY_METADATA_PREFIX ) ||
+		! content.includes( LEGACY_METADATA_SUFFIX )
+	) {
+		return content;
+	}
+	const end = content.indexOf( LEGACY_METADATA_SUFFIX );
+	let body = content.slice( end + LEGACY_METADATA_SUFFIX.length );
+	if ( body.startsWith( '\r\n' ) ) {
+		body = body.slice( 2 );
+	} else if ( body.startsWith( '\n' ) ) {
+		body = body.slice( 1 );
+	}
+	return body;
+}
+
+function stripHtml( value: string ): string {
+	if ( typeof document !== 'undefined' ) {
+		const template = document.createElement( 'template' );
+		template.innerHTML = value;
+		return ( template.content.textContent ?? '' ).trim();
+	}
+	return value.replace( /<[^>]*>/g, '' ).trim();
+}
+
+function truncate( value: string, max: number ): string {
+	return value.length > max ? `${ value.slice( 0, max ) }...` : value;
+}
+
+function modifiedTimeMs( guideline: RestStickyGuideline ): number {
+	if (
+		typeof guideline.desktop_mode_modified_ms === 'number' &&
+		Number.isFinite( guideline.desktop_mode_modified_ms )
+	) {
+		return guideline.desktop_mode_modified_ms;
+	}
+	if ( ! guideline.modified ) {
+		return 0;
+	}
+	const parsed = Date.parse( guideline.modified );
+	return Number.isFinite( parsed ) ? parsed : 0;
+}
+
+function isFiniteNumber( value: unknown ): value is number {
+	return typeof value === 'number' && Number.isFinite( value );
+}

--- a/src/sticky-notes/types.ts
+++ b/src/sticky-notes/types.ts
@@ -1,0 +1,65 @@
+export type RestTextField =
+	| string
+	| {
+			raw?: string;
+			rendered?: string;
+		}
+	| null
+	| undefined;
+
+export interface RestGuidelineTerm {
+	id: number;
+	name?: string;
+	slug: string;
+	parent?: number;
+}
+
+export interface RestStickyGuideline {
+	id: number;
+	slug?: string;
+	status?: string;
+	title?: RestTextField;
+	content?: RestTextField;
+	excerpt?: RestTextField;
+	modified?: string;
+	desktop_mode_modified_ms?: number;
+	link?: string;
+	wp_guideline_type?: number[];
+}
+
+export interface StickyTerms {
+	stickyTermId: number;
+	termIds: number[];
+}
+
+export interface StickyNote {
+	localId: string;
+	guidelineId: number | null;
+	title: string;
+	body: string;
+	modified?: string;
+	modifiedMs?: number;
+	link?: string;
+	termIds: number[];
+}
+
+export interface StickyGeometry {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	desktopId?: string;
+}
+
+export interface StickyNotesHeartbeatSubscribe {
+	stickyTermId: number;
+	knownIds: number[];
+	version: number;
+}
+
+export interface StickyNotesHeartbeatPayload {
+	notes?: RestStickyGuideline[];
+	removed?: number[];
+	serverTimeMs?: number;
+	truncated?: boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1460,8 +1460,9 @@ export interface SessionWindow {
 }
 
 /**
- * The user's saved desktop session — open windows, focused id, last-write
- * timestamp. Restored by the shell on load; written back debounced.
+ * The user's saved desktop session — open windows, virtual desktops, focused
+ * id, active desktop id, and last-write timestamp. Restored by the shell on
+ * load; written back debounced.
  *
  * `desktops` + `activeDesktop` are post-multi-desktop additions and
  * carry sane defaults from the server side, so older clients reading
@@ -1763,6 +1764,14 @@ export interface DesktopConfig {
 	session: Session;
 	/** REST endpoint for reading/writing the session. */
 	sessionUrl: string;
+	/**
+	 * REST API root from `rest_url()`. Compose arbitrary REST
+	 * endpoints with `joinRestUrl()` so plain-permalink installs
+	 * (`?rest_route=/`) work alongside pretty `/wp-json/` installs.
+	 *
+	 * @since 0.8.8
+	 */
+	restUrl?: string;
 	/** REST endpoint for media uploads (wp/v2/media). */
 	mediaUrl: string;
 	/**

--- a/src/ui/components/wpd-textarea/wpd-textarea.ts
+++ b/src/ui/components/wpd-textarea/wpd-textarea.ts
@@ -43,6 +43,7 @@ export class WpdTextarea extends Component {
 		'placeholder',
 		'disabled',
 		'readonly',
+		'ariaLabel',
 		'name',
 		'rows',
 		'maxlength',
@@ -66,6 +67,7 @@ export class WpdTextarea extends Component {
 			{ name: 'placeholder', type: 'string', description: 'Native placeholder.' },
 			{ name: 'disabled', type: 'boolean attribute' },
 			{ name: 'readonly', type: 'boolean attribute' },
+			{ name: 'aria-label', type: 'string', description: 'Accessible label when no visible label is rendered.' },
 			{ name: 'name', type: 'string', description: 'Forwarded to native textarea for form submission.' },
 			{ name: 'rows', type: 'integer (string)', default: '3', description: 'Initial visible row count.' },
 			{ name: 'maxlength', type: 'integer (string)' },
@@ -106,6 +108,7 @@ export class WpdTextarea extends Component {
 		const placeholder = this._attr( 'placeholder' ) || '';
 		const disabled = this._boolAttr( 'disabled' );
 		const readonly = this._boolAttr( 'readonly' );
+		const ariaLabel = this._attr( 'aria-label' ) || label;
 		const name = this._attr( 'name' ) || '';
 		const rows = Number( this._attr( 'rows' ) ) || 3;
 		const maxLength = this._attr( 'maxlength' );
@@ -131,7 +134,7 @@ export class WpdTextarea extends Component {
 				minlength=${ minLength ?? '' }
 				name=${ name }
 				aria-invalid=${ invalid ? 'true' : 'false' }
-				aria-label=${ label || '' }
+				aria-label=${ ariaLabel || '' }
 				@input=${ ( e: Event ) => this._onInput( e ) }
 				@change=${ ( e: Event ) => this._onChange( e ) }
 				@keydown=${ ( e: KeyboardEvent ) => this._onKeyDown( e ) }

--- a/tests/phpunit/tests/desktopModeHooks.php
+++ b/tests/phpunit/tests/desktopModeHooks.php
@@ -108,7 +108,7 @@ class Tests_DesktopMode_DesktopModeHooks extends WP_UnitTestCase {
 		desktop_mode_enqueue_assets();
 
 		$this->assertIsArray( $received );
-		foreach ( array( 'currentPage', 'currentTitle', 'currentIcon', 'adminUrl', 'colorScheme', 'dockItems', 'fromPortal', 'fromPortalIntent' ) as $key ) {
+		foreach ( array( 'currentPage', 'currentTitle', 'currentIcon', 'adminUrl', 'restUrl', 'colorScheme', 'dockItems', 'fromPortal', 'fromPortalIntent' ) as $key ) {
 			$this->assertArrayHasKey( $key, $received, "Config missing key: $key" );
 		}
 	}

--- a/tests/phpunit/tests/stickyNotesHeartbeat.php
+++ b/tests/phpunit/tests/stickyNotesHeartbeat.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Tests for Gutenberg sticky notes over the Desktop Mode Heartbeat bus.
+ *
+ * @group desktop-mode
+ * @group desktop-mode-sticky-notes
+ */
+class Tests_DesktopMode_StickyNotesHeartbeat extends WP_UnitTestCase {
+
+	protected static $user_id;
+	protected $sticky_term_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		update_user_meta( self::$user_id, 'desktop_mode_mode', '1' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$user_id );
+		$this->register_guidelines_surface();
+		$this->sticky_term_id = $this->ensure_term( 'sticky', 'Sticky' );
+	}
+
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::desktop_mode_sticky_notes_compute_heartbeat_delta
+	 * @covers ::desktop_mode_sticky_notes_shape_guideline
+	 */
+	public function test_delta_returns_changed_private_sticky_guidelines() {
+		$sticky_id = $this->create_guideline(
+			array(
+				'post_title'   => 'Remember',
+				'post_content' => 'Do the thing',
+				'terms'        => array( $this->sticky_term_id ),
+			)
+		);
+		$this->create_guideline(
+			array(
+				'post_title' => 'Not sticky',
+				'terms'      => array(),
+			)
+		);
+
+		$delta = desktop_mode_sticky_notes_compute_heartbeat_delta(
+			$this->sticky_term_id,
+			array(),
+			0,
+			100
+		);
+
+		$this->assertCount( 1, $delta['notes'] );
+		$this->assertSame( $sticky_id, $delta['notes'][0]['id'] );
+		$this->assertSame( 'Remember', $delta['notes'][0]['title']['raw'] );
+		$this->assertSame( 'Do the thing', $delta['notes'][0]['content']['raw'] );
+		$this->assertContains( $this->sticky_term_id, $delta['notes'][0]['wp_guideline_type'] );
+		$this->assertGreaterThan( 0, $delta['notes'][0]['desktop_mode_modified_ms'] );
+		$this->assertSame( array(), $delta['removed'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sticky_notes_compute_heartbeat_delta
+	 * @covers ::desktop_mode_sticky_notes_alive_known_ids
+	 */
+	public function test_delta_reports_known_ids_that_are_no_longer_stickies_as_removed() {
+		$sticky_id = $this->create_guideline(
+			array(
+				'post_title' => 'Alive sticky',
+				'terms'      => array( $this->sticky_term_id ),
+			)
+		);
+		$plain_id  = $this->create_guideline(
+			array(
+				'post_title' => 'Plain guideline',
+				'terms'      => array(),
+			)
+		);
+
+		$delta = desktop_mode_sticky_notes_compute_heartbeat_delta(
+			$this->sticky_term_id,
+			array( $sticky_id, $plain_id, 999999 ),
+			0,
+			100
+		);
+
+		$this->assertContains( $plain_id, $delta['removed'] );
+		$this->assertContains( 999999, $delta['removed'] );
+		$this->assertNotContains( $sticky_id, $delta['removed'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sticky_notes_heartbeat_received
+	 */
+	public function test_heartbeat_handler_uses_subscription_payload() {
+		$sticky_id = $this->create_guideline(
+			array(
+				'post_title' => 'Heartbeat sticky',
+				'terms'      => array( $this->sticky_term_id ),
+			)
+		);
+
+		$response = desktop_mode_sticky_notes_heartbeat_received(
+			array( 'other' => 'untouched' ),
+			array(
+				'desktop_mode_sticky_notes_subscribe' => array(
+					'stickyTermId' => $this->sticky_term_id,
+					'knownIds'     => array(),
+					'version'      => 0,
+				),
+			)
+		);
+
+		$this->assertSame( 'untouched', $response['other'] );
+		$this->assertArrayHasKey( 'desktop_mode_sticky_notes', $response );
+		$this->assertSame( $sticky_id, $response['desktop_mode_sticky_notes']['notes'][0]['id'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sticky_notes_heartbeat_received
+	 */
+	public function test_filter_is_registered_on_heartbeat_received() {
+		$this->assertNotFalse(
+			has_filter(
+				'heartbeat_received',
+				'desktop_mode_sticky_notes_heartbeat_received'
+			),
+			'Sticky notes should hook the shared Heartbeat response.'
+		);
+	}
+
+	protected function register_guidelines_surface() {
+		if ( ! post_type_exists( DESKTOP_MODE_STICKY_NOTES_POST_TYPE ) ) {
+			register_post_type(
+				DESKTOP_MODE_STICKY_NOTES_POST_TYPE,
+				array(
+					'public'       => false,
+					'show_in_rest' => true,
+					'supports'     => array( 'title', 'editor', 'excerpt' ),
+				)
+			);
+		}
+		if ( ! taxonomy_exists( DESKTOP_MODE_STICKY_NOTES_TAXONOMY ) ) {
+			register_taxonomy(
+				DESKTOP_MODE_STICKY_NOTES_TAXONOMY,
+				DESKTOP_MODE_STICKY_NOTES_POST_TYPE,
+				array(
+					'hierarchical' => true,
+					'show_in_rest' => true,
+				)
+			);
+		}
+	}
+
+	protected function ensure_term( $slug, $name ) {
+		$existing = get_term_by( 'slug', $slug, DESKTOP_MODE_STICKY_NOTES_TAXONOMY );
+		if ( $existing ) {
+			return (int) $existing->term_id;
+		}
+		$term = wp_insert_term(
+			$name,
+			DESKTOP_MODE_STICKY_NOTES_TAXONOMY,
+			array( 'slug' => $slug )
+		);
+		return (int) $term['term_id'];
+	}
+
+	protected function create_guideline( $args = array() ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => DESKTOP_MODE_STICKY_NOTES_POST_TYPE,
+				'post_status'  => 'private',
+				'post_title'   => isset( $args['post_title'] ) ? $args['post_title'] : 'Guideline',
+				'post_content' => isset( $args['post_content'] ) ? $args['post_content'] : '',
+			)
+		);
+		if ( ! empty( $args['terms'] ) ) {
+			wp_set_object_terms(
+				$post_id,
+				array_map( 'intval', (array) $args['terms'] ),
+				DESKTOP_MODE_STICKY_NOTES_TAXONOMY
+			);
+		}
+		return (int) $post_id;
+	}
+}

--- a/tests/vitest/boot-session.test.ts
+++ b/tests/vitest/boot-session.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { hasRestorableSession } from '../../src/boot/session';
+import { wireSessionEvents } from '../../src/boot/shell-lifecycle';
+import { HOOKS } from '../../src/hooks';
+import {
+	clearHooksStub,
+	installHooksStub,
+} from './helpers/hooks-stub';
+import type { Session } from '../../src/types';
+
+afterEach( () => {
+	clearHooksStub();
+} );
+
+describe( 'boot session helpers', () => {
+	test( 'treats desktop-only state as restorable once it has been saved', () => {
+		expect(
+			hasRestorableSession(
+				session( {
+					desktops: [
+						{ id: 'desktop-1', label: 'Desktop 1' },
+						{ id: 'desktop-2', label: 'Desktop 2' },
+					],
+					activeDesktop: 'desktop-2',
+					updated: 10,
+				} ),
+			),
+		).toBe( true );
+	} );
+
+	test( 'does not treat the server default empty shape as a saved session', () => {
+		expect(
+			hasRestorableSession(
+				session( {
+					updated: 0,
+				} ),
+			),
+		).toBe( false );
+	} );
+
+	test( 'desktop lifecycle hooks schedule session persistence', () => {
+		const hooks = installHooksStub();
+		const save = vi.fn();
+		wireSessionEvents( save );
+
+		hooks.doAction( HOOKS.DESKTOP_CREATED, { desktopId: 'desktop-2' } );
+		hooks.doAction( HOOKS.DESKTOP_SWITCHED, {
+			from: 'desktop-1',
+			to: 'desktop-2',
+		} );
+		hooks.doAction( HOOKS.DESKTOP_CLOSED, {
+			desktopId: 'desktop-2',
+			migratedTo: 'desktop-1',
+		} );
+
+		expect( save ).toHaveBeenCalledTimes( 3 );
+	} );
+} );
+
+function session( patch: Partial< Session > = {} ): Session {
+	return {
+		windows: [],
+		desktops: [ { id: 'desktop-1', label: 'Desktop 1' } ],
+		activeDesktop: 'desktop-1',
+		focused: '',
+		updated: 0,
+		...patch,
+	};
+}

--- a/tests/vitest/sticky-notes.test.ts
+++ b/tests/vitest/sticky-notes.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+	_resetHeartbeatBusForTests,
+	bootHeartbeatBus,
+} from '../../src/heartbeat';
+import {
+	__resetStickyNotesHeartbeatForTests,
+	startStickyNotesHeartbeat,
+} from '../../src/sticky-notes/heartbeat';
+import { StickyNotesLayer } from '../../src/sticky-notes/layer';
+import {
+	editorBody,
+	noteComponentsForBody,
+	noteFromGuideline,
+	removeLegacyMetadataComment,
+	titleField,
+	titleForBody,
+} from '../../src/sticky-notes/text';
+import { buildGuidelineEditUrl, pickStickyTerms } from '../../src/sticky-notes/rest';
+import type { StickyNote } from '../../src/sticky-notes/types';
+
+interface HeartbeatHandlers {
+	'heartbeat-send'?: ( e: unknown, data: Record< string, unknown > ) => void;
+	'heartbeat-tick'?: ( e: unknown, response: Record< string, unknown > ) => void;
+}
+
+afterEach( () => {
+	_resetHeartbeatBusForTests();
+	__resetStickyNotesHeartbeatForTests();
+	vi.restoreAllMocks();
+	window.localStorage.removeItem( 'desktop-mode-sticky-notes-geometry' );
+	delete ( window as unknown as { jQuery?: unknown } ).jQuery;
+} );
+
+describe( 'sticky notes text helpers', () => {
+	test( 'titleField prefers raw text and strips rendered HTML fallback', () => {
+		expect(
+			titleField( { raw: '', rendered: '<strong>Rendered title</strong>' } ),
+		).toBe( 'Rendered title' );
+		expect( titleField( { raw: 'Raw title', rendered: 'Rendered' } ) ).toBe(
+			'Raw title',
+		);
+	} );
+
+	test( 'editorBody does not duplicate a title already present in content', () => {
+		expect( editorBody( 'Plan', 'Plan\nDo the thing' ) ).toBe(
+			'Plan\nDo the thing',
+		);
+		expect( editorBody( 'Plan', 'Do the thing' ) ).toBe(
+			'Plan\nDo the thing',
+		);
+	} );
+
+	test( 'noteComponentsForBody stores first line as title and rest as content', () => {
+		expect( noteComponentsForBody( 'Title\nBody line', 'Fallback' ) ).toEqual( {
+			title: 'Title',
+			content: 'Body line',
+			excerpt: 'Body line',
+		} );
+		expect( noteComponentsForBody( 'Only title', 'Fallback' ) ).toMatchObject( {
+			title: 'Only title',
+			content: '',
+		} );
+	} );
+
+	test( 'removeLegacyMetadataComment strips Whispress legacy metadata', () => {
+		expect(
+			removeLegacyMetadataComment(
+				'<!-- wpworkspace-sticky:{"x":1} -->\nActual body',
+			),
+		).toBe( 'Actual body' );
+	} );
+
+	test( 'noteFromGuideline builds the editable note body', () => {
+		const note = noteFromGuideline( {
+			id: 9,
+			title: { raw: 'Sticky A' },
+			content: { raw: 'Remember this' },
+			desktop_mode_modified_ms: 1234,
+			wp_guideline_type: [ 3, 5 ],
+		} );
+		expect( note.guidelineId ).toBe( 9 );
+		expect( note.title ).toBe( 'Sticky A' );
+		expect( note.body ).toBe( 'Sticky A\nRemember this' );
+		expect( note.modifiedMs ).toBe( 1234 );
+		expect( note.termIds ).toEqual( [ 3, 5 ] );
+	} );
+
+	test( 'titleForBody falls back for empty notes', () => {
+		expect( titleForBody( '\n\t' ) ).toBe( 'Sticky Note' );
+	} );
+} );
+
+describe( 'sticky notes heartbeat', () => {
+	test( 'contributes sticky subscription and applies heartbeat payloads', () => {
+		const handlers: HeartbeatHandlers = {};
+		( window as unknown as { jQuery: unknown } ).jQuery = () => ( {
+			on: (
+				event: keyof HeartbeatHandlers,
+				handler: ( e: unknown, data: Record< string, unknown > ) => void,
+			) => {
+				handlers[ event ] = handler;
+			},
+		} );
+		bootHeartbeatBus();
+
+		const applyHeartbeatPayload = vi.fn();
+		startStickyNotesHeartbeat( {
+			getHeartbeatSubscription: () => ( {
+				stickyTermId: 5,
+				knownIds: [ 10, 12 ],
+				version: 1700,
+			} ),
+			applyHeartbeatPayload,
+		} );
+
+		const data: Record< string, unknown > = {};
+		handlers[ 'heartbeat-send' ]?.( {}, data );
+		expect( data.desktop_mode_sticky_notes_subscribe ).toEqual( {
+			stickyTermId: 5,
+			knownIds: [ 10, 12 ],
+			version: 1700,
+		} );
+
+		const payload = {
+			notes: [ { id: 14, title: { raw: 'Remote' } } ],
+			removed: [ 10 ],
+			serverTimeMs: 1800,
+		};
+		handlers[ 'heartbeat-tick' ]?.( {}, {
+			desktop_mode_sticky_notes: payload,
+		} );
+		expect( applyHeartbeatPayload ).toHaveBeenCalledWith( payload );
+	} );
+} );
+
+describe( 'sticky notes layer', () => {
+	test( 'uses compact default geometry for desktop notes', () => {
+		const host = createSizedHost();
+		const layer = new StickyNotesLayer( {
+			host,
+			config: { adminUrl: 'https://example.test/wp-admin/' },
+			openArtifact: vi.fn(),
+		} );
+
+		expect( layer.defaultGeometry( 0 ) ).toMatchObject( {
+			width: 264,
+			height: 176,
+		} );
+
+		host.remove();
+	} );
+
+	test( 'brings the selected sticky note to the top of the sticky layer', () => {
+		const host = createSizedHost();
+
+		const layer = new StickyNotesLayer( {
+			host,
+			config: { adminUrl: 'https://example.test/wp-admin/' },
+			openArtifact: vi.fn(),
+		} );
+		const upsert = (
+			layer as unknown as {
+				upsert: ( note: StickyNote, index: number ) => { element: HTMLElement };
+			}
+		).upsert.bind( layer );
+
+		const older = upsert( stickyNote( 1, 1000 ), 0 );
+		const newer = upsert( stickyNote( 2, 2000 ), 1 );
+
+		expect( Number( newer.element.style.zIndex ) ).toBeGreaterThan(
+			Number( older.element.style.zIndex ),
+		);
+
+		older.element.dispatchEvent(
+			new MouseEvent( 'pointerdown', { bubbles: true } ),
+		);
+
+		expect( Number( older.element.style.zIndex ) ).toBeGreaterThan(
+			Number( newer.element.style.zIndex ),
+		);
+
+		host.remove();
+	} );
+
+	test( 'assigns new sticky notes to the active desktop', () => {
+		let activeDesktopId = 'desktop-1';
+		const host = createSizedHost();
+		const layer = new StickyNotesLayer( {
+			host,
+			config: { adminUrl: 'https://example.test/wp-admin/' },
+			getActiveDesktopId: () => activeDesktopId,
+			openArtifact: vi.fn(),
+		} );
+		const privateLayer = layer as unknown as {
+			upsert: ( note: StickyNote, index: number ) => { element: HTMLElement };
+			refreshDesktopVisibility: () => void;
+		};
+
+		const note = privateLayer.upsert( stickyNote( 3, 3000 ), 0 );
+		expect( note.element.style.display ).toBe( '' );
+		expect(
+			JSON.parse(
+				window.localStorage.getItem( 'desktop-mode-sticky-notes-geometry' ) ??
+					'{}',
+			)[ 'guideline:3' ].desktopId,
+		).toBe( 'desktop-1' );
+
+		activeDesktopId = 'desktop-2';
+		privateLayer.refreshDesktopVisibility();
+		expect( note.element.style.display ).toBe( 'none' );
+
+		activeDesktopId = 'desktop-1';
+		privateLayer.refreshDesktopVisibility();
+		expect( note.element.style.display ).toBe( '' );
+
+		host.remove();
+	} );
+
+	test( 'migrates sticky assignments when a desktop is closed', () => {
+		let activeDesktopId = 'desktop-2';
+		window.localStorage.setItem(
+			'desktop-mode-sticky-notes-geometry',
+			JSON.stringify( {
+				'guideline:4': {
+					x: 0.1,
+					y: 0.1,
+					width: 264,
+					height: 176,
+					desktopId: 'desktop-2',
+				},
+			} ),
+		);
+		const host = createSizedHost();
+		const layer = new StickyNotesLayer( {
+			host,
+			config: { adminUrl: 'https://example.test/wp-admin/' },
+			getActiveDesktopId: () => activeDesktopId,
+			openArtifact: vi.fn(),
+		} );
+		const privateLayer = layer as unknown as {
+			upsert: ( note: StickyNote, index: number ) => { element: HTMLElement };
+			migrateDesktopAssignments: ( desktopId: string, migratedTo: string ) => void;
+			refreshDesktopVisibility: () => void;
+		};
+		const note = privateLayer.upsert( stickyNote( 4, 4000 ), 0 );
+		expect( note.element.style.display ).toBe( '' );
+
+		activeDesktopId = 'desktop-1';
+		privateLayer.migrateDesktopAssignments( 'desktop-2', 'desktop-1' );
+		privateLayer.refreshDesktopVisibility();
+
+		expect( note.element.style.display ).toBe( '' );
+		expect(
+			JSON.parse(
+				window.localStorage.getItem( 'desktop-mode-sticky-notes-geometry' ) ??
+					'{}',
+			)[ 'guideline:4' ].desktopId,
+		).toBe( 'desktop-1' );
+
+		host.remove();
+	} );
+
+	test( 'preserves a stored desktop id that is not registered yet during boot', () => {
+		window.localStorage.setItem(
+			'desktop-mode-sticky-notes-geometry',
+			JSON.stringify( {
+				'guideline:5': {
+					x: 0.1,
+					y: 0.1,
+					width: 264,
+					height: 176,
+					desktopId: 'desktop-2',
+				},
+			} ),
+		);
+		const host = createSizedHost();
+		const layer = new StickyNotesLayer( {
+			host,
+			config: { adminUrl: 'https://example.test/wp-admin/' },
+			getActiveDesktopId: () => 'desktop-1',
+			openArtifact: vi.fn(),
+		} );
+		const privateLayer = layer as unknown as {
+			upsert: ( note: StickyNote, index: number ) => { element: HTMLElement };
+		};
+
+		const note = privateLayer.upsert( stickyNote( 5, 5000 ), 0 );
+
+		expect( note.element.style.display ).toBe( 'none' );
+		expect(
+			JSON.parse(
+				window.localStorage.getItem( 'desktop-mode-sticky-notes-geometry' ) ??
+					'{}',
+			)[ 'guideline:5' ].desktopId,
+		).toBe( 'desktop-2' );
+
+		host.remove();
+	} );
+
+	test( 'keeps editor keystrokes from reaching global shortcut listeners', () => {
+		const host = createSizedHost();
+		const layer = new StickyNotesLayer( {
+			host,
+			config: { adminUrl: 'https://example.test/wp-admin/' },
+			openArtifact: vi.fn(),
+		} );
+		const privateLayer = layer as unknown as {
+			upsert: ( note: StickyNote, index: number ) => { element: HTMLElement };
+		};
+		const note = privateLayer.upsert( stickyNote( 6, 6000 ), 0 );
+		const onDocumentKey = vi.fn();
+		document.addEventListener( 'keydown', onDocumentKey );
+
+		note.element
+			.querySelector( 'wpd-textarea' )!
+			.dispatchEvent(
+				new KeyboardEvent( 'keydown', {
+					key: 'n',
+					bubbles: true,
+					composed: true,
+				} ),
+			);
+
+		expect( onDocumentKey ).not.toHaveBeenCalled();
+
+		document.removeEventListener( 'keydown', onDocumentKey );
+		host.remove();
+	} );
+} );
+
+describe( 'sticky notes REST helpers', () => {
+	test( 'pickStickyTerms prefers sticky under artifact/artifacts parent', () => {
+		expect(
+			pickStickyTerms(
+				[ { id: 10, slug: 'artifacts' } ],
+				[ { id: 11, slug: 'note', parent: 10 } ],
+				[
+					{ id: 99, slug: 'sticky', parent: 1 },
+					{ id: 12, slug: 'sticky', parent: 10 },
+				],
+			),
+		).toEqual( {
+			stickyTermId: 12,
+			termIds: [ 10, 11, 12 ],
+		} );
+	} );
+
+	test( 'buildGuidelineEditUrl points at the CPT edit screen', () => {
+		expect( buildGuidelineEditUrl( 'https://example.test/wp-admin/', 42 ) )
+			.toBe( 'https://example.test/wp-admin/post.php?post=42&action=edit' );
+	} );
+} );
+
+function stickyNote( id: number, modifiedMs: number ): StickyNote {
+	return {
+		localId: `guideline:${ id }`,
+		guidelineId: id,
+		title: `Sticky ${ id }`,
+		body: `Sticky ${ id }`,
+		modifiedMs,
+		termIds: [ 5 ],
+	};
+}
+
+function createSizedHost(): HTMLElement {
+	const host = document.createElement( 'div' );
+	Object.defineProperty( host, 'clientWidth', {
+		value: 1200,
+		configurable: true,
+	} );
+	Object.defineProperty( host, 'clientHeight', {
+		value: 800,
+		configurable: true,
+	} );
+	document.body.appendChild( host );
+	return host;
+}


### PR DESCRIPTION
## What changed

- Adds Gutenberg Guidelines-backed sticky notes to Desktop Mode, loading `wp_guideline` posts tagged with sticky artifact terms into a draggable/resizable desktop note layer.
- Adds a wallpaper context-menu action for creating a new sticky note in desktop mode, with autosave through `trackedFetch`.
- Hooks sticky notes into the shared WordPress Heartbeat bus so other-tab/editor changes arrive as deltas and deleted/retagged notes disappear without a refresh.
- Scopes sticky placement to virtual desktops: new notes land on the active desktop, switch with Spaces, migrate when a desktop is closed, and survive refresh even when no windows are open.
- Keeps sticky-note editor keystrokes inside the editor so shell/admin global shortcuts do not fire while typing note text.
- Adds REST root config, sticky term resolution/creation, sticky note text parsing, local geometry persistence, and focused tests.
- Updates `wp-env` so Gutenberg is installed and the Guidelines experiment is enabled automatically for local dev/test containers.
- Documents the new shell config and session-persistence behavior.

## Why

Desktop Mode needs to surface Gutenberg Guidelines sticky artifacts directly on the desktop when they are present, keep them fresh across open tabs, and make fresh local environments testable without manual Gutenberg setup.


https://github.com/user-attachments/assets/b4c0e3c2-3139-4463-94e3-a24168b3b595



## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:js -- sticky-notes boot-session`
- `npm run test:js`
- `npm run build`
- `npm run package`
- `unzip -t desktop-mode.zip`
- `npm run test:php -- --filter='Tests_DesktopMode_StickyNotesHeartbeat'`
- Browser smoke in local wp-env: confirmed `New sticky note` appears in the wallpaper menu and creates a sticky note.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-265-cf2f6084241a3760a452457e49eefe3a86b5a115.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->