### PR TITLE
Fix dock icon alignment: lone system tile and off-center separator

### DIFF
--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -581,6 +581,27 @@
 	display: none;
 }
 
+/*
+ * Drop an empty `__scroll` from the flex flow entirely. When only
+ * system tiles are present (e.g. just the Recycle Bin), the empty
+ * wrapper would otherwise still occupy the rail: its `flex-grow`
+ * stretches it — shoving the lone `__pinned` tile to the far edge on
+ * vertical docks — and the inter-wrapper `gap` leaves a phantom
+ * offset that nudges the tile off-center on the bottom dock. Removing
+ * it lets the dock center the lone system tile. As soon as a menu
+ * tile is added the `:has()` no longer matches and normal flow
+ * resumes.
+ *
+ * The `[data-desktop-mode-dock-placement]` qualifier is load-bearing:
+ * the per-placement rules that set `display: flex` on `__scroll` are
+ * (0,3,0); this selector must out-specify them, so it carries the
+ * placement attribute to reach (0,4,0).
+ */
+.desktop-mode-dock[ data-desktop-mode-dock-placement ]
+	.desktop-mode-dock__scroll:not(:has( .desktop-mode-dock__item )) {
+	display: none;
+}
+
 /* Tooltip — anchor modifiers are applied directly to the tooltip
  * element (NOT via a descendant selector on `.desktop-mode-dock`)
  * because the tooltip lives in `document.body`. JS writes the
@@ -782,7 +803,13 @@ body.desktop-mode-show-desktop-active
 	   intrinsic height, leaving the hairline effectively invisible.
 	   28px matches the dock tile inner glyph area. */
 	height: 28px;
-	margin: auto 4px auto 8px;
+	/* Symmetric horizontal margin so the divider sits centered in the
+	 * inter-tile gap: the 6px flex gap on each side (`__scroll`→`__pinned`
+	 * on the left, `__pinned`'s own gap on the right) plus an equal 6px
+	 * margin per side balances out. An asymmetric margin here nudges the
+	 * divider — and the whole menu cluster with it — off the pill's
+	 * center. */
+	margin: auto 6px;
 	background: var( --desktop-mode-dock-border );
 	flex-shrink: 0;
 }


### PR DESCRIPTION
Two dock-alignment fixes, both in `assets/css/dock.css`.

## 1. Lone system tile not centered
When the dock has only a system tile (e.g. Recycle Bin), the empty `__scroll` still grows and shoves the tile to the edge. Fix: collapse an empty `__scroll` with `display: none`, qualified with `[data-desktop-mode-dock-placement]` so it out-specifies the per-placement `display: flex` rules (0,4,0 > 0,3,0).

Before | After
--- | ---
<img width="118" height="93" alt="Screenshot 2026-07-13 at 14 10 27" src="https://github.com/user-attachments/assets/13a9ed90-f6b0-4212-b947-143499436f70" /> | <img width="112" height="89" alt="Screenshot 2026-07-13 at 16 39 35" src="https://github.com/user-attachments/assets/375d749e-9f41-492d-9a98-b6b0ce0a0b63" />


## 2. Menu-vs-system separator off-center
The separator's asymmetric `margin: auto 4px auto 8px` left it ~2.5px right of the pill center. Fix: symmetric `margin: auto 6px` → centered, 12px each side.

Before | After
--- | ---
<img width="180" height="124" alt="Screenshot 2026-07-13 at 16 39 58" src="https://github.com/user-attachments/assets/cf6445fc-6176-4b85-ad83-75f6a5d7d016" /> | <img width="166" height="121" alt="Screenshot 2026-07-13 at 17 13 58" src="https://github.com/user-attachments/assets/5c04c681-5d3a-4f65-83a7-603cc448fb6c" />


## Testing
**To replicate the original issue, deactivate all plugins** — with no plugins the dock shows only the Recycle Bin (the lone-tile case).

1. Deactivate all plugins.
2. Confirm the trash icon is centered in the dock (all placements: bottom/left/right).
3. Activate one plugin (e.g. Gutenberg) and confirm the separator sits centered between the app tile and the trash tile.

Note: the PWA service worker precaches `dock.css`, so clear site data (DevTools → Application → Clear site data) before testing an already-loaded client.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-341-9e9a76f88f1bbd5ac90de490239e112dd6f60319.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->