### PR TITLE
Fix active tab underline highlight in Appearance Add Theme view

### DIFF
--- a/includes/themes-tabs.php
+++ b/includes/themes-tabs.php
@@ -94,11 +94,11 @@ add_filter( 'desktop_mode_dock_item', 'desktop_mode_inject_appearance_tabs', 10,
  * chrome on next paint).
  *
  * The minimum-viable shim: inline JS that reads the real `browse`
- * value via URLSearchParams, finds the matching `[data-sort]` tab,
- * and sets `current` + `aria-current` on it. A MutationObserver on
- * `.filter-links` keeps the tab synced if WP's router fires again
- * (e.g. the user picks Latest, then comes back to Popular via the
- * route's pushState).
+ * value dynamically via URLSearchParams on every check, finds the
+ * matching `[data-sort]` tab, and sets `current` + `aria-current` on it.
+ * A MutationObserver on `.filter-links` keeps the tab synced when WP's
+ * router fires or state changes (e.g. switching tabs to Latest or
+ * returning via pushState).
  */
 function desktop_mode_theme_install_active_tab_script() {
 	if ( ! desktop_mode_is_chromeless_request() ) {
@@ -110,11 +110,17 @@ function desktop_mode_theme_install_active_tab_script() {
 
 	$js = <<<'JS'
 ( function () {
-    var browseParam = new URLSearchParams( window.location.search ).get( 'browse' );
-    if ( ! browseParam ) {
+    function getBrowseParam() {
+        return new URLSearchParams( window.location.search ).get( 'browse' );
+    }
+    if ( ! getBrowseParam() ) {
         return;
     }
     function applyActiveTab() {
+        var browseParam = getBrowseParam();
+        if ( ! browseParam ) {
+            return true;
+        }
         var match = document.querySelector(
             '.filter-links li > a[data-sort="' + browseParam + '"]'
         );

--- a/tests/phpunit/tests/desktopModeInjectAppearanceTabs.php
+++ b/tests/phpunit/tests/desktopModeInjectAppearanceTabs.php
@@ -172,6 +172,7 @@ class Tests_DesktopMode_InjectAppearanceTabs extends WP_UnitTestCase {
 
 		$_GET['desktop_mode_chromeless'] = '1';
 		$GLOBALS['pagenow']              = 'theme-install.php';
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
 
 		ob_start();
 		desktop_mode_theme_install_active_tab_script();
@@ -181,5 +182,6 @@ class Tests_DesktopMode_InjectAppearanceTabs extends WP_UnitTestCase {
 
 		unset( $_GET['desktop_mode_chromeless'] );
 		unset( $GLOBALS['pagenow'] );
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
 	}
 }

--- a/tests/phpunit/tests/desktopModeInjectAppearanceTabs.php
+++ b/tests/phpunit/tests/desktopModeInjectAppearanceTabs.php
@@ -13,6 +13,7 @@
  * @group desktop-mode
  *
  * @covers ::desktop_mode_inject_appearance_tabs
+ * @covers ::desktop_mode_theme_install_active_tab_script
  */
 class Tests_DesktopMode_InjectAppearanceTabs extends WP_UnitTestCase {
 
@@ -154,5 +155,31 @@ class Tests_DesktopMode_InjectAppearanceTabs extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 10, $priority );
+	}
+
+	/**
+	 * Tests that desktop_mode_theme_install_active_tab_script() registers on
+	 * `admin_footer` at priority 100 and outputs the inline active tab script.
+	 *
+	 * @covers ::desktop_mode_theme_install_active_tab_script
+	 */
+	public function test_theme_install_active_tab_script_registered_and_emits_dynamic_browse_param() {
+		$priority = has_action(
+			'admin_footer',
+			'desktop_mode_theme_install_active_tab_script'
+		);
+		$this->assertSame( 100, $priority );
+
+		$_GET['desktop_mode_chromeless'] = '1';
+		$GLOBALS['pagenow']              = 'theme-install.php';
+
+		ob_start();
+		desktop_mode_theme_install_active_tab_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'function getBrowseParam()', $output );
+
+		unset( $_GET['desktop_mode_chromeless'] );
+		unset( $GLOBALS['pagenow'] );
 	}
 }


### PR DESCRIPTION
## What?
Closes #447 

Fixes the bug where the colored underline bar/highlight always stays stuck on "Popular" in the Appearance -> Add Theme (theme installer) screen and does not update when other tabs ("Latest", "Block Themes", "Favorites") are clicked.

## Why?
The theme installer (`theme-install.php`) runs in a chromeless iframe context (`desktop_mode_chromeless=1`). WordPress Core's legacy Backbone router updates the URL in place using `history.replaceState` or `pushState`, but it doesn't correctly update the DOM's active state tab classes in this environment because the initial `browse` query parameter from `window.location.search` was only evaluated once on initial page load, ignoring subsequent client-side URL changes.

## How?
- `includes/themes-tabs.php`:
  - Refactored `desktop_mode_theme_install_active_tab_script()` inline JavaScript to dynamically evaluate the `browse` URL query parameter on every DOM check via a helper function `getBrowseParam()`, rather than caching the initial query parameter.
  - Updated the `MutationObserver` on `.filter-links` to fetch the fresh `browse` parameter on every mutation, correctly updating the `current` class and `aria-current="page"` attribute dynamically.
- `tests/phpunit/tests/desktopModeInjectAppearanceTabs.php`:
  - Added `test_theme_install_active_tab_script_registered_and_emits_dynamic_browse_param()` to assert that the active tab script is hooked to `admin_footer` at priority `100` and outputs the inline JS helper.

## Testing Instructions
1. Open the Desktop environment and go to **Appearance -> Add Theme** (the "Popular" tab is active by default).
2. Click on the "Latest", "Block Themes", or "Favorites" tabs.
3. Verify that the colored highlight bar/underline correctly moves to the active tab.

## Screencast

https://github.com/user-attachments/assets/b86d614a-53a4-422b-8758-861703d55903

## Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini
Used for: Reviewing the existing implementation and suggesting the changes. Final decisions and edits were made by me.
