### PR TITLE
Fix window drag bounds

### DIFF
--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -66,6 +66,7 @@ import {
 } from './snap-zones';
 import { cancelOverviewTimers, enterOverview, exitOverview } from './overview';
 import { loadNativeWindowGeometry } from './native-window-geometry';
+import { clampWindowPosition } from '../window/pointer';
 
 /** Base z-index for desktop windows. */
 const BASE_Z_INDEX = 100;
@@ -379,9 +380,12 @@ export class WindowManager {
 	/**
 	 * Re-apply state-driven bounds to any window whose geometry is
 	 * derived from the desktop area's dimensions: maximized (full
-	 * area) and snapped-left / snapped-right (half area). Called from
-	 * the desktop-area ResizeObserver so shrinking the browser window
-	 * drags the stateful windows along with it.
+	 * area) and snapped-left / snapped-right (half area). Also
+	 * clamps normal (floating) windows to the GRAB_MARGIN boundaries
+	 * so they are not stranded off-screen when the viewport shrinks.
+	 *
+	 * Called from the desktop-area ResizeObserver so shrinking the
+	 * browser window drags the windows along with it.
 	 *
 	 * Inlines the geometry writes instead of calling `applySnap` —
 	 * that method emits `_emitChange('state')` which would spam the
@@ -424,6 +428,18 @@ export class WindowManager {
 				w.element.style.top = '0px';
 				w.element.style.width = `${ halfW }px`;
 				w.element.style.height = `${ height }px`;
+			} else if ( w.state === 'normal' ) {
+				const currentX = parseInt( w.element.style.left, 10 ) || 0;
+				const currentY = parseInt( w.element.style.top, 10 ) || 0;
+				const width = w.element.offsetWidth || 0;
+
+				const safe = clampWindowPosition( currentX, currentY, width, parent.clientWidth, parent.clientHeight );
+
+				if ( currentX !== safe.x || currentY !== safe.y ) {
+					w.element.classList.add( 'desktop-mode-window--reflowing' );
+					w.element.style.left = `${ safe.x }px`;
+					w.element.style.top = `${ safe.y }px`;
+				}
 			}
 		}
 

--- a/src/window/constants.ts
+++ b/src/window/constants.ts
@@ -20,6 +20,13 @@
 export const EDGE_MARGIN = 0;
 
 /**
+ * Minimum visible area (in pixels) of the title bar that must remain
+ * on-screen when dragging or reflowing windows. Prevents the window
+ * from becoming completely unreachable.
+ */
+export const GRAB_MARGIN = 40;
+
+/**
  * Minimum cursor travel (in pixels) before a pointerdown counts as a
  * drag rather than a click. Applied as squared distance so the check
  * is cheap (no sqrt) inside the pointermove loop. 5 px matches the

--- a/src/window/pointer.ts
+++ b/src/window/pointer.ts
@@ -14,7 +14,7 @@
  */
 
 import { doAction, HOOKS } from '../hooks';
-import { DRAG_THRESHOLD_SQUARED, EDGE_MARGIN } from './constants';
+import { DRAG_THRESHOLD_SQUARED, EDGE_MARGIN, GRAB_MARGIN } from './constants';
 import type { Window } from './index';
 
 /**
@@ -229,11 +229,12 @@ export function handleDragStart( win: Window, e: PointerEvent ): void {
 		let x = ev.clientX - win._dragOffsetX;
 		let y = ev.clientY - win._dragOffsetY;
 
-		// Constrain to desktop bounds.
+		// Constrain to desktop bounds keeping GRAB_MARGIN visible.
 		const desktop = win.element.parentElement;
 		if ( desktop ) {
-			x = Math.max( EDGE_MARGIN, Math.min( x, desktop.clientWidth - EDGE_MARGIN ) );
-			y = Math.max( EDGE_MARGIN, Math.min( y, desktop.clientHeight - EDGE_MARGIN ) );
+			const safe = clampWindowPosition( x, y, win.element.offsetWidth, desktop.clientWidth, desktop.clientHeight );
+			x = safe.x;
+			y = safe.y;
 		}
 
 		// Quantise to the live grid when snap is on. Round (not floor)
@@ -387,17 +388,24 @@ function commitUnstate(
 	);
 	win.element.style.width = `${ params.targetW }px`;
 	win.element.style.height = `${ params.targetH }px`;
-	// Clamp the re-anchor to the same lower bound the drag-move loop
-	// enforces. A snapped-LEFT window whose floating width exceeds the
+	// Clamp the initial re-anchor to EDGE_MARGIN (0) on the left so the
+	// window doesn't start the drag already half off-screen. The drag-move
+	// loop (clampWindowPosition) uses a looser bound — GRAB_MARGIN - width —
+	// which allows the window to bleed past the left edge as long as
+	// GRAB_MARGIN px of the title bar stays visible. Using EDGE_MARGIN here
+	// is intentionally tighter: we want the snap-to-float commit to land in
+	// a fully-reachable position, and any subsequent left-bleed is then the
+	// user's own drag choice.
+	// Background: a snapped-LEFT window whose floating width exceeds the
 	// half-screen would otherwise re-anchor at a NEGATIVE left (cursor
 	// ratio × restored width reaches past the desktop's left edge),
-	// and since the drag offsets derive from the position written
-	// here, every subsequent move stays negative too — the move-loop
-	// clamp then pins the window at x=0 until the cursor has traveled
-	// the whole overshoot, which reads as "the left window can't be
-	// dragged out of split view." Snapped-RIGHT never overshoots (its
-	// cursor sits in the right half, so the anchor math stays
-	// positive) — that asymmetry was the bug's tell.
+	// and since the drag offsets derive from the position written here,
+	// every subsequent move stays negative too — the move-loop clamp then
+	// pins the window at x=0 until the cursor has traveled the whole
+	// overshoot, which reads as "the left window can't be dragged out of
+	// split view." Snapped-RIGHT never overshoots (its cursor sits in the
+	// right half, so the anchor math stays positive) — that asymmetry was
+	// the bug's tell.
 	const left = Math.max(
 		EDGE_MARGIN,
 		Math.round(
@@ -619,4 +627,27 @@ export function computeResize(
 	}
 
 	return { x, y, width, height };
+}
+
+/**
+ * Clamp a window's left/top coordinate to ensure a minimum clickable grab area
+ * (GRAB_MARGIN) remains visible within the parent desktop boundaries, and the top
+ * edge is strictly constrained above the top menu (EDGE_MARGIN).
+ */
+export function clampWindowPosition(
+	x: number,
+	y: number,
+	width: number,
+	desktopW: number,
+	desktopH: number,
+): { x: number; y: number } {
+	const minX = GRAB_MARGIN - width;
+	const maxX = desktopW - GRAB_MARGIN;
+	const safeX = Math.max( minX, Math.min( x, maxX ) );
+
+	const minY = EDGE_MARGIN;
+	const maxY = desktopH - GRAB_MARGIN;
+	const safeY = Math.max( minY, Math.min( y, maxY ) );
+
+	return { x: safeX, y: safeY };
 }

--- a/src/window/pointer.ts
+++ b/src/window/pointer.ts
@@ -229,11 +229,11 @@ export function handleDragStart( win: Window, e: PointerEvent ): void {
 		let x = ev.clientX - win._dragOffsetX;
 		let y = ev.clientY - win._dragOffsetY;
 
-		// Constrain to desktop bounds (prevents window from disappearing off edges).
+		// Constrain to desktop bounds.
 		const desktop = win.element.parentElement;
 		if ( desktop ) {
-			x = Math.max( EDGE_MARGIN, Math.min( x, desktop.clientWidth - win.element.offsetWidth - EDGE_MARGIN ) );
-			y = Math.max( EDGE_MARGIN, Math.min( y, desktop.clientHeight - win.element.offsetHeight - EDGE_MARGIN ) );
+			x = Math.max( EDGE_MARGIN, Math.min( x, desktop.clientWidth - EDGE_MARGIN ) );
+			y = Math.max( EDGE_MARGIN, Math.min( y, desktop.clientHeight - EDGE_MARGIN ) );
 		}
 
 		// Quantise to the live grid when snap is on. Round (not floor)

--- a/tests/vitest/drag-unstate.test.ts
+++ b/tests/vitest/drag-unstate.test.ts
@@ -8,7 +8,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
-import { handleDragStart } from '../../src/window/pointer';
+import { clampWindowPosition, handleDragStart } from '../../src/window/pointer';
 import { Window } from '../../src/window';
 import type { WindowConfig } from '../../src/types';
 
@@ -39,6 +39,16 @@ function mountWindow( cfg: WindowConfig ): {
 	document.body.appendChild( parent );
 	const win = new Window( cfg );
 	parent.appendChild( win.element );
+
+	Object.defineProperty( win.element, 'offsetWidth', {
+		get: () => parseInt( win.element.style.width, 10 ) || 0,
+		configurable: true,
+	} );
+	Object.defineProperty( win.element, 'offsetHeight', {
+		get: () => parseInt( win.element.style.height, 10 ) || 0,
+		configurable: true,
+	} );
+
 	return {
 		win,
 		parent,
@@ -343,5 +353,61 @@ describe( 'drag auto-unstate', () => {
 		expect( win.element.classList.contains( 'desktop-mode-window--dragging' ) ).toBe( false );
 		expect( win._isDragging ).toBe( false );
 		cleanup();
+	} );
+
+	test( 'drag bounds: allows bleeding off left, right, and bottom up to GRAB_MARGIN, locks top at y=0', () => {
+		const handle = mountWindow( baseConfig() );
+		const { win, cleanup } = handle;
+		Object.defineProperty( win._titleBar, 'setPointerCapture', { value: () => { /* noop */ } } );
+		Object.defineProperty( win._titleBar, 'getBoundingClientRect', {
+			value: () => ( {
+				left: 100, top: 100, right: 900, bottom: 140,
+				width: 800, height: 40, x: 100, y: 100, toJSON: () => ( {} ),
+			} ) as DOMRect,
+		} );
+
+		win.element.style.left = '100px';
+		win.element.style.top = '100px';
+		win.element.style.width = '800px';
+		win.element.style.height = '600px';
+
+		handleDragStart( win, fakePointer( win._titleBar, 150, 110 ) );
+
+		// 1. Drag far past the left edge -> minX = GRAB_MARGIN (40) - width (800) = -760px
+		fakeMove( win._titleBar, 150, 110, -1000, 0 );
+		expect( parseInt( win.element.style.left, 10 ) ).toBe( -760 );
+
+		// 2. Drag far past the top edge -> strictly locked at y = 0 (EDGE_MARGIN)
+		fakeMove( win._titleBar, 150, 110, 0, -1000 );
+		expect( parseInt( win.element.style.top, 10 ) ).toBe( 0 );
+
+		// 3. Drag far past the right edge -> desktop.clientWidth (1600) - GRAB_MARGIN (40) = 1560px
+		fakeMove( win._titleBar, 150, 110, 3000, 0 );
+		expect( parseInt( win.element.style.left, 10 ) ).toBe( 1560 );
+
+		// 4. Drag far past the bottom edge -> desktop.clientHeight (900) - GRAB_MARGIN (40) = 860px
+		fakeMove( win._titleBar, 150, 110, 0, 3000 );
+		expect( parseInt( win.element.style.top, 10 ) ).toBe( 860 );
+
+		cleanup();
+	} );
+} );
+
+describe( 'clampWindowPosition', () => {
+	test( 'clamps left/right/bottom to GRAB_MARGIN and top to EDGE_MARGIN', () => {
+		// Inside desktop bounds (no clamping needed)
+		expect( clampWindowPosition( 100, 100, 800, 1600, 900 ) ).toEqual( { x: 100, y: 100 } );
+
+		// Off left edge: minX = GRAB_MARGIN (40) - width (800) = -760
+		expect( clampWindowPosition( -1000, 100, 800, 1600, 900 ) ).toEqual( { x: -760, y: 100 } );
+
+		// Off top edge: minY = EDGE_MARGIN = 0
+		expect( clampWindowPosition( 100, -500, 800, 1600, 900 ) ).toEqual( { x: 100, y: 0 } );
+
+		// Off right edge: maxX = 1600 - GRAB_MARGIN (40) = 1560
+		expect( clampWindowPosition( 2000, 100, 800, 1600, 900 ) ).toEqual( { x: 1560, y: 100 } );
+
+		// Off bottom edge: maxY = 900 - GRAB_MARGIN (40) = 860
+		expect( clampWindowPosition( 100, 2000, 800, 1600, 900 ) ).toEqual( { x: 100, y: 860 } );
 	} );
 } );


### PR DESCRIPTION
## What?
Closes #404 

Allows windows to be dragged partially off-screen without losing access to them, and smoothly recovers stranded windows during browser resizes. 

## Why?

This allows to replicate how macOS and Windows naturally handle desktop boundaries: allowing users to push large windows partially out of the way to clear visual space. 

Previously, floating windows could be dragged completely off-screen and lost. A prior attempt to fix this (PR #406) strictly trapped windows inside the viewport, which felt a bit restrictive. Additionally, making the browser window smaller would leave floating windows completely stranded outside the visible desktop area with no way to retrieve them without refresh or making the browser window large. 

## How?

- **Revert**: Reverted the strict boundary constraints introduced in PR #406, replacing them with a grab-margin based approach.
- `src/window/constants.ts`: 
  - Added a 40px `GRAB_MARGIN` constant to ensure a minimum clickable grab area is always maintained.
- `src/window/pointer.ts`: 
  - Introduced `clampWindowPosition()` to let windows bleed off the left, right, and bottom edges, stopping only when just 40px of the title bar remains visible. The top edge strictly locks at `0`.
  - Updated `handleDragStart()` to enforce these new boundaries during drag moves.
- `src/window-manager/index.ts`: 
  - Updated `reflowStatefulWindows()` to include standard floating windows. If a browser resize leaves a window stranded off-screen, it smoothly pulls it back into the 40px grab area.
- `tests/vitest/drag-unstate.test.ts`:
  - Added dedicated unit tests for the new clamping constraints and drag bounds.

## Testing Instructions

1. Open a standard floating window.
2. Drag the window past the left, right, and bottom edges of the desktop. Verify it stops moving once only 40px of the title bar is left visible.
3. Drag the window to the top edge and verify it strictly stops at the top boundary.
4. Drag a window to the bottom-right corner, then shrink your browser window so the window is stranded outside the visible desktop area.
5. Verify the window smoothly reflows back into view, stopping at the 40px grab margin limit.

## Screencast

**Before**

https://github.com/user-attachments/assets/ab16343c-eb3b-4a65-ac3d-0fe63a6a12da

**After**

https://github.com/user-attachments/assets/eee58751-72bb-4d6d-a58c-9f5f964cc5ed


## Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini and Claude
Used for: Reviewing the existing implementation and suggesting the changes. Final decisions and edits were made by me.
