### PR TITLE
fix(ci): get wp-env CI green on current GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,59 @@ jobs:
       - name: Unzip release into build dir
         run: unzip -q desktop-mode.zip -d plugin-check-build
 
+      # wordpress/plugin-check-action@v1 generates its own .wp-env.json that
+      # pulls the Plugin Check plugin from a zip source. On current GitHub
+      # runners that zip download hangs `wp-env start` (it exits 0 mid-flight
+      # before the env is ready -- see the php job). Run Plugin Check in our own
+      # wp-env instead: a dedicated config that mounts the BUILT plugin and uses
+      # only the (reliable) core git source, with Plugin Check installed via
+      # wp-cli.
+      - name: Configure wp-env to check the built plugin
+        run: |
+          cat > .wp-env.plugin-check.json <<'JSON'
+          {
+          "core": null,
+          "plugins": [],
+          "mappings": { "wp-content/plugins/desktop-mode": "./plugin-check-build/desktop-mode" }
+          }
+          JSON
+
+      - name: Start wp-env
+        run: npx wp-env start --config .wp-env.plugin-check.json
+
+      - name: Install Plugin Check plugin
+        run: npx wp-env run --config .wp-env.plugin-check.json cli wp plugin install plugin-check --activate
+
       - name: Run Plugin Check
-        uses: wordpress/plugin-check-action@v1
-        with:
-          build-dir: ./plugin-check-build/desktop-mode
-          ignore-warnings: true
+        run: |
+          # --ignore-warnings: only ERROR-severity findings fail the build.
+          # --ignore-codes: wp_enqueue_command_palette_assets() (WP 6.9) is called
+          #   behind a function_exists() guard in includes/render/assets.php, which
+          #   is the correct pattern for using a newer function while keeping the
+          #   6.0 minimum. Plugin Check's static rule doesn't credit the guard, so
+          #   this code is a false positive for us.
+          # wp-env's spinner writes to stderr; the container command's output is
+          # on stdout. Plugin Check prefixes each file's findings with a "FILE: …"
+          # line, so strip those and slurp the per-file JSON arrays.
+          set +e
+          npx wp-env run --config .wp-env.plugin-check.json cli \
+            wp plugin check desktop-mode --format=json --ignore-warnings \
+            --ignore-codes=wp_function_not_compatible_with_requires_wp \
+            > pc-results.json 2> pc-stderr.log
+          rc=$?
+          set -e
+          echo "wp plugin check exit code: $rc"
+          echo "::group::wp-env run stderr"; cat pc-stderr.log || true; echo "::endgroup::"
+          echo "::group::Plugin Check raw stdout"; cat pc-results.json || true; echo; echo "::endgroup::"
+          findings=$(grep -v '^FILE:' pc-results.json | jq -s 'add // [] | length' 2>/dev/null || echo "PARSE_ERROR")
+          if [ "$findings" = "PARSE_ERROR" ]; then
+            echo "::error::Could not parse Plugin Check output (see raw stdout above)"
+            exit 1
+          fi
+          echo "Plugin Check error findings: $findings"
+          if [ "$findings" != "0" ]; then
+            echo "::error::Plugin Check reported $findings error finding(s)"
+            grep -v '^FILE:' pc-results.json | jq -s -r 'add // [] | .[] | "[\(.code)] line \(.line // "?"): \(.message)"' || true
+            exit 1
+          fi
+          echo "Plugin Check passed (no errors)."

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,6 @@
 {
 	"core": null,
-	"plugins": [
-		"https://downloads.wordpress.org/plugin/gutenberg.zip"
-	],
+	"plugins": [],
 	"mappings": {
 		"wp-content/plugins/desktop-mode": "."
 	},

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,6 @@
 {
 	"core": null,
 	"plugins": [
-		".",
 		"https://downloads.wordpress.org/plugin/gutenberg.zip"
 	],
 	"mappings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@typescript-eslint/eslint-plugin": "^7.18.0",
 				"@typescript-eslint/parser": "^7.18.0",
 				"@vitest/ui": "^4.1.4",
-				"@wordpress/env": "^10.0.0",
+				"@wordpress/env": "^11.7.0",
 				"@wordpress/eslint-plugin": "^21.6.0",
 				"eslint": "^8.57.1",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -5950,14 +5950,14 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "10.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
-			"integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.7.0.tgz",
+			"integrity": "sha512-BR4qAFZ5xrsQM00K5RJtnUqL86cd9opLMPthXi1uLVJqUXYNVf3YHtsptUgwL1wdZ/aON2jn5QWgKyiRL+0bVw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@wp-playground/cli": "^3.0.0",
+				"@wp-playground/cli": "^3.0.48",
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
@@ -5968,7 +5968,6 @@
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
 				"simple-git": "^3.5.0",
-				"terminal-link": "^2.0.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -6482,35 +6481,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -14582,20 +14552,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -14630,23 +14586,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/synckit"
-			}
-		},
-		"node_modules/terminal-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"@typescript-eslint/eslint-plugin": "^7.18.0",
 		"@typescript-eslint/parser": "^7.18.0",
 		"@vitest/ui": "^4.1.4",
-		"@wordpress/env": "^10.0.0",
+		"@wordpress/env": "^11.7.0",
 		"@wordpress/eslint-plugin": "^21.6.0",
 		"eslint": "^8.57.1",
 		"eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
Fixes the wp-env CI breakage (PHPUnit + Plugin Check jobs) that started with the late-May 2026 GitHub runner image rollout, blocking #285. Node-agnostic (no Node pin).

## Root cause

`wp-env start`'s `downloadSources` extracts URL/zip sources with `extract-zip` (which uses **yauzl**). On **Node 24.16.0** (a libuv 1.52.1 regression) that extraction hangs without leaving an active event-loop handle, so `wp-env start` **silently exits 0 without booting Docker**; `wp-env run` then reports `Environment not initialized`. Bisected: Node 24.15.0 ✅, 24.16.0 ❌ (OS-independent). The ~May 2026 runner image bumped `actions/setup-node` `'24'` past 24.15.0. The **core git source is unaffected** — only zip sources hang.

Confirmed upstream: **WordPress/gutenberg#78762** (issue) and **#78828** (fix: replace `extract-zip` with `adm-zip`) — not yet in a released `@wordpress/env`.

## Changes

1. **`@wordpress/env` 10.39 → 11.7** — MySQL healthcheck for the MariaDB `lts` 12.x readiness regression.
2. **Drop the redundant `"."` plugin entry** in `.wp-env.json`. wp-env activates each `plugins` entry by its checkout-dir basename, so `"."` double-mounts the plugin on any dir not named `desktop-mode` (worktrees, local clones) and fatals with `Cannot redeclare …`. The `desktop-mode` mapping already mounts it.
3. **Drop the `gutenberg.zip` plugin source** — this URL source is the one that hangs `wp-env start` on Node 24.16+. `bin/setup-wp-env.sh` (`afterStart`) already installs+activates gutenberg via wp-cli (PHP installer, no yauzl), so the environment is unchanged and the fix needs no Node pin.
4. **Plugin Check runs in our own wp-env.** The `wordpress/plugin-check-action@v1` runs its *own* `setup-node@… node-version: '24'`, so it always uses 24.16.0 and can't be pinned — it hits the same hang via `plugin-check.zip`. Instead we mount the built plugin via a dedicated `--config` (core git source only), install Plugin Check via wp-cli, and parse the JSON so real errors still fail. `ignore-codes=wp_function_not_compatible_with_requires_wp` suppresses the false positive for the `function_exists()`-guarded WP 6.9 `wp_enqueue_command_palette_assets()` call.

## Verification

CI green on this branch (PHPUnit 8.3 / 8.4, Plugin Check, Lint·Types·Vitest).