### PR TITLE
Live-refresh list windows on content changes (posts, CPTs, comments, WooCommerce orders)

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -87,6 +87,9 @@ require_once DESKTOP_MODE_DIR . 'includes/extended-options.php';
 require_once DESKTOP_MODE_DIR . 'includes/oauth-relay.php';
 require_once DESKTOP_MODE_DIR . 'includes/devtools.php';
 require_once DESKTOP_MODE_DIR . 'includes/ai-copilot/bootstrap.php';
+// Content-changes must load before the recycle bin — the bin's
+// changelog delegates into the generic recorder.
+require_once DESKTOP_MODE_DIR . 'includes/content-changes.php';
 require_once DESKTOP_MODE_DIR . 'includes/recycle-bin/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/desktop-files/bootstrap.php';
 require_once DESKTOP_MODE_DIR . 'includes/notes/bootstrap.php';

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -77,6 +77,7 @@ The full surface is documented in [`javascript-reference.md`](./javascript-refer
 | `heartbeat` | `HeartbeatBus` *(WordPress Heartbeat bridge)* | Stable *(0.5.5)* |
 | `broadcast` | `<T>( topic: string, payload: T ) => void` *(cross-window)* | Stable *(0.5.5)* |
 | `subscribe` | `( topic: string, cb ) => () => void` *(cross-window)* | Stable *(0.5.5)* |
+| — topic family | `desktop-mode.<type>.changed` *(content-change realtime; `{ source, action, ids }`)* | Stable *(0.9.7)* |
 | `presence` | `PresenceApi` | Stable *(0.5.5)* |
 
 ### Commands, palettes, AI, settings

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -72,6 +72,8 @@ Emitted on **every** chromeless page load, **including `identity: null`** — a 
 
 **Re-announced after block-editor saves** *(since 0.9.6)*: Gutenberg saves over REST without navigating, so the bridge also watches the `core/editor` save lifecycle and, after every real (non-autosave) save, refetches a server-recomputed identity from `GET /desktop-mode/v1/content-identity?post={id}` (capability-gated to `edit_post`; both identity filters run there with `$screen = null`) and posts this same message again. The parent engine diffs repeats, so identical re-announcements are free. See [`docs/examples/window-links.md`](./examples/window-links.md).
 
+**Save broadcast** *(since 0.9.7)*: on the same save-success edge the watcher also posts an upstream `{ type: 'desktop-mode-broadcast', topic: 'desktop-mode.<postType>.changed', payload: { source: 'editor', action: 'created' | 'updated', ids: [ postId ] } }` to the parent, which fans it out to every window — list windows showing that type refresh instantly. `action` is `'created'` exactly when the post was still new on the tick the save started. This is the block editor's leg of the content-change realtime layer (`includes/content-changes.php`); form-POST → redirect flows are covered server-side by the chromeless-footer emitter instead. The iframe-side consumer is the soft-reload handler: `edit.php` / `upload.php` / `edit-comments.php` are matched generically by list type, and non-standard list screens (the HPOS `wc-orders` list) are declared via the PHP-printed `/*__DESKTOP_MODE_SOFT_RELOAD_EXTRAS__*/` placeholder, filterable server-side through `desktop_mode_soft_reload_rules`.
+
 ### Connection bridge — `desktop-mode-bridge-*`
 
 | Type | Direction | Carries | Purpose |

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -50,6 +50,7 @@ defined( 'ABSPATH' ) || exit;
 - [Open a file in the Code editor (deep-link from any window)](./code-editor-open.md)
 - [Cross-window devtools — instrumentation primitives](./devtools-instrumentation.md)
 - [Extend the Recycle Bin](./recycle-bin.md)
+- [Content changes — live-refresh every window listing your type](./content-changes.md)
 - [Customize note → post conversion — `desktop_mode_notes_convert_post_args`](./notes-convert-to-post.md)
 - [Programmatic folder sharing — invite from PHP, listen for share events](./share-folder.md)
 - [Native Posts window — default-on, remap registry, hooks](./native-posts.md)

--- a/docs/examples/content-changes.md
+++ b/docs/examples/content-changes.md
@@ -1,0 +1,112 @@
+# Content changes — live-refresh every window listing your type
+
+Since 0.9.7 the framework ships a generic content-change realtime
+layer: any create / update / trash of a post, page, `show_ui` CPT,
+comment, or WooCommerce order is broadcast to every window as
+`desktop-mode.<type>.changed`, and windows listing that type refresh
+themselves — iframe list pages via the built-in soft reload, native
+windows via their own subscriptions. This recipe shows what (little)
+a third-party plugin needs to do to join in, on both sides.
+
+## You probably need to do nothing
+
+If your content is a registered post type with `show_ui => true` and
+your list screen is the standard `edit.php?post_type=<type>`, the
+framework already covers you end to end: saves are recorded by the
+`wp_after_insert_post` publisher, and the soft-reload matcher derives
+your list page's type from its URL. Open two windows, save in one,
+watch the other repaint.
+
+## Publisher — content that is NOT a post
+
+A plugin with its own storage (custom table, settings blob) records
+mutations explicitly. One call per mutation:
+
+```php
+/**
+ * After my plugin writes a row.
+ */
+function myplugin_after_save_item( $item_id, $is_new ) {
+	if ( function_exists( 'desktop_mode_content_changes_record' ) ) {
+		desktop_mode_content_changes_record(
+			'myplugin_item',                    // becomes desktop-mode.myplugin_item.changed
+			$item_id,
+			$is_new ? 'created' : 'updated'     // or trashed / untrashed / deleted
+		);
+	}
+}
+```
+
+That single call feeds every delivery path: the instant
+chromeless-footer broadcast (survives the form-POST → redirect via a
+per-user buffer) and the Heartbeat catch-all (other tabs, other
+users, REST/WP-CLI, ≤ one tick).
+
+## Consumer — a list screen on a custom admin URL
+
+The generic soft-reload matcher only understands `edit.php` /
+`upload.php` / `edit-comments.php`. If your list lives at
+`admin.php?page=myplugin-items`, declare it:
+
+```php
+add_filter( 'desktop_mode_soft_reload_rules', function ( $rules ) {
+	$rules[] = array(
+		'topic'       => 'desktop-mode.myplugin_item.changed',
+		'path'        => 'admin.php',
+		'query'       => array( 'page' => 'myplugin-items' ),
+		// Keep the single-item editor out — a background body swap
+		// would destroy unsaved form state.
+		'queryAbsent' => array( 'action' ),
+	);
+	return $rules;
+} );
+```
+
+Now any `desktop-mode.myplugin_item.changed` broadcast makes an open
+`admin.php?page=myplugin-items` iframe refetch its own URL and swap
+`#wpbody-content` in place — no spinner, no scroll jump. Re-bind any
+custom JS after the swap by listening for `desktop-mode-soft-reloaded`
+on the iframe's `document`.
+
+(This is exactly how the built-in WooCommerce HPOS orders rule works:
+`admin.php?page=wc-orders` reacts to `desktop-mode.shop_order.changed`,
+with `queryAbsent: [ 'action' ]` protecting the order editor.)
+
+## Consumer — a native window
+
+Subscribe on the broadcast bus and refetch. Skip your own emissions
+by `source` if your window also publishes:
+
+```js
+const unsubscribe = wp.desktop.subscribe(
+	'desktop-mode.myplugin_item.changed',
+	( { source, action, ids } ) => {
+		if ( source === 'myplugin-window' ) {
+			return; // our own mutation already refreshed the table
+		}
+		void refreshTable();
+	}
+);
+// Call unsubscribe() in your window-closed teardown.
+```
+
+Payload contract: `{ source, action, ids }` — `source` is `'admin'`
+(server-recorded), `'editor'` (block-editor save), `'heartbeat'`
+(catch-all — MAY repeat a change a faster path already delivered, so
+refreshes must be idempotent), or a client emitter's own id.
+
+## Suppressing / observing
+
+```php
+// Keep a high-churn internal type out of the realtime system.
+add_filter( 'desktop_mode_content_changes_should_record', function ( $record, $type ) {
+	return 'myplugin_log_entry' === $type ? false : $record;
+}, 10, 2 );
+
+// Mirror every recorded change into your own realtime channel (SSE, websocket).
+add_action( 'desktop_mode_content_change_recorded', function ( $type, $id, $action ) {
+	myplugin_sse_push( compact( 'type', 'id', 'action' ) );
+}, 10, 3 );
+```
+
+Full surface: [hooks-reference.md → Content-change realtime layer](../hooks-reference.md#content-change-realtime-layer-since-097).

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1971,6 +1971,156 @@ See [`docs/examples/devtools-instrumentation.md`](./examples/devtools-instrument
 
 ---
 
+## Content-change realtime layer (since 0.9.7)
+
+`includes/content-changes.php` — the generic "something changed,
+every window listing that type should refresh" system. Any create /
+update / trash of a post, page, `show_ui` CPT, comment, or
+WooCommerce order is recorded into a per-request changelog and
+relayed to the parent shell as a cross-window broadcast
+(`desktop-mode.<type>.changed`, see the topic contract under
+[Recycle Bin → Cross-window broadcast](#cross-window-broadcast)).
+Consumers already in place: the chromeless soft-reload for iframe
+list pages, and the native Posts / Pages / Users / Comments windows.
+
+Three delivery paths:
+
+1. **Chromeless footer (instant).** Form-POST → redirect flows
+   (classic editor, WooCommerce order Update, bulk actions). The
+   changelog survives the redirect in a 60 s per-user transient and
+   is flushed by the next chromeless `admin_footer` render.
+2. **Block editor (instant).** Gutenberg saves over REST with no
+   navigation; the chromeless bridge's save-watcher posts the
+   broadcast directly (`source: 'editor'`).
+3. **Heartbeat (catch-all, ≤ one tick).** Every record is appended to
+   the pruned `_desktop_mode_content_changes_log` option
+   (autoload=false, 5-minute window, 100 entries max); opted-in
+   shells send `desktop_mode_content_changes_seen_ts` per tick and
+   re-broadcast the fresh entries (`source: 'heartbeat'`). Covers
+   Quick Edit, AJAX moderation / status flips, other browser tabs,
+   REST and WP-CLI mutations. Tabs that never opt in pay zero.
+
+Built-in publishers: `wp_after_insert_post` (revisions, autosaves,
+auto-drafts, trash-status writes, and non-`show_ui` types skipped),
+`wp_insert_comment` / `edit_comment` / `transition_comment_status`
+(trash transitions skipped — the Recycle Bin owns the trash verbs),
+and — when WooCommerce is active — `woocommerce_new_order` /
+`woocommerce_update_order` / `woocommerce_order_status_changed` /
+`woocommerce_trash_order` / `woocommerce_untrash_order` /
+`woocommerce_delete_order`, always recorded as type `shop_order` so
+one topic serves both HPOS and legacy storage.
+
+### `desktop_mode_content_changes_record()` — Stable *(function, since 0.9.7)*
+
+The public recorder — call it from your own mutation paths (custom
+tables, settings screens) and every window listing your type
+refreshes exactly like core content:
+
+```php
+desktop_mode_content_changes_record( string $type, int $id, string $action ): bool
+// $action: 'created' | 'updated' | 'trashed' | 'untrashed' | 'deleted'
+```
+
+Dedupe is first-writer-wins per `type:id` within a request — the more
+specific verb (recorded by an earlier hook) wins over a later generic
+`updated`. If your list screen is not a standard
+`edit.php?post_type=<type>` page, pair the recorder with a
+`desktop_mode_soft_reload_rules` entry (below).
+
+### `desktop_mode_content_changes_should_record` — Stable *(filter, since 0.9.7)*
+
+Veto gate in front of every record — return `false` to keep a
+mutation out of the realtime system entirely (footer broadcast AND
+heartbeat log).
+
+```php
+apply_filters( 'desktop_mode_content_changes_should_record', bool $record, string $type, int $id, string $action );
+```
+
+### `desktop_mode_content_change_recorded` — Stable *(action, since 0.9.7)*
+
+Fires after every successful record. Push your own real-time channel
+(websocket, SSE) here without re-hooking every mutation path.
+
+```php
+do_action( 'desktop_mode_content_change_recorded', string $type, int $id, string $action );
+```
+
+### `desktop_mode_content_change_topic` — Experimental *(filter, since 0.9.7)*
+
+Broadcast topic per type, applied while the footer emitter builds
+envelopes. Default `desktop-mode.<type>.changed`.
+
+```php
+apply_filters( 'desktop_mode_content_change_topic', string $topic, string $type, string $action );
+```
+
+### `desktop_mode_content_changes_broadcasts` — Experimental *(filter, since 0.9.7)*
+
+The full envelope list (`array( array( 'topic' => …, 'payload' => … ) )`)
+just before the chromeless footer emits. Return an empty array to
+suppress the emit for this render.
+
+```php
+apply_filters( 'desktop_mode_content_changes_broadcasts', array $broadcasts );
+```
+
+### `desktop_mode_content_changes_emitted` — Experimental *(action, since 0.9.7)*
+
+Fires after the footer printed the emit script, with the envelopes it
+carried.
+
+```php
+do_action( 'desktop_mode_content_changes_emitted', array $broadcasts );
+```
+
+### `desktop_mode_soft_reload_rules` — Stable *(filter, since 0.9.7)*
+
+Declarative soft-reload rules injected into every chromeless iframe,
+for list screens that are **not** a standard `edit.php?post_type=X` /
+`upload.php` / `edit-comments.php` page (those are matched
+generically — see the soft-reload contract under
+[Recycle Bin → Cross-window broadcast](#cross-window-broadcast)).
+
+```php
+apply_filters( 'desktop_mode_soft_reload_rules', array $rules );
+```
+
+Rule shape (all matched against the iframe's current URL):
+
+```php
+array(
+    'topic'       => 'desktop-mode.my_type.changed', // broadcast topic to react to
+    'path'        => 'admin.php',                    // wp-admin filename
+    'query'       => array( 'page' => 'my-list' ),   // required query params (exact match)
+    'queryAbsent' => array( 'action' ),              // params that must NOT be present
+)
+```
+
+The default rule set ships one entry — WooCommerce's HPOS orders list
+(`admin.php?page=wc-orders`, topic `desktop-mode.shop_order.changed`),
+with `queryAbsent: [ 'action' ]` so the single-order **editor**
+(`…&action=edit`) keeps the single-edit exclusion and never loses
+unsaved state to a background refresh.
+
+### Heartbeat contract
+
+| Direction | Field | Shape |
+|---|---|---|
+| client → server | `desktop_mode_content_changes_seen_ts` | `int` server-ms high-water mark; `0` on the first (handshake) tick. |
+| server → client | `desktop_mode_content_changes` | `{ ts: int, entries: [ { ts, type, action, ids } ] }` — entries newer than the client's seen ts. |
+
+The shell's first tick is a pure handshake (adopts the server clock,
+broadcasts nothing) so client/server clock skew can never drop
+changes. A change that already arrived via the footer or editor path
+is re-broadcast once on the next tick — consumers are idempotent by
+contract.
+
+See [`docs/examples/content-changes.md`](./examples/content-changes.md)
+for an end-to-end third-party recipe.
+
+---
+
 ## Recycle Bin
 
 The Recycle Bin stamps who-deleted-what-when metadata on posts, pages, attachments, and comments as they pass through the WordPress trash (attachments only reach trash when `MEDIA_TRASH` is enabled) and exposes browse / restore / purge over REST. Every decision the bin makes is filterable.
@@ -2111,23 +2261,33 @@ do_action( 'desktop_mode_recycle_bin_after_purge_comment',    int $comment_id );
 
 After every restore / purge / empty the bin publishes one topic
 **per affected post type** on the shell-wide broadcast bus
-(`wp.desktop.broadcast`). The same chromeless footer in
-`realtime.php` also emits these topics for any admin request
-that ran `wp_trash_post` / `untrash_post` / `before_delete_post`
-/ `trashed_comment` / `untrashed_comment` / `deleted_comment` —
-so the recycle bin learns instantly when a list-table trashes
-something, and the corresponding list iframe refreshes when the
-bin restores something.
+(`wp.desktop.broadcast`). Since 0.9.7 the bin's changelog delegates
+into the generic
+[content-change realtime layer](#content-change-realtime-layer-since-097),
+whose chromeless footer emits the same topics for any admin request
+that trashed, restored, deleted — or **created / updated** — content.
+The recycle bin learns instantly when a list-table trashes
+something, list iframes refresh when the bin restores something,
+and (0.9.7+) list windows also refresh when content is saved in
+another window.
 
-Topic format: **`desktop-mode.<post_type>.changed`** — the literal
-post-type slug (`post`, `page`, `attachment`, `comment`, or any
-CPT). Payload:
+Topic format: **`desktop-mode.<type>.changed`** — the literal
+post-type slug (`post`, `page`, `attachment`, `comment`, any CPT, or
+`shop_order` for WooCommerce orders under both HPOS and legacy
+storage). Payload:
 
 ```js
-{ source: 'recycle-bin' | 'admin' | <plugin>,
-  action: 'trashed' | 'untrashed' | 'deleted',
+{ source: 'recycle-bin' | 'admin' | 'editor' | 'heartbeat' | <plugin>,
+  action: 'created' | 'updated' | 'trashed' | 'untrashed' | 'deleted',
   ids:    number[] }
 ```
+
+`source` values: `'admin'` (server-recorded, chromeless-footer
+relay), `'editor'` (block-editor save-watcher), `'heartbeat'` (the
+catch-all re-broadcast — note this MAY repeat a change your window
+already handled; consumers must treat refreshes as idempotent),
+`'recycle-bin'` / `'posts-window'` / plugin names (client-side
+emitters identifying themselves for echo suppression).
 
 **Iframe-side default behaviour: soft reload.** The chromeless
 bridge installs a built-in subscriber that, when the topic
@@ -2135,20 +2295,27 @@ matches the iframe's current page, *fetches the URL it's already
 on* and replaces `#wpbody-content` in place. The user sees the
 list update — restored post appears, trashed media disappears —
 without the WP loading spinner that `location.reload()` would
-show. Mappings:
+show. Matching is generic since 0.9.7: the page's list type is
+derived from the URL and compared to the `<type>` in the topic —
 
-| Topic                              | List page                           |
-|------------------------------------|-------------------------------------|
-| `desktop-mode.post.changed`          | `edit.php` (post type unset / `post`) |
-| `desktop-mode.page.changed`          | `edit.php?post_type=page`           |
-| `desktop-mode.attachment.changed`    | `upload.php`                        |
-| `desktop-mode.comment.changed`       | `edit-comments.php`                 |
+| List page | Reacts to |
+|---|---|
+| `edit.php` (post type unset / `post`) | `desktop-mode.post.changed` |
+| `edit.php?post_type=<X>` (any CPT) | `desktop-mode.<X>.changed` |
+| `upload.php` | `desktop-mode.attachment.changed` |
+| `edit-comments.php` | `desktop-mode.comment.changed` |
+| `admin.php?page=wc-orders` (HPOS orders list) | `desktop-mode.shop_order.changed` |
 
-Single-edit pages (`post.php`, `post-new.php`) deliberately have
+— plus any declarative rule added via the
+`desktop_mode_soft_reload_rules` filter (how the `wc-orders` row
+above is implemented).
+
+Single-edit pages (`post.php`, `post-new.php`, the HPOS order editor
+`admin.php?page=wc-orders&action=edit`) deliberately have
 **no** soft-reload handler, because replacing their body would
-destroy unsaved Gutenberg / classic-editor state. Plugins wanting
-specific behaviour for those pages subscribe to the same topic
-themselves and decide how to react.
+destroy unsaved editor state. Plugins wanting specific behaviour
+for those pages subscribe to the same topic themselves and decide
+how to react.
 
 After every successful soft-reload the bridge dispatches
 `desktop-mode-soft-reloaded` on the iframe's `document` so plugins

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1671,6 +1671,20 @@ wp.desktop.subscribe( 'posts/updated', ( { id } ) => {
 
 **Mirror onto activity** *(since 0.5.5)* — every `broadcast()` *also* publishes on the activity bus under the same topic name (so long as it matches the `<plugin>/<event>` shape), so in-tab subscribers can use the unified `activity.subscribe` surface without knowing whether the producer ran broadcast vs activity. Cross-iframe fan-out stays the broadcast bus's job.
 
+**The `desktop-mode.<type>.changed` topic family** *(extended 0.9.7)* — the framework's own content-change traffic rides this bus. One topic per content type (`post`, `page`, `attachment`, `comment`, any CPT slug, `shop_order` for WooCommerce orders), payload:
+
+```typescript
+{
+    source: 'admin' | 'editor' | 'heartbeat' | 'recycle-bin' | string, // emitter id
+    action: 'created' | 'updated' | 'trashed' | 'untrashed' | 'deleted',
+    ids:    number[],
+}
+```
+
+Publishers: the server-side changelog relayed through the chromeless footer (`source: 'admin'`), the block-editor save-watcher (`'editor'`), the Heartbeat catch-all (`'heartbeat'` — may repeat a change delivered earlier by a faster path; treat refreshes as idempotent), and client-side emitters that identify themselves (`'recycle-bin'`, `'posts-window'`, your plugin). Subscribing to your type's topic is all a list window needs to stay live; publishing is one `desktop_mode_content_changes_record()` call server-side (see [hooks-reference.md → Content-change realtime layer](./hooks-reference.md#content-change-realtime-layer-since-097)) or a direct `wp.desktop.broadcast()` client-side — set a distinctive `source` so you can skip your own echoes.
+
+**Heartbeat fields** *(since 0.9.7)* — the shell contributes `desktop_mode_content_changes_seen_ts` (server-ms high-water mark, `0` on the handshake tick) and consumes `desktop_mode_content_changes: { ts, entries: [ { ts, type, action, ids } ] }`, re-broadcasting each fresh entry on this bus. Timestamps are server-clock; the first tick is a pure handshake so client/server skew can never drop changes.
+
 ---
 
 ### `showToast( opts )` — Stable *(since 0.6.0)*

--- a/includes/content-changes.php
+++ b/includes/content-changes.php
@@ -1,0 +1,625 @@
+<?php
+/**
+ * Desktop Mode — generic content-change realtime layer.
+ *
+ * Records create/update/trash mutations of posts, pages, CPTs,
+ * comments, and WooCommerce orders into a per-request changelog and
+ * relays them to the parent shell as cross-window broadcasts
+ * (`desktop-mode.<type>.changed`, payload `{ source, action, ids }`),
+ * so every window listing that content type can refresh without an F5.
+ *
+ * Three delivery paths, mirroring the Recycle Bin realtime layer
+ * (`includes/recycle-bin/realtime.php`) which delegates its own
+ * changelog into this module:
+ *
+ *   1. **Chromeless footer — fast path.** At `admin_footer` on a
+ *      chromeless render, one inline script postMessages a
+ *      `desktop-mode-broadcast` envelope per `[type][action]` entry
+ *      to the parent shell. Because the dominant admin mutation flow
+ *      is form-POST → 302 → GET (the mutating request renders no
+ *      footer), the changelog is buffered across the redirect in a
+ *      short-TTL per-user transient and flushed on the next
+ *      chromeless footer render (~500 ms after the click).
+ *
+ *   2. **Block editor — client-side.** Gutenberg saves over REST with
+ *      no navigation; the chromeless bridge's save-watcher
+ *      (`includes/render/chromeless-bridge.php`) posts the broadcast
+ *      directly on save success. This module still records the REST
+ *      save server-side for path 3.
+ *
+ *   3. **Heartbeat — catch-all.** Every record is appended to a
+ *      pruned changelog option; the Heartbeat response answers
+ *      "entries newer than your seen ts" for opted-in shells. Covers
+ *      Quick Edit, AJAX status flips, other browser tabs, REST and
+ *      WP-CLI mutations within one tick (15–60 s).
+ *
+ * @package WPDesktopMode
+ * @since   0.9.7
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const DESKTOP_MODE_CONTENT_CHANGES_LOG_OPTION = '_desktop_mode_content_changes_log';
+
+/**
+ * Milliseconds of heartbeat-changelog history to retain.
+ *
+ * @since 0.9.7
+ */
+const DESKTOP_MODE_CONTENT_CHANGES_LOG_WINDOW_MS = 300000;
+
+/**
+ * Maximum retained heartbeat-changelog entries.
+ *
+ * @since 0.9.7
+ */
+const DESKTOP_MODE_CONTENT_CHANGES_LOG_MAX = 100;
+
+/**
+ * TTL for the redirect-surviving per-user changelog buffer.
+ *
+ * @since 0.9.7
+ */
+const DESKTOP_MODE_CONTENT_CHANGES_BUFFER_TTL = 60;
+
+/**
+ * Per-request state shared by the recorder, the footer emitter, and
+ * the shutdown handler.
+ *
+ * Function-static-by-reference so it survives across hook callbacks
+ * within one PHP request — same pattern as the Recycle Bin changelog.
+ *
+ * Shape:
+ *   - `log`     — `[ type ][ action ] = int[] ids` for this request.
+ *   - `seen`    — `"type:id" => true` first-writer-wins dedupe set.
+ *   - `staged`  — flat `{ type, action, id }` rows for the heartbeat log.
+ *   - `flushed` — true once the footer emitter consumed `log`, so the
+ *                 shutdown handler doesn't buffer it a second time.
+ *
+ * @since 0.9.7
+ *
+ * @return array Per-request state, by reference.
+ */
+function &desktop_mode_content_changes_state() {
+	static $state = null;
+	if ( null === $state ) {
+		$state = array(
+			'log'     => array(),
+			'seen'    => array(),
+			'staged'  => array(),
+			'flushed' => false,
+		);
+	}
+	return $state;
+}
+
+/**
+ * Resets the per-request state. Test isolation only.
+ *
+ * @since 0.9.7
+ * @internal
+ */
+function desktop_mode_content_changes_reset() {
+	$state = &desktop_mode_content_changes_state();
+	$state = array(
+		'log'     => array(),
+		'seen'    => array(),
+		'staged'  => array(),
+		'flushed' => false,
+	);
+}
+
+/**
+ * Records a content change into the per-request changelog.
+ *
+ * This is the public entry point for third-party plugins with their
+ * own storage (an HPOS-style custom table, a settings screen, …):
+ * call it from your mutation path and every open window listing your
+ * type refreshes, exactly like core content. Pair it with a
+ * `desktop_mode_soft_reload_rules` filter entry if your list screen
+ * is not a standard `edit.php?post_type=<type>` page.
+ *
+ * Dedupe is first-writer-wins per `type:id` within the request: core
+ * fires the trash verbs (`wp_trash_post`, `untrash_post`) BEFORE the
+ * internal status write reaches `wp_after_insert_post`, so the more
+ * specific verb is recorded and the follow-up `updated` for the same
+ * id is dropped. The same mechanism collapses WooCommerce legacy-mode
+ * double-fires (post hooks + `woocommerce_update_order`).
+ *
+ * @since 0.9.7
+ *
+ * @param string $type   Content type slug — a post type, `comment`,
+ *                       or `shop_order`. Becomes the broadcast topic
+ *                       `desktop-mode.<type>.changed`.
+ * @param int    $id     Mutated object id.
+ * @param string $action One of 'created', 'updated', 'trashed',
+ *                       'untrashed', 'deleted'.
+ * @return bool Whether the change was recorded.
+ */
+function desktop_mode_content_changes_record( $type, $id, $action ) {
+	$type   = (string) $type;
+	$id     = (int) $id;
+	$action = (string) $action;
+
+	if ( '' === $type || $id <= 0 || '' === $action ) {
+		return false;
+	}
+
+	/**
+	 * Filters whether a content change is recorded into the realtime
+	 * changelog.
+	 *
+	 * Return false to keep a mutation out of the cross-window refresh
+	 * system entirely (footer broadcast AND heartbeat log) — e.g. a
+	 * high-churn internal type whose list windows manage their own
+	 * realtime.
+	 *
+	 * @since 0.9.7
+	 *
+	 * @param bool   $record Whether to record. Default true.
+	 * @param string $type   Content type slug.
+	 * @param int    $id     Mutated object id.
+	 * @param string $action Verb (created/updated/trashed/untrashed/deleted).
+	 */
+	if ( ! apply_filters( 'desktop_mode_content_changes_should_record', true, $type, $id, $action ) ) {
+		return false;
+	}
+
+	$state = &desktop_mode_content_changes_state();
+	$key   = $type . ':' . $id;
+	if ( isset( $state['seen'][ $key ] ) ) {
+		return false;
+	}
+	$state['seen'][ $key ] = true;
+
+	if ( ! isset( $state['log'][ $type ] ) ) {
+		$state['log'][ $type ] = array();
+	}
+	if ( ! isset( $state['log'][ $type ][ $action ] ) ) {
+		$state['log'][ $type ][ $action ] = array();
+	}
+	$state['log'][ $type ][ $action ][] = $id;
+
+	$state['staged'][] = array(
+		'type'   => $type,
+		'action' => $action,
+		'id'     => $id,
+	);
+
+	/**
+	 * Fires after a content change is recorded into the realtime
+	 * changelog.
+	 *
+	 * Subscribers can push their own real-time signal (websocket,
+	 * SSE, …) without re-hooking every mutation path individually.
+	 *
+	 * @since 0.9.7
+	 *
+	 * @param string $type   Content type slug.
+	 * @param int    $id     Mutated object id.
+	 * @param string $action Verb (created/updated/trashed/untrashed/deleted).
+	 */
+	do_action( 'desktop_mode_content_change_recorded', $type, $id, $action );
+
+	return true;
+}
+
+/**
+ * Returns the per-request changelog: `[ type ][ action ] = int[] ids`.
+ *
+ * @since 0.9.7
+ *
+ * @return array
+ */
+function desktop_mode_content_changes_log() {
+	$state = &desktop_mode_content_changes_state();
+	return $state['log'];
+}
+
+/**
+ * Merges changelog `$b` into changelog `$a` (both
+ * `[ type ][ action ] = int[] ids`).
+ *
+ * @since 0.9.7
+ *
+ * @param array $a Base changelog.
+ * @param array $b Changelog to merge in.
+ * @return array
+ */
+function desktop_mode_content_changes_merge( $a, $b ) {
+	foreach ( (array) $b as $type => $by_action ) {
+		foreach ( (array) $by_action as $action => $ids ) {
+			$existing               = isset( $a[ $type ][ $action ] ) ? (array) $a[ $type ][ $action ] : array();
+			$a[ $type ][ $action ] = array_values( array_unique( array_merge( $existing, array_map( 'intval', (array) $ids ) ) ) );
+		}
+	}
+	return $a;
+}
+
+/**
+ * Transient key of the redirect-surviving changelog buffer for a user.
+ *
+ * @since 0.9.7
+ *
+ * @param int $user_id User id.
+ * @return string
+ */
+function desktop_mode_content_changes_buffer_key( $user_id ) {
+	return 'desktop_mode_content_buf_' . (int) $user_id;
+}
+
+/**
+ * `wp_after_insert_post` handler — posts, pages, and every `show_ui`
+ * custom post type.
+ *
+ * `wp_after_insert_post` (not `save_post`) so terms and meta are
+ * already persisted when subscribers refetch. Trash-status writes are
+ * skipped — the Recycle Bin hooks own the trash verbs and record them
+ * first (`wp_trash_post` fires before the internal status update
+ * reaches this hook).
+ *
+ * Post types without `show_ui` are skipped: they have no list screen
+ * to refresh, and internal types (notes, …) run their own realtime.
+ * Plugins that want one tracked anyway can call
+ * `desktop_mode_content_changes_record()` from their own hooks.
+ *
+ * @since 0.9.7
+ *
+ * @param int          $post_id     Post id.
+ * @param WP_Post      $post        Saved post.
+ * @param bool         $update      Whether this is an update.
+ * @param WP_Post|null $post_before Pre-save post, null on creation.
+ */
+function desktop_mode_content_changes_on_after_insert_post( $post_id, $post, $update, $post_before ) {
+	if ( ! $post instanceof WP_Post ) {
+		return;
+	}
+	if ( wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
+		return;
+	}
+	if ( function_exists( 'wp_doing_autosave' ) && wp_doing_autosave() ) {
+		return;
+	}
+	if ( in_array( $post->post_status, array( 'auto-draft', 'trash' ), true ) ) {
+		return;
+	}
+	$post_type_object = get_post_type_object( $post->post_type );
+	if ( ! $post_type_object || empty( $post_type_object->show_ui ) ) {
+		return;
+	}
+
+	// The first real save of a new post arrives as an "update" of the
+	// auto-draft shell `post-new.php` created — report it as created.
+	$is_created = ! $update || ( $post_before instanceof WP_Post && 'auto-draft' === $post_before->post_status );
+
+	desktop_mode_content_changes_record( $post->post_type, (int) $post_id, $is_created ? 'created' : 'updated' );
+}
+
+/**
+ * `transition_comment_status` handler.
+ *
+ * Trash transitions are skipped in both directions: the Recycle Bin's
+ * `trashed_comment` / `untrashed_comment` hooks record those verbs,
+ * and they fire AFTER the transition — without the skip the dedupe
+ * set would keep this handler's less-specific `updated`.
+ *
+ * @since 0.9.7
+ *
+ * @param string     $new_status New comment status.
+ * @param string     $old_status Old comment status.
+ * @param WP_Comment $comment    Comment object.
+ */
+function desktop_mode_content_changes_on_comment_transition( $new_status, $old_status, $comment ) {
+	if ( 'trash' === $new_status || 'trash' === $old_status ) {
+		return;
+	}
+	if ( ! $comment instanceof WP_Comment ) {
+		return;
+	}
+	desktop_mode_content_changes_record( 'comment', (int) $comment->comment_ID, 'updated' );
+}
+
+/**
+ * Wires the WooCommerce order hooks. No-op unless WooCommerce is
+ * active.
+ *
+ * The `woocommerce_*` family is required for HPOS, where orders live
+ * in custom tables and none of the post hooks fire. Under legacy
+ * (posts-table) storage the post hooks fire too; the recorder's
+ * per-request dedupe collapses the double-fire. The type is always
+ * recorded as `shop_order` so one broadcast topic
+ * (`desktop-mode.shop_order.changed`) serves both storage modes.
+ *
+ * @since 0.9.7
+ *
+ * @return bool Whether the hooks were registered.
+ */
+function desktop_mode_content_changes_register_wc_hooks() {
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'wc_get_order' ) ) {
+		return false;
+	}
+
+	add_action( 'woocommerce_new_order', function ( $order_id ) {
+		desktop_mode_content_changes_record( 'shop_order', (int) $order_id, 'created' );
+	} );
+	add_action( 'woocommerce_update_order', function ( $order_id ) {
+		desktop_mode_content_changes_record( 'shop_order', (int) $order_id, 'updated' );
+	} );
+	// Some AJAX status-flip paths reach `woocommerce_order_status_changed`
+	// without `woocommerce_update_order`; the dedupe set absorbs the
+	// overlap when both fire.
+	add_action( 'woocommerce_order_status_changed', function ( $order_id ) {
+		desktop_mode_content_changes_record( 'shop_order', (int) $order_id, 'updated' );
+	} );
+	add_action( 'woocommerce_trash_order', function ( $order_id ) {
+		desktop_mode_content_changes_record( 'shop_order', (int) $order_id, 'trashed' );
+	} );
+	add_action( 'woocommerce_untrash_order', function ( $order_id ) {
+		desktop_mode_content_changes_record( 'shop_order', (int) $order_id, 'untrashed' );
+	} );
+	add_action( 'woocommerce_delete_order', function ( $order_id ) {
+		desktop_mode_content_changes_record( 'shop_order', (int) $order_id, 'deleted' );
+	} );
+
+	return true;
+}
+
+/**
+ * Emits the chromeless-footer broadcast script.
+ *
+ * Merges the in-memory changelog with the redirect-surviving buffer
+ * (consumed on read), builds one broadcast envelope per
+ * `[ type ][ action ]`, and prints one inline script that postMessages
+ * each to the parent shell. The parent's broadcast receiver fans them
+ * out as `desktop-mode.<type>.changed` — iframe list pages soft-reload
+ * and native list windows refetch.
+ *
+ * Runs at `admin_footer` priority 100, same slot as the Recycle Bin's
+ * bin-specific ts signal.
+ *
+ * @since 0.9.7
+ */
+function desktop_mode_content_changes_emit_footer() {
+	if ( ! function_exists( 'desktop_mode_is_chromeless_request' ) || ! desktop_mode_is_chromeless_request() ) {
+		return;
+	}
+
+	$state = &desktop_mode_content_changes_state();
+	$log   = $state['log'];
+
+	$user_id = get_current_user_id();
+	if ( $user_id > 0 ) {
+		$key      = desktop_mode_content_changes_buffer_key( $user_id );
+		$buffered = get_transient( $key );
+		if ( is_array( $buffered ) && ! empty( $buffered ) ) {
+			delete_transient( $key );
+			$log = desktop_mode_content_changes_merge( $buffered, $log );
+		}
+	}
+
+	// The in-memory log is consumed regardless of whether anything is
+	// emitted — the shutdown handler must not re-buffer what the
+	// footer already had the chance to flush.
+	$state['flushed'] = true;
+
+	if ( empty( $log ) ) {
+		return;
+	}
+
+	$broadcasts = array();
+	foreach ( $log as $type => $by_action ) {
+		foreach ( $by_action as $action => $ids ) {
+			/**
+			 * Filters the broadcast topic for a content-change type.
+			 *
+			 * @since 0.9.7
+			 *
+			 * @param string $topic  Default `desktop-mode.<type>.changed`.
+			 * @param string $type   Content type slug.
+			 * @param string $action Verb for this envelope.
+			 */
+			$topic = (string) apply_filters( 'desktop_mode_content_change_topic', 'desktop-mode.' . $type . '.changed', $type, $action );
+
+			$broadcasts[] = array(
+				'topic'   => $topic,
+				'payload' => array(
+					'source' => 'admin',
+					'action' => (string) $action,
+					'ids'    => array_values( array_unique( array_map( 'intval', (array) $ids ) ) ),
+				),
+			);
+		}
+	}
+
+	/**
+	 * Filters the full set of content-change broadcast envelopes just
+	 * before the chromeless footer emits them.
+	 *
+	 * Each entry is `array( 'topic' => string, 'payload' => array )`.
+	 * Return an empty array to suppress the emit.
+	 *
+	 * @since 0.9.7
+	 *
+	 * @param array $broadcasts Broadcast envelopes.
+	 */
+	$broadcasts = (array) apply_filters( 'desktop_mode_content_changes_broadcasts', $broadcasts );
+	if ( empty( $broadcasts ) ) {
+		return;
+	}
+
+	$broadcasts_json = wp_json_encode( array_values( $broadcasts ) );
+	if ( ! $broadcasts_json ) {
+		return;
+	}
+
+	?>
+	<script id="desktop-mode-content-changes-signal">
+		( function () {
+			if ( window.parent === window ) {
+				return;
+			}
+			var origin = window.location.origin;
+			var broadcasts = <?php echo $broadcasts_json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode output. ?>;
+			for ( var i = 0; i < broadcasts.length; i++ ) {
+				try {
+					window.parent.postMessage( {
+						type: 'desktop-mode-broadcast',
+						topic: broadcasts[ i ].topic,
+						payload: broadcasts[ i ].payload
+					}, origin );
+				} catch ( _err ) { /* parent gone */ }
+			}
+		} )();
+	</script>
+	<?php
+
+	/**
+	 * Fires after the chromeless footer emitted the content-change
+	 * broadcast envelopes.
+	 *
+	 * @since 0.9.7
+	 *
+	 * @param array $broadcasts Emitted broadcast envelopes.
+	 */
+	do_action( 'desktop_mode_content_changes_emitted', $broadcasts );
+}
+
+/**
+ * `shutdown` handler — persists the heartbeat changelog and buffers
+ * an unflushed in-request changelog across the coming redirect.
+ *
+ * One `update_option` per mutating request; requests that recorded
+ * nothing pay a static-array read and return.
+ *
+ * @since 0.9.7
+ */
+function desktop_mode_content_changes_on_shutdown() {
+	$state = &desktop_mode_content_changes_state();
+
+	if ( ! empty( $state['staged'] ) ) {
+		$now = (int) round( microtime( true ) * 1000 );
+
+		// Group staged rows into per-[type][action] heartbeat entries.
+		$grouped = array();
+		foreach ( $state['staged'] as $row ) {
+			$grouped[ $row['type'] . '|' . $row['action'] ][] = (int) $row['id'];
+		}
+
+		$log     = get_option( DESKTOP_MODE_CONTENT_CHANGES_LOG_OPTION, array() );
+		$entries = ( is_array( $log ) && isset( $log['entries'] ) && is_array( $log['entries'] ) ) ? $log['entries'] : array();
+
+		foreach ( $grouped as $group_key => $ids ) {
+			list( $type, $action ) = explode( '|', $group_key, 2 );
+			$entries[]             = array(
+				'ts'     => $now,
+				'type'   => $type,
+				'action' => $action,
+				'ids'    => array_values( array_unique( $ids ) ),
+			);
+		}
+
+		// Prune: drop entries older than the retention window, cap the
+		// tail. The option stays small no matter how chatty the site.
+		$cutoff  = $now - DESKTOP_MODE_CONTENT_CHANGES_LOG_WINDOW_MS;
+		$entries = array_values( array_filter( $entries, function ( $entry ) use ( $cutoff ) {
+			return isset( $entry['ts'] ) && (int) $entry['ts'] >= $cutoff;
+		} ) );
+		if ( count( $entries ) > DESKTOP_MODE_CONTENT_CHANGES_LOG_MAX ) {
+			$entries = array_slice( $entries, -DESKTOP_MODE_CONTENT_CHANGES_LOG_MAX );
+		}
+
+		update_option(
+			DESKTOP_MODE_CONTENT_CHANGES_LOG_OPTION,
+			array(
+				'ts'      => $now,
+				'entries' => $entries,
+			),
+			false
+		);
+	}
+
+	if ( $state['flushed'] || empty( $state['log'] ) ) {
+		return;
+	}
+	$user_id = get_current_user_id();
+	if ( $user_id <= 0 ) {
+		return;
+	}
+
+	$key      = desktop_mode_content_changes_buffer_key( $user_id );
+	$existing = get_transient( $key );
+	$merged   = desktop_mode_content_changes_merge( is_array( $existing ) ? $existing : array(), $state['log'] );
+	set_transient( $key, $merged, DESKTOP_MODE_CONTENT_CHANGES_BUFFER_TTL );
+}
+
+/**
+ * Heartbeat handler — answers "which content changed since you last
+ * heard from me?".
+ *
+ * Opt-in via the client-sent `desktop_mode_content_changes_seen_ts`
+ * key; requests without it early-return so non-desktop tabs pay zero
+ * per tick. The response carries the server high-water mark plus the
+ * entries newer than the client's seen ts; the shell re-broadcasts
+ * each as `desktop-mode.<type>.changed`.
+ *
+ * @since 0.9.7
+ *
+ * @param array $response Heartbeat response.
+ * @param array $data     Client-sent payload.
+ * @return array
+ */
+function desktop_mode_content_changes_heartbeat_received( $response, $data ) {
+	if ( ! is_array( $response ) ) {
+		$response = array();
+	}
+	if ( ! isset( $data['desktop_mode_content_changes_seen_ts'] ) ) {
+		return $response;
+	}
+
+	$seen = (int) $data['desktop_mode_content_changes_seen_ts'];
+	$log  = get_option( DESKTOP_MODE_CONTENT_CHANGES_LOG_OPTION, array() );
+
+	$ts      = ( is_array( $log ) && isset( $log['ts'] ) ) ? (int) $log['ts'] : 0;
+	$entries = ( is_array( $log ) && isset( $log['entries'] ) && is_array( $log['entries'] ) ) ? $log['entries'] : array();
+
+	$fresh = array();
+	foreach ( $entries as $entry ) {
+		if ( isset( $entry['ts'] ) && (int) $entry['ts'] > $seen ) {
+			$fresh[] = $entry;
+		}
+	}
+
+	$response['desktop_mode_content_changes'] = array(
+		'ts'      => $ts,
+		'entries' => $fresh,
+	);
+
+	return $response;
+}
+
+/**
+ * Wires every content-change hook.
+ *
+ * One bootstrap so the wiring is auditable —
+ * `grep desktop_mode_content_changes_record` finds every emitter.
+ *
+ * @since 0.9.7
+ */
+function desktop_mode_content_changes_register_hooks() {
+	add_action( 'wp_after_insert_post', 'desktop_mode_content_changes_on_after_insert_post', 10, 4 );
+
+	add_action( 'wp_insert_comment', function ( $comment_id ) {
+		desktop_mode_content_changes_record( 'comment', (int) $comment_id, 'created' );
+	} );
+	add_action( 'edit_comment', function ( $comment_id ) {
+		desktop_mode_content_changes_record( 'comment', (int) $comment_id, 'updated' );
+	} );
+	add_action( 'transition_comment_status', 'desktop_mode_content_changes_on_comment_transition', 10, 3 );
+
+	desktop_mode_content_changes_register_wc_hooks();
+
+	add_action( 'admin_footer', 'desktop_mode_content_changes_emit_footer', 100 );
+	add_action( 'shutdown', 'desktop_mode_content_changes_on_shutdown' );
+	add_filter( 'heartbeat_received', 'desktop_mode_content_changes_heartbeat_received', 10, 2 );
+}
+add_action( 'init', 'desktop_mode_content_changes_register_hooks', 5 );

--- a/includes/recycle-bin/realtime.php
+++ b/includes/recycle-bin/realtime.php
@@ -13,7 +13,10 @@
  *      `postMessage`s the parent shell with `type:
  *      'desktop-mode-recycle-bin-changed'`. The parent dispatches our
  *      `CustomEvent`, the open window refreshes. Cost: ~zero unless
- *      a delete actually happened in this request.
+ *      a delete actually happened in this request. The per-domain
+ *      `desktop-mode.<type>.changed` list-refresh broadcasts ride the
+ *      generic content-changes emitter instead (the changelog below
+ *      delegates into `includes/content-changes.php` since 0.9.7).
  *
  *   2. **Catch-all path — Heartbeat**
  *      Every delete also bumps a single autoload=false option
@@ -114,11 +117,18 @@ function desktop_mode_recycle_bin_signal_change_for_post( $post_id, $action = 't
 /**
  * Per-request changelog: `[ post_type ][ action ] = int[] ids`.
  *
- * Reads when called without args; mutates when called with a
- * post_type. Static-store pattern, same shape as the dirty
- * helper above so test introspection is symmetric.
+ * Thin wrapper over the generic content-changes recorder
+ * (`includes/content-changes.php`) — since 0.9.7 the generic module
+ * owns the changelog AND the per-domain `desktop-mode.<type>.changed`
+ * footer broadcasts, so a trash and a save flow through one emitter.
+ * The wrapper is kept because the recycle-bin hook wiring below and
+ * third-party code grep for it.
+ *
+ * Reads when called without args; records when called with a
+ * post_type.
  *
  * @since 0.6.0
+ * @since 0.9.7 Delegates to `desktop_mode_content_changes_record()`.
  *
  * @param string $post_type Optional. Mutate this domain.
  * @param int    $post_id   Optional. Id to record.
@@ -126,19 +136,10 @@ function desktop_mode_recycle_bin_signal_change_for_post( $post_id, $action = 't
  * @return array Full changelog when called with no args.
  */
 function desktop_mode_recycle_bin_record_change( $post_type = '', $post_id = 0, $action = '' ) {
-	static $log = array();
-
-	if ( '' === $post_type ) {
-		return $log;
+	if ( '' !== $post_type ) {
+		desktop_mode_content_changes_record( (string) $post_type, (int) $post_id, (string) $action );
 	}
-	if ( ! isset( $log[ $post_type ] ) ) {
-		$log[ $post_type ] = array();
-	}
-	if ( ! isset( $log[ $post_type ][ $action ] ) ) {
-		$log[ $post_type ][ $action ] = array();
-	}
-	$log[ $post_type ][ $action ][] = (int) $post_id;
-	return $log;
+	return desktop_mode_content_changes_log();
 }
 
 /**
@@ -200,41 +201,26 @@ function desktop_mode_recycle_bin_emit_footer_signal() {
 		return;
 	}
 
-	$ts        = (int) get_option( DESKTOP_MODE_RECYCLE_BIN_CHANGE_OPTION, 0 );
-	$changelog = desktop_mode_recycle_bin_record_change();
+	$ts = (int) get_option( DESKTOP_MODE_RECYCLE_BIN_CHANGE_OPTION, 0 );
 
-	if ( $ts <= 0 && empty( $changelog ) ) {
+	if ( $ts <= 0 ) {
 		// Nothing has ever been trashed via this site — no point
 		// teaching the parent shell about a 0 high-water mark.
 		return;
 	}
 
-	// Per-domain broadcast envelope: one entry per affected
-	// post_type, with verb-keyed id lists. The parent shell's
-	// `installBroadcastReceiver` translates each into a
-	// `desktop-mode.<post_type>.changed` broadcast — the bin (and
-	// any plugin that subscribes to that exact topic) reacts.
-	$broadcasts = array();
-	foreach ( $changelog as $post_type => $by_action ) {
-		foreach ( $by_action as $action => $ids ) {
-			$broadcasts[] = array(
-				'topic'   => 'desktop-mode.' . $post_type . '.changed',
-				'payload' => array(
-					'source' => 'admin',
-					'action' => (string) $action,
-					'ids'    => array_values( array_unique( array_map( 'intval', $ids ) ) ),
-				),
-			);
-		}
-	}
-	$broadcasts_json = wp_json_encode( $broadcasts );
+	// Only the bin-specific ts signal is emitted here. The per-domain
+	// `desktop-mode.<post_type>.changed` broadcasts moved to the
+	// generic content-changes emitter (`includes/content-changes.php`,
+	// same `admin_footer` slot) — the bin's changelog delegates into
+	// it, so a trash and a save flow through one emitter and each
+	// type/action pair is broadcast exactly once per render.
 	?>
 	<script id="desktop-mode-recycle-bin-realtime-signal">
 		( function () {
 			if ( window.parent === window ) {
 				return;
 			}
-			var origin = window.location.origin;
 			try {
 				window.parent.postMessage(
 					{
@@ -242,28 +228,9 @@ function desktop_mode_recycle_bin_emit_footer_signal() {
 						ts: <?php echo (int) $ts; ?>,
 						source: 'chromeless'
 					},
-					origin
+					window.location.origin
 				);
 			} catch ( _err ) { /* swallow */ }
-
-			/*
-			 * Per-domain broadcast envelopes — one postMessage per
-			 * affected post type. The parent shell's broadcast
-			 * receiver fans these out as `desktop-mode.<type>.changed`
-			 * subscriptions. Only emitted when the request actually
-			 * mutated something: a no-op chromeless render skips this
-			 * branch entirely.
-			 */
-			var broadcasts = <?php echo $broadcasts_json ? $broadcasts_json : '[]'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-			for ( var i = 0; i < broadcasts.length; i++ ) {
-				try {
-					window.parent.postMessage( {
-						type: 'desktop-mode-broadcast',
-						topic: broadcasts[ i ].topic,
-						payload: broadcasts[ i ].payload
-					}, origin );
-				} catch ( _err ) { /* swallow */ }
-			}
 		} )();
 	</script>
 	<?php

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -391,11 +391,20 @@ function desktop_mode_chromeless_bridge_script() {
 				return;
 			}
 			var wasSaving = false;
+			var wasNew = false;
 			var inFlight = false;
 			wpg.data.subscribe( function () {
 				var saving =
 					editor.isSavingPost() &&
 					! ( editor.isAutosavingPost && editor.isAutosavingPost() );
+				if ( saving && ! wasSaving ) {
+					// Capture "is this the first real save?" on the tick
+					// where saving STARTS — after the save completes the
+					// post is no longer new and the flag reads false.
+					wasNew = !! (
+						editor.isEditedPostNew && editor.isEditedPostNew()
+					);
+				}
 				var finished = wasSaving && ! saving;
 				wasSaving = saving;
 				if ( ! finished || inFlight ) {
@@ -410,6 +419,35 @@ function desktop_mode_chromeless_bridge_script() {
 				var postId = editor.getCurrentPostId();
 				if ( ! postId ) {
 					return;
+				}
+
+				/*
+				 * Announce the save as a cross-window content-change
+				 * broadcast. Gutenberg saves over REST with no
+				 * navigation, so the server-side chromeless-footer
+				 * emitter (includes/content-changes.php) never runs
+				 * here — this is the only instant path for block-editor
+				 * saves. The parent's broadcast receiver fans it out;
+				 * list windows showing this post type refresh.
+				 */
+				if ( editor.getCurrentPostType ) {
+					try {
+						window.parent.postMessage(
+							{
+								type: 'desktop-mode-broadcast',
+								topic:
+									'desktop-mode.' +
+									editor.getCurrentPostType() +
+									'.changed',
+								payload: {
+									source: 'editor',
+									action: wasNew ? 'created' : 'updated',
+									ids: [ postId ],
+								},
+							},
+							window.location.origin
+						);
+					} catch ( _err ) { /* parent gone */ }
 				}
 				inFlight = true;
 				wpg
@@ -2321,11 +2359,22 @@ function desktop_mode_chromeless_bridge_script() {
 	 * post appears, deleted media disappears — without the WP loading
 	 * spinner that `location.reload()` would show.
 	 *
-	 * Single-edit pages (`post.php`, `post-new.php`) are deliberately
-	 * NOT in the rule set: replacing their body would destroy any
-	 * unsaved Gutenberg/classic-editor state. Plugins that want
-	 * specific behaviour for those pages can subscribe to the same
-	 * topic on `document` and handle it themselves.
+	 * Single-edit pages (`post.php`, `post-new.php`, the HPOS order
+	 * editor) are deliberately NOT matched: replacing their body would
+	 * destroy any unsaved Gutenberg/classic-editor state. Plugins that
+	 * want specific behaviour for those pages can subscribe to the
+	 * same topic on `document` and handle it themselves.
+	 *
+	 * Matching is generic: the current page's "list type" is derived
+	 * from the URL (`edit.php` → its `post_type` param or `post`,
+	 * `upload.php` → `attachment`, `edit-comments.php` → `comment`)
+	 * and compared against the `<type>` captured from any
+	 * `desktop-mode.<type>.changed` topic — so every custom post
+	 * type's `edit.php?post_type=X` screen participates with zero
+	 * per-type code. Non-`edit.php` list screens (e.g. WooCommerce's
+	 * HPOS `admin.php?page=wc-orders`) are covered by declarative
+	 * extra rules, filterable server-side via
+	 * `desktop_mode_soft_reload_rules`.
 	 *
 	 * The fetch carries a custom header so a later phase can serve a
 	 * minimal partial response if we want to optimise; for now WP
@@ -2336,37 +2385,64 @@ function desktop_mode_chromeless_bridge_script() {
 	 * a swap (e.g. inline-edit double-binding), that page's plugin
 	 * should listen for `desktop-mode-soft-reloaded` and rebind.
 	 * ----------------------------------------------------------------- */
-	var DESKTOP_MODE_SOFT_RELOAD_RULES = [
-		{
-			topic: 'desktop-mode.post.changed',
-			match: function () {
-				if ( ! _desktop_modeEndsWith( location.pathname, '/wp-admin/edit.php' ) ) return false;
-				var t = new URLSearchParams( location.search ).get( 'post_type' );
-				return t === null || t === 'post';
-			}
-		},
-		{
-			topic: 'desktop-mode.page.changed',
-			match: function () {
-				if ( ! _desktop_modeEndsWith( location.pathname, '/wp-admin/edit.php' ) ) return false;
-				return new URLSearchParams( location.search ).get( 'post_type' ) === 'page';
-			}
-		},
-		{
-			topic: 'desktop-mode.attachment.changed',
-			match: function () {
-				return _desktop_modeEndsWith( location.pathname, '/wp-admin/upload.php' );
-			}
-		},
-		{
-			topic: 'desktop-mode.comment.changed',
-			match: function () {
-				return _desktop_modeEndsWith( location.pathname, '/wp-admin/edit-comments.php' );
-			}
-		}
-	];
+	var DESKTOP_MODE_SOFT_RELOAD_EXTRAS = /*__DESKTOP_MODE_SOFT_RELOAD_EXTRAS__*/;
 
 	function _desktop_modeEndsWith( s, suffix ) { return s.lastIndexOf( suffix ) === s.length - suffix.length; }
+
+	function _desktop_modeListType() {
+		if ( _desktop_modeEndsWith( location.pathname, '/wp-admin/edit.php' ) ) {
+			return new URLSearchParams( location.search ).get( 'post_type' ) || 'post';
+		}
+		if ( _desktop_modeEndsWith( location.pathname, '/wp-admin/upload.php' ) ) {
+			return 'attachment';
+		}
+		if ( _desktop_modeEndsWith( location.pathname, '/wp-admin/edit-comments.php' ) ) {
+			return 'comment';
+		}
+		return null;
+	}
+
+	function _desktop_modeMatchesExtraRule( rule ) {
+		if ( ! rule || ! rule.path ) {
+			return false;
+		}
+		if ( ! _desktop_modeEndsWith( location.pathname, '/wp-admin/' + rule.path ) ) {
+			return false;
+		}
+		var params = new URLSearchParams( location.search );
+		if ( rule.query ) {
+			for ( var key in rule.query ) {
+				if ( ! Object.prototype.hasOwnProperty.call( rule.query, key ) ) {
+					continue;
+				}
+				if ( params.get( key ) !== String( rule.query[ key ] ) ) {
+					return false;
+				}
+			}
+		}
+		if ( rule.queryAbsent ) {
+			for ( var i = 0; i < rule.queryAbsent.length; i++ ) {
+				if ( params.has( rule.queryAbsent[ i ] ) ) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	function _desktop_modeSoftReloadTopicMatches( topic ) {
+		var m = /^desktop-mode\.(.+)\.changed$/.exec( topic );
+		if ( m && m[ 1 ] === _desktop_modeListType() ) {
+			return true;
+		}
+		for ( var i = 0; i < DESKTOP_MODE_SOFT_RELOAD_EXTRAS.length; i++ ) {
+			var rule = DESKTOP_MODE_SOFT_RELOAD_EXTRAS[ i ];
+			if ( rule && rule.topic === topic && _desktop_modeMatchesExtraRule( rule ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	var _desktop_modeSoftReloadInFlight = false;
 	var _desktop_modeSoftReloadQueued = false;
@@ -2423,12 +2499,8 @@ function desktop_mode_chromeless_bridge_script() {
 		var detail = e.detail || {};
 		var topic = detail.topic;
 		if ( ! topic ) return;
-		for ( var i = 0; i < DESKTOP_MODE_SOFT_RELOAD_RULES.length; i++ ) {
-			var r = DESKTOP_MODE_SOFT_RELOAD_RULES[ i ];
-			if ( r.topic === topic && r.match() ) {
-				_desktop_modeSoftReload();
-				return;
-			}
+		if ( _desktop_modeSoftReloadTopicMatches( topic ) ) {
+			_desktop_modeSoftReload();
 		}
 	} );
 
@@ -3045,6 +3117,50 @@ JS;
 		}
 	}
 
+	// Declarative soft-reload rules for list screens that are NOT a
+	// standard `edit.php?post_type=<type>` / `upload.php` /
+	// `edit-comments.php` page (those are matched generically in the
+	// bridge script). Rule shape:
+	//   - `topic`       — the `desktop-mode.<type>.changed` topic.
+	//   - `path`        — wp-admin filename (`admin.php`).
+	//   - `query`       — required query params (exact match).
+	//   - `queryAbsent` — params that must NOT be present.
+	//
+	// The default rule covers WooCommerce's HPOS orders list.
+	// `queryAbsent: [ 'action' ]` is load-bearing: with `&action=edit`
+	// the same path is the single-order EDITOR, which must keep the
+	// single-edit exclusion (a soft reload would destroy unsaved
+	// order state). Shipped unconditionally — when WooCommerce is
+	// absent the URL never renders and the rule is inert.
+	$soft_reload_rules = array(
+		array(
+			'topic'       => 'desktop-mode.shop_order.changed',
+			'path'        => 'admin.php',
+			'query'       => array( 'page' => 'wc-orders' ),
+			'queryAbsent' => array( 'action' ),
+		),
+	);
+
+	/**
+	 * Filters the declarative soft-reload rules injected into every
+	 * chromeless iframe.
+	 *
+	 * Lets a plugin whose list screen lives on a custom admin URL
+	 * participate in cross-window refresh: pair a rule here with
+	 * `desktop_mode_content_changes_record()` calls (or your own
+	 * `desktop-mode.<type>.changed` broadcasts) on the publish side.
+	 *
+	 * @since 0.9.7
+	 *
+	 * @param array $soft_reload_rules Rule arrays with keys `topic`,
+	 *                                 `path`, `query`, `queryAbsent`.
+	 */
+	$soft_reload_rules = (array) apply_filters( 'desktop_mode_soft_reload_rules', $soft_reload_rules );
+	$soft_reload_json  = wp_json_encode( array_values( $soft_reload_rules ) );
+	if ( ! $soft_reload_json ) {
+		$soft_reload_json = '[]';
+	}
+
 	// Substitute the server-built menu payload into the bridge
 	// script. `wp_json_encode` guarantees safe JSON output — no need
 	// for an additional escape pass. When the page isn't on our
@@ -3053,6 +3169,7 @@ JS;
 	$js = str_replace( '/*__DESKTOP_MODE_MENU_PAYLOAD__*/', $menu_payload_json, $js );
 	$js = str_replace( '/*__DESKTOP_MODE_MENU_SIG__*/', $menu_sig_json, $js );
 	$js = str_replace( '/*__DESKTOP_MODE_CONTENT_IDENTITY__*/', $content_identity_json, $js );
+	$js = str_replace( '/*__DESKTOP_MODE_SOFT_RELOAD_EXTRAS__*/', $soft_reload_json, $js );
 
 	wp_print_inline_script_tag( $js );
 }

--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -94,6 +94,10 @@ interface ShellApi {
 	activity?: {
 		publish?: ( channel: string, payload: unknown ) => void;
 	};
+	subscribe?: (
+		topic: string,
+		cb: ( payload: unknown ) => void,
+	) => () => void;
 	ai?: {
 		ask?: ( prompt: string ) => Promise< { answer: string } >;
 	};
@@ -763,6 +767,33 @@ async function renderCommentsWindow( body: HTMLElement ): Promise< void > {
 	countsTimer = window.setInterval( pollCounts, 30000 );
 	void pollCounts();
 
+	// Realtime: cross-window broadcast. Any comment mutation elsewhere
+	// (an edit-comments.php iframe, a post's discussion box, the
+	// recycle bin, another user via the heartbeat catch-all) fires
+	// `desktop-mode.comment.changed` — refresh the active panel
+	// directly instead of showing the "reload" pill; the pill/count
+	// poller stays as the fallback for anything the broadcast misses.
+	let unsubBroadcast: ( () => void ) | null = null;
+	{
+		const api = getApi();
+		if ( typeof api?.subscribe === 'function' ) {
+			unsubBroadcast = api.subscribe(
+				'desktop-mode.comment.changed',
+				() => {
+					void refresh( activeTab, { force: true } ).then( () => {
+						if ( activeTab === 'pending' ) {
+							// The refreshed list already shows the new
+							// state — re-baseline so the next counts
+							// poll doesn't offer a stale "reload" pill.
+							lastSeenPending = panels.pending.total;
+							newPillEl.hidden = true;
+						}
+					} );
+				},
+			);
+		}
+	}
+
 	// Keyboard moderation
 	const onKey = ( e: KeyboardEvent ): void => {
 		const ownerDoc = body.ownerDocument;
@@ -899,6 +930,12 @@ async function renderCommentsWindow( body: HTMLElement ): Promise< void > {
 			window.clearInterval( countsTimer );
 			countsTimer = null;
 		}
+		try {
+			unsubBroadcast?.();
+		} catch {
+			/* swallow */
+		}
+		unsubBroadcast = null;
 		document.removeEventListener( 'keydown', onKey );
 		document.removeEventListener( 'desktop-mode-window-closed', onClosed );
 		setActiveConfig( null );

--- a/src/content-changes/heartbeat.ts
+++ b/src/content-changes/heartbeat.ts
@@ -1,0 +1,115 @@
+/**
+ * Content-changes Heartbeat catch-all.
+ *
+ * The chromeless-footer fast path (`includes/content-changes.php`)
+ * and the block-editor save-watcher only cover mutations that happen
+ * inside this tab's iframes AND produce either a footer render or a
+ * `core/editor` save. Everything else — Quick Edit, list-table AJAX
+ * moderation, WooCommerce AJAX status flips, REST/WP-CLI mutations,
+ * other browser tabs, other users — reaches the shell through this
+ * module: the server appends every recorded change to a pruned
+ * changelog option, and each Heartbeat tick answers "entries newer
+ * than your seen ts". Fresh entries are re-broadcast on the bus as
+ * `desktop-mode.<type>.changed`, so the same consumers (iframe
+ * soft-reload, native list windows) refresh within one tick
+ * (15–60 s) with zero extra plumbing.
+ *
+ * Timestamps are SERVER milliseconds. The first tick is a pure
+ * handshake: it sends `seenTs: 0`, adopts the server's high-water
+ * mark, and broadcasts nothing — comparing a client `Date.now()`
+ * against server timestamps would silently drop changes whenever the
+ * clocks disagree (a change recorded "before" a skewed client boot
+ * time is never re-broadcast). Changes older than the first tick are
+ * assumed already delivered via the fast paths.
+ *
+ * Accepted redundancy: a change that already arrived via the footer
+ * or editor path is re-broadcast once on the next tick (the bus has
+ * no per-change identity to dedupe on). Consumers are idempotent —
+ * the cost is one extra refresh fetch per change.
+ *
+ * @since 0.9.7
+ */
+
+import { broadcast } from '../broadcast';
+import { heartbeat } from '../heartbeat';
+
+interface ContentChangeEntry {
+	ts: number;
+	type: string;
+	action: string;
+	ids: number[];
+}
+
+interface ContentChangesBlock {
+	ts: number;
+	entries: ContentChangeEntry[];
+}
+
+/**
+ * Server-clock high-water mark of processed entries. `null` until
+ * the handshake tick adopts the server's mark.
+ */
+let seenTs: number | null = null;
+
+/**
+ * Wire the content-changes Heartbeat channel. Called once by
+ * `desktop.ts` after `bootHeartbeatBus()`.
+ *
+ * @internal
+ */
+export function bootContentChangesHeartbeat(): void {
+	heartbeat.contribute( 'desktop_mode_content_changes_seen_ts', () =>
+		seenTs === null ? 0 : seenTs,
+	);
+
+	heartbeat.subscribe< ContentChangesBlock >(
+		'desktop_mode_content_changes',
+		( block ) => {
+			if ( ! block || typeof block.ts !== 'number' ) {
+				return;
+			}
+
+			const handshake = seenTs === null;
+			const floor = seenTs ?? 0;
+			let maxTs = Math.max( floor, block.ts );
+
+			if ( ! handshake && Array.isArray( block.entries ) ) {
+				for ( const entry of block.entries ) {
+					if (
+						! entry ||
+						typeof entry.ts !== 'number' ||
+						entry.ts <= floor ||
+						typeof entry.type !== 'string' ||
+						entry.type === ''
+					) {
+						continue;
+					}
+					broadcast( `desktop-mode.${ entry.type }.changed`, {
+						source: 'heartbeat',
+						action:
+							typeof entry.action === 'string' && entry.action !== ''
+								? entry.action
+								: 'updated',
+						ids: Array.isArray( entry.ids )
+							? entry.ids.map( Number ).filter( ( id ) => id > 0 )
+							: [],
+					} );
+					if ( entry.ts > maxTs ) {
+						maxTs = entry.ts;
+					}
+				}
+			}
+
+			seenTs = maxTs;
+		},
+	);
+}
+
+/**
+ * Test-only reset of the high-water mark.
+ *
+ * @internal
+ */
+export function _resetContentChangesHeartbeatForTests(): void {
+	seenTs = null;
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -163,6 +163,7 @@ import {
 } from './presence';
 import { type ActivityApi } from './activity';
 import { bootHeartbeatBus, type HeartbeatBus } from './heartbeat';
+import { bootContentChangesHeartbeat } from './content-changes/heartbeat';
 import { bootNonceRefresh } from './nonce-refresh';
 import { bootAuthRecovery } from './auth-recovery';
 import { bindTopWindowLinkInterceptor } from './boot/link-interceptor';
@@ -3349,6 +3350,13 @@ function init(): void {
 	bootGamesChallenges( {
 		currentUserId: Number( config.currentUserId ) || 0,
 	} );
+
+	// Content-changes catch-all: re-broadcasts server-recorded
+	// mutations (Quick Edit, AJAX status flips, other tabs/users)
+	// as `desktop-mode.<type>.changed` on each Heartbeat tick. Idle
+	// boot is safe — the first tick lands ~15 s after init and the
+	// first tick is a handshake anyway (see the module docblock).
+	scheduleIdleBoot( () => bootContentChangesHeartbeat() );
 
 	// Subscribe to heartbeat-driven nonce refresh so cached
 	// `restNonce` values in `window.desktopModeConfig` and

--- a/tests/phpunit/tests/contentChanges.php
+++ b/tests/phpunit/tests/contentChanges.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * Tests for the generic content-change realtime layer
+ * (includes/content-changes.php): recorder dedupe + gates, post /
+ * comment hook wiring, the redirect-surviving buffer, the chromeless
+ * footer emitter, and the Heartbeat catch-all.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ */
+class Tests_DesktopMode_ContentChanges extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+		desktop_mode_content_changes_reset();
+		delete_option( DESKTOP_MODE_CONTENT_CHANGES_LOG_OPTION );
+		delete_transient( desktop_mode_content_changes_buffer_key( self::$admin_id ) );
+	}
+
+	public function tear_down() {
+		desktop_mode_content_changes_reset();
+		delete_option( DESKTOP_MODE_CONTENT_CHANGES_LOG_OPTION );
+		delete_transient( desktop_mode_content_changes_buffer_key( self::$admin_id ) );
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+		unset( $_GET['desktop_mode_chromeless'] );
+		remove_all_filters( 'desktop_mode_content_changes_should_record' );
+		remove_all_filters( 'desktop_mode_content_changes_broadcasts' );
+		if ( post_type_exists( 'wpd_hidden_cpt' ) ) {
+			unregister_post_type( 'wpd_hidden_cpt' );
+		}
+		if ( post_type_exists( 'wpd_shown_cpt' ) ) {
+			unregister_post_type( 'wpd_shown_cpt' );
+		}
+		parent::tear_down();
+	}
+
+	private function enter_chromeless() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['desktop_mode_chromeless'] = '1';
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Recorder
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * @covers ::desktop_mode_content_changes_record
+	 */
+	public function test_record_rejects_invalid_args() {
+		$this->assertFalse( desktop_mode_content_changes_record( '', 1, 'updated' ) );
+		$this->assertFalse( desktop_mode_content_changes_record( 'post', 0, 'updated' ) );
+		$this->assertFalse( desktop_mode_content_changes_record( 'post', 1, '' ) );
+		$this->assertSame( array(), desktop_mode_content_changes_log() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_record
+	 */
+	public function test_record_dedupes_first_writer_wins() {
+		$this->assertTrue( desktop_mode_content_changes_record( 'post', 9, 'trashed' ) );
+		$this->assertFalse( desktop_mode_content_changes_record( 'post', 9, 'updated' ) );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( 9 ), $log['post']['trashed'] );
+		$this->assertArrayNotHasKey( 'updated', $log['post'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_record
+	 */
+	public function test_should_record_filter_vetoes() {
+		add_filter( 'desktop_mode_content_changes_should_record', '__return_false' );
+		$this->assertFalse( desktop_mode_content_changes_record( 'post', 3, 'updated' ) );
+		$this->assertSame( array(), desktop_mode_content_changes_log() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_record
+	 */
+	public function test_recorded_action_fires() {
+		$seen = array();
+		add_action(
+			'desktop_mode_content_change_recorded',
+			function ( $type, $id, $action ) use ( &$seen ) {
+				$seen[] = array( $type, $id, $action );
+			},
+			10,
+			3
+		);
+
+		desktop_mode_content_changes_record( 'shop_order', 12, 'created' );
+
+		$this->assertSame( array( array( 'shop_order', 12, 'created' ) ), $seen );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Post hooks
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_after_insert_post
+	 */
+	public function test_new_post_records_created() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertContains( $post_id, $log['post']['created'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_after_insert_post
+	 */
+	public function test_updating_a_post_records_updated_and_skips_the_revision() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		desktop_mode_content_changes_reset();
+
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Fresh title',
+			)
+		);
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( $post_id ), $log['post']['updated'] );
+		$this->assertArrayNotHasKey( 'revision', $log );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_after_insert_post
+	 */
+	public function test_first_real_save_of_an_auto_draft_records_created() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Auto Draft',
+				'post_status' => 'auto-draft',
+			)
+		);
+		// The auto-draft shell itself must not be recorded.
+		$this->assertSame( array(), desktop_mode_content_changes_log() );
+
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_title'  => 'Real title',
+				'post_status' => 'draft',
+			)
+		);
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( $post_id ), $log['post']['created'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_after_insert_post
+	 */
+	public function test_post_type_without_show_ui_is_skipped() {
+		register_post_type( 'wpd_hidden_cpt', array( 'show_ui' => false ) );
+
+		self::factory()->post->create( array( 'post_type' => 'wpd_hidden_cpt' ) );
+
+		$this->assertArrayNotHasKey( 'wpd_hidden_cpt', desktop_mode_content_changes_log() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_after_insert_post
+	 */
+	public function test_show_ui_cpt_is_recorded_under_its_own_type() {
+		register_post_type( 'wpd_shown_cpt', array( 'show_ui' => true ) );
+
+		$post_id = self::factory()->post->create( array( 'post_type' => 'wpd_shown_cpt' ) );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertContains( $post_id, $log['wpd_shown_cpt']['created'] );
+	}
+
+	/**
+	 * Trashing must record ONLY the recycle-bin's `trashed` verb — the
+	 * internal status write reaches `wp_after_insert_post` afterwards
+	 * and the first-writer-wins dedupe (plus the trash-status skip)
+	 * must drop it. Proves the recycle-bin delegation end to end.
+	 *
+	 * @covers ::desktop_mode_content_changes_record
+	 * @covers ::desktop_mode_recycle_bin_record_change
+	 */
+	public function test_trash_records_only_the_trashed_verb() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		desktop_mode_content_changes_reset();
+
+		wp_trash_post( $post_id );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( $post_id ), $log['post']['trashed'] );
+		$this->assertArrayNotHasKey( 'updated', $log['post'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_record
+	 * @covers ::desktop_mode_recycle_bin_record_change
+	 */
+	public function test_untrash_records_only_the_untrashed_verb() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_trash_post( $post_id );
+		desktop_mode_content_changes_reset();
+
+		wp_untrash_post( $post_id );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( $post_id ), $log['post']['untrashed'] );
+		$this->assertArrayNotHasKey( 'updated', $log['post'] );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Comment hooks
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_comment_transition
+	 */
+	public function test_new_comment_records_created() {
+		$post_id    = self::factory()->post->create();
+		desktop_mode_content_changes_reset();
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertContains( $comment_id, $log['comment']['created'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_comment_transition
+	 */
+	public function test_approving_a_comment_records_updated() {
+		$post_id    = self::factory()->post->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '0',
+			)
+		);
+		desktop_mode_content_changes_reset();
+
+		wp_set_comment_status( $comment_id, 'approve' );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( $comment_id ), $log['comment']['updated'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_comment_transition
+	 */
+	public function test_trashing_a_comment_records_only_the_trashed_verb() {
+		$post_id    = self::factory()->post->create();
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $post_id ) );
+		desktop_mode_content_changes_reset();
+
+		wp_trash_comment( $comment_id );
+
+		$log = desktop_mode_content_changes_log();
+		$this->assertSame( array( $comment_id ), $log['comment']['trashed'] );
+		$this->assertArrayNotHasKey( 'updated', $log['comment'] );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * WooCommerce guard
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * @covers ::desktop_mode_content_changes_register_wc_hooks
+	 */
+	public function test_wc_hooks_are_not_registered_without_woocommerce() {
+		$this->assertFalse( class_exists( 'WooCommerce' ) );
+		$this->assertFalse( desktop_mode_content_changes_register_wc_hooks() );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Redirect-surviving buffer + footer emitter
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_shutdown
+	 */
+	public function test_shutdown_buffers_an_unflushed_changelog() {
+		desktop_mode_content_changes_record( 'post', 5, 'updated' );
+
+		desktop_mode_content_changes_on_shutdown();
+
+		$buffered = get_transient( desktop_mode_content_changes_buffer_key( self::$admin_id ) );
+		$this->assertSame( array( 5 ), $buffered['post']['updated'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_emit_footer
+	 */
+	public function test_footer_emits_broadcasts_and_consumes_the_buffer() {
+		$this->enter_chromeless();
+
+		// Mutating request: record + buffer across the redirect.
+		desktop_mode_content_changes_record( 'shop_order', 12, 'updated' );
+		desktop_mode_content_changes_on_shutdown();
+
+		// Redirect target: fresh request state, footer flushes the buffer.
+		desktop_mode_content_changes_reset();
+		ob_start();
+		desktop_mode_content_changes_emit_footer();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'desktop-mode.shop_order.changed', $html );
+		$this->assertStringContainsString( '"ids":[12]', $html );
+		$this->assertStringContainsString( '"action":"updated"', $html );
+		$this->assertFalse( get_transient( desktop_mode_content_changes_buffer_key( self::$admin_id ) ) );
+
+		// A later chromeless render with nothing new emits nothing.
+		desktop_mode_content_changes_reset();
+		ob_start();
+		desktop_mode_content_changes_emit_footer();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_emit_footer
+	 */
+	public function test_footer_emits_nothing_outside_chromeless() {
+		desktop_mode_content_changes_record( 'post', 7, 'updated' );
+
+		ob_start();
+		desktop_mode_content_changes_emit_footer();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * The footer must consume the in-memory changelog even when it
+	 * emits: shutdown afterwards must not re-buffer what the parent
+	 * shell already received.
+	 *
+	 * @covers ::desktop_mode_content_changes_emit_footer
+	 * @covers ::desktop_mode_content_changes_on_shutdown
+	 */
+	public function test_shutdown_does_not_rebuffer_a_flushed_changelog() {
+		$this->enter_chromeless();
+		desktop_mode_content_changes_record( 'post', 21, 'updated' );
+
+		ob_start();
+		desktop_mode_content_changes_emit_footer();
+		ob_end_clean();
+
+		desktop_mode_content_changes_on_shutdown();
+
+		$this->assertFalse( get_transient( desktop_mode_content_changes_buffer_key( self::$admin_id ) ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_emit_footer
+	 */
+	public function test_broadcasts_filter_can_suppress_the_emit() {
+		$this->enter_chromeless();
+		desktop_mode_content_changes_record( 'post', 8, 'updated' );
+		add_filter( 'desktop_mode_content_changes_broadcasts', '__return_empty_array' );
+
+		ob_start();
+		desktop_mode_content_changes_emit_footer();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Heartbeat catch-all
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * @covers ::desktop_mode_content_changes_heartbeat_received
+	 */
+	public function test_heartbeat_without_opt_in_key_is_untouched() {
+		$response = desktop_mode_content_changes_heartbeat_received( array(), array() );
+		$this->assertArrayNotHasKey( 'desktop_mode_content_changes', $response );
+	}
+
+	/**
+	 * @covers ::desktop_mode_content_changes_on_shutdown
+	 * @covers ::desktop_mode_content_changes_heartbeat_received
+	 */
+	public function test_heartbeat_returns_entries_newer_than_seen_ts() {
+		desktop_mode_content_changes_record( 'page', 33, 'updated' );
+		desktop_mode_content_changes_on_shutdown();
+
+		$response = desktop_mode_content_changes_heartbeat_received(
+			array(),
+			array( 'desktop_mode_content_changes_seen_ts' => 0 )
+		);
+
+		$block = $response['desktop_mode_content_changes'];
+		$this->assertGreaterThan( 0, $block['ts'] );
+		$this->assertCount( 1, $block['entries'] );
+		$this->assertSame( 'page', $block['entries'][0]['type'] );
+		$this->assertSame( 'updated', $block['entries'][0]['action'] );
+		$this->assertSame( array( 33 ), $block['entries'][0]['ids'] );
+
+		// A client already at the high-water mark gets no entries.
+		$caught_up = desktop_mode_content_changes_heartbeat_received(
+			array(),
+			array( 'desktop_mode_content_changes_seen_ts' => $block['ts'] )
+		);
+		$this->assertSame( array(), $caught_up['desktop_mode_content_changes']['entries'] );
+		$this->assertSame( $block['ts'], $caught_up['desktop_mode_content_changes']['ts'] );
+	}
+}

--- a/tests/vitest/content-changes-heartbeat.test.ts
+++ b/tests/vitest/content-changes-heartbeat.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the content-changes Heartbeat catch-all: handshake
+ * semantics, re-broadcast fan-out, high-water-mark advance, and
+ * malformed-entry hygiene.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	bootHeartbeatBus,
+	_resetHeartbeatBusForTests,
+} from '../../src/heartbeat';
+import {
+	bootContentChangesHeartbeat,
+	_resetContentChangesHeartbeatForTests,
+} from '../../src/content-changes/heartbeat';
+import { subscribe } from '../../src/broadcast';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+interface JQueryHandlers {
+	'heartbeat-send'?: ( e: unknown, data: Record< string, unknown > ) => void;
+	'heartbeat-tick'?: (
+		e: unknown,
+		response: Record< string, unknown >,
+	) => void;
+}
+
+function installFakeJQuery(): JQueryHandlers {
+	const handlers: JQueryHandlers = {};
+	( window as unknown as { jQuery: unknown } ).jQuery = (
+		_: Document,
+	): {
+		on: ( ev: string, cb: ( ...args: unknown[] ) => void ) => void;
+	} => ( {
+		on( ev, cb ) {
+			( handlers as Record< string, unknown > )[ ev ] = cb as unknown;
+		},
+	} );
+	return handlers;
+}
+
+function boot(): JQueryHandlers {
+	const handlers = installFakeJQuery();
+	bootHeartbeatBus();
+	bootContentChangesHeartbeat();
+	return handlers;
+}
+
+function sentSeenTs( handlers: JQueryHandlers ): unknown {
+	const data: Record< string, unknown > = {};
+	handlers[ 'heartbeat-send' ]?.( {}, data );
+	return data.desktop_mode_content_changes_seen_ts;
+}
+
+function tick(
+	handlers: JQueryHandlers,
+	block: unknown,
+): void {
+	handlers[ 'heartbeat-tick' ]?.( {}, {
+		desktop_mode_content_changes: block,
+	} );
+}
+
+describe( 'content-changes heartbeat', () => {
+	beforeEach( () => {
+		installHooksStub();
+		_resetHeartbeatBusForTests();
+		_resetContentChangesHeartbeatForTests();
+		delete ( window as unknown as { jQuery?: unknown } ).jQuery;
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		_resetHeartbeatBusForTests();
+		_resetContentChangesHeartbeatForTests();
+		delete ( window as unknown as { jQuery?: unknown } ).jQuery;
+	} );
+
+	test( 'first tick is a handshake: sends 0, adopts server ts, broadcasts nothing', () => {
+		const handlers = boot();
+		const seen = vi.fn();
+		const off = subscribe( '*', seen );
+
+		expect( sentSeenTs( handlers ) ).toBe( 0 );
+
+		tick( handlers, {
+			ts: 5000,
+			entries: [ { ts: 4000, type: 'post', action: 'updated', ids: [ 7 ] } ],
+		} );
+
+		expect( seen ).not.toHaveBeenCalled();
+		expect( sentSeenTs( handlers ) ).toBe( 5000 );
+		off();
+	} );
+
+	test( 'post-handshake entries re-broadcast as desktop-mode.<type>.changed', () => {
+		const handlers = boot();
+		tick( handlers, { ts: 1000, entries: [] } );
+
+		const onOrder = vi.fn();
+		const off = subscribe( 'desktop-mode.shop_order.changed', onOrder );
+
+		tick( handlers, {
+			ts: 2000,
+			entries: [
+				{ ts: 2000, type: 'shop_order', action: 'created', ids: [ 42 ] },
+			],
+		} );
+
+		expect( onOrder ).toHaveBeenCalledTimes( 1 );
+		expect( onOrder.mock.calls[ 0 ][ 0 ] ).toEqual( {
+			source: 'heartbeat',
+			action: 'created',
+			ids: [ 42 ],
+		} );
+		off();
+	} );
+
+	test( 'entries at or below the high-water mark are not re-broadcast', () => {
+		const handlers = boot();
+		tick( handlers, { ts: 1000, entries: [] } );
+
+		const seen = vi.fn();
+		const off = subscribe( 'desktop-mode.post.changed', seen );
+
+		const block = {
+			ts: 3000,
+			entries: [ { ts: 3000, type: 'post', action: 'updated', ids: [ 1 ] } ],
+		};
+		tick( handlers, block );
+		expect( seen ).toHaveBeenCalledTimes( 1 );
+
+		// The same block on the next tick is stale — seenTs advanced.
+		tick( handlers, block );
+		expect( seen ).toHaveBeenCalledTimes( 1 );
+		expect( sentSeenTs( handlers ) ).toBe( 3000 );
+		off();
+	} );
+
+	test( 'high-water mark advances from block.ts even with no entries', () => {
+		const handlers = boot();
+		tick( handlers, { ts: 1000, entries: [] } );
+		tick( handlers, { ts: 9000, entries: [] } );
+		expect( sentSeenTs( handlers ) ).toBe( 9000 );
+	} );
+
+	test( 'malformed entries are skipped without stranding valid ones', () => {
+		const handlers = boot();
+		tick( handlers, { ts: 1000, entries: [] } );
+
+		const seen = vi.fn();
+		const off = subscribe( '*', seen );
+
+		tick( handlers, {
+			ts: 2000,
+			entries: [
+				null,
+				{ ts: 2000, type: '', action: 'updated', ids: [ 1 ] },
+				{ type: 'post', action: 'updated', ids: [ 1 ] },
+				{ ts: 2000, type: 'page', action: '', ids: [ 'x', 3, -1 ] },
+			],
+		} );
+
+		expect( seen ).toHaveBeenCalledTimes( 1 );
+		expect( seen.mock.calls[ 0 ][ 0 ] ).toEqual( {
+			source: 'heartbeat',
+			action: 'updated',
+			ids: [ 3 ],
+		} );
+		expect( seen.mock.calls[ 0 ][ 1 ] ).toEqual( {
+			topic: 'desktop-mode.page.changed',
+		} );
+		off();
+	} );
+
+	test( 'a malformed block is ignored entirely', () => {
+		const handlers = boot();
+		tick( handlers, { ts: 1000, entries: [] } );
+
+		const seen = vi.fn();
+		const off = subscribe( '*', seen );
+		tick( handlers, null );
+		tick( handlers, { entries: [ { ts: 2000, type: 'post', ids: [ 1 ] } ] } );
+		expect( seen ).not.toHaveBeenCalled();
+		expect( sentSeenTs( handlers ) ).toBe( 1000 );
+		off();
+	} );
+} );


### PR DESCRIPTION
Fixes #372

## Problem

Adding or updating a WooCommerce order in one desktop window left an open Orders-list window stale. The gap generalizes: the shell already had all the *consumer* machinery — the cross-window broadcast bus (`desktop-mode.<type>.changed`), the iframe soft-reload, native list windows that subscribe — but **nothing published those topics on a normal save**. Only the recycle bin (trash verbs) and the native posts window's own mutations emitted.

## Solution — a generic content-change realtime layer

Any create / update / trash of a post, page, `show_ui` CPT, comment, or WooCommerce order (HPOS **and** legacy, one `shop_order` topic for both) now reaches every window through three delivery paths:

1. **Chromeless footer (instant)** — new `includes/content-changes.php` records mutations into a per-request changelog (`wp_after_insert_post` with revision/autosave/auto-draft/trash-status skips, comment hooks, `woocommerce_*` order hooks behind a `class_exists` guard). Because the dominant save flow is form-POST → 302 → GET, the changelog survives the redirect in a 60 s per-user transient flushed by the next chromeless `admin_footer` render (~500 ms after the click).
2. **Block editor (instant)** — the bridge's existing `core/editor` save-watcher now also posts the broadcast upstream on save success (`source: 'editor'`, `created` vs `updated` captured on the save-start tick). Gutenberg saves over REST, so no footer ever renders there.
3. **Heartbeat catch-all (≤ 1 tick)** — every record is appended to a pruned `_desktop_mode_content_changes_log` option (autoload=false, 5-min window / 100 entries); opted-in shells re-broadcast fresh entries (`source: 'heartbeat'`). Covers Quick Edit, AJAX status flips, other browser tabs/users, REST/WP-CLI. The first tick is a pure handshake that adopts the server clock, so client/server skew can never drop changes. Tabs that never opt in pay zero per tick.

### Consumers

- The iframe **soft-reload matcher is now generic**: `edit.php?post_type=X` reacts to `desktop-mode.X.changed` for any post type with zero per-type code (also covers legacy `edit.php?post_type=shop_order`).
- **Declarative extras** via the new `desktop_mode_soft_reload_rules` filter, shipping one rule for the HPOS orders list (`admin.php?page=wc-orders`). `queryAbsent: [ 'action' ]` is load-bearing — it keeps the single-order *editor* under the single-edit exclusion so a background refresh can never destroy unsaved order state.
- The **native Comments window** now subscribes to `desktop-mode.comment.changed` and refreshes in place (the 30 s count-poll + reload pill stays as fallback).
- Native Posts / Pages / Users windows already subscribed — they light up automatically.

### Recycle-bin delegation

The bin's per-domain changelog now forwards into the generic recorder (`desktop_mode_recycle_bin_record_change()` kept as a thin wrapper), so a trash and a save flow through **one** footer emitter — each type/action pair broadcasts exactly once per render. The bin-specific `desktop-mode-recycle-bin-changed` ts signal, option, and heartbeat handler are unchanged. First-writer-wins dedupe per `type:id` keeps the more specific trash verb over the follow-up status-write `updated`.

## New public surface (all documented)

- `desktop_mode_content_changes_record( $type, $id, $action )` — public recorder for plugins with custom storage
- Filters: `desktop_mode_content_changes_should_record`, `desktop_mode_content_change_topic`, `desktop_mode_content_changes_broadcasts`, `desktop_mode_soft_reload_rules`
- Actions: `desktop_mode_content_change_recorded`, `desktop_mode_content_changes_emitted`
- Heartbeat fields: `desktop_mode_content_changes_seen_ts` (client → server), `desktop_mode_content_changes` (server → client)
- Extended `desktop-mode.<type>.changed` payload contract: `source` gains `'editor'` / `'heartbeat'`, `action` gains `'created'` / `'updated'`

Docs updated in the same change: `hooks-reference.md` (new section + rewritten cross-window broadcast contract), `javascript-reference.md`, `bridge-protocol.md`, `api-index.md`, new `examples/content-changes.md` recipe.

## Tests

- **PHPUnit** (`tests/phpunit/tests/contentChanges.php`, 22 cases): recorder validation + first-writer-wins dedupe, `should_record` veto, created-vs-updated (auto-draft first save), revision/`show_ui` skips, trash/untrash integration proving the recycle-bin delegation end-to-end, comment transitions, WC guard, redirect buffer, footer emitter (emit + buffer consumption + no-rebuffer + chromeless gate + suppress filter), heartbeat filter.
- **Vitest** (`tests/vitest/content-changes-heartbeat.test.ts`, 6 cases): handshake semantics, re-broadcast fan-out, high-water-mark advance, malformed-entry hygiene.
- Full suites green: 1269 PHP / 2108 JS; build + lint + typecheck clean.

## Manual QA notes

Verified flows: HPOS order status change + new order (instant list refresh, no spinner), legacy WC, Gutenberg save → posts list + native Posts window, CPT saves, comment moderation, AJAX status flip via heartbeat, cross-tab catch-up, and the regression checks (single soft-reload fetch per change; dirty editors never background-reloaded).

Known accepted redundancy (documented): a change delivered instantly by the footer/editor path is re-broadcast once by the next heartbeat tick — consumers are idempotent, cost is one extra refresh fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-388-dda5bd2f177561b4ce2315bfb3ee079851967286.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->