### PR TITLE
Snow wallpaper + per-wallpaper settings dialogs (renderConfig)

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -245,6 +245,59 @@
 }
 
 /*
+ * Wallpaper config slot — hosts the "Wallpaper settings" button when
+ * the ACTIVE wallpaper ships a `renderConfig` dialog. Same 0fr → 1fr
+ * collapse as the slots above; TS drives `[data-expanded]` from
+ * `syncWallpaperConfigButton()`.
+ */
+.desktop-mode-os-settings__wallpaper-config-slot {
+	display: grid;
+	grid-template-rows: 0fr;
+	margin-top: 0;
+	opacity: 0;
+	transition:
+		grid-template-rows 0.25s cubic-bezier(0.2, 0, 0.2, 1),
+		margin-top 0.25s cubic-bezier(0.2, 0, 0.2, 1),
+		opacity 0.2s ease;
+}
+
+.desktop-mode-os-settings__wallpaper-config-slot[data-expanded="true"] {
+	grid-template-rows: 1fr;
+	margin-top: 12px;
+	opacity: 1;
+}
+
+.desktop-mode-os-settings__wallpaper-config-slot-inner {
+	overflow: hidden;
+	min-height: 0;
+}
+
+.desktop-mode-os-settings__wallpaper-config wpd-icon {
+	margin-inline-end: 4px;
+}
+
+/*
+ * Wallpaper config dialog body — the container `renderConfig` renders
+ * into inside the `<wpd-modal>`. A simple vertical rhythm; each
+ * `<wpd-*>` field owns its own label / control styling. The critical
+ * column rules are ALSO inlined by the dialog opener (long-lived
+ * sessions can lazy-load the dialog with a stylesheet that predates
+ * this block); keep the two in sync.
+ */
+.desktop-mode-os-settings__wallpaper-config-form {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	min-width: 0;
+}
+
+/* Bare buttons in a config form (Reset to defaults and friends) are
+ * actions, not fields — don't stretch them to the column width. */
+.desktop-mode-os-settings__wallpaper-config-form > wpd-button {
+	align-self: flex-start;
+}
+
+/*
  * Custom-gradient editor fills the inner slot. Kept as a separate
  * class (vs. scoping to __editor-slot-inner) so a future plugin
  * renderEditor can opt out of these per-control rules.
@@ -587,6 +640,7 @@
  * --------------------------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {
 	.desktop-mode-os-settings__editor-slot,
+	.desktop-mode-os-settings__wallpaper-config-slot,
 	.desktop-mode-os-settings__upload-tile,
 	.desktop-mode-os-settings__library-tile,
 	wpd-swatch {

--- a/docs/examples/register-wallpaper.md
+++ b/docs/examples/register-wallpaper.md
@@ -212,6 +212,63 @@ wp.hooks.addFilter(
 
 ---
 
+## Recipe 5 — A settings dialog with persisted values *(since 0.9.5)*
+
+`renderEditor` (Recipe 3) is an inline panel and owns its own state. For a fuller settings form with **persistence for free**, ship `renderConfig` instead: OS Settings shows a "Wallpaper settings" button for your wallpaper (only when selected, only because you opted in), clicking it opens a `<wpd-modal>` with your form inside, and `ctx.setSettings()` saves through the user's OS Settings (localStorage + user meta — values follow the user across devices).
+
+Every wallpaper context (`mount`, `renderPreview`, `renderEditor`, `renderConfig`) reads the persisted bag back as `ctx.settings`. Each `setSettings` call also fires the `desktop-mode.wallpaper.settings-changed` action with the full post-merge bag, so a mounted wallpaper applies edits live — the dialog doubles as a tuning panel.
+
+```javascript
+window.desktopModeWallpapers[ 'my-plugin/aquarium' ] = {
+    id: 'my-plugin/aquarium',
+    label: 'Aquarium',
+    type: 'canvas',
+    preview: '#04263b',
+    needs: [ 'pixijs' ],
+
+    mount: async ( container, ctx ) => {
+        // Untrusted read-back: clamp to your defaults.
+        const scene = await swim( container, Number( ctx.settings.fishCount ) || 12 );
+
+        const onSettings = ( detail ) => {
+            if ( detail?.id !== 'my-plugin/aquarium' ) {
+                return;
+            }
+            scene.setFishCount( Number( detail.settings.fishCount ) || 12 );
+        };
+        wp.hooks.addAction(
+            'desktop-mode.wallpaper.settings-changed',
+            'my-plugin/aquarium-live',
+            onSettings
+        );
+        return () => {
+            wp.hooks.removeAction(
+                'desktop-mode.wallpaper.settings-changed',
+                'my-plugin/aquarium-live'
+            );
+            scene.destroy();
+        };
+    },
+
+    renderConfig: ( container, ctx ) => {
+        const field = document.createElement( 'wpd-range-field' );
+        field.setAttribute( 'label', 'Fish' );
+        field.setAttribute( 'min', '1' );
+        field.setAttribute( 'max', '60' );
+        field.setAttribute( 'value', String( Number( ctx.settings.fishCount ) || 12 ) );
+        field.addEventListener( 'wpd-range-change', ( e ) => {
+            ctx.setSettings( { fishCount: e.detail.value } );  // persists + fires the action
+        } );
+        container.appendChild( field );
+        return () => {};
+    },
+};
+```
+
+Scalar values only (`string | number | boolean`) — the server-side sanitizer drops anything else, and caps the bag at 32 keys (strings at 256 chars). The built-in Snow wallpaper (`wp-snow`, `src/plugins/snow-wallpaper/`) is the in-tree reference: wind, snowflake count, flake size, and backdrop colour, all live-applied.
+
+---
+
 ## Removing or reordering built-ins
 
 The `desktop-mode.wallpapers` filter receives the full list — add, remove, or reorder in one shot.
@@ -238,5 +295,5 @@ The one rule worth stealing: **fetch through the framework, never raw `fetch()`*
 ## Reference
 
 - [Hooks catalog](../javascript-reference.md#4-hooks--desktop-mode) — every `desktop-mode.*` hook with its payload shape.
-- [Wallpaper registration API](../javascript-reference.md#5-wallpaper-registration-api) — full `WallpaperDef` type, including `renderPreview` / `previewParams`.
+- [Wallpaper registration API](../javascript-reference.md#5-wallpaper-registration-api) — full `WallpaperDef` type, including `renderPreview` / `previewParams` / `renderConfig`.
 - [The Living Tree — algorithm definition](../living-tree-algorithm.md) — a worked canvas-wallpaper spec that consumes REST site data.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3220,6 +3220,7 @@ if ( wp.desktop.isReady() ) {
 | `desktop-mode.wallpaper.mount-failed` | action | Stable | `{ id, error }` |
 | `desktop-mode.wallpaper.visibility` | action | Stable | `{ id, state: 'visible' \| 'hidden' }` |
 | `desktop-mode.wallpaper.preview-params` | filter | Experimental *(since 0.9.5)* | `Record<string, unknown> → Record<string, unknown>`, second arg `wallpaperId` — override a wallpaper's live-preview parameters before its `renderPreview` runs |
+| `desktop-mode.wallpaper.settings-changed` | action | Experimental *(since 0.9.5)* | `{ id, settings }` — the user edited the wallpaper's settings through its `renderConfig` dialog; `settings` is the full post-merge bag. Mounted wallpapers live-apply from here |
 | `desktop-mode.wallpaper.surfaces` | filter | Stable | `WallpaperSurface[] → WallpaperSurface[]` — see below |
 
 #### Arrange & Overview
@@ -3337,7 +3338,7 @@ Equivalent legacy entry point: `wp.desktop.widgetLayer?.redock( id )`. New code 
 | `desktop-mode.widget.added` | action | Stable | `{ id }` — user added via the picker |
 | `desktop-mode.widget.removed` | action | Stable | `{ id }` — user removed via the card's × |
 
-The `ctx` argument exposes `{ id, pluginUrl, storage }` — `storage` is a per-widget key/value store auto-namespaced in `localStorage` (`desktop-mode.widget.<id>.<key>`), so two widgets can both persist a `layout` key without colliding. (Canvas wallpapers receive a different context: `{ id, pluginUrl, prefersReducedMotion, visible }`.) Enabled widgets persist per-user in `localStorage` (`desktop-mode-widgets`).
+The `ctx` argument exposes `{ id, pluginUrl, storage }` — `storage` is a per-widget key/value store auto-namespaced in `localStorage` (`desktop-mode.widget.<id>.<key>`), so two widgets can both persist a `layout` key without colliding. (Canvas wallpapers receive a different context: `{ id, pluginUrl, prefersReducedMotion, visible, settings }`.) Enabled widgets persist per-user in `localStorage` (`desktop-mode-widgets`).
 
 #### Window lifecycle
 
@@ -3624,6 +3625,7 @@ type WallpaperDef =
           renderEditor?: WallpaperEditor;
           renderPreview?: WallpaperPreview;              // Live tile preview (since 0.9.5)
           previewParams?: Record<string, unknown>;       // Preview defaults (since 0.9.5)
+          renderConfig?: WallpaperConfig;                // Settings dialog (since 0.9.5)
       }
     | {
           type: 'canvas';
@@ -3636,6 +3638,7 @@ type WallpaperDef =
           renderEditor?: WallpaperEditor;
           renderPreview?: WallpaperPreview;              // Live tile preview (since 0.9.5)
           previewParams?: Record<string, unknown>;       // Preview defaults (since 0.9.5)
+          renderConfig?: WallpaperConfig;                // Settings dialog (since 0.9.5)
       };
 
 interface WallpaperContext {
@@ -3643,6 +3646,7 @@ interface WallpaperContext {
     pluginUrl: string;                // no trailing slash
     prefersReducedMotion: boolean;
     visible: boolean;                 // current document visibility
+    settings: Record<string, unknown>; // persisted per-wallpaper settings (since 0.9.5)
 }
 
 // Passed to renderPreview (since 0.9.5).
@@ -3653,6 +3657,14 @@ interface WallpaperPreviewContext extends WallpaperContext {
 }
 
 type WallpaperPreview = ( container: HTMLElement, ctx: WallpaperPreviewContext ) =>
+        ( () => void ) | Promise<() => void>;
+
+// Passed to renderConfig (since 0.9.5).
+interface WallpaperConfigContext extends WallpaperContext {
+    setSettings( partial: Record<string, string | number | boolean> ): void;
+}
+
+type WallpaperConfig = ( container: HTMLElement, ctx: WallpaperConfigContext ) =>
         ( () => void ) | Promise<() => void>;
 ```
 
@@ -3801,6 +3813,68 @@ wp.hooks.addFilter(
 ```
 
 The same fields work on `type: 'css'` defs too (rarely needed — a CSS wallpaper's `preview` string usually IS the wallpaper).
+
+### `renderConfig` — the wallpaper settings dialog *(Experimental, since 0.9.5)*
+
+Wallpapers with real tunables (particle counts, palettes, physics) can ship a `renderConfig` callback. When the wallpaper is the active selection in OS Settings, a **"Wallpaper settings"** button appears below the picker grid; clicking it opens a `<wpd-modal>` whose body is handed to your callback. Wallpapers without `renderConfig` show no button — the surface is invisible unless you opt in.
+
+Contrast with `renderEditor`: the editor is an always-visible inline panel below the grid (right for one or two controls the user plays with constantly, like the custom gradient's colours); `renderConfig` is a modal for a fuller settings form that would crowd the panel.
+
+The shell owns everything except the form:
+
+- **Chrome** — title (`<label> settings`), focus trap, ESC / click-outside, a Done button. Your callback renders only the controls, and returns a teardown (sync or via Promise) that runs when the dialog closes.
+- **Persistence** — `ctx.setSettings( partial )` merges into the wallpaper's settings bag and saves through the normal OS Settings pipeline (localStorage + debounced user-meta sync, so values follow the user across devices). Scalar values only (`string | number | boolean`) — anything else is dropped by the server-side sanitizer. The bag round-trips through PHP capped at 64 wallpapers × 32 keys, strings at 256 chars.
+- **Read-back** — every wallpaper context (`mount`, `renderPreview`, `renderEditor`, `renderConfig`) carries `ctx.settings`: the persisted bag, empty object when never configured. Treat the values as untrusted; clamp to your own defaults.
+- **Live apply** — each `setSettings` fires the `desktop-mode.wallpaper.settings-changed` action with `{ id, settings }` (the full post-merge bag). A mounted wallpaper subscribes and applies the change in place — no remount, so the dialog behaves as a live tuning panel.
+
+```javascript
+window.desktopModeWallpapers[ 'my-plugin/aquarium' ] = {
+    id: 'my-plugin/aquarium',
+    label: 'Aquarium',
+    type: 'canvas',
+    preview: '#03252e',
+    needs: [ 'pixijs' ],
+
+    mount: async ( container, ctx ) => {
+        const fishCount = Number( ctx.settings.fishCount ) || 12;
+        const scene = await buildScene( container, fishCount );
+
+        const onSettings = ( detail ) => {
+            if ( detail?.id !== 'my-plugin/aquarium' ) {
+                return;
+            }
+            scene.setFishCount( Number( detail.settings.fishCount ) || 12 );
+        };
+        wp.hooks.addAction(
+            'desktop-mode.wallpaper.settings-changed',
+            'my-plugin/aquarium-live',
+            onSettings
+        );
+        return () => {
+            wp.hooks.removeAction(
+                'desktop-mode.wallpaper.settings-changed',
+                'my-plugin/aquarium-live'
+            );
+            scene.destroy();
+        };
+    },
+
+    renderConfig: ( container, ctx ) => {
+        const field = document.createElement( 'wpd-range-field' );
+        field.setAttribute( 'label', 'Fish' );
+        field.setAttribute( 'min', '1' );
+        field.setAttribute( 'max', '60' );
+        field.setAttribute( 'value', String( Number( ctx.settings.fishCount ) || 12 ) );
+        field.addEventListener( 'wpd-range-change', ( e ) => {
+            ctx.setSettings( { fishCount: e.detail.value } );   // persists + fires the action
+        } );
+        container.appendChild( field );
+        return () => {};
+    },
+};
+```
+
+The built-in Snow wallpaper (`src/plugins/snow-wallpaper/`) is the canonical in-tree consumer — wind, snowflake count, flake size, and backdrop colour, all applied live.
 
 ### `window.wp.desktop` members
 

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -364,6 +364,28 @@ function desktop_mode_register_assets() {
 		true
 	);
 
+	// `desktop-mode-snow-wallpaper` — built-in PixiJS canvas
+	// wallpaper: snowfall that accumulates on window tops and melts
+	// away. Same lazy-load path as the animated logo: the wallpaper
+	// `server-sync` injects this handle when the user selects the
+	// `wp-snow` wallpaper (or opens OS Settings → Wallpaper and the
+	// picker pulls the def in). The bundle's only side effect is
+	// publishing the `WallpaperDef` on
+	// `window.desktopModeWallpapers['wp-snow']`.
+	$snow_js = DESKTOP_MODE_DIR . 'assets/js/snow-wallpaper' . $suffix . '.js';
+	wp_register_script(
+		'desktop-mode-snow-wallpaper',
+		DESKTOP_MODE_URL . 'assets/js/snow-wallpaper' . $suffix . '.js',
+		array( 'wp-hooks', 'wp-i18n' ),
+		file_exists( $snow_js ) ? (string) filemtime( $snow_js ) : $version,
+		true
+	);
+	wp_set_script_translations(
+		'desktop-mode-snow-wallpaper',
+		'desktop-mode',
+		DESKTOP_MODE_DIR . 'languages'
+	);
+
 	// `desktop-mode-ai-assistant` — AI Copilot spotlight overlay,
 	// moved out of `desktop.min.js` in 0.8.4. The main bundle ships a
 	// stub matching the public `wp.desktop.ai` contract; the stub

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -64,6 +64,13 @@ function desktop_mode_default_os_settings() {
 			'angle' => 135,
 		),
 		'customImage'                 => null,
+		// Per-wallpaper settings bags, keyed by wallpaper id — the
+		// values a wallpaper's `renderConfig` dialog writes (e.g. the
+		// Snow wallpaper's wind / particle count / flake size /
+		// background). Scalar values only; the wallpaper owns the keys'
+		// meaning. Missing ids mean "never configured" — the wallpaper
+		// falls back to its defaults. Capped at 64 wallpapers × 32 keys.
+		'wallpaperSettings'           => array(),
 		'libraryHdOnly'               => true,
 		'ai'                          => array(
 			'enabled' => false,    // AI assistant is opt-in; enabled from OS Settings → Features once a provider is configured.
@@ -338,6 +345,59 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		}
 	}
 
+	// wallpaperSettings — map<wallpaper id, map<key, scalar>>. Wallpaper
+	// ids follow the same charset as unfocus-effect ids (slashes allowed
+	// for `vendor/sub-id` namespacing); setting keys follow the JS
+	// identifier-ish charset wallpaper authors use (camelCase, hyphens,
+	// underscores). Values must be scalar — booleans and numbers pass
+	// through typed, strings are sanitized and length-capped. Unknown
+	// wallpaper ids are kept (a deactivated wallpaper plugin's settings
+	// should survive reactivation). Capped at 64 ids × 32 keys.
+	$wallpaper_settings = array();
+	if ( isset( $raw['wallpaperSettings'] ) && is_array( $raw['wallpaperSettings'] ) ) {
+		$id_count = 0;
+		foreach ( $raw['wallpaperSettings'] as $wp_id => $bag ) {
+			if ( $id_count >= 64 ) {
+				break;
+			}
+			if ( ! is_string( $wp_id ) || '' === $wp_id || ! is_array( $bag ) ) {
+				continue;
+			}
+			$wp_slug = preg_replace( '/[^a-z0-9_\/-]/', '', strtolower( $wp_id ) );
+			if ( '' === $wp_slug ) {
+				continue;
+			}
+			$clean_bag = array();
+			$key_count = 0;
+			foreach ( $bag as $key => $value ) {
+				if ( $key_count >= 32 ) {
+					break;
+				}
+				if ( ! is_string( $key ) || '' === $key || ! preg_match( '/^[a-zA-Z0-9_-]+$/', $key ) ) {
+					continue;
+				}
+				if ( is_bool( $value ) ) {
+					$clean_bag[ $key ] = $value;
+				} elseif ( is_int( $value ) || is_float( $value ) ) {
+					if ( ! is_finite( (float) $value ) ) {
+						continue;
+					}
+					$clean_bag[ $key ] = $value;
+				} elseif ( is_string( $value ) ) {
+					$clean_bag[ $key ] = mb_substr( sanitize_text_field( $value ), 0, 256 );
+				} else {
+					continue;
+				}
+				++$key_count;
+			}
+			if ( empty( $clean_bag ) ) {
+				continue;
+			}
+			$wallpaper_settings[ $wp_slug ] = $clean_bag;
+			++$id_count;
+		}
+	}
+
 	// Library HD only — boolean.
 	$library_hd_only = isset( $raw['libraryHdOnly'] ) ? (bool) $raw['libraryHdOnly'] : $defaults['libraryHdOnly'];
 
@@ -531,6 +591,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'windowLinkHighlight'         => $window_link_highlight,
 		'customGradient'              => $custom_gradient,
 		'customImage'                 => $custom_image,
+		'wallpaperSettings'           => $wallpaper_settings,
 		'libraryHdOnly'               => $library_hd_only,
 		'ai'                          => $ai,
 		'heartbeatRate'               => $heartbeat_rate,

--- a/includes/wallpapers.php
+++ b/includes/wallpapers.php
@@ -85,5 +85,21 @@ function desktop_mode_register_builtin_wallpapers() {
 		'script'      => 'desktop-mode-animated-logo-wallpaper',
 		'description' => __( 'Thousands of luminous particles holding the shape of the WordPress W. Sweep your cursor through and they scatter like sand, then drift home again.', 'desktop-mode' ),
 	) );
+
+	// Snow — built-in PixiJS canvas wallpaper. The preview gradient
+	// must match the default backdrop the JS side paints behind the
+	// canvas (`backdropCss()` in `src/plugins/snow-wallpaper/settings.ts`)
+	// — the swatch renders before the wallpaper script has ever
+	// loaded, so a mismatch would show one sky in the picker and a
+	// different one once selected. First built-in wallpaper with a
+	// `renderConfig` settings dialog (wind, snowflake count, flake
+	// size, background colour).
+	desktop_mode_register_wallpaper( 'wp-snow', array(
+		'label'       => __( 'Snow', 'desktop-mode' ),
+		'preview'     => 'linear-gradient(180deg, #0c1a36 0%, #1d355e 55%, #425d8a 100%)',
+		'type'        => 'canvas',
+		'script'      => 'desktop-mode-snow-wallpaper',
+		'description' => __( 'Snow falling over a midnight sky. Flakes settle on the top edge of every window, pile into little drifts, then quietly melt away. Open the wallpaper settings to tune the wind, the snowfall, the flake size, and the colour of the night.', 'desktop-mode' ),
+	) );
 }
 add_action( 'init', 'desktop_mode_register_builtin_wallpapers', 5 );

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		}
 	},
 	"scripts": {
-		"build": "npm run vendor:pixi && npm run build:desktop && npm run build:iframe-bridge && npm run build:gutenberg-drop-receiver && npm run build:recycle-bin && npm run build:posts-window && npm run build:plugins-window && npm run build:comments-window && npm run build:my-wordpress && npm run build:content-graph && npm run build:ai-assistant && npm run build:animated-logo-wallpaper && npm run build:living-tree-wallpaper && npm run build:about-scene && npm run build:os-settings-panel && npm run build:shell-overlays && npm run build:window-system && npm run build:widget-heartbeat && npm run build:widget-recent-comments && npm run build:widget-post-stats && npm run build:widget-site-views && npm run build:widget-jazz-quote && npm run build:widget-starter && npm run build:pwa-sw",
+		"build": "npm run vendor:pixi && npm run build:desktop && npm run build:iframe-bridge && npm run build:gutenberg-drop-receiver && npm run build:recycle-bin && npm run build:posts-window && npm run build:plugins-window && npm run build:comments-window && npm run build:my-wordpress && npm run build:content-graph && npm run build:ai-assistant && npm run build:animated-logo-wallpaper && npm run build:living-tree-wallpaper && npm run build:snow-wallpaper && npm run build:about-scene && npm run build:os-settings-panel && npm run build:shell-overlays && npm run build:window-system && npm run build:widget-heartbeat && npm run build:widget-recent-comments && npm run build:widget-post-stats && npm run build:widget-site-views && npm run build:widget-jazz-quote && npm run build:widget-starter && npm run build:pwa-sw",
 		"build:desktop": "vite build --mode development && vite build --mode production",
 		"build:iframe-bridge": "DESKTOP_MODE_TARGET=iframe-bridge vite build --mode development && DESKTOP_MODE_TARGET=iframe-bridge vite build --mode production",
 		"build:gutenberg-drop-receiver": "DESKTOP_MODE_TARGET=gutenberg-drop-receiver vite build --mode development && DESKTOP_MODE_TARGET=gutenberg-drop-receiver vite build --mode production",
@@ -40,6 +40,7 @@
 		"build:ai-assistant": "DESKTOP_MODE_TARGET=ai-assistant vite build --mode development && DESKTOP_MODE_TARGET=ai-assistant vite build --mode production",
 		"build:animated-logo-wallpaper": "DESKTOP_MODE_TARGET=animated-logo-wallpaper vite build --mode development && DESKTOP_MODE_TARGET=animated-logo-wallpaper vite build --mode production",
 		"build:living-tree-wallpaper": "DESKTOP_MODE_TARGET=living-tree-wallpaper vite build --mode development && DESKTOP_MODE_TARGET=living-tree-wallpaper vite build --mode production",
+		"build:snow-wallpaper": "DESKTOP_MODE_TARGET=snow-wallpaper vite build --mode development && DESKTOP_MODE_TARGET=snow-wallpaper vite build --mode production",
 		"build:about-scene": "DESKTOP_MODE_TARGET=about-scene vite build --mode development && DESKTOP_MODE_TARGET=about-scene vite build --mode production",
 		"build:os-settings-panel": "DESKTOP_MODE_TARGET=os-settings-panel vite build --mode development && DESKTOP_MODE_TARGET=os-settings-panel vite build --mode production",
 		"build:shell-overlays": "DESKTOP_MODE_TARGET=shell-overlays vite build --mode development && DESKTOP_MODE_TARGET=shell-overlays vite build --mode production",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -185,6 +185,16 @@ export const HOOKS = {
 	 * Settings picker. Args: `( params, wallpaperId )`.
 	 */
 	WALLPAPER_PREVIEW_PARAMS: 'desktop-mode.wallpaper.preview-params',
+	/**
+	 * Action, fires after a wallpaper's persisted settings change (the
+	 * user edited them through the wallpaper's config dialog in OS
+	 * Settings). Payload: `{ id, settings }` — the wallpaper id and the
+	 * full post-merge settings object. A mounted wallpaper subscribes to
+	 * live-apply changes without a remount.
+	 *
+	 * @since 0.9.5
+	 */
+	WALLPAPER_SETTINGS_CHANGED: 'desktop-mode.wallpaper.settings-changed',
 
 	// ------------------------------------------------------------------
 	// Observability — iframe errors, iframe network, shell-side errors,

--- a/src/plugins/snow-wallpaper/index.ts
+++ b/src/plugins/snow-wallpaper/index.ts
@@ -1,0 +1,462 @@
+/**
+ * Snow — wallpaper plugin entry.
+ *
+ * A PixiJS canvas wallpaper: snowflakes fall, accumulate on the top
+ * edge of every visible window (and widget card, taskbar, and the
+ * shell floor), then melt away. The simulation lives in `scene.ts`;
+ * this file owns the wallpaper def, the shell hook wiring, the OS
+ * Settings tile preview, and the settings dialog (`renderConfig`).
+ *
+ * Publishing pattern (same as animated-logo / living-tree): the
+ * bundle's only side effect is writing
+ * `window.desktopModeWallpapers['wp-snow']`; the shell's wallpaper
+ * `server-sync` reads that global after the script loads. Server
+ * registration lives in `includes/wallpapers.php`.
+ *
+ * First built-in consumer of the per-wallpaper settings surface: the
+ * "Wallpaper settings" dialog edits wind, particle count, flake size,
+ * and backdrop colour; a mounted instance live-applies them through
+ * the `desktop-mode.wallpaper.settings-changed` action.
+ *
+ * @since 0.9.5
+ */
+
+import { __ } from '../../i18n';
+import { addAction, removeAction, HOOKS } from '../../hooks';
+// Register the tags the config dialog creates — `defineComponent` is
+// idempotent, so double-registration with the OS Settings panel
+// bundle (which ships the same components) is safe.
+import '../../ui/components/wpd-range-field/wpd-range-field';
+import '../../ui/components/wpd-color-field/wpd-color-field';
+import '../../ui/components/wpd-button/wpd-button';
+import type { WallpaperSurface } from '../../wallpapers/surfaces';
+import type {
+	WallpaperConfigContext,
+	WallpaperContext,
+	WallpaperDef,
+	WallpaperPreviewContext,
+	WallpaperTeardown,
+} from '../../wallpapers/types';
+import { getPixi } from './pixi-types';
+import { mountSnowScene, type SnowScene } from './scene';
+import {
+	sanitizeSnowSettings,
+	SNOW_DEFAULTS,
+	SNOW_LIMITS,
+	backdropCss,
+	type SnowSettings,
+} from './settings';
+
+/** Stable id — persisted to localStorage as the user's selected wallpaper. */
+const WALLPAPER_ID = 'wp-snow';
+
+/** Hook-namespace prefix for every listener this wallpaper registers. */
+const NAMESPACE = 'desktop-mode/snow';
+
+/**
+ * Swatch preview — pure CSS, shown in OS Settings before PixiJS
+ * loads. The same midnight-to-dusk gradient the scene paints behind
+ * the transparent canvas (at default settings), so selecting feels
+ * continuous.
+ */
+const PREVIEW = backdropCss( SNOW_DEFAULTS.background );
+
+/**
+ * Tile-preview particle count. The full field would read as a
+ * blizzard at swatch scale — a few dozen flakes over the same
+ * backdrop communicates the wallpaper honestly and keeps the tile's
+ * frame cost negligible. Overridable through `previewParams` /
+ * the `desktop-mode.wallpaper.preview-params` filter.
+ */
+const PREVIEW_PARTICLES = 140;
+
+/** Read `wp.desktop.getWallpaperSurfaces` off the public API. */
+function surfacesSupplier(): ( () => WallpaperSurface[] ) | null {
+	const api = window.wp?.desktop as
+		| { getWallpaperSurfaces?: () => WallpaperSurface[] }
+		| undefined;
+	if ( ! api || typeof api.getWallpaperSurfaces !== 'function' ) {
+		return null;
+	}
+	return () => ( api.getWallpaperSurfaces as () => WallpaperSurface[] )();
+}
+
+/**
+ * Wire the shell hooks a mounted scene needs and return the matching
+ * un-wire function. Kept out of `scene.ts` so the simulation stays a
+ * pure function of its inputs.
+ */
+function wireSceneHooks( scene: SnowScene ): () => void {
+	// Pause when the document is hidden or the user switched
+	// wallpapers (the shell still has us mounted briefly).
+	const visibilityHandler = ( ...args: unknown[] ): void => {
+		const detail = args[ 0 ] as
+			| { id?: string; state?: 'visible' | 'hidden' }
+			| undefined;
+		if ( ! detail || detail.id !== WALLPAPER_ID ) {
+			return;
+		}
+		scene.setAnimating( detail.state === 'visible' );
+	};
+	addAction(
+		HOOKS.WALLPAPER_VISIBILITY,
+		`${ NAMESPACE }/visibility`,
+		visibilityHandler,
+	);
+
+	// WINDOW_CLOSING fires *before* the shell detaches the window
+	// element, and hands us the live DOM node — so stuck flakes match
+	// by identity instead of reverse-engineering the id → selector
+	// mapping. Every matching flake detaches back into the falling
+	// state: the surface under it is physically disappearing, so the
+	// realistic behavior is gravity — not melting in place. Flakes
+	// then continue through the normal collision path and may land on
+	// whatever window (or the shell floor) sits beneath.
+	const detachHandler = ( ...args: unknown[] ): void => {
+		const detail = args[ 0 ] as { element?: HTMLElement } | undefined;
+		if ( ! detail || ! detail.element ) {
+			return;
+		}
+		scene.detachFlakesAnchoredTo( detail.element );
+	};
+	addAction(
+		HOOKS.WINDOW_CLOSING,
+		`${ NAMESPACE }/window-closing`,
+		detachHandler,
+	);
+
+	// WINDOW_MINIMIZED — the shell hides the window via opacity 0 +
+	// transform, NOT display: none, so `offsetParent` stays non-null
+	// and the per-frame "start melt if anchor is hidden" heuristic
+	// never trips. Without an explicit listener, stuck flakes track
+	// the minimize transform off-screen and hang in mid-air for the
+	// full stuck lifetime before melting on their natural schedule —
+	// visually "snow floating."
+	//
+	// Detach to FALLING — not melt — because from the user's
+	// perspective the window has vanished. Melting in place would
+	// freeze flakes at the (now invisible) minimize-transformed
+	// coordinates. Falling lets snowfall continue past where the
+	// window used to be, naturally re-colliding against whatever
+	// surface sits beneath. `detachFlakesAnchoredTo` also flips the
+	// surface cache dirty so NEW flakes falling toward the
+	// disappeared window's y-coordinate pass through to the next
+	// surface beneath instead of landing on nothing.
+	addAction(
+		HOOKS.WINDOW_MINIMIZED,
+		`${ NAMESPACE }/window-minimized`,
+		detachHandler,
+	);
+
+	// WINDOW_BOUNDS_CHANGED is rAF-coalesced by the shell and fires
+	// on drag, resize, snap — anything pointer-driven that moves a
+	// window edge. Flipping the dirty bit here short-circuits the
+	// scene's 20Hz refresh cadence so the next tick rebuilds the
+	// surface cache against the current rects; stuck flakes following
+	// the anchor still read DOM rects directly, but *new* collisions
+	// get a fresh edge list within one frame.
+	const dirtyHandler = (): void => {
+		scene.markSurfacesDirty();
+	};
+	addAction(
+		HOOKS.WINDOW_BOUNDS_CHANGED,
+		`${ NAMESPACE }/bounds-changed`,
+		dirtyHandler,
+	);
+
+	// Geometry changes that don't ride WINDOW_BOUNDS_CHANGED — it is
+	// pointer-driven, so programmatic state transitions (restore,
+	// maximize, unmaximize, fullscreen enter/exit) change a window's
+	// solid-surface rect without signaling the cache. Without these,
+	// the cache stays stale for up to the 50ms timed refresh, and
+	// flakes spawned during that window collide against the OLD edge
+	// (e.g. the pre-maximize floating rect).
+	addAction(
+		HOOKS.WINDOW_RESTORED,
+		`${ NAMESPACE }/window-restored`,
+		dirtyHandler,
+	);
+	addAction(
+		HOOKS.WINDOW_MAXIMIZED,
+		`${ NAMESPACE }/window-maximized`,
+		dirtyHandler,
+	);
+	addAction(
+		HOOKS.WINDOW_UNMAXIMIZED,
+		`${ NAMESPACE }/window-unmaximized`,
+		dirtyHandler,
+	);
+	addAction(
+		HOOKS.WINDOW_FULLSCREEN_ENTERED,
+		`${ NAMESPACE }/window-fullscreen-entered`,
+		dirtyHandler,
+	);
+	addAction(
+		HOOKS.WINDOW_FULLSCREEN_EXITED,
+		`${ NAMESPACE }/window-fullscreen-exited`,
+		dirtyHandler,
+	);
+
+	// WIDGET_UNMOUNTING fires *before* the widget layer runs the
+	// widget's teardown, so the card element is still in the DOM and
+	// reachable via `[data-widget-id="…"]` — every stuck flake on it
+	// drops into the falling state. Same reasoning as WINDOW_CLOSING.
+	// The payload is `{ id }` only (no element), so we query by
+	// attribute; if the widget was never actually rendered (fast
+	// add/remove) the selector misses and nothing happens — safe
+	// no-op.
+	const widgetUnmountingHandler = ( ...args: unknown[] ): void => {
+		const detail = args[ 0 ] as { id?: string } | undefined;
+		if ( ! detail || ! detail.id ) {
+			return;
+		}
+		const safeId =
+			window.CSS && typeof CSS.escape === 'function'
+				? CSS.escape( detail.id )
+				: String( detail.id ).replace( /"/g, '\\"' );
+		const card = document.querySelector< HTMLElement >(
+			`[data-widget-id="${ safeId }"]`,
+		);
+		if ( ! card ) {
+			return;
+		}
+		scene.detachFlakesAnchoredTo( card );
+	};
+	addAction(
+		HOOKS.WIDGET_UNMOUNTING,
+		`${ NAMESPACE }/widget-unmounting`,
+		widgetUnmountingHandler,
+	);
+
+	// Live settings — the config dialog publishes through the shell,
+	// which fires this action with the full post-merge object.
+	const settingsHandler = ( ...args: unknown[] ): void => {
+		const detail = args[ 0 ] as
+			| { id?: string; settings?: Record< string, unknown > }
+			| undefined;
+		if ( ! detail || detail.id !== WALLPAPER_ID ) {
+			return;
+		}
+		scene.applySettings( sanitizeSnowSettings( detail.settings ) );
+	};
+	addAction(
+		HOOKS.WALLPAPER_SETTINGS_CHANGED,
+		`${ NAMESPACE }/settings-changed`,
+		settingsHandler,
+	);
+
+	return (): void => {
+		removeAction( HOOKS.WALLPAPER_VISIBILITY, `${ NAMESPACE }/visibility` );
+		removeAction( HOOKS.WINDOW_CLOSING, `${ NAMESPACE }/window-closing` );
+		removeAction( HOOKS.WINDOW_MINIMIZED, `${ NAMESPACE }/window-minimized` );
+		removeAction( HOOKS.WINDOW_RESTORED, `${ NAMESPACE }/window-restored` );
+		removeAction( HOOKS.WINDOW_MAXIMIZED, `${ NAMESPACE }/window-maximized` );
+		removeAction(
+			HOOKS.WINDOW_UNMAXIMIZED,
+			`${ NAMESPACE }/window-unmaximized`,
+		);
+		removeAction(
+			HOOKS.WINDOW_FULLSCREEN_ENTERED,
+			`${ NAMESPACE }/window-fullscreen-entered`,
+		);
+		removeAction(
+			HOOKS.WINDOW_FULLSCREEN_EXITED,
+			`${ NAMESPACE }/window-fullscreen-exited`,
+		);
+		removeAction(
+			HOOKS.WINDOW_BOUNDS_CHANGED,
+			`${ NAMESPACE }/bounds-changed`,
+		);
+		removeAction(
+			HOOKS.WIDGET_UNMOUNTING,
+			`${ NAMESPACE }/widget-unmounting`,
+		);
+		removeAction(
+			HOOKS.WALLPAPER_SETTINGS_CHANGED,
+			`${ NAMESPACE }/settings-changed`,
+		);
+	};
+}
+
+/**
+ * Build one labelled `<wpd-range-field>` wired to a settings key.
+ * Imperative DOM (no templating import) — the dialog is four fields
+ * and a reset button; pulling `ui/core` into this bundle for that
+ * would be pure weight.
+ */
+function rangeField(
+	label: string,
+	limits: { min: number; max: number },
+	step: number,
+	value: number,
+	onChange: ( next: number ) => void,
+): HTMLElement {
+	const field = document.createElement( 'wpd-range-field' );
+	field.setAttribute( 'label', label );
+	field.setAttribute( 'min', String( limits.min ) );
+	field.setAttribute( 'max', String( limits.max ) );
+	field.setAttribute( 'step', String( step ) );
+	field.setAttribute( 'value', String( value ) );
+	field.addEventListener( 'wpd-range-change', ( e: Event ) => {
+		onChange( ( e as CustomEvent< { value: number } > ).detail.value );
+	} );
+	return field;
+}
+
+/**
+ * `renderConfig` — the "Wallpaper settings" dialog body. Four
+ * controls (wind, particle count, flake size, backdrop colour) that
+ * write through `ctx.setSettings` on every edit; the mounted scene
+ * live-applies via the settings-changed action, so the dialog acts
+ * as a live tuning panel. "Reset to defaults" writes the canonical
+ * values back in one shot.
+ */
+function renderSnowConfig(
+	container: HTMLElement,
+	ctx: WallpaperConfigContext,
+): WallpaperTeardown {
+	let current = sanitizeSnowSettings( ctx.settings );
+
+	const set = ( partial: Partial< SnowSettings > ): void => {
+		current = { ...current, ...partial };
+		ctx.setSettings( partial );
+	};
+
+	const windField = rangeField(
+		__( 'Wind' ),
+		SNOW_LIMITS.wind,
+		1,
+		current.wind,
+		( value ) => set( { wind: value } ),
+	);
+	const particlesField = rangeField(
+		__( 'Snowflakes' ),
+		SNOW_LIMITS.particleCount,
+		10,
+		current.particleCount,
+		( value ) => set( { particleCount: Math.round( value ) } ),
+	);
+	const sizeField = rangeField(
+		__( 'Flake size' ),
+		SNOW_LIMITS.flakeSize,
+		1,
+		current.flakeSize,
+		( value ) => set( { flakeSize: value } ),
+	);
+
+	const colorField = document.createElement( 'wpd-color-field' );
+	colorField.setAttribute( 'label', __( 'Background color' ) );
+	colorField.setAttribute( 'value', current.background );
+	colorField.addEventListener( 'wpd-color-change', ( e: Event ) => {
+		const value = ( e as CustomEvent< { value: string } > ).detail.value;
+		set( { background: sanitizeSnowSettings( { background: value } ).background } );
+	} );
+
+	const reset = document.createElement( 'wpd-button' );
+	reset.setAttribute( 'variant', 'ghost' );
+	// The dialog body is a stretch-aligned flex column — left-align
+	// the button and add a hair of separation so it reads as a footer
+	// action, not another form field.
+	reset.style.alignSelf = 'flex-start';
+	reset.style.marginTop = '4px';
+	reset.textContent = __( 'Reset to defaults' );
+	reset.addEventListener( 'click', () => {
+		set( { ...SNOW_DEFAULTS } );
+		windField.setAttribute( 'value', String( SNOW_DEFAULTS.wind ) );
+		particlesField.setAttribute(
+			'value',
+			String( SNOW_DEFAULTS.particleCount ),
+		);
+		sizeField.setAttribute( 'value', String( SNOW_DEFAULTS.flakeSize ) );
+		colorField.setAttribute( 'value', SNOW_DEFAULTS.background );
+	} );
+
+	container.appendChild( windField );
+	container.appendChild( particlesField );
+	container.appendChild( sizeField );
+	container.appendChild( colorField );
+	container.appendChild( reset );
+
+	// No long-lived resources — listeners die with the dialog DOM.
+	return (): void => {
+		/* noop */
+	};
+}
+
+const def: WallpaperDef = {
+	id: WALLPAPER_ID,
+	label: __( 'Snow' ),
+	type: 'canvas',
+	preview: PREVIEW,
+	previewParams: { particleCount: PREVIEW_PARTICLES },
+	/**
+	 * Live tile preview for the OS Settings picker — the real
+	 * simulation at tile scale, minus surface collision (surface
+	 * rects are viewport-space and meaningless inside a tile) and at
+	 * a fraction of the field density.
+	 */
+	renderPreview: async (
+		container: HTMLElement,
+		ctx: WallpaperPreviewContext,
+	): Promise< WallpaperTeardown > => {
+		const pixi = getPixi();
+		if ( ! pixi ) {
+			return (): void => {
+				/* noop */
+			};
+		}
+		const settings = sanitizeSnowSettings( ctx.settings );
+		const rawCount = ctx.params.particleCount;
+		const previewCount =
+			typeof rawCount === 'number' && Number.isFinite( rawCount )
+				? rawCount
+				: PREVIEW_PARTICLES;
+		const scene = await mountSnowScene( {
+			container,
+			pixi,
+			settings: sanitizeSnowSettings( {
+				...settings,
+				particleCount: previewCount,
+			} ),
+			prefersReducedMotion: ctx.prefersReducedMotion,
+			getSurfaces: null,
+		} );
+		return (): void => scene.destroy();
+	},
+	needs: [ 'pixijs' ],
+	mount: async (
+		container: HTMLElement,
+		ctx: WallpaperContext,
+	): Promise< WallpaperTeardown > => {
+		// `needs: ['pixijs']` guarantees `window.PIXI` is set.
+		const pixi = getPixi();
+		if ( ! pixi ) {
+			return (): void => {
+				/* noop */
+			};
+		}
+		const scene = await mountSnowScene( {
+			container,
+			pixi,
+			settings: sanitizeSnowSettings( ctx.settings ),
+			prefersReducedMotion: ctx.prefersReducedMotion,
+			getSurfaces: surfacesSupplier(),
+		} );
+		const unwireHooks = wireSceneHooks( scene );
+
+		return (): void => {
+			unwireHooks();
+			scene.destroy();
+		};
+	},
+	renderConfig: renderSnowConfig,
+};
+
+declare global {
+	interface Window {
+		desktopModeWallpapers?: Record< string, WallpaperDef >;
+	}
+}
+
+window.desktopModeWallpapers = window.desktopModeWallpapers || {};
+window.desktopModeWallpapers[ WALLPAPER_ID ] = def;

--- a/src/plugins/snow-wallpaper/pixi-types.ts
+++ b/src/plugins/snow-wallpaper/pixi-types.ts
@@ -1,0 +1,107 @@
+/**
+ * Snow wallpaper — minimal Pixi type surface.
+ *
+ * PixiJS is loaded as a vendor script (`window.PIXI`) via the
+ * wallpaper def's `needs: ['pixijs']`, NOT imported. We declare the
+ * narrow set of Pixi v8 types this bundle uses — the particle fast
+ * path (`ParticleContainer` + `Particle`) rather than the display-
+ * list `Sprite` tree the other canvas wallpapers use — mirroring
+ * `src/plugins/living-tree-wallpaper/pixi-types.ts` so the two stay
+ * type-compatible without a hard dependency on the `pixi.js` package.
+ *
+ * @since 0.9.5
+ */
+
+export interface PixiTexture {
+	destroy( destroyBase?: boolean ): void;
+}
+
+/**
+ * Pixi v8 `Particle` — the flat-property child type of
+ * `ParticleContainer`. Unlike `Sprite` there is no `.position` /
+ * `.scale` object; `x`, `y`, `scaleX`, `scaleY`, `alpha`, `rotation`
+ * are plain fields the render pipeline reads per frame.
+ */
+export interface PixiParticle {
+	x: number;
+	y: number;
+	scaleX: number;
+	scaleY: number;
+	alpha: number;
+	rotation: number;
+	tint: number;
+}
+
+export interface PixiParticleContainer {
+	addParticle( particle: PixiParticle ): void;
+}
+
+export interface PixiTicker {
+	deltaMS: number;
+	add( cb: ( ticker: PixiTicker ) => void ): void;
+	remove( cb: ( ticker: PixiTicker ) => void ): void;
+	start(): void;
+	stop(): void;
+	update(): void;
+}
+
+export interface PixiApp {
+	canvas: HTMLCanvasElement;
+	stage: { addChild( child: unknown ): void };
+	ticker: PixiTicker;
+	init( opts: {
+		resizeTo?: HTMLElement;
+		backgroundAlpha?: number;
+		antialias?: boolean;
+		autoDensity?: boolean;
+		resolution?: number;
+	} ): Promise< void >;
+	/**
+	 * First arg is Pixi's `RendererDestroyOptions`. Pass an options
+	 * object (e.g. `{ removeView: true }`), never a literal `true` —
+	 * `true` triggers `releaseGlobalResources()`, which wipes Pixi's
+	 * page-global texture/object pools out from under every OTHER live
+	 * Application (active wallpaper vs. OS Settings preview).
+	 */
+	destroy(
+		rendererOpts?: { removeView?: boolean },
+		opts?: { children?: boolean; texture?: boolean; textureSource?: boolean },
+	): void;
+}
+
+export interface PixiNamespace {
+	Application: new () => PixiApp;
+	/**
+	 * `dynamicProperties` declares which per-particle attributes we
+	 * mutate each frame so Pixi lays the GPU buffers out for per-frame
+	 * updates vs. upload-once. NOTE: there is no `scale` key —
+	 * `scaleX`/`scaleY` live in the *vertex* buffer, so `vertex: true`
+	 * is what makes per-frame scale writes upload.
+	 */
+	ParticleContainer: new ( opts: {
+		dynamicProperties: {
+			position?: boolean;
+			vertex?: boolean;
+			rotation?: boolean;
+			color?: boolean;
+		};
+	} ) => PixiParticleContainer;
+	Particle: new ( opts: {
+		texture: PixiTexture;
+		anchorX?: number;
+		anchorY?: number;
+		alpha?: number;
+		tint?: number;
+	} ) => PixiParticle;
+	Texture: { from( source: unknown ): PixiTexture };
+}
+
+/**
+ * Read the vendor-loaded Pixi namespace off `window`. Returns `null`
+ * if the module hasn't loaded — callers bail out gracefully rather
+ * than dereferencing null.
+ */
+export function getPixi(): PixiNamespace | null {
+	const pixi = ( window as unknown as { PIXI?: PixiNamespace } ).PIXI;
+	return pixi ?? null;
+}

--- a/src/plugins/snow-wallpaper/scene.ts
+++ b/src/plugins/snow-wallpaper/scene.ts
@@ -1,0 +1,1111 @@
+/**
+ * Snow wallpaper — the PixiJS simulation.
+ *
+ * Simulation contract:
+ *   1. A fixed-size sprite pool is built up front (sized to the
+ *      settings ceiling so the particle-count knob never forces a
+ *      pool rebuild). No per-frame allocations.
+ *   2. Each tick, free sprites are spawned off the top of the canvas
+ *      with randomized velocity, size, alpha, sway — while the live
+ *      count is under the user's `particleCount`.
+ *   3. Wind is a slow global sin sweep; per-particle sway layers a
+ *      small per-particle sin on top so the field never feels
+ *      uniform.
+ *   4. Every frame, each falling flake checks the last-frame Y
+ *      against the top edge of every visible surface the shell
+ *      publishes (windows, widget cards, taskbar, the shell floor).
+ *      A crossing sticks the flake at the top of the existing pile in
+ *      that column (see the pile model below), with an anchor offset
+ *      so the whole pile drags along when the user moves the window.
+ *   5. A stuck flake lives for `stuckLifeSec ± jitter` then starts
+ *      the melt phase — shrink + fade over `meltDurationSec`, then
+ *      returned to the free list and the pile column it occupied is
+ *      decremented.
+ *
+ * Pile model (snow-on-snow stacking):
+ *   - Each `top`-face surface gets a per-bucket pile-height array
+ *     keyed by surface id. Buckets are `pileBucketPx` wide in
+ *     surface-local space; bucket index = floor((vpX - r.x)/bucketPx).
+ *   - On collision, the flake's stick Y is offset upward by
+ *     `pile[bucket]` so successive flakes in the same column stack.
+ *     The bucket's height is then incremented by
+ *     `flakeSize * pileContribution`, and immediate neighbors get a
+ *     fraction so piles slope naturally instead of forming towers.
+ *   - On melt/release/detach, the bucket is decremented by the same
+ *     amount this flake added (the bucket id is stored on the
+ *     particle so it can be found again).
+ *   - Pile arrays are pruned when their surface disappears from the
+ *     shell's surface list (window close, widget unmount, minimize).
+ *     Stale-pile reads after a prune are safe no-ops.
+ *   - Anchored flakes follow their surface element, so dragging a
+ *     window moves both flakes AND pile heights (heights are
+ *     surface-local; the element's live rect bridges into viewport
+ *     space).
+ *
+ * Deallocation:
+ *   - Melted sprites reset alpha/scale and are pushed back on the
+ *     free list; particle objects are reused for the life of the
+ *     wallpaper.
+ *   - Teardown destroys the Pixi Application (WebGL context, texture,
+ *     every particle) and restores the container's prior
+ *     `background` style. Hook wiring lives in `index.ts`, not here.
+ *
+ * The OS Settings tile preview reuses this scene with
+ * `getSurfaces: null` (no collisions, no piles — surface rects are
+ * viewport-space and meaningless inside a tile) and a scaled-down
+ * particle count.
+ *
+ * @since 0.9.5
+ */
+
+import type { WallpaperSurface } from '../../wallpapers/surfaces';
+import type {
+	PixiApp,
+	PixiNamespace,
+	PixiParticle,
+	PixiTicker,
+} from './pixi-types';
+import { backdropCss, SNOW_LIMITS, type SnowSettings } from './settings';
+
+/**
+ * Texture canvas size — the snowflake is rasterized into a square of
+ * this many CSS pixels. Particle scale is set so the rendered flake
+ * is `pSize[idx]` CSS pixels wide (`scale = size / TEXTURE_SIZE`),
+ * keeping the size setting in intuitive on-screen units. 64 px is
+ * plenty for a smooth radial gradient — there is no fine structure
+ * to preserve because real snow seen by eye reads as a soft sphere,
+ * not a Christmas-card crystal.
+ */
+const TEXTURE_SIZE = 64;
+
+/**
+ * Fixed physics / simulation tuning. All values are CSS pixels or
+ * seconds unless noted. Adjust together — changing one usually means
+ * revisiting the others. The four user-tunable values (wind
+ * amplitude, particle count, flake size, backdrop) live in
+ * {@link SnowSettings} instead.
+ */
+const TUNING = {
+	/**
+	 * Spawn rate (flakes/s) while the field is unsaturated, at the
+	 * default particle count. Scaled linearly with the user's
+	 * particle count so the pool fills in the same wall-clock time at
+	 * every density. The pool cap is the real ceiling — once hit,
+	 * spawn pauses until something melts or recycles.
+	 */
+	spawnPerSecondAtDefault: 90,
+	/** The particle count `spawnPerSecondAtDefault` is calibrated for. */
+	spawnCalibrationCount: 660,
+	/**
+	 * Min / max vertical drift (px/s). Real snow falls slowly and
+	 * reaches terminal velocity fast — air resistance dominates over
+	 * gravity at flake mass — so velocity is modeled as a constant
+	 * per particle rather than accelerating. Range chosen for an
+	 * atmospheric feel rather than a hailstorm.
+	 */
+	gravityMin: 28,
+	gravityMax: 72,
+	/** Period of the global wind sweep (seconds). */
+	windPeriodSec: 11,
+	/** Per-particle sway amplitude (px/s target). */
+	driftAmplitude: 32,
+	driftPeriodMin: 2.5,
+	driftPeriodMax: 5.5,
+	/**
+	 * Max rotation speed (rad/s). Spheres are rotation-invariant by
+	 * construction — kept tiny only so any minor bilinear-filter
+	 * asymmetries don't lock to a fixed orientation across the field.
+	 */
+	rotationMax: 0.2,
+	alphaMin: 0.7,
+	alphaMax: 1.0,
+	/** Melt duration once a stuck flake starts melting. */
+	meltDurationSec: 1.8,
+	/**
+	 * How long a flake stays stuck before it starts melting. Visible
+	 * piles take time to build — a short lifetime barely lets a
+	 * column reach 2–3 flakes before the bottom one melts. A small
+	 * jitter is applied per flake so an entire windowful doesn't melt
+	 * in lockstep.
+	 */
+	stuckLifeSec: 9.0,
+	stuckLifeJitter: 2.5,
+	/**
+	 * A small inset on the window top so flakes don't visibly overlap
+	 * the title-bar drop shadow.
+	 */
+	collisionMarginY: 2,
+	/**
+	 * Width of one pile-height bucket in CSS px (surface-local X).
+	 * Each surface keeps a Float32Array of bucket heights; a falling
+	 * flake's bucket index is `floor((vpX - r.x) / bucket)`. 8 px is
+	 * roughly half a flake wide — narrow enough that two flakes
+	 * landing in the same column visibly stack rather than overlap,
+	 * wide enough that buckets feel continuous rather than discrete
+	 * bins.
+	 */
+	pileBucketPx: 8,
+	/**
+	 * Cap on per-column pile height in CSS px. Beyond this, further
+	 * flakes still stick but don't push the pile higher — surfaces
+	 * visually "saturate" with snow rather than growing unbounded
+	 * towers. ~3 flakes deep at the largest default flake size reads
+	 * as a small drift edge.
+	 */
+	pileMaxPx: 48,
+	/**
+	 * Fraction of a flake's size added to its bucket's pile height on
+	 * landing. Successive flakes' centres sit only
+	 * `pileContribution * size` apart, so 0.1 puts new flake centres
+	 * just 10% of a diameter above the previous one. The bright cores
+	 * (~30% of the size) heavily overlap, reading as a continuous
+	 * mass of snow rather than a stack of discrete dots with visible
+	 * interstitial halo. Lower = denser pile, slower vertical growth.
+	 */
+	pileContribution: 0.1,
+	/**
+	 * Fraction of `pileContribution` that bleeds into the two
+	 * neighbor buckets — gives piles a natural slope instead of
+	 * letting one column tower over its neighbors.
+	 */
+	pileSpread: 0.4,
+} as const;
+
+/**
+ * Pool capacity — the settings ceiling, allocated up front so the
+ * particle-count setting can move live without rebuilding typed
+ * arrays or the particle list. Inactive slots cost a few bytes each
+ * and are hidden via alpha.
+ */
+const POOL_SIZE = SNOW_LIMITS.particleCount.max;
+
+/** What the scene hands back to the wallpaper entry. */
+export interface SnowScene {
+	/** Pause / resume the ticker (visibility, reduced motion). */
+	setAnimating( animating: boolean ): void;
+	/** Live-apply new user settings — no remount needed. */
+	applySettings( settings: SnowSettings ): void;
+	/** Flag the surface cache stale (window moved / state changed). */
+	markSurfacesDirty(): void;
+	/**
+	 * Drop every flake stuck to the given element back into the
+	 * falling state — the surface under them is disappearing, so
+	 * gravity takes over rather than melting in place.
+	 */
+	detachFlakesAnchoredTo( element: HTMLElement ): void;
+	/** Full teardown — WebGL context, texture, listeners, backdrop. */
+	destroy(): void;
+}
+
+export interface SnowSceneOptions {
+	container: HTMLElement;
+	pixi: PixiNamespace;
+	settings: SnowSettings;
+	prefersReducedMotion: boolean;
+	/**
+	 * Live surface supplier (`wp.desktop.getWallpaperSurfaces`), or
+	 * `null` to disable collisions entirely (tile previews — surface
+	 * rects are viewport-space and meaningless inside a tile).
+	 */
+	getSurfaces: ( () => WallpaperSurface[] ) | null;
+}
+
+/**
+ * Rasterize a soft white sphere on a `TEXTURE_SIZE` × `TEXTURE_SIZE`
+ * canvas and hand it to Pixi as a shared texture. One texture is used
+ * by every particle — the hot loop only varies scale, alpha,
+ * rotation, position.
+ *
+ * This is intentionally NOT the stylized six-armed crystal of a
+ * Christmas-card snowflake. Real falling snow seen by eye reads as a
+ * soft, slightly-blue-white blob — the dendrite structure is far too
+ * small to resolve at any realistic viewing distance, and rendering
+ * it on a handful of pixels would alias to noise anyway.
+ *
+ * Single radial gradient: bright white core, fading to a faint
+ * cool-blue edge, fully transparent at the texture rim so adjacent
+ * sprites don't overlap with a hard rectangular border.
+ */
+function buildSnowflakeTexture( pixi: PixiNamespace ) {
+	const size = TEXTURE_SIZE;
+	const canvas = document.createElement( 'canvas' );
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext( '2d' );
+	if ( ! ctx ) {
+		return pixi.Texture.from( canvas );
+	}
+	const cx = size / 2;
+	const cy = size / 2;
+	// Use slightly less than half the canvas so the outermost alpha=0
+	// stop falls inside the texture — eliminates any 1-px-wide rim
+	// from edge-clipping when the sprite is sampled at non-integer
+	// positions.
+	const radius = size / 2 - 1;
+
+	const grad = ctx.createRadialGradient( cx, cy, 0, cx, cy, radius );
+	// Solid white core — the bright "mass" of the flake, ~30% of the
+	// radius. Beyond that the alpha rolls off so the glow occupies
+	// the outer 70% as a soft halo. The whole envelope reads as a
+	// single sphere; the inner ~30% is the dense centre, the rest is
+	// the softness that gives the flake its "real" rather than
+	// "pixelated" quality.
+	grad.addColorStop( 0, 'rgba(255, 255, 255, 1)' );
+	grad.addColorStop( 0.3, 'rgba(250, 252, 255, 0.9)' );
+	// Mid rolloff — visible but clearly fading. Without this midpoint
+	// the alpha drops too sharply and the flake reads as a
+	// hard-edged dot.
+	grad.addColorStop( 0.6, 'rgba(235, 245, 255, 0.32)' );
+	// Faint halo trailing off into the rim.
+	grad.addColorStop( 0.88, 'rgba(220, 232, 255, 0.07)' );
+	grad.addColorStop( 1, 'rgba(210, 228, 255, 0)' );
+	ctx.fillStyle = grad;
+	ctx.fillRect( 0, 0, size, size );
+
+	return pixi.Texture.from( canvas );
+}
+
+function rand( a: number, b: number ): number {
+	return a + Math.random() * ( b - a );
+}
+
+/**
+ * Create the Pixi application, build the particle pool, and start the
+ * simulation. Resolves to the scene handle; rejects if Pixi fails to
+ * initialize (no WebGL, context limit) — the caller restores the
+ * backdrop and reports through the shell's mount-failure path.
+ */
+export async function mountSnowScene(
+	opts: SnowSceneOptions,
+): Promise< SnowScene > {
+	const { container, pixi, getSurfaces } = opts;
+
+	// Backdrop: pure CSS; the transparent Pixi canvas overlays it and
+	// gives the field its sense of depth.
+	const priorBackground = container.style.background;
+	container.style.background = backdropCss( opts.settings.background );
+
+	// Live-tunable copy of the user settings — applySettings() swaps
+	// the values and the hot loop reads them per frame.
+	const tunables: SnowSettings = { ...opts.settings };
+
+	const app: PixiApp = new pixi.Application();
+	try {
+		await app.init( {
+			resizeTo: container,
+			backgroundAlpha: 0,
+			antialias: true,
+			autoDensity: true,
+			resolution: Math.min( window.devicePixelRatio || 1, 2 ),
+		} );
+	} catch ( err ) {
+		container.style.background = priorBackground;
+		throw err;
+	}
+
+	container.appendChild( app.canvas );
+	app.canvas.style.position = 'absolute';
+	app.canvas.style.inset = '0';
+	app.canvas.style.width = '100%';
+	app.canvas.style.height = '100%';
+	app.canvas.style.pointerEvents = 'none';
+
+	const texture = buildSnowflakeTexture( pixi );
+
+	// Pixi v8's ParticleContainer is the fast path for many sprites
+	// sharing a single texture: it bypasses the full display-list
+	// tree and batches per-particle attributes into tight vertex
+	// buffers. `dynamicProperties` declares which fields we mutate
+	// each frame — NOTE `vertex: true` is what makes scaleX/scaleY
+	// upload per-frame (there is no `scale` key; see pixi-types.ts).
+	const stage = new pixi.ParticleContainer( {
+		dynamicProperties: {
+			position: true,
+			vertex: true,
+			rotation: true,
+			color: true,
+		},
+	} );
+	app.stage.addChild( stage );
+
+	const MAX = POOL_SIZE;
+
+	// Flat typed arrays — the tick loop does zero heap allocations
+	// per particle per frame.
+	const pX = new Float32Array( MAX );
+	const pY = new Float32Array( MAX );
+	const pVX = new Float32Array( MAX );
+	const pVY = new Float32Array( MAX );
+	const pSize = new Float32Array( MAX );
+	const pRot = new Float32Array( MAX );
+	const pRotVel = new Float32Array( MAX );
+	const pDriftPhase = new Float32Array( MAX );
+	const pDriftFreq = new Float32Array( MAX );
+	const pDriftAmp = new Float32Array( MAX );
+	const pBaseAlpha = new Float32Array( MAX );
+	/** 0 free · 1 falling · 2 stuck · 3 melting */
+	const pState = new Uint8Array( MAX );
+	/** Surface element this flake is stuck to (null = synthetic). */
+	const pAnchor: Array< HTMLElement | null > = new Array( MAX );
+	const pAnchorDX = new Float32Array( MAX );
+	const pAnchorDY = new Float32Array( MAX );
+	const pStuckLife = new Float32Array( MAX );
+	const pMelt = new Float32Array( MAX );
+	/**
+	 * Surface id (e.g. `window:foo`, `shell:floor`) this flake is
+	 * stuck to. Used at release/detach time to find the pile bucket
+	 * array and decrement the height this flake added. `null` when
+	 * the flake isn't stuck.
+	 */
+	const pSurfaceId: Array< string | null > = new Array( MAX );
+	/**
+	 * Index into the per-surface pile array — the column this flake
+	 * landed in. `-1` when not stuck. Stored separately from
+	 * `pAnchorDX` because the bucket is a discrete integer while DX
+	 * is a sub-pixel float used for positioning.
+	 */
+	const pBucket = new Int32Array( MAX );
+	/**
+	 * Pile height this flake contributed when it landed (in CSS px).
+	 * Recomputable from `pSize * pileContribution`, but storing the
+	 * exact value handles tuning changes mid-session without
+	 * orphaning pile height.
+	 */
+	const pPileAdd = new Float32Array( MAX );
+	/**
+	 * How much of `pPileAdd` is still in the pile right now. As the
+	 * flake melts, this gets gradually decremented (and the pile
+	 * height with it). On release, any residual is returned in one
+	 * shot. Tracked separately so a partially-melted flake can be
+	 * detached early (window close mid-melt) and still return the
+	 * correct amount to the pile without double-counting against the
+	 * gradual decrement that was already happening.
+	 */
+	const pPileRemaining = new Float32Array( MAX );
+
+	const particles: Array< PixiParticle | null > = new Array( MAX );
+	const freeList: number[] = new Array( MAX );
+	for ( let i = 0; i < MAX; i++ ) {
+		const particle = new pixi.Particle( {
+			texture,
+			anchorX: 0.5,
+			anchorY: 0.5,
+			// Free particles are hidden via alpha rather than removed
+			// from the container — the mutation is already on the
+			// GPU's dynamic-color path, so this is cheaper than
+			// churning the particle list.
+			alpha: 0,
+			tint: 0xffffff,
+		} );
+		stage.addParticle( particle );
+		particles[ i ] = particle;
+		pState[ i ] = 0;
+		pAnchor[ i ] = null;
+		pSurfaceId[ i ] = null;
+		pBucket[ i ] = -1;
+		pPileAdd[ i ] = 0;
+		pPileRemaining[ i ] = 0;
+		// Populate the free-list in reverse so we spawn from index 0
+		// onward — a minor quality-of-life for debugging.
+		freeList[ i ] = MAX - 1 - i;
+	}
+	let freeCount: number = MAX;
+
+	/**
+	 * Per-surface snow-pile height profile, keyed by `surface.id`.
+	 * Each value is a `Float32Array` indexed by bucket — bucket width
+	 * is `TUNING.pileBucketPx` and indices run from the surface's
+	 * left edge in surface-local coordinates. Stored in the closure
+	 * rather than on the surface object so piles survive surface
+	 * refreshes; pruned when their surface disappears from the
+	 * shell's surface list.
+	 *
+	 * Indexed reads/writes are bounds-checked at the call site — a
+	 * stale `pBucket` for a now-pruned surface harmlessly hits the
+	 * `pileHeights.get(...) === undefined` path and skips the
+	 * decrement.
+	 */
+	const pileHeights = new Map< string, Float32Array >();
+
+	// Cached list of solid surfaces with a `top` face — the shell
+	// owns the authoritative list (windows, taskbar, widget cards,
+	// shell floor, plus anything plugin filters push in via
+	// `desktop-mode.wallpaper.surfaces`) and hands it back via
+	// `getSurfaces`. Refreshed on a 20Hz cadence, and eagerly
+	// whenever the entry flips the dirty bit on a window-geometry
+	// hook so stuck-flake positions track fast-moving windows
+	// without a one-tick lag.
+	const surfaces: WallpaperSurface[] = [];
+	let surfacesDirty = true;
+	let canvasRect = app.canvas.getBoundingClientRect();
+
+	function refreshCanvasRect(): void {
+		canvasRect = app.canvas.getBoundingClientRect();
+	}
+
+	function refreshSurfacesIfDirty(): void {
+		if ( ! surfacesDirty ) {
+			return;
+		}
+		surfaces.length = 0;
+		if ( ! getSurfaces ) {
+			surfacesDirty = false;
+			return;
+		}
+		const all = getSurfaces();
+		let liveIds: Set< string > | null = null; // only build the set if there are piles to prune
+		for ( let k = 0; k < all.length; k++ ) {
+			const s = all[ k ];
+			// Accumulation is only defined for horizontal tops.
+			// Vertical surfaces (dock edge) are in the list but snow
+			// doesn't pile on them — skip.
+			if ( s.face !== 'top' ) {
+				continue;
+			}
+			if ( s.rect.width <= 0 || s.rect.height <= 0 ) {
+				continue;
+			}
+			surfaces.push( s );
+			if ( pileHeights.size > 0 ) {
+				if ( liveIds === null ) {
+					liveIds = new Set();
+				}
+				liveIds.add( s.id );
+			}
+		}
+		// Prune pile entries whose surface is no longer in the
+		// shell's list (window closed, widget removed, virtual-
+		// desktop switch). Stuck flakes pointing at the pruned
+		// surface have already been detached or are about to be (the
+		// per-particle stuck branch detects `isConnected` false /
+		// `offsetParent` null on the next tick); after detach their
+		// `pSurfaceId` is reset to null so a later release won't try
+		// to decrement the gone pile.
+		if ( pileHeights.size > 0 ) {
+			pileHeights.forEach( ( _arr, id ) => {
+				if ( ! liveIds || ! liveIds.has( id ) ) {
+					pileHeights.delete( id );
+				}
+			} );
+		}
+		surfacesDirty = false;
+	}
+
+	/**
+	 * Fetch (and lazily allocate / resize) the pile-height array for
+	 * a surface. Bucket count tracks the surface's current width — if
+	 * the surface resizes between calls we reallocate and copy what
+	 * fits, which preserves accumulated snow on the left side of a
+	 * window during a right-edge resize and only sacrifices the
+	 * columns that fell off.
+	 */
+	function getPileForSurface( surface: WallpaperSurface ): Float32Array {
+		const bucketCount = Math.max(
+			1,
+			Math.ceil( surface.rect.width / TUNING.pileBucketPx ),
+		);
+		const existing = pileHeights.get( surface.id );
+		if ( existing && existing.length === bucketCount ) {
+			return existing;
+		}
+		const fresh = new Float32Array( bucketCount );
+		if ( existing ) {
+			// Preserve overlapping range so a horizontal resize keeps
+			// the snow that's still under the window's footprint
+			// rather than blanking the pile.
+			const copyLen = Math.min( existing.length, bucketCount );
+			for ( let i = 0; i < copyLen; i++ ) {
+				fresh[ i ] = existing[ i ];
+			}
+		}
+		pileHeights.set( surface.id, fresh );
+		return fresh;
+	}
+
+	function spawn(): void {
+		if ( freeCount === 0 ) {
+			return;
+		}
+		const idx = freeList[ --freeCount ];
+		const w = app.canvas.clientWidth;
+		const sizeMax = tunables.flakeSize;
+		const sizeMin = sizeMax / 2;
+		pX[ idx ] = Math.random() * w;
+		// Spawn well above the canvas top so the flake drifts down
+		// for ~1–3 s before becoming visible — by the time it crosses
+		// the viewport edge it already has a horizontal wind/sway
+		// component and varied alpha, which reads as "entering from
+		// above" rather than "popping into existence at the top
+		// edge". The wide range (50–180 px) also staggers the entry
+		// timing so the field never has a visible horizontal "front"
+		// of fresh flakes.
+		pY[ idx ] = -rand( 50, 180 );
+		pVX[ idx ] = rand( -8, 8 );
+		pVY[ idx ] = rand( TUNING.gravityMin, TUNING.gravityMax );
+		pSize[ idx ] = rand( sizeMin, sizeMax );
+		pRot[ idx ] = Math.random() * Math.PI * 2;
+		pRotVel[ idx ] = rand( -TUNING.rotationMax, TUNING.rotationMax );
+		pDriftPhase[ idx ] = Math.random() * Math.PI * 2;
+		pDriftFreq[ idx ] =
+			( 2 * Math.PI ) /
+			rand( TUNING.driftPeriodMin, TUNING.driftPeriodMax );
+		pDriftAmp[ idx ] = rand( 6, TUNING.driftAmplitude );
+		pBaseAlpha[ idx ] = rand( TUNING.alphaMin, TUNING.alphaMax );
+		pMelt[ idx ] = 0;
+		pStuckLife[ idx ] = 0;
+		pAnchor[ idx ] = null;
+		pSurfaceId[ idx ] = null;
+		pBucket[ idx ] = -1;
+		pPileAdd[ idx ] = 0;
+		pState[ idx ] = 1;
+		pPileRemaining[ idx ] = 0;
+
+		const particle = particles[ idx ];
+		if ( ! particle ) {
+			return;
+		}
+		const scale = pSize[ idx ] / TEXTURE_SIZE;
+		particle.scaleX = scale;
+		particle.scaleY = scale;
+		particle.alpha = pBaseAlpha[ idx ];
+		particle.rotation = pRot[ idx ];
+		particle.x = pX[ idx ];
+		particle.y = pY[ idx ];
+	}
+
+	/**
+	 * Subtract this flake's REMAINING pile contribution from the pile
+	 * column it occupies — used by release() and detachToFalling().
+	 * `pPileRemaining` tracks how much of the landing-time `pPileAdd`
+	 * is still in the pile; melt-phase ticks gradually return
+	 * contribution to the pile, so by the time release fires this is
+	 * usually zero. Detaches that happen mid-melt (window close)
+	 * still return any residual.
+	 */
+	function decrementPileFor( idx: number ): void {
+		const sid = pSurfaceId[ idx ];
+		if ( sid === null ) {
+			return;
+		}
+		const pile = pileHeights.get( sid );
+		if ( ! pile ) {
+			return;
+		}
+		const b = pBucket[ idx ];
+		if ( b < 0 || b >= pile.length ) {
+			return;
+		}
+		const add = pPileRemaining[ idx ];
+		if ( add <= 0 ) {
+			return;
+		}
+		const spread = add * TUNING.pileSpread;
+		pile[ b ] = Math.max( 0, pile[ b ] - add );
+		if ( b > 0 ) {
+			pile[ b - 1 ] = Math.max( 0, pile[ b - 1 ] - spread );
+		}
+		if ( b + 1 < pile.length ) {
+			pile[ b + 1 ] = Math.max( 0, pile[ b + 1 ] - spread );
+		}
+		pPileRemaining[ idx ] = 0;
+	}
+
+	function release( idx: number ): void {
+		// Returns any residual pile contribution; a naturally-melted
+		// flake's `pPileRemaining` is already zero by this point.
+		decrementPileFor( idx );
+		pState[ idx ] = 0;
+		pAnchor[ idx ] = null;
+		pSurfaceId[ idx ] = null;
+		pBucket[ idx ] = -1;
+		pPileAdd[ idx ] = 0;
+		pPileRemaining[ idx ] = 0;
+		// Hide via alpha — the particle stays in the container and is
+		// reused when the free-list hands this index back out from
+		// spawn().
+		const particle = particles[ idx ];
+		if ( particle ) {
+			particle.alpha = 0;
+		}
+		freeList[ freeCount++ ] = idx;
+	}
+
+	/**
+	 * Anchor a freshly-collided flake to a surface, with its vertical
+	 * offset set so it sits on top of the existing pile in its bucket
+	 * (DY is negative because the surface rect's top is the reference
+	 * — pile grows upward in screen space).
+	 */
+	function stick(
+		idx: number,
+		anchorEl: HTMLElement | null,
+		dx: number,
+		pileHeight: number,
+		surfaceId: string,
+		bucket: number,
+		pileAdd: number,
+	): void {
+		pState[ idx ] = 2;
+		pAnchor[ idx ] = anchorEl;
+		pAnchorDX[ idx ] = dx;
+		// Anchor is the surface's top edge; subtract the pile so the
+		// flake renders on top of the existing column.
+		// `collisionMarginY` keeps the bottom of the pile a hair
+		// below the surface edge so the title-bar shadow doesn't poke
+		// through.
+		pAnchorDY[ idx ] = TUNING.collisionMarginY - pileHeight;
+		pSurfaceId[ idx ] = surfaceId;
+		pBucket[ idx ] = bucket;
+		pPileAdd[ idx ] = pileAdd;
+		pPileRemaining[ idx ] = pileAdd;
+		pVX[ idx ] = 0;
+		pVY[ idx ] = 0;
+		pRotVel[ idx ] = 0;
+		pStuckLife[ idx ] = rand(
+			TUNING.stuckLifeSec - TUNING.stuckLifeJitter,
+			TUNING.stuckLifeSec + TUNING.stuckLifeJitter,
+		);
+	}
+
+	function startMelt( idx: number ): void {
+		pState[ idx ] = 3;
+		pMelt[ idx ] = 0;
+	}
+
+	/**
+	 * Drop a stuck flake back into the falling state — used when the
+	 * surface under it disappears (window closes) rather than melts.
+	 * Physically: the "ground" has been yanked away, so gravity takes
+	 * over and the flake resumes its descent from wherever it was
+	 * resting.
+	 *
+	 * Velocity is the full freshly-spawned gravity range — a reduced
+	 * "gentle restart" velocity reads as flakes floating in place at
+	 * these sizes. Real snow detached from a surface reaches the same
+	 * terminal velocity as snow falling from the sky, so the model
+	 * uses the spawn-time range.
+	 */
+	function detachToFalling( idx: number ): void {
+		decrementPileFor( idx );
+		pState[ idx ] = 1;
+		pAnchor[ idx ] = null;
+		pSurfaceId[ idx ] = null;
+		pBucket[ idx ] = -1;
+		pPileAdd[ idx ] = 0;
+		pPileRemaining[ idx ] = 0;
+		pVX[ idx ] = rand( -6, 6 );
+		pVY[ idx ] = rand( TUNING.gravityMin, TUNING.gravityMax );
+		pRotVel[ idx ] = rand( -TUNING.rotationMax, TUNING.rotationMax );
+	}
+
+	/**
+	 * Collision test — falling flake vs every `top` surface the shell
+	 * publishes, AND the running pile of snow that has already
+	 * settled on each surface's columns. Crossing is detected by
+	 * comparing last-frame Y to this-frame Y against the
+	 * pile-adjusted edge line, so fast-moving flakes can't "tunnel"
+	 * through in a single tick.
+	 *
+	 * Coordinates: pX / pY live in the Pixi canvas's local space
+	 * (0,0 = top-left of the wallpaper layer). Surface rects come in
+	 * viewport coordinates (see `WallpaperSurface`), so we bridge
+	 * through canvasRect.
+	 *
+	 * The shell's surface list already covers the floor (as
+	 * `shell:floor`), taskbar top, widget-card tops, and every
+	 * non-minimized window top — no separate floor path needed.
+	 */
+	function collideWithSurfaces( idx: number, prevY: number ): boolean {
+		const vpX = pX[ idx ] + canvasRect.left;
+		const vpY = pY[ idx ] + canvasRect.top;
+		const prevVpY = prevY + canvasRect.top;
+		for ( let k = 0; k < surfaces.length; k++ ) {
+			const s = surfaces[ k ];
+			const r = s.rect;
+			if ( vpX < r.x || vpX > r.x + r.width ) {
+				continue;
+			}
+
+			// Resolve which pile bucket this flake's X column falls
+			// into (surface-local). Clamp to valid range — a
+			// sub-pixel rounding error at the surface's right edge
+			// can push the index one past the end.
+			const pile = getPileForSurface( s );
+			let bucket = Math.floor( ( vpX - r.x ) / TUNING.pileBucketPx );
+			if ( bucket < 0 ) {
+				bucket = 0;
+			} else if ( bucket >= pile.length ) {
+				bucket = pile.length - 1;
+			}
+			const pileHeight = pile[ bucket ];
+			const top = r.y + TUNING.collisionMarginY - pileHeight;
+
+			if ( prevVpY <= top && vpY >= top ) {
+				// Compute this flake's contribution before we stick —
+				// once stuck the size is fixed so we can record the
+				// exact amount for an accurate decrement at release
+				// time.
+				const add = pSize[ idx ] * TUNING.pileContribution;
+				const spread = add * TUNING.pileSpread;
+
+				// Stick first, then grow the pile. The `pileHeight`
+				// just read is what THIS flake sits on top of —
+				// successive flakes in this bucket will see a taller
+				// pile and land higher up.
+				stick( idx, s.element, vpX - r.x, pileHeight, s.id, bucket, add );
+
+				// Pile growth caps at `pileMaxPx` per bucket — beyond
+				// that the surface is "saturated" and further flakes
+				// still stick but don't push the column higher
+				// (visually they pile up invisibly inside the cap).
+				pile[ bucket ] = Math.min( TUNING.pileMaxPx, pile[ bucket ] + add );
+				if ( bucket > 0 ) {
+					pile[ bucket - 1 ] = Math.min(
+						TUNING.pileMaxPx,
+						pile[ bucket - 1 ] + spread,
+					);
+				}
+				if ( bucket + 1 < pile.length ) {
+					pile[ bucket + 1 ] = Math.min(
+						TUNING.pileMaxPx,
+						pile[ bucket + 1 ] + spread,
+					);
+				}
+				return true;
+			}
+		}
+		return false;
+	}
+
+	let elapsed = 0;
+	let lastRectRefresh = -1;
+	let spawnAccum = 0;
+	let animating = ! opts.prefersReducedMotion;
+
+	/** Spawn rate scaled so every density fills in the same time. */
+	function spawnPerSecond(): number {
+		return (
+			( TUNING.spawnPerSecondAtDefault * tunables.particleCount ) /
+			TUNING.spawnCalibrationCount
+		);
+	}
+
+	if ( ! animating ) {
+		// A static frame: spawn a partial field once, pause.
+		const staticCount = tunables.particleCount * 0.35;
+		for ( let s = 0; s < staticCount; s++ ) {
+			spawn();
+		}
+	}
+
+	function tick( ticker: PixiTicker ): void {
+		let dt = ticker.deltaMS / 1000;
+		if ( dt > 0.1 ) {
+			dt = 0.1; // clamp tab-restore hiccups
+		}
+		elapsed += dt;
+
+		// Cheap refresh cadence — the surface cache is only stale by
+		// one frame during a drag, imperceptible to the eye. The
+		// window-geometry hooks additionally flip the dirty bit
+		// mid-interval during active drags, so stuck flakes track
+		// fast-moving windows smoothly.
+		if ( elapsed - lastRectRefresh > 0.05 ) {
+			surfacesDirty = true;
+			lastRectRefresh = elapsed;
+		}
+		refreshCanvasRect();
+		refreshSurfacesIfDirty();
+
+		const wind =
+			Math.sin( ( elapsed / TUNING.windPeriodSec ) * Math.PI * 2 ) *
+			tunables.wind;
+
+		if ( animating ) {
+			spawnAccum += dt * spawnPerSecond();
+			while ( spawnAccum >= 1 ) {
+				// The user's particle count is the live ceiling — the
+				// pool itself is allocated at the settings maximum so
+				// the knob can move without a rebuild.
+				if ( MAX - freeCount >= tunables.particleCount ) {
+					spawnAccum = 0;
+					break;
+				}
+				spawn();
+				spawnAccum -= 1;
+			}
+		}
+
+		const w = app.canvas.clientWidth;
+		const h = app.canvas.clientHeight;
+
+		for ( let idx = 0; idx < MAX; idx++ ) {
+			const st = pState[ idx ];
+			if ( st === 0 ) {
+				continue;
+			}
+			const particle = particles[ idx ];
+			if ( ! particle ) {
+				continue;
+			}
+
+			if ( st === 1 ) {
+				const prevY = pY[ idx ];
+
+				const sway =
+					Math.sin( elapsed * pDriftFreq[ idx ] + pDriftPhase[ idx ] ) *
+					pDriftAmp[ idx ];
+				// Ease vx toward (wind + sway) so gusts feel inertial
+				// rather than snapping.
+				pVX[ idx ] +=
+					( wind + sway - pVX[ idx ] ) * Math.min( 1, dt * 1.5 );
+
+				pX[ idx ] += pVX[ idx ] * dt;
+				pY[ idx ] += pVY[ idx ] * dt;
+				pRot[ idx ] += pRotVel[ idx ] * dt;
+
+				// Horizontal wrap — keeps the field dense without
+				// spawning sideways edge cases.
+				if ( pX[ idx ] < -16 ) {
+					pX[ idx ] += w + 32;
+				} else if ( pX[ idx ] > w + 16 ) {
+					pX[ idx ] -= w + 32;
+				}
+
+				if ( collideWithSurfaces( idx, prevY ) ) {
+					// Position already handled by stick().
+				} else if ( pY[ idx ] > h + 24 ) {
+					// Fell past every surface — the shell floor should
+					// have caught the flake, but if no surfaces exist
+					// (tile preview, or no shell) recycle anyway.
+					release( idx );
+					continue;
+				}
+
+				if ( pState[ idx ] === 1 ) {
+					particle.x = pX[ idx ];
+					particle.y = pY[ idx ];
+					particle.rotation = pRot[ idx ];
+				}
+			}
+
+			if ( pState[ idx ] === 2 ) {
+				const anchorEl = pAnchor[ idx ];
+				if ( anchorEl ) {
+					// Two distinct "anchor is gone" modes:
+					//
+					//   `!isConnected` → the anchor element has been
+					//   removed from the DOM entirely (the underlying
+					//   window / widget / card has been destroyed).
+					//   Physically this is "someone yanked the ground
+					//   away" — the realistic response is gravity, so
+					//   we detach the flake back into the falling
+					//   state and let it continue its descent.
+					//
+					//   `offsetParent === null` → the element is still
+					//   in the DOM but not rendering (minimized
+					//   window, switched virtual desktop, collapsed
+					//   widget). Physically the ground is still there,
+					//   just hidden — the flake has nowhere to fall
+					//   to, so it melts in place. This also prevents a
+					//   minimize/restore cycle from visually
+					//   "respawning" flakes mid-air.
+					if ( ! anchorEl.isConnected ) {
+						detachToFalling( idx );
+					} else if ( anchorEl.offsetParent === null ) {
+						startMelt( idx );
+					} else {
+						const arect = anchorEl.getBoundingClientRect();
+						// Resize-shrink guard: the flake's anchored
+						// X-offset is relative to the surface's left
+						// edge AT THE MOMENT OF STICKING. If the user
+						// has since resized the window such that the
+						// flake's column is no longer over the surface
+						// (width shrank past it, or left edge moved
+						// right past it), physically the ground under
+						// the flake is gone. Detach to falling — same
+						// "ground yanked away" reasoning as a window
+						// close — rather than render the flake
+						// floating outside the live rect.
+						if (
+							pAnchorDX[ idx ] < 0 ||
+							pAnchorDX[ idx ] > arect.width
+						) {
+							detachToFalling( idx );
+							continue;
+						}
+						const ax =
+							arect.left - canvasRect.left + pAnchorDX[ idx ];
+						const ay =
+							arect.top - canvasRect.top + pAnchorDY[ idx ];
+						pX[ idx ] = ax;
+						pY[ idx ] = ay;
+						particle.x = ax;
+						particle.y = ay;
+					}
+				} else {
+					particle.x = pX[ idx ];
+					particle.y = pY[ idx ];
+				}
+
+				if ( pState[ idx ] === 2 ) {
+					pStuckLife[ idx ] -= dt;
+					if ( pStuckLife[ idx ] <= 0 ) {
+						startMelt( idx );
+					}
+				}
+			}
+
+			if ( pState[ idx ] === 3 ) {
+				pMelt[ idx ] += dt / TUNING.meltDurationSec;
+				const t = pMelt[ idx ] > 1 ? 1 : pMelt[ idx ];
+				particle.alpha = pBaseAlpha[ idx ] * ( 1 - t );
+				const meltScale =
+					( pSize[ idx ] / TEXTURE_SIZE ) * ( 1 - t * 0.6 );
+				particle.scaleX = meltScale;
+				particle.scaleY = meltScale;
+
+				// Gradual pile decrement + slide-above-flakes-down. As
+				// this flake fades visually, its pile contribution is
+				// returned proportionally — same fraction of
+				// `pPileAdd` as `dt / meltDurationSec`. Each frame we
+				// also slide every flake stacked above this one (same
+				// surface, same bucket, smaller `pAnchorDY`) down by
+				// the same delta, so the column compacts smoothly
+				// instead of leaving upper flakes hanging in mid-air
+				// when this one finishes melting.
+				if ( pPileRemaining[ idx ] > 0 && pSurfaceId[ idx ] !== null ) {
+					const meltStep = dt / TUNING.meltDurationSec;
+					const rawDelta = pPileAdd[ idx ] * meltStep;
+					const delta =
+						rawDelta < pPileRemaining[ idx ]
+							? rawDelta
+							: pPileRemaining[ idx ];
+					pPileRemaining[ idx ] -= delta;
+
+					const pile = pileHeights.get( pSurfaceId[ idx ] as string );
+					if (
+						pile &&
+						pBucket[ idx ] >= 0 &&
+						pBucket[ idx ] < pile.length
+					) {
+						const bk = pBucket[ idx ];
+						const spread = delta * TUNING.pileSpread;
+						pile[ bk ] = Math.max( 0, pile[ bk ] - delta );
+						if ( bk > 0 ) {
+							pile[ bk - 1 ] = Math.max(
+								0,
+								pile[ bk - 1 ] - spread,
+							);
+						}
+						if ( bk + 1 < pile.length ) {
+							pile[ bk + 1 ] = Math.max(
+								0,
+								pile[ bk + 1 ] - spread,
+							);
+						}
+					}
+
+					// Slide everything stacked above this flake in the
+					// same surface + bucket down by `delta`. "Above" =
+					// smaller `pAnchorDY` (= higher on screen, in
+					// pAnchorDY's down-positive convention). The cost
+					// of iterating the pool per melting flake per
+					// frame is modest — even the maximum pool with a
+					// few dozen simultaneous melts stays well under a
+					// millisecond per frame in practice.
+					const mySid = pSurfaceId[ idx ];
+					const myBucket = pBucket[ idx ];
+					const myDY = pAnchorDY[ idx ];
+					for ( let j = 0; j < MAX; j++ ) {
+						if (
+							pState[ j ] === 2 &&
+							pSurfaceId[ j ] === mySid &&
+							pBucket[ j ] === myBucket &&
+							pAnchorDY[ j ] < myDY
+						) {
+							pAnchorDY[ j ] += delta;
+						}
+					}
+				}
+
+				if ( t >= 1 ) {
+					release( idx );
+				}
+			}
+		}
+	}
+
+	app.ticker.add( tick );
+	if ( ! animating ) {
+		// Render one frame so the static field populates, then hold.
+		app.ticker.update();
+		app.ticker.stop();
+	}
+
+	let destroyed = false;
+
+	return {
+		setAnimating( next: boolean ): void {
+			if ( destroyed ) {
+				return;
+			}
+			animating = next && ! opts.prefersReducedMotion;
+			if ( animating ) {
+				app.ticker.start();
+			} else {
+				app.ticker.stop();
+			}
+		},
+		applySettings( next: SnowSettings ): void {
+			if ( destroyed ) {
+				return;
+			}
+			// Wind applies on the next frame; flake size on the next
+			// spawn (the field turns over within seconds); a lowered
+			// particle count drains through natural recycling while a
+			// raised one fills at the scaled spawn rate.
+			tunables.wind = next.wind;
+			tunables.particleCount = next.particleCount;
+			tunables.flakeSize = next.flakeSize;
+			if ( next.background !== tunables.background ) {
+				tunables.background = next.background;
+				container.style.background = backdropCss( next.background );
+			}
+		},
+		markSurfacesDirty(): void {
+			surfacesDirty = true;
+		},
+		detachFlakesAnchoredTo( element: HTMLElement ): void {
+			if ( destroyed ) {
+				return;
+			}
+			surfacesDirty = true;
+			for ( let i = 0; i < MAX; i++ ) {
+				if ( pState[ i ] === 2 && pAnchor[ i ] === element ) {
+					detachToFalling( i );
+				}
+			}
+		},
+		destroy(): void {
+			if ( destroyed ) {
+				return;
+			}
+			destroyed = true;
+			app.ticker.stop();
+			app.ticker.remove( tick );
+			// Destroy the Pixi app — releases the WebGL context, the
+			// canvas, every particle, and the generated texture.
+			app.destroy(
+				{ removeView: true },
+				{ children: true, texture: true, textureSource: true },
+			);
+			// Break references the GC might not reclaim otherwise.
+			for ( let i = 0; i < MAX; i++ ) {
+				particles[ i ] = null;
+				pAnchor[ i ] = null;
+			}
+			container.style.background = priorBackground;
+		},
+	};
+}

--- a/src/plugins/snow-wallpaper/settings.ts
+++ b/src/plugins/snow-wallpaper/settings.ts
@@ -1,0 +1,199 @@
+/**
+ * Snow wallpaper — user-tunable settings.
+ *
+ * Four knobs surface in the wallpaper's config dialog (OS Settings →
+ * Wallpaper → "Wallpaper settings"): wind strength, particle count,
+ * flake size, and the backdrop colour. Everything else in the
+ * simulation stays fixed tuning (see `scene.ts`).
+ *
+ * Values persist through the shell's per-wallpaper settings surface
+ * (`ctx.settings` / `ctx.setSettings`), so they arrive untrusted —
+ * {@link sanitizeSnowSettings} clamps every field back to a sane
+ * range and falls back to the defaults for anything missing or
+ * malformed.
+ *
+ * @since 0.9.5
+ */
+
+/** Resolved, validated settings the scene consumes. */
+export interface SnowSettings {
+	/**
+	 * Peak horizontal wind (px/s) of the slow global sin sweep.
+	 * 0 disables the sweep entirely (per-particle sway remains).
+	 */
+	wind: number;
+	/**
+	 * Sprite-pool size — how many flakes can exist at once. Larger =
+	 * denser field, heavier frame cost. At saturation the visible rate
+	 * of new flakes equals `count / lifetime`, so this (not the spawn
+	 * rate) sets the steady-state "actively snowing" feel.
+	 */
+	particleCount: number;
+	/**
+	 * Largest flake diameter in CSS px (soft halo included). The
+	 * smallest flake is always half this, preserving the field's
+	 * near/far depth mix at every size.
+	 */
+	flakeSize: number;
+	/**
+	 * Backdrop base colour (hex). The night-sky gradient behind the
+	 * canvas is derived from it — see {@link backdropCss}.
+	 */
+	background: string;
+}
+
+/**
+ * Defaults — the wallpaper's canonical tuning. The dialog's sliders
+ * start here, and {@link sanitizeSnowSettings} falls back here.
+ */
+export const SNOW_DEFAULTS: SnowSettings = {
+	wind: 22,
+	particleCount: 660,
+	flakeSize: 16,
+	background: '#0c1a36',
+};
+
+/** Slider bounds for the config dialog — also the sanitizer clamps. */
+export const SNOW_LIMITS = {
+	wind: { min: 0, max: 80 },
+	particleCount: { min: 100, max: 2000 },
+	flakeSize: { min: 6, max: 40 },
+} as const;
+
+/** Clamp a numeric setting into its limits, defaulting when invalid. */
+function clampNumber(
+	value: unknown,
+	limits: { min: number; max: number },
+	fallback: number,
+): number {
+	if ( typeof value !== 'number' || ! Number.isFinite( value ) ) {
+		return fallback;
+	}
+	return Math.min( limits.max, Math.max( limits.min, value ) );
+}
+
+/**
+ * Coerce an untrusted settings bag (from `ctx.settings`) into a fully
+ * populated {@link SnowSettings}.
+ */
+export function sanitizeSnowSettings(
+	raw: Record< string, unknown > | undefined,
+): SnowSettings {
+	const bag = raw ?? {};
+	return {
+		wind: clampNumber( bag.wind, SNOW_LIMITS.wind, SNOW_DEFAULTS.wind ),
+		particleCount: Math.round(
+			clampNumber(
+				bag.particleCount,
+				SNOW_LIMITS.particleCount,
+				SNOW_DEFAULTS.particleCount,
+			),
+		),
+		flakeSize: clampNumber(
+			bag.flakeSize,
+			SNOW_LIMITS.flakeSize,
+			SNOW_DEFAULTS.flakeSize,
+		),
+		background:
+			typeof bag.background === 'string' &&
+			/^#[0-9a-f]{6}$/i.test( bag.background )
+				? bag.background.toLowerCase()
+				: SNOW_DEFAULTS.background,
+	};
+}
+
+/**
+ * HSL deltas between the backdrop's base colour and its two lighter
+ * stops, measured from the canonical midnight gradient
+ * (`#0c1a36 → #1d355e @55% → #425d8a @100%`). Applying the deltas to
+ * the default base reproduces those stops byte-for-byte; applying
+ * them to a user-picked base keeps the same "night sky lightening
+ * toward the horizon" relationship — hue drifts slightly, lightness
+ * rises, saturation washes out.
+ */
+const STOP_55_DELTA = { h: -2.1538461538461604, s: -0.10790835181079084, l: 0.11176470588235296 };
+const STOP_100_DELTA = { h: -2.5, s: -0.2834224598930483, l: 0.2705882352941177 };
+
+/** Parse `#rrggbb` into HSL (h in degrees, s/l in 0–1). */
+function hexToHsl( hex: string ): { h: number; s: number; l: number } {
+	const r = parseInt( hex.slice( 1, 3 ), 16 ) / 255;
+	const g = parseInt( hex.slice( 3, 5 ), 16 ) / 255;
+	const b = parseInt( hex.slice( 5, 7 ), 16 ) / 255;
+	const max = Math.max( r, g, b );
+	const min = Math.min( r, g, b );
+	const l = ( max + min ) / 2;
+	const d = max - min;
+	if ( d === 0 ) {
+		return { h: 0, s: 0, l };
+	}
+	const s = l < 0.5 ? d / ( max + min ) : d / ( 2 - max - min );
+	let h;
+	if ( max === r ) {
+		h = ( g - b ) / d + ( g < b ? 6 : 0 );
+	} else if ( max === g ) {
+		h = ( b - r ) / d + 2;
+	} else {
+		h = ( r - g ) / d + 4;
+	}
+	return { h: h * 60, s, l };
+}
+
+/** Convert HSL (h degrees, s/l 0–1, both clamped) back to `#rrggbb`. */
+function hslToHex( h: number, s: number, l: number ): string {
+	h = ( ( h % 360 ) + 360 ) % 360;
+	s = Math.min( 1, Math.max( 0, s ) );
+	l = Math.min( 1, Math.max( 0, l ) );
+	const c = ( 1 - Math.abs( 2 * l - 1 ) ) * s;
+	const x = c * ( 1 - Math.abs( ( ( h / 60 ) % 2 ) - 1 ) );
+	const m = l - c / 2;
+	let r = 0;
+	let g = 0;
+	let b = 0;
+	if ( h < 60 ) {
+		r = c;
+		g = x;
+	} else if ( h < 120 ) {
+		r = x;
+		g = c;
+	} else if ( h < 180 ) {
+		g = c;
+		b = x;
+	} else if ( h < 240 ) {
+		g = x;
+		b = c;
+	} else if ( h < 300 ) {
+		r = x;
+		b = c;
+	} else {
+		r = c;
+		b = x;
+	}
+	const channel = ( v: number ): string =>
+		Math.round( ( v + m ) * 255 )
+			.toString( 16 )
+			.padStart( 2, '0' );
+	return `#${ channel( r ) }${ channel( g ) }${ channel( b ) }`;
+}
+
+/**
+ * Build the backdrop CSS gradient from a base colour. Pure CSS — the
+ * transparent Pixi canvas overlays it, which is what gives the field
+ * its sense of depth.
+ *
+ * With the default base this returns the canonical
+ * `linear-gradient(180deg, #0c1a36 0%, #1d355e 55%, #425d8a 100%)`.
+ */
+export function backdropCss( background: string ): string {
+	const base = hexToHsl( background );
+	const mid = hslToHex(
+		base.h + STOP_55_DELTA.h,
+		base.s + STOP_55_DELTA.s,
+		base.l + STOP_55_DELTA.l,
+	);
+	const bottom = hslToHex(
+		base.h + STOP_100_DELTA.h,
+		base.s + STOP_100_DELTA.s,
+		base.l + STOP_100_DELTA.l,
+	);
+	return `linear-gradient(180deg, ${ background } 0%, ${ mid } 55%, ${ bottom } 100%)`;
+}

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -163,6 +163,7 @@ export const DEFAULTS: OsSettingsState = {
 		angle: 135,
 	},
 	customImage: null,
+	wallpaperSettings: {},
 	libraryHdOnly: true,
 	ai: {
 		enabled: false,

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -42,6 +42,7 @@
 import type { WallpaperLayer } from '../wallpapers/layer';
 import type { WallpaperTeardown } from '../wallpapers/types';
 import * as registry from '../wallpapers/registry';
+import { seedWallpaperSettings } from '../wallpapers/settings-store';
 import {
 	DEFAULT_WALLPAPER_ID,
 	DOCK_SIZES,
@@ -279,6 +280,13 @@ export class OsSettings implements SettingsCtx {
 		if ( ! shell ) {
 			return;
 		}
+
+		// Mirror the persisted per-wallpaper settings into the shared
+		// runtime store BEFORE the layer mounts anything, so the mount's
+		// `ctx.settings` reads the user's saved values. apply() runs on
+		// boot, on every settings change, and after a save-failure
+		// rollback — re-seeding on each covers all three paths.
+		seedWallpaperSettings( this.state.wallpaperSettings );
 
 		// Wallpaper — look up in the registry. Fall back to the
 		// server-declared default id (via `desktop_mode_default_wallpaper`)

--- a/src/settings/sections/wallpaper-previews.ts
+++ b/src/settings/sections/wallpaper-previews.ts
@@ -24,6 +24,7 @@
 
 import { applyFilters, HOOKS } from '../../hooks';
 import * as registry from '../../wallpapers/registry';
+import { getWallpaperSettings } from '../../wallpapers/settings-store';
 import type {
 	WallpaperDef,
 	WallpaperPreviewContext,
@@ -246,6 +247,7 @@ export function createWallpaperPreviewManager(
 			pluginUrl: pluginUrl(),
 			prefersReducedMotion: prefersReducedMotion(),
 			visible: ! document.hidden,
+			settings: getWallpaperSettings( def.id ),
 			params: previewParams( def ),
 			width: p.mountWidth,
 			height: p.mountHeight,

--- a/src/settings/sections/wallpaper.ts
+++ b/src/settings/sections/wallpaper.ts
@@ -5,10 +5,21 @@
  * over the OS Settings state they render from.
  */
 
-import { __ } from '../../i18n';
+import { __, sprintf } from '../../i18n';
 import { html, render } from '../../ui/core';
 import * as registry from '../../wallpapers/registry';
-import type { WallpaperDef, WallpaperTeardown } from '../../wallpapers/types';
+import {
+	getWallpaperSettings,
+	publishWallpaperSettings,
+	type WallpaperSettings,
+} from '../../wallpapers/settings-store';
+import type {
+	WallpaperConfigContext,
+	WallpaperDef,
+	WallpaperTeardown,
+} from '../../wallpapers/types';
+import '../../ui/components/wpd-modal/wpd-modal';
+import '../../ui/components/wpd-button/wpd-button';
 import {
 	CUSTOM_GRADIENT_ID,
 	CUSTOM_IMAGE_ID,
@@ -118,6 +129,185 @@ export function selectWallpaper(
 	if ( slot ) {
 		syncWallpaperDescription( ctx, slot );
 	}
+	const configSlot = body.querySelector<HTMLElement>(
+		'.desktop-mode-os-settings__wallpaper-config-slot',
+	);
+	if ( configSlot ) {
+		syncWallpaperConfigButton( ctx, configSlot );
+	}
+}
+
+/**
+ * Render (or collapse) the "Wallpaper settings" button for the active
+ * selection. Only wallpapers whose def carries `renderConfig` get the
+ * button — for everything else the slot stays collapsed, so the
+ * surface is invisible unless the wallpaper opted in.
+ *
+ * @since 0.9.5
+ */
+export function syncWallpaperConfigButton(
+	ctx: SettingsCtx,
+	slot: HTMLElement,
+): void {
+	const inner = slot.firstElementChild as HTMLElement | null;
+	if ( ! inner ) {
+		return;
+	}
+	const def = registry.get( ctx.state.wallpaper );
+	if ( ! def || typeof def.renderConfig !== 'function' ) {
+		slot.dataset.expanded = 'false';
+		slot.style.marginTop = '';
+		return;
+	}
+	// The expanded margin also lives in os-settings.css, but this
+	// surface is reached by lazy-loaded JS in long-lived sessions
+	// whose stylesheet predates it — inline the one load-bearing
+	// spacing rule so the button never renders flush against the
+	// description card above it.
+	slot.style.marginTop = '12px';
+	render(
+		html`
+			<div class="desktop-mode-os-settings__wallpaper-config">
+				<wpd-button
+					variant="secondary"
+					@click=${ () => openWallpaperConfigDialog( ctx, def ) }
+				>
+					<wpd-icon name="admin-generic"></wpd-icon>
+					${ __( 'Wallpaper settings' ) }
+				</wpd-button>
+			</div>
+		`,
+		inner,
+	);
+	slot.dataset.expanded = 'true';
+}
+
+/**
+ * Open the wallpaper's settings dialog: a `<wpd-modal>` on
+ * `document.body` whose body is handed to the def's `renderConfig`.
+ * The shell owns the chrome (title, focus trap, Done button, ESC /
+ * click-outside); the wallpaper owns the form.
+ *
+ * The config context's `setSettings` merges into the persisted
+ * per-wallpaper bag, saves through the normal OS Settings pipeline,
+ * and publishes to the shared store — which fires
+ * `desktop-mode.wallpaper.settings-changed` so a mounted instance of
+ * the wallpaper live-applies without a remount.
+ *
+ * @since 0.9.5
+ */
+export function openWallpaperConfigDialog(
+	ctx: SettingsCtx,
+	def: WallpaperDef,
+): void {
+	if ( typeof def.renderConfig !== 'function' ) {
+		return;
+	}
+
+	const modal = document.createElement( 'wpd-modal' );
+	modal.setAttribute( 'size', 'sm' );
+	modal.setAttribute(
+		'title',
+		sprintf(
+			/* translators: %s: wallpaper name. */
+			__( '%s settings' ),
+			def.label,
+		),
+	);
+
+	const body = document.createElement( 'div' );
+	body.className = 'desktop-mode-os-settings__wallpaper-config-form';
+	// Same class exists in os-settings.css, but the dialog opens from
+	// lazy-loaded JS in sessions whose stylesheet may predate this
+	// surface — without the column layout the fields flow inline and
+	// the form is unreadable. Inline the critical rules so the dialog
+	// is correct in every session; the stylesheet adds the finish.
+	body.style.display = 'flex';
+	body.style.flexDirection = 'column';
+	body.style.gap = '14px';
+	modal.appendChild( body );
+
+	const done = document.createElement( 'wpd-button' );
+	done.setAttribute( 'slot', 'footer' );
+	done.setAttribute( 'variant', 'primary' );
+	done.textContent = __( 'Done' );
+	modal.appendChild( done );
+
+	let configTeardown: WallpaperTeardown | null = null;
+	let closed = false;
+	const close = (): void => {
+		if ( closed ) {
+			return;
+		}
+		closed = true;
+		if ( configTeardown ) {
+			try {
+				configTeardown();
+			} catch ( err ) {
+				if ( typeof console !== 'undefined' ) {
+					console.error(
+						`[desktop-mode] Wallpaper "${ def.id }" config teardown threw:`,
+						err,
+					);
+				}
+			}
+			configTeardown = null;
+		}
+		modal.remove();
+	};
+	done.addEventListener( 'click', close );
+	modal.addEventListener( 'wpd-modal-cancel', close );
+
+	const configCtx: WallpaperConfigContext = {
+		id: def.id,
+		pluginUrl: '',
+		prefersReducedMotion:
+			typeof window.matchMedia === 'function' &&
+			window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches,
+		visible: ! document.hidden,
+		settings: getWallpaperSettings( def.id ),
+		setSettings: ( partial ) => {
+			const merged: WallpaperSettings = {
+				...( ctx.state.wallpaperSettings[ def.id ] ?? {} ),
+				...partial,
+			};
+			ctx.state.wallpaperSettings[ def.id ] = merged;
+			ctx.save();
+			publishWallpaperSettings( def.id, merged );
+		},
+	};
+
+	document.body.appendChild( modal );
+	modal.setAttribute( 'open', '' );
+
+	try {
+		const result = def.renderConfig( body, configCtx );
+		if ( isPromise( result ) ) {
+			result.then( ( teardown: WallpaperTeardown ) => {
+				if ( closed ) {
+					// The user closed the dialog before the async render
+					// resolved — release immediately.
+					try {
+						teardown();
+					} catch {
+						/* best-effort */
+					}
+					return;
+				}
+				configTeardown = teardown;
+			} );
+		} else {
+			configTeardown = result;
+		}
+	} catch ( err ) {
+		if ( typeof console !== 'undefined' ) {
+			console.error(
+				`[desktop-mode] Wallpaper "${ def.id }" renderConfig threw:`,
+				err,
+			);
+		}
+		close();
+	}
 }
 
 /**
@@ -212,6 +402,7 @@ export function syncEditorSlot(
 			typeof window.matchMedia === 'function' &&
 			window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches,
 		visible: ! document.hidden,
+		settings: getWallpaperSettings( def.id ),
 	};
 
 	try {
@@ -375,6 +566,17 @@ export function buildWallpaperSection(
 		'desktop-mode-os-settings__wallpaper-description-slot-inner';
 	descriptionSlot.appendChild( descriptionInner );
 
+	// Config slot: same collapsing pattern, hosting the "Wallpaper
+	// settings" button when the selected wallpaper ships a
+	// `renderConfig` dialog (see syncWallpaperConfigButton).
+	const configSlot = document.createElement( 'div' );
+	configSlot.className = 'desktop-mode-os-settings__wallpaper-config-slot';
+	configSlot.dataset.expanded = 'false';
+	const configInner = document.createElement( 'div' );
+	configInner.className =
+		'desktop-mode-os-settings__wallpaper-config-slot-inner';
+	configSlot.appendChild( configInner );
+
 	const onPick = ( e: Event ): void => {
 		const id = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
 		const def = registry.get( id );
@@ -428,7 +630,8 @@ export function buildWallpaperSection(
 								</wpd-swatch>`,
 		) }
 					</div>
-					${ descriptionSlot } ${ editorSlot } ${ customImageSection }
+					${ descriptionSlot } ${ configSlot } ${ editorSlot }
+					${ customImageSection }
 				</wpd-section>
 			`,
 			wrapper,
@@ -444,6 +647,7 @@ export function buildWallpaperSection(
 		syncEditorSlot( ctx, editorSlot, editorInner, active );
 	}
 	syncWallpaperDescription( ctx, descriptionSlot );
+	syncWallpaperConfigButton( ctx, configSlot );
 
 	// Live-update when plugins register or unregister wallpapers
 	// mid-session. The server-sync module fires register()/unregister()
@@ -471,6 +675,7 @@ export function buildWallpaperSection(
 			syncEditorSlot( ctx, editorSlot, editorInner, now );
 		}
 		syncWallpaperDescription( ctx, descriptionSlot );
+		syncWallpaperConfigButton( ctx, configSlot );
 	} );
 
 	return wrapper;

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -154,6 +154,7 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 				: DEFAULTS.windowLinkHighlight,
 		customGradient: sanitizeCustomGradient( parsed.customGradient ),
 		customImage: sanitizeCustomImage( parsed.customImage ),
+		wallpaperSettings: sanitizeWallpaperSettings( parsed.wallpaperSettings ),
 		libraryHdOnly:
 			typeof parsed.libraryHdOnly === 'boolean'
 				? parsed.libraryHdOnly
@@ -216,6 +217,80 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 			parsed.dockPromotedPositions,
 		),
 	};
+}
+
+/**
+ * Coerce an untrusted `wallpaperSettings` value into per-wallpaper
+ * scalar bags. Non-scalar values are dropped; ids follow the
+ * wallpaper-id charset (`vendor/sub-id` slashes allowed, mirroring
+ * the unfocus-effect ids); keys follow the JS identifier-ish charset
+ * wallpaper authors use (`camelCase`, hyphens, underscores). Capped
+ * at 64 wallpapers × 32 keys with 256-char string values so a
+ * corrupted server payload can't bloat the cell.
+ */
+export function sanitizeWallpaperSettings(
+	raw: unknown,
+): Record< string, Record< string, string | number | boolean > > {
+	if ( ! raw || typeof raw !== 'object' || Array.isArray( raw ) ) {
+		return {};
+	}
+	const out: Record<
+		string,
+		Record< string, string | number | boolean >
+	> = {};
+	let idCount = 0;
+	for ( const [ id, bag ] of Object.entries(
+		raw as Record< string, unknown >,
+	) ) {
+		if ( idCount >= 64 ) {
+			break;
+		}
+		if (
+			typeof id !== 'string' ||
+			id === '' ||
+			! /^[a-z0-9_/-]+$/.test( id )
+		) {
+			continue;
+		}
+		if ( ! bag || typeof bag !== 'object' || Array.isArray( bag ) ) {
+			continue;
+		}
+		const clean: Record< string, string | number | boolean > = {};
+		let keyCount = 0;
+		for ( const [ key, value ] of Object.entries(
+			bag as Record< string, unknown >,
+		) ) {
+			if ( keyCount >= 32 ) {
+				break;
+			}
+			if (
+				typeof key !== 'string' ||
+				key === '' ||
+				! /^[a-zA-Z0-9_-]+$/.test( key )
+			) {
+				continue;
+			}
+			if ( typeof value === 'boolean' ) {
+				clean[ key ] = value;
+			} else if (
+				typeof value === 'number' &&
+				Number.isFinite( value )
+			) {
+				clean[ key ] = value;
+			} else if ( typeof value === 'string' ) {
+				clean[ key ] = value.slice( 0, 256 );
+			} else {
+				continue;
+			}
+			keyCount++;
+		}
+		if ( keyCount === 0 ) {
+			continue;
+		}
+		out[ id ] = clean;
+		idCount++;
+	}
+	return out;
 }
 
 function sanitizeItemVisibility(
@@ -362,6 +437,12 @@ function _cloneState( state: OsSettingsState ): OsSettingsState {
 		...state,
 		customGradient: { ...state.customGradient },
 		customImage: state.customImage ? { ...state.customImage } : null,
+		wallpaperSettings: Object.fromEntries(
+			Object.entries( state.wallpaperSettings ).map( ( [ k, v ] ) => [
+				k,
+				{ ...v },
+			] ),
+		),
 		ai: { ...state.ai },
 		nativePostsHiddenColumns: state.nativePostsHiddenColumns.slice(),
 		itemVisibility: { ...state.itemVisibility },
@@ -565,6 +646,7 @@ export function structuredDefaults(): OsSettingsState {
 		...DEFAULTS,
 		customGradient: { ...DEFAULTS.customGradient },
 		customImage: null,
+		wallpaperSettings: { ...DEFAULTS.wallpaperSettings },
 		ai: { ...DEFAULTS.ai },
 		// Clone the collection fields too. A shallow `...DEFAULTS`
 		// aliases these nested objects, so a later in-place mutation

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -147,6 +147,20 @@ export interface OsSettingsState {
 	customGradient: CustomGradient;
 	customImage: CustomImage | null;
 	/**
+	 * Per-wallpaper settings bags, keyed by wallpaper id — the values a
+	 * wallpaper's `renderConfig` dialog writes (e.g. the Snow
+	 * wallpaper's wind / particle count / flake size / background).
+	 * Scalar values only; the wallpaper owns the keys' meaning. Missing
+	 * ids mean "never configured" — the wallpaper uses its defaults.
+	 * Capped at 64 wallpapers × 32 keys.
+	 *
+	 * @since 0.9.5
+	 */
+	wallpaperSettings: Record<
+		string,
+		Record< string, string | number | boolean >
+	>;
+	/**
 	 * Whether the Media Library picker filters out small images. Default
 	 * on — smaller images are icons/avatars that look terrible stretched
 	 * to cover the desktop.

--- a/src/ui/components/wpd-button/wpd-button.styles.ts
+++ b/src/ui/components/wpd-button/wpd-button.styles.ts
@@ -45,7 +45,7 @@ export const styles = css`
 		cursor: not-allowed;
 	}
 	button:hover:not( :disabled ) {
-		background: rgba( 0, 0, 0, 0.04 );
+		background: var( --wpd-button-bg-hover, rgba( 0, 0, 0, 0.04 ) );
 	}
 	/* Primary */
 	:host( [ variant='primary' ] ) button {

--- a/src/ui/components/wpd-button/wpd-button.ts
+++ b/src/ui/components/wpd-button/wpd-button.ts
@@ -22,6 +22,7 @@
  * `docs/components-reference.md`):
  *
  *   --wpd-button-bg              — background color
+ *   --wpd-button-bg-hover        — hover wash (ghost + secondary)
  *   --wpd-button-fg              — text color
  *   --wpd-button-border          — shorthand for the border
  *   --wpd-button-border-radius   — corner radius (default 6px)
@@ -92,6 +93,10 @@ export class WpdButton extends Component {
 		parts: [ { name: 'button', description: 'Underlying <button> element.' } ],
 		cssProps: [
 			{ name: '--wpd-button-bg', description: 'Background color.' },
+			{
+				name: '--wpd-button-bg-hover',
+				description: 'Hover wash (ghost + secondary variants).',
+			},
 			{ name: '--wpd-button-fg', description: 'Text color.' },
 			{ name: '--wpd-button-border', description: 'Border shorthand.' },
 			{ name: '--wpd-button-border-radius', default: '6px' },

--- a/src/ui/components/wpd-color-field/wpd-color-field.styles.ts
+++ b/src/ui/components/wpd-color-field/wpd-color-field.styles.ts
@@ -43,13 +43,14 @@ export const styles = css`
 	}
 	/*
 	 * WebKit paints the color swatch inside an extra wrapper with
-	 * a default 4 px border — strip it so the input reads as a
-	 * flat colored panel matching the rest of OS Settings.
+	 * a default border — strip it in EVERY variant so the input
+	 * reads as a single flat colored panel with our border, not a
+	 * double frame.
 	 */
-	:host( [ variant='block' ] ) input[ type='color' ]::-webkit-color-swatch-wrapper {
+	input[ type='color' ]::-webkit-color-swatch-wrapper {
 		padding: 2px;
 	}
-	:host( [ variant='block' ] ) input[ type='color' ]::-webkit-color-swatch {
+	input[ type='color' ]::-webkit-color-swatch {
 		border: none;
 		border-radius: 2px;
 	}

--- a/src/ui/components/wpd-modal/wpd-modal.styles.ts
+++ b/src/ui/components/wpd-modal/wpd-modal.styles.ts
@@ -10,6 +10,24 @@ export const modalStyles = css`
 		background: rgba( 0, 0, 0, 0.45 );
 		backdrop-filter: blur( 2px );
 		z-index: 10000;
+
+		/* The dialog surface is dark regardless of the admin color
+		   scheme, but the shared surface tokens the component kit
+		   reads (labels, value readouts, control borders) default to
+		   light-admin values — near-black text and gray hairlines
+		   that vanish on this background. Re-point them here so both
+		   shadow internals AND slotted light-DOM content (custom
+		   properties cross the slot boundary) resolve readable
+		   dark-surface colors. Anything can still override per
+		   instance — these carry normal cascade specificity. */
+		--desktop-mode-text: #f0f0f1;
+		--desktop-mode-text-muted: #bbc1c7;
+		--desktop-mode-muted: #a7aaad;
+		--desktop-mode-muted-fg: #a7aaad;
+		--desktop-mode-border: rgba( 255, 255, 255, 0.25 );
+		/* Ghost/secondary button hover washes — the light-surface
+		   defaults are black-on-black here. */
+		--wpd-button-bg-hover: rgba( 255, 255, 255, 0.08 );
 	}
 
 	:host( [ open ] ) {

--- a/src/ui/components/wpd-modal/wpd-modal.ts
+++ b/src/ui/components/wpd-modal/wpd-modal.ts
@@ -37,7 +37,7 @@ export class WpdModal extends Component {
 	static help = {
 		title: 'Modal overlay',
 		summary:
-			'Overlay container with title, body, and footer slots. Handles ESC, click-outside, focus trap. Use for rich modal flows that go beyond a yes/no confirm.',
+			'Overlay container with title, body, and footer slots. Handles ESC, click-outside, focus trap. Use for rich modal flows that go beyond a yes/no confirm. The dialog surface is dark and re-points the shared surface tokens (--desktop-mode-text/-muted/-border, --wpd-button-bg-hover) so wpd-* controls slotted into it resolve readable dark-surface colors automatically.',
 		status: 'experimental',
 		since: '0.8.5',
 		props: [

--- a/src/wallpapers/layer.ts
+++ b/src/wallpapers/layer.ts
@@ -17,6 +17,7 @@
 
 import { doAction, HOOKS } from '../hooks';
 import { loadModules } from '../modules/registry';
+import { getWallpaperSettings } from './settings-store';
 import type {
 	CanvasWallpaperDef,
 	CssWallpaperDef,
@@ -35,6 +36,7 @@ export function createContext(
 		pluginUrl,
 		prefersReducedMotion: prefersReducedMotion(),
 		visible: ! document.hidden,
+		settings: getWallpaperSettings( id ),
 	};
 }
 

--- a/src/wallpapers/settings-store.ts
+++ b/src/wallpapers/settings-store.ts
@@ -1,0 +1,102 @@
+/**
+ * Desktop Mode — Per-wallpaper settings store.
+ *
+ * Holds the current user's per-wallpaper settings (the values edited
+ * through a wallpaper's `renderConfig` dialog in OS Settings). The
+ * canonical persisted copy lives in `OsSettingsState.wallpaperSettings`
+ * (user meta + localStorage, same save pipeline as every other OS
+ * Settings preference); this store is the runtime mirror every bundle
+ * reads from:
+ *
+ *   - The wallpaper layer stamps the active wallpaper's settings onto
+ *     `WallpaperContext.settings` at mount time.
+ *   - The OS Settings preview manager does the same for tile previews.
+ *   - The config dialog writes through {@link publishWallpaperSettings},
+ *     which also fires `desktop-mode.wallpaper.settings-changed` so a
+ *     mounted wallpaper can live-apply without a remount.
+ *
+ * Routed through `createSharedStore` because the OS Settings panel
+ * ships in its own Vite bundle — a module-level map would give the
+ * main bundle and the panel bundle each their own copy (see
+ * AGENTS.md, "Cross-bundle state").
+ *
+ * @since 0.9.5
+ */
+
+import { doAction, HOOKS } from '../hooks';
+import { createSharedStore } from '../shared-store';
+
+/**
+ * A wallpaper's settings bag. Scalar values only — the shape mirrors
+ * what the PHP sanitizer (`includes/os-settings.php`) round-trips.
+ */
+export type WallpaperSettings = Record< string, string | number | boolean >;
+
+interface WallpaperSettingsStore {
+	values: Record< string, WallpaperSettings >;
+}
+
+const store = createSharedStore< WallpaperSettingsStore >(
+	'desktop-mode/wallpaper-settings',
+	() => ( { values: {} } ),
+);
+
+/**
+ * Read a wallpaper's current settings. Returns a copy — mutating the
+ * result never writes back; use {@link publishWallpaperSettings}.
+ *
+ * @since 0.9.5
+ *
+ * @param id Wallpaper id.
+ * @return The wallpaper's settings (empty object when none saved).
+ */
+export function getWallpaperSettings( id: string ): WallpaperSettings {
+	return { ...( store.state.values[ id ] ?? {} ) };
+}
+
+/**
+ * Replace the whole store from the persisted OS Settings state. Called
+ * on boot (and after a save-failure rollback) by `OsSettings.apply()`.
+ * Silent — no change hook fires; the boot path re-applies the active
+ * wallpaper anyway, and firing per-id here would double-notify.
+ *
+ * @since 0.9.5
+ *
+ * @param all Map of wallpaper id → settings.
+ */
+export function seedWallpaperSettings(
+	all: Record< string, WallpaperSettings >,
+): void {
+	const values = store.state.values;
+	for ( const key of Object.keys( values ) ) {
+		delete values[ key ];
+	}
+	for ( const [ id, settings ] of Object.entries( all ) ) {
+		values[ id ] = { ...settings };
+	}
+}
+
+/**
+ * Write a wallpaper's settings into the store and fire the
+ * `desktop-mode.wallpaper.settings-changed` action so a mounted
+ * wallpaper (or anything else watching) can live-apply.
+ *
+ * Persistence is the caller's job — the OS Settings config dialog
+ * writes the same object into `state.wallpaperSettings` and calls
+ * `ctx.save()` alongside this.
+ *
+ * @since 0.9.5
+ *
+ * @param id       Wallpaper id.
+ * @param settings Full post-merge settings object for the wallpaper.
+ */
+export function publishWallpaperSettings(
+	id: string,
+	settings: WallpaperSettings,
+): void {
+	store.state.values[ id ] = { ...settings };
+	doAction( HOOKS.WALLPAPER_SETTINGS_CHANGED, {
+		id,
+		settings: { ...settings },
+	} );
+}

--- a/src/wallpapers/types.ts
+++ b/src/wallpapers/types.ts
@@ -37,6 +37,20 @@ export interface WallpaperContext {
 	 * asset paths — e.g. `${ctx.pluginUrl}/assets/vendor/pixi.min.js`.
 	 */
 	pluginUrl: string;
+	/**
+	 * The current user's persisted settings for this wallpaper — the
+	 * values last written through the wallpaper's `renderConfig` dialog
+	 * (empty object when the wallpaper has never been configured). The
+	 * wallpaper owns the keys' meaning; treat every value as untrusted
+	 * and fall back to defaults for missing/invalid entries.
+	 *
+	 * This is a snapshot taken when the context was created. To follow
+	 * changes while mounted, subscribe to the
+	 * `desktop-mode.wallpaper.settings-changed` action.
+	 *
+	 * @since 0.9.5
+	 */
+	settings: Record< string, unknown >;
 }
 
 /**
@@ -104,6 +118,53 @@ export type WallpaperPreview = (
 ) => WallpaperMountResult;
 
 /**
+ * Context object passed to {@link WallpaperConfig} callbacks —
+ * everything {@link WallpaperContext} carries, plus the write half of
+ * the settings surface.
+ *
+ * @since 0.9.5
+ */
+export interface WallpaperConfigContext extends WallpaperContext {
+	/**
+	 * Merge a partial settings object into the wallpaper's persisted
+	 * settings. The shell persists the result through the OS Settings
+	 * save pipeline (localStorage + debounced user-meta sync) and fires
+	 * the `desktop-mode.wallpaper.settings-changed` action with the
+	 * post-merge object, so a mounted instance of the wallpaper can
+	 * live-apply without a remount.
+	 *
+	 * Values must be scalars (string | number | boolean) — anything
+	 * else is dropped by the server-side sanitizer on the next load.
+	 */
+	setSettings( partial: Record< string, string | number | boolean > ): void;
+}
+
+/**
+ * Optional settings dialog for the wallpaper, opened from the
+ * "Wallpaper settings" button in OS Settings (the button only renders
+ * for the selected wallpaper and only when its def carries this
+ * callback). The shell owns the dialog chrome (`<wpd-modal>`, focus
+ * trap, close/done affordances); the callback renders the form
+ * controls into the dialog body it receives.
+ *
+ * Contract mirrors `mount`: return a teardown (sync or via Promise)
+ * that releases anything the form wired up. The teardown runs when
+ * the dialog closes.
+ *
+ * Distinct from {@link WallpaperEditor} on purpose: `renderEditor` is
+ * an always-visible inline panel below the picker grid (good for one
+ * or two controls the user plays with constantly, like the custom
+ * gradient's colors); `renderConfig` is a modal for a fuller settings
+ * form that would crowd the panel.
+ *
+ * @since 0.9.5
+ */
+export type WallpaperConfig = (
+	container: HTMLElement,
+	ctx: WallpaperConfigContext,
+) => WallpaperMountResult;
+
+/**
  * Shared fields on every wallpaper definition — identification, a
  * preview value for the swatch grid in OS Settings, and the optional
  * editor callback.
@@ -152,6 +213,14 @@ interface WallpaperDefBase {
 	 * @since 0.9.5
 	 */
 	renderPreview?: WallpaperPreview;
+	/**
+	 * Optional settings dialog, opened from the "Wallpaper settings"
+	 * button OS Settings shows for the selected wallpaper. Wallpapers
+	 * without this callback show no button. See {@link WallpaperConfig}.
+	 *
+	 * @since 0.9.5
+	 */
+	renderConfig?: WallpaperConfig;
 	/**
 	 * Author-declared default parameters for `renderPreview`, exposed
 	 * to `ctx.params` after the `desktop-mode.wallpaper.preview-params`

--- a/tests/phpunit/tests/osSettings.php
+++ b/tests/phpunit/tests/osSettings.php
@@ -480,4 +480,129 @@ class Tests_DesktopMode_OsSettings extends WP_UnitTestCase {
 		$this->assertFalse( $loaded['windowLinkRaiseOnFocus'] );
 		$this->assertTrue( $loaded['windowLinkHighlight'] );
 	}
+
+	/**
+	 * @covers ::desktop_mode_default_os_settings
+	 */
+	public function test_default_includes_empty_wallpaper_settings() {
+		$defaults = desktop_mode_default_os_settings();
+		$this->assertArrayHasKey( 'wallpaperSettings', $defaults );
+		$this->assertSame( array(), $defaults['wallpaperSettings'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_keeps_well_formed_wallpaper_settings() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'wallpaperSettings' => array(
+					'wp-snow'         => array(
+						'wind'          => 40,
+						'particleCount' => 900,
+						'flakeSize'     => 12.5,
+						'background'    => '#123456',
+						'enabled'       => true,
+					),
+					// Namespaced ids (`vendor/sub-id`) keep the slash.
+					'vendor/aquarium' => array( 'fishCount' => 7 ),
+				),
+			)
+		);
+		$this->assertSame( 40, $clean['wallpaperSettings']['wp-snow']['wind'] );
+		$this->assertSame( 900, $clean['wallpaperSettings']['wp-snow']['particleCount'] );
+		$this->assertSame( 12.5, $clean['wallpaperSettings']['wp-snow']['flakeSize'] );
+		$this->assertSame( '#123456', $clean['wallpaperSettings']['wp-snow']['background'] );
+		$this->assertTrue( $clean['wallpaperSettings']['wp-snow']['enabled'] );
+		$this->assertSame( 7, $clean['wallpaperSettings']['vendor/aquarium']['fishCount'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_drops_malformed_wallpaper_settings() {
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'wallpaperSettings' => array(
+					// Non-scalar values are dropped; the bag survives if
+					// anything valid remains.
+					'wp-snow'   => array(
+						'wind'   => 10,
+						'nested' => array( 'evil' => true ),
+					),
+					// Bags with nothing valid are dropped entirely.
+					'wp-empty'  => array( 'cb' => array( 1, 2 ) ),
+					// Chars outside the id charset are stripped (same
+					// normalization as unfocus-effect ids).
+					'<script>'  => array( 'x' => 1 ),
+					// Non-array bags are dropped.
+					'wp-string' => 'not-a-bag',
+				),
+			)
+		);
+		$this->assertSame( array( 'wind' => 10 ), $clean['wallpaperSettings']['wp-snow'] );
+		$this->assertArrayNotHasKey( 'wp-empty', $clean['wallpaperSettings'] );
+		$this->assertArrayNotHasKey( 'wp-string', $clean['wallpaperSettings'] );
+		$this->assertArrayHasKey( 'script', $clean['wallpaperSettings'] );
+		$this->assertCount( 2, $clean['wallpaperSettings'] );
+
+		// Non-array payload falls back to the default empty map.
+		$clean = desktop_mode_sanitize_os_settings( array( 'wallpaperSettings' => 'bogus' ) );
+		$this->assertSame( array(), $clean['wallpaperSettings'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_sanitize_os_settings
+	 */
+	public function test_sanitize_caps_and_trims_wallpaper_settings() {
+		// String values are length-capped at 256 characters.
+		$clean = desktop_mode_sanitize_os_settings(
+			array(
+				'wallpaperSettings' => array(
+					'wp-snow' => array( 'label' => str_repeat( 'a', 300 ) ),
+				),
+			)
+		);
+		$this->assertSame( 256, strlen( $clean['wallpaperSettings']['wp-snow']['label'] ) );
+
+		// Wallpaper ids cap at 64 entries.
+		$many = array();
+		for ( $i = 0; $i < 70; $i++ ) {
+			$many[ 'wp-' . $i ] = array( 'x' => $i );
+		}
+		$clean = desktop_mode_sanitize_os_settings( array( 'wallpaperSettings' => $many ) );
+		$this->assertCount( 64, $clean['wallpaperSettings'] );
+
+		// Keys per bag cap at 32.
+		$bag = array();
+		for ( $i = 0; $i < 40; $i++ ) {
+			$bag[ 'k' . $i ] = $i;
+		}
+		$clean = desktop_mode_sanitize_os_settings(
+			array( 'wallpaperSettings' => array( 'wp-snow' => $bag ) )
+		);
+		$this->assertCount( 32, $clean['wallpaperSettings']['wp-snow'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_save_os_settings
+	 * @covers ::desktop_mode_get_os_settings
+	 */
+	public function test_user_meta_round_trip_keeps_wallpaper_settings() {
+		$user_id = self::factory()->user->create();
+		desktop_mode_save_os_settings(
+			$user_id,
+			array(
+				'wallpaperSettings' => array(
+					'wp-snow' => array(
+						'wind'       => 55,
+						'background' => '#0c1a36',
+					),
+				),
+			)
+		);
+		$loaded = desktop_mode_get_os_settings( $user_id );
+		$this->assertSame( 55, $loaded['wallpaperSettings']['wp-snow']['wind'] );
+		$this->assertSame( '#0c1a36', $loaded['wallpaperSettings']['wp-snow']['background'] );
+	}
 }

--- a/tests/phpunit/tests/wallpapers.php
+++ b/tests/phpunit/tests/wallpapers.php
@@ -177,12 +177,36 @@ class Tests_DesktopMode_Wallpapers extends WP_UnitTestCase {
 		}
 
 		// Every built-in ships a non-empty description…
-		foreach ( array( 'dark', 'aurora', 'sunset', 'forest', 'mono', 'wp-animated-logo', 'wp-living-tree' ) as $id ) {
+		foreach ( array( 'dark', 'aurora', 'sunset', 'forest', 'mono', 'wp-animated-logo', 'wp-living-tree', 'wp-snow' ) as $id ) {
 			$this->assertArrayHasKey( $id, $by_id );
 			$this->assertNotSame( '', $by_id[ $id ]['description'], "{$id} should carry a description" );
 		}
 		// …and the Living Tree's is the open-source tribute.
 		$this->assertStringContainsString( 'Matt Mullenweg', $by_id['wp-living-tree']['description'] );
 		$this->assertStringContainsString( 'open source', $by_id['wp-living-tree']['description'] );
+	}
+
+	/**
+	 * The Snow wallpaper is a canvas built-in: it must declare its
+	 * script handle (the def with `mount` / `renderConfig` is published
+	 * on the JS global by that script), and its picker swatch must
+	 * match the default backdrop the JS side paints — the swatch
+	 * renders before the wallpaper script has ever loaded, so a
+	 * mismatch would show one sky in the picker and a different one
+	 * once selected.
+	 *
+	 * @covers ::desktop_mode_register_builtin_wallpapers
+	 */
+	public function test_snow_builtin_is_canvas_with_script_and_backdrop_preview() {
+		$snow = desktop_mode_desktop_wallpaper_registry( 'wp-snow' );
+
+		$this->assertIsArray( $snow );
+		$this->assertSame( 'canvas', $snow['type'] );
+		$this->assertSame( 'desktop-mode-snow-wallpaper', $snow['script'] );
+		$this->assertTrue( wp_script_is( 'desktop-mode-snow-wallpaper', 'registered' ) );
+		$this->assertSame(
+			'linear-gradient(180deg, #0c1a36 0%, #1d355e 55%, #425d8a 100%)',
+			$snow['preview']
+		);
 	}
 }

--- a/tests/vitest/snow-wallpaper-settings.test.ts
+++ b/tests/vitest/snow-wallpaper-settings.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Snow wallpaper — settings sanitization + backdrop derivation.
+ *
+ * The backdrop test is load-bearing: the OS Settings swatch is a
+ * static PHP-registered gradient string, and the JS side must paint
+ * the exact same gradient at default settings — a drift between the
+ * two would show one sky in the picker and a different one once
+ * selected (the PHPUnit side pins the PHP half).
+ */
+import { describe, expect, test } from 'vitest';
+import {
+	backdropCss,
+	sanitizeSnowSettings,
+	SNOW_DEFAULTS,
+	SNOW_LIMITS,
+} from '../../src/plugins/snow-wallpaper/settings';
+
+describe( 'sanitizeSnowSettings', () => {
+	test( 'empty / missing input falls back to defaults', () => {
+		expect( sanitizeSnowSettings( undefined ) ).toEqual( SNOW_DEFAULTS );
+		expect( sanitizeSnowSettings( {} ) ).toEqual( SNOW_DEFAULTS );
+	} );
+
+	test( 'keeps well-formed values', () => {
+		expect(
+			sanitizeSnowSettings( {
+				wind: 40,
+				particleCount: 900,
+				flakeSize: 12,
+				background: '#123ABC',
+			} ),
+		).toEqual( {
+			wind: 40,
+			particleCount: 900,
+			flakeSize: 12,
+			background: '#123abc',
+		} );
+	} );
+
+	test( 'clamps out-of-range numbers into limits', () => {
+		const clean = sanitizeSnowSettings( {
+			wind: 9999,
+			particleCount: 1,
+			flakeSize: -4,
+		} );
+		expect( clean.wind ).toBe( SNOW_LIMITS.wind.max );
+		expect( clean.particleCount ).toBe( SNOW_LIMITS.particleCount.min );
+		expect( clean.flakeSize ).toBe( SNOW_LIMITS.flakeSize.min );
+	} );
+
+	test( 'drops malformed values back to defaults', () => {
+		const clean = sanitizeSnowSettings( {
+			wind: 'gusty',
+			particleCount: NaN,
+			flakeSize: null,
+			background: 'not-a-color',
+		} );
+		expect( clean ).toEqual( SNOW_DEFAULTS );
+	} );
+
+	test( 'rounds fractional particle counts', () => {
+		expect( sanitizeSnowSettings( { particleCount: 500.6 } ).particleCount ).toBe( 501 );
+	} );
+} );
+
+describe( 'backdropCss', () => {
+	test( 'default background reproduces the canonical gradient exactly', () => {
+		// Must match the `preview` string registered in
+		// includes/wallpapers.php byte for byte.
+		expect( backdropCss( SNOW_DEFAULTS.background ) ).toBe(
+			'linear-gradient(180deg, #0c1a36 0%, #1d355e 55%, #425d8a 100%)',
+		);
+	} );
+
+	test( 'derives lighter stops from a custom base', () => {
+		const css = backdropCss( '#301a0c' );
+		const stops = css.match( /#[0-9a-f]{6}/g );
+		expect( css ).toMatch( /^linear-gradient\(180deg, #301a0c 0%, / );
+		expect( stops ).toHaveLength( 3 );
+		// Each successive stop is lighter than the base (night sky
+		// lightening toward the horizon).
+		const luma = ( hex: string ): number =>
+			parseInt( hex.slice( 1, 3 ), 16 ) +
+			parseInt( hex.slice( 3, 5 ), 16 ) +
+			parseInt( hex.slice( 5, 7 ), 16 );
+		const [ base, mid, bottom ] = stops as string[];
+		expect( luma( mid ) ).toBeGreaterThan( luma( base ) );
+		expect( luma( bottom ) ).toBeGreaterThan( luma( mid ) );
+	} );
+
+	test( 'extreme bases stay clamped and well-formed', () => {
+		for ( const base of [ '#000000', '#ffffff', '#ff0000' ] ) {
+			const css = backdropCss( base );
+			expect( css.match( /#[0-9a-f]{6}/g ) ).toHaveLength( 3 );
+		}
+	} );
+} );

--- a/tests/vitest/wallpaper-settings-store.test.ts
+++ b/tests/vitest/wallpaper-settings-store.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Per-wallpaper settings — the shared store, the OS Settings config
+ * button, and the `<wpd-modal>` config dialog.
+ *
+ * Covers: store seed/get/publish semantics (including the
+ * settings-changed action), the config button rendering only for
+ * defs that ship `renderConfig`, and the dialog wiring — the
+ * wallpaper's `renderConfig` receives the persisted settings and its
+ * `setSettings` merges + saves + publishes.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import * as registry from '../../src/wallpapers/registry';
+import {
+	getWallpaperSettings,
+	publishWallpaperSettings,
+	seedWallpaperSettings,
+} from '../../src/wallpapers/settings-store';
+import { HOOKS } from '../../src/hooks';
+import {
+	openWallpaperConfigDialog,
+	syncWallpaperConfigButton,
+} from '../../src/settings/sections/wallpaper';
+import type { SettingsCtx } from '../../src/settings/types';
+import type { WallpaperConfigContext } from '../../src/wallpapers/types';
+
+function slotElement(): HTMLElement {
+	const slot = document.createElement( 'div' );
+	slot.dataset.expanded = 'false';
+	slot.appendChild( document.createElement( 'div' ) );
+	document.body.appendChild( slot );
+	return slot;
+}
+
+function ctxFor( wallpaper: string ): SettingsCtx {
+	return {
+		state: { wallpaper, wallpaperSettings: {} },
+		save: vi.fn(),
+		apply: vi.fn(),
+	} as unknown as SettingsCtx;
+}
+
+beforeEach( () => {
+	installHooksStub();
+	seedWallpaperSettings( {} );
+} );
+
+afterEach( () => {
+	for ( const def of registry.all() ) {
+		if ( def.id.startsWith( 'test-' ) ) {
+			registry.unregister( def.id );
+		}
+	}
+	seedWallpaperSettings( {} );
+	document.body.innerHTML = '';
+	clearHooksStub();
+} );
+
+describe( 'wallpaper settings store', () => {
+	test( 'getWallpaperSettings returns an isolated copy', () => {
+		seedWallpaperSettings( { 'test-a': { wind: 10 } } );
+		const first = getWallpaperSettings( 'test-a' );
+		first.wind = 99;
+		expect( getWallpaperSettings( 'test-a' ).wind ).toBe( 10 );
+		expect( getWallpaperSettings( 'test-unknown' ) ).toEqual( {} );
+	} );
+
+	test( 'seed replaces prior content silently', () => {
+		const heard: unknown[] = [];
+		window.wp!.hooks!.addAction(
+			HOOKS.WALLPAPER_SETTINGS_CHANGED,
+			'test/seed',
+			( detail ) => heard.push( detail ),
+		);
+		seedWallpaperSettings( { 'test-a': { wind: 10 } } );
+		seedWallpaperSettings( { 'test-b': { size: 5 } } );
+		expect( getWallpaperSettings( 'test-a' ) ).toEqual( {} );
+		expect( getWallpaperSettings( 'test-b' ) ).toEqual( { size: 5 } );
+		expect( heard ).toHaveLength( 0 );
+	} );
+
+	test( 'publish stores values and fires the settings-changed action', () => {
+		const heard: Array<{ id?: string; settings?: Record<string, unknown> }> = [];
+		window.wp!.hooks!.addAction(
+			HOOKS.WALLPAPER_SETTINGS_CHANGED,
+			'test/publish',
+			( ...args: unknown[] ) =>
+				heard.push( args[ 0 ] as ( typeof heard )[ number ] ),
+		);
+		publishWallpaperSettings( 'test-a', { wind: 42 } );
+		expect( getWallpaperSettings( 'test-a' ) ).toEqual( { wind: 42 } );
+		expect( heard ).toHaveLength( 1 );
+		expect( heard[ 0 ].id ).toBe( 'test-a' );
+		expect( heard[ 0 ].settings ).toEqual( { wind: 42 } );
+	} );
+} );
+
+describe( 'wallpaper config button', () => {
+	test( 'renders for the selected def with renderConfig', () => {
+		registry.register( {
+			id: 'test-configurable',
+			label: 'Configurable',
+			type: 'css',
+			value: '#111111',
+			preview: '#111111',
+			renderConfig: () => () => {},
+		} );
+		const slot = slotElement();
+		syncWallpaperConfigButton( ctxFor( 'test-configurable' ), slot );
+		expect( slot.dataset.expanded ).toBe( 'true' );
+		expect( slot.querySelector( 'wpd-button' ) ).not.toBeNull();
+	} );
+
+	test( 'collapses for defs without renderConfig', () => {
+		registry.register( {
+			id: 'test-plain',
+			label: 'Plain',
+			type: 'css',
+			value: '#222222',
+			preview: '#222222',
+		} );
+		const slot = slotElement();
+		slot.dataset.expanded = 'true';
+		syncWallpaperConfigButton( ctxFor( 'test-plain' ), slot );
+		expect( slot.dataset.expanded ).toBe( 'false' );
+	} );
+} );
+
+describe( 'wallpaper config dialog', () => {
+	test( 'renderConfig gets persisted settings; setSettings merges, saves, publishes', () => {
+		seedWallpaperSettings( { 'test-configurable': { wind: 10 } } );
+
+		let received: WallpaperConfigContext | null = null;
+		const def = {
+			id: 'test-configurable',
+			label: 'Configurable',
+			type: 'css' as const,
+			value: '#111111',
+			preview: '#111111',
+			renderConfig: ( _el: HTMLElement, cfg: WallpaperConfigContext ) => {
+				received = cfg;
+				return () => {};
+			},
+		};
+		registry.register( def );
+
+		const ctx = ctxFor( 'test-configurable' );
+		ctx.state.wallpaperSettings[ 'test-configurable' ] = { wind: 10 };
+
+		const heard: Array<{ settings?: Record<string, unknown> }> = [];
+		window.wp!.hooks!.addAction(
+			HOOKS.WALLPAPER_SETTINGS_CHANGED,
+			'test/dialog',
+			( ...args: unknown[] ) =>
+				heard.push( args[ 0 ] as ( typeof heard )[ number ] ),
+		);
+
+		openWallpaperConfigDialog( ctx, def );
+
+		const modal = document.body.querySelector( 'wpd-modal' );
+		expect( modal ).not.toBeNull();
+		expect( modal!.getAttribute( 'open' ) ).not.toBeNull();
+		expect( received ).not.toBeNull();
+		expect( received!.settings ).toEqual( { wind: 10 } );
+
+		received!.setSettings( { size: 8 } );
+		// Merge (not replace), persisted into state + saved + published.
+		expect( ctx.state.wallpaperSettings[ 'test-configurable' ] ).toEqual( {
+			wind: 10,
+			size: 8,
+		} );
+		expect( ctx.save ).toHaveBeenCalled();
+		expect( getWallpaperSettings( 'test-configurable' ) ).toEqual( {
+			wind: 10,
+			size: 8,
+		} );
+		expect( heard ).toHaveLength( 1 );
+		expect( heard[ 0 ].settings ).toEqual( { wind: 10, size: 8 } );
+	} );
+
+	test( 'teardown runs when the dialog is cancelled', () => {
+		const teardown = vi.fn();
+		const def = {
+			id: 'test-configurable',
+			label: 'Configurable',
+			type: 'css' as const,
+			value: '#111111',
+			preview: '#111111',
+			renderConfig: () => teardown,
+		};
+		registry.register( def );
+
+		openWallpaperConfigDialog( ctxFor( 'test-configurable' ), def );
+		const modal = document.body.querySelector( 'wpd-modal' );
+		expect( modal ).not.toBeNull();
+
+		modal!.dispatchEvent(
+			new CustomEvent( 'wpd-modal-cancel', { bubbles: true } ),
+		);
+		expect( teardown ).toHaveBeenCalledTimes( 1 );
+		expect( document.body.querySelector( 'wpd-modal' ) ).toBeNull();
+	} );
+} );

--- a/vite.config.js
+++ b/vite.config.js
@@ -392,6 +392,17 @@ const TARGETS = {
 		fileBase: 'living-tree-wallpaper',
 		iifeName: 'desktopModeLivingTreeWallpaper',
 	},
+	// Snow wallpaper — built-in canvas wallpaper: PixiJS snowfall that
+	// accumulates on window tops (via `wp.desktop.getWallpaperSurfaces`)
+	// and melts away. Lazy-loaded by the wallpaper server-sync when
+	// selected. Publishes the `WallpaperDef` on
+	// `window.desktopModeWallpapers['wp-snow']`; first built-in
+	// consumer of the `renderConfig` wallpaper-settings dialog.
+	'snow-wallpaper': {
+		entry:    'src/plugins/snow-wallpaper/index.ts',
+		fileBase: 'snow-wallpaper',
+		iifeName: 'desktopModeSnowWallpaper',
+	},
 	// About-scene — the PixiJS particle scene rendered inside OS
 	// Settings → About. ~25 kB of code that only ever runs after the
 	// user explicitly opens that tab. Loaded by the main-bundle


### PR DESCRIPTION
## What

Two things, one built on the other:

### 1. A new built-in canvas wallpaper: **Snow** (`wp-snow`)

PixiJS snowfall over a midnight sky. Flakes fall with a slow global wind sweep plus per-particle sway, collide with the top edge of every visible surface the shell publishes via `wp.desktop.getWallpaperSurfaces()` (windows, widget cards, taskbar, shell floor), stack into per-column piles that slope naturally, then melt away while the column above compacts smoothly. Dragging a window carries its snow along; closing or minimizing one drops the flakes back into the air.

- Own lazy-loaded Vite bundle (`snow-wallpaper[.min].js`), registered through the same public `desktop_mode_register_wallpaper()` surface third-party wallpapers use.
- Live tile preview in the OS Settings picker (`renderPreview`) — the real simulation at reduced density, collisions off.
- Honors `prefers-reduced-motion` (static field, no ticker) and the wallpaper visibility hook (pauses when hidden).

### 2. New framework surface: **wallpaper settings dialogs** (`renderConfig`)

A wallpaper def can now ship a `renderConfig` callback. When it does, OS Settings → Wallpaper shows a **"Wallpaper settings"** button for the selected wallpaper (hidden for wallpapers that don't opt in) that opens a `<wpd-modal>` hosting the wallpaper's form. The shell owns everything except the controls:

- **Persistence** — `ctx.setSettings( partial )` merges into a per-wallpaper bag persisted with the rest of the OS Settings state (localStorage + debounced user-meta sync, so values follow the user across devices). Sanitized on both sides: scalar values only, 64 wallpapers × 32 keys, strings capped at 256 chars.
- **Read-back** — every wallpaper context (`mount` / `renderPreview` / `renderEditor` / `renderConfig`) now carries `ctx.settings`.
- **Live apply** — each edit fires the new `desktop-mode.wallpaper.settings-changed` action with the full post-merge bag, so a mounted wallpaper live-applies without a remount. The dialog doubles as a live tuning panel.

Snow's dialog tunes **wind, snowflake count, flake size, and the backdrop colour** — defaults match the canonical tuning. The backdrop gradient derives from the base colour in HSL space and reproduces the registered picker swatch **byte-for-byte** at the default; tests on both the JS and PHP sides pin the two strings so they can never drift.

### Component-kit fixes surfaced by the dialog

- `<wpd-modal>` re-points the shared surface tokens (`--desktop-mode-text/-muted/-border`, new `--wpd-button-bg-hover`) to dark-surface values for its whole subtree — token-reading controls slotted into any modal were rendering light-admin colours (near-black text on the dark dialog).
- `<wpd-color-field>` strips WebKit's built-in swatch frame in every variant (was `block`-only), removing the double border.
- The wallpaper config dialog inlines its load-bearing layout so it renders correctly even in long-lived sessions whose stylesheet predates the feature.

## Docs

- `docs/javascript-reference.md` — `WallpaperDef.renderConfig`, `WallpaperContext.settings`, `WallpaperConfigContext`, the new action in the hooks table, and a full `renderConfig` section.
- `docs/examples/register-wallpaper.md` — new Recipe 5: a settings dialog with persisted values.

## Tests

- **vitest** (15 new): settings-store semantics (seed/get/publish + action), config button visibility, dialog wiring (settings in, merge/save/publish out, teardown on cancel), snow settings sanitization, backdrop-gradient exactness at defaults.
- **PHPUnit** (7 new): `wallpaperSettings` sanitizer (well-formed, malformed, caps, round-trip through user meta) and the `wp-snow` registration (canvas type, script handle, swatch matches the JS backdrop).
- Full suites green: 1836 vitest, 1080 PHPUnit; build + lint + typecheck clean.

## Test steps

1. OS Settings → Wallpaper → pick **Snow**; open a window and watch flakes pile on its title bar, then melt.
2. Click **"Wallpaper settings"** → drag the sliders — wind/density/size change live; pick a background colour — the sky re-tints in place.
3. Reload — settings persist (and sync to user meta; check `desktop_mode_os_settings`).
4. Select any other wallpaper — no settings button appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-353-8cbee44602dc2dca742e65d487cd0c2e5af3a09e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->