### PR TITLE
Agents: scope the chat sidebar to the active agent's conversations

### DIFF
--- a/src/agent-run-window.ts
+++ b/src/agent-run-window.ts
@@ -343,13 +343,22 @@ function renderChat( body: HTMLElement ): ( () => void ) | void {
 			? agentsChatStore.state.conversationIds?.[ agent.id ] ?? null
 			: null;
 
-		if ( conversationsLoaded && conversations.length === 0 ) {
+		// Per-agent scope: with an agent active, the sidebar is THAT
+		// agent's history only — conversations never mix across agents.
+		// With no agent seeded yet (a cold-open or session-restored
+		// window) the full list acts as the picker, since a row click
+		// re-targets the chat to its agent anyway.
+		const visible = agent
+			? conversations.filter( ( row ) => row.agentId === agent.id )
+			: conversations;
+
+		if ( conversationsLoaded && visible.length === 0 ) {
 			const none = document.createElement( 'div' );
 			none.className = 'dm-agent-chat__convs-empty';
 			none.textContent = __( 'No conversations yet.', 'desktop-mode' );
 			list.appendChild( none );
 		}
-		for ( const row of conversations ) {
+		for ( const row of visible ) {
 			const item = document.createElement( 'div' );
 			item.className = 'dm-agent-chat__conv';
 			if ( row.id === activeId ) {

--- a/tests/vitest/agent-run-window.test.ts
+++ b/tests/vitest/agent-run-window.test.ts
@@ -552,6 +552,77 @@ describe( 'agent chat window', () => {
 		}
 	} );
 
+	test( 'the sidebar shows only the active agent\'s conversations', async () => {
+		const mine = {
+			id: 71,
+			agentId: 5,
+			agentName: 'TLDR Editor',
+			agentDescription: '',
+			agentAvatarUrl: 'https://example.test/bot.svg',
+			title: 'Summarize post 12',
+			preview: 'Done.',
+			lastRole: 'agent',
+			messageCount: 2,
+			createdAt: '2026-07-30T10:00:00Z',
+			updatedAt: '2026-07-30T10:05:00Z',
+		};
+		const theirs = {
+			...mine,
+			id: 72,
+			agentId: 9,
+			agentName: 'Historian',
+			title: 'Something else entirely',
+			preview: 'Elsewhere.',
+		};
+		const fetchMock: FetchMock = vi.fn( async ( input: unknown ) => {
+			const url = String( input );
+			if ( url.endsWith( '/agents/conversations' ) ) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => [ mine, theirs ],
+				} as unknown as Response;
+			}
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ( {} ),
+			} as unknown as Response;
+		} );
+		( globalThis as unknown as { fetch: FetchMock } ).fetch = fetchMock;
+
+		const body = makeBody();
+		const cleanup = getRender()( body );
+		await flush();
+
+		// No active agent: the full list is the picker.
+		expect(
+			body.querySelectorAll( '.dm-agent-chat__conv' ),
+		).toHaveLength( 2 );
+
+		openAgentChat( {
+			id: 5,
+			name: 'TLDR Editor',
+			description: '',
+			avatarUrl: 'https://example.test/bot.svg',
+		} );
+		await flush();
+
+		// Active agent: only its own history — never another agent's.
+		const rows = body.querySelectorAll< HTMLElement >(
+			'.dm-agent-chat__conv',
+		);
+		expect( rows ).toHaveLength( 1 );
+		expect(
+			rows[ 0 ].querySelector( '.dm-agent-chat__conv-name' )!.textContent,
+		).toBe( 'TLDR Editor' );
+		expect( body.textContent ).not.toContain( 'Something else entirely' );
+
+		if ( typeof cleanup === 'function' ) {
+			cleanup();
+		}
+	} );
+
 	test( 'clicking a conversation avatar opens the agent editor, not the conversation', async () => {
 		const summary = {
 			id: 77,


### PR DESCRIPTION
## What it does

Scopes the Agent chat sidebar to the active agent: opening Localizer shows only Localizer's conversations, tldr only tldr's. Conversations never mix across agents anymore.

## Rationale

The sidebar listed every agent's conversations in one mixed list — the hub model carried over from the reference chat app (#428). In practice the window is always opened *for* a specific agent (Chat button, desktop tile, drag, Send to), so seeing other agents' history in that context read as a bug.

## Implementation

Presentation-level filter in `buildSidebar()` (`src/agent-run-window.ts`): with an agent active, only its rows render. One deliberate carve-out — a window with no agent seeded yet (cold-open / session restore) keeps the full labeled list as a picker, because a row click already re-targets the chat to its agent and filtering an empty context would strand every conversation.

The REST list route is unchanged (still owner-scoped with per-row agent identity), so the behavior is trivially adjustable later.

## Testing instructions

```bash
npm run test:js -- agent-run-window
```

New test: the picker state (no agent) shows both agents' rows; activating an agent hides the other agent's conversation. Verified live: tldr open → 7 rows, all tldr; Localizer open → only its 2.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-490-8539c3ee5ac70f9dd6b1257bbafa79e7e74598fe.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->