### PR TITLE
fix(mio): interpolate the desk between samples, so a dragged window pushes smoothly

### DIFF
--- a/docs/mio.md
+++ b/docs/mio.md
@@ -366,6 +366,24 @@ The look merges **last**, after server config and the JS filter. Everything befo
 
 Every frame (throttled to 20 Hz) Mio asks the shell for the live collision set via `wp.os.getWallpaperSurfaces()` — the same surfaces the snow wallpaper piles on — and converts them into its own coordinate space. Window rects, widget cards, the dock edge, and the shell floor all become solid obstacles the rim collides with.
 
+### The desk is sampled, but it moves continuously
+
+Measuring is throttled; *presenting* is not. A dozen `getBoundingClientRect()` reads is not a per-frame cost, but a window drag writes the window's `left` / `top` on every `pointermove` — so a sample taken at 20 Hz is up to three frames stale, and then advances by a whole interval of pointer travel at once. Contact resolution is a positional push, so that entire delta lands in one step: Mio resting against a window edge hops, holds for three frames, hops again as the window is dragged past it.
+
+`obstacle-track.ts` fixes that without touching the sample rate, by treating measurements as **keyframes** rather than as the truth right now. It holds the previous sample alongside the current one and hands the solver a rect lerped between the two, so a 20 Hz measurement drives a 60 Hz push. Sizes interpolate too, which makes a resizing window sweep against Mio instead of stepping.
+
+The lerp spans the **throttle**, not the measured gap between the last two samples, and that distinction is what makes the hand-off seamless. The gap is irregular by construction — the ticker decides which frame `readSurfaces()` runs on, so a 50 ms throttle fires at 50 ms and at 66.7 ms in whatever order the frames fall. Spread over the previous gap, the interpolation is left unfinished whenever a short gap follows a long one, and the next keyframe pair starts from the position the last one was still travelling toward: a jump, the smaller cousin of the one being removed. Spread over the throttle, it is guaranteed to have arrived before the next sample can land, because the throttle is a floor on the gap. The worst case degrades to a hold of a frame or two at the end of an interval.
+
+The cost is one sample interval of latency — Mio is pushed by where the window was 50 ms ago. That is invisible on a decorative blob, and it is what makes interpolation preferable to extrapolation, which buys the latency back but overshoots and snaps back every time a drag stops.
+
+Three cases are deliberately **not** interpolated, because none of them are motion:
+
+- **An obstacle with no previous keyframe** — a window that just opened, or the very first sample. It is solid where it is; sliding it in from nowhere would read as a window materialising mid-desk and then sweeping across it.
+- **A gap longer than 250 ms between samples** — the tab was in the background. The two samples are before-and-after, not two moments of one movement.
+- **Anything following a layer resize.** A new layer origin re-bases every obstacle coordinate at once, so the track drops its history rather than lerp the whole desk across the rebase.
+
+A still desk — the overwhelmingly common case — costs nothing: the two keyframes are geometrically identical, so the track short-circuits and hands back the measured array itself.
+
 ### Windows are magnets, not ground
 
 There is **no global "down"**. A window attracts Mio toward the closest point on its edge from whatever direction Mio is in, so it can just as happily stick to the underside of a window as sit on top of one. Strength smoothsteps in from `0` at `physics.magnetRange` to `1` on contact, and the idle float fades out as it takes hold, so a stuck Mio sits still rather than vibrating against the surface.
@@ -803,7 +821,7 @@ The preference is watched live, so toggling it at the OS level takes effect with
 
 - **Nothing downloads until Mio is switched on.** The always-on cost is the controller.
 - The ticker stops on `visibilitychange`, and resumes with a drained accumulator so a tab that was hidden for a minute doesn't come back with a catch-up avalanche.
-- Surfaces are re-measured at 20 Hz, not per frame.
+- Surfaces are re-measured at 20 Hz, not per frame — and interpolated between measurements so the collision set still moves at frame rate. A still desk skips the interpolation entirely.
 - Per frame at the shipped `glow: 10`: six `Graphics.clear()` calls and roughly 400 curved cells — 72 for the core and 216 across the bloom's three shells, both at full ribbon resolution because they carry the gradient; 72 across the halo's six, and forty across the sheen's five, all of them coarse because a blur is about to dissolve anything finer. Then a blur pass over each of the halo, the bloom and the sheen. The body is a single filled path of `points` curve segments. At the top of the `glow` slider the two glow passes reach 480 cells between them.
 - Ribbon resolution is fixed at 144 samples rather than scaled off `points`, so raising the rim resolution costs simulation time but not render time.
 - The Pixi application is destroyed with `destroy( { removeView: true }, { children: true, texture: true } )`. **Never `destroy( true )`** — that runs Pixi's `releaseGlobalResources()` and corrupts every other live Application on the page (the active wallpaper, the content graph, OS Settings previews).

--- a/src/mio/mio.ts
+++ b/src/mio/mio.ts
@@ -32,6 +32,7 @@ import {
 	magnetPull,
 	type Obstacle,
 } from './environment';
+import { createObstacleTrack } from './obstacle-track';
 import { createPointerTracker, type PointerTracker } from './pointer';
 import { drawMio, glowBlurStrength, type MioLayers } from './render';
 import {
@@ -364,7 +365,8 @@ export async function mountMio(
 	// State.
 	// ------------------------------------------------------------------
 	const pointer: PointerTracker = createPointerTracker();
-	let obstacles: Obstacle[] = [];
+	const desk = createObstacleTrack( SURFACE_REFRESH_MS );
+	let obstacles: readonly Obstacle[] = [];
 	let lastSurfaceRead = 0;
 	let animating = true;
 	let destroyed = false;
@@ -448,16 +450,29 @@ export async function mountMio(
 		tilt = { x: ( x / len ) * strength, y: ( y / len ) * strength };
 	};
 
+	/**
+	 * Bring the desk up to date for this frame.
+	 *
+	 * Measuring is throttled — a dozen `getBoundingClientRect()` reads
+	 * is not a per-frame cost — but *presenting* is not. Each
+	 * measurement goes into the track as a keyframe, and every frame
+	 * asks the track where the desk is now, so a window dragged at
+	 * pointer rate pushes Mio continuously instead of in one lurch per
+	 * throttle interval. See `obstacle-track.ts`.
+	 */
 	const readSurfaces = ( nowMs: number ): void => {
-		if ( nowMs - lastSurfaceRead < SURFACE_REFRESH_MS ) {
-			return;
+		if ( nowMs - lastSurfaceRead >= SURFACE_REFRESH_MS ) {
+			lastSurfaceRead = nowMs;
+			origin = originOf();
+			const surfaces = window.wp?.os?.getWallpaperSurfaces?.();
+			desk.sample(
+				Array.isArray( surfaces )
+					? collectObstacles( surfaces, origin, size() )
+					: [],
+				nowMs,
+			);
 		}
-		lastSurfaceRead = nowMs;
-		origin = originOf();
-		const surfaces = window.wp?.os?.getWallpaperSurfaces?.();
-		obstacles = Array.isArray( surfaces )
-			? collectObstacles( surfaces, origin, size() )
-			: [];
+		obstacles = desk.at( nowMs );
 	};
 
 	const toLayer = ( p: { x: number; y: number } ): { x: number; y: number } => ( {
@@ -798,6 +813,11 @@ export async function mountMio(
 		const { width, height } = size();
 		app.renderer.resize( width, height );
 		origin = originOf();
+		// Every obstacle coordinate is layer-local, so a new origin
+		// re-bases the lot at once. That is a discontinuity, not motion:
+		// drop the interpolation history rather than lerp the whole desk
+		// across the rebase.
+		desk.reset();
 		// Pull Mio back inside a shrunken shell.
 		const r = body.radius;
 		const x = clamp( body.core.x, r, Math.max( r, width - r ) );

--- a/src/mio/obstacle-track.ts
+++ b/src/mio/obstacle-track.ts
@@ -1,0 +1,221 @@
+/**
+ * OpenStation — Mio obstacle interpolation.
+ *
+ * The desk is measured on a throttle: `readSurfaces()` reads every
+ * window, widget and dock rect out of the DOM at `SURFACE_REFRESH_MS`,
+ * because `getBoundingClientRect()` on a dozen nodes is not something
+ * to do sixty times a second. The simulation, meanwhile, runs every
+ * frame.
+ *
+ * Feeding a sampled rect straight to a per-frame solver is what makes
+ * a dragged window shove Mio in lurches: the window's own `left` /
+ * `top` are written on every `pointermove`, so by the time the next
+ * sample lands the rect has travelled a whole throttle interval, and
+ * the contact pass — which is a positional push — applies that entire
+ * delta in one step. Mio hops, holds for three frames, hops again.
+ *
+ * The fix is not a faster sample. It is to stop treating samples as
+ * *the truth right now* and start treating them as **keyframes**: hold
+ * the previous sample alongside the current one and hand the solver a
+ * rect lerped between the two across the interval that separated them.
+ * A 20 Hz measurement then drives a 60 Hz push, smoothly.
+ *
+ * The cost is that Mio reacts one sample interval late — it is chasing
+ * where the window *was* 50 ms ago. That is invisible on a decorative
+ * blob, and it is the trade that makes this preferable to
+ * extrapolation, which buys back the latency but overshoots every time
+ * the window stops and then snaps back.
+ *
+ * Two things this deliberately does **not** interpolate:
+ *
+ *   - **An obstacle with no previous keyframe** — a window that just
+ *     opened, or the very first sample. It appears solid where it is.
+ *     Sliding it in from nowhere would mean a window materialised
+ *     mid-desk and then swept across it.
+ *   - **Anything, after {@link ObstacleTrack.reset}.** A layout change
+ *     re-bases every coordinate at once; lerping across that is a
+ *     smear, not motion.
+ *
+ * Pure and DOM-free, like the rest of `environment.ts`, so the
+ * behaviour is unit testable without a browser.
+ */
+
+import type { Obstacle } from './environment';
+
+/**
+ * Gap between samples, past which the pair is not one motion.
+ *
+ * A tab that was in the background comes back with two samples that are
+ * before-and-after rather than two moments of a drag. Sweeping the
+ * whole desk from one to the other would be a smear across everything
+ * at once, so the newer sample is taken at face value instead.
+ */
+const MAX_STALE_MS = 250;
+
+/** A pair of sampled desks, presented as one continuously moving desk. */
+export interface ObstacleTrack {
+	/**
+	 * Record a freshly measured desk as the newest keyframe.
+	 *
+	 * @param obstacles The measured obstacle set. Retained by reference
+	 *                  until the next sample — and handed straight back
+	 *                  out of `at()` while the desk is still — so pass a
+	 *                  fresh array, not a reused buffer.
+	 * @param nowMs     Timestamp of the measurement.
+	 */
+	sample( obstacles: readonly Obstacle[], nowMs: number ): void;
+	/**
+	 * The desk as it stands at `nowMs`, interpolated between the two
+	 * newest keyframes.
+	 *
+	 * Never runs past the newest keyframe: a frame that arrives late
+	 * holds against it rather than extrapolating, because overshooting
+	 * and snapping back is the artefact this module exists to avoid and
+	 * it would reappear at the end of every drag.
+	 *
+	 * @param nowMs Frame timestamp, on the same clock as `sample()`.
+	 */
+	at( nowMs: number ): readonly Obstacle[];
+	/**
+	 * Drop the interpolation history, keeping the newest keyframe.
+	 *
+	 * For discontinuities that are not motion — a shell resize rebasing
+	 * every coordinate. The next `at()` returns the newest sample
+	 * verbatim rather than lerping toward it from coordinates that
+	 * meant something else.
+	 */
+	reset(): void;
+}
+
+/**
+ * Key a sample by identity, disambiguating repeats.
+ *
+ * Surface ids are namespaced and stable (`window:foo`, `dock:edge`),
+ * which is what makes matching across two samples possible at all. They
+ * are not, however, *guaranteed* unique — the widget branch of
+ * `collectWallpaperSurfaces()` falls back to a positional index when a
+ * card has no `data-widget-id`, and a plugin filter can return whatever
+ * it likes. An occurrence counter keeps a duplicate id from collapsing
+ * two obstacles onto one key, which would drop one of them from the
+ * interpolated set entirely.
+ */
+function keyed( obstacles: readonly Obstacle[] ): Map< string, Obstacle > {
+	const out = new Map< string, Obstacle >();
+	const seen = new Map< string, number >();
+	for ( const o of obstacles ) {
+		const n = seen.get( o.id ) ?? 0;
+		seen.set( o.id, n + 1 );
+		out.set( 0 === n ? o.id : `${ o.id }#${ n }`, o );
+	}
+	return out;
+}
+
+/** Whether two keyed samples describe the same geometry. */
+function unchanged(
+	a: Map< string, Obstacle >,
+	b: Map< string, Obstacle >,
+): boolean {
+	if ( a.size !== b.size ) {
+		return false;
+	}
+	for ( const [ key, prev ] of a ) {
+		const next = b.get( key );
+		if (
+			! next ||
+			next.x !== prev.x ||
+			next.y !== prev.y ||
+			next.width !== prev.width ||
+			next.height !== prev.height
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function lerp( a: number, b: number, t: number ): number {
+	return a + ( b - a ) * t;
+}
+
+/**
+ * Create an obstacle track.
+ *
+ * A still desk — the overwhelmingly common case — costs nothing: the
+ * two keyframes are geometrically identical, so `at()` short-circuits
+ * and hands back the measured array itself, exactly as the caller would
+ * have had without any of this.
+ *
+ * **`intervalMs` is the caller's throttle, not the measured gap between
+ * the last two samples, and that is what makes the hand-off seamless.**
+ * The gap varies — the ticker decides which frame `readSurfaces()`
+ * actually runs on, so a 50 ms throttle produces gaps of 50 ms and
+ * 66.7 ms in whatever order the frames fall. Spreading the lerp over
+ * the *previous* gap and then sampling early leaves the interpolation
+ * unfinished, and the new keyframe pair starts from the position the
+ * old one was still travelling toward: a jump, the smaller cousin of
+ * exactly the one this module exists to remove. Spreading it over the
+ * throttle instead guarantees the lerp has arrived before the next
+ * sample can land, because the throttle is a floor on the gap. The
+ * worst case degrades to a hold of a frame or two at the end of an
+ * interval, which reads as nothing at all.
+ *
+ * @param intervalMs The caller's minimum gap between `sample()` calls.
+ */
+export function createObstacleTrack( intervalMs: number ): ObstacleTrack {
+	const interval = Math.max( 1, intervalMs );
+	let previous = new Map< string, Obstacle >();
+	let current = new Map< string, Obstacle >();
+	/** The measured array behind `current`, for the still-desk path. */
+	let currentList: readonly Obstacle[] = [];
+	let sampledAt = 0;
+	/** True while the desk is not moving, or while history is dropped. */
+	let still = true;
+
+	return {
+		sample( obstacles: readonly Obstacle[], nowMs: number ): void {
+			const gap = nowMs - sampledAt;
+			previous = current;
+			current = keyed( obstacles );
+			currentList = obstacles;
+			sampledAt = nowMs;
+			still = gap > MAX_STALE_MS || unchanged( previous, current );
+		},
+
+		at( nowMs: number ): readonly Obstacle[] {
+			if ( still ) {
+				return currentList;
+			}
+			const t = Math.min(
+				1,
+				Math.max( 0, ( nowMs - sampledAt ) / interval ),
+			);
+			if ( 1 <= t ) {
+				return currentList;
+			}
+			const out: Obstacle[] = [];
+			for ( const [ key, o ] of current ) {
+				const prev = previous.get( key );
+				if ( ! prev ) {
+					// Newly on the desk: solid where it is.
+					out.push( o );
+					continue;
+				}
+				out.push( {
+					id: o.id,
+					kind: o.kind,
+					face: o.face,
+					x: lerp( prev.x, o.x, t ),
+					y: lerp( prev.y, o.y, t ),
+					width: lerp( prev.width, o.width, t ),
+					height: lerp( prev.height, o.height, t ),
+				} );
+			}
+			return out;
+		},
+
+		reset(): void {
+			previous = current;
+			still = true;
+		},
+	};
+}

--- a/tests/vitest/mio-obstacle-track.test.ts
+++ b/tests/vitest/mio-obstacle-track.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Mio obstacle interpolation — turning a throttled measurement of the
+ * desk into a desk that moves continuously, so a dragged window pushes
+ * Mio smoothly instead of one lurch per sample.
+ */
+import { describe, expect, test } from 'vitest';
+import { createObstacleTrack } from '../../src/mio/obstacle-track';
+import type { Obstacle } from '../../src/mio/environment';
+
+function obstacle( over: Partial< Obstacle > = {} ): Obstacle {
+	return {
+		id: 'window:posts',
+		kind: 'window',
+		face: 'top',
+		x: 100,
+		y: 200,
+		width: 400,
+		height: 300,
+		...over,
+	};
+}
+
+/** The throttle Mio samples the desk on, and the lerp window. */
+const INTERVAL = 50;
+
+/** The single obstacle in a track's view of the desk at `nowMs`. */
+function only(
+	track: ReturnType< typeof createObstacleTrack >,
+	nowMs: number,
+): Obstacle {
+	const set = track.at( nowMs );
+	expect( set ).toHaveLength( 1 );
+	return set[ 0 ];
+}
+
+describe( 'createObstacleTrack', () => {
+	test( 'the first sample is solid where it is, not lerped in from nowhere', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle() ], 1000 );
+
+		// Half an interval later it must still be exactly where it was
+		// measured: a window that just appeared has no history to
+		// slide in from.
+		expect( only( track, 1025 ) ).toMatchObject( { x: 100, y: 200 } );
+	} );
+
+	test( 'a still desk hands back the measured array untouched', () => {
+		const track = createObstacleTrack( INTERVAL );
+		const first = [ obstacle() ];
+		track.sample( first, 1000 );
+		const second = [ obstacle() ];
+		track.sample( second, 1050 );
+
+		// Identity, not just equality — the still-desk path is the
+		// common case and must not allocate a parallel set per frame.
+		expect( track.at( 1075 ) ).toBe( second );
+	} );
+
+	test( 'a moving obstacle is presented one interval behind, continuously', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { x: 100 } ) ], 1000 );
+		track.sample( [ obstacle( { x: 150 } ) ], 1050 );
+
+		// At the sample instant we show where it *was* — the lag that
+		// buys the smoothness.
+		expect( only( track, 1050 ).x ).toBe( 100 );
+		expect( only( track, 1062.5 ).x ).toBe( 112.5 );
+		expect( only( track, 1075 ).x ).toBe( 125 );
+		expect( only( track, 1100 ).x ).toBe( 150 );
+	} );
+
+	test( 'the presented position never runs past the newest sample', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { x: 100 } ) ], 1000 );
+		track.sample( [ obstacle( { x: 150 } ) ], 1050 );
+
+		// A late frame clamps rather than extrapolating: overshooting
+		// and snapping back is the artefact this module exists to
+		// avoid, and it would reappear every time a drag stopped.
+		expect( only( track, 5000 ).x ).toBe( 150 );
+	} );
+
+	test( 'successive samples hand off without a seam', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { x: 100 } ) ], 1000 );
+		track.sample( [ obstacle( { x: 150 } ) ], 1050 );
+		const endOfInterval = only( track, 1100 ).x;
+
+		track.sample( [ obstacle( { x: 200 } ) ], 1100 );
+		expect( only( track, 1100 ).x ).toBe( endOfInterval );
+	} );
+
+	test( 'a short gap after a long one still hands off without a seam', () => {
+		// The gaps between samples are irregular by construction: a
+		// 50 ms throttle read on 16.7 ms frames fires at 50 ms and at
+		// 66.7 ms in whatever order the frames fall. Spreading the lerp
+		// over the *measured* previous gap would leave it unfinished
+		// whenever a short gap follows a long one, and the next keyframe
+		// pair would start from the position the last one was still
+		// travelling toward — a jump.
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { x: 100 } ) ], 1000 );
+		track.sample( [ obstacle( { x: 150 } ) ], 1066.7 );
+
+		// The lerp spans the throttle, which the throttle guarantees is
+		// no longer than the gap — so it has arrived by now.
+		expect( only( track, 1116.7 ).x ).toBe( 150 );
+
+		track.sample( [ obstacle( { x: 200 } ) ], 1116.7 );
+		expect( only( track, 1116.7 ).x ).toBe( 150 );
+	} );
+
+	test( 'size is interpolated too, so a resizing window sweeps', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { width: 400, height: 300 } ) ], 1000 );
+		track.sample( [ obstacle( { width: 500, height: 400 } ) ], 1050 );
+
+		expect( only( track, 1075 ) ).toMatchObject( {
+			width: 450,
+			height: 350,
+		} );
+	} );
+
+	test( 'a window that opens mid-drag appears solid, its neighbour keeps lerping', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { id: 'window:a', x: 100 } ) ], 1000 );
+		track.sample(
+			[
+				obstacle( { id: 'window:a', x: 150 } ),
+				obstacle( { id: 'window:b', x: 700 } ),
+			],
+			1050,
+		);
+
+		const set = track.at( 1075 );
+		expect( set.find( ( o ) => 'window:a' === o.id )?.x ).toBe( 125 );
+		expect( set.find( ( o ) => 'window:b' === o.id )?.x ).toBe( 700 );
+	} );
+
+	test( 'a window that closes simply leaves the set', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample(
+			[
+				obstacle( { id: 'window:a', x: 100 } ),
+				obstacle( { id: 'window:b', x: 700 } ),
+			],
+			1000,
+		);
+		track.sample( [ obstacle( { id: 'window:a', x: 150 } ) ], 1050 );
+
+		const set = track.at( 1075 );
+		expect( set.map( ( o ) => o.id ) ).toEqual( [ 'window:a' ] );
+	} );
+
+	test( 'duplicate ids stay two obstacles', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample(
+			[
+				obstacle( { id: 'widget:0', x: 100 } ),
+				obstacle( { id: 'widget:0', x: 700 } ),
+			],
+			1000,
+		);
+		track.sample(
+			[
+				obstacle( { id: 'widget:0', x: 150 } ),
+				obstacle( { id: 'widget:0', x: 750 } ),
+			],
+			1050,
+		);
+
+		// Keying on the bare id would collapse the pair and silently
+		// drop one solid surface out of the simulation.
+		expect( track.at( 1075 ).map( ( o ) => o.x ) ).toEqual( [ 125, 725 ] );
+	} );
+
+	test( 'a long gap between samples is taken at face value', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { x: 100 } ) ], 1000 );
+		// Tab backgrounded for two seconds. Interpolating across that
+		// would crawl the desk toward its real position for a quarter
+		// of a second after the user came back.
+		track.sample( [ obstacle( { x: 900 } ) ], 3000 );
+
+		expect( only( track, 3125 ).x ).toBe( 900 );
+	} );
+
+	test( 'reset drops the history, keeping the newest sample', () => {
+		const track = createObstacleTrack( INTERVAL );
+		track.sample( [ obstacle( { x: 100 } ) ], 1000 );
+		track.sample( [ obstacle( { x: 150 } ) ], 1050 );
+		track.reset();
+
+		// A layer rebase is not motion — after it, the newest
+		// measurement is the truth immediately.
+		expect( only( track, 1050 ).x ).toBe( 150 );
+		expect( only( track, 1075 ).x ).toBe( 150 );
+	} );
+} );


### PR DESCRIPTION
Mio jumped rather than slid when a window was dragged into it: resting against a window edge, it hopped, held for three frames, and hopped again as the window swept past.

## What was actually wrong

Not the window hooks. `src/window/pointer.ts` writes the window's `left` / `top` on every `pointermove`, and `WINDOW_BOUNDS_CHANGED` is rAF-coalesced — both are ~60 Hz. Mio doesn't listen to that hook at all; it **polls** `wp.os.getWallpaperSurfaces()` behind `SURFACE_REFRESH_MS = 50`. So its obstacle set was up to three frames stale, then advanced by a whole interval of pointer travel at once — and contact resolution is a positional push, so that entire delta landed in one step.

## The fix

Not a faster sample. Stop treating a sample as *the truth right now* and start treating it as a **keyframe**: hold the previous sample beside the current one and hand the solver a rect lerped between the two, so a 20 Hz measurement drives a 60 Hz push. Sizes interpolate too, which makes a resizing window sweep against Mio instead of stepping.

New module `src/mio/obstacle-track.ts`; `readSurfaces()` in `src/mio/mio.ts` now samples on the throttle and *presents* every frame.

### The lerp spans the throttle, not the measured gap

This is the part that took a second pass. The gap between samples is irregular by construction — the ticker decides which frame `readSurfaces()` runs on, so a 50 ms throttle fires at 50 ms and at 66.7 ms in whatever order the frames fall. Spread the lerp over the *previous gap* and it is left unfinished whenever a short gap follows a long one, so the next keyframe pair starts from the position the last one was still travelling toward — a jump, the smaller cousin of the one being removed.

Spread over the **throttle**, it has always arrived before the next sample can land, because the throttle is a floor on the gap. The worst case degrades to a hold of a frame or two at the end of an interval. `mio-obstacle-track.test.ts` pins that case specifically.

### Interpolation, not extrapolation

Costs one interval of latency — Mio is pushed by where the window was 50 ms ago, invisible on a decorative blob — and buys never overshooting and snapping back when the drag stops.

### Three cases deliberately not interpolated

None of them are motion:

- **No previous keyframe** — a window that just opened is solid where it is. Sliding it in from nowhere would read as a window materialising mid-desk and then sweeping across it.
- **A gap longer than 250 ms** — the tab was in the background; the two samples are before-and-after, not two moments of one movement.
- **After a layer resize** — a new origin re-bases every obstacle coordinate at once, so the track drops its history rather than lerp the whole desk across the rebase.

A still desk, the overwhelmingly common case, short-circuits and hands back the measured array itself — no allocation, byte-identical behaviour to before.

## Scope

Contact still treats obstacles as **static**: a moving window displaces Mio without imparting momentum, exactly as today. The same keyframe pair would give obstacle velocity for free, but making contact reflect about relative velocity changes how contact feels everywhere, not just during drags — deliberately left out.

Internal only: no hook, no `wp.os` surface, no payload change.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` — clean
- `npm run test:js` — 299 files, 3646 tests green (12 new)
- Manual: drag a window into Mio while it rests against a desk edge; the push is continuous instead of stepping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-481-37842a7e8590bcc6a4a541c36392eec51d44c279.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20OpenStation%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;openstation_is_enabled&#039;%20)%20%7C%7C%20!%20openstation_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;openstation&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.os.ready(function()%7Bvar%20games%3Dwindow.wp.os.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->