### PR TITLE
Fix legacy file-path menu slugs (WP-Sweep) and missing tab strips on tile-opened windows

### DIFF
--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -96,6 +96,14 @@ Some plugins register WordPress admin menu entries in shapes that our dock can't
 
 **Plugins this addresses**: every wc-admin React route (Customers, Analytics, Marketing, …); also Yoast SEO and other plugins that pack paths into menu slugs.
 
+### Legacy file-path menu slugs (`vendor/file.php`)
+
+Old-school plugins register their admin page with a file-path slug — `add_management_page( …, 'wp-sweep/admin.php' )` — instead of a plain slug. The slug contains `.php`, so a naive "does it look like an admin file?" test routes it to `admin_url( 'wp-sweep/admin.php' )`, a 404. WordPress actually serves the page at `tools.php?page=wp-sweep/admin.php` (the slug is a key in the `$_parent_pages` global, exactly like a plain plugin-page slug).
+
+**Fix**: both URL resolvers — `desktop_mode_menu_item_url()` (dock / window tabs) and `desktop_mode_build_command_menu_map()` (command palette) — check `$_parent_pages` for the raw slug **before** the direct-file test. A registered slug goes through the canonical `menu_page_url()`-style resolution regardless of what characters it contains; only unregistered `.php` slugs are treated as real files under `wp-admin/`.
+
+**Plugins this addresses**: WP-Sweep; any plugin still using the pre-3.0-era file-path registration style.
+
 ### `esc_url_raw()` for JSON contexts
 
 Dock URLs flow into the shell config as JSON, then end up assigned to `iframe.src` / `window.location.href`. Browsers do **not** decode `&#038;` HTML entities in those JS string contexts.

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1610,8 +1610,18 @@ function desktop_mode_menu_item_url( $slug ) {
 	// Strip path traversal sequences.
 	$slug = str_replace( '..', '', $slug );
 
-	// Direct file reference (e.g., 'edit.php', 'upload.php').
-	if ( false !== strpos( $slug, '.php' ) ) {
+	global $_parent_pages;
+
+	// Direct file reference (e.g., 'edit.php', 'upload.php') — but
+	// NOT a registered plugin page that merely looks like one.
+	// Legacy file-path slugs (WP-Sweep's 'wp-sweep/admin.php',
+	// registered via add_management_page()) contain '.php' yet are
+	// page slugs, not admin-root files; `$_parent_pages` is keyed by
+	// the raw registered slug, so a hit there routes the slug to the
+	// canonical resolver below (→ `tools.php?page=wp-sweep/admin.php`,
+	// byte-identical to what core's menu_page_url() builds) instead
+	// of a 404 at `admin_url( 'wp-sweep/admin.php' )`.
+	if ( false !== strpos( $slug, '.php' ) && ! isset( $_parent_pages[ $slug ] ) ) {
 		return esc_url_raw( admin_url( $slug ) );
 	}
 
@@ -1646,7 +1656,6 @@ function desktop_mode_menu_item_url( $slug ) {
 	//   3. Slug not registered at all → fall back to `admin.php`
 	//      so the URL still targets a real dispatcher (matches the
 	//      pre-resolver behavior callers depended on).
-	global $_parent_pages;
 	$host = 'admin.php?page=' . rawurlencode( $slug );
 	if ( isset( $_parent_pages[ $slug ] ) ) {
 		$parent_slug = $_parent_pages[ $slug ];

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -821,7 +821,7 @@ add_filter( 'style_loader_tag', 'desktop_mode_defer_non_critical_styles', 10, 4 
  * @return array<int, array{label:string, url:string, name:string}>
  */
 function desktop_mode_build_command_menu_map() {
-	global $menu, $submenu;
+	global $menu, $submenu, $_parent_pages;
 	if ( ! is_array( $menu ) ) {
 		return array();
 	}
@@ -868,7 +868,10 @@ function desktop_mode_build_command_menu_map() {
 		$menu_label = $extract_root_text( $menu_item[0] );
 		$menu_slug  = $menu_item[2];
 		$menu_url   = '';
-		if ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) {
+		// Registered plugin pages win over the direct-file test: a
+		// legacy file-path slug ('wp-sweep/admin.php') matches the
+		// `.php` regex yet must route through menu_page_url().
+		if ( ! isset( $_parent_pages[ $menu_slug ] ) && ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) ) {
 			$menu_url = $menu_slug;
 		} elseif ( ! empty( menu_page_url( $menu_slug, false ) ) ) {
 			$menu_url = menu_page_url( $menu_slug, false );
@@ -891,7 +894,8 @@ function desktop_mode_build_command_menu_map() {
 				$submenu_label = $extract_root_text( $submenu_item[0] );
 				$submenu_slug  = $submenu_item[2];
 				$submenu_url   = '';
-				if ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) {
+				// Same registered-page-first rule as the top-level loop.
+				if ( ! isset( $_parent_pages[ $submenu_slug ] ) && ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) ) {
 					$submenu_url = $submenu_slug;
 				} elseif ( ! empty( menu_page_url( $submenu_slug, false ) ) ) {
 					$submenu_url = menu_page_url( $submenu_slug, false );

--- a/src/desktop-files/built-in-openers.ts
+++ b/src/desktop-files/built-in-openers.ts
@@ -36,6 +36,7 @@ import {
 import { renderPlacementPreview, renderPreviewEmpty } from './preview';
 import { openEmbedWindow } from './embed-window';
 import { deriveWindowId } from '../utils';
+import { findMenuEntryForUrl } from './menu-entry';
 
 interface ConfigShape {
 	adminUrl?: string;
@@ -491,12 +492,22 @@ export function registerBuiltInFileOpeners(): void {
 						const id = adminUrl
 							? deriveWindowId( u.toString(), adminUrl )
 							: `desktop-icon-${ file.ref() }`;
+						// Enrich with the matching admin-menu entry so
+						// the window gets the same submenu tab strip /
+						// parent-tab / multi behavior as a dock open.
+						// Without this, Spatial-layout core tiles (and
+						// any dock-promoted shortcut) opened windows
+						// with no tab strip at all.
+						const entry = findMenuEntryForUrl( u.toString() );
 						wp.windowManager.open( {
 							id,
 							baseId: id,
 							url: u.toString(),
+							parentUrl: entry?.url ?? u.toString(),
 							title: file.title(),
 							icon: file.icon(),
+							submenu: entry?.submenu,
+							multi: !! entry?.multi,
 						} );
 					} catch {
 						// Malformed URL — silently ignore. The

--- a/src/desktop-files/menu-entry.ts
+++ b/src/desktop-files/menu-entry.ts
@@ -1,0 +1,70 @@
+/**
+ * Desktop Mode — Admin-menu entry lookup for URL-based openers.
+ *
+ * Windows opened straight from a URL (wallpaper shortcut tiles,
+ * server-registered desktop icons) historically shipped a bare
+ * `{ id, url, title, icon }` config — no `submenu` / `parentUrl` /
+ * `multi` — so they rendered without the in-window submenu tab
+ * strip that the same window gets when opened from the dock
+ * (`openItem` in `desktop-layout.ts`) or via session restore
+ * (`findDockEntryForUrl` in `boot/geometry.ts`). This helper closes
+ * that gap: given a target URL, find the admin-menu item the URL
+ * belongs to so callers can enrich their window config with the
+ * same dock metadata every other open path passes.
+ *
+ * Kept as a leaf module (imports only `utils` + `types`) so the
+ * lazy desktop-files/icons bundles don't drag in a bundle entry as
+ * a side effect — see the cross-bundle warning in AGENTS.md.
+ *
+ * @since 0.11.3
+ */
+
+import { deriveWindowId } from '../utils';
+import type { DesktopConfig, DockItemConfig } from '../types';
+
+/** Runtime shape of the `window.wp` global the lookup reads. */
+interface ShellGlobalShape {
+	desktop?: {
+		getMenuItems?: () => DockItemConfig[];
+		config?: { adminUrl?: string };
+	};
+}
+
+/**
+ * Find the dock entry — top-level item or the parent of a matching
+ * submenu child — whose URL derives the same window id as `url`.
+ *
+ * Reads the live menu list from `wp.desktop.getMenuItems()` when the
+ * shell API is up (it reflects live menu refreshes), falling back to
+ * the boot `desktopModeConfig.dockItems` snapshot. Returns the
+ * PARENT top-level entry in both match cases — mirroring
+ * `findDockEntryForUrl()` in `boot/geometry.ts` — so callers can
+ * read `submenu` / `multi` and use `entry.url` as the window's
+ * `parentUrl` (the synthetic "back to parent" tab target).
+ *
+ * @param url Target admin URL being opened.
+ * @return The matching top-level dock item, or `null`.
+ */
+export function findMenuEntryForUrl( url: string ): DockItemConfig | null {
+	const wp = ( window.wp as ShellGlobalShape | undefined )?.desktop;
+	const bootConfig = (
+		window as unknown as { desktopModeConfig?: DesktopConfig }
+	).desktopModeConfig;
+
+	const adminUrl = wp?.config?.adminUrl ?? bootConfig?.adminUrl;
+	if ( ! adminUrl ) {
+		return null;
+	}
+
+	const items = wp?.getMenuItems?.() ?? bootConfig?.dockItems ?? [];
+	const targetId = deriveWindowId( url, adminUrl );
+	return (
+		items.find(
+			( item ) =>
+				deriveWindowId( item.url, adminUrl ) === targetId ||
+				( item.submenu ?? [] ).some(
+					( sub ) => deriveWindowId( sub.url, adminUrl ) === targetId,
+				),
+		) ?? null
+	);
+}

--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -35,6 +35,7 @@
  */
 
 import { activity } from './activity';
+import { findMenuEntryForUrl } from './desktop-files/menu-entry';
 import { tryOpenExternalUrl } from './external-url';
 import { __, _n, sprintf } from './i18n';
 import { doAction, HOOKS } from './hooks';
@@ -539,12 +540,20 @@ function openTarget(
 			// indicator. See the docstring on
 			// `DesktopIconRenderDeps.deriveWindowId`.
 			const windowId = deps.deriveWindowId( parsed.toString() );
+			// Enrich with the matching admin-menu entry so the window
+			// gets the same submenu tab strip / parent-tab / multi
+			// behavior as a dock open (mirrors `openItem` in
+			// `desktop-layout.ts`).
+			const menuEntry = findMenuEntryForUrl( parsed.toString() );
 			void deps.manager.open( {
 				id: windowId,
 				baseId: windowId,
 				url: parsed.toString(),
+				parentUrl: menuEntry?.url ?? parsed.toString(),
 				title: entry.title,
 				icon: entry.icon,
+				submenu: menuEntry?.submenu,
+				multi: !! menuEntry?.multi,
 			} );
 		} catch {
 			// Malformed URL — ignore rather than surface a broken

--- a/tests/phpunit/tests/commandMenuMap.php
+++ b/tests/phpunit/tests/commandMenuMap.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for the command-palette admin-menu map builder.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ *
+ * @covers ::desktop_mode_build_command_menu_map
+ */
+class Tests_DesktopMode_CommandMenuMap extends WP_UnitTestCase {
+
+	/**
+	 * Legacy file-path slugs (WP-Sweep's `wp-sweep/admin.php`,
+	 * registered via `add_management_page()`) contain `.php` yet are
+	 * registered plugin pages — the map must route them through
+	 * `menu_page_url()` (→ `tools.php?page=wp-sweep/admin.php`), not
+	 * treat them as a raw file link that 404s.
+	 */
+	public function test_registered_file_path_slug_routes_through_parent() {
+		global $menu, $submenu, $_parent_pages;
+		$menu_backup    = $menu;
+		$submenu_backup = $submenu;
+
+		$menu    = array(
+			array( 'Tools', '', 'tools.php', '', '', 'menu-tools', '' ),
+		);
+		$submenu = array(
+			'tools.php' => array(
+				array( 'Sweep', '', 'wp-sweep/admin.php' ),
+			),
+		);
+
+		$_parent_pages['wp-sweep/admin.php'] = 'tools.php';
+
+		$map = desktop_mode_build_command_menu_map();
+
+		$menu    = $menu_backup;
+		$submenu = $submenu_backup;
+		unset( $_parent_pages['wp-sweep/admin.php'] );
+
+		$sweep = null;
+		foreach ( $map as $entry ) {
+			if ( 'tools.php-wp-sweep/admin.php' === $entry['name'] ) {
+				$sweep = $entry;
+				break;
+			}
+		}
+		$this->assertNotNull( $sweep, 'expected the Sweep submenu entry in the command map' );
+		$this->assertStringContainsString( 'tools.php', $sweep['url'] );
+		parse_str( (string) wp_parse_url( html_entity_decode( $sweep['url'] ), PHP_URL_QUERY ), $args );
+		$this->assertSame( 'wp-sweep/admin.php', $args['page'] );
+	}
+
+	/**
+	 * Plain `.php` file slugs with no page registration keep the
+	 * direct-link behavior.
+	 */
+	public function test_unregistered_file_slug_stays_direct_link() {
+		global $menu, $submenu;
+		$menu_backup    = $menu;
+		$submenu_backup = $submenu;
+
+		$menu    = array(
+			array( 'Posts', '', 'edit.php', '', '', 'menu-posts', '' ),
+		);
+		$submenu = array();
+
+		$map = desktop_mode_build_command_menu_map();
+
+		$menu    = $menu_backup;
+		$submenu = $submenu_backup;
+
+		$posts = null;
+		foreach ( $map as $entry ) {
+			if ( 'edit.php' === $entry['name'] ) {
+				$posts = $entry;
+				break;
+			}
+		}
+		$this->assertNotNull( $posts, 'expected the Posts entry in the command map' );
+		$this->assertSame( 'edit.php', $posts['url'] );
+	}
+}

--- a/tests/phpunit/tests/desktopModeMenuItemUrl.php
+++ b/tests/phpunit/tests/desktopModeMenuItemUrl.php
@@ -200,4 +200,39 @@ class Tests_DesktopMode_MenuItemUrl extends WP_UnitTestCase {
 		parse_str( wp_parse_url( html_entity_decode( $result ), PHP_URL_QUERY ), $args );
 		$this->assertSame( 'wc-admin', $args['page'] );
 	}
+
+	/**
+	 * Legacy file-path slugs — WP-Sweep registers its Tools page as
+	 * `add_management_page( …, 'wp-sweep/admin.php' )`: the slug
+	 * contains `.php` yet is a registered plugin page, not an
+	 * admin-root file. The registered-page check must win over the
+	 * direct-file branch — otherwise the dock links the Sweep tab to
+	 * a 404 at `wp-admin/wp-sweep/admin.php` instead of the page
+	 * WordPress actually serves at `tools.php?page=wp-sweep/admin.php`.
+	 */
+	public function test_routes_registered_file_path_slug_through_php_parent() {
+		global $_parent_pages;
+		$_parent_pages['wp-sweep/admin.php'] = 'tools.php';
+
+		$result = desktop_mode_menu_item_url( 'wp-sweep/admin.php' );
+
+		$this->assertStringContainsString( 'tools.php', $result );
+		$this->assertStringNotContainsString( admin_url( 'wp-sweep/admin.php' ), $result );
+		parse_str( wp_parse_url( html_entity_decode( $result ), PHP_URL_QUERY ), $args );
+		$this->assertSame( 'wp-sweep/admin.php', $args['page'] );
+
+		unset( $_parent_pages['wp-sweep/admin.php'] );
+	}
+
+	/**
+	 * A file-path slug with NO `$_parent_pages` registration keeps
+	 * the direct-file behavior — it really is a file under
+	 * `wp-admin/` (e.g. `network/sites.php`-style references).
+	 */
+	public function test_unregistered_file_path_slug_still_routes_as_direct_file() {
+		$this->assertSame(
+			esc_url_raw( admin_url( 'network/sites.php' ) ),
+			desktop_mode_menu_item_url( 'network/sites.php' )
+		);
+	}
 }

--- a/tests/vitest/desktop-files-menu-entry.test.ts
+++ b/tests/vitest/desktop-files-menu-entry.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for `findMenuEntryForUrl()` — the admin-menu lookup
+ * that URL-based openers (wallpaper shortcut tiles, desktop icons)
+ * use to enrich their window configs with `submenu` / `parentUrl` /
+ * `multi`, so tile-opened windows get the same in-window tab strip
+ * a dock open produces.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+// Same-origin as the jsdom environment — the shortcut opener
+// window.open()s cross-origin URLs instead of opening a window.
+const ADMIN_URL = `${ window.location.origin }/wp-admin/`;
+
+const TOOLS_ITEM = {
+	id: 'menu-tools',
+	title: 'Tools',
+	icon: 'dashicons-admin-tools',
+	url: `${ ADMIN_URL }tools.php`,
+	badge: 0,
+	submenu: [
+		{ title: 'Import', url: `${ ADMIN_URL }import.php` },
+		{
+			title: 'Sweep',
+			url: `${ ADMIN_URL }tools.php?page=wp-sweep%2Fadmin.php`,
+		},
+	],
+	multi: false,
+};
+
+const POSTS_ITEM = {
+	id: 'menu-posts',
+	title: 'Posts',
+	icon: 'dashicons-admin-post',
+	url: `${ ADMIN_URL }edit.php`,
+	badge: 0,
+	submenu: [ { title: 'Add New', url: `${ ADMIN_URL }post-new.php` } ],
+	multi: true,
+};
+
+type WindowWithGlobals = Window & {
+	wp?: unknown;
+	desktopModeConfig?: unknown;
+};
+
+function stubGlobals( {
+	viaApi,
+	viaConfig,
+}: {
+	viaApi?: unknown[];
+	viaConfig?: unknown[];
+} ): void {
+	const w = window as WindowWithGlobals;
+	w.wp = viaApi
+		? {
+				desktop: {
+					getMenuItems: () => viaApi,
+					config: { adminUrl: ADMIN_URL },
+				},
+		  }
+		: undefined;
+	w.desktopModeConfig = viaConfig
+		? { adminUrl: ADMIN_URL, dockItems: viaConfig }
+		: undefined;
+}
+
+async function load() {
+	vi.resetModules();
+	return import( '../../src/desktop-files/menu-entry' );
+}
+
+afterEach( () => {
+	const w = window as WindowWithGlobals;
+	delete w.wp;
+	delete w.desktopModeConfig;
+} );
+
+describe( 'findMenuEntryForUrl', () => {
+	test( 'matches a top-level item by URL', async () => {
+		stubGlobals( { viaApi: [ POSTS_ITEM, TOOLS_ITEM ] } );
+		const { findMenuEntryForUrl } = await load();
+		const entry = findMenuEntryForUrl( `${ ADMIN_URL }tools.php` );
+		expect( entry?.id ).toBe( 'menu-tools' );
+		expect( entry?.submenu ).toHaveLength( 2 );
+	} );
+
+	test( 'returns the PARENT item for a submenu child URL', async () => {
+		stubGlobals( { viaApi: [ POSTS_ITEM, TOOLS_ITEM ] } );
+		const { findMenuEntryForUrl } = await load();
+		const entry = findMenuEntryForUrl( `${ ADMIN_URL }import.php` );
+		expect( entry?.id ).toBe( 'menu-tools' );
+	} );
+
+	test( 'ignores transient query params when matching', async () => {
+		stubGlobals( { viaApi: [ TOOLS_ITEM ] } );
+		const { findMenuEntryForUrl } = await load();
+		const entry = findMenuEntryForUrl(
+			`${ ADMIN_URL }tools.php?desktop_mode_chromeless=1`,
+		);
+		expect( entry?.id ).toBe( 'menu-tools' );
+	} );
+
+	test( 'returns null when nothing matches', async () => {
+		stubGlobals( { viaApi: [ POSTS_ITEM ] } );
+		const { findMenuEntryForUrl } = await load();
+		expect(
+			findMenuEntryForUrl( `${ ADMIN_URL }options-general.php` ),
+		).toBeNull();
+	} );
+
+	test( 'falls back to the boot config snapshot when the API is absent', async () => {
+		stubGlobals( { viaConfig: [ TOOLS_ITEM ] } );
+		const { findMenuEntryForUrl } = await load();
+		const entry = findMenuEntryForUrl( `${ ADMIN_URL }tools.php` );
+		expect( entry?.id ).toBe( 'menu-tools' );
+	} );
+
+	test( 'returns null when no adminUrl is available anywhere', async () => {
+		const { findMenuEntryForUrl } = await load();
+		expect( findMenuEntryForUrl( `${ ADMIN_URL }tools.php` ) ).toBeNull();
+	} );
+} );
+
+describe( 'shortcut opener enrichment', () => {
+	test( 'passes submenu/parentUrl/multi from the matching dock item', async () => {
+		const open = vi.fn();
+
+		vi.resetModules();
+		const { installHooksStub, clearHooksStub } = await import(
+			'./helpers/hooks-stub'
+		);
+		// installHooksStub REPLACES window.wp — attach `desktop` after.
+		installHooksStub();
+		( window.wp as unknown as Record< string, unknown > ).desktop = {
+			getMenuItems: () => [ POSTS_ITEM, TOOLS_ITEM ],
+			config: { adminUrl: ADMIN_URL },
+			windowManager: { open },
+		};
+		const openers = await import( '../../src/desktop-files/openers' );
+		const { registerBuiltInFileOpeners } = await import(
+			'../../src/desktop-files/built-in-openers'
+		);
+		const { DefaultDesktopFile } = await import(
+			'../../src/desktop-files/file'
+		);
+		registerBuiltInFileOpeners();
+
+		const opener = openers.resolveOpener( 'shortcut' );
+		expect( opener ).not.toBeNull();
+		const file = new DefaultDesktopFile(
+			{
+				type: 'shortcut',
+				ref: 'dock-promoted:menu-tools',
+				title: 'Tools',
+				icon: 'dashicons-admin-tools',
+				previewUrl: '',
+				exists: true,
+				shortcutUrl: `${ ADMIN_URL }tools.php`,
+			} as ConstructorParameters< typeof DefaultDesktopFile >[ 0 ],
+			'shortcut',
+		);
+		if ( opener?.handler.kind === 'js' ) {
+			await opener.handler.open( file );
+		}
+
+		expect( open ).toHaveBeenCalledTimes( 1 );
+		const cfg = open.mock.calls[ 0 ][ 0 ];
+		expect( cfg.url ).toBe( `${ ADMIN_URL }tools.php` );
+		expect( cfg.parentUrl ).toBe( `${ ADMIN_URL }tools.php` );
+		expect( cfg.submenu ).toHaveLength( 2 );
+		expect( cfg.multi ).toBe( false );
+		clearHooksStub();
+	} );
+
+	test( 'omits enrichment gracefully when no dock entry matches', async () => {
+		const open = vi.fn();
+
+		vi.resetModules();
+		const { installHooksStub, clearHooksStub } = await import(
+			'./helpers/hooks-stub'
+		);
+		installHooksStub();
+		( window.wp as unknown as Record< string, unknown > ).desktop = {
+			getMenuItems: () => [ POSTS_ITEM ],
+			config: { adminUrl: ADMIN_URL },
+			windowManager: { open },
+		};
+		const openers = await import( '../../src/desktop-files/openers' );
+		const { registerBuiltInFileOpeners } = await import(
+			'../../src/desktop-files/built-in-openers'
+		);
+		const { DefaultDesktopFile } = await import(
+			'../../src/desktop-files/file'
+		);
+		registerBuiltInFileOpeners();
+
+		const opener = openers.resolveOpener( 'shortcut' );
+		const file = new DefaultDesktopFile(
+			{
+				type: 'shortcut',
+				ref: 'dock-promoted:menu-settings',
+				title: 'Settings',
+				icon: 'dashicons-admin-settings',
+				previewUrl: '',
+				exists: true,
+				shortcutUrl: `${ ADMIN_URL }options-general.php`,
+			} as ConstructorParameters< typeof DefaultDesktopFile >[ 0 ],
+			'shortcut',
+		);
+		if ( opener?.handler.kind === 'js' ) {
+			await opener.handler.open( file );
+		}
+
+		expect( open ).toHaveBeenCalledTimes( 1 );
+		const cfg = open.mock.calls[ 0 ][ 0 ];
+		expect( cfg.url ).toBe( `${ ADMIN_URL }options-general.php` );
+		expect( cfg.parentUrl ).toBe( `${ ADMIN_URL }options-general.php` );
+		expect( cfg.submenu ).toBeUndefined();
+		expect( cfg.multi ).toBe( false );
+		clearHooksStub();
+	} );
+} );


### PR DESCRIPTION
## Why

Installing **WP-Sweep** appeared to "crash the whole tabs system": windows opened from Tools / Dashboard / any main menu lost their submenu tab strip, and the new Sweep entry linked to a 404. Live debugging against the dev site showed these are **two independent bugs** — one genuinely triggered by WP-Sweep's menu registration, one a Spatial-layout regression (from #329) that the install merely made visible.

WP-Sweep itself is well-behaved; its only quirk is a legacy **file-path menu slug**: `add_management_page( …, 'wp-sweep/admin.php' )`.

## Bug 1 — file-path slugs routed to 404s

`desktop_mode_menu_item_url()` treated any slug containing `.php` as a direct admin file, so `wp-sweep/admin.php` became `admin_url( 'wp-sweep/admin.php' )` → **HTTP 404**. WordPress actually serves that page at `tools.php?page=wp-sweep/admin.php` — the slug is a registered plugin page, keyed in the `$_parent_pages` global. The command-palette menu map (`desktop_mode_build_command_menu_map()`) had the same flaw via its anchored `/\.php($|\?)/` test.

**Fix:** both resolvers consult `$_parent_pages` **before** the direct-file test. Registered plugin pages go through the canonical `menu_page_url()`-style resolution regardless of what characters the slug contains; only unregistered `.php` slugs are treated as real files under `wp-admin/`. Behavior for plain file slugs (`edit.php`), query-embedded slugs (`wc-admin&path=…`), and unregistered slugs is unchanged.

## Bug 2 — tile-opened windows had no tab strip at all

In the Spatial layout, core menus open from wallpaper shortcut tiles (`dock-promoted:*` placements). The shortcut opener (`built-in-openers.ts`) and the desktop-icon opener (`desktop-icons.ts`) called `windowManager.open()` with only `{ id, url, title, icon }` — no `submenu` / `parentUrl` / `multi` — and the tab strip is built once at window construction from `config.submenu`. Result: **every fresh tile-open rendered with zero tabs**. Session restore backfills the metadata via `findDockEntryForUrl()`, so reloaded windows had their tabs back — which made the breakage look intermittent and hard to attribute.

**Fix:** new leaf helper `src/desktop-files/menu-entry.ts` (`findMenuEntryForUrl()`) looks up the admin-menu item matching the target URL (live `wp.desktop.getMenuItems()` with a boot-config fallback, matched by `deriveWindowId`) and both open paths now pass the same `submenu` / `parentUrl` / `multi` a dock open passes. The public `wp.desktop.windowManager.open()` facade is untouched — no behavior change for third-party callers.

## Tests & docs

- 4 new PHPUnit cases: the WP-Sweep slug shape routes through `tools.php?page=…` in both resolvers, plus regression guards for unregistered file slugs.
- 8 new Vitest cases: `findMenuEntryForUrl()` matching/fallback semantics, and the shortcut opener passing (or gracefully omitting) the enrichment.
- `docs/plugin-compat-layer.md`: new "Legacy file-path menu slugs" adaptation entry.

## Verification

- `npm run build` / `lint` / `typecheck` clean; `test:js` 1609 passed; `test:php` 1021 passed.
- Verified live on the dev site with WP-Sweep active (headless browser): the Sweep tab now loads the real WP-Sweep screen inside the window (was a 404), and a never-before-opened Products tile-open shows its full 7-tab strip (was 0 tabs). WooCommerce's `wc-admin&path=…` routes spot-checked unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-335-b0278c7275ce1031ebafb6aac11850bd534a7c0e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->