### PR TITLE
Give tooltips their own two theming tokens

### DIFF
--- a/assets/css/content-graph.css
+++ b/assets/css/content-graph.css
@@ -1010,8 +1010,14 @@
 	gap: 2px;
 	max-width: 240px;
 	padding: 6px 10px;
-	background: var( --wpd-surface-elevated, #1a1f2b );
-	color: var( --wpd-fg-on-accent, #fff );
+	background: var(
+		--desktop-mode-tooltip-bg,
+		var( --wpd-surface-elevated, #1a1f2b )
+	);
+	color: var(
+		--desktop-mode-tooltip-fg,
+		var( --wpd-fg-on-accent, #fff )
+	);
 	border-radius: 6px;
 	box-shadow: 0 4px 14px rgba( 17, 24, 39, 0.18 );
 	font-size: 12px;

--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -477,8 +477,14 @@
 .desktop-mode-dock__tooltip {
 	position: fixed;
 	padding: 6px 12px;
-	background: var( --wpd-scrim, rgba( 0, 0, 0, 0.85 ) );
-	color: var( --wpd-fg-on-accent, #fff );
+	background: var(
+		--desktop-mode-tooltip-bg,
+		var( --wpd-scrim, rgba( 0, 0, 0, 0.85 ) )
+	);
+	color: var(
+		--desktop-mode-tooltip-fg,
+		var( --wpd-fg-on-accent, #fff )
+	);
 	font-size: 12px;
 	font-weight: 400;
 	line-height: 1.4;

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -503,8 +503,14 @@
 	position: fixed;
 	z-index: 100000;
 	max-width: 320px;
-	background: var( --desktop-mode-surface, var( --wpd-surface, #fff ) );
-	color: var( --desktop-mode-fg, #1d2327 );
+	background: var(
+		--desktop-mode-tooltip-bg,
+		var( --desktop-mode-surface, var( --wpd-surface, #fff ) )
+	);
+	color: var(
+		--desktop-mode-tooltip-fg,
+		var( --desktop-mode-fg, #1d2327 )
+	);
 	border: 1px solid var( --wpd-border, #dcdcde );
 	border-radius: 6px;
 	padding: 12px;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -249,6 +249,36 @@
 	 * @since 0.9.8
 	 */
 
+	/*
+	 * ---- Tooltips ---------------------------------------------
+	 *
+	 * Undeclared, like the palette above — every tooltip reads
+	 * `var( --desktop-mode-tooltip-bg, <the chain it always had> )`,
+	 * so an unthemed shell renders exactly as before.
+	 *
+	 *   --desktop-mode-tooltip-bg   the chip / card surface
+	 *   --desktop-mode-tooltip-fg   its primary text
+	 *
+	 * They exist because tooltips used to borrow their two colours
+	 * from unrelated families — `--wpd-scrim` (an overlay BACKDROP)
+	 * or `--wpd-surface-elevated` for the surface, `--wpd-fg-on-accent`
+	 * for the text. Those pairings hold for the default look and come
+	 * apart under a custom theme: a theme that sets `--wpd-scrim` to a
+	 * translucent wash for its modals turns every tooltip translucent
+	 * with it, and a light theme that sets `--wpd-surface-elevated`
+	 * light while `--wpd-fg-on-accent` stays white renders white text
+	 * on a white tooltip. A theme could not fix either without
+	 * breaking the modal backdrop or the text on its accent buttons,
+	 * because it had no name for "tooltip" to aim at. Now it does.
+	 *
+	 * Consumers: dock.css (dock tile tooltip), content-graph.css
+	 * (satellite tooltip), my-wordpress.css (entity hover card).
+	 *
+	 * Secondary text inside the richer tooltips — the hover card's
+	 * excerpt — still follows `--wpd-fg-muted`; these two tokens
+	 * cover the surface and the primary text on it.
+	 */
+
 	/* Dock */
 	--desktop-mode-dock-width: 56px;
 	--desktop-mode-dock-icon-size: 20px;

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -312,6 +312,42 @@ Read `assets/css/variables.css` for the full set.
 }
 ```
 
+#### Tooltips
+
+Two shell tokens own every tooltip in the shell — the dock tile
+tooltip, the content-graph satellite tooltip, and the My WordPress
+entity hover card:
+
+| Token | Role |
+|---|---|
+| `--desktop-mode-tooltip-bg` | The tooltip chip / card surface |
+| `--desktop-mode-tooltip-fg` | Its primary text |
+
+```json
+"tokens": {
+  "--desktop-mode-tooltip-bg": "#1e1c44",
+  "--desktop-mode-tooltip-fg": "#e9e7ff"
+}
+```
+
+They are worth setting explicitly. Without them, tooltips fall back
+to colours borrowed from other families — `--wpd-scrim` or
+`--wpd-surface-elevated` for the surface, `--wpd-fg-on-accent` for the
+text — and those pairings come apart under a custom palette. Set
+`--wpd-scrim` to a translucent wash for your modals and the dock
+tooltip goes translucent with it; keep a light `--wpd-surface-elevated`
+next to a white `--wpd-fg-on-accent` and the satellite tooltip renders
+white text on a white chip. Neither was fixable from the palette alone,
+because fixing it would have broken the modal backdrop or the text on
+accent-filled buttons.
+
+Both tokens are **undeclared by default**, so a theme that ignores
+them keeps the tooltip look the shell has always had.
+
+Secondary text inside the richer tooltips — the hover card's excerpt —
+still follows `--wpd-fg-muted`; these two cover the surface and the
+primary text on it.
+
 ### A note on WordPress core's CSS
 
 Native windows render in the parent shell, not in an iframe, so

--- a/tests/vitest/tooltip-tokens.test.ts
+++ b/tests/vitest/tooltip-tokens.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tooltip theming tokens.
+ *
+ * Every tooltip in the shell used to borrow its two colours from
+ * unrelated token families — `--wpd-scrim` (an overlay BACKDROP) or
+ * `--wpd-surface-elevated` for the surface, `--wpd-fg-on-accent` for
+ * the text. Those pairings hold for the default look and come apart
+ * under a custom desktop theme, and a theme author had no name to aim
+ * at that would fix the tooltip without also moving the modal
+ * backdrop or the text on accent-filled buttons.
+ *
+ * `--desktop-mode-tooltip-bg` / `--desktop-mode-tooltip-fg` are that
+ * name. Two things have to stay true for them to be worth having:
+ *
+ *   1. Every tooltip surface reads the dedicated token FIRST, with
+ *      its old chain as the fallback.
+ *   2. Neither token is declared anywhere, so an unthemed shell
+ *      resolves to exactly the literals it always did.
+ *
+ * These are asserted against the stylesheet text because the rules
+ * live in plain CSS with no module to import — jsdom does not resolve
+ * a nested `var()` chain against undeclared properties, so a computed
+ * -style assertion would prove nothing.
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CSS_DIR = resolve( __dirname, '../../assets/css' );
+
+function readCss( file: string ): string {
+	return readFileSync( resolve( CSS_DIR, file ), 'utf8' );
+}
+
+/**
+ * Extract a single rule body by selector. Deliberately naive — these
+ * selectors each appear once as a rule head in their sheet.
+ */
+function ruleBody( css: string, selector: string ): string {
+	const at = css.indexOf( selector + ' {' );
+	expect( at, `${ selector } not found` ).toBeGreaterThan( -1 );
+	const open = css.indexOf( '{', at );
+	const close = css.indexOf( '}', open );
+	return css.slice( open + 1, close );
+}
+
+/** Collapse whitespace so multi-line `var()` chains compare cleanly. */
+function flat( text: string ): string {
+	return text.replace( /\s+/g, ' ' );
+}
+
+const TOOLTIPS: Array< {
+	label: string;
+	file: string;
+	selector: string;
+	/** The chain each site fell back to before the tokens existed. */
+	bgFallback: string;
+	fgFallback: string;
+} > = [
+	{
+		label: 'dock tile tooltip',
+		file: 'dock.css',
+		selector: '.desktop-mode-dock__tooltip',
+		bgFallback: 'var( --wpd-scrim, rgba( 0, 0, 0, 0.85 ) )',
+		fgFallback: 'var( --wpd-fg-on-accent, #fff )',
+	},
+	{
+		label: 'content-graph satellite tooltip',
+		file: 'content-graph.css',
+		selector: '.desktop-mode-content-graph__tooltip',
+		bgFallback: 'var( --wpd-surface-elevated, #1a1f2b )',
+		fgFallback: 'var( --wpd-fg-on-accent, #fff )',
+	},
+	{
+		label: 'My WordPress entity hover card',
+		file: 'my-wordpress.css',
+		selector: '.desktop-mode-my-wordpress__tooltip',
+		bgFallback: 'var( --desktop-mode-surface, var( --wpd-surface, #fff ) )',
+		fgFallback: 'var( --desktop-mode-fg, #1d2327 )',
+	},
+];
+
+describe( 'tooltip tokens', () => {
+	test.each( TOOLTIPS )(
+		'$label reads the dedicated tokens first',
+		( { file, selector, bgFallback, fgFallback } ) => {
+			const body = flat( ruleBody( readCss( file ), selector ) );
+
+			expect( body ).toContain(
+				`background: var( --desktop-mode-tooltip-bg, ${ bgFallback } )`
+			);
+			expect( body ).toContain(
+				`color: var( --desktop-mode-tooltip-fg, ${ fgFallback } )`
+			);
+		}
+	);
+
+	test( 'neither token is declared, so the default look cannot drift', () => {
+		// A declaration is `--name:`; a read is `var( --name,`. Only
+		// the former would pin a value and defeat the fallback chains
+		// asserted above.
+		for ( const file of [
+			'variables.css',
+			...TOOLTIPS.map( ( t ) => t.file ),
+		] ) {
+			const css = readCss( file );
+
+			expect(
+				/--desktop-mode-tooltip-(?:bg|fg)\s*:/.test( css ),
+				`${ file } declares a tooltip token`
+			).toBe( false );
+		}
+	} );
+
+	test( 'variables.css documents both tokens', () => {
+		const css = readCss( 'variables.css' );
+
+		expect( css ).toContain( '--desktop-mode-tooltip-bg' );
+		expect( css ).toContain( '--desktop-mode-tooltip-fg' );
+	} );
+} );


### PR DESCRIPTION
Tooltips had no tokens of their own, so each one borrowed its surface and text colour from an unrelated family. Those pairings hold at the framework defaults and come apart under a custom desktop theme — and there was no name a theme could aim at to fix one without moving the other thing that token controls.

- `.desktop-mode-dock__tooltip` took its surface from `--wpd-scrim`, an overlay **backdrop**. The Neon Glass reference theme sets that to `rgba( 6, 4, 24, 0.68 )` for its modals, which made every dock tooltip 68% opaque with the wallpaper reading through the label. Dropping the scrim's alpha to fix it would have made every modal backdrop opaque.
- `.desktop-mode-content-graph__tooltip` paired `--wpd-surface-elevated` with `--wpd-fg-on-accent`. A light theme sets the first light and leaves the second white — white text on a white chip. Retuning either would have moved raised strips, or the text on accent-filled buttons.

## What changed

`--desktop-mode-tooltip-bg` / `--desktop-mode-tooltip-fg` are that name. All three tooltip surfaces read the dedicated token first, with their old chain as the fallback:

| Surface | Sheet |
|---|---|
| Dock tile tooltip | `assets/css/dock.css` |
| Corkboard satellite tooltip | `assets/css/content-graph.css` |
| Site window entity hover card | `assets/css/my-wordpress.css` |

Both tokens are left **undeclared**, matching the `--wpd-*` palette and the texture family: every site reads `var( --desktop-mode-tooltip-bg, <the chain it always had> )`, so an unthemed shell computes exactly the literals it did before. No default drift, no flag day.

**No PHP needed** — `desktop_mode_sanitize_desktop_theme_tokens()` already accepts anything matching `^--desktop-mode-[a-z0-9-]+$`. Verified by running the real sanitizer over an updated manifest: nothing dropped.

## Scope note

Secondary text inside the richer tooltips — the hover card's excerpt — still follows `--wpd-fg-muted`. These two tokens cover the surface and the primary text on it. A theme setting a dark `tooltip-bg` inside an otherwise-light palette would want a `--desktop-mode-tooltip-fg-muted` companion; I documented that boundary rather than expanding the surface with a third token unasked.

## Docs

New **Tooltips** subsection under Shell tokens in `docs/desktop-themes.md` — the table, a JSON snippet, and why setting them explicitly is worth it.

## Tests

`tests/vitest/tooltip-tokens.test.ts` pins both halves of the contract: each surface reads the token first with its exact prior fallback, and neither token is declared anywhere. Asserted against stylesheet text, because jsdom will not resolve a nested `var()` chain against undeclared properties — a computed-style assertion would prove nothing.

Gates: `npm run build`, `lint`, `typecheck`, and `test:js` (256 files / 2481 tests) all green. No PHP touched.

## Testing

Hover any dock icon. For the other two: open **Corkboard**, click a node so satellites fan out, hover a satellite bubble; open the window named after your site and hover a post or user tile.

To exercise the tokens without a theme:

```js
document.documentElement.style.setProperty( '--desktop-mode-tooltip-bg', '#7c5cff' );
document.documentElement.style.setProperty( '--desktop-mode-tooltip-fg', '#fff' );
```

Or upload this theme :) 

[neon-glass.zip](https://github.com/user-attachments/files/30501919/neon-glass.zip)

All three turn purple. `removeProperty` on both should return them to exactly their previous look — that's the undeclared-by-default half, and the part most worth confirming by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-446-ba00a5b74511ccd1cbc1d37747ac895a8dffbd87.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->