### PR TITLE
feat(ai-assistant): make the AI-disabled error link to AI Settings

### DIFF
--- a/assets/css/ai-assistant.css
+++ b/assets/css/ai-assistant.css
@@ -383,6 +383,37 @@
 	align-items: flex-start;
 }
 
+/* Inline "AI Settings" link inside the "AI not enabled" error — opens
+ * OS Settings on the AI tab. Styled as a link within the surrounding
+ * error text, not a standalone button: inherits the error color and
+ * flows with the sentence. */
+.desktop-mode-ai__settings-link {
+	appearance: none;
+	border: 0;
+	margin: 0;
+	padding: 0;
+	background: none;
+	font: inherit;
+	font-weight: 600;
+	color: inherit;
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.desktop-mode-ai__settings-link:hover {
+	text-decoration: none;
+}
+
+/* The shell forces `cursor: default !important` on every clickable
+ * surface (see the cursor policy at the top of desktop.css). This
+ * recovery link is an explicit, user-approved exception: it keeps a
+ * pointer so it reads as the actionable link it is. Scoped under
+ * `body.desktop-mode-active` so it out-specifies the policy's
+ * `!important` rule, same trick the resize-handle exceptions use. */
+body.desktop-mode-active .desktop-mode-ai__settings-link {
+	cursor: pointer !important;
+}
+
 @keyframes desktop-mode-spin {
 	to { transform: rotate( 360deg ); }
 }

--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -30,6 +30,9 @@ body.desktop-mode-active {
  *     them would make corner-grabs guesswork.
  *   - Text inputs / textareas / contenteditable surfaces keep the
  *     browser-default I-beam.
+ *   - The AI assistant's inline "AI Settings" recovery link keeps a
+ *     pointer so it reads as a genuine link (rule lives in
+ *     ai-assistant.css).
  *
  * `!important` is needed because the specific `cursor: pointer` and
  * drag-state declarations elsewhere in the codebase have the same or

--- a/docs/dock-customization.md
+++ b/docs/dock-customization.md
@@ -190,7 +190,7 @@ to a specific layer reaches for these instead of DOM scraping. All
 
 | API | Returns | Use it for |
 |---|---|---|
-| `wp.desktop.openOsSettings()` | `void` | Portable opener for the shell's OS Settings window — same window the dock tile opens. Avoids the Classic-layout gotcha where the OS Settings tile lives on a different rail than your custom renderer. |
+| `wp.desktop.openOsSettings( opts? )` | `void` | Portable opener for the shell's OS Settings window — same window the dock tile opens. Avoids the Classic-layout gotcha where the OS Settings tile lives on a different rail than your custom renderer. Pass `{ tabId }` (e.g. `'ai'`, `'features'`) to deep-link to a specific tab. |
 | `wp.desktop.listSystemTiles()` | `Array<{ id, title, icon, affinity }>` | Enumerate every JS-registered system tile (OS Settings, plugin native-window launchers). Compose your own launcher palette without scraping the DOM. |
 | `wp.desktop.getSystemTile( id )` | `SystemDockItem \| null` | Fetch a specific tile to invoke its `onOpen()` callback. |
 | `wp.desktop.getMenuItems()` | `DockItem[]` | The complete admin-menu list, regardless of how the active layout would partition it. Renderer-agnostic alternative to `mount-deps.fullMenu`. |
@@ -202,6 +202,9 @@ wp.desktop.getSystemTile( 'desktop-mode-os-settings' )?.onOpen();
 
 // Or the dedicated entry point for OS Settings:
 wp.desktop.openOsSettings();
+
+// Deep-link straight to a specific settings tab:
+wp.desktop.openOsSettings( { tabId: 'ai' } );
 
 // Iterate all system tiles for a custom launcher.
 for ( const tile of wp.desktop.listSystemTiles() ) {

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2362,13 +2362,24 @@ Snapshot of every currently registered rail renderer in registration order. Used
 
 ---
 
-### `openOsSettings()` — Stable *(since 0.18.0)*
+### `openOsSettings( opts? )` — Stable *(since 0.18.0)*
 
 Open (or focus, if already open) the shell's OS Settings window. Routes through the same `windowManager.open()` call the dock's OS Settings tile uses, so a window opened via `wp.desktop.openOsSettings()` is indistinguishable from one opened by clicking the dock tile — same id, same render callback, same dimensions, same focus / minimize behaviour.
 
 ```js
 wp.desktop.openOsSettings();
 ```
+
+Pass `{ tabId }` to land directly on a specific settings tab. The built-in tab ids are `'appearance'`, `'ai'`, `'features'`, `'apps-icons'`, `'extended'`, `'help'`, and `'about'`; a tab registered via `registerSettingsTab()` is addressable by its own id. The tab is selected before the window opens, and if OS Settings is already open the live tab strip switches in place:
+
+```js
+// Deep-link straight to the AI Settings tab.
+wp.desktop.openOsSettings( { tabId: 'ai' } );
+```
+
+| Param | Type | Notes |
+|---|---|---|
+| `opts.tabId` | `string` (optional) | Settings tab to activate. Unknown ids are ignored (the panel keeps its current/default tab). |
 
 The motivating use case: a custom dock rail renderer in **Classic** layout doesn't see the OS Settings tile (it lives on the side rail with the core menus, not the primary rail the custom renderer owns). Opening OS Settings from inside the renderer used to require DOM-scraping `[data-system-id="desktop-mode-os-settings"]` and clicking it; this method is the documented portable path.
 

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -86,11 +86,16 @@ function desktop_mode_register_assets() {
 		$built_version( 'assets/css/chromeless.css' )
 	);
 
+	// `filemtime`-stamped — the AI assistant surface (error states,
+	// inline affordances) iterates faster than plugin version bumps.
+	// Without an mtime stamp the browser keeps `?ver=<plugin-version>`
+	// valid for the whole release cycle and the user keeps seeing
+	// yesterday's CSS even after a hard reload.
 	wp_register_style(
 		'desktop-mode-ai-assistant',
 		DESKTOP_MODE_URL . 'assets/css/ai-assistant.css',
 		array( 'desktop-mode-variables' ),
-		$version
+		$built_version( 'assets/css/ai-assistant.css' )
 	);
 
 	wp_register_style(

--- a/src/ai-assistant/impl.ts
+++ b/src/ai-assistant/impl.ts
@@ -230,6 +230,7 @@ interface WindowManagerLite {
 interface DesktopShellLite {
 	windowManager?: WindowManagerLite;
 	deriveWindowId?: ( url: string, adminUrl?: string ) => string;
+	openOsSettings?: ( opts?: { tabId?: string } ) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -857,7 +858,12 @@ export class AiAssistant implements AiAssistantApi {
 		};
 
 		es.onmessage = ( ev ) => {
-			let data: { event?: string; message?: string; result?: SearchResult };
+			let data: {
+				event?: string;
+				message?: string;
+				code?: string;
+				result?: SearchResult;
+			};
 			try {
 				data = JSON.parse( ev.data );
 			} catch {
@@ -883,7 +889,7 @@ export class AiAssistant implements AiAssistantApi {
 					finish();
 					break;
 				case 'error':
-					this._showError( data.message ?? 'Something went wrong.' );
+					this._showError( data.message ?? 'Something went wrong.', data.code );
 					finish();
 					break;
 			}
@@ -929,8 +935,11 @@ export class AiAssistant implements AiAssistantApi {
 			);
 
 			if ( ! res.ok ) {
-				const err = await res.json().catch( () => ( {} ) );
-				this._showError( ( err as { message?: string } ).message ?? `Server returned ${ res.status }` );
+				const err = await res.json().catch( () => ( {} ) ) as {
+					message?: string;
+					code?: string;
+				};
+				this._showError( err.message ?? `Server returned ${ res.status }`, err.code );
 				return;
 			}
 
@@ -962,6 +971,20 @@ export class AiAssistant implements AiAssistantApi {
 			wp?: { desktop?: DesktopShellLite };
 		} ).wp?.desktop;
 		return shell ?? null;
+	}
+
+	/**
+	 * Open OS Settings on the AI tab so the user can enable AI in one
+	 * click from the "AI features are not enabled" error state. Closes
+	 * the assistant first so the settings window isn't hidden behind
+	 * it, and drops the stored focus target so closing doesn't bounce
+	 * focus back to the launcher away from the settings window.
+	 */
+	private _openAiSettings(): void {
+		const shell = this._getDesktopShell();
+		this._previousFocus = null;
+		this.close();
+		shell?.openOsSettings?.( { tabId: 'ai' } );
 	}
 
 	private _openInLegacyWindow( url: string, title: string, icon?: string ): void {
@@ -1339,8 +1362,35 @@ export class AiAssistant implements AiAssistantApi {
 		`;
 	}
 
-	private _showError( message: string ): void {
+	private _showError( message: string, code?: string ): void {
 		this._resultsEl.hidden = false;
+
+		// The "AI not enabled" case is recoverable in one click, so we
+		// turn the "OS Settings → AI Settings" mention in the message
+		// into an inline link that opens OS Settings on the AI tab.
+		// Keyed on the server error code, not the wording, so the
+		// affordance survives copy tweaks; the regex spans whatever sits
+		// between the two anchors (arrow, spacing) and falls back to a
+		// trailing link if the phrase is absent.
+		if ( code === 'desktop_mode_ai_disabled' ) {
+			const escaped = this._esc( message );
+			const linkify = ( text: string ) =>
+				`<button type="button" class="desktop-mode-ai__settings-link">${ text }</button>`;
+			const phrase = /OS Settings.*?AI Settings/;
+			const withLink = phrase.test( escaped )
+				? escaped.replace( phrase, ( match ) => linkify( match ) )
+				: `${ escaped } ${ linkify( 'AI Settings' ) }`;
+			this._resultsEl.innerHTML = `
+				<div class="desktop-mode-ai__state desktop-mode-ai__state--error">
+					<span>${ withLink }</span>
+				</div>
+			`;
+			this._resultsEl
+				.querySelector< HTMLButtonElement >( '.desktop-mode-ai__settings-link' )
+				?.addEventListener( 'click', () => this._openAiSettings() );
+			return;
+		}
+
 		this._resultsEl.innerHTML = `
 			<div class="desktop-mode-ai__state desktop-mode-ai__state--error">
 				<span>${ this._esc( message ) }</span>

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -221,7 +221,7 @@ export interface BuildPublicApiDeps {
 	placeSystemTile: ( item: SystemDockItem ) => void;
 	setDefaultWindow: ( url: string | null ) => Promise< void >;
 	refreshMenu: () => Promise< void >;
-	openOsSettings: () => void;
+	openOsSettings: ( opts?: { tabId?: string } ) => void;
 	aiAssistant: AiAssistantApi;
 	dragBridge: DragBridgeApi;
 	dragManager: DragManagerApi;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -944,7 +944,7 @@ export interface WpDesktopPublicApi {
 	 *
 	 * @since 0.18.0
 	 */
-	openOsSettings: () => void;
+	openOsSettings: ( opts?: { tabId?: string } ) => void;
 	/**
 	 * Read the current OS Settings snapshot. Mirrors the same shape
 	 * any settings tab sees via its `ctx.getOsSettings()`. Use this
@@ -2345,9 +2345,17 @@ function init(): void {
 	 * — custom rail renderers needed a portable way to surface OS
 	 * Settings inside their own UI.
 	 *
+	 * Pass `{ tabId }` to land directly on a specific settings tab
+	 * (e.g. `'ai'`, `'apps-icons'`). The tab is set before the window
+	 * opens so a fresh render mounts on it; if the window is already
+	 * open, `focusTab` switches the live tab strip in place.
+	 *
 	 * @since 0.18.0
 	 */
-	function openOsSettings(): void {
+	function openOsSettings( opts: { tabId?: string } = {} ): void {
+		if ( opts.tabId ) {
+			osSettings.activeTabId = opts.tabId;
+		}
 		void manager.open( {
 			id: OS_SETTINGS_WINDOW_ID,
 			baseId: OS_SETTINGS_WINDOW_ID,
@@ -2361,6 +2369,9 @@ function init(): void {
 			minWidth: 560,
 			minHeight: 480,
 		} );
+		if ( opts.tabId ) {
+			osSettings.focusTab( opts.tabId );
+		}
 	}
 
 	/**

--- a/src/plugins-window/index.ts
+++ b/src/plugins-window/index.ts
@@ -240,10 +240,10 @@ async function markIntroSeen( config: PluginsWindowConfig ): Promise< void > {
 
 function openOsSettingsFeatures(): void {
 	const api = ( window as unknown as {
-		wp?: { desktop?: { openOsSettings?: ( tab?: string ) => void } };
+		wp?: { desktop?: { openOsSettings?: ( opts?: { tabId?: string } ) => void } };
 	} ).wp?.desktop;
 	if ( typeof api?.openOsSettings === 'function' ) {
-		api.openOsSettings( 'features' );
+		api.openOsSettings( { tabId: 'features' } );
 	}
 }
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -370,6 +370,30 @@ export class OsSettings implements SettingsCtx {
 	 * that actually shrinks `desktop.min.js`. See the Stage 8
 	 * section of `BUNDLE-SIZE-REPORT.md` for the full picture.
 	 */
+	/**
+	 * Switch the active settings tab. Records the choice on
+	 * {@link activeTabId} (so the next render mounts on it) and, when
+	 * the panel is currently mounted, flips the live `<wpd-tabs>` value
+	 * in place so an already-open OS Settings window jumps to the tab
+	 * without a full re-render. Deep-linking entry points
+	 * (`openOsSettings({ tabId })`) call this after opening the window.
+	 *
+	 * @param tabId Settings tab id, e.g. `'ai'`, `'apps-icons'`.
+	 */
+	public focusTab( tabId: string ): void {
+		this.activeTabId = tabId;
+		const body = this._lastRenderedBody;
+		if ( ! body?.isConnected ) {
+			return;
+		}
+		const tabs = body.querySelector( 'wpd-tabs' ) as
+			| ( HTMLElement & { value?: string } )
+			| null;
+		if ( tabs ) {
+			tabs.value = tabId;
+		}
+	}
+
 	public renderPanel( body: HTMLElement ): void {
 		// Track the body so the save-failure rollback handler can
 		// re-render after restoring the last-confirmed state.


### PR DESCRIPTION
## What & why

When AI features aren't enabled, the AI Assistant showed a plain red sentence — *"AI features are not enabled. Enable them in OS Settings → AI Settings."* — with nothing to click. This makes the **"OS Settings → AI Settings"** phrase an inline link that opens OS Settings directly on the AI tab, so the error is recoverable in one click.

<img width="1456" height="608" alt="CleanShot 2026-06-04 at 18 17 24@2x" src="https://github.com/user-attachments/assets/a09687bd-80b2-4913-b4f6-c3db7e637729" />


## Changes

**AI Assistant (`src/ai-assistant/impl.ts`)**
- On the `desktop_mode_ai_disabled` error, linkify the "OS Settings → AI Settings" phrase. Keyed on the server **error code**, not the wording, so copy/translation tweaks don't break the affordance; falls back to a trailing link if the phrase is absent.
- New `_openAiSettings()` closes the assistant and deep-links to the AI tab.
- Threaded the error `code` through the error paths that carry it (fetch 403 body + SSE `error` event).

**`openOsSettings({ tabId })` (`src/desktop.ts`, `src/settings/index.ts`, `src/api/facade.ts`)**
- `openOsSettings` now accepts an optional `{ tabId }`. The tab is set before the window opens (fresh mount lands on it); new `OsSettings.focusTab()` live-switches the `<wpd-tabs>` value when the window is already open.
- Backwards-compatible, additive widening of the public type. Also makes the previously **dead** tab-targeting callers work (`item-visibility-menu` already passed `{ tabId: 'apps-icons' }`); fixed `plugins-window` which passed a bare string.

**Styling (`assets/css/ai-assistant.css`, `assets/css/desktop.css`)**
- Style the phrase as an inline text link (bold + underline, inherits the error color).
- Add a **scoped pointer-cursor exception** to the shell's deliberate `cursor: default !important` no-pointer policy, so a genuine link reads as clickable. Scoped under `body.desktop-mode-active` to out-specify the policy (same trick the resize-handle exceptions use), and cross-referenced in the policy comment so the documented exception list stays accurate.

**Caching (`includes/assets.php`)**
- `filemtime`-stamp `ai-assistant.css` (was on the static plugin version) so this fast-iterating surface busts cache without a version bump — same pattern `windows.css`/`chromeless.css` already use.

**Docs**
- Documented `openOsSettings({ tabId })` in `javascript-reference.md` and `dock-customization.md`.

## Test plan

1. As a user with AI features **disabled**, open the AI Assistant and submit any query.
2. The error now renders *"…Enable them in **OS Settings → AI Settings**."* with the phrase as an underlined link (pointer cursor on hover).
3. Clicking it closes the assistant and opens **OS Settings on the AI tab**.
4. Bonus, now working: right-click a dock/desktop tile → **Apps & Icons settings…** lands on the Apps & Icons tab; the Plugins window "configure features" entry lands on the Features tab.

Gates: `typecheck`, `lint`, `test:js` (1519 tests) green; full build clean.

## Note

The opt-in SSE transport returns a bare `403` before streaming on this gate, so that (non-default) path still shows the generic "Lost connection" message rather than the link. Left out of scope; happy to make the SSE handler emit the disabled error too if wanted.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-295-457b9d7c9048d442ab3723ff26c53448cfd9ec26.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->