### PR TITLE
Feat: Allow selecting window from Overview view

### DIFF
--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -3,7 +3,7 @@
  *
  * Animate every eligible window to a grid thumbnail, plus a top bar
  * showing one tile per virtual desktop. Clicking a thumbnail exits
- * overview and fullscreens the clicked window. Pressing Escape or
+ * overview, focusing and bringing the clicked window to the front. Pressing Escape or
  * clicking the backdrop exits without selection.
  *
  * The lifecycle is big (enter/exit + click + key handlers + top bar
@@ -74,9 +74,9 @@ function inertWindowChildren( mgr: WindowManager, inactive: boolean ): void {
 
 /**
  * Enter overview mode — animate every eligible window to a grid
- * thumbnail layout. Clicking a thumbnail exits overview and
- * fullscreens the clicked window. Pressing Escape or clicking the
- * backdrop exits without selection.
+ * thumbnail layout. Clicking a thumbnail exits overview,
+ * focusing and bringing the clicked window to the front. Pressing Escape
+ * or clicking the backdrop exits without selection.
  */
 export function enterOverview( mgr: WindowManager ): void {
 	if ( mgr._overviewActive ) {
@@ -86,7 +86,8 @@ export function enterOverview( mgr: WindowManager ): void {
 	// desktop is minimized — the canonical Show Desktop state — entering
 	// overview would otherwise show an empty grid, contradicting the
 	// user's expectation that Overview reveals their work. Restore them
-	// first so they participate in the layout below.
+	// first so they participate in the layout below, allowing them to be
+	// selected and focused in their restored states.
 	const onActive = mgr._stack.filter(
 		( w ) => w.config.desktopId === mgr._activeDesktopId,
 	);
@@ -112,7 +113,7 @@ export function enterOverview( mgr: WindowManager ): void {
 	// grid; windows on other desktops stay hidden underneath. The top
 	// bar (rendered later) gives the user a way to switch. Native
 	// windows (OS Settings, Jorvy, etc.) participate as first-class
-	// citizens — clicking their thumbnail maximizes them, they lay
+	// citizens — clicking their thumbnail focuses them, they lay
 	// out in the grid, they count toward the top-bar tile's window
 	// count.
 	const eligible = mgr._stack.filter(
@@ -724,8 +725,8 @@ export function exitOverview(
 	}
 
 	// Start labels fading immediately — they overshoot the area when
-	// a selected window maximizes, and we don't want them lingering
-	// as the window grows beneath. Opacity transition is CSS-side
+	// a selected window focuses, and we don't want them lingering
+	// over it during the 300ms transition. Opacity transition is CSS-side
 	// (see `.desktop-mode-overview-label--out`).
 	for ( const label of mgr._overviewLabels.values() ) {
 		label.classList.add( 'desktop-mode-overview-label--out' );

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -60,6 +60,19 @@ function inertWpBodyContentChildren( inactive: boolean ): void {
 }
 
 /**
+ * Toggle inert on every direct child of window elements so keyboard focus
+ * cannot land on inner controls / titlebar buttons / iframes during overview,
+ * while leaving the window root element non-inert so thumbnail pointer hits succeed.
+ */
+function inertWindowChildren( mgr: WindowManager, inactive: boolean ): void {
+	for ( const w of mgr._stack ) {
+		for ( const child of Array.from( w.element.children ) ) {
+			( child as HTMLElement & { inert: boolean } ).inert = inactive;
+		}
+	}
+}
+
+/**
  * Enter overview mode — animate every eligible window to a grid
  * thumbnail layout. Clicking a thumbnail exits overview and
  * fullscreens the clicked window. Pressing Escape or clicking the
@@ -125,9 +138,10 @@ export function enterOverview( mgr: WindowManager ): void {
 	// Make all siblings of the shell inside wpbody-content inert
 	// so focus doesn't land on hidden screen options / help buttons.
 	inertWpBodyContentChildren( true );
-	for ( const w of mgr._stack ) {
-		( w.element as HTMLElement & { inert: boolean } ).inert = true;
-	}
+	// Make all window children (iframes, titlebars, tabs) inert so
+	// keyboard focus cannot traverse hidden window controls during
+	// overview, while leaving window root elements non-inert for clicks.
+	inertWindowChildren( mgr, true );
 
 	// Snapshot current transform + transition so exit can restore
 	// exactly — matters when plugins have applied custom transforms
@@ -308,7 +322,7 @@ export function enterOverview( mgr: WindowManager ): void {
 		}
 		const selected = mgr.getById( pressed.id );
 		doAction( HOOKS.OVERVIEW_WINDOW_CLICK, { windowId: pressed.id } );
-		exitOverview( mgr, selected, true );
+		exitOverview( mgr, selected );
 	};
 
 	mgr._overviewKeyHandler = ( e: KeyboardEvent ) => {
@@ -662,8 +676,8 @@ export function exitOverview(
 	mgr._overviewAddTileFocused = false;
 
 	doAction( HOOKS.OVERVIEW_EXITING, {
-		windowId: selected && maximize ? selected.id : undefined,
-		reason: selected && maximize ? 'select' : 'cancel',
+		windowId: selected ? selected.id : undefined,
+		reason: selected ? 'select' : 'cancel',
 	} );
 
 	// Remove area + shell classes AT T=0 so the backdrop fades and
@@ -686,16 +700,11 @@ export function exitOverview(
 		}
 	}
 	inertWpBodyContentChildren( false );
-	for ( const w of mgr._stack ) {
-		( w.element as HTMLElement & { inert: boolean } ).inert = false;
-	}
+	inertWindowChildren( mgr, false );
 
 	// Unselected windows: transform → '' (snaps back to their
 	// pre-overview inline geometry). Selected window (if any):
-	// transform is cleared the same way, AND `maximize()` fires,
-	// setting inline left/top/width/height to maximize bounds. Both
-	// transitions animate together for a single frictionless path
-	// from grid to maximized.
+	// transform is cleared the same way, AND focused to top of stack.
 	for ( const [ id, snap ] of mgr._overviewSnapshot ) {
 		const w = mgr.getById( id );
 		if ( ! w ) {
@@ -704,12 +713,14 @@ export function exitOverview(
 		w.element.style.transform = snap.transform;
 	}
 
-	if ( selected && maximize ) {
+	if ( selected ) {
 		// Focus first so z-index and focused-class are right from the
 		// moment the animation starts — no pop-to-top late in the
 		// transition.
 		mgr.focus( selected );
-		selected.maximize();
+		if ( maximize ) {
+			selected.maximize();
+		}
 	}
 
 	// Start labels fading immediately — they overshoot the area when
@@ -762,8 +773,8 @@ export function exitOverview(
 			mgr._overviewClickBlocker = null;
 		}
 		doAction( HOOKS.OVERVIEW_EXITED, {
-			windowId: selected && maximize ? selected.id : undefined,
-			reason: selected && maximize ? 'select' : 'cancel',
+			windowId: selected ? selected.id : undefined,
+			reason: selected ? 'select' : 'cancel',
 		} );
 	}, ANIMATION_MS ) as unknown as number;
 

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -531,8 +531,12 @@ describe( 'WindowManager — virtual desktops', async () => {
 				expect( sideDock.inert ).toBe( true );
 				expect( widgets.inert ).toBe( true );
 				expect( notice.inert ).toBe( true );
-				expect( a.element.inert ).toBe( true );
-				expect( b.element.inert ).toBe( true );
+				// Window root elements remain non-inert for thumbnail pointer clicks,
+				// while inner window child elements are inerted to trap keyboard focus.
+				expect( a.element.inert ).toBeFalsy();
+				expect( b.element.inert ).toBeFalsy();
+				expect( ( a.element.children[ 0 ] as HTMLElement ).inert ).toBe( true );
+				expect( ( b.element.children[ 0 ] as HTMLElement ).inert ).toBe( true );
 
 				manager.exitOverview();
 
@@ -542,13 +546,53 @@ describe( 'WindowManager — virtual desktops', async () => {
 				expect( sideDock.inert ).toBe( false );
 				expect( widgets.inert ).toBe( false );
 				expect( notice.inert ).toBe( false );
-				expect( a.element.inert ).toBe( false );
-				expect( b.element.inert ).toBe( false );
+				expect( a.element.inert ).toBeFalsy();
+				expect( b.element.inert ).toBeFalsy();
+				expect( ( a.element.children[ 0 ] as HTMLElement ).inert ).toBe( false );
+				expect( ( b.element.children[ 0 ] as HTMLElement ).inert ).toBe( false );
 			} finally {
 				for ( const el of toRemove ) {
 					el.remove();
 				}
 			}
+		} );
+
+		test( 'clicking a window thumbnail in overview selects and focuses it without forcing maximize', async () => {
+			const a = await manager.open( openConfig( 'a' ) );
+			const b = await manager.open( openConfig( 'b' ) );
+			expect( manager.getFocused() ).toBe( b );
+			expect( a.state ).toBe( 'normal' );
+			expect( b.state ).toBe( 'normal' );
+
+			manager.enterOverview();
+			expect( manager._overviewActive ).toBe( true );
+
+			vi.spyOn( a.element, 'getBoundingClientRect' ).mockReturnValue(
+				new DOMRect( 100, 100, 200, 150 ),
+			);
+
+			a.element.dispatchEvent(
+				new MouseEvent( 'pointerdown', {
+					bubbles: true,
+					cancelable: true,
+					button: 0,
+					clientX: 150,
+					clientY: 150,
+				} ),
+			);
+			a.element.dispatchEvent(
+				new MouseEvent( 'pointerup', {
+					bubbles: true,
+					cancelable: true,
+					button: 0,
+					clientX: 150,
+					clientY: 150,
+				} ),
+			);
+
+			expect( manager._overviewActive ).toBe( false );
+			expect( manager.getFocused() ).toBe( a );
+			expect( a.state ).toBe( 'normal' );
 		} );
 
 		// Each desktop tile was a single <button>; the close X was a child


### PR DESCRIPTION
## What?
Closes #380

Allows users to select and focus a specific window by clicking its thumbnail in Overview mode, bringing it to the top of the stack without forcing it to maximize.

## Why?
Previously, when viewing all open windows via "Arrange windows → Overview", clicking a window's thumbnail would close the overview but leave the windows in their original order. Allowing to be able to use Overview as a window switcher to bring a specific background window to the front can be useful. Additionally, the underlying mechanism was hardcoded to force the selected window into a maximized state upon exiting, which may disrupt user workflow.

## How?
- `src/window-manager/overview.ts`: 
  - Introduced `inertWindowChildren` to apply the `inert` attribute to the *children* of window elements rather than the root wrappers. This safely traps keyboard focus within the overview while keeping the window roots interactive for pointer events (clicks and hover states).
  - Updated the `exitOverview` call within the pointer up handler to omit the `maximize: true` argument, allowing the window to simply focus and restore to its original geometry.
  - Updated `HOOKS.OVERVIEW_EXITING` and `HOOKS.OVERVIEW_EXITED` event payloads to correctly report `reason: 'select'` and emit the `windowId` whenever a window is selected, regardless of whether it is maximizing.
- `tests/vitest/desktops.test.ts`: Added a new test block (`'clicking a window thumbnail in overview selects and focuses it without forcing maximize'`) to simulate a thumbnail click using `MouseEvent` and verify that the correct window focuses while retaining a `'normal'` state. Updated existing inert assertions to match the new child-element logic.

## Testing Instructions
1. Open multiple overlapping windows (e.g., Pages, Media, Settings).
2. Ensure at least one window is partially or fully obscured by the currently active window.
3. Enter Overview mode via the top bar menu (Arrange windows → Overview).
4. Click the thumbnail of one of the background windows.
5. Verify that Overview mode closes, and the window you clicked is now active and brought to the very front.

## Screencast

https://github.com/user-attachments/assets/db80294c-4fac-469f-adc6-1c7ba471d7be

## Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini
Used for: Diagnosing the issue, updating tests, and assistance with implementation.
