### PR TITLE
Expand the release changelog (as 0.9.5) and require changelog confirmation in release.sh

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,6 +10,8 @@
 #                           GitHub's auto-generated release notes. Use when
 #                           you've already hand-written the changelog block,
 #                           or for hotfixes with nothing notable to log.
+#                           The interactive changelog confirmation still
+#                           runs; only the drafting step is skipped.
 #   --dry-run-changelog     Print the changelog draft that would be inserted
 #                           into readme.txt, then exit without modifying any
 #                           files or pushing. Useful for previewing the
@@ -131,6 +133,39 @@ generate_changelog_draft() {
 	printf '%s\n' "$draft"
 }
 
+# Show the '= $new =' changelog block currently in readme.txt (or a loud
+# warning when there is none) and require an explicit yes before the
+# release continues. Runs on EVERY path — drafted, hand-written,
+# --skip-changelog, and resume — so a release can never reach the tag
+# push with an unreviewed or missing changelog.
+confirm_changelog() {
+	local block
+	block=$(awk -v ver="$new" '
+		$0 == "= " ver " =" { found = 1; print; next }
+		found && /^=/ { exit }
+		found { print }
+	' readme.txt)
+
+	echo ""
+	echo "=========================================================="
+	if [[ -n "$block" ]]; then
+		echo "readme.txt changelog for $new (what WordPress.org users will see):"
+		echo "----------------------------------------------------------"
+		printf '%s\n' "$block"
+	else
+		echo "WARNING: readme.txt has NO '= $new =' changelog block."
+		echo "WordPress.org users would see no notes for this release."
+	fi
+	echo "=========================================================="
+	local reply
+	read -r -p "Is this changelog complete and correct? [y/N] " reply
+	if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+		echo "Aborted: changelog not confirmed. Edit the '= $new =' block in readme.txt and re-run; the script resumes where it left off." >&2
+		echo "(If the bump commit was already pushed, commit and push the readme fix before re-running.)" >&2
+		exit 1
+	fi
+}
+
 # --dry-run-changelog short-circuits before any preflight checks so it
 # works from any branch and any working-tree state. Use it to preview
 # the draft + interaction without mutating anything.
@@ -149,6 +184,9 @@ if [[ "$dry_run_changelog" == "1" ]]; then
 		echo "  Please update readme.txt if needed, save, and press Enter when done."
 		echo "  (Ctrl-C to abort, then 'git checkout readme.txt' to undo.)"
 		echo "  Press Enter when done..."
+		echo ""
+		echo "…then display the final '= $new =' block and require:"
+		echo "  Is this changelog complete and correct? [y/N]"
 		echo ""
 		echo "Dry run complete. No files changed."
 	fi
@@ -199,6 +237,7 @@ stable=$(awk '/^Stable tag:/ { print $3; exit }' readme.txt)
 
 if [[ "$pkg" == "$new" && "$header" == "$new" && "$constant" == "$new" && "$stable" == "$new" ]]; then
 	echo "All version locations already at $new — skipping bump, resuming at CI wait."
+	confirm_changelog
 else
 	# Refresh translation files BEFORE the version bump so any churn
 	# (renumbered #: source refs, fresh POT-Creation-Date, fuzzy
@@ -264,6 +303,11 @@ else
 	else
 		echo "Skipping changelog draft (--skip-changelog)."
 	fi
+
+	# However the block got here (drafted above, hand-written beforehand,
+	# left over from an aborted attempt, or absent), show the final state
+	# and require an explicit yes before the bump commit.
+	confirm_changelog
 
 	./bin/bump-version.sh "$new"
 	if git diff --quiet; then

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,12 +8,12 @@ Maintainer guide. Users install by downloading `/releases/latest/download/deskto
 ./bin/release.sh 0.5.0
 ```
 
-Refreshes translation files (`npm run i18n`), drafts a `= X.Y.Z =` changelog block into `readme.txt` from GitHub's auto-generated release notes and **pauses interactively** so you can curate it (press Enter when done), bumps all four version locations, commits, pushes to trunk, **waits for CI green**, tags, pushes the tag. Aborts cleanly if the tree is dirty, you're not on trunk, local trunk is out of sync with origin, or CI fails. Resumable — re-running after a mid-flow failure picks up where it left off.
+Refreshes translation files (`npm run i18n`), drafts a `= X.Y.Z =` changelog block into `readme.txt` from GitHub's auto-generated release notes and **pauses interactively** so you can curate it (press Enter when done), then **shows the final changelog block and requires an explicit `y` to continue** — on every path, including `--skip-changelog` and resumed runs, and with a loud warning if the block is missing. After confirmation it bumps all four version locations, commits, pushes to trunk, **waits for CI green**, tags, pushes the tag. Aborts cleanly if the tree is dirty, you're not on trunk, local trunk is out of sync with origin, CI fails, or the changelog isn't confirmed. Resumable — re-running after a mid-flow failure picks up where it left off.
 
 Flags:
 
 - `--skip-i18n` — skip the translation-file refresh. Use for hotfix releases where you don't want `.pot`/`.po`/`.json` churn in the bump commit.
-- `--skip-changelog` — skip drafting the `readme.txt` changelog block. Use when you've already hand-written it, or for hotfixes with nothing notable to log.
+- `--skip-changelog` — skip drafting the `readme.txt` changelog block. Use when you've already hand-written it, or for hotfixes with nothing notable to log. The interactive changelog confirmation still runs; only the drafting step is skipped.
 - `--dry-run-changelog` — print the changelog draft that would be inserted into `readme.txt`, then exit without modifying any files or pushing.
 
 The tag push fires [`.github/workflows/release.yml`](../.github/workflows/release.yml), which builds and publishes a GitHub Release with `desktop-mode.zip` attached.

--- a/readme.txt
+++ b/readme.txt
@@ -114,12 +114,27 @@ The plugin bundles the following third-party JavaScript library, loaded on deman
 
 == Changelog ==
 
-= 0.9.4 =
+= 0.9.5 =
 * AI Copilot now uses WordPress 7.0 providers: configure a provider once in Settings → Connectors and the assistant uses it — no more per-plugin keys
 * AI Copilot tools are now WordPress Abilities, so the assistant works across any configured provider; plugin authors add their own tools with the Abilities API (`desktop_mode_register_ai_tool()` was removed)
 * Removed the OS Settings → AI tab; the per-user "AI assistant" toggle now lives in OS Settings → Features next to "Score new comments with AI"
 * Requires WordPress 7.0 for the AI assistant only; on older WordPress the assistant is hidden and the rest of Desktop Mode is unaffected
 * Stored AI keys are deleted from the database on upgrade
+* Five new built-in widgets: Recent Comments, Post Stats, Site Views, Jazz Quote, and Starter
+* Widgets can now be resized, and docked widget heights persist across sessions
+* Two new wallpapers, Living Tree and Snow, plus per-wallpaper settings dialogs
+* Window links: windows showing related content are visually connected, with pluggable link renderers for plugin authors
+* Spring-loading: hovering a window while dragging anything brings it to the front
+* New developer mode setting (OS Settings → Features) unlocks developer-facing surfaces
+* WordPress update notices now surface once in the desktop shell instead of repeating in every window
+* Desktop shortcuts stay in sync and core icons follow the spatial layout
+* Extended options merged into the OS Settings → Features tab
+* Fixed selection bugs that could point destructive actions at the wrong files
+* Closing a window with unsaved changes now warns instead of silently losing work
+* Fixed windows and dock state leaking across virtual desktops
+* Fixed Overview keyboard navigation and focus trapping
+* The dock now refreshes live when a plugin registers a new post type
+* Fixed dock icon alignment, "Add New" window titles and icons, and count-label pluralization
 
 = 0.9.3 =
 * Rewrite WordPress.org plugin page, leaner copy, video embed, screenshots


### PR DESCRIPTION
## What it does

Two changes ahead of the 0.9.5 release:

1. **Expands the readme.txt changelog** so it covers the whole release, not just the AI/Connectors migration, and retitles the block from `= 0.9.4 =` to `= 0.9.5 =` — the 0.9.4 release was discarded on WordPress.org before rollout, so 0.9.5 is the version that actually ships these changes there.
2. **`bin/release.sh` now always confirms the changelog interactively** before the release can proceed.

## Rationale

The 0.9.4 changelog listed only the five AI bullets while the release contained 33 commits, including headline features (built-in widgets, two wallpapers, window links) and user-visible fixes. Nothing in `release.sh` forced a review: a pre-existing `= X.Y.Z =` block, a failed draft, `--skip-changelog`, and resumed runs all skipped straight past the changelog with no prompt.

## Implementation

New `confirm_changelog()` in `bin/release.sh` extracts the `= $new =` block from `readme.txt` and prints it, then requires an explicit `y`:

```
Is this changelog complete and correct? [y/N]
```

It runs on **every** path — after drafting, when the block was hand-written beforehand, with `--skip-changelog` (the flag now only skips the drafting step), and on resumed runs (before the CI wait, so even a resume can't reach the tag push unreviewed). A missing block prints a loud warning and still requires the explicit `y`. Answering `n` aborts resume-safely.

`docs/RELEASE.md` is updated to match.

## Testing instructions

1. `bash -n bin/release.sh` — syntax check.
2. `./bin/release.sh 0.9.5 --dry-run-changelog` — previews the draft flow, including the new confirmation prompt text.
3. The full interactive flow is exercised by the actual 0.9.5 release: the script should detect the existing `= 0.9.5 =` block, skip drafting, display it, and wait for `y`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-358-fa3d16811b58fac56775edf709aacbfeaee2ef79.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->