### PR TITLE
Fix empty custom-gradient editor after re-selecting the wallpaper

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3893,6 +3893,8 @@ Canvas wallpapers receive `ctx.prefersReducedMotion` and should render a single 
 
 Any wallpaper can ship a `renderEditor` callback — when that wallpaper is the selected swatch in OS Settings, a collapsible panel opens below the grid and the editor is rendered into it. Same animation as the built-in custom-gradient editor.
 
+Every mount receives a brand-new `container` element — the shell never recycles the previous mount's DOM, so editors built on renderers that cache state per container (lit-html and friends) work across select-away-and-back cycles without any special handling. Treat the container as yours until your returned teardown runs; don't keep references to it afterwards.
+
 ```javascript
 wp.desktop.registerWallpaper( {
     id: 'my-plugin/tunable',

--- a/src/settings/sections/wallpaper.ts
+++ b/src/settings/sections/wallpaper.ts
@@ -380,15 +380,27 @@ export function refreshWallpaperPressedState(
  * Mount the given wallpaper's editor into the editor slot, tearing
  * down any prior editor first. If the wallpaper has no editor, the
  * slot collapses.
+ *
+ * Every mount gets a brand-new inner container. Recycling the previous
+ * element looks equivalent, but breaks any editor that keeps
+ * per-container state keyed on element identity — the framework's own
+ * `render()` caches its mounted parts per container, so a cleared-then-
+ * reused element would take the update fast path against detached
+ * nodes and paint nothing (that was the "custom gradient can't be
+ * edited after switching away and back" bug). Third-party editors
+ * built on lit-html carry the same per-container cache. A fresh
+ * element also can't leak the previous editor's classes.
  */
 export function syncEditorSlot(
 	ctx: SettingsCtx,
 	slot: HTMLElement,
-	inner: HTMLElement,
 	def: WallpaperDef,
 ): void {
 	teardownEditor( ctx );
-	inner.innerHTML = '';
+	const inner = document.createElement( 'div' );
+	inner.className = 'desktop-mode-os-settings__editor-slot-inner';
+	slot.textContent = '';
+	slot.appendChild( inner );
 
 	if ( ! def.renderEditor ) {
 		slot.dataset.expanded = 'false';
@@ -547,7 +559,9 @@ export function buildWallpaperSection(
 	// (CSS animates grid-template-rows 0fr ↔ 1fr). Kept as imperative
 	// DOM refs because `renderEditor` contracts with third-party
 	// plugins receive a plain `HTMLElement` — no templating, just a
-	// container they can own.
+	// container they can own. `syncEditorSlot` replaces the inner
+	// element on every mount; this initial one just keeps the collapsed
+	// slot's grid row populated until the first sync.
 	const editorSlot = document.createElement( 'div' );
 	editorSlot.className = 'desktop-mode-os-settings__editor-slot';
 	editorSlot.dataset.expanded = 'false';
@@ -584,7 +598,7 @@ export function buildWallpaperSection(
 			return;
 		}
 		selectWallpaper( ctx, def.id, body );
-		syncEditorSlot( ctx, editorSlot, editorInner, def );
+		syncEditorSlot( ctx, editorSlot, def );
 		paint();
 	};
 
@@ -644,7 +658,7 @@ export function buildWallpaperSection(
 	// doesn't animate on panel open.
 	const active = registry.get( ctx.state.wallpaper );
 	if ( active ) {
-		syncEditorSlot( ctx, editorSlot, editorInner, active );
+		syncEditorSlot( ctx, editorSlot, active );
 	}
 	syncWallpaperDescription( ctx, descriptionSlot );
 	syncWallpaperConfigButton( ctx, configSlot );
@@ -672,7 +686,7 @@ export function buildWallpaperSection(
 		// new wallpaper).
 		const now = registry.get( ctx.state.wallpaper );
 		if ( now ) {
-			syncEditorSlot( ctx, editorSlot, editorInner, now );
+			syncEditorSlot( ctx, editorSlot, now );
 		}
 		syncWallpaperDescription( ctx, descriptionSlot );
 		syncWallpaperConfigButton( ctx, configSlot );

--- a/src/ui/core/html.ts
+++ b/src/ui/core/html.ts
@@ -352,9 +352,32 @@ function compile( strings: TemplateStringsArray ): Compiled {
 interface MountState {
 	strings: TemplateStringsArray;
 	parts: Part[];
+	/** Top-level nodes mounted into the container — see {@link mountIntact}. */
+	nodes: Node[];
 }
 
 const mountState = new WeakMap<Element | DocumentFragment, MountState>();
+
+/**
+ * Whether the mounted top-level nodes are still children of the
+ * container. Imperative code outside the renderer can wipe a previous
+ * render's DOM (`container.innerHTML = ''`) while the cache entry for
+ * the container survives; updating those detached parts would
+ * silently render nothing, since insertion is anchored on text nodes
+ * that no longer have a parent. Detect the wipe and fall through to a
+ * fresh mount instead.
+ */
+function mountIntact(
+	state: MountState,
+	container: Element | DocumentFragment,
+): boolean {
+	for ( const node of state.nodes ) {
+		if ( node.parentNode !== container ) {
+			return false;
+		}
+	}
+	return true;
+}
 
 /**
  * Render `result` into `container`. Idempotent — subsequent calls
@@ -366,7 +389,11 @@ export function render(
 	container: Element | DocumentFragment,
 ): void {
 	const existing = mountState.get( container );
-	if ( existing && existing.strings === result.strings ) {
+	if (
+		existing &&
+		existing.strings === result.strings &&
+		mountIntact( existing, container )
+	) {
 		applyValues( existing.parts, result.values );
 		return;
 	}
@@ -374,6 +401,7 @@ export function render(
 	const compiled = compile( result.strings );
 	const fragment = compiled.template.content.cloneNode( true ) as DocumentFragment;
 	const parts = compiled.buildParts( fragment );
+	const nodes = Array.from( fragment.childNodes );
 
 	while ( container.firstChild ) {
 		container.removeChild( container.firstChild );
@@ -381,7 +409,7 @@ export function render(
 	container.appendChild( fragment );
 
 	applyValues( parts, result.values );
-	mountState.set( container, { strings: result.strings, parts } );
+	mountState.set( container, { strings: result.strings, parts, nodes } );
 }
 
 /** Update each part to the new slot value if it actually changed. */

--- a/tests/vitest/ui-core.test.ts
+++ b/tests/vitest/ui-core.test.ts
@@ -97,6 +97,20 @@ describe( 'wpd-ui html renderer', () => {
 		expect( first.textContent ).toBe( 'two' );
 	} );
 
+	test( 'remounts when the container was cleared behind the renderer\'s back', () => {
+		// Hosts that mix imperative DOM management with the templater
+		// (the OS Settings editor slot did) can wipe the container
+		// between renders. The cached mount must not take the
+		// update-in-place fast path against those detached nodes —
+		// that renders nothing, silently.
+		const update = ( value: string ) =>
+			render( html`<p>${ value }</p>`, host );
+		update( 'one' );
+		host.innerHTML = '';
+		update( 'two' );
+		expect( host.querySelector( 'p' )?.textContent ).toBe( 'two' );
+	} );
+
 	test( 'no-op re-render doesn\'t touch the text-node slot', () => {
 		const update = ( value: string ) =>
 			render( html`<p>${ value }</p>`, host );

--- a/tests/vitest/wallpaper-editor-slot.test.ts
+++ b/tests/vitest/wallpaper-editor-slot.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Wallpaper editor slot — mounting `renderEditor` output into the OS
+ * Settings panel.
+ *
+ * Covers the DESKMOD-51 regression: re-selecting a wallpaper with an
+ * editor after having selected one without must re-render the editor
+ * content, not just expand an empty slot. The original bug recycled
+ * the slot's inner element across mounts; the framework `render()`
+ * cache then took its update fast path against nodes a previous
+ * `innerHTML = ''` had detached, and painted nothing.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import { syncEditorSlot, teardownEditor } from '../../src/settings/sections/wallpaper';
+import { html, render } from '../../src/ui/core';
+import type { SettingsCtx } from '../../src/settings/types';
+import type { WallpaperDef } from '../../src/wallpapers/types';
+
+function ctxStub(): SettingsCtx {
+	return {
+		state: { wallpaper: 'test-editable' },
+		activeEditorTeardown: null,
+	} as unknown as SettingsCtx;
+}
+
+function slotElement(): HTMLElement {
+	const slot = document.createElement( 'div' );
+	slot.className = 'desktop-mode-os-settings__editor-slot';
+	slot.dataset.expanded = 'false';
+	const inner = document.createElement( 'div' );
+	inner.className = 'desktop-mode-os-settings__editor-slot-inner';
+	slot.appendChild( inner );
+	document.body.appendChild( slot );
+	return slot;
+}
+
+/**
+ * Mirrors the custom-gradient editor: renders through the framework
+ * templater with a stable call-site template, so repeated mounts into
+ * a recycled container would hit the renderer's per-container cache.
+ */
+const paintEditor = ( container: HTMLElement, label: string ): void =>
+	render( html`<span class="test-editor">${ label }</span>`, container );
+
+function editableDef( teardown: () => void = () => {} ): WallpaperDef {
+	return {
+		id: 'test-editable',
+		label: 'Editable',
+		type: 'css',
+		value: '#123',
+		preview: '#123',
+		renderEditor: ( container ) => {
+			paintEditor( container, 'controls' );
+			return teardown;
+		},
+	};
+}
+
+const plainDef: WallpaperDef = {
+	id: 'test-plain',
+	label: 'Plain',
+	type: 'css',
+	value: '#456',
+	preview: '#456',
+};
+
+beforeEach( () => {
+	installHooksStub();
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+	clearHooksStub();
+} );
+
+describe( 'wallpaper editor slot', () => {
+	test( 'mounts the editor and expands the slot', () => {
+		const ctx = ctxStub();
+		const slot = slotElement();
+		syncEditorSlot( ctx, slot, editableDef() );
+		expect( slot.dataset.expanded ).toBe( 'true' );
+		expect( slot.querySelector( '.test-editor' )?.textContent ).toBe(
+			'controls',
+		);
+	} );
+
+	test( 'collapses for a wallpaper without an editor', () => {
+		const ctx = ctxStub();
+		const slot = slotElement();
+		syncEditorSlot( ctx, slot, editableDef() );
+		syncEditorSlot( ctx, slot, plainDef );
+		expect( slot.dataset.expanded ).toBe( 'false' );
+		expect( slot.querySelector( '.test-editor' ) ).toBeNull();
+	} );
+
+	test( 're-selecting the editable wallpaper re-renders its content', () => {
+		const ctx = ctxStub();
+		const slot = slotElement();
+		syncEditorSlot( ctx, slot, editableDef() );
+		syncEditorSlot( ctx, slot, plainDef );
+		// The regression: this third sync expanded the slot but left it
+		// empty, because the recycled inner element still carried the
+		// renderer's stale per-container cache.
+		syncEditorSlot( ctx, slot, editableDef() );
+		expect( slot.dataset.expanded ).toBe( 'true' );
+		expect( slot.querySelector( '.test-editor' )?.textContent ).toBe(
+			'controls',
+		);
+	} );
+
+	test( 'tears down the previous editor before mounting the next', () => {
+		const ctx = ctxStub();
+		const slot = slotElement();
+		const teardown = vi.fn();
+		syncEditorSlot( ctx, slot, editableDef( teardown ) );
+		expect( teardown ).not.toHaveBeenCalled();
+		syncEditorSlot( ctx, slot, plainDef );
+		expect( teardown ).toHaveBeenCalledTimes( 1 );
+		// And the collapse path cleared the stored teardown — a later
+		// explicit teardown must not double-invoke it.
+		teardownEditor( ctx );
+		expect( teardown ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
## What it does

Fixes the Custom gradient wallpaper becoming uneditable in OS Settings. Selecting Custom gradient, switching to any other wallpaper, then selecting Custom gradient again expanded the editor slot but rendered nothing: no From/To color fields, no Angle slider, no console errors. The only recovery was closing and reopening the settings window.


|Before | After|
|-------|------|
|<img width="3424" height="2830" alt="CleanShot 2026-07-20 at 12 40 48@2x" src="https://github.com/user-attachments/assets/e7bb2794-d16c-4714-b4d1-0bbf474fbdfc" />|  <img width="3424" height="2830" alt="CleanShot 2026-07-20 at 12 44 13@2x" src="https://github.com/user-attachments/assets/c6a6273a-8da2-41b3-99f0-26dc8b7c543d" />|

## Rationale

The templater's `render()` (in `src/ui/core/html.ts`) caches its mounted parts per container in a WeakMap keyed on the element. `syncEditorSlot()` recycled the same inner element across editor mounts and cleared it with `innerHTML = ''` in between. On re-selection, `render()` saw the same template strings for the same container and took its update-in-place fast path against nodes the clear had detached. Insertion anchors on text nodes whose `parentNode` is gone, so `insertBeforeAnchor()` silently no-ops and nothing is painted.

## Implementation

Two layers, so both the surface and the framework are protected:

- `render()` now records the top-level nodes it mounts and validates that they are still children of the container before taking the fast path. If imperative code wiped the container behind the renderer's back, it falls through to a fresh mount:

```typescript
if (
    existing &&
    existing.strings === result.strings &&
    mountIntact( existing, container )
) {
    applyValues( existing.parts, result.values );
    return;
}
```

- `syncEditorSlot()` creates a brand-new inner container for every `renderEditor` mount instead of recycling the previous one. This also protects third-party editors built on renderers with the same per-container caching (real lit-html stamps its part cache on the container element), and stops the previous editor's classes leaking onto the next one. The fresh-container guarantee is now documented in the `renderEditor` contract in `docs/javascript-reference.md`.

## Testing instructions

```bash
npm run test:js -- ui-core wallpaper-editor-slot
```

New coverage: a renderer test that clears the container between renders of the same template, and `wallpaper-editor-slot.test.ts` with the select-away-and-back regression plus teardown ordering.

Manual check: open OS Settings, select **Custom gradient**, select **Graphite**, select **Custom gradient** again. The From/To/Angle controls must reappear and edits must repaint the desktop live.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-376-159a5005c1db5a348e8bb52c27c72a73173a1c6e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->