### PR TITLE
Don't hijack updates.js-owned row Delete links in the chromeless bridge

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -180,6 +180,8 @@ Parent dispatch (in `src/window/iframe-bridge.ts`, wired by `bindAdminLinkDispat
 
 Modifier-key clicks (cmd / ctrl / shift / alt, middle-click, `target="_blank"`, `target` other than `_self`, `download` attribute) short-circuit the bridge's interceptor entirely — the browser's native open-in-new-tab path runs unchanged.
 
+Links owned by core's `wp-admin/js/updates.js` are also left alone: the card-style `install-now` / `update-link` / `update-now` / `delete-plugin` / `delete-theme` / `install-theme` buttons, the plugins-list-table row Delete (`[data-plugin] a.delete`), and the network themes row Delete (`.themes-php.network-admin a.delete`). updates.js `preventDefault`s these itself and runs an in-place AJAX operation; if the bridge hijacked them, the parent-driven navigation would race the AJAX call (a `wp.updates.beforeunload` "Leave site?" prompt followed by the no-JS fallback screen for an already-deleted plugin).
+
 Forms submit through a separate `submit` listener that only rewrites the action URL (to keep `desktop_mode_chromeless=1`) and never `preventDefault`s. Same-origin form posts to a different page would currently navigate the iframe in place; if that becomes a UX problem it can join this protocol as a `desktop-mode-iframe-admin-form-submit` message.
 
 ## Activity-footprint launcher inside chromeless iframes — Stable *(since 0.9.1)*

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1160,6 +1160,19 @@ function desktop_mode_chromeless_bridge_script() {
 		 * which is what users perceive as "Install Now keeps loading and
 		 * opens a new tab". Skip these classes so updates.js's bubble
 		 * handler runs as core intended.
+		 *
+		 * The plugins-list-table row action "Delete" is the same story
+		 * with a different marker: a bare `a.delete` inside a
+		 * `tr[data-plugin]` (updates.js binds `[data-plugin] a.delete`;
+		 * the network themes list is `.themes-php.network-admin
+		 * a.delete`) — it never carries the `delete-plugin` /
+		 * `delete-theme` classes of the card-style buttons above.
+		 * Hijacking it navigated the iframe to the link's no-JS
+		 * bulk-delete fallback WHILE updates.js's AJAX delete was
+		 * already running: `wp.updates.beforeunload` raised a native
+		 * "Leave site?" prompt, and leaving landed on a delete
+		 * confirmation screen for a plugin whose files the AJAX call
+		 * had just removed — an empty "You are about to remove:" list.
 		 */
 		if (
 			link.classList.contains( 'install-now' ) ||
@@ -1167,7 +1180,11 @@ function desktop_mode_chromeless_bridge_script() {
 			link.classList.contains( 'update-now' ) ||
 			link.classList.contains( 'delete-plugin' ) ||
 			link.classList.contains( 'delete-theme' ) ||
-			link.classList.contains( 'install-theme' )
+			link.classList.contains( 'install-theme' ) ||
+			( link.classList.contains( 'delete' ) &&
+				( link.closest( '[data-plugin]' ) ||
+					( document.body.classList.contains( 'themes-php' ) &&
+						document.body.classList.contains( 'network-admin' ) ) ) )
 		) {
 			return;
 		}


### PR DESCRIPTION
## What it does

Fixes plugin deletion inside the desktop shell. Clicking a plugin's row-action **Delete** on the Plugins screen now runs core's in-place AJAX delete, instead of triggering a "Leave site?" browser prompt followed by a delete-confirmation screen with an empty plugin list and a PHP deprecation notice.

## Rationale

The chromeless bridge's capture-phase link interceptor skips links owned by core's `wp-admin/js/updates.js` (`install-now`, `update-now`, `delete-plugin`, `delete-theme`, …) so their in-place AJAX handlers can run. But the plugins-list-table row Delete is a bare `a.delete` inside `tr[data-plugin]` — it carries none of those classes, so the bridge hijacked it. Two paths then raced on every click:

1. `updates.js` (delegated on `[data-plugin] a.delete`) ran its confirm prompt and started the AJAX delete, setting `wp.updates.ajaxLocked`.
2. The bridge `preventDefault`-ed the click and had the parent shell `location.assign()` the iframe to the link's no-JS fallback URL (`plugins.php?action=delete-selected&checked[]=…`).

The navigation while AJAX was in flight fired `wp.updates.beforeunload` — the "Leave site?" prompt. After "Leave", the confirmation screen rendered for a plugin whose files the AJAX call had already removed, hence the empty "You are about to remove the following plugins:" list.

The `preg_replace(): Passing null to parameter #3` deprecation on that screen is a WordPress trunk issue, not ours — it reproduces with desktop-mode deactivated (`get_admin_page_title()` passes the unset `$plugin_page` global into `get_plugin_page_hook()`). This fix simply stops routing users onto that screen.

## Implementation

Extends the skip list with the delegated selectors `updates.js` itself binds — `[data-plugin] a.delete` (plugins list) and `.themes-php.network-admin a.delete` (network themes list):

```js
( link.classList.contains( 'delete' ) &&
    ( link.closest( '[data-plugin]' ) ||
        ( document.body.classList.contains( 'themes-php' ) &&
            document.body.classList.contains( 'network-admin' ) ) ) )
```

No live dock-refresh handling is needed for the AJAX path: only inactive plugins are deletable, and inactive plugins contribute nothing to the menu payload (same reasoning as the existing `install-now` skip). Documented the exclusion in `docs/bridge-protocol.md`.

## Testing instructions

1. Using Desktop Mode, install a plugin.
2. Click **Delete** on the Classic Editor row.
3. Core's native confirm ("Are you sure you want to delete Classic Editor?") appears; accept it.
4. The row is replaced in place with "Classic Editor was successfully deleted." — no leave-site prompt, no navigation, no deprecation screen. 
5.  The plugin list confirms the files are gone.

`npm run build`, `lint`, `typecheck`, and `test:js` (1866 tests) pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-357-8e06887cc400dd7d0df59e7c0fc82674b2f0456f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->