### PR TITLE
ci(debug): pin Docker Compose v2.37.3 to fix wp-env start on new runner [do not merge]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,53 +53,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # `wp-env start` exits 0 with no error partway through its host-side work,
-      # right after the DB containers come up, before recording the runtime --
-      # so `wp-env run` then reports "Environment not initialized". The abrupt
-      # exit drops buffered stdout, so wp-env's own logs don't reveal the last
-      # call. Shim git+docker to an append-only logfile (survives the exit) to
-      # capture the exact final command before the process vanishes.
-      - name: Install git/docker tracing shim
-        run: |
-          mkdir -p /tmp/shim
-          WPENV_REAL_GIT="$(command -v git)"
-          WPENV_REAL_DOCKER="$(command -v docker)"
-          echo "WPENV_REAL_GIT=$WPENV_REAL_GIT" >> "$GITHUB_ENV"
-          echo "WPENV_REAL_DOCKER=$WPENV_REAL_DOCKER" >> "$GITHUB_ENV"
-          echo "/tmp/shim" >> "$GITHUB_PATH"
-          cat > /tmp/shim/git <<'EOF'
-          #!/usr/bin/env bash
-          echo "$(date +%s.%3N) [git] $*" >> /tmp/cmd.log
-          "$WPENV_REAL_GIT" "$@"
-          rc=$?
-          echo "$(date +%s.%3N) [git] -> exit $rc" >> /tmp/cmd.log
-          exit $rc
-          EOF
-          cat > /tmp/shim/docker <<'EOF'
-          #!/usr/bin/env bash
-          echo "$(date +%s.%3N) [docker] $*" >> /tmp/cmd.log
-          "$WPENV_REAL_DOCKER" "$@"
-          rc=$?
-          echo "$(date +%s.%3N) [docker] -> exit $rc" >> /tmp/cmd.log
-          exit $rc
-          EOF
-          chmod +x /tmp/shim/git /tmp/shim/docker
-
-      - name: Start wp-env (traced)
+      - name: Start wp-env
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        run: |
-          which git docker
-          npm run env:start; echo "wp-env start exit code: $?"
+        run: npm run env:start
 
       - name: Diagnostics (always)
         if: always()
         run: |
-          echo "::group::traced git/docker commands (last before exit)"; cat /tmp/cmd.log 2>/dev/null || echo "(no cmd.log)"; echo "::endgroup::"
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-          echo "::group::~/.wp-env and ~/wp-env"; ls -la ~/.wp-env ~/wp-env 2>/dev/null || true; echo "::endgroup::"
-          echo "::group::wp-env-cache.json"; find ~/.wp-env ~/wp-env -maxdepth 2 -name 'wp-env-cache.json' -print -exec cat {} \; 2>/dev/null || true; echo "::endgroup::"
-          echo "::group::workdir source dirs"; find ~/.wp-env ~/wp-env -maxdepth 2 -type d 2>/dev/null || true; echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,43 +53,53 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # On a COLD GitHub runner, `wp-env start` exits 0 with no error partway
-      # through its host-side source work (the simple-git clone of WordPress
-      # core + zip downloads), before bringing up the WordPress/cli containers
-      # and before it records the runtime -- so `wp-env run` then reports
-      # "Environment not initialized". Local dev never sees this because a warm
-      # ~/.wp-env cache means the clones already exist and wp-env skips them.
-      #
-      # The clones live in the host workdir and persist across `start` runs, and
-      # wp-env skips any source already present. So re-running `start` warms the
-      # cache step by step until a run gets far enough to finish. Probe tests-cli
-      # to detect a fully-initialized env and stop as soon as it's ready.
-      - name: Start wp-env (retry until ready)
+      # `wp-env start` exits 0 with no error partway through its host-side work,
+      # right after the DB containers come up, before recording the runtime --
+      # so `wp-env run` then reports "Environment not initialized". The abrupt
+      # exit drops buffered stdout, so wp-env's own logs don't reveal the last
+      # call. Shim git+docker to an append-only logfile (survives the exit) to
+      # capture the exact final command before the process vanishes.
+      - name: Install git/docker tracing shim
+        run: |
+          mkdir -p /tmp/shim
+          WPENV_REAL_GIT="$(command -v git)"
+          WPENV_REAL_DOCKER="$(command -v docker)"
+          echo "WPENV_REAL_GIT=$WPENV_REAL_GIT" >> "$GITHUB_ENV"
+          echo "WPENV_REAL_DOCKER=$WPENV_REAL_DOCKER" >> "$GITHUB_ENV"
+          echo "/tmp/shim" >> "$GITHUB_PATH"
+          cat > /tmp/shim/git <<'EOF'
+          #!/usr/bin/env bash
+          echo "$(date +%s.%3N) [git] $*" >> /tmp/cmd.log
+          "$WPENV_REAL_GIT" "$@"
+          rc=$?
+          echo "$(date +%s.%3N) [git] -> exit $rc" >> /tmp/cmd.log
+          exit $rc
+          EOF
+          cat > /tmp/shim/docker <<'EOF'
+          #!/usr/bin/env bash
+          echo "$(date +%s.%3N) [docker] $*" >> /tmp/cmd.log
+          "$WPENV_REAL_DOCKER" "$@"
+          rc=$?
+          echo "$(date +%s.%3N) [docker] -> exit $rc" >> /tmp/cmd.log
+          exit $rc
+          EOF
+          chmod +x /tmp/shim/git /tmp/shim/docker
+
+      - name: Start wp-env (traced)
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
         run: |
-          ready=0
-          for i in 1 2 3 4 5; do
-            echo "::group::wp-env start attempt $i"
-            npm run env:start -- --debug || echo "start attempt $i returned $?"
-            echo "::endgroup::"
-            if npx wp-env run tests-cli true >/dev/null 2>&1; then
-              echo "::notice::tests-cli ready after attempt $i"
-              ready=1
-              break
-            fi
-            echo "not ready after attempt $i"
-          done
-          [ "$ready" = "1" ]
+          which git docker
+          npm run env:start; echo "wp-env start exit code: $?"
 
       - name: Diagnostics (always)
         if: always()
         run: |
-          echo "::group::docker compose version"; docker compose version; echo "::endgroup::"
+          echo "::group::traced git/docker commands (last before exit)"; cat /tmp/cmd.log 2>/dev/null || echo "(no cmd.log)"; echo "::endgroup::"
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-          echo "::group::wp-env install-path"; npx wp-env install-path || true; echo "::endgroup::"
           echo "::group::~/.wp-env and ~/wp-env"; ls -la ~/.wp-env ~/wp-env 2>/dev/null || true; echo "::endgroup::"
           echo "::group::wp-env-cache.json"; find ~/.wp-env ~/wp-env -maxdepth 2 -name 'wp-env-cache.json' -print -exec cat {} \; 2>/dev/null || true; echo "::endgroup::"
+          echo "::group::workdir source dirs"; find ~/.wp-env ~/wp-env -maxdepth 2 -type d 2>/dev/null || true; echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,25 +53,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # The GitHub runner image rolled out Docker Compose v2.38.2 (late May 2026),
-      # which the docker-compose npm wrapper that wp-env drives mis-handles: a
-      # `docker compose` child returns in a way the wrapper maps to a null exit
-      # code, so wp-env's CLI does `process.exit(error.exitCode)` (= exit 0) and
-      # `wp-env start` silently aborts mid-flight before recording the runtime.
-      # Pin a known-good pre-2.38 Compose CLI to sidestep the interaction.
-      - name: Pin Docker Compose to v2.37.3
-        run: |
-          mkdir -p ~/.docker/cli-plugins
-          curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" \
-            -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
-          echo "--- docker compose version (after pin) ---"
-          docker compose version
-
-      - name: Start wp-env (debug)
+      # On a COLD GitHub runner, `wp-env start` exits 0 with no error partway
+      # through its host-side source work (the simple-git clone of WordPress
+      # core + zip downloads), before bringing up the WordPress/cli containers
+      # and before it records the runtime -- so `wp-env run` then reports
+      # "Environment not initialized". Local dev never sees this because a warm
+      # ~/.wp-env cache means the clones already exist and wp-env skips them.
+      #
+      # The clones live in the host workdir and persist across `start` runs, and
+      # wp-env skips any source already present. So re-running `start` warms the
+      # cache step by step until a run gets far enough to finish. Probe tests-cli
+      # to detect a fully-initialized env and stop as soon as it's ready.
+      - name: Start wp-env (retry until ready)
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        run: npm run env:start -- --debug
+        run: |
+          ready=0
+          for i in 1 2 3 4 5; do
+            echo "::group::wp-env start attempt $i"
+            npm run env:start -- --debug || echo "start attempt $i returned $?"
+            echo "::endgroup::"
+            if npx wp-env run tests-cli true >/dev/null 2>&1; then
+              echo "::notice::tests-cli ready after attempt $i"
+              ready=1
+              break
+            fi
+            echo "not ready after attempt $i"
+          done
+          [ "$ready" = "1" ]
 
       - name: Diagnostics (always)
         if: always()
@@ -103,17 +112,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      # Same Compose pin as the php job: the plugin-check action runs its own
-      # `wp-env start` internally, which hits the same v2.38.2 wrapper bug.
-      - name: Pin Docker Compose to v2.37.3
-        run: |
-          mkdir -p ~/.docker/cli-plugins
-          curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" \
-            -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
-          echo "--- docker compose version (after pin) ---"
-          docker compose version
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3' ]   # DEBUG: single leg while validating the fix
+        php: [ '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v6
@@ -57,11 +57,6 @@ jobs:
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
         run: npm run env:start
-
-      - name: Diagnostics (always)
-        if: always()
-        run: |
-          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install
@@ -94,8 +89,56 @@ jobs:
       - name: Unzip release into build dir
         run: unzip -q desktop-mode.zip -d plugin-check-build
 
+      # wordpress/plugin-check-action@v1 generates its own .wp-env.json that
+      # pulls the Plugin Check plugin from a zip source. On current GitHub
+      # runners that zip download hangs `wp-env start` (it exits 0 mid-flight
+      # before the env is ready -- see the php job). Run Plugin Check in our own
+      # wp-env instead: a dedicated config that mounts the BUILT plugin and uses
+      # only the (reliable) core git source, with Plugin Check installed via
+      # wp-cli.
+      - name: Configure wp-env to check the built plugin
+        run: |
+          cat > .wp-env.plugin-check.json <<'JSON'
+          {
+          "core": null,
+          "plugins": [],
+          "mappings": { "wp-content/plugins/desktop-mode": "./plugin-check-build/desktop-mode" }
+          }
+          JSON
+
+      - name: Start wp-env
+        run: npx wp-env start --config .wp-env.plugin-check.json
+
+      - name: Install Plugin Check plugin
+        run: npx wp-env run --config .wp-env.plugin-check.json cli wp plugin install plugin-check --activate
+
       - name: Run Plugin Check
-        uses: wordpress/plugin-check-action@v1
-        with:
-          build-dir: ./plugin-check-build/desktop-mode
-          ignore-warnings: true
+        run: |
+          # --ignore-warnings: only ERROR-severity findings should fail the build
+          # (matches the previous action config). wp-env's spinner goes to stderr,
+          # so stdout is clean JSON.
+          set +e
+          npx wp-env run --config .wp-env.plugin-check.json cli \
+            wp plugin check desktop-mode --format=json --ignore-warnings \
+            > pc-results.json 2> pc-stderr.log
+          rc=$?
+          set -e
+          echo "wp plugin check exit code: $rc"
+          echo "::group::wp-env run stderr"; cat pc-stderr.log || true; echo "::endgroup::"
+          echo "::group::Plugin Check raw stdout"; cat pc-results.json || true; echo; echo "::endgroup::"
+          if [ ! -s pc-results.json ]; then
+            echo "No JSON output; treating as no error findings."
+            exit 0
+          fi
+          findings=$(jq 'if type=="array" then length else 0 end' pc-results.json 2>/dev/null || echo "PARSE_ERROR")
+          if [ "$findings" = "PARSE_ERROR" ]; then
+            echo "::error::Could not parse Plugin Check output as JSON (see raw stdout above)"
+            exit 1
+          fi
+          echo "Plugin Check error findings: $findings"
+          if [ "$findings" != "0" ]; then
+            echo "::error::Plugin Check reported $findings error finding(s)"
+            jq -r '.[] | "\(.file // .location // ""):\(.line // "") [\(.code)] \(.message)"' pc-results.json || true
+            exit 1
+          fi
+          echo "Plugin Check passed (no errors)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,31 +114,34 @@ jobs:
 
       - name: Run Plugin Check
         run: |
-          # --ignore-warnings: only ERROR-severity findings should fail the build
-          # (matches the previous action config). wp-env's spinner goes to stderr,
-          # so stdout is clean JSON.
+          # --ignore-warnings: only ERROR-severity findings fail the build.
+          # --ignore-codes: wp_enqueue_command_palette_assets() (WP 6.9) is called
+          #   behind a function_exists() guard in includes/render/assets.php, which
+          #   is the correct pattern for using a newer function while keeping the
+          #   6.0 minimum. Plugin Check's static rule doesn't credit the guard, so
+          #   this code is a false positive for us.
+          # wp-env's spinner writes to stderr; the container command's output is
+          # on stdout. Plugin Check prefixes each file's findings with a "FILE: …"
+          # line, so strip those and slurp the per-file JSON arrays.
           set +e
           npx wp-env run --config .wp-env.plugin-check.json cli \
             wp plugin check desktop-mode --format=json --ignore-warnings \
+            --ignore-codes=wp_function_not_compatible_with_requires_wp \
             > pc-results.json 2> pc-stderr.log
           rc=$?
           set -e
           echo "wp plugin check exit code: $rc"
           echo "::group::wp-env run stderr"; cat pc-stderr.log || true; echo "::endgroup::"
           echo "::group::Plugin Check raw stdout"; cat pc-results.json || true; echo; echo "::endgroup::"
-          if [ ! -s pc-results.json ]; then
-            echo "No JSON output; treating as no error findings."
-            exit 0
-          fi
-          findings=$(jq 'if type=="array" then length else 0 end' pc-results.json 2>/dev/null || echo "PARSE_ERROR")
+          findings=$(grep -v '^FILE:' pc-results.json | jq -s 'add // [] | length' 2>/dev/null || echo "PARSE_ERROR")
           if [ "$findings" = "PARSE_ERROR" ]; then
-            echo "::error::Could not parse Plugin Check output as JSON (see raw stdout above)"
+            echo "::error::Could not parse Plugin Check output (see raw stdout above)"
             exit 1
           fi
           echo "Plugin Check error findings: $findings"
           if [ "$findings" != "0" ]; then
             echo "::error::Plugin Check reported $findings error finding(s)"
-            jq -r '.[] | "\(.file // .location // ""):\(.line // "") [\(.code)] \(.message)"' pc-results.json || true
+            grep -v '^FILE:' pc-results.json | jq -s -r 'add // [] | .[] | "[\(.code)] line \(.line // "?"): \(.message)"' || true
             exit 1
           fi
           echo "Plugin Check passed (no errors)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3', '8.4' ]
+        php: [ '8.3' ]   # DEBUG: single leg while validating the fix
 
     steps:
       - uses: actions/checkout@v6
@@ -53,10 +53,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Start wp-env
+      # The GitHub runner image rolled out Docker Compose v2.38.2 (late May 2026),
+      # which the docker-compose npm wrapper that wp-env drives mis-handles: a
+      # `docker compose` child returns in a way the wrapper maps to a null exit
+      # code, so wp-env's CLI does `process.exit(error.exitCode)` (= exit 0) and
+      # `wp-env start` silently aborts mid-flight before recording the runtime.
+      # Pin a known-good pre-2.38 Compose CLI to sidestep the interaction.
+      - name: Pin Docker Compose to v2.37.3
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" \
+            -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+          echo "--- docker compose version (after pin) ---"
+          docker compose version
+
+      - name: Start wp-env (debug)
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-        run: npm run env:start
+        run: npm run env:start -- --debug
+
+      - name: Diagnostics (always)
+        if: always()
+        run: |
+          echo "::group::docker compose version"; docker compose version; echo "::endgroup::"
+          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
+          echo "::group::wp-env install-path"; npx wp-env install-path || true; echo "::endgroup::"
+          echo "::group::~/.wp-env and ~/wp-env"; ls -la ~/.wp-env ~/wp-env 2>/dev/null || true; echo "::endgroup::"
+          echo "::group::wp-env-cache.json"; find ~/.wp-env ~/wp-env -maxdepth 2 -name 'wp-env-cache.json' -print -exec cat {} \; 2>/dev/null || true; echo "::endgroup::"
 
       - name: Install PHP dev dependencies
         run: npm run test:php:install
@@ -79,6 +103,17 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Same Compose pin as the php job: the plugin-check action runs its own
+      # `wp-env start` internally, which hits the same v2.38.2 wrapper bug.
+      - name: Pin Docker Compose to v2.37.3
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.3/docker-compose-linux-x86_64" \
+            -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+          echo "--- docker compose version (after pin) ---"
+          docker compose version
 
       - name: Build
         run: npm run build

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,6 @@
 {
 	"core": null,
-	"plugins": [
-		"https://downloads.wordpress.org/plugin/gutenberg.zip"
-	],
+	"plugins": [],
 	"mappings": {
 		"wp-content/plugins/desktop-mode": "."
 	},

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,6 @@
 {
 	"core": null,
 	"plugins": [
-		".",
 		"https://downloads.wordpress.org/plugin/gutenberg.zip"
 	],
 	"mappings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@typescript-eslint/eslint-plugin": "^7.18.0",
 				"@typescript-eslint/parser": "^7.18.0",
 				"@vitest/ui": "^4.1.4",
-				"@wordpress/env": "^10.0.0",
+				"@wordpress/env": "^11.7.0",
 				"@wordpress/eslint-plugin": "^21.6.0",
 				"eslint": "^8.57.1",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -5950,14 +5950,14 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "10.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
-			"integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.7.0.tgz",
+			"integrity": "sha512-BR4qAFZ5xrsQM00K5RJtnUqL86cd9opLMPthXi1uLVJqUXYNVf3YHtsptUgwL1wdZ/aON2jn5QWgKyiRL+0bVw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@wp-playground/cli": "^3.0.0",
+				"@wp-playground/cli": "^3.0.48",
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
@@ -5968,7 +5968,6 @@
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
 				"simple-git": "^3.5.0",
-				"terminal-link": "^2.0.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -6482,35 +6481,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -14582,20 +14552,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -14630,23 +14586,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/synckit"
-			}
-		},
-		"node_modules/terminal-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"@typescript-eslint/eslint-plugin": "^7.18.0",
 		"@typescript-eslint/parser": "^7.18.0",
 		"@vitest/ui": "^4.1.4",
-		"@wordpress/env": "^10.0.0",
+		"@wordpress/env": "^11.7.0",
 		"@wordpress/eslint-plugin": "^21.6.0",
 		"eslint": "^8.57.1",
 		"eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
Debug branch (off #287, so it carries the `@wordpress/env` 11.x bump + `.` mount removal).

## Hypothesis under test

The GitHub runner image rolled out Docker Compose **v2.38.2** (late May 2026). With 11.7.0, `wp-env start` exits **0** but `wp-env run` then reports `Environment not initialized` — because wp-env's CLI does `process.exit(error.exitCode)` and a `docker compose` child returns in a way the `docker-compose` npm wrapper maps to a null/0 exit code, so `start` silently aborts mid-flight **before** recording the runtime. Raw `docker compose up` works on 2.38.2, so the suspect is the wrapper × 2.38.2 interaction.

## What this run does

- Pins a pre-2.38 Compose CLI (**v2.37.3**) into `~/.docker/cli-plugins` in both the `php` and `plugin-check` jobs.
- Runs `wp-env start --debug` with **no** workaround, so this is a clean test of whether the pin alone makes wp-env's own orchestration succeed end-to-end.
- Single PHP leg + always-on diagnostics (docker ps -a, install-path, `wp-env-cache.json`) for fast iteration.

If green, the pin folds into #287 (restored to the full PHP matrix, `--debug` removed). [do not merge]

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-289-165fd787efd079b23bb52805c47c68ae71d86c6e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->