### PR TITLE
fix: persist welcome-dialog dismissal when Desktop Mode is disabled

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -719,6 +719,9 @@ The filter only fires after Desktop Mode has already verified that:
 2. The user is logged in and can `read`.
 3. The request is NOT chromeless.
 4. The user has not yet dismissed the `activation-welcome` intro (stored in the `desktop_mode_seen_intros` user meta — the same storage every other native-app intro uses, and the same surface the "Reset what's-new dialogs" button in OS Settings → Features wipes).
+5. Desktop Mode is not already enabled for the user — this is a "switch to Desktop Mode" promo, so it has nothing to say once the user is in the shell.
+
+Dismissal persists through the same `POST /desktop-mode/v1/intros/seen` route the in-shell intros use, with one wrinkle: because the dialog only appears while Desktop Mode is **disabled**, that route makes a scoped exception for the `activation-welcome` slug and accepts it from any logged-in `read`-capable account (every other slug still requires Desktop Mode enabled). Without it the dismissal would `403` and the dialog would re-appear on every classic-admin page load.
 
 Return `false` to suppress the dialog — useful for managed-host onboarding flows that ship their own welcome UX.
 

--- a/includes/seen-intros.php
+++ b/includes/seen-intros.php
@@ -190,17 +190,53 @@ function desktop_mode_register_seen_intros_routes() {
 add_action( 'rest_api_init', 'desktop_mode_register_seen_intros_routes' );
 
 /**
- * Permission gate — any logged-in user with desktop mode enabled may
- * manage their own seen-intros list. See
- * {@see desktop_mode_rest_require_enabled()} for why `read` alone is
- * insufficient.
+ * Permission gate for the seen-intros routes.
+ *
+ * In-shell intros (slug `posts`, `pages`, …) are only ever shown to a
+ * user who has already entered Desktop Mode, so they keep the strict
+ * {@see desktop_mode_rest_require_enabled()} gate — `read` alone is
+ * insufficient (every role, Subscriber included, carries `read`).
+ *
+ * The one exception is the first-run welcome dialog
+ * ({@see DESKTOP_MODE_WELCOME_INTRO_SLUG}): it renders in the *classic*
+ * admin precisely when Desktop Mode is NOT enabled, which is the only
+ * state it ever appears in. Gating its dismissal behind
+ * `desktop_mode_rest_require_enabled()` would make the dismissal POST
+ * return 403 every time, so the slug could never be recorded as seen and
+ * the dialog re-rendered on every classic-admin page load. We therefore
+ * let that single slug through for any logged-in `read`-capable account
+ * (the exact audience the dialog is shown to); writing one's own
+ * dismissal flag carries no privileged surface. The DELETE /intros route
+ * ("Reset what's-new dialogs") carries no slug and keeps the strict gate.
  *
  * @since 0.8.0
  * @since 0.8.10 Hardened to require desktop mode enabled (was `read`).
+ * @since 0.30.1 Allow the `activation-welcome` slug without the enabled
+ *               gate, so the welcome dialog's dismissal can persist.
  *
+ * @param WP_REST_Request $request The REST request.
  * @return true|WP_Error
  */
-function desktop_mode_rest_seen_intros_permission() {
+function desktop_mode_rest_seen_intros_permission( WP_REST_Request $request ) {
+	$slug = sanitize_key( (string) $request->get_param( 'slug' ) );
+	if ( defined( 'DESKTOP_MODE_WELCOME_INTRO_SLUG' ) && DESKTOP_MODE_WELCOME_INTRO_SLUG === $slug ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Authentication required.', 'desktop-mode' ),
+				array( 'status' => 401 )
+			);
+		}
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You are not allowed to do that.', 'desktop-mode' ),
+				array( 'status' => 403 )
+			);
+		}
+		return true;
+	}
+
 	return desktop_mode_rest_require_enabled();
 }
 

--- a/tests/phpunit/tests/seenIntros.php
+++ b/tests/phpunit/tests/seenIntros.php
@@ -176,4 +176,53 @@ class Tests_DesktopMode_SeenIntros extends WP_UnitTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 401, $response->get_status() );
 	}
+
+	/**
+	 * Regression: the first-run welcome dialog (slug `activation-welcome`)
+	 * renders only while Desktop Mode is *disabled*, so its dismissal must
+	 * persist through this route without the enabled gate. Previously the
+	 * shared `desktop_mode_rest_require_enabled()` gate 403'd the POST, the
+	 * slug was never recorded, and the dialog re-appeared on every
+	 * classic-admin page load.
+	 *
+	 * @covers ::desktop_mode_rest_seen_intros_permission
+	 */
+	public function test_rest_welcome_slug_persists_without_desktop_mode_enabled() {
+		// Reproduce the exact state the welcome dialog appears in: a
+		// logged-in, `read`-capable account that has NOT enabled Desktop Mode.
+		delete_user_meta( self::$user_id, 'desktop_mode_mode' );
+		wp_set_current_user( self::$user_id );
+
+		$request = new WP_REST_Request( 'POST', '/desktop-mode/v1/intros/seen' );
+		$request->set_param( 'slug', DESKTOP_MODE_WELCOME_INTRO_SLUG );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertContains(
+			DESKTOP_MODE_WELCOME_INTRO_SLUG,
+			$response->get_data()['seenIntros']
+		);
+		$this->assertTrue(
+			desktop_mode_has_seen_intro( self::$user_id, DESKTOP_MODE_WELCOME_INTRO_SLUG )
+		);
+	}
+
+	/**
+	 * The welcome-slug exception is scoped to that one slug: every other
+	 * (in-shell) intro still requires Desktop Mode enabled, so a not-enabled
+	 * caller posting e.g. `posts` is still rejected with 403.
+	 *
+	 * @covers ::desktop_mode_rest_seen_intros_permission
+	 */
+	public function test_rest_non_welcome_slug_still_requires_enabled() {
+		delete_user_meta( self::$user_id, 'desktop_mode_mode' );
+		wp_set_current_user( self::$user_id );
+
+		$request = new WP_REST_Request( 'POST', '/desktop-mode/v1/intros/seen' );
+		$request->set_param( 'slug', 'posts' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertFalse( desktop_mode_has_seen_intro( self::$user_id, 'posts' ) );
+	}
 }


### PR DESCRIPTION
## Problem

The first-run **Welcome to Desktop Mode** dialog re-appears on **every** classic-admin page load and can never be dismissed for good, even after clicking *Got it* / *×* / Escape.

It is, by design, an *invite* shown in the classic admin only while Desktop Mode is **disabled** for the user. Dismissing it POSTs the `activation-welcome` slug to `POST /desktop-mode/v1/intros/seen` to remember the dismissal. But that route's permission callback is `desktop_mode_rest_require_enabled()`, which returns **403 whenever Desktop Mode is not enabled**, which is the *only* state the dialog ever appears in. So the dismissal could never persist → the dialog showed forever.

This is a Catch-22 introduced when the seen-intros route was hardened to require Desktop Mode enabled (previously `read`), while the welcome dialog, added later, reused that same endpoint.

## Fix

Scope a single-slug exception in `desktop_mode_rest_seen_intros_permission()`:

- The `activation-welcome` slug is accepted from any logged-in, `read`-capable account (the exact audience the dialog is shown to). Writing one's own dismissal flag carries no privileged surface.
- Every other (in-shell) intro slug still requires Desktop Mode enabled.
- The `DELETE /intros` ("Reset what's-new dialogs") route carries no slug and is unaffected.

Net behavior: the welcome invite now shows **once** after activation, stays dismissed, and never shows once Desktop Mode is enabled.

## Tests

- New regression test: a logged-in, not-enabled user can persist the `activation-welcome` dismissal (`200`, recorded).
- New scope test: a not-enabled user posting any other slug (e.g. `posts`) is still rejected (`403`).
- Full suites green: `build`, `lint`, `typecheck`, `test:js` (1568), `test:php` for the affected classes (20 tests).

## Docs

Updated the `desktop_mode_show_welcome_dialog` entry in `docs/hooks-reference.md` to document the not-enabled gate and the scoped dismissal-persistence exception.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-303-54283fa0b6bc9d5be54deab8198a66a45569d6de.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->