### PR TITLE
Keep URL-style menu slugs (ACF) as direct admin links

### DIFF
--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -102,7 +102,9 @@ Old-school plugins register their admin page with a file-path slug — `add_mana
 
 **Fix**: both URL resolvers — `desktop_mode_menu_item_url()` (dock / window tabs) and `desktop_mode_build_command_menu_map()` (command palette) — check `$_parent_pages` for the raw slug **before** the direct-file test. A registered slug goes through the canonical `menu_page_url()`-style resolution regardless of what characters it contains; only unregistered `.php` slugs are treated as real files under `wp-admin/`.
 
-**Plugins this addresses**: WP-Sweep; any plugin still using the pre-3.0-era file-path registration style.
+**Refinement (v0.9.6)**: the registered-page check alone over-matched. URL-style slugs — ACF's `add_menu_page( …, 'edit.php?post_type=acf-field-group' )` — *also* land in `$_parent_pages`, yet reference a real `wp-admin/` file; routing them through `admin.php?page=…` makes core's dispatcher die with "Cannot load edit.php?post_type=acf-field-group." The resolvers now apply the same tiebreaker classic admin's `menu-header.php` uses: `desktop_mode_is_admin_file_slug()` strips the query portion and checks whether the remaining path exists under `wp-admin/`. A real admin file stays a direct link even when registered; a registered non-file slug (WP-Sweep) still resolves through its parent.
+
+**Plugins this addresses**: WP-Sweep; any plugin still using the pre-3.0-era file-path registration style; ACF and any plugin registering URL-style menu slugs (`edit.php?post_type=…`).
 
 ### `esc_url_raw()` for JSON contexts
 

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1650,6 +1650,44 @@ function desktop_mode_build_native_windows_payload() {
 }
 
 /**
+ * Determines whether a menu slug references a real file under `wp-admin/`.
+ *
+ * Mirrors the decision core's `wp-admin/menu-header.php` makes when
+ * linking menu items: strip the query portion, then check whether the
+ * remaining path exists inside `wp-admin/`. Two registered-slug shapes
+ * hinge on this distinction:
+ *
+ *  - URL-style slugs — ACF registers its top-level menu as
+ *    `edit.php?post_type=acf-field-group` via `add_menu_page()`. The
+ *    slug lands in `$_parent_pages`, but `edit.php` is a real admin
+ *    file: classic admin links it directly, and routing it through
+ *    `admin.php?page=…` makes core's dispatcher `wp_die()` with
+ *    "Cannot load edit.php?post_type=acf-field-group."
+ *  - Legacy file-path slugs — WP-Sweep registers
+ *    `wp-sweep/admin.php` via `add_management_page()`. No such file
+ *    exists under `wp-admin/`, so it must resolve as a plugin page
+ *    (`tools.php?page=wp-sweep/admin.php`).
+ *
+ * @since 0.9.6
+ *
+ * @param string $slug The raw menu item slug.
+ * @return bool True when the query-stripped slug is a file under `wp-admin/`.
+ */
+function desktop_mode_is_admin_file_slug( $slug ) {
+	$file = $slug;
+	$pos  = strpos( $file, '?' );
+	if ( false !== $pos ) {
+		$file = substr( $file, 0, $pos );
+	}
+
+	if ( '' === $file || 0 !== validate_file( $file ) ) {
+		return false;
+	}
+
+	return file_exists( ABSPATH . 'wp-admin/' . $file );
+}
+
+/**
  * Converts a menu item slug to a full admin URL.
  *
  * Handles three slug shapes:
@@ -1706,7 +1744,19 @@ function desktop_mode_menu_item_url( $slug ) {
 	// canonical resolver below (→ `tools.php?page=wp-sweep/admin.php`,
 	// byte-identical to what core's menu_page_url() builds) instead
 	// of a 404 at `admin_url( 'wp-sweep/admin.php' )`.
-	if ( false !== strpos( $slug, '.php' ) && ! isset( $_parent_pages[ $slug ] ) ) {
+	//
+	// The reverse also happens: URL-style slugs registered through
+	// `add_menu_page()` / `add_submenu_page()` (ACF's
+	// 'edit.php?post_type=acf-field-group') sit in `$_parent_pages`
+	// too, yet reference a real `wp-admin/` file — those must stay
+	// direct links, or core's `admin.php` dispatcher dies with
+	// "Cannot load edit.php?post_type=acf-field-group." The admin-
+	// file check wins over the registration check, same as classic
+	// admin's `menu-header.php`.
+	if (
+		false !== strpos( $slug, '.php' ) &&
+		( ! isset( $_parent_pages[ $slug ] ) || desktop_mode_is_admin_file_slug( $slug ) )
+	) {
 		return esc_url_raw( admin_url( $slug ) );
 	}
 

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -899,8 +899,12 @@ function desktop_mode_build_command_menu_map() {
 		$menu_url   = '';
 		// Registered plugin pages win over the direct-file test: a
 		// legacy file-path slug ('wp-sweep/admin.php') matches the
-		// `.php` regex yet must route through menu_page_url().
-		if ( ! isset( $_parent_pages[ $menu_slug ] ) && ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) ) {
+		// `.php` regex yet must route through menu_page_url(). The
+		// exception is URL-style slugs referencing a real admin file
+		// (ACF's 'edit.php?post_type=acf-field-group' — also a
+		// registered page) — those stay direct links, matching
+		// classic admin's menu-header.php.
+		if ( ( ! isset( $_parent_pages[ $menu_slug ] ) || desktop_mode_is_admin_file_slug( $menu_slug ) ) && ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) ) {
 			$menu_url = $menu_slug;
 		} elseif ( ! empty( menu_page_url( $menu_slug, false ) ) ) {
 			$menu_url = menu_page_url( $menu_slug, false );
@@ -923,8 +927,9 @@ function desktop_mode_build_command_menu_map() {
 				$submenu_label = $extract_root_text( $submenu_item[0] );
 				$submenu_slug  = $submenu_item[2];
 				$submenu_url   = '';
-				// Same registered-page-first rule as the top-level loop.
-				if ( ! isset( $_parent_pages[ $submenu_slug ] ) && ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) ) {
+				// Same registered-page vs admin-file rule as the
+				// top-level loop.
+				if ( ( ! isset( $_parent_pages[ $submenu_slug ] ) || desktop_mode_is_admin_file_slug( $submenu_slug ) ) && ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) ) {
 					$submenu_url = $submenu_slug;
 				} elseif ( ! empty( menu_page_url( $submenu_slug, false ) ) ) {
 					$submenu_url = menu_page_url( $submenu_slug, false );

--- a/tests/phpunit/tests/commandMenuMap.php
+++ b/tests/phpunit/tests/commandMenuMap.php
@@ -82,4 +82,54 @@ class Tests_DesktopMode_CommandMenuMap extends WP_UnitTestCase {
 		$this->assertNotNull( $posts, 'expected the Posts entry in the command map' );
 		$this->assertSame( 'edit.php', $posts['url'] );
 	}
+
+	/**
+	 * URL-style slugs registered via `add_menu_page()` (ACF's
+	 * `edit.php?post_type=acf-field-group`) sit in `$_parent_pages`
+	 * yet reference a real `wp-admin/` file — they must keep the
+	 * direct-link behavior. Routing them through `menu_page_url()`
+	 * yields `admin.php?page=edit.php?post_type=…`, which core's
+	 * dispatcher rejects with "Cannot load …" (GH#367).
+	 */
+	public function test_registered_url_style_slug_stays_direct_link() {
+		global $menu, $submenu, $_parent_pages;
+		$menu_backup    = $menu;
+		$submenu_backup = $submenu;
+
+		$menu    = array(
+			array( 'ACF', '', 'edit.php?post_type=acf-field-group', '', '', 'menu-acf', '' ),
+		);
+		$submenu = array(
+			'edit.php?post_type=acf-field-group' => array(
+				array( 'Post Types', '', 'edit.php?post_type=acf-post-type' ),
+			),
+		);
+
+		$_parent_pages['edit.php?post_type=acf-field-group'] = false;
+		$_parent_pages['edit.php?post_type=acf-post-type']   = 'edit.php?post_type=acf-field-group';
+
+		$map = desktop_mode_build_command_menu_map();
+
+		$menu    = $menu_backup;
+		$submenu = $submenu_backup;
+		unset(
+			$_parent_pages['edit.php?post_type=acf-field-group'],
+			$_parent_pages['edit.php?post_type=acf-post-type']
+		);
+
+		$acf        = null;
+		$post_types = null;
+		foreach ( $map as $entry ) {
+			if ( 'edit.php?post_type=acf-field-group' === $entry['name'] ) {
+				$acf = $entry;
+			}
+			if ( 'edit.php?post_type=acf-field-group-edit.php?post_type=acf-post-type' === $entry['name'] ) {
+				$post_types = $entry;
+			}
+		}
+		$this->assertNotNull( $acf, 'expected the ACF entry in the command map' );
+		$this->assertSame( 'edit.php?post_type=acf-field-group', $acf['url'] );
+		$this->assertNotNull( $post_types, 'expected the ACF Post Types submenu entry in the command map' );
+		$this->assertSame( 'edit.php?post_type=acf-post-type', $post_types['url'] );
+	}
 }

--- a/tests/phpunit/tests/desktopModeMenuItemUrl.php
+++ b/tests/phpunit/tests/desktopModeMenuItemUrl.php
@@ -8,6 +8,7 @@
  * @group desktop-mode
  *
  * @covers ::desktop_mode_menu_item_url
+ * @covers ::desktop_mode_is_admin_file_slug
  */
 class Tests_DesktopMode_MenuItemUrl extends WP_UnitTestCase {
 
@@ -234,5 +235,67 @@ class Tests_DesktopMode_MenuItemUrl extends WP_UnitTestCase {
 			esc_url_raw( admin_url( 'network/sites.php' ) ),
 			desktop_mode_menu_item_url( 'network/sites.php' )
 		);
+	}
+
+	/**
+	 * URL-style slugs registered as a top-level menu — ACF's
+	 * `add_menu_page( …, 'edit.php?post_type=acf-field-group' )`.
+	 * The slug lands in `$_parent_pages` (value `false`), yet
+	 * `edit.php` is a real `wp-admin/` file, so it must stay a
+	 * direct link. Routing it through `admin.php?page=…` makes
+	 * core's dispatcher die with "Cannot load
+	 * edit.php?post_type=acf-field-group." — the exact regression
+	 * behind GH#367, introduced by the WP-Sweep fix (GH#309) whose
+	 * registered-page check didn't exempt real admin files.
+	 */
+	public function test_registered_url_style_slug_stays_direct_admin_file_link() {
+		global $_parent_pages;
+		$_parent_pages['edit.php?post_type=acf-field-group'] = false;
+
+		$this->assertSame(
+			esc_url_raw( admin_url( 'edit.php?post_type=acf-field-group' ) ),
+			desktop_mode_menu_item_url( 'edit.php?post_type=acf-field-group' )
+		);
+
+		unset( $_parent_pages['edit.php?post_type=acf-field-group'] );
+	}
+
+	/**
+	 * Same shape one level down — ACF's children (`Post Types`,
+	 * `Taxonomies`, …) are `add_submenu_page()`-registered URL-style
+	 * slugs, so `$_parent_pages` maps them to the URL-style parent.
+	 * They too must resolve as direct admin-file links.
+	 */
+	public function test_registered_url_style_submenu_slug_stays_direct_admin_file_link() {
+		global $_parent_pages;
+		$_parent_pages['edit.php?post_type=acf-field-group'] = false;
+		$_parent_pages['edit.php?post_type=acf-post-type']   = 'edit.php?post_type=acf-field-group';
+
+		$this->assertSame(
+			esc_url_raw( admin_url( 'edit.php?post_type=acf-post-type' ) ),
+			desktop_mode_menu_item_url( 'edit.php?post_type=acf-post-type' )
+		);
+
+		unset(
+			$_parent_pages['edit.php?post_type=acf-field-group'],
+			$_parent_pages['edit.php?post_type=acf-post-type']
+		);
+	}
+
+	/**
+	 * The admin-file exemption must not weaken the WP-Sweep fix: a
+	 * registered file-path slug whose file does NOT live under
+	 * `wp-admin/` still routes through its `.php` parent even though
+	 * the query-stripping helper ran on it.
+	 */
+	public function test_admin_file_check_ignores_registered_plugin_file_slug_with_query() {
+		global $_parent_pages;
+		$_parent_pages['wp-sweep/admin.php?tab=cleanup'] = 'tools.php';
+
+		$result = desktop_mode_menu_item_url( 'wp-sweep/admin.php?tab=cleanup' );
+
+		$this->assertStringContainsString( 'tools.php', $result );
+
+		unset( $_parent_pages['wp-sweep/admin.php?tab=cleanup'] );
 	}
 }


### PR DESCRIPTION
Fixes #367.

## What happened

v0.9.5's WP-Sweep fix (#335, for #309) made registered plugin pages win over the direct-file test in the menu-slug URL resolvers: any slug found in `$_parent_pages` was routed through the canonical `menu_page_url()`-style resolution instead of being linked directly.

That check over-matched. URL-style slugs registered via `add_menu_page()` — ACF's `edit.php?post_type=acf-field-group` — **also** land in `$_parent_pages`, so the dock started building `admin.php?page=edit.php%3Fpost_type%3Dacf-field-group`, which core's `admin.php` dispatcher rejects with exactly the error in the issue screenshot:

> Cannot load edit.php?post_type=acf-field-group.

ACF's submenu entries (Post Types, Taxonomies, …) and the command-palette map were broken the same way. Classic mode was unaffected, which matches the report.

## The fix

Mirror the tiebreaker classic admin's own `wp-admin/menu-header.php` uses: a new helper `desktop_mode_is_admin_file_slug()` strips the slug's query portion and checks whether the remaining path is a real file under `wp-admin/`.

- `edit.php?post_type=acf-field-group` → `edit.php` exists under `wp-admin/` → stays a **direct link**, even though registered. (ACF restored)
- `wp-sweep/admin.php` → no such file under `wp-admin/` → still resolves through its parent to `tools.php?page=wp-sweep/admin.php`. (WP-Sweep fix preserved)

Applied in both resolvers touched by #335: `desktop_mode_menu_item_url()` (dock / window tabs) and `desktop_mode_build_command_menu_map()` (command palette).

## Tests

- `desktopModeMenuItemUrl.php`: registered URL-style top-level slug stays direct; registered URL-style submenu slug stays direct; registered plugin-file slug with a query still routes through its parent (guards the WP-Sweep behavior against the new query-stripping).
- `commandMenuMap.php`: ACF-shaped top-level + submenu entries keep direct URLs.
- Full suite green: 1209 tests, 3 pre-existing skips.

Docs: `docs/plugin-compat-layer.md` legacy file-path section updated with the refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-368-6de470b4d4222cb78a1fec5b47947e47a097cab0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->