### PR TITLE
Admin bar: Keep the fullscreen tooltip in sync with the button state

### DIFF
--- a/assets/js/admin-bar.js
+++ b/assets/js/admin-bar.js
@@ -184,11 +184,11 @@
 			if ( on ) {
 				fsBtn.classList.add( 'is-fullscreen' );
 				if ( fsLabel ) fsLabel.textContent = fsI18n.exitFullscreen || 'Exit fullscreen';
-				if ( fsLink ) fsLink.setAttribute( 'title', fsI18n.exitTitle || 'Exit fullscreen' );
+				repaintLabel( fsLink, fsI18n.exitTitle || 'Exit fullscreen' );
 			} else {
 				fsBtn.classList.remove( 'is-fullscreen' );
 				if ( fsLabel ) fsLabel.textContent = fsI18n.enterFullscreen || 'Fullscreen';
-				if ( fsLink ) fsLink.setAttribute( 'title', fsI18n.enterTitle || 'Enter fullscreen' );
+				repaintLabel( fsLink, fsI18n.enterTitle || 'Enter fullscreen' );
 			}
 		}
 		fsBtn.addEventListener( 'click', function( e ) {
@@ -258,8 +258,8 @@
 	 * Re-anchors a native `title` attribute to a `data-desktop-tooltip`
 	 * data attribute on the same node, plus mirrors it to `aria-label`
 	 * so assistive tech keeps the description. Pure-CSS tooltip then
-	 * renders from the data attribute via the `[data-desktop-tooltip]
-	 * .ab-item::after` rule in admin-bar.php.
+	 * renders from the data attribute via the
+	 * `.ab-item[ data-desktop-tooltip ]::after` rule in admin-bar.php.
 	 */
 	function wireTooltipsFor( ids ) {
 		for ( var i = 0; i < ids.length; i++ ) {
@@ -275,6 +275,30 @@
 				link.setAttribute( 'aria-label', label );
 			}
 		}
+	}
+
+	/**
+	 * Relabels a button whose action changed under it (today: Fullscreen,
+	 * which flips between enter and exit). Writing only `title` is wrong
+	 * once `wireTooltipsFor()` has run: the visible tooltip renders from
+	 * `data-desktop-tooltip` and the accessible name comes from
+	 * `aria-label`, so a stale pair describes the opposite action while
+	 * the freshly re-added `title` brings the native OS tooltip back on
+	 * top of ours (GH#493).
+	 *
+	 * `title` is only touched when the node is still wearing one, which
+	 * makes this safe to call before wiring as well — the label lands on
+	 * `title` and `wireTooltipsFor()` re-anchors it from there.
+	 */
+	function repaintLabel( link, label ) {
+		if ( ! link ) return;
+		if ( link.hasAttribute( 'title' ) ) {
+			link.setAttribute( 'title', label );
+		}
+		if ( link.hasAttribute( 'data-desktop-tooltip' ) ) {
+			link.setAttribute( 'data-desktop-tooltip', label );
+		}
+		link.setAttribute( 'aria-label', label );
 	}
 
 	function wireShortcutsPopover( btn, data ) {

--- a/tests/vitest/admin-bar-fullscreen-label.test.ts
+++ b/tests/vitest/admin-bar-fullscreen-label.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The Fullscreen admin-bar button's label has to survive the tooltip
+ * rewrite.
+ *
+ * `assets/js/admin-bar.js` runs two passes over the same node.
+ * `wireTooltipsFor()` moves the server-rendered `title` onto
+ * `data-desktop-tooltip` (what the pure-CSS tooltip in `admin-bar.php`
+ * renders) and `aria-label` (the accessible name), then drops `title`
+ * so the native OS tooltip stops competing. `paintFullscreen()` then
+ * relabels the button on every `fullscreenchange`.
+ *
+ * Those two only agree if the repaint writes the same three attributes
+ * the wiring left behind. Writing `title` alone — which is what it used
+ * to do — left the tooltip and the accessible name describing the
+ * opposite action, and re-added the native tooltip on top of ours
+ * (GH#493).
+ *
+ * The file is a plain-JS IIFE with no exports (it's loaded by the
+ * server as a `<script>`, and it's one of the two hand-written files
+ * under `assets/js/`), so we mount the admin-bar markup the server
+ * renders and evaluate the real shipped source against it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE = readFileSync(
+	resolve( __dirname, '../../assets/js/admin-bar.js' ),
+	'utf8'
+);
+
+/** The i18n bag `openstation_admin_bar_config()` ships to the script. */
+const I18N = {
+	enterFullscreen: 'Fullscreen',
+	exitFullscreen: 'Exit fullscreen',
+	enterTitle: 'Enter fullscreen',
+	exitTitle: 'Exit fullscreen',
+};
+
+/**
+ * Renders the admin bar the way `admin_bar_menu` does. The toggle and
+ * the layout menu are both load-bearing for the fixture: the script
+ * returns early without either, and the server renders all three
+ * together whenever the shell is active. The Fullscreen button's only
+ * label is the `title` on its `.ab-item`.
+ */
+function mountAdminBar(): void {
+	document.body.innerHTML = `
+		<div id="wpadminbar">
+			<ul id="wp-admin-bar-top-secondary">
+				<li id="wp-admin-bar-os-toggle">
+					<a class="ab-item" href="#">Toggle</a>
+				</li>
+				<li id="wp-admin-bar-desktop-fullscreen" class="desktop-fullscreen-btn">
+					<a class="ab-item" role="menuitem" href="#" title="Enter fullscreen">
+						<span class="ab-icon dashicons dashicons-fullscreen-alt" aria-hidden="true"></span>
+					</a>
+				</li>
+				<li id="wp-admin-bar-desktop-layout-menu">
+					<a class="ab-item" href="#" title="Arrange windows"></a>
+					<div class="ab-sub-wrapper"><ul></ul></div>
+				</li>
+			</ul>
+		</div>
+	`;
+}
+
+function fsLink(): HTMLAnchorElement {
+	return document.querySelector(
+		'#wp-admin-bar-desktop-fullscreen .ab-item'
+	) as HTMLAnchorElement;
+}
+
+/**
+ * jsdom implements neither `fullscreenElement` nor the request/exit
+ * methods, so we stand in for the browser: define the property and let
+ * each test drive it before firing the event the script listens on.
+ */
+function setFullscreen( on: boolean ): void {
+	Object.defineProperty( document, 'fullscreenElement', {
+		value: on ? document.documentElement : null,
+		configurable: true,
+	} );
+	document.dispatchEvent( new Event( 'fullscreenchange' ) );
+}
+
+function runAdminBarScript(): void {
+	// eslint-disable-next-line no-new-func -- the shipped file is an
+	// IIFE with no exports; evaluating it is the only way to test it.
+	new Function( SOURCE )();
+}
+
+describe( 'admin-bar Fullscreen button label', () => {
+	beforeEach( () => {
+		( window as unknown as Record< string, unknown > )
+			.openStationAdminBar = { i18n: I18N };
+		mountAdminBar();
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		document.body.className = '';
+		delete ( window as unknown as Record< string, unknown > )
+			.openStationAdminBar;
+	} );
+
+	test( 'wiring moves the server title onto the tooltip + aria-label', () => {
+		runAdminBarScript();
+
+		const link = fsLink();
+		expect( link.hasAttribute( 'title' ) ).toBe( false );
+		expect( link.getAttribute( 'data-desktop-tooltip' ) ).toBe(
+			'Enter fullscreen'
+		);
+		expect( link.getAttribute( 'aria-label' ) ).toBe( 'Enter fullscreen' );
+	} );
+
+	test( 'entering fullscreen repaints tooltip and accessible name', () => {
+		runAdminBarScript();
+		setFullscreen( true );
+
+		const link = fsLink();
+		expect(
+			document.getElementById( 'wp-admin-bar-desktop-fullscreen' )
+				?.classList.contains( 'is-fullscreen' )
+		).toBe( true );
+		expect( link.getAttribute( 'data-desktop-tooltip' ) ).toBe(
+			'Exit fullscreen'
+		);
+		expect( link.getAttribute( 'aria-label' ) ).toBe( 'Exit fullscreen' );
+	} );
+
+	test( 'the repaint does not resurrect the native title tooltip', () => {
+		runAdminBarScript();
+		setFullscreen( true );
+
+		// Both tooltips visible at once was the other half of GH#493:
+		// ours from the data attribute, the browser's from `title`.
+		expect( fsLink().hasAttribute( 'title' ) ).toBe( false );
+	} );
+
+	test( 'exiting fullscreen restores the enter label', () => {
+		runAdminBarScript();
+		setFullscreen( true );
+		setFullscreen( false );
+
+		const link = fsLink();
+		expect(
+			document.getElementById( 'wp-admin-bar-desktop-fullscreen' )
+				?.classList.contains( 'is-fullscreen' )
+		).toBe( false );
+		expect( link.getAttribute( 'data-desktop-tooltip' ) ).toBe(
+			'Enter fullscreen'
+		);
+		expect( link.getAttribute( 'aria-label' ) ).toBe( 'Enter fullscreen' );
+		expect( link.hasAttribute( 'title' ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Fixes #493

## Proposed changes

The Fullscreen button in the admin bar now updates its tooltip and its `aria-label` when it flips between enter and exit, not just its icon and CSS class.

Before | After
--- | ---
<img width="113" height="68" alt="Screenshot 2026-08-05 at 15 51 13" src="https://github.com/user-attachments/assets/63ee388b-3717-4dda-a145-7ef51c5c2a78" /> |  <img width="129" height="72" alt="Screenshot 2026-08-05 at 15 53 31" src="https://github.com/user-attachments/assets/118d44d4-1f2b-4197-a7d9-87c002cbece6" />


## Why are these changes being made?

Because the tooltip of the exit fullscreen button said "Enter fullscreen" and screen readers announced the same, while the button would actually exit. 

## Testing instructions

1. Open OpenStation.
2. Hover the fullscreen icon in the admin bar (top right, next to the keyboard shortcuts icon). Make sure the tooltip says "Enter fullscreen" and only one tooltip appears.
3. Click it to enter fullscreen.
4. Hover it again. Make sure the tooltip now says "Exit fullscreen", and that there is still only one tooltip (on trunk you get our tooltip saying "Enter fullscreen" plus a native browser one saying "Exit fullscreen" a moment later).
5. Inspect the element. Make sure `data-desktop-tooltip="Exit fullscreen"` and `aria-label="Exit fullscreen"`, and that there is no `title` attribute. On trunk all three are wrong.
6. With a screen reader on (VoiceOver: Cmd+F5), focus the button while in fullscreen. Make sure it announces "Exit fullscreen".
7. Press Esc to leave fullscreen, then hover and inspect again. Make sure everything is back to "Enter fullscreen". Repeat with a click on the button instead of Esc, both paths go through the same repaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-499-3afd8af5b16fef25d854b5e38d3d032821b1b77d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->