### PR TITLE
Convert pinned notes into draft posts

### DIFF
--- a/assets/css/notes.css
+++ b/assets/css/notes.css
@@ -251,12 +251,19 @@
 	inset-inline: 8px;
 	top: 6px;
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
+	gap: 4px;
 	height: 26px;
 	opacity: 0;
 	transition: opacity 150ms ease-out;
 	z-index: 1;
+}
+
+/* Push the color dot to the left edge; the action buttons cluster on
+   the right. Keeps a stable layout whether or not the convert button
+   is present (it's gated on the `edit_posts` capability). */
+.desktop-mode-pinned-note__meta .desktop-mode-pinned-note__color-dot {
+	margin-inline-end: auto;
 }
 
 .desktop-mode-pinned-note:hover .desktop-mode-pinned-note__meta,
@@ -302,6 +309,50 @@
 	width: 20px;
 	height: 20px;
 	color: var(--dm-note-ink, #4d4419);
+}
+
+/* "Convert to post" — same treatment as the visibility toggle. Only
+   rendered for users who can author posts. */
+.desktop-mode-pinned-note__convert {
+	--wpd-btn-color: var(--dm-note-ink-soft);
+	opacity: 0.75;
+}
+
+.desktop-mode-pinned-note__convert:hover {
+	opacity: 1;
+}
+
+.desktop-mode-pinned-note__convert svg {
+	width: 20px;
+	height: 20px;
+	fill: var(--dm-note-ink, #4d4419);
+}
+
+/* ------------------------------------------------------------------
+   "Convert to post" drop-target highlight
+   ------------------------------------------------------------------
+   Set on the Posts dock tile / native Posts window body while a note
+   pin is dragged over it (`data-desktop-mode-posts-drop-active`, from
+   src/notes/posts-drop-target.ts). Mirrors the recycle-bin affordance. */
+.desktop-mode-dock__item[data-menu-slug="menu-posts"][data-desktop-mode-posts-drop-active],
+.desktop-mode-dock__item[data-menu-slug="editphp"][data-desktop-mode-posts-drop-active] {
+	outline: 2px solid var(--wp-admin-theme-color, #3858e9);
+	outline-offset: 2px;
+	border-radius: 12px;
+	background: color-mix(
+		in srgb,
+		var(--wp-admin-theme-color, #3858e9) 14%,
+		transparent
+	);
+	transition:
+		outline-color 80ms ease,
+		background 80ms ease;
+}
+
+[data-desktop-mode-posts-root][data-desktop-mode-posts-drop-active] {
+	position: relative;
+	box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color, #3858e9);
+	transition: box-shadow 80ms ease;
 }
 
 /* ------------------------------------------------------------------

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -48,6 +48,7 @@ defined( 'ABSPATH' ) || exit;
 - [Open a file in the Code editor (deep-link from any window)](./code-editor-open.md)
 - [Cross-window devtools — instrumentation primitives](./devtools-instrumentation.md)
 - [Extend the Recycle Bin](./recycle-bin.md)
+- [Customize note → post conversion — `desktop_mode_notes_convert_post_args`](./notes-convert-to-post.md)
 - [Programmatic folder sharing — invite from PHP, listen for share events](./share-folder.md)
 - [Native Posts window — default-on, remap registry, hooks](./native-posts.md)
 - [Native Plugins window — Browse / Install / Reviews / Drag-to-dock](./plugins-window-extras.md)

--- a/docs/examples/notes-convert-to-post.md
+++ b/docs/examples/notes-convert-to-post.md
@@ -1,0 +1,68 @@
+# Customize note → post conversion
+
+Pinned notes can be turned into draft posts — via the inline "Convert
+to post" button on an owned note, or by dragging the note's pushpin
+onto the **Posts** dock tile. Both go through
+`POST /desktop-mode/v1/notes/:id/convert`, which:
+
+1. spawns a **draft `post`** authored by the note owner, titled from
+   the note's first line, with the body wrapped in `wp:paragraph`
+   blocks (blank lines split paragraphs, single newlines become
+   `<br>`);
+2. **trashes the note** and links it to the draft, so the standard
+   restore route (the Undo toast) reverses both sides — the note comes
+   back and the draft is discarded;
+3. auto-opens the draft in the block editor.
+
+The affordances only appear for users who can author posts
+(`current_user_can( 'edit_posts' )`, surfaced to the shell as
+`desktopModeConfig.canCreatePosts`).
+
+## Reshape the draft it creates
+
+Use `desktop_mode_notes_convert_post_args` to change the post
+type/status, assign a taxonomy, or rewrite the block markup. It filters
+the array handed to `wp_insert_post()`.
+
+```php
+<?php
+/**
+ * Plugin Name: Notes → Posts policy
+ */
+defined( 'ABSPATH' ) || exit;
+
+// File converted notes into the "Notes" category and hold them for
+// review instead of saving a plain draft.
+add_filter( 'desktop_mode_notes_convert_post_args', static function ( $args, $note ) {
+    $args['post_status'] = 'pending';
+
+    $term = get_term_by( 'slug', 'notes', 'category' );
+    if ( $term ) {
+        $args['post_category'] = array( $term->term_id );
+    }
+
+    return $args;
+}, 10, 2 );
+```
+
+The convert route is owner-only and `edit_posts`-gated regardless of
+what this filter returns — it shapes the draft, it doesn't widen who
+may create one.
+
+## React after a conversion
+
+`desktop_mode_notes_converted` fires once the draft exists and the note
+has been trashed — a good place to seed post meta, notify an editor, or
+log the event.
+
+```php
+add_action( 'desktop_mode_notes_converted', static function ( $post_id, $note ) {
+    update_post_meta( $post_id, '_from_pinned_note', (int) $note->ID );
+}, 10, 2 );
+```
+
+## Related
+
+- [Hooks Reference — `desktop_mode_notes_convert_post_args`](../hooks-reference.md#desktop_mode_notes_convert_post_args--experimental-filter-since-096)
+- [Hooks Reference — `desktop_mode_notes_converted`](../hooks-reference.md#desktop_mode_notes_converted--experimental-action-since-096)
+- [JavaScript Reference — Pinned-note drag payloads](../javascript-reference.md#pinned-note-drag-payloads--experimental-since-096)

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -3124,6 +3124,55 @@ add_filter( 'desktop_mode_notes_colors', static function ( $colors ) {
 - **Param** `string[] $colors` — allowed slugs. Default `butter`, `blush`, `sky`, `mint`, `lilac`, `peach`.
 - **Return** `string[]` — each entry passes through `sanitize_key()`; empties are dropped.
 
+### `desktop_mode_notes_convert_post_args` — Experimental *(filter, since 0.9.6)*
+
+Filters the arguments passed to `wp_insert_post()` when a note is
+converted to a post via `POST /desktop-mode/v1/notes/:id/convert` (the
+inline "Convert to post" button and the drag-onto-Posts gesture). The
+default spawns a **draft `post`** authored by the note owner, titled
+from the note's first line, with the note body wrapped in
+`wp:paragraph` blocks (blank lines split paragraphs; single newlines
+become `<br>`). Hook here to change the post type/status, assign a
+category, or rewrite the block markup. The convert route itself is
+gated on the owner + the `edit_posts` capability, which this filter
+does not loosen.
+
+```php
+apply_filters( 'desktop_mode_notes_convert_post_args', array $post_args, WP_Post $note, WP_REST_Request $request );
+```
+
+**Example — file converted notes into a "Notes" category as pending drafts:**
+
+```php
+add_filter( 'desktop_mode_notes_convert_post_args', static function ( $args, $note ) {
+	$args['post_status'] = 'pending';
+	$term = get_term_by( 'slug', 'notes', 'category' );
+	if ( $term ) {
+		$args['post_category'] = array( $term->term_id );
+	}
+	return $args;
+}, 10, 2 );
+```
+
+- **Param** `array $post_args` — the `wp_insert_post()` array (`post_type`, `post_status`, `post_author`, `post_title`, `post_content`).
+- **Param** `WP_Post $note` — the source note (about to be trashed).
+- **Param** `WP_REST_Request $request` — the convert request.
+- **Return** `array` — the (possibly modified) insert args.
+
+### `desktop_mode_notes_converted` — Experimental *(action, since 0.9.6)*
+
+Fires after a note has been converted to a draft post: the draft
+exists and the source note has been trashed (and linked to the draft
+so the restore route can undo both sides).
+
+```php
+do_action( 'desktop_mode_notes_converted', int $new_post_id, WP_Post $note, WP_REST_Request $request );
+```
+
+- **Param** `int $new_post_id` — the new draft post id.
+- **Param** `WP_Post $note` — the source note (now trashed).
+- **Param** `WP_REST_Request $request` — the convert request.
+
 ---
 
 ## Asset loading

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -362,6 +362,28 @@ Both are consumed by the wallpaper canvas target (create / reposition
 (soft-trash with Undo; `accept` is gated on `data.canEdit`). Plugin
 drop targets can filter on these slugs like any other payload type.
 
+A `'note'` drag is also accepted by the **Posts** drop targets, which
+convert the note to a draft post — the drag counterpart of the inline
+"Convert to post" button (`src/notes/posts-drop-target.ts`). Three
+surfaces, registered only when `desktopModeConfig.canCreatePosts` is
+true (the current user has `edit_posts`):
+
+1. The Posts **dock tile** (`[data-menu-slug="menu-posts"]`) and
+2. the open **native Posts window** body (`[data-desktop-mode-posts-root]`)
+   — both get a real `DropTarget` and set
+   `data-desktop-mode-posts-drop-active` while a note hovers.
+3. The Posts **shortcut tile in the Spatial layout**. There the core
+   menu icons are files-layer shortcut tiles already claimed by the
+   files layer's per-tile reject target, so notes can't register their
+   own target. Instead the files layer exposes a **tile-payload seam**
+   (`registerTilePayloadHandler( type, { appliesTo, accept, acceptLabel,
+   onDrop } )` in `src/desktop-files/tile-payloads.ts`); the reject
+   target consults it, so a feature can opt a payload type into a tile
+   whose placement it recognizes. Notes register a `'note'` handler
+   scoped to tiles whose `file.shortcutUrl` points at the Posts screen.
+   The same seam is available to any plugin that wants to accept a drop
+   on its own shortcut icon.
+
 One companion CustomEvent (document-level):
 
 ```javascript
@@ -375,7 +397,16 @@ document.addEventListener( 'desktop-mode-note-created', ( e ) => {
 
 The REST base is surfaced to the shell as `desktopModeConfig.notesUrl`
 (`/desktop-mode/v1/notes`); the notes layer only boots when it is
-present.
+present. The controller's routes are `GET`/`POST /notes`, `PATCH`/
+`DELETE /notes/:id`, `POST /notes/:id/restore`, and — since 0.9.6 —
+`POST /notes/:id/convert`, which spawns a draft post from the note,
+trashes the note, and returns `{ noteId, postId, editUrl }`. The
+convert route is owner-only and requires the `edit_posts` capability;
+the shell exposes whether the current user qualifies as
+`desktopModeConfig.canCreatePosts` (since 0.9.6) so the "Convert to
+post" affordances only render for eligible users. Restoring a
+convert-trashed note (the Undo path) also discards the draft it
+spawned.
 
 ### `wp.desktop.dragBridge` — cross-iframe drag — Stable *(since 0.6.0)*
 
@@ -3953,7 +3984,7 @@ The built-in Snow wallpaper (`src/plugins/snow-wallpaper/`) is the canonical in-
 | `getOsSettings()` | Stable | Defensive copy of the persisted OS Settings snapshot — same shape a settings tab's `ctx.getOsSettings()` returns. |
 | `subscribeOsSettings( cb )` | Stable | Subscribe to OS Settings changes; returns an unsubscribe function. Mirrors the settings-tab `ctx.subscribeOsSettings` API. |
 | `updateOsSettings( patch, opts? )` | Stable *(since 0.7.2)* | Patch + persist the OS Settings state (whitelisted keys only). See [`updateOsSettings`](#updateossettings-patch-opts---stable-since-072). |
-| `config` | Stable | The `DesktopConfig` that booted the shell. Notable read-only fields plugins reach for: `pluginUrl` (no trailing slash) and `pluginVersion` (the active plugin semver — surfaced in OS Settings → About; useful for version-gated features); `stickyNotes.available` (boolean, since 0.9.1 — whether Gutenberg's Guidelines experiment is registered, so the sticky-notes layer only boots when its REST routes exist); `notesUrl` (string, since 0.9.6 — REST base for the pinned-notes controller at `/desktop-mode/v1/notes`; the notes layer only boots when present). Filterable server-side via `desktop_mode_shell_config`. |
+| `config` | Stable | The `DesktopConfig` that booted the shell. Notable read-only fields plugins reach for: `pluginUrl` (no trailing slash) and `pluginVersion` (the active plugin semver — surfaced in OS Settings → About; useful for version-gated features); `stickyNotes.available` (boolean, since 0.9.1 — whether Gutenberg's Guidelines experiment is registered, so the sticky-notes layer only boots when its REST routes exist); `notesUrl` (string, since 0.9.6 — REST base for the pinned-notes controller at `/desktop-mode/v1/notes`; the notes layer only boots when present); `canCreatePosts` (boolean, since 0.9.6 — whether the current user has `edit_posts`, gating the note "Convert to post" affordances). Filterable server-side via `desktop_mode_shell_config`. |
 
 ### System tiles
 

--- a/includes/notes/rest.php
+++ b/includes/notes/rest.php
@@ -11,6 +11,9 @@
  *   PATCH  /notes/(?P<id>\d+)         Partial update — owner only.
  *   DELETE /notes/(?P<id>\d+)         Soft-trash — owner only.
  *   POST   /notes/(?P<id>\d+)/restore Untrash (Undo toast) — owner only.
+ *   POST   /notes/(?P<id>\d+)/convert Spawn a draft post from the note,
+ *                                     then trash the note — owner only,
+ *                                     requires the `edit_posts` cap.
  *
  * Ownership model: a note belongs to its `post_author`, and ONLY the
  * owner may mutate it — deliberately including administrators. Public
@@ -114,6 +117,16 @@ function desktop_mode_notes_register_rest_routes() {
 			'methods'             => WP_REST_Server::CREATABLE,
 			'permission_callback' => 'desktop_mode_notes_rest_permission',
 			'callback'            => 'desktop_mode_notes_rest_restore',
+		)
+	);
+
+	register_rest_route(
+		$ns,
+		'/notes/(?P<id>\d+)/convert',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'permission_callback' => 'desktop_mode_notes_rest_permission',
+			'callback'            => 'desktop_mode_notes_rest_convert',
 		)
 	);
 }
@@ -479,5 +492,137 @@ function desktop_mode_notes_rest_restore( $request ) {
 		return new WP_Error( 'desktop_mode_notes_restore_failed', __( 'Could not restore the note.', 'desktop-mode' ), array( 'status' => 500 ) );
 	}
 
+	// If this note was trashed by a "convert to post" action, undoing
+	// the conversion must also discard the draft it spawned — otherwise
+	// Undo would leave the note back on the wall AND a stray draft. The
+	// link is written by the convert route (`_wpd_note_converted_post`)
+	// and consumed once here. Only a still-present draft is trashed; a
+	// draft the user already published or trashed themselves is left be.
+	$converted_post_id = (int) get_post_meta( $post->ID, '_wpd_note_converted_post', true );
+	if ( $converted_post_id > 0 ) {
+		delete_post_meta( $post->ID, '_wpd_note_converted_post' );
+		$draft = get_post( $converted_post_id );
+		if ( $draft instanceof WP_Post && 'draft' === $draft->post_status ) {
+			wp_trash_post( $converted_post_id );
+		}
+	}
+
 	return rest_ensure_response( desktop_mode_notes_prepare( get_post( $post->ID ) ) );
+}
+
+/**
+ * Convert a note's plain text into Gutenberg paragraph-block markup.
+ *
+ * Blank lines split paragraphs; single newlines within a paragraph
+ * become `<br>`. The result lands clean in the block editor rather
+ * than as one classic-HTML blob.
+ *
+ * @since 0.9.6
+ *
+ * @param string $text Note text.
+ * @return string Serialized block markup (empty string for empty text).
+ */
+function desktop_mode_notes_text_to_blocks( $text ) {
+	$text       = str_replace( array( "\r\n", "\r" ), "\n", (string) $text );
+	$paragraphs = preg_split( '/\n{2,}/', trim( $text ) );
+	$blocks     = array();
+	foreach ( $paragraphs as $paragraph ) {
+		$paragraph = trim( $paragraph, "\n" );
+		if ( '' === $paragraph ) {
+			continue;
+		}
+		$html     = nl2br( esc_html( $paragraph ), false );
+		$blocks[] = "<!-- wp:paragraph -->\n<p>{$html}</p>\n<!-- /wp:paragraph -->";
+	}
+	return implode( "\n\n", $blocks );
+}
+
+/**
+ * POST /notes/:id/convert — spawn a draft post from a note, then trash
+ * the note. Owner only, and the owner must be able to author posts.
+ *
+ * The note is trashed (not hard-deleted) and linked to its new draft
+ * via `_wpd_note_converted_post` so the standard restore route can undo
+ * both sides of the conversion (see `desktop_mode_notes_rest_restore`).
+ *
+ * @since 0.9.6
+ *
+ * @param WP_REST_Request $request Request.
+ * @return WP_REST_Response|WP_Error
+ */
+function desktop_mode_notes_rest_convert( $request ) {
+	$post = desktop_mode_notes_get_note( $request['id'] );
+	if ( is_wp_error( $post ) ) {
+		return $post;
+	}
+	$owner = desktop_mode_notes_require_owner( $post );
+	if ( is_wp_error( $owner ) ) {
+		return $owner;
+	}
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		return new WP_Error( 'desktop_mode_notes_cannot_create_posts', __( 'You are not allowed to create posts.', 'desktop-mode' ), array( 'status' => 403 ) );
+	}
+
+	$text  = (string) get_post_field( 'post_content', $post, 'raw' );
+	$title = desktop_mode_notes_derive_title( $text );
+
+	/**
+	 * Filters the arguments used to create the draft post from a note.
+	 *
+	 * Hook here to change the post type/status, assign a category or
+	 * author, or wrap the body in different block markup.
+	 *
+	 * @since 0.9.6
+	 *
+	 * @param array           $post_args Args passed to `wp_insert_post()`.
+	 * @param WP_Post         $post      The source note.
+	 * @param WP_REST_Request $request   The convert request.
+	 */
+	$post_args = apply_filters(
+		'desktop_mode_notes_convert_post_args',
+		array(
+			'post_type'    => 'post',
+			'post_status'  => 'draft',
+			'post_author'  => (int) $post->post_author,
+			'post_title'   => $title,
+			'post_content' => desktop_mode_notes_text_to_blocks( $text ),
+		),
+		$post,
+		$request
+	);
+
+	$new_post_id = wp_insert_post( $post_args, true );
+	if ( is_wp_error( $new_post_id ) ) {
+		$new_post_id->add_data( array( 'status' => 500 ) );
+		return $new_post_id;
+	}
+
+	// Link the note to its draft BEFORE trashing so restore can reverse
+	// both sides. If the trash fails, roll the draft back so a failed
+	// conversion never leaves an orphan draft behind.
+	update_post_meta( $post->ID, '_wpd_note_converted_post', (int) $new_post_id );
+	if ( ! wp_trash_post( $post->ID ) ) {
+		wp_delete_post( $new_post_id, true );
+		delete_post_meta( $post->ID, '_wpd_note_converted_post' );
+		return new WP_Error( 'desktop_mode_notes_convert_failed', __( 'Could not convert the note to a post.', 'desktop-mode' ), array( 'status' => 500 ) );
+	}
+
+	/**
+	 * Fires after a note has been converted to a draft post.
+	 *
+	 * @since 0.9.6
+	 *
+	 * @param int             $new_post_id The draft post id.
+	 * @param WP_Post         $post        The source note (now trashed).
+	 * @param WP_REST_Request $request     The convert request.
+	 */
+	do_action( 'desktop_mode_notes_converted', (int) $new_post_id, $post, $request );
+
+	return rest_ensure_response(
+		array(
+			'noteId'  => (int) $post->ID,
+			'postId'  => (int) $new_post_id,
+			'editUrl' => (string) get_edit_post_link( $new_post_id, 'raw' ),
+		)
+	);
 }

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -420,6 +420,10 @@ function desktop_mode_enqueue_assets() {
 			// Pinned-notes REST base (`includes/notes/rest.php`). The
 			// notes layer boots only when this is present.
 			'notesUrl'               => esc_url_raw( rest_url( 'desktop-mode/v1/notes' ) ),
+			// Gates the "Convert to post" note affordance — the convert
+			// route (and its dock drop target) only make sense for users
+			// who can author posts.
+			'canCreatePosts'         => current_user_can( 'edit_posts' ),
 			'serverWallpaperMenuItems' => $server_wallpaper_menu_items,
 			'accentColors'     => desktop_mode_get_accent_colors(),
 			'toastTypes'       => desktop_mode_get_toast_types(),

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -1610,15 +1610,24 @@ function registerTileRejectTarget(
 	placement: RestPlacementShape,
 ): () => void {
 	const ctx = { placement };
+	// The manager calls `accept( payload )` and then reads `acceptLabel`
+	// in the same hover pass, so recording the hovered type here lets the
+	// getter below return the label for the exact handler that accepted —
+	// and recompute each hover, so a handler registered after this tile
+	// mounted still gets the right chip.
+	let hoveredType: string | null = null;
 	return dragManager.registerDropTarget( {
 		id: `desktop-mode-files-tile-${ placement.id }-reject`,
 		element: tile,
-		// Static label picked from whichever seam handler claims this
-		// placement; only ever surfaces while a payload it also accepts
-		// hovers the tile (the manager shows the accept chip only when
-		// `accept` returns true).
-		acceptLabel: tilePayloadAcceptLabel( ctx ),
-		accept: ( payload ) => tilePayloadAccepts( payload, ctx ),
+		get acceptLabel() {
+			return hoveredType
+				? tilePayloadAcceptLabel( hoveredType, ctx )
+				: undefined;
+		},
+		accept: ( payload ) => {
+			hoveredType = payload.type;
+			return tilePayloadAccepts( payload, ctx );
+		},
 		onEnter: () => {
 			tile.classList.add( `${ TILE_CLASS }--drop-target` );
 		},

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -26,6 +26,11 @@
 import { doAction } from '../hooks';
 import { rest, store as filesStoreApi } from './layer-deps';
 import { buildTile, setTilePosition, TILE_CLASS } from './file-tile';
+import {
+	tilePayloadAccepts,
+	tilePayloadAcceptLabel,
+	tilePayloadDrop,
+} from './tile-payloads';
 import { openTileMenu, type TileMenuItem } from './tile-menu';
 import { openCreateFolderDialog } from './create-folder-dialog';
 import { openFile } from './open';
@@ -337,13 +342,10 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			if ( shouldRejectTileDrops( placement ) ) {
 				const dragManager = getDragManager();
 				if ( dragManager ) {
-					const deregister = dragManager.registerDropTarget( {
-						id: `desktop-mode-files-tile-${ placement.id }-reject`,
-						element: tile,
-						accept: () => false,
-						onDrop: () => {},
-					} );
-					tileRejectDeregisters.set( placement.id, deregister );
+					tileRejectDeregisters.set(
+						placement.id,
+						registerTileRejectTarget( dragManager, tile, placement ),
+					);
 				}
 			}
 			return tile;
@@ -372,13 +374,10 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		} else if ( shouldRejectTileDrops( placement ) ) {
 			const dragManager = getDragManager();
 			if ( dragManager ) {
-				const deregister = dragManager.registerDropTarget( {
-					id: `desktop-mode-files-tile-${ placement.id }-reject`,
-					element: tile,
-					accept: () => false,
-					onDrop: () => {},
-				} );
-				tileRejectDeregisters.set( placement.id, deregister );
+				tileRejectDeregisters.set(
+					placement.id,
+					registerTileRejectTarget( dragManager, tile, placement ),
+				);
 			}
 		}
 		return tile;
@@ -1593,6 +1592,44 @@ function hidePromotedDockItem( dockItemId: string ): void {
 	const current = api.getOsSettings().itemVisibility ?? {};
 	const next = { ...current, [ dockItemId ]: 'dock' };
 	api.updateOsSettings( { itemVisibility: next } );
+}
+
+/**
+ * Register the per-tile drop claimant for a NON-folder tile. A tile
+ * normally hard-rejects every foreign payload so the drop doesn't fall
+ * through to the wallpaper (`shouldRejectTileDrops`). A feature can opt
+ * a payload type IN via the tile-payload seam (`tile-payloads.ts`) —
+ * e.g. pinned notes accept a `'note'` drop on the Posts shortcut icon
+ * (Spatial layout) and convert it to a draft. Unknown payloads — and
+ * payloads whose handler doesn't recognize this placement — still
+ * reject, preserving the original "Can't drop here" feedback.
+ */
+function registerTileRejectTarget(
+	dragManager: DragManagerApi,
+	tile: HTMLElement,
+	placement: RestPlacementShape,
+): () => void {
+	const ctx = { placement };
+	return dragManager.registerDropTarget( {
+		id: `desktop-mode-files-tile-${ placement.id }-reject`,
+		element: tile,
+		// Static label picked from whichever seam handler claims this
+		// placement; only ever surfaces while a payload it also accepts
+		// hovers the tile (the manager shows the accept chip only when
+		// `accept` returns true).
+		acceptLabel: tilePayloadAcceptLabel( ctx ),
+		accept: ( payload ) => tilePayloadAccepts( payload, ctx ),
+		onEnter: () => {
+			tile.classList.add( `${ TILE_CLASS }--drop-target` );
+		},
+		onLeave: () => {
+			tile.classList.remove( `${ TILE_CLASS }--drop-target` );
+		},
+		onDrop: ( session, ev ) => {
+			tile.classList.remove( `${ TILE_CLASS }--drop-target` );
+			tilePayloadDrop( session, ev, ctx );
+		},
+	} );
 }
 
 /**

--- a/src/desktop-files/tile-payloads.ts
+++ b/src/desktop-files/tile-payloads.ts
@@ -64,20 +64,20 @@ export function registerTilePayloadHandler(
 }
 
 /**
- * The accept-chip label for the first handler that applies to this
- * tile, or `undefined` when none does. The files layer sets this as the
- * tile target's static `acceptLabel`; it only ever surfaces while a
- * payload the handler also accepts hovers the tile.
+ * The accept-chip label for the handler registered for `type`, when it
+ * applies to this tile — or `undefined` otherwise. Keyed by payload type
+ * (like `tilePayloadAccepts`) so the chip always reflects the handler
+ * that actually accepted the hovered payload, never a different type's
+ * handler that happens to also claim the tile. The files layer reads
+ * this per-hover (via a getter) so a handler registered after the tile
+ * mounted is picked up without a repaint.
  */
 export function tilePayloadAcceptLabel(
+	type: string,
 	ctx: TilePayloadContext,
 ): string | undefined {
-	for ( const handler of handlers.values() ) {
-		if ( handler.appliesTo( ctx ) ) {
-			return handler.acceptLabel;
-		}
-	}
-	return undefined;
+	const handler = handlers.get( type );
+	return handler && handler.appliesTo( ctx ) ? handler.acceptLabel : undefined;
 }
 
 /** Consulted by the tile target's `accept` for a concrete payload. */

--- a/src/desktop-files/tile-payloads.ts
+++ b/src/desktop-files/tile-payloads.ts
@@ -1,0 +1,112 @@
+/**
+ * Desktop Mode — Shortcut/reference tile drop-payload handlers.
+ *
+ * Same seam shape as `recycle-bin-payloads.ts` and `canvas-payloads.ts`,
+ * but for the per-tile "reject" claimants the files layer registers on
+ * every non-folder tile (`shouldRejectTileDrops`). Those tiles otherwise
+ * hard-reject every foreign payload so a drop doesn't fall through to the
+ * wallpaper. This registry lets a feature opt a payload type INTO a tile
+ * whose placement it recognizes — e.g. the pinned-notes "convert to post"
+ * drop onto the Posts shortcut icon in the Spatial layout, where the
+ * Posts menu item is a files-layer shortcut tile rather than a dock tile.
+ *
+ * The files layer owns the actual `DropTarget` on each tile (the registry
+ * allows one target per element); it consults this registry for the
+ * accept predicate, the chip label, and the drop dispatch, so a feature
+ * never has to fight the claimant for the element.
+ *
+ * @since 0.9.6
+ */
+
+import type { DragPayload, DragSession } from '../drag';
+import type { RestPlacementShape } from './rest';
+
+export interface TilePayloadContext {
+	/** The placement backing the tile under the cursor. */
+	placement: RestPlacementShape;
+}
+
+export interface TilePayloadHandler {
+	/**
+	 * Cheap, payload-independent check on the placement — "is this a
+	 * tile I care about?" (e.g. the Posts shortcut). Used at tile
+	 * registration to choose the accept-chip label, and as a
+	 * precondition of `accept`/`onDrop`.
+	 */
+	appliesTo( ctx: TilePayloadContext ): boolean;
+	/** Whether a concrete payload is acceptable on this tile. */
+	accept( data: Record< string, unknown >, ctx: TilePayloadContext ): boolean;
+	/** Ghost-chip label shown while a matching payload hovers the tile. */
+	acceptLabel: string;
+	onDrop(
+		session: DragSession,
+		ev: { clientX: number; clientY: number },
+		ctx: TilePayloadContext,
+	): void;
+}
+
+const handlers = new Map< string, TilePayloadHandler >();
+
+/**
+ * Register a handler for a payload `type`. Returns a deregister
+ * function. Re-registering a type replaces the previous handler.
+ */
+export function registerTilePayloadHandler(
+	type: string,
+	handler: TilePayloadHandler,
+): () => void {
+	handlers.set( type, handler );
+	return () => {
+		if ( handlers.get( type ) === handler ) {
+			handlers.delete( type );
+		}
+	};
+}
+
+/**
+ * The accept-chip label for the first handler that applies to this
+ * tile, or `undefined` when none does. The files layer sets this as the
+ * tile target's static `acceptLabel`; it only ever surfaces while a
+ * payload the handler also accepts hovers the tile.
+ */
+export function tilePayloadAcceptLabel(
+	ctx: TilePayloadContext,
+): string | undefined {
+	for ( const handler of handlers.values() ) {
+		if ( handler.appliesTo( ctx ) ) {
+			return handler.acceptLabel;
+		}
+	}
+	return undefined;
+}
+
+/** Consulted by the tile target's `accept` for a concrete payload. */
+export function tilePayloadAccepts(
+	payload: DragPayload,
+	ctx: TilePayloadContext,
+): boolean {
+	const handler = handlers.get( payload.type );
+	return handler
+		? handler.appliesTo( ctx ) &&
+				handler.accept( payload.data as Record< string, unknown >, ctx )
+		: false;
+}
+
+/** Dispatch a drop for a handler-owned payload type. Returns whether handled. */
+export function tilePayloadDrop(
+	session: DragSession,
+	ev: { clientX: number; clientY: number },
+	ctx: TilePayloadContext,
+): boolean {
+	const handler = handlers.get( session.payload.type );
+	if ( ! handler || ! handler.appliesTo( ctx ) ) {
+		return false;
+	}
+	handler.onDrop( session, ev, ctx );
+	return true;
+}
+
+/** Test-only. */
+export function __resetTilePayloadHandlersForTests(): void {
+	handlers.clear();
+}

--- a/src/notes/convert.ts
+++ b/src/notes/convert.ts
@@ -1,0 +1,120 @@
+/**
+ * Desktop Mode — Pinned notes "convert to post" flow.
+ *
+ * Spawn a draft post from a note (`POST /notes/:id/convert` server-side),
+ * with optimistic eviction, auto-opening the draft in the block editor,
+ * and an Undo toast that reverses BOTH sides — restoring the note and
+ * discarding the draft (the server's restore route consumes the note→
+ * draft link, see `desktop_mode_notes_rest_restore`). Mirrors the trash
+ * flow (`src/notes/trash.ts`); the layer injects eviction/restore
+ * callbacks so this module stays DOM-free.
+ *
+ * @since 0.9.6
+ */
+
+import { __ } from '../i18n';
+import { convertNote, restoreNote } from './rest';
+import type { Note } from './types';
+
+interface DesktopApi {
+	showToast?: ( opts: {
+		message: string;
+		duration?: number;
+		action?: { label: string; onClick: () => void };
+	} ) => void;
+	deriveWindowId?: ( url: string, adminUrl?: string ) => string;
+	windowManager?: {
+		open?: ( config: {
+			id: string;
+			baseId?: string;
+			url: string;
+			title?: string;
+			icon?: string;
+		} ) => unknown;
+		getById?: ( id: string ) => { close?: () => void } | undefined;
+	};
+}
+
+function getDesktopApi(): DesktopApi | null {
+	return ( window as { wp?: { desktop?: DesktopApi } } ).wp?.desktop ?? null;
+}
+
+/**
+ * Open the draft's admin edit URL as a chromeless window and return the
+ * window id (so Undo can close it again). Falls back to a full-tab
+ * navigation only if the window APIs are somehow absent — the shell
+ * exposes both at boot, so that path is effectively dead.
+ */
+function openDraftEditor( url: string ): string | null {
+	const api = getDesktopApi();
+	if ( ! api?.windowManager?.open || ! api.deriveWindowId ) {
+		window.location.href = url;
+		return null;
+	}
+	const id = api.deriveWindowId( url );
+	api.windowManager.open( {
+		id,
+		baseId: id,
+		url,
+		title: __( 'Edit draft', 'desktop-mode' ),
+		icon: 'dashicons-admin-post',
+	} );
+	return id;
+}
+
+export interface ConvertNoteCallbacks {
+	/** Remove the note from the wall (optimistic). */
+	onEvict( noteId: number ): void;
+	/** Put a restored note back (Undo succeeded, or convert failed). */
+	onRestore( note: Note ): void;
+}
+
+/**
+ * Convert with auto-open + Undo. On failure the note is put back so the
+ * wall stays truthful. Undo restores the note and (server-side) trashes
+ * the draft, then closes the editor window this flow opened.
+ */
+export async function convertNoteToPost(
+	note: Note,
+	callbacks: ConvertNoteCallbacks,
+): Promise< void > {
+	callbacks.onEvict( note.id );
+	try {
+		const result = await convertNote( note.id );
+		const editorWindowId = openDraftEditor( result.editUrl );
+		getDesktopApi()?.showToast?.( {
+			message: __( 'Note converted to a draft post', 'desktop-mode' ),
+			duration: 6000,
+			action: {
+				label: __( 'Undo', 'desktop-mode' ),
+				onClick: () => {
+					// Close the editor we auto-opened first — restoring
+					// the note also trashes the draft server-side, so
+					// leaving its window open would show a trashed post.
+					if ( editorWindowId ) {
+						getDesktopApi()
+							?.windowManager?.getById?.( editorWindowId )
+							?.close?.();
+					}
+					void restoreNote( note.id )
+						.then( ( restored ) => callbacks.onRestore( restored ) )
+						.catch( ( err: unknown ) => {
+							// eslint-disable-next-line no-console
+							console.error(
+								'[desktop-mode] notes: convert undo failed:',
+								err,
+							);
+						} );
+				},
+			},
+		} );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( '[desktop-mode] notes: convert failed:', err );
+		callbacks.onRestore( note );
+		getDesktopApi()?.showToast?.( {
+			message: __( 'Could not convert the note to a post.', 'desktop-mode' ),
+			duration: 5000,
+		} );
+	}
+}

--- a/src/notes/index.ts
+++ b/src/notes/index.ts
@@ -12,6 +12,7 @@
 import type { DesktopConfig } from '../types';
 import { NotesLayer } from './layer';
 import { installNoteDropHandlers } from './drop-handlers';
+import { installNotesPostsDropTarget } from './posts-drop-target';
 import { installNotesRestDeps } from './rest';
 import { NOTE_CREATED_EVENT, type Note } from './types';
 
@@ -38,9 +39,11 @@ export function bootNotes( options: BootNotesOptions ): NotesLayer | null {
 	const layer = new NotesLayer( {
 		host: options.host,
 		pluginUrl: options.config.pluginUrl ?? '',
+		canCreatePosts: options.config.canCreatePosts ?? false,
 		onError: options.onError,
 	} );
 	installNoteDropHandlers( layer );
+	installNotesPostsDropTarget( layer );
 	document.addEventListener( NOTE_CREATED_EVENT, ( ev ) => {
 		const note = ( ev as CustomEvent< { note?: Note } > ).detail?.note;
 		if ( note && typeof note.id === 'number' ) {

--- a/src/notes/layer.ts
+++ b/src/notes/layer.ts
@@ -488,10 +488,10 @@ export class NoteController {
 			const convert = document.createElement( 'wpd-window-button' );
 			convert.className = 'desktop-mode-pinned-note__convert';
 			convert.innerHTML = ICON_POST;
-			convert.setAttribute(
-				'title',
-				__( 'Convert to a draft post', 'desktop-mode' ),
-			);
+			const convertLabel = __( 'Convert to a draft post', 'desktop-mode' );
+			convert.setAttribute( 'title', convertLabel );
+			// Icon-only button — give screen readers an accessible name.
+			convert.setAttribute( 'aria-label', convertLabel );
 			convert.addEventListener( 'wpd-button-activate', () =>
 				this.layer.convertNote( this.note ),
 			);

--- a/src/notes/layer.ts
+++ b/src/notes/layer.ts
@@ -42,6 +42,7 @@ import {
 } from './rest';
 import { startNotesHeartbeat } from './heartbeat';
 import { trashNoteWithUndo } from './trash';
+import { convertNoteToPost } from './convert';
 import {
 	NOTE_PAYLOAD_TYPE,
 	type Note,
@@ -76,16 +77,29 @@ function jitterSeed( note: Note ): number {
 	return note.seed || Math.abs( note.id ) || 1;
 }
 
+/**
+ * The `post` glyph from `@wordpress/icons`, inlined (the package isn't
+ * a shell dependency). Marks the "Convert to post" affordance. `fill`
+ * inherits from the button's ink color (see notes.css).
+ */
+const ICON_POST = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true" focusable="false"><path d="m7.3 9.7 1.4 1.4c.2-.2.3-.3.4-.5 0 0 0-.1.1-.1.3-.5.4-1.1.3-1.6L12 7 9 4 7.2 6.5c-.6-.1-1.1 0-1.6.3 0 0-.1 0-.1.1-.3.1-.4.2-.6.4l1.4 1.4L4 11v1h1l2.3-2.3zM4 20h9v-1.5H4V20zm0-5.5V16h16v-1.5H4z" /></svg>`;
+
 export interface NotesLayerOptions {
 	host: HTMLElement;
 	/** Plugin base URL (no trailing slash) — locates the pushpin SVG. */
 	pluginUrl: string;
+	/**
+	 * Whether the viewer can author posts. Gates the "Convert to post"
+	 * affordance on owned notes (inline button + Posts dock drop target).
+	 */
+	canCreatePosts?: boolean;
 	onError?: ( message: string ) => void;
 }
 
 export class NotesLayer {
 	readonly host: HTMLElement;
 	readonly pluginUrl: string;
+	readonly canCreatePosts: boolean;
 	private onError?: ( message: string ) => void;
 	private root: HTMLElement | null = null;
 	private liveRegion: HTMLElement | null = null;
@@ -97,6 +111,7 @@ export class NotesLayer {
 	constructor( options: NotesLayerOptions ) {
 		this.host = options.host;
 		this.pluginUrl = options.pluginUrl;
+		this.canCreatePosts = options.canCreatePosts ?? false;
 		this.onError = options.onError;
 	}
 
@@ -213,6 +228,23 @@ export class NotesLayer {
 
 	trashNote( note: Note ): void {
 		void trashNoteWithUndo( note, {
+			onEvict: ( noteId ) => this.removeNote( noteId ),
+			onRestore: ( restored ) => {
+				this.bumpHighWater( restored.updatedAtMs );
+				this.upsertNote( restored, { animate: 'move' } );
+			},
+		} );
+	}
+
+	/**
+	 * Convert a note to a draft post: evict optimistically, auto-open
+	 * the draft editor, Undo restores the note (and discards the draft).
+	 */
+	convertNote( note: Note ): void {
+		if ( ! this.canCreatePosts || ! note.canEdit ) {
+			return;
+		}
+		void convertNoteToPost( note, {
 			onEvict: ( noteId ) => this.removeNote( noteId ),
 			onRestore: ( restored ) => {
 				this.bumpHighWater( restored.updatedAtMs );
@@ -447,6 +479,24 @@ export class NoteController {
 		);
 
 		meta.append( colorDot, visibility );
+
+		// "Convert to post" — only for users who can author posts. Drops
+		// the note into a fresh draft (the note itself is trashed) and
+		// opens the block editor. The pin can also be dragged onto the
+		// Posts dock tile for the same effect (see posts-drop-target.ts).
+		if ( this.layer.canCreatePosts ) {
+			const convert = document.createElement( 'wpd-window-button' );
+			convert.className = 'desktop-mode-pinned-note__convert';
+			convert.innerHTML = ICON_POST;
+			convert.setAttribute(
+				'title',
+				__( 'Convert to a draft post', 'desktop-mode' ),
+			);
+			convert.addEventListener( 'wpd-button-activate', () =>
+				this.layer.convertNote( this.note ),
+			);
+			meta.append( convert );
+		}
 
 		const editor = document.createElement( 'wpd-textarea' ) as WpdTextareaElement;
 		editor.className = 'desktop-mode-pinned-note__editor';

--- a/src/notes/posts-drop-target.ts
+++ b/src/notes/posts-drop-target.ts
@@ -1,0 +1,280 @@
+/**
+ * Desktop Mode — "Convert note to post" drop target.
+ *
+ * Registers the Posts surfaces as drop zones that accept a pinned-note
+ * pin drag (`'note'` payload) and convert the note into a draft post —
+ * the second entry point for the conversion, alongside the inline
+ * "Convert to post" button on each owned note.
+ *
+ *   1. The Posts dock tile. The dock tags each tile with
+ *      `data-menu-slug = sanitize_key( $item[5] ?? $item[2] )` — for the
+ *      core Posts menu that's `menu-posts` (WP's `$menu[5][5]`), never
+ *      `edit.php` (which `sanitize_key()` would mangle to `editphp`
+ *      anyway). The dock is rebuilt on `HOOKS.DOCK_AFTER_RENDER`; we
+ *      re-discover + re-register on that signal plus a `MutationObserver`
+ *      fallback.
+ *   2. The native Posts window body (`[data-desktop-mode-posts-root]`,
+ *      the opt-in `desktop-mode-posts` window). Registered on
+ *      `WINDOW_OPENED`, deregistered on `WINDOW_CLOSED`.
+ *
+ *   3. The Posts shortcut TILE in the Spatial layout. On files-layer
+ *      shells, core menu icons render as shortcut file-tiles rather than
+ *      dock tiles, and every non-folder tile is already claimed by the
+ *      files layer's reject target (one target per element). So for this
+ *      surface we can't register our own `DropTarget` — we hook the
+ *      files-layer tile-payload seam (`registerTilePayloadHandler`) and
+ *      claim a `'note'` drop only on tiles whose shortcut points at the
+ *      Posts screen.
+ *
+ * Surfaces (1) and (2) aren't claimed by anything else, so there we
+ * register a real `DropTarget` directly.
+ *
+ * The whole module is a no-op when the viewer can't author posts
+ * (`layer.canCreatePosts` is false) — no drop targets, matching the
+ * hidden inline button.
+ *
+ * @since 0.9.6
+ */
+
+import { __ } from '../i18n';
+import { addAction, HOOKS } from '../hooks';
+import type { DragManagerApi, DragPayload, DragSession } from '../drag';
+import {
+	registerTilePayloadHandler,
+	type TilePayloadContext,
+} from '../desktop-files/tile-payloads';
+import { NOTE_PAYLOAD_TYPE, type NoteDragData } from './types';
+import type { NotesLayer } from './layer';
+
+const DROP_ACTIVE_ATTR = 'data-desktop-mode-posts-drop-active';
+const POSTS_WINDOW_ID = 'desktop-mode-posts';
+// The core Posts tile carries `menu-posts`; `editphp` is the fallback
+// when a site's menu row has no id (`$item[5]`) so the dock falls back
+// to `sanitize_key( $item[2] )` = `sanitize_key( 'edit.php' )`.
+const POSTS_DOCK_SELECTOR =
+	'.desktop-mode-dock__item[data-menu-slug="menu-posts"],' +
+	'.desktop-mode-dock__item[data-menu-slug="editphp"]';
+const POSTS_WINDOW_SELECTOR = '[data-desktop-mode-posts-root]';
+
+function getDragManager(): DragManagerApi | null {
+	return (
+		window as unknown as {
+			wp?: { desktop?: { dragManager?: DragManagerApi } };
+		}
+	).wp?.desktop?.dragManager ?? null;
+}
+
+function isNotePayload( payload: DragPayload ): boolean {
+	if ( payload.type !== NOTE_PAYLOAD_TYPE ) {
+		return false;
+	}
+	const data = payload.data as Partial< NoteDragData >;
+	return data.canEdit === true;
+}
+
+/**
+ * Whether a URL points at the Posts screen — the Posts list (`edit.php`)
+ * or Add New Post (`post-new.php`), with `post_type` absent or `post`
+ * (so the Pages/CPT icons, which carry `post_type=page` etc., don't
+ * masquerade as Posts).
+ */
+function isPostsUrl( url: string ): boolean {
+	if ( ! url ) {
+		return false;
+	}
+	let path = url;
+	let search = '';
+	try {
+		const parsed = new URL( url, window.location.origin );
+		path = parsed.pathname;
+		search = parsed.search;
+	} catch {
+		// Relative/malformed — fall back to raw-string matching below.
+	}
+	const onPostsScreen =
+		/(?:^|\/)(?:edit\.php|post-new\.php)$/.test( path ) ||
+		( ! path.includes( '/' ) &&
+			( path === 'edit.php' || path === 'post-new.php' ) );
+	if ( ! onPostsScreen ) {
+		return false;
+	}
+	const postType = new URLSearchParams( search ).get( 'post_type' );
+	return ! postType || postType === 'post';
+}
+
+/** Whether a tile's placement is the Posts shortcut icon. */
+function isPostsShortcutTile( ctx: TilePayloadContext ): boolean {
+	const file = ctx.placement.file;
+	if ( ! file || file.type !== 'shortcut' ) {
+		return false;
+	}
+	const url = typeof file.shortcutUrl === 'string' ? file.shortcutUrl : '';
+	return isPostsUrl( url );
+}
+
+/** Shared drop action: convert the dragged note (surfaces 1–3). */
+function convertDraggedNote( layer: NotesLayer, session: DragSession ): void {
+	if ( session.payload.type !== NOTE_PAYLOAD_TYPE ) {
+		return;
+	}
+	const data = session.payload.data as Partial< NoteDragData >;
+	if ( typeof data.noteId !== 'number' ) {
+		return;
+	}
+	const controller = layer.get( data.noteId );
+	if ( controller ) {
+		layer.convertNote( controller.note );
+	}
+}
+
+let _installed = false;
+let _dockDeregister: ( () => void ) | null = null;
+let _windowDeregister: ( () => void ) | null = null;
+let _tileDeregister: ( () => void ) | null = null;
+let _mutationObserver: MutationObserver | null = null;
+
+function registerOn(
+	dragManager: DragManagerApi,
+	layer: NotesLayer,
+	id: string,
+	el: HTMLElement,
+): () => void {
+	return dragManager.registerDropTarget( {
+		id,
+		element: el,
+		acceptLabel: __( 'Convert to post', 'desktop-mode' ),
+		accept: ( payload ) => isNotePayload( payload ),
+		onEnter: () => {
+			el.setAttribute( DROP_ACTIVE_ATTR, '' );
+		},
+		onLeave: () => {
+			el.removeAttribute( DROP_ACTIVE_ATTR );
+		},
+		onDrop: ( session: DragSession ) => {
+			el.removeAttribute( DROP_ACTIVE_ATTR );
+			convertDraggedNote( layer, session );
+		},
+	} );
+}
+
+/**
+ * Read the live element of a currently-registered target, or null.
+ * Lets the dock reprobe skip re-registration when nothing moved.
+ */
+function registeredElement(
+	dragManager: DragManagerApi,
+	id: string,
+): HTMLElement | null {
+	const t = dragManager
+		.debug()
+		.listTargets()
+		.find( ( target ) => target.id === id );
+	return t ? t.element : null;
+}
+
+/**
+ * Wire up the "convert to post" drop targets. Idempotent, and a no-op
+ * when the viewer can't author posts.
+ */
+export function installNotesPostsDropTarget( layer: NotesLayer ): void {
+	if ( _installed || ! layer.canCreatePosts ) {
+		return;
+	}
+	const dragManager = getDragManager();
+	if ( ! dragManager ) {
+		return;
+	}
+	_installed = true;
+
+	// Surface 3: the Spatial-layout Posts shortcut tile. The files layer
+	// owns the tile's DropTarget; we opt the `'note'` payload in via the
+	// tile-payload seam, scoped to tiles whose shortcut points at Posts.
+	_tileDeregister = registerTilePayloadHandler( NOTE_PAYLOAD_TYPE, {
+		appliesTo: ( ctx ) => isPostsShortcutTile( ctx ),
+		acceptLabel: __( 'Convert to post', 'desktop-mode' ),
+		accept: ( data ) => ( data as Partial< NoteDragData > ).canEdit === true,
+		onDrop: ( session ) => convertDraggedNote( layer, session ),
+	} );
+
+	const reprobeTile = (): void => {
+		const el = document.querySelector( POSTS_DOCK_SELECTOR );
+		if ( ! ( el instanceof HTMLElement ) ) {
+			_dockDeregister?.();
+			_dockDeregister = null;
+			return;
+		}
+		if (
+			_dockDeregister &&
+			registeredElement( dragManager, 'notes-convert-dock' ) === el
+		) {
+			return;
+		}
+		_dockDeregister?.();
+		_dockDeregister = registerOn( dragManager, layer, 'notes-convert-dock', el );
+	};
+
+	reprobeTile();
+
+	addAction(
+		HOOKS.DOCK_AFTER_RENDER,
+		'desktop-mode/notes/convert-dock-target',
+		reprobeTile,
+	);
+
+	if ( typeof MutationObserver !== 'undefined' ) {
+		_mutationObserver = new MutationObserver( () => {
+			reprobeTile();
+		} );
+		_mutationObserver.observe( document.body, {
+			childList: true,
+			subtree: true,
+		} );
+	}
+
+	// Native Posts window body — register on open, drop on close.
+	addAction(
+		HOOKS.WINDOW_OPENED,
+		'desktop-mode/notes/convert-window-target',
+		( detail: { windowId?: string } ) => {
+			if ( detail.windowId !== POSTS_WINDOW_ID ) {
+				return;
+			}
+			_windowDeregister?.();
+			_windowDeregister = null;
+			const el = document.querySelector( POSTS_WINDOW_SELECTOR );
+			if ( el instanceof HTMLElement ) {
+				_windowDeregister = registerOn(
+					dragManager,
+					layer,
+					'notes-convert-window',
+					el,
+				);
+			}
+		},
+	);
+
+	addAction(
+		HOOKS.WINDOW_CLOSED,
+		'desktop-mode/notes/convert-window-cleanup',
+		( detail: { windowId?: string } ) => {
+			if ( detail.windowId !== POSTS_WINDOW_ID ) {
+				return;
+			}
+			_windowDeregister?.();
+			_windowDeregister = null;
+		},
+	);
+}
+
+/** Test-only — resets the install latch + clears registrations. */
+export function __resetNotesPostsDropTargetForTests(): void {
+	_dockDeregister?.();
+	_windowDeregister?.();
+	_tileDeregister?.();
+	_mutationObserver?.disconnect();
+	_dockDeregister = null;
+	_windowDeregister = null;
+	_tileDeregister = null;
+	_mutationObserver = null;
+	_installed = false;
+}

--- a/src/notes/rest.ts
+++ b/src/notes/rest.ts
@@ -168,6 +168,24 @@ export function restoreNote( id: number ): Promise< Note > {
 	return call< Note >( `/${ id }/restore`, { method: 'POST' } );
 }
 
+/** Result of converting a note into a draft post. */
+export interface ConvertNoteResult {
+	/** The (now-trashed) source note id. */
+	noteId: number;
+	/** The new draft post id. */
+	postId: number;
+	/** Absolute admin edit URL for the draft (`post.php?post=…&action=edit`). */
+	editUrl: string;
+}
+
+/**
+ * Convert a note into a draft post. The server spawns the draft, trashes
+ * the note, and links the two so `restoreNote` reverses both sides.
+ */
+export function convertNote( id: number ): Promise< ConvertNoteResult > {
+	return call< ConvertNoteResult >( `/${ id }/convert`, { method: 'POST' } );
+}
+
 /** Test-only. */
 export function __resetNotesRestForTests(): void {
 	deps = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1824,6 +1824,14 @@ export interface DesktopConfig {
 	 */
 	notesUrl?: string;
 	/**
+	 * Whether the current user can author posts (`edit_posts`). Gates
+	 * the "Convert to post" note affordance (inline button + Posts dock
+	 * drop target). Absent on older server payloads → treated as false.
+	 *
+	 * @since 0.9.6
+	 */
+	canCreatePosts?: boolean;
+	/**
 	 * Roles eligible to appear in the folder Share Settings role
 	 * picker. Server applies `desktop_mode_files_share_eligible_roles`
 	 * before serializing — default = roles with `edit_posts`.

--- a/tests/phpunit/tests/notesRest.php
+++ b/tests/phpunit/tests/notesRest.php
@@ -334,6 +334,128 @@ class Tests_DesktopMode_NotesRest extends WP_UnitTestCase {
 		$this->assertSame( 404, $resp->get_error_data()['status'] );
 	}
 
+	private function convert_request( $id ) {
+		$request = new WP_REST_Request( 'POST', '/desktop-mode/v1/notes/' . $id . '/convert' );
+		$request->set_param( 'id', $id );
+		return $request;
+	}
+
+	/**
+	 * @covers ::desktop_mode_notes_rest_convert
+	 * @covers ::desktop_mode_notes_text_to_blocks
+	 */
+	public function test_convert_spawns_draft_and_trashes_note() {
+		$note = $this->create_note( array( 'text' => "First para\nsame para\n\nSecond para" ) );
+
+		$resp = desktop_mode_notes_rest_convert( $this->convert_request( $note['id'] ) );
+		$this->assertNotWPError( $resp );
+		$data = $resp->get_data();
+
+		$this->assertSame( $note['id'], $data['noteId'] );
+		$this->assertGreaterThan( 0, $data['postId'] );
+		$this->assertNotEmpty( $data['editUrl'] );
+
+		// The note is trashed and linked to its draft.
+		$this->assertSame( 'trash', get_post_status( $note['id'] ) );
+		$this->assertSame(
+			$data['postId'],
+			(int) get_post_meta( $note['id'], '_wpd_note_converted_post', true )
+		);
+
+		// The draft is a real post, owned by the note author, titled from
+		// the first line, with the body as separate paragraph blocks.
+		$draft = get_post( $data['postId'] );
+		$this->assertSame( 'post', $draft->post_type );
+		$this->assertSame( 'draft', $draft->post_status );
+		$this->assertSame( self::$owner_id, (int) $draft->post_author );
+		$this->assertSame( 'First para', $draft->post_title );
+		$this->assertStringContainsString( '<!-- wp:paragraph -->', $draft->post_content );
+		$this->assertSame( 2, substr_count( $draft->post_content, '<!-- wp:paragraph -->' ) );
+		// A single newline within a paragraph becomes a <br> (nl2br keeps
+		// the trailing newline).
+		$this->assertMatchesRegularExpression( '/First para<br>\s*same para/', $draft->post_content );
+	}
+
+	/**
+	 * @covers ::desktop_mode_notes_rest_convert
+	 */
+	public function test_convert_requires_edit_posts_capability() {
+		$note = $this->create_note();
+
+		// A subscriber has desktop mode on but cannot author posts.
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		update_user_meta( $subscriber, 'desktop_mode_mode', '1' );
+
+		// The note stays owned by the editor; hand ownership to the
+		// subscriber so the owner gate passes and the cap gate is what
+		// rejects.
+		wp_update_post( array( 'ID' => $note['id'], 'post_author' => $subscriber ) );
+		wp_set_current_user( $subscriber );
+
+		$resp = desktop_mode_notes_rest_convert( $this->convert_request( $note['id'] ) );
+		$this->assertWPError( $resp );
+		$this->assertSame( 403, $resp->get_error_data()['status'] );
+		$this->assertSame( 'private', get_post_status( $note['id'] ), 'A rejected convert leaves the note untouched.' );
+	}
+
+	/**
+	 * @covers ::desktop_mode_notes_rest_convert
+	 * @covers ::desktop_mode_notes_require_owner
+	 */
+	public function test_non_owner_cannot_convert_even_as_admin() {
+		$note = $this->create_note( array( 'public' => true ) );
+
+		wp_set_current_user( self::$admin_id );
+		$resp = desktop_mode_notes_rest_convert( $this->convert_request( $note['id'] ) );
+		$this->assertWPError( $resp );
+		$this->assertSame( 403, $resp->get_error_data()['status'] );
+		$this->assertSame( 'publish', get_post_status( $note['id'] ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_notes_rest_convert
+	 * @covers ::desktop_mode_notes_rest_restore
+	 */
+	public function test_restore_after_convert_undoes_both_sides() {
+		$note = $this->create_note( array( 'public' => true, 'text' => 'draft me' ) );
+
+		$convert = desktop_mode_notes_rest_convert( $this->convert_request( $note['id'] ) )->get_data();
+		$post_id = $convert['postId'];
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+
+		// Undo — restore the note; the spawned draft is discarded and the
+		// link meta cleared.
+		$restore = new WP_REST_Request( 'POST', '/desktop-mode/v1/notes/' . $note['id'] . '/restore' );
+		$restore->set_param( 'id', $note['id'] );
+		$resp = desktop_mode_notes_rest_restore( $restore );
+		$this->assertNotWPError( $resp );
+
+		$this->assertSame( 'publish', get_post_status( $note['id'] ), 'The note is back at its prior status.' );
+		$this->assertSame( 'trash', get_post_status( $post_id ), 'The draft it spawned is discarded.' );
+		$this->assertSame( '', get_post_meta( $note['id'], '_wpd_note_converted_post', true ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_notes_rest_convert
+	 */
+	public function test_convert_post_args_filter_can_override_type_and_status() {
+		$note = $this->create_note( array( 'text' => 'make me a page' ) );
+
+		$filter = static function ( $args ) {
+			$args['post_type']   = 'page';
+			$args['post_status'] = 'pending';
+			return $args;
+		};
+		add_filter( 'desktop_mode_notes_convert_post_args', $filter );
+		$resp = desktop_mode_notes_rest_convert( $this->convert_request( $note['id'] ) );
+		remove_filter( 'desktop_mode_notes_convert_post_args', $filter );
+
+		$this->assertNotWPError( $resp );
+		$draft = get_post( $resp->get_data()['postId'] );
+		$this->assertSame( 'page', $draft->post_type );
+		$this->assertSame( 'pending', $draft->post_status );
+	}
+
 	/**
 	 * @covers ::desktop_mode_notes_compute_heartbeat_delta
 	 * @covers ::desktop_mode_notes_query_visible_ids

--- a/tests/vitest/notes-convert.test.ts
+++ b/tests/vitest/notes-convert.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Pinned-notes "convert to post" flow: optimistic eviction, auto-open
+ * of the draft editor, and the Undo toast that restores the note and
+ * closes the editor window it opened.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Note } from '../../src/notes/types';
+
+const convertNoteMock = vi.fn();
+const restoreNoteMock = vi.fn();
+
+vi.mock( '../../src/notes/rest', () => ( {
+	convertNote: ( ...args: unknown[] ) => convertNoteMock( ...args ),
+	restoreNote: ( ...args: unknown[] ) => restoreNoteMock( ...args ),
+} ) );
+
+// Imported after the mock is registered.
+import { convertNoteToPost } from '../../src/notes/convert';
+
+const NOTE: Note = {
+	id: 7,
+	text: 'draft me',
+	color: 'sky',
+	x: 0.2,
+	y: 0.3,
+	z: 4,
+	public: false,
+	seed: 77,
+	ownerId: 1,
+	ownerName: 'Ana',
+	ownerAvatar: '',
+	canEdit: true,
+	updatedAtMs: 1000,
+};
+
+describe( 'convertNoteToPost', () => {
+	let showToast: ReturnType< typeof vi.fn >;
+	let openWindow: ReturnType< typeof vi.fn >;
+	let closeWindow: ReturnType< typeof vi.fn >;
+	let getById: ReturnType< typeof vi.fn >;
+
+	beforeEach( () => {
+		convertNoteMock.mockReset();
+		restoreNoteMock.mockReset();
+		showToast = vi.fn();
+		openWindow = vi.fn();
+		closeWindow = vi.fn();
+		getById = vi.fn( () => ( { close: closeWindow } ) );
+		( window as unknown as { wp: unknown } ).wp = {
+			desktop: {
+				showToast,
+				deriveWindowId: ( url: string ) => `win:${ url }`,
+				windowManager: { open: openWindow, getById },
+			},
+		};
+	} );
+
+	afterEach( () => {
+		delete ( window as unknown as { wp?: unknown } ).wp;
+	} );
+
+	test( 'evicts, opens the editor, and shows an Undo toast on success', async () => {
+		convertNoteMock.mockResolvedValueOnce( {
+			noteId: 7,
+			postId: 99,
+			editUrl: 'https://x.test/wp-admin/post.php?post=99&action=edit',
+		} );
+		const onEvict = vi.fn();
+		const onRestore = vi.fn();
+
+		await convertNoteToPost( NOTE, { onEvict, onRestore } );
+
+		expect( onEvict ).toHaveBeenCalledWith( 7 );
+		expect( convertNoteMock ).toHaveBeenCalledWith( 7 );
+		expect( openWindow ).toHaveBeenCalledTimes( 1 );
+		expect( openWindow.mock.calls[ 0 ][ 0 ].url ).toContain( 'post=99' );
+		expect( showToast ).toHaveBeenCalledTimes( 1 );
+		expect( showToast.mock.calls[ 0 ][ 0 ].action.label ).toBeTruthy();
+	} );
+
+	test( 'Undo restores the note and closes the editor window', async () => {
+		convertNoteMock.mockResolvedValueOnce( {
+			noteId: 7,
+			postId: 99,
+			editUrl: 'https://x.test/wp-admin/post.php?post=99&action=edit',
+		} );
+		restoreNoteMock.mockResolvedValueOnce( { ...NOTE } );
+		const onRestore = vi.fn();
+
+		await convertNoteToPost( NOTE, { onEvict: vi.fn(), onRestore } );
+		// Fire the Undo action.
+		await showToast.mock.calls[ 0 ][ 0 ].action.onClick();
+		// Let the restore promise settle.
+		await vi.waitFor( () => expect( onRestore ).toHaveBeenCalled() );
+
+		expect( closeWindow ).toHaveBeenCalledTimes( 1 );
+		expect( restoreNoteMock ).toHaveBeenCalledWith( 7 );
+	} );
+
+	test( 'a convert failure rolls the note back and warns', async () => {
+		convertNoteMock.mockRejectedValueOnce( new Error( 'boom' ) );
+		const onRestore = vi.fn();
+		const errorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		await convertNoteToPost( NOTE, { onEvict: vi.fn(), onRestore } );
+
+		expect( onRestore ).toHaveBeenCalledWith( NOTE );
+		expect( openWindow ).not.toHaveBeenCalled();
+		expect( showToast ).toHaveBeenCalledTimes( 1 );
+		errorSpy.mockRestore();
+	} );
+} );

--- a/tests/vitest/notes-posts-drop-target.test.ts
+++ b/tests/vitest/notes-posts-drop-target.test.ts
@@ -183,14 +183,14 @@ describe( 'notes → posts dock drop target', () => {
 		};
 
 		// Posts list → claimed + accepted; Pages / Media → not claimed.
-		expect( tilePayloadAcceptLabel( shortcut( '/wp-admin/edit.php' ) ) ).toBe(
+		expect( tilePayloadAcceptLabel( 'note', shortcut( '/wp-admin/edit.php' ) ) ).toBe(
 			'Convert to post',
 		);
 		expect( tilePayloadAccepts( notePayload, shortcut( '/wp-admin/edit.php' ) ) ).toBe( true );
 		expect(
 			tilePayloadAccepts( notePayload, shortcut( '/wp-admin/edit.php?post_type=page' ) ),
 		).toBe( false );
-		expect( tilePayloadAcceptLabel( shortcut( '/wp-admin/upload.php' ) ) ).toBeUndefined();
+		expect( tilePayloadAcceptLabel( 'note', shortcut( '/wp-admin/upload.php' ) ) ).toBeUndefined();
 
 		// Drop over the Posts shortcut converts the dragged note.
 		tilePayloadDrop(

--- a/tests/vitest/notes-posts-drop-target.test.ts
+++ b/tests/vitest/notes-posts-drop-target.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression test for the "convert note to post" DOCK drop target.
+ *
+ * The bug this guards: the dock tile's `data-menu-slug` for the core
+ * Posts menu is `menu-posts` (WP's `$menu[5][5]`), NOT `edit.php` — the
+ * first selector never matched, so the target never registered and a
+ * note dragged onto the Posts icon fell through to "Can't pin here".
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import type { DropTarget } from '../../src/drag';
+import {
+	installNotesPostsDropTarget,
+	__resetNotesPostsDropTargetForTests,
+} from '../../src/notes/posts-drop-target';
+import {
+	tilePayloadAccepts,
+	tilePayloadAcceptLabel,
+	tilePayloadDrop,
+} from '../../src/desktop-files/tile-payloads';
+import type { Note } from '../../src/notes/types';
+
+const NOTE: Note = {
+	id: 7,
+	text: 'draft me',
+	color: 'sky',
+	x: 0.2,
+	y: 0.3,
+	z: 4,
+	public: false,
+	seed: 77,
+	ownerId: 1,
+	ownerName: 'Ana',
+	ownerAvatar: '',
+	canEdit: true,
+	updatedAtMs: 1000,
+};
+
+function noteSession( data: Partial< Note & { noteId: number } > = {} ) {
+	return {
+		payload: {
+			type: 'note',
+			source: document.createElement( 'div' ),
+			data: { noteId: 7, canEdit: true, updatedAtMs: 1000, ...data },
+		},
+	} as never;
+}
+
+describe( 'notes → posts dock drop target', () => {
+	let targets: DropTarget[];
+	let convertNote: ReturnType< typeof vi.fn >;
+	let layer: { canCreatePosts: boolean; get: ( id: number ) => unknown; convertNote: typeof convertNote };
+
+	function fakeDragManager() {
+		return {
+			registerDropTarget: ( t: DropTarget ) => {
+				targets.push( t );
+				return () => {
+					const i = targets.indexOf( t );
+					if ( i >= 0 ) {
+						targets.splice( i, 1 );
+					}
+				};
+			},
+			debug: () => ( { listTargets: () => targets } ),
+		};
+	}
+
+	function makeTile( slug: string ): HTMLElement {
+		const tile = document.createElement( 'div' );
+		tile.className = 'desktop-mode-dock__item';
+		tile.setAttribute( 'data-menu-slug', slug );
+		document.body.appendChild( tile );
+		return tile;
+	}
+
+	beforeEach( () => {
+		installHooksStub();
+		__resetNotesPostsDropTargetForTests();
+		targets = [];
+		convertNote = vi.fn();
+		layer = {
+			canCreatePosts: true,
+			get: ( id: number ) => ( id === 7 ? { note: NOTE } : undefined ),
+			convertNote,
+		};
+		// `installHooksStub()` mounted `window.wp.hooks`; add `desktop`
+		// alongside it rather than clobbering the whole `wp` object.
+		( window as unknown as { wp: { desktop?: unknown } } ).wp.desktop = {
+			dragManager: fakeDragManager(),
+		};
+	} );
+
+	afterEach( () => {
+		__resetNotesPostsDropTargetForTests();
+		document.body.innerHTML = '';
+		delete ( window as unknown as { wp: { desktop?: unknown } } ).wp.desktop;
+		clearHooksStub();
+	} );
+
+	test( 'registers a drop target on the core Posts tile (menu-posts)', () => {
+		const tile = makeTile( 'menu-posts' );
+		installNotesPostsDropTarget( layer as never );
+		expect( targets ).toHaveLength( 1 );
+		expect( targets[ 0 ].element ).toBe( tile );
+	} );
+
+	test( 'also matches the sanitized-slug fallback (editphp)', () => {
+		const tile = makeTile( 'editphp' );
+		installNotesPostsDropTarget( layer as never );
+		expect( targets ).toHaveLength( 1 );
+		expect( targets[ 0 ].element ).toBe( tile );
+	} );
+
+	test( 'does NOT match the raw edit.php slug (the original bug)', () => {
+		makeTile( 'edit.php' );
+		installNotesPostsDropTarget( layer as never );
+		expect( targets ).toHaveLength( 0 );
+	} );
+
+	test( 'accepts an editable note payload and rejects others', () => {
+		makeTile( 'menu-posts' );
+		installNotesPostsDropTarget( layer as never );
+		const t = targets[ 0 ];
+		expect( t.accept( noteSession().payload ) ).toBe( true );
+		expect( t.accept( noteSession( { canEdit: false } ).payload ) ).toBe( false );
+		expect(
+			t.accept( { type: 'desktop-file', source: document.createElement( 'div' ), data: {} } ),
+		).toBe( false );
+	} );
+
+	test( 'onDrop converts the dragged note; enter/leave toggle the highlight', () => {
+		const tile = makeTile( 'menu-posts' );
+		installNotesPostsDropTarget( layer as never );
+		const t = targets[ 0 ];
+
+		t.onEnter?.( noteSession() );
+		expect( tile.hasAttribute( 'data-desktop-mode-posts-drop-active' ) ).toBe( true );
+
+		t.onDrop( noteSession(), new MouseEvent( 'mouseup' ) as never );
+		expect( convertNote ).toHaveBeenCalledWith( NOTE );
+		expect( tile.hasAttribute( 'data-desktop-mode-posts-drop-active' ) ).toBe( false );
+	} );
+
+	test( 'no-op when the user cannot author posts', () => {
+		makeTile( 'menu-posts' );
+		installNotesPostsDropTarget( { ...layer, canCreatePosts: false } as never );
+		expect( targets ).toHaveLength( 0 );
+	} );
+
+	// Surface 3: the Spatial-layout Posts shortcut file-tile, handled via
+	// the files-layer tile-payload seam (the tile is claimed by the files
+	// layer, so we can't register our own DropTarget there).
+	test( 'registers a tile-payload handler scoped to the Posts shortcut', () => {
+		makeTile( 'menu-posts' );
+		installNotesPostsDropTarget( layer as never );
+
+		const shortcut = ( url: string ) => ( {
+			placement: {
+				id: 1,
+				parentId: 0,
+				x: 0,
+				y: 0,
+				sortOrder: 0,
+				updatedAtMs: 1,
+				meta: null,
+				file: {
+					type: 'shortcut',
+					ref: 'dock-promoted:menu-posts',
+					title: 'Posts',
+					icon: '',
+					previewUrl: '',
+					exists: true,
+					shortcutUrl: url,
+				},
+			},
+		} as never );
+
+		const notePayload = {
+			type: 'note',
+			source: document.body,
+			data: { noteId: 7, canEdit: true },
+		};
+
+		// Posts list → claimed + accepted; Pages / Media → not claimed.
+		expect( tilePayloadAcceptLabel( shortcut( '/wp-admin/edit.php' ) ) ).toBe(
+			'Convert to post',
+		);
+		expect( tilePayloadAccepts( notePayload, shortcut( '/wp-admin/edit.php' ) ) ).toBe( true );
+		expect(
+			tilePayloadAccepts( notePayload, shortcut( '/wp-admin/edit.php?post_type=page' ) ),
+		).toBe( false );
+		expect( tilePayloadAcceptLabel( shortcut( '/wp-admin/upload.php' ) ) ).toBeUndefined();
+
+		// Drop over the Posts shortcut converts the dragged note.
+		tilePayloadDrop(
+			{ payload: notePayload } as never,
+			{ clientX: 0, clientY: 0 },
+			shortcut( '/wp-admin/edit.php' ),
+		);
+		expect( convertNote ).toHaveBeenCalledWith( NOTE );
+	} );
+} );

--- a/tests/vitest/notes-rest.test.ts
+++ b/tests/vitest/notes-rest.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
 	__resetNotesRestForTests,
+	convertNote,
 	createNote,
 	deleteNote,
 	installNotesRestDeps,
@@ -126,6 +127,25 @@ describe( 'notes REST client', () => {
 		expect( ( fetchSpy.mock.calls[ 0 ][ 1 ] as RequestInit ).method ).toBe( 'DELETE' );
 		expect( String( fetchSpy.mock.calls[ 1 ][ 0 ] ) ).toContain( '/notes/12/restore' );
 		expect( ( fetchSpy.mock.calls[ 1 ][ 1 ] as RequestInit ).method ).toBe( 'POST' );
+	} );
+
+	test( 'convertNote POSTs the convert route and returns the draft link', async () => {
+		fetchSpy.mockResolvedValueOnce(
+			jsonResponse( {
+				noteId: 12,
+				postId: 99,
+				editUrl: 'https://example.test/wp-admin/post.php?post=99&action=edit',
+			} ),
+		);
+		const result = await convertNote( 12 );
+		expect( result.postId ).toBe( 99 );
+		expect( result.editUrl ).toContain( 'post=99' );
+		expect( String( fetchSpy.mock.calls[ 0 ][ 0 ] ) ).toContain(
+			'/notes/12/convert',
+		);
+		expect( ( fetchSpy.mock.calls[ 0 ][ 1 ] as RequestInit ).method ).toBe(
+			'POST',
+		);
 	} );
 
 	test( 'non-409 errors surface code + message', async () => {

--- a/tests/vitest/tile-payloads.test.ts
+++ b/tests/vitest/tile-payloads.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The files-layer tile-payload seam: a feature opts a payload type into
+ * a non-folder tile the files layer would otherwise hard-reject.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+	registerTilePayloadHandler,
+	tilePayloadAccepts,
+	tilePayloadAcceptLabel,
+	tilePayloadDrop,
+	__resetTilePayloadHandlersForTests,
+	type TilePayloadContext,
+} from '../../src/desktop-files/tile-payloads';
+import type { RestPlacementShape } from '../../src/desktop-files/rest';
+
+function placement( shortcutUrl: string ): RestPlacementShape {
+	return {
+		id: 1,
+		parentId: 0,
+		x: 0,
+		y: 0,
+		sortOrder: 0,
+		updatedAtMs: 1,
+		meta: null,
+		file: {
+			type: 'shortcut',
+			ref: 'dock-promoted:menu-posts',
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			previewUrl: '',
+			exists: true,
+			shortcutUrl,
+		},
+	};
+}
+
+const session = ( type: string ) =>
+	( { payload: { type, source: document.createElement( 'div' ), data: { noteId: 5 } } } as never );
+
+afterEach( () => __resetTilePayloadHandlersForTests() );
+
+describe( 'tile-payload seam', () => {
+	test( 'accepts only the registered type on tiles the handler claims', () => {
+		const onDrop = vi.fn();
+		registerTilePayloadHandler( 'note', {
+			appliesTo: ( ctx ) => ctx.placement.file.ref === 'dock-promoted:menu-posts',
+			acceptLabel: 'Convert to post',
+			accept: ( data ) => ( data as { canEdit?: boolean } ).canEdit === true,
+			onDrop,
+		} );
+
+		const ctx: TilePayloadContext = { placement: placement( '/wp-admin/edit.php' ) };
+		const notePayload = { type: 'note', source: document.body, data: { canEdit: true } };
+		const filePayload = { type: 'desktop-file', source: document.body, data: {} };
+
+		expect( tilePayloadAccepts( notePayload, ctx ) ).toBe( true );
+		expect( tilePayloadAccepts( filePayload, ctx ) ).toBe( false );
+		expect( tilePayloadAcceptLabel( ctx ) ).toBe( 'Convert to post' );
+	} );
+
+	test( 'rejects on tiles the handler does not claim (appliesTo false)', () => {
+		registerTilePayloadHandler( 'note', {
+			appliesTo: ( ctx ) => ctx.placement.file.ref === 'dock-promoted:menu-posts',
+			acceptLabel: 'Convert to post',
+			accept: () => true,
+			onDrop: vi.fn(),
+		} );
+		const otherTile: TilePayloadContext = {
+			placement: { ...placement( '' ), file: { ...placement( '' ).file, ref: 'dock-promoted:menu-media' } },
+		};
+		const notePayload = { type: 'note', source: document.body, data: { canEdit: true } };
+		expect( tilePayloadAccepts( notePayload, otherTile ) ).toBe( false );
+		expect( tilePayloadAcceptLabel( otherTile ) ).toBeUndefined();
+	} );
+
+	test( 'drop dispatches to the handler; returns false when unhandled', () => {
+		const onDrop = vi.fn();
+		registerTilePayloadHandler( 'note', {
+			appliesTo: () => true,
+			acceptLabel: 'x',
+			accept: () => true,
+			onDrop,
+		} );
+		const ctx: TilePayloadContext = { placement: placement( '/wp-admin/edit.php' ) };
+		expect( tilePayloadDrop( session( 'note' ), { clientX: 0, clientY: 0 }, ctx ) ).toBe( true );
+		expect( onDrop ).toHaveBeenCalledTimes( 1 );
+		expect( tilePayloadDrop( session( 'shortcut' ), { clientX: 0, clientY: 0 }, ctx ) ).toBe( false );
+	} );
+
+	test( 'deregister removes the handler', () => {
+		const off = registerTilePayloadHandler( 'note', {
+			appliesTo: () => true,
+			acceptLabel: 'x',
+			accept: () => true,
+			onDrop: vi.fn(),
+		} );
+		const ctx: TilePayloadContext = { placement: placement( '' ) };
+		off();
+		expect( tilePayloadAccepts( { type: 'note', source: document.body, data: {} }, ctx ) ).toBe( false );
+	} );
+} );

--- a/tests/vitest/tile-payloads.test.ts
+++ b/tests/vitest/tile-payloads.test.ts
@@ -55,7 +55,10 @@ describe( 'tile-payload seam', () => {
 
 		expect( tilePayloadAccepts( notePayload, ctx ) ).toBe( true );
 		expect( tilePayloadAccepts( filePayload, ctx ) ).toBe( false );
-		expect( tilePayloadAcceptLabel( ctx ) ).toBe( 'Convert to post' );
+		expect( tilePayloadAcceptLabel( 'note', ctx ) ).toBe( 'Convert to post' );
+		// Keyed by payload type: a type with no handler has no label,
+		// even on a tile another handler claims.
+		expect( tilePayloadAcceptLabel( 'desktop-file', ctx ) ).toBeUndefined();
 	} );
 
 	test( 'rejects on tiles the handler does not claim (appliesTo false)', () => {
@@ -70,7 +73,25 @@ describe( 'tile-payload seam', () => {
 		};
 		const notePayload = { type: 'note', source: document.body, data: { canEdit: true } };
 		expect( tilePayloadAccepts( notePayload, otherTile ) ).toBe( false );
-		expect( tilePayloadAcceptLabel( otherTile ) ).toBeUndefined();
+		expect( tilePayloadAcceptLabel( 'note', otherTile ) ).toBeUndefined();
+	} );
+
+	test( 'label is payload-type-aware when two handlers claim the same tile', () => {
+		registerTilePayloadHandler( 'note', {
+			appliesTo: () => true,
+			acceptLabel: 'Convert to post',
+			accept: () => true,
+			onDrop: vi.fn(),
+		} );
+		registerTilePayloadHandler( 'widget', {
+			appliesTo: () => true,
+			acceptLabel: 'Add as widget',
+			accept: () => true,
+			onDrop: vi.fn(),
+		} );
+		const ctx: TilePayloadContext = { placement: placement( '/wp-admin/edit.php' ) };
+		expect( tilePayloadAcceptLabel( 'note', ctx ) ).toBe( 'Convert to post' );
+		expect( tilePayloadAcceptLabel( 'widget', ctx ) ).toBe( 'Add as widget' );
 	} );
 
 	test( 'drop dispatches to the handler; returns false when unhandled', () => {


### PR DESCRIPTION
Turn a pinned note into a draft post. A "Convert to post" action is available three ways: an inline button on each owned note, dragging the note's pin onto the Posts icon, or dragging it onto the native Posts window. Converting creates a draft from the note's text, removes the note, and opens the draft in the editor. Undo brings the note back and discards the draft.

Only shown to users who can author posts (`edit_posts`).

## Testing

Prerequisites: log in as a user with Desktop Mode enabled who can create posts (Administrator or Editor).

### Create a note to work with
1. Open the **Note Pad** widget (Add widget → Note Pad, or an existing one).
2. Type some text with two paragraphs (leave a blank line between them).
3. Click **Pin to desktop**. A paper note appears on the wallpaper.

### Convert via the inline button
1. Hover the note. In the top row of the note, next to the color dot and the lock/globe toggle, there is a **post icon** button.
2. Click it.
3. Expect: the note disappears, a toast reads "Note converted to a draft post", and the block editor opens a new draft.
4. Confirm the draft title is the note's first line and the body is separate paragraphs (one block per blank-line-separated paragraph).
5. Click **Undo** on the toast. Expect: the editor window closes and the note returns to the wallpaper. The draft is gone (check Posts → Drafts).

### Convert by dragging to the Posts icon (dock layout)
1. Open **OS Settings → Appearance** and set the desktop layout to **Unified** (or any non-Spatial layout with a dock).
2. Drag the note by its **red pushpin** onto the **Posts** icon in the dock.
3. While hovering the Posts icon, expect the icon to highlight and the drag label to read "Convert to post".
4. Release. Expect the same result as above (note removed, draft created, editor opens).

### Convert by dragging to the Posts icon (Spatial layout)
1. Open **OS Settings → Appearance** and set the desktop layout to **Spatial**. The core menu items now appear as icons on the wallpaper.
2. Make sure the **Posts** icon on the wallpaper is not covered by a window (close or move any open windows).
3. Drag the note by its pushpin onto the **Posts** wallpaper icon.
4. Expect the Posts icon to highlight and the label to read "Convert to post"; release to convert.
5. Drag a note onto the **Pages** or **Media** icon instead. Expect it to be rejected ("Can't pin here") — only Posts converts.

### Convert via the native Posts window (optional)
1. Open **OS Settings → Features** and enable the native Posts window.
2. Open **Posts**. Drag a note's pushpin onto the Posts window body.
3. Expect it to highlight and convert on release.

### Capability gate
1. Log in as a **Subscriber** (Desktop Mode enabled) or a user who cannot create posts.
2. Expect: no convert button on notes, and dragging a note onto the Posts icon does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-364-4d2d19454d035da1c4d90b485eacae13f353de0e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->