### PR TITLE
Games: Refresh the scoreboard live, and repair the activity bus

### DIFF
--- a/docs/event-driven-framework.md
+++ b/docs/event-driven-framework.md
@@ -244,6 +244,11 @@ const safe = wp.os.activity.filter(
 Channels follow the convention `<plugin>/<event>`. The runtime
 routes them through `os.activity.<channel>` on the hook
 bus, so devtools can list activity traffic as a discrete group.
+Hook names can't contain a slash (`@wordpress/hooks` rejects the
+registration), so the channel separator becomes a period there:
+`my-plugin/thing-happened` lands on
+`desktop-mode.activity.my-plugin.thing-happened`. Only relevant if
+you register through raw `wp.hooks` instead of the API below.
 Type the payload by augmenting `ActivityChannelMap` in your own
 `.d.ts`:
 
@@ -269,6 +274,7 @@ mirrors here so plugins can subscribe through one unified API:
 | `desktop-mode/open-requested` | No | Every `wp.os.openWindow()`, BEFORE deciding `opened` vs `reopened`. Carries `source`. |
 | `desktop-mode/presence-changed` | No | Every presence transition (mirror of the `os-presence-changed` CustomEvent). |
 | `desktop-mode/presence-snapshot-applied` | No | After every presence batch — `{ applied, transitions }`. |
+| `desktop-mode/game-score-recorded` | No | After a game's `submitScore()` write resolves (free play and challenge completion both). Games play in their own window, so this is how a leaderboard in another window learns it went stale. Payload carries `challengeId` on the completion path. |
 
 **Activity ↔ broadcast mirror.** `wp.os.broadcast(topic, payload)`
 publishes both onto the broadcast bus (cross-iframe, cross-tab)

--- a/docs/examples/notify.md
+++ b/docs/examples/notify.md
@@ -72,7 +72,7 @@ that one was shown:
 
 ```js
 wp.hooks.addFilter(
-    'os.activity.desktop-mode/notification-requested',
+    'os.activity.desktop-mode.notification-requested',
     'my-plugin/dnd',
     ( intent ) => {
         if ( isDoNotDisturbActive() ) {
@@ -94,7 +94,8 @@ wp.os.activity.subscribe(
 
 Note the asymmetry: filter *registration* goes through
 `wp.hooks.addFilter` on the `os.activity.<channel>` hook
-name. `wp.os.activity.filter( channel, value )` is the
+name, writing the channel's separator as a period.
+`wp.os.activity.filter( channel, value )` is the
 publisher-side *apply* call — it runs the registered filters against
 `value` and returns the result; passing it a callback registers
 nothing.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1473,7 +1473,7 @@ wp.os.onWindow(
 Cross-plugin activity bus. The transport layer for "thing X happened in plugin A; plugin B might care." Built on top of `wp.hooks` with three benefits over raw `doAction`/`addAction`:
 
 1. **A documented naming convention** (`<plugin>/<event>`).
-2. **A predictable hook prefix** (`os.activity.<channel>`) so devtools can list activity traffic as a discrete group.
+2. **A predictable hook prefix** (`os.activity.<channel>`) so devtools can list activity traffic as a discrete group. The channel's separator becomes a period on the hook bus: `my-plugin/thing-happened` is registered as `os.activity.my-plugin.thing-happened`. This only matters if you reach the bus through raw `wp.hooks`; `publish`/`subscribe`/`filter` take the channel slug and handle the mapping.
 3. **Type-safe payloads** via the `ActivityChannelMap` interface (extend in your own `.d.ts`).
 
 ```typescript
@@ -1505,6 +1505,7 @@ interface ActivityApi {
 | `desktop-mode/open-requested` | Fire-and-forget — `wp.os.openWindow()` publishes here BEFORE deciding `opened` vs `reopened`. | `{ windowId, source }` | No. |
 | `desktop-mode/presence-changed` | Per-transition mirror of the `os-presence-changed` CustomEvent. | `{ userId, oldStatus, newStatus, lastSeenMs, lastActiveMs }` | No. |
 | `desktop-mode/presence-snapshot-applied` | Batch-level — fires after every presence snapshot OR `applyPresenceBatch()`. | `{ applied: number, transitions: number }` | No. |
+| `desktop-mode/game-score-recorded` | Fire-and-forget. Fires after a game's `submitScore()` write resolves, on both the free-play and challenge-completion paths. | `{ game, score, meta, windowId, challengeId? }` | No. |
 
 **Plugin channels** — pick a `<plugin>/<event>` slug and publish. Augment `ActivityChannelMap` for compile-time payload checking:
 
@@ -1703,6 +1704,8 @@ window.openStationGames[ 'my-plugin-puzzle' ] = {
 ```
 
 `render` receives a `GameLaunchContext`: `container` (the window body), `config` (the PHP-registered blob), `challenge` (set when the run is an accepted score-to-beat challenge: `{ id, scoreToBeat, scoreMeta, challengerName }`), `submitScore( { score, meta } )` (routes to the leaderboard, or to the challenge-completion endpoint in challenge mode), and `close()`. The framework suspends the wallpaper for the window's lifetime and opens the window as `os-game-<id>` (no dock tile).
+
+**Score announcements.** Once a `submitScore()` write resolves, the launcher publishes `desktop-mode/game-score-recorded` on the activity bus with `{ game, score, meta, windowId, challengeId? }` (both paths publish; `challengeId` only on challenge completion). Games play in their own window, so this is how leaderboards elsewhere in the shell find out they went stale: the hub's scoreboard subscribes and reloads the page the viewer is on. Subscribe to it if your plugin paints anything derived from scores. A failed write publishes nothing.
 
 **Framework config keys**. For server-registered games, the payload merges framework-level keys underneath the game's own `config` (the game's keys win): **`config.wordsUrl`** is the URL of the shared ~20k-word dictionary asset (`assets/games/words.txt`) — identical for every player, so seeded games (Alphabet Soup's date-seeded daily puzzle) generate the same grid worldwide. Parse it with the framework loader (`src/games/dictionary.ts` — `loadDictionary( url )` → `{ size, pick( minLen, maxLen, rng ) }`); the PHP-side URL + filter is `openstation_games_words_url` in [hooks-reference.md](./hooks-reference.md).
 

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -189,6 +189,25 @@ export interface ActivityChannelMap {
 		applied: number;
 		transitions: number;
 	};
+	/**
+	 * Framework: a game run landed on the leaderboard. Fires after
+	 * the REST write resolves, so a subscriber that refetches sees
+	 * the new row. Games run in their own window
+	 * (`os-game-<id>`); this is how the Games hub, a
+	 * different window and possibly a different bundle, learns that
+	 * its scoreboard went stale.
+	 *
+	 * Both submission paths publish: free play and challenge
+	 * completion (completing a challenge writes a leaderboard row
+	 * too). `challengeId` is set only on the latter.
+	 */
+	'desktop-mode/game-score-recorded': {
+		game: string;
+		score: number;
+		meta: Record< string, string | number >;
+		windowId: string;
+		challengeId?: number;
+	};
 	// Plugin channels go here. The catch-all index signature lets
 	// third-party plugins fall through without explicit type
 	// augmentation; declare specific channels in your own .d.ts
@@ -198,8 +217,13 @@ export interface ActivityChannelMap {
 
 const HOOK_PREFIX = 'os.activity.';
 
+/**
+ * Channel slug → hook name. Characters outside the charset
+ * `@wordpress/hooks` accepts in a hook name collapse to a period,
+ * the separator the prefix already uses.
+ */
 function hookName< K extends keyof ActivityChannelMap >( channel: K ): string {
-	return `${ HOOK_PREFIX }${ String( channel ) }`;
+	return HOOK_PREFIX + String( channel ).replace( /[^a-zA-Z0-9_.-]/g, '.' );
 }
 
 /**

--- a/src/games/launch.ts
+++ b/src/games/launch.ts
@@ -18,15 +18,20 @@
  *      stops — on EVERY close path: normal close, crash inside
  *      render, failed script load.
  *
+ * A finished run also publishes `desktop-mode/game-score-recorded`
+ * on the activity bus so the Games hub's scoreboard (a different
+ * window) can refresh itself.
+ *
  * Uses the `wp.os` public surface (registerWindow, wallpaper,
- * onWindow, loadVendorScript) rather than direct imports so the
- * behavior is identical whether this module is compiled into the
- * main bundle or the games bundle.
+ * onWindow, loadVendorScript, activity) rather than direct imports
+ * so the behavior is identical whether this module is compiled into
+ * the main bundle or the games bundle.
  */
 
 import * as registry from './registry';
 import { startPlaytimeTracker } from './playtime';
 import type { PlaytimeTracker } from './playtime';
+import { ingestChallenges } from './challenges-store';
 import { completeChallenge, submitScore } from './rest';
 import type {
 	GameChallengeContext,
@@ -75,6 +80,9 @@ interface DesktopGlobal {
 		getByBaseId?: ( baseId: string ) => GameWindowLike | undefined;
 		getActiveDesktopId?: () => string;
 		switchDesktop?: ( id: string ) => void;
+	};
+	activity?: {
+		publish: ( channel: string, payload?: unknown ) => void;
 	};
 }
 
@@ -234,14 +242,39 @@ export async function launchGame(
 		restored: () => tracker?.resume(),
 	} );
 
+	// The run finished in THIS window; the Games hub is a different
+	// window (and may be a different bundle) holding a leaderboard
+	// that just went stale. Announce on the activity bus rather than
+	// reaching into the hub. The framework is the transport, the hub
+	// owns what it does about it.
+	const announce = (
+		result: GameScoreSubmission,
+		challengeId?: number,
+	): void => {
+		desktop.activity?.publish( 'desktop-mode/game-score-recorded', {
+			game: id,
+			score: result.score,
+			meta: result.meta ?? {},
+			windowId,
+			challengeId,
+		} );
+	};
+
 	const submit = ( result: GameScoreSubmission ): Promise< void > => {
 		if ( opts.challenge ) {
-			return completeChallenge( opts.challenge.id, result, {
+			const challengeId = opts.challenge.id;
+			return completeChallenge( challengeId, result, {
 				windowId,
-			} ).then( () => undefined );
+			} ).then( ( { challenge } ) => {
+				// The completion response is the authoritative updated
+				// row, so feed the shared store now rather than
+				// waiting for the next Heartbeat delta to carry it.
+				ingestChallenges( [ challenge ] );
+				announce( result, challengeId );
+			} );
 		}
-		return submitScore( id, result, { windowId } ).then(
-			() => undefined,
+		return submitScore( id, result, { windowId } ).then( () =>
+			announce( result ),
 		);
 	};
 

--- a/src/games/scoreboard.ts
+++ b/src/games/scoreboard.ts
@@ -10,6 +10,10 @@
  *
  * Hosted by the Games hub's detail panel (Steam-library style):
  * one instance per selected game, torn down on re-selection.
+ *
+ * Refreshes itself when `desktop-mode/game-score-recorded` names
+ * the mounted game, so a run finishing in the game's own window
+ * repaints the board here without a re-selection or an F5.
  */
 
 // Side-effect imports — register the `<os-*>` components this module
@@ -20,6 +24,7 @@ import '../ui/components/os-relative-time/os-relative-time';
 import '../ui/components/os-table/os-table';
 
 import { __ } from '../i18n';
+import { activity } from '../activity';
 import { fetchScores } from './rest';
 import { openChallengeDialog } from './challenge-dialog';
 import type { OsTable, OsTableColumn } from '../ui/components/os-table/os-table';
@@ -211,9 +216,25 @@ export function renderScoreboard(
 		}
 	};
 
+	// Games play in their own window, so a run finishing is invisible
+	// here without the bus. Reload the page the viewer is looking at
+	// rather than jumping back to page 1. A new score lands at the
+	// top, but yanking them off page 3 to show it is worse than
+	// leaving them where they were.
+	const unsubscribe = activity.subscribe(
+		'desktop-mode/game-score-recorded',
+		( payload ) => {
+			if ( disposed || payload?.game !== game.id ) {
+				return;
+			}
+			void load( page );
+		},
+	);
+
 	void load( 1 );
 
 	return () => {
 		disposed = true;
+		unsubscribe();
 	};
 }

--- a/tests/vitest/activity.test.ts
+++ b/tests/vitest/activity.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { activity } from '../../src/activity';
-import { addFilter, removeFilter } from '../../src/hooks';
+import { addFilter, doAction, removeFilter } from '../../src/hooks';
 import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
 
 describe( 'wp.os.activity', () => {
@@ -52,9 +52,11 @@ describe( 'wp.os.activity', () => {
 		expect( b ).not.toHaveBeenCalled();
 	} );
 
+	// A plugin reaching the bus through raw `wp.hooks` has to spell
+	// the hook name the way the channel maps onto it.
 	test( 'filter mutates the value through registered filters', () => {
 		addFilter(
-			'os.activity.plugin-x/redact',
+			'os.activity.plugin-x.redact',
 			'plugin-x-test',
 			( v: unknown ) => {
 				return ( v as string ).replace( /secret/g, '***' );
@@ -65,7 +67,21 @@ describe( 'wp.os.activity', () => {
 			'this is a secret',
 		);
 		expect( out ).toBe( 'this is a ***' );
-		removeFilter( 'os.activity.plugin-x/redact', 'plugin-x-test' );
+		removeFilter( 'os.activity.plugin-x.redact', 'plugin-x-test' );
+	} );
+
+	test( 'a channel maps onto a hook name @wordpress/hooks accepts', () => {
+		// The regression that made every `subscribe()` a silent no-op
+		// in a browser: `addAction` bails on an invalid name, and
+		// `doAction` still "succeeds" against zero handlers.
+		const cb = vi.fn();
+		activity.subscribe( 'desktop-mode/game-score-recorded', cb );
+		// Reaching the same channel by its raw hook name proves the
+		// mapping, not just that publish/subscribe agree with itself.
+		doAction( 'os.activity.desktop-mode.game-score-recorded', {
+			game: 'inkfall',
+		} );
+		expect( cb ).toHaveBeenCalledWith( { game: 'inkfall' } );
 	} );
 
 	test( 'filter falls through when no filters registered', () => {

--- a/tests/vitest/games-launch.test.ts
+++ b/tests/vitest/games-launch.test.ts
@@ -28,6 +28,7 @@ interface FakeDesktop {
 		getActiveDesktopId?: ReturnType< typeof vi.fn >;
 		switchDesktop?: ReturnType< typeof vi.fn >;
 	};
+	activity: { publish: ReturnType< typeof vi.fn > };
 	fetch: ReturnType< typeof vi.fn >;
 	config: { restUrl: string; restNonce: string };
 }
@@ -75,6 +76,7 @@ describe( 'games/launch.ts', () => {
 			wallpaper: { suspend: vi.fn(), resume: vi.fn() },
 			loadVendorScript: vi.fn().mockResolvedValue( undefined ),
 			windowManager: { getById: vi.fn().mockReturnValue( undefined ) },
+			activity: { publish: vi.fn() },
 			fetch: vi.fn().mockResolvedValue(
 				new Response( JSON.stringify( { id: 1 } ), { status: 200 } ),
 			),
@@ -286,5 +288,94 @@ describe( 'games/launch.ts', () => {
 
 		const [ url ] = fake.fetch.mock.calls[ 0 ] as [ string ];
 		expect( url ).toContain( 'desktop-mode/v1/games/challenges/7/complete' );
+	} );
+
+	test( 'a recorded score announces on the activity bus', async () => {
+		const { registry, launch } = await loadModules();
+		registerGame( registry );
+
+		await launch.launchGame( 'test-game' );
+		await capturedCtx!.submitScore( { score: 42, meta: { wpm: 61 } } );
+
+		expect( fake.activity.publish ).toHaveBeenCalledWith(
+			'desktop-mode/game-score-recorded',
+			{
+				game: 'test-game',
+				score: 42,
+				meta: { wpm: 61 },
+				windowId: 'os-game-test-game',
+				challengeId: undefined,
+			},
+		);
+	} );
+
+	test( 'the announcement waits for the REST write to resolve', async () => {
+		const { registry, launch } = await loadModules();
+		registerGame( registry );
+		let settle: ( () => void ) | undefined;
+		fake.fetch.mockImplementation(
+			() =>
+				new Promise< Response >( ( resolve ) => {
+					settle = () =>
+						resolve(
+							new Response( JSON.stringify( { id: 1 } ), {
+								status: 200,
+							} ),
+						);
+				} ),
+		);
+
+		await launch.launchGame( 'test-game' );
+		const pending = capturedCtx!.submitScore( { score: 42 } );
+		// Subscribers refetch on this event; publishing before the
+		// write lands would have them read the pre-score leaderboard.
+		expect( fake.activity.publish ).not.toHaveBeenCalled();
+
+		settle!();
+		await pending;
+		expect( fake.activity.publish ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'a failed submit announces nothing', async () => {
+		const { registry, launch } = await loadModules();
+		registerGame( registry );
+		fake.fetch.mockResolvedValue(
+			new Response( JSON.stringify( { message: 'nope' } ), {
+				status: 500,
+			} ),
+		);
+
+		await launch.launchGame( 'test-game' );
+		await expect(
+			capturedCtx!.submitScore( { score: 42 } ),
+		).rejects.toThrow( 'nope' );
+
+		expect( fake.activity.publish ).not.toHaveBeenCalled();
+	} );
+
+	test( 'challenge completion announces with the challenge id', async () => {
+		const { registry, launch } = await loadModules();
+		registerGame( registry );
+		fake.fetch.mockResolvedValue(
+			new Response(
+				JSON.stringify( { challenge: { id: 7, game: 'test-game' } } ),
+				{ status: 200 },
+			),
+		);
+
+		await launch.launchGame( 'test-game', {
+			challenge: {
+				id: 7,
+				scoreToBeat: 100,
+				scoreMeta: {},
+				challengerName: 'A',
+			},
+		} );
+		await capturedCtx!.submitScore( { score: 120 } );
+
+		expect( fake.activity.publish ).toHaveBeenCalledWith(
+			'desktop-mode/game-score-recorded',
+			expect.objectContaining( { game: 'test-game', challengeId: 7 } ),
+		);
 	} );
 } );

--- a/tests/vitest/games-scoreboard.test.ts
+++ b/tests/vitest/games-scoreboard.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for `src/games/scoreboard.ts`: the live refresh that
+ * keeps the Games hub's leaderboard in step with runs finishing in
+ * the game's own window, plus the `time` column formatter.
+ *
+ * The REST client is mocked so the tests assert on refetches rather
+ * than on painted rows; `<os-table>` is left to its real
+ * implementation (it only has to accept the assignments).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import type { GameRegistryEntry, GameScoreRow } from '../../src/games/types';
+
+const fetchScoresSpy = vi.fn();
+
+vi.mock( '../../src/games/rest', () => ( {
+	fetchScores: ( ...args: unknown[] ) => fetchScoresSpy( ...args ),
+} ) );
+
+type Activity = typeof import( '../../src/activity' );
+type Scoreboard = typeof import( '../../src/games/scoreboard' );
+
+async function loadModules(): Promise< {
+	activity: Activity;
+	scoreboard: Scoreboard;
+} > {
+	vi.resetModules();
+	return {
+		activity: await import( '../../src/activity' ),
+		scoreboard: await import( '../../src/games/scoreboard' ),
+	};
+}
+
+const GAME: GameRegistryEntry = {
+	id: 'inkfall',
+	title: 'Inkfall',
+	icon: 'dashicons-admin-generic',
+	scoreColumns: [ { key: 'score', label: 'Score' } ],
+};
+
+const makeRow = ( overrides: Partial< GameScoreRow > = {} ): GameScoreRow => ( {
+	id: 1,
+	userId: 1,
+	userName: 'Player',
+	userAvatar: 'https://example.test/a.png',
+	score: 100,
+	meta: {},
+	createdAtMs: 1_700_000_000_000,
+	...overrides,
+} );
+
+/** A leaderboard page big enough to paginate (PER_PAGE is 25). */
+const page = ( total: number ): { scores: GameScoreRow[]; total: number } => ( {
+	scores: [ makeRow() ],
+	total,
+} );
+
+describe( 'games/scoreboard.ts', () => {
+	let container: HTMLElement;
+
+	beforeEach( () => {
+		installHooksStub();
+		fetchScoresSpy.mockReset();
+		fetchScoresSpy.mockResolvedValue( page( 1 ) );
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		container.remove();
+	} );
+
+	test( 'formatTimeValue renders seconds as m:ss', async () => {
+		const { scoreboard } = await loadModules();
+
+		expect( scoreboard.formatTimeValue( 0 ) ).toBe( '0:00' );
+		expect( scoreboard.formatTimeValue( 9 ) ).toBe( '0:09' );
+		expect( scoreboard.formatTimeValue( 125 ) ).toBe( '2:05' );
+		// Junk and negatives floor at zero rather than rendering NaN.
+		expect( scoreboard.formatTimeValue( -5 ) ).toBe( '0:00' );
+		expect( scoreboard.formatTimeValue( 'nope' ) ).toBe( '0:00' );
+	} );
+
+	test( 'a recorded score for this game refetches the board', async () => {
+		const { activity, scoreboard } = await loadModules();
+		const teardown = scoreboard.renderScoreboard( container, GAME );
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 ),
+		);
+
+		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+			game: 'inkfall',
+			score: 42,
+			meta: {},
+			windowId: 'os-game-inkfall',
+		} );
+
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 2 ),
+		);
+		teardown();
+	} );
+
+	test( 'a recorded score for another game is ignored', async () => {
+		const { activity, scoreboard } = await loadModules();
+		const teardown = scoreboard.renderScoreboard( container, GAME );
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 ),
+		);
+
+		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+			game: 'alphabet-soup',
+			score: 42,
+			meta: {},
+			windowId: 'os-game-alphabet-soup',
+		} );
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 );
+		teardown();
+	} );
+
+	test( 'the refresh reloads the page being viewed, not page 1', async () => {
+		const { activity, scoreboard } = await loadModules();
+		// 60 rows over a 25-per-page board, enough for a page 3.
+		fetchScoresSpy.mockResolvedValue( page( 60 ) );
+		const teardown = scoreboard.renderScoreboard( container, GAME );
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 ),
+		);
+
+		// Walk to page 2 the way the pager does.
+		const next = Array.from(
+			container.querySelectorAll( 'os-button' ),
+		).find( ( btn ) => 'Next' === btn.textContent );
+		next?.dispatchEvent( new Event( 'click' ) );
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenLastCalledWith(
+				'inkfall',
+				expect.objectContaining( { page: 2 } ),
+			),
+		);
+
+		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+			game: 'inkfall',
+			score: 42,
+			meta: {},
+			windowId: 'os-game-inkfall',
+		} );
+
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 3 ),
+		);
+		expect( fetchScoresSpy ).toHaveBeenLastCalledWith(
+			'inkfall',
+			expect.objectContaining( { page: 2 } ),
+		);
+		teardown();
+	} );
+
+	test( 'teardown unsubscribes so a torn-down board never refetches', async () => {
+		const { activity, scoreboard } = await loadModules();
+		const teardown = scoreboard.renderScoreboard( container, GAME );
+		await vi.waitFor( () =>
+			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 ),
+		);
+
+		teardown();
+		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+			game: 'inkfall',
+			score: 42,
+			meta: {},
+			windowId: 'os-game-inkfall',
+		} );
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/tests/vitest/helpers/hooks-stub.ts
+++ b/tests/vitest/helpers/hooks-stub.ts
@@ -25,6 +25,31 @@ export interface FakeWpHooks {
 	hasFilter: ( name: string, ns?: string ) => boolean | number;
 }
 
+/**
+ * The same validation the real `@wordpress/hooks` applies before
+ * registering a handler. `addAction`/`addFilter` silently bail on an
+ * invalid name while `doAction`/`applyFilters` still run against an
+ * empty handler list, so a stub that skips this reports a working
+ * bus where a browser would register nothing. Throwing (rather than
+ * WordPress's console.error) turns that into a red test.
+ */
+function assertValidHookName( name: string ): void {
+	if ( ! /^[a-zA-Z][a-zA-Z0-9_.-]*$/.test( name ) || /^__/.test( name ) ) {
+		throw new Error(
+			`Invalid hook name "${ name }": @wordpress/hooks allows only ` +
+				'letters, numbers, dashes, periods and underscores, ' +
+				'and would reject this registration at runtime.',
+		);
+	}
+}
+
+/** Namespaces use a looser charset than hook names. */
+function assertValidNamespace( ns: string ): void {
+	if ( ! /^[a-zA-Z][a-zA-Z0-9_.\-/]*$/.test( ns ) ) {
+		throw new Error( `Invalid hook namespace "${ ns }".` );
+	}
+}
+
 export function createHooksStub(): FakeWpHooks {
 	const filters = new Map<
 		string,
@@ -41,11 +66,15 @@ export function createHooksStub(): FakeWpHooks {
 
 	return {
 		addFilter( name, ns, cb, priority = 10 ) {
+			assertValidHookName( name );
+			assertValidNamespace( ns );
 			const list = filters.get( name ) ?? [];
 			list.push( { ns, cb, priority } );
 			filters.set( name, list );
 		},
 		addAction( name, ns, cb, priority = 10 ) {
+			assertValidHookName( name );
+			assertValidNamespace( ns );
 			const list = actions.get( name ) ?? [];
 			list.push( { ns, cb, priority } );
 			actions.set( name, list );


### PR DESCRIPTION
Finishing a game left the Games hub showing a stale leaderboard. The score was saved, but the board only caught up if you re-selected the game or reloaded. Affects both Inkfall and Alphabet Soup.

Games play in their own window (`os-game-<id>`), and the hub had no way to hear that a run had finished: the scoreboard fetched once on mount and never again.

## What it does

The launcher publishes `desktop-mode/game-score-recorded` on the activity bus once a score write resolves, and the scoreboard subscribes. The hub is the transport's consumer, not something the game window reaches into.

- Both submission paths publish. Completing a challenge writes a leaderboard row too (`desktop_mode_games_complete_challenge()`), so it carries a `challengeId`.
- The refresh reloads the page the viewer is on, not page 1. A new score lands at the top, but pulling someone off page 3 to show it is worse than leaving them put.
- Publishing happens after the REST write resolves. Subscribers refetch, so announcing earlier would have them read the pre-score board. A failed write announces nothing.
- Challenge completion now feeds its response into the shared challenges store rather than waiting for the next Heartbeat tick, so the Challenges list updates at the same moment.

Play time is still a one-shot fetch. It flushes on window close rather than on score, so it needs a different trigger.

## The activity bus was dead

The first version of this worked in tests and did nothing in a browser, which turned out to be a framework bug rather than anything in the games code.

**`wp.os.activity.subscribe()` has never registered a handler.** The bus built its hook name as `os.activity.` + the channel slug, producing names like `os.activity.desktop-mode/game-score-recorded`. `@wordpress/hooks` validates hook names against `/^[a-zA-Z][a-zA-Z0-9_.-]*$/`, and a slash is not in that set. Only namespaces may contain one.

It fails silently in both directions:

- `addAction` / `addFilter` call `validateHookName()` and return early, logging a console error and registering nothing.
- `doAction` / `applyFilters` do not validate. They create an empty handler bucket and run against it, so every publish looks successful.

The documented channel convention is `<plugin>/<event>`, so every channel hit this, including the DND filter recipe in `docs/examples/notify.md`.

The fix maps any character outside the allowed set onto a period, so `desktop-mode/game-score-recorded` becomes `os.activity.desktop-mode.game-score-recorded`. Not a breaking change in practice: the old names could never be registered against, so nothing can depend on them. The four places that documented the old spelling are corrected.

The tests missed it because `tests/vitest/helpers/hooks-stub.ts` skipped the validation the real implementation performs, so the bus round-tripped happily with itself. The stub now enforces the same name and namespace rules and throws on a violation. It immediately caught the one existing test that hand-wrote a slashed hook name, and the rest of the suite passes under it, so the activity bus was the only offender.

## Testing instructions

Rebased onto the OpenStation rebrand. Games are opt-in: enable them first at OS Settings > Features > Extended options.

1. Enter Desktop Mode, open **Games**, select **Inkfall**, and note the scoreboard.
2. Click **Play** and finish a run.
3. Make sure your score appears in the scoreboard **while the game window is still open**, with no re-selection and no reload.
4. Repeat with **Alphabet Soup**.

Page preservation, on a leaderboard with more than 25 scores:

1. Page the scoreboard to page 2.
2. Play a run and finish it.
3. Make sure the board reloads **page 2**, not page 1.

Challenges:

1. Send a challenge to a second user, then accept it as that user and play it.
2. Make sure both the scoreboard and the Challenges list update as soon as the run ends, without waiting for a Heartbeat tick.

The activity bus itself, from the console on the desktop page:

```js
wp.os.activity.subscribe( 'my-plugin/test', ( p ) => console.log( 'got', p ) );
wp.os.activity.publish( 'my-plugin/test', { hello: 'world' } );
```

Make sure `got { hello: 'world' }` is logged and no hook-name error appears. On trunk the subscribe logs "The hook name can only contain numbers, letters, dashes, periods and underscores" and the callback never fires.

Automated:

```bash
npm run test:js
```

3656 tests, including a new `tests/vitest/games-scoreboard.test.ts` and coverage for the channel-to-hook-name mapping asserted through the raw hook name so it cannot pass by self-agreement.

## Docs

`javascript-reference.md`, `event-driven-framework.md` and `examples/notify.md`: the new channel in both built-in channel tables, a score-announcements note in the games section, and the corrected hook-name spelling everywhere it appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-476-6d7de5d580980bf9ecc0b1a40aa677e2658fda7d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20OpenStation%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;openstation_is_enabled&#039;%20)%20%7C%7C%20!%20openstation_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;openstation&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.os.ready(function()%7Bvar%20games%3Dwindow.wp.os.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->