### PR TITLE
Focus the hovered window during any drag (spring-loading)

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -90,6 +90,14 @@ The forwarder listens in **bubble phase** at the iframe's `document`, so any in-
 
 Only drops where neither bail fires (the empty page background, or an inner handler that never called `preventDefault()`) escalate to the shell.
 
+### Drag-hover heartbeat — `desktop-mode-drag-hover`
+
+*(since 0.9.4)* Native drag events don't cross iframe boundaries, so when the user holds any drag (an OS file, an image lifted off another admin page, a text selection) over an iframe window, the parent shell can't see the hover. Both bridges (inline chromeless + standalone) forward a throttled heartbeat while `dragover` fires inside the iframe, so the shell's focus-on-drag-hover module can raise the hovered window after its ~250 ms dwell (see the `desktop-mode.window.focus-on-drag-hover` filter in `javascript-reference.md`).
+
+| Type | Direction | Carries | Purpose |
+|---|---|---|---|
+| `desktop-mode-drag-hover` | iframe → parent | `{ payloadType: 'os-file' \| 'external' }` | "A drag is currently hovering me." Throttled to one message per 150 ms. Purely observational — the forwarder never calls `preventDefault()` and carries no coordinates or payload data; the parent resolves the hovered window from `MessageEvent.source` (the sender iframe **is** the hovered window). The parent resets its hover state when heartbeats stop (~1 s watchdog), so no end message exists or is needed. |
+
 ### Pre-close unsaved-changes query — `desktop-mode-bridge-beforeunload-*`
 
 *(since 0.9.4)* Before tearing down an iframe-backed (non-native) window, `Window.close()` gives the page inside a chance to veto — the same protection a real browser tab close gets from the page's `beforeunload` handler, which a same-origin admin iframe never triggers on its own (there's no real navigation happening).

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -330,6 +330,19 @@ postMessages and the `desktop-mode-cross-frame-drag-start` /
 payload channel) are a separate, lower-level surface and remain
 Stable since 0.5.0.
 
+**Focus follows the drag** *(since 0.9.4)*: while a drag is in
+flight — any drag, whatever its source or payload: a DragManager
+session, a cross-iframe bridge drag (Media Library), an OS file, an
+image or text selection lifted from anywhere — the window under the
+cursor is raised (focused) after a ~250 ms hover dwell, macOS
+spring-loading style, so the drop target comes forward. Sweeping
+across a window without resting on it does not raise it. Drags
+hovering an iframe window from outside a bridge session are detected
+via the `desktop-mode-drag-hover` heartbeat the chromeless bridge
+forwards (see `bridge-protocol.md`). Plugins can veto per activation
+via the `desktop-mode.window.focus-on-drag-hover` filter (see the
+[window lifecycle hooks table](#window-lifecycle)).
+
 ### `wp.desktop.dragBridge` — cross-iframe drag — Stable *(since 0.6.0)*
 
 The bridge is the postMessage channel that lets shell-side drags
@@ -3234,6 +3247,7 @@ All window actions include at minimum `{ windowId: string }` — additional fiel
 | `desktop-mode.window.fullscreen-entered` | action | Stable | `{ windowId, element }` |
 | `desktop-mode.window.fullscreen-exited` | action | Stable | `{ windowId, element }` |
 | `desktop-mode.window.auto-exit-fullscreen` | filter | Stable *(0.8.6)* | `( shouldExit: boolean, ctx: { windowId, focusedTo } ) => boolean` — decides whether a fullscreen window should auto-exit when focus moves elsewhere. Default `true`. Return `false` to keep persistent-fullscreen surfaces (slideshow, video, game) in fullscreen across focus changes. |
+| `desktop-mode.window.focus-on-drag-hover` | filter | Stable *(0.9.4)* | `( shouldFocus: boolean, ctx: { windowId, payloadType } ) => boolean` — decides whether the window under the cursor is raised (focused) after a ~250 ms hover dwell during any drag. `payloadType` is the DragManager payload's `type` slug (`'desktop-file'`, `'shortcut'`, plugin-defined), the bridge payload's `kind` (`'attachment'`, `'post'`, `'user'`), `'os-file'` for OS file drags, or `'external'` for any other native drag. Default `true`. Return `false` to keep HUD/palette/pinned-reference windows from stealing z-order during drags. |
 | `desktop-mode.window.drag-start` | action | Stable | `{ windowId }` |
 | `desktop-mode.window.drag-end` | action | Stable | `{ windowId, x, y }` |
 | `desktop-mode.window.moved` | action | Stable | `{ windowId, x, y }` — fires with drag-end |

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1381,6 +1381,45 @@ function desktop_mode_chromeless_bridge_script() {
 	}, false );
 
 	/*
+	 * Drag-hover forwarder. Native drag events don't cross iframe
+	 * boundaries, so when the user holds ANY drag (an OS file, an
+	 * image lifted off another admin page, a text selection) over
+	 * this window, the parent shell has no idea the window is being
+	 * hovered. Forward a throttled, payload-free heartbeat so the
+	 * shell's focus-on-drag-hover module
+	 * (`src/drag/focus-window-on-drag-hover.ts`) can raise this
+	 * window after its dwell. Purely observational — no
+	 * `preventDefault()`, no interference with in-page drop zones.
+	 * The parent identifies the hovered window from the message
+	 * source, so no coordinates travel.
+	 *
+	 * Sentinel-guarded: the standalone bridge bundle
+	 * (`iframe-bridge-standalone.ts`) installs the same forwarder,
+	 * and unlike the drop forwarder above there is no
+	 * `defaultPrevented` handshake to dedupe a double install.
+	 */
+	if ( ! window.__desktopModeDragHoverForwarderInstalled ) {
+		window.__desktopModeDragHoverForwarderInstalled = true;
+		var dragHoverLastSent = 0;
+		document.addEventListener( 'dragover', function ( ev ) {
+			var now = Date.now();
+			if ( now - dragHoverLastSent < 150 ) {
+				return;
+			}
+			dragHoverLastSent = now;
+			try {
+				window.parent.postMessage(
+					{
+						type: 'desktop-mode-drag-hover',
+						payloadType: bridgeHasFiles( ev ) ? 'os-file' : 'external',
+					},
+					window.location.origin
+				);
+			} catch ( err ) { /* cross-origin parent; swallow */ }
+		}, true );
+	}
+
+	/*
 	 * Cmd+K / Ctrl+K forwarder — single-press, unconditional.
 	 *
 	 * Native keydown events don't cross iframe boundaries. Inside a

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -133,6 +133,7 @@ import { type KeyedListOptions } from './ui/util/keyed-list';
 import { DragBridge, type DragBridgeApi } from './drag-bridge';
 import { DragManager, type DragManagerApi, DRAG_EVENTS } from './drag';
 import { installIframeDropTargets } from './drag/iframe-drop-targets';
+import { installFocusWindowOnDragHover } from './drag/focus-window-on-drag-hover';
 import {
 	type DesktopCommand,
 } from './commands';
@@ -1943,6 +1944,12 @@ function init(): void {
 	// idle: drop targets only matter when the user actually
 	// drags something, which can't happen before init() returns.
 	scheduleIdleBoot( () => installIframeDropTargets( dragManager ) );
+
+	// Focus-on-drag-hover — raises the window under the cursor after
+	// a short dwell during a drag, so the drop target comes forward.
+	// Listens to the DRAG_EVENTS CustomEvents; only needs the
+	// WindowManager as its focus host, not the DragManager.
+	scheduleIdleBoot( () => installFocusWindowOnDragHover( manager ) );
 
 	// Surface a toast when an iframe receiver (Gutenberg drop-
 	// receiver today) reports a failed insert — most commonly a

--- a/src/drag/focus-window-on-drag-hover.ts
+++ b/src/drag/focus-window-on-drag-hover.ts
@@ -1,0 +1,368 @@
+/**
+ * Desktop Mode — Focus the hovered window during a drag.
+ *
+ * While a drag is in flight — ANY drag, whatever its source, origin,
+ * or payload — the window under the cursor is raised (focused) after
+ * a short hover dwell, macOS spring-loading style. Without this,
+ * dragging a payload toward a background window leaves the drop
+ * target buried behind the source window: the drop works, but the
+ * user can't see where it lands.
+ *
+ * Three channels feed one shared dwell state machine:
+ *
+ *   1. Shell `DragManager` sessions (file tiles, My WordPress tiles,
+ *      plugin sources) — pointer-event gestures, driven by the
+ *      `DRAG_EVENTS.MOVE` / `.END` CustomEvents on `document`.
+ *   2. Native HTML5 drags over shell surfaces — OS files, images,
+ *      text, links, cross-iframe bridge drags (Media Library). The
+ *      parent document's own `dragover` supplies the coordinates.
+ *      For bridge drags this covers iframe windows too: the
+ *      iframe-drop-targets module suppresses `pointer-events` on
+ *      every iframe for the session, so `dragover` falls through to
+ *      the parent everywhere.
+ *   3. Native HTML5 drags hovering an iframe window OUTSIDE a bridge
+ *      session (an OS file held over a post window, an image dragged
+ *      out of one admin page over another). Those `dragover` events
+ *      fire inside the iframe's document and never reach the parent
+ *      — but the hovered window IS the iframe's window, so the
+ *      chromeless bridge (`includes/render/chromeless-bridge.php`,
+ *      mirrored in `iframe-bridge-standalone.ts`) posts a throttled
+ *      `desktop-mode-drag-hover` message and the parent resolves the
+ *      sender to its window id. No coordinates needed.
+ *
+ * Ends are heterogeneous — `DRAG_EVENTS.END` for channel 1,
+ * `drop` / `dragend` / leave-the-window `dragleave` for channel 2,
+ * and nothing at all for channel 3 (a drop inside the iframe is
+ * invisible to the parent) — so the HTML5 channels additionally arm
+ * a watchdog: when hover signals stop arriving, the state resets and
+ * any pending dwell dies with it.
+ *
+ * The dwell (rather than focus-on-enter) is deliberate:
+ *
+ *   - Focus permanently reorders the z-stack. Sweeping across
+ *     intermediate windows on the way to a target must not raise
+ *     every window the path happens to cross.
+ *   - Each focus change fans out `WINDOW_BLURRED` / `WINDOW_FOCUSED`
+ *     hooks and CustomEvents to the dock, unfocus effects, etc. —
+ *     per-crossing churn is real work.
+ *   - `WindowManager.focus()` auto-exits a fullscreen window; an
+ *     accidental 50 ms crossing must not kick one out.
+ *
+ * Like `iframe-drop-targets.ts`, this module never imports the
+ * WindowManager — it takes a minimal structural focus host, keeping
+ * `src/drag/` framework-agnostic. Raising a window mid-drag is safe:
+ * `WindowManager.focus()` only reorders z-indices and CSS classes,
+ * it never moves keyboard focus, so the drag-recovery blur-cancel
+ * cannot trip.
+ *
+ * Plugins can veto per activation via the
+ * `desktop-mode.window.focus-on-drag-hover` filter.
+ *
+ * @since 0.9.4
+ */
+
+import { applyFilters, HOOKS } from '../hooks';
+import { DRAG_EVENTS, type DragPayload } from './types';
+import {
+	DRAG_BRIDGE_EVENTS,
+	type DragBridgePayload,
+} from '../drag-bridge';
+import { findWindowRootAtPoint, windowIdFromRoot } from './window-at-point';
+
+/** How long the cursor must rest on a window before it is raised. */
+export const FOCUS_ON_DRAG_HOVER_DWELL_MS = 250;
+
+/**
+ * How long the HTML5 channels may go silent before the hover state
+ * resets. `dragover` re-fires every ~350 ms even on a stationary
+ * cursor (and the iframe forwarder throttles to well under that), so
+ * a full second of silence reliably means the drag ended somewhere
+ * the parent can't observe (a drop inside an iframe, an Escape
+ * cancel, the cursor leaving the browser).
+ */
+export const FOCUS_ON_DRAG_HOVER_WATCHDOG_MS = 1000;
+
+/** Iframe→parent postMessage announcing an in-iframe drag hover. */
+export const DRAG_HOVER_MESSAGE_TYPE = 'desktop-mode-drag-hover';
+
+/** The one window method the dwell activation needs. */
+export interface FocusableWindow {
+	isFocused(): boolean;
+}
+
+/**
+ * Minimal structural slice of the WindowManager. Kept local so
+ * `src/drag/` stays decoupled from the window system (see the module
+ * rationale in `types.ts`).
+ */
+export interface WindowFocusHost< W extends FocusableWindow = FocusableWindow > {
+	getById( id: string ): W | undefined;
+	focus( win: W ): void;
+}
+
+let _installed = false;
+let _host: WindowFocusHost | null = null;
+let _lastHoverWindowId: string | null = null;
+let _dwellTimer: ReturnType< typeof setTimeout > | null = null;
+let _watchdogTimer: ReturnType< typeof setTimeout > | null = null;
+/** Payload slug of the active bridge session, or null when none. */
+let _bridgePayloadKind: string | null = null;
+
+function clearDwell(): void {
+	if ( _dwellTimer !== null ) {
+		clearTimeout( _dwellTimer );
+		_dwellTimer = null;
+	}
+}
+
+function clearWatchdog(): void {
+	if ( _watchdogTimer !== null ) {
+		clearTimeout( _watchdogTimer );
+		_watchdogTimer = null;
+	}
+}
+
+function resetHoverState(): void {
+	clearDwell();
+	clearWatchdog();
+	_lastHoverWindowId = null;
+}
+
+function bumpWatchdog(): void {
+	clearWatchdog();
+	_watchdogTimer = setTimeout( () => {
+		_watchdogTimer = null;
+		resetHoverState();
+	}, FOCUS_ON_DRAG_HOVER_WATCHDOG_MS );
+}
+
+function fireFocus( windowId: string, payloadType: string ): void {
+	const win = _host?.getById( windowId );
+	if ( ! win || win.isFocused() ) {
+		// Closed mid-dwell, or already on top (e.g. the drag-source
+		// window) — nothing to raise.
+		return;
+	}
+	const shouldFocus = applyFilters<
+		boolean,
+		[ { windowId: string; payloadType: string } ]
+	>(
+		HOOKS.WINDOW_FOCUS_ON_DRAG_HOVER,
+		true,
+		{ windowId, payloadType },
+	);
+	if ( ! shouldFocus ) {
+		return;
+	}
+	try {
+		_host?.focus( win );
+	} catch ( err ) {
+		console.error( '[desktop-mode] focus-on-drag-hover focus() threw:', windowId, err );
+	}
+}
+
+/**
+ * The shared dwell state machine. Fed the hovered window id (or null
+ * for wallpaper/dock/none) by whichever channel is driving the drag.
+ */
+function trackHoverWindowId( windowId: string | null, payloadType: string ): void {
+	if ( windowId === _lastHoverWindowId ) {
+		// Still over the same window (or still over none) — let a
+		// pending dwell run to completion rather than restarting it.
+		return;
+	}
+	clearDwell();
+	_lastHoverWindowId = windowId;
+	if ( windowId === null ) {
+		// Wallpaper, dock, taskbar — leave focus as-is.
+		return;
+	}
+	_dwellTimer = setTimeout( () => {
+		_dwellTimer = null;
+		fireFocus( windowId, payloadType );
+	}, FOCUS_ON_DRAG_HOVER_DWELL_MS );
+}
+
+function trackHoverAtPoint( clientX: number, clientY: number, payloadType: string ): void {
+	const root = findWindowRootAtPoint( clientX, clientY );
+	trackHoverWindowId( root ? windowIdFromRoot( root ) : null, payloadType );
+}
+
+// ------------------------------------------------------------------
+// Channel 1 — shell DragManager sessions (pointer-event gesture).
+// Has a definitive END event, so no watchdog involvement.
+// ------------------------------------------------------------------
+
+const onDragMove = ( e: Event ): void => {
+	const detail = ( e as CustomEvent ).detail as
+		| { payload?: DragPayload; clientX?: number; clientY?: number }
+		| undefined;
+	if (
+		typeof detail?.clientX !== 'number' ||
+		typeof detail?.clientY !== 'number'
+	) {
+		return;
+	}
+	trackHoverAtPoint( detail.clientX, detail.clientY, detail.payload?.type ?? '' );
+};
+
+const onDragEnd = (): void => {
+	resetHoverState();
+};
+
+// ------------------------------------------------------------------
+// Channel 2 — native HTML5 drags over shell surfaces (parent-document
+// `dragover`). Covers OS files, images/text/links from anywhere, and
+// — because iframe pointer-events are suppressed during a bridge
+// session — cross-iframe bridge drags over iframe windows too.
+// ------------------------------------------------------------------
+
+function dragHasFiles( e: DragEvent ): boolean {
+	const types = e.dataTransfer?.types;
+	if ( ! types ) {
+		return false;
+	}
+	// DataTransfer.types is a frozen array in modern engines, a
+	// DOMStringList in older ones.
+	const list = types as unknown as {
+		includes?: ( s: string ) => boolean;
+		contains?: ( s: string ) => boolean;
+	};
+	if ( typeof list.includes === 'function' ) {
+		return list.includes( 'Files' );
+	}
+	return typeof list.contains === 'function' && list.contains( 'Files' );
+}
+
+const onNativeDragOver = ( e: DragEvent ): void => {
+	bumpWatchdog();
+	const payloadType =
+		_bridgePayloadKind ?? ( dragHasFiles( e ) ? 'os-file' : 'external' );
+	trackHoverAtPoint( e.clientX, e.clientY, payloadType );
+};
+
+const onNativeDragSettled = (): void => {
+	// `drop` or `dragend` anywhere in the parent document — the
+	// gesture is over.
+	resetHoverState();
+};
+
+const onNativeDragLeave = ( e: DragEvent ): void => {
+	// A null relatedTarget means the drag left the parent document
+	// (out of the browser window, or into an iframe — where channel 3
+	// takes over). Kill any pending dwell rather than letting it fire
+	// on a window the cursor is no longer over.
+	if ( e.relatedTarget === null ) {
+		resetHoverState();
+	}
+};
+
+// ------------------------------------------------------------------
+// Channel 3 — in-iframe drag hovers, forwarded by the chromeless
+// bridge as `desktop-mode-drag-hover` postMessages. The sender iframe
+// IS the hovered window; no coordinates travel.
+// ------------------------------------------------------------------
+
+/** Resolve a posted-from `Window` source to its host window id. */
+function windowIdFromMessageSource(
+	source: MessageEventSource | null,
+): string | null {
+	if ( ! source ) {
+		return null;
+	}
+	const iframes = document.querySelectorAll< HTMLIFrameElement >( 'iframe' );
+	for ( const f of Array.from( iframes ) ) {
+		if ( f.contentWindow === source ) {
+			const host = f.closest( '[data-window-id]' );
+			return host?.getAttribute( 'data-window-id' ) || null;
+		}
+	}
+	return null;
+}
+
+const onHoverMessage = ( e: MessageEvent ): void => {
+	if ( e.origin !== window.location.origin ) {
+		return;
+	}
+	const data = e.data as { type?: unknown; payloadType?: unknown } | null;
+	if ( ! data || data.type !== DRAG_HOVER_MESSAGE_TYPE ) {
+		return;
+	}
+	const windowId = windowIdFromMessageSource( e.source );
+	if ( ! windowId ) {
+		return;
+	}
+	bumpWatchdog();
+	trackHoverWindowId(
+		windowId,
+		typeof data.payloadType === 'string' ? data.payloadType : 'external',
+	);
+};
+
+// ------------------------------------------------------------------
+// Bridge session bookkeeping — only used to tag channel-2 hovers with
+// the bridge payload's kind for the veto filter.
+// ------------------------------------------------------------------
+
+const onBridgeStart = ( e: Event ): void => {
+	const detail = ( e as CustomEvent ).detail as
+		| { payload?: DragBridgePayload }
+		| undefined;
+	if ( detail?.payload ) {
+		_bridgePayloadKind = detail.payload.kind ?? '';
+	}
+};
+
+const onBridgeEnd = (): void => {
+	_bridgePayloadKind = null;
+	resetHoverState();
+};
+
+/**
+ * Install the focus-on-drag-hover behavior. Idempotent. Bind ONCE at
+ * shell boot; the rest is driven by drag events.
+ *
+ * @public
+ * @since 0.9.4
+ *
+ * @param host The WindowManager (or any object exposing `getById` +
+ *             `focus`).
+ */
+export function installFocusWindowOnDragHover( host: WindowFocusHost ): void {
+	if ( _installed ) {
+		return;
+	}
+	_installed = true;
+	_host = host;
+	// Channel 1 — END fires last on both the commit and cancel
+	// paths, so one listener covers all teardown.
+	document.addEventListener( DRAG_EVENTS.MOVE, onDragMove );
+	document.addEventListener( DRAG_EVENTS.END, onDragEnd );
+	document.addEventListener( DRAG_BRIDGE_EVENTS.START, onBridgeStart );
+	document.addEventListener( DRAG_BRIDGE_EVENTS.END, onBridgeEnd );
+	// Channel 2 — capture phase so the coordinates arrive regardless
+	// of what deeper handlers do with the events.
+	document.addEventListener( 'dragover', onNativeDragOver, true );
+	document.addEventListener( 'drop', onNativeDragSettled, true );
+	document.addEventListener( 'dragend', onNativeDragSettled, true );
+	document.addEventListener( 'dragleave', onNativeDragLeave, true );
+	// Channel 3.
+	window.addEventListener( 'message', onHoverMessage );
+}
+
+/** Test-only. Drops the install latch + detaches the listeners. */
+export function __resetFocusWindowOnDragHoverForTests(): void {
+	resetHoverState();
+	_bridgePayloadKind = null;
+	document.removeEventListener( DRAG_EVENTS.MOVE, onDragMove );
+	document.removeEventListener( DRAG_EVENTS.END, onDragEnd );
+	document.removeEventListener( DRAG_BRIDGE_EVENTS.START, onBridgeStart );
+	document.removeEventListener( DRAG_BRIDGE_EVENTS.END, onBridgeEnd );
+	document.removeEventListener( 'dragover', onNativeDragOver, true );
+	document.removeEventListener( 'drop', onNativeDragSettled, true );
+	document.removeEventListener( 'dragend', onNativeDragSettled, true );
+	document.removeEventListener( 'dragleave', onNativeDragLeave, true );
+	window.removeEventListener( 'message', onHoverMessage );
+	_installed = false;
+	_host = null;
+}

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -60,6 +60,7 @@ import {
 	DRAG_BRIDGE_EVENTS,
 	type DragBridgePayload,
 } from '../drag-bridge';
+import { findWindowRootAtPoint } from './window-at-point';
 
 const TARGET_ID_PREFIX = 'desktop-mode-iframe-drop-';
 const IFRAME_SELECTOR = 'iframe.desktop-mode-window__iframe';
@@ -110,12 +111,8 @@ function findIframeAtCursor(
 	clientX: number,
 	clientY: number,
 ): HTMLIFrameElement | null {
-	const el = document.elementFromPoint( clientX, clientY );
-	if ( ! el ) {
-		return null;
-	}
-	const win = el.closest( '.desktop-mode-window' );
-	if ( ! ( win instanceof HTMLElement ) ) {
+	const win = findWindowRootAtPoint( clientX, clientY );
+	if ( ! win ) {
 		return null;
 	}
 	const iframe = win.querySelector( IFRAME_SELECTOR );

--- a/src/drag/window-at-point.ts
+++ b/src/drag/window-at-point.ts
@@ -1,0 +1,64 @@
+/**
+ * Desktop Mode — Window-at-point resolution.
+ *
+ * Shared helper for modules that need to know which desktop window
+ * the cursor is over during a DragManager session. The resolution is
+ * a plain `elementFromPoint` walk, which is reliable mid-drag
+ * because:
+ *
+ *   - The ghost element is permanently `pointer-events: none`
+ *     (`ghost.ts`), so it never shadows the hit test.
+ *   - Iframe windows have their iframe's `pointer-events` suppressed
+ *     for the duration of a bridge drag (`iframe-drop-targets.ts`),
+ *     so `elementFromPoint` returns the window body rather than the
+ *     opaque iframe boundary.
+ *   - Minimized and closing windows are `pointer-events: none` via
+ *     CSS (`window-states.css`), so they never match.
+ *
+ * Every window root — iframe and native alike — is built by
+ * `window/dom.ts` as `.desktop-mode-window` with the id
+ * `wp-window-<windowId>`, which is what these helpers key off.
+ *
+ * @since 0.9.4
+ */
+
+/** Selector matching every window root element (iframe + native). */
+export const WINDOW_ROOT_SELECTOR = '.desktop-mode-window';
+
+/** Prefix of the DOM id stamped on every window root. */
+export const WINDOW_ID_PREFIX = 'wp-window-';
+
+/**
+ * Find the window root element under the given client coordinates,
+ * or `null` when the point is over the wallpaper, dock, or any other
+ * non-window surface.
+ *
+ * @param clientX Pointer x in client (viewport) space.
+ * @param clientY Pointer y in client (viewport) space.
+ */
+export function findWindowRootAtPoint(
+	clientX: number,
+	clientY: number,
+): HTMLElement | null {
+	const el = document.elementFromPoint( clientX, clientY );
+	if ( ! el ) {
+		return null;
+	}
+	const root = el.closest( WINDOW_ROOT_SELECTOR );
+	return root instanceof HTMLElement ? root : null;
+}
+
+/**
+ * Extract the window-manager id from a window root element
+ * (`wp-window-<id>` → `<id>`), or `null` when the element has no
+ * stamped id.
+ *
+ * @param root A window root element (see `WINDOW_ROOT_SELECTOR`).
+ */
+export function windowIdFromRoot( root: HTMLElement ): string | null {
+	if ( ! root.id.startsWith( WINDOW_ID_PREFIX ) ) {
+		return null;
+	}
+	const id = root.id.slice( WINDOW_ID_PREFIX.length );
+	return id.length > 0 ? id : null;
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -491,6 +491,32 @@ export const HOOKS = {
 	 */
 	WINDOW_AUTO_EXIT_FULLSCREEN: 'desktop-mode.window.auto-exit-fullscreen',
 	/**
+	 * Filter, decides whether the window under the cursor is raised
+	 * (focused) after a short hover dwell during a drag — any drag,
+	 * whatever its source: a shell DragManager session, a
+	 * cross-iframe bridge drag, an OS file, or an arbitrary native
+	 * HTML5 drag.
+	 *
+	 * Default is `true`: dragging a payload over a background window
+	 * and resting there for ~250 ms brings it forward, so the user
+	 * can see the drop target they're aiming at (macOS spring-loading
+	 * style). Plugins whose windows must never steal z-order during a
+	 * drag — pinned reference panels, HUD/palette windows — can
+	 * return `false` for their window id.
+	 *
+	 * Signature:
+	 *
+	 *     ( shouldFocus: boolean, ctx: {
+	 *         windowId: string,     // the hovered window
+	 *         payloadType: string,  // DragManager payload `type`,
+	 *                               // bridge payload `kind`,
+	 *                               // 'os-file', or 'external'
+	 *     } ) => boolean
+	 *
+	 * @since 0.9.4
+	 */
+	WINDOW_FOCUS_ON_DRAG_HOVER: 'desktop-mode.window.focus-on-drag-hover',
+	/**
 	 * Action, fires at most once per animation frame during an
 	 * active drag or resize with the live geometry. Payload: `{
 	 * windowId: string, x: number, y: number, width: number,

--- a/src/iframe-bridge-standalone.ts
+++ b/src/iframe-bridge-standalone.ts
@@ -739,6 +739,7 @@ interface IframeWp {
 	const sentinelHost = window as unknown as {
 		__desktopModeScreenMetaInstalled?: boolean;
 		__desktopModeOsFileDropForwarderInstalled?: boolean;
+		__desktopModeDragHoverForwarderInstalled?: boolean;
 	};
 	if ( ! sentinelHost.__desktopModeScreenMetaInstalled ) {
 		sentinelHost.__desktopModeScreenMetaInstalled = true;
@@ -878,6 +879,61 @@ interface IframeWp {
 				}
 			},
 			false,
+		);
+	}
+
+	/*
+	 * Drag-hover forwarder. Mirrors the inline equivalent in
+	 * `includes/render/chromeless-bridge.php`. Native drag events
+	 * don't cross iframe boundaries, so when the user holds ANY drag
+	 * (an OS file, an image lifted off another admin page, a text
+	 * selection) over this window, the parent shell has no idea the
+	 * window is being hovered. Forward a throttled, payload-free
+	 * heartbeat so the shell's focus-on-drag-hover module
+	 * (`src/drag/focus-window-on-drag-hover.ts`) can raise this
+	 * window after its dwell. Purely observational — no
+	 * `preventDefault()`, no interference with in-page drop zones.
+	 * The parent identifies the hovered window from the message
+	 * source, so no coordinates travel.
+	 */
+	if ( ! sentinelHost.__desktopModeDragHoverForwarderInstalled ) {
+		sentinelHost.__desktopModeDragHoverForwarderInstalled = true;
+		const hoverHasFiles = ( ev: DragEvent ): boolean => {
+			const types = ev.dataTransfer?.types;
+			if ( ! types ) {
+				return false;
+			}
+			const list = types as unknown as {
+				includes?: ( s: string ) => boolean;
+				contains?: ( s: string ) => boolean;
+			};
+			if ( typeof list.includes === 'function' ) {
+				return list.includes( 'Files' );
+			}
+			return typeof list.contains === 'function' && list.contains( 'Files' );
+		};
+		let dragHoverLastSent = 0;
+		document.addEventListener(
+			'dragover',
+			( ev: DragEvent ) => {
+				const now = Date.now();
+				if ( now - dragHoverLastSent < 150 ) {
+					return;
+				}
+				dragHoverLastSent = now;
+				try {
+					window.parent.postMessage(
+						{
+							type: 'desktop-mode-drag-hover',
+							payloadType: hoverHasFiles( ev ) ? 'os-file' : 'external',
+						},
+						parentOrigin,
+					);
+				} catch {
+					/* cross-origin parent; swallow */
+				}
+			},
+			true,
 		);
 	}
 

--- a/tests/vitest/drag-focus-on-hover.test.ts
+++ b/tests/vitest/drag-focus-on-hover.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Unit tests for focus-on-drag-hover.
+ *
+ * The module is driven entirely by `DRAG_EVENTS` CustomEvents on
+ * `document`, so no real DragManager is needed — the tests dispatch
+ * MOVE/END directly and assert against a fake focus host.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { addFilter, HOOKS } from '../../src/hooks';
+import { DRAG_EVENTS } from '../../src/drag/types';
+import { DRAG_BRIDGE_EVENTS } from '../../src/drag-bridge';
+import {
+	DRAG_HOVER_MESSAGE_TYPE,
+	FOCUS_ON_DRAG_HOVER_DWELL_MS,
+	FOCUS_ON_DRAG_HOVER_WATCHDOG_MS,
+	installFocusWindowOnDragHover,
+	__resetFocusWindowOnDragHoverForTests,
+	type FocusableWindow,
+} from '../../src/drag/focus-window-on-drag-hover';
+import {
+	findWindowRootAtPoint,
+	windowIdFromRoot,
+} from '../../src/drag/window-at-point';
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+/**
+ * Build a window root (`.desktop-mode-window` + `wp-window-<id>`)
+ * with an inner body element — `elementFromPoint` in the real shell
+ * returns an inner element, never the root itself.
+ */
+function makeWindowRoot( id: string ): { root: HTMLElement; inner: HTMLElement } {
+	const root = document.createElement( 'div' );
+	root.className = 'desktop-mode-window';
+	root.id = `wp-window-${ id }`;
+	const inner = document.createElement( 'div' );
+	inner.className = 'desktop-mode-window__body';
+	root.appendChild( inner );
+	document.body.appendChild( root );
+	return { root, inner };
+}
+
+/**
+ * jsdom computes no layout, so hit-testing is stubbed: each region
+ * maps a client-space rect to the element `elementFromPoint` should
+ * return there. Later regions win on overlap.
+ */
+function installElementFromPointStub( regions: Array< { el: Element; rect: Rect } > ): void {
+	document.elementFromPoint = ( x: number, y: number ): Element | null => {
+		for ( let i = regions.length - 1; i >= 0; i -= 1 ) {
+			const { el, rect } = regions[ i ];
+			if ( x >= rect.x && x < rect.x + rect.w && y >= rect.y && y < rect.y + rect.h ) {
+				return el;
+			}
+		}
+		return null;
+	};
+}
+
+function makeFakeWindow( id: string, focused = false ): FocusableWindow & { id: string; focused: boolean } {
+	return {
+		id,
+		focused,
+		isFocused() {
+			return this.focused;
+		},
+	};
+}
+
+function makeHost( windows: Array< ReturnType< typeof makeFakeWindow > > ) {
+	return {
+		windows,
+		getById: vi.fn( ( id: string ) => windows.find( ( w ) => w.id === id ) ),
+		focus: vi.fn(),
+	};
+}
+
+function dispatchMove( clientX: number, clientY: number, payloadType = 'desktop-file' ): void {
+	document.dispatchEvent(
+		new CustomEvent( DRAG_EVENTS.MOVE, {
+			detail: {
+				payload: { type: payloadType, source: document.body, data: {} },
+				clientX,
+				clientY,
+			},
+		} ),
+	);
+}
+
+function dispatchEnd(): void {
+	document.dispatchEvent(
+		new CustomEvent( DRAG_EVENTS.END, {
+			detail: { payload: { type: 'desktop-file' }, reason: 'commit' },
+		} ),
+	);
+}
+
+/**
+ * jsdom doesn't construct `DragEvent`s — synthesize a plain Event
+ * with the fields the module reads, same trick as `pointerEvent` in
+ * `drag-manager.test.ts`.
+ */
+function dragEvent(
+	type: 'dragover' | 'drop' | 'dragend' | 'dragleave',
+	opts: {
+		clientX?: number;
+		clientY?: number;
+		relatedTarget?: EventTarget | null;
+		types?: string[];
+	} = {},
+): Event {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'clientX', { value: opts.clientX ?? 0 } );
+	Object.defineProperty( ev, 'clientY', { value: opts.clientY ?? 0 } );
+	Object.defineProperty( ev, 'relatedTarget', {
+		value: opts.relatedTarget ?? null,
+	} );
+	Object.defineProperty( ev, 'dataTransfer', {
+		value: { types: opts.types ?? [] },
+	} );
+	return ev;
+}
+
+describe( 'focus-on-drag-hover', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.useFakeTimers();
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		__resetFocusWindowOnDragHoverForTests();
+		vi.useRealTimers();
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'hovering an unfocused window for the dwell raises it once', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const winB = makeFakeWindow( 'b' );
+		const host = makeHost( [ winB ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 );
+		expect( host.focus ).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+		expect( host.focus ).toHaveBeenCalledWith( winB );
+	} );
+
+	test( 'leaving for the wallpaper before the dwell elapses cancels the raise', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS - 50 );
+		dispatchMove( 500, 500 ); // wallpaper — no window
+		vi.advanceTimersByTime( 1000 );
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 'crossing B then C within the dwell focuses only C', () => {
+		const b = makeWindowRoot( 'b' );
+		const c = makeWindowRoot( 'c' );
+		installElementFromPointStub( [
+			{ el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } },
+			{ el: c.inner, rect: { x: 100, y: 0, w: 100, h: 100 } },
+		] );
+		const winB = makeFakeWindow( 'b' );
+		const winC = makeFakeWindow( 'c' );
+		const host = makeHost( [ winB, winC ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 ); // over B
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS - 50 );
+		dispatchMove( 150, 50 ); // over C — restarts the dwell
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+		expect( host.focus ).toHaveBeenCalledWith( winC );
+	} );
+
+	test( 'repeated moves over the same window do not restart the dwell', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 20, 20 );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS / 2 );
+		dispatchMove( 60, 60 ); // still over B
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS / 2 );
+		// Fires at the original deadline — the second move didn't reset it.
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'an already-focused window (the drag source) is not re-focused', () => {
+		const a = makeWindowRoot( 'a' );
+		installElementFromPointStub( [ { el: a.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'a', true ) ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 'DRAG_EVENTS.END mid-dwell clears the pending raise', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 );
+		dispatchEnd();
+		vi.advanceTimersByTime( 1000 );
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 'the focus-on-drag-hover filter can veto, and receives the ctx', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		const seenCtx: unknown[] = [];
+		addFilter< boolean, [ { windowId: string; payloadType: string } ] >(
+			HOOKS.WINDOW_FOCUS_ON_DRAG_HOVER,
+			'test/veto',
+			( _value, ctx ) => {
+				seenCtx.push( ctx );
+				return false;
+			},
+		);
+
+		dispatchMove( 50, 50, 'shortcut' );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).not.toHaveBeenCalled();
+		expect( seenCtx ).toEqual( [ { windowId: 'b', payloadType: 'shortcut' } ] );
+	} );
+
+	test( 'window closed mid-dwell is a silent no-op', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [] ); // getById finds nothing
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 );
+		expect( () => vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS ) ).not.toThrow();
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 're-hovering a window it already focused does not re-fire', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const winB = makeFakeWindow( 'b' );
+		const host = makeHost( [ winB ] );
+		host.focus.mockImplementation( () => {
+			winB.focused = true;
+		} );
+		installFocusWindowOnDragHover( host );
+
+		dispatchMove( 50, 50 );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+
+		// Leave, then come back — the window is focused now, so the
+		// second dwell resolves to a no-op.
+		dispatchMove( 500, 500 );
+		dispatchMove( 50, 50 );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'focus-on-drag-hover — native HTML5 channel', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.useFakeTimers();
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		__resetFocusWindowOnDragHoverForTests();
+		vi.useRealTimers();
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'a plain dragover hover raises the window after the dwell', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const winB = makeFakeWindow( 'b' );
+		const host = makeHost( [ winB ] );
+		installFocusWindowOnDragHover( host );
+
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+		expect( host.focus ).toHaveBeenCalledWith( winB );
+	} );
+
+	test( 'payloadType is os-file for Files drags, external otherwise, bridge kind when a session is live', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const winB = makeFakeWindow( 'b' );
+		const host = makeHost( [ winB ] );
+		installFocusWindowOnDragHover( host );
+
+		const seenTypes: string[] = [];
+		addFilter< boolean, [ { windowId: string; payloadType: string } ] >(
+			HOOKS.WINDOW_FOCUS_ON_DRAG_HOVER,
+			'test/collect',
+			( value, ctx ) => {
+				seenTypes.push( ctx.payloadType );
+				return value;
+			},
+		);
+
+		// OS file drag.
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50, types: [ 'Files' ] } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		document.dispatchEvent( dragEvent( 'drop' ) );
+
+		// Arbitrary external drag (text/html).
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50, types: [ 'text/html' ] } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		document.dispatchEvent( dragEvent( 'dragend' ) );
+
+		// Bridge session — kind takes precedence over DataTransfer sniffing.
+		document.dispatchEvent(
+			new CustomEvent( DRAG_BRIDGE_EVENTS.START, {
+				detail: { payload: { kind: 'attachment', id: 1, url: '', title: '', alt: '', mime: 'image/jpeg' } },
+			} ),
+		);
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+
+		expect( seenTypes ).toEqual( [ 'os-file', 'external', 'attachment' ] );
+	} );
+
+	test( 'drop and dragend clear a pending dwell', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		document.dispatchEvent( dragEvent( 'drop' ) );
+		vi.advanceTimersByTime( 5000 );
+		expect( host.focus ).not.toHaveBeenCalled();
+
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		document.dispatchEvent( dragEvent( 'dragend' ) );
+		vi.advanceTimersByTime( 5000 );
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 'dragleave out of the document clears a pending dwell', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		document.dispatchEvent( dragEvent( 'dragleave', { relatedTarget: null } ) );
+		vi.advanceTimersByTime( 5000 );
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a dragleave into another element does NOT clear the dwell', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const host = makeHost( [ makeFakeWindow( 'b' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		document.dispatchEvent( dragEvent( 'dragleave', { relatedTarget: b.inner } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'watchdog silence resets the hover state so a later drag re-tracks', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		const winB = makeFakeWindow( 'b' );
+		const host = makeHost( [ winB ] );
+		installFocusWindowOnDragHover( host );
+
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+
+		// Signals stop (drag ended out of sight). After the watchdog,
+		// a fresh drag over the same still-unfocused window must
+		// re-run the dwell rather than being swallowed by the
+		// same-window check.
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_WATCHDOG_MS );
+		document.dispatchEvent( dragEvent( 'dragover', { clientX: 50, clientY: 50 } ) );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
+describe( 'focus-on-drag-hover — iframe message channel', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.useFakeTimers();
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		__resetFocusWindowOnDragHoverForTests();
+		vi.useRealTimers();
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	/** Build a window host carrying an iframe, jsdom-style. */
+	function makeIframeWindow( id: string ): HTMLIFrameElement {
+		const hostEl = document.createElement( 'div' );
+		hostEl.className = 'desktop-mode-window';
+		hostEl.id = `wp-window-${ id }`;
+		hostEl.setAttribute( 'data-window-id', id );
+		const iframe = document.createElement( 'iframe' );
+		hostEl.appendChild( iframe );
+		document.body.appendChild( hostEl );
+		return iframe;
+	}
+
+	function dispatchHoverMessage(
+		source: MessageEventSource | null,
+		origin: string = window.location.origin,
+		payloadType = 'os-file',
+	): void {
+		window.dispatchEvent(
+			new MessageEvent( 'message', {
+				origin,
+				source,
+				data: { type: DRAG_HOVER_MESSAGE_TYPE, payloadType },
+			} ),
+		);
+	}
+
+	test( 'a hover heartbeat from an iframe window raises that window after the dwell', () => {
+		const iframe = makeIframeWindow( 'post-editor' );
+		const win = makeFakeWindow( 'post-editor' );
+		const host = makeHost( [ win ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchHoverMessage( iframe.contentWindow );
+		expect( host.focus ).not.toHaveBeenCalled();
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+		expect( host.focus ).toHaveBeenCalledWith( win );
+	} );
+
+	test( 'repeated heartbeats from the same iframe do not restart the dwell', () => {
+		const iframe = makeIframeWindow( 'post-editor' );
+		const host = makeHost( [ makeFakeWindow( 'post-editor' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchHoverMessage( iframe.contentWindow );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS / 2 );
+		dispatchHoverMessage( iframe.contentWindow );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS / 2 );
+		expect( host.focus ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'cross-origin and unresolvable-source messages are ignored', () => {
+		const iframe = makeIframeWindow( 'post-editor' );
+		const host = makeHost( [ makeFakeWindow( 'post-editor' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		dispatchHoverMessage( iframe.contentWindow, 'https://evil.example' );
+		dispatchHoverMessage( null );
+		vi.advanceTimersByTime( 5000 );
+		expect( host.focus ).not.toHaveBeenCalled();
+	} );
+
+	test( 'the filter ctx carries the forwarded payloadType', () => {
+		const iframe = makeIframeWindow( 'post-editor' );
+		const host = makeHost( [ makeFakeWindow( 'post-editor' ) ] );
+		installFocusWindowOnDragHover( host );
+
+		const seenCtx: unknown[] = [];
+		addFilter< boolean, [ { windowId: string; payloadType: string } ] >(
+			HOOKS.WINDOW_FOCUS_ON_DRAG_HOVER,
+			'test/ctx',
+			( value, ctx ) => {
+				seenCtx.push( ctx );
+				return value;
+			},
+		);
+
+		dispatchHoverMessage( iframe.contentWindow, window.location.origin, 'external' );
+		vi.advanceTimersByTime( FOCUS_ON_DRAG_HOVER_DWELL_MS );
+		expect( seenCtx ).toEqual( [ { windowId: 'post-editor', payloadType: 'external' } ] );
+	} );
+} );
+
+describe( 'window-at-point', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'resolves the window root from a nested element', () => {
+		const b = makeWindowRoot( 'b' );
+		installElementFromPointStub( [ { el: b.inner, rect: { x: 0, y: 0, w: 100, h: 100 } } ] );
+		expect( findWindowRootAtPoint( 50, 50 ) ).toBe( b.root );
+	} );
+
+	test( 'returns null over the wallpaper', () => {
+		document.elementFromPoint = () => null;
+		expect( findWindowRootAtPoint( 50, 50 ) ).toBeNull();
+	} );
+
+	test( 'windowIdFromRoot parses the wp-window- prefix', () => {
+		const { root } = makeWindowRoot( 'edit-php' );
+		expect( windowIdFromRoot( root ) ).toBe( 'edit-php' );
+	} );
+
+	test( 'windowIdFromRoot returns null for unstamped roots', () => {
+		const el = document.createElement( 'div' );
+		el.className = 'desktop-mode-window';
+		expect( windowIdFromRoot( el ) ).toBeNull();
+		el.id = 'wp-window-'; // prefix with no id
+		expect( windowIdFromRoot( el ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
## Why

Dragging something toward another window — a cat photo from the Media Library into a post, a file from the OS, a desktop tile — left the target window buried behind the source. The drop itself worked, but you couldn't see where it was going to land.

Now, resting the cursor on a window for ~250ms mid-drag raises and focuses it, macOS spring-loading style. The dwell is deliberate: sweeping across intermediate windows on the way to a target doesn't disturb the z-order.

## How

One dwell state machine, fed by three channels so **every** drag source is covered:

1. **Shell DragManager sessions** (desktop tiles, My WordPress tiles) — via the existing `desktop-mode.drag.move` events.
2. **Native HTML5 drags over shell surfaces** — an always-on `dragover` listener on the parent document. Covers Media Library bridge drags (iframe pointer-events are already suppressed during those, so the parent sees everything), OS files, and images/text dragged from anywhere.
3. **Drags hovering an iframe window outside a bridge session** — drag events can't cross iframe boundaries, so the chromeless bridge now forwards a throttled, purely-observational `desktop-mode-drag-hover` heartbeat; the parent resolves the sender to its window. No coordinates or payload travel, no `preventDefault()`.

A ~1s silence watchdog plus `drop`/`dragend`/`dragleave` handling guarantees a pending raise never fires after the drag ended somewhere the parent can't observe.

## Extensibility

New filter `desktop-mode.window.focus-on-drag-hover` `( shouldFocus, { windowId, payloadType } )` lets plugins keep HUD/palette/pinned windows from stealing z-order. Documented in `docs/javascript-reference.md`; the new bridge message in `docs/bridge-protocol.md`.

## Testing

- 23 new vitest cases (`tests/vitest/drag-focus-on-hover.test.ts`) covering all three channels, dwell semantics, filter veto, watchdog, and teardown edge cases.
- `php -l`, `npm run build`, `lint`, `typecheck`, `test:js` (1624) all green.
- Manually verified: Media Library → post editor image drag raises the post window after the dwell; quick sweeps don't.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-334-8268fdf700bf9ae7f44b3cffb8ce131457d11328.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->