### PR TITLE
Make native list windows opt-in (Beta) instead of opt-out

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Desktop Mode
  * Plugin URI:        https://github.com/WordPress/desktop-mode
  * Description:       Renders the WordPress admin as a desktop OS. Admin screens become draggable, resizable, minimizable windows floating on a desktop with a dock. Purely opt-in per user.
- * Version:           0.9.0
+ * Version:           0.10.0
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            Daniel López Sánchez
@@ -17,7 +17,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DESKTOP_MODE_VERSION', '0.9.0' );
+define( 'DESKTOP_MODE_VERSION', '0.10.0' );
 define( 'DESKTOP_MODE_FILE', __FILE__ );
 define( 'DESKTOP_MODE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'DESKTOP_MODE_URL', plugin_dir_url( __FILE__ ) );
@@ -46,6 +46,9 @@ require_once DESKTOP_MODE_DIR . 'includes/presence.php';
 require_once DESKTOP_MODE_DIR . 'includes/nonce-refresh.php';
 require_once DESKTOP_MODE_DIR . 'includes/sticky-notes/heartbeat.php';
 require_once DESKTOP_MODE_DIR . 'includes/os-settings.php';
+// One-time data migrations. After os-settings.php so the meta-key
+// constant and save/sanitize helpers the migrations call already exist.
+require_once DESKTOP_MODE_DIR . 'includes/migrations.php';
 require_once DESKTOP_MODE_DIR . 'includes/seen-intros.php';
 require_once DESKTOP_MODE_DIR . 'includes/welcome-dialog.php';
 require_once DESKTOP_MODE_DIR . 'includes/portal.php';

--- a/docs/examples/native-posts.md
+++ b/docs/examples/native-posts.md
@@ -1,6 +1,6 @@
 # Example: native Posts window
 
-A `<wpd-table>`-driven replacement for the chromeless `edit.php` iframe. Server-paginated, sortable, filterable, multi-select bulk-trash, sub-row excerpt + featured image. **Opt-OUT as of 0.8.0** — fresh installs use it by default; users can flip it off via **OS Settings → Features → Use the native Posts window**. The dock tile stays where it is; only the destination changes.
+A `<wpd-table>`-driven replacement for the chromeless `edit.php` iframe. Server-paginated, sortable, filterable, multi-select bulk-trash, sub-row excerpt + featured image. **Opt-IN Beta as of 0.10.0** (was opt-out in 0.8.0–0.9.0) — fresh installs use the classic iframe; users turn it on via **OS Settings → Features → Beta features → Use the native Posts window**. The dock tile stays where it is; only the destination changes.
 
 > Status: **Experimental** since 0.8.0. Hook names are stable; the JS column-filter shape may grow.
 
@@ -304,7 +304,7 @@ The recycle bin window is already a subscriber — that's how trashing 12 posts 
 ## Hooks reference (Experimental, 0.8.0)
 
 PHP:
-- `desktop_mode_posts_window_user_can_use( $can, $user_id )` — gate. Default: `edit_posts` AND the user hasn't flipped the opt-out toggle off.
+- `desktop_mode_posts_window_user_can_use( $can, $user_id )` — gate. Default: `edit_posts` AND the user has turned the opt-in toggle on.
 - `desktop_mode_posts_window_args( $args )` — args passed to `desktop_mode_register_window()` (title, icon, dimensions, config blob).
 - `desktop_mode_posts_window_template_html( $html )` — the rendered template HTML before `wp_kses`.
 - `desktop_mode_posts_window_query_args( $args )` — outbound REST query params (`_fields`, `_embed`, `post_type`).

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1884,11 +1884,11 @@ See [`docs/examples/recycle-bin.md`](./examples/recycle-bin.md) for end-to-end r
 
 ## Native Posts window
 
-`<wpd-table>`-driven native window that replaces the chromeless `edit.php` iframe. **Opt-OUT as of 0.8.0** — fresh installs land on it; users can flip it off via **OS Settings → Features → Use the native Posts window** (persisted as `OsSettingsState.nativePostsEnabled`, default `true`). The dock tile that points at `edit.php` is unchanged — every click path consults the URL → native-window remap registry first and falls back to the iframe on no-match. See [`examples/native-posts.md`](./examples/native-posts.md) for end-to-end recipes.
+`<wpd-table>`-driven native window that replaces the chromeless `edit.php` iframe. **Opt-IN Beta as of 0.10.0** (was opt-out in 0.8.0–0.9.0) — fresh installs land on the classic iframe; users turn it on via **OS Settings → Features → Beta features → Use the native Posts window** (persisted as `OsSettingsState.nativePostsEnabled`, default `false`). The dock tile that points at `edit.php` is unchanged — every click path consults the URL → native-window remap registry first and falls back to the iframe on no-match. See [`examples/native-posts.md`](./examples/native-posts.md) for end-to-end recipes.
 
 ### `desktop_mode_posts_window_user_can_use` — Stable *(filter, since 0.8.0)*
 
-The two-condition gate: `edit_posts` AND the user hasn't toggled the opt-out. Returning `false` here forces the classic chromeless `edit.php` iframe to remain the destination.
+The two-condition gate: `edit_posts` AND the user has turned the opt-in toggle on. Returning `false` here forces the classic chromeless `edit.php` iframe to remain the destination.
 
 ```php
 apply_filters( 'desktop_mode_posts_window_user_can_use', bool $can, int $user_id );
@@ -1987,7 +1987,7 @@ Returning `false` from `enabled` (or `matches`) lets the click fall through. An 
 
 ## Native Plugins window (since 0.9.0)
 
-A two-tab native window that replaces the chromeless `plugins.php` (Installed list) and `plugin-install.php` (Browse the .org repo) iframes. **Opt-OUT** — fresh installs land on it; users can flip it off via **OS Settings → Features → Use the native Plugins window** (persisted as `OsSettingsState.nativePluginsEnabled`, default `true`). `plugin-editor.php` is intentionally NOT claimed; that surface stays on the existing iframe.
+A two-tab native window that replaces the chromeless `plugins.php` (Installed list) and `plugin-install.php` (Browse the .org repo) iframes. **Opt-IN Beta as of 0.10.0** (was opt-out in 0.9.0) — fresh installs land on the classic iframe; users turn it on via **OS Settings → Features → Beta features → Use the native Plugins window** (persisted as `OsSettingsState.nativePluginsEnabled`, default `false`). `plugin-editor.php` is intentionally NOT claimed; that surface stays on the existing iframe.
 
 Architecture summary: read paths use Core REST (`/wp/v2/plugins`); admin-only paths (browse / info / reviews / .zip upload) live on `admin-ajax.php` (`wp_ajax_desktop_mode_plugins_*`) so we never need to `require_once ABSPATH . 'wp-admin/…'`. Install-by-slug delegates to Core's existing `wp_ajax_install_plugin` handler. Mutations are followed by `wp.desktop.refreshMenu()` so the dock repaints live.
 
@@ -2001,7 +2001,7 @@ apply_filters( 'desktop_mode_plugins_window_user_can_register', bool $can, int $
 
 ### `desktop_mode_plugins_window_user_can_use` — Stable *(filter, since 0.9.0)*
 
-Combined cap-and-opt-in. Returns `true` when the user has `activate_plugins` AND has not flipped `nativePluginsEnabled` to `false`.
+Combined cap-and-opt-in. Returns `true` when the user has `activate_plugins` AND has turned `nativePluginsEnabled` on (default `false`).
 
 ```php
 apply_filters( 'desktop_mode_plugins_window_user_can_use', bool $can, int $user_id ): bool
@@ -2157,7 +2157,7 @@ apply_filters( 'desktop_mode_plugins_featured_response', array $payload, array $
 
 Replaces the chromeless `edit-comments.php` iframe with a moderation queue native window: Pending / All / Spam / Trash / Mine tabs, bulk approve / spam / trash with an 8-second undo, inline reply editor, keyboard moderation (`j/k/a/s/d/r/e/u/?`), spam-confidence chip per row, author-insights drawer.
 
-Per-user opt-out via OS Settings → Features → `nativeCommentsEnabled`. URL remap claims `edit-comments.php`; `comment.php?action=editcomment&c=…` still falls through to the chromeless iframe path.
+Per-user opt-in Beta (default `false` as of 0.10.0) via OS Settings → Features → Beta features → `nativeCommentsEnabled`. URL remap claims `edit-comments.php`; `comment.php?action=editcomment&c=…` still falls through to the chromeless iframe path.
 
 ### `desktop_mode_comments_window_user_can_register` — Stable *(filter, since 0.19.0)*
 

--- a/includes/migrations.php
+++ b/includes/migrations.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Desktop Mode — one-time data migrations.
+ *
+ * A tiny, option-versioned migration runner modeled on the lazy schema
+ * installer in `includes/desktop-files/schema.php`: a stored option holds
+ * the highest migration version that has run; on every admin load we
+ * compare it against {@see DESKTOP_MODE_MIGRATION_VERSION} and run any
+ * pending migrations exactly once. Guarded so it is a cheap no-op after
+ * the first successful pass.
+ *
+ * @package WPDesktopMode
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Highest migration version shipped by the plugin.
+ *
+ * Bump this (and add a matching branch in
+ * {@see desktop_mode_run_pending_migrations}) whenever a new one-time
+ * migration is needed.
+ *
+ * - 1: native list windows flipped from opt-out (default ON) to opt-in
+ *   Beta (default OFF). Clears the five `native*Enabled` flags from every
+ *   user who had them persisted so the whole install reverts to opt-in.
+ *
+ * @since 0.10.0
+ */
+const DESKTOP_MODE_MIGRATION_VERSION = 1;
+
+/** Option storing the highest migration version that has run. autoload=no. */
+const DESKTOP_MODE_MIGRATION_OPTION = 'desktop_mode_migration_version';
+
+/**
+ * Runs any pending migrations, then records the new high-water mark.
+ *
+ * Idempotent: bails immediately when the stored version is already at
+ * or above the shipped version, so it is safe to fire on every request.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function desktop_mode_maybe_run_migrations() {
+	$installed = (int) get_option( DESKTOP_MODE_MIGRATION_OPTION, 0 );
+	if ( $installed >= DESKTOP_MODE_MIGRATION_VERSION ) {
+		return;
+	}
+
+	desktop_mode_run_pending_migrations( $installed );
+
+	update_option( DESKTOP_MODE_MIGRATION_OPTION, DESKTOP_MODE_MIGRATION_VERSION, false );
+}
+add_action( 'admin_init', 'desktop_mode_maybe_run_migrations' );
+
+/**
+ * Dispatches each migration whose version is newer than what has run.
+ *
+ * @since 0.10.0
+ *
+ * @param int $from The highest migration version already applied.
+ * @return void
+ */
+function desktop_mode_run_pending_migrations( $from ) {
+	$from = (int) $from;
+
+	if ( $from < 1 ) {
+		desktop_mode_migrate_os_settings_optin();
+	}
+}
+
+/**
+ * Migration 1 — reset the native list windows to opt-in.
+ *
+ * The native Posts/Pages/Users/Plugins/Comments windows used to default
+ * ON (opt-out). The shell persists the whole OS-settings object on every
+ * change, so most active users already have these flags stored as `true`
+ * and would keep the native UI even after the default flips. This clears
+ * the five flags from every user who has the meta, leaving the rest of
+ * their settings (wallpaper, accent, dock order, …) untouched. On the
+ * next read the cleared keys fall back to the new `false` default, so the
+ * whole install lands on opt-in and users re-enable each window from
+ * OS Settings → Features → Beta features.
+ *
+ * Only users who actually have the meta are queried — fresh accounts and
+ * users who never touched OS Settings are skipped entirely.
+ *
+ * @since 0.10.0
+ *
+ * @return void
+ */
+function desktop_mode_migrate_os_settings_optin() {
+	$flags = array(
+		'nativePostsEnabled',
+		'nativePagesEnabled',
+		'nativeUsersEnabled',
+		'nativePluginsEnabled',
+		'nativeCommentsEnabled',
+	);
+
+	$user_ids = get_users(
+		array(
+			'fields'     => 'ID',
+			'meta_key'   => DESKTOP_MODE_OS_SETTINGS_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- one-time migration; the key is indexed in usermeta and the scan is guarded to run once.
+			'meta_compare' => 'EXISTS',
+		)
+	);
+
+	foreach ( $user_ids as $user_id ) {
+		$raw = get_user_meta( (int) $user_id, DESKTOP_MODE_OS_SETTINGS_META_KEY, true );
+		if ( ! is_array( $raw ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $flags as $flag ) {
+			if ( array_key_exists( $flag, $raw ) ) {
+				unset( $raw[ $flag ] );
+				$changed = true;
+			}
+		}
+
+		if ( ! $changed ) {
+			continue;
+		}
+
+		// Re-save through the canonical sanitizer so the cleared flags are
+		// backfilled with the new `false` default and the rest of the
+		// settings array is normalized exactly as a client write would be.
+		desktop_mode_save_os_settings( (int) $user_id, $raw );
+	}
+}

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -79,42 +79,42 @@ function desktop_mode_default_os_settings() {
 			'apiKeys'   => array(), // Per-provider keys: { [provider_id]: string }.
 			'transport' => 'off',   // Live-progress transport: 'sse' | 'off'. Default off — see DESKTOP_MODE_OS_SETTINGS_AI_TRANSPORTS.
 		),
-		// Per-user opt-OUT for the native Posts window. When true,
+		// Per-user opt-IN for the native Posts window. When true,
 		// clicking the Posts dock tile opens the `<wpd-table>`-driven
 		// native window instead of the chromeless `edit.php` iframe.
-		// Default ON as of 0.8.0 — the native UI is the canonical
-		// Desktop Mode Posts experience; users can flip it off to fall
-		// back to the classic iframe.
+		// Default OFF as of 0.10.0 — the native windows are now opt-in
+		// Beta. Fresh installs land on the classic iframe; users turn
+		// this on in OS Settings → Features → Beta features to try it.
 		// Per-user override of the WordPress Heartbeat interval, in
 		// seconds. 60s matches Core's "idle" default; values below
 		// 15 force a lower `minimalInterval` too. See
 		// `desktop_mode_apply_heartbeat_rate_setting` for the
 		// `heartbeat_settings` filter that applies this.
 		'heartbeatRate'               => 60,
-		'nativePostsEnabled'          => true,
+		'nativePostsEnabled'          => false,
 		// Per-user list of column keys hidden in the native Posts
 		// window (e.g. array( 'author', 'tags' )). Empty array means
 		// every column is visible. The sticky 'title' column is always
 		// shown — the UI prevents toggling it.
 		'nativePostsHiddenColumns'    => array(),
-		// Per-user opt-OUT for the native Pages window. Same posture as
-		// nativePostsEnabled — defaults ON, users can flip off to keep
-		// the classic `edit.php?post_type=page` iframe.
-		'nativePagesEnabled'          => true,
-		// Per-user opt-OUT for the native Users window. Defaults ON;
-		// the server-side cap gate (`list_users`) means the toggle
-		// only matters for users who could see the Users tile anyway.
-		'nativeUsersEnabled'          => true,
-		// Per-user opt-OUT for the native Plugins window. Defaults ON;
-		// the server-side cap gate (`activate_plugins`) means the
-		// toggle only matters for users who could see the Plugins
-		// tile anyway. When `false`, the dock click falls back to the
-		// classic `plugins.php` chromeless iframe path.
-		'nativePluginsEnabled'        => true,
-		// Per-user opt-OUT for the native Comments window. Defaults ON;
-		// the server-side cap gate (`edit_posts`) means the toggle only
-		// matters for users who could see the Comments tile anyway.
-		'nativeCommentsEnabled'       => true,
+		// Per-user opt-IN for the native Pages window. Same posture as
+		// nativePostsEnabled — defaults OFF (Beta), users opt in to swap
+		// the classic `edit.php?post_type=page` iframe for the native UI.
+		'nativePagesEnabled'          => false,
+		// Per-user opt-IN for the native Users window. Defaults OFF
+		// (Beta); the server-side cap gate (`list_users`) means the
+		// toggle only matters for users who could see the Users tile.
+		'nativeUsersEnabled'          => false,
+		// Per-user opt-IN for the native Plugins window. Defaults OFF
+		// (Beta); the server-side cap gate (`activate_plugins`) means
+		// the toggle only matters for users who could see the Plugins
+		// tile anyway. When `false`, the dock click uses the classic
+		// `plugins.php` chromeless iframe path.
+		'nativePluginsEnabled'        => false,
+		// Per-user opt-IN for the native Comments window. Defaults OFF
+		// (Beta); the server-side cap gate (`edit_posts`) means the
+		// toggle only matters for users who could see the Comments tile.
+		'nativeCommentsEnabled'       => false,
 		// When true, left-clicking the empty wallpaper triggers the
 		// "Show desktop" toggle (macOS-style) and the matching entry is
 		// hidden from the wallpaper context menu. When false (default),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "desktop-mode",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"private": true,
 	"type": "module",
 	"description": "WordPress admin as a desktop OS — draggable, resizable windows on a desktop with a dock.",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: desktop, admin, ui, productivity, ai
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 0.9.0
+Stable tag: 0.10.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -106,6 +106,11 @@ The plugin bundles the following third-party JavaScript library, loaded on deman
 * **[PixiJS](https://pixijs.com/)** (MIT License) — used by the interactive **OS Settings → About** scene, the **Content Graph** window, and built-in canvas wallpapers (e.g. the animated WordPress logo). PixiJS is loaded from the plugin's own `assets/vendor/` directory; no CDN requests are made.
 
 == Changelog ==
+
+= 0.10.0 =
+* The native Posts, Pages, Users, Plugins, and Comments windows are now opt-in Beta — they no longer replace the classic admin screens by default
+* New "Beta features" section in OS Settings → Features to turn each native window on
+* One-time upgrade resets the native windows to off so the redesigned screens are a deliberate choice
 
 = 0.9.0 =
 * Gate per-user REST routes on desktop mode enabled

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -165,29 +165,30 @@ export const DEFAULTS: OsSettingsState = {
 		apiKeys: {},
 		transport: 'off',
 	},
-	// Opt-out as of 0.8.0. Fresh installs land on the native Posts
-	// window — same screen the rest of desktop mode is built for. A
-	// user can still flip this off to fall back to the chromeless
-	// `edit.php` iframe, but the new default is "use the native UI."
+	// Opt-IN Beta as of 0.10.0. Fresh installs land on the classic
+	// chromeless `edit.php` iframe; a user opts in via OS Settings →
+	// Features → Beta features to get the native Posts window. The
+	// native windows used to default ON (opt-out, 0.8.0) but are now
+	// opt-in so the redesign is a deliberate choice, not imposed.
 	heartbeatRate: 60,
-	nativePostsEnabled: true,
+	nativePostsEnabled: false,
 	nativePostsHiddenColumns: [],
-	// Same opt-out posture as Posts — fresh installs land on the
-	// native Pages window, users can flip back to the iframe.
-	nativePagesEnabled: true,
-	// Native Users window — same opt-out posture. Capability-gated
+	// Same opt-in Beta posture as Posts — fresh installs keep the
+	// iframe; users opt in to the native Pages window.
+	nativePagesEnabled: false,
+	// Native Users window — same opt-in Beta posture. Capability-gated
 	// server-side (the window is only registered for users with
-	// `list_users`), so flipping this off only affects the small set
-	// of users who can see the Users tile in the first place.
-	nativeUsersEnabled: true,
+	// `list_users`), so this toggle only affects the small set of
+	// users who can see the Users tile in the first place.
+	nativeUsersEnabled: false,
 	// Native Plugins window — replaces `plugins.php` and
-	// `plugin-install.php`. Same opt-out posture; cap-gated on
-	// `activate_plugins` server-side, so flipping this off only
-	// affects users who could see the Plugins tile anyway.
-	nativePluginsEnabled: true,
+	// `plugin-install.php`. Same opt-in Beta posture; cap-gated on
+	// `activate_plugins` server-side, so this toggle only affects
+	// users who could see the Plugins tile anyway.
+	nativePluginsEnabled: false,
 	// Native Comments window — replaces `edit-comments.php`. Same
-	// opt-out posture; cap-gated on `edit_posts` server-side.
-	nativeCommentsEnabled: true,
+	// opt-in Beta posture; cap-gated on `edit_posts` server-side.
+	nativeCommentsEnabled: false,
 	showDesktopOnWallpaperClick: false,
 	showPostStatusRibbons: true,
 	foldersSharingEnabled: true,

--- a/src/settings/sections/features.ts
+++ b/src/settings/sections/features.ts
@@ -6,9 +6,12 @@
  * `OsSettingsState` via `ctx.save()` — no dedicated REST endpoint;
  * the existing OS-settings sync debounces the write to user meta.
  *
- * Today: the native Posts window opt-in. As more per-user feature
- * flags land they slot in here so the Features tab grows by one row
- * at a time, not one tab at a time.
+ * The tab renders two sections: a "Beta features" group holding the
+ * opt-in native-window toggles (Posts, Pages, Users, Plugins,
+ * Comments — all off by default as of 0.10.0), and the general
+ * "Features" group below it. As more per-user feature flags land they
+ * slot into the matching section so the tab grows by one row at a
+ * time, not one tab at a time.
  *
  * The save indicator (`<wpd-save-status auto>`) hooks the same
  * `desktop-mode-os-settings-save-lifecycle` CustomEvent the panel
@@ -300,9 +303,9 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 		render(
 			html`
 				<wpd-section
-					heading=${ __( 'Features' ) }
+					heading=${ __( 'Beta features' ) }
 					description=${ __(
-						'Tune individual Desktop Mode behaviors. Each toggle affects only your account and takes effect immediately — no reload required. Watch the dot in the OS Settings title bar to see when a change has been saved.',
+						'Experimental redesigns of core admin screens. Off by default — opt in to try them. Each toggle affects only your account and takes effect immediately, no reload required.',
 					) }
 				>
 					<div class="desktop-mode-features__item">
@@ -313,7 +316,7 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 						></wpd-checkbox-label>
 						<p class="desktop-mode-features__hint">
 							${ __(
-								'Replaces the classic Posts list iframe with a native, table-driven window: sticky header, server-paginated rows, multi-select bulk actions, and a sub-row preview. On by default. Toggle off to return to the classic experience.',
+								'Beta — off by default. Turn on to replace the classic Posts list iframe with a native, table-driven window: sticky header, server-paginated rows, multi-select bulk actions, and a sub-row preview. Toggle off any time to return to the classic screen.',
 							) }
 						</p>
 					</div>
@@ -325,7 +328,7 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 						></wpd-checkbox-label>
 						<p class="desktop-mode-features__hint">
 							${ __(
-								'Same table-driven experience as the Posts window, tailored for Pages: a Parent column, hierarchical sort, and the same lock indicator when another user is editing a page. On by default. Toggle off to return to the classic experience.',
+								'Beta — off by default. Turn on for the same table-driven experience as the Posts window, tailored for Pages: a Parent column, hierarchical sort, and a lock indicator when another user is editing a page. Toggle off any time to return to the classic screen.',
 							) }
 						</p>
 					</div>
@@ -337,7 +340,7 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 						></wpd-checkbox-label>
 						<p class="desktop-mode-features__hint">
 							${ __(
-								'A native Users list with bulk role change, last-login tracking, live online indicators, click-to-copy email, and one-click password resets. Capability-gated — readers see a read-only view, role assignment respects WordPress role permissions. On by default.',
+								'Beta — off by default. Turn on for a native Users list with bulk role change, last-login tracking, live online indicators, click-to-copy email, and one-click password resets. Capability-gated — readers see a read-only view, role assignment respects WordPress role permissions.',
 							) }
 						</p>
 					</div>
@@ -349,7 +352,7 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 						></wpd-checkbox-label>
 						<p class="desktop-mode-features__hint">
 							${ __(
-								'A native two-tab Plugins window: an Installed list with bulk activate / deactivate / delete, and a Browse gallery powered by the WordPress.org repository — rich detail flyout with screenshots, ratings histogram, and recent reviews. Drag a .zip onto the window to install, or drag a card from Browse to the dock to pin it. On by default.',
+								'Beta — off by default. Turn on for a native two-tab Plugins window: an Installed list with bulk activate / deactivate / delete, and a Browse gallery powered by the WordPress.org repository — rich detail flyout with screenshots, ratings histogram, and recent reviews. Drag a .zip onto the window to install, or drag a card from Browse to the dock to pin it.',
 							) }
 						</p>
 					</div>
@@ -361,10 +364,17 @@ export function buildFeaturesSection( ctx: SettingsCtx ): HTMLElement {
 						></wpd-checkbox-label>
 						<p class="desktop-mode-features__hint">
 							${ __(
-								'A redesigned moderation queue with Pending / All / Spam / Trash / Mine tabs, bulk approve/spam/trash plus an 8-second undo, inline reply right in the row, an author insights drawer, a per-row spam confidence score (Akismet + heuristics), and full keyboard moderation (j/k navigate, a approve, s spam, d trash, r reply, e edit, u undo). On by default.',
+								'Beta — off by default. Turn on for a redesigned moderation queue with Pending / All / Spam / Trash / Mine tabs, bulk approve/spam/trash plus an 8-second undo, inline reply right in the row, an author insights drawer, a per-row spam confidence score (Akismet + heuristics), and full keyboard moderation (j/k navigate, a approve, s spam, d trash, r reply, e edit, u undo).',
 							) }
 						</p>
 					</div>
+				</wpd-section>
+				<wpd-section
+					heading=${ __( 'Features' ) }
+					description=${ __(
+						'Tune individual Desktop Mode behaviors. Each toggle affects only your account and takes effect immediately — no reload required. Watch the dot in the OS Settings title bar to see when a change has been saved.',
+					) }
+				>
 					${ shellCfg?.commentsAi
 						? html`
 							<div class="desktop-mode-features__item">

--- a/tests/phpunit/tests/osSettingsMigration.php
+++ b/tests/phpunit/tests/osSettingsMigration.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for the one-time OS-settings opt-in migration (migration v1).
+ *
+ * Migration 1 flips the native list windows from opt-out (default ON)
+ * to opt-in Beta (default OFF) and clears the five `native*Enabled`
+ * flags from every user who had them persisted, so an existing install
+ * reverts to opt-in without losing the rest of each user's settings.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-os-settings
+ */
+class Tests_DesktopMode_OsSettingsMigration extends WP_UnitTestCase {
+
+	/**
+	 * The five native-window flags the migration clears.
+	 *
+	 * @var string[]
+	 */
+	private $flags = array(
+		'nativePostsEnabled',
+		'nativePagesEnabled',
+		'nativeUsersEnabled',
+		'nativePluginsEnabled',
+		'nativeCommentsEnabled',
+	);
+
+	public function set_up() {
+		parent::set_up();
+		// Start every test from a pre-migration state.
+		delete_option( DESKTOP_MODE_MIGRATION_OPTION );
+	}
+
+	/**
+	 * A user who explicitly had the native windows on is reset to opt-in,
+	 * and unrelated settings (wallpaper) survive untouched.
+	 *
+	 * @covers ::desktop_mode_migrate_os_settings_optin
+	 */
+	public function test_migration_clears_flags_but_preserves_other_settings() {
+		$user_id = self::factory()->user->create();
+		desktop_mode_save_os_settings(
+			$user_id,
+			array(
+				'wallpaper'             => 'custom-gradient',
+				'nativePostsEnabled'    => true,
+				'nativePagesEnabled'    => true,
+				'nativeUsersEnabled'    => true,
+				'nativePluginsEnabled'  => true,
+				'nativeCommentsEnabled' => true,
+			)
+		);
+
+		desktop_mode_migrate_os_settings_optin();
+
+		$loaded = desktop_mode_get_os_settings( $user_id );
+		foreach ( $this->flags as $flag ) {
+			$this->assertFalse(
+				$loaded[ $flag ],
+				"`$flag` should be reset to the opt-in default (false) after the migration."
+			);
+		}
+		$this->assertSame(
+			'custom-gradient',
+			$loaded['wallpaper'],
+			'Unrelated settings must survive the migration.'
+		);
+	}
+
+	/**
+	 * A user who never saved any OS settings has no meta row, so the
+	 * migration leaves them alone — and they read the new default anyway.
+	 *
+	 * @covers ::desktop_mode_migrate_os_settings_optin
+	 */
+	public function test_migration_skips_users_without_meta() {
+		$user_id = self::factory()->user->create();
+
+		desktop_mode_migrate_os_settings_optin();
+
+		$raw = get_user_meta( $user_id, DESKTOP_MODE_OS_SETTINGS_META_KEY, true );
+		$this->assertSame( '', $raw, 'No meta row should be created for an untouched user.' );
+
+		$loaded = desktop_mode_get_os_settings( $user_id );
+		$this->assertFalse( $loaded['nativePostsEnabled'] );
+	}
+
+	/**
+	 * The runner stamps the option to the shipped version so it never
+	 * runs twice, and a user who re-opts-in after the migration keeps
+	 * their choice — the guarded runner must not re-clear it.
+	 *
+	 * @covers ::desktop_mode_maybe_run_migrations
+	 */
+	public function test_migration_is_guarded_and_does_not_re_run() {
+		$user_id = self::factory()->user->create();
+		desktop_mode_save_os_settings(
+			$user_id,
+			array( 'nativePostsEnabled' => true )
+		);
+
+		desktop_mode_maybe_run_migrations();
+
+		$this->assertSame(
+			DESKTOP_MODE_MIGRATION_VERSION,
+			(int) get_option( DESKTOP_MODE_MIGRATION_OPTION ),
+			'The migration high-water mark should be stamped after running.'
+		);
+		$this->assertFalse( desktop_mode_get_os_settings( $user_id )['nativePostsEnabled'] );
+
+		// User deliberately re-enables the native window post-migration.
+		desktop_mode_save_os_settings(
+			$user_id,
+			array( 'nativePostsEnabled' => true )
+		);
+
+		// Re-running is a no-op now that the option is at the latest version.
+		desktop_mode_maybe_run_migrations();
+
+		$this->assertTrue(
+			desktop_mode_get_os_settings( $user_id )['nativePostsEnabled'],
+			'A re-opt-in after the migration must not be clobbered by a second run.'
+		);
+	}
+
+	/**
+	 * Running the migration when the option is already current must not
+	 * touch user settings at all.
+	 *
+	 * @covers ::desktop_mode_maybe_run_migrations
+	 */
+	public function test_maybe_run_is_noop_when_already_current() {
+		update_option( DESKTOP_MODE_MIGRATION_OPTION, DESKTOP_MODE_MIGRATION_VERSION, false );
+
+		$user_id = self::factory()->user->create();
+		desktop_mode_save_os_settings(
+			$user_id,
+			array( 'nativePostsEnabled' => true )
+		);
+
+		desktop_mode_maybe_run_migrations();
+
+		$this->assertTrue(
+			desktop_mode_get_os_settings( $user_id )['nativePostsEnabled'],
+			'With the option already current the migration must not run.'
+		);
+	}
+}

--- a/tests/phpunit/tests/pluginsWindowRegistration.php
+++ b/tests/phpunit/tests/pluginsWindowRegistration.php
@@ -93,10 +93,19 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 	// ----------------------------------------------------------------
 
 	/**
+	 * Opt-in Beta as of 0.10.0: an admin who has not turned the native
+	 * Plugins window on gets the classic iframe. Opting in opens the gate.
+	 *
 	 * @covers ::desktop_mode_plugins_window_user_can_use
 	 */
-	public function test_gate_open_by_default_for_admins() {
+	public function test_gate_closed_by_default_until_admin_opts_in() {
 		wp_set_current_user( $this->admin_id );
+		$this->assertFalse( desktop_mode_plugins_window_user_can_use() );
+
+		desktop_mode_save_os_settings(
+			$this->admin_id,
+			array( 'nativePluginsEnabled' => true )
+		);
 		$this->assertTrue( desktop_mode_plugins_window_user_can_use() );
 	}
 
@@ -207,15 +216,15 @@ class Tests_DesktopMode_PluginsWindowRegistration extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Default OS Settings payload must include the new flag with its
-	 * documented default (true / opt-out).
+	 * Default OS Settings payload must include the flag with its
+	 * documented default (false / opt-in Beta as of 0.10.0).
 	 *
 	 * @covers ::desktop_mode_default_os_settings
 	 */
-	public function test_native_plugins_enabled_defaults_on() {
+	public function test_native_plugins_enabled_defaults_off() {
 		$defaults = desktop_mode_default_os_settings();
 		$this->assertArrayHasKey( 'nativePluginsEnabled', $defaults );
-		$this->assertTrue( $defaults['nativePluginsEnabled'] );
+		$this->assertFalse( $defaults['nativePluginsEnabled'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/postsWindowRegistration.php
+++ b/tests/phpunit/tests/postsWindowRegistration.php
@@ -97,14 +97,20 @@ class Tests_DesktopMode_PostsWindowRegistration extends WP_UnitTestCase {
 	// ----------------------------------------------------------------
 
 	/**
-	 * Native Posts is opt-OUT — admins (any user with `edit_posts`)
-	 * are in by default. Toggling the OS Settings flag off is what
-	 * closes the gate.
+	 * Native Posts is opt-in Beta as of 0.10.0 — even a user with
+	 * `edit_posts` gets the classic iframe until they turn the toggle
+	 * on. Opting in is what opens the gate.
 	 *
 	 * @covers ::desktop_mode_posts_window_user_can_use
 	 */
-	public function test_gate_open_by_default_for_admins() {
+	public function test_gate_closed_by_default_until_admin_opts_in() {
 		wp_set_current_user( $this->admin_id );
+		$this->assertFalse( desktop_mode_posts_window_user_can_use() );
+
+		desktop_mode_save_os_settings(
+			$this->admin_id,
+			array( 'nativePostsEnabled' => true )
+		);
 		$this->assertTrue( desktop_mode_posts_window_user_can_use() );
 	}
 

--- a/tests/phpunit/tests/postsWindowSettings.php
+++ b/tests/phpunit/tests/postsWindowSettings.php
@@ -17,19 +17,19 @@
 class Tests_DesktopMode_PostsWindowSettings extends WP_UnitTestCase {
 
 	/**
-	 * As of 0.8.0 the native Posts window is the default — fresh
-	 * installs should land on it, with the legacy iframe available
-	 * as an opt-OUT. This guards against an accidental flip back to
-	 * opt-in semantics.
+	 * As of 0.10.0 the native Posts window is opt-in Beta — fresh
+	 * installs land on the classic iframe and users explicitly turn
+	 * the native window ON. This guards against an accidental flip
+	 * back to opt-out (default ON) semantics.
 	 *
 	 * @covers ::desktop_mode_default_os_settings
 	 */
 	public function test_default_includes_native_posts_enabled() {
 		$defaults = desktop_mode_default_os_settings();
 		$this->assertArrayHasKey( 'nativePostsEnabled', $defaults );
-		$this->assertTrue(
+		$this->assertFalse(
 			$defaults['nativePostsEnabled'],
-			'`nativePostsEnabled` defaults ON: the native Posts window is the canonical Desktop Mode experience; users explicitly toggle it OFF to fall back to the classic iframe.'
+			'`nativePostsEnabled` defaults OFF: the native Posts window is opt-in Beta; users explicitly toggle it ON to replace the classic iframe.'
 		);
 	}
 
@@ -85,9 +85,9 @@ class Tests_DesktopMode_PostsWindowSettings extends WP_UnitTestCase {
 		$clean = desktop_mode_sanitize_os_settings(
 			array( 'wallpaper' => 'dark' )
 		);
-		$this->assertTrue(
+		$this->assertFalse(
 			$clean['nativePostsEnabled'],
-			'Missing field should fall back to the default — opt-OUT means the default is ON.'
+			'Missing field should fall back to the default — opt-in Beta means the default is OFF.'
 		);
 	}
 


### PR DESCRIPTION
## Why

Users told us they didn't like the redesigned **Posts, Pages, Comments, and Plugins** windows being forced on them. Today these native windows (plus the native **Users** window) are **opt-out**: they default ON and a user has to dig into OS Settings → Features to fall back to the classic admin screens.

This PR flips them to **opt-in Beta** — default OFF, surfaced under a clearly labelled **"Beta features"** group — so the redesigned experience is a deliberate choice rather than something imposed.

## What changed

### 1. Defaults flipped `true` → `false`
The five per-user flags now default off, in lockstep across the server snapshot and the TS fallback:

| Flag | Before | After |
|---|---|---|
| `nativePostsEnabled` | `true` | `false` |
| `nativePagesEnabled` | `true` | `false` |
| `nativeUsersEnabled` | `true` | `false` |
| `nativePluginsEnabled` | `true` | `false` |
| `nativeCommentsEnabled` | `true` | `false` |

- `includes/os-settings.php` — `desktop_mode_default_os_settings()` (server snapshot / user-meta default).
- `src/settings/constants.ts` — `DEFAULTS` (pre-hydration / localStorage fallback).

No runtime remap logic changed: each native window already gates on `snapshot.native*Enabled === true` and falls back to the chromeless iframe, so flipping the defaults is enough to route fresh/opted-out users to the classic screens.

### 2. One-time migration resets existing users to opt-in
The shell persists the *whole* OS-settings object on every change, so most active users already have these flags saved as `true` and would otherwise keep the native UI even after the default flip. A guarded, option-versioned migration clears the five flags so the **whole install reverts to opt-in**:

- New `includes/migrations.php` — an option-versioned runner (`desktop_mode_migration_version`) on `admin_init`, modeled on the existing files-schema installer in `includes/desktop-files/schema.php`.
- Queries only users who actually have the OS-settings meta (indexed `meta_key` EXISTS), unsets the five flags, and re-saves through `desktop_mode_save_os_settings()` so the rest of each user's settings (wallpaper, accent, dock order, …) is untouched and the cleared flags backfill to the new `false` default.
- Idempotent + guarded: stamps the high-water mark on completion and never re-runs, so a user who re-opts-in afterwards keeps their choice.

> **Note:** there is intentionally **no** activation-hook short-circuit. Stamping the option on activation would skip the migration on a deactivate/reactivate upgrade path. The scan is cheap (one indexed query, guarded to run once), so it just runs on the first admin load.

### 3. "Beta features" section in OS Settings → Features
`src/settings/sections/features.ts` now renders the five native-window toggles in a dedicated `<wpd-section heading="Beta features">` group above the general Features controls, with opt-in copy ("Beta — off by default. Turn on to…"). The AI-scoring toggle and the other behaviors (show-desktop, status ribbons, folder sharing, heartbeat, reset intros) stay in the main Features section.

### 4. Tests
- Updated the default/gate assertions that encoded the old opt-out behavior in `postsWindowSettings.php`, `postsWindowRegistration.php`, and `pluginsWindowRegistration.php` (e.g. `test_gate_closed_by_default_until_admin_opts_in`, `*_defaults_off`).
- Added `tests/phpunit/tests/osSettingsMigration.php`:
  - clears the five flags while preserving unrelated settings,
  - skips users with no meta,
  - is guarded and does not re-run / clobber a post-migration re-opt-in.

### 5. Docs + version
- `docs/hooks-reference.md` and `docs/examples/native-posts.md` updated from opt-out / default `true` to opt-in Beta / default `false`.
- Version bumped to **0.10.0** in `desktop-mode.php`, `package.json`, `readme.txt` (+ changelog entry).

## Behavior after merge

- **Fresh installs:** all five windows off — users get the classic admin screens until they opt in.
- **Existing users:** reset to opt-in on the next admin load; the redesigned windows are re-enabled per-feature from **OS Settings → Features → Beta features**. Each toggle takes effect immediately, no reload.
- **Users who re-opt-in** keep their choice across subsequent loads — the migration does not run twice.

## Testing

- `npm run build` / `npm run lint` / `npm run typecheck` — clean.
- `npm run test:js` — **1519 passed**.
- PHPUnit full suite — **904 tests / 2131 assertions**, all green except one pre-existing, network-dependent test (`wp_update_plugins()` reaching WordPress.org from an offline container — untouched by this change).

### Manual QA
1. As a user with the native windows currently on, confirm Posts/Pages/Comments/Plugins/Users open as native windows.
2. Reload wp-admin once (fires the `admin_init` migration).
3. The five dock tiles now open the **classic chromeless iframe**.
4. OS Settings → Features shows the **Beta features** group with all five toggles OFF; enabling one routes that tile to the native window immediately (no reload), disabling returns to the iframe.
5. Confirm unrelated settings (wallpaper, accent, dock order) survived the migration.
6. Reload again — migration doesn't re-run, and any toggle turned back on stays on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-297-7bd4011c7a44254c7f9a3baeebd13af79adae661.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->