### PR TITLE
Release: Write the 1.0.0 changelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,33 @@ The **Inkfall** game's word list (`assets/games/inkfall/words.txt`) is generated
 
 == Changelog ==
 
+= 1.0.0 =
+* Desktop Mode is now OpenStation — new name, new look, same plugin. Settings, files, sessions and desktop layouts carry over untouched.
+* The site folder is now WP Explorer, and OS Settings is now OpenStation Preferences.
+* A new palette and typography, with four wallpapers: Galaxy (the new default), Space, Holomesh and Pulsemesh.
+* Desktop Mode (Legacy) — a built-in desktop theme that puts the previous look back in one click, WordPress blue included.
+* Mio — a soft-body desk companion that drifts across the wallpaper and gets pushed around by your windows. Off by default; turn it on from the dock. It also ships as a standalone script you can drop on any page, WordPress or not.
+* Holographic controls — switches, primary buttons and selected items catch an iridescent mesh on hover and press.
+* New Switch component, and a searchable Components tab in OpenStation Preferences.
+* Select more than one thing at a time — click, Ctrl-click, Shift-click, marquee and Cmd+A on the desktop and in every folder window, with WordPress's own bulk actions and multi-item drag.
+* Custom post types now appear in WP Explorer, grouped into a folder named after the plugin or theme that registered them.
+* Post tiles show their featured image instead of a generic icon, which turns a catalogue into a photo grid.
+* WooCommerce — Orders, Products, Coupons and Customers as browsable folders, with out-of-stock, low-stock, backorder and sale ribbons, and a details pane showing price, stock, order totals, line items and coupon usage.
+* Open a customer for their lifetime spend, what they buy most and their recent orders, and follow a product to its buyers or a coupon to who redeemed it.
+* The editor's preview companion follows your typing in the classic editor too, and opens straight away instead of waiting on a save.
+* Plugins can accept files dropped onto their own desktop icon, via `wp.os.files.registerTilePayloadHandler()`.
+* The Games leaderboard refreshes the moment a run finishes, instead of waiting for a reload.
+* Fix the Media Library's uploader button opening a window instead of the inline uploader, and uploaded files not reaching the grid until the window was reopened.
+* Fix context menus opened near the bottom of the screen running off the edge, which put most of their options out of reach.
+* Fix Quick Edit and Bulk Edit going dead once a list refreshed in place.
+* Fix the classic revisions screen opening in a browser tab instead of a window, and restoring a revision leaving a stale editor behind.
+* Fix closed windows reappearing after a refresh, and window state being lost when several windows were closed in quick succession.
+* Fix the widget column rendering empty.
+* Desktop icons and file tiles now fade out in Overview, so they no longer collide with window thumbnails.
+* Fix `wp.os.activity.subscribe()` never receiving events — channel names containing a slash were silently rejected.
+* The portal URL moved from `/desktop-mode/` to `/openstation/`. Reinstall the app if you added OpenStation to your home screen.
+* For plugin authors: `wp.desktop` is now `wp.os`, `<wpd-*>` components are `<os-*>`, PHP functions and hooks use the `openstation_` prefix, and activity channels moved from `desktop-mode/<event>` to `os/<event>`. Stored data — options, meta, custom tables, REST namespaces and the WordPress.org slug — is unchanged.
+
 = 0.9.8 =
 * Desktop Themes — uploadable ZIP theme system
 * Add a Drafts widget
@@ -384,6 +411,9 @@ The **Inkfall** game's word list (`assets/games/inkfall/words.txt`) is generated
 See the [GitHub releases page](https://github.com/WordPress/openstation/releases) for the full history.
 
 == Upgrade Notice ==
+
+= 1.0.0 =
+Desktop Mode is now OpenStation. Settings, files and desktop layouts carry over. The portal URL moved to /openstation/, so reinstall the app if you added it to your home screen. Plugins extending the shell need updating: `wp.desktop` is now `wp.os`, and PHP uses the `openstation_` prefix.
 
 = 0.8.1 =
 Framework and stability rework, reworked drag and drop, native Posts/Pages/Users windows, and a new Content Graph tool. Backwards-compatible.


### PR DESCRIPTION
Hand-writes the `= 1.0.0 =` block in `readme.txt` ahead of the release, so it can ship with `./bin/release.sh 1.0.0 --skip-changelog`. No release is cut by this PR and nothing is deployed to WordPress.org.

Rebased on trunk and relabelled for 1.0.0. The branch previously held a `= 0.9.9 =` block covering the first twelve PRs of the cycle; we never cut 0.9.9, so the block keeps its 17 lines and gains what the rest of the cycle is worth highlighting.

`bin/release.sh` drafts this block automatically from the squash-merge titles, but that draft reads like a commit log ("Rebrand (1/2): the OpenStation palette, themes and the mascot", "Make the glow a glow"). This is the same cycle rewritten for someone installing the plugin.

## Proposed changes

- `= 1.0.0 =` in `== Changelog ==`, 25 lines against 44 commits since `v0.9.8`.
- A `= 1.0.0 =` entry in `== Upgrade Notice ==`, which is what wp.org shows in the update prompt. The section had nothing since 0.8.1, and this release has three things a user has to act on: the rename, the portal URL move, and the API renames for anyone extending the shell.

`Stable tag:` is deliberately untouched, `bin/bump-version.sh` owns it at release time.

## Editing rules

**A line earns its place by being visible to someone installing the plugin**, which is why the auto-draft's PHPCS chore (#483), Playground blueprint (#479), docs PRs (#519, #520, #521), PR previews (#528), `AGENTS.md` (#516) and the Dependabot bumps are all absent.

**A bug that only ever existed mid-cycle is not news.** Mio ships new here, so its in-cycle fixes (#477, #478, #481) collapse into the one Mio line rather than advertising bugs no released build ever had. Same for the rebrand announcement rework (#511). The empty widget column (#484) is the exception and keeps its line, because nightly users could have hit it.

**Polish is not a highlight.** Eight visible-but-small fixes are deliberately out: the loading spinner fade (#525), the rename dialog's field (#503), the segmented-control pill (#515), the fullscreen tooltip (#499), entity-encoded commenter names (#507), the POT support-forum URL (#522), dock status dots (#509) and the wp.org link fallback in the Plugins window (#495). Also out: the admin-bar poll (#504) and the fresh-install migration flag (#514), both real fixes for states a released install could not reach.

## Added since the original block

Multi-select (#501), the WP Explorer and OpenStation Preferences renames (#500), the Woo customer window and two-way relations (#485), live preview in the classic editor (#494), Mio as a standalone script (#505), and four fixes people actually reported: the Media Library uploader (#487), context menus running off the bottom of the screen (#523), Quick Edit after a refresh (#502) and the classic revisions screen (#498).

Two of the original lines were corrected rather than kept: #500 renamed the site window to WP Explorer and OS Settings to OpenStation Preferences, so the lines naming them had to follow. The plugin-author line gained the activity-channel rename from #512.

## Two names corrected against their PR bodies

- #472 documents the drop seam as `wp.desktop.files.registerTilePayloadHandler()`, but it merged before the rename. The shipped name is `wp.os.files.…`, confirmed against `src/desktop-files/layer.ts`.
- #475's table says `open_station_*()` / `OPEN_STATION_*`. What shipped is `openstation_*` / `OPENSTATION_*`.

## Testing instructions

The diff is `readme.txt` only, so this is a proofread rather than a functional test.

1. Read the `= 1.0.0 =` block top to bottom. Every line should be something a user or a plugin author can see. Flag anything that reads as an internal detail, and anything left out that you would have led with.
2. Cross-check against the merge log:
   ```
   git log --oneline v0.9.8..trunk
   ```
   Make sure nothing listed here failed to ship, and that nothing user-facing is missing.
3. Paste the file into the [wp.org readme validator](https://wordpress.org/plugins/developers/readme-validator/) and confirm it parses with no new warnings. The Upgrade Notice entry is the new section; wp.org truncates it around 300 characters and this one is under that.
4. Confirm `Stable tag: 0.9.8` is unchanged.

## Still open before 1.0.0 ships

Both were flagged when this branch was first opened and neither has landed.

1. **The Playground demo links are broken until 1.0.0 ships.** `blueprint.json` and the README button point at `openstation.zip`, which no release carries. v0.9.8 only has `desktop-mode.zip`, so the Playground badge, the Studio link and the wp.org Live Preview all 404 in the meantime. Cheapest fix without cutting a release is to upload a copy of v0.9.8's zip to that release under the name `openstation.zip`. It self-heals once 1.0.0 lands.
2. **The rename still has no `docs/migration-*.md`.** `wp.desktop` to `wp.os`, `<wpd-*>` to `<os-*>` and the PHP prefix change are breaking for anyone extending the shell, and `AGENTS.md` asks for a migration note on a breaking change. `docs/migration-activity-channels.md` covers the channel rename only. This matters more at 1.0.0 than it did at 0.9.9, since that is the version plugin authors will read as the stable contract.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-486-d3e4dfa283721f2a76da8c73b2866266e503e1fb.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->