### PR TITLE
Reset the plugin-update notifiers live after updates run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Payload shape (`desktop_mode_build_menu_payload()` in `includes/core/payload.php
   serverWindowSlotScripts, serverWindowSlots,
   serverWindowChromeScripts, serverWindowChromes,
   serverWindowNotices, serverGames,
-  desktopIcons }
+  desktopIcons, updateCounts }
 ```
 
 - **PHP-declared** things are in the payload: dock, native windows, widgets, wallpapers. The shell diffs them and fires `registry.subscribe` listeners → UI repaints. No F5.

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -212,8 +212,9 @@ Typed messages between the parent shell and iframe windows. Full shapes in [`bri
 | `desktop-mode-window-publish` | iframe → parent | Stable *(0.5.5)* |
 | `desktop-mode-window-send` | parent → iframe | Stable *(0.5.5)* |
 | `desktop-mode-bridge-*` *(connection-bridge family)* | both | Stable *(0.5.5)* |
-| `desktop-mode-plugins-changed` | iframe → parent | Stable *(0.7.0)* |
-| `desktop-mode-menu-signature` | iframe → parent | Stable *(0.9.4)* |
+| `desktop-mode-plugins-changed` | iframe → shell (top window since 0.9.7) | Stable *(0.7.0)* |
+| `desktop-mode-menu-signature` | iframe → shell (top window since 0.9.7) | Stable *(0.9.4)* |
+| `desktop-mode-updates-changed` *(shiny-update completion nudge)* | iframe → shell | Stable *(0.9.7)* |
 | `wp-desktop-code-open` *(ships with the `desktop-mode-code-editor` extension)* | iframe → parent | Stable *(0.5.4)* |
 | `desktop-mode-drag-start` / `-end` / `-payload-request` | iframe → parent | Stable *(0.7.0)* |
 | `desktop-mode-drag-payload` *(reply to `-payload-request`)* | parent → iframe | Stable *(0.7.0)* |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3294,10 +3294,29 @@ Each `HarvestedCommand` carries a `kind` field the iframe computes by **statical
 
 #### `desktop-mode-plugins-changed` — Stable
 
-Carries a full menu payload harvested from real admin context. Emitted by the chromeless bridge when the iframe lands on a page whose completion commonly mutates the admin menu (`plugins.php`, `plugin-install.php`, `update.php`, `themes.php`), and by the hidden refresh probe [`wp.desktop.refreshMenu()`](#refreshmenu) spawns. The shell diffs the payload against its prior snapshot by `id` and repaints only the registries that actually changed (dock, native windows, widgets, …) — no browser reload. The payload also carries `menuSig`, its own [menu signature](#desktop-mode-menu-signature--stable-since-094), which the shell adopts as its last-known value.
+Carries a full menu payload harvested from real admin context. Emitted by the chromeless bridge when the iframe lands on a page whose completion commonly mutates the admin menu (`plugins.php`, `plugin-install.php`, `update.php`, `themes.php`), and by the hidden refresh probe [`wp.desktop.refreshMenu()`](#refreshmenu) spawns. The shell diffs the payload against its prior snapshot by `id` and repaints only the registries that actually changed (dock, native windows, widgets, …) — no browser reload. The payload also carries `menuSig`, its own [menu signature](#desktop-mode-menu-signature--stable-since-094), which the shell adopts as its last-known value, and `updateCounts` (since 0.9.7), the aggregate pending-update numbers the shell mirrors onto the admin-bar circle-arrows notifier (`#wp-admin-bar-updates`) so an in-window update run resets it without a hard refresh (GH#296).
+
+Since 0.9.7 the bridge posts this message (and `desktop-mode-menu-signature`) to the **top** window rather than the immediate parent. For a normal window iframe they're the same frame; the distinction matters for nested flows like the bulk updater, where `update-core.php` hosts a progress iframe of `update.php` whose post-upgrade payload must still reach the shell.
 
 ```typescript
-{ type: 'desktop-mode-plugins-changed'; payload: { dockItems: unknown[]; nativeWindows: unknown[]; /* … */ menuSig: string } }
+{
+    type: 'desktop-mode-plugins-changed';
+    payload: {
+        dockItems: unknown[];
+        nativeWindows: unknown[];
+        /* … */
+        updateCounts?: { total: number; formatted: string; text: string; url: string };
+        menuSig: string;
+    };
+}
+```
+
+#### `desktop-mode-updates-changed` — Stable *(since 0.9.7)*
+
+A payload-less nudge emitted by the chromeless bridge when Core's shiny updater (`wp-admin/js/updates.js`) finishes an AJAX plugin/theme update or delete run inside the iframe — the jQuery events `wp-plugin-update-success` / `-error`, `wp-plugin-delete-success`, and their theme counterparts. Those runs mutate the update transients server-side without any navigation, so no full payload is coming on its own; on receipt the shell debounces briefly and spends one [`wp.desktop.refreshMenu()`](#refreshmenu) probe, whose payload carries the fresh dock badge and `updateCounts` (GH#296). While updates.js is still draining a bulk queue the bridge stays quiet and lets the final job send the single nudge.
+
+```typescript
+{ type: 'desktop-mode-updates-changed' }
 ```
 
 #### `desktop-mode-menu-signature` — Stable *(since 0.9.4)*

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1168,6 +1168,30 @@ function desktop_mode_build_menu_payload() {
 		$payload[ $key ] = function_exists( $builder ) ? $builder() : array();
 	}
 
+	// Aggregate update counts for the admin bar's "updates" notifier
+	// (the circle-arrows badge Core renders top-left). The node is
+	// static server HTML on the shell page, so after an in-window
+	// update run the shell needs fresh numbers to repaint it — GH#296.
+	// `wp_get_update_data()` is capability-aware (plugins / themes /
+	// core each gated), so the count matches what this user can act
+	// on. Strings are prebuilt here so the client repaint stays
+	// locale-correct without shipping translations to JS.
+	if ( function_exists( 'wp_get_update_data' ) ) {
+		$update_data  = wp_get_update_data();
+		$update_total = isset( $update_data['counts']['total'] ) ? (int) $update_data['counts']['total'] : 0;
+
+		$payload['updateCounts'] = array(
+			'total'     => $update_total,
+			'formatted' => number_format_i18n( $update_total ),
+			'text'      => sprintf(
+				/* translators: %s: number of pending updates. */
+				_n( '%s update available', '%s updates available', $update_total, 'desktop-mode' ),
+				number_format_i18n( $update_total )
+			),
+			'url'       => network_admin_url( 'update-core.php' ),
+		);
+	}
+
 	// A cheap structural fingerprint of the admin menu the shell uses to
 	// decide whether a live refresh is warranted. Shipped in every full
 	// payload so the shell can seed / update its last-known signature

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1089,9 +1089,23 @@ function desktop_mode_chromeless_bridge_script() {
 		/* Harvest is best-effort; on any failure we still ship the
 		 * server-built payload, which is exactly the pre-fix behavior. */
 	}
+	/*
+	 * Menu payload / signature target: the SHELL, i.e. the top window —
+	 * not the immediate parent. For a normal window iframe the two are
+	 * the same frame, but the bulk updater nests: update-core.php (the
+	 * window iframe) hosts a progress iframe of `update.php?action=
+	 * update-selected`, whose `iframe_footer()` fires `admin_footer`
+	 * AFTER the upgrades ran — exactly the fresh payload the shell
+	 * wants. Posting that to `window.parent` hands it to the
+	 * update-core.php page, which has no listener, and the dock badge
+	 * stays stale (GH#296). `window.top` reaches the shell from any
+	 * nesting depth; the targetOrigin pin means a cross-origin top
+	 * (foreign page iframing wp-admin) simply never receives it.
+	 */
 	try {
+		var __wpdShell = window.top || window.parent;
 		if ( __DESKTOP_MODE_MENU_PAYLOAD__ ) {
-			window.parent.postMessage(
+			__wpdShell.postMessage(
 				{
 					type: 'desktop-mode-plugins-changed',
 					payload: __DESKTOP_MODE_MENU_PAYLOAD__
@@ -1107,7 +1121,7 @@ function desktop_mode_chromeless_bridge_script() {
 			 * menu on save, …) and spend a refresh probe only then.
 			 * GH#325.
 			 */
-			window.parent.postMessage(
+			__wpdShell.postMessage(
 				{
 					type: 'desktop-mode-menu-signature',
 					sig: __DESKTOP_MODE_MENU_SIG__
@@ -3067,6 +3081,73 @@ function desktop_mode_chromeless_bridge_script() {
 					try { window.location.reload(); } catch ( _err ) { /* swallow */ }
 				}
 			} );
+		}
+		attach();
+		if ( document.readyState === 'loading' ) {
+			document.addEventListener( 'DOMContentLoaded', attach, { once: true } );
+		}
+		window.addEventListener( 'load', attach, { once: true } );
+	} )();
+
+	/* -----------------------------------------------------------------
+	 * Shiny-update watcher (GH#296).
+	 *
+	 * Core's updates.js applies plugin/theme updates and deletes over
+	 * AJAX — no navigation, so the load-time payload emit above never
+	 * re-fires and the shell's update notifiers (admin-bar circle-arrows
+	 * count, dock Plugins badge) keep showing the pre-update numbers
+	 * until a hard refresh. Watch the jQuery events updates.js triggers
+	 * on `document` after each job and nudge the shell to spend one
+	 * `refreshMenu()` probe, whose payload carries fresh counts.
+	 *
+	 * Error events are included deliberately: `wp_ajax_update_plugin`
+	 * calls `wp_update_plugins()` up front, which can mutate the
+	 * update transient even when the upgrade itself fails.
+	 *
+	 * When updates.js is processing a queue (bulk-selected shiny
+	 * updates), per-job events fire while later jobs are still
+	 * pending — skip those and let the final job's event send the one
+	 * nudge. The shell debounces on its side too, so this is purely
+	 * an optimization, not a correctness gate.
+	 *
+	 * If jQuery never loads on this page this block is a no-op — and
+	 * so is updates.js, which requires it.
+	 * ----------------------------------------------------------------- */
+	( function _wpdInstallShinyUpdateWatcher() {
+		var attached = false;
+		function notify() {
+			try {
+				var queue = window.wp && window.wp.updates && window.wp.updates.queue;
+				if ( queue && queue.length > 0 ) {
+					return;
+				}
+			} catch ( _err ) { /* queue introspection is best-effort */ }
+			try {
+				var shell = window.top || window.parent;
+				if ( shell && shell !== window ) {
+					shell.postMessage(
+						{ type: 'desktop-mode-updates-changed' },
+						window.location.origin
+					);
+				}
+			} catch ( _err ) { /* shell gone or cross-origin */ }
+		}
+		function attach() {
+			if ( attached || ! window.jQuery ) {
+				return;
+			}
+			attached = true;
+			window.jQuery( document ).on(
+				[
+					'wp-plugin-update-success.wpdUpdates',
+					'wp-plugin-update-error.wpdUpdates',
+					'wp-plugin-delete-success.wpdUpdates',
+					'wp-theme-update-success.wpdUpdates',
+					'wp-theme-update-error.wpdUpdates',
+					'wp-theme-delete-success.wpdUpdates'
+				].join( ' ' ),
+				notify
+			);
 		}
 		attach();
 		if ( document.readyState === 'loading' ) {

--- a/src/admin-bar-updates.ts
+++ b/src/admin-bar-updates.ts
@@ -1,0 +1,137 @@
+/**
+ * Admin-bar "updates" notifier repaint.
+ *
+ * Core renders `#wp-admin-bar-updates` (the circle-arrows icon + count
+ * at the top-left) as static server HTML when the shell page loads —
+ * and omits the node entirely when nothing is pending. After an
+ * in-window update run the numbers are stale until a hard refresh
+ * (GH#296), so the live menu-refresh payload now carries the aggregate
+ * counts (`updateCounts`, built by `desktop_mode_build_menu_payload()`)
+ * and this module mirrors them onto the node: text + screen-reader
+ * label when the count changes, hidden at zero, re-created when
+ * updates appear on a shell that booted with none.
+ *
+ * All user-facing strings arrive prebuilt (translated + number-
+ * formatted) from PHP, so this module never touches i18n.
+ *
+ * @since 0.9.7
+ */
+
+/** Shape of the payload's `updateCounts` key. */
+export interface UpdateCountsEntry {
+	/** Aggregate pending-update count (`wp_get_update_data()` total). */
+	total: number;
+	/** Locale-formatted count for the visible label ("3"). */
+	formatted: string;
+	/** Screen-reader text ("3 updates available"). */
+	text: string;
+	/** The update-core.php URL the node links to. */
+	url: string;
+}
+
+/** Runtime-narrow an unknown payload value into `UpdateCountsEntry`. */
+export function parseUpdateCounts( raw: unknown ): UpdateCountsEntry | null {
+	if ( ! raw || typeof raw !== 'object' ) {
+		return null;
+	}
+	const entry = raw as Record< string, unknown >;
+	if ( typeof entry.total !== 'number' || ! Number.isFinite( entry.total ) ) {
+		return null;
+	}
+	return {
+		total: Math.max( 0, Math.floor( entry.total ) ),
+		formatted:
+			typeof entry.formatted === 'string' && entry.formatted !== ''
+				? entry.formatted
+				: String( entry.total ),
+		text: typeof entry.text === 'string' ? entry.text : '',
+		url: typeof entry.url === 'string' ? entry.url : '',
+	};
+}
+
+/**
+ * Build a fresh `#wp-admin-bar-updates` node mirroring Core's
+ * `wp_admin_bar_updates_menu()` markup, so admin-bar CSS (which keys
+ * off the ids/classes) styles it identically to a server-rendered one.
+ */
+function createNode( counts: UpdateCountsEntry ): HTMLLIElement | null {
+	if ( ! counts.url ) {
+		// Without a target URL the node would be a dead link — leave
+		// the bar alone and let the next full page load render it.
+		return null;
+	}
+	const li = document.createElement( 'li' );
+	li.id = 'wp-admin-bar-updates';
+
+	const anchor = document.createElement( 'a' );
+	anchor.className = 'ab-item';
+	anchor.href = counts.url;
+
+	const icon = document.createElement( 'span' );
+	icon.className = 'ab-icon';
+	icon.setAttribute( 'aria-hidden', 'true' );
+
+	const label = document.createElement( 'span' );
+	label.className = 'ab-label';
+	label.setAttribute( 'aria-hidden', 'true' );
+
+	const srText = document.createElement( 'span' );
+	srText.className = 'screen-reader-text updates-available-text';
+
+	anchor.append( icon, label, srText );
+	li.appendChild( anchor );
+	return li;
+}
+
+/**
+ * Mirror fresh update counts onto the admin-bar node. Safe no-op when
+ * the shell has no admin bar (headless tests, exotic chrome).
+ */
+export function applyAdminBarUpdates( raw: unknown ): void {
+	const counts = parseUpdateCounts( raw );
+	if ( ! counts ) {
+		return;
+	}
+
+	let node = document.getElementById( 'wp-admin-bar-updates' );
+
+	if ( counts.total <= 0 ) {
+		// Core omits the node entirely at zero; hiding (rather than
+		// removing) keeps repaints cheap when updates reappear later.
+		if ( node ) {
+			node.style.display = 'none';
+		}
+		return;
+	}
+
+	if ( ! node ) {
+		// The shell booted with zero pending updates, so Core never
+		// rendered the node — build one in Core's slot (before the
+		// comments bubble, matching admin_bar_menu priority order).
+		const bar = document.getElementById( 'wp-admin-bar-root-default' );
+		if ( ! bar ) {
+			return;
+		}
+		node = createNode( counts );
+		if ( ! node ) {
+			return;
+		}
+		const comments = document.getElementById( 'wp-admin-bar-comments' );
+		if ( comments && comments.parentNode === bar ) {
+			bar.insertBefore( node, comments );
+		} else {
+			bar.appendChild( node );
+		}
+	}
+
+	node.style.display = '';
+
+	const label = node.querySelector( '.ab-label' );
+	if ( label ) {
+		label.textContent = counts.formatted;
+	}
+	const srText = node.querySelector( '.updates-available-text' );
+	if ( srText ) {
+		srText.textContent = counts.text;
+	}
+}

--- a/src/boot/menu-refresh.ts
+++ b/src/boot/menu-refresh.ts
@@ -51,6 +51,14 @@ import type {
  */
 const MENU_REFRESH_TIMEOUT_MS = 8000;
 
+/**
+ * Trailing debounce for `desktop-mode-updates-changed` nudges. Long
+ * enough to collapse the burst from several open windows reporting the
+ * same shiny-update run, short enough that the badge repaint still
+ * reads as immediate.
+ */
+const UPDATES_REFRESH_DEBOUNCE_MS = 600;
+
 export interface MenuRefreshDeps {
 	layoutDispatcher: LayoutDispatcher | null;
 	desktopArea: HTMLElement;
@@ -142,6 +150,18 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 	// can't spawn overlapping refresh probes for the same change.
 	let sigRefreshInFlight = false;
 
+	// `desktop-mode-updates-changed` scheduling state. The chromeless
+	// bridge nudges after Core's shiny (AJAX) plugin/theme updates and
+	// deletes complete (GH#296); the nudge carries no payload, so the
+	// shell answers with one refresh probe. Debounce collapses a burst
+	// (several windows watching the same run), and the in-flight flag +
+	// queued bit guarantee a nudge that lands mid-probe still gets a
+	// fresh probe afterwards — that probe's counts would predate the
+	// change that triggered the nudge.
+	let updatesRefreshTimer: number | null = null;
+	let updatesRefreshInFlight = false;
+	let updatesRefreshQueued = false;
+
 	const refresh = (): Promise< void > => {
 		if ( ! config.adminUrl ) {
 			return Promise.resolve();
@@ -212,6 +232,31 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 		} );
 	};
 
+	const runUpdatesRefresh = (): void => {
+		if ( updatesRefreshInFlight ) {
+			updatesRefreshQueued = true;
+			return;
+		}
+		updatesRefreshInFlight = true;
+		void refresh().finally( () => {
+			updatesRefreshInFlight = false;
+			if ( updatesRefreshQueued ) {
+				updatesRefreshQueued = false;
+				runUpdatesRefresh();
+			}
+		} );
+	};
+
+	const scheduleUpdatesRefresh = (): void => {
+		if ( updatesRefreshTimer !== null ) {
+			window.clearTimeout( updatesRefreshTimer );
+		}
+		updatesRefreshTimer = window.setTimeout( () => {
+			updatesRefreshTimer = null;
+			runUpdatesRefresh();
+		}, UPDATES_REFRESH_DEBOUNCE_MS );
+	};
+
 	window.addEventListener( 'message', ( e: MessageEvent ) => {
 		if ( e.origin !== INITIAL_ORIGIN ) {
 			return;
@@ -257,6 +302,16 @@ export function bindMenuRefresh( deps: MenuRefreshDeps ): () => Promise< void > 
 					lastMenuSig = data.payload.menuSig;
 				}
 			}
+			return;
+		}
+
+		if ( data.type === 'desktop-mode-updates-changed' ) {
+			// A chromeless page reports that Core's shiny updater just
+			// finished a plugin/theme update or delete run. The update
+			// transient changed server-side without any navigation, so
+			// no full payload is coming on its own — spend one probe to
+			// pull fresh badge + admin-bar counts. GH#296.
+			scheduleUpdatesRefresh();
 			return;
 		}
 

--- a/src/menu-refresh-apply.ts
+++ b/src/menu-refresh-apply.ts
@@ -34,6 +34,7 @@ import type {
 	NativeWindowServerEntry,
 } from './types';
 import { applyServerWindowNotices } from './window-notices-server-sync';
+import { applyAdminBarUpdates } from './admin-bar-updates';
 
 /** Shape of every payload key the bridge may carry. */
 export interface MenuRefreshPayload {
@@ -52,6 +53,7 @@ export interface MenuRefreshPayload {
 	serverWindowNotices?: unknown;
 	serverGames?: unknown;
 	desktopIcons?: unknown;
+	updateCounts?: unknown;
 }
 
 /** Dependencies the applier needs from the shell. */
@@ -415,5 +417,13 @@ export function createApplyPayload(
 				desktopIcons as ReadonlyArray< { id?: unknown } >,
 			);
 		}
+
+		// Admin-bar "updates" notifier — mirror the aggregate pending-
+		// update counts onto Core's `#wp-admin-bar-updates` node (label,
+		// screen-reader text, hidden at zero). Without this, the count
+		// rendered at shell boot survives every in-window update run
+		// until a hard refresh (GH#296). Missing key (older payload)
+		// means "no change."
+		applyAdminBarUpdates( payload.updateCounts );
 	};
 }

--- a/tests/phpunit/tests/desktopModeBuildDockItems.php
+++ b/tests/phpunit/tests/desktopModeBuildDockItems.php
@@ -802,6 +802,49 @@ class Tests_DesktopMode_BuildDockItems extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The payload aggregates pending-update counts so the shell can
+	 * repaint the admin-bar "updates" notifier live (GH#296) — the
+	 * top-left circle-arrows badge is static server HTML that would
+	 * otherwise show its boot-time count until a hard refresh.
+	 *
+	 * @covers ::desktop_mode_build_menu_payload
+	 */
+	public function test_payload_carries_update_counts() {
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+
+		global $menu;
+		$menu = array(
+			$this->make_menu_row( 'Dashboard', 'read', 'index.php' ),
+		);
+
+		// Two pending plugin updates, nothing else. Mirrors the raw
+		// transient shape wp_get_update_data() counts.
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'response' => array(
+					'foo/foo.php' => (object) array( 'new_version' => '2.0' ),
+					'bar/bar.php' => (object) array( 'new_version' => '1.1' ),
+				),
+			)
+		);
+
+		$payload = desktop_mode_build_menu_payload();
+
+		$this->assertArrayHasKey( 'updateCounts', $payload );
+		$counts = $payload['updateCounts'];
+		$this->assertSame( 2, $counts['total'] );
+		$this->assertSame( '2', $counts['formatted'] );
+		$this->assertSame( '2 updates available', $counts['text'] );
+		$this->assertSame( network_admin_url( 'update-core.php' ), $counts['url'] );
+
+		// And the zero case — the client hides the node on this signal.
+		set_site_transient( 'update_plugins', (object) array( 'response' => array() ) );
+		$payload = desktop_mode_build_menu_payload();
+		$this->assertSame( 0, $payload['updateCounts']['total'] );
+	}
+
+	/**
 	 * Core menu slugs never resolve to a plugin file — even if some
 	 * callback happens to be registered on the page hook. The classifier
 	 * short-circuits before reflecting on $wp_filter, so the dock never

--- a/tests/vitest/admin-bar-updates.test.ts
+++ b/tests/vitest/admin-bar-updates.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for `src/admin-bar-updates.ts`.
+ *
+ * The live menu-refresh payload carries `updateCounts` (aggregate
+ * pending-update numbers built by `desktop_mode_build_menu_payload()`)
+ * and `applyAdminBarUpdates()` mirrors them onto Core's
+ * `#wp-admin-bar-updates` node — the top-left circle-arrows notifier
+ * that otherwise shows its boot-time count until a hard refresh
+ * (GH#296).
+ */
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+	applyAdminBarUpdates,
+	parseUpdateCounts,
+} from '../../src/admin-bar-updates';
+
+const UPDATE_CORE_URL = 'https://example.test/wp-admin/update-core.php';
+
+function counts( total: number ): unknown {
+	return {
+		total,
+		formatted: String( total ),
+		text:
+			total === 1
+				? '1 update available'
+				: `${ total } updates available`,
+		url: UPDATE_CORE_URL,
+	};
+}
+
+/** Server-rendered admin bar with the updates node present (count 3). */
+function mountBarWithUpdatesNode(): void {
+	document.body.innerHTML = `
+		<div id="wpadminbar">
+			<ul id="wp-admin-bar-root-default">
+				<li id="wp-admin-bar-site-name"><a class="ab-item" href="#">Site</a></li>
+				<li id="wp-admin-bar-updates">
+					<a class="ab-item" href="${ UPDATE_CORE_URL }">
+						<span class="ab-icon" aria-hidden="true"></span>
+						<span class="ab-label" aria-hidden="true">3</span>
+						<span class="screen-reader-text updates-available-text">3 updates available</span>
+					</a>
+				</li>
+				<li id="wp-admin-bar-comments"><a class="ab-item" href="#">Comments</a></li>
+			</ul>
+		</div>
+	`;
+}
+
+/** Server-rendered admin bar with NO updates node (booted at zero). */
+function mountBarWithoutUpdatesNode(): void {
+	document.body.innerHTML = `
+		<div id="wpadminbar">
+			<ul id="wp-admin-bar-root-default">
+				<li id="wp-admin-bar-site-name"><a class="ab-item" href="#">Site</a></li>
+				<li id="wp-admin-bar-comments"><a class="ab-item" href="#">Comments</a></li>
+			</ul>
+		</div>
+	`;
+}
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'parseUpdateCounts', () => {
+	test( 'rejects non-objects and missing totals', () => {
+		expect( parseUpdateCounts( undefined ) ).toBeNull();
+		expect( parseUpdateCounts( null ) ).toBeNull();
+		expect( parseUpdateCounts( 'nope' ) ).toBeNull();
+		expect( parseUpdateCounts( {} ) ).toBeNull();
+		expect( parseUpdateCounts( { total: 'three' } ) ).toBeNull();
+		expect( parseUpdateCounts( { total: NaN } ) ).toBeNull();
+	} );
+
+	test( 'normalizes totals and fills string fallbacks', () => {
+		expect( parseUpdateCounts( { total: 2.9 } ) ).toEqual( {
+			total: 2,
+			formatted: '2.9',
+			text: '',
+			url: '',
+		} );
+		expect( parseUpdateCounts( { total: -4 } )?.total ).toBe( 0 );
+	} );
+} );
+
+describe( 'applyAdminBarUpdates', () => {
+	test( 'updates label and screen-reader text on the existing node', () => {
+		mountBarWithUpdatesNode();
+		applyAdminBarUpdates( counts( 1 ) );
+
+		const node = document.getElementById( 'wp-admin-bar-updates' )!;
+		expect( node.style.display ).toBe( '' );
+		expect( node.querySelector( '.ab-label' )?.textContent ).toBe( '1' );
+		expect(
+			node.querySelector( '.updates-available-text' )?.textContent,
+		).toBe( '1 update available' );
+	} );
+
+	test( 'hides the node when the count drops to zero', () => {
+		mountBarWithUpdatesNode();
+		applyAdminBarUpdates( counts( 0 ) );
+
+		const node = document.getElementById( 'wp-admin-bar-updates' )!;
+		expect( node.style.display ).toBe( 'none' );
+	} );
+
+	test( 'zero → N → zero round-trips through the same node', () => {
+		mountBarWithUpdatesNode();
+		applyAdminBarUpdates( counts( 0 ) );
+		applyAdminBarUpdates( counts( 5 ) );
+
+		const node = document.getElementById( 'wp-admin-bar-updates' )!;
+		expect( node.style.display ).toBe( '' );
+		expect( node.querySelector( '.ab-label' )?.textContent ).toBe( '5' );
+
+		applyAdminBarUpdates( counts( 0 ) );
+		expect( node.style.display ).toBe( 'none' );
+	} );
+
+	test( 'creates the node in Core slot order when the shell booted at zero', () => {
+		mountBarWithoutUpdatesNode();
+		applyAdminBarUpdates( counts( 2 ) );
+
+		const node = document.getElementById( 'wp-admin-bar-updates' );
+		expect( node ).not.toBeNull();
+		// Core order: site-name (30) → updates (50) → comments (60).
+		expect( node!.nextElementSibling?.id ).toBe( 'wp-admin-bar-comments' );
+		const anchor = node!.querySelector( 'a.ab-item' ) as HTMLAnchorElement;
+		expect( anchor.href ).toBe( UPDATE_CORE_URL );
+		expect( node!.querySelector( '.ab-label' )?.textContent ).toBe( '2' );
+		expect(
+			node!.querySelector( '.updates-available-text' )?.textContent,
+		).toBe( '2 updates available' );
+		expect(
+			node!.querySelector( '.ab-icon' )?.getAttribute( 'aria-hidden' ),
+		).toBe( 'true' );
+	} );
+
+	test( 'does not create a node for a zero count', () => {
+		mountBarWithoutUpdatesNode();
+		applyAdminBarUpdates( counts( 0 ) );
+		expect( document.getElementById( 'wp-admin-bar-updates' ) ).toBeNull();
+	} );
+
+	test( 'does not create a dead-link node when the payload has no URL', () => {
+		mountBarWithoutUpdatesNode();
+		applyAdminBarUpdates( { total: 2, formatted: '2', text: '', url: '' } );
+		expect( document.getElementById( 'wp-admin-bar-updates' ) ).toBeNull();
+	} );
+
+	test( 'is a no-op without an admin bar in the DOM', () => {
+		document.body.innerHTML = '<div id="desktop-mode-area"></div>';
+		expect( () => applyAdminBarUpdates( counts( 3 ) ) ).not.toThrow();
+	} );
+
+	test( 'ignores payloads without the key (older bridge)', () => {
+		mountBarWithUpdatesNode();
+		applyAdminBarUpdates( undefined );
+		const node = document.getElementById( 'wp-admin-bar-updates' )!;
+		expect( node.querySelector( '.ab-label' )?.textContent ).toBe( '3' );
+		expect( node.style.display ).toBe( '' );
+	} );
+} );

--- a/tests/vitest/menu-refresh-apply.test.ts
+++ b/tests/vitest/menu-refresh-apply.test.ts
@@ -379,6 +379,60 @@ describe( 'menu-refresh-apply.createApplyPayload', () => {
 		} );
 	} );
 
+	// GH#296: the payload's `updateCounts` must repaint the admin-bar
+	// "updates" notifier — the top-left circle-arrows count is static
+	// server HTML that otherwise survives every in-window update run.
+	describe( 'updateCounts live-refresh (GH#296)', () => {
+		test( 'fresh counts repaint #wp-admin-bar-updates; zero hides it', () => {
+			document.body.innerHTML = `
+				<ul id="wp-admin-bar-root-default">
+					<li id="wp-admin-bar-updates">
+						<a class="ab-item" href="https://example.test/wp-admin/update-core.php">
+							<span class="ab-icon" aria-hidden="true"></span>
+							<span class="ab-label" aria-hidden="true">3</span>
+							<span class="screen-reader-text updates-available-text">3 updates available</span>
+						</a>
+					</li>
+				</ul>
+			`;
+			const { deps } = makeDeps();
+			const apply = createApplyPayload( deps );
+
+			apply( {
+				dockItems: [ ...MIN_DOCK ],
+				updateCounts: {
+					total: 0,
+					formatted: '0',
+					text: '0 updates available',
+					url: 'https://example.test/wp-admin/update-core.php',
+				},
+			} );
+
+			const node = document.getElementById( 'wp-admin-bar-updates' )!;
+			expect( node.style.display ).toBe( 'none' );
+			document.body.innerHTML = '';
+		} );
+
+		test( 'missing key (older bridge): leaves the node untouched', () => {
+			document.body.innerHTML = `
+				<ul id="wp-admin-bar-root-default">
+					<li id="wp-admin-bar-updates">
+						<a class="ab-item" href="#"><span class="ab-label">3</span></a>
+					</li>
+				</ul>
+			`;
+			const { deps } = makeDeps();
+			const apply = createApplyPayload( deps );
+
+			apply( { dockItems: [ ...MIN_DOCK ] } );
+
+			const node = document.getElementById( 'wp-admin-bar-updates' )!;
+			expect( node.style.display ).not.toBe( 'none' );
+			expect( node.querySelector( '.ab-label' )?.textContent ).toBe( '3' );
+			document.body.innerHTML = '';
+		} );
+	} );
+
 	test( 'serverTitleBarButtonScripts: live-refresh contract', () => {
 		// Same shape of regression risk as desktopIcons — recently
 		// added payload key, easy to forget to wire on the live


### PR DESCRIPTION
Closes #296

## What it does

After updating plugins (or themes) inside the desktop shell, the two update notifiers now reset live, with no hard refresh:

- the admin-bar **circle-arrows count** at the top-left (`#wp-admin-bar-updates`) — the element reported in #296,
- the **dock Plugins badge**.

Both flows are covered: per-plugin "update now" links on `plugins.php` (Core's shiny AJAX updater) and the bulk "Update Plugins" run on the Updates screen. When the count reaches zero the admin-bar node disappears, exactly as a fresh server render would; if updates appear later on a shell that booted clean, the node is re-created in Core's slot order.

## Rationale

Two gaps compounded:

1. The chromeless bridge emits a fresh menu payload only on a **full page load** of `plugins.php` / `themes.php` / etc. Shiny updates run over AJAX with no navigation, so the shell never learned the counts changed — the dock badge went stale.
2. Nothing ever repainted `#wp-admin-bar-updates`: it is static server HTML rendered at shell boot, so even a fresh payload could not fix it.

A third, related gap: the bulk updater nests a progress iframe (`update-core.php` → `update.php?action=update-selected`) whose `iframe_footer()` fires `admin_footer` *after* the upgrades ran — a perfectly fresh payload — but posted it to `window.parent`, i.e. the intermediate `update-core.php` page, which has no listener.

## Implementation

Follows the existing live-refresh pattern (payload key + shell applier), no new mechanism:

- **`includes/render/chromeless-bridge.php`** — a shiny-update watcher binds the jQuery events `updates.js` triggers on `document` (`wp-plugin-update-success` / `-error`, `wp-plugin-delete-success`, theme counterparts) and posts a payload-less `desktop-mode-updates-changed` nudge once `wp.updates.queue` is drained. Error events are included deliberately: `wp_ajax_update_plugin` calls `wp_update_plugins()` up front, which can mutate the transient even when the upgrade fails. The payload/signature emit now targets the **top** window instead of the immediate parent — identical for normal window iframes, and it lets the nested bulk-updater payload reach the shell.
- **`includes/core/payload.php`** — the menu payload gains `updateCounts` (`total`, locale-formatted count, translated screen-reader text, `update-core.php` URL) from capability-aware `wp_get_update_data()`, prebuilt server-side so the client repaint stays locale-correct.
- **`src/boot/menu-refresh.ts`** — handles the nudge with a 600 ms trailing debounce plus in-flight coalescing (a nudge landing mid-probe queues exactly one follow-up probe), then spends one existing `refreshMenu()` probe.
- **`src/admin-bar-updates.ts`** (new, wired from `src/menu-refresh-apply.ts`) — mirrors `updateCounts` onto the admin-bar node: label + screen-reader text, hidden at zero, re-created mirroring Core's `wp_admin_bar_updates_menu()` markup when absent. Missing key (older payload) means "no change". The dock badge needs no new code — the probe's payload already recomputes it.

Docs updated in the same change: `docs/javascript-reference.md` (payload shape + new message), `docs/api-index.md`, and the payload key listing in `AGENTS.md`.

## Testing instructions

```bash
npm run test:js    # includes 8 new cases for the admin-bar repaint + 2 payload-contract cases
npm run test:php -- --filter test_payload_carries_update_counts
```

Manual repro (mirrors the issue):

1. Install outdated plugins, e.g. `wp plugin install classic-editor --version=1.6.5` and `wp plugin install akismet --version=5.3`, then `wp eval 'wp_update_plugins();'`.
2. Load the desktop shell — top-left shows the circle-arrows count, the dock Plugins tile shows a badge.
3. Update the plugins from the Plugins window ("update now" links) — the count steps down live and both notifiers disappear at zero.
4. Repeat via the Updates screen with "Update Plugins" (bulk) — same live reset when the run completes.

Verified end-to-end on wp-env: counter stepped 3→2→1→hidden with per-plugin updates, and the bulk run cleared both notifiers the moment "All updates have been completed" appeared. Full suites green: 2178 vitest tests, 1333 PHPUnit tests, typecheck, ESLint, PHPCS (no new violations).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-408-efd24bb6366a4e8a9ecc3a0d2ad9837bd95ce0c6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->