### PR TITLE
docs: wp-env mount semantics and parallel worktree QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@
 # Vite bundle-visualizer reports (`${fileBase}.report.html`) — dev-only.
 /assets/js/*.report.html
 
+# Local wp-env overrides — per-checkout ports so several worktree
+# instances can run in parallel. See docs/DEVELOPMENT.md.
+/.wp-env.override.json
+
 .DS_Store
 
 # Default output file of macOS/BSD `script(1)` — a terminal session

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -19,7 +19,37 @@ npm run test:php           # the PHPUnit run itself
 npm run env:stop           # when you're done
 ```
 
-`npm run env:start` spins up a self-contained WordPress + MariaDB stack under `wp-content/plugins/desktop-mode` — it's scoped to automated tests. Manual QA is a separate concern and runs against the Dockerised environment in the parent Core-checkout repo (`env:start` / `env:install` there).
+`npm run env:start` spins up a self-contained WordPress + MariaDB stack with this checkout bind-mounted as the plugin. It hosts the PHPUnit suite and doubles as the manual QA environment on `http://localhost:8890/wp-admin/` (`admin` / `password`). See [Manual QA and per-worktree instances](#manual-qa-and-per-worktree-instances-wp-env) for how the mount works and how to run one instance per git worktree.
+
+## Manual QA and per-worktree instances (wp-env)
+
+### How the instance works
+
+- The `"wp-content/plugins/desktop-mode": "."` mapping in `.wp-env.json` bind-mounts the directory you run `wp-env start` from straight into the container. PHP edits are live on the next request; JS changes appear after `npm run build`, because the site serves whatever is in `assets/js/` right now. The enqueued bundles' `?ver=` cache-buster is filemtime-based, so a normal browser reload picks up fresh builds.
+- wp-env keys everything to that start directory: it hashes the path and gives each directory its own containers, database, and WordPress volume under `~/.wp-env/<hash>/`. Same directory, same instance, every time.
+- Ports come from `.wp-env.json`: `8890` (dev) and `8891` (tests). They are remapped from wp-env's defaults so the stack coexists with a Core checkout's environment (see the PHPUnit section of `AGENTS.md`).
+- `bin/sync-to-wp-develop.sh` does **not** feed this instance. It mirrors the tree into a wordpress-develop checkout, which is a different environment entirely. The wp-env instance always serves the start directory live through the mount; there is no copy step to forget.
+
+### Testing several worktrees at once
+
+Because the instance identity is the start directory, every git worktree can run its own fully isolated stack in parallel. The only knob is ports, since each worktree inherits `8890`/`8891` from the tracked `.wp-env.json`:
+
+```bash
+cd <path-to-worktree>
+npm install        # worktrees start bare
+npm run build
+WP_ENV_PORT=8894 WP_ENV_TESTS_PORT=8895 npm run env:start
+```
+
+`http://localhost:8894/wp-admin/` now serves that worktree's code while the main checkout's instance keeps serving `:8890`. Databases, uploads, and user state are all per-instance.
+
+Notes:
+
+- **Skipping the port override fails loudly, not subtly.** If another running instance already holds `8890`, Docker refuses to bind ("port is already allocated") and `wp-env start` aborts; nothing silently cross-connects to the other site. Instances only conflict while running, so a stopped main instance frees `8890` for a worktree.
+- **Prefer `.wp-env.override.json` for long-lived worktrees.** Drop `{ "port": 8894, "testsPort": 8895 }` in the worktree root (git-ignored) and a plain `npm run env:start` does the right thing from then on. The `WP_ENV_PORT` / `WP_ENV_TESTS_PORT` env vars win over the override file when both are set.
+- **Run wp-env commands from the worktree's directory.** `env:start`, `env:stop`, `env:destroy`, and `test:php` all resolve the instance from the current directory.
+- **Cost.** Each instance is six containers (WordPress plus tests WordPress, two CLI, two database). `npm run env:stop` parks an instance and keeps its data; `npm run env:destroy` deletes it.
+- `npm run test:php` in a worktree runs inside that worktree's own tests containers, so PHPUnit is isolated per worktree too.
 
 ## Module layout
 


### PR DESCRIPTION
## What it does

Documents in `docs/DEVELOPMENT.md` how the wp-env instance actually serves code, and adds a recipe for running one isolated instance per git worktree in parallel. Also gitignores `.wp-env.override.json` so per-worktree port overrides stay local.

## Rationale

The doc claimed the wp-env stack was scoped to automated tests and pointed manual QA at the parent Core-checkout environment. In practice the instance bind-mounts the start directory as the plugin and is the day-to-day manual QA site on `:8890`. That gap caused real confusion while verifying #376: `bin/sync-to-wp-develop.sh` mirrors into a wordpress-develop checkout that `:8890` never reads, so a "synced" fix looked unfixed.

The new section covers:

- mount semantics: PHP edits live on next request, JS after `npm run build`, filemtime-based `?ver=` cache busting, and the explicit note that the sync script does not feed this instance
- per-worktree instances: wp-env keys containers/DB/volumes to the start directory, so each worktree gets its own stack; only the ports need overriding (`WP_ENV_PORT`/`WP_ENV_TESTS_PORT`, or a git-ignored `.wp-env.override.json`)
- the failure mode when ports are not overridden (Docker refuses the bind and `wp-env start` aborts; nothing silently cross-connects)
- instance cost and teardown (`env:stop` vs `env:destroy`), and per-worktree PHPUnit isolation

## Testing instructions

Docs only. To exercise the recipe: from any worktree, `npm install && npm run build`, then `WP_ENV_PORT=8896 WP_ENV_TESTS_PORT=8897 npm run env:start` and browse `http://localhost:8896/wp-admin/` while `:8890` keeps serving the main checkout.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-377-e6de2e181c5b977158d699a1335116d2440e1b48.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->