### PR TITLE
fix: cancel pending overview timers on WindowManager teardown

### DIFF
--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -64,7 +64,7 @@ import {
 	commitSnapIfPending,
 	updateSnapZoneForDrag,
 } from './snap-zones';
-import { enterOverview, exitOverview } from './overview';
+import { cancelOverviewTimers, enterOverview, exitOverview } from './overview';
 import { loadNativeWindowGeometry } from './native-window-geometry';
 
 /** Base z-index for desktop windows. */
@@ -255,6 +255,22 @@ export class WindowManager {
 	 * @internal
 	 */
 	public _overviewAddTileFocused = false;
+	/**
+	 * Handle of the pending "grid animation settled" timer scheduled
+	 * by `enterOverview()`. Tracked so `destroy()` can cancel it —
+	 * otherwise a caller that discards the manager mid-transition
+	 * leaves a real `setTimeout` that fires later and reaches for
+	 * globals (`window.wp.hooks`) that may already be torn down.
+	 * @internal
+	 */
+	public _overviewEnterTimeoutId: number | null = null;
+	/**
+	 * Handle of the pending "exit animation settled" timer scheduled
+	 * by `exitOverview()`. Same rationale as
+	 * {@link _overviewEnterTimeoutId}.
+	 * @internal
+	 */
+	public _overviewExitTimeoutId: number | null = null;
 
 	// ---- Snap-zone state (edge-snap + split overview) ----
 
@@ -1511,6 +1527,27 @@ export class WindowManager {
 	}
 	public exitOverview( selected?: Window, maximize = false ): void {
 		exitOverview( this, selected, maximize );
+	}
+
+	/**
+	 * Release resources this instance owns outside its own DOM
+	 * subtree: the document-level overview key handler and any
+	 * pending overview transition timers. Removing `desktop` from the
+	 * DOM does not reach either of those — a caller discarding a
+	 * manager instance (tests; a future SPA-style unmount) that skips
+	 * this leaves a real `setTimeout` to fire later and reach for
+	 * globals that may already be gone, plus a `keydown` listener on
+	 * `document` that keeps responding on behalf of a manager nothing
+	 * else references.
+	 *
+	 * Safe to call unconditionally — a no-op when overview was never
+	 * entered or was already cleanly exited.
+	 */
+	public destroy(): void {
+		if ( this._overviewActive ) {
+			exitOverview( this );
+		}
+		cancelOverviewTimers( this );
 	}
 
 	/**

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -344,12 +344,31 @@ export function enterOverview( mgr: WindowManager ): void {
 
 	// Signal "entered" after the grid animation settles. Matches the
 	// 280 ms transform transition — plugins listening here can safely
-	// read final layout positions.
-	window.setTimeout( () => {
+	// read final layout positions. Handle is tracked so `destroy()`
+	// can cancel it if the manager is discarded before it fires.
+	mgr._overviewEnterTimeoutId = window.setTimeout( () => {
+		mgr._overviewEnterTimeoutId = null;
 		if ( mgr._overviewActive ) {
 			doAction( HOOKS.OVERVIEW_ENTERED, {} );
 		}
-	}, 300 );
+	}, 300 ) as unknown as number;
+}
+
+/**
+ * Cancel any pending overview transition timers without running their
+ * callbacks. Called from `WindowManager.destroy()` so a discarded
+ * manager can never fire a delayed `doAction()` that reaches for
+ * globals torn down after the manager itself.
+ */
+export function cancelOverviewTimers( mgr: WindowManager ): void {
+	if ( mgr._overviewEnterTimeoutId !== null ) {
+		window.clearTimeout( mgr._overviewEnterTimeoutId );
+		mgr._overviewEnterTimeoutId = null;
+	}
+	if ( mgr._overviewExitTimeoutId !== null ) {
+		window.clearTimeout( mgr._overviewExitTimeoutId );
+		mgr._overviewExitTimeoutId = null;
+	}
 }
 
 /** Build the overview top bar — a tile per virtual desktop plus "+". */
@@ -640,9 +659,12 @@ export function exitOverview(
 
 	// After the animation completes, strip the per-window overview
 	// class (kept in place through the transition for the
-	// transform-origin reason noted above) and the labels.
+	// transform-origin reason noted above) and the labels. Handle is
+	// tracked so `destroy()` can cancel it if the manager is
+	// discarded before it fires.
 	const ANIMATION_MS = 280;
-	window.setTimeout( () => {
+	mgr._overviewExitTimeoutId = window.setTimeout( () => {
+		mgr._overviewExitTimeoutId = null;
 		for ( const w of mgr._stack ) {
 			w.element.classList.remove( 'desktop-mode-window--overview' );
 		}
@@ -672,7 +694,7 @@ export function exitOverview(
 			windowId: selected && maximize ? selected.id : undefined,
 			reason: selected && maximize ? 'select' : 'cancel',
 		} );
-	}, ANIMATION_MS );
+	}, ANIMATION_MS ) as unknown as number;
 
 	if ( mgr._overviewPointerDownHandler ) {
 		mgr._desktop.removeEventListener(

--- a/tests/vitest/desktop-shortcuts.test.ts
+++ b/tests/vitest/desktop-shortcuts.test.ts
@@ -10,7 +10,7 @@
  * bottom so we don't double up on `installDesktopArrowShortcuts`
  * idempotency.
  */
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
 import {
 	cycleOverviewCursor,
@@ -43,15 +43,6 @@ describe( 'WindowManager — arrow-key desktop shortcuts', async () => {
 	beforeEach( async () => {
 		hooks = installHooksStub();
 		void hooks;
-		// Several tests enter overview without explicitly exiting it.
-		// `enterOverview` (and `exitOverview`) schedule setTimeout
-		// callbacks that fire `doAction(OVERVIEW_ENTERED / OVERVIEW_EXITED)`
-		// 280–300 ms later. Under real timers those fire AFTER `afterEach`
-		// has cleared the hooks stub, and `getWpHooks` then throws —
-		// flaky locally, deterministic on CI. Fake timers keep those
-		// callbacks pending in the queue so they're discarded when
-		// `vi.useRealTimers()` resets the timer state below.
-		vi.useFakeTimers();
 		desktopArea = document.createElement( 'div' );
 		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
 			value: () =>
@@ -80,14 +71,16 @@ describe( 'WindowManager — arrow-key desktop shortcuts', async () => {
 	} );
 
 	afterEach( async () => {
+		// Several tests enter overview without explicitly exiting it.
+		// `manager.destroy()` cancels the pending overview transition
+		// timers (and, if still active, runs a synchronous exit) so
+		// none of them fire later and reach for `window.wp.hooks`
+		// after `clearHooksStub()` below has removed it.
+		manager.destroy();
 		for ( const win of manager.getAll() ) {
 			win.destroy();
 		}
 		desktopArea.remove();
-		// Restore real timers BEFORE clearing the stub so any callbacks
-		// the test queued get discarded along with the fake-timer state,
-		// not run against an already-cleared `window.wp`.
-		vi.useRealTimers();
 		clearHooksStub();
 	} );
 

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -9,7 +9,7 @@
  *   - migration target picks the left neighbour by default
  *   - the desktop-mode.desktop.* action firings
  */
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
 import {
 	clearHooksStub,
@@ -62,6 +62,12 @@ describe( 'WindowManager — virtual desktops', async () => {
 	} );
 
 	afterEach( async () => {
+		// Several tests enter overview without explicitly exiting it.
+		// `manager.destroy()` cancels the pending overview transition
+		// timers (and, if still active, runs a synchronous exit) so
+		// none of them fire later and reach for `window.wp.hooks`
+		// after `clearHooksStub()` below has removed it.
+		manager.destroy();
 		for ( const win of manager.getAll() ) {
 			win.destroy();
 		}
@@ -469,5 +475,87 @@ describe( 'WindowManager — virtual desktops', async () => {
 
 		expect( manager.toggleShowDesktop() ).toBe( false );
 		expect( b.state ).toBe( 'normal' );
+	} );
+} );
+
+describe( 'WindowManager — destroy()', async () => {
+	let hooks: FakeWpHooks;
+	let desktopArea: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( async () => {
+		hooks = installHooksStub();
+		desktopArea = document.createElement( 'div' );
+		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		Object.defineProperty( desktopArea, 'clientWidth', { value: 1600, configurable: true } );
+		Object.defineProperty( desktopArea, 'clientHeight', { value: 900, configurable: true } );
+		document.body.appendChild( desktopArea );
+		manager = new WindowManager( desktopArea );
+	} );
+
+	afterEach( async () => {
+		vi.useRealTimers();
+		for ( const win of manager.getAll() ) {
+			win.destroy();
+		}
+		desktopArea.remove();
+		clearHooksStub();
+	} );
+
+	test( 'cancels the pending "entered" timer left by an un-exited enterOverview()', async () => {
+		vi.useFakeTimers();
+		manager.enterOverview();
+		expect( manager._overviewEnterTimeoutId ).not.toBeNull();
+
+		manager.destroy();
+		expect( manager._overviewEnterTimeoutId ).toBeNull();
+
+		// Removing `window.wp.hooks` proves the cancelled timer never
+		// fires — a leaked one would throw reaching for it here, which
+		// is exactly the flake this regression test guards against.
+		clearHooksStub();
+		vi.advanceTimersByTime( 1000 );
+	} );
+
+	test( 'cancels the pending "exited" timer left by an un-awaited exitOverview()', async () => {
+		vi.useFakeTimers();
+		manager.enterOverview();
+		vi.advanceTimersByTime( 1000 );
+		manager.exitOverview();
+		expect( manager._overviewExitTimeoutId ).not.toBeNull();
+
+		manager.destroy();
+		expect( manager._overviewExitTimeoutId ).toBeNull();
+
+		clearHooksStub();
+		vi.advanceTimersByTime( 1000 );
+	} );
+
+	test( 'synchronously exits overview when destroyed mid-session', async () => {
+		manager.enterOverview();
+		expect( manager._overviewActive ).toBe( true );
+
+		manager.destroy();
+
+		expect( manager._overviewActive ).toBe( false );
+		expect( hooks.didAction( 'desktop-mode.overview.exiting' ) ).toBe( 1 );
+	} );
+
+	test( 'is a no-op when overview was never entered', async () => {
+		expect( () => manager.destroy() ).not.toThrow();
+		expect( manager._overviewActive ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
## Summary
- `desktops.test.ts` (and CI) intermittently threw `[desktop-mode] window.wp.hooks is not available` from `overview.ts` — a real, root-cause bug, not a stale/flaky-and-fine test.
- `enterOverview()`/`exitOverview()` schedule real `setTimeout` callbacks (280–300ms) that fire `doAction(OVERVIEW_ENTERED/EXITED)`. Nothing tracked or cancelled those timers, so a caller that discards the manager mid-transition leaves a timer that fires later and throws reaching for `window.wp.hooks` after it's gone.
- `desktop-shortcuts.test.ts` had already hit this and duct-taped around it with `vi.useFakeTimers()`; `desktops.test.ts` never got the same treatment, which is what surfaced in CI.
- Fix: add `WindowManager.destroy()` — synchronously exits overview if still active, then cancels any pending overview timer (tracked via new `_overviewEnterTimeoutId` / `_overviewExitTimeoutId` fields and an exported `cancelOverviewTimers()` helper). Both test files now call `manager.destroy()` in `afterEach` instead of relying on fake timers to swallow leaked callbacks.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:js` — 177 files / 1620 tests passed, run 4× back-to-back with zero unhandled errors each time (was previously timing-dependent flaky)
- [x] `npm run build`
- [x] New regression tests in `desktops.test.ts` prove `destroy()` actually cancels pending timers via `vi.useFakeTimers()` + `vi.advanceTimersByTime`, rather than just "didn't crash this run"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-348-e149a6978e54d0f2972660c7c816ff3a4be9f44b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->