### PR TITLE
fix(agents): provider robustness — OpenAI strict schema, Anthropic refusals, retries, real request timeout

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -4231,7 +4231,10 @@ Pre-filter for one generation turn. Return a non-null
 `{ text, function_calls, message }` array (or a `WP_Error`) to
 short-circuit the Core AI Client — the seam PHPUnit and alternative
 runtimes plug into. When any callback is attached, the runner
-considers itself available even without the WP 7.0 AI Client.
+considers itself available even without the WP 7.0 AI Client. On a
+transient provider failure (a gateway 5xx, a timeout, an empty
+Anthropic `content`, a failed models-list fetch) the loop retries the
+turn once, so the filter can be invoked twice for the same turn.
 
 - **Param** `array|WP_Error|null $generated` — null to proceed with the AI Client.
 - **Param** `array $history` — neutral history rows (`{ type: 'user_text'|'assistant'|'tool_results', … }`).

--- a/includes/agents/runner.php
+++ b/includes/agents/runner.php
@@ -503,15 +503,15 @@ function desktop_mode_agent_runner_loop( $agent_user_id, $instructions, $message
 	for ( $turn = 1; $turn <= DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS; $turn++ ) {
 		$generated = desktop_mode_agent_runner_generate( $agent_user_id, $history, $tool_defs, $instructions );
 		if ( is_wp_error( $generated ) && desktop_mode_agent_generate_error_is_transient( $generated ) ) {
-			// One bounded retry for provider-side flaps (an Anthropic
-			// 2xx with an empty `content`, a failed models-list fetch,
-			// a gateway timeout). Each of these resolves on a fresh
-			// request far more often than not — a manual "try again"
-			// was already the working recovery, so automate it once.
+			// One bounded retry for provider-side hiccups (a failed
+			// models-list fetch, a gateway timeout, a borderline
+			// refusal). A manual "try again" was already the working
+			// recovery for the flaky ones — automate it once, never
+			// loop.
 			$generated = desktop_mode_agent_runner_generate( $agent_user_id, $history, $tool_defs, $instructions );
 		}
 		if ( is_wp_error( $generated ) ) {
-			return $generated;
+			return desktop_mode_agent_humanize_generate_error( $generated );
 		}
 
 		$function_calls = isset( $generated['function_calls'] ) && is_array( $generated['function_calls'] )
@@ -825,11 +825,17 @@ function desktop_mode_agent_parse_answer( $text ) {
  * rejects (an invalid schema, a too-large prompt, a bad key).
  *
  * The signatures are message-based because the AI Client SDK surfaces
- * provider exceptions as text: the Anthropic provider throws
+ * provider exceptions as text: the model finder reports "No models
+ * found …" when a provider's models-list fetch failed, gateway errors
+ * arrive as "… (502/503/504)", and the Anthropic provider throws
  * "Unexpected Anthropic API response: Missing the "content" key." for
- * a 2xx whose `content` is empty, the model finder reports "No models
- * found …" when a provider's models-list fetch failed, and gateway
- * errors arrive as "… (502/503/504)".
+ * a 2xx whose `content` array is empty. The last one is usually a
+ * model REFUSAL (`stop_reason: "refusal"` — the provider crashes on
+ * the empty content before reaching its own refusal handling), which
+ * a retry rarely changes; it stays in the list because borderline
+ * refusals are stochastic and one extra request is cheap, and
+ * {@see desktop_mode_agent_humanize_generate_error()} explains the
+ * failure when the retry doesn't help.
  *
  * @param WP_Error $error Failed generation.
  * @return bool
@@ -838,7 +844,7 @@ function desktop_mode_agent_generate_error_is_transient( WP_Error $error ) {
 	$message = $error->get_error_message();
 
 	$signatures = array(
-		'Missing the "content" key', // Anthropic 2xx, empty content array.
+		'Missing the "content" key', // Anthropic refusal surfaced as a parse error.
 		'No models found',           // Provider models-list fetch flapped.
 		'cURL error 28',             // Transport timeout.
 		'Operation timed out',
@@ -851,6 +857,33 @@ function desktop_mode_agent_generate_error_is_transient( WP_Error $error ) {
 
 	// Provider/gateway 5xx — the SDK formats statuses like "(504)".
 	return (bool) preg_match( '/\(50[0-9]\)/', $message );
+}
+
+/**
+ * Translate known-cryptic provider failures into something a user can
+ * act on. The Anthropic provider reports a model refusal
+ * (`stop_reason: "refusal"`, empty `content` array) as a parse error —
+ * "Missing the "content" key" — which reads like a plugin bug when it
+ * actually means the model's safety system declined the request
+ * (observed live: a translation request refused with
+ * `stop_details.category: "bio"` over innocuous demo content). The
+ * original message is preserved in the error data.
+ *
+ * @param WP_Error $error Failed generation.
+ * @return WP_Error
+ */
+function desktop_mode_agent_humanize_generate_error( WP_Error $error ) {
+	if ( false !== stripos( $error->get_error_message(), 'Missing the "content" key' ) ) {
+		return new WP_Error(
+			'desktop_mode_agent_provider_refusal',
+			__( 'The AI provider returned an empty answer — its safety system most likely declined this request. Rephrase and try again, or switch the provider in Settings → Connectors.', 'desktop-mode' ),
+			array(
+				'status' => 502,
+				'detail' => $error->get_error_message(),
+			)
+		);
+	}
+	return $error;
 }
 
 /**
@@ -950,16 +983,32 @@ function desktop_mode_agent_with_http_timeout( callable $callback ) {
 	$raise = static function ( $current ) use ( $timeout ) {
 		return max( (int) $current, $timeout );
 	};
+	$raise_float = static function ( $current ) use ( $timeout ) {
+		return max( (float) $current, (float) $timeout );
+	};
 
 	// Last, so it sees whatever the site settled on — and because it
 	// only raises, running last cannot undo another plugin's larger
 	// value.
+	//
+	// BOTH filters matter. `http_request_timeout` covers transports
+	// that fall back to the WordPress default, but Core's
+	// `WP_AI_Client_Prompt_Builder` constructor pins an EXPLICIT
+	// 30-second timeout via the SDK's `RequestOptions`, which reaches
+	// the transport directly and bypasses the WordPress default
+	// entirely ("cURL error 28: Operation timed out after 30007
+	// milliseconds"). Its own `wp_ai_client_default_request_timeout`
+	// filter runs inside `wp_ai_client_prompt()` — i.e. inside the
+	// callback below — so raising it here is scoped exactly like the
+	// generic one.
 	add_filter( 'http_request_timeout', $raise, PHP_INT_MAX );
+	add_filter( 'wp_ai_client_default_request_timeout', $raise_float, PHP_INT_MAX );
 
 	try {
 		return $callback();
 	} finally {
 		remove_filter( 'http_request_timeout', $raise, PHP_INT_MAX );
+		remove_filter( 'wp_ai_client_default_request_timeout', $raise_float, PHP_INT_MAX );
 	}
 }
 

--- a/includes/agents/runner.php
+++ b/includes/agents/runner.php
@@ -644,11 +644,16 @@ function desktop_mode_agent_answer_schema() {
 							'description' => 'The literal message sent back as the user\'s answer when this button is pressed.',
 						),
 					),
-					'required'             => array( 'id', 'label', 'reply' ),
+					// Strict structured output: `required` must list
+					// EVERY property — optional fields don't exist in
+					// strict mode. The sanitizer still defaults a
+					// bad/missing style to `secondary` for lenient
+					// (pre-filter / non-strict) answers.
+					'required'             => array( 'id', 'label', 'style', 'reply' ),
 				),
 			),
 		),
-		'required'             => array( 'text' ),
+		'required'             => array( 'text', 'call_to_actions' ),
 	);
 }
 

--- a/includes/agents/runner.php
+++ b/includes/agents/runner.php
@@ -502,6 +502,14 @@ function desktop_mode_agent_runner_loop( $agent_user_id, $instructions, $message
 
 	for ( $turn = 1; $turn <= DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS; $turn++ ) {
 		$generated = desktop_mode_agent_runner_generate( $agent_user_id, $history, $tool_defs, $instructions );
+		if ( is_wp_error( $generated ) && desktop_mode_agent_generate_error_is_transient( $generated ) ) {
+			// One bounded retry for provider-side flaps (an Anthropic
+			// 2xx with an empty `content`, a failed models-list fetch,
+			// a gateway timeout). Each of these resolves on a fresh
+			// request far more often than not — a manual "try again"
+			// was already the working recovery, so automate it once.
+			$generated = desktop_mode_agent_runner_generate( $agent_user_id, $history, $tool_defs, $instructions );
+		}
 		if ( is_wp_error( $generated ) ) {
 			return $generated;
 		}
@@ -587,6 +595,28 @@ function desktop_mode_agent_runner_loop( $agent_user_id, $instructions, $message
 		$history[] = array(
 			'type'    => 'tool_results',
 			'results' => $results,
+		);
+	}
+
+	// Cap reached with the model still asking for tools. Force one
+	// last TOOL-LESS generate over the transcript so far: with nothing
+	// to call, the model can only produce a final answer from what it
+	// already gathered. A best-effort summary beats discarding the
+	// whole run (observed on Anthropic: a model happily spends the cap
+	// re-searching before it answers).
+	$generated = desktop_mode_agent_runner_generate( $agent_user_id, $history, array(), $instructions );
+	if ( is_wp_error( $generated ) && desktop_mode_agent_generate_error_is_transient( $generated ) ) {
+		$generated = desktop_mode_agent_runner_generate( $agent_user_id, $history, array(), $instructions );
+	}
+	if ( ! is_wp_error( $generated )
+		&& empty( $generated['function_calls'] )
+		&& isset( $generated['text'] ) && is_string( $generated['text'] ) && '' !== trim( $generated['text'] ) ) {
+		$answer = desktop_mode_agent_parse_answer( $generated['text'] );
+		return array(
+			'text'          => $answer['text'],
+			'callToActions' => $answer['callToActions'],
+			'toolCalls'     => $tool_trace,
+			'turns'         => DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS + 1,
 		);
 	}
 
@@ -790,6 +820,40 @@ function desktop_mode_agent_parse_answer( $text ) {
 }
 
 /**
+ * Whether a failed generation looks like a one-off provider flap worth
+ * retrying, as opposed to a request the provider deterministically
+ * rejects (an invalid schema, a too-large prompt, a bad key).
+ *
+ * The signatures are message-based because the AI Client SDK surfaces
+ * provider exceptions as text: the Anthropic provider throws
+ * "Unexpected Anthropic API response: Missing the "content" key." for
+ * a 2xx whose `content` is empty, the model finder reports "No models
+ * found …" when a provider's models-list fetch failed, and gateway
+ * errors arrive as "… (502/503/504)".
+ *
+ * @param WP_Error $error Failed generation.
+ * @return bool
+ */
+function desktop_mode_agent_generate_error_is_transient( WP_Error $error ) {
+	$message = $error->get_error_message();
+
+	$signatures = array(
+		'Missing the "content" key', // Anthropic 2xx, empty content array.
+		'No models found',           // Provider models-list fetch flapped.
+		'cURL error 28',             // Transport timeout.
+		'Operation timed out',
+	);
+	foreach ( $signatures as $signature ) {
+		if ( false !== stripos( $message, $signature ) ) {
+			return true;
+		}
+	}
+
+	// Provider/gateway 5xx — the SDK formats statuses like "(504)".
+	return (bool) preg_match( '/\(50[0-9]\)/', $message );
+}
+
+/**
  * One generate turn: pre-filter first (tests / alternative runtimes),
  * then the Core AI Client via the Copilot's adapter.
  *
@@ -806,7 +870,10 @@ function desktop_mode_agent_runner_generate( $agent_user_id, array $history, arr
 	 * Pre-filter one generation turn. Return a non-null
 	 * `{ text, function_calls, message }` array (or a WP_Error) to
 	 * short-circuit the Core AI Client — the seam PHPUnit and
-	 * alternative runtimes plug into.
+	 * alternative runtimes plug into. On a transient provider failure
+	 * (see {@see desktop_mode_agent_generate_error_is_transient()}) the
+	 * loop retries the turn once, so the filter can be invoked twice
+	 * for the same turn.
 	 *
 	 * @param array|WP_Error|null $generated     Null to proceed with the AI Client.
 	 * @param array               $history       Neutral history rows.

--- a/includes/ai-copilot/schema.php
+++ b/includes/ai-copilot/schema.php
@@ -55,6 +55,15 @@ defined( 'ABSPATH' ) || exit;
 function desktop_mode_ai_normalize_response_schema( array $schema ) {
 	if ( desktop_mode_ai_schema_is_object_node( $schema ) ) {
 		$schema['additionalProperties'] = false;
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) && array() !== $schema['properties'] ) {
+			// Strict structured output (OpenAI `strict: true`) also
+			// demands that `required` lists EVERY key in `properties` —
+			// optional fields do not exist in strict mode, and one
+			// missing key 400s the whole request ("'required' is
+			// required to be supplied and to be an array including
+			// every key in properties").
+			$schema['required'] = array_keys( $schema['properties'] );
+		}
 	}
 
 	foreach ( array( 'properties', 'patternProperties', '$defs', 'definitions' ) as $map_key ) {

--- a/tests/phpunit/tests/agentsRunner.php
+++ b/tests/phpunit/tests/agentsRunner.php
@@ -569,7 +569,51 @@ class Tests_DesktopMode_AgentsRunner extends WP_UnitTestCase {
 		$result = desktop_mode_agent_invoke( $agent->ID, 'loop' );
 		$this->assertWPError( $result );
 		$this->assertSame( 'desktop_mode_agent_runner_max_turns', $result->get_error_code() );
-		$this->assertSame( DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS, $calls );
+		// Cap turns + the forced tool-less attempt (which here still
+		// "called a tool", so the error is preserved).
+		$this->assertSame( DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS + 1, $calls );
+	}
+
+	/**
+	 * When the cap is hit, one forced TOOL-LESS generate turns the
+	 * transcript into a best-effort final answer instead of an error.
+	 *
+	 * @covers ::desktop_mode_agent_runner_loop
+	 */
+	public function test_turn_cap_forces_a_final_toolless_answer() {
+		$agent = $this->create_agent();
+		$calls          = 0;
+		$forced_tools   = null;
+		$this->stub_generate(
+			static function ( $ignored, $history, $tool_defs ) use ( &$calls, &$forced_tools ) {
+				++$calls;
+				if ( $calls <= DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS ) {
+					return array(
+						'text'           => null,
+						'function_calls' => array(
+							array(
+								'name'      => 'never_registered',
+								'call_id'   => 'call-' . $calls,
+								'arguments' => '{}',
+							),
+						),
+						'message'        => null,
+					);
+				}
+				$forced_tools = $tool_defs;
+				return array(
+					'text'           => 'Best effort from what I gathered.',
+					'function_calls' => array(),
+					'message'        => null,
+				);
+			}
+		);
+
+		$result = desktop_mode_agent_invoke( $agent->ID, 'loop' );
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'Best effort from what I gathered.', $result['text'] );
+		$this->assertSame( DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS + 1, $result['turns'] );
+		$this->assertSame( array(), $forced_tools, 'The forced final turn must advertise no tools.' );
 	}
 
 	/**
@@ -818,5 +862,115 @@ class Tests_DesktopMode_AgentsRunner extends WP_UnitTestCase {
 
 		$this->assertNotWPError( $result );
 		$this->assertSame( 5, $during );
+	}
+
+	/**
+	 * @covers ::desktop_mode_agent_generate_error_is_transient
+	 */
+	public function test_transient_error_detection() {
+		$transient = array(
+			'Unexpected Anthropic API response: Missing the "content" key.',
+			'No models found that support text_generation for this prompt.',
+			'Gateway Timeout (504) - upstream timed out',
+			'cURL error 28: Operation timed out after 180001 milliseconds',
+		);
+		foreach ( $transient as $message ) {
+			$this->assertTrue(
+				desktop_mode_agent_generate_error_is_transient( new WP_Error( 'e', $message ) ),
+				"Should be transient: {$message}"
+			);
+		}
+
+		$permanent = array(
+			"Bad Request (400) - Invalid schema for response_format 'response_schema'.",
+			'Message must be a non-empty string.',
+			'This agent reached its hourly invocation limit.',
+		);
+		foreach ( $permanent as $message ) {
+			$this->assertFalse(
+				desktop_mode_agent_generate_error_is_transient( new WP_Error( 'e', $message ) ),
+				"Should be permanent: {$message}"
+			);
+		}
+	}
+
+	/**
+	 * A transient generate failure is retried once — the flap the user
+	 * recovered from by typing "Can you try again?" heals silently.
+	 *
+	 * @covers ::desktop_mode_agent_invoke
+	 */
+	public function test_transient_generate_failure_is_retried_once() {
+		$agent = $this->create_agent();
+		$calls = 0;
+		$this->stub_generate(
+			static function () use ( &$calls ) {
+				$calls++;
+				if ( 1 === $calls ) {
+					return new WP_Error(
+						'desktop_mode_ai_error',
+						'Unexpected Anthropic API response: Missing the "content" key.'
+					);
+				}
+				return array(
+					'text'           => 'Recovered.',
+					'function_calls' => array(),
+					'message'        => null,
+				);
+			}
+		);
+
+		$result = desktop_mode_agent_invoke( $agent->ID, 'Say hi.' );
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'Recovered.', $result['text'] );
+		$this->assertSame( 2, $calls );
+	}
+
+	/**
+	 * Deterministic rejections are NOT retried — a schema the provider
+	 * rejects would fail identically and only add latency and spend.
+	 *
+	 * @covers ::desktop_mode_agent_invoke
+	 */
+	public function test_permanent_generate_failure_is_not_retried() {
+		$agent = $this->create_agent();
+		$calls = 0;
+		$this->stub_generate(
+			static function () use ( &$calls ) {
+				$calls++;
+				return new WP_Error(
+					'desktop_mode_ai_error',
+					"Bad Request (400) - Invalid schema for response_format 'response_schema'."
+				);
+			}
+		);
+
+		$result = desktop_mode_agent_invoke( $agent->ID, 'Say hi.' );
+		$this->assertWPError( $result );
+		$this->assertSame( 1, $calls );
+	}
+
+	/**
+	 * A flap that persists through the retry still surfaces as an error
+	 * — exactly one retry, never a loop.
+	 *
+	 * @covers ::desktop_mode_agent_invoke
+	 */
+	public function test_persistent_transient_failure_surfaces_after_one_retry() {
+		$agent = $this->create_agent();
+		$calls = 0;
+		$this->stub_generate(
+			static function () use ( &$calls ) {
+				$calls++;
+				return new WP_Error(
+					'desktop_mode_ai_error',
+					'Gateway Timeout (504) - upstream timed out'
+				);
+			}
+		);
+
+		$result = desktop_mode_agent_invoke( $agent->ID, 'Say hi.' );
+		$this->assertWPError( $result );
+		$this->assertSame( 2, $calls );
 	}
 }

--- a/tests/phpunit/tests/agentsRunner.php
+++ b/tests/phpunit/tests/agentsRunner.php
@@ -765,6 +765,28 @@ class Tests_DesktopMode_AgentsRunner extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The AI Client pins an EXPLICIT 30s timeout via `RequestOptions`
+	 * in the `WP_AI_Client_Prompt_Builder` constructor, bypassing the
+	 * WordPress HTTP default entirely — the wrapper must raise its
+	 * `wp_ai_client_default_request_timeout` filter too, or long
+	 * generations die at 30s ("timed out after 30007 milliseconds").
+	 *
+	 * @covers ::desktop_mode_agent_with_http_timeout
+	 */
+	public function test_ai_client_request_timeout_is_raised_too() {
+		$seen = null;
+		desktop_mode_agent_with_http_timeout(
+			static function () use ( &$seen ) {
+				$seen = apply_filters( 'wp_ai_client_default_request_timeout', 30.0 );
+			}
+		);
+
+		$this->assertSame( (float) DESKTOP_MODE_AGENT_HTTP_TIMEOUT, $seen );
+		// Released afterwards, like the generic filter.
+		$this->assertSame( 30.0, apply_filters( 'wp_ai_client_default_request_timeout', 30.0 ) );
+	}
+
+	/**
 	 * Released afterwards — an agent run must not widen the timeout for
 	 * unrelated requests later in the same page load.
 	 *
@@ -948,6 +970,32 @@ class Tests_DesktopMode_AgentsRunner extends WP_UnitTestCase {
 		$result = desktop_mode_agent_invoke( $agent->ID, 'Say hi.' );
 		$this->assertWPError( $result );
 		$this->assertSame( 1, $calls );
+	}
+
+	/**
+	 * A provider refusal (surfaced by the Anthropic plugin as the
+	 * cryptic missing-content parse error) is translated into an
+	 * actionable message once the retry doesn't help.
+	 *
+	 * @covers ::desktop_mode_agent_humanize_generate_error
+	 */
+	public function test_refusal_is_translated_for_the_user() {
+		$agent = $this->create_agent();
+		$this->stub_generate(
+			static function () {
+				return new WP_Error(
+					'desktop_mode_ai_error',
+					'Unexpected Anthropic API response: Missing the "content" key.'
+				);
+			}
+		);
+
+		$result = desktop_mode_agent_invoke( $agent->ID, 'Translate this.' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'desktop_mode_agent_provider_refusal', $result->get_error_code() );
+		$this->assertStringContainsString( 'safety system', $result->get_error_message() );
+		// The provider's original message survives for debugging.
+		$this->assertStringContainsString( 'Missing the "content" key', $result->get_error_data()['detail'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/aiResponseSchemaNormalization.php
+++ b/tests/phpunit/tests/aiResponseSchemaNormalization.php
@@ -288,7 +288,51 @@ class Tests_DesktopMode_AiResponseSchemaNormalization extends WP_UnitTestCase {
 
 		$this->assertFalse( $schema['additionalProperties'] );
 		$this->assertFalse( $schema['properties']['call_to_actions']['items']['additionalProperties'] );
+		// OpenAI strict mode: `required` must list EVERY property.
+		// `style` missing from the items' required (and call_to_actions
+		// from the root's) was the second 400 after additionalProperties.
+		$this->assertSame(
+			array_keys( $schema['properties'] ),
+			$schema['required']
+		);
+		$items = $schema['properties']['call_to_actions']['items'];
+		$this->assertSame( array_keys( $items['properties'] ), $items['required'] );
 		$this->assertSame( $schema, desktop_mode_ai_normalize_response_schema( $schema ) );
+	}
+
+	/**
+	 * A partial `required` list is repaired to cover every property —
+	 * strict mode has no optional fields ("'required' is required to be
+	 * supplied and to be an array including every key in properties").
+	 *
+	 * @covers ::desktop_mode_ai_normalize_response_schema
+	 */
+	public function test_partial_required_is_repaired() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'text'  => array( 'type' => 'string' ),
+				'items' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'label' => array( 'type' => 'string' ),
+							'style' => array( 'type' => 'string' ),
+						),
+						'required'   => array( 'label' ),
+					),
+				),
+			),
+			'required'   => array( 'text' ),
+		);
+
+		$normalized = desktop_mode_ai_normalize_response_schema( $schema );
+		$this->assertSame( array( 'text', 'items' ), $normalized['required'] );
+		$this->assertSame(
+			array( 'label', 'style' ),
+			$normalized['properties']['items']['items']['required']
+		);
 	}
 
 	/**


### PR DESCRIPTION
Stacked on #466.

## Testing 
<img width="2402" height="1726" alt="CleanShot 2026-07-31 at 19 09 57@2x" src="https://github.com/user-attachments/assets/8bc4ce3a-4ba6-4a76-944d-a45674317624" />


## What it does

Fixes four provider failures hit while testing #466:

1. The 400 every agent chat hit on the OpenAI connector (below).
2. `Unexpected Anthropic API response: Missing the "content" key.` — a model REFUSAL the Anthropic provider plugin crashes on before its own refusal handling.
3. `Agent stopped after 8 turns without a final answer.` — the model spending the whole turn cap on tool calls.
4. `cURL error 28: Operation timed out after 30007 milliseconds` — the AI Client's own 30-second request timeout, which #466's `http_request_timeout` raise cannot reach.

### OpenAI: strict structured output 400

> Bad Request (400) - Invalid schema for response_format 'response_schema': In context=('properties', 'call_to_actions', 'items'), 'required' is required to be supplied and to be an array including every key in properties. Missing 'style'.

## Rationale

The OpenAI provider sends the answer schema verbatim with `strict: true`, and strict structured output has **no optional fields**: every key in `properties` must also appear in `required`. The agent answer schema listed `style` as optional in the call-to-action items (and `call_to_actions` as optional at the root), which OpenAI rejects before generating anything. #466 already covered the other strict rule (`additionalProperties: false`) and fixed the Copilot/drafts schemas; the agent answer schema's `required` lists were the remaining gap.

## Implementation

- `desktop_mode_agent_answer_schema()` declares full `required` lists: `[id, label, style, reply]` on the items, `[text, call_to_actions]` at the root. The lenient parse/sanitize path is untouched — a bad or missing `style` still defaults to `secondary` for pre-filter runtimes and non-strict providers.
- `desktop_mode_ai_normalize_response_schema()` (the safety net #466 introduced for `additionalProperties`) now also repairs partial `required` lists in the same recursive walk, so a plugin-filtered schema addition cannot reintroduce the 400. Provider-safe: Google's provider already strips response-schema keys its API rejects.

## Testing instructions

```bash
npm run test:php -- --filter='Tests_DesktopMode_AiResponseSchemaNormalization'   # 16 tests
```

Manual, with only the OpenAI provider plugin active (deactivate the Google/Anthropic providers to force routing): chat with any agent asking for a proposal that needs approval. Before this fix the answer is the 400 above; after, a structured answer arrives with working call-to-action buttons. Verified live against the OpenAI connector.

## Anthropic: refusal handling, retry, forced final answer, real timeout

All reproduced live with only the Anthropic provider active. A raw-body trace of the failing "Missing content" case settled what it actually is:

```
TURN: status=200 stop=refusal content=[]
BODY: {"model":"claude-sonnet-5", ..., "content":[], "stop_reason":"refusal",
       "stop_details":{"type":"refusal","category":"bio", ...}}
```

A model **refusal** (a safety-classifier false positive over innocuous demo content), returned as a 200 with an empty `content` array — which the provider plugin throws on ("Missing the "content" key") before reaching its own `refusal` handling. Not a flap: retries usually reproduce it.

- **Refusal translation**: `desktop_mode_agent_humanize_generate_error()` maps that parse error to an actionable message ("its safety system most likely declined this request — rephrase, or switch the provider in Settings → Connectors"), preserving the provider's original text in the error data.
- **Bounded retry**: one retry per generate turn for transient signatures — a failed models-list fetch (`No models found …`), gateway 5xx, transport timeouts, and the empty-content case (kept because borderline refusals are stochastic and one request is cheap). `desktop_mode_agent_generate_error_is_transient()` is the pure, unit-tested classifier; deterministic rejections (schema 400s, rate limits) are never retried.
- **Forced final answer at the turn cap**: when the model spends all `DESKTOP_MODE_AGENT_RUNNER_MAX_TURNS` turns calling tools, the runner makes one last TOOL-LESS generate over the transcript — with nothing to call, the model can only answer from what it already gathered. Falls back to the original max-turns error if even that fails; `turns` reports `MAX + 1`. The `desktop_mode_agent_runner_generate` filter doc notes it can now be invoked more than once per turn.
- **The 30s timeout**: Core's `WP_AI_Client_Prompt_Builder` constructor pins an explicit 30-second timeout via the SDK's `RequestOptions`, bypassing the WordPress HTTP default that #466's wrapper raises — hence "timed out after 30007 milliseconds" despite the 180s allowance. The wrapper now also raises Core's `wp_ai_client_default_request_timeout` filter, with identical raise-only + `finally`-removal scoping.

Verified live with only the Anthropic provider active: the question that produced the 8-turn error now completes (turns 7 and 8 across runs), and a refused translation request surfaces the explained refusal instead of the parse error.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fdesktop-mode%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-467-bf378bde0879dbd0abc764ef582cab3eaa6c8f12.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20Desktop%20Mode%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;desktop_mode_is_enabled&#039;%20)%20%7C%7C%20!%20desktop_mode_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;desktop-mode&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.desktop.ready(function()%7Bvar%20games%3Dwindow.wp.desktop.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.desktop.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.desktop.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->

