### PR TITLE
Refine recycle bin badge styling and sync on stop

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/bin/sync-to-wp-develop.sh\"",
+            "timeout": 1200,
+            "statusMessage": "Syncing completed changes to wp-develop"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -422,6 +422,23 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 	pointer-events: none;
 }
 
+.desktop-mode-icon[ data-icon-id="desktop-mode-recycle-bin" ] > .desktop-mode-icon__badge {
+	top: 39px;
+	inset-inline-end: 20px;
+	min-width: 15px;
+	height: 15px;
+	padding: 0 4px;
+	border-radius: 999px;
+	background: rgba( 29, 35, 39, 0.74 );
+	color: rgba( 255, 255, 255, 0.96 );
+	font-size: 9px;
+	font-weight: 700;
+	letter-spacing: 0;
+	box-shadow:
+		inset 0 0 0 1px rgba( 255, 255, 255, 0.28 ),
+		0 1px 2px rgba( 0, 0, 0, 0.28 );
+}
+
 .desktop-mode-icon:hover,
 .desktop-mode-icon:focus-visible {
 	background: rgba(255, 255, 255, 0.12);

--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -209,6 +209,33 @@
 	top: -4px;
 }
 
+/*
+ * Recycle Bin count — unlike unread/update badges, the trash count
+ * is ambient state. Keep it inside the bin glyph as a quiet neutral
+ * marker instead of a red alert on the tile corner.
+ */
+.desktop-mode-dock__item[ data-system-id="desktop-mode-recycle-bin" ] .desktop-mode-dock__badge {
+	top: 20px;
+	inset-inline-end: 7px;
+	min-width: 13px;
+	height: 13px;
+	padding: 0 3px;
+	border-radius: 999px;
+	background: rgba( 29, 35, 39, 0.72 );
+	color: rgba( 255, 255, 255, 0.92 );
+	font-size: 8px;
+	font-weight: 700;
+	letter-spacing: 0;
+	box-shadow:
+		inset 0 0 0 1px rgba( 255, 255, 255, 0.26 ),
+		0 1px 2px rgba( 0, 0, 0, 0.24 );
+}
+
+.desktop-mode-dock__item[ data-system-id="desktop-mode-recycle-bin" ]:hover .desktop-mode-dock__badge {
+	top: 20px;
+	transform: scale( 1.03 );
+}
+
 /* System tiles — same footprint as menu tiles, no badges, no rails. */
 .desktop-mode-dock__item--system .desktop-mode-dock__item-primary {
 	color: rgba( 255, 255, 255, 0.8 );


### PR DESCRIPTION
## Summary
- Restyles the recycle bin badge on the desktop icon and dock to read as a subtle ambient count instead of an alert
- Adds a Codex stop hook to sync completed changes into `wp-develop`


<img width="3424" height="2830" alt="CleanShot 2026-06-03 at 18 09 46@2x" src="https://github.com/user-attachments/assets/29d9d86b-2274-4e9e-817a-f4da5fa9d00c" />


## Testing
- Open Desktop Mode and trash something
- Check the icon displays correctly