### PR TITLE
fix(comments): clear table selection after bulk moderation

### DIFF
--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -1552,6 +1552,15 @@ async function runBulk(
 		} );
 		updateDockBadge( result.counts.pending );
 		await refresh( state.tab, { force: true } );
+		// The acted-on rows have left (or changed in) the current tab, but
+		// `<wpd-table>` deliberately keeps its selection set across data
+		// refreshes (stale ids are only hidden at paint time — see
+		// wpd-table.ts). Left alone, those ids linger in `table.selection`,
+		// so the next row the user picks reads as "2 selected" and a
+		// follow-up bulk action operates on the phantom id too. Reset the
+		// selection here; clearSelection() emits `wpd-table-selection-change`,
+		// which refreshes the "N selected" chip and hides the bulk bar.
+		state.table?.clearSelection();
 	} catch ( err ) {
 		/* translators: %s: bulk action name (e.g. "approve", "spam"). */
 		const fallback = sprintf( __( 'Bulk %s failed.' ), action );


### PR DESCRIPTION
## Summary

Fixes a selection-state bug in the Comments window: after a bulk action, the acted-on comment's id stayed in the table's selection set, so the next selection read as "2 selected" and the following bulk action also hit the previously-actioned comment.

### Steps to reproduce

1. Select a comment, click **Trash**.
2. Select a different comment. The bar shows **2 selected** (should be 1).
3. Click **Spam**. Both the new comment and the previously trashed one are spammed.

### Root cause

`<wpd-table>` deliberately keeps its selection across `data` refreshes (stale ids are filtered out only at paint time, to support cross-page selection). The Comments window never cleared the selection after a bulk action, so trashed/spammed ids lingered in `table.selection`. Setting `.data` doesn't emit `wpd-table-selection-change`, so the "N selected" chip didn't refresh either.

### Fix

After a successful bulk action, `runBulk` calls `state.table.clearSelection()`. That emits `wpd-table-selection-change`, which resets the "N selected" chip and hides the bulk bar. This covers every moderation path (the bulk buttons and the `j`/`k`/`a`/`s`/`d` keyboard shortcuts all route through `runBulk`).

### Testing

- `npm run build`, `npm run lint`, `npm run typecheck`, and `npm run test:js` (1519 tests) all pass.
- Verified manually on local dev: trash a comment, select another (reads "1 selected"), spam, and only the intended comment is affected.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-293-3414bffac3b8b005d13e58430293e9f46e138671.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->