### PR TITLE
ci(debug): diagnose wp-env tests-cli startup failure [do not merge]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3', '8.4' ]
+        php: [ '8.3' ]   # DEBUG: single leg while diagnosing
 
     steps:
       - uses: actions/checkout@v6
@@ -79,6 +79,30 @@ jobs:
           echo "::endgroup::"
           echo "::group::wp-env logs (tests)"; timeout 25 npx wp-env logs tests --watch=false 2>&1 || true; echo "::endgroup::"
           echo "::group::resources"; df -h / || true; free -h || true; echo "::endgroup::"
+
+      - name: Show generated compose + direct `docker compose up` (always)
+        if: always()
+        # DEBUG: wp-env swallows the docker-compose error (it only prints
+        # "Command failed with exit code 1"). Dump the generated compose file
+        # and run `docker compose up` directly so the REAL stderr is visible
+        # (e.g. "dependency failed to start: container ... is unhealthy",
+        # a port bind clash, or a compose-version incompatibility).
+        run: |
+          echo "::group::versions"
+          docker version --format 'engine {{.Server.Version}}' || true
+          docker compose version || true
+          echo "::endgroup::"
+          CFG=$(ls -d "$HOME"/.wp-env/*/ 2>/dev/null | head -1)
+          echo "wp-env config dir: $CFG"
+          echo "::group::docker-compose.yml"
+          cat "${CFG}docker-compose.yml" 2>/dev/null || echo "(no compose file found)"
+          echo "::endgroup::"
+          echo "::group::direct docker compose up -d (real stderr)"
+          docker compose -f "${CFG}docker-compose.yml" up -d 2>&1 || true
+          echo "::endgroup::"
+          echo "::group::docker ps -a after direct up"
+          docker ps -a
+          echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,33 +53,45 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start wp-env (traced)
+      - name: Start wp-env (traced + debug)
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        # DEBUG: shim `docker` to log every invocation + exit code, so we
-        # capture the EXACT command wp-env runs that exits non-zero (every
-        # command reproduced by hand exits 0, so we need the real argv).
+        # DEBUG: shim docker/git/svn to log argv + exit code, and run wp-env
+        # with --debug capturing full output. The failure is a non-docker
+        # step (downloadSources/readWordPressVersion/downloadWPPHPUnit) that
+        # exits 1; this pins down exactly which command.
         run: |
-          REAL="$(command -v docker)"
-          echo "real docker: $REAL"
           mkdir -p /tmp/shim
-          {
-            echo '#!/usr/bin/env bash'
-            echo 'echo "ARGV: $*" >> /tmp/dc.log'
-            echo "$REAL"' "$@"; rc=$?'
-            echo 'echo "   -> exit=$rc" >> /tmp/dc.log'
-            echo 'exit $rc'
-          } > /tmp/shim/docker
-          chmod +x /tmp/shim/docker
+          for t in docker git svn; do
+            real="$(command -v "$t" || true)"
+            [ -z "$real" ] && continue
+            {
+              printf '%s\n' '#!/usr/bin/env bash'
+              printf 'echo "[%s] $*" >> /tmp/dc.log\n' "$t"
+              printf '%s "$@"; rc=$?\n' "$real"
+              printf 'echo "   -> [%s] exit=$rc" >> /tmp/dc.log\n' "$t"
+              printf '%s\n' 'exit $rc'
+            } > "/tmp/shim/$t"
+            chmod +x "/tmp/shim/$t"
+          done
           : > /tmp/dc.log
           export PATH="/tmp/shim:$PATH"
-          npm run env:start
+          set +e
+          npx wp-env start --debug > /tmp/start.log 2>&1
+          echo "WPENV_EXIT=$?"
 
-      - name: Traced docker calls (always)
+      - name: wp-env start log + trace (always)
         if: always()
         run: |
-          echo "=== docker invocations during wp-env start (with exit codes) ==="
+          echo "::group::wp-env start --debug (tail 60)"
+          tail -60 /tmp/start.log 2>/dev/null || echo "(no start log)"
+          echo "::endgroup::"
+          echo "::group::traced commands that exited non-zero"
+          grep -B1 'exit=[^0]' /tmp/dc.log 2>/dev/null || echo "(all traced docker/git/svn commands exited 0)"
+          echo "::endgroup::"
+          echo "::group::full docker/git/svn trace"
           cat /tmp/dc.log 2>/dev/null || echo "(no trace)"
+          echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
 
   php:
     name: PHPUnit · PHP ${{ matrix.php }}
-    runs-on: ubuntu-latest
+    # DEBUG: pin to the older runner image (Docker/Compose) to test whether
+    # the ubuntu-24.04 20260525 build is what breaks `wp-env start`.
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
 
   php:
     name: PHPUnit · PHP ${{ matrix.php }}
-    # DEBUG: pin to the older runner image (Docker/Compose) to test whether
-    # the ubuntu-24.04 20260525 build is what breaks `wp-env start`.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -100,10 +98,22 @@ jobs:
           echo "::group::docker-compose.yml"
           cat "${CFG}/docker-compose.yml" 2>/dev/null || echo "(no compose file found)"
           echo "::endgroup::"
-          echo "::group::direct docker compose up -d (real stderr)"
-          docker compose -f "${CFG}/docker-compose.yml" up -d 2>&1 || true
+          F="${CFG}/docker-compose.yml"
+          echo "::group::reset (down -v) so we reproduce a clean failure"
+          docker compose -f "$F" down -v 2>&1 || true
           echo "::endgroup::"
-          echo "::group::docker ps -a after direct up"
+          echo "::group::EXACT wp-env upMany command (real stderr)"
+          # Mirrors @wordpress/env runtime/docker/index.js:
+          #   dockerCompose.upMany(['wordpress','tests-wordpress','cli','tests-cli'],
+          #     { commandOptions: ['--build','--force-recreate'] })
+          docker compose -f "$F" up -d --build --force-recreate \
+            wordpress tests-wordpress cli tests-cli 2>&1
+          echo "EXIT=$?"
+          echo "::endgroup::"
+          echo "::group::plain up -d (control: no --build/--force-recreate)"
+          docker compose -f "$F" up -d 2>&1; echo "EXIT=$?"
+          echo "::endgroup::"
+          echo "::group::docker ps -a"
           docker ps -a
           echo "::endgroup::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,33 +12,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
           cache-dependency-path: package-lock.json
-
       - name: Install dependencies
         run: npm ci
-
       - name: ESLint
         run: npm run lint
-
       - name: TypeScript (no emit)
         run: npx tsc --noEmit
-
       - name: Vitest
         run: npm run test:js
 
   php:
-    name: PHPUnit · PHP ${{ matrix.php }}
+    name: "PHPUnit (core=${{ matrix.core || 'default' }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3' ]   # DEBUG: single leg while diagnosing
+        # leg 1: default (core:null -> latest stable WP, currently 7.0) -> capture the literal error
+        # leg 2: the proposed fix -> WordPress 7.0 from wordpress-develop (version 7.0.1-alpha)
+        core: [ "", "WordPress/wordpress-develop#7.0" ]
 
     steps:
       - uses: actions/checkout@v6
@@ -53,13 +50,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Apply core override
+        if: matrix.core != ''
+        run: |
+          printf '{ "core": "%s" }\n' '${{ matrix.core }}' > .wp-env.override.json
+          echo "override:"; cat .wp-env.override.json
+
       - name: Start wp-env (traced + debug)
         env:
-          WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        # DEBUG: shim docker/git/svn to log argv + exit code, and run wp-env
-        # with --debug capturing full output. The failure is a non-docker
-        # step (downloadSources/readWordPressVersion/downloadWPPHPUnit) that
-        # exits 1; this pins down exactly which command.
+          WP_ENV_PHP_VERSION: '8.3'
         run: |
           mkdir -p /tmp/shim
           for t in docker git svn; do
@@ -80,55 +79,22 @@ jobs:
           npx wp-env start --debug > /tmp/start.log 2>&1
           echo "WPENV_EXIT=$?"
 
-      - name: wp-env start log + trace (always)
+      - name: Diagnostics (always)
         if: always()
         run: |
-          echo "::group::errors + phase markers in start.log"
-          grep -inE "error|fail|cannot|fatal|could not|not found|fetching |checking out|phpunit suite|wp_version|throw|ENOENT|couldn't find|tag '?[0-9]" /tmp/start.log 2>/dev/null | tail -40 || echo "(none)"
+          echo "::group::errors in start.log"
+          grep -inE "error|fail|cannot|fatal|could not|not found|throw|ENOENT|couldn't|exit code|reject|at /|establishing a database|undefined|TypeError" /tmp/start.log 2>/dev/null | tail -50 || echo "(none)"
           echo "::endgroup::"
-          echo "::group::wp-env start --debug (tail 60)"
-          tail -60 /tmp/start.log 2>/dev/null || echo "(no start log)"
+          echo "::group::start.log tail 120"
+          tail -120 /tmp/start.log 2>/dev/null || echo "(no log)"
           echo "::endgroup::"
           echo "::group::traced commands that exited non-zero"
-          grep -B1 'exit=[^0]' /tmp/dc.log 2>/dev/null || echo "(all traced docker/git/svn commands exited 0)"
+          grep -B1 'exit=[^0]' /tmp/dc.log 2>/dev/null || echo "(all traced commands exited 0)"
           echo "::endgroup::"
-          echo "::group::full docker/git/svn trace"
-          cat /tmp/dc.log 2>/dev/null || echo "(no trace)"
-          echo "::endgroup::"
+          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install
 
       - name: Run PHPUnit
         run: npm run test:php
-
-  plugin-check:
-    name: Plugin Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Package release zip
-        run: npm run package
-
-      - name: Unzip release into build dir
-        run: unzip -q desktop-mode.zip -d plugin-check-build
-
-      - name: Run Plugin Check
-        uses: wordpress/plugin-check-action@v1
-        with:
-          build-dir: ./plugin-check-build/desktop-mode
-          ignore-warnings: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
   php:
     name: PHPUnit · PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    # FIX TEST: Docker Compose 2.38 makes BuildKit `bake` the default for
-    # `--build`. wp-env runs `up --build -d mysql` for the image-only DB
-    # service (no build context); under bake that errors with no target,
-    # so `wp-env start` aborts right after creating mysql. Disable bake.
-    env:
-      COMPOSE_BAKE: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -59,34 +53,33 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start wp-env
+      - name: Start wp-env (traced)
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        run: npm run env:start
+        # DEBUG: shim `docker` to log every invocation + exit code, so we
+        # capture the EXACT command wp-env runs that exits non-zero (every
+        # command reproduced by hand exits 0, so we need the real argv).
+        run: |
+          REAL="$(command -v docker)"
+          echo "real docker: $REAL"
+          mkdir -p /tmp/shim
+          {
+            echo '#!/usr/bin/env bash'
+            echo 'echo "ARGV: $*" >> /tmp/dc.log'
+            echo "$REAL"' "$@"; rc=$?'
+            echo 'echo "   -> exit=$rc" >> /tmp/dc.log'
+            echo 'exit $rc'
+          } > /tmp/shim/docker
+          chmod +x /tmp/shim/docker
+          : > /tmp/dc.log
+          export PATH="/tmp/shim:$PATH"
+          npm run env:start
 
-      - name: Mechanism check (always)
+      - name: Traced docker calls (always)
         if: always()
         run: |
-          echo "::group::versions"; docker compose version || true; echo "::endgroup::"
-          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-          # Prove the cause: reproduce wp-env's upOne('mysql', {--build})
-          # both ways. Expect bake -> non-zero, no-bake -> 0.
-          CFG="$(npx wp-env install-path 2>/dev/null | tail -1)"
-          F="$CFG/docker-compose.yml"
-          if [ -f "$F" ]; then
-            docker compose -f "$F" down -v >/dev/null 2>&1 || true
-            echo "--- COMPOSE_BAKE=true (expect non-zero) ---"
-            COMPOSE_BAKE=true docker compose -f "$F" up --build --force-recreate -d mysql > /tmp/b1.log 2>&1 \
-              && echo "EXIT(bake)=0" || echo "EXIT(bake)=$?"
-            tail -8 /tmp/b1.log
-            docker compose -f "$F" down -v >/dev/null 2>&1 || true
-            echo "--- COMPOSE_BAKE=false (expect 0) ---"
-            COMPOSE_BAKE=false docker compose -f "$F" up --build --force-recreate -d mysql > /tmp/b2.log 2>&1 \
-              && echo "EXIT(no-bake)=0" || echo "EXIT(no-bake)=$?"
-            tail -8 /tmp/b2.log
-          else
-            echo "no compose file at [$F]"
-          fi
+          echo "=== docker invocations during wp-env start (with exit codes) ==="
+          cat /tmp/dc.log 2>/dev/null || echo "(no trace)"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install
@@ -97,10 +90,6 @@ jobs:
   plugin-check:
     name: Plugin Check
     runs-on: ubuntu-latest
-    # FIX TEST: same Compose-bake issue; the plugin-check action runs
-    # `wp-env start` internally, so disable bake at the job level too.
-    env:
-      COMPOSE_BAKE: "false"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start wp-env
+      - name: Start wp-env (verbose)
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        run: npm run env:start
+        # DEBUG: --debug surfaces the docker-compose invocation + output that
+        # `npm run env:start` (plain `wp-env start`) swallows in CI.
+        run: npx wp-env start --debug
+
+      - name: Diagnose wp-env (always)
+        if: always()
+        # DEBUG: capture WHY a container (esp. tests-cli/tests-*) isn't running.
+        # `wp-env start` has been exiting 0 in CI without the tests env up, so
+        # we dump container states + logs to see the real failure (crash, OOM,
+        # port clash, image pull, MySQL init, ...).
+        run: |
+          echo "::group::wp-env version"; npx wp-env --version || true; echo "::endgroup::"
+          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
+          echo "::group::container states + logs"
+          for c in $(docker ps -a --format '{{.Names}}'); do
+            state=$(docker inspect -f '{{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' "$c" 2>/dev/null)
+            echo "===== $c :: $state ====="
+            docker logs --tail 150 "$c" 2>&1 || true
+            echo
+          done
+          echo "::endgroup::"
+          echo "::group::wp-env logs (tests)"; timeout 25 npx wp-env logs tests --watch=false 2>&1 || true; echo "::endgroup::"
+          echo "::group::resources"; df -h / || true; free -h || true; echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,13 +92,14 @@ jobs:
           docker version --format 'engine {{.Server.Version}}' || true
           docker compose version || true
           echo "::endgroup::"
-          CFG=$(ls -d "$HOME"/.wp-env/*/ 2>/dev/null | head -1)
-          echo "wp-env config dir: $CFG"
+          CFG="$(npx wp-env install-path 2>/dev/null | tail -1)"
+          echo "wp-env install-path: [$CFG]"
+          ls -la "$CFG" 2>/dev/null || true
           echo "::group::docker-compose.yml"
-          cat "${CFG}docker-compose.yml" 2>/dev/null || echo "(no compose file found)"
+          cat "${CFG}/docker-compose.yml" 2>/dev/null || echo "(no compose file found)"
           echo "::endgroup::"
           echo "::group::direct docker compose up -d (real stderr)"
-          docker compose -f "${CFG}docker-compose.yml" up -d 2>&1 || true
+          docker compose -f "${CFG}/docker-compose.yml" up -d 2>&1 || true
           echo "::endgroup::"
           echo "::group::docker ps -a after direct up"
           docker ps -a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,12 @@ jobs:
         run: npm run test:js
 
   php:
-    name: "PHPUnit (core=${{ matrix.core || 'default' }})"
+    name: PHPUnit · PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # leg 1: default (core:null -> latest stable WP, currently 7.0) -> capture the literal error
-        # leg 2: the proposed fix -> WordPress 7.0 from wordpress-develop (version 7.0.1-alpha)
-        core: [ "", "WordPress/wordpress-develop#7.0" ]
+        php: [ '8.3' ]   # DEBUG: single leg while validating the fix
 
     steps:
       - uses: actions/checkout@v6
@@ -50,47 +48,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Apply core override
-        if: matrix.core != ''
-        run: |
-          printf '{ "core": "%s" }\n' '${{ matrix.core }}' > .wp-env.override.json
-          echo "override:"; cat .wp-env.override.json
-
-      - name: Start wp-env (traced + debug)
+      - name: Start wp-env
         env:
-          WP_ENV_PHP_VERSION: '8.3'
+          WP_ENV_PHP_VERSION: ${{ matrix.php }}
+        # wp-env start on the current runner brings up only the dev DB and
+        # returns (sometimes exit 0, sometimes non-zero). Don't let that fail
+        # the job; we bring the rest up explicitly next.
+        run: npm run env:start || echo "::warning::wp-env start returned $? (continuing; bringing stack up explicitly)"
+
+      - name: Ensure full container stack is up
+        # FIX (option 1): docker compose up against wp-env's own generated
+        # compose file reliably starts ALL services (proven), whereas
+        # wp-env's own orchestration stops after mysql on the current runner.
         run: |
-          mkdir -p /tmp/shim
-          for t in docker git svn; do
-            real="$(command -v "$t" || true)"
-            [ -z "$real" ] && continue
-            {
-              printf '%s\n' '#!/usr/bin/env bash'
-              printf 'echo "[%s] $*" >> /tmp/dc.log\n' "$t"
-              printf '%s "$@"; rc=$?\n' "$real"
-              printf 'echo "   -> [%s] exit=$rc" >> /tmp/dc.log\n' "$t"
-              printf '%s\n' 'exit $rc'
-            } > "/tmp/shim/$t"
-            chmod +x "/tmp/shim/$t"
-          done
-          : > /tmp/dc.log
-          export PATH="/tmp/shim:$PATH"
-          set +e
-          npx wp-env start --debug > /tmp/start.log 2>&1
-          echo "WPENV_EXIT=$?"
+          CFG="$(npx wp-env install-path 2>/dev/null | tail -1)"
+          echo "compose file: $CFG/docker-compose.yml"
+          docker compose -f "$CFG/docker-compose.yml" up -d
+          echo "--- containers ---"
+          docker ps --format '{{.Names}}\t{{.Status}}'
 
       - name: Diagnostics (always)
         if: always()
         run: |
-          echo "::group::errors in start.log"
-          grep -inE "error|fail|cannot|fatal|could not|not found|throw|ENOENT|couldn't|exit code|reject|at /|establishing a database|undefined|TypeError" /tmp/start.log 2>/dev/null | tail -50 || echo "(none)"
-          echo "::endgroup::"
-          echo "::group::start.log tail 120"
-          tail -120 /tmp/start.log 2>/dev/null || echo "(no log)"
-          echo "::endgroup::"
-          echo "::group::traced commands that exited non-zero"
-          grep -B1 'exit=[^0]' /tmp/dc.log 2>/dev/null || echo "(all traced commands exited 0)"
-          echo "::endgroup::"
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
 
       - name: Install PHP dev dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: wp-env start log + trace (always)
         if: always()
         run: |
+          echo "::group::errors + phase markers in start.log"
+          grep -inE "error|fail|cannot|fatal|could not|not found|fetching |checking out|phpunit suite|wp_version|throw|ENOENT|couldn't find|tag '?[0-9]" /tmp/start.log 2>/dev/null | tail -40 || echo "(none)"
+          echo "::endgroup::"
           echo "::group::wp-env start --debug (tail 60)"
           tail -60 /tmp/start.log 2>/dev/null || echo "(no start log)"
           echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
   php:
     name: PHPUnit · PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    # FIX TEST: Docker Compose 2.38 makes BuildKit `bake` the default for
+    # `--build`. wp-env runs `up --build -d mysql` for the image-only DB
+    # service (no build context); under bake that errors with no target,
+    # so `wp-env start` aborts right after creating mysql. Disable bake.
+    env:
+      COMPOSE_BAKE: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -53,69 +59,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start wp-env (verbose)
+      - name: Start wp-env
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        # DEBUG: --debug surfaces the docker-compose invocation + output that
-        # `npm run env:start` (plain `wp-env start`) swallows in CI.
-        run: npx wp-env start --debug
+        run: npm run env:start
 
-      - name: Diagnose wp-env (always)
+      - name: Mechanism check (always)
         if: always()
-        # DEBUG: capture WHY a container (esp. tests-cli/tests-*) isn't running.
-        # `wp-env start` has been exiting 0 in CI without the tests env up, so
-        # we dump container states + logs to see the real failure (crash, OOM,
-        # port clash, image pull, MySQL init, ...).
         run: |
-          echo "::group::wp-env version"; npx wp-env --version || true; echo "::endgroup::"
+          echo "::group::versions"; docker compose version || true; echo "::endgroup::"
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-          echo "::group::container states + logs"
-          for c in $(docker ps -a --format '{{.Names}}'); do
-            state=$(docker inspect -f '{{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' "$c" 2>/dev/null)
-            echo "===== $c :: $state ====="
-            docker logs --tail 150 "$c" 2>&1 || true
-            echo
-          done
-          echo "::endgroup::"
-          echo "::group::wp-env logs (tests)"; timeout 25 npx wp-env logs tests --watch=false 2>&1 || true; echo "::endgroup::"
-          echo "::group::resources"; df -h / || true; free -h || true; echo "::endgroup::"
-
-      - name: Show generated compose + direct `docker compose up` (always)
-        if: always()
-        # DEBUG: wp-env swallows the docker-compose error (it only prints
-        # "Command failed with exit code 1"). Dump the generated compose file
-        # and run `docker compose up` directly so the REAL stderr is visible
-        # (e.g. "dependency failed to start: container ... is unhealthy",
-        # a port bind clash, or a compose-version incompatibility).
-        run: |
-          echo "::group::versions"
-          docker version --format 'engine {{.Server.Version}}' || true
-          docker compose version || true
-          echo "::endgroup::"
+          # Prove the cause: reproduce wp-env's upOne('mysql', {--build})
+          # both ways. Expect bake -> non-zero, no-bake -> 0.
           CFG="$(npx wp-env install-path 2>/dev/null | tail -1)"
-          echo "wp-env install-path: [$CFG]"
-          ls -la "$CFG" 2>/dev/null || true
-          echo "::group::docker-compose.yml"
-          cat "${CFG}/docker-compose.yml" 2>/dev/null || echo "(no compose file found)"
-          echo "::endgroup::"
-          F="${CFG}/docker-compose.yml"
-          echo "::group::reset (down -v) so we reproduce a clean failure"
-          docker compose -f "$F" down -v 2>&1 || true
-          echo "::endgroup::"
-          echo "::group::EXACT wp-env upMany command (real stderr)"
-          # Mirrors @wordpress/env runtime/docker/index.js:
-          #   dockerCompose.upMany(['wordpress','tests-wordpress','cli','tests-cli'],
-          #     { commandOptions: ['--build','--force-recreate'] })
-          docker compose -f "$F" up -d --build --force-recreate \
-            wordpress tests-wordpress cli tests-cli 2>&1
-          echo "EXIT=$?"
-          echo "::endgroup::"
-          echo "::group::plain up -d (control: no --build/--force-recreate)"
-          docker compose -f "$F" up -d 2>&1; echo "EXIT=$?"
-          echo "::endgroup::"
-          echo "::group::docker ps -a"
-          docker ps -a
-          echo "::endgroup::"
+          F="$CFG/docker-compose.yml"
+          if [ -f "$F" ]; then
+            docker compose -f "$F" down -v >/dev/null 2>&1 || true
+            echo "--- COMPOSE_BAKE=true (expect non-zero) ---"
+            COMPOSE_BAKE=true docker compose -f "$F" up --build --force-recreate -d mysql > /tmp/b1.log 2>&1 \
+              && echo "EXIT(bake)=0" || echo "EXIT(bake)=$?"
+            tail -8 /tmp/b1.log
+            docker compose -f "$F" down -v >/dev/null 2>&1 || true
+            echo "--- COMPOSE_BAKE=false (expect 0) ---"
+            COMPOSE_BAKE=false docker compose -f "$F" up --build --force-recreate -d mysql > /tmp/b2.log 2>&1 \
+              && echo "EXIT(no-bake)=0" || echo "EXIT(no-bake)=$?"
+            tail -8 /tmp/b2.log
+          else
+            echo "no compose file at [$F]"
+          fi
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install
@@ -126,6 +97,10 @@ jobs:
   plugin-check:
     name: Plugin Check
     runs-on: ubuntu-latest
+    # FIX TEST: same Compose-bake issue; the plugin-check action runs
+    # `wp-env start` internally, so disable bake at the job level too.
+    env:
+      COMPOSE_BAKE: "false"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Temporary diagnostic branch (off `trunk`, not for merge) to root-cause the `service "tests-cli" is not running` / `Environment not initialized` failures in the PHPUnit and Plugin Check jobs.

Adds to the PHPUnit job:
- `wp-env start --debug` (surfaces the docker-compose output that plain `wp-env start` swallows in CI)
- an always-run step dumping `docker ps -a`, per-container state + logs, `wp-env logs tests`, and disk/memory

Goal: see why the tests environment exits (crash / OOM / port clash / image pull / MySQL init). This reproduces on `trunk` and other PRs, so it is independent of the security fix in #285.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-286-301c1fcbcb3fe84186402d80c93763cba55a4f46.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->