### PR TITLE
fix(ai): enforce strict structured-output schemas at the provider boundary

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1685,6 +1685,8 @@ Mutate the JSON Schema handed to the provider for structured-output comment anal
 apply_filters( 'desktop_mode_ai_schema_comment', array $schema );
 ```
 
+You don't need to write the provider's strict-mode boilerplate: after the filter runs, every object subschema in the tree is stamped with `additionalProperties: false` (the key strict structured output requires and JSON Schema treats as optional). Add a nested object and it will pass validation. Strict mode does still reject numeric/string constraints (`minimum`, `maxLength`, …) and recursive `$ref`s — those are not repaired for you.
+
 ### `desktop_mode_ai_comment_prompt` — Stable
 
 Customise the user-side prompt handed to the model for comment analysis. The filter receives the default prompt plus the comment object.
@@ -1745,6 +1747,8 @@ The JSON Schema the model must answer in. Changing the shape changes the REST re
 ```php
 apply_filters( 'desktop_mode_drafts_ai_schema', array $schema, WP_Post $post );
 ```
+
+As with [`desktop_mode_ai_schema_comment`](#desktop_mode_ai_schema_comment--experimental), object subschemas are stamped with `additionalProperties: false` after the filter runs, so a nested object you add doesn't have to carry the provider's strict-mode boilerplate itself.
 
 ### `desktop_mode_drafts_ai_content_limit` — Experimental
 

--- a/includes/agents/runner.php
+++ b/includes/agents/runner.php
@@ -590,12 +590,17 @@ function desktop_mode_agent_runner_loop( $agent_user_id, $instructions, $message
  * a typed reply. Each action's `reply` is the literal message sent
  * back as the user's next turn when its button is pressed.
  *
+ * Every object node declares `additionalProperties: false` because strict
+ * structured output requires it; {@see desktop_mode_ai_normalize_response_schema()}
+ * enforces the same thing at the provider boundary.
+ *
  * @return array
  */
 function desktop_mode_agent_answer_schema() {
 	return array(
-		'type'       => 'object',
-		'properties' => array(
+		'type'                 => 'object',
+		'additionalProperties' => false,
+		'properties'           => array(
 			'text'            => array(
 				'type'        => 'string',
 				'description' => 'The answer, in markdown.',
@@ -604,8 +609,9 @@ function desktop_mode_agent_answer_schema() {
 				'type'        => 'array',
 				'description' => 'Buttons to render when user confirmation or a choice is required. Empty when no input is needed.',
 				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
 						'id'    => array( 'type' => 'string' ),
 						'label' => array(
 							'type'        => 'string',
@@ -620,11 +626,11 @@ function desktop_mode_agent_answer_schema() {
 							'description' => 'The literal message sent back as the user\'s answer when this button is pressed.',
 						),
 					),
-					'required'   => array( 'id', 'label', 'reply' ),
+					'required'             => array( 'id', 'label', 'reply' ),
 				),
 			),
 		),
-		'required'   => array( 'text' ),
+		'required'             => array( 'text' ),
 	);
 }
 

--- a/includes/ai-copilot/bootstrap.php
+++ b/includes/ai-copilot/bootstrap.php
@@ -11,6 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/settings.php';
+require_once __DIR__ . '/schema.php';
 require_once __DIR__ . '/client.php';
 require_once __DIR__ . '/analysis.php';
 require_once __DIR__ . '/jobs.php';

--- a/includes/ai-copilot/client.php
+++ b/includes/ai-copilot/client.php
@@ -155,7 +155,10 @@ function desktop_mode_ai_client_generate( $user_id, array $messages, array $tool
 	}
 
 	if ( is_array( $answer_schema ) ) {
-		$builder = $builder->as_json_response( $answer_schema );
+		// Strict structured output: providers reject an object subschema that
+		// doesn't set `additionalProperties: false`, and one such node 400s the
+		// whole turn. Normalize here so no schema author has to know that.
+		$builder = $builder->as_json_response( desktop_mode_ai_normalize_response_schema( $answer_schema ) );
 	}
 
 	$result = $builder->generate_result();

--- a/includes/ai-copilot/jobs.php
+++ b/includes/ai-copilot/jobs.php
@@ -106,7 +106,7 @@ function desktop_mode_ai_analyze_comment_now( WP_Comment $comment, $user_id ) {
 	}
 	// Provider + model are chosen by the Core AI Client; Desktop Mode pins neither.
 
-	$json = $builder->as_json_response( $schema )->generate_text();
+	$json = $builder->as_json_response( desktop_mode_ai_normalize_response_schema( $schema ) )->generate_text();
 	if ( is_wp_error( $json ) ) {
 		return $json;
 	}

--- a/includes/ai-copilot/schema.php
+++ b/includes/ai-copilot/schema.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Desktop Mode — AI Copilot: structured-output schema normalization.
+ *
+ * Every schema handed to `as_json_response()` becomes the provider's
+ * structured-output contract (`output_format.schema` on Anthropic, the
+ * equivalent response-schema field elsewhere). Providers validate that
+ * contract in STRICT mode, which is narrower than JSON Schema: an object
+ * subschema that does not say `additionalProperties: false` is rejected
+ * outright —
+ *
+ *     Bad Request (400) - output_format.schema: For 'object' type,
+ *     'additionalProperties' must be explicitly set to false
+ *
+ * — and the whole request fails, not just the offending branch. That is a
+ * trap for the schemas we ship (one missing key anywhere in the tree kills
+ * the feature) and worse for the filtered ones: `desktop_mode_ai_schema_comment`,
+ * `desktop_mode_drafts_ai_schema`, and any plugin that adds a nested object
+ * would otherwise have to know the provider's strict-mode rules to add a
+ * property safely.
+ *
+ * So normalization runs at the choke point instead of relying on every
+ * author getting it right: `desktop_mode_ai_normalize_response_schema()`
+ * walks the tree and stamps `additionalProperties: false` on every object
+ * subschema, at every depth, after the filters have run.
+ *
+ * Tool INPUT schemas are a different contract with different rules — see
+ * `desktop_mode_ai_normalize_tool_schema()` in search.php.
+ *
+ * @package WPDesktopMode
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Forces a structured-output schema into the strict shape providers require.
+ *
+ * The only rewrite is `additionalProperties: false` on object subschemas —
+ * the key providers demand and JSON Schema treats as optional. A node counts
+ * as an object when its `type` is (or includes) `"object"`, or when it
+ * declares `properties` / `patternProperties` without a `type` at all. An
+ * existing `additionalProperties` is overwritten: `true` and schema-shaped
+ * values are exactly what strict mode rejects, so preserving them would only
+ * preserve the 400.
+ *
+ * The walk is structure-aware, covering every position a subschema can
+ * occupy: property values (maps keyed by PROPERTY NAME, so a property
+ * literally called `items` is never mistaken for the keyword), `items` in
+ * both single-schema and tuple form, `prefixItems`, `not`, the `oneOf` /
+ * `allOf` / `anyOf` branches, and `$defs` / `definitions` pools.
+ *
+ * @param array $schema A structured-output (sub)schema.
+ * @return array The schema with `additionalProperties: false` on every object node.
+ */
+function desktop_mode_ai_normalize_response_schema( array $schema ) {
+	if ( desktop_mode_ai_schema_is_object_node( $schema ) ) {
+		$schema['additionalProperties'] = false;
+	}
+
+	foreach ( array( 'properties', 'patternProperties', '$defs', 'definitions' ) as $map_key ) {
+		if ( isset( $schema[ $map_key ] ) && is_array( $schema[ $map_key ] ) ) {
+			foreach ( $schema[ $map_key ] as $name => $sub ) {
+				if ( is_array( $sub ) ) {
+					$schema[ $map_key ][ $name ] = desktop_mode_ai_normalize_response_schema( $sub );
+				}
+			}
+		}
+	}
+
+	if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+		$items   = $schema['items'];
+		$is_list = array_keys( $items ) === range( 0, count( $items ) - 1 );
+		if ( $is_list && array() !== $items ) {
+			// Tuple form — a list of schemas.
+			foreach ( $items as $i => $sub ) {
+				if ( is_array( $sub ) ) {
+					$items[ $i ] = desktop_mode_ai_normalize_response_schema( $sub );
+				}
+			}
+			$schema['items'] = $items;
+		} else {
+			$schema['items'] = desktop_mode_ai_normalize_response_schema( $items );
+		}
+	}
+
+	foreach ( array( 'oneOf', 'allOf', 'anyOf', 'prefixItems' ) as $list_key ) {
+		if ( isset( $schema[ $list_key ] ) && is_array( $schema[ $list_key ] ) ) {
+			foreach ( $schema[ $list_key ] as $i => $sub ) {
+				if ( is_array( $sub ) ) {
+					$schema[ $list_key ][ $i ] = desktop_mode_ai_normalize_response_schema( $sub );
+				}
+			}
+		}
+	}
+
+	if ( isset( $schema['not'] ) && is_array( $schema['not'] ) ) {
+		$schema['not'] = desktop_mode_ai_normalize_response_schema( $schema['not'] );
+	}
+
+	return $schema;
+}
+
+/**
+ * Whether a (sub)schema describes an object, and so needs the strict key.
+ *
+ * Covers the three ways a schema says "object": the literal type, a type
+ * union that includes it (`array( 'object', 'null' )` — how a nullable
+ * branch is usually written), and the untyped-but-shaped form that declares
+ * `properties` with no `type` at all.
+ *
+ * @param array $schema A structured-output (sub)schema.
+ * @return bool
+ */
+function desktop_mode_ai_schema_is_object_node( array $schema ) {
+	if ( isset( $schema['type'] ) ) {
+		$types = is_array( $schema['type'] ) ? $schema['type'] : array( $schema['type'] );
+		return in_array( 'object', $types, true );
+	}
+
+	return isset( $schema['properties'] ) || isset( $schema['patternProperties'] );
+}

--- a/includes/widgets/widget-drafts.php
+++ b/includes/widgets/widget-drafts.php
@@ -320,7 +320,7 @@ function desktop_mode_rest_draft_suggestions( WP_REST_Request $request ) {
 	try {
 		$json = wp_ai_client_prompt( desktop_mode_drafts_ai_prompt_text( $post ) )
 			->using_system_instruction( desktop_mode_drafts_ai_instructions( $post ) )
-			->as_json_response( desktop_mode_drafts_ai_schema( $post ) )
+			->as_json_response( desktop_mode_ai_normalize_response_schema( desktop_mode_drafts_ai_schema( $post ) ) )
 			->generate_text();
 	} catch ( \Throwable $e ) {
 		$json = new WP_Error( 'desktop_mode_ai_failed', $e->getMessage() );

--- a/tests/phpunit/tests/aiResponseSchemaNormalization.php
+++ b/tests/phpunit/tests/aiResponseSchemaNormalization.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Tests for `desktop_mode_ai_normalize_response_schema()` — the projection that
+ * keeps a structured-output schema from 400-ing on providers that validate it
+ * in strict mode ("For 'object' type, 'additionalProperties' must be explicitly
+ * set to false").
+ *
+ * The function is pure (no network, no provider), so each shape can be asserted
+ * directly. The schemas we ship are asserted here too: a missing key anywhere in
+ * one of those trees kills the feature that uses it.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group desktop-mode
+ * @group desktop-mode-ai
+ */
+class Tests_DesktopMode_AiResponseSchemaNormalization extends WP_UnitTestCase {
+
+	/**
+	 * The root object gets the key even when the schema never mentioned it.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_root_object_gets_additional_properties_false() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => 'object',
+				'properties' => array( 'text' => array( 'type' => 'string' ) ),
+				'required'   => array( 'text' ),
+			)
+		);
+
+		$this->assertFalse( $out['additionalProperties'] );
+		// Everything else is preserved.
+		$this->assertSame( array( 'text' ), $out['required'] );
+		$this->assertSame( array( 'type' => 'string' ), $out['properties']['text'] );
+	}
+
+	/**
+	 * Scalar leaves are left alone — only object nodes carry the key.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_scalar_properties_are_untouched() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'count' => array( 'type' => 'integer' ),
+					'tags'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'additionalProperties', $out['properties']['count'] );
+		$this->assertArrayNotHasKey( 'additionalProperties', $out['properties']['tags'] );
+		$this->assertArrayNotHasKey( 'additionalProperties', $out['properties']['tags']['items'] );
+	}
+
+	/**
+	 * A nested object under `properties` is normalized at its own depth —
+	 * the provider rejects the request over any node in the tree, not just
+	 * the root.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_nested_object_property_is_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'readiness' => array(
+						'type'       => 'object',
+						'properties' => array( 'summary' => array( 'type' => 'string' ) ),
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $out['properties']['readiness']['additionalProperties'] );
+	}
+
+	/**
+	 * Array `items` in single-schema form — the agents answer schema's
+	 * `call_to_actions` shape.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_array_items_object_is_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'actions' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array( 'id' => array( 'type' => 'string' ) ),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $out['properties']['actions']['items']['additionalProperties'] );
+	}
+
+	/**
+	 * Tuple-form `items` (a list of schemas) is walked entry by entry.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_tuple_items_are_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'  => 'array',
+				'items' => array(
+					array( 'type' => 'string' ),
+					array( 'type' => 'object', 'properties' => array( 'id' => array( 'type' => 'string' ) ) ),
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'additionalProperties', $out['items'][0] );
+		$this->assertFalse( $out['items'][1]['additionalProperties'] );
+	}
+
+	/**
+	 * Objects inside `anyOf` / `oneOf` / `allOf` branches — how a nullable
+	 * object is usually written.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_combinator_branches_are_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'entity' => array(
+						'anyOf' => array(
+							array( 'type' => 'object', 'properties' => array( 'id' => array( 'type' => 'integer' ) ) ),
+							array( 'type' => 'null' ),
+						),
+					),
+					'either' => array(
+						'oneOf' => array( array( 'type' => 'object', 'properties' => array() ) ),
+					),
+					'merged' => array(
+						'allOf' => array( array( 'type' => 'object', 'properties' => array() ) ),
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $out['properties']['entity']['anyOf'][0]['additionalProperties'] );
+		$this->assertArrayNotHasKey( 'additionalProperties', $out['properties']['entity']['anyOf'][1] );
+		$this->assertFalse( $out['properties']['either']['oneOf'][0]['additionalProperties'] );
+		$this->assertFalse( $out['properties']['merged']['allOf'][0]['additionalProperties'] );
+	}
+
+	/**
+	 * A type UNION that includes "object" still needs the key.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_type_union_including_object_is_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => array( 'object', 'null' ),
+				'properties' => array( 'id' => array( 'type' => 'integer' ) ),
+			)
+		);
+
+		$this->assertFalse( $out['additionalProperties'] );
+	}
+
+	/**
+	 * An untyped node that declares `properties` is an object as far as the
+	 * validator is concerned.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_untyped_node_with_properties_is_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array( 'properties' => array( 'id' => array( 'type' => 'integer' ) ) )
+		);
+
+		$this->assertFalse( $out['additionalProperties'] );
+	}
+
+	/**
+	 * `true` and schema-shaped values are exactly what strict mode rejects,
+	 * so an existing `additionalProperties` is overwritten rather than kept.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_permissive_additional_properties_is_overwritten() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'                 => 'object',
+				'additionalProperties' => true,
+				'properties'           => array(
+					'nested' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'string' ),
+						'properties'           => array(),
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $out['additionalProperties'] );
+		$this->assertFalse( $out['properties']['nested']['additionalProperties'] );
+	}
+
+	/**
+	 * A property literally named `items` / `properties` is a property, not a
+	 * keyword — the walk is structure-aware.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_property_named_like_a_keyword_is_treated_as_a_property() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'       => 'object',
+				'properties' => array(
+					'items'      => array( 'type' => 'string' ),
+					'properties' => array(
+						'type'       => 'object',
+						'properties' => array( 'colour' => array( 'type' => 'string' ) ),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'type' => 'string' ), $out['properties']['items'] );
+		$this->assertFalse( $out['properties']['properties']['additionalProperties'] );
+		$this->assertArrayNotHasKey(
+			'additionalProperties',
+			$out['properties']['properties']['properties']['colour']
+		);
+	}
+
+	/**
+	 * `$defs` / `definitions` pools are walked too — a `$ref` target is a
+	 * schema the validator sees.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_definition_pools_are_normalized() {
+		$out = desktop_mode_ai_normalize_response_schema(
+			array(
+				'type'  => 'object',
+				'$defs' => array(
+					'link' => array( 'type' => 'object', 'properties' => array( 'url' => array( 'type' => 'string' ) ) ),
+				),
+			)
+		);
+
+		$this->assertFalse( $out['$defs']['link']['additionalProperties'] );
+	}
+
+	/**
+	 * A schema that already complies is returned unchanged.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_compliant_schema_is_unchanged() {
+		$schema = array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'text' ),
+			'properties'           => array( 'text' => array( 'type' => 'string' ) ),
+		);
+
+		$this->assertSame( $schema, desktop_mode_ai_normalize_response_schema( $schema ) );
+	}
+
+	/**
+	 * The agents answer schema is compliant as written — the shape that
+	 * produced the original 400.
+	 *
+	 * @covers ::desktop_mode_agent_answer_schema
+	 */
+	public function test_agent_answer_schema_is_strict() {
+		$schema = desktop_mode_agent_answer_schema();
+
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertFalse( $schema['properties']['call_to_actions']['items']['additionalProperties'] );
+		$this->assertSame( $schema, desktop_mode_ai_normalize_response_schema( $schema ) );
+	}
+
+	/**
+	 * Every schema we hand to `as_json_response()` is already strict, so
+	 * normalization is a safety net rather than a load-bearing rewrite.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_shipped_schemas_are_strict_as_written() {
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'draft' ) );
+
+		$schemas = array(
+			'copilot answer' => desktop_mode_ai_search_answer_schema(),
+			'comment'        => desktop_mode_ai_schema_comment(),
+			'drafts'         => desktop_mode_drafts_ai_schema( $post ),
+		);
+
+		foreach ( $schemas as $label => $schema ) {
+			$this->assertSame(
+				$schema,
+				desktop_mode_ai_normalize_response_schema( $schema ),
+				"The {$label} schema is not strict as written."
+			);
+		}
+	}
+
+	/**
+	 * A plugin that adds a nested object through a documented schema filter
+	 * can't break the request by omitting the provider-only key.
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_filtered_schema_addition_is_repaired() {
+		$add_field = static function ( $schema ) {
+			$schema['properties']['compliance'] = array(
+				'type'       => 'object',
+				'properties' => array( 'flagged' => array( 'type' => 'boolean' ) ),
+			);
+			return $schema;
+		};
+
+		add_filter( 'desktop_mode_ai_schema_comment', $add_field );
+		$schema = desktop_mode_ai_normalize_response_schema( desktop_mode_ai_schema_comment() );
+		remove_filter( 'desktop_mode_ai_schema_comment', $add_field );
+
+		$this->assertFalse( $schema['properties']['compliance']['additionalProperties'] );
+	}
+}


### PR DESCRIPTION
## The bug

Agent runs fail on the Anthropic provider with:

```
Bad Request (400) - output_format.schema: For 'object' type,
'additionalProperties' must be explicitly set to false
```

Providers validate the schema passed to `as_json_response()` in **strict** mode, which is narrower than JSON Schema: an object subschema that doesn't say `additionalProperties: false` is rejected, and that rejects the **whole request**, not just the offending branch.

`desktop_mode_agent_answer_schema()` (`text` + `call_to_actions[]`) declared neither of its two object nodes that way, so every agent turn 400'd before reaching the model.

## The fix

1. **Fix the schema.** Both object nodes in the agents answer schema now declare `additionalProperties: false`.
2. **Stop the class of bug.** New `desktop_mode_ai_normalize_response_schema()` (`includes/ai-copilot/schema.php`) walks a structured-output schema and stamps `additionalProperties: false` on every object node, at every depth. It runs at all three `as_json_response()` call sites — the agentic loop (`desktop_mode_ai_client_generate()`, used by both the Copilot and agents), comment analysis, and draft suggestions — **after** the schema filters have run.

That second part matters for plugin authors: `desktop_mode_ai_schema_comment` and `desktop_mode_drafts_ai_schema` are documented extension points, and adding a nested object through either would otherwise 400 the feature unless the author happened to know the provider's strict-mode rules.

### Normalization details

- **Structure-aware walk.** Property maps are keyed by property *name*, so a property literally called `items` is never mistaken for the keyword. Recursion covers `properties` / `patternProperties`, `items` in both single-schema and tuple form, `prefixItems`, `not`, the `oneOf` / `allOf` / `anyOf` branches, and `$defs` / `definitions` pools.
- **Object detection** covers the literal `type`, a type union that includes `"object"` (how a nullable branch is usually written), and the untyped-but-shaped form that declares `properties` with no `type`.
- **An existing `additionalProperties` is overwritten.** `true` and schema-shaped values are exactly what strict mode rejects, so preserving them would only preserve the 400.
- **Only that key is rewritten.** Strict mode also rejects numeric/string constraints and recursive `$ref`s; those are left alone and documented rather than silently repaired.

Tool *input* schemas keep their own separate projection (`desktop_mode_ai_normalize_tool_schema()`) — different contract, different rules.

## Tests

New `tests/phpunit/tests/aiResponseSchemaNormalization.php` — 15 tests covering nested objects, array items (single + tuple), combinator branches, type unions, untyped nodes, keyword-named properties, `$defs`, permissive-value overwrite, and the no-op case. Two of them assert the shipped schemas (Copilot answer, comment, drafts, agents answer) are strict *as written*, so normalization stays a safety net rather than load-bearing; one asserts a filter-added nested object gets repaired.

`npm run test:php`: **1816 tests, 4839 assertions, OK** (4 pre-existing skips). `php -l` and `phpcs` clean on every changed file (`runner.php`'s remaining warnings are pre-existing on trunk).

## Docs

`docs/hooks-reference.md` — both documented schema filters now state that object subschemas are normalized after the filter runs, and what strict mode still rejects.

## Testing steps

Enable an Anthropic connector under **Settings → Connectors**, then run an agent from the chat window. Previously: a 502/400 with the `output_format.schema` message. Now: a normal answer, with call-to-action buttons when the agent asks for confirmation. Worth a second pass on the Copilot palette (Cmd+K), the comment spam score, and the drafts widget's AI suggestions — all three route through the same normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sKW1mu1SGg5k9oSHgxv5s

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-462-c10b685cf5a9023fe4af5d686614771bb0315a6d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->