### PR TITLE
fix: decode html entities in recycle bin

### DIFF
--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -17,6 +17,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { decodeHTML } from '../utils';
 // Side-effect imports — register the `<wpd-*>` components this
 // bundle constructs that the main shell does not ship.
 import '../ui/components/wpd-table/wpd-table';
@@ -282,16 +283,18 @@ function buildColumns(): WpdTableColumn< RecycleBinItem >[] {
 				const title = document.createElement( 'span' );
 				title.style.cssText =
 					'font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:320px;';
-				title.textContent = row.title;
-				title.title = row.title;
+				const decodedTitle = decodeHTML( row.title );
+				title.textContent = decodedTitle;
+				title.title = decodedTitle;
 				titleRow.appendChild( title );
 				stack.appendChild( titleRow );
 				if ( row.subtitle ) {
 					const sub = document.createElement( 'span' );
 					sub.style.cssText =
 						'font-size:12px;color:var( --wpd-fg-muted, #50575e );white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:320px;';
-					sub.textContent = row.subtitle;
-					sub.title = row.subtitle;
+					const decodedSubtitle = decodeHTML( row.subtitle );
+					sub.textContent = decodedSubtitle;
+					sub.title = decodedSubtitle;
 					stack.appendChild( sub );
 				}
 				wrap.appendChild( stack );


### PR DESCRIPTION
Closes #454

### Description
This PR fixes a visual bug where HTML entities in deleted post titles and subtitles (such as ampersands `&amp;` or apostrophes `&#8217;`) were rendered raw inside the row items of the native Recycle Bin window.

### Root Causes & Fixes
**Missing Entity Decoding in Recycle Bin Title and Subtitle Render:**
* **Issue**: The REST API returns deleted items with HTML-encoded entities in the `title` and `subtitle` payloads. The Recycle Bin window set these directly using `.textContent`, which caused them to render literally on the screen (e.g. `Q&amp;A: User&#8217;s Guide`).
* **Fix**: Imported the shared `decodeHTML` utility from `src/utils.ts` and updated the column builder in `src/recycle-bin/index.ts` to decode both `row.title` and `row.subtitle` before setting them as `.textContent` and `.title` attributes on the list view elements.

### Verification
* **Build**: `npm run build` completed successfully.
* **Typecheck**: `npm run typecheck` completed successfully with zero errors.
* **Linter**: `npm run lint` completed successfully with zero errors.
* **Unit Tests**: `npm run test:js` completed successfully with all 2529/2529 Vitest tests passing.
* **PHP Tests**: `npm run test:php` completed successfully with all 1017/1017 PHPUnit tests passing.

### Screenshots

**Before Fix** 
<img width="874" height="556" alt="Screenshot 2026-07-30 at 3 43 34 PM" src="https://github.com/user-attachments/assets/7b8081f1-e95b-41b3-8160-31f49473db6e" />


**After Fix**
<img width="873" height="554" alt="Screenshot 2026-07-30 at 8 17 18 PM" src="https://github.com/user-attachments/assets/10ec08e4-3f48-486f-aa92-f763df1787fa" />

