### PR TITLE
Fix: Admin bar visibility when fullscreen window is minimized

### DIFF
--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -102,7 +102,7 @@ export function withChromelessParam( url: string ): string | null {
  */
 export function updateFullscreenBodyClass(): void {
 	const hasFullscreen =
-		document.querySelectorAll( '.desktop-mode-window--fullscreen' ).length > 0;
+		document.querySelectorAll( '.desktop-mode-window--fullscreen:not(.desktop-mode-window--minimized)' ).length > 0;
 	document.body.classList.toggle( 'desktop-mode-has-fullscreen-window', hasFullscreen );
 }
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1494,6 +1494,10 @@ export class Window {
 			windowId: this.id,
 			element: this.element,
 		} );
+
+		if ( this._stateBeforeMinimize === 'fullscreen' ) {
+			updateFullscreenBodyClass();
+		}
 	}
 
 	/**

--- a/tests/vitest/window-state-transitions.test.ts
+++ b/tests/vitest/window-state-transitions.test.ts
@@ -262,6 +262,53 @@ describe( 'Window — state transitions are mutually exclusive', () => {
 		).toBe( true );
 	} );
 
+	test( 'fullscreen → minimize: clears fullscreen body class while minimized', () => {
+		// Regression guard for the admin-bar bug: minimizing a
+		// fullscreen window used to leave
+		// `body.desktop-mode-has-fullscreen-window` in place, keeping
+		// the admin bar hidden even though no fullscreen window was
+		// visible. `updateFullscreenBodyClass()` now ignores windows
+		// that are fullscreen *and* minimized, and `minimize()` re-runs
+		// it for the fullscreen path.
+		handle.win.toggleFullscreen();
+		expect(
+			document.body.classList.contains( 'desktop-mode-has-fullscreen-window' ),
+		).toBe( true );
+
+		handle.win.minimize();
+
+		expect(
+			document.body.classList.contains( 'desktop-mode-has-fullscreen-window' ),
+		).toBe( false );
+	} );
+
+	test( 'minimizing one fullscreen window keeps body class for another visible fullscreen window', () => {
+		// The `:not(--minimized)` selector must count *visible*
+		// fullscreen windows only — but any one of them is enough to
+		// keep the class. Guards against a "simplification" that keys
+		// the class off the window being minimized instead of scanning
+		// the document.
+		const other = mountWindow( baseConfig( { id: 'w2' } ) );
+		try {
+			handle.win.toggleFullscreen();
+			other.win.toggleFullscreen();
+
+			handle.win.minimize();
+
+			expect(
+				document.body.classList.contains( 'desktop-mode-has-fullscreen-window' ),
+			).toBe( true );
+
+			other.win.minimize();
+
+			expect(
+				document.body.classList.contains( 'desktop-mode-has-fullscreen-window' ),
+			).toBe( false );
+		} finally {
+			other.cleanup();
+		}
+	} );
+
 	test( 'fullscreen → minimize → restore: refreshes focus-button aria-pressed/label', () => {
 		// The focus (fullscreen) title-bar button is rendered by the
 		// controls system, so the easiest reliable way to assert its


### PR DESCRIPTION
## What?
Closes #383 

Fixes the bug where the WordPress admin bar remains hidden when a fullscreen window is minimized.

## Why?
When a window enters fullscreen mode, it adds a global CSS class (`desktop-mode-has-fullscreen-window`) to the body to hide the admin bar for an immersive experience. Previously, minimizing this fullscreen window kept the class active because the window retained its underlying fullscreen state, leaving the admin bar inaccessible across the entire desktop.

## How?
- `src/window/dom.ts`: 
  - Updated `updateFullscreenBodyClass()` to ignore minimized windows (`:not(.desktop-mode-window--minimized)`). This ensures the body class is removed if the only fullscreen windows are docked.
- `src/window/index.ts`: 
  - Updated the `minimize()` method to immediately call `updateFullscreenBodyClass()` if the window being minimized is in fullscreen mode, instantly updating the admin bar's visibility.

## Testing Instructions
1. Open any window in the desktop mode environment.
2. Enter fullscreen mode for that window.
3. Observe that the WordPress admin bar disappears.
4. Minimize the fullscreen window.
5. Verify that the WordPress admin bar immediately reappears.

## Screencast

https://github.com/user-attachments/assets/386743de-8751-48d1-b449-58c22dfae744



