### PR TITLE
Fix: folder rename not reflected on the desktop until refresh

### DIFF
--- a/src/desktop-files/file-tile.ts
+++ b/src/desktop-files/file-tile.ts
@@ -27,6 +27,7 @@ import { applyFilters, doAction } from '../hooks';
 import { resolve as resolveFileType } from './registry';
 import { openFile } from './open';
 import { showToast } from '../toast';
+import { currentPlacement } from './store';
 import type { RestPlacementShape } from './rest';
 import {
 	buildTileFromSpec,
@@ -35,6 +36,24 @@ import {
 } from './tile-spec';
 
 export { TILE_CLASS };
+
+/**
+ * Visible label for a placement — the per-placement `meta.name`
+ * override when present, the file's own title otherwise.
+ *
+ * Exported for the layer's fast-path repaints: they reuse tile DOM
+ * instead of rebuilding, so they re-derive the label with this same
+ * rule and patch the `<wpd-tile>` `label` attribute in place.
+ *
+ * @since 0.9.5
+ */
+export function placementLabel( placement: RestPlacementShape ): string {
+	const metaName =
+		placement.meta && typeof ( placement.meta as { name?: unknown } ).name === 'string'
+			? ( placement.meta as { name: string } ).name.trim()
+			: '';
+	return metaName !== '' ? metaName : resolveFileType( placement.file ).title();
+}
 
 /**
  * Convert a placement into the generic spec the unified renderer
@@ -48,11 +67,7 @@ function placementToSpec(
 	const file = resolveFileType( placement.file );
 	const previewUrl = file.previewUrl();
 
-	const metaName =
-		placement.meta && typeof ( placement.meta as { name?: unknown } ).name === 'string'
-			? ( placement.meta as { name: string } ).name.trim()
-			: '';
-	const label = metaName !== '' ? metaName : file.title();
+	const label = placementLabel( placement );
 
 	const metaIconUrl =
 		placement.meta && typeof ( placement.meta as { iconUrl?: unknown } ).iconUrl === 'string'
@@ -84,7 +99,6 @@ export function buildTile(
 	placement: RestPlacementShape,
 	folderId: number,
 ): HTMLElement {
-	const file = resolveFileType( placement.file );
 	const tile = buildTileFromSpec( placementToSpec( placement, folderId ) );
 
 	// Back-compat: placement-shaped class filter. Documented in
@@ -116,10 +130,16 @@ export function buildTile(
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
 		e.stopPropagation();
-		if ( placement.accessGated ) {
+		// Re-read the live placement — the layer's fast-path repaints
+		// reuse this tile's DOM without re-wiring, so the captured
+		// `placement` can be stale by now (an in-place rename would
+		// otherwise leak the old title into the opened window).
+		const live = currentPlacement( placement );
+		const file = resolveFileType( live.file );
+		if ( live.accessGated ) {
 			showToast( {
 				message:
-					`You don’t have permission to open "${ placement.file.title || file.title() }". ` +
+					`You don’t have permission to open "${ live.file.title || file.title() }". ` +
 					'Ask the folder owner if you need access to this item.',
 				duration: 6000,
 			} );
@@ -127,10 +147,10 @@ export function buildTile(
 		}
 		void openFile( file, {
 			placement: {
-				id: placement.id,
-				x: placement.x,
-				y: placement.y,
-				meta: placement.meta,
+				id: live.id,
+				x: live.x,
+				y: live.y,
+				meta: live.meta,
 			},
 		} );
 	} );

--- a/src/desktop-files/layer-deps.ts
+++ b/src/desktop-files/layer-deps.ts
@@ -11,6 +11,7 @@
 
 export * as rest from './rest';
 export {
+	currentPlacement,
 	getFilesState,
 	removeFolder,
 	removePlacement,
@@ -21,6 +22,7 @@ export {
 } from './store';
 
 import {
+	currentPlacement,
 	getFilesState,
 	removeFolder,
 	removePlacement,
@@ -38,4 +40,5 @@ export const store = {
 	upsertFolder,
 	removePlacement,
 	removeFolder,
+	currentPlacement,
 };

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -25,7 +25,7 @@
 
 import { doAction } from '../hooks';
 import { rest, store as filesStoreApi } from './layer-deps';
-import { buildTile, setTilePosition, TILE_CLASS } from './file-tile';
+import { buildTile, placementLabel, setTilePosition, TILE_CLASS } from './file-tile';
 import {
 	tilePayloadAccepts,
 	tilePayloadAcceptLabel,
@@ -471,11 +471,14 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 
 		const { pinnedSlots, displaced } = computeLayout( list );
 
-		// Update positions on shared tiles + build new ones for adds.
+		// Update positions + labels on shared tiles, build new ones
+		// for adds. The label sync covers "a shared tile was renamed
+		// in the same delta that added/removed another placement".
 		for ( const placement of list ) {
 			const tile = existing.get( placement.id );
 			if ( tile ) {
 				applyTilePosition( tile, placement, pinnedSlots, displaced );
+				syncTileLabel( tile, placement );
 				continue;
 			}
 			container.appendChild(
@@ -906,7 +909,10 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			// bubble to the canvas-level click and immediately
 			// deselect. Stop the bubble.
 			e.stopPropagation();
-			setSelected( placement );
+			// Live lookup — the captured placement can be stale after
+			// a fast-path repaint (see `attachTileDrag`), and selection
+			// consumers (status bar, right pane) display the title.
+			setSelected( filesStoreApi.currentPlacement( placement ) );
 		} );
 	}
 
@@ -1448,11 +1454,14 @@ function persistDockPromotedPosition(
  * rebuild path.
  *
  * The fast path is correct when the ONLY thing that changed is one
- * or more tiles' `x` / `y` / `sortOrder` / `updatedAtMs`. We can
- * detect that without keeping a previous-snapshot map by reading
- * the structural fields the renderer already encodes onto tile data
+ * or more tiles' `x` / `y` / `sortOrder` / `updatedAtMs` — or the
+ * visible label, which `syncTileLabel()` patches in place (the
+ * `<wpd-tile>` component observes its `label` attribute and repaints
+ * itself, so a rename doesn't need any rewiring). We can detect
+ * structural sameness without keeping a previous-snapshot map by
+ * reading the fields the renderer already encodes onto tile data
  * attributes (`data-placement-id`, `data-file-type`, `data-file-ref`)
- * plus the `--pinned` class. Anything else — adds, removes, renames,
+ * plus the `--pinned` class. Anything else — adds, removes,
  * file-type changes, parent moves, pin-flag flips — falls back so
  * the renderer can re-run pinned-slot allocation, drop-target
  * registration, drag wiring, etc.
@@ -1560,9 +1569,33 @@ function tryPatchPositions(
 		} else {
 			setTilePosition( tile, placement.x, placement.y );
 		}
+		syncTileLabel( tile, placement );
 	}
 
 	return true;
+}
+
+/**
+ * Sync a reused tile's visible label with the placement's current
+ * title. `<wpd-tile>` observes `label`, so writing the attribute
+ * repaints the label + aria-label in place while preserving
+ * consumer-appended children (share badges). No-op when already
+ * current.
+ *
+ * Both DOM-reusing repaint paths call this — without it a folder
+ * rename patches the store but the tile keeps showing the old name
+ * until the next wholesale rebuild (i.e. until F5).
+ *
+ * @since 0.9.5
+ */
+function syncTileLabel(
+	tile: HTMLElement,
+	placement: RestPlacementShape,
+): void {
+	const label = placementLabel( placement );
+	if ( tile.getAttribute( 'label' ) !== label ) {
+		tile.setAttribute( 'label', label );
+	}
 }
 
 /**
@@ -1891,11 +1924,19 @@ function attachTileDrag(
  */
 function attachContextMenu(
 	tile: HTMLElement,
-	placement: RestPlacementShape,
+	wiredPlacement: RestPlacementShape,
 ): void {
 	tile.addEventListener( 'contextmenu', ( e: MouseEvent ) => {
 		e.preventDefault();
 		e.stopPropagation();
+		// Same staleness hazard as `attachTileDrag`: the fast-path
+		// repaints reuse tile DOM without re-wiring, so the
+		// closure-captured placement can be stale by open time (old
+		// title after an in-place rename, old coords after a drag).
+		// Menu actions spread the placement into optimistic store
+		// patches — and the rename dialog pre-fills its title — so
+		// re-read the live version here.
+		const placement = filesStoreApi.currentPlacement( wiredPlacement );
 		const items: TileMenuItem[] = [
 			{
 				id: 'open',

--- a/src/desktop-files/store.ts
+++ b/src/desktop-files/store.ts
@@ -188,6 +188,39 @@ export function getFilesState(): FilesState {
 	return getFilesStore().getState() as FilesState;
 }
 
+/**
+ * Resolve the store's CURRENT version of a placement, falling back
+ * to the given snapshot when the store no longer tracks it.
+ *
+ * Tile event handlers capture the placement that existed when the
+ * tile was wired; the fast-path repaints (`tryPatchPositions` /
+ * `tryPatchIncremental` in `layer.ts`) reuse tile DOM without
+ * re-wiring, so a captured snapshot can be stale by event time —
+ * old title after an in-place rename, old coords after a drag.
+ * Handlers should route through this at event time instead of
+ * trusting the closure.
+ *
+ * @since 0.9.5
+ */
+export function currentPlacement( snapshot: RestPlacementShape ): RestPlacementShape {
+	const state = getFilesState();
+	const sameFolder = state.placementsByFolder
+		.get( snapshot.parentId )
+		?.find( ( p ) => p && p.id === snapshot.id );
+	if ( sameFolder ) {
+		return sameFolder;
+	}
+	// Parent changed between wire time and event time — scan the
+	// remaining buckets before giving up.
+	for ( const list of state.placementsByFolder.values() ) {
+		const hit = list.find( ( p ) => p && p.id === snapshot.id );
+		if ( hit ) {
+			return hit;
+		}
+	}
+	return snapshot;
+}
+
 /** Test-only — clears every map. */
 export function __resetFilesStoreForTests(): void {
 	const store = getFilesStore();

--- a/tests/vitest/desktop-files-layer.test.ts
+++ b/tests/vitest/desktop-files-layer.test.ts
@@ -281,6 +281,96 @@ describe( 'FilesLayer', () => {
 		handle.dispose();
 	} );
 
+	test( 'in-place rename repaints the tile label without rebuilding the tile', async () => {
+		// The user-reported bug: rename a folder from the tile context
+		// menu → the store gets the optimistic title patch, but the
+		// position-only fast path (`tryPatchPositions`) reused the
+		// tile DOM and never touched the label — the old name stuck
+		// around until F5.
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const folderFile = ( title: string ) => ( {
+			type: 'folder',
+			ref: '7',
+			title,
+			icon: 'dashicons-category',
+			previewUrl: '',
+			exists: true,
+		} );
+		store.setFolderPlacements( 0, [
+			placement( 1, { file: folderFile( 'Old name' ) } ),
+		] );
+
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '.desktop-mode-file-tile' )!;
+		expect(
+			tile.querySelector( '.desktop-mode-file-tile__label' )?.textContent,
+		).toBe( 'Old name' );
+		// Mark the node so we can prove DOM identity survived — the
+		// rename must patch in place, not wholesale-rebuild.
+		tile.dataset.testMark = 'kept';
+
+		// Exactly what the rename dialog's onSubmit does before the
+		// REST roundtrip resolves.
+		store.upsertPlacement( placement( 1, { file: folderFile( 'New name' ) } ) );
+
+		const after = host.querySelector< HTMLElement >( '.desktop-mode-file-tile' )!;
+		expect( after.dataset.testMark ).toBe( 'kept' );
+		expect( after.getAttribute( 'label' ) ).toBe( 'New name' );
+		expect(
+			after.querySelector( '.desktop-mode-file-tile__label' )?.textContent,
+		).toBe( 'New name' );
+		expect( after.getAttribute( 'aria-label' ) ).toBe( 'New name' );
+		handle.dispose();
+	} );
+
+	test( 'rename arriving together with an add still repaints the label (incremental path)', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const folderFile = ( title: string ) => ( {
+			type: 'folder',
+			ref: '7',
+			title,
+			icon: 'dashicons-category',
+			previewUrl: '',
+			exists: true,
+		} );
+		store.setFolderPlacements( 0, [
+			placement( 1, { file: folderFile( 'Old name' ) } ),
+		] );
+
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '.desktop-mode-file-tile' )!;
+		tile.dataset.testMark = 'kept';
+
+		// One delta: the folder was renamed AND a sibling was added —
+		// tile counts differ, so this exercises `tryPatchIncremental`.
+		store.setFolderPlacements( 0, [
+			placement( 1, { file: folderFile( 'New name' ) } ),
+			placement( 2 ),
+		] );
+
+		const renamed = host.querySelector< HTMLElement >(
+			'[data-placement-id="1"]',
+		)!;
+		expect( renamed.dataset.testMark ).toBe( 'kept' );
+		expect(
+			renamed.querySelector( '.desktop-mode-file-tile__label' )?.textContent,
+		).toBe( 'New name' );
+		expect(
+			host.querySelectorAll( '.desktop-mode-file-tile' ).length,
+		).toBe( 2 );
+		handle.dispose();
+	} );
+
 	test( 'fingerprint short-circuit avoids rebuilding tiles when nothing changed', async () => {
 		const { layer, store, rest } = await load();
 		store.__resetFilesStoreForTests();


### PR DESCRIPTION
## What it does

Renaming a folder from its tile context menu now updates the tile label immediately. Before, the new name only appeared after a full page refresh, even though the rename had persisted.

## Rationale

The rename flow was correct at the data layer — the dialog's submit optimistically patched the store and REST persisted the new name — but the repaint's DOM-reusing fast paths (`tryPatchPositions` and `tryPatchIncremental` in `layer.ts`) only wrote positions. Their structural checks (placement id, file type, file ref, pin flag) all pass on a rename, so the label change was silently swallowed. The `tryPatchPositions` doc comment claimed renames fall back to the wholesale rebuild; nothing in the checks actually detected them.

A sibling staleness bug rode along: tile event handlers (context menu, click-select, dblclick-open) capture the placement object at wire time. Since fast paths reuse DOM without re-wiring, a second rename pre-filled the dialog with the old name, and double-clicking a renamed folder opened a window titled with the old name.

## Implementation

- `syncTileLabel()` in `layer.ts`: both fast paths now sync the `<wpd-tile>` `label` attribute on reused tiles. The component observes `label` and repaints the label + `aria-label` in place — no rebuild, no wallpaper flash, consumer-appended children (share badges) survive.
- `placementLabel()` exported from `file-tile.ts` so the patch derives the label with the same `meta.name`-override rule as the renderer.
- `currentPlacement()` in `store.ts`: contextmenu, select-on-click, and dblclick handlers re-read the live placement at event time instead of trusting the closure — the same pattern `attachTileDrag` already uses for its `updatedAtMs` staleness. Internal only; the public `wp.desktop.files.store` facade is unchanged.

## Testing instructions

```bash
npm run test:js -- desktop-files-layer
```

Two new regression tests cover a rename repainting the label without rebuilding the tile (fast path) and a rename arriving in the same delta as an add (incremental path).

Manual QA: create a folder on the desktop, right-click → Rename…, submit a new name. The tile label updates instantly; reopening Rename pre-fills the current name; the name survives F5. Verified in wp-env against this branch, and the bug reproduced on trunk with the same steps.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-387-7b8599cc03b0f03e3792f252f91b29a5e461d88c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->