### PR TITLE
Fix placement, gear/Help, and dock⇄desktop visibility bugs

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2791,11 +2791,13 @@ Posted by the chromeless bridge's `fetch` and `XMLHttpRequest` wrappers whenever
 ```
 
 #### `desktop-mode-screen-meta` — Stable
-Announces the screen-meta panels (Screen Options / Help) that the iframe page exposes. The parent renders corresponding title-bar buttons.
+Announces the screen-meta panels (Screen Options / Help) that the iframe page exposes. The parent renders one title-bar button per announced panel, replacing any previously rendered set.
 
 ```typescript
 { type: 'desktop-mode-screen-meta'; panels: ( 'screen-options' | 'help' )[] }
 ```
+
+The iframe sends this on every load — **including an empty `panels: []`** — so the parent can clear stale buttons when a page (e.g. after an in-place same-slug navigation) exposes no screen meta. A panel is announced only when its toggle link is present **and** the panel actually has content: a Screen Options panel with no form controls, or a Help tab registered with empty `content` and no callback, is omitted so the title bar never shows a button that opens an empty panel.
 
 #### `desktop-mode-screen-meta-state` — Stable
 Reports which screen-meta panel (if any) is currently open inside the iframe.

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -464,7 +464,13 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		}
 	}
 
-	// dockOrder — ordered list of sanitize_key()-clean ids.
+	// dockOrder — ordered list of item ids. Most are sanitize_key()-
+	// clean dock slugs, but cross-rail tiles the user promoted carry a
+	// rail-synthesis prefix (`desktop:<id>` / `dock:<id>`, built by
+	// src/settings/item-placement.ts). sanitize_key() strips the colon,
+	// which silently breaks the JS order match on reload and can collide
+	// with an unrelated id — so allow the colon (and hyphen/underscore)
+	// while still rejecting anything outside the JS id charset.
 	$dock_order = array();
 	if ( isset( $raw['dockOrder'] ) && is_array( $raw['dockOrder'] ) ) {
 		$seen = array();
@@ -472,7 +478,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 			if ( ! is_string( $id ) || '' === $id ) {
 				continue;
 			}
-			$slug = sanitize_key( $id );
+			$slug = (string) preg_replace( '/[^a-z0-9_:-]+/', '', strtolower( $id ) );
 			if ( '' === $slug || isset( $seen[ $slug ] ) ) {
 				continue;
 			}

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1949,29 +1949,55 @@ function desktop_mode_chromeless_bridge_script() {
 	}
 	window.__desktopModeScreenMetaInstalled = true;
 
-	var links = document.getElementById( 'screen-meta-links' );
-	if ( ! links ) {
-		return;
+	// Real screen options render form controls (column toggles, a
+	// per-page input, custom settings). An empty wrap should not
+	// surface a dead gear button.
+	function hasScreenOptionsContent() {
+		var wrap = document.getElementById( 'screen-options-wrap' );
+		return !! wrap && !! wrap.querySelector( 'input, select, textarea, button, fieldset' );
 	}
-	var screenOptionsBtn = document.getElementById( 'show-settings-link' );
-	var helpBtn = document.getElementById( 'contextual-help-link' );
+	// A help tab registered with empty content + no callback still
+	// produces #contextual-help-link but an empty panel. Require some
+	// non-whitespace tab/sidebar text before announcing the button.
+	function hasHelpContent() {
+		var wrap = document.getElementById( 'contextual-help-wrap' );
+		if ( ! wrap ) {
+			return false;
+		}
+		var panelEls = wrap.querySelectorAll( '.help-tab-content, .contextual-help-sidebar' );
+		for ( var i = 0; i < panelEls.length; i++ ) {
+			if ( ( panelEls[ i ].textContent || '' ).trim() !== '' ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	var links = document.getElementById( 'screen-meta-links' );
+	var screenOptionsBtn = links ? document.getElementById( 'show-settings-link' ) : null;
+	var helpBtn = links ? document.getElementById( 'contextual-help-link' ) : null;
 	var panels = [];
-	if ( screenOptionsBtn ) {
+	if ( screenOptionsBtn && hasScreenOptionsContent() ) {
 		panels.push( 'screen-options' );
 	}
-	if ( helpBtn ) {
+	if ( helpBtn && hasHelpContent() ) {
 		panels.push( 'help' );
-	}
-	if ( panels.length === 0 ) {
-		return;
 	}
 
 	var origin = window.location.origin;
 
+	// ALWAYS announce — including an empty array — so the parent removes
+	// stale gear/Help buttons when this page (e.g. after an in-place
+	// same-slug navigation) has no screen meta. addScreenMetaButtons()
+	// clears then repopulates, so an empty array removes everything.
 	window.parent.postMessage( {
 		type: 'desktop-mode-screen-meta',
 		panels: panels
 	}, origin );
+
+	if ( panels.length === 0 ) {
+		return;
+	}
 
 	function getOpenPanel() {
 		if ( screenOptionsBtn && screenOptionsBtn.getAttribute( 'aria-expanded' ) === 'true' ) {

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1954,7 +1954,11 @@ function desktop_mode_chromeless_bridge_script() {
 	// surface a dead gear button.
 	function hasScreenOptionsContent() {
 		var wrap = document.getElementById( 'screen-options-wrap' );
-		return !! wrap && !! wrap.querySelector( 'input, select, textarea, button, fieldset' );
+		// WP always renders a nonce hidden input and an "Apply" submit
+		// inside the wrap, so match only interactive option controls
+		// (toggles, per-page, radios, selects) — never that always-
+		// present scaffolding — or an empty panel reads as non-empty.
+		return !! wrap && !! wrap.querySelector( 'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="reset"]), select, textarea' );
 	}
 	// A help tab registered with empty content + no callback still
 	// produces #contextual-help-link but an empty panel. Require some

--- a/src/desktop-layout.ts
+++ b/src/desktop-layout.ts
@@ -341,15 +341,32 @@ export function createLayoutDispatcher(
 			return;
 		}
 		// Spatial owns the wallpaper as the "core surface": synthesized
-		// core menu icons render here. Server-registered plugin
-		// desktop icons are deliberately suppressed — plugin admin
-		// menus live in the bottom dock, and duplicating them on the
-		// wallpaper would create two paths to the same screen. The
-		// only Spatial-mode wallpaper additions beyond core synthesis
-		// are items the user EXPLICITLY promoted via OS Settings (an
-		// `itemVisibility` override on a dock-native item).
+		// core menu icons render here. Server-registered PLUGIN desktop
+		// icons with no override are deliberately suppressed — their
+		// admin menu lives in the bottom dock, and duplicating them on
+		// the wallpaper would create two paths to the same screen.
+		//
+		// Two classes of server icon MUST survive the Spatial layout,
+		// or the layout choice silently eats them:
+		//   1. Framework-owned `pinned` icons (e.g. My WordPress). These
+		//      are not plugin menus and have no dock equivalent;
+		//      suppressing them made the icon vanish from the wallpaper
+		//      with the ONLY recovery being "move it to the dock" via
+		//      OS Settings.
+		//   2. Icons the user EXPLICITLY moved to the desktop / both in
+		//      OS Settings → Apps & Icons. Without this the picker's
+		//      "On the desktop" choice silently no-ops in Spatial.
+		// Dock-native items the user promoted are appended separately
+		// below (they have no serverIcons entry).
 		const { core } = partition();
 		const synthesized = core.map( coreItemToIconEntry );
+		const keptServerIcons = serverIcons.filter( ( icon ) => {
+			const override = settings.itemVisibility[ icon.id ];
+			if ( override ) {
+				return override === 'desktop' || override === 'both';
+			}
+			return Boolean( icon.pinned );
+		} );
 		const explicitlyPromoted: DesktopIconServerEntry[] = [];
 		let synthIndex = 0;
 		for ( const item of items ) {
@@ -365,7 +382,11 @@ export function createLayoutDispatcher(
 				} );
 			}
 		}
-		deps.renderIcons( [ ...synthesized, ...explicitlyPromoted ] );
+		deps.renderIcons( [
+			...synthesized,
+			...keptServerIcons,
+			...explicitlyPromoted,
+		] );
 	};
 
 	const tearDownDocks = (): void => {

--- a/src/iframe-bridge-standalone.ts
+++ b/src/iframe-bridge-standalone.ts
@@ -847,26 +847,60 @@ interface IframeWp {
 	}
 
 	function installScreenMetaHoist( origin: string ): void {
+		// Real screen options render form controls (column toggles, a
+		// per-page input, custom settings). An empty wrap — a screen
+		// that forced the toggle on via the `screen_options_show_screen`
+		// filter but rendered nothing — should not surface a dead gear.
+		const hasScreenOptionsContent = (): boolean => {
+			const wrap = document.getElementById( 'screen-options-wrap' );
+			return (
+				!! wrap &&
+				!! wrap.querySelector(
+					'input, select, textarea, button, fieldset',
+				)
+			);
+		};
+		// A help tab registered with empty `content` and no callback
+		// still produces `#contextual-help-link` but an empty panel.
+		// Require at least one tab-content panel (or the sidebar) to
+		// carry non-whitespace text before announcing the Help button.
+		const hasHelpContent = (): boolean => {
+			const wrap = document.getElementById( 'contextual-help-wrap' );
+			if ( ! wrap ) {
+				return false;
+			}
+			const panelEls = wrap.querySelectorAll(
+				'.help-tab-content, .contextual-help-sidebar',
+			);
+			for ( let i = 0; i < panelEls.length; i++ ) {
+				if ( ( panelEls[ i ].textContent || '' ).trim() !== '' ) {
+					return true;
+				}
+			}
+			return false;
+		};
+
 		const start = (): void => {
 			const links = document.getElementById( 'screen-meta-links' );
-			if ( ! links ) {
-				return;
-			}
-			const screenOptionsBtn = document.getElementById(
-				'show-settings-link',
-			);
-			const helpBtn = document.getElementById( 'contextual-help-link' );
+			const screenOptionsBtn = links
+				? document.getElementById( 'show-settings-link' )
+				: null;
+			const helpBtn = links
+				? document.getElementById( 'contextual-help-link' )
+				: null;
 			const panels: string[] = [];
-			if ( screenOptionsBtn ) {
+			if ( screenOptionsBtn && hasScreenOptionsContent() ) {
 				panels.push( 'screen-options' );
 			}
-			if ( helpBtn ) {
+			if ( helpBtn && hasHelpContent() ) {
 				panels.push( 'help' );
 			}
-			if ( panels.length === 0 ) {
-				return;
-			}
 
+			// ALWAYS announce — including an empty array — so the parent
+			// removes stale gear/Help buttons when this page (e.g. after
+			// an in-place same-slug navigation) has no screen meta. The
+			// parent's addScreenMetaButtons() clears then repopulates, so
+			// `[]` is the correct "remove everything" signal.
 			try {
 				window.parent.postMessage(
 					{ type: 'desktop-mode-screen-meta', panels },
@@ -874,6 +908,10 @@ interface IframeWp {
 				);
 			} catch {
 				/* parent gone */
+			}
+
+			if ( panels.length === 0 ) {
+				return; // Nothing to observe or toggle on this page.
 			}
 
 			const getOpenPanel = (): 'screen-options' | 'help' | null => {

--- a/src/iframe-bridge-standalone.ts
+++ b/src/iframe-bridge-standalone.ts
@@ -853,10 +853,15 @@ interface IframeWp {
 		// filter but rendered nothing — should not surface a dead gear.
 		const hasScreenOptionsContent = (): boolean => {
 			const wrap = document.getElementById( 'screen-options-wrap' );
+			// WP always renders a nonce hidden input and an "Apply"
+			// submit inside the wrap, so match only *interactive option*
+			// controls (column toggles, per-page number, view-mode
+			// radios, custom selects) — never that always-present
+			// scaffolding — or an empty panel would read as non-empty.
 			return (
 				!! wrap &&
 				!! wrap.querySelector(
-					'input, select, textarea, button, fieldset',
+					'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="reset"]), select, textarea',
 				)
 			);
 		};

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -24,7 +24,11 @@
 
 import { __, sprintf } from './i18n';
 import { openWithShellOverlays } from './shell-overlays/loader';
-import { canonicalItemId } from './settings/item-placement';
+import {
+	canonicalItemId,
+	resolvePlacement,
+	type NativeRail,
+} from './settings/item-placement';
 import { wpdConfirm } from './ui/components/wpd-confirm-dialog/wpd-confirm-dialog';
 import { trackedFetch } from './tracked-fetch';
 import { showToast } from './toast';
@@ -72,6 +76,47 @@ function writeVisibility(
 	// desktop" / "Also show on dock" back into single-rail behavior.
 	next[ canonicalId ] = placement;
 	api.updateOsSettings( { itemVisibility: next } );
+}
+
+/**
+ * The item's native rail, derived from the rail-synthesis prefix on
+ * the DOM id. A bare id means the tile is rendered on its native rail
+ * (so the native rail equals the surface it was right-clicked on); a
+ * `dock:` / `desktop:` prefix names the originating rail explicitly.
+ */
+function railFromId( id: string, surface: 'dock' | 'desktop' ): NativeRail {
+	if ( id.startsWith( 'dock:' ) ) {
+		return 'dock';
+	}
+	if ( id.startsWith( 'desktop:' ) ) {
+		return 'desktop';
+	}
+	return surface;
+}
+
+/**
+ * Compute the placement a "Hide from <surface>" pick should write,
+ * branching on the item's CURRENT placement rather than blindly
+ * setting the opposite rail.
+ *
+ * - A 'both' item is demoted to the rail it is NOT being hidden from
+ *   (it stays visible where it still belongs).
+ * - A single-rail item is genuinely hidden ('hidden'). Writing the
+ *   opposite rail here was the bug: "Hide from dock" on a dock-only
+ *   tile wrote 'desktop' and the tile reappeared on the wallpaper
+ *   instead of disappearing.
+ */
+function computeHideTarget(
+	canonicalId: string,
+	nativeRail: NativeRail,
+	hideSurface: 'dock' | 'desktop',
+): ItemVisibility {
+	const visibility = getApi()?.getOsSettings?.().itemVisibility ?? {};
+	const current = resolvePlacement( canonicalId, nativeRail, visibility );
+	if ( current === 'both' ) {
+		return hideSurface === 'dock' ? 'desktop' : 'dock';
+	}
+	return 'hidden';
 }
 
 export interface OpenItemVisibilityMenuOpts {
@@ -141,6 +186,16 @@ function openItemVisibilityMenuImmediate(
 	closeMenu();
 
 	const canonical = canonicalItemId( opts.id );
+	const nativeRail = railFromId( opts.id, opts.surface );
+	// Current resolved placement drives which options are offered: the
+	// "Also show on <rail>" entry is hidden when the item is already on
+	// that rail (it would be a no-op), and "Hide from <surface>" reads
+	// the live state at pick time via computeHideTarget.
+	const currentPlacement = resolvePlacement(
+		canonical,
+		nativeRail,
+		getApi()?.getOsSettings?.().itemVisibility ?? {},
+	);
 
 	type MenuOption =
 		| {
@@ -160,27 +215,39 @@ function openItemVisibilityMenuImmediate(
 			id: 'hide-from-dock',
 			label: __( 'Hide from dock' ),
 			icon: 'dashicons-hidden',
-			onPick: () => writeVisibility( canonical, 'desktop' ),
+			onPick: () =>
+				writeVisibility(
+					canonical,
+					computeHideTarget( canonical, nativeRail, 'dock' ),
+				),
 		} );
-		options.push( {
-			id: 'show-on-desktop-too',
-			label: __( 'Also show on desktop' ),
-			icon: 'dashicons-desktop',
-			onPick: () => writeVisibility( canonical, 'both' ),
-		} );
+		if ( currentPlacement !== 'both' ) {
+			options.push( {
+				id: 'show-on-desktop-too',
+				label: __( 'Also show on desktop' ),
+				icon: 'dashicons-desktop',
+				onPick: () => writeVisibility( canonical, 'both' ),
+			} );
+		}
 	} else {
 		options.push( {
 			id: 'hide-from-desktop',
 			label: __( 'Hide from desktop' ),
 			icon: 'dashicons-hidden',
-			onPick: () => writeVisibility( canonical, 'dock' ),
+			onPick: () =>
+				writeVisibility(
+					canonical,
+					computeHideTarget( canonical, nativeRail, 'desktop' ),
+				),
 		} );
-		options.push( {
-			id: 'show-on-dock-too',
-			label: __( 'Also show on dock' ),
-			icon: 'dashicons-menu',
-			onPick: () => writeVisibility( canonical, 'both' ),
-		} );
+		if ( currentPlacement !== 'both' ) {
+			options.push( {
+				id: 'show-on-dock-too',
+				label: __( 'Also show on dock' ),
+				icon: 'dashicons-menu',
+				onPick: () => writeVisibility( canonical, 'both' ),
+			} );
+		}
 	}
 	options.push( {
 		id: 'hide-everywhere',

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -83,8 +83,13 @@ function writeVisibility(
  * the DOM id. A bare id means the tile is rendered on its native rail
  * (so the native rail equals the surface it was right-clicked on); a
  * `dock:` / `desktop:` prefix names the originating rail explicitly.
+ *
+ * Exported for unit testing — it is otherwise an internal helper.
  */
-function railFromId( id: string, surface: 'dock' | 'desktop' ): NativeRail {
+export function railFromId(
+	id: string,
+	surface: 'dock' | 'desktop',
+): NativeRail {
 	if ( id.startsWith( 'dock:' ) ) {
 		return 'dock';
 	}
@@ -105,13 +110,16 @@ function railFromId( id: string, surface: 'dock' | 'desktop' ): NativeRail {
  *   opposite rail here was the bug: "Hide from dock" on a dock-only
  *   tile wrote 'desktop' and the tile reappeared on the wallpaper
  *   instead of disappearing.
+ *
+ * Pure in `visibility` (the caller passes the live map) so it can be
+ * unit-tested without stubbing the shell API.
  */
-function computeHideTarget(
+export function computeHideTarget(
 	canonicalId: string,
 	nativeRail: NativeRail,
 	hideSurface: 'dock' | 'desktop',
+	visibility: Record< string, ItemVisibility >,
 ): ItemVisibility {
-	const visibility = getApi()?.getOsSettings?.().itemVisibility ?? {};
 	const current = resolvePlacement( canonicalId, nativeRail, visibility );
 	if ( current === 'both' ) {
 		return hideSurface === 'dock' ? 'desktop' : 'dock';
@@ -218,7 +226,12 @@ function openItemVisibilityMenuImmediate(
 			onPick: () =>
 				writeVisibility(
 					canonical,
-					computeHideTarget( canonical, nativeRail, 'dock' ),
+					computeHideTarget(
+						canonical,
+						nativeRail,
+						'dock',
+						getApi()?.getOsSettings?.().itemVisibility ?? {},
+					),
 				),
 		} );
 		if ( currentPlacement !== 'both' ) {
@@ -237,7 +250,12 @@ function openItemVisibilityMenuImmediate(
 			onPick: () =>
 				writeVisibility(
 					canonical,
-					computeHideTarget( canonical, nativeRail, 'desktop' ),
+					computeHideTarget(
+						canonical,
+						nativeRail,
+						'desktop',
+						getApi()?.getOsSettings?.().itemVisibility ?? {},
+					),
 				),
 		} );
 		if ( currentPlacement !== 'both' ) {

--- a/src/settings/desktop-shortcuts-sync.ts
+++ b/src/settings/desktop-shortcuts-sync.ts
@@ -143,6 +143,54 @@ let reentrant = false;
 const removedServerPlacementsByRef = new Map< string, RestPlacementShape >();
 
 /**
+ * Strip the given source-item ids from the persisted
+ * `dockPromotedPositions` map via the public OS-settings writer.
+ *
+ * Called when a promoted item is demoted or hidden, so its
+ * last-dragged coordinate doesn't linger forever (counting toward the
+ * 256-entry cap for, say, a deactivated plugin) or silently resurrect
+ * the old slot if the item is re-promoted later. The `reentrant` guard
+ * in {@link syncShortcutsWithVisibility} blocks the resulting
+ * settings-change notification from re-running the sync synchronously,
+ * and a later async re-run is a no-op (the position is already gone).
+ */
+function prunePromotedPositions( ids: string[] ): void {
+	const api = ( window as unknown as {
+		wp?: {
+			desktop?: {
+				getOsSettings?: () => {
+					dockPromotedPositions?: Record<
+						string,
+						{ x: number; y: number }
+					>;
+				};
+				updateOsSettings?: ( patch: {
+					dockPromotedPositions: Record<
+						string,
+						{ x: number; y: number }
+					>;
+				} ) => void;
+			};
+		};
+	} ).wp?.desktop;
+	if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
+		return;
+	}
+	const current = api.getOsSettings().dockPromotedPositions ?? {};
+	const next: Record< string, { x: number; y: number } > = { ...current };
+	let changed = false;
+	for ( const id of ids ) {
+		if ( id in next ) {
+			delete next[ id ];
+			changed = true;
+		}
+	}
+	if ( changed ) {
+		api.updateOsSettings( { dockPromotedPositions: next } );
+	}
+}
+
+/**
  * Bring the files store in line with the current
  * {@link OsSettingsState.itemVisibility} map. The `positions`
  * argument is the matching `dockPromotedPositions` map — synth
@@ -205,11 +253,20 @@ export function syncShortcutsWithVisibility(
 				}
 			}
 		}
-		// Remove synthetic placements that are no longer wanted.
+		// Remove synthetic placements that are no longer wanted, and
+		// prune their persisted drag position so stale coordinates can't
+		// leak or silently resurrect on a future re-promote.
+		const positionsToPrune: string[] = [];
 		for ( const [ sourceId, p ] of currentSynth ) {
 			if ( ! desiredSynth.has( sourceId ) ) {
 				filesApi.store.removePlacement( p.id );
+				if ( positions[ sourceId ] ) {
+					positionsToPrune.push( sourceId );
+				}
 			}
+		}
+		if ( positionsToPrune.length > 0 ) {
+			prunePromotedPositions( positionsToPrune );
 		}
 
 		// 2. Reconcile server-registered shortcuts (icons registered via

--- a/src/settings/desktop-shortcuts-sync.ts
+++ b/src/settings/desktop-shortcuts-sync.ts
@@ -35,6 +35,7 @@ import { filesApi } from '../desktop-files';
 import type { RestPlacementShape } from '../desktop-files/rest';
 import type { DesktopConfig, DesktopIconServerEntry, DockItemConfig } from '../types';
 import type { ItemVisibility, OsSettingsState } from './types';
+import type { OsSettingsSnapshot } from './registry';
 
 /** Marker on `placement.meta` for shortcuts we synthesized. */
 const SYNTH_META_KEY = '__synthFromDockItem';
@@ -158,18 +159,10 @@ function prunePromotedPositions( ids: string[] ): void {
 	const api = ( window as unknown as {
 		wp?: {
 			desktop?: {
-				getOsSettings?: () => {
-					dockPromotedPositions?: Record<
-						string,
-						{ x: number; y: number }
-					>;
-				};
-				updateOsSettings?: ( patch: {
-					dockPromotedPositions: Record<
-						string,
-						{ x: number; y: number }
-					>;
-				} ) => void;
+				getOsSettings?: () => OsSettingsSnapshot;
+				updateOsSettings?: (
+					patch: Partial< OsSettingsSnapshot >,
+				) => void;
 			};
 		};
 	} ).wp?.desktop;

--- a/src/settings/panel.ts
+++ b/src/settings/panel.ts
@@ -53,7 +53,7 @@ import '../ui/components/wpd-swatch/wpd-swatch';
 import '../ui/components/wpd-swatch-grid/wpd-swatch-grid';
 import '../ui/components/wpd-tabs/wpd-tabs';
 import '../ui/components/wpd-text-field/wpd-text-field';
-import { DEFAULTS } from './constants';
+import { structuredDefaults } from './state';
 import type { OsSettings } from './index';
 import type { DesktopSettingsTab } from './registry';
 import { listSettingsTabs, subscribeSettingsTabs } from './registry';
@@ -139,7 +139,10 @@ export function renderOsSettingsPanel(
 		// image still lives in Media Library, and it's an easy
 		// re-pick.
 		const preservedImage = ctx.state.customImage;
-		ctx.state = { ...DEFAULTS, customImage: preservedImage };
+		// `structuredDefaults()` deep-clones the nested objects, so the
+		// reset can never alias (and later corrupt) the module-level
+		// DEFAULTS singleton — see the function's own note.
+		ctx.state = { ...structuredDefaults(), customImage: preservedImage };
 		ctx.save();
 		ctx.apply();
 		ctx.renderPanel( body );

--- a/src/settings/sections/apps-icons.ts
+++ b/src/settings/sections/apps-icons.ts
@@ -96,14 +96,13 @@ export function buildAppsIconsSection( ctx: SettingsCtx ): HTMLElement {
 				}
 			};
 
-	const paint = (): void => {
+	const paint = (
+		visibility: Record< string, ItemVisibility > = ctx.state
+			.itemVisibility,
+	): void => {
 		const dockItems = readDockItems();
 		const desktopIcons = readDesktopIcons();
-		const rows = listPlaceableItems(
-			dockItems,
-			desktopIcons,
-			ctx.state.itemVisibility,
-		);
+		const rows = listPlaceableItems( dockItems, desktopIcons, visibility );
 
 		render(
 			html`
@@ -160,5 +159,34 @@ export function buildAppsIconsSection( ctx: SettingsCtx ): HTMLElement {
 	};
 
 	paint();
+
+	// Repaint when an EXTERNAL writer (the right-click visibility menu,
+	// or any other OS-settings consumer) mutates itemVisibility, so a
+	// row's <wpd-select> never shows a stale placement while this tab is
+	// open. Self-unsubscribes once the panel is torn down (the wrapper
+	// is no longer in the DOM), mirroring the wallpaper section's
+	// registry.subscribe pattern so listeners don't pile up across
+	// repeated settings-window opens.
+	const wpDesktop = ( window as unknown as {
+		wp?: {
+			desktop?: {
+				subscribeOsSettings?: (
+					cb: ( snapshot: {
+						itemVisibility: Record< string, ItemVisibility >;
+					} ) => void,
+				) => () => void;
+			};
+		};
+	} ).wp?.desktop;
+	if ( wpDesktop?.subscribeOsSettings ) {
+		const unsubscribe = wpDesktop.subscribeOsSettings( ( snapshot ) => {
+			if ( ! wrapper.isConnected ) {
+				unsubscribe();
+				return;
+			}
+			paint( snapshot.itemVisibility );
+		} );
+	}
+
 	return wrapper;
 }

--- a/src/settings/sections/apps-icons.ts
+++ b/src/settings/sections/apps-icons.ts
@@ -15,6 +15,7 @@ import { __ } from '../../i18n';
 import { html, render } from '../../ui/core';
 import { renderIcon } from '../../icon';
 import type { ItemVisibility, SettingsCtx } from '../types';
+import type { OsSettingsSnapshot } from '../registry';
 import { listPlaceableItems } from '../item-placement';
 import type { DesktopConfig } from '../../types';
 import type { DockItem } from '../../dock';
@@ -171,9 +172,7 @@ export function buildAppsIconsSection( ctx: SettingsCtx ): HTMLElement {
 		wp?: {
 			desktop?: {
 				subscribeOsSettings?: (
-					cb: ( snapshot: {
-						itemVisibility: Record< string, ItemVisibility >;
-					} ) => void,
+					cb: ( snapshot: OsSettingsSnapshot ) => void,
 				) => () => void;
 			};
 		};

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -539,6 +539,14 @@ export function structuredDefaults(): OsSettingsState {
 		customGradient: { ...DEFAULTS.customGradient },
 		customImage: null,
 		ai: { ...DEFAULTS.ai },
+		// Clone the collection fields too. A shallow `...DEFAULTS`
+		// aliases these nested objects, so a later in-place mutation
+		// (e.g. dragging the gradient editor after a Reset, which spreads
+		// these defaults into live state) would corrupt the module-level
+		// DEFAULTS singleton for the rest of the session.
+		itemVisibility: { ...DEFAULTS.itemVisibility },
+		dockOrder: [ ...DEFAULTS.dockOrder ],
+		dockPromotedPositions: { ...DEFAULTS.dockPromotedPositions },
 	};
 }
 

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -544,6 +544,12 @@ export function structuredDefaults(): OsSettingsState {
 		// (e.g. dragging the gradient editor after a Reset, which spreads
 		// these defaults into live state) would corrupt the module-level
 		// DEFAULTS singleton for the rest of the session.
+		//
+		// These are one-level clones, which is sufficient *because* all
+		// three defaults are empty (`{}` / `[]`) — there are no inner
+		// objects to share. If `DEFAULTS.dockPromotedPositions` ever
+		// ships seeded entries, its `{ x, y }` values would need a
+		// deeper clone here.
 		itemVisibility: { ...DEFAULTS.itemVisibility },
 		dockOrder: [ ...DEFAULTS.dockOrder ],
 		dockPromotedPositions: { ...DEFAULTS.dockPromotedPositions },

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -257,8 +257,11 @@ export interface OsSettingsState {
 	 *   - `'hidden'`  — hide from every shell surface.
 	 *
 	 * Missing keys mean "no override" — items use whichever rail they
-	 * natively live on. The `'both'` value is never persisted (the
-	 * server drops it on save) so the map stays compact.
+	 * natively live on. All four values — including `'both'` — are
+	 * persisted verbatim: PHP's sanitizer
+	 * (`includes/os-settings.php`, `$allowed_placements`) whitelists
+	 * `'both'`, and the right-click menu stores it explicitly, so a
+	 * "show on both rails" choice survives a reload.
 	 *
 	 * @since 0.25.0
 	 */

--- a/tests/phpunit/tests/osSettings.php
+++ b/tests/phpunit/tests/osSettings.php
@@ -254,4 +254,45 @@ class Tests_DesktopMode_OsSettings extends WP_UnitTestCase {
 		);
 		$this->assertCount( 256, $clean['dockPromotedPositions'] );
 	}
+
+	/**
+	 * dockOrder entries may carry a rail-synthesis prefix
+	 * (`desktop:<id>` / `dock:<id>`) for cross-rail tiles the user
+	 * promoted. `sanitize_key()` would strip the colon and silently
+	 * break the JS order match (and risk an id collision) on reload, so
+	 * the sanitizer must preserve it.
+	 *
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_preserves_rail_prefix_colon_in_dock_order() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'dockOrder' => array( 'desktop:my-icon', 'edit-php', 'dock:woocommerce' ),
+			)
+		);
+		$this->assertSame(
+			array( 'desktop:my-icon', 'edit-php', 'dock:woocommerce' ),
+			$clean['dockOrder']
+		);
+	}
+
+	/**
+	 * The dockOrder sanitizer still rejects characters outside the JS
+	 * id charset — spaces collapse, case folds, and punctuation/markup
+	 * is stripped — so an evil blob can't smuggle anything unexpected
+	 * into the persisted order.
+	 *
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_normalizes_dock_order_ids() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'dockOrder' => array( 'Edit Php', '<script>x', 'desktop:My-Icon' ),
+			)
+		);
+		$this->assertSame(
+			array( 'editphp', 'scriptx', 'desktop:my-icon' ),
+			$clean['dockOrder']
+		);
+	}
 }

--- a/tests/vitest/desktop-layout.test.ts
+++ b/tests/vitest/desktop-layout.test.ts
@@ -256,7 +256,7 @@ describe( 'desktop-layout dispatcher', () => {
 		expect( bottomTiles ).not.toContain( 'edit.php' );
 	} );
 
-	test( 'spatial: renders only synthesized core icons, drops server icons', () => {
+	test( 'spatial: drops non-pinned server icons without an override', () => {
 		const { deps, renderIcons } = makeDeps();
 		const serverIcons: DesktopIconServerEntry[] = [
 			{
@@ -280,14 +280,75 @@ describe( 'desktop-layout dispatcher', () => {
 		const ids = ( lastCall as DesktopIconServerEntry[] ).map(
 			( i ) => i.id,
 		);
-		// Server-registered plugin icons are deliberately suppressed
-		// in Spatial — the wallpaper is the "core surface." Plugin
-		// menus live in the bottom dock; doubling them up on the
-		// wallpaper was the user-reported bug.
+		// Plugin icons with no explicit placement override stay
+		// suppressed in Spatial — the wallpaper is the "core surface,"
+		// and their admin menu lives in the bottom dock. Doubling them
+		// up on the wallpaper was the original user-reported bug.
 		expect( ids ).toEqual( [
 			'dock-core:index.php',
 			'dock-core:edit.php',
 		] );
+	} );
+
+	test( 'spatial: keeps pinned server icons (e.g. My WordPress)', () => {
+		const { deps, renderIcons } = makeDeps();
+		const serverIcons: DesktopIconServerEntry[] = [
+			{
+				id: 'desktop-mode-my-wordpress',
+				title: 'My WordPress',
+				icon: 'dashicons-wordpress',
+				window: 'desktop-mode-my-wordpress',
+				url: '',
+				position: -1,
+				pinned: true,
+			},
+		];
+		createLayoutDispatcher(
+			deps,
+			'spatial',
+			[ dashboard, posts ],
+			serverIcons,
+		);
+
+		const ids = (
+			renderIcons.mock.calls.at( -1 )![ 0 ] as DesktopIconServerEntry[]
+		).map( ( i ) => i.id );
+		// Regression guard: a framework-owned pinned icon must survive
+		// the Spatial layout. Suppressing it made My WordPress vanish
+		// from the wallpaper on installs using Spatial.
+		expect( ids ).toContain( 'desktop-mode-my-wordpress' );
+	} );
+
+	test( 'spatial: keeps server icons the user explicitly promoted to the desktop', () => {
+		const { deps, renderIcons } = makeDeps( {
+			getSettings: () => ( {
+				itemVisibility: { 'plugin-icon': 'desktop' },
+				dockOrder: [],
+			} ),
+		} );
+		const serverIcons: DesktopIconServerEntry[] = [
+			{
+				id: 'plugin-icon',
+				title: 'Plugin',
+				icon: 'dashicons-admin-plugins',
+				window: 'plugin-window',
+				url: '',
+				position: 50,
+			},
+		];
+		createLayoutDispatcher(
+			deps,
+			'spatial',
+			[ dashboard, posts ],
+			serverIcons,
+		);
+
+		const ids = (
+			renderIcons.mock.calls.at( -1 )![ 0 ] as DesktopIconServerEntry[]
+		).map( ( i ) => i.id );
+		// The OS Settings → Apps & Icons "On the desktop" choice must
+		// not silently no-op in Spatial.
+		expect( ids ).toContain( 'plugin-icon' );
 	} );
 
 	test( 'classic + unified: renderIcons gets only the server list (no synthesis)', () => {

--- a/tests/vitest/item-visibility-menu.test.ts
+++ b/tests/vitest/item-visibility-menu.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the pure helpers behind the right-click visibility
+ * menu — the native-rail derivation and the "Hide from <surface>"
+ * placement computation. `computeHideTarget` is the core correctness
+ * fix for the "teleporting tile" bug, so it gets direct coverage here
+ * rather than only through integration paths.
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+	railFromId,
+	computeHideTarget,
+} from '../../src/item-visibility-menu';
+
+describe( 'railFromId', () => {
+	test( 'derives the native rail from a synthesis prefix', () => {
+		expect( railFromId( 'dock:edit-php', 'desktop' ) ).toBe( 'dock' );
+		expect( railFromId( 'desktop:my-icon', 'dock' ) ).toBe( 'desktop' );
+	} );
+
+	test( 'a bare id is native to the surface it was clicked on', () => {
+		expect( railFromId( 'woocommerce', 'dock' ) ).toBe( 'dock' );
+		expect( railFromId( 'my-icon', 'desktop' ) ).toBe( 'desktop' );
+	} );
+} );
+
+describe( 'computeHideTarget', () => {
+	test( 'a both-rail item is demoted to the rail it is NOT hidden from', () => {
+		expect(
+			computeHideTarget( 'woo', 'dock', 'dock', { woo: 'both' } ),
+		).toBe( 'desktop' );
+		expect(
+			computeHideTarget( 'mw', 'desktop', 'desktop', { mw: 'both' } ),
+		).toBe( 'dock' );
+	} );
+
+	test( 'a single-rail item is genuinely hidden, not teleported', () => {
+		// Regression guard: a dock-only tile (no override → resolves to
+		// its native dock rail) hidden from the dock must become
+		// 'hidden'. The pre-fix bug wrote 'desktop', so the tile
+		// reappeared on the wallpaper instead of disappearing.
+		expect( computeHideTarget( 'woo', 'dock', 'dock', {} ) ).toBe(
+			'hidden',
+		);
+		expect(
+			computeHideTarget( 'woo', 'dock', 'dock', { woo: 'dock' } ),
+		).toBe( 'hidden' );
+		// Symmetric case: a desktop-native icon hidden from the desktop.
+		expect(
+			computeHideTarget( 'my-icon', 'desktop', 'desktop', {} ),
+		).toBe( 'hidden' );
+		expect(
+			computeHideTarget( 'my-icon', 'desktop', 'desktop', {
+				'my-icon': 'desktop',
+			} ),
+		).toBe( 'hidden' );
+	} );
+
+	test( 'an explicit override is honored over the native rail', () => {
+		// A desktop-native icon the user moved to the dock, then hides
+		// from the dock → 'hidden' (it is no longer on the desktop).
+		expect(
+			computeHideTarget( 'my-icon', 'desktop', 'dock', {
+				'my-icon': 'dock',
+			} ),
+		).toBe( 'hidden' );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes a cluster of app-placement, screen-meta, and item-visibility bugs surfaced by a behavioral audit. Two were user-reported (My WordPress missing from the wallpaper; gear/Help buttons showing with nothing behind them); the rest are adjacent correctness issues found while tracing those paths. Every finding was reproduced in code and adversarially verified before fixing.

No public-API breakage. The only documented surface touched is the `desktop-mode-screen-meta` bridge message, whose change is backwards-compatible (an empty `panels: []` was already a valid payload) — `docs/javascript-reference.md` is updated in the same PR.

## Why

- **My WordPress vanished from the desktop on some installs.** Root cause: the Spatial desktop layout silently dropped *all* server-registered desktop icons. The only recovery was OS Settings → Apps → move it to the dock.
- **Gear / Help title-bar buttons appeared with nothing to show.** Two causes: the buttons were never cleared when an iframe navigated in place to a page with no screen meta, and detection keyed on element presence rather than panel content.
- **"Hide" on a dock/desktop tile didn't hide it** for single-rail items — it teleported the tile to the *other* rail.

## Changes

### 🔴 High

- **Spatial layout no longer drops the pinned My WordPress icon** — `src/desktop-layout.ts`
  `repaintIcons()`'s spatial branch now keeps server icons that are either `pinned` (framework-owned, e.g. My WordPress) or carry an explicit `desktop`/`both` placement override. Non-pinned plugin icons with no override stay suppressed (the deliberate "core surface" design). This also fixes the OS Settings "On the desktop" picker silently no-opping in Spatial.

- **Right-click "Hide" stops teleporting items** — `src/item-visibility-menu.ts`
  "Hide from dock/desktop" now derives the target from the item's *current* placement via a new `computeHideTarget()` (`both` → the other rail; single-rail → `hidden`) instead of unconditionally writing the opposite rail. Native rail is derived from the rail-synthesis id prefix.

### 🟠 Medium

- **Stale gear/Help cleared on navigation** — `src/iframe-bridge-standalone.ts`, `includes/render/chromeless-bridge.php`
  Both bridges now *always* announce `desktop-mode-screen-meta` (including an empty `panels: []`) so the parent removes stale buttons when a page exposes no screen meta after an in-place same-slug navigation.

- **Visibility menu is state-aware** — `src/item-visibility-menu.ts`
  "Also show on \<rail\>" is hidden when the item is already on `both` (it was a no-op re-write).

- **OS Settings → Apps & Icons repaints live** — `src/settings/sections/apps-icons.ts`
  The tab subscribes to `wp.desktop.subscribeOsSettings` and repaints on external writes (e.g. a right-click visibility change), self-unsubscribing once the panel is torn down. Previously the row dropdown showed stale placement until the panel was rebuilt.

- **Reset no longer corrupts the DEFAULTS singleton** — `src/settings/state.ts`, `src/settings/panel.ts`
  `structuredDefaults()` now deep-clones the collection fields (`itemVisibility`, `dockOrder`, `dockPromotedPositions`), and `onReset` uses it instead of a shallow `{ ...DEFAULTS }`. Fixes the custom-gradient editor mutating the module-level `DEFAULTS` for the rest of the session after a Reset.

- **`dockOrder` survives the PHP round-trip** — `includes/os-settings.php`
  Cross-rail tiles persist with a rail-synthesis prefix (`desktop:<id>` / `dock:<id>`). `sanitize_key()` stripped the colon, silently resetting the user's order (and risking an id collision) on reload. The `dockOrder` sanitizer now preserves the colon while still rejecting anything outside the JS id charset. (itemVisibility / dockPromotedPositions keys are canonical and unaffected.)

### 🟡 Low

- **Content-less Screen Options / Help no longer surface a dead button** — both bridges
  A panel is announced only when its toggle link is present **and** the panel has renderable content (form controls for Screen Options; non-empty tab/sidebar text for Help).

- **Contract drift corrected** — `src/settings/types.ts`, `docs/javascript-reference.md`
  The `itemVisibility` docblock wrongly claimed `'both'` is never persisted; it *is* (PHP whitelists it, the menu stores it). Doc updated, plus the empty-array `screen-meta` semantics.

- **`dockPromotedPositions` no longer leaks** — `src/settings/desktop-shortcuts-sync.ts`
  When a promoted item is demoted/hidden, its persisted drag position is pruned (reentrancy-safe), so stale coordinates can't accumulate toward the 256-entry cap or silently resurrect on a future re-promote.

> Investigated and **dismissed** (no change): the "first-run seeding / absent key resolves to hidden" theory. `resolvePlacement` correctly falls back to the native rail for an unset key, so fresh and existing accounts behave identically — the real My WordPress cause was the Spatial branch above.

## Testing

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test:js` ✓ — **1548 passed** (added spatial-layout coverage: pinned icon kept, explicit promotion kept, non-pinned/no-override still dropped)
- `npm run build` ✓
- `php -l` ✓ on both changed PHP files
- `npm run test:php` ✓ — **926 tests / 2175 assertions** (added `dockOrder` colon-preservation + normalization tests)

## Notes for reviewers

- **Spatial design decision (#1):** I kept the deliberate suppression of *non-pinned, no-override* plugin desktop icons in Spatial — only `pinned` framework icons and explicitly-promoted icons survive — to avoid unilaterally changing the documented "core surface" behavior. If we'd rather Spatial mirror Classic/Unified and show all desktop-resolved server icons, it's a one-line change to the filter.
- The screen-meta fix is applied to **both** the standalone TS bridge and the inline PHP chromeless bridge so they stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-300-6d146d2eddb0f3231eb390bb4260b8546c54ec15.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->