### PR TITLE
Woo: a Customers section, and relations that run both ways

### DIFF
--- a/assets/css/my-wordpress-woocommerce.css
+++ b/assets/css/my-wordpress-woocommerce.css
@@ -204,3 +204,308 @@ os-ribbon.os-woo-ribbon {
 	font-size: 20px;
 	font-weight: 600;
 }
+
+/* ----- Customer tiles ----- */
+
+/*
+ * The band badge, for VIP and lapsed only.
+ *
+ * It lives INSIDE the 48px avatar box, straddling its bottom edge —
+ * the way a status dot sits on a contact photo. That costs the tile
+ * no vertical space, so the icon stays an icon: a face, a name, and
+ * at most one mark. Everything else about a customer (spend, orders,
+ * last purchase) is one click away in the pane, which has room to say
+ * it properly.
+ *
+ * Two rejected alternatives, both tried: `<os-ribbon>`, the 45°
+ * corner banner the Products grid uses — right across a product
+ * photo, vandalism across a face, covering a third of the avatar at
+ * this size. And a line of text under the name — spend and order
+ * count stacked above a 48px avatar crowd the tile past reading, and
+ * they push the name down the grid.
+ */
+.os-woo-customer-avatar {
+	position: relative;
+	/* The badge is wider than 48px and must not be clipped. */
+	overflow: visible;
+}
+
+.os-woo-customer-band {
+	position: absolute;
+	inset-block-end: -4px;
+	inset-inline-start: 50%;
+	transform: translateX( -50% );
+	z-index: 1;
+	padding: 0 5px;
+	border-radius: 999px;
+	font-size: 8px;
+	font-weight: 700;
+	line-height: 14px;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	white-space: nowrap;
+	pointer-events: none;
+}
+
+/*
+ * A solid surface under the tone, because this sits ON a photograph:
+ * the 12%-alpha wash `<os-badge>` uses would take whatever colour the
+ * avatar happens to be. The tone survives as the text and the ring,
+ * read from the same tokens (and the same fallback literals) the
+ * panel's band pill uses — so tile and pane can never disagree, and a
+ * desktop theme moves both at once.
+ */
+.os-woo-customer-band--vip,
+.os-woo-customer-band--lapsed {
+	background: var( --os-ui-surface, #fff );
+	box-shadow:
+		inset 0 0 0 1px currentColor,
+		0 1px 3px rgba( 0, 0, 0, 0.35 );
+}
+
+.os-woo-customer-band--vip {
+	color: var( --os-ui-badge-success, var( --os-ui-success-fg, #1a7f37 ) );
+}
+
+.os-woo-customer-band--lapsed {
+	color: var( --os-ui-badge-warning, var( --os-ui-warning-fg, #9a6700 ) );
+}
+
+/*
+ * RTL: `translateX(-50%)` is a physical transform, so the logical
+ * `inset-inline-start` above would place the badge correctly and the
+ * transform would then drag it the wrong way.
+ */
+[ dir='rtl' ] .os-woo-customer-band {
+	transform: translateX( 50% );
+}
+
+/* ----- Customer panel ----- */
+
+/*
+ * The band pill sits inline after the lifetime-spend figure, so it
+ * needs to sit on the text baseline rather than on the line box —
+ * otherwise it rides high next to the larger spend number.
+ */
+.os-woo-panel--customer .os-woo-panel__pill {
+	vertical-align: baseline;
+}
+
+/* ----- The Customer window ----- */
+
+/*
+ * A native window on one person. The layout is a single column with
+ * generous vertical rhythm rather than a dashboard grid: this is a
+ * thing you READ — who they are, what they're worth, what they
+ * bought — not a control panel you operate.
+ */
+.os-woo-customer-window {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	padding: 20px 24px 24px;
+	box-sizing: border-box;
+	min-height: 100%;
+	color: var( --os-ui-fg, #1e1e1e );
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.os-woo-customer-window__loading,
+.os-woo-customer-window__empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	min-height: 160px;
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+}
+
+/* ----- Identity strip ----- */
+
+.os-woo-customer-window__header {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+}
+
+.os-woo-customer-window__avatar {
+	width: 64px;
+	height: 64px;
+	border-radius: 50%;
+	object-fit: cover;
+	flex: none;
+}
+
+.os-woo-customer-window__identity {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+}
+
+.os-woo-customer-window__name {
+	margin: 0;
+	font-size: 20px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.os-woo-customer-window__contact {
+	margin: 0;
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+	overflow-wrap: anywhere;
+}
+
+.os-woo-customer-window__band {
+	align-self: flex-start;
+}
+
+/* ----- The four numbers ----- */
+
+/*
+ * `auto-fit` rather than a fixed four-up: the window is resizable and
+ * a merchant may well park it narrow beside an order. Four cards
+ * become two rows, then one, without a media query.
+ */
+.os-woo-customer-window__stats {
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 150px, 1fr ) );
+	gap: 12px;
+}
+
+.os-woo-customer-window__stat {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 12px 14px;
+	border-radius: 8px;
+	background: var( --os-ui-surface-2, rgba( 0, 0, 0, 0.04 ) );
+}
+
+.os-woo-customer-window__stat-value {
+	font-size: 19px;
+	font-weight: 600;
+	line-height: 1.2;
+	overflow-wrap: anywhere;
+}
+
+.os-woo-customer-window__stat-label {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+}
+
+.os-woo-customer-window__stat-hint {
+	font-size: 11px;
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+}
+
+/* ----- Sections ----- */
+
+.os-woo-customer-window__section {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.os-woo-customer-window__section-title {
+	margin: 0;
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+}
+
+.os-woo-customer-window__favourite {
+	margin: 0;
+}
+
+/* ----- Order history ----- */
+
+/*
+ * Three columns per row — identity, context, money — with the total
+ * pinned to the end so a column of prices lines up and can be
+ * scanned vertically. A table would give the same alignment and cost
+ * a header row saying "Order / Date / Total", which the rows already
+ * say for themselves.
+ */
+.os-woo-customer-window__orders {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+}
+
+.os-woo-customer-window__order {
+	display: grid;
+	grid-template-columns: minmax( 0, auto ) 1fr auto;
+	align-items: center;
+	gap: 4px 12px;
+	padding: 8px 0;
+	border-block-end: 1px solid
+		var( --os-ui-border, rgba( 0, 0, 0, 0.08 ) );
+}
+
+.os-woo-customer-window__order:last-child {
+	border-block-end: 0;
+}
+
+.os-woo-customer-window__order-head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.os-woo-customer-window__order-meta {
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+	font-size: 12px;
+	min-width: 0;
+}
+
+.os-woo-customer-window__order-total {
+	font-weight: 600;
+	text-align: end;
+	white-space: nowrap;
+}
+
+/* ----- Addresses ----- */
+
+.os-woo-customer-window__addresses {
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 200px, 1fr ) );
+	gap: 12px;
+}
+
+.os-woo-customer-window__address-label {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var( --os-ui-fg-muted, rgba( 0, 0, 0, 0.6 ) );
+	margin-block-end: 2px;
+}
+
+.os-woo-customer-window__address-value {
+	overflow-wrap: anywhere;
+}
+
+/* ----- Actions ----- */
+
+/*
+ * `margin-block-start: auto` pins the row to the bottom of a window
+ * taller than its content, so the buttons are where the hand expects
+ * them regardless of how much order history a customer has.
+ */
+.os-woo-customer-window__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-block-start: auto;
+	padding-block-start: 4px;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,6 +178,10 @@ REST surface:
 - `POST /wp-json/desktop-mode/v1/session` — overwrite the session. Body: `{ session: { windows: [...], desktops: [...], activeDesktop, focused, updated } }`.
 - `DELETE /wp-json/desktop-mode/v1/session` — clear it.
 
+Each entry in `windows[]` carries the window's id, geometry, state, desktop assignment — and, for **native** windows, an optional `params` bag: the open-time arguments saying *what* the window was showing (`{ userId: 12 }`, `{ customerId: 7 }`). A native window is addressed by id, and its id is its identity, so a singleton that retargets has nowhere else to record its subject; without `params` such a window restored onto its default and read as having silently changed subject. Values are limited to strings, finite numbers and booleans — anything else is dropped on save rather than taking the whole write down. Iframe windows carry none: their URL already says what they show. See [`wp.os.openWindow`](./javascript-reference.md#wposopenwindow-id-opts---stable).
+
+Param **keys** are filtered to `[A-Za-z0-9_-]` and capped, deliberately *not* passed through `sanitize_key()` — that lowercases, and every param name in the shell is camelCase, so `customerId` would be stored as `customerid` and the client's read would come back `undefined`. A window that restores blank with the data sitting right there under a name nobody looks up is worse than one that doesn't restore at all.
+
 `updated` is the write-ordering key, in **epoch milliseconds** (`Date.now()`). The server rejects a POST whose `updated` is lower than the stored one, so a slow request that was snapshotted earlier cannot clobber newer state — the case that matters is a `keepalive` fetch still in flight when the `pagehide` beacon fires. Equal values tie and the first processed wins. Omit the field and the server stamps it for you; sessions written before the field moved to milliseconds carry a seconds value, which any current write outranks.
 
 ### What comes back, and how

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -549,7 +549,7 @@ apply_filters(
 
 `$identity` shape (mirrors the JS `WindowContentRef`): `type` (lowercase object-type slug; namespace yours `vendor/order`), `id` (int|string), optional `label`, optional `root => array( 'type', 'id' )`, optional `links => array( array( 'type', 'id', 'rel'? ), … )`. A ref **without** `root` is itself a root (the post a comment window points back to); a ref **with** `root` joins that root's relation group as a child (an edge pointing at the root — the built-in renderer marks the target end with its larger endpoint dot). `links` declare outbound ties: the default (`rel` omitted) is a `reference` — an edge FROM this window TO the linked object ("my content points at that"); `rel => 'child'` reverses it — the linked object BELONGS TO this content (a post's embedded media), drawn exactly like a root tie. Mutual references merge into one bidirectional edge. One reading everywhere: **the edge points at what its source belongs to or refers to** — relational structure, never navigation history.
 
-Built-in detection covers `post.php` (post/page/CPT edit → root, with `links` extracted from the content's internal hyperlinks, its embedded media — `wp-image-{id}`, which catches inserted-but-unattached images — its featured image, and its assigned public-taxonomy terms as `term/{taxonomy}` refs), attachment edit — both the classic `post.php` screen and the `upload.php?item=N` Media Library grid detail — (`media`, rooted at `post_parent` when attached), `comment.php` (`comment`, rooted at the parent post), `edit-comments.php?p=N` — the per-post filtered comments list the Related menu opens — (`comments`, rooted at the post; the unfiltered list stays identity-less;), and `term.php` (`term/{taxonomy}` → root, which assigned posts reference). Use this filter to add identities for your own admin screens, or return `null` to suppress detection:
+Built-in detection covers `post.php` (post/page/CPT edit → root, with `links` extracted from the content's internal hyperlinks, its embedded media — `wp-image-{id}`, which catches inserted-but-unattached images — its featured image, and its assigned public-taxonomy terms as `term/{taxonomy}` refs), attachment edit — both the classic `post.php` screen and the `upload.php?item=N` Media Library grid detail — (`media`, rooted at `post_parent` when attached), `comment.php` (`comment`, rooted at the parent post), `edit-comments.php?p=N` — the per-post filtered comments list the Related menu opens — (`comments`, rooted at the post; the unfiltered list stays identity-less;), `term.php` (`term/{taxonomy}` → root, which assigned posts reference), and `user-edit.php` / `profile.php` (`user` → root, gated on `edit_user` — a person is what a post's author and an order's customer both point at). Use this filter to add identities for your own admin screens, or return `null` to suppress detection:
 
 ```php
 add_filter( 'openstation_window_content_identity', function ( $identity, $screen ) {
@@ -3210,16 +3210,41 @@ apply_filters( 'openstation_my_wordpress_woo_summary', array $data, string $type
 ```
 
 The merchant summary rendered in the right pane. `$type` is one of
-`product`, `order`, `coupon`. Add keys and the bundle ignores them —
-paint them yourself by also subscribing to
+`product`, `order`, `coupon`, `customer`. Add keys and the bundle
+ignores them — paint them yourself by also subscribing to
 [`os.my-wordpress.preview-extras`](./javascript-reference.md#action--openstationmy-wordpresspreview-extras).
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_summary_type', array|null $data, string $type, int $id ): array|null
+apply_filters( 'openstation_my_wordpress_woo_summary_capability', true|WP_Error|null $allowed, string $type, int $id ): true|WP_Error|null
+```
+
+Add a whole new summary type to `GET
+desktop-mode/v1/woocommerce/summary/<type>/<id>` — a subscription, a
+booking, a membership. The route is the one place the site window asks
+"tell me about this shop object", so joining here means a new object
+type needs neither its own endpoint nor its own client transport.
+
+Return `null` from the first filter (the default) to leave the type
+unknown, which answers 400. Whatever you return then passes through
+`openstation_my_wordpress_woo_summary` like the built-in types do.
+
+**Answer the capability filter too.** Without it your type inherits a
+`current_user_can( 'edit_post', $id )` check, which is meaningless for
+an id that isn't a post — and, where post and user ids collide, wrong.
+Return `true` to allow or a `WP_Error` to deny; `null` falls through
+to the post check.
+
+The built-in `customer` type is the first consumer of both.
 
 ```php
 apply_filters( 'openstation_my_wordpress_woo_store', array $data ): array
 ```
 
 The store headline numbers shown on the Woo folder — revenue this
-month, orders awaiting action, out-of-stock count.
+month, orders awaiting action, out-of-stock count, and (for a viewer
+with customer access) the customer count, the VIP / lapsed split, and
+guest-checkout revenue.
 
 ```php
 apply_filters( 'openstation_my_wordpress_woo_order_bands', array[] $bands ): array[]
@@ -3250,6 +3275,85 @@ Post type slug → dashicon class for the WooCommerce sections. These
 types are submenu entries under the WooCommerce menu, so they carry no
 `menu_icon` of their own and would otherwise fall back to the generic
 post pin.
+
+#### Customers
+
+The **Customers** section renders through the built-in `user` entity
+kind — avatar tiles, the dossier preview, the footprint route, the
+drag-out seam — with a `openstation_woo_customer` payload on every row
+carrying lifetime spend, order count, average order value, first and
+last order, days since the last one, and the band that summarises all
+of it. The same field is registered on the core `user` REST resource,
+so the built-in Users section (and any plugin reading `/wp/v2/users`)
+gets it for free.
+
+Who appears: every user who has placed a paid order, plus every user
+holding the `customer` role. Guests have no account to render — their
+revenue is reported on the folder's Store panel instead of being
+dropped.
+
+Access needs **both** order access and `list_users`. An editor has
+neither.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_customer_spend_map', array $map ): array
+```
+
+The per-customer order aggregate the whole section is built from —
+band definitions, band ordering, per-row facts and folder counts all
+read this one map, gathered in a single grouped query over the order
+store (HPOS or legacy) and cached for five minutes.
+
+Keyed by user id; `0` is the guest aggregate. Each value is
+`array( 'orders' => int, 'spend' => float, 'first' => gmt datetime,
+'last' => gmt datetime )`. A store that keeps order money somewhere
+else — a subscriptions plugin, a marketplace split — can rewrite the
+whole map here and every band, tile and panel follows.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_customer_bands', array[] $bands ): array[]
+apply_filters( 'openstation_my_wordpress_woo_customer_band', string $band, array $stats ): string
+```
+
+The bands the Customers section groups by, and which one a given
+aggregate lands in. Defaults, in render order: `vip`, `lapsed`,
+`repeat`, `new`, `none` — the two a merchant can act on first.
+
+The definitions filter only names and orders the bands; changing a
+membership rule means filtering `..._customer_band` as well. A band id
+the definitions don't declare is parked under `none` rather than
+dropped, because a customer missing from the list is worse than one in
+an unexpected group.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_vip_threshold', float $threshold, float $aov ): float
+apply_filters( 'openstation_my_wordpress_woo_customer_lapse_days', int $days ): int
+```
+
+The two numbers the default banding turns on. The VIP threshold is
+derived rather than fixed — three times the store's average order
+value — because "spent over 500" means nothing without knowing whether
+the store sells postcards or pianos. A store with no paid orders has an
+average of zero, and a zero threshold promotes nobody.
+
+The lapse window defaults to 180 days and is floored at 1.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_customer_ids', array $ids ): array
+apply_filters( 'openstation_my_wordpress_woo_customer_query_args', array $args, WP_REST_Request $request ): array
+apply_filters( 'openstation_my_wordpress_woo_customer_facts', array $facts, int $user_id ): array
+```
+
+The candidate set, the `WP_User_Query` args behind
+`GET desktop-mode/v1/woocommerce/customers`, and the compact fact
+payload carried on every row. `number` and `paged` are set by the
+paginator and will be overwritten.
+
+Past `OPENSTATION_WOO_MAX_ORDERED_CUSTOMERS` (5000) candidates the
+section stops band-ordering and falls back to newest-registered-first,
+exactly like the catalogue does past its own cap. Read
+`X-Desktop-Mode-Woo-Customers-Mode` off the response to tell which
+mode you got.
 
 ### `openstation_my_wordpress_template_html` — Experimental (filter)
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -3355,6 +3355,46 @@ exactly like the catalogue does past its own cap. Read
 `X-Desktop-Mode-Woo-Customers-Mode` off the response to tell which
 mode you got.
 
+Past the cap the folder's Store panel reports the band counts as
+**not counted** rather than as zero — the payload carries
+`bandsCapped: true` and omits `vips` / `lapsed` entirely, because a
+large store being told it has "0 VIPs" is a wrong answer stated
+confidently.
+
+#### The Customer window
+
+A native window on one person, opened with a `customerId` param from a
+customer tile, an order's Related menu, or a session restore. It is a
+retargetable singleton: opening it on a second customer repaints the
+open window rather than stacking a new one.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_customer_window_template_html', string $html ): string
+```
+
+The window's static template body before it is emitted into the
+native-window template element. The default is a bare mount point —
+the whole surface is data-driven, so a markup skeleton would only be a
+second place for the layout to live and drift.
+
+Keep the `data-os-woo-customer-root` attribute intact: the render
+callback mounts into it, and a template without it paints into the
+window body instead. The result is passed through
+`openstation_kses_native_window_template()`.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_customer_window_args', array $args ): array
+```
+
+The `openstation_register_window()` args for the Customer window —
+title, icon, size and minimums, the `desktop-mode-woo-customer` id's
+script and style handles, and `placement => 'none'` (it is never
+opened from a dock tile, because "the customer window" with no
+customer means nothing).
+
+Both filters only run when WooCommerce is active and the viewer passes
+the customers permission gate — order access **and** `list_users`.
+
 ### `openstation_my_wordpress_template_html` — Experimental (filter)
 
 The static template body before it's emitted into the native-window template element. Keep the `data-os-my-wordpress-*` data hooks intact so the JS bundle can find its mount points.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -5701,6 +5701,27 @@ key your endpoint returns is stripped before the bundle sees it unless
 the section declares it in `listFields` (see
 [`openstation_my_wordpress_entities`](./hooks-reference.md#openstation_my_wordpress_entities--experimental)).
 
+**`editUrl` — rows that don't live in `wp_posts`.** Opening a row for
+editing normally means `post.php?post=<id>`, derived from the row's
+id. A section whose records are stored somewhere else has no such URL:
+a WooCommerce order under High-Performance Order Storage is the
+in-tree case, and `post.php` on its id opens a different post or
+nothing at all.
+
+Return an `editUrl` on the row and the window uses it verbatim
+wherever it would have built one:
+
+```php
+add_filter( 'rest_prepare_my_thing', function ( $response, $thing ) {
+    $response->data['editUrl'] = admin_url( 'admin.php?page=my-thing&id=' . $thing->id );
+    return $response;
+}, 10, 2 );
+```
+
+Declare it in the section's `listFields` — otherwise `_fields` strips
+it off the list rows and only the single-row fetch carries it, which
+reads as "edit works from the preview pane but not from a tile".
+
 ### Action — `os.my-wordpress.list-tile`
 
 Decorate a list tile. Fires once per tile, after the built-in chrome
@@ -5846,7 +5867,11 @@ interface MyWordPressEntity {
     groupLabel?: string | null;
     groupIcon?: string | null;
     groupOrder?: number | null;
-    /** Extra REST fields to keep on this section's list rows. */
+    /**
+     * Extra REST fields to keep on this section's list rows —
+     * anything outside the built-in `_fields` set, `editUrl`
+     * included.
+     */
     listFields?: string[];
     /** Extra query params sent with this section's list requests. */
     listQuery?: Record< string, string >;

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -86,7 +86,16 @@ document.addEventListener( 'os-window-reopened', ( e ) => {
 **`detail` shape:**
 
 ```typescript
-{ windowId: string, baseId: string, wasMinimized: boolean, navigated: boolean }
+{
+    windowId: string,
+    baseId: string,
+    wasMinimized: boolean,
+    navigated: boolean,
+    // The window's open-time params AFTER the reopen — the framework
+    // applies any the caller passed before firing this. `{}` when the
+    // window takes none. See `opts.params` on `wp.os.openWindow`.
+    params: Record< string, string | number | boolean >,
+}
 ```
 
 `wasMinimized` reflects the state at the moment of the call, BEFORE the framework's automatic restore-from-minimized happens. Useful for animating "popped from the dock".
@@ -916,7 +925,10 @@ Open (or focus) a server-registered native window by id. Symmetric with `opensta
 ```typescript
 wp.os.openWindow(
     id:    string,
-    opts?: { source?: string },
+    opts?: {
+        source?: string;
+        params?: Record< string, string | number | boolean >;
+    },
 ): boolean;
 ```
 
@@ -937,6 +949,32 @@ wp.os.activity.subscribe( 'desktop-mode/open-requested', ( { windowId, source } 
 ```
 
 Conventional `source` values: `'dock'`, `'taskbar'`, `'icon'`, `'shortcut'`, `'palette'`, `'api'` (default when omitted). Custom strings are fine — pick one that matches the surface the user clicked.
+
+**`opts.params`** — open-time arguments: *what* the window is showing this time, as opposed to *what it is*.
+
+A native window is addressed by id, and its id is its identity: `desktop-mode-user-edit` is "the profile editor", not "the profile editor for user 12". Anything that varies per open has nowhere else to live — and a module-level variable or a shared store **does not survive a page reload**, so a restored window comes back on its default. That is exactly how the profile window used to reopen showing whoever was logged in rather than the person the user had open.
+
+```javascript
+wp.os.openWindow( 'my-plugin/contact', {
+    source: 'contacts-list',
+    params: { contactId: 42 },
+} );
+```
+
+Read them in the render callback:
+
+```javascript
+window.openStationNativeWindows[ 'my-plugin/contact' ] = ( body, { params } ) => {
+    paint( body, Number( params.contactId ) || 0 );
+};
+```
+
+Rules worth knowing:
+
+- **Params are persisted.** They are written into the session snapshot and staged back onto the window on restore, so the window reopens showing the same thing. Keep them small and serializable — ids and slugs, not objects. Values that aren't strings, finite numbers, or booleans are dropped on save rather than crashing it (one plugin's careless value must not cost every window its geometry).
+- **Reopening with params retargets a live window.** `open()` focuses an existing window rather than rebuilding it, so the render callback does not re-run. The framework updates the window's params first and puts them on the [`os-window-reopened`](#os-window-reopened--stable) detail — subscribe there to repaint.
+- **An argument-less reopen leaves them alone.** A dock click on an already-open profile window must not wipe whose profile it is.
+- **Iframe windows ignore this.** Their URL already says what they're showing, and it round-trips through the session on its own.
 
 ```javascript
 // Open the Code editor (requires the desktop-mode-code-editor extension).
@@ -5308,6 +5346,10 @@ The `desktop-mode-plugins` native window replaces the chromeless `plugins.php` a
 
 Both `plugins.php` and `plugin-install.php` are claimed by `registerNativeUrlRemap`. The latter stashes a `tab: 'browse'` hint in the shared store `'desktop-mode/plugins-window/tab-target'` so the bundle's first paint activates the Browse tab. When `nativePluginsEnabled` is `false`, the click falls through to the classic iframe path.
 
+**Threading state into the window a remap opens.** A remap entry may declare a `params( url, parsed )` hook returning open-time [`params`](#wposopenwindow-id-opts---stable) for its native window. **Prefer it over a shared store**: params are persisted with the session and staged back on restore, so the window reopens on the same subject after a reload — a shared store does not survive the reload and the window comes back on its default. A throwing hook is logged and the window still opens, the same tolerance `onMatch` has. Remaps that declare no hook call the opener with one argument exactly as before.
+
+**Two views of the same object.** Some URLs are the only address WordPress has for a thing, and more than one window may legitimately want them. `user-edit.php?user_id=12` is the only URL for a person, but a shop asks a different question about that person than "edit their role". The `os_person_view` query flag resolves it: the built-in profile remap stands down on any person-URL carrying it, so a specific view can claim the URL without having to win a registration-order race. The value is the claiming view's id (`wc-customer`), so a third view can join without either existing one changing. Exported as `OS_PERSON_VIEW_PARAM`; the PHP side that builds such URLs must use the same literal.
+
 ### Drag bridge integration
 
 Cards in the Browse gallery call `wp.os.dragManager.start({ … })` on pointer-down. The payload is:
@@ -5460,9 +5502,10 @@ raw server record (a `MediaListItem`, post `EntityListItem`, etc.).
 ### Action — `os.my-wordpress.preview-extras`
 
 Inject DOM into named slots on the right pane (`'header' | 'meta'
-| 'footer'`). Fires once per slot per preview render, for **both**
-media previews and post-kind previews (posts, pages, and every CPT
-section) — one contract covers every section.
+| 'footer'`). Fires once per slot per preview render, for media
+previews, post-kind previews (posts, pages, and every CPT section),
+and user-kind previews (the Users section and any section serving
+people) — one contract covers every section.
 
 ```ts
 wp.hooks.addAction(
@@ -5489,16 +5532,124 @@ interface PreviewExtras {
     entityId: string;
     /** Render kind — `'post'`, `'user'`, `'media'`, or a custom one. */
     kind: string;
-    /** The row being previewed (post or attachment). */
+    /** The row being previewed (post, attachment, or user). */
     item: Record< string, unknown >;
 }
 ```
 
 Slot order in a post-kind pane is `header` (above the featured image
 and the rendered content), `meta` (below the content, above the action
-row), then `footer`. Subscribers that fetch data should re-check
+row), then `footer`.
+
+A user-kind pane fires all three, and the useful one is `meta`:
+`header` sits above the identity header, `meta` sits directly under
+the name, face and biography, and `footer` sits below the action row.
+**A summary of a person belongs in `meta`** — money or metrics placed
+above someone's avatar read as a label on them, and a reader cannot
+tell whose figure it is until they have scrolled past it to the name.
+The WooCommerce customer panel paints into `meta` for exactly that
+reason.
+
+Subscribers that fetch data should re-check
 `container.isConnected` before painting — the pane repaints on every
 selection change, and a slow request can outlive its pane.
+
+### Filter — `os.my-wordpress.user-dossier-sections`
+
+Choose which blocks a user preview renders. The identity header (name,
+face, roles) is not in the list — a dossier without it is not a
+dossier.
+
+```ts
+wp.hooks.addFilter(
+    'os.my-wordpress.user-dossier-sections',
+    'my-plugin/customers',
+    ( sections, ctx ) =>
+        ctx.entityId === 'wc-customers'
+            ? sections.filter( ( id ) => id === 'bio' )
+            : sections,
+);
+```
+
+Sections, in render order: `'bio' | 'stats' | 'activity' |
+'milestones' | 'recent' | 'terms'`. Context:
+`{ entityId: string; kind: string; userId: number }`.
+
+The built-in dossier answers *"what has this person written"* — post
+and page counts, a publishing sparkline, recent posts, top categories.
+That is right in the Users folder and wrong in a section whose people
+have never written anything: four zeroes above the figure you came for
+read as the answer. Drop what doesn't apply.
+
+The filter does not fire for the author / contributor sub-folders
+inside a post's detail view — those have no section context and always
+render every block.
+
+### Filter — `os.my-wordpress.user-activate`
+
+Claim "the user opened this person" — the double-click on a user tile.
+
+```ts
+wp.hooks.addFilter(
+    'os.my-wordpress.user-activate',
+    'my-plugin/contacts',
+    ( handled, ctx ) => {
+        if ( handled || ctx.entityId !== 'my-contacts' ) {
+            return handled;
+        }
+        return wp.os.openWindow( 'my-plugin/contact', {
+            params: { contactId: Number( ctx.item.id ) },
+        } );
+    },
+);
+```
+
+Context: `{ entityId: string; kind: string; item: Record< string, unknown > }`.
+Return `true` to say you handled it — the built-in navigation is then skipped. Anything else falls through, so a filter that forgets to return can't leave double-click doing nothing.
+
+The built-in answer is the activity footprint, which is right in the Users folder (a person there is someone who writes) and wrong anywhere they aren't. The WooCommerce Customers section claims it for the Customer window.
+
+### Filter — `os.my-wordpress.user-preview-actions`
+
+The buttons in a user preview's action row. Built-ins are
+`'footprint'` ("View activity footprint", primary) and
+`'open-profile'` ("Show profile", secondary).
+
+```ts
+wp.hooks.addFilter(
+    'os.my-wordpress.user-preview-actions',
+    'my-plugin/orders',
+    ( actions, ctx ) => {
+        if ( ctx.entityId !== 'wc-customers' ) {
+            return actions;
+        }
+        return [
+            {
+                id: 'wc-orders',
+                label: 'View their orders',
+                variant: 'primary',
+                onSelect: () => openOrders( ctx.item.id ),
+            },
+            ...actions.filter( ( a ) => a.id !== 'footprint' ),
+        ];
+    },
+);
+```
+
+```ts
+interface UserPreviewAction {
+    id: string;
+    label: string;
+    /** Native tooltip. */
+    title?: string;
+    variant?: 'primary' | 'secondary';
+    onSelect: () => void;
+}
+```
+
+Context: `{ entityId: string; kind: string; item: Record< string, unknown > }`.
+Entries without a callable `onSelect` are dropped; returning an empty
+array removes the action row entirely rather than leaving an empty bar.
 
 ### Filter — `os.my-wordpress.list-bands`
 
@@ -5574,6 +5725,18 @@ wp.hooks.addAction(
 Payload: `{ tile: HTMLElement; entityId: string; kind: string; item: EntityListItem }`.
 The tile is positioned, so a badge should be absolutely positioned
 within it.
+
+Fires for post-kind and user-kind tiles alike. Check `kind` rather
+than `entityId` when your decoration is about the *thing* rather than
+about the section — a user who has spent money is a customer whether
+you are looking at the Users list or a shop's Customers list, and the
+WooCommerce integration keys its tile decoration off `kind === 'user'`
+for exactly that reason.
+
+A user tile carries a `.os-my-wordpress__user-tile-sub` sub-line
+("role · N posts" by default). Rewriting its `textContent` is the
+supported way to say something truer about the person for your
+section.
 
 ### Action — `os.my-wordpress.group-extras`
 

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -287,10 +287,203 @@ count on the Woo folder itself. Data comes from
 for products and coupons, the `shop_order` edit capability for orders
 and store totals).
 
+**Customers were a report, not a place.** WooCommerce ships two views
+of the people who buy from a store and neither is somewhere you can
+work: `users.php` is a role list that knows nothing about money, and
+Analytics → Customers is a report you read and then leave. Neither one
+opens next to the order it explains.
+
+`includes/my-wordpress/integrations/woocommerce-customers.php` adds a
+**Customers** section rendering through the built-in `user` entity kind
+— avatar tiles, the dossier pane, the footprint route, the drag-out
+seam — so a customer is a first-class desktop object. Rows carry an
+`openstation_woo_customer` payload (lifetime spend, order count,
+average order, first and last order, days since) that the bundle turns
+into a money sub-line on the tile, a VIP / Lapsed corner ribbon, and a
+Customer panel in the preview pane.
+
+The whole section costs **one grouped query** over the order store,
+cached for five minutes and flushed on any order change. Band
+ordering, per-row facts and folder counts all read that one map, so a
+page of customers fires no per-row order queries. See the
+[Customers hooks](./hooks-reference.md#woocommerce-integration--experimental-filters)
+for the bands and the thresholds behind them.
+
+Because the field is registered on the core `user` REST resource
+rather than only on our collection, the built-in **Users** section
+gets the same decoration for free. That is the point: on a store,
+"who is this person" and "what have they spent" are the same question.
+
+Two seams had to exist for the pane to read right, and both are
+generic. The built-in user dossier answers *"what has this person
+written"* — post and page counts, a publishing sparkline, recent
+posts — which for someone who came to buy a hat is four zeroes above
+the figure you actually wanted;
+[`os.my-wordpress.user-dossier-sections`](./javascript-reference.md#filter--osmy-wordpressuser-dossier-sections)
+drops them. And "View activity footprint" opens a publishing-history
+surface that for a customer is an empty screen;
+[`os.my-wordpress.user-preview-actions`](./javascript-reference.md#filter--osmy-wordpressuser-preview-actions)
+swaps it for **View their orders**, which opens the filtered orders
+screen as its own window — beside the customer, not instead of them.
+
+The panel paints into the `meta` slot rather than `header`: money
+above an avatar reads as a label on the person, and you cannot tell
+whose figure it is until you have scrolled past it to the name. Name
+and face first, then the summary.
+
+The tile marker is a small badge on the bottom edge of the avatar, the
+way a status dot sits on a contact photo — not the `<os-ribbon>`
+corner banner the Products grid uses, and not a line of text under the
+name. A 45° banner across the artwork works on a product photo and is
+vandalism on a face; a line of text crowds an 88px icon and pushes the
+name down the grid. An icon is a face, a name, and at most one mark.
+Everything else is one click away, where there is room to say it
+properly.
+
+**Double-clicking a customer opens the Customer window**
+(`desktop-mode-woo-customer`, registered in
+`woocommerce-customer-window.php`, rendered from the same integration
+bundle): identity, the four numbers a merchant reads first, what they
+buy most, their recent orders, and their addresses — each order
+opening in its own window. It exists because both screens WordPress
+offers instead are the wrong one: the activity footprint answers "what
+has this person published", which for someone who came to buy a hat is
+an empty page, and `user-edit.php` is a settings form.
+
+The window is a retargeting singleton — its id is "the customer
+window", and *which* customer is an open-time
+[`params`](./javascript-reference.md#wposopenwindow-id-opts---stable)
+value. Sections claim the double-click through
+[`os.my-wordpress.user-activate`](./javascript-reference.md#filter--osmy-wordpressuser-activate);
+only the Customers section does, so a person in the Users folder still
+opens their footprint.
+
+One trap worth naming, because it cost a real bug report: the panel's
+links used to carry `target="_blank"`. In a browser tab that threw the
+admin screen out of the shell entirely — and once OpenStation is
+installed as a PWA, a `_blank` navigation to a same-origin admin URL
+is inside the app's scope, so **clicking a product name relaunched the
+whole app**. Panel links now keep a real `href` (middle-click and
+"copy link" still work) and claim the plain click to open a desktop
+window instead.
+
+**An order was the most connected object in WordPress and the least
+connected screen.** It names a customer, some products, maybe a coupon
+— and every one of those is text. To go from an order to the product
+it sold you go back to the catalogue and search for it.
+
+`includes/my-wordpress/integrations/woocommerce-relations.php` wires
+WooCommerce into the two relation surfaces the shell already has.
+[`openstation_window_content_identity`](./hooks-reference.md#openstation_window_content_identity--experimental)
+gives an order window an identity plus `links` refs to its customer
+(`user`), its products (`product`) and its coupons (`shop_coupon`), so
+opening any of those beside it draws a tie on the desktop.
+[`openstation_window_related_entities`](./hooks-reference.md#openstation_window_related_entities--experimental)
+fills the title bar's Related menu: the customer's profile, all their
+orders, every line item, every coupon — each opening as its own window
+rather than navigating away from what you were reading.
+
+The menu runs **both directions**, which is the half WooCommerce never
+had. An order names its products, so order → product was always
+possible; the reverse — *is this selling, and to whom?* — is the
+question a merchant actually asks, and the catalogue screen has no
+answer at all. A **product** now lists its categories, tags, reviews,
+variations, the recent orders containing it, the customers on those
+orders, and the coupons that discount it. A **coupon** lists what it
+is restricted to plus the orders that redeemed it and who redeemed
+them — its usage count was a bare number with nothing behind it.
+
+Those reverse lookups read `{$prefix}woocommerce_order_items` +
+`woocommerce_order_itemmeta` directly, because no WooCommerce API
+answers "orders containing product X" and walking orders to find one
+would mean loading every order on the store. Those two tables are the
+right index and are populated under **both** storages — HPOS moves
+the order rows, not the line items. Coupon restrictions are a
+comma-joined id string in postmeta, which no meta query can search
+safely (`LIKE '%12%'` matches 112 and 121), so those rows are read and
+split in PHP under a bounded scan.
+
+Every group carries an explicit budget. The relations engine hard-caps
+a window's `related` list at 64 items, and an unbudgeted group pushes
+the trailing ones silently over — you'd lose the orders because a
+product happened to carry thirty tags. Product worst case is 48,
+coupon 58.
+
+The **Reviews** item needed its own identity, and the reason is worth
+remembering because it generalises: a tie needs **both** windows to
+have one. Every other item in a product's Related menu drew a line
+because its target already announces an identity (a term screen, a
+post editor, a profile, an order). WooCommerce moved reviews off
+`edit-comments.php` onto its own admin page
+(`edit.php?post_type=product&page=product-reviews&product_id=N`), which
+the built-in detection has no reason to know about — so the window
+opened and sat there unconnected. It now announces
+`{ type: 'reviews', id, root: { type: 'product', id } }`, rooted at
+the product exactly as core's comments identity is rooted at its post.
+The unfiltered all-reviews list stays identity-less, for the same
+reason core leaves the unfiltered comments list alone: a window
+showing everything belongs to nothing in particular.
+
+**If you add a Related item and it opens but draws no line, that is
+the thing to check first** — not the menu, the destination.
+
+The Customer window hit the same wall from the other side, and it is
+worth stating plainly because it catches every native window: **an
+iframe window announces its identity for free, a native window never
+does.** The chromeless bridge builds one from the real admin screen
+and posts it up; a native window has no such screen, so nothing speaks
+on its behalf and the engine simply doesn't know it exists. It calls
+[`wp.os.relations.set()`](./javascript-reference.md#wposrelations) in
+its render callback — before the summary fetch, since the identity is
+already in the window's `params` and waiting a round trip would leave
+it unconnected exactly while the user is looking at it next to the
+order they came from.
+
+It announces `type: 'user'` rather than a private `wc-customer` type,
+which is the whole trick: that is what `user-edit.php` announces too,
+so the Customer window and a profile window on the same person join
+one group — and an order, whose identity links `user:<id>`, ties to
+either.
+
+**Following "Customer" from an order** used to land on the profile
+editor, which is the wrong answer to the question being asked: from an
+order, *customer* means "this is who bought it", not "change their
+role". The Related menu can only express a destination as a URL, and
+the only URL WordPress has for a person is `user-edit.php?user_id=N`
+— so the item and the profile editor were competing for one address.
+The `os_person_view=wc-customer` flag settles it: the shell's built-in
+profile remap stands down on any person-URL carrying the marker, and
+the WooCommerce remap claims it and opens the Customer window with
+`params: { customerId }`. No registration-order race, and the profile
+editor is still one item away in the same menu, unmarked. Buyer
+entries on a product or a coupon carry the marker too. With the
+integration bundle absent the marker is just an unused query arg and
+the profile opens, which is the right fallback.
+
+HPOS matters here twice over. It moves the order editor to
+`admin.php?page=wc-orders&action=edit&id=N`, where the built-in
+`post.php` detection can never see it — so under HPOS this file is the
+only source of an order identity at all. Under legacy storage the
+built-in detection does fire, but the identity arrives with no links:
+an order has no `post_content`, so the hyperlink / media / term
+extractor finds nothing.
+
+The `user` half of that needed one built-in: `user-edit.php` and
+`profile.php` now announce a `user` identity (see
+`includes/window-links.php`), gated on `edit_user`. It is generic —
+a post's author and a comment's writer point at the same root — and it
+is what lets an order tie to a profile window opened from anywhere.
+
 The integration talks to the site window only through the public
 action contract — nothing in `src/my-wordpress/index.ts` knows
 WooCommerce exists. A third-party plugin would write exactly the same
 code.
+
+**Known gap:** the Customers grid is band-*ordered* (VIP first, then
+lapsed, repeat, new, no-orders) but not band-*headed*. Banding chrome
+lives in the post-kind list renderer; the user-kind renderer doesn't
+have it yet. The order is right, the headings aren't there — the band
+shows on the tile as a ribbon instead.
 
 ## Adding a new fix
 

--- a/includes/my-wordpress/bootstrap.php
+++ b/includes/my-wordpress/bootstrap.php
@@ -32,3 +32,6 @@ require_once __DIR__ . '/preview-actions.php';
 // Third-party integrations. Each file is inert unless its plugin is
 // active, so requiring them unconditionally costs one include.
 require_once __DIR__ . '/integrations/woocommerce.php';
+require_once __DIR__ . '/integrations/woocommerce-customers.php';
+require_once __DIR__ . '/integrations/woocommerce-customer-window.php';
+require_once __DIR__ . '/integrations/woocommerce-relations.php';

--- a/includes/my-wordpress/integrations/woocommerce-customer-window.php
+++ b/includes/my-wordpress/integrations/woocommerce-customer-window.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * OpenStation — the Customer window.
+ *
+ * A native window that opens on one customer: who they are, what they
+ * are worth, what they bought, and where it ships. Double-clicking a
+ * customer tile lands here.
+ *
+ * It exists because the two things WordPress offers instead are both
+ * the wrong screen. The activity footprint answers "what has this
+ * person published", which for someone who came to buy a hat is an
+ * empty page. `user-edit.php` is a settings form — the place you go to
+ * change someone's role, not to understand them.
+ *
+ * Singleton and retargeting, like the profile window: the id is
+ * "the customer window", and *which* customer is an open-time param
+ * (`{ customerId }`). Params ride the session, so a reload brings the
+ * window back on the same person rather than on a default.
+ *
+ * Everything here is inert unless WooCommerce is active and the
+ * viewer may see customer money.
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The window's template body.
+ *
+ * Deliberately a bare mount point rather than a markup skeleton: the
+ * whole surface is data-driven, so a static shell would only be a
+ * second place for the layout to live and drift.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_customer_window_template() {
+	ob_start();
+	?>
+	<div class="os-woo-customer-window" data-os-woo-customer-root>
+		<div class="os-woo-customer-window__loading" data-os-woo-customer-loading>
+			<os-spinner></os-spinner>
+		</div>
+	</div>
+	<?php
+	$html = (string) ob_get_clean();
+
+	/**
+	 * Filter the Customer window's template HTML.
+	 *
+	 * Keep `data-os-woo-customer-root` intact — the render callback
+	 * mounts into it.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param string $html Default template HTML.
+	 */
+	$filtered = (string) apply_filters( 'openstation_my_wordpress_woo_customer_window_template_html', $html );
+
+	if ( function_exists( 'openstation_kses_native_window_template' ) ) {
+		echo openstation_kses_native_window_template( $filtered ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- helper kses-escapes.
+	} else {
+		echo wp_kses( $filtered, wp_kses_allowed_html( 'post' ) );
+	}
+}
+
+/**
+ * Register the Customer window.
+ *
+ * `placement => 'none'`: it is never opened from a dock tile, because
+ * "the customer window" with no customer means nothing. It is always
+ * opened with a `customerId` param from a tile, a menu, or a session
+ * restore.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_customer_window_register() {
+	if ( ! openstation_my_wordpress_woo_active() ) {
+		return;
+	}
+	if ( ! function_exists( 'openstation_register_window' ) ) {
+		return;
+	}
+	if ( true !== openstation_my_wordpress_woo_customers_permission() ) {
+		return;
+	}
+
+	$args = array(
+		'title'      => __( 'Customer', 'desktop-mode' ),
+		'icon'       => 'dashicons-businessperson',
+		'template'   => 'openstation_my_wordpress_woo_customer_window_template',
+		// Rides the integration bundle that already ships the
+		// summary transport and the panel renderers — one more
+		// window, no second bundle.
+		'script'     => 'os-my-wordpress-woocommerce',
+		'style'      => 'os-my-wordpress-woocommerce',
+		'width'      => 880,
+		'height'     => 700,
+		'min_width'  => 520,
+		'min_height' => 420,
+		'placement'  => 'none',
+		'config'     => array(
+			'restRoot'  => esc_url_raw( rest_url( 'desktop-mode/v1/woocommerce/' ) ),
+			'restNonce' => wp_create_nonce( 'wp_rest' ),
+		),
+	);
+
+	/**
+	 * Filter the Customer window's registration args.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param array $args `openstation_register_window()` args.
+	 */
+	$args = (array) apply_filters( 'openstation_my_wordpress_woo_customer_window_args', $args );
+
+	$registered = openstation_register_window( 'desktop-mode-woo-customer', $args );
+	if ( is_wp_error( $registered ) ) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log(
+			'[openstation] Customer window registration failed: '
+			. $registered->get_error_message()
+		);
+	}
+}
+add_action( 'init', 'openstation_my_wordpress_woo_customer_window_register', 25 );

--- a/includes/my-wordpress/integrations/woocommerce-customers.php
+++ b/includes/my-wordpress/integrations/woocommerce-customers.php
@@ -617,6 +617,10 @@ add_action( 'woocommerce_update_order', 'openstation_my_wordpress_woo_flush_cust
 add_action( 'woocommerce_order_status_changed', 'openstation_my_wordpress_woo_flush_customer_caches' );
 add_action( 'woocommerce_delete_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
 add_action( 'woocommerce_trash_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
+// Untrash is its own event, not an update: restoring a paid order has
+// to move the buyer's spend and band back where they were, and nothing
+// else fires when it happens.
+add_action( 'woocommerce_untrash_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
 
 /*
 -------------------------------------------------------------------
@@ -846,11 +850,31 @@ function openstation_my_wordpress_woo_customers( $request ) {
 	$total = (int) $query->get_total();
 	$pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
 
-	$rows = array();
+	$users = array();
 	foreach ( (array) $query->get_results() as $user ) {
 		if ( $user instanceof WP_User ) {
-			$rows[] = openstation_my_wordpress_woo_customer_row( $user );
+			$users[] = $user;
 		}
+	}
+
+	// The customer *facts* come from one cached aggregate, but the
+	// generic user summary on each row is two indexed queries a piece
+	// — 200 of them on a full page. Prefetch the page in two grouped
+	// queries and every row below answers from memory.
+	if ( function_exists( 'openstation_my_wordpress_user_summary_prime' ) ) {
+		openstation_my_wordpress_user_summary_prime(
+			array_map(
+				static function ( $user ) {
+					return (int) $user->ID;
+				},
+				$users
+			)
+		);
+	}
+
+	$rows = array();
+	foreach ( $users as $user ) {
+		$rows[] = openstation_my_wordpress_woo_customer_row( $user );
 	}
 
 	$response = rest_ensure_response( $rows );
@@ -946,12 +970,19 @@ function openstation_my_wordpress_woo_customer_favourite( $user_id ) {
 	$product_id = (int) array_key_first( $tally );
 	$top        = $tally[ $product_id ];
 
+	// The link is gated, the fact isn't: someone who may read customer
+	// money but not edit products should still be told what that
+	// person buys — the name just stops being clickable.
+	// `get_edit_post_link()` returns null without `edit_post`, and the
+	// cast turns that into the empty string the client reads as "no
+	// link"; the explicit check states the intent rather than leaving
+	// it resting on a core side-effect.
+	$can_edit = get_post( $product_id ) && current_user_can( 'edit_post', $product_id );
+
 	return array(
 		'label'    => (string) $top['label'],
 		'quantity' => (int) $top['quantity'],
-		'editUrl'  => get_post( $product_id )
-			? (string) get_edit_post_link( $product_id, 'raw' )
-			: '',
+		'editUrl'  => $can_edit ? (string) get_edit_post_link( $product_id, 'raw' ) : '',
 	);
 }
 
@@ -1319,9 +1350,18 @@ function openstation_my_wordpress_woo_customer_store_totals( $data ) {
 	$guest = $map[0] ?? null;
 	$plan  = openstation_my_wordpress_woo_customer_plan();
 
-	$data['customers']   = (int) ( $plan['customers'] ?? 0 );
-	$data['vips']        = (int) ( ( $plan['counts'] ?? array() )['vip'] ?? 0 );
-	$data['lapsed']      = (int) ( ( $plan['counts'] ?? array() )['lapsed'] ?? 0 );
+	$data['customers'] = (int) ( $plan['customers'] ?? 0 );
+
+	// Past the ordering cap the plan holds no bands, so the band
+	// counts are not zero — they are unknown. Saying so is the whole
+	// point: a store with 40,000 customers reporting "0 VIPs" is a
+	// wrong answer stated confidently, which is worse than no answer.
+	$data['bandsCapped'] = ! empty( $plan['capped'] );
+	if ( empty( $data['bandsCapped'] ) ) {
+		$data['vips']   = (int) ( ( $plan['counts'] ?? array() )['vip'] ?? 0 );
+		$data['lapsed'] = (int) ( ( $plan['counts'] ?? array() )['lapsed'] ?? 0 );
+	}
+
 	$data['guestSpend']  = $guest && (float) $guest['spend'] > 0
 		? openstation_my_wordpress_woo_price( (float) $guest['spend'] )
 		: '';

--- a/includes/my-wordpress/integrations/woocommerce-customers.php
+++ b/includes/my-wordpress/integrations/woocommerce-customers.php
@@ -1,0 +1,1344 @@
+<?php
+/**
+ * OpenStation — My WordPress: WooCommerce **Customers**.
+ *
+ * WooCommerce ships two views of the people who buy from a store, and
+ * neither is a place you can work from: `users.php` is a role list that
+ * knows nothing about money, and Analytics → Customers is a report you
+ * read and then leave. Neither one opens next to the order it explains.
+ *
+ * This file adds a **Customers** section to the Woo folder in the site
+ * window. It renders through the existing `user` entity kind — avatar
+ * tiles, the dossier preview, the drag-out seam, the footprint route —
+ * so a customer is a first-class object on the desktop: drag one onto
+ * the wallpaper, open their orders beside their profile, tie the
+ * windows together with the relations layer.
+ *
+ * What makes it a *customer* list rather than a user list is the
+ * `openstation_woo_customer` payload on every row: lifetime spend,
+ * order count, average order value, first and last order, days since
+ * the last one, and the band that summarises all of it.
+ *
+ * ## Bands
+ *
+ * Ordered so the two bands a merchant can *act on* come first:
+ *
+ *   1. **VIP**    — spend at or above the VIP threshold (three times
+ *                   the store's average order value by default). Who
+ *                   to look after.
+ *   2. **Lapsed** — has ordered, but not within the lapse window (180
+ *                   days by default). Who to win back.
+ *   3. **Repeat** — two or more orders, still active.
+ *   4. **New**    — exactly one order.
+ *   5. **No orders** — registered, never bought.
+ *
+ * ## Who appears
+ *
+ * Every user who has placed a paid order, plus every user holding the
+ * `customer` role. Guests (orders with no account) have no user to
+ * render — their revenue is reported as a single line on the Woo
+ * folder's Store panel instead of being silently dropped.
+ *
+ * ## Cost
+ *
+ * One grouped query over the order store gives every customer's
+ * aggregate at once — order count, spend, first and last order date —
+ * cached for five minutes and flushed whenever an order changes. The
+ * band ordering, the per-row facts and the folder counts all read that
+ * one map, so a page of customers costs no per-row order queries at
+ * all. Stores past `OPENSTATION_WOO_MAX_ORDERED_CUSTOMERS` users skip
+ * the band ordering and fall back to newest-first, exactly like the
+ * catalogue does past its own cap.
+ *
+ * REST surface (read-only, gated on `list_users` + order access):
+ *
+ *   GET desktop-mode/v1/woocommerce/customers
+ *   GET desktop-mode/v1/woocommerce/customers/<id>
+ *   GET desktop-mode/v1/woocommerce/summary/customer/<id>
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Above this many candidate customers the section stops band-ordering
+ * and falls back to newest-registered-first. The ordering plan holds
+ * one id per customer in a transient; the cap is what keeps that
+ * option from growing without bound on a store with a large user base.
+ */
+const OPENSTATION_WOO_MAX_ORDERED_CUSTOMERS = 5000;
+
+/**
+ * Days without an order after which a customer counts as lapsed.
+ * Filterable through `openstation_my_wordpress_woo_customer_lapse_days`.
+ */
+const OPENSTATION_WOO_CUSTOMER_LAPSE_DAYS = 180;
+
+/*
+-------------------------------------------------------------------
+ * Aggregates
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * Order statuses that count as money actually taken.
+ *
+ * Mirrors `wc_get_customer_total_spent()`, so the lifetime spend on a
+ * tile agrees with the number WooCommerce itself would report.
+ *
+ * @return string[] Statuses WITH the `wc-` prefix.
+ */
+function openstation_my_wordpress_woo_paid_statuses() {
+	$statuses = function_exists( 'wc_get_is_paid_statuses' )
+		? (array) wc_get_is_paid_statuses()
+		: array( 'processing', 'completed' );
+
+	return array_values(
+		array_map(
+			static function ( $status ) {
+				return 0 === strpos( (string) $status, 'wc-' ) ? (string) $status : 'wc-' . $status;
+			},
+			$statuses
+		)
+	);
+}
+
+/**
+ * Whether the store keeps orders in WooCommerce's own tables (HPOS)
+ * rather than in `wp_posts`.
+ *
+ * @return bool
+ */
+function openstation_my_wordpress_woo_hpos_enabled() {
+	return class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' )
+		&& \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+}
+
+/**
+ * Every customer's order aggregate, in one query.
+ *
+ * The whole section — band definitions, band ordering, per-row facts,
+ * folder counts — reads this one map. Doing it per user would be one
+ * or two queries per tile, and the band ordering would need the whole
+ * user base walked before the first tile could paint.
+ *
+ * Guest orders (no account) are aggregated under the `0` key. They can
+ * never appear as a tile — there is no user to render — but their
+ * revenue is real and the Store panel reports it rather than letting
+ * it vanish.
+ *
+ * @return array<int, array{orders:int, spend:float, first:string, last:string}>
+ *         Keyed by user id; `0` holds the guest aggregate.
+ */
+function openstation_my_wordpress_woo_customer_spend_map() {
+	static $memo = null;
+	if ( null !== $memo ) {
+		return $memo;
+	}
+
+	$cached = get_transient( 'desktop_mode_woo_customer_spend' );
+	if ( is_array( $cached ) ) {
+		$memo = $cached;
+		return $memo;
+	}
+
+	global $wpdb;
+
+	$statuses     = openstation_my_wordpress_woo_paid_statuses();
+	$placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
+
+	if ( openstation_my_wordpress_woo_hpos_enabled() ) {
+		$table = $wpdb->prefix . 'wc_orders';
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name and the placeholder list are structural; every value is prepared.
+		$sql = $wpdb->prepare(
+			"SELECT customer_id AS uid,
+				COUNT(*) AS orders,
+				SUM(total_amount) AS spend,
+				MIN(date_created_gmt) AS first_order,
+				MAX(date_created_gmt) AS last_order
+			FROM {$table}
+			WHERE type = 'shop_order' AND status IN ( {$placeholders} )
+			GROUP BY customer_id",
+			$statuses
+		);
+	} else {
+		// Legacy storage: `_customer_user` is the account id (0 for a
+		// guest) and `_order_total` the gross. `+0` casts the meta
+		// strings so SUM/comparison behave numerically.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- ditto.
+		$sql = $wpdb->prepare(
+			"SELECT cu.meta_value + 0 AS uid,
+				COUNT(*) AS orders,
+				SUM( tot.meta_value + 0 ) AS spend,
+				MIN(p.post_date_gmt) AS first_order,
+				MAX(p.post_date_gmt) AS last_order
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->postmeta} cu ON cu.post_id = p.ID AND cu.meta_key = '_customer_user'
+			LEFT JOIN {$wpdb->postmeta} tot ON tot.post_id = p.ID AND tot.meta_key = '_order_total'
+			WHERE p.post_type = 'shop_order' AND p.post_status IN ( {$placeholders} )
+			GROUP BY cu.meta_value",
+			$statuses
+		);
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- one grouped aggregate with no core API equivalent; $sql came out of $wpdb->prepare() above, and the result is cached in the transient below.
+	$rows = $wpdb->get_results( $sql );
+
+	$map = array();
+	foreach ( (array) $rows as $row ) {
+		$uid = (int) $row->uid;
+		if ( $uid < 0 ) {
+			continue;
+		}
+		$map[ $uid ] = array(
+			'orders' => (int) $row->orders,
+			'spend'  => (float) $row->spend,
+			'first'  => (string) $row->first_order,
+			'last'   => (string) $row->last_order,
+		);
+	}
+
+	/**
+	 * Filter the per-customer order aggregate the Customers section
+	 * is built from.
+	 *
+	 * Keyed by user id (`0` is the guest aggregate); each value is
+	 * `array( 'orders' => int, 'spend' => float, 'first' => gmt
+	 * datetime, 'last' => gmt datetime )`. A store that keeps order
+	 * money somewhere else — a subscriptions plugin, a marketplace
+	 * split — can rewrite the whole map here and every band, tile and
+	 * panel follows.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param array $map Aggregate keyed by user id.
+	 */
+	$map = (array) apply_filters( 'openstation_my_wordpress_woo_customer_spend_map', $map );
+
+	set_transient( 'desktop_mode_woo_customer_spend', $map, 5 * MINUTE_IN_SECONDS );
+	$memo = $map;
+
+	return $memo;
+}
+
+/**
+ * The store's average order value across every paid order.
+ *
+ * Includes guests: a threshold derived only from account holders would
+ * sit wherever the checkout-registration rate happened to put it.
+ *
+ * @return float
+ */
+function openstation_my_wordpress_woo_store_aov() {
+	$orders = 0;
+	$spend  = 0.0;
+	foreach ( openstation_my_wordpress_woo_customer_spend_map() as $stats ) {
+		$orders += (int) $stats['orders'];
+		$spend  += (float) $stats['spend'];
+	}
+
+	return $orders > 0 ? $spend / $orders : 0.0;
+}
+
+/**
+ * Lifetime spend at or above which a customer is a VIP.
+ *
+ * Derived rather than fixed: "spent over 500" means nothing without
+ * knowing whether the store sells postcards or pianos. Three average
+ * orders is the default — enough to be deliberate repeat custom on any
+ * store, cheap to compute, and one filter away from a merchant's own
+ * number.
+ *
+ * @return float Threshold, or `0.0` when the store has no paid orders
+ *               yet (in which case nothing can qualify).
+ */
+function openstation_my_wordpress_woo_vip_threshold() {
+	$aov = openstation_my_wordpress_woo_store_aov();
+
+	/**
+	 * Filter the lifetime-spend threshold for the VIP band.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param float $threshold Threshold in store currency.
+	 * @param float $aov       The store's average order value.
+	 */
+	return (float) apply_filters(
+		'openstation_my_wordpress_woo_vip_threshold',
+		$aov * 3,
+		$aov
+	);
+}
+
+/**
+ * Days without an order after which a customer counts as lapsed.
+ *
+ * @return int
+ */
+function openstation_my_wordpress_woo_customer_lapse_days() {
+	/**
+	 * Filter the lapse window for the Customers section.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param int $days Days since the last order.
+	 */
+	$days = (int) apply_filters(
+		'openstation_my_wordpress_woo_customer_lapse_days',
+		OPENSTATION_WOO_CUSTOMER_LAPSE_DAYS
+	);
+
+	return max( 1, $days );
+}
+
+/*
+-------------------------------------------------------------------
+ * Bands
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * Band definitions for the Customers section, in display order.
+ *
+ * VIP and Lapsed lead because they are the two the merchant can do
+ * something about — one to look after, one to win back. Everything
+ * else is context, and "No orders" trails because a registered
+ * account that never bought is the least urgent row on the screen.
+ *
+ * @return array[] Each entry: `id`, `label`, `order`, optional `tone`.
+ */
+function openstation_my_wordpress_woo_customer_band_defs() {
+	$bands = array(
+		array(
+			'id'    => 'vip',
+			'label' => __( 'VIP', 'desktop-mode' ),
+			'order' => 10,
+			'tone'  => 'success',
+		),
+		array(
+			'id'    => 'lapsed',
+			'label' => __( 'Lapsed', 'desktop-mode' ),
+			'order' => 20,
+			'tone'  => 'warn',
+		),
+		array(
+			'id'    => 'repeat',
+			'label' => __( 'Repeat', 'desktop-mode' ),
+			'order' => 30,
+		),
+		array(
+			'id'    => 'new',
+			'label' => __( 'New', 'desktop-mode' ),
+			'order' => 40,
+		),
+		array(
+			'id'    => 'none',
+			'label' => __( 'No orders yet', 'desktop-mode' ),
+			'order' => 50,
+		),
+	);
+
+	/**
+	 * Filter the band definitions for the Customers section.
+	 *
+	 * Changing a band's membership rule means filtering
+	 * `openstation_my_wordpress_woo_customer_band` as well — this
+	 * filter only decides what the bands are called and in which
+	 * order they render.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param array[] $bands Band descriptors.
+	 */
+	return (array) apply_filters( 'openstation_my_wordpress_woo_customer_bands', $bands );
+}
+
+/**
+ * Which band a customer's aggregate puts them in.
+ *
+ * @param array $stats Aggregate row: `orders`, `spend`, `last`.
+ * @return string Band id.
+ */
+function openstation_my_wordpress_woo_customer_band_id( $stats ) {
+	$orders = (int) ( $stats['orders'] ?? 0 );
+	$spend  = (float) ( $stats['spend'] ?? 0 );
+	$last   = (string) ( $stats['last'] ?? '' );
+
+	$band = 'none';
+	if ( $orders > 0 ) {
+		$threshold = openstation_my_wordpress_woo_vip_threshold();
+		$lapsed    = openstation_my_wordpress_woo_customer_days_since( $last );
+
+		if ( $threshold > 0 && $spend >= $threshold ) {
+			// VIP outranks lapsed on purpose: a big spender who has
+			// gone quiet is still the row you want at the top of the
+			// screen, and the days-since line in the pane says the
+			// rest.
+			$band = 'vip';
+		} elseif ( null !== $lapsed && $lapsed > openstation_my_wordpress_woo_customer_lapse_days() ) {
+			$band = 'lapsed';
+		} elseif ( $orders > 1 ) {
+			$band = 'repeat';
+		} else {
+			$band = 'new';
+		}
+	}
+
+	/**
+	 * Filter the band a customer lands in.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param string $band  Band id.
+	 * @param array  $stats The customer's order aggregate.
+	 */
+	return (string) apply_filters( 'openstation_my_wordpress_woo_customer_band', $band, $stats );
+}
+
+/**
+ * Whole days between a GMT datetime and now, or `null` when the input
+ * isn't a usable date.
+ *
+ * @param string $gmt_datetime `Y-m-d H:i:s` in GMT.
+ * @return int|null
+ */
+function openstation_my_wordpress_woo_customer_days_since( $gmt_datetime ) {
+	if ( '' === (string) $gmt_datetime ) {
+		return null;
+	}
+	$stamp = strtotime( $gmt_datetime . ' GMT' );
+	if ( ! $stamp ) {
+		return null;
+	}
+
+	return (int) floor( ( time() - $stamp ) / DAY_IN_SECONDS );
+}
+
+/**
+ * Band definitions with an exact row count each, for the client.
+ *
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_customer_bands_with_counts() {
+	$plan   = openstation_my_wordpress_woo_customer_plan();
+	$counts = (array) ( $plan['counts'] ?? array() );
+
+	$bands = array();
+	foreach ( openstation_my_wordpress_woo_customer_band_defs() as $band ) {
+		$band['count'] = (int) ( $counts[ $band['id'] ] ?? 0 );
+		$bands[]       = $band;
+	}
+
+	return $bands;
+}
+
+/*
+-------------------------------------------------------------------
+ * The ordering plan
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * Candidate customer ids — everyone who has paid for something, plus
+ * everyone holding the `customer` role.
+ *
+ * The union matters in both directions: a shop manager who buys from
+ * their own store is a customer, and a checkout-registered account
+ * that hasn't ordered yet is a customer the merchant would want to
+ * see. Neither query alone finds both.
+ *
+ * @return int[] User ids, unordered.
+ */
+function openstation_my_wordpress_woo_customer_candidate_ids() {
+	$ids = array();
+	foreach ( openstation_my_wordpress_woo_customer_spend_map() as $user_id => $stats ) {
+		$user_id = (int) $user_id;
+		if ( $user_id > 0 ) {
+			$ids[ $user_id ] = true;
+		}
+	}
+
+	$role_users = get_users(
+		array(
+			'role'    => 'customer',
+			'fields'  => 'ID',
+			'number'  => OPENSTATION_WOO_MAX_ORDERED_CUSTOMERS + 1,
+			'orderby' => 'registered',
+			'order'   => 'DESC',
+		)
+	);
+	foreach ( (array) $role_users as $user_id ) {
+		$ids[ (int) $user_id ] = true;
+	}
+
+	/**
+	 * Filter the set of users the Customers section considers.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param int[] $ids Candidate user ids.
+	 */
+	return array_values(
+		array_map( 'intval', array_keys( (array) apply_filters( 'openstation_my_wordpress_woo_customer_ids', $ids ) ) )
+	);
+}
+
+/**
+ * The band-ordered customer id list plus an exact count per band.
+ *
+ * Same contract as the catalogue's plan, and for the same reason:
+ * bands only stop reshuffling if rows *arrive* in band order. A band
+ * that fills late expands above whatever the user is already reading.
+ *
+ * Cached for five minutes and flushed on any order change.
+ *
+ * @return array{ids:int[], counts:array<string,int>, capped:bool, customers:int}
+ */
+function openstation_my_wordpress_woo_customer_plan() {
+	static $memo = null;
+	if ( null !== $memo ) {
+		return $memo;
+	}
+
+	$cached = get_transient( 'desktop_mode_woo_customer_plan' );
+	if ( is_array( $cached ) && isset( $cached['ids'], $cached['counts'] ) ) {
+		$memo = $cached;
+		return $memo;
+	}
+
+	$candidates = openstation_my_wordpress_woo_customer_candidate_ids();
+	$total      = count( $candidates );
+
+	if ( $total > OPENSTATION_WOO_MAX_ORDERED_CUSTOMERS ) {
+		$memo = array(
+			'ids'       => array(),
+			'counts'    => array(),
+			'capped'    => true,
+			'customers' => $total,
+		);
+		set_transient( 'desktop_mode_woo_customer_plan', $memo, 5 * MINUTE_IN_SECONDS );
+		return $memo;
+	}
+
+	$map     = openstation_my_wordpress_woo_customer_spend_map();
+	$buckets = array();
+	$counts  = array();
+	foreach ( openstation_my_wordpress_woo_customer_band_defs() as $band ) {
+		$buckets[ $band['id'] ] = array();
+		$counts[ $band['id'] ]  = 0;
+	}
+
+	foreach ( $candidates as $user_id ) {
+		$stats = $map[ $user_id ] ?? array(
+			'orders' => 0,
+			'spend'  => 0.0,
+			'first'  => '',
+			'last'   => '',
+		);
+		$band  = openstation_my_wordpress_woo_customer_band_id( $stats );
+		if ( ! isset( $buckets[ $band ] ) ) {
+			// A filter invented a band the definitions don't declare.
+			// Park it under "no orders" rather than dropping the row:
+			// a customer missing from the list is a worse outcome than
+			// one in an unexpected group.
+			$band = 'none';
+			if ( ! isset( $buckets[ $band ] ) ) {
+				continue;
+			}
+		}
+		// Highest spend first inside every band — the ordering the
+		// merchant would apply by hand.
+		$buckets[ $band ][] = array(
+			'id'    => $user_id,
+			'spend' => (float) $stats['spend'],
+		);
+		++$counts[ $band ];
+	}
+
+	$ordered = array();
+	foreach ( $buckets as $rows ) {
+		usort(
+			$rows,
+			static function ( $a, $b ) {
+				if ( $a['spend'] === $b['spend'] ) {
+					return $a['id'] <=> $b['id'];
+				}
+				return $b['spend'] <=> $a['spend'];
+			}
+		);
+		foreach ( $rows as $row ) {
+			$ordered[] = (int) $row['id'];
+		}
+	}
+
+	$memo = array(
+		'ids'       => $ordered,
+		'counts'    => $counts,
+		'capped'    => false,
+		'customers' => $total,
+	);
+	set_transient( 'desktop_mode_woo_customer_plan', $memo, 5 * MINUTE_IN_SECONDS );
+
+	return $memo;
+}
+
+/**
+ * A readable summary of whether the Customers list is band-ordered,
+ * for diagnosing a section whose bands look wrong. Mirrors the
+ * catalogue's `ordering` blob.
+ *
+ * @return array{mode:string, customers:int, ordered:int, limit:int}
+ */
+function openstation_my_wordpress_woo_customer_ordering_state() {
+	$plan = openstation_my_wordpress_woo_customer_plan();
+
+	return array(
+		'mode'      => ! empty( $plan['capped'] ) ? 'capped' : 'ordered',
+		'customers' => (int) ( $plan['customers'] ?? 0 ),
+		'ordered'   => count( (array) ( $plan['ids'] ?? array() ) ),
+		'limit'     => OPENSTATION_WOO_MAX_ORDERED_CUSTOMERS,
+	);
+}
+
+/**
+ * Drop the cached aggregate and plan when an order changes, so a
+ * first-time buyer moves out of "No orders yet" on the next load
+ * rather than five minutes later.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_flush_customer_caches() {
+	delete_transient( 'desktop_mode_woo_customer_spend' );
+	delete_transient( 'desktop_mode_woo_customer_plan' );
+}
+add_action( 'woocommerce_new_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
+add_action( 'woocommerce_update_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
+add_action( 'woocommerce_order_status_changed', 'openstation_my_wordpress_woo_flush_customer_caches' );
+add_action( 'woocommerce_delete_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
+add_action( 'woocommerce_trash_order', 'openstation_my_wordpress_woo_flush_customer_caches' );
+
+/*
+-------------------------------------------------------------------
+ * Per-customer facts
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * The `openstation_woo_customer` payload for one user — everything a
+ * tile, a band, and the compact pane row need, and nothing that costs
+ * an extra query.
+ *
+ * Every field here is read from the cached aggregate. The deeper
+ * facts (last order number, favourite product, billing address) live
+ * in the customer *summary* below, which only runs for the one row
+ * actually selected.
+ *
+ * @param int $user_id User id.
+ * @return array
+ */
+function openstation_my_wordpress_woo_customer_facts( $user_id ) {
+	$user_id = (int) $user_id;
+	$map     = openstation_my_wordpress_woo_customer_spend_map();
+	$stats   = $map[ $user_id ] ?? array(
+		'orders' => 0,
+		'spend'  => 0.0,
+		'first'  => '',
+		'last'   => '',
+	);
+
+	$orders = (int) $stats['orders'];
+	$spend  = (float) $stats['spend'];
+	$days   = openstation_my_wordpress_woo_customer_days_since( $stats['last'] );
+
+	$facts = array(
+		'band'       => openstation_my_wordpress_woo_customer_band_id( $stats ),
+		'orders'     => $orders,
+		'spend'      => openstation_my_wordpress_woo_price( $spend ),
+		// Raw alongside the formatted string: the client sorts and
+		// compares on this, and no locale can break a float.
+		'spendRaw'   => round( $spend, 2 ),
+		'aov'        => $orders > 0 ? openstation_my_wordpress_woo_price( $spend / $orders ) : '',
+		'firstOrder' => '' !== $stats['first'] ? mysql2date( 'c', $stats['first'], false ) : '',
+		'lastOrder'  => '' !== $stats['last'] ? mysql2date( 'c', $stats['last'], false ) : '',
+		'daysSince'  => $days,
+		// The list screen filtered to this person. On the row rather
+		// than only in the summary so the tile's context menu can open
+		// it without first fetching a panel the user never asked for.
+		'ordersUrl'  => $orders > 0 ? openstation_my_wordpress_woo_customer_orders_url( $user_id ) : '',
+	);
+
+	/**
+	 * Filter the compact customer facts carried on every row of the
+	 * Customers section (and on `/wp/v2/users` rows).
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param array $facts   Fact payload.
+	 * @param int   $user_id The customer.
+	 */
+	return (array) apply_filters( 'openstation_my_wordpress_woo_customer_facts', $facts, $user_id );
+}
+
+/**
+ * Register `openstation_woo_customer` on the core `user` resource.
+ *
+ * Deliberately not limited to our own collection: it means the
+ * built-in Users section, and any plugin reading `/wp/v2/users`, gets
+ * lifetime spend for free. The field is gated the same way the rest of
+ * the section is — a viewer who can't see orders sees no money.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_register_customer_field() {
+	if ( ! openstation_my_wordpress_woo_active() ) {
+		return;
+	}
+
+	register_rest_field(
+		'user',
+		'openstation_woo_customer',
+		array(
+			'get_callback' => static function ( $user ) {
+				if ( true !== openstation_my_wordpress_woo_customers_permission() ) {
+					return null;
+				}
+				$id = isset( $user['id'] ) ? (int) $user['id'] : 0;
+				return $id > 0 ? openstation_my_wordpress_woo_customer_facts( $id ) : null;
+			},
+			'schema'       => array(
+				'description' => __( 'WooCommerce lifetime facts for this customer.', 'desktop-mode' ),
+				'type'        => array( 'object', 'null' ),
+				'context'     => array( 'view', 'edit', 'embed' ),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'openstation_my_wordpress_woo_register_customer_field' );
+
+/*
+-------------------------------------------------------------------
+ * REST
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * Whether the current user may see customer money.
+ *
+ * Two gates, both required: order access (the data *is* order data)
+ * and `list_users` (the rows are people). An editor who can moderate
+ * comments has neither.
+ *
+ * @return true|WP_Error
+ */
+function openstation_my_wordpress_woo_customers_permission() {
+	$orders = openstation_my_wordpress_woo_orders_permission();
+	if ( is_wp_error( $orders ) ) {
+		return $orders;
+	}
+
+	if ( ! current_user_can( 'list_users' ) ) {
+		return new WP_Error(
+			'openstation_woo_forbidden',
+			__( 'Sorry, you are not allowed to view customers.', 'desktop-mode' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Shape a user as the row the site window's `user` entity kind reads —
+ * the same field set `/wp/v2/users` returns, plus our two payloads.
+ *
+ * @param WP_User $user User.
+ * @return array
+ */
+function openstation_my_wordpress_woo_customer_row( $user ) {
+	$avatars = array();
+	foreach ( rest_get_avatar_sizes() as $size ) {
+		$avatars[ (string) $size ] = get_avatar_url( $user->ID, array( 'size' => $size ) );
+	}
+
+	return array(
+		'id'                       => (int) $user->ID,
+		'name'                     => $user->display_name,
+		'slug'                     => $user->user_nicename,
+		'description'              => (string) get_user_meta( $user->ID, 'description', true ),
+		'link'                     => (string) get_author_posts_url( $user->ID ),
+		'avatar_urls'              => $avatars,
+		'openstation_summary'      => function_exists( 'openstation_my_wordpress_user_summary_payload' )
+			? openstation_my_wordpress_user_summary_payload( $user->ID )
+			: array(),
+		'openstation_woo_customer' => openstation_my_wordpress_woo_customer_facts( $user->ID ),
+	);
+}
+
+/**
+ * `GET /woocommerce/customers` — paginated, user-shaped customer list.
+ *
+ * @param WP_REST_Request $request Request.
+ * @return WP_REST_Response
+ */
+function openstation_my_wordpress_woo_customers( $request ) {
+	$per_page = max( 1, min( 100, (int) ( $request['per_page'] ?? 24 ) ) );
+	$page     = max( 1, (int) ( $request['page'] ?? 1 ) );
+	$search   = trim( (string) ( $request['search'] ?? '' ) );
+
+	$plan   = openstation_my_wordpress_woo_customer_plan();
+	$capped = ! empty( $plan['capped'] );
+
+	$args = array(
+		'number' => $per_page,
+		'paged'  => $page,
+		'fields' => 'all',
+	);
+
+	if ( $capped ) {
+		// Past the cap the plan holds no ids, so hand the ordering
+		// back to the database: newest accounts first, which is the
+		// only useful order left once bands are off.
+		$args['role']    = 'customer';
+		$args['orderby'] = 'registered';
+		$args['order']   = 'DESC';
+	} else {
+		$ids = (array) $plan['ids'];
+		if ( empty( $ids ) ) {
+			$response = rest_ensure_response( array() );
+			$response->header( 'X-WP-Total', '0' );
+			$response->header( 'X-WP-TotalPages', '1' );
+			return $response;
+		}
+		$args['include'] = $ids;
+		// `include` + `orderby => include` replays the plan's order
+		// verbatim, the same trick the catalogue uses with `post__in`.
+		$args['orderby'] = 'include';
+	}
+
+	if ( '' !== $search ) {
+		$args['search']         = '*' . $search . '*';
+		$args['search_columns'] = array( 'user_login', 'user_email', 'user_nicename', 'display_name' );
+		// A search is a different question from "show me the roster",
+		// and the plan's order would hide matches below the fold.
+		// Ordering falls back to relevance-free display name, which is
+		// at least stable.
+		if ( ! $capped ) {
+			$args['orderby'] = 'display_name';
+			$args['order']   = 'ASC';
+		}
+	}
+
+	/**
+	 * Filter the `WP_User_Query` args for the Customers section.
+	 *
+	 * `number` and `paged` are set by the paginator and will be
+	 * overwritten.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param array           $args    Query args.
+	 * @param WP_REST_Request $request The request.
+	 */
+	$args = (array) apply_filters( 'openstation_my_wordpress_woo_customer_query_args', $args, $request );
+
+	$query = new WP_User_Query( $args );
+	$total = (int) $query->get_total();
+	$pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 1;
+
+	$rows = array();
+	foreach ( (array) $query->get_results() as $user ) {
+		if ( $user instanceof WP_User ) {
+			$rows[] = openstation_my_wordpress_woo_customer_row( $user );
+		}
+	}
+
+	$response = rest_ensure_response( $rows );
+	$response->header( 'X-WP-Total', (string) $total );
+	$response->header( 'X-WP-TotalPages', (string) max( 1, $pages ) );
+	// Same diagnostic contract the Orders route carries: an empty
+	// folder with a confident count should be answerable from the
+	// network tab, not guessed at.
+	$response->header( 'X-Desktop-Mode-Woo-Customers-Mode', $capped ? 'capped' : 'ordered' );
+
+	return $response;
+}
+
+/**
+ * `GET /woocommerce/customers/<id>` — one user-shaped customer.
+ *
+ * @param WP_REST_Request $request Request.
+ * @return WP_REST_Response|WP_Error
+ */
+function openstation_my_wordpress_woo_customer( $request ) {
+	$user = get_userdata( (int) $request['id'] );
+	if ( ! $user instanceof WP_User ) {
+		return new WP_Error(
+			'openstation_woo_no_customer',
+			__( 'Customer not found.', 'desktop-mode' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	return rest_ensure_response( openstation_my_wordpress_woo_customer_row( $user ) );
+}
+
+/*
+-------------------------------------------------------------------
+ * The customer summary — the right pane
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * The customer's most-bought product, resolved from their recent
+ * orders.
+ *
+ * Bounded to the last 50 orders: this runs once per selection, and a
+ * decade of order history would turn a preview pane into a page load.
+ *
+ * @param int $user_id User id.
+ * @return array{label:string, editUrl:string, quantity:int}|null
+ */
+function openstation_my_wordpress_woo_customer_favourite( $user_id ) {
+	$orders = wc_get_orders(
+		array(
+			'customer_id' => (int) $user_id,
+			'limit'       => 50,
+			'status'      => openstation_my_wordpress_woo_paid_statuses(),
+			'orderby'     => 'date',
+			'order'       => 'DESC',
+			'return'      => 'objects',
+		)
+	);
+
+	$tally = array();
+	foreach ( (array) $orders as $maybe_order ) {
+		$order = is_scalar( $maybe_order ) ? wc_get_order( (int) $maybe_order ) : $maybe_order;
+		if ( ! $order instanceof WC_Abstract_Order ) {
+			continue;
+		}
+		foreach ( $order->get_items() as $item ) {
+			$product_id = method_exists( $item, 'get_product_id' ) ? (int) $item->get_product_id() : 0;
+			if ( $product_id <= 0 ) {
+				continue;
+			}
+			if ( ! isset( $tally[ $product_id ] ) ) {
+				$tally[ $product_id ] = array(
+					'label'    => $item->get_name(),
+					'quantity' => 0,
+				);
+			}
+			$tally[ $product_id ]['quantity'] += (int) $item->get_quantity();
+		}
+	}
+
+	if ( empty( $tally ) ) {
+		return null;
+	}
+
+	uasort(
+		$tally,
+		static function ( $a, $b ) {
+			return $b['quantity'] <=> $a['quantity'];
+		}
+	);
+
+	$product_id = (int) array_key_first( $tally );
+	$top        = $tally[ $product_id ];
+
+	return array(
+		'label'    => (string) $top['label'],
+		'quantity' => (int) $top['quantity'],
+		'editUrl'  => get_post( $product_id )
+			? (string) get_edit_post_link( $product_id, 'raw' )
+			: '',
+	);
+}
+
+/**
+ * A customer's most recent orders, shaped for a list.
+ *
+ * Bounded and only fetched for the one customer being looked at — the
+ * list rows never touch this.
+ *
+ * @param int $user_id User id.
+ * @param int $limit   How many.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_customer_recent_orders( $user_id, $limit = 8 ) {
+	$orders = wc_get_orders(
+		array(
+			'customer_id' => (int) $user_id,
+			'limit'       => max( 1, (int) $limit ),
+			'orderby'     => 'date',
+			'order'       => 'DESC',
+			'return'      => 'objects',
+		)
+	);
+
+	$statuses = wc_get_order_statuses();
+	$rows     = array();
+	foreach ( (array) $orders as $maybe_order ) {
+		$order = is_scalar( $maybe_order ) ? wc_get_order( (int) $maybe_order ) : $maybe_order;
+		if ( ! $order instanceof WC_Abstract_Order ) {
+			continue;
+		}
+		$rows[] = array(
+			'id'          => (int) $order->get_id(),
+			'number'      => (string) $order->get_order_number(),
+			'status'      => (string) $order->get_status(),
+			'statusLabel' => (string) ( $statuses[ 'wc-' . $order->get_status() ] ?? $order->get_status() ),
+			'date'        => $order->get_date_created()
+				? $order->get_date_created()->date( 'c' )
+				: '',
+			'total'       => openstation_my_wordpress_woo_price( $order->get_total(), $order->get_currency() ),
+			'items'       => (int) $order->get_item_count(),
+			'editUrl'     => method_exists( $order, 'get_edit_order_url' )
+				? (string) $order->get_edit_order_url()
+				: '',
+		);
+	}
+
+	return $rows;
+}
+
+/**
+ * Merchant facts for one customer — the right-pane panel.
+ *
+ * @param int $id User id.
+ * @return array|WP_Error
+ */
+function openstation_my_wordpress_woo_customer_summary( $id ) {
+	$user = get_userdata( (int) $id );
+	if ( ! $user instanceof WP_User ) {
+		return new WP_Error(
+			'openstation_woo_no_customer',
+			__( 'Customer not found.', 'desktop-mode' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	$facts = openstation_my_wordpress_woo_customer_facts( $user->ID );
+	$bands = array();
+	foreach ( openstation_my_wordpress_woo_customer_band_defs() as $band ) {
+		$bands[ $band['id'] ] = (string) $band['label'];
+	}
+
+	// The most recent order, for the "last bought" line and the jump
+	// into it. One query, only for the selected row.
+	$recent = wc_get_orders(
+		array(
+			'customer_id' => $user->ID,
+			'limit'       => 1,
+			'orderby'     => 'date',
+			'order'       => 'DESC',
+			'return'      => 'objects',
+		)
+	);
+	$last   = null;
+	foreach ( (array) $recent as $maybe_order ) {
+		$order = is_scalar( $maybe_order ) ? wc_get_order( (int) $maybe_order ) : $maybe_order;
+		if ( $order instanceof WC_Abstract_Order ) {
+			$last = $order;
+			break;
+		}
+	}
+
+	$customer = null;
+	if ( class_exists( 'WC_Customer' ) ) {
+		try {
+			$customer = new WC_Customer( $user->ID );
+		} catch ( Exception $e ) {
+			$customer = null;
+		}
+	}
+
+	$location = '';
+	$billing  = '';
+	$shipping = '';
+	$phone    = '';
+	if ( $customer ) {
+		$parts    = array_filter(
+			array(
+				$customer->get_billing_city(),
+				$customer->get_billing_country(),
+			)
+		);
+		$location = implode( ', ', $parts );
+		$phone    = (string) $customer->get_billing_phone();
+
+		// `WC_Customer` has no formatted-address accessor of its own,
+		// so build the lines the way WooCommerce's order screen does.
+		$format   = static function ( array $address ) {
+			if ( ! function_exists( 'WC' ) || ! WC()->countries ) {
+				return '';
+			}
+			return trim(
+				wp_strip_all_tags(
+					(string) WC()->countries->get_formatted_address( $address, ', ' )
+				)
+			);
+		};
+		$billing  = $format(
+			array(
+				'address_1' => $customer->get_billing_address_1(),
+				'address_2' => $customer->get_billing_address_2(),
+				'city'      => $customer->get_billing_city(),
+				'state'     => $customer->get_billing_state(),
+				'postcode'  => $customer->get_billing_postcode(),
+				'country'   => $customer->get_billing_country(),
+			)
+		);
+		$shipping = $format(
+			array(
+				'address_1' => $customer->get_shipping_address_1(),
+				'address_2' => $customer->get_shipping_address_2(),
+				'city'      => $customer->get_shipping_city(),
+				'state'     => $customer->get_shipping_state(),
+				'postcode'  => $customer->get_shipping_postcode(),
+				'country'   => $customer->get_shipping_country(),
+			)
+		);
+	}
+
+	return array(
+		'type'           => 'customer',
+		'id'             => (int) $user->ID,
+		'name'           => $user->display_name,
+		'username'       => $user->user_login,
+		'avatar'         => (string) get_avatar_url( $user->ID, array( 'size' => 96 ) ),
+		'email'          => $user->user_email,
+		'phone'          => $phone,
+		'billing'        => $billing,
+		'shipping'       => $shipping,
+		// Only the window asks for these; the preview pane's panel
+		// ignores them. One payload, two consumers — cheaper than a
+		// second route, and the window is where the depth belongs.
+		'recentOrders'   => openstation_my_wordpress_woo_customer_recent_orders( $user->ID ),
+		'spendRaw'       => (float) $facts['spendRaw'],
+		'band'           => (string) $facts['band'],
+		'bandLabel'      => $bands[ $facts['band'] ] ?? (string) $facts['band'],
+		'orders'         => (int) $facts['orders'],
+		'spend'          => (string) $facts['spend'],
+		'aov'            => (string) $facts['aov'],
+		'firstOrder'     => (string) $facts['firstOrder'],
+		'lastOrder'      => (string) $facts['lastOrder'],
+		'daysSince'      => $facts['daysSince'],
+		'lastOrderNo'    => $last ? (string) $last->get_order_number() : '',
+		'lastOrderUrl'   => $last && method_exists( $last, 'get_edit_order_url' )
+			? (string) $last->get_edit_order_url()
+			: '',
+		'lastOrderTotal' => $last
+			? openstation_my_wordpress_woo_price( $last->get_total(), $last->get_currency() )
+			: '',
+		'favourite'      => openstation_my_wordpress_woo_customer_favourite( $user->ID ),
+		'location'       => $location,
+		'registered'     => '' !== $user->user_registered
+			? mysql2date( 'c', $user->user_registered, false )
+			: '',
+		'ordersUrl'      => openstation_my_wordpress_woo_customer_orders_url( $user->ID ),
+		'profileUrl'     => current_user_can( 'edit_user', $user->ID )
+			? (string) get_edit_user_link( $user->ID )
+			: '',
+	);
+}
+
+/**
+ * The admin URL listing this customer's orders — HPOS and legacy
+ * storage put that screen in different places.
+ *
+ * @param int $user_id User id.
+ * @return string
+ */
+function openstation_my_wordpress_woo_customer_orders_url( $user_id ) {
+	$user_id = (int) $user_id;
+
+	if ( openstation_my_wordpress_woo_hpos_enabled() ) {
+		return admin_url( 'admin.php?page=wc-orders&_customer_user=' . $user_id );
+	}
+
+	return admin_url( 'edit.php?post_type=shop_order&_customer_user=' . $user_id );
+}
+
+/**
+ * Add the `customer` type to the shared summary route.
+ *
+ * Joining through the route's own extension seam rather than editing
+ * its switch keeps the whole Customers surface in one file — and
+ * proves the seam works, since this is the first thing to use it.
+ *
+ * @param array|null $data Summary payload (untouched for other types).
+ * @param string     $type Summary type.
+ * @param int        $id   Object id.
+ * @return array|WP_Error|null
+ */
+function openstation_my_wordpress_woo_customer_summary_filter( $data, $type, $id ) {
+	if ( 'customer' !== $type ) {
+		return $data;
+	}
+
+	return openstation_my_wordpress_woo_customer_summary( $id );
+}
+
+/**
+ * Gate the `customer` summary type. The generic fallback checks
+ * `edit_post` against the id, which for a user id is meaningless —
+ * and, on a site where post and user ids collide, wrong.
+ *
+ * @param true|WP_Error|null $allowed Permission verdict so far.
+ * @param string             $type    Summary type.
+ * @param int                $id      Object id.
+ * @return true|WP_Error|null
+ */
+function openstation_my_wordpress_woo_customer_summary_capability( $allowed, $type, $id ) {
+	unset( $id );
+	if ( 'customer' !== $type ) {
+		return $allowed;
+	}
+
+	return openstation_my_wordpress_woo_customers_permission();
+}
+
+/**
+ * Register the Customers routes.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_register_customer_routes() {
+	if ( ! openstation_my_wordpress_woo_active() ) {
+		return;
+	}
+
+	register_rest_route(
+		'desktop-mode/v1',
+		'/woocommerce/customers',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'openstation_my_wordpress_woo_customers',
+			'permission_callback' => 'openstation_my_wordpress_woo_customers_permission',
+			'args'                => array(
+				'page'     => array(
+					'type'    => 'integer',
+					'default' => 1,
+				),
+				'per_page' => array(
+					'type'    => 'integer',
+					'default' => 24,
+				),
+				'search'   => array( 'type' => 'string' ),
+			),
+		)
+	);
+
+	register_rest_route(
+		'desktop-mode/v1',
+		'/woocommerce/customers/(?P<id>\d+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => 'openstation_my_wordpress_woo_customer',
+			'permission_callback' => 'openstation_my_wordpress_woo_customers_permission',
+			'args'                => array(
+				'id' => array( 'type' => 'integer' ),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'openstation_my_wordpress_woo_register_customer_routes' );
+
+/*
+-------------------------------------------------------------------
+ * The section
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * Append the Customers section to the Woo folder.
+ *
+ * Registered on the same filter as Orders and at the same priority,
+ * so it lands next to it inside the folder rather than at the end of
+ * the entity list.
+ *
+ * @param array[] $entities Entity descriptors.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_customer_entity( $entities ) {
+	if ( ! is_array( $entities ) || ! openstation_my_wordpress_woo_active() ) {
+		return $entities;
+	}
+	if ( true !== openstation_my_wordpress_woo_customers_permission() ) {
+		return $entities;
+	}
+
+	$group = openstation_my_wordpress_woo_group(
+		array(
+			'id'    => 'plugin:woocommerce',
+			'label' => 'WooCommerce',
+			'icon'  => 'dashicons-admin-plugins',
+			'order' => 20,
+		),
+		'shop_order'
+	);
+
+	$entities[] = array(
+		'id'         => 'wc-customers',
+		'label'      => __( 'Customers', 'desktop-mode' ),
+		'icon'       => 'dashicons-groups',
+		'restPath'   => 'desktop-mode/v1/woocommerce/customers',
+		// Renders through the built-in user kind: avatar tiles, the
+		// dossier pane, the footprint route, the drag-out seam. A
+		// customer is a person before it is a row of money.
+		'kind'       => 'user',
+		// Keeps the facts payload from being stripped by `_fields`.
+		'listFields' => array( 'openstation_woo_customer' ),
+		'group'      => $group['id'],
+		'groupLabel' => $group['label'],
+		'groupIcon'  => $group['icon'],
+		'groupOrder' => $group['order'],
+	);
+
+	return $entities;
+}
+
+/**
+ * Add the people numbers to the Woo folder's Store panel.
+ *
+ * Guest revenue is here because it is the one figure the Customers
+ * section structurally cannot show: an order with no account has no
+ * tile to sit on. Reporting it as a line on the folder is the honest
+ * alternative to letting it disappear.
+ *
+ * @param array $data Store totals.
+ * @return array
+ */
+function openstation_my_wordpress_woo_customer_store_totals( $data ) {
+	if ( ! is_array( $data ) || true !== openstation_my_wordpress_woo_customers_permission() ) {
+		return $data;
+	}
+
+	$map   = openstation_my_wordpress_woo_customer_spend_map();
+	$guest = $map[0] ?? null;
+	$plan  = openstation_my_wordpress_woo_customer_plan();
+
+	$data['customers']   = (int) ( $plan['customers'] ?? 0 );
+	$data['vips']        = (int) ( ( $plan['counts'] ?? array() )['vip'] ?? 0 );
+	$data['lapsed']      = (int) ( ( $plan['counts'] ?? array() )['lapsed'] ?? 0 );
+	$data['guestSpend']  = $guest && (float) $guest['spend'] > 0
+		? openstation_my_wordpress_woo_price( (float) $guest['spend'] )
+		: '';
+	$data['guestOrders'] = $guest ? (int) $guest['orders'] : 0;
+
+	return $data;
+}
+
+/**
+ * Boot the Customers surface.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_customers_boot() {
+	add_filter( 'openstation_my_wordpress_woo_store', 'openstation_my_wordpress_woo_customer_store_totals' );
+	add_filter( 'openstation_my_wordpress_entities', 'openstation_my_wordpress_woo_customer_entity', 5 );
+	add_filter( 'openstation_my_wordpress_woo_summary_type', 'openstation_my_wordpress_woo_customer_summary_filter', 10, 3 );
+	add_filter( 'openstation_my_wordpress_woo_summary_capability', 'openstation_my_wordpress_woo_customer_summary_capability', 10, 3 );
+}
+openstation_my_wordpress_woo_customers_boot();

--- a/includes/my-wordpress/integrations/woocommerce-relations.php
+++ b/includes/my-wordpress/integrations/woocommerce-relations.php
@@ -1,0 +1,1089 @@
+<?php
+/**
+ * OpenStation — My WordPress: WooCommerce × the relations layer.
+ *
+ * An order is the most connected object in WordPress and the least
+ * connected screen. It names a customer, some products and maybe a
+ * coupon, and every one of those is a dead end: WooCommerce prints the
+ * customer's name as text, the line items as text, the coupon as a
+ * token. To go from an order to the product it sold you go back to the
+ * catalogue and search for it.
+ *
+ * The shell already knows how to express that. Two surfaces, both
+ * public, neither WooCommerce-specific:
+ *
+ *   1. **Content identity** (`openstation_window_content_identity`) —
+ *      what a window is showing, plus the objects it refers to. Two
+ *      open windows whose identities meet get a drawn tie on the
+ *      desktop. Open an order beside the product it sold and the line
+ *      between them is the shell telling you they are the same story.
+ *
+ *   2. **Related entities** (`openstation_window_related_entities`) —
+ *      the title bar's "Related" menu. One click from the order to the
+ *      customer's profile, to any product on it, to the coupon that
+ *      discounted it, each opening as its own window rather than
+ *      navigating away from what you were reading.
+ *
+ * Both run inside the chromeless iframe — real admin context — so the
+ * relations resolve against live WooCommerce objects rather than
+ * against a URL we guessed at.
+ *
+ * Screens covered:
+ *
+ *   - Order edit, both storages. High-Performance Order Storage moves
+ *     the screen to `admin.php?page=wc-orders&action=edit&id=N`, where
+ *     the built-in `post.php` detection can never see it; legacy
+ *     storage lands on `post.php` and gets an identity already, but
+ *     one with no links on it.
+ *   - Product edit — categories, tags, reviews, and the media the
+ *     built-in extractor already finds.
+ *   - Coupon edit — the products and categories it is restricted to,
+ *     which WooCommerce shows as bare token fields you have to click
+ *     into to read.
+ *   - User edit — a customer's orders, when the viewer may see them.
+ *
+ * Everything here is inert without WooCommerce.
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * How many line items / coupons one order announces.
+ *
+ * The relations engine caps a ref's whole `links` array at 64 and its
+ * `related` list at 64; a 200-line wholesale order would spend the
+ * entire budget on products and silently drop the customer. Bounded
+ * here so the trailing groups always survive.
+ */
+const OPENSTATION_WOO_RELATION_ITEM_CAP = 20;
+
+/**
+ * Query flag marking a person-URL as a request for a *particular*
+ * view of that person rather than for the profile editor.
+ *
+ * Must stay equal to `OS_PERSON_VIEW_PARAM` in
+ * `src/native-url-remap.ts` — the URL is built here and read there,
+ * so the two ends have to agree on the literal.
+ */
+const OPENSTATION_PERSON_VIEW_PARAM = 'os_person_view';
+
+/*
+-------------------------------------------------------------------
+ * Screen resolution
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * The order the current admin screen is editing, whichever storage
+ * the store uses.
+ *
+ * @return WC_Abstract_Order|null
+ */
+function openstation_my_wordpress_woo_current_order() {
+	if ( ! openstation_my_wordpress_woo_active() ) {
+		return null;
+	}
+
+	$pagenow = isset( $GLOBALS['pagenow'] ) ? (string) $GLOBALS['pagenow'] : '';
+
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only identity harvest; the host admin page enforces capability + nonce.
+	$id = 0;
+	if ( 'admin.php' === $pagenow ) {
+		// HPOS. `wc-orders` for shop orders, `wc-orders--{type}` for
+		// custom order types (subscriptions and friends) — both are
+		// orders as far as the relations layer cares.
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+		if ( 0 !== strpos( $page, 'wc-orders' ) ) {
+			return null;
+		}
+		$action = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
+		if ( 'edit' !== $action ) {
+			return null;
+		}
+		$id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+	} elseif ( 'post.php' === $pagenow ) {
+		// Legacy storage: orders are posts.
+		$id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+		if ( $id > 0 && 'shop_order' !== get_post_type( $id ) ) {
+			return null;
+		}
+	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( $id <= 0 ) {
+		return null;
+	}
+
+	$order = wc_get_order( $id );
+
+	return $order instanceof WC_Abstract_Order ? $order : null;
+}
+
+/**
+ * Whether the viewer may see this order at all.
+ *
+ * @return bool
+ */
+function openstation_my_wordpress_woo_can_read_orders() {
+	return true === openstation_my_wordpress_woo_orders_permission();
+}
+
+/**
+ * The content identity for WooCommerce's product-reviews screen when
+ * it is filtered to a single product.
+ *
+ * `edit.php?post_type=product&page=product-reviews&product_id=N`.
+ * The unfiltered all-reviews list stays identity-less, the same way
+ * core leaves the unfiltered comments list alone: a window showing
+ * everything belongs to nothing in particular.
+ *
+ * @return array|null
+ */
+function openstation_my_wordpress_woo_reviews_identity() {
+	$pagenow = isset( $GLOBALS['pagenow'] ) ? (string) $GLOBALS['pagenow'] : '';
+	if ( 'edit.php' !== $pagenow ) {
+		return null;
+	}
+
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only identity harvest; the host admin page enforces capability + nonce.
+	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+	if ( 'product-reviews' !== $page ) {
+		return null;
+	}
+	$product_id = isset( $_GET['product_id'] ) ? absint( $_GET['product_id'] ) : 0;
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( $product_id <= 0 || 'product' !== get_post_type( $product_id ) ) {
+		return null;
+	}
+	if ( ! current_user_can( 'edit_post', $product_id ) ) {
+		return null;
+	}
+
+	return array(
+		'type'  => 'reviews',
+		'id'    => $product_id,
+		/* translators: %s: product name. */
+		'label' => sprintf( __( 'Reviews of %s', 'desktop-mode' ), get_the_title( $product_id ) ),
+		'root'  => array(
+			'type' => 'product',
+			'id'   => $product_id,
+		),
+	);
+}
+
+/*
+-------------------------------------------------------------------
+ * Content identity
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * The objects an order refers to — its customer, its products, its
+ * coupons — as relation refs.
+ *
+ * Direction is `references` throughout: the order points at them. A
+ * product does not belong to an order (it outlives it), and a customer
+ * certainly doesn't, so `child` would be a lie the arrowheads would
+ * then tell on screen.
+ *
+ * @param WC_Abstract_Order $order Order.
+ * @return array[] Ref entries for the identity's `links` array.
+ */
+function openstation_my_wordpress_woo_order_refs( $order ) {
+	$links = array();
+	$seen  = array();
+
+	$push = static function ( $type, $id ) use ( &$links, &$seen ) {
+		$id  = (int) $id;
+		$key = $type . ':' . $id;
+		if ( $id <= 0 || isset( $seen[ $key ] ) || count( $links ) >= 64 ) {
+			return;
+		}
+		$seen[ $key ] = true;
+		$links[]      = array(
+			'type' => $type,
+			'id'   => $id,
+		);
+	};
+
+	// The customer. `user` is the type the shell's own user-edit
+	// screens announce, so the tie forms against a profile window
+	// opened from anywhere — not just from the shop.
+	$customer_id = method_exists( $order, 'get_customer_id' ) ? (int) $order->get_customer_id() : 0;
+	if ( $customer_id > 0 ) {
+		$push( 'user', $customer_id );
+	}
+
+	$items = 0;
+	foreach ( $order->get_items() as $item ) {
+		if ( $items >= OPENSTATION_WOO_RELATION_ITEM_CAP ) {
+			break;
+		}
+		$product_id = method_exists( $item, 'get_product_id' ) ? (int) $item->get_product_id() : 0;
+		if ( $product_id > 0 && 'product' === get_post_type( $product_id ) ) {
+			$push( 'product', $product_id );
+			++$items;
+		}
+	}
+
+	$coupons = 0;
+	foreach ( $order->get_items( 'coupon' ) as $line ) {
+		if ( $coupons >= OPENSTATION_WOO_RELATION_ITEM_CAP ) {
+			break;
+		}
+		$coupon = new WC_Coupon( $line->get_code() );
+		if ( $coupon->get_id() ) {
+			$push( 'shop_coupon', $coupon->get_id() );
+			++$coupons;
+		}
+	}
+
+	return $links;
+}
+
+/**
+ * The objects a coupon refers to — the products and categories it is
+ * restricted to.
+ *
+ * @param WC_Coupon $coupon Coupon.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_coupon_refs( $coupon ) {
+	$links = array();
+
+	foreach ( array_slice( (array) $coupon->get_product_ids(), 0, OPENSTATION_WOO_RELATION_ITEM_CAP ) as $product_id ) {
+		$product_id = (int) $product_id;
+		if ( $product_id > 0 && 'product' === get_post_type( $product_id ) ) {
+			$links[] = array(
+				'type' => 'product',
+				'id'   => $product_id,
+			);
+		}
+	}
+
+	foreach ( array_slice( (array) $coupon->get_product_categories(), 0, OPENSTATION_WOO_RELATION_ITEM_CAP ) as $term_id ) {
+		$term_id = (int) $term_id;
+		$term    = $term_id ? get_term( $term_id, 'product_cat' ) : null;
+		if ( $term instanceof WP_Term ) {
+			$links[] = array(
+				'type' => 'term/product_cat',
+				'id'   => $term_id,
+			);
+		}
+	}
+
+	return $links;
+}
+
+/**
+ * Announce an identity for WooCommerce's own screens, and hang the
+ * shop's links off the identities the built-in detection already
+ * produces.
+ *
+ * @param array|null     $identity Identity so far.
+ * @param WP_Screen|null $screen   Current screen, when available.
+ * @return array|null
+ */
+function openstation_my_wordpress_woo_content_identity( $identity, $screen ) {
+	unset( $screen );
+	if ( ! openstation_my_wordpress_woo_active() ) {
+		return $identity;
+	}
+
+	// 1. Order edit. Under HPOS there is no identity yet at all —
+	// `post.php` never runs — so this is the only place it can come
+	// from. Under legacy storage there IS one (the generic post
+	// branch), and it arrives with no links: an order's content is
+	// empty, so the hyperlink/media/term extractor finds nothing.
+	$order = openstation_my_wordpress_woo_current_order();
+	if ( $order && openstation_my_wordpress_woo_can_read_orders() ) {
+		$name = method_exists( $order, 'get_formatted_billing_full_name' )
+			? trim( $order->get_formatted_billing_full_name() )
+			: '';
+
+		$identity = array(
+			'type'  => 'shop_order',
+			'id'    => (int) $order->get_id(),
+			'label' => '' !== $name
+				? sprintf(
+					/* translators: 1: order number, 2: customer name. */
+					__( 'Order #%1$s · %2$s', 'desktop-mode' ),
+					$order->get_order_number(),
+					$name
+				)
+				: sprintf(
+					/* translators: %s: order number. */
+					__( 'Order #%s', 'desktop-mode' ),
+					$order->get_order_number()
+				),
+		);
+
+		$links = openstation_my_wordpress_woo_order_refs( $order );
+		if ( ! empty( $links ) ) {
+			$identity['links'] = $links;
+		}
+
+		return $identity;
+	}
+
+	// 2. The product-reviews screen, filtered to one product —
+	// `edit.php?post_type=product&page=product-reviews&product_id=N`,
+	// the target the Related menu's "Reviews" item opens.
+	//
+	// Without this the item opened a window that drew no tie to the
+	// product it came from, while every other item in the same menu
+	// did. The reason is structural rather than a bug in the menu:
+	// a tie needs BOTH windows to have an identity, and WooCommerce
+	// moved reviews off `edit-comments.php` onto its own admin page,
+	// which the built-in detection has no reason to know about. (The
+	// older `edit-comments.php?p=N` route is already covered by core
+	// detection, which is why a post's comments window ties.)
+	//
+	// Rooted at the product, exactly like the built-in comments
+	// identity is rooted at its post: reviews belong to the thing
+	// they review.
+	$reviews_identity = openstation_my_wordpress_woo_reviews_identity();
+	if ( $reviews_identity ) {
+		return $reviews_identity;
+	}
+
+	// 3. Coupon edit — the built-in post branch gives the identity;
+	// the restrictions are what make it interesting.
+	if ( is_array( $identity ) && 'shop_coupon' === ( $identity['type'] ?? '' ) ) {
+		$coupon = new WC_Coupon( (int) $identity['id'] );
+		if ( $coupon->get_id() ) {
+			$links = openstation_my_wordpress_woo_coupon_refs( $coupon );
+			if ( ! empty( $links ) ) {
+				$identity['links'] = array_merge(
+					(array) ( $identity['links'] ?? array() ),
+					$links
+				);
+			}
+		}
+	}
+
+	return $identity;
+}
+
+/*
+-------------------------------------------------------------------
+ * Related entities — the title bar's "Related" menu
+ * ----------------------------------------------------------------
+ */
+
+/**
+ * A related-entity item, with the fields the sanitizer requires.
+ *
+ * @param string $id          Unique id in the list.
+ * @param string $group       Section key.
+ * @param string $group_label Section header.
+ * @param string $label       Item label.
+ * @param string $icon        Dashicon class.
+ * @param string $url         Admin URL to open.
+ * @param int    $count       Optional count badge; 0 omits it.
+ * @return array
+ */
+function openstation_my_wordpress_woo_related_item( $id, $group, $group_label, $label, $icon, $url, $count = 0 ) {
+	$item = array(
+		'id'         => $id,
+		'group'      => $group,
+		'groupLabel' => $group_label,
+		'label'      => $label,
+		'icon'       => $icon,
+		'url'        => $url,
+	);
+	if ( $count > 0 ) {
+		$item['count'] = (int) $count;
+	}
+
+	return $item;
+}
+
+/**
+ * Related items for an order: the customer, every product on it, and
+ * every coupon it used.
+ *
+ * @param WC_Abstract_Order $order Order.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_order_related( $order ) {
+	$related = array();
+
+	$customer_id = method_exists( $order, 'get_customer_id' ) ? (int) $order->get_customer_id() : 0;
+	if ( $customer_id > 0 ) {
+		$user = get_userdata( $customer_id );
+		if ( $user instanceof WP_User ) {
+			$label = $user->display_name ? $user->display_name : $user->user_login;
+
+			if ( current_user_can( 'edit_user', $customer_id ) ) {
+				// The person, as a customer. From an order, "customer"
+				// means *this is who bought it* — not *change their
+				// role* — so this opens the Customer window rather
+				// than the profile editor.
+				//
+				// The Related menu can only express a destination as
+				// a URL, and the only URL WordPress has for a person
+				// is their profile editor. The marker is what lets a
+				// specific view claim that URL: the shell's built-in
+				// profile remap stands down on any person-URL carrying
+				// it, so the claim doesn't depend on winning a
+				// registration-order race.
+				$related[] = openstation_my_wordpress_woo_related_item(
+					'wc-customer-' . $customer_id,
+					'wc-customer',
+					__( 'Customer', 'desktop-mode' ),
+					$label,
+					'dashicons-businessperson',
+					add_query_arg(
+						OPENSTATION_PERSON_VIEW_PARAM,
+						'wc-customer',
+						(string) get_edit_user_link( $customer_id )
+					)
+				);
+
+				// The profile editor is still one item away, unmarked
+				// — it is a real destination, just not the one
+				// "customer" means from an order.
+				$related[] = openstation_my_wordpress_woo_related_item(
+					'wc-customer-profile-' . $customer_id,
+					'wc-customer',
+					__( 'Customer', 'desktop-mode' ),
+					__( 'Edit profile', 'desktop-mode' ),
+					'dashicons-admin-users',
+					(string) get_edit_user_link( $customer_id )
+				);
+			}
+
+			// Their other orders. The count comes off the cached
+			// aggregate the Customers section already builds, so this
+			// is free — and an item that opens a list the merchant
+			// then has to filter by hand is not worth the click.
+			$map    = function_exists( 'openstation_my_wordpress_woo_customer_spend_map' )
+				? openstation_my_wordpress_woo_customer_spend_map()
+				: array();
+			$orders = (int) ( $map[ $customer_id ]['orders'] ?? 0 );
+			if ( $orders > 1 && function_exists( 'openstation_my_wordpress_woo_customer_orders_url' ) ) {
+				$related[] = openstation_my_wordpress_woo_related_item(
+					'wc-customer-orders-' . $customer_id,
+					'wc-customer',
+					__( 'Customer', 'desktop-mode' ),
+					__( 'All orders by this customer', 'desktop-mode' ),
+					'dashicons-cart',
+					openstation_my_wordpress_woo_customer_orders_url( $customer_id ),
+					$orders
+				);
+			}
+		}
+	}
+
+	$items = 0;
+	foreach ( $order->get_items() as $item ) {
+		if ( $items >= OPENSTATION_WOO_RELATION_ITEM_CAP ) {
+			break;
+		}
+		$product_id = method_exists( $item, 'get_product_id' ) ? (int) $item->get_product_id() : 0;
+		if ( $product_id <= 0 || ! get_post( $product_id ) ) {
+			// A line item whose product has since been deleted has no
+			// screen to open. It still reads correctly as text on the
+			// order itself; it just isn't navigation.
+			continue;
+		}
+		if ( ! current_user_can( 'edit_post', $product_id ) ) {
+			continue;
+		}
+		$related[] = openstation_my_wordpress_woo_related_item(
+			'wc-product-' . $product_id,
+			'wc-products',
+			__( 'Products', 'desktop-mode' ),
+			$item->get_name(),
+			'dashicons-products',
+			(string) get_edit_post_link( $product_id, 'raw' ),
+			(int) $item->get_quantity()
+		);
+		++$items;
+	}
+
+	$coupons = 0;
+	foreach ( $order->get_items( 'coupon' ) as $line ) {
+		if ( $coupons >= OPENSTATION_WOO_RELATION_ITEM_CAP ) {
+			break;
+		}
+		$coupon = new WC_Coupon( $line->get_code() );
+		if ( ! $coupon->get_id() || ! current_user_can( 'edit_post', $coupon->get_id() ) ) {
+			continue;
+		}
+		$related[] = openstation_my_wordpress_woo_related_item(
+			'wc-coupon-' . $coupon->get_id(),
+			'wc-coupons',
+			__( 'Coupons', 'desktop-mode' ),
+			$coupon->get_code(),
+			'dashicons-tickets-alt',
+			(string) get_edit_post_link( $coupon->get_id(), 'raw' )
+		);
+		++$coupons;
+	}
+
+	return $related;
+}
+
+/**
+ * Order ids containing a given product, newest first.
+ *
+ * Read from the order-items tables rather than through
+ * `wc_get_orders()`, because there is no "orders containing product X"
+ * query in the WooCommerce API and walking orders to find one would
+ * mean loading every order on the store. Those two tables are the
+ * right index and they are populated under BOTH storages — High
+ * Performance Order Storage moves the order rows, not the line items.
+ *
+ * Matches `_variation_id` as well as `_product_id`: a variation is
+ * sold as its own line, and a merchant asking "who bought this
+ * product" means the variable product too.
+ *
+ * @param int $product_id Product id.
+ * @param int $limit      How many orders.
+ * @return int[] Order ids.
+ */
+function openstation_my_wordpress_woo_orders_with_product( $product_id, $limit = 10 ) {
+	global $wpdb;
+
+	$product_id = (int) $product_id;
+	$limit      = max( 1, (int) $limit );
+	// The order-items tables are WooCommerce's, not core's. Without
+	// the plugin they don't exist, and the query would print a
+	// "table doesn't exist" notice into whatever page called it.
+	if ( $product_id <= 0 || ! openstation_my_wordpress_woo_active() ) {
+		return array();
+	}
+
+	$items    = $wpdb->prefix . 'woocommerce_order_items';
+	$itemmeta = $wpdb->prefix . 'woocommerce_order_itemmeta';
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are structural; every value is prepared.
+	$sql = $wpdb->prepare(
+		"SELECT DISTINCT oi.order_id
+		FROM {$items} oi
+		INNER JOIN {$itemmeta} oim ON oim.order_item_id = oi.order_item_id
+		WHERE oi.order_item_type = 'line_item'
+			AND oim.meta_key IN ( '_product_id', '_variation_id' )
+			AND oim.meta_value = %d
+		ORDER BY oi.order_id DESC
+		LIMIT %d",
+		$product_id,
+		$limit
+	);
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- no core API answers "orders containing product X"; $sql came out of prepare() above, and the result feeds one menu render.
+	$ids = $wpdb->get_col( $sql );
+
+	return array_map( 'intval', (array) $ids );
+}
+
+/**
+ * Coupons restricted to a given product (or to one of its categories).
+ *
+ * WooCommerce stores both restrictions as comma-separated id strings
+ * in postmeta, which no meta query can search reliably — `LIKE
+ * '%12%'` matches 112 and 121. So the rows are read and split in PHP.
+ * Bounded: a store with more coupons than this has a coupon strategy,
+ * not a coupon, and the menu is not the place to enumerate it.
+ *
+ * @param int $product_id Product id.
+ * @param int $limit      How many coupons.
+ * @return int[] Coupon post ids.
+ */
+function openstation_my_wordpress_woo_coupons_for_product( $product_id, $limit = 8 ) {
+	global $wpdb;
+
+	$product_id = (int) $product_id;
+	if ( $product_id <= 0 ) {
+		return array();
+	}
+
+	$category_ids = wp_get_post_terms( $product_id, 'product_cat', array( 'fields' => 'ids' ) );
+	$category_ids = is_wp_error( $category_ids ) ? array() : array_map( 'intval', $category_ids );
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are structural.
+	$sql = "SELECT pm.post_id, pm.meta_key, pm.meta_value
+		FROM {$wpdb->postmeta} pm
+		INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+		WHERE p.post_type = 'shop_coupon'
+			AND p.post_status = 'publish'
+			AND pm.meta_key IN ( 'product_ids', 'product_categories' )
+		LIMIT 400";
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- comma-joined id strings can't be searched with a meta query; bounded scan feeding one menu render.
+	$rows = $wpdb->get_results( $sql );
+
+	$matched = array();
+	foreach ( (array) $rows as $row ) {
+		if ( count( $matched ) >= $limit ) {
+			break;
+		}
+		$values = array_filter( array_map( 'intval', explode( ',', (string) $row->meta_value ) ) );
+		if ( empty( $values ) ) {
+			continue;
+		}
+		$hit = 'product_ids' === $row->meta_key
+			? in_array( $product_id, $values, true )
+			: ( ! empty( array_intersect( $category_ids, $values ) ) );
+		if ( $hit ) {
+			$matched[ (int) $row->post_id ] = true;
+		}
+	}
+
+	return array_map( 'intval', array_keys( $matched ) );
+}
+
+/**
+ * Related items for a product: everything the catalogue screen knows
+ * about it and can't take you to.
+ *
+ * The built-in related pass covers `post` and `page` only, so a
+ * product gets none of this for free — its taxonomies are exactly as
+ * navigable as its order history, which is to say not at all.
+ *
+ * Budgets are per group and add up deliberately. The engine hard-caps
+ * the whole `related` list at 64, and an unbudgeted group would push
+ * the trailing ones silently over — losing the orders because a
+ * product happened to carry thirty tags. Worst case here is
+ * 10 + 10 + 1 + 1 + 10 + 8 + 8 = 48.
+ *
+ * @param int $product_id Product id.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_product_related( $product_id ) {
+	$related = array();
+	$product = wc_get_product( $product_id );
+	if ( ! $product ) {
+		return $related;
+	}
+
+	foreach ( array( 'product_cat', 'product_tag' ) as $taxonomy ) {
+		$tax = get_taxonomy( $taxonomy );
+		if ( ! $tax ) {
+			continue;
+		}
+		$terms = get_the_terms( $product_id, $taxonomy );
+		if ( ! is_array( $terms ) ) {
+			continue;
+		}
+		foreach ( array_slice( $terms, 0, 10 ) as $term ) {
+			$related[] = openstation_my_wordpress_woo_related_item(
+				'wc-term-' . $taxonomy . '-' . (int) $term->term_id,
+				'terms/' . $taxonomy,
+				(string) $tax->labels->name,
+				$term->name,
+				'product_cat' === $taxonomy ? 'dashicons-category' : 'dashicons-tag',
+				admin_url(
+					'term.php?taxonomy=' . rawurlencode( $taxonomy ) . '&tag_ID=' . (int) $term->term_id . '&post_type=product'
+				)
+			);
+		}
+	}
+
+	// Reviews. WooCommerce files them as comments of type `review`,
+	// and its own Reviews screen is the comment list with that filter
+	// pre-applied — which is exactly the URL worth linking.
+	$reviews = (int) $product->get_review_count();
+	if ( $reviews > 0 && current_user_can( 'moderate_comments' ) ) {
+		$related[] = openstation_my_wordpress_woo_related_item(
+			'wc-reviews-' . $product_id,
+			'wc-reviews',
+			__( 'Reviews', 'desktop-mode' ),
+			__( 'Reviews', 'desktop-mode' ),
+			'dashicons-star-filled',
+			admin_url( 'edit.php?post_type=product&page=product-reviews&product_id=' . (int) $product_id ),
+			$reviews
+		);
+	}
+
+	// Variations edit through their parent's screen, but a variable
+	// product's children are the thing a merchant actually adjusts —
+	// surface the parent screen's variations tab as one jump.
+	if ( $product->is_type( 'variable' ) ) {
+		$children = count( $product->get_children() );
+		if ( $children > 0 ) {
+			$related[] = openstation_my_wordpress_woo_related_item(
+				'wc-variations-' . $product_id,
+				'wc-products',
+				__( 'Product', 'desktop-mode' ),
+				__( 'Variations', 'desktop-mode' ),
+				'dashicons-networking',
+				(string) get_edit_post_link( $product_id, 'raw' ) . '#variable_product_options',
+				$children
+			);
+		}
+	}
+
+	// The other half of the story: who bought it. An order names its
+	// products, so the order → product jump has always worked; the
+	// reverse is the one a merchant actually asks for ("is this
+	// selling? who to?") and the catalogue screen has no answer at
+	// all.
+	//
+	// Gated on order access rather than on `edit_post`: this is order
+	// data reached from a product screen, and a shop editor who may
+	// not read orders must not read them sideways.
+	if ( openstation_my_wordpress_woo_can_read_orders() ) {
+		$customers = array();
+		foreach ( openstation_my_wordpress_woo_orders_with_product( $product_id, 10 ) as $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Abstract_Order ) {
+				continue;
+			}
+
+			$name  = method_exists( $order, 'get_formatted_billing_full_name' )
+				? trim( $order->get_formatted_billing_full_name() )
+				: '';
+			$total = openstation_my_wordpress_woo_price(
+				$order->get_total(),
+				$order->get_currency()
+			);
+
+			$related[] = openstation_my_wordpress_woo_related_item(
+				'wc-order-' . $order_id,
+				'wc-orders',
+				__( 'Orders', 'desktop-mode' ),
+				'' !== $name
+					? sprintf(
+						/* translators: 1: order number, 2: customer name, 3: order total. */
+						__( '#%1$s · %2$s · %3$s', 'desktop-mode' ),
+						$order->get_order_number(),
+						$name,
+						$total
+					)
+					: sprintf(
+						/* translators: 1: order number, 2: order total. */
+						__( '#%1$s · %2$s', 'desktop-mode' ),
+						$order->get_order_number(),
+						$total
+					),
+				'dashicons-cart',
+				method_exists( $order, 'get_edit_order_url' )
+					? (string) $order->get_edit_order_url()
+					: ''
+			);
+
+			// Harvested from the same orders rather than queried
+			// again — the buyers of a product ARE the customers on
+			// its orders, and a second query would only say so more
+			// slowly.
+			$customer_id = method_exists( $order, 'get_customer_id' )
+				? (int) $order->get_customer_id()
+				: 0;
+			if ( $customer_id > 0 && ! isset( $customers[ $customer_id ] ) ) {
+				$customers[ $customer_id ] = true;
+			}
+		}
+
+		$shown = 0;
+		foreach ( array_keys( $customers ) as $customer_id ) {
+			if ( $shown >= 8 ) {
+				break;
+			}
+			$user = get_userdata( (int) $customer_id );
+			if ( ! $user instanceof WP_User || ! current_user_can( 'edit_user', $user->ID ) ) {
+				continue;
+			}
+			$related[] = openstation_my_wordpress_woo_related_item(
+				'wc-buyer-' . (int) $customer_id,
+				'wc-customer',
+				__( 'Customers', 'desktop-mode' ),
+				$user->display_name ? $user->display_name : $user->user_login,
+				'dashicons-businessperson',
+				// The Customer window, not the profile editor — from
+				// a product or a coupon, a person is a buyer.
+				add_query_arg(
+					OPENSTATION_PERSON_VIEW_PARAM,
+					'wc-customer',
+					(string) get_edit_user_link( $user->ID )
+				)
+			);
+			++$shown;
+		}
+	}
+
+	// Coupons that discount it — WooCommerce shows the relationship
+	// only from the coupon's side, as a token field, so from the
+	// product there is currently no way to learn it is on offer.
+	foreach ( openstation_my_wordpress_woo_coupons_for_product( $product_id, 8 ) as $coupon_id ) {
+		if ( ! current_user_can( 'edit_post', $coupon_id ) ) {
+			continue;
+		}
+		$coupon = new WC_Coupon( $coupon_id );
+		if ( ! $coupon->get_id() ) {
+			continue;
+		}
+		$related[] = openstation_my_wordpress_woo_related_item(
+			'wc-product-coupon-' . $coupon_id,
+			'wc-coupons',
+			__( 'Coupons', 'desktop-mode' ),
+			$coupon->get_code(),
+			'dashicons-tickets-alt',
+			(string) get_edit_post_link( $coupon_id, 'raw' )
+		);
+	}
+
+	return $related;
+}
+
+/**
+ * Order ids that used a given coupon code, newest first.
+ *
+ * Coupon usage is a line item like any other, so it lives in the same
+ * always-populated order-items tables. `order_item_name` holds the
+ * code, lowercased by WooCommerce on apply.
+ *
+ * @param string $code  Coupon code.
+ * @param int    $limit How many orders.
+ * @return int[] Order ids.
+ */
+function openstation_my_wordpress_woo_orders_with_coupon( $code, $limit = 10 ) {
+	global $wpdb;
+
+	$code = strtolower( trim( (string) $code ) );
+	// Same table-ownership caveat as the product lookup above.
+	if ( '' === $code || ! openstation_my_wordpress_woo_active() ) {
+		return array();
+	}
+
+	$items = $wpdb->prefix . 'woocommerce_order_items';
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is structural; every value is prepared.
+	$sql = $wpdb->prepare(
+		"SELECT DISTINCT order_id
+		FROM {$items}
+		WHERE order_item_type = 'coupon' AND LOWER( order_item_name ) = %s
+		ORDER BY order_id DESC
+		LIMIT %d",
+		$code,
+		max( 1, (int) $limit )
+	);
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- no core API answers "orders that used coupon X"; $sql came out of prepare() above, and the result feeds one menu render.
+	$ids = $wpdb->get_col( $sql );
+
+	return array_map( 'intval', (array) $ids );
+}
+
+/**
+ * Related items for a coupon: what it is restricted to, and who
+ * actually used it.
+ *
+ * WooCommerce renders the restrictions as select2 token fields —
+ * readable only by clicking into each token, and not links to
+ * anywhere. The usage count it does show is a bare number with
+ * nothing behind it.
+ *
+ * Budgets: 20 + 20 + 10 + 8 = 58, inside the engine's 64-item cap.
+ *
+ * @param int $coupon_id Coupon id.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_coupon_related( $coupon_id ) {
+	$related = array();
+	$coupon  = new WC_Coupon( (int) $coupon_id );
+	if ( ! $coupon->get_id() ) {
+		return $related;
+	}
+
+	foreach ( array_slice( (array) $coupon->get_product_ids(), 0, OPENSTATION_WOO_RELATION_ITEM_CAP ) as $product_id ) {
+		$product = wc_get_product( (int) $product_id );
+		if ( ! $product || ! current_user_can( 'edit_post', (int) $product_id ) ) {
+			continue;
+		}
+		$related[] = openstation_my_wordpress_woo_related_item(
+			'wc-coupon-product-' . (int) $product_id,
+			'wc-products',
+			__( 'Applies to', 'desktop-mode' ),
+			$product->get_name(),
+			'dashicons-products',
+			(string) get_edit_post_link( (int) $product_id, 'raw' )
+		);
+	}
+
+	foreach ( array_slice( (array) $coupon->get_product_categories(), 0, OPENSTATION_WOO_RELATION_ITEM_CAP ) as $term_id ) {
+		$term = get_term( (int) $term_id, 'product_cat' );
+		if ( ! $term instanceof WP_Term ) {
+			continue;
+		}
+		$related[] = openstation_my_wordpress_woo_related_item(
+			'wc-coupon-cat-' . (int) $term_id,
+			'terms/product_cat',
+			__( 'Applies to', 'desktop-mode' ),
+			$term->name,
+			'dashicons-category',
+			admin_url( 'term.php?taxonomy=product_cat&tag_ID=' . (int) $term_id . '&post_type=product' )
+		);
+	}
+
+	// Who redeemed it. The coupon screen shows a usage count and
+	// nothing behind it, so "did this campaign work, and for whom" is
+	// a question you currently answer by exporting orders.
+	if ( openstation_my_wordpress_woo_can_read_orders() ) {
+		$customers = array();
+		foreach ( openstation_my_wordpress_woo_orders_with_coupon( $coupon->get_code(), 10 ) as $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Abstract_Order ) {
+				continue;
+			}
+
+			$name  = method_exists( $order, 'get_formatted_billing_full_name' )
+				? trim( $order->get_formatted_billing_full_name() )
+				: '';
+			$total = openstation_my_wordpress_woo_price(
+				$order->get_total(),
+				$order->get_currency()
+			);
+
+			$related[] = openstation_my_wordpress_woo_related_item(
+				'wc-coupon-order-' . $order_id,
+				'wc-orders',
+				__( 'Used on', 'desktop-mode' ),
+				'' !== $name
+					? sprintf(
+						/* translators: 1: order number, 2: customer name, 3: order total. */
+						__( '#%1$s · %2$s · %3$s', 'desktop-mode' ),
+						$order->get_order_number(),
+						$name,
+						$total
+					)
+					: sprintf(
+						/* translators: 1: order number, 2: order total. */
+						__( '#%1$s · %2$s', 'desktop-mode' ),
+						$order->get_order_number(),
+						$total
+					),
+				'dashicons-cart',
+				method_exists( $order, 'get_edit_order_url' )
+					? (string) $order->get_edit_order_url()
+					: ''
+			);
+
+			$customer_id = method_exists( $order, 'get_customer_id' )
+				? (int) $order->get_customer_id()
+				: 0;
+			if ( $customer_id > 0 ) {
+				$customers[ $customer_id ] = true;
+			}
+		}
+
+		$shown = 0;
+		foreach ( array_keys( $customers ) as $customer_id ) {
+			if ( $shown >= 8 ) {
+				break;
+			}
+			$user = get_userdata( (int) $customer_id );
+			if ( ! $user instanceof WP_User || ! current_user_can( 'edit_user', $user->ID ) ) {
+				continue;
+			}
+			$related[] = openstation_my_wordpress_woo_related_item(
+				'wc-coupon-buyer-' . (int) $customer_id,
+				'wc-customer',
+				__( 'Customers', 'desktop-mode' ),
+				$user->display_name ? $user->display_name : $user->user_login,
+				'dashicons-businessperson',
+				// The Customer window, not the profile editor — from
+				// a product or a coupon, a person is a buyer.
+				add_query_arg(
+					OPENSTATION_PERSON_VIEW_PARAM,
+					'wc-customer',
+					(string) get_edit_user_link( $user->ID )
+				)
+			);
+			++$shown;
+		}
+	}
+
+	return $related;
+}
+
+/**
+ * Related items for a user identity: their orders, when they have any
+ * and the viewer may see them.
+ *
+ * @param int $user_id User id.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_user_related( $user_id ) {
+	if (
+		! function_exists( 'openstation_my_wordpress_woo_customer_spend_map' )
+		|| true !== openstation_my_wordpress_woo_customers_permission()
+	) {
+		return array();
+	}
+
+	$map    = openstation_my_wordpress_woo_customer_spend_map();
+	$stats  = $map[ (int) $user_id ] ?? null;
+	$orders = $stats ? (int) $stats['orders'] : 0;
+	if ( $orders <= 0 ) {
+		return array();
+	}
+
+	return array(
+		openstation_my_wordpress_woo_related_item(
+			'wc-user-orders-' . (int) $user_id,
+			'wc-orders',
+			__( 'Store', 'desktop-mode' ),
+			__( 'Orders', 'desktop-mode' ),
+			'dashicons-cart',
+			openstation_my_wordpress_woo_customer_orders_url( (int) $user_id ),
+			$orders
+		),
+	);
+}
+
+/**
+ * Hang WooCommerce's relations off whatever identity the screen
+ * resolved to.
+ *
+ * @param array[]        $related  Related items so far.
+ * @param array          $identity The resolved content identity.
+ * @param WP_Screen|null $screen   Current screen, when available.
+ * @return array[]
+ */
+function openstation_my_wordpress_woo_related_entities( $related, $identity, $screen ) {
+	unset( $screen );
+	if ( ! openstation_my_wordpress_woo_active() || ! is_array( $identity ) ) {
+		return $related;
+	}
+
+	$type = (string) ( $identity['type'] ?? '' );
+	$id   = (int) ( $identity['id'] ?? 0 );
+	if ( $id <= 0 ) {
+		return $related;
+	}
+
+	if ( 'shop_order' === $type && openstation_my_wordpress_woo_can_read_orders() ) {
+		$order = wc_get_order( $id );
+		if ( $order instanceof WC_Abstract_Order ) {
+			$related = array_merge( (array) $related, openstation_my_wordpress_woo_order_related( $order ) );
+		}
+	} elseif ( 'product' === $type ) {
+		$related = array_merge( (array) $related, openstation_my_wordpress_woo_product_related( $id ) );
+	} elseif ( 'shop_coupon' === $type ) {
+		$related = array_merge( (array) $related, openstation_my_wordpress_woo_coupon_related( $id ) );
+	} elseif ( 'user' === $type ) {
+		$related = array_merge( (array) $related, openstation_my_wordpress_woo_user_related( $id ) );
+	}
+
+	return $related;
+}
+
+/**
+ * Boot the relations wiring.
+ *
+ * Priority 20 on the identity filter so a site that overrides the
+ * order identity for its own reasons still wins.
+ *
+ * @return void
+ */
+function openstation_my_wordpress_woo_relations_boot() {
+	add_filter( 'openstation_window_content_identity', 'openstation_my_wordpress_woo_content_identity', 20, 2 );
+	add_filter( 'openstation_window_related_entities', 'openstation_my_wordpress_woo_related_entities', 20, 3 );
+}
+openstation_my_wordpress_woo_relations_boot();

--- a/includes/my-wordpress/integrations/woocommerce.php
+++ b/includes/my-wordpress/integrations/woocommerce.php
@@ -1634,11 +1634,37 @@ function openstation_my_wordpress_woo_summary( $request ) {
 			$data = openstation_my_wordpress_woo_coupon_summary( $id );
 			break;
 		default:
-			return new WP_Error(
-				'openstation_woo_bad_type',
-				__( 'Unknown summary type.', 'desktop-mode' ),
-				array( 'status' => 400 )
-			);
+			/**
+			 * Filter in a summary payload for a type this route
+			 * doesn't handle itself.
+			 *
+			 * The route is the one place the site window asks "tell
+			 * me about this shop object", so a new object type — a
+			 * customer, a subscription, a booking — joins here rather
+			 * than needing its own endpoint and its own client
+			 * transport. Return `null` (the default) to leave the
+			 * type unknown, which answers 400.
+			 *
+			 * A subscriber MUST also gate its type in
+			 * `openstation_my_wordpress_woo_summary_capability`,
+			 * which decides who may ask.
+			 *
+			 * **Status: Experimental**
+			 *
+			 * @param array|null $data Summary payload, or `null`.
+			 * @param string     $type The requested type.
+			 * @param int        $id   Object id.
+			 */
+			$data = apply_filters( 'openstation_my_wordpress_woo_summary_type', null, $type, $id );
+
+			if ( ! is_array( $data ) && ! is_wp_error( $data ) ) {
+				return new WP_Error(
+					'openstation_woo_bad_type',
+					__( 'Unknown summary type.', 'desktop-mode' ),
+					array( 'status' => 400 )
+				);
+			}
+			break;
 	}
 
 	if ( is_wp_error( $data ) ) {
@@ -1673,6 +1699,29 @@ function openstation_my_wordpress_woo_summary_permission( $request ) {
 
 	if ( 'order' === $type ) {
 		return openstation_my_wordpress_woo_orders_permission();
+	}
+
+	/**
+	 * Filter the permission check for a summary type this route
+	 * doesn't handle itself.
+	 *
+	 * Return `true` to allow, a `WP_Error` to deny, or `null` (the
+	 * default) to fall through to the post-capability check below —
+	 * which is only meaningful for types whose id IS a post id. Any
+	 * type added through
+	 * `openstation_my_wordpress_woo_summary_type` must answer here
+	 * too, or it inherits a capability check that means nothing for
+	 * it.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param true|WP_Error|null $allowed Permission verdict.
+	 * @param string             $type    The requested type.
+	 * @param int                $id      Object id.
+	 */
+	$allowed = apply_filters( 'openstation_my_wordpress_woo_summary_capability', null, $type, $id );
+	if ( true === $allowed || is_wp_error( $allowed ) ) {
+		return $allowed;
 	}
 
 	if ( ! current_user_can( 'edit_post', $id ) ) {
@@ -1901,19 +1950,26 @@ function openstation_my_wordpress_woo_enqueue() {
 			'window.openStationWooConfig=%s;',
 			wp_json_encode(
 				array(
-					'restRoot'     => esc_url_raw( rest_url( 'desktop-mode/v1/woocommerce/' ) ),
-					'restNonce'    => wp_create_nonce( 'wp_rest' ),
-					'canOrders'    => true === openstation_my_wordpress_woo_orders_permission(),
-					'orderBands'   => openstation_my_wordpress_woo_order_bands(),
-					'productBands' => openstation_my_wordpress_woo_product_bands(),
-					'couponBands'  => openstation_my_wordpress_woo_coupon_bands_with_counts(),
+					'restRoot'      => esc_url_raw( rest_url( 'desktop-mode/v1/woocommerce/' ) ),
+					'restNonce'     => wp_create_nonce( 'wp_rest' ),
+					'canOrders'     => true === openstation_my_wordpress_woo_orders_permission(),
+					'canCustomers'  => true === openstation_my_wordpress_woo_customers_permission(),
+					'orderBands'    => openstation_my_wordpress_woo_order_bands(),
+					'productBands'  => openstation_my_wordpress_woo_product_bands(),
+					'couponBands'   => openstation_my_wordpress_woo_coupon_bands_with_counts(),
+					// Only built for a viewer who may see them — the
+					// band counts are money, and the plan behind them
+					// is a full pass over the user base.
+					'customerBands' => true === openstation_my_wordpress_woo_customers_permission()
+						? openstation_my_wordpress_woo_customer_bands_with_counts()
+						: array(),
 					// Whether the catalogue is small enough to be
 					// band-ordered server-side. Read it from the
 					// console (`window.openStationWooConfig.ordering`)
 					// when the Products bands look wrong: `capped`
 					// means rows arrive stock-ordered only and the
 					// category bands fill progressively.
-					'ordering'     => openstation_my_wordpress_woo_ordering_state(),
+					'ordering'      => openstation_my_wordpress_woo_ordering_state(),
 				)
 			)
 		),

--- a/includes/my-wordpress/user-list-fields.php
+++ b/includes/my-wordpress/user-list-fields.php
@@ -26,9 +26,130 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Compute the summary payload for one user. Cheap enough to call
- * per-row (each branch is one indexed query); WP's object cache
- * absorbs repeats inside a single request.
+ * The post types a summary counts. Kept in one place so the per-user
+ * query and the grouped prefetch below can't drift apart — a tile
+ * whose count changes depending on how the page was loaded is worse
+ * than no count at all.
+ *
+ * @return string[]
+ */
+function openstation_my_wordpress_user_summary_post_types() {
+	return array( 'post', 'page' );
+}
+
+/**
+ * Per-request store of prefetched post counts and last-active dates,
+ * keyed by user id. Populated by
+ * {@see openstation_my_wordpress_user_summary_prime()}; read by the
+ * payload builder below.
+ *
+ * @param array|null $write Rows to merge in, or null to read.
+ * @return array<int,array{postCount:int,lastActive:string}>
+ */
+function &openstation_my_wordpress_user_summary_cache( $write = null ) {
+	static $cache = array();
+
+	if ( is_array( $write ) ) {
+		$cache = $cache + $write;
+	}
+
+	return $cache;
+}
+
+/**
+ * Prefetch the two queried facts — authored-post count and latest
+ * publish date — for a whole page of users in two grouped queries.
+ *
+ * Without this, a list view pays `count_user_posts()` plus a
+ * `MAX(post_date_gmt)` lookup *per row*: 200 uncached queries for a
+ * 100-row page. Call this once with the page's ids and the payload
+ * builder answers from memory.
+ *
+ * @param int[] $user_ids User ids on the page.
+ * @return void
+ */
+function openstation_my_wordpress_user_summary_prime( $user_ids ) {
+	global $wpdb;
+
+	$cached = openstation_my_wordpress_user_summary_cache();
+	$ids    = array();
+	foreach ( (array) $user_ids as $user_id ) {
+		$user_id = (int) $user_id;
+		if ( $user_id > 0 && ! isset( $cached[ $user_id ] ) ) {
+			$ids[ $user_id ] = true;
+		}
+	}
+
+	$ids = array_keys( $ids );
+	if ( empty( $ids ) ) {
+		return;
+	}
+
+	$types      = openstation_my_wordpress_user_summary_post_types();
+	$id_slots   = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+	$type_slots = implode( ',', array_fill( 0, count( $types ), '%s' ) );
+
+	$rows = array();
+	foreach ( $ids as $user_id ) {
+		$rows[ $user_id ] = array(
+			'postCount'  => 0,
+			'lastActive' => '',
+		);
+	}
+
+	// The count `count_user_posts( $id, $types, true )` would produce,
+	// for every id at once. Its `$public_only = true` resolves — via
+	// `get_posts_by_author_sql()` — to exactly `post_status =
+	// 'publish'`, so that is what this reproduces.
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- placeholder lists are built from counts, values are passed through prepare().
+	$counts = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT post_author, COUNT(*) AS total FROM {$wpdb->posts}
+			WHERE post_author IN ( {$id_slots} )
+				AND post_type IN ( {$type_slots} )
+				AND post_status = 'publish'
+			GROUP BY post_author",
+			array_merge( $ids, $types )
+		)
+	);
+
+	$actives = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT post_author, MAX(post_date_gmt) AS latest FROM {$wpdb->posts}
+			WHERE post_author IN ( {$id_slots} )
+				AND post_status = 'publish'
+				AND post_type IN ( {$type_slots} )
+			GROUP BY post_author",
+			array_merge( $ids, $types )
+		)
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	foreach ( (array) $counts as $row ) {
+		$user_id = (int) $row->post_author;
+		if ( isset( $rows[ $user_id ] ) ) {
+			$rows[ $user_id ]['postCount'] = (int) $row->total;
+		}
+	}
+
+	foreach ( (array) $actives as $row ) {
+		$user_id = (int) $row->post_author;
+		if ( isset( $rows[ $user_id ] ) && $row->latest ) {
+			$rows[ $user_id ]['lastActive'] = (string) mysql2date( 'c', $row->latest, false );
+		}
+	}
+
+	openstation_my_wordpress_user_summary_cache( $rows );
+}
+
+/**
+ * Compute the summary payload for one user.
+ *
+ * Answers from the prefetch when
+ * {@see openstation_my_wordpress_user_summary_prime()} has run for
+ * this id, and falls back to the two per-user queries when it hasn't —
+ * so a single-row caller stays correct without having to know about
+ * the batch path.
  *
  * @param int $user_id User id.
  * @return array{postCount:int,roleLabels:array<int,string>,registered:string,lastActive:string}
@@ -57,10 +178,15 @@ function openstation_my_wordpress_user_summary_payload( $user_id ) {
 	$can_see_private = current_user_can( 'list_users' )
 		|| ( get_current_user_id() === $user_id );
 
+	$primed = openstation_my_wordpress_user_summary_cache();
+	$types  = openstation_my_wordpress_user_summary_post_types();
+
 	// `count_user_posts` accepts an array of post types since 4.5; we
 	// limit to public ones the dossier already counts so the tile and
 	// the dossier agree.
-	$post_count = (int) count_user_posts( $user_id, array( 'post', 'page' ), true );
+	$post_count = isset( $primed[ $user_id ] )
+		? (int) $primed[ $user_id ]['postCount']
+		: (int) count_user_posts( $user_id, $types, true );
 
 	$role_labels = array();
 	if ( $can_see_private && function_exists( 'wp_roles' ) ) {
@@ -80,17 +206,24 @@ function openstation_my_wordpress_user_summary_payload( $user_id ) {
 	// Latest published post — useful at-a-glance "active recently?"
 	// signal for the tile. Drawn from `post_date_gmt` so timezone
 	// drift can't shift the displayed date.
-	global $wpdb;
-	$last_active_raw = $wpdb->get_var(
-		$wpdb->prepare(
-			"SELECT MAX(post_date_gmt) FROM {$wpdb->posts}
-			WHERE post_author = %d
-				AND post_status = 'publish'
-				AND post_type IN ( 'post', 'page' )",
-			$user_id
-		)
-	);
-	$last_active     = $last_active_raw ? mysql2date( 'c', $last_active_raw, false ) : '';
+	if ( isset( $primed[ $user_id ] ) ) {
+		$last_active = (string) $primed[ $user_id ]['lastActive'];
+	} else {
+		global $wpdb;
+
+		$type_slots      = implode( ',', array_fill( 0, count( $types ), '%s' ) );
+		$last_active_raw = $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- placeholder list is built from a count, values pass through prepare().
+				"SELECT MAX(post_date_gmt) FROM {$wpdb->posts}
+				WHERE post_author = %d
+					AND post_status = 'publish'
+					AND post_type IN ( {$type_slots} )",
+				array_merge( array( $user_id ), $types )
+			)
+		);
+		$last_active     = $last_active_raw ? mysql2date( 'c', $last_active_raw, false ) : '';
+	}
 
 	return array(
 		'postCount'  => $post_count,

--- a/includes/session.php
+++ b/includes/session.php
@@ -28,6 +28,14 @@ const OPENSTATION_SESSION_META_KEY = 'desktop_mode_session';
 /** Hard cap on persisted windows — guards against runaway meta size. */
 const OPENSTATION_SESSION_MAX_WINDOWS = 32;
 
+/**
+ * Hard cap on a native window's persisted open-time params. These are
+ * "which user / which customer / which tab" — a handful of scalars,
+ * never a payload. The cap is what stops a careless (or hostile)
+ * client turning the session blob into a data store.
+ */
+const OPENSTATION_SESSION_MAX_PARAMS = 12;
+
 /** Hard cap on persisted desktops ("Spaces"). Generous — power-users
  * with 8+ desktops are vanishingly rare, and we'd rather drop tail
  * desktops than balloon user meta. */
@@ -380,6 +388,25 @@ function openstation_sanitize_session( $session ) {
 			// sessions of plain admin windows keep their existing shape.
 			if ( $is_native ) {
 				$entry['native'] = true;
+
+				// A native window's open-time arguments: WHAT it is
+				// showing, as opposed to what it is. A native window
+				// is addressed by id, and its id is its identity
+				// (`desktop-mode-user-edit` is "the profile editor",
+				// not "the profile editor for user 12"), so a
+				// singleton that retargets has nowhere else to record
+				// its subject. Drop these and the window restores onto
+				// its default — the profile window comes back showing
+				// whoever is logged in, the customer window comes back
+				// empty.
+				//
+				// Only for native entries: an iframe window's URL
+				// already says what it shows, and it round-trips on
+				// its own.
+				$params = openstation_sanitize_session_params( $win['params'] ?? null );
+				if ( ! empty( $params ) ) {
+					$entry['params'] = $params;
+				}
 			}
 
 			// Sanitize external sub-tabs. Each entry carries a URL
@@ -471,6 +498,66 @@ function openstation_sanitize_session_dimension( $value, $min, $max ) {
 		return (int) $max;
 	}
 	return $value;
+}
+
+/**
+ * Sanitize a native window's open-time params.
+ *
+ * These say WHAT a native window is showing (`{ userId: 12 }`,
+ * `{ customerId: 7 }`) as opposed to what it is — see
+ * `WindowConfig.params` on the JS side. They come from the client, so
+ * they are untrusted, unbounded, and arbitrarily nested unless this
+ * says otherwise.
+ *
+ * The rules mirror the client's own sanitizer so both ends agree on
+ * what survives: scalar values only (string, finite number, bool),
+ * and hard caps on both the number of keys and the length of a string
+ * value. Anything else is dropped rather than rejected — one careless
+ * value from a plugin must not cost the user every window's geometry.
+ *
+ * Keys are filtered to `[A-Za-z0-9_-]` rather than passed through
+ * `sanitize_key()`, which **lowercases**. Every param name in the
+ * shell is camelCase (`customerId`, `userId`), so lowercasing would
+ * store `customerid` and the client's `params.customerId` would read
+ * `undefined` — a window that restores blank, with the data sitting
+ * right there under a name nobody looks up.
+ *
+ * @param mixed $params Raw params from the payload.
+ * @return array Sanitized params, possibly empty.
+ */
+function openstation_sanitize_session_params( $params ) {
+	if ( ! is_array( $params ) ) {
+		return array();
+	}
+
+	$clean = array();
+	foreach ( $params as $key => $value ) {
+		if ( count( $clean ) >= OPENSTATION_SESSION_MAX_PARAMS ) {
+			break;
+		}
+		$key = substr( preg_replace( '/[^A-Za-z0-9_-]/', '', (string) $key ), 0, 64 );
+		if ( '' === $key ) {
+			continue;
+		}
+		if ( is_bool( $value ) ) {
+			$clean[ $key ] = $value;
+			continue;
+		}
+		if ( is_int( $value ) || is_float( $value ) ) {
+			if ( is_finite( (float) $value ) ) {
+				$clean[ $key ] = $value + 0;
+			}
+			continue;
+		}
+		if ( is_string( $value ) ) {
+			// A window param is an id, a slug or a short label. The
+			// cap keeps a runaway client from pushing megabytes into
+			// user meta, the same way the external-tab URL cap does.
+			$clean[ $key ] = substr( sanitize_text_field( $value ), 0, 256 );
+		}
+	}
+
+	return $clean;
 }
 
 /**

--- a/includes/window-links.php
+++ b/includes/window-links.php
@@ -41,6 +41,9 @@ defined( 'ABSPATH' ) || exit;
  *  - `comment.php` (comment edit / moderation) — `comment`, rooted at
  *    the parent post. The URL alone can't answer this one; only real
  *    admin context can.
+ *  - `user-edit.php` / `profile.php` — `user`, a root identity. What
+ *    points at a person (a post's author, an order's customer) does so
+ *    from its own `links`.
  *
  * @return array|null Identity array, or `null` when none applies.
  */
@@ -176,6 +179,22 @@ function openstation_build_content_identity() {
 				'type'  => 'term/' . sanitize_key( $term->taxonomy ),
 				'id'    => (int) $term->term_id,
 				'label' => $term->name,
+			);
+		}
+	} elseif ( 'user-edit.php' === $pagenow || 'profile.php' === $pagenow ) {
+		// Profile editor — `user-edit.php?user_id=N`, or `profile.php`
+		// for your own. A person is its own root: everything that
+		// points AT them (an order's customer, a post's author) does
+		// so through its identity's `links`, so an open profile window
+		// ties to whatever else on the desktop is about them.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only identity harvest; the host admin page enforces capability + nonce.
+		$user_id = isset( $_GET['user_id'] ) ? absint( $_GET['user_id'] ) : get_current_user_id();
+		$user    = $user_id ? get_userdata( $user_id ) : null;
+		if ( $user instanceof WP_User && current_user_can( 'edit_user', $user->ID ) ) {
+			$identity = array(
+				'type'  => 'user',
+				'id'    => (int) $user->ID,
+				'label' => $user->display_name ? $user->display_name : $user->user_login,
 			);
 		}
 	}

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -251,8 +251,20 @@ export interface BuildPublicApiDeps {
 	saveSession: () => void;
 	widgetLayer: WidgetLayer | null;
 	registerWindow: ( def: NativeWindowDef ) => Promise< DesktopWindow >;
-	openWindowById: ( id: string, opts?: { source?: string } ) => boolean;
-	openNewWindowById: ( id: string, opts?: { source?: string } ) => boolean;
+	openWindowById: (
+		id: string,
+		opts?: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		},
+	) => boolean;
+	openNewWindowById: (
+		id: string,
+		opts?: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		},
+	) => boolean;
 	placeSystemTile: ( item: SystemDockItem ) => void;
 	setDefaultWindow: ( url: string | null ) => Promise< void >;
 	refreshMenu: () => Promise< void >;

--- a/src/boot/session.ts
+++ b/src/boot/session.ts
@@ -170,6 +170,12 @@ export async function restoreSession(
 			y: clamped.y,
 			width: clamped.width,
 			height: clamped.height,
+			// What the window was showing, not just which window it
+			// was. A native window is addressed by id, so without this
+			// a singleton that retargets (the profile editor, the
+			// customer window) reopens on its default and reads as
+			// having silently changed subject.
+			...( win.params ? { params: win.params } : {} ),
 		};
 	}
 	if ( Object.keys( nativeSeeds ).length > 0 ) {

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -21,6 +21,7 @@ import {
 import { Dock, type DockItem, type SystemDockItem } from './dock';
 import {
 	bindNativeUrlRemap,
+	OS_PERSON_VIEW_PARAM,
 	registerNativeUrlRemap,
 	tryNativeUrlRemap,
 } from './native-url-remap';
@@ -2190,7 +2191,7 @@ function init(): void {
 	// dispatcher changes needed.
 	bindNativeUrlRemap( {
 		getSnapshot: () => osSettings.getOsSettingsSnapshot(),
-		openById: ( id ) => nativeWindows.openById( id ),
+		openById: ( id, opts ) => nativeWindows.openById( id, opts ),
 		adminUrl: config.adminUrl,
 	} );
 
@@ -2313,6 +2314,15 @@ function init(): void {
 		id: 'desktop-mode-user-edit',
 		nativeWindowId: 'desktop-mode-user-edit',
 		matches: ( _url, parsed ) => {
+			// A URL that explicitly marks itself as a different kind
+			// of view onto this person is not a profile-edit request.
+			// The marker is how another remap — WooCommerce's Customer
+			// window — claims the same person without having to win a
+			// registration-order race with this entry, and without
+			// this one having to know what claimed it.
+			if ( parsed.searchParams.has( OS_PERSON_VIEW_PARAM ) ) {
+				return false;
+			}
 			const path = parsed.pathname;
 			if ( path.endsWith( '/profile.php' ) ) {
 				return true;

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -21,7 +21,7 @@ import {
 import { Dock, type DockItem, type SystemDockItem } from './dock';
 import {
 	bindNativeUrlRemap,
-	OS_PERSON_VIEW_PARAM,
+	isPersonViewClaimed,
 	registerNativeUrlRemap,
 	tryNativeUrlRemap,
 } from './native-url-remap';
@@ -2320,7 +2320,7 @@ function init(): void {
 			// window — claims the same person without having to win a
 			// registration-order race with this entry, and without
 			// this one having to know what claimed it.
-			if ( parsed.searchParams.has( OS_PERSON_VIEW_PARAM ) ) {
+			if ( isPersonViewClaimed( parsed ) ) {
 				return false;
 			}
 			const path = parsed.pathname;

--- a/src/my-wordpress/agents-renderer.ts
+++ b/src/my-wordpress/agents-renderer.ts
@@ -149,7 +149,13 @@ function openChatWindow( agent: Agent ): void {
 }
 
 interface OpenStationSurface {
-	openWindow?: ( id: string, opts?: { source?: string } ) => boolean;
+	openWindow?: (
+		id: string,
+		opts?: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		},
+	) => boolean;
 	windowManager?: {
 		open: ( opts: {
 			id: string;
@@ -204,6 +210,8 @@ function openAgentProfile( agent: Agent ): void {
 	const desktop = openStation();
 	const opened = desktop?.openWindow?.( 'desktop-mode-user-edit', {
 		source: 'agents/profile',
+		// Survives a reload; the shared store above does not.
+		params: { userId: agent.id },
 	} );
 	if ( ! opened ) {
 		desktop?.windowManager?.open( {

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -1874,7 +1874,7 @@ function buildEntityTile(
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
 		hideTooltip();
-		openEditor( entity, item.id, titleText );
+		openEditor( entity, item.id, titleText, item.editUrl );
 	} );
 
 	tile.addEventListener( 'contextmenu', ( e ) => {
@@ -2123,7 +2123,12 @@ function appendPostArticle(
 	editBtn.setAttribute( 'variant', 'primary' );
 	editBtn.textContent = __( 'Open in editor', 'desktop-mode' );
 	editBtn.addEventListener( 'click', () => {
-		openEditor( entity, detail.id, stripTags( detail.title?.rendered ?? '' ) );
+		openEditor(
+			entity,
+			detail.id,
+			stripTags( detail.title?.rendered ?? '' ),
+			detail.editUrl,
+		);
 	} );
 	footer.appendChild( editBtn );
 
@@ -3186,12 +3191,96 @@ function contributorToView( c: ContributorRef ): SubItemView {
  * top categories + activity sparkline. On permission errors we
  * fall through to the compact `/wp/v2/users/<id>` view.
  */
+/**
+ * The optional blocks a user dossier is made of, in render order.
+ * The identity header is not in the list — a dossier without a name
+ * and a face is not a dossier.
+ *
+ * @public
+ */
+export type UserDossierSection =
+	| 'bio'
+	| 'stats'
+	| 'activity'
+	| 'milestones'
+	| 'recent'
+	| 'terms';
+
+const USER_DOSSIER_SECTIONS: UserDossierSection[] = [
+	'bio',
+	'stats',
+	'activity',
+	'milestones',
+	'recent',
+	'terms',
+];
+
+/**
+ * Which blocks a dossier renders, for the section showing it.
+ *
+ * The built-in dossier answers "what has this person written" —
+ * post and page counts, a publishing sparkline, recent posts. That is
+ * the right answer in the Users folder and the wrong one in a shop's
+ * Customers folder, where the person has never written anything and
+ * the counts are four zeroes above the number you actually came for.
+ *
+ * Plugins drop what doesn't apply by returning a shorter list.
+ *
+ * @param entityId Section the dossier is being rendered in.
+ * @param kind     The section's entity kind.
+ * @param userId   The person.
+ * @return Sections to render, in order.
+ */
+function resolveDossierSections(
+	entityId: string,
+	kind: string,
+	userId: number,
+): UserDossierSection[] {
+	const resolved = applyFilters<
+		UserDossierSection[],
+		[ { entityId: string; kind: string; userId: number } ]
+	>( 'os.my-wordpress.user-dossier-sections', USER_DOSSIER_SECTIONS, {
+		entityId,
+		kind,
+		userId,
+	} );
+	return Array.isArray( resolved ) ? resolved : USER_DOSSIER_SECTIONS;
+}
+
 async function renderUserDossier( opts: {
 	userId: number;
 	fallbackName: string;
 	fallbackAvatar: string;
 	fallbackDescription: string;
+	/**
+	 * The section this dossier is being rendered in, when it has one.
+	 * Drives `os.my-wordpress.user-dossier-sections`; omitted (the
+	 * author / contributor sub-folders) means every section renders,
+	 * which is the historical behaviour.
+	 */
+	context?: { entityId: string; kind: string };
 } ): Promise< HTMLElement > {
+	const sections = resolveDossierSections(
+		opts.context?.entityId ?? '',
+		opts.context?.kind ?? 'user',
+		opts.userId,
+	);
+	const shows = ( section: UserDossierSection ): boolean =>
+		sections.includes( section );
+
+	/**
+	 * The `meta` slot anchor — sits directly under the identity
+	 * header and the bio, so a plugin's facts about this person read
+	 * where a reader is already looking, rather than above their name.
+	 */
+	const metaSlot = (): HTMLElement => {
+		const host = document.createElement( 'div' );
+		host.className =
+			'os-my-wordpress__article-slot os-my-wordpress__article-slot--meta';
+		host.dataset.slot = 'meta';
+		host.dataset.userSlot = 'meta';
+		return host;
+	};
 	let stats: UserStats | null = null;
 	try {
 		stats = await fetchUserStats( opts.userId );
@@ -3221,12 +3310,13 @@ async function renderUserDossier( opts: {
 			link: basic?.link ?? '',
 		} );
 		const desc = basic?.description ?? opts.fallbackDescription;
-		if ( desc ) {
+		if ( desc && shows( 'bio' ) ) {
 			const bio = document.createElement( 'div' );
 			bio.className = 'os-my-wordpress__user-bio';
 			bio.textContent = desc;
 			wrap.appendChild( bio );
 		}
+		wrap.appendChild( metaSlot() );
 		return wrap;
 	}
 
@@ -3240,12 +3330,14 @@ async function renderUserDossier( opts: {
 		link: profile.link,
 	} );
 
-	if ( profile.description ) {
+	if ( profile.description && shows( 'bio' ) ) {
 		const bio = document.createElement( 'div' );
 		bio.className = 'os-my-wordpress__user-bio';
 		bio.textContent = profile.description;
 		wrap.appendChild( bio );
 	}
+
+	wrap.appendChild( metaSlot() );
 
 	// Stat cards row.
 	const cards = document.createElement( 'div' );
@@ -3290,22 +3382,26 @@ async function renderUserDossier( opts: {
 			'',
 		),
 	);
-	wrap.appendChild( cards );
+	if ( shows( 'stats' ) ) {
+		wrap.appendChild( cards );
+	}
 
 	// Activity sparkline (12-month publishing rhythm).
-	const spark = buildActivitySparkline( activity );
+	const spark = shows( 'activity' ) ? buildActivitySparkline( activity ) : null;
 	if ( spark ) {
 		wrap.appendChild( spark );
 	}
 
 	// Milestones row.
-	const milestoneRow = buildMilestonesRow( profile, milestones );
+	const milestoneRow = shows( 'milestones' )
+		? buildMilestonesRow( profile, milestones )
+		: null;
 	if ( milestoneRow ) {
 		wrap.appendChild( milestoneRow );
 	}
 
 	// Recent activity list.
-	if ( recent.length > 0 ) {
+	if ( recent.length > 0 && shows( 'recent' ) ) {
 		const section = document.createElement( 'section' );
 		section.className = 'os-my-wordpress__user-section';
 		const h = document.createElement( 'h3' );
@@ -3332,7 +3428,7 @@ async function renderUserDossier( opts: {
 	}
 
 	// Top categories / tags as chips.
-	if ( topTerms.length > 0 ) {
+	if ( topTerms.length > 0 && shows( 'terms' ) ) {
 		const section = document.createElement( 'section' );
 		section.className = 'os-my-wordpress__user-section';
 		const h = document.createElement( 'h3' );
@@ -4031,12 +4127,32 @@ function formatDate( iso: string ): string {
 	}
 }
 
+/**
+ * Open a row's editor as its own window.
+ *
+ * `editUrl` on the row wins when present. `buildEditUrl()` assumes
+ * `post.php?post=<id>` — true for anything stored in `wp_posts`, and
+ * wrong for a section whose rows live somewhere else: a WooCommerce
+ * order under High-Performance Order Storage edits at
+ * `admin.php?page=wc-orders&action=edit&id=N`, and the guessed URL
+ * lands on a 404. A section serving rows from its own route declares
+ * `editUrl` in `listFields` and puts the real one there.
+ *
+ * @param entity  The section the row belongs to.
+ * @param id      Row id.
+ * @param title   Window title.
+ * @param editUrl Explicit editor URL from the row, when it has one.
+ */
 function openEditor(
 	entity: MyWordPressEntity,
 	id: number,
 	title: string,
+	editUrl?: unknown,
 ): void {
-	const url = buildEditUrl( id );
+	const url =
+		typeof editUrl === 'string' && editUrl !== ''
+			? editUrl
+			: buildEditUrl( id );
 	openIframeWindow( {
 		id: `${ entity.id }-edit-${ id }`,
 		url,
@@ -4144,7 +4260,7 @@ function openTileMenu(
 		const detail = ( e as CustomEvent< { id: string } > ).detail;
 		closeAnyTileMenu();
 		if ( detail.id === 'open' ) {
-			openEditor( entity, item.id, title );
+			openEditor( entity, item.id, title, item.editUrl );
 			return;
 		}
 		if ( detail.id === 'navigate-into' ) {
@@ -4855,12 +4971,15 @@ function buildUserTile(
 	} );
 
 	tile.addEventListener( 'click', () => {
-		selectUserTile( state, ctx, tile, item );
+		selectUserTile( state, ctx, entity, tile, item );
 	} );
 
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
 		hideTooltip();
+		if ( activateUserTile( entity, item ) ) {
+			return;
+		}
 		// Double-click on a user opens the activity footprint — the
 		// at-a-glance surface we want users to land on first. The
 		// classic profile editor is one click away from the preview
@@ -4880,6 +4999,18 @@ function buildUserTile(
 			x: e.clientX,
 			y: e.clientY,
 		} );
+	} );
+
+	// Same per-tile decoration seam the post and media grids fire, so
+	// a subscriber written for one kind of tile works on all three.
+	// A user tile's stock sub-line is "role · N posts", which is the
+	// wrong sentence about a customer — a subscriber can say
+	// something truer here.
+	doAction( 'os.my-wordpress.list-tile', {
+		tile,
+		entityId: entity.id,
+		kind: entity.kind ?? 'user',
+		item: item as unknown as Record< string, unknown >,
 	} );
 
 	return tile;
@@ -4942,9 +5073,42 @@ function buildUserTooltip(
 	return tip;
 }
 
+/**
+ * Give a plugin the chance to claim "the user opened this person".
+ *
+ * The built-in answer is the activity footprint — right for the Users
+ * folder, where a person is someone who writes, and wrong for any
+ * section where they aren't. A shop's Customers folder wants the
+ * customer window; a CRM's contacts folder wants its own.
+ *
+ * A subscriber returns `true` to say it handled the activation; the
+ * built-in navigation is then skipped. Anything else falls through,
+ * so a filter that returns nothing can't accidentally make
+ * double-click do nothing at all.
+ *
+ * @param entity The section the tile belongs to.
+ * @param item   The user row.
+ * @return true when a plugin handled it.
+ */
+function activateUserTile(
+	entity: MyWordPressEntity,
+	item: UserListItem,
+): boolean {
+	const handled = applyFilters<
+		boolean,
+		[ { entityId: string; kind: string; item: Record< string, unknown > } ]
+	>( 'os.my-wordpress.user-activate', false, {
+		entityId: entity.id,
+		kind: entity.kind ?? 'user',
+		item: item as unknown as Record< string, unknown >,
+	} );
+	return handled === true;
+}
+
 function selectUserTile(
 	state: RenderState,
 	ctx: UserListContext,
+	entity: MyWordPressEntity,
 	tile: HTMLElement,
 	item: UserListItem,
 ): void {
@@ -4956,12 +5120,65 @@ function selectUserTile(
 	tile.classList.add( 'os-file-tile--selected' );
 	ctx.selectedTile = tile;
 	ctx.selectedId = item.id;
-	void renderUserPreviewPane( state, ctx, item );
+	void renderUserPreviewPane( state, ctx, entity, item );
+}
+
+/**
+ * Build a slot container and fire
+ * `os.my-wordpress.preview-extras` against it, so plugins can append
+ * arbitrary DOM to a user-kind preview pane.
+ *
+ * Same action, same payload shape as the post and media panes — one
+ * contract covers every section, and `kind: 'user'` is what a
+ * subscriber checks. Without this the user pane was the only preview
+ * a plugin could not reach, which is exactly where a store's
+ * lifetime-spend panel belongs.
+ *
+ * @param slot   Slot identifier.
+ * @param item   The user being previewed.
+ * @param entity The section they belong to.
+ * @return The slot container.
+ */
+function userArticleSlot(
+	slot: MediaPreviewSlot,
+	item: UserListItem,
+	entity: MyWordPressEntity,
+): HTMLElement {
+	const host = document.createElement( 'div' );
+	host.className = `os-my-wordpress__article-slot os-my-wordpress__article-slot--${ slot }`;
+	host.dataset.slot = slot;
+	doAction( 'os.my-wordpress.preview-extras', {
+		slot,
+		container: host,
+		entityId: entity.id,
+		kind: entity.kind ?? 'user',
+		item: item as unknown as Record< string, unknown >,
+	} );
+	return host;
+}
+
+/**
+ * One button in the user preview pane's action row.
+ *
+ * The built-ins are "View activity footprint" and "Show profile" —
+ * both about a person who writes. A section serving people who buy
+ * drops the first and adds its own; the filter is
+ * `os.my-wordpress.user-preview-actions`.
+ *
+ * @public
+ */
+export interface UserPreviewAction {
+	id: string;
+	label: string;
+	title?: string;
+	variant?: 'primary' | 'secondary';
+	onSelect: () => void;
 }
 
 async function renderUserPreviewPane(
 	state: RenderState,
 	ctx: UserListContext,
+	entity: MyWordPressEntity,
 	item: UserListItem,
 ): Promise< void > {
 	const fallbackName = item.name || item.slug || `#${ item.id }`;
@@ -4977,6 +5194,7 @@ async function renderUserPreviewPane(
 			fallbackName,
 			fallbackAvatar,
 			fallbackDescription: item.description ?? '',
+			context: { entityId: entity.id, kind: entity.kind ?? 'user' },
 		} );
 	} catch ( err ) {
 		if ( ctx.selectedId !== userId ) {
@@ -4990,46 +5208,98 @@ async function renderUserPreviewPane(
 		return;
 	}
 
-	// Append "open profile" / "view footprint" actions so the
-	// preview pane doubles as the launch point for both deep
-	// actions. The dossier itself doesn't carry these because it's
-	// also reused inside post-detail sub-folders (author / contrib).
+	// `header` slot — above everything, for a subscriber that wants to
+	// speak before the identity header does. Rare: a person's name and
+	// face are what a reader looks for first, so the interesting slot
+	// for facts ABOUT them is `meta`, below.
+	node.prepend( userArticleSlot( 'header', item, entity ) );
+
+	// `meta` slot — the anchor the dossier left directly under the
+	// identity header and bio. This is where a plugin's summary of the
+	// person belongs: you read who they are, then what they are worth.
+	const metaAnchor = node.querySelector< HTMLElement >(
+		'[data-user-slot="meta"]',
+	);
+	if ( metaAnchor ) {
+		doAction( 'os.my-wordpress.preview-extras', {
+			slot: 'meta',
+			container: metaAnchor,
+			entityId: entity.id,
+			kind: entity.kind ?? 'user',
+			item: item as unknown as Record< string, unknown >,
+		} );
+	}
+
+	// Action row, so the preview pane doubles as the launch point for
+	// the deep surfaces. The dossier itself doesn't carry these
+	// because it's also reused inside post-detail sub-folders (author
+	// / contrib).
 	const footer = document.createElement( 'footer' );
 	footer.className = 'os-my-wordpress__article-footer';
 
 	// Primary action matches the double-click affordance — activity
 	// footprint first, the classic profile editor demoted to a
 	// secondary button.
-	const footprintBtn = document.createElement( 'os-button' );
-	footprintBtn.setAttribute( 'variant', 'primary' );
-	footprintBtn.textContent = __( 'View activity footprint', 'desktop-mode' );
-	footprintBtn.title = __(
-		'Open the full activity footprint surface for this user.',
-		'desktop-mode',
-	);
-	footprintBtn.addEventListener( 'click', () => {
-		navigate( state, {
-			kind: 'user-footprint',
-			entityId: 'users',
-			userId,
-			userName: fallbackName,
-		} );
-	} );
-	footer.appendChild( footprintBtn );
+	const actions: UserPreviewAction[] = [
+		{
+			id: 'footprint',
+			label: __( 'View activity footprint', 'desktop-mode' ),
+			title: __(
+				'Open the full activity footprint surface for this user.',
+				'desktop-mode',
+			),
+			variant: 'primary',
+			onSelect: () =>
+				navigate( state, {
+					kind: 'user-footprint',
+					entityId: 'users',
+					userId,
+					userName: fallbackName,
+				} ),
+		},
+		{
+			id: 'open-profile',
+			label: __( 'Show profile', 'desktop-mode' ),
+			title: __(
+				'Open this user’s profile editor in a new window.',
+				'desktop-mode',
+			),
+			variant: 'secondary',
+			onSelect: () => openUserEditWindow( userId ),
+		},
+	];
 
-	const editBtn = document.createElement( 'os-button' );
-	editBtn.setAttribute( 'variant', 'secondary' );
-	editBtn.textContent = __( 'Show profile', 'desktop-mode' );
-	editBtn.title = __(
-		'Open this user’s profile editor in a new window.',
-		'desktop-mode',
-	);
-	editBtn.addEventListener( 'click', () => {
-		openUserEditWindow( userId );
+	const finalActions = applyFilters<
+		UserPreviewAction[],
+		[ { entityId: string; kind: string; item: Record< string, unknown > } ]
+	>( 'os.my-wordpress.user-preview-actions', actions, {
+		entityId: entity.id,
+		kind: entity.kind ?? 'user',
+		item: item as unknown as Record< string, unknown >,
 	} );
-	footer.appendChild( editBtn );
 
-	node.appendChild( footer );
+	for ( const action of Array.isArray( finalActions )
+		? finalActions
+		: actions ) {
+		if ( ! action || typeof action.onSelect !== 'function' ) {
+			continue;
+		}
+		const btn = document.createElement( 'os-button' );
+		btn.setAttribute( 'variant', action.variant ?? 'secondary' );
+		btn.textContent = action.label;
+		if ( action.title ) {
+			btn.title = action.title;
+		}
+		btn.addEventListener( 'click', () => action.onSelect() );
+		footer.appendChild( btn );
+	}
+
+	if ( footer.childElementCount > 0 ) {
+		node.appendChild( footer );
+	}
+
+	// `footer` slot — below the action row.
+	node.appendChild( userArticleSlot( 'footer', item, entity ) );
 
 	ctx.preview.replaceChildren( node );
 }
@@ -5213,8 +5483,17 @@ function openUserEditWindow( userId: number ): void {
 		) => SharedStoreApi< T >;
 		openWindow?: (
 			id: string,
-			opts?: { source?: string },
+			opts?: {
+				source?: string;
+				params?: Record< string, string | number | boolean >;
+			},
 		) => boolean | undefined;
+		relations?: {
+			set?: (
+				windowId: string,
+				ref: { type: string; id: number | string; label?: string } | null,
+			) => void;
+		};
 	}
 	interface UserEditTarget {
 		userId: number | null;
@@ -5240,9 +5519,26 @@ function openUserEditWindow( userId: number ): void {
 
 	const opened = desktop?.openWindow?.( 'desktop-mode-user-edit', {
 		source: 'my-wordpress/user-tile',
+		// Persisted with the session, so a reload brings the window
+		// back on this person. The shared store above only lives as
+		// long as the page does.
+		params: { userId },
 	} );
 
-	if ( ! opened ) {
+	if ( opened ) {
+		// Announce who the window is now showing. The profile window
+		// is a singleton that retargets through the shared store, so
+		// nothing else can tell the relations engine its identity
+		// changed — and without this a window opened onto a customer
+		// draws no tie to the order that sent you there.
+		//
+		// Matches the `user` identity the chromeless bridge announces
+		// for `user-edit.php`, so both paths join the same group.
+		desktop?.relations?.set?.( 'desktop-mode-user-edit', {
+			type: 'user',
+			id: userId,
+		} );
+	} else {
 		// Native window not registered — open the classic admin
 		// user-edit page in an iframe window. Same shape as the
 		// post fallback in `openEditor()`.

--- a/src/my-wordpress/integrations/woocommerce.ts
+++ b/src/my-wordpress/integrations/woocommerce.ts
@@ -18,7 +18,11 @@
  * — the same one any third-party plugin would use.
  */
 import { addAction, addFilter } from '../../hooks';
-import { __, sprintf } from '../../i18n';
+import {
+	OS_PERSON_VIEW_PARAM,
+	registerNativeUrlRemap,
+} from '../../native-url-remap';
+import { __, _n, sprintf } from '../../i18n';
 import { trackedFetch } from '../../tracked-fetch';
 // Registers the `<os-ribbon>` tag this bundle stamps onto tiles. The
 // main desktop bundle defines it too, but this bundle can load into a
@@ -59,9 +63,12 @@ interface WooConfig {
 	restRoot: string;
 	restNonce: string;
 	canOrders: boolean;
+	/** Whether the viewer may see customer money at all. */
+	canCustomers?: boolean;
 	orderBands?: OrderBand[];
 	productBands?: WooBand[];
 	couponBands?: WooBand[];
+	customerBands?: WooBand[];
 }
 
 /** A name paired with the screen that edits it. */
@@ -94,6 +101,15 @@ interface ListTilePayload {
 interface ListBanding {
 	bands: Array< { id: string; label: string; order?: number } >;
 	assign: ( item: Record< string, unknown > ) => string | null;
+}
+
+/** One button in the user preview pane's action row. */
+interface UserPreviewAction {
+	id: string;
+	label: string;
+	title?: string;
+	variant?: 'primary' | 'secondary';
+	onSelect: () => void;
 }
 
 /** The `openstation_woo` REST field on a product row. */
@@ -175,13 +191,81 @@ interface CouponSummary {
 	editUrl: string;
 }
 
+/**
+ * The `openstation_woo_customer` field carried on every row of the
+ * Customers section — and on `/wp/v2/users` rows, so the built-in
+ * Users section knows about money too.
+ */
+interface CustomerFacts {
+	band: string;
+	orders: number;
+	spend: string;
+	spendRaw: number;
+	aov: string;
+	firstOrder: string;
+	lastOrder: string;
+	daysSince: number | null;
+	ordersUrl: string;
+}
+
+/** One row of a customer's order history. */
+interface CustomerOrderRow {
+	id: number;
+	number: string;
+	status: string;
+	statusLabel: string;
+	date: string;
+	total: string;
+	items: number;
+	editUrl: string;
+}
+
+interface CustomerSummary {
+	type: 'customer';
+	id: number;
+	name: string;
+	username: string;
+	avatar: string;
+	email: string;
+	phone: string;
+	billing: string;
+	shipping: string;
+	recentOrders: CustomerOrderRow[];
+	spendRaw: number;
+	band: string;
+	bandLabel: string;
+	orders: number;
+	spend: string;
+	aov: string;
+	firstOrder: string;
+	lastOrder: string;
+	daysSince: number | null;
+	lastOrderNo: string;
+	lastOrderUrl: string;
+	lastOrderTotal: string;
+	favourite: { label: string; quantity: number; editUrl: string } | null;
+	location: string;
+	registered: string;
+	ordersUrl: string;
+	profileUrl: string;
+}
+
 interface StoreSummary {
 	revenue: string;
 	processing: number;
 	outOfStock: number;
+	customers?: number;
+	vips?: number;
+	lapsed?: number;
+	guestSpend?: string;
+	guestOrders?: number;
 }
 
-type Summary = ProductSummary | OrderSummary | CouponSummary;
+type Summary =
+	| ProductSummary
+	| OrderSummary
+	| CouponSummary
+	| CustomerSummary;
 
 const PANEL_CLASS = 'os-woo-panel';
 
@@ -197,6 +281,7 @@ const LOW_STOCK_THRESHOLD = 5;
 const SECTION_ORDERS = 'wc-orders';
 const SECTION_PRODUCTS = 'cpt-product';
 const SECTION_COUPONS = 'cpt-shop_coupon';
+const SECTION_CUSTOMERS = 'wc-customers';
 
 function getConfig(): WooConfig | null {
 	const cfg = ( window as unknown as { openStationWooConfig?: WooConfig } )
@@ -325,10 +410,36 @@ function link( label: string, href: string ): Node {
 	a.className = `${ PANEL_CLASS }__link`;
 	a.href = href;
 	a.textContent = label;
-	// Admin screens open as their own desktop window rather than
-	// navigating the shell out from under the user.
-	a.target = '_blank';
 	a.rel = 'noopener noreferrer';
+
+	// Open as a desktop window, which is the whole point: the product
+	// opens BESIDE the order that sold it.
+	//
+	// This used to be `target="_blank"` and it was wrong twice over.
+	// In a browser tab it threw the admin screen outside the shell
+	// entirely; and once OpenStation is installed as a PWA, a
+	// `_blank` navigation to a same-origin admin URL is handled by
+	// the app's scope — so clicking a product name in the preview
+	// pane LAUNCHED THE INSTALLED APP. Nothing about "open this in a
+	// window" implies "start the operating system again".
+	//
+	// The `href` stays real so middle-click, ⌘-click and "copy link"
+	// still behave; only the plain click is claimed.
+	a.addEventListener( 'click', ( event ) => {
+		if (
+			event.defaultPrevented ||
+			event.button !== 0 ||
+			event.metaKey ||
+			event.ctrlKey ||
+			event.shiftKey ||
+			event.altKey
+		) {
+			return;
+		}
+		event.preventDefault();
+		openAdminWindow( href, label );
+	} );
+
 	return a;
 }
 
@@ -542,6 +653,20 @@ function orderToneFor( status: string ): BadgeTone {
 		status === 'refunded'
 	) {
 		return 'danger';
+	}
+	return 'neutral';
+}
+
+/**
+ * Customer-band tint. VIP reads as good news, lapsed as something to
+ * do; everything between them is context and stays neutral.
+ */
+function customerToneFor( band: string ): BadgeTone {
+	if ( band === 'vip' ) {
+		return 'success';
+	}
+	if ( band === 'lapsed' ) {
+		return 'warning';
 	}
 	return 'neutral';
 }
@@ -788,6 +913,145 @@ function renderCoupon( data: CouponSummary ): Array< HTMLElement | null > {
 	];
 }
 
+/**
+ * "3 months ago", "today" — the sentence a merchant actually thinks
+ * in. An ISO date alone makes you do the arithmetic.
+ */
+function sinceLabel( days: number | null ): string {
+	if ( days === null || ! Number.isFinite( days ) ) {
+		return '';
+	}
+	if ( days <= 0 ) {
+		return __( 'Today', 'desktop-mode' );
+	}
+	if ( days < 60 ) {
+		return sprintf(
+			/* translators: %d: number of days. */
+			_n( '%d day ago', '%d days ago', days ),
+			days,
+		);
+	}
+	const months = Math.round( days / 30 );
+	if ( months < 24 ) {
+		return sprintf(
+			/* translators: %d: number of months. */
+			_n( '%d month ago', '%d months ago', months ),
+			months,
+		);
+	}
+	const years = Math.round( days / 365 );
+	return sprintf(
+		/* translators: %d: number of years. */
+		_n( '%d year ago', '%d years ago', years ),
+		years,
+	);
+}
+
+function renderCustomer( data: CustomerSummary ): Array< HTMLElement | null > {
+	const orders = Number( data.orders ) || 0;
+	const since = sinceLabel( data.daysSince ?? null );
+
+	// Lifetime spend leads. It is the one number that ranks two
+	// customers against each other, and every other row on this panel
+	// is an explanation of it.
+	return [
+		row(
+			__( 'Lifetime spend', 'desktop-mode' ),
+			data.spend
+				? ( () => {
+					const wrap = document.createElement( 'span' );
+					const strong = document.createElement( 'strong' );
+					strong.textContent = data.spend;
+					wrap.appendChild( strong );
+					if ( data.bandLabel ) {
+						wrap.appendChild( document.createTextNode( ' ' ) );
+						wrap.appendChild(
+							pill(
+								data.bandLabel,
+								customerToneFor( data.band ),
+							),
+						);
+					}
+					return wrap;
+				} )()
+				: null,
+		),
+		row(
+			__( 'Orders', 'desktop-mode' ),
+			orders > 0
+				? sprintf(
+					/* translators: %d: number of orders. */
+					_n( '%d order', '%d orders', orders ),
+					orders,
+				)
+				: __( 'None yet', 'desktop-mode' ),
+		),
+		row( __( 'Average order', 'desktop-mode' ), data.aov ),
+		row(
+			__( 'Last order', 'desktop-mode' ),
+			data.lastOrderNo
+				? ( () => {
+					const wrap = document.createElement( 'span' );
+					wrap.appendChild(
+						link(
+							sprintf(
+								/* translators: %s: order number. */
+								__( '#%s', 'desktop-mode' ),
+								data.lastOrderNo,
+							),
+							data.lastOrderUrl,
+						),
+					);
+					const tail = [ data.lastOrderTotal, since ].filter(
+						Boolean,
+					);
+					if ( tail.length ) {
+						wrap.appendChild(
+							document.createTextNode(
+								` · ${ tail.join( ' · ' ) }`,
+							),
+						);
+					}
+					return wrap;
+				} )()
+				: null,
+		),
+		row( __( 'First order', 'desktop-mode' ), shortDate( data.firstOrder ) ),
+		row(
+			__( 'Buys most', 'desktop-mode' ),
+			data.favourite
+				? ( () => {
+					const wrap = document.createElement( 'span' );
+					wrap.appendChild(
+						link( data.favourite.label, data.favourite.editUrl ),
+					);
+					if ( data.favourite.quantity > 1 ) {
+						wrap.appendChild(
+							document.createTextNode(
+								` · ${ sprintf(
+									/* translators: %d: units bought. */
+									__( '×%d', 'desktop-mode' ),
+									data.favourite.quantity,
+								) }`,
+							),
+						);
+					}
+					return wrap;
+				} )()
+				: null,
+		),
+		row( __( 'Location', 'desktop-mode' ), data.location ),
+		row( __( 'Email', 'desktop-mode' ), data.email ),
+		row( __( 'Customer since', 'desktop-mode' ), shortDate( data.registered ) ),
+		row(
+			__( 'Open', 'desktop-mode' ),
+			orders > 0 && data.ordersUrl
+				? link( __( 'All their orders', 'desktop-mode' ), data.ordersUrl )
+				: null,
+		),
+	];
+}
+
 /* -------------------------------------------------------------------
  * Wiring
  * ---------------------------------------------------------------- */
@@ -802,12 +1066,14 @@ const PANEL_TITLES: Record< Summary[ 'type' ], string > = {
 	product: __( 'Product', 'desktop-mode' ),
 	order: __( 'Order', 'desktop-mode' ),
 	coupon: __( 'Coupon', 'desktop-mode' ),
+	customer: __( 'Customer', 'desktop-mode' ),
 };
 
 const PANEL_ROW_COUNTS: Record< Summary[ 'type' ], number > = {
 	product: 8,
 	order: 10,
 	coupon: 12,
+	customer: 9,
 };
 
 /** Which summary type — if any — a section maps to. */
@@ -824,6 +1090,25 @@ function summaryTypeFor( entityId: string ): Summary[ 'type' ] | null {
 	return null;
 }
 
+/**
+ * Which summary a preview pane should show.
+ *
+ * Section id decides it for post-shaped sections, but a *person* is
+ * decided by kind rather than by section: the same customer panel
+ * belongs on the Customers list and on the built-in Users list, and
+ * on any section a plugin adds that renders people. Gated on
+ * `canCustomers` so a viewer without order access never fires a
+ * request that would 403.
+ */
+function previewSummaryTypeFor(
+	payload: PreviewExtrasPayload,
+): Summary[ 'type' ] | null {
+	if ( payload.kind === 'user' || payload.entityId === SECTION_CUSTOMERS ) {
+		return getConfig()?.canCustomers ? 'customer' : null;
+	}
+	return summaryTypeFor( payload.entityId );
+}
+
 /** Read the `openstation_woo` REST field off a product list row. */
 function productFacts( item: Record< string, unknown > ): ProductRowFacts | null {
 	const facts = item.openstation_woo as ProductRowFacts | null | undefined;
@@ -834,6 +1119,30 @@ function productFacts( item: Record< string, unknown > ): ProductRowFacts | null
 function wooBand( item: Record< string, unknown > ): string | null {
 	const facts = item.openstation_woo as { band?: string } | null | undefined;
 	return facts && typeof facts.band === 'string' ? facts.band : null;
+}
+
+/**
+ * Read the `openstation_woo_customer` REST field off a user row.
+ *
+ * Present on the Customers section AND on `/wp/v2/users`, so the
+ * built-in Users section gets the same decoration for free — which is
+ * the point: on a store, "who is this person" and "what have they
+ * spent" are the same question.
+ */
+function customerFacts(
+	item: Record< string, unknown >,
+): CustomerFacts | null {
+	const facts = item.openstation_woo_customer as
+		| CustomerFacts
+		| null
+		| undefined;
+	return facts && typeof facts.band === 'string' ? facts : null;
+}
+
+/** The translated label for a customer band, from the server's list. */
+function customerBandLabel( band: string ): string {
+	const found = getConfig()?.customerBands?.find( ( b ) => b.id === band );
+	return found?.label ?? '';
 }
 
 addFilter(
@@ -886,10 +1195,128 @@ addFilter(
 	},
 );
 
+/**
+ * Turn a user tile into a customer tile.
+ *
+ * An icon is an icon: a face, a name, and at most one mark. Anything
+ * else belongs one click away in the pane, where there is room to say
+ * it properly. So this does exactly two things — it takes the stock
+ * "Customer · 0 posts" sub-line off the Customers grid (in a folder
+ * where every row is a customer, the word says nothing), and it puts
+ * a small badge on the bottom edge of the avatar for the two bands a
+ * merchant scans the grid to find.
+ *
+ * Deliberately NOT the corner ribbon the Products grid uses. A ribbon
+ * is a 45° banner across the artwork: right on a product photo, wrong
+ * on a face — at 88px it covers a third of the avatar and turns a
+ * roster of people into a wall of diagonal shouting. And deliberately
+ * NOT a line of text under the name: spend and order counts stacked
+ * above a 48px avatar crowd the tile into unreadability, and they are
+ * in the pane already.
+ *
+ * Runs for the Customers section AND the built-in Users section: the
+ * facts ride `/wp/v2/users` too, and a user who has spent money is a
+ * customer wherever you happen to be looking at them. The sub-line is
+ * only stripped in the Customers section — in the Users folder
+ * "Editor · 12 posts" is still the truest thing about someone.
+ *
+ * @param payload The `os.my-wordpress.list-tile` payload.
+ * @return true when the tile was a customer tile and was handled.
+ */
+function decorateCustomerTile( payload: ListTilePayload ): boolean {
+	if ( payload.kind !== 'user' ) {
+		return false;
+	}
+	const facts = customerFacts( payload.item );
+	if ( ! facts ) {
+		return false;
+	}
+
+	if ( payload.entityId === SECTION_CUSTOMERS ) {
+		payload.tile
+			.querySelector( '.os-my-wordpress__user-tile-sub' )
+			?.remove();
+	}
+
+	// Only the two actionable bands get a badge. Marking every band
+	// would put one on every tile, which is the same as putting one
+	// on none.
+	if ( facts.band === 'vip' || facts.band === 'lapsed' ) {
+		payload.tile.dataset.wooCustomerBand = facts.band;
+		stampCustomerBand( payload.tile );
+	}
+
+	return true;
+}
+
+/**
+ * Put the band badge back on a tile that remembers it.
+ *
+ * `<os-tile>._paint()` rebuilds its children on every paint, and
+ * selection triggers a paint — same reason the product ribbon is
+ * re-stamped from `os.tile.rendered` rather than added once.
+ *
+ * The badge goes INSIDE `.os-file-tile__visual`, straddling the
+ * avatar's bottom edge, rather than into the tile's text column. Two
+ * reasons: it costs the tile no vertical space at all, and it sits
+ * where the eye already is — on the face — instead of adding a line
+ * the reader has to scan past to reach the name.
+ *
+ * @param tile The tile element.
+ */
+function stampCustomerBand( tile: HTMLElement ): void {
+	const band = tile.dataset.wooCustomerBand;
+	if ( ! band ) {
+		return;
+	}
+
+	// One badge per tile, wherever it currently sits. Scoped to the
+	// tile rather than to the avatar because the avatar is not stable:
+	// `<os-tile>._paint()` destroys and recreates
+	// `.os-file-tile__visual`, so a check scoped to the new visual
+	// says "no badge here" while the old one is still on screen.
+	if ( tile.querySelector( '.os-woo-customer-band' ) ) {
+		return;
+	}
+
+	// No visual yet — nothing to pin a badge to.
+	//
+	// This is the normal state on the first call: the decoration
+	// action fires from the tile builder while the element is still
+	// detached and `<os-tile>` has not painted, so there is no avatar
+	// box to reach. Falling back to the tile itself (which this used
+	// to do) put a second badge under the name that the later,
+	// correct stamp never noticed. Doing nothing is right — the
+	// `os.tile.rendered` pass runs at the end of every paint and
+	// stamps it then.
+	const host = tile.querySelector< HTMLElement >( '.os-file-tile__visual' );
+	if ( ! host ) {
+		return;
+	}
+	host.classList.add( 'os-woo-customer-avatar' );
+
+	const label =
+		customerBandLabel( band ) ||
+		( band === 'vip'
+			? __( 'VIP', 'desktop-mode' )
+			: __( 'Lapsed', 'desktop-mode' ) );
+
+	const chip = document.createElement( 'span' );
+	chip.className = `os-woo-customer-band os-woo-customer-band--${ band }`;
+	chip.textContent = label;
+	// The badge is decoration over a face; the name is the accessible
+	// label, and the band is stated in full in the preview pane.
+	chip.setAttribute( 'aria-hidden', 'true' );
+	host.appendChild( chip );
+}
+
 addAction(
 	'os.my-wordpress.list-tile',
 	'desktop-mode/woocommerce',
 	( payload: ListTilePayload ) => {
+		if ( decorateCustomerTile( payload ) ) {
+			return;
+		}
 		if ( payload.entityId !== SECTION_PRODUCTS ) {
 			return;
 		}
@@ -977,6 +1404,7 @@ addAction(
 	'desktop-mode/woocommerce',
 	( payload: { tile: HTMLElement } ) => {
 		stampRibbon( payload.tile );
+		stampCustomerBand( payload.tile );
 	},
 );
 
@@ -984,12 +1412,16 @@ addAction(
 	'os.my-wordpress.preview-extras',
 	'desktop-mode/woocommerce',
 	( payload: PreviewExtrasPayload ) => {
-		// One panel per preview, above the content.
-		if ( payload.slot !== 'header' ) {
+		const type = previewSummaryTypeFor( payload );
+		if ( ! type ) {
 			return;
 		}
-		const type = summaryTypeFor( payload.entityId );
-		if ( ! type ) {
+		// One panel per preview. A thing goes above its content
+		// (`header`); a *person* goes below their name and face
+		// (`meta`) — putting money above someone's avatar reads as a
+		// price tag on them, and you can't tell whose figure it is
+		// until you've scrolled past it to the name.
+		if ( payload.slot !== ( type === 'customer' ? 'meta' : 'header' ) ) {
 			return;
 		}
 		const id = Number( payload.item?.id );
@@ -1019,11 +1451,141 @@ addAction(
 				if ( data.type === 'coupon' ) {
 					return { rows: renderCoupon( data ) };
 				}
+				if ( data.type === 'customer' ) {
+					return { rows: renderCustomer( data ) };
+				}
 				return { rows: [] };
 			},
 		);
 	},
 );
+
+/**
+ * A customer's dossier is not an author's.
+ *
+ * The built-in dossier answers "what has this person written" — post
+ * and page counts, a publishing sparkline, recent posts, top
+ * categories. For someone who came to the site to buy a hat, every
+ * one of those is a zero, and four zeroes above the lifetime-spend
+ * figure is worse than nothing: it reads as the answer.
+ *
+ * Only in the Customers section. In the built-in Users folder an
+ * author is still an author, and their spend is an extra fact rather
+ * than a replacement for the rest of them.
+ */
+addFilter(
+	'os.my-wordpress.user-dossier-sections',
+	'desktop-mode/woocommerce',
+	( sections: string[], ctx: { entityId: string } ): string[] => {
+		if ( ctx.entityId !== SECTION_CUSTOMERS ) {
+			return sections;
+		}
+		return Array.isArray( sections )
+			? sections.filter( ( id ) => id === 'bio' )
+			: sections;
+	},
+);
+
+/**
+ * Swap the preview pane's action row for one a merchant can use.
+ *
+ * "View activity footprint" opens a publishing-history surface, which
+ * for a customer is an empty screen. Their order history is the
+ * equivalent question, and it is one window away.
+ */
+addFilter(
+	'os.my-wordpress.user-preview-actions',
+	'desktop-mode/woocommerce',
+	(
+		actions: UserPreviewAction[],
+		ctx: { entityId: string; item: Record< string, unknown > },
+	): UserPreviewAction[] => {
+		if ( ctx.entityId !== SECTION_CUSTOMERS || ! Array.isArray( actions ) ) {
+			return actions;
+		}
+
+		const kept = actions.filter( ( a ) => a?.id !== 'footprint' );
+		const facts = customerFacts( ctx.item );
+		if ( ! facts?.ordersUrl ) {
+			// No orders, no list to open — and a button onto an empty
+			// filtered screen is a dead end.
+			return kept.map( ( a ) =>
+				a.id === 'open-profile' ? { ...a, variant: 'primary' } : a,
+			);
+		}
+
+		return [
+			{
+				id: 'wc-orders',
+				label: __( 'View their orders', 'desktop-mode' ),
+				title: __(
+					'Open the orders screen filtered to this customer, in its own window.',
+					'desktop-mode',
+				),
+				variant: 'primary',
+				onSelect: () => openAdminWindow( facts.ordersUrl, __( 'Orders', 'desktop-mode' ) ),
+			},
+			...kept,
+		];
+	},
+);
+
+/**
+ * Open an admin URL as its own desktop window.
+ *
+ * The whole point of the section: the orders screen opens *beside*
+ * the customer rather than replacing them, so you can read one while
+ * looking at the other.
+ *
+ * The fallback is `window.open`, and it is a genuine last resort —
+ * with the shell missing there is nowhere to put a window. Note it
+ * behaves badly inside an installed PWA (a same-origin admin URL is
+ * in scope, so the app relaunches), which is exactly why the panel's
+ * links route here instead of carrying `target="_blank"`.
+ *
+ * @param url   Admin URL.
+ * @param title Window title.
+ */
+function openAdminWindow( url: string, title: string ): void {
+	const os = (
+		window.wp as
+			| {
+					os?: {
+						deriveWindowId?: ( target: string ) => string;
+						windowManager?: {
+							open: ( args: {
+								id: string;
+								url: string;
+								title: string;
+								icon?: string;
+							} ) => unknown;
+						};
+					};
+			}
+			| undefined
+	)?.os;
+	const manager = os?.windowManager;
+	if ( ! manager || typeof manager.open !== 'function' ) {
+		window.open( url, '_blank', 'noopener,noreferrer' );
+		return;
+	}
+
+	// `manager.open()` REQUIRES a non-empty id and throws a TypeError
+	// without one — a deliberately loud boundary, since a window
+	// without an id can never be focused, deduped or restored.
+	//
+	// `wp.os.deriveWindowId` is the shell's own slug derivation, the
+	// same one the dock and the admin-link dispatcher use, so a
+	// product opened from here lands on the SAME window the dock
+	// would open rather than a private duplicate. The fallback slug
+	// only matters if the API is missing.
+	const id =
+		typeof os?.deriveWindowId === 'function'
+			? os.deriveWindowId( url )
+			: `os-woo-${ url.replace( /[^a-z0-9]+/gi, '-' ).slice( -60 ) }`;
+
+	manager.open( { id, url, title, icon: 'dashicons-cart' } );
+}
 
 addAction(
 	'os.my-wordpress.group-extras',
@@ -1041,13 +1603,18 @@ addAction(
 			payload.container,
 			__( 'Store', 'desktop-mode' ),
 			'store',
-			3,
+			cfg.canCustomers ? 6 : 3,
 			async () => {
 				const result = await fetchJson< StoreSummary >( 'store' );
 				if ( 'error' in result ) {
 					return result;
 				}
 				const { data } = result;
+				const customers = Number( data.customers ) || 0;
+				const vips = Number( data.vips ) || 0;
+				const lapsed = Number( data.lapsed ) || 0;
+				const guestOrders = Number( data.guestOrders ) || 0;
+
 				return {
 					rows: [
 						row(
@@ -1072,9 +1639,712 @@ addAction(
 								)
 								: __( 'None', 'desktop-mode' ),
 						),
+						row(
+							__( 'Customers', 'desktop-mode' ),
+							customers > 0
+								? sprintf(
+									/* translators: %d: number of customers. */
+									_n( '%d person', '%d people', customers ),
+									customers,
+								)
+								: null,
+						),
+						row(
+							__( 'VIP · lapsed', 'desktop-mode' ),
+							vips > 0 || lapsed > 0
+								? sprintf(
+									/* translators: 1: VIP customer count, 2: lapsed customer count. */
+									__( '%1$d · %2$d', 'desktop-mode' ),
+									vips,
+									lapsed,
+								)
+								: null,
+						),
+						// Guests can't appear in the Customers list —
+						// there is no account to render — so their
+						// money is reported here or nowhere.
+						row(
+							__( 'Guest checkout', 'desktop-mode' ),
+							data.guestSpend
+								? sprintf(
+									/* translators: 1: formatted revenue, 2: number of orders. */
+									__( '%1$s over %2$d orders', 'desktop-mode' ),
+									data.guestSpend,
+									guestOrders,
+								)
+								: null,
+						),
 					],
 				};
 			},
 		);
 	},
 );
+
+/* -------------------------------------------------------------------
+ * The Customer window
+ *
+ * A native window on one person: who they are, what they are worth,
+ * what they bought, where it ships. Double-clicking a customer tile
+ * lands here.
+ *
+ * It exists because the two screens WordPress offers instead are both
+ * the wrong one. The activity footprint answers "what has this person
+ * published", which for someone who came to buy a hat is an empty
+ * page. `user-edit.php` is a settings form — where you go to change
+ * someone's role, not to understand them.
+ *
+ * Singleton and retargeting: the window id is "the customer window",
+ * and WHICH customer is an open-time param. Params ride the session,
+ * so a reload brings it back on the same person.
+ * ---------------------------------------------------------------- */
+
+const CUSTOMER_WINDOW_ID = 'desktop-mode-woo-customer';
+
+/**
+ * Announce what the Customer window is showing, so the relations
+ * layer can tie it to everything else about that person.
+ *
+ * An iframe window gets this for free: the chromeless bridge builds
+ * an identity from the real admin screen and posts it up. A NATIVE
+ * window has no such screen — nothing announces on its behalf, and
+ * without this call it is invisible to the engine. That is why the
+ * window opened beside the order it came from and drew no line while
+ * every iframe window in the same desktop did.
+ *
+ * The type is `user`, matching what `user-edit.php` announces, so the
+ * Customer window and a profile window on the same person join one
+ * group — and an order, whose identity links `user:<id>`, ties to
+ * either.
+ *
+ * @param body       The window body, for resolving the window id.
+ * @param customerId The person.
+ * @param name       Their name, for tooltips.
+ */
+function announceCustomerIdentity(
+	body: HTMLElement,
+	customerId: number,
+	name: string,
+): void {
+	// `wp-window-<id>` is the id-of-record for anything holding a DOM
+	// node but not a `Window` reference — the same walk the file-drop
+	// manager and the drag targets use.
+	const root = body.closest< HTMLElement >( '[id^="wp-window-"]' );
+	const windowId = root?.id.slice( 'wp-window-'.length );
+	if ( ! windowId ) {
+		return;
+	}
+
+	const set = (
+		window.wp as
+			| {
+					os?: {
+						relations?: {
+							set?: (
+								id: string,
+								ref: {
+									type: string;
+									id: number | string;
+									label?: string;
+								} | null,
+							) => void;
+						};
+					};
+			}
+			| undefined
+	)?.os?.relations?.set;
+	if ( typeof set !== 'function' ) {
+		return;
+	}
+
+	set(
+		windowId,
+		customerId > 0
+			? { type: 'user', id: customerId, label: name || undefined }
+			: null,
+	);
+}
+
+/**
+ * Open (or retarget) the Customer window.
+ *
+ * @param customerId The person.
+ * @param name       Their name, for the window title.
+ * @return true when the shell took it.
+ */
+function openCustomerWindow( customerId: number, name: string ): boolean {
+	if ( ! Number.isFinite( customerId ) || customerId <= 0 ) {
+		return false;
+	}
+	const open = (
+		window.wp as
+			| {
+					os?: {
+						openWindow?: (
+							id: string,
+							opts?: {
+								source?: string;
+								params?: Record<
+									string,
+									string | number | boolean
+								>;
+							},
+						) => boolean;
+					};
+			}
+			| undefined
+	)?.os?.openWindow;
+	if ( typeof open !== 'function' ) {
+		return false;
+	}
+	return (
+		open( CUSTOMER_WINDOW_ID, {
+			source: 'woocommerce/customer-tile',
+			// `name` travels too so a restored window can title itself
+			// before its first request comes back — otherwise every
+			// reload flashes a generic "Customer" title bar.
+			params: { customerId, customerName: name },
+		} ) === true
+	);
+}
+
+/**
+ * Claim the "Customer" entry in an order's Related menu.
+ *
+ * The menu can only express a destination as a URL, and the only URL
+ * WordPress has for a person is their profile editor — so following
+ * the customer from an order landed on a settings form. Which is the
+ * wrong answer to the question being asked: from an order, "customer"
+ * means *this is who bought it*, not *change their role*.
+ *
+ * The server marks that item's URL with `os_person_view=wc-customer`;
+ * the built-in profile remap stands down on any URL carrying the
+ * marker, so this claim doesn't depend on winning a registration-
+ * order race with it. The profile editor is still one item away in
+ * the same menu, unmarked.
+ */
+registerNativeUrlRemap( {
+	id: 'desktop-mode/woo-customer',
+	nativeWindowId: CUSTOMER_WINDOW_ID,
+	matches: ( _url, parsed ) =>
+		parsed.searchParams.get( OS_PERSON_VIEW_PARAM ) === 'wc-customer' &&
+		Number( parsed.searchParams.get( 'user_id' ) ) > 0,
+	// Params rather than a shared store: they ride the session, so
+	// the window reopens on the same person after a reload.
+	params: ( _url, parsed ) => ( {
+		customerId: Number( parsed.searchParams.get( 'user_id' ) ) || 0,
+	} ),
+} );
+
+/**
+ * Claim the double-click on a customer tile.
+ *
+ * Only in the Customers section. In the Users folder a person is
+ * someone who writes, and the activity footprint is the right answer
+ * there — the point of the seam is that each section gets to say what
+ * "open this person" means.
+ */
+addFilter(
+	'os.my-wordpress.user-activate',
+	'desktop-mode/woocommerce',
+	(
+		handled: boolean,
+		ctx: { entityId: string; item: Record< string, unknown > },
+	): boolean => {
+		if ( handled || ctx.entityId !== SECTION_CUSTOMERS ) {
+			return handled;
+		}
+		const id = Number( ctx.item?.id );
+		const name = String( ctx.item?.name ?? '' );
+		return openCustomerWindow( id, name );
+	},
+);
+
+/**
+ * Fix up the customer tile's context menu.
+ *
+ * "View activity footprint" is the publishing-history screen and
+ * "View author archive" is a front-end blog page for someone who has
+ * never written a post — both are dead ends for a customer. They are
+ * replaced by the two things a merchant actually wants from a
+ * right-click: the customer window and their orders.
+ */
+addFilter(
+	'os.my-wordpress.tile-context-menu',
+	'desktop-mode/woocommerce',
+	(
+		options: Array< {
+			id: string;
+			label: string;
+			icon: string;
+			onSelect?: ( () => void ) | null;
+		} >,
+		ctx: { entityId: string; kind: string; item: Record< string, unknown > },
+	) => {
+		if (
+			ctx.kind !== 'user' ||
+			ctx.entityId !== SECTION_CUSTOMERS ||
+			! Array.isArray( options )
+		) {
+			return options;
+		}
+
+		const id = Number( ctx.item?.id );
+		const name = String( ctx.item?.name ?? '' );
+		const facts = customerFacts( ctx.item );
+
+		const kept = options.filter(
+			( o ) => o?.id !== 'footprint' && o?.id !== 'author-archive',
+		);
+
+		const added: typeof options = [
+			{
+				id: 'wc-customer-window',
+				label: __( 'Open customer', 'desktop-mode' ),
+				icon: 'dashicons-businessperson',
+				onSelect: () => {
+					openCustomerWindow( id, name );
+				},
+			},
+		];
+		if ( facts?.ordersUrl ) {
+			added.push( {
+				id: 'wc-customer-orders',
+				label: __( 'View their orders', 'desktop-mode' ),
+				icon: 'dashicons-cart',
+				onSelect: () => {
+					openAdminWindow(
+						facts.ordersUrl,
+						__( 'Orders', 'desktop-mode' ),
+					);
+				},
+			} );
+		}
+
+		return [ ...added, ...kept ];
+	},
+);
+
+/* ----- Window rendering primitives ----- */
+
+const CW = 'os-woo-customer-window';
+
+/** A big number with a caption under it. */
+function statCard( value: string, label: string, hint = '' ): HTMLElement {
+	const card = document.createElement( 'div' );
+	card.className = `${ CW }__stat`;
+
+	const v = document.createElement( 'div' );
+	v.className = `${ CW }__stat-value`;
+	v.textContent = value;
+	card.appendChild( v );
+
+	const l = document.createElement( 'div' );
+	l.className = `${ CW }__stat-label`;
+	l.textContent = label;
+	card.appendChild( l );
+
+	if ( hint ) {
+		const h = document.createElement( 'div' );
+		h.className = `${ CW }__stat-hint`;
+		h.textContent = hint;
+		card.appendChild( h );
+	}
+
+	return card;
+}
+
+/** A titled block. Returns null when it would be empty. */
+function section( title: string, body: Node | null ): HTMLElement | null {
+	if ( ! body ) {
+		return null;
+	}
+	const host = document.createElement( 'section' );
+	host.className = `${ CW }__section`;
+
+	const h = document.createElement( 'h3' );
+	h.className = `${ CW }__section-title`;
+	h.textContent = title;
+	host.append( h, body );
+
+	return host;
+}
+
+/** The identity strip: avatar, name, contact, band. */
+function customerHeader( data: CustomerSummary ): HTMLElement {
+	const header = document.createElement( 'header' );
+	header.className = `${ CW }__header`;
+
+	if ( data.avatar ) {
+		const img = document.createElement( 'img' );
+		img.className = `${ CW }__avatar`;
+		img.src = data.avatar;
+		img.alt = '';
+		img.width = 64;
+		img.height = 64;
+		header.appendChild( img );
+	}
+
+	const meta = document.createElement( 'div' );
+	meta.className = `${ CW }__identity`;
+
+	const name = document.createElement( 'h2' );
+	name.className = `${ CW }__name`;
+	name.textContent = data.name || data.username || `#${ data.id }`;
+	meta.appendChild( name );
+
+	const contact = [ data.email, data.phone ].filter( Boolean ).join( ' · ' );
+	if ( contact ) {
+		const line = document.createElement( 'p' );
+		line.className = `${ CW }__contact`;
+		line.textContent = contact;
+		meta.appendChild( line );
+	}
+
+	if ( data.bandLabel ) {
+		const badge = document.createElement( 'os-badge' );
+		badge.setAttribute( 'tone', customerToneFor( data.band ) );
+		badge.className = `${ CW }__band`;
+		badge.textContent = data.bandLabel;
+		meta.appendChild( badge );
+	}
+
+	header.appendChild( meta );
+	return header;
+}
+
+/** The four numbers a merchant reads first. */
+function customerStats( data: CustomerSummary ): HTMLElement {
+	const grid = document.createElement( 'div' );
+	grid.className = `${ CW }__stats`;
+
+	const orders = Number( data.orders ) || 0;
+	grid.append(
+		statCard(
+			data.spend || '—',
+			__( 'Lifetime spend', 'desktop-mode' ),
+			data.aov
+				? sprintf(
+					/* translators: %s: formatted average order value. */
+					__( '%s average', 'desktop-mode' ),
+					data.aov,
+				)
+				: '',
+		),
+		statCard(
+			String( orders ),
+			_n( 'Order', 'Orders', orders ),
+			data.firstOrder
+				? sprintf(
+					/* translators: %s: date of the first order. */
+					__( 'since %s', 'desktop-mode' ),
+					shortDate( data.firstOrder ),
+				)
+				: '',
+		),
+		statCard(
+			sinceLabel( data.daysSince ?? null ) || '—',
+			__( 'Last order', 'desktop-mode' ),
+			data.lastOrderTotal,
+		),
+		statCard(
+			data.location || '—',
+			__( 'Location', 'desktop-mode' ),
+			data.registered
+				? sprintf(
+					/* translators: %s: registration date. */
+					__( 'joined %s', 'desktop-mode' ),
+					shortDate( data.registered ),
+				)
+				: '',
+		),
+	);
+
+	return grid;
+}
+
+/** The order history, as rows that open the order in a window. */
+function customerOrders( data: CustomerSummary ): Node | null {
+	const rows = Array.isArray( data.recentOrders ) ? data.recentOrders : [];
+	if ( rows.length === 0 ) {
+		return null;
+	}
+
+	const list = document.createElement( 'ul' );
+	list.className = `${ CW }__orders`;
+
+	for ( const order of rows ) {
+		const li = document.createElement( 'li' );
+		li.className = `${ CW }__order`;
+
+		const head = document.createElement( 'div' );
+		head.className = `${ CW }__order-head`;
+		head.appendChild(
+			link(
+				sprintf(
+					/* translators: %s: order number. */
+					__( '#%s', 'desktop-mode' ),
+					order.number,
+				),
+				order.editUrl,
+			),
+		);
+		const badge = document.createElement( 'os-badge' );
+		badge.setAttribute( 'tone', orderToneFor( order.status ) );
+		badge.textContent = order.statusLabel;
+		head.appendChild( badge );
+		li.appendChild( head );
+
+		const meta = document.createElement( 'div' );
+		meta.className = `${ CW }__order-meta`;
+		meta.textContent = [
+			shortDate( order.date ),
+			sprintf(
+				/* translators: %d: number of line items. */
+				_n( '%d item', '%d items', order.items ),
+				order.items,
+			),
+		]
+			.filter( Boolean )
+			.join( ' · ' );
+		li.appendChild( meta );
+
+		const total = document.createElement( 'div' );
+		total.className = `${ CW }__order-total`;
+		total.textContent = order.total;
+		li.appendChild( total );
+
+		list.appendChild( li );
+	}
+
+	return list;
+}
+
+/** Billing / shipping, side by side when they differ. */
+function customerAddresses( data: CustomerSummary ): Node | null {
+	const entries: Array< [ string, string ] > = [];
+	if ( data.billing ) {
+		entries.push( [ __( 'Billing', 'desktop-mode' ), data.billing ] );
+	}
+	// Only when it says something the billing address doesn't — two
+	// identical blocks are a waste of the reader's attention.
+	if ( data.shipping && data.shipping !== data.billing ) {
+		entries.push( [ __( 'Shipping', 'desktop-mode' ), data.shipping ] );
+	}
+	if ( entries.length === 0 ) {
+		return null;
+	}
+
+	const grid = document.createElement( 'div' );
+	grid.className = `${ CW }__addresses`;
+	for ( const [ label, value ] of entries ) {
+		const block = document.createElement( 'div' );
+		block.className = `${ CW }__address`;
+
+		const l = document.createElement( 'div' );
+		l.className = `${ CW }__address-label`;
+		l.textContent = label;
+
+		const v = document.createElement( 'div' );
+		v.className = `${ CW }__address-value`;
+		v.textContent = value;
+
+		block.append( l, v );
+		grid.appendChild( block );
+	}
+
+	return grid;
+}
+
+/** The action row — every one of these opens its own window. */
+function customerActions( data: CustomerSummary ): HTMLElement {
+	const footer = document.createElement( 'footer' );
+	footer.className = `${ CW }__actions`;
+
+	const button = (
+		label: string,
+		variant: 'primary' | 'secondary',
+		onClick: () => void,
+	): void => {
+		const btn = document.createElement( 'os-button' );
+		btn.setAttribute( 'variant', variant );
+		btn.textContent = label;
+		btn.addEventListener( 'click', onClick );
+		footer.appendChild( btn );
+	};
+
+	if ( data.ordersUrl && Number( data.orders ) > 0 ) {
+		button( __( 'All orders', 'desktop-mode' ), 'primary', () =>
+			openAdminWindow( data.ordersUrl, __( 'Orders', 'desktop-mode' ) ),
+		);
+	}
+	if ( data.profileUrl ) {
+		button( __( 'Edit profile', 'desktop-mode' ), 'secondary', () =>
+			openAdminWindow( data.profileUrl, data.name ),
+		);
+	}
+	if ( data.email ) {
+		button( __( 'Send email', 'desktop-mode' ), 'secondary', () => {
+			// `location.href` rather than `window.open`: a `mailto:`
+			// is handed to the OS handler, and opening it in a new
+			// browsing context leaves a blank tab behind — or, in the
+			// installed PWA, relaunches the app.
+			window.location.href = `mailto:${ encodeURIComponent(
+				data.email,
+			) }`;
+		} );
+	}
+
+	return footer;
+}
+
+/**
+ * Paint the whole window for one customer.
+ *
+ * @param root       The window's mount point.
+ * @param customerId Who to show.
+ * @param fallback   Name to title the window with before data lands.
+ */
+async function renderCustomerWindow(
+	root: HTMLElement,
+	customerId: number,
+	fallback: string,
+): Promise< void > {
+	const loading = document.createElement( 'div' );
+	loading.className = `${ CW }__loading`;
+	loading.appendChild( document.createElement( 'os-spinner' ) );
+	root.replaceChildren( loading );
+
+	if ( ! Number.isFinite( customerId ) || customerId <= 0 ) {
+		const empty = document.createElement( 'p' );
+		empty.className = `${ CW }__empty`;
+		empty.textContent = __(
+			'No customer selected. Open one from the Customers folder.',
+			'desktop-mode',
+		);
+		root.replaceChildren( empty );
+		return;
+	}
+
+	const result = await fetchJson< CustomerSummary >(
+		`summary/customer/${ customerId }`,
+	);
+
+	// The window may have been retargeted (or closed) while the
+	// request was in flight.
+	if ( ! root.isConnected ) {
+		return;
+	}
+	if ( 'error' in result ) {
+		const err = document.createElement( 'p' );
+		err.className = `${ CW }__empty`;
+		err.textContent = result.error;
+		root.replaceChildren( err );
+		return;
+	}
+
+	const data = result.data;
+	const frag = document.createDocumentFragment();
+	frag.append( customerHeader( data ), customerStats( data ) );
+
+	const favourite = data.favourite
+		? ( () => {
+			const wrap = document.createElement( 'p' );
+			wrap.className = `${ CW }__favourite`;
+			wrap.appendChild(
+				link( data.favourite.label, data.favourite.editUrl ),
+			);
+			if ( data.favourite.quantity > 1 ) {
+				wrap.appendChild(
+					document.createTextNode(
+						` · ${ sprintf(
+							/* translators: %d: units bought. */
+							__( '×%d bought', 'desktop-mode' ),
+							data.favourite.quantity,
+						) }`,
+					),
+				);
+			}
+			return wrap;
+		} )()
+		: null;
+
+	for ( const block of [
+		section( __( 'Buys most', 'desktop-mode' ), favourite ),
+		section( __( 'Recent orders', 'desktop-mode' ), customerOrders( data ) ),
+		section( __( 'Addresses', 'desktop-mode' ), customerAddresses( data ) ),
+	] ) {
+		if ( block ) {
+			frag.appendChild( block );
+		}
+	}
+
+	frag.appendChild( customerActions( data ) );
+
+	root.replaceChildren( frag );
+	// Not used for display — the fallback title is only the pre-paint
+	// placeholder — but a stable marker makes "which customer is this
+	// window on" answerable from the DOM.
+	root.dataset.customerId = String( customerId );
+	root.dataset.customerName = data.name || fallback;
+}
+
+/**
+ * The native-window render callback. Registered on the global the
+ * shell reads rather than through an import, because the shell owns
+ * the window lifecycle and calls in.
+ */
+type NativeWindowRenderer = (
+	body: HTMLElement,
+	ctx?: { params?: Record< string, string | number | boolean > },
+) => unknown;
+
+const nativeWindowRegistry = window as unknown as {
+	openStationNativeWindows?: Record< string, NativeWindowRenderer >;
+};
+nativeWindowRegistry.openStationNativeWindows =
+	nativeWindowRegistry.openStationNativeWindows ?? {};
+
+nativeWindowRegistry.openStationNativeWindows[ CUSTOMER_WINDOW_ID ] = (
+	body,
+	ctx,
+) => {
+	const root =
+		body.querySelector< HTMLElement >( '[data-os-woo-customer-root]' ) ??
+		body;
+
+	const paint = ( params: Record< string, string | number | boolean > ) => {
+		const customerId = Number( params.customerId ?? 0 );
+		const name = String( params.customerName ?? '' );
+		// Announced before the fetch, not after: the identity is
+		// already known from the params, and waiting for the summary
+		// would leave the window unconnected for a round trip —
+		// exactly when the user is looking at it next to the order
+		// they came from.
+		announceCustomerIdentity( body, customerId, name );
+		void renderCustomerWindow( root, customerId, name );
+	};
+
+	paint( ctx?.params ?? {} );
+
+	// Retarget while open: reopening the window with a different
+	// customer fires `os-window-reopened` carrying the live params,
+	// which the manager has already updated. Without this the window
+	// would focus and keep showing the previous person — the failure
+	// mode that reads as "clicking a second customer does nothing".
+	const onReopen = ( event: Event ): void => {
+		const detail = ( event as CustomEvent ).detail as {
+			windowId?: string;
+			params?: Record< string, string | number | boolean >;
+		};
+		if ( detail?.windowId !== CUSTOMER_WINDOW_ID || ! root.isConnected ) {
+			return;
+		}
+		paint( detail.params ?? {} );
+	};
+	document.addEventListener( 'os-window-reopened', onReopen );
+
+	return () => {
+		document.removeEventListener( 'os-window-reopened', onReopen );
+	};
+};

--- a/src/my-wordpress/integrations/woocommerce.ts
+++ b/src/my-wordpress/integrations/woocommerce.ts
@@ -257,6 +257,11 @@ interface StoreSummary {
 	customers?: number;
 	vips?: number;
 	lapsed?: number;
+	/**
+	 * True when the store is past the band-ordering cap, so `vips` and
+	 * `lapsed` were never computed. Not the same as both being zero.
+	 */
+	bandsCapped?: boolean;
 	guestSpend?: string;
 	guestOrders?: number;
 }
@@ -1615,6 +1620,25 @@ addAction(
 				const lapsed = Number( data.lapsed ) || 0;
 				const guestOrders = Number( data.guestOrders ) || 0;
 
+				// Past the ordering cap the server never computed the
+				// bands, so they are unknown rather than zero. Saying
+				// so is the point: printing "0 · 0" would claim a
+				// large store has no VIPs at all.
+				let bands: string | null = null;
+				if ( data.bandsCapped ) {
+					bands = __(
+						'Not counted on a store this large',
+						'desktop-mode',
+					);
+				} else if ( vips > 0 || lapsed > 0 ) {
+					bands = sprintf(
+						/* translators: 1: VIP customer count, 2: lapsed customer count. */
+						__( '%1$d · %2$d', 'desktop-mode' ),
+						vips,
+						lapsed,
+					);
+				}
+
 				return {
 					rows: [
 						row(
@@ -1649,17 +1673,7 @@ addAction(
 								)
 								: null,
 						),
-						row(
-							__( 'VIP · lapsed', 'desktop-mode' ),
-							vips > 0 || lapsed > 0
-								? sprintf(
-									/* translators: 1: VIP customer count, 2: lapsed customer count. */
-									__( '%1$d · %2$d', 'desktop-mode' ),
-									vips,
-									lapsed,
-								)
-								: null,
-						),
+						row( __( 'VIP · lapsed', 'desktop-mode' ), bands ),
 						// Guests can't appear in the Customers list —
 						// there is no account to render — so their
 						// money is reported here or nowhere.
@@ -2199,6 +2213,17 @@ function customerActions( data: CustomerSummary ): HTMLElement {
 }
 
 /**
+ * Monotonic ticket for Customer-window paints.
+ *
+ * The window is a retargetable singleton: clicking a second customer
+ * repaints the same root while the first customer's summary may still
+ * be in flight. `root.isConnected` can't see that — the node is the
+ * same one and stays connected — so each paint claims a ticket and
+ * drops its response if a later paint has since claimed one.
+ */
+let customerPaintTicket = 0;
+
+/**
  * Paint the whole window for one customer.
  *
  * @param root       The window's mount point.
@@ -2210,6 +2235,10 @@ async function renderCustomerWindow(
 	customerId: number,
 	fallback: string,
 ): Promise< void > {
+	const ticket = ++customerPaintTicket;
+	const stale = (): boolean =>
+		! root.isConnected || ticket !== customerPaintTicket;
+
 	const loading = document.createElement( 'div' );
 	loading.className = `${ CW }__loading`;
 	loading.appendChild( document.createElement( 'os-spinner' ) );
@@ -2231,8 +2260,9 @@ async function renderCustomerWindow(
 	);
 
 	// The window may have been retargeted (or closed) while the
-	// request was in flight.
-	if ( ! root.isConnected ) {
+	// request was in flight. Landing here late would overwrite the
+	// customer the user is now looking at with the one they left.
+	if ( stale() ) {
 		return;
 	}
 	if ( 'error' in result ) {

--- a/src/my-wordpress/rest.ts
+++ b/src/my-wordpress/rest.ts
@@ -324,12 +324,31 @@ export async function fetchUserList(
 		const url = new URL( buildUrl( entity.restPath ) );
 		url.searchParams.set( 'page', String( params.page ) );
 		url.searchParams.set( 'per_page', String( params.perPage ) );
+		// Same `listFields` contract the post-shaped fetcher honours:
+		// a section serving user-shaped rows from its own route (the
+		// WooCommerce Customers list) carries extra payloads, and
+		// `rest_filter_response_fields()` strips anything not named
+		// here before the bundle ever sees it.
 		url.searchParams.set(
 			'_fields',
-			'id,name,slug,description,link,avatar_urls,openstation_summary',
+			[
+				'id',
+				'name',
+				'slug',
+				'description',
+				'link',
+				'avatar_urls',
+				'openstation_summary',
+				...( entity.listFields ?? [] ),
+			].join( ',' ),
 		);
 		url.searchParams.set( 'orderby', 'name' );
 		url.searchParams.set( 'order', 'asc' );
+		// Section-declared markers, so a server-side query filter can
+		// tell a site-window request from any other REST caller's.
+		for ( const [ key, value ] of Object.entries( entity.listQuery ?? {} ) ) {
+			url.searchParams.set( key, value );
+		}
 		if ( mode === 'edit' ) {
 			url.searchParams.set( 'context', 'edit' );
 		} else {

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -266,6 +266,14 @@ export interface EntityDetail {
 	 * older API responses that don't carry this.
 	 */
 	openstation_attached_media?: number[];
+	/**
+	 * Explicit editor URL, for a section whose rows don't live in
+	 * `wp_posts` and so can't be edited at `post.php?post=<id>` — a
+	 * WooCommerce order under High-Performance Order Storage is the
+	 * in-tree case. Declare it in the section's `listFields` so
+	 * `_fields` doesn't strip it off the list rows.
+	 */
+	editUrl?: string;
 	_links?: Record< string, Array< { href: string; count?: number } > >;
 	_embedded?: EntityListItem[ '_embedded' ] & {
 		author?: Array< {

--- a/src/native-url-remap.ts
+++ b/src/native-url-remap.ts
@@ -50,6 +50,26 @@ import { createSharedStore } from './shared-store';
 export const OS_PERSON_VIEW_PARAM = 'os_person_view';
 
 /**
+ * Whether a person-URL has already been claimed by a specific view.
+ *
+ * The stand-down half of {@link OS_PERSON_VIEW_PARAM}: a remap whose
+ * subject is "this person, generally" — the built-in profile editor —
+ * calls this first and returns `false` when it is true, leaving the
+ * URL to whichever view marked it.
+ *
+ * Exported so both halves of the hand-off read the same predicate.
+ * Two matchers each spelling out their own version of it is how a
+ * claim quietly stops being honoured.
+ *
+ * @public
+ * @param parsed Resolved URL.
+ * @return True when some other view has claimed this person-URL.
+ */
+export function isPersonViewClaimed( parsed: URL ): boolean {
+	return parsed.searchParams.has( OS_PERSON_VIEW_PARAM );
+}
+
+/**
  * A single URL → native-window remap.
  */
 export interface NativeUrlRemap {

--- a/src/native-url-remap.ts
+++ b/src/native-url-remap.ts
@@ -28,6 +28,28 @@ import type { OsSettingsSnapshot } from './settings/registry';
 import { createSharedStore } from './shared-store';
 
 /**
+ * Query flag marking a person-URL as a request for a *particular*
+ * view of that person rather than for the profile editor.
+ *
+ * `user-edit.php?user_id=12` means "edit user 12". A shop wants a
+ * different answer to the same person — the Customer window — and the
+ * Related menu can only express a destination as a URL. Rather than
+ * make two remaps race for the same URL in registration order, the
+ * marker lets the specific one claim it and the built-in profile
+ * remap stand down.
+ *
+ * The value is the claiming view's id (`'wc-customer'`), so a third
+ * one can join without either of the existing two changing.
+ *
+ * The VALUE keeps its `os_` spelling on purpose: it appears in URLs
+ * that are built server-side and consumed client-side, so the two
+ * ends must agree on the literal.
+ *
+ * @public
+ */
+export const OS_PERSON_VIEW_PARAM = 'os_person_view';
+
+/**
  * A single URL → native-window remap.
  */
 export interface NativeUrlRemap {
@@ -63,11 +85,33 @@ export interface NativeUrlRemap {
 	 * native open and falls back if it fails.
 	 */
 	onMatch?( url: string, parsed: URL ): void;
+	/**
+	 * Optional open-time params for the native window — what it is
+	 * showing this time (`{ customerId: 7 }`).
+	 *
+	 * Prefer this over threading state through `onMatch` into a
+	 * shared store: params are persisted with the session and staged
+	 * back on restore, so the window reopens on the same subject
+	 * after a reload. A shared store does not survive the reload, and
+	 * the window silently comes back on its default.
+	 *
+	 * See `WindowConfig.params`.
+	 */
+	params?(
+		url: string,
+		parsed: URL,
+	): Record< string, string | number | boolean > | undefined;
 }
 
 interface RemapDeps {
 	getSnapshot(): OsSettingsSnapshot;
-	openById( id: string ): boolean;
+	openById(
+		id: string,
+		opts?: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		},
+	): boolean;
 	adminUrl: string;
 }
 
@@ -231,7 +275,32 @@ export function tryNativeUrlRemap( url: string ): boolean {
 				);
 			}
 		}
-		if ( deps.openById( entry.nativeWindowId ) ) {
+		let params:
+			| Record< string, string | number | boolean >
+			| undefined;
+		if ( entry.params ) {
+			try {
+				params = entry.params( url, parsed ) ?? undefined;
+			} catch ( err ) {
+				// Same tolerance as `onMatch`: a throwing hook must
+				// not block the open. The window still opens, just
+				// without whatever the hook meant to tell it.
+				// eslint-disable-next-line no-console
+				console.warn(
+					`[openstation] URL remap params hook threw for "${ entry.id }":`,
+					err,
+				);
+			}
+		}
+		// Called with ONE argument when there are no params, rather
+		// than with an explicit `undefined`. The opener's signature is
+		// older than this hook and most remaps will never use it;
+		// passing a trailing `undefined` would change what every
+		// existing caller observes for no benefit.
+		const opened = params
+			? deps.openById( entry.nativeWindowId, { params } )
+			: deps.openById( entry.nativeWindowId );
+		if ( opened ) {
 			return true;
 		}
 	}

--- a/src/native-windows.ts
+++ b/src/native-windows.ts
@@ -140,7 +140,10 @@ let _ctxInstance = 0;
  *
  * @internal
  */
-function buildNativeRenderContext( windowId: string ): {
+function buildNativeRenderContext(
+	windowId: string,
+	params: Record< string, string | number | boolean > = {},
+): {
 	ctx: NativeRenderContext;
 	dispose: () => void;
 } {
@@ -284,6 +287,7 @@ function buildNativeRenderContext( windowId: string ): {
 				},
 			);
 		},
+		params,
 	};
 
 	const dispose = (): void => {
@@ -917,7 +921,13 @@ export interface NativeWindowSync {
 	 * so the body always has the cloned template before the render
 	 * callback fires. **Do not duplicate this elsewhere.**
 	 */
-	openById: ( id: string ) => boolean;
+	openById: (
+		id: string,
+		opts?: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		},
+	) => boolean;
 
 	/**
 	 * Spawn a BRAND-NEW instance of a registered native window — even
@@ -932,7 +942,13 @@ export interface NativeWindowSync {
 	 *
 	 * Returns `false` when the id isn't registered.
 	 */
-	openNewById: ( id: string ) => boolean;
+	openNewById: (
+		id: string,
+		opts?: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		},
+	) => boolean;
 }
 
 export function createNativeWindowSync(
@@ -1075,7 +1091,10 @@ export function createNativeWindowSync(
 		loadedScripts.add( entry.scriptUrl );
 	};
 
-	const openFromEntry = ( entry: NativeWindowServerEntry ): void => {
+	const openFromEntry = (
+		entry: NativeWindowServerEntry,
+		params?: Record< string, string | number | boolean >,
+	): void => {
 		const render = readGlobalRegistry()[ entry.id ];
 
 		// Pre-populate the window body with the cloned template, then
@@ -1121,6 +1140,13 @@ export function createNativeWindowSync(
 			render: finalRender,
 			autofocus: entry.autofocus,
 			ownerHandle: entry.ownerHandle || entry.scriptHandle,
+			// What this open is showing. Persisted with the session,
+			// so a singleton that retargets comes back on the same
+			// subject after a reload instead of on its default.
+			// Omitted rather than set empty: `manager.open()` focuses
+			// an existing window rather than rebuilding it, and an
+			// argument-less reopen must not wipe what it was showing.
+			...( params ? { params } : {} ),
 		} );
 	};
 
@@ -1130,7 +1156,10 @@ export function createNativeWindowSync(
 	 * render callback is built fresh per call — every duplicate gets
 	 * its own template clone and its own teardown.
 	 */
-	const openNewFromEntry = ( entry: NativeWindowServerEntry ): void => {
+	const openNewFromEntry = (
+		entry: NativeWindowServerEntry,
+		params?: Record< string, string | number | boolean >,
+	): void => {
 		const render = readGlobalRegistry()[ entry.id ];
 
 		const finalRender: RenderCallback = ( body, ctx ) => {
@@ -1161,6 +1190,7 @@ export function createNativeWindowSync(
 			render: finalRender,
 			autofocus: entry.autofocus,
 			ownerHandle: entry.ownerHandle || entry.scriptHandle,
+			...( params ? { params } : {} ),
 		} );
 	};
 
@@ -1241,7 +1271,10 @@ export function createNativeWindowSync(
 
 	const openById = (
 		id: string,
-		opts: { source?: string } = {},
+		opts: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		} = {},
 	): boolean => {
 		const entry = entriesById.get( id );
 		if ( ! entry ) {
@@ -1257,13 +1290,16 @@ export function createNativeWindowSync(
 			windowId: id,
 			source: opts.source ?? 'api',
 		} );
-		openFromEntry( entry );
+		openFromEntry( entry, opts.params );
 		return true;
 	};
 
 	const openNewById = (
 		id: string,
-		opts: { source?: string } = {},
+		opts: {
+			source?: string;
+			params?: Record< string, string | number | boolean >;
+		} = {},
 	): boolean => {
 		const entry = entriesById.get( id );
 		if ( ! entry ) {
@@ -1273,7 +1309,7 @@ export function createNativeWindowSync(
 			windowId: id,
 			source: opts.source ?? 'api',
 		} );
-		openNewFromEntry( entry );
+		openNewFromEntry( entry, opts.params );
 		return true;
 	};
 

--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -3054,7 +3054,10 @@ registry[ 'desktop-mode-users' ] = ( body: HTMLElement ) => {
 // viewer's own id) and sets the `user-id` attribute on the
 // component. Subsequent target changes flip the same attribute,
 // triggering an in-place re-mount.
-registry[ 'desktop-mode-user-edit' ] = ( body: HTMLElement ) => {
+registry[ 'desktop-mode-user-edit' ] = (
+	body: HTMLElement,
+	ctx?: { params?: Record< string, string | number | boolean > },
+) => {
 	const profile = body.querySelector(
 		'os-user-profile[data-os-user-profile-host]',
 	) as HTMLElement | null;
@@ -3064,6 +3067,17 @@ registry[ 'desktop-mode-user-edit' ] = ( body: HTMLElement ) => {
 	void import( './user-edit-target' ).then( ( target ) => {
 		const pending = target.readUserEditTarget();
 		let userId = pending.userId && pending.userId > 0 ? pending.userId : 0;
+		// The window's open-time params, which survive a reload — the
+		// shared store does not. Without this a session restored after
+		// F5 fell straight through to the `currentUserId` fallback and
+		// the window came back showing whoever was logged in rather
+		// than the person the user had open.
+		if ( userId <= 0 ) {
+			const fromParams = Number( ctx?.params?.userId ?? 0 );
+			if ( Number.isFinite( fromParams ) && fromParams > 0 ) {
+				userId = fromParams;
+			}
+		}
 		if ( userId <= 0 ) {
 			try {
 				userId =

--- a/src/posts-window/users-render.ts
+++ b/src/posts-window/users-render.ts
@@ -120,7 +120,13 @@ function openUserEditWindow( userId: number ): void {
 	const w = window as unknown as {
 		wp?: {
 			os?: {
-				openWindow?: ( id: string, opts?: { source?: string } ) => boolean;
+				openWindow?: (
+					id: string,
+					opts?: {
+						source?: string;
+						params?: Record< string, string | number | boolean >;
+					},
+				) => boolean;
 			};
 		};
 	};
@@ -147,6 +153,10 @@ function openUserEditWindow( userId: number ): void {
 	}
 	const opened = fn( 'desktop-mode-user-edit', {
 		source: 'users-window/row-click',
+		// Persisted with the session, so the window comes back on this
+		// person after a reload. The shared store above only carries
+		// the target for this page life.
+		...( userId > 0 ? { params: { userId } } : {} ),
 	} );
 	if ( ! opened ) {
 		// eslint-disable-next-line no-console

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,32 @@ export interface WindowConfig {
 	 */
 	ephemeral?: boolean;
 	/**
+	 * Open-time arguments for a **native** window — what it is showing
+	 * this time, as opposed to what it is.
+	 *
+	 * A native window is addressed by id, and its id is its identity:
+	 * `desktop-mode-user-edit` is "the profile editor", not "the
+	 * profile editor for user 12". Anything that varies per open has
+	 * nowhere else to live, and a module-level variable or a shared
+	 * store does not survive a reload — which is exactly how the
+	 * profile window used to come back showing whoever was logged in
+	 * rather than the person you had open.
+	 *
+	 * Params are part of the window's identity for persistence: they
+	 * are written into the session snapshot and staged back onto the
+	 * window when it is restored, so a native window reopens showing
+	 * the same thing.
+	 *
+	 * Keep them small and serializable — ids and slugs, not objects
+	 * and not functions. They go through `JSON.stringify` on the way
+	 * to the server. Values that aren't strings, finite numbers or
+	 * booleans are dropped on save rather than crashing it.
+	 *
+	 * Iframe windows don't need this: their URL already says what they
+	 * are showing, and it round-trips through the session on its own.
+	 */
+	params?: Record< string, string | number | boolean >;
+	/**
 	 * Per-window appearance overrides — themes (CSS variables),
 	 * controls (close / minimize / maximize layout + custom buttons),
 	 * slots (named title-bar regions), and chrome (full title-bar
@@ -645,6 +671,28 @@ export interface NativeRenderContext {
 	 * that were paused while hidden.
 	 */
 	onShow( cb: () => void ): () => void;
+
+	/**
+	 * The window's open-time arguments — what it is showing this
+	 * time. Empty object when the window was opened without any.
+	 *
+	 * A native window is addressed by id, so a singleton that
+	 * retargets (a profile editor, a customer window) has nowhere
+	 * else to put "which one". Read it here rather than from a
+	 * module-level variable: params are written into the session and
+	 * staged back on restore, so a window reopened after a reload
+	 * still knows what it was showing. A module variable does not
+	 * survive the reload, and the window silently changes subject.
+	 *
+	 * ```ts
+	 * render: ( body, { params } ) => {
+	 *     paint( body, Number( params.userId ) || 0 );
+	 * }
+	 * ```
+	 *
+	 * @see WindowConfig.params
+	 */
+	params: Record< string, string | number | boolean >;
 }
 
 /**
@@ -1460,6 +1508,15 @@ export interface SessionWindow {
 	 * Absent on plain admin-page windows.
 	 */
 	native?: boolean;
+	/**
+	 * A native window's open-time arguments — which user the profile
+	 * editor was showing, which customer the customer window was on.
+	 * Absent for iframe windows, whose URL already carries that, and
+	 * for native windows that take no arguments.
+	 *
+	 * See {@link WindowConfig.params}.
+	 */
+	params?: Record< string, string | number | boolean >;
 	url: string;
 	title: string;
 	icon: string;

--- a/src/wallpapers/vendor-loader.ts
+++ b/src/wallpapers/vendor-loader.ts
@@ -29,13 +29,22 @@ const pending = new Map<string, Promise<void>>();
  * time evaluates it a second time — which duplicates every hook
  * subscription the bundle registers.
  *
+ * Origin is part of the identity, though the query string isn't:
+ * `loadVendorScript` is public API and vendor bundles have generic
+ * paths, so two CDNs both serving `/dist/index.js` are two different
+ * bundles. Matching on pathname alone would silently swallow the
+ * second one.
+ *
  * @param url Candidate URL.
  * @return The existing tag, or `null`.
  */
 function findScriptByPath( url: string ): HTMLScriptElement | null {
+	let origin: string;
 	let path: string;
 	try {
-		path = new URL( url, document.baseURI ).pathname;
+		const parsed = new URL( url, document.baseURI );
+		origin = parsed.origin;
+		path = parsed.pathname;
 	} catch {
 		return null;
 	}
@@ -47,7 +56,11 @@ function findScriptByPath( url: string ): HTMLScriptElement | null {
 	);
 	for ( const tag of Array.from( tags ) ) {
 		try {
-			if ( new URL( tag.src, document.baseURI ).pathname === path ) {
+			const candidate = new URL( tag.src, document.baseURI );
+			if (
+				candidate.origin === origin &&
+				candidate.pathname === path
+			) {
 				return tag;
 			}
 		} catch {

--- a/src/wallpapers/vendor-loader.ts
+++ b/src/wallpapers/vendor-loader.ts
@@ -20,6 +20,44 @@
 const pending = new Map<string, Promise<void>>();
 
 /**
+ * Find a `<script src>` already in the document serving the same
+ * file, ignoring the query string.
+ *
+ * `wp_enqueue_script()` prints `…/desktop.min.js?ver=0.9.8` while a
+ * registry entry may hold the bare path or a different `ver`. Within
+ * one document those are the same bundle, and injecting it a second
+ * time evaluates it a second time — which duplicates every hook
+ * subscription the bundle registers.
+ *
+ * @param url Candidate URL.
+ * @return The existing tag, or `null`.
+ */
+function findScriptByPath( url: string ): HTMLScriptElement | null {
+	let path: string;
+	try {
+		path = new URL( url, document.baseURI ).pathname;
+	} catch {
+		return null;
+	}
+	if ( ! path ) {
+		return null;
+	}
+	const tags = document.querySelectorAll< HTMLScriptElement >(
+		'script[src]',
+	);
+	for ( const tag of Array.from( tags ) ) {
+		try {
+			if ( new URL( tag.src, document.baseURI ).pathname === path ) {
+				return tag;
+			}
+		} catch {
+			/* A malformed src can't match anything — skip it. */
+		}
+	}
+	return null;
+}
+
+/**
  * Inline `extra` data harvested from a registered WP script handle by
  * {@link openstation_resolve_script_payload} on the server. Without
  * this, the lazy-load path would silently drop everything attached
@@ -98,6 +136,39 @@ export function loadVendorScript(
 				() => reject( new Error( `Failed to load ${ url }` ) ),
 				{ once: true },
 			);
+			return;
+		}
+
+		// The page may already carry this file from
+		// `wp_enqueue_script()` — which is normal and expected the
+		// moment a plugin names an ALREADY-ENQUEUED handle as its
+		// native window's `script`. Those tags have no
+		// `data-os-vendor` marker, so the check above misses them and
+		// we would inject a second copy of the same bundle.
+		//
+		// A bundle evaluated twice registers every `addAction` /
+		// `addFilter` twice, and `@wordpress/hooks` appends rather
+		// than replaces on a repeated namespace — so every subscriber
+		// runs twice. It shows up as duplicated UI: two identical
+		// panels stacked in a folder, two badges on one tile. Nothing
+		// in the symptom points at script loading, which is what made
+		// it expensive to find.
+		//
+		// Matched on pathname rather than href: WordPress appends
+		// `?ver=…` and a caller may hold the same file with a
+		// different (or no) query. Within one document the path IS
+		// the identity of the bundle.
+		const alreadyInDocument = findScriptByPath( url );
+		if ( alreadyInDocument ) {
+			// Resolved rather than awaited. A tag the document
+			// printed for itself is the document's own ordering
+			// problem; ours is only to not print it twice. Waiting on
+			// a `load` that already fired would hang the sync
+			// forever, and the caller tolerates an absent render
+			// callback.
+			alreadyInDocument.dataset.osVendor = url;
+			alreadyInDocument.dataset.loaded = '1';
+			resolve();
 			return;
 		}
 

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -1725,6 +1725,15 @@ export class WindowManager {
 			const snap = w.getSnapshot();
 			const externalTabs = w.getExternalTabsSnapshot();
 			const native = !! w.config.native;
+			// Read once into a local rather than narrowing
+			// `w.config.params` and re-reading it inside a nested
+			// closure: property narrowing that has to survive a
+			// function boundary is a compile that works by accident.
+			const openParams = w.config.params;
+			const params =
+				native && openParams
+					? this.sanitizeParams( openParams )
+					: null;
 			return {
 				id: w.id,
 				baseId: w.config.baseId || w.id,
@@ -1735,12 +1744,7 @@ export class WindowManager {
 				// restores by id alone and comes back showing its default
 				// (the profile editor on whoever is logged in), which
 				// reads as the window silently changing subject.
-				...( native && w.config.params
-					? ( () => {
-						const params = this.sanitizeParams( w.config.params );
-						return params ? { params } : {};
-					} )()
-					: {} ),
+				...( params ? { params } : {} ),
 				// Native windows have no navigable URL — `config.url` is
 				// the `#slug` marker they were opened with, and
 				// `getCurrentUrl()` reads an iframe they don't have.

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -570,11 +570,24 @@ export class WindowManager {
 			// event is the unambiguous "open requested while already
 			// open" signal — fires exactly once per `open()` call on
 			// an existing instance.
+			// Retarget: a native singleton reopened with new params is
+			// being asked to show something else. Write them onto the
+			// live config BEFORE the reopen event so a subscriber can
+			// read `params` and repaint, and so the next session save
+			// records what the window is showing NOW rather than what
+			// it opened on. An argument-less reopen leaves the params
+			// alone — a dock click on an already-open profile window
+			// must not wipe whose profile it is.
+			if ( config.params ) {
+				existing.config.params = { ...config.params };
+			}
+
 			const reopenedDetail = {
 				windowId: existing.id,
 				baseId,
 				wasMinimized,
 				navigated,
+				params: existing.config.params ?? {},
 			};
 			document.dispatchEvent(
 				new CustomEvent( 'os-window-reopened', { detail: reopenedDetail } ),
@@ -1660,6 +1673,33 @@ export class WindowManager {
 	}
 
 	/**
+	 * Keep only what survives a round-trip through the session store.
+	 *
+	 * The snapshot is `JSON.stringify`d and POSTed, so a param holding
+	 * a DOM node, a function or a cyclic object would take the whole
+	 * save down with it — losing every window's geometry to one
+	 * plugin's careless value. Drop the offender, keep the session.
+	 *
+	 * @param params Raw params off the window config.
+	 * @return Serializable subset; `undefined` when nothing survives.
+	 */
+	private sanitizeParams(
+		params: Record< string, unknown >,
+	): Record< string, string | number | boolean > | undefined {
+		const out: Record< string, string | number | boolean > = {};
+		for ( const [ key, value ] of Object.entries( params ) ) {
+			if (
+				typeof value === 'string' ||
+				typeof value === 'boolean' ||
+				( typeof value === 'number' && Number.isFinite( value ) )
+			) {
+				out[ key ] = value;
+			}
+		}
+		return Object.keys( out ).length > 0 ? out : undefined;
+	}
+
+	/**
 	 * Serialize the current window stack for session persistence.
 	 *
 	 * Order in the returned `windows` array mirrors z-order (earliest
@@ -1690,6 +1730,17 @@ export class WindowManager {
 				baseId: w.config.baseId || w.id,
 				desktopId: w.config.desktopId || this._activeDesktopId,
 				...( native ? { native: true } : {} ),
+				// Open-time arguments — what a native window is showing
+				// this time. Without these a singleton native window
+				// restores by id alone and comes back showing its default
+				// (the profile editor on whoever is logged in), which
+				// reads as the window silently changing subject.
+				...( native && w.config.params
+					? ( () => {
+						const params = this.sanitizeParams( w.config.params );
+						return params ? { params } : {};
+					} )()
+					: {} ),
 				// Native windows have no navigable URL — `config.url` is
 				// the `#slug` marker they were opened with, and
 				// `getCurrentUrl()` reads an iframe they don't have.

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -694,7 +694,10 @@ export class Window {
 		// down + aborts the controller; we capture it on the
 		// instance so `close()` can fire it before the user-returned
 		// teardown runs.
-		const { ctx, dispose } = _buildNativeRenderContext( this.id );
+		const { ctx, dispose } = _buildNativeRenderContext(
+			this.id,
+			this.config.params ?? {},
+		);
 		this._nativeRenderCtxDispose = dispose;
 
 		// Capture the optional teardown returned by the render callback

--- a/tests/phpunit/tests/myWordpressUserSummaryPayload.php
+++ b/tests/phpunit/tests/myWordpressUserSummaryPayload.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * The per-user summary payload every user-shaped list row carries, and
+ * the grouped prefetch that keeps a page of them from costing two
+ * queries a row.
+ *
+ * The prefetch is the whole point of the file: a 100-row Customers
+ * page fired ~200 uncached queries before it existed. What has to
+ * hold is that the fast path and the slow path answer the *same*
+ * thing — a tile whose post count depends on how the page was loaded
+ * is worse than no count at all.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group desktop-mode-my-wordpress
+ */
+class Tests_OpenStation_MyWordpressUserSummaryPayload extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $author_id;
+	protected static $quiet_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$author_id = $factory->user->create( array( 'role' => 'author' ) );
+		self::$quiet_id  = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$factory->post->create(
+			array(
+				'post_author' => self::$author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+				'post_date'   => '2024-03-01 10:00:00',
+			)
+		);
+		$factory->post->create(
+			array(
+				'post_author' => self::$author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+				'post_date'   => '2024-06-01 10:00:00',
+			)
+		);
+		// Neither of these counts: a draft is not public, and a
+		// revision is not a page anyone wrote.
+		$factory->post->create(
+			array(
+				'post_author' => self::$author_id,
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+		$this->reset_prime_cache();
+	}
+
+	public function tear_down() {
+		$this->reset_prime_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * The prefetch store is a per-request static keyed by user id, and
+	 * PHPUnit runs many "requests" in one process. Overwriting the
+	 * ids under test with an empty row is enough to force the
+	 * un-primed path for the next assertion.
+	 *
+	 * @return void
+	 */
+	protected function reset_prime_cache() {
+		$cache = &openstation_my_wordpress_user_summary_cache();
+		$cache = array();
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_user_summary_payload
+	 */
+	public function test_the_payload_counts_public_posts_and_pages() {
+		$summary = openstation_my_wordpress_user_summary_payload( self::$author_id );
+
+		$this->assertSame( 2, $summary['postCount'] );
+		// The most recent of the two published dates, not the draft's.
+		$this->assertStringStartsWith( '2024-06-01', $summary['lastActive'] );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_user_summary_payload
+	 */
+	public function test_a_user_who_never_published_reads_as_zero_not_unknown() {
+		$summary = openstation_my_wordpress_user_summary_payload( self::$quiet_id );
+
+		$this->assertSame( 0, $summary['postCount'] );
+		$this->assertSame( '', $summary['lastActive'] );
+	}
+
+	/**
+	 * The contract that makes the prefetch safe to add: primed and
+	 * un-primed must be indistinguishable from the outside.
+	 *
+	 * @covers ::openstation_my_wordpress_user_summary_prime
+	 * @covers ::openstation_my_wordpress_user_summary_payload
+	 */
+	public function test_the_prefetch_answers_exactly_what_the_per_user_path_does() {
+		$ids = array( self::$admin_id, self::$author_id, self::$quiet_id );
+
+		$slow = array();
+		foreach ( $ids as $id ) {
+			$slow[ $id ] = openstation_my_wordpress_user_summary_payload( $id );
+		}
+
+		$this->reset_prime_cache();
+		openstation_my_wordpress_user_summary_prime( $ids );
+
+		$fast = array();
+		foreach ( $ids as $id ) {
+			$fast[ $id ] = openstation_my_wordpress_user_summary_payload( $id );
+		}
+
+		$this->assertSame( $slow, $fast );
+	}
+
+	/**
+	 * The reason the prefetch exists. Two grouped queries for the
+	 * whole page, not two per row.
+	 *
+	 * @covers ::openstation_my_wordpress_user_summary_prime
+	 */
+	public function test_priming_a_page_costs_the_same_as_priming_one_row() {
+		global $wpdb;
+
+		// Measured as "does the cost scale with the row count" rather
+		// than against a fixed number: the queries themselves are two,
+		// but the first `mysql2date()` of the process can warm an
+		// option, and pinning an absolute total would make this test
+		// about that instead.
+		$one = self::factory()->user->create();
+		self::factory()->post->create(
+			array(
+				'post_author' => $one,
+				'post_status' => 'publish',
+			)
+		);
+
+		$before = $wpdb->num_queries;
+		openstation_my_wordpress_user_summary_prime( array( $one ) );
+		$single = $wpdb->num_queries - $before;
+
+		$many = array();
+		for ( $i = 0; $i < 20; $i++ ) {
+			$id     = self::factory()->user->create();
+			$many[] = $id;
+			self::factory()->post->create(
+				array(
+					'post_author' => $id,
+					'post_status' => 'publish',
+				)
+			);
+		}
+
+		$before = $wpdb->num_queries;
+		openstation_my_wordpress_user_summary_prime( $many );
+		$batch = $wpdb->num_queries - $before;
+
+		$this->assertLessThanOrEqual(
+			$single,
+			$batch,
+			'the prefetch must be grouped — 20 rows cost no more than one'
+		);
+
+		// And the rows themselves are then free of the two lookups.
+		// `get_userdata()` may still hit the DB on a cold cache, so
+		// the bound is generous and still far below the 2-per-row it
+		// replaces.
+		$before = $wpdb->num_queries;
+		foreach ( $many as $id ) {
+			openstation_my_wordpress_user_summary_payload( $id );
+		}
+		$this->assertLessThan(
+			2 * count( $many ),
+			$wpdb->num_queries - $before,
+			'primed rows should not be re-querying post counts'
+		);
+	}
+
+	/**
+	 * A second prime for ids already held must not re-query them —
+	 * otherwise paging back and forth silently pays again.
+	 *
+	 * @covers ::openstation_my_wordpress_user_summary_prime
+	 */
+	public function test_priming_the_same_ids_twice_queries_once() {
+		global $wpdb;
+
+		openstation_my_wordpress_user_summary_prime( array( self::$author_id ) );
+
+		$before = $wpdb->num_queries;
+		openstation_my_wordpress_user_summary_prime( array( self::$author_id ) );
+
+		$this->assertSame( $before, $wpdb->num_queries );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_user_summary_prime
+	 */
+	public function test_priming_nothing_is_a_no_op() {
+		global $wpdb;
+
+		$before = $wpdb->num_queries;
+		openstation_my_wordpress_user_summary_prime( array() );
+		openstation_my_wordpress_user_summary_prime( array( 0, -3 ) );
+
+		$this->assertSame( $before, $wpdb->num_queries );
+	}
+
+	/**
+	 * The private half of the payload is capability-gated, and the
+	 * prefetch must not have become a way around that: it carries
+	 * counts and dates only.
+	 *
+	 * @covers ::openstation_my_wordpress_user_summary_payload
+	 */
+	public function test_a_subscriber_sees_counts_but_not_roles_or_registration() {
+		openstation_my_wordpress_user_summary_prime( array( self::$author_id ) );
+		wp_set_current_user( self::$quiet_id );
+
+		$summary = openstation_my_wordpress_user_summary_payload( self::$author_id );
+
+		$this->assertSame( 2, $summary['postCount'] );
+		$this->assertSame( array(), $summary['roleLabels'] );
+		$this->assertSame( '', $summary['registered'] );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_user_summary_payload
+	 */
+	public function test_an_administrator_sees_the_private_half() {
+		$summary = openstation_my_wordpress_user_summary_payload( self::$author_id );
+
+		$this->assertNotEmpty( $summary['roleLabels'] );
+		$this->assertNotSame( '', $summary['registered'] );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_user_summary_payload
+	 */
+	public function test_a_user_who_does_not_exist_returns_the_empty_shape() {
+		$summary = openstation_my_wordpress_user_summary_payload( 999999 );
+
+		$this->assertSame(
+			array(
+				'postCount'  => 0,
+				'roleLabels' => array(),
+				'registered' => '',
+				'lastActive' => '',
+			),
+			$summary
+		);
+	}
+}

--- a/tests/phpunit/tests/myWordpressWoocommerceCustomers.php
+++ b/tests/phpunit/tests/myWordpressWoocommerceCustomers.php
@@ -425,6 +425,60 @@ class Tests_OpenStation_MyWordpressWoocommerceCustomers extends WP_UnitTestCase 
 	}
 
 	// ────────────────────────────────────────────────────────────────
+	// Cache invalidation. The aggregate is a five-minute transient,
+	// so a lifecycle event nobody wired up doesn't fail — it just
+	// leaves a customer's spend and band wrong for five minutes,
+	// which reads as "the numbers are made up".
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * Every order lifecycle event that can move money must flush.
+	 * Untrash is the one that hides: it is not an update, nothing else
+	 * fires when it happens, and restoring a paid order has to put the
+	 * buyer's spend and band back.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_flush_customer_caches
+	 *
+	 * @dataProvider data_order_lifecycle_hooks
+	 *
+	 * @param string $hook Hook name.
+	 */
+	public function test_every_order_lifecycle_event_flushes_the_caches( $hook ) {
+		$this->assertSame(
+			10,
+			has_action( $hook, 'openstation_my_wordpress_woo_flush_customer_caches' ),
+			"{$hook} does not flush the customer caches"
+		);
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function data_order_lifecycle_hooks() {
+		return array(
+			array( 'woocommerce_new_order' ),
+			array( 'woocommerce_update_order' ),
+			array( 'woocommerce_order_status_changed' ),
+			array( 'woocommerce_delete_order' ),
+			array( 'woocommerce_trash_order' ),
+			array( 'woocommerce_untrash_order' ),
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_flush_customer_caches
+	 */
+	public function test_the_flush_drops_both_transients() {
+		set_transient( 'desktop_mode_woo_customer_spend', array( 'x' ), HOUR_IN_SECONDS );
+		set_transient( 'desktop_mode_woo_customer_plan', array( 'y' ), HOUR_IN_SECONDS );
+
+		openstation_my_wordpress_woo_flush_customer_caches();
+
+		$this->assertFalse( get_transient( 'desktop_mode_woo_customer_spend' ) );
+		$this->assertFalse( get_transient( 'desktop_mode_woo_customer_plan' ) );
+	}
+
+	// ────────────────────────────────────────────────────────────────
 	// Permissions. These rows are money AND people, so both gates
 	// have to hold independently.
 	// ────────────────────────────────────────────────────────────────

--- a/tests/phpunit/tests/myWordpressWoocommerceCustomers.php
+++ b/tests/phpunit/tests/myWordpressWoocommerceCustomers.php
@@ -1,0 +1,691 @@
+<?php
+/**
+ * Tests for the WooCommerce Customers section and the WooCommerce ×
+ * relations wiring.
+ *
+ * Same split as the rest of the integration's tests: everything that
+ * needs a live WooCommerce (order aggregates, summaries, `wc_price()`
+ * formatting) is covered by the manual QA checklist against a real
+ * store. What is tested here is what has to hold on a site *without*
+ * WooCommerce — which is every site by default — plus the pure banding
+ * and screen-resolution logic, which is where the bugs that reach a
+ * merchant actually live.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group desktop-mode-my-wordpress
+ */
+class Tests_OpenStation_MyWordpressWoocommerceCustomers extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'openstation_my_wordpress_entities' );
+		remove_all_filters( 'openstation_my_wordpress_woo_customer_bands' );
+		remove_all_filters( 'openstation_my_wordpress_woo_customer_band' );
+		remove_all_filters( 'openstation_my_wordpress_woo_vip_threshold' );
+		remove_all_filters( 'openstation_my_wordpress_woo_customer_lapse_days' );
+		remove_all_filters( 'openstation_my_wordpress_woo_summary_type' );
+		remove_all_filters( 'openstation_my_wordpress_woo_summary_capability' );
+		remove_all_filters( 'openstation_window_content_identity' );
+		remove_all_filters( 'openstation_window_related_entities' );
+		unset( $GLOBALS['pagenow'], $_GET['page'], $_GET['action'], $_GET['id'], $_GET['post'] );
+		parent::tear_down();
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Inert without WooCommerce. Every site starts here.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_entity
+	 */
+	public function test_no_customers_section_without_woocommerce() {
+		$entities = openstation_my_wordpress_woo_customer_entity( array() );
+
+		$this->assertSame( array(), $entities );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_entity
+	 */
+	public function test_customers_section_leaves_a_non_array_alone() {
+		$this->assertNull( openstation_my_wordpress_woo_customer_entity( null ) );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_register_customer_routes
+	 */
+	public function test_no_customer_routes_without_woocommerce() {
+		do_action( 'rest_api_init' );
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayNotHasKey( '/desktop-mode/v1/woocommerce/customers', $routes );
+	}
+
+	/**
+	 * The Customer window is never opened from a dock tile — "the
+	 * customer window" with no customer means nothing — so it must
+	 * not register one, and on a site without WooCommerce it must not
+	 * register at all.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_customer_window_register
+	 */
+	public function test_no_customer_window_without_woocommerce() {
+		openstation_my_wordpress_woo_customer_window_register();
+
+		$this->assertArrayNotHasKey(
+			'desktop-mode-woo-customer',
+			(array) openstation_native_window_registry()
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_window_template
+	 */
+	public function test_the_customer_window_template_keeps_its_mount_point() {
+		ob_start();
+		openstation_my_wordpress_woo_customer_window_template();
+		$html = (string) ob_get_clean();
+
+		// The render callback mounts into this attribute; kses
+		// stripping it would leave a window that paints nothing.
+		$this->assertStringContainsString( 'data-os-woo-customer-root', $html );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_related_entities
+	 */
+	public function test_relations_are_inert_without_woocommerce() {
+		$related = openstation_my_wordpress_woo_related_entities(
+			array( 'sentinel' ),
+			array(
+				'type' => 'shop_order',
+				'id'   => 7,
+			),
+			null
+		);
+
+		$this->assertSame( array( 'sentinel' ), $related );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_content_identity
+	 */
+	public function test_identity_is_untouched_without_woocommerce() {
+		$identity = array(
+			'type' => 'post',
+			'id'   => 3,
+		);
+
+		$this->assertSame(
+			$identity,
+			openstation_my_wordpress_woo_content_identity( $identity, null )
+		);
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// The reviews screen. A tie needs BOTH windows to have an
+	// identity, and WooCommerce moved reviews off `edit-comments.php`
+	// onto its own admin page — which the built-in detection has no
+	// reason to know about. Without this the Reviews item opened a
+	// window that drew no connection to the product it came from
+	// while every other item in the same menu did.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_reviews_identity
+	 */
+	public function test_the_reviews_screen_roots_at_its_product() {
+		// Registered for real: the identity gates on
+		// `current_user_can( 'edit_post', … )`, and `map_meta_cap`
+		// can't map that reliably for an unregistered type.
+		register_post_type(
+			'product',
+			array(
+				'public'  => true,
+				'show_ui' => true,
+			)
+		);
+		$product_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'product',
+				'post_title' => 'Hiking Boots',
+			)
+		);
+
+		$GLOBALS['pagenow']  = 'edit.php';
+		$_GET['page']        = 'product-reviews';
+		$_GET['product_id']  = (string) $product_id;
+
+		$identity = openstation_my_wordpress_woo_reviews_identity();
+
+		$this->assertSame( 'reviews', $identity['type'] );
+		$this->assertSame( $product_id, $identity['id'] );
+		$this->assertSame(
+			array(
+				'type' => 'product',
+				'id'   => $product_id,
+			),
+			$identity['root']
+		);
+		$this->assertStringContainsString( 'Hiking Boots', $identity['label'] );
+
+		unset( $_GET['page'], $_GET['product_id'] );
+		unregister_post_type( 'product' );
+	}
+
+	/**
+	 * A window showing everything belongs to nothing in particular —
+	 * the same reason core leaves the unfiltered comments list
+	 * identity-less.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_reviews_identity
+	 */
+	public function test_the_unfiltered_reviews_list_has_no_identity() {
+		$GLOBALS['pagenow'] = 'edit.php';
+		$_GET['page']       = 'product-reviews';
+
+		$this->assertNull( openstation_my_wordpress_woo_reviews_identity() );
+
+		unset( $_GET['page'] );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_reviews_identity
+	 */
+	public function test_another_edit_screen_is_not_mistaken_for_reviews() {
+		$GLOBALS['pagenow'] = 'edit.php';
+
+		$this->assertNull( openstation_my_wordpress_woo_reviews_identity() );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_current_order
+	 */
+	public function test_no_current_order_without_woocommerce() {
+		$GLOBALS['pagenow'] = 'admin.php';
+		$_GET['page']       = 'wc-orders';
+		$_GET['action']     = 'edit';
+		$_GET['id']         = '42';
+
+		$this->assertNull( openstation_my_wordpress_woo_current_order() );
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Banding. Pure logic over an aggregate row — and the part a
+	// merchant sees first, because it decides what floats to the top
+	// of the folder.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_band_defs
+	 */
+	public function test_bands_lead_with_the_two_actionable_ones() {
+		$ids = wp_list_pluck( openstation_my_wordpress_woo_customer_band_defs(), 'id' );
+
+		// VIP is who to look after, lapsed is who to win back. Both
+		// come before the bands that are only context.
+		$this->assertSame( array( 'vip', 'lapsed', 'repeat', 'new', 'none' ), $ids );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_a_customer_with_no_orders_is_unbanded() {
+		$this->assertSame(
+			'none',
+			openstation_my_wordpress_woo_customer_band_id(
+				array(
+					'orders' => 0,
+					'spend'  => 0.0,
+					'last'   => '',
+				)
+			)
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_one_recent_order_is_new() {
+		$this->assertSame(
+			'new',
+			openstation_my_wordpress_woo_customer_band_id(
+				array(
+					'orders' => 1,
+					'spend'  => 10.0,
+					'last'   => gmdate( 'Y-m-d H:i:s' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_two_recent_orders_are_repeat() {
+		$this->assertSame(
+			'repeat',
+			openstation_my_wordpress_woo_customer_band_id(
+				array(
+					'orders' => 2,
+					'spend'  => 20.0,
+					'last'   => gmdate( 'Y-m-d H:i:s' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_an_old_last_order_is_lapsed() {
+		$this->assertSame(
+			'lapsed',
+			openstation_my_wordpress_woo_customer_band_id(
+				array(
+					'orders' => 4,
+					'spend'  => 40.0,
+					'last'   => gmdate( 'Y-m-d H:i:s', time() - ( 400 * DAY_IN_SECONDS ) ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * VIP wins over lapsed deliberately: a big spender who has gone
+	 * quiet is still the first row you want to see, and the
+	 * days-since line in the pane says the rest.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_vip_outranks_lapsed() {
+		add_filter(
+			'openstation_my_wordpress_woo_vip_threshold',
+			static function () {
+				return 100.0;
+			}
+		);
+
+		$this->assertSame(
+			'vip',
+			openstation_my_wordpress_woo_customer_band_id(
+				array(
+					'orders' => 3,
+					'spend'  => 500.0,
+					'last'   => gmdate( 'Y-m-d H:i:s', time() - ( 400 * DAY_IN_SECONDS ) ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * A store with no paid orders has an average order value of zero,
+	 * and three times zero is zero — which would make every customer
+	 * a VIP if the threshold weren't floored.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_a_zero_threshold_promotes_nobody() {
+		add_filter(
+			'openstation_my_wordpress_woo_vip_threshold',
+			static function () {
+				return 0.0;
+			}
+		);
+
+		$this->assertSame(
+			'new',
+			openstation_my_wordpress_woo_customer_band_id(
+				array(
+					'orders' => 1,
+					'spend'  => 0.0,
+					'last'   => gmdate( 'Y-m-d H:i:s' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_lapse_days
+	 */
+	public function test_the_lapse_window_is_filterable_and_floored() {
+		$this->assertSame( 180, openstation_my_wordpress_woo_customer_lapse_days() );
+
+		add_filter(
+			'openstation_my_wordpress_woo_customer_lapse_days',
+			static function () {
+				return 0;
+			}
+		);
+
+		// A zero-day window would make every customer lapsed the
+		// moment they ordered.
+		$this->assertSame( 1, openstation_my_wordpress_woo_customer_lapse_days() );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_band_id
+	 */
+	public function test_the_band_is_filterable() {
+		add_filter(
+			'openstation_my_wordpress_woo_customer_band',
+			static function () {
+				return 'wholesale';
+			}
+		);
+
+		$this->assertSame(
+			'wholesale',
+			openstation_my_wordpress_woo_customer_band_id( array( 'orders' => 1 ) )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_days_since
+	 */
+	public function test_days_since_reads_a_gmt_datetime() {
+		$this->assertNull( openstation_my_wordpress_woo_customer_days_since( '' ) );
+		$this->assertNull( openstation_my_wordpress_woo_customer_days_since( 'not a date' ) );
+		$this->assertSame(
+			0,
+			openstation_my_wordpress_woo_customer_days_since( gmdate( 'Y-m-d H:i:s' ) )
+		);
+		$this->assertSame(
+			10,
+			openstation_my_wordpress_woo_customer_days_since(
+				gmdate( 'Y-m-d H:i:s', time() - ( 10 * DAY_IN_SECONDS ) )
+			)
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_paid_statuses
+	 */
+	public function test_paid_statuses_carry_the_wc_prefix() {
+		$statuses = openstation_my_wordpress_woo_paid_statuses();
+
+		$this->assertContains( 'wc-completed', $statuses );
+		$this->assertContains( 'wc-processing', $statuses );
+		foreach ( $statuses as $status ) {
+			$this->assertStringStartsWith( 'wc-', $status );
+		}
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Permissions. These rows are money AND people, so both gates
+	// have to hold independently.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customers_permission
+	 */
+	public function test_a_subscriber_may_not_see_customers() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertWPError( openstation_my_wordpress_woo_customers_permission() );
+	}
+
+	/**
+	 * An editor can moderate comments and edit everybody's posts, and
+	 * still has no business reading what anyone spent.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_customers_permission
+	 */
+	public function test_an_editor_may_not_see_customers() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertWPError( openstation_my_wordpress_woo_customers_permission() );
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// The summary route's extension seams. The Customers surface is
+	// the first consumer, so these hold the contract a third party
+	// would use for a subscription or a booking.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_summary
+	 */
+	public function test_an_unknown_summary_type_still_answers_400() {
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/woocommerce/summary/nonsense/1' );
+		$request->set_param( 'type', 'nonsense' );
+		$request->set_param( 'id', 1 );
+
+		$result = openstation_my_wordpress_woo_summary( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'openstation_woo_bad_type', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_summary
+	 */
+	public function test_a_filter_can_add_a_summary_type() {
+		add_filter(
+			'openstation_my_wordpress_woo_summary_type',
+			static function ( $data, $type, $id ) {
+				return 'booking' === $type
+					? array(
+						'type' => 'booking',
+						'id'   => $id,
+					)
+					: $data;
+			},
+			10,
+			3
+		);
+
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/woocommerce/summary/booking/9' );
+		$request->set_param( 'type', 'booking' );
+		$request->set_param( 'id', 9 );
+
+		$response = openstation_my_wordpress_woo_summary( $request );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( 'booking', $response->get_data()['type'] );
+		$this->assertSame( 9, $response->get_data()['id'] );
+	}
+
+	/**
+	 * The generic fallback checks `edit_post` against the id, which
+	 * for a user id means nothing — a type added through the seam has
+	 * to answer for itself.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_summary_permission
+	 */
+	public function test_a_filter_can_gate_its_own_summary_type() {
+		add_filter(
+			'openstation_my_wordpress_woo_summary_capability',
+			static function ( $allowed, $type ) {
+				return 'booking' === $type
+					? new WP_Error( 'nope', 'No.', array( 'status' => 403 ) )
+					: $allowed;
+			},
+			10,
+			2
+		);
+
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/woocommerce/summary/booking/9' );
+		$request->set_param( 'type', 'booking' );
+		$request->set_param( 'id', 9 );
+
+		$this->assertWPError( openstation_my_wordpress_woo_summary_permission( $request ) );
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Screen resolution. HPOS moves the order editor somewhere the
+	// built-in `post.php` detection can never see it, so this is the
+	// only thing standing between an order window and no relations
+	// at all.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_customer_orders_url
+	 */
+	public function test_orders_url_points_at_the_legacy_list_without_hpos() {
+		$url = openstation_my_wordpress_woo_customer_orders_url( 12 );
+
+		$this->assertStringContainsString( 'post_type=shop_order', $url );
+		$this->assertStringContainsString( '_customer_user=12', $url );
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_hpos_enabled
+	 */
+	public function test_hpos_is_off_without_woocommerce() {
+		$this->assertFalse( openstation_my_wordpress_woo_hpos_enabled() );
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Reverse lookups. An order names its products, so order →
+	// product has always worked; the reverse — "is this selling, and
+	// to whom?" — is the question a merchant actually asks, and the
+	// catalogue screen has no answer at all.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_orders_with_product
+	 */
+	public function test_orders_with_product_rejects_a_bad_id() {
+		$this->assertSame(
+			array(),
+			openstation_my_wordpress_woo_orders_with_product( 0 )
+		);
+		$this->assertSame(
+			array(),
+			openstation_my_wordpress_woo_orders_with_product( -5 )
+		);
+	}
+
+	/**
+	 * The order-items tables exist on any WooCommerce install and are
+	 * populated under BOTH storages — HPOS moves the order rows, not
+	 * the line items. On a site without WooCommerce they don't exist,
+	 * and the lookup must come back empty rather than fatal.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_orders_with_product
+	 */
+	public function test_orders_with_product_is_empty_without_the_tables() {
+		$this->assertSame(
+			array(),
+			openstation_my_wordpress_woo_orders_with_product( 42 )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_orders_with_coupon
+	 */
+	public function test_orders_with_coupon_rejects_an_empty_code() {
+		$this->assertSame(
+			array(),
+			openstation_my_wordpress_woo_orders_with_coupon( '' )
+		);
+		$this->assertSame(
+			array(),
+			openstation_my_wordpress_woo_orders_with_coupon( '   ' )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_coupons_for_product
+	 */
+	public function test_coupons_for_product_rejects_a_bad_id() {
+		$this->assertSame(
+			array(),
+			openstation_my_wordpress_woo_coupons_for_product( 0 )
+		);
+	}
+
+	/**
+	 * The restriction meta is a comma-joined id string, so it cannot
+	 * be searched with a meta query — `LIKE '%12%'` matches 112 and
+	 * 121. The rows are read and split in PHP instead, and this pins
+	 * that a near-miss id doesn't match.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_coupons_for_product
+	 */
+	public function test_coupons_for_product_does_not_match_a_substring_id() {
+		$coupon_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'shop_coupon',
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $coupon_id, 'product_ids', '112,121,1212' );
+
+		// 12 is a substring of every stored id and a member of none.
+		$this->assertNotContains(
+			$coupon_id,
+			openstation_my_wordpress_woo_coupons_for_product( 12 )
+		);
+		$this->assertContains(
+			$coupon_id,
+			openstation_my_wordpress_woo_coupons_for_product( 121 )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_my_wordpress_woo_related_item
+	 */
+	public function test_a_related_item_omits_a_zero_count() {
+		$item = openstation_my_wordpress_woo_related_item(
+			'x',
+			'g',
+			'Group',
+			'Label',
+			'dashicons-cart',
+			'https://example.org/wp-admin/',
+			0
+		);
+
+		$this->assertArrayNotHasKey( 'count', $item );
+
+		$counted = openstation_my_wordpress_woo_related_item(
+			'x',
+			'g',
+			'Group',
+			'Label',
+			'dashicons-cart',
+			'https://example.org/wp-admin/',
+			3
+		);
+
+		$this->assertSame( 3, $counted['count'] );
+	}
+
+	/**
+	 * Every field the shell's sanitizer demands, or the whole
+	 * identity is discarded client-side — one malformed item costs
+	 * the window its relations, not just its own row.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_related_item
+	 */
+	public function test_a_related_item_carries_every_required_field() {
+		$item = openstation_my_wordpress_woo_related_item(
+			'wc-product-5',
+			'wc-products',
+			'Products',
+			'Blue hat',
+			'dashicons-products',
+			'https://example.org/wp-admin/post.php?post=5&action=edit'
+		);
+
+		foreach ( array( 'id', 'group', 'label', 'url' ) as $required ) {
+			$this->assertArrayHasKey( $required, $item );
+			$this->assertNotSame( '', trim( $item[ $required ] ) );
+		}
+	}
+}

--- a/tests/phpunit/tests/openStationSession.php
+++ b/tests/phpunit/tests/openStationSession.php
@@ -210,6 +210,121 @@ class Tests_OpenStation_Session extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A native window is addressed by id, and its id is its identity:
+	 * `desktop-mode-user-edit` is "the profile editor", not "the
+	 * profile editor for user 12". Params are the only record of WHAT
+	 * it was showing — drop them here and the window restores onto its
+	 * default: the profile window comes back on whoever is logged in,
+	 * the customer window comes back empty.
+	 *
+	 * @covers ::openstation_sanitize_session
+	 */
+	public function test_sanitize_keeps_native_window_params() {
+		$clean = openstation_sanitize_session(
+			array(
+				'desktops'      => array( array( 'id' => 'desktop-1', 'label' => 'A' ) ),
+				'activeDesktop' => 'desktop-1',
+				'windows'       => array(
+					array(
+						'id'     => 'desktop-mode-woo-customer',
+						'native' => true,
+						'url'    => '#desktop-mode-woo-customer',
+						'title'  => 'Customer',
+						'icon'   => 'dashicons-businessperson',
+						'state'  => 'normal',
+						'params' => array(
+							'customerId'   => 7,
+							'customerName' => 'Ada Lovelace',
+							'compact'      => true,
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'customerId'   => 7,
+				'customerName' => 'Ada Lovelace',
+				'compact'      => true,
+			),
+			$clean['windows'][0]['params']
+		);
+	}
+
+	/**
+	 * An iframe window's URL already says what it is showing and
+	 * round-trips on its own, so params on one are noise.
+	 *
+	 * @covers ::openstation_sanitize_session
+	 */
+	public function test_sanitize_drops_params_from_iframe_windows() {
+		$clean = openstation_sanitize_session(
+			array(
+				'desktops'      => array( array( 'id' => 'desktop-1', 'label' => 'A' ) ),
+				'activeDesktop' => 'desktop-1',
+				'windows'       => array(
+					$this->make_window(
+						array( 'params' => array( 'customerId' => 7 ) )
+					),
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'params', $clean['windows'][0] );
+	}
+
+	/**
+	 * Params come from the client, so they are untrusted and
+	 * unbounded. Scalars only, capped in count and in string length —
+	 * the session blob is not a data store.
+	 *
+	 * @covers ::openstation_sanitize_session_params
+	 */
+	public function test_sanitize_params_keeps_only_bounded_scalars() {
+		$clean = openstation_sanitize_session_params(
+			array(
+				'customerId' => 7,
+				'ratio'      => 1.5,
+				'flag'       => false,
+				'nested'     => array( 'no' => 'thanks' ),
+				'null'       => null,
+				'long'       => str_repeat( 'x', 400 ),
+			)
+		);
+
+		$this->assertSame( 7, $clean['customerId'] );
+		$this->assertSame( 1.5, $clean['ratio'] );
+		$this->assertFalse( $clean['flag'] );
+		$this->assertArrayNotHasKey( 'nested', $clean );
+		$this->assertArrayNotHasKey( 'null', $clean );
+		$this->assertSame( 256, strlen( $clean['long'] ) );
+	}
+
+	/**
+	 * @covers ::openstation_sanitize_session_params
+	 */
+	public function test_sanitize_params_caps_the_key_count() {
+		$many = array();
+		for ( $i = 0; $i < 40; $i++ ) {
+			$many[ 'k' . $i ] = $i;
+		}
+
+		$this->assertCount(
+			OPENSTATION_SESSION_MAX_PARAMS,
+			openstation_sanitize_session_params( $many )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_sanitize_session_params
+	 */
+	public function test_sanitize_params_tolerates_a_non_array() {
+		$this->assertSame( array(), openstation_sanitize_session_params( null ) );
+		$this->assertSame( array(), openstation_sanitize_session_params( 'nope' ) );
+	}
+
+	/**
 	 * The stored marker is built from the sanitized id, never from
 	 * the client's `url`. Nothing navigates to it, so there's no
 	 * reason to round-trip a client-controlled string through user

--- a/tests/phpunit/tests/windowLinks.php
+++ b/tests/phpunit/tests/windowLinks.php
@@ -29,7 +29,7 @@ class Tests_OpenStation_WindowLinks extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		unset( $_GET['c'], $_GET['item'], $_GET['tag_ID'], $GLOBALS['pagenow'], $GLOBALS['post'] );
+		unset( $_GET['c'], $_GET['item'], $_GET['tag_ID'], $_GET['user_id'], $GLOBALS['pagenow'], $GLOBALS['post'] );
 		remove_all_filters( 'openstation_window_content_identity' );
 		remove_all_filters( 'openstation_window_preview_url' );
 		parent::tear_down();
@@ -454,6 +454,70 @@ class Tests_OpenStation_WindowLinks extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'root', $identity );
 
 		unset( $_GET['tag_ID'] );
+	}
+
+	// ────────────────────────────────────────────────────────────────
+	// Profile screens. A person is a root identity: an order's
+	// customer, a post's author and a comment's writer all point AT
+	// them from their own `links`, so an open profile window ties to
+	// whatever else on the desktop is about that person.
+	// ────────────────────────────────────────────────────────────────
+
+	/**
+	 * @covers ::openstation_build_content_identity
+	 */
+	public function test_user_edit_screen_yields_a_user_identity() {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'         => 'subscriber',
+				'display_name' => 'Ada Lovelace',
+			)
+		);
+
+		$GLOBALS['pagenow'] = 'user-edit.php';
+		$_GET['user_id']    = (string) $user_id;
+		set_current_screen( 'user-edit' );
+
+		$identity = openstation_build_content_identity();
+
+		$this->assertSame( 'user', $identity['type'] );
+		$this->assertSame( $user_id, $identity['id'] );
+		$this->assertSame( 'Ada Lovelace', $identity['label'] );
+		$this->assertArrayNotHasKey( 'root', $identity );
+	}
+
+	/**
+	 * `profile.php` carries no `user_id` — it is always your own.
+	 *
+	 * @covers ::openstation_build_content_identity
+	 */
+	public function test_profile_screen_identifies_the_current_user() {
+		$GLOBALS['pagenow'] = 'profile.php';
+		set_current_screen( 'profile' );
+
+		$identity = openstation_build_content_identity();
+
+		$this->assertSame( 'user', $identity['type'] );
+		$this->assertSame( self::$admin_id, $identity['id'] );
+	}
+
+	/**
+	 * No identity for a person the viewer may not edit — announcing
+	 * one would leak the display name of every account on the site to
+	 * anyone who can guess a URL.
+	 *
+	 * @covers ::openstation_build_content_identity
+	 */
+	public function test_user_edit_screen_respects_the_capability() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$other_id  = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $editor_id );
+
+		$GLOBALS['pagenow'] = 'user-edit.php';
+		$_GET['user_id']    = (string) $other_id;
+		set_current_screen( 'user-edit' );
+
+		$this->assertNull( openstation_build_content_identity() );
 	}
 
 	// ────────────────────────────────────────────────────────────────

--- a/tests/vitest/my-wordpress-woocommerce.test.ts
+++ b/tests/vitest/my-wordpress-woocommerce.test.ts
@@ -21,7 +21,11 @@ import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
 import { applyFilters, doAction } from '../../src/hooks';
 import {
 	bindNativeUrlRemap,
+	isPersonViewClaimed,
+	listNativeUrlRemaps,
+	registerNativeUrlRemap,
 	tryNativeUrlRemap,
+	unregisterNativeUrlRemap,
 } from '../../src/native-url-remap';
 import type { OsSettingsSnapshot } from '../../src/settings/registry';
 
@@ -681,6 +685,79 @@ describe( 'my-wordpress — WooCommerce integration', () => {
 			);
 		} );
 
+		test( 'both halves of the hand-off registered: the claim wins, the profile stands down', () => {
+			// The two entries are tested apart everywhere else, which
+			// can't catch the failure that matters: both registered,
+			// and the built-in profile remap claiming the marked URL
+			// because it comes first in the walk. So the profile entry
+			// is put in FRONT of the Customer claim here — the least
+			// favourable order, and the only one that proves the
+			// stand-down is doing the work rather than luck.
+			const openById = vi.fn().mockReturnValue( true );
+			const profileMatches = vi.fn( ( _url: string, parsed: URL ) => {
+				if ( isPersonViewClaimed( parsed ) ) {
+					return false;
+				}
+				return (
+					parsed.pathname.endsWith( '/profile.php' ) ||
+					( parsed.pathname.endsWith( '/user-edit.php' ) &&
+						parsed.searchParams.has( 'user_id' ) )
+				);
+			} );
+
+			const claim = listNativeUrlRemaps().find(
+				( r ) => r.id === 'desktop-mode/woo-customer',
+			);
+			expect( claim ).toBeDefined();
+			// Re-registering appends, so dropping and re-adding the
+			// claim is how it ends up behind the profile entry.
+			unregisterNativeUrlRemap( 'desktop-mode/woo-customer' );
+			registerNativeUrlRemap( {
+				id: 'desktop-mode-user-edit',
+				nativeWindowId: 'desktop-mode-user-edit',
+				matches: profileMatches,
+			} );
+			registerNativeUrlRemap( claim! );
+
+			try {
+				bindNativeUrlRemap( {
+					getSnapshot: () => ( {} as OsSettingsSnapshot ),
+					openById,
+					adminUrl: 'http://example.test/wp-admin/',
+				} );
+
+				// Marked: the profile remap is consulted first and
+				// must decline, leaving the Customer window to claim.
+				expect(
+					tryNativeUrlRemap(
+						'http://example.test/wp-admin/user-edit.php?user_id=11&os_person_view=wc-customer',
+					),
+				).toBe( true );
+				expect( profileMatches ).toHaveBeenCalled();
+				expect( openById ).toHaveBeenCalledWith(
+					'desktop-mode-woo-customer',
+					{ params: { customerId: 11 } },
+				);
+
+				// Unmarked: the same URL without the marker is still
+				// the profile editor's. A stand-down that swallowed
+				// every person-URL would be the opposite bug.
+				openById.mockClear();
+				expect(
+					tryNativeUrlRemap(
+						'http://example.test/wp-admin/user-edit.php?user_id=11',
+					),
+				).toBe( true );
+				// One argument: the opener is called without a trailing
+				// `undefined` when a remap declares no params.
+				expect( openById ).toHaveBeenCalledWith(
+					'desktop-mode-user-edit',
+				);
+			} finally {
+				unregisterNativeUrlRemap( 'desktop-mode-user-edit' );
+			}
+		} );
+
 		test( 'an unmarked person-URL is left to the profile editor', () => {
 			const openById = vi.fn().mockReturnValue( true );
 			bindNativeUrlRemap( {
@@ -747,6 +824,186 @@ describe( 'my-wordpress — WooCommerce integration', () => {
 				'desktop-mode-woo-customer',
 				expect.objectContaining( { type: 'user', id: 11 } ),
 			);
+		} );
+
+		test( 'a retarget beats a slow response for the customer it replaced', async () => {
+			// The window is a retargetable singleton: clicking a
+			// second customer repaints the same root while the first
+			// summary may still be in flight. `root.isConnected` can't
+			// see that — same node, still connected — so a slow first
+			// response would land last and quietly put the window back
+			// on the person the user just navigated away from.
+			const bodies: Record< string, () => void > = {};
+			vi.stubGlobal(
+				'fetch',
+				vi.fn( ( url: string ) =>
+					new Promise< Response >( ( resolve ) => {
+						const id = url.includes( '/11' ) ? '11' : '22';
+						bodies[ id ] = () =>
+							resolve(
+								new Response(
+									JSON.stringify( {
+										name:
+											'11' === id
+												? 'Ada'
+												: 'Grace',
+										email: '',
+										spend: '£1.00',
+										orders: 1,
+										band: 'new',
+										bandLabel: 'New',
+										firstOrder: '',
+										lastOrder: '',
+										daysSince: null,
+										lastOrderNo: '',
+										lastOrderUrl: '',
+										lastOrderTotal: '',
+										favourite: null,
+										location: '',
+										registered: '',
+										ordersUrl: '',
+										profileUrl: '',
+										recent: [],
+										billing: '',
+										shipping: '',
+									} ),
+									{
+										status: 200,
+										headers: {
+											'Content-Type':
+												'application/json',
+										},
+									},
+								),
+							);
+					} ),
+				),
+			);
+
+			const root = document.createElement( 'div' );
+			root.id = 'wp-window-desktop-mode-woo-customer';
+			const body = document.createElement( 'div' );
+			const mount = document.createElement( 'div' );
+			mount.setAttribute( 'data-os-woo-customer-root', '' );
+			body.appendChild( mount );
+			root.appendChild( body );
+			document.body.appendChild( root );
+
+			const render = (
+				window as unknown as {
+					openStationNativeWindows: Record<
+						string,
+						(
+							body: HTMLElement,
+							ctx?: {
+								params?: Record<
+									string,
+									string | number | boolean
+								>;
+							},
+						) => unknown
+					>;
+				}
+			 ).openStationNativeWindows[ 'desktop-mode-woo-customer' ];
+
+			render( body, {
+				params: { customerId: 11, customerName: 'Ada' },
+			} );
+			// Retarget before the first request answers.
+			document.dispatchEvent(
+				new CustomEvent( 'os-window-reopened', {
+					detail: {
+						windowId: 'desktop-mode-woo-customer',
+						params: { customerId: 22, customerName: 'Grace' },
+					},
+				} ),
+			);
+
+			await vi.waitFor( () => {
+				if ( ! bodies[ '11' ] || ! bodies[ '22' ] ) {
+					throw new Error( 'requests not issued yet' );
+				}
+			} );
+
+			// Second customer answers first, then the abandoned one.
+			bodies[ '22' ]();
+			await vi.waitFor( () => {
+				if ( mount.dataset.customerId !== '22' ) {
+					throw new Error( 'second paint not applied' );
+				}
+			} );
+			// Let the abandoned response run all the way through
+			// `fetch` → `json()` → paint. If it is going to overwrite
+			// the window, it has had every chance to.
+			bodies[ '11' ]();
+			for ( let i = 0; i < 5; i++ ) {
+				await new Promise( ( r ) => setTimeout( r, 0 ) );
+			}
+
+			expect( mount.dataset.customerId ).toBe( '22' );
+			expect( mount.textContent ).toContain( 'Grace' );
+			expect( mount.textContent ).not.toContain( 'Ada' );
+		} );
+
+		test( 'a capped store says the bands were not counted, not zero', async () => {
+			stubSummary( {
+				revenue: '£10.00',
+				processing: 0,
+				outOfStock: 0,
+				customers: 40000,
+				bandsCapped: true,
+			} );
+
+			const container = document.createElement( 'div' );
+			document.body.appendChild( container );
+			doAction( 'os.my-wordpress.group-extras', {
+				container,
+				groupId: 'plugin:woocommerce',
+				entityIds: [ CUSTOMERS ],
+			} );
+
+			await vi.waitFor( () => {
+				const panel = container.querySelector( '.os-woo-panel' );
+				if ( ! panel || panel.hasAttribute( 'aria-busy' ) ) {
+					throw new Error( 'panel still loading' );
+				}
+			} );
+
+			// Past the cap the server never computed the bands. "0 · 0"
+			// would be a wrong answer stated confidently.
+			expect( container.textContent ).toContain( 'Not counted' );
+			expect( container.textContent ).not.toContain( '0 · 0' );
+		} );
+
+		test( 'an uncapped store with no VIPs omits the row entirely', async () => {
+			stubSummary( {
+				revenue: '£10.00',
+				processing: 0,
+				outOfStock: 0,
+				customers: 3,
+				vips: 0,
+				lapsed: 0,
+			} );
+
+			const container = document.createElement( 'div' );
+			document.body.appendChild( container );
+			doAction( 'os.my-wordpress.group-extras', {
+				container,
+				groupId: 'plugin:woocommerce',
+				entityIds: [ CUSTOMERS ],
+			} );
+
+			await vi.waitFor( () => {
+				const panel = container.querySelector( '.os-woo-panel' );
+				if ( ! panel || panel.hasAttribute( 'aria-busy' ) ) {
+					throw new Error( 'panel still loading' );
+				}
+			} );
+
+			// Genuinely none is a different statement from unknown,
+			// and neither is worth a row.
+			expect( container.textContent ).not.toContain( 'VIP · lapsed' );
+			expect( container.textContent ).not.toContain( 'Not counted' );
 		} );
 
 		test( 'the customers dossier drops the author sections', () => {

--- a/tests/vitest/my-wordpress-woocommerce.test.ts
+++ b/tests/vitest/my-wordpress-woocommerce.test.ts
@@ -19,8 +19,14 @@ import {
 } from 'vitest';
 import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
 import { applyFilters, doAction } from '../../src/hooks';
+import {
+	bindNativeUrlRemap,
+	tryNativeUrlRemap,
+} from '../../src/native-url-remap';
+import type { OsSettingsSnapshot } from '../../src/settings/registry';
 
 const PRODUCTS = 'cpt-product';
+const CUSTOMERS = 'wc-customers';
 
 interface WooGlobal {
 	openStationWooConfig?: Record< string, unknown >;
@@ -31,6 +37,14 @@ function setConfig( extra: Record< string, unknown > = {} ): void {
 		restRoot: 'http://example.test/wp-json/desktop-mode/v1/woocommerce/',
 		restNonce: 'nonce',
 		canOrders: true,
+		canCustomers: true,
+		customerBands: [
+			{ id: 'vip', label: 'VIP', order: 10, count: 2 },
+			{ id: 'lapsed', label: 'Lapsed', order: 20, count: 5 },
+			{ id: 'repeat', label: 'Repeat', order: 30, count: 9 },
+			{ id: 'new', label: 'New', order: 40, count: 3 },
+			{ id: 'none', label: 'No orders yet', order: 50, count: 1 },
+		],
 		productBands: [
 			{
 				id: 'stock:outofstock',
@@ -46,6 +60,17 @@ function setConfig( extra: Record< string, unknown > = {} ): void {
 		],
 		...extra,
 	};
+}
+
+/**
+ * Put a spy on `wp.os.openWindow` without disturbing `wp.hooks` —
+ * replacing the whole `wp` global takes the filter bus with it, and
+ * every subscriber in this file rides that bus.
+ */
+function stubOpenWindow( fn: () => boolean ): void {
+	const w = window as unknown as { wp?: Record< string, unknown > };
+	w.wp = w.wp ?? {};
+	( w.wp as { os?: unknown } ).os = { openWindow: fn };
 }
 
 /** A product list row carrying the server-decided band + stock facts. */
@@ -349,6 +374,545 @@ describe( 'my-wordpress — WooCommerce integration', () => {
 				entityId: PRODUCTS,
 				kind: 'post',
 				item: { id: 7 },
+			} );
+
+			expect( container.children ).toHaveLength( 0 );
+		} );
+	} );
+
+	// ────────────────────────────────────────────────────────────
+	// Customers. The facts ride `/wp/v2/users` as well as the
+	// Customers collection, so the decoration is keyed off the tile
+	// KIND rather than off a section id — a person who has spent
+	// money is a customer wherever you are looking at them.
+	// ────────────────────────────────────────────────────────────
+
+	describe( 'customers', () => {
+		/** A user row carrying the server's customer facts. */
+		function customerRow( facts: Record< string, unknown > ) {
+			return { id: 11, name: 'Ada', openstation_woo_customer: facts };
+		}
+
+		/** A user tile with the built-in avatar box and sub-line. */
+		function decorateUser(
+			item: Record< string, unknown >,
+			entityId = CUSTOMERS,
+			{ painted = true }: { painted?: boolean } = {},
+		): HTMLElement {
+			const tile = document.createElement( 'div' );
+			if ( painted ) {
+				const visual = document.createElement( 'span' );
+				visual.className = 'os-file-tile__visual';
+				tile.appendChild( visual );
+			}
+			const sub = document.createElement( 'span' );
+			sub.className = 'os-my-wordpress__user-tile-sub';
+			sub.textContent = 'Customer · 0 posts';
+			tile.appendChild( sub );
+			document.body.appendChild( tile );
+			doAction( 'os.my-wordpress.list-tile', {
+				tile,
+				entityId,
+				kind: 'user',
+				item,
+			} );
+			return tile;
+		}
+
+		/** Stand in for `<os-tile>._paint()`: the visual is replaced. */
+		function repaint( tile: HTMLElement ): void {
+			tile.querySelector( '.os-file-tile__visual' )?.remove();
+			const visual = document.createElement( 'span' );
+			visual.className = 'os-file-tile__visual';
+			tile.prepend( visual );
+			doAction( 'os.tile.rendered', { tile } );
+		}
+
+		test( 'the Customers grid drops the sub-line entirely', () => {
+			const tile = decorateUser(
+				customerRow( {
+					band: 'repeat',
+					orders: 4,
+					spend: '£240.00',
+					spendRaw: 240,
+				} ),
+			);
+
+			// An icon is a face, a name, and at most one mark. In a
+			// folder where every row is a customer, "Customer" says
+			// nothing — and spend belongs in the pane, which has room
+			// to say it properly.
+			expect(
+				tile.querySelector( '.os-my-wordpress__user-tile-sub' ),
+			).toBeNull();
+		} );
+
+		test( 'the Users grid keeps its sub-line', () => {
+			const tile = decorateUser(
+				customerRow( { band: 'vip', orders: 4, spend: '£240.00' } ),
+				'users',
+			);
+
+			// "Editor · 12 posts" is still the truest thing about
+			// someone in the Users folder.
+			expect(
+				tile.querySelector( '.os-my-wordpress__user-tile-sub' )
+					?.textContent,
+			).toBe( 'Customer · 0 posts' );
+		} );
+
+		test.each( [
+			[ 'vip', 'VIP' ],
+			[ 'lapsed', 'Lapsed' ],
+		] )( 'the %s band earns a badge inside the avatar', ( band, label ) => {
+			const tile = decorateUser(
+				customerRow( { band, orders: 3, spend: '£90.00' } ),
+			);
+			const badge = tile.querySelector( '.os-woo-customer-band' );
+
+			expect( badge ).not.toBeNull();
+			expect( badge?.textContent ).toBe( label );
+			expect( badge?.classList.contains(
+				`os-woo-customer-band--${ band }`,
+			) ).toBe( true );
+			// Inside the avatar box, so it costs the tile no vertical
+			// space and the icon stays an icon.
+			expect( badge?.parentElement?.className ).toContain(
+				'os-file-tile__visual',
+			);
+			// A 45° banner works on a product photo and is vandalism
+			// on a face — at 88px it covers a third of the avatar.
+			expect( tile.querySelector( 'os-ribbon' ) ).toBeNull();
+		} );
+
+		test( 'the badge survives a repaint', () => {
+			const tile = decorateUser(
+				customerRow( { band: 'vip', orders: 3, spend: '£90.00' } ),
+			);
+			// `<os-tile>._paint()` destroys and recreates the avatar
+			// box, and selection triggers a paint.
+			repaint( tile );
+
+			expect(
+				tile.querySelectorAll( '.os-woo-customer-band' ),
+			).toHaveLength( 1 );
+		} );
+
+		test( 'a tile decorated before it paints gets exactly one badge', () => {
+			// The real sequence, and the one that produced two badges.
+			// The decoration action fires from the tile builder while
+			// the element is still detached and `<os-tile>` has not
+			// painted, so there is no avatar box to reach yet. Falling
+			// back to the tile itself put a badge under the name that
+			// the later, correct stamp never noticed.
+			const tile = decorateUser(
+				customerRow( { band: 'vip', orders: 3, spend: '£90.00' } ),
+				CUSTOMERS,
+				{ painted: false },
+			);
+
+			expect(
+				tile.querySelectorAll( '.os-woo-customer-band' ),
+			).toHaveLength( 0 );
+
+			repaint( tile );
+
+			const badges = tile.querySelectorAll( '.os-woo-customer-band' );
+			expect( badges ).toHaveLength( 1 );
+			expect( badges[ 0 ].parentElement?.className ).toContain(
+				'os-file-tile__visual',
+			);
+		} );
+
+		test( 'repeated paints never accumulate badges', () => {
+			const tile = decorateUser(
+				customerRow( { band: 'lapsed', orders: 1, spend: '£9.00' } ),
+			);
+			repaint( tile );
+			repaint( tile );
+			repaint( tile );
+
+			expect(
+				tile.querySelectorAll( '.os-woo-customer-band' ),
+			).toHaveLength( 1 );
+		} );
+
+		test.each( [ 'repeat', 'new', 'none' ] )(
+			'the %s band gets no badge — a mark on every tile is a mark on none',
+			( band ) => {
+				const tile = decorateUser(
+					customerRow( { band, orders: 2, spend: '£20.00' } ),
+				);
+
+				expect(
+					tile.querySelector( '.os-woo-customer-band' ),
+				).toBeNull();
+			},
+		);
+
+		test( 'the built-in Users section gets the same decoration', () => {
+			const tile = decorateUser(
+				customerRow( { band: 'vip', orders: 9, spend: '£900.00' } ),
+				'users',
+			);
+
+			expect(
+				tile.querySelector( '.os-woo-customer-band' ),
+			).not.toBeNull();
+		} );
+
+		test( 'a user row with no facts is left alone', () => {
+			const tile = decorateUser( { id: 11, name: 'Ada' }, 'users' );
+
+			expect( tile.querySelector( '.os-woo-customer-band' ) ).toBeNull();
+			expect(
+				tile.querySelector( '.os-my-wordpress__user-tile-sub' )
+					?.textContent,
+			).toBe( 'Customer · 0 posts' );
+		} );
+
+		test( 'double-click on a customer opens the customer window', () => {
+			// Assign onto the existing `wp`, don't replace it —
+			// `window.wp.hooks` is the bus every filter here rides.
+			const openWindow = vi.fn( () => true );
+			stubOpenWindow( openWindow );
+
+			const handled = applyFilters(
+				'os.my-wordpress.user-activate',
+				false,
+				{
+					entityId: CUSTOMERS,
+					kind: 'user',
+					item: { id: 11, name: 'Ada' },
+				},
+			);
+
+			expect( handled ).toBe( true );
+			expect( openWindow ).toHaveBeenCalledWith(
+				'desktop-mode-woo-customer',
+				expect.objectContaining( {
+					// Params, not a module variable: they ride the
+					// session, so a reload brings the window back on
+					// the same person.
+					params: { customerId: 11, customerName: 'Ada' },
+				} ),
+			);
+		} );
+
+		test( 'double-click in the Users folder is left alone', () => {
+			// Assign onto the existing `wp`, don't replace it —
+			// `window.wp.hooks` is the bus every filter here rides.
+			const openWindow = vi.fn( () => true );
+			stubOpenWindow( openWindow );
+
+			// A person in the Users folder is someone who writes, and
+			// the activity footprint is the right answer there.
+			expect(
+				applyFilters( 'os.my-wordpress.user-activate', false, {
+					entityId: 'users',
+					kind: 'user',
+					item: { id: 11, name: 'Ada' },
+				} ),
+			).toBe( false );
+			expect( openWindow ).not.toHaveBeenCalled();
+		} );
+
+		test( 'the context menu drops the author-archive dead end', () => {
+			const base = [
+				{ id: 'footprint', label: 'Footprint', icon: 'a' },
+				{ id: 'open-profile', label: 'Show profile', icon: 'b' },
+				{ id: 'author-archive', label: 'Author archive', icon: 'c' },
+			];
+			const options = applyFilters(
+				'os.my-wordpress.tile-context-menu',
+				base,
+				{
+					entityId: CUSTOMERS,
+					kind: 'user',
+					item: customerRow( {
+						band: 'vip',
+						orders: 3,
+						ordersUrl: 'http://example.test/wp-admin/orders',
+					} ),
+				},
+			) as Array< { id: string } >;
+
+			const ids = options.map( ( o ) => o.id );
+			// A blog archive for someone who has never written a post.
+			expect( ids ).not.toContain( 'author-archive' );
+			expect( ids ).not.toContain( 'footprint' );
+			expect( ids ).toContain( 'wc-customer-window' );
+			expect( ids ).toContain( 'wc-customer-orders' );
+			expect( ids ).toContain( 'open-profile' );
+		} );
+
+		test( 'the customer window renderer registers on the shell global', () => {
+			const registry = (
+				window as unknown as {
+					openStationNativeWindows?: Record< string, unknown >;
+				}
+			 ).openStationNativeWindows;
+
+			expect( typeof registry?.[ 'desktop-mode-woo-customer' ] ).toBe(
+				'function',
+			);
+		} );
+
+		test( 'the customer marker routes a person-URL to the customer window', () => {
+			const openById = vi.fn().mockReturnValue( true );
+			bindNativeUrlRemap( {
+				getSnapshot: () => ( {} as OsSettingsSnapshot ),
+				openById,
+				adminUrl: 'http://example.test/wp-admin/',
+			} );
+
+			// From an order, "customer" means *this is who bought it*,
+			// not *change their role* — but the only URL WordPress has
+			// for a person is their profile editor, so the marker is
+			// what lets the Customer window claim it.
+			const claimed = tryNativeUrlRemap(
+				'http://example.test/wp-admin/user-edit.php?user_id=11&os_person_view=wc-customer',
+			);
+
+			expect( claimed ).toBe( true );
+			expect( openById ).toHaveBeenCalledWith(
+				'desktop-mode-woo-customer',
+				{ params: { customerId: 11 } },
+			);
+		} );
+
+		test( 'an unmarked person-URL is left to the profile editor', () => {
+			const openById = vi.fn().mockReturnValue( true );
+			bindNativeUrlRemap( {
+				getSnapshot: () => ( {} as OsSettingsSnapshot ),
+				openById,
+				adminUrl: 'http://example.test/wp-admin/',
+			} );
+
+			expect(
+				tryNativeUrlRemap(
+					'http://example.test/wp-admin/user-edit.php?user_id=11',
+				),
+			).toBe( false );
+			expect( openById ).not.toHaveBeenCalled();
+		} );
+
+		test( 'the customer window announces a `user` identity', () => {
+			// A native window has no admin screen, so nothing
+			// announces on its behalf the way the chromeless bridge
+			// does for an iframe. Without this call the window is
+			// invisible to the relations engine — it opens beside the
+			// order it came from and draws no line.
+			const set = vi.fn();
+			const w = window as unknown as { wp?: Record< string, unknown > };
+			w.wp = w.wp ?? {};
+			( w.wp as { os?: unknown } ).os = { relations: { set } };
+
+			// The window root the shell stamps; the id-of-record walk
+			// looks for exactly this.
+			const root = document.createElement( 'div' );
+			root.id = 'wp-window-desktop-mode-woo-customer';
+			const body = document.createElement( 'div' );
+			const mount = document.createElement( 'div' );
+			mount.setAttribute( 'data-os-woo-customer-root', '' );
+			body.appendChild( mount );
+			root.appendChild( body );
+			document.body.appendChild( root );
+
+			const render = (
+				window as unknown as {
+					openStationNativeWindows: Record<
+						string,
+						(
+							body: HTMLElement,
+							ctx?: {
+								params?: Record<
+									string,
+									string | number | boolean
+								>;
+							},
+						) => unknown
+					>;
+				}
+			 ).openStationNativeWindows[ 'desktop-mode-woo-customer' ];
+			render( body, {
+				params: { customerId: 11, customerName: 'Ada' },
+			} );
+
+			// `user`, matching what `user-edit.php` announces — so the
+			// Customer window and a profile window on the same person
+			// join one group, and an order (whose identity links
+			// `user:<id>`) ties to either.
+			expect( set ).toHaveBeenCalledWith(
+				'desktop-mode-woo-customer',
+				expect.objectContaining( { type: 'user', id: 11 } ),
+			);
+		} );
+
+		test( 'the customers dossier drops the author sections', () => {
+			const sections = applyFilters(
+				'os.my-wordpress.user-dossier-sections',
+				[ 'bio', 'stats', 'activity', 'milestones', 'recent', 'terms' ],
+				{ entityId: CUSTOMERS, kind: 'user', userId: 11 },
+			);
+
+			// Four zeroes above the lifetime-spend figure read as the
+			// answer to a question nobody asked.
+			expect( sections ).toEqual( [ 'bio' ] );
+		} );
+
+		test( 'the Users section keeps its author sections', () => {
+			const all = [
+				'bio',
+				'stats',
+				'activity',
+				'milestones',
+				'recent',
+				'terms',
+			];
+			expect(
+				applyFilters( 'os.my-wordpress.user-dossier-sections', all, {
+					entityId: 'users',
+					kind: 'user',
+					userId: 11,
+				} ),
+			).toEqual( all );
+		} );
+
+		test( 'the action row swaps the footprint for their orders', () => {
+			const base = [
+				{ id: 'footprint', label: 'Footprint', onSelect: () => {} },
+				{ id: 'open-profile', label: 'Show profile', onSelect: () => {} },
+			];
+			const actions = applyFilters(
+				'os.my-wordpress.user-preview-actions',
+				base,
+				{
+					entityId: CUSTOMERS,
+					kind: 'user',
+					item: customerRow( {
+						band: 'vip',
+						orders: 3,
+						spend: '£90.00',
+						ordersUrl: 'http://example.test/wp-admin/orders',
+					} ),
+				},
+			) as Array< { id: string; variant?: string } >;
+
+			expect( actions.map( ( a ) => a.id ) ).toEqual( [
+				'wc-orders',
+				'open-profile',
+			] );
+			expect( actions[ 0 ].variant ).toBe( 'primary' );
+		} );
+
+		test( 'no orders means no dead-end button onto an empty list', () => {
+			const base = [
+				{ id: 'footprint', label: 'Footprint', onSelect: () => {} },
+				{ id: 'open-profile', label: 'Show profile', onSelect: () => {} },
+			];
+			const actions = applyFilters(
+				'os.my-wordpress.user-preview-actions',
+				base,
+				{
+					entityId: CUSTOMERS,
+					kind: 'user',
+					item: customerRow( {
+						band: 'none',
+						orders: 0,
+						spend: '',
+						ordersUrl: '',
+					} ),
+				},
+			) as Array< { id: string; variant?: string } >;
+
+			expect( actions.map( ( a ) => a.id ) ).toEqual( [ 'open-profile' ] );
+			// Something has to be the primary action.
+			expect( actions[ 0 ].variant ).toBe( 'primary' );
+		} );
+
+		test( 'a user preview asks for the customer summary', async () => {
+			stubSummary( {
+				type: 'customer',
+				name: 'Ada',
+				email: 'ada@example.test',
+				band: 'vip',
+				bandLabel: 'VIP',
+				orders: 6,
+				spend: '£600.00',
+				aov: '£100.00',
+				firstOrder: '2024-01-02T00:00:00',
+				lastOrder: '2026-07-01T00:00:00',
+				daysSince: 34,
+				lastOrderNo: '1042',
+				lastOrderUrl: 'http://example.test/wp-admin/order',
+				lastOrderTotal: '£120.00',
+				favourite: null,
+				location: 'Lisbon, PT',
+				registered: '2023-11-04T00:00:00',
+				ordersUrl: 'http://example.test/wp-admin/orders',
+				profileUrl: '',
+			} );
+
+			const container = document.createElement( 'div' );
+			// Attached on purpose: `paintPanel` drops the swap when the
+			// shell has left the document, so an orphaned container
+			// would sit on its placeholders forever and the assertion
+			// below would fail for a reason that has nothing to do
+			// with customers.
+			document.body.appendChild( container );
+			// `meta`, not `header`: a person's panel goes below their
+			// name and face. Money above an avatar reads as a price
+			// tag on them, and you can't tell whose figure it is until
+			// you've scrolled past it to the name.
+			doAction( 'os.my-wordpress.preview-extras', {
+				slot: 'meta',
+				container,
+				entityId: CUSTOMERS,
+				kind: 'user',
+				item: { id: 11 },
+			} );
+			await vi.waitFor( () => {
+				const panel = container.querySelector( '.os-woo-panel' );
+				if ( ! panel || panel.hasAttribute( 'aria-busy' ) ) {
+					throw new Error( 'panel still loading' );
+				}
+			} );
+			expect(
+				container.querySelector( '.os-woo-panel--customer' ),
+			).not.toBeNull();
+
+			const url = ( global.fetch as ReturnType< typeof vi.fn > ).mock
+				.calls[ 0 ][ 0 ] as string;
+			expect( url ).toContain( 'summary/customer/11' );
+			expect( container.textContent ).toContain( '£600.00' );
+			expect( container.textContent ).toContain( '6 orders' );
+		} );
+
+		test( 'the header slot stays empty for a person', () => {
+			const container = document.createElement( 'div' );
+			document.body.appendChild( container );
+			doAction( 'os.my-wordpress.preview-extras', {
+				slot: 'header',
+				container,
+				entityId: CUSTOMERS,
+				kind: 'user',
+				item: { id: 11 },
+			} );
+
+			expect( container.children ).toHaveLength( 0 );
+		} );
+
+		test( 'no panel for a viewer who may not see customer money', () => {
+			setConfig( { canCustomers: false } );
+
+			const container = document.createElement( 'div' );
+			doAction( 'os.my-wordpress.preview-extras', {
+				slot: 'meta',
+				container,
+				entityId: CUSTOMERS,
+				kind: 'user',
+				item: { id: 11 },
 			} );
 
 			expect( container.children ).toHaveLength( 0 );

--- a/tests/vitest/native-url-remap.test.ts
+++ b/tests/vitest/native-url-remap.test.ts
@@ -218,3 +218,69 @@ describe( 'tryNativeUrlRemap — multiple entries', () => {
 		expect( openById ).toHaveBeenNthCalledWith( 2, 'b' );
 	} );
 } );
+
+describe( 'tryNativeUrlRemap — open-time params', () => {
+	function bind( openOk = true ) {
+		const openById = vi.fn().mockReturnValue( openOk );
+		bindNativeUrlRemap( {
+			getSnapshot: () => snapshot(),
+			openById,
+			adminUrl: ADMIN_URL,
+		} );
+		return openById;
+	}
+
+	test( 'a params hook reaches the opener', () => {
+		const openById = bind();
+		registerNativeUrlRemap( {
+			id: 'customer',
+			nativeWindowId: 'desktop-mode-woo-customer',
+			matches: () => true,
+			params: ( _url, parsed ) => ( {
+				customerId: Number( parsed.searchParams.get( 'user_id' ) ) || 0,
+			} ),
+		} );
+
+		expect(
+			tryNativeUrlRemap( ADMIN_URL + 'user-edit.php?user_id=7' ),
+		).toBe( true );
+		expect( openById ).toHaveBeenCalledWith( 'desktop-mode-woo-customer', {
+			params: { customerId: 7 },
+		} );
+	} );
+
+	test( 'a remap without params calls the opener with one argument', () => {
+		const openById = bind();
+		registerNativeUrlRemap( {
+			id: 'plain',
+			nativeWindowId: 'plain',
+			matches: () => true,
+		} );
+
+		tryNativeUrlRemap( ADMIN_URL + 'edit.php' );
+
+		// Not `( 'plain', undefined )`. The opener's signature is
+		// older than the params hook and most remaps will never use
+		// it; a trailing `undefined` would change what every existing
+		// caller observes for no benefit.
+		expect( openById ).toHaveBeenCalledWith( 'plain' );
+	} );
+
+	test( 'a throwing params hook still opens the window', () => {
+		const openById = bind();
+		vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+		registerNativeUrlRemap( {
+			id: 'boom',
+			nativeWindowId: 'boom',
+			matches: () => true,
+			params: () => {
+				throw new Error( 'nope' );
+			},
+		} );
+
+		// Same tolerance `onMatch` has: the window opens, just
+		// without whatever the hook meant to tell it.
+		expect( tryNativeUrlRemap( ADMIN_URL + 'edit.php' ) ).toBe( true );
+		expect( openById ).toHaveBeenCalledWith( 'boom' );
+	} );
+} );

--- a/tests/vitest/vendor-loader.test.ts
+++ b/tests/vitest/vendor-loader.test.ts
@@ -73,6 +73,37 @@ describe( 'loadVendorScript — no double injection', () => {
 		expect( scriptCount( '/b.min.js' ) ).toBe( 1 );
 	} );
 
+	test( 'the same path on a different origin is a different bundle', () => {
+		// `loadVendorScript` is public API and vendor bundles have
+		// generic paths — two CDNs both serving `/dist/index.js` is
+		// not a hypothetical. Matching on pathname alone would adopt
+		// the first as the second and never load it.
+		const first = document.createElement( 'script' );
+		first.src = 'http://cdn-one.test/dist/index.js?ver=1';
+		document.head.appendChild( first );
+
+		void loadVendorScript( 'http://cdn-two.test/dist/index.js' );
+
+		expect( scriptCount( '/dist/index.js' ) ).toBe( 2 );
+		// The pre-existing tag belongs to the other origin and must
+		// not have been adopted as ours.
+		expect( first.dataset.osVendor ).toBeUndefined();
+	} );
+
+	test( 'a protocol-relative URL resolves against the document', () => {
+		// `//example.test/…` is same-origin here, so it IS the same
+		// bundle — origin matching must resolve, not string-compare.
+		const url =
+			'http://example.test/wp-content/plugins/x/assets/js/d.min.js';
+		const enqueued = document.createElement( 'script' );
+		enqueued.src = '//example.test/wp-content/plugins/x/assets/js/d.min.js';
+		document.head.appendChild( enqueued );
+
+		void loadVendorScript( url );
+
+		expect( scriptCount( '/d.min.js' ) ).toBe( 1 );
+	} );
+
 	test( 'the adopted tag is marked so re-entry short-circuits', async () => {
 		// Its own URL: the loader memoizes resolved loads by URL for
 		// the life of the module, so reusing another test's URL would

--- a/tests/vitest/vendor-loader.test.ts
+++ b/tests/vitest/vendor-loader.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The lazy vendor-script loader, and the one thing it must never do:
+ * inject a second copy of a file the page already has.
+ *
+ * A bundle evaluated twice registers every `addAction` / `addFilter`
+ * twice, and `@wordpress/hooks` appends rather than replaces on a
+ * repeated namespace — so every subscriber runs twice. The symptom is
+ * duplicated UI (two identical panels stacked in a folder, two badges
+ * on one tile) and nothing about it points at script loading, which is
+ * what made it expensive to find.
+ *
+ * It happens the moment a plugin names an already-enqueued handle as
+ * its native window's `script` — a normal thing to do, and how the
+ * WooCommerce Customer window is wired.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { loadVendorScript } from '../../src/wallpapers/vendor-loader';
+
+const BUNDLE = 'http://example.test/wp-content/plugins/x/assets/js/a.min.js';
+
+function scriptCount( pathFragment: string ): number {
+	return Array.from(
+		document.querySelectorAll< HTMLScriptElement >( 'script[src]' ),
+	).filter( ( s ) => s.src.includes( pathFragment ) ).length;
+}
+
+describe( 'loadVendorScript — no double injection', () => {
+	beforeEach( () => {
+		document.head.innerHTML = '';
+		document.body.innerHTML = '';
+	} );
+
+	afterEach( () => {
+		document.head.innerHTML = '';
+		document.body.innerHTML = '';
+	} );
+
+	test( 'a page-enqueued script is not injected again', async () => {
+		// What `wp_enqueue_script()` prints: a plain tag with a `ver`
+		// query and no `data-os-vendor` marker.
+		const enqueued = document.createElement( 'script' );
+		enqueued.src = `${ BUNDLE }?ver=0.9.8`;
+		document.head.appendChild( enqueued );
+
+		await loadVendorScript( BUNDLE );
+
+		expect( scriptCount( '/a.min.js' ) ).toBe( 1 );
+	} );
+
+	test( 'the query string is not part of the identity', async () => {
+		const enqueued = document.createElement( 'script' );
+		enqueued.src = `${ BUNDLE }?ver=1.2.3`;
+		document.head.appendChild( enqueued );
+
+		// Same file, different `ver` — within one document that is the
+		// same bundle, and loading it again would evaluate it again.
+		await loadVendorScript( `${ BUNDLE }?ver=9.9.9` );
+
+		expect( scriptCount( '/a.min.js' ) ).toBe( 1 );
+	} );
+
+	test( 'a different file is still injected', async () => {
+		const enqueued = document.createElement( 'script' );
+		enqueued.src = `${ BUNDLE }?ver=0.9.8`;
+		document.head.appendChild( enqueued );
+
+		const other =
+			'http://example.test/wp-content/plugins/x/assets/js/b.min.js';
+		// Not awaited: nothing fires `load` in jsdom for an injected
+		// src, and the assertion is about the tag existing.
+		void loadVendorScript( other );
+
+		expect( scriptCount( '/b.min.js' ) ).toBe( 1 );
+	} );
+
+	test( 'the adopted tag is marked so re-entry short-circuits', async () => {
+		// Its own URL: the loader memoizes resolved loads by URL for
+		// the life of the module, so reusing another test's URL would
+		// return that promise and never reach the adoption path.
+		const url =
+			'http://example.test/wp-content/plugins/x/assets/js/c.min.js';
+		const enqueued = document.createElement( 'script' );
+		enqueued.src = `${ url }?ver=0.9.8`;
+		document.head.appendChild( enqueued );
+
+		await loadVendorScript( url );
+
+		expect( scriptCount( '/c.min.js' ) ).toBe( 1 );
+		// Adopted, so the cheap `data-os-vendor` fast path catches it
+		// next time instead of re-walking every script tag.
+		expect( enqueued.dataset.osVendor ).toBe( url );
+		expect( enqueued.dataset.loaded ).toBe( '1' );
+	} );
+} );

--- a/tests/vitest/window-manager-params.test.ts
+++ b/tests/vitest/window-manager-params.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Native-window open-time params, and their survival through the
+ * session.
+ *
+ * A native window is addressed by id, and its id is its identity:
+ * `desktop-mode-user-edit` is "the profile editor", not "the profile
+ * editor for user 12". Anything that varies per open has nowhere else
+ * to live — and the shared store the profile window used had no
+ * answer for a page reload, so the restored window came back showing
+ * whoever was logged in rather than the person the user had open.
+ *
+ * These tests pin the whole round trip: opening with params, staging
+ * them onto a live window, writing them into the snapshot, and
+ * dropping values that would take the save down with them.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { __resetNativeWindowGeometryForTests } from '../../src/window-manager/native-window-geometry';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+function nativeConfig( id: string, extras: Record< string, unknown > = {} ) {
+	return {
+		id,
+		baseId: id,
+		native: true,
+		url: `#${ id }`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+		render: () => undefined,
+		...extras,
+	};
+}
+
+describe( 'native window params', () => {
+	let desktopArea: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		__resetNativeWindowGeometryForTests();
+		desktopArea = document.createElement( 'div' );
+		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		document.body.appendChild( desktopArea );
+		manager = new WindowManager( desktopArea );
+	} );
+
+	afterEach( () => {
+		for ( const win of manager.getAll() ) {
+			win.destroy();
+		}
+		desktopArea.remove();
+		clearHooksStub();
+		__resetNativeWindowGeometryForTests();
+	} );
+
+	test( 'params ride the window config', async () => {
+		const win = await manager.open(
+			nativeConfig( 'desktop-mode-user-edit', {
+				params: { userId: 12 },
+			} ),
+		);
+
+		expect( win.config.params ).toEqual( { userId: 12 } );
+	} );
+
+	test( 'reopening with new params retargets the live window', async () => {
+		await manager.open(
+			nativeConfig( 'desktop-mode-user-edit', {
+				params: { userId: 12 },
+			} ),
+		);
+		const again = await manager.open(
+			nativeConfig( 'desktop-mode-user-edit', {
+				params: { userId: 44 },
+			} ),
+		);
+
+		// `open()` focuses an existing window rather than rebuilding
+		// it, so without this the window keeps showing user 12 — the
+		// failure mode that reads as "clicking a second person does
+		// nothing".
+		expect( again.config.params ).toEqual( { userId: 44 } );
+	} );
+
+	test( 'an argument-less reopen leaves the target alone', async () => {
+		await manager.open(
+			nativeConfig( 'desktop-mode-user-edit', {
+				params: { userId: 12 },
+			} ),
+		);
+		// A dock click on an already-open profile window must not wipe
+		// whose profile it is.
+		const again = await manager.open(
+			nativeConfig( 'desktop-mode-user-edit' ),
+		);
+
+		expect( again.config.params ).toEqual( { userId: 12 } );
+	} );
+
+	test( 'the snapshot carries params for native windows', async () => {
+		await manager.open(
+			nativeConfig( 'desktop-mode-woo-customer', {
+				params: { customerId: 7, customerName: 'Ada' },
+			} ),
+		);
+
+		const saved = manager
+			.snapshot()
+			.windows.find( ( w ) => w.id === 'desktop-mode-woo-customer' );
+
+		expect( saved?.params ).toEqual( {
+			customerId: 7,
+			customerName: 'Ada',
+		} );
+	} );
+
+	test( 'an iframe window carries no params — its URL already says', async () => {
+		await manager.open( {
+			id: 'edit-php',
+			baseId: 'edit-php',
+			url: 'http://example.test/wp-admin/edit.php',
+			title: 'Posts',
+			icon: 'dashicons-admin-post',
+			params: { userId: 12 },
+		} );
+
+		const saved = manager
+			.snapshot()
+			.windows.find( ( w ) => w.id === 'edit-php' );
+
+		expect( saved?.params ).toBeUndefined();
+	} );
+
+	test( 'unserializable values are dropped rather than taking the save down', async () => {
+		const cyclic: Record< string, unknown > = {};
+		cyclic.self = cyclic;
+
+		await manager.open(
+			nativeConfig( 'desktop-mode-woo-customer', {
+				params: {
+					customerId: 7,
+					// A plugin's careless value must not cost every
+					// other window its geometry.
+					node: document.createElement( 'div' ),
+					cb: () => undefined,
+					cyclic,
+					nan: Number.NaN,
+				},
+			} ),
+		);
+
+		const saved = manager
+			.snapshot()
+			.windows.find( ( w ) => w.id === 'desktop-mode-woo-customer' );
+
+		expect( saved?.params ).toEqual( { customerId: 7 } );
+		expect( () => JSON.stringify( manager.snapshot() ) ).not.toThrow();
+	} );
+
+	test( 'a window opened with no params writes none', async () => {
+		await manager.open( nativeConfig( 'desktop-mode-os-settings' ) );
+
+		const saved = manager
+			.snapshot()
+			.windows.find( ( w ) => w.id === 'desktop-mode-os-settings' );
+
+		expect( saved?.params ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Adds a **Customers** section to the Woo folder, a **Customer window**, and the reverse half of the relations graph — plus the framework seams those needed, and three bugs found on the way.

## Customers

Renders through the built-in `user` entity kind — avatar tiles, drag-out, the dossier pane — with lifetime spend, order count, AOV, first/last order and a band (VIP → lapsed → repeat → new → none, the two actionable ones first) on every row. VIP is derived (3× store AOV) rather than fixed, because "spent over 500" means nothing without knowing whether the store sells postcards or pianos.

The whole section costs **one grouped query** over the order store (HPOS or legacy), cached and flushed on any order change; band ordering, per-row facts and folder counts all read it, so a page of customers fires no per-row order queries. The facts field is registered on the core `user` REST resource, so the built-in Users section gets them for free.

Double-clicking a customer opens the **Customer window**: identity, four stat cards, what they buy most, recent orders (each opening in its own window), addresses.

## Relations, both directions

An order announces `links` to its customer, products and coupons. The new half: a **product** reaches its orders, its buyers and the coupons that discount it; a **coupon** reaches the orders that redeemed it and who redeemed them. An order names its products, so that direction always worked — *is this selling, and to whom?* is the question a merchant actually asks, and the catalogue screen had no answer.

Reviews and profile screens gained content identities, so those windows tie rather than opening unconnected.

## Framework changes (all generic)

- **`WindowConfig.params`** — open-time arguments for a native window, persisted with the session and staged back on restore. A native window is addressed by id, so a singleton that retargets had nowhere to record its subject; the profile window came back showing whoever was logged in after F5.
- **`os.my-wordpress.user-dossier-sections`**, **`…user-preview-actions`**, **`…user-activate`** — a user pane is not always an author pane. Post counts and a publishing sparkline are four zeroes above the figure a merchant came for.
- `preview-extras` and `list-tile` now fire for **user** tiles; the user pane gained a `meta` slot under the identity header.
- URL remaps can declare a **`params`** hook, and **`os_person_view`** lets a specific view claim a person-URL without racing the built-in profile remap.

## Bugs fixed

- **`loadVendorScript` deduped only against tags it had injected**, so naming an already-enqueued handle as a native window's `script` evaluated the bundle twice. `@wordpress/hooks` appends on a repeated namespace, so every subscriber ran twice — two Store panels, two badges. Nothing in the symptom pointed at script loading.
- **Panel links carried `target="_blank"`.** In a tab that threw admin screens out of the shell; inside the installed PWA a same-origin admin URL is in scope, so clicking a product name **relaunched the app**.
- **The session sanitizer dropped unknown window fields**, so `params` never survived the POST — and `sanitize_key()` would have lowercased camelCase names, storing `customerid` for a client reading `customerId`.
- `openAdminWindow` called `manager.open()` with no `id`, which throws.

## Tests

1998 PHPUnit, 3717 Vitest, all green. New: `myWordpressWoocommerceCustomers.php`, `window-manager-params.test.ts`, `vendor-loader.test.ts`, plus additions to the session, window-links, remap and Woo suites.

## Known gap

The Customers grid is band-*ordered* but not band-*headed* — that chrome lives in the post-kind list renderer and the user-kind one doesn't have it yet. The order is right; the band shows as a tile badge instead. Noted in `docs/plugin-compat-layer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-485-ddcac09570657c88f3a59bf8f24595a6cc50cd31.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->