### PR TITLE
ci(debug): wp-env 11.x start trace + pinned-compose test [do not merge]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,33 +12,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
           cache-dependency-path: package-lock.json
-
       - name: Install dependencies
         run: npm ci
-
       - name: ESLint
         run: npm run lint
-
       - name: TypeScript (no emit)
         run: npx tsc --noEmit
-
       - name: Vitest
         run: npm run test:js
 
   php:
-    name: PHPUnit · PHP ${{ matrix.php }}
+    name: "wp-env (compose=${{ matrix.compose }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3', '8.4' ]
+        # default = runner's Docker Compose v2.38.2; pinned = older plugin binary.
+        compose: [ "default", "v2.29.7" ]
 
     steps:
       - uses: actions/checkout@v6
@@ -53,44 +49,63 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start wp-env
+      - name: Pin docker compose CLI (matrix)
+        if: matrix.compose != 'default'
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -fsSL "https://github.com/docker/compose/releases/download/${{ matrix.compose }}/docker-compose-linux-x86_64" \
+            -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+
+      - name: Versions
+        run: |
+          docker version --format 'engine {{.Server.Version}}' || true
+          docker compose version || true
+          node -e "console.log('@wordpress/env', require('@wordpress/env/package.json').version)"
+
+      - name: Start wp-env (traced + debug)
         env:
-          WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        run: npm run env:start
+          WP_ENV_PHP_VERSION: '8.3'
+        run: |
+          mkdir -p /tmp/shim
+          for t in docker git; do
+            real="$(command -v "$t" || true)"; [ -z "$real" ] && continue
+            {
+              printf '%s\n' '#!/usr/bin/env bash'
+              printf 'echo "[%s] $*" >> /tmp/dc.log\n' "$t"
+              printf '%s "$@"; rc=$?\n' "$real"
+              printf 'echo "   -> [%s] exit=$rc" >> /tmp/dc.log\n' "$t"
+              printf '%s\n' 'exit $rc'
+            } > "/tmp/shim/$t"
+            chmod +x "/tmp/shim/$t"
+          done
+          : > /tmp/dc.log
+          export PATH="/tmp/shim:$PATH"
+          set +e
+          npx wp-env start --debug > /tmp/start.log 2>&1
+          echo "WPENV_EXIT=$?"
+
+      - name: Diagnostics (always)
+        if: always()
+        run: |
+          echo "::group::errors in start.log"
+          grep -inE "error|fail|cannot|fatal|could not|not found|throw|ENOENT|exit code|reject|at /|establishing a database|undefined|unhealthy|dependency|timed out|timeout|TypeError|not running|not initialized" /tmp/start.log 2>/dev/null | tail -50 || echo "(none)"
+          echo "::endgroup::"
+          echo "::group::start.log tail 150"
+          tail -150 /tmp/start.log 2>/dev/null || echo "(no log)"
+          echo "::endgroup::"
+          echo "::group::traced commands that exited non-zero"
+          grep -B1 'exit=[^0]' /tmp/dc.log 2>/dev/null || echo "(all traced commands exited 0)"
+          echo "::endgroup::"
+          echo "::group::full docker/git trace"
+          cat /tmp/dc.log 2>/dev/null || echo "(no trace)"
+          echo "::endgroup::"
+          echo "::group::docker ps -a"
+          docker ps -a
+          echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install
 
       - name: Run PHPUnit
         run: npm run test:php
-
-  plugin-check:
-    name: Plugin Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Package release zip
-        run: npm run package
-
-      - name: Unzip release into build dir
-        run: unzip -q desktop-mode.zip -d plugin-check-build
-
-      - name: Run Plugin Check
-        uses: wordpress/plugin-check-action@v1
-        with:
-          build-dir: ./plugin-check-build/desktop-mode
-          ignore-warnings: true

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,6 @@
 {
 	"core": null,
 	"plugins": [
-		".",
 		"https://downloads.wordpress.org/plugin/gutenberg.zip"
 	],
 	"mappings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@typescript-eslint/eslint-plugin": "^7.18.0",
 				"@typescript-eslint/parser": "^7.18.0",
 				"@vitest/ui": "^4.1.4",
-				"@wordpress/env": "^10.0.0",
+				"@wordpress/env": "^11.7.0",
 				"@wordpress/eslint-plugin": "^21.6.0",
 				"eslint": "^8.57.1",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -5950,14 +5950,14 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "10.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
-			"integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.7.0.tgz",
+			"integrity": "sha512-BR4qAFZ5xrsQM00K5RJtnUqL86cd9opLMPthXi1uLVJqUXYNVf3YHtsptUgwL1wdZ/aON2jn5QWgKyiRL+0bVw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@wp-playground/cli": "^3.0.0",
+				"@wp-playground/cli": "^3.0.48",
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
@@ -5968,7 +5968,6 @@
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
 				"simple-git": "^3.5.0",
-				"terminal-link": "^2.0.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -6482,35 +6481,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -14582,20 +14552,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -14630,23 +14586,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/synckit"
-			}
-		},
-		"node_modules/terminal-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"@typescript-eslint/eslint-plugin": "^7.18.0",
 		"@typescript-eslint/parser": "^7.18.0",
 		"@vitest/ui": "^4.1.4",
-		"@wordpress/env": "^10.0.0",
+		"@wordpress/env": "^11.7.0",
 		"@wordpress/eslint-plugin": "^21.6.0",
 		"eslint": "^8.57.1",
 		"eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
Dual-purpose diagnostic on @wordpress/env 11.7.0: (1) shim-trace + --debug to localize why wp-env start stalls after 'Reading configuration' on the runner, (2) matrix leg pinning docker compose to v2.29.7 to test whether an older Compose fixes it. Not for merge.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-288-4fe6f31a431f60e1b61f4ae9ed47615d9f8ed90b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->