### PR TITLE
Fix illegible text fields inside wpd-modal dialogs

### DIFF
--- a/src/ui/components/wpd-modal/wpd-modal.styles.ts
+++ b/src/ui/components/wpd-modal/wpd-modal.styles.ts
@@ -25,6 +25,12 @@ export const modalStyles = css`
 		--desktop-mode-muted: #a7aaad;
 		--desktop-mode-muted-fg: #a7aaad;
 		--desktop-mode-border: rgba( 255, 255, 255, 0.25 );
+		/* Input / popover surface. The :root default is #fff (windows
+		   are light), which here rendered white fields with the light
+		   --desktop-mode-text above — near-invisible values. Solid, not
+		   translucent: wpd-menu / wpd-multiselect popovers read this
+		   token too and must stay opaque over slotted content. */
+		--desktop-mode-window-bg: #2c3338;
 		/* Ghost/secondary button hover washes — the light-surface
 		   defaults are black-on-black here. */
 		--wpd-button-bg-hover: rgba( 255, 255, 255, 0.08 );

--- a/src/ui/components/wpd-modal/wpd-modal.ts
+++ b/src/ui/components/wpd-modal/wpd-modal.ts
@@ -37,7 +37,7 @@ export class WpdModal extends Component {
 	static help = {
 		title: 'Modal overlay',
 		summary:
-			'Overlay container with title, body, and footer slots. Handles ESC, click-outside, focus trap. Use for rich modal flows that go beyond a yes/no confirm. The dialog surface is dark and re-points the shared surface tokens (--desktop-mode-text/-muted/-border, --wpd-button-bg-hover) so wpd-* controls slotted into it resolve readable dark-surface colors automatically.',
+			'Overlay container with title, body, and footer slots. Handles ESC, click-outside, focus trap. Use for rich modal flows that go beyond a yes/no confirm. The dialog surface is dark and re-points the shared surface tokens (--desktop-mode-text/-muted/-border/-window-bg, --wpd-button-bg-hover) so wpd-* controls slotted into it resolve readable dark-surface colors automatically.',
 		status: 'experimental',
 		since: '0.8.5',
 		props: [


### PR DESCRIPTION
## What it does

Makes text fields inside `<wpd-modal>` dialogs legible again. The "Upload to Media Library" drag-and-drop dialog rendered its pre-filled Title / Filename / Alt text values as near-white text on white inputs.

|Before | After|
|-------|------|
|<img width="3424" height="2830" alt="CleanShot 2026-07-20 at 10 56 49@2x" src="https://github.com/user-attachments/assets/208e5f84-24ba-48b0-b9d5-93b2dd7b884d" />| <img width="3424" height="2830" alt="CleanShot 2026-07-20 at 10 55 42@2x" src="https://github.com/user-attachments/assets/7abe82f8-2e40-441b-b27c-0ec224fddaa3" />|

## Rationale

`<wpd-modal>`'s dialog surface is dark and re-points the shared kit tokens (`--desktop-mode-text`, `--desktop-mode-border`, the muted colors) so slotted `wpd-*` controls resolve dark-surface colors, but it never re-pointed `--desktop-mode-window-bg`. That token is the input background for `<wpd-text-field>` / `<wpd-textarea>`, so it kept its `:root` value of `#fff` (windows are light) while the text inside resolved to the modal's light `#f0f0f1` — invisible values.

## Implementation

Added the missing token to the existing dark-token block on the modal `:host`:

```css
--desktop-mode-window-bg: #2c3338;
```

Solid rather than translucent on purpose: `wpd-menu` and `wpd-multiselect` popovers read the same token and must stay opaque over slotted content. Because the fix is at the modal level, it also repairs every other modal hosting form fields (folder share settings, wallpaper `renderConfig` dialogs, the games challenge dialog). The share-settings capability control keeps its own instance-level inline overrides, which still win.

The `static help` summary on `WpdModal` now lists `-window-bg` among the re-pointed tokens.

## Testing instructions

1. Drag a file from your OS onto the desktop shell.
2. In the "Upload to Media Library" dialog, the Title / Filename / Alt text / Caption / Description fields should render dark inputs with legible pre-filled text.
3. `npm run test:js` stays green (2051 tests).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-374-c456d9681cbcf5baa8a703c49e3d454fe4c88a37.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->