### PR TITLE
chore(codex): don't let a failing sync block the agent

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$(git rev-parse --show-toplevel)/bin/sync-to-wp-develop.sh\"",
+            "command": "bash \"$(git rev-parse --show-toplevel)/bin/sync-to-wp-develop.sh\" || true",
             "timeout": 1200,
             "statusMessage": "Syncing completed changes to wp-develop"
           }


### PR DESCRIPTION
## Summary

The Codex `Stop` hook runs `bin/sync-to-wp-develop.sh` after each turn. The script uses `set -euo pipefail`, so a build or rsync failure exits non-zero and surfaces as a hook error that can interrupt the agent.

Appending `|| true` forces a `0` exit, so a failed sync is discarded and never stops the agent. Output is left un-redirected, so it stays visible.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-294-467c6aeb743aabbd3b8688325bdd9ff68cf12ac5.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->