### PR TITLE
Add embedded web bookmarks

### DIFF
--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -45,7 +45,8 @@
 	}
 }
 
-[ data-files-drop-active ] {
+[ data-files-drop-active ],
+[ data-desktop-mode-url-drop-active ] {
 	position: relative;
 	outline: 3px dashed var( --wp-admin-theme-color, #2271b1 );
 	outline-offset: -8px;
@@ -79,7 +80,8 @@
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-	[ data-files-drop-active ] {
+	[ data-files-drop-active ],
+	[ data-desktop-mode-url-drop-active ] {
 		animation: none;
 	}
 }
@@ -535,6 +537,67 @@
 	height: 48px;
 	font-size: 32px;
 	line-height: 1;
+}
+
+/*
+ * Web favicons are normally 16–32 px. Stretching them to the standard 48 px
+ * tile well makes them soft; leaving them bare makes the whole bookmark read
+ * undersized beside folders and apps. The monitor supplies the desktop-scale
+ * silhouette while the artwork stays at its intrinsic size (capped at 24 px).
+ */
+.desktop-mode-file-tile__visual--favicon {
+	position: relative;
+	box-sizing: border-box;
+	padding-bottom: 8px;
+	color: currentColor;
+}
+
+.desktop-mode-file-tile__visual--favicon::before {
+	content: '';
+	position: absolute;
+	top: 3px;
+	left: 2px;
+	width: 44px;
+	height: 34px;
+	box-sizing: border-box;
+	border: 2px solid currentColor;
+	border-radius: 5px;
+	background: var( --desktop-mode-window-bg, #fff );
+	box-shadow:
+		inset 0 0 0 1px rgba( 0, 0, 0, 0.08 ),
+		0 1px 2px rgba( 0, 0, 0, 0.24 );
+}
+
+.desktop-mode-file-tile__visual--favicon::after {
+	content: '';
+	position: absolute;
+	left: 13px;
+	bottom: 2px;
+	width: 22px;
+	height: 8px;
+	box-sizing: border-box;
+	border-bottom: 2px solid currentColor;
+	background: linear-gradient( currentColor, currentColor ) center top / 2px 7px no-repeat;
+}
+
+.desktop-mode-file-tile__visual--favicon > .desktop-mode-file-tile__icon {
+	position: relative;
+	z-index: 1;
+}
+
+.desktop-mode-file-tile__visual--favicon > img.desktop-mode-file-tile__icon {
+	width: auto;
+	height: auto;
+	max-width: 24px;
+	max-height: 24px;
+	object-fit: contain;
+}
+
+.desktop-mode-file-tile__visual--favicon > span.desktop-mode-file-tile__icon {
+	width: 24px;
+	height: 24px;
+	font-size: 24px;
+	background-size: contain;
 }
 
 .desktop-mode-file-tile__preview {

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -44,9 +44,9 @@ A **file type** is a slug that points the registry at the right subclass. The bu
 | `link` | `Desktop_Mode_Link_File` | URL string — opens in a new browser tab |
 | `embed` | `Desktop_Mode_Embed_File` | URL string — opens in an iframe-backed desktop window; geometry persists on `placement.meta.window` |
 
-`link` and `embed` placements both carry an optional human-friendly label on `placement.meta.name` (set by the wallpaper-menu "New URL" entry) — the tile renderer prefers it over `file.title()` so two tiles pointing at the same URL can carry different labels. `embed` placements additionally persist `{ x, y, width, height }` on `placement.meta.window` after every drag-end / resize-end of the spawned window; the next open clamps that geometry to the current desktop area before restoring.
+`link` and `embed` placements both carry an optional human-friendly label on `placement.meta.name`. The wallpaper-menu "New bookmark" entry, URL drops, and URL pastes create `embed` placements. A user-entered name is preserved; otherwise the hostname appears immediately and is replaced by a fetched page title when enrichment succeeds. The tile renderer prefers the placement name over `file.title()` so two tiles pointing at the same URL can carry different labels. `embed` placements additionally persist `{ x, y, width, height }` on `placement.meta.window` after every drag-end / resize-end of the spawned window; the next open clamps that geometry to the current desktop area before restoring.
 
-`link` placements also carry a server-resolved favicon on `placement.meta.iconUrl`. The string is a base64 data URI of the form `data:image/(png|jpeg|gif|webp|x-icon|svg+xml);base64,<payload>`. The favicon resolver runs inline during `POST /placements` (server-side, via `wp_safe_remote_get` + `DOMDocument` parsing of the page's `<link rel="icon">` tags, with a `/favicon.ico` fallback). When the resolver fails — bad host, network error, oversized body, content-type mismatch — `meta.iconUrl` is omitted and the tile falls back to the file type's dashicon. Icons are capped at 256 KB raw bytes, enforced during the download via `limit_response_size` (WP_Http stops reading one byte over the cap, and the truncated over-cap body is then rejected by the size check — never buffered whole); the cap keeps `meta` blobs small. The step-1 page-HTML fetch is itself capped at 1 MB (`DESKTOP_MODE_FAVICON_MAX_PAGE_BYTES`). Plugins can short-circuit or override the resolved value via the `desktop_mode_resolve_favicon` filter. The `meta.iconUrl` precedence is generic — any plugin can attach a custom per-placement icon (URL or data URI) on any type, not just `link`.
+Web placements can carry a server-resolved favicon on `placement.meta.iconUrl`. The string is a base64 data URI of the form `data:image/(png|jpeg|gif|webp|x-icon|svg+xml);base64,<payload>`. External `link` and `bookmark` creation resolves it inline; the tile uses it immediately when present and updates in place if the metadata arrives later. Favicons render at their intrinsic size, capped at 24 px, inside a 48 px monitor frame so small native artwork stays crisp while matching the visual weight of neighboring desktop icons. New `embed` bookmarks are usable immediately, then call `POST /placements/<id>/web-metadata` in the background to merge a sanitized page title and favicon without replacing a later rename, saved window geometry, or other metadata. Resolution uses `wp_safe_remote_get` + `DOMDocument`, with a `/favicon.ico` fallback. When it fails — bad host, network error, oversized body, content-type mismatch — metadata is left alone and the tile keeps its hostname and generic icon. Icons are capped at 256 KB raw bytes and page HTML at 1 MB. Plugins can continue to short-circuit or override favicon resolution through the `desktop_mode_resolve_favicon` filter. The `meta.iconUrl` precedence is generic — any plugin can attach a custom per-placement icon (URL or data URI) on any type.
 
 `page` and any custom post type collapse into `post`; `category` and `post_tag` collapse into `term`. UI labels per concrete post type / taxonomy come from the `desktop_mode_file_serialize` filter — there's no need to register a separate type for every CPT.
 
@@ -286,6 +286,7 @@ All under `/wp-json/desktop-mode/v1/files`. Permission gate: logged-in + desktop
 | `POST` | `/placements` | `{ parentId?, type, ref, x?, y?, sortOrder?, meta? }` |
 | `PATCH` | `/placements/<id>` | `{ parentId?, x?, y?, sortOrder?, meta? }` |
 | `DELETE` | `/placements/<id>` | Soft-trash to the recycle bin (restorable). Pass `?force=1` to permanently purge. |
+| `POST` | `/placements/<id>/web-metadata` | Resolve and merge the stored `embed` URL's page title and favicon. The request body cannot choose a URL. |
 | `GET` | `/folders` | List folders the viewer owns (Phase 6 expands to shared folders). |
 | `POST` | `/folders` | `{ name, shareMode?, shareMeta? }` |
 | `PATCH` | `/folders/<id>` | `{ name?, shareMode?, shareMeta? }` |
@@ -465,9 +466,13 @@ Legacy: HTML5 drag (`setShortcutDragPayload` /
 `dataTransfer`, but is deprecated. New code uses the
 manager.
 
-### Open
+### URL intake and open
 
-Double-click on a tile resolves the placement's serialized shape into a `DesktopFile` instance and calls `wp.desktop.files.open()`, which routes through the opener registry (Phase 1).
+Dropping one URL on the wallpaper or an open folder creates an `embed` bookmark in the nearest free grid cell. Dropping on a closed folder tile creates it inside that folder. Paste uses the currently active desktop or folder surface and the next free cell. Intake prefers `text/uri-list` (ignoring comment lines) and falls back to standalone `text/plain`; it accepts HTTP/HTTPS URLs and domain-like values normalized to HTTPS, and rejects credentials, unsafe schemes, arbitrary prose, and file drags. Paste is ignored while an editable control, modal, or iframe owns focus. Only one bookmark is created per gesture.
+
+When the same URL already exists in a folder, a drop repositions and selects it while paste only selects it; stored names, icons, and window geometry remain intact. The layer announces creation, duplicate selection, and invalid input through the accessible toast surface.
+
+Double-click or Enter on a selected tile resolves the placement's serialized shape into a `DesktopFile` instance and calls `wp.desktop.files.open()`, which routes through the opener registry (Phase 1). Single-click and Space select without opening. `embed` URLs are validated again before an iframe window is created. Because sites may block framing with `X-Frame-Options` or CSP and that cannot be detected reliably, bookmark windows always show an **Open in browser** title-bar action as well as the overflow-menu command. External URLs are passed through exactly when detached; only same-origin WordPress/admin URLs receive Desktop Mode query adjustments.
 
 ### Plugin extension points
 
@@ -505,7 +510,7 @@ Clicking empty wallpaper used to call `windowManager.toggleShowDesktop()` direct
 | Id | Label | Behavior |
 |---|---|---|
 | `create-folder` | New folder | Prompts for a name, then `POST /folders`. |
-| `new-url` | New URL | Prompts for a name + URL, then `POST /placements` with a `link` placement (the tile opens the URL in a new browser tab). |
+| `new-url` | New bookmark | Prompts for an optional name + URL, then creates an `embed` placement that opens inside an iframe-backed desktop window. |
 | `sort-by` | Sort by | Submenu with checkable options: Name (A → Z), Name (Z → A), Date (newest first), Date (oldest first); re-sorts the desktop icons. |
 | `show-desktop` | Show desktop | Calls `windowManager.toggleShowDesktop()` (the legacy single-click gesture). |
 | `os-settings` | OS Settings | Opens the OS Settings window. |

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -956,7 +956,7 @@ add_filter( 'desktop_mode_resolve_file_opener', function ( $opener_id, $type, $u
 
 ### `desktop_mode_resolve_favicon` — Stable
 
-Last-mile filter on the favicon data URI returned by `desktop_mode_resolve_favicon()`. The resolver runs inline during `POST /placements` for `link`-type placements: it fetches the page via `wp_safe_remote_get`, walks `<link rel="icon|shortcut icon|apple-touch-icon">`, falls back to `/favicon.ico`, and base64-encodes the bytes into a `data:image/<subtype>;base64,…` URI for the placement's `meta.iconUrl`. The filter lets plugins short-circuit the network round-trips (return a synthetic data URI), force-skip caching (return `null`), or post-process whatever the resolver produced.
+Last-mile filter on the favicon data URI returned by `desktop_mode_resolve_favicon()`. The resolver runs inline during `POST /placements` for external `link` and `bookmark` placements: it fetches the page via `wp_safe_remote_get`, walks `<link rel="icon|shortcut icon|apple-touch-icon">`, falls back to `/favicon.ico`, and base64-encodes the bytes into a `data:image/<subtype>;base64,…` URI for the placement's `meta.iconUrl`. The filter lets plugins short-circuit the network round-trips (return a synthetic data URI), force-skip caching (return `null`), or post-process whatever the resolver produced.
 
 ```php
 apply_filters( 'desktop_mode_resolve_favicon', ?string $data_uri, string $page_url );

--- a/includes/desktop-files/favicon.php
+++ b/includes/desktop-files/favicon.php
@@ -72,7 +72,8 @@ const DESKTOP_MODE_FAVICON_TIMEOUT = 4;
  * @return string|null Data URI on success; `null` on any failure.
  */
 function desktop_mode_resolve_favicon( $page_url ) {
-	$result = desktop_mode_resolve_favicon_internal( (string) $page_url );
+	$metadata = desktop_mode_resolve_web_metadata_internal( (string) $page_url );
+	$result   = isset( $metadata['iconUrl'] ) ? $metadata['iconUrl'] : null;
 
 	/**
 	 * Filters the favicon data URI before it is returned to the
@@ -92,6 +93,63 @@ function desktop_mode_resolve_favicon( $page_url ) {
 }
 
 /**
+ * Resolve the best-effort display metadata for a web placement.
+ *
+ * The existing favicon filter remains the single extension point for
+ * icon resolution. Page titles are deliberately not filterable here:
+ * callers may still rename the placement, and the REST merge never
+ * overwrites a non-empty name.
+ *
+ * @param string $page_url HTTP(S) page URL.
+ * @return array{name?:string,iconUrl?:string}
+ */
+function desktop_mode_files_resolve_web_metadata( $page_url ) {
+	$metadata = desktop_mode_resolve_web_metadata_internal( (string) $page_url );
+	$icon     = isset( $metadata['iconUrl'] ) ? $metadata['iconUrl'] : null;
+	$filtered = apply_filters( 'desktop_mode_resolve_favicon', $icon, (string) $page_url );
+
+	if ( is_string( $filtered ) && '' !== $filtered ) {
+		$metadata['iconUrl'] = $filtered;
+	} else {
+		unset( $metadata['iconUrl'] );
+	}
+
+	return $metadata;
+}
+
+/**
+ * Validate a serialized placement URL without accepting credentials or
+ * non-web schemes.
+ *
+ * @param string $url Candidate URL.
+ * @return string Sanitized URL, or an empty string when invalid.
+ */
+function desktop_mode_files_normalize_web_url( $url ) {
+	$url = trim( (string) $url );
+	if ( '' === $url || preg_match( '/[\r\n]/', $url ) ) {
+		return '';
+	}
+
+	$parts = wp_parse_url( $url );
+	if (
+		! is_array( $parts )
+		|| empty( $parts['host'] )
+		|| empty( $parts['scheme'] )
+		|| isset( $parts['user'] )
+		|| isset( $parts['pass'] )
+	) {
+		return '';
+	}
+
+	$scheme = strtolower( (string) $parts['scheme'] );
+	if ( 'http' !== $scheme && 'https' !== $scheme ) {
+		return '';
+	}
+
+	return esc_url_raw( $url, array( 'http', 'https' ) );
+}
+
+/**
  * Internal resolver — see {@see desktop_mode_resolve_favicon}.
  *
  * Kept separate so the public function is the only place the
@@ -104,14 +162,26 @@ function desktop_mode_resolve_favicon( $page_url ) {
  * @return string|null
  */
 function desktop_mode_resolve_favicon_internal( $page_url ) {
-	$parts = wp_parse_url( $page_url );
-	if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
-		return null;
+	$metadata = desktop_mode_resolve_web_metadata_internal( $page_url );
+	return isset( $metadata['iconUrl'] ) ? $metadata['iconUrl'] : null;
+}
+
+/**
+ * Resolve title and favicon with one bounded page request.
+ *
+ * @internal
+ *
+ * @param string $page_url Page URL.
+ * @return array{name?:string,iconUrl?:string}
+ */
+function desktop_mode_resolve_web_metadata_internal( $page_url ) {
+	$page_url = desktop_mode_files_normalize_web_url( $page_url );
+	if ( '' === $page_url ) {
+		return array();
 	}
-	$scheme = isset( $parts['scheme'] ) ? strtolower( $parts['scheme'] ) : '';
-	if ( 'http' !== $scheme && 'https' !== $scheme ) {
-		return null;
-	}
+
+	$parts  = wp_parse_url( $page_url );
+	$scheme = strtolower( (string) $parts['scheme'] );
 
 	$page_response = wp_safe_remote_get( $page_url, desktop_mode_favicon_request_args( DESKTOP_MODE_FAVICON_MAX_PAGE_BYTES ) );
 	$page_body     = '';
@@ -119,14 +189,62 @@ function desktop_mode_resolve_favicon_internal( $page_url ) {
 		$page_body = (string) wp_remote_retrieve_body( $page_response );
 	}
 
+	$metadata      = array();
+	$title         = '' !== $page_body ? desktop_mode_web_metadata_extract_title( $page_body ) : '';
 	$candidate_url = '' !== $page_body
 		? desktop_mode_favicon_extract_link_href( $page_body, $page_url )
 		: '';
+	if ( '' !== $title ) {
+		$metadata['name'] = $title;
+	}
 	if ( '' === $candidate_url ) {
 		$candidate_url = $scheme . '://' . $parts['host'] . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' ) . '/favicon.ico';
 	}
 
-	return desktop_mode_favicon_fetch_as_data_uri( $candidate_url );
+	$icon = desktop_mode_favicon_fetch_as_data_uri( $candidate_url );
+	if ( is_string( $icon ) && '' !== $icon ) {
+		$metadata['iconUrl'] = $icon;
+	}
+
+	return $metadata;
+}
+
+/**
+ * Extract and sanitize the first HTML title.
+ *
+ * @internal
+ *
+ * @param string $html Page body.
+ * @return string
+ */
+function desktop_mode_web_metadata_extract_title( $html ) {
+	if ( ! class_exists( 'DOMDocument' ) ) {
+		if ( ! preg_match( '/<title\b[^>]*>(.*?)<\/title>/is', (string) $html, $matches ) ) {
+			return '';
+		}
+		$title = wp_strip_all_tags( (string) $matches[1] );
+		$title = html_entity_decode( $title, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$title = sanitize_text_field( preg_replace( '/\s+/u', ' ', trim( $title ) ) );
+		return function_exists( 'mb_substr' ) ? mb_substr( $title, 0, 160 ) : substr( $title, 0, 160 );
+	}
+
+	$dom         = new DOMDocument();
+	$prev_errors = libxml_use_internal_errors( true );
+	$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_NOWARNING | LIBXML_NOERROR );
+	libxml_clear_errors();
+	libxml_use_internal_errors( $prev_errors );
+
+	$titles = $dom->getElementsByTagName( 'title' );
+	if ( ! $titles || 0 === $titles->length ) {
+		return '';
+	}
+
+	$title = html_entity_decode( (string) $titles->item( 0 )->textContent, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+	$title = sanitize_text_field( preg_replace( '/\s+/u', ' ', trim( $title ) ) );
+	if ( function_exists( 'mb_substr' ) ) {
+		return mb_substr( $title, 0, 160 );
+	}
+	return substr( $title, 0, 160 );
 }
 
 /**
@@ -172,6 +290,13 @@ function desktop_mode_favicon_request_args( $limit_response_size = DESKTOP_MODE_
  * @return string
  */
 function desktop_mode_favicon_extract_link_href( $html, $base_url ) {
+	if ( ! class_exists( 'DOMDocument' ) ) {
+		// Metadata is best-effort. The caller will fall back to the
+		// origin's `/favicon.ico`, which is preferable to a PHP fatal in
+		// lightweight browser runtimes that omit ext-dom.
+		return '';
+	}
+
 	$dom         = new DOMDocument();
 	$prev_errors = libxml_use_internal_errors( true );
 	// `LIBXML_NOWARNING | LIBXML_NOERROR` suppresses libxml's stderr
@@ -315,6 +440,9 @@ function desktop_mode_favicon_fetch_as_data_uri( $icon_url ) {
 	// `.ico` files in some PHP builds. SVG is XML, not a recognized
 	// image format by getimagesize, so we skip the check for it.
 	if ( 'svg+xml' !== $subtype ) {
+		if ( ! function_exists( 'getimagesizefromstring' ) ) {
+			return null;
+		}
 		$dimensions = @getimagesizefromstring( $body );
 		if ( false === $dimensions ) {
 			return null;

--- a/includes/desktop-files/rest.php
+++ b/includes/desktop-files/rest.php
@@ -9,6 +9,8 @@
  *   POST   /placements                 Create a placement.
  *   PATCH  /placements/(?P<id>\d+)     Move / update a placement.
  *   DELETE /placements/(?P<id>\d+)     Remove a placement.
+ *   POST   /placements/(?P<id>\d+)/web-metadata
+ *                                       Enrich a web bookmark.
  *
  *   GET    /folders                    List folders visible to the viewer.
  *   POST   /folders                    Create a folder.
@@ -149,6 +151,12 @@ function desktop_mode_files_register_rest_routes() {
 			'permission_callback' => 'desktop_mode_files_rest_permission',
 			'callback'            => 'desktop_mode_files_rest_delete_placement',
 		),
+	) );
+
+	register_rest_route( $ns, '/files/placements/(?P<id>\d+)/web-metadata', array(
+		'methods'             => WP_REST_Server::CREATABLE,
+		'permission_callback' => 'desktop_mode_files_rest_permission',
+		'callback'            => 'desktop_mode_files_rest_enrich_web_metadata',
 	) );
 
 	register_rest_route( $ns, '/files/folders', array(
@@ -347,11 +355,18 @@ function desktop_mode_files_rest_create_placement( WP_REST_Request $req ) {
 	$ref  = (string) $req->get_param( 'ref' );
 	$meta = $req->get_param( 'meta' );
 
-	// `link` placements get a server-resolved favicon stuffed onto
+	if ( 'embed' === $type ) {
+		$ref = desktop_mode_files_normalize_web_url( $ref );
+		if ( '' === $ref ) {
+			return new WP_Error( 'desktop_mode_files_invalid_web_url', __( 'Enter a valid HTTP or HTTPS URL without credentials.', 'desktop-mode' ), array( 'status' => 400 ) );
+		}
+	}
+
+	// External `link` / `bookmark` placements get a server-resolved favicon stuffed onto
 	// `meta.iconUrl` so the tile renderer can paint it without the
 	// browser making a third-party request on every render. Other
 	// types skip the resolver entirely (no extra fetch latency).
-	if ( 'link' === $type && '' !== $ref ) {
+	if ( in_array( $type, array( 'link', 'bookmark' ), true ) && '' !== $ref ) {
 		$icon_data_uri = desktop_mode_resolve_favicon( $ref );
 		if ( is_string( $icon_data_uri ) && '' !== $icon_data_uri ) {
 			$meta_arr             = is_array( $meta ) ? $meta : array();
@@ -366,17 +381,83 @@ function desktop_mode_files_rest_create_placement( WP_REST_Request $req ) {
 		$type,
 		$ref,
 		array(
-			'x'          => (int) $req->get_param( 'x' ),
-			'y'          => (int) $req->get_param( 'y' ),
-			'sort_order' => (int) $req->get_param( 'sortOrder' ),
-			'meta'       => $meta,
+			'x'                          => (int) $req->get_param( 'x' ),
+			'y'                          => (int) $req->get_param( 'y' ),
+			'sort_order'                 => (int) $req->get_param( 'sortOrder' ),
+			'meta'                       => $meta,
+			'preserve_meta_on_duplicate' => 'embed' === $type,
 		)
 	);
 	if ( is_wp_error( $id ) ) {
 		return $id;
 	}
 	$row = desktop_mode_files_get_placement( $id );
+	if ( ! $row ) {
+		return new WP_Error( 'desktop_mode_files_not_found_after_create', __( 'The bookmark was saved but could not be read back.', 'desktop-mode' ), array( 'status' => 500 ) );
+	}
 	return rest_ensure_response( desktop_mode_files_shape_placement( $row ) );
+}
+
+/**
+ * POST /placements/<id>/web-metadata
+ *
+ * The URL comes exclusively from the stored placement. A capability
+ * check runs before the remote request and again before the merge so a
+ * deleted or moved placement cannot be resurrected by a slow response.
+ */
+function desktop_mode_files_rest_enrich_web_metadata( WP_REST_Request $req ) {
+	$id      = (int) $req['id'];
+	$user_id = get_current_user_id();
+	$current = desktop_mode_files_get_placement( $id );
+	if ( ! $current || ! empty( $current['trashed_at_ms'] ) ) {
+		return new WP_Error( 'desktop_mode_files_not_found', __( 'Placement not found.', 'desktop-mode' ), array( 'status' => 404 ) );
+	}
+	if ( 'embed' !== (string) $current['file_type'] ) {
+		return new WP_Error( 'desktop_mode_files_not_web_bookmark', __( 'This placement is not a web bookmark.', 'desktop-mode' ), array( 'status' => 400 ) );
+	}
+
+	$authorized = desktop_mode_files_move( $id, $user_id, array() );
+	if ( is_wp_error( $authorized ) ) {
+		return $authorized;
+	}
+
+	$metadata = desktop_mode_files_resolve_web_metadata( (string) $current['file_ref'] );
+
+	for ( $attempt = 0; $attempt < 3; $attempt++ ) {
+		$latest = desktop_mode_files_get_placement( $id );
+		if ( ! $latest || ! empty( $latest['trashed_at_ms'] ) || 'embed' !== (string) $latest['file_type'] ) {
+			return new WP_Error( 'desktop_mode_files_not_found', __( 'Placement not found.', 'desktop-mode' ), array( 'status' => 404 ) );
+		}
+
+		$meta    = is_array( $latest['meta'] ) ? $latest['meta'] : array();
+		$changed = false;
+		if ( empty( $meta['name'] ) && ! empty( $metadata['name'] ) ) {
+			$meta['name'] = (string) $metadata['name'];
+			$changed      = true;
+		}
+		if ( ! empty( $metadata['iconUrl'] ) && ( ! isset( $meta['iconUrl'] ) || $meta['iconUrl'] !== $metadata['iconUrl'] ) ) {
+			$meta['iconUrl'] = (string) $metadata['iconUrl'];
+			$changed         = true;
+		}
+		if ( ! $changed ) {
+			return rest_ensure_response( desktop_mode_files_shape_placement( $latest ) );
+		}
+
+		$updated = desktop_mode_files_replace_meta_if_unchanged(
+			$id,
+			$user_id,
+			(int) $latest['updated_at_ms'],
+			$meta
+		);
+		if ( ! is_wp_error( $updated ) ) {
+			return rest_ensure_response( desktop_mode_files_shape_placement( desktop_mode_files_get_placement( $id ) ) );
+		}
+		if ( 'desktop_mode_files_metadata_race' !== $updated->get_error_code() ) {
+			return $updated;
+		}
+	}
+
+	return new WP_Error( 'desktop_mode_files_metadata_race', __( 'The placement kept changing while metadata was loading.', 'desktop-mode' ), array( 'status' => 409 ) );
 }
 
 /**

--- a/includes/desktop-files/store.php
+++ b/includes/desktop-files/store.php
@@ -32,7 +32,8 @@ defined( 'ABSPATH' ) || exit;
  * @param int    $parent_id Folder id, or 0 for the desktop root.
  * @param string $type      File-type slug.
  * @param string $ref       Entity reference.
- * @param array  $args      Optional. `x`, `y`, `sort_order`, `meta`.
+ * @param array  $args      Optional. `x`, `y`, `sort_order`, `meta`,
+ *                          `preserve_meta_on_duplicate`.
  * @return int|WP_Error Placement id on success, `WP_Error` otherwise.
  */
 function desktop_mode_files_place( $user_id, $parent_id, $type, $ref, $args = array() ) {
@@ -90,10 +91,11 @@ function desktop_mode_files_place( $user_id, $parent_id, $type, $ref, $args = ar
 	$args = wp_parse_args(
 		$args,
 		array(
-			'x'          => 0,
-			'y'          => 0,
-			'sort_order' => 0,
-			'meta'       => null,
+			'x'                          => 0,
+			'y'                          => 0,
+			'sort_order'                 => 0,
+			'meta'                       => null,
+			'preserve_meta_on_duplicate' => false,
 		)
 	);
 
@@ -171,6 +173,15 @@ function desktop_mode_files_place( $user_id, $parent_id, $type, $ref, $args = ar
 		// this is a no-op in the soft-trashed branch above.
 		desktop_mode_files_clear_tombstones_for( 'placement', $existing_id );
 
+		$duplicate_meta = $args['meta'];
+		if ( $args['preserve_meta_on_duplicate'] ) {
+			$stored_meta = ! empty( $existing['meta'] ) ? json_decode( (string) $existing['meta'], true ) : array();
+			$incoming    = is_array( $args['meta'] ) ? $args['meta'] : array();
+			// Stored keys win: a stale repeat-create must not undo a rename,
+			// resolved icon, or saved window geometry.
+			$duplicate_meta = array_merge( $incoming, is_array( $stored_meta ) ? $stored_meta : array() );
+		}
+
 		$move = desktop_mode_files_move(
 			$existing_id,
 			$user_id,
@@ -179,7 +190,7 @@ function desktop_mode_files_place( $user_id, $parent_id, $type, $ref, $args = ar
 				'x'          => (int) $args['x'],
 				'y'          => (int) $args['y'],
 				'sort_order' => (int) $args['sort_order'],
-				'meta'       => $args['meta'],
+				'meta'       => $duplicate_meta,
 			)
 		);
 		if ( is_wp_error( $move ) ) {
@@ -189,6 +200,30 @@ function desktop_mode_files_place( $user_id, $parent_id, $type, $ref, $args = ar
 		return $existing_id;
 	}
 	$id = (int) $wpdb->insert_id;
+	if ( $id <= 0 ) {
+		// SQLite-backed environments have occasionally committed an INSERT
+		// without carrying the generated id back through `$wpdb->insert_id`.
+		// The placement identity is unique, so recover the committed row
+		// instead of returning id 0 and fatalling while shaping the response.
+		$id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$tables['placements']}
+				WHERE owner_id = %d
+					AND parent_id = %d
+					AND file_type = %s
+					AND file_ref = %s
+				ORDER BY id DESC
+				LIMIT 1",
+				$user_id,
+				max( 0, $parent_id ),
+				$type,
+				$ref
+			)
+		);
+	}
+	if ( $id <= 0 ) {
+		return new WP_Error( 'desktop_mode_files_insert_failed', __( 'Failed to read the new placement.', 'desktop-mode' ), array( 'status' => 500 ) );
+	}
 
 	$row['id'] = $id;
 
@@ -338,7 +373,10 @@ function desktop_mode_files_move( $placement_id, $user_id, $changes = array() ) 
 		return true; // No-op.
 	}
 
-	$set['updated_at_ms'] = desktop_mode_files_now_ms();
+	// Treat this timestamp as the row version as well as its wall-clock time.
+	// Two mutations can land in the same millisecond during fast UI updates;
+	// always advance it so compare-and-swap callers can distinguish them.
+	$set['updated_at_ms'] = max( desktop_mode_files_now_ms(), (int) $row['updated_at_ms'] + 1 );
 	$fmt[]                = '%d';
 	// Track who actually fired this mutation so a future
 	// `If-Match` 409 can name the session that won the race,
@@ -362,6 +400,65 @@ function desktop_mode_files_move( $placement_id, $user_id, $changes = array() ) 
 	 */
 	do_action( 'desktop_mode_file_moved', $placement_id, $next, $row );
 
+	return true;
+}
+
+/**
+ * Replace placement metadata only when the row still matches a known version.
+ *
+ * Web metadata arrives after a remote request. A rename, move, or window resize
+ * may win while that request is in flight, so the ordinary read/merge/write
+ * sequence is not sufficient: it can overwrite the newer metadata between the
+ * final read and write. This compare-and-swap keeps that merge atomic; callers
+ * may reload and retry when the version changed.
+ *
+ * @internal
+ *
+ * @param int   $placement_id Placement id.
+ * @param int   $user_id      Acting user.
+ * @param int   $expected_ms  Expected `updated_at_ms` value.
+ * @param array $meta         Complete merged metadata value.
+ * @return true|WP_Error
+ */
+function desktop_mode_files_replace_meta_if_unchanged( $placement_id, $user_id, $expected_ms, array $meta ) {
+	global $wpdb;
+
+	$authorized = desktop_mode_files_move( $placement_id, $user_id, array() );
+	if ( is_wp_error( $authorized ) ) {
+		return $authorized;
+	}
+
+	$previous = desktop_mode_files_get_placement( $placement_id );
+	if ( ! $previous || ! empty( $previous['trashed_at_ms'] ) ) {
+		return new WP_Error( 'desktop_mode_files_not_found', __( 'Placement not found.', 'desktop-mode' ), array( 'status' => 404 ) );
+	}
+	if ( (int) $previous['updated_at_ms'] !== (int) $expected_ms ) {
+		return new WP_Error( 'desktop_mode_files_metadata_race', __( 'The placement changed while metadata was loading.', 'desktop-mode' ), array( 'status' => 409 ) );
+	}
+
+	$tables = desktop_mode_files_table_names();
+	$now    = max( desktop_mode_files_now_ms(), (int) $expected_ms + 1 );
+	$updated = $wpdb->update(
+		$tables['placements'],
+		array(
+			'meta'          => wp_json_encode( $meta ),
+			'updated_at_ms' => $now,
+			'updated_by'    => (int) $user_id,
+		),
+		array(
+			'id'             => (int) $placement_id,
+			'updated_at_ms'  => (int) $expected_ms,
+			'trashed_at_ms'  => null,
+		),
+		array( '%s', '%d', '%d' ),
+		array( '%d', '%d', '%s' )
+	);
+	if ( 1 !== $updated ) {
+		return new WP_Error( 'desktop_mode_files_metadata_race', __( 'The placement changed while metadata was loading.', 'desktop-mode' ), array( 'status' => 409 ) );
+	}
+
+	$next = desktop_mode_files_get_placement( $placement_id );
+	do_action( 'desktop_mode_file_moved', (int) $placement_id, $next, $previous );
 	return true;
 }
 
@@ -815,6 +912,7 @@ function desktop_mode_files_normalize_placement_row( $row ) {
 		'y'             => (int) $row['y'],
 		'sort_order'    => (int) $row['sort_order'],
 		'updated_at_ms' => (int) $row['updated_at_ms'],
+		'trashed_at_ms' => ! empty( $row['trashed_at_ms'] ) ? (int) $row['trashed_at_ms'] : null,
 		'meta'          => is_array( $meta ) ? $meta : null,
 	);
 }

--- a/src/boot/session.ts
+++ b/src/boot/session.ts
@@ -212,6 +212,7 @@ export async function restoreSession(
 			desktopId: win.desktopId,
 			multi: !! dockEntry?.multi,
 			url: win.url,
+			allowExternalUrl: win.id.startsWith( 'desktop-mode-embed-' ),
 			// `dockEntry?.url` is the parent menu's landing page —
 			// recover it so the synthetic "back to parent" tab in
 			// the in-window strip points at the dock URL even when

--- a/src/desktop-files/built-in-openers.ts
+++ b/src/desktop-files/built-in-openers.ts
@@ -38,6 +38,7 @@ import { openEmbedWindow } from './embed-window';
 import { deriveWindowId } from '../utils';
 import { findMenuEntryForUrl } from './menu-entry';
 import { navigateToDownload } from './download-nav';
+import { serializedWebUrl } from './web-url';
 
 interface ConfigShape {
 	adminUrl?: string;
@@ -47,32 +48,6 @@ function adminBase(): string {
 	const cfg = ( window.wp as { desktop?: { config?: ConfigShape } } | undefined )?.desktop?.config;
 	const url = cfg?.adminUrl ?? '/wp-admin/';
 	return url.endsWith( '/' ) ? url : `${ url }/`;
-}
-
-/**
- * The server-sanitized URL of a bookmark/link tile, or `''`.
- *
- * The PHP `serialize()` for these types runs the stored ref
- * through `esc_url_raw()` and ships the result as `shape.url` —
- * read that field (like the preview pane does) instead of the
- * raw `ref()`. Re-validate the protocol client-side as well so a
- * shape mangled after the fact can't smuggle a `javascript:` or
- * `data:` URL into `window.open`.
- */
-function sanitizedWebUrl( file: DesktopFile ): string {
-	const url = typeof file.shape.url === 'string' ? file.shape.url : '';
-	if ( ! url ) {
-		return '';
-	}
-	try {
-		const parsed = new URL( url, window.location.href );
-		if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
-			return '';
-		}
-	} catch {
-		return '';
-	}
-	return url;
 }
 
 export function registerBuiltInFileOpeners(): void {
@@ -586,7 +561,7 @@ export function registerBuiltInFileOpeners(): void {
 		handler: {
 			kind: 'js',
 			open: ( file: DesktopFile ) => {
-				const url = sanitizedWebUrl( file );
+				const url = serializedWebUrl( file );
 				if ( ! url ) {
 					return;
 				}
@@ -608,7 +583,7 @@ export function registerBuiltInFileOpeners(): void {
 		handler: {
 			kind: 'js',
 			open: ( file: DesktopFile ) => {
-				const url = sanitizedWebUrl( file );
+				const url = serializedWebUrl( file );
 				if ( ! url ) {
 					return;
 				}

--- a/src/desktop-files/embed-window.ts
+++ b/src/desktop-files/embed-window.ts
@@ -14,6 +14,8 @@ import { addAction, removeAction, HOOKS } from '../hooks';
 import * as filesRest from './rest';
 import type { DesktopFile } from './file';
 import type { OpenerContext } from './openers';
+import { registerTitleBarButton } from '../title-bar-buttons/registry';
+import { serializedWebUrl } from './web-url';
 
 interface SavedGeometry {
 	x: number;
@@ -24,6 +26,7 @@ interface SavedGeometry {
 
 interface EmbedMeta {
 	name?: string;
+	iconUrl?: string;
 	window?: SavedGeometry;
 }
 
@@ -53,13 +56,10 @@ export function openEmbedWindow(
 	file: DesktopFile,
 	ctx?: OpenerContext,
 ): void {
-	const url = file.ref();
+	const url = serializedWebUrl( file );
 	if ( ! url ) {
 		return;
 	}
-	// External URLs only — same-origin URLs would be served as
-	// chromeless admin pages anyway, but we don't second-guess the
-	// user; whatever they pasted lands in the iframe src as-is.
 	const wm = ( window.wp as
 		| { desktop?: { windowManager?: WindowManagerLike } }
 		| undefined )?.desktop?.windowManager;
@@ -80,8 +80,9 @@ export function openEmbedWindow(
 		id: windowId,
 		baseId: windowId,
 		url,
+		allowExternalUrl: true,
 		title,
-		icon: file.icon(),
+		icon: meta?.iconUrl?.trim() || file.icon(),
 		minWidth: MIN_W,
 		minHeight: MIN_H,
 	};
@@ -114,6 +115,25 @@ export function openEmbedWindow(
 	}
 
 	wm.open( cfg );
+}
+
+let titleBarButtonInstalled = false;
+
+/** Keep the browser escape hatch visible even when a site blocks framing. */
+export function installEmbedTitleBarButton(): void {
+	if ( titleBarButtonInstalled ) {
+		return;
+	}
+	titleBarButtonInstalled = true;
+	registerTitleBarButton( {
+		id: 'desktop-mode/embed-open-browser',
+		label: 'Open in browser',
+		icon: 'dashicons-external',
+		placement: 'right',
+		order: 10,
+		match: ( desktopWindow ) => desktopWindow.id.startsWith( ID_PREFIX ),
+		onClick: ( desktopWindow ) => desktopWindow.detach(),
+	} );
 }
 
 /**

--- a/src/desktop-files/file-tile.ts
+++ b/src/desktop-files/file-tile.ts
@@ -53,6 +53,36 @@ export function placementLabel( placement: RestPlacementShape ): string {
 	return metaName !== '' ? metaName : resolveFileType( placement.file ).title();
 }
 
+interface PlacementVisual {
+	thumbnail: string;
+	icon: string;
+	favicon: boolean;
+}
+
+/**
+ * Resolve the current tile artwork from placement metadata and file defaults.
+ * Exported for the layer's DOM-reuse paths so late favicon enrichment can
+ * update an existing tile without forcing a wholesale grid rebuild.
+ */
+export function placementVisual( placement: RestPlacementShape ): PlacementVisual {
+	const file = resolveFileType( placement.file );
+	const thumbnail = file.previewUrl();
+	const metaIconUrl =
+		placement.meta && typeof ( placement.meta as { iconUrl?: unknown } ).iconUrl === 'string'
+			? ( placement.meta as { iconUrl: string } ).iconUrl.trim()
+			: '';
+
+	return {
+		thumbnail,
+		icon: thumbnail
+			? ''
+			: ( metaIconUrl ||
+				resolveThemedIcon( slotForFileType( placement.file.type ) ) ||
+				file.icon() ),
+		favicon: ! thumbnail && metaIconUrl !== '',
+	};
+}
+
 /**
  * Convert a placement into the generic spec the unified renderer
  * consumes. Picks up per-placement `meta.iconUrl` / `meta.name`
@@ -62,22 +92,15 @@ function placementToSpec(
 	placement: RestPlacementShape,
 	folderId: number,
 ): TileSpec {
-	const file = resolveFileType( placement.file );
-	const previewUrl = file.previewUrl();
-
 	const label = placementLabel( placement );
-
-	const metaIconUrl =
-		placement.meta && typeof ( placement.meta as { iconUrl?: unknown } ).iconUrl === 'string'
-			? ( placement.meta as { iconUrl: string } ).iconUrl.trim()
-			: '';
+	const visual = placementVisual( placement );
 
 	return {
 		type: placement.file.type,
 		ref: placement.file.ref,
 		label,
 		// Preview wins over icon (matches the previous behavior).
-		thumbnail: previewUrl || undefined,
+		thumbnail: visual.thumbnail || undefined,
 		// Precedence when no preview exists:
 		//   per-placement `meta.iconUrl`  (the user/plugin said so
 		//                                  about THIS tile)
@@ -86,11 +109,8 @@ function placementToSpec(
 		//   → the file type's own icon.
 		// The per-placement override outranks the theme on purpose:
 		// it is specific, deliberate, and about one object.
-		icon: previewUrl
-			? undefined
-			: ( metaIconUrl ||
-				resolveThemedIcon( slotForFileType( placement.file.type ) ) ||
-				file.icon() ),
+		icon: visual.icon || undefined,
+		favicon: visual.favicon,
 		x: placement.x,
 		y: placement.y,
 		dataset: {
@@ -137,9 +157,7 @@ export function buildTile(
 		tile.appendChild( extra );
 	}
 
-	tile.addEventListener( 'dblclick', ( e ) => {
-		e.preventDefault();
-		e.stopPropagation();
+	const activate = (): void => {
 		// Re-read the live placement — the layer's fast-path repaints
 		// reuse this tile's DOM without re-wiring, so the captured
 		// `placement` can be stale by now (an in-place rename would
@@ -163,7 +181,26 @@ export function buildTile(
 				meta: live.meta,
 			},
 		} );
+	};
+
+	tile.addEventListener( 'dblclick', ( e ) => {
+		e.preventDefault();
+		e.stopPropagation();
+		activate();
 	} );
+
+	// `<wpd-tile>` maps both Enter and Space to click. Desktop files use
+	// Space/click for selection, but Enter is the keyboard equivalent of
+	// double-click Open, so claim Enter before the component synthesizes
+	// a selection-only click.
+	tile.addEventListener( 'keydown', ( e: KeyboardEvent ) => {
+		if ( e.key !== 'Enter' || e.isComposing ) {
+			return;
+		}
+		e.preventDefault();
+		e.stopImmediatePropagation();
+		activate();
+	}, true );
 
 	// Internal consumer: `share-menu-items.ts` paints the shared-
 	// folder badge on every render. Kept on the placement-shaped

--- a/src/desktop-files/index.ts
+++ b/src/desktop-files/index.ts
@@ -38,7 +38,10 @@ import {
 import { installOpenDeps, openFile, type OpenDeps } from './open';
 import { registerBuiltInFileTypes } from './built-in-types';
 import { registerBuiltInFileOpeners } from './built-in-openers';
-import { installEmbedPersistence } from './embed-window';
+import {
+	installEmbedPersistence,
+	installEmbedTitleBarButton,
+} from './embed-window';
 import { registerFileAssociationsTab } from './settings-tab';
 import { installShareMenuItems } from './share-menu-items';
 import { installShareInviteBanner } from './share-invite-banner';
@@ -63,6 +66,7 @@ import type { DesktopFileShape, DesktopFileTypeServerEntry } from './types';
 registerBuiltInFileTypes();
 registerBuiltInFileOpeners();
 installEmbedPersistence();
+installEmbedTitleBarButton();
 registerFileAssociationsTab();
 installShareMenuItems();
 installUploadMenuItems();

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -22,8 +22,15 @@
  */
 
 import { doAction } from '../hooks';
+import { showToast } from '../toast';
 import { rest, store as filesStoreApi } from './layer-deps';
-import { buildTile, placementLabel, setTilePosition, TILE_CLASS } from './file-tile';
+import {
+	buildTile,
+	placementLabel,
+	placementVisual,
+	setTilePosition,
+	TILE_CLASS,
+} from './file-tile';
 import {
 	tilePayloadAccepts,
 	tilePayloadAcceptLabel,
@@ -36,6 +43,7 @@ import { resolve as resolveFileType } from './registry';
 import {
 	cellKey,
 	cellToPos,
+	buildOccupiedSet,
 	GRID_CELL_H,
 	GRID_CELL_W,
 	GRID_PADDING,
@@ -54,6 +62,8 @@ import type {
 	DesktopFileDragData,
 	ShortcutDragData,
 } from './drag-payloads';
+import { registerUrlIntakeTarget } from './url-intake';
+import { createWebBookmark } from './web-bookmarks';
 
 /**
  * Build a cross-frame bridge payload from a placement, or return
@@ -489,6 +499,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			if ( tile ) {
 				applyTilePosition( tile, placement, pinnedSlots, displaced );
 				syncTileLabel( tile, placement );
+				syncTileVisual( tile, placement );
 				continue;
 			}
 			container.appendChild(
@@ -1140,6 +1151,93 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		resizeObserver.observe( host );
 	}
 
+	const unregisterUrlIntake = registerUrlIntakeTarget( {
+		host,
+		onUrl: async ( request ) => {
+			try {
+				let targetFolderId = folderId;
+				const eventElement = request.eventTarget instanceof Element
+					? request.eventTarget
+					: null;
+				const folderTile = eventElement?.closest< HTMLElement >(
+					`.${ TILE_CLASS }[data-file-type="folder"]`,
+				);
+				if ( folderTile && host.contains( folderTile ) ) {
+					const folderRef = Number( folderTile.dataset.fileRef ?? 0 );
+					if ( Number.isFinite( folderRef ) && folderRef > 0 ) {
+						targetFolderId = folderRef;
+					}
+				}
+
+				if (
+					targetFolderId !== folderId &&
+					! filesStoreApi.getState().hydratedFolders.has( targetFolderId )
+				) {
+					const response = await rest.listPlacements( targetFolderId );
+					filesStoreApi.setFolderPlacements(
+						targetFolderId,
+						response.placements,
+					);
+				}
+
+				const peers =
+					filesStoreApi.getState().placementsByFolder.get( targetFolderId ) ?? [];
+				const occupied = buildOccupiedSet( peers );
+				let cell;
+				if (
+					request.source === 'drop' &&
+					targetFolderId === folderId &&
+					typeof request.clientX === 'number' &&
+					typeof request.clientY === 'number'
+				) {
+					const rect = container.getBoundingClientRect();
+					cell = snapToEmptyCell(
+						Math.max( 0, request.clientX - rect.left ),
+						Math.max( 0, request.clientY - rect.top ),
+						occupied,
+						host,
+					);
+				} else {
+					cell = nextRowMajorCell(
+						occupied,
+						targetFolderId === folderId ? host : null,
+					);
+				}
+
+				const result = await createWebBookmark( {
+					folderId: targetFolderId,
+					url: request.url,
+					x: cell.x,
+					y: cell.y,
+					repositionExisting: request.source === 'drop',
+				} );
+				if ( targetFolderId === folderId ) {
+					setSelected( result.placement );
+				}
+				if ( request.source === 'drop' && targetFolderId === 0 ) {
+					doAction( 'desktop-mode.files.tile-manually-placed', {
+						folderId: 0,
+						placementId: result.placement.id,
+					} );
+				}
+				showToast( {
+					message: result.created
+						? 'Bookmark added.'
+						: 'That bookmark is already in this folder.',
+				} );
+			} catch ( err ) {
+				const detail = err instanceof Error ? err.message : '';
+				// eslint-disable-next-line no-console
+				console.error( '[desktop-mode] bookmark creation failed:', err );
+				showToast( {
+					message: detail.includes( 'read access' )
+						? 'You don’t have permission to add bookmarks to this folder.'
+						: 'Could not add that bookmark.',
+				} );
+			}
+		},
+	} );
+
 	return {
 		host,
 		folderId,
@@ -1153,6 +1251,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		reflow,
 		hydrated,
 		dispose() {
+			unregisterUrlIntake();
 			off();
 			resizeObserver?.disconnect();
 			resizeObserver = null;
@@ -1584,6 +1683,7 @@ function tryPatchPositions(
 			setTilePosition( tile, placement.x, placement.y );
 		}
 		syncTileLabel( tile, placement );
+		syncTileVisual( tile, placement );
 	}
 
 	return true;
@@ -1607,6 +1707,35 @@ function syncTileLabel(
 	const label = placementLabel( placement );
 	if ( tile.getAttribute( 'label' ) !== label ) {
 		tile.setAttribute( 'label', label );
+	}
+}
+
+/**
+ * Sync artwork on a reused tile. Web metadata enrichment updates
+ * `meta.iconUrl` after the tile is already visible; the fast repaint paths
+ * preserve DOM identity, so they must explicitly reflect the new icon.
+ */
+function syncTileVisual(
+	tile: HTMLElement,
+	placement: RestPlacementShape,
+): void {
+	const visual = placementVisual( placement );
+	for ( const [ attribute, value ] of [
+		[ 'thumbnail', visual.thumbnail ],
+		[ 'icon', visual.icon ],
+	] as const ) {
+		if ( value ) {
+			if ( tile.getAttribute( attribute ) !== value ) {
+				tile.setAttribute( attribute, value );
+			}
+		} else if ( tile.hasAttribute( attribute ) ) {
+			tile.removeAttribute( attribute );
+		}
+	}
+	if ( visual.favicon ) {
+		tile.setAttribute( 'favicon', '' );
+	} else {
+		tile.removeAttribute( 'favicon' );
 	}
 }
 

--- a/src/desktop-files/rest.ts
+++ b/src/desktop-files/rest.ts
@@ -266,6 +266,17 @@ export function updatePlacement(
 	} );
 }
 
+/**
+ * Best-effort page-title/favicon enrichment for a persisted web placement.
+ * The server derives the URL from the placement id, so callers cannot turn
+ * this route into an arbitrary fetch primitive.
+ */
+export function enrichWebMetadata( id: number ): Promise< RestPlacementShape > {
+	return call< RestPlacementShape >( `/placements/${ id }/web-metadata`, {
+		method: 'POST',
+	} );
+}
+
 export function deletePlacement( id: number ): Promise< { deleted: true } > {
 	return call< { deleted: true } >( `/placements/${ id }`, { method: 'DELETE' } );
 }

--- a/src/desktop-files/tile-spec.ts
+++ b/src/desktop-files/tile-spec.ts
@@ -55,6 +55,8 @@ export interface TileSpec {
 	label: string;
 	/** Dashicon class, http(s) URL, or data: URI. Ignored if `thumbnail` is set. */
 	icon?: string;
+	/** Paint the icon inside the compact web/monitor frame. */
+	favicon?: boolean;
 	/**
 	 * Preview image URL (replaces the icon for media tiles + the
 	 * desktop link favicon). Renders as `<img class="…__preview">`.
@@ -136,6 +138,9 @@ export function buildTileFromSpec( spec: TileSpec ): HTMLElement {
 	tile.setAttribute( 'label', spec.label );
 	if ( spec.icon ) {
 		tile.setAttribute( 'icon', spec.icon );
+	}
+	if ( spec.favicon ) {
+		tile.setAttribute( 'favicon', '' );
 	}
 	if ( spec.thumbnail ) {
 		tile.setAttribute( 'thumbnail', spec.thumbnail );

--- a/src/desktop-files/url-dialog.ts
+++ b/src/desktop-files/url-dialog.ts
@@ -14,6 +14,7 @@
  */
 
 import { applyFilters, doAction } from '../hooks';
+import { normalizeWebUrl } from './web-url';
 // Pre-registered globally by the lazy shell-overlays bundle (Stage 10) — see src/shell-overlays/entry.ts.
 
 const ROOT_CLASS = 'desktop-mode-url-dialog';
@@ -178,14 +179,9 @@ export function openUrlDialog( options: UrlDialogOptions ): void {
 			showError( 'Please enter a URL.' );
 			return;
 		}
-		// Coerce bare hostnames into a fully-qualified https:// URL.
-		const finalUrl = /^[a-z][a-z0-9+\-.]*:/i.test( url ) ? url : `https://${ url }`;
-		try {
-			// Validate by parsing.
-			// eslint-disable-next-line no-new
-			new URL( finalUrl );
-		} catch {
-			showError( 'That doesn\'t look like a valid URL.' );
+		const finalUrl = normalizeWebUrl( url );
+		if ( ! finalUrl ) {
+			showError( 'Enter an HTTP or HTTPS URL without a username or password.' );
 			return;
 		}
 		const name = readValue( nameField ).trim();

--- a/src/desktop-files/url-intake.ts
+++ b/src/desktop-files/url-intake.ts
@@ -1,0 +1,305 @@
+/**
+ * Native browser URL drop + focused-files-surface paste intake.
+ *
+ * This is separate from DragManager (in-shell pointer drags) and the OS file
+ * drop manager (`Files` payloads). It only claims native drags advertising
+ * `text/uri-list` or `text/plain`, so the three systems do not compete.
+ */
+
+import { looksLikeWebUrl, normalizeWebUrl, urlFromUriList } from './web-url';
+import { showToast } from '../toast';
+
+export interface UrlIntakeRequest {
+	url: string;
+	source: 'drop' | 'paste';
+	clientX?: number;
+	clientY?: number;
+	eventTarget: EventTarget | null;
+}
+
+export interface UrlIntakeTarget {
+	host: HTMLElement;
+	onUrl: ( request: UrlIntakeRequest ) => Promise< void > | void;
+}
+
+interface ReadResult {
+	url: string;
+	intentional: boolean;
+}
+
+const targets = new Set< UrlIntakeTarget >();
+let activeTarget: UrlIntakeTarget | null = null;
+let highlighted: HTMLElement | null = null;
+let dragWatchdog: ReturnType< typeof setTimeout > | null = null;
+let listenersInstalled = false;
+
+function transferTypes( transfer: DataTransfer | null ): string[] {
+	if ( ! transfer?.types ) {
+		return [];
+	}
+	return Array.from( transfer.types as unknown as ArrayLike< string > );
+}
+
+export function transferMayContainUrl( transfer: DataTransfer | null ): boolean {
+	const types = transferTypes( transfer );
+	return (
+		! types.includes( 'Files' ) &&
+		( types.includes( 'text/uri-list' ) || types.includes( 'text/plain' ) )
+	);
+}
+
+function readUrl( getter: ( type: string ) => string ): ReadResult {
+	const uriList = getter( 'text/uri-list' );
+	if ( uriList.trim() ) {
+		return { url: urlFromUriList( uriList ), intentional: true };
+	}
+	const plain = getter( 'text/plain' ).trim();
+	if ( ! plain || ! looksLikeWebUrl( plain ) ) {
+		return { url: '', intentional: false };
+	}
+	return { url: normalizeWebUrl( plain ), intentional: true };
+}
+
+function targetFromPath( path: EventTarget[] ): UrlIntakeTarget | null {
+	for ( const item of path ) {
+		if ( ! ( item instanceof Element ) ) {
+			continue;
+		}
+		for ( const target of targets ) {
+			if ( item === target.host ) {
+				return target;
+			}
+		}
+		// The root desktop host contains every window. Crossing a window
+		// before finding a nested folder layer means this is not a files
+		// surface and must not fall through to the wallpaper.
+		if ( item.classList.contains( 'desktop-mode-window' ) ) {
+			return null;
+		}
+	}
+	return null;
+}
+
+/**
+ * Return the outermost connected files surface. The wallpaper layer mounts
+ * before folder layers in production, but choosing by containment keeps the
+ * fallback deterministic in tests and during remounts too.
+ */
+function defaultTarget(): UrlIntakeTarget | null {
+	let candidate: UrlIntakeTarget | null = null;
+	for ( const target of targets ) {
+		if ( ! document.contains( target.host ) ) {
+			continue;
+		}
+		if ( ! candidate || target.host.contains( candidate.host ) ) {
+			candidate = target;
+		}
+	}
+	return candidate;
+}
+
+function clearHighlight(): void {
+	highlighted?.removeAttribute( 'data-desktop-mode-url-drop-active' );
+	highlighted = null;
+	if ( dragWatchdog !== null ) {
+		clearTimeout( dragWatchdog );
+		dragWatchdog = null;
+	}
+}
+
+function paintHighlight( target: UrlIntakeTarget, eventTarget: EventTarget | null ): void {
+	const element = eventTarget instanceof Element ? eventTarget : null;
+	const folderTile = element?.closest< HTMLElement >(
+		'.desktop-mode-file-tile[data-file-type="folder"]',
+	);
+	const next = folderTile && target.host.contains( folderTile )
+		? folderTile
+		: target.host;
+	if ( highlighted !== next ) {
+		clearHighlight();
+		highlighted = next;
+		highlighted.setAttribute( 'data-desktop-mode-url-drop-active', '' );
+	}
+	dragWatchdog = setTimeout( clearHighlight, 180 );
+}
+
+function pathIsEditable( path: EventTarget[] ): boolean {
+	return path.some(
+		( item ) =>
+			item instanceof Element &&
+			item.matches(
+				'input, textarea, select, [contenteditable]:not([contenteditable="false"]), wpd-text-field',
+			),
+	);
+}
+
+function modalOrIframeOwnsFocus( target: UrlIntakeTarget ): boolean {
+	const ownerDocument = target.host.ownerDocument;
+	if ( ownerDocument.activeElement instanceof HTMLIFrameElement ) {
+		return true;
+	}
+	return Boolean(
+		ownerDocument.querySelector(
+			'wpd-modal, dialog[open], [aria-modal="true"]',
+		),
+	);
+}
+
+function reportInvalid(): void {
+	showToast( {
+		message: 'Only HTTP and HTTPS URLs can be added as bookmarks.',
+	} );
+}
+
+function installListeners(): void {
+	if ( listenersInstalled ) {
+		return;
+	}
+	listenersInstalled = true;
+
+	document.addEventListener( 'pointerdown', onPointerDown, true );
+	document.addEventListener( 'focusin', onFocusIn, true );
+	document.addEventListener( 'paste', onPaste );
+	window.addEventListener( 'dragover', onDragOver );
+	window.addEventListener( 'drop', onDrop );
+	window.addEventListener( 'dragend', clearHighlight );
+	window.addEventListener( 'blur', clearHighlight );
+	document.addEventListener( 'visibilitychange', onVisibilityChange );
+}
+
+function uninstallListeners(): void {
+	if ( ! listenersInstalled ) {
+		return;
+	}
+	listenersInstalled = false;
+	document.removeEventListener( 'pointerdown', onPointerDown, true );
+	document.removeEventListener( 'focusin', onFocusIn, true );
+	document.removeEventListener( 'paste', onPaste );
+	window.removeEventListener( 'dragover', onDragOver );
+	window.removeEventListener( 'drop', onDrop );
+	window.removeEventListener( 'dragend', clearHighlight );
+	window.removeEventListener( 'blur', clearHighlight );
+	document.removeEventListener( 'visibilitychange', onVisibilityChange );
+	activeTarget = null;
+	clearHighlight();
+}
+
+function onPointerDown( event: PointerEvent ): void {
+	activeTarget = targetFromPath( event.composedPath() );
+}
+
+function onFocusIn( event: FocusEvent ): void {
+	activeTarget = targetFromPath( event.composedPath() );
+}
+
+function onPaste( event: ClipboardEvent ): void {
+	if (
+		event.defaultPrevented ||
+		! activeTarget ||
+		! document.contains( activeTarget.host ) ||
+		modalOrIframeOwnsFocus( activeTarget ) ||
+		pathIsEditable( event.composedPath() )
+	) {
+		return;
+	}
+	const clipboard = event.clipboardData;
+	if ( ! clipboard ) {
+		return;
+	}
+	const result = readUrl( ( type ) => clipboard.getData( type ) );
+	if ( ! result.intentional ) {
+		return;
+	}
+	event.preventDefault();
+	if ( ! result.url ) {
+		reportInvalid();
+		return;
+	}
+	void activeTarget.onUrl( {
+		url: result.url,
+		source: 'paste',
+		eventTarget: event.target,
+	} );
+}
+
+function onDragOver( event: DragEvent ): void {
+	if ( event.defaultPrevented || ! transferMayContainUrl( event.dataTransfer ) ) {
+		return;
+	}
+	const target = targetFromPath( event.composedPath() );
+	if ( ! target ) {
+		clearHighlight();
+		return;
+	}
+	event.preventDefault();
+	if ( event.dataTransfer ) {
+		event.dataTransfer.dropEffect = 'copy';
+	}
+	paintHighlight( target, event.target );
+}
+
+function onDrop( event: DragEvent ): void {
+	if ( event.defaultPrevented || ! transferMayContainUrl( event.dataTransfer ) ) {
+		return;
+	}
+	const target = targetFromPath( event.composedPath() );
+	if ( ! target || ! event.dataTransfer ) {
+		clearHighlight();
+		return;
+	}
+	event.preventDefault();
+	clearHighlight();
+	const result = readUrl( ( type ) => event.dataTransfer?.getData( type ) ?? '' );
+	if ( ! result.url ) {
+		if ( result.intentional ) {
+			reportInvalid();
+		}
+		return;
+	}
+	activeTarget = target;
+	void target.onUrl( {
+		url: result.url,
+		source: 'drop',
+		clientX: event.clientX,
+		clientY: event.clientY,
+		eventTarget: event.target,
+	} );
+}
+
+function onVisibilityChange(): void {
+	if ( document.visibilityState === 'hidden' ) {
+		clearHighlight();
+	}
+}
+
+export function registerUrlIntakeTarget( target: UrlIntakeTarget ): () => void {
+	targets.add( target );
+	installListeners();
+	// A freshly mounted desktop is already the active application surface.
+	// Requiring a pointer/focus event after mount made the first paste a silent
+	// no-op, especially in Playground where the user may copy the URL before
+	// the files layer finishes booting. Prefer a newly registered outer host,
+	// but never replace an explicitly active nested folder with a sibling.
+	if (
+		! activeTarget ||
+		! document.contains( activeTarget.host ) ||
+		target.host.contains( activeTarget.host )
+	) {
+		activeTarget = target;
+	}
+	return () => {
+		targets.delete( target );
+		if ( activeTarget === target ) {
+			activeTarget = defaultTarget();
+		}
+		if ( targets.size === 0 ) {
+			uninstallListeners();
+		}
+	};
+}
+
+/** Test-only teardown for the module-level target registry. */
+export function __resetUrlIntakeForTests(): void {
+	targets.clear();
+	uninstallListeners();
+}

--- a/src/desktop-files/web-bookmarks.ts
+++ b/src/desktop-files/web-bookmarks.ts
@@ -1,0 +1,126 @@
+/** Persistent `embed` placement creation + best-effort web metadata. */
+
+import { rest, store } from './layer-deps';
+import type { RestPlacementShape } from './rest';
+import { normalizeWebUrl } from './web-url';
+
+export interface CreateWebBookmarkOptions {
+	folderId: number;
+	url: string;
+	x: number;
+	y: number;
+	name?: string;
+	repositionExisting?: boolean;
+}
+
+export interface CreateWebBookmarkResult {
+	placement: RestPlacementShape;
+	created: boolean;
+}
+
+function metaString(
+	placement: RestPlacementShape,
+	key: 'name' | 'iconUrl',
+): string {
+	const value = placement.meta?.[ key ];
+	return typeof value === 'string' ? value.trim() : '';
+}
+
+function enrichInBackground( placement: RestPlacementShape ): void {
+	if ( metaString( placement, 'name' ) && metaString( placement, 'iconUrl' ) ) {
+		return;
+	}
+	void rest
+		.enrichWebMetadata( placement.id )
+		.then( ( enriched ) => {
+			store.upsertPlacement( enriched, 'remote' );
+		} )
+		.catch( ( err: unknown ) => {
+			// Metadata is decoration, not a creation gate. The bookmark
+			// remains usable with its hostname + generic icon.
+			// eslint-disable-next-line no-console
+			console.warn( '[desktop-mode] bookmark metadata lookup failed:', err );
+		} );
+}
+
+function matchingBookmark(
+	placements: readonly RestPlacementShape[],
+	url: string,
+): RestPlacementShape | undefined {
+	return placements.find(
+		( placement ) =>
+			placement.file.type === 'embed' &&
+			normalizeWebUrl( placement.file.ref ) === url,
+	);
+}
+
+/**
+ * Create a web bookmark or reuse the matching placement in the same folder.
+ * The database's unique key already encodes this identity; the client-side
+ * lookup prevents a repeat paste from wiping saved name/window metadata.
+ */
+export async function createWebBookmark(
+	options: CreateWebBookmarkOptions,
+): Promise< CreateWebBookmarkResult > {
+	const url = normalizeWebUrl( options.url );
+	if ( ! url ) {
+		throw new Error( 'Only HTTP and HTTPS URLs can be added as bookmarks.' );
+	}
+
+	const peers = store.getState().placementsByFolder.get( options.folderId ) ?? [];
+	const existing = matchingBookmark( peers, url );
+	if ( existing ) {
+		let placement = existing;
+		if (
+			options.repositionExisting &&
+			( existing.x !== options.x || existing.y !== options.y )
+		) {
+			placement = await rest.updatePlacement(
+				existing.id,
+				{ x: options.x, y: options.y },
+				existing.updatedAtMs,
+			);
+			store.upsertPlacement( placement, 'remote' );
+		}
+		enrichInBackground( placement );
+		return { placement, created: false };
+	}
+
+	const name = options.name?.trim() ?? '';
+	let placement: RestPlacementShape;
+	try {
+		placement = await rest.createPlacement( {
+			type: 'embed',
+			ref: url,
+			parentId: options.folderId,
+			x: options.x,
+			y: options.y,
+			meta: name ? { name } : undefined,
+		} );
+	} catch ( createError ) {
+		// Some SQLite/Playground failures can happen after the INSERT
+		// commits but before WordPress serializes the response. Reconcile
+		// once before reporting failure so a real row never appears beside
+		// a misleading "Could not add" toast.
+		try {
+			const refreshed = await rest.listPlacements( options.folderId );
+			store.setFolderPlacements( options.folderId, refreshed.placements );
+			const recovered = matchingBookmark( refreshed.placements, url );
+			if ( recovered ) {
+				enrichInBackground( recovered );
+				return { placement: recovered, created: true };
+			}
+		} catch ( reconcileError ) {
+			// Keep the original create error as the actionable failure.
+			// eslint-disable-next-line no-console
+			console.warn(
+				'[desktop-mode] bookmark reconciliation failed:',
+				reconcileError,
+			);
+		}
+		throw createError;
+	}
+	store.upsertPlacement( placement, 'remote' );
+	enrichInBackground( placement );
+	return { placement, created: true };
+}

--- a/src/desktop-files/web-url.ts
+++ b/src/desktop-files/web-url.ts
@@ -1,0 +1,69 @@
+/**
+ * Web-URL helpers shared by bookmark creation and openers.
+ *
+ * Intake deliberately accepts only one standalone HTTP(S) URL. A bare
+ * hostname is convenient enough to normalize to HTTPS, while arbitrary prose
+ * containing a URL is left alone so a normal paste never turns into a desktop
+ * item by surprise.
+ */
+
+import type { DesktopFile } from './file';
+
+const EXPLICIT_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+const BARE_WEB_TARGET = /^(?:localhost(?::\d+)?|(?:\[[0-9a-f:]+\]|(?:[^\s/?#]+\.)+[^\s./?#]+)(?::\d+)?)(?:[/?#].*)?$/i;
+
+/** Normalize one user-supplied web URL, or return an empty string. */
+export function normalizeWebUrl( input: string ): string {
+	const raw = input.trim();
+	if ( ! raw || /[\r\n]/.test( raw ) ) {
+		return '';
+	}
+
+	let candidate = raw;
+	if ( BARE_WEB_TARGET.test( candidate ) ) {
+		candidate = `https://${ candidate }`;
+	} else if ( ! EXPLICIT_SCHEME.test( candidate ) ) {
+		return '';
+	}
+
+	try {
+		const parsed = new URL( candidate );
+		if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
+			return '';
+		}
+		if ( parsed.username || parsed.password || ! parsed.hostname ) {
+			return '';
+		}
+		return parsed.toString();
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Read the server-sanitized URL serialized for a web file. Never fall back to
+ * the raw ref: filters can alter shapes, so every opener re-validates the
+ * final wire value immediately before using it.
+ */
+export function serializedWebUrl( file: DesktopFile ): string {
+	const raw = typeof file.shape.url === 'string' ? file.shape.url : '';
+	return normalizeWebUrl( raw );
+}
+
+/** Parse the first non-comment entry in a standard text/uri-list payload. */
+export function urlFromUriList( value: string ): string {
+	for ( const line of value.split( /\r?\n/ ) ) {
+		const candidate = line.trim();
+		if ( ! candidate || candidate.startsWith( '#' ) ) {
+			continue;
+		}
+		return normalizeWebUrl( candidate );
+	}
+	return '';
+}
+
+/** Whether plain text looks intentional enough to treat as URL intake. */
+export function looksLikeWebUrl( value: string ): boolean {
+	const raw = value.trim();
+	return EXPLICIT_SCHEME.test( raw ) || BARE_WEB_TARGET.test( raw );
+}

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -248,6 +248,7 @@ import {
 } from './desktop-files/wallpaper-menu';
 import { openCreateFolderDialog } from './desktop-files/create-folder-dialog';
 import { openUrlDialog } from './desktop-files/url-dialog';
+import { createWebBookmark } from './desktop-files/web-bookmarks';
 import type {
 	DesktopConfig,
 	DesktopWallpaperServerEntry,
@@ -4081,15 +4082,13 @@ function init(): void {
 					submitLabel: 'Create',
 					onSubmit: async ( { name, url } ) => {
 						const cell = cellAtClick();
-						const placement = await filesRest.createPlacement( {
-							type: 'link',
-							ref: url,
-							parentId: 0,
+						await createWebBookmark( {
+							folderId: 0,
+							url,
 							x: cell.x,
 							y: cell.y,
-							meta: name ? { name } : undefined,
+							name,
 						} );
-						filesApi.store.upsertPlacement( placement );
 					},
 				} );
 			};
@@ -4113,8 +4112,8 @@ function init(): void {
 				},
 				createUrl: () =>
 					createUrlPlacement(
-						'New URL',
-						'Opens the URL in a new browser tab.',
+						'New bookmark',
+						'Opens the URL in a desktop window.',
 					),
 				toggleShowDesktop: () => manager.toggleShowDesktop(),
 				openOsSettings: () => openOsSettings(),
@@ -4134,7 +4133,7 @@ function init(): void {
 					sortNameDesc: 'Name (Z → A)',
 					sortDateAsc: 'Date (oldest first)',
 					sortDateDesc: 'Date (newest first)',
-					newUrl: 'New URL',
+					newUrl: 'New bookmark',
 				},
 				serverItems: ( config.serverWallpaperMenuItems as
 				| ServerWallpaperMenuItem[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,12 @@ export interface WindowConfig {
 	 */
 	native?: boolean;
 	/**
+	 * Permit a validated external HTTP(S) URL in this iframe. The normal
+	 * admin-window path remains same-origin-only; web bookmark windows opt
+	 * in explicitly and provide their own permanent browser fallback.
+	 */
+	allowExternalUrl?: boolean;
+	/**
 	 * Render callback for native windows. Invoked once after the window
 	 * element mounts; receives the `.desktop-mode-window__body` and
 	 * an optional render context whose `window.send` / `window.on`

--- a/src/ui/components/wpd-tile/wpd-tile.ts
+++ b/src/ui/components/wpd-tile/wpd-tile.ts
@@ -84,6 +84,7 @@ const REACTIVE_PROPS = [
 	'ref',
 	'label',
 	'icon',
+	'favicon',
 	'thumbnail',
 	'kind',
 	'status',
@@ -111,6 +112,7 @@ export class WpdTile extends Component {
 			{ name: 'ref', type: 'string' },
 			{ name: 'label', type: 'string' },
 			{ name: 'icon', type: 'string', description: 'Dashicon class / URL / data URI. Ignored when `thumbnail` is set.' },
+			{ name: 'favicon', type: 'boolean', description: 'Frames a web icon at its intrinsic size inside a monitor silhouette.' },
 			{ name: 'thumbnail', type: 'string', description: 'Preview image URL. Renders as `<img>` and wins over `icon`.' },
 			{ name: 'kind', type: '`entry` | `folder`' },
 			{ name: 'status', type: '`draft` | `pending` | `private` | `future` | `publish`' },
@@ -186,6 +188,7 @@ export class WpdTile extends Component {
 		const ref = this.getAttribute( 'ref' ) ?? '';
 		const label = this.getAttribute( 'label' ) ?? '';
 		const icon = this.getAttribute( 'icon' ) ?? '';
+		const favicon = this.hasAttribute( 'favicon' );
 		const thumbnail = this.getAttribute( 'thumbnail' ) ?? '';
 		const kind = this.getAttribute( 'kind' ) ?? 'entry';
 		const status = this.getAttribute( 'status' ) ?? '';
@@ -272,6 +275,9 @@ export class WpdTile extends Component {
 
 		const visual = document.createElement( 'span' );
 		visual.className = `${ TILE_CLASS }__visual`;
+		if ( favicon && icon && ! thumbnail ) {
+			visual.classList.add( `${ TILE_CLASS }__visual--favicon` );
+		}
 		if ( thumbnail ) {
 			const img = document.createElement( 'img' );
 			img.src = thumbnail;

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -82,6 +82,26 @@ export function withChromelessParam( url: string ): string | null {
 	return parsed.toString();
 }
 
+/** Validate a bookmark iframe URL, adding chromeless mode only on-site. */
+function withExternalIframePermission( url: string ): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL( url, INITIAL_ORIGIN );
+	} catch {
+		return null;
+	}
+	if (
+		( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) ||
+		parsed.username ||
+		parsed.password
+	) {
+		return null;
+	}
+	return parsed.origin === INITIAL_ORIGIN
+		? withChromelessParam( url )
+		: url;
+}
+
 /**
  * Toggle `desktop-mode-has-fullscreen-window` on `<body>` based on whether
  * any window is currently in fullscreen state.
@@ -553,9 +573,12 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 		// `config.url` is required for iframe windows — enforced at
 		// the type level (it's only marked optional to cover the
 		// native-window case, which never reaches this branch).
-		const chromelessSrc = config.url
-			? withChromelessParam( config.url )
-			: null;
+		let chromelessSrc: string | null = null;
+		if ( config.url ) {
+			chromelessSrc = config.allowExternalUrl
+				? withExternalIframePermission( config.url )
+				: withChromelessParam( config.url );
+		}
 		iframe.src = chromelessSrc ?? 'about:blank';
 
 		body.appendChild( iframe );

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1873,8 +1873,7 @@ export class Window {
 	}
 
 	/**
-	 * Open the window's current URL in a new browser tab as classic
-	 * wp-admin.
+	 * Open the window's current URL in a new browser tab.
 	 *
 	 * Strips the chromeless `desktop_mode_chromeless` flag and the transient
 	 * `desktop_mode_portal` flag, and tags the URL with
@@ -1884,29 +1883,39 @@ export class Window {
 	 * request; once the browser renders the page, the user's in-tab
 	 * navigation returns to normal admin flow.
 	 *
-	 * The desktop window itself stays open — detach is a branch, not
-	 * a move. If the user wants to close it afterwards, they can.
+	 * External HTTP(S) URLs are preserved exactly. Same-origin wp-admin
+	 * URLs have Desktop Mode's transient flags removed and receive the
+	 * classic-mode escape flag. The desktop window itself stays open —
+	 * detach is a branch, not a move.
 	 */
 	public detach(): void {
 		const current = this.getCurrentUrl();
 		let url: URL;
+		let target = current;
 		try {
 			url = new URL( current, INITIAL_ORIGIN );
 		} catch {
 			return;
 		}
-		if ( url.origin !== INITIAL_ORIGIN ) {
+		if (
+			( url.protocol !== 'http:' && url.protocol !== 'https:' ) ||
+			url.username ||
+			url.password
+		) {
 			return;
 		}
-		url.searchParams.delete( 'desktop_mode_chromeless' );
-		url.searchParams.delete( 'desktop_mode_portal' );
-		url.searchParams.set( 'desktop_mode_classic', '1' );
+		if ( url.origin === INITIAL_ORIGIN ) {
+			url.searchParams.delete( 'desktop_mode_chromeless' );
+			url.searchParams.delete( 'desktop_mode_portal' );
+			url.searchParams.set( 'desktop_mode_classic', '1' );
+			target = url.toString();
+		}
 
 		// `noopener` is required for security (tabs should not be able
 		// to reach back into window.opener), and it also lets the
 		// browser move the new tab to its own process.
-		window.open( url.toString(), '_blank', 'noopener' );
-		doAction( HOOKS.WINDOW_DETACHED, { windowId: this.id, url: url.toString() } );
+		window.open( target, '_blank', 'noopener,noreferrer' );
+		doAction( HOOKS.WINDOW_DETACHED, { windowId: this.id, url: target } );
 	}
 
 	/**

--- a/tests/phpunit/tests/desktopFilesFavicon.php
+++ b/tests/phpunit/tests/desktopFilesFavicon.php
@@ -267,6 +267,57 @@ class Tests_DesktopMode_Files_Favicon extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @covers ::desktop_mode_web_metadata_extract_title
+	 */
+	public function test_extracts_sanitized_bounded_page_title() {
+		$title = desktop_mode_web_metadata_extract_title(
+			'<html><head><title>  Example &amp; Co. <b>Workbench</b>  </title></head></html>'
+		);
+		$this->assertSame( 'Example & Co. Workbench', $title );
+		$this->assertLessThanOrEqual(
+			160,
+			strlen( desktop_mode_web_metadata_extract_title( '<title>' . str_repeat( 'a', 220 ) . '</title>' ) )
+		);
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_resolve_web_metadata
+	 */
+	public function test_metadata_resolves_title_and_icon_with_one_page_fetch() {
+		$html       = '<html><head><title>Example Domain</title><link rel="icon" href="/icon.png"></head></html>';
+		$page_calls = 0;
+		$page       = $this->http_response( $html );
+		$icon       = $this->http_response( self::PNG_BYTES, 200, 'image/png' );
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$page_calls, $page, $icon ) {
+				if ( false !== strpos( $url, '/icon.png' ) ) {
+					return $icon;
+				}
+				$page_calls++;
+				return $page;
+			},
+			10,
+			3
+		);
+
+		$metadata = desktop_mode_files_resolve_web_metadata( 'https://example.com/path' );
+		$this->assertSame( 1, $page_calls );
+		$this->assertSame( 'Example Domain', $metadata['name'] );
+		$this->assertSame( $this->expected_png_data_uri(), $metadata['iconUrl'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_normalize_web_url
+	 */
+	public function test_web_url_validation_rejects_credentials_and_unsafe_schemes() {
+		$this->assertSame( 'https://example.com/path', desktop_mode_files_normalize_web_url( 'https://example.com/path' ) );
+		$this->assertSame( '', desktop_mode_files_normalize_web_url( 'https://user:pass@example.com/' ) );
+		$this->assertSame( '', desktop_mode_files_normalize_web_url( 'javascript:alert(1)' ) );
+		$this->assertSame( '', desktop_mode_files_normalize_web_url( "https://example.com/\nhttps://other.test/" ) );
+	}
+
 	// Note: SSRF protection (loopback / private-IP rejection) is
 	// `wp_safe_remote_get`'s job, not ours — not unit-testable here
 	// because `pre_http_request` runs BEFORE `wp_http_validate_url`,

--- a/tests/phpunit/tests/desktopFilesRestPlacements.php
+++ b/tests/phpunit/tests/desktopFilesRestPlacements.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tests for the placement REST creation handler — specifically
- * the favicon-resolver wiring that runs for `link` placements.
+ * the favicon-resolver wiring that runs for external URL placements.
  *
  * @package WordPress
  * @subpackage UnitTests
@@ -46,6 +46,12 @@ class Tests_DesktopMode_Files_RestPlacements extends WP_UnitTestCase {
 		return $req;
 	}
 
+	private function build_metadata_request( $id ) {
+		$req       = new WP_REST_Request( 'POST', '/desktop-mode/v1/files/placements/' . (int) $id . '/web-metadata' );
+		$req['id'] = (int) $id;
+		return $req;
+	}
+
 	/**
 	 * @covers ::desktop_mode_files_rest_create_placement
 	 */
@@ -76,6 +82,27 @@ class Tests_DesktopMode_Files_RestPlacements extends WP_UnitTestCase {
 		$this->assertIsArray( $data['meta'] );
 		$this->assertSame( 'Example', $data['meta']['name'] );
 		$this->assertSame( $synthetic, $data['meta']['iconUrl'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_rest_create_placement
+	 */
+	public function test_create_bookmark_placement_stores_iconUrl_when_resolver_returns_data_uri() {
+		add_filter(
+			'desktop_mode_resolve_favicon',
+			static function () {
+				return 'data:image/png;base64,BOOKMARK';
+			}
+		);
+
+		$resp = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type'     => 'bookmark',
+			'ref'      => 'https://example.com/',
+			'parentId' => 0,
+		) ) );
+		$data = $resp->get_data();
+		$this->assertSame( 'bookmark', $data['file']['type'] );
+		$this->assertSame( 'data:image/png;base64,BOOKMARK', $data['meta']['iconUrl'] );
 	}
 
 	/**
@@ -171,5 +198,173 @@ class Tests_DesktopMode_Files_RestPlacements extends WP_UnitTestCase {
 		// The point of this test is that the resolver is never invoked.
 		desktop_mode_files_rest_create_placement( $req );
 		$this->assertSame( 0, $called );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_rest_create_placement
+	 */
+	public function test_create_embed_rejects_unsafe_or_credentialed_urls() {
+		foreach ( array( 'javascript:alert(1)', 'https://user:pass@example.com/' ) as $url ) {
+			$result = desktop_mode_files_rest_create_placement(
+				$this->build_request( array( 'type' => 'embed', 'ref' => $url ) )
+			);
+			$this->assertWPError( $result );
+			$this->assertSame( 'desktop_mode_files_invalid_web_url', $result->get_error_code() );
+		}
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_place
+	 */
+	public function test_duplicate_embed_preserves_later_metadata_while_repositioning() {
+		$meta = array(
+			'name'    => 'My later rename',
+			'iconUrl' => 'data:image/png;base64,AA',
+			'window'  => array( 'x' => 4, 'y' => 5, 'width' => 640, 'height' => 480 ),
+		);
+		$first = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type' => 'embed',
+			'ref'  => 'https://example.com/',
+			'x'    => 16,
+			'y'    => 16,
+			'meta' => $meta,
+		) ) );
+		$id = $first->get_data()['id'];
+
+		$second = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type' => 'embed',
+			'ref'  => 'https://example.com/',
+			'x'    => 208,
+			'y'    => 112,
+			'meta' => array( 'name' => 'example.com' ),
+		) ) );
+		$data = $second->get_data();
+		$this->assertSame( $id, $data['id'] );
+		$this->assertSame( 208, $data['x'] );
+		$this->assertSame( 112, $data['y'] );
+		$this->assertSame( $meta, $data['meta'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_rest_enrich_web_metadata
+	 */
+	public function test_metadata_enrichment_merges_without_overwriting_name_or_window() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'offline', 'Network unavailable' );
+			}
+		);
+		add_filter(
+			'desktop_mode_resolve_favicon',
+			static function () {
+				return 'data:image/png;base64,SYNTH';
+			}
+		);
+		$window = array( 'x' => 4, 'y' => 5, 'width' => 640, 'height' => 480 );
+		$created = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type' => 'embed',
+			'ref'  => 'https://example.com/',
+			'meta' => array( 'name' => 'Custom name', 'window' => $window ),
+		) ) );
+
+		$response = desktop_mode_files_rest_enrich_web_metadata(
+			$this->build_metadata_request( $created->get_data()['id'] )
+		);
+		$data = $response->get_data();
+		$this->assertSame( 'Custom name', $data['meta']['name'] );
+		$this->assertSame( $window, $data['meta']['window'] );
+		$this->assertSame( 'data:image/png;base64,SYNTH', $data['meta']['iconUrl'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_rest_enrich_web_metadata
+	 */
+	public function test_metadata_enrichment_adds_sanitized_title_and_survives_network_failure() {
+		$page = array(
+			'response' => array( 'code' => 200, 'message' => 'OK' ),
+			'body'     => '<html><head><title>  Example &amp; Friends  </title></head></html>',
+			'headers'  => array( 'content-type' => 'text/html' ),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $page ) {
+				return false !== strpos( $url, '/favicon.ico' )
+					? new WP_Error( 'offline', 'No icon' )
+					: $page;
+			},
+			10,
+			3
+		);
+		$created = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type' => 'embed',
+			'ref'  => 'https://example.com/',
+		) ) );
+		$response = desktop_mode_files_rest_enrich_web_metadata(
+			$this->build_metadata_request( $created->get_data()['id'] )
+		);
+		$this->assertSame( 'Example & Friends', $response->get_data()['meta']['name'] );
+
+		remove_all_filters( 'pre_http_request' );
+		add_filter( 'pre_http_request', static function () {
+			return new WP_Error( 'offline', 'Network unavailable' );
+		} );
+		$again = desktop_mode_files_rest_enrich_web_metadata(
+			$this->build_metadata_request( $created->get_data()['id'] )
+		);
+		$this->assertInstanceOf( 'WP_REST_Response', $again );
+		$this->assertSame( 'Example & Friends', $again->get_data()['meta']['name'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_rest_enrich_web_metadata
+	 */
+	public function test_metadata_enrichment_honors_authorization_and_deleted_rows() {
+		$created = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type' => 'embed',
+			'ref'  => 'https://example.com/',
+		) ) );
+		$id = $created->get_data()['id'];
+		$other = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $other );
+		$forbidden = desktop_mode_files_rest_enrich_web_metadata( $this->build_metadata_request( $id ) );
+		$this->assertWPError( $forbidden );
+		$this->assertSame( 403, $forbidden->get_error_data()['status'] );
+
+		wp_set_current_user( self::$admin_id );
+		desktop_mode_files_trash_placement( self::$admin_id, $id );
+		$missing = desktop_mode_files_rest_enrich_web_metadata( $this->build_metadata_request( $id ) );
+		$this->assertWPError( $missing );
+		$this->assertSame( 404, $missing->get_error_data()['status'] );
+	}
+
+	/**
+	 * @covers ::desktop_mode_files_replace_meta_if_unchanged
+	 */
+	public function test_atomic_metadata_replace_refuses_to_overwrite_a_later_rename() {
+		$created = desktop_mode_files_rest_create_placement( $this->build_request( array(
+			'type' => 'embed',
+			'ref'  => 'https://example.com/',
+			'meta' => array( 'name' => 'Initial name' ),
+		) ) );
+		$id       = $created->get_data()['id'];
+		$expected = desktop_mode_files_get_placement( $id )['updated_at_ms'];
+		$later    = array(
+			'name'   => 'Renamed while loading',
+			'window' => array( 'x' => 20, 'y' => 30, 'width' => 700, 'height' => 500 ),
+		);
+		desktop_mode_files_move( $id, self::$admin_id, array( 'meta' => $later ) );
+
+		$result = desktop_mode_files_replace_meta_if_unchanged(
+			$id,
+			self::$admin_id,
+			$expected,
+			array( 'name' => 'Initial name', 'iconUrl' => 'data:image/png;base64,STALE' )
+		);
+		$this->assertWPError( $result );
+		$this->assertSame( 'desktop_mode_files_metadata_race', $result->get_error_code() );
+		$this->assertSame( $later, desktop_mode_files_get_placement( $id )['meta'] );
 	}
 }

--- a/tests/vitest/desktop-files-layer.test.ts
+++ b/tests/vitest/desktop-files-layer.test.ts
@@ -328,6 +328,48 @@ describe( 'FilesLayer', () => {
 		handle.dispose();
 	} );
 
+	test( 'late favicon metadata repaints an external link icon without rebuilding the tile', async () => {
+		const { layer, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://example.test/files', nonce: 'n' } );
+		setupRestStub();
+		const linkFile = {
+			type: 'link',
+			ref: 'https://example.test/',
+			title: 'example.test',
+			icon: 'dashicons-admin-links',
+			previewUrl: '',
+			exists: true,
+		};
+		store.setFolderPlacements( 0, [ placement( 1, { file: linkFile } ) ] );
+
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		const handle = layer.mountFilesLayer( host, 0 );
+		const tile = host.querySelector< HTMLElement >( '.desktop-mode-file-tile' )!;
+		tile.dataset.testMark = 'kept';
+		expect( tile.getAttribute( 'icon' ) ).toBe( 'dashicons-admin-links' );
+
+		const favicon = 'https://example.test/favicon.ico';
+		store.upsertPlacement( placement( 1, {
+			file: linkFile,
+			meta: { iconUrl: favicon },
+			updatedAtMs: 2,
+		} ), 'remote' );
+
+		const after = host.querySelector< HTMLElement >( '.desktop-mode-file-tile' )!;
+		expect( after.dataset.testMark ).toBe( 'kept' );
+		expect( after.getAttribute( 'icon' ) ).toBe( favicon );
+		expect( after.hasAttribute( 'favicon' ) ).toBe( true );
+		expect(
+			after.querySelector( '.desktop-mode-file-tile__visual--favicon' ),
+		).not.toBeNull();
+		expect(
+			after.querySelector< HTMLImageElement >( '.desktop-mode-file-tile__icon' )?.src,
+		).toBe( favicon );
+		handle.dispose();
+	} );
+
 	test( 'rename arriving together with an add still repaints the label (incremental path)', async () => {
 		const { layer, store, rest } = await load();
 		store.__resetFilesStoreForTests();

--- a/tests/vitest/desktop-files-tile-meta-icon-url.test.ts
+++ b/tests/vitest/desktop-files-tile-meta-icon-url.test.ts
@@ -75,6 +75,10 @@ describe( 'file-tile — meta.iconUrl precedence', () => {
 		);
 		expect( img ).not.toBeNull();
 		expect( img!.src ).toBe( PNG_DATA_URI );
+		expect( tile.hasAttribute( 'favicon' ) ).toBe( true );
+		expect(
+			tile.querySelector( '.desktop-mode-file-tile__visual--favicon' ),
+		).not.toBeNull();
 		// `<img>` is `draggable=true` by default — leaving it that
 		// way lets the browser hijack the parent tile's pointer
 		// gesture with a native image-drag, breaking rearrange.
@@ -104,6 +108,7 @@ describe( 'file-tile — meta.iconUrl precedence', () => {
 		expect( iconEl ).not.toBeNull();
 		expect( iconEl!.classList.contains( 'dashicons' ) ).toBe( true );
 		expect( iconEl!.classList.contains( 'dashicons-admin-links' ) ).toBe( true );
+		expect( tile.hasAttribute( 'favicon' ) ).toBe( false );
 	} );
 
 	test( 'missing meta falls back to file.icon() dashicon', async () => {

--- a/tests/vitest/desktop-files-url-intake.test.ts
+++ b/tests/vitest/desktop-files-url-intake.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+type IntakeModule = typeof import( '../../src/desktop-files/url-intake' );
+
+async function load(): Promise< IntakeModule > {
+	vi.resetModules();
+	return import( '../../src/desktop-files/url-intake' );
+}
+
+function transfer(
+	data: Record< string, string >,
+	types = Object.keys( data ),
+): DataTransfer {
+	return {
+		types,
+		dropEffect: 'none',
+		getData: ( type: string ) => data[ type ] ?? '',
+	} as unknown as DataTransfer;
+}
+
+function withTransfer< T extends Event >(
+	event: T,
+	key: 'clipboardData' | 'dataTransfer',
+	value: DataTransfer,
+): T {
+	Object.defineProperty( event, key, { value } );
+	return event;
+}
+
+function activate( host: HTMLElement ): void {
+	host.dispatchEvent( new Event( 'pointerdown', { bubbles: true, composed: true } ) );
+}
+
+afterEach( () => {
+	document.body.innerHTML = '';
+	vi.restoreAllMocks();
+} );
+
+describe( 'desktop URL intake controller', () => {
+	test( 'accepts the first paste without a preliminary desktop click', async () => {
+		const intake = await load();
+		const host = document.createElement( 'main' );
+		document.body.appendChild( host );
+		const onUrl = vi.fn();
+		intake.registerUrlIntakeTarget( { host, onUrl } );
+
+		const event = withTransfer(
+			new Event( 'paste', { bubbles: true, cancelable: true, composed: true } ) as ClipboardEvent,
+			'clipboardData',
+			transfer( { 'text/plain': 'https://example.com/first-paste' } ),
+		);
+		host.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( true );
+		expect( onUrl ).toHaveBeenCalledWith( expect.objectContaining( {
+			url: 'https://example.com/first-paste',
+			source: 'paste',
+		} ) );
+		intake.__resetUrlIntakeForTests();
+	} );
+
+	test( 'prefers URI-list on paste and tears down cleanly', async () => {
+		const intake = await load();
+		const host = document.createElement( 'main' );
+		document.body.appendChild( host );
+		const onUrl = vi.fn();
+		const unregister = intake.registerUrlIntakeTarget( { host, onUrl } );
+		activate( host );
+
+		const event = withTransfer(
+			new Event( 'paste', { bubbles: true, cancelable: true, composed: true } ) as ClipboardEvent,
+			'clipboardData',
+			transfer( {
+				'text/uri-list': '# dragged link\nhttps://uri.example/path',
+				'text/plain': 'https://plain.example/',
+			} ),
+		);
+		host.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( true );
+		expect( onUrl ).toHaveBeenCalledWith( expect.objectContaining( {
+			url: 'https://uri.example/path',
+			source: 'paste',
+		} ) );
+
+		unregister();
+		host.dispatchEvent( withTransfer(
+			new Event( 'paste', { bubbles: true, cancelable: true } ) as ClipboardEvent,
+			'clipboardData',
+			transfer( { 'text/plain': 'https://after.example/' } ),
+		) );
+		expect( onUrl ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does not interfere with OS file drops', async () => {
+		const intake = await load();
+		const host = document.createElement( 'main' );
+		document.body.appendChild( host );
+		const onUrl = vi.fn();
+		intake.registerUrlIntakeTarget( { host, onUrl } );
+
+		const event = withTransfer(
+			new Event( 'drop', { bubbles: true, cancelable: true, composed: true } ) as DragEvent,
+			'dataTransfer',
+			transfer( { 'text/uri-list': 'https://example.com/' }, [ 'Files', 'text/uri-list' ] ),
+		);
+		host.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( onUrl ).not.toHaveBeenCalled();
+		intake.__resetUrlIntakeForTests();
+	} );
+
+	test( 'drop includes pointer coordinates and the closed-folder tile target', async () => {
+		const intake = await load();
+		const host = document.createElement( 'main' );
+		const folder = document.createElement( 'div' );
+		folder.className = 'desktop-mode-file-tile';
+		folder.dataset.fileType = 'folder';
+		host.appendChild( folder );
+		document.body.appendChild( host );
+		const onUrl = vi.fn();
+		intake.registerUrlIntakeTarget( { host, onUrl } );
+
+		const event = withTransfer(
+			new Event( 'drop', { bubbles: true, cancelable: true, composed: true } ) as DragEvent,
+			'dataTransfer',
+			transfer( { 'text/plain': 'example.com' } ),
+		);
+		Object.defineProperties( event, {
+			clientX: { value: 123 },
+			clientY: { value: 234 },
+		} );
+		folder.dispatchEvent( event );
+
+		expect( onUrl ).toHaveBeenCalledWith( expect.objectContaining( {
+			url: 'https://example.com/',
+			source: 'drop',
+			clientX: 123,
+			clientY: 234,
+			eventTarget: folder,
+		} ) );
+		intake.__resetUrlIntakeForTests();
+	} );
+
+	test( 'paste is ignored in editable controls, modals, and iframes', async () => {
+		const intake = await load();
+		const host = document.createElement( 'main' );
+		const input = document.createElement( 'input' );
+		host.appendChild( input );
+		document.body.appendChild( host );
+		const onUrl = vi.fn();
+		intake.registerUrlIntakeTarget( { host, onUrl } );
+		activate( host );
+
+		const paste = ( target: HTMLElement ) => target.dispatchEvent( withTransfer(
+			new Event( 'paste', { bubbles: true, cancelable: true, composed: true } ) as ClipboardEvent,
+			'clipboardData',
+			transfer( { 'text/plain': 'https://example.com/' } ),
+		) );
+
+		paste( input );
+		const modal = document.createElement( 'div' );
+		modal.setAttribute( 'aria-modal', 'true' );
+		document.body.appendChild( modal );
+		paste( host );
+		modal.remove();
+		const frame = document.createElement( 'iframe' );
+		document.body.appendChild( frame );
+		frame.focus();
+		paste( host );
+
+		expect( onUrl ).not.toHaveBeenCalled();
+		intake.__resetUrlIntakeForTests();
+	} );
+} );

--- a/tests/vitest/desktop-files-web-bookmark-open.test.ts
+++ b/tests/vitest/desktop-files-web-bookmark-open.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+describe( 'web bookmark activation and window safety', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+
+	afterEach( async () => {
+		const openers = await import( '../../src/desktop-files/openers' );
+		const registry = await import( '../../src/desktop-files/registry' );
+		const buttons = await import( '../../src/title-bar-buttons/registry' );
+		openers.__resetOpenersForTests();
+		registry.__resetForTests();
+		buttons.unregisterTitleBarButton( 'desktop-mode/embed-open-browser' );
+		clearHooksStub();
+		document.body.innerHTML = '';
+		vi.restoreAllMocks();
+	} );
+
+	test( 'double-click and Enter share the opener while click and Space do not open', async () => {
+		vi.resetModules();
+		const fileTile = await import( '../../src/desktop-files/file-tile' );
+		const registry = await import( '../../src/desktop-files/registry' );
+		const openers = await import( '../../src/desktop-files/openers' );
+		const open = await import( '../../src/desktop-files/open' );
+		registry.registerType( { type: 'embed', label: 'Web bookmark', sort: 1 } );
+		const activate = vi.fn();
+		openers.registerOpener( {
+			id: 'test-embed',
+			label: 'Test embed',
+			types: [ 'embed' ],
+			isDefault: true,
+			handler: { kind: 'js', open: activate },
+		} );
+		open.installOpenDeps( {
+			openUrl: () => true,
+			openNativeWindow: () => true,
+			deriveWindowId: () => 'unused',
+		} );
+		const row = {
+			id: 8,
+			parentId: 0,
+			x: 16,
+			y: 16,
+			sortOrder: 0,
+			updatedAtMs: 1,
+			meta: null,
+			file: {
+				type: 'embed',
+				ref: 'https://example.com/',
+				title: 'example.com',
+				icon: 'dashicons-welcome-view-site',
+				previewUrl: '',
+				exists: true,
+				url: 'https://example.com/',
+			},
+		};
+		const tile = fileTile.buildTile( row, 0 );
+		document.body.appendChild( tile );
+
+		tile.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		tile.dispatchEvent( new KeyboardEvent( 'keydown', { key: ' ', bubbles: true } ) );
+		expect( activate ).not.toHaveBeenCalled();
+
+		tile.dispatchEvent( new MouseEvent( 'dblclick', { bubbles: true, cancelable: true } ) );
+		tile.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true, cancelable: true } ) );
+		await Promise.resolve();
+		expect( activate ).toHaveBeenCalledTimes( 2 );
+		expect( activate.mock.calls[ 0 ][ 1 ] ).toMatchObject( {
+			placement: { id: 8 },
+		} );
+	} );
+
+	test( 'embed opener validates the serialized URL and restores geometry', async () => {
+		vi.resetModules();
+		const { DefaultDesktopFile } = await import( '../../src/desktop-files/file' );
+		const { openEmbedWindow } = await import( '../../src/desktop-files/embed-window' );
+		const open = vi.fn();
+		( window.wp as unknown as { desktop: { windowManager: { open: typeof open } } } ).desktop = {
+			windowManager: { open },
+		};
+		const area = document.createElement( 'div' );
+		area.id = 'desktop-mode-area';
+		Object.defineProperties( area, {
+			clientWidth: { value: 1200 },
+			clientHeight: { value: 900 },
+		} );
+		document.body.appendChild( area );
+
+		const safe = new DefaultDesktopFile( {
+			type: 'embed',
+			ref: 'https://example.com/',
+			title: 'example.com',
+			icon: 'dashicons-welcome-view-site',
+			previewUrl: '',
+			exists: true,
+			url: 'https://example.com/path',
+		}, 'embed' );
+		openEmbedWindow( safe, { placement: {
+			id: 9,
+			x: 0,
+			y: 0,
+			meta: {
+				name: 'Kept title',
+				iconUrl: 'data:image/png;base64,AA',
+				window: { x: 44, y: 55, width: 640, height: 480 },
+			},
+		} } );
+		expect( open ).toHaveBeenCalledWith( expect.objectContaining( {
+			id: 'desktop-mode-embed-9',
+			url: 'https://example.com/path',
+			title: 'Kept title',
+			icon: 'data:image/png;base64,AA',
+			x: 44,
+			y: 55,
+			width: 640,
+			height: 480,
+		} ) );
+
+		const unsafe = new DefaultDesktopFile( {
+			...safe.shape,
+			url: 'javascript:alert(1)',
+		}, 'embed' );
+		openEmbedWindow( unsafe );
+		expect( open ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'installs an always-visible browser title-bar action', async () => {
+		vi.resetModules();
+		const { installEmbedTitleBarButton } = await import( '../../src/desktop-files/embed-window' );
+		const { listTitleBarButtons } = await import( '../../src/title-bar-buttons/registry' );
+		installEmbedTitleBarButton();
+		installEmbedTitleBarButton();
+
+		const button = listTitleBarButtons().find(
+			( item ) => item.id === 'desktop-mode/embed-open-browser',
+		);
+		expect( button ).toMatchObject( {
+			label: 'Open in browser',
+			placement: 'right',
+		} );
+		const detach = vi.fn();
+		const embedWindow = { id: 'desktop-mode-embed-4', detach } as never;
+		expect( button?.match( embedWindow ) ).toBe( true );
+		button?.onClick?.( embedWindow, new MouseEvent( 'click' ) );
+		expect( detach ).toHaveBeenCalledOnce();
+		expect(
+			listTitleBarButtons().filter(
+				( item ) => item.id === 'desktop-mode/embed-open-browser',
+			),
+		).toHaveLength( 1 );
+	} );
+} );

--- a/tests/vitest/desktop-files-web-bookmarks.test.ts
+++ b/tests/vitest/desktop-files-web-bookmarks.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+type BookmarkModule = typeof import( '../../src/desktop-files/web-bookmarks' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+
+const placement = ( overrides: Record< string, unknown > = {} ) => ( {
+	id: 41,
+	parentId: 0,
+	x: 16,
+	y: 16,
+	sortOrder: 0,
+	updatedAtMs: 10,
+	meta: null,
+	file: {
+		type: 'embed',
+		ref: 'https://example.com/',
+		title: 'example.com',
+		icon: 'dashicons-welcome-view-site',
+		previewUrl: '',
+		exists: true,
+		url: 'https://example.com/',
+	},
+	...overrides,
+} );
+
+async function load(): Promise< {
+	bookmarks: BookmarkModule;
+	store: StoreModule;
+	rest: RestModule;
+} > {
+	vi.resetModules();
+	return {
+		bookmarks: await import( '../../src/desktop-files/web-bookmarks' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+	};
+}
+
+describe( 'persistent web bookmark creation', () => {
+	beforeEach( () => {
+		vi.stubGlobal( 'fetch', vi.fn() );
+	} );
+
+	afterEach( () => {
+		vi.unstubAllGlobals();
+	} );
+
+	test( 'creates an embed with the optional custom name', async () => {
+		const { bookmarks, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://station.test/files', nonce: 'n' } );
+		const created = placement( { meta: { name: 'My Example' } } );
+		const enriched = placement( {
+			meta: { name: 'My Example', iconUrl: 'data:image/png;base64,AA' },
+			updatedAtMs: 11,
+		} );
+		const fetchSpy = vi.mocked( fetch );
+		fetchSpy
+			.mockResolvedValueOnce( new Response( JSON.stringify( created ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ) )
+			.mockResolvedValueOnce( new Response( JSON.stringify( enriched ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ) );
+
+		const result = await bookmarks.createWebBookmark( {
+			folderId: 0,
+			url: 'example.com',
+			x: 16,
+			y: 16,
+			name: '  My Example  ',
+		} );
+
+		expect( result.created ).toBe( true );
+		const createBody = JSON.parse( String( fetchSpy.mock.calls[ 0 ][ 1 ]?.body ) );
+		expect( createBody ).toMatchObject( {
+			type: 'embed',
+			ref: 'https://example.com/',
+			meta: { name: 'My Example' },
+		} );
+		expect( String( fetchSpy.mock.calls[ 1 ][ 0 ] ) ).toContain(
+			'/placements/41/web-metadata',
+		);
+	} );
+
+	test( 'paste selects an existing bookmark without moving or erasing metadata', async () => {
+		const { bookmarks, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://station.test/files', nonce: 'n' } );
+		const existing = placement( {
+			meta: {
+				name: 'Renamed later',
+				iconUrl: 'data:image/png;base64,AA',
+				window: { x: 9, y: 8, width: 700, height: 500 },
+			},
+		} );
+		store.setFolderPlacements( 0, [ existing ] );
+
+		const result = await bookmarks.createWebBookmark( {
+			folderId: 0,
+			url: 'https://example.com/',
+			x: 112,
+			y: 16,
+			repositionExisting: false,
+		} );
+
+		expect( result ).toEqual( { placement: existing, created: false } );
+		expect( fetch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'drop repositions an existing bookmark while preserving its metadata', async () => {
+		const { bookmarks, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://station.test/files', nonce: 'n' } );
+		const meta = {
+			name: 'Keep me',
+			iconUrl: 'data:image/png;base64,AA',
+			window: { x: 9, y: 8, width: 700, height: 500 },
+		};
+		const existing = placement( { meta } );
+		const moved = placement( { x: 208, y: 112, meta, updatedAtMs: 12 } );
+		store.setFolderPlacements( 0, [ existing ] );
+		vi.mocked( fetch ).mockResolvedValueOnce(
+			new Response( JSON.stringify( moved ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ),
+		);
+
+		const result = await bookmarks.createWebBookmark( {
+			folderId: 0,
+			url: 'https://example.com/',
+			x: 208,
+			y: 112,
+			repositionExisting: true,
+		} );
+
+		expect( result.placement.meta ).toEqual( meta );
+		const updateBody = JSON.parse( String( vi.mocked( fetch ).mock.calls[ 0 ][ 1 ]?.body ) );
+		expect( updateBody ).toEqual( { x: 208, y: 112 } );
+	} );
+
+	test( 'recovers a bookmark saved before a failed create response', async () => {
+		const { bookmarks, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://station.test/files', nonce: 'n' } );
+		const recovered = placement( {
+			meta: {
+				name: 'Recovered example',
+				iconUrl: 'data:image/png;base64,AA',
+			},
+		} );
+		const fetchSpy = vi.mocked( fetch );
+		fetchSpy
+			.mockResolvedValueOnce( new Response( JSON.stringify( {
+				code: 'desktop_mode_files_not_found_after_create',
+				message: 'The bookmark was saved but could not be read back.',
+			} ), {
+				status: 500,
+				headers: { 'Content-Type': 'application/json' },
+			} ) )
+			.mockResolvedValueOnce( new Response( JSON.stringify( {
+				placements: [ recovered ],
+				folderId: 0,
+			} ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ) );
+
+		const result = await bookmarks.createWebBookmark( {
+			folderId: 0,
+			url: 'example.com',
+			x: 16,
+			y: 16,
+		} );
+
+		expect( result ).toEqual( { placement: recovered, created: true } );
+		expect( fetchSpy ).toHaveBeenCalledTimes( 2 );
+		expect( String( fetchSpy.mock.calls[ 1 ][ 0 ] ) ).toContain(
+			'/placements?folder=0',
+		);
+		expect(
+			store.getFilesState().placementsByFolder.get( 0 ),
+		).toEqual( [ recovered ] );
+	} );
+
+	test( 'preserves a genuine create error when reconciliation finds nothing', async () => {
+		const { bookmarks, store, rest } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( { baseUrl: 'https://station.test/files', nonce: 'n' } );
+		const fetchSpy = vi.mocked( fetch );
+		fetchSpy
+			.mockResolvedValueOnce( new Response( JSON.stringify( {
+				code: 'desktop_mode_files_insert_failed',
+				message: 'Failed to write placement.',
+			} ), {
+				status: 500,
+				headers: { 'Content-Type': 'application/json' },
+			} ) )
+			.mockResolvedValueOnce( new Response( JSON.stringify( {
+				placements: [],
+				folderId: 0,
+			} ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ) );
+
+		await expect( bookmarks.createWebBookmark( {
+			folderId: 0,
+			url: 'example.com',
+			x: 16,
+			y: 16,
+		} ) ).rejects.toThrow( 'Failed to write placement.' );
+		expect( fetchSpy ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/tests/vitest/desktop-files-web-url.test.ts
+++ b/tests/vitest/desktop-files-web-url.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import {
+	looksLikeWebUrl,
+	normalizeWebUrl,
+	urlFromUriList,
+} from '../../src/desktop-files/web-url';
+
+describe( 'desktop web URL parsing', () => {
+	test.each( [
+		[ 'https://example.com/path?q=1', 'https://example.com/path?q=1' ],
+		[ 'http://example.com', 'http://example.com/' ],
+		[ 'example.com/docs', 'https://example.com/docs' ],
+		[ 'localhost:8888/wp-admin', 'https://localhost:8888/wp-admin' ],
+	] )( 'normalizes %s', ( input, expected ) => {
+		expect( normalizeWebUrl( input ) ).toBe( expected );
+	} );
+
+	test.each( [
+		'javascript:alert(1)',
+		'data:text/html,hello',
+		'ftp://example.com',
+		'https://user:pass@example.com/',
+		'https://user@example.com/',
+		'some prose containing https://example.com',
+		'https://example.com/\nhttps://example.org/',
+	] )( 'rejects unsafe or non-standalone input %s', ( input ) => {
+		expect( normalizeWebUrl( input ) ).toBe( '' );
+	} );
+
+	test( 'URI lists ignore comments and use only the first entry', () => {
+		expect(
+			urlFromUriList(
+				'# Source: browser\r\n# another comment\r\nhttps://first.example/a\r\nhttps://second.example/',
+			),
+		).toBe( 'https://first.example/a' );
+	} );
+
+	test( 'plain-text intent excludes arbitrary prose', () => {
+		expect( looksLikeWebUrl( 'example.com' ) ).toBe( true );
+		expect( looksLikeWebUrl( 'https://example.com' ) ).toBe( true );
+		expect( looksLikeWebUrl( 'visit example.com tomorrow' ) ).toBe( false );
+	} );
+} );

--- a/tests/vitest/window-lifecycle-hooks.test.ts
+++ b/tests/vitest/window-lifecycle-hooks.test.ts
@@ -205,12 +205,14 @@ describe( 'Window — lifecycle hook firing', () => {
 		openSpy.mockRestore();
 	} );
 
-	test( 'detach refuses cross-origin URLs and fires nothing', () => {
+	test( 'detach preserves cross-origin URLs exactly', () => {
 		handle.cleanup();
+		const externalUrl = 'https://evil.example.com/a%2Fb?desktop_mode_portal=1&keep=%2F#frag';
 		handle = mountWindow(
 			baseConfig( {
 				id: 'external',
-				url: 'https://evil.example.com/wp-admin/',
+				url: externalUrl,
+				allowExternalUrl: true,
 			} ),
 		);
 		const openSpy = vi
@@ -220,10 +222,16 @@ describe( 'Window — lifecycle hook firing', () => {
 		const log = recordActions( hooks, LIFECYCLE_HOOKS );
 		handle.win.detach();
 
-		expect(
-			log.some( ( e ) => e.name === 'desktop-mode.window.detached' ),
-		).toBe( false );
-		expect( openSpy ).not.toHaveBeenCalled();
+		expect( openSpy ).toHaveBeenCalledWith(
+			externalUrl,
+			'_blank',
+			'noopener,noreferrer',
+		);
+		const evt = log.find( ( e ) => e.name === 'desktop-mode.window.detached' );
+		expect( evt?.args[ 0 ] ).toEqual( {
+			windowId: 'external',
+			url: externalUrl,
+		} );
 
 		openSpy.mockRestore();
 	} );


### PR DESCRIPTION
## Scope

This branch is current `WordPress/desktop-mode:trunk` plus one focused feature commit. It does **not** include showcase themes, generated demo bundles, compatibility-patch files, OpenStation branding, or unrelated window/chrome changes. Every changed file belongs to URL intake, bookmark persistence/metadata, embedded-window behavior, documentation, or direct test coverage.

## Summary

- turn the existing **New URL** action into **New bookmark**, backed by the existing persistent `embed` placement and iframe-window opener
- accept a standalone HTTP(S) URL or domain from native drag-and-drop and focused-surface paste on the wallpaper and inside folders
- normalize safe domains to HTTPS, reject credentials and unsafe schemes, ignore file drags and ordinary prose, and preserve existing placement metadata when a URL already exists
- enrich newly created bookmarks asynchronously with a sanitized page title and favicon through `POST /desktop-mode/v1/files/placements/<id>/web-metadata`
- display fetched favicons at their native scale inside a desktop-sized monitor frame, keeping them crisp without making the tile look undersized
- keep custom names and saved window geometry intact during metadata merges, with hostname/generic-icon fallbacks when remote metadata is unavailable
- validate serialized URLs immediately before opening, make Enter share the double-click opener path, and add an always-visible **Open in browser** title-bar action for sites that block framing
- preserve external URLs exactly when opening them in the browser; Desktop Mode query adjustments remain same-origin-only

No database migration or new file type is required. Existing `link` and `bookmark` placements retain their external-browser behavior.

## URL intake behavior

- `text/uri-list` is preferred over `text/plain`; URI-list comments are ignored
- one standalone URL is accepted per paste/drop
- drops use the nearest free grid cell; paste uses the next free cell
- dropping on a closed folder creates the bookmark inside that folder
- pasting an existing URL selects it without moving it; dropping it repositions the existing placement
- paste is ignored while an editable control, modal, or iframe owns focus

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test:js` — 280 files, 2,817 tests
- `npm run build`
- `npm run package` — packaged and archive-tested under Bash 5
- `phpunit --group desktop-mode-files` — 235 tests, 803 assertions
- full PHP suite — 1,920 tests executed; 1 unrelated existing plugins-window test errored because the local Docker environment could not establish a secure connection to WordPress.org, with 5 skips

## Manual demo

This preview contains only the PR-built Desktop Mode plugin on its default, unthemed desktop. It does not install an OpenStation theme or any other showcase package.

[Open the stock Desktop Mode web-bookmarks preview](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fos.regionallyfamous.com%2Fplayground%2Fapps%2Fdesktop-mode-pr-474-web-bookmarks.zip%3Fv%3D9bef5f2&mode=seamless&storage=temp&networking=yes&can-save=no&page-title=Desktop+Mode+Embedded+Web+Bookmarks+PR+474)

Try dragging or pasting a URL onto the desktop, then double-click it. Sites that send restrictive frame headers remain available through the title-bar **Open in browser** action.