### PR TITLE
Fix invisible context menus and confirm dialogs (transparent panel background)

### DIFF
--- a/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.styles.ts
+++ b/src/ui/components/wpd-confirm-dialog/wpd-confirm-dialog.styles.ts
@@ -23,7 +23,12 @@ export const dialogStyles = css`
 
 	.dialog {
 		width: min( 420px, 92vw );
-		background: var( --wpd-confirm-dialog-bg, var( --desktop-mode-bg, #1d2327 ) );
+		/* Longhand on purpose: the texture slot below owns
+		   background-image, and the shorthand would reset it. The
+		   fallback must be a literal colour — --desktop-mode-bg is the
+		   wallpaper token and can hold a gradient, which is invalid as
+		   a background-color and would leave the dialog transparent. */
+		background-color: var( --wpd-confirm-dialog-bg, #1d2327 );
 		/* Desktop-theme texture slot: unset resolves to none. */
 		background-image: var( --wpd-dialog-bg-image, none );
 		background-repeat: var( --wpd-dialog-bg-image-repeat, repeat );

--- a/src/ui/components/wpd-context-menu/wpd-context-menu.styles.ts
+++ b/src/ui/components/wpd-context-menu/wpd-context-menu.styles.ts
@@ -11,7 +11,12 @@ export const menuStyles = css`
 		display: none;
 		position: fixed;
 		min-width: 180px;
-		background: var( --wpd-context-menu-bg, var( --desktop-mode-bg, #1d2327 ) );
+		/* Longhand on purpose: the texture slot below owns
+		   background-image, and the shorthand would reset it. The
+		   fallback must be a literal colour — --desktop-mode-bg is the
+		   wallpaper token and can hold a gradient, which is invalid as
+		   a background-color and would leave the menu transparent. */
+		background-color: var( --wpd-context-menu-bg, #1d2327 );
 		/* Desktop-theme texture slot: unset resolves to none. */
 		background-image: var( --wpd-menu-bg-image, none );
 		background-repeat: var( --wpd-menu-bg-image-repeat, repeat );

--- a/src/ui/components/wpd-modal/wpd-modal.styles.ts
+++ b/src/ui/components/wpd-modal/wpd-modal.styles.ts
@@ -48,7 +48,12 @@ export const modalStyles = css`
 	.dialog {
 		max-width: 92vw;
 		max-height: 90vh;
-		background: var( --wpd-modal-bg, var( --desktop-mode-bg, #1d2327 ) );
+		/* Longhand on purpose: the texture slot below owns
+		   background-image, and the shorthand would reset it. The
+		   fallback must be a literal colour — --desktop-mode-bg is the
+		   wallpaper token and can hold a gradient, which is invalid as
+		   a background-color and would leave the dialog transparent. */
+		background-color: var( --wpd-modal-bg, #1d2327 );
 		/* Desktop-theme texture slot: unset resolves to none. */
 		background-image: var( --wpd-dialog-bg-image, none );
 		background-repeat: var( --wpd-dialog-bg-image-repeat, repeat );


### PR DESCRIPTION
## What it does

Restores the opaque dark panel behind `<wpd-context-menu>`, `<wpd-confirm-dialog>`, and `<wpd-modal>`. All three currently render fully transparent — right-clicking a tile in My WordPress shows the menu items as loose white text floating over the window body, and the delete-confirmation prompt is equally unreadable.


|Before | After|
|-------|------|
| <img width="3200" height="2434" alt="CleanShot 2026-07-28 at 10 46 54@2x" src="https://github.com/user-attachments/assets/de517f26-b93c-4fe2-990a-6182dc453b10" />|  <img width="3244" height="2434" alt="CleanShot 2026-07-28 at 12 54 36@2x" src="https://github.com/user-attachments/assets/4de99ec4-b4f7-4ca2-88a8-700e1697b6fe" />|

## Rationale

The desktop-themes texture work (#420) added a texture-slot longhand immediately after each surface's `background:` shorthand:

```css
background: var( --wpd-context-menu-bg, var( --desktop-mode-bg, #1d2327 ) );
background-image: var( --wpd-menu-bg-image, none ); /* texture slot */
```

`--desktop-mode-bg` is the wallpaper token and holds a **gradient** — an `<image>`, not a `<color>`. The shorthand therefore routed the entire paint into `background-image` (leaving `background-color: transparent`), and the texture slot's `none` fallback then wiped that image out. With no desktop theme active, nothing painted at all.

#420 converted other surfaces from `background:` to `background-color` for exactly this shorthand-resets-the-texture reason; these three were missed because their fallback chain bottoms out in the gradient rather than a color literal.

## Implementation

Each surface now splits the paint into its two longhands, so the texture slot owns `background-image` outright:

```css
background-color: var( --wpd-context-menu-bg, #1d2327 );
background-image: var( --wpd-menu-bg-image, none );
```

`--desktop-mode-bg` leaves the chain deliberately: an image-valued token can never feed `background-color`, and keeping it as the texture slot's fallback would paint the default gradient over any theme-set surface color (the `:root` gradient is always defined). The literal `#1d2327` matches the gradient's base tone, so the default look is unchanged apart from losing an imperceptible tint sweep. A comment at each site documents the constraint.

## Testing instructions

1. `npm run env:start`, then in the desktop shell open **My WordPress → Media** (any section with tiles works).
2. Right-click a tile — the context menu must render on an opaque dark panel with white items and a red *Delete permanently*.
3. Pick *Delete permanently* — the confirmation dialog must render the same opaque panel; *Cancel* dismisses it.
4. `npm run test:js` (2353 tests), `npm run lint`, `npm run typecheck` — all green.
