### PR TITLE
Expose dock glyph and focused window control colours as tokens

### DIFF
--- a/assets/css/dock-peek.css
+++ b/assets/css/dock-peek.css
@@ -33,10 +33,20 @@
 		filter 240ms ease-out;
 }
 
+/* Same two glyph/wash tokens as the base hover rule in dock.css —
+ * this sheet re-states hover to add the lift and the drop shadow, and
+ * it wins on specificity, so a theme that only reached the base rule
+ * would see its colour vanish the moment the peek sheet loaded. */
 .desktop-mode-dock__item:hover .desktop-mode-dock__item-primary,
 .desktop-mode-dock__item[data-peek-active] .desktop-mode-dock__item-primary {
-	background: rgba( 255, 255, 255, 0.15 );
-	color: var( --wpd-fg-on-accent, #fff );
+	background: var(
+		--desktop-mode-dock-item-bg-hover,
+		rgba( 255, 255, 255, 0.15 )
+	);
+	color: var(
+		--desktop-mode-dock-icon-color-hover,
+		var( --wpd-fg-on-accent, #fff )
+	);
 	transform: scale( 1.08 );
 	filter: drop-shadow( 0 4px 8px rgba( 0, 0, 0, 0.18 ) );
 }

--- a/assets/css/dock-peek.css
+++ b/assets/css/dock-peek.css
@@ -36,10 +36,17 @@
 /* Same two glyph/wash tokens as the base hover rule in dock.css —
  * this sheet re-states hover to add the lift and the drop shadow, and
  * it wins on specificity, so a theme that only reached the base rule
- * would see its colour vanish the moment the peek sheet loaded. */
+ * would see its colour vanish the moment the peek sheet loaded.
+ *
+ * `background-color`, not the `background` shorthand it used to be:
+ * the shorthand also reset `background-image`, which erased the
+ * DOCK_ITEM texture from under the cursor on any theme that ships
+ * one. dock.css sets the resting wash as a colour for exactly this
+ * reason — "so it composes with the texture rather than erasing it" —
+ * and this rule quietly undid it on hover. */
 .desktop-mode-dock__item:hover .desktop-mode-dock__item-primary,
 .desktop-mode-dock__item[data-peek-active] .desktop-mode-dock__item-primary {
-	background: var(
+	background-color: var(
 		--desktop-mode-dock-item-bg-hover,
 		rgba( 255, 255, 255, 0.15 )
 	);

--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -79,13 +79,24 @@
 	background-repeat: var( --desktop-mode-dock-item-image-repeat, no-repeat );
 	background-size: var( --desktop-mode-dock-item-image-size, auto );
 	background-position: var( --desktop-mode-dock-item-image-position, center );
-	color: rgba( 255, 255, 255, 0.7 );
+	/*
+	 * Dock glyph colour. The literal is what this rule always said;
+	 * the token is the name a theme aims at when its dock strip is
+	 * not dark. See the "Dock glyphs" block in variables.css.
+	 */
+	color: var( --desktop-mode-dock-icon-color, rgba( 255, 255, 255, 0.7 ) );
 	transition: background-color 0.15s ease, transform 0.15s ease, color 0.15s ease;
 }
 
 .desktop-mode-dock__item-primary:hover {
-	background-color: rgba( 255, 255, 255, 0.15 );
-	color: var( --wpd-fg-on-accent, #fff );
+	background-color: var(
+		--desktop-mode-dock-item-bg-hover,
+		rgba( 255, 255, 255, 0.15 )
+	);
+	color: var(
+		--desktop-mode-dock-icon-color-hover,
+		var( --wpd-fg-on-accent, #fff )
+	);
 	transform: scale( 1.1 );
 }
 
@@ -94,7 +105,10 @@
 }
 
 .desktop-mode-dock__item-primary:focus-visible {
-	outline: 2px solid rgba( 255, 255, 255, 0.7 );
+	outline: 2px solid var(
+		--desktop-mode-dock-item-outline,
+		rgba( 255, 255, 255, 0.7 )
+	);
 	outline-offset: 2px;
 }
 
@@ -378,9 +392,14 @@
 	transform: scale( 1.03 );
 }
 
-/* System tiles — same footprint as menu tiles, no badges, no rails. */
+/* System tiles — same footprint as menu tiles, no badges, no rails.
+ *
+ * Reads the SAME glyph token as a menu tile, with its own literal as
+ * the fallback: unthemed, system tiles keep sitting a notch brighter
+ * than the rest (0.8 vs 0.7); themed, one colour covers every glyph
+ * in the dock rather than leaving these four stranded white. */
 .desktop-mode-dock__item--system .desktop-mode-dock__item-primary {
-	color: rgba( 255, 255, 255, 0.8 );
+	color: var( --desktop-mode-dock-icon-color, rgba( 255, 255, 255, 0.8 ) );
 }
 
 /* -----------------------------------------------------------------------------

--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -138,7 +138,12 @@
 	line-height: 1;
 }
 
-/* SVG icon (for custom post types with data:image/svg+xml icons). */
+/* SVG icon (for custom post types with data:image/svg+xml icons).
+ *
+ * The FALLBACK path now: `_makeSvgIcon()` paints these as a mask
+ * filled with `currentColor` (see `__item-mask` below) and only lands
+ * here when the mask refuses the URL — one carrying quotes, spaces or
+ * parens. The filter is what that fallback still needs. */
 .desktop-mode-dock__item-svg {
 	width: var( --desktop-mode-dock-icon-size, 20px );
 	height: var( --desktop-mode-dock-icon-size, 20px );
@@ -148,7 +153,9 @@
 	/* Some plugin SVGs ship hardcoded `fill="..."` attributes inside
 	   the markup, which override `fill: currentColor` and make the
 	   icon keep its brand color. Force the monochrome white palette
-	   to match dashicons. */
+	   to match dashicons. Flattens to WHITE specifically, which is why
+	   the mask path is preferred: a filter has no colour to name, so a
+	   theme cannot reach it. */
 	filter: brightness(0) invert(1);
 	transition: opacity 0.15s ease;
 }
@@ -158,19 +165,28 @@
 }
 
 /*
- * Desktop-theme TINTED icon — the glyph is painted as a CSS mask
- * filled with the colour the theme named, so only the source
- * artwork's alpha is used.
+ * MASKED icon — the glyph is painted as a CSS mask filled with a
+ * colour, so only the source artwork's alpha is used.
+ *
+ * Two callers, one shape:
+ *
+ *   - A desktop theme's tinted iconset, filled with the colour the
+ *     theme named for that slot.
+ *   - Every other plugin / CPT image icon, filled with
+ *     `currentColor` — which is `--desktop-mode-dock-icon-color`, the
+ *     same token the dashicons follow.
  *
  * Deliberately NOT `__item-svg`: that class force-whitens its content
- * with `filter: brightness(0) invert(1)` so plugin SVGs carrying
- * hardcoded `fill` attributes still match the dock. Here the fill is
- * the whole point, and the filter would flatten every theme's colour
- * to white.
+ * with `filter: brightness(0) invert(1)`. Both mechanisms discard the
+ * artwork's colours and keep its alpha, but only one of them has a
+ * colour a theme can name.
  *
- * Full opacity at rest, unlike the untinted icon paths: a theme that
- * names a colour has already decided how prominent its glyphs should
- * be, and dimming it to 0.7 would silently mix it with the dock.
+ * Full opacity, unlike `__item-svg`'s 0.7: the fill carries its own
+ * alpha. Unthemed that is `rgba( 255, 255, 255, 0.7 )` at rest and
+ * `#fff` on hover — exactly what the filter plus the opacity pair
+ * used to compute — and a theme that names a colour has already
+ * decided how prominent its glyphs should be, so dimming it again
+ * would silently mix it with the dock.
  *
  * @since 0.9.8
  */

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -339,13 +339,13 @@
 	 * keep their notch of extra prominence and themed they follow the
 	 * single colour the theme named.
 	 *
-	 * Named a *colour*, not a fill, on purpose: a desktop theme whose
-	 * iconset uses `"iconColor": "currentColor"` is masked with the
-	 * glyph colour, so this one token drives dashicons, the theme's
-	 * own artwork, and the hover transition together. Plugin SVGs
-	 * carrying hardcoded `fill` attributes are the exception — the
-	 * `__item-svg` path force-whitens them (see the note in dock.css),
-	 * and an iconset is how a theme overrides those.
+	 * Named a *colour*, not a fill, on purpose: every image glyph in
+	 * the dock is painted as a mask filled with this colour — a
+	 * theme's own iconset via `"iconColor": "currentColor"`, and
+	 * plugin / CPT artwork via `currentColor` on the tile. So one
+	 * token drives dashicons, theme art, plugin art, and the hover
+	 * transition between them. The `__item-svg` fallback (a URL the
+	 * mask can't take) still force-whitens; see the note in dock.css.
 	 *
 	 * Consumers: dock.css, dock-peek.css (which re-states the hover
 	 * rule and so must read the same two tokens).

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -192,6 +192,45 @@
 	 */
 
 	/*
+	 * ---- Title-bar control glyphs -----------------------------
+	 *
+	 * The colour of the buttons themselves — minimise / maximise /
+	 * close, the ⋯ menu trigger, and the screen-meta cluster — in
+	 * each of the two title-bar states.
+	 *
+	 *   Focused    --desktop-mode-titlebar-btn-focused-color
+	 *              --desktop-mode-titlebar-btn-focused-color-hover
+	 *              --desktop-mode-titlebar-btn-focused-bg-hover
+	 *              --desktop-mode-titlebar-btn-focused-bg-active
+	 *              --desktop-mode-titlebar-btn-focused-outline
+	 *   Unfocused  --desktop-mode-titlebar-btn-color
+	 *              --desktop-mode-titlebar-btn-color-hover
+	 *              --desktop-mode-titlebar-btn-bg-hover
+	 *              --desktop-mode-titlebar-btn-bg-active
+	 *
+	 * Undeclared, like everything above: each rule reads
+	 * `var( --name, <the literal it always had> )`.
+	 *
+	 * The unfocused half additionally DERIVES from
+	 * `--desktop-mode-titlebar-color` under an active desktop theme,
+	 * so most themes never need to name it. The focused half cannot
+	 * do the same — its glyphs sit on `-bg-focused`, a fill a theme
+	 * may set to anything from near-black to a pastel, and there is
+	 * no contrast-safe function of a background colour in CSS. So it
+	 * stays explicit: white at 70% until a theme says otherwise.
+	 *
+	 * Why these need names at all: the declarations land on the
+	 * WINDOW element (`.desktop-mode-window--focused`), which outranks
+	 * a `--wpd-btn-*` set at the shell root, and those names are
+	 * shared with buttons outside the title bar. A theme had no way to
+	 * recolour a focused control without also moving sticky-note and
+	 * desk chrome.
+	 *
+	 * Consumers: window-chrome.css (control cluster, ⋯ trigger,
+	 * screen-meta buttons).
+	 */
+
+	/*
 	 * ---- Typography ------------------------------------------
 	 *
 	 * Also deliberately UNDECLARED, for the same reason as the
@@ -277,6 +316,39 @@
 	 * Secondary text inside the richer tooltips — the hover card's
 	 * excerpt — still follows `--wpd-fg-muted`; these two tokens
 	 * cover the surface and the primary text on it.
+	 */
+
+	/*
+	 * ---- Dock glyphs ------------------------------------------
+	 *
+	 * `--desktop-mode-dock-bg` below is declared, so a theme can and
+	 * does repaint the strip. What it paints ON the strip was, until
+	 * these tokens, fixed white — the glyph, its hover brightening,
+	 * the hover wash behind the tile, and the focus ring. Set the
+	 * dock to anything pale and every tile went blank.
+	 *
+	 *   --desktop-mode-dock-icon-color        glyph at rest
+	 *   --desktop-mode-dock-icon-color-hover  glyph on hover / peek
+	 *   --desktop-mode-dock-item-bg-hover     wash behind the tile
+	 *   --desktop-mode-dock-item-outline      keyboard focus ring
+	 *
+	 * Undeclared, like the palette: each site reads
+	 * `var( --name, <the literal it always had> )`. System tiles
+	 * (OS Settings, recycle bin, …) read the same `-icon-color` with
+	 * their own slightly brighter literal behind it, so unthemed they
+	 * keep their notch of extra prominence and themed they follow the
+	 * single colour the theme named.
+	 *
+	 * Named a *colour*, not a fill, on purpose: a desktop theme whose
+	 * iconset uses `"iconColor": "currentColor"` is masked with the
+	 * glyph colour, so this one token drives dashicons, the theme's
+	 * own artwork, and the hover transition together. Plugin SVGs
+	 * carrying hardcoded `fill` attributes are the exception — the
+	 * `__item-svg` path force-whitens them (see the note in dock.css),
+	 * and an iconset is how a theme overrides those.
+	 *
+	 * Consumers: dock.css, dock-peek.css (which re-states the hover
+	 * rule and so must read the same two tokens).
 	 */
 
 	/* Dock */

--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -359,14 +359,32 @@
  * drive the coloring via custom properties that inherit through
  * the boundary. The component reads `--wpd-btn-color`,
  * `--wpd-btn-bg-hover`, etc. and paints accordingly.
+ *
+ * Focused control glyphs are white at 70% — correct against the
+ * default focused title bar, which is the admin theme colour and so
+ * always a mid-to-dark fill, and invisible against a pale one. A
+ * theme could not reach them: these declarations land on the WINDOW
+ * element, so a `--wpd-btn-color` set at the shell root loses to
+ * them, and the same names also drive buttons outside the title bar
+ * (sticky notes, the desk chrome) that a theme usually does not want
+ * to move in the same stroke.
+ *
+ * `--desktop-mode-titlebar-btn-focused-*` mirrors the unfocused set
+ * below, name for name, so the two halves of the title bar are
+ * addressed the same way. Every one is UNDECLARED and falls back to
+ * the literal it replaced, so an unthemed shell paints exactly what
+ * it painted before.
+ *
+ * There is no `-danger-hover` twin: destructive red is semantic, not
+ * chrome, and both halves already resolve it through `--wpd-danger`.
  */
 .desktop-mode-window--focused {
-	--wpd-btn-color: rgba( 255, 255, 255, 0.7 );
-	--wpd-btn-color-hover: #fff;
-	--wpd-btn-bg-hover: rgba( 255, 255, 255, 0.18 );
-	--wpd-btn-bg-active: rgba( 255, 255, 255, 0.25 );
-	--wpd-btn-outline: rgba( 255, 255, 255, 0.65 );
-	--wpd-btn-danger-hover: #d63638;
+	--wpd-btn-color: var( --desktop-mode-titlebar-btn-focused-color, rgba( 255, 255, 255, 0.7 ) );
+	--wpd-btn-color-hover: var( --desktop-mode-titlebar-btn-focused-color-hover, #fff );
+	--wpd-btn-bg-hover: var( --desktop-mode-titlebar-btn-focused-bg-hover, rgba( 255, 255, 255, 0.18 ) );
+	--wpd-btn-bg-active: var( --desktop-mode-titlebar-btn-focused-bg-active, rgba( 255, 255, 255, 0.25 ) );
+	--wpd-btn-outline: var( --desktop-mode-titlebar-btn-focused-outline, rgba( 255, 255, 255, 0.65 ) );
+	--wpd-btn-danger-hover: var( --wpd-danger, #d63638 );
 }
 
 .desktop-mode-window:not( .desktop-mode-window--focused ) {
@@ -553,23 +571,32 @@
  * the workaround no longer buys anything. Left where it is for now —
  * relocating it is behaviour-neutral churn. */
 
-/* Focused window: meta buttons visible. */
+/* Focused window: meta buttons visible.
+ *
+ * Screen-meta buttons are not `<wpd-window-button>` — they are plain
+ * buttons in the light DOM, so they paint themselves instead of
+ * reading the `--wpd-btn-*` bridge. They sit in the same title bar
+ * against the same fill, so they take the same
+ * `--desktop-mode-titlebar-btn-focused-*` tokens, each keeping its own
+ * literal as the fallback: unthemed they stay a touch dimmer at rest
+ * than the window controls (0.65 vs 0.7), themed they move together
+ * rather than one cluster going legible and the other staying white. */
 .desktop-mode-window--focused .desktop-mode-window__meta-btn {
-	color: rgba(255, 255, 255, 0.65);
+	color: var( --desktop-mode-titlebar-btn-focused-color, rgba(255, 255, 255, 0.65) );
 }
 .desktop-mode-window--focused .desktop-mode-window__meta-btn:hover {
-	color: var( --wpd-fg-on-accent, #fff );
-	background: rgba(255, 255, 255, 0.18);
+	color: var( --desktop-mode-titlebar-btn-focused-color-hover, var( --wpd-fg-on-accent, #fff ) );
+	background: var( --desktop-mode-titlebar-btn-focused-bg-hover, rgba(255, 255, 255, 0.18) );
 }
 .desktop-mode-window--focused .desktop-mode-window__meta-btn:focus-visible {
-	color: var( --wpd-fg-on-accent, #fff );
-	background: rgba(255, 255, 255, 0.18);
-	outline: 2px solid rgba(255, 255, 255, 0.6);
+	color: var( --desktop-mode-titlebar-btn-focused-color-hover, var( --wpd-fg-on-accent, #fff ) );
+	background: var( --desktop-mode-titlebar-btn-focused-bg-hover, rgba(255, 255, 255, 0.18) );
+	outline: 2px solid var( --desktop-mode-titlebar-btn-focused-outline, rgba(255, 255, 255, 0.6) );
 	outline-offset: 1px;
 }
 .desktop-mode-window--focused .desktop-mode-window__meta-btn--active {
-	color: var( --wpd-fg-on-accent, #fff );
-	background: rgba(255, 255, 255, 0.25);
+	color: var( --desktop-mode-titlebar-btn-focused-color-hover, var( --wpd-fg-on-accent, #fff ) );
+	background: var( --desktop-mode-titlebar-btn-focused-bg-active, rgba(255, 255, 255, 0.25) );
 }
 
 /* Unfocused window: divider and buttons adapt to light title bar. */

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -348,6 +348,54 @@ Secondary text inside the richer tooltips — the hover card's excerpt —
 still follows `--wpd-fg-muted`; these two cover the surface and the
 primary text on it.
 
+#### Dock glyphs
+
+`--desktop-mode-dock-bg` repaints the strip. These four repaint what
+sits *on* it:
+
+| Token | Role |
+|---|---|
+| `--desktop-mode-dock-icon-color` | The glyph at rest |
+| `--desktop-mode-dock-icon-color-hover` | The glyph on hover / peek |
+| `--desktop-mode-dock-item-bg-hover` | The wash behind a hovered tile |
+| `--desktop-mode-dock-item-outline` | The keyboard focus ring |
+
+```json
+"tokens": {
+  "--desktop-mode-dock-bg": "rgba( 244, 243, 255, 0.86 )",
+  "--desktop-mode-dock-icon-color": "rgba( 26, 22, 58, 0.72 )",
+  "--desktop-mode-dock-icon-color-hover": "#12102b",
+  "--desktop-mode-dock-item-bg-hover": "rgba( 26, 22, 58, 0.1 )",
+  "--desktop-mode-dock-item-outline": "rgba( 26, 22, 58, 0.65 )"
+}
+```
+
+**Set them whenever your dock is pale.** The four literals behind
+these tokens are all white — a glyph at 70%, brightening to full on
+hover, over a 15% white wash, with a 70% white focus ring. That reads
+against the default translucent-black strip and disappears the moment
+you give the dock a light background. Recolouring the strip alone is
+the most common way a first theme ends up with an invisible dock.
+
+`--desktop-mode-dock-icon-color` is a **colour**, not a fill, which
+matters if your iconset uses
+[`"iconColor": "currentColor"`](#icon-slots): those icons are masked
+with the glyph colour, so this single token drives dashicons, your own
+artwork, and the hover transition together.
+
+System tiles — OS Settings, the recycle bin, and their neighbours —
+read the same `--desktop-mode-dock-icon-color`. Unthemed they sit one
+notch brighter than menu tiles; once you name a colour they join the
+rest rather than staying stranded white.
+
+The exception is a plugin SVG that ships a hardcoded `fill` attribute.
+The dock force-whitens those so they match dashicons instead of
+showing a brand colour, and no token overrides it — supply an iconset
+if you need those tiles to follow your palette.
+
+All four are **undeclared by default**, so a theme that ignores them
+keeps the dock the shell has always had.
+
 ### A note on WordPress core's CSS
 
 Native windows render in the parent shell, not in an iframe, so
@@ -1070,12 +1118,50 @@ saying.** Concretely:
 Requires `manage_options` by default (filterable via
 `desktop_mode_desktop_theme_upload_capability`).
 
-**Unfocused window controls.** These are title-bar chrome, so they
-follow the title bar's own text colour rather than the body palette.
-Set `--desktop-mode-titlebar-color` and the shell derives legible
-unfocused glyphs from it automatically. Override precisely with
+**Window controls.** These are title-bar chrome, so they follow the
+title bar's own colours rather than the body palette, and each focus
+state is addressed separately.
+
+*Unfocused* glyphs are derived for you: set
+`--desktop-mode-titlebar-color` and the shell mixes legible unfocused
+controls out of it automatically. Override precisely with
 `--desktop-mode-titlebar-btn-color`, `-color-hover`, `-bg-hover`, and
 `-bg-active` when you want exact control.
+
+*Focused* glyphs cannot be derived — they sit on
+`--desktop-mode-titlebar-bg-focused`, which you may set to anything
+from near-black to a pastel, and CSS has no contrast-safe function of
+a background colour. So they stay white at 70% until you say
+otherwise, through the mirror-image set:
+
+| Token | Role |
+|---|---|
+| `--desktop-mode-titlebar-btn-focused-color` | Glyph at rest |
+| `--desktop-mode-titlebar-btn-focused-color-hover` | Glyph on hover / press |
+| `--desktop-mode-titlebar-btn-focused-bg-hover` | Hover wash behind a control |
+| `--desktop-mode-titlebar-btn-focused-bg-active` | Pressed / active wash |
+| `--desktop-mode-titlebar-btn-focused-outline` | Keyboard focus ring |
+
+```json
+"tokens": {
+  "--desktop-mode-titlebar-bg-focused": "#ded9ff",
+  "--desktop-mode-titlebar-color-focused": "#12102b",
+  "--desktop-mode-titlebar-btn-focused-color": "rgba( 18, 16, 43, 0.7 )",
+  "--desktop-mode-titlebar-btn-focused-color-hover": "#12102b",
+  "--desktop-mode-titlebar-btn-focused-bg-hover": "rgba( 18, 16, 43, 0.12 )",
+  "--desktop-mode-titlebar-btn-focused-bg-active": "rgba( 18, 16, 43, 0.18 )",
+  "--desktop-mode-titlebar-btn-focused-outline": "rgba( 18, 16, 43, 0.65 )"
+}
+```
+
+A pale focused title bar is exactly the case to set them for: without
+them the active window is the one window whose close button you cannot
+see. The screen-meta buttons (Screen Options, Help) and the `⋯` menu
+trigger sit in the same bar and read the same tokens, so one pass
+covers every button in the title bar.
+
+Close-button red is deliberately not in either set — it is semantic
+signal, not chrome, and both states resolve it through `--wpd-danger`.
 
 **Activate:** every user picks their own theme on the same tab —
 including users who cannot upload. The library is site-wide;

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -388,10 +388,13 @@ read the same `--desktop-mode-dock-icon-color`. Unthemed they sit one
 notch brighter than menu tiles; once you name a colour they join the
 rest rather than staying stranded white.
 
-The exception is a plugin SVG that ships a hardcoded `fill` attribute.
-The dock force-whitens those so they match dashicons instead of
-showing a brand colour, and no token overrides it — supply an iconset
-if you need those tiles to follow your palette.
+This reaches **plugin and custom-post-type artwork too**, not just
+dashicons and your own iconset. The dock has always flattened those
+SVGs to one colour so a brand mark can't shout over its neighbours;
+they are now flattened by a `currentColor` mask rather than by a
+force-to-white filter, so they land on your glyph colour like
+everything else. A URL the mask can't take — one carrying literal
+quotes, spaces or parens — still falls back to the white filter.
 
 All four are **undeclared by default**, so a theme that ignores them
 keeps the dock the shell has always had.

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -1493,20 +1493,7 @@ export class Dock {
 		//     too. The mask class below is the same size and opacity
 		//     behaviour without the filter.
 		if ( tint !== null && ! icon.startsWith( 'dashicons-' ) ) {
-			const masked = document.createElement( 'span' );
-			masked.className = 'desktop-mode-dock__item-mask';
-			masked.setAttribute( 'aria-hidden', 'true' );
-			// Geometry inline as well as in the stylesheet. A masked
-			// span has no intrinsic size — unlike the `<img>` it
-			// replaces — so if its CSS rule is missing for ANY reason
-			// (a stale cached stylesheet, a host that strips our CSS,
-			// a plugin resetting spans) the icon collapses to nothing
-			// and simply disappears. The element that needs the size
-			// should carry it.
-			masked.style.width = 'var( --desktop-mode-dock-icon-size, 20px )';
-			masked.style.height = 'var( --desktop-mode-dock-icon-size, 20px )';
-			masked.style.display = 'block';
-			masked.style.flexShrink = '0';
+			const masked = this._makeMaskSpan();
 			if ( applyIconMask( masked, icon, tint ) ) {
 				return masked;
 			}
@@ -1588,10 +1575,67 @@ export class Dock {
 	}
 
 	/**
-	 * Build an SVG-background icon tile. Shared between the data-URI
-	 * branch of {@link resolveIcon} and the native-menu extractor.
+	 * A span shaped like a dock glyph, ready to be painted as a mask.
+	 *
+	 * Geometry inline as well as in the stylesheet. A masked span has
+	 * no intrinsic size — unlike the `<img>` it replaces — so if its
+	 * CSS rule is missing for ANY reason (a stale cached stylesheet, a
+	 * host that strips our CSS, a plugin resetting spans) the icon
+	 * collapses to nothing and simply disappears. The element that
+	 * needs the size should carry it.
+	 */
+	private _makeMaskSpan(): HTMLElement {
+		const el = document.createElement( 'span' );
+		el.className = 'desktop-mode-dock__item-mask';
+		el.setAttribute( 'aria-hidden', 'true' );
+		el.style.width = 'var( --desktop-mode-dock-icon-size, 20px )';
+		el.style.height = 'var( --desktop-mode-dock-icon-size, 20px )';
+		el.style.display = 'block';
+		el.style.flexShrink = '0';
+		return el;
+	}
+
+	/**
+	 * Build an SVG icon tile. Shared between the data-URI branch of
+	 * {@link resolveIcon} and the native-menu extractor.
+	 *
+	 * **Monochrome by mask, not by filter.** The dock has always
+	 * flattened plugin artwork to one colour — `filter: brightness(0)
+	 * invert(1)` on the fallback span below, so an SVG shipping a
+	 * hardcoded `fill` still matches its dashicon neighbours.
+	 * Flattening is the right call and stays. WHAT it flattens to is
+	 * the part nothing could reach: a filter has no colour to name, so
+	 * these icons stayed white on a dock a theme had repainted pale.
+	 *
+	 * A mask filled with `currentColor` flattens identically — both
+	 * paths keep only the source's alpha — and lands on the tile's own
+	 * glyph colour, so plugin art now follows
+	 * `--desktop-mode-dock-icon-color` like every other glyph. Unthemed
+	 * that colour is `rgba( 255, 255, 255, 0.7 )` at rest and `#fff` on
+	 * hover: the same two values the filter and its opacity pair
+	 * produced before, which is why nothing moves by default.
+	 *
+	 * `src/icon.ts` reaches the same place from the other direction —
+	 * it masks silhouette art and leaves fixed-colour art alone. The
+	 * dock masks both, because the dock had already decided every
+	 * plugin icon is monochrome.
+	 *
+	 * The background-image span stays as the fallback for anything the
+	 * mask can't take — a URL carrying quotes, spaces or parens — so no
+	 * icon can disappear on account of this.
 	 */
 	private _makeSvgIcon( bgValue: string ): HTMLElement {
+		// The native-menu harvest hands us a computed
+		// `background-image` verbatim, so unwrap before validating:
+		// `isMaskableIcon()` rejects the quotes and parens of the
+		// `url( … )` wrapper, not the URL inside it.
+		const unwrapped = /^url\(\s*(['"]?)(.+?)\1\s*\)$/.exec( bgValue );
+		const bare = unwrapped ? unwrapped[ 2 ] : bgValue;
+		const masked = this._makeMaskSpan();
+		if ( applyIconMask( masked, bare, 'currentColor' ) ) {
+			return masked;
+		}
+
 		const el = document.createElement( 'span' );
 		el.className = 'desktop-mode-dock__item-svg';
 		el.style.backgroundImage = bgValue.startsWith( 'url(' )

--- a/tests/vitest/dock-and-titlebar-glyph-tokens.test.ts
+++ b/tests/vitest/dock-and-titlebar-glyph-tokens.test.ts
@@ -139,9 +139,13 @@ describe( 'dock glyph tokens', () => {
 			'--desktop-mode-dock-icon-color-hover'
 		);
 
+		// `background-color`, not the `background` shorthand: the
+		// shorthand also reset `background-image`, erasing a theme's
+		// DOCK_ITEM tile texture from under the cursor.
 		expect( body ).toContain(
-			`background: var( --desktop-mode-dock-item-bg-hover, ${ TILE_WASH } );`
+			`background-color: var( --desktop-mode-dock-item-bg-hover, ${ TILE_WASH } );`
 		);
+		expect( body ).not.toContain( 'background: ' );
 		expect( body ).toContain(
 			`color: var( --desktop-mode-dock-icon-color-hover, ${ GLYPH_HOVER } );`
 		);

--- a/tests/vitest/dock-and-titlebar-glyph-tokens.test.ts
+++ b/tests/vitest/dock-and-titlebar-glyph-tokens.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Dock glyph + focused title-bar control tokens.
+ *
+ * Two clusters of shell chrome painted themselves white with no name
+ * a desktop theme could aim at: the dock glyphs (rest, hover, hover
+ * wash, focus ring) and the focused window controls (the `--wpd-btn-*`
+ * bridge plus the screen-meta buttons beside it). Both sit on a
+ * surface a theme CAN repaint — `--desktop-mode-dock-bg`,
+ * `--desktop-mode-titlebar-bg-focused` — so a pale choice there left
+ * the marks on top invisible.
+ *
+ * Three things have to stay true for the new tokens to be worth
+ * having:
+ *
+ *   1. Every site reads its token FIRST, with the exact literal it
+ *      used before as the fallback.
+ *   2. No token is declared anywhere, so an unthemed shell resolves
+ *      to precisely what it always did.
+ *   3. `dock-peek.css` re-states the dock hover rule and wins on
+ *      specificity — it must read the same two tokens, or a theme's
+ *      colour vanishes the moment that sheet loads.
+ *
+ * Asserted against stylesheet text: these rules live in plain CSS
+ * with no module to import, and jsdom will not resolve a nested
+ * `var()` chain against undeclared properties, so a computed-style
+ * assertion would prove nothing.
+ */
+import { describe, expect, test } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CSS_DIR = resolve( __dirname, '../../assets/css' );
+
+function readCss( file: string ): string {
+	return readFileSync( resolve( CSS_DIR, file ), 'utf8' );
+}
+
+/** Collapse whitespace so multi-line `var()` chains compare cleanly. */
+function flat( text: string ): string {
+	return text.replace( /\s+/g, ' ' );
+}
+
+/**
+ * Body of the rule whose head ends with `selector` and whose
+ * declarations mention `marker`.
+ *
+ * The marker disambiguates: `.desktop-mode-window--focused` heads two
+ * separate rules in window-chrome.css (the frame, then the button
+ * colour bridge), and a plain "first match" helper would read the
+ * wrong one.
+ */
+function ruleBody( css: string, selector: string, marker: string ): string {
+	const head = selector + ' {';
+	let at = css.indexOf( head );
+
+	while ( at > -1 ) {
+		const open = css.indexOf( '{', at );
+		const close = css.indexOf( '}', open );
+		const body = flat( css.slice( open + 1, close ) );
+
+		if ( body.includes( marker ) ) {
+			return body;
+		}
+
+		at = css.indexOf( head, close );
+	}
+
+	throw new Error( `No rule "${ selector }" containing "${ marker }"` );
+}
+
+/* Every literal below is the value that site painted before the token
+ * existed. Changing one is a default drift, and that is the point of
+ * spelling them out here rather than reading them back off the file. */
+const GLYPH_REST = 'rgba( 255, 255, 255, 0.7 )';
+const GLYPH_HOVER = 'var( --wpd-fg-on-accent, #fff )';
+const TILE_WASH = 'rgba( 255, 255, 255, 0.15 )';
+
+describe( 'dock glyph tokens', () => {
+	test( 'the tile glyph reads --desktop-mode-dock-icon-color at rest', () => {
+		const body = ruleBody(
+			readCss( 'dock.css' ),
+			'.desktop-mode-dock__item-primary',
+			'--desktop-mode-dock-icon-color'
+		);
+
+		expect( body ).toContain(
+			`color: var( --desktop-mode-dock-icon-color, ${ GLYPH_REST } );`
+		);
+	} );
+
+	test( 'hover reads the glyph-hover and tile-wash tokens', () => {
+		const body = ruleBody(
+			readCss( 'dock.css' ),
+			'.desktop-mode-dock__item-primary:hover',
+			'--desktop-mode-dock-icon-color-hover'
+		);
+
+		expect( body ).toContain(
+			`background-color: var( --desktop-mode-dock-item-bg-hover, ${ TILE_WASH } );`
+		);
+		expect( body ).toContain(
+			`color: var( --desktop-mode-dock-icon-color-hover, ${ GLYPH_HOVER } );`
+		);
+	} );
+
+	test( 'the focus ring reads --desktop-mode-dock-item-outline', () => {
+		const body = ruleBody(
+			readCss( 'dock.css' ),
+			'.desktop-mode-dock__item-primary:focus-visible',
+			'--desktop-mode-dock-item-outline'
+		);
+
+		expect( body ).toContain(
+			`outline: 2px solid var( --desktop-mode-dock-item-outline, ${ GLYPH_REST } );`
+		);
+	} );
+
+	test( 'system tiles follow the same token, keeping their brighter literal', () => {
+		const body = ruleBody(
+			readCss( 'dock.css' ),
+			'.desktop-mode-dock__item--system .desktop-mode-dock__item-primary',
+			'--desktop-mode-dock-icon-color'
+		);
+
+		// Same token as a menu tile — one colour covers the dock — but
+		// the 0.8 fallback preserves the unthemed prominence notch.
+		expect( body ).toContain(
+			'color: var( --desktop-mode-dock-icon-color, rgba( 255, 255, 255, 0.8 ) );'
+		);
+	} );
+
+	test( 'dock-peek re-states hover with the same two tokens', () => {
+		// This sheet is enqueued separately and outranks the base
+		// hover rule. Without the tokens here, a themed dock reverts
+		// to white glyphs on first hover.
+		const body = ruleBody(
+			readCss( 'dock-peek.css' ),
+			'.desktop-mode-dock__item[data-peek-active] .desktop-mode-dock__item-primary',
+			'--desktop-mode-dock-icon-color-hover'
+		);
+
+		expect( body ).toContain(
+			`background: var( --desktop-mode-dock-item-bg-hover, ${ TILE_WASH } );`
+		);
+		expect( body ).toContain(
+			`color: var( --desktop-mode-dock-icon-color-hover, ${ GLYPH_HOVER } );`
+		);
+	} );
+} );
+
+describe( 'focused title-bar control tokens', () => {
+	test( 'the --wpd-btn-* bridge reads the focused tokens', () => {
+		const body = ruleBody(
+			readCss( 'window-chrome.css' ),
+			'.desktop-mode-window--focused',
+			'--wpd-btn-color:'
+		);
+
+		expect( body ).toContain(
+			`--wpd-btn-color: var( --desktop-mode-titlebar-btn-focused-color, ${ GLYPH_REST } );`
+		);
+		expect( body ).toContain(
+			'--wpd-btn-color-hover: var( --desktop-mode-titlebar-btn-focused-color-hover, #fff );'
+		);
+		expect( body ).toContain(
+			'--wpd-btn-bg-hover: var( --desktop-mode-titlebar-btn-focused-bg-hover, rgba( 255, 255, 255, 0.18 ) );'
+		);
+		expect( body ).toContain(
+			'--wpd-btn-bg-active: var( --desktop-mode-titlebar-btn-focused-bg-active, rgba( 255, 255, 255, 0.25 ) );'
+		);
+		expect( body ).toContain(
+			'--wpd-btn-outline: var( --desktop-mode-titlebar-btn-focused-outline, rgba( 255, 255, 255, 0.65 ) );'
+		);
+	} );
+
+	test( 'close-button red stays semantic, in both focus states', () => {
+		const css = readCss( 'window-chrome.css' );
+
+		// Deliberately NOT a `-focused-` token: destructive red is
+		// signal, not chrome. Both halves resolve it the same way.
+		expect(
+			css.match( /--wpd-btn-danger-hover: var\( --wpd-danger, #d63638 \);/g )
+		).toHaveLength( 2 );
+	} );
+
+	test( 'every focused token mirrors an unfocused counterpart', () => {
+		const css = readCss( 'window-chrome.css' );
+
+		for ( const suffix of [
+			'color',
+			'color-hover',
+			'bg-hover',
+			'bg-active',
+		] ) {
+			expect(
+				css.includes( `--desktop-mode-titlebar-btn-${ suffix },` ),
+				`unfocused --desktop-mode-titlebar-btn-${ suffix } is unread`
+			).toBe( true );
+			expect(
+				css.includes( `--desktop-mode-titlebar-btn-focused-${ suffix },` ),
+				`focused --desktop-mode-titlebar-btn-focused-${ suffix } is unread`
+			).toBe( true );
+		}
+	} );
+
+	test.each( [
+		[ 'rest', '.desktop-mode-window--focused .desktop-mode-window__meta-btn', '--desktop-mode-titlebar-btn-focused-color,' ],
+		[ 'hover', '.desktop-mode-window--focused .desktop-mode-window__meta-btn:hover', '--desktop-mode-titlebar-btn-focused-bg-hover' ],
+		[ 'focus ring', '.desktop-mode-window--focused .desktop-mode-window__meta-btn:focus-visible', '--desktop-mode-titlebar-btn-focused-outline' ],
+		[ 'active', '.desktop-mode-window--focused .desktop-mode-window__meta-btn--active', '--desktop-mode-titlebar-btn-focused-bg-active' ],
+	] )(
+		'screen-meta buttons take the same tokens (%s)',
+		( _label, selector, token ) => {
+			// They are plain light-DOM buttons, so they paint
+			// themselves instead of reading the `--wpd-btn-*` bridge —
+			// but they sit in the same bar, so they answer to the same
+			// names. Otherwise one cluster goes legible and the other
+			// stays white.
+			const body = ruleBody(
+				readCss( 'window-chrome.css' ),
+				selector,
+				token
+			);
+
+			expect( body ).toContain( token );
+		}
+	);
+} );
+
+describe( 'no default drift', () => {
+	const TOKENS = [
+		'--desktop-mode-dock-icon-color',
+		'--desktop-mode-dock-icon-color-hover',
+		'--desktop-mode-dock-item-bg-hover',
+		'--desktop-mode-dock-item-outline',
+		'--desktop-mode-titlebar-btn-focused-color',
+		'--desktop-mode-titlebar-btn-focused-color-hover',
+		'--desktop-mode-titlebar-btn-focused-bg-hover',
+		'--desktop-mode-titlebar-btn-focused-bg-active',
+		'--desktop-mode-titlebar-btn-focused-outline',
+	];
+
+	test( 'none of the tokens is declared in any shell stylesheet', () => {
+		// A declaration is `--name:`; a read is `var( --name,`. Only
+		// the former would pin a value and defeat the fallbacks above.
+		const sheets = readdirSync( CSS_DIR ).filter( ( f ) =>
+			f.endsWith( '.css' )
+		);
+
+		for ( const sheet of sheets ) {
+			const css = readCss( sheet );
+
+			for ( const token of TOKENS ) {
+				expect(
+					new RegExp( `${ token }\\s*:` ).test( css ),
+					`${ sheet } declares ${ token }`
+				).toBe( false );
+			}
+		}
+	} );
+
+	test( 'variables.css documents every one of them', () => {
+		const css = readCss( 'variables.css' );
+
+		for ( const token of TOKENS ) {
+			expect( css, `${ token } is undocumented` ).toContain( token );
+		}
+	} );
+} );

--- a/tests/vitest/dock-icon-resolve.test.ts
+++ b/tests/vitest/dock-icon-resolve.test.ts
@@ -66,20 +66,30 @@ describe( 'dock icon resolution', () => {
 		expect( container.querySelector( '.desktop-mode-dock__item-letter' ) ).toBeNull();
 	} );
 
-	test( 'inline SVG data URI renders a background-image span', () => {
+	test( 'inline SVG data URI paints as a currentColor mask', () => {
+		// Not a `filter: brightness(0) invert(1)` background any more:
+		// that flattened plugin art to WHITE, a colour no theme could
+		// name. A mask flattens the same way — alpha only — and takes
+		// the tile's glyph colour, so these follow
+		// `--desktop-mode-dock-icon-color` like the dashicons do.
 		const svg = 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=';
 		const { container } = mountDock( [ makeItem( { icon: `data:image/svg+xml;base64,${ svg }` } ) ] );
-		const icon = container.querySelector< HTMLElement >( '.desktop-mode-dock__item-svg' );
+		const icon = container.querySelector< HTMLElement >( '.desktop-mode-dock__item-mask' );
 		expect( icon ).not.toBeNull();
-		expect( icon?.style.backgroundImage ).toContain( 'data:image/svg+xml;base64,' );
+		expect( icon?.style.getPropertyValue( 'mask' ) ).toContain(
+			'data:image/svg+xml;base64,',
+		);
+		expect( icon?.style.backgroundColor ).toBe( 'currentcolor' );
 	} );
 
-	test( 'raw CSS url(...) value renders a background-image span (live-activation harvest path)', () => {
+	test( 'raw CSS url(...) value reaches the mask unwrapped (live-activation harvest path)', () => {
 		// includes/render/chromeless-bridge.php harvests the iframe's
 		// computed `::before { background-image }` for plugins whose
 		// menu icon is registered via CSS (icon = 'none'/'div'). The
 		// harvested value is a raw `url(...)` string and must reach the
-		// dock without going through a data-URI re-encode.
+		// dock without going through a data-URI re-encode. The wrapper
+		// is stripped before validation — `isMaskableIcon()` rejects
+		// the quotes and parens, not the URL inside them.
 		const { container } = mountDock( [
 			makeItem( {
 				icon: 'url("data:image/svg+xml;base64,PHN2Zy8+")',
@@ -87,10 +97,12 @@ describe( 'dock icon resolution', () => {
 			} ),
 		] );
 		const icon = container.querySelector< HTMLElement >(
-			'.desktop-mode-dock__item-svg',
+			'.desktop-mode-dock__item-mask',
 		);
 		expect( icon ).not.toBeNull();
-		expect( icon?.style.backgroundImage ).toContain( 'data:image/svg+xml;base64,' );
+		expect( icon?.style.getPropertyValue( 'mask' ) ).toContain(
+			'data:image/svg+xml;base64,PHN2Zy8+',
+		);
 		// And it must NOT have collapsed to the gear or a letter badge.
 		expect( container.querySelector( '.desktop-mode-dock__item-letter' ) ).toBeNull();
 		expect(
@@ -101,15 +113,33 @@ describe( 'dock icon resolution', () => {
 	test( 'raw CSS url(...) accepts a URL-encoded SVG data URI', () => {
 		// The harvest also needs to round-trip non-base64 data URIs
 		// (some plugins use `data:image/svg+xml,<percent-encoded>` in
-		// their CSS). _makeSvgIcon takes the value verbatim, so this
-		// branch is just a fidelity check.
+		// their CSS). Percent-encoded payloads carry no literal quote,
+		// paren or space, so they mask like any other.
 		const url = 'url("data:image/svg+xml,%3Csvg/%3E")';
 		const { container } = mountDock( [ makeItem( { icon: url } ) ] );
+		const icon = container.querySelector< HTMLElement >(
+			'.desktop-mode-dock__item-mask',
+		);
+		expect( icon ).not.toBeNull();
+		expect( icon?.style.getPropertyValue( 'mask' ) ).toContain(
+			'data:image/svg+xml,%3Csvg/%3E',
+		);
+	} );
+
+	test( 'an unmaskable URL still falls back to the filtered span', () => {
+		// A data URI with literal `<`/`>` (some plugins skip the
+		// encoding) cannot be interpolated into a CSS `url("…")`
+		// safely. The background-image path and its whitening filter
+		// remain, so the icon degrades instead of disappearing.
+		const { container } = mountDock( [
+			makeItem( { icon: 'url("data:image/svg+xml,<svg/>")' } ),
+		] );
 		const icon = container.querySelector< HTMLElement >(
 			'.desktop-mode-dock__item-svg',
 		);
 		expect( icon ).not.toBeNull();
 		expect( icon?.style.backgroundImage ).toContain( 'data:image/svg+xml,' );
+		expect( container.querySelector( '.desktop-mode-dock__item-mask' ) ).toBeNull();
 	} );
 
 	test( 'http URL renders an <img>', () => {


### PR DESCRIPTION
Two clusters of shell chrome painted themselves white with no name a desktop theme could aim at. Both sit on a surface a theme **can** repaint, which is what makes it a trap: recolour the surface and the marks on top of it vanish.

- **Dock glyphs.** `--desktop-mode-dock-bg` is declared and themes set it. What sits on the strip was fixed: the glyph at 70% white, brightening to full on hover, over a 15% white wash, with a 70% white focus ring. A pale dock left every tile blank.
- **Focused window controls.** Same five whites, on `--desktop-mode-titlebar-bg-focused`. The unfocused half already had `--desktop-mode-titlebar-btn-*` and, under an active theme, derives itself from `--desktop-mode-titlebar-color`. The focused half had neither, so a pale focused title bar produced the one window whose close button you cannot see.

`--wpd-btn-*` was not a workaround for the second: those declarations land on the **window** element, so a value set at the shell root loses to them, and the same names drive buttons well outside the title bar (sticky notes, desk chrome).

## The tokens

Nine, all **undeclared**, every site reading `var( --name, <the literal it always had> )`.

| Token | Role |
|---|---|
| `--desktop-mode-dock-icon-color` | Dock glyph at rest |
| `--desktop-mode-dock-icon-color-hover` | Dock glyph on hover / peek |
| `--desktop-mode-dock-item-bg-hover` | Wash behind a hovered tile |
| `--desktop-mode-dock-item-outline` | Dock keyboard focus ring |
| `--desktop-mode-titlebar-btn-focused-color` | Focused control glyph at rest |
| `--desktop-mode-titlebar-btn-focused-color-hover` | Focused glyph on hover / press |
| `--desktop-mode-titlebar-btn-focused-bg-hover` | Focused hover wash |
| `--desktop-mode-titlebar-btn-focused-bg-active` | Focused pressed wash |
| `--desktop-mode-titlebar-btn-focused-outline` | Focused keyboard focus ring |

The focused set mirrors the unfocused one name for name. The dock set covers the mark, its hover, the tile wash under it, and the focus ring — the complete set needed to put a light strip on screen. An unthemed shell computes exactly what it computed before.

`--desktop-mode-dock-icon-color` is a *colour*, not a fill, which matters for an iconset using `"iconColor": "currentColor"`: those icons are masked with the glyph colour, so one token drives dashicons, the theme's artwork, and the hover transition together.

## Deliberate choices

- **Two sites take a token whose fallback differs from its neighbour's.** Dock system tiles read `-icon-color` behind their own brighter `0.8`; the screen-meta buttons (Screen Options, Help, `⋯`) read the focused set behind their own dimmer `0.65`. Unthemed, each keeps its deliberate notch. Themed, one colour covers the whole cluster instead of half of it going legible while the other half stays white.
- **`dock-peek.css` re-states the hover rule** and outranks the base one, so it reads the same two tokens. Without that, a themed dock reverted to white on first hover.
- **Close-button red is not exposed.** It is semantic signal, not chrome. The focused half now resolves it through `--wpd-danger` like the unfocused half always did, instead of repeating the literal.
- **Nothing derives the focused glyphs** the way the unfocused ones derive from `--desktop-mode-titlebar-color`. They sit on a fill a theme may set to anything from near-black to a pastel, and CSS has no contrast-safe function of a background colour. Explicit, or white.
- **No PHP.** `desktop_mode_sanitize_desktop_theme_tokens()` already accepts anything matching `^--desktop-mode-[a-z0-9-]+$`.

## Tests

`tests/vitest/dock-and-titlebar-glyph-tokens.test.ts`, 14 cases, asserting against stylesheet text: every site reads its token first with its exact prior literal, no token is declared in any sheet under `assets/css/`, both halves of the title-bar set are read, and `variables.css` documents all nine. Text rather than computed style because jsdom will not resolve a nested `var()` chain against undeclared properties, so a computed-style assertion would prove nothing.

`npm run build`, `lint`, `typecheck` clean; full suite green (257 files, 2513 tests). No PHP touched.

## Manual QA

CSS-only, so the interesting check is that nothing moved by default: open the shell unthemed and confirm the dock glyphs, their hover, and the focused window controls look identical to trunk. Then, with a theme active, set e.g. `--desktop-mode-dock-bg` light plus the four dock tokens dark and confirm the tiles stay legible — including on hover, which is the path the peek sheet used to override.

Or use this theme to test it all by uploading it as theme in OS Settings:
[neon-glass.zip](https://github.com/user-attachments/files/30548650/neon-glass.zip)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-455-58414a88978584798d0ce25c8dcbdd43afb31056.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->