### PR TITLE
Contain window-reveal play failures and stop over-promising `owner`

### DIFF
--- a/docs/examples/window-reveal.md
+++ b/docs/examples/window-reveal.md
@@ -35,9 +35,12 @@ wp.desktop.ready( () => {
 Enqueue that as a normal admin script and the reveal appears in the
 selector on the next load.
 
-`owner` should be your script handle. It is what lets the shell
-unregister your reveal live when your plugin is deactivated, instead of
-leaving a dead entry in the user's selector until they reload.
+`owner` should be your script handle. Today it is only a tag: the
+live-unregister sweep on plugin deactivation is not wired for reveals
+yet (same known gap as palettes), so a deactivated plugin's reveal
+stays in the selector until the next reload. Set it anyway — the moment
+the sweep lands, your reveal starts being cleaned up live, with no def
+change on your side.
 
 ## The one rule: `from` and `to` must interpolate
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2270,7 +2270,7 @@ Register a **window reveal** — the transition that uncovers a window's content
 
 The surface is a **sibling of the `<iframe>`** inside `.desktop-mode-window__body`, never a wrapper and never inside the framed document. Nothing is injected into the page being revealed, the content keeps its own compositing layer and hit-testing, and native windows are treated identically to iframe windows. A reveal cannot interfere with what it reveals.
 
-**Throws** a `RegistrationError` on validation failure (bad/missing `id`, the reserved id `'none'`, a missing `from`/`to`, or a `from`/`to` pair that cannot interpolate).
+**Throws** a `RegistrationError` on validation failure (bad/missing `id`, the reserved id `'none'`, a missing `from`/`to`, a `from`/`to` pair that cannot interpolate, or an `easing` the browser cannot parse).
 
 **`WindowRevealDef`:**
 
@@ -2284,11 +2284,11 @@ The surface is a **sibling of the `<iframe>`** inside `.desktop-mode-window__bod
 | `layers` | `{ from, to, color? }[]` | Several independent covering layers instead of one. See **Multi-layer reveals** below. |
 | `render` | `() => { element, play }` | Build the covering DOM yourself. See **Rendering your own** below. Supply exactly one of `from`/`to`, `layers`, or `render`. |
 | `duration` | `number` | Optional, ms. Defaults to `460`. Clamped to 80–4000. Overridden by the user's OS-Settings speed and by the theme token — see **Speed** below. |
-| `easing` | `string` | Optional CSS easing. Defaults to `cubic-bezier( 0.33, 0, 0.2, 1 )`. |
+| `easing` | `string` | Optional CSS easing. Defaults to `cubic-bezier( 0.33, 0, 0.2, 1 )`. Validated at registration: an easing `Element.animate()` cannot parse is rejected there, instead of throwing at play time with the covering surface over the window. |
 | `surfaceColor` | `string` | Optional `background` for the covering surface, overriding the theme token. Reach for it only when the paint **is** the reveal — see the note below. |
 | `edgeColor` | `string` | Optional `background` for the trailing edge, overriding the theme token. A multi-layer reveal usually wants this **darker** than its surface. |
 | `edgeLag` | `number` | Optional, ms the leading edge trails the surface. Defaults to `70`; `0` drops the edge layer. Clamped to 0–600. Overridden outright by the `--desktop-mode-window-reveal-edge-thickness` theme token. |
-| `owner` | `string` | Optional. Set to your script handle for live-unregister-on-deactivate. |
+| `owner` | `string` | Optional. Your script handle, as a grouping tag. The live-unregister sweep on plugin deactivation is **not wired for reveals yet** — see **Registration is JS-only** below. Setting it now means your reveal is swept the moment that sweep lands, with no def change. |
 
 > **`from` and `to` are a matched pair, not two independent values.** CSS only interpolates a `clip-path` between values using the **same shape function** — and, for `polygon()`, the same **vertex count** and fill rule. A mismatched pair is not an error to the browser: it jumps between the two values at the halfway mark, which reads as a flicker on a window that just finished loading. Registration rejects a mismatched shape function outright rather than letting that ship. Vertex counts are your responsibility; build both endpoints from one function so the ring structure cannot drift.
 
@@ -2383,7 +2383,7 @@ Whatever wins, `edgeLag` is scaled by the same ratio, so the edge band keeps its
 - **`prefers-reduced-motion` skips the animation** and uncovers the content directly. Same for environments without the Web Animations API.
 - **The colours are theme tokens**: `--desktop-mode-window-reveal-surface` (white) and `--desktop-mode-window-reveal-edge` (`transparent` — no edge). A def can override them with `surfaceColor` / `edgeColor`, or per layer with `layers[].color`, but should not unless the paint is the point. `obturator` is the only built-in that does, and only per layer: its six leaves have to differ from one another or the mechanism reads as a single shape.
 - **A desktop theme can recommend a reveal**, via `recommendedOsSettings.windowReveal` and `recommendedOsSettings.windowRevealDuration` — applied once on first activation, or on demand from the Themes tab's "Apply recommended layout and effects" button.
-- **Registration is JS-only.** Unlike unfocus effects, there is no `desktop_mode_register_window_reveal_script()` PHP companion yet, so a reveal registered by a plugin activated mid-session appears in the selector only after a reload. Same known gap as palettes.
+- **Registration is JS-only.** Unlike unfocus effects, there is no `desktop_mode_register_window_reveal_script()` PHP companion yet, so a reveal registered by a plugin activated mid-session appears in the selector only after a reload — and a deactivated plugin's reveal stays listed until a reload too (`owner` is recorded, but nothing sweeps by it on deactivation yet). Same known gap as palettes.
 
 The raw `desktop-mode.window-reveals` JS filter receives the registry array on every read, mirroring `desktop-mode.unfocus-effects` — use it to reorder, remove, or conditionally swap reveals. The user's selection persists in the `windowReveal` OS-settings key (reveal id or `'none'`, the default — reveals are opt-in), readable via `getOsSettings().windowReveal`. An unknown id (a deactivated plugin's reveal still named in user meta) resolves to no reveal rather than to a substitute, and starts working again the moment that plugin re-registers it.
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1127,9 +1127,10 @@ export interface WpDesktopPublicApi {
 	 * whole window, `to` is empty. Both must use the same shape
 	 * function or the values cannot interpolate — registration rejects
 	 * a mismatched pair rather than letting it flicker at runtime. Set
-	 * `owner` to the script handle for live unregistration on
-	 * deactivation. The five built-ins are registered through this same
-	 * API.
+	 * `owner` to the script handle to tag the reveal for grouped
+	 * removal — the live-unregister sweep on plugin deactivation is not
+	 * wired for reveals yet (same known gap as palettes). The built-ins
+	 * are registered through this same API.
 	 *
 	 * Throws a `RegistrationError` on validation failure.
 	 */

--- a/src/reveals/registry.ts
+++ b/src/reveals/registry.ts
@@ -6,7 +6,7 @@
  * plugins can register via `wp.desktop.registerWindowReveal()` and also
  * reach the raw filter for reorder / remove / conditional swap.
  *
- * The five built-ins are seeded here through the very same `register()`
+ * The built-ins are seeded here through the very same `register()`
  * the public hook calls — the shipped reveals dogfood the extensibility
  * API rather than taking a private shortcut.
  *
@@ -225,6 +225,27 @@ function pairErrors( pair: Partial< WindowRevealLayer >, label: string ): string
 }
 
 /**
+ * Whether the browser can parse `easing`. `Element.animate()` throws a
+ * `TypeError` on an easing it cannot parse — and it would do so at PLAY
+ * time, with the opaque armed surface already covering the window, so
+ * the string has to be rejected here at registration instead. A
+ * throwaway `KeyframeEffect` runs the same parser `animate()` uses.
+ * Environments without the Web Animations API (jsdom, reduced-motion
+ * fallback paths) accept everything: they never call `animate()`.
+ */
+function isParseableEasing( easing: string ): boolean {
+	if ( typeof KeyframeEffect !== 'function' ) {
+		return true;
+	}
+	try {
+		void new KeyframeEffect( null, null, { easing } );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Register (or replace) a window reveal. Re-registering the same id
  * replaces the previous entry — mirrors WordPress's `register_*`
  * semantics where the latest call wins.
@@ -288,6 +309,15 @@ export function registerWindowReveal( def: WindowRevealDef ): void {
 				...pairErrors( def, '' ).map( ( e ) => e.replace( /^\./, '' ) ),
 			);
 		}
+		if ( def.easing !== undefined ) {
+			if ( typeof def.easing !== 'string' || def.easing.trim() === '' ) {
+				errors.push( 'easing (not a non-empty string)' );
+			} else if ( ! isParseableEasing( def.easing ) ) {
+				errors.push(
+					'easing (not an easing the browser can parse — `Element.animate()` would throw at play time, with the covering surface already over the window)',
+				);
+			}
+		}
 	}
 
 	throwOnRegistrationErrors( 'WindowReveal', errors, def );
@@ -305,9 +335,14 @@ export function unregisterWindowReveal( id: string ): void {
 }
 
 /**
- * Remove every reveal registered by a given owner (script handle). Used
- * by the server-sync module on plugin deactivation. Returns the number
- * removed.
+ * Remove every reveal registered by a given owner (script handle).
+ * Returns the number removed.
+ *
+ * This is the grouped-eviction primitive for a live-unregister sweep on
+ * plugin deactivation — but reveals have no PHP script-registration
+ * companion yet (same known gap as palettes), so nothing calls it on
+ * the deactivation path today. Defs that set `owner` now start being
+ * swept the moment that sweep lands, with no def change.
  */
 export function unregisterWindowRevealsByOwner( owner: string ): number {
 	if ( ! owner ) {

--- a/src/reveals/surface.ts
+++ b/src/reveals/surface.ts
@@ -607,7 +607,21 @@ export function playWindowReveal( windowEl: HTMLElement ): void {
 	}
 	// Resolve against the reveal that ARMED this surface, not the one
 	// selected right now — see REVEAL_ID_ATTR.
-	const def = getWindowReveal( surface.getAttribute( REVEAL_ID_ATTR ) ?? '' );
+	let def: WindowRevealDef | undefined;
+	try {
+		def = getWindowReveal( surface.getAttribute( REVEAL_ID_ATTR ) ?? '' );
+	} catch ( err ) {
+		// The lookup runs the `desktop-mode.window-reveals` filter, and
+		// a throwing filter callback lands here — with the armed opaque
+		// surface already over the window. Degrade to "no reveal" so the
+		// content is uncovered no matter what a plugin's filter does.
+		if ( typeof console !== 'undefined' ) {
+			console.error(
+				'[desktop-mode] window-reveal lookup threw; uncovering without a reveal:',
+				err,
+			);
+		}
+	}
 	if ( ! def ) {
 		findLayers( body ).forEach( ( layer ) => layer.remove() );
 		return;
@@ -730,17 +744,34 @@ export function playWindowReveal( windowEl: HTMLElement ): void {
 		// it would keep a layer alive for every window in the shell; the
 		// element is removed on finish, which retires the hint with it.
 		layer.style.willChange = 'clip-path';
-		const animation = layer.animate(
-			[ { clipPath: pair.from }, { clipPath: pair.to } ],
-			{
-				duration: layerDuration,
-				easing,
-				delay,
-				// `both` holds the `from` shape through the delay, so the
-				// layers stay fully covering while the spinner fades.
-				fill: 'both',
-			},
-		);
+		let animation: Animation;
+		try {
+			animation = layer.animate(
+				[ { clipPath: pair.from }, { clipPath: pair.to } ],
+				{
+					duration: layerDuration,
+					easing,
+					delay,
+					// `both` holds the `from` shape through the delay, so the
+					// layers stay fully covering while the spinner fades.
+					fill: 'both',
+				},
+			);
+		} catch ( err ) {
+			// Registration validates `easing`, but a def injected by the
+			// `desktop-mode.window-reveals` filter never went through
+			// registration — and `animate()` throws on input it cannot
+			// parse. Uncover rather than leave the window under a
+			// surface that cannot animate away.
+			if ( typeof console !== 'undefined' ) {
+				console.error(
+					`[desktop-mode] window reveal "${ def.id }" failed to animate; uncovering:`,
+					err,
+				);
+			}
+			layer.remove();
+			return null;
+		}
 		running.set( layer, animation );
 		return animation;
 	};
@@ -759,6 +790,15 @@ export function playWindowReveal( windowEl: HTMLElement ): void {
 
 	const surfaceAnimation = surfaceAnimations[ 0 ] ?? null;
 	const edgeAnimation = edgeAnimations[ 0 ] ?? null;
+
+	// Every layer can bail inside `play()` — a def re-registered
+	// mid-load with fewer layers, or `animate()` refusing its input.
+	// The layers are already gone; what `finish()` still owns is the
+	// `--revealing` pin, which must not outlive the reveal.
+	if ( ! surfaceAnimation && ! edgeAnimation ) {
+		finish();
+		return;
+	}
 
 	// Events rather than the `finished` promise: cancelling an animation
 	// rejects that promise, and a window closed mid-reveal would surface

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -89,8 +89,8 @@ export interface OsSettingsSnapshot {
 	unfocusEffect: string;
 	/**
 	 * Active window-reveal id — the `clip-path` transition that
-	 * uncovers a window's content when it finishes loading. `'sweep'`
-	 * is the shipped default; `'none'` disables the transition.
+	 * uncovers a window's content when it finishes loading. `'none'`
+	 * (no transition) is the default: reveals are opt-in.
 	 */
 	windowReveal: string;
 	/**

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -140,7 +140,8 @@ export interface OsSettingsState {
 	 * uncovers a window's content once it has finished loading.
 	 * Resolves through the window-reveal registry; `'none'` means no
 	 * reveal (the plain opacity fade), and an unknown id is treated as
-	 * `'none'` until/if a matching reveal registers. Default `'sweep'`.
+	 * `'none'` until/if a matching reveal registers. Default `'none'`
+	 * — reveals are opt-in.
 	 */
 	windowReveal: string;
 	/**

--- a/tests/vitest/window-reveal-registry.test.ts
+++ b/tests/vitest/window-reveal-registry.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for `src/reveals/registry.ts`.
  *
  * Shared-store-backed like the unfocus-effect registry, so each test
- * resets the stores and re-imports fresh. The five built-ins are seeded
+ * resets the stores and re-imports fresh. The built-ins are seeded
  * at module load through the public `register()` path, so a fresh
  * import always starts with them present.
  *
@@ -193,6 +193,49 @@ describe( 'reveals/registry.ts — registration', () => {
 		expect( () =>
 			registerWindowReveal( { ...valid, label: '  ' } ),
 		).toThrow( /label/ );
+	} );
+
+	test( 'rejects a non-string easing', async () => {
+		const { registerWindowReveal } = await loadRegistry();
+		expect( () =>
+			registerWindowReveal( {
+				...valid,
+				easing: 42 as unknown as string,
+			} ),
+		).toThrow( /easing/ );
+	} );
+
+	test( 'rejects an easing the browser cannot parse', async () => {
+		// jsdom ships no `KeyframeEffect`, so model a browser whose
+		// constructor rejects what it cannot parse — the same parser
+		// `Element.animate()` runs, which is exactly why an unparsable
+		// easing has to die at registration and not at play time, when
+		// the opaque surface is already covering the window.
+		vi.stubGlobal(
+			'KeyframeEffect',
+			class {
+				constructor(
+					_target: null,
+					_keyframes: null,
+					options: { easing?: string },
+				) {
+					if ( options.easing === 'ease-out-back' ) {
+						throw new TypeError( 'unparsable easing' );
+					}
+				}
+			},
+		);
+		try {
+			const { registerWindowReveal, getWindowReveal } =
+				await loadRegistry();
+			expect( () =>
+				registerWindowReveal( { ...valid, easing: 'ease-out-back' } ),
+			).toThrow( /easing/ );
+			registerWindowReveal( { ...valid, easing: 'linear' } );
+			expect( getWindowReveal( 'acme/wipe' )?.easing ).toBe( 'linear' );
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	} );
 
 	test( 'accepts a polygon pair with equal vertex counts', async () => {

--- a/tests/vitest/window-reveal-surface.test.ts
+++ b/tests/vitest/window-reveal-surface.test.ts
@@ -1127,3 +1127,55 @@ describe( 'reveals/surface.ts — playWindowReveal lifecycle', () => {
 		vi.unstubAllGlobals();
 	} );
 } );
+
+describe( 'reveals/surface.ts — failure containment', () => {
+	test( 'uncovers the window instead of throwing when `animate()` refuses its input', async () => {
+		// Registration validates `easing`, but a def injected through
+		// the `desktop-mode.window-reveals` filter never went through
+		// registration — `animate()` can still throw. The one
+		// unacceptable outcome is a window stranded under the opaque
+		// armed surface.
+		( Element.prototype as unknown as { animate: unknown } ).animate =
+			() => {
+				throw new TypeError( 'unparsable easing' );
+			};
+		const errorSpy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		const { surface, engine } = await load();
+		engine.setActiveWindowRevealId( 'sweep' );
+		const win = makeWindow();
+		surface.armWindowReveal( win );
+
+		expect( () => surface.playWindowReveal( win ) ).not.toThrow();
+		expect( layersOf( win ) ).toHaveLength( 0 );
+		expect(
+			bodyOf( win ).classList.contains( surface.REVEALING_BODY_CLASS ),
+		).toBe( false );
+		expect( errorSpy ).toHaveBeenCalled();
+		errorSpy.mockRestore();
+	} );
+
+	test( 'uncovers the window when the reveals filter throws at play time', async () => {
+		// The play-time def lookup runs the `desktop-mode.window-reveals`
+		// filter; a plugin's throwing callback must degrade to "no
+		// reveal", not propagate with the surface still covering the
+		// window.
+		const hooks = installHooksStub();
+		const errorSpy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		const { surface, engine } = await load();
+		engine.setActiveWindowRevealId( 'sweep' );
+		const win = makeWindow();
+		surface.armWindowReveal( win );
+		hooks.addFilter( 'desktop-mode.window-reveals', 'test/boom', () => {
+			throw new Error( 'boom' );
+		} );
+
+		expect( () => surface.playWindowReveal( win ) ).not.toThrow();
+		expect( layersOf( win ) ).toHaveLength( 0 );
+		expect( errorSpy ).toHaveBeenCalled();
+		errorSpy.mockRestore();
+	} );
+} );


### PR DESCRIPTION
Follow-up to #459, fixing review findings that surfaced after it merged.

## Play failures could strand a window under the armed surface

`Element.animate()` throws on an easing it cannot parse — at play time, after the opaque armed surface is already covering the window and before any finish/cancel handler is attached. The exception escaped `playWindowReveal` into the `WINDOW_CONTENT_LOADED` action, so the window stayed covered on every load, the loading-overlay teardown never ran, and the remaining subscribers for that event were cut off. The custom-render path already guarded its third-party callback; the clip-path path now gets the same containment:

- **Registration rejects an unparsable `easing`.** A throwaway `KeyframeEffect` runs the same parser `animate()` uses, so the bad string dies with a stack frame at registration time. Environments without the Web Animations API accept everything — they never call `animate()`.
- **`playWindowReveal` survives a throwing `animate()`** (a def injected through the `desktop-mode.window-reveals` filter never went through registration) by dropping that layer, and it now clears the `--revealing` pin when every layer bailed.
- **The play-time def lookup survives a throwing filter callback** by degrading to "no reveal": layers removed, content uncovered.

## `owner` was documented as something it does not do

The reveal def table, the example, and the `registerWindowReveal` docblock all said `owner` gets a reveal live-unregistered on plugin deactivation. `unregisterWindowRevealsByOwner()` exists, but nothing calls it on the deactivation path — reveals have no PHP script-registration companion yet, the same known gap as palettes that the reference already acknowledged a paragraph later. The docs now describe `owner` as a grouping tag that starts working the moment the sweep lands, rather than promising a sweep that does not exist. Wiring the actual sweep (payload key + `src/reveals/server-sync.ts`, per the established pattern) is left as a follow-up since it adds PHP API surface.

## Stale docblocks from the default flip

The commit that defaulted reveals to off missed two docblocks still claiming `'sweep'` as the shipped default (`src/settings/registry.ts`, `src/settings/types.ts` — the file the JS reference names as the authoritative snapshot shape) and two more claiming "five built-ins" (there are twelve).

## Tests

- Registration rejects a non-string easing and an unparsable easing (stubbed `KeyframeEffect`), and still accepts valid ones.
- A throwing `animate()` uncovers the window and clears the `--revealing` pin instead of propagating.
- A throwing reveals filter at play time uncovers the window instead of stranding it.

All suites green: eslint, tsc, vitest (2748), PHPUnit (1700).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-464-426983ff895db3a04097a21a1d667c8d15593a3b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20Desktop%20Mode%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;desktop_mode_is_enabled&#039;%20)%20%7C%7C%20!%20desktop_mode_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;desktop-mode&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.desktop.ready(function()%7Bvar%20games%3Dwindow.wp.desktop.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.desktop.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.desktop.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->