### PR TITLE
The holographic layer, <os-switch>, and the Components tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ The imperative rules for working in this repo, plus the contributor-only gotchas
 - [Hard rules](#hard-rules)
   - [Never hand-edit JS in `assets/js/`](#never-hand-edit-js-in-assetsjs)
   - [The palette lives in `variables.css`](#the-palette-lives-in-variablescss--one-declaration-one-owner)
+  - [The holographic layer lives in `src/ui/holo.ts`](#the-holographic-layer-lives-in-srcuiholots)
   - [Never declare a themeable token on a component's `:host`](#never-declare-a-themeable-token-on-a-components-host)
   - [The Legacy theme manifest is frozen data](#the-legacy-theme-manifest-is-frozen-data-not-build-output)
   - [`desktop_mode_*` values are frozen](#desktop_mode_-values-are-frozen--the-namevalue-mismatch-is-deliberate)
@@ -65,6 +66,25 @@ Three rules follow from that, and all have tests:
 2. **Every consuming rule keeps reading `var( --token, <literal> )`**, and that literal stays the pre-brand WordPress-admin value. It is the floor if the stylesheet fails to load, and it is what the Legacy snapshot collected. Never "tidy" a fallback away.
 
 **The failure mode to watch for after a palette change** is a chain that now means something else: a fill resolving to a 10%-alpha wash, or a base and its hover state — declared in two different rules, distinguished only by their fallback literals — collapsing onto the same value once the shared token is declared. `<os-button>`'s ghost/secondary hover did exactly that. When a surface stops reacting to the pointer, check whether both states resolve through the same palette token, and declare the second one.
+
+### The holographic layer lives in `src/ui/holo.ts`
+
+**"Holographic" is a moment, not a skin, and there is exactly one module that decides what it means.**
+
+The brand ships five mesh gradients with one instruction attached — *"meshes reserved for hero surfaces"* — and `src/ui/holo.ts` is how a control gets to be one. It exports six `css` fragments (`holoTokens`, `holoFill`, `holoSheen`, `holoEdge`, `holoField`, `holoCheck`, `holoDrift`, plus the `holo` barrel) that components interpolate into their own styles. The meshes themselves are transcribed stop-for-stop from the brand SVGs into `--os-mesh-*` in `variables.css`; they are gradient stacks rather than `url()`s because `background-position` can slide a gradient, and that slide *is* the effect.
+
+Three rules, all with tests:
+
+1. **A control paints the mesh when it is on, selected, primary or filled — and wears Obsidian the rest of the time.** A panel where every surface is iridescent has no identity moments left to spend. `<os-button variant="holo">` exists precisely so the loud version is hard to reach for by accident; `primary` deliberately did *not* become the mesh, because it is three-to-a-row in OS Settings and a mesh three-to-a-row is wallpaper.
+2. **`holoTokens` is a prerequisite for every other fragment** — it declares the private `--_holo-*` aliases they read. Include it once per component. Never declare a `--os-ui-*` name on the bare `:host` (see the next rule).
+3. **Reduced motion stops the tilt, never the fill.** A control that lost its mesh under `prefers-reduced-motion` would lose its *state*, not just its animation.
+
+Two things that will bite you:
+
+- **Comments inside a `` css`` `` template cannot contain backticks.** It is a JS template literal; a backtick in a CSS comment terminates it and the file stops parsing with a bare "expected a semicolon". Write `--_drag` and `::before` unquoted in those comments.
+- **`holoField` uses bare `input` / `select` / `textarea` selectors** — safe inside a shadow root, and one careless `:not()` away from outranking every component's own `aria-invalid` ring. The type exclusions are wrapped in `:where()` to hold the selector at (0,1,1). Don't unwrap them.
+
+`tests/vitest/holo-layer.test.ts` pins the mesh transcriptions against the brand's hexes, the alias privacy, and the `:where()` specificity. Public surface: [`docs/components-reference.md`](docs/components-reference.md#the-holographic-layer) and the token table in [`docs/desktop-themes.md`](docs/desktop-themes.md).
 
 ### Never declare a themeable token on a component's `:host`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,12 +79,15 @@ Three rules, all with tests:
 2. **`holoTokens` is a prerequisite for every other fragment** — it declares the private `--_holo-*` aliases they read. Include it once per component. Never declare a `--os-ui-*` name on the bare `:host` (see the next rule).
 3. **Reduced motion stops the tilt, never the fill.** A control that lost its mesh under `prefers-reduced-motion` would lose its *state*, not just its animation.
 
-Two things that will bite you:
+Three things that will bite you:
 
-- **Comments inside a `` css`` `` template cannot contain backticks.** It is a JS template literal; a backtick in a CSS comment terminates it and the file stops parsing with a bare "expected a semicolon". Write `--_drag` and `::before` unquoted in those comments.
+- **Comments inside a `` css`` `` template cannot contain backticks.** It is a JS template literal; a backtick in a CSS comment terminates it and the file stops parsing with a bare "expected a semicolon" pointing at prose. Write `--_drag` and `::before` unquoted in those comments. `tests/vitest/css-template-hygiene.test.ts` is the guard, and its message says what to do — it exists because this mistake is easy, frequent, and completely opaque the first few times.
 - **`holoField` uses bare `input` / `select` / `textarea` selectors** — safe inside a shadow root, and one careless `:not()` away from outranking every component's own `aria-invalid` ring. The type exclusions are wrapped in `:where()` to hold the selector at (0,1,1). Don't unwrap them.
+- **The pseudo-element budget is spent.** `holoSheen` owns `::before` and `holoEdge` owns `::after`; a control wearing both has none left. That is why `holoGlint` and `holoRing` are element-based (`<span class="os-holo-glint">`) and driven from the parent's state through the **child** combinator — `:active` matches every ancestor of the pressed element, so `:active .os-holo-ring` fires every ring on the page. New motion fragments should follow the same shape rather than competing for a pseudo.
 
-`tests/vitest/holo-layer.test.ts` pins the mesh transcriptions against the brand's hexes, the alias privacy, and the `:where()` specificity. Public surface: [`docs/components-reference.md`](docs/components-reference.md#the-holographic-layer) and the token table in [`docs/desktop-themes.md`](docs/desktop-themes.md).
+**How loud the station is** is one token: `--os-ui-accent-dim`, Pulse one step back. Every ambient use of the accent — glows, washes, focus blooms — resolves through it, so "tone it down" is one edit rather than an audit. `--os-ui-accent` itself stays `#f252fc`; that one is the brand's, not ours, and `brand-palette.test.ts` pins it. The focus **ring** deliberately does not dim — only the bloom behind it does.
+
+`tests/vitest/holo-layer.test.ts` pins the mesh transcriptions against the brand's hexes, the alias privacy, the `:where()` specificity, the dim routing, and reduced-motion coverage on every fragment. Public surface: [`docs/components-reference.md`](docs/components-reference.md#the-holographic-layer) and the token tables in [`docs/desktop-themes.md`](docs/desktop-themes.md).
 
 ### Never declare a themeable token on a component's `:host`
 

--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -21,6 +21,41 @@ body.os-active {
 }
 
 /*
+ * Text selection.
+ *
+ * The shell had no ::selection rule at all, so every selection in it
+ * was the browser default — a colour chosen for a white page, landing
+ * on a near-black one. In Chrome that is a dark translucent blue over
+ * Obsidian, which is roughly 1.3:1 against the surface and leaves the
+ * selected text at a contrast the UA never checked, because the UA
+ * assumed a light background. Dragging across a paragraph produced no
+ * visible change at all on some displays.
+ *
+ * Both halves are set on purpose. `background` alone is the common
+ * half-fix: the UA then keeps its own selected-text colour, which is
+ * frequently forced to black and lands on this violet at ~2:1.
+ *
+ * Scoped to the shell document. `variables.css` is a dependency of
+ * `chromeless.css` and so loads inside every iframe window, but this
+ * file does not — a wp-admin page in a window keeps the selection
+ * colour it has outside one, which is the same promise the palette
+ * makes about everything else.
+ *
+ * `::-moz-selection` is a separate rule rather than a second selector
+ * on this one: an unrecognised pseudo-element invalidates the entire
+ * selector list, so pairing them would leave Chrome unstyled too.
+ */
+body.os-active ::selection {
+	background: var( --os-ui-selection-bg, rgba( 159, 152, 255, 0.6 ) );
+	color: var( --os-ui-selection-fg, #fffbff );
+}
+
+body.os-active ::-moz-selection {
+	background: var( --os-ui-selection-bg, rgba( 159, 152, 255, 0.6 ) );
+	color: var( --os-ui-selection-fg, #fffbff );
+}
+
+/*
  * Cursor policy — default arrow everywhere in OpenStation.
  *
  * Per user preference (since 0.20.0): no hand/pointer/grab/grabbing/

--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -827,11 +827,6 @@
 	color: var( --os-ui-info-fg, #123fb3 );
 }
 
-.os-settings__help-since {
-	font-size: 11px;
-	color: var( --os-ui-fg-muted, #646970 );
-}
-
 .os-settings__help-summary {
 	margin: 0 0 16px;
 	color: var( --os-ui-fg, #1d2327 );

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -336,6 +336,174 @@ body.os-active {
 	--os-ui-accent-soft: rgba(242, 82, 252, 0.18);
 
 	/*
+	 * ---- The meshes ---------------------------------------------
+	 *
+	 * The brand ships five mesh gradients as SVG artwork. These are
+	 * those same meshes transcribed into CSS: the base linear plus
+	 * every radial glow, at the offsets, radii, colours and alphas
+	 * the vector files declare, converted from the 1440×960 artboard
+	 * into percentages so they scale to any box.
+	 *
+	 * Transcribed rather than referenced on purpose. A `url()` to an
+	 * SVG cannot be animated, cannot be tinted, costs a request, and
+	 * cannot resize its glows independently of the box — a mesh
+	 * painted on a 40 px switch track would be one flat corner of the
+	 * artwork. As gradient stacks they rasterise at whatever size the
+	 * control happens to be, and `background-position` can slide them,
+	 * which is the entire holographic effect: a foil that shifts as
+	 * you tilt it.
+	 *
+	 * Layer order is inverted from the SVG. In SVG the last `<rect>`
+	 * paints on top; in a CSS `background-image` list the FIRST layer
+	 * is on top. So each mesh below reads bottom-glow-first and ends
+	 * with its base linear.
+	 *
+	 * The brand's own rule — "meshes reserved for hero surfaces" — is
+	 * why none of these is a surface colour. They are what the shell
+	 * paints at an identity moment: a switch that is on, the primary
+	 * action in a dialog, the filled part of a progress bar. See the
+	 * `--os-ui-holo-*` block below for the tokens components actually
+	 * read.
+	 */
+
+	/*
+	 * Holomesh. Lavender base under eight glows — white, cyan, pink,
+	 * warm, mint, white, pink, blue. The default holographic fill.
+	 */
+	--os-mesh-holo:
+		radial-gradient(ellipse 21.7% 39.6% at 96.5% 13.5%, rgba(159, 214, 255, 0.6) 0%, rgba(159, 214, 255, 0) 100%),
+		radial-gradient(ellipse 26.3% 57.2% at 83.3% 56.2%, rgba(243, 181, 236, 0.75) 0%, rgba(243, 181, 236, 0) 100%),
+		radial-gradient(ellipse 18.2% 47.3% at 73.6% 64.5%, rgba(255, 253, 255, 0.7) 0%, rgba(255, 253, 255, 0) 100%),
+		radial-gradient(ellipse 18.4% 34.1% at 29.8% 83.4%, rgba(147, 240, 198, 0.8) 0%, rgba(147, 240, 198, 0) 100%),
+		radial-gradient(ellipse 17.4% 35.7% at 23% 67.7%, rgba(248, 242, 182, 0.85) 0%, rgba(248, 242, 182, 0) 100%),
+		radial-gradient(ellipse 23.3% 45.9% at 45.2% 45.8%, rgba(245, 159, 232, 1) 0%, rgba(245, 168, 234, 0.55) 55%, rgba(245, 168, 234, 0) 100%),
+		radial-gradient(ellipse 29.9% 53.6% at 53.5% 7.3%, rgba(125, 239, 245, 0.9) 0%, rgba(142, 233, 247, 0.45) 60%, rgba(142, 233, 247, 0) 100%),
+		radial-gradient(ellipse 26.9% 70.7% at 29.8% 44.8%, rgba(255, 253, 255, 0.95) 0%, rgba(255, 253, 255, 0.5) 55%, rgba(255, 253, 255, 0) 100%),
+		linear-gradient(124deg, #afa2e8 0%, #b7abea 55%, #c3b8ef 100%);
+
+	/*
+	 * Pulsemesh. The loud one — a blue-to-violet base torn open by
+	 * magenta. Reserved for the moments Holomesh would undersell.
+	 */
+	--os-mesh-pulse:
+		radial-gradient(ellipse 39.1% 48.6% at 92% 94.5%, rgba(255, 253, 255, 0.95) 0%, rgba(255, 240, 252, 0.55) 50%, rgba(255, 240, 252, 0) 100%),
+		radial-gradient(ellipse 33.3% 50% at 61.1% 62.5%, rgba(251, 134, 236, 0.85) 0%, rgba(251, 134, 236, 0) 100%),
+		radial-gradient(ellipse 36.1% 54.2% at 10.4% 39.6%, rgba(250, 61, 248, 1) 0%, rgba(250, 61, 248, 0) 100%),
+		radial-gradient(ellipse 87.3% 104.8% at 10.6% 100%, rgba(240, 75, 245, 1) 0%, rgba(240, 75, 245, 0.75) 43%, rgba(240, 75, 245, 0) 100%),
+		radial-gradient(ellipse 36.1% 45.8% at 92.4% 12.5%, rgba(125, 239, 245, 0.95) 0%, rgba(125, 239, 245, 0) 100%),
+		radial-gradient(ellipse 43.1% 54.2% at 81.3% 34.4%, rgba(108, 143, 245, 0.6) 0%, rgba(108, 143, 245, 0) 100%),
+		linear-gradient(236deg, #8d9bf3 0%, #c878f0 100%);
+
+	/* Auromesh. Lavender through mint into cyan — the calm mesh. */
+	--os-mesh-auro: linear-gradient(80deg, #d1c6f8 9.5%, #cefada 50%, #b8ffff 90.5%);
+
+	/* Starmesh. A Starlight glow falling away into Cloud. */
+	--os-mesh-star:
+		radial-gradient(ellipse 72.7% 72.7% at 50% 12.5%, #fffbff 0%, #fffbff 67.8%, #ccc8ce 100%);
+
+	/* Miomesh. The mascot's own sweep. Mio's, and used sparingly. */
+	--os-mesh-mio: linear-gradient(90deg, #f252fc 7%, #aa67ff 48.3%, #a580ff 70.7%, #4b3eff 93%);
+
+	/*
+	 * ---- Holographic controls -----------------------------------
+	 *
+	 * What a control reads when it wants to be holographic. Every
+	 * `<os-*>` resolves these through a private `--_holo-*` alias (see
+	 * `src/ui/holo.ts`), so a desktop theme can re-point any of them
+	 * and every control in the kit changes together.
+	 *
+	 * The holographic state is a MOMENT, not a skin. A control paints
+	 * `--os-ui-holo-fill` when it is on, selected, primary or filled —
+	 * the one instant it is speaking for the brand — and wears
+	 * ordinary Obsidian the rest of the time. That is the difference
+	 * between a station and a novelty; a panel where every control is
+	 * iridescent has no identity moments left to spend.
+	 */
+
+	/* The fill itself. Holomesh, so the mesh is the default look. */
+	--os-ui-holo-fill: var(--os-mesh-holo);
+	/*
+	 * Glyphs and text ON that fill. Void, not Starlight — every mesh
+	 * in the brand is a LIGHT surface (its darkest stop, Holomesh's
+	 * #afa2e8, still sits at 62% luminance), so Starlight on it is a
+	 * white-on-lilac 1.4:1 that looks fine in a mock and is unreadable
+	 * on a screen. Void carries at 8.6:1 against the same stop.
+	 */
+	--os-ui-holo-ink: #0c0b0f;
+	/*
+	 * The hover film. A control that is NOT in its holographic state
+	 * still hints at one under the pointer: a low-alpha sweep of the
+	 * mesh's own hues, laid over whatever the surface already is.
+	 *
+	 * Alphas are deliberately in the 6–12% range. This lands on
+	 * Obsidian, where anything stronger stops reading as a sheen and
+	 * starts reading as a second, wrongly-coloured surface.
+	 */
+	--os-ui-holo-sheen: linear-gradient(
+		124deg,
+		rgba(159, 214, 255, 0.1) 0%,
+		rgba(236, 155, 255, 0.12) 34%,
+		rgba(242, 82, 252, 0.1) 58%,
+		rgba(147, 240, 198, 0.09) 100%
+	);
+	/*
+	 * The iridescent hairline. Painted as a gradient on a padding-box
+	 * mask rather than a `border-color`, because a border cannot hold
+	 * a gradient and `border-image` loses the corner radius.
+	 */
+	--os-ui-holo-edge: linear-gradient(
+		124deg,
+		rgba(154, 242, 255, 0.7) 0%,
+		rgba(236, 155, 255, 0.85) 38%,
+		rgba(242, 82, 252, 0.7) 62%,
+		rgba(159, 152, 255, 0.6) 100%
+	);
+	/* Resting edge — the same hairline, quieted, for an idle control. */
+	--os-ui-holo-edge-quiet: linear-gradient(
+		124deg,
+		rgba(154, 242, 255, 0.22) 0%,
+		rgba(236, 155, 255, 0.28) 38%,
+		rgba(242, 82, 252, 0.22) 62%,
+		rgba(159, 152, 255, 0.2) 100%
+	);
+	/*
+	 * The bloom around a holographic surface. Pulse, because on a Void
+	 * desk the glow is what separates "lit" from "light-coloured".
+	 */
+	--os-ui-holo-glow: 0 0 0 1px rgba(242, 82, 252, 0.28), 0 2px 10px rgba(242, 82, 252, 0.22);
+	--os-ui-holo-glow-strong: 0 0 0 1px rgba(242, 82, 252, 0.42), 0 4px 18px rgba(242, 82, 252, 0.38),
+		0 1px 3px rgba(12, 11, 15, 0.6);
+	/*
+	 * The unlit half. Switch tracks, empty progress, an unselected
+	 * segment: a sunken Void well inside the Obsidian surface, so the
+	 * lit half has something to be lit AGAINST.
+	 */
+	--os-ui-holo-track: rgba(12, 11, 15, 0.55);
+	/*
+	 * Focus. One ring for the whole kit — Pulse, offset, over a soft
+	 * Nebula halo, so it reads on Obsidian, on a mesh, and on the
+	 * near-white of a legacy theme alike.
+	 */
+	--os-ui-focus-ring: 0 0 0 2px rgba(12, 11, 15, 0.9), 0 0 0 4px #f252fc,
+		0 0 12px 2px rgba(242, 82, 252, 0.45);
+	/*
+	 * …and one for FIELDS, which is a different problem. A text input
+	 * already has a border to thicken and it sits in a column of other
+	 * inputs, so the ring above — designed to survive landing on a
+	 * bright mesh — reads as an alarm on a settings form. This one
+	 * tightens the field's own edge to Pulse and puts a soft halo
+	 * outside it: unmistakable, and quiet enough to live in a stack of
+	 * twelve.
+	 */
+	--os-ui-focus-ring-field: 0 0 0 1px #f252fc, 0 0 0 4px rgba(242, 82, 252, 0.18);
+	/*
+	 * How long the foil takes to tilt. One duration for every
+	 * holographic transition in the kit, so a panel full of controls
+	 * moves as one surface rather than as thirty independent ones.
+	 */
+	--os-ui-holo-transition: 220ms;
+
+	/*
 	 * Status. Derived, not quoted — see the header note. Info takes
 	 * Sirius and success takes Holomesh's mint because the brand
 	 * already has a colour that means those things; danger and warning
@@ -427,6 +595,14 @@ body.os-active {
 	 */
 	--os-ui-ribbon-fg: #0c0b0f;
 	--os-ui-step-chip-fg: #0c0b0f;
+	/*
+	 * The step chip is the right size and shape for the mesh: a small
+	 * round fill, one per row, already carrying dark text. Its
+	 * `--os-ui-step-chip-fg` above is Void, which is what the mesh
+	 * needs anyway — the two decisions were made independently and
+	 * agree, which is usually the sign a palette is holding together.
+	 */
+	--os-ui-step-chip-bg: var(--os-mesh-holo);
 
 	--os-ui-ribbon-info: #c2f1f1;
 	--os-ui-ribbon-warning: #f8f2b6;
@@ -460,6 +636,21 @@ body.os-active {
 	--os-ui-log-border: 1px solid rgba(255, 251, 255, 0.08);
 	--os-ui-log-row-border: 1px solid rgba(255, 251, 255, 0.06);
 	--os-ui-progress-track-bg: rgba(255, 251, 255, 0.1);
+	/*
+	 * The filled part of a progress bar is the one surface in the kit
+	 * that is *already* a hero: bounded, watched, and the only thing
+	 * moving on screen. So it takes Holomesh, and the bar stretches
+	 * the mesh as it grows — the hue travelling from lavender toward
+	 * cyan IS the progress, which a flat accent could only report.
+	 *
+	 * Retinted here rather than in `<os-progress-bar>` because the
+	 * component's own literal has to stay the pre-brand WordPress blue
+	 * (it is the no-stylesheet floor, and it is what Legacy collected).
+	 * The tone modifiers — success, warning, danger — still declare
+	 * flat colours and still win: a failing job should read as red, not
+	 * as brand.
+	 */
+	--os-ui-progress-fill: var(--os-mesh-holo);
 	--os-ui-rating-star: #f8f2b6;
 	--os-ui-rating-fill: linear-gradient(90deg, #f8f2b6 0%, #fffbff 100%);
 	--os-ui-avatar-dot-ring: #1a1721;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -330,10 +330,69 @@ body.os-active {
 	--os-ui-hover: rgba(255, 251, 255, 0.06);
 	--os-ui-scrim: rgba(12, 11, 15, 0.72);
 
+	/*
+	 * ---- Text selection ------------------------------------------
+	 *
+	 * Lagoon, the brand's violet-blue, at 60%. It is the one primary
+	 * colour in the guidelines the shell had no job for, and this is
+	 * the right job: violet-blue is what every OS has trained people
+	 * to read as "selected", so it needs no learning.
+	 *
+	 * The alpha is where the accessibility is, and it is squeezed from
+	 * both ends. A selection has to satisfy two constraints at once:
+	 *
+	 *   1. the selected TEXT stays readable on it — Starlight over
+	 *      Lagoon@60% is 5.1:1 on Obsidian, 5.5:1 on Void; and
+	 *   2. the highlight is distinguishable from the unselected
+	 *      background — 3.4:1 and 3.5:1 respectively.
+	 *
+	 * Raising the alpha helps (2) and hurts (1); lowering it does the
+	 * reverse. 60% is the middle of the band where both clear their
+	 * bar on both surfaces. An accent wash cannot do this at all: the
+	 * Pulse family only separates from the background above 75%, by
+	 * which point it is a fill rather than a highlight.
+	 *
+	 * The text colour is Starlight — the colour body text already is.
+	 * A selection that also RECOLOURS the text destroys every
+	 * distinction the text was carrying: syntax highlighting, a red
+	 * error, a muted timestamp. Highlighting is not restyling.
+	 */
+	--os-ui-selection-bg: rgba(159, 152, 255, 0.6);
+	--os-ui-selection-fg: #fffbff;
+
 	/* Accent — the identity moment. */
 	--os-ui-accent: #f252fc;
 	--os-ui-accent-strong: #ec9bff;
-	--os-ui-accent-soft: rgba(242, 82, 252, 0.18);
+	--os-ui-accent-soft: color-mix(in srgb, var(--os-ui-accent-dim) 14%, transparent);
+	/*
+	 * Pulse, one step back — and the single knob for how loud the
+	 * station is.
+	 *
+	 * Pulse is not a contrast problem: #f252fc carries 6.2:1 against
+	 * Obsidian, better than most accents in a dark UI manage. What it
+	 * is, is SATURATED — HSL 296, 97, 65 — and the places that hurt
+	 * are the ones where it is spread rather than stated: a bloom
+	 * behind a focused control, a 18% wash under a selected row, a
+	 * fill wider than a chip. Ten of those on one panel and the whole
+	 * surface hums.
+	 *
+	 * So the fix is not to move Pulse. It is to spend it where it is
+	 * a statement and to spend THIS where it is atmosphere: the same
+	 * hue with saturation and lightness pulled down together (S 77,
+	 * L 53), which is what keeps it recognisably Pulse rather than a
+	 * different purple. 4.6:1 on Obsidian, and Starlight over it goes
+	 * from 2.8:1 to 3.8:1 — so the wash also stopped eating text.
+	 *
+	 * Everything ambient below resolves through it: the glows, the
+	 * soft wash, the focus bloom. Turning the station up or down is
+	 * one edit here.
+	 *
+	 * `--os-ui-accent` itself stays #f252fc. That one is the brand's,
+	 * not ours — it is what the guidelines name and what
+	 * `brand-palette.test.ts` pins, and moving it is a brand decision
+	 * rather than a UI one.
+	 */
+	--os-ui-accent-dim: #d92ee3;
 
 	/*
 	 * ---- The meshes ---------------------------------------------
@@ -470,22 +529,55 @@ body.os-active {
 	 * The bloom around a holographic surface. Pulse, because on a Void
 	 * desk the glow is what separates "lit" from "light-coloured".
 	 */
-	--os-ui-holo-glow: 0 0 0 1px rgba(242, 82, 252, 0.28), 0 2px 10px rgba(242, 82, 252, 0.22);
-	--os-ui-holo-glow-strong: 0 0 0 1px rgba(242, 82, 252, 0.42), 0 4px 18px rgba(242, 82, 252, 0.38),
+	--os-ui-holo-glow: 0 0 0 1px color-mix(in srgb, var(--os-ui-accent-dim) 20%, transparent),
+		0 2px 10px color-mix(in srgb, var(--os-ui-accent-dim) 15%, transparent);
+	--os-ui-holo-glow-strong: 0 0 0 1px color-mix(in srgb, var(--os-ui-accent-dim) 30%, transparent),
+		0 4px 18px color-mix(in srgb, var(--os-ui-accent-dim) 26%, transparent),
 		0 1px 3px rgba(12, 11, 15, 0.6);
 	/*
-	 * The unlit half. Switch tracks, empty progress, an unselected
-	 * segment: a sunken Void well inside the Obsidian surface, so the
-	 * lit half has something to be lit AGAINST.
+	 * The unlit half — switch tracks, empty progress, the unchecked
+	 * checkbox.
+	 *
+	 * This was a sunken Void well, and it was a mistake that measured
+	 * badly: `rgba(12, 11, 15, 0.55)` composites to #121017 on an
+	 * Obsidian panel, which is **1.07:1** against that panel. An off
+	 * switch was, to a very good approximation, not drawn. WCAG 1.4.11
+	 * asks for 3:1 on the boundary of a control, and this was not in
+	 * the same postcode.
+	 *
+	 * So the well is LIFTED rather than sunk: a Starlight wash, which
+	 * also means it tracks whatever surface a theme puts behind it
+	 * instead of pinning a grey that only works on Obsidian. Every
+	 * dark OS does the same thing with its switches for the same
+	 * reason — on a dark UI the visible thing is the lighter one.
+	 *
+	 * The fill alone still only reaches ~1.6:1, which is a *look*
+	 * rather than a boundary. The 3:1 comes from the edge below, and
+	 * the two together are what make an off switch findable.
 	 */
-	--os-ui-holo-track: rgba(12, 11, 15, 0.55);
+	--os-ui-holo-track: rgba(255, 251, 255, 0.16);
+	/*
+	 * The unlit half's boundary. Pewter, and not a rounder-looking
+	 * neighbour, because Pewter is the first step on the Shade ramp
+	 * that reaches 3.00:1 against Obsidian — Silver manages 2.03 and
+	 * Astro 1.37. This is the declaration that makes an off control
+	 * satisfy WCAG 1.4.11.
+	 */
+	--os-ui-holo-track-edge: #66636b;
 	/*
 	 * Focus. One ring for the whole kit — Pulse, offset, over a soft
-	 * Nebula halo, so it reads on Obsidian, on a mesh, and on the
-	 * near-white of a legacy theme alike.
+	 * halo, so it reads on Obsidian, on a mesh, and on the near-white
+	 * of a legacy theme alike.
+	 *
+	 * Note which layer dims and which does not. The RING is full Pulse
+	 * and stays there: it is the only thing on screen saying where the
+	 * keyboard is, and a focus indicator is the last place to trade
+	 * legibility for calm. Only the bloom behind it comes down, from
+	 * 45% to 30%, and onto the dim — which is the layer that was
+	 * making a focused control look like it was on fire.
 	 */
 	--os-ui-focus-ring: 0 0 0 2px rgba(12, 11, 15, 0.9), 0 0 0 4px #f252fc,
-		0 0 12px 2px rgba(242, 82, 252, 0.45);
+		0 0 12px 2px color-mix(in srgb, var(--os-ui-accent-dim) 30%, transparent);
 	/*
 	 * …and one for FIELDS, which is a different problem. A text input
 	 * already has a border to thicken and it sits in a column of other
@@ -495,13 +587,46 @@ body.os-active {
 	 * outside it: unmistakable, and quiet enough to live in a stack of
 	 * twelve.
 	 */
-	--os-ui-focus-ring-field: 0 0 0 1px #f252fc, 0 0 0 4px rgba(242, 82, 252, 0.18);
+	--os-ui-focus-ring-field: 0 0 0 1px #f252fc,
+		0 0 0 4px color-mix(in srgb, var(--os-ui-accent-dim) 16%, transparent);
+
 	/*
-	 * How long the foil takes to tilt. One duration for every
-	 * holographic transition in the kit, so a panel full of controls
-	 * moves as one surface rather than as thirty independent ones.
+	 * ---- Motion --------------------------------------------------
+	 *
+	 * Four durations and three curves, and every animated thing in the
+	 * kit picks from them. Not for tidiness: a panel where the switch
+	 * settles in 220ms, the segmented thumb in 300 and the tab
+	 * underline in 150 does not read as three well-tuned controls, it
+	 * reads as one surface that cannot keep time.
+	 *
+	 * The scale is roughly logarithmic because perceived duration is:
+	 * 90 and 140 are distinguishable, 220 and 240 are not.
+	 */
+	/* A state flip with no travel — a colour, an opacity, a tick. */
+	--os-ui-motion-fast: 140ms;
+	/*
+	 * How long the foil takes to tilt, and the kit's default. One
+	 * duration for every holographic transition, so a panel full of
+	 * controls moves as one surface rather than as thirty independent
+	 * ones.
 	 */
 	--os-ui-holo-transition: 220ms;
+	/* Something crossing a distance: a thumb, a drawer, a card. */
+	--os-ui-motion-slow: 340ms;
+	/* An ambient loop — a shimmer, a drift. Long enough to ignore. */
+	--os-ui-motion-ambient: 12s;
+
+	/*
+	 * The curves. `spring` overshoots ~9% and settles; it is what makes
+	 * a knob feel thrown rather than moved, and it is wrong for
+	 * anything that changes size (an overshooting width reads as a
+	 * glitch, not as weight).
+	 */
+	--os-ui-ease-spring: cubic-bezier(0.32, 1.5, 0.55, 1);
+	/* Decelerating. The default for anything arriving. */
+	--os-ui-ease-out: cubic-bezier(0.22, 0.9, 0.28, 1);
+	/* Symmetric, for a loop that has to come back where it started. */
+	--os-ui-ease-loop: cubic-bezier(0.45, 0, 0.55, 1);
 
 	/*
 	 * Status. Derived, not quoted — see the header note. Info takes
@@ -603,6 +728,14 @@ body.os-active {
 	 * agree, which is usually the sign a palette is holding together.
 	 */
 	--os-ui-step-chip-bg: var(--os-mesh-holo);
+
+	/*
+	 * The default ribbon. One per tile, small, angled, and already
+	 * paired with Void ink above — which is what a mesh needs anyway.
+	 * The status ribbons below keep their flat colours: a ribbon that
+	 * says "deprecated" should say it in warning yellow, not in brand.
+	 */
+	--os-ui-ribbon-bg: var(--os-mesh-holo);
 
 	--os-ui-ribbon-info: #c2f1f1;
 	--os-ui-ribbon-warning: #f8f2b6;

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -48,6 +48,7 @@ The search box above the list filters on the flattened descriptor, not just the 
 | `<os-range-field>` | `OsRangeField` | `os-range-field/os-range-field.ts` | Slider with live numeric readout. |
 | `<os-checkbox>` | `OsCheckbox` | `os-checkbox/os-checkbox.ts` | Standalone checkbox. |
 | `<os-checkbox-label>` | `OsCheckboxLabel` | `os-checkbox-label/os-checkbox-label.ts` | Checkbox + inline label pair. |
+| `<os-switch>` | `OsSwitch` | `os-switch/os-switch.ts` | On/off switch for settings that apply immediately. Tap, drag or keyboard. |
 | `<os-select>` / `<os-option>` | `OsSelect`, `OsOption` | `os-select/os-select.ts` | Native select with custom chrome. |
 | `<os-multiselect>` | `OsMultiselect` | `os-multiselect/os-multiselect.ts` | Multi-select with chips. |
 | `<os-segmented>` / `<os-segment>` | `OsSegmented`, `OsSegment` | `os-segmented/os-segmented.ts` | Segmented control (radio group as buttons). |
@@ -116,6 +117,66 @@ The search box above the list filters on the flattened descriptor, not just the 
 | --- | --- | --- | --- |
 | `<os-swatch>` | `OsSwatch` | `os-swatch/os-swatch.ts` | Single color swatch button. |
 | `<os-swatch-grid>` | `OsSwatchGrid` | `os-swatch-grid/os-swatch-grid.ts` | Grid of color swatches with selection. |
+
+## The holographic layer
+
+The kit wears the [OpenStation brand](https://nuriapenya.github.io/open-station-brand/), and the brand ships five mesh gradients with one instruction attached: *"meshes reserved for hero surfaces."* `src/ui/holo.ts` is how a control gets to be one without every component reinventing what holographic means.
+
+**It is a moment, not a skin.** A control paints the mesh when it is on, selected, primary or filled — the one instant it speaks for the brand — and wears ordinary Obsidian the rest of the time. A panel where every surface is iridescent has no identity moments left to spend.
+
+Three treatments, in ascending loudness:
+
+| Fragment | What it does | Who gets it |
+| --- | --- | --- |
+| `holoEdge` | An iridescent hairline, invisible at rest, lit on hover and focus. | `<os-button>` (all variants but `link`/`danger`), and the *selected* state of `<os-chip>`, `<os-card>`, `<os-swatch>`. |
+| `holoSheen` | A ~10%-alpha film of the mesh's hues over the existing surface, faded in under the pointer. | `<os-button>`, `<os-key>`, unselected `<os-segment>`. |
+| `holoFill` | The mesh itself, at full strength, with Void ink on top. | The on state of `<os-switch>`, checked `<os-checkbox>` / `<os-checkbox-label>` / `<os-menu-item>`, the selected `<os-segment>`, the elapsed track of `<os-range-field>`, the fill of `<os-progress-bar>`, the `<os-step>` chip, and `<os-button variant="holo">`. |
+
+Two shared fragments carry the states that are not decorative:
+
+- **`holoField`** — one hover, one focus ring, one transition duration and one placeholder colour for every text-like control (`<os-text-field>`, `<os-textarea>`, `<os-number-field>`, `<os-select>`, and any component that renders a bare `input` / `select` / `textarea` in its shadow root). Its selectors wrap their type exclusions in `:where()` so a component's own `aria-invalid` ring still outranks it — an invalid field focuses in red, not in Pulse.
+- **`holoCheck`** — the checkbox and radio paint, shared by `<os-checkbox>`, `<os-checkbox-label>` and `<os-table>`'s selection column. It replaced `accent-color`, which takes a *colour* where the checked state here is a *gradient*.
+
+### Tokens
+
+Declared in `assets/css/variables.css`, on `body.os-active` (never `:root` — the file also loads inside every iframe window). Every component reads them through a private `--_holo-*` alias, so a desktop theme can re-point any of them and the whole kit changes together.
+
+| Token | Meaning |
+| --- | --- |
+| `--os-mesh-holo` / `-pulse` / `-auro` / `-star` / `-mio` | The brand's five meshes, transcribed stop-for-stop from the SVGs into CSS gradient stacks. |
+| `--os-ui-holo-fill` | What an "on" surface paints. Holomesh by default. |
+| `--os-ui-holo-ink` | Glyphs and text on that fill. Void — every mesh in the brand is a light surface. |
+| `--os-ui-holo-sheen` | The hover film. |
+| `--os-ui-holo-edge` / `--os-ui-holo-edge-quiet` | The iridescent hairline, lit and at rest. |
+| `--os-ui-holo-glow` / `--os-ui-holo-glow-strong` | The Pulse bloom around a lit surface. |
+| `--os-ui-holo-track` | The unlit half — switch tracks, empty progress. |
+| `--os-ui-focus-ring` | The **target** ring: buttons, switches, checkboxes, swatches. Built to survive landing on a bright mesh. |
+| `--os-ui-focus-ring-field` | The **field** ring: quieter, tightens the input's own border. A form of twelve inputs should not look alarmed. |
+| `--os-ui-holo-transition` | One duration for every holographic transition, so a panel moves as one surface. |
+
+Every fragment honours `prefers-reduced-motion` by stopping the tilt — never by removing the fill. A control that lost its mesh under reduced motion would lose its *state*, not just its animation.
+
+### Using it in your own component
+
+```ts
+import { css } from '../../core';
+import { holoTokens, holoEdge, holoFill } from '../../holo';
+
+export const styles = css`
+	${ holoTokens }
+	${ holoEdge }
+	${ holoFill }
+
+	button:focus-visible { box-shadow: var( --_holo-focus ); }
+`;
+```
+
+`holoTokens` declares the aliases the others read — include it once per component. Import `holo` instead for the whole vocabulary.
+
+Two rules the guards enforce (`tests/vitest/holo-layer.test.ts`, `tests/vitest/component-token-reachability.test.ts`):
+
+1. **Never declare a `--os-ui-*` name on a bare `:host`.** A property declared on the host beats anything it would inherit, so it kills the palette's *and* every theme's declaration of that name. Read the public token into a private `--_alias` instead.
+2. **Comments inside a `` css`` `` template cannot contain backticks.** The template is a JS template literal; a backtick in a CSS comment terminates it and the file stops parsing.
 
 ## Importing the classes (for TypeScript)
 

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -132,6 +132,19 @@ Three treatments, in ascending loudness:
 | `holoSheen` | A ~10%-alpha film of the mesh's hues over the existing surface, faded in under the pointer. | `<os-button>`, `<os-key>`, unselected `<os-segment>`. |
 | `holoFill` | The mesh itself, at full strength, with Void ink on top. | The on state of `<os-switch>`, checked `<os-checkbox>` / `<os-checkbox-label>` / `<os-menu-item>`, the selected `<os-segment>`, the elapsed track of `<os-range-field>`, the fill of `<os-progress-bar>`, the `<os-step>` chip, and `<os-button variant="holo">`. |
 
+…and four motions, which are what make the surfaces read as foil rather than as paint:
+
+| Fragment | What it does | Who gets it |
+| --- | --- | --- |
+| `holoGlint` | A specular band crosses the surface once on hover. The single most "holographic" thing in the kit. | `<os-button>`, `<os-key>`, interactive `<os-card>`. |
+| `holoRing` | A ring expands out of the control and fades on `:active`, so a press reads as received before its result paints. | `<os-button>`, `<os-key>`. |
+| `holoShimmer` | The mesh travelling, for waits of unknown length. | Indeterminate `<os-progress-bar>`. |
+| `holoEnter` | Scale-and-fade arrival on the spring. | `<os-menu>`, `<os-context-menu>`, `<os-modal>`, `<os-confirm-dialog>`. |
+
+Plus the motions that belong to one component and stayed there: the `<os-segmented>` thumb that slides between segments, the `<os-tabs>` underline that grows from the centre, the `<os-switch>` knob's spring-and-squash, the `<os-checkbox>` tick landing with an overshoot, `<os-toast>` arriving from above and leaving sideways, and the `<os-avatar>` presence ring — which pulses **only** on `online`, so "who is here" survives being read by someone who cannot separate the three dot colours.
+
+**The pseudo-element budget.** An element has two, and this module wants four effects. `holoSheen` takes `::before` and `holoEdge` takes `::after` — that is the whole budget for a control wearing both, as `<os-button>` does. So `holoGlint` and `holoRing` are **element-based**: the component stamps a `<span class="os-holo-glint">` / `<span class="os-holo-ring">` and the fragment styles it. Both are driven from the parent's state via the **child** combinator (`:active > .os-holo-ring`), which is load-bearing: `:active` matches an activated element *and every ancestor of it*, so a descendant selector would fire every ring on the page.
+
 Two shared fragments carry the states that are not decorative:
 
 - **`holoField`** — one hover, one focus ring, one transition duration and one placeholder colour for every text-like control (`<os-text-field>`, `<os-textarea>`, `<os-number-field>`, `<os-select>`, and any component that renders a bare `input` / `select` / `textarea` in its shadow root). Its selectors wrap their type exclusions in `:where()` so a component's own `aria-invalid` ring still outranks it — an invalid field focuses in red, not in Pulse.
@@ -150,9 +163,23 @@ Declared in `assets/css/variables.css`, on `body.os-active` (never `:root` — t
 | `--os-ui-holo-edge` / `--os-ui-holo-edge-quiet` | The iridescent hairline, lit and at rest. |
 | `--os-ui-holo-glow` / `--os-ui-holo-glow-strong` | The Pulse bloom around a lit surface. |
 | `--os-ui-holo-track` | The unlit half — switch tracks, empty progress. |
+| `--os-ui-accent-dim` | Pulse one step back (same hue, S and L pulled down together). **The single knob for how loud the station is** — every ambient use of the accent resolves through it. |
 | `--os-ui-focus-ring` | The **target** ring: buttons, switches, checkboxes, swatches. Built to survive landing on a bright mesh. |
 | `--os-ui-focus-ring-field` | The **field** ring: quieter, tightens the input's own border. A form of twelve inputs should not look alarmed. |
-| `--os-ui-holo-transition` | One duration for every holographic transition, so a panel moves as one surface. |
+| `--os-ui-motion-fast` / `--os-ui-holo-transition` / `--os-ui-motion-slow` / `--os-ui-motion-ambient` | The duration scale: a state flip, the default tilt, something crossing a distance, an ambient loop. |
+| `--os-ui-ease-spring` / `--os-ui-ease-out` / `--os-ui-ease-loop` | The three curves. `spring` overshoots ~9% and is wrong for anything that changes *size*. |
+
+### Turning the station up or down
+
+`--os-ui-accent` is Pulse `#f252fc` and stays there — it is what the brand guidelines name, and `brand-palette.test.ts` pins it. Pulse is also not a contrast problem: it carries 6.2:1 against Obsidian.
+
+What makes a panel read as loud is the *ambient* use — a bloom behind a focused control, an 18% wash under a selected row, a fill wider than a chip. Those all resolve through `--os-ui-accent-dim`, so:
+
+```css
+body.os-active { --os-ui-accent-dim: #b02ab8; }  /* quieter still */
+```
+
+is the whole edit. The focus **ring** deliberately does not follow it — only the bloom behind the ring does. A focus indicator is the last place to trade legibility for calm.
 
 Every fragment honours `prefers-reduced-motion` by stopping the tilt — never by removing the fill. A control that lost its mesh under reduced motion would lose its *state*, not just its animation.
 

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -413,6 +413,49 @@ A dark theme's minimum viable body palette:
 }
 ```
 
+### The holographic tokens
+
+The kit has one more family, and it is the one that decides how a
+control looks at the moment it is *on*. A switch that is on, a checked
+checkbox, the selected segment, the filled part of a progress bar and
+the step-number chip all paint `--os-ui-holo-fill` — by default the
+brand's Holomesh, transcribed into CSS in `--os-mesh-holo`.
+
+| Token | Role |
+|---|---|
+| `--os-ui-holo-fill` | What an on / selected / filled surface paints. |
+| `--os-ui-holo-ink` | Glyphs and text on that fill. |
+| `--os-ui-holo-sheen` | The hover film over a surface that is *not* lit. |
+| `--os-ui-holo-edge`, `--os-ui-holo-edge-quiet` | The iridescent hairline, lit and at rest. |
+| `--os-ui-holo-glow`, `--os-ui-holo-glow-strong` | The bloom around a lit surface. |
+| `--os-ui-holo-track` | The unlit half — switch tracks, empty progress. |
+| `--os-ui-focus-ring` | Focus on a *target*: buttons, switches, checkboxes, swatches. |
+| `--os-ui-focus-ring-field` | Focus on a *field*: quieter, tightens the input's own border. |
+| `--os-ui-holo-transition` | Duration for every holographic transition in the kit. |
+
+Setting `--os-ui-holo-fill` alone retints every one of those surfaces
+at once, which is the shortest route to a theme that does not look
+like OpenStation. A flat colour works:
+
+```json
+"tokens": {
+  "--os-ui-holo-fill": "#7c5cff",
+  "--os-ui-holo-ink":  "#ffffff"
+}
+```
+
+**Change the ink when you change the fill.** The default ink is Void,
+because every mesh in the brand is a *light* surface — a dark fill with
+the default ink is near-black on near-black, and it looks fine in a
+screenshot of the off state.
+
+The five meshes themselves (`--os-mesh-holo`, `--os-mesh-pulse`,
+`--os-mesh-auro`, `--os-mesh-star`, `--os-mesh-mio`) are also settable,
+and are the right lever when you want your own gradient everywhere the
+brand's would have gone. `--os-mesh-mio` belongs to the mascot; retint
+it and Mio changes with the rest of the station, which may or may not
+be what you meant.
+
 ### Shell tokens
 
 `--os-*` names must match `^--os-[a-z0-9-]+$`.

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -429,9 +429,23 @@ brand's Holomesh, transcribed into CSS in `--os-mesh-holo`.
 | `--os-ui-holo-edge`, `--os-ui-holo-edge-quiet` | The iridescent hairline, lit and at rest. |
 | `--os-ui-holo-glow`, `--os-ui-holo-glow-strong` | The bloom around a lit surface. |
 | `--os-ui-holo-track` | The unlit half — switch tracks, empty progress. |
+| `--os-ui-accent-dim` | The accent, one step back. Every *ambient* use of it — glows, washes, focus blooms — resolves through this, so it is the single knob for how loud a theme reads. |
 | `--os-ui-focus-ring` | Focus on a *target*: buttons, switches, checkboxes, swatches. |
 | `--os-ui-focus-ring-field` | Focus on a *field*: quieter, tightens the input's own border. |
 | `--os-ui-holo-transition` | Duration for every holographic transition in the kit. |
+
+And the motion scale, which is worth setting as a group or not at all — a theme that changes one duration gets a panel where the controls disagree about how fast they are:
+
+| Token | Role |
+|---|---|
+| `--os-ui-motion-fast` | A state flip with no travel: a colour, an opacity, a tick. |
+| `--os-ui-motion-slow` | Something crossing a distance: a thumb, a drawer, a card. |
+| `--os-ui-motion-ambient` | An ambient loop — a shimmer, a drift. |
+| `--os-ui-ease-spring` | Overshoots and settles. Wrong for anything that changes *size*. |
+| `--os-ui-ease-out` | Decelerating. The default for anything arriving. |
+| `--os-ui-ease-loop` | Symmetric, for a loop that returns where it started. |
+
+Setting all three durations to `1ms` is a supported way to build a still theme; every fragment in the kit already does exactly that under `prefers-reduced-motion`.
 
 Setting `--os-ui-holo-fill` alone retints every one of those surfaces
 at once, which is the shortest route to a theme that does not look

--- a/src/settings/sections/help.ts
+++ b/src/settings/sections/help.ts
@@ -392,7 +392,6 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 function renderDetail( entry: ComponentEntry ) {
 	const help = entry.help;
 	const status = help?.status ?? 'stable';
-	const since = help?.since;
 
 	return html`
 		<header class="os-settings__help-head">
@@ -407,11 +406,6 @@ function renderDetail( entry: ComponentEntry ) {
 				) }
 				>${ statusLabel( status ) }</span
 			>
-			${ since
-				? html`<span class="os-settings__help-since"
-						>${ __( 'Since' ) } ${ since }</span
-					>`
-				: html`` }
 		</header>
 
 		${ help?.summary

--- a/src/settings/sections/help.ts
+++ b/src/settings/sections/help.ts
@@ -105,6 +105,50 @@ function matchesQuery( entry: ComponentEntry, query: string ): boolean {
 }
 
 /**
+ * Run the active component's `exampleInit` against its own container.
+ *
+ * Half the kit takes its data through a JS property rather than an
+ * attribute — `segments`, `data`, `columns`, `entries`, `ratings` —
+ * and those cannot be populated from markup at all. Their examples
+ * rendered as empty shells until this hook existed.
+ *
+ * `customElements.upgrade()` first, and it is not optional. On the
+ * FIRST paint this section is still detached — `buildHelpSection()`
+ * returns `el` for the caller to append — so the custom elements the
+ * renderer just created have not upgraded yet. Assigning `.segments`
+ * to an un-upgraded element defines an OWN property, which then
+ * permanently shadows the class accessor the upgrade installs on the
+ * prototype: the setter never runs, and the component sits there
+ * empty holding data it cannot see. Upgrading first makes the
+ * accessor exist before anything is written through it.
+ */
+function runExampleInit(
+	root: HTMLElement,
+	active: ComponentEntry | undefined,
+): void {
+	const init = active?.help?.exampleInit;
+	const host = root.querySelector< HTMLElement >(
+		'.os-settings__help-example',
+	);
+	if ( ! init || ! host ) {
+		return;
+	}
+	customElements.upgrade( host );
+	try {
+		init( host );
+	} catch ( err ) {
+		// An example is documentation. A broken one is worth a console
+		// line, and is never worth taking the Components tab down with
+		// it — the props, events and CSS tables below are still fine.
+		// eslint-disable-next-line no-console
+		console.error(
+			`[openstation] <${ active?.tag }> exampleInit threw:`,
+			err,
+		);
+	}
+}
+
+/**
  * Module-level guard so the "intentional demo" console banner is
  * logged exactly once per page lifetime, no matter how many times
  * the Components tab is opened or repainted.
@@ -154,6 +198,21 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 
 	let activeTag = entries[ 0 ]?.tag ?? '';
 	let query = '';
+	/**
+	 * Which component the detail pane last painted.
+	 *
+	 * The pane is its own scroll container, and `render()` diffs — so
+	 * the same `<div>` survives every repaint and keeps its
+	 * `scrollTop`. Picking a component while scrolled down through a
+	 * long one (`<os-table>` has five sections) left the new one
+	 * opened halfway down, which reads as a component with nothing at
+	 * the top rather than as a scroll position.
+	 *
+	 * Compared rather than reset unconditionally, because typing in
+	 * the filter box repaints too and yanking the pane to the top on
+	 * every keystroke is its own bug.
+	 */
+	let paintedTag = '';
 
 	const paint = (): void => {
 		if ( ctx.state.developerModeEnabled ) {
@@ -287,6 +346,16 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 			`,
 			el,
 		);
+
+		const detail = el.querySelector< HTMLElement >(
+			'.os-settings__help-detail',
+		);
+		if ( detail && ( active?.tag ?? '' ) !== paintedTag ) {
+			detail.scrollTop = 0;
+		}
+		paintedTag = active?.tag ?? '';
+
+		runExampleInit( el, active );
 	};
 
 	paint();

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -23,6 +23,7 @@ export { OsTextField } from './os-text-field/os-text-field';
 export { OsNumberField } from './os-number-field/os-number-field';
 export { OsCheckbox } from './os-checkbox/os-checkbox';
 export { OsCheckboxLabel } from './os-checkbox-label/os-checkbox-label';
+export { OsSwitch } from './os-switch/os-switch';
 export { OsToast, OsToastContainer } from './os-toast/os-toast';
 export { OsTabs, OsTab, OsTabPanel } from './os-tabs/os-tabs';
 export { OsWindowButton } from './os-window-button/os-window-button';

--- a/src/ui/components/os-avatar/os-avatar.styles.ts
+++ b/src/ui/components/os-avatar/os-avatar.styles.ts
@@ -174,8 +174,54 @@ export const avatarStyles = css`
 		z-index: 2;
 	}
 
+	/*
+	 * Online breathes; the other two do not, and that asymmetry is the
+	 * point.
+	 *
+	 * Three flat dots differing only in hue put the whole burden of
+	 * "who is here right now" on colour discrimination — which is
+	 * exactly the channel a red/green-blind user does not have. A slow
+	 * ring expanding out of the live one carries the same fact through
+	 * motion instead, and it is the only state that gets it, so
+	 * "moving" reads unambiguously as "online".
+	 *
+	 * Six seconds, so it is a pulse rather than a blink: at this rate
+	 * a sidebar of twenty avatars reads as a room with people in it,
+	 * not as twenty notifications.
+	 */
 	.os-avatar__dot--online {
 		background: var( --os-ui-success-fg, #00a32a );
+	}
+
+	.os-avatar__dot--online::after {
+		content: '';
+		position: absolute;
+		inset: -2px;
+		border-radius: 50%;
+		border: 1px solid var( --os-ui-success-fg, #00a32a );
+		animation: os-avatar-presence 6s
+			var( --os-ui-ease-out, cubic-bezier( 0.22, 0.9, 0.28, 1 ) ) infinite;
+		pointer-events: none;
+	}
+
+	@keyframes os-avatar-presence {
+		0% {
+			opacity: 0.6;
+			transform: scale( 1 );
+		}
+
+		/* The whole expansion happens in the first fifth of the cycle;
+		   the rest is the rest. A pulse that eased continuously would
+		   read as a loading spinner. */
+		20% {
+			opacity: 0;
+			transform: scale( 2.2 );
+		}
+
+		100% {
+			opacity: 0;
+			transform: scale( 2.2 );
+		}
 	}
 	.os-avatar__dot--inactive {
 		background: var( --os-ui-warning-fg, #dba617 );
@@ -189,6 +235,17 @@ export const avatarStyles = css`
 	 * box-shadow is gentle enough to keep; only the heavy motion
 	 * channels get muted. */
 	@media ( prefers-reduced-motion: reduce ) {
+		/*
+		 * The presence ring stops but stays: at rest it is a static
+		 * halo around the live dot, so the second, non-colour channel
+		 * for "online" survives the preference. Removing it would trade
+		 * a motion complaint for a contrast one.
+		 */
+		.os-avatar__dot--online::after {
+			animation: none;
+			opacity: 0.6;
+		}
+
 		.os-avatar__tile {
 			transform: none;
 			transition: box-shadow 200ms;

--- a/src/ui/components/os-avatar/os-avatar.ts
+++ b/src/ui/components/os-avatar/os-avatar.ts
@@ -45,7 +45,6 @@ export class OsAvatar extends Component {
 		summary:
 			'Image-or-initials user tile with an optional presence dot. Falls back to a deterministic-hue letter tile when src is empty. Set user-id to auto-subscribe the dot to os-presence-changed.',
 		status: 'stable',
-		since: '0.6.0',
 		props: [
 			{ name: 'src', type: 'string', description: 'Image URL. Falls back to initials when empty or load fails.' },
 			{ name: 'alt', type: 'string', description: 'Alt text for the image. Defaults to `name` when omitted.' },

--- a/src/ui/components/os-badge/os-badge.styles.ts
+++ b/src/ui/components/os-badge/os-badge.styles.ts
@@ -7,8 +7,11 @@
  * the surrounding pill background is independently themable.
  */
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: inline-flex;
 		align-items: center;
@@ -60,6 +63,35 @@ export const styles = css`
 	:host( [ tone="neutral" ] ) {
 		--os-ui-badge-color: var( --os-ui-badge-neutral, var( --os-ui-fg-muted, #57606a ) );
 		--os-ui-badge-bg: var( --os-ui-badge-neutral-bg, rgba( 87, 96, 106, 0.12 ) );
+	}
+
+	/*
+	 * The sixth tone, and the only one that is not a status: "accent"
+	 * is the badge saying "this is the one", and it takes the mesh.
+	 *
+	 * A badge is a good place for it — small, one per row, already a
+	 * filled pill — and it stays deliberately OUT of the five status
+	 * tones above, because a badge that means "failing" has to say so
+	 * in red. Brand is not a status.
+	 *
+	 * Longhands: --_holo-fill is a nine-layer list and a trailing
+	 * position in the background shorthand would bind to the last
+	 * layer only.
+	 */
+	:host( [ tone="accent" ] ) {
+		--os-ui-badge-color: var( --os-ui-badge-accent, var( --_holo-ink ) );
+		background-color: transparent;
+		background-image: var( --os-ui-badge-accent-bg, var( --_holo-fill ) );
+		background-size: 220% 220%;
+		background-position: 22% 28%;
+		background-repeat: no-repeat;
+		box-shadow: var( --_holo-glow );
+		font-weight: 600;
+	}
+
+	/* The dot would be a Void hole punched in a bright pill. */
+	:host( [ tone="accent" ] ) .dot {
+		display: none;
 	}
 
 	/*

--- a/src/ui/components/os-badge/os-badge.ts
+++ b/src/ui/components/os-badge/os-badge.ts
@@ -18,7 +18,13 @@
 import { Component, defineComponent, html } from '../../core';
 import { styles } from './os-badge.styles';
 
-export type OsBadgeTone = 'success' | 'warning' | 'danger' | 'info' | 'neutral';
+export type OsBadgeTone =
+	| 'success'
+	| 'warning'
+	| 'danger'
+	| 'info'
+	| 'neutral'
+	| 'accent';
 
 export class OsBadge extends Component {
 	static props = [ 'tone', 'noDot' ] as const;
@@ -33,9 +39,9 @@ export class OsBadge extends Component {
 		props: [
 			{
 				name: 'tone',
-				type: '"success" | "warning" | "danger" | "info" | "neutral"',
+				type: '"success" | "warning" | "danger" | "info" | "neutral" | "accent"',
 				description:
-					'Color tone applied to the dot + pill background. Default is "neutral".',
+					'Color tone applied to the dot + pill background. Default is "neutral". "accent" is the odd one out and is not a status: it fills the pill with the brand mesh and drops the dot, for the badge that means "this is the one" rather than "this is the state".',
 			},
 			{
 				name: 'no-dot',

--- a/src/ui/components/os-badge/os-badge.ts
+++ b/src/ui/components/os-badge/os-badge.ts
@@ -34,8 +34,7 @@ export class OsBadge extends Component {
 		title: 'Badge',
 		summary:
 			'Status pill with a colored leading dot and a label slot. Use for window-attached states, count chips, version markers, and any other small status surface where a leading tone-coded dot communicates meaning at a glance.',
-		status: 'experimental',
-		since: '0.6.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'tone',

--- a/src/ui/components/os-body/os-body.ts
+++ b/src/ui/components/os-body/os-body.ts
@@ -46,7 +46,6 @@ export class OsBody extends Component {
 		summary:
 			'Top-level native-window body wrapper. Fills the parent, stacks children in a flex column, and optionally owns the scrollable region so overflowing content scrolls inside the body rather than the window frame.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'gap',

--- a/src/ui/components/os-button/os-button.styles.ts
+++ b/src/ui/components/os-button/os-button.styles.ts
@@ -24,6 +24,17 @@
  * in OS Settings — and a mesh three to a row is wallpaper. It gets the
  * edge and the sheen like everything else.
  *
+ * ## And two motions
+ *
+ * The **glint** crosses the face once on hover; the **press ring**
+ * expands and fades on `:active`. Both are element-based (a `<span>`
+ * each in the template) rather than pseudo-elements, because the sheen
+ * and the edge have already spent this button's `::before` and
+ * `::after` — see the pseudo-element budget note in `src/ui/holo.ts`.
+ *
+ * `link` gets neither: it has no surface for a highlight to cross and
+ * no box for a ring to leave.
+ *
  * The fill is written out rather than borrowed from the `.os-holo-fill`
  * utility class because `--os-ui-button-bg-image` is a desktop-theme
  * texture slot on the base rule: a utility class setting
@@ -31,12 +42,21 @@
  * button, not just the holographic one.
  */
 import { css } from '../../core';
-import { holoTokens, holoSheen, holoEdge, holoDrift } from '../../holo';
+import {
+	holoTokens,
+	holoSheen,
+	holoEdge,
+	holoGlint,
+	holoRing,
+	holoDrift,
+} from '../../holo';
 
 export const styles = css`
 	${ holoTokens }
 	${ holoSheen }
 	${ holoEdge }
+	${ holoGlint }
+	${ holoRing }
 	${ holoDrift }
 
 	:host {
@@ -104,11 +124,12 @@ export const styles = css`
 		outline: none;
 		box-shadow: var( --_holo-focus );
 	}
-	/* The iridescent hairline and the hover film are suppressed while
-	   the button is unavailable — a disabled control that lights up
-	   under the pointer is advertising an action it will not take. */
+	/* Every lit layer is suppressed while the button is unavailable —
+	   a disabled control that lights up under the pointer is
+	   advertising an action it will not take. */
 	button:disabled::before,
-	button:disabled::after {
+	button:disabled::after,
+	button:disabled .os-holo-glint {
 		opacity: 0 !important;
 	}
 	/* Primary */
@@ -201,9 +222,12 @@ export const styles = css`
 		padding: 0;
 		text-decoration: underline;
 	}
-	/* No chrome means nothing to put an edge or a film on. */
+	/* No chrome means nothing to put an edge, a film, a highlight or a
+	   ring on — a link is text, and text does not catch the light. */
 	:host( [ variant='link' ] ) button::before,
-	:host( [ variant='link' ] ) button::after {
+	:host( [ variant='link' ] ) button::after,
+	:host( [ variant='link' ] ) .os-holo-glint,
+	:host( [ variant='link' ] ) .os-holo-ring {
 		display: none;
 	}
 	:host( [ variant='link' ] ) button:active:not( :disabled ) {

--- a/src/ui/components/os-button/os-button.styles.ts
+++ b/src/ui/components/os-button/os-button.styles.ts
@@ -4,10 +4,41 @@
  * paintable property reads from a CSS custom property FIRST so
  * authors can tune individual buttons (or whole panels) without
  * reimplementing the component.
+ *
+ * ## The holographic layer
+ *
+ * Two of the three treatments from `src/ui/holo.ts`, applied the way
+ * that module argues for — as a moment, not a skin:
+ *
+ *   - **Every** variant gets the iridescent hairline and the sheen
+ *     under the pointer. At rest they cost nothing (both are
+ *     `opacity: 0`), so a panel of buttons still reads as Obsidian
+ *     chrome until you reach for one.
+ *   - **`variant="holo"`** gets the mesh itself. That is the hero
+ *     CTA, one per surface at most — the brand's "meshes reserved for
+ *     hero surfaces" written as a variant name so it is hard to reach
+ *     for by accident.
+ *
+ * `primary` deliberately did NOT become the mesh. It is the accent
+ * fill and it is everywhere — in dialogs, in toolbars, three to a row
+ * in OS Settings — and a mesh three to a row is wallpaper. It gets the
+ * edge and the sheen like everything else.
+ *
+ * The fill is written out rather than borrowed from the `.os-holo-fill`
+ * utility class because `--os-ui-button-bg-image` is a desktop-theme
+ * texture slot on the base rule: a utility class setting
+ * `background-image` would silently outrank a theme's texture on every
+ * button, not just the holographic one.
  */
 import { css } from '../../core';
+import { holoTokens, holoSheen, holoEdge, holoDrift } from '../../holo';
 
 export const styles = css`
+	${ holoTokens }
+	${ holoSheen }
+	${ holoEdge }
+	${ holoDrift }
+
 	:host {
 		display: inline-flex;
 	}
@@ -26,8 +57,9 @@ export const styles = css`
 		font: inherit;
 		font-weight: 500;
 		cursor: pointer;
-		transition: background-color 0.12s ease, color 0.12s ease,
-			border-color 0.12s ease;
+		transition: background-color var( --_holo-t ) ease, color var( --_holo-t ) ease,
+			border-color var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease,
+			transform 80ms ease;
 		/* Ghost (default) */
 		background: var( --os-ui-button-bg, transparent );
 		/* Desktop-theme texture slot: unset resolves to none. Declared
@@ -51,8 +83,33 @@ export const styles = css`
 		opacity: 0.5;
 		cursor: not-allowed;
 	}
+	/*
+	 * A press should move. One pixel is enough to read as travel and
+	 * small enough that a toolbar of them does not look like it is
+	 * bouncing; it is also the cheapest possible transform, so a grid
+	 * of forty keypad buttons costs nothing to animate.
+	 */
+	button:active:not( :disabled ) {
+		transform: translateY( 1px );
+	}
 	button:hover:not( :disabled ) {
 		background-color: var( --os-ui-button-bg-hover, var( --os-ui-hover, rgba( 0, 0, 0, 0.04 ) ) );
+	}
+	/*
+	 * One focus ring for the whole kit, replacing the browser default.
+	 * It has to survive landing on a bright mesh, which a flat outline
+	 * does not — see the note on --_holo-focus.
+	 */
+	button:focus-visible {
+		outline: none;
+		box-shadow: var( --_holo-focus );
+	}
+	/* The iridescent hairline and the hover film are suppressed while
+	   the button is unavailable — a disabled control that lights up
+	   under the pointer is advertising an action it will not take. */
+	button:disabled::before,
+	button:disabled::after {
+		opacity: 0 !important;
 	}
 	/* Primary */
 	:host( [ variant='primary' ] ) button {
@@ -63,6 +120,46 @@ export const styles = css`
 	:host( [ variant='primary' ] ) button:hover:not( :disabled ) {
 		filter: brightness( 1.06 );
 		background-color: var( --os-ui-button-bg, var( --wp-admin-theme-color, #2271b1 ) );
+		box-shadow: var( --_holo-glow );
+	}
+	/*
+	 * Holo — the hero CTA. The mesh itself, with Void ink on it (every
+	 * mesh in the brand is a light surface; see --os-ui-holo-ink), and
+	 * the tilt-on-hover that makes it read as foil rather than as a
+	 * pink rectangle. One per surface, at most.
+	 */
+	:host( [ variant='holo' ] ) button {
+		background-color: transparent;
+		background-image: var( --_holo-fill );
+		background-size: 220% 220%;
+		background-position: 22% 28%;
+		background-repeat: no-repeat;
+		color: var( --os-ui-button-fg, var( --_holo-ink ) );
+		border: var( --os-ui-button-border, 1px solid transparent );
+		box-shadow: var( --_holo-glow );
+		font-weight: 600;
+		transition: background-position var( --_holo-t ) ease,
+			box-shadow var( --_holo-t ) ease, filter var( --_holo-t ) ease,
+			transform 80ms ease;
+	}
+	:host( [ variant='holo' ] ) button:hover:not( :disabled ) {
+		background-color: transparent;
+		background-position: 74% 66%;
+		box-shadow: var( --_holo-glow-strong );
+	}
+	:host( [ variant='holo' ] ) button:active:not( :disabled ) {
+		background-position: 88% 82%;
+		filter: brightness( 0.94 );
+	}
+	/* The sheen has nothing to add over a full mesh, and reads as haze. */
+	:host( [ variant='holo' ] ) button::before {
+		display: none;
+	}
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ variant='holo' ] ) button:hover:not( :disabled ),
+		:host( [ variant='holo' ] ) button:active:not( :disabled ) {
+			background-position: 22% 28%;
+		}
 	}
 	/* Secondary — quiet filled control. Neutral chrome, no underline.
 	 * Semantic fit for "not the primary action but also not a
@@ -86,6 +183,15 @@ export const styles = css`
 		background-color: var( --os-ui-danger, #d63638 );
 		color: var( --os-ui-fg-on-accent, #fff );
 	}
+	/*
+	 * Danger keeps its own edge. The iridescent hairline says "brand
+	 * moment" and a delete button is the one place that is the wrong
+	 * sentence — the border should stay red all the way through the
+	 * hover, which is the only warning the user gets.
+	 */
+	:host( [ variant='danger' ] ) button::after {
+		display: none;
+	}
 	/* Link */
 	:host( [ variant='link' ] ) button {
 		background-color: transparent;
@@ -95,9 +201,31 @@ export const styles = css`
 		padding: 0;
 		text-decoration: underline;
 	}
+	/* No chrome means nothing to put an edge or a film on. */
+	:host( [ variant='link' ] ) button::before,
+	:host( [ variant='link' ] ) button::after {
+		display: none;
+	}
+	:host( [ variant='link' ] ) button:active:not( :disabled ) {
+		transform: none;
+	}
 	:host( [ busy ] ) button {
 		pointer-events: none;
 		opacity: 0.75;
+	}
+	/*
+	 * A busy holo button keeps drifting. It is the one place in the kit
+	 * where the ambient animation is load-bearing rather than
+	 * decorative: the mesh moving is what says the work is still
+	 * running, next to a spinner that says the same thing more quietly.
+	 */
+	:host( [ variant='holo' ][ busy ] ) button {
+		animation: os-holo-drift 12s ease-in-out infinite;
+	}
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ variant='holo' ][ busy ] ) button {
+			animation: none;
+		}
 	}
 	.os-button__spinner {
 		box-sizing: border-box;

--- a/src/ui/components/os-button/os-button.ts
+++ b/src/ui/components/os-button/os-button.ts
@@ -148,6 +148,15 @@ export class OsButton extends Component {
 					? html`<span class="os-button__spinner" aria-hidden="true"></span>`
 					: '' }
 				<slot></slot>
+				<!--
+					The two motion layers. Elements rather than
+					pseudo-elements because the sheen and the hairline
+					have already taken this button's ::before and
+					::after — see the pseudo-element budget note in
+					src/ui/holo.ts. Both are inert and aria-hidden.
+				-->
+				<span class="os-holo-glint" aria-hidden="true"></span>
+				<span class="os-holo-ring" aria-hidden="true"></span>
 			</button>
 		`;
 	}

--- a/src/ui/components/os-button/os-button.ts
+++ b/src/ui/components/os-button/os-button.ts
@@ -4,6 +4,11 @@
  *
  * Variants (Stable, will not be renamed within a major release):
  *
+ *   - `holo`      — the hero CTA. Filled with the brand's Holomesh,
+ *                   Void ink on top, and a Pulse glow; the fill tilts
+ *                   under the pointer the way a foil card does. The
+ *                   brand reserves meshes for hero surfaces, so this
+ *                   is at most one per surface — often none.
  *   - `primary`   — accent-colored, attention-grabbing action. One
  *                   per surface.
  *   - `secondary` — neutral filled control. Quiet action in a row
@@ -12,6 +17,12 @@
  *   - `danger`    — destructive action. Red outline → red fill on hover.
  *   - `ghost`     — default. Transparent background, 1 px border.
  *   - `link`      — underline only, no chrome.
+ *
+ * Every variant except `link` and `danger` also carries the kit's
+ * holographic hairline and hover film — invisible at rest, lit under
+ * the pointer and on focus. `danger` keeps its red border all the way
+ * through the hover, because that border is the only warning the user
+ * gets and an iridescent one says the wrong thing.
  *
  * `fill-cell` boolean attribute makes the host fill its parent
  * cell (flex / grid item), growing width AND the inner button
@@ -42,6 +53,7 @@ import { styles } from './os-button.styles';
  * plugin-side TS can narrow.
  */
 export type OsButtonVariant =
+	| 'holo'
 	| 'primary'
 	| 'secondary'
 	| 'ghost'
@@ -61,10 +73,10 @@ export class OsButton extends Component {
 		props: [
 			{
 				name: 'variant',
-				type: "'primary' | 'secondary' | 'ghost' | 'danger' | 'link'",
+				type: "'holo' | 'primary' | 'secondary' | 'ghost' | 'danger' | 'link'",
 				default: 'ghost',
 				description:
-					'Visual weight of the button. Use primary for the single attention-grabbing action per surface.',
+					'Visual weight of the button. Use primary for the single attention-grabbing action per surface, and holo — the Holomesh fill — only for a hero call to action.',
 			},
 			{
 				name: 'disabled',
@@ -108,6 +120,7 @@ export class OsButton extends Component {
 		],
 		example: html`
 			<os-cluster gap="8">
+				<os-button variant="holo">Holo</os-button>
 				<os-button variant="primary">Primary</os-button>
 				<os-button variant="secondary">Secondary</os-button>
 				<os-button variant="ghost">Ghost</os-button>
@@ -126,6 +139,7 @@ export class OsButton extends Component {
 		return html`
 			<button
 				part="button"
+				class="os-holo-edge os-holo-sheen"
 				type=${ type }
 				?disabled=${ disabled || busy }
 				aria-busy=${ busy ? 'true' : 'false' }

--- a/src/ui/components/os-button/os-button.ts
+++ b/src/ui/components/os-button/os-button.ts
@@ -69,7 +69,6 @@ export class OsButton extends Component {
 		summary:
 			'Thin wrapper around <button> with consistent variant styling and a slot for the label.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'variant',

--- a/src/ui/components/os-card/os-card.styles.ts
+++ b/src/ui/components/os-card/os-card.styles.ts
@@ -1,8 +1,24 @@
 import { css } from '../../core';
-import { holoTokens } from '../../holo';
+import { holoTokens, holoGlint } from '../../holo';
 
 export const styles = css`
 	${ holoTokens }
+	${ holoGlint }
+
+	/*
+	 * The specular pass, on interactive cards only. A card is the
+	 * largest surface in the kit that responds to a pointer, so it is
+	 * where a highlight travelling across has the most room to read —
+	 * and it is the clearest "this is clickable" the card can give
+	 * without changing its own colour.
+	 *
+	 * Suppressed on a read-only card, which would otherwise catch the
+	 * light while advertising a click it does not take.
+	 */
+	:host( :not( [ interactive ] ) ) .os-holo-glint,
+	:host( [ disabled ] ) .os-holo-glint {
+		display: none;
+	}
 
 	:host {
 		display: flex;

--- a/src/ui/components/os-card/os-card.styles.ts
+++ b/src/ui/components/os-card/os-card.styles.ts
@@ -1,9 +1,17 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: flex;
 		flex-direction: column;
+		/* Anchors the selected card's iridescent frame, which is an
+		   absolutely-positioned ::after. Without it the frame would
+		   escape to the nearest positioned ancestor and draw itself
+		   around some panel three levels up. */
+		position: relative;
 		gap: var( --os-ui-card-gap, 12px );
 		padding: var( --os-ui-card-padding, 16px );
 		border: 1px solid var( --os-ui-card-border, var( --os-ui-border, rgba( 0, 0, 0, 0.08 ) ) );
@@ -51,6 +59,11 @@ export const styles = css`
 		);
 	}
 
+	:host( [ interactive ]:focus-visible ) {
+		outline: none;
+		box-shadow: var( --_holo-focus );
+	}
+
 	:host( [ selected ] ) {
 		border-color: var(
 			--os-ui-card-border-selected,
@@ -60,6 +73,29 @@ export const styles = css`
 			--os-ui-card-shadow-selected,
 			0 0 0 1px var( --wp-admin-theme-color, #2271b1 ) inset
 		);
+	}
+
+	/*
+	 * The iridescent hairline, on the chosen card only.
+	 *
+	 * A card is a big surface and there are usually several on screen,
+	 * so this is the one state that earns the edge — and it is drawn
+	 * OUTSIDE the border (inset: -1px) so it reads as a frame around
+	 * the card rather than as a second border inside the first.
+	 */
+	:host( [ selected ] )::after {
+		content: '';
+		position: absolute;
+		inset: -1px;
+		border-radius: inherit;
+		padding: 1px;
+		background-image: var( --_holo-edge );
+		pointer-events: none;
+		-webkit-mask: linear-gradient( #000 0 0 ) content-box,
+			linear-gradient( #000 0 0 );
+		-webkit-mask-composite: xor;
+		mask: linear-gradient( #000 0 0 ) content-box, linear-gradient( #000 0 0 );
+		mask-composite: exclude;
 	}
 
 	:host( [ disabled ] ) {

--- a/src/ui/components/os-card/os-card.ts
+++ b/src/ui/components/os-card/os-card.ts
@@ -68,7 +68,6 @@ export class OsCard extends Component {
 		summary:
 			'Generic hover-aware container. Becomes click-emitting + focusable when `interactive`. Slots for header / default body / footer have built-in layout rhythm so consumers don\'t need bespoke wrapper components.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'interactive',

--- a/src/ui/components/os-card/os-card.ts
+++ b/src/ui/components/os-card/os-card.ts
@@ -171,7 +171,11 @@ export class OsCard extends Component {
 		// `connectedCallback` runs once on first mount; this picks up
 		// `interactive`/`disabled` flips after that.
 		this._syncRoles();
-		return html`<slot name="header"></slot><slot></slot><slot name="footer"></slot>`;
+		// The glint is stamped unconditionally and gated in CSS to
+		// [interactive]: a read-only digest tile that caught the light
+		// on hover would be advertising a click it does not take.
+		return html`<span class="os-holo-glint" aria-hidden="true"></span
+			><slot name="header"></slot><slot></slot><slot name="footer"></slot>`;
 	}
 
 	private _syncRoles(): void {

--- a/src/ui/components/os-category-picker/os-category-picker.ts
+++ b/src/ui/components/os-category-picker/os-category-picker.ts
@@ -100,8 +100,7 @@ export class OsCategoryPicker extends Component {
 		title: 'Category picker',
 		summary:
 			'Hierarchical multi-select for taxonomy terms. Compact chip row + tree popover with search, collapsible branches, indent guides, keyboard navigation. Aligns with WordPress core: any subset selectable, "Uncategorized" rendered as a muted dashed sentinel when the value is empty.',
-		status: 'experimental',
-		since: '0.8.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'placeholder',

--- a/src/ui/components/os-category-picker/os-category-picker.ts
+++ b/src/ui/components/os-category-picker/os-category-picker.ts
@@ -177,9 +177,30 @@ export class OsCategoryPicker extends Component {
 				detail: '{ id: number; name: string }',
 			},
 		],
+		/*
+		 * `items` is a property — the tree cannot be expressed in
+		 * markup — so without this hook the picker rendered as a
+		 * search box above nothing.
+		 */
 		example: html`
 			<os-category-picker placeholder="Search categories…"></os-category-picker>
 		`,
+		exampleInit: ( root: HTMLElement ) => {
+			const picker = root.querySelector( 'os-category-picker' );
+			if ( ! picker ) {
+				return;
+			}
+			const p = picker as OsCategoryPicker;
+			p.items = [
+				{ id: 1, name: 'Uncategorised', parent: 0 },
+				{ id: 2, name: 'Tech', parent: 0 },
+				{ id: 3, name: 'Web Dev', parent: 2 },
+				{ id: 4, name: 'Frontend', parent: 3 },
+				{ id: 5, name: 'Backend', parent: 3 },
+				{ id: 6, name: 'Announcements', parent: 0 },
+			];
+			p.value = [ 4 ];
+		},
 	} as const;
 
 	private _items: OsCategoryItem[] = [];

--- a/src/ui/components/os-checkbox-label/os-checkbox-label.styles.ts
+++ b/src/ui/components/os-checkbox-label/os-checkbox-label.styles.ts
@@ -1,22 +1,37 @@
 import { css } from '../../core';
+import { holoTokens, holoCheck } from '../../holo';
 
+/**
+ * `<os-checkbox-label>` — the opinionated label-row checkbox.
+ *
+ * The box is `holoCheck` from `src/ui/holo.ts`, the same fragment
+ * `<os-checkbox>` uses: one tick, one mesh, one focus ring across
+ * both. Swapping between the two components is then purely a layout
+ * decision, which is the only difference they were ever meant to have.
+ */
 export const styles = css`
+	${ holoTokens }
+	${ holoCheck }
+
 	:host {
 		display: inline-flex;
 		align-items: center;
-		gap: 6px;
+		gap: 8px;
 		font-size: 12px;
 		color: var( --os-ui-fg, #1d2327 );
 		cursor: pointer;
+		/*
+		 * A label row is a target, not a text run. Selecting the text
+		 * on a fast double-toggle leaves the row highlighted and is
+		 * never what anyone meant by clicking it twice.
+		 */
+		-webkit-user-select: none;
+		user-select: none;
 	}
 	label {
 		display: inline-flex;
 		align-items: center;
-		gap: 6px;
-		cursor: pointer;
-	}
-	input[ type='checkbox' ] {
-		accent-color: var( --wp-admin-theme-color, #2271b1 );
+		gap: 8px;
 		cursor: pointer;
 	}
 	:host( [ disabled ] ) {

--- a/src/ui/components/os-checkbox-label/os-checkbox-label.ts
+++ b/src/ui/components/os-checkbox-label/os-checkbox-label.ts
@@ -15,7 +15,6 @@ export class OsCheckboxLabel extends Component {
 		summary:
 			'Opinionated label-row variant of <os-checkbox>: label text + checkbox in a single aligned row. Use when you want the shipped layout without any layout work.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'label',

--- a/src/ui/components/os-checkbox/os-checkbox.styles.ts
+++ b/src/ui/components/os-checkbox/os-checkbox.styles.ts
@@ -1,16 +1,23 @@
 import { css } from '../../core';
+import { holoTokens, holoCheck } from '../../holo';
 
 /**
  * Styles for the standalone checkbox. Paired-label counterpart lives
  * in `<os-checkbox-label>`; this component paints just the box so
  * callers can place labels above/beside/after freely.
  *
- * The native checkbox is styled via `accent-color` so it picks up the
- * active admin theme color. Size is fixed at 16 px to match the
- * WordPress admin's prevailing checkbox metrics.
+ * The box itself comes from `holoCheck` in `src/ui/holo.ts`, shared
+ * with `<os-checkbox-label>` so the tick is the same tick in both. It
+ * replaced `accent-color`, which is the right answer for a native
+ * checkbox and the wrong one here: `accent-color` takes a colour, and
+ * checked in this kit is the Holomesh. Size stays 16 px, the
+ * WordPress admin's prevailing checkbox metric.
  */
 
 export const styles = css`
+	${ holoTokens }
+	${ holoCheck }
+
 	:host {
 		display: inline-flex;
 		align-items: center;
@@ -57,21 +64,6 @@ export const styles = css`
 		align-items: center;
 		gap: 6px;
 		cursor: inherit;
-	}
-
-	input[ type='checkbox' ] {
-		appearance: auto;
-		-webkit-appearance: auto;
-		accent-color: var( --wp-admin-theme-color, #2271b1 );
-		width: 16px;
-		height: 16px;
-		margin: 0;
-		cursor: inherit;
-	}
-
-	input[ type='checkbox' ]:focus-visible {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: 2px;
 	}
 
 	.os-checkbox__label {

--- a/src/ui/components/os-checkbox/os-checkbox.ts
+++ b/src/ui/components/os-checkbox/os-checkbox.ts
@@ -36,7 +36,6 @@ export class OsCheckbox extends Component {
 		summary:
 			'Standalone checkbox primitive. Paints the native control with the admin accent colour and optionally renders an inline label. Use when you need full control over label placement.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'checked',

--- a/src/ui/components/os-chip/os-chip.styles.ts
+++ b/src/ui/components/os-chip/os-chip.styles.ts
@@ -7,8 +7,11 @@
  * the global default.
  */
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: inline-flex;
 		max-width: 100%;
@@ -115,7 +118,7 @@ export const styles = css`
 		outline: none;
 	}
 	.os-chip__dismiss:focus-visible {
-		box-shadow: 0 0 0 2px var( --wp-admin-theme-color, #2271b1 );
+		box-shadow: var( --_holo-focus );
 	}
 	.os-chip__dismiss[ disabled ] {
 		opacity: 0.35;
@@ -137,5 +140,41 @@ export const styles = css`
 	:host( [ size='compact' ] ) .os-chip {
 		padding: var( --os-ui-chip-padding, 1px 6px );
 		font-size: var( --os-ui-chip-font-size, 11px );
+	}
+
+	/*
+	 * The holographic hairline, and ONLY on a selected chip.
+	 *
+	 * Chips arrive in rows of eight and twelve — a tag column, a
+	 * filter bar, a category picker — so the treatment here has to be
+	 * the one that costs nothing when repeated. An edge on the one
+	 * chip the user has chosen reads instantly in a row of otherwise
+	 * flat pills; an edge on all of them reads as noise.
+	 *
+	 * Drawn on a mask-composited ::after rather than a border, because
+	 * border-color takes a colour and this is a gradient. Same
+	 * technique as .os-holo-edge; written out here because the chip's
+	 * frame belongs to .os-chip, an inner element rather than the
+	 * host, and the shared class hangs its ring on whatever carries
+	 * the class.
+	 */
+	:host( [ selected ] ) .os-chip {
+		position: relative;
+		background: var( --os-ui-chip-bg, var( --os-ui-accent-soft, rgba( 34, 113, 177, 0.14 ) ) );
+		color: var( --os-ui-chip-fg, var( --os-ui-fg, #1d2327 ) );
+	}
+	:host( [ selected ] ) .os-chip::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		padding: 1px;
+		background-image: var( --_holo-edge );
+		pointer-events: none;
+		-webkit-mask: linear-gradient( #000 0 0 ) content-box,
+			linear-gradient( #000 0 0 );
+		-webkit-mask-composite: xor;
+		mask: linear-gradient( #000 0 0 ) content-box, linear-gradient( #000 0 0 );
+		mask-composite: exclude;
 	}
 `;

--- a/src/ui/components/os-chip/os-chip.ts
+++ b/src/ui/components/os-chip/os-chip.ts
@@ -45,6 +45,7 @@ export class OsChip extends Component {
 		'dismissible',
 		'disabled',
 		'pending',
+		'selected',
 	] as const;
 	static styles = [ styles ];
 
@@ -91,6 +92,12 @@ export class OsChip extends Component {
 				type: 'boolean attribute',
 				description:
 					'Renders a subtle pulse animation while a REST mutation is in flight. Auto-applied by <os-tag-input>; safe to set by hand.',
+			},
+			{
+				name: 'selected',
+				type: 'boolean attribute',
+				description:
+					'Marks the chip as chosen: an accent wash plus the kit’s iridescent hairline. Deliberately the only state that gets the hairline — chips arrive in rows of a dozen, and an edge on all of them is noise.',
 			},
 		],
 		slots: [

--- a/src/ui/components/os-chip/os-chip.ts
+++ b/src/ui/components/os-chip/os-chip.ts
@@ -53,8 +53,7 @@ export class OsChip extends Component {
 		title: 'Chip',
 		summary:
 			'Labelled pill primitive with optional leading icon and trailing dismiss button. Tones mirror <os-badge>; pair with <os-tag-input> for full add/remove ergonomics.',
-		status: 'experimental',
-		since: '0.8.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'label',

--- a/src/ui/components/os-cluster/os-cluster.ts
+++ b/src/ui/components/os-cluster/os-cluster.ts
@@ -32,7 +32,6 @@ export class OsCluster extends Component {
 		summary:
 			'Horizontal flex layout with a gap + wrap. The sibling of <os-stack> — use it for rows of controls (button groups, toolbars). Children wrap gracefully when the container narrows.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'gap',

--- a/src/ui/components/os-code/os-code.ts
+++ b/src/ui/components/os-code/os-code.ts
@@ -35,8 +35,7 @@ export class OsCode extends Component {
 		title: 'Code',
 		summary:
 			'Inline monospace code badge — safe for URLs, flag names, and any string that would otherwise steal keypresses if rendered as <os-key>. Set `block` for a multi-line snippet box. Set `copy` for a built-in copy-to-clipboard affordance.',
-		status: 'experimental',
-		since: '0.5.1',
+		status: 'stable',
 		props: [
 			{
 				name: 'block',

--- a/src/ui/components/os-color-field/os-color-field.styles.ts
+++ b/src/ui/components/os-color-field/os-color-field.styles.ts
@@ -1,6 +1,9 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: inline-flex;
 		align-items: center;
@@ -21,6 +24,21 @@ export const styles = css`
 		border-radius: 6px;
 		background: transparent;
 		cursor: pointer;
+		transition: border-color var( --_holo-t ) ease,
+			box-shadow var( --_holo-t ) ease;
+	}
+	input[ type='color' ]:hover {
+		border-color: var( --os-ui-border-strong, #8c8f94 );
+	}
+	/*
+	 * The target ring, not the field one. A colour swatch is a small
+	 * filled tile that could be any colour at all — including Pulse
+	 * itself — so it needs the ring that carries a Void spacer and a
+	 * bloom rather than the one that merely tints its own border.
+	 */
+	input[ type='color' ]:focus-visible {
+		outline: none;
+		box-shadow: var( --_holo-focus );
 	}
 	/*
 	 * Block variant: the host fills its parent, the input stretches

--- a/src/ui/components/os-color-field/os-color-field.ts
+++ b/src/ui/components/os-color-field/os-color-field.ts
@@ -21,7 +21,6 @@ export class OsColorField extends Component {
 		summary:
 			'Label + native color input. Reflects the value attribute both ways and emits os-color-change live on every edit (no debounce — callers debounce upstream).',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'label',

--- a/src/ui/components/os-confirm-dialog/os-confirm-dialog.styles.ts
+++ b/src/ui/components/os-confirm-dialog/os-confirm-dialog.styles.ts
@@ -1,6 +1,9 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const dialogStyles = css`
+	${ holoTokens }
+
 	:host {
 		display: none;
 		position: fixed;
@@ -17,8 +20,41 @@ export const dialogStyles = css`
 		z-index: 10000;
 	}
 
+	/*
+	 * Same arrival as <os-modal>: the scrim fades, the dialog lands on
+	 * the spring. Duplicated rather than shared because the two
+	 * components have separate shadow roots and separate keyframe
+	 * scopes — an @keyframes in one is invisible to the other, so the
+	 * only way to share it would be a fragment in src/ui/holo.ts, and
+	 * a two-line animation used twice does not earn one.
+	 */
 	:host( [ open ] ) {
 		display: flex;
+		animation: os-confirm-scrim var( --_holo-t ) var( --_holo-ease );
+	}
+
+	:host( [ open ] ) .dialog {
+		animation: os-confirm-dialog var( --_holo-t ) var( --_holo-spring );
+	}
+
+	@keyframes os-confirm-scrim {
+		from {
+			opacity: 0;
+		}
+	}
+
+	@keyframes os-confirm-dialog {
+		from {
+			opacity: 0;
+			transform: scale( 0.96 ) translateY( 8px );
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ open ] ),
+		:host( [ open ] ) .dialog {
+			animation: none;
+		}
 	}
 
 	.dialog {

--- a/src/ui/components/os-confirm-dialog/os-confirm-dialog.ts
+++ b/src/ui/components/os-confirm-dialog/os-confirm-dialog.ts
@@ -72,6 +72,67 @@ export class OsConfirmDialog extends Component {
 				description: 'Fires on cancel (Cancel button, Escape, backdrop click). Detail: `{ confirmed: false }`.',
 			},
 		],
+		/*
+		 * A dialog is `display: none` until `[open]`, so mounting one
+		 * on its own shows nothing — which is exactly what this
+		 * component's help pane did before. The trigger IS the
+		 * example: a dialog you cannot open demonstrates nothing.
+		 *
+		 * Wiring lives in `exampleInit` rather than in an `@click` in
+		 * the template so the lookup is scoped to the example's own
+		 * container. `onclick =` assignment rather than
+		 * `addEventListener` because the panel re-runs this on every
+		 * keystroke in the filter box, and assignment replaces where
+		 * adding would stack.
+		 */
+		example: html`
+			<os-cluster gap="8">
+				<os-button data-demo="ask">Ask me something</os-button>
+				<os-button data-demo="danger" variant="danger">
+					…and a destructive one
+				</os-button>
+			</os-cluster>
+			<os-confirm-dialog
+				title="Close this window?"
+				message="Any unsaved changes will be lost."
+				confirm-label="Close"
+			></os-confirm-dialog>
+		`,
+		exampleInit: ( root: HTMLElement ) => {
+			const dialog = root.querySelector( 'os-confirm-dialog' );
+			if ( ! dialog ) {
+				return;
+			}
+			const ask = root.querySelector< HTMLElement >( '[data-demo="ask"]' );
+			const danger = root.querySelector< HTMLElement >(
+				'[data-demo="danger"]',
+			);
+			// Assignment, not addEventListener: see the note above.
+			if ( ask ) {
+				ask.onclick = () => {
+					dialog.removeAttribute( 'danger' );
+					dialog.setAttribute( 'title', 'Close this window?' );
+					dialog.setAttribute(
+						'message',
+						'Any unsaved changes will be lost.',
+					);
+					dialog.setAttribute( 'confirm-label', 'Close' );
+					dialog.setAttribute( 'open', '' );
+				};
+			}
+			if ( danger ) {
+				danger.onclick = () => {
+					dialog.setAttribute( 'danger', '' );
+					dialog.setAttribute( 'title', 'Empty the recycle bin?' );
+					dialog.setAttribute(
+						'message',
+						'47 items will be deleted permanently. This cannot be undone.',
+					);
+					dialog.setAttribute( 'confirm-label', 'Delete forever' );
+					dialog.setAttribute( 'open', '' );
+				};
+			}
+		},
 	} as const;
 
 	connectedCallback() {

--- a/src/ui/components/os-confirm-dialog/os-confirm-dialog.ts
+++ b/src/ui/components/os-confirm-dialog/os-confirm-dialog.ts
@@ -50,8 +50,7 @@ export class OsConfirmDialog extends Component {
 		title: 'Confirm dialog',
 		summary:
 			'Modal Yes/No replacement for window.confirm(). Two consumption paths: declarative element with `open` + `os-confirm` event, or the imperative Promise-returning `osConfirm()` helper.',
-		status: 'experimental',
-		since: '0.9.0',
+		status: 'stable',
 		props: [
 			{ name: 'open', type: 'boolean attribute', description: 'Mounts the dialog visible.' },
 			{ name: 'title', type: 'string', description: 'Heading shown at the top.' },

--- a/src/ui/components/os-context-menu/os-context-menu.styles.ts
+++ b/src/ui/components/os-context-menu/os-context-menu.styles.ts
@@ -5,8 +5,12 @@
  * pixels — just the markup.
  */
 import { css } from '../../core';
+import { holoTokens, holoEnter } from '../../holo';
 
 export const menuStyles = css`
+	${ holoTokens }
+	${ holoEnter }
+
 	:host {
 		display: none;
 		position: fixed;
@@ -32,8 +36,31 @@ export const menuStyles = css`
 		z-index: 9999;
 	}
 
+	/*
+	 * The menu grows from the pointer. Its top inline-start corner is
+	 * placed at the click, so that corner is the one thing on screen
+	 * the user is already looking at — scaling from the centre would
+	 * have it expand back over the spot they just clicked.
+	 *
+	 * The animation hangs off [open] rather than off :host, because
+	 * this component toggles display rather than mounting: a keyframe
+	 * on the base rule would only ever run once, the first time the
+	 * element was painted.
+	 */
 	:host( [ open ] ) {
 		display: block;
+		animation: os-holo-enter var( --_holo-t-fast ) var( --_holo-ease );
+		transform-origin: top left;
+	}
+
+	:host( [ open ]:dir( rtl ) ) {
+		transform-origin: top right;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ open ] ) {
+			animation: none;
+		}
 	}
 `;
 

--- a/src/ui/components/os-context-menu/os-context-menu.ts
+++ b/src/ui/components/os-context-menu/os-context-menu.ts
@@ -49,8 +49,7 @@ export class OsContextMenu extends Component {
 		title: 'Context menu',
 		summary:
 			'Floating popup menu primitive. Pair with <os-context-menu-option> children. Toggle via the `open` boolean attribute. Listen for `os-context-menu-pick` to handle activation.',
-		status: 'experimental',
-		since: '0.9.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'open',
@@ -130,8 +129,7 @@ export class OsContextMenuOption extends Component {
 		title: 'Context menu option',
 		summary:
 			'Single row inside <os-context-menu>. Use `icon` for a leading dashicon, `danger` for destructive items, `heading` for a non-interactive section header, `has-children` to render a trailing chevron.',
-		status: 'experimental',
-		since: '0.9.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-context-menu/os-context-menu.ts
+++ b/src/ui/components/os-context-menu/os-context-menu.ts
@@ -67,6 +67,37 @@ export class OsContextMenu extends Component {
 				description: 'Bubbled from a non-disabled, non-heading option on activation. Detail: `{ id, value }`.',
 			},
 		],
+		/*
+		 * Shown open and pinned back into normal flow.
+		 *
+		 * In use the menu is `position: fixed` and placed at the
+		 * pointer, which in a documentation pane means it would either
+		 * be invisible (closed) or floating over the settings window
+		 * at coordinates nothing set (open). The inline
+		 * `position: relative` beats the `:host` rule and puts it in
+		 * the page where it can actually be looked at — the one thing
+		 * the example is for.
+		 */
+		example: html`
+			<os-context-menu open style="position: relative; z-index: 0">
+				<os-context-menu-option heading>Window</os-context-menu-option>
+				<os-context-menu-option value="open" icon="dashicons-external">
+					Open in a new window
+				</os-context-menu-option>
+				<os-context-menu-option value="rename" icon="dashicons-edit">
+					Rename…
+				</os-context-menu-option>
+				<os-context-menu-option value="more" icon="dashicons-portfolio" has-children>
+					Move to
+				</os-context-menu-option>
+				<os-context-menu-option value="locked" icon="dashicons-lock" disabled>
+					Permissions
+				</os-context-menu-option>
+				<os-context-menu-option value="trash" icon="dashicons-trash" danger>
+					Move to Recycle Bin
+				</os-context-menu-option>
+			</os-context-menu>
+		`,
 	} as const;
 
 	protected render() {
@@ -147,6 +178,31 @@ export class OsContextMenuOption extends Component {
 				description: 'Bubbled on click / Enter for non-heading non-disabled options. Detail: `{ id, value }`.',
 			},
 		],
+		/*
+		 * An option only has a shape inside a menu — on its own it is
+		 * an unpadded row on the panel background. So the example is
+		 * the parent in miniature, showing every modifier this
+		 * component actually has.
+		 */
+		example: html`
+			<os-context-menu open style="position: relative; z-index: 0">
+				<os-context-menu-option heading>Every variant</os-context-menu-option>
+				<os-context-menu-option value="plain">Plain</os-context-menu-option>
+				<os-context-menu-option value="icon" icon="dashicons-admin-page">
+					With an icon
+				</os-context-menu-option>
+				<os-context-menu-option value="checked" checked>
+					Checked
+				</os-context-menu-option>
+				<os-context-menu-option value="children" has-children>
+					With a submenu
+				</os-context-menu-option>
+				<os-context-menu-option value="off" disabled>Disabled</os-context-menu-option>
+				<os-context-menu-option value="del" danger icon="dashicons-trash">
+					Danger
+				</os-context-menu-option>
+			</os-context-menu>
+		`,
 	} as const;
 
 	connectedCallback() {

--- a/src/ui/components/os-crumb-chain/os-crumb-chain.ts
+++ b/src/ui/components/os-crumb-chain/os-crumb-chain.ts
@@ -96,16 +96,25 @@ export class OsCrumbChain extends Component {
 					'{ index: number; id?: number | string; segment: OsCrumbSegment; segments: OsCrumbSegment[]; dragEvent: DragEvent }',
 			},
 		],
-		example: html`
-			<os-crumb-chain id="example-chain" removable></os-crumb-chain>
-			<script>
-				document.getElementById( 'example-chain' ).segments = [
-					{ id: 1, name: 'Tech', color: '#2271b1' },
-					{ id: 2, name: 'Web Dev', color: '#3a8ed4' },
-					{ id: 3, name: 'Frontend', color: '#5cb0ff' },
+		/*
+		 * The chain takes its data through the `segments` PROPERTY,
+		 * so there is no markup that can fill it — hence the
+		 * `exampleInit` hook rather than a `<script>` in the template.
+		 * A script here would never have run: the template is compiled
+		 * through `innerHTML`, which flags parsed scripts as already
+		 * started, and the cloning steps copy that flag.
+		 */
+		example: html`<os-crumb-chain removable></os-crumb-chain>`,
+		exampleInit: ( root: HTMLElement ) => {
+			const chain = root.querySelector( 'os-crumb-chain' );
+			if ( chain ) {
+				( chain as OsCrumbChain ).segments = [
+					{ id: 1, name: 'Tech', color: '#4b3eff' },
+					{ id: 2, name: 'Web Dev', color: '#a580ff' },
+					{ id: 3, name: 'Frontend', color: '#f252fc' },
 				];
-			</script>
-		`,
+			}
+		},
 	} as const;
 
 	private _segments: OsCrumbSegment[] = [];

--- a/src/ui/components/os-crumb-chain/os-crumb-chain.ts
+++ b/src/ui/components/os-crumb-chain/os-crumb-chain.ts
@@ -59,8 +59,7 @@ export class OsCrumbChain extends Component {
 		title: 'Crumb chain',
 		summary:
 			'Chevron-interlocking breadcrumb. Segments slot together like puzzle pieces, with each segment in its own color so the eye reads root → leaf as a single merged path. Reusable for any parent → child → grandchild relationship.',
-		status: 'experimental',
-		since: '0.8.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'removable',

--- a/src/ui/components/os-display/os-display.ts
+++ b/src/ui/components/os-display/os-display.ts
@@ -44,7 +44,6 @@ export class OsDisplay extends Component {
 		summary:
 			'Single-line numeric/text readout — right-aligned, tabular-nums, auto-ellipsized. The readout every calculator, stopwatch, ticker, counter, or meter reinvents. Host is aria-live="polite" so screen readers announce value changes without yanking focus.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-empty-state/os-empty-state.ts
+++ b/src/ui/components/os-empty-state/os-empty-state.ts
@@ -38,7 +38,6 @@ export class OsEmptyState extends Component {
 		summary:
 			'Centered placeholder for "nothing here yet" UI: icon + heading + description + optional CTA. A canonical shape so empty states look consistent across the shell.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'icon',

--- a/src/ui/components/os-flyout/os-flyout.test.ts
+++ b/src/ui/components/os-flyout/os-flyout.test.ts
@@ -349,7 +349,7 @@ describe( 'os-flyout', () => {
 	test( 'static help block carries the documented surface', async () => {
 		const { OsFlyout } = await load();
 		expect( OsFlyout.help?.title ).toBe( 'Flyout' );
-		expect( OsFlyout.help?.status ).toBe( 'experimental' );
+		expect( OsFlyout.help?.status ).toBe( 'stable' );
 		const propNames = ( OsFlyout.help?.props ?? [] ).map( ( p ) => p.name );
 		expect( propNames ).toEqual(
 			expect.arrayContaining( [ 'open', 'placement', 'scope' ] ),

--- a/src/ui/components/os-flyout/os-flyout.ts
+++ b/src/ui/components/os-flyout/os-flyout.ts
@@ -93,8 +93,7 @@ export class OsFlyout extends Component {
 		title: 'Flyout',
 		summary:
 			'Window-scoped sliding card. Lives `position: absolute` inside a window body, slides in from the configured edge with margins on every side, captures the previously-focused element as the trigger for restore-on-close, traps focus while open, and dismisses on Escape / pointerdown-outside / `[data-flyout-close]` click / imperative `open`-removal — all firing one `os-flyout-dismiss` event with a `reason` discriminator.',
-		status: 'experimental',
-		since: '0.8.2',
+		status: 'stable',
 		props: [
 			{
 				name: 'open',

--- a/src/ui/components/os-form/os-form.ts
+++ b/src/ui/components/os-form/os-form.ts
@@ -104,8 +104,7 @@ export class OsForm extends Component {
 		title: 'Form',
 		summary:
 			'Container-query-driven responsive form. Auto-collects named fields, validates required, exposes setError / setFieldInvalid / setBusy / reset, fires os-form-submit with the collected values map.',
-		status: 'experimental',
-		since: '0.8.1',
+		status: 'stable',
 		props: [
 			{
 				name: 'submit-label',

--- a/src/ui/components/os-grid/os-grid.ts
+++ b/src/ui/components/os-grid/os-grid.ts
@@ -36,7 +36,6 @@ export class OsGrid extends Component {
 		summary:
 			'Neutral CSS grid container. The 2-D twin of <os-stack>/<os-cluster>. No role is emitted — callers wrap in role="grid"/"radiogroup" if warranted.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'columns',

--- a/src/ui/components/os-icon/os-icon.ts
+++ b/src/ui/components/os-icon/os-icon.ts
@@ -39,7 +39,6 @@ export class OsIcon extends Component {
 		summary:
 			'Dashicon wrapper that inherits theme colour + sizing from its context. Accepts either the dashicon suffix ("calculator") or the full class ("dashicons-calculator"). Marked aria-hidden; wrap in a button/link with its own label for accessible use.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'name',

--- a/src/ui/components/os-key/os-key.styles.ts
+++ b/src/ui/components/os-key/os-key.styles.ts
@@ -1,6 +1,23 @@
 import { css } from '../../core';
+import { holoTokens, holoSheen } from '../../holo';
 
+/**
+ * `<os-key>` — the keypad tile.
+ *
+ * A key is pressed far more often than it is looked at, so the
+ * holographic layer here is the *quietest* one in the kit: the hover
+ * film only, no edge and no mesh. A grid of twenty iridescent tiles
+ * would be a screensaver.
+ *
+ * `variant="primary"` is the exception, and stays an accent fill
+ * rather than a mesh for the same reason a primary button does — on a
+ * calculator that variant is the `=` key, and it is on screen next to
+ * nineteen others every second the window is open.
+ */
 export const styles = css`
+	${ holoTokens }
+	${ holoSheen }
+
 	:host {
 		display: inline-flex;
 		user-select: none;
@@ -40,6 +57,15 @@ export const styles = css`
 	}
 	button:hover:not( :disabled ) {
 		background: var( --os-ui-key-bg-hover, var( --os-ui-hover, rgba( 0, 0, 0, 0.1 ) ) );
+	}
+	button:focus-visible {
+		outline: none;
+		box-shadow: var( --_holo-focus );
+	}
+	/* A disabled key must not light up under the pointer — the film
+	   would advertise a press that will not happen. */
+	button:disabled::before {
+		opacity: 0 !important;
 	}
 	:host( [ variant='primary' ] ) button {
 		background: var( --os-ui-key-bg, var( --wp-admin-theme-color, #2271b1 ) );

--- a/src/ui/components/os-key/os-key.styles.ts
+++ b/src/ui/components/os-key/os-key.styles.ts
@@ -1,22 +1,30 @@
 import { css } from '../../core';
-import { holoTokens, holoSheen } from '../../holo';
+import { holoTokens, holoSheen, holoGlint, holoRing } from '../../holo';
 
 /**
  * `<os-key>` — the keypad tile.
  *
  * A key is pressed far more often than it is looked at, so the
  * holographic layer here is the *quietest* one in the kit: the hover
- * film only, no edge and no mesh. A grid of twenty iridescent tiles
- * would be a screensaver.
+ * film, no edge and no mesh. A grid of twenty iridescent tiles would
+ * be a screensaver.
  *
  * `variant="primary"` is the exception, and stays an accent fill
  * rather than a mesh for the same reason a primary button does — on a
  * calculator that variant is the `=` key, and it is on screen next to
  * nineteen others every second the window is open.
+ *
+ * It does get both motions, though, and a keypad is where they earn
+ * the most: the glint on hover, and the press ring on `:active`. A key
+ * already squashes (`scale( 0.96 )` plus an inset shadow) — the ring
+ * is what makes a *fast repeated* press legible, where the squash
+ * alone blurs into one continuous dent.
  */
 export const styles = css`
 	${ holoTokens }
 	${ holoSheen }
+	${ holoGlint }
+	${ holoRing }
 
 	:host {
 		display: inline-flex;

--- a/src/ui/components/os-key/os-key.ts
+++ b/src/ui/components/os-key/os-key.ts
@@ -201,6 +201,8 @@ export class OsKey extends Component {
 				${ label !== null && label !== undefined && label !== ''
 		? label
 		: html`<slot></slot>` }
+				<span class="os-holo-glint" aria-hidden="true"></span>
+				<span class="os-holo-ring" aria-hidden="true"></span>
 			</button>
 		`;
 	}

--- a/src/ui/components/os-key/os-key.ts
+++ b/src/ui/components/os-key/os-key.ts
@@ -193,6 +193,7 @@ export class OsKey extends Component {
 		return html`
 			<button
 				part="button"
+				class="os-holo-sheen"
 				type="button"
 				?disabled=${ disabled }
 				@click=${ ( e: MouseEvent ) => this.handleClick( e ) }

--- a/src/ui/components/os-key/os-key.ts
+++ b/src/ui/components/os-key/os-key.ts
@@ -76,7 +76,6 @@ export class OsKey extends Component {
 		summary:
 			'Semantic key cap — a press-sensitive tile that fires os-key on click AND when the matching event.key/event.code is pressed anywhere on the document. Use for calculators, on-screen keyboards, synths, and keybinding demos.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'key',

--- a/src/ui/components/os-log/os-log.ts
+++ b/src/ui/components/os-log/os-log.ts
@@ -110,8 +110,7 @@ export class OsLog< T = unknown > extends Component {
 		title: 'Log (virtualized)',
 		summary:
 			'Append-only streaming list for high-rate output (SQL queries, network calls, log lines). Virtualises so thousands of rows render without layout cost; pins to the bottom while the viewport sits there, releases when the user scrolls up.',
-		status: 'experimental',
-		since: '0.6.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'row-height',

--- a/src/ui/components/os-log/os-log.ts
+++ b/src/ui/components/os-log/os-log.ts
@@ -157,9 +157,29 @@ export class OsLog< T = unknown > extends Component {
 			{ name: '--os-ui-log-row-border', default: '1px solid rgba(0,0,0,0.04)' },
 			{ name: '--os-ui-log-min-height', default: '120px' },
 		],
+		/*
+		 * `entries` is a property, so the markup alone renders the
+		 * empty-state. Height comes from the caller — the log is a
+		 * scroll container and has no intrinsic one.
+		 */
 		example: html`
-			<os-log id="sample-log" row-height="22" max-rows="500"></os-log>
+			<div style="height:160px">
+				<os-log row-height="22" max-rows="500"></os-log>
+			</div>
 		`,
+		exampleInit: ( root: HTMLElement ) => {
+			const log = root.querySelector( 'os-log' );
+			if ( log ) {
+				( log as OsLog< string > ).entries = [
+					'[12:04:01] GET /wp-admin/index.php → 200 (48ms)',
+					'[12:04:01] SELECT * FROM wp_options WHERE autoload = 1',
+					'[12:04:02] GET /wp-json/desktop-mode/v1/session → 200 (12ms)',
+					'[12:04:02] SELECT * FROM wp_posts ORDER BY post_date DESC LIMIT 5',
+					'[12:04:03] POST /wp-admin/admin-ajax.php → 200 (31ms)',
+					'[12:04:04] GET /wp-json/desktop-mode/v1/files → 200 (19ms)',
+				];
+			}
+		},
 	} as const;
 
 	private _entries: T[] = [];

--- a/src/ui/components/os-menu/os-menu.styles.ts
+++ b/src/ui/components/os-menu/os-menu.styles.ts
@@ -1,14 +1,26 @@
 import { css } from '../../core';
+import { holoTokens, holoEnter } from '../../holo';
 
 /**
  * Menu / menu-item share a frame (padding, font, radius) but each
  * controls its own shadow root. Two exported stylesheets;
  * co-located so the visual language stays in one file.
+ *
+ * The menu arrives rather than appears: `holoEnter` scales it from 96%
+ * on the spring curve. The origin is the top inline-start corner
+ * rather than the centre, because a menu is anchored — growing from
+ * the middle makes it look like it came from nowhere, growing from the
+ * corner makes it look like it came from the thing that opened it.
  */
 
 export const menuStyles = css`
+	${ holoTokens }
+	${ holoEnter }
+
 	:host {
 		display: block;
+		animation: os-holo-enter var( --_holo-t ) var( --_holo-spring );
+		transform-origin: top left;
 		min-width: 220px;
 		padding: 4px;
 		background: var( --os-window-bg, #fff );
@@ -22,6 +34,16 @@ export const menuStyles = css`
 		border-radius: 8px;
 		box-shadow: 0 8px 24px rgba( 0, 0, 0, 0.18 ),
 			0 2px 6px rgba( 0, 0, 0, 0.08 );
+	}
+
+	:host( :dir( rtl ) ) {
+		transform-origin: top right;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host {
+			animation: none;
+		}
 	}
 	:host( [ hidden ] ) {
 		display: none;

--- a/src/ui/components/os-menu/os-menu.styles.ts
+++ b/src/ui/components/os-menu/os-menu.styles.ts
@@ -56,9 +56,16 @@ export const menuItemStyles = css`
 		color: var( --os-ui-fg, #000 );
 		outline: none;
 	}
+	/*
+	 * Inset, not the kit's outer ring. A menu item is flush against
+	 * the popover's padding edge, so an outward ring is clipped on one
+	 * side and reads as a broken box; an inset ring traces the item
+	 * itself and is the only one that survives at the top and bottom
+	 * of the list.
+	 */
 	button:focus-visible {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: -2px;
+		outline: none;
+		box-shadow: inset 0 0 0 2px var( --os-ui-accent, #2271b1 );
 	}
 	.os-menu-item__icon {
 		flex-shrink: 0;
@@ -94,9 +101,26 @@ export const menuItemStyles = css`
 	.os-menu-item__check[ hidden ] {
 		display: none;
 	}
+	/*
+	 * A checked menu item's box is the same identity moment as a
+	 * checked <os-checkbox>, and now wears the same mesh — through
+	 * --os-ui-holo-fill, so the two cannot drift apart. The tick
+	 * turns Void with it: every mesh in the brand is a light surface
+	 * and the white tick that used to sit here would vanish.
+	 */
 	:host( [ checked ] ) .os-menu-item__check {
-		background: var( --wp-admin-theme-color, #2271b1 );
-		border-color: var( --wp-admin-theme-color, #2271b1 );
+		background-color: transparent;
+		background-image: var(
+			--os-ui-holo-fill,
+			linear-gradient( 124deg, #afa2e8 0%, #f5a8ea 46%, #8ee9f7 100% )
+		);
+		background-size: 200% 200%;
+		background-position: 25% 30%;
+		border-color: transparent;
+		box-shadow: var(
+			--os-ui-holo-glow,
+			0 0 0 1px rgba( 242, 82, 252, 0.28 ), 0 2px 10px rgba( 242, 82, 252, 0.22 )
+		);
 	}
 	:host( [ checked ] ) .os-menu-item__check::after {
 		content: '';
@@ -105,7 +129,7 @@ export const menuItemStyles = css`
 		left: 4px;
 		width: 4px;
 		height: 8px;
-		border: solid var( --os-ui-fg-on-accent, #fff );
+		border: solid var( --os-ui-holo-ink, #0c0b0f );
 		border-width: 0 2px 2px 0;
 		transform: rotate( 45deg );
 	}

--- a/src/ui/components/os-menu/os-menu.ts
+++ b/src/ui/components/os-menu/os-menu.ts
@@ -30,7 +30,6 @@ export class OsMenu extends Component {
 		summary:
 			'Popover menu used in window title bars and other overflow triggers. Presentation-only: the consumer owns open/close state via the `hidden` attribute and any outside-click dismissal.',
 		status: 'stable',
-		since: '0.9.0',
 		slots: [
 			{ name: '(default)', description: '<os-menu-item> children.' },
 		],
@@ -68,7 +67,6 @@ export class OsMenuItem extends Component {
 		summary:
 			'Single row inside a <os-menu>. Supports three looks: plain label, left-aligned dashicon (icon="dashicons-…"), or a checkbox indicator (role="menuitemcheckbox" + checked).',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'icon',

--- a/src/ui/components/os-menu/os-menu.ts
+++ b/src/ui/components/os-menu/os-menu.ts
@@ -96,6 +96,22 @@ export class OsMenuItem extends Component {
 				detail: '{ value: string | null }',
 			},
 		],
+		/*
+		 * An item has no shape outside a menu — it takes its padding,
+		 * width and surface from the parent — so the example is the
+		 * parent in miniature, showing each modifier the item has.
+		 */
+		example: html`
+			<os-menu>
+				<os-menu-item value="plain">Plain item</os-menu-item>
+				<os-menu-item value="icon" icon="dashicons-external">
+					With an icon
+				</os-menu-item>
+				<os-menu-item value="startup" role="menuitemcheckbox" checked>
+					Checked (menuitemcheckbox)
+				</os-menu-item>
+			</os-menu>
+		`,
 	} as const;
 
 	connectedCallback(): void {

--- a/src/ui/components/os-modal/os-modal.styles.ts
+++ b/src/ui/components/os-modal/os-modal.styles.ts
@@ -1,6 +1,9 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const modalStyles = css`
+	${ holoTokens }
+
 	:host {
 		display: none;
 		position: fixed;
@@ -54,8 +57,49 @@ export const modalStyles = css`
 		);
 	}
 
+	/*
+	 * Two animations, because a dialog is two things.
+	 *
+	 * The SCRIM fades. It is a state change over the whole viewport
+	 * and anything else would draw the eye to the background at the
+	 * exact moment the foreground is asking for attention.
+	 *
+	 * The DIALOG scales in from 96% on the spring, and lands slightly
+	 * faster than the scrim finishes — so the surface arrives on top
+	 * of a backdrop that is already there, which is the order the eye
+	 * expects from a physical object.
+	 *
+	 * Both hang off [open] rather than the base rule: this component
+	 * toggles display rather than mounting, so a keyframe on :host
+	 * would only ever run the first time.
+	 */
 	:host( [ open ] ) {
 		display: flex;
+		animation: os-modal-scrim var( --_holo-t ) var( --_holo-ease );
+	}
+
+	:host( [ open ] ) .dialog {
+		animation: os-modal-dialog var( --_holo-t ) var( --_holo-spring );
+	}
+
+	@keyframes os-modal-scrim {
+		from {
+			opacity: 0;
+		}
+	}
+
+	@keyframes os-modal-dialog {
+		from {
+			opacity: 0;
+			transform: scale( 0.96 ) translateY( 8px );
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ open ] ),
+		:host( [ open ] ) .dialog {
+			animation: none;
+		}
 	}
 
 	.dialog {

--- a/src/ui/components/os-modal/os-modal.ts
+++ b/src/ui/components/os-modal/os-modal.ts
@@ -67,6 +67,41 @@ export class OsModal extends Component {
 					'The dialog box itself, inside the scrim. Reach for it when a consumer needs the scrim and the box to behave differently — e.g. a live-preview panel that makes the scrim transparent and click-through (`pointer-events: none` on the host) while keeping the box interactive (`::part(dialog) { pointer-events: auto }`).',
 			},
 		],
+		/*
+		 * Hidden until `[open]`, so a bare mount renders nothing at
+		 * all. The trigger is the example.
+		 */
+		example: html`
+			<os-button data-demo="open">Open a modal</os-button>
+			<os-modal size="md" title="Window settings">
+				<p style="margin:0 0 12px">
+					A modal traps focus, closes on Escape or a backdrop click,
+					and returns focus to whatever opened it.
+				</p>
+				<os-cluster gap="8">
+					<os-button variant="primary" data-demo="close">Done</os-button>
+					<os-button data-demo="close">Cancel</os-button>
+				</os-cluster>
+			</os-modal>
+		`,
+		exampleInit: ( root: HTMLElement ) => {
+			const modal = root.querySelector( 'os-modal' );
+			if ( ! modal ) {
+				return;
+			}
+			const open = root.querySelector< HTMLElement >( '[data-demo="open"]' );
+			if ( open ) {
+				// Assignment rather than addEventListener: the help
+				// panel re-runs this on every keystroke in its filter
+				// box, and adding would stack a listener per repaint.
+				open.onclick = () => modal.setAttribute( 'open', '' );
+			}
+			for ( const btn of Array.from(
+				root.querySelectorAll< HTMLElement >( '[data-demo="close"]' ),
+			) ) {
+				btn.onclick = () => modal.removeAttribute( 'open' );
+			}
+		},
 	} as const;
 
 	private _prevFocus: HTMLElement | null = null;

--- a/src/ui/components/os-modal/os-modal.ts
+++ b/src/ui/components/os-modal/os-modal.ts
@@ -36,8 +36,7 @@ export class OsModal extends Component {
 		title: 'Modal overlay',
 		summary:
 			'Overlay container with title, body, and footer slots. Handles ESC, click-outside, focus trap. Use for rich modal flows that go beyond a yes/no confirm. The dialog surface is dark and re-points the shared surface tokens (--os-ui-fg/-muted/-border/-window-bg, --os-ui-button-bg-hover) so os-* controls slotted into it resolve readable dark-surface colors automatically.',
-		status: 'experimental',
-		since: '0.8.5',
+		status: 'stable',
 		props: [
 			{ name: 'open', type: 'boolean attribute', description: 'Mounts the dialog visible.' },
 			{ name: 'title', type: 'string', description: 'Heading shown at the top of the dialog.' },

--- a/src/ui/components/os-multiselect/os-multiselect.styles.ts
+++ b/src/ui/components/os-multiselect/os-multiselect.styles.ts
@@ -62,8 +62,11 @@ export const multiselectStyles = css`
 
 	.os-multiselect__trigger:focus-visible {
 		outline: none;
-		border-color: var( --wp-admin-theme-color, #2271b1 );
-		box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 );
+		border-color: var( --os-ui-accent, #2271b1 );
+		box-shadow: var(
+			--os-ui-focus-ring-field,
+			0 0 0 1px #2271b1, 0 0 0 4px rgba( 34, 113, 177, 0.18 )
+		);
 	}
 
 	.os-multiselect__trigger:disabled {

--- a/src/ui/components/os-multiselect/os-multiselect.ts
+++ b/src/ui/components/os-multiselect/os-multiselect.ts
@@ -53,8 +53,7 @@ export class OsMultiselect extends Component {
 		title: 'Multi-select',
 		summary:
 			'Multi-select dropdown picker that mirrors <os-select> ergonomically. Trigger button shows a one-line summary; clicking opens a checkbox popover. value is a comma-joined id list so it round-trips through plain string attributes.',
-		status: 'experimental',
-		since: '0.8.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-notice/os-notice.ts
+++ b/src/ui/components/os-notice/os-notice.ts
@@ -53,8 +53,7 @@ export class OsNotice extends Component {
 		title: 'Notice',
 		summary:
 			'Full-width banner placed inside a window (typically the after-titlebar slot). Tone-coded background + accent stripe, optional close button, optional dashicons leading glyph. Slotted content is HTML — links and basic formatting are supported.',
-		status: 'experimental',
-		since: '0.8.6',
+		status: 'stable',
 		props: [
 			{
 				name: 'tone',

--- a/src/ui/components/os-number-field/os-number-field.ts
+++ b/src/ui/components/os-number-field/os-number-field.ts
@@ -59,7 +59,6 @@ export class OsNumberField extends Component {
 		summary:
 			'Labelled numeric input. Wraps <os-text-field> semantics but forces type="number" and emits already-parsed numbers, clamping to min/max on commit.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{ name: 'label', type: 'string', description: 'Visible label above the input.' },
 			{ name: 'value', type: 'number (string)', description: 'Current numeric value; two-way reflected.' },

--- a/src/ui/components/os-panel/os-panel.ts
+++ b/src/ui/components/os-panel/os-panel.ts
@@ -36,7 +36,6 @@ export class OsPanel extends Component {
 		summary:
 			'Padded, flex-column container matching the default inset and rhythm of a native-window body. Opt-in for the OS-Settings-style padded layout.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'gap',

--- a/src/ui/components/os-progress-bar/os-progress-bar.styles.ts
+++ b/src/ui/components/os-progress-bar/os-progress-bar.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '../../core';
+import { holoTokens, holoShimmer } from '../../holo';
 
 /**
  * Why every default is a `--_alias` and not a `--os-ui-progress-*`
@@ -20,6 +21,9 @@ import { css } from '../../core';
  * less blocked layer. (Mirrors `<os-rating-summary>`.)
  */
 export const styles = css`
+	${ holoTokens }
+	${ holoShimmer }
+
 	:host {
 		display: block;
 		--_track-bg: var(
@@ -99,11 +103,40 @@ export const styles = css`
 		--os-ui-progress-fill: var( --os-ui-danger, #d63638 );
 	}
 
-	/* Indeterminate — sweeping bar across the track. */
+	/*
+	 * Indeterminate — the full track, with the mesh travelling through
+	 * it.
+	 *
+	 * The old shape was a 33% block sliding left to right forever, and
+	 * it has one real problem: a block moving in one direction looks
+	 * like it is measuring something. It is not. An indeterminate bar
+	 * knows nothing about how far along the work is, and the honest
+	 * picture of that is a surface that is *alive* without advancing —
+	 * which is exactly what the shimmer is.
+	 *
+	 * The block is still there for a tone modifier, though: a flat
+	 * --os-ui-progress-fill (success / warning / danger, or any
+	 * caller's colour) has no mesh to travel, so it keeps sliding. See
+	 * the rule below.
+	 */
 	:host( [ indeterminate ] ) .fill {
-		width: 33%;
-		animation: os-progress-sweep 1.1s linear infinite;
+		width: 100%;
 		transition: none;
+		background-image: var( --_fill );
+		background-size: 300% 300%;
+		background-repeat: no-repeat;
+		animation: os-holo-shimmer 2.4s var( --_holo-loop ) infinite;
+	}
+
+	/*
+	 * A tone means a flat colour, and a flat colour cannot shimmer —
+	 * it would sit there at 100% looking like a finished job. Those
+	 * fall back to the travelling block.
+	 */
+	:host( [ indeterminate ][ tone ] ) .fill {
+		width: 33%;
+		background-image: none;
+		animation: os-progress-sweep 1.1s linear infinite;
 	}
 
 	@keyframes os-progress-sweep {
@@ -119,7 +152,8 @@ export const styles = css`
 		.fill {
 			transition: none;
 		}
-		:host( [ indeterminate ] ) .fill {
+		:host( [ indeterminate ] ) .fill,
+		:host( [ indeterminate ][ tone ] ) .fill {
 			animation: none;
 			width: 100%;
 			opacity: 0.6;

--- a/src/ui/components/os-progress-bar/os-progress-bar.ts
+++ b/src/ui/components/os-progress-bar/os-progress-bar.ts
@@ -41,8 +41,7 @@ export class OsProgressBar extends Component {
 		title: 'Progress bar',
 		summary:
 			'Linear progress indicator. Determinate mode shows `value/max` as a fill width; indeterminate mode sweeps across the track. Supports tone tinting, an optional inline label + percent header, and full CSS-variable theming.',
-		status: 'experimental',
-		since: '0.31.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-range-field/os-range-field.styles.ts
+++ b/src/ui/components/os-range-field/os-range-field.styles.ts
@@ -80,7 +80,7 @@ export const styles = css`
 		background-size: auto, 260% 260%;
 		background-position: center, 30% 50%;
 		background-repeat: no-repeat;
-		box-shadow: inset 0 0 0 1px var( --os-ui-border, rgba( 0, 0, 0, 0.12 ) );
+		box-shadow: inset 0 0 0 1px var( --_holo-track-edge );
 	}
 
 	input[ type='range' ]::-moz-range-track {
@@ -95,7 +95,7 @@ export const styles = css`
 		background-size: auto, 260% 260%;
 		background-position: center, 30% 50%;
 		background-repeat: no-repeat;
-		box-shadow: inset 0 0 0 1px var( --os-ui-border, rgba( 0, 0, 0, 0.12 ) );
+		box-shadow: inset 0 0 0 1px var( --_holo-track-edge );
 	}
 
 	/* The thumb. Starlight, so it grips against both the lit and the

--- a/src/ui/components/os-range-field/os-range-field.styles.ts
+++ b/src/ui/components/os-range-field/os-range-field.styles.ts
@@ -1,6 +1,46 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
+/**
+ * `<os-range-field>` — label, track, readout.
+ *
+ * ## The elapsed track is the mesh
+ *
+ * A slider is the one control in the kit that shows a *quantity*, and
+ * the filled part of it is the natural place for the brand to live:
+ * it is already where the eye goes, it is already bounded, and it
+ * grows — so the mesh is revealed rather than merely applied.
+ *
+ * `accent-color` cannot do this. It takes a colour and the fill here
+ * is a gradient, so the track is repainted from scratch with two
+ * background layers:
+ *
+ *   1. an opaque wedge of the unlit track colour covering everything
+ *      PAST the current value, and
+ *   2. the mesh underneath, showing through where layer 1 is
+ *      transparent.
+ *
+ * The boundary between them is --_fill, a percentage the component
+ * writes on every input event. One custom property, no per-frame
+ * layout, and the mesh itself never moves — which matters, because a
+ * mesh that rescaled with the value would shift hue under the user's
+ * thumb while they dragged and read as a bug.
+ *
+ * RTL flips the wedge by flipping its angle, not its stops:
+ * --_range-angle is 90deg in LTR and 270deg in RTL, both written by
+ * the component from the computed direction.
+ *
+ * ## Why every pseudo-element gets its own rule
+ *
+ * ::-webkit-slider-thumb and ::-moz-range-thumb cannot share a
+ * selector list. One unknown pseudo-element invalidates the whole
+ * list, so a combined rule applies in NEITHER engine — the classic
+ * way a custom range ends up styled in Chrome and native in Firefox.
+ * Every rule below is duplicated for that reason. Do not merge them.
+ */
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: flex;
 		align-items: center;
@@ -8,20 +48,134 @@ export const styles = css`
 		font-size: 12px;
 		color: var( --os-ui-fg-muted, #646970 );
 	}
+
 	input[ type='range' ] {
+		appearance: none;
+		-webkit-appearance: none;
 		flex: 1;
-		accent-color: var( --wp-admin-theme-color, #2271b1 );
+		min-width: 0;
+		height: 18px;
+		margin: 0;
+		padding: 0;
+		background: transparent;
+		cursor: pointer;
 	}
+
+	input[ type='range' ]:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	/* The track. Two layers, first-on-top: the unfilled wedge, then
+	   the mesh. See the file docblock for why it is built this way. */
+	input[ type='range' ]::-webkit-slider-runnable-track {
+		height: 6px;
+		border-radius: 999px;
+		background-image: linear-gradient(
+				var( --_range-angle, 90deg ),
+				transparent var( --_fill, 0% ),
+				var( --_holo-track ) var( --_fill, 0% )
+			),
+			var( --_holo-fill );
+		background-size: auto, 260% 260%;
+		background-position: center, 30% 50%;
+		background-repeat: no-repeat;
+		box-shadow: inset 0 0 0 1px var( --os-ui-border, rgba( 0, 0, 0, 0.12 ) );
+	}
+
+	input[ type='range' ]::-moz-range-track {
+		height: 6px;
+		border-radius: 999px;
+		background-image: linear-gradient(
+				var( --_range-angle, 90deg ),
+				transparent var( --_fill, 0% ),
+				var( --_holo-track ) var( --_fill, 0% )
+			),
+			var( --_holo-fill );
+		background-size: auto, 260% 260%;
+		background-position: center, 30% 50%;
+		background-repeat: no-repeat;
+		box-shadow: inset 0 0 0 1px var( --os-ui-border, rgba( 0, 0, 0, 0.12 ) );
+	}
+
+	/* The thumb. Starlight, so it grips against both the lit and the
+	   unlit half of the track. The negative margin centres it on a
+	   6px track, which WebKit will not do once the track has a
+	   custom height. */
+	input[ type='range' ]::-webkit-slider-thumb {
+		appearance: none;
+		-webkit-appearance: none;
+		width: 16px;
+		height: 16px;
+		margin-top: -5px;
+		border: 0;
+		border-radius: 50%;
+		background: var( --os-ui-switch-knob, #fffbff );
+		box-shadow: 0 1px 3px rgba( 12, 11, 15, 0.5 ),
+			0 0 0 1px rgba( 12, 11, 15, 0.14 );
+		cursor: inherit;
+		transition: transform var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease;
+	}
+
+	input[ type='range' ]::-moz-range-thumb {
+		width: 16px;
+		height: 16px;
+		border: 0;
+		border-radius: 50%;
+		background: var( --os-ui-switch-knob, #fffbff );
+		box-shadow: 0 1px 3px rgba( 12, 11, 15, 0.5 ),
+			0 0 0 1px rgba( 12, 11, 15, 0.14 );
+		cursor: inherit;
+		transition: transform var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease;
+	}
+
+	/* Grows and picks up the Pulse bloom while it is held. */
+	input[ type='range' ]:active::-webkit-slider-thumb {
+		transform: scale( 1.15 );
+		box-shadow: var( --_holo-glow-strong );
+	}
+
+	input[ type='range' ]:active::-moz-range-thumb {
+		transform: scale( 1.15 );
+		box-shadow: var( --_holo-glow-strong );
+	}
+
+	/* Focus lands on the thumb, not on the whole 18px-tall input: a
+	   ring around the input traces a box whose edges the user cannot
+	   see, while a ring on the thumb points at the thing the arrow
+	   keys are about to move. */
+	input[ type='range' ]:focus-visible {
+		outline: none;
+	}
+
+	input[ type='range' ]:focus-visible::-webkit-slider-thumb {
+		box-shadow: var( --_holo-focus );
+	}
+
+	input[ type='range' ]:focus-visible::-moz-range-thumb {
+		box-shadow: var( --_holo-focus );
+	}
+
 	.os-range-field__value {
 		/* Fixed, not min-width: the readout shares a row with the
 		   track, so a box that grows with its contents shoves the
 		   slider sideways under the thumb the user is dragging. The
 		   width comes from the range's own bounds — see
-		   \`readoutWidth()\`. */
+		   readoutWidth() in the component. */
 		width: var( --os-ui-range-readout-width, 3ch );
 		flex: none;
 		text-align: end;
 		font-variant-numeric: tabular-nums;
 		color: var( --os-ui-fg, #1d2327 );
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		input[ type='range' ]::-webkit-slider-thumb {
+			transition-duration: 1ms;
+		}
+
+		input[ type='range' ]::-moz-range-thumb {
+			transition-duration: 1ms;
+		}
 	}
 `;

--- a/src/ui/components/os-range-field/os-range-field.ts
+++ b/src/ui/components/os-range-field/os-range-field.ts
@@ -84,7 +84,6 @@ export class OsRangeField extends Component {
 		summary:
 			'Label + range slider + live numeric readout. Emits os-range-change with an already-parsed number.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'label',

--- a/src/ui/components/os-range-field/os-range-field.ts
+++ b/src/ui/components/os-range-field/os-range-field.ts
@@ -16,6 +16,26 @@
 import { Component, defineComponent, html } from '../../core';
 import { styles } from './os-range-field.styles';
 
+/**
+ * Where the lit half of the track ends, as a percentage string.
+ *
+ * The track paints the mesh under an opaque wedge and this is the
+ * boundary between them — see the styles docblock. Clamped, because a
+ * caller is free to set `value` outside `min`/`max` and a negative
+ * gradient stop would drop the whole background layer rather than
+ * degrade.
+ */
+function fillPercent( value: string, min: string, max: string ): string {
+	const v = Number.parseFloat( value );
+	const lo = Number.parseFloat( min );
+	const hi = Number.parseFloat( max );
+	if ( ! Number.isFinite( v ) || ! Number.isFinite( lo ) || ! Number.isFinite( hi ) || hi === lo ) {
+		return '0%';
+	}
+	const fraction = ( v - lo ) / ( hi - lo );
+	return `${ Math.min( 100, Math.max( 0, fraction * 100 ) ).toFixed( 2 ) }%`;
+}
+
 /** Decimal places implied by a step, when the caller hasn't said. */
 function decimalsForStep( step: string ): number {
 	const dot = step.indexOf( '.' );
@@ -156,6 +176,7 @@ export class OsRangeField extends Component {
 				min=${ min }
 				max=${ max }
 				step=${ step }
+				style="--_fill: ${ fillPercent( value, min, max ) }"
 				.value=${ value }
 				@input=${ ( e: Event ) => this._onInput( e ) }
 			/>
@@ -165,6 +186,19 @@ export class OsRangeField extends Component {
 				>${ readout }${ suffix }</span
 			>
 		`;
+	}
+
+	connectedCallback(): void {
+		super.connectedCallback();
+		// The unlit wedge is a linear-gradient, and a gradient angle is
+		// physical. RTL therefore needs the wedge to run the other way,
+		// and the angle is the only thing that has to know: the stops,
+		// the mesh and --_fill stay exactly as they are. Read once on
+		// connect — a document that changes direction mid-session is not
+		// a case worth a MutationObserver per slider.
+		if ( getComputedStyle( this ).direction === 'rtl' ) {
+			this.style.setProperty( '--_range-angle', '270deg' );
+		}
 	}
 
 	private _onInput( e: Event ): void {

--- a/src/ui/components/os-rating-summary/os-rating-summary.ts
+++ b/src/ui/components/os-rating-summary/os-rating-summary.ts
@@ -59,9 +59,25 @@ export class OsRatingSummary extends Component {
 			{ name: '--os-ui-rating-fg', description: 'Primary text color.' },
 			{ name: '--os-ui-rating-fg-muted', description: 'Secondary text color.' },
 		],
-		example: html`
-			<os-rating-summary rating="92"></os-rating-summary>
-		`,
+		/*
+		 * `rating` is an attribute but the per-star bars come from the
+		 * `ratings` PROPERTY, so the attribute-only example drew the
+		 * stars above five empty tracks — the half of this component
+		 * that is actually interesting.
+		 */
+		example: html`<os-rating-summary rating="92" total="184"></os-rating-summary>`,
+		exampleInit: ( root: HTMLElement ) => {
+			const summary = root.querySelector( 'os-rating-summary' );
+			if ( summary ) {
+				( summary as OsRatingSummary ).ratings = {
+					5: 132,
+					4: 34,
+					3: 11,
+					2: 4,
+					1: 3,
+				};
+			}
+		},
 	} as const;
 
 	private _ratings: OsRatingBuckets = {};

--- a/src/ui/components/os-rating-summary/os-rating-summary.ts
+++ b/src/ui/components/os-rating-summary/os-rating-summary.ts
@@ -33,8 +33,7 @@ export class OsRatingSummary extends Component {
 		title: 'Rating summary',
 		summary:
 			'Two-pane rating distribution: big average + 5-star cluster + total count on the left, one animated bar per star bucket on the right. Mirrors the WordPress.org plugin reviews summary.',
-		status: 'experimental',
-		since: '0.8.5',
+		status: 'stable',
 		props: [
 			{
 				name: 'rating',

--- a/src/ui/components/os-relative-time/os-relative-time.ts
+++ b/src/ui/components/os-relative-time/os-relative-time.ts
@@ -220,8 +220,7 @@ export class OsRelativeTime extends Component {
 		title: 'Relative time',
 		summary:
 			'Auto-ticking relative timestamp. Renders "5 minutes ago" / "yesterday" / "in 3 hours" via Intl.RelativeTimeFormat and updates itself every 30s while connected. Useful for any list cell that should age live (recycle bin, notifications, activity log) without forcing the surrounding view to repaint. Set `compact` for dense lists ("5m", "3h", "2d").',
-		status: 'experimental',
-		since: '0.6.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'datetime',

--- a/src/ui/components/os-ribbon/os-ribbon.styles.ts
+++ b/src/ui/components/os-ribbon/os-ribbon.styles.ts
@@ -47,10 +47,22 @@ export const styles = css`
 		letter-spacing: var( --os-ui-ribbon-tracking, 0.06em );
 		text-transform: uppercase;
 		color: var( --os-ui-ribbon-fg, var( --os-ui-fg-on-accent, #fff ) );
+		/*
+		 * The default ribbon fill arrives through --os-ui-ribbon-bg,
+		 * which the palette points at Holomesh. A ribbon is a good
+		 * home for it: one per tile, small, angled, and already
+		 * carrying Void text (--os-ui-ribbon-fg) because a bright fill
+		 * needs dark ink whether it is a mesh or not.
+		 *
+		 * The literal stays the pre-brand blue — it is the
+		 * no-stylesheet floor, and it is what Legacy collected.
+		 */
 		background: var(
 			--os-ui-ribbon-bg,
 			var( --wp-admin-theme-color, #2271b1 )
 		);
+		background-size: 260% 260%;
+		background-position: 30% 40%;
 		box-shadow: var(
 			--os-ui-ribbon-shadow,
 			0 2px 4px rgba( 0, 0, 0, 0.2 )

--- a/src/ui/components/os-ribbon/os-ribbon.ts
+++ b/src/ui/components/os-ribbon/os-ribbon.ts
@@ -50,8 +50,7 @@ export class OsRibbon extends Component {
 		title: 'Ribbon',
 		summary:
 			'45° corner ribbon. Wraps the top-end (default), top-start, bottom-end, or bottom-start corner of its positioned parent. The host owns clipping + rotation; consumers only set position-relative on the parent and drop a label inside.',
-		status: 'experimental',
-		since: '0.8.6',
+		status: 'stable',
 		props: [
 			{
 				name: 'placement',

--- a/src/ui/components/os-role-picker/os-role-picker.ts
+++ b/src/ui/components/os-role-picker/os-role-picker.ts
@@ -29,8 +29,7 @@ export class OsRolePicker extends Component {
 		title: 'Role picker',
 		summary:
 			'Chip multi-select for WordPress roles. Reads eligible roles from openStationConfig.shareEligibleRoles; emits os-role-toggle { slug, selected } on every change.',
-		status: 'experimental',
-		since: '0.8.5',
+		status: 'stable',
 		props: [
 			{
 				name: 'selected',

--- a/src/ui/components/os-role-picker/os-role-picker.ts
+++ b/src/ui/components/os-role-picker/os-role-picker.ts
@@ -49,6 +49,20 @@ export class OsRolePicker extends Component {
 				description: 'Emitted on every click. Detail: `{ slug, selected }`.',
 			},
 		],
+		/*
+		 * `roles` is passed here explicitly rather than left to the
+		 * global config: a site whose `shareEligibleRoles` is empty —
+		 * or a docs pane loaded before that config lands — would
+		 * otherwise render an empty row and look broken. The attribute
+		 * override is a documented prop, so the example is also
+		 * demonstrating it.
+		 */
+		example: html`
+			<os-role-picker
+				selected="editor,author"
+				roles='[{"slug":"administrator","name":"Administrator"},{"slug":"editor","name":"Editor"},{"slug":"author","name":"Author"},{"slug":"contributor","name":"Contributor"},{"slug":"subscriber","name":"Subscriber"}]'
+			></os-role-picker>
+		`,
 	} as const;
 
 	private _selectedSet(): Set< string > {

--- a/src/ui/components/os-row/os-row.ts
+++ b/src/ui/components/os-row/os-row.ts
@@ -43,7 +43,6 @@ export class OsRow extends Component {
 		summary:
 			'Horizontal 12-column grid row. Children declare their width via a `col="N"` attribute (1..12); a child without `col` spans the full row. The col attribute lives on the child, so any element type works.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'gap',

--- a/src/ui/components/os-save-status/os-save-status.ts
+++ b/src/ui/components/os-save-status/os-save-status.ts
@@ -96,8 +96,7 @@ export class OsSaveStatus extends Component {
 		title: 'Save status',
 		summary:
 			'Tiny status indicator for "is this change saved yet?" affordances. Three layouts (dot / icon / pill), five phases, optional auto-listen to a save-lifecycle CustomEvent so every input in the panel inherits feedback for free.',
-		status: 'experimental',
-		since: '0.8.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'phase',

--- a/src/ui/components/os-section/os-section.ts
+++ b/src/ui/components/os-section/os-section.ts
@@ -24,7 +24,6 @@ export class OsSection extends Component {
 		summary:
 			'Titled panel with heading + description + a body slot. The canonical OS Settings section wrapper.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'heading',

--- a/src/ui/components/os-segmented/os-segmented.styles.ts
+++ b/src/ui/components/os-segmented/os-segmented.styles.ts
@@ -25,12 +25,87 @@ import { holoTokens, holoSheen } from '../../holo';
  */
 
 export const segmentedStyles = css`
+	${ holoTokens }
+
 	:host {
 		display: inline-flex;
+		position: relative;
 		padding: 3px;
 		background: var( --os-ui-segmented-bg, var( --os-ui-hover, rgba( 0, 0, 0, 0.05 ) ) );
 		border-radius: 7px;
 		gap: 2px;
+	}
+
+	/*
+	 * The thumb — the lit pill that slides between segments.
+	 *
+	 * It lives in the GROUP's shadow root, not in the selected child,
+	 * and that is the whole trick. A fill that belongs to the selected
+	 * segment can only appear and disappear; one that belongs to the
+	 * group is a single element that moves, so the selection travels
+	 * and the eye follows it instead of hunting for what changed.
+	 *
+	 * Painted before the <slot> in the shadow tree, so it sits under
+	 * the slotted labels with no z-index needed — the segments'
+	 * buttons are transparent and the thumb shows through.
+	 *
+	 * Geometry comes from the component, which measures the selected
+	 * child against the host and writes --_thumb-x / --_thumb-w.
+	 * Measured rather than computed from the child count, because the
+	 * segments are content-sized: "Small | Medium | Large" are three
+	 * different widths and an nth-child rule would put the pill under
+	 * the wrong word.
+	 */
+	.os-segmented__thumb {
+		position: absolute;
+		top: 3px;
+		bottom: 3px;
+		left: 0;
+		width: var( --_thumb-w, 0px );
+		border-radius: 5px;
+		background-color: var( --os-ui-segmented-selected-bg, transparent );
+		background-image: var(
+			--os-ui-segmented-selected-image,
+			var( --_holo-fill )
+		);
+		background-size: 220% 220%;
+		background-position: 22% 28%;
+		background-repeat: no-repeat;
+		box-shadow: var( --_holo-glow );
+		transform: translateX( var( --_thumb-x, 0px ) );
+		pointer-events: none;
+		opacity: 0;
+	}
+
+	/*
+	 * Two flags, and they are not the same thing.
+	 *
+	 * data-thumb says a segment is selected and the pill has been
+	 * measured — without it the thumb is a zero-width smear at the
+	 * origin, which is what an unselected group and the first frame
+	 * both look like.
+	 *
+	 * data-thumb-ready is set one frame LATER and is what turns the
+	 * transition on. Enabling it with the first measurement would
+	 * animate the pill in from x=0 on every page load: a settings
+	 * panel where six controls all slide into place on arrival, which
+	 * reads as the page assembling itself rather than as a selection
+	 * moving.
+	 */
+	:host( [ data-thumb ] ) .os-segmented__thumb {
+		opacity: 1;
+	}
+
+	:host( [ data-thumb-ready ] ) .os-segmented__thumb {
+		transition: transform var( --_holo-t-slow ) var( --_holo-spring ),
+			width var( --_holo-t-slow ) var( --_holo-ease ),
+			opacity var( --_holo-t-fast ) linear;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ data-thumb-ready ] ) .os-segmented__thumb {
+			transition-duration: 1ms;
+		}
 	}
 `;
 
@@ -74,34 +149,19 @@ export const segmentStyles = css`
 	}
 
 	/*
-	 * Longhands, not the background shorthand. --_holo-fill is a
-	 * nine-layer gradient list, and in a shorthand a trailing
-	 * "center / 220% 220%" binds to the LAST layer only — the eight
-	 * above it would fall back to auto and the mesh would come apart.
+	 * The selected segment paints NO fill of its own — the group's
+	 * thumb is sliding underneath it, and a second fill arriving on
+	 * the child at the same time would land instantly and give the
+	 * pill something to race.
+	 *
+	 * All the child does is take the ink that reads on the mesh, and
+	 * it takes it on the fast duration so the text has flipped by the
+	 * time the pill gets there rather than after.
 	 */
 	:host( [ aria-checked='true' ] ) button {
-		background-color: var( --os-ui-segmented-selected-bg, transparent );
-		background-image: var(
-			--os-ui-segmented-selected-image,
-			var( --_holo-fill )
-		);
-		background-size: 220% 220%;
-		background-position: 22% 28%;
-		background-repeat: no-repeat;
 		color: var( --os-ui-segmented-selected-fg, var( --_holo-ink ) );
-		box-shadow: var( --_holo-glow );
 		font-weight: 600;
-	}
-
-	:host( [ aria-checked='true' ] ) button:hover {
-		background-position: 74% 66%;
-		color: var( --os-ui-segmented-selected-fg, var( --_holo-ink ) );
-	}
-
-	@media ( prefers-reduced-motion: reduce ) {
-		:host( [ aria-checked='true' ] ) button:hover {
-			background-position: 22% 28%;
-		}
+		transition-duration: var( --_holo-t-fast );
 	}
 
 	/* The selected segment has nothing to gain from the hover film —

--- a/src/ui/components/os-segmented/os-segmented.styles.ts
+++ b/src/ui/components/os-segmented/os-segmented.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '../../core';
+import { holoTokens, holoSheen } from '../../holo';
 
 /**
  * Styles for the iOS-style segmented control. We ship TWO
@@ -6,6 +7,21 @@ import { css } from '../../core';
  * only the rules that apply to it. Keeping them in one file keeps
  * the visual decisions co-located (the parent pill + the inner
  * buttons share a visual language).
+ *
+ * ## The selected segment is the mesh
+ *
+ * Of every "one of these is chosen" control in the kit this is the
+ * best-behaved place to spend an identity moment: exactly one segment
+ * is lit at a time, the lit area is small and bounded, and the thing
+ * being said — *this* one — is precisely what an accent is for.
+ *
+ * A caller who disagrees has two declarations to write —
+ * `--os-ui-segmented-selected-image: none` and
+ * `--os-ui-segmented-selected-bg: <colour>` — which is how a settings
+ * panel with four segmented controls stacked in a column flattens
+ * them without touching this file. Two rather than one because a
+ * background *colour* cannot override a background *image*; they are
+ * different properties and the mesh lives in the second.
  */
 
 export const segmentedStyles = css`
@@ -19,6 +35,9 @@ export const segmentedStyles = css`
 `;
 
 export const segmentStyles = css`
+	${ holoTokens }
+	${ holoSheen }
+
 	:host {
 		flex: 1 1 auto;
 		min-width: 0;
@@ -35,16 +54,59 @@ export const segmentStyles = css`
 		color: var( --os-ui-fg-muted, #646970 );
 		cursor: pointer;
 		border-radius: 5px;
-		transition: background-color 0.12s ease, color 0.12s ease;
+		transition: background-color var( --_holo-t ) ease, color var( --_holo-t ) ease,
+			box-shadow var( --_holo-t ) ease, background-position var( --_holo-t ) ease;
 		/* Single-line labels — let the host grow horizontally to fit
 		 * the widest segment instead of wrapping mid-word. The pill
 		 * is naturally inline-flex so width follows content. */
 		white-space: nowrap;
 	}
-	:host( [ aria-checked='true' ] ) button {
-		background: var( --os-window-bg, #fff );
+
+	/* An unselected segment lifts toward its own text colour under
+	   the pointer; the holographic film underneath does the rest. */
+	button:hover {
 		color: var( --os-ui-fg, #1d2327 );
-		box-shadow: 0 1px 3px rgba( 0, 0, 0, 0.12 );
-		font-weight: 500;
+	}
+
+	button:focus-visible {
+		outline: none;
+		box-shadow: var( --_holo-focus );
+	}
+
+	/*
+	 * Longhands, not the background shorthand. --_holo-fill is a
+	 * nine-layer gradient list, and in a shorthand a trailing
+	 * "center / 220% 220%" binds to the LAST layer only — the eight
+	 * above it would fall back to auto and the mesh would come apart.
+	 */
+	:host( [ aria-checked='true' ] ) button {
+		background-color: var( --os-ui-segmented-selected-bg, transparent );
+		background-image: var(
+			--os-ui-segmented-selected-image,
+			var( --_holo-fill )
+		);
+		background-size: 220% 220%;
+		background-position: 22% 28%;
+		background-repeat: no-repeat;
+		color: var( --os-ui-segmented-selected-fg, var( --_holo-ink ) );
+		box-shadow: var( --_holo-glow );
+		font-weight: 600;
+	}
+
+	:host( [ aria-checked='true' ] ) button:hover {
+		background-position: 74% 66%;
+		color: var( --os-ui-segmented-selected-fg, var( --_holo-ink ) );
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:host( [ aria-checked='true' ] ) button:hover {
+			background-position: 22% 28%;
+		}
+	}
+
+	/* The selected segment has nothing to gain from the hover film —
+	   it is already the loudest thing in the control. */
+	:host( [ aria-checked='true' ] ) button::before {
+		display: none;
 	}
 `;

--- a/src/ui/components/os-segmented/os-segmented.test.ts
+++ b/src/ui/components/os-segmented/os-segmented.test.ts
@@ -64,6 +64,89 @@ describe( '<os-segmented> + <os-segment>', () => {
 		expect( group.getAttribute( 'value' ) ).toBe( 'km' );
 	} );
 
+	/**
+	 * jsdom has no layout, so every box measures zero. These give the
+	 * group and its segments a pretend geometry: the group starts at
+	 * x=100 with 3px of padding, and three 60px segments sit inside it.
+	 */
+	function layOut( group: Element ): void {
+		const rect = ( left: number, width: number ) =>
+			( { left, width, right: left + width, top: 0, bottom: 24, height: 24, x: left, y: 0, toJSON: () => ( {} ) } ) as DOMRect;
+		group.getBoundingClientRect = () => rect( 100, 189 );
+		const segs = Array.from( group.querySelectorAll( ':scope > os-segment' ) );
+		segs.forEach( ( seg, i ) => {
+			seg.getBoundingClientRect = () => rect( 103 + i * 62, 60 );
+		} );
+	}
+
+	test( 'the thumb is measured onto the selected segment', async () => {
+		host.innerHTML = `
+			<os-segmented value="b">
+				<os-segment value="a">A</os-segment>
+				<os-segment value="b">B</os-segment>
+				<os-segment value="c">C</os-segment>
+			</os-segmented>
+		`;
+		await tick();
+		const group = host.querySelector( 'os-segmented' ) as HTMLElement;
+		layOut( group );
+
+		// Re-render so the deferred placement runs against the geometry.
+		group.setAttribute( 'value', 'b' );
+		( group as HTMLElement & { value: string } ).value = 'b';
+		await tick();
+		await tick();
+
+		// Second segment: 103 + 62 = 165, minus the group's own 100.
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '65px' );
+		expect( group.style.getPropertyValue( '--_thumb-w' ) ).toBe( '60px' );
+		expect( group.hasAttribute( 'data-thumb' ) ).toBe( true );
+	} );
+
+	test( 'the thumb travels when the selection changes', async () => {
+		host.innerHTML = `
+			<os-segmented value="a">
+				<os-segment value="a">A</os-segment>
+				<os-segment value="b">B</os-segment>
+				<os-segment value="c">C</os-segment>
+			</os-segmented>
+		`;
+		await tick();
+		const group = host.querySelector( 'os-segmented' ) as HTMLElement;
+		layOut( group );
+		( group as HTMLElement & { value: string } ).value = 'a';
+		await tick();
+		await tick();
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '3px' );
+
+		host
+			.querySelector( 'os-segment[value="c"]' )!
+			.shadowRoot!.querySelector( 'button' )!
+			.click();
+		await tick();
+		await tick();
+
+		// Third segment: 103 + 124 = 227, minus 100.
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '127px' );
+	} );
+
+	test( 'an unmeasurable group hides the thumb rather than smearing it at the origin', async () => {
+		// A collapsed panel, a display:none tab, a group that has never
+		// been painted: every box is zero. A thumb placed from those
+		// numbers is a hairline at the group's left edge, which looks
+		// like a rendering bug rather than like nothing.
+		host.innerHTML = `
+			<os-segmented value="a">
+				<os-segment value="a">A</os-segment>
+			</os-segmented>
+		`;
+		await tick();
+		await tick();
+
+		const group = host.querySelector( 'os-segmented' )!;
+		expect( group.hasAttribute( 'data-thumb' ) ).toBe( false );
+	} );
+
 	test( '.items setter falls back to first entry when current value is no longer in the list', async () => {
 		host.innerHTML = `<os-segmented value="km"></os-segmented>`;
 		await tick();

--- a/src/ui/components/os-segmented/os-segmented.ts
+++ b/src/ui/components/os-segmented/os-segmented.ts
@@ -40,6 +40,19 @@ export class OsSegment extends Component {
 				detail: '{ value: string }',
 			},
 		],
+		/*
+		 * A segment on its own is a transparent button with no pill
+		 * around it and no thumb under it — the lit surface belongs to
+		 * the GROUP, which owns one and slides it. So the example is
+		 * the group.
+		 */
+		example: html`
+			<os-segmented value="md" label="Dock size">
+				<os-segment value="sm">Small</os-segment>
+				<os-segment value="md">Medium</os-segment>
+				<os-segment value="lg">Large</os-segment>
+			</os-segmented>
+		`,
 	} as const;
 
 	protected render() {

--- a/src/ui/components/os-segmented/os-segmented.ts
+++ b/src/ui/components/os-segmented/os-segmented.ts
@@ -22,7 +22,6 @@ export class OsSegment extends Component {
 		summary:
 			'Single pill inside a <os-segmented> group. Value identifies it for selection; aria-checked is mirrored by the parent.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'value',
@@ -85,7 +84,6 @@ export class OsSegmented extends Component {
 		summary:
 			'iOS-style segmented radio group. Pill-shaped bar of equal-width <os-segment> children where exactly one is active.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-segmented/os-segmented.ts
+++ b/src/ui/components/os-segmented/os-segmented.ts
@@ -45,7 +45,11 @@ export class OsSegment extends Component {
 	protected render() {
 		this.setAttribute( 'role', 'radio' );
 		return html`
-			<button type="button" @click=${ () => this._onPick() }>
+			<button
+				type="button"
+				class="os-holo-sheen"
+				@click=${ () => this._onPick() }
+			>
 				<slot></slot>
 			</button>
 		`;

--- a/src/ui/components/os-segmented/os-segmented.ts
+++ b/src/ui/components/os-segmented/os-segmented.ts
@@ -109,6 +109,9 @@ export class OsSegmented extends Component {
 		`,
 	} as const;
 
+	/** Re-measures the thumb when the group is resized by its container. */
+	private _resizeObserver: ResizeObserver | null = null;
+
 	connectedCallback(): void {
 		super.connectedCallback();
 		// Delegated pick handler — children bubble
@@ -121,6 +124,66 @@ export class OsSegmented extends Component {
 			( this as unknown as { value: string } ).value = detail.value;
 			this.emit( 'os-pick', { value: detail.value } );
 		} );
+		// The segments are content-sized, so the pill has to be
+		// re-measured whenever the group's box changes — a window
+		// resize, a panel column reflowing, a font finally arriving.
+		// Guarded because jsdom has no ResizeObserver.
+		if ( typeof ResizeObserver !== 'undefined' ) {
+			this._resizeObserver = new ResizeObserver( () => this._placeThumb() );
+			this._resizeObserver.observe( this );
+		}
+	}
+
+	disconnectedCallback(): void {
+		this._resizeObserver?.disconnect();
+		this._resizeObserver = null;
+	}
+
+	/**
+	 * Put the thumb under the selected segment.
+	 *
+	 * Measured with `getBoundingClientRect()` rather than `offsetLeft`:
+	 * the segments are light-DOM children whose `offsetParent` is this
+	 * host, and `offsetLeft` is quoted from the offset parent's BORDER
+	 * box while an absolutely-positioned element in the shadow root is
+	 * placed against its PADDING box. With a border on the group those
+	 * two differ, and the pill would sit a border-width off — visible
+	 * on exactly the themes that add one.
+	 *
+	 * A zero-width measurement means the group has not been laid out
+	 * yet (display:none, a collapsed panel, a tab that has never been
+	 * opened). Leaving the thumb hidden is right in every one of those
+	 * cases; the ResizeObserver brings it back the moment there is a
+	 * box to measure.
+	 */
+	private _placeThumb(): void {
+		const thumb = this.shadowRoot?.querySelector(
+			'.os-segmented__thumb',
+		) as HTMLElement | null;
+		if ( ! thumb ) {
+			return;
+		}
+		const current = ( this as unknown as { value: string | null } ).value;
+		const selected = Array.from(
+			this.querySelectorAll( ':scope > os-segment' ),
+		).find( ( el ) => el.getAttribute( 'value' ) === current );
+		const box = selected?.getBoundingClientRect();
+		if ( ! box || box.width === 0 ) {
+			this.removeAttribute( 'data-thumb' );
+			return;
+		}
+		const host = this.getBoundingClientRect();
+		this.style.setProperty( '--_thumb-x', `${ box.left - host.left }px` );
+		this.style.setProperty( '--_thumb-w', `${ box.width }px` );
+		this.setAttribute( 'data-thumb', '' );
+		// One frame later than the first placement, so the pill does
+		// not animate in from the origin on page load. See the note on
+		// the two flags in the stylesheet.
+		if ( ! this.hasAttribute( 'data-thumb-ready' ) ) {
+			requestAnimationFrame( () =>
+				this.setAttribute( 'data-thumb-ready', '' ),
+			);
+		}
 	}
 
 	/**
@@ -185,8 +248,12 @@ export class OsSegmented extends Component {
 					v === current ? 'true' : 'false',
 				);
 			}
+			this._placeThumb();
 		} );
-		return html`<slot></slot>`;
+		// The thumb before the slot, so it paints under the labels
+		// without either side needing a z-index.
+		return html`<span class="os-segmented__thumb" aria-hidden="true"></span
+			><slot></slot>`;
 	}
 }
 defineComponent( 'os-segmented', OsSegmented );

--- a/src/ui/components/os-select/os-select.styles.ts
+++ b/src/ui/components/os-select/os-select.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '../../core';
+import { holoTokens, holoField } from '../../holo';
 
 /**
  * Styles for the dropdown picker. Two stylesheets in one file —
@@ -15,6 +16,9 @@ import { css } from '../../core';
  */
 
 export const selectStyles = css`
+	${ holoTokens }
+	${ holoField }
+
 	/*
 	 * Host is block-level flex so the component fills its parent
 	 * cell (grid row col=N, flex container, plain block container).
@@ -63,18 +67,15 @@ export const selectStyles = css`
 		font-size: 13px;
 		color: var( --os-ui-fg, #1d2327 );
 		cursor: pointer;
-		transition: background-color 0.12s ease, border-color 0.12s ease,
-			box-shadow 0.12s ease;
 	}
 
-	select:hover {
+	/*
+	 * The background half of the hover. holoField owns the border half
+	 * for every field in the kit; a select is the one that also lifts
+	 * its fill, because it has no visible border at rest to move.
+	 */
+	select:hover:not( :disabled ) {
 		background: var( --os-ui-hover, rgba( 0, 0, 0, 0.08 ) );
-	}
-
-	select:focus-visible {
-		outline: none;
-		border-color: var( --wp-admin-theme-color, #2271b1 );
-		box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 );
 	}
 
 	select:disabled {
@@ -99,9 +100,15 @@ export const selectStyles = css`
 
 	/* Slight chevron tint on hover + focus — matches the select's
 	 * own border transition so the two feel like one affordance. */
-	select:hover ~ .os-select__chevron,
-	select:focus-visible ~ .os-select__chevron {
+	select:hover ~ .os-select__chevron {
 		color: var( --os-ui-fg, #1d2327 );
+	}
+
+	/* On focus it goes all the way to the accent, so the caret agrees
+	   with the ring instead of staying grey inside a lit field. */
+	select:focus ~ .os-select__chevron,
+	select:focus-visible ~ .os-select__chevron {
+		color: var( --os-ui-accent, #2271b1 );
 	}
 `;
 

--- a/src/ui/components/os-select/os-select.ts
+++ b/src/ui/components/os-select/os-select.ts
@@ -45,7 +45,6 @@ export class OsOption extends Component {
 		summary:
 			'Opaque data carrier for <os-select>. Carries its identifier in `value` and its visible label in textContent. Not rendered directly — the parent reads these and builds a native <select>.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'value',
@@ -102,7 +101,6 @@ export class OsSelect extends Component {
 		summary:
 			'Dropdown picker that wraps a native <select>. Mirrors the <os-segmented> contract (set value, listen for os-pick) so callers can swap tag names when a list outgrows a pill bar.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-select/os-select.ts
+++ b/src/ui/components/os-select/os-select.ts
@@ -61,6 +61,21 @@ export class OsOption extends Component {
 		slots: [
 			{ name: '(default)', description: 'Label text read from textContent.' },
 		],
+		/*
+		 * This component paints nothing — `:host { display: none }`,
+		 * by design. So the example shows the only thing there is to
+		 * see: what the parent builds out of it. A blank Example
+		 * section here would look like a bug rather than like the
+		 * deliberate choice it is.
+		 */
+		example: html`
+			<os-select value="md" label="Dock size (built from os-option children)">
+				<os-option value="sm">Small</os-option>
+				<os-option value="md">Medium</os-option>
+				<os-option value="lg">Large</os-option>
+				<os-option value="xl" disabled>Extra large (disabled)</os-option>
+			</os-select>
+		`,
 	} as const;
 
 	protected render() {

--- a/src/ui/components/os-spinner/os-spinner.ts
+++ b/src/ui/components/os-spinner/os-spinner.ts
@@ -224,8 +224,7 @@ export class OsSpinner extends Component {
 		title: 'Spinner',
 		summary:
 			'Animated WordPress-mark loading indicator with five curated presets and full per-attribute overrides. The `inline` preset swaps the mark for a bare arc sized for text-adjacent use. CSS variables drive disc + accent colors and size; reduced-motion preferences are respected.',
-		status: 'experimental',
-		since: '0.6.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'preset',

--- a/src/ui/components/os-stack/os-stack.ts
+++ b/src/ui/components/os-stack/os-stack.ts
@@ -38,7 +38,6 @@ export class OsStack extends Component {
 		summary:
 			'Vertical flex layout with a gap — the "stack" primitive every design system eventually invents. Use it instead of hand-rolling display:flex; flex-direction:column.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'gap',

--- a/src/ui/components/os-steps/os-steps.styles.ts
+++ b/src/ui/components/os-steps/os-steps.styles.ts
@@ -48,10 +48,19 @@ export const stepStyles = css`
 		width: var( --os-ui-step-chip-size, 28px );
 		height: var( --os-ui-step-chip-size, 28px );
 		border-radius: 50%;
+		/*
+		 * The step number sits on a bright fill, which is exactly the
+		 * shape an identity moment takes: small, round, one per row.
+		 * The mesh arrives through --os-ui-step-chip-bg from the
+		 * palette rather than from here, so this literal stays the
+		 * pre-brand blue Legacy collected.
+		 */
 		background: var(
 			--os-ui-step-chip-bg,
 			var( --wp-admin-theme-color, #2271b1 )
 		);
+		background-size: 200% 200%;
+		background-position: 30% 40%;
 		color: var( --os-ui-step-chip-fg, var( --os-ui-fg-on-accent, #fff ) );
 		font-size: var( --os-ui-step-chip-font-size, 13px );
 		font-weight: 600;

--- a/src/ui/components/os-steps/os-steps.ts
+++ b/src/ui/components/os-steps/os-steps.ts
@@ -34,8 +34,7 @@ export class OsSteps extends Component {
 		title: 'Steps',
 		summary:
 			'Ordered/numbered-steps container. Children are <os-step> elements; numbers are assigned via a CSS counter so insertions renumber automatically. Use for onboarding, setup flows, migration guides.',
-		status: 'experimental',
-		since: '0.5.1',
+		status: 'stable',
 		slots: [
 			{
 				name: '(default)',
@@ -72,8 +71,7 @@ export class OsStep extends Component {
 		title: 'Step',
 		summary:
 			'A single numbered step inside <os-steps>. Renders an auto-numbered chip and an optional bold title above the slotted body.',
-		status: 'experimental',
-		since: '0.5.1',
+		status: 'stable',
 		props: [
 			{
 				name: 'title',

--- a/src/ui/components/os-swatch-grid/os-swatch-grid.ts
+++ b/src/ui/components/os-swatch-grid/os-swatch-grid.ts
@@ -16,7 +16,6 @@ export class OsSwatchGrid extends Component {
 		summary:
 			'Flex grid container for <os-swatch> children. Emits radiogroup semantics so screen readers announce the tiles as a unit.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'label',

--- a/src/ui/components/os-swatch/os-swatch.styles.ts
+++ b/src/ui/components/os-swatch/os-swatch.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 /**
  * Two size variants:
@@ -16,6 +17,8 @@ import { css } from '../../core';
  * the outer shape changes.
  */
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: block;
 		width: 100%;
@@ -71,9 +74,38 @@ export const styles = css`
 	button:hover {
 		transform: scale( 1.04 );
 	}
+	button:focus-visible {
+		outline: none;
+		box-shadow: var( --_holo-focus );
+	}
+	/*
+	 * Chosen. The ring is the mesh rather than a flat accent, drawn
+	 * on a ::before frame because box-shadow and border-color both
+	 * take colours and this one is a gradient.
+	 *
+	 * inset: -4px puts the ring OUTSIDE the tile, which matters for
+	 * a wallpaper swatch: the artwork is the content, and a ring
+	 * drawn on top of it would crop the thing the user is choosing.
+	 */
 	button[ aria-pressed='true' ] {
-		border-color: var( --wp-admin-theme-color, #2271b1 );
-		box-shadow: 0 0 0 2px var( --wp-admin-theme-color, #2271b1 );
+		border-color: transparent;
+	}
+	button[ aria-pressed='true' ]::before {
+		content: '';
+		position: absolute;
+		inset: -4px;
+		border-radius: inherit;
+		padding: 2px;
+		background-image: var( --_holo-edge );
+		pointer-events: none;
+		-webkit-mask: linear-gradient( #000 0 0 ) content-box,
+			linear-gradient( #000 0 0 );
+		-webkit-mask-composite: xor;
+		mask: linear-gradient( #000 0 0 ) content-box, linear-gradient( #000 0 0 );
+		mask-composite: exclude;
+	}
+	:host( [ size='small' ] ) button[ aria-pressed='true' ]::before {
+		border-radius: 50%;
 	}
 	/*
 	 * Wallpaper variant uses a softer lift to pair with the

--- a/src/ui/components/os-swatch/os-swatch.ts
+++ b/src/ui/components/os-swatch/os-swatch.ts
@@ -19,7 +19,6 @@ export class OsSwatch extends Component {
 		summary:
 			'Selectable color/wallpaper tile. Renders as an aria-pressed button with a background driven by the preview attribute.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'value',

--- a/src/ui/components/os-switch/os-switch.styles.ts
+++ b/src/ui/components/os-switch/os-switch.styles.ts
@@ -1,0 +1,288 @@
+import { css } from '../../core';
+import { holoTokens, holoFill, holoEdge } from '../../holo';
+
+/**
+ * `<os-switch>` — shadow-DOM styles.
+ *
+ * ## The geometry
+ *
+ * Everything derives from one number, `--_h` (the track height). The
+ * track is `2 × --_h` wide, the knob is `--_h − 2 × --_pad`, and the
+ * "on" travel is the difference between the two. Change `--_h` in a
+ * size modifier and the whole control rescales with no other rule
+ * touched — which is what makes `size="sm|md|lg"` three declarations
+ * instead of three stylesheets.
+ *
+ * ## The knob is not `left`-animated
+ *
+ * It is `translate`d. `left` is a layout property: animating it makes
+ * the browser re-lay-out the track sixty times a second, and on a
+ * settings panel with a dozen switches that is measurable. `translate`
+ * is compositor-only. It is also what makes the drag gesture cheap —
+ * see `_onPointerMove` in the component, which writes a single
+ * `--_drag` custom property while the finger is down and lets this
+ * rule do the arithmetic.
+ *
+ * ## The stretch
+ *
+ * `:active` widens the knob toward the direction of travel, the way
+ * the iOS switch does. It costs one `width` transition on a 20 px box
+ * and it is most of why the control feels physical rather than
+ * drawn — the knob reads as something being pushed rather than
+ * something being redrawn somewhere else.
+ */
+export const styles = css`
+	${ holoTokens }
+	${ holoFill }
+	${ holoEdge }
+
+	:host {
+		/* Track height. Every other measurement derives from it. */
+		--_h: 22px;
+		/* Gap between knob and track edge, all round. */
+		--_pad: 2px;
+		/* Knob diameter and the distance it travels, both derived. */
+		--_knob: calc( var( --_h ) - 2 * var( --_pad ) );
+		--_travel: calc( var( --_w ) - var( --_knob ) - 2 * var( --_pad ) );
+		--_w: calc( var( --_h ) * 1.85 );
+		/*
+		 * Live drag offset in px, written by the component while a
+		 * pointer is down and cleared on release. 0 the rest of the
+		 * time, which is why the resting rule below can add it
+		 * unconditionally.
+		 */
+		--_drag: 0px;
+		/* Travel sign: 1 in LTR, -1 in RTL. Written by the component. */
+		--_dir: 1;
+
+		display: inline-flex;
+		align-items: center;
+		gap: 10px;
+		font-size: 13px;
+		line-height: 1.3;
+		color: var( --os-ui-fg, #1d2327 );
+		cursor: pointer;
+		/*
+		 * A switch is a target, not a text run. Selecting the label on
+		 * a double-click — which is what a fast double-toggle looks
+		 * like to the browser — leaves the row highlighted blue and is
+		 * never what anyone meant.
+		 */
+		-webkit-user-select: none;
+		user-select: none;
+	}
+
+	:host( [ size='sm' ] ) {
+		--_h: 16px;
+		--_pad: 2px;
+		font-size: 12px;
+		gap: 8px;
+	}
+
+	:host( [ size='lg' ] ) {
+		--_h: 30px;
+		--_pad: 3px;
+		font-size: 14px;
+		gap: 12px;
+	}
+
+	/* Full-width settings row: label left, switch hard right. */
+	:host( [ block ] ) {
+		display: flex;
+		width: 100%;
+		justify-content: space-between;
+	}
+
+	:host( [ label-position='start' ] ) .os-switch__row {
+		flex-direction: row-reverse;
+	}
+
+	:host( [ disabled ] ) {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.os-switch__row {
+		display: inline-flex;
+		align-items: center;
+		gap: inherit;
+		flex: 1 1 auto;
+		justify-content: inherit;
+	}
+
+	/*
+	 * The control. A real button element, so Space and Enter, the
+	 * disabled semantics and the focus ring all come from the
+	 * platform; role="switch" plus aria-checked are set in the
+	 * template, which is the pairing screen readers announce as
+	 * "on/off" rather than as "pressed".
+	 */
+	button {
+		appearance: none;
+		flex: 0 0 auto;
+		position: relative;
+		box-sizing: content-box;
+		width: var( --_w );
+		height: var( --_h );
+		padding: 0;
+		margin: 0;
+		border: 1px solid var( --os-ui-border, #c3c4c7 );
+		border-radius: 999px;
+		background-color: var( --_holo-track );
+		background-image: none;
+		cursor: inherit;
+		outline: none;
+		transition: background-color var( --_holo-t ) ease,
+			border-color var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+	}
+
+	button:focus-visible {
+		box-shadow: var( --_holo-focus );
+	}
+
+	/*
+	 * ON. The identity moment, and the reason this component exists in
+	 * a holographic kit: the track becomes the mesh.
+	 *
+	 * The .os-holo-fill class (from src/ui/holo.ts) brings the mesh, the
+	 * oversized background so it has room to slide, and the tilt on
+	 * hover. The border goes transparent because a 1 px Astro line
+	 * around a bright mesh reads as a seam, and the glow replaces it
+	 * as the thing that separates the track from the surface.
+	 */
+	:host( [ checked ] ) button {
+		border-color: transparent;
+		box-shadow: var( --_holo-glow );
+	}
+
+	:host( [ checked ] ) button:focus-visible {
+		box-shadow: var( --_holo-focus );
+	}
+
+	/*
+	 * Flat tones, for a switch that should not spend an identity
+	 * moment — a row of twelve in a settings list, a destructive
+	 * toggle that wants to read as danger rather than as brand. The
+	 * fill class is still on the element; background-image: none
+	 * takes the mesh back off and lets the colour through.
+	 */
+	:host( [ tone='accent' ][ checked ] ) button,
+	:host( [ tone='danger' ][ checked ] ) button,
+	:host( [ tone='success' ][ checked ] ) button {
+		background-image: none;
+	}
+
+	:host( [ tone='accent' ][ checked ] ) button {
+		background-color: var( --os-ui-accent, #2271b1 );
+	}
+
+	:host( [ tone='danger' ][ checked ] ) button {
+		background-color: var( --os-ui-danger, #d63638 );
+		box-shadow: 0 0 0 1px rgba( 255, 90, 90, 0.3 ),
+			0 2px 10px rgba( 255, 90, 90, 0.25 );
+	}
+
+	:host( [ tone='success' ][ checked ] ) button {
+		background-color: var( --os-ui-success-fg, #00a32a );
+		box-shadow: 0 0 0 1px rgba( 147, 240, 198, 0.3 ),
+			0 2px 10px rgba( 147, 240, 198, 0.25 );
+	}
+
+	/* The knob. */
+	.os-switch__knob {
+		position: absolute;
+		top: var( --_pad );
+		inset-inline-start: var( --_pad );
+		width: var( --_knob );
+		height: var( --_knob );
+		border-radius: 999px;
+		background: var( --os-ui-switch-knob, #fffbff );
+		box-shadow: 0 1px 2px rgba( 12, 11, 15, 0.45 ),
+			0 0 0 0.5px rgba( 12, 11, 15, 0.12 );
+		pointer-events: none;
+		transition: transform var( --_holo-t ) cubic-bezier( 0.32, 1.5, 0.55, 1 ),
+			width var( --_holo-t ) ease;
+	}
+
+	/*
+	 * Resting position. --_drag is 0 unless a finger is down, so one
+	 * rule covers both the settled state and the live gesture — the
+	 * component never has to swap classes mid-drag.
+	 *
+	 * RTL travels the other way, and --_dir is how: the component
+	 * writes 1 or -1 onto the host from the computed direction, and
+	 * every offset below is multiplied by it. :host-context() would
+	 * have been the CSS-only way and is not shipped by Firefox; :dir()
+	 * is too new to rely on. The knob's resting side is placed with
+	 * inset-inline-start, which needs no help.
+	 */
+	.os-switch__knob {
+		transform: translateX( calc( var( --_dir ) * var( --_drag ) ) );
+	}
+
+	:host( [ checked ] ) .os-switch__knob {
+		transform: translateX(
+			calc( var( --_dir ) * ( var( --_travel ) + var( --_drag ) ) )
+		);
+	}
+
+	/* The squash. Widens toward travel while the control is pressed. */
+	:host( :not( [ disabled ] ) ) button:active .os-switch__knob {
+		width: calc( var( --_knob ) * 1.28 );
+	}
+
+	:host( [ checked ]:not( [ disabled ] ) ) button:active .os-switch__knob {
+		width: calc( var( --_knob ) * 1.28 );
+		transform: translateX(
+			calc(
+				var( --_dir ) *
+					( var( --_travel ) - var( --_knob ) * 0.28 + var( --_drag ) )
+			)
+		);
+	}
+
+	/*
+	 * While dragging, the knob follows the finger with no easing —
+	 * a transition here would make it lag behind the pointer, which
+	 * reads as a broken control rather than a smooth one. The easing
+	 * comes back on release, which is what produces the snap.
+	 */
+	:host( [ data-dragging ] ) .os-switch__knob {
+		transition: width var( --_holo-t ) ease;
+	}
+
+	.os-switch__label {
+		line-height: 1.3;
+	}
+
+	.os-switch__label:empty {
+		display: none;
+	}
+
+	/*
+	 * Optional secondary line. A settings switch almost always wants
+	 * one ("Off means the dock hides on scroll"), and without a slot
+	 * for it every caller reinvents the two-line row.
+	 */
+	.os-switch__text {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.os-switch__description {
+		font-size: 0.92em;
+		color: var( --os-ui-fg-muted, #646970 );
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-switch__knob {
+			transition-duration: 1ms;
+		}
+	}
+`;

--- a/src/ui/components/os-switch/os-switch.styles.ts
+++ b/src/ui/components/os-switch/os-switch.styles.ts
@@ -117,31 +117,50 @@ export const styles = css`
 	 * template, which is the pairing screen readers announce as
 	 * "on/off" rather than as "pressed".
 	 */
+	/*
+	 * The track.
+	 *
+	 * NO BORDER, and that is a fix rather than a style. With a 1px
+	 * border and the default border-box background clip, the fill
+	 * paints UNDER the border: the off state showed a grey ring over
+	 * the fill's outer edge, and the on state (border-color:
+	 * transparent) let the mesh through it. The pill's visible outline
+	 * therefore moved outward by a pixel on each side as it turned on,
+	 * and the control looked like it changed size when it changed
+	 * state.
+	 *
+	 * The off-state edge is an INSET shadow instead. It occupies no
+	 * layout, so the box is byte-identical in both states, and it can
+	 * be swapped for the glow when lit without anything moving.
+	 */
 	button {
 		appearance: none;
 		flex: 0 0 auto;
 		position: relative;
-		box-sizing: content-box;
+		box-sizing: border-box;
 		width: var( --_w );
 		height: var( --_h );
 		padding: 0;
 		margin: 0;
-		border: 1px solid var( --os-ui-border, #c3c4c7 );
+		border: 0;
 		border-radius: 999px;
 		background-color: var( --_holo-track );
 		background-image: none;
+		/*
+		 * The boundary WCAG 1.4.11 asks for. The fill alone is a
+		 * ~1.6:1 wash — enough to shape the control, not enough to
+		 * prove it is there; --_holo-track-edge is Pewter, the first
+		 * step on the Shade ramp that reaches 3:1 on Obsidian.
+		 */
+		box-shadow: inset 0 0 0 1px var( --_holo-track-edge );
 		cursor: inherit;
 		outline: none;
 		transition: background-color var( --_holo-t ) ease,
-			border-color var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease;
+			box-shadow var( --_holo-t ) ease;
 	}
 
 	button:disabled {
 		cursor: not-allowed;
-	}
-
-	button:focus-visible {
-		box-shadow: var( --_holo-focus );
 	}
 
 	/*
@@ -150,13 +169,24 @@ export const styles = css`
 	 *
 	 * The .os-holo-fill class (from src/ui/holo.ts) brings the mesh, the
 	 * oversized background so it has room to slide, and the tilt on
-	 * hover. The border goes transparent because a 1 px Astro line
-	 * around a bright mesh reads as a seam, and the glow replaces it
-	 * as the thing that separates the track from the surface.
+	 * hover. The inset edge is dropped — a grey line around a bright
+	 * mesh reads as a seam — and the glow takes over as the thing
+	 * separating the track from the surface. Both are box-shadows, so
+	 * the swap moves nothing.
 	 */
 	:host( [ checked ] ) button {
-		border-color: transparent;
 		box-shadow: var( --_holo-glow );
+	}
+
+	/*
+	 * Focused and OFF keeps the inset edge alongside the focus ring:
+	 * the ring says where the keyboard is, the edge still says where
+	 * the control is, and losing the second while gaining the first is
+	 * a trade nothing asked for.
+	 */
+	button:focus-visible {
+		box-shadow: var( --_holo-focus ),
+			inset 0 0 0 1px var( --_holo-track-edge );
 	}
 
 	:host( [ checked ] ) button:focus-visible {
@@ -192,7 +222,22 @@ export const styles = css`
 			0 2px 10px rgba( 147, 240, 198, 0.25 );
 	}
 
-	/* The knob. */
+	/*
+	 * The knob.
+	 *
+	 * Starlight, and the hairline around it is what makes that
+	 * survivable. Against the lit track it has almost nothing to
+	 * contrast with — Holomesh's white glow is #fffdff, so a Starlight
+	 * knob sitting on that part of the mesh measures **1.01:1** and is
+	 * simply gone. The old ring, Void at 12%, was nowhere near enough
+	 * to rescue it.
+	 *
+	 * At 55% the ring composites to ~#7d7c7f over that glow, which
+	 * carries the knob at 3.5:1 there and 6.9:1 over the mesh's
+	 * darkest stop — so the knob has an outline everywhere the mesh
+	 * can go, and the same ring is what separates it from the unlit
+	 * track too. One declaration, both states.
+	 */
 	.os-switch__knob {
 		position: absolute;
 		top: var( --_pad );
@@ -202,9 +247,9 @@ export const styles = css`
 		border-radius: 999px;
 		background: var( --os-ui-switch-knob, #fffbff );
 		box-shadow: 0 1px 2px rgba( 12, 11, 15, 0.45 ),
-			0 0 0 0.5px rgba( 12, 11, 15, 0.12 );
+			0 0 0 1px var( --os-ui-switch-knob-edge, rgba( 12, 11, 15, 0.55 ) );
 		pointer-events: none;
-		transition: transform var( --_holo-t ) cubic-bezier( 0.32, 1.5, 0.55, 1 ),
+		transition: transform var( --_holo-t ) var( --_holo-spring ),
 			width var( --_holo-t ) ease;
 	}
 

--- a/src/ui/components/os-switch/os-switch.test.ts
+++ b/src/ui/components/os-switch/os-switch.test.ts
@@ -286,6 +286,48 @@ describe( '<os-switch>', () => {
 		);
 	} );
 
+	test( 'the track has no border, so the pill cannot change size with state', () => {
+		// The bug this replaced: a 1px border plus the default
+		// border-box background clip meant the off state drew a grey
+		// ring OVER the fill's outer edge while the on state
+		// (border-color: transparent) let the mesh through it. The
+		// visible pill grew a pixel on each side as it turned on, and
+		// the switch looked like it resized when it changed state.
+		//
+		// The off edge is an inset shadow instead: no layout, so both
+		// states occupy exactly the same box.
+		expect( styles.cssText ).toMatch( /button\s*{[^}]*border:\s*0;/ );
+		expect( styles.cssText ).toMatch(
+			/button\s*{[^}]*box-shadow:\s*inset 0 0 0 1px var\( --_holo-track-edge \)/,
+		);
+		expect( styles.cssText ).not.toContain( 'border-color: transparent' );
+	} );
+
+	test( 'both states carry a boundary, and neither is a bare fill', () => {
+		// WCAG 1.4.11 wants 3:1 on the boundary of a control. Off gets
+		// the Pewter inset edge; on swaps it for the glow, which is a
+		// box-shadow too — so the swap moves nothing.
+		expect( styles.cssText ).toMatch(
+			/:host\(\s*\[\s*checked\s*\]\s*\)\s*button\s*{[^}]*box-shadow:\s*var\(\s*--_holo-glow\s*\)/,
+		);
+		// Focused-and-off keeps BOTH: the ring says where the keyboard
+		// is, the edge still says where the control is.
+		expect( styles.cssText ).toMatch(
+			/button:focus-visible\s*{[^}]*var\( --_holo-focus \),\s*inset 0 0 0 1px var\( --_holo-track-edge \)/,
+		);
+	} );
+
+	test( 'the knob has a hairline strong enough to survive the lit mesh', () => {
+		// Starlight on Holomesh's white glow (#fffdff) is 1.01:1 — the
+		// knob is not dim there, it is absent. The ring is what carries
+		// it: Void at 55% composites to ~#7d7c7f over that glow, which
+		// holds the knob at 3.5:1. The previous 0.12 alpha did nothing.
+		expect( styles.cssText ).toMatch(
+			/0 0 0 1px var\( --os-ui-switch-knob-edge, rgba\( 12, 11, 15, 0\.55 \) \)/,
+		);
+		expect( styles.cssText ).not.toContain( '0 0 0 0.5px' );
+	} );
+
 	test( 'the palette reaches the component — no themed token is pinned on :host', () => {
 		// The kit-wide rule, asserted here too because this component
 		// declares an unusually large private block and the temptation to

--- a/src/ui/components/os-switch/os-switch.test.ts
+++ b/src/ui/components/os-switch/os-switch.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import './os-switch';
+import { styles } from './os-switch.styles';
+
+const tick = (): Promise< void > => Promise.resolve();
+
+/**
+ * jsdom implements neither pointer capture nor `PointerEvent`, so the
+ * gesture tests below drive the handlers with `MouseEvent`s carrying the
+ * two fields the component reads (`pointerId`, `clientX`) and stub the
+ * capture call. That is enough to exercise every branch of the drag
+ * logic — the arithmetic is the part worth pinning, and it is pure.
+ */
+function pointer( type: string, clientX: number, pointerId = 1 ): Event {
+	const e = new MouseEvent( type, { bubbles: true, clientX } );
+	Object.defineProperty( e, 'pointerId', { value: pointerId } );
+	return e;
+}
+
+/**
+ * Give the track real geometry. jsdom lays everything out at zero, and
+ * a drag over zero travel is correctly ignored — a control with no
+ * width cannot be dragged.
+ *
+ * Only the track is measured: travel is `clientWidth - clientHeight`,
+ * which is the stylesheet's own `w - knob - 2·pad` with the pads
+ * cancelled out. Deliberately independent of the knob, which widens to
+ * 1.28× under `:active` — see the note in `_onPointerDown`.
+ */
+function layOut( track: HTMLElement, travel: number ): void {
+	Object.defineProperty( track, 'clientWidth', {
+		value: travel + 20,
+		configurable: true,
+	} );
+	Object.defineProperty( track, 'clientHeight', {
+		value: 20,
+		configurable: true,
+	} );
+}
+
+describe( '<os-switch>', () => {
+	let host: HTMLElement;
+
+	beforeEach( () => {
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+	} );
+	afterEach( () => host.remove() );
+
+	async function mount( markup: string ) {
+		host.innerHTML = markup;
+		await tick();
+		const el = host.querySelector( 'os-switch' ) as HTMLElement;
+		const button = el.shadowRoot!.querySelector( 'button' ) as HTMLButtonElement;
+		button.setPointerCapture = () => undefined;
+		return { el, button };
+	}
+
+	test( 'renders a role="switch" button reflecting aria-checked', async () => {
+		const { el, button } = await mount( `<os-switch label="Reduce motion"></os-switch>` );
+
+		expect( button.getAttribute( 'role' ) ).toBe( 'switch' );
+		expect( button.getAttribute( 'aria-checked' ) ).toBe( 'false' );
+
+		el.setAttribute( 'checked', '' );
+		await tick();
+		expect( button.getAttribute( 'aria-checked' ) ).toBe( 'true' );
+	} );
+
+	test( 'a click toggles and emits both event names with the same detail', async () => {
+		const { el, button } = await mount(
+			`<os-switch label="Dock" value="dock"></os-switch>`,
+		);
+
+		const heard: Record< string, unknown > = {};
+		el.addEventListener( 'os-switch-change', ( e ) => {
+			heard.own = ( e as CustomEvent ).detail;
+		} );
+		el.addEventListener( 'os-checkbox-change', ( e ) => {
+			heard.alias = ( e as CustomEvent ).detail;
+		} );
+
+		button.click();
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+		expect( heard.own ).toEqual( { checked: true, value: 'dock' } );
+		// The compatibility alias is what lets a switch drop into a
+		// listener already bound to <os-checkbox>. Same detail, same tick.
+		expect( heard.alias ).toEqual( heard.own );
+	} );
+
+	test( 'clicking an on switch turns it off', async () => {
+		const { el, button } = await mount( `<os-switch checked></os-switch>` );
+
+		button.click();
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+	} );
+
+	test( 'a disabled switch does not toggle', async () => {
+		const { el, button } = await mount( `<os-switch disabled></os-switch>` );
+
+		button.click();
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+		expect( button.disabled ).toBe( true );
+	} );
+
+	test( 'ArrowRight/End force on, ArrowLeft/Home force off', async () => {
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+
+		button.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'ArrowRight', bubbles: true } ) );
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+
+		// Idempotent: pressing it again on an already-on switch is not a
+		// toggle, which is the whole point of an absolute key.
+		let changes = 0;
+		el.addEventListener( 'os-switch-change', () => changes++ );
+		button.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'End', bubbles: true } ) );
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+		expect( changes ).toBe( 0 );
+
+		button.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'ArrowLeft', bubbles: true } ) );
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+
+		button.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Home', bubbles: true } ) );
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+	} );
+
+	test( 'dragging past the midpoint turns the switch on', async () => {
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		button.dispatchEvent( pointer( 'pointermove', 16 ) );
+		expect( el.getAttribute( 'data-dragging' ) ).toBe( '' );
+		expect( el.style.getPropertyValue( '--_drag' ) ).toBe( '16px' );
+
+		button.dispatchEvent( pointer( 'pointerup', 16 ) );
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+		// The live offset is handed back to CSS on release — the settled
+		// position comes from `--_travel`, not from the leftover drag.
+		expect( el.style.getPropertyValue( '--_drag' ) ).toBe( '' );
+		expect( el.hasAttribute( 'data-dragging' ) ).toBe( false );
+	} );
+
+	test( 'travel is read from the track alone, not from the knob', async () => {
+		// The knob widens to 1.28x under :active, and whether :active
+		// has landed by the time pointerdown is dispatched is not
+		// something the spec pins down. Measuring the knob would
+		// therefore shorten the travel by a quarter on some presses and
+		// not others, and the switch would flip early — intermittently.
+		//
+		// Travel is clientWidth - clientHeight, which is the
+		// stylesheet's w - knob - 2*pad with the pads cancelled. A knob
+		// laid out at any width at all must not move the midpoint.
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+		layOut( button, 20 );
+		const knob = el.shadowRoot!.querySelector(
+			'.os-switch__knob',
+		) as HTMLElement;
+		Object.defineProperty( knob, 'offsetWidth', {
+			value: 999,
+			configurable: true,
+		} );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		// 11 of a 20px travel: past the midpoint, and only past it if
+		// the midpoint is still 10.
+		button.dispatchEvent( pointer( 'pointermove', 11 ) );
+		button.dispatchEvent( pointer( 'pointerup', 11 ) );
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+	} );
+
+	test( 'a drag released short of the midpoint snaps back', async () => {
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		button.dispatchEvent( pointer( 'pointermove', 8 ) );
+		button.dispatchEvent( pointer( 'pointerup', 8 ) );
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+	} );
+
+	test( 'the click that follows a drag does not toggle a second time', async () => {
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		button.dispatchEvent( pointer( 'pointermove', 18 ) );
+		button.dispatchEvent( pointer( 'pointerup', 18 ) );
+		// The browser fires this immediately after `pointerup`. Without
+		// the swallow flag it would flip the switch straight back off.
+		button.click();
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+	} );
+
+	test( 'movement under the tap threshold is still a tap', async () => {
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		button.dispatchEvent( pointer( 'pointermove', 2 ) );
+		expect( el.hasAttribute( 'data-dragging' ) ).toBe( false );
+		button.dispatchEvent( pointer( 'pointerup', 2 ) );
+		// `pointerup` deferred to the click, which the browser fires next.
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+		button.click();
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( true );
+	} );
+
+	test( 'an on switch can be dragged back off, and cannot be dragged further on', async () => {
+		const { el, button } = await mount( `<os-switch checked></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		// Pushing further to the right is a no-op: the knob is already at
+		// the end of the track, so the clamp holds it at 0.
+		button.dispatchEvent( pointer( 'pointermove', 30 ) );
+		expect( el.style.getPropertyValue( '--_drag' ) ).toBe( '0px' );
+
+		button.dispatchEvent( pointer( 'pointermove', -16 ) );
+		expect( el.style.getPropertyValue( '--_drag' ) ).toBe( '-16px' );
+		button.dispatchEvent( pointer( 'pointerup', -16 ) );
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+	} );
+
+	test( 'pointercancel abandons the gesture without toggling', async () => {
+		const { el, button } = await mount( `<os-switch></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		button.dispatchEvent( pointer( 'pointermove', 18 ) );
+		button.dispatchEvent( pointer( 'pointercancel', 18 ) );
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+		expect( el.style.getPropertyValue( '--_drag' ) ).toBe( '' );
+	} );
+
+	test( 'a disabled switch ignores the drag gesture entirely', async () => {
+		const { el, button } = await mount( `<os-switch disabled></os-switch>` );
+		layOut( button, 20 );
+
+		button.dispatchEvent( pointer( 'pointerdown', 0 ) );
+		button.dispatchEvent( pointer( 'pointermove', 18 ) );
+		button.dispatchEvent( pointer( 'pointerup', 18 ) );
+
+		expect( el.hasAttribute( 'checked' ) ).toBe( false );
+		expect( el.hasAttribute( 'data-dragging' ) ).toBe( false );
+	} );
+
+	test( 'the description renders and is wired to aria-describedby only when present', async () => {
+		const { button } = await mount( `<os-switch label="Dock"></os-switch>` );
+		// Dropped rather than emptied: an aria-describedby pointing at an
+		// empty node is a described element with nothing to say, and
+		// screen readers announce the pause.
+		expect( button.hasAttribute( 'aria-describedby' ) ).toBe( false );
+
+		const { el: el2, button: button2 } = await mount(
+			`<os-switch label="Dock" description="Slides away until you point at the edge."></os-switch>`,
+		);
+		expect( button2.getAttribute( 'aria-describedby' ) ).toBe( 'os-switch-desc' );
+		expect(
+			el2.shadowRoot!.querySelector( '#os-switch-desc' )!.textContent,
+		).toContain( 'Slides away' );
+	} );
+
+	test( 'the on state is the holographic fill, and a tone takes it back off', () => {
+		// The reason this component exists in a holographic kit: `on` is
+		// an identity moment and identity moments wear the mesh. A `tone`
+		// is the documented way out for a settings list that would rather
+		// not spend one per row — if that override stops landing, twelve
+		// switches all go iridescent at once.
+		expect( styles.cssText ).toContain( '.os-holo-fill' );
+		expect( styles.cssText ).toMatch(
+			/:host\(\s*\[\s*checked\s*\]\s*\)\s*button\s*{[^}]*box-shadow:\s*var\(\s*--_holo-glow\s*\)/,
+		);
+		expect( styles.cssText ).toMatch(
+			/tone='accent'\s*\]\[\s*checked\s*\][\s\S]*?background-image:\s*none/,
+		);
+	} );
+
+	test( 'the palette reaches the component — no themed token is pinned on :host', () => {
+		// The kit-wide rule, asserted here too because this component
+		// declares an unusually large private block and the temptation to
+		// put `--os-ui-holo-fill` in it is real. Guarded globally by
+		// tests/vitest/component-token-reachability.test.ts.
+		const hostBlock = styles.cssText.slice(
+			styles.cssText.indexOf( ':host {' ),
+			styles.cssText.indexOf( ':host( [ size=' ),
+		);
+		expect( hostBlock ).not.toMatch( /\n\t\t--os-ui-[a-z-]+:/ );
+	} );
+} );

--- a/src/ui/components/os-switch/os-switch.ts
+++ b/src/ui/components/os-switch/os-switch.ts
@@ -1,0 +1,378 @@
+/**
+ * `<os-switch>` — the on/off switch.
+ *
+ * A checkbox says "this item is included". A switch says "this
+ * setting is on", and it says it in the present tense: flipping it
+ * takes effect now, with no Save button waiting downstream. That
+ * distinction is the whole reason both exist, and it is the one to
+ * check before reaching for either. If the change lands on submit,
+ * use `<os-checkbox>`.
+ *
+ * ```html
+ * <os-switch checked label="Reduce motion"></os-switch>
+ * <os-switch block label="Auto-hide the dock"
+ *            description="The dock slides away until you point at the edge."></os-switch>
+ * <os-switch size="sm" tone="danger" label="Developer mode"></os-switch>
+ * ```
+ *
+ * ## The holographic state
+ *
+ * On is an identity moment, so on is the mesh: the track fills with
+ * Holomesh and picks up a Pulse glow, and the fill tilts under the
+ * pointer the way a foil card does. `tone="accent" | "danger" |
+ * "success"` takes the mesh back off for the cases where brand is the
+ * wrong thing to say — a dozen switches in one settings list, or a
+ * destructive toggle that should read as danger.
+ *
+ * ## Gestures
+ *
+ * Tap toggles. Drag also works, iOS-style: press the track, move, and
+ * the knob follows the pointer in real time; release past the halfway
+ * mark and it snaps on. A drag that ends where it started is treated
+ * as a tap, so a shaky finger never eats the interaction.
+ *
+ * Keyboard: Space and Enter toggle (from the native `<button>`),
+ * ArrowLeft/Home force off and ArrowRight/End force on — the explicit
+ * pair, so a keyboard user can set a known state without tracking the
+ * current one.
+ *
+ * ## Events
+ *
+ * Emits `os-switch-change` with `{ checked, value }`. It ALSO emits
+ * `os-checkbox-change` with the same detail, which makes the switch a
+ * drop-in for any listener already bound to `<os-checkbox>` /
+ * `<os-checkbox-label>` at a common ancestor — swapping a checkbox for
+ * a switch is then a tag change and nothing else. New code should
+ * listen for `os-switch-change`; the alias exists for the swap.
+ *
+ * Accessibility: `role="switch"` plus `aria-checked` on a real
+ * `<button>`. That pairing is announced as "on"/"off" rather than
+ * "pressed", `disabled` comes from the platform, and the focus ring is
+ * the kit's shared `--os-ui-focus-ring`.
+ */
+
+import { Component, defineComponent, html } from '../../core';
+import { styles } from './os-switch.styles';
+
+/**
+ * Pointer travel, in px, below which a drag is treated as a tap.
+ *
+ * Set from the smallest deliberate drag a finger makes rather than
+ * from a mouse: below this, the movement is almost always tremor
+ * during a click, and treating it as a drag means a tap on an "on"
+ * switch would sometimes leave it on.
+ */
+const TAP_SLOP = 4;
+
+export class OsSwitch extends Component {
+	static props = [
+		'checked',
+		'value',
+		'label',
+		'description',
+		'disabled',
+		'size',
+		'tone',
+		'block',
+		'labelPosition',
+	] as const;
+	static styles = [ styles ];
+
+	static help = {
+		title: 'Switch',
+		summary:
+			'On/off switch for settings that take effect immediately. On is the holographic moment — the track fills with Holomesh and glows. Supports tap, drag and keyboard, and emits os-checkbox-change alongside its own event so it drops straight into checkbox listeners.',
+		status: 'stable',
+		props: [
+			{
+				name: 'checked',
+				type: 'boolean attribute',
+				description: 'Reflects + controls the on state; updated on user toggle.',
+			},
+			{
+				name: 'value',
+				type: 'string',
+				description:
+					'Identifier returned in the event detail — useful when several switches share a listener.',
+			},
+			{
+				name: 'label',
+				type: 'string',
+				description: 'Text rendered beside the switch.',
+			},
+			{
+				name: 'description',
+				type: 'string',
+				description:
+					'Optional second line under the label, for the sentence that explains what off means.',
+			},
+			{
+				name: 'disabled',
+				type: 'boolean attribute',
+				description: 'Disables the control.',
+			},
+			{
+				name: 'size',
+				type: "'sm' | 'md' | 'lg'",
+				default: "'md'",
+				description: 'Track height; every other measurement derives from it.',
+			},
+			{
+				name: 'tone',
+				type: "'holo' | 'accent' | 'danger' | 'success'",
+				default: "'holo'",
+				description:
+					'What the on state paints. The default is the Holomesh fill; the others are flat colours for when brand is the wrong thing to say.',
+			},
+			{
+				name: 'block',
+				type: 'boolean attribute',
+				description:
+					'Full-width settings row — label hard left, switch hard right.',
+			},
+			{
+				name: 'label-position',
+				type: "'end' | 'start'",
+				default: "'end'",
+				description: 'Which side of the switch the label sits on.',
+			},
+		],
+		events: [
+			{
+				name: 'os-switch-change',
+				description: 'Fires when the user toggles the switch.',
+				detail: '{ checked: boolean, value: string | null }',
+			},
+			{
+				name: 'os-checkbox-change',
+				description:
+					'Same detail, same moment — the compatibility alias that lets a switch drop into an existing checkbox listener.',
+				detail: '{ checked: boolean, value: string | null }',
+			},
+		],
+		cssProps: [
+			{ name: '--os-ui-holo-fill', description: 'The on-state mesh.' },
+			{ name: '--os-ui-holo-track', description: 'The off-state track.' },
+			{ name: '--os-ui-holo-glow', description: 'The bloom around an on switch.' },
+			{ name: '--os-ui-switch-knob', description: 'Knob colour.' },
+		],
+		example: html`
+			<os-stack gap="10">
+				<os-switch checked label="Reduce motion"></os-switch>
+				<os-switch label="Auto-hide the dock"></os-switch>
+				<os-switch size="sm" checked tone="accent" label="Small, flat accent"></os-switch>
+				<os-switch size="lg" checked label="Large"></os-switch>
+				<os-switch checked disabled label="Locked on"></os-switch>
+			</os-stack>
+		`,
+	} as const;
+
+	/** Pointer id owning the current gesture, or null when idle. */
+	private _pointerId: number | null = null;
+
+	/** Client X where the gesture started. */
+	private _startX = 0;
+
+	/** How far the knob may travel, in px. Measured on pointerdown. */
+	private _travel = 0;
+
+	/** True once the pointer has moved past {@link TAP_SLOP}. */
+	private _moved = false;
+
+	/** 1 in LTR, -1 in RTL. Resolved per gesture. */
+	private _dir = 1;
+
+	/**
+	 * Set when a drag has already decided the outcome, so the `click`
+	 * the browser fires after `pointerup` does not toggle a second time
+	 * and undo it. Cleared by that same click.
+	 */
+	private _swallowClick = false;
+
+	protected render() {
+		const checked = this._attr( 'checked' ) !== null;
+		const disabled = this._attr( 'disabled' ) !== null;
+		const label = this._attr( 'label' ) || '';
+		const description = this._attr( 'description' ) || '';
+		return html`
+			<div class="os-switch__row">
+				<span class="os-switch__text">
+					<span class="os-switch__label">${ label }</span>
+					<span class="os-switch__description" id="os-switch-desc"
+						>${ description }</span
+					>
+				</span>
+				<button
+					type="button"
+					role="switch"
+					class="os-holo-fill"
+					aria-checked=${ checked ? 'true' : 'false' }
+					aria-label=${ label || 'Toggle' }
+					aria-describedby=${ description ? 'os-switch-desc' : '' }
+					?disabled=${ disabled }
+					@click=${ () => this._onClick() }
+					@keydown=${ ( e: KeyboardEvent ) => this._onKeyDown( e ) }
+					@pointerdown=${ ( e: PointerEvent ) => this._onPointerDown( e ) }
+					@pointermove=${ ( e: PointerEvent ) => this._onPointerMove( e ) }
+					@pointerup=${ ( e: PointerEvent ) => this._onPointerUp( e ) }
+					@pointercancel=${ () => this._endGesture() }
+				>
+					<span class="os-switch__knob"></span>
+				</button>
+			</div>
+		`;
+	}
+
+	// ------------------------------------------------------------------
+	// Gestures
+	// ------------------------------------------------------------------
+
+	private _onPointerDown( e: PointerEvent ): void {
+		if ( this._attr( 'disabled' ) !== null ) {
+			return;
+		}
+		const track = e.currentTarget as HTMLElement;
+		this._pointerId = e.pointerId;
+		this._startX = e.clientX;
+		this._moved = false;
+		this._dir = getComputedStyle( this ).direction === 'rtl' ? -1 : 1;
+		this.style.setProperty( '--_dir', String( this._dir ) );
+		/*
+		 * How far the knob can go, from the TRACK alone.
+		 *
+		 * The stylesheet defines travel as `w - knob - 2·pad`, and the
+		 * knob as `h - 2·pad`, so the two pads cancel and the whole
+		 * thing collapses to `w - h` — the track's own client box,
+		 * width minus height. That identity is worth using rather than
+		 * measuring the knob, because by the time this handler runs the
+		 * browser may already have applied `:active`, which widens the
+		 * knob to 1.28× as its press feedback. Measuring it there would
+		 * shorten the travel by a quarter and the switch would flip
+		 * noticeably early — intermittently, since whether `:active`
+		 * lands before `pointerdown` is not something the spec pins
+		 * down.
+		 *
+		 * Measured rather than read from the tokens all the same: a
+		 * caller is free to re-point `--_h` or `--_pad` from the
+		 * document tree, and the laid-out box is the only honest
+		 * source for what those ended up being.
+		 */
+		this._travel = Math.max( 0, track.clientWidth - track.clientHeight );
+		track.setPointerCapture( e.pointerId );
+	}
+
+	private _onPointerMove( e: PointerEvent ): void {
+		if ( this._pointerId !== e.pointerId || this._travel === 0 ) {
+			return;
+		}
+		const delta = ( e.clientX - this._startX ) * this._dir;
+		if ( ! this._moved && Math.abs( delta ) >= TAP_SLOP ) {
+			this._moved = true;
+			this.setAttribute( 'data-dragging', '' );
+		}
+		if ( ! this._moved ) {
+			return;
+		}
+		// Clamp to the track. The knob starts at one end or the other
+		// depending on state, so the legal range for the offset differs:
+		// an "on" switch can only be dragged back toward zero.
+		const on = this._attr( 'checked' ) !== null;
+		const min = on ? -this._travel : 0;
+		const max = on ? 0 : this._travel;
+		this.style.setProperty(
+			'--_drag',
+			`${ Math.min( max, Math.max( min, delta ) ) }px`,
+		);
+	}
+
+	private _onPointerUp( e: PointerEvent ): void {
+		if ( this._pointerId !== e.pointerId ) {
+			return;
+		}
+		const wasDrag = this._moved;
+		const delta = ( e.clientX - this._startX ) * this._dir;
+		this._swallowClick = wasDrag;
+		this._endGesture();
+		if ( ! wasDrag ) {
+			// A tap. `click` fires next and does the toggling — doing it
+			// here as well would toggle twice and land back where it
+			// started.
+			return;
+		}
+		// Released past the midpoint? The knob's final resting place is
+		// wherever it already is, rounded to the nearer end.
+		const on = this._attr( 'checked' ) !== null;
+		const position = ( on ? this._travel : 0 ) + delta;
+		const next = position > this._travel / 2;
+		if ( next !== on ) {
+			this._commit( next );
+		}
+	}
+
+	private _endGesture(): void {
+		this._pointerId = null;
+		this._moved = false;
+		this.removeAttribute( 'data-dragging' );
+		this.style.removeProperty( '--_drag' );
+	}
+
+	// ------------------------------------------------------------------
+	// Toggling
+	// ------------------------------------------------------------------
+
+	private _onClick(): void {
+		// A drag that crossed the slop threshold ends in a `click` too.
+		// `_onPointerUp` has already decided the outcome; toggling again
+		// here would undo it. Checked before `disabled` so the flag is
+		// always consumed by the click it was raised for.
+		if ( this._swallowClick ) {
+			this._swallowClick = false;
+			return;
+		}
+		if ( this._attr( 'disabled' ) !== null ) {
+			return;
+		}
+		this._commit( this._attr( 'checked' ) === null );
+	}
+
+	private _onKeyDown( e: KeyboardEvent ): void {
+		if ( this._attr( 'disabled' ) !== null ) {
+			return;
+		}
+		// The explicit pair. Space and Enter toggle relative to the
+		// current state, which a screen-reader user has to be tracking;
+		// these set an absolute one.
+		if ( e.key === 'ArrowRight' || e.key === 'End' ) {
+			e.preventDefault();
+			if ( this._attr( 'checked' ) === null ) {
+				this._commit( true );
+			}
+		} else if ( e.key === 'ArrowLeft' || e.key === 'Home' ) {
+			e.preventDefault();
+			if ( this._attr( 'checked' ) !== null ) {
+				this._commit( false );
+			}
+		}
+	}
+
+	/** Reflect the new state and announce it. */
+	private _commit( next: boolean ): void {
+		if ( next ) {
+			this.setAttribute( 'checked', '' );
+		} else {
+			this.removeAttribute( 'checked' );
+		}
+		const detail = { checked: next, value: this._attr( 'value' ) };
+		this.emit( 'os-switch-change', detail );
+		// The compatibility alias — see the class docblock. Same detail,
+		// same tick, so a listener bound to either name sees one change.
+		this.emit( 'os-checkbox-change', detail );
+	}
+
+	/** Typed read of a declared prop. */
+	private _attr( name: string ): string | null {
+		return ( this as unknown as Record< string, string | null > )[ name ] ?? null;
+	}
+}
+
+defineComponent( 'os-switch', OsSwitch );

--- a/src/ui/components/os-tab-chip/os-tab-chip.styles.ts
+++ b/src/ui/components/os-tab-chip/os-tab-chip.styles.ts
@@ -1,6 +1,9 @@
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const styles = css`
+	${ holoTokens }
+
 	:host {
 		display: inline-flex;
 	}
@@ -26,19 +29,28 @@ export const styles = css`
 		transform: translateY( -1px );
 	}
 	:host( [ variant='detach' ] ) button:focus-visible {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: 1px;
+		outline: none;
+		color: var( --os-ui-accent, #2271b1 );
+		background: var( --os-ui-accent-soft, rgba( 34, 113, 177, 0.12 ) );
+		box-shadow: var( --_holo-focus );
 	}
 	/* Close (red destructive wash) */
 	:host( [ variant='close' ] ) button:hover {
 		color: var( --os-ui-fg-on-accent, #fff );
 		background: var( --os-ui-danger, #d63638 );
 	}
+	/*
+	 * Close keeps a RED ring rather than the kit's Pulse one. The
+	 * shared ring says "this has focus"; on the one control that
+	 * destroys something, the ring should also say what it destroys.
+	 */
 	:host( [ variant='close' ] ) button:focus-visible {
 		color: var( --os-ui-fg-on-accent, #fff );
 		background: var( --os-ui-danger, #d63638 );
-		outline: 2px solid var( --os-ui-danger-hover, rgba( 214, 54, 56, 0.6 ) );
-		outline-offset: 1px;
+		outline: none;
+		box-shadow: 0 0 0 2px rgba( 12, 11, 15, 0.9 ),
+			0 0 0 4px var( --os-ui-danger, #d63638 ),
+			0 0 12px 2px rgba( 214, 54, 56, 0.45 );
 	}
 	svg {
 		display: block;

--- a/src/ui/components/os-tab-chip/os-tab-chip.ts
+++ b/src/ui/components/os-tab-chip/os-tab-chip.ts
@@ -24,7 +24,6 @@ export class OsTabChip extends Component {
 		summary:
 			'Small action button dropped inside an external sub-tab. `detach` lifts with an accent wash on hover; `close` uses a red destructive wash. Click bubbles as a native click — consumers read `variant` if they need to distinguish.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'variant',

--- a/src/ui/components/os-table/os-table.styles.ts
+++ b/src/ui/components/os-table/os-table.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '../../core';
+import { holoTokens, holoCheck } from '../../holo';
 
 /**
  * Styles for `<os-table>`.
@@ -53,6 +54,9 @@ import { css } from '../../core';
  * ancestor case. Same pattern as `<os-rating-summary>`.
  */
 export const styles = css`
+	${ holoTokens }
+	${ holoCheck }
+
 	:host {
 		display: block;
 		/* --os-ui-surface is the host theme's surface color; #fff is
@@ -300,8 +304,9 @@ export const styles = css`
 	}
 	.filter-input:focus,
 	.filter-select:focus {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: -1px;
+		outline: none;
+		border-color: var( --os-ui-accent, #2271b1 );
+		box-shadow: var( --_holo-focus-field );
 	}
 
 	/* Expander column. */
@@ -373,9 +378,11 @@ export const styles = css`
 			var( --_row-hover )
 		);
 	}
+	/* Inset — a header cell is flush with the table edge, so an
+	   outward ring would be clipped on the first and last column. */
 	thead th.is-sortable:focus-visible {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: -2px;
+		outline: none;
+		box-shadow: inset 0 0 0 2px var( --os-ui-accent, #2271b1 );
 	}
 	.sort-indicator {
 		font-size: 10px;
@@ -417,6 +424,34 @@ export const styles = css`
 			var( --wp-admin-theme-color, #2271b1 ) 16%,
 			var( --_bg )
 		);
+	}
+
+	/*
+	 * The selected row's leading-edge marker.
+	 *
+	 * A 10%-alpha wash is the correct selection tint and a weak
+	 * signal: in a table of forty rows it is easy to lose, and for
+	 * anyone who cannot separate those two greys it is not there at
+	 * all. The marker states the same thing a second way — a 3 px
+	 * accent bar down the leading edge of the first cell.
+	 *
+	 * An inset box-shadow rather than a background layer, because the
+	 * cell backgrounds are already carrying the stripe and the hover
+	 * overlay (see the sticky-cell rule at the top of this file) and
+	 * a third layer would have to win an argument with both. An inset
+	 * shadow paints above every one of them and costs no layout, which
+	 * a border-inline-start would.
+	 *
+	 * box-shadow offsets are physical, so RTL takes the :dir() rule
+	 * below. Where :dir() is unsupported the marker stays on the left
+	 * in an RTL table — cosmetically wrong, still legible, and not
+	 * worth a per-table direction probe in JS.
+	 */
+	tbody tr.is-selected td:first-child {
+		box-shadow: inset 3px 0 0 0 var( --os-ui-accent, #2271b1 );
+	}
+	tbody:dir( rtl ) tr.is-selected td:first-child {
+		box-shadow: inset -3px 0 0 0 var( --os-ui-accent, #2271b1 );
 	}
 
 	/* Loading skeleton. */

--- a/src/ui/components/os-table/os-table.ts
+++ b/src/ui/components/os-table/os-table.ts
@@ -241,8 +241,7 @@ export class OsTable< T extends Record< string, unknown > = Record< string, unkn
 		title: 'Table',
 		summary:
 			'Data-driven table. Assign `columns` + `data` and you get a styled table with optional per-column filters, click-to-sort, multi-row selection, sticky columns/header, sub-tables, custom cell renderers, loading skeleton, and a slottable empty state.',
-		status: 'experimental',
-		since: '0.6.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'sticky-columns',

--- a/src/ui/components/os-table/os-table.ts
+++ b/src/ui/components/os-table/os-table.ts
@@ -306,9 +306,30 @@ export class OsTable< T extends Record< string, unknown > = Record< string, unkn
 			{ name: '--os-ui-table-max-height' },
 			{ name: '--os-ui-table-skeleton-color' },
 		],
-		example: html`
-			<os-table id="sample-table" sticky-header striped hover></os-table>
-		`,
+		/*
+		 * `data` and `columns` are properties, not attributes, so the
+		 * markup alone renders an empty frame — which is what this
+		 * example was before `exampleInit` existed.
+		 */
+		example: html`<os-table striped hover></os-table>`,
+		exampleInit: ( root: HTMLElement ) => {
+			const table = root.querySelector( 'os-table' );
+			if ( ! table ) {
+				return;
+			}
+			const t = table as OsTable< Record< string, unknown > >;
+			t.columns = [
+				{ key: 'name', label: 'Name' },
+				{ key: 'kind', label: 'Kind', filter: 'select' },
+				{ key: 'size', label: 'Size', align: 'end' },
+			];
+			t.data = [
+				{ name: 'wp-config.php', kind: 'PHP', size: '4 KB' },
+				{ name: 'style.css', kind: 'CSS', size: '61 KB' },
+				{ name: 'header.php', kind: 'PHP', size: '3 KB' },
+				{ name: 'screenshot.png', kind: 'Image', size: '210 KB' },
+			];
+		},
 	} as const;
 
 	private _data: T[] = [];

--- a/src/ui/components/os-tabs/os-tabs.styles.ts
+++ b/src/ui/components/os-tabs/os-tabs.styles.ts
@@ -5,6 +5,7 @@
  * tight spacing, panel focus outline) side-by-side.
  */
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const tabsStyles = css`
 	:host {
@@ -30,19 +31,36 @@ export const tabPanelStyles = css`
 		display: none;
 	}
 	:host( :focus-visible ) {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+		outline: 2px solid var( --os-ui-accent, #2271b1 );
 		outline-offset: 4px;
 		border-radius: 4px;
 	}
 `;
 
+/**
+ * The selected tab's underline is the mesh.
+ *
+ * `border-bottom-color` takes a colour, so the underline is drawn as
+ * an `::after` bar instead — which also lets it animate its width from
+ * the centre out, and lets the mesh sit at the bar's own scale rather
+ * than being stretched across a 2 px strip of a nine-layer gradient.
+ *
+ * The bar exists on every tab and is simply zero-width until the tab
+ * is chosen. Growing an element that is already in the layout costs a
+ * transform-adjacent repaint; inserting one on selection would cost a
+ * layout pass and would arrive after the colour change rather than
+ * with it.
+ */
 export const tabStyles = css`
+	${ holoTokens }
+
 	:host {
 		display: inline-block;
 	}
 	button {
 		appearance: none;
-		padding: 6px 10px;
+		position: relative;
+		padding: 6px 10px 8px;
 		border: none;
 		background: transparent;
 		color: var( --os-ui-fg-muted, #50575e );
@@ -50,19 +68,47 @@ export const tabStyles = css`
 		font-size: 12px;
 		font-weight: 500;
 		cursor: pointer;
-		border-bottom: 2px solid transparent;
 		margin-bottom: -1px;
-		transition: color 0.15s ease, border-color 0.15s ease;
+		transition: color var( --_holo-t ) ease;
+	}
+	button::after {
+		content: '';
+		position: absolute;
+		inset-inline: 50%;
+		bottom: 0;
+		height: 2px;
+		border-radius: 2px 2px 0 0;
+		background-image: var( --_holo-fill );
+		background-size: 100% 100%;
+		opacity: 0;
+		transition: inset-inline var( --_holo-t ) ease, opacity var( --_holo-t ) ease;
 	}
 	button:hover {
-		color: var( --wp-admin-theme-color, #2271b1 );
+		color: var( --os-ui-fg, #1d2327 );
+	}
+	/* Half-width on hover: enough to read as "this one is about to
+	   be it" without competing with the tab that already is. */
+	button:hover::after {
+		inset-inline: 30%;
+		opacity: 0.45;
 	}
 	button:focus-visible {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: 2px;
+		outline: none;
+		box-shadow: var( --_holo-focus );
+		border-radius: 4px;
 	}
 	:host( [ aria-selected='true' ] ) button {
-		color: var( --wp-admin-theme-color, #2271b1 );
-		border-bottom-color: var( --wp-admin-theme-color, #2271b1 );
+		color: var( --os-ui-fg, #1d2327 );
+		font-weight: 600;
+	}
+	:host( [ aria-selected='true' ] ) button::after,
+	:host( [ aria-selected='true' ] ) button:hover::after {
+		inset-inline: 0;
+		opacity: 1;
+	}
+	@media ( prefers-reduced-motion: reduce ) {
+		button::after {
+			transition-duration: 1ms;
+		}
 	}
 `;

--- a/src/ui/components/os-tabs/os-tabs.ts
+++ b/src/ui/components/os-tabs/os-tabs.ts
@@ -39,7 +39,6 @@ export class OsTab extends Component {
 		summary:
 			'Single tab inside a <os-tabs> strip. Carries its identifier via `value`; aria-selected + tabindex are mirrored by the parent.',
 		status: 'stable',
-		since: '0.7.0',
 		props: [
 			{
 				name: 'value',
@@ -101,7 +100,6 @@ export class OsTabs extends Component {
 		summary:
 			'Underline-accent tab strip. Pair with sibling <os-tabpanel for="…"> elements and the strip auto-toggles their hidden attribute on selection.',
 		status: 'stable',
-		since: '0.7.0',
 		props: [
 			{
 				name: 'value',
@@ -240,7 +238,6 @@ export class OsTabPanel extends Component {
 		summary:
 			'Auto-managed panel paired with a sibling <os-tabs>. Declares which tab it belongs to via `for="<tab-value>"`; the parent strip toggles `hidden` whenever the active tab changes. role="tabpanel" and tabindex="0" are set automatically.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{
 				name: 'for',

--- a/src/ui/components/os-tabs/os-tabs.ts
+++ b/src/ui/components/os-tabs/os-tabs.ts
@@ -57,6 +57,22 @@ export class OsTab extends Component {
 				detail: '{ value: string | null }',
 			},
 		],
+		/*
+		 * A tab is a borderless button until a strip gives it the
+		 * underline and the selected state, so the example is the
+		 * strip — with panels, since a tab that switches nothing
+		 * demonstrates half a component.
+		 */
+		example: html`
+			<os-tabs value="one" label="Demo tabs">
+				<os-tab value="one">One</os-tab>
+				<os-tab value="two">Two</os-tab>
+				<os-tab value="three">Three</os-tab>
+			</os-tabs>
+			<os-tabpanel for="one">The first panel.</os-tabpanel>
+			<os-tabpanel for="two">The second panel.</os-tabpanel>
+			<os-tabpanel for="three">The third panel.</os-tabpanel>
+		`,
 	} as const;
 
 	protected render() {
@@ -235,6 +251,25 @@ export class OsTabPanel extends Component {
 		slots: [
 			{ name: '(default)', description: 'Panel body content.' },
 		],
+		/*
+		 * A panel is `hidden` unless its sibling strip is on its
+		 * `for` value, so a lone panel renders nothing — which is what
+		 * this help pane showed before. It needs the strip to be a
+		 * demonstration of anything at all.
+		 */
+		example: html`
+			<os-tabs value="two" label="Demo tabs">
+				<os-tab value="one">One</os-tab>
+				<os-tab value="two">Two</os-tab>
+			</os-tabs>
+			<os-tabpanel for="one">
+				Hidden — the strip is on "two".
+			</os-tabpanel>
+			<os-tabpanel for="two">
+				Visible, because this panel's <code>for</code> matches the
+				strip's <code>value</code>.
+			</os-tabpanel>
+		`,
 	} as const;
 	// Shadow DOM — the render target for this component is its
 	// own shadow root, which holds a single `<slot>` that projects

--- a/src/ui/components/os-tag-input/os-tag-input.styles.ts
+++ b/src/ui/components/os-tag-input/os-tag-input.styles.ts
@@ -65,7 +65,10 @@ export const styles = css`
 	.os-tag-input__add:focus-visible {
 		outline: none;
 		border-style: solid;
-		box-shadow: 0 0 0 2px var( --wp-admin-theme-color, #2271b1 );
+		box-shadow: var(
+			--os-ui-focus-ring,
+			0 0 0 2px rgba( 12, 11, 15, 0.9 ), 0 0 0 4px #2271b1
+		);
 	}
 	.os-tag-input__add:disabled {
 		opacity: 0.5;
@@ -99,12 +102,11 @@ export const styles = css`
 	}
 	.os-tag-input__input:focus {
 		outline: none;
-		box-shadow: 0 0 0 2px
-			color-mix(
-				in srgb,
-				var( --wp-admin-theme-color, #2271b1 ) 30%,
-				transparent
-			);
+		border-color: var( --os-ui-accent, #2271b1 );
+		box-shadow: var(
+			--os-ui-focus-ring-field,
+			0 0 0 1px #2271b1, 0 0 0 4px rgba( 34, 113, 177, 0.18 )
+		);
 	}
 
 	/* Popover — pinned to the editor, full width by default. Z-index

--- a/src/ui/components/os-tag-input/os-tag-input.ts
+++ b/src/ui/components/os-tag-input/os-tag-input.ts
@@ -122,8 +122,9 @@ export class OsTagInput extends Component {
 			{
 				name: 'add-label',
 				type: 'string',
-				description: 'Label of the "+" trigger button.',
-				default: '+ Add',
+				description:
+					'Label of the trigger button. The button draws its own plus icon, so this is text only — passing "+ Add" puts two pluses on screen.',
+				default: 'Add',
 			},
 			{
 				name: 'creatable',
@@ -351,9 +352,20 @@ export class OsTagInput extends Component {
 				! readonly );
 		const creatable =
 			( this as unknown as { creatable: string | null } ).creatable !== null;
+		/*
+		 * "Add", not "+ Add". The button already renders an SVG plus
+		 * beside this text, so a literal one in the label put two of
+		 * them on screen — it read as "++ Add".
+		 *
+		 * The icon is the one to keep: it is `aria-hidden`, so the
+		 * accessible name is exactly this string, and a screen reader
+		 * announcing "plus Add" was the same duplication in the other
+		 * modality. A caller who wants a glyph in the text can still
+		 * pass one through `add-label`.
+		 */
 		const addLabel =
 			( this as unknown as { 'add-label': string | null } )[ 'add-label' ] ||
-			'+ Add';
+			'Add';
 		const placeholder =
 			( this as unknown as { placeholder: string | null } ).placeholder ||
 			'Add a tag…';

--- a/src/ui/components/os-tag-input/os-tag-input.ts
+++ b/src/ui/components/os-tag-input/os-tag-input.ts
@@ -105,8 +105,7 @@ export class OsTagInput extends Component {
 		title: 'Tag input',
 		summary:
 			'Multi-tag picker with autocomplete and free-form creation. Purely presentational — emits os-tag-suggest / os-tag-add / os-tag-remove and lets the consumer drive REST + optimistic UI.',
-		status: 'experimental',
-		since: '0.8.0',
+		status: 'stable',
 		props: [
 			{
 				name: 'label',

--- a/src/ui/components/os-text-field/os-text-field.styles.ts
+++ b/src/ui/components/os-text-field/os-text-field.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '../../core';
+import { holoTokens, holoField } from '../../holo';
 
 /**
  * Styles for the labelled text / number field shared between
@@ -6,9 +7,20 @@ import { css } from '../../core';
  * matches `<os-color-field>` / `<os-range-field>` — a stacked
  * label on top, the input beneath, muted label color, accent focus
  * ring.
+ *
+ * The hover, focus, placeholder and selection states come from
+ * `holoField` in `src/ui/holo.ts`, shared with every other text-like
+ * control so the whole form family reacts identically. This file
+ * keeps only what is this component's own shape — padding, radius,
+ * the suffix slot, the reveal button and the password mask — plus the
+ * `aria-invalid` rings, which deliberately outweigh the shared focus
+ * rule so an invalid field focuses in red.
  */
 
 export const textFieldStyles = css`
+	${ holoTokens }
+	${ holoField }
+
 	/*
 	 * Host is block-level flex so the field fills its parent cell
 	 * (grid row col=N, flex container, plain block container). An
@@ -54,7 +66,6 @@ export const textFieldStyles = css`
 		font: inherit;
 		font-size: 13px;
 		color: var( --os-ui-fg, #1d2327 );
-		transition: border-color 0.12s ease, box-shadow 0.12s ease;
 	}
 
 	/* Suffix slot for units / currency badges — rendered when the
@@ -96,11 +107,15 @@ export const textFieldStyles = css`
 		transition: color 0.12s ease;
 	}
 	.os-text-field__reveal:hover {
-		color: var( --wp-admin-theme-color, #2271b1 );
+		color: var( --os-ui-accent, #2271b1 );
 	}
 	.os-text-field__reveal:focus-visible {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: -2px;
+		outline: none;
+		color: var( --os-ui-accent, #2271b1 );
+		/* Inset, because the button sits flush inside the field's own
+		   border — a ring outside it would trace the field, not the
+		   button, and read as the wrong thing having focus. */
+		box-shadow: inset 0 0 0 2px var( --os-ui-accent, #2271b1 );
 		border-radius: 0 6px 6px 0;
 	}
 	.os-text-field__reveal:disabled {
@@ -131,25 +146,26 @@ export const textFieldStyles = css`
 		}
 	}
 
-	input:hover {
-		border-color: var( --os-ui-fg-muted, #8c8f94 );
-	}
-	input:focus-visible {
-		outline: none;
-		border-color: var( --wp-admin-theme-color, #2271b1 );
-		box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 );
-	}
 	input:disabled {
 		opacity: 0.55;
 		cursor: not-allowed;
 		background: var( --os-ui-hover, rgba( 0, 0, 0, 0.03 ) );
 	}
 
-	input[ aria-invalid='true' ] {
+	/*
+	 * Invalid outranks the shared focus ring — see the note on
+	 * :where() in holoField. An invalid field focuses in red, because
+	 * the ring is the only thing on screen saying so at that moment.
+	 */
+	input[ aria-invalid='true' ],
+	input[ aria-invalid='true' ]:hover:not( :disabled ) {
 		border-color: var( --os-ui-danger, #d63638 );
 	}
+	input[ aria-invalid='true' ]:focus,
 	input[ aria-invalid='true' ]:focus-visible {
-		box-shadow: 0 0 0 1px var( --os-ui-danger, #d63638 );
+		border-color: var( --os-ui-danger, #d63638 );
+		box-shadow: 0 0 0 1px var( --os-ui-danger, #d63638 ),
+			0 0 0 4px rgba( 214, 54, 56, 0.18 );
 	}
 
 	/* Hide the native spinner on number inputs — the suffix slot and

--- a/src/ui/components/os-text-field/os-text-field.ts
+++ b/src/ui/components/os-text-field/os-text-field.ts
@@ -61,7 +61,6 @@ export class OsTextField extends Component {
 		summary:
 			'Labelled text input primitive. Two-way reflects `value`, emits os-input-change per keystroke, os-input-commit on blur/change, and os-submit on Enter. Optional password reveal toggle.',
 		status: 'stable',
-		since: '0.5.0',
 		props: [
 			{ name: 'label', type: 'string', description: 'Visible label above the input.' },
 			{ name: 'value', type: 'string', description: 'Current input value; reflected two-way.' },

--- a/src/ui/components/os-textarea/os-textarea.styles.ts
+++ b/src/ui/components/os-textarea/os-textarea.styles.ts
@@ -1,11 +1,17 @@
 import { css } from '../../core';
+import { holoTokens, holoField } from '../../holo';
 
 /**
  * Styles for `<os-textarea>` — multi-line text input. Visually
  * matches `<os-text-field>` (same border, padding, focus ring) so
- * forms can mix the two without a seam.
+ * forms can mix the two without a seam — and now literally so: both
+ * take their hover, focus, placeholder and selection states from the
+ * shared `holoField` fragment rather than each declaring its own.
  */
 export const textareaStyles = css`
+	${ holoTokens }
+	${ holoField }
+
 	:host {
 		display: flex;
 		flex-direction: column;
@@ -39,28 +45,24 @@ export const textareaStyles = css`
 		line-height: 1.45;
 		color: var( --os-ui-fg, #1d2327 );
 		resize: vertical;
-		transition: border-color 0.12s ease, box-shadow 0.12s ease;
 	}
 
-	textarea:hover {
-		border-color: var( --os-ui-fg-muted, #8c8f94 );
-	}
-	textarea:focus-visible {
-		outline: none;
-		border-color: var( --wp-admin-theme-color, #2271b1 );
-		box-shadow: 0 0 0 1px var( --wp-admin-theme-color, #2271b1 );
-	}
 	textarea:disabled {
 		opacity: 0.55;
 		cursor: not-allowed;
 		background: var( --os-ui-hover, rgba( 0, 0, 0, 0.03 ) );
 	}
 
-	textarea[ aria-invalid='true' ] {
+	/* Outranks the shared focus ring — see the :where() note in holoField. */
+	textarea[ aria-invalid='true' ],
+	textarea[ aria-invalid='true' ]:hover:not( :disabled ) {
 		border-color: var( --os-ui-danger, #d63638 );
 	}
+	textarea[ aria-invalid='true' ]:focus,
 	textarea[ aria-invalid='true' ]:focus-visible {
-		box-shadow: 0 0 0 1px var( --os-ui-danger, #d63638 );
+		border-color: var( --os-ui-danger, #d63638 );
+		box-shadow: 0 0 0 1px var( --os-ui-danger, #d63638 ),
+			0 0 0 4px rgba( 214, 54, 56, 0.18 );
 	}
 
 	/* Auto-grow mode: hide native resize affordance — we manage rows. */

--- a/src/ui/components/os-textarea/os-textarea.ts
+++ b/src/ui/components/os-textarea/os-textarea.ts
@@ -58,7 +58,6 @@ export class OsTextarea extends Component {
 		summary:
 			'Multi-line text input. Same event shape as os-text-field. Optional auto-grow up to max-rows; optional submit-on-enter (Enter sends, Shift+Enter newlines).',
 		status: 'stable',
-		since: '0.6.0',
 		props: [
 			{ name: 'label', type: 'string', description: 'Visible label above the textarea.' },
 			{ name: 'value', type: 'string', description: 'Current value; reflected two-way.' },

--- a/src/ui/components/os-tile/os-tile.ts
+++ b/src/ui/components/os-tile/os-tile.ts
@@ -121,6 +121,63 @@ export class OsTile extends Component {
 			{ name: 'drag-title', type: 'string' },
 			{ name: 'drag-icon', type: 'string' },
 		],
+		/*
+		 * The tile is the one LIGHT-DOM component in the kit
+		 * (`static shadow = false`), so its chrome comes from
+		 * `assets/css/desktop-files.css` rather than from a shadow
+		 * stylesheet — which means it only looks like a tile where
+		 * that file is loaded. It is, in the shell.
+		 *
+		 * Shown on a dark strip because tiles live on the wallpaper,
+		 * and their label is Starlight with a text shadow — on the
+		 * settings panel's own light surface the labels would be
+		 * white-on-white and the example would look empty.
+		 */
+		example: html`
+			<div
+				style="display:flex;gap:18px;flex-wrap:wrap;padding:16px;border-radius:8px;background:var( --os-ui-surface-sunken, #101018 );"
+			>
+				<os-tile
+					type="post"
+					ref="1"
+					label="Hello world"
+					icon="dashicons-admin-post"
+					kind="entry"
+					status="publish"
+				></os-tile>
+				<os-tile
+					type="post"
+					ref="2"
+					label="A draft"
+					icon="dashicons-admin-post"
+					kind="entry"
+					status="draft"
+				></os-tile>
+				<os-tile
+					type="folder"
+					ref="3"
+					label="Screenshots"
+					icon="dashicons-portfolio"
+					kind="folder"
+				></os-tile>
+				<os-tile
+					type="post"
+					ref="4"
+					label="Selected"
+					icon="dashicons-media-document"
+					kind="entry"
+					selected
+				></os-tile>
+				<os-tile
+					type="post"
+					ref="5"
+					label="Locked"
+					icon="dashicons-lock"
+					kind="entry"
+					access-gated
+				></os-tile>
+			</div>
+		`,
 	} as const;
 
 	private _pointerdownHandler: ( ( e: PointerEvent ) => void ) | null = null;

--- a/src/ui/components/os-tile/os-tile.ts
+++ b/src/ui/components/os-tile/os-tile.ts
@@ -104,8 +104,7 @@ export class OsTile extends Component {
 		title: 'Tile',
 		summary:
 			'Canonical file/entity tile. Used across the wallpaper, folder windows, every My WordPress section, and plugin surfaces. Renders the standard `.os-file-tile` chrome + optional status ribbon and wires the shared drag-out helper.',
-		status: 'experimental',
-		since: '0.8.6',
+		status: 'stable',
 		props: [
 			{ name: 'type', type: 'string' },
 			{ name: 'ref', type: 'string' },

--- a/src/ui/components/os-toast/os-toast.styles.ts
+++ b/src/ui/components/os-toast/os-toast.styles.ts
@@ -6,6 +6,7 @@
  * transition) side-by-side.
  */
 import { css } from '../../core';
+import { holoTokens } from '../../holo';
 
 export const containerStyles = css`
 	:host {
@@ -21,6 +22,8 @@ export const containerStyles = css`
 `;
 
 export const toastStyles = css`
+	${ holoTokens }
+
 	:host {
 		display: flex;
 		align-items: center;
@@ -52,17 +55,32 @@ export const toastStyles = css`
 		font-size: 13px;
 		line-height: 1.4;
 		opacity: 0;
-		transform: translateY( -8px );
-		transition: opacity 0.18s ease, transform 0.18s ease;
+		/*
+		 * Arrives from above and slightly small, on the spring — a
+		 * toast drops in from the edge it is docked to, and the scale
+		 * is what stops eight stacked toasts reading as one list
+		 * scrolling.
+		 */
+		transform: translateY( -10px ) scale( 0.97 );
+		transition: opacity var( --_holo-t-fast ) linear,
+			transform var( --_holo-t ) var( --_holo-spring );
 		pointer-events: auto;
 	}
 	:host( [ state='in' ] ) {
 		opacity: 1;
-		transform: translateY( 0 );
+		transform: translateY( 0 ) scale( 1 );
 	}
+	/*
+	 * Leaving is not arriving in reverse. It exits sideways, toward
+	 * the edge it is docked to, and on the plain ease rather than the
+	 * spring: an overshoot on the way out reads as the toast being
+	 * yanked back before it goes.
+	 */
 	:host( [ state='out' ] ) {
 		opacity: 0;
-		transform: translateY( -8px );
+		transform: translateX( 16px ) scale( 0.97 );
+		transition: opacity var( --_holo-t-fast ) linear,
+			transform var( --_holo-t ) var( --_holo-ease );
 	}
 	.os-toast__label {
 		flex: 1;

--- a/src/ui/components/os-toast/os-toast.ts
+++ b/src/ui/components/os-toast/os-toast.ts
@@ -25,7 +25,6 @@ export class OsToastContainer extends Component {
 		summary:
 			'Singleton stack beneath <body> that hosts transient <os-toast> notifications in the top-right. Created lazily by showToast(); authors rarely place one themselves.',
 		status: 'stable',
-		since: '0.9.0',
 		slots: [
 			{ name: '(default)', description: '<os-toast> children, stacked vertically.' },
 		],
@@ -60,7 +59,6 @@ export class OsToast extends Component {
 		summary:
 			'Single transient notification. Message is slotted; fade-in / fade-out is CSS-driven by flipping the state attribute between "in" and "out". Usually created via the showToast() helper rather than authored by hand.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'action',

--- a/src/ui/components/os-user-search/os-user-search.styles.ts
+++ b/src/ui/components/os-user-search/os-user-search.styles.ts
@@ -18,8 +18,12 @@ export const userSearchStyles = css`
 		box-sizing: border-box;
 	}
 	.input:focus {
-		outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
-		outline-offset: -1px;
+		outline: none;
+		border-color: var( --os-ui-accent, #2271b1 );
+		box-shadow: var(
+			--os-ui-focus-ring-field,
+			0 0 0 1px #2271b1, 0 0 0 4px rgba( 34, 113, 177, 0.18 )
+		);
 	}
 
 	.dropdown {

--- a/src/ui/components/os-user-search/os-user-search.ts
+++ b/src/ui/components/os-user-search/os-user-search.ts
@@ -39,8 +39,7 @@ export class OsUserSearch extends Component {
 		title: 'User autocomplete',
 		summary:
 			'Debounced autocomplete over /desktop-mode/v1/files/users/search. Emits os-user-pick { user } when a row is chosen. Dropdown anchors as position: fixed so it escapes overflow:auto ancestors.',
-		status: 'experimental',
-		since: '0.8.5',
+		status: 'stable',
 		props: [
 			{ name: 'placeholder', type: 'string', description: 'Input placeholder text.' },
 			{

--- a/src/ui/components/os-user-search/os-user-search.ts
+++ b/src/ui/components/os-user-search/os-user-search.ts
@@ -57,6 +57,19 @@ export class OsUserSearch extends Component {
 		events: [
 			{ name: 'os-user-pick', description: 'Emitted on pick. Detail: `{ user: SearchUser }`.' },
 		],
+		/*
+		 * Just the closed input. The dropdown only exists after a
+		 * debounced REST round-trip, and firing user searches from a
+		 * documentation pane on every keystroke is not something a
+		 * help screen should do on the reader's behalf — so the
+		 * example shows the resting state and the prose says what
+		 * happens next.
+		 */
+		example: html`
+			<os-user-search
+				placeholder="Search users to share with…"
+			></os-user-search>
+		`,
 	} as const;
 
 	private _timer: ReturnType< typeof setTimeout > | null = null;

--- a/src/ui/components/os-window-button/os-window-button.styles.ts
+++ b/src/ui/components/os-window-button/os-window-button.styles.ts
@@ -43,7 +43,22 @@ export const styles = css`
 		background-position: var( --os-ui-btn-bg-image-position, center );
 		color: var( --os-ui-btn-color, currentColor );
 		cursor: pointer;
-		transition: background-color 0.15s ease, color 0.15s ease;
+		transition: background-color 0.15s ease, color 0.15s ease,
+			transform 80ms ease;
+	}
+	/*
+	 * A title-bar control gets a squash rather than the kit's press
+	 * ring. The ring expands ten pixels past the button, and these sit
+	 * three abreast at the very edge of the window — the bloom would
+	 * spill onto its neighbours and off the title bar entirely.
+	 */
+	button:active {
+		transform: scale( 0.9 );
+	}
+	@media ( prefers-reduced-motion: reduce ) {
+		button:active {
+			transform: none;
+		}
 	}
 	button:hover {
 		color: var( --os-ui-btn-color-hover, currentColor );

--- a/src/ui/components/os-window-button/os-window-button.ts
+++ b/src/ui/components/os-window-button/os-window-button.ts
@@ -137,7 +137,6 @@ export class OsWindowButton extends Component {
 		summary:
 			'Chrome button used in native-window title bars. Built-in icons cover the standard controls (minimize, maximize, fullscreen, detach, close, menu). Focused/unfocused coloring is driven by --os-ui-btn-* CSS custom properties the window shell owns.',
 		status: 'stable',
-		since: '0.9.0',
 		props: [
 			{
 				name: 'icon',

--- a/src/ui/components/tags.ts
+++ b/src/ui/components/tags.ts
@@ -26,6 +26,7 @@ export const OS_COMPONENT_TAGS = [
 	'os-number-field',
 	'os-checkbox',
 	'os-checkbox-label',
+	'os-switch',
 	'os-toast',
 	'os-toast-container',
 	'os-tabs',

--- a/src/ui/core/help.ts
+++ b/src/ui/core/help.ts
@@ -60,10 +60,18 @@ export interface OsHelp {
 	title?: string;
 	/** One-paragraph summary. Keep short; examples carry the nuance. */
 	summary?: string;
-	/** Stability label. Defaults to `'stable'` when omitted. */
+	/**
+	 * Stability label. Defaults to `'stable'` when omitted.
+	 *
+	 * There is deliberately no `since` alongside this. A version
+	 * stamp is a version-history annotation, which `AGENTS.md` bans
+	 * in docs and comments for the same reason it does not belong
+	 * here: git is the changelog, and a descriptor's job is to say
+	 * what the component does now. When a change matters enough that
+	 * "since when?" is a real question for plugin authors, it is a
+	 * breaking change and wants a `docs/migration-*.md` note.
+	 */
 	status?: OsHelpStatus;
-	/** Semver the component first shipped in (e.g. `'0.9.0'`). */
-	since?: string;
 	props?: readonly OsHelpProp[];
 	slots?: readonly OsHelpSlot[];
 	parts?: readonly OsHelpPart[];

--- a/src/ui/core/help.ts
+++ b/src/ui/core/help.ts
@@ -73,6 +73,44 @@ export interface OsHelp {
 	 * Live example rendered inside the Help panel. Must be a plain
 	 * `html\`\`` template — the panel renders it into an isolated
 	 * container so the example can exercise the real component.
+	 *
+	 * **A `<script>` tag in here will never run.** The template is
+	 * compiled by assigning to a `<template>`'s `innerHTML`, and the
+	 * HTML fragment-parsing algorithm sets a script's *already
+	 * started* flag; the cloning steps then copy that flag to every
+	 * clone. The script is inert in the template and inert in the
+	 * rendered output. Use {@link OsHelp.exampleInit} instead.
 	 */
 	example?: TemplateResult;
+	/**
+	 * Imperative setup for the example, run after it is rendered.
+	 *
+	 * Half the kit takes its data through a JS **property** rather
+	 * than an attribute — `segments`, `data`, `columns`, `entries`,
+	 * `items`, `ratings`. Those components cannot be populated from
+	 * markup at all, so their examples rendered as an empty shell:
+	 * a table with no rows, a log with no lines, a breadcrumb with no
+	 * crumbs. This is the hook that fills them in.
+	 *
+	 * `root` is the example's own container, so a lookup is scoped to
+	 * this example rather than to the document — the panel renders one
+	 * example at a time, but a `document.getElementById()` in a shared
+	 * settings window is a collision waiting for the second one.
+	 *
+	 * ```ts
+	 * example: html`<os-crumb-chain removable></os-crumb-chain>`,
+	 * exampleInit: ( root ) => {
+	 *   const chain = root.querySelector( 'os-crumb-chain' );
+	 *   if ( chain ) {
+	 *     ( chain as OsCrumbChain ).segments = [ … ];
+	 *   }
+	 * },
+	 * ```
+	 *
+	 * Must be **idempotent**: the panel repaints on every keystroke in
+	 * the filter box, and re-runs this each time against the same
+	 * nodes. Assigning properties is naturally safe; appending
+	 * children or adding listeners is not.
+	 */
+	exampleInit?: ( root: HTMLElement ) => void;
 }

--- a/src/ui/holo.ts
+++ b/src/ui/holo.ts
@@ -1,0 +1,620 @@
+/**
+ * os-ui — the holographic layer.
+ *
+ * The brand ships five mesh gradients and one instruction about them:
+ * *"meshes reserved for hero surfaces."* This module is how a control
+ * gets to be one, without every component reinventing what
+ * "holographic" means and drifting from the others.
+ *
+ * ## What holographic means here
+ *
+ * Not a skin. A **moment**. A control paints the mesh when it is on,
+ * selected, primary or filled — the one instant it speaks for the
+ * brand — and wears ordinary Obsidian the rest of the time. A panel
+ * where every surface is iridescent has no identity moments left to
+ * spend, which is the failure mode this module is shaped to avoid.
+ *
+ * Three treatments, in ascending loudness:
+ *
+ * 1. **Edge** ({@link holoEdge}) — an iridescent hairline around an
+ *    otherwise ordinary control. Costs nothing at rest, lights up on
+ *    hover and focus. This is the one most controls get.
+ * 2. **Sheen** ({@link holoSheen}) — a 10%-alpha film of the mesh's
+ *    own hues laid over the existing surface. The hover state for
+ *    something that is not yet lit.
+ * 3. **Fill** ({@link holoFill}) — the mesh itself, at full strength,
+ *    with Void ink on top. Reserved for the on/selected/primary state.
+ *
+ * ## Why the mesh is a gradient stack and not an SVG
+ *
+ * `background-position` can slide a gradient. That slide *is* the
+ * holographic effect — a foil card shifting hue as you tilt it — and
+ * it is why {@link holoFill} oversizes the mesh to 220% and moves it
+ * under the pointer. A `url()` to the brand's SVG could not do that,
+ * would rasterise one flat corner of a 1440×960 artboard onto a 44 px
+ * switch track, and would cost a request. The meshes are transcribed
+ * stop-for-stop into `--os-mesh-*` in `assets/css/variables.css`.
+ *
+ * ## The alias discipline
+ *
+ * Every fragment here reads its public token into a private `--_holo-*`
+ * alias on `:host`, never declaring the public name. A custom property
+ * declared on `:host` matches the host ELEMENT and beats anything the
+ * element would INHERIT — so declaring `--os-ui-holo-fill` there would
+ * make the palette's and every desktop theme's declaration of that name
+ * dead on arrival. See `AGENTS.md`, "Never declare a themeable token on
+ * a component's `:host`", and its guard in
+ * `tests/vitest/component-token-reachability.test.ts`.
+ *
+ * ## Using it
+ *
+ * ```ts
+ * import { css } from '../../core';
+ * import { holoTokens, holoEdge, holoFill } from '../../holo';
+ *
+ * export const styles = css`
+ *   ${ holoTokens }
+ *   ${ holoEdge }
+ *   ${ holoFill }
+ *   button { ... }
+ *   button:focus-visible { box-shadow: var( --_holo-focus ); }
+ * `;
+ * ```
+ *
+ * `holoTokens` is a prerequisite for the others — it declares the
+ * aliases they read. Include it once per component.
+ */
+
+import { css } from './core';
+
+/**
+ * Fallback Holomesh, for the moment `variables.css` has not loaded.
+ *
+ * Three stops rather than the nine-layer transcription: this is a
+ * floor, not the artwork, and it is inlined into every component that
+ * takes a holographic fill. The full mesh is one declaration away in
+ * `--os-mesh-holo`; what matters here is that a control with no
+ * stylesheet is still recognisably lit rather than transparent.
+ */
+const HOLO_FALLBACK =
+	'linear-gradient( 124deg, #afa2e8 0%, #f5a8ea 46%, #8ee9f7 100% )';
+
+/**
+ * Private aliases the rest of this module reads.
+ *
+ * Include this in every component that uses any other fragment here.
+ * It declares nothing themeable — only `--_holo-*` names, which are
+ * component-private by convention and invisible to the palette.
+ */
+export const holoTokens = css`
+	:host {
+		--_holo-fill: var( --os-ui-holo-fill, ${ HOLO_FALLBACK } );
+		--_holo-ink: var( --os-ui-holo-ink, #0c0b0f );
+		--_holo-sheen: var(
+			--os-ui-holo-sheen,
+			linear-gradient(
+				124deg,
+				rgba( 159, 214, 255, 0.1 ) 0%,
+				rgba( 236, 155, 255, 0.12 ) 34%,
+				rgba( 242, 82, 252, 0.1 ) 58%,
+				rgba( 147, 240, 198, 0.09 ) 100%
+			)
+		);
+		--_holo-edge: var(
+			--os-ui-holo-edge,
+			linear-gradient(
+				124deg,
+				rgba( 154, 242, 255, 0.7 ) 0%,
+				rgba( 236, 155, 255, 0.85 ) 38%,
+				rgba( 242, 82, 252, 0.7 ) 62%,
+				rgba( 159, 152, 255, 0.6 ) 100%
+			)
+		);
+		--_holo-edge-quiet: var(
+			--os-ui-holo-edge-quiet,
+			linear-gradient(
+				124deg,
+				rgba( 154, 242, 255, 0.22 ) 0%,
+				rgba( 236, 155, 255, 0.28 ) 38%,
+				rgba( 242, 82, 252, 0.22 ) 62%,
+				rgba( 159, 152, 255, 0.2 ) 100%
+			)
+		);
+		--_holo-glow: var(
+			--os-ui-holo-glow,
+			0 0 0 1px rgba( 242, 82, 252, 0.28 ), 0 2px 10px rgba( 242, 82, 252, 0.22 )
+		);
+		--_holo-glow-strong: var(
+			--os-ui-holo-glow-strong,
+			0 0 0 1px rgba( 242, 82, 252, 0.42 ), 0 4px 18px rgba( 242, 82, 252, 0.38 ),
+				0 1px 3px rgba( 12, 11, 15, 0.6 )
+		);
+		--_holo-track: var( --os-ui-holo-track, rgba( 12, 11, 15, 0.55 ) );
+		/*
+		 * One focus ring for the whole kit. Three layers, and each
+		 * earns its place: a Void spacer so the ring never touches the
+		 * control it is describing, the Pulse ring itself, and a soft
+		 * bloom so the ring survives landing on a bright mesh — where a
+		 * flat 2 px line would simply vanish into the pink.
+		 */
+		--_holo-focus: var(
+			--os-ui-focus-ring,
+			0 0 0 2px rgba( 12, 11, 15, 0.9 ), 0 0 0 4px #f252fc,
+				0 0 12px 2px rgba( 242, 82, 252, 0.45 )
+		);
+		/*
+		 * The field ring. A text input already has a border to
+		 * thicken and it lives in a column of siblings, so the target
+		 * ring above — built to survive a bright mesh — reads as an
+		 * alarm on a settings form. This one tightens the field's own
+		 * edge to Pulse and adds a soft halo outside it.
+		 */
+		--_holo-focus-field: var(
+			--os-ui-focus-ring-field,
+			0 0 0 1px #f252fc, 0 0 0 4px rgba( 242, 82, 252, 0.18 )
+		);
+		--_holo-t: var( --os-ui-holo-transition, 220ms );
+	}
+`;
+
+/**
+ * `.os-holo-fill` — the mesh itself.
+ *
+ * The surface an "on" control paints. Oversized to 220% and parked
+ * off-centre so there is somewhere to travel to: `:hover` slides the
+ * mesh across the box, `:active` pushes it further, and the eye reads
+ * the hue shift as a tilt rather than as a colour change.
+ *
+ * Text and glyphs inside inherit `--_holo-ink` (Void) — see the note
+ * on that token; every mesh in the brand is a light surface and
+ * Starlight on it is unreadable.
+ */
+export const holoFill = css`
+	.os-holo-fill {
+		background-color: transparent;
+		background-image: var( --_holo-fill );
+		background-size: 220% 220%;
+		background-position: 22% 28%;
+		background-repeat: no-repeat;
+		color: var( --_holo-ink );
+		transition: background-position var( --_holo-t ) ease,
+			box-shadow var( --_holo-t ) ease, filter var( --_holo-t ) ease;
+	}
+
+	.os-holo-fill:hover {
+		background-position: 74% 66%;
+	}
+
+	.os-holo-fill:active {
+		background-position: 88% 82%;
+		filter: brightness( 0.94 );
+	}
+
+	/*
+	 * The tilt is the whole effect, so when motion is unwelcome the
+	 * mesh simply stops moving — it does not stop being a mesh. A
+	 * control that lost its fill under reduced-motion would lose its
+	 * state, not just its animation.
+	 */
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-holo-fill {
+			transition-duration: 1ms;
+		}
+
+		.os-holo-fill:hover,
+		.os-holo-fill:active {
+			background-position: 22% 28%;
+		}
+	}
+`;
+
+/**
+ * `.os-holo-sheen` — the hover film for a control that is NOT lit.
+ *
+ * Paints `--_holo-sheen` in a `::before` above the surface and below
+ * the content, so it tints whatever background the control already
+ * has instead of replacing it. Fades in on `:hover` and on
+ * `:focus-visible`, and drifts a little while it is there.
+ *
+ * The host needs `position: relative` (or any non-`static` position)
+ * and content that establishes its own stacking above `::before`;
+ * every consumer in the kit already does.
+ */
+export const holoSheen = css`
+	.os-holo-sheen {
+		position: relative;
+		isolation: isolate;
+	}
+
+	.os-holo-sheen::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		border-radius: inherit;
+		background-image: var( --_holo-sheen );
+		background-size: 200% 200%;
+		background-position: 20% 30%;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity var( --_holo-t ) ease,
+			background-position var( --_holo-t ) ease;
+	}
+
+	.os-holo-sheen:hover::before,
+	.os-holo-sheen:focus-visible::before {
+		opacity: 1;
+		background-position: 76% 68%;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-holo-sheen::before {
+			transition-duration: 1ms;
+		}
+
+		.os-holo-sheen:hover::before,
+		.os-holo-sheen:focus-visible::before {
+			background-position: 20% 30%;
+		}
+	}
+`;
+
+/**
+ * `.os-holo-edge` — the iridescent hairline.
+ *
+ * A gradient border, which CSS has no direct way to draw: `border-color`
+ * takes a colour and `border-image` throws away `border-radius`. The
+ * standard workaround, and the one used here, is a `::after` filled
+ * with the gradient and masked to just its own padding ring — two
+ * mask layers composited with `exclude`, so the middle is punched out
+ * and only a 1 px frame survives, corners included.
+ *
+ * At rest the edge is `--_holo-edge-quiet` at ~40% and reads as a
+ * slightly livelier border. On hover and focus it goes to the full
+ * `--_holo-edge`. Add `.is-lit` to hold it at full strength for a
+ * control that is permanently in its holographic state.
+ */
+export const holoEdge = css`
+	.os-holo-edge {
+		position: relative;
+	}
+
+	.os-holo-edge::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		padding: 1px;
+		background-image: var( --_holo-edge-quiet );
+		opacity: 0;
+		pointer-events: none;
+		/*
+		 * Two masks: one clipped to the content box, one covering the
+		 * whole element. "exclude" keeps the difference — the 1 px
+		 * padding ring — which is the border. The -webkit- pair comes
+		 * first for Safari, which still ships the prefixed property and
+		 * spells the operation "xor" rather than "exclude".
+		 */
+		-webkit-mask: linear-gradient( #000 0 0 ) content-box,
+			linear-gradient( #000 0 0 );
+		-webkit-mask-composite: xor;
+		mask: linear-gradient( #000 0 0 ) content-box, linear-gradient( #000 0 0 );
+		mask-composite: exclude;
+		transition: opacity var( --_holo-t ) ease;
+	}
+
+	.os-holo-edge:hover::after,
+	.os-holo-edge:focus-visible::after {
+		background-image: var( --_holo-edge );
+		opacity: 1;
+	}
+
+	.os-holo-edge.is-lit::after {
+		background-image: var( --_holo-edge );
+		opacity: 1;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-holo-edge::after {
+			transition-duration: 1ms;
+		}
+	}
+`;
+
+/**
+ * Field chrome — the interaction layer every text-like control shares.
+ *
+ * Bare element selectors, which would be reckless in a global
+ * stylesheet and are exactly right inside a shadow root: the only
+ * `input`, `select` or `textarea` this can reach is the component's
+ * own. That is what lets one fragment give the whole form family a
+ * single hover, a single focus ring and a single transition duration
+ * without every component re-deciding them.
+ *
+ * It deliberately sets no padding, radius, background or font. Those
+ * are each component's own shape — a `<os-textarea>` is not a
+ * `<os-select>` — and a shared fragment that reached for them would
+ * turn every future tweak into a negotiation.
+ *
+ * Checkboxes and radios are excluded throughout: they are painted by
+ * {@link holoCheck}, which gives them the target ring rather than the
+ * field one, and a hover that moves their border instead of their
+ * background.
+ *
+ * ## Why the exclusions are wrapped in `:where()`
+ *
+ * `:not()` carries the specificity of its argument, so the honest
+ * spelling — `input:not([type='checkbox']):not([type='radio']):focus`
+ * — weighs (0,3,1). That is heavier than
+ * `input[aria-invalid='true']:focus` at (0,2,1), which means a shared
+ * fragment would quietly outrank every component's own error ring and
+ * an invalid field would focus in Pulse instead of red. `:where()`
+ * contributes nothing, so the same selector lands at (0,1,1) and every
+ * component keeps the last word about its own states.
+ */
+export const holoField = css`
+	input:where( :not( [ type='checkbox' ] ):not( [ type='radio' ] ) ),
+	select,
+	textarea {
+		transition: background-color var( --_holo-t ) ease,
+			border-color var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease;
+	}
+
+	input:where( :not( [ type='checkbox' ] ):not( [ type='radio' ] ) ):hover:not(
+			:disabled
+		),
+	select:hover:not( :disabled ),
+	textarea:hover:not( :disabled ) {
+		border-color: var( --os-ui-border-strong, #8c8f94 );
+	}
+
+	input:where( :not( [ type='checkbox' ] ):not( [ type='radio' ] ) ):focus,
+	input:where( :not( [ type='checkbox' ] ):not( [ type='radio' ] ) ):focus-visible,
+	select:focus,
+	select:focus-visible,
+	textarea:focus,
+	textarea:focus-visible {
+		outline: none;
+		border-color: var( --os-ui-accent, #2271b1 );
+		box-shadow: var( --_holo-focus-field );
+	}
+
+	/*
+	 * Placeholders go one step further down the Shade ramp than muted
+	 * body text. At the same value they compete with a real entry and
+	 * the field reads as filled when it is empty.
+	 */
+	input::placeholder,
+	textarea::placeholder {
+		color: var( --os-ui-fg-faint, #8c8f94 );
+		opacity: 1;
+	}
+
+	/*
+	 * Selection inside a field. Left to the browser it is the OS blue,
+	 * which is the one colour on the station that belongs to nothing
+	 * on it.
+	 */
+	input::selection,
+	textarea::selection {
+		background: var( --os-ui-accent-soft, rgba( 34, 113, 177, 0.2 ) );
+		color: var( --os-ui-fg, #1d2327 );
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		input:where( :not( [ type='checkbox' ] ):not( [ type='radio' ] ) ),
+		select,
+		textarea {
+			transition-duration: 1ms;
+		}
+	}
+`;
+
+/**
+ * The checkbox and radio paint.
+ *
+ * Shared because two components already draw this box —
+ * `<os-checkbox>` and `<os-checkbox-label>` — and every picker in the
+ * kit that grows a multi-select row will draw a third. One fragment
+ * means the tick is the same tick everywhere.
+ *
+ * ## Why `accent-color` had to go
+ *
+ * `accent-color` is the right answer for a native checkbox and the
+ * wrong one here: it takes a *colour*, and the checked state in this
+ * kit is a *mesh*. There is no way to hand a gradient to the native
+ * control, so the box is repainted from scratch — `appearance: none`,
+ * a border, the mesh as a background, and the tick drawn as two
+ * borders of a rotated box.
+ *
+ * The tick is CSS rather than an inline SVG on purpose: it inherits
+ * `--_holo-ink`, so it stays Void on the mesh and follows a theme that
+ * re-points the ink without anyone having to re-encode a data URI.
+ *
+ * `:indeterminate` is styled too, even though no component in the kit
+ * sets it yet — it is one line, it is what a "select all" header
+ * checkbox will need, and an unstyled indeterminate box under
+ * `appearance: none` renders as an empty one, which is a silent lie
+ * about the state.
+ */
+export const holoCheck = css`
+	input[ type='checkbox' ],
+	input[ type='radio' ] {
+		appearance: none;
+		-webkit-appearance: none;
+		position: relative;
+		flex: 0 0 auto;
+		box-sizing: border-box;
+		width: 16px;
+		height: 16px;
+		margin: 0;
+		padding: 0;
+		border: 1px solid var( --os-ui-border-strong, #8c8f94 );
+		border-radius: 4px;
+		background-color: var( --_holo-track );
+		background-image: none;
+		background-repeat: no-repeat;
+		cursor: inherit;
+		transition: background-position var( --_holo-t ) ease,
+			border-color var( --_holo-t ) ease, box-shadow var( --_holo-t ) ease;
+	}
+
+	input[ type='radio' ] {
+		border-radius: 50%;
+	}
+
+	input[ type='checkbox' ]:hover:not( :disabled ),
+	input[ type='radio' ]:hover:not( :disabled ) {
+		border-color: var( --os-ui-accent, #2271b1 );
+	}
+
+	input[ type='checkbox' ]:focus-visible,
+	input[ type='radio' ]:focus-visible {
+		outline: none;
+		box-shadow: var( --_holo-focus );
+	}
+
+	/* Checked is the identity moment: the box fills with the mesh. */
+	input[ type='checkbox' ]:checked,
+	input[ type='checkbox' ]:indeterminate,
+	input[ type='radio' ]:checked {
+		border-color: transparent;
+		background-image: var( --_holo-fill );
+		background-size: 220% 220%;
+		background-position: 22% 28%;
+		box-shadow: var( --_holo-glow );
+	}
+
+	input[ type='checkbox' ]:checked:hover:not( :disabled ),
+	input[ type='radio' ]:checked:hover:not( :disabled ) {
+		background-position: 74% 66%;
+	}
+
+	input[ type='checkbox' ]:checked:focus-visible,
+	input[ type='radio' ]:checked:focus-visible {
+		box-shadow: var( --_holo-focus );
+	}
+
+	/*
+	 * The tick. Two borders of a box, rotated — the oldest trick in
+	 * CSS and still the only one that scales with the font and takes
+	 * its colour from a custom property.
+	 */
+	input[ type='checkbox' ]:checked::after {
+		content: '';
+		position: absolute;
+		inset-inline-start: 50%;
+		top: 46%;
+		width: 3.5px;
+		height: 7.5px;
+		border: solid var( --_holo-ink );
+		border-width: 0 2px 2px 0;
+		transform: translate( -50%, -50% ) rotate( 45deg );
+		animation: os-holo-tick 180ms cubic-bezier( 0.3, 1.4, 0.6, 1 );
+	}
+
+	/* Indeterminate: a bar, not a tick. Same ink, same box. */
+	input[ type='checkbox' ]:indeterminate::after {
+		content: '';
+		position: absolute;
+		inset-inline-start: 50%;
+		top: 50%;
+		width: 8px;
+		height: 2px;
+		border: 0;
+		border-radius: 1px;
+		background: var( --_holo-ink );
+		transform: translate( -50%, -50% );
+	}
+
+	input[ type='radio' ]:checked::after {
+		content: '';
+		position: absolute;
+		inset-inline-start: 50%;
+		top: 50%;
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var( --_holo-ink );
+		transform: translate( -50%, -50% );
+		animation: os-holo-tick 180ms cubic-bezier( 0.3, 1.4, 0.6, 1 );
+	}
+
+	input[ type='checkbox' ]:disabled,
+	input[ type='radio' ]:disabled {
+		cursor: not-allowed;
+	}
+
+	/*
+	 * The tick lands rather than appears. 180ms with a slight
+	 * overshoot, which is short enough to feel like a response to the
+	 * click and not like an animation being played at you.
+	 */
+	@keyframes os-holo-tick {
+		from {
+			opacity: 0;
+			transform: translate( -50%, -50% ) rotate( 45deg ) scale( 0.4 );
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		input[ type='checkbox' ]:checked::after,
+		input[ type='radio' ]:checked::after {
+			animation: none;
+		}
+	}
+`;
+
+/**
+ * `@keyframes os-holo-drift` plus the `.os-holo-alive` opt-in.
+ *
+ * A slow, always-running traverse of the mesh, for the handful of surfaces
+ * that should look powered rather than merely painted: a busy button,
+ * an indeterminate progress bar, a spinner. Twelve seconds, so it
+ * reads as ambient rather than as an animation demanding attention,
+ * and off entirely under `prefers-reduced-motion`.
+ */
+export const holoDrift = css`
+	@keyframes os-holo-drift {
+		0% {
+			background-position: 16% 26%;
+		}
+
+		50% {
+			background-position: 84% 74%;
+		}
+
+		100% {
+			background-position: 16% 26%;
+		}
+	}
+
+	.os-holo-alive {
+		animation: os-holo-drift 12s ease-in-out infinite;
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-holo-alive {
+			animation: none;
+		}
+	}
+`;
+
+/**
+ * Every fragment above, in dependency order.
+ *
+ * Convenience for a component that wants the whole vocabulary. The
+ * cost of an unused fragment is a few hundred bytes of text in one
+ * constructable stylesheet, shared by every instance of that
+ * component — cheap enough that reaching for this instead of picking
+ * fragments is fine unless the component is a hot path.
+ */
+export const holo = css`
+	${ holoTokens }
+	${ holoFill }
+	${ holoSheen }
+	${ holoEdge }
+	${ holoField }
+	${ holoCheck }
+	${ holoDrift }
+`;

--- a/src/ui/holo.ts
+++ b/src/ui/holo.ts
@@ -14,7 +14,7 @@
  * where every surface is iridescent has no identity moments left to
  * spend, which is the failure mode this module is shaped to avoid.
  *
- * Three treatments, in ascending loudness:
+ * Three surface treatments, in ascending loudness:
  *
  * 1. **Edge** ({@link holoEdge}) — an iridescent hairline around an
  *    otherwise ordinary control. Costs nothing at rest, lights up on
@@ -24,6 +24,22 @@
  *    something that is not yet lit.
  * 3. **Fill** ({@link holoFill}) — the mesh itself, at full strength,
  *    with Void ink on top. Reserved for the on/selected/primary state.
+ *
+ * …and four motions, which are what make the surfaces read as foil
+ * rather than as paint:
+ *
+ * - **Glint** ({@link holoGlint}) — a specular band crossing once on
+ *   hover. The single most "holographic" thing here.
+ * - **Ring** ({@link holoRing}) — a press response that expands and
+ *   fades, so a click reads as received before its result paints.
+ * - **Shimmer** ({@link holoShimmer}) — the mesh travelling, for waits
+ *   of unknown length.
+ * - **Enter** ({@link holoEnter}) — scale-and-fade arrival for menus,
+ *   toasts and dialogs.
+ *
+ * Every one of them stops under `prefers-reduced-motion`, and the
+ * timings all come from `--os-ui-motion-*` / `--os-ui-ease-*` so a
+ * panel of controls moves as one surface.
  *
  * ## Why the mesh is a gradient stack and not an SVG
  *
@@ -129,7 +145,15 @@ export const holoTokens = css`
 			0 0 0 1px rgba( 242, 82, 252, 0.42 ), 0 4px 18px rgba( 242, 82, 252, 0.38 ),
 				0 1px 3px rgba( 12, 11, 15, 0.6 )
 		);
-		--_holo-track: var( --os-ui-holo-track, rgba( 12, 11, 15, 0.55 ) );
+		--_holo-track: var( --os-ui-holo-track, rgba( 255, 251, 255, 0.16 ) );
+		--_holo-track-edge: var( --os-ui-holo-track-edge, #8c8f94 );
+		/*
+		 * The press ring's colour. The DIM Pulse, not Pulse: this one
+		 * expands to ten pixels past the control and is on screen for
+		 * a third of a second, which is exactly the "spread rather
+		 * than stated" case the dim exists for.
+		 */
+		--_holo-ring-color: var( --os-ui-accent-dim, #2271b1 );
 		/*
 		 * One focus ring for the whole kit. Three layers, and each
 		 * earns its place: a Void spacer so the ring never touches the
@@ -154,6 +178,15 @@ export const holoTokens = css`
 			0 0 0 1px #f252fc, 0 0 0 4px rgba( 242, 82, 252, 0.18 )
 		);
 		--_holo-t: var( --os-ui-holo-transition, 220ms );
+		--_holo-t-fast: var( --os-ui-motion-fast, 140ms );
+		--_holo-t-slow: var( --os-ui-motion-slow, 340ms );
+		--_holo-t-ambient: var( --os-ui-motion-ambient, 12s );
+		--_holo-spring: var(
+			--os-ui-ease-spring,
+			cubic-bezier( 0.32, 1.5, 0.55, 1 )
+		);
+		--_holo-ease: var( --os-ui-ease-out, cubic-bezier( 0.22, 0.9, 0.28, 1 ) );
+		--_holo-loop: var( --os-ui-ease-loop, cubic-bezier( 0.45, 0, 0.55, 1 ) );
 	}
 `;
 
@@ -322,6 +355,257 @@ export const holoEdge = css`
 `;
 
 /**
+ * ## A note on the pseudo-element budget
+ *
+ * An element has exactly two of these to spend, and this module wants
+ * four effects. {@link holoSheen} takes `::before` and {@link holoEdge}
+ * takes `::after`, which is already the whole budget for a control
+ * wearing both — as `<os-button>` does.
+ *
+ * So the two motion fragments below are **element-based** instead: the
+ * component stamps a `<span>` and the fragment styles it. That costs
+ * one node and buys free composition — a button can carry the film,
+ * the hairline, the glint and the press ring at once, and no future
+ * fragment has to negotiate for a pseudo that is already taken.
+ *
+ * Both are driven from the PARENT's state via the child combinator
+ * (`:active > .os-holo-ring`). The combinator is load-bearing: `:active`
+ * matches an activated element *and every ancestor of it*, so
+ * `:active .os-holo-ring` would fire every ring on the page the moment
+ * anything inside the panel was pressed.
+ */
+
+/**
+ * `.os-holo-glint` — the specular pass.
+ *
+ * A narrow band of light that crosses the surface once, on hover. This
+ * is the gesture people mean by "holographic" far more than any static
+ * gradient is: real foil does not glow, it *catches* — a highlight
+ * travels across it as the angle changes, and is gone.
+ *
+ * Deliberately once-per-hover rather than looping. A loop is a progress
+ * indicator; this is a response. The difference is whether the surface
+ * is telling you something is happening or acknowledging that you
+ * arrived.
+ *
+ * Stamp it as a child of the control:
+ *
+ * ```html
+ * <button class="os-holo-edge"><span class="os-holo-glint"></span>…</button>
+ * ```
+ */
+export const holoGlint = css`
+	.os-holo-glint {
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		/* Clips the band to the control's shape. On the span rather
+		   than the control, so the control keeps its own overflow. */
+		overflow: hidden;
+		pointer-events: none;
+	}
+
+	.os-holo-glint::before {
+		content: '';
+		position: absolute;
+		/*
+		 * Oversized and rotated, so the band is a plain rectangle that
+		 * happens to cross the box diagonally. Translating a clipped
+		 * rectangle is a composited move; animating gradient stops
+		 * would repaint every frame.
+		 */
+		top: -60%;
+		bottom: -60%;
+		width: 45%;
+		inset-inline-start: -60%;
+		background: linear-gradient(
+			90deg,
+			transparent 0%,
+			rgba( 255, 251, 255, 0.14 ) 45%,
+			rgba( 255, 251, 255, 0.22 ) 50%,
+			rgba( 255, 251, 255, 0.14 ) 55%,
+			transparent 100%
+		);
+		transform: rotate( 18deg ) translateX( 0 );
+		opacity: 0;
+	}
+
+	/*
+	 * Two forms, because the glint is stamped in two places.
+	 *
+	 * Inside a control (a button, a key) it is a child of that
+	 * element, and the "hover >" form reaches it. Directly in a
+	 * component's shadow root (a card, a tile) its parent is the
+	 * shadow ROOT, which no selector matches — that form finds nothing
+	 * there. The :host( :hover ) > form is the one that does, and the
+	 * two are mutually exclusive in practice, so both can always be
+	 * present.
+	 */
+	:hover > .os-holo-glint::before,
+	:focus-visible > .os-holo-glint::before,
+	:host( :hover ) > .os-holo-glint::before,
+	:host( :focus-visible ) > .os-holo-glint::before {
+		animation: os-holo-glint var( --_holo-t-slow ) var( --_holo-ease );
+	}
+
+	@keyframes os-holo-glint {
+		0% {
+			opacity: 0;
+			transform: rotate( 18deg ) translateX( 0 );
+		}
+
+		15% {
+			opacity: 1;
+		}
+
+		85% {
+			opacity: 1;
+		}
+
+		100% {
+			opacity: 0;
+			/*
+			 * Far enough that the band has cleared a very wide box.
+			 * Viewport units rather than a percentage of the element:
+			 * a percentage translate on a 45%-wide band means one thing
+			 * on a 40px chip and another on a 900px row, and the chip's
+			 * glint would finish before it was visible.
+			 */
+			transform: rotate( 18deg ) translateX( 240vw );
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:hover > .os-holo-glint::before,
+		:focus-visible > .os-holo-glint::before,
+		:host( :hover ) > .os-holo-glint::before,
+		:host( :focus-visible ) > .os-holo-glint::before {
+			animation: none;
+		}
+	}
+`;
+
+/**
+ * `.os-holo-ring` — the press response.
+ *
+ * A ring that expands out of the control and fades, on `:active`.
+ * Centred rather than pointer-anchored: anchoring needs a JS listener
+ * on every control, and at the ~40px targets in this kit nobody can
+ * see where it started anyway.
+ *
+ * The point is latency, not decoration. A press that only changes
+ * colour reads as either instant or broken; a press that *moves* reads
+ * as received, which is worth the ~100ms before whatever it triggered
+ * actually paints.
+ */
+export const holoRing = css`
+	.os-holo-ring {
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		box-shadow: 0 0 0 0 var( --_holo-ring-color );
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	/* Both forms, for the same reason as the glint above. */
+	:active:not( :disabled ) > .os-holo-ring,
+	:host( :active:not( [ disabled ] ) ) > .os-holo-ring {
+		animation: os-holo-ring var( --_holo-t-slow ) var( --_holo-ease );
+	}
+
+	@keyframes os-holo-ring {
+		0% {
+			opacity: 0.45;
+			box-shadow: 0 0 0 0 var( --_holo-ring-color );
+		}
+
+		100% {
+			opacity: 0;
+			box-shadow: 0 0 0 10px transparent;
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		:active:not( :disabled ) > .os-holo-ring,
+		:host( :active:not( [ disabled ] ) ) > .os-holo-ring {
+			animation: none;
+		}
+	}
+`;
+
+/**
+ * `.os-holo-shimmer` — the loading pass.
+ *
+ * The mesh, oversized and travelling, for anything whose duration is
+ * unknown: an indeterminate progress bar, a skeleton row, a table
+ * still fetching. It replaces the usual grey-bar-sliding-right-forever,
+ * and it earns the swap by carrying information the grey bar does not
+ * — the station's own colour, so "waiting" looks like part of the
+ * product rather than like a gap in it.
+ *
+ * `--os-ui-motion-ambient` slow by default. Fast shimmer reads as
+ * urgency, and the thing about an indeterminate wait is that nobody
+ * knows whether it is urgent.
+ */
+export const holoShimmer = css`
+	.os-holo-shimmer {
+		background-image: var( --_holo-fill );
+		background-size: 300% 300%;
+		background-repeat: no-repeat;
+		animation: os-holo-shimmer 2.4s var( --_holo-loop ) infinite;
+	}
+
+	@keyframes os-holo-shimmer {
+		0% {
+			background-position: 0% 50%;
+		}
+
+		100% {
+			background-position: 100% 50%;
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-holo-shimmer {
+			animation: none;
+			background-position: 30% 50%;
+		}
+	}
+`;
+
+/**
+ * `.os-holo-enter` — the arrival.
+ *
+ * Scale-and-fade from 96%, for anything that appears rather than
+ * changes: a menu, a flyout, a toast, a dialog. Short and on the
+ * spring curve, so it lands rather than drifts.
+ *
+ * `transform-origin` is left to the consumer — an anchored popover
+ * should grow from its anchor, and only the component positioning it
+ * knows where that is. The default is `center`, which is right for a
+ * dialog and wrong for a flyout.
+ */
+export const holoEnter = css`
+	.os-holo-enter {
+		animation: os-holo-enter var( --_holo-t ) var( --_holo-spring );
+	}
+
+	@keyframes os-holo-enter {
+		from {
+			opacity: 0;
+			transform: scale( 0.96 );
+		}
+	}
+
+	@media ( prefers-reduced-motion: reduce ) {
+		.os-holo-enter {
+			animation: none;
+		}
+	}
+`;
+
+/**
  * Field chrome — the interaction layer every text-like control shares.
  *
  * Bare element selectors, which would be reckless in a global
@@ -391,14 +675,23 @@ export const holoField = css`
 	}
 
 	/*
-	 * Selection inside a field. Left to the browser it is the OS blue,
-	 * which is the one colour on the station that belongs to nothing
-	 * on it.
+	 * Selection inside a field.
+	 *
+	 * A shadow root does not inherit the document's ::selection rule,
+	 * so the shell-wide one in desktop.css cannot reach in here — this
+	 * has to be restated, and it reads the same two tokens so the two
+	 * cannot drift.
+	 *
+	 * It used to read --os-ui-accent-soft, which is a 14% wash meant
+	 * for a hover tint. As a selection it was ~1.2:1 against the field
+	 * behind it: technically present, effectively invisible. Both
+	 * halves are set, because leaving the text colour to the UA is how
+	 * a selection ends up as black-on-violet.
 	 */
 	input::selection,
 	textarea::selection {
-		background: var( --os-ui-accent-soft, rgba( 34, 113, 177, 0.2 ) );
-		color: var( --os-ui-fg, #1d2327 );
+		background: var( --os-ui-selection-bg, rgba( 159, 152, 255, 0.6 ) );
+		color: var( --os-ui-selection-fg, #fffbff );
 	}
 
 	@media ( prefers-reduced-motion: reduce ) {
@@ -449,7 +742,14 @@ export const holoCheck = css`
 		height: 16px;
 		margin: 0;
 		padding: 0;
-		border: 1px solid var( --os-ui-border-strong, #8c8f94 );
+		/*
+		 * The unchecked box's boundary carries the whole control: an
+		 * empty checkbox IS its outline. --_holo-track-edge rather
+		 * than --os-ui-border-strong because the latter is Silver, at
+		 * 2.03:1 against Obsidian — under the 3:1 WCAG 1.4.11 asks of
+		 * a control boundary, and visibly so on a dark panel.
+		 */
+		border: 1px solid var( --_holo-track-edge );
 		border-radius: 4px;
 		background-color: var( --_holo-track );
 		background-image: none;
@@ -590,7 +890,7 @@ export const holoDrift = css`
 	}
 
 	.os-holo-alive {
-		animation: os-holo-drift 12s ease-in-out infinite;
+		animation: os-holo-drift var( --_holo-t-ambient ) var( --_holo-loop ) infinite;
 	}
 
 	@media ( prefers-reduced-motion: reduce ) {
@@ -614,6 +914,10 @@ export const holo = css`
 	${ holoFill }
 	${ holoSheen }
 	${ holoEdge }
+	${ holoGlint }
+	${ holoRing }
+	${ holoShimmer }
+	${ holoEnter }
 	${ holoField }
 	${ holoCheck }
 	${ holoDrift }

--- a/tests/vitest/css-template-hygiene.test.ts
+++ b/tests/vitest/css-template-hygiene.test.ts
@@ -1,0 +1,126 @@
+/**
+ * A backtick inside a `css``` template is a parse error.
+ *
+ * `css``` is a JS template literal, so a backtick anywhere in it —
+ * including inside a `/* … *\/` CSS comment — closes the template
+ * early. What follows is then parsed as JavaScript, and the error the
+ * toolchain reports is "Expected a semicolon or an implicit semicolon
+ * after a statement", pointing at prose. It is a five-second fix once
+ * you know, and a genuinely baffling one until you do.
+ *
+ * The build does catch it. This test exists because the build's message
+ * does not say what is wrong, and because the habit that causes it —
+ * writing `--_drag` or `::before` in backticks, the way every other
+ * comment in this codebase correctly does — is a good habit everywhere
+ * except here.
+ *
+ * The scan is textual rather than AST-based on purpose: a file with
+ * this defect cannot be parsed, so anything that needed to parse it
+ * first would report nothing at all.
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ROOT = resolve( __dirname, '../..' );
+const UI = resolve( ROOT, 'src/ui' );
+
+/** Every `.ts` under `src/ui`, recursively. */
+function walk( dir: string ): string[] {
+	return readdirSync( dir ).flatMap( ( name ) => {
+		const path = join( dir, name );
+		if ( statSync( path ).isDirectory() ) {
+			return walk( path );
+		}
+		return path.endsWith( '.ts' ) && ! path.endsWith( '.test.ts' )
+			? [ path ]
+			: [];
+	} );
+}
+
+/**
+ * Line numbers of backticks that fall inside a `css``` template.
+ *
+ * Walks the file once, tracking whether we are inside a template that
+ * was opened by `css`. The first backtick after that opener closes it,
+ * so any backtick found while inside IS the bug — there is no
+ * legitimate nested-backtick case, and an escaped one (`\``) is
+ * skipped rather than reported.
+ */
+function offendingLines( src: string ): number[] {
+	const out: number[] = [];
+	let i = src.indexOf( 'css`' );
+	while ( i !== -1 ) {
+		// Two kinds of occurrence are prose rather than code, and the
+		// parser never sees a template in either:
+		//
+		//   - a JSDoc block, where this module documents how to USE
+		//     css`` in a fenced example;
+		//   - a string literal, where `core/css.ts` names css`` in the
+		//     TypeError it throws at a bad interpolation.
+		const lineStart = src.lastIndexOf( '\n', i ) + 1;
+		const before = src.slice( lineStart, i );
+		const quoted =
+			( before.split( "'" ).length - 1 ) % 2 === 1 ||
+			( before.split( '"' ).length - 1 ) % 2 === 1;
+		if ( /^\s*(\*|\/\/)/.test( before ) || quoted ) {
+			i = src.indexOf( 'css`', i + 1 );
+			continue;
+		}
+		let j = i + 4;
+		let closed = false;
+		while ( j < src.length ) {
+			if ( src[ j ] === '\\' ) {
+				j += 2;
+				continue;
+			}
+			if ( src[ j ] === '`' ) {
+				// The template's own terminator. Whether it is the
+				// intended one is exactly what we cannot know from
+				// here — which is the point: to the parser, this is
+				// where the template ends either way.
+				closed = true;
+				break;
+			}
+			j++;
+		}
+		if ( ! closed ) {
+			break;
+		}
+		// Is the character run we just closed on plausibly a comment
+		// backtick rather than the real terminator? The real one is
+		// followed (modulo whitespace) by `;` or `,` or `)`.
+		const after = src.slice( j + 1, j + 40 ).trimStart();
+		if ( after !== '' && ! /^[;,)\]]/.test( after ) ) {
+			out.push( src.slice( 0, j ).split( '\n' ).length );
+		}
+		i = src.indexOf( 'css`', j + 1 );
+	}
+	return out;
+}
+
+const files = walk( UI );
+
+describe( 'css`` templates contain no backticks', () => {
+	test( 'the sweep found files to check', () => {
+		// Guards the guard: a move of src/ui would otherwise turn every
+		// assertion below into a silent pass.
+		expect( files.length ).toBeGreaterThan( 40 );
+	} );
+
+	test.each( files.map( ( f ) => [ f.slice( ROOT.length + 1 ), f ] ) )(
+		'%s',
+		( label, path ) => {
+			const lines = offendingLines( readFileSync( path, 'utf8' ) );
+			expect(
+				lines,
+				`${ label } closes a css\`\` template early at line ${ lines.join(
+					', '
+				) }. A backtick inside the template — usually one quoting a ` +
+					'token or a selector in a CSS comment — terminates the ' +
+					'JS template literal. Drop the backticks in comments ' +
+					'inside css`` and use plain prose or "double quotes".'
+			).toEqual( [] );
+		}
+	);
+} );

--- a/tests/vitest/help-examples.test.ts
+++ b/tests/vitest/help-examples.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Every component's help example must actually show something.
+ *
+ * The Components tab in OS Settings is the kit's shop window, and a
+ * whole class of its examples rendered blank without anyone noticing —
+ * because a blank example is not an error, it is an empty `<div>`.
+ * Three separate causes, all of them silent:
+ *
+ *   1. **`<script>` in the template.** `<os-crumb-chain>` set its
+ *      `segments` from an inline script. `html``` compiles by
+ *      assigning to a `<template>`'s `innerHTML`; the HTML
+ *      fragment-parsing algorithm sets a parsed script's *already
+ *      started* flag, and the cloning steps copy it. The script was
+ *      inert in the template and inert in every clone — it could
+ *      never have run.
+ *   2. **Property-driven components with no data.** `segments`,
+ *      `data`, `columns`, `entries`, `ratings` and `items` are JS
+ *      properties, not attributes, so no markup can fill them.
+ *      `<os-table>` and `<os-log>` rendered their empty states, and
+ *      the two vestigial `id="sample-table"` / `id="sample-log"`
+ *      attributes are the fossil of a script that was meant to
+ *      populate them.
+ *   3. **No example at all.** Twelve classes had `static help`
+ *      without an `example` — including every overlay, which is
+ *      `display: none` until opened and so needs a trigger to
+ *      demonstrate at all, and every child component, which has no
+ *      shape outside its parent.
+ *
+ * This pins all three. It is deliberately a source scan rather than a
+ * render: jsdom has no layout, so "did this paint anything" is not a
+ * question it can answer — but "did the author give it something to
+ * paint" is, and that is the failure that actually shipped.
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve( __dirname, '../..' );
+const COMPONENTS = resolve( ROOT, 'src/ui/components' );
+
+/** Every component source file, paired with its text. */
+const files = readdirSync( COMPONENTS, { withFileTypes: true } )
+	.filter( ( e ) => e.isDirectory() )
+	.map( ( dir ) => {
+		const path = resolve( COMPONENTS, dir.name, `${ dir.name }.ts` );
+		try {
+			return [ dir.name, readFileSync( path, 'utf8' ) ] as const;
+		} catch {
+			return null;
+		}
+	} )
+	.filter( ( e ): e is readonly [ string, string ] => e !== null );
+
+/**
+ * The `defineComponent( 'tag', Class )` calls in a file, so a file
+ * defining three components is checked as three components.
+ */
+function tagsIn( src: string ): string[] {
+	return Array.from( src.matchAll( /defineComponent\(\s*'([^']+)'/g ) ).map(
+		( m ) => m[ 1 ],
+	);
+}
+
+describe( 'help examples', () => {
+	test( 'the component sweep found sources to check', () => {
+		expect( files.length ).toBeGreaterThan( 40 );
+	} );
+
+	test.each( files )( '%s declares an example for every class', ( name, src ) => {
+		const classes = ( src.match( /static help = \{/g ) ?? [] ).length;
+		const examples = ( src.match( /\bexample: html`/g ) ?? [] ).length;
+
+		expect(
+			examples,
+			`${ name } defines ${ classes } help descriptor(s) but ${ examples } example(s). ` +
+				`Tags in this file: ${ tagsIn( src ).join( ', ' ) }. ` +
+				'Every class with `static help` needs its own `example`, including ' +
+				'child components — the Components tab lists them separately, and a ' +
+				'child shown outside its parent has no shape. Use the parent in ' +
+				'miniature.',
+		).toBe( classes );
+	} );
+
+	test.each( files )( '%s puts no <script> in an example', ( name, src ) => {
+		// Only inside the css/html template — a <script> in a JSDoc
+		// fence is prose and is fine.
+		const inExample = src
+			.split( 'example: html`' )
+			.slice( 1 )
+			.some( ( chunk ) => chunk.slice( 0, chunk.indexOf( '`' ) ).includes( '<script' ) );
+
+		expect(
+			inExample,
+			`${ name } has a <script> inside a help example. It can never run: the ` +
+				'template is compiled through innerHTML, which flags parsed scripts as ' +
+				'already-started, and cloning copies the flag. Use `exampleInit` instead.',
+		).toBe( false );
+	} );
+
+	/**
+	 * Components whose data arrives through a property. Each needs an
+	 * `exampleInit` or its example is a documented empty state.
+	 */
+	const PROPERTY_DRIVEN = [
+		[ 'os-crumb-chain', 'segments' ],
+		[ 'os-table', 'columns' ],
+		[ 'os-log', 'entries' ],
+		[ 'os-category-picker', 'items' ],
+		[ 'os-rating-summary', 'ratings' ],
+	] as const;
+
+	test.each( PROPERTY_DRIVEN )(
+		'%s fills its example through exampleInit',
+		( name, prop ) => {
+			const src = files.find( ( [ n ] ) => n === name )?.[ 1 ] ?? '';
+			expect( src, `${ name } source not found` ).not.toBe( '' );
+			expect(
+				src.includes( 'exampleInit:' ),
+				`${ name } takes its data through the \`${ prop }\` property, which no ` +
+					'markup can set — without exampleInit its example renders as an ' +
+					'empty shell.',
+			).toBe( true );
+		},
+	);
+
+	/**
+	 * Overlays are `display: none` until opened, so an example that
+	 * only mounts one shows nothing at all. Each needs a trigger.
+	 */
+	test.each( [ 'os-modal', 'os-confirm-dialog' ] )(
+		'%s ships a trigger, not just a mounted overlay',
+		( name ) => {
+			const src = files.find( ( [ n ] ) => n === name )?.[ 1 ] ?? '';
+			expect( src ).toContain( 'data-demo' );
+			expect( src ).toContain( 'exampleInit:' );
+		},
+	);
+
+	test( 'exampleInit wires listeners by assignment, never by accumulation', () => {
+		// The help panel repaints on every keystroke in its filter box
+		// and re-runs exampleInit against the same nodes. addEventListener
+		// would stack one listener per keystroke; `onclick =` replaces.
+		for ( const [ name, src ] of files ) {
+			if ( ! src.includes( 'exampleInit:' ) ) {
+				continue;
+			}
+			// From the hook to the end of the help descriptor, with
+			// comments stripped — every one of these files EXPLAINS in
+			// prose why it does not use addEventListener, and a scan
+			// that read the explanation as the offence would fail on
+			// exactly the files that got it right.
+			const init = src.slice( src.indexOf( 'exampleInit:' ) );
+			const body = init
+				.slice( 0, init.indexOf( '\n\t} as const;' ) )
+				.replace( /\/\*[\s\S]*?\*\//g, '' )
+				.replace( /\/\/[^\n]*/g, '' );
+			expect(
+				body.includes( 'addEventListener' ),
+				`${ name }'s exampleInit calls addEventListener. The panel re-runs it ` +
+					'on every repaint, so listeners accumulate — assign to `onclick` ' +
+					'instead, which replaces.',
+			).toBe( false );
+		}
+	} );
+} );

--- a/tests/vitest/help-examples.test.ts
+++ b/tests/vitest/help-examples.test.ts
@@ -136,6 +136,32 @@ describe( 'help examples', () => {
 		},
 	);
 
+	test.each( files )( '%s carries no version stamp', ( name, src ) => {
+		// `AGENTS.md`: no version-history annotations in docs or
+		// comments. A `since:` in a help descriptor is exactly that,
+		// rendered into the UI — and it ages badly in the one place a
+		// plugin author reads to learn what a component does NOW. Git
+		// is the changelog; a change big enough that "since when?"
+		// matters is a breaking one and wants a migration note.
+		expect(
+			src.includes( 'since:' ),
+			`${ name } declares \`since\` in its help descriptor.`,
+		).toBe( false );
+	} );
+
+	test.each( files )( '%s does not claim to be experimental', ( name, src ) => {
+		// The kit shipped; every component in it is stable. A badge
+		// that says "experimental" on a component three other windows
+		// already depend on is not a caveat, it is stale metadata —
+		// and it tells plugin authors not to rely on something they
+		// safely can. `OsHelpStatus` still accepts the value, for a
+		// component that genuinely is one.
+		expect(
+			src.includes( "status: 'experimental'" ),
+			`${ name } is marked experimental.`,
+		).toBe( false );
+	} );
+
 	test( 'exampleInit wires listeners by assignment, never by accumulation', () => {
 		// The help panel repaints on every keystroke in its filter box
 		// and re-runs exampleInit against the same nodes. addEventListener

--- a/tests/vitest/holo-layer.test.ts
+++ b/tests/vitest/holo-layer.test.ts
@@ -28,6 +28,10 @@ import {
 	holoFill,
 	holoSheen,
 	holoEdge,
+	holoGlint,
+	holoRing,
+	holoShimmer,
+	holoEnter,
 	holoField,
 	holoCheck,
 	holoDrift,
@@ -149,9 +153,16 @@ describe( 'the holo fragments keep the palette reachable', () => {
 			'--os-ui-holo-glow',
 			'--os-ui-holo-glow-strong',
 			'--os-ui-holo-track',
+			'--os-ui-accent-dim',
 			'--os-ui-focus-ring',
 			'--os-ui-focus-ring-field',
 			'--os-ui-holo-transition',
+			'--os-ui-motion-fast',
+			'--os-ui-motion-slow',
+			'--os-ui-motion-ambient',
+			'--os-ui-ease-spring',
+			'--os-ui-ease-out',
+			'--os-ui-ease-loop',
 		] ) {
 			expect( declared( token ), `${ token } is missing from variables.css` )
 				.not.toBeNull();
@@ -196,16 +207,155 @@ describe( 'the shared field chrome cannot outrank a component', () => {
 	} );
 } );
 
+describe( 'Pulse is spent where it is stated, not where it is spread', () => {
+	test( 'the identity colour is untouched and the dim is its neighbour', () => {
+		// The designer's note was about how loud the station reads, and
+		// the answer is not to move Pulse — #f252fc is the brand's, it
+		// is what the guidelines name, and at 6.2:1 on Obsidian it is
+		// not a contrast problem. What comes down is everything AMBIENT
+		// derived from it.
+		expect( declared( '--os-ui-accent' ) ).toBe( '#f252fc' );
+		expect( declared( '--os-ui-accent-dim' ) ).toBe( '#d92ee3' );
+	} );
+
+	test( 'every ambient use of Pulse resolves through the dim', () => {
+		// One knob. If a glow, a wash or a bloom stops reading through
+		// --os-ui-accent-dim, turning the station down stops being one
+		// edit and starts being an audit.
+		for ( const token of [
+			'--os-ui-accent-soft',
+			'--os-ui-holo-glow',
+			'--os-ui-holo-glow-strong',
+			'--os-ui-focus-ring-field',
+		] ) {
+			expect( declared( token ), token ).toContain( '--os-ui-accent-dim' );
+		}
+	} );
+
+	test( 'the focus RING itself stays full Pulse', () => {
+		// Only the bloom behind it dims. A focus indicator is the last
+		// place to trade legibility for calm — it is the one thing on
+		// screen saying where the keyboard is.
+		const ring = declared( '--os-ui-focus-ring' ) ?? '';
+		expect( ring ).toContain( '0 0 0 4px #f252fc' );
+		expect( ring ).toContain( '--os-ui-accent-dim' );
+	} );
+} );
+
+describe( 'the unlit half is visible, and the selection is legible', () => {
+	test( 'the off-state track is a LIFTED wash, not a sunken well', () => {
+		// It used to be rgba( 12, 11, 15, 0.55 ), which composites to
+		// #121017 on an Obsidian panel: 1.07:1. An off switch was, to a
+		// good approximation, not drawn. On a dark UI the visible thing
+		// is the lighter one — which is what every dark OS does with
+		// its switches, for this reason.
+		const track = declared( '--os-ui-holo-track' ) ?? '';
+		expect( track ).toContain( '255, 251, 255' );
+		expect( track ).not.toContain( '12, 11, 15' );
+	} );
+
+	test( 'the track carries a 3:1 boundary of its own', () => {
+		// Pewter. The first step on the Shade ramp that reaches 3.00:1
+		// against Obsidian — Silver manages 2.03 and Astro 1.37 — which
+		// is what WCAG 1.4.11 asks of a control boundary. The fill
+		// alone is ~1.6:1 and is a look, not a boundary.
+		expect( declared( '--os-ui-holo-track-edge' ) ).toBe( '#66636b' );
+		expect( holoTokens.cssText.replace( /\s+/g, ' ' ) ).toContain(
+			'var( --os-ui-holo-track-edge,'
+		);
+	} );
+
+	test( 'the selection sets BOTH halves, and keeps the text its own colour', () => {
+		// Setting only `background` is the common half-fix: the UA then
+		// keeps its own selected-text colour, which is often forced to
+		// black and lands on this violet at ~2:1.
+		expect( declared( '--os-ui-selection-bg' ) ).toBe(
+			'rgba(159, 152, 255, 0.6)'
+		);
+		// Starlight — the colour body text already is. A selection that
+		// RECOLOURS text destroys every distinction the text carried:
+		// syntax highlighting, a red error, a muted timestamp.
+		expect( declared( '--os-ui-selection-fg' ) ).toBe( '#fffbff' );
+	} );
+
+	test( 'the selection reaches the shell AND every shadow root', () => {
+		// A shadow root does not inherit the document's ::selection
+		// rule, so the shell-wide one in desktop.css cannot reach into
+		// a component. Both have to exist, and both have to read the
+		// same tokens or they drift.
+		const shell = readFileSync(
+			resolve( ROOT, 'assets/css/desktop.css' ),
+			'utf8'
+		);
+		expect( shell ).toContain( 'body.os-active ::selection' );
+		// Prefixed Firefox spelling as its OWN rule: an unrecognised
+		// pseudo-element invalidates the whole selector list, so
+		// pairing them would leave Chrome unstyled too.
+		expect( shell ).toContain( 'body.os-active ::-moz-selection' );
+		expect( shell ).toContain( '--os-ui-selection-bg' );
+		expect( holoField.cssText ).toContain( '--os-ui-selection-bg' );
+		expect( holoField.cssText ).toContain( '--os-ui-selection-fg' );
+	} );
+
+	test( 'the shell selection rule does NOT reach inside iframe windows', () => {
+		// variables.css is a dependency of chromeless.css and so loads
+		// in every iframe; desktop.css is not. A wp-admin page in a
+		// window keeps the selection it has outside one — the same
+		// promise the palette makes about everything else.
+		const chromeless = readFileSync(
+			resolve( ROOT, 'assets/css/chromeless.css' ),
+			'utf8'
+		);
+		expect( chromeless ).not.toContain( '::selection' );
+	} );
+} );
+
 describe( 'motion is optional everywhere', () => {
 	test.each( [
 		[ 'holoFill', holoFill ],
 		[ 'holoSheen', holoSheen ],
 		[ 'holoEdge', holoEdge ],
+		[ 'holoGlint', holoGlint ],
+		[ 'holoRing', holoRing ],
+		[ 'holoShimmer', holoShimmer ],
+		[ 'holoEnter', holoEnter ],
 		[ 'holoField', holoField ],
 		[ 'holoCheck', holoCheck ],
 		[ 'holoDrift', holoDrift ],
 	] )( '%s honours prefers-reduced-motion', ( _name, fragment ) => {
 		expect( fragment.cssText ).toContain( 'prefers-reduced-motion' );
+	} );
+
+	test( 'every duration and curve comes from the shared scale', () => {
+		// A panel where the switch settles in 220ms, the segmented
+		// thumb in 300 and the tab underline in 150 does not read as
+		// three well-tuned controls. It reads as one surface that
+		// cannot keep time.
+		for ( const fragment of [ holoGlint, holoRing, holoEnter ] ) {
+			expect( fragment.cssText ).toMatch( /var\( --_holo-t/ );
+			expect( fragment.cssText ).toMatch(
+				/var\( --_holo-(ease|spring|loop) \)/
+			);
+		}
+	} );
+
+	test( 'the two motion fragments are element-based, not pseudo-based', () => {
+		// The sheen owns ::before and the edge owns ::after, so a
+		// control wearing both has spent its whole pseudo-element
+		// budget. Glint and ring are stamped as spans for that reason;
+		// moving either onto a pseudo would silently disable one of
+		// the other two on <os-button>.
+		expect( holoGlint.cssText ).toContain( '.os-holo-glint {' );
+		expect( holoRing.cssText ).toContain( '.os-holo-ring {' );
+	} );
+
+	test( 'both motions are driven by the CHILD combinator', () => {
+		// `:active` matches the activated element AND every ancestor of
+		// it, so a descendant selector here would fire every ring on
+		// the page the moment anything inside the panel was pressed.
+		expect( holoRing.cssText ).toContain( '> .os-holo-ring' );
+		expect( holoRing.cssText ).not.toMatch( /:active[^>{]*\s\.os-holo-ring/ );
+		expect( holoGlint.cssText ).toContain( '> .os-holo-glint' );
 	} );
 
 	test( 'reduced motion stops the tilt without removing the fill', () => {
@@ -227,6 +377,10 @@ describe( 'the barrel', () => {
 			holoFill,
 			holoSheen,
 			holoEdge,
+			holoGlint,
+			holoRing,
+			holoShimmer,
+			holoEnter,
 			holoField,
 			holoCheck,
 			holoDrift,

--- a/tests/vitest/holo-layer.test.ts
+++ b/tests/vitest/holo-layer.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The holographic layer, pinned.
+ *
+ * Three things here would break quietly, and each has cost time
+ * somewhere in this repo before:
+ *
+ *   1. **The meshes are transcriptions, not inventions.** Every stop
+ *      in `--os-mesh-*` came from a brand SVG. A hex typo is invisible
+ *      in review and wrong forever, and nobody diffs a nine-layer
+ *      gradient by eye.
+ *   2. **A `:host` declaration of a public token kills the palette.**
+ *      `src/ui/holo.ts` declares eleven aliases on `:host`, which is
+ *      exactly the shape the reachability rule bans when the name is
+ *      public. Every one of them has to start with `--_`.
+ *   3. **Specificity.** `holoField` uses bare element selectors, so it
+ *      is one careless `:not()` away from outranking every component's
+ *      own error ring. The `:where()` wrapper is what keeps it at
+ *      (0,1,1), and losing it turns an invalid field's red focus ring
+ *      Pulse — a change no test that renders a valid form would see.
+ *
+ * Brand reference: https://nuriapenya.github.io/open-station-brand/
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+	holoTokens,
+	holoFill,
+	holoSheen,
+	holoEdge,
+	holoField,
+	holoCheck,
+	holoDrift,
+	holo,
+} from '../../src/ui/holo';
+
+const ROOT = resolve( __dirname, '../..' );
+const CSS = readFileSync( resolve( ROOT, 'assets/css/variables.css' ), 'utf8' );
+
+/** The value `variables.css` declares for a token, whitespace-flattened. */
+function declared( token: string ): string | null {
+	const match = new RegExp( `\\n\\t${ token }:\\s*([\\s\\S]*?);\\n` ).exec( CSS );
+	return match ? match[ 1 ].replace( /\s+/g, ' ' ).trim() : null;
+}
+
+describe( 'the meshes are the brand’s own', () => {
+	test( 'Holomesh carries its base linear and all eight glows', () => {
+		const holomesh = declared( '--os-mesh-holo' ) ?? '';
+
+		// The base, from holo_base in assets/holomesh.svg.
+		expect( holomesh ).toContain( '#afa2e8' );
+		expect( holomesh ).toContain( '#b7abea' );
+		expect( holomesh ).toContain( '#c3b8ef' );
+
+		// One radial per glow, holo_r0 … holo_r7.
+		expect( holomesh.match( /radial-gradient/g ) ?? [] ).toHaveLength( 8 );
+
+		// The glow colours, in the SVG's own order: white, cyan, pink,
+		// warm, mint, white, pink, blue. Stated as rgb() because a
+		// gradient stop needs an alpha and the hexes do not carry one.
+		for ( const rgb of [
+			'255, 253, 255', // #fffdff
+			'125, 239, 245', // #7deff5
+			'245, 159, 232', // #f59fe8
+			'248, 242, 182', // #f8f2b6
+			'147, 240, 198', // #93f0c6
+			'243, 181, 236', // #f3b5ec
+			'159, 214, 255', // #9fd6ff
+		] ) {
+			expect( holomesh ).toContain( rgb );
+		}
+	} );
+
+	test( 'Pulsemesh, Auromesh, Starmesh and Miomesh are all declared', () => {
+		expect( declared( '--os-mesh-pulse' ) ).toContain( '#8d9bf3' );
+		expect( declared( '--os-mesh-pulse' ) ).toContain( '#c878f0' );
+		expect( declared( '--os-mesh-auro' ) ).toContain( '#cefada' );
+		expect( declared( '--os-mesh-star' ) ).toContain( '#fffbff' );
+		// Miomesh belongs to the mascot; the sweep runs Pulse → deep blue.
+		expect( declared( '--os-mesh-mio' ) ).toContain( '#f252fc' );
+		expect( declared( '--os-mesh-mio' ) ).toContain( '#4b3eff' );
+	} );
+
+	test( 'the default holographic fill IS Holomesh, and its ink is Void', () => {
+		expect( declared( '--os-ui-holo-fill' ) ).toBe( 'var(--os-mesh-holo)' );
+		// Not Starlight. Every mesh in the brand is a light surface —
+		// Holomesh's darkest stop still sits above 60% luminance — so
+		// white glyphs on one are unreadable in a way that looks fine
+		// in a screenshot.
+		expect( declared( '--os-ui-holo-ink' ) ).toBe( '#0c0b0f' );
+	} );
+
+	test( 'the surfaces that took the mesh are the bounded ones', () => {
+		// Retinted in the palette rather than in the components, which
+		// is what keeps each component's own literal as the pre-brand
+		// floor and keeps Legacy able to revert them.
+		expect( declared( '--os-ui-progress-fill' ) ).toBe( 'var(--os-mesh-holo)' );
+		expect( declared( '--os-ui-step-chip-bg' ) ).toBe( 'var(--os-mesh-holo)' );
+	} );
+} );
+
+describe( 'the holo fragments keep the palette reachable', () => {
+	test( 'every custom property declared on :host is private', () => {
+		// The rule from AGENTS.md, applied to the one module that
+		// declares eleven properties on a bare :host. A public name
+		// here would be unreachable from the palette AND from every
+		// desktop theme, silently, forever.
+		const declarations =
+			holoTokens.cssText.match( /--[a-z0-9_-]+\s*:/g ) ?? [];
+		const publicNames = declarations
+			.map( ( d ) => d.replace( /\s*:$/, '' ) )
+			.filter( ( name ) => ! name.startsWith( '--_' ) );
+
+		expect( publicNames ).toEqual( [] );
+		expect( declarations.length ).toBeGreaterThan( 8 );
+	} );
+
+	test( 'every alias reads its public token with a literal fallback', () => {
+		// The alias is only worth having if it resolves the inherited
+		// value; a hardcoded right-hand side would be the blocked
+		// declaration with extra steps. Whitespace-flattened because
+		// several of these wrap across lines to stay inside the column
+		// limit, and a line break inside var() is not a difference.
+		const flat = holoTokens.cssText.replace( /\s+/g, ' ' );
+		for ( const token of [
+			'--os-ui-holo-fill',
+			'--os-ui-holo-ink',
+			'--os-ui-holo-sheen',
+			'--os-ui-holo-edge',
+			'--os-ui-holo-edge-quiet',
+			'--os-ui-holo-glow',
+			'--os-ui-holo-glow-strong',
+			'--os-ui-holo-track',
+			'--os-ui-focus-ring',
+			'--os-ui-focus-ring-field',
+			'--os-ui-holo-transition',
+		] ) {
+			expect( flat ).toContain( `var( ${ token },` );
+		}
+	} );
+
+	test( 'the public tokens the aliases read are all declared in the palette', () => {
+		for ( const token of [
+			'--os-ui-holo-fill',
+			'--os-ui-holo-ink',
+			'--os-ui-holo-sheen',
+			'--os-ui-holo-edge',
+			'--os-ui-holo-edge-quiet',
+			'--os-ui-holo-glow',
+			'--os-ui-holo-glow-strong',
+			'--os-ui-holo-track',
+			'--os-ui-focus-ring',
+			'--os-ui-focus-ring-field',
+			'--os-ui-holo-transition',
+		] ) {
+			expect( declared( token ), `${ token } is missing from variables.css` )
+				.not.toBeNull();
+		}
+	} );
+
+	test( 'the palette is on body.os-active, never :root', () => {
+		// variables.css is a dependency of chromeless.css, so it loads
+		// inside every iframe window — a real wp-admin document. On
+		// :root the meshes and the focus ring would reach in and
+		// repaint WordPress's own UI.
+		const holoBlock = CSS.slice( CSS.indexOf( '--os-mesh-holo' ) );
+		expect( CSS ).toContain( 'body.os-active {' );
+		expect( holoBlock.slice( 0, holoBlock.indexOf( '}' ) ) ).not.toContain(
+			':root',
+		);
+	} );
+} );
+
+describe( 'the shared field chrome cannot outrank a component', () => {
+	test( 'the type exclusions are wrapped in :where()', () => {
+		// :not() carries its argument's specificity, so the honest
+		// spelling weighs (0,3,1) — heavier than
+		// input[aria-invalid='true']:focus at (0,2,1). An invalid field
+		// would then focus in Pulse instead of red, and no test that
+		// renders a valid form would ever notice.
+		const bare = holoField.cssText.match(
+			/input:not\(\s*\[\s*type='checkbox'/g,
+		);
+		expect( bare ).toBeNull();
+		expect( holoField.cssText ).toContain(
+			"input:where( :not( [ type='checkbox' ] ):not( [ type='radio' ] ) )",
+		);
+	} );
+
+	test( 'checkboxes and radios are excluded from the field ring', () => {
+		// They get the target ring from holoCheck instead — a checkbox
+		// is a target sitting on an arbitrary background, not a field
+		// with its own border to thicken.
+		expect( holoCheck.cssText ).toContain( 'var( --_holo-focus )' );
+		expect( holoField.cssText ).toContain( 'var( --_holo-focus-field )' );
+	} );
+} );
+
+describe( 'motion is optional everywhere', () => {
+	test.each( [
+		[ 'holoFill', holoFill ],
+		[ 'holoSheen', holoSheen ],
+		[ 'holoEdge', holoEdge ],
+		[ 'holoField', holoField ],
+		[ 'holoCheck', holoCheck ],
+		[ 'holoDrift', holoDrift ],
+	] )( '%s honours prefers-reduced-motion', ( _name, fragment ) => {
+		expect( fragment.cssText ).toContain( 'prefers-reduced-motion' );
+	} );
+
+	test( 'reduced motion stops the tilt without removing the fill', () => {
+		// A control that lost its mesh under reduced motion would lose
+		// its STATE, not just its animation — an "on" switch would go
+		// back to looking off.
+		const reduced = holoFill.cssText.slice(
+			holoFill.cssText.indexOf( 'prefers-reduced-motion' ),
+		);
+		expect( reduced ).toContain( 'background-position: 22% 28%' );
+		expect( reduced ).not.toContain( 'background-image: none' );
+	} );
+} );
+
+describe( 'the barrel', () => {
+	test( 'holo bundles every fragment', () => {
+		for ( const fragment of [
+			holoTokens,
+			holoFill,
+			holoSheen,
+			holoEdge,
+			holoField,
+			holoCheck,
+			holoDrift,
+		] ) {
+			// Compare on a distinctive slice rather than the whole text:
+			// the barrel interpolates each fragment verbatim, so any
+			// non-trivial run of it must survive.
+			const probe = fragment.cssText.trim().slice( 0, 60 );
+			expect( holo.cssText ).toContain( probe );
+		}
+	} );
+} );


### PR DESCRIPTION
The brand ships five mesh gradients and one instruction about them — *"meshes reserved for hero surfaces"* — and nothing in the component kit was wearing them. This puts them in, as **a moment rather than a skin**: a control paints the mesh when it is on, selected, primary or filled, and wears ordinary Obsidian the rest of the time. A panel where every surface is iridescent has no identity moments left to spend, which is the failure mode the whole shape of this is built to avoid.

Four commits: the layer, its motion, a pile of Components-tab bugs the review turned up, and two stale labels.

---

## The meshes, in CSS

`--os-mesh-holo` / `-pulse` / `-auro` / `-star` / `-mio` are the brand's SVGs transcribed stop-for-stop — Holomesh is its base linear plus all eight radial glows, at the artboard's own offsets, radii, colours and alphas, converted from 1440×960 into percentages.

Gradient stacks rather than `url()`s, and that is the point rather than an optimisation. **`background-position` can slide a gradient, and that slide IS the holographic effect** — a foil card shifting hue as you tilt it. An SVG could not be animated, could not be tinted, and would rasterise one flat corner of a 1440×960 artboard onto a 44 px switch track.

## `src/ui/holo.ts`

Eleven `css` fragments so no component re-decides what holographic means. Three surfaces — `holoEdge` (an iridescent hairline), `holoSheen` (a 10%-alpha film), `holoFill` (the mesh itself, Void ink on top) — and four motions:

| | |
|---|---|
| **glint** | a specular band crossing once on hover. Foil does not glow, it *catches*. |
| **ring** | a press response that expands and fades, so a click reads as received before its result paints. |
| **shimmer** | the mesh travelling, for waits of unknown length. |
| **enter** | scale-and-fade arrival for menus, dialogs and popovers. |

Plus the ones that belong to a single component: the **`<os-segmented>` thumb that slides between segments** (the group owns one lit pill that *moves*, rather than each child owning a fill that appears — so the selection travels and the eye follows it), the `<os-tabs>` underline growing from the centre, `<os-toast>` arriving from above and leaving sideways, and the `<os-avatar>` presence ring, which pulses **only** on `online` so "who is here" stops depending on telling three dot colours apart.

Every fragment honours `prefers-reduced-motion` by stopping the tilt — **never** by removing the fill. A control that lost its mesh would lose its *state*, not just its animation.

## `<os-switch>`

New component. `role="switch"` on a real `<button>`, so Space, Enter, the disabled semantics and the focus ring come from the platform. Off is a lifted well; on is the Holomesh with a Pulse glow and Void ink. Tap, drag (the knob tracks the pointer live and snaps past the midpoint), plus ArrowLeft/Home and ArrowRight/End for absolute off/on — the pair a screen-reader user can use without tracking the current state.

It emits `os-checkbox-change` alongside `os-switch-change`, so swapping a checkbox for a switch is a tag change and nothing else.

## Dimming Pulse

Per a designer note, and the measurement disagrees with the premise. **Pulse `#f252fc` is not a contrast problem** — it carries 6.2:1 against Obsidian. It is *saturated* (HSL 296, 97, 65), and what hurts is where it is **spread** rather than **stated**.

So `--os-ui-accent` stays `#f252fc` (that one is the brand's, not ours, and `brand-palette.test.ts` pins it) and **`--os-ui-accent-dim` `#d92ee3`** takes over everything ambient — glows, washes, focus blooms. Turning the station up or down is now one edit. The focus **ring** deliberately does not follow it; only the bloom behind it does, because a focus indicator is the last place to trade legibility for calm.

---

## Three contrast fixes, all measured

**The switch changed size between states.** A 1px border plus the default border-box background clip: off drew a grey ring *over* the fill's outer edge, on (`border-color: transparent`) let the mesh through it. The visible pill grew a pixel per side as it turned on. The border is gone; the off edge is an inset shadow, which occupies no layout.

**The unlit half was not drawn.** `--os-ui-holo-track` was `rgba( 12, 11, 15, 0.55 )`, which composites to `#121017` on an Obsidian panel: **1.07:1**. An off switch was, to a good approximation, invisible — and the same token is the unchecked checkbox and every empty slider half. The well is now *lifted* rather than sunk, and the 3:1 WCAG 1.4.11 asks of a control boundary comes from a new `--os-ui-holo-track-edge`: Pewter `#66636b`, the first step on the Shade ramp that reaches it (Silver manages 2.03, Astro 1.37).

**The knob vanished on its own mesh.** Holomesh's white glow is `#fffdff`, so the Starlight knob measured **1.01:1** where the lit track is brightest. Not dim — absent. Its ring was Void at 12% alpha; at 55% it carries the knob at 3.5:1 there and 6.9:1 over the mesh's darkest stop.

**Text selection had no rule at all.** The shell shipped no `::selection`, so every selection was the browser default — a colour chosen for a white page landing on a near-black one. `--os-ui-selection-bg` is Lagoon at 60%: the one primary colour in the guidelines the shell had no job for, and violet-blue is what every OS has trained people to read as "selected". The alpha is squeezed from both ends — the selected text must stay readable (Starlight over it, 5.1:1 on Obsidian) *and* the highlight must separate from the unselected background (3.4:1). An accent wash cannot do this at all: the Pulse family only separates above 75%, by which point it is a fill rather than a highlight. Both halves are set, because leaving the text colour to the UA is how a selection ends up black-on-violet.

---

## The Components tab was showing empty examples

Seventeen of them, in three ways, none of which fails loudly — a blank example is not an error, it is an empty `<div>`.

1. **A `<script>` that could never run.** `<os-crumb-chain>` set its `segments` from an inline script. The `html` tag compiles by assigning to a `<template>`'s `innerHTML`; the fragment-parsing algorithm sets a parsed script's *already-started* flag, and the cloning steps copy it. Inert in the template, inert in every clone.
2. **Property-driven components with nothing to render.** `segments`, `data`, `columns`, `entries`, `ratings` are JS properties — no markup can fill them, so `<os-table>` and `<os-log>` rendered their empty states. `OsHelp` gains **`exampleInit( root )`**, run after the example renders and scoped to its own container. It calls `customElements.upgrade()` first, and that is not belt-and-braces: on the first paint the section is still detached, so assigning to an un-upgraded element defines an *own* property that permanently shadows the accessor the upgrade installs — the setter never runs and the component sits there empty holding data it cannot see.
3. **Twelve classes with no example at all.** Overlays are `display: none` until opened, so they now ship a trigger; children like `<os-tab>` have no shape outside their parent, so each example is the parent in miniature.

Two more from the same review: `<os-tag-input>` rendered **"++ Add"** (the default label was literally `'+ Add'` *and* the button draws its own SVG plus — and since the icon is `aria-hidden`, a screen reader was announcing "plus Add" too), and the detail pane kept its `scrollTop` when switching components, so a long entry opened the next one halfway down.

## Two labels that had stopped telling the truth

`since` was a version-history annotation rendered into the UI, which `AGENTS.md` already bans in docs and comments for the reason it is wrong here too. Removed from all 63 declarations, from `OsHelp`, from the panel and from the stylesheet.

`experimental` was on 27 components that several windows already depend on. A badge saying "experimental" on a shipped component is not a caveat, it is stale metadata — it tells plugin authors not to rely on something they safely can. All promoted to stable; `OsHelpStatus` still accepts the value for a component that genuinely is one.

---

## Guards

- `holo-layer.test.ts` — the mesh transcriptions against the brand's own hexes (a typo in a nine-layer gradient is invisible in review and wrong forever), alias privacy, the `:where()` specificity below, the dim routing, and `prefers-reduced-motion` on every fragment.
- `help-examples.test.ts` — every class with `static help` has an example, no example contains a `<script>`, every property-driven component has an `exampleInit`, every overlay ships a trigger, no `exampleInit` accumulates listeners, and no descriptor carries a version stamp or an experimental badge.
- `css-template-hygiene.test.ts` — a backtick inside a `css` template closes it early and the toolchain reports "expected a semicolon" pointing at prose. This one says what is actually wrong; it caught a live defect in `<os-progress-bar>` on its first run.

## Two traps worth knowing about

**`holoField` uses bare `input` / `select` / `textarea` selectors** — safe inside a shadow root. Spelled honestly with `:not()` they weigh (0,3,1), heavier than `input[aria-invalid='true']:focus` at (0,2,1) — so the shared fragment would have outranked every component's own error ring and an invalid field would focus in Pulse instead of red. The exclusions are wrapped in `:where()` to hold the selector at (0,1,1). **No test that renders a valid form would have caught this.**

**The pseudo-element budget is spent.** `holoSheen` owns `::before` and `holoEdge` owns `::after`. Glint and ring are therefore element-based, driven from the parent's state through the **child** combinator — `:active` matches an activated element *and every ancestor of it*, so `:active .os-holo-ring` would fire every ring on the page.

---

Green: `lint`, `typecheck`, **3634 vitest**, `build`. No PHP touched.

Docs: a *holographic layer* section in `docs/components-reference.md` (which treatment goes where, the token tables, how to use it in your own component), the new themeable tokens and motion scale in `docs/desktop-themes.md`, and rules in `AGENTS.md` for the holo module, the accent-dim knob and the backtick trap.

**Worth looking at on a real install:** OS Settings (the sliding segmented thumb, switches off *and* on), any dialog (spring entry), a Posts table (selection marker, checkboxes), the Components tab end to end, and drag-selecting some text anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-480-0f54003109681d2042eb38b0e18660284f36aa89.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20OpenStation%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;openstation_is_enabled&#039;%20)%20%7C%7C%20!%20openstation_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;openstation&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.os.ready(function()%7Bvar%20games%3Dwindow.wp.os.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->