### PR TITLE
Feat/unfocus window effects

### DIFF
--- a/assets/css/effects.css
+++ b/assets/css/effects.css
@@ -1,0 +1,37 @@
+/**
+ * Desktop Mode — Window effects.
+ *
+ * Visual treatments applied to windows by the unfocus-effect engine
+ * (`src/effects/unfocus-engine.ts`). The engine toggles a per-effect
+ * class on the window root (`.desktop-mode-window`) while the window
+ * is NOT focused; each effect ships the matching rule here (or, for
+ * plugin effects, in the plugin's own stylesheet).
+ *
+ * The fade is driven by the `filter` entry in the shared
+ * `.desktop-mode-window` transition (see `window-chrome.css`), so
+ * effects that animate via `filter` get a smooth two-way transition as
+ * focus moves between windows — and collapse to instant under
+ * `prefers-reduced-motion` along with every other window transition.
+ *
+ * Loaded as an @import from `windows.css` so it ships under the single
+ * `desktop-mode-windows` style handle.
+ *
+ * @since 0.26.0
+ */
+
+/*
+ * Built-in `darken` effect. Dims unfocused windows — title bar and
+ * body alike — so the focused window reads as the active surface.
+ * Exposed as custom properties so a theme or plugin can re-tune the
+ * intensity without overriding the whole rule.
+ */
+.desktop-mode-window {
+	--desktop-mode-fx-darken-brightness: 0.82;
+	--desktop-mode-fx-darken-saturate: 0.92;
+}
+
+.desktop-mode-window--fx-darken {
+	filter:
+		brightness( var( --desktop-mode-fx-darken-brightness, 0.82 ) )
+		saturate( var( --desktop-mode-fx-darken-saturate, 0.92 ) );
+}

--- a/assets/css/effects.css
+++ b/assets/css/effects.css
@@ -20,18 +20,68 @@
  */
 
 /*
- * Built-in `darken` effect. Dims unfocused windows — title bar and
- * body alike — so the focused window reads as the active surface.
- * Exposed as custom properties so a theme or plugin can re-tune the
- * intensity without overriding the whole rule.
+ * Built-in effect tuning knobs. Every shipped effect is driven by
+ * custom properties so a theme or plugin can re-tune the intensity
+ * without overriding the whole rule (and so the values read as a set).
  */
 .desktop-mode-window {
+	/* How long an effect takes to ramp in/out as focus moves between
+	 * windows. Drives the `filter` entry of the shared window
+	 * transition (see `window-chrome.css`); applies to every
+	 * filter-based effect (darken, frost, grayscale) in BOTH
+	 * directions — losing focus and regaining it. Bump it up for a
+	 * slower, dreamier blur; drop it for a snappier feel. Collapses to
+	 * instant under `prefers-reduced-motion`. */
+	--desktop-mode-fx-transition-duration: 0.5s;
+
+	/* darken — dim + slight desaturate */
 	--desktop-mode-fx-darken-brightness: 0.82;
 	--desktop-mode-fx-darken-saturate: 0.92;
+
+	/* frost — frosted-glass blur, lifted + cooled */
+	--desktop-mode-fx-frost-blur: 3px;
+	--desktop-mode-fx-frost-saturate: 0.7;
+	--desktop-mode-fx-frost-brightness: 1.08;
+
+	/* grayscale — drain colour, settle brightness */
+	--desktop-mode-fx-grayscale-amount: 1;
+	--desktop-mode-fx-grayscale-brightness: 0.95;
 }
 
+/*
+ * `darken` — dims unfocused windows (title bar and body alike) so the
+ * focused window reads as the active surface.
+ */
 .desktop-mode-window--fx-darken {
 	filter:
 		brightness( var( --desktop-mode-fx-darken-brightness, 0.82 ) )
 		saturate( var( --desktop-mode-fx-darken-saturate, 0.92 ) );
+}
+
+/*
+ * `frost` — throws the window literally out of focus. Blur is the
+ * universal "not in focus" cue; lifting the brightness and pulling the
+ * saturation down turns it into a pane of cold, frosted glass between
+ * the user and the content. `filter: blur()` rasterizes the whole
+ * window subtree — iframe content included — so the frosting is total,
+ * not just chrome-deep.
+ */
+.desktop-mode-window--fx-frost {
+	filter:
+		blur( var( --desktop-mode-fx-frost-blur, 3px ) )
+		saturate( var( --desktop-mode-fx-frost-saturate, 0.7 ) )
+		brightness( var( --desktop-mode-fx-frost-brightness, 1.08 ) );
+}
+
+/*
+ * `grayscale` — drains the colour from unfocused windows so the focused
+ * one is the only thing still in colour. The eye is drawn to colour, so
+ * this makes the active window pop without dimming anything into the
+ * dark. A touch of brightness settling keeps the mono windows from
+ * glaring.
+ */
+.desktop-mode-window--fx-grayscale {
+	filter:
+		grayscale( var( --desktop-mode-fx-grayscale-amount, 1 ) )
+		brightness( var( --desktop-mode-fx-grayscale-brightness, 0.95 ) );
 }

--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -51,10 +51,12 @@
 		transform 0.2s ease,
 		opacity 0.2s ease,
 		box-shadow 0.2s ease,
-		/* Unfocus effects (e.g. `--fx-darken`) toggle `filter`; keep it
-		 * in the shared transition list so the treatment fades both
-		 * ways as focus moves between windows. */
-		filter 0.2s ease;
+		/* Unfocus effects (e.g. `--fx-darken` / `--fx-frost`) toggle
+		 * `filter`; keep it in the shared transition list so the
+		 * treatment fades both ways as focus moves between windows.
+		 * Duration is a custom property (default in `effects.css`) so
+		 * the blur/darken ramp can be tuned without editing this list. */
+		filter var( --desktop-mode-fx-transition-duration, 0.5s ) ease-in-out;
 }
 
 /*

--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -50,7 +50,11 @@
 		border-radius 0.25s ease,
 		transform 0.2s ease,
 		opacity 0.2s ease,
-		box-shadow 0.2s ease;
+		box-shadow 0.2s ease,
+		/* Unfocus effects (e.g. `--fx-darken`) toggle `filter`; keep it
+		 * in the shared transition list so the treatment fades both
+		 * ways as focus moves between windows. */
+		filter 0.2s ease;
 }
 
 /*

--- a/assets/css/windows.css
+++ b/assets/css/windows.css
@@ -31,6 +31,7 @@
 @import url( "window-states.css" );
 @import url( "window-overview.css" );
 @import url( "os-settings.css" );
+@import url( "effects.css" );
 
 /*
  * Cross-window drag drop highlight — kept INLINE in this file

--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -67,6 +67,7 @@ require_once DESKTOP_MODE_DIR . 'includes/commands.php';
 require_once DESKTOP_MODE_DIR . 'includes/settings-tabs.php';
 require_once DESKTOP_MODE_DIR . 'includes/dock-rail-renderer.php';
 require_once DESKTOP_MODE_DIR . 'includes/title-bar-buttons.php';
+require_once DESKTOP_MODE_DIR . 'includes/unfocus-effects.php';
 require_once DESKTOP_MODE_DIR . 'includes/window-chrome.php';
 require_once DESKTOP_MODE_DIR . 'includes/window-notices.php';
 require_once DESKTOP_MODE_DIR . 'includes/wallpapers.php';

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -97,6 +97,9 @@ The full surface is documented in [`javascript-reference.md`](./javascript-refer
 |---|---|---|
 | `registerTitleBarButton` | `( def: TitleBarButtonDef ) => void` | Stable *(0.17.0)* |
 | `unregisterTitleBarButton` | `( id: string ) => void` | Stable *(0.17.0)* |
+| `registerUnfocusEffect` | `( def: UnfocusEffectDef ) => void` | Experimental *(0.26.0)* |
+| `unregisterUnfocusEffect` | `( id: string ) => void` | Experimental *(0.26.0)* |
+| `listUnfocusEffects` | `() => UnfocusEffectDef[]` | Experimental *(0.26.0)* |
 | `registerWindowTheme` | `( def: WindowThemeDef ) => void` | Stable *(0.6.0)* |
 | `registerWindowControl` | `( def: WindowControlDef ) => void` | Stable *(0.6.0)* |
 | `registerWindowSlot` | `( def: WindowSlotDef ) => void` | Stable *(0.6.0)* |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,7 @@ Robustness guarantees:
 Persistence:
 
 - `dockRailRenderer` lives on `OsSettingsState` (REST-synced to user meta via `/wp-json/desktop-mode/v1/os-settings`). The field takes any `sanitize_key()`-clean string; the JS-side registry resolves at use time and falls back to `'default'` when the named renderer is missing (plugin deactivated, typo). No server-side allow-list — renderers register from JS at runtime.
+- `unfocusEffect` lives on `OsSettingsState` the same way (default `'darken'`, `'none'` disables). The value is an unfocus-effect registry id or `'none'`; it is lower-cased and stripped to `[a-z0-9_/-]` server-side (slashes preserved so `vendor/sub-id` round-trips — unlike `sanitize_key()`). The engine resolves it at use time and treats an unknown id as "no effect". Plugin effects register from JS at runtime; PHP opt-in via `desktop_mode_register_unfocus_effect_script()` adds the `serverUnfocusEffectScripts` payload entry so a plugin's effect surfaces in OS Settings → Effects without an F5.
 
 See [`docs/dock-customization.md`](./dock-customization.md) for the plugin-author overview and [`docs/examples/`](./examples/README.md) for full walk-throughs.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -25,6 +25,7 @@ defined( 'ABSPATH' ) || exit;
 - [Window controls — reorder / hide / replace close-min-max](./window-controls.md)
 - [Window slots — replace icon, title, banners above/below the title bar](./window-slot.md)
 - [Custom window chrome — full title-bar replacement (Experimental)](./custom-chrome.md)
+- [Register a custom unfocused-window effect (Experimental)](./custom-unfocus-effect.md)
 - [Inject data into `desktopModeConfig`](./inject-shell-config.md)
 - [Register a wallpaper (CSS + canvas)](./register-wallpaper.md)
 - [Register a desktop icon (Jorvy)](./register-icon.md)

--- a/docs/examples/custom-unfocus-effect.md
+++ b/docs/examples/custom-unfocus-effect.md
@@ -1,0 +1,116 @@
+# Register a custom unfocused-window effect
+
+An **unfocus effect** is a visual treatment applied to every window
+that isn't the focused one — the family of effects surfaced in
+**OS Settings → Effects → "Unfocused windows"**. The plugin ships one
+built-in, `darken` (it dims unfocused windows), registered through the
+exact same public hook a plugin would use. This page shows a plugin
+adding its own.
+
+**Status:** Experimental since 0.26.0.
+
+## How it works
+
+The framework owns *when* the chosen effect runs — it watches focus
+changes, the user's selection, and excludes minimized windows — and
+toggles your effect on every unfocused window's root element
+(`.desktop-mode-window`). Your def owns *what* the effect is: either a
+CSS class to toggle (the cheap path) or `apply`/`clear` callbacks for
+anything a static class can't express.
+
+The user picks among registered effects (plus a "None" option) in
+OS Settings; the choice persists per-user as the `unfocusEffect`
+setting.
+
+## The declarative path — a CSS class
+
+Ship a stylesheet rule and register an effect that names its class:
+
+```javascript
+wp.desktop.ready( () => {
+    wp.desktop.registerUnfocusEffect( {
+        id:          'acme/blur',
+        label:       'Blur',
+        description: 'Softly blur windows you are not working in.',
+        className:   'acme-window--blur',
+        owner:       'acme-effects', // live-unregister on deactivate
+    } );
+} );
+```
+
+```css
+/* The framework adds this class to unfocused windows while
+ * `acme/blur` is the selected effect, and removes it on focus. */
+.acme-window--blur {
+    filter: blur( 2px );
+}
+```
+
+To get a smooth fade as focus moves, the framework already includes
+`filter` in the shared window transition — so a `filter`-based effect
+animates both ways for free (and collapses to instant under
+`prefers-reduced-motion`). For other properties, add your own
+`transition` to the class.
+
+## The imperative path — apply / clear
+
+When a static class isn't enough (you need to compute per-window
+state, attach a canvas, etc.), provide callbacks instead:
+
+```javascript
+wp.desktop.registerUnfocusEffect( {
+    id:    'acme/grayscale-fade',
+    label: 'Grayscale',
+    apply: ( el ) => {
+        el.style.filter = 'grayscale(1)';
+    },
+    clear: ( el ) => {
+        el.style.filter = '';
+    },
+    owner: 'acme-effects',
+} );
+```
+
+`apply` receives the window root when it becomes unfocused under your
+effect; `clear` must undo whatever `apply` did and is called when the
+window regains focus or the user switches effects. You can provide
+both a `className` and callbacks — the framework removes the class for
+you and also calls `clear`.
+
+## Make it appear live on activation
+
+So a plugin activated mid-session shows up in the selector without a
+page reload, opt the script in from PHP:
+
+```php
+add_action( 'admin_enqueue_scripts', function () {
+    wp_register_script(
+        'acme-effects',
+        plugins_url( 'js/effects.js', __FILE__ ),
+        array( 'desktop-mode' ),
+        '1.0.0',
+        true
+    );
+    wp_enqueue_script( 'acme-effects' );
+} );
+desktop_mode_register_unfocus_effect_script( 'acme-effects' );
+```
+
+The handle you pass here should match the `owner` on your
+`registerUnfocusEffect` calls — that's what lets the framework
+live-unregister your effect when the plugin is deactivated.
+
+## Notes
+
+- **Reserved id.** `'none'` is the selector's "no effect" sentinel and
+  cannot be used as an effect id.
+- **Namespacing.** Ids accept `vendor/sub-id` (`[a-z0-9_/-]+`). The
+  persisted setting preserves the slash, so a namespaced id round-trips
+  cleanly.
+- **Reading the selection.** `wp.desktop.getOsSettings().unfocusEffect`
+  is the active effect id (or `'none'`).
+- **Filter.** The raw `desktop-mode.unfocus-effects` JS filter receives
+  the registry array on every read — reorder, remove, or conditionally
+  swap effects, mirroring `desktop-mode.wallpapers`.
+
+See also: [`registerUnfocusEffect`](../javascript-reference.md#registerunfocuseffect-def--experimental--since-0260) in the JavaScript reference and [`desktop_mode_register_unfocus_effect_script`](../hooks-reference.md#desktop_mode_register_unfocus_effect_script-handle--experimental-php-function-since-0260) in the hooks reference.

--- a/docs/examples/custom-unfocus-effect.md
+++ b/docs/examples/custom-unfocus-effect.md
@@ -2,10 +2,10 @@
 
 An **unfocus effect** is a visual treatment applied to every window
 that isn't the focused one — the family of effects surfaced in
-**OS Settings → Effects → "Unfocused windows"**. The plugin ships one
-built-in, `darken` (it dims unfocused windows), registered through the
-exact same public hook a plugin would use. This page shows a plugin
-adding its own.
+**OS Settings → Effects → "Unfocused windows"**. The plugin ships three
+built-ins — `darken` (dims), `frost` (frosted-glass blur), and
+`grayscale` (drains colour) — each registered through the exact same
+public hook a plugin would use. This page shows a plugin adding its own.
 
 **Status:** Experimental since 0.26.0.
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -437,7 +437,7 @@ desktop_mode_register_unfocus_effect_script( 'my-plugin-effects' );
 
 For live unregistration on deactivation, set `owner: 'my-plugin-effects'` on each `registerUnfocusEffect` call. Untagged effects survive past deactivation until the next page reload — graceful backwards-compat.
 
-The built-in `darken` effect is registered through the same JS hook (`wp.desktop.registerUnfocusEffect`) — there is no PHP for it, since it is pure CSS shipped with the plugin.
+The built-in effects (`darken`, `frost`, `grayscale`) are registered through the same JS hook (`wp.desktop.registerUnfocusEffect`) — there is no PHP for them, since they are pure CSS shipped with the plugin.
 
 ---
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -409,6 +409,38 @@ For live unregistration on deactivation, set `owner: 'my-plugin-titlebar'` on ea
 
 ---
 
+### `desktop_mode_unfocus_effect_script_registered` — Experimental (since 0.26.0)
+
+Fires after `desktop_mode_register_unfocus_effect_script()` stores an unfocus-effect script handle.
+
+```php
+do_action( 'desktop_mode_unfocus_effect_script_registered', string $handle );
+```
+
+### `desktop_mode_register_unfocus_effect_script( $handle )` — Experimental (PHP function, since 0.26.0)
+
+Declares a WP-registered script handle as an unfocused-window-effect provider. The shell injects the resolved URL on plugin activation so `wp.desktop.registerUnfocusEffect()` calls made by the plugin's JS surface in **OS Settings → Effects** (and apply to unfocused windows) **without a page reload**.
+
+```php
+add_action( 'admin_enqueue_scripts', function () {
+    wp_register_script(
+        'my-plugin-effects',
+        plugins_url( 'js/effects.js', __FILE__ ),
+        array( 'desktop-mode' ),
+        '1.0.0',
+        true
+    );
+    wp_enqueue_script( 'my-plugin-effects' );
+} );
+desktop_mode_register_unfocus_effect_script( 'my-plugin-effects' );
+```
+
+For live unregistration on deactivation, set `owner: 'my-plugin-effects'` on each `registerUnfocusEffect` call. Untagged effects survive past deactivation until the next page reload — graceful backwards-compat.
+
+The built-in `darken` effect is registered through the same JS hook (`wp.desktop.registerUnfocusEffect`) — there is no PHP for it, since it is pure CSS shipped with the plugin.
+
+---
+
 ### `desktop_mode_settings_tab_script_registered` — Stable *(since 0.17.0)*
 
 Fires after `desktop_mode_register_settings_tab_script()` stores an OS Settings tab script handle. Also fires when `desktop_mode_register_settings_tab()` implicitly registers its `script` argument.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1903,6 +1903,51 @@ desktop_mode_register_titlebar_button_script( 'my-plugin-titlebar' );
 
 ---
 
+### `registerUnfocusEffect( def )` — Experimental  *(since 0.26.0)*
+
+Register a visual treatment applied to every window that **isn't** focused — surfaced in **OS Settings → Effects → "Unfocused windows"**. The built-in `darken` effect is registered through this same hook; plugins add their own the identical way. The framework owns *when* the effect runs (focus changes, the user's selection, minimized-window exclusion); your def owns *what* it does.
+
+**Throws** a `RegistrationError` on validation failure (bad/missing `id`, the reserved id `'none'`, or neither `className` nor `apply` provided).
+
+**`UnfocusEffectDef`:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `string` | Unique. `[a-z0-9_/-]+` (slashes welcome for `vendor/sub-id`). `'none'` is reserved (it is the selector's "no effect" sentinel). Re-registering replaces. |
+| `label` | `string` | Shown in the selector. |
+| `description` | `string` | Optional. Shown under the selector when this effect is active. |
+| `className` | `string` | Optional. CSS class toggled on the window root (`.desktop-mode-window`) while unfocused. The cheap, declarative path — ship the matching rule in your stylesheet. |
+| `apply` | `( el ) => void` | Optional. Imperative apply, called with the window root when it becomes unfocused under this effect. Use when a static class isn't enough. |
+| `clear` | `( el ) => void` | Optional. Teardown, called when the window regains focus or the effect is switched away. Must undo `apply`; the framework removes `className` for you. |
+| `owner` | `string` | Optional. Set to your script handle for live-unregister-on-deactivate. |
+
+At least one of `className` / `apply` is required.
+
+```javascript
+wp.desktop.ready( () => {
+    wp.desktop.registerUnfocusEffect( {
+        id:        'acme/blur',
+        label:     'Blur',
+        className: 'acme-window--blur', // ship `.acme-window--blur { filter: blur(2px); }`
+        owner:     'my-plugin-effects',
+    } );
+} );
+```
+
+PHP companion (so plugins activated mid-session surface in the selector live):
+
+```php
+desktop_mode_register_unfocus_effect_script( 'my-plugin-effects' );
+```
+
+The raw `desktop-mode.unfocus-effects` JS filter receives the registry array on every read, mirroring `desktop-mode.wallpapers` — use it to reorder, remove, or conditionally swap effects. The user's selection persists in the `unfocusEffect` OS-settings key (effect id or `'none'`; default `'darken'`), readable via `getOsSettings().unfocusEffect`.
+
+### `unregisterUnfocusEffect( id )` / `listUnfocusEffects()` — Experimental  *(since 0.26.0)*
+
+Remove an effect by id, or read the current list (post-filter). `listUnfocusEffects()` always includes the built-in `darken` unless a filter removed it.
+
+---
+
 ### `Window.setTitle( title )` — Stable
 
 Update a window's title bar from outside it. Useful for plugins that want to retitle a preview window as the user types ("Live Preview — My Post"), prefix with status, etc. Fires `desktop-mode.window.title-changed` with `{ windowId, title }` so other subscribers can react.
@@ -2167,7 +2212,7 @@ Register a tab in the OS Settings window. The tab is appended (or sorted-in by `
 | Field | Type | Notes |
 |---|---|---|
 | `isAdmin` | `boolean` | `true` when current user has `manage_options`. |
-| `getOsSettings()` | `function` | Snapshot of the persisted OS Settings state — `{ wallpaper, accent, dockSize, ai: { enabled, provider, apiKey, transport } }`. `transport` is `'sse' \| 'off'` (default `'off'`) — the user's preferred live-progress transport for AI search; SSE is opt-in because some hosts block long-lived `text/event-stream` connections. Read-only; returns a defensive copy. Equivalent to what the built-in AI tab sees. |
+| `getOsSettings()` | `function` | Snapshot of the persisted OS Settings state — `{ wallpaper, accent, dockSize, unfocusEffect, ai: { enabled, provider, apiKey, transport } }`. `unfocusEffect` is the active unfocused-window effect id (`'darken'` default, `'none'` disables). `transport` is `'sse' \| 'off'` (default `'off'`) — the user's preferred live-progress transport for AI search; SSE is opt-in because some hosts block long-lived `text/event-stream` connections. Read-only; returns a defensive copy. Equivalent to what the built-in AI tab sees. |
 | `subscribeOsSettings( cb )` | `function` | Subscribe to in-panel OS Settings changes (user edits the AI key in the adjacent AI tab, etc.). Returns an unsubscribe function. Fires on local edits only — cross-device changes arrive on the next page load. |
 
 ```javascript

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1905,7 +1905,7 @@ desktop_mode_register_titlebar_button_script( 'my-plugin-titlebar' );
 
 ### `registerUnfocusEffect( def )` — Experimental  *(since 0.26.0)*
 
-Register a visual treatment applied to every window that **isn't** focused — surfaced in **OS Settings → Effects → "Unfocused windows"**. The built-in `darken` effect is registered through this same hook; plugins add their own the identical way. The framework owns *when* the effect runs (focus changes, the user's selection, minimized-window exclusion); your def owns *what* it does.
+Register a visual treatment applied to every window that **isn't** focused — surfaced in **OS Settings → Effects → "Unfocused windows"**. The built-in effects (`darken` dims, `frost` blurs to frosted glass, `grayscale` drains colour) are registered through this same hook; plugins add their own the identical way. The framework owns *when* the effect runs (focus changes, the user's selection, minimized-window exclusion); your def owns *what* it does.
 
 **Throws** a `RegistrationError` on validation failure (bad/missing `id`, the reserved id `'none'`, or neither `className` nor `apply` provided).
 
@@ -1922,6 +1922,8 @@ Register a visual treatment applied to every window that **isn't** focused — s
 | `owner` | `string` | Optional. Set to your script handle for live-unregister-on-deactivate. |
 
 At least one of `className` / `apply` is required.
+
+> **Windows hosting a WebGL `<canvas>` are exempt.** Native Pixi scenes (content graph, posts mind-map / tag-cloud, the About scene) render a live WebGL canvas in the parent DOM; a CSS `filter` over such an element can trigger a GPU context loss that crashes the canvas's render loop. The engine detects a `<canvas>` in the window root and skips the effect for that window. Canvases inside *iframe* windows live in a separate document and aren't affected.
 
 ```javascript
 wp.desktop.ready( () => {
@@ -1944,7 +1946,7 @@ The raw `desktop-mode.unfocus-effects` JS filter receives the registry array on 
 
 ### `unregisterUnfocusEffect( id )` / `listUnfocusEffects()` — Experimental  *(since 0.26.0)*
 
-Remove an effect by id, or read the current list (post-filter). `listUnfocusEffects()` always includes the built-in `darken` unless a filter removed it.
+Remove an effect by id, or read the current list (post-filter). `listUnfocusEffects()` always includes the built-ins (`darken`, `frost`, `grayscale`) unless a filter removed them.
 
 ---
 

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1159,6 +1159,9 @@ function desktop_mode_build_menu_payload() {
 		'serverTitleBarButtonScripts' => function_exists( 'desktop_mode_build_desktop_titlebar_button_scripts_payload' )
 			? desktop_mode_build_desktop_titlebar_button_scripts_payload()
 			: array(),
+		'serverUnfocusEffectScripts' => function_exists( 'desktop_mode_build_desktop_unfocus_effect_scripts_payload' )
+			? desktop_mode_build_desktop_unfocus_effect_scripts_payload()
+			: array(),
 		'serverWindowThemeScripts'  => function_exists( 'desktop_mode_build_window_theme_scripts_payload' )
 			? desktop_mode_build_window_theme_scripts_payload()
 			: array(),
@@ -1449,6 +1452,9 @@ function desktop_mode_flush_script_handle_registries() {
 	}
 	if ( function_exists( 'desktop_mode_flush_desktop_titlebar_button_script_registry' ) ) {
 		desktop_mode_flush_desktop_titlebar_button_script_registry();
+	}
+	if ( function_exists( 'desktop_mode_flush_desktop_unfocus_effect_script_registry' ) ) {
+		desktop_mode_flush_desktop_unfocus_effect_script_registry();
 	}
 	if ( function_exists( 'desktop_mode_flush_window_theme_script_registry' ) ) {
 		desktop_mode_flush_window_theme_script_registry();

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -65,6 +65,7 @@ function desktop_mode_default_os_settings() {
 		'dockSize'                    => 'default',
 		'desktopLayout'               => 'classic',
 		'dockRailRenderer'            => 'default',
+		'unfocusEffect'               => 'darken',
 		'customGradient'              => array(
 			'from'  => '#2271b1',
 			'to'    => '#7c3aed',
@@ -263,6 +264,21 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		$slug = sanitize_key( $raw['dockRailRenderer'] );
 		if ( '' !== $slug ) {
 			$dock_rail_renderer = $slug;
+		}
+	}
+
+	// Unfocus effect id — accept the `none` sentinel or any registry id.
+	// Effect ids mirror the JS registry pattern `^[a-z0-9_/-]+$` (slashes
+	// allowed for `vendor/sub-id` namespacing), so we lower-case and strip
+	// to that charset rather than using sanitize_key() (which would drop
+	// the slash and break a namespaced id on round-trip). No allow-list:
+	// the JS engine resolves at use time and treats an unknown id as "no
+	// effect".
+	$unfocus_effect = $defaults['unfocusEffect'];
+	if ( isset( $raw['unfocusEffect'] ) && is_string( $raw['unfocusEffect'] ) ) {
+		$slug = preg_replace( '/[^a-z0-9_\/-]/', '', strtolower( $raw['unfocusEffect'] ) );
+		if ( '' !== $slug ) {
+			$unfocus_effect = $slug;
 		}
 	}
 
@@ -515,6 +531,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'dockSize'                    => $dock_size,
 		'desktopLayout'               => $desktop_layout,
 		'dockRailRenderer'            => $dock_rail_renderer,
+		'unfocusEffect'               => $unfocus_effect,
 		'customGradient'              => $custom_gradient,
 		'customImage'                 => $custom_image,
 		'libraryHdOnly'               => $library_hd_only,

--- a/includes/unfocus-effects.php
+++ b/includes/unfocus-effects.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Desktop unfocused-window effect registration API.
+ *
+ * Mirrors the command-script / title-bar-button-script registration
+ * pattern: minimum-ceremony PHP opt-in
+ * (`desktop_mode_register_unfocus_effect_script`) tells the shell which
+ * enqueued scripts contribute unfocus effects. The shell injects the
+ * script URL into the live-refresh payload so a plugin activated
+ * mid-session surfaces its effect in OS Settings → Effects immediately,
+ * no F5 needed.
+ *
+ * Effects themselves are declared JS-side via
+ * `wp.desktop.registerUnfocusEffect( … )` — the CSS class, apply/clear
+ * callbacks, and label all live in the plugin's TypeScript /
+ * JavaScript. The built-in `darken` is registered through the very
+ * same JS hook (see `src/effects/registry.ts`).
+ *
+ * @since 0.26.0
+ * @package WPDesktopMode
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Declare a WP-registered script handle as an unfocus-effect provider.
+ *
+ * Example:
+ *
+ * ```php
+ * add_action( 'admin_enqueue_scripts', function () {
+ *     wp_register_script(
+ *         'my-plugin-effects',
+ *         plugins_url( 'js/effects.js', __FILE__ ),
+ *         array( 'desktop-mode' ),
+ *         '1.0.0',
+ *         true
+ *     );
+ *     wp_enqueue_script( 'my-plugin-effects' );
+ * } );
+ * desktop_mode_register_unfocus_effect_script( 'my-plugin-effects' );
+ * ```
+ *
+ * For live unregistration on deactivation, the plugin's JS should set
+ * `owner: 'my-plugin-effects'` on each `registerUnfocusEffect` call.
+ * Otherwise the effect stays until the next page reload — graceful
+ * backwards-compat.
+ *
+ * @since 0.26.0
+ *
+ * @param string $handle WP-registered script handle.
+ * @return true|WP_Error `true` on success; `WP_Error` on validation failure.
+ */
+function desktop_mode_register_unfocus_effect_script( $handle ) {
+	$handle = (string) $handle;
+	if ( '' === $handle ) {
+		return desktop_mode_registration_error(
+			'desktop_mode_missing_handle',
+			__( 'Unfocus effect script registration requires a non-empty script handle.', 'desktop-mode' )
+		);
+	}
+
+	desktop_mode_desktop_unfocus_effect_script_registry( $handle, true );
+
+	/**
+	 * Fires after a desktop unfocus-effect script handle is registered.
+	 *
+	 * @since 0.26.0
+	 *
+	 * @param string $handle The registered script handle.
+	 */
+	do_action( 'desktop_mode_unfocus_effect_script_registered', $handle );
+
+	return true;
+}
+
+/**
+ * Internal module-level registry for unfocus-effect script handles.
+ *
+ * @since 0.26.0
+ * @internal
+ *
+ * @param string    $handle Script handle to read or write.
+ * @param bool|null $value  Pass `true` to register; `null` to read only.
+ * @return array|bool When called with no args returns the full store.
+ */
+function desktop_mode_desktop_unfocus_effect_script_registry( $handle = '', $value = null ) {
+	static $store = array();
+
+	if ( '__flush__' === (string) $handle ) {
+		$store = array();
+		return array();
+	}
+	if ( '' === (string) $handle ) {
+		return $store;
+	}
+	if ( null !== $value ) {
+		$store[ (string) $handle ] = (bool) $value;
+	}
+	return isset( $store[ (string) $handle ] ) ? $store[ (string) $handle ] : false;
+}
+
+/**
+ * Test-only: clear the registry between PHPUnit cases. See
+ * {@see desktop_mode_flush_script_handle_registries()}.
+ *
+ * @since 0.26.0
+ */
+function desktop_mode_flush_desktop_unfocus_effect_script_registry() {
+	desktop_mode_desktop_unfocus_effect_script_registry( '__flush__' );
+}
+
+/**
+ * Build the script-handle payload fed to the shell. Handles that
+ * aren't currently enqueued resolve to an empty URL and are dropped.
+ *
+ * @since 0.26.0
+ *
+ * @return array[] List of `{ handle, scriptUrl, … }` entries.
+ */
+function desktop_mode_build_desktop_unfocus_effect_scripts_payload() {
+	$registry = desktop_mode_desktop_unfocus_effect_script_registry();
+	if ( ! is_array( $registry ) || empty( $registry ) ) {
+		return array();
+	}
+
+	$out  = array();
+	$seen = array();
+	foreach ( $registry as $handle => $active ) {
+		if ( ! $active || isset( $seen[ $handle ] ) ) {
+			continue;
+		}
+		$payload = desktop_mode_resolve_script_payload( $handle );
+		if ( '' === $payload['url'] ) {
+			// Loud diagnostic — visible under WP_DEBUG. Deduped by
+			// `desktop_mode_warn_unresolvable_script_handle` so the
+			// notice fires once per handle per request.
+			desktop_mode_warn_unresolvable_script_handle(
+				'desktop_mode_register_unfocus_effect_script',
+				'Unfocus effect',
+				(string) $handle
+			);
+			continue;
+		}
+		$out[]           = array(
+			'handle'             => (string) $handle,
+			'scriptUrl'          => $payload['url'],
+			'scriptBefore'       => $payload['before'],
+			'scriptAfter'        => $payload['after'],
+			'scriptL10n'         => $payload['l10n'],
+			'scriptTranslations' => $payload['translations'],
+		);
+		$seen[ $handle ] = true;
+	}
+	return $out;
+}

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -84,6 +84,11 @@ import {
 	unregisterTitleBarButton,
 } from '../title-bar-buttons/registry';
 import {
+	listUnfocusEffects,
+	registerUnfocusEffect,
+	unregisterUnfocusEffect,
+} from '../effects/registry';
+import {
 	listWindowThemes,
 	registerWindowTheme,
 	unregisterWindowTheme,
@@ -181,6 +186,7 @@ export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'isDockElement', 'registerDockSelector',
 	'registerTitleBarButton',
 	'unregisterTitleBarButton', 'listTitleBarButtons',
+	'registerUnfocusEffect', 'unregisterUnfocusEffect', 'listUnfocusEffects',
 	'registerWindowTheme', 'unregisterWindowTheme', 'listWindowThemes',
 	'applyWindowTheme',
 	'registerWindowControl', 'unregisterWindowControl', 'listWindowControls',
@@ -499,6 +505,9 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): WpDesktopPublicApi {
 		registerTitleBarButton,
 		unregisterTitleBarButton,
 		listTitleBarButtons,
+		registerUnfocusEffect,
+		unregisterUnfocusEffect,
+		listUnfocusEffects,
 		registerWindowTheme,
 		unregisterWindowTheme,
 		listWindowThemes,

--- a/src/boot/menu-refresh.ts
+++ b/src/boot/menu-refresh.ts
@@ -34,6 +34,7 @@ import type {
 	DesktopSettingsTabScriptServerEntry,
 	DesktopSettingsTabServerEntry,
 	DesktopTitleBarButtonScriptServerEntry,
+	DesktopUnfocusEffectScriptServerEntry,
 	DesktopWallpaperServerEntry,
 	DesktopWidgetServerEntry,
 	NativeWindowServerEntry,
@@ -66,6 +67,9 @@ export interface MenuRefreshDeps {
 	syncServerTitleBarButtons: (
 		scripts: DesktopTitleBarButtonScriptServerEntry[],
 	) => Promise< void >;
+	syncServerUnfocusEffects: (
+		scripts: DesktopUnfocusEffectScriptServerEntry[],
+	) => Promise< void >;
 	syncServerDockRailRenderers: (
 		scripts: DesktopDockRailRendererScriptServerEntry[],
 	) => Promise< void >;
@@ -92,6 +96,7 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 		syncServerCommands,
 		syncServerSettingsTabs,
 		syncServerTitleBarButtons,
+		syncServerUnfocusEffects,
 		syncServerDockRailRenderers,
 		renderIcons,
 	} = deps;
@@ -106,6 +111,7 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 		syncServerCommands,
 		syncServerSettingsTabs,
 		syncServerTitleBarButtons,
+		syncServerUnfocusEffects,
 		syncServerDockRailRenderers,
 		renderIcons,
 	} );
@@ -127,6 +133,7 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 				serverSettingsTabs?: unknown;
 				serverDockRailRendererScripts?: unknown;
 				serverTitleBarButtonScripts?: unknown;
+				serverUnfocusEffectScripts?: unknown;
 				desktopIcons?: unknown;
 			};
 		} | null;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -62,6 +62,9 @@ import {
 	type TitleBarButtonDef,
 } from './title-bar-buttons/registry';
 import { createTitleBarButtonRegistrySync } from './title-bar-buttons/server-sync';
+import { type UnfocusEffectDef } from './effects/types';
+import { createUnfocusEffectRegistrySync } from './effects/server-sync';
+import { startUnfocusEngine } from './effects/unfocus-engine';
 import { createDockRailRendererSync } from './dock-rail/server-sync';
 import {
 	type WindowThemeDef,
@@ -1122,6 +1125,23 @@ export interface WpDesktopPublicApi {
 	unregisterTitleBarButton: ( id: string ) => void;
 	/** Snapshot of registered title-bar buttons. @since 0.17.0 */
 	listTitleBarButtons: () => TitleBarButtonDef[];
+	/**
+	 * Register (or replace) an unfocused-window effect — a visual
+	 * treatment applied to every window that isn't focused, surfaced in
+	 * OS Settings → Effects. Ship a `className` to toggle (the cheap
+	 * path) and/or `apply`/`clear` callbacks. Set `owner` to the script
+	 * handle for live unregistration on deactivation. The built-in
+	 * `darken` is registered through this same API.
+	 *
+	 * Throws a `RegistrationError` on validation failure.
+	 *
+	 * @since 0.26.0
+	 */
+	registerUnfocusEffect: ( def: UnfocusEffectDef ) => void;
+	/** Remove a previously registered unfocus effect. @since 0.26.0 */
+	unregisterUnfocusEffect: ( id: string ) => void;
+	/** Snapshot of registered unfocus effects (filter applied). @since 0.26.0 */
+	listUnfocusEffects: () => UnfocusEffectDef[];
 	/**
 	 * Register (or replace) a per-window theme — a CSS-variable map
 	 * applied to every matching window's outer element. The shell
@@ -2711,6 +2731,22 @@ function init(): void {
 			: [],
 	);
 
+	// Unfocus-effect sync — same pattern. Loads opted-in scripts so a
+	// plugin's `registerUnfocusEffect()` lands and surfaces in
+	// OS Settings → Effects; deactivation drops effects by `owner` tag.
+	const syncServerUnfocusEffects = createUnfocusEffectRegistrySync();
+	void syncServerUnfocusEffects(
+		Array.isArray( config.serverUnfocusEffectScripts )
+			? config.serverUnfocusEffectScripts
+			: [],
+	);
+
+	// Unfocus-effect engine — applies the user's chosen effect to every
+	// unfocused window and keeps it in sync with focus changes, the
+	// effect registry, and the OS Settings selection. Purely additive:
+	// it only listens to existing window-lifecycle events.
+	startUnfocusEngine( { manager, osSettings } );
+
 	// Dock rail renderer sync — loads plugin renderer scripts on
 	// activation so OS Settings → Dock style surfaces them
 	// without an F5; owner-tagged sweep on deactivation. The
@@ -2972,6 +3008,7 @@ function init(): void {
 		syncServerCommands,
 		syncServerSettingsTabs,
 		syncServerTitleBarButtons,
+		syncServerUnfocusEffects,
 		syncServerDockRailRenderers,
 		renderIcons,
 	} );

--- a/src/effects/registry.ts
+++ b/src/effects/registry.ts
@@ -195,3 +195,21 @@ registerUnfocusEffect( {
 	description: __( 'Dim unfocused windows so the focused one stands out.' ),
 	className: 'desktop-mode-window--fx-darken',
 } );
+
+registerUnfocusEffect( {
+	id: 'frost',
+	label: __( 'Frost' ),
+	description: __(
+		'Throw unfocused windows out of focus — a soft, frosted-glass blur, as if you were looking at them through an iced-over pane.',
+	),
+	className: 'desktop-mode-window--fx-frost',
+} );
+
+registerUnfocusEffect( {
+	id: 'grayscale',
+	label: __( 'Grayscale' ),
+	description: __(
+		'Drain the colour from unfocused windows so the focused one is the only thing still in colour — your eye snaps right to it.',
+	),
+	className: 'desktop-mode-window--fx-grayscale',
+} );

--- a/src/effects/registry.ts
+++ b/src/effects/registry.ts
@@ -1,0 +1,197 @@
+/**
+ * Desktop Mode — Unfocused-window effect registry.
+ *
+ * Owns the in-memory list of available unfocus effects and applies the
+ * `desktop-mode.unfocus-effects` filter each time callers read it, so
+ * plugins can register via `wp.desktop.registerUnfocusEffect()` and
+ * also reach the raw filter for reorder / remove / conditional swap.
+ *
+ * The built-in `darken` is seeded here, through the very same
+ * `register()` the public hook calls — the shipped effect dogfoods the
+ * extensibility API rather than taking a private shortcut.
+ *
+ * Cross-bundle: the seed list AND the subscriber set live in a
+ * `createSharedStore` record so the lazy OS-Settings-panel bundle and
+ * the main shell bundle share a single registry (see AGENTS.md →
+ * "Cross-bundle state"). Without it the panel's selector would iterate
+ * its own empty copy and the engine would never hear about effects the
+ * panel registered.
+ *
+ * @since 0.26.0
+ */
+
+import { applyFilters, HOOKS } from '../hooks';
+import { __ } from '../i18n';
+import { throwOnRegistrationErrors } from '../registration-errors';
+import { createSharedStore } from '../shared-store';
+import type { UnfocusEffectDef } from './types';
+
+type RegistryListener = () => void;
+
+interface UnfocusEffectRegistryStore {
+	registry: Map< string, UnfocusEffectDef >;
+	listeners: Set< RegistryListener >;
+}
+const store = createSharedStore< UnfocusEffectRegistryStore >(
+	'desktop-mode/unfocus-effect-registry',
+	() => ( { registry: new Map(), listeners: new Set() } ),
+);
+const registry = store.state.registry;
+const listeners = store.state.listeners;
+
+/**
+ * Valid effect id: lower-case alphanum, hyphen, underscore, slash —
+ * same shape as the title-bar-button / command registries so plugins
+ * can namespace `vendor/sub-id`. Empty strings rejected.
+ *
+ * @internal
+ */
+const UNFOCUS_EFFECT_ID = /^[a-z0-9_/-]+$/;
+
+/**
+ * Register (or replace) an unfocus effect. Re-registering the same id
+ * replaces the previous entry — mirrors WordPress's `register_*`
+ * semantics where the latest call wins.
+ *
+ * Throws a {@link RegistrationError} on validation failure so plugin
+ * authors get a stack frame at registration time instead of a silently
+ * missing selector entry.
+ *
+ * @param  def Effect definition.
+ * @throws {RegistrationError} when `def` fails validation.
+ */
+export function registerUnfocusEffect( def: UnfocusEffectDef ): void {
+	const errors: string[] = [];
+
+	if ( ! def || typeof def !== 'object' ) {
+		errors.push( 'def (not an object)' );
+	} else {
+		if ( typeof def.id !== 'string' || def.id.trim() === '' ) {
+			errors.push( 'id (missing)' );
+		} else if ( ! UNFOCUS_EFFECT_ID.test( def.id.trim().toLowerCase() ) ) {
+			errors.push(
+				`id (must match ${ UNFOCUS_EFFECT_ID } — lowercase alphanum, hyphens, underscores, slashes for vendor/sub-id)`,
+			);
+		} else if ( def.id.trim().toLowerCase() === 'none' ) {
+			// `none` is the engine's reserved "no effect" sentinel — it
+			// is offered in the selector but is never a registered def.
+			errors.push( 'id ("none" is reserved)' );
+		}
+		if ( typeof def.label !== 'string' || def.label.trim() === '' ) {
+			errors.push( 'label (missing)' );
+		}
+		if (
+			typeof def.className !== 'string' &&
+			typeof def.apply !== 'function'
+		) {
+			errors.push(
+				'className|apply (at least one must be provided — a CSS class to toggle or an apply callback)',
+			);
+		}
+	}
+
+	throwOnRegistrationErrors( 'UnfocusEffect', errors, def );
+
+	const id = def.id.trim().toLowerCase();
+	registry.set( id, { ...def, id } );
+	notify();
+}
+
+/** Remove an effect by id. */
+export function unregisterUnfocusEffect( id: string ): void {
+	if ( registry.delete( id.toLowerCase() ) ) {
+		notify();
+	}
+}
+
+/**
+ * Remove every effect registered by a given owner (script handle).
+ * Used by the server-sync module on plugin deactivation. Returns the
+ * number removed.
+ */
+export function unregisterUnfocusEffectsByOwner( owner: string ): number {
+	if ( ! owner ) {
+		return 0;
+	}
+	let removed = 0;
+	for ( const [ id, def ] of Array.from( registry.entries() ) ) {
+		if ( def.owner === owner ) {
+			registry.delete( id );
+			removed++;
+		}
+	}
+	if ( removed > 0 ) {
+		notify();
+	}
+	return removed;
+}
+
+/**
+ * Current effect list with the `desktop-mode.unfocus-effects` filter
+ * applied. The map values are copied so a filter callback can mutate
+ * its input safely; a misbehaving filter that returns a non-array
+ * falls back to the unfiltered list.
+ */
+export function listUnfocusEffects(): UnfocusEffectDef[] {
+	const copy = Array.from( registry.values() );
+	const filtered = applyFilters< UnfocusEffectDef[] >(
+		HOOKS.UNFOCUS_EFFECTS,
+		copy,
+	);
+	if ( ! Array.isArray( filtered ) ) {
+		if ( typeof console !== 'undefined' ) {
+			console.warn(
+				'[desktop-mode] `desktop-mode.unfocus-effects` filter ' +
+					'returned a non-array; falling back to registry list.',
+			);
+		}
+		return copy;
+	}
+	return filtered;
+}
+
+/** Look up an effect by id, post-filter. */
+export function getUnfocusEffect( id: string ): UnfocusEffectDef | undefined {
+	return listUnfocusEffects().find( ( e ) => e.id === id );
+}
+
+/**
+ * Subscribe to registry changes — the OS Settings selector repaints
+ * and the engine recomputes when this fires. Returns an unsubscribe.
+ */
+export function subscribeUnfocusEffects( cb: RegistryListener ): () => void {
+	listeners.add( cb );
+	return () => {
+		listeners.delete( cb );
+	};
+}
+
+function notify(): void {
+	const snapshot = Array.from( listeners );
+	for ( const cb of snapshot ) {
+		try {
+			cb();
+		} catch ( err ) {
+			if ( typeof console !== 'undefined' ) {
+				console.error(
+					'[desktop-mode] unfocus-effect registry listener threw:',
+					err,
+				);
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Built-in effects
+//
+// Seeded through the public `register()` path so the shipped effect is
+// indistinguishable from a plugin's. `register()` replaces by id, so a
+// re-import (the panel bundle also evaluates this module) is idempotent.
+// ---------------------------------------------------------------------------
+registerUnfocusEffect( {
+	id: 'darken',
+	label: __( 'Darken' ),
+	description: __( 'Dim unfocused windows so the focused one stands out.' ),
+	className: 'desktop-mode-window--fx-darken',
+} );

--- a/src/effects/registry.ts
+++ b/src/effects/registry.ts
@@ -28,6 +28,14 @@ import type { UnfocusEffectDef } from './types';
 
 type RegistryListener = () => void;
 
+/**
+ * Reserved effect id meaning "no effect". It is offered in the OS
+ * Settings selector and is the engine's sentinel, but it is never a
+ * registered def — `registerUnfocusEffect` rejects it. Single source
+ * of truth, imported by the engine and the settings section.
+ */
+export const UNFOCUS_EFFECT_NONE = 'none';
+
 interface UnfocusEffectRegistryStore {
 	registry: Map< string, UnfocusEffectDef >;
 	listeners: Set< RegistryListener >;
@@ -72,7 +80,7 @@ export function registerUnfocusEffect( def: UnfocusEffectDef ): void {
 			errors.push(
 				`id (must match ${ UNFOCUS_EFFECT_ID } — lowercase alphanum, hyphens, underscores, slashes for vendor/sub-id)`,
 			);
-		} else if ( def.id.trim().toLowerCase() === 'none' ) {
+		} else if ( def.id.trim().toLowerCase() === UNFOCUS_EFFECT_NONE ) {
 			// `none` is the engine's reserved "no effect" sentinel — it
 			// is offered in the selector but is never a registered def.
 			errors.push( 'id ("none" is reserved)' );

--- a/src/effects/server-sync.ts
+++ b/src/effects/server-sync.ts
@@ -1,0 +1,81 @@
+/**
+ * Server-driven unfocus-effect sync.
+ *
+ * Mirrors `src/title-bar-buttons/server-sync.ts`. Plugins opt in
+ * server-side with `desktop_mode_register_unfocus_effect_script()`;
+ * this module loads each opted-in script on activation, and on
+ * deactivation unregisters every effect whose `owner` matches the
+ * departing handle.
+ *
+ * Effects that don't set `owner` survive past deactivation until the
+ * next page reload — graceful backwards-compat. The OS Settings
+ * selector and the engine react live via the registry's subscribe
+ * fan-out.
+ *
+ * @since 0.26.0
+ */
+
+import { doAction, HOOKS } from '../hooks';
+import { loadVendorScript } from '../wallpapers/vendor-loader';
+import { unregisterUnfocusEffectsByOwner } from './registry';
+import type { DesktopUnfocusEffectScriptServerEntry } from '../types';
+
+export function createUnfocusEffectRegistrySync(): (
+	scripts: DesktopUnfocusEffectScriptServerEntry[],
+) => Promise< void > {
+	const loadedHandles = new Set< string >();
+	const loadedUrls = new Set< string >();
+
+	const ensureScript = async (
+		entry: DesktopUnfocusEffectScriptServerEntry,
+	): Promise< void > => {
+		if ( ! entry.scriptUrl || loadedUrls.has( entry.scriptUrl ) ) {
+			loadedHandles.add( entry.handle );
+			return;
+		}
+		try {
+			await loadVendorScript( entry.scriptUrl, {
+				translations: entry.scriptTranslations,
+				l10n: entry.scriptL10n,
+				before: entry.scriptBefore,
+				after: entry.scriptAfter,
+			} );
+		} catch ( err ) {
+			doAction( HOOKS.SHELL_ERROR, {
+				scope: 'unfocus-effect-script-load',
+				handle: entry.handle,
+				url: entry.scriptUrl,
+				error: err,
+			} );
+			return;
+		}
+		loadedUrls.add( entry.scriptUrl );
+		loadedHandles.add( entry.handle );
+	};
+
+	return async ( scripts ) => {
+		const incomingHandles = new Set< string >();
+		for ( const entry of scripts ) {
+			if ( entry.handle ) {
+				incomingHandles.add( entry.handle );
+			}
+		}
+
+		// Deactivation — drop effects owned by departing handles.
+		for ( const handle of Array.from( loadedHandles ) ) {
+			if ( incomingHandles.has( handle ) ) {
+				continue;
+			}
+			unregisterUnfocusEffectsByOwner( handle );
+			loadedHandles.delete( handle );
+		}
+
+		// Activation — inject any newly-arrived scripts.
+		for ( const entry of scripts ) {
+			if ( ! entry.handle || loadedHandles.has( entry.handle ) ) {
+				continue;
+			}
+			await ensureScript( entry );
+		}
+	};
+}

--- a/src/effects/types.ts
+++ b/src/effects/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Desktop Mode — Unfocused-window effect types.
+ *
+ * An "unfocus effect" is a visual treatment applied to every window
+ * that is NOT the focused one — the first of a growing family of
+ * desktop effects surfaced in OS Settings → Effects. The built-in
+ * `darken` dims unfocused windows; plugins register their own through
+ * the same public hook (`wp.desktop.registerUnfocusEffect`).
+ *
+ * An effect is intentionally tiny: it either toggles a CSS class on
+ * the window root (the cheap, declarative path the built-in uses) or
+ * runs `apply` / `clear` callbacks for effects that need to touch the
+ * DOM directly. The engine (`unfocus-engine.ts`) owns *when* an effect
+ * is applied; the def owns *what* it does.
+ *
+ * @since 0.26.0
+ */
+
+export interface UnfocusEffectDef {
+	/**
+	 * Unique id matching `/^[a-z0-9_/-]+$/` — lower-case alphanum plus
+	 * hyphen, underscore, and slash so plugins can namespace
+	 * `vendor/sub-id`, the same convention every other JS registry
+	 * uses (`registerCommand`, `registerTitleBarButton`, …).
+	 */
+	id: string;
+	/** Human-readable label shown in the OS Settings selector. */
+	label: string;
+	/** Optional one-line description shown under the selector. */
+	description?: string;
+	/**
+	 * CSS class toggled on the window root (`.desktop-mode-window`)
+	 * while the window is unfocused. The declarative path — ship the
+	 * matching rule in your stylesheet. The built-in `darken` uses
+	 * `desktop-mode-window--fx-darken`.
+	 */
+	className?: string;
+	/**
+	 * Imperative apply hook, called with the window root element when
+	 * the window becomes (or starts) unfocused under this effect. Use
+	 * for effects that can't be expressed as a single static class.
+	 */
+	apply?: ( el: HTMLElement ) => void;
+	/**
+	 * Imperative teardown, called with the window root element when the
+	 * window regains focus or the effect is switched away. Must undo
+	 * whatever `apply` did. The engine removes `className` for you.
+	 */
+	clear?: ( el: HTMLElement ) => void;
+	/**
+	 * Owner tag — the WordPress script handle that registered the
+	 * effect. Set this when plugin deactivation should live-unregister
+	 * the effect (mirrors commands / settings tabs / title-bar
+	 * buttons). Effects without an owner survive until the next reload.
+	 */
+	owner?: string;
+}

--- a/src/effects/unfocus-engine.ts
+++ b/src/effects/unfocus-engine.ts
@@ -18,16 +18,38 @@
  * @since 0.26.0
  */
 
-import { getUnfocusEffect, listUnfocusEffects, subscribeUnfocusEffects } from './registry';
+import {
+	getUnfocusEffect,
+	listUnfocusEffects,
+	subscribeUnfocusEffects,
+	UNFOCUS_EFFECT_NONE,
+} from './registry';
 import type { UnfocusEffectDef } from './types';
 import type { OsSettings } from '../settings';
 import type { WindowManager } from '../window-manager';
 
-/** The reserved id that means "no effect". Never a registered def. */
-const NONE = 'none';
-
 /** Data attribute stamped on a window root carrying the active effect id. */
 const EFFECT_ATTR = 'data-desktop-unfocus-effect';
+
+/**
+ * Data attribute stamped with the exact CSS class an effect applied.
+ * Persisting the class (not just the effect id) means `clear()` can
+ * always remove it — even after the effect's def has been unregistered
+ * (plugin deactivation), when the registry can no longer tell us which
+ * class an id used.
+ */
+const EFFECT_CLASS_ATTR = 'data-desktop-unfocus-effect-class';
+
+/**
+ * Module-level once-guard. The engine wires `document` event listeners
+ * that — unlike registry subscribers held in a Set — can't be cheaply
+ * deduped or inspected after the fact, so a double `startUnfocusEngine`
+ * (HMR, a future refactor, test bleed) would silently double every
+ * `recompute`. The engine is only imported by the main shell bundle,
+ * so a plain module-level flag is sufficient; `vi.resetModules()`
+ * resets it between tests.
+ */
+let _started = false;
 
 /**
  * True when the window root contains a `<canvas>` in the parent
@@ -54,22 +76,40 @@ export interface UnfocusEngineDeps {
  * navigation, which discards the listeners with it).
  */
 export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps ): void {
+	if ( _started ) {
+		return;
+	}
+	_started = true;
+
 	let currentId = osSettings.getOsSettingsSnapshot().unfocusEffect;
 
-	/** Strip every effect marker we might have set from a window root. */
-	const clear = ( el: HTMLElement ): void => {
-		// Remove the class for whatever effect the element currently
-		// carries (read from the data attr) even if that def has since
-		// been unregistered, plus defensively sweep all known classes.
+	/**
+	 * Strip every effect marker we might have set from a window root.
+	 *
+	 * @param el         Window root.
+	 * @param allEffects Snapshot of registered effects, hoisted out of
+	 *                   the per-window loop so the `applyFilters` behind
+	 *                   `listUnfocusEffects()` runs once per recompute,
+	 *                   not once per window.
+	 */
+	const clear = ( el: HTMLElement, allEffects: UnfocusEffectDef[] ): void => {
+		// Remove the exact class we applied — read from the dedicated
+		// attribute so it works even after the effect's def has been
+		// unregistered (the registry can no longer map the id → class).
+		const storedClass = el.getAttribute( EFFECT_CLASS_ATTR );
+		if ( storedClass ) {
+			el.classList.remove( storedClass );
+			el.removeAttribute( EFFECT_CLASS_ATTR );
+		}
+		// Run the effect's own teardown if it's still registered.
 		const priorId = el.getAttribute( EFFECT_ATTR );
 		if ( priorId ) {
-			const prior = getUnfocusEffect( priorId );
-			if ( prior?.className ) {
-				el.classList.remove( prior.className );
-			}
-			prior?.clear?.( el );
+			getUnfocusEffect( priorId )?.clear?.( el );
 		}
-		for ( const def of listUnfocusEffects() ) {
+		// Defensive sweep across still-registered effects, in case an
+		// effect's class was added by some path that didn't stamp the
+		// attribute.
+		for ( const def of allEffects ) {
 			if ( def.className ) {
 				el.classList.remove( def.className );
 			}
@@ -81,6 +121,7 @@ export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps )
 	const apply = ( el: HTMLElement, def: UnfocusEffectDef ): void => {
 		if ( def.className ) {
 			el.classList.add( def.className );
+			el.setAttribute( EFFECT_CLASS_ATTR, def.className );
 		}
 		el.setAttribute( EFFECT_ATTR, def.id );
 		def.apply?.( el );
@@ -88,7 +129,12 @@ export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps )
 
 	const recompute = (): void => {
 		const def =
-			currentId === NONE ? undefined : getUnfocusEffect( currentId );
+			currentId === UNFOCUS_EFFECT_NONE
+				? undefined
+				: getUnfocusEffect( currentId );
+		// One filter call per recompute, shared across every window's
+		// clear() sweep below.
+		const allEffects = listUnfocusEffects();
 		for ( const win of manager.getAll() ) {
 			const el = win.element;
 			if ( ! el ) {
@@ -96,7 +142,7 @@ export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps )
 			}
 			// Reset first so switching effects (or to "none") never
 			// leaves a stale class behind.
-			clear( el );
+			clear( el, allEffects );
 			if ( ! def || win.isFocused() || win.state === 'minimized' ) {
 				continue;
 			}

--- a/src/effects/unfocus-engine.ts
+++ b/src/effects/unfocus-engine.ts
@@ -1,0 +1,112 @@
+/**
+ * Desktop Mode — Unfocused-window effect engine.
+ *
+ * The framework is a transport, not a UX-policy maker: this engine
+ * decides *when* the user's chosen unfocus effect is applied, and to
+ * which windows — but the effect itself (the visual) lives in the
+ * registered {@link UnfocusEffectDef}. The engine never invents an
+ * effect; it only toggles whichever one the user picked in OS Settings
+ * → Effects on every window that isn't focused.
+ *
+ * It listens to the existing window-lifecycle CustomEvents
+ * (`desktop-mode-window-{opened,closed,focused,blurred,reopened}`),
+ * the OS-settings change stream (the selected effect id), and the
+ * effect-registry change stream (a plugin's effect arriving / leaving
+ * live). On any of those it recomputes from scratch — cheap, since
+ * there are only ever a handful of open windows.
+ *
+ * @since 0.26.0
+ */
+
+import { getUnfocusEffect, listUnfocusEffects, subscribeUnfocusEffects } from './registry';
+import type { UnfocusEffectDef } from './types';
+import type { OsSettings } from '../settings';
+import type { WindowManager } from '../window-manager';
+
+/** The reserved id that means "no effect". Never a registered def. */
+const NONE = 'none';
+
+/** Data attribute stamped on a window root carrying the active effect id. */
+const EFFECT_ATTR = 'data-desktop-unfocus-effect';
+
+export interface UnfocusEngineDeps {
+	manager: WindowManager;
+	osSettings: OsSettings;
+}
+
+/**
+ * Wire the unfocus-effect engine. Idempotent per shell boot — call
+ * once. Returns nothing; the engine self-manages via event listeners
+ * that live for the page's lifetime (the shell is torn down only on
+ * navigation, which discards the listeners with it).
+ */
+export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps ): void {
+	let currentId = osSettings.getOsSettingsSnapshot().unfocusEffect;
+
+	/** Strip every effect marker we might have set from a window root. */
+	const clear = ( el: HTMLElement ): void => {
+		// Remove the class for whatever effect the element currently
+		// carries (read from the data attr) even if that def has since
+		// been unregistered, plus defensively sweep all known classes.
+		const priorId = el.getAttribute( EFFECT_ATTR );
+		if ( priorId ) {
+			const prior = getUnfocusEffect( priorId );
+			if ( prior?.className ) {
+				el.classList.remove( prior.className );
+			}
+			prior?.clear?.( el );
+		}
+		for ( const def of listUnfocusEffects() ) {
+			if ( def.className ) {
+				el.classList.remove( def.className );
+			}
+		}
+		el.removeAttribute( EFFECT_ATTR );
+	};
+
+	/** Apply the active effect to an unfocused window root. */
+	const apply = ( el: HTMLElement, def: UnfocusEffectDef ): void => {
+		if ( def.className ) {
+			el.classList.add( def.className );
+		}
+		el.setAttribute( EFFECT_ATTR, def.id );
+		def.apply?.( el );
+	};
+
+	const recompute = (): void => {
+		const def =
+			currentId === NONE ? undefined : getUnfocusEffect( currentId );
+		for ( const win of manager.getAll() ) {
+			const el = win.element;
+			if ( ! el ) {
+				continue;
+			}
+			// Reset first so switching effects (or to "none") never
+			// leaves a stale class behind.
+			clear( el );
+			if ( ! def || win.isFocused() || win.state === 'minimized' ) {
+				continue;
+			}
+			apply( el, def );
+		}
+	};
+
+	for ( const name of [
+		'desktop-mode-window-opened',
+		'desktop-mode-window-reopened',
+		'desktop-mode-window-closed',
+		'desktop-mode-window-focused',
+		'desktop-mode-window-blurred',
+	] ) {
+		document.addEventListener( name, () => recompute() );
+	}
+
+	osSettings.subscribeOsSettings( ( snapshot ) => {
+		currentId = snapshot.unfocusEffect;
+		recompute();
+	} );
+
+	subscribeUnfocusEffects( () => recompute() );
+
+	recompute();
+}

--- a/src/effects/unfocus-engine.ts
+++ b/src/effects/unfocus-engine.ts
@@ -29,6 +29,19 @@ const NONE = 'none';
 /** Data attribute stamped on a window root carrying the active effect id. */
 const EFFECT_ATTR = 'data-desktop-unfocus-effect';
 
+/**
+ * True when the window root contains a `<canvas>` in the parent
+ * document — i.e. a native WebGL/Pixi scene. Such windows are exempt
+ * from unfocus effects: a CSS `filter` over a live WebGL canvas can
+ * cause a GPU context loss that crashes the Pixi render loop. Iframe
+ * windows hide their content in a separate document, so a canvas there
+ * isn't matched (and filtering the iframe element is safe for the
+ * non-WebGL admin pages we host).
+ */
+function hostsCanvas( el: HTMLElement ): boolean {
+	return el.querySelector( 'canvas' ) !== null;
+}
+
 export interface UnfocusEngineDeps {
 	manager: WindowManager;
 	osSettings: OsSettings;
@@ -85,6 +98,20 @@ export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps )
 			// leaves a stale class behind.
 			clear( el );
 			if ( ! def || win.isFocused() || win.state === 'minimized' ) {
+				continue;
+			}
+			// Never paint an unfocus effect over a window that hosts a
+			// WebGL `<canvas>` — the native Pixi scenes (content graph,
+			// posts mind-map / tag-cloud, About scene). A CSS `filter`
+			// (or any property that re-rasterizes the subtree) on an
+			// element wrapping a live WebGL canvas can trigger a context
+			// loss, and the shell's Pixi apps run on their own tickers
+			// that then crash on a dead GL context ("null geometry").
+			// See the context-loss guard in `content-graph/scene.ts`.
+			// Canvases inside iframe windows live in a separate document
+			// and aren't reached by this query — that's fine, admin
+			// iframes don't run WebGL.
+			if ( hostsCanvas( el ) ) {
 				continue;
 			}
 			apply( el, def );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -167,6 +167,8 @@ export const HOOKS = {
 
 	/** Filter, receives the wallpaper registry array. */
 	WALLPAPERS: 'desktop-mode.wallpapers',
+	/** Filter, receives the unfocused-window effect registry array. */
+	UNFOCUS_EFFECTS: 'desktop-mode.unfocus-effects',
 	/** Action before a canvas wallpaper mounts. */
 	WALLPAPER_MOUNTING: 'desktop-mode.wallpaper.mounting',
 	/** Action after a canvas wallpaper mounts successfully. */

--- a/src/menu-refresh-apply.ts
+++ b/src/menu-refresh-apply.ts
@@ -25,6 +25,7 @@ import type {
 	DesktopSettingsTabScriptServerEntry,
 	DesktopSettingsTabServerEntry,
 	DesktopTitleBarButtonScriptServerEntry,
+	DesktopUnfocusEffectScriptServerEntry,
 	DesktopWallpaperServerEntry,
 	DesktopWidgetServerEntry,
 	DesktopWindowNoticeServerEntry,
@@ -44,6 +45,7 @@ export interface MenuRefreshPayload {
 	serverSettingsTabs?: unknown;
 	serverDockRailRendererScripts?: unknown;
 	serverTitleBarButtonScripts?: unknown;
+	serverUnfocusEffectScripts?: unknown;
 	serverWindowNotices?: unknown;
 	desktopIcons?: unknown;
 }
@@ -78,6 +80,9 @@ export interface MenuRefreshDeps {
 	) => Promise< void >;
 	syncServerTitleBarButtons: (
 		scripts: DesktopTitleBarButtonScriptServerEntry[],
+	) => Promise< void >;
+	syncServerUnfocusEffects: (
+		scripts: DesktopUnfocusEffectScriptServerEntry[],
 	) => Promise< void >;
 	syncServerDockRailRenderers: (
 		scripts: DesktopDockRailRendererScriptServerEntry[],
@@ -174,6 +179,7 @@ export function createApplyPayload(
 		syncServerCommands,
 		syncServerSettingsTabs,
 		syncServerTitleBarButtons,
+		syncServerUnfocusEffects,
 		syncServerDockRailRenderers,
 		renderIcons,
 	} = deps;
@@ -189,6 +195,7 @@ export function createApplyPayload(
 		const serverSettingsTabs = payload.serverSettingsTabs;
 		const serverDockRailRendererScripts = payload.serverDockRailRendererScripts;
 		const serverTitleBarButtonScripts = payload.serverTitleBarButtonScripts;
+		const serverUnfocusEffectScripts = payload.serverUnfocusEffectScripts;
 		const serverWindowNotices = payload.serverWindowNotices;
 		const desktopIcons = payload.desktopIcons;
 
@@ -301,6 +308,18 @@ export function createApplyPayload(
 			);
 			config.serverTitleBarButtonScripts =
 				serverTitleBarButtonScripts as DesktopConfig[ 'serverTitleBarButtonScripts' ];
+		}
+
+		// Unfocus-effect sync — same shape. Loads plugin effect scripts
+		// on activation (their `registerUnfocusEffect()` surfaces in
+		// OS Settings → Effects and re-runs the engine); owner-tagged
+		// sweep on deactivation.
+		if ( Array.isArray( serverUnfocusEffectScripts ) ) {
+			void syncServerUnfocusEffects(
+				serverUnfocusEffectScripts as DesktopUnfocusEffectScriptServerEntry[],
+			);
+			config.serverUnfocusEffectScripts =
+				serverUnfocusEffectScripts as DesktopConfig[ 'serverUnfocusEffectScripts' ];
 		}
 
 		// Dock rail renderer sync — load plugin renderer scripts on

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -151,6 +151,7 @@ export const DEFAULTS: OsSettingsState = {
 	dockSize: 'default',
 	desktopLayout: 'classic',
 	dockRailRenderer: 'default',
+	unfocusEffect: 'darken',
 	customGradient: {
 		from: '#2271b1',
 		to: '#7c3aed',

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -184,6 +184,7 @@ export class OsSettings implements SettingsCtx {
 			dockSize: this.state.dockSize,
 			desktopLayout: this.state.desktopLayout,
 			dockRailRenderer: this.state.dockRailRenderer,
+			unfocusEffect: this.state.unfocusEffect,
 			ai: { ...this.state.ai },
 			nativePostsEnabled: this.state.nativePostsEnabled,
 			nativePostsHiddenColumns: this.state.nativePostsHiddenColumns.slice(),

--- a/src/settings/panel.ts
+++ b/src/settings/panel.ts
@@ -64,6 +64,7 @@ import { buildAppsIconsSection } from './sections/apps-icons';
 import { buildDesktopLayoutSection } from './sections/desktop-layout';
 import { buildDockSizeSection } from './sections/dock-size';
 import { buildDockRailRendererSection } from './sections/dock-rail-renderer';
+import { buildEffectsSection } from './sections/effects';
 import { buildExtendedSection } from './sections/extended';
 import { buildFeaturesSection } from './sections/features';
 import { buildHelpSection } from './sections/help';
@@ -210,6 +211,16 @@ export function renderOsSettingsPanel(
 			>`,
 			panel: html`<wpd-tabpanel for="apps-icons">
 				<wpd-panel>${ buildAppsIconsSection( ctx ) }</wpd-panel>
+			</wpd-tabpanel>`,
+		},
+		{
+			id: 'effects',
+			order: 27,
+			tab: html`<wpd-tab value="effects"
+				>${ __( 'Effects' ) }</wpd-tab
+			>`,
+			panel: html`<wpd-tabpanel for="effects">
+				<wpd-panel>${ buildEffectsSection( ctx ) }</wpd-panel>
 			</wpd-tabpanel>`,
 		},
 	];

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -51,6 +51,14 @@ export interface OsSettingsSnapshot {
 	 * @since 0.18.0
 	 */
 	dockRailRenderer: string;
+	/**
+	 * Active unfocused-window effect id; mirrors the unfocus-effect
+	 * registry's resolution. `'darken'` is the shipped built-in,
+	 * `'none'` disables the effect.
+	 *
+	 * @since 0.26.0
+	 */
+	unfocusEffect: string;
 	ai: {
 		enabled: boolean;
 		provider: string;

--- a/src/settings/sections/effects.ts
+++ b/src/settings/sections/effects.ts
@@ -1,0 +1,113 @@
+/**
+ * Effects section — "Unfocused windows" selector bound to
+ * `state.unfocusEffect`.
+ *
+ * Lists every effect registered via `wp.desktop.registerUnfocusEffect`
+ * (the built-in `darken` plus any plugin effects), preceded by a
+ * `None` option that maps to the engine's reserved `'none'` sentinel.
+ * Subscribes to the effect registry so a plugin activated mid-session
+ * surfaces its effect immediately without reopening OS Settings.
+ *
+ * The picker is a `<wpd-select>` rather than a `<wpd-segmented>` pill
+ * bar because the effect list is open-ended — plugins append, and a
+ * dropdown scales past the two shipped choices.
+ *
+ * @since 0.26.0
+ */
+
+import { __ } from '../../i18n';
+import { html, render } from '../../ui/core';
+import {
+	listUnfocusEffects,
+	subscribeUnfocusEffects,
+} from '../../effects/registry';
+import type { UnfocusEffectDef } from '../../effects/types';
+import type { SettingsCtx } from '../types';
+
+/** The reserved value meaning "no effect"; mirrors the engine. */
+const NONE = 'none';
+
+export function buildEffectsSection( ctx: SettingsCtx ): HTMLElement {
+	const wrapper = document.createElement( 'div' );
+
+	const onPick = ( e: Event ): void => {
+		const id = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
+		if ( id === '' ) {
+			return;
+		}
+		// Accept `none` or any currently-registered effect id. Guard
+		// against stale option values (an effect unregistered between
+		// paint and pick).
+		if ( id !== NONE && ! effects.some( ( fx ) => fx.id === id ) ) {
+			return;
+		}
+		ctx.state.unfocusEffect = id;
+		ctx.save();
+		ctx.apply();
+		paint();
+	};
+
+	let effects: UnfocusEffectDef[] = listUnfocusEffects();
+
+	const paint = (): void => {
+		const active = effects.find(
+			( fx ) => fx.id === ctx.state.unfocusEffect,
+		);
+		const fallbackDescription = __(
+			'Apply a visual treatment to every window except the one you are working in.',
+		);
+		const description =
+			ctx.state.unfocusEffect !== NONE && active?.description
+				? active.description
+				: fallbackDescription;
+
+		render(
+			html`
+				<wpd-section
+					heading=${ __( 'Unfocused windows' ) }
+					description=${ description }
+				>
+					<wpd-select
+						value=${ ctx.state.unfocusEffect }
+						label=${ __( 'Unfocused window effect' ) }
+						@wpd-pick=${ onPick }
+					>
+						<wpd-option value=${ NONE }>
+							${ __( 'None' ) }
+						</wpd-option>
+						${ effects.map(
+							( fx ) =>
+								html`<wpd-option value=${ fx.id }
+									>${ fx.label }</wpd-option
+								>`,
+						) }
+					</wpd-select>
+				</wpd-section>
+			`,
+			wrapper,
+		);
+	};
+
+	const unsubscribe = subscribeUnfocusEffects( () => {
+		effects = listUnfocusEffects();
+		paint();
+	} );
+
+	const observer = new MutationObserver( () => {
+		if ( ! wrapper.isConnected ) {
+			unsubscribe();
+			observer.disconnect();
+		}
+	} );
+	queueMicrotask( () => {
+		if ( wrapper.parentNode ) {
+			observer.observe( wrapper.parentNode, {
+				childList: true,
+				subtree: false,
+			} );
+		}
+	} );
+
+	paint();
+	return wrapper;
+}

--- a/src/settings/sections/effects.ts
+++ b/src/settings/sections/effects.ts
@@ -20,12 +20,10 @@ import { html, render } from '../../ui/core';
 import {
 	listUnfocusEffects,
 	subscribeUnfocusEffects,
+	UNFOCUS_EFFECT_NONE as NONE,
 } from '../../effects/registry';
 import type { UnfocusEffectDef } from '../../effects/types';
 import type { SettingsCtx } from '../types';
-
-/** The reserved value meaning "no effect"; mirrors the engine. */
-const NONE = 'none';
 
 export function buildEffectsSection( ctx: SettingsCtx ): HTMLElement {
 	const wrapper = document.createElement( 'div' );
@@ -99,6 +97,13 @@ export function buildEffectsSection( ctx: SettingsCtx ): HTMLElement {
 			observer.disconnect();
 		}
 	} );
+	// Note: this watches `wrapper.parentNode` for direct child removals,
+	// so it fires when the panel unmounts `wrapper` — the only teardown
+	// path in practice (the OS Settings panel always removes the section
+	// wrapper directly). If an ancestor higher up were detached without
+	// touching the parent's child list, the observer wouldn't fire and
+	// the registry listener would leak. Matches the accepted pattern in
+	// the sibling settings sections (e.g. `dock-rail-renderer.ts`).
 	queueMicrotask( () => {
 		if ( wrapper.parentNode ) {
 			observer.observe( wrapper.parentNode, {

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -121,6 +121,14 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 			/^[a-z0-9_-]+$/.test( parsed.dockRailRenderer )
 				? parsed.dockRailRenderer
 				: DEFAULTS.dockRailRenderer,
+		// Unfocus effect — any registry id (`vendor/sub-id` allowed) or
+		// the `'none'` sentinel survives; the engine resolves at use
+		// time and treats an unknown id as "no effect".
+		unfocusEffect:
+			typeof parsed.unfocusEffect === 'string' &&
+			/^[a-z0-9_/-]+$/.test( parsed.unfocusEffect )
+				? parsed.unfocusEffect
+				: DEFAULTS.unfocusEffect,
 		customGradient: sanitizeCustomGradient( parsed.customGradient ),
 		customImage: sanitizeCustomImage( parsed.customImage ),
 		libraryHdOnly:

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -112,6 +112,15 @@ export interface OsSettingsState {
 	 * @since 0.18.0
 	 */
 	dockRailRenderer: string;
+	/**
+	 * Active unfocused-window effect id. Resolves through the
+	 * unfocus-effect registry; `'none'` means no effect, an unknown id
+	 * is treated as `'none'` by the engine until/if a matching effect
+	 * registers. Default `'darken'`.
+	 *
+	 * @since 0.26.0
+	 */
+	unfocusEffect: string;
 	customGradient: CustomGradient;
 	customImage: CustomImage | null;
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1059,6 +1059,32 @@ export interface DesktopTitleBarButtonScriptServerEntry {
 }
 
 /**
+ * Server-declared unfocus-effect script entry. One per
+ * `desktop_mode_register_unfocus_effect_script()` call. The shell
+ * injects each `scriptUrl` on mid-session activation; the loaded
+ * script calls `wp.desktop.registerUnfocusEffect()` and the effects
+ * registry subscriber re-runs the engine so the new effect appears in
+ * the OS Settings selector without an F5.
+ *
+ * @public
+ * @since 0.26.0
+ */
+export interface DesktopUnfocusEffectScriptServerEntry {
+	/** WordPress script handle — doubles as the effect `owner` key for live unregistration. */
+	handle: string;
+	/** Absolute URL of the plugin's enqueued script. Empty entries are dropped by the PHP payload builder. */
+	scriptUrl: string;
+	/** @since 0.6.0 */
+	scriptBefore?: string[];
+	/** @since 0.6.0 */
+	scriptAfter?: string[];
+	/** @since 0.6.0 */
+	scriptL10n?: string[];
+	/** @since 0.6.0 */
+	scriptTranslations?: string;
+}
+
+/**
  * Server-declared window-theme script entry. One per
  * `desktop_mode_register_window_theme_script()` call. The shell
  * injects each `scriptUrl` on mid-session activation; the loaded
@@ -1571,6 +1597,16 @@ export interface DesktopConfig {
 	 * @since 0.17.0
 	 */
 	serverTitleBarButtonScripts?: DesktopTitleBarButtonScriptServerEntry[];
+	/**
+	 * Script handles opted-in via
+	 * `desktop_mode_register_unfocus_effect_script()`. Shell injects
+	 * each URL on boot and on mid-session activation so newly-installed
+	 * plugins surface their unfocus effect in OS Settings → Effects
+	 * live. Owner-tagged registrations live-unregister on deactivation.
+	 *
+	 * @since 0.26.0
+	 */
+	serverUnfocusEffectScripts?: DesktopUnfocusEffectScriptServerEntry[];
 	/**
 	 * Script handles opted-in via
 	 * `desktop_mode_register_window_theme_script()`. The shell loads

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -1002,9 +1002,28 @@ export class WindowManager {
 			this._stack.splice( idx, 1 );
 		}
 
-		// Focus the next topmost window.
-		if ( this._stack.length > 0 ) {
-			this.focus( this._stack[ this._stack.length - 1 ] );
+		// Focus the next topmost FOCUSABLE window — walk the stack
+		// top-down and skip windows the user can't actually see take
+		// focus: minimized ones, and ones living on another virtual
+		// desktop (the stack spans every desktop). Blindly focusing
+		// `_stack[length-1]` would hand focus to an invisible window —
+		// leaving every visible window looking unfocused (and, with an
+		// unfocus effect active, darkened with nothing bright). Mirrors
+		// the active-desktop filter used by `getByBaseIdOnActiveDesktop`.
+		// If nothing qualifies (only minimized / off-desktop windows
+		// remain), we focus nothing rather than force-restore one.
+		for ( let i = this._stack.length - 1; i >= 0; i-- ) {
+			const candidate = this._stack[ i ];
+			if ( candidate.state === 'minimized' ) {
+				continue;
+			}
+			const candidateDesktop =
+				candidate.config.desktopId || this._activeDesktopId;
+			if ( candidateDesktop !== this._activeDesktopId ) {
+				continue;
+			}
+			this.focus( candidate );
+			break;
 		}
 
 		// `closing` fires FIRST, while the element is still in the DOM

--- a/tests/phpunit/tests/unfocusEffects.php
+++ b/tests/phpunit/tests/unfocusEffects.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for `desktop_mode_register_unfocus_effect_script()` — the
+ * minimum-ceremony PHP opt-in that puts a plugin's JS handle into the
+ * live-refresh payload so newly-installed plugins surface their
+ * unfocus effect in OS Settings → Effects immediately — plus the
+ * `unfocusEffect` OS-setting sanitizer and its presence in the menu
+ * payload.
+ *
+ * Mirrors `tests/phpunit/tests/titleBarButtons.php` — same pattern,
+ * different registry.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-unfocus-effects
+ */
+class Tests_DesktopMode_UnfocusEffects extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		desktop_mode_flush_script_handle_registries();
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_unfocus_effect_script
+	 */
+	public function test_stores_handle() {
+		$handle = 'fx-a-' . substr( md5( uniqid() ), 0, 8 );
+		$ok     = desktop_mode_register_unfocus_effect_script( $handle );
+		$this->assertTrue( $ok );
+		$this->assertTrue( desktop_mode_desktop_unfocus_effect_script_registry( $handle ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_unfocus_effect_script
+	 */
+	public function test_rejects_empty_handle() {
+		$r = desktop_mode_register_unfocus_effect_script( '' );
+		$this->assertInstanceOf( 'WP_Error', $r );
+		$this->assertSame( 'desktop_mode_missing_handle', $r->get_error_code() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_build_desktop_unfocus_effect_scripts_payload
+	 */
+	public function test_payload_resolves_registered_handle() {
+		$handle = 'fx-b-' . substr( md5( uniqid() ), 0, 8 );
+		wp_register_script( $handle, 'https://example.test/fx.js', array(), '1.0', true );
+		desktop_mode_register_unfocus_effect_script( $handle );
+
+		$payload = desktop_mode_build_desktop_unfocus_effect_scripts_payload();
+		$entry   = null;
+		foreach ( $payload as $p ) {
+			if ( $p['handle'] === $handle ) {
+				$entry = $p;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry );
+		$this->assertStringContainsString( 'fx.js', $entry['scriptUrl'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_build_desktop_unfocus_effect_scripts_payload
+	 */
+	public function test_payload_omits_unresolvable_handles() {
+		$this->setExpectedIncorrectUsage( 'desktop_mode_register_unfocus_effect_script' );
+
+		$handle = 'fx-c-' . substr( md5( uniqid() ), 0, 8 );
+		desktop_mode_register_unfocus_effect_script( $handle );
+		$payload = desktop_mode_build_desktop_unfocus_effect_scripts_payload();
+		foreach ( $payload as $entry ) {
+			$this->assertNotSame( $handle, $entry['handle'] );
+		}
+	}
+
+	/**
+	 * @covers ::desktop_mode_register_unfocus_effect_script
+	 */
+	public function test_registered_action_fires() {
+		$captured = array();
+		add_action( 'desktop_mode_unfocus_effect_script_registered', function ( $h ) use ( &$captured ) {
+			$captured[] = $h;
+		} );
+		$h = 'fx-d-' . substr( md5( uniqid() ), 0, 8 );
+		desktop_mode_register_unfocus_effect_script( $h );
+		$this->assertContains( $h, $captured );
+	}
+
+	/**
+	 * The menu payload advertises the script array so the shell's
+	 * live-refresh applier can lazy-load plugin effect scripts.
+	 *
+	 * @covers ::desktop_mode_build_menu_payload
+	 */
+	public function test_menu_payload_includes_unfocus_effect_scripts_key() {
+		$payload = desktop_mode_build_menu_payload();
+		$this->assertArrayHasKey( 'serverUnfocusEffectScripts', $payload );
+		$this->assertIsArray( $payload['serverUnfocusEffectScripts'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_unfocus_effect_defaults_to_darken() {
+		$clean = desktop_mode_sanitize_os_settings( array() );
+		$this->assertSame( 'darken', $clean['unfocusEffect'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_unfocus_effect_accepts_none_and_namespaced_ids() {
+		$none = desktop_mode_sanitize_os_settings( array( 'unfocusEffect' => 'none' ) );
+		$this->assertSame( 'none', $none['unfocusEffect'] );
+
+		// Slashes survive — namespaced `vendor/sub-id` round-trips.
+		$ns = desktop_mode_sanitize_os_settings( array( 'unfocusEffect' => 'acme/Glow' ) );
+		$this->assertSame( 'acme/glow', $ns['unfocusEffect'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_unfocus_effect_falls_back_on_garbage() {
+		$clean = desktop_mode_sanitize_os_settings( array( 'unfocusEffect' => '!!!' ) );
+		$this->assertSame( 'darken', $clean['unfocusEffect'] );
+
+		$nonstr = desktop_mode_sanitize_os_settings( array( 'unfocusEffect' => 123 ) );
+		$this->assertSame( 'darken', $nonstr['unfocusEffect'] );
+	}
+}

--- a/tests/vitest/effects-server-sync.test.ts
+++ b/tests/vitest/effects-server-sync.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for `src/effects/server-sync.ts`.
+ *
+ * The sync module bridges the `serverUnfocusEffectScripts` payload
+ * (built in PHP, arrives via `applyPayload`) and the effect registry.
+ * It mirrors `commands/server-sync.ts`, so we exercise the same three
+ * behaviours: fresh scripts inject, re-sync is idempotent, and a
+ * departing handle unregisters owner-tagged effects while untagged
+ * ones survive.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import { _resetAllSharedStoresForTests } from '../../src/shared-store';
+
+type Sync = typeof import( '../../src/effects/server-sync' );
+type Registry = typeof import( '../../src/effects/registry' );
+type Loader = typeof import( '../../src/wallpapers/vendor-loader' );
+
+async function loadModules(): Promise< {
+	sync: Sync;
+	registry: Registry;
+	loader: Loader;
+} > {
+	_resetAllSharedStoresForTests();
+	vi.resetModules();
+	const sync = await import( '../../src/effects/server-sync' );
+	const registry = await import( '../../src/effects/registry' );
+	const loader = await import( '../../src/wallpapers/vendor-loader' );
+	return { sync, registry, loader };
+}
+
+describe( 'effects/server-sync.ts', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		vi.restoreAllMocks();
+		document.head.innerHTML = '';
+	} );
+
+	test( 'injects a <script> for each new handle', async () => {
+		const { sync, loader } = await loadModules();
+		const spy = vi
+			.spyOn( loader, 'loadVendorScript' )
+			.mockResolvedValue( undefined );
+
+		const run = sync.createUnfocusEffectRegistrySync();
+		await run( [
+			{ handle: 'plugin-a', scriptUrl: 'https://example.test/a.js' },
+			{ handle: 'plugin-b', scriptUrl: 'https://example.test/b.js' },
+		] );
+
+		expect( spy ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'is idempotent — re-sync with the same handle is a no-op', async () => {
+		const { sync, loader } = await loadModules();
+		const spy = vi
+			.spyOn( loader, 'loadVendorScript' )
+			.mockResolvedValue( undefined );
+
+		const run = sync.createUnfocusEffectRegistrySync();
+		await run( [ { handle: 'plugin-a', scriptUrl: 'https://example.test/a.js' } ] );
+		await run( [ { handle: 'plugin-a', scriptUrl: 'https://example.test/a.js' } ] );
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'unregisters owner-tagged effects when a handle leaves the payload', async () => {
+		const { sync, registry, loader } = await loadModules();
+		vi.spyOn( loader, 'loadVendorScript' ).mockResolvedValue( undefined );
+
+		const run = sync.createUnfocusEffectRegistrySync();
+		await run( [ { handle: 'plugin-a', scriptUrl: 'https://example.test/a.js' } ] );
+
+		// Simulate plugin-a's just-loaded JS registering its effects.
+		registry.registerUnfocusEffect( {
+			id: 'a-glow',
+			label: 'Glow',
+			className: 'x',
+			owner: 'plugin-a',
+		} );
+		registry.registerUnfocusEffect( {
+			id: 'untagged',
+			label: 'No owner',
+			className: 'y',
+		} );
+
+		expect( registry.getUnfocusEffect( 'a-glow' ) ).toBeDefined();
+
+		// Plugin-a deactivates — sync with an empty payload.
+		await run( [] );
+
+		expect( registry.getUnfocusEffect( 'a-glow' ) ).toBeUndefined();
+		// Untagged effect survives (graceful backwards-compat).
+		expect( registry.getUnfocusEffect( 'untagged' ) ).toBeDefined();
+	} );
+
+	test( 'silently skips entries with an empty scriptUrl', async () => {
+		const { sync, loader } = await loadModules();
+		const spy = vi
+			.spyOn( loader, 'loadVendorScript' )
+			.mockResolvedValue( undefined );
+
+		const run = sync.createUnfocusEffectRegistrySync();
+		await run( [ { handle: 'plugin-a', scriptUrl: '' } ] );
+
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/vitest/unfocus-effects-registry.test.ts
+++ b/tests/vitest/unfocus-effects-registry.test.ts
@@ -37,6 +37,24 @@ describe( 'effects/registry.ts', () => {
 		).toContain( 'darken' );
 	} );
 
+	test( 'ships the built-in `frost` and `grayscale` effects with classes', async () => {
+		const { listUnfocusEffects, getUnfocusEffect } = await loadRegistry();
+		expect( getUnfocusEffect( 'frost' )?.className ).toBe(
+			'desktop-mode-window--fx-frost',
+		);
+		expect( getUnfocusEffect( 'grayscale' )?.className ).toBe(
+			'desktop-mode-window--fx-grayscale',
+		);
+		// All three built-ins resolve and each carries a description.
+		const ids = listUnfocusEffects().map( ( e ) => e.id );
+		expect( ids ).toEqual(
+			expect.arrayContaining( [ 'darken', 'frost', 'grayscale' ] ),
+		);
+		for ( const id of [ 'darken', 'frost', 'grayscale' ] ) {
+			expect( getUnfocusEffect( id )?.description ).toBeTruthy();
+		}
+	} );
+
 	test( 'register adds an effect', async () => {
 		const { registerUnfocusEffect, getUnfocusEffect } = await loadRegistry();
 		registerUnfocusEffect( {

--- a/tests/vitest/unfocus-effects-registry.test.ts
+++ b/tests/vitest/unfocus-effects-registry.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for `src/effects/registry.ts`.
+ *
+ * The registry is shared-store-backed (so the main bundle and the
+ * lazy OS-settings-panel bundle share one list), so we reset the
+ * shared stores and re-import fresh in each test. The built-in
+ * `darken` effect is seeded at module load through the public
+ * `register()` path, so a fresh import always starts with it present.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import { _resetAllSharedStoresForTests } from '../../src/shared-store';
+
+type Registry = typeof import( '../../src/effects/registry' );
+
+async function loadRegistry(): Promise< Registry > {
+	_resetAllSharedStoresForTests();
+	vi.resetModules();
+	return import( '../../src/effects/registry' );
+}
+
+describe( 'effects/registry.ts', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+	} );
+
+	test( 'ships the built-in `darken` effect with a class', async () => {
+		const { listUnfocusEffects, getUnfocusEffect } = await loadRegistry();
+		const darken = getUnfocusEffect( 'darken' );
+		expect( darken ).toBeDefined();
+		expect( darken?.className ).toBe( 'desktop-mode-window--fx-darken' );
+		expect(
+			listUnfocusEffects().map( ( e ) => e.id ),
+		).toContain( 'darken' );
+	} );
+
+	test( 'register adds an effect', async () => {
+		const { registerUnfocusEffect, getUnfocusEffect } = await loadRegistry();
+		registerUnfocusEffect( {
+			id: 'blur',
+			label: 'Blur',
+			className: 'x-blur',
+		} );
+		expect( getUnfocusEffect( 'blur' )?.label ).toBe( 'Blur' );
+	} );
+
+	test( 'register with an existing id replaces (late wins)', async () => {
+		const { registerUnfocusEffect, getUnfocusEffect } = await loadRegistry();
+		registerUnfocusEffect( { id: 'x', label: 'First', className: 'a' } );
+		registerUnfocusEffect( { id: 'x', label: 'Second', className: 'b' } );
+		expect( getUnfocusEffect( 'x' )?.label ).toBe( 'Second' );
+	} );
+
+	test( 'accepts an `apply` callback in place of a className', async () => {
+		const { registerUnfocusEffect, getUnfocusEffect } = await loadRegistry();
+		const apply = vi.fn();
+		registerUnfocusEffect( { id: 'fn', label: 'Fn', apply } );
+		expect( getUnfocusEffect( 'fn' )?.apply ).toBe( apply );
+	} );
+
+	test( 'rejects a def missing both className and apply', async () => {
+		const { registerUnfocusEffect } = await loadRegistry();
+		expect( () =>
+			registerUnfocusEffect( {
+				id: 'bad',
+				label: 'Bad',
+			} as never ),
+		).toThrow();
+	} );
+
+	test( 'rejects the reserved id "none"', async () => {
+		const { registerUnfocusEffect } = await loadRegistry();
+		expect( () =>
+			registerUnfocusEffect( {
+				id: 'none',
+				label: 'None',
+				className: 'x',
+			} ),
+		).toThrow();
+	} );
+
+	test( 'rejects ids outside the allowed charset', async () => {
+		const { registerUnfocusEffect } = await loadRegistry();
+		expect( () =>
+			registerUnfocusEffect( {
+				id: 'Bad Id!',
+				label: 'Bad',
+				className: 'x',
+			} ),
+		).toThrow();
+	} );
+
+	test( 'unregister removes an effect', async () => {
+		const { registerUnfocusEffect, unregisterUnfocusEffect, getUnfocusEffect } =
+			await loadRegistry();
+		registerUnfocusEffect( { id: 'temp', label: 'Temp', className: 'x' } );
+		unregisterUnfocusEffect( 'temp' );
+		expect( getUnfocusEffect( 'temp' ) ).toBeUndefined();
+	} );
+
+	test( 'unregisterByOwner removes only the matching owner', async () => {
+		const {
+			registerUnfocusEffect,
+			unregisterUnfocusEffectsByOwner,
+			getUnfocusEffect,
+		} = await loadRegistry();
+		registerUnfocusEffect( {
+			id: 'a',
+			label: 'A',
+			className: 'x',
+			owner: 'plugin-a',
+		} );
+		registerUnfocusEffect( {
+			id: 'b',
+			label: 'B',
+			className: 'y',
+			owner: 'plugin-b',
+		} );
+		const removed = unregisterUnfocusEffectsByOwner( 'plugin-a' );
+		expect( removed ).toBe( 1 );
+		expect( getUnfocusEffect( 'a' ) ).toBeUndefined();
+		expect( getUnfocusEffect( 'b' ) ).toBeDefined();
+	} );
+
+	test( 'subscribe fires on register and unregister', async () => {
+		const { registerUnfocusEffect, unregisterUnfocusEffect, subscribeUnfocusEffects } =
+			await loadRegistry();
+		const cb = vi.fn();
+		const unsub = subscribeUnfocusEffects( cb );
+		registerUnfocusEffect( { id: 'z', label: 'Z', className: 'x' } );
+		unregisterUnfocusEffect( 'z' );
+		expect( cb ).toHaveBeenCalledTimes( 2 );
+		unsub();
+		registerUnfocusEffect( { id: 'z2', label: 'Z2', className: 'x' } );
+		expect( cb ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/tests/vitest/unfocus-engine.test.ts
+++ b/tests/vitest/unfocus-engine.test.ts
@@ -104,6 +104,28 @@ describe( 'effects/unfocus-engine.ts', () => {
 		).toBe( 'darken' );
 	} );
 
+	test( 'does not apply to windows hosting a WebGL <canvas> (Pixi scenes)', async () => {
+		const { engine } = await loadModules();
+		const pixi = makeWin( 'graph', false );
+		// Native Pixi window: a <canvas> lives in the window root's
+		// parent DOM. Filtering it would risk a WebGL context loss.
+		pixi.element.appendChild( document.createElement( 'canvas' ) );
+		const plain = makeWin( 'posts', false );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ pixi, plain ] ),
+			osSettings,
+		} );
+
+		// The canvas window is exempt; the plain window still darkens.
+		expect( pixi.element.classList.contains( DARKEN_CLASS ) ).toBe( false );
+		expect(
+			pixi.element.hasAttribute( 'data-desktop-unfocus-effect' ),
+		).toBe( false );
+		expect( plain.element.classList.contains( DARKEN_CLASS ) ).toBe( true );
+	} );
+
 	test( 'does not apply to minimized windows', async () => {
 		const { engine } = await loadModules();
 		const minimized = makeWin( 'm', false, 'minimized' );

--- a/tests/vitest/unfocus-engine.test.ts
+++ b/tests/vitest/unfocus-engine.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for `src/effects/unfocus-engine.ts`.
+ *
+ * The engine applies the user's chosen unfocus effect to every window
+ * that isn't focused, and keeps it in sync with focus changes, the OS
+ * Settings selection, and the effect registry. We drive it with fake
+ * `WindowManager` / `OsSettings` doubles and real DOM nodes so we can
+ * assert the class toggling on each window root.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import { _resetAllSharedStoresForTests } from '../../src/shared-store';
+import type { OsSettings } from '../../src/settings';
+import type { OsSettingsSnapshot } from '../../src/settings/registry';
+import type { WindowManager } from '../../src/window-manager';
+import type { Window as DesktopWindow } from '../../src/window';
+
+const DARKEN_CLASS = 'desktop-mode-window--fx-darken';
+
+type Engine = typeof import( '../../src/effects/unfocus-engine' );
+type Registry = typeof import( '../../src/effects/registry' );
+
+async function loadModules(): Promise< { engine: Engine; registry: Registry } > {
+	_resetAllSharedStoresForTests();
+	vi.resetModules();
+	const engine = await import( '../../src/effects/unfocus-engine' );
+	const registry = await import( '../../src/effects/registry' );
+	return { engine, registry };
+}
+
+interface FakeWin {
+	id: string;
+	element: HTMLElement;
+	state: string;
+	focused: boolean;
+}
+
+function makeWin( id: string, focused: boolean, state = 'normal' ): FakeWin {
+	const element = document.createElement( 'div' );
+	element.className = 'desktop-mode-window';
+	return { id, element, state, focused };
+}
+
+function makeManager( wins: FakeWin[] ): WindowManager {
+	return {
+		getAll: () =>
+			wins.map(
+				( w ) =>
+					( {
+						id: w.id,
+						element: w.element,
+						state: w.state,
+						isFocused: () => w.focused,
+					} as unknown as DesktopWindow ),
+			),
+	} as unknown as WindowManager;
+}
+
+function makeOsSettings( initial: string ): {
+	osSettings: OsSettings;
+	setEffect: ( id: string ) => void;
+} {
+	let snapshot = { unfocusEffect: initial } as unknown as OsSettingsSnapshot;
+	let cb: ( ( s: OsSettingsSnapshot ) => void ) | null = null;
+	const osSettings = {
+		getOsSettingsSnapshot: () => snapshot,
+		subscribeOsSettings: ( fn: ( s: OsSettingsSnapshot ) => void ) => {
+			cb = fn;
+			return () => {
+				cb = null;
+			};
+		},
+	} as unknown as OsSettings;
+	const setEffect = ( id: string ): void => {
+		snapshot = { unfocusEffect: id } as unknown as OsSettingsSnapshot;
+		cb?.( snapshot );
+	};
+	return { osSettings, setEffect };
+}
+
+describe( 'effects/unfocus-engine.ts', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+	} );
+
+	test( 'applies the effect class to unfocused windows only', async () => {
+		const { engine } = await loadModules();
+		const focused = makeWin( 'a', true );
+		const unfocused = makeWin( 'b', false );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ focused, unfocused ] ),
+			osSettings,
+		} );
+
+		expect( focused.element.classList.contains( DARKEN_CLASS ) ).toBe( false );
+		expect( unfocused.element.classList.contains( DARKEN_CLASS ) ).toBe( true );
+		expect(
+			unfocused.element.getAttribute( 'data-desktop-unfocus-effect' ),
+		).toBe( 'darken' );
+	} );
+
+	test( 'does not apply to minimized windows', async () => {
+		const { engine } = await loadModules();
+		const minimized = makeWin( 'm', false, 'minimized' );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ minimized ] ),
+			osSettings,
+		} );
+
+		expect( minimized.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'clears the effect when the setting switches to "none"', async () => {
+		const { engine } = await loadModules();
+		const unfocused = makeWin( 'b', false );
+		const { osSettings, setEffect } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ unfocused ] ),
+			osSettings,
+		} );
+		expect( unfocused.element.classList.contains( DARKEN_CLASS ) ).toBe( true );
+
+		setEffect( 'none' );
+		expect( unfocused.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			false,
+		);
+		expect(
+			unfocused.element.hasAttribute( 'data-desktop-unfocus-effect' ),
+		).toBe( false );
+	} );
+
+	test( 'reacts to a focus change event', async () => {
+		const { engine } = await loadModules();
+		const a = makeWin( 'a', true );
+		const b = makeWin( 'b', false );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ a, b ] ),
+			osSettings,
+		} );
+		expect( a.element.classList.contains( DARKEN_CLASS ) ).toBe( false );
+		expect( b.element.classList.contains( DARKEN_CLASS ) ).toBe( true );
+
+		// Focus moves to b.
+		a.focused = false;
+		b.focused = true;
+		document.dispatchEvent(
+			new CustomEvent( 'desktop-mode-window-focused', {
+				detail: { windowId: 'b' },
+			} ),
+		);
+
+		expect( a.element.classList.contains( DARKEN_CLASS ) ).toBe( true );
+		expect( b.element.classList.contains( DARKEN_CLASS ) ).toBe( false );
+	} );
+} );

--- a/tests/vitest/unfocus-engine.test.ts
+++ b/tests/vitest/unfocus-engine.test.ts
@@ -186,4 +186,61 @@ describe( 'effects/unfocus-engine.ts', () => {
 		expect( a.element.classList.contains( DARKEN_CLASS ) ).toBe( true );
 		expect( b.element.classList.contains( DARKEN_CLASS ) ).toBe( false );
 	} );
+
+	test( 'removes the applied class even after the effect is unregistered', async () => {
+		const { engine, registry } = await loadModules();
+		const pluginClass = 'plugin-fx-glow';
+		registry.registerUnfocusEffect( {
+			id: 'plugin/glow',
+			label: 'Glow',
+			className: pluginClass,
+			owner: 'plugin-a',
+		} );
+		const unfocused = makeWin( 'b', false );
+		// User has the plugin effect selected.
+		const { osSettings } = makeOsSettings( 'plugin/glow' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ unfocused ] ),
+			osSettings,
+		} );
+		expect( unfocused.element.classList.contains( pluginClass ) ).toBe(
+			true,
+		);
+
+		// Plugin deactivates: its def leaves the registry, which fires
+		// the engine's registry subscriber → recompute. The class must
+		// be removed even though the registry can no longer map the id
+		// back to its class.
+		registry.unregisterUnfocusEffectsByOwner( 'plugin-a' );
+
+		expect( unfocused.element.classList.contains( pluginClass ) ).toBe(
+			false,
+		);
+		expect(
+			unfocused.element.hasAttribute(
+				'data-desktop-unfocus-effect-class',
+			),
+		).toBe( false );
+	} );
+
+	test( 'a second startUnfocusEngine call is a no-op (no doubled listeners)', async () => {
+		const { engine } = await loadModules();
+		const { osSettings } = makeOsSettings( 'darken' );
+		const manager = makeManager( [ makeWin( 'a', true ) ] );
+
+		const spy = vi.spyOn( document, 'addEventListener' );
+
+		engine.startUnfocusEngine( { manager, osSettings } );
+		const afterFirst = spy.mock.calls.length;
+
+		engine.startUnfocusEngine( { manager, osSettings } );
+		const afterSecond = spy.mock.calls.length;
+
+		// The first call wired the listeners; the second added none.
+		expect( afterFirst ).toBeGreaterThan( 0 );
+		expect( afterSecond ).toBe( afterFirst );
+
+		spy.mockRestore();
+	} );
 } );

--- a/tests/vitest/window-manager-close-focus.test.ts
+++ b/tests/vitest/window-manager-close-focus.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Focus-transfer-on-close tests for {@link WindowManager}.
+ *
+ * Closing the focused window must hand focus to the next window the
+ * user can actually *see* take it — the topmost non-minimized window
+ * on the active desktop — not blindly the top of the stack (which
+ * spans every virtual desktop and includes minimized windows). With
+ * an unfocus effect active, focusing an invisible window would leave
+ * every visible window darkened with nothing bright.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+function cfg(
+	id: string,
+	overrides: Partial< { desktopId: string } > = {},
+) {
+	return {
+		id,
+		url: `http://example.test/${ id }.php`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+		desktopId: overrides.desktopId,
+	};
+}
+
+function makeDesktop(): HTMLElement {
+	const desktop = document.createElement( 'div' );
+	desktop.id = 'desktop-mode-area';
+	Object.defineProperty( desktop, 'getBoundingClientRect', {
+		value: () =>
+			( {
+				left: 0,
+				top: 0,
+				right: 1600,
+				bottom: 900,
+				width: 1600,
+				height: 900,
+				x: 0,
+				y: 0,
+				toJSON: () => ( {} ),
+			} ) as DOMRect,
+	} );
+	Object.defineProperty( desktop, 'clientWidth', {
+		value: 1600,
+		configurable: true,
+	} );
+	Object.defineProperty( desktop, 'clientHeight', {
+		value: 900,
+		configurable: true,
+	} );
+	return desktop;
+}
+
+describe( 'WindowManager — focus transfer on close', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'closing the focused window focuses the remaining one', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+		expect( b.isFocused() ).toBe( true );
+
+		b.close();
+
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [ 'a' ] );
+		expect( a.isFocused() ).toBe( true );
+	} );
+
+	test( 'with N windows, closing the focused one focuses the next topmost', async () => {
+		await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+		const c = await manager.open( cfg( 'c' ) );
+		expect( c.isFocused() ).toBe( true );
+
+		c.close();
+
+		expect( b.isFocused() ).toBe( true );
+		expect( manager.getAll().some( ( w ) => w.isFocused() ) ).toBe( true );
+	} );
+
+	test( 'skips a minimized sibling and focuses the visible window', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+		// Minimize A, then re-focus B so the focused window (B) sits
+		// above a minimized window (A) in the stack.
+		a.minimize();
+		manager.focus( b );
+		expect( b.isFocused() ).toBe( true );
+		expect( a.state ).toBe( 'minimized' );
+
+		b.close();
+
+		// A is the only remaining window but it's minimized — it must
+		// NOT be force-focused (the user can't see it take focus).
+		expect( a.isFocused() ).toBe( false );
+		expect( a.state ).toBe( 'minimized' );
+	} );
+
+	test( 'skips a minimized window in favour of a visible one', async () => {
+		const a = await manager.open( cfg( 'a' ) ); // visible
+		const b = await manager.open( cfg( 'b' ) ); // will minimize
+		const c = await manager.open( cfg( 'c' ) ); // focused
+		b.minimize();
+		manager.focus( c );
+		expect( c.isFocused() ).toBe( true );
+
+		c.close();
+
+		// Topmost FOCUSABLE remaining window is A (B is minimized).
+		expect( a.isFocused() ).toBe( true );
+		expect( b.isFocused() ).toBe( false );
+	} );
+
+	test( 'does not focus a window on another virtual desktop', async () => {
+		const onOther = await manager.open( cfg( 'other', { desktopId: 'desktop-2' } ) );
+		const onActive = await manager.open( cfg( 'active' ) );
+		expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+		expect( onActive.isFocused() ).toBe( true );
+
+		onActive.close();
+
+		// The only remaining window lives on desktop-2 — invisible from
+		// the active desktop, so it must not be focused.
+		expect( onOther.isFocused() ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
- Implemented a registry for unfocus effects allowing plugins to register their own effects via `wp.desktop.registerUnfocusEffect()`.
- Created a server-sync module to manage the loading and unloading of unfocus effects based on server-side registrations.
- Developed an unfocus engine that applies the selected unfocus effect to all unfocused windows, responding to window lifecycle events and OS settings changes.
- Added a settings section for users to select their preferred unfocus effect, including a built-in 'darken' effect.
- Introduced unit tests for the new functionality, covering registration, synchronization, and effect application logic.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-299-e67c1bca7ccfdecb09459d8d716871db82554739.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->