### PR TITLE
Show the whole component kit in OS Settings, and make it searchable

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -710,16 +710,35 @@
 	}
 }
 
+/*
+ * Search box + nav share one column so the field stays pinned while
+ * the component list below it scrolls.
+ */
+.desktop-mode-os-settings__help-sidebar {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	min-height: 0;
+}
+
 .desktop-mode-os-settings__help-nav {
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
 	align-self: stretch;
+	min-height: 0;
 	overflow-y: auto;
 	padding: 4px;
 	background: var( --wpd-surface-elevated, #f6f7f7 );
 	border: 1px solid var( --wpd-border, #dcdcde );
 	border-radius: 8px;
+}
+
+.desktop-mode-os-settings__help-nav-empty {
+	margin: 0;
+	padding: 8px 10px;
+	font-size: 12px;
+	color: var( --wpd-fg-muted, #646970 );
 }
 
 .desktop-mode-os-settings__help-nav-item {

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -12,7 +12,15 @@ Components are **side-effect registered** at import time, per bundle, into the p
 2. Add the class export to `src/ui/components/index.ts`.
 3. Add the tag to `src/ui/components/tags.ts` (the single source of `WPD_COMPONENT_TAGS`, re-exported by `index.ts`).
 4. Add a row to this table.
-5. Document via the `static help = { … }` block on the class — surfaced in OS Settings → Help live.
+5. Document via the `static help = { … }` block on the class — surfaced in OS Settings → Components live.
+
+## Browsing the kit at runtime
+
+**OS Settings → Components** (admin-only) renders this table live: every tag in `WPD_COMPONENT_TAGS`, with its props, slots, events, parts, CSS custom properties, and a working example rendered from the `static help.example` template.
+
+The tab side-effect-imports the whole component barrel so the list is the full kit rather than "whatever other bundles happen to have loaded" — the per-bundle registration model described above means an unimported component reaches no custom-element registry, and a tab that only enumerated registered tags silently under-reported itself.
+
+The search box above the list filters on the flattened descriptor, not just the title: tag name, summary, status, `static props` names, and the name *and* description of every documented prop, slot, event, part, and CSS custom property. Terms are ANDed and order-independent, so `field number` and `number clamp` both reach `<wpd-number-field>`.
 
 ## Layout & structure
 
@@ -121,4 +129,4 @@ The remaining classes are internal-only for now — subpath / source-path import
 
 ## Per-component help
 
-Every class has a `static help = { … }` block with full props / slots / events / examples / status. The OS Settings → Help tab iterates `WPD_COMPONENT_TAGS` and renders these descriptors live; that's the authoritative per-component reference. The table above is a directory; the `static help` block is the manual.
+Every class has a `static help = { … }` block with full props / slots / events / examples / status. The OS Settings → Components tab iterates `WPD_COMPONENT_TAGS` and renders these descriptors live; that's the authoritative per-component reference. The table above is a directory; the `static help` block is the manual.

--- a/src/settings/sections/help.ts
+++ b/src/settings/sections/help.ts
@@ -19,7 +19,18 @@
  * this tab doesn't see intentional console.error noise.
  */
 
-import { __ } from '../../i18n';
+// Side-effect import of the whole kit. Feature code elsewhere
+// imports components one file at a time, so a component nothing
+// happens to use is tree-shaken out of every bundle — it never
+// reaches `customElements`, and `collectEntries()` silently skips
+// it. That made the tab a list of "components some other screen
+// loaded" rather than "components this plugin ships". Importing
+// the barrel here registers every tag in `WPD_COMPONENT_TAGS`,
+// which is also what makes the live `help.example` markup render
+// instead of collapsing to unknown elements.
+import '../../ui/components';
+
+import { __, sprintf } from '../../i18n';
 import { html, render, type WpdHelp } from '../../ui/core';
 import { WPD_COMPONENT_TAGS } from '../../ui/components/tags';
 import type { SettingsCtx } from '../types';
@@ -35,6 +46,62 @@ interface ComponentEntry {
 	title: string;
 	help: WpdHelp | null;
 	props: readonly string[];
+	/**
+	 * Pre-flattened lowercase blob of everything worth searching on:
+	 * title, tag, summary, status, and the name + description of every
+	 * documented prop, slot, event, part, and CSS custom property.
+	 * Built once in `collectEntries()` so filtering on each keystroke
+	 * is a substring scan rather than a walk of the descriptor tree.
+	 */
+	haystack: string;
+}
+
+/**
+ * Flatten a descriptor into the searchable blob stored on
+ * {@link ComponentEntry.haystack}.
+ *
+ * Descriptions are included deliberately — searching "clipboard" or
+ * "clamp" should surface the component that mentions it even when the
+ * word appears in no name. `static props` names are folded in too, so
+ * undocumented components (no `help`) stay findable by attribute.
+ */
+function buildHaystack(
+	tag: string,
+	title: string,
+	help: WpdHelp | null,
+	props: readonly string[],
+): string {
+	const parts: string[] = [ tag, title, ...props ];
+	if ( help ) {
+		parts.push( help.summary ?? '', help.status ?? '' );
+		const groups = [
+			help.props,
+			help.slots,
+			help.events,
+			help.parts,
+			help.cssProps,
+		];
+		for ( const group of groups ) {
+			for ( const item of group ?? [] ) {
+				const entry = item as { name?: string; description?: string };
+				parts.push( entry.name ?? '', entry.description ?? '' );
+			}
+		}
+	}
+	return parts.join( ' ' ).toLowerCase();
+}
+
+/**
+ * Split a raw query into lowercase terms and AND them together, so
+ * "field number" matches `<wpd-number-field>` regardless of the order
+ * the words were typed.
+ */
+function matchesQuery( entry: ComponentEntry, query: string ): boolean {
+	const terms = query.toLowerCase().split( /\s+/ ).filter( Boolean );
+	if ( ! terms.length ) {
+		return true;
+	}
+	return terms.every( ( term ) => entry.haystack.includes( term ) );
 }
 
 /**
@@ -86,12 +153,18 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 	el.classList.add( 'desktop-mode-os-settings__help' );
 
 	let activeTag = entries[ 0 ]?.tag ?? '';
+	let query = '';
 
 	const paint = (): void => {
 		if ( ctx.state.developerModeEnabled ) {
 			logDemoBanner();
 		}
-		const active = entries.find( ( e ) => e.tag === activeTag ) ?? entries[ 0 ];
+		const visible = entries.filter( ( e ) => matchesQuery( e, query ) );
+		// Keep the selection when it survives the filter; otherwise fall
+		// back to the first match so the detail pane never goes blank
+		// while results exist.
+		const active =
+			visible.find( ( e ) => e.tag === activeTag ) ?? visible[ 0 ];
 		render(
 			html`
 				<wpd-section
@@ -101,7 +174,18 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 					) }
 				>
 					<p class="desktop-mode-os-settings__help-count">
-						${ String( entries.length ) } ${ __( 'components registered.' ) }
+						${ query
+							? sprintf(
+									/* translators: 1: number of matching components, 2: total number of components. */
+									__( '%1$s of %2$s components match.' ),
+									String( visible.length ),
+									String( entries.length ),
+								)
+							: sprintf(
+									/* translators: %s: number of registered components. */
+									__( '%s components registered.' ),
+									String( entries.length ),
+								) }
 					</p>
 				</wpd-section>
 
@@ -141,11 +225,33 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 					: '' }
 
 				<div class="desktop-mode-os-settings__help-layout">
+					<div class="desktop-mode-os-settings__help-sidebar">
+						<wpd-text-field
+							class="desktop-mode-os-settings__help-search"
+							type="search"
+							label=${ __( 'Search components' ) }
+							placeholder=${ __( 'Name, tag, prop, event…' ) }
+							autocomplete="off"
+							value=${ query }
+							@wpd-input-change=${ ( e: Event ) => {
+			query = (
+				( e as CustomEvent< { value: string } > ).detail?.value ?? ''
+			).trim();
+			paint();
+		} }
+						></wpd-text-field>
 					<nav
 						class="desktop-mode-os-settings__help-nav"
 						aria-label=${ __( 'Components' ) }
 					>
-						${ entries.map(
+						${ ! visible.length
+							? html`<p
+									class="desktop-mode-os-settings__help-nav-empty"
+								>
+									${ __( 'No components match.' ) }
+								</p>`
+							: '' }
+						${ visible.map(
 							( entry ) => html`
 								<button
 									type="button"
@@ -173,6 +279,7 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 							`,
 						) }
 					</nav>
+					</div>
 					<div class="desktop-mode-os-settings__help-detail">
 						${ active ? renderDetail( active ) : renderEmpty() }
 					</div>
@@ -430,7 +537,13 @@ function collectEntries(): ComponentEntry[] {
 		const help = ctor.help ?? null;
 		const title = help?.title ?? defaultTitleFromTag( tag );
 		const props = ctor.props ?? [];
-		entries.push( { tag, title, help, props } );
+		entries.push( {
+			tag,
+			title,
+			help,
+			props,
+			haystack: buildHaystack( tag, title, help, props ),
+		} );
 	}
 	// Stable alphabetical sort by title so plugin authors can find
 	// components without having to memorise registration order.

--- a/tests/vitest/os-settings-components-tab.test.ts
+++ b/tests/vitest/os-settings-components-tab.test.ts
@@ -1,0 +1,164 @@
+/**
+ * OS Settings → Components tab.
+ *
+ * Two things are covered here, and they're related:
+ *
+ * 1. **Every tag in `WPD_COMPONENT_TAGS` actually registers.** Feature
+ *    code imports components one file at a time, so before the tab
+ *    side-effect-imported the barrel, any component nothing happened to
+ *    use was tree-shaken out of every bundle. It never reached
+ *    `customElements`, and the tab silently skipped it — the reason
+ *    `<wpd-number-field>` and 24 others were missing from a list that
+ *    claims to show everything the plugin ships.
+ *
+ * 2. **The search box filters on the whole descriptor**, not just the
+ *    title, so "number" finds the number field and "clamp" finds it via
+ *    its prop description.
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import { buildHelpSection } from '../../src/settings/sections/help';
+import { WPD_COMPONENT_TAGS } from '../../src/ui/components/tags';
+import type { SettingsCtx } from '../../src/settings/types';
+
+function ctxStub(): SettingsCtx {
+	return {
+		state: { developerModeEnabled: false },
+	} as unknown as SettingsCtx;
+}
+
+function navTitles( el: HTMLElement ): string[] {
+	return Array.from(
+		el.querySelectorAll( '.desktop-mode-os-settings__help-nav-title' ),
+	).map( ( n ) => n.textContent?.trim() ?? '' );
+}
+
+function navTags( el: HTMLElement ): string[] {
+	return Array.from(
+		el.querySelectorAll( '.desktop-mode-os-settings__help-nav-tag' ),
+	).map( ( n ) => n.textContent?.trim().replace( /^<|>$/g, '' ) ?? '' );
+}
+
+/**
+ * Drive the search field the way a user does: set the inner input's
+ * value and let the component emit `wpd-input-change`.
+ */
+function search( el: HTMLElement, term: string ): void {
+	const field = el.querySelector( '.desktop-mode-os-settings__help-search' );
+	if ( ! field ) {
+		throw new Error( 'search field not rendered' );
+	}
+	field.dispatchEvent(
+		new CustomEvent( 'wpd-input-change', {
+			detail: { value: term },
+			bubbles: true,
+			composed: true,
+		} ),
+	);
+}
+
+describe( 'OS Settings — Components tab', () => {
+	let el: HTMLElement;
+
+	beforeEach( () => {
+		el = buildHelpSection( ctxStub() );
+		document.body.appendChild( el );
+	} );
+
+	test( 'every declared tag is registered on customElements', () => {
+		const unregistered = WPD_COMPONENT_TAGS.filter(
+			( tag ) => ! customElements.get( tag ),
+		);
+		expect( unregistered ).toEqual( [] );
+	} );
+
+	test( 'lists every declared component, not just the loaded ones', () => {
+		expect( navTags( el ).sort() ).toEqual(
+			[ ...WPD_COMPONENT_TAGS ].sort(),
+		);
+	} );
+
+	test( 'wpd-number-field is listed', () => {
+		expect( navTags( el ) ).toContain( 'wpd-number-field' );
+		expect( navTitles( el ) ).toContain( 'Number field' );
+	} );
+
+	test( 'search narrows the list and keeps the relevant match', () => {
+		search( el, 'number' );
+		const tags = navTags( el );
+		expect( tags ).toContain( 'wpd-number-field' );
+		expect( tags.length ).toBeLessThan( WPD_COMPONENT_TAGS.length );
+	} );
+
+	test( 'search filters by exact tag name', () => {
+		search( el, 'wpd-progress-bar' );
+		expect( navTags( el ) ).toEqual( [ 'wpd-progress-bar' ] );
+	} );
+
+	test( 'search matches prop and event descriptions, not only names', () => {
+		// "clamp" appears in the number field's min/max prop
+		// descriptions and nowhere in its title or tag.
+		search( el, 'clamp' );
+		expect( navTags( el ) ).toContain( 'wpd-number-field' );
+	} );
+
+	test( 'search terms are ANDed regardless of order', () => {
+		search( el, 'number field' );
+		const forward = navTags( el );
+		search( el, 'field number' );
+		expect( navTags( el ) ).toEqual( forward );
+		expect( forward ).toContain( 'wpd-number-field' );
+		// Both terms must be present — ANDing has to narrow past
+		// either term on its own.
+		search( el, 'number' );
+		expect( forward.length ).toBeLessThanOrEqual( navTags( el ).length );
+	} );
+
+	test( 'search is case-insensitive', () => {
+		search( el, 'number field' );
+		const lower = navTags( el );
+		search( el, 'NUMBER FIELD' );
+		expect( navTags( el ) ).toEqual( lower );
+	} );
+
+	test( 'clearing the search restores the full list', () => {
+		search( el, 'number' );
+		expect( navTags( el ).length ).toBeLessThan(
+			WPD_COMPONENT_TAGS.length,
+		);
+		search( el, '' );
+		expect( navTags( el ) ).toHaveLength( WPD_COMPONENT_TAGS.length );
+	} );
+
+	test( 'no matches renders an empty message and no nav items', () => {
+		search( el, 'zzzz-no-such-component' );
+		expect( navTags( el ) ).toEqual( [] );
+		expect(
+			el.querySelector( '.desktop-mode-os-settings__help-nav-empty' ),
+		).not.toBeNull();
+	} );
+
+	test( 'count line reports matches while filtering', () => {
+		const count = (): string =>
+			el
+				.querySelector( '.desktop-mode-os-settings__help-count' )
+				?.textContent?.trim() ?? '';
+
+		expect( count() ).toContain(
+			`${ WPD_COMPONENT_TAGS.length } components registered.`,
+		);
+		search( el, 'wpd-progress-bar' );
+		expect( count() ).toContain( `1 of ${ WPD_COMPONENT_TAGS.length }` );
+	} );
+
+	test( 'selection follows the filter instead of going blank', () => {
+		const detail = (): string =>
+			el.querySelector( '.desktop-mode-os-settings__help-detail' )
+				?.textContent ?? '';
+
+		// The initial selection is the first entry alphabetically; a
+		// search that excludes it must move the detail pane onto a
+		// surviving match rather than render the empty state.
+		search( el, 'wpd-number-field' );
+		expect( detail() ).toContain( 'wpd-number-field' );
+	} );
+} );


### PR DESCRIPTION
## The bug

`<wpd-number-field>` doesn't appear in OS Settings → Components. Neither do 24 other components.

The tab iterates `WPD_COMPONENT_TAGS`, looks each tag up with `customElements.get()`, and skips anything unregistered:

```ts
const ctor = customElements.get( tag ) as CtorWithHelp | undefined;
if ( ! ctor ) {
    continue;
}
```

Feature code imports components one file at a time (`import '../ui/components/wpd-button/wpd-button'`) and **nothing imported the barrel**. So any component that no screen happened to use was tree-shaken out of every bundle, never reached the custom-element registry, and got silently dropped from a list whose own description promises "every `<wpd-*>` web component shipped by this plugin".

The tab was showing *components some other screen loaded*, not *components this plugin ships*. 38 of 63.

Invisible before this change: badge, body, card, category-picker, checkbox, chip, cluster, code, crumb-chain, display, flyout, form, grid, key, log, multiselect, **number-field**, rating-summary, relative-time, row, stack, step, steps, table, tag-input.

`WpdNumberField` was in **zero** built bundles — the tag was inert everywhere in the shell, not merely absent from the tab.

## The fix

Side-effect-import the barrel from the tab. Verified in the built bundle: `defineComponent(...)` calls in `os-settings-panel.js` went 21 → 63.

## Search

A `<wpd-text-field type="search">` above the list, filtering a haystack flattened once per entry in `collectEntries()` — so each keystroke is a substring scan, not a walk of the descriptor tree.

Matches on tag, title, summary, status, `static props` names, and the name **and description** of every documented prop, slot, event, part, and CSS custom property. Descriptions are in deliberately: searching `clamp` should reach `<wpd-number-field>` through its `min`/`max` prop docs even though the word appears in no name.

Terms are ANDed and order-independent — `field number` and `number field` return the same set. The count line switches to "N of 63 components match", selection follows the filter instead of blanking the detail pane, and an empty result renders a message rather than an empty column.

## On "are other components undocumented?"

Checked, and no: `tags.ts` ↔ source tree is exactly in sync (63/63, no orphans in either direction), every one of the 63 classes carries a `static help` descriptor, and `docs/components-reference.md` covers them all — the 8 that look absent from its table are child tags (`<wpd-option>`, `<wpd-segment>`, `<wpd-tabpanel>`, …) documented on their parent's row. Tree-shaking was the entire gap.

## Trade-off worth a look

`os-settings-panel.min.js` grows **40.2 → 88.0 KB gzip**, and that bundle loads whenever anyone opens OS Settings — to serve a tab that's admin-only and developer-facing.

The alternative is a separate `build:components-help` target loaded on demand when the tab opens; `loadOsSettingsPanelBundle()` in `src/settings/index.ts` is an existing pattern to copy. That's a new Vite target, PHP asset registration, and an async section builder, so I didn't fold it into this PR. Happy to do it as a follow-up if the 48 KB is unwelcome.

## Tests

12 new tests in `tests/vitest/os-settings-components-tab.test.ts`. One pins the regression directly:

```ts
test( 'every declared tag is registered on customElements', () => {
    const unregistered = WPD_COMPONENT_TAGS.filter(
        ( tag ) => ! customElements.get( tag ),
    );
    expect( unregistered ).toEqual( [] );
} );
```

Full suite: **2511 passed / 257 files**. `typecheck`, `lint`, and `build` all clean (the single CSS minify warning reproduces on `trunk` — pre-existing).

## Manual test steps

OS Settings → Components:

1. Count line reads **63 components registered** (was 38).
2. Type `number` — list narrows, `<wpd-number-field>` present with a live rendered example.
3. Type `clamp` — still finds it, matched only via prop descriptions.
4. Type `field number`, then `number field` — identical results.
5. Type nonsense — "No components match." and the detail pane empty-states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-451-44cea6682166412ddd046532432156a7cf21ef56.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->