### PR TITLE
feat: add "View activity footprint" row action in Users list

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -148,6 +148,26 @@ Modifier-key clicks (cmd / ctrl / shift / alt, middle-click, `target="_blank"`, 
 
 Forms submit through a separate `submit` listener that only rewrites the action URL (to keep `desktop_mode_chromeless=1`) and never `preventDefault`s. Same-origin form posts to a different page would currently navigate the iframe in place; if that becomes a UX problem it can join this protocol as a `desktop-mode-iframe-admin-form-submit` message.
 
+## Activity-footprint launcher inside chromeless iframes — Stable *(since 0.23.0)*
+
+The classic Users list table (`users.php`, rendered as a chromeless iframe) grows a **"View activity footprint"** row action — added server-side by `desktop_mode_user_footprint_row_action` (see [`hooks-reference.md`](hooks-reference.md)). Clicking it opens the target user's GitHub-style activity footprint inside the **My WordPress** native window, *without* closing the Users list.
+
+This deliberately does NOT reuse the admin-link path above: that path closes the source iframe on a native-window remap hit (it models a navigation *away*). A row action is an auxiliary *peek*, so it gets its own message.
+
+**Carrier contract.** The row-action link declares the target on the anchor itself:
+
+| Attribute | Value |
+|---|---|
+| `data-desktop-mode-footprint` | Target user id (positive integer). **Required** — its presence is what the bridge sniffs. |
+| `data-desktop-mode-footprint-name` | Display name, used to seed the footprint breadcrumb before the REST payload resolves. Optional. |
+| `href` | A real `user-edit.php?user_id=N` / `profile.php` URL — the graceful fallback followed only when JS is off or on a modifier / middle click. |
+
+| Type | Direction | Carries | Purpose |
+|---|---|---|---|
+| `desktop-mode-open-user-footprint` | iframe → parent | `{ userId: number, userName: string }` | Posted from the chromeless bridge when a `[data-desktop-mode-footprint]` link is clicked (checked *before* the admin-link classifier, so the fallback `href` is never followed inside the shell). The parent opens / focuses the My WordPress window on that user's footprint route and leaves the source window open. |
+
+**Parent dispatch** (`src/window/iframe-bridge.ts`): calls `openUserFootprintWindow( { userId, userName } )` (`src/my-wordpress/footprint-target.ts`), which stashes the target in the `desktop-mode/my-wordpress/footprint-target` shared store, then opens the window via `wp.desktop.openWindow`. Cold-start safe: the My WordPress bundle reads the target on mount and subscribes for re-targets while it's already open. See [`javascript-reference.md`](javascript-reference.md) for the public `wp.desktop.myWordpress.openUserFootprint`.
+
 ## Public hooks
 
 | Hook | Kind | Status | Payload |

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2289,6 +2289,16 @@ apply_filters( 'desktop_mode_my_wordpress_user_footprint', array $payload, int $
 
 The per-user activity-footprint payload returned by `GET /desktop-mode/v1/user-footprint/<id>` — drives the full-body "View activity footprint" surface (right-click on a user tile → footprint). Carries a year of day-by-day activity, weekday + hour-of-day distribution, streak math, recent-events timeline, and totals. Plugins can extend the timeline with their own activity rows (deploys, badges earned, etc.) or replace the streak math with a domain-specific definition.
 
+### `desktop_mode_user_footprint_row_action` — Stable (filter, since 0.23.0)
+
+```php
+apply_filters( 'desktop_mode_user_footprint_row_action', bool $show, WP_User $user_object ): bool
+```
+
+Gates the **"View activity footprint"** row action added to the classic Users list table (`users.php`). The action is only ever appended on a chromeless request (inside the desktop shell's iframe, where the bridge is present to receive the click); this filter is the final say within that context. Return `false` to suppress the action for a given user — e.g. to scope it to a role, or hide it on the viewer's own row. Default `true`.
+
+The action carries the target user id in a `data-desktop-mode-footprint` attribute; the chromeless bridge escalates the click as the `desktop-mode-open-user-footprint` message (see [`bridge-protocol.md`](bridge-protocol.md) and [`javascript-reference.md`](javascript-reference.md)), opening the My WordPress window on that user's footprint without closing the Users list. The link's `href` is a real `user-edit.php` / `profile.php` URL — the graceful fallback for no-JS or modifier clicks.
+
 ### `desktop_mode_my_wordpress_media_usage` — Experimental (filter, since 0.21.0)
 
 ```php

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2761,6 +2761,13 @@ Posted when a link inside the iframe points off-site; the parent opens an extern
 { type: 'desktop-mode-external-link'; url: string; label?: string }
 ```
 
+#### `desktop-mode-open-user-footprint` — Stable *(since 0.23.0)*
+Posted when a `[data-desktop-mode-footprint]` link is clicked inside a chromeless iframe — the "View activity footprint" row action on the classic Users table. Checked *before* the admin-link classifier, so the link's fallback `href` is never followed inside the shell. The parent opens (or focuses) the My WordPress window on that user's footprint route and leaves the source window open (it's an auxiliary peek, not a navigation away — contrast `desktop-mode-iframe-admin-link`, which closes the source on a remap hit). The public entry point is [`wp.desktop.myWordpress.openUserFootprint`](#public-api--wpdesktopmywordpress); see also `bridge-protocol.md`.
+
+```typescript
+{ type: 'desktop-mode-open-user-footprint'; userId: number; userName: string }
+```
+
 #### `desktop-mode-iframe-error` — Stable
 Posted from inside the chromeless iframe's `error` / `unhandledrejection` handlers. The parent re-dispatches as `HOOKS.IFRAME_ERROR` with `{ windowId, kind, message, filename, lineno, colno, stack }` so monitor widgets can subscribe.
 
@@ -4257,6 +4264,22 @@ interface MyWordpressApi {
      * @since 0.21.0
      */
     openMedia( args: { mediaId: number; mediaTitle?: string } ): void;
+
+    /**
+     * Open a user's GitHub-style activity footprint. Mirror of
+     * `openDetail` / `openMedia`, for users. Idempotent and
+     * cold-start safe — opens (or focuses) the window and navigates
+     * it to the footprint route even from a session that never
+     * opened My WordPress.
+     *
+     * This is the same window the "View activity footprint" row
+     * action in the classic Users table reaches (that path routes
+     * through the `desktop-mode-open-user-footprint` bridge message;
+     * see § 3 and `bridge-protocol.md`).
+     *
+     * @since 0.23.0
+     */
+    openUserFootprint( args: { userId: number; userName?: string } ): void;
 
     /**
      * Register a renderer for a custom entity kind so a plugin

--- a/includes/my-wordpress/bootstrap.php
+++ b/includes/my-wordpress/bootstrap.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/lock.php';
 require_once __DIR__ . '/user-stats.php';
 require_once __DIR__ . '/user-list-fields.php';
 require_once __DIR__ . '/user-footprint.php';
+require_once __DIR__ . '/users-list-footprint.php';
 require_once __DIR__ . '/term-stats.php';
 require_once __DIR__ . '/comment-stats.php';
 require_once __DIR__ . '/media-usage.php';

--- a/includes/my-wordpress/users-list-footprint.php
+++ b/includes/my-wordpress/users-list-footprint.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Desktop Mode — "View activity footprint" row action in the classic
+ * Users list table.
+ *
+ * Adds a hover row action to `wp-admin/users.php` that, inside the
+ * desktop shell's chromeless iframe, opens the user's GitHub-style
+ * activity footprint in the "My WordPress" native window. The link's
+ * `href` is a real profile-edit URL so a no-JS load or a modifier /
+ * middle click degrades to a sensible page; inside the shell the
+ * chromeless bridge (`includes/render/chromeless-bridge.php`)
+ * intercepts the `data-desktop-mode-footprint` attribute and
+ * postMessages the parent to open the footprint WITHOUT navigating the
+ * Users list away.
+ *
+ * Only rendered on chromeless requests — the one context where the
+ * desktop shell is present to receive the message. In a detached
+ * classic tab (`?desktop_mode_classic=1`) or with desktop mode off the
+ * action is omitted rather than shown as a link that would mislabel the
+ * profile editor as the footprint. When the native Users window opt-in
+ * is on, `users.php` is remapped to that window and never renders this
+ * classic list, so there is no conflict.
+ *
+ * @package WPDesktopMode
+ * @since   0.23.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Append the "View activity footprint" action to a Users-table row.
+ *
+ * Hooked on `user_row_actions`. Returns the actions unchanged outside
+ * a chromeless request, for an invalid user object, or when the
+ * `desktop_mode_user_footprint_row_action` filter opts the row out.
+ *
+ * @since 0.23.0
+ *
+ * @param string[] $actions     Row action links keyed by slug.
+ * @param WP_User  $user_object The user the row represents.
+ * @return string[] Filtered row actions.
+ */
+function desktop_mode_user_footprint_row_action( $actions, $user_object ) {
+	if ( ! desktop_mode_is_chromeless_request() ) {
+		return $actions;
+	}
+
+	if ( ! ( $user_object instanceof WP_User ) || $user_object->ID <= 0 ) {
+		return $actions;
+	}
+
+	$user_id = (int) $user_object->ID;
+
+	/**
+	 * Filters whether the "View activity footprint" row action is shown
+	 * for a user in the classic Users list table.
+	 *
+	 * Return false to suppress the action — e.g. to scope it to a role,
+	 * or to hide it on the current user's own row. Default true for any
+	 * chromeless request that reaches this filter (where the row is
+	 * already gated by the `list_users` capability the table requires).
+	 *
+	 * @since 0.23.0
+	 *
+	 * @param bool    $show        Whether to show the action. Default true.
+	 * @param WP_User $user_object The user the row represents.
+	 */
+	if ( ! apply_filters( 'desktop_mode_user_footprint_row_action', true, $user_object ) ) {
+		return $actions;
+	}
+
+	// Graceful fallback target, followed only when JS is off or on a
+	// modifier / middle click: the profile-edit screen for this user
+	// (own profile uses profile.php). Inside the shell the chromeless
+	// bridge preventDefaults the click and opens the footprint instead.
+	$fallback_url = get_current_user_id() === $user_id
+		? admin_url( 'profile.php' )
+		: add_query_arg( 'user_id', $user_id, admin_url( 'user-edit.php' ) );
+
+	$actions['desktop-mode-footprint'] = sprintf(
+		'<a href="%1$s" data-desktop-mode-footprint="%2$d" data-desktop-mode-footprint-name="%3$s">%4$s</a>',
+		esc_url( $fallback_url ),
+		$user_id,
+		esc_attr( $user_object->display_name ),
+		esc_html__( 'View activity footprint', 'desktop-mode' )
+	);
+
+	return $actions;
+}
+add_filter( 'user_row_actions', 'desktop_mode_user_footprint_row_action', 10, 2 );

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1056,6 +1056,41 @@ function desktop_mode_chromeless_bridge_script() {
 			return;
 		}
 		/*
+		 * Activity-footprint launcher. A "View activity footprint" row
+		 * action (added to the Users list table by
+		 * `desktop_mode_user_footprint_row_action`) carries the target
+		 * user id in `data-desktop-mode-footprint`. The iframe has no
+		 * shell API of its own, so we escalate the click to the parent
+		 * shell, which opens the My WordPress window on that user's
+		 * footprint. Checked BEFORE classifyLink so the link's real
+		 * href — a graceful profile-edit fallback for no-JS — is never
+		 * followed inside the shell. Modifier-key / middle clicks are
+		 * already filtered above, so cmd/ctrl-click still opens that
+		 * fallback in a new browser tab.
+		 */
+		var footprintAttr = link.getAttribute( 'data-desktop-mode-footprint' );
+		if ( footprintAttr ) {
+			var footprintUid = parseInt( footprintAttr, 10 );
+			if ( footprintUid > 0 ) {
+				e.preventDefault();
+				try {
+					window.parent.postMessage(
+						{
+							type: 'desktop-mode-open-user-footprint',
+							userId: footprintUid,
+							userName: link.getAttribute( 'data-desktop-mode-footprint-name' ) || ''
+						},
+						window.location.origin
+					);
+				} catch ( footprintErr ) {
+					/* Same-origin postMessage can only fail in a sandbox
+					 * we don't support — swallow rather than block the
+					 * click. */
+				}
+				return;
+			}
+		}
+		/*
 		 * WordPress core's wp-admin/js/updates.js owns the click on these
 		 * AJAX-driven plugin/theme management buttons — it binds in bubble
 		 * phase and calls preventDefault to take over with an in-place

--- a/src/my-wordpress/footprint-target.ts
+++ b/src/my-wordpress/footprint-target.ts
@@ -1,0 +1,193 @@
+/**
+ * My WordPress — cross-bundle "open this user's activity footprint"
+ * target.
+ *
+ * The native My WordPress window's bundle is lazy-loaded and lives in
+ * its own Vite IIFE. The click that requests a footprint originates
+ * elsewhere — most notably the chromeless `users.php` iframe, whose
+ * row-action click is routed through the window-system bundle's
+ * `handleWindowMessage`. Module-level state in one bundle is invisible
+ * to another (see `AGENTS.md` § "Cross-bundle state"), so the target
+ * user is threaded through `wp.desktop.createSharedStore` — the same
+ * mechanism `src/posts-window/user-edit-target.ts` uses for the User
+ * Edit window.
+ *
+ * Flow:
+ *   1. A caller (parent shell handler, plugin code) invokes
+ *      `openUserFootprintWindow( { userId, userName } )`.
+ *   2. That stashes the target here, then calls
+ *      `wp.desktop.openWindow( 'desktop-mode-my-wordpress' )`, which
+ *      opens the window — triggering the lazy bundle load — or focuses
+ *      it when it is already open.
+ *   3. The My WordPress bundle reads the target on mount (cold open)
+ *      and subscribes for re-targets (warm, already-open window). See
+ *      `src/my-wordpress/index.ts`.
+ *
+ * Cold-start safety is the whole point of routing through the shared
+ * store rather than `wp.desktop.myWordpress.openDetail()`: the latter
+ * only exists once the lazy bundle has mounted (the early stub in
+ * `early-api.ts` buffers `registerEntityKind` and nothing else), so a
+ * footprint click in a session that never opened My WordPress would
+ * silently no-op.
+ *
+ * @since 0.23.0
+ */
+
+/** Native My WordPress window id — the lazy bundle's `WINDOW_ID`. */
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+interface SharedStoreApi< T > {
+	state: T;
+	notify(): void;
+	subscribe( cb: ( state: T ) => void ): () => void;
+}
+
+/** Pending footprint target shared across bundles. */
+export interface FootprintTarget {
+	/** Target user id, or `null` when nothing is pending. */
+	userId: number | null;
+	/**
+	 * Display name for the breadcrumb/title before the REST footprint
+	 * payload resolves. Empty string when the caller didn't supply one.
+	 */
+	userName: string;
+	/**
+	 * `Date.now()` of the last `set` — lets consumers tell a fresh
+	 * request apart from a stale one and dedupe the mount-read vs the
+	 * subscribe callback.
+	 */
+	requestedAt: number;
+}
+
+interface DesktopFacade {
+	createSharedStore?: < T >(
+		key: string,
+		initial: () => T,
+	) => SharedStoreApi< T >;
+	openWindow?: (
+		id: string,
+		opts?: { source?: string },
+	) => boolean | undefined;
+}
+
+const _initial: FootprintTarget = {
+	userId: null,
+	userName: '',
+	requestedAt: 0,
+};
+
+function getDesktop(): DesktopFacade | undefined {
+	return ( window as unknown as { wp?: { desktop?: DesktopFacade } } ).wp
+		?.desktop;
+}
+
+let _store: SharedStoreApi< FootprintTarget > | null = null;
+function getStore(): SharedStoreApi< FootprintTarget > | null {
+	if ( _store ) {
+		return _store;
+	}
+	const factory = getDesktop()?.createSharedStore;
+	if ( typeof factory !== 'function' ) {
+		return null;
+	}
+	_store = factory< FootprintTarget >(
+		'desktop-mode/my-wordpress/footprint-target',
+		() => ( { ..._initial } ),
+	);
+	return _store;
+}
+
+/**
+ * Set the pending footprint target the next My WordPress window open
+ * should render. Must be called BEFORE
+ * `openWindow( 'desktop-mode-my-wordpress' )`.
+ */
+export function setFootprintTarget( userId: number, userName = '' ): void {
+	const store = getStore();
+	if ( store ) {
+		store.state.userId = userId;
+		store.state.userName = userName;
+		store.state.requestedAt = Date.now();
+		// `createSharedStore` is mutate-then-notify; subscribers don't
+		// fire on field assignment alone. Easy to forget, silent
+		// failure when you do — see `user-edit-target.ts`.
+		store.notify();
+		return;
+	}
+	// Pre-facade fallback (tests / very early boot before
+	// `wp.desktop.createSharedStore` exists): stash on `window`.
+	(
+		window as unknown as { _wpdFootprintTarget?: FootprintTarget }
+	)._wpdFootprintTarget = {
+		userId,
+		userName,
+		requestedAt: Date.now(),
+	};
+}
+
+/** Read the pending target. `userId === null` means nothing pending. */
+export function readFootprintTarget(): FootprintTarget {
+	const store = getStore();
+	if ( store ) {
+		return { ...store.state };
+	}
+	return (
+		( window as unknown as { _wpdFootprintTarget?: FootprintTarget } )
+			._wpdFootprintTarget ?? { ..._initial }
+	);
+}
+
+/** Clear the target after a consumer has captured it. */
+export function clearFootprintTarget(): void {
+	const store = getStore();
+	if ( store ) {
+		store.state.userId = null;
+		store.state.userName = '';
+		store.state.requestedAt = 0;
+		store.notify();
+	}
+	const w = window as unknown as { _wpdFootprintTarget?: FootprintTarget };
+	if ( w._wpdFootprintTarget ) {
+		w._wpdFootprintTarget = { ..._initial };
+	}
+}
+
+/**
+ * Subscribe to target changes — fires when a new target is set after
+ * the window is already open, so the live render can navigate to the
+ * footprint without a close/reopen. Returns an unsubscribe function.
+ */
+export function subscribeFootprintTarget(
+	cb: ( target: FootprintTarget ) => void,
+): () => void {
+	const store = getStore();
+	if ( ! store ) {
+		return () => {};
+	}
+	return store.subscribe( ( state ) => cb( { ...state } ) );
+}
+
+/**
+ * Open (or focus) the My WordPress window scoped to a user's activity
+ * footprint. Cold-start safe: stashes the shared target first, then
+ * opens the window so the freshly-mounted bundle reads it back.
+ *
+ * @since 0.23.0
+ *
+ * @param args          Footprint target.
+ * @param args.userId   Target user id (must be a positive integer).
+ * @param args.userName Optional display name for the breadcrumb.
+ */
+export function openUserFootprintWindow( args: {
+	userId: number;
+	userName?: string;
+} ): void {
+	const userId = Number( args.userId );
+	if ( ! Number.isFinite( userId ) || userId <= 0 ) {
+		return;
+	}
+	setFootprintTarget( userId, args.userName ?? '' );
+	getDesktop()?.openWindow?.( WINDOW_ID, {
+		source: 'my-wordpress/open-user-footprint',
+	} );
+}

--- a/src/my-wordpress/footprint-target.ts
+++ b/src/my-wordpress/footprint-target.ts
@@ -52,9 +52,16 @@ export interface FootprintTarget {
 	 */
 	userName: string;
 	/**
-	 * `Date.now()` of the last `set` — lets consumers tell a fresh
-	 * request apart from a stale one and dedupe the mount-read vs the
-	 * subscribe callback.
+	 * `Date.now()` of the last `set`. Currently informational and
+	 * reserved for future dedup — e.g. telling a fresh request apart
+	 * from a stale one, or distinguishing the mount-read from the
+	 * subscribe callback if the shell ever batches notifications. No
+	 * consumer reads it today: the subscribe callback navigates on any
+	 * `userId > 0`, which is correct under the current synchronous
+	 * notify model (two quick opens on different users should navigate
+	 * twice and land on the last one — a `requestedAt`-based skip with
+	 * `Date.now()`'s millisecond resolution could wrongly drop the
+	 * second).
 	 */
 	requestedAt: number;
 }
@@ -70,11 +77,15 @@ interface DesktopFacade {
 	) => boolean | undefined;
 }
 
-const _initial: FootprintTarget = {
+// Frozen sentinel — only ever spread into a fresh mutable object
+// (`{ ..._initial }`), never mutated in place. Freezing turns an
+// accidental direct mutation into a loud error instead of silent
+// shared-state corruption.
+const _initial: Readonly< FootprintTarget > = Object.freeze( {
 	userId: null,
 	userName: '',
 	requestedAt: 0,
-};
+} );
 
 function getDesktop(): DesktopFacade | undefined {
 	return ( window as unknown as { wp?: { desktop?: DesktopFacade } } ).wp
@@ -82,6 +93,22 @@ function getDesktop(): DesktopFacade | undefined {
 }
 
 let _store: SharedStoreApi< FootprintTarget > | null = null;
+
+/**
+ * Resolve the shared store, memoizing once `wp.desktop.createSharedStore`
+ * is available. Returns `null` until then, which routes `set`/`read`
+ * to the `window._wpdFootprintTarget` stash fallback.
+ *
+ * Known, accepted trade-off (mirrors `user-edit-target.ts`): a target
+ * stashed via the fallback BEFORE the store exists is NOT promoted
+ * into the store once it initialises. A subsequent `readFootprintTarget`
+ * after init reads the freshly-created store (empty) and the stash is
+ * silently dropped. This only bites in the narrow window before
+ * `wp.desktop.createSharedStore` is wired at boot — well before any
+ * users-table click can reach `openUserFootprintWindow` — so it's left
+ * as-is rather than adding stash→store reconciliation. Documented here
+ * so it's a deliberate choice, not a latent surprise.
+ */
 function getStore(): SharedStoreApi< FootprintTarget > | null {
 	if ( _store ) {
 		return _store;

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -201,9 +201,16 @@ interface RenderState {
 }
 
 interface StatusContext {
-	view: 'root' | 'list' | 'detail' | 'sub-list';
+	view: 'root' | 'list' | 'detail' | 'sub-list' | 'user-footprint';
 	entityId?: string;
 	postId?: number;
+	/**
+	 * Target user id. Only set on the `'user-footprint'` view — kept
+	 * distinct from `postId` so `desktop-mode.my-wordpress.status-bar`
+	 * filters can tell a user surface apart from a post surface
+	 * instead of mistaking a user id for a post id.
+	 */
+	userId?: number;
 	relation?: string;
 }
 
@@ -4596,7 +4603,7 @@ function renderUserFootprint(
 				sort: 10,
 			},
 		],
-		{ view: 'detail', entityId: entity.id, postId: userId },
+		{ view: 'user-footprint', entityId: entity.id, userId },
 	);
 
 	void ( async () => {
@@ -4615,7 +4622,7 @@ function renderUserFootprint(
 						sort: 10,
 					},
 				],
-				{ view: 'detail', entityId: entity.id, postId: userId },
+				{ view: 'user-footprint', entityId: entity.id, userId },
 			);
 			return;
 		}
@@ -4674,7 +4681,7 @@ function renderUserFootprint(
 					sort: 10,
 				},
 			],
-			{ view: 'detail', entityId: entity.id, postId: userId },
+			{ view: 'user-footprint', entityId: entity.id, userId },
 		);
 	} )();
 }

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -37,6 +37,12 @@ import { renderListToolbar } from './list-toolbar';
 import { renderMediaList } from './media-list';
 import { renderMediaDetail } from './media-detail';
 import {
+	clearFootprintTarget,
+	openUserFootprintWindow,
+	readFootprintTarget,
+	subscribeFootprintTarget,
+} from './footprint-target';
+import {
 	renderBreadcrumbs,
 	type BreadcrumbSegment,
 } from '../desktop-files/breadcrumbs';
@@ -6002,7 +6008,26 @@ function renderInto( body: HTMLElement ): ( () => void ) | undefined {
 
 	// If the consumer opened the window via `openDetail` while it
 	// was closed, the queued route is the actual destination.
-	const initialRoute = pendingRoute ?? { kind: 'root' };
+	//
+	// A pending footprint target (set cross-bundle by
+	// `openUserFootprintWindow` — e.g. the chromeless `users.php`
+	// row action routed through the window-system bridge) wins over
+	// the queued `pendingRoute` and the root fallback: it is the most
+	// recent, explicit user intent and survives the lazy-bundle load
+	// because it lives in a shared store rather than this module's
+	// `pendingRoute`. Consume + clear so a later plain open lands on
+	// root.
+	const footprint = readFootprintTarget();
+	let initialRoute: Route;
+	if ( footprint.userId && footprint.userId > 0 ) {
+		initialRoute = footprintRouteFor(
+			footprint.userId,
+			footprint.userName,
+		);
+		clearFootprintTarget();
+	} else {
+		initialRoute = pendingRoute ?? { kind: 'root' };
+	}
 	pendingRoute = null;
 	navigate( state, initialRoute );
 
@@ -6107,6 +6132,22 @@ function asRenderState( host: EntityRenderHost ): RenderState {
  *  @since 0.8.0
  * ------------------------------------------------------------------ */
 
+/**
+ * Build a `user-footprint` route for a target user. `entityId` is the
+ * built-in `'users'` entity (registered server-side in
+ * `includes/my-wordpress/window.php`); `getEntity( 'users' )` resolves
+ * it inside `navigate()`. A missing entity renders the in-window
+ * "Unknown entity type" error rather than throwing.
+ */
+function footprintRouteFor( userId: number, userName: string ): Route {
+	return {
+		kind: 'user-footprint',
+		entityId: 'users',
+		userId,
+		userName,
+	};
+}
+
 interface OpenDetailArgs {
 	entityId: string;
 	postId: number;
@@ -6179,9 +6220,32 @@ function openMedia( args: OpenMediaArgs ): void {
 	desktop?.openWindow?.( WINDOW_ID, { source: 'my-wordpress/open-media' } );
 }
 
+interface OpenUserFootprintArgs {
+	userId: number;
+	userName?: string;
+}
+
+/**
+ * Route the My WordPress window directly into a user's activity
+ * footprint. Cross-bundle and cold-start safe: delegates to the shared
+ * `openUserFootprintWindow` helper, which stashes the target in a
+ * shared store and opens-or-focuses the window so the freshly-mounted
+ * (or already-live) bundle navigates to the footprint route. Mirrors
+ * `openDetail()` / `openMedia()`, for users.
+ *
+ * @public
+ * @since 0.23.0
+ *
+ * @param args Footprint target (`userId` required, `userName` optional).
+ */
+function openUserFootprint( args: OpenUserFootprintArgs ): void {
+	openUserFootprintWindow( args );
+}
+
 interface MyWordpressApi {
 	openDetail: ( args: OpenDetailArgs ) => void;
 	openMedia: ( args: OpenMediaArgs ) => void;
+	openUserFootprint: ( args: OpenUserFootprintArgs ) => void;
 	registerEntityKind: ( kind: string, renderer: EntityRenderer ) => () => void;
 	/**
 	 * Trash an entity by its My WordPress entity id (`'posts'`,
@@ -6245,9 +6309,29 @@ if ( desktopGlobal ) {
 	desktopGlobal.myWordpress = {
 		openDetail,
 		openMedia,
+		openUserFootprint,
 		registerEntityKind,
 		trashEntity: trashEntityById,
 	};
+
+	// Warm re-target. When a footprint open arrives while a My
+	// WordPress window is already mounted, `openWindow()` just focuses
+	// the existing instance (no remount), so `renderInto`'s mount-read
+	// never runs. Navigate the most-recently-active instance to the
+	// requested footprint instead. The cold case (window closed, or
+	// the bundle not yet loaded) is handled by the mount-read in
+	// `renderInto`, so the `! activeState` guard here intentionally
+	// no-ops — the store stays set for that mount to consume.
+	subscribeFootprintTarget( ( next ) => {
+		if ( ! next.userId || next.userId <= 0 || ! activeState ) {
+			return;
+		}
+		navigate(
+			activeState,
+			footprintRouteFor( next.userId, next.userName ),
+		);
+		clearFootprintTarget();
+	} );
 
 	// Live-tile pruning on trash. Every live My WordPress list body
 	// listens for the broadcast — `trashEntityById` fires this after

--- a/src/protocol/window-messages.ts
+++ b/src/protocol/window-messages.ts
@@ -36,6 +36,16 @@ export type BridgeEventFromIframe =
 		open: 'screen-options' | 'help' | null;
 	}
 	| { type: 'desktop-mode-commands-list'; commands: HarvestedCommand[] }
+	// Activity-footprint launcher — a "View activity footprint" row
+	// action inside the chromeless `users.php` iframe escalates a
+	// click to the parent shell, which opens the My WordPress window
+	// on that user's footprint route. `userName` seeds the breadcrumb
+	// before the REST payload resolves (empty string when unknown).
+	| {
+		type: 'desktop-mode-open-user-footprint';
+		userId: number;
+		userName: string;
+	}
 	// -------------------------------------------------------------------
 	// Cross-window connection bridge — extensible pub/sub between any
 	// parent-side caller (e.g. a plugin's title-bar dropdown) and a
@@ -98,6 +108,7 @@ export const BRIDGE_EVENT_TYPES: ReadonlySet< BridgeEventType > = new Set( [
 	'desktop-mode-screen-meta',
 	'desktop-mode-screen-meta-state',
 	'desktop-mode-commands-list',
+	'desktop-mode-open-user-footprint',
 	'desktop-mode-bridge-handshake-ack',
 	// To iframe.
 	'desktop-mode-focus',

--- a/src/window/iframe-bridge.ts
+++ b/src/window/iframe-bridge.ts
@@ -18,6 +18,7 @@ import { dispatchFromWindow, markWindowContentReady } from '../window-channels';
 import { tryNativeUrlRemap } from '../native-url-remap';
 import { createSharedStore } from '../shared-store';
 import { matchDestructiveAdminAction } from '../destructive-admin-actions';
+import { openUserFootprintWindow } from '../my-wordpress/footprint-target';
 
 /**
  * Origin snapshot taken once at module load. Any subsequent mutation
@@ -248,6 +249,29 @@ export function handleWindowMessage( win: Window, event: MessageEvent ): void {
 				typeof data.label === 'string' ? data.label : '';
 			handleCrossPageAdminLink( win, data.url, linkLabel, deps );
 		}
+	}
+
+	// Activity-footprint launcher. A "View activity footprint" row
+	// action inside the chromeless `users.php` iframe posts this; we
+	// open (or focus) the My WordPress window on that user's footprint
+	// route via the shared-store hand-off (cold-start safe — see
+	// `my-wordpress/footprint-target.ts`).
+	//
+	// Deliberately NOT the admin-link remap path above: that path
+	// calls `win.close()` on a remap hit because it models a
+	// navigation away from the source page. A row action is an
+	// auxiliary "peek" at another user — closing the users list out
+	// from under the click would be hostile, so the source window is
+	// left untouched.
+	if (
+		data.type === 'desktop-mode-open-user-footprint' &&
+		typeof data.userId === 'number' &&
+		data.userId > 0
+	) {
+		openUserFootprintWindow( {
+			userId: data.userId,
+			userName: typeof data.userName === 'string' ? data.userName : '',
+		} );
 	}
 
 	// Iframe-initiated toast. Plugin pages inside iframes use this

--- a/tests/phpunit/tests/myWordpressUsersListFootprint.php
+++ b/tests/phpunit/tests/myWordpressUsersListFootprint.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests for the "View activity footprint" row action added to the
+ * classic Users list table (`desktop_mode_user_footprint_row_action`,
+ * hooked on `user_row_actions`).
+ *
+ * @package WPDesktopMode
+ *
+ * @group desktop-mode
+ */
+class Tests_DesktopMode_MyWordpress_UsersListFootprint extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id = $factory->user->create(
+			array(
+				'role'         => 'editor',
+				'display_name' => 'Edie & Co',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+		delete_user_meta( self::$editor_id, 'desktop_mode_mode' );
+		unset( $_GET['desktop_mode_chromeless'], $_GET[ DESKTOP_MODE_CLASSIC_FLAG ] );
+		remove_all_filters( 'desktop_mode_user_footprint_row_action' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Put the current user into a genuine chromeless request: desktop
+	 * mode enabled + the iframe query flag the shell stamps.
+	 */
+	private function enable_chromeless( $user_id ) {
+		update_user_meta( $user_id, 'desktop_mode_mode', '1' );
+		$_GET['desktop_mode_chromeless'] = '1';
+	}
+
+	/**
+	 * Run the filter against a user the way `WP_Users_List_Table` does.
+	 */
+	private function row_actions_for( $user_id ) {
+		return desktop_mode_user_footprint_row_action(
+			array(),
+			get_userdata( $user_id )
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_action_absent_when_mode_off() {
+		$actions = $this->row_actions_for( self::$editor_id );
+		$this->assertArrayNotHasKey( 'desktop-mode-footprint', $actions );
+	}
+
+	/**
+	 * Desktop mode on but a normal (non-iframe) request — the action
+	 * is omitted so it never renders as a dead link outside the shell.
+	 *
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_action_absent_when_enabled_but_not_chromeless() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$actions = $this->row_actions_for( self::$editor_id );
+		$this->assertArrayNotHasKey( 'desktop-mode-footprint', $actions );
+	}
+
+	/**
+	 * A detached classic tab carries `?desktop_mode_classic=1` but NOT
+	 * the chromeless flag, so the shell is absent — the action must be
+	 * omitted (the link would otherwise open the profile editor under a
+	 * misleading "footprint" label).
+	 *
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_action_absent_in_detached_classic_tab() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET[ DESKTOP_MODE_CLASSIC_FLAG ] = '1';
+		$actions                           = $this->row_actions_for( self::$editor_id );
+		$this->assertArrayNotHasKey( 'desktop-mode-footprint', $actions );
+	}
+
+	/**
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_action_present_on_chromeless_request() {
+		$this->enable_chromeless( self::$admin_id );
+		$actions = $this->row_actions_for( self::$editor_id );
+		$this->assertArrayHasKey( 'desktop-mode-footprint', $actions );
+		$this->assertStringContainsString(
+			'View activity footprint',
+			$actions['desktop-mode-footprint']
+		);
+	}
+
+	/**
+	 * Carries the target user id in the data attribute the chromeless
+	 * bridge reads, escapes the display name, and links to the user's
+	 * edit screen as the no-JS fallback.
+	 *
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_action_markup_attributes_and_escaping() {
+		$this->enable_chromeless( self::$admin_id );
+		$html = $this->row_actions_for( self::$editor_id )['desktop-mode-footprint'];
+
+		$this->assertStringContainsString(
+			'data-desktop-mode-footprint="' . self::$editor_id . '"',
+			$html
+		);
+		// `display_name` is "Edie & Co" — esc_attr() must encode the
+		// ampersand.
+		$this->assertStringContainsString(
+			'data-desktop-mode-footprint-name="Edie &amp; Co"',
+			$html
+		);
+		$this->assertStringContainsString( 'user-edit.php', $html );
+		$this->assertStringContainsString( 'user_id=' . self::$editor_id, $html );
+	}
+
+	/**
+	 * The viewer's own row falls back to `profile.php`, not
+	 * `user-edit.php` (which would redirect there anyway in core).
+	 *
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_self_row_fallback_uses_profile_php() {
+		$this->enable_chromeless( self::$admin_id );
+		$html = $this->row_actions_for( self::$admin_id )['desktop-mode-footprint'];
+		$this->assertStringContainsString( 'profile.php', $html );
+		$this->assertStringNotContainsString( 'user-edit.php', $html );
+	}
+
+	/**
+	 * The `desktop_mode_user_footprint_row_action` filter can suppress
+	 * the action for a given user.
+	 *
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_filter_can_suppress_the_action() {
+		$this->enable_chromeless( self::$admin_id );
+		add_filter( 'desktop_mode_user_footprint_row_action', '__return_false' );
+		$actions = $this->row_actions_for( self::$editor_id );
+		$this->assertArrayNotHasKey( 'desktop-mode-footprint', $actions );
+	}
+
+	/**
+	 * An invalid user object leaves the incoming actions untouched.
+	 *
+	 * @covers ::desktop_mode_user_footprint_row_action
+	 */
+	public function test_invalid_user_object_returns_actions_unchanged() {
+		$this->enable_chromeless( self::$admin_id );
+		$actions = desktop_mode_user_footprint_row_action(
+			array( 'edit' => '<a>Edit</a>' ),
+			null
+		);
+		$this->assertArrayNotHasKey( 'desktop-mode-footprint', $actions );
+		$this->assertArrayHasKey( 'edit', $actions );
+	}
+}

--- a/tests/vitest/my-wordpress-footprint-target.test.ts
+++ b/tests/vitest/my-wordpress-footprint-target.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the cross-bundle "open this user's activity
+ * footprint" hand-off (`src/my-wordpress/footprint-target.ts`) and the
+ * parent-shell bridge handler that drives it
+ * (`desktop-mode-open-user-footprint` in `src/window/iframe-bridge.ts`).
+ *
+ * The footprint launcher's whole reason for existing is robustness:
+ * the click originates in the chromeless `users.php` iframe (no shell
+ * API), the target is threaded through a shared store so it survives
+ * the lazy My WordPress bundle load, and the source window must NOT be
+ * closed (it's an auxiliary peek, not a navigation away). Each of
+ * those properties is asserted below.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	_resetAllSharedStoresForTests,
+	createSharedStore,
+} from '../../src/shared-store';
+import {
+	clearFootprintTarget,
+	openUserFootprintWindow,
+	readFootprintTarget,
+	setFootprintTarget,
+	subscribeFootprintTarget,
+} from '../../src/my-wordpress/footprint-target';
+import { handleWindowMessage } from '../../src/window/iframe-bridge';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+let openWindow: ReturnType< typeof vi.fn >;
+
+beforeEach( () => {
+	installHooksStub();
+	openWindow = vi.fn( () => true );
+	( window as unknown as { wp?: unknown } ).wp = {
+		desktop: { createSharedStore, openWindow },
+	};
+	_resetAllSharedStoresForTests();
+} );
+
+afterEach( () => {
+	clearHooksStub();
+	_resetAllSharedStoresForTests();
+	delete ( window as unknown as { wp?: unknown } ).wp;
+} );
+
+describe( 'footprint-target — shared store', () => {
+	test( 'set / read round-trips userId + userName', () => {
+		setFootprintTarget( 42, 'Jane Doe' );
+		const got = readFootprintTarget();
+		expect( got.userId ).toBe( 42 );
+		expect( got.userName ).toBe( 'Jane Doe' );
+		expect( got.requestedAt ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'clear zeroes the target', () => {
+		setFootprintTarget( 7, 'Bob' );
+		clearFootprintTarget();
+		const got = readFootprintTarget();
+		expect( got.userId ).toBeNull();
+		expect( got.userName ).toBe( '' );
+	} );
+
+	test( 'subscribe fires on set and reports the new target', () => {
+		const seen: Array< number | null > = [];
+		subscribeFootprintTarget( ( t ) => seen.push( t.userId ) );
+		setFootprintTarget( 99, 'Eve' );
+		expect( seen ).toEqual( [ 99 ] );
+	} );
+
+	test( 'subscribe sees null after clear (no stale userId)', () => {
+		const seen: Array< number | null > = [];
+		setFootprintTarget( 5, 'A' );
+		subscribeFootprintTarget( ( t ) => seen.push( t.userId ) );
+		clearFootprintTarget();
+		expect( seen ).toEqual( [ null ] );
+	} );
+} );
+
+describe( 'footprint-target — openUserFootprintWindow', () => {
+	test( 'stashes the target then opens the My WordPress window', () => {
+		openUserFootprintWindow( { userId: 12, userName: 'Carol' } );
+		const got = readFootprintTarget();
+		expect( got.userId ).toBe( 12 );
+		expect( got.userName ).toBe( 'Carol' );
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		expect( openWindow ).toHaveBeenCalledWith( WINDOW_ID, {
+			source: 'my-wordpress/open-user-footprint',
+		} );
+	} );
+
+	test( 'defaults userName to empty string when omitted', () => {
+		openUserFootprintWindow( { userId: 3 } );
+		expect( readFootprintTarget().userName ).toBe( '' );
+	} );
+
+	test.each( [ 0, -1, NaN ] )(
+		'ignores a non-positive / non-finite userId (%s)',
+		( bad ) => {
+			openUserFootprintWindow( { userId: bad } );
+			expect( openWindow ).not.toHaveBeenCalled();
+			expect( readFootprintTarget().userId ).toBeNull();
+		},
+	);
+} );
+
+/**
+ * Build a Window-shaped fake exposing the fields the bridge inspects
+ * for this message: the iframe contentWindow (source gate) and a
+ * `close` spy so we can assert the source window is left open.
+ */
+function buildFakeWindow() {
+	const close = vi.fn();
+	const fakeContentWindow = {} as Window;
+	return {
+		win: {
+			id: 'users',
+			iframe: {
+				contentWindow: fakeContentWindow,
+			} as unknown as HTMLIFrameElement,
+			close,
+			setTitle: vi.fn(),
+		},
+		fakeContentWindow,
+		close,
+	};
+}
+
+function postFrom( source: Window, data: unknown ): MessageEvent {
+	return new MessageEvent( 'message', {
+		origin: window.location.origin,
+		source,
+		data,
+	} );
+}
+
+describe( 'iframe-bridge — desktop-mode-open-user-footprint', () => {
+	test( 'opens the footprint window and leaves the source window open', () => {
+		const { win, fakeContentWindow, close } = buildFakeWindow();
+		handleWindowMessage(
+			win as Parameters< typeof handleWindowMessage >[ 0 ],
+			postFrom( fakeContentWindow, {
+				type: 'desktop-mode-open-user-footprint',
+				userId: 42,
+				userName: 'Jane Doe',
+			} ),
+		);
+		expect( openWindow ).toHaveBeenCalledWith( WINDOW_ID, {
+			source: 'my-wordpress/open-user-footprint',
+		} );
+		expect( readFootprintTarget().userId ).toBe( 42 );
+		// The defining property: a row-action peek must NOT close the
+		// users list it was launched from.
+		expect( close ).not.toHaveBeenCalled();
+	} );
+
+	test( 'ignores a message with a non-positive userId', () => {
+		const { win, fakeContentWindow } = buildFakeWindow();
+		handleWindowMessage(
+			win as Parameters< typeof handleWindowMessage >[ 0 ],
+			postFrom( fakeContentWindow, {
+				type: 'desktop-mode-open-user-footprint',
+				userId: 0,
+				userName: '',
+			} ),
+		);
+		expect( openWindow ).not.toHaveBeenCalled();
+		expect( readFootprintTarget().userId ).toBeNull();
+	} );
+
+	test( 'ignores a message whose userId is not a number', () => {
+		const { win, fakeContentWindow } = buildFakeWindow();
+		handleWindowMessage(
+			win as Parameters< typeof handleWindowMessage >[ 0 ],
+			postFrom( fakeContentWindow, {
+				type: 'desktop-mode-open-user-footprint',
+				userId: '42',
+				userName: '',
+			} ),
+		);
+		expect( openWindow ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/vitest/my-wordpress-footprint-target.test.ts
+++ b/tests/vitest/my-wordpress-footprint-target.test.ts
@@ -182,3 +182,37 @@ describe( 'iframe-bridge — desktop-mode-open-user-footprint', () => {
 		expect( openWindow ).not.toHaveBeenCalled();
 	} );
 } );
+
+describe( 'footprint-target — window-stash fallback (no shared store yet)', () => {
+	test( 'set / read round-trip via window._wpdFootprintTarget before the store exists', async () => {
+		// A fresh module instance so its memoized `_store` starts null,
+		// plus a facade with no `createSharedStore`, so `getStore()`
+		// returns null and the `window._wpdFootprintTarget` stash path
+		// runs end to end (the env always has the real store otherwise).
+		vi.resetModules();
+		( window as unknown as { wp?: unknown } ).wp = {};
+		delete ( window as unknown as { _wpdFootprintTarget?: unknown } )
+			._wpdFootprintTarget;
+
+		const mod = await import( '../../src/my-wordpress/footprint-target' );
+		mod.setFootprintTarget( 77, 'Stash User' );
+
+		// The stash actually held the value...
+		expect(
+			(
+				window as unknown as {
+					_wpdFootprintTarget?: { userId: number };
+				}
+			)._wpdFootprintTarget?.userId,
+		).toBe( 77 );
+
+		// ...and read returns it while the store is still unavailable.
+		const got = mod.readFootprintTarget();
+		expect( got.userId ).toBe( 77 );
+		expect( got.userName ).toBe( 'Stash User' );
+
+		// clear zeroes the stash too.
+		mod.clearFootprintTarget();
+		expect( mod.readFootprintTarget().userId ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
- Introduced a new row action in the classic Users list table to view a user's GitHub-style activity footprint.
- Implemented the `desktop_mode_user_footprint_row_action` filter to control the visibility of the action based on user roles and context.
- Enhanced the chromeless iframe bridge to handle clicks on the new action and open the My WordPress window without navigating away from the Users list.
- Added necessary JavaScript and TypeScript functions to manage the footprint target across bundles, ensuring cold-start safety and shared state.
- Created unit tests for the new functionality, covering various scenarios including action visibility and shared store behavior.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-302-eb87dc85cc29e878261e1e283d394b37e9a5d71e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->