### PR TITLE
Normalize AI Copilot tool schemas for the provider

### DIFF
--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -609,7 +609,9 @@ function desktop_mode_ai_normalize_tool_schema( $schema ) {
 	unset( $schema['oneOf'], $schema['allOf'], $schema['anyOf'] );
 
 	// An empty PHP array encodes as `[]`; an object schema's properties need `{}`.
-	if ( isset( $schema['properties'] ) && array() === $schema['properties'] ) {
+	// A schema with no `properties` at all (e.g. one whose only content was a
+	// stripped top-level combinator) gets an empty object for the same reason.
+	if ( ! isset( $schema['properties'] ) || array() === $schema['properties'] ) {
 		$schema['properties'] = (object) array();
 	}
 

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -564,6 +564,59 @@ function desktop_mode_ai_search_resumable_tools() {
 }
 
 /**
+ * Projects a tool's `parameters` schema onto the provider-supported subset.
+ *
+ * The Abilities API (and plugin-supplied tools) may use the full breadth of JSON
+ * Schema, but the provider's tool-schema validator does not — and it rejects the
+ * whole request, not just the offending tool, so ONE tool with a
+ * legal-but-unsupported schema makes the entire assistant return a 400 before the
+ * model runs. Three shapes that are valid JSON Schema, but rejected here, have
+ * been seen in the wild (see the linked issue):
+ *
+ *   1. `type` as an array, e.g. ['object','null'] — an ability's GET/null
+ *      run-path. The provider wants the literal string "object" at the top level.
+ *   2. A top-level `oneOf` / `anyOf` / `allOf`, e.g. "post_id OR slug". Rejected
+ *      with "does not support oneOf, allOf, or anyOf at the top level".
+ *   3. `properties` as an empty PHP array, which encodes to JSON as `[]` where an
+ *      object schema needs `{}`.
+ *
+ * This reshapes only the copy advertised to the model. The ability itself is
+ * untouched: `WP_Ability::execute()` still validates arguments against the real
+ * schema and `permission_callback` still gates execution, so nothing loses
+ * enforcement — the model is simply told the constraint in prose (the tool
+ * description) instead of in a schema construct the provider can't parse. Only
+ * the TOP level is constrained; a combinator nested inside a property is a real
+ * constraint the provider accepts, so it is left intact.
+ *
+ * @since 0.9.6
+ *
+ * @param mixed $schema A tool parameters schema (array), or empty/non-array.
+ * @return array A provider-safe object schema for a tool `parameters` block.
+ */
+function desktop_mode_ai_normalize_tool_schema( $schema ) {
+	if ( ! is_array( $schema ) || empty( $schema ) ) {
+		return array(
+			'type'       => 'object',
+			'properties' => (object) array(),
+		);
+	}
+
+	// Top-level tool parameters must be the literal "object", never a union.
+	$schema['type'] = 'object';
+
+	// Strip top-level combinators — the provider rejects them outright, and one
+	// such tool 400s the whole request. Nested combinators are left alone.
+	unset( $schema['oneOf'], $schema['allOf'], $schema['anyOf'] );
+
+	// An empty PHP array encodes as `[]`; an object schema's properties need `{}`.
+	if ( isset( $schema['properties'] ) && array() === $schema['properties'] ) {
+		$schema['properties'] = (object) array();
+	}
+
+	return $schema;
+}
+
+/**
  * Runs the agentic content-search loop.
  *
  * The model receives focused tools — search_posts, search_pages,
@@ -846,6 +899,19 @@ The message field is always a friendly sentence or two shown directly to the use
 		$tools,
 		array( 'user_id' => $user_id, 'request_id' => $request_id, 'query' => $query )
 	);
+
+	// Normalize every tool's schema onto the provider-supported subset, AFTER the
+	// filter so it covers the complete list the provider will receive — built-in
+	// abilities, command tools, and anything a plugin injected. One tool with a
+	// legal-but-unsupported schema otherwise 400s the entire request, not just its
+	// own tool. Only the model-facing copy is reshaped; abilities still validate
+	// arguments against their real schema in execute(). Idempotent, so a plugin
+	// that already normalizes on the filter above is unaffected.
+	foreach ( $tools as $ti => $tool ) {
+		if ( is_array( $tool ) && isset( $tool['parameters'] ) ) {
+			$tools[ $ti ]['parameters'] = desktop_mode_ai_normalize_tool_schema( $tool['parameters'] );
+		}
+	}
 
 	// Widen the permitted-tools list with the command tools — the agent loop
 	// rejects any `function_call` whose name isn't in here (built-in ability

--- a/tests/phpunit/tests/aiToolSchemaNormalization.php
+++ b/tests/phpunit/tests/aiToolSchemaNormalization.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for `desktop_mode_ai_normalize_tool_schema()` — the projection that keeps
+ * one ability's legal-but-unsupported input schema from 400-ing the whole
+ * assistant.
+ *
+ * The function is pure (no network, no registry), so each rejected JSON Schema
+ * shape can be asserted directly. Every case here is a schema the Abilities API
+ * accepts and the provider's tool-schema validator rejects.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-ai
+ */
+class Tests_DesktopMode_AiToolSchemaNormalization extends WP_UnitTestCase {
+
+	/**
+	 * A `type` array (an ability's GET/null run-path) becomes the literal
+	 * "object" the provider requires at the top level.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_type_union_becomes_object() {
+		$out = desktop_mode_ai_normalize_tool_schema( array(
+			'type'       => array( 'object', 'null' ),
+			'properties' => array( 'range' => array( 'type' => 'integer' ) ),
+		) );
+
+		$this->assertSame( 'object', $out['type'] );
+		// The rest of the schema is preserved.
+		$this->assertSame(
+			array( 'range' => array( 'type' => 'integer' ) ),
+			$out['properties']
+		);
+	}
+
+	/**
+	 * Top-level oneOf / anyOf / allOf are stripped — the provider rejects them
+	 * outright, and one such tool fails the entire request.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_top_level_combinators_are_stripped() {
+		$out = desktop_mode_ai_normalize_tool_schema( array(
+			'type'  => 'object',
+			'anyOf' => array(
+				array( 'required' => array( 'post_id' ) ),
+				array( 'required' => array( 'slug' ) ),
+			),
+			'oneOf' => array( array( 'const' => 1 ) ),
+			'allOf' => array( array( 'const' => 2 ) ),
+			'properties' => array(
+				'post_id' => array( 'type' => 'integer' ),
+				'slug'    => array( 'type' => 'string' ),
+			),
+		) );
+
+		$this->assertArrayNotHasKey( 'anyOf', $out );
+		$this->assertArrayNotHasKey( 'oneOf', $out );
+		$this->assertArrayNotHasKey( 'allOf', $out );
+		// The properties the combinator referenced survive — the model still
+		// sees post_id and slug, and execute() still enforces "one of".
+		$this->assertArrayHasKey( 'post_id', $out['properties'] );
+		$this->assertArrayHasKey( 'slug', $out['properties'] );
+	}
+
+	/**
+	 * A combinator NESTED inside a property is a real constraint the provider
+	 * accepts — only the top level is projected.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_nested_combinators_are_preserved() {
+		$nested = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'anyOf' => array(
+						array( 'type' => 'integer' ),
+						array( 'type' => 'null' ),
+					),
+				),
+			),
+		);
+
+		$out = desktop_mode_ai_normalize_tool_schema( $nested );
+
+		$this->assertArrayHasKey( 'anyOf', $out['properties']['id'] );
+	}
+
+	/**
+	 * An empty PHP `properties` array (which would encode as `[]`) becomes an
+	 * object, so the emitted JSON is `{}`.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_empty_properties_array_becomes_object() {
+		$out = desktop_mode_ai_normalize_tool_schema( array(
+			'type'       => 'object',
+			'properties' => array(),
+		) );
+
+		$this->assertIsObject( $out['properties'] );
+		$this->assertSame( '{}', wp_json_encode( $out['properties'] ) );
+	}
+
+	/**
+	 * A no-args ability (empty or non-array schema) becomes a valid empty object
+	 * schema rather than passing nothing through.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_empty_or_non_array_becomes_object_schema() {
+		foreach ( array( array(), null, '', 0, false ) as $empty ) {
+			$out = desktop_mode_ai_normalize_tool_schema( $empty );
+			$this->assertSame( 'object', $out['type'] );
+			$this->assertSame(
+				'{"type":"object","properties":{}}',
+				wp_json_encode( $out ),
+				'empty/non-array input yields a provider-safe empty object schema'
+			);
+		}
+	}
+
+	/**
+	 * Normalizing an already-normalized schema changes nothing — the projection
+	 * is a fixed point, so it is safe to apply more than once (e.g. a plugin that
+	 * also normalizes on the `desktop_mode_ai_tools` filter).
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_idempotent() {
+		$once  = desktop_mode_ai_normalize_tool_schema( array(
+			'type'       => array( 'object', 'null' ),
+			'anyOf'      => array( array( 'required' => array( 'a' ) ) ),
+			'properties' => array(),
+		) );
+		$twice = desktop_mode_ai_normalize_tool_schema( $once );
+
+		$this->assertEquals( $once, $twice );
+		$this->assertSame( wp_json_encode( $once ), wp_json_encode( $twice ) );
+	}
+}

--- a/tests/phpunit/tests/aiToolSchemaNormalization.php
+++ b/tests/phpunit/tests/aiToolSchemaNormalization.php
@@ -125,6 +125,51 @@ class Tests_DesktopMode_AiToolSchemaNormalization extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A schema whose only content is a top-level combinator (nothing duplicated
+	 * at the top level — e.g. `{ oneOf: [ { properties: … }, … ] }`) must not
+	 * normalize to a bare `{"type":"object"}` with no `properties` key: the
+	 * missing key is defaulted to an empty object so the emitted schema is
+	 * always a complete object schema.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_combinator_only_schema_gets_empty_properties() {
+		$out = desktop_mode_ai_normalize_tool_schema( array(
+			'oneOf' => array(
+				array(
+					'properties' => array( 'post_id' => array( 'type' => 'integer' ) ),
+					'required'   => array( 'post_id' ),
+				),
+				array(
+					'properties' => array( 'slug' => array( 'type' => 'string' ) ),
+					'required'   => array( 'slug' ),
+				),
+			),
+		) );
+
+		$this->assertSame(
+			'{"type":"object","properties":{}}',
+			wp_json_encode( $out ),
+			'a combinator-only schema projects to a complete empty object schema'
+		);
+	}
+
+	/**
+	 * A non-empty schema that never declared `properties` (e.g. a bare
+	 * `{ type: ['object','null'] }`) gains an empty-object `properties`.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_tool_schema
+	 */
+	public function test_missing_properties_key_is_defaulted() {
+		$out = desktop_mode_ai_normalize_tool_schema( array(
+			'type' => array( 'object', 'null' ),
+		) );
+
+		$this->assertIsObject( $out['properties'] );
+		$this->assertSame( '{}', wp_json_encode( $out['properties'] ) );
+	}
+
+	/**
 	 * Normalizing an already-normalized schema changes nothing — the projection
 	 * is a fixed point, so it is safe to apply more than once (e.g. a plugin that
 	 * also normalizes on the `desktop_mode_ai_tools` filter).


### PR DESCRIPTION
Fixes #362.

Thanks @AllTerrainDeveloper for confirming the approach on the issue. This is the normalization fix; the fail-soft-per-tool and name-the-culprit ideas are left as the follow-ups you flagged.

## The problem

`desktop_mode_ai_run_search()` advertises each built-in tool with its ability's `input_schema` passed straight through as the tool `parameters` (`includes/ai-copilot/search.php`). The Abilities API accepts the full breadth of JSON Schema, but the provider's tool-schema validator does not — and it rejects the **whole** request, not just the offending tool. So a single tool with a legal-but-unsupported schema makes Ask AI return a 400 for **every** query: unusable, not degraded, and the error names a `tools.N` index rather than the plugin, so it's painful to trace.

Three shapes, all valid JSON Schema, trigger it in the wild:

1. **`type` as an array** — e.g. `['object','null']`, an ability's GET/null run-path. The provider wants the literal `"object"` at the top level.
2. **A top-level `oneOf` / `anyOf` / `allOf`** — e.g. "supply `post_id` OR `slug`". Rejected with *"does not support oneOf, allOf, or anyOf at the top level"*.
3. **An empty `properties`** — a no-args tool's `[]`, where an object schema needs `{}`.

## The fix

A small pure helper, `desktop_mode_ai_normalize_tool_schema()`, projects a schema onto the provider-supported subset:

- forces top-level `type` to `"object"`
- strips **top-level** `oneOf` / `anyOf` / `allOf` (nested combinators are left intact — those are real constraints the provider accepts)
- coerces an empty `properties` array to an object
- empty / non-array input becomes `{"type":"object","properties":{}}`

It's applied to every tool in the final list, **after** the `desktop_mode_ai_tools` filter — so it covers the complete set the provider receives: built-in abilities, command tools, and anything a plugin injected. No single tool, from any source, can 400 the request.

**Nothing loses enforcement.** This reshapes only the copy advertised to the model. `WP_Ability::execute()` still validates arguments against the real schema and `permission_callback` still gates execution — the model is simply told the constraint in prose (the tool description) instead of a schema construct the provider can't parse. The projection is idempotent, so a plugin that already normalizes on the filter is unaffected.

## Tests

`tests/phpunit/tests/aiToolSchemaNormalization.php` covers each of the three shapes, nested-combinator preservation, empty/non-array input, and idempotence. The helper is pure, so these run without the network or the ability registry.

## Notes

- **Fail-soft-per-tool** (drop the offending tool and name it, rather than 400-ing) and **naming the culprit** are the resilience follow-ups you called out — happy to open a separate PR for those; they're a different concern from this correctness fix.
- I tagged `@since 0.9.6` as a guess against the current `0.9.5` release — please adjust to your intended version.
- Verified the helper's behaviour directly and confirmed `phpcs` reports no new violations on the change. I couldn't run the full PHPUnit suite locally (needs the wp-env test DB), so I'd lean on CI for the `test:php` leg.

---

*Prepared by @juanlentino with Claude Code assistance.*
