### PR TITLE
Add a window corner-radius setting (Sharp / Default / Round)

### DIFF
--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -20,6 +20,9 @@ const DESKTOP_MODE_OS_SETTINGS_META_KEY = 'desktop_mode_os_settings';
 /** Valid dock-size IDs — mirrors the TS `DOCK_SIZES` constant. */
 const DESKTOP_MODE_OS_SETTINGS_DOCK_SIZES = array( 'compact', 'default', 'large' );
 
+/** Valid window-radius IDs — mirrors the TS `WINDOW_RADII` constant. */
+const DESKTOP_MODE_OS_SETTINGS_WINDOW_RADII = array( 'sharp', 'default', 'round' );
+
 /** Valid desktop-layout IDs — mirrors the TS `DESKTOP_LAYOUTS` constant. */
 const DESKTOP_MODE_OS_SETTINGS_DESKTOP_LAYOUTS = array( 'classic', 'unified', 'spatial' );
 
@@ -38,6 +41,7 @@ function desktop_mode_default_os_settings() {
 		'wallpaper'                   => 'dark',
 		'accent'                      => 'wp-blue',
 		'dockSize'                    => 'default',
+		'windowRadius'                => 'default',
 		'desktopLayout'               => 'classic',
 		'dockRailRenderer'            => 'default',
 		'unfocusEffect'               => 'darken',
@@ -245,6 +249,11 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 	$dock_size = isset( $raw['dockSize'] ) && in_array( $raw['dockSize'], DESKTOP_MODE_OS_SETTINGS_DOCK_SIZES, true )
 		? (string) $raw['dockSize']
 		: $defaults['dockSize'];
+
+	// Window radius — must be one of the three known values.
+	$window_radius = isset( $raw['windowRadius'] ) && in_array( $raw['windowRadius'], DESKTOP_MODE_OS_SETTINGS_WINDOW_RADII, true )
+		? (string) $raw['windowRadius']
+		: $defaults['windowRadius'];
 
 	// Desktop layout — must be one of the three known values
 	// (`classic`, `unified`, `spatial`). Default `classic`.
@@ -581,6 +590,7 @@ function desktop_mode_sanitize_os_settings( $raw ) {
 		'wallpaper'                   => $wallpaper,
 		'accent'                      => $accent,
 		'dockSize'                    => $dock_size,
+		'windowRadius'                => $window_radius,
 		'desktopLayout'               => $desktop_layout,
 		'dockRailRenderer'            => $dock_rail_renderer,
 		'unfocusEffect'               => $unfocus_effect,

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -118,6 +118,17 @@ export const DOCK_SIZES = [
 ] as const;
 
 /**
+ * Window corner-radius presets. `value` (px) is written to the
+ * `--desktop-mode-window-radius` custom property by the settings apply
+ * pass, so the choice reflows every open window's corners live.
+ */
+export const WINDOW_RADII = [
+	{ id: 'sharp', label: 'Sharp', value: 0 },
+	{ id: 'default', label: 'Default', value: 8 },
+	{ id: 'round', label: 'Round', value: 16 },
+] as const;
+
+/**
  * Dock-placement options. Drives the `data-desktop-mode-dock-placement`
  * attribute that each `Dock` instance writes onto its own root. CSS
  * keys off that attribute to position the rail, flip the tooltip
@@ -149,6 +160,7 @@ export const DEFAULTS: OsSettingsState = {
 	wallpaper: DEFAULT_WALLPAPER_ID,
 	accent: 'wp-blue',
 	dockSize: 'default',
+	windowRadius: 'default',
 	desktopLayout: 'classic',
 	dockRailRenderer: 'default',
 	unfocusEffect: 'darken',

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -46,6 +46,7 @@ import { seedWallpaperSettings } from '../wallpapers/settings-store';
 import {
 	DEFAULT_WALLPAPER_ID,
 	DOCK_SIZES,
+	WINDOW_RADII,
 	getAccents,
 	getDefaultWallpaperId,
 } from './constants';
@@ -306,6 +307,9 @@ export class OsSettings implements SettingsCtx {
 		const accent = accents.find( ( a ) => a.id === this.state.accent ) ?? accents[ 0 ];
 		const dockSize =
 			DOCK_SIZES.find( ( d ) => d.id === this.state.dockSize ) ?? DOCK_SIZES[ 1 ];
+		const windowRadius =
+			WINDOW_RADII.find( ( r ) => r.id === this.state.windowRadius ) ??
+			WINDOW_RADII[ 1 ];
 
 		// Set on <html> rather than the shell so the cascade reaches
 		// siblings of #desktop-mode-shell — specifically the WordPress
@@ -317,6 +321,10 @@ export class OsSettings implements SettingsCtx {
 		root.style.setProperty( '--wp-admin-theme-color', accent.value );
 		root.style.setProperty( '--desktop-mode-dock-width', `${ dockSize.width }px` );
 		root.style.setProperty( '--desktop-mode-dock-icon-size', `${ dockSize.icon }px` );
+		root.style.setProperty(
+			'--desktop-mode-window-radius',
+			`${ windowRadius.value }px`,
+		);
 
 		// Desktop layout is driven by an attribute on the shell root;
 		// the layout dispatcher (desktop.ts) reads it on init and on

--- a/src/settings/labels.ts
+++ b/src/settings/labels.ts
@@ -13,6 +13,7 @@ import type {
 	DesktopLayoutId,
 	DockPlacementId,
 	DockSizeId,
+	WindowRadiusId,
 } from './types';
 
 export function translateAccentLabel( id: AccentId, fallback: string ): string {
@@ -42,6 +43,22 @@ export function translateDockSizeLabel( id: DockSizeId, fallback: string ): stri
 			return __( 'Default' );
 		case 'large':
 			return __( 'Large' );
+		default:
+			return fallback;
+	}
+}
+
+export function translateWindowRadiusLabel(
+	id: WindowRadiusId,
+	fallback: string,
+): string {
+	switch ( id ) {
+		case 'sharp':
+			return __( 'Sharp' );
+		case 'default':
+			return __( 'Default' );
+		case 'round':
+			return __( 'Round' );
 		default:
 			return fallback;
 	}

--- a/src/settings/panel.ts
+++ b/src/settings/panel.ts
@@ -63,6 +63,7 @@ import { buildAccentSection } from './sections/accent';
 import { buildAppsIconsSection } from './sections/apps-icons';
 import { buildDesktopLayoutSection } from './sections/desktop-layout';
 import { buildDockSizeSection } from './sections/dock-size';
+import { buildWindowRadiusSection } from './sections/window-radius';
 import { buildDockRailRendererSection } from './sections/dock-rail-renderer';
 import { buildEffectsSection } from './sections/effects';
 import { buildExtendedSection } from './sections/extended';
@@ -184,6 +185,7 @@ export function renderOsSettingsPanel(
 					${ buildAccentSection( ctx ) }
 					${ buildDesktopLayoutSection( ctx ) }
 					${ buildDockSizeSection( ctx ) }
+					${ buildWindowRadiusSection( ctx ) }
 					${ buildDockRailRendererSection( ctx ) }
 				</wpd-panel>
 			</wpd-tabpanel>`,

--- a/src/settings/sections/window-radius.ts
+++ b/src/settings/sections/window-radius.ts
@@ -1,0 +1,54 @@
+/**
+ * Window-radius section — segmented control (Sharp / Default / Round)
+ * bound to `state.windowRadius`. Writes the window corner radius as a
+ * CSS custom property (`--desktop-mode-window-radius`) via `ctx.apply()`,
+ * so every open window's corners reflow live.
+ */
+
+import { __ } from '../../i18n';
+import { html, render } from '../../ui/core';
+import { WINDOW_RADII } from '../constants';
+import { translateWindowRadiusLabel } from '../labels';
+import type { SettingsCtx, WindowRadiusId } from '../types';
+
+export function buildWindowRadiusSection( ctx: SettingsCtx ): HTMLElement {
+	const onPick = ( e: Event ): void => {
+		const id = ( ( e as CustomEvent ).detail?.value ?? '' ) as string;
+		if ( ! WINDOW_RADII.some( ( r ) => r.id === id ) ) {
+			return;
+		}
+		ctx.state.windowRadius = id as WindowRadiusId;
+		ctx.save();
+		ctx.apply();
+		paint();
+	};
+
+	const wrapper = document.createElement( 'div' );
+	const paint = (): void =>
+		render(
+			html`
+				<wpd-section
+					heading=${ __( 'Window corners' ) }
+					description=${ __( 'How rounded the corners of windows are.' ) }
+				>
+					<wpd-segmented
+						value=${ ctx.state.windowRadius }
+						label=${ __( 'Window corners' ) }
+						@wpd-pick=${ onPick }
+					>
+						${ WINDOW_RADII.map(
+		( r ) => html`<wpd-segment value=${ r.id }
+								>${ translateWindowRadiusLabel(
+			r.id,
+			r.label,
+		) }</wpd-segment
+							>`,
+	) }
+					</wpd-segmented>
+				</wpd-section>
+			`,
+			wrapper,
+		);
+	paint();
+	return wrapper;
+}

--- a/src/settings/state.ts
+++ b/src/settings/state.ts
@@ -23,6 +23,7 @@ import {
 	DESKTOP_LAYOUTS,
 	DOCK_SIZES,
 	STORAGE_KEY,
+	WINDOW_RADII,
 	getAccents,
 	getDefaultWallpaperId,
 } from './constants';
@@ -34,6 +35,7 @@ import type {
 	DesktopLayoutId,
 	DockSizeId,
 	OsSettingsState,
+	WindowRadiusId,
 } from './types';
 import { isHexColor } from './utils';
 import { trackedFetch } from '../tracked-fetch';
@@ -105,6 +107,9 @@ function _parseRaw( parsed: Partial<OsSettingsState> ): OsSettingsState {
 		dockSize: DOCK_SIZES.some( ( d ) => d.id === parsed.dockSize )
 			? ( parsed.dockSize as DockSizeId )
 			: DEFAULTS.dockSize,
+		windowRadius: WINDOW_RADII.some( ( r ) => r.id === parsed.windowRadius )
+			? ( parsed.windowRadius as WindowRadiusId )
+			: DEFAULTS.windowRadius,
 		desktopLayout: DESKTOP_LAYOUTS.some(
 			( l ) => l.id === parsed.desktopLayout,
 		)

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -8,7 +8,7 @@
 
 import type { WallpaperLayer } from '../wallpapers/layer';
 import type { WallpaperTeardown } from '../wallpapers/types';
-import type { DOCK_SIZES } from './constants';
+import type { DOCK_SIZES, WINDOW_RADII } from './constants';
 
 /**
  * Accent id. Historically derived from the built-in `ACCENTS` tuple,
@@ -19,6 +19,7 @@ import type { DOCK_SIZES } from './constants';
  */
 export type AccentId = string;
 export type DockSizeId = ( typeof DOCK_SIZES )[ number ][ 'id' ];
+export type WindowRadiusId = ( typeof WINDOW_RADII )[ number ][ 'id' ];
 export type DockPlacementId = 'left' | 'right' | 'bottom';
 
 /**
@@ -88,6 +89,7 @@ export interface OsSettingsState {
 	wallpaper: string;
 	accent: AccentId;
 	dockSize: DockSizeId;
+	windowRadius: WindowRadiusId;
 	desktopLayout: DesktopLayoutId;
 	/**
 	 * Active dock rail-renderer id. Resolves through the dock-rail


### PR DESCRIPTION
## Summary

Adds an **OS Settings → Appearance** control, **"Window corners"**, that lets the user choose how rounded window corners are:

- **Sharp** — 0px
- **Default** — 8px (current behaviour, unchanged for existing users)
- **Round** — 16px

The choice writes the existing `--desktop-mode-window-radius` custom property on the shell root during the settings apply pass, so every open window reflows its corners **live** (no reload). It persists per user like the other appearance settings.

## Why

Corner radius was a fixed token (`--desktop-mode-window-radius: 8px`) with no way to change it short of custom CSS. Exposing it as a segmented control is a small, self-contained personalisation that fits alongside Accent color / Dock size.

## Implementation

Follows the **Dock size** section pattern exactly:

- `src/settings/constants.ts` — `WINDOW_RADII` presets + `windowRadius` default.
- `src/settings/types.ts` — `WindowRadiusId` type + `windowRadius` on `OsSettingsState`.
- `src/settings/state.ts` — default + validated coercion on load.
- `src/settings/labels.ts` — `translateWindowRadiusLabel`.
- `src/settings/sections/window-radius.ts` — new `<wpd-segmented>` section (mirrors `dock-size.ts`).
- `src/settings/panel.ts` — mounts the section under the Appearance tab (after Dock size).
- `src/settings/index.ts` — apply pass sets `--desktop-mode-window-radius` on `<html>` (next to the dock-size / accent vars).
- `includes/os-settings.php` — server-side default, sanitise (allow-list of the three ids), and output, mirroring `dockSize`.

Only affects **windows** — widgets and the dock keep their own radii.

## Testing

- `npm run typecheck`, `npm run lint`, `php -l` on the PHP file, and builds of the `desktop` + `os-settings-panel` targets all pass.
- Verified in wp-env: the control renders in Appearance; picking Sharp/Default/Round changes `--desktop-mode-window-radius` to `0/8/16px` live; the choice survives a page reload (persisted server-side).
