### PR TITLE
fix: live-refresh the dock when a post type is added off the plugins page

### DIFF
--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -196,6 +196,7 @@ Typed messages between the parent shell and iframe windows. Full shapes in [`bri
 | `desktop-mode-window-send` | parent → iframe | Stable *(0.5.5)* |
 | `desktop-mode-bridge-*` *(connection-bridge family)* | both | Stable *(0.5.5)* |
 | `desktop-mode-plugins-changed` | iframe → parent | Stable *(0.7.0)* |
+| `desktop-mode-menu-signature` | iframe → parent | Stable *(0.9.4)* |
 | `wp-desktop-code-open` *(ships with the `desktop-mode-code-editor` extension)* | iframe → parent | Stable *(0.5.4)* |
 | `desktop-mode-drag-start` / `-end` / `-payload-request` | iframe → parent | Stable *(0.7.0)* |
 | `desktop-mode-drag-payload` *(reply to `-payload-request`)* | parent → iframe | Stable *(0.7.0)* |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2980,6 +2980,24 @@ Each `HarvestedCommand` carries a `kind` field the iframe computes by **statical
 }
 ```
 
+#### `desktop-mode-plugins-changed` — Stable
+
+Carries a full menu payload harvested from real admin context. Emitted by the chromeless bridge when the iframe lands on a page whose completion commonly mutates the admin menu (`plugins.php`, `plugin-install.php`, `update.php`, `themes.php`), and by the hidden refresh probe [`wp.desktop.refreshMenu()`](#refreshmenu) spawns. The shell diffs the payload against its prior snapshot by `id` and repaints only the registries that actually changed (dock, native windows, widgets, …) — no browser reload. The payload also carries `menuSig`, its own [menu signature](#desktop-mode-menu-signature--stable-since-094), which the shell adopts as its last-known value.
+
+```typescript
+{ type: 'desktop-mode-plugins-changed'; payload: { dockItems: unknown[]; nativeWindows: unknown[]; /* … */ menuSig: string } }
+```
+
+#### `desktop-mode-menu-signature` — Stable *(since 0.9.4)*
+
+A lightweight structural fingerprint of the admin menu, emitted by the chromeless bridge on **every** chromeless admin page that does *not* already carry a full `desktop-mode-plugins-changed` payload. The shell compares `sig` against its last-known value (seeded from `desktopModeConfig.menuSig` at boot, updated on every applied payload) and — only when it differs — spends one [`wp.desktop.refreshMenu()`](#refreshmenu) probe to reconcile the dock.
+
+This closes the gap where a custom post type registered through a settings tool (CPT UI, Pods, ACF, …) saves on its own `admin.php?page=…` / `options.php` screen — none of which is on the full-payload allowlist — so the new menu item never reached the live dock until a full browser reload (GH#325). An unchanged menu costs nothing beyond the tiny message; a full harvest happens only on a real change.
+
+```typescript
+{ type: 'desktop-mode-menu-signature'; sig: string }
+```
+
 ---
 
 ### parent → iframe
@@ -3625,7 +3643,7 @@ wp.desktop.registerWallpaper( {
 | `ready( cb )` | Stable *(since 0.5.1)* | **Recommended bootstrap entry point.** Run `cb` after `desktop-mode.init` has fired — immediately (via microtask) if it already fired, queued otherwise. Safe for scripts loaded at any point in the lifecycle, including server-sync-injected plugin scripts. Short alias of `whenReady( cb )`. |
 | `whenReady( cb )` | Stable | Original name for `ready( cb )` — same behaviour; keep using it if you've already adopted it. |
 | `isReady()` | Stable | Synchronous boolean — has `desktop-mode.init` fired yet. Branch between "register directly" and "schedule via `ready`" without racing. |
-| `refreshMenu()` | Stable | Force a refresh of the live admin-menu split. Auto-fired on plugin activation / deactivation; manual calls spawn a hidden iframe at `admin.php?desktop_mode_chromeless=1&desktop_mode_menu_refresh=1` whose server-side handler short-circuits the response with the fresh menu payload (a `<script>` that postMessages `desktop-mode-plugins-changed`) without rendering admin-header / admin-footer — resolves in milliseconds. The full chromeless bridge still emits the same payload when the iframe lands on a real admin page (`plugins.php` etc.). |
+| `refreshMenu()` | Stable | Force a refresh of the live admin-menu split. Auto-fired on plugin activation / deactivation, and (since 0.9.4) whenever a chromeless page reports a [`desktop-mode-menu-signature`](#desktop-mode-menu-signature--stable-since-094) that differs from the shell's last-known value — so a custom post type added via a settings tool surfaces without a browser reload (GH#325). Manual calls spawn a hidden iframe at `admin.php?desktop_mode_chromeless=1&desktop_mode_menu_refresh=1` whose server-side handler short-circuits the response with the fresh menu payload (a `<script>` that postMessages `desktop-mode-plugins-changed`) without rendering admin-header / admin-footer — resolves in milliseconds. The full chromeless bridge still emits the same payload when the iframe lands on a real admin page (`plugins.php` etc.). |
 | `setDefaultWindow( url \| null )` | Stable | Update the user's "open on startup" preference (`null` clears it). Async — persists through the REST endpoint; on success updates `config.defaultWindow` in place and dispatches the [`desktop-mode-default-window-changed`](#desktop-mode-default-window-changed--stable-since-070) CustomEvent on `document`. |
 | `openNewWindow( id, opts? )` | Stable *(since 0.8.3)* | Spawn a brand-new instance of a registered native window, even when one is already open. See [`wp.desktop.openNewWindow`](#wpdesktopopennewwindow-id-opts---stable-since-083). |
 | `cloneTemplate( templateOrId )` | Stable | Clone a `<template>` element's contents into a fresh `DocumentFragment`. Accepts the element's DOM id or the element itself; throws if the reference doesn't resolve to a template. `desktop_mode_register_window()` plugins don't need it — the shell pre-clones the declared template into the window body — it's for advanced re-cloning / custom hydration. |

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1166,7 +1166,89 @@ function desktop_mode_build_menu_payload() {
 		$payload[ $key ] = function_exists( $builder ) ? $builder() : array();
 	}
 
+	// A cheap structural fingerprint of the admin menu the shell uses to
+	// decide whether a live refresh is warranted. Shipped in every full
+	// payload so the shell can seed / update its last-known signature
+	// without recomputing it client-side (which would risk drift from
+	// the server's capability-gated view). See
+	// desktop_mode_menu_signature().
+	$payload['menuSig'] = desktop_mode_menu_signature();
+
 	return $payload;
+}
+
+/**
+ * Cheap structural fingerprint of the current admin menu.
+ *
+ * The chromeless bridge emits the *full* menu payload only from the
+ * handful of pages whose completion commonly mutates the admin menu
+ * (activation / install / theme switch). That leaves a gap: a custom
+ * post type registered through a settings-based tool (CPT UI, Pods,
+ * ACF, …) saves on its own `admin.php?page=…` / `options.php` screen,
+ * none of which is in that list, so the new top-level menu never
+ * reaches the live dock until a full browser reload rebuilds the shell
+ * (GH#325).
+ *
+ * Building the full payload on *every* chromeless page just to catch
+ * that case would be wasteful — most navigations don't touch the menu.
+ * Instead every chromeless page ships this lightweight signature; the
+ * shell compares it against its last-known value and only spends a
+ * `wp.desktop.refreshMenu()` probe when it actually changed.
+ *
+ * The hash covers the capability-passing top-level + submenu slugs and
+ * their (badge-stripped) titles — i.e. exactly the add / remove /
+ * rename events the dock cares about. Transient badge counts (update
+ * notifications, moderation queues) are stripped so they don't churn
+ * the signature; those have their own refresh path.
+ *
+ * @since 0.9.4
+ *
+ * @return string 32-char md5 fingerprint, or '' when the menu is
+ *                unavailable (non-admin context).
+ */
+function desktop_mode_menu_signature() {
+	global $menu, $submenu;
+
+	if ( empty( $menu ) || ! is_array( $menu ) ) {
+		return '';
+	}
+
+	$clean_title = static function ( $raw ) {
+		// Mirror desktop_mode_build_dock_items(): drop badge spans first,
+		// then any remaining markup, so update counts don't move the hash.
+		$stripped = preg_replace( '/<span[^>]*>.*?<\/span>/s', '', (string) $raw );
+		return trim( wp_strip_all_tags( (string) $stripped ) );
+	};
+
+	$parts = array();
+
+	foreach ( $menu as $item ) {
+		if ( empty( $item[2] ) ) {
+			continue;
+		}
+		if ( ! empty( $item[4] ) && false !== strpos( $item[4], 'wp-menu-separator' ) ) {
+			continue;
+		}
+		if ( ! empty( $item[1] ) && ! current_user_can( $item[1] ) ) {
+			continue;
+		}
+
+		$slug    = (string) $item[2];
+		$parts[] = $slug . '|' . $clean_title( $item[0] ?? '' );
+
+		if ( empty( $submenu[ $slug ] ) || ! is_array( $submenu[ $slug ] ) ) {
+			continue;
+		}
+		foreach ( $submenu[ $slug ] as $sub_item ) {
+			if ( ! empty( $sub_item[1] ) && ! current_user_can( $sub_item[1] ) ) {
+				continue;
+			}
+			$parts[] = "\t" . ( isset( $sub_item[2] ) ? (string) $sub_item[2] : '' )
+				. '|' . $clean_title( $sub_item[0] ?? '' );
+		}
+	}
+
+	return md5( implode( "\n", $parts ) );
 }
 
 /**

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -389,6 +389,10 @@ function desktop_mode_enqueue_assets() {
 			'adminUrl'         => esc_url( admin_url() ),
 			'colorScheme'      => sanitize_html_class( get_user_option( 'admin_color' ), 'fresh' ),
 			'dockItems'        => $dock_items,
+			// Baseline menu fingerprint. The shell seeds its last-known
+			// signature from this so the first off-allowlist menu change
+			// (vs. this boot state) is caught without a wasted probe. GH#325.
+			'menuSig'          => isset( $menu_payload['menuSig'] ) ? (string) $menu_payload['menuSig'] : '',
 			'nativeWindows'    => $native_windows,
 			'serverWidgets'    => $server_widgets,
 			'serverWallpapers' => $server_wallpapers,

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -841,6 +841,7 @@ function desktop_mode_chromeless_bridge_script() {
 	 *   - themes.php          — theme switch (rare but can add menus).
 	 */
 	var __DESKTOP_MODE_MENU_PAYLOAD__ = /*__DESKTOP_MODE_MENU_PAYLOAD__*/;
+	var __DESKTOP_MODE_MENU_SIG__ = /*__DESKTOP_MODE_MENU_SIG__*/;
 	/*
 	 * Icon harvest from the iframe's authoritative #adminmenu.
 	 *
@@ -941,6 +942,22 @@ function desktop_mode_chromeless_bridge_script() {
 				{
 					type: 'desktop-mode-plugins-changed',
 					payload: __DESKTOP_MODE_MENU_PAYLOAD__
+				},
+				window.location.origin
+			);
+		} else if ( __DESKTOP_MODE_MENU_SIG__ ) {
+			/*
+			 * No full payload on this page — but we still ship the cheap
+			 * menu signature so the shell can notice a menu change that
+			 * happened somewhere off the plugins/themes/update path (a
+			 * CPT registered via a settings tool, a plugin that adds a
+			 * menu on save, …) and spend a refresh probe only then.
+			 * GH#325.
+			 */
+			window.parent.postMessage(
+				{
+					type: 'desktop-mode-menu-signature',
+					sig: __DESKTOP_MODE_MENU_SIG__
 				},
 				window.location.origin
 			);
@@ -2837,12 +2854,29 @@ function desktop_mode_chromeless_bridge_script() {
 } )();
 JS;
 
+	// On pages that don't carry a full payload, ship the lightweight
+	// menu signature so the shell can detect an off-allowlist menu
+	// change (e.g. a CPT registered via a settings tool) and refresh
+	// only then. The full payload already embeds its own `menuSig`, so
+	// there's no point recomputing it when one is being sent. GH#325.
+	$menu_sig_json = 'null';
+	if ( 'null' === $menu_payload_json ) {
+		$menu_sig = desktop_mode_menu_signature();
+		if ( '' !== $menu_sig ) {
+			$encoded_sig = wp_json_encode( $menu_sig );
+			if ( false !== $encoded_sig ) {
+				$menu_sig_json = $encoded_sig;
+			}
+		}
+	}
+
 	// Substitute the server-built menu payload into the bridge
 	// script. `wp_json_encode` guarantees safe JSON output — no need
 	// for an additional escape pass. When the page isn't on our
 	// menu-altering allowlist the placeholder resolves to `null` and
 	// the bridge skips the postMessage.
 	$js = str_replace( '/*__DESKTOP_MODE_MENU_PAYLOAD__*/', $menu_payload_json, $js );
+	$js = str_replace( '/*__DESKTOP_MODE_MENU_SIG__*/', $menu_sig_json, $js );
 
 	wp_print_inline_script_tag( $js );
 }

--- a/src/boot/menu-refresh.ts
+++ b/src/boot/menu-refresh.ts
@@ -120,40 +120,15 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 		syncShortcuts,
 	} );
 
-	window.addEventListener( 'message', ( e: MessageEvent ) => {
-		if ( e.origin !== INITIAL_ORIGIN ) {
-			return;
-		}
-		const data = e.data as {
-			type?: string;
-			payload?: {
-				dockItems?: unknown;
-				nativeWindows?: unknown;
-				serverWidgets?: unknown;
-				serverWallpapers?: unknown;
-				serverCommandScripts?: unknown;
-				serverCommands?: unknown;
-				serverSettingsTabScripts?: unknown;
-				serverSettingsTabs?: unknown;
-				serverDockRailRendererScripts?: unknown;
-				serverTitleBarButtonScripts?: unknown;
-				serverUnfocusEffectScripts?: unknown;
-				desktopIcons?: unknown;
-			};
-		} | null;
-		if ( ! data || data.type !== 'desktop-mode-plugins-changed' ) {
-			return;
-		}
-
-		// The chromeless bridge always embeds a fresh menu payload
-		// captured from real admin context — plugins that gate
-		// `admin_menu` on `is_admin()` at load time registered
-		// normally there. Messages without a payload are stale /
-		// out-of-spec and ignored.
-		if ( data.payload ) {
-			applyPayload( data.payload );
-		}
-	} );
+	// Last-known admin-menu fingerprint. Seeded from the boot config so
+	// the first off-allowlist menu change (vs. boot state) is detected
+	// without a wasted probe. Updated whenever a full payload lands (it
+	// carries its own `menuSig`) or a lighter signature message arrives.
+	let lastMenuSig: string =
+		typeof config.menuSig === 'string' ? config.menuSig : '';
+	// Guard so a burst of signature messages (rapid window navigation)
+	// can't spawn overlapping refresh probes for the same change.
+	let sigRefreshInFlight = false;
 
 	const refresh = (): Promise< void > => {
 		if ( ! config.adminUrl ) {
@@ -206,9 +181,9 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 				if ( ! data || data.type !== 'desktop-mode-plugins-changed' ) {
 					return;
 				}
-				// The shell-wide listener registered above will apply
-				// the payload. We just need to know the probe
-				// completed so we can dispose the iframe.
+				// The shell-wide `message` listener applies the payload
+				// (and adopts its signature). Here we just need to know
+				// the probe completed so we can dispose the iframe.
 				cleanup();
 			};
 
@@ -224,6 +199,77 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 			document.body.appendChild( iframe );
 		} );
 	};
+
+	window.addEventListener( 'message', ( e: MessageEvent ) => {
+		if ( e.origin !== INITIAL_ORIGIN ) {
+			return;
+		}
+		const data = e.data as {
+			type?: string;
+			sig?: unknown;
+			payload?: {
+				dockItems?: unknown;
+				nativeWindows?: unknown;
+				serverWidgets?: unknown;
+				serverWallpapers?: unknown;
+				serverCommandScripts?: unknown;
+				serverCommands?: unknown;
+				serverSettingsTabScripts?: unknown;
+				serverSettingsTabs?: unknown;
+				serverDockRailRendererScripts?: unknown;
+				serverTitleBarButtonScripts?: unknown;
+				serverUnfocusEffectScripts?: unknown;
+				desktopIcons?: unknown;
+				menuSig?: unknown;
+			};
+		} | null;
+		if ( ! data ) {
+			return;
+		}
+
+		if ( data.type === 'desktop-mode-plugins-changed' ) {
+			// The chromeless bridge always embeds a fresh menu payload
+			// captured from real admin context — plugins that gate
+			// `admin_menu` on `is_admin()` at load time registered
+			// normally there. Messages without a payload are stale /
+			// out-of-spec and ignored.
+			if ( data.payload ) {
+				applyPayload( data.payload );
+				// The payload carries the authoritative signature for the
+				// state we just applied — adopt it so a later signature
+				// message for the same menu doesn't trigger a redundant
+				// refresh.
+				if ( typeof data.payload.menuSig === 'string' ) {
+					lastMenuSig = data.payload.menuSig;
+				}
+			}
+			return;
+		}
+
+		if ( data.type === 'desktop-mode-menu-signature' ) {
+			// A chromeless page off the full-payload allowlist reported
+			// its menu fingerprint. If it differs from what we last knew,
+			// the admin menu changed somewhere we don't otherwise watch
+			// (a CPT registered via a settings tool, a plugin that adds a
+			// menu on save) — spend one refresh probe to reconcile. GH#325.
+			const sig = data.sig;
+			if (
+				typeof sig === 'string' &&
+				sig !== '' &&
+				sig !== lastMenuSig &&
+				! sigRefreshInFlight
+			) {
+				// Adopt optimistically so repeat reports of the SAME new
+				// signature don't each queue a probe; a genuinely newer
+				// signature still gets through once this one settles.
+				lastMenuSig = sig;
+				sigRefreshInFlight = true;
+				void refresh().finally( () => {
+					sigRefreshInFlight = false;
+				} );
+			}
+		}
+	} );
 
 	return refresh;
 }

--- a/src/boot/menu-refresh.ts
+++ b/src/boot/menu-refresh.ts
@@ -120,10 +120,12 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 		syncShortcuts,
 	} );
 
-	// Last-known admin-menu fingerprint. Seeded from the boot config so
-	// the first off-allowlist menu change (vs. boot state) is detected
-	// without a wasted probe. Updated whenever a full payload lands (it
-	// carries its own `menuSig`) or a lighter signature message arrives.
+	// Fingerprint of the admin menu the dock currently reflects. Seeded
+	// from the boot config so the first off-allowlist menu change (vs.
+	// boot state) is detected without a wasted probe, and thereafter
+	// updated only when a full payload is applied (it carries its own
+	// `menuSig`). Signature messages are compared against it but never
+	// mutate it — see the handler below.
 	let lastMenuSig: string =
 		typeof config.menuSig === 'string' ? config.menuSig : '';
 	// Guard so a burst of signature messages (rapid window navigation)
@@ -248,10 +250,19 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 
 		if ( data.type === 'desktop-mode-menu-signature' ) {
 			// A chromeless page off the full-payload allowlist reported
-			// its menu fingerprint. If it differs from what we last knew,
-			// the admin menu changed somewhere we don't otherwise watch
-			// (a CPT registered via a settings tool, a plugin that adds a
-			// menu on save) — spend one refresh probe to reconcile. GH#325.
+			// its menu fingerprint. If it differs from the state the dock
+			// currently reflects, the admin menu changed somewhere we
+			// don't otherwise watch (a CPT registered via a settings tool,
+			// a plugin that adds a menu on save) — spend one refresh probe
+			// to reconcile. GH#325.
+			//
+			// `lastMenuSig` is deliberately NOT updated here: it tracks the
+			// state the dock actually reflects, so it moves only when a
+			// payload is applied (the branch above, or the probe's own
+			// payload). The in-flight guard collapses a burst of reports
+			// into a single probe; leaving `lastMenuSig` untouched means a
+			// probe that times out is retried on the next navigation
+			// rather than silently swallowed.
 			const sig = data.sig;
 			if (
 				typeof sig === 'string' &&
@@ -259,10 +270,6 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 				sig !== lastMenuSig &&
 				! sigRefreshInFlight
 			) {
-				// Adopt optimistically so repeat reports of the SAME new
-				// signature don't each queue a probe; a genuinely newer
-				// signature still gets through once this one settles.
-				lastMenuSig = sig;
 				sigRefreshInFlight = true;
 				void refresh().finally( () => {
 					sigRefreshInFlight = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1517,6 +1517,16 @@ export interface DesktopConfig {
 	/** The active color scheme slug. */
 	colorScheme: string;
 	/**
+	 * Baseline fingerprint of the admin menu at boot. The live
+	 * menu-refresh pipeline seeds its last-known signature from this so
+	 * an off-allowlist menu change (e.g. a custom post type registered
+	 * through a settings tool) is detected against the boot state
+	 * without a wasted refresh probe. Empty string when unavailable.
+	 *
+	 * @since 0.9.4
+	 */
+	menuSig?: string;
+	/**
 	 * Dock items derived from the admin menu. Core WordPress pages
 	 * (Dashboard, Posts, Plugins, Users, Settings, CPTs) are ordered
 	 * first; plugin-contributed top-level menus (`admin.php?page=*`)

--- a/tests/phpunit/tests/desktopModeMenuSignature.php
+++ b/tests/phpunit/tests/desktopModeMenuSignature.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Tests for the admin-menu signature the chromeless bridge ships on
+ * every page so the shell can live-refresh the dock when the menu
+ * changes off the plugins/themes/update allowlist (GH#325) — e.g. a
+ * custom post type registered through a settings tool.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ *
+ * @covers ::desktop_mode_menu_signature
+ */
+class Tests_DesktopMode_MenuSignature extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	protected $original_menu;
+	protected $original_submenu;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		global $menu, $submenu;
+		$this->original_menu    = $menu;
+		$this->original_submenu = $submenu;
+		$menu                   = array();
+		$submenu                = array();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		global $menu, $submenu;
+		$menu    = $this->original_menu;
+		$submenu = $this->original_submenu;
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: build a $menu row in the canonical 7-element layout used
+	 * throughout wp-admin/menu.php.
+	 */
+	private function make_menu_row( $title, $cap, $slug, $icon = 'dashicons-admin-post' ) {
+		return array(
+			$title,
+			$cap,
+			$slug,
+			'',
+			'',
+			'menu-' . sanitize_key( str_replace( array( '.', '?', '=' ), '-', $slug ) ),
+			$icon,
+		);
+	}
+
+	public function test_returns_empty_string_when_menu_is_empty() {
+		global $menu;
+		$menu = array();
+		$this->assertSame( '', desktop_mode_menu_signature() );
+	}
+
+	public function test_is_a_stable_md5_for_a_given_menu() {
+		global $menu;
+		$menu = array(
+			$this->make_menu_row( 'Dashboard', 'read', 'index.php' ),
+			$this->make_menu_row( 'Posts', 'edit_posts', 'edit.php' ),
+		);
+
+		$first  = desktop_mode_menu_signature();
+		$second = desktop_mode_menu_signature();
+
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{32}$/', $first );
+		$this->assertSame( $first, $second, 'Signature must be deterministic for an unchanged menu.' );
+	}
+
+	/**
+	 * The core GH#325 scenario: a new top-level menu (e.g. a custom post
+	 * type registered by a settings tool) must move the signature so the
+	 * shell knows to refresh.
+	 */
+	public function test_changes_when_a_top_level_menu_is_added() {
+		global $menu;
+		$menu = array(
+			$this->make_menu_row( 'Dashboard', 'read', 'index.php' ),
+		);
+		$before = desktop_mode_menu_signature();
+
+		$menu[] = $this->make_menu_row( 'Books', 'edit_posts', 'edit.php?post_type=book', 'dashicons-book-alt' );
+		$after  = desktop_mode_menu_signature();
+
+		$this->assertNotSame( $before, $after );
+	}
+
+	public function test_changes_when_a_menu_is_removed() {
+		global $menu;
+		$menu = array(
+			$this->make_menu_row( 'Dashboard', 'read', 'index.php' ),
+			$this->make_menu_row( 'Books', 'edit_posts', 'edit.php?post_type=book' ),
+		);
+		$before = desktop_mode_menu_signature();
+
+		array_pop( $menu );
+		$after = desktop_mode_menu_signature();
+
+		$this->assertNotSame( $before, $after );
+	}
+
+	public function test_changes_when_a_title_is_renamed() {
+		global $menu;
+		$menu   = array( $this->make_menu_row( 'Books', 'edit_posts', 'edit.php?post_type=book' ) );
+		$before = desktop_mode_menu_signature();
+
+		$menu[0][0] = 'Publications';
+		$after      = desktop_mode_menu_signature();
+
+		$this->assertNotSame( $before, $after );
+	}
+
+	/**
+	 * Transient update badges (`<span class="update-plugins count-N">`)
+	 * ride inside the menu title HTML and fluctuate constantly. They
+	 * must NOT move the signature — otherwise the dock would refresh on
+	 * every moderation/update-count tick. Mirrors the badge-strip in
+	 * desktop_mode_build_dock_items().
+	 */
+	public function test_ignores_update_badge_count_changes() {
+		global $menu;
+		$menu = array(
+			array(
+				'Plugins <span class="update-plugins count-2"><span class="plugin-count">2</span></span>',
+				'activate_plugins',
+				'plugins.php',
+				'',
+				'',
+				'menu-plugins',
+				'dashicons-admin-plugins',
+			),
+		);
+		$two = desktop_mode_menu_signature();
+
+		// Same menu, only the badge count moved 2 -> 5.
+		$menu[0][0] = 'Plugins <span class="update-plugins count-5"><span class="plugin-count">5</span></span>';
+		$five       = desktop_mode_menu_signature();
+
+		$this->assertSame( $two, $five, 'A changing update badge count must not churn the signature.' );
+	}
+
+	public function test_reflects_submenu_additions() {
+		global $menu, $submenu;
+		$menu                = array( $this->make_menu_row( 'Posts', 'edit_posts', 'edit.php' ) );
+		$submenu['edit.php'] = array(
+			array( 'All Posts', 'edit_posts', 'edit.php' ),
+		);
+		$before = desktop_mode_menu_signature();
+
+		$submenu['edit.php'][] = array( 'Add New', 'edit_posts', 'post-new.php' );
+		$after                 = desktop_mode_menu_signature();
+
+		$this->assertNotSame( $before, $after, 'A new submenu entry must move the signature.' );
+	}
+
+	/**
+	 * The signature is computed against the *current user's*
+	 * capability-passing view — the same gate the dock uses. A menu the
+	 * viewer can't see must neither appear in nor churn the signature,
+	 * so activation of an admin-only tool never triggers a wasted
+	 * refresh for a lower-privileged user.
+	 */
+	public function test_respects_capability_gating() {
+		global $menu;
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		$menu   = array( $this->make_menu_row( 'Dashboard', 'read', 'index.php' ) );
+		$before = desktop_mode_menu_signature();
+
+		// Add a menu the subscriber cannot access.
+		$menu[] = $this->make_menu_row( 'Settings', 'manage_options', 'options-general.php' );
+		$after  = desktop_mode_menu_signature();
+
+		$this->assertSame( $before, $after, 'An item the viewer lacks the cap for must not move their signature.' );
+	}
+
+	/**
+	 * Separator rows carry no slug/title the dock renders; they must be
+	 * skipped so a Core reshuffle of separators doesn't churn the hash.
+	 */
+	public function test_ignores_separators() {
+		global $menu;
+		$menu = array(
+			$this->make_menu_row( 'Dashboard', 'read', 'index.php' ),
+			array( '', 'read', 'separator1', '', 'wp-menu-separator' ),
+			$this->make_menu_row( 'Posts', 'edit_posts', 'edit.php' ),
+		);
+		$with_separator = desktop_mode_menu_signature();
+
+		unset( $menu[1] );
+		$menu           = array_values( $menu );
+		$without        = desktop_mode_menu_signature();
+
+		$this->assertSame( $with_separator, $without );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #325.

A newly-registered custom post type didn't show up in the dock / side menu until the user reloaded the entire browser window.

**Root cause.** The chromeless bridge only emits the full menu-refresh payload from four pages — `plugins.php`, `plugin-install.php`, `update.php`, `themes.php` — plus the explicit `wp.desktop.refreshMenu()` probe. That covers plugin activation, but a CPT registered through a settings-based tool (CPT UI, Pods, ACF, …) is saved on its own `admin.php?page=…` / `options.php` screen, none of which is on that allowlist. So the shell never received a fresh menu payload and the new top-level menu stayed invisible until a full reload rebuilt the shell from `$menu`.

## Fix — a lightweight menu signature

Rather than emit the full payload on every navigation (wasteful, and the reason the allowlist exists), every chromeless page now ships a cheap fingerprint of the admin menu; the shell only spends a refresh probe when it actually changes.

- **`desktop_mode_menu_signature()`** (`includes/core/payload.php`) — md5 over the capability-passing top-level + submenu slugs and their badge-stripped titles, i.e. exactly the add / remove / rename events the dock cares about. Transient badge counts (update notifications, moderation queues) are stripped so they don't churn the hash.
- **Bridge** (`includes/render/chromeless-bridge.php`) — emits a `desktop-mode-menu-signature` postMessage on every chromeless page that isn't already sending a full payload. The full payload now embeds its own `menuSig` so the shell can adopt it.
- **Boot config** (`includes/render/assets.php`) — seeds `desktopModeConfig.menuSig` so the shell has a baseline from the first paint (no wasted probe on the first window opened).
- **Shell** (`src/boot/menu-refresh.ts`) — tracks the last-known signature and calls the existing `wp.desktop.refreshMenu()` only when a reported signature differs, with an in-flight guard so a burst of navigations can't stack probes.

Net effect: off-allowlist menu changes (CPTs, and any plugin that adds a menu on save) now surface live; unchanged menus cost nothing beyond a tiny message.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` — clean
- `npm run test:js` — 1608 tests pass
- PHP: `php -l` clean; the added lines are PHPCS-clean against `phpcs.xml.dist`
- **Manual, in `wp-env`:**
  - Registered a CPT while the shell was running (off the plugins page). After any fresh chromeless navigation the bridge posts `desktop-mode-menu-signature`, the shell detects the change, runs one refresh probe, and the new tile appears in the dock — **no browser reload**.
  - Negative case: loading a chromeless page when the menu is unchanged posts the signature but triggers **no** refresh probe.
  - Regression: plugin activate/deactivate live-refresh still works (full payload path unchanged).

## Docs

Updated `docs/javascript-reference.md` (new `desktop-mode-menu-signature` bridge message + `desktop-mode-plugins-changed` catalog entry, `refreshMenu()` note) and `docs/api-index.md` (postMessage inventory).
