### PR TITLE
Improve the agents chat and Agents section UX

### DIFF
--- a/assets/css/agents.css
+++ b/assets/css/agents.css
@@ -71,7 +71,7 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	padding: 6px 8px;
+	padding: 7px 8px;
 	border-radius: 8px;
 	cursor: pointer;
 }
@@ -85,20 +85,51 @@
 }
 
 .dm-agent-chat__conv-avatar {
-	width: 20px;
-	height: 20px;
-	border-radius: 50%;
 	flex: none;
-	background: #fff;
 }
 
-.dm-agent-chat__conv-title {
+/* Two-line row: agent + time on top, the tail of the last message
+   below. Both lines clamp to one line — the sidebar is 190px wide and
+   a wrapping row would push the next conversation out of reach. */
+.dm-agent-chat__conv-text {
 	flex: 1;
 	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+}
+
+.dm-agent-chat__conv-top {
+	display: flex;
+	align-items: baseline;
+	gap: 6px;
+	min-width: 0;
+}
+
+.dm-agent-chat__conv-name {
+	flex: 1;
+	min-width: 0;
+	font-size: 12px;
+	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	font-size: 12px;
+}
+
+.dm-agent-chat__conv-time {
+	flex: none;
+	font-size: 11px;
+	opacity: 0.55;
+	font-variant-numeric: tabular-nums;
+}
+
+.dm-agent-chat__conv-preview {
+	min-width: 0;
+	font-size: 11.5px;
+	opacity: 0.65;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .dm-agent-chat__conv-delete {
@@ -136,10 +167,6 @@
 }
 
 .dm-agent-chat__avatar {
-	width: 40px;
-	height: 40px;
-	border-radius: 50%;
-	background: #fff;
 	flex: none;
 }
 
@@ -216,21 +243,6 @@
 	word-break: break-all;
 }
 
-/* Section-level loading — same scale curve as the My WordPress
-   preview loader and the window-loading overlay, instead of the
-   bare 48px component default. */
-.dm-agents__loading {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
-	min-height: 320px;
-}
-
-.dm-agents__loading wpd-spinner {
-	--wpd-spinner-size: clamp( 96px, 14vw, 192px );
-}
-
 /* Call-to-action buttons under an agent answer. */
 .dm-agent-chat__ctas {
 	display: flex;
@@ -276,11 +288,82 @@
 }
 
 .dm-agent-chat__msg-avatar {
-	width: 28px;
-	height: 28px;
-	border-radius: 50%;
-	background: #fff;
 	flex: none;
+}
+
+/* The object a drop / "Send to" handed the agent. Rendered instead of
+   the runner-facing sentence, and clickable — it opens the entity's
+   admin screen in its own window. */
+.dm-agent-chat__attachment {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	inline-size: 100%;
+	min-inline-size: 0;
+	padding: 8px 10px;
+	border: 1px solid rgba( 255, 255, 255, 0.35 );
+	border-radius: 10px;
+	background: rgba( 255, 255, 255, 0.16 );
+	color: inherit;
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
+}
+
+.dm-agent-chat__attachment:hover,
+.dm-agent-chat__attachment:focus-visible {
+	background: rgba( 255, 255, 255, 0.28 );
+}
+
+.dm-agent-chat__msg--agent .dm-agent-chat__attachment,
+.dm-agent-chat__msg--error .dm-agent-chat__attachment {
+	border-color: var( --desktop-mode-border, rgba( 0, 0, 0, 0.12 ) );
+	background: rgba( 0, 0, 0, 0.04 );
+}
+
+.dm-agent-chat__msg--agent .dm-agent-chat__attachment:hover,
+.dm-agent-chat__msg--error .dm-agent-chat__attachment:hover {
+	background: rgba( 0, 0, 0, 0.08 );
+}
+
+.dm-agent-chat__attachment-icon {
+	flex: none;
+	font-size: 20px;
+	inline-size: 20px;
+	block-size: 20px;
+}
+
+.dm-agent-chat__attachment-text {
+	flex: 1;
+	min-inline-size: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+}
+
+.dm-agent-chat__attachment-title {
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.dm-agent-chat__attachment-meta {
+	font-size: 11px;
+	opacity: 0.75;
+}
+
+.dm-agent-chat__attachment-open {
+	flex: none;
+	font-size: 15px;
+	inline-size: 15px;
+	block-size: 15px;
+	opacity: 0.7;
+}
+
+.dm-agent-chat__msg-caption {
+	font-size: 11px;
+	opacity: 0.75;
 }
 
 /* The in-flight bubble: wide enough to read as a live surface, not a

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -1900,11 +1900,19 @@ wpd-tile[ status='future' ] .desktop-mode-file-tile__icon {
 	box-sizing: border-box;
 }
 
+/* Section-level loading — same scale curve as the My WordPress
+   preview loader and the window-loading overlay, instead of the bare
+   48px component default. */
 .dm-agents__loading {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	height: 100%;
+	min-height: 320px;
+}
+
+.dm-agents__loading wpd-spinner {
+	--wpd-spinner-size: clamp( 96px, 14vw, 192px );
 }
 
 .dm-agents__layout {
@@ -1914,14 +1922,42 @@ wpd-tile[ status='future' ] .desktop-mode-file-tile__icon {
 	gap: 12px;
 }
 
+/* Sidebar column: a fixed "Create agent" header over the scrolling
+   list. The button used to be the list's last child, which put it out
+   of reach on any site with enough agents to need it. */
+.dm-agents__sidebar {
+	display: flex;
+	flex-direction: column;
+	flex: 0 0 260px;
+	/* `min-width: auto` on a flex item resolves to its min-content
+	   width, and the rows carry long `white-space: nowrap` descriptions
+	   — without this the column ignores its 260px basis and eats the
+	   detail pane. The scroll container used to be this item, whose
+	   non-visible overflow zeroed the minimum for free. */
+	min-width: 0;
+	min-height: 0;
+	border-inline-end: 1px solid var( --desktop-mode-border, rgba( 0, 0, 0, 0.08 ) );
+}
+
+.dm-agents__list-toolbar {
+	flex: none;
+	display: flex;
+	padding-block-end: 8px;
+	padding-inline-end: 8px;
+}
+
+.dm-agents__list-toolbar .dm-agents__create {
+	flex: 1;
+}
+
 .dm-agents__list {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
-	flex: 0 0 260px;
+	flex: 1;
+	min-height: 0;
 	overflow-y: auto;
-	padding-right: 4px;
-	border-right: 1px solid var( --desktop-mode-border, rgba( 0, 0, 0, 0.08 ) );
+	padding-inline-end: 4px;
 }
 
 .dm-agents__row {
@@ -1971,9 +2007,6 @@ wpd-tile[ status='future' ] .desktop-mode-file-tile__icon {
 	text-overflow: ellipsis;
 }
 
-.dm-agents__create {
-	margin-top: 8px;
-}
 
 .dm-agents__detail {
 	flex: 1;
@@ -2013,6 +2046,15 @@ wpd-tile[ status='future' ] .desktop-mode-file-tile__icon {
 	opacity: 0.6;
 }
 
+/* Verbs get their own row under the identity block: the set grows
+   (profile, contributions, desktop, chat, delete) and squeezing them
+   beside the name truncated it first. */
+.dm-agents__detail-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .dm-agents__tabs {
 	display: flex;
 	gap: 4px;
@@ -2042,6 +2084,20 @@ wpd-tile[ status='future' ] .desktop-mode-file-tile__icon {
 	flex-direction: column;
 	gap: 10px;
 	padding-bottom: 12px;
+}
+
+/* Pane-level loading: same big, centered WordPress mark the section
+   loader uses, instead of a bare 48px spinner pinned to the top-left
+   of the pane. */
+.dm-agents__pane--loading {
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	min-height: 260px;
+}
+
+.dm-agents__pane--loading wpd-spinner {
+	--wpd-spinner-size: clamp( 96px, 12vw, 160px );
 }
 
 .dm-agents__hint {

--- a/docs/examples/agents.md
+++ b/docs/examples/agents.md
@@ -138,6 +138,30 @@ wp.desktop.whenReady( () => {
 } );
 ```
 
+### Hand the agent an object
+
+A transcript row may carry an `attachment` — the entity the message is
+about. The chat renders it as a card instead of the message text, and
+clicking the card opens that object's admin screen in its own window.
+The drag-drop and "Send to" intakes both set it; a plugin pushing its
+own row can too:
+
+```js
+store.state.transcripts[ 12 ].push( {
+	role: 'user',
+	// The prose is what the RUNNER reads — keep it explicit.
+	text: 'Review the post "Hello world" (id 188).',
+	at: Date.now(),
+	// The card is what the USER sees.
+	attachment: { kind: 'post', id: 188, title: 'Hello world' },
+} );
+store.notify();
+```
+
+`kind` is one of `post`, `page`, `media`, `user`, `comment`. The
+attachment is persisted with the conversation, so a reopened
+transcript still shows the card.
+
 ## Safety knobs
 
 ```php

--- a/includes/agents/conversations.php
+++ b/includes/agents/conversations.php
@@ -39,6 +39,19 @@ const DESKTOP_MODE_AGENT_CONVERSATION_MESSAGE_CAP = 200;
 /** Stored per-message text cap. Wider than the runner's replay cap so long answers reload intact. */
 const DESKTOP_MODE_AGENT_CONVERSATION_TEXT_CAP = 20000;
 
+/** Characters of the last message shown as the sidebar's second line. */
+const DESKTOP_MODE_AGENT_CONVERSATION_PREVIEW_CAP = 80;
+
+/**
+ * Entity kinds a message attachment may reference — mirrors the
+ * client's `DroppedEntityKind` and the drag-trigger config enum.
+ *
+ * @return string[]
+ */
+function desktop_mode_agent_conversation_attachment_kinds() {
+	return array( 'post', 'page', 'media', 'user', 'comment' );
+}
+
 /**
  * Register the conversation post type. Private plumbing: no admin UI,
  * no front-end queries, no revisions; rows die with their author.
@@ -71,6 +84,11 @@ add_action( 'init', 'desktop_mode_agent_conversations_register_post_type', 5 );
  * timestamp. Tool calls keep name/args/error for the transcript
  * display but DROP `output` — tool outputs can embed entire post
  * bodies and are never rendered.
+ *
+ * An `attachment` block survives too: the entity a drop or a "Send
+ * to" pick carried into the conversation, so a reopened transcript
+ * still renders the clickable object card instead of only the
+ * boilerplate sentence the model was handed.
  *
  * @param mixed $messages Incoming message rows.
  * @return array<int, array<string, mixed>>
@@ -113,6 +131,13 @@ function desktop_mode_agent_conversation_sanitize_messages( $messages ) {
 			$entry['ctaUsed'] = true;
 		}
 
+		if ( isset( $row['attachment'] ) ) {
+			$attachment = desktop_mode_agent_conversation_sanitize_attachment( $row['attachment'] );
+			if ( null !== $attachment ) {
+				$entry['attachment'] = $attachment;
+			}
+		}
+
 		if ( isset( $row['toolCalls'] ) && is_array( $row['toolCalls'] ) ) {
 			$calls = array();
 			foreach ( $row['toolCalls'] as $call ) {
@@ -142,6 +167,35 @@ function desktop_mode_agent_conversation_sanitize_messages( $messages ) {
 }
 
 /**
+ * Normalize one message attachment, or null when the block does not
+ * describe an entity this site understands.
+ *
+ * Only the identity triple is stored — kind, id, title. The client
+ * resolves the object's URL at click time from the kind, so a
+ * renamed or re-permalinked entity never leaves a stale link behind
+ * in an old transcript.
+ *
+ * @param mixed $raw Incoming attachment block.
+ * @return array<string, mixed>|null
+ */
+function desktop_mode_agent_conversation_sanitize_attachment( $raw ) {
+	if ( ! is_array( $raw ) ) {
+		return null;
+	}
+	$kind = isset( $raw['kind'] ) ? sanitize_key( (string) $raw['kind'] ) : '';
+	$id   = isset( $raw['id'] ) ? (int) $raw['id'] : 0;
+	if ( $id <= 0 || ! in_array( $kind, desktop_mode_agent_conversation_attachment_kinds(), true ) ) {
+		return null;
+	}
+	$title = isset( $raw['title'] ) ? trim( wp_strip_all_tags( (string) $raw['title'] ) ) : '';
+	return array(
+		'kind'  => $kind,
+		'id'    => $id,
+		'title' => '' !== $title ? mb_substr( $title, 0, 200 ) : '#' . $id,
+	);
+}
+
+/**
  * Derive a list title from the first user message.
  *
  * @param array $messages Sanitized messages.
@@ -154,6 +208,38 @@ function desktop_mode_agent_conversation_title( array $messages ) {
 		}
 	}
 	return __( 'Conversation', 'desktop-mode' );
+}
+
+/**
+ * The sidebar's second line: the TAIL of the last message.
+ *
+ * The title is derived from the FIRST user message, which makes every
+ * conversation with the same opener look identical in the list. The
+ * preview answers the other question — "where did this one get to?" —
+ * so it reads from the end ("…and search relevance.") rather than the
+ * beginning. An attachment-carrying row previews the object instead of
+ * the boilerplate sentence the model was handed.
+ *
+ * @param array $messages Sanitized messages.
+ * @return string
+ */
+function desktop_mode_agent_conversation_preview( array $messages ) {
+	$last = empty( $messages ) ? null : $messages[ count( $messages ) - 1 ];
+	if ( ! is_array( $last ) ) {
+		return '';
+	}
+	if ( isset( $last['attachment']['title'] ) ) {
+		return (string) $last['attachment']['title'];
+	}
+
+	$text = trim( (string) preg_replace( '/\s+/u', ' ', wp_strip_all_tags( (string) $last['text'] ) ) );
+	if ( '' === $text ) {
+		return '';
+	}
+	if ( mb_strlen( $text ) <= DESKTOP_MODE_AGENT_CONVERSATION_PREVIEW_CAP ) {
+		return $text;
+	}
+	return '…' . mb_substr( $text, -DESKTOP_MODE_AGENT_CONVERSATION_PREVIEW_CAP );
 }
 
 /**
@@ -192,6 +278,8 @@ function desktop_mode_agent_conversation_prepare( WP_Post $post, $with_messages 
 		$messages = array();
 	}
 
+	$last = empty( $messages ) ? null : $messages[ count( $messages ) - 1 ];
+
 	$out = array(
 		'id'               => (int) $post->ID,
 		'agentId'          => $agent_id,
@@ -199,6 +287,10 @@ function desktop_mode_agent_conversation_prepare( WP_Post $post, $with_messages 
 		'agentDescription' => $agent ? (string) get_user_meta( $agent_id, '_desktop_mode_agent_description', true ) : '',
 		'agentAvatarUrl'   => function_exists( 'desktop_mode_agent_avatar_url' ) ? desktop_mode_agent_avatar_url() : '',
 		'title'            => (string) $post->post_title,
+		// Second sidebar line + who spoke last, so the list can say
+		// where each conversation got to instead of repeating its opener.
+		'preview'          => desktop_mode_agent_conversation_preview( $messages ),
+		'lastRole'         => is_array( $last ) && isset( $last['role'] ) ? (string) $last['role'] : '',
 		'messageCount'     => count( $messages ),
 		'createdAt'        => mysql2date( 'c', $post->post_date_gmt, false ),
 		'updatedAt'        => mysql2date( 'c', $post->post_modified_gmt, false ),

--- a/src/agent-run-window.ts
+++ b/src/agent-run-window.ts
@@ -16,17 +16,26 @@
  * @public
  */
 
-import { __ } from './i18n';
+import { __, sprintf } from './i18n';
 import { renderMarkdown } from './markdown';
+import './ui/components/wpd-avatar/wpd-avatar';
 import './ui/components/wpd-button/wpd-button';
 import './ui/components/wpd-empty-state/wpd-empty-state';
 import './ui/components/wpd-spinner/wpd-spinner';
 import './ui/components/wpd-textarea/wpd-textarea';
+import { applyAvatarSrc } from './ui/util/avatar-resolve';
 import {
 	agentsChatStore,
 	type AgentChatAgent,
+	type AgentChatAttachment,
 	type AgentChatMessage,
 } from './agents-chat-store';
+import { openAgentEditor } from './agents-editor-target';
+import {
+	attachmentIcon,
+	attachmentKindLabel,
+	openAttachmentWindow,
+} from './agents-entity-window';
 import {
 	describeDragEntity,
 	dispatchAgentDrop,
@@ -92,6 +101,132 @@ function getRunConfig(): RunWindowConfig | null {
 		| RunWindowConfig
 		| undefined;
 	return cfg && typeof cfg.restRoot === 'string' ? cfg : null;
+}
+
+/**
+ * Sidebar timestamp: time of day for today, "Yesterday", the weekday
+ * inside the last week, a short date beyond that. Same ladder every
+ * messaging app uses — the point is recency at a glance, not
+ * precision, so the full stamp goes in the row's `title` instead.
+ */
+function formatConversationTime( iso: string ): string {
+	const when = new Date( iso );
+	if ( Number.isNaN( when.getTime() ) ) {
+		return '';
+	}
+	const now = new Date();
+	const startOfDay = ( d: Date ): number =>
+		new Date( d.getFullYear(), d.getMonth(), d.getDate() ).getTime();
+	const days = Math.round(
+		( startOfDay( now ) - startOfDay( when ) ) / 86400000,
+	);
+	if ( days <= 0 ) {
+		return when.toLocaleTimeString( undefined, {
+			hour: 'numeric',
+			minute: '2-digit',
+		} );
+	}
+	if ( days === 1 ) {
+		return __( 'Yesterday', 'desktop-mode' );
+	}
+	if ( days < 7 ) {
+		return when.toLocaleDateString( undefined, { weekday: 'short' } );
+	}
+	return when.toLocaleDateString( undefined, {
+		month: 'short',
+		day: 'numeric',
+	} );
+}
+
+/**
+ * Build a `<wpd-avatar>`. Gravatar URLs go through the probe so users
+ * with no registered Gravatar get their initials tile instead of the
+ * mystery-person silhouette (a raw Gravatar URL answers 200 with the
+ * silhouette, so the component's own error fallback never fires).
+ */
+function buildAvatar(
+	className: string,
+	size: number,
+	src: string,
+	name: string,
+): HTMLElement {
+	const avatar = document.createElement( 'wpd-avatar' );
+	avatar.className = className;
+	avatar.setAttribute( 'size', String( size ) );
+	avatar.setAttribute( 'name', name );
+	avatar.setAttribute( 'alt', name );
+	if ( src ) {
+		applyAvatarSrc( avatar, src );
+	}
+	return avatar;
+}
+
+/**
+ * Turn an avatar into the agent's editor shortcut: clickable tile,
+ * and both the click and the Enter/Space keydown stop at the avatar so
+ * a row that is itself a button doesn't fire twice.
+ */
+function linkAvatarToAgentEditor( avatar: HTMLElement, agentId: number ): void {
+	avatar.setAttribute( 'clickable', '' );
+	avatar.setAttribute(
+		'title',
+		__( 'Open the agent in My WordPress', 'desktop-mode' ),
+	);
+	avatar.addEventListener( 'click', ( e: Event ) => {
+		e.stopPropagation();
+		openAgentEditor( agentId );
+	} );
+	avatar.addEventListener( 'keydown', ( e: KeyboardEvent ) => {
+		if ( e.key === 'Enter' || e.key === ' ' ) {
+			e.stopPropagation();
+		}
+	} );
+}
+
+/**
+ * The object a drop / "Send to" handed the agent, as a card the user
+ * can open. Clicking it opens the entity's admin screen in its own
+ * window — the conversation stays put.
+ */
+function attachmentCard( attachment: AgentChatAttachment ): HTMLElement {
+	const card = document.createElement( 'button' );
+	card.type = 'button';
+	card.className = 'dm-agent-chat__attachment';
+	card.title = sprintf(
+		/* translators: 1: entity kind (Post, Media, …), 2: entity title. */
+		__( 'Open the %1$s "%2$s"', 'desktop-mode' ),
+		attachmentKindLabel( attachment.kind ),
+		attachment.title,
+	);
+
+	const icon = document.createElement( 'span' );
+	icon.className = `dm-agent-chat__attachment-icon dashicons ${ attachmentIcon(
+		attachment.kind,
+	) }`;
+	icon.setAttribute( 'aria-hidden', 'true' );
+
+	const text = document.createElement( 'span' );
+	text.className = 'dm-agent-chat__attachment-text';
+	const title = document.createElement( 'span' );
+	title.className = 'dm-agent-chat__attachment-title';
+	title.textContent = attachment.title;
+	const meta = document.createElement( 'span' );
+	meta.className = 'dm-agent-chat__attachment-meta';
+	meta.textContent = `${ attachmentKindLabel( attachment.kind ) } · #${
+		attachment.id
+	}`;
+	text.append( title, meta );
+
+	const chevron = document.createElement( 'span' );
+	chevron.className =
+		'dm-agent-chat__attachment-open dashicons dashicons-external';
+	chevron.setAttribute( 'aria-hidden', 'true' );
+
+	card.append( icon, text, chevron );
+	card.addEventListener( 'click', () => {
+		openAttachmentWindow( attachment );
+	} );
+	return card;
 }
 
 function transcriptFor( agent: AgentChatAgent ): AgentChatMessage[] {
@@ -222,15 +357,39 @@ function renderChat( body: HTMLElement ): ( () => void ) | void {
 			}
 			item.setAttribute( 'role', 'button' );
 			item.tabIndex = 0;
+			// The title (first user message) is the one line the rows
+			// have in common when a workflow always opens the same way —
+			// it belongs in the tooltip, not as the row's identity.
 			item.title = `${ row.agentName } — ${ row.title }`;
 
-			const face = document.createElement( 'img' );
-			face.className = 'dm-agent-chat__conv-avatar';
-			face.src = row.agentAvatarUrl;
-			face.alt = '';
+			const face = buildAvatar(
+				'dm-agent-chat__conv-avatar',
+				28,
+				row.agentAvatarUrl,
+				row.agentName,
+			);
+			if ( row.agentId > 0 ) {
+				linkAvatarToAgentEditor( face, row.agentId );
+			}
+
+			// Two lines: who the conversation is with, and where it got
+			// to. The timestamp rides the first line, right-aligned.
 			const label = document.createElement( 'span' );
-			label.className = 'dm-agent-chat__conv-title';
-			label.textContent = row.title;
+			label.className = 'dm-agent-chat__conv-text';
+			const top = document.createElement( 'span' );
+			top.className = 'dm-agent-chat__conv-top';
+			const name = document.createElement( 'span' );
+			name.className = 'dm-agent-chat__conv-name';
+			name.textContent = row.agentName;
+			const time = document.createElement( 'time' );
+			time.className = 'dm-agent-chat__conv-time';
+			time.dateTime = row.updatedAt;
+			time.textContent = formatConversationTime( row.updatedAt );
+			top.append( name, time );
+			const preview = document.createElement( 'span' );
+			preview.className = 'dm-agent-chat__conv-preview';
+			preview.textContent = row.preview || row.title;
+			label.append( top, preview );
 
 			const open = (): void => {
 				if ( busy || ! cfg ) {
@@ -310,10 +469,13 @@ function renderChat( body: HTMLElement ): ( () => void ) | void {
 
 		const head = document.createElement( 'div' );
 		head.className = 'dm-agent-chat__head';
-		const avatar = document.createElement( 'img' );
-		avatar.className = 'dm-agent-chat__avatar';
-		avatar.src = agent.avatarUrl;
-		avatar.alt = '';
+		const avatar = buildAvatar(
+			'dm-agent-chat__avatar',
+			40,
+			agent.avatarUrl,
+			agent.name,
+		);
+		linkAvatarToAgentEditor( avatar, agent.id );
 		const title = document.createElement( 'div' );
 		title.className = 'dm-agent-chat__title';
 		const name = document.createElement( 'strong' );
@@ -390,18 +552,32 @@ function renderChat( body: HTMLElement ): ( () => void ) | void {
 
 		// WhatsApp-style avatars: the agent on the left, the viewer on
 		// the right. Error rows sit on the agent side, avatar-less.
-		let avatarUrl = '';
+		// `<wpd-avatar>` rather than a bare `<img>` so a viewer with no
+		// registered Gravatar gets their initials instead of the
+		// mystery-person silhouette.
 		if ( message.role === 'agent' ) {
-			avatarUrl = agent.avatarUrl;
+			line.appendChild(
+				buildAvatar(
+					'dm-agent-chat__msg-avatar',
+					28,
+					agent.avatarUrl,
+					agent.name,
+				),
+			);
 		} else if ( message.role === 'user' ) {
-			avatarUrl = getRunConfig()?.currentUser?.avatarUrl ?? '';
-		}
-		if ( avatarUrl ) {
-			const face = document.createElement( 'img' );
-			face.className = 'dm-agent-chat__msg-avatar';
-			face.src = avatarUrl;
-			face.alt = '';
-			line.appendChild( face );
+			const viewer = getRunConfig()?.currentUser;
+			// Nothing to draw when the config carries no viewer — an
+			// empty initials disc would read as a broken avatar.
+			if ( viewer?.avatarUrl || viewer?.name ) {
+				line.appendChild(
+					buildAvatar(
+						'dm-agent-chat__msg-avatar',
+						28,
+						viewer.avatarUrl ?? '',
+						viewer.name ?? '',
+					),
+				);
+			}
 		}
 
 		const row = document.createElement( 'div' );
@@ -410,17 +586,31 @@ function renderChat( body: HTMLElement ): ( () => void ) | void {
 			row.classList.add( 'dm-agent-chat__msg--pending' );
 		}
 		line.appendChild( row );
-		const text = document.createElement( 'div' );
-		text.className = 'dm-agent-chat__msg-text';
-		if ( message.role === 'agent' && ! message.pending ) {
-			// Agent answers arrive as markdown; renderMarkdown escapes
-			// the input before re-interpreting tokens, so the result is
-			// safe for innerHTML.
-			text.innerHTML = renderMarkdown( message.text );
+
+		if ( message.attachment ) {
+			// The row's `text` is the sentence the RUNNER was handed
+			// ("The user dropped the post … onto you. Handle it …") —
+			// machine-facing boilerplate that reads as noise in a chat.
+			// The card says the same thing better, and unlike the
+			// sentence it opens the object.
+			row.appendChild( attachmentCard( message.attachment ) );
+			const caption = document.createElement( 'div' );
+			caption.className = 'dm-agent-chat__msg-caption';
+			caption.textContent = __( 'Shared with the agent', 'desktop-mode' );
+			row.appendChild( caption );
 		} else {
-			text.textContent = message.text;
+			const text = document.createElement( 'div' );
+			text.className = 'dm-agent-chat__msg-text';
+			if ( message.role === 'agent' && ! message.pending ) {
+				// Agent answers arrive as markdown; renderMarkdown escapes
+				// the input before re-interpreting tokens, so the result is
+				// safe for innerHTML.
+				text.innerHTML = renderMarkdown( message.text );
+			} else {
+				text.textContent = message.text;
+			}
+			row.appendChild( text );
 		}
-		row.appendChild( text );
 		if ( message.pending ) {
 			const spinner = document.createElement( 'wpd-spinner' );
 			row.appendChild( spinner );

--- a/src/agents-chat-store.ts
+++ b/src/agents-chat-store.ts
@@ -26,10 +26,24 @@ export interface AgentChatAgent {
 	avatarUrl: string;
 }
 
+/**
+ * The entity a message carried into the conversation — a drag drop or
+ * a "Send to" pick. Stored as the identity triple only; the chat
+ * resolves the object's admin URL at click time, so an old transcript
+ * never holds a stale link.
+ */
+export interface AgentChatAttachment {
+	kind: 'post' | 'page' | 'media' | 'user' | 'comment';
+	id: number;
+	title: string;
+}
+
 /** One transcript row. */
 export interface AgentChatMessage {
 	role: 'user' | 'agent' | 'error';
 	text: string;
+	/** Object the user handed the agent with this message, if any. */
+	attachment?: AgentChatAttachment;
 	toolCalls?: AgentToolCall[];
 	/** Confirmation buttons the answer carries (agent rows only). */
 	callToActions?: AgentCallToAction[];

--- a/src/agents-conversations.ts
+++ b/src/agents-conversations.ts
@@ -24,6 +24,10 @@ export interface AgentConversationSummary {
 	agentDescription: string;
 	agentAvatarUrl: string;
 	title: string;
+	/** Tail of the last message — the sidebar's second line. */
+	preview: string;
+	/** Role that spoke last (`user` | `agent` | `error`), or ''. */
+	lastRole: string;
 	messageCount: number;
 	createdAt: string;
 	updatedAt: string;

--- a/src/agents-dispatch.ts
+++ b/src/agents-dispatch.ts
@@ -25,6 +25,7 @@ import {
 	agentsChatStore,
 	openAgentChat,
 	type AgentChatAgent,
+	type AgentChatAttachment,
 	type AgentChatMessage,
 } from './agents-chat-store';
 import { persistAgentTranscript } from './agents-conversations';
@@ -213,7 +214,17 @@ export function dispatchAgentSendTo(
 		composeSendToMessage( entity ),
 		rest,
 		'send-to',
+		attachmentFromEntity( entity ),
 	);
+}
+
+/**
+ * The stored, chat-renderable form of a dropped / sent entity.
+ * Spelled out field by field so the transcript payload stays a stable
+ * triple even if {@link DroppedEntity} grows.
+ */
+function attachmentFromEntity( entity: DroppedEntity ): AgentChatAttachment {
+	return { kind: entity.kind, id: entity.id, title: entity.title };
 }
 
 /**
@@ -257,6 +268,7 @@ export async function invokeAgentIntoTranscript(
 	message: string,
 	rest: { restRoot: string; restNonce: string },
 	source: 'chat' | 'drag' | 'send-to',
+	attachment?: AgentChatAttachment,
 ): Promise< void > {
 	openAgentChat( agent );
 	const transcript = agentsChatStore.state.transcripts[ agent.id ];
@@ -267,7 +279,10 @@ export async function invokeAgentIntoTranscript(
 	const history = transcript
 		.filter( ( row ) => ! row.pending && row.role !== 'error' )
 		.map( ( row ) => ( { role: row.role, text: row.text } ) );
-	transcript.push( { role: 'user', text: message, at: Date.now() } );
+	// The attachment rides ALONGSIDE the composed sentence, never
+	// instead of it: the model keeps reading the same prose it always
+	// did, the chat gains an object it can open.
+	transcript.push( { role: 'user', text: message, at: Date.now(), attachment } );
 	const pending: AgentChatMessage = {
 		role: 'agent',
 		text: __( 'Working…', 'desktop-mode' ),
@@ -347,5 +362,6 @@ export function dispatchAgentDrop(
 		composeDropMessage( entity ),
 		rest,
 		'drag',
+		attachmentFromEntity( entity ),
 	);
 }

--- a/src/agents-editor-target.ts
+++ b/src/agents-editor-target.ts
@@ -1,0 +1,104 @@
+/**
+ * Agents — cross-bundle "open this agent's editor" target.
+ *
+ * The Agent chat window and the My WordPress window are two separate
+ * lazy Vite bundles, so the click that asks for an agent's editor
+ * (an avatar in the chat) can't reach the Agents section renderer
+ * directly. The requested agent is threaded through a shared store
+ * instead, exactly like `my-wordpress/footprint-target.ts` does for
+ * the activity footprint.
+ *
+ * Flow:
+ *   1. A caller invokes {@link openAgentEditor}, which stashes the
+ *      agent id and opens (or focuses) the My WordPress window.
+ *   2. The My WordPress bundle reads the target while choosing its
+ *      initial route — cold open — or navigates on the subscription
+ *      when the window was already mounted.
+ *   3. The Agents section renderer consumes the target on mount and
+ *      selects that agent, then clears it.
+ *
+ * The renderer owns the clear (not the router) because it runs
+ * synchronously inside `navigate()`, so the target is always still
+ * there when the section paints.
+ *
+ * @public
+ */
+
+import { createSharedStore } from './shared-store';
+
+/** Native My WordPress window id — the lazy bundle's `WINDOW_ID`. */
+const MY_WORDPRESS_WINDOW_ID = 'desktop-mode-my-wordpress';
+
+/** Entity id of the Agents section inside My WordPress. */
+export const AGENTS_ENTITY_ID = 'agents';
+
+export interface AgentEditorTarget {
+	/** Agent user id to select, or null when nothing is pending. */
+	agentId: number | null;
+	/** `Date.now()` of the last request — informational. */
+	requestedAt: number;
+}
+
+export const agentEditorTarget = createSharedStore< AgentEditorTarget >(
+	'desktop-mode/agents/editor-target',
+	() => ( { agentId: null, requestedAt: 0 } ),
+);
+
+/** Read the pending target. `agentId === null` means nothing pending. */
+export function readAgentEditorTarget(): AgentEditorTarget {
+	return { ...agentEditorTarget.state };
+}
+
+/** Clear the target once a consumer has captured it. */
+export function clearAgentEditorTarget(): void {
+	agentEditorTarget.state.agentId = null;
+	agentEditorTarget.state.requestedAt = 0;
+	agentEditorTarget.notify();
+}
+
+/**
+ * Subscribe to target changes — fires when a request arrives while
+ * the My WordPress window is already open, so the live render can
+ * navigate without a close/reopen.
+ */
+export function subscribeAgentEditorTarget(
+	cb: ( target: AgentEditorTarget ) => void,
+): () => void {
+	return agentEditorTarget.subscribe( ( state ) => cb( { ...state } ) );
+}
+
+/**
+ * Open (or focus) My WordPress on the Agents section with `agentId`
+ * selected. Cold-start safe: the target is stashed before the window
+ * opens, so the freshly-mounted bundle reads it back.
+ *
+ * @param agentId Agent user id.
+ *
+ * @public
+ */
+export function openAgentEditor( agentId: number ): void {
+	if ( ! Number.isFinite( agentId ) || agentId <= 0 ) {
+		return;
+	}
+	agentEditorTarget.state.agentId = agentId;
+	agentEditorTarget.state.requestedAt = Date.now();
+	// `createSharedStore` is mutate-then-notify; field assignment
+	// alone never wakes subscribers.
+	agentEditorTarget.notify();
+
+	const openWindow = (
+		window as unknown as {
+			wp?: {
+				desktop?: {
+					openWindow?: (
+						id: string,
+						opts?: { source?: string },
+					) => boolean;
+				};
+			};
+		}
+	).wp?.desktop?.openWindow;
+	if ( typeof openWindow === 'function' ) {
+		openWindow( MY_WORDPRESS_WINDOW_ID, { source: 'agents/editor' } );
+	}
+}

--- a/src/agents-entity-window.ts
+++ b/src/agents-entity-window.ts
@@ -1,0 +1,123 @@
+/**
+ * Agents — open the object a message carried, in its own window.
+ *
+ * A drop or a "Send to" pick puts an {@link AgentChatAttachment} on the
+ * user's transcript row; the chat renders it as a card the user can
+ * click. This module turns that identity triple into the admin screen
+ * for the object and hands it to the shell's window manager, the same
+ * way the desktop's built-in file openers do.
+ *
+ * The URL is resolved at CLICK time rather than stored with the
+ * message: transcripts outlive permalinks, and an old conversation
+ * should still open whatever the entity is today.
+ *
+ * @public
+ */
+
+import { __ } from './i18n';
+import type { AgentChatAttachment } from './agents-chat-store';
+
+interface DesktopFacade {
+	config?: { adminUrl?: string };
+	deriveWindowId?: ( url: string, adminUrl?: string ) => string;
+	windowManager?: {
+		open?: ( config: {
+			id: string;
+			baseId?: string;
+			url: string;
+			title?: string;
+			icon?: string;
+		} ) => unknown;
+	};
+}
+
+function getDesktop(): DesktopFacade | undefined {
+	return ( window as unknown as { wp?: { desktop?: DesktopFacade } } ).wp
+		?.desktop;
+}
+
+function adminBase(): string {
+	const url = getDesktop()?.config?.adminUrl ?? '/wp-admin/';
+	return url.endsWith( '/' ) ? url : `${ url }/`;
+}
+
+/** Dashicon shown on the attachment card and the opened window. */
+export function attachmentIcon( kind: AgentChatAttachment[ 'kind' ] ): string {
+	switch ( kind ) {
+		case 'page':
+			return 'dashicons-admin-page';
+		case 'media':
+			return 'dashicons-admin-media';
+		case 'user':
+			return 'dashicons-admin-users';
+		case 'comment':
+			return 'dashicons-admin-comments';
+		default:
+			return 'dashicons-admin-post';
+	}
+}
+
+/** Translated, human-readable name of the entity kind. */
+export function attachmentKindLabel(
+	kind: AgentChatAttachment[ 'kind' ],
+): string {
+	switch ( kind ) {
+		case 'page':
+			return __( 'Page', 'desktop-mode' );
+		case 'media':
+			return __( 'Media', 'desktop-mode' );
+		case 'user':
+			return __( 'User', 'desktop-mode' );
+		case 'comment':
+			return __( 'Comment', 'desktop-mode' );
+		default:
+			return __( 'Post', 'desktop-mode' );
+	}
+}
+
+/**
+ * The admin URL that edits/inspects the attached object. Mirrors the
+ * built-in desktop-file openers so a post opened from a chat and a
+ * post opened from its wallpaper tile land in the same window.
+ */
+export function attachmentUrl( attachment: AgentChatAttachment ): string {
+	const id = encodeURIComponent( String( attachment.id ) );
+	switch ( attachment.kind ) {
+		case 'user':
+			return `${ adminBase() }user-edit.php?user_id=${ id }`;
+		case 'comment':
+			return `${ adminBase() }comment.php?action=editcomment&c=${ id }`;
+		// Posts, pages and attachments are all edited through post.php.
+		default:
+			return `${ adminBase() }post.php?post=${ id }&action=edit`;
+	}
+}
+
+/**
+ * Open the attached object in a window. Reuses the shell's derived
+ * window id so clicking the same object twice focuses one window
+ * instead of stacking duplicates.
+ *
+ * @param attachment The object the message carried.
+ * @return True when a window was opened (or focused).
+ *
+ * @public
+ */
+export function openAttachmentWindow(
+	attachment: AgentChatAttachment,
+): boolean {
+	const desktop = getDesktop();
+	if ( ! desktop?.windowManager?.open || ! desktop.deriveWindowId ) {
+		return false;
+	}
+	const url = attachmentUrl( attachment );
+	const id = desktop.deriveWindowId( url, adminBase() );
+	desktop.windowManager.open( {
+		id,
+		baseId: id,
+		url,
+		title: attachment.title,
+		icon: attachmentIcon( attachment.kind ),
+	} );
+	return true;
+}

--- a/src/my-wordpress/agents-renderer.ts
+++ b/src/my-wordpress/agents-renderer.ts
@@ -43,6 +43,10 @@ import { createSharedStore } from '../shared-store';
 import { refreshSendToAgents } from './agents-send-to';
 import { openAgentChat } from '../agents-chat-store';
 import {
+	clearAgentEditorTarget,
+	readAgentEditorTarget,
+} from '../agents-editor-target';
+import {
 	agentAcceptsDrop,
 	describeDragEntity,
 	dispatchAgentDrop,
@@ -103,6 +107,18 @@ function agentsConfig(): AgentsSectionConfig {
 			connectorsUrl: '',
 			runWindowId: 'desktop-mode-agent-run',
 		}
+	);
+}
+
+/**
+ * Whether the site folder still exposes a Users section. The
+ * GitHub-style contributions view is a route under it, so the
+ * "View contributions" button hides when a filter dropped the entity.
+ */
+function hasUsersEntity(): boolean {
+	const { entities } = getConfig();
+	return (
+		Array.isArray( entities ) && entities.some( ( e ) => e.id === 'users' )
 	);
 }
 
@@ -252,6 +268,26 @@ async function sendAgentToDesktop( agent: Agent ): Promise< string > {
 	}
 }
 
+/**
+ * `<wpd-option>` list for a role picker. A role the agent already
+ * carries but the site no longer registers (a plugin that shipped it
+ * was deactivated) is appended so the select shows the truth instead
+ * of silently reading as the first registered role.
+ */
+function roleOptions( roles: RoleChoice[], current: string ) {
+	const known = roles.some( ( r ) => r.slug === current );
+	return html`
+		${ roles.map(
+			( role ) => html`
+				<wpd-option value=${ role.slug }>${ role.label }</wpd-option>
+			`,
+		) }
+		${ current && ! known
+			? html`<wpd-option value=${ current }>${ current }</wpd-option>`
+			: html`` }
+	`;
+}
+
 function draftFromAgent( agent: Agent | null ): AgentsState[ 'draft' ] {
 	return {
 		name: agent?.name ?? '',
@@ -284,6 +320,17 @@ export function renderAgents( host: EntityRenderHost ): void {
 		draft: draftFromAgent( null ),
 		createDraft: { name: '', description: '', instructions: '', role: 'author' },
 	};
+
+	// Arriving from an agent avatar in the chat window: preselect that
+	// agent. Consumed HERE rather than in the router because this
+	// renderer runs synchronously inside `navigate()` — the target is
+	// guaranteed to still be set, and clearing it here means a later
+	// plain open of the section lands wherever the user left it.
+	const pendingEditor = readAgentEditorTarget();
+	if ( pendingEditor.agentId && pendingEditor.agentId > 0 ) {
+		state.selectedId = pendingEditor.agentId;
+		clearAgentEditorTarget();
+	}
 
 	let disposed = false;
 	const mountId = ++agentsMountSeq;
@@ -594,8 +641,31 @@ export function renderAgents( host: EntityRenderHost ): void {
 		`;
 	};
 
+	// "Create agent" lives ABOVE the list, not after the last row: at
+	// the bottom of a scrolling column it drifts off-screen exactly on
+	// the sites that have enough agents to need it.
 	const listPane = () => html`
-		<div class="dm-agents__list" role="listbox" aria-label=${ __( 'Agents', 'desktop-mode' ) }>
+		<div class="dm-agents__sidebar">
+			${ cfg.canManage
+				? html`
+						<div class="dm-agents__list-toolbar">
+							<wpd-button
+								class="dm-agents__create"
+								variant="primary"
+								?disabled=${ state.saving }
+								@click=${ () => {
+									state.creating = true;
+									state.notice = '';
+									void ensureRoles();
+									paint();
+								} }
+							>
+								${ __( '+ Create agent', 'desktop-mode' ) }
+							</wpd-button>
+						</div>
+				  `
+				: html`` }
+			<div class="dm-agents__list" role="listbox" aria-label=${ __( 'Agents', 'desktop-mode' ) }>
 			${ state.agents.map(
 				( agent ) => html`
 					<div
@@ -625,22 +695,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 					</div>
 				`,
 			) }
-			${ cfg.canManage
-				? html`
-						<wpd-button
-							class="dm-agents__create"
-							?disabled=${ state.saving }
-							@click=${ () => {
-								state.creating = true;
-								state.notice = '';
-								void ensureRoles();
-								paint();
-							} }
-						>
-							${ __( '+ Create agent', 'desktop-mode' ) }
-						</wpd-button>
-				  `
-				: html`` }
+			</div>
 		</div>
 	`;
 
@@ -717,14 +772,31 @@ export function renderAgents( host: EntityRenderHost ): void {
 							${ __( 'Role', 'desktop-mode' ) }: ${ agent.role }
 					  </p>`
 					: html`
-							<wpd-text-field
-								label=${ __( 'Role', 'desktop-mode' ) }
-								value=${ state.draft.role }
-								@wpd-input-change=${ ( e: CustomEvent< { value: string } > ) => {
-									state.draft.role = e.detail.value;
-									paint();
-								} }
-							></wpd-text-field>
+							${ state.roles
+								? html`
+										<wpd-select
+											label=${ __( 'Role', 'desktop-mode' ) }
+											value=${ state.draft.role }
+											@wpd-pick=${ ( e: CustomEvent< { value: string } > ) => {
+												state.draft.role =
+													e.detail?.value ?? state.draft.role;
+												paint();
+											} }
+										>
+											${ roleOptions( state.roles, state.draft.role ) }
+										</wpd-select>
+								  `
+								: html`
+										<wpd-select
+											label=${ __( 'Role', 'desktop-mode' ) }
+											value=${ state.draft.role }
+											disabled
+										>
+											<wpd-option value=${ state.draft.role }>
+												${ state.draft.role }
+											</wpd-option>
+										</wpd-select>
+								  ` }
 							<p class="dm-agents__hint">
 								${ __(
 									'The agent acts with this role\'s capabilities — pick the least privilege that still lets it do its job.',
@@ -754,7 +826,9 @@ export function renderAgents( host: EntityRenderHost ): void {
 
 	const toolsPane = ( agent: Agent ) => {
 		if ( state.abilities === null ) {
-			return html`<div class="dm-agents__pane"><wpd-spinner></wpd-spinner></div>`;
+			return html`<div class="dm-agents__pane dm-agents__pane--loading">
+				<wpd-spinner></wpd-spinner>
+			</div>`;
 		}
 		const byCategory = new Map< string, Ability[] >();
 		for ( const ability of state.abilities ) {
@@ -881,7 +955,9 @@ export function renderAgents( host: EntityRenderHost ): void {
 
 	const triggersPane = ( agent: Agent ) => {
 		if ( state.triggerKinds === null ) {
-			return html`<div class="dm-agents__pane"><wpd-spinner></wpd-spinner></div>`;
+			return html`<div class="dm-agents__pane dm-agents__pane--loading">
+				<wpd-spinner></wpd-spinner>
+			</div>`;
 		}
 		const kindLabel = ( slug: string ): string =>
 			state.triggerKinds?.find( ( k ) => k.slug === slug )?.label ?? slug;
@@ -992,11 +1068,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 								state.createDraft.role = e.detail?.value ?? state.createDraft.role;
 							} }
 						>
-							${ state.roles.map(
-								( role ) => html`
-									<wpd-option value=${ role.slug }>${ role.label }</wpd-option>
-								`,
-							) }
+							${ roleOptions( state.roles, state.createDraft.role ) }
 						</wpd-select>
 				  `
 				: html`<wpd-spinner></wpd-spinner>` }
@@ -1064,9 +1136,26 @@ export function renderAgents( host: EntityRenderHost ): void {
 					<h3>${ agent.name }</h3>
 					<span class="dm-agents__detail-slug">@agent-${ agent.slug }</span>
 				</div>
+			</div>
+			<div class="dm-agents__detail-actions">
 				<wpd-button @click=${ () => openAgentProfile( agent ) }>
 					${ __( 'Open profile', 'desktop-mode' ) }
 				</wpd-button>
+				${ hasUsersEntity()
+					? html`
+							<wpd-button
+								@click=${ () =>
+									host.navigate( {
+										kind: 'user-footprint',
+										entityId: 'users',
+										userId: agent.id,
+										userName: agent.name,
+									} ) }
+							>
+								${ __( 'View contributions', 'desktop-mode' ) }
+							</wpd-button>
+					  `
+					: html`` }
 				${ cfg.canManage
 					? html`
 							<wpd-button
@@ -1086,6 +1175,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 				${ cfg.canInvoke
 					? html`
 							<wpd-button
+								variant="primary"
 								?disabled=${ state.aiReady === false }
 								@click=${ () => openChatWindow( agent ) }
 							>
@@ -1150,6 +1240,10 @@ export function renderAgents( host: EntityRenderHost ): void {
 	paint();
 	void load();
 	void probeAi();
+	// The Define pane's role picker needs the catalogue as soon as an
+	// agent is selected, which happens the moment the list resolves —
+	// fetch alongside the list rather than on the first click.
+	void ensureRoles();
 }
 
 registerEntityKind( 'agent', renderAgents );

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -42,6 +42,11 @@ import {
 	subscribeFootprintTarget,
 } from './footprint-target';
 import {
+	AGENTS_ENTITY_ID,
+	readAgentEditorTarget,
+	subscribeAgentEditorTarget,
+} from '../agents-editor-target';
+import {
 	renderBreadcrumbs,
 	type BreadcrumbSegment,
 } from '../desktop-files/breadcrumbs';
@@ -6124,7 +6129,13 @@ function renderInto( body: HTMLElement ): ( () => void ) | undefined {
 	// because it lives in a shared store rather than this module's
 	// `pendingRoute`. Consume + clear so a later plain open lands on
 	// root.
+	// A pending agent-editor target (set cross-bundle by an avatar
+	// click in the Agent chat window) routes to the Agents section the
+	// same way. The section renderer — not this router — consumes and
+	// clears the target, because it needs the agent id to preselect
+	// the row and runs synchronously inside `navigate()`.
 	const footprint = readFootprintTarget();
+	const agentEditor = readAgentEditorTarget();
 	let initialRoute: Route;
 	if ( footprint.userId && footprint.userId > 0 ) {
 		initialRoute = footprintRouteFor(
@@ -6132,6 +6143,8 @@ function renderInto( body: HTMLElement ): ( () => void ) | undefined {
 			footprint.userName,
 		);
 		clearFootprintTarget();
+	} else if ( agentEditor.agentId && agentEditor.agentId > 0 ) {
+		initialRoute = { kind: 'list', entityId: AGENTS_ENTITY_ID };
 	} else {
 		initialRoute = pendingRoute ?? { kind: 'root' };
 	}
@@ -6486,6 +6499,17 @@ if ( desktopGlobal ) {
 			footprintRouteFor( next.userId, next.userName ),
 		);
 		clearFootprintTarget();
+	} );
+
+	// Warm re-target for the Agents section — same cold/warm split as
+	// the footprint above. The section renderer clears the target as
+	// it consumes it, and its own clear notifies with a null id, which
+	// this guard drops.
+	subscribeAgentEditorTarget( ( next ) => {
+		if ( ! next.agentId || next.agentId <= 0 || ! activeState ) {
+			return;
+		}
+		navigate( activeState, { kind: 'list', entityId: AGENTS_ENTITY_ID } );
 	} );
 
 	// Live-tile pruning on trash. Every live My WordPress list body

--- a/tests/phpunit/tests/agentsConversations.php
+++ b/tests/phpunit/tests/agentsConversations.php
@@ -102,6 +102,152 @@ class Tests_DesktopMode_AgentsConversations extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The list's second line reads from the END of the conversation:
+	 * the title comes from the first user message, so every chat that
+	 * starts the same way looks identical without it.
+	 *
+	 * @covers ::desktop_mode_agent_conversation_preview
+	 */
+	public function test_preview_reads_the_tail_of_the_last_message() {
+		$short = desktop_mode_agent_conversation_preview(
+			array(
+				array(
+					'role' => 'user',
+					'text' => 'Summarize post 12',
+					'at'   => 1,
+				),
+				array(
+					'role' => 'agent',
+					'text' => "Done.\n\nHere  it is.",
+					'at'   => 2,
+				),
+			)
+		);
+		// Whitespace is collapsed so a multi-line answer stays one line.
+		$this->assertSame( 'Done. Here it is.', $short );
+
+		$tail = str_repeat( 'a', 200 ) . ' and search relevance.';
+		$long = desktop_mode_agent_conversation_preview(
+			array(
+				array(
+					'role' => 'agent',
+					'text' => $tail,
+					'at'   => 1,
+				),
+			)
+		);
+		$this->assertStringStartsWith( '…', $long );
+		$this->assertStringEndsWith( 'and search relevance.', $long );
+		$this->assertSame(
+			DESKTOP_MODE_AGENT_CONVERSATION_PREVIEW_CAP + 1,
+			mb_strlen( $long )
+		);
+
+		$this->assertSame( '', desktop_mode_agent_conversation_preview( array() ) );
+	}
+
+	/**
+	 * @covers ::desktop_mode_agent_conversation_preview
+	 */
+	public function test_preview_prefers_the_attachment_title() {
+		$preview = desktop_mode_agent_conversation_preview(
+			array(
+				array(
+					'role'       => 'user',
+					'text'       => 'The user dropped the post "Hello world" (id 12) onto you.',
+					'at'         => 1,
+					'attachment' => array(
+						'kind'  => 'post',
+						'id'    => 12,
+						'title' => 'Hello world',
+					),
+				),
+			)
+		);
+		$this->assertSame( 'Hello world', $preview );
+	}
+
+	/**
+	 * A dropped / "Send to" object survives the round-trip so a
+	 * reopened conversation still renders the clickable card.
+	 *
+	 * @covers ::desktop_mode_agent_conversation_sanitize_attachment
+	 * @covers ::desktop_mode_agent_conversation_prepare
+	 */
+	public function test_attachments_round_trip_and_are_validated() {
+		$data = $this->create_conversation(
+			array(
+				array(
+					'role'       => 'user',
+					'text'       => 'Handle this one.',
+					'at'         => 1,
+					'attachment' => array(
+						'kind'  => 'media',
+						'id'    => '44',
+						'title' => '<em>Hornet</em>',
+					),
+				),
+				array(
+					'role'       => 'agent',
+					'text'       => 'Rejected — unknown kind.',
+					'at'         => 2,
+					'attachment' => array(
+						'kind'  => 'widget',
+						'id'    => 7,
+						'title' => 'Nope',
+					),
+				),
+				array(
+					'role'       => 'agent',
+					'text'       => 'Rejected — no id.',
+					'at'         => 3,
+					'attachment' => array(
+						'kind'  => 'post',
+						'id'    => 0,
+						'title' => 'Nope',
+					),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'kind'  => 'media',
+				'id'    => 44,
+				'title' => 'Hornet',
+			),
+			$data['messages'][0]['attachment']
+		);
+		$this->assertArrayNotHasKey( 'attachment', $data['messages'][1] );
+		$this->assertArrayNotHasKey( 'attachment', $data['messages'][2] );
+
+		// Titleless attachments fall back to the id so the card always
+		// has something to render.
+		$this->assertSame(
+			'#9',
+			desktop_mode_agent_conversation_sanitize_attachment(
+				array(
+					'kind' => 'user',
+					'id'   => 9,
+				)
+			)['title']
+		);
+		$this->assertNull(
+			desktop_mode_agent_conversation_sanitize_attachment( 'not-an-array' )
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_agent_conversation_prepare
+	 */
+	public function test_prepare_ships_preview_and_last_role() {
+		$data = $this->create_conversation();
+
+		$this->assertSame( 'Here is the summary.', $data['preview'] );
+		$this->assertSame( 'agent', $data['lastRole'] );
+	}
+
+	/**
 	 * @covers ::desktop_mode_agents_rest_conversations_create
 	 */
 	public function test_create_rejects_non_agent_target() {

--- a/tests/vitest/agent-run-window.test.ts
+++ b/tests/vitest/agent-run-window.test.ts
@@ -9,6 +9,10 @@ import {
 	agentsChatStore,
 	openAgentChat,
 } from '../../src/agents-chat-store';
+import {
+	agentEditorTarget,
+	clearAgentEditorTarget,
+} from '../../src/agents-editor-target';
 
 const WINDOW_ID = 'desktop-mode-agent-run';
 
@@ -154,7 +158,7 @@ describe( 'agent chat window', () => {
 		}
 	} );
 
-	test( 'rows carry avatars, agent markdown renders, and New chat resets', () => {
+	test( 'rows carry avatars, agent markdown renders, and New chat resets', async () => {
 		const body = makeBody();
 		const cleanup = getRender()( body );
 		openAgentChat( {
@@ -170,11 +174,18 @@ describe( 'agent chat window', () => {
 		agentsChatStore.notify();
 
 		// WhatsApp-style: agent avatar left row, viewer avatar from the
-		// window config on the user row.
+		// window config on the user row. `<wpd-avatar>` rather than a
+		// bare `<img>` so a Gravatar-less viewer gets initials instead
+		// of the mystery-person silhouette — the URL lands on the
+		// element once the resolver's probe settles.
+		await flush();
 		const agentAvatar = body.querySelector(
 			'.dm-agent-chat__line--agent .dm-agent-chat__msg-avatar',
-		) as HTMLImageElement;
-		expect( agentAvatar?.src ).toBe( 'https://example.test/agent.svg' );
+		) as HTMLElement;
+		expect( agentAvatar?.tagName.toLowerCase() ).toBe( 'wpd-avatar' );
+		expect( agentAvatar?.getAttribute( 'src' ) ).toBe(
+			'https://example.test/agent.svg',
+		);
 		expect(
 			body.querySelector(
 				'.dm-agent-chat__line--user .dm-agent-chat__msg-avatar',
@@ -468,6 +479,8 @@ describe( 'agent chat window', () => {
 			agentDescription: 'Remembers things.',
 			agentAvatarUrl: 'https://example.test/bot.svg',
 			title: 'Summarize post 12',
+			preview: '…and search relevance.',
+			lastRole: 'agent',
 			messageCount: 2,
 			createdAt: '2026-07-30T10:00:00Z',
 			updatedAt: '2026-07-30T10:05:00Z',
@@ -506,10 +519,24 @@ describe( 'agent chat window', () => {
 		const cleanup = getRender()( body );
 		await flush();
 
-		// The list paints even with no active agent.
+		// The list paints even with no active agent. Two lines: who the
+		// conversation is with, and where it got to — NOT the title,
+		// which repeats across every conversation that opens the same
+		// way. The title stays as the row tooltip.
 		const row = body.querySelector< HTMLElement >( '.dm-agent-chat__conv' );
 		expect( row ).not.toBeNull();
-		expect( row!.textContent ).toContain( 'Summarize post 12' );
+		expect(
+			row!.querySelector( '.dm-agent-chat__conv-name' )!.textContent,
+		).toBe( 'Historian' );
+		expect(
+			row!.querySelector( '.dm-agent-chat__conv-preview' )!.textContent,
+		).toBe( '…and search relevance.' );
+		const time = row!.querySelector< HTMLTimeElement >(
+			'.dm-agent-chat__conv-time',
+		)!;
+		expect( time.dateTime ).toBe( '2026-07-30T10:05:00Z' );
+		expect( time.textContent ).not.toBe( '' );
+		expect( row!.title ).toContain( 'Summarize post 12' );
 
 		row!.click();
 		await flush();
@@ -522,6 +549,119 @@ describe( 'agent chat window', () => {
 
 		if ( typeof cleanup === 'function' ) {
 			cleanup();
+		}
+	} );
+
+	test( 'clicking a conversation avatar opens the agent editor, not the conversation', async () => {
+		const summary = {
+			id: 77,
+			agentId: 9,
+			agentName: 'Historian',
+			agentDescription: 'Remembers things.',
+			agentAvatarUrl: 'https://example.test/bot.svg',
+			title: 'Summarize post 12',
+			preview: 'Done.',
+			lastRole: 'agent',
+			messageCount: 2,
+			createdAt: '2026-07-30T10:00:00Z',
+			updatedAt: '2026-07-30T10:05:00Z',
+		};
+		const fetchMock: FetchMock = vi.fn( async ( input: unknown ) => ( {
+			ok: true,
+			status: 200,
+			json: async () =>
+				String( input ).endsWith( '/agents/conversations' )
+					? [ summary ]
+					: {},
+		} ) as unknown as Response );
+		( globalThis as unknown as { fetch: FetchMock } ).fetch = fetchMock;
+
+		const openWindow = vi.fn( () => true );
+		( window as unknown as Record< string, unknown > ).wp = {
+			desktop: { openWindow },
+		};
+
+		try {
+			const body = makeBody();
+			const cleanup = getRender()( body );
+			await flush();
+
+			const avatar = body.querySelector< HTMLElement >(
+				'.dm-agent-chat__conv-avatar',
+			)!;
+			expect( avatar.hasAttribute( 'clickable' ) ).toBe( true );
+			avatar.click();
+			await flush();
+
+			expect( openWindow ).toHaveBeenCalledWith(
+				'desktop-mode-my-wordpress',
+				{ source: 'agents/editor' },
+			);
+			expect( agentEditorTarget.state.agentId ).toBe( 9 );
+			// The row's own click handler must NOT have run — the
+			// conversation stays closed.
+			expect( agentsChatStore.state.activeAgent ).toBeNull();
+
+			if ( typeof cleanup === 'function' ) {
+				cleanup();
+			}
+		} finally {
+			clearAgentEditorTarget();
+			delete ( window as unknown as Record< string, unknown > ).wp;
+		}
+	} );
+
+	test( 'a message attachment renders as a card that opens the object', () => {
+		const open = vi.fn();
+		( window as unknown as Record< string, unknown > ).wp = {
+			desktop: {
+				config: { adminUrl: 'https://example.test/wp-admin/' },
+				deriveWindowId: () => 'post-php-188',
+				windowManager: { open },
+			},
+		};
+
+		try {
+			const body = makeBody();
+			const cleanup = getRender()( body );
+			openAgentChat( {
+				id: 5,
+				name: 'Audit Agent',
+				description: '',
+				avatarUrl: 'data:image/svg+xml;base64,x',
+			} );
+			agentsChatStore.state.transcripts[ 5 ] = [
+				{
+					role: 'user',
+					text: 'The user dropped the post "Hello world" (id 188) onto you.',
+					at: 1,
+					attachment: { kind: 'post', id: 188, title: 'Hello world' },
+				},
+			];
+			agentsChatStore.notify();
+
+			const card = body.querySelector< HTMLElement >(
+				'.dm-agent-chat__attachment',
+			)!;
+			expect( card ).not.toBeNull();
+			expect( card.textContent ).toContain( 'Hello world' );
+			// The runner-facing sentence is replaced by the card.
+			expect( body.textContent ).not.toContain( 'The user dropped' );
+
+			card.click();
+			expect( open ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					id: 'post-php-188',
+					url: 'https://example.test/wp-admin/post.php?post=188&action=edit',
+					title: 'Hello world',
+				} ),
+			);
+
+			if ( typeof cleanup === 'function' ) {
+				cleanup();
+			}
+		} finally {
+			delete ( window as unknown as Record< string, unknown > ).wp;
 		}
 	} );
 

--- a/tests/vitest/agents-dispatch.test.ts
+++ b/tests/vitest/agents-dispatch.test.ts
@@ -175,6 +175,13 @@ describe( 'dispatchAgentDrop', () => {
 		const transcript = agentsChatStore.state.transcripts[ 9 ];
 		expect( transcript ).toHaveLength( 2 );
 		expect( transcript[ 0 ].role ).toBe( 'user' );
+		// The dropped object rides the row so the chat can render it as
+		// a card the user can open — the runner still gets the prose.
+		expect( transcript[ 0 ].attachment ).toEqual( {
+			kind: 'media',
+			id: 44,
+			title: 'Hornet',
+		} );
 		expect( transcript[ 1 ].role ).toBe( 'agent' );
 		expect( transcript[ 1 ].text ).toBe( 'Done, new attachment 99.' );
 		expect( transcript[ 1 ].pending ).toBe( false );


### PR DESCRIPTION
Chat window:

- Conversation rows are two lines — agent name + the **tail** of the last message — with a timestamp. The title (first user message) moves to the tooltip; it repeated across every conversation that opened the same way.
- The header avatar and the sidebar row avatars open the agent in My WordPress.
- The viewer's avatar goes through `<wpd-avatar>` + the Gravatar probe, so a Gravatar-less user gets initials instead of the mystery-person silhouette.
- An object sent to an agent (drop or "Send to") renders as a clickable card that opens it in its own window, instead of the runner-facing boilerplate sentence. Persisted with the conversation.

Agents section:

- "Create agent" moves above the list (it used to be the last row of a scrolling column).
- The detail verbs get their own row under the name, and gain **View contributions** → the GitHub-style footprint.
- Role is a dropdown when editing an agent, not a free-text field.
- The Tools/Triggers loading spinner is big and centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-465-4d762aef788305cf567f809dad7b26a3a99d8149.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20Desktop%20Mode%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;desktop_mode_is_enabled&#039;%20)%20%7C%7C%20!%20desktop_mode_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;desktop-mode&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.desktop.ready(function()%7Bvar%20games%3Dwindow.wp.desktop.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.desktop.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.desktop.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->