### PR TITLE
Focus Timer: react to the linked window closing

### DIFF
--- a/src/plugins/focus-timer-widget/desktop.ts
+++ b/src/plugins/focus-timer-widget/desktop.ts
@@ -27,6 +27,7 @@ interface WindowManager {
 
 interface DesktopApi {
 	windowManager?: WindowManager;
+	showToast?( opts: { message: string; type?: string } ): unknown;
 }
 
 function desktopApi(): DesktopApi | undefined {
@@ -63,4 +64,9 @@ export function shakeWindow( id: string ): boolean {
 	}
 	win.shake();
 	return true;
+}
+
+/** Show a transient toast via the shell (no-op if unavailable). */
+export function toast( message: string ): void {
+	desktopApi()?.showToast?.( { message } );
 }

--- a/src/plugins/focus-timer-widget/index.ts
+++ b/src/plugins/focus-timer-widget/index.ts
@@ -87,38 +87,21 @@ const mount = (
 	// --- Window link picker -------------------------------------------
 
 	function windowItems(): Array< { value: string; label: string } > {
-		const s = timer.snapshot();
 		const items: Array< { value: string; label: string } > = [
 			{
 				value: NONE,
 				label: __( 'No window — just alarm', 'desktop-mode' ),
 			},
 		];
-		let linkedStillOpen = false;
+		// Only currently-open windows are offered — a closed window is
+		// nothing to shake, so it never appears as a choice (issue #410).
 		for ( const w of listWindows() ) {
 			if ( w.id === WIDGET_ID ) {
 				continue;
 			}
 			items.push( {
 				value: w.id,
-				label:
-					w.config.title ||
-					__( 'Untitled window', 'desktop-mode' ),
-			} );
-			if ( w.id === s.linkedWindowId ) {
-				linkedStillOpen = true;
-			}
-		}
-		// The remembered window was closed — keep it visible as dangling
-		// rather than silently switching the selection to None.
-		if ( s.linkedWindowId && ! linkedStillOpen ) {
-			items.push( {
-				value: s.linkedWindowId,
-				label: sprintf(
-					/* translators: %s: window title/id. */
-					__( '%s (closed)', 'desktop-mode' ),
-					s.linkedWindowId,
-				),
+				label: w.config.title || __( 'Untitled window', 'desktop-mode' ),
 			} );
 		}
 		return items;
@@ -128,8 +111,13 @@ const mount = (
 		if ( ! windowSelect ) {
 			return;
 		}
-		windowSelect.items = windowItems();
-		windowSelect.value = timer.snapshot().linkedWindowId ?? NONE;
+		const items = windowItems();
+		windowSelect.items = items;
+		// Show the linked window only if it is still open; otherwise fall
+		// back to "No window".
+		const linked = timer.snapshot().linkedWindowId;
+		windowSelect.value =
+			linked && items.some( ( i ) => i.value === linked ) ? linked : NONE;
 	}
 
 	// --- Phase skeletons -----------------------------------------------

--- a/src/plugins/focus-timer-widget/timer.ts
+++ b/src/plugins/focus-timer-widget/timer.ts
@@ -19,7 +19,8 @@
  */
 
 import { Alarm } from './alarm';
-import { shakeWindow } from './desktop';
+import { shakeWindow, toast } from './desktop';
+import { __ } from '../../i18n';
 
 export type Phase = 'idle' | 'running' | 'paused' | 'finished';
 
@@ -70,6 +71,52 @@ class FocusTimer {
 	private readonly subs = new Set<() => void >();
 	private storage: StorageLike | null = null;
 	private hydrated = false;
+	private windowListenerInstalled = false;
+
+	constructor() {
+		this.installWindowListener();
+	}
+
+	/**
+	 * React to the linked window being closed. The runtime (not the view)
+	 * owns this subscription so it fires even when the widget card has
+	 * been torn down or re-docked — a running timer must still respond to
+	 * its target window going away. Per the widget's product decision
+	 * (see issue #410): closing the linked window cancels the timer.
+	 */
+	private installWindowListener(): void {
+		if ( this.windowListenerInstalled ) {
+			return;
+		}
+		this.windowListenerInstalled = true;
+		window.addEventListener( 'desktop-mode-window-closed', ( e ) => {
+			const id = ( e as CustomEvent< { windowId?: string } > ).detail
+				?.windowId;
+			if ( ! id || id !== this.linkedWindowId ) {
+				return;
+			}
+			this.onLinkedWindowClosed();
+		} );
+	}
+
+	private onLinkedWindowClosed(): void {
+		const wasActive =
+			this.phase === 'running' || this.phase === 'paused';
+		this.linkedWindowId = null;
+		if ( wasActive ) {
+			// reset() persists (with the now-cleared link) and notifies.
+			this.reset();
+			toast(
+				__(
+					'Focus timer cancelled — the linked window was closed.',
+					'desktop-mode',
+				),
+			);
+		} else {
+			this.persist();
+			this.notify();
+		}
+	}
 
 	/**
 	 * Wire up persistence and restore any saved timer. Called on every


### PR DESCRIPTION
Fixes #410

Follow-up to #403 (which added the Focus Timer widget) — addresses the review feedback in #410.

## Changes

- The window picker now lists **only currently-open windows** — a closed window is nothing to shake, so it is never offered as a choice (drops the previous dangling "(closed)" entry).
- The timer runtime now **listens for `desktop-mode-window-closed`**. If the linked window is closed while the timer is running or paused, the timer is **cancelled** (back to idle) and a toast explains why. The listener lives in the page-wide runtime rather than the view, so it fires even when the widget card has been re-docked or torn down.

## Testing

- `npm run typecheck`, `npm run lint` (on the new sources), and `npm run build:widget-focus-timer` all pass.
- Verified in wp-env: closing a *different* window does not affect a running timer; closing the *linked* window cancels it (→ idle) with a toast; the picker no longer lists closed windows.
