### PR TITLE
Restore the widget layer, and make session persistence hold

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,6 +178,8 @@ REST surface:
 - `POST /wp-json/desktop-mode/v1/session` — overwrite the session. Body: `{ session: { windows: [...], desktops: [...], activeDesktop, focused, updated } }`.
 - `DELETE /wp-json/desktop-mode/v1/session` — clear it.
 
+`updated` is the write-ordering key, in **epoch milliseconds** (`Date.now()`). The server rejects a POST whose `updated` is lower than the stored one, so a slow request that was snapshotted earlier cannot clobber newer state — the case that matters is a `keepalive` fetch still in flight when the `pagehide` beacon fires. Equal values tie and the first processed wins. Omit the field and the server stamps it for you; sessions written before the field moved to milliseconds carry a seconds value, which any current write outranks.
+
 ### What comes back, and how
 
 Two kinds of window are persisted, restored by two different routes.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1289,6 +1289,8 @@ window.wp.os.windowManager.focus( someWindow );
 window.wp.os.saveSession();
 ```
 
+Calling it is cheap and safe to do liberally — it schedules, it does not send. Writes are trailing-edge debounced and then rate limited to at most one network request per interval, so a burst of changes collapses into a single POST. Nothing is dropped to achieve that: a call that arrives too soon is delayed rather than discarded, a call made while a request is in flight is re-sent after it settles, and `pagehide` flushes the current snapshot past both the debounce and the rate limit via `navigator.sendBeacon`. The last state always reaches the server.
+
 ---
 
 ### `presence` — Stable

--- a/includes/session.php
+++ b/includes/session.php
@@ -36,6 +36,20 @@ const OPENSTATION_SESSION_MAX_DESKTOPS = 16;
 /** Allowed values for a window's state field. */
 const OPENSTATION_SESSION_STATES = array( 'normal', 'minimized', 'maximized', 'fullscreen' );
 
+/**
+ * Current time as epoch milliseconds.
+ *
+ * The session's `updated` field is the ordering key for the
+ * stale-write guard and the client stamps it with `Date.now()`.
+ * Server-side fallbacks have to speak the same unit — see
+ * {@see openstation_save_session()} for why the resolution matters.
+ *
+ * @return int Epoch milliseconds.
+ */
+function openstation_session_now_ms() {
+	return (int) round( microtime( true ) * 1000 );
+}
+
 /** Default desktop entry seeded into empty / corrupt sessions. */
 function openstation_default_desktop() {
 	return array(
@@ -107,12 +121,25 @@ function openstation_get_session( $user_id ) {
  * Rejects writes whose `updated` timestamp is older than what's
  * already on file — a simple last-write-wins guard that prevents two
  * tabs open on the same user from clobbering each other. The client
- * stamps `updated` with `Math.floor(Date.now() / 1000)` at snapshot
- * time (see `WindowManager.snapshot`), so this comparison lines up
- * with real wall-clock ordering on same-machine multi-tab setups.
+ * stamps `updated` with `Date.now()` — epoch MILLISECONDS — at
+ * snapshot time (see `WindowManager.snapshot`), so this comparison
+ * lines up with real wall-clock ordering on same-machine multi-tab
+ * setups.
  *
- * Equal timestamps (two writes in the same second) are accepted —
- * that's a tie and whichever the server processes first wins.
+ * Millisecond resolution is load-bearing, not cosmetic. The two
+ * writes that race hardest are a `keepalive` fetch still in flight
+ * and the `pagehide` beacon that supersedes it; at second resolution
+ * they tie, and the tie rule below hands the win to whichever the
+ * server processes last — which can be the stale one, reinstating a
+ * window the user just closed.
+ *
+ * Sessions written before the switch carry a seconds value. Those are
+ * ~1000x smaller than any millisecond stamp, so the first write after
+ * an upgrade always wins — which is the correct outcome for a stamp
+ * that is genuinely older.
+ *
+ * Equal timestamps are still accepted — that's a tie and whichever the
+ * server processes first wins.
  *
  * @param int   $user_id The user ID.
  * @param array $session Raw session payload (will be sanitized).
@@ -171,15 +198,18 @@ function openstation_sanitize_session( $session ) {
 	$clean = openstation_empty_session();
 
 	if ( ! is_array( $session ) ) {
-		$clean['updated'] = time();
+		$clean['updated'] = openstation_session_now_ms();
 		return $clean;
 	}
 
 	// Preserve the client's `updated` timestamp so the stale-write guard
 	// in openstation_save_session compares client-to-client (not client-to-server
-	// wallclock) — two saves landing in the same second must tie, not lose.
+	// wallclock) — two saves landing in the same millisecond must tie, not lose.
+	// The fallback matches the client's unit (epoch milliseconds); mixing
+	// units here would store a seconds value that every later comparison
+	// treats as ancient, quietly disabling the guard.
 	$incoming_updated = isset( $session['updated'] ) ? (int) $session['updated'] : 0;
-	$clean['updated'] = $incoming_updated > 0 ? $incoming_updated : time();
+	$clean['updated'] = $incoming_updated > 0 ? $incoming_updated : openstation_session_now_ms();
 
 	if ( isset( $session['focused'] ) && is_string( $session['focused'] ) ) {
 		$clean['focused'] = sanitize_key( $session['focused'] );

--- a/src/boot/session-saver.ts
+++ b/src/boot/session-saver.ts
@@ -2,8 +2,8 @@
  * Boot-time session saver.
  *
  * Owns the debounced + immediate session persistence pipeline:
- * normal mutations schedule a debounced REST POST through
- * `trackedFetch`; unload-time saves use `navigator.sendBeacon`
+ * normal mutations schedule a debounced, rate-limited REST POST
+ * through `trackedFetch`; unload-time saves use `navigator.sendBeacon`
  * with the nonce on the URL because WP REST's cookie-auth
  * middleware reads the nonce from `$_REQUEST` (URL query string +
  * form-encoded body), NOT from JSON bodies.
@@ -21,6 +21,21 @@ import type { DesktopConfig } from '../types';
 const SESSION_SAVE_DEBOUNCE_MS = 500;
 
 /**
+ * Floor (ms) between the starts of two consecutive network writes.
+ *
+ * The debounce alone only collapses changes that arrive closer
+ * together than its own window. Closing three windows a beat apart
+ * clears it every time and posts three times; so does a settling
+ * in-flight save handing straight over to its queued successor. This
+ * is the rate limit underneath the debounce — never more than one
+ * write per interval, however the changes are spaced.
+ *
+ * Nothing is dropped to honour it: a save that arrives too soon is
+ * delayed to the floor, and unload still flushes immediately.
+ */
+const SESSION_SAVE_MIN_INTERVAL_MS = 1500;
+
+/**
  * Creates the debounced+immediate session saver. Returns a single
  * function that schedules a debounced REST write on each call.
  * Also exposed on `wp.os.saveSession()` for plugins that want
@@ -32,13 +47,31 @@ export function createSessionSaver(
 ): () => void {
 	let debounceTimer: number | null = null;
 	let inFlight = false;
+	let dirty = false;
+	/** When the last network write started. 0 = none yet. */
+	let lastSaveStartedAt = 0;
 
 	const doSave = async (): Promise< void > => {
 		if ( inFlight ) {
+			// A save is already on the wire, and this call was
+			// triggered by state the in-flight payload predates.
+			// Dropping it here loses that mutation for good — the
+			// debounce timer has already fired and cleared itself, so
+			// nothing retries. Mark the session dirty instead and
+			// re-run once the current request settles.
+			//
+			// Symptom of getting this wrong: close two windows in
+			// quick succession on a slow connection, reload, and the
+			// second one is back.
+			dirty = true;
 			return;
 		}
-		const payload = manager.snapshot();
 		inFlight = true;
+		lastSaveStartedAt = Date.now();
+		// Snapshot as late as possible — after the in-flight guard —
+		// so the payload reflects the state at send time, not at the
+		// moment the save was queued.
+		const payload = manager.snapshot();
 		try {
 			// Session save is a debounced background ping — silent
 			// so the user doesn't see a spinner every time they
@@ -67,6 +100,14 @@ export function createSessionSaver(
 			doAction( HOOKS.SHELL_ERROR, { scope: 'session-save', error: err } );
 		} finally {
 			inFlight = false;
+			if ( dirty ) {
+				dirty = false;
+				// Back through `schedule()`, not straight into another
+				// `doSave()`. Handing over directly would let a slow
+				// request chain into an immediate second write and
+				// sidestep both the debounce and the rate limit.
+				schedule();
+			}
 		}
 	};
 
@@ -75,6 +116,10 @@ export function createSessionSaver(
 			clearTimeout( debounceTimer );
 			debounceTimer = null;
 		}
+		// The beacon below carries a snapshot taken right now, so it
+		// supersedes any queued re-run. Clearing the flag keeps a
+		// settling in-flight save from firing a redundant duplicate.
+		dirty = false;
 		// Use sendBeacon for unload-time saves where fetch may not
 		// complete. WP REST's cookie-auth middleware reads the nonce
 		// from `$_REQUEST` (URL query string + form-encoded body),
@@ -106,10 +151,24 @@ export function createSessionSaver(
 		if ( debounceTimer !== null ) {
 			clearTimeout( debounceTimer );
 		}
+		// Trailing-edge debounce, then held back to the rate limit if
+		// the previous write started too recently. Whichever wait is
+		// longer governs — so a burst collapses to one write, and a
+		// steady drip of changes still can't exceed one write per
+		// interval. The delay only postpones; the last snapshot always
+		// lands, and `pagehide` flushes past all of it.
+		let wait = SESSION_SAVE_DEBOUNCE_MS;
+		if ( lastSaveStartedAt !== 0 ) {
+			const sinceLastSave = Date.now() - lastSaveStartedAt;
+			wait = Math.max(
+				wait,
+				SESSION_SAVE_MIN_INTERVAL_MS - sinceLastSave,
+			);
+		}
 		debounceTimer = window.setTimeout( () => {
 			debounceTimer = null;
 			void doSave();
-		}, SESSION_SAVE_DEBOUNCE_MS ) as unknown as number;
+		}, wait ) as unknown as number;
 	};
 
 	// pagehide is the reliable unload signal across browsers

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1837,7 +1837,7 @@ function init(): void {
 	// built-ins synchronously so the `os.widgets` filter
 	// already carries them when plugins hook in, then hydrate the
 	// layer which mounts whichever widgets the user last had on.
-	const widgetsEl = document.getElementById( 'desktop-mode-widgets' );
+	const widgetsEl = document.getElementById( 'os-widgets' );
 	let widgetLayer: WidgetLayer | null = null;
 	registerBuiltInWidgets();
 	// Dock rail renderer registry — install the built-in `'default'`

--- a/src/window-links/render-host.ts
+++ b/src/window-links/render-host.ts
@@ -327,7 +327,7 @@ export function startWindowLinkRenderHost( {
 		elevatedLayer.setAttribute( 'aria-hidden', 'true' );
 		// After the widget layer so DOM order mirrors the z-order
 		// (widgets z 1 → links z 50 → windows z 100+).
-		const widgets = document.getElementById( 'desktop-mode-widgets' );
+		const widgets = document.getElementById( 'os-widgets' );
 		if ( widgets && widgets.parentElement === area ) {
 			widgets.insertAdjacentElement( 'afterend', elevatedLayer );
 			widgets.insertAdjacentElement( 'afterend', layer );

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -1711,7 +1711,15 @@ export class WindowManager {
 			desktops: this.getDesktops(),
 			activeDesktop: this._activeDesktopId,
 			focused: focusedId,
-			updated: Math.floor( Date.now() / 1000 ),
+			// Epoch MILLISECONDS, not seconds. This is the ordering key
+			// the server's stale-write guard compares, and at second
+			// resolution the two writes that race hardest — a
+			// `keepalive` fetch still on the wire and the `pagehide`
+			// beacon that supersedes it — almost always tie. A tie is
+			// accepted, so the loser is whichever the server happens to
+			// process last, and a stale payload can reinstate a window
+			// the user just closed. Milliseconds separate them.
+			updated: Date.now(),
 		};
 	}
 

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -39,7 +39,7 @@ const OVERVIEW_INERT_ELEMENTS = [
 	'adminmenuback',
 	'os-dock',
 	'os-side-dock',
-	'desktop-mode-widgets',
+	'os-widgets',
 ];
 
 const OVERVIEW_FULLSCREEN_DATA_KEY = 'osHadFullscreenBeforeOverview';

--- a/tests/phpunit/tests/openStationSession.php
+++ b/tests/phpunit/tests/openStationSession.php
@@ -413,6 +413,69 @@ class Tests_OpenStation_Session extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The two writes that race hardest are a `keepalive` fetch still
+	 * in flight and the `pagehide` beacon that supersedes it. They can
+	 * land milliseconds apart, so the ordering key has to resolve
+	 * milliseconds — at second granularity they tie, the tie rule
+	 * hands the win to whichever the server processes last, and a
+	 * stale payload reinstates a window the user just closed.
+	 *
+	 * @covers ::openstation_save_session
+	 */
+	public function test_save_session_orders_writes_within_the_same_second() {
+		$base = 1_700_000_000_000; // Epoch ms.
+
+		// Beacon: the user closed the window, snapshot has none.
+		$beacon = array(
+			'windows' => array(),
+			'focused' => '',
+			'updated' => $base + 500,
+		);
+		$this->assertTrue( openstation_save_session( self::$admin_id, $beacon ) );
+
+		// The slower `keepalive` fetch, snapshotted 300ms EARLIER,
+		// arrives second and still carries the window.
+		$stale = array(
+			'windows' => array( $this->make_window() ),
+			'focused' => 'wp-window-edit-php',
+			'updated' => $base + 200,
+		);
+		$this->assertFalse(
+			openstation_save_session( self::$admin_id, $stale ),
+			'A late-arriving older snapshot must not reopen a closed window.'
+		);
+
+		$stored = openstation_get_session( self::$admin_id );
+		$this->assertCount(
+			0,
+			$stored['windows'],
+			'The closed window must stay closed after a reload.'
+		);
+	}
+
+	/**
+	 * The server-side fallback stamp has to speak the same unit as the
+	 * client's `Date.now()`. Mixing units would store a seconds value
+	 * that every later millisecond comparison treats as ancient,
+	 * quietly disabling the stale-write guard.
+	 *
+	 * @covers ::openstation_sanitize_session
+	 * @covers ::openstation_session_now_ms
+	 */
+	public function test_sanitize_session_fallback_timestamp_is_milliseconds() {
+		$clean = openstation_sanitize_session(
+			array(
+				'windows' => array( $this->make_window() ),
+				// no `updated` — server must stamp it.
+			)
+		);
+
+		// Epoch ms is ~1000x epoch seconds. Anchor on a date well in
+		// the past so the assertion never goes stale.
+		$this->assertGreaterThan( 1_600_000_000_000, $clean['updated'] );
+	}
+
+	/**
 	 * Missing `updated` on the incoming payload should not block the
 	 * save — first-write-ever and edge cases where the client couldn't
 	 * compute a timestamp stay functional.

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -471,6 +471,20 @@ describe( 'WindowManager — virtual desktops', async () => {
 		expect( snap.focused ).toBe( '' );
 	} );
 
+	test( 'snapshot stamps `updated` in epoch milliseconds', async () => {
+		await manager.open( openConfig( 'a' ) );
+
+		const before = Date.now();
+		const snap = manager.snapshot();
+		const after = Date.now();
+
+		// `updated` is the server's stale-write ordering key. At second
+		// resolution the `keepalive` fetch and the `pagehide` beacon
+		// tie, and a stale payload can reinstate a closed window.
+		expect( snap.updated ).toBeGreaterThanOrEqual( before );
+		expect( snap.updated ).toBeLessThanOrEqual( after );
+	} );
+
 	// -----------------------------------------------------------------
 	// Active-desktop scoping for isActive / isActiveByBaseId /
 	// getAllByBaseIdOnActiveDesktop / minimizeAll / restoreFrom /
@@ -625,7 +639,7 @@ describe( 'WindowManager — virtual desktops', async () => {
 				document.body.appendChild( sideDock );
 				toRemove.push( sideDock );
 				const widgets = document.createElement( 'div' );
-				widgets.id = 'desktop-mode-widgets';
+				widgets.id = 'os-widgets';
 				document.body.appendChild( widgets );
 				toRemove.push( widgets );
 

--- a/tests/vitest/observability.test.ts
+++ b/tests/vitest/observability.test.ts
@@ -359,7 +359,7 @@ describe( 'SHELL_ERROR action fires alongside mount failures', () => {
 		] );
 
 		const host = document.createElement( 'div' );
-		host.id = 'desktop-mode-widgets';
+		host.id = 'os-widgets';
 		document.body.appendChild( host );
 		const layer = new WidgetLayer( host, '' );
 		layer.ensureMounted( 'boom' );
@@ -618,7 +618,7 @@ describe( 'WidgetLayer.ensureMounted', () => {
 	test( 'returns false for an unregistered id', async () => {
 		const { WidgetLayer } = await import( '../../src/widgets/layer' );
 		const host = document.createElement( 'div' );
-		host.id = 'desktop-mode-widgets';
+		host.id = 'os-widgets';
 		document.body.appendChild( host );
 		const layer = new WidgetLayer( host, '' );
 		expect( layer.ensureMounted( 'really-not-a-widget-id-xyz' ) ).toBe( false );
@@ -638,7 +638,7 @@ describe( 'WidgetLayer.ensureMounted', () => {
 		} );
 
 		const host = document.createElement( 'div' );
-		host.id = 'desktop-mode-widgets';
+		host.id = 'os-widgets';
 		document.body.appendChild( host );
 		const layer = new WidgetLayer( host, '' );
 

--- a/tests/vitest/session-saver.test.ts
+++ b/tests/vitest/session-saver.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for the boot-time session saver — the pipeline that persists
+ * open windows so a reload brings the desktop back the way the user
+ * left it.
+ *
+ * The bugs these pin are all the same user-visible symptom: "I close a
+ * window, refresh, and it's back." Each has a different cause.
+ *
+ *   1. A save triggered while another is on the wire used to be
+ *      DROPPED — the debounce timer had already fired and cleared
+ *      itself, so nothing retried and the mutation was lost.
+ *   2. The unload beacon must carry a snapshot taken at unload time,
+ *      with the nonce on the URL (WP REST reads it from `$_REQUEST`,
+ *      never from a JSON body).
+ *   3. `updated` is the server's stale-write ordering key, and at
+ *      second resolution the `keepalive` fetch and the `pagehide`
+ *      beacon tie — letting a stale payload win.
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from 'vitest';
+import { createSessionSaver } from '../../src/boot/session-saver';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import type { WindowManager } from '../../src/window-manager';
+import type { DesktopConfig, Session } from '../../src/types';
+
+const trackedFetchMock = vi.hoisted( () => vi.fn() );
+
+vi.mock( '../../src/boot/tracked-fetch', () => ( {
+	trackedFetch: trackedFetchMock,
+} ) );
+
+const SESSION_URL = 'https://example.test/wp-json/desktop-mode/v1/session';
+const NONCE = 'nonce-abc';
+
+/** A deferred promise, so a test can hold a save "in flight". */
+function deferred< T >() {
+	let resolve!: ( v: T ) => void;
+	const promise = new Promise< T >( ( r ) => {
+		resolve = r;
+	} );
+	return { promise, resolve };
+}
+
+/**
+ * Minimal WindowManager stand-in. `openIds` is mutable so a test can
+ * change the desktop state between saves and assert which snapshot
+ * each request carried.
+ */
+function fakeManager( openIds: string[] ) {
+	return {
+		snapshot: (): Session => ( {
+			windows: openIds.map( ( id ) => ( {
+				id,
+				url: `https://example.test/wp-admin/${ id }.php`,
+				title: id,
+				icon: 'dashicons-admin-generic',
+				state: 'normal',
+				x: 0,
+				y: 0,
+				width: 800,
+				height: 600,
+			} ) ) as Session[ 'windows' ],
+			desktops: [ { id: 'desktop-1', label: 'Desktop 1' } ],
+			activeDesktop: 'desktop-1',
+			focused: openIds[ openIds.length - 1 ] || '',
+			updated: Date.now(),
+		} ),
+	} as unknown as WindowManager;
+}
+
+function fakeConfig(): DesktopConfig {
+	return {
+		sessionUrl: SESSION_URL,
+		restNonce: NONCE,
+	} as unknown as DesktopConfig;
+}
+
+/** Window ids in the body of the Nth trackedFetch call. */
+function windowIdsOfCall( call: number ): string[] {
+	const init = trackedFetchMock.mock.calls[ call ][ 2 ] as RequestInit;
+	const parsed = JSON.parse( init.body as string ) as { session: Session };
+	return parsed.session.windows.map( ( w ) => w.id );
+}
+
+/**
+ * `createSessionSaver` binds `pagehide` / `visibilitychange` for the
+ * life of the page and never unbinds — correct in production (one
+ * saver per load) but the listeners accumulate on the shared jsdom
+ * window across tests, so a later `pagehide` fires every previous
+ * test's saver too. Record what each test binds and unbind it after.
+ */
+const boundListeners: Array<
+	[ EventTarget, string, EventListenerOrEventListenerObject ]
+> = [];
+
+function trackListeners( target: EventTarget ): void {
+	const original = target.addEventListener.bind( target );
+	vi.spyOn( target, 'addEventListener' ).mockImplementation(
+		( type, cb, opts ) => {
+			if ( cb ) {
+				boundListeners.push( [ target, type, cb ] );
+			}
+			original( type, cb, opts );
+		},
+	);
+}
+
+/** Install a `navigator.sendBeacon` without replacing all of `navigator`. */
+function stubSendBeacon( impl: ( ...a: unknown[] ) => boolean ) {
+	const mock = vi.fn( impl );
+	Object.defineProperty( navigator, 'sendBeacon', {
+		value: mock,
+		configurable: true,
+		writable: true,
+	} );
+	return mock;
+}
+
+describe( 'session saver', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		installHooksStub();
+		trackedFetchMock.mockReset();
+		trackedFetchMock.mockResolvedValue( new Response( '{}' ) );
+		trackListeners( window );
+		trackListeners( document );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		for ( const [ target, type, cb ] of boundListeners ) {
+			target.removeEventListener( type, cb );
+		}
+		boundListeners.length = 0;
+		delete ( navigator as { sendBeacon?: unknown } ).sendBeacon;
+		clearHooksStub();
+		vi.useRealTimers();
+	} );
+
+	test( 'collapses a burst of changes into a single write', async () => {
+		const save = createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+
+		save();
+		save();
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'a change during an in-flight save is re-sent, not dropped', async () => {
+		// The regression: closing a second window while the first
+		// close is still on the wire used to lose the second close
+		// entirely, so a reload brought that window back.
+		const openIds = [ 'a', 'b' ];
+		const save = createSessionSaver(
+			fakeManager( openIds ),
+			fakeConfig(),
+		);
+
+		const first = deferred< Response >();
+		trackedFetchMock.mockReturnValueOnce( first.promise );
+
+		// Close nothing yet — first save carries both windows.
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( windowIdsOfCall( 0 ) ).toEqual( [ 'a', 'b' ] );
+
+		// User closes `b` while the first request is still open.
+		openIds.pop();
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		// Still only the in-flight request — the second is queued.
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		// First request settles → the queued save must run. It goes
+		// back through the debounce + rate limit rather than firing
+		// the instant the previous request lands.
+		first.resolve( new Response( '{}' ) );
+		await vi.advanceTimersByTimeAsync( 2000 );
+
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 2 );
+		expect( windowIdsOfCall( 1 ) ).toEqual( [ 'a' ] );
+	} );
+
+	test( 'a queued save runs once, not once per suppressed call', async () => {
+		const save = createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+		const first = deferred< Response >();
+		trackedFetchMock.mockReturnValueOnce( first.promise );
+
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+
+		// Three separate mutations while the request is in flight.
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+
+		first.resolve( new Response( '{}' ) );
+		await vi.advanceTimersByTimeAsync( 2000 );
+
+		// One catch-up write carrying the latest state — not three.
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'closing several windows a beat apart is rate limited to one write', async () => {
+		// Each close is spaced wider than the 500ms debounce, so the
+		// debounce alone would let all three through. The rate limit
+		// underneath it collapses them.
+		const openIds = [ 'a', 'b', 'c', 'd' ];
+		const save = createSessionSaver(
+			fakeManager( openIds ),
+			fakeConfig(),
+		);
+
+		openIds.pop();
+		save();
+		await vi.advanceTimersByTimeAsync( 600 );
+		// First close cleared the debounce and went out.
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		openIds.pop();
+		save();
+		await vi.advanceTimersByTimeAsync( 600 );
+		openIds.pop();
+		save();
+		await vi.advanceTimersByTimeAsync( 600 );
+
+		// Both later closes are still held behind the rate limit —
+		// three closes, one write so far, where the debounce alone
+		// would have sent three.
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		// …and the write that does go out carries the final state, so
+		// nothing was dropped to achieve the throttling.
+		await vi.advanceTimersByTimeAsync( 2000 );
+		const calls = trackedFetchMock.mock.calls.length;
+		expect( windowIdsOfCall( calls - 1 ) ).toEqual( [ 'a' ] );
+	} );
+
+	test( 'the rate limit never drops the final state', async () => {
+		const openIds = [ 'a', 'b' ];
+		const save = createSessionSaver(
+			fakeManager( openIds ),
+			fakeConfig(),
+		);
+
+		save();
+		await vi.advanceTimersByTimeAsync( 600 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		// A change immediately after a write — the worst case for a
+		// throttle that drops instead of delays.
+		openIds.pop();
+		save();
+		await vi.advanceTimersByTimeAsync( 3000 );
+
+		const calls = trackedFetchMock.mock.calls.length;
+		expect( calls ).toBe( 2 );
+		expect( windowIdsOfCall( calls - 1 ) ).toEqual( [ 'a' ] );
+	} );
+
+	test( 'a failed save still lets the next one through', async () => {
+		const save = createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+		trackedFetchMock.mockRejectedValueOnce( new Error( 'offline' ) );
+
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		// `inFlight` must have been released in the `finally`, or the
+		// saver deadlocks and nothing persists for the rest of the
+		// session. Past the rate limit, not just the debounce.
+		save();
+		await vi.advanceTimersByTimeAsync( 2000 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'pagehide beacons the current snapshot with the nonce on the URL', () => {
+		const sendBeacon = stubSendBeacon( () => true );
+
+		const openIds = [ 'a', 'b' ];
+		createSessionSaver( fakeManager( openIds ), fakeConfig() );
+
+		// User closes `b`, then immediately reloads.
+		openIds.pop();
+		window.dispatchEvent( new Event( 'pagehide' ) );
+
+		expect( sendBeacon ).toHaveBeenCalledTimes( 1 );
+		const url = sendBeacon.mock.calls[ 0 ][ 0 ] as string;
+		// WP REST cookie auth reads the nonce from `$_REQUEST`, so a
+		// JSON body alone gets a 403 and the close never persists.
+		expect( url ).toContain( `_wpnonce=${ NONCE }` );
+		expect( url.startsWith( SESSION_URL ) ).toBe( true );
+	} );
+
+	test( 'pagehide cancels a pending debounce rather than double-writing', async () => {
+		const sendBeacon = stubSendBeacon( () => true );
+
+		const save = createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+		save();
+		window.dispatchEvent( new Event( 'pagehide' ) );
+		await vi.advanceTimersByTimeAsync( 1000 );
+
+		expect( sendBeacon ).toHaveBeenCalledTimes( 1 );
+		expect( trackedFetchMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'falls back to a normal POST when sendBeacon refuses', async () => {
+		stubSendBeacon( () => false );
+
+		createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+		window.dispatchEvent( new Event( 'pagehide' ) );
+		await vi.advanceTimersByTimeAsync( 0 );
+
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/tests/vitest/shell-element-ids.test.ts
+++ b/tests/vitest/shell-element-ids.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The shell's element ids agree across PHP and TypeScript.
+ *
+ * `openstation_render_shell()` prints a fixed skeleton — the shell
+ * root, the wallpaper, the dock, the desktop area, the widget column —
+ * and the boot path finds each one by `getElementById`. Nothing binds
+ * the two sides together: PHP prints a string, TS reads a string.
+ *
+ * A mismatch does not throw. `getElementById` returns `null`, the
+ * guard around it takes the "not present" branch, and the feature
+ * simply never mounts — no error, no console warning, no failing test.
+ * That is exactly how the widget column disappeared: the rebrand
+ * renamed `desktop-mode-widgets` to `os-widgets` in the markup and
+ * left three TS lookups on the old id, so `WidgetLayer` was never
+ * constructed and the right-hand column rendered empty on every load.
+ *
+ * Parsed out of the sources rather than asserted through a running
+ * WordPress, because this is a question about two string literals in
+ * two languages and neither test suite can see both.
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join( __dirname, '../..' );
+
+/**
+ * Ids the shell markup renders and the client must be able to find.
+ *
+ * Deliberately an explicit list rather than "every id in the file":
+ * plenty of `getElementById` calls in the client target elements the
+ * client itself created (`os-window-links`, per-window nodes), and
+ * those have no PHP counterpart to compare against. These five are
+ * the server-rendered contract.
+ */
+const SHELL_IDS = [
+	'os-shell',
+	'os-wallpaper',
+	'os-dock',
+	'os-area',
+	'os-widgets',
+] as const;
+
+const shellPhp = readFileSync(
+	join( ROOT, 'includes/render/shell.php' ),
+	'utf8',
+);
+
+/** Every `id="…"` the shell template prints. */
+const renderedIds = new Set(
+	[ ...shellPhp.matchAll( /\bid="([a-z0-9-]+)"/g ) ].map( ( m ) => m[ 1 ] ),
+);
+
+/** Recursively collect `src/**\/*.ts`. */
+function collectSources( dir: string, out: string[] = [] ): string[] {
+	for ( const entry of readdirSync( dir ) ) {
+		const full = join( dir, entry );
+		if ( statSync( full ).isDirectory() ) {
+			collectSources( full, out );
+		} else if ( entry.endsWith( '.ts' ) ) {
+			out.push( full );
+		}
+	}
+	return out;
+}
+
+const sources = collectSources( join( ROOT, 'src' ) ).map( ( file ) => ( {
+	file,
+	text: readFileSync( file, 'utf8' ),
+} ) );
+
+/** Every id passed to `getElementById` anywhere in `src/`. */
+const lookedUpIds = new Set< string >();
+for ( const { text } of sources ) {
+	for ( const m of text.matchAll(
+		/getElementById\(\s*'([^']+)'\s*\)/g,
+	) ) {
+		lookedUpIds.add( m[ 1 ] );
+	}
+}
+
+describe( 'shell element ids', () => {
+	test.each( SHELL_IDS )( '`%s` is rendered by the shell template', ( id ) => {
+		expect( renderedIds.has( id ) ).toBe( true );
+	} );
+
+	test.each( SHELL_IDS )( '`%s` is looked up by the client', ( id ) => {
+		expect( lookedUpIds.has( id ) ).toBe( true );
+	} );
+
+	test( 'no client lookup targets a pre-rebrand shell id', () => {
+		// The rebrand renamed every `desktop-mode-*` shell element to
+		// `os-*`. A lookup still using the old spelling silently
+		// resolves to `null` forever.
+		const stale = [ ...lookedUpIds ].filter( ( id ) =>
+			SHELL_IDS.some(
+				( current ) =>
+					id === current.replace( /^os-/, 'desktop-mode-' ),
+			),
+		);
+		expect( stale ).toEqual( [] );
+	} );
+} );

--- a/tests/vitest/window-links-render-host.test.ts
+++ b/tests/vitest/window-links-render-host.test.ts
@@ -133,7 +133,7 @@ beforeEach( () => {
 	document.body.innerHTML =
 		'<div id="os-shell">' +
 		'<div id="os-area">' +
-		'<aside id="desktop-mode-widgets"></aside>' +
+		'<aside id="os-widgets"></aside>' +
 		'</div></div>';
 } );
 afterEach( () => {
@@ -186,9 +186,7 @@ describe( 'window-link render host — end-to-end (jsdom)', () => {
 		expect( layer ).not.toBeNull();
 		// Behind the windows, inside the desktop area, after widgets.
 		expect( layer!.parentElement!.id ).toBe( 'os-area' );
-		expect( layer!.previousElementSibling!.id ).toBe(
-			'desktop-mode-widgets',
-		);
+		expect( layer!.previousElementSibling!.id ).toBe( 'os-widgets' );
 
 		// The edge touches the FOCUSED comment window → it draws on the
 		// elevated sibling layer.


### PR DESCRIPTION
Two unrelated regressions, both silent — nothing threw, nothing warned.

## The widget column stopped rendering

The rebrand (#475) renamed the shell element `desktop-mode-widgets` to `os-widgets` in `includes/render/shell.php` and left three TypeScript lookups on the old id.

The one that mattered is `src/desktop.ts` — it decides whether `WidgetLayer` is ever constructed:

```ts
const widgetsEl = document.getElementById( 'desktop-mode-widgets' ); // → null
if ( widgetsEl ) { widgetLayer = new WidgetLayer( widgetsEl, pluginUrl ); }
```

`getElementById` returned `null`, the guard took the "not present" branch, and the right-hand column rendered empty on every load. The other two stale lookups set the window-links z-order insertion point and the overview inert list.

I swept the rest of the rebrand. Everything else lines up; the remaining `desktop-mode-*` literals are the frozen ones (localStorage keys, native-window ids) and are correct per `AGENTS.md`.

## Closed windows came back on refresh

Three separate causes, same symptom.

**Saves were silently dropped.** `doSave()` returned early when a request was in flight — and the debounce timer had already fired and cleared itself, so nothing retried. Close a second window while the first close is still on the wire and that close was lost for good. It now marks the session dirty and re-runs once the request settles.

**The write-ordering key was too coarse.** `updated` was `Math.floor( Date.now() / 1000 )`. The two writes that race hardest are the `keepalive` fetch still in flight and the `pagehide` beacon that supersedes it; at second resolution they tie, and the server's tie rule hands the win to whichever it processes *last* — which can be the stale one, reinstating a window the user just closed. Now epoch milliseconds on both sides, with `openstation_session_now_ms()` matching the `(int) round( microtime( true ) * 1000 )` idiom already used in presence and content-changes. Sessions written before the switch carry a seconds value, ~1000× smaller, so the first write after an upgrade correctly wins.

**The debounce had no floor under it.** The existing 500ms window only collapsed changes that arrived closer together than itself — closes a beat apart cleared it every time and posted three times, and a settling in-flight save would hand straight over to its queued successor. `SESSION_SAVE_MIN_INTERVAL_MS = 1500` sits underneath the debounce and holds writes to one per interval however the changes are spaced. Nothing is dropped to honour it: a save arriving too soon is *delayed*, not discarded, and `pagehide` still flushes past both via `sendBeacon`.

## Tests

`createSessionSaver` had no coverage at all; it has nine tests now, covering burst collapsing, the in-flight re-send, the rate limit, failure recovery, and the beacon path. `shell-element-ids.test.ts` pins the five server-rendered shell ids on both sides so a rename can't silently orphan one again.

Each guard was verified to fail against the unfixed code — the two coalescing tests fail without the `dirty` flag, and the rate-limit test fails with the interval set to `0`.

One thing worth calling out for review: the new PHPUnit `test_save_session_orders_writes_within_the_same_second` documents the ordering contract but is **not** a regression guard for the millisecond fix — the server comparison was already `<` and is unit-agnostic. The real guards for that one are the vitest `snapshot stamps updated in epoch milliseconds` and the PHPUnit fallback-unit test.

Green: build, typecheck, lint, PHPCS, 3667 vitest, 1954 PHPUnit.

Docs updated in `architecture.md` (the `updated` ordering contract) and `javascript-reference.md` (`saveSession` scheduling semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-484-4482d09363368259c26b5fa756c9fcce599d1cdc.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fdesktop-mode%22%2C%22ref%22%3A%22trunk%22%2C%22refType%22%3A%22branch%22%2C%22path%22%3A%22extensions%2Fdesktop-mode-popup-siege%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%2C%22targetFolderName%22%3A%22desktop-mode-popup-siege%22%7D%7D%2C%7B%22step%22%3A%22runPHP%22%2C%22code%22%3A%22%3C%3Fphp%5Cnrequire_once%20&#039;%2Fwordpress%2Fwp-load.php&#039;%3B%5Cn%24options%20%3D%20get_option(%20&#039;desktop_mode_extended_options&#039;%2C%20array()%20)%3B%5Cn%24options%20%3D%20is_array(%20%24options%20)%20%3F%20%24options%20%3A%20array()%3B%5Cn%24options%5B&#039;games&#039;%5D%20%3D%20true%3B%5Cnupdate_option(%20&#039;desktop_mode_extended_options&#039;%2C%20%24options%2C%20false%20)%3B%5Cnupdate_option(%20&#039;blogname&#039;%2C%20&#039;WP%20OpenStation%20%E2%80%94%20Popup%20Siege%20Demo&#039;%20)%3B%22%7D%2C%7B%22step%22%3A%22writeFile%22%2C%22path%22%3A%22%2Fwordpress%2Fwp-content%2Fmu-plugins%2Fpopup-siege-demo.php%22%2C%22data%22%3A%7B%22resource%22%3A%22literal%22%2C%22name%22%3A%22popup-siege-demo.php%22%2C%22contents%22%3A%22%3C%3Fphp%5Cn%2F**%20Automatically%20stage%20Popup%20Siege%20on%20the%20disposable%20Playground%20demo.%20*%2F%5Cnadd_action(%5Cn%5Ct&#039;admin_enqueue_scripts&#039;%2C%5Cn%5Ctstatic%20function%20()%20%7B%5Cn%5Ct%5Ctif%20(%20!%20function_exists(%20&#039;openstation_is_enabled&#039;%20)%20%7C%7C%20!%20openstation_is_enabled()%20)%20%7B%5Cn%5Ct%5Ct%5Ctreturn%3B%5Cn%5Ct%5Ct%7D%5Cn%5Ct%5Ctwp_add_inline_script(%5Cn%5Ct%5Ct%5Ct&#039;openstation&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;window.wp.os.ready(function()%7Bvar%20games%3Dwindow.wp.os.games%3Bif(games%26%26typeof%20games.launch%3D%3D%3D%5C%22function%5C%22)%7BPromise.resolve(games.launch(%5C%22popup-siege%5C%22)).catch(function()%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D)%3B%7Delse%7Bwindow.wp.os.openWindow(%5C%22desktop-mode-games%5C%22%2C%7Bsource%3A%5C%22popup-siege-demo%5C%22%7D)%3B%7D%7D)%3B&#039;%2C%5Cn%5Ct%5Ct%5Ct&#039;after&#039;%5Cn%5Ct%5Ct)%3B%5Cn%5Ct%7D%2C%5Cn%5Ct100%5Cn)%3B%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->