### PR TITLE
fix: title native Pages "Add New" window as "Add New Page"

### DIFF
--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -2563,9 +2563,10 @@ export async function renderPostsWindow(
 			return;
 		}
 		if ( target.closest( NEW_BTN ) ) {
+			const isPages = cfg.mode === 'pages';
 			openAdminUrl( cfg.newPostUrl, {
-				title: __( 'Add New Post' ),
-				icon: 'dashicons-admin-post',
+				title: isPages ? __( 'Add New Page' ) : __( 'Add New Post' ),
+				icon: isPages ? 'dashicons-admin-page' : 'dashicons-admin-post',
 			} );
 			return;
 		}


### PR DESCRIPTION
## Summary

Fixes #324.

The native Posts and Pages windows share a single bundle (`src/posts-window/index.ts`), differentiated at runtime by `cfg.mode`. The window toolbar's **Add New** handler hardcoded the Post variant, so opening a new page from the native Pages window produced a window titled **"Add New Post"** with the post icon (`dashicons-admin-post`).

## Fix

Derive the title and icon from `cfg.mode`:

- Pages mode → `Add New Page` + `dashicons-admin-page`
- Posts mode → `Add New Post` + `dashicons-admin-post` (unchanged)

The Users window uses a separate renderer, so this handler only ever runs in posts/pages mode.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test:js` — 1608 tests pass
- `npm run build` — clean
- Manual, in `wp-env` with the native Pages window enabled (OS Settings → Features): clicking **+ Add New** now opens a window titled **"Add New Page"** with the page icon. Confirmed via the title bar and the window manager (`title: "Add New Page"`, `icon: dashicons-admin-page`).
