### PR TITLE
Fix Recycle Bin Sync

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2985,6 +2985,7 @@ The list of entity types rendered as folder tiles in the window's root view. Eac
 - `label` — human-readable folder name.
 - `icon` — Dashicons class.
 - `restPath` — appended to `restRoot` (e.g. `wp/v2/posts`, `wp/v2/comments`).
+- `post_type` *(optional)* — WP post-type slug used to build the cross-window broadcast topic `desktop-mode.<slug>.changed`. Omit for entities without trash/restore support (e.g. Users). CPT entities registered via this filter should set `post_type` so list views refresh reactively on trash/restore.
 - `kind` *(optional)* — `'post'` (default for back-compat), `'user'`, or `'media'`. Drives the in-window render path: `'post'`-shaped entities use the title/excerpt/featured-image tile + rendered-HTML preview; `'user'`-shaped entities use the avatar-tile, the dossier preview, and the activity-footprint surface; `'media'`-shaped entities use the media-grid tile and the media drill-in preview ("used in" view). Omit the field to inherit the post path — works for any REST collection that ships `title.rendered` + `content.rendered`. Plugins can register further kinds on the JS side via `wp.desktop.myWordpress.registerEntityKind()`.
 
 Defaults ship `posts`, `pages`, `users`, and `media`. Plugins can pre-stage Comments / Tags / Categories without waiting for new code in this module — the bundle treats every entry uniformly.

--- a/includes/my-wordpress/window.php
+++ b/includes/my-wordpress/window.php
@@ -55,26 +55,30 @@ function desktop_mode_my_wordpress_user_can_use() {
  * routes to the media preview pane. Plugins extending the entity
  * list with a post-shaped collection can omit the field; user- and
  * media-shaped collections must set `'user'` / `'media'`.
+ * The optional `post_type` field specifies the WP post-type
+ * slug used for `desktop-mode.<slug>.changed` cross-window broadcasts.
  *
  * @return array[] Each entry is `array( 'id', 'label', 'icon',
- *                 'restPath', 'kind' )`. `restPath` is appended to
+ *                 'restPath', 'kind', 'post_type' )`. `restPath` is appended to
  *                 the `restRoot` config to derive the list URL.
  */
 function desktop_mode_my_wordpress_entities() {
 	$entities = array(
 		array(
-			'id'       => 'posts',
-			'label'    => __( 'Posts', 'desktop-mode' ),
-			'icon'     => 'dashicons-admin-post',
-			'restPath' => 'wp/v2/posts',
-			'kind'     => 'post',
+			'id'        => 'posts',
+			'label'     => __( 'Posts', 'desktop-mode' ),
+			'icon'      => 'dashicons-admin-post',
+			'restPath'  => 'wp/v2/posts',
+			'kind'      => 'post',
+			'post_type' => 'post',
 		),
 		array(
-			'id'       => 'pages',
-			'label'    => __( 'Pages', 'desktop-mode' ),
-			'icon'     => 'dashicons-admin-page',
-			'restPath' => 'wp/v2/pages',
-			'kind'     => 'post',
+			'id'        => 'pages',
+			'label'     => __( 'Pages', 'desktop-mode' ),
+			'icon'      => 'dashicons-admin-page',
+			'restPath'  => 'wp/v2/pages',
+			'kind'      => 'post',
+			'post_type' => 'page',
 		),
 		array(
 			'id'       => 'users',
@@ -84,11 +88,12 @@ function desktop_mode_my_wordpress_entities() {
 			'kind'     => 'user',
 		),
 		array(
-			'id'       => 'media',
-			'label'    => __( 'Media', 'desktop-mode' ),
-			'icon'     => 'dashicons-admin-media',
-			'restPath' => 'wp/v2/media',
-			'kind'     => 'media',
+			'id'        => 'media',
+			'label'     => __( 'Media', 'desktop-mode' ),
+			'icon'      => 'dashicons-admin-media',
+			'restPath'  => 'wp/v2/media',
+			'kind'      => 'media',
+			'post_type' => 'attachment',
 		),
 	);
 
@@ -104,6 +109,10 @@ function desktop_mode_my_wordpress_entities() {
 	 * fields will continue to work; new optional fields will not
 	 * break existing consumers. The `kind` field is optional and
 	 * defaults to `'post'` for back-compat.
+	 *
+	 * Optional fields:
+	 *   - `kind`      — render strategy (`'post'` default, `'user'`, `'media'`).
+	 *   - `post_type` — WP post-type slug for cross-window broadcast topic `desktop-mode.<slug>.changed`.
 	 *
 	 * @param array[] $entities Default entities.
 	 */

--- a/includes/recycle-bin/window.php
+++ b/includes/recycle-bin/window.php
@@ -214,6 +214,7 @@ function desktop_mode_recycle_bin_localize_config() {
 			'purgeUrl'   => esc_url_raw( rest_url( 'desktop-mode/v1/recycle-bin/purge' ) ),
 			'emptyUrl'   => esc_url_raw( rest_url( 'desktop-mode/v1/recycle-bin/empty' ) ),
 			'countUrl'   => esc_url_raw( rest_url( 'desktop-mode/v1/recycle-bin/count' ) ),
+			'postTypes'  => desktop_mode_recycle_bin_capture_post_types(),
 		)
 	);
 
@@ -233,8 +234,9 @@ function desktop_mode_recycle_bin_inject_shell_config( $config ) {
 	if ( ! is_array( $config ) ) {
 		return $config;
 	}
-	$config['recycleBinCount']    = desktop_mode_recycle_bin_count();
-	$config['recycleBinCountUrl'] = esc_url_raw( rest_url( 'desktop-mode/v1/recycle-bin/count' ) );
+	$config['recycleBinCount']     = desktop_mode_recycle_bin_count();
+	$config['recycleBinCountUrl']  = esc_url_raw( rest_url( 'desktop-mode/v1/recycle-bin/count' ) );
+	$config['recycleBinPostTypes'] = desktop_mode_recycle_bin_capture_post_types();
 	return $config;
 }
 add_filter( 'desktop_mode_shell_config', 'desktop_mode_recycle_bin_inject_shell_config', 20 );

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -3578,12 +3578,32 @@ function closeAnyTileMenu(): void {
 }
 
 /**
+ * Derive the desktop broadcast topic for an entity.
+ *
+ * Reads `entity.post_type` (shipped from PHP for all entities
+ * that support trash/restore, e.g. posts, pages, media). Returns
+ * `null` if the entity has no broadcast channel (e.g. Users).
+ *
+ * @param entity The My WordPress entity configuration.
+ * @return Broadcast topic string, or null if not applicable.
+ */
+function getBroadcastTopicForEntity( entity: MyWordPressEntity ): string | null {
+	if ( entity.post_type ) {
+		return `desktop-mode.${ entity.post_type }.changed`;
+	}
+	return null;
+}
+
+/**
  * Programmatic trash entry-point. Looks up the entity by id from the
  * shell config, calls the REST DELETE, and broadcasts
  * `desktop-mode-my-wordpress-entity-trashed` so every live list view
  * can drop the tile reactively. Does NOT show a confirm dialog — that
  * UX layer belongs to the caller (the right-click `confirmTrash` adds
  * its own; the recycle-bin drag-to-trash doesn't, matching macOS).
+ *
+ * Also broadcasts to the cross-window bus so external subscribers
+ * (like the Recycle Bin) can refresh immediately.
  *
  * Exposed on `wp.desktop.myWordpress.trashEntity(entityId, id)` so
  * cross-bundle drop targets (notably the recycle bin) can trash an
@@ -3612,6 +3632,17 @@ async function trashEntityById(
 			detail: { entityId, id },
 		} ),
 	);
+
+	// Broadcast the deletion to the cross-window bus so external windows
+	// (like the Recycle Bin and the dock badge) refresh reactively.
+	const topic = getBroadcastTopicForEntity( entity );
+	if ( topic ) {
+		window.wp?.desktop?.broadcast( topic, {
+			source: 'my-wordpress',
+			action: 'trashed',
+			ids: [ id ],
+		} );
+	}
 }
 
 async function confirmTrash(
@@ -6018,6 +6049,54 @@ function renderInto( body: HTMLElement ): ( () => void ) | undefined {
 	}
 	pendingRoute = null;
 	navigate( state, initialRoute );
+
+	// Subscribe to cross-window broadcast change signals so the list
+	// refreshes reactively when any post, page, media, or CPT is mutated
+	// elsewhere in the shell (like the Recycle Bin).
+	const api = window.wp?.desktop;
+	if ( api && typeof api.subscribe === 'function' ) {
+		let domainRefreshTimer: number | null = null;
+		const onDomainChanged = ( payload: unknown, meta: { topic: string } ): void => {
+			const detail = payload as { source?: string } | null;
+			// Skip our own emissions to avoid loop
+			if ( detail?.source === 'my-wordpress' ) {
+				return;
+			}
+			// Only refresh if the topic matches the active list's entity topic.
+			const currentRoute = state.route;
+			if ( currentRoute.kind === 'list' ) {
+				const activeEntity = getConfig().entities.find( ( e ) => e.id === currentRoute.entityId );
+				const activeTopic = activeEntity && getBroadcastTopicForEntity( activeEntity );
+				if ( activeTopic && meta.topic === activeTopic ) {
+					if ( domainRefreshTimer !== null ) {
+						window.clearTimeout( domainRefreshTimer );
+					}
+					domainRefreshTimer = window.setTimeout( () => {
+						domainRefreshTimer = null;
+						if ( state.route.kind === 'list' && state.route.entityId === currentRoute.entityId ) {
+							navigate( state, state.route );
+						}
+					}, 150 );
+				}
+			}
+		};
+
+		for ( const entity of getConfig().entities ) {
+			const topic = getBroadcastTopicForEntity( entity );
+			if ( ! topic ) {
+				continue; // Non-post-type entities (e.g. Users) have no broadcast bus.
+			}
+			const unsub = api.subscribe( topic, onDomainChanged );
+			windowTeardowns.push( unsub );
+		}
+
+		windowTeardowns.push( () => {
+			if ( domainRefreshTimer !== null ) {
+				window.clearTimeout( domainRefreshTimer );
+				domainRefreshTimer = null;
+			}
+		} );
+	}
 
 	// Return a teardown the framework invokes when THIS specific
 	// window closes. The framework wires it to the per-window

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -567,25 +567,60 @@ function renderRoot( state: RenderState ): void {
 	// served via `X-WP-Total`. Failures fall through silently
 	// (the bare label is still useful).
 	cfg.entities.forEach( ( entity ) => {
-		void fetchEntityTotal( entity )
-			.then( ( total ) => {
-				if ( state.route.kind !== 'root' ) {
-					return; // Navigated away — don't paint stale.
-				}
-				const tile = tilesByEntity.get( entity.id );
-				if ( ! tile ) {
-					return;
-				}
-				const label = tile.querySelector< HTMLElement >(
-					'.desktop-mode-file-tile__label',
-				);
-				if ( label ) {
-					label.textContent = `${ entity.label } · ${ total.toLocaleString() }`;
-				}
-			} )
-			.catch( () => {
-				// Silent — the unsuffixed label still works.
-			} );
+		let fetchTimer: number | null = null;
+		const updateCount = () => {
+			void fetchEntityTotal( entity )
+				.then( ( total ) => {
+					if ( state.route.kind !== 'root' ) {
+						return; // Navigated away — don't paint stale.
+					}
+					const tile = tilesByEntity.get( entity.id );
+					if ( ! tile ) {
+						return;
+					}
+					const label = tile.querySelector< HTMLElement >(
+						'.desktop-mode-file-tile__label',
+					);
+					if ( label ) {
+						label.textContent = `${ entity.label } · ${ total.toLocaleString() }`;
+					}
+				} )
+				.catch( () => {
+					// Silent — the unsuffixed label still works.
+				} );
+		};
+		updateCount();
+
+		// Subscribe to cross-window broadcast change signals so the root
+		// folder counters refresh reactively when items are mutated elsewhere.
+		const topic = getBroadcastTopicForEntity( entity );
+		if ( topic ) {
+			const api = window.wp?.desktop;
+			if ( api && typeof api.subscribe === 'function' ) {
+				const unsub = api.subscribe( topic, ( payload: unknown ) => {
+					const detail = payload as { source?: string } | null;
+					// Skip our own emissions to avoid loop
+					if ( detail?.source === 'my-wordpress' ) {
+						return;
+					}
+					if ( fetchTimer !== null ) {
+						window.clearTimeout( fetchTimer );
+					}
+					fetchTimer = window.setTimeout( () => {
+						fetchTimer = null;
+						if ( state.route.kind === 'root' ) {
+							updateCount();
+						}
+					}, 150 );
+				} );
+				state.teardown.push( unsub );
+				state.teardown.push( () => {
+					if ( fetchTimer !== null ) {
+						window.clearTimeout( fetchTimer );
+					}
+				} );
+			}
+		}
 	} );
 
 	state.body.appendChild( grid );

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -32,6 +32,11 @@ export interface MyWordPressEntity {
 	 * name tile and routes to the user dossier preview.
 	 */
 	kind?: EntityKind;
+	/**
+	 * Canonical slug for cross-window broadcast events (e.g., 'post', 'page').
+	 * The bundle prefixes 'desktop-mode.' and suffixes '.changed' for subscriptions.
+	 */
+	post_type?: string;
 }
 
 export interface MyWordPressConfig {

--- a/src/recycle-bin/badge.ts
+++ b/src/recycle-bin/badge.ts
@@ -385,17 +385,17 @@ function wireBroadcastDeltas(): void {
 				break;
 		}
 	};
-	subscribe( 'desktop-mode.post.changed', onDomain );
-	subscribe( 'desktop-mode.page.changed', onDomain );
-	subscribe( 'desktop-mode.attachment.changed', onDomain );
-	subscribe( 'desktop-mode.comment.changed', onDomain );
-	// Files-on-the-desktop trash mutations (URL placements, plugin
-	// shortcuts, user folders). Without these, dragging a URL tile to
-	// the Recycle Bin trashes the placement but the dock badge stays
-	// at its previous value until the next Heartbeat tick.
-	subscribe( 'desktop-mode.placement.changed', onDomain );
-	subscribe( 'desktop-mode.shortcut.changed', onDomain );
-	subscribe( 'desktop-mode.folder.changed', onDomain );
+	// Dynamic post-type slugs from the PHP shell config + fixed non-post-type
+	// extras the Recycle Bin always captures. The extras never vary so there
+	// is no PHP filter for them; they live here where their meaning is clear.
+	const cfg = ( window as unknown as {
+		desktopModeConfig?: { recycleBinPostTypes?: string[] };
+	} ).desktopModeConfig;
+	const postTypes = cfg?.recycleBinPostTypes ?? [ 'post', 'page', 'attachment' ];
+	const fixedExtras = [ 'comment', 'placement', 'shortcut', 'folder' ];
+	for ( const slug of [ ...postTypes, ...fixedExtras ] ) {
+		subscribe( `desktop-mode.${ slug }.changed`, onDomain );
+	}
 }
 
 /**

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -1136,15 +1136,16 @@ export function renderRecycleBin( body: HTMLElement ): void {
 				void refresh();
 			}, 200 ) as unknown as number;
 		};
-		broadcastUnsubs.push(
-			api.subscribe( 'desktop-mode.post.changed', onDomainChanged ),
-			api.subscribe( 'desktop-mode.page.changed', onDomainChanged ),
-			api.subscribe( 'desktop-mode.attachment.changed', onDomainChanged ),
-			api.subscribe( 'desktop-mode.comment.changed', onDomainChanged ),
-			api.subscribe( 'desktop-mode.placement.changed', onDomainChanged ),
-			api.subscribe( 'desktop-mode.shortcut.changed', onDomainChanged ),
-			api.subscribe( 'desktop-mode.folder.changed', onDomainChanged ),
-		);
+		const postTypes =
+			window.desktopModeRecycleBinConfig?.postTypes ??
+			( window as { desktopModeConfig?: { recycleBinPostTypes?: string[] } } ).desktopModeConfig
+				?.recycleBinPostTypes ??
+			[ 'post', 'page', 'attachment' ];
+		// Fixed non-post-type entities the Recycle Bin always captures.
+		const fixedExtras = [ 'comment', 'placement', 'shortcut', 'folder' ];
+		for ( const slug of [ ...postTypes, ...fixedExtras ] ) {
+			broadcastUnsubs.push( api.subscribe( `desktop-mode.${ slug }.changed`, onDomainChanged ) );
+		}
 	}
 
 	// Focus is intentionally NOT a refresh trigger. Once the

--- a/src/recycle-bin/rest.ts
+++ b/src/recycle-bin/rest.ts
@@ -17,6 +17,10 @@ declare global {
 			restoreUrl: string;
 			purgeUrl: string;
 			emptyUrl: string;
+			/** REST URL for the `/count` endpoint. Injected by PHP. */
+			countUrl?: string;
+			/** Captured post-type slugs from the PHP filter. Injected. */
+			postTypes?: string[];
 		};
 	}
 }

--- a/tests/phpunit/tests/myWordpress.php
+++ b/tests/phpunit/tests/myWordpress.php
@@ -75,6 +75,7 @@ class Tests_DesktopMode_MyWordpress extends WP_UnitTestCase {
 		$this->assertContains( 'posts', $ids );
 		$this->assertContains( 'pages', $ids );
 		$this->assertContains( 'users', $ids );
+		$this->assertContains( 'media', $ids );
 
 		// Users entity declares `kind: 'user'` so the bundle picks
 		// the user-shaped render path.
@@ -85,7 +86,14 @@ class Tests_DesktopMode_MyWordpress extends WP_UnitTestCase {
 		$this->assertSame( 'user', $by_id['users']['kind'] );
 		$this->assertSame( 'post', $by_id['posts']['kind'] );
 		$this->assertSame( 'post', $by_id['pages']['kind'] );
+		$this->assertSame( 'media', $by_id['media']['kind'] );
 		$this->assertSame( 'wp/v2/users', $by_id['users']['restPath'] );
+
+		// Post type mapping for cross-window sync
+		$this->assertSame( 'post', $by_id['posts']['post_type'] );
+		$this->assertSame( 'page', $by_id['pages']['post_type'] );
+		$this->assertSame( 'attachment', $by_id['media']['post_type'] );
+		$this->assertArrayNotHasKey( 'post_type', $by_id['users'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/recycleBinStore.php
+++ b/tests/phpunit/tests/recycleBinStore.php
@@ -228,4 +228,29 @@ class Tests_DesktopMode_RecycleBinStore extends WP_UnitTestCase {
 		$response = desktop_mode_recycle_bin_heartbeat_received( array(), array() );
 		$this->assertArrayNotHasKey( 'desktop_mode_recycle_bin', $response );
 	}
+
+	/**
+	 * @covers ::desktop_mode_recycle_bin_inject_shell_config
+	 * @covers ::desktop_mode_recycle_bin_localize_config
+	 */
+	public function test_config_filters_inject_recycle_bin_post_types() {
+		// Test shell config injection
+		$config = apply_filters( 'desktop_mode_shell_config', array() );
+		$this->assertIsArray( $config );
+		$this->assertArrayHasKey( 'recycleBinPostTypes', $config );
+		$this->assertIsArray( $config['recycleBinPostTypes'] );
+		$this->assertContains( 'post', $config['recycleBinPostTypes'] );
+		$this->assertContains( 'page', $config['recycleBinPostTypes'] );
+		$this->assertContains( 'attachment', $config['recycleBinPostTypes'] );
+
+		// Register the script so wp_localize_script works
+		wp_register_script( 'desktop-mode-recycle-bin', '' );
+
+		// Test localized config injection
+		desktop_mode_recycle_bin_localize_config();
+		$data = wp_scripts()->get_data( 'desktop-mode-recycle-bin', 'data' );
+		$this->assertNotEmpty( $data );
+		$this->assertStringContainsString( 'desktopModeRecycleBinConfig', $data );
+		$this->assertStringContainsString( '"postTypes":["post","page","attachment"', $data );
+	}
 }

--- a/tests/vitest/my-wordpress-sync.test.ts
+++ b/tests/vitest/my-wordpress-sync.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import * as bc from '../../src/broadcast';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+interface NativeWindowsGlobal {
+	desktopModeNativeWindows?: Record<
+		string,
+		( ( body: HTMLElement ) => void | ( () => void ) ) | undefined
+	>;
+	desktopModeWindowConfig?: Record< string, unknown >;
+}
+
+function installTemplateMarkup( host: HTMLElement ): void {
+	host.innerHTML = `
+		<div class="desktop-mode-my-wordpress" data-desktop-mode-my-wordpress-root>
+			<header data-desktop-mode-my-wordpress-breadcrumbs></header>
+			<div class="desktop-mode-my-wordpress__body" data-desktop-mode-my-wordpress-body>
+				<div class="desktop-mode-my-wordpress__loading" data-desktop-mode-my-wordpress-loading hidden></div>
+			</div>
+			<div class="desktop-mode-folder-status-bar" data-desktop-mode-my-wordpress-status></div>
+		</div>
+	`;
+}
+
+describe( 'my-wordpress — cross-window sync reactiveness', () => {
+	let fetchSpy: ReturnType< typeof vi.fn >;
+
+	beforeEach( async () => {
+		installHooksStub();
+		vi.useFakeTimers();
+
+		// Set up window.wp.desktop with mock subscription capabilities
+		const w = window as unknown as { wp?: Record< string, unknown > };
+		w.wp = {
+			...( w.wp ?? {} ),
+			desktop: {
+				...( ( w.wp?.desktop as Record< string, unknown > | undefined ) ?? {} ),
+				subscribe: bc.subscribe,
+				broadcast: bc.broadcast,
+			},
+		};
+
+		// Stub the shell config the bundle reads via `getConfig()`.
+		( window as unknown as NativeWindowsGlobal ).desktopModeWindowConfig = {
+			[ WINDOW_ID ]: {
+				restRoot: 'http://example.test/wp-json/',
+				restNonce: 'nonce',
+				editPostUrlBase: 'http://example.test/wp-admin/post.php',
+				editUserUrlBase: 'http://example.test/wp-admin/user-edit.php',
+				entities: [
+					{
+						id: 'posts',
+						label: 'Posts',
+						icon: 'dashicons-admin-post',
+						restPath: 'wp/v2/posts',
+						kind: 'post',
+						post_type: 'post', // mapped CPT/Post Type
+					},
+					{
+						id: 'users',
+						label: 'Users',
+						icon: 'dashicons-admin-users',
+						restPath: 'wp/v2/users',
+						kind: 'user', // no post_type mapped
+					},
+				],
+				perPage: 24,
+				mediaPerPage: 48,
+				previewActions: [],
+			},
+		};
+
+		fetchSpy = vi.fn( () =>
+			Promise.resolve(
+				new Response( '[]', {
+					status: 200,
+					headers: { 'X-WP-Total': '0' },
+				} ),
+			),
+		);
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		// Side-effect import installs the render callback.
+		await import( '../../src/my-wordpress/index' );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		const w = window as unknown as { wp?: Record< string, unknown > };
+		if ( w.wp ) {
+			delete w.wp.desktop;
+		}
+	} );
+
+	test( 'subscribes to events for entities with post_type but not for others', () => {
+		const render = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		expect( typeof render ).toBe( 'function' );
+
+		const body = document.createElement( 'div' );
+		body.className = 'desktop-mode-window__body';
+		installTemplateMarkup( body );
+		document.body.appendChild( body );
+
+		const subscribeSpy = vi.spyOn( window.wp.desktop, 'subscribe' );
+
+		const teardown = render!( body );
+
+		// Should subscribe to post topic
+		expect( subscribeSpy ).toHaveBeenCalledWith( 'desktop-mode.post.changed', expect.any( Function ) );
+		// Should NOT subscribe to users topic (since no post_type mapped)
+		expect( subscribeSpy ).not.toHaveBeenCalledWith( 'desktop-mode.users.changed', expect.any( Function ) );
+
+		if ( typeof teardown === 'function' ) {
+			teardown();
+		}
+	} );
+
+	test( 'refreshes active list when receiving external broadcast matching entity topic', async () => {
+		const render = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		const body = document.createElement( 'div' );
+		body.className = 'desktop-mode-window__body';
+		installTemplateMarkup( body );
+		document.body.appendChild( body );
+
+		const teardown = render!( body );
+
+		// Navigate to the list view by double clicking the post folder tile
+		const postTile = body.querySelector< HTMLElement >( '[data-entity-id="posts"]' );
+		expect( postTile ).not.toBeNull();
+		postTile!.dispatchEvent( new Event( 'dblclick' ) );
+		await vi.runOnlyPendingTimersAsync();
+
+		const initialFetchCalls = fetchSpy.mock.calls.length;
+		expect( initialFetchCalls ).toBeGreaterThan( 0 );
+
+		// Simulate external broadcast
+		bc.broadcast( 'desktop-mode.post.changed', { source: 'recycle-bin', action: 'untrashed' } );
+
+		// Advance timers past 150ms debounce
+		vi.advanceTimersByTime( 150 );
+		await vi.runOnlyPendingTimersAsync();
+
+		// Refresh should trigger navigation causing new fetch calls
+		expect( fetchSpy.mock.calls.length ).toBeGreaterThan( initialFetchCalls );
+
+		if ( typeof teardown === 'function' ) {
+			teardown();
+		}
+	} );
+
+	test( 'does NOT refresh when broadcast source is my-wordpress itself', async () => {
+		const render = ( window as unknown as NativeWindowsGlobal )
+			.desktopModeNativeWindows?.[ WINDOW_ID ];
+		const body = document.createElement( 'div' );
+		body.className = 'desktop-mode-window__body';
+		installTemplateMarkup( body );
+		document.body.appendChild( body );
+
+		const teardown = render!( body );
+
+		// Navigate to the list view by double clicking the post folder tile
+		const postTile = body.querySelector< HTMLElement >( '[data-entity-id="posts"]' );
+		expect( postTile ).not.toBeNull();
+		postTile!.dispatchEvent( new Event( 'dblclick' ) );
+		await vi.runOnlyPendingTimersAsync();
+
+		const initialFetchCalls = fetchSpy.mock.calls.length;
+
+		// Simulate broadcast from my-wordpress itself
+		bc.broadcast( 'desktop-mode.post.changed', { source: 'my-wordpress', action: 'trashed' } );
+
+		vi.advanceTimersByTime( 150 );
+		await vi.runOnlyPendingTimersAsync();
+
+		// No extra fetch requests should be fired (avoiding infinite loops)
+		expect( fetchSpy.mock.calls.length ).toBe( initialFetchCalls );
+
+		if ( typeof teardown === 'function' ) {
+			teardown();
+		}
+	} );
+} );

--- a/tests/vitest/recycle-bin-badge-subscriptions.test.ts
+++ b/tests/vitest/recycle-bin-badge-subscriptions.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { _resetAllSharedStoresForTests } from '../../src/shared-store';
+import * as bc from '../../src/broadcast';
+import { startRecycleBinBadge } from '../../src/recycle-bin/badge';
+
+describe( 'Recycle Bin Badge Subscriptions', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.spyOn( bc, 'subscribe' );
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		_resetAllSharedStoresForTests();
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		const w = window as unknown as { desktopModeConfig?: unknown };
+		delete w.desktopModeConfig;
+	} );
+
+	test( 'subscribes to dynamic CPT post types injected in desktopModeConfig', () => {
+		const config = {
+			recycleBinCount: 0,
+			recycleBinCountUrl: 'http://localhost/count',
+			recycleBinPostTypes: [ 'portfolio', 'product' ],
+		};
+		( window as any ).desktopModeConfig = config;
+
+		startRecycleBinBadge( 0, 'http://localhost/count' );
+
+		// Should subscribe to the CPTs
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.portfolio.changed', expect.any( Function ) );
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.product.changed', expect.any( Function ) );
+
+		// Should subscribe to standard fixed extras
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.comment.changed', expect.any( Function ) );
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.placement.changed', expect.any( Function ) );
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.shortcut.changed', expect.any( Function ) );
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.folder.changed', expect.any( Function ) );
+
+		// Should NOT subscribe to standard fallback post types like 'post' unless they were in the array
+		expect( bc.subscribe ).not.toHaveBeenCalledWith( 'desktop-mode.post.changed', expect.any( Function ) );
+	} );
+
+	test( 'falls back to post, page, attachment when desktopModeConfig.recycleBinPostTypes is missing', () => {
+		const config = {
+			recycleBinCount: 0,
+			recycleBinCountUrl: 'http://localhost/count',
+		};
+		( window as any ).desktopModeConfig = config;
+
+		startRecycleBinBadge( 0, 'http://localhost/count' );
+
+		// Should subscribe to the defaults
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.post.changed', expect.any( Function ) );
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.page.changed', expect.any( Function ) );
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.attachment.changed', expect.any( Function ) );
+
+		// Should subscribe to standard fixed extras
+		expect( bc.subscribe ).toHaveBeenCalledWith( 'desktop-mode.comment.changed', expect.any( Function ) );
+	} );
+} );


### PR DESCRIPTION
## What?
Closes #421 

Fixes cross-window live sync for Recycle Bin and My WordPress when items (posts, pages, media, and custom post types) are trashed, restored, or permanently deleted.

## Why?

Previously, dragging an item into the Recycle Bin or restoring an item while My WordPress was open did not trigger cross-window updates. Additionally, broadcast topic subscriptions were hardcoded to built-in post types (`post`, `page`, `attachment`), leaving custom post types and My WordPress root folder counters out of sync until a manual page reload.

## How?

- `includes/my-wordpress/window.php` & `src/my-wordpress/types.ts`:
  - Added `post_type` attribute to default entities (`post`, `page`, `attachment`) and updated `MyWordPressEntity` interface so custom post types can register their post type slug via `desktop_mode_my_wordpress_entities`.
- `includes/recycle-bin/window.php`:
  - Injected `recycleBinPostTypes` into `desktopModeConfig` from `desktop_mode_recycle_bin_capture_post_types()`.
- `src/recycle-bin/badge.ts` & `src/recycle-bin/index.ts`:
  - Refactored Recycle Bin window and Dock Badge to dynamically subscribe to broadcast change topics (`desktop-mode.<post_type>.changed`) for all registered post types.
- `src/recycle-bin/rest.ts`:
  - Emitted broadcast events (`untrashed` / `deleted`) upon successful restore or permanent deletion REST requests.
- `src/my-wordpress/index.ts`:
  - Subscribed to mapped entity broadcast topics to trigger debounced list view refreshes.
  - Subscribed to broadcast topics in `renderRoot` to dynamically update entity folder counters (e.g., `Posts · X`, `Pages · Y`).
- `docs/hooks-reference.md`:
  - Documented `post_type` property in `desktop_mode_my_wordpress_entities` filter reference.
- `tests/`:
  - Added Vitest suites (`my-wordpress-sync.test.ts`, `recycle-bin-badge-subscriptions.test.ts`) for broadcast subscriptions and debouncing.
  - Added PHPUnit tests in `myWordpress.php` and `recycleBinStore.php` verifying entity schemas and localized script configurations.

## Testing Instructions

1. Open both **Recycle Bin** and **My WordPress** windows simultaneously.
2. Trash an item (post, page, or custom post type) by dragging it into the Recycle Bin or via an action menu.
3. Verify that:
   - The Recycle Bin window updates instantly to show the trashed item.
   - The Dock/Tile Recycle Bin badge counter increments.
   - The My WordPress list view and root folder counter update reactively.
4. In the Recycle Bin window, click **Restore** on the item.
5. Verify that:
   - The item disappears from the Recycle Bin.
   - The Recycle Bin badge counter decrements.
   - The My WordPress window reactively updates its list and folder counter without a manual browser reload.

## Screencast


https://github.com/user-attachments/assets/71e45ec9-fc4e-47ea-8d9d-778f1777cd03


## Use of AI Tools

AI assistance: Yes  
Tool(s): Antigravity  
Model(s): Gemini  
Used for: Reviewing the existing implementation, evaluating approaches and suggesting the changes. Final decisions and edits were made by me.