### PR TITLE
Fix hardcoded plurals in count labels (use _n())

### DIFF
--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -21,7 +21,7 @@
  * @since 0.8.3
  */
 
-import { __, sprintf } from '../i18n';
+import { __, _n, sprintf } from '../i18n';
 import { trackedFetch } from '../tracked-fetch';
 import { applyAvatarSrc } from '../ui/util/avatar-resolve';
 // Side-effect imports — register the `<wpd-*>` components this
@@ -1078,7 +1078,11 @@ function buildColumns(
 				tog.className = 'desktop-mode-comments__replies-toggle';
 				tog.textContent = sprintf(
 					/* translators: %d: number of direct replies. */
-					__( '+ %d replies' ),
+					_n(
+						'+ %d reply',
+						'+ %d replies',
+						row.desktop_mode_replies_count,
+					),
 					row.desktop_mode_replies_count,
 				);
 				tog.addEventListener( 'click', ( e ) => {

--- a/src/content-graph/panel.ts
+++ b/src/content-graph/panel.ts
@@ -23,7 +23,7 @@
  * @since 0.8.2
  */
 
-import { __, sprintf } from '../i18n';
+import { __, _n, sprintf } from '../i18n';
 import {
 	fetchCommentStats,
 	fetchTermStats,
@@ -1159,7 +1159,7 @@ export function renderPanel(
 			'desktop-mode-content-graph__panel-section-label';
 		labelEl.textContent = sprintf(
 			/* translators: %d: number of comment replies. */
-			__( 'Replies (%d)' ),
+			_n( 'Reply (%d)', 'Replies (%d)', replies.length ),
 			replies.length,
 		);
 		wrap.appendChild( labelEl );

--- a/src/posts-window/categories-mindmap.ts
+++ b/src/posts-window/categories-mindmap.ts
@@ -24,7 +24,7 @@
  * @since 0.8.0
  */
 
-import { __, sprintf } from '../i18n';
+import { __, _n, sprintf } from '../i18n';
 import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import { type PostsWindowClient, type TermRow } from './rest';
@@ -2544,7 +2544,11 @@ export async function mountCategoriesMindmap(
 		meta.className = 'wpd-mindmap__sidebar-meta';
 		meta.textContent = sprintf(
 			/* translators: %d: post count. */
-			__( '%d posts in this category.' ),
+			_n(
+				'%d post in this category.',
+				'%d posts in this category.',
+				node.count,
+			),
 			node.count,
 		);
 		sidebar.appendChild( meta );

--- a/src/posts-window/categories-mindmap.ts
+++ b/src/posts-window/categories-mindmap.ts
@@ -2983,7 +2983,7 @@ export async function mountCategoriesMindmap(
 			countEl.className = 'wpd-mindmap__search-meta';
 			countEl.textContent = sprintf(
 				/* translators: %d: number of posts assigned to a category. */
-				__( '%d posts' ),
+				_n( '%d post', '%d posts', n.count ),
 				n.count,
 			);
 			btn.appendChild( nameEl );

--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -21,7 +21,7 @@
  * @since 0.8.0
  */
 
-import { __, sprintf } from '../i18n';
+import { __, _n, sprintf } from '../i18n';
 import { trackedFetch } from '../tracked-fetch';
 import { applyAvatarSrc } from '../ui/util/avatar-resolve';
 import { showPostsIntroDialog } from './intro-dialog';
@@ -821,7 +821,7 @@ function buildCommentsCell( row: PostListItem ): HTMLElement {
 	cell.setAttribute(
 		'aria-label',
 		// translators: %d is the comment count for a row.
-		`${ sprintf( __( '%d comments' ), count ) }`,
+		`${ sprintf( _n( '%d comment', '%d comments', count ), count ) }`,
 	);
 	return cell;
 }

--- a/src/posts-window/tags-cloud.ts
+++ b/src/posts-window/tags-cloud.ts
@@ -29,7 +29,7 @@
  * @since 0.7.2
  */
 
-import { __, sprintf } from '../i18n';
+import { __, _n, sprintf } from '../i18n';
 import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import {
@@ -1861,7 +1861,11 @@ export async function mountTagsCloud(
 		meta.className = 'wpd-tagcloud__sidebar-meta';
 		meta.textContent = sprintf(
 			/* translators: %d: post count. */
-			__( '%d posts tagged with this.' ),
+			_n(
+				'%d post tagged with this.',
+				'%d posts tagged with this.',
+				box.count,
+			),
 			box.count,
 		);
 		sidebar.appendChild( meta );

--- a/src/posts-window/tags-cloud.ts
+++ b/src/posts-window/tags-cloud.ts
@@ -2331,7 +2331,7 @@ export async function mountTagsCloud(
 			countEl.className = 'wpd-tagcloud__search-meta';
 			countEl.textContent = sprintf(
 				/* translators: %d: number of posts assigned to a tag. */
-				__( '%d posts' ),
+				_n( '%d post', '%d posts', t.count ),
 				t.count,
 			);
 			btn.appendChild( nameEl );

--- a/src/posts-window/user-edit-render.ts
+++ b/src/posts-window/user-edit-render.ts
@@ -1052,7 +1052,7 @@ function buildAsideStatGrid( data: UserInsightsPayload ): HTMLElement {
 	if ( stats.daysSinceRegistration !== null ) {
 		memberValue = sprintf(
 			// translators: %d is a number of days.
-			__( '%d days' ),
+			_n( '%d day', '%d days', stats.daysSinceRegistration ),
 			stats.daysSinceRegistration,
 		);
 	}

--- a/src/posts-window/user-edit-render.ts
+++ b/src/posts-window/user-edit-render.ts
@@ -21,7 +21,7 @@
  * @since 0.8.1
  */
 
-import { __, sprintf } from '../i18n';
+import { __, _n, sprintf } from '../i18n';
 import { joinRestUrl } from '../rest-url';
 import { trackedFetch } from '../tracked-fetch';
 import { applyAvatarSrc } from '../ui/util/avatar-resolve';
@@ -1017,13 +1017,16 @@ function buildAsideStatGrid( data: UserInsightsPayload ): HTMLElement {
 	};
 
 	const stats = data.stats;
-	grid.appendChild(
-		tile(
-			__( 'Posts' ),
-			String( stats.posts ),
+	let postsSub: string | undefined;
+	if ( stats.pages > 0 ) {
+		postsSub = sprintf(
 			// translators: %d is a count of pages.
-			stats.pages > 0 ? sprintf( __( '+ %d pages' ), stats.pages ) : undefined,
-		),
+			_n( '+ %d page', '+ %d pages', stats.pages ),
+			stats.pages,
+		);
+	}
+	grid.appendChild(
+		tile( __( 'Posts' ), String( stats.posts ), postsSub ),
 	);
 	let commentsSub: string | undefined;
 	if ( stats.commentsReceived > 0 ) {


### PR DESCRIPTION
## Summary

Several count labels across the Desktop Mode UI were built with a single hardcoded plural string via `__()` + `sprintf()` instead of `_n()`, so at a count of **1** they render ungrammatically — e.g. "1 posts in this category.", "1 replies", "Replies (1)". This switches each to `_n( singular, plural, number )`.

Spans the **Posts** window (Categories, Tags, post list, Profile), the **Comments** window, and the **Content Graph** — same defect class throughout. One fix per commit.

Fixes #350.

## Changes

| File | String | Surface |
|---|---|---|
| `src/posts-window/categories-mindmap.ts` | `%d posts in this category.` | Categories — node sidebar meta |
| `src/posts-window/categories-mindmap.ts` | `%d posts` | Categories — search-result count |
| `src/posts-window/tags-cloud.ts` | `%d posts tagged with this.` | Tags — tag sidebar meta |
| `src/posts-window/tags-cloud.ts` | `%d posts` | Tags — search-result count |
| `src/posts-window/index.ts` | `%d comments` | Post list — comment-cell aria-label |
| `src/comments-window/index.ts` | `+ %d replies` | Comments — replies toggle |
| `src/content-graph/panel.ts` | `Replies (%d)` | Content Graph — panel section label |
| `src/posts-window/user-edit-render.ts` | `+ %d pages` | Profile — Posts stats tile sub-label |
| `src/posts-window/user-edit-render.ts` | `%d days` | Profile — "member for" stat |

The Content Graph label now matches the already-correct `_n( 'Reply (%d)', 'Replies (%d)', … )` in `src/my-wordpress/index.ts`.

## Out of scope

Non-pluralizing / abbreviated `%d` strings are correct as-is and left untouched: `%d selected`, `%d published`, `%d received`, `%d total`, `Approved %d.` (no noun); `%d KB`, `%d min/h/d ago`, `%d ★`, `%d / 100` (abbreviations/scores); `#%d`, `Desktop %d`, `%d:00` (IDs/numbers); and the intentional `%d post(s)` / `%d item(s)` "(s)" shorthand. PHP `%d` strings are HTTP/error codes, not counts.

## Testing

- `npm run build` — clean
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:js` — 1821 passed

No POT/PO regeneration (batched i18n step, per contributor guide).
