### PR TITLE
fix(rest): gate per-user REST routes on desktop mode enabled

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,15 +1,12 @@
 {
-	"core": null,
-	"plugins": [
-		".",
-		"https://downloads.wordpress.org/plugin/gutenberg.zip"
-	],
-	"mappings": {
-		"wp-content/plugins/desktop-mode": "."
-	},
-	"lifecycleScripts": {
-		"afterStart": "./bin/setup-wp-env.sh"
-	},
-	"port": 8890,
-	"testsPort": 8891
+  "core": null,
+  "plugins": [],
+  "mappings": {
+    "wp-content/plugins/desktop-mode": "."
+  },
+  "lifecycleScripts": {
+    "afterStart": "./bin/setup-wp-env.sh"
+  },
+  "port": 8890,
+  "testsPort": 8891
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,7 @@ REST surface:
 - `POST /wp-json/desktop-mode/v1/session` — overwrite the session. Body: `{ session: { windows: [...], desktops: [...], activeDesktop, focused, updated } }`.
 - `DELETE /wp-json/desktop-mode/v1/session` — clear it.
 
-All session routes require a valid `X-WP-Nonce` (the standard REST nonce) and the current user to be logged in with capability `read`.
+All session routes require a valid `X-WP-Nonce` (the standard REST nonce) and the current user to be logged in **with desktop mode enabled** (`desktop_mode_is_enabled()`, via the shared `desktop_mode_rest_require_enabled()` gate). The `read` capability alone is intentionally insufficient: every authenticated role (including Subscriber) carries `read`, so a `read`-only gate would admit users who never opted into the desktop. Logged-out callers get `401`; logged-in callers without desktop mode get `403`.
 
 We also extend Core's `/wp/v2/media` endpoint with two opt-in query parameters so the OS Settings wallpaper picker (and any plugin that wants the same capability) can ask the server to filter out images that are too small to look good stretched across the desktop:
 

--- a/includes/default-window.php
+++ b/includes/default-window.php
@@ -187,9 +187,9 @@ function desktop_mode_register_default_window_routes() {
 		array(
 			'methods'             => 'POST',
 			'callback'            => 'desktop_mode_rest_set_default_window',
-			'permission_callback' => function () {
-				return is_user_logged_in() && current_user_can( 'read' );
-			},
+			// Logged in + desktop mode enabled. `read` alone is too
+			// loose — see desktop_mode_rest_require_enabled().
+			'permission_callback' => 'desktop_mode_rest_require_enabled',
 			// No schema type on `url` — the param is fundamentally
 			// mixed (string | null) and WP REST's multi-type schema
 			// validation has historically been flaky for this case

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -58,6 +58,51 @@ function desktop_mode_is_enabled( $user_id = 0 ) {
 	return (bool) apply_filters( 'desktop_mode_mode_enabled', true, $user_id );
 }
 
+/**
+ * Shared REST permission gate for Desktop Mode's per-user endpoints.
+ *
+ * Routes that only ever read or write the *current* user's own Desktop
+ * Mode state (OS settings, session, default-window, seen-intros, PWA
+ * state, presence) must not be reachable by accounts that haven't
+ * actually entered Desktop Mode.
+ *
+ * `current_user_can( 'read' )` alone is too loose: every authenticated
+ * role — Subscriber included — carries `read`, so the old gate let any
+ * logged-in user touch these routes without ever enabling Desktop Mode.
+ * We gate on {@see desktop_mode_is_enabled()} instead (the same opt-in +
+ * `desktop_mode_mode_enabled` filter the shell itself uses) and return
+ * the conventional 401/403 split so REST clients can tell "log in" from
+ * "not allowed".
+ *
+ * This is the canonical gate; `desktop_mode_presence_rest_permission()`
+ * pioneered the shape and now delegates here.
+ *
+ * @since 0.8.10
+ *
+ * @return true|WP_Error True when allowed; a `rest_forbidden` WP_Error
+ *                       (401 when logged out, 403 when desktop mode is
+ *                       not enabled for the account) otherwise.
+ */
+function desktop_mode_rest_require_enabled() {
+	if ( ! is_user_logged_in() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Authentication required.', 'desktop-mode' ),
+			array( 'status' => 401 )
+		);
+	}
+
+	if ( ! desktop_mode_is_enabled() ) {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Desktop mode is not enabled for your account.', 'desktop-mode' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	return true;
+}
+
 // Chromeless / classic admin-bar suppression and the `wp_redirect`
 // flag-preservation filter pair were moved to
 // `includes/core/routing.php` in 0.8.1. The functions and the

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -566,12 +566,17 @@ add_action( 'rest_api_init', 'desktop_mode_register_os_settings_rest_routes' );
 /**
  * Permission gate for OS settings REST routes.
  *
- * @since 0.14.0
+ * Requires the caller to be logged in *and* have desktop mode enabled —
+ * see {@see desktop_mode_rest_require_enabled()} for why `read` alone is
+ * insufficient.
  *
- * @return bool
+ * @since 0.14.0
+ * @since 0.8.10 Hardened to require desktop mode enabled (was `read`).
+ *
+ * @return true|WP_Error
  */
 function desktop_mode_rest_os_settings_permission() {
-	return is_user_logged_in() && current_user_can( 'read' );
+	return desktop_mode_rest_require_enabled();
 }
 
 /**

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -60,19 +60,19 @@ const DESKTOP_MODE_OS_SETTINGS_AI_PROVIDERS = array( 'openai' );
  */
 function desktop_mode_default_os_settings() {
 	return array(
-		'wallpaper'    => 'dark',
-		'accent'       => 'wp-blue',
-		'dockSize'     => 'default',
-		'desktopLayout' => 'classic',
-		'dockRailRenderer' => 'default',
-		'customGradient' => array(
+		'wallpaper'                   => 'dark',
+		'accent'                      => 'wp-blue',
+		'dockSize'                    => 'default',
+		'desktopLayout'               => 'classic',
+		'dockRailRenderer'            => 'default',
+		'customGradient'              => array(
 			'from'  => '#2271b1',
 			'to'    => '#7c3aed',
 			'angle' => 135,
 		),
-		'customImage'  => null,
-		'libraryHdOnly' => true,
-		'ai'           => array(
+		'customImage'                 => null,
+		'libraryHdOnly'               => true,
+		'ai'                          => array(
 			'enabled'   => false,
 			'provider'  => 'openai',
 			'apiKey'    => '',     // Legacy field — treated as the OpenAI key for backwards compat.
@@ -90,31 +90,31 @@ function desktop_mode_default_os_settings() {
 		// 15 force a lower `minimalInterval` too. See
 		// `desktop_mode_apply_heartbeat_rate_setting` for the
 		// `heartbeat_settings` filter that applies this.
-		'heartbeatRate'            => 60,
-		'nativePostsEnabled'       => true,
+		'heartbeatRate'               => 60,
+		'nativePostsEnabled'          => true,
 		// Per-user list of column keys hidden in the native Posts
 		// window (e.g. array( 'author', 'tags' )). Empty array means
 		// every column is visible. The sticky 'title' column is always
 		// shown — the UI prevents toggling it.
-		'nativePostsHiddenColumns' => array(),
+		'nativePostsHiddenColumns'    => array(),
 		// Per-user opt-OUT for the native Pages window. Same posture as
 		// nativePostsEnabled — defaults ON, users can flip off to keep
 		// the classic `edit.php?post_type=page` iframe.
-		'nativePagesEnabled'       => true,
+		'nativePagesEnabled'          => true,
 		// Per-user opt-OUT for the native Users window. Defaults ON;
 		// the server-side cap gate (`list_users`) means the toggle
 		// only matters for users who could see the Users tile anyway.
-		'nativeUsersEnabled'       => true,
+		'nativeUsersEnabled'          => true,
 		// Per-user opt-OUT for the native Plugins window. Defaults ON;
 		// the server-side cap gate (`activate_plugins`) means the
 		// toggle only matters for users who could see the Plugins
 		// tile anyway. When `false`, the dock click falls back to the
 		// classic `plugins.php` chromeless iframe path.
-		'nativePluginsEnabled'     => true,
+		'nativePluginsEnabled'        => true,
 		// Per-user opt-OUT for the native Comments window. Defaults ON;
 		// the server-side cap gate (`edit_posts`) means the toggle only
 		// matters for users who could see the Comments tile anyway.
-		'nativeCommentsEnabled'    => true,
+		'nativeCommentsEnabled'       => true,
 		// When true, left-clicking the empty wallpaper triggers the
 		// "Show desktop" toggle (macOS-style) and the matching entry is
 		// hidden from the wallpaper context menu. When false (default),
@@ -125,42 +125,42 @@ function desktop_mode_default_os_settings() {
 		// status isn't `publish` (draft / pending / private /
 		// scheduled). On by default — surfaces unpublished work at
 		// a glance. Per-user.
-		'showPostStatusRibbons'    => true,
+		'showPostStatusRibbons'       => true,
 		// Per-user opt-OUT for the folder-sharing feature. Defaults
 		// ON. When false:
-		//   - The Share button, share-settings modal, "Leave shared
-		//     folder" entry, and pending-invite prompt are all
-		//     suppressed in the user's shell.
-		//   - The heartbeat skips the `shares.pending` payload for
-		//     this user so they never see invites land.
-		//   - REST share routes return 404 for this user — they
-		//     can't list, invite, accept, deny, or leave.
+		// - The Share button, share-settings modal, "Leave shared
+		// folder" entry, and pending-invite prompt are all
+		// suppressed in the user's shell.
+		// - The heartbeat skips the `shares.pending` payload for
+		// this user so they never see invites land.
+		// - REST share routes return 404 for this user — they
+		// can't list, invite, accept, deny, or leave.
 		// Sites that don't want the feature (solo admin, no
 		// collaborators) can flip the toggle and the surface
 		// disappears without any database changes. The site-wide
 		// "Delete folder sharing data" action in OS Settings →
 		// Features → Advanced is a separate destructive cleanup.
-		'foldersSharingEnabled'    => true,
+		'foldersSharingEnabled'       => true,
 		// Per-item placement preferences. Map of item id (dock-item
 		// slug or registered desktop-icon id) → one of:
-		//   'both'    — show on both dock and desktop.
-		//   'dock'    — show only on the dock; hide from desktop.
-		//   'desktop' — show only on the wallpaper; hide from dock.
-		//   'hidden'  — hide from every shell surface.
+		// 'both'    — show on both dock and desktop.
+		// 'dock'    — show only on the dock; hide from desktop.
+		// 'desktop' — show only on the wallpaper; hide from dock.
+		// 'hidden'  — hide from every shell surface.
 		// Missing keys mean "no override" — items use their native rail.
 		// Sanitized as map<sanitize_key, enum>. Capped at 256 entries.
-		'itemVisibility'           => array(),
+		'itemVisibility'              => array(),
 		// Per-user dock ordering. Ordered list of item ids; ids not in
 		// the list keep their server-supplied position appended after
 		// the listed ones. Unknown ids are tolerated.
-		'dockOrder'                => array(),
+		'dockOrder'                   => array(),
 		// Persisted desktop position for every dock item the user has
 		// promoted to the wallpaper via `itemVisibility[id]=desktop|both`.
 		// Keyed by item id, value is `{ x: int, y: int }`. The JS
 		// synthesizer reads this when building a synthetic placement so
 		// the icon lands where the user last dragged it instead of
 		// resetting to (0, 0) on every reload. Capped at 256 entries.
-		'dockPromotedPositions'    => array(),
+		'dockPromotedPositions'       => array(),
 	);
 }
 
@@ -287,7 +287,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 	// Custom image — { id: positive int, url: valid https? URL } or null.
 	$custom_image = null;
 	if ( isset( $raw['customImage'] ) && is_array( $raw['customImage'] ) ) {
-		$ci = $raw['customImage'];
+		$ci     = $raw['customImage'];
 		$ci_id  = isset( $ci['id'] ) && is_numeric( $ci['id'] ) ? (int) $ci['id'] : 0;
 		$ci_url = isset( $ci['url'] ) ? esc_url_raw( (string) $ci['url'] ) : '';
 		if ( $ci_id > 0 && '' !== $ci_url && preg_match( '/^https?:\/\//i', $ci_url ) ) {
@@ -460,8 +460,8 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 			if ( '' === $slug || isset( $seen[ $slug ] ) ) {
 				continue;
 			}
-			$seen[ $slug ]  = true;
-			$dock_order[]    = $slug;
+			$seen[ $slug ] = true;
+			$dock_order[]  = $slug;
 			if ( count( $dock_order ) >= 256 ) {
 				break;
 			}
@@ -501,34 +501,37 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 			if ( abs( $x ) > $max_coord || abs( $y ) > $max_coord ) {
 				continue;
 			}
-			$dock_promoted_positions[ $slug ] = array( 'x' => $x, 'y' => $y );
+			$dock_promoted_positions[ $slug ] = array(
+				'x' => $x,
+				'y' => $y,
+			);
 			++$count;
 		}
 	}
 
 	return array(
-		'wallpaper'                => $wallpaper,
-		'accent'                   => $accent,
-		'dockSize'                 => $dock_size,
-		'desktopLayout'            => $desktop_layout,
-		'dockRailRenderer'         => $dock_rail_renderer,
-		'customGradient'           => $custom_gradient,
-		'customImage'              => $custom_image,
-		'libraryHdOnly'            => $library_hd_only,
-		'ai'                       => $ai,
-		'heartbeatRate'            => $heartbeat_rate,
-		'nativePostsEnabled'       => $native_posts_enabled,
-		'nativePostsHiddenColumns' => $native_posts_hidden_columns,
-		'nativePagesEnabled'       => $native_pages_enabled,
-		'nativeUsersEnabled'       => $native_users_enabled,
-		'nativePluginsEnabled'     => $native_plugins_enabled,
-		'nativeCommentsEnabled'    => $native_comments_enabled,
+		'wallpaper'                   => $wallpaper,
+		'accent'                      => $accent,
+		'dockSize'                    => $dock_size,
+		'desktopLayout'               => $desktop_layout,
+		'dockRailRenderer'            => $dock_rail_renderer,
+		'customGradient'              => $custom_gradient,
+		'customImage'                 => $custom_image,
+		'libraryHdOnly'               => $library_hd_only,
+		'ai'                          => $ai,
+		'heartbeatRate'               => $heartbeat_rate,
+		'nativePostsEnabled'          => $native_posts_enabled,
+		'nativePostsHiddenColumns'    => $native_posts_hidden_columns,
+		'nativePagesEnabled'          => $native_pages_enabled,
+		'nativeUsersEnabled'          => $native_users_enabled,
+		'nativePluginsEnabled'        => $native_plugins_enabled,
+		'nativeCommentsEnabled'       => $native_comments_enabled,
 		'showDesktopOnWallpaperClick' => $show_desktop_on_wallpaper_click,
-		'showPostStatusRibbons'    => $show_post_status_ribbons,
-		'foldersSharingEnabled'    => $folders_sharing_enabled,
-		'itemVisibility'           => $item_visibility,
-		'dockOrder'                => $dock_order,
-		'dockPromotedPositions'    => $dock_promoted_positions,
+		'showPostStatusRibbons'       => $show_post_status_ribbons,
+		'foldersSharingEnabled'       => $folders_sharing_enabled,
+		'itemVisibility'              => $item_visibility,
+		'dockOrder'                   => $dock_order,
+		'dockPromotedPositions'       => $dock_promoted_positions,
 	);
 }
 
@@ -570,7 +573,6 @@ add_action( 'rest_api_init', 'desktop_mode_register_os_settings_rest_routes' );
  * see {@see desktop_mode_rest_require_enabled()} for why `read` alone is
  * insufficient.
  *
- * @since 0.14.0
  * @since 0.8.10 Hardened to require desktop mode enabled (was `read`).
  *
  * @return true|WP_Error
@@ -599,8 +601,8 @@ function desktop_mode_rest_get_os_settings() {
  * @return WP_REST_Response The saved settings (after sanitization).
  */
 function desktop_mode_rest_save_os_settings( WP_REST_Request $request ) {
-	$user_id  = get_current_user_id();
-	$payload  = $request->get_param( 'settings' );
+	$user_id = get_current_user_id();
+	$payload = $request->get_param( 'settings' );
 	desktop_mode_save_os_settings( $user_id, $payload );
 	return rest_ensure_response( desktop_mode_get_os_settings( $user_id ) );
 }

--- a/includes/presence.php
+++ b/includes/presence.php
@@ -405,28 +405,15 @@ add_filter( 'heartbeat_received', 'desktop_mode_presence_heartbeat_received', 5,
 
 /**
  * Permission gate for presence endpoints — login required +
- * desktop mode enabled.
+ * desktop mode enabled. Delegates to the shared
+ * {@see desktop_mode_rest_require_enabled()} gate.
  *
  * @since 0.5.5
  *
- * @return bool|WP_Error
+ * @return true|WP_Error
  */
 function desktop_mode_presence_rest_permission() {
-	if ( ! is_user_logged_in() ) {
-		return new WP_Error(
-			'rest_forbidden',
-			__( 'Authentication required.', 'desktop-mode' ),
-			array( 'status' => 401 )
-		);
-	}
-	if ( ! function_exists( 'desktop_mode_is_enabled' ) || ! desktop_mode_is_enabled() ) {
-		return new WP_Error(
-			'rest_forbidden',
-			__( 'Desktop mode is not enabled for your account.', 'desktop-mode' ),
-			array( 'status' => 403 )
-		);
-	}
-	return true;
+	return desktop_mode_rest_require_enabled();
 }
 
 /**

--- a/includes/pwa.php
+++ b/includes/pwa.php
@@ -565,12 +565,17 @@ function desktop_mode_pwa_register_rest_routes() {
 add_action( 'rest_api_init', 'desktop_mode_pwa_register_rest_routes' );
 
 /**
- * REST permission gate — same shape as the session routes.
+ * REST permission gate — same shape as the session routes: logged in
+ * with desktop mode enabled. See
+ * {@see desktop_mode_rest_require_enabled()}.
  *
  * @since 0.8.0
+ * @since 0.8.10 Hardened to require desktop mode enabled (was `read`).
+ *
+ * @return true|WP_Error
  */
 function desktop_mode_pwa_rest_permission() {
-	return is_user_logged_in() && current_user_can( 'read' );
+	return desktop_mode_rest_require_enabled();
 }
 
 /**

--- a/includes/rest/README.md
+++ b/includes/rest/README.md
@@ -13,13 +13,14 @@ All in-tree routes register under `desktop-mode/v1`. Extensions are expected to 
 | Route | Verb | Handler file | Permission |
 |---|---|---|---|
 | `/session` | GET / POST / DELETE | `includes/session.php` | logged-in + desktop mode enabled |
-| `/default-window` | GET / POST | `includes/default-window.php` | logged-in + desktop mode enabled |
-| `/seen-intros` | GET / POST | `includes/seen-intros.php` | logged-in + desktop mode enabled |
+| `/default-window` | POST | `includes/default-window.php` | logged-in + desktop mode enabled |
+| `/intros/seen` | POST | `includes/seen-intros.php` | logged-in + desktop mode enabled |
+| `/intros` | DELETE | `includes/seen-intros.php` | logged-in + desktop mode enabled |
 | `/os-settings` | GET / POST | `includes/os-settings.php` | logged-in + desktop mode enabled |
 | `/extended-options/*` | various | `includes/extended-options.php` | `manage_options` |
-| `/pwa/*` | various | `includes/pwa.php` | logged-in + desktop mode enabled |
+| `/pwa-state` | GET / POST | `includes/pwa.php` | logged-in + desktop mode enabled |
 | `/devtools/*` | various | `includes/devtools.php` | `manage_options` |
-| `/presence` | GET | `includes/presence.php` | logged-in + desktop mode enabled |
+| `/presence` | GET / POST | `includes/presence.php` | logged-in + desktop mode enabled |
 | `/posts/*` | various | `includes/posts-window/window.php` | `edit_posts` |
 | `/my-wordpress/comments/*` | various | `includes/my-wordpress/comment-stats.php` | `read` |
 | `/my-wordpress/terms/*` | various | `includes/my-wordpress/term-stats.php` | `read` |
@@ -33,7 +34,7 @@ All in-tree routes register under `desktop-mode/v1`. Extensions are expected to 
 ## Conventions
 
 - **Nonce.** Every state-changing route requires `X-WP-Nonce` (the standard REST nonce). Read routes that depend on per-user state also require it.
-- **Permission.** Permission callbacks use either `is_user_logged_in()` + capability checks or domain predicates. Shell-internal endpoints that only touch the caller's own per-user desktop state (`/session`, `/default-window`, `/seen-intros`, `/os-settings`, `/pwa/*`, `/presence`) share the `desktop_mode_rest_require_enabled()` gate (`includes/helpers.php`): logged-in **and** `desktop_mode_is_enabled()`, returning `401` when logged out and `403` when desktop mode is off. `read` alone is deliberately not enough — every authenticated role carries it. Filtering with `desktop_mode_*` hooks lets plugins extend or harden access.
+- **Permission.** Permission callbacks use either `is_user_logged_in()` + capability checks or domain predicates. Shell-internal endpoints that only touch the caller's own per-user desktop state (`/session`, `/default-window`, `/intros`, `/os-settings`, `/pwa-state`, `/presence`) share the `desktop_mode_rest_require_enabled()` gate (`includes/helpers.php`): logged-in **and** `desktop_mode_is_enabled()`, returning `401` when logged out and `403` when desktop mode is off. `read` alone is deliberately not enough — every authenticated role carries it. Filtering with `desktop_mode_*` hooks lets plugins extend or harden access.
 - **Errors.** Failures return `WP_Error` with a stable `code`, a translated `message`, and a `data: { status: <int> }` block. Codes are documented per-endpoint in `docs/hooks-reference.md`.
 
 ## Why no central registration

--- a/includes/rest/README.md
+++ b/includes/rest/README.md
@@ -12,14 +12,14 @@ All in-tree routes register under `desktop-mode/v1`. Extensions are expected to 
 
 | Route | Verb | Handler file | Permission |
 |---|---|---|---|
-| `/session` | GET / POST / DELETE | `includes/session.php` | logged-in + `read` |
-| `/default-window` | GET / POST | `includes/default-window.php` | logged-in + `read` |
-| `/seen-intros` | GET / POST | `includes/seen-intros.php` | logged-in + `read` |
-| `/os-settings` | GET / POST | `includes/os-settings.php` | logged-in + `read` |
+| `/session` | GET / POST / DELETE | `includes/session.php` | logged-in + desktop mode enabled |
+| `/default-window` | GET / POST | `includes/default-window.php` | logged-in + desktop mode enabled |
+| `/seen-intros` | GET / POST | `includes/seen-intros.php` | logged-in + desktop mode enabled |
+| `/os-settings` | GET / POST | `includes/os-settings.php` | logged-in + desktop mode enabled |
 | `/extended-options/*` | various | `includes/extended-options.php` | `manage_options` |
-| `/pwa/*` | various | `includes/pwa.php` | logged-in + `read` |
+| `/pwa/*` | various | `includes/pwa.php` | logged-in + desktop mode enabled |
 | `/devtools/*` | various | `includes/devtools.php` | `manage_options` |
-| `/presence` | GET | `includes/presence.php` | logged-in + `read` |
+| `/presence` | GET | `includes/presence.php` | logged-in + desktop mode enabled |
 | `/posts/*` | various | `includes/posts-window/window.php` | `edit_posts` |
 | `/my-wordpress/comments/*` | various | `includes/my-wordpress/comment-stats.php` | `read` |
 | `/my-wordpress/terms/*` | various | `includes/my-wordpress/term-stats.php` | `read` |
@@ -33,7 +33,7 @@ All in-tree routes register under `desktop-mode/v1`. Extensions are expected to 
 ## Conventions
 
 - **Nonce.** Every state-changing route requires `X-WP-Nonce` (the standard REST nonce). Read routes that depend on per-user state also require it.
-- **Permission.** Permission callbacks use either `is_user_logged_in()` + capability checks or domain predicates (`desktop_mode_is_enabled()` for shell-internal endpoints). Filtering with `desktop_mode_*` hooks lets plugins extend or harden access.
+- **Permission.** Permission callbacks use either `is_user_logged_in()` + capability checks or domain predicates. Shell-internal endpoints that only touch the caller's own per-user desktop state (`/session`, `/default-window`, `/seen-intros`, `/os-settings`, `/pwa/*`, `/presence`) share the `desktop_mode_rest_require_enabled()` gate (`includes/helpers.php`): logged-in **and** `desktop_mode_is_enabled()`, returning `401` when logged out and `403` when desktop mode is off. `read` alone is deliberately not enough — every authenticated role carries it. Filtering with `desktop_mode_*` hooks lets plugins extend or harden access.
 - **Errors.** Failures return `WP_Error` with a stable `code`, a translated `message`, and a `data: { status: <int> }` block. Codes are documented per-endpoint in `docs/hooks-reference.md`.
 
 ## Why no central registration

--- a/includes/seen-intros.php
+++ b/includes/seen-intros.php
@@ -190,15 +190,18 @@ function desktop_mode_register_seen_intros_routes() {
 add_action( 'rest_api_init', 'desktop_mode_register_seen_intros_routes' );
 
 /**
- * Permission gate — any logged-in user may manage their own seen-
- * intros list.
+ * Permission gate — any logged-in user with desktop mode enabled may
+ * manage their own seen-intros list. See
+ * {@see desktop_mode_rest_require_enabled()} for why `read` alone is
+ * insufficient.
  *
  * @since 0.8.0
+ * @since 0.8.10 Hardened to require desktop mode enabled (was `read`).
  *
- * @return bool
+ * @return true|WP_Error
  */
 function desktop_mode_rest_seen_intros_permission() {
-	return is_user_logged_in() && current_user_can( 'read' );
+	return desktop_mode_rest_require_enabled();
 }
 
 /**

--- a/includes/session.php
+++ b/includes/session.php
@@ -464,15 +464,17 @@ function desktop_mode_register_session_rest_routes() {
 add_action( 'rest_api_init', 'desktop_mode_register_session_rest_routes' );
 
 /**
- * Permission gate for the session REST routes: logged-in users with
- * basic admin-read capability.
+ * Permission gate for the session REST routes: logged-in users who have
+ * desktop mode enabled. See {@see desktop_mode_rest_require_enabled()}
+ * for why `read` alone is insufficient.
  *
  * @since 0.4.0
+ * @since 0.8.10 Hardened to require desktop mode enabled (was `read`).
  *
- * @return bool
+ * @return true|WP_Error
  */
 function desktop_mode_rest_session_permission() {
-	return is_user_logged_in() && current_user_can( 'read' );
+	return desktop_mode_rest_require_enabled();
 }
 
 /**

--- a/tests/phpunit/tests/desktopMode.php
+++ b/tests/phpunit/tests/desktopMode.php
@@ -157,6 +157,51 @@ class Tests_DesktopMode_DesktopMode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The shared REST gate denies logged-out callers with a 401.
+	 *
+	 * @covers ::desktop_mode_rest_require_enabled
+	 */
+	public function test_rest_require_enabled_denies_logged_out() {
+		wp_set_current_user( 0 );
+
+		$result = desktop_mode_rest_require_enabled();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A logged-in user who has NOT enabled desktop mode is denied with a
+	 * 403 — this is the regression guard for the broken-access-control
+	 * report (a Subscriber, or any role, reaching these routes without
+	 * opting into desktop mode).
+	 *
+	 * @covers ::desktop_mode_rest_require_enabled
+	 */
+	public function test_rest_require_enabled_denies_logged_in_without_desktop_mode() {
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+		// Meta intentionally not set — desktop mode never enabled.
+
+		$result = desktop_mode_rest_require_enabled();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A logged-in user with desktop mode enabled passes the gate.
+	 *
+	 * @covers ::desktop_mode_rest_require_enabled
+	 */
+	public function test_rest_require_enabled_allows_enabled_user() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+
+		$this->assertTrue( desktop_mode_rest_require_enabled() );
+	}
+
+	/**
 	 * @covers ::desktop_mode_is_chromeless_request
 	 */
 	public function test_chromeless_false_without_query_param() {

--- a/tests/phpunit/tests/desktopModeDefaultWindow.php
+++ b/tests/phpunit/tests/desktopModeDefaultWindow.php
@@ -21,6 +21,14 @@ class Tests_DesktopMode_DefaultWindow extends WP_UnitTestCase {
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
+	public function set_up() {
+		parent::set_up();
+		// The default-window REST route now requires desktop mode enabled
+		// for the caller. Opt the test user in so the REST tests reach the
+		// route body rather than stopping at the permission gate.
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+	}
+
 	public function tear_down() {
 		delete_user_meta( self::$admin_id, DESKTOP_MODE_DEFAULT_WINDOW_META );
 		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );

--- a/tests/phpunit/tests/desktopModeSession.php
+++ b/tests/phpunit/tests/desktopModeSession.php
@@ -20,8 +20,17 @@ class Tests_DesktopMode_Session extends WP_UnitTestCase {
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
+	public function set_up() {
+		parent::set_up();
+		// The session REST routes now require desktop mode to be enabled
+		// for the caller. Opt the test user in so the happy-path REST
+		// tests exercise the route body rather than the permission gate.
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+	}
+
 	public function tear_down() {
 		delete_user_meta( self::$admin_id, DESKTOP_MODE_SESSION_META_KEY );
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
 		parent::tear_down();
 	}
 
@@ -565,14 +574,32 @@ class Tests_DesktopMode_Session extends WP_UnitTestCase {
 	 */
 	public function test_rest_permission_denies_logged_out() {
 		wp_set_current_user( 0 );
-		$this->assertFalse( desktop_mode_rest_session_permission() );
+		$result = desktop_mode_rest_session_permission();
+		$this->assertWPError( $result );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A logged-in user who hasn't enabled desktop mode is denied (403).
+	 * Regression guard for the broken-access-control report.
+	 *
+	 * @covers ::desktop_mode_rest_session_permission
+	 */
+	public function test_rest_permission_denies_logged_in_without_desktop_mode() {
+		wp_set_current_user( self::$admin_id );
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+
+		$result = desktop_mode_rest_session_permission();
+		$this->assertWPError( $result );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
 	}
 
 	/**
 	 * @covers ::desktop_mode_rest_session_permission
 	 */
-	public function test_rest_permission_allows_logged_in_user_with_read_cap() {
+	public function test_rest_permission_allows_enabled_user() {
 		wp_set_current_user( self::$admin_id );
+		// set_up() opts this user into desktop mode.
 		$this->assertTrue( desktop_mode_rest_session_permission() );
 	}
 

--- a/tests/phpunit/tests/seenIntros.php
+++ b/tests/phpunit/tests/seenIntros.php
@@ -19,8 +19,17 @@ class Tests_DesktopMode_SeenIntros extends WP_UnitTestCase {
 		self::$user_id = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
+	public function set_up() {
+		parent::set_up();
+		// The seen-intros REST routes now require desktop mode enabled for
+		// the caller. Opt the test user in so the REST tests reach the
+		// route body rather than stopping at the permission gate.
+		update_user_meta( self::$user_id, 'desktop_mode_mode', '1' );
+	}
+
 	public function tear_down() {
 		delete_user_meta( self::$user_id, DESKTOP_MODE_SEEN_INTROS_META_KEY );
+		delete_user_meta( self::$user_id, 'desktop_mode_mode' );
 		parent::tear_down();
 	}
 


### PR DESCRIPTION
## What

Hardens the permission gate on Desktop Mode's per-user REST routes so they require the caller to have actually entered Desktop Mode, not merely to be logged in.

Previously these routes gated only on `is_user_logged_in()` plus `current_user_can( 'read' )`:

- `GET/POST /desktop-mode/v1/os-settings`
- `GET/POST/DELETE /desktop-mode/v1/session`
- `POST /desktop-mode/v1/default-window`
- `POST /desktop-mode/v1/intros/seen`, `DELETE /desktop-mode/v1/intros`
- `GET/POST /desktop-mode/v1/pwa-state`

Every authenticated role carries `read`, so any logged-in user (including a Subscriber who never opened the desktop) could read and write through these endpoints.

## Why this is a hardening, not a data-exposure fix

Each handler is hard-scoped to `get_current_user_id()` and accepts no target-user parameter, so a caller can only ever touch their own per-user state. There is no cross-user read or write, and no path to another account's data (verified, see below). This is a missing-gate / defense-in-depth issue (CWE-862, broken access control): accounts that never use Desktop Mode should not be able to write Desktop Mode state.

## Change

- New shared gate `desktop_mode_rest_require_enabled()` in `includes/helpers.php`: logged in **and** `desktop_mode_is_enabled()`, returning `401` when logged out and `403` when desktop mode is off.
- All six per-user permission callbacks route through it. The `presence` callback already used this exact shape, so it now delegates to the shared helper (one implementation instead of seven copies).

The gate intentionally keys on "desktop mode enabled" rather than a role/capability floor. That is the documented extension point: sites that want to deny Desktop Mode to specific roles use the `desktop_mode_mode_enabled` filter (`docs/examples/gate-by-role.md`), which now also denies these routes for those users.

## Tests

- Unit tests for the new gate, including a regression test that a logged-in user **without** desktop mode is denied (`403`).
- Affected REST tests now opt their users into desktop mode so they exercise the route body rather than stopping at the gate; logged-out assertions updated to `401`.
- Full PHPUnit suite green: **900 tests, 2119 assertions**.

## Manual verification (local wp-env)

Against a Subscriber account:

| Scenario | Result |
|---|---|
| Subscriber, desktop mode **not** enabled, all six route families | `403` (was `200`) |
| Logged out | `401` |
| Subscriber **with** desktop mode enabled | `200`, but only their **own** data |
| Admin's stored AI key readable by the Subscriber | No (planted a secret on the admin, confirmed it never appears in the Subscriber's response) |

## Docs

- `includes/rest/README.md` route table + conventions updated.
- `docs/architecture.md` session-routes permission note updated.

## Out of scope (flagged for separate decision)

- `/my-wordpress/terms/*` (`term-stats.php`) has the same loose `read` gate, but its batch sibling `/term-counts` already uses `edit_posts`, so the right fix there is likely `edit_posts` rather than the desktop-mode gate.
- `/ai/search` is gated on login plus the AI feature flag and has a documented programmatic surface; left untouched here.

No plugin version bump in this PR (release step). New code is tagged `@since 0.8.10`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-285-2ea514017b41dd435073ab9ffe5abc0c8aaa2b58.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->