### PR TITLE
ci: add 2-day npm supply-chain cooldown (min-release-age)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,3 +9,13 @@
 # scripts (build, test, vendor:pixi, ...) are unaffected; only pre/post/install
 # lifecycle hooks are blocked.
 ignore-scripts=true
+
+# Supply-chain cooldown: never resolve a dependency version that was published
+# less than 2 days ago. This buys time for the ecosystem to detect and unpublish
+# a malicious release before it can be pinned into our lockfile (the vector
+# behind the recent self-propagating npm worms). Value is in DAYS.
+#
+# This filters resolution only: `npm install`/`npm update` and Dependabot-style
+# bumps won't pick a brand-new version, while `npm ci` is unaffected because it
+# installs the already-resolved versions straight from package-lock.json.
+min-release-age=2


### PR DESCRIPTION
## Why

Follow-up supply-chain hardening after #290. Adds a publication "cooldown" so npm will not resolve any dependency version that was published less than 2 days ago. This gives the ecosystem time to detect and unpublish a malicious release before it can be pinned into our lockfile, the propagation path behind the recent self-replicating npm worms.

## What

One line in `.npmrc`:

```
min-release-age=2
```

The value is in **days**.

## How it behaves

- npm consumes `min-release-age` at config-load time and derives `before = now - 2 days`, recomputed on every invocation (a rolling window, not a frozen date).
- It filters **resolution only**: `npm install` / `npm update` and Dependabot-style bumps won't pick a brand-new version.
- **`npm ci` is unaffected**, verified with a dry-run producing a byte-identical install plan with and without the setting, because it installs already-resolved versions straight from `package-lock.json`. All three CI jobs use `npm ci`, so CI behavior does not change.
- No conflict with npm's `exclusive` rule between `min-release-age` and `before`: we only set `min-release-age` and npm derives `before` itself.

## Operational note

The 2-day window can occasionally make `npm install <brand-new-package>` or a same-day `npm update` fail to resolve until the version ages past the cutoff. The fix is a one-off `--min-release-age=0` (or `--before=""`) on that single command, not a config change.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-291-3712634f9b553dda4b12294d277da500b8d97d30.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->