### PR TITLE
Fix 404 from wallpaper Sort By when a synthetic tile is on the desktop

### DIFF
--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -1216,7 +1216,7 @@ function readSynthSource( placement: RestPlacementShape ): string | null {
  * placements live JS-only, so persisting their (x, y) / parentId
  * would 404 with `rest_no_route`.
  */
-function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
+export function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
 	return placement.id <= 0 || readSynthSource( placement ) !== null;
 }
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -215,7 +215,7 @@ import {
 	setUserAssociations as setFilesUserAssociations,
 	type FilesApi,
 } from './desktop-files';
-import { mountFilesLayer } from './desktop-files/layer';
+import { isSyntheticPlacement, mountFilesLayer } from './desktop-files/layer';
 import { installRecycleBinDropTargets } from './desktop-files/recycle-bin-targets';
 import { startFilesHeartbeat } from './desktop-files/heartbeat';
 import { startFilesRestoreSync } from './desktop-files/restore-sync';
@@ -3689,7 +3689,13 @@ function init(): void {
 				y: cell.y,
 				sortOrder: i,
 			} );
-			if ( ! persist ) {
+			// Synthetic placements (dock-item promotions, Spatial-layout
+			// core icons) live JS-only — `settings/desktop-shortcuts-sync.ts`
+			// mints them with a negative id and never persists them via
+			// the files REST layer. PATCHing one 404s (`rest_no_route`,
+			// the route regex only matches positive ids). See
+			// `isSyntheticPlacement` in `desktop-files/layer.ts`.
+			if ( ! persist || isSyntheticPlacement( p ) ) {
 				continue;
 			}
 			void filesRest


### PR DESCRIPTION
## Summary
- Right-clicking the wallpaper → **Sort by** → any order threw a 404 whenever a synthetic tile (a dock item promoted to the desktop, or a Spatial-layout core icon) was present on the wallpaper.
- `relayoutRoot()` in `src/desktop.ts` re-tiles every placement in the root folder and PATCHes each one's new position via the files REST API. Synthetic tiles only live in the JS store (`settings/desktop-shortcuts-sync.ts`) and are minted with a deterministic **negative** id, which doesn't match the REST route's `\d+` id pattern — confirmed via the access log: `PATCH /wp-json/desktop-mode/v1/files/placements/-1690305366 → 404`.
- The drag-and-drop path already solved this exact problem with an `isSyntheticPlacement()` guard in `src/desktop-files/layer.ts`. Exported that helper and reused it to gate the same REST call in `relayoutRoot`, which also covers Clean Up and the auto-arrange resize path since they share the function.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:js` (2051 tests passing)
- [ ] Manual: right-click wallpaper → Sort by → any option, with a dock item promoted to the desktop (or Spatial layout on) — no 404 in Network tab, tiles re-order correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-370-84c2a64efeacdd5bd812033586c81a4a6d56dc08.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->