### PR TITLE
Fix: welcome dialog reappears on every page when the admin is served from an origin that differs from `site_url`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /desktop-mode.zip
 /dist/
 /tests/phpunit/.phpunit.result.cache
+/.scratch/
 
 # Vite build output under assets/js/ — regenerate locally with `npm run
 # build`. Adding a new bundle in vite.config.js does not require updating

--- a/includes/welcome-dialog.php
+++ b/includes/welcome-dialog.php
@@ -632,6 +632,27 @@ function desktop_mode_render_welcome_dialog() {
 		document.removeEventListener( 'keydown', onKey );
 	}
 
+	// Rebuilds an absolute URL onto the origin the admin page was actually
+	// loaded from. `rest_url()` / `admin_url()` are pinned to `site_url()`,
+	// but the admin may be viewed through a different origin — a reverse
+	// proxy, a Flexible-SSL edge, a mapped multisite domain, or simply an
+	// HTTPS dev proxy in front of an HTTP site. POSTing the *absolute*
+	// site_url URL from such a page is cross-origin (and mixed-content when
+	// the page is HTTPS and site_url is HTTP); the browser blocks it, the
+	// dismissal never reaches the server, and the dialog re-renders on every
+	// page load. Reissuing the request to `window.location.origin` keeps it
+	// same-origin — where the logged-in cookie (domain-scoped, not
+	// port-scoped) and the `wp_rest` nonce (session-bound, origin-agnostic)
+	// are both valid.
+	function sameOrigin( url ) {
+		try {
+			var parsed = new URL( url, window.location.href );
+			return window.location.origin + parsed.pathname + parsed.search;
+		} catch ( e ) {
+			return url;
+		}
+	}
+
 	function persist() {
 		// Fire-and-forget. The seen-intros endpoint always returns the
 		// post-mutation list, but we don't need it here; if the request
@@ -639,24 +660,40 @@ function desktop_mode_render_welcome_dialog() {
 		// again next page load — exactly the behavior a user would
 		// expect from a "save my dismissal" call that didn't reach the
 		// server.
-		//
-		// `keepalive: true` keeps the POST alive across the navigation
-		// that "Enable it now" triggers — otherwise the redirect into the
-		// shell can abort the in-flight request and the dismissal is lost.
-		// (The `desktop_mode_is_enabled()` gate already stops the dialog
-		// re-rendering in the shell, but this keeps the seen-state correct
-		// for the classic admin too, e.g. if the user switches back.)
+		var url     = sameOrigin( cfg.url );
+		var payload = JSON.stringify( { slug: cfg.slug } );
+
+		// Prefer `navigator.sendBeacon`: it is queued by the browser and
+		// survives the navigation that "Enable it now" triggers without the
+		// keepalive caveats, and it is inherently same-origin-credentialed.
+		// The `wp_rest` nonce rides along as `_wpnonce` (REST cookie auth
+		// reads it from `$_REQUEST`), and the Blob's `application/json` type
+		// lets the REST server parse the `slug` body param.
+		try {
+			if ( navigator.sendBeacon ) {
+				var beaconUrl = url +
+					( url.indexOf( '?' ) === -1 ? '?' : '&' ) +
+					'_wpnonce=' + encodeURIComponent( cfg.nonce );
+				var blob = new Blob( [ payload ], { type: 'application/json' } );
+				if ( navigator.sendBeacon( beaconUrl, blob ) ) {
+					return;
+				}
+			}
+		} catch ( e ) {}
+
+		// Fallback: `keepalive: true` keeps the POST alive across the
+		// "Enable it now" redirect on browsers without sendBeacon.
 		try {
 			var headers = { 'Content-Type': 'application/json' };
 			if ( cfg.nonce ) {
 				headers[ 'X-WP-Nonce' ] = cfg.nonce;
 			}
-			fetch( cfg.url, {
+			fetch( url, {
 				method: 'POST',
 				credentials: 'same-origin',
 				keepalive: true,
 				headers: headers,
-				body: JSON.stringify( { slug: cfg.slug } ),
+				body: payload,
 			} ).catch( function () {} );
 		} catch ( e ) {}
 	}
@@ -688,7 +725,7 @@ function desktop_mode_render_welcome_dialog() {
 		form.append( 'nonce', cfg.ajaxNonce );
 		form.append( 'enabled', '1' );
 
-		fetch( cfg.ajaxUrl, {
+		fetch( sameOrigin( cfg.ajaxUrl ), {
 			method: 'POST',
 			credentials: 'same-origin',
 			body: form,

--- a/tests/phpunit/tests/welcomeDialog.php
+++ b/tests/phpunit/tests/welcomeDialog.php
@@ -83,4 +83,35 @@ class Tests_DesktopMode_WelcomeDialog extends WP_UnitTestCase {
 
 		$this->assertFalse( desktop_mode_should_show_welcome_dialog() );
 	}
+
+	/**
+	 * Regression: the dismissal must be sent to the origin the admin page was
+	 * actually loaded from, not the absolute `site_url()` origin. When the
+	 * admin is viewed through a different origin (reverse proxy, Flexible-SSL
+	 * edge, mapped multisite domain, or an HTTPS dev proxy in front of an HTTP
+	 * site), POSTing the absolute URL is cross-origin / mixed-content, the
+	 * browser blocks it, the slug is never recorded, and the dialog re-renders
+	 * on every classic-admin page load. Guard the same-origin reconstruction
+	 * (and the `sendBeacon` delivery that survives the "Enable it now"
+	 * navigation) so neither can silently regress.
+	 *
+	 * @covers ::desktop_mode_render_welcome_dialog
+	 */
+	public function test_dismissal_is_sent_same_origin() {
+		ob_start();
+		desktop_mode_render_welcome_dialog();
+		$markup = ob_get_clean();
+
+		$this->assertNotEmpty( $markup, 'The dialog should render for a fresh classic-admin user.' );
+		$this->assertStringContainsString(
+			'window.location.origin',
+			$markup,
+			'The dismissal request must be reissued onto the current browsing origin.'
+		);
+		$this->assertStringContainsString(
+			'sendBeacon',
+			$markup,
+			'The dismissal should use sendBeacon so it survives the "Enable it now" navigation.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

The first-run **"Welcome to Desktop Mode"** dialog is meant to appear once and
stay gone after you dismiss it. Instead, on sites where the admin is browsed
from an origin that differs from WordPress's stored `site_url` — an HTTPS edge
in front of an `http://`-configured site, a `www` vs non-`www` mismatch, a
reverse proxy, or a domain-mapped multisite — it re-appeared on **every**
classic-admin page load and could never be dismissed.

Root cause: the dialog persisted its dismissal by POSTing to the **absolute**
`rest_url()` URL, which is pinned to `site_url()`. When the page itself is
served from a different origin, that POST is **cross-origin**, and when the
schemes differ (HTTPS page → HTTP request) it is **mixed active content**,
which browsers hard-block per the W3C Mixed Content spec. The request's
`.catch(function(){})` swallowed the block silently, the `activation-welcome`
slug was never written to the `desktop_mode_seen_intros` user meta, and the
gate kept rendering the dialog.

The fix re-issues the dismissal (and the "Enable it now" AJAX call) to the
**origin the page was actually loaded from**, where the request is same-origin
and the credentials are valid.

## Root cause in detail

`includes/welcome-dialog.php` built its endpoints with:

```php
$rest_url = esc_url_raw( rest_url( 'desktop-mode/v1/intros/seen' ) );
$ajax_url = esc_url_raw( admin_url( 'admin-ajax.php' ) );
```

Both resolve to the stored `site_url()` origin. When the admin is browsed from
a different origin:

1. The page origin and the POST target origin differ.
2. If the page is HTTPS and `site_url` is HTTP, the POST is **mixed active
   content** → the browser blocks it unconditionally. (A cross-origin
   credentialed POST is likewise blocked when the origins differ.)
3. `fetch(...).catch(function(){})` swallows the failure with no surface.
4. The slug is never recorded → `desktop_mode_should_show_welcome_dialog()`
   keeps returning `true` → the dialog renders on every page.

The gate itself and the REST/persistence layer were always correct — verified
end-to-end (a request with a valid cookie + nonce + JSON body returns `200`
and persists the slug). The only broken link was the client-side **delivery
origin**.

This does not reproduce on a correctly-configured single-origin install, where
`window.location.origin === site_url`, so the absolute URL is already
same-origin — which is why a healthy site never shows the dialog twice.

## The fix

`includes/welcome-dialog.php` (inline dialog script):

- New `sameOrigin( url )` helper rebuilds any absolute URL onto
  `window.location.origin`, preserving the path and query. In the normal
  single-origin case this is a no-op; under an origin mismatch it keeps the
  request same-origin.
- `persist()` now sends the dismissal to `sameOrigin( cfg.url )` and prefers
  `navigator.sendBeacon`, which:
  - is queued by the browser and survives the navigation that
    "Enable it now" triggers (no `keepalive` caveats), and
  - is inherently same-origin-credentialed.
  The `wp_rest` nonce rides along as `?_wpnonce=` (REST cookie auth reads it
  from `$_REQUEST`), and the `application/json` Blob type lets the REST server
  parse the `slug` body param. A `keepalive` `fetch()` remains as a fallback
  for browsers without `sendBeacon`.
- The "Enable it now" path POSTs to `sameOrigin( cfg.ajaxUrl )`.

### Why the credentials still validate same-origin

- The WordPress **login cookie is domain-scoped**, so it is sent to the
  browsing origin regardless of which port/scheme the request uses.
- The **`wp_rest` nonce is session-bound, not origin-bound**, so it validates
  regardless of which origin the request lands on.
- The cookie *name* (`wordpress_logged_in_<COOKIEHASH>`) derives from
  `site_url()` and is therefore stable across access origins.

## Testing

- **Manual:** with the admin served from an origin that differs from
  `site_url` (e.g. an HTTPS edge in front of an HTTP-configured site), Desktop
  Mode off, and the intro reset — dismiss with "Got it" and navigate between
  admin screens. The dialog now stays gone.
- **PHPUnit:** added `test_dismissal_is_sent_same_origin` to
  `Tests_DesktopMode_WelcomeDialog`, asserting the rendered dialog routes the
  dismissal through `window.location.origin` and uses `sendBeacon` — a
  regression guard against reverting to the cross-origin POST. Full class is
  green (6/6).
- `php -l` clean; `npm run build` green.

```
npm run test:php -- --filter='Tests_DesktopMode_WelcomeDialog'
# OK (6 tests, 8 assertions)
```

## Risk / compatibility

- **No public API, hook, REST route, or payload change.** This is purely a
  client-side delivery hardening inside the existing welcome dialog.
- **No behavior change on single-origin installs** —
  `window.location.origin` already equals the `site_url` origin there, so
  `sameOrigin()` returns the same URL.
- "Reset what's-new dialogs" (DELETE `/intros`) is unaffected.

## Files changed

- `includes/welcome-dialog.php` — `sameOrigin()` helper; `sendBeacon` +
  same-origin delivery for dismissal and the enable-now AJAX call.
- `tests/phpunit/tests/welcomeDialog.php` — regression test.
- `.gitignore` — ignore `/.scratch/`

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-310-3d69d855c26beb2664bc70aa2382936b9c2a5259.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->