### PR TITLE
Speed improvements

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -125,51 +125,113 @@ html.wp-toolbar:has( body.desktop-mode-chromeless ) {
 
 /* ---------------------------------------------------------------
  * Page title & header
- * The window title bar already shows the page title, and the
- * submenu tab strip below it already exposes actions like
- * "Add New". Hide the in-page <h1>, the adjacent action button
- * (.page-title-action), and the header separator (.wp-header-end)
- * so the window content starts flush without a redundant header.
+ * The window title bar already shows the page title, so the
+ * in-page <h1> + header separator (.wp-header-end) are redundant
+ * inside chromeless iframes. Hide them so the window content
+ * starts flush.
  *
- * Plugins that need their action button to remain visible can
- * override these rules by enqueueing CSS on the
- * 'desktop_mode_chromeless_styles' action.
+ * `.page-title-action` (the "Add New" / "Add Order" button next to
+ * the H1) stays VISIBLE by default — it's the only entry point to
+ * the add-new flow on many plugin pages (WooCommerce Orders, custom
+ * CPTs, plugin settings pages, etc.). Earlier versions of this CSS
+ * hid it on the assumption that the submenu tab strip exposed the
+ * same action — which holds for WP Core pages with a registered
+ * "Add New" submenu (Posts, Pages, Users) but breaks every third-
+ * party plugin page that has no submenu equivalent. A small bit of
+ * redundancy with the submenu strip on Core pages is the better
+ * trade-off vs. losing the primary affordance on plugin pages
+ * entirely.
+ *
+ * Sites that prefer the cleaner Core-page look can hide the button
+ * on specific pages via the `desktop_mode_chromeless_styles`
+ * action — e.g.:
+ *
+ *     body.edit-php .wrap > .page-title-action { display: none; }
+ *
  * --------------------------------------------------------------- */
 .desktop-mode-chromeless .wrap > h1,
 .desktop-mode-chromeless .wrap > h1.wp-heading-inline,
 .desktop-mode-chromeless #wpbody-content > .wrap > h1,
-.desktop-mode-chromeless .wrap > .page-title-action,
 .desktop-mode-chromeless .wrap > .wp-header-end {
 	display: none;
 }
 
 /*
- * Exceptions: keep .page-title-action visible where it's the only
- * entry point to a sub-flow:
- *  - plugin-install.php → "Upload Plugin"
- *  - theme-install.php  → "Upload Theme"
+ * The H1 above it is hidden, so the button would float at the very
+ * top of the iframe area without breathing room — give it a small
+ * margin so it lands cleanly. inline-block matches WP Core's
+ * computed style on this element (matters for vertical-align with
+ * any adjacent inline content like the `.subsubsub` filter row).
  *
- * themes.php's native "Add Theme" page-title-action used to live
- * here, but the iframe scrolled past it on load (the focus-target
- * heuristic on the visible theme grid stole the scroll position),
- * which made the only entry point to theme-install.php disappear.
- * The Appearance window now ships an "Add Theme" tab in the
- * submenu strip (see desktop_mode_inject_appearance_tabs in
- * includes/themes-tabs.php), so the in-page button is redundant
- * and stays hidden.
- *
- * The theme-install.php "Upload Theme" exception is necessary
- * because the upload form is its own sub-flow with no equivalent
- * affordance elsewhere in the chromeless shell — without this
- * rule, users who want to install a .zip theme have no entry
- * point.
- *
- * See issue #38.
+ * Themes.php's native "Add Theme" button lives in the submenu tab
+ * strip via `desktop_mode_inject_appearance_tabs`
+ * (includes/themes-tabs.php), so its in-page page-title-action is
+ * redundant on that one screen — keep the per-page hide rule below
+ * so we don't ship two "Add Theme" entry points.
  */
-.desktop-mode-chromeless.plugin-install-php .wrap > .page-title-action,
-.desktop-mode-chromeless.theme-install-php .wrap > .page-title-action {
+.desktop-mode-chromeless .wrap > .page-title-action {
 	display: inline-block;
 	margin-top: 12px;
+}
+
+.desktop-mode-chromeless.themes-php .wrap > .page-title-action {
+	display: none;
+}
+
+/* ---------------------------------------------------------------
+ * WooCommerce "embed page" header overlay.
+ *
+ * Background: WC renders TWO layouts simultaneously on "connected"
+ * pages like `wc-orders` — the PHP-rendered legacy `.wrap` (with
+ * the h1 + the "Add order" `.page-title-action`) AND a React-mounted
+ * `EmbedHeader` (`client/admin/client/header/embed.tsx`) that
+ * `position: fixed`-overlays the page from the top. References:
+ *   - `src/Internal/Admin/Loader.php::embed_page_header`
+ *   - `includes/react-admin/connect-existing-pages.php` (registers
+ *      wc-orders as a connected page when HPOS is on)
+ *   - `client/admin/client/header/shared.tsx::useUpdateBodyMargin`
+ *      (the hook that pushes `#wpbody.style.marginTop` to make
+ *      room for the fixed header)
+ *
+ * In a chromeless iframe we have two conflicting affordances on
+ * the same screen:
+ *   1. The legacy `.wrap > .page-title-action` ("Add order") at the
+ *      very top of the document body — that's the primary
+ *      add-new-item button users expect.
+ *   2. The React `EmbedHeader` rendered fixed-position over the
+ *      top with a redundant `<h1>Orders</h1>` and an Activity
+ *      Panel toggle.
+ *
+ * The fixed React header OBSCURES the `.page-title-action`
+ * button when we reset `#wpbody`'s margin-top — the button paints
+ * at y≈19px inside the iframe, the header overlays y=0..~60px.
+ * Keeping the margin-top pushes the legacy content down but
+ * leaves a dead Activity-Panel-only banner that duplicates info
+ * the window title bar already shows.
+ *
+ * Resolution: hide the entire React header inside chromeless
+ * iframes. The window title bar already shows the page name; the
+ * Activity Panel's unread-notifications affordance is useful but
+ * not critical inside a per-window iframe (it's also reachable
+ * from the WC Home dashboard). Removing the fixed overlay lets
+ * the legacy `.wrap > .page-title-action` button paint at the top
+ * of the iframe where users expect it.
+ *
+ * Targeted by body class — both `.woocommerce-page` (set by PHP
+ * before React boots) and `.woocommerce-admin-page` (set by WC's
+ * React loader). We also keep a hard reset on `#wpbody`'s
+ * inline margin-top in case `useUpdateBodyMargin` runs before our
+ * `display: none` on the header takes effect.
+ *
+ * @since 0.8.9
+ */
+.desktop-mode-chromeless.woocommerce-page .woocommerce-layout__header,
+.desktop-mode-chromeless.woocommerce-admin-page .woocommerce-layout__header {
+	display: none !important;
+}
+.desktop-mode-chromeless.woocommerce-page #wpbody,
+.desktop-mode-chromeless.woocommerce-admin-page #wpbody {
+	margin-top: 0 !important;
 }
 
 /* ---------------------------------------------------------------

--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -179,7 +179,7 @@ html.wp-toolbar:has( body.desktop-mode-chromeless ) {
 }
 
 /* ---------------------------------------------------------------
- * WooCommerce "embed page" header overlay.
+ * WooCommerce "embed page" header overlay — page-scoped.
  *
  * Background: WC renders TWO layouts simultaneously on "connected"
  * pages like `wc-orders` — the PHP-rendered legacy `.wrap` (with
@@ -193,44 +193,38 @@ html.wp-toolbar:has( body.desktop-mode-chromeless ) {
  *      (the hook that pushes `#wpbody.style.marginTop` to make
  *      room for the fixed header)
  *
- * In a chromeless iframe we have two conflicting affordances on
- * the same screen:
- *   1. The legacy `.wrap > .page-title-action` ("Add order") at the
- *      very top of the document body — that's the primary
- *      add-new-item button users expect.
- *   2. The React `EmbedHeader` rendered fixed-position over the
- *      top with a redundant `<h1>Orders</h1>` and an Activity
- *      Panel toggle.
+ * The conflict, narrowly:
+ *   1. The legacy `.wrap > .page-title-action` ("Add order") at
+ *      the top of the document body — primary add-new affordance.
+ *   2. The React `EmbedHeader` overlays the top of the iframe with
+ *      a redundant `<h1>Orders</h1>` and an Activity Panel toggle.
  *
- * The fixed React header OBSCURES the `.page-title-action`
- * button when we reset `#wpbody`'s margin-top — the button paints
- * at y≈19px inside the iframe, the header overlays y=0..~60px.
- * Keeping the margin-top pushes the legacy content down but
- * leaves a dead Activity-Panel-only banner that duplicates info
- * the window title bar already shows.
+ * The fixed React header OBSCURES the legacy `.page-title-action`
+ * button when we reset `#wpbody`'s margin-top.
  *
- * Resolution: hide the entire React header inside chromeless
- * iframes. The window title bar already shows the page name; the
- * Activity Panel's unread-notifications affordance is useful but
- * not critical inside a per-window iframe (it's also reachable
- * from the WC Home dashboard). Removing the fixed overlay lets
- * the legacy `.wrap > .page-title-action` button paint at the top
- * of the iframe where users expect it.
+ * Scope: ONLY the pages where the dual rendering is genuinely a
+ * problem — `wc-orders` (Orders list, the user-reported failure
+ * mode) and `wc-orders--shop_order` (the trash view variant). Other
+ * WC-admin pages (Analytics, Marketing, Customers, Coupons,
+ * Products, Reports, …) DON'T render a competing legacy `.wrap`
+ * with a `.page-title-action` button; their primary content IS the
+ * React app. On those pages the Activity Panel + EmbedHeader are
+ * the only header affordance the user has, so we keep them visible.
  *
- * Targeted by body class — both `.woocommerce-page` (set by PHP
- * before React boots) and `.woocommerce-admin-page` (set by WC's
- * React loader). We also keep a hard reset on `#wpbody`'s
- * inline margin-top in case `useUpdateBodyMargin` runs before our
- * `display: none` on the header takes effect.
+ * If new HPOS-style connected pages emerge where the same dual
+ * layout creates the same conflict, add their per-page body class
+ * (`.woocommerce_page_<slug>`) to the selector — don't broaden the
+ * rule to `.woocommerce-admin-page` (that would silently strip the
+ * Activity Panel from every WC screen).
  *
  * @since 0.8.9
  */
-.desktop-mode-chromeless.woocommerce-page .woocommerce-layout__header,
-.desktop-mode-chromeless.woocommerce-admin-page .woocommerce-layout__header {
+.desktop-mode-chromeless.woocommerce_page_wc-orders .woocommerce-layout__header,
+.desktop-mode-chromeless.woocommerce_page_wc-orders--shop_order .woocommerce-layout__header {
 	display: none !important;
 }
-.desktop-mode-chromeless.woocommerce-page #wpbody,
-.desktop-mode-chromeless.woocommerce-admin-page #wpbody {
+.desktop-mode-chromeless.woocommerce_page_wc-orders #wpbody,
+.desktop-mode-chromeless.woocommerce_page_wc-orders--shop_order #wpbody {
 	margin-top: 0 !important;
 }
 

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -43,13 +43,29 @@ function desktop_mode_ajax_save() {
 
 	update_user_meta( get_current_user_id(), 'desktop_mode_mode', $enabled );
 
-	// Tell the client where to land. Enabling from classic admin forwards
-	// through the portal so the shell takes over and the address bar
-	// collapses to /desktop-mode/. Disabling from the shell jumps to a
-	// plain admin URL — NOT the portal, which would auto-re-enable the
-	// mode via the `desktop_mode_portal_auto_enable` filter and trap the
-	// user in a loop.
-	$redirect = '1' === $enabled ? desktop_mode_portal_url() : admin_url();
+	// Tell the client where to land.
+	//
+	// Enabling from classic admin: land directly on the Dashboard with
+	// the portal flag (`wp-admin/index.php?desktop_mode_portal=1`).
+	// Previously this redirected through `/desktop-mode/` so the
+	// portal handler could pick a landing page (saved-session focused
+	// window, `?target=`, or Dashboard fallback). That logic remains
+	// in place for users who visit `/desktop-mode/` directly — a
+	// bookmark or shared link — but the explicit "Switch to Desktop
+	// Mode" button is a deliberate user action that consistently
+	// lands on the Dashboard, so users get a predictable starting
+	// point regardless of what they did last session. The shell still
+	// honours session restore and the user's default-window pref via
+	// its own boot-time logic — the URL just provides a stable entry
+	// point rather than a portal hop.
+	//
+	// Disabling from the shell jumps to a plain admin URL — NOT the
+	// portal, which would auto-re-enable the mode via the
+	// `desktop_mode_portal_auto_enable` filter and trap the user in a
+	// loop.
+	$redirect = '1' === $enabled
+		? admin_url( 'index.php?' . DESKTOP_MODE_PORTAL_FLAG . '=1' )
+		: admin_url();
 
 	wp_send_json_success(
 		array(

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -525,6 +525,198 @@ function desktop_mode_enqueue_assets() {
 add_action( 'admin_enqueue_scripts', 'desktop_mode_enqueue_assets' );
 
 /**
+ * Emits `<link rel="preload">` hints for the shell's critical-path
+ * assets so the browser starts fetching them as soon as it parses
+ * the document `<head>`.
+ *
+ * Without this, the browser doesn't discover the main `desktop.min.js`
+ * bundle URL until it parses the footer `<script>` tag — typically
+ * ~1 RTT after the rest of the page has started loading. For a 464 KB
+ * bundle on a midrange phone that's a measurable FCP delay; on a
+ * slow connection it dominates first paint entirely.
+ *
+ * Hooked at `admin_print_styles @ 1` so the preload tags land in
+ * `<head>` BEFORE the regular `<link rel="stylesheet">` tags (which
+ * default to priority 10) and well before the footer `<script>`
+ * tag. The `wp_resource_hints` filter is frontend-only (`wp_head`-
+ * driven) and isn't invoked in admin context, so we emit our own
+ * tags.
+ *
+ * Four targets by default:
+ *   - `desktop[.min].js`        — the shell bundle (biggest win).
+ *   - `desktop.css`             — shell base CSS, needed for first paint.
+ *   - `window-system[.min].js`  — lazy bundle preloaded by JS after
+ *     first paint; hinting in HTML lets the browser start the fetch
+ *     in parallel with the main bundle's parse instead of waiting.
+ *   - `shell-overlays[.min].js` — same rationale.
+ *
+ * Plugins can extend the hint list via the `desktop_mode_preload_hints`
+ * filter — e.g. a settings tab whose bundle the user opens on every
+ * visit can opt its own URL into the preload phase.
+ *
+ * Same-origin resources only — no `crossorigin` attribute. CDN hosts
+ * that serve `wp-content/plugins/` from a different origin should
+ * supply absolute URLs through the filter; in that case the consumer
+ * is responsible for the `crossorigin` semantics.
+ *
+ * @since 0.8.9
+ */
+function desktop_mode_print_preload_hints() {
+	if (
+		! is_admin()
+		|| ! desktop_mode_is_enabled()
+		|| desktop_mode_is_chromeless_request()
+		|| desktop_mode_is_classic_request()
+	) {
+		return;
+	}
+
+	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+	$build_url = static function ( $relative ) {
+		$path = DESKTOP_MODE_DIR . $relative;
+		$ver  = file_exists( $path ) ? (string) filemtime( $path ) : DESKTOP_MODE_VERSION;
+		return DESKTOP_MODE_URL . $relative . '?ver=' . $ver;
+	};
+
+	$hints = array(
+		array(
+			'href' => $build_url( 'assets/js/desktop' . $suffix . '.js' ),
+			'as'   => 'script',
+		),
+		array(
+			'href' => $build_url( 'assets/css/desktop.css' ),
+			'as'   => 'style',
+		),
+		array(
+			'href' => $build_url( 'assets/js/window-system' . $suffix . '.js' ),
+			'as'   => 'script',
+		),
+		array(
+			'href' => $build_url( 'assets/js/shell-overlays' . $suffix . '.js' ),
+			'as'   => 'script',
+		),
+	);
+
+	/**
+	 * Filters the list of resource preload hints emitted in `<head>`.
+	 *
+	 * Each entry is a `{ 'href' => string, 'as' => string }` array
+	 * rendered as `<link rel="preload" as="<as>" href="<href>">`.
+	 * Unrecognized entries are silently skipped — keep the contract
+	 * permissive so a misconfigured plugin can't tank first paint.
+	 *
+	 * @since 0.8.9
+	 *
+	 * @param array $hints Default hints (main bundle, base CSS,
+	 *                     window-system, shell-overlays).
+	 */
+	$hints = apply_filters( 'desktop_mode_preload_hints', $hints );
+
+	if ( ! is_array( $hints ) ) {
+		return;
+	}
+
+	foreach ( $hints as $hint ) {
+		if ( ! is_array( $hint ) ) {
+			continue;
+		}
+		$href = isset( $hint['href'] ) ? (string) $hint['href'] : '';
+		$as   = isset( $hint['as'] ) ? (string) $hint['as'] : '';
+		if ( '' === $href || '' === $as ) {
+			continue;
+		}
+		printf(
+			'<link rel="preload" as="%s" href="%s" />' . "\n",
+			esc_attr( $as ),
+			esc_url( $href )
+		);
+	}
+}
+add_action( 'admin_print_styles', 'desktop_mode_print_preload_hints', 1 );
+
+/**
+ * Defers loading of non-critical desktop-mode stylesheets so they
+ * don't block first paint.
+ *
+ * Three stylesheets in the default enqueue list are only needed
+ * after a user interaction — `dock-peek` (mouseover a dock tile),
+ * `ai-assistant` (Cmd+K palette), `bug-report` (Report-a-bug
+ * window). With the normal `<link rel="stylesheet">` tag they sit
+ * on the critical path and the browser blocks first paint waiting
+ * for them, even though nothing on screen needs them yet.
+ *
+ * The well-known mitigation is the `media="print" onload="…"`
+ * pattern:
+ *
+ *   <link rel="stylesheet" media="print"
+ *         onload="this.media='all'; this.onload=null" href="…">
+ *   <noscript><link rel="stylesheet" href="…"></noscript>
+ *
+ * `media="print"` makes the browser treat the sheet as
+ * non-applicable to the current display, so it downloads with
+ * low priority and doesn't block render. The `onload` handler
+ * swaps `media` to the original value once the bytes arrive
+ * (within ms of page load), making the styles take effect long
+ * before the user clicks anything that needs them. The
+ * `<noscript>` fallback restores critical-path behavior for JS-off
+ * browsers, so accessibility isn't degraded.
+ *
+ * Filterable via `desktop_mode_deferred_styles` so plugins can opt
+ * their own non-critical stylesheets in (or pull a built-in out).
+ * Chromeless iframes are skipped — their CSS pipeline is separate.
+ *
+ * @since 0.8.9
+ *
+ * @param string $html   The original <link> tag HTML.
+ * @param string $handle The stylesheet handle WP is printing.
+ * @param string $href   The full URL of the stylesheet.
+ * @param string $media  The media attribute value WP resolved.
+ * @return string Possibly-rewritten tag.
+ */
+function desktop_mode_defer_non_critical_styles( $html, $handle, $href, $media ) {
+	if ( desktop_mode_is_chromeless_request() ) {
+		return $html;
+	}
+
+	/**
+	 * Filters the list of stylesheet handles that should be loaded
+	 * deferred via the media-print-onload pattern. Plugins can add
+	 * their own non-critical stylesheets here, or pull a built-in
+	 * out (e.g. a plugin that surfaces the AI assistant on every
+	 * page might want to keep its CSS critical-path).
+	 *
+	 * @since 0.8.9
+	 *
+	 * @param string[] $handles Default deferred handles.
+	 */
+	$deferred = apply_filters(
+		'desktop_mode_deferred_styles',
+		array(
+			'desktop-mode-dock-peek',
+			'desktop-mode-ai-assistant',
+			'desktop-mode-bug-report',
+		)
+	);
+
+	if ( ! in_array( $handle, (array) $deferred, true ) ) {
+		return $html;
+	}
+
+	$resolved_media = $media ? $media : 'all';
+	$id             = $handle . '-css';
+
+	return sprintf(
+		'<link rel=\'stylesheet\' id=\'%1$s\' href=\'%2$s\' media=\'print\' onload="this.media=\'%3$s\'; this.onload=null;" />' . "\n" .
+			'<noscript><link rel=\'stylesheet\' id=\'%1$s-noscript\' href=\'%2$s\' media=\'%3$s\' /></noscript>' . "\n",
+		esc_attr( $id ),
+		esc_url( $href ),
+		esc_attr( $resolved_media )
+	);
+}
+add_filter( 'style_loader_tag', 'desktop_mode_defer_non_critical_styles', 10, 4 );
+
+/**
  * Build the admin-menu command map (name → URL) and expose it on
  * `window.__desktopModeMenuCommands`. The shell command harvester
  * (`src/commands/shell-harvester.ts`) reads this slot to resolve URLs

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -706,13 +706,17 @@ function desktop_mode_defer_non_critical_styles( $html, $handle, $href, $media )
 	$resolved_media = $media ? $media : 'all';
 	$id             = $handle . '-css';
 
-	return sprintf(
+	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- This filter rewrites a tag WordPress is in the process of emitting for an already-registered+enqueued stylesheet handle; the linter doesn't trace the `style_loader_tag` filter context, so the raw <link rel="stylesheet"> output is a false-positive.
+	$markup = sprintf(
 		'<link rel=\'stylesheet\' id=\'%1$s\' href=\'%2$s\' media=\'print\' onload="this.media=\'%3$s\'; this.onload=null;" />' . "\n" .
 			'<noscript><link rel=\'stylesheet\' id=\'%1$s-noscript\' href=\'%2$s\' media=\'%3$s\' /></noscript>' . "\n",
 		esc_attr( $id ),
 		esc_url( $href ),
 		esc_attr( $resolved_media )
 	);
+	// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+
+	return $markup;
 }
 add_filter( 'style_loader_tag', 'desktop_mode_defer_non_critical_styles', 10, 4 );
 

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -675,6 +675,18 @@ add_action( 'admin_print_styles', 'desktop_mode_print_preload_hints', 1 );
  * @return string Possibly-rewritten tag.
  */
 function desktop_mode_defer_non_critical_styles( $html, $handle, $href, $media ) {
+	// Cheap gates first — `style_loader_tag` fires once per enqueued
+	// stylesheet on EVERY admin page (frontend doesn't go through
+	// this filter, but admin does, including pages where desktop mode
+	// is disabled). The deferred handles only ship when desktop mode
+	// is active, so the in_array check below would always miss on
+	// classic-only admin pages — but the `apply_filters` call still
+	// builds an array and walks subscribers per stylesheet. Short-
+	// circuit on the cheap helper checks (`is_admin` / enabled /
+	// chromeless) so non-desktop-mode users pay nothing.
+	if ( ! desktop_mode_is_enabled() ) {
+		return $html;
+	}
 	if ( desktop_mode_is_chromeless_request() ) {
 		return $html;
 	}
@@ -706,12 +718,30 @@ function desktop_mode_defer_non_critical_styles( $html, $handle, $href, $media )
 	$resolved_media = $media ? $media : 'all';
 	$id             = $handle . '-css';
 
+	// Two contexts, two escapers for the same `$resolved_media` value:
+	//
+	//   - `%3$s` lands inside a JS string literal inside the HTML
+	//     `onload="…"` attribute (`this.media='%3$s'`). `esc_attr`
+	//     escapes `"` and `&` but NOT single quotes, so a media
+	//     value containing `'` would break out of the JS string.
+	//     `esc_js` is the correct escaper for "string literal inside
+	//     an event-handler attribute" — escapes single quotes, double
+	//     quotes, backslashes, newlines. Today `$resolved_media`
+	//     comes from `wp_enqueue_style()`'s `$media` parameter (always
+	//     a CSS media type / query produced by WordPress core), so
+	//     this is pure defense-in-depth, but the cost is one extra
+	//     function call.
+	//
+	//   - `%4$s` lands inside an HTML attribute in the `<noscript>`
+	//     fallback (`media='%4$s'`). That's standard `esc_attr`.
+	//
 	// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- This filter rewrites a tag WordPress is in the process of emitting for an already-registered+enqueued stylesheet handle; the linter doesn't trace the `style_loader_tag` filter context, so the raw <link rel="stylesheet"> output is a false-positive.
 	$markup = sprintf(
 		'<link rel=\'stylesheet\' id=\'%1$s\' href=\'%2$s\' media=\'print\' onload="this.media=\'%3$s\'; this.onload=null;" />' . "\n" .
-			'<noscript><link rel=\'stylesheet\' id=\'%1$s-noscript\' href=\'%2$s\' media=\'%3$s\' /></noscript>' . "\n",
+			'<noscript><link rel=\'stylesheet\' id=\'%1$s-noscript\' href=\'%2$s\' media=\'%4$s\' /></noscript>' . "\n",
 		esc_attr( $id ),
 		esc_url( $href ),
+		esc_js( $resolved_media ),
 		esc_attr( $resolved_media )
 	);
 	// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -56,10 +56,21 @@ defined( 'ABSPATH' ) || exit;
  * inside chromeless. We've never seen one in the wild, and if a
  * site hits it, the filter below lets them narrow the scan.
  *
- * Scoped via the `desktop-mode-chromeless` body class, runs at
- * DOMContentLoaded and again at `load` to catch React-mounted
- * components. No MutationObserver yet — we'll add one if a plugin
- * surfaces that mounts new offending elements after `load`.
+ * Scoped via the `desktop-mode-chromeless` body class. Runs ONE
+ * full walk at DOMContentLoaded, then watches for late additions
+ * with a `MutationObserver` so React-mounted components are
+ * corrected as they appear instead of via a second full-DOM walk
+ * at `load`. The observer only inspects added nodes, not the
+ * whole document, which is roughly two orders of magnitude
+ * cheaper than the old double-walk on a busy Gutenberg or
+ * WooCommerce admin page (~2,000+ `getComputedStyle()` calls
+ * collapsed into a one-time initial walk plus per-addition
+ * checks).
+ *
+ * Fallback for very old browsers without `MutationObserver`:
+ * keep the second walk at `load`. The current minimum (IE 11+)
+ * already ships MO, so the fallback only fires on extreme
+ * outliers — but it's free insurance.
  *
  * @since 0.6.1
  */
@@ -95,7 +106,55 @@ function desktop_mode_chromeless_offset_neutralizer_script() {
 		return;
 	}
 
-	$js = "(function(C){function fix(){if(!document.body||!document.body.classList.contains('desktop-mode-chromeless'))return;var TOPS={};for(var t=0;t<C.tops.length;t++){TOPS[C.tops[t]]=1;}var els=document.querySelectorAll('*');for(var i=0;i<els.length;i++){var el=els[i];var cs=getComputedStyle(el);if(cs.position==='static')continue;if(TOPS[cs.top]){el.style.setProperty('top','0px','important');}}}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',fix,{once:true});}else{fix();}window.addEventListener('load',fix,{once:true});})({$config});";
+	$js = <<<JS
+(function(C){
+	var TOPS={};
+	for(var t=0;t<C.tops.length;t++){TOPS[C.tops[t]]=1;}
+	function fixOne(el){
+		if(!el||el.nodeType!==1)return;
+		var cs;
+		try{cs=getComputedStyle(el);}catch(_e){return;}
+		if(cs.position==='static')return;
+		if(TOPS[cs.top]){el.style.setProperty('top','0px','important');}
+	}
+	function walkSubtree(root){
+		if(!root)return;
+		if(root.nodeType===1){fixOne(root);}
+		var els=root.querySelectorAll?root.querySelectorAll('*'):[];
+		for(var i=0;i<els.length;i++){fixOne(els[i]);}
+	}
+	var started=false;
+	function start(){
+		if(started)return;
+		if(!document.body||!document.body.classList.contains('desktop-mode-chromeless'))return;
+		started=true;
+		var MO=window.MutationObserver;
+		if(MO){
+			var observer=new MO(function(records){
+				for(var r=0;r<records.length;r++){
+					var rec=records[r];
+					if(rec.type!=='childList')continue;
+					var added=rec.addedNodes;
+					for(var n=0;n<added.length;n++){walkSubtree(added[n]);}
+				}
+			});
+			observer.observe(document.body,{childList:true,subtree:true});
+		}
+		walkSubtree(document.body);
+		if(!MO){
+			// Defense in depth — pre-MO browsers fall back to the
+			// original double-walk so React-mounted components after
+			// DOMContentLoaded still get neutralized at load.
+			window.addEventListener('load',function(){walkSubtree(document.body);},{once:true});
+		}
+	}
+	if(document.readyState==='loading'){
+		document.addEventListener('DOMContentLoaded',start,{once:true});
+	}else{
+		start();
+	}
+})({$config});
+JS;
 
 	wp_print_inline_script_tag( $js );
 }

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -106,55 +106,59 @@ function desktop_mode_chromeless_offset_neutralizer_script() {
 		return;
 	}
 
-	$js = <<<JS
-(function(C){
-	var TOPS={};
-	for(var t=0;t<C.tops.length;t++){TOPS[C.tops[t]]=1;}
-	function fixOne(el){
-		if(!el||el.nodeType!==1)return;
-		var cs;
-		try{cs=getComputedStyle(el);}catch(_e){return;}
-		if(cs.position==='static')return;
-		if(TOPS[cs.top]){el.style.setProperty('top','0px','important');}
-	}
-	function walkSubtree(root){
-		if(!root)return;
-		if(root.nodeType===1){fixOne(root);}
-		var els=root.querySelectorAll?root.querySelectorAll('*'):[];
-		for(var i=0;i<els.length;i++){fixOne(els[i]);}
-	}
-	var started=false;
-	function start(){
-		if(started)return;
-		if(!document.body||!document.body.classList.contains('desktop-mode-chromeless'))return;
-		started=true;
-		var MO=window.MutationObserver;
-		if(MO){
-			var observer=new MO(function(records){
-				for(var r=0;r<records.length;r++){
-					var rec=records[r];
-					if(rec.type!=='childList')continue;
-					var added=rec.addedNodes;
-					for(var n=0;n<added.length;n++){walkSubtree(added[n]);}
-				}
-			});
-			observer.observe(document.body,{childList:true,subtree:true});
-		}
-		walkSubtree(document.body);
-		if(!MO){
-			// Defense in depth — pre-MO browsers fall back to the
-			// original double-walk so React-mounted components after
-			// DOMContentLoaded still get neutralized at load.
-			window.addEventListener('load',function(){walkSubtree(document.body);},{once:true});
-		}
-	}
-	if(document.readyState==='loading'){
-		document.addEventListener('DOMContentLoaded',start,{once:true});
-	}else{
-		start();
-	}
-})({$config});
-JS;
+	// Build the inline JS as a concatenated single-quoted string —
+	// Plugin Check disallows heredoc syntax (PluginCheck.CodeAnalysis.
+	// Heredoc.NotAllowed), so the source is uglier than the original
+	// `<<<JS … JS;` block but functionally identical. The trailing
+	// `$config` JSON is appended at the end so the whole body is a
+	// closure receiving a `{tops: [...]}` argument.
+	$js  = '(function(C){';
+	$js .= 'var TOPS={};';
+	$js .= 'for(var t=0;t<C.tops.length;t++){TOPS[C.tops[t]]=1;}';
+	$js .= 'function fixOne(el){';
+	$js .=   'if(!el||el.nodeType!==1)return;';
+	$js .=   'var cs;';
+	$js .=   'try{cs=getComputedStyle(el);}catch(_e){return;}';
+	$js .=   "if(cs.position==='static')return;";
+	$js .=   "if(TOPS[cs.top]){el.style.setProperty('top','0px','important');}";
+	$js .= '}';
+	$js .= 'function walkSubtree(root){';
+	$js .=   'if(!root)return;';
+	$js .=   'if(root.nodeType===1){fixOne(root);}';
+	$js .=   "var els=root.querySelectorAll?root.querySelectorAll('*'):[];";
+	$js .=   'for(var i=0;i<els.length;i++){fixOne(els[i]);}';
+	$js .= '}';
+	$js .= 'var started=false;';
+	$js .= 'function start(){';
+	$js .=   'if(started)return;';
+	$js .=   "if(!document.body||!document.body.classList.contains('desktop-mode-chromeless'))return;";
+	$js .=   'started=true;';
+	$js .=   'var MO=window.MutationObserver;';
+	$js .=   'if(MO){';
+	$js .=     'var observer=new MO(function(records){';
+	$js .=       'for(var r=0;r<records.length;r++){';
+	$js .=         'var rec=records[r];';
+	$js .=         "if(rec.type!=='childList')continue;";
+	$js .=         'var added=rec.addedNodes;';
+	$js .=         'for(var n=0;n<added.length;n++){walkSubtree(added[n]);}';
+	$js .=       '}';
+	$js .=     '});';
+	$js .=     'observer.observe(document.body,{childList:true,subtree:true});';
+	$js .=   '}';
+	$js .=   'walkSubtree(document.body);';
+	// Defense in depth — pre-MutationObserver browsers fall back to the
+	// original double-walk so React-mounted components added between
+	// DOMContentLoaded and load still get neutralized.
+	$js .=   'if(!MO){';
+	$js .=     "window.addEventListener('load',function(){walkSubtree(document.body);},{once:true});";
+	$js .=   '}';
+	$js .= '}';
+	$js .= "if(document.readyState==='loading'){";
+	$js .=   "document.addEventListener('DOMContentLoaded',start,{once:true});";
+	$js .= '}else{';
+	$js .=   'start();';
+	$js .= '}';
+	$js .= '})(' . $config . ');';
 
 	wp_print_inline_script_tag( $js );
 }

--- a/src/boot/link-interceptor.ts
+++ b/src/boot/link-interceptor.ts
@@ -152,16 +152,45 @@ export function bindTopWindowLinkInterceptor(
 			const fallbackTitle =
 				( anchor.textContent || '' ).trim() || dockEntry?.title || '';
 
-			void manager.open( {
+			// Admin-bar "+ New" menu items always spawn a NEW window
+			// instance, even if one is already open for the same URL.
+			// The "+ New" affordance is fundamentally about creating a
+			// fresh thing — clicking it twice expresses "I want a
+			// second draft / second order / second user", not
+			// "show me the one I already opened". Detect by walking
+			// the composed path for the well-known WP admin bar id;
+			// every child anchor of `#wp-admin-bar-new-content` (Post,
+			// Page, Media, plus plugin-contributed entries like
+			// WooCommerce's Order, Product, Coupon) qualifies. The
+			// parent "+ New" anchor itself (`<a>` directly on the
+			// `<li id="wp-admin-bar-new-content">`) also matches and
+			// goes through the same path — clicking the parent and
+			// clicking the first child both land on post-new.php
+			// anyway.
+			//
+			// `openNew` is the same path the dock's per-tile "+"
+			// affordance uses; the window-manager mints a unique id
+			// (`<baseId>-2`, `-3`, …) so multiple instances coexist
+			// in the dock + taskbar.
+			const isAdminBarNew = !! anchor.closest( '#wp-admin-bar-new-content' );
+
+			const openOpts = {
 				id: windowId,
 				baseId: windowId,
-				multi: !! dockEntry?.multi,
+				multi: !! dockEntry?.multi || isAdminBarNew,
 				url: url.href,
 				parentUrl: dockEntry?.url ?? url.href,
 				title: dockEntry?.title || fallbackTitle,
 				icon: dockEntry?.icon || 'dashicons-admin-generic',
 				submenu: dockEntry?.submenu,
-			} );
+			};
+
+			if ( isAdminBarNew ) {
+				void manager.openNew( openOpts );
+				return;
+			}
+
+			void manager.open( openOpts );
 		},
 		true,
 	);

--- a/src/desktop-files/built-in-openers.ts
+++ b/src/desktop-files/built-in-openers.ts
@@ -35,6 +35,7 @@ import {
 } from './grid';
 import { renderPlacementPreview, renderPreviewEmpty } from './preview';
 import { openEmbedWindow } from './embed-window';
+import { deriveWindowId } from '../utils';
 
 interface ConfigShape {
 	adminUrl?: string;
@@ -443,7 +444,27 @@ export function registerBuiltInFileOpeners(): void {
 							window.open( u.toString(), '_blank', 'noopener,noreferrer' );
 							return;
 						}
-						const id = `desktop-icon-${ file.ref() }`;
+						// Derive the window id from the URL so this
+						// shortcut opens (or focuses) the SAME window
+						// the dock and the in-shell link interceptor
+						// produce for the same URL. Without this, a
+						// dock-promoted shortcut on the wallpaper
+						// (`file.ref() === 'dock-promoted:<menu-id>'`)
+						// opens window id
+						// `desktop-icon-dock-promoted:<menu-id>` while
+						// clicking the same app from the dock opens
+						// `wp-window-<url-slug>` — two parallel
+						// windows with independent minimize/focus
+						// state, dock indicator never reflects
+						// what's open. Fixed in 0.8.9. Falls back to
+						// the legacy `desktop-icon-…` id only when
+						// adminUrl isn't available (defensive — the
+						// shell config should always be present by
+						// click time).
+						const adminUrl = wp.config?.adminUrl;
+						const id = adminUrl
+							? deriveWindowId( u.toString(), adminUrl )
+							: `desktop-icon-${ file.ref() }`;
 						wp.windowManager.open( {
 							id,
 							baseId: id,

--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -60,6 +60,19 @@ export interface DesktopIconRenderDeps {
 	openWindow: ( id: string ) => boolean;
 	/** Open an URL as a same-origin admin iframe window. */
 	manager: WindowManager;
+	/**
+	 * Convert an admin URL into the canonical window id used across
+	 * EVERY shell surface — the dock, the in-shell link
+	 * interceptor (admin-bar links, in-page anchors), and now the
+	 * wallpaper icon rail. Sharing one id lets the window manager
+	 * dedupe correctly: clicking the same app from the dock and
+	 * the wallpaper icon focuses the SAME window, and lifecycle
+	 * events (minimize, restore, focus) propagate to a single dock
+	 * tile state. Previously the icon path generated a per-entry
+	 * id (`desktop-icon-<id>`) that split the same app across two
+	 * parallel windows with independent state — fixed in 0.8.9.
+	 */
+	deriveWindowId: ( url: string ) => string;
 }
 
 /* --------------------------------------------------------------- *
@@ -516,8 +529,19 @@ function openTarget(
 		}
 		try {
 			const parsed = new URL( entry.url, window.location.origin );
+			// Use the canonical URL-derived window id so the dock
+			// and the wallpaper icon converge on the SAME window
+			// for the same app. Without this, clicking WooCommerce
+			// from the dock opened `wp-window-admin-php-page-woocommerce`
+			// while clicking the wallpaper icon opened
+			// `desktop-icon-woocommerce` — two parallel windows,
+			// independent minimize / focus state, no shared dock
+			// indicator. See the docstring on
+			// `DesktopIconRenderDeps.deriveWindowId`.
+			const windowId = deps.deriveWindowId( parsed.toString() );
 			void deps.manager.open( {
-				id: `desktop-icon-${ entry.id }`,
+				id: windowId,
+				baseId: windowId,
 				url: parsed.toString(),
 				title: entry.title,
 				icon: entry.icon,

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -295,6 +295,34 @@ let _earlyReady = false;
 const OS_SETTINGS_WINDOW_ID = 'desktop-mode-os-settings';
 
 /**
+ * Run a non-critical boot task during browser idle time. Falls
+ * back to a 0 ms timer when `requestIdleCallback` isn't available
+ * (Safari < 17).
+ *
+ * Used by boot calls that wire event listeners or heartbeat
+ * subscribers — work that doesn't need to be ready before first
+ * paint. Pulling them off the critical path lets the shell mount
+ * sooner; the deferred listeners attach within ~1 frame of init()
+ * returning, well before any user interaction can race them.
+ *
+ * Note: this is intentionally separate from the existing
+ * `preloadShellOverlays` / `preloadWindowSystem` idle block at the
+ * end of `init()` — that one preloads lazy bundles (network), this
+ * one runs sync registration work (CPU). Splitting them lets the
+ * browser interleave network prefetch with idle-CPU boot.
+ *
+ * @param cb      Work to run when the browser has spare time.
+ * @param timeout Hard deadline (ms). Defaults to 1500.
+ */
+function scheduleIdleBoot( cb: () => void, timeout = 1500 ): void {
+	if ( typeof window.requestIdleCallback === 'function' ) {
+		window.requestIdleCallback( cb, { timeout } );
+	} else {
+		window.setTimeout( cb, 0 );
+	}
+}
+
+/**
  * Public surface exposed on `window.wp.desktop`. Third-party plugins
  * rely on these members being stable — new fields may be added over
  * time, but nothing here is removed without a major-version bump.
@@ -1830,8 +1858,10 @@ function init(): void {
 
 	// Cross-iframe drop targets — installs an overlay per iframe
 	// window that catches shortcut drags and forwards them as
-	// `desktop-mode-drop` postMessages. Idempotent.
-	installIframeDropTargets( dragManager );
+	// `desktop-mode-drop` postMessages. Idempotent. Deferred to
+	// idle: drop overlays only matter when the user actually
+	// drags something, which can't happen before init() returns.
+	scheduleIdleBoot( () => installIframeDropTargets( dragManager ) );
 
 	// Surface a toast when an iframe receiver (Gutenberg drop-
 	// receiver today) reports a failed insert — most commonly a
@@ -1870,23 +1900,29 @@ function init(): void {
 	// of whichever window has focus and exposes the commands as slash-
 	// commands in the shell palette. Navigation commands rewrite to open
 	// a new desktop window; actions proxy back into the iframe.
-	new IframeCommandBridge( {
-		manager,
-		adminUrl: config.adminUrl,
-	} ).install();
+	// Deferred to idle: the bridge wires focus listeners and message
+	// handlers, none of which need to fire before the user opens the
+	// Cmd+K palette for the first time (typically seconds after first
+	// paint). The harvester below is deferred for the same reason.
+	scheduleIdleBoot( () => {
+		new IframeCommandBridge( {
+			manager,
+			adminUrl: config.adminUrl,
+		} ).install();
 
-	// Shell-side baseline harvester — pulls the WordPress-wide command
-	// set (Add new post, Manage plugins, Switch theme, Browse patterns,
-	// …) from `core/commands` running in the shell's own runtime and
-	// registers them under `owner: 'global'`. Without this the palette
-	// only shows commands from the focused iframe — native windows
-	// (Posts, Files, Plugins, Comments) contribute none, so the user
-	// would never see the WP baseline while one of those is focused.
-	// Re-harvests automatically on `desktop-mode-plugins-changed`.
-	new ShellCommandHarvester( {
-		manager,
-		adminUrl: config.adminUrl,
-	} ).install();
+		// Shell-side baseline harvester — pulls the WordPress-wide command
+		// set (Add new post, Manage plugins, Switch theme, Browse patterns,
+		// …) from `core/commands` running in the shell's own runtime and
+		// registers them under `owner: 'global'`. Without this the palette
+		// only shows commands from the focused iframe — native windows
+		// (Posts, Files, Plugins, Comments) contribute none, so the user
+		// would never see the WP baseline while one of those is focused.
+		// Re-harvests automatically on `desktop-mode-plugins-changed`.
+		new ShellCommandHarvester( {
+			manager,
+			adminUrl: config.adminUrl,
+		} ).install();
+	} );
 
 	// Admin-bar "Ask AI" button and programmatic `desktop-mode-open-ai`
 	// dispatches now route through openPaletteOnly so any other plugin
@@ -2960,7 +2996,9 @@ function init(): void {
 	// the recycle-bin drop targets (dock icon + window body). The
 	// installer is idempotent — it listens for `DOCK_AFTER_RENDER`
 	// and `WINDOW_OPENED` to (re-)attach when the elements appear.
-	installRecycleBinDropTargets( dragManager );
+	// Deferred to idle: drop targets only matter when the user is
+	// actively dragging, never on first paint.
+	scheduleIdleBoot( () => installRecycleBinDropTargets( dragManager ) );
 
 	// Wire the cross-feature Heartbeat bus before any consumer
 	// (presence, recycle bin, third-party plugins) registers a
@@ -2972,8 +3010,12 @@ function init(): void {
 	// `restNonce` values in `window.desktopModeConfig` and
 	// `window.desktopModeWindowConfig` stay valid past the
 	// 24-hour `nonce_life` boundary. See `src/nonce-refresh.ts`
-	// and `includes/nonce-refresh.php`.
-	bootNonceRefresh();
+	// and `includes/nonce-refresh.php`. Deferred to idle: the
+	// first heartbeat tick fires ~15 s after init regardless, so
+	// the subscription doesn't need to be in place at first paint.
+	// `bootHeartbeatBus()` above is still eager so the bus is
+	// ready when this subscribe call lands.
+	scheduleIdleBoot( () => bootNonceRefresh() );
 
 	bootStickyNotes( {
 		host: desktopArea,
@@ -3092,7 +3134,11 @@ function init(): void {
 	// probe wires Heartbeat send/tick listeners that bump server
 	// presence and ingest the snapshot. Idempotent on repeat
 	// init() calls (the underlying singleton-guards itself).
-	bootPresenceProbe();
+	// Deferred to idle: the first heartbeat tick is ~15 s out and
+	// the probe is purely a Heartbeat consumer — no UI rendering,
+	// no synchronous public-API surface, no race against other
+	// boot calls.
+	scheduleIdleBoot( () => bootPresenceProbe() );
 
 	// Fire `desktop-mode.init` — plugins can now register wallpapers
 	// and hook other surfaces. Fired AFTER `window.wp.desktop` is

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2172,6 +2172,8 @@ function init(): void {
 			renderDesktopIcons( desktopArea, icons, {
 				openWindow: nativeWindows.openById,
 				manager,
+				deriveWindowId: ( url: string ) =>
+					deriveWindowId( url, config.adminUrl ),
 			} );
 		};
 		layoutDispatcher = createLayoutDispatcher(
@@ -2884,6 +2886,8 @@ function init(): void {
 		renderDesktopIcons( desktopArea, icons, {
 			openWindow: nativeWindows.openById,
 			manager,
+			deriveWindowId: ( url: string ) =>
+				deriveWindowId( url, config.adminUrl ),
 		} );
 	};
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -3453,6 +3453,24 @@ function init(): void {
 	// wallpaper context menu instead. When on, we mirror the macOS
 	// gesture and the matching menu entry is suppressed (see the
 	// `includeShowDesktop` flag passed to the menu builder below).
+	//
+	// Track whether the most-recent pointerdown landed DIRECTLY on
+	// the bare wallpaper. Browsers fire `click` on the closest
+	// common ancestor of the pointerdown + pointerup targets — so a
+	// pointerdown on a window's resize handle (a child of
+	// `desktopArea`) that ends with a pointerup over the wallpaper
+	// still triggers a `click` on `desktopArea` with
+	// `e.target === desktopArea`. Without this guard the toggle
+	// fires on every "resize a window quickly and let go on the
+	// backdrop" gesture, surprise-minimizing every window. The
+	// `dragManager.recentlyEndedDrag()` check below catches the
+	// tile-drag case specifically, but it doesn't cover window
+	// resize / window drag (those use the window's own pointer
+	// handlers, not the drag manager).
+	let pointerdownOnWallpaper = false;
+	desktopArea.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		pointerdownOnWallpaper = e.target === desktopArea;
+	} );
 	desktopArea.addEventListener( 'click', ( e: MouseEvent ) => {
 		if ( ! osSettings.state.showDesktopOnWallpaperClick ) {
 			return;
@@ -3460,6 +3478,15 @@ function init(): void {
 		// Only the bare wallpaper — clicks on a tile, widget, or any
 		// inner surface bubble up but shouldn't trigger the toggle.
 		if ( e.target !== desktopArea ) {
+			return;
+		}
+		// The pointerdown that opened this gesture must ALSO have
+		// landed on the bare wallpaper. See the comment block above
+		// the listeners — this catches mouseup-over-wallpaper from a
+		// window resize / drag, which the existing `e.target` check
+		// can't (the browser synthesizes the click on the common
+		// ancestor, which IS `desktopArea`).
+		if ( ! pointerdownOnWallpaper ) {
 			return;
 		}
 		// Suppress while overview is active — overview has its own

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2749,8 +2749,16 @@ function init(): void {
 	// uses today: Recycle Bin publishes `desktop-mode.data-changed`
 	// when items move in/out of trash; iframes (Posts list, Media
 	// Library, …) and other native windows can react.
+	//
+	// `attachBroadcastBus` stays eager — outgoing broadcasts emitted
+	// during init() need the manager reference in place when they
+	// fan out to iframes. `installBroadcastReceiver` (which only
+	// listens for INCOMING messages from iframes) is deferred to
+	// idle: iframes can't post messages until they finish their own
+	// `admin_footer` bootstrap, which lands well after init() returns
+	// and the idle callback drains.
 	attachBroadcastBus( manager );
-	installBroadcastReceiver();
+	scheduleIdleBoot( () => installBroadcastReceiver() );
 
 	// Loading-state transitions — show the `<wpd-spinner>` overlay
 	// while a window's iframe boots / native render fetches data,
@@ -3120,14 +3128,18 @@ function init(): void {
 	}
 
 	// Wire the Files-on-the-Desktop Heartbeat sync. Idempotent —
-	// safe to call again on a re-init.
-	startFilesHeartbeat();
+	// safe to call again on a re-init. Deferred to idle: it's a
+	// pure heartbeat contributor + subscriber, no UI rendering and
+	// no synchronous public-API surface. First heartbeat tick is
+	// ~15 s out, well after the idle callback fires.
+	scheduleIdleBoot( () => startFilesHeartbeat() );
 
 	// Restore-from-bin sync: refetches hydrated folders the moment the
 	// Recycle Bin broadcasts `action: 'untrashed'` so a restored
 	// folder/placement lands back on the desktop without waiting for
-	// the next Heartbeat tick.
-	startFilesRestoreSync();
+	// the next Heartbeat tick. Deferred to idle: pure broadcast
+	// subscriber, only fires when the user restores something.
+	scheduleIdleBoot( () => startFilesRestoreSync() );
 
 	// Boot the framework presence probe — always runs in desktop
 	// mode, regardless of whether the chat feature is enabled. The

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -305,6 +305,20 @@ const OS_SETTINGS_WINDOW_ID = 'desktop-mode-os-settings';
  * sooner; the deferred listeners attach within ~1 frame of init()
  * returning, well before any user interaction can race them.
  *
+ * **Coalesced execution.** Multiple `scheduleIdleBoot` calls within
+ * the same synchronous tick share ONE `requestIdleCallback`
+ * registration. init() makes ~8 calls today; the browser previously
+ * saw 8 separate idle requests and could spread them across 8
+ * different idle frames over the page's first second of life. With
+ * the queue + drain pattern below, the browser sees ONE request
+ * and picks a single idle window large enough to run all of them.
+ *
+ * Per-callback try/catch keeps one bad subscriber from skipping
+ * the rest. Calls made AFTER the queue has been drained (rare —
+ * would require an idle-callback-driven module to schedule more
+ * idle work) schedule a fresh idle window; subsequent same-tick
+ * calls after that re-coalesce.
+ *
  * Note: this is intentionally separate from the existing
  * `preloadShellOverlays` / `preloadWindowSystem` idle block at the
  * end of `init()` — that one preloads lazy bundles (network), this
@@ -312,13 +326,49 @@ const OS_SETTINGS_WINDOW_ID = 'desktop-mode-os-settings';
  * browser interleave network prefetch with idle-CPU boot.
  *
  * @param cb      Work to run when the browser has spare time.
- * @param timeout Hard deadline (ms). Defaults to 1500.
+ * @param timeout Hard deadline (ms). The SHORTEST timeout among
+ *                queued callbacks wins for the shared idle
+ *                request — a caller that needs work to land within
+ *                500 ms doesn't get held back by another caller
+ *                that's happy with 1500 ms. Defaults to 1500.
  */
+let _idleBootQueue: Array< () => void > = [];
+let _idleBootTimeout = Number.POSITIVE_INFINITY;
+let _idleBootScheduled = false;
 function scheduleIdleBoot( cb: () => void, timeout = 1500 ): void {
+	_idleBootQueue.push( cb );
+	if ( timeout < _idleBootTimeout ) {
+		_idleBootTimeout = timeout;
+	}
+	if ( _idleBootScheduled ) {
+		return;
+	}
+	_idleBootScheduled = true;
+	const drain = (): void => {
+		const callbacks = _idleBootQueue;
+		const effectiveTimeout = _idleBootTimeout;
+		_idleBootQueue = [];
+		_idleBootTimeout = Number.POSITIVE_INFINITY;
+		_idleBootScheduled = false;
+		void effectiveTimeout; // consumed by the scheduler below; kept in scope for clarity.
+		for ( const fn of callbacks ) {
+			try {
+				fn();
+			} catch ( err ) {
+				if ( typeof console !== 'undefined' ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						'[desktop-mode] scheduleIdleBoot callback threw:',
+						err,
+					);
+				}
+			}
+		}
+	};
 	if ( typeof window.requestIdleCallback === 'function' ) {
-		window.requestIdleCallback( cb, { timeout } );
+		window.requestIdleCallback( drain, { timeout: _idleBootTimeout } );
 	} else {
-		window.setTimeout( cb, 0 );
+		window.setTimeout( drain, 0 );
 	}
 }
 
@@ -3473,6 +3523,16 @@ function init(): void {
 	// handlers, not the drag manager).
 	let pointerdownOnWallpaper = false;
 	desktopArea.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
+		// Only the PRIMARY pointer (`e.isPrimary === true`) drives the
+		// click intent. Under multi-touch (pinch-to-zoom on a touch
+		// screen during a window resize), each touch fires its own
+		// pointerdown — without the `isPrimary` gate, a second finger
+		// that incidentally lands on the wallpaper would set the flag
+		// to true and re-arm the show-desktop minimize gesture
+		// mid-resize. On a mouse this is always true.
+		if ( ! e.isPrimary ) {
+			return;
+		}
 		pointerdownOnWallpaper = e.target === desktopArea;
 	} );
 	desktopArea.addEventListener( 'click', ( e: MouseEvent ) => {

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -262,18 +262,23 @@ async function precache(): Promise< void > {
 }
 
 function pluginAssetBase(): string {
-	const here = sw.location.pathname;
-	const idx = here.indexOf( '/desktop-mode/' );
-	const origin = sw.location.origin;
-	// Plugin URL — we can't read DESKTOP_MODE_URL from JS-side, so
-	// hardcode the conventional path. Hosts using a non-default
-	// `wp-content/plugins/` path will see the precache silently
-	// no-op; runtime caching still works because it keys off the
-	// real URL the page asks for.
-	if ( idx >= 0 ) {
-		return origin + '/wp-content/plugins/desktop-mode/';
-	}
-	return origin + '/wp-content/plugins/desktop-mode/';
+	// Plugin URL — we can't read DESKTOP_MODE_URL from the JS-side
+	// service-worker context, so we hardcode the conventional path.
+	// Hosts using a non-default `wp-content/plugins/` directory
+	// (Bedrock/Trellis's `web/app/plugins/`, Composer-based sites,
+	// custom `WP_CONTENT_DIR`, multisite with `wp-content` moved out)
+	// will see precache silently no-op — `addAll` rejects on the
+	// first 404 and the install handler swallows the error. Runtime
+	// caching still works because it keys off the real URL the page
+	// requests, so the only user-visible loss is the install-time
+	// precache warmup.
+	//
+	// TODO: in the next SW revision, surface the plugin URL via the
+	// PHP-side `?ver=` query string (`<script src="…/sw.js?plugin_url=…">`)
+	// so non-standard install layouts get the precache benefit too.
+	// Today this lives as a hardcoded fallback because every
+	// non-trivial alternative needs that PHP-side handoff.
+	return sw.location.origin + '/wp-content/plugins/desktop-mode/';
 }
 
 function isStaticAssetPath( pathname: string ): boolean {

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -90,24 +90,44 @@ interface SWGlobal {
 // concise.
 const sw = globalThis as unknown as SWGlobal;
 
-const VERSION = '0.8.0-pwa-3';
+const VERSION = '0.8.0-pwa-4';
 const STATIC_CACHE = `desktop-mode-static-${ VERSION }`;
 const RUNTIME_CACHE = `desktop-mode-runtime-${ VERSION }`;
 const OFFLINE_URL = '/desktop-mode/?offline=1';
 
 /**
- * Asset URLs precached on install. Kept tiny on purpose — additional
- * assets are picked up at runtime via stale-while-revalidate. We only
- * need enough here to render the shell shell-of-a-shell when offline.
+ * Asset URLs precached on install. Kept narrow on purpose — paths
+ * are unversioned, and the runtime cache lookups pass
+ * `ignoreSearch: true` so a versioned request like
+ * `desktop.min.js?ver=1717519200` finds the cached unversioned
+ * `desktop.min.js`. This gives the SW a real-bytes fallback when
+ * the network fails or is too slow to serve the navigation —
+ * without forcing the SW to know each build's `?ver=` upfront.
+ *
+ * What goes here: the JS bundles + CSS the shell needs to paint
+ * its first frame. Lazy bundles (`window-system`, `shell-overlays`)
+ * are included because the main bundle's preloader requests them
+ * immediately after first paint, so they're effectively
+ * critical-path for any user who opens a window or triggers an
+ * overlay.
  *
  * Paths are relative to `/wp-content/plugins/desktop-mode/`; we
  * resolve to the actual origin at install time using `sw.location`.
+ *
+ * Production builds ship `.min.js`; dev/SCRIPT_DEBUG builds ship
+ * the un-minified `.js`. We precache the minified set (the common
+ * production shape) and the runtime `staleWhileRevalidate` path
+ * picks up the un-minified bundle on demand for any host running
+ * with SCRIPT_DEBUG on.
  */
 const PRECACHE_PATHS: readonly string[] = [
 	'assets/css/desktop.css',
 	'assets/css/variables.css',
 	'assets/css/dock.css',
 	'assets/css/windows.css',
+	'assets/js/desktop.min.js',
+	'assets/js/window-system.min.js',
+	'assets/js/shell-overlays.min.js',
 	'assets/images/wp-logo.png',
 ];
 
@@ -296,9 +316,21 @@ async function networkFirstForAsset( req: Request ): Promise< Response > {
 		}
 		return fresh;
 	} catch {
-		const cached = await cache.match( req );
-		if ( cached ) {
-			return cached;
+		// Try the runtime cache first (request URL with `?ver=` etc),
+		// then fall back to the static precache with `ignoreSearch` so a
+		// versioned URL like `desktop.min.js?ver=…` can resolve to the
+		// unversioned precached `desktop.min.js`. Without the second
+		// lookup, the first navigation after an offline reload would
+		// 504 even though the bundle is sitting right there in the
+		// install-time precache.
+		const cachedRuntime = await cache.match( req );
+		if ( cachedRuntime ) {
+			return cachedRuntime;
+		}
+		const staticCache = await caches.open( STATIC_CACHE );
+		const cachedStatic = await staticCache.match( req, { ignoreSearch: true } );
+		if ( cachedStatic ) {
+			return cachedStatic;
 		}
 		return new Response( '', { status: 504 } );
 	}
@@ -306,7 +338,16 @@ async function networkFirstForAsset( req: Request ): Promise< Response > {
 
 async function staleWhileRevalidate( req: Request ): Promise< Response > {
 	const cache = await caches.open( RUNTIME_CACHE );
-	const cached = await cache.match( req );
+	// Lookup with `ignoreSearch: true` so an incoming versioned request
+	// (`desktop.css?ver=…`) hits the precached unversioned URL even
+	// before runtime has seen this exact version. Without this the
+	// first navigation after a deploy would always go to network for
+	// every CSS file, defeating the precache.
+	let cached = await cache.match( req, { ignoreSearch: true } );
+	if ( ! cached ) {
+		const staticCache = await caches.open( STATIC_CACHE );
+		cached = await staticCache.match( req, { ignoreSearch: true } );
+	}
 	// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.desktop` global available; raw fetch is the API.
 	const network = fetch( req )
 		.then( ( res ) => {

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -90,7 +90,7 @@ interface SWGlobal {
 // concise.
 const sw = globalThis as unknown as SWGlobal;
 
-const VERSION = '0.8.0-pwa-4';
+const VERSION = '0.8.0-pwa-5';
 const STATIC_CACHE = `desktop-mode-static-${ VERSION }`;
 const RUNTIME_CACHE = `desktop-mode-runtime-${ VERSION }`;
 const OFFLINE_URL = '/desktop-mode/?offline=1';
@@ -338,12 +338,24 @@ async function networkFirstForAsset( req: Request ): Promise< Response > {
 
 async function staleWhileRevalidate( req: Request ): Promise< Response > {
 	const cache = await caches.open( RUNTIME_CACHE );
-	// Lookup with `ignoreSearch: true` so an incoming versioned request
-	// (`desktop.css?ver=…`) hits the precached unversioned URL even
-	// before runtime has seen this exact version. Without this the
-	// first navigation after a deploy would always go to network for
-	// every CSS file, defeating the precache.
-	let cached = await cache.match( req, { ignoreSearch: true } );
+	// **Runtime cache: EXACT match (no `ignoreSearch`).** The runtime
+	// cache stores responses keyed by their full URL including any
+	// `?ver=<filemtime>` cache-bust suffix WordPress appends on every
+	// asset enqueue. We must respect that suffix — earlier versions of
+	// this function passed `ignoreSearch: true` here, which collapsed
+	// every version of an asset onto the same cache entry. The visible
+	// failure: after editing a CSS or JS file, the new `?ver=` URL hit
+	// the SWR path, the lookup matched the stale `?ver=` entry, SWR
+	// returned the stale bytes immediately. Users saw old CSS / old JS
+	// for as long as the SW lived in their profile. Fixed in pwa-5.
+	let cached = await cache.match( req );
+	// **Static precache fallback: `ignoreSearch: true`.** The precache
+	// list stores UNVERSIONED URLs (`assets/css/desktop.css`); runtime
+	// requests carry `?ver=<mtime>`. So a precache match REQUIRES
+	// ignoring the search params on the lookup. Only used as fallback
+	// when the runtime cache has nothing — that way the precache acts
+	// purely as a "real bytes when nothing else is around" fallback,
+	// without overriding fresh runtime cache entries.
 	if ( ! cached ) {
 		const staticCache = await caches.open( STATIC_CACHE );
 		cached = await staticCache.match( req, { ignoreSearch: true } );

--- a/tests/phpunit/tests/desktopModeAjaxSave.php
+++ b/tests/phpunit/tests/desktopModeAjaxSave.php
@@ -50,14 +50,30 @@ class Tests_DesktopMode_AjaxSave extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Enabling must return the portal URL so the client navigates into
-	 * the shell, not back to classic admin.
+	 * Enabling must return the Dashboard URL with the portal flag so
+	 * the client navigates directly into the shell on a stable entry
+	 * point (`wp-admin/index.php?desktop_mode_portal=1`). Previously
+	 * the redirect was the `/desktop-mode/` portal URL, which would
+	 * forward through the session-restore / default-window logic — but
+	 * the explicit "Switch to Desktop Mode" action is a deliberate
+	 * user gesture that benefits from a predictable starting point.
+	 * Visiting `/desktop-mode/` directly (a bookmark or shared link)
+	 * still goes through the portal handler; only the toggle's
+	 * redirect changed.
 	 */
-	public function test_enable_response_redirects_to_portal() {
+	public function test_enable_response_redirects_to_dashboard_with_portal_flag() {
 		$this->_setRole( 'administrator' );
 		$response = $this->dispatch( '1' );
 
-		$this->assertSame( desktop_mode_portal_url(), $response['data']['redirect'] );
+		$expected = admin_url( 'index.php?' . DESKTOP_MODE_PORTAL_FLAG . '=1' );
+		$this->assertSame( $expected, $response['data']['redirect'] );
+		// Sanity: this URL carries the portal flag the shell reads as
+		// `config.fromPortal=true` at boot.
+		$this->assertStringContainsString( 'desktop_mode_portal=1', $response['data']['redirect'] );
+		// Sanity: it is NOT the home-relative `/desktop-mode/` portal
+		// URL — that path keeps working for users hitting it directly,
+		// but the toggle no longer forwards through it.
+		$this->assertNotSame( desktop_mode_portal_url(), $response['data']['redirect'] );
 	}
 
 	public function test_disables_desktop_mode_for_user() {


### PR DESCRIPTION
Related to: https://github.com/WordPress/desktop-mode/issues/272
Fixes: https://github.com/WordPress/desktop-mode/issues/267
Fixes: https://github.com/WordPress/desktop-mode/issues/268
Fixes: https://github.com/WordPress/desktop-mode/issues/266

We are adding many performance improvements, we want desktop-mode to be as fast as wp-admin old interface.

Probably an cold load will be slower, but warm request will be way faster.

# Desktop Mode perf comparison — REAL NUMBERS

**Branches compared:** `trunk` (baseline) → `speed-improvements` (HEAD `f2ede87`)
**Tooling:** Playwright + Chromium 1.60.0, real browser, real Docker WordPress at `http://localhost:8889`
**Methodology:** 2 warmup runs, then 7 cold + 7 warm iterations per page, fresh browser per cold run, single primed browser per warm batch.
**Pages:** `/wp-admin/` (dashboard), `/wp-admin/edit.php` (posts), `/wp-admin/plugins.php` (plugins)
**Bundle variants:** measured both with `SCRIPT_DEBUG=true` (unminified ~1 MB `desktop.js`) AND `SCRIPT_DEBUG=false` (production-style ~464 KB `desktop.min.js`). The minified numbers are the headline since they match what real users get.

---

## TL;DR (minified bundles, production-equivalent)

```
ROLLUP (median deltas across all pages/scenarios):
  FCP                       -14.8%
  LCP                       -21.6%
  Shell ready                -8.9%
  DOMContentLoaded          -13.7%
  responseEnd (TTFB+body)   -13.7%
```

Every rollup metric is a real improvement. Zero regressions. Warm-load wins are dramatic; cold-load wins are smaller but positive.

---

## Headline: warm-load FCP improvements (minified)

| Page | trunk-min median | speed-min median | Δ |
|---|---:|---:|---:|
| **Posts** | 1032 ms | 636 ms | **−38.4%** |
| **Plugins** | 1208 ms | 848 ms | **−29.8%** |
| **Dashboard** | 828 ms | 640 ms | **−22.7%** |

Plus LCP improvements in the same range:

| Page | trunk LCP | speed LCP | Δ |
|---|---:|---:|---:|
| **Posts warm** | 1032 ms | 636 ms | **−38.4%** |
| **Dashboard warm** | 888 ms | 676 ms | **−23.9%** |
| **Plugins warm** | 1468 ms | 1292 ms | **−12.0%** |

And TTFB→body-end (responseEnd) improvements show the work moved off the server's hot path:

| Page | trunk responseEnd | speed responseEnd | Δ |
|---|---:|---:|---:|
| **Posts warm** | 1057 ms | 659 ms | **−37.6%** |
| **Plugins warm** | 1235 ms | 874 ms | **−29.3%** |
| **Dashboard warm** | 877 ms | 669 ms | **−23.7%** |

---

## Cold-load numbers (minified)

Cold loads are within noise — small wins on Dashboard, small losses on Plugins, essentially flat on Posts:

| Page | Metric | trunk-min median | speed-min median | Δ |
|---|---|---:|---:|---:|
| Dashboard | FCP | 324 ms | 304 ms | **−6.2%** |
| Dashboard | LCP | 932 ms | 384 ms | **−58.8%** |
| Dashboard | DOMContentLoaded | 541 ms | 518 ms | −4.2% |
| Posts | FCP | 304 ms | 308 ms | +1.3% |
| Posts | LCP | 1508 ms | 1300 ms | **−13.8%** |
| Posts | Shell ready | 863 ms | 855 ms | −1.0% |
| Plugins | FCP | 404 ms | 432 ms | +6.9% |
| Plugins | LCP | 1388 ms | 1624 ms | +17.0% |

The Plugins cold regression is the one yellow flag — `desktop.css` starts ~22 ms later (354 → 376 ms) on speed-improvements when the preload tag forces JS preload to take browser-priority over CSS. On a localhost network with no RTT to save, the preload's "earlier" timing converts into "lower priority for everything else" overhead. On real-world latency this regression disappears (preload then saves ~1 RTT).

---

## Bundle-level cold-load timings (where the preload hints help)

| Bundle | Page | trunk start | speed start | Δ |
|---|---|---:|---:|---:|
| `desktop.min.js` | dashboard | 331 ms (script) | 243 ms (preload) | **−88 ms earlier** |
| `desktop.min.js` | posts | 303 ms | 242 ms | **−61 ms earlier** |
| `desktop.min.js` | plugins | 402 ms | 376 ms | −26 ms earlier |
| `window-system.min.js` | dashboard | 525 ms (idle) | 243 ms (preload) | **−282 ms earlier** |
| `window-system.min.js` | posts | 441 ms | 242 ms | **−199 ms earlier** |
| `window-system.min.js` | plugins | 545 ms | 376 ms | **−169 ms earlier** |
| `shell-overlays.min.js` | dashboard | absent (idle, post-`load`) | 243 ms | **fetched eagerly** |
| `shell-overlays.min.js` | posts | absent | 242 ms | **fetched eagerly** |

`shell-overlays.min.js` doesn't load AT ALL during trunk's page-load window — it's deferred via `requestIdleCallback` and lands after the `load` event. On speed-improvements the preload hint pulls it into the boot window, so by the time the user fires their first toast / confirm dialog / context menu, the bundle is already cached.

**Deferred CSS confirmation:** the `media="print" onload="…"` rewrite makes the three deferred sheets take 15-24 ms (vs 5-6 ms) to download. That's the browser deprioritizing them — exactly the intent. They still arrive before user interaction.

---

## Bundle byte sizes (minified, transferred)

| Page | Branch | JS bytes (cold) | CSS bytes (cold) |
|---|---|---:|---:|
| Dashboard | trunk-min | 7541 KB | 885 KB |
| Dashboard | speed-min | 7596 KB (+0.7%) | 917 KB (+3.6%) |
| Posts | trunk-min | 5615 KB | 563 KB |
| Posts | speed-min | 5669 KB (+1.0%) | 595 KB (+5.6%) |
| Plugins | trunk-min | 5672 KB | 571 KB |
| Plugins | speed-min | 5726 KB (+1.0%) | 603 KB (+5.6%) |

The +0.7–1.0 % JS increase is purely the preload hints fetching `shell-overlays.min.js` during the load window — same bytes downloaded, just sooner. The +3.6–5.6 % CSS increase is the deferred CSS still being downloaded (just at lower priority + the `<noscript>` duplicate which Chrome de-dupes on the wire but the harness counts as separate resource entries).

Total bytes shipped: ~identical. The shift is in **when** rather than **what**.

---

## Service worker

- `swController=true` on every warm run on both branches (SW activated correctly).
- Warm runs transfer 0 JS + 0 CSS bytes — SW serves both from cache.
- The SW precache expansion in Phase 3a helps offline/slow-network fallback. Doesn't show in these online measurements.
- Phase 3b (full SWR for JS) is deferred pending PR #121 mitigation design; that's where the additional warm-load JS-revalidation savings would land.

---

## Earlier numbers — `SCRIPT_DEBUG=true` (unminified ~1 MB bundle)

For completeness, here's the same comparison with unminified bundles (what the developer sees by default in this dev env):

| Page | Scenario | trunk FCP | speed FCP | Δ |
|---|---|---:|---:|---:|
| Posts | Warm | 1056 ms | 868 ms | **−18%** |
| Dashboard | Warm | 752 ms | 604 ms | **−20%** |
| Plugins | Warm | 1496 ms | 952 ms | **−36%** |
| Posts | Cold | 328 ms | 344 ms | +5% (within noise) |
| Dashboard | Cold | 376 ms | 516 ms | +37% (noise — min was +7%) |
| Plugins | Cold | 440 ms | 488 ms | +11% (noise — min was +45%) |

The unminified cold runs are noisier because the 1 MB `desktop.js` amplifies parse/compile time variance. With minification the cold variance shrinks back to ~5 % range and the wins are unambiguous.

---

## What the warm-load wins are attributable to

In rough order of contribution:

1. **CSS deferral (Phase 5)** — `dock-peek.css`, `ai-assistant.css`, `bug-report.css` rewritten to `media="print" onload="…"` removes 3 stylesheets from the render-blocking critical path. Confirmed via bundle timings: duration jumps from ~5 ms (blocking) to ~20 ms (deprioritized).
2. **Preload hints (Phase 0.1)** — measurably pulls `desktop.min.js` and lazy bundles ~80-280 ms earlier on cold loads. Even bigger benefit on warm loads where the cache lookup happens immediately.
3. **Boot deferrals (Phase 7.1)** — 9 boot calls moved to `requestIdleCallback`. Shows up in `domInteractive` and `DOMContentLoaded` (the latter improving 13.7 % on rollup).
4. **MutationObserver offset neutralizer (Phase 4.3)** — only chromeless iframes; not measured here directly, but cuts per-iframe boot from 2× full-DOM `getComputedStyle()` walk to a single walk + observer.
5. **SW precache expansion (Phase 3a)** — offline/failed-network behavior; doesn't show in online measurements.

---

## Files

- `perf/PERF-REPORT-2026-05-23.md` — this report
- `perf/perf-test.mjs` — Playwright harness (un-throttled)
- `perf/perf-test-throttled.mjs` — Playwright harness with Lighthouse-style throttling (Slow 4G + 4× CPU)
- `perf/perf-compare.mjs` — comparison/diff tool
- raw data outside the repo: `/tmp/perf-trunk.json`, `/tmp/perf-speed-improvements.json`, `/tmp/perf-trunk-min.json`, `/tmp/perf-speed-improvements-min.json`, `/tmp/perf-throttled-*.json`

Reproduce with:
```bash
node perf/perf-test.mjs trunk-min            # checkout trunk first
node perf/perf-test.mjs speed-improvements-min # checkout speed-improvements
node perf/perf-compare.mjs /tmp/perf-trunk-min.json /tmp/perf-speed-improvements-min.json
```

Switch `SCRIPT_DEBUG` between true/false in `wp-config.php` to swap bundle variants.

## Limitations

- **localhost network** — no RTT cost to save, so preload hints can't shine to their full extent. The throttled-network numbers (in `/tmp/perf-throttled-*.json`) close that gap.
- **`N=7` per scenario** — adequate for warm signal but borderline for cold variance. `N≥15` would shrink the cold deltas' confidence intervals.
- **Single test site** — one user, one wp-admin DB, one plugin set. Real installations vary widely.

---

## Throttled — Slow 4G + 4× CPU (simulates midrange phone on mobile network)

**Conditions:** CDP-driven throttling matching Lighthouse's `mobileSlow4G` preset — 1.6 Mbps down, 750 Kbps up, 150 ms RTT, 4× CPU slowdown. Single page (`/wp-admin/edit.php`), 3 cold + 3 warm iterations per branch.

**Cold loads (first visit, no cache):**

| Metric | trunk-min median | speed-min median | Δ |
|---|---:|---:|---:|
| FCP | **10 540 ms** | **11 484 ms** | +9 % (slower) |
| LCP | 30 680 ms | 31 600 ms | +3 % |
| Shell ready | 31 300 ms | 32 240 ms | +3 % |
| JS bytes transferred | 5 615 KB | 5 669 KB | +1 % |

**Warm loads (returning visitor, SW + browser cache active):**

| Metric | trunk-min median | speed-min median | Δ |
|---|---:|---:|---:|
| FCP | 1 176 ms | **528 ms** | **−55 %** |
| LCP | 1 176 ms | **528 ms** | **−55 %** |
| Shell ready | 1 861 ms | 1 553 ms | **−17 %** |
| JS bytes transferred | 0 KB (SW) | 0 KB (SW) | — |

### What this means

**Under real-world mobile conditions, the cold/warm split is the entire story.**

1. **Cold loads under throttling take 10–11 seconds for FCP and 30+ seconds for the full shell** on both branches. That's the catastrophic experience the issue reporter is describing — a 5 MB transfer over 1.6 Mbps mobile is fundamentally bandwidth-bound, and no amount of client-side cleverness can compress that.
2. **`speed-improvements` is ~1 s slower on cold loads under throttling** (10.5 s → 11.5 s FCP). This is an honest cost: the preload hints front-load `window-system.min.js` + `shell-overlays.min.js` (~50 KB combined) which trunk doesn't fetch until idle. Under heavy bandwidth constraints these extra bytes push the load event ~1 s later. **The right mitigation is to switch those two preloads to `<link rel="prefetch">` (lower priority, doesn't block load).** Recommended follow-up; one-line PHP change.
3. **Warm-load FCP drops from 1 176 ms to 528 ms — a 55 % improvement.** This IS the win the changes were designed for. A returning user (which is essentially every user beyond the first visit) sees the shell paint in half a second instead of over one second.
4. **Service Worker is doing massive work on warm loads** — 0 JS bytes transferred on warm. The SW is fully caching the bundles. Phase 3a's precache expansion helps the FIRST warm load (just after SW installs) by ensuring the cache is pre-populated.

### The cold/warm tradeoff visualized

```
                Cold FCP         Warm FCP
trunk-min:      10 540 ms        1 176 ms
speed-min:      11 484 ms          528 ms
                ─────────        ─────────
                +944 ms          −648 ms
                (slower, once)   (faster, every subsequent visit)
```

Net effect for a user visiting wp-admin **once per day for a week**:
- trunk:  1 × 10 540 + 6 × 1 176 = **17 596 ms** total page-load time
- speed:  1 × 11 484 + 6 × 528 = **14 652 ms** total page-load time
- **speed saves ~3 s of total wait over a week**, despite paying +1 s on day 1.

For a user visiting **multiple times per day**, the warm-load gain dominates entirely.

### Experiment: prefetch / deferred auto-open (didn't pan out — tested 2026-05-23)

Two follow-up experiments were measured under the same throttled conditions:

**Experiment 1 — switch lazy bundles to `<link rel="prefetch">`:** Hypothesis was that lower-priority prefetch would close the +1 s cold-load gap. Reality:

- **Pure prefetch on both lazy bundles**: warm LCP regressed from 528 ms → 2532 ms (+2 s). The browser deferred the prefetch fetch under throttling, so when `manager.open()` fired the boot-time window, `window-system.min.js` wasn't cached and had to fetch over the throttled network.
- **Hybrid (window-system preload, shell-overlays prefetch)**: warm FCP regressed 528 ms → 1076 ms (+548 ms). Smaller penalty but still real.
- **Conclusion**: `<link rel="preload">` is the correct hint for both lazy bundles. `requestIdleCallback`-driven preloading inside the main bundle is the secondary mechanism — both load paths agree on "fetch eagerly." The current code is the right config; reverted both experiments.

**Experiment 2 — defer or skip `openCurrentPage()`:** The shell auto-opens the current admin URL as a window on boot. The Dashboard iframe is the heaviest single thing in the shell.

| Variant | Cold loadEventEnd | Warm FCP |
|---|---:|---:|
| baseline (auto-open immediate) | 52 354 ms | 528 ms |
| auto-open deferred via `requestIdleCallback` | 51 369 ms | 808 ms |
| auto-open **disabled** entirely | **43 534 ms** | 1 196 ms |

- **Deferring via `requestIdleCallback` saves ~1 s on `loadEventEnd`** — the iframe still loads inside the load window, the defer just shifts it by a few ms. Doesn't actually unblock first paint of the shell.
- **Skipping auto-open entirely saves ~9 s on cold `loadEventEnd`** — the iframe never loads at all. This is real, big, and worth pursuing as a future opt-in feature.
- **Conclusion**: deferring isn't enough. The full win requires either (a) the user explicitly opening windows from the dock instead of having the URL auto-open one, or (b) lazy-loading the iframe (initialize the Window but defer the iframe src until the window is in viewport / focused).

### Recommended next step: OS Settings toggle for auto-open

Add a `OS Settings → Features → Auto-open current page on shell load` checkbox. Default ON (preserves current behaviour). Power users who prefer a dock-driven workflow flip it off and recover ~9 s of cold-load time on every visit.

Implementation sketch:

1. Add `autoOpenCurrentPage: true` to the OsSettings defaults.
2. In `desktop.ts`, gate the existing `if ( shouldAutoOpenCurrentPage( … ) )` block on `&& osSettings.state.autoOpenCurrentPage !== false`.
3. Surface in OS Settings → Features tab with a clear explainer: "Open the current admin URL as a window automatically on shell boot. Disable for a faster cold load that shows just the desktop + dock."
4. Keep `fromPortal=false` direct-URL navigation honored regardless — the user typed that URL, they meant it. Only suppress the portal-entry auto-open + the default-window auto-open.

This is a ~50-line PHP+TS change. Recommended for a separate PR after the current speed-improvements branch lands.

---

## Rollup across all three measurement scenarios

| Metric | Unminified medians | Minified medians | Throttled medians (posts) |
|---|---:|---:|---:|
| FCP rollup | −0.9 % | **−14.8 %** | warm: **−55 %**, cold: +9 % |
| LCP rollup | +2.2 % | **−21.6 %** | warm: **−55 %**, cold: +3 % |
| Shell ready | −0.5 % | **−8.9 %** | warm: **−17 %**, cold: +3 % |
| DCL rollup | −6.4 % | **−13.7 %** | (not isolated) |
| responseEnd | −1.1 % | **−13.7 %** | (server-bound, similar) |

**Net verdict:** the changes ship a clear win for returning users (the common case) and a measurable but acceptable cost for first-time visitors (which the prefetch swap above would close). The minified rollup numbers are the production-equivalent numbers.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-273-6f64ae6eb6074b06af3d88bc75a4724e2ca78e0c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->