### PR TITLE
fix: gamepad icon missing from the window title bar (data-URI window icons)

### DIFF
--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -133,6 +133,12 @@
 	flex-shrink: 0;
 }
 
+/* Letter-badge fallback (unrecognized icon values) — shrink the
+ * one-/two-letter monogram so it fits the 18px icon box. */
+.desktop-mode-window__icon.desktop-mode-icon-letter {
+	font-size: 9px;
+}
+
 /* Activity indicator slot — sits between the icon and the title.
  * Reserves a fixed width so the indicator's blink animation can't
  * shift the title text horizontally. The inner `<wpd-save-status>`

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -9,7 +9,8 @@
  */
 
 import type { WindowConfig } from '../types';
-import { sanitizeClassName, urlMatchKey } from '../utils';
+import { urlMatchKey } from '../utils';
+import { renderIcon } from '../icon';
 import { __, sprintf } from '../i18n';
 // Side-effect import — registers `<wpd-spinner>` so the loading
 // overlay rendered below upgrades synchronously when the body is
@@ -433,9 +434,15 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 	// Default content for `icon` and `title` reproduces the legacy
 	// title-bar visual; the other slots are empty by default.
 	const slotIcon = createSlotHost( 'icon' );
-	const iconEl = document.createElement( 'span' );
-	iconEl.className = `desktop-mode-window__icon dashicons ${ sanitizeClassName( config.icon ) }`;
-	iconEl.setAttribute( 'aria-hidden', 'true' );
+	// `renderIcon` is the canonical dispatcher for every icon shape a
+	// window can register (dashicons class, SVG/raster data URI,
+	// http(s) URL, letter-badge fallback). Rendering only the
+	// dashicons shape here left data-URI icons — e.g. the Games
+	// window's gamepad SVG — invisible in the title bar.
+	const iconEl = renderIcon( config.icon, {
+		title: config.title,
+		className: 'desktop-mode-window__icon',
+	} );
 	slotIcon.appendChild( iconEl );
 
 	const slotTitle = createSlotHost( 'title' );

--- a/tests/vitest/window-titlebar-icon.test.ts
+++ b/tests/vitest/window-titlebar-icon.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Title-bar icon rendering — `createWindowElement` must honor every
+ * icon shape `renderIcon` supports, not just Dashicons classes.
+ *
+ * Catches the regression where a native window registered with a
+ * `data:image/svg+xml;base64,…` icon (e.g. the Games window's
+ * gamepad SVG) rendered an empty `<span class="dashicons …">` in
+ * the title bar — the data URI was squeezed through the
+ * dashicons-class code path and stripped into a garbage class name.
+ *
+ * @since 0.9.7
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { createWindowElement } from '../../src/window/dom';
+import { _resetWindowChannelsForTests } from '../../src/window-channels';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+const SVG_DATA_URI =
+	'data:image/svg+xml;base64,' +
+	btoa( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64"/></svg>' );
+
+function makeWindow( icon: string ): HTMLElement {
+	return createWindowElement( {
+		id: 'probe-icon',
+		url: '#probe-icon',
+		title: 'Games',
+		icon,
+		x: 0,
+		y: 0,
+		width: 800,
+		height: 600,
+	} );
+}
+
+function titleBarIcon( el: HTMLElement ): HTMLElement | null {
+	return el.querySelector< HTMLElement >( '.desktop-mode-window__icon' );
+}
+
+describe( 'createWindowElement — title-bar icon shapes', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		_resetWindowChannelsForTests();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'dashicons class renders the classic dashicons span', () => {
+		const iconEl = titleBarIcon( makeWindow( 'dashicons-admin-post' ) );
+		expect( iconEl ).not.toBeNull();
+		expect( iconEl!.tagName ).toBe( 'SPAN' );
+		expect( iconEl!.classList.contains( 'dashicons' ) ).toBe( true );
+		expect( iconEl!.classList.contains( 'dashicons-admin-post' ) ).toBe( true );
+		expect( iconEl!.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+	} );
+
+	test( 'SVG data URI renders as a background-image span (the Games gamepad case)', () => {
+		const iconEl = titleBarIcon( makeWindow( SVG_DATA_URI ) );
+		expect( iconEl ).not.toBeNull();
+		expect( iconEl!.style.backgroundImage ).toContain( SVG_DATA_URI );
+		// The old code path stamped `dashicons` + a stripped class —
+		// make sure the data URI never lands there again.
+		expect( iconEl!.classList.contains( 'dashicons' ) ).toBe( false );
+	} );
+
+	test( 'http(s) URL renders as an <img>', () => {
+		const iconEl = titleBarIcon(
+			makeWindow( 'https://example.com/icon.png' ),
+		);
+		expect( iconEl ).not.toBeNull();
+		expect( iconEl!.tagName ).toBe( 'IMG' );
+		expect( ( iconEl as HTMLImageElement ).src ).toBe(
+			'https://example.com/icon.png',
+		);
+	} );
+
+	test( 'unrecognized value falls back to the letter badge', () => {
+		const iconEl = titleBarIcon( makeWindow( 'none' ) );
+		expect( iconEl ).not.toBeNull();
+		expect(
+			iconEl!.classList.contains( 'desktop-mode-icon-letter' ),
+		).toBe( true );
+		expect( iconEl!.textContent ).toBe( 'GA' );
+	} );
+} );


### PR DESCRIPTION
## What

The Games window opened with an empty space where its gamepad icon should be — the icon in the top-left of the window title bar never rendered.

## Why

`createWindowElement()` in `src/window/dom.ts` built the title-bar icon exclusively as a dashicons `<span>`:

```ts
iconEl.className = `desktop-mode-window__icon dashicons ${ sanitizeClassName( config.icon ) }`;
```

The Games window registers its icon as a `data:image/svg+xml;base64,…` URI (`desktop_mode_games_icon_svg()` in `includes/games/window.php`). Squeezed through `sanitizeClassName()`, the data URI became a garbage class name on an empty dashicons span — an invisible icon. The docs already promise that icons can be a Dashicons class, an http(s) URL, or a data URI; the title bar was the one surface not honoring that contract (some callers even coerce non-dashicons icons to `dashicons-admin-generic` to paper over it).

## How

Route the title-bar icon through `renderIcon()` (`src/icon.ts`) — the canonical icon dispatcher already used by desktop icons, tiles, and the apps-icons settings section. The title bar now renders every documented shape:

- `dashicons-…` → the classic dashicons `<span>` (unchanged output)
- `data:image/svg+xml;base64,…` → background-image span (**fixes the gamepad**)
- raster data URIs and `http(s)://…` → `<img>`
- anything unrecognized → letter-badge fallback (plus a small CSS rule so the monogram fits the 18px icon box)

## Testing

- New `tests/vitest/window-titlebar-icon.test.ts` covers all four shapes, including the exact Games regression (SVG data URI must not land in the dashicons code path).
- `npm run build`, `npm run lint`, `npm run typecheck`, `npm run test:js` (231 files / 2155 tests) all green.
- Manual check: open the Games window on :8889 — the gamepad SVG should now show in the title bar's top-left; dashicons windows (Posts, Media, …) look identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-389-11939b1604754996de4bc037cee39bc0b3aa7b91.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->