### PR TITLE
Fix content graph taxonomy fallback

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -3053,7 +3053,7 @@ Gates icon registration and window registration in one shot. Default `current_us
 apply_filters( 'desktop_mode_content_graph_post_types', array[] $post_types ): array[]
 ```
 
-The list of post types shown in the graph's filter bar. Each entry declares `slug`, `label`, and `icon`. Default: every public post type except `attachment` (media renders in the side panel rather than as nodes). Removing an entry hides it from the filter bar AND excludes it from the graph entirely.
+The list of post types shown in the graph's filter bar. Each entry declares `slug`, `label`, `icon`, and `taxonomies` (`array( 'category' => bool, 'post_tag' => bool )`), used to keep types without a taxonomy out of the shared Uncategorized/Untagged clusters. Entries added without `taxonomies` get it derived via `is_object_in_taxonomy()`. Default: every public post type except `attachment` (media renders in the side panel rather than as nodes). Removing an entry hides it from the filter bar AND excludes it from the graph entirely.
 
 ### `desktop_mode_content_graph_template_html` — Experimental (filter)
 

--- a/includes/content-graph/graph-builder.php
+++ b/includes/content-graph/graph-builder.php
@@ -120,6 +120,13 @@ function desktop_mode_content_graph_build( array $types ) {
 		$post_cats = isset( $terms_by_post[ $id ]['category'] )
 			? $terms_by_post[ $id ]['category']
 			: array();
+		// A category-supporting post with zero terms is what WP treats
+		// as "in the default category" at authoring time (core auto-
+		// assigns it on save for `post`). Mirror that here so such
+		// posts group under the real default-category cluster instead
+		// of the client's synthetic "Uncategorized" pseudo-cluster
+		// (`cat:uncat`, kept client-side only as a stale-payload
+		// fallback).
 		if ( empty( $post_cats ) && is_object_in_taxonomy( $row->post_type, 'category' ) ) {
 			$post_cats = array( $default_category );
 		}

--- a/includes/content-graph/graph-builder.php
+++ b/includes/content-graph/graph-builder.php
@@ -31,7 +31,7 @@ defined( 'ABSPATH' ) || exit;
 // previous schema (e.g. missing per-node `contributor_ids`) and
 // surface as runtime errors on the client. Each bump is a one-time
 // cache miss for every site that updates the plugin.
-const DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_PREFIX = 'desktop_mode_cg2_';
+const DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_PREFIX = 'desktop_mode_cg3_';
 const DESKTOP_MODE_CONTENT_GRAPH_TRANSIENT_TTL    = 6 * HOUR_IN_SECONDS;
 
 /**
@@ -98,6 +98,8 @@ function desktop_mode_content_graph_build( array $types ) {
 	// we don't N+1 `wp_get_post_revisions` per node.
 	$contribs_by_post = desktop_mode_content_graph_collect_post_contributors( $post_ids );
 
+	$default_category = max( 1, (int) get_option( 'default_category', 1 ) );
+
 	$nodes       = array();
 	$nodes_by_id = array();
 	$author_ids  = array();
@@ -118,6 +120,9 @@ function desktop_mode_content_graph_build( array $types ) {
 		$post_cats = isset( $terms_by_post[ $id ]['category'] )
 			? $terms_by_post[ $id ]['category']
 			: array();
+		if ( empty( $post_cats ) && is_object_in_taxonomy( $row->post_type, 'category' ) ) {
+			$post_cats = array( $default_category );
+		}
 		$post_tags = isset( $terms_by_post[ $id ]['post_tag'] )
 			? $terms_by_post[ $id ]['post_tag']
 			: array();

--- a/includes/content-graph/rest.php
+++ b/includes/content-graph/rest.php
@@ -112,10 +112,7 @@ function desktop_mode_content_graph_rest_post_types() {
 			'label'      => isset( $entry['label'] ) ? (string) $entry['label'] : $slug,
 			'icon'       => isset( $entry['icon'] ) ? (string) $entry['icon'] : 'dashicons-admin-post',
 			'count'      => $count,
-			'taxonomies' => isset( $entry['taxonomies'] ) ? $entry['taxonomies'] : array(
-				'category' => is_object_in_taxonomy( $slug, 'category' ),
-				'post_tag' => is_object_in_taxonomy( $slug, 'post_tag' ),
-			),
+			'taxonomies' => $entry['taxonomies'],
 		);
 	}
 	return rest_ensure_response( $out );

--- a/includes/content-graph/rest.php
+++ b/includes/content-graph/rest.php
@@ -6,7 +6,7 @@
  *
  *   GET /post-types
  *     Lists the types eligible for the graph (`slug`, `label`, `icon`,
- *     `count`).
+ *     `count`, `taxonomies`).
  *
  *   GET /nodes?types=post,page,...
  *     Returns the full `{ nodes, edges, stats }` tuple. Cached server-
@@ -108,10 +108,14 @@ function desktop_mode_content_graph_rest_post_types() {
 			}
 		}
 		$out[] = array(
-			'slug'  => $slug,
-			'label' => isset( $entry['label'] ) ? (string) $entry['label'] : $slug,
-			'icon'  => isset( $entry['icon'] ) ? (string) $entry['icon'] : 'dashicons-admin-post',
-			'count' => $count,
+			'slug'       => $slug,
+			'label'      => isset( $entry['label'] ) ? (string) $entry['label'] : $slug,
+			'icon'       => isset( $entry['icon'] ) ? (string) $entry['icon'] : 'dashicons-admin-post',
+			'count'      => $count,
+			'taxonomies' => isset( $entry['taxonomies'] ) ? $entry['taxonomies'] : array(
+				'category' => is_object_in_taxonomy( $slug, 'category' ),
+				'post_tag' => is_object_in_taxonomy( $slug, 'post_tag' ),
+			),
 		);
 	}
 	return rest_ensure_response( $out );

--- a/includes/content-graph/window.php
+++ b/includes/content-graph/window.php
@@ -48,7 +48,7 @@ function desktop_mode_content_graph_user_can_use() {
  *
  * @since 0.8.2
  *
- * @return array[] Each entry: `array( 'slug', 'label', 'icon' )`.
+ * @return array[] Each entry: `array( 'slug', 'label', 'icon', 'taxonomies' )`.
  */
 function desktop_mode_content_graph_post_types() {
 	$types  = get_post_types( array( 'public' => true ), 'objects' );
@@ -61,15 +61,19 @@ function desktop_mode_content_graph_post_types() {
 			continue;
 		}
 		$result[] = array(
-			'slug'  => (string) $type->name,
-			'label' => (string) $type->labels->name,
-			'icon'  => (string) ( ! empty( $type->menu_icon ) ? $type->menu_icon : 'dashicons-admin-post' ),
+			'slug'       => (string) $type->name,
+			'label'      => (string) $type->labels->name,
+			'icon'       => (string) ( ! empty( $type->menu_icon ) ? $type->menu_icon : 'dashicons-admin-post' ),
+			'taxonomies' => array(
+				'category' => is_object_in_taxonomy( $type->name, 'category' ),
+				'post_tag' => is_object_in_taxonomy( $type->name, 'post_tag' ),
+			),
 		);
 	}
 
 	/**
 	 * Filter the list of post types shown in the Content Graph filter
-	 * bar. Each entry must declare `slug`, `label`, and `icon`. Removing
+	 * bar. Each entry must declare `slug`, `label`, `icon`, and `taxonomies`. Removing
 	 * an entry hides it from the filter bar AND excludes it from the
 	 * graph entirely.
 	 *

--- a/includes/content-graph/window.php
+++ b/includes/content-graph/window.php
@@ -73,7 +73,10 @@ function desktop_mode_content_graph_post_types() {
 
 	/**
 	 * Filter the list of post types shown in the Content Graph filter
-	 * bar. Each entry must declare `slug`, `label`, `icon`, and `taxonomies`. Removing
+	 * bar. Each entry declares `slug`, `label`, `icon`, and optionally
+	 * `taxonomies` (`array( 'category' => bool, 'post_tag' => bool )`);
+	 * entries missing `taxonomies` get it derived from
+	 * `is_object_in_taxonomy()` after filtering. Removing
 	 * an entry hides it from the filter bar AND excludes it from the
 	 * graph entirely.
 	 *

--- a/includes/content-graph/window.php
+++ b/includes/content-graph/window.php
@@ -82,7 +82,17 @@ function desktop_mode_content_graph_post_types() {
 	 * @param array[] $result Default: every public post type except attachment.
 	 */
 	$filtered = apply_filters( 'desktop_mode_content_graph_post_types', $result );
-	return is_array( $filtered ) ? array_values( $filtered ) : $result;
+	$filtered = is_array( $filtered ) ? array_values( $filtered ) : $result;
+
+	foreach ( $filtered as $i => $entry ) {
+		$slug                         = isset( $entry['slug'] ) ? (string) $entry['slug'] : '';
+		$filtered[ $i ]['taxonomies'] = array(
+			'category' => isset( $entry['taxonomies'] ) ? ! empty( $entry['taxonomies']['category'] ) : is_object_in_taxonomy( $slug, 'category' ),
+			'post_tag' => isset( $entry['taxonomies'] ) ? ! empty( $entry['taxonomies']['post_tag'] ) : is_object_in_taxonomy( $slug, 'post_tag' ),
+		);
+	}
+
+	return $filtered;
 }
 
 /**

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -949,7 +949,7 @@ export class GraphScene {
 		// treated as not supporting the taxonomy so it gets its own
 		// cat:type_<slug> / tag:type_<slug> cluster rather than silently
 		// merging into the shared Uncategorized / Untagged pool.
-		return pt ? pt.taxonomies[ taxonomy ] : false;
+		return pt?.taxonomies?.[ taxonomy ] ?? false;
 	}
 
 	private postTypeLabel( typeSlug: string ): string {

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -263,6 +263,7 @@ export class GraphScene {
 	private callbacks: SceneCallbacks;
 	private onSatelliteClick: SatelliteOnClick;
 	private postTypeIcon: PostTypeIconLookup;
+	private postTypes: PostTypeDescriptor[];
 
 	constructor(
 		host: HTMLElement,
@@ -273,6 +274,7 @@ export class GraphScene {
 		this.host = host;
 		this.callbacks = callbacks;
 		this.onSatelliteClick = onSatelliteClick;
+		this.postTypes = postTypes;
 		const map = new Map< string, string >();
 		for ( const t of postTypes ) {
 			map.set( t.slug, normalizeDashiconName( t.icon ) );
@@ -941,14 +943,34 @@ export class GraphScene {
 		}
 	}
 
+	private postTypeSupportsTaxonomy( typeSlug: string, taxonomy: 'category' | 'post_tag' ): boolean {
+		const pt = this.postTypes.find( ( t ) => t.slug === typeSlug );
+		// Unknown type (not registered in the scene's post-type list) is
+		// treated as not supporting the taxonomy so it gets its own
+		// cat:type_<slug> / tag:type_<slug> cluster rather than silently
+		// merging into the shared Uncategorized / Untagged pool.
+		return pt ? pt.taxonomies[ taxonomy ] : false;
+	}
+
+	private postTypeLabel( typeSlug: string ): string {
+		const pt = this.postTypes.find( ( t ) => t.slug === typeSlug );
+		return pt?.label ?? typeSlug;
+	}
+
 	private deriveGroupKeys( n: GraphNode, facet: GroupFacet ): string[] {
 		switch ( facet ) {
 			case 'category':
+				if ( ! this.postTypeSupportsTaxonomy( n.type, 'category' ) ) {
+					return [ `cat:type_${ n.type }` ];
+				}
 				if ( n.category_ids.length === 0 ) {
 					return [ 'cat:uncat' ];
 				}
 				return n.category_ids.map( ( id ) => `cat:${ id }` );
 			case 'tag':
+				if ( ! this.postTypeSupportsTaxonomy( n.type, 'post_tag' ) ) {
+					return [ `tag:type_${ n.type }` ];
+				}
 				if ( n.tag_ids.length === 0 ) {
 					return [ 'tag:untagged' ];
 				}
@@ -998,12 +1020,18 @@ export class GraphScene {
 				if ( rest === 'uncat' ) {
 					return __( 'Uncategorized' );
 				}
+				if ( rest.startsWith( 'type_' ) ) {
+					return this.postTypeLabel( rest.slice( 5 ) );
+				}
 				const id = Number( rest );
 				return this.groupCatalogs.categories[ id ]?.name ?? `#${ id }`;
 			}
 			case 'tag': {
 				if ( rest === 'untagged' ) {
 					return __( 'Untagged' );
+				}
+				if ( rest.startsWith( 'type_' ) ) {
+					return this.postTypeLabel( rest.slice( 5 ) );
 				}
 				const id = Number( rest );
 				return this.groupCatalogs.tags[ id ]?.name ?? `#${ id }`;

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -263,7 +263,7 @@ export class GraphScene {
 	private callbacks: SceneCallbacks;
 	private onSatelliteClick: SatelliteOnClick;
 	private postTypeIcon: PostTypeIconLookup;
-	private postTypes: PostTypeDescriptor[];
+	private postTypeBySlug: Map< string, PostTypeDescriptor >;
 
 	constructor(
 		host: HTMLElement,
@@ -274,10 +274,11 @@ export class GraphScene {
 		this.host = host;
 		this.callbacks = callbacks;
 		this.onSatelliteClick = onSatelliteClick;
-		this.postTypes = postTypes;
 		const map = new Map< string, string >();
+		this.postTypeBySlug = new Map();
 		for ( const t of postTypes ) {
 			map.set( t.slug, normalizeDashiconName( t.icon ) );
+			this.postTypeBySlug.set( t.slug, t );
 		}
 		// Always seeded so unknown CPTs without a registered menu_icon
 		// still pick up a sensible default.
@@ -944,17 +945,15 @@ export class GraphScene {
 	}
 
 	private postTypeSupportsTaxonomy( typeSlug: string, taxonomy: 'category' | 'post_tag' ): boolean {
-		const pt = this.postTypes.find( ( t ) => t.slug === typeSlug );
 		// Unknown type (not registered in the scene's post-type list) is
 		// treated as not supporting the taxonomy so it gets its own
 		// cat:type_<slug> / tag:type_<slug> cluster rather than silently
 		// merging into the shared Uncategorized / Untagged pool.
-		return pt?.taxonomies?.[ taxonomy ] ?? false;
+		return this.postTypeBySlug.get( typeSlug )?.taxonomies?.[ taxonomy ] ?? false;
 	}
 
 	private postTypeLabel( typeSlug: string ): string {
-		const pt = this.postTypes.find( ( t ) => t.slug === typeSlug );
-		return pt?.label ?? typeSlug;
+		return this.postTypeBySlug.get( typeSlug )?.label ?? typeSlug;
 	}
 
 	private deriveGroupKeys( n: GraphNode, facet: GroupFacet ): string[] {

--- a/src/content-graph/types.ts
+++ b/src/content-graph/types.ts
@@ -14,6 +14,10 @@ export interface PostTypeDescriptor {
 	label: string;
 	icon: string;
 	count: number;
+	taxonomies: {
+		category: boolean;
+		post_tag: boolean;
+	};
 }
 
 export interface GraphNodePayload {

--- a/src/content-graph/types.ts
+++ b/src/content-graph/types.ts
@@ -14,7 +14,7 @@ export interface PostTypeDescriptor {
 	label: string;
 	icon: string;
 	count: number;
-	taxonomies: {
+	taxonomies?: {
 		category: boolean;
 		post_tag: boolean;
 	};

--- a/tests/phpunit/tests/contentGraphGroupBy.php
+++ b/tests/phpunit/tests/contentGraphGroupBy.php
@@ -299,6 +299,35 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_post_types_normalizes_legacy_filtered_descriptors() {
+		$filter_callback = function( $types ) {
+			$types[] = array(
+				'slug'  => 'page',
+				'label' => 'Pages',
+				'icon'  => 'dashicons-admin-page',
+				// Omit 'taxonomies' to simulate legacy filter callback
+			);
+			return $types;
+		};
+
+		add_filter( 'desktop_mode_content_graph_post_types', $filter_callback );
+		$post_types = desktop_mode_content_graph_post_types();
+		remove_filter( 'desktop_mode_content_graph_post_types', $filter_callback );
+
+		$page_entry = null;
+		foreach ( $post_types as $entry ) {
+			if ( 'page' === $entry['slug'] ) {
+				$page_entry = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $page_entry, 'Filtered post type entry must be present.' );
+		$this->assertArrayHasKey( 'taxonomies', $page_entry, 'Post type entry must be normalized with taxonomies key.' );
+		$this->assertFalse( $page_entry['taxonomies']['category'], 'Page should not support category by default.' );
+		$this->assertFalse( $page_entry['taxonomies']['post_tag'], 'Page should not support post_tag by default.' );
+	}
+
 	/**
 	 * @param array $payload
 	 * @param int   $post_id

--- a/tests/phpunit/tests/contentGraphGroupBy.php
+++ b/tests/phpunit/tests/contentGraphGroupBy.php
@@ -184,6 +184,11 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 		$payload = desktop_mode_content_graph_build( array( 'dm_test_no_cat' ) );
 		$node    = $this->find_node( $payload, $post_id );
 
+		// Clean up BEFORE asserting so the CPT never leaks into other
+		// tests even when an assertion fails.
+		unregister_post_type( 'dm_test_no_cat' );
+		desktop_mode_content_graph_flush_cache();
+
 		// category is not registered for this type — the default
 		// category fallback must NOT be injected.
 		$this->assertSame(
@@ -191,9 +196,6 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 			$node['category_ids'],
 			'The default category must not be injected for a post type that does not support category.'
 		);
-
-		unregister_post_type( 'dm_test_no_cat' );
-		desktop_mode_content_graph_flush_cache();
 	}
 
 	public function test_post_in_two_categories_lists_both() {

--- a/tests/phpunit/tests/contentGraphGroupBy.php
+++ b/tests/phpunit/tests/contentGraphGroupBy.php
@@ -301,11 +301,14 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 
 	public function test_post_types_normalizes_legacy_filtered_descriptors() {
 		$filter_callback = function( $types ) {
+			// Use a slug that is NOT in the default list — the built-in
+			// entries already carry `taxonomies`, so asserting on one of
+			// them would pass even without the normalization pass.
 			$types[] = array(
-				'slug'  => 'page',
-				'label' => 'Pages',
+				'slug'  => 'dm_legacy',
+				'label' => 'Legacy',
 				'icon'  => 'dashicons-admin-page',
-				// Omit 'taxonomies' to simulate legacy filter callback
+				// Omit 'taxonomies' to simulate a legacy filter callback.
 			);
 			return $types;
 		};
@@ -314,18 +317,18 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 		$post_types = desktop_mode_content_graph_post_types();
 		remove_filter( 'desktop_mode_content_graph_post_types', $filter_callback );
 
-		$page_entry = null;
+		$legacy_entry = null;
 		foreach ( $post_types as $entry ) {
-			if ( 'page' === $entry['slug'] ) {
-				$page_entry = $entry;
+			if ( 'dm_legacy' === $entry['slug'] ) {
+				$legacy_entry = $entry;
 				break;
 			}
 		}
 
-		$this->assertNotNull( $page_entry, 'Filtered post type entry must be present.' );
-		$this->assertArrayHasKey( 'taxonomies', $page_entry, 'Post type entry must be normalized with taxonomies key.' );
-		$this->assertFalse( $page_entry['taxonomies']['category'], 'Page should not support category by default.' );
-		$this->assertFalse( $page_entry['taxonomies']['post_tag'], 'Page should not support post_tag by default.' );
+		$this->assertNotNull( $legacy_entry, 'Filtered post type entry must be present.' );
+		$this->assertArrayHasKey( 'taxonomies', $legacy_entry, 'Post type entry must be normalized with taxonomies key.' );
+		$this->assertFalse( $legacy_entry['taxonomies']['category'], 'Unregistered legacy slug must derive category support = false.' );
+		$this->assertFalse( $legacy_entry['taxonomies']['post_tag'], 'Unregistered legacy slug must derive post_tag support = false.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/contentGraphGroupBy.php
+++ b/tests/phpunit/tests/contentGraphGroupBy.php
@@ -110,7 +110,11 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_post_with_no_terms_emits_empty_arrays() {
+	public function test_post_with_no_category_falls_back_to_default_category() {
+		// Pin the option so the test is self-contained regardless of
+		// whatever default_category the test-suite DB was seeded with.
+		update_option( 'default_category', 1 );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_author' => self::$author_a_id,
@@ -118,16 +122,78 @@ class Tests_DesktopMode_ContentGraphGroupBy extends WP_UnitTestCase {
 				'post_type'   => 'post',
 			)
 		);
-		// No category, no tag — the default category factory hook can
-		// auto-assign "Uncategorized"; clear it for a clean assertion.
+		// The factory hook auto-assigns "Uncategorized" (term 1); clear
+		// it so we exercise the builder's own fallback rather than
+		// inheriting the factory-side assignment.
 		wp_set_object_terms( $post_id, array(), 'category' );
 		wp_set_object_terms( $post_id, array(), 'post_tag' );
 
 		$payload = desktop_mode_content_graph_build( array( 'post' ) );
 		$node    = $this->find_node( $payload, $post_id );
 
-		$this->assertSame( array(), $node['category_ids'] );
+		$this->assertSame(
+			array( 1 ),
+			$node['category_ids'],
+			'A post that supports category but has no terms must fall back to the default category.'
+		);
 		$this->assertSame( array(), $node['tag_ids'] );
+	}
+
+	public function test_default_category_appears_in_groups_catalog_after_fallback() {
+		update_option( 'default_category', 1 );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$author_a_id,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+		wp_set_object_terms( $post_id, array(), 'category' );
+
+		$payload = desktop_mode_content_graph_build( array( 'post' ) );
+
+		// The client resolves cluster labels from groups.categories;
+		// the fallback ID must be present there so the label renders.
+		$this->assertArrayHasKey(
+			1,
+			$payload['groups']['categories'],
+			'The default category must be in the groups catalog when it is used as a fallback.'
+		);
+	}
+
+	public function test_post_type_not_supporting_category_keeps_empty_category_ids() {
+		// Register a minimal public CPT so the graph builder includes it,
+		// and clean it up afterwards so it does not bleed into other tests.
+		register_post_type(
+			'dm_test_no_cat',
+			array(
+				'public'     => true,
+				'taxonomies' => array( 'post_tag' ),
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$author_a_id,
+				'post_status' => 'publish',
+				'post_type'   => 'dm_test_no_cat',
+			)
+		);
+
+		$payload = desktop_mode_content_graph_build( array( 'dm_test_no_cat' ) );
+		$node    = $this->find_node( $payload, $post_id );
+
+		// category is not registered for this type — the default
+		// category fallback must NOT be injected.
+		$this->assertSame(
+			array(),
+			$node['category_ids'],
+			'The default category must not be injected for a post type that does not support category.'
+		);
+
+		unregister_post_type( 'dm_test_no_cat' );
+		desktop_mode_content_graph_flush_cache();
 	}
 
 	public function test_post_in_two_categories_lists_both() {

--- a/tests/vitest/content-graph-scene-grouping.test.ts
+++ b/tests/vitest/content-graph-scene-grouping.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Content Graph — group-key derivation + cluster label contract.
+ *
+ * Pins the `cat:type_<slug>` / `tag:type_<slug>` isolation behavior
+ * for post types that don't support a taxonomy (and for descriptors
+ * missing `taxonomies` entirely — the pre-normalization legacy
+ * shape), without dragging Pixi into the test: the scene constructor
+ * is renderer-free, all the heavy work lives in `mount()`.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { GraphScene } from '../../src/content-graph/scene';
+import type {
+	GraphNode,
+	GroupFacet,
+	PostTypeDescriptor,
+} from '../../src/content-graph/types';
+
+const POST_TYPES: PostTypeDescriptor[] = [
+	{
+		slug: 'post',
+		label: 'Posts',
+		icon: 'dashicons-admin-post',
+		count: 3,
+		taxonomies: { category: true, post_tag: true },
+	},
+	{
+		slug: 'page',
+		label: 'Pages',
+		icon: 'dashicons-admin-page',
+		count: 2,
+		taxonomies: { category: false, post_tag: false },
+	},
+	{
+		slug: 'legacy',
+		label: 'Legacy',
+		icon: 'dashicons-book',
+		count: 1,
+		// No `taxonomies` — a descriptor from a filter written to the
+		// pre-taxonomies contract that bypassed server normalization.
+	},
+];
+
+// The methods under test are private; reach in through a structural
+// cast so the contract stays testable without widening the public API.
+interface GroupingInternals {
+	deriveGroupKeys: ( n: GraphNode, facet: GroupFacet ) => string[];
+	labelForGroupKey: ( key: string ) => string;
+}
+
+function makeScene(): GroupingInternals {
+	return new GraphScene(
+		document.createElement( 'div' ),
+		{},
+		() => {},
+		POST_TYPES,
+	) as unknown as GroupingInternals;
+}
+
+function makeNode( overrides: Partial< GraphNode > ): GraphNode {
+	return {
+		id: 1,
+		type: 'post',
+		title: 'Node',
+		status: 'publish',
+		slug: 'node',
+		edit_url: '',
+		author_id: 1,
+		contributor_ids: [],
+		year: 2026,
+		year_month: '2026-07',
+		category_ids: [],
+		tag_ids: [],
+		x: 0,
+		y: 0,
+		vx: 0,
+		vy: 0,
+		pinned: false,
+		radius: 4,
+		color: 0,
+		degree: 0,
+		...overrides,
+	};
+}
+
+describe( 'deriveGroupKeys — taxonomy-support isolation', () => {
+	test( 'category: non-supporting type gets its own type cluster', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'page' } ),
+			'category',
+		);
+		expect( keys ).toEqual( [ 'cat:type_page' ] );
+	} );
+
+	test( 'category: supporting type with no terms falls back to uncat', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'post', category_ids: [] } ),
+			'category',
+		);
+		expect( keys ).toEqual( [ 'cat:uncat' ] );
+	} );
+
+	test( 'category: supporting type maps term ids', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'post', category_ids: [ 4, 5 ] } ),
+			'category',
+		);
+		expect( keys ).toEqual( [ 'cat:4', 'cat:5' ] );
+	} );
+
+	test( 'category: descriptor without taxonomies is treated as non-supporting', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'legacy', category_ids: [ 4 ] } ),
+			'category',
+		);
+		expect( keys ).toEqual( [ 'cat:type_legacy' ] );
+	} );
+
+	test( 'category: unknown type gets its own type cluster', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'ghost' } ),
+			'category',
+		);
+		expect( keys ).toEqual( [ 'cat:type_ghost' ] );
+	} );
+
+	test( 'tag: non-supporting type gets its own type cluster', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'page' } ),
+			'tag',
+		);
+		expect( keys ).toEqual( [ 'tag:type_page' ] );
+	} );
+
+	test( 'tag: supporting type with no terms falls back to untagged', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'post', tag_ids: [] } ),
+			'tag',
+		);
+		expect( keys ).toEqual( [ 'tag:untagged' ] );
+	} );
+
+	test( 'tag: supporting type maps term ids', () => {
+		const scene = makeScene();
+		const keys = scene.deriveGroupKeys(
+			makeNode( { type: 'post', tag_ids: [ 7 ] } ),
+			'tag',
+		);
+		expect( keys ).toEqual( [ 'tag:7' ] );
+	} );
+} );
+
+describe( 'labelForGroupKey — type-cluster labels', () => {
+	test( 'resolves the post type label for type clusters', () => {
+		const scene = makeScene();
+		expect( scene.labelForGroupKey( 'cat:type_page' ) ).toBe( 'Pages' );
+		expect( scene.labelForGroupKey( 'tag:type_page' ) ).toBe( 'Pages' );
+	} );
+
+	test( 'falls back to the raw slug for unknown types', () => {
+		const scene = makeScene();
+		expect( scene.labelForGroupKey( 'cat:type_ghost' ) ).toBe( 'ghost' );
+	} );
+
+	test( 'keeps the shared fallback cluster labels', () => {
+		const scene = makeScene();
+		expect( scene.labelForGroupKey( 'cat:uncat' ) ).toBe( 'Uncategorized' );
+		expect( scene.labelForGroupKey( 'tag:untagged' ) ).toBe( 'Untagged' );
+	} );
+} );


### PR DESCRIPTION
## What?
Closes #356  

Fixes the bug where Pages and other Custom Post Types (CPTs) without taxonomy support are incorrectly grouped into a fallback "Uncategorized" or "Untagged" cluster in the Content Graph.

## Why?
Previously, the Content Graph client-side logic grouped any node with an empty `category_ids` array into `cat:uncat` ("Uncategorized"), and empty `tag_ids` into `tag:untagged` ("Untagged"). 
While this makes sense for Posts (which support categories but might have their terms cleared), it creates misleading clusters for Pages and CPTs that don't support those taxonomies at all. Pages were visually dumped into the same "Uncategorized" and "Untagged" buckets as standard Posts.

## How?
- `includes/content-graph/window.php`:
  - Updated the backend `desktop_mode_content_graph_post_types()` config to expose a `taxonomies` object for each post type, indicating whether it supports `category` and `post_tag`.
- `src/content-graph/types.ts`: 
  - Updated the frontend `PostTypeDescriptor` interface to require the new `taxonomies` field.
- `src/content-graph/scene.ts`: 
  - Added `postTypeSupportsTaxonomy()` to check if a post type supports the active facet.
  - Updated `deriveGroupKeys()`: if a post type does *not* support the active taxonomy, it now generates a distinct grouping key (e.g., `cat:type_page` or `tag:type_page`) instead of falling back to the generic "Uncategorized" or "Untagged" pools.
  - Updated cluster label resolution to render the real post type name (e.g., "Pages") for these isolated clusters.
- `tests/phpunit/tests/contentGraphGroupBy.php`:
  - Fixed and expanded PHPUnit tests to verify the backend data contract for taxonomy fallbacks. Added coverage to guarantee that taxonomy-supporting posts correctly inject the default category (`term ID 1`), the fallback term resolves in the catalog, and CPTs without taxonomy support correctly bypass this injection.

## Testing Instructions
1. Open the Content Graph in the desktop mode environment.
2. Select **Group by category** from the toolbar.
3. Observe that Pages are now grouped in their own distinct "Pages" cluster, rather than being grouped under "Uncategorized".
4. Select **Group by tag** from the toolbar.
5. Observe that Pages are similarly grouped under their own "Pages" cluster, while untagged Posts correctly fall under "Untagged".
6. If you test with a custom post type that does not support categories or tags, verify that it also forms its own distinct cluster based on the post type name.

## Screenshots
**Group by Category**
<img width="1470" height="802" alt="Default_Group_By_Cat" src="https://github.com/user-attachments/assets/c5699906-b84f-4f1a-96a2-6fdc988a6881" />

**Group by Tag**
<img width="1470" height="801" alt="Default_Group_By_Tag" src="https://github.com/user-attachments/assets/b5f7d7dd-50c5-4226-8d44-7a94b33a5491" />


## Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini, Claude
Used for: Diagnosing the issue, implementing the fix and tests. Final decisions and edits were made by me.
