### PR TITLE
Fix selection identity & staleness bugs that let destructive actions hit the wrong items

### DIFF
--- a/docs/examples/data-table.md
+++ b/docs/examples/data-table.md
@@ -334,7 +334,8 @@ If editing is the primary use case, request a first-class `column.editor` API �
 | `select(id)` / `deselect(id)` | Mutate the selection by id. |
 | `selectAll()` / `clearSelection()` | Bulk operations (multi-mode). `selectAll()` selects only the rows passing the active client-side filters. |
 | `selection` | Get/set the selection set. |
-| `selectedRows` | Resolved row objects matching `selection`. |
+| `selectedRows` | Resolved row objects matching `selection` (resolves against the full `data` buffer). |
+| `visibleRows` | Rows passing the active client-side filters — the set `selectAll()` operates on. Destructive bulk consumers should resolve `selection` against this, not `data`. |
 | `getRowId` | Stable-id extractor (default: index). |
 | `sort` | Get/set the active `{ key, direction }` (or `null`). |
 | `filters` | Get/set the filter map. |
@@ -395,7 +396,7 @@ If editing is the primary use case, request a first-class `column.editor` API �
 - **Editable cells losing focus.** Reassigning `table.data` on every keystroke triggers a full body repaint — the new `<input>` is a different element, so focus is lost. Commit on blur/Enter, or hold edits in a side buffer until save.
 - **Selection going stale on data refresh.** Without `getRowId`, ids are array indices — selections drift if rows reorder. Set `getRowId = ( row ) => row.id` whenever rows have a natural identifier.
 - **Colliding ids across mixed row kinds.** Two rows whose `getRowId` returns the same value are one row as far as selection is concerned — ticking one ticks both. Qualify the id (``( row ) => `${ row.type }:${ row.id }` ``) when a list mixes entities from independent id sequences.
-- **Stale selection feeding destructive bulk actions.** Selection survives `data` reassignment by design. If your bulk actions read `table.selection` (trash, delete…), call `clearSelection()` whenever the query (page, search, filter) changes, or resolve the selection against the currently rendered rows before acting.
+- **Stale selection feeding destructive bulk actions.** Selection survives `data` reassignment by design. If your bulk actions read `table.selection` (trash, delete…), call `clearSelection()` whenever the query (page, search, filter) changes, **and** resolve the selection against `table.visibleRows` (not `data`) before acting — a data-driven change can hide a selected row without any filter event firing, and rows the user can't see must never be swept into a destructive action.
 
 ## See also
 

--- a/docs/examples/data-table.md
+++ b/docs/examples/data-table.md
@@ -135,12 +135,18 @@ table.addEventListener( 'wpd-table-selection-change', ( e ) => {
 // Programmatic API
 table.select( 'alice@a.com' );
 table.deselect( 'alice@a.com' );
-table.selectAll();                          // multi only
+table.selectAll();                          // multi only — selects the VISIBLE rows
 table.clearSelection();
 table.selection = new Set( savedIds );      // bulk replace
 ```
 
+`selectAll()` (and the header select-all checkbox) selects the rows passing the active client-side filters — never rows a filter is currently hiding. The header checkbox tri-state follows the same rule: "checked" means every *visible* row is selected. Tables without client-side filters are unaffected.
+
 **Why `getRowId` matters:** when the user reloads `data` from the server, selections survive the refresh because they're keyed by stable id, not array index. Fall back to the default (index) only when rows have no natural identifier.
+
+**Ids must be unique across the whole data set.** If the table mixes entity kinds whose id sequences are independent (e.g. posts and comments carry numeric ids from different tables), qualify the id with the kind — ``getRowId = ( row ) => `${ row.type }:${ row.id }` `` — or two different rows will share one selection key and select (and act) together.
+
+**Destructive consumers: clear the selection when the data set changes.** Selection deliberately survives `data` reassignment, so ids from a previous page / search / filter linger invisibly. If your bulk actions consume `table.selection` (trash, delete, role changes…), call `table.clearSelection()` whenever the query changes — otherwise a forgotten off-page selection rides silently into the next action. See `src/comments-window/index.ts` and `src/posts-window/index.ts` for the pattern.
 
 ## Sticky columns and sticky header
 
@@ -326,7 +332,7 @@ If editing is the primary use case, request a first-class `column.editor` API �
 | `clearFilters()` | Drop every filter; emits `filter-change`. |
 | `clearSort()` | Drop the active sort; emits `sort-change`. |
 | `select(id)` / `deselect(id)` | Mutate the selection by id. |
-| `selectAll()` / `clearSelection()` | Bulk operations (multi-mode). |
+| `selectAll()` / `clearSelection()` | Bulk operations (multi-mode). `selectAll()` selects only the rows passing the active client-side filters. |
 | `selection` | Get/set the selection set. |
 | `selectedRows` | Resolved row objects matching `selection`. |
 | `getRowId` | Stable-id extractor (default: index). |
@@ -388,6 +394,8 @@ If editing is the primary use case, request a first-class `column.editor` API �
 - **Mixing `column.align: 'end'` with custom `render`.** Alignment applies to the cell, but if your renderer returns a `display: block`-ish element it may not pick up text-align. Either set `text-align: end` on the rendered element or wrap in a `<span>`.
 - **Editable cells losing focus.** Reassigning `table.data` on every keystroke triggers a full body repaint — the new `<input>` is a different element, so focus is lost. Commit on blur/Enter, or hold edits in a side buffer until save.
 - **Selection going stale on data refresh.** Without `getRowId`, ids are array indices — selections drift if rows reorder. Set `getRowId = ( row ) => row.id` whenever rows have a natural identifier.
+- **Colliding ids across mixed row kinds.** Two rows whose `getRowId` returns the same value are one row as far as selection is concerned — ticking one ticks both. Qualify the id (``( row ) => `${ row.type }:${ row.id }` ``) when a list mixes entities from independent id sequences.
+- **Stale selection feeding destructive bulk actions.** Selection survives `data` reassignment by design. If your bulk actions read `table.selection` (trash, delete…), call `clearSelection()` whenever the query (page, search, filter) changes, or resolve the selection against the currently rendered rows before acting.
 
 ## See also
 

--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -1560,10 +1560,12 @@ async function runBulk(
 			counts: result.counts,
 		} );
 		updateDockBadge( result.counts.pending );
-		// refresh() clears the table selection after the new data
-		// lands, so the acted-on ids can't linger as phantoms in the
-		// next bulk action; clearSelection() emits
-		// `wpd-table-selection-change`, which hides the bulk bar.
+		// Clear BEFORE the refresh, not just via refresh()'s own
+		// post-assignment clear: if the follow-up fetch fails, the
+		// bulk action still completed and the acted-on ids must not
+		// linger in the bulk bar. clearSelection() emits
+		// `wpd-table-selection-change`, which hides the bar.
+		state.table?.clearSelection();
 		await refresh( state.tab, { force: true } );
 	} catch ( err ) {
 		/* translators: %s: bulk action name (e.g. "approve", "spam"). */
@@ -1618,7 +1620,12 @@ function moveFocus( state: PanelState, direction: 1 | -1 ): void {
 	if ( ! nextId ) {
 		return;
 	}
-	state.table.selection = [ nextId ];
+	// clearSelection() + select() rather than assigning `selection`:
+	// the bare setter emits no `wpd-table-selection-change`, so the
+	// "N selected" chip and bulk bar would silently desync from the
+	// keyboard cursor — while a / s / d act on the real selection.
+	state.table.clearSelection();
+	state.table.select( nextId );
 	const tr = state.tableHost?.querySelector< HTMLElement >(
 		`tr[data-row-id="${ nextId }"]`,
 	);

--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -676,6 +676,13 @@ async function renderCommentsWindow( body: HTMLElement ): Promise< void > {
 			// into it; see the matching note in wirePanel().
 			await customElements.whenDefined( 'wpd-table' );
 			state.table.data = state.rows;
+			// `<wpd-table>` keeps its selection set across `data`
+			// reassignment, and bulk actions here act on the RAW
+			// selected ids (not resolved through the visible rows) —
+			// so ids from the previous result set would silently ride
+			// into the next moderation action. Every data replacement
+			// starts with a clean selection.
+			state.table.clearSelection();
 			updatePager( state );
 			if ( tab === 'pending' && ! opts.force ) {
 				if ( lastSeenPending === 0 ) {
@@ -1283,6 +1290,10 @@ async function reloadActivePanel( state: PanelState ): Promise< void > {
 		state.totalPages = result.totalPages;
 		await customElements.whenDefined( 'wpd-table' );
 		state.table.data = state.rows;
+		// See the matching note in refresh(): stale selected ids must
+		// not survive a data replacement (pagination, search, manual
+		// refresh) — they'd be swept into the next bulk action.
+		state.table.clearSelection();
 		updatePager( state );
 	} catch ( err ) {
 		// eslint-disable-next-line no-console
@@ -1549,16 +1560,11 @@ async function runBulk(
 			counts: result.counts,
 		} );
 		updateDockBadge( result.counts.pending );
+		// refresh() clears the table selection after the new data
+		// lands, so the acted-on ids can't linger as phantoms in the
+		// next bulk action; clearSelection() emits
+		// `wpd-table-selection-change`, which hides the bulk bar.
 		await refresh( state.tab, { force: true } );
-		// The acted-on rows have left (or changed in) the current tab, but
-		// `<wpd-table>` deliberately keeps its selection set across data
-		// refreshes (stale ids are only hidden at paint time — see
-		// wpd-table.ts). Left alone, those ids linger in `table.selection`,
-		// so the next row the user picks reads as "2 selected" and a
-		// follow-up bulk action operates on the phantom id too. Reset the
-		// selection here; clearSelection() emits `wpd-table-selection-change`,
-		// which refreshes the "N selected" chip and hides the bulk bar.
-		state.table?.clearSelection();
 	} catch ( err ) {
 		/* translators: %s: bulk action name (e.g. "approve", "spam"). */
 		const fallback = sprintf( __( 'Bulk %s failed.' ), action );

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -181,6 +181,11 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 	statusFilter.addEventListener( 'wpd-pick', ( ev: Event ) => {
 		const detail = ( ev as CustomEvent< { value: string } > ).detail;
 		state.statusFilter = detail?.value ?? '';
+		// `<wpd-table>` keeps selected ids across `data` reassignment,
+		// so a plugin ticked under the previous filter would stay
+		// selected while hidden — and ride silently into the next bulk
+		// action (bulk Delete included). Start each view clean.
+		table.clearSelection();
 		paintTable();
 	} );
 
@@ -195,6 +200,8 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		window.clearTimeout( searchDebounce );
 		searchDebounce = window.setTimeout( () => {
 			state.search = value;
+			// Same rationale as the status-filter handler above.
+			table.clearSelection();
 			paintTable();
 		}, 200 );
 	} );

--- a/src/plugins-window/installed-view.ts
+++ b/src/plugins-window/installed-view.ts
@@ -763,6 +763,17 @@ export function mountInstalledView( host: HTMLElement ): () => void {
 		}
 		table.data = filterRows( state.rows );
 		paintUpdateCount();
+		// Rebuild the bulk bar from the LIVE selection + fresh rows.
+		// Reassigning `data` emits no selection-change, so without
+		// this a background reload/mergeRow (broadcast-driven) leaves
+		// the bulk buttons holding closures over stale row snapshots —
+		// e.g. a "Delete N" button still offering a plugin that was
+		// just activated elsewhere. Repainting here re-resolves the
+		// selection against current state.rows every time the table
+		// repaints.
+		paintBulkBar(
+			Array.from( table.selection ?? [] ).map( String ),
+		);
 	}
 
 	/**

--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -2418,6 +2418,18 @@ export async function renderPostsWindow(
 		);
 	};
 
+	// A query change (page, search, status, sort, column filters)
+	// replaces the result set, but `<wpd-table>` keeps selected ids
+	// across `data` reassignment — and bulk actions consume the raw
+	// selection (`ctx.getSelectedIds()`), not the visible rows. Left
+	// alone, off-page ids ride silently into the next bulk action.
+	// Called from every query-changing handler; deliberately NOT from
+	// refresh() itself so background broadcast-driven reloads don't
+	// wipe a selection the user is in the middle of building.
+	const clearSelectionOnQueryChange = (): void => {
+		table.clearSelection();
+	};
+
 	const buildParams = (): PostsListParams => ( {
 		page: view.page,
 		perPage: view.perPage,
@@ -2534,6 +2546,7 @@ export async function renderPostsWindow(
 		const value = ( e as CustomEvent< { value: string } > ).detail?.value ?? '';
 		view.status = value;
 		goToFirstPage();
+		clearSelectionOnQueryChange();
 		void refresh();
 	} );
 
@@ -2548,6 +2561,7 @@ export async function renderPostsWindow(
 			}
 			view.searchDebounce = window.setTimeout( () => {
 				goToFirstPage();
+				clearSelectionOnQueryChange();
 				void refresh();
 			}, SEARCH_DEBOUNCE_MS );
 		},
@@ -2573,6 +2587,7 @@ export async function renderPostsWindow(
 		if ( target.closest( PREV ) ) {
 			if ( view.page > 1 ) {
 				view.page -= 1;
+				clearSelectionOnQueryChange();
 				void refresh();
 			}
 			return;
@@ -2580,6 +2595,7 @@ export async function renderPostsWindow(
 		if ( target.closest( NEXT ) ) {
 			if ( view.page < totalPages ) {
 				view.page += 1;
+				clearSelectionOnQueryChange();
 				void refresh();
 			}
 		}
@@ -2611,6 +2627,7 @@ export async function renderPostsWindow(
 		}
 		view.perPage = next;
 		goToFirstPage();
+		clearSelectionOnQueryChange();
 		void refresh();
 	} );
 
@@ -2629,6 +2646,7 @@ export async function renderPostsWindow(
 			view.orderby = mapColumnToOrderby( detail.sort.key );
 			view.order = detail.sort.direction;
 		}
+		clearSelectionOnQueryChange();
 		void refresh();
 	} );
 
@@ -2660,6 +2678,7 @@ export async function renderPostsWindow(
 		view.author = nextAuthor;
 		view.tag = nextTag;
 		view.page = 1;
+		clearSelectionOnQueryChange();
 		void refresh();
 	} );
 

--- a/src/posts-window/users-render.ts
+++ b/src/posts-window/users-render.ts
@@ -1017,12 +1017,23 @@ export async function renderUsersWindow(
 				if ( ! role ) {
 					return;
 				}
+				// Read the selection at CLICK time — the `ids` captured
+				// when the bulk bar was painted can go stale (a live
+				// `patchUserRow` can drop a row from the table without
+				// firing a selection-change repaint). The confirm count
+				// and the REST payload must describe the same set.
+				const targetIds = Array.from(
+					table.selection ?? [],
+				).map( ( id ) => Number( id ) );
+				if ( targetIds.length === 0 ) {
+					return;
+				}
 				const ok = await wpdConfirmGlobal( {
 					title: __( 'Change role for selected users?' ),
 					message: sprintf(
 						// translators: %1$d is a user count, %2$s is a role label.
 						__( "Set %1$d user(s)' role to %2$s?" ),
-						ids.length,
+						targetIds.length,
 						assignable[ role ],
 					),
 					confirmLabel: __( 'Set role' ),
@@ -1030,20 +1041,22 @@ export async function renderUsersWindow(
 				if ( ! ok ) {
 					return;
 				}
-				const out = await client.bulkSetRole( ids, role ).catch( ( err ) => {
-					notifyToast(
-						String( ( err as Error ).message ?? err ),
-						{ kind: 'error' },
-					);
-					return null;
-				} );
+				const out = await client
+					.bulkSetRole( targetIds, role )
+					.catch( ( err ) => {
+						notifyToast(
+							String( ( err as Error ).message ?? err ),
+							{ kind: 'error' },
+						);
+						return null;
+					} );
 				if ( ! out ) {
 					return;
 				}
 				const successes = Object.values( out.results ).filter(
 					( r ) => r.ok,
 				).length;
-				const failures = ids.length - successes;
+				const failures = targetIds.length - successes;
 				if ( successes > 0 ) {
 					notifyToast(
 						sprintf(

--- a/src/posts-window/users-render.ts
+++ b/src/posts-window/users-render.ts
@@ -1017,11 +1017,13 @@ export async function renderUsersWindow(
 				if ( ! role ) {
 					return;
 				}
-				// Read the selection at CLICK time — the `ids` captured
-				// when the bulk bar was painted can go stale (a live
-				// `patchUserRow` can drop a row from the table without
-				// firing a selection-change repaint). The confirm count
-				// and the REST payload must describe the same set.
+				// Read the selection at CLICK time rather than reusing
+				// the `ids` captured when the bulk bar was painted —
+				// defensive hygiene so the confirm count and the REST
+				// payload always describe the same set, independent of
+				// when the bar was last repainted or of future callers
+				// of the silent `selection` setter (which emits no
+				// selection-change).
 				const targetIds = Array.from(
 					table.selection ?? [],
 				).map( ( id ) => Number( id ) );

--- a/src/posts-window/users-render.ts
+++ b/src/posts-window/users-render.ts
@@ -867,6 +867,15 @@ export async function renderUsersWindow(
 		perPageEl.value = String( view.perPage );
 	}
 
+	// A query change (page, search, status, per-page) replaces the
+	// result set, but `<wpd-table>` keeps selected ids across `data`
+	// reassignment — and the bulk role apply consumes the raw
+	// selection. Left alone, off-page ids ride silently into the next
+	// bulk action. Called from every query-changing handler.
+	const clearSelectionOnQueryChange = (): void => {
+		table.clearSelection();
+	};
+
 	const indicator = root.querySelector< HTMLElement >( PAGE_INDICATOR );
 	const prevBtn = root.querySelector< HTMLButtonElement >( PREV );
 	const nextBtn = root.querySelector< HTMLButtonElement >( NEXT );
@@ -888,6 +897,7 @@ export async function renderUsersWindow(
 			const detail = ( e as CustomEvent< { value: string } > ).detail;
 			view.status = detail?.value ?? '';
 			view.page = 1;
+			clearSelectionOnQueryChange();
 			void refresh();
 		} );
 	}
@@ -902,6 +912,7 @@ export async function renderUsersWindow(
 			view.searchDebounce = window.setTimeout( () => {
 				view.search = searchEl.value.trim();
 				view.page = 1;
+				clearSelectionOnQueryChange();
 				void refresh();
 			}, SEARCH_DEBOUNCE_MS );
 		} );
@@ -942,6 +953,7 @@ export async function renderUsersWindow(
 		if ( Number.isFinite( n ) && n > 0 ) {
 			view.perPage = n;
 			view.page = 1;
+			clearSelectionOnQueryChange();
 			void refresh();
 		}
 	} );
@@ -1045,6 +1057,11 @@ export async function renderUsersWindow(
 				} else {
 					notifyToast( __( 'No users updated.' ), { kind: 'error' } );
 				}
+				// The action is complete — drop the selection so a second
+				// Apply can't silently re-target the same (possibly now
+				// off-page) user set. Emits selection-change, which hides
+				// the bulk bar.
+				table.clearSelection();
 				void refresh();
 			} );
 
@@ -1059,12 +1076,14 @@ export async function renderUsersWindow(
 	prevBtn?.addEventListener( 'click', () => {
 		if ( view.page > 1 ) {
 			view.page -= 1;
+			clearSelectionOnQueryChange();
 			void refresh();
 		}
 	} );
 	nextBtn?.addEventListener( 'click', () => {
 		if ( view.page < totalPages ) {
 			view.page += 1;
+			clearSelectionOnQueryChange();
 			void refresh();
 		}
 	} );

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -210,8 +210,10 @@ function itemsFingerprint( items: RecycleBinItem[] ): string {
 	// Sort first — server order can vary on ties (same `modified`
 	// timestamp). Comparing the sorted projection makes the
 	// fingerprint stable against ordering churn.
+	// Type-qualified like getRowId — post #5 and comment #5 are
+	// distinct items and must produce distinct fingerprint parts.
 	const parts = items
-		.map( ( i ) => `${ i.id }:${ i.deleted_at }` )
+		.map( ( i ) => `${ i.type }:${ i.id }:${ i.deleted_at }` )
 		.sort();
 	return parts.join( '|' );
 }
@@ -512,7 +514,14 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	currentRowActionPurge = ( ref ) => void handlePurge( [ ref ] );
 
 	table.columns = buildColumns();
-	table.getRowId = ( row ) => row.id;
+	// Composite identity — the bin mixes entity types whose numeric id
+	// sequences are independent (comments live in wp_comments; posts /
+	// pages / attachments in wp_posts; placements / folders / shortcuts
+	// in their own tables), so post #5 and comment #5 routinely coexist
+	// in the list. A bare `row.id` would give both rows the SAME
+	// selection key: ticking one would select — and bulk-purge — the
+	// other. Qualifying with the type makes identity unambiguous.
+	table.getRowId = ( row ) => `${ row.type }:${ row.id }`;
 	// No `fileTypeForRow` here on purpose: trashed items are
 	// for restoring, not for pinning to the desktop. The Pin to
 	// Desktop toolbar action still covers the rare "I want both
@@ -637,13 +646,15 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	};
 
 	// Each selection entry resolves back to the row so we know its
-	// `type` — bulk handlers send `[{id, type}]` to the server.
+	// `type` — bulk handlers send `[{id, type}]` to the server. Keys
+	// are the composite `type:id` produced by getRowId above; matching
+	// on the bare numeric id would fan one selected row out to every
+	// same-id row of another type.
 	const collectSelectedItems = (): RecycleBinItemRef[] => {
-		const sel = Array.from( table.selection ?? [] );
-		const idSet = new Set( sel.map( ( id ) => Number( id ) ) );
+		const sel = new Set( Array.from( table.selection ?? [], String ) );
 		const out: RecycleBinItemRef[] = [];
 		for ( const row of table.data ?? [] ) {
-			if ( idSet.has( row.id ) ) {
+			if ( sel.has( `${ row.type }:${ row.id }` ) ) {
 				out.push( { id: row.id, type: row.type } );
 			}
 		}
@@ -881,6 +892,11 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	root.querySelector( FILTER )?.addEventListener( 'wpd-pick', ( e: Event ) => {
 		const detail = ( e as CustomEvent< { value: string } > ).detail;
 		state.filter = ( detail?.value ?? '' ) as BinState[ 'filter' ];
+		// The result set is about to change wholesale. `<wpd-table>`
+		// keeps selected ids across `data` reassignment, so ids picked
+		// under the previous filter would linger invisibly and resurface
+		// checked when the user switches back. Start the new view clean.
+		table.clearSelection();
 		void refresh();
 	} );
 
@@ -892,6 +908,8 @@ export function renderRecycleBin( body: HTMLElement ): void {
 			window.clearTimeout( state.searchDebounce );
 		}
 		state.searchDebounce = window.setTimeout( () => {
+			// Same rationale as the type-filter handler above.
+			table.clearSelection();
 			void refresh();
 		}, 250 );
 	} );

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -585,18 +585,21 @@ export function renderRecycleBin( body: HTMLElement ): void {
 				table.data = items;
 				currentFingerprint = next;
 				cachedItems = items;
-				// Prune selection keys whose row left the list (purged /
-				// restored elsewhere, surfaced by a realtime refresh).
-				// `collectSelectedItems()` already ignores keys with no
-				// matching row, so this is not load-bearing for safety —
-				// it keeps the bulk bar's "N selected" count truthful
-				// instead of overcounting ghosts. Selections of rows
-				// still present are deliberately preserved.
-				const present = new Set(
-					items.map( ( i ) => `${ i.type }:${ i.id }` ),
+				// Prune selection keys whose row is no longer VISIBLE —
+				// it left the list (purged / restored elsewhere) or a
+				// data-driven change hid it behind an active column
+				// filter. `collectSelectedItems()` already resolves
+				// against the visible rows, so this is not load-bearing
+				// for safety — it keeps the bulk bar's "N selected"
+				// count truthful instead of overcounting ghosts.
+				// Selections of still-visible rows are preserved.
+				const visible = new Set(
+					( table.visibleRows ?? [] ).map(
+						( row ) => `${ row.type }:${ row.id }`,
+					),
 				);
 				const kept = Array.from( table.selection ?? [], String )
-					.filter( ( key ) => present.has( key ) );
+					.filter( ( key ) => visible.has( key ) );
 				if ( kept.length !== ( table.selection?.size ?? 0 ) ) {
 					table.selection = kept;
 				}
@@ -665,10 +668,16 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	// are the composite `type:id` produced by getRowId above; matching
 	// on the bare numeric id would fan one selected row out to every
 	// same-id row of another type.
+	//
+	// Resolve against the VISIBLE rows, not the full `data` buffer:
+	// a data-driven change (e.g. a realtime refresh replacing a row
+	// whose new title no longer matches an active Title column filter)
+	// can hide a selected row without any filter event firing — and a
+	// row the user cannot see must never ride into a purge.
 	const collectSelectedItems = (): RecycleBinItemRef[] => {
 		const sel = new Set( Array.from( table.selection ?? [], String ) );
 		const out: RecycleBinItemRef[] = [];
-		for ( const row of table.data ?? [] ) {
+		for ( const row of table.visibleRows ?? [] ) {
 			if ( sel.has( `${ row.type }:${ row.id }` ) ) {
 				out.push( { id: row.id, type: row.type } );
 			}
@@ -703,47 +712,59 @@ export function renderRecycleBin( body: HTMLElement ): void {
 		if ( refs.length === 0 ) {
 			return;
 		}
-		// First, restore the items so they exist again at their
-		// canonical post/comment id. Then place each on the
-		// desktop at staggered coordinates near the top-left so
-		// the user sees them all without overlap.
+		// Restore first so the items exist again at their canonical
+		// post/comment id, then place each on the desktop at staggered
+		// coordinates near the top-left so the user sees them all
+		// without overlap.
+		//
+		// One restore call PER REF, not one batched call: the bulk
+		// response's `ok` array carries bare numeric ids with no type,
+		// so with a mixed selection like post #5 + comment #5 a batch
+		// can't say WHICH #5 succeeded — a failed comment restore
+		// would be pinned anyway because the post's id matched. The
+		// server dispatches per item either way, so per-ref calls cost
+		// the same work and keep the success signal unambiguous.
 		const types = Array.from( new Set( refs.map( ( r ) => r.type ) ) );
-		try {
-			const restored = await restoreItems( refs );
-			const filesApi = ( window.wp as { desktop?: { files?: { rest?: { createPlacement: ( payload: unknown ) => Promise< unknown > } } } } | undefined )
-				?.desktop?.files?.rest;
-			if ( filesApi ) {
-				let i = 0;
-				for ( const ref of refs ) {
-					if ( ! restored.ok.includes( ref.id ) ) {
-						continue;
-					}
-					const desktopType = mapRecycleTypeToFileType( ref.type );
-					if ( ! desktopType ) {
-						continue;
-					}
-					try {
-						// Match the grid in src/desktop-files/grid.ts
-						// (padding 16 + col 96 + row 110, column-major
-						// fill). The math is duplicated because this
-						// bundle is a separate vite target and can't
-						// reach into the desktop bundle's internals.
-						await filesApi.createPlacement( {
-							type: desktopType,
-							ref: String( ref.id ),
-							x: 16 + ( i % 5 ) * 96,
-							y: 16 + Math.floor( i / 5 ) * 110,
-						} );
-					} catch ( err ) {
-						console.error( '[recycle-bin] pin-to-desktop placement failed', err );
-					}
-					i += 1;
-				}
+		const okIds: number[] = [];
+		const allErrors: Array< { id: number; code: string; message: string } > = [];
+		const filesApi = ( window.wp as { desktop?: { files?: { rest?: { createPlacement: ( payload: unknown ) => Promise< unknown > } } } } | undefined )
+			?.desktop?.files?.rest;
+		let placed = 0;
+		for ( const ref of refs ) {
+			let restored;
+			try {
+				restored = await restoreItems( [ ref ] );
+			} catch ( err ) {
+				console.error( '[recycle-bin] pin-to-desktop restore failed', err );
+				continue;
 			}
-			emitDoneEvent( 'restore', restored.ok, restored.errors, types, restored.ok );
-		} catch ( err ) {
-			console.error( '[recycle-bin] pin-to-desktop failed', err );
+			allErrors.push( ...restored.errors );
+			if ( ! restored.ok.includes( ref.id ) ) {
+				continue;
+			}
+			okIds.push( ref.id );
+			const desktopType = mapRecycleTypeToFileType( ref.type );
+			if ( ! filesApi || ! desktopType ) {
+				continue;
+			}
+			try {
+				// Match the grid in src/desktop-files/grid.ts
+				// (padding 16 + col 96 + row 110, column-major
+				// fill). The math is duplicated because this
+				// bundle is a separate vite target and can't
+				// reach into the desktop bundle's internals.
+				await filesApi.createPlacement( {
+					type: desktopType,
+					ref: String( ref.id ),
+					x: 16 + ( placed % 5 ) * 96,
+					y: 16 + Math.floor( placed / 5 ) * 110,
+				} );
+			} catch ( err ) {
+				console.error( '[recycle-bin] pin-to-desktop placement failed', err );
+			}
+			placed += 1;
 		}
+		emitDoneEvent( 'restore', okIds, allErrors, types, okIds );
 		table.clearSelection();
 		await refresh();
 	};

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -585,6 +585,21 @@ export function renderRecycleBin( body: HTMLElement ): void {
 				table.data = items;
 				currentFingerprint = next;
 				cachedItems = items;
+				// Prune selection keys whose row left the list (purged /
+				// restored elsewhere, surfaced by a realtime refresh).
+				// `collectSelectedItems()` already ignores keys with no
+				// matching row, so this is not load-bearing for safety —
+				// it keeps the bulk bar's "N selected" count truthful
+				// instead of overcounting ghosts. Selections of rows
+				// still present are deliberately preserved.
+				const present = new Set(
+					items.map( ( i ) => `${ i.type }:${ i.id }` ),
+				);
+				const kept = Array.from( table.selection ?? [], String )
+					.filter( ( key ) => present.has( key ) );
+				if ( kept.length !== ( table.selection?.size ?? 0 ) ) {
+					table.selection = kept;
+				}
 			} else {
 				// Fingerprint unchanged — keep DOM as-is, just
 				// refresh the cache reference so it survives
@@ -825,10 +840,15 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	};
 
 	const handleEmpty = async (): Promise< void > => {
+		// The server's empty endpoint purges the ENTIRE bin — it takes
+		// no type/search scope (see desktop_mode_recycle_bin_empty()).
+		// The confirm copy must say so; claiming "the current view"
+		// while a filter is active would purge items the user filtered
+		// out of sight.
 		const ok = await wpdConfirmGlobal( {
 			title: __( 'Empty bin?' ),
 			message: __(
-				'Empty the recycle bin? Every item visible in the current view will be permanently deleted.',
+				'Permanently delete ALL items in the recycle bin? This includes every type and any items hidden by the current filter or search. This cannot be undone.',
 			),
 			confirmLabel: __( 'Empty bin' ),
 			danger: true,
@@ -952,6 +972,16 @@ export function renderRecycleBin( body: HTMLElement ): void {
 
 	table.addEventListener( 'wpd-table-selection-change', () => {
 		refreshBulkBar();
+	} );
+
+	// The Title / "By" columns declare client-side `filter: 'text'`
+	// filters. A row ticked BEFORE the user types into one stays
+	// selected while hidden — and it's still in `table.data`, so
+	// `collectSelectedItems()` would sweep it into a bulk purge the
+	// user can't see coming. Same hygiene as the toolbar filter /
+	// search: any visibility change starts with a clean selection.
+	table.addEventListener( 'wpd-table-filter-change', () => {
+		table.clearSelection();
 	} );
 
 	// Default sort: most-recently-deleted first. Users can change it.

--- a/src/ui/components/wpd-table/wpd-table.test.ts
+++ b/src/ui/components/wpd-table/wpd-table.test.ts
@@ -508,6 +508,25 @@ describe( '<wpd-table>', () => {
 		expect( headerCb.indeterminate ).toBe( false );
 	} );
 
+	test( 'visibleRows returns only rows passing the active client-side filters', async () => {
+		host.innerHTML = `<wpd-table></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.data = sampleData;
+		await tick();
+		expect( table.visibleRows.length ).toBe( 3 );
+
+		table.filters = { role: 'admin' };
+		await tick();
+		expect( table.visibleRows.map( ( r ) => r.name ) ).toEqual( [
+			'Alice',
+			'Carol',
+		] );
+		// The full buffer is untouched.
+		expect( table.data.length ).toBe( 3 );
+	} );
+
 	test( 'header select-all tri-state tracks visible rows, not the full buffer', async () => {
 		host.innerHTML = `<wpd-table selectable="multi"></wpd-table>`;
 		await tick();

--- a/src/ui/components/wpd-table/wpd-table.test.ts
+++ b/src/ui/components/wpd-table/wpd-table.test.ts
@@ -477,6 +477,60 @@ describe( '<wpd-table>', () => {
 		expect( headerCb.indeterminate ).toBe( false );
 	} );
 
+	test( 'selectAll() selects only rows passing the active client-side filter', async () => {
+		host.innerHTML = `<wpd-table selectable="multi"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.getRowId = ( row ) => row.email;
+		table.data = sampleData;
+		// Only the two admins (Alice, Carol) are visible.
+		table.filters = { role: 'admin' };
+		await tick();
+
+		table.selectAll();
+		await tick();
+
+		// Bob is hidden by the filter — a destructive bulk action fed
+		// from this selection must not be able to reach him.
+		expect( Array.from( table.selection ).sort() ).toEqual( [
+			'alice@a.com',
+			'carol@c.com',
+		] );
+
+		// The header select-all reads checked (not indeterminate):
+		// every VISIBLE row is selected, which is what the checkbox
+		// claims to control.
+		const headerCb = table.shadowRoot!.querySelector(
+			'thead .select-all-checkbox',
+		) as HTMLInputElement;
+		expect( headerCb.checked ).toBe( true );
+		expect( headerCb.indeterminate ).toBe( false );
+	} );
+
+	test( 'header select-all tri-state tracks visible rows, not the full buffer', async () => {
+		host.innerHTML = `<wpd-table selectable="multi"></wpd-table>`;
+		await tick();
+		const table = host.querySelector( 'wpd-table' ) as WpdTable< User >;
+		table.columns = sampleColumns;
+		table.getRowId = ( row ) => row.email;
+		table.data = sampleData;
+		table.select( 'bob@b.com' );
+		await tick();
+
+		// Bob (editor) is selected, then a filter hides him. The two
+		// visible admins are unselected — the header checkbox must
+		// read fully unchecked, not indeterminate, because nothing
+		// the user can see is selected.
+		table.filters = { role: 'admin' };
+		await tick();
+		const headerCb = table.shadowRoot!.querySelector(
+			'thead .select-all-checkbox',
+		) as HTMLInputElement;
+		expect( headerCb.checked ).toBe( false );
+		expect( headerCb.indeterminate ).toBe( false );
+	} );
+
 	test( 'selectable=single: enforces at-most-one selected', async () => {
 		host.innerHTML = `<wpd-table selectable="single"></wpd-table>`;
 		await tick();

--- a/src/ui/components/wpd-table/wpd-table.ts
+++ b/src/ui/components/wpd-table/wpd-table.ts
@@ -573,14 +573,20 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 		this._syncSelectionDom( [ id ] );
 	}
 
-	/** Select every row currently in `data` (multi-mode only). */
+	/** Select every visible row — the rows passing the active client-side filters (multi-mode only). */
 	selectAll(): void {
 		if ( this._readSelectable() !== 'multi' ) {
 			return;
 		}
-		this._data.forEach( ( row, i ) =>
-			this._selection.add( this._getRowId( row, i ) ),
-		);
+		// Only the rows the user can see. Selecting the full `_data`
+		// buffer would let the header checkbox silently sweep rows a
+		// client-side column filter is hiding — and a destructive bulk
+		// action would then hit rows the user never saw. Tables without
+		// client-side filters are unaffected (`_filteredRows()` returns
+		// the full buffer).
+		for ( const { row, index } of this._filteredRows() ) {
+			this._selection.add( this._getRowId( row, index ) );
+		}
 		this._emitSelectionChange();
 		this._syncSelectionDom( 'all' );
 	}
@@ -661,11 +667,9 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 			'thead .select-all-checkbox',
 		);
 		if ( headerCb ) {
-			const total = this._data.length;
-			const selectedCount = this._countSelectedInData();
-			headerCb.checked = total > 0 && selectedCount === total;
-			headerCb.indeterminate =
-				selectedCount > 0 && selectedCount < total;
+			const { total, selected } = this._visibleSelectionStats();
+			headerCb.checked = total > 0 && selected === total;
+			headerCb.indeterminate = selected > 0 && selected < total;
 		}
 	}
 
@@ -1020,10 +1024,9 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 				cb.className = 'select-all-checkbox';
 				cb.setAttribute( 'data-noclick', '' );
 				cb.setAttribute( 'aria-label', 'Select all rows' );
-				const total = this._data.length;
-				const selectedCount = this._countSelectedInData();
-				cb.checked = total > 0 && selectedCount === total;
-				cb.indeterminate = selectedCount > 0 && selectedCount < total;
+				const { total, selected } = this._visibleSelectionStats();
+				cb.checked = total > 0 && selected === total;
+				cb.indeterminate = selected > 0 && selected < total;
 				cb.addEventListener( 'change', () => {
 					if ( cb.checked ) {
 						this.selectAll();
@@ -1588,14 +1591,23 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 		return Array.from( seen ).sort();
 	}
 
-	private _countSelectedInData(): number {
-		let n = 0;
-		this._data.forEach( ( row, i ) => {
-			if ( this._selection.has( this._getRowId( row, i ) ) ) {
-				n++;
+	/**
+	 * Selection stats over the VISIBLE (client-side-filtered) rows —
+	 * the same set `selectAll()` operates on. The header select-all
+	 * tri-state derives from these so "checked" always means "every
+	 * row the user can see is selected", even while ids of currently
+	 * hidden rows linger in the selection set.
+	 */
+	private _visibleSelectionStats(): { total: number; selected: number } {
+		let total = 0;
+		let selected = 0;
+		for ( const { row, index } of this._filteredRows() ) {
+			total++;
+			if ( this._selection.has( this._getRowId( row, index ) ) ) {
+				selected++;
 			}
-		} );
-		return n;
+		}
+		return { total, selected };
 	}
 
 	// ------------------------------------------------------------------

--- a/src/ui/components/wpd-table/wpd-table.ts
+++ b/src/ui/components/wpd-table/wpd-table.ts
@@ -418,6 +418,26 @@ export class WpdTable< T extends Record< string, unknown > = Record< string, unk
 		return out;
 	}
 
+	/**
+	 * The rows currently visible — i.e. passing the active client-side
+	 * filters, in data order. This is the row set `selectAll()` and
+	 * the header select-all tri-state operate on.
+	 *
+	 * Destructive bulk consumers should resolve `selection` against
+	 * THIS list rather than `data`: selection deliberately survives
+	 * `data` reassignment, and a data-driven change (a realtime
+	 * refresh editing a row so it no longer matches an active filter)
+	 * can hide a selected row without any filter event firing. Rows
+	 * the user cannot see must never be swept into a destructive
+	 * action. See `collectSelectedItems()` in src/recycle-bin/index.ts
+	 * for the canonical consumer.
+	 *
+	 * @since 0.9.4
+	 */
+	get visibleRows(): T[] {
+		return this._filteredRows().map( ( entry ) => entry.row );
+	}
+
 	/** Stable row-id extractor. Default is row index. */
 	get getRowId(): WpdTableGetRowId< T > {
 		return this._getRowId;

--- a/tests/vitest/recycle-bin-selection-identity.test.ts
+++ b/tests/vitest/recycle-bin-selection-identity.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Recycle Bin — selection identity across mixed entity types.
+ *
+ * Regression coverage for the cross-type id collision: the bin lists
+ * posts and comments together, and their numeric id sequences are
+ * independent (wp_posts vs wp_comments), so post #5 and comment #5
+ * routinely coexist. Row identity (and therefore `<wpd-table>`
+ * selection keys) must be type-qualified — with bare numeric ids,
+ * ticking the post's checkbox also selected the comment, and a bulk
+ * "Delete forever" permanently purged BOTH.
+ *
+ * The suite mounts the real `renderRecycleBin()` against the real
+ * `<wpd-table>` in jsdom, with the REST layer mocked at the module
+ * boundary, and drives the checkbox + bulk-purge flow end to end.
+ */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted( () => ( {
+	fetchList: vi.fn(),
+	purgeItems: vi.fn(),
+	restoreItems: vi.fn(),
+	emptyBin: vi.fn(),
+} ) );
+
+vi.mock( '../../src/recycle-bin/rest', () => mocks );
+vi.mock( '../../src/recycle-bin/badge', () => ( {
+	setRecycleBinBadge: vi.fn(),
+} ) );
+vi.mock( '../../src/recycle-bin/realtime', () => ( {
+	start: vi.fn(),
+	stop: vi.fn(),
+} ) );
+
+import { renderRecycleBin } from '../../src/recycle-bin/index';
+import type { WpdTable } from '../../src/ui/components/wpd-table/wpd-table';
+import type { RecycleBinItem } from '../../src/recycle-bin/rest';
+
+/** Flush pending promises + the microtask paint queue a few times. */
+const settle = async (): Promise< void > => {
+	for ( let i = 0; i < 6; i++ ) {
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+	}
+};
+
+const makeItem = (
+	overrides: Partial< RecycleBinItem > & Pick< RecycleBinItem, 'id' | 'type' | 'title' >,
+): RecycleBinItem => ( {
+	subtitle: '',
+	mime: '',
+	preview: '',
+	icon: '',
+	deleted_at: '2026-07-01T10:00:00',
+	deleted_by: 'admin',
+	deleted_by_id: 1,
+	can_restore: true,
+	can_purge: true,
+	edit_link: '',
+	...overrides,
+} );
+
+const TEMPLATE = `
+	<div data-desktop-mode-recycle-bin-root>
+		<wpd-segmented data-desktop-mode-recycle-bin-filter></wpd-segmented>
+		<wpd-text-field data-desktop-mode-recycle-bin-search></wpd-text-field>
+		<div data-desktop-mode-recycle-bin-bulk hidden>
+			<span data-desktop-mode-recycle-bin-count></span>
+			<button data-desktop-mode-recycle-bin-restore-selected></button>
+			<button data-desktop-mode-recycle-bin-pin-to-desktop></button>
+			<button data-desktop-mode-recycle-bin-purge-selected></button>
+		</div>
+		<button data-desktop-mode-recycle-bin-refresh></button>
+		<wpd-table data-desktop-mode-recycle-bin-table selectable="multi" loading></wpd-table>
+	</div>
+`;
+
+describe( 'recycle-bin selection identity', () => {
+	let body: HTMLElement;
+	let table: WpdTable< RecycleBinItem >;
+
+	beforeEach( async () => {
+		vi.clearAllMocks();
+		( window as unknown as { wp: unknown } ).wp = {
+			desktop: { confirm: async () => true },
+		};
+		mocks.fetchList.mockResolvedValue( {
+			items: [
+				makeItem( { id: 5, type: 'post', title: 'Trashed post' } ),
+				makeItem( { id: 5, type: 'comment', title: 'Trashed comment' } ),
+			],
+			total: 2,
+		} );
+		mocks.purgeItems.mockResolvedValue( { ok: [ 5 ], errors: [] } );
+		mocks.restoreItems.mockResolvedValue( { ok: [ 5 ], errors: [] } );
+
+		document.body.innerHTML = '';
+		body = document.createElement( 'div' );
+		body.innerHTML = TEMPLATE;
+		document.body.appendChild( body );
+
+		renderRecycleBin( body );
+		await settle();
+		table = body.querySelector( '[data-desktop-mode-recycle-bin-table]' ) as WpdTable< RecycleBinItem >;
+	} );
+
+	test( 'post #5 and comment #5 get distinct, type-qualified row ids', () => {
+		const rows = table.shadowRoot!.querySelectorAll< HTMLElement >(
+			'tbody tr[data-row-id]',
+		);
+		const ids = Array.from( rows, ( tr ) => tr.dataset.rowId ).sort();
+		expect( ids ).toEqual( [ 'comment:5', 'post:5' ] );
+	} );
+
+	test( 'selecting the post does NOT select the same-id comment', async () => {
+		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
+			'tr[data-row-id="post:5"] input.select-row-checkbox',
+		)!;
+		postCb.checked = true;
+		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await settle();
+
+		const commentRow = table.shadowRoot!.querySelector< HTMLElement >(
+			'tr[data-row-id="comment:5"]',
+		)!;
+		expect( commentRow.classList.contains( 'is-selected' ) ).toBe( false );
+		expect(
+			commentRow.querySelector< HTMLInputElement >(
+				'input.select-row-checkbox',
+			)!.checked,
+		).toBe( false );
+		expect( Array.from( table.selection ) ).toEqual( [ 'post:5' ] );
+	} );
+
+	test( 'bulk "Delete forever" purges only the selected {id, type} pair', async () => {
+		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
+			'tr[data-row-id="post:5"] input.select-row-checkbox',
+		)!;
+		postCb.checked = true;
+		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await settle();
+
+		body
+			.querySelector( '[data-desktop-mode-recycle-bin-purge-selected]' )!
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		await settle();
+
+		expect( mocks.purgeItems ).toHaveBeenCalledTimes( 1 );
+		expect( mocks.purgeItems ).toHaveBeenCalledWith( [
+			{ id: 5, type: 'post' },
+		] );
+	} );
+} );

--- a/tests/vitest/recycle-bin-selection-identity.test.ts
+++ b/tests/vitest/recycle-bin-selection-identity.test.ts
@@ -73,6 +73,8 @@ const TEMPLATE = `
 	</div>
 `;
 
+const createPlacement = vi.fn();
+
 describe( 'recycle-bin selection identity', () => {
 	let body: HTMLElement;
 	let table: WpdTable< RecycleBinItem >;
@@ -80,7 +82,10 @@ describe( 'recycle-bin selection identity', () => {
 	beforeEach( async () => {
 		vi.clearAllMocks();
 		( window as unknown as { wp: unknown } ).wp = {
-			desktop: { confirm: async () => true },
+			desktop: {
+				confirm: async () => true,
+				files: { rest: { createPlacement } },
+			},
 		};
 		mocks.fetchList.mockResolvedValue( {
 			items: [
@@ -196,5 +201,74 @@ describe( 'recycle-bin selection identity', () => {
 		expect( mocks.purgeItems ).toHaveBeenCalledWith( [
 			{ id: 5, type: 'post' },
 		] );
+	} );
+
+	test( 'a selected row hidden by a DATA-driven filter mismatch is not purgeable', async () => {
+		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
+			'tr[data-row-id="post:5"] input.select-row-checkbox',
+		)!;
+		postCb.checked = true;
+		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await settle();
+
+		// Programmatic filter assignment does NOT fire
+		// `wpd-table-filter-change` — this simulates a data-driven
+		// visibility change (e.g. a realtime refresh replaced the row
+		// with a title that no longer matches an already-active column
+		// filter). The selected post is now hidden but still in `data`.
+		table.filters = { title: 'comment' };
+		await settle();
+
+		body
+			.querySelector( '[data-desktop-mode-recycle-bin-purge-selected]' )!
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		await settle();
+
+		// Nothing visible was selected → no confirm, no purge.
+		expect( mocks.purgeItems ).not.toHaveBeenCalled();
+	} );
+
+	test( 'pin-to-desktop restores per ref and never places a same-id item whose restore failed', async () => {
+		// Post #5 restores fine; comment #5 is refused. A batched
+		// restore's bare-numeric `ok: [5]` could not tell these apart.
+		mocks.restoreItems.mockImplementation(
+			async ( refs: Array< { id: number; type: string } > ) =>
+				refs[ 0 ].type === 'post'
+					? { ok: [ 5 ], errors: [] }
+					: {
+						ok: [],
+						errors: [
+							{ id: 5, code: 'forbidden', message: 'nope' },
+						],
+					},
+		);
+
+		for ( const key of [ 'post:5', 'comment:5' ] ) {
+			const cb = table.shadowRoot!.querySelector< HTMLInputElement >(
+				`tr[data-row-id="${ key }"] input.select-row-checkbox`,
+			)!;
+			cb.checked = true;
+			cb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		}
+		await settle();
+
+		body
+			.querySelector( '[data-desktop-mode-recycle-bin-pin-to-desktop]' )!
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		await settle();
+
+		// One restore call per ref (unambiguous success signal)…
+		expect( mocks.restoreItems ).toHaveBeenCalledTimes( 2 );
+		expect( mocks.restoreItems ).toHaveBeenNthCalledWith( 1, [
+			{ id: 5, type: 'post' },
+		] );
+		expect( mocks.restoreItems ).toHaveBeenNthCalledWith( 2, [
+			{ id: 5, type: 'comment' },
+		] );
+		// …and only the successfully restored post gets a tile.
+		expect( createPlacement ).toHaveBeenCalledTimes( 1 );
+		expect( createPlacement ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'post', ref: '5' } ),
+		);
 	} );
 } );

--- a/tests/vitest/recycle-bin-selection-identity.test.ts
+++ b/tests/vitest/recycle-bin-selection-identity.test.ts
@@ -130,6 +130,55 @@ describe( 'recycle-bin selection identity', () => {
 		expect( Array.from( table.selection ) ).toEqual( [ 'post:5' ] );
 	} );
 
+	test( 'changing a client-side column filter clears the selection', async () => {
+		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
+			'tr[data-row-id="post:5"] input.select-row-checkbox',
+		)!;
+		postCb.checked = true;
+		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await settle();
+		expect( table.selection.size ).toBe( 1 );
+
+		// Type into the Title column filter — the previously selected
+		// row may now be hidden while still present in `data`, so the
+		// app must drop the selection rather than let it ride into a
+		// bulk purge the user can't see.
+		const input = table.shadowRoot!.querySelector< HTMLInputElement >(
+			'.filter-input',
+		)!;
+		input.value = 'comment';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		await settle();
+
+		expect( table.selection.size ).toBe( 0 );
+	} );
+
+	test( 'a refresh prunes selection keys whose row left the list', async () => {
+		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
+			'tr[data-row-id="post:5"] input.select-row-checkbox',
+		)!;
+		postCb.checked = true;
+		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await settle();
+		expect( Array.from( table.selection ) ).toEqual( [ 'post:5' ] );
+
+		// Someone else purges post #5; a realtime-driven refresh
+		// replaces the list. The ghost key must not linger in the
+		// selection (it would overcount the bulk bar).
+		mocks.fetchList.mockResolvedValue( {
+			items: [
+				makeItem( { id: 5, type: 'comment', title: 'Trashed comment' } ),
+			],
+			total: 1,
+		} );
+		body
+			.querySelector( '[data-desktop-mode-recycle-bin-refresh]' )!
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		await settle();
+
+		expect( table.selection.size ).toBe( 0 );
+	} );
+
 	test( 'bulk "Delete forever" purges only the selected {id, type} pair', async () => {
 		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
 			'tr[data-row-id="post:5"] input.select-row-checkbox',


### PR DESCRIPTION
## Context

A user selected a comment in the native Comments app, hit Trash, and a *different* comment was trashed. The immediate comments bug was fixed in #293 (clear selection after bulk moderation), but an audit of every native app found the same bug class alive in three forms — including a critical one in the Recycle Bin. This PR fixes all of them in one pass.

## Fixes

### 1. Recycle Bin — cross-type numeric-id collision (critical)

`src/recycle-bin/index.ts` keyed rows by bare `row.id`, but the bin lists posts/pages/attachments (wp_posts ids) alongside comments (wp_comments ids) — so **post #5 and comment #5 shared one selection key**. Ticking the post also selected the comment, and bulk "Delete forever" permanently purged both. Realtime refreshes could even slot a colliding item *under* an existing selection.

Row identity is now the composite `type:id` throughout: `getRowId`, `collectSelectedItems()` (which builds the `[{id, type}]` REST payload), and `itemsFingerprint()`. The type filter and search also clear the selection when they replace the view.

### 2. `<wpd-table>` — select-all swept rows hidden by client-side filters

`selectAll()` iterated the full `data` buffer, ignoring live column filters. In the Recycle Bin (Title / "By" column filters): filter 200 rows down to 2, click select-all intending "these 2", Delete forever → all 200 purged, 198 of them invisible.

`selectAll()` and the header checkbox tri-state now operate on the **visible (filtered) row set** — "checked" means "every row the user can see is selected". Tables without client-side filters are unaffected.

### 3. Selection hygiene — stale ids riding into bulk actions

`<wpd-table>` deliberately keeps its selection across `data` reassignment, so ids selected on a previous page / search / filter lingered invisibly and were swept into the next bulk action:

- **Comments** (this is the remaining path for the originally-reported bug on post-#293 builds): selection now clears on every panel data replacement — pagination, search, per-page, manual refresh, heartbeat reload, tab re-activation.
- **Posts & Pages** (same code, both modes): cleared on status/search/pagination/per-page/sort/author-tag-filter changes. Deliberately *not* cleared inside `refresh()` itself, so background broadcast-driven reloads don't wipe an in-progress selection.
- **Users**: cleared on status/search/pagination/per-page changes *and* after the bulk role apply (previously never cleared anywhere).
- **Plugins**: cleared on status-filter/search changes — a plugin ticked under one filter could ride hidden into bulk **Delete**.

## Audited and confirmed safe (no changes needed)

My WordPress (per-tile id closures, id-keyed removal), media grid, desktop files, sticky notes, tag cloud / category mindmap term actions, user-edit window, plugins per-row actions + update queue, and all REST layers (no index-based request/response mapping anywhere).

## Tests

- `wpd-table.test.ts`: `selectAll()` with an active filter selects only visible rows; header tri-state tracks visible rows when a selected row is filtered out.
- New `tests/vitest/recycle-bin-selection-identity.test.ts`: mounts the real `renderRecycleBin()` + `<wpd-table>` in jsdom with mocked REST; asserts post #5 / comment #5 get distinct `type:id` row keys, selecting one does not select the other, and bulk purge sends exactly `[{id: 5, type: 'post'}]`.
- Full suite: 193 files / 1816 tests green; lint + typecheck + build clean.

## Docs

`docs/examples/data-table.md`: documented the visible-rows semantics of `selectAll()`, the "ids must be unique across mixed row kinds" rule, and the clear-selection-on-query-change pattern for destructive consumers (Selection section, methods table, Common pitfalls).

## Manual test plan (on :8889)

1. Trash a post and a comment that share the same numeric id (or just any post + any comment). Open Recycle Bin → tick only the post → only that row shows checked → Delete forever → confirm dialog says 1 item → only the post is purged.
2. Recycle Bin: type in the Title column filter, click the header select-all → only the visible rows select.
3. Comments: select a comment on page 1 → Next page → bulk bar is hidden, nothing pre-selected → select one → Trash → only that one is trashed.
4. Posts/Pages/Users/Plugins: select rows, then change search/filter/page → selection resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-349-1184c6beeadd6dd80bb187a684a5c80377f33e24.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->