### PR TITLE
Fix inline reply/edit in the native Comments window (shadow-DOM row lookup)

### DIFF
--- a/assets/css/comments-window.css
+++ b/assets/css/comments-window.css
@@ -108,6 +108,8 @@
 	min-block-size: 0;
 	display: flex;
 	overflow: hidden;
+	/* Anchors the docked inline reply/edit sheet (position: absolute). */
+	position: relative;
 }
 
 .desktop-mode-comments__body wpd-table {
@@ -257,12 +259,37 @@
 
 /* --- Inline reply / edit --- */
 
+/*
+ * Docked bottom sheet over the table body. Rows render inside
+ * `<wpd-table>`'s shadow DOM, so the editor can't sit inline after a
+ * `<tr>`; it anchors to `.desktop-mode-comments__body` (position:
+ * relative) and floats above the list instead.
+ */
 .desktop-mode-comments__inline-host {
+	position: absolute;
+	inset-inline: 8px;
+	inset-block-end: 8px;
+	/*
+	 * Above the table's sticky cells. `<wpd-table>` doesn't isolate its
+	 * stacking context, so its sticky header/column cells (z-index up to
+	 * 40 in the shadow tree) share this positioned ancestor's context;
+	 * the sheet must clear them or the Author column bleeds through.
+	 */
+	z-index: 50;
+	max-block-size: 70%;
+	overflow: auto;
 	background: var( --wp-desktop-elevated-bg, var( --wpd-surface-elevated, #f6f7f7 ) );
 	border: 1px solid var( --wp-desktop-border-color, var( --wpd-border, #dcdcde ) );
 	border-radius: 6px;
-	padding: 8px;
-	margin: 4px 0 12px;
+	padding: 10px;
+	box-shadow: 0 -6px 20px rgba( 0, 0, 0, 0.18 );
+}
+
+.desktop-mode-comments__inline-context {
+	font-size: 12px;
+	font-weight: 600;
+	margin-block-end: 6px;
+	color: var( --wp-desktop-muted-text-color, var( --wpd-fg-muted, #50575e ) );
 }
 
 .desktop-mode-comments__reply {

--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -1475,7 +1475,11 @@ function inlineHostFor( state: PanelState, contextLabel: string ): HTMLElement {
 	return host;
 }
 
-function openReplyFor(
+// Exported as a test seam: the regression these guard against (the
+// editor landing in a detached node when the row lives in shadow DOM)
+// is only observable by driving these directly and asserting the
+// mounted editor is connected to the document.
+export function openReplyFor(
 	state: PanelState,
 	id: number,
 	cfg: CommentsConfig,
@@ -1532,7 +1536,7 @@ function openReplyFor(
 	editor.focus();
 }
 
-function openEditFor(
+export function openEditFor(
 	state: PanelState,
 	id: number,
 	cfg: CommentsConfig,

--- a/src/comments-window/index.ts
+++ b/src/comments-window/index.ts
@@ -1265,9 +1265,29 @@ function wirePanel(
 	};
 	renderBulkActions();
 
+	// A visible Reply affordance. The bulk bar otherwise exposes only
+	// moderation actions, leaving inline reply reachable through the `r`
+	// shortcut alone; this surfaces it for pointer users. Shown only when
+	// exactly one comment is selected (matching the shortcut's guard) and
+	// opens the same inline editor via openReplyFor().
+	const replyChip = document.createElement( 'wpd-button' );
+	replyChip.setAttribute( 'variant', 'primary' );
+	replyChip.textContent = __( 'Reply' );
+	replyChip.hidden = true;
+	replyChip.addEventListener( 'click', () => {
+		const sel = Array.from( table.selection )
+			.map( ( v ) => Number( v ) )
+			.filter( Boolean );
+		if ( sel.length === 1 ) {
+			openReplyFor( state, sel[ 0 ], cfg );
+		}
+	} );
+	bulkActionsHost.prepend( replyChip );
+
 	table.addEventListener( 'wpd-table-selection-change', () => {
 		const count = table.selection.size;
 		bulkBar.hidden = count === 0;
+		replyChip.hidden = count !== 1;
 		countEl.textContent = sprintf(
 			/* translators: %d: count of selected rows. */
 			__( '%d selected' ),
@@ -1430,6 +1450,31 @@ async function toggleReplies(
 /* Inline reply / edit                                                        */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * Returns a fresh inline-editor host for the panel.
+ *
+ * Rows live inside `<wpd-table>`'s shadow DOM, so the editor can't be
+ * anchored after a specific `<tr>` from the light DOM. Instead it docks as
+ * a bottom sheet over the table body — a single host, so reply and edit
+ * stay mutually exclusive — with a context line naming the target comment.
+ */
+function inlineHostFor( state: PanelState, contextLabel: string ): HTMLElement {
+	const parent = state.tableHost;
+	parent
+		?.querySelectorAll( ':scope > .desktop-mode-comments__inline-host' )
+		.forEach( ( el ) => el.remove() );
+	const host = document.createElement( 'div' );
+	host.className = 'desktop-mode-comments__inline-host';
+	if ( contextLabel ) {
+		const ctx = document.createElement( 'div' );
+		ctx.className = 'desktop-mode-comments__inline-context';
+		ctx.textContent = contextLabel;
+		host.appendChild( ctx );
+	}
+	parent?.appendChild( host );
+	return host;
+}
+
 function openReplyFor(
 	state: PanelState,
 	id: number,
@@ -1439,20 +1484,11 @@ function openReplyFor(
 	if ( ! row ) {
 		return;
 	}
-	const tr = state.tableHost?.querySelector< HTMLElement >(
-		`tr[data-row-id="${ id }"]`,
+	const host = inlineHostFor(
+		state,
+		/* translators: %s: comment author's name. */
+		sprintf( __( 'Replying to %s' ), row.author_name || __( 'Anonymous' ) ),
 	);
-	const host = tr?.nextElementSibling?.classList.contains(
-		'desktop-mode-comments__inline-host',
-	)
-		? ( tr.nextElementSibling as HTMLElement )
-		: ( () => {
-			const ins = document.createElement( 'div' );
-			ins.className = 'desktop-mode-comments__inline-host';
-			tr?.after( ins );
-			return ins;
-		} )();
-	host.replaceChildren();
 	const editor = mountReplyEditor(
 		cfg.replyEditor,
 		__( 'Write a reply…' ),
@@ -1507,15 +1543,7 @@ function openEditFor(
 		showToast( __( 'You can\'t edit this comment.' ) );
 		return;
 	}
-	const tr = state.tableHost?.querySelector< HTMLElement >(
-		`tr[data-row-id="${ id }"]`,
-	);
-	if ( ! tr ) {
-		return;
-	}
-	const host = document.createElement( 'div' );
-	host.className = 'desktop-mode-comments__inline-host';
-	tr.after( host );
+	const host = inlineHostFor( state, __( 'Editing comment' ) );
 	const editor = mountReplyEditor( cfg.replyEditor, __( 'Edit comment…' ) );
 	host.appendChild( editor.root );
 	// Seed with current content
@@ -1666,7 +1694,9 @@ function moveFocus( state: PanelState, direction: 1 | -1 ): void {
 	// keyboard cursor — while a / s / d act on the real selection.
 	state.table.clearSelection();
 	state.table.select( nextId );
-	const tr = state.tableHost?.querySelector< HTMLElement >(
+	// Rows live in `<wpd-table>`'s (open) shadow DOM, so reach through
+	// the shadow root — a light-DOM query on tableHost can't cross it.
+	const tr = state.table.shadowRoot?.querySelector< HTMLElement >(
 		`tr[data-row-id="${ nextId }"]`,
 	);
 	tr?.scrollIntoView( { block: 'nearest', behavior: 'smooth' } );

--- a/tests/vitest/comments-window-inline-reply.test.ts
+++ b/tests/vitest/comments-window-inline-reply.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression guard for the native Comments window inline reply/edit.
+ *
+ * The bug: `<wpd-table>` renders its rows inside an (open) shadow DOM,
+ * but openReplyFor()/openEditFor() located the target row with a
+ * light-DOM `tableHost.querySelector('tr[data-row-id]')`. That query
+ * can't cross the shadow boundary, so it returned null, `tr.after()`
+ * was a no-op, and the editor was appended to a DETACHED node — clicking
+ * Reply/Edit did nothing, no editor ever appeared. The window is opt-in
+ * and off by default, so this shipped broken and unnoticed.
+ *
+ * These tests assert the observable contract that broke: after opening
+ * a reply/edit, the mounted editor is CONNECTED to the document (anchored
+ * under the panel body), independent of where the rows live.
+ */
+import { describe, expect, test, afterEach } from 'vitest';
+import { openReplyFor, openEditFor } from '../../src/comments-window/index';
+import type { CommentRow, CommentsConfig } from '../../src/comments-window/index';
+
+type State = Parameters< typeof openReplyFor >[ 0 ];
+
+function makeRow( over: Partial< CommentRow > = {} ): CommentRow {
+	return {
+		id: 1,
+		post: 5,
+		author_name: 'Marta Ruiz',
+		content: { raw: 'Original text', rendered: 'Original text' },
+		desktop_mode_can_edit: true,
+		...over,
+	} as unknown as CommentRow;
+}
+
+function makeState( rows: CommentRow[], tableHost: HTMLElement ): State {
+	return {
+		tab: 'all',
+		page: 1,
+		perPage: 20,
+		total: rows.length,
+		totalPages: 1,
+		search: '',
+		rows,
+		root: tableHost,
+		tableHost,
+		repliesByParent: new Map(),
+		openReplies: new Set(),
+	} as unknown as State;
+}
+
+const cfg = { replyEditor: 'plain' } as unknown as CommentsConfig;
+
+describe( 'Comments window — inline reply/edit anchoring', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'opening a reply mounts the editor connected to the document', () => {
+		const tableHost = document.createElement( 'div' );
+		document.body.appendChild( tableHost );
+
+		openReplyFor( makeState( [ makeRow() ], tableHost ), 1, cfg );
+
+		const input = document.querySelector( '.desktop-mode-comments__reply-input' );
+		expect( input ).not.toBeNull();
+		// The regression: the editor used to land in a detached node.
+		expect( input?.isConnected ).toBe( true );
+
+		const host = document.querySelector( '.desktop-mode-comments__inline-host' );
+		expect( host?.parentElement ).toBe( tableHost );
+	} );
+
+	test( 'opening an edit mounts the editor connected to the document', () => {
+		const tableHost = document.createElement( 'div' );
+		document.body.appendChild( tableHost );
+
+		openEditFor(
+			makeState( [ makeRow() ], tableHost ),
+			1,
+			cfg,
+			async () => {},
+		);
+
+		const input = document.querySelector( '.desktop-mode-comments__reply-input' );
+		expect( input ).not.toBeNull();
+		expect( input?.isConnected ).toBe( true );
+	} );
+
+	test( 'only one inline editor is open at a time', () => {
+		const tableHost = document.createElement( 'div' );
+		document.body.appendChild( tableHost );
+		const state = makeState( [ makeRow(), makeRow( { id: 2 } ) ], tableHost );
+
+		openReplyFor( state, 1, cfg );
+		openReplyFor( state, 2, cfg );
+
+		expect(
+			document.querySelectorAll( '.desktop-mode-comments__inline-host' ),
+		).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
## Summary

Inline **reply** and **edit** never opened in the native Comments window — clicking them (or pressing `r` / `e`) did nothing, no editor appeared.

`openReplyFor()` / `openEditFor()` located the target row with a light-DOM lookup:

```js
const tr = state.tableHost?.querySelector( 'tr[data-row-id="…"]' );
tr?.after( editorHost ); // inserts the editor after the row
```

But `<wpd-table>` renders its rows inside its **(open) shadow DOM**. `querySelector` doesn't cross the shadow boundary, so `tr` was `null`, `tr?.after()` was a no-op, and the editor ended up in a **detached node** that never reached the page.

The native Comments window is **opt-in** (Settings → Features → *Use the native Comments experience*) and **off by default**, which is why this went unnoticed when the table moved to shadow DOM — there's no test covering the interaction and little real-world exposure.

## Fix

- **Re-anchor the editor** as a docked bottom sheet over the table body (`inlineHostFor()`), instead of trying to insert it after a shadow-DOM `<tr>`. A single host keeps reply and edit mutually exclusive, and a context line names the target comment (e.g. *"Replying to Marta Ruiz"*).
- **Surface a visible `Reply` action** in the bulk bar, shown when exactly one comment is selected (mirroring the `r` shortcut's guard). Inline reply was previously reachable **only** via the keyboard shortcut — undiscoverable for pointer users.
- **Fix keyboard `j` / `k` scroll-into-view**, which hit the same light-DOM row lookup, by reaching through the table's shadow root.

## Notes

- The docked sheet sits at `z-index: 50` so it clears the table's sticky header/column cells (`<wpd-table>` doesn't isolate its stacking context, so its sticky cells — z-index up to 40 in the shadow tree — share the positioned ancestor's context; without this the sticky Author column bled through the sheet).
- No behavior change for the classic (chromeless `edit-comments.php`) experience — this only touches the native window bundle.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` clean.
- `npm run test:js` green (unrelated pre-existing `desktop-files-restore-sync` failure aside).
- Manually verified in wp-env: with the native Comments window enabled, `Reply` and `Edit` now open the docked editor, the Author column no longer bleeds through, and `j`/`k` scroll the focused row into view.
