### PR TITLE
ci: harden CI workflow and disable npm install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,23 @@ on:
   pull_request:
     branches: [ trunk ]
 
+# Least privilege: this workflow only reads the repo to lint, build, and test.
+# It never writes commits, comments, or releases, so the token needs no more
+# than read access to repository contents.
+permissions:
+  contents: read
+
 jobs:
   js:
     name: Lint · Types · Vitest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Don't leave the GITHUB_TOKEN in .git/config; later steps run
+          # PR-authored code (npm scripts, build) and this job never needs
+          # git auth after checkout.
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -42,6 +53,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Don't leave the GITHUB_TOKEN in .git/config; later steps run
+          # PR-authored code (npm scripts, build) and this job never needs
+          # git auth after checkout.
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -69,6 +85,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Don't leave the GITHUB_TOKEN in .git/config; later steps run
+          # PR-authored code (npm scripts, build) and this job never needs
+          # git auth after checkout.
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+# Security hardening: do not run dependency lifecycle scripts (preinstall,
+# install, postinstall, prepare) on `npm ci` / `npm install`. This neutralizes
+# the most common supply-chain vector, a compromised transitive dependency
+# executing arbitrary code during install, in CI and on contributors' machines.
+#
+# Safe for this project: no dependency in package-lock.json declares an install
+# script, and esbuild delivers its binary via @esbuild/<platform> optional
+# packages rather than a postinstall download. Explicitly invoked `npm run`
+# scripts (build, test, vendor:pixi, ...) are unaffected; only pre/post/install
+# lifecycle hooks are blocked.
+ignore-scripts=true


### PR DESCRIPTION
## Why

Security hardening for the public repo's `CI` workflow. Because the repo is public and `ci.yml` triggers on `pull_request`, any fork PR runs the build/test steps on a runner. The workflow was also the only one in the repo without an explicit `permissions:` block.

These are hardening gaps, not active vulnerabilities. The workflow already uses the safe `pull_request` trigger (not `pull_request_target`), `npm ci` (lockfile-pinned), and interpolates no PR-controlled data into `run:` blocks (no script-injection vector).

## What

- **`permissions: contents: read`** at the top level. The workflow only reads the repo to lint, build, and test; it never writes commits, comments, or releases. Previously it inherited the repo/org default token scopes, which can be read-write. This also brings `ci.yml` in line with the other workflows, which all set explicit permissions.
- **`persist-credentials: false`** on all three `actions/checkout` steps. The default leaves `GITHUB_TOKEN` in `.git/config`, and later steps execute PR-authored code (npm scripts, build). The job never needs git auth after checkout.
- **`.npmrc` with `ignore-scripts=true`** to block dependency lifecycle scripts (pre/install/post) on `npm ci`, neutralizing the compromised-transitive-dependency supply-chain vector.

## Why `ignore-scripts` is safe here

- No dependency in `package-lock.json` declares an install script (`hasInstallScript` appears nowhere).
- esbuild 0.21.5 delivers its binary via the `@esbuild/<platform>` optional packages, not a postinstall download.
- npm still runs explicitly-invoked `npm run` scripts; only pre/post/install lifecycle hooks are blocked. `build`, `test:js`, `vendor:pixi`, and `test:php:install` are unaffected.

The `.npmrc` is repo-wide, so it also applies to contributors' local `npm ci`/`npm install` as defense-in-depth (a no-op functionally given the above).

## Out of scope

SHA-pinning the actions (currently `@v6`/`@v1`) plus a Dependabot config for `github-actions` was identified as a lower-priority follow-up and intentionally left out to keep this diff focused.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-290-f251528f4af5c0679efa9f6ebbd440892237649d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->