### PR TITLE
fix: sync package-lock.json engines.node with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"vitest": "^4.1.4"
 			},
 			"engines": {
-				"node": ">=24.0.0"
+				"node": ">=24.0.0 <25.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Summary
- `package-lock.json`'s root `engines.node` was stale (`>=24.0.0`), out of sync with `package.json`'s `>=24.0.0 <25.0.0`. Running `npm install` against a stale lockfile can silently leave older dependency versions in place (this is how `@wordpress/env` ended up pinned at `10.39.0` locally instead of the `^11.7.0` the repo requires).

## Test plan
- [x] `npm install` regenerates the lockfile with no further diff
- [x] `WP_ENV_PORT=8894 npm run env:start` succeeds

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-413-533f17d453b65aead6ad61593dc2bab7266a55e2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->