### PR TITLE
Hide desktop icons and files layer during Overview

### DIFF
--- a/assets/css/window-overview.css
+++ b/assets/css/window-overview.css
@@ -160,6 +160,23 @@
 	}
 }
 
+/*
+ * Desktop shortcut icons & files-layer tiles —
+ * hidden during overview so they don't compete with window
+ * thumbnails or overlap them (especially noticeable with few
+ * windows or Spatial layout). Matches the fade-out pattern
+ * used by widgets and sticky notes. Scoped to DIRECT children
+ * of the desktop area only: folder windows mount their own
+ * files layer inside the window body, and that must stay
+ * visible in its thumbnail.
+ */
+.os-area--overview > .os-icons,
+.os-area--overview > .os-files-layer {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.22s ease;
+}
+
 /* ---------------------------------------------------------------
  * Overview thumbnail labels.
  *
@@ -268,6 +285,10 @@
 @media ( prefers-reduced-motion: reduce ) {
 	.os-area--overview,
 	.os-window--overview {
+		transition-duration: 0.01ms;
+	}
+	.os-area--overview > .os-icons,
+	.os-area--overview > .os-files-layer {
 		transition-duration: 0.01ms;
 	}
 }


### PR DESCRIPTION
This PR fixes desktop shortcut icons (wpd-tile elements and legacy icons) remaining visible and overlapping window thumbnails when the user enters the Overview (zoom-out grid) view. The icons and files layer now fade out during Overview, matching how widgets, sticky notes, and the dock already behave.

Closes #453 

## Why?
Overview is a task-switching view - its job is to show only open windows so the user can pick one. 
But the desktop icons and file tiles stayed visible at full opacity beside the thumbnails, and with few open windows (e.g. 2), the left thumbnail could visually collide with a tile, which looked broken. 
The Spatial desktop layout made this worst, since it renders core menu items as desktop icons on the wallpaper, producing more tiles to collide with. 
Every other non-window surface (widgets, notes, dock) already hides during Overview, so leaving icons and tiles visible was an inconsistency, not a deliberate choice.

## What Changed?

| **Before**                                                                                                             | **After**                                                                                                             |
| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
| <img width="600" alt="Before" src="https://github.com/user-attachments/assets/bedf236e-d3a7-4643-8694-5b41105c237a" /> | <img width="600" alt="After" src="https://github.com/user-attachments/assets/9609f9e9-de75-450e-97b4-78b2d03f18a2" /> |

- Added a CSS rule in `assets/css/window-overview.css` that fades .desktop-mode-icons and .desktop-mode-files-layer to opacity: 0 with pointer-events: none (0.22s ease transition) when .desktop-mode-area--overview is active, matching the existing widget/sticky-note fade pattern.
- Scoped the selector with the direct-child combinator (>) so files layers mounted inside folder-native-window bodies are excluded - folder thumbnails in the grid keep their tiles visible.
- Extended the prefers-reduced-motion block to collapse the new transition to 0.01ms for accessibility.