### PR TITLE
feat: enhance widget resizing and persistence for docked heights

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -625,6 +625,7 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
  * --------------------------------------------------------------- */
 
 .desktop-mode-widgets {
+	border-radius: 14px;
 	position: absolute;
 	top: 16px;
 	bottom: 16px;
@@ -661,6 +662,7 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	padding: 4px;
 }
 
 /*
@@ -673,6 +675,12 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 .desktop-mode-widgets__card {
 	position: relative;
 	padding: 0;
+	/* Column layout so the body can flex-shrink and scroll when the
+	 * frame writes a fixed inline height (floating / resized cards).
+	 * Without this the body keeps its natural height and content
+	 * spills past the card's rounded bottom edge. */
+	display: flex;
+	flex-direction: column;
 	pointer-events: auto;
 	background: rgba( 20, 20, 22, 0.55 );
 	backdrop-filter: blur( 18px ) saturate( 140% );
@@ -684,13 +692,14 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 		0 8px 28px rgba( 0, 0, 0, 0.35 ),
 		inset 0 0 0 1px rgba( 255, 255, 255, 0.04 );
 	transition:
-		transform 0.18s ease,
 		box-shadow 0.18s ease,
 		opacity 0.18s ease;
 }
 
+/* Hover feedback is shadow-only — no transform. Cards must feel
+ * anchored; a hover nudge reads as the widget drifting under the
+ * pointer (and fought the user's chosen position on floating cards). */
 .desktop-mode-widgets__card:hover {
-	transform: translateX( -2px );
 	box-shadow:
 		0 12px 36px rgba( 0, 0, 0, 0.45 ),
 		inset 0 0 0 1px rgba( 255, 255, 255, 0.08 );
@@ -699,6 +708,10 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 .desktop-mode-widgets__card-body {
 	padding: 16px;
 	min-height: 48px;
+	flex: 1 1 auto;
+	overflow-x: hidden;
+	overflow-y: auto;
+	scrollbar-width: thin;
 }
 
 .desktop-mode-widgets__card-close {
@@ -742,6 +755,7 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
  */
 .desktop-mode-widgets__chrome {
 	display: flex;
+	flex-shrink: 0;
 	align-items: center;
 	gap: 8px;
 	padding: 6px 8px;
@@ -845,16 +859,11 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 
 /*
  * Floating widgets — absolute-positioned, inline top/left/width/height
- * written by the frame. The hover translate-X effect would fight the
- * user's chosen position, so disable it.
+ * written by the frame.
  */
 .desktop-mode-widgets__card--floating {
 	position: absolute;
 	margin: 0;
-}
-
-.desktop-mode-widgets__card--floating:hover {
-	transform: none;
 }
 
 .desktop-mode-widgets__card--dragging,
@@ -941,11 +950,13 @@ body.desktop-mode-has-fullscreen-window .desktop-mode-shell {
 }
 
 /*
- * Non-movable resizable widgets only expose the bottom-edge handle —
- * width stays locked to the column width. Hide the other seven so the
- * cursor doesn't lie about what's interactive.
+ * Only floating cards expose the full 8-direction handle set. A
+ * column-docked card — non-movable OR movable-but-not-yet-liberated —
+ * resizes on the height axis alone (the frame ignores every other
+ * direction while docked), so hide all handles except the bottom
+ * edge and the cursor never lies about what's interactive.
  */
-.desktop-mode-widgets__card--resizable:not( .desktop-mode-widgets__card--movable ) .desktop-mode-widgets__resize:not( .desktop-mode-widgets__resize--s ) {
+.desktop-mode-widgets__card--resizable:not( .desktop-mode-widgets__card--floating ) .desktop-mode-widgets__resize:not( .desktop-mode-widgets__resize--s ) {
 	display: none;
 }
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3179,7 +3179,7 @@ wp.desktop.registerWidget( {
 } );
 ```
 
-User-placed geometry (position + size of liberated widgets) persists per-user in `localStorage` under `desktop-mode-widgets-geometry`. Removing a widget clears its stored geometry so a re-add starts docked in the column again.
+User-placed geometry (position + size of liberated widgets) persists per-user in `localStorage` under `desktop-mode-widgets-geometry`. Height resizes made while a resizable widget is docked in the column persist separately under `desktop-mode-widgets-docked-heights` (height only — column widgets have no free position, and a full geometry record would mark the widget as floating at boot). Removing a widget clears both records so a re-add starts docked at its natural height.
 
 ##### `wp.desktop.widgets.redock( id )` — Stable since 0.6.0
 

--- a/src/plugins/heartbeat-widget/index.ts
+++ b/src/plugins/heartbeat-widget/index.ts
@@ -277,8 +277,8 @@ async function mountWithPixi(
 	// Soft halo behind the heart (pulses with glow), the heart
 	// itself in the middle, and a centred WP logo sprite on top.
 	const halo: Graphics = buildHalo( pixi );
-	const heart: Container = buildHeart( pixi );
-	const logo: Sprite = buildLogoSprite( pixi, logoUrl( ctx ) );
+	const { view: heart, body: heartBody } = buildHeart( pixi );
+	const logo: Container = buildLogoSprite( pixi, logoUrl( ctx ) );
 	app.stage.addChild( halo );
 	app.stage.addChild( heart );
 	heart.addChild( logo );
@@ -399,8 +399,11 @@ async function mountWithPixi(
 
 		// Color tint: blend toward the lighter "beating" hue with
 		// the big-beat envelope so the colour and the scale move
-		// together.
-		( heart as unknown as { tint: number } ).tint = lerpColor(
+		// together. Tint ONLY the gradient body sprite — tinting the
+		// whole heart container multiplied the white WP logo and the
+		// specular highlights down to the body's own red, camouflaging
+		// them against the heart (the "barely visible W" bug).
+		heartBody.tint = lerpColor(
 			HEART_COLOR_REST,
 			HEART_COLOR_BEAT,
 			Math.min( 1, glow * 0.6 + bigBeatT * 0.4 ),
@@ -601,11 +604,11 @@ function buildHalo( pixi: typeof import( 'pixi.js' ) ): Graphics {
 }
 
 /**
- * Parametric heart curve. Bounding box for the unscaled formula:
- *   x ∈ [-16, 16]   →   width  = 32
- *   y ∈ [-15, 9]    →   height = 24
- * That's already a slightly wider-than-tall heart (4:3). We add a
- * small x-axis stretch (× 1.08) so the silhouette reads
+ * Parametric heart curve. Bounding box for the unscaled formula
+ * (y negated for screen coords, so +y is the bottom tip):
+ *   x ∈ [-17.28, 17.28]   →   width  ≈ 34.6  (incl. the 1.08 stretch)
+ *   y ∈ [-11.92, 17.00]   →   height ≈ 28.9
+ * We add a small x-axis stretch (× 1.08) so the silhouette reads
  * unambiguously wider — closer to a Hallmark heart than a
  * mathematically pure one. Y is left alone; per-layer Y offsets
  * are gone (they were stretching the silhouette in the old
@@ -629,7 +632,15 @@ function heartPath( scaleMul = 1 ): number[] {
 	return pts;
 }
 
-function buildHeart( pixi: typeof import( 'pixi.js' ) ): Container {
+/**
+ * Build the heart. Returns the container (`view`) plus the gradient
+ * body sprite (`body`) so the ticker can tint the body alone — the
+ * highlights, outline, and logo must stay untinted or they dissolve
+ * into the body color.
+ */
+function buildHeart(
+	pixi: typeof import( 'pixi.js' ),
+): { view: Container; body: Sprite } {
 	const wrap = new pixi.Container();
 	const bounds = heartBoundingY();
 
@@ -657,6 +668,10 @@ function buildHeart( pixi: typeof import( 'pixi.js' ) ): Container {
 	gradientSprite.height = heartHeight;
 	gradientSprite.x = -overscan / 2;
 	gradientSprite.y = bounds.minY;
+
+	// Start at the resting tint so the first painted frame matches
+	// what the ticker will keep writing.
+	gradientSprite.tint = HEART_COLOR_REST;
 
 	const mask = new pixi.Graphics();
 	mask.poly( heartPath( 1.0 ) );
@@ -698,19 +713,33 @@ function buildHeart( pixi: typeof import( 'pixi.js' ) ): Container {
 	outline.stroke( { color: 0xffffff, alpha: 0.18, width: 1 } );
 	wrap.addChild( outline );
 
-	return wrap;
+	return { view: wrap, body: gradientSprite };
 }
 
 /**
  * Vertical span of the heart path in local pixels — used to size
  * the gradient sprite exactly.
+ *
+ * Derived from the sampled path itself rather than hardcoded: a
+ * previous hand-computed range (−15…+9) undershot the curve's real
+ * extent (−11.92…+17.0), so the gradient sprite ended ~28% above
+ * the heart's bottom tip — the mask had nothing to reveal there
+ * except the black drop-shadow, painting the tip as a flat dark
+ * band with a hard horizontal seam.
  */
 function heartBoundingY(): { minY: number; maxY: number } {
-	const s = HEART_SIZE / 17;
-	return {
-		minY: -15 * s,
-		maxY: 9 * s,
-	};
+	const pts = heartPath( 1.0 );
+	let minY = Infinity;
+	let maxY = -Infinity;
+	for ( let i = 1; i < pts.length; i += 2 ) {
+		if ( pts[ i ] < minY ) {
+			minY = pts[ i ];
+		}
+		if ( pts[ i ] > maxY ) {
+			maxY = pts[ i ];
+		}
+	}
+	return { minY, maxY };
 }
 
 /**
@@ -741,31 +770,104 @@ function makeGradientCanvas(): HTMLCanvasElement {
 function buildLogoSprite(
 	pixi: typeof import( 'pixi.js' ),
 	url: string,
-): Sprite {
-	const sprite = new pixi.Sprite();
-	sprite.anchor.set( 0.5 );
-	sprite.alpha = 0.95;
+): Container {
+	const wrap = new pixi.Container();
 	// Visual centre — pulled a touch BELOW the heart's geometric
 	// midline so the W mark sits in the meaty mid-body of the
 	// heart rather than floating between the upper lobes. The
 	// optical centre of a heart shape is below its geometric one
 	// because the lobes are visually heavier than the V-cleft.
-	sprite.y = HEART_SIZE * 0.08;
+	wrap.y = HEART_SIZE * 0.08;
+
+	// Soft drop shadow — a dark copy of the mark nudged down. The
+	// white glyph alone sat directly on the mid-body reds and could
+	// wash out; the shadow gives every stroke a dark edge to read
+	// against, whatever the current beat tint.
+	const shadow = new pixi.Sprite();
+	shadow.anchor.set( 0.5 );
+	shadow.tint = HEART_PALETTE.rim;
+	shadow.alpha = 0.6;
+	shadow.y = HEART_SIZE * 0.035;
+	wrap.addChild( shadow );
+
+	const mark = new pixi.Sprite();
+	mark.anchor.set( 0.5 );
+	wrap.addChild( mark );
 
 	const targetWidth = HEART_SIZE * 0.92;
-	pixi.Assets
-		.load( url )
-		.then( ( texture: Texture ) => {
-			sprite.texture = texture;
-			const scale = targetWidth / Math.max( 1, texture.width );
-			sprite.scale.set( scale );
+	// The source PNG is 1000 × 1000 but renders at ~48 CSS px. Sampling
+	// that big texture directly leaves the GPU's linear filter (no
+	// mipmaps in PIXI v8 by default) to skip most texels at ~20×
+	// minification — visibly pixelated edges. Rasterize once to a
+	// canvas at the exact display size instead, so the GPU samples
+	// near 1:1 and the mark stays crisp.
+	const img = new Image();
+	img.src = url;
+	img
+		.decode()
+		.then( () => {
+			const resolution = Math.min( window.devicePixelRatio || 1, 2 );
+			// ×1.7 headroom keeps the mark sharp at the big-beat peak
+			// (heart scales to ×1.55 plus the squish overshoot).
+			const widthPx = Math.ceil( targetWidth * resolution * 1.7 );
+			const canvas = rasterizeLogo( img, widthPx );
+			const texture: Texture = pixi.Texture.from( canvas );
+			const scale = targetWidth / canvas.width;
+			shadow.texture = texture;
+			shadow.scale.set( scale );
+			mark.texture = texture;
+			mark.scale.set( scale );
 		} )
 		.catch( () => {
 			// PNG missing or CSP block — heart still looks fine
 			// without the logo.
 		} );
 
-	return sprite;
+	return wrap;
+}
+
+/**
+ * Downscale the logo image to `widthPx` via canvas, halving in steps.
+ * A single drawImage from 1000 px straight to ~160 px undersamples on
+ * some engines (Firefox ignores `imageSmoothingQuality`) and shimmers;
+ * step-halving to ≤ 2× the target first keeps every stage within the
+ * filter's window, then the final draw lands on the exact size.
+ */
+function rasterizeLogo(
+	img: HTMLImageElement,
+	widthPx: number,
+): HTMLCanvasElement {
+	let src: HTMLImageElement | HTMLCanvasElement = img;
+	let w = img.naturalWidth;
+	let h = img.naturalHeight;
+	while ( w / 2 >= widthPx * 2 ) {
+		w = Math.round( w / 2 );
+		h = Math.round( h / 2 );
+		const step = document.createElement( 'canvas' );
+		step.width = w;
+		step.height = h;
+		const g = step.getContext( '2d' );
+		if ( ! g ) {
+			break;
+		}
+		g.imageSmoothingEnabled = true;
+		g.imageSmoothingQuality = 'high';
+		g.drawImage( src, 0, 0, w, h );
+		src = step;
+	}
+	const out = document.createElement( 'canvas' );
+	out.width = Math.max( 1, widthPx );
+	out.height = Math.max(
+		1,
+		Math.round( ( widthPx * img.naturalHeight ) / Math.max( 1, img.naturalWidth ) ),
+	);
+	const g = out.getContext( '2d' );
+	if ( g ) {
+		g.imageSmoothingEnabled = true;
+		g.imageSmoothingQuality = 'high';
+		g.drawImage( src, 0, 0, out.width, out.height );
+	}
+	return out;
 }
 
 function wpHeartbeatInterval(): number {

--- a/src/widgets/frame.ts
+++ b/src/widgets/frame.ts
@@ -67,9 +67,16 @@ export interface FrameHandlers {
 	 * Fired after the user finishes a drag or resize — handler
 	 * persists + fires hooks. Called with the current geometry in
 	 * desktop-area-local coordinates; handler is free to clamp /
-	 * reject.
+	 * reject. Only fires for floating cards.
 	 */
 	onGeometryChanged( geometry: WidgetGeometry ): void;
+	/**
+	 * Fired after the user finishes a height resize on a DOCKED
+	 * (column) card. Kept separate from `onGeometryChanged` because
+	 * docked cards persist only their height — a full geometry
+	 * record would mark the widget as floating on the next boot.
+	 */
+	onDockedHeightChanged( height: number ): void;
 	/**
 	 * Fired the first time a column-docked movable widget is dragged
 	 * (the "liberate" transition). Handler should re-parent the card
@@ -96,6 +103,12 @@ export interface FrameContext {
 	floatingParent: HTMLElement;
 	/** Persisted geometry for this id, or undefined for column-docked. */
 	geometry: WidgetGeometry | undefined;
+	/**
+	 * Persisted column-mode height for this id, or undefined for
+	 * natural (content-driven) height. Only applied when the card
+	 * mounts docked AND the widget is resizable.
+	 */
+	dockedHeight?: number;
 }
 
 export interface Frame {
@@ -143,13 +156,33 @@ export function buildFrame(
 
 	// Pre-apply saved geometry if the widget is already floating. The
 	// caller (layer) handles which parent to insert into — we just
-	// own the inline styles.
-	let isFloating = false;
+	// own the inline styles. Persisted coordinates are clamped to the
+	// current parent bounds so a stale entry (smaller screen, an old
+	// bug's leftovers) can never mount the card off-screen where the
+	// user has no way to grab it back.
 	if ( ctx.geometry ) {
-		applyGeometry( card, ctx.geometry );
+		applyGeometry(
+			card,
+			clampGeometryToParent( ctx.geometry, ctx.floatingParent ),
+		);
 		card.classList.add( FLOATING_CLASS );
-		isFloating = true;
+	} else if ( resizable && typeof ctx.dockedHeight === 'number' ) {
+		// Docked card with a persisted height resize — re-apply it,
+		// clamped to the def's current limits in case the widget's
+		// min/max changed between sessions.
+		card.style.height = `${ clampDockedHeight( ctx.dockedHeight, def ) }px`;
 	}
+
+	/**
+	 * Floating state is derived from the `--floating` class — the
+	 * single source of truth the layer also writes to on redock. A
+	 * closure boolean here previously went stale when the layer
+	 * re-docked the card (the frame was never told), so the next
+	 * resize wrote desktop-area left/top offsets onto a relatively-
+	 * positioned column card and flung it off-screen.
+	 */
+	const isFloating = (): boolean =>
+		card.classList.contains( FLOATING_CLASS );
 
 	// Resize handles — always built for resizable widgets, but only
 	// the ones that match the movable state are visible (CSS hides
@@ -164,7 +197,7 @@ export function buildFrame(
 			handle.dataset.dir = dir;
 			card.appendChild( handle );
 			resizeCleanups.push(
-				attachResize( card, handle, dir, def, ctx, handlers, () => isFloating ),
+				attachResize( card, handle, dir, def, ctx, handlers, isFloating ),
 			);
 		}
 	}
@@ -179,9 +212,7 @@ export function buildFrame(
 			'.desktop-mode-widgets__chrome',
 		);
 		if ( chrome ) {
-			dragCleanup = attachDrag( card, chrome, def, ctx, handlers, ( next ) => {
-				isFloating = next;
-			} );
+			dragCleanup = attachDrag( card, chrome, def, ctx, handlers );
 		}
 	}
 
@@ -323,7 +354,6 @@ function attachDrag(
 	def: WidgetDef,
 	ctx: FrameContext,
 	handlers: FrameHandlers,
-	setFloating: ( next: boolean ) => void,
 ): () => void {
 	let pointerId: number | null = null;
 	let startX = 0;
@@ -400,7 +430,6 @@ function attachDrag(
 			};
 			applyGeometry( card, initial );
 			card.classList.add( FLOATING_CLASS );
-			setFloating( true );
 			handlers.onLiberate( initial );
 			// Re-read the inline styles — the applyGeometry call
 			// above just wrote them. Without this, the first
@@ -566,7 +595,15 @@ function attachResize(
 		}
 		pointerId = null;
 		card.classList.remove( RESIZING_CLASS );
-		handlers.onGeometryChanged( currentGeometry( card ) );
+		// Floating and docked resizes persist through DIFFERENT
+		// channels: a geometry record's presence is what marks a
+		// widget as floating on the next boot, so a docked height
+		// resize must never write one — it persists height alone.
+		if ( isFloating() ) {
+			handlers.onGeometryChanged( currentGeometry( card ) );
+		} else {
+			handlers.onDockedHeightChanged( card.offsetHeight );
+		}
 	};
 
 	handle.addEventListener( 'pointerdown', onDown );
@@ -611,6 +648,46 @@ function currentGeometry( card: HTMLElement ): WidgetGeometry {
 		width: card.offsetWidth,
 		height: card.offsetHeight,
 	};
+}
+
+/**
+ * Clamp a persisted docked height to the def's current min/max —
+ * the stored value was clamped at resize time, but the widget's
+ * declared limits may have changed between sessions.
+ */
+function clampDockedHeight( height: number, def: WidgetDef ): number {
+	return clamp(
+		height,
+		def.minHeight ?? DEFAULT_MIN_HEIGHT,
+		def.maxHeight ?? Infinity,
+	);
+}
+
+/**
+ * Clamp a persisted geometry's position into the parent's bounds
+ * before mounting. Guards against stale localStorage entries — a
+ * smaller screen than last session, or coordinates written by an
+ * older buggy build — mounting the card off-screen where the user
+ * can never grab it back. Size is left untouched; only the position
+ * is pulled back into view.
+ */
+function clampGeometryToParent(
+	geometry: WidgetGeometry,
+	parent: HTMLElement,
+): WidgetGeometry {
+	// Parent not laid out yet (zero size) — clamping against it would
+	// snap everything to the origin. Trust the persisted values.
+	if ( ! parent.clientWidth || ! parent.clientHeight ) {
+		return geometry;
+	}
+	const clamped = clampToParent(
+		geometry.x,
+		geometry.y,
+		geometry.width,
+		geometry.height,
+		parent,
+	);
+	return { ...geometry, x: clamped.x, y: clamped.y };
 }
 
 function clampToParent(

--- a/src/widgets/layer.ts
+++ b/src/widgets/layer.ts
@@ -30,9 +30,11 @@ import * as registry from './registry';
 import { openWidgetPicker, refreshWidgetPicker } from './picker';
 import { applyGeometry, buildFrame, type Frame } from './frame';
 import {
+	loadDockedHeights,
 	loadEnabledIds,
 	loadGeometry,
 	readRawEnabled,
+	saveDockedHeights,
 	saveEnabledIds,
 	saveGeometry,
 } from './state';
@@ -63,6 +65,7 @@ export class WidgetLayer {
 	private pluginUrl: string;
 	private enabledIds: string[];
 	private geometry: Record< string, WidgetGeometry >;
+	private dockedHeights: Record< string, number >;
 	private mounted: Map< string, MountedWidget > = new Map();
 
 	/**
@@ -89,6 +92,7 @@ export class WidgetLayer {
 		this.pluginUrl = pluginUrl;
 		this.enabledIds = loadEnabledIds();
 		this.geometry = loadGeometry();
+		this.dockedHeights = loadDockedHeights();
 		this.floatingHost = floatingHost ?? root.parentElement ?? root;
 
 		this.listEl = document.createElement( 'div' );
@@ -164,6 +168,12 @@ export class WidgetLayer {
 		if ( this.geometry[ id ] ) {
 			delete this.geometry[ id ];
 			saveGeometry( this.geometry );
+		}
+		// Same for the docked-height record — a re-add starts at the
+		// widget's natural (content-driven) height.
+		if ( this.dockedHeights[ id ] !== undefined ) {
+			delete this.dockedHeights[ id ];
+			saveDockedHeights( this.dockedHeights );
 		}
 		this.unmountById( id );
 		this.paintEmptyState();
@@ -271,10 +281,16 @@ export class WidgetLayer {
 		const initialGeometry = def.movable === true ? this.geometry[ id ] : undefined;
 		const frame = buildFrame(
 			def,
-			{ floatingParent: this.floatingHost, geometry: initialGeometry },
+			{
+				floatingParent: this.floatingHost,
+				geometry: initialGeometry,
+				dockedHeight: this.dockedHeights[ id ],
+			},
 			{
 				onRemove: () => this.remove( id ),
 				onGeometryChanged: ( geom ) => this.persistGeometry( id, geom ),
+				onDockedHeightChanged: ( height ) =>
+					this.persistDockedHeight( id, height ),
 				onLiberate: ( geom ) => this.liberate( id, geom ),
 				onRedock: () => this.redock( id ),
 			},
@@ -461,13 +477,16 @@ export class WidgetLayer {
 		}
 		// Strip the inline geometry so the card renders back at its
 		// flex-column natural size — no phantom left/top offsets
-		// bleed into column layout.
+		// bleed into column layout. A persisted docked height (from a
+		// previous column resize) is re-applied instead of cleared.
 		const card = record.frame.card;
 		card.classList.remove( 'desktop-mode-widgets__card--floating' );
 		card.style.left = '';
 		card.style.top = '';
 		card.style.width = '';
-		card.style.height = '';
+		const dockedHeight = this.dockedHeights[ id ];
+		card.style.height =
+			dockedHeight !== undefined ? `${ dockedHeight }px` : '';
 		// Re-append before the add-tile so the card lands at the
 		// bottom of the existing stack (matches the new-widget
 		// insertion order — "most recently added / redocked is last").
@@ -478,6 +497,14 @@ export class WidgetLayer {
 	private persistGeometry( id: string, geometry: WidgetGeometry ): void {
 		this.geometry[ id ] = geometry;
 		saveGeometry( this.geometry );
+	}
+
+	private persistDockedHeight( id: string, height: number ): void {
+		if ( ! Number.isFinite( height ) || height <= 0 ) {
+			return;
+		}
+		this.dockedHeights[ id ] = height;
+		saveDockedHeights( this.dockedHeights );
 	}
 
 	/**

--- a/src/widgets/state.ts
+++ b/src/widgets/state.ts
@@ -1,7 +1,7 @@
 /**
  * Desktop Mode — Widget persistence.
  *
- * Two separate localStorage records:
+ * Three separate localStorage records:
  *
  *   - `desktop-mode-widgets`           — ordered list of enabled widget
  *                                      ids (today's format; unchanged
@@ -12,6 +12,13 @@
  *                                      liberated from the column.
  *                                      Missing keys mean "still docked
  *                                      in the column."
+ *   - `desktop-mode-widgets-docked-heights` — per-id height (px) for
+ *                                      resizable widgets the user has
+ *                                      height-resized while docked.
+ *                                      Kept apart from the geometry
+ *                                      record because a geometry
+ *                                      entry's mere presence marks a
+ *                                      widget as floating at boot.
  *
  * Each record writes-through independently so a quota failure in one
  * doesn't corrupt the other.
@@ -23,6 +30,7 @@ import type { WidgetGeometry } from './types';
 
 const IDS_KEY = 'desktop-mode-widgets';
 const GEOMETRY_KEY = 'desktop-mode-widgets-geometry';
+const DOCKED_HEIGHTS_KEY = 'desktop-mode-widgets-docked-heights';
 
 /**
  * Raw read so callers can distinguish "never saved" (null) from
@@ -90,6 +98,41 @@ export function saveGeometry(
 ): void {
 	try {
 		window.localStorage.setItem( GEOMETRY_KEY, JSON.stringify( geometry ) );
+	} catch {
+		/* best-effort */
+	}
+}
+
+export function loadDockedHeights(): Record< string, number > {
+	try {
+		const raw = window.localStorage.getItem( DOCKED_HEIGHTS_KEY );
+		if ( ! raw ) {
+			return {};
+		}
+		const parsed = JSON.parse( raw );
+		if ( ! parsed || typeof parsed !== 'object' ) {
+			return {};
+		}
+		const out: Record< string, number > = {};
+		for ( const [ id, value ] of Object.entries( parsed ) ) {
+			if ( typeof value === 'number' && Number.isFinite( value ) && value > 0 ) {
+				out[ id ] = value;
+			}
+		}
+		return out;
+	} catch {
+		return {};
+	}
+}
+
+export function saveDockedHeights(
+	heights: Record< string, number >,
+): void {
+	try {
+		window.localStorage.setItem(
+			DOCKED_HEIGHTS_KEY,
+			JSON.stringify( heights ),
+		);
 	} catch {
 		/* best-effort */
 	}

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -123,6 +123,9 @@ describe( 'widgets/layer', () => {
 		try {
 			window.localStorage.removeItem( 'desktop-mode-widgets' );
 			window.localStorage.removeItem( 'desktop-mode-widgets-geometry' );
+			window.localStorage.removeItem(
+				'desktop-mode-widgets-docked-heights',
+			);
 		} catch {
 			/* jsdom */
 		}
@@ -583,6 +586,235 @@ describe( 'widgets/layer', () => {
 		expect( docked.width ).toBe( 300 );
 		expect( docked.x ).toBe( 100 );
 		expect( docked.height ).toBe( 400 );
+	} );
+
+	test( 're-docking then resizing keeps the card in the column (no stale floating state)', async () => {
+		// Reproduces the "widget fully disappears while playing with
+		// drag / resize / re-attach" bug. The frame used to track
+		// floating state in a closure boolean that the layer's redock
+		// never reset — after re-docking, a resize still took the
+		// floating code path and wrote desktop-area coordinates into
+		// left/top on a relatively-positioned column card, flinging
+		// it off-screen with no error.
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'redock-rs',
+			label: 'Redock resize',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			resizable: true,
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem( 'desktop-mode-widgets', '["redock-rs"]' );
+		window.localStorage.setItem(
+			'desktop-mode-widgets-geometry',
+			JSON.stringify( {
+				'redock-rs': { x: 400, y: 300, width: 300, height: 200 },
+			} ),
+		);
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+		// Floating cards mount into the floating host (host's parent,
+		// i.e. document.body in this harness), not the column.
+		const card = document.querySelector< HTMLElement >(
+			'[data-widget-id="redock-rs"]',
+		)!;
+		expect( card ).toBeTruthy();
+		expect(
+			card.classList.contains( 'desktop-mode-widgets__card--floating' ),
+		).toBe( true );
+
+		// Put it back in the column.
+		layer.redock( 'redock-rs' );
+		expect(
+			card.classList.contains( 'desktop-mode-widgets__card--floating' ),
+		).toBe( false );
+		expect( card.style.left ).toBe( '' );
+
+		// Now resize from the bottom edge, as a user would. Stub the
+		// rects jsdom won't compute: the card sits at the column's
+		// on-screen position (x≈1200) inside a 1536-wide desktop.
+		card.getBoundingClientRect = (): DOMRect => ( {
+			x: 1200, y: 40, width: 300, height: 200,
+			top: 40, left: 1200, right: 1500, bottom: 240,
+			toJSON: () => ( {} ),
+		} );
+		document.body.getBoundingClientRect = (): DOMRect => ( {
+			x: 0, y: 0, width: 1536, height: 800,
+			top: 0, left: 0, right: 1536, bottom: 800,
+			toJSON: () => ( {} ),
+		} );
+		const ptr = ( type: string, x: number, y: number ): Event => {
+			const e = new Event( type, { bubbles: true } );
+			Object.defineProperty( e, 'pointerId', { value: 1 } );
+			Object.defineProperty( e, 'button', { value: 0 } );
+			Object.defineProperty( e, 'clientX', { value: x } );
+			Object.defineProperty( e, 'clientY', { value: y } );
+			return e;
+		};
+		const handle = card.querySelector< HTMLElement >(
+			'.desktop-mode-widgets__resize--s',
+		)!;
+		( handle as unknown as { setPointerCapture: () => void } ).setPointerCapture = () => undefined;
+		( handle as unknown as { releasePointerCapture: () => void } ).releasePointerCapture = () => undefined;
+		handle.dispatchEvent( ptr( 'pointerdown', 1350, 240 ) );
+		handle.dispatchEvent( ptr( 'pointermove', 1350, 300 ) );
+		handle.dispatchEvent( ptr( 'pointerup', 1350, 300 ) );
+
+		// Height resize works…
+		expect( card.style.height ).toBe( '260px' );
+		// …but position must be untouched — before the fix left/top
+		// were written with desktop-area coords (left: 1200px on a
+		// position: relative card → off-screen).
+		expect( card.style.left ).toBe( '' );
+		expect( card.style.top ).toBe( '' );
+		// And no geometry record persists: a record marks the widget
+		// as floating on the next boot and would teleport it out of
+		// the column.
+		const geom = JSON.parse(
+			window.localStorage.getItem( 'desktop-mode-widgets-geometry' ) ||
+				'{}',
+		);
+		expect( geom[ 'redock-rs' ] ).toBeUndefined();
+
+		layer.disposeAll();
+	} );
+
+	test( 'docked height resize persists and re-applies on the next boot', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'dock-rs',
+			label: 'Dock resize',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			resizable: true,
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem( 'desktop-mode-widgets', '["dock-rs"]' );
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+		const card = host.querySelector< HTMLElement >(
+			'[data-widget-id="dock-rs"]',
+		)!;
+		expect( card ).toBeTruthy();
+
+		// Stub the rects jsdom won't compute. `offsetHeight` mirrors
+		// the inline style the resize writes, like a real layout would.
+		card.getBoundingClientRect = (): DOMRect => ( {
+			x: 1200, y: 40, width: 300, height: 200,
+			top: 40, left: 1200, right: 1500, bottom: 240,
+			toJSON: () => ( {} ),
+		} );
+		Object.defineProperty( card, 'offsetHeight', {
+			configurable: true,
+			get: () => parseFloat( card.style.height ) || 200,
+		} );
+		document.body.getBoundingClientRect = (): DOMRect => ( {
+			x: 0, y: 0, width: 1536, height: 800,
+			top: 0, left: 0, right: 1536, bottom: 800,
+			toJSON: () => ( {} ),
+		} );
+		const ptr = ( type: string, x: number, y: number ): Event => {
+			const e = new Event( type, { bubbles: true } );
+			Object.defineProperty( e, 'pointerId', { value: 1 } );
+			Object.defineProperty( e, 'button', { value: 0 } );
+			Object.defineProperty( e, 'clientX', { value: x } );
+			Object.defineProperty( e, 'clientY', { value: y } );
+			return e;
+		};
+		const handle = card.querySelector< HTMLElement >(
+			'.desktop-mode-widgets__resize--s',
+		)!;
+		( handle as unknown as { setPointerCapture: () => void } ).setPointerCapture = () => undefined;
+		( handle as unknown as { releasePointerCapture: () => void } ).releasePointerCapture = () => undefined;
+		handle.dispatchEvent( ptr( 'pointerdown', 1350, 240 ) );
+		handle.dispatchEvent( ptr( 'pointermove', 1350, 300 ) );
+		handle.dispatchEvent( ptr( 'pointerup', 1350, 300 ) );
+
+		expect( card.style.height ).toBe( '260px' );
+		const saved = JSON.parse(
+			window.localStorage.getItem(
+				'desktop-mode-widgets-docked-heights',
+			) || '{}',
+		);
+		expect( saved[ 'dock-rs' ] ).toBe( 260 );
+		// No floating-geometry record — the card must boot docked.
+		const geom = JSON.parse(
+			window.localStorage.getItem( 'desktop-mode-widgets-geometry' ) ||
+				'{}',
+		);
+		expect( geom[ 'dock-rs' ] ).toBeUndefined();
+
+		layer.disposeAll();
+
+		// Fresh boot (F5 equivalent): height re-applies, still docked.
+		const layer2 = new WidgetLayer( host, '' );
+		layer2.hydrate();
+		const card2 = host.querySelector< HTMLElement >(
+			'[data-widget-id="dock-rs"]',
+		)!;
+		expect( card2.style.height ).toBe( '260px' );
+		expect(
+			card2.classList.contains( 'desktop-mode-widgets__card--floating' ),
+		).toBe( false );
+		layer2.disposeAll();
+	} );
+
+	test( 'persisted off-screen geometry is clamped back into view at mount', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'lost',
+			label: 'Lost',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem( 'desktop-mode-widgets', '["lost"]' );
+		// Coordinates far outside any plausible desktop — e.g. written
+		// by the stale-floating bug or a much larger prior screen.
+		window.localStorage.setItem(
+			'desktop-mode-widgets-geometry',
+			JSON.stringify( {
+				lost: { x: 5000, y: 4000, width: 300, height: 200 },
+			} ),
+		);
+		// The floating host (document.body here) must report a laid-out
+		// size for the mount-time clamp to engage.
+		Object.defineProperty( document.body, 'clientWidth', {
+			value: 1000,
+			configurable: true,
+		} );
+		Object.defineProperty( document.body, 'clientHeight', {
+			value: 600,
+			configurable: true,
+		} );
+
+		try {
+			const layer = new WidgetLayer( host, '' );
+			layer.hydrate();
+			const card = document.querySelector< HTMLElement >(
+				'[data-widget-id="lost"]',
+			)!;
+			// Clamped to parent bounds minus the 20px margin — the card
+			// is on-screen and grabbable again.
+			expect( card.style.left ).toBe( `${ 1000 - 300 - 20 }px` );
+			expect( card.style.top ).toBe( `${ 600 - 200 - 20 }px` );
+			layer.disposeAll();
+		} finally {
+			// Don't leak the stubbed body metrics into later tests.
+			delete ( document.body as unknown as Record< string, unknown > )
+				.clientWidth;
+			delete ( document.body as unknown as Record< string, unknown > )
+				.clientHeight;
+		}
 	} );
 
 	test( 'add-then-remove before async mount resolves discards the stale mount', async () => {


### PR DESCRIPTION
## Summary

This PR addresses several existing issues in the widget framework that I identified during testing. These are unrelated to the changes from previous PRs and are all contained within the widget framework.

### Fixes

* Fixed widgets occasionally disappearing after interactions such as dragging, re-docking, or resizing.
* Fixed widget height not persisting across page reloads.
* Improved widget background styling.
* Fixed buggy behavior in the Heartbeat widget.
* Improved widget hover effects.
* Fixed content overflowing widget containers during resize operations.

## Testing

1. Open the dashboard with multiple widgets.
2. Drag widgets to different positions and verify they remain visible.
3. Dock and undock widgets multiple times and confirm they continue to render correctly.
4. Resize widgets (both width and height) and verify content stays within widget boundaries.
5. Refresh the page and confirm widget height is preserved.
6. Verify the updated widget background styling and hover effects.
7. Open and interact with the Heartbeat widget to ensure it behaves correctly.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-326-26d3bd76dd08a13626421882281b00ce8db5a1bf.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->