### PR TITLE
Selection: hold more than one thing at a time

### DIFF
--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -152,7 +152,25 @@
 	align-items: center;
 	justify-content: flex-start;
 	gap: 6px;
-	width: 88px;
+	/*
+	 * `box-sizing` is load-bearing, not housekeeping. Without it the
+	 * horizontal padding is ADDED to the declared width, so an 88px
+	 * tile occupies 96px — which was exactly the desktop's old cell
+	 * pitch, and why icons sat edge to edge with no gap at all while
+	 * the maths insisted there were 8px between them.
+	 *
+	 * The tile is the size the grid says it is. Padding lives inside.
+	 */
+	box-sizing: border-box;
+	width: var( --os-tile-w, 88px );
+	/*
+	 * Fixed, not minimum. The tile box IS the selection ring, and a
+	 * box that grows with its label gives a row of selected icons a
+	 * ragged top edge — one height per label that happened to wrap
+	 * to two lines. Every tile occupies its cell; short labels leave
+	 * the slack inside the ring, where it reads as padding.
+	 */
+	height: var( --os-tile-h, 104px );
 	padding: 8px 4px;
 	border: 0;
 	background: transparent;
@@ -754,6 +772,58 @@
 	--os-tile-selected-bg: rgba( 34, 113, 177, 0.12 );
 }
 
+/* Type breakdown under a multi-selection's count in a folder
+ * window's preview pane. The count is the headline; this is the
+ * detail that tells you which actions the menu will offer. */
+.os-files-preview__selection-breakdown {
+	font-size: 12px;
+	opacity: 0.75;
+}
+
+/* While a rubber band is live, nothing in the shell is selectable.
+ *
+ * The band starts on bare canvas, which — unlike a tile — IS
+ * selectable, so the browser begins its own text selection on the
+ * same press and keeps extending it as the pointer travels. Inside
+ * the canvas that stays invisible; drag out over another window and
+ * it starts highlighting that window's text in blue, mid-gesture.
+ *
+ * The controller also refuses `selectstart` outright while the band
+ * is up. This rule is the second half: it covers anything already
+ * selectable that the event route misses. */
+body[ data-os-marquee ] {
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+/* Marquee (rubber-band) selection box. Painted by the shared
+ * selection controller on any canvas that opts into it — the
+ * wallpaper, folder windows, every My WordPress list — so this one
+ * declaration dresses all of them.
+ *
+ * `pointer-events: none` is load-bearing: the box tracks under the
+ * cursor for the whole gesture, and without it every hit-test
+ * (drop targets, the controller's own tile lookup) would land on
+ * the box instead of what's beneath it. */
+.os-selection-marquee {
+	position: absolute;
+	z-index: 5;
+	pointer-events: none;
+	border: 1px solid
+		var( --os-tile-focus-ring, var( --wp-admin-theme-color, #2271b1 ) );
+	border-radius: 2px;
+	/* A WASH, not a fill — the whole point of a rubber band is that
+	 * you can see what it is about to catch. `--os-ui-accent-dim` is a
+	 * solid hex (Pulse, one step back), so reaching for it directly
+	 * paints an opaque rectangle over the icons; `--os-ui-accent-soft`
+	 * is that same colour already taken down to a 14% wash, which is
+	 * what every other ambient accent surface in the shell uses. */
+	background: var(
+		--os-selection-marquee-bg,
+		var( --os-ui-accent-soft, rgba( 34, 113, 177, 0.14 ) )
+	);
+}
+
 .os-folder-status-bar {
 	display: flex;
 	justify-content: space-between;
@@ -961,7 +1031,10 @@ button.os-folder-status-bar__segment:hover {
 .os-file-tile__label {
 	font-size: 12px;
 	line-height: 1.2;
-	max-width: 84px;
+	/* Follows the tile rather than restating its width, so a section
+	 * that re-points `--os-tile-w` (image-led sections do) gets a
+	 * label that grows with the tile instead of staying narrow. */
+	max-width: calc( var( --os-tile-w, 88px ) - 4px );
 	text-align: center;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1001,6 +1074,65 @@ button.os-folder-status-bar__segment:hover {
 
 .os-drag-ghost--reject {
 	cursor: no-drop;
+}
+
+/* Multi-item drag ghost: the grabbed tile, with the rest of the set
+ * implied by two offset cards behind it and stated by a count badge.
+ * The stack is drawn with pseudo-elements rather than real clones —
+ * three cloned tiles cost three subtree copies per lift, and only
+ * the top one is ever legible. */
+.os-drag-stack {
+	/* The drag manager overwrites this with `position: fixed` when it
+	 * mounts the ghost. It stays declared so the stack still composes
+	 * correctly if the helper is used outside a live drag — both
+	 * values establish the containing block the cards and the badge
+	 * are placed against. */
+	position: relative;
+}
+
+.os-drag-stack::before,
+.os-drag-stack::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	z-index: -1;
+	border-radius: 6px;
+	background: var( --os-ui-surface, rgba( 30, 30, 40, 0.9 ) );
+	box-shadow: 0 4px 14px rgba( 0, 0, 0, 0.35 );
+}
+
+.os-drag-stack::before {
+	transform: translate( 6px, 6px );
+	opacity: 0.7;
+}
+
+.os-drag-stack::after {
+	transform: translate( 12px, 12px );
+	opacity: 0.45;
+}
+
+.os-drag-stack__count {
+	position: absolute;
+	inset-block-start: -8px;
+	inset-inline-end: -8px;
+	z-index: 1;
+	min-width: 20px;
+	height: 20px;
+	padding: 0 6px;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 10px;
+	background: var(
+		--os-ui-accent,
+		var( --wp-admin-theme-color, #2271b1 )
+	);
+	color: #fff;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1;
+	box-shadow: 0 2px 8px rgba( 0, 0, 0, 0.4 );
 }
 
 /* ============================================================ *

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -217,8 +217,17 @@
  * The cell pitch lives in `TILE_METRICS_LARGE` (src/my-wordpress/
  * index.ts) and the two MUST move together — a wider tile in a cell
  * that didn't grow overlaps its neighbour. */
-.os-my-wordpress__tiles--large .os-file-tile {
-	width: 132px;
+/*
+ * Image-led sections re-point the tile tokens for their whole
+ * subtree rather than overriding the tile's width directly. The base
+ * `.os-file-tile` rule then sizes itself from them, and so does
+ * everything derived from them (the label's max-width, the loading
+ * skeletons) — one declaration instead of a chain of overrides that
+ * have to be kept in step.
+ */
+.os-my-wordpress__tiles--large {
+	--os-tile-w: var( --os-tile-w-large, 132px );
+	--os-tile-h: var( --os-tile-h-large, 160px );
 }
 
 .os-my-wordpress__tiles--large .os-file-tile__visual,
@@ -504,7 +513,10 @@
 	flex-direction: column;
 	align-items: center;
 	gap: 6px;
-	width: 88px;
+	/* Same box as the real tile it stands in for — a skeleton that
+	 * doesn't match the grid makes the list jump when rows land. */
+	width: var( --os-tile-w, 88px );
+	height: var( --os-tile-h, 104px );
 	padding: 8px 4px;
 	box-sizing: border-box;
 	pointer-events: none;
@@ -561,6 +573,8 @@
 
 .os-my-wordpress__preview-empty {
 	display: flex;
+	flex-direction: column;
+	gap: 6px;
 	align-items: center;
 	justify-content: center;
 	height: 100%;
@@ -568,6 +582,29 @@
 	font-size: 13px;
 	padding: 24px;
 	text-align: center;
+}
+
+/* Type / status breakdown under a multi-selection's count. */
+.os-my-wordpress__preview-selection-breakdown {
+	font-size: 12px;
+	opacity: 0.75;
+}
+
+/* One labelled control in the bulk-edit modal. Label above field,
+ * because the fields are wide (a category tree, a tag row) and a
+ * two-column grid would put a one-word label beside a control four
+ * times its height. */
+.os-my-wordpress__bulk-row {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-block-end: 16px;
+}
+
+.os-my-wordpress__bulk-label {
+	font-size: 12px;
+	font-weight: 600;
+	color: var( --os-ui-fg-muted, #787c82 );
 }
 
 .os-my-wordpress__preview-loading {
@@ -1820,8 +1857,12 @@ os-tile[ status='future' ] .os-file-tile__icon {
 .os-my-wordpress__media-grid {
 	display: grid;
 	grid-template-columns: repeat( auto-fill, minmax( 120px, 1fr ) );
-	gap: 12px;
-	padding: 16px;
+	/* A flow grid rather than the absolute canvas, but the air
+	 * between two icons should not depend on which window you are
+	 * looking at — so the gaps and the gutter come from the same
+	 * tokens the canvas pitch is built from. */
+	gap: var( --os-grid-gap-y, 16px ) var( --os-grid-gap-x, 20px );
+	padding: var( --os-grid-padding, 16px );
 	overflow-y: auto;
 	align-content: start;
 }
@@ -1840,6 +1881,10 @@ os-tile[ status='future' ] .os-file-tile__icon {
 	 * the tile. */
 	position: relative;
 	width: auto;
+	/* …and out of the fixed tile height for the same reason: a media
+	 * tile is a square thumbnail plus a caption, sized by the grid
+	 * column it lands in, not by the icon-canvas cell. */
+	height: auto;
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
@@ -2008,8 +2053,8 @@ os-tile[ status='future' ] .os-file-tile__icon {
 .os-my-wordpress__usage-grid {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 12px 8px;
-	padding: 16px;
+	gap: var( --os-grid-gap-y, 16px ) var( --os-grid-gap-x, 20px );
+	padding: var( --os-grid-padding, 16px );
 	align-content: flex-start;
 }
 
@@ -2018,7 +2063,7 @@ os-tile[ status='future' ] .os-file-tile__icon {
  * canvas-positioned post tiles use — except for `position: static`
  * so they participate in the flex layout. */
 .os-my-wordpress__tile--usage {
-	width: 88px;
+	width: var( --os-tile-w, 88px );
 	align-items: center;
 	padding: 8px 4px;
 	gap: 6px;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -143,6 +143,52 @@ body.os-active {
 	--os-backstop: #0c0b0f;
 	--os-area-inset: 0;
 
+	/*
+	 * ── The icon grid ────────────────────────────────────────────
+	 *
+	 * ONE grid, everywhere placements are laid out: the wallpaper,
+	 * folder windows, and every canvas in the site folder. Before
+	 * these tokens each surface carried its own pitch and its own
+	 * tile width, and the two drifted apart — the desktop ended up
+	 * with an 88px tile in a 96px cell whose 8px of air the tile's
+	 * own padding ate, so icons touched edge to edge while the site
+	 * folder had 20px between them.
+	 *
+	 * The cell is derived, never declared: `cell = tile + gap`. A
+	 * gap you can see is the whole point, so it is the number that
+	 * gets tuned; the pitch follows.
+	 *
+	 * The TypeScript side mirrors these in `src/desktop-files/grid.ts`
+	 * (layout maths can't read CSS), and
+	 * `tests/vitest/grid-metrics.test.ts` parses this file to prove
+	 * the two agree. Change a number here and that test tells you
+	 * exactly which constant to move with it.
+	 */
+	--os-tile-w: 88px;
+	/*
+	 * A FIXED height, and it has to fit the tallest a tile can get:
+	 * 8px padding + 48px icon well + 6px gap + two clamped label
+	 * lines (2 × 12px × 1.2 = 28.8px) + 8px padding = 98.8px, so
+	 * 104px with a little slack for font metrics.
+	 *
+	 * Fixed rather than minimum because the selection ring is drawn
+	 * around the tile box: let the box follow its label and a row of
+	 * selected icons is a ragged run of different-height rectangles,
+	 * one per label that happened to wrap.
+	 */
+	--os-tile-h: 104px;
+	--os-grid-gap-x: 20px;
+	--os-grid-gap-y: 16px;
+	/* Gutter from the top / inline-start edge of any icon canvas. */
+	--os-grid-padding: 16px;
+	/*
+	 * Image-led sections opt into a bigger tile (`tileSize: 'large'`)
+	 * — a shop's products read as a catalogue, not a file list. Same
+	 * gaps, bigger tile.
+	 */
+	--os-tile-w-large: 132px;
+	--os-tile-h-large: 160px;
+
 	/* Window chrome — Obsidian body inside a Starlight hairline. */
 	--os-window-bg: #1a1721;
 	--os-window-border: rgba(255, 251, 255, 0.12);

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -80,6 +80,7 @@ The full surface is documented in [`javascript-reference.md`](./javascript-refer
 | `subscribe` | `( topic: string, cb ) => () => void` *(cross-window)* | Stable |
 | — topic family | `os.<type>.changed` *(content-change realtime; `{ source, action, ids }`)* | Stable |
 | `presence` | `PresenceApi` | Stable |
+| `selection` | `SelectionApi` *(`active()`, `resolveCommonActions()`, `createModel()`)* | Experimental |
 
 ### Commands, palettes, AI, settings
 
@@ -211,6 +212,7 @@ Every event bubbles from `document`. See [`javascript-reference.md`](./javascrip
 | `os-window-content-changed` | Experimental |
 | `os-window-link-groups-changed` | Experimental |
 | `os-presence-changed` | Stable |
+| `os-selection-changed` | Experimental |
 | `os-layout-changed` | Stable |
 | `os-registry-changed` | Stable |
 | `os.drag.start` / `.move` / `.enter` / `.leave` / `.rejected` / `.commit` / `.cancel` / `.end` | Stable |

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -100,7 +100,7 @@ The search box above the list filters on the flattened descriptor, not just the 
 | --- | --- | --- | --- |
 | `<os-table>` | `OsTable` | `os-table/os-table.ts` | Sortable, filterable data table with sub-tables. |
 | `<os-log>` | `OsLog` | `os-log/os-log.ts` | Virtualized streaming log container. |
-| `<os-tile>` | `OsTile` | `os-tile/os-tile.ts` | Desktop-style icon tile (used by the desktop file layer, folder windows, and the site folder). |
+| `<os-tile>` | `OsTile` | `os-tile/os-tile.ts` | Desktop-style icon tile (used by the desktop file layer, folder windows, and the site folder). `selectable` switches it from `listitem` to `option` so it can carry `aria-selected` — the selection controller sets it. |
 
 ## Tabs & navigation
 

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -483,6 +483,23 @@ Read `assets/css/variables.css` for the full set.
 > defaults to the dark `#1d2327`, which would read as a dark blink on a
 > light theme.
 
+> **The icon grid is a token set, and it is one grid.**
+> `--os-tile-w` / `--os-tile-h`, `--os-grid-gap-x` / `--os-grid-gap-y`
+> and `--os-grid-padding` describe every surface that lays out
+> placements: the wallpaper, folder windows, and each canvas in the
+> site folder. Widen a gap and all of them widen together — that is
+> the point of them being one declaration.
+>
+> The **cell pitch is derived, never declared**: `cell = tile + gap`.
+> The layout maths can't read CSS, so `src/desktop-files/grid.ts`
+> mirrors these numbers and `tests/vitest/grid-metrics.test.ts` parses
+> the stylesheet to prove the mirror is faithful. A theme retuning
+> them shifts the *visual* spacing; stored icon coordinates snap to
+> the new pitch the next time a tile is dragged or the canvas is
+> sorted, so expect a one-time reshuffle rather than an instant
+> re-layout. `--os-tile-w-large` / `--os-tile-h-large` do the same job
+> for image-led sections (`tileSize: 'large'`).
+
 > **`--os-window-radius` is not one of them in practice.**
 > The Window-corners preset in OpenStation Settings writes that property as an
 > inline style on the shell root, which outranks any stylesheet rule,

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
 - [Site folder — add a preview-pane action button](./my-wordpress-media-action.md)
 - [Site folder — custom post types and their folder](./my-wordpress-cpt-section.md)
 - [Accept drops on your desktop icon](./tile-drop-handler.md)
+- [Add an action that works on a whole selection](./multi-selection-action.md)
 - [Window lifecycle hooks (one subscriber per state)](./window-lifecycle.md)
 - [Custom arrange-menu action](./arrange-action.md)
 - [Style a specific admin page inside the iframe](./chromeless-style-override.md)

--- a/docs/examples/multi-selection-action.md
+++ b/docs/examples/multi-selection-action.md
@@ -1,0 +1,161 @@
+# Add an action that works on a whole selection
+
+Every tile canvas in OpenStation is multi-select: the wallpaper, folder windows, and each list inside the site folder. A menu entry you add through `os.files.tile-menu` or `os.my-wordpress.tile-context-menu` keeps working exactly as before — and appears only when **one** item is selected — until you tell the framework it is safe for a set.
+
+This recipe adds an "Archive" action that appears for a single tile *and* for a selection of many, and that hits the server once for the whole set rather than once per item.
+
+## The whole thing
+
+```php
+<?php
+/**
+ * Plugin Name: Archive Action
+ */
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'admin_enqueue_scripts', function () {
+    if ( ! function_exists( 'openstation_is_enabled' ) || ! openstation_is_enabled() ) {
+        return;
+    }
+    wp_enqueue_script(
+        'my-archive-action',
+        plugin_dir_url( __FILE__ ) . 'archive-action.js',
+        array( 'wp-hooks' ),
+        '1.0.0',
+        true
+    );
+} );
+```
+
+```js
+// archive-action.js
+( function () {
+    async function archive( placements ) {
+        const ids = placements.map( ( p ) => p.id );
+        // One request for the set. Always route HTTP through
+        // wp.os.fetch so the window's spinner and the activity bus
+        // see it.
+        await window.wp.os.fetch(
+            '/wp-json/my-plugin/v1/archive',
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify( { ids } ),
+            },
+            { source: 'my-plugin/archive' }
+        );
+        window.wp.os.showToast( {
+            message:
+                ids.length === 1
+                    ? 'Archived.'
+                    : `${ ids.length } items archived.`,
+        } );
+    }
+
+    window.wp.hooks.addFilter(
+        'os.files.tile-menu',
+        'my-plugin/archive',
+        function ( items, placement ) {
+            // Only archive real user files.
+            if ( placement.file.type === 'shortcut' ) {
+                return items;
+            }
+            items.push( {
+                id: 'my-plugin/archive',
+                label: 'Archive',
+                icon: 'dashicons-archive',
+                sort: 50,
+
+                // Opt in. Without this the entry is single-item only.
+                multi: true,
+
+                // What the entry says about a set.
+                bulkLabel: ( n ) => `Archive ${ n } items`,
+
+                // ONE call for the whole selection.
+                bulk: ( placements ) => archive( placements ),
+
+                // The single-item handler. Still required — it is what
+                // runs when exactly one tile is selected.
+                onClick: () => archive( [ placement ] ),
+            } );
+            return items;
+        }
+    );
+} )();
+```
+
+## What the framework does with that
+
+When the user right-clicks with several tiles selected, the shell asks *every* selected placement for its actions and keeps the ids that all of them offer **and** that all of them mark `multi: true`. Your entry survives a selection of five posts; it drops out the moment one of the five is a `shortcut`, because your own guard didn't offer it there. That is the point — the menu can only ever show you what is true for the whole set.
+
+Then it runs `bulk( items )` once. Had you omitted `bulk`, the framework would have fanned out instead, calling each item's own `onClick` in turn — correct, but five requests and five toasts where one of each will do.
+
+## Two things worth knowing
+
+**`multiId` merges actions that are the same deed under different labels.** A folder tile offers `delete-folder` ("Move folder to Trash") and a file tile offers `remove` ("Move to Trash"). Selecting one of each is ordinary, and intersecting on the raw ids would leave that selection with nothing to do. Both declare `multiId: 'trash'` and merge into one entry. If your plugin adds a differently-labelled variant of an existing action, give it the same `multiId`.
+
+**Don't opt in what can't take it.** An action that opens a modal, prompts for a name, or navigates the window is about one thing. Left as-is it simply won't appear for a set, which is the honest outcome — better than twelve stacked dialogs.
+
+## Acting on a set from outside the menu
+
+`os.selection.actions` fires on the already-resolved list for a multi-selection (never for a single item), so you can add an entry that only makes sense for several things at once:
+
+```js
+window.wp.hooks.addFilter(
+    'os.selection.actions',
+    'my-plugin/compare',
+    ( actions, { items, count } ) =>
+        count === 2
+            ? [
+                ...actions,
+                {
+                    id: 'my-plugin/compare',
+                    label: 'Compare these two',
+                    icon: 'dashicons-columns',
+                    onClick: () => openComparison( items ),
+                },
+            ]
+            : actions
+);
+```
+
+## Accepting a dropped selection
+
+A drop target sees the same set the menu does. The two helpers give
+you one code path for "one" and "many":
+
+```js
+import { dragPlacements } from 'openstation/desktop-files';
+
+wp.os.dragManager.registerDropTarget( {
+    id: 'my-plugin/zone',
+    element: myZone,
+    // Every member has to be acceptable. Taking a set and handling
+    // part of it tells the user the whole drop worked.
+    accept: ( payload ) =>
+        payload.type === 'desktop-file' &&
+        dragPlacements( payload.data ).every( ( p ) => p.file.type === 'post' ),
+    onDrop: ( session ) => {
+        const placements = dragPlacements( session.payload.data );
+        // One request for the set, not one per item.
+        void archiveAll( placements );
+    },
+} );
+```
+
+Targets that ignore `placements` entirely still work — they act on
+`data.placement`, the tile the user actually grabbed.
+
+## Reacting to selection
+
+To react anywhere in the shell without owning a menu at all:
+
+```js
+document.addEventListener( 'os-selection-changed', ( e ) => {
+    const { surface, keys, count } = e.detail;
+    console.log( count, 'selected in', surface, keys );
+} );
+```
+
+**See also:** [`wp.os.selection`](../javascript-reference.md#selection--experimental) for the full field table, and [files on the desktop](../files-on-desktop.md) for the FilesLayer handle's `getSelection()` / `onSelectionChanged()`.

--- a/docs/examples/multi-selection-action.md
+++ b/docs/examples/multi-selection-action.md
@@ -95,6 +95,16 @@ Then it runs `bulk( items )` once. Had you omitted `bulk`, the framework would h
 
 **`multiId` merges actions that are the same deed under different labels.** A folder tile offers `delete-folder` ("Move folder to Trash") and a file tile offers `remove` ("Move to Trash"). Selecting one of each is ordinary, and intersecting on the raw ids would leave that selection with nothing to do. Both declare `multiId: 'trash'` and merge into one entry. If your plugin adds a differently-labelled variant of an existing action, give it the same `multiId`.
 
+Merging does **not** hand one runner the whole set. The framework groups the selection by `bulk` function identity and calls each runner once with the items whose own contributor declared it — so a folder is never pushed through a file's implementation just because the user happened to select it first. If you want your merged action to batch as a single call alongside a built-in, share the same function reference:
+
+```js
+// Shared once, at module scope — not a fresh arrow at each site,
+// which is a different identity and therefore a second batch.
+const archiveAll = ( placements ) => archive( placements );
+
+// …then `bulk: archiveAll` everywhere the action is offered.
+```
+
 **Don't opt in what can't take it.** An action that opens a modal, prompts for a name, or navigates the window is about one thing. Left as-is it simply won't appear for a set, which is the honest outcome — better than twelve stacked dialogs.
 
 ## Acting on a set from outside the menu

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -350,6 +350,46 @@ Every store mutation also dispatches a `os-files-changed` CustomEvent on `docume
 
 A `FilesLayer` is the renderer that mounts on a host element (the `#os-area` for the root) and paints one tile per placement. The shell automatically mounts a root layer at boot when the desktop area DOM is present.
 
+### The grid
+
+There is **one** icon grid, and every surface that lays out
+placements uses it — the wallpaper, folder windows, and each canvas
+in the site folder. It is declared once, as design tokens in
+`assets/css/variables.css`:
+
+| Token | Default | What it is |
+|---|---|---|
+| `--os-tile-w` / `--os-tile-h` | `88px` / `104px` | The tile's box. Height is **fixed**, not a minimum — see below. |
+| `--os-grid-gap-x` / `--os-grid-gap-y` | `20px` / `16px` | Air between neighbours. |
+| `--os-grid-padding` | `16px` | Gutter from the canvas edge. |
+| `--os-tile-w-large` / `--os-tile-h-large` | `132px` / `160px` | Image-led sections (`tileSize: 'large'`). |
+
+**The cell pitch is derived, never declared** — `cell = tile + gap`.
+A gap you can see is the thing worth tuning; the pitch just follows.
+`src/desktop-files/grid.ts` mirrors these numbers for the layout
+maths (which can't read CSS) and exports `GRID_METRICS` /
+`GRID_METRICS_LARGE` so no surface has to restate them.
+`tests/vitest/grid-metrics.test.ts` parses the stylesheet and fails
+if the two ever drift.
+
+Two consequences worth knowing, both learned the hard way:
+
+- The tile is `box-sizing: border-box`, so its declared width **is**
+  its real width. Without that the horizontal padding lands outside
+  the declared box, fills the cell, and neighbouring icons touch
+  while the arithmetic insists there is a gap between them.
+- The height is **fixed**, not a minimum. The tile box is what the
+  selection ring is drawn around, so a box that grows with its label
+  gives a row of selected icons a ragged top edge — one height per
+  label that happened to wrap to two lines. `--os-tile-h` has to fit
+  the tallest a tile can be (icon well + two clamped label lines +
+  padding); a test asserts it does, and tells you so if you change
+  the icon size or the label clamp.
+
+Surfaces that lay tiles out in CSS flow rather than on the canvas —
+the media grid — opt out with `height: auto`, because a square
+thumbnail is sized by its grid column, not by the icon cell.
+
 ### Tile DOM contract
 
 ```html
@@ -390,6 +430,52 @@ Lifecycle:
      (the FilesLayer's canvas / a folder tile / the Trash);
      non-accepting hover ends with `os.drag.cancel`
      (`reason: 'rejected'` or `'no-target'`).
+
+### Dragging a selection
+
+A drag that starts on a **selected** tile carries the whole selection;
+starting on an unselected one makes that tile the selection first and
+drags it alone — Finder's rule, and the reason a drag never moves
+something the user can't see is highlighted.
+
+The payload grew one field per type, and nothing else changed:
+
+```ts
+// 'desktop-file'
+{ placement: RestPlacementShape,       // the tile the user grabbed
+  placements?: RestPlacementShape[],   // the whole set — absent when 1
+  sourceFolderId: number, … }
+
+// 'shortcut'
+{ kind, ref, title?, icon?, entityId?, // the entity the user grabbed
+  items?: ShortcutDragItem[], …  }     // the whole set — absent when 1
+```
+
+**A drop target written before multi-drag is not broken.** It reads
+`data.placement` and acts on the grabbed tile, which is the one the
+user pointed at. To handle sets, read them through the helper:
+
+```ts
+import { dragPlacements, dragShortcutItems } from 'openstation/desktop-files';
+
+onDrop: ( session ) => {
+    for ( const placement of dragPlacements( session.payload.data ) ) {
+        // Runs once for a single drag, N times for a set.
+    }
+},
+```
+
+Two rules the built-in targets follow, and yours should:
+
+- **Accept all or refuse all.** Every per-item gate (folder cycles,
+  synthetic placements, `canTrash`) is applied to every member of the
+  set, and one failure refuses the drop. Accepting a set and moving
+  four of five reports success for an operation that half-happened.
+- **One gesture, one outcome.** Dropping a set on the Trash produces
+  one toast with one Undo that restores all of it, not N of each.
+
+The ghost shows the grabbed tile over a stack with a count badge, and
+the hover chip says the count too ("Move 3 items here").
 
 Drop target contract (`wp.os.dragManager.registerDropTarget`):
 
@@ -487,14 +573,61 @@ doAction( 'os.tile.rendered', { tile: HTMLElement } );
 
 Use the generic `os.tile.*` pair when you want to decorate tiles **everywhere** (site-folder sections, drill-in usage grids, any future surface using `<os-tile>`). The placement-shaped pair stays scoped to desktop files. Both are **Stable** (placement-shaped) and **Experimental** (generic).
 
+### Selection
+
+The layer runs the framework selection controller (see
+[`wp.os.selection`](./javascript-reference.md#selection--experimental)), so
+the wallpaper and every folder window behave like a file manager:
+click replaces, `Ctrl`/`Cmd`+click toggles, `Shift`+click extends,
+a drag on empty wallpaper draws a marquee, `Ctrl`/`Cmd`+A selects
+all, `Escape` clears. Selection survives every repaint path — a
+heartbeat delta or a peer's edit doesn't drop what the user is
+holding — and a placement that disappears drops out of the set.
+
+Right-clicking a tile that is **not** selected replaces the selection
+with it before opening the menu (Finder / Explorer behaviour); one
+that **is** selected leaves the set alone, so the menu acts on all of
+it. What a mixed set may do is decided by `resolveCommonActions`:
+actions common to every selected placement, and only those declaring
+`multi: true`. `os.files.tile-menu` entries are unchanged and stay
+single-item until they opt in — see the field table in the JS
+reference.
+
+The built-ins that opted in: **Open** (fan-out, with a confirm past
+five windows), **Move to Trash** (one batched runner — one toast, one
+Undo, one broadcast; folder and file entries share
+`multiId: 'trash'` so a mixed set is still throwable-away), and
+**Hide from desktop** (one settings write for the whole set).
+*Rename…*, *Navigate into* and *Download* are inherently single-item.
+
+The folder window's status bar gains a `selection` segment
+(`"3 selected"`) while a selection exists, and its preview pane shows
+a count-and-type summary instead of previewing one arbitrary member.
+The `os.files.folder-window.status-bar` filter context carries
+`selectedCount`.
+
 ### Public API
 
 ```ts
 import { mountFilesLayer } from 'openstation/desktop-files';
 const handle = mountFilesLayer( hostElement, folderId );
+
+// Selection.
+handle.getSelection();                    // RestPlacementShape[], visual order
+handle.onSelectionChanged( ( ps ) => …);  // the whole set, every change
+handle.onSelectionChange( ( p ) => … );   // the ONE selected placement, else null
+handle.selectAll();
+handle.clearSelection();
+
 // later
 handle.dispose();
 ```
+
+`onSelectionChange` predates multi-selection and keeps its contract:
+it reports the placement when exactly one is selected and `null`
+otherwise — an empty selection and a multi-selection are the same
+news to a consumer that shows one thing at a time. Use
+`onSelectionChanged` to see the set.
 
 ## Wallpaper context menu *(Phase 4)*
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -276,6 +276,34 @@ document.addEventListener( 'os-presence-changed', ( e ) => {
 
 ---
 
+### `os-selection-changed` — Experimental
+
+Fires whenever the selection changes on any tile canvas in the shell — the wallpaper, a folder window, or a list inside My WordPress. Every surface routes through the same controller, so one listener covers all of them.
+
+```javascript
+document.addEventListener( 'os-selection-changed', ( e ) => {
+    const { surface, scope, keys, count } = e.detail;
+    if ( surface === 'files' && count > 1 ) {
+        showBulkHint( count );
+    }
+} );
+```
+
+**`detail` shape:**
+
+```typescript
+{
+    surface: string,   // 'files' | 'my-wordpress' | a plugin's own slug
+    scope:   string,   // folder id, entity id — narrows the surface
+    keys:    string[], // the surface's item keys, in visual order
+    count:   number,
+}
+```
+
+An empty selection fires too, with `keys: []` and `count: 0`. See [`wp.os.selection`](#selection--experimental) for the synchronous reader and the action-resolution rules.
+
+---
+
 ### `os-layout-changed` — Stable
 Fires when the user picks a new top-level desktop layout in OpenStation Settings → Appearance. The shell tears down and rebuilds the dock(s) before the event fires; plugins that cached `wp.os.dock` should re-fetch from the event detail (or read `wp.os.dock` again — it's mutated in place). The shell root reflects the new value in `data-os-layout` attribute by the time this fires, so CSS selectors keyed on it will already match.
 
@@ -336,6 +364,29 @@ document.addEventListener( 'os.drag.end', ( e ) => {
     // e.detail.{ payload, reason }
 } );
 ```
+
+**Multi-item drags** — *Experimental.* A drag that starts on a tile
+belonging to the current selection carries the whole selection. Two
+optional payload fields express it, and a target that ignores them
+still behaves correctly:
+
+| Payload type | Grabbed item | The whole set |
+|---|---|---|
+| `'desktop-file'` | `data.placement` | `data.placements?` |
+| `'shortcut'` | `data.{ kind, ref, … }` | `data.items?` |
+
+Both are **absent for a single-item drag**, so payloads for the
+ordinary gesture are unchanged. Read them through
+`dragPlacements( data )` / `dragShortcutItems( data )`, which fall
+back to the grabbed item — one code path for "one" and "many". A
+target that keeps reading `data.placement` acts on the tile the user
+pointed at, which is a defensible outcome rather than a broken one.
+
+If your target supports sets, apply its accept-gates to every member
+and refuse the whole drop when any one fails: accepting a set and
+handling part of it reports success for an operation that
+half-happened. See [files on the desktop](./files-on-desktop.md#dragging-a-selection)
+for the full contract.
 
 The cross-iframe `os-drag-*` / `os-drop`
 postMessages and the `os-cross-frame-drag-start` /
@@ -1384,6 +1435,86 @@ The server-side `openstation_presence_visible_users` filter gates which users su
 **Companion CustomEvent:** [`os-presence-changed`](#os-presence-changed--stable) fires once per status transition per user, with a `null` oldStatus on first sighting.
 
 **See also:** [`docs/examples/presence.md`](./examples/presence.md) for an end-to-end recipe.
+
+---
+
+### `selection` — Experimental
+
+Multi-selection is framework-level. Every tile canvas in the shell — the wallpaper, folder windows, and each list inside My WordPress — runs the same selection controller, so the gestures are identical everywhere: click replaces, `Ctrl`/`Cmd`+click toggles, `Shift`+click extends from the anchor, a drag on empty space draws a marquee, `Ctrl`/`Cmd`+A selects all, `Escape` clears.
+
+```javascript
+// Snapshot of the most recent selection change anywhere in the shell.
+wp.os.selection.active();
+// → { surface: 'files', scope: '0', keys: [ '12', '19' ], count: 2 } | null
+
+// React to selection anywhere.
+document.addEventListener( 'os-selection-changed', ( e ) => {
+    console.log( e.detail.count, 'selected in', e.detail.surface );
+} );
+```
+
+`surface` is `'files'` for a FilesLayer canvas and `'my-wordpress'` for a My WordPress list; `scope` narrows it (folder id, entity id). `keys` are the surface's own item keys — placement ids on the desktop, entry ids in My WordPress — as strings.
+
+#### What a mixed selection may do
+
+The hard part of multi-selection isn't the highlight, it's deciding what a set of unlike things can be asked to do. The rule lives in one place, `wp.os.selection.resolveCommonActions( items, actionsFor )`:
+
+- **One item selected** → that item's own action list, untouched. Single-item menus are exactly what they were before multi-selection existed.
+- **Several** → intersect by action `id`, and keep an id only when **every** contributing action declares `multi: true`.
+
+So selecting a post and an image leaves *Move to Trash* (both offer it, both marked multi-safe) and drops *Navigate into* (post-only) and *Download* (image-only).
+
+`multi` is opt-in on purpose. An action written against one item — "Rename…", "Share folder…", anything that opens a modal — would misbehave run twelve times over, and its author never agreed to that. Your menu entries keep working unchanged and simply don't appear in a multi-selection until you opt in.
+
+Four fields control the multi-selection behaviour of any menu entry, on both the `os.files.tile-menu` and `os.my-wordpress.tile-context-menu` filters:
+
+| Field | Meaning |
+|---|---|
+| `multi` | `true` to allow the action into a multi-selection menu. Default `false`. |
+| `multiId` | Identity to intersect on, when the same *deed* carries different single-item labels. The folder tile's `delete-folder` and the file tile's `remove` both declare `multiId: 'trash'`, so a mixed selection can still be thrown away. Defaults to `id`. |
+| `bulkLabel( n )` | Label for a set. Falls back to `"<label> (N items)"`. |
+| `bulk( items )` | Batched runner, called ONCE with the whole set. Without it the framework fans out, running each item's own `onClick` in turn. |
+
+```javascript
+wp.os.hooks.addFilter(
+    'os.files.tile-menu',
+    'my-plugin/archive',
+    ( items, placement ) => [
+        ...items,
+        {
+            id: 'my-plugin/archive',
+            label: 'Archive',
+            icon: 'dashicons-archive',
+            sort: 50,
+            multi: true,
+            bulkLabel: ( n ) => `Archive ${ n } items`,
+            bulk: ( placements ) => archiveAll( placements ),
+            onClick: () => archiveAll( [ placement ] ),
+        },
+    ],
+);
+```
+
+Prefer a `bulk` runner over fan-out whenever the action talks to the server or the user: it is what turns twelve REST calls, twelve toasts and twelve Undo buttons into one of each. The built-in "Move to Trash" does exactly this.
+
+#### `os.selection.actions` — JS filter
+
+Fires on the **resolved** action list for a multi-selection (never for a single item, whose menu is the surface's own). Receives the merged actions plus `{ items, count }`, so you can add an entry that only makes sense for a set.
+
+```javascript
+wp.os.hooks.addFilter(
+    'os.selection.actions',
+    'my-plugin/compare',
+    ( actions, { items, count } ) =>
+        count === 2
+            ? [ ...actions, { id: 'compare', label: 'Compare these two', onClick: () => compare( items ) } ]
+            : actions,
+);
+```
+
+#### Building your own selectable canvas
+
+`wp.os.selection.createModel( { order } )` returns the set + anchor primitive (`set` / `add` / `remove` / `toggle` / `selectRange` / `selectAll` / `clear` / `prune` / `subscribe`) if you are wiring a surface the shell doesn't own. `order()` must return the item keys in the order the user *sees* them — that is what a `Shift`+click range walks.
 
 ---
 
@@ -5817,11 +5948,56 @@ wp.hooks.addFilter(
 );
 ```
 
-Context: `{ entityId, kind, item }`. Currently wired on the post /
-page tile menu (`kind` from the entity, default `'post'`) and the
-media tile menu (`kind: 'attachment'`); the user tile menu will
-subscribe to the same hook in a follow-up — write the filter as if
-the hook fires for every section.
+Context: `{ entityId, kind, item }`. Wired on the post / page tile
+menu (`kind` from the entity, default `'post'`), the media tile menu
+(`kind: 'attachment'`), and the user tile menu (`kind: 'user'`) —
+write the filter as if the hook fires for every section.
+
+**Multi-selection.** These lists are multi-select, and an entry you
+add here appears only while ONE tile is selected until it opts in.
+Add `multi: true` (plus optionally `sort`, `bulkLabel( n )`, and a
+`bulk( items )` runner) to let it act on a set — the fields and the
+intersection rules are the same ones the file-tile menu uses, and
+they're documented under
+[`wp.os.selection`](#selection--experimental).
+
+#### Built-in bulk actions
+
+The lists carry wp-admin's own bulk actions, as multi-safe entries
+on the same menu. Your filter sees them in `options` and can reorder
+or remove them by id.
+
+| Section | Id | Equivalent in wp-admin |
+|---|---|---|
+| Posts / Pages / CPTs | `open` | Row action → Edit |
+| | `navigate-into` | *(no equivalent — the dossier view)* |
+| | `bulk-edit` | **Bulk actions → Edit** — status, author, comments, sticky, add categories, add tags |
+| | `publish` | Row action → Publish *(hidden for already-published entries)* |
+| | `to-draft` | Row action → Switch to Draft *(hidden for entries already drafts)* |
+| | `copy-links` | *(no equivalent)* |
+| | `trash` | **Bulk actions → Move to Trash** |
+| Media | `navigate-into`, `open-source` | Row actions |
+| | `detach` | Row action → Detach *(hidden for unattached files)* |
+| | `copy-links` | *(copies `source_url`)* |
+| | `delete` | **Bulk actions → Delete permanently** |
+| Users | `footprint`, `open-profile`, `author-archive` | Row actions |
+| | `change-role` | **Bulk actions → Change role to…** |
+| | `delete-user` | **Bulk actions → Delete** — asks core's "delete their content or reassign it" question |
+
+Two behaviours of the bulk-edit modal are worth knowing because they
+are core's, not ours: every control starts on **— No change —** and a
+field left alone is absent from the request (so a bulk edit can never
+overwrite eleven entries with the twelfth's values), and **categories
+and tags are additive** — the terms you pick are added to what each
+entry already has. Controls appear only where the post type supports
+them: no `categories` key in the REST response means no category
+picker, and sticky is offered for the built-in `post` type only.
+
+The status actions are a good illustration of the intersection rule
+in the wild: `publish` is offered only for an entry that isn't
+published and `to-draft` only for one that isn't a draft, so a
+selection holding one of each has neither in common and the menu
+shows only what applies to all of them.
 
 ### Filter — `os.my-wordpress.status-bar` (existing)
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1473,7 +1473,27 @@ Four fields control the multi-selection behaviour of any menu entry, on both the
 | `multi` | `true` to allow the action into a multi-selection menu. Default `false`. |
 | `multiId` | Identity to intersect on, when the same *deed* carries different single-item labels. The folder tile's `delete-folder` and the file tile's `remove` both declare `multiId: 'trash'`, so a mixed selection can still be thrown away. Defaults to `id`. |
 | `bulkLabel( n )` | Label for a set. Falls back to `"<label> (N items)"`. |
-| `bulk( items )` | Batched runner, called ONCE with the whole set. Without it the framework fans out, running each item's own `onClick` in turn. |
+| `bulk( items )` | Batched runner. Called once with **the items that declared it** — see below. Without it, that item's own `onClick` runs instead. |
+
+**Every item goes to the runner its own contributor declared.** When
+actions merge under a shared `multiId` there is no rule that they
+share an implementation — the folder tile and the file tile could
+trash things differently, and a plugin can merge a third of its own.
+So the framework groups the selection by `bulk` *function identity*
+and calls each runner once with its own subset; contributors that
+ship no `bulk` fan out through `onClick`.
+
+Two things follow:
+
+- If your action merges with a built-in and you want one batched
+  call for the whole set, **share the same function reference** —
+  `bulk: theSameFn`, not a fresh `bulk: ( items ) => theSameFn( items )`
+  arrow at each site, which is a different identity and therefore a
+  second batch. The built-in Trash entries share one reference for
+  exactly this reason, so a mixed folder + file selection is one
+  toast with one Undo.
+- If your runner only understands your own items, you don't have to
+  do anything: it will only ever be handed those.
 
 ```javascript
 wp.os.hooks.addFilter(

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -40,6 +40,7 @@ import { showToast } from '../toast';
 import { activity } from '../activity';
 import { heartbeat } from '../heartbeat';
 import { presenceApi } from '../presence';
+import { selectionApi } from '../selection';
 import { createSharedStore } from '../shared-store';
 import { osConfirm } from '../os-confirm';
 import { loadVendorScript } from '../wallpapers/vendor-loader';
@@ -229,7 +230,8 @@ export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'connect', 'getConnection',
 	'broadcast', 'subscribe', 'registerPalette', 'unregisterPalette',
 	'listPalettes', 'openPalette', 'devtools', 'createSharedStore',
-	'presence', 'activity', 'heartbeat', 'showToast', 'renderKeyedList',
+	'presence', 'selection', 'activity', 'heartbeat', 'showToast',
+	'renderKeyedList',
 	'clearKeyedList', 'registerNamespace',
 	'notify', 'pwa',
 	'getWindowConfig', 'debug',
@@ -728,6 +730,7 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): OpenStationPublicApi
 		devtools,
 		createSharedStore,
 		presence: presenceApi,
+		selection: selectionApi,
 		activity,
 		heartbeat,
 		showToast,

--- a/src/desktop-files/built-in-openers.ts
+++ b/src/desktop-files/built-in-openers.ts
@@ -33,7 +33,11 @@ import {
 	GRID_PADDING,
 	snapToEmptyCell,
 } from './grid';
-import { renderPlacementPreview, renderPreviewEmpty } from './preview';
+import {
+	renderPlacementPreview,
+	renderPreviewEmpty,
+	renderSelectionSummary,
+} from './preview';
 import { openEmbedWindow } from './embed-window';
 import { deriveWindowId } from '../utils';
 import { findMenuEntryForUrl } from './menu-entry';
@@ -336,16 +340,26 @@ export function registerBuiltInFileOpeners(): void {
 								layerHost,
 								route.folderId,
 							);
-							const offSelection = layer.onSelectionChange(
-								( placement ) => {
-									if ( ! placement ) {
+							// One subscription for the whole selection —
+							// the pane has three states, not two: empty,
+							// one item (preview it), several (say so and
+							// how they break down by type).
+							const offSelection = layer.onSelectionChanged(
+								( placements ) => {
+									if ( placements.length === 0 ) {
 										previewPane.replaceChildren(
 											renderPreviewEmpty(),
 										);
 										return;
 									}
+									if ( placements.length > 1 ) {
+										previewPane.replaceChildren(
+											renderSelectionSummary( placements ),
+										);
+										return;
+									}
 									renderPlacementPreview(
-										placement,
+										placements[ 0 ],
 										previewPane,
 									);
 								},
@@ -459,6 +473,16 @@ export function registerBuiltInFileOpeners(): void {
 							const status = mountFolderStatusBar(
 								bodyHost,
 								route.folderId,
+								{
+									selection: {
+										count: () =>
+											layer.getSelection().length,
+										subscribe: ( cb ) =>
+											layer.onSelectionChanged( () =>
+												cb(),
+											),
+									},
+								},
 							);
 
 							currentDispose = (): void => {

--- a/src/desktop-files/drag-payloads.ts
+++ b/src/desktop-files/drag-payloads.ts
@@ -23,8 +23,25 @@ import type { RestPlacementShape } from './rest';
 import type { DragBridgePayload } from '../drag-bridge';
 
 export interface DesktopFileDragData {
-	/** The placement being dragged (full record). */
+	/**
+	 * The placement being dragged — the one the user actually grabbed.
+	 *
+	 * Always present, even for a multi-item drag, and always a member
+	 * of {@link DesktopFileDragData.placements}. Every drop target
+	 * written before multi-drag existed reads this field and keeps
+	 * working: it acts on the grabbed tile, which is the one the user
+	 * pointed at.
+	 */
 	placement: RestPlacementShape;
+	/**
+	 * Every placement in the gesture, in visual order.
+	 *
+	 * Absent for a single-item drag. Targets that support sets read
+	 * them through `dragPlacements( data )`, which falls back to
+	 * `[ placement ]` — so "handle one" and "handle many" are the same
+	 * code path with a different array length.
+	 */
+	placements?: RestPlacementShape[];
 	/** Folder the source tile lives in, BEFORE the drop. */
 	sourceFolderId: number;
 	/**
@@ -40,7 +57,12 @@ export interface DesktopFileDragData {
 	bridgePayload?: DragBridgePayload;
 }
 
-export interface ShortcutDragData {
+/**
+ * One entity in a shortcut drag. A single-item drag carries exactly
+ * this shape at the top level; a multi-item drag repeats it in
+ * `ShortcutDragData.items`.
+ */
+export interface ShortcutDragItem {
 	/** File-type slug — `'post'`, `'page'`, `'user'`, plugin-defined. */
 	kind: string;
 	/** Opaque ref the file type resolves (post id as string, etc.). */
@@ -69,6 +91,56 @@ export interface ShortcutDragData {
 	 * drop behavior.
 	 */
 	bridgePayload?: DragBridgePayload;
+}
+
+/**
+ * A shortcut drag. The top-level fields describe the entity the user
+ * grabbed — unchanged, and what every pre-existing drop target reads.
+ * `items` carries the whole set when the drag started from a
+ * multi-selection.
+ */
+export interface ShortcutDragData extends ShortcutDragItem {
+	/**
+	 * Every entity in the gesture, in visual order. Absent for a
+	 * single-item drag; read it through `dragShortcutItems( data )`,
+	 * which falls back to the top-level fields.
+	 */
+	items?: ShortcutDragItem[];
+}
+
+/**
+ * Placements a `'desktop-file'` drop should act on.
+ *
+ * The one call every drop target needs to make to support sets. A
+ * target that keeps reading `data.placement` isn't broken, it just
+ * acts on the grabbed tile alone.
+ *
+ * @public
+ */
+export function dragPlacements(
+	data: DesktopFileDragData,
+): RestPlacementShape[] {
+	const many = data.placements;
+	if ( Array.isArray( many ) && many.length > 0 ) {
+		return many;
+	}
+	return data.placement ? [ data.placement ] : [];
+}
+
+/**
+ * Entities a `'shortcut'` drop should act on. Mirror of
+ * {@link dragPlacements}.
+ *
+ * @public
+ */
+export function dragShortcutItems(
+	data: ShortcutDragData,
+): ShortcutDragItem[] {
+	const many = data.items;
+	if ( Array.isArray( many ) && many.length > 0 ) {
+		return many;
+	}
+	return data.ref ? [ data ] : [];
 }
 
 /** Concrete payload shapes consumed by drop targets. */

--- a/src/desktop-files/folder-status-bar.ts
+++ b/src/desktop-files/folder-status-bar.ts
@@ -51,8 +51,22 @@ export interface StatusBarSegment {
 	onClick?: ( e: MouseEvent ) => void;
 }
 
+/**
+ * How the status bar learns about the window's selection. Deliberately
+ * structural rather than a `FilesLayer` — the My WordPress surfaces
+ * paint this same bar from a different renderer, and a bar that only
+ * understood file placements couldn't say "3 selected" for them.
+ */
+export interface StatusBarSelectionSource {
+	count: () => number;
+	/** Subscribe to selection changes. Returns an unsubscribe. */
+	subscribe: ( cb: () => void ) => () => void;
+}
+
 export interface StatusBarContext {
 	folderId: number;
+	/** How many items the user currently has selected. */
+	selectedCount: number;
 	totals: {
 		files: number;
 		folders: number;
@@ -69,7 +83,11 @@ export interface StatusBarContext {
 }
 
 /** Mount the status bar at the bottom of `host`. */
-export function mountFolderStatusBar( host: HTMLElement, folderId: number ): {
+export function mountFolderStatusBar(
+	host: HTMLElement,
+	folderId: number,
+	opts: { selection?: StatusBarSelectionSource } = {},
+): {
 	dispose: () => void;
 } {
 	const bar = document.createElement( 'div' );
@@ -95,6 +113,7 @@ export function mountFolderStatusBar( host: HTMLElement, folderId: number ): {
 		}
 		const ctx: StatusBarContext = {
 			folderId,
+			selectedCount: opts.selection?.count() ?? 0,
 			totals: { files, folders, total: list.length, bytes },
 		};
 		const segments = computeSegments( ctx );
@@ -103,9 +122,11 @@ export function mountFolderStatusBar( host: HTMLElement, folderId: number ): {
 
 	repaint();
 	const off = subscribeFilesStore( () => repaint() );
+	const offSelection = opts.selection?.subscribe( () => repaint() );
 	return {
 		dispose() {
 			off();
+			offSelection?.();
 			bar.remove();
 		},
 	};
@@ -126,6 +147,17 @@ function computeSegments( ctx: StatusBarContext ): StatusBarSegment[] {
 			sort: 10,
 		},
 	];
+	// Selection count sits on the trailing edge, and only while there
+	// IS one — a permanent "0 selected" would be noise on a bar whose
+	// whole job is to be glanceable.
+	if ( ctx.selectedCount > 0 ) {
+		builtIns.push( {
+			id: 'selection',
+			label: `${ ctx.selectedCount } selected`,
+			align: 'end',
+			sort: 10,
+		} );
+	}
 	const filtered = applyFilters< StatusBarSegment[], [ StatusBarContext ] >(
 		'os.files.folder-window.status-bar',
 		builtIns,

--- a/src/desktop-files/grid.ts
+++ b/src/desktop-files/grid.ts
@@ -1,24 +1,82 @@
 /**
- * OpenStation — Files grid snapping.
+ * OpenStation — the icon grid.
  *
  * Tiles align to a column-major grid (top-to-bottom, then
  * left-to-right) so the desktop reads as one tidy surface
  * instead of arbitrary pointer-position coordinates.
  *
- * Geometry:
+ * **This module is the one place the grid's shape is expressed in
+ * TypeScript, for every surface that lays out placements** — the
+ * wallpaper, folder windows, and each canvas in the site folder.
+ * They used to disagree: the desktop ran a 96×110 pitch and the site
+ * folder a 108×112 one, so the same three icons had 8px between them
+ * in one window and 20px in another. Worse, the desktop's 8px was a
+ * fiction — the tile's own horizontal padding was added on top of
+ * its width, filling the cell exactly, and icons touched.
  *
- *   - GRID_PADDING — gutter from the edge of the host (top + left).
- *   - GRID_CELL_W  — column width  (88px tile + 8px gap).
- *   - GRID_CELL_H  — row height    (~96px tile + 14px gap).
+ * The declaration lives in `assets/css/variables.css`, because that
+ * is where this codebase keeps design tokens and because a desktop
+ * theme can then retune the grid. Layout maths can't read CSS, so
+ * the numbers are mirrored here — and
+ * `tests/vitest/grid-metrics.test.ts` parses the stylesheet to prove
+ * the mirror is faithful. Change one, that test names the other.
  *
- * The same numbers are baked into `assets/css/desktop-files.css`
- * (the tile width / icon size). Anyone changing one must change
- * the other.
+ * The CELL is derived, never declared. A gap you can see is the
+ * thing worth tuning; the pitch is just tile + gap.
  */
 
+/** Gutter from the top / inline-start edge of an icon canvas. */
 export const GRID_PADDING = 16;
-export const GRID_CELL_W = 96;
-export const GRID_CELL_H = 110;
+
+/**
+ * Tile box, and the air around it. Mirrors `--os-tile-*` /
+ * `--os-grid-gap-*`.
+ *
+ * `TILE_H` is a FIXED height, not a minimum: the tile box is what
+ * the selection ring is drawn around, so a box that grew with its
+ * label would give a row of selected icons a ragged top edge.
+ */
+export const TILE_W = 88;
+export const TILE_H = 104;
+export const GRID_GAP_X = 20;
+export const GRID_GAP_Y = 16;
+
+/** Image-led sections (`tileSize: 'large'`). Same gaps, bigger tile. */
+export const TILE_W_LARGE = 132;
+export const TILE_H_LARGE = 160;
+
+export const GRID_CELL_W = TILE_W + GRID_GAP_X;
+export const GRID_CELL_H = TILE_H + GRID_GAP_Y;
+
+export const GRID_CELL_W_LARGE = TILE_W_LARGE + GRID_GAP_X;
+export const GRID_CELL_H_LARGE = TILE_H_LARGE + GRID_GAP_Y;
+
+/**
+ * Cell pitch for an icon canvas, in the shape the site folder's
+ * layout engine consumes. Exported so that surface reads the same
+ * numbers rather than declaring its own.
+ *
+ * @public
+ */
+export interface GridMetrics {
+	w: number;
+	h: number;
+	pad: number;
+}
+
+/** @public */
+export const GRID_METRICS: GridMetrics = {
+	w: GRID_CELL_W,
+	h: GRID_CELL_H,
+	pad: GRID_PADDING,
+};
+
+/** @public */
+export const GRID_METRICS_LARGE: GridMetrics = {
+	w: GRID_CELL_W_LARGE,
+	h: GRID_CELL_H_LARGE,
+	pad: GRID_PADDING,
+};
 
 export interface GridPos {
 	col: number;

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -24,15 +24,20 @@
 import { doAction } from '../hooks';
 import { rest, store as filesStoreApi } from './layer-deps';
 import { buildTile, placementLabel, setTilePosition, TILE_CLASS } from './file-tile';
+import { buildDragStackGhost } from './tile-spec';
 import {
 	tilePayloadAccepts,
 	tilePayloadAcceptLabel,
 	tilePayloadDrop,
 } from './tile-payloads';
-import { openTileMenu, type TileMenuItem } from './tile-menu';
-import { openCreateFolderDialog } from './create-folder-dialog';
-import { openFile } from './open';
-import { resolve as resolveFileType } from './registry';
+import { openPlacementActionMenu } from './tile-menu';
+import { buildPlacementActions } from './tile-actions';
+import { attachSelection, type SelectionHandle } from '../selection/controller';
+import { resolveCommonActions } from '../selection/actions';
+import {
+	isSyntheticPlacement as isSyntheticPlacementImpl,
+	readSynthSource,
+} from './synthetic';
 import {
 	cellKey,
 	cellToPos,
@@ -49,10 +54,11 @@ import type { DragBridgePayload } from '../drag-bridge';
 import { isConflict, showConflictToast } from './conflict-toast';
 import { canvasPayloadAccepts, canvasPayloadDrop } from './canvas-payloads';
 import type { DragManagerApi, DragSession, DropTarget } from '../drag';
-import { trashFolderWithUndo, trashPlacementWithUndo } from './trash';
-import type {
-	DesktopFileDragData,
-	ShortcutDragData,
+import {
+	dragPlacements,
+	dragShortcutItems,
+	type DesktopFileDragData,
+	type ShortcutDragData,
 } from './drag-payloads';
 
 /**
@@ -145,12 +151,29 @@ export interface FilesLayer {
 	folderId: number;
 	/**
 	 * Subscribe to selection changes inside this layer. Fires with
-	 * the newly-selected placement (or `null` when the user clicked
-	 * empty canvas to deselect). Returns an unsubscribe function.
+	 * the selected placement when exactly ONE is selected, and with
+	 * `null` otherwise — an empty selection and a multi-selection are
+	 * the same news to a consumer that shows one thing at a time.
+	 * Use {@link FilesLayer.onSelectionChanged} to see the whole set.
+	 * Returns an unsubscribe function.
 	 */
 	onSelectionChange: (
 		cb: ( placement: RestPlacementShape | null ) => void,
 	) => () => void;
+	/**
+	 * Subscribe to the full selection. Fires with every selected
+	 * placement in visual order, empty array included. Returns an
+	 * unsubscribe function.
+	 */
+	onSelectionChanged: (
+		cb: ( placements: RestPlacementShape[] ) => void,
+	) => () => void;
+	/** Currently selected placements, in visual order. */
+	getSelection: () => RestPlacementShape[];
+	/** Select every tile in this layer. */
+	selectAll: () => void;
+	/** Drop the selection. */
+	clearSelection: () => void;
 	/**
 	 * Sort the visible tiles row-major into a clean grid in the
 	 * requested order, persisting each new (x, y) to REST. Same
@@ -218,49 +241,78 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	host.appendChild( container );
 
 	let lastFingerprint = '';
-	let selectedId: number | null = null;
+
+	/**
+	 * Resolve a selected key (the placement id as a string) back to
+	 * the LIVE placement. Reads the store rather than a cached list —
+	 * a menu opened after a heartbeat delta must act on what the
+	 * server last said, not on what was painted.
+	 */
+	const placementsForKeys = ( keys: readonly string[] ): RestPlacementShape[] => {
+		const bucket =
+			filesStoreApi.getState().placementsByFolder.get( folderId ) ?? [];
+		const byId = new Map< string, RestPlacementShape >();
+		for ( const p of bucket ) {
+			if ( p ) {
+				byId.set( String( p.id ), p );
+			}
+		}
+		return keys
+			.map( ( key ) => byId.get( key ) )
+			.filter( ( p ): p is RestPlacementShape => !! p );
+	};
+
 	type SelectionListener = (
 		placement: RestPlacementShape | null,
 	) => void;
+	type MultiSelectionListener = (
+		placements: RestPlacementShape[],
+	) => void;
 	const selectionListeners = new Set< SelectionListener >();
-	const notifySelection = (
-		placement: RestPlacementShape | null,
-	): void => {
-		for ( const cb of selectionListeners ) {
-			try {
-				cb( placement );
-			} catch ( err ) {
-				// eslint-disable-next-line no-console
-				console.error(
-					'[openstation] files: selection listener threw:',
-					err,
-				);
+	const multiSelectionListeners = new Set< MultiSelectionListener >();
+
+	const selection = attachSelection( container, {
+		itemSelector: `.${ TILE_CLASS }`,
+		background: host,
+		surface: 'files',
+		scope: String( folderId ),
+		keyOf: ( el ) => el.dataset.placementId ?? null,
+		onChange: ( keys ) => {
+			const placements = placementsForKeys( keys );
+			// The single-placement listeners are the older contract
+			// (preview panes, the right pane in a folder window). They
+			// hear `null` for an empty selection AND for a multi one:
+			// "no single thing to preview" is the same message either
+			// way, and it keeps every existing consumer correct without
+			// teaching it about sets.
+			const single = placements.length === 1 ? placements[ 0 ] : null;
+			for ( const cb of selectionListeners ) {
+				try {
+					cb( single );
+				} catch ( err ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						'[openstation] files: selection listener threw:',
+						err,
+					);
+				}
 			}
-		}
-	};
-	const setSelected = (
-		placement: RestPlacementShape | null,
-	): void => {
-		const newId = placement ? placement.id : null;
-		if ( newId === selectedId ) {
-			return;
-		}
-		// Selected state lives on the `selected` attribute —
-		// `<os-tile>._paint()` derives the `--selected` class from
-		// it. Toggling the class directly survives until the next
-		// attribute change repaints the tile and wipes it.
-		container
-			.querySelectorAll( `.${ TILE_CLASS }--selected` )
-			.forEach( ( n ) => n.removeAttribute( 'selected' ) );
-		if ( placement ) {
-			const tile = container.querySelector< HTMLElement >(
-				`[data-placement-id="${ placement.id }"]`,
-			);
-			tile?.setAttribute( 'selected', '' );
-		}
-		selectedId = newId;
-		notifySelection( placement );
-	};
+			for ( const cb of multiSelectionListeners ) {
+				try {
+					cb( placements );
+				} catch ( err ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						'[openstation] files: selection listener threw:',
+						err,
+					);
+				}
+			}
+		},
+	} );
+
+	const currentSelection = (): RestPlacementShape[] =>
+		placementsForKeys( selection.keys() );
 
 	/**
 	 * Compute pinned-slot map + displaced map for a list. Shared by
@@ -349,8 +401,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		if ( pinnedSlot ) {
 			setTilePosition( tile, pinnedSlot.x, pinnedSlot.y );
 			tile.classList.add( `${ TILE_CLASS }--pinned` );
-			attachContextMenu( tile, placement );
-			attachSelectOnClick( tile, placement );
+			attachContextMenu( tile, placement, selection, currentSelection );
 			if ( shouldRejectTileDrops( placement ) ) {
 				const dragManager = getDragManager();
 				if ( dragManager ) {
@@ -366,9 +417,8 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		if ( moved ) {
 			setTilePosition( tile, moved.x, moved.y );
 		}
-		attachTileDrag( tile, placement, folderId );
-		attachContextMenu( tile, placement );
-		attachSelectOnClick( tile, placement );
+		attachTileDrag( tile, placement, folderId, selection, currentSelection );
+		attachContextMenu( tile, placement, selection, currentSelection );
 		if ( placement.file.type === 'folder' ) {
 			const targetFolderId = parseInt( placement.file.ref, 10 );
 			if ( targetFolderId > 0 ) {
@@ -496,18 +546,11 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			);
 		}
 
-		// Selection bookkeeping — match the wholesale path so right-
-		// pane consumers stay in sync when the selected tile was the
-		// removed one.
-		if (
-			selectedId !== null &&
-			! container.querySelector(
-				`[data-placement-id="${ selectedId }"]`,
-			)
-		) {
-			selectedId = null;
-			notifySelection( null );
-		}
+		// Selection bookkeeping — re-assert the selected attribute on
+		// reused tiles and drop keys whose tiles were just removed, so
+		// right-pane consumers stay in sync when a selected tile was
+		// the deleted one.
+		selection.refresh();
 
 		doAction( 'os.files.grid-rendered', {
 			folderId,
@@ -586,22 +629,10 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				wireTile( placement, pinnedSlots, displaced ),
 			);
 		}
-		// If the previously-selected tile is gone (deleted, moved
-		// folders), drop the selection so the right pane can clear.
-		if (
-			selectedId !== null &&
-			! container.querySelector( `[data-placement-id="${ selectedId }"]` )
-		) {
-			selectedId = null;
-			notifySelection( null );
-		} else if ( selectedId !== null ) {
-			// Re-apply the selected state after a wholesale rebuild
-			// (attribute, not class — see notes in `setSelectedId`).
-			const tile = container.querySelector< HTMLElement >(
-				`[data-placement-id="${ selectedId }"]`,
-			);
-			tile?.setAttribute( 'selected', '' );
-		}
+		// Re-apply selected state after the wholesale rebuild (every
+		// tile is a fresh node) and drop keys whose placements are
+		// gone — deleted, or moved to another folder.
+		selection.refresh();
 		doAction( 'os.files.grid-rendered', {
 			folderId,
 			count: list.length,
@@ -730,8 +761,15 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			// instant snap-back vs. a 409 toast after the REST hit.
 			if ( folderId > 0 && payload.type === 'desktop-file' ) {
 				const data = payload.data as unknown as DesktopFileDragData;
-				if ( data.placement.file?.type === 'folder' ) {
-					const movingFolderId = parseInt( data.placement.file.ref, 10 );
+				// Every member of the set has to be droppable, not just
+				// the grabbed one. Accepting a set and then silently
+				// moving four of five is worse than refusing: the user
+				// sees a successful drop and finds out later.
+				for ( const placement of dragPlacements( data ) ) {
+					if ( placement.file?.type !== 'folder' ) {
+						continue;
+					}
+					const movingFolderId = parseInt( placement.file.ref, 10 );
 					if (
 						! Number.isNaN( movingFolderId ) &&
 						wouldCreateFolderCycle( movingFolderId, folderId )
@@ -785,102 +823,130 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 
 			if ( session.payload.type === 'desktop-file' ) {
 				const data = session.payload.data as unknown as DesktopFileDragData;
-				const occupied = buildVisualOccupiedSet( peers, data.placement.id );
-				const cell = snapToEmptyCell( rawX, rawY, occupied, host );
-				const next: RestPlacementShape = {
-					...data.placement,
-					x: cell.x,
-					y: cell.y,
-					parentId: folderId,
-				};
-				filesStoreApi.upsertPlacement( next );
-				// Notify the shell that a tile was placed by the user
-				// (not by Sort By / Clean Up). The desktop root listens
-				// to drop out of auto-arrange mode so the user's manual
-				// position survives the next desktop resize.
-				doAction( 'os.files.tile-manually-placed', {
-					folderId,
-					placementId: data.placement.id,
-				} );
-				if ( isSyntheticPlacement( data.placement ) ) {
-					// Synthetic placements (dock-item promotions —
-					// negative ids minted by
-					// `settings/desktop-shortcuts-sync.ts`) have no DB
-					// row, so the REST `/files/placements/(?P<id>\d+)`
-					// route can't accept the PATCH. Persist the new
-					// position into `OsSettingsState.dockPromotedPositions`
-					// instead so the synthesizer can restore it on the
-					// next page load — without this write the icon
-					// snaps back to (0, 0) every reload.
-					const dockItemId = readSynthSource( data.placement );
-					if ( dockItemId ) {
-						persistDockPromotedPosition(
-							dockItemId,
-							cell.x,
-							cell.y,
+				const moving = dragPlacements( data );
+				const movingIds = new Set( moving.map( ( p ) => p.id ) );
+				// Every tile in the set vacates its cell, so none of
+				// them counts as occupied while we place the others.
+				const occupied = buildVisualOccupiedSet( peers, movingIds );
+				const primaryCell = snapToEmptyCell( rawX, rawY, occupied, host );
+				occupied.add( cellKey( primaryCell.col, primaryCell.row ) );
+
+				for ( const placement of moving ) {
+					let cell = primaryCell;
+					if ( placement.id !== data.placement.id ) {
+						// Keep the set's shape: each tile lands the same
+						// distance from the grabbed one as it started,
+						// then snaps to the nearest free cell. Dropping
+						// three icons in a row gives you three icons in
+						// a row, which is what the ghost implied.
+						const dx = placement.x - data.placement.x;
+						const dy = placement.y - data.placement.y;
+						cell = snapToEmptyCell(
+							Math.max( 0, primaryCell.x + dx ),
+							Math.max( 0, primaryCell.y + dy ),
+							occupied,
+							host,
 						);
+						occupied.add( cellKey( cell.col, cell.row ) );
 					}
-					return;
-				}
-				void rest
-					.updatePlacement(
-						data.placement.id,
-						{
-							x: cell.x,
-							y: cell.y,
-							parentId: folderId,
-						},
-						data.placement.updatedAtMs,
-					)
-					.then( ( server ) => {
-						filesStoreApi.upsertPlacement( server, 'remote' );
-					} )
-					.catch( ( err ) => {
-						if ( isConflict( err ) ) {
-							showConflictToast( err );
-						} else {
-							// eslint-disable-next-line no-console
-							console.error(
-								'[openstation] files: drag persist failed',
-								err,
+					const next: RestPlacementShape = {
+						...placement,
+						x: cell.x,
+						y: cell.y,
+						parentId: folderId,
+					};
+					filesStoreApi.upsertPlacement( next );
+					// Notify the shell that a tile was placed by the user
+					// (not by Sort By / Clean Up). The desktop root listens
+					// to drop out of auto-arrange mode so the user's manual
+					// position survives the next desktop resize.
+					doAction( 'os.files.tile-manually-placed', {
+						folderId,
+						placementId: placement.id,
+					} );
+					if ( isSyntheticPlacement( placement ) ) {
+						// Synthetic placements (dock-item promotions —
+						// negative ids minted by
+						// `settings/desktop-shortcuts-sync.ts`) have no DB
+						// row, so the REST `/files/placements/(?P<id>\d+)`
+						// route can't accept the PATCH. Persist the new
+						// position into `OsSettingsState.dockPromotedPositions`
+						// instead so the synthesizer can restore it on the
+						// next page load — without this write the icon
+						// snaps back to (0, 0) every reload.
+						const dockItemId = readSynthSource( placement );
+						if ( dockItemId ) {
+							persistDockPromotedPosition(
+								dockItemId,
+								cell.x,
+								cell.y,
 							);
 						}
-						filesStoreApi.upsertPlacement( data.placement );
-					} );
+						continue;
+					}
+					void rest
+						.updatePlacement(
+							placement.id,
+							{
+								x: cell.x,
+								y: cell.y,
+								parentId: folderId,
+							},
+							placement.updatedAtMs,
+						)
+						.then( ( server ) => {
+							filesStoreApi.upsertPlacement( server, 'remote' );
+						} )
+						.catch( ( err ) => {
+							if ( isConflict( err ) ) {
+								showConflictToast( err );
+							} else {
+								// eslint-disable-next-line no-console
+								console.error(
+									'[openstation] files: drag persist failed',
+									err,
+								);
+							}
+							filesStoreApi.upsertPlacement( placement );
+						} );
+				}
 				return;
 			}
 
 			if ( session.payload.type === 'shortcut' ) {
 				const data = session.payload.data as unknown as ShortcutDragData;
-				// New shortcut — pack row-major (top-left, then across)
-				// so the new tile lands at a visible cell regardless of
+				// New shortcuts — pack row-major (top-left, then across)
+				// so the new tiles land at visible cells regardless of
 				// where the user released the cursor. Cursor-position
 				// snap is wrong for shortcut creates because users
 				// rarely aim precisely; row-major is the "tidy" outcome.
 				const occupied = buildVisualOccupiedSet( peers );
-				const cell = nextRowMajorCell( occupied, host );
-				void rest
-					.createPlacement( {
-						parentId: folderId,
-						type: data.kind,
-						ref: data.ref,
-						x: cell.x,
-						y: cell.y,
-					} )
-					.then( ( placement ) => {
-						filesStoreApi.upsertPlacement( placement );
-						doAction( 'os.files.shortcut-dropped', {
-							folderId,
-							placement,
+				for ( const entity of dragShortcutItems( data ) ) {
+					const cell = nextRowMajorCell( occupied, host );
+					occupied.add( cellKey( cell.col, cell.row ) );
+					void rest
+						.createPlacement( {
+							parentId: folderId,
+							type: entity.kind,
+							ref: entity.ref,
+							x: cell.x,
+							y: cell.y,
+						} )
+						.then( ( placement ) => {
+							filesStoreApi.upsertPlacement( placement );
+							doAction( 'os.files.shortcut-dropped', {
+								folderId,
+								placement,
+							} );
+						} )
+						.catch( ( err: unknown ) => {
+							// eslint-disable-next-line no-console
+							console.error(
+								'[openstation] shortcut drop failed:',
+								err,
+							);
 						} );
-					} )
-					.catch( ( err: unknown ) => {
-						// eslint-disable-next-line no-console
-						console.error(
-							'[openstation] shortcut drop failed:',
-							err,
-						);
-					} );
+				}
 				// `rawX` / `rawY` retained for parity with desktop-file
 				// case logging if a future hook needs the cursor pos.
 				void rawX;
@@ -895,36 +961,9 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		);
 	}
 
-	// Single-click on tile = select; click on bare canvas =
-	// deselect. Same model as macOS Finder / Explorer. Tile clicks
-	// fire `attachSelectOnClick`'s handler (added per-tile during
-	// repaint); the canvas-level click below catches "click landed
-	// on the layer container or host but not on any tile."
-	const onCanvasClick = ( e: MouseEvent ): void => {
-		if ( e.target instanceof Element && e.target.closest( `.${ TILE_CLASS }` ) ) {
-			return;
-		}
-		setSelected( null );
-	};
-	host.addEventListener( 'click', onCanvasClick );
-
-	// Per-tile click handler attached during repaint. Captured
-	// here so the per-tile closure can reach `setSelected`.
-	function attachSelectOnClick(
-		tile: HTMLElement,
-		placement: RestPlacementShape,
-	): void {
-		tile.addEventListener( 'click', ( e: MouseEvent ) => {
-			// Tile is a `<button>` — its native focus + click would
-			// bubble to the canvas-level click and immediately
-			// deselect. Stop the bubble.
-			e.stopPropagation();
-			// Live lookup — the captured placement can be stale after
-			// a fast-path repaint (see `attachTileDrag`), and selection
-			// consumers (status bar, right pane) display the title.
-			setSelected( filesStoreApi.currentPlacement( placement ) );
-		} );
-	}
+	// Click, Ctrl/Cmd-click, Shift-click, marquee, Ctrl/Cmd+A and
+	// Escape are all owned by the selection controller attached
+	// above — the layer no longer wires per-tile click handlers.
 
 	// Boot fast-path: PHP inlines the root folder's placements into
 	// the shell config (`filesBootPlacements`, built by the same
@@ -1149,6 +1188,15 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				selectionListeners.delete( cb );
 			};
 		},
+		onSelectionChanged( cb ) {
+			multiSelectionListeners.add( cb );
+			return () => {
+				multiSelectionListeners.delete( cb );
+			};
+		},
+		getSelection: currentSelection,
+		selectAll: () => selection.model.selectAll(),
+		clearSelection: () => selection.model.clear(),
 		sort,
 		reflow,
 		hydrated,
@@ -1180,8 +1228,9 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				}
 			}
 			tileRejectDeregisters.clear();
-			host.removeEventListener( 'click', onCanvasClick );
+			selection.destroy();
 			selectionListeners.clear();
+			multiSelectionListeners.clear();
 			container.remove();
 		},
 	};
@@ -1216,38 +1265,13 @@ function isPinned( placement: RestPlacementShape ): boolean {
 }
 
 /**
- * If `placement` is a synthesized shortcut from a dock-item the user
- * promoted to the desktop (via OS Settings → Apps & Icons), return
- * the source dock-item id. Returns `null` for real placements.
- *
- * Marker key matches the one written by
- * `settings/desktop-shortcuts-sync.ts`.
- */
-function readSynthSource( placement: RestPlacementShape ): string | null {
-	const meta = placement.meta;
-	if ( ! meta || typeof meta !== 'object' ) {
-		return null;
-	}
-	const v = ( meta as Record< string, unknown > ).__synthFromDockItem;
-	return typeof v === 'string' && v !== '' ? v : null;
-}
-
-/**
- * Whether `placement` is a synthetic (no DB row) one. Two signals:
- *   - The `__synthFromDockItem` meta marker — definitive when present.
- *   - A non-positive id — `settings/desktop-shortcuts-sync.ts` mints
- *     deterministic negative ids for these, and Core's REST regex on
- *     `/files/placements/(?P<id>\d+)` only matches positive integers,
- *     so any non-positive id would 404 anyway. Treating the two as
- *     equivalent keeps the gate robust against future synth sources
- *     that forget to stamp the marker.
- *
- * Used to gate the three REST PATCH callsites in this module — synth
- * placements live JS-only, so persisting their (x, y) / parentId
- * would 404 with `rest_no_route`.
+ * Whether `placement` is a synthetic (no DB row) one — see
+ * `synthetic.ts`. Re-exported here because this module's path is the
+ * published one for it; the implementation moved so the tile-action
+ * builder could share it without importing the layer.
  */
 export function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
-	return placement.id <= 0 || readSynthSource( placement ) !== null;
+	return isSyntheticPlacementImpl( placement );
 }
 
 /** Recycle-bin tile id; matched on the shortcut tile's `file.ref`. */
@@ -1309,8 +1333,18 @@ function shouldRejectTileDrops( placement: RestPlacementShape ): boolean {
  */
 function buildVisualOccupiedSet(
 	placements: ReadonlyArray< RestPlacementShape >,
-	excludeId?: number,
+	/**
+	 * Id (or ids) to treat as absent — the tiles being dragged. They
+	 * are about to vacate their cells, so counting them as occupied
+	 * would push the drop one cell sideways for a single drag, and
+	 * scatter a multi-drag around its own footprint.
+	 */
+	excludeId?: number | ReadonlySet< number >,
 ): Set< string > {
+	const excluded =
+		typeof excludeId === 'number'
+			? new Set( [ excludeId ] )
+			: excludeId ?? null;
 	// Sort pinned-first to mirror the repaint's iteration order, so
 	// pinned-slot indices match what's on screen. `Array.sort` is
 	// stable across all engines we support — within the pinned
@@ -1324,7 +1358,7 @@ function buildVisualOccupiedSet(
 	const set = new Set< string >();
 	let pinnedIdx = 0;
 	for ( const p of sorted ) {
-		if ( excludeId !== undefined && p.id === excludeId ) {
+		if ( excluded?.has( p.id ) ) {
 			continue;
 		}
 		if ( isPinned( p ) ) {
@@ -1611,35 +1645,6 @@ function syncTileLabel(
 }
 
 /**
- * Hide a dock item the user previously promoted onto the desktop.
- * Mutates `OsSettingsState.itemVisibility[ dockItemId ]` to `'dock'`
- * via the public API; the shortcuts-sync subscription removes the
- * synthetic placement on the next tick.
- */
-function hidePromotedDockItem( dockItemId: string ): void {
-	const api = (
-		window as unknown as {
-			wp?: {
-				os?: {
-					getOsSettings?: () => {
-						itemVisibility: Record< string, string >;
-					};
-					updateOsSettings?: ( patch: {
-						itemVisibility?: Record< string, string >;
-					} ) => void;
-				};
-			};
-		}
-	).wp?.os;
-	if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
-		return;
-	}
-	const current = api.getOsSettings().itemVisibility ?? {};
-	const next = { ...current, [ dockItemId ]: 'dock' };
-	api.updateOsSettings( { itemVisibility: next } );
-}
-
-/**
  * Register the per-tile drop claimant for a NON-folder tile. A tile
  * normally hard-rejects every foreign payload so the drop doesn't fall
  * through to the wallpaper (`shouldRejectTileDrops`). A feature can opt
@@ -1709,42 +1714,48 @@ function registerFolderDropTarget(
 			}
 			if ( payload.type === 'desktop-file' ) {
 				const data = payload.data as unknown as DesktopFileDragData;
-				// Don't accept a folder dropped onto itself.
-				if (
-					data.placement.file.type === 'folder' &&
-					parseInt( data.placement.file.ref, 10 ) === targetFolderId
-				) {
-					return false;
-				}
-				// No-op move: dropping a tile from folder X onto folder
-				// X's own tile would just round-trip via REST. Reject
-				// so the user gets reject feedback instead of a silent
-				// no-op.
-				if ( data.placement.parentId === targetFolderId ) {
-					return false;
-				}
-				// Synthetic placements (dock-item promotions) have no
-				// DB row, so "move into folder" can't be persisted
-				// today — the REST PATCH would 404 on its negative
-				// id. Reject the drop so the user gets a clear "this
-				// can't go there" cue instead of an apparent move that
-				// silently snaps back on the next sync.
-				if ( isSyntheticPlacement( data.placement ) ) {
-					return false;
-				}
-				// Folder cycle: dropping folder X onto folder Y
-				// when Y is somewhere inside X creates an
-				// unreachable loop. The server's authoritative
-				// check rejects it too, but doing the preflight
-				// here gives the user a clean "this can't go
-				// there" snap-back instead of a 409 toast.
-				if ( data.placement.file.type === 'folder' ) {
-					const movingFolderId = parseInt( data.placement.file.ref, 10 );
+				// Each of these gates is per-placement, and the whole
+				// set has to clear them. Accepting a mixed set and
+				// moving only the legal half would report success for
+				// a move that half-happened.
+				for ( const placement of dragPlacements( data ) ) {
+					// Don't accept a folder dropped onto itself.
 					if (
-						! Number.isNaN( movingFolderId ) &&
-						wouldCreateFolderCycle( movingFolderId, targetFolderId )
+						placement.file.type === 'folder' &&
+						parseInt( placement.file.ref, 10 ) === targetFolderId
 					) {
 						return false;
+					}
+					// No-op move: dropping a tile from folder X onto folder
+					// X's own tile would just round-trip via REST. Reject
+					// so the user gets reject feedback instead of a silent
+					// no-op.
+					if ( placement.parentId === targetFolderId ) {
+						return false;
+					}
+					// Synthetic placements (dock-item promotions) have no
+					// DB row, so "move into folder" can't be persisted
+					// today — the REST PATCH would 404 on its negative
+					// id. Reject the drop so the user gets a clear "this
+					// can't go there" cue instead of an apparent move that
+					// silently snaps back on the next sync.
+					if ( isSyntheticPlacement( placement ) ) {
+						return false;
+					}
+					// Folder cycle: dropping folder X onto folder Y
+					// when Y is somewhere inside X creates an
+					// unreachable loop. The server's authoritative
+					// check rejects it too, but doing the preflight
+					// here gives the user a clean "this can't go
+					// there" snap-back instead of a 409 toast.
+					if ( placement.file.type === 'folder' ) {
+						const movingFolderId = parseInt( placement.file.ref, 10 );
+						if (
+							! Number.isNaN( movingFolderId ) &&
+							wouldCreateFolderCycle( movingFolderId, targetFolderId )
+						) {
+							return false;
+						}
 					}
 				}
 			}
@@ -1760,32 +1771,33 @@ function registerFolderDropTarget(
 			tile.classList.remove( `${ TILE_CLASS }--drop-target` );
 			if ( session.payload.type === 'desktop-file' ) {
 				const data = session.payload.data as unknown as DesktopFileDragData;
-				const next: RestPlacementShape = {
-					...data.placement,
-					parentId: targetFolderId,
-				};
-				filesStoreApi.upsertPlacement( next );
-				void rest
-					.updatePlacement(
-						data.placement.id,
-						{ parentId: targetFolderId },
-						data.placement.updatedAtMs,
-					)
-					.then( ( server ) => {
-						filesStoreApi.upsertPlacement( server, 'remote' );
-					} )
-					.catch( ( err ) => {
-						if ( isConflict( err ) ) {
-							showConflictToast( err );
-						} else {
-							// eslint-disable-next-line no-console
-							console.error(
-								'[openstation] files: move-into-folder persist failed',
-								err,
-							);
-						}
-						filesStoreApi.upsertPlacement( data.placement );
+				for ( const placement of dragPlacements( data ) ) {
+					filesStoreApi.upsertPlacement( {
+						...placement,
+						parentId: targetFolderId,
 					} );
+					void rest
+						.updatePlacement(
+							placement.id,
+							{ parentId: targetFolderId },
+							placement.updatedAtMs,
+						)
+						.then( ( server ) => {
+							filesStoreApi.upsertPlacement( server, 'remote' );
+						} )
+						.catch( ( err ) => {
+							if ( isConflict( err ) ) {
+								showConflictToast( err );
+							} else {
+								// eslint-disable-next-line no-console
+								console.error(
+									'[openstation] files: move-into-folder persist failed',
+									err,
+								);
+							}
+							filesStoreApi.upsertPlacement( placement );
+						} );
+				}
 				return;
 			}
 			if ( session.payload.type === 'shortcut' ) {
@@ -1799,29 +1811,33 @@ function registerFolderDropTarget(
 				// We can't read the destination folder window's host
 				// width from here, so default to 4 cols inside
 				// `nextRowMajorCell` — sensible for any folder window.
-				const cell = nextRowMajorCell( buildVisualOccupiedSet( peers ) );
-				void rest
-					.createPlacement( {
-						parentId: targetFolderId,
-						type: data.kind,
-						ref: data.ref,
-						x: cell.x,
-						y: cell.y,
-					} )
-					.then( ( placement ) => {
-						filesStoreApi.upsertPlacement( placement );
-						doAction( 'os.files.shortcut-dropped', {
-							folderId: targetFolderId,
-							placement,
+				const occupied = buildVisualOccupiedSet( peers );
+				for ( const entity of dragShortcutItems( data ) ) {
+					const cell = nextRowMajorCell( occupied );
+					occupied.add( cellKey( cell.col, cell.row ) );
+					void rest
+						.createPlacement( {
+							parentId: targetFolderId,
+							type: entity.kind,
+							ref: entity.ref,
+							x: cell.x,
+							y: cell.y,
+						} )
+						.then( ( placement ) => {
+							filesStoreApi.upsertPlacement( placement );
+							doAction( 'os.files.shortcut-dropped', {
+								folderId: targetFolderId,
+								placement,
+							} );
+						} )
+						.catch( ( err: unknown ) => {
+							// eslint-disable-next-line no-console
+							console.error(
+								'[openstation] shortcut drop into folder failed:',
+								err,
+							);
 						} );
-					} )
-					.catch( ( err: unknown ) => {
-						// eslint-disable-next-line no-console
-						console.error(
-							'[openstation] shortcut drop into folder failed:',
-							err,
-						);
-					} );
+				}
 			}
 		},
 	};
@@ -1851,9 +1867,18 @@ function attachTileDrag(
 	tile: HTMLElement,
 	placement: RestPlacementShape,
 	folderId: number,
+	selection: SelectionHandle,
+	selectedPlacements: () => RestPlacementShape[],
 ): void {
 	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
 		if ( e.button !== 0 ) {
+			return;
+		}
+		// A modifier means the user is composing a selection, not
+		// picking the tile up. Without this, Ctrl/Cmd-clicking a
+		// second tile arms a drag session whose ghost follows the
+		// pointer for the rest of the gesture.
+		if ( e.shiftKey || e.ctrlKey || e.metaKey ) {
 			return;
 		}
 		const dragManager = getDragManager();
@@ -1887,12 +1912,92 @@ function attachTileDrag(
 		// "drag jumps to the pinned slot" bug).
 		const visibleX = parseFloat( tile.style.left ) || livePlacement.x;
 		const visibleY = parseFloat( tile.style.top ) || livePlacement.y;
+
+		// Grabbing a tile that is part of the selection drags the whole
+		// selection; grabbing one outside it drags only that tile, and
+		// the selection catches up when the drag actually lifts.
+		//
+		// The selection is deliberately NOT mutated here. `pointerdown`
+		// is the one moment where changing it is destructive: a
+		// selection change repaints the tile, and a tile that repaints
+		// between `mousedown` and `mouseup` gets no `click` from the
+		// browser — so no `dblclick`, and the tile stops opening. That
+		// is the bug this comment exists to prevent from coming back.
+		// (`<os-tile>` now takes a children-preserving path for
+		// selection attributes too — belt and braces.)
+		const inSelection = selection.model.has( String( livePlacement.id ) );
+		const set = inSelection ? selectedPlacements() : [];
+		const placements =
+			set.length > 1 && set.some( ( p ) => p.id === livePlacement.id )
+				? set
+				: [ livePlacement ];
+
+		if ( ! inSelection ) {
+			// Sync the highlight to what's moving — but only once the
+			// gesture is provably a drag. By `os.drag.start` the
+			// pointer has passed the threshold, so there is no pending
+			// click left to break.
+			const syncSelection = (): void => {
+				document.removeEventListener( 'os.drag.start', syncSelection );
+				selection.model.set( [ String( livePlacement.id ) ] );
+			};
+			document.addEventListener( 'os.drag.start', syncSelection );
+			// A sub-threshold press is a click, not a drag: drop the
+			// listener so a later, unrelated drag can't apply it.
+			const cancelSync = (): void => {
+				document.removeEventListener( 'os.drag.start', syncSelection );
+				document.removeEventListener( 'pointerup', cancelSync );
+			};
+			document.addEventListener( 'pointerup', cancelSync );
+		}
+
+		// Dim every tile in the set, not just the grabbed one — the
+		// manager only knows about `payload.source`.
+		//
+		// Hung off `os.drag.start` rather than applied here, for the
+		// same reason the selection is: a press that turns out to be a
+		// click must leave the canvas exactly as it found it. Dimming
+		// on `pointerdown` would grey five tiles for every click on a
+		// multi-selection and only undim them at the next drag's end.
+		if ( placements.length > 1 ) {
+			const dimmed: HTMLElement[] = [];
+			const undim = (): void => {
+				for ( const el of dimmed ) {
+					el.classList.remove( `${ TILE_CLASS }--dragging` );
+				}
+				dimmed.length = 0;
+				document.removeEventListener( 'os.drag.start', dim );
+				document.removeEventListener( 'os.drag.end', undim );
+				document.removeEventListener( 'pointerup', undim );
+			};
+			const dim = (): void => {
+				for ( const p of placements ) {
+					const el = tile.parentElement?.querySelector< HTMLElement >(
+						`[data-placement-id="${ p.id }"]`,
+					);
+					if ( el && el !== tile ) {
+						el.classList.add( `${ TILE_CLASS }--dragging` );
+						dimmed.push( el );
+					}
+				}
+			};
+			document.addEventListener( 'os.drag.start', dim );
+			document.addEventListener( 'os.drag.end', undim );
+			// Backstop for the press that never became a drag — the
+			// manager fires no `end` for those.
+			document.addEventListener( 'pointerup', undim );
+		}
+
 		const session = dragManager.start( {
 			payload: {
 				type: 'desktop-file',
 				source: tile,
 				data: {
 					placement: livePlacement,
+					// Only set for a real multi-drag, so a single-item
+					// gesture produces byte-identical payloads to the
+					// ones every existing drop target was written for.
+					...( placements.length > 1 ? { placements } : {} ),
 					sourceFolderId: folderId,
 					// Synthesize a cross-frame bridge payload from the
 					// placement's file shape so a wallpaper-placed
@@ -1906,6 +2011,22 @@ function attachTileDrag(
 				ghost: {
 					offsetX: e.clientX - tile.getBoundingClientRect().left,
 					offsetY: e.clientY - tile.getBoundingClientRect().top,
+					element:
+						placements.length > 1
+							? buildDragStackGhost( tile, placements.length )
+							: undefined,
+					// Say the count in words as well as on the badge —
+					// the chip is what the user reads while hovering a
+					// target, and "Move here" over the Trash with five
+					// tiles in hand is an under-statement.
+					hint:
+						placements.length > 1
+							? {
+								accept: `Move ${ placements.length } items here`,
+								reject: `Can’t drop ${ placements.length } items here`,
+								neutral: `Moving ${ placements.length } items`,
+							}
+							: undefined,
 				},
 			},
 			origin: e,
@@ -1924,19 +2045,23 @@ function attachTileDrag(
 }
 
 /**
- * Wire right-click → context menu on a tile. Items vary by file
- * type — folders get a "Delete folder" that wipes the underlying
- * folder row plus its placements; non-folder user placements get
- * "Move to Trash" that drops only the placement (the entity stays
- * intact — that's the file-references-not-copies contract).
- * Plugin-registered icons (file type `'shortcut'`) and synthetic
- * dock-promotion shortcuts get "Hide from desktop" instead — they
- * aren't user data, so they're hidden via the visibility map and
- * restorable from OS Settings → Apps & Icons rather than trashed.
+ * Wire right-click → context menu on a tile.
+ *
+ * The item set for ONE placement lives in `tile-actions.ts`; what
+ * happens here is the selection part. Right-clicking a tile that
+ * isn't selected replaces the selection with it — Finder and
+ * Explorer both do that, and the alternative (acting on a hidden
+ * selection elsewhere on the canvas) is how people delete the wrong
+ * files. Right-clicking one that IS selected leaves the set alone,
+ * so a menu on five selected tiles acts on all five.
+ *
+ * `resolveCommonActions` then decides what a mixed set may offer.
  */
 function attachContextMenu(
 	tile: HTMLElement,
 	wiredPlacement: RestPlacementShape,
+	selection: SelectionHandle,
+	selectedPlacements: () => RestPlacementShape[],
 ): void {
 	tile.addEventListener( 'contextmenu', ( e: MouseEvent ) => {
 		e.preventDefault();
@@ -1949,220 +2074,14 @@ function attachContextMenu(
 		// patches — and the rename dialog pre-fills its title — so
 		// re-read the live version here.
 		const placement = filesStoreApi.currentPlacement( wiredPlacement );
-		const items: TileMenuItem[] = [
-			{
-				id: 'open',
-				label: 'Open',
-				icon: 'dashicons-external',
-				sort: 10,
-				onClick: () => {
-					const file = resolveFileType( placement.file );
-					void openFile( file );
-				},
-			},
-		];
-
-		// "Navigate into" — drills into the entity's detail dossier
-		// (Author / Comments / Tags / Categories / Attached media /
-		// Revisions). For post-type tiles, route straight to My
-		// WordPress's existing detail view via the public
-		// `wp.os.myWordpress.openDetail` API — no duplication
-		// of the dossier code here.
-		if ( placement.file.type === 'post' ) {
-			items.push( {
-				id: 'navigate-into',
-				label: 'Navigate into',
-				icon: 'dashicons-category',
-				sort: 20,
-				onClick: () => {
-					const postId = parseInt( placement.file.ref, 10 );
-					if ( ! postId ) {
-						return;
-					}
-					const api = (
-						window.wp as
-							| {
-									os?: {
-										myWordpress?: {
-											openDetail: ( a: {
-												entityId: string;
-												postId: number;
-												postTitle: string;
-											} ) => void;
-										};
-									};
-							}
-							| undefined
-					)?.os?.myWordpress;
-					// Map the post type → the My WordPress entity
-					// id. Pages live under `pages`; everything else
-					// (post + CPTs) defaults to `posts`. The shape
-					// matches the entities config the My WordPress
-					// PHP module ships.
-					const postType =
-						typeof placement.file.postType === 'string'
-							? ( placement.file.postType as string )
-							: 'post';
-					const entityId =
-						postType === 'page' ? 'pages' : 'posts';
-					api?.openDetail( {
-						entityId,
-						postId,
-						postTitle: placement.file.title || `#${ postId }`,
-					} );
-				},
-			} );
+		if ( ! selection.model.has( String( placement.id ) ) ) {
+			selection.model.set( [ String( placement.id ) ] );
 		}
-
-		const isFolder = placement.file.type === 'folder';
-		if ( isFolder ) {
-			items.push( {
-				id: 'rename-folder',
-				label: 'Rename…',
-				icon: 'dashicons-edit',
-				sort: 30,
-				onClick: () => {
-					const folderId = parseInt( placement.file.ref, 10 );
-					if ( ! folderId ) {
-						return;
-					}
-					// Renaming is purely cosmetic — the folder's
-					// numeric `id` is the only thing placements,
-					// folder windows, and the auto-place orphan
-					// backfill ever reference. Updating `name`
-					// can never break a reference.
-					openCreateFolderDialog( {
-						title: 'Rename folder',
-						label: 'New name',
-						submitLabel: 'Rename',
-						initialName: placement.file.title,
-						onSubmit: async ( name ) => {
-							const trimmed = name.trim();
-							if ( ! trimmed || trimmed === placement.file.title ) {
-								return;
-							}
-							// Optimistic rename: patch the store so
-							// the tile + any open folder window
-							// retitle immediately, then sync to REST.
-							// Roll back on failure.
-							const previousTitle = placement.file.title;
-							const optimistic: RestPlacementShape = {
-								...placement,
-								file: { ...placement.file, title: trimmed },
-							};
-							filesStoreApi.upsertPlacement( optimistic );
-							try {
-								const folderUpdatedAtMs =
-									filesStoreApi
-										.getState()
-										.folders.get( folderId )?.updatedAtMs ?? 0;
-								const updated = await rest.updateFolder(
-									folderId,
-									{ name: trimmed },
-									folderUpdatedAtMs,
-								);
-								filesStoreApi.upsertFolder( updated );
-								// Refresh the placement list for the
-								// tile's parent so all folder views
-								// (root + open folder windows that
-								// contain this folder as a child) see
-								// the new label.
-								const refreshed = await rest.listPlacements(
-									placement.parentId,
-								);
-								filesStoreApi.setFolderPlacements(
-									placement.parentId,
-									refreshed.placements,
-								);
-							} catch ( err ) {
-								// eslint-disable-next-line no-console
-								console.error(
-									'[openstation] rename folder failed:',
-									err,
-								);
-								// Roll back the optimistic title.
-								filesStoreApi.upsertPlacement( {
-									...placement,
-									file: {
-										...placement.file,
-										title: previousTitle,
-									},
-								} );
-							}
-						},
-					} );
-				},
-			} );
-			// Only surface "Move folder to Trash" when the server
-			// says the viewer is allowed to. For a recipient's root
-			// placement of a SHARED folder the share-trash gate
-			// returns false (the correct affordance is "Leave shared
-			// folder", added by `share-menu-items.ts`), so the
-			// destructive entry stays out of their menu entirely.
-			// `undefined` falls through for legacy payloads — the
-			// server REST 403 + toast still backstop those.
-			if ( placement.canTrash !== false ) {
-				items.push( {
-					id: 'delete-folder',
-					label: 'Move folder to Trash',
-					icon: 'dashicons-trash',
-					sort: 90,
-					danger: true,
-					onClick: () => trashFolderWithUndo( placement ),
-				} );
-			}
-		} else {
-			// Two cases get "Hide from desktop" instead of "Move to
-			// Trash":
-			//
-			//   1. Synthetic shortcuts the user promoted from a dock
-			//      item via OS Settings → Apps & Icons. They aren't
-			//      real placements — they're derived from the
-			//      visibility map and live only in the in-memory store,
-			//      so trashing them would 404 on the REST endpoint.
-			//
-			//   2. Plugin-registered icons (file type `'shortcut'`) —
-			//      Content Graph, Recycle Bin, My WordPress, and any
-			//      icon registered via `openstation_register_icon()`.
-			//      These are framework/plugin shortcuts, not user
-			//      data, and shouldn't be deletable from the wallpaper.
-			//      The user can hide them here and restore via OS
-			//      Settings → Apps & Icons.
-			//
-			// Both write `itemVisibility[ id ] = 'dock'` — the layout
-			// dispatcher's settings subscription drops the desktop tile
-			// on the next tick.
-			const synthFromDockItem = readSynthSource( placement );
-			const isRegisteredIcon = placement.file.type === 'shortcut';
-			if ( synthFromDockItem || isRegisteredIcon ) {
-				const hideId = synthFromDockItem ?? placement.file.ref;
-				items.push( {
-					id: 'hide-from-desktop',
-					label: 'Hide from desktop',
-					icon: 'dashicons-hidden',
-					sort: 90,
-					onClick: () => hidePromotedDockItem( hideId ),
-				} );
-			} else if ( placement.canTrash !== false ) {
-				// Only surface "Move to Trash" when the server says
-				// the viewer is allowed to. `canTrash === false`
-				// applies to placements inside a shared folder where
-				// the viewer lacks write capability — without this
-				// guard the user could pick the menu item, attempt
-				// the REST call, and only see the failure logged to
-				// the console while the tile sat un-moved. `undefined`
-				// (legacy payloads) falls through to "let it through"
-				// so older clients keep behaving as today.
-				items.push( {
-					id: 'remove',
-					label: 'Move to Trash',
-					icon: 'dashicons-trash',
-					sort: 90,
-					danger: true,
-					onClick: () => trashPlacementWithUndo( placement ),
-				} );
-			}
-		}
-		openTileMenu( { x: e.clientX, y: e.clientY }, { placement, items } );
+		const targets = selectedPlacements();
+		const items = targets.length > 0 ? targets : [ placement ];
+		const actions = resolveCommonActions( items, buildPlacementActions );
+		openPlacementActionMenu( { x: e.clientX, y: e.clientY }, actions, {
+			placementIds: items.map( ( p ) => p.id ),
+		} );
 	} );
 }

--- a/src/desktop-files/preview.ts
+++ b/src/desktop-files/preview.ts
@@ -879,3 +879,46 @@ export function renderPreviewEmpty(): HTMLElement {
 	);
 	return wrap;
 }
+
+/**
+ * Summary node for a multi-selection — what the right pane shows
+ * instead of a preview when the user holds several items. Previewing
+ * one arbitrary member of the set would be worse than saying nothing:
+ * it reads as "this is the thing you selected" when it isn't.
+ *
+ * Lists the type breakdown because that is exactly what determines
+ * which actions the context menu will offer.
+ *
+ * @public
+ */
+export function renderSelectionSummary(
+	items: ReadonlyArray< { file: { type: string } } >,
+): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'os-my-wordpress__preview-empty';
+
+	const heading = document.createElement( 'strong' );
+	heading.textContent = sprintf(
+		/* translators: %d: number of selected items. */
+		__( '%d items selected', 'desktop-mode' ),
+		items.length,
+	);
+	wrap.appendChild( heading );
+
+	const counts = new Map< string, number >();
+	for ( const item of items ) {
+		const type = item.file?.type || 'item';
+		counts.set( type, ( counts.get( type ) ?? 0 ) + 1 );
+	}
+	const breakdown = Array.from( counts.entries() )
+		.sort( ( a, b ) => b[ 1 ] - a[ 1 ] || a[ 0 ].localeCompare( b[ 0 ] ) )
+		.map( ( [ type, n ] ) => `${ n } × ${ type }` )
+		.join( ' · ' );
+	if ( breakdown ) {
+		const detail = document.createElement( 'div' );
+		detail.className = 'os-files-preview__selection-breakdown';
+		detail.textContent = breakdown;
+		wrap.appendChild( detail );
+	}
+	return wrap;
+}

--- a/src/desktop-files/recycle-bin-targets.ts
+++ b/src/desktop-files/recycle-bin-targets.ts
@@ -34,13 +34,19 @@
 import { __ } from '../i18n';
 import { addAction, HOOKS } from '../hooks';
 import type { DragManagerApi, DragSession } from '../drag';
-import { trashByFileType } from './trash';
+import { trashManyWithUndo } from './trash';
+import { showToast } from '../toast';
 import {
 	recycleBinPayloadAccepts,
 	recycleBinPayloadDrop,
 } from './recycle-bin-payloads';
 import type { RestPlacementShape } from './rest';
-import type { ShortcutDragData } from './drag-payloads';
+import {
+	dragPlacements,
+	dragShortcutItems,
+	type DesktopFileDragData,
+	type ShortcutDragData,
+} from './drag-payloads';
 
 /**
  * My WordPress entity kinds the recycle bin knows how to trash via
@@ -172,6 +178,20 @@ function registerOn(
 				if ( ! placement ) {
 					return false;
 				}
+				// A multi-drag is accepted only when EVERY item can be
+				// trashed. Half-trashing a set the user dropped as one
+				// gesture is the kind of partial success that reads as
+				// total success.
+				const set = dragPlacements(
+					data as unknown as DesktopFileDragData,
+				);
+				if ( set.length > 1 ) {
+					return set.every(
+						( p ) =>
+							p.file?.ref !== RECYCLE_BIN_WINDOW_ID &&
+							p.canTrash !== false,
+					);
+				}
 				// Never trash the recycle bin into itself. Both drop
 				// surfaces (the bin's wallpaper tile + the bin window
 				// body) share this `accept`, so dragging the bin onto
@@ -199,7 +219,10 @@ function registerOn(
 			// Trash" CMO so both gestures end at the same REST call.
 			if ( payload.type === 'shortcut' ) {
 				const data = payload.data as Partial< ShortcutDragData >;
-				return isTrashableShortcut( data );
+				const set = dragShortcutItems( data as ShortcutDragData );
+				return (
+					set.length > 0 && set.every( ( i ) => isTrashableShortcut( i ) )
+				);
 			}
 			// Payload types this module doesn't own (the pinned-notes
 			// `'note'` drag today) can be claimed by a registered bin
@@ -217,8 +240,15 @@ function registerOn(
 		onDrop: ( session, ev ) => {
 			el.removeAttribute( TRASH_DROP_ACTIVE_ATTR );
 			if ( isDesktopFilePayload( session ) ) {
-				const placement = session.payload.data.placement;
-				void trashByFileType( placement );
+				// One gesture, one trash operation: `trashManyWithUndo`
+				// collapses a set into a single toast whose Undo brings
+				// all of them back. It routes a single item straight to
+				// the per-item helper, so this covers both.
+				void trashManyWithUndo(
+					dragPlacements(
+						session.payload.data as unknown as DesktopFileDragData,
+					),
+				);
 				return;
 			}
 			if (
@@ -228,24 +258,50 @@ function registerOn(
 				return;
 			}
 			if ( isShortcutPayload( session ) ) {
-				const data = session.payload.data;
 				const api = getMyWordpressTrashApi();
-				if ( ! api?.trashEntity || ! data.entityId ) {
+				if ( ! api?.trashEntity ) {
 					return;
 				}
-				const numericRef = Number.parseInt( data.ref, 10 );
-				if ( ! Number.isFinite( numericRef ) || numericRef <= 0 ) {
+				const trashEntity = api.trashEntity;
+				const set = dragShortcutItems( session.payload.data );
+				const trashing = set
+					.map( ( item ) => ( {
+						entityId: item.entityId,
+						ref: Number.parseInt( item.ref, 10 ),
+					} ) )
+					.filter(
+						( t ): t is { entityId: string; ref: number } =>
+							!! t.entityId &&
+							Number.isFinite( t.ref ) &&
+							t.ref > 0,
+					);
+				if ( trashing.length === 0 ) {
 					return;
 				}
-				void api.trashEntity( data.entityId, numericRef ).catch(
-					( err: unknown ) => {
+				void Promise.allSettled(
+					trashing.map( ( t ) => trashEntity( t.entityId, t.ref ) ),
+				).then( ( results ) => {
+					const failed = results.filter(
+						( r ) => r.status === 'rejected',
+					);
+					for ( const failure of failed ) {
 						// eslint-disable-next-line no-console
 						console.error(
 							'[openstation] recycle-bin: shortcut trash failed:',
-							err,
+							( failure as PromiseRejectedResult ).reason,
 						);
-					},
-				);
+					}
+					const moved = trashing.length - failed.length;
+					if ( moved > 1 || failed.length > 0 ) {
+						showToast( {
+							message:
+								failed.length > 0
+									? `${ moved } moved to Trash · ${ failed.length } could not be moved`
+									: `${ moved } items moved to Trash`,
+							duration: failed.length > 0 ? 6000 : 4000,
+						} );
+					}
+				} );
 			}
 		},
 	} );

--- a/src/desktop-files/synthetic.ts
+++ b/src/desktop-files/synthetic.ts
@@ -1,0 +1,83 @@
+/**
+ * OpenStation — synthetic placements.
+ *
+ * A "synthetic" placement is a desktop tile with no row behind it:
+ * a dock item the user promoted to the wallpaper via OpenStation
+ * Settings → Apps & Icons. `settings/desktop-shortcuts-sync.ts`
+ * mints them into the store with deterministic negative ids, so any
+ * REST write aimed at one would 404 (`/files/placements/(?P<id>\d+)`
+ * only matches positive integers).
+ *
+ * Extracted from `layer.ts` so the tile-action builder can share
+ * these predicates without importing the layer — the layer imports
+ * the builder, and a cycle between the two would be a real hazard
+ * given how much module-level state `layer.ts` sets up.
+ */
+
+import type { RestPlacementShape } from './rest';
+
+/**
+ * If `placement` is a synthesized shortcut from a promoted dock item,
+ * return the source dock-item id. Returns `null` for real placements.
+ *
+ * Marker key matches the one written by
+ * `settings/desktop-shortcuts-sync.ts`.
+ */
+export function readSynthSource( placement: RestPlacementShape ): string | null {
+	const meta = placement.meta;
+	if ( ! meta || typeof meta !== 'object' ) {
+		return null;
+	}
+	const v = ( meta as Record< string, unknown > ).__synthFromDockItem;
+	return typeof v === 'string' && v !== '' ? v : null;
+}
+
+/**
+ * Whether `placement` is a synthetic (no DB row) one. Two signals:
+ *   - The `__synthFromDockItem` meta marker — definitive when present.
+ *   - A non-positive id — see the module header for why those can
+ *     never round-trip through REST either.
+ *
+ * Used to gate every REST write against a placement.
+ */
+export function isSyntheticPlacement( placement: RestPlacementShape ): boolean {
+	return placement.id <= 0 || readSynthSource( placement ) !== null;
+}
+
+/**
+ * Hide a dock item the user previously promoted onto the desktop.
+ * Mutates `OsSettingsState.itemVisibility[ dockItemId ]` to `'dock'`
+ * via the public API; the shortcuts-sync subscription removes the
+ * synthetic placement on the next tick.
+ *
+ * Accepts several ids at once so hiding a multi-selection is a single
+ * settings write — one round-trip, one re-render, instead of N of
+ * each racing the sync subscription.
+ */
+export function hidePromotedDockItems( dockItemIds: readonly string[] ): void {
+	if ( dockItemIds.length === 0 ) {
+		return;
+	}
+	const api = (
+		window as unknown as {
+			wp?: {
+				os?: {
+					getOsSettings?: () => {
+						itemVisibility: Record< string, string >;
+					};
+					updateOsSettings?: ( patch: {
+						itemVisibility?: Record< string, string >;
+					} ) => void;
+				};
+			};
+		}
+	).wp?.os;
+	if ( ! api?.getOsSettings || ! api?.updateOsSettings ) {
+		return;
+	}
+	const next = { ...( api.getOsSettings().itemVisibility ?? {} ) };
+	for ( const id of dockItemIds ) {
+		next[ id ] = 'dock';
+	}
+	api.updateOsSettings( { itemVisibility: next } );
+}

--- a/src/desktop-files/tile-actions.ts
+++ b/src/desktop-files/tile-actions.ts
@@ -50,6 +50,21 @@ import type { RestPlacementShape } from './rest';
  */
 const OPEN_CONFIRM_THRESHOLD = 5;
 
+/**
+ * The batched Trash runner, as ONE function reference shared by the
+ * folder entry and the file entry.
+ *
+ * They merge on `multiId: 'trash'`, and the resolver batches by
+ * runner IDENTITY — each distinct `bulk` function is called once with
+ * the items that declared it. Written inline at each site these would
+ * be two different closures over the same helper, so a mixed
+ * selection would produce two calls and therefore two toasts with two
+ * Undos, for what the user did as one gesture. Sharing the reference
+ * keeps it one of each.
+ */
+const trashMany = ( placements: RestPlacementShape[] ): Promise< void > =>
+	trashManyWithUndo( placements );
+
 /** Open every placement in a set, checking first if the set is large. */
 async function openMany( placements: readonly RestPlacementShape[] ): Promise< void > {
 	if ( placements.length > OPEN_CONFIRM_THRESHOLD ) {
@@ -224,7 +239,7 @@ export function buildPlacementActions(
 				danger: true,
 				multi: true,
 				bulkLabel: ( n ) => `Move ${ n } items to Trash`,
-				bulk: ( placements ) => trashManyWithUndo( placements ),
+				bulk: trashMany,
 				onClick: () => trashFolderWithUndo( placement ),
 			} );
 		}
@@ -287,7 +302,7 @@ export function buildPlacementActions(
 				danger: true,
 				multi: true,
 				bulkLabel: ( n ) => `Move ${ n } items to Trash`,
-				bulk: ( placements ) => trashManyWithUndo( placements ),
+				bulk: trashMany,
 				onClick: () => trashPlacementWithUndo( placement ),
 			} );
 		}

--- a/src/desktop-files/tile-actions.ts
+++ b/src/desktop-files/tile-actions.ts
@@ -1,0 +1,303 @@
+/**
+ * OpenStation — what a file tile can do.
+ *
+ * One function, `buildPlacementActions( placement )`, answering the
+ * single-item half of the selection contract: *what can be done to
+ * THIS placement?* The framework's `resolveCommonActions()` calls it
+ * once per selected tile and intersects the results.
+ *
+ * Lifted verbatim out of `layer.ts`'s `attachContextMenu` — the item
+ * set, the ids, the sort values, the `os.files.tile-menu` filter and
+ * its argument shape are all unchanged, because plugin authors have
+ * been filtering that list since it shipped. What's new is the
+ * multi-selection metadata on the built-ins: `multi`, `multiId`,
+ * `bulkLabel` and `bulk`.
+ *
+ * Which built-ins opted in, and why the rest didn't:
+ *
+ *   Open              yes — fan-out, with a confirm past a handful
+ *                     of windows.
+ *   Move to Trash     yes — one batched runner, one Undo. Folder and
+ *                     file entries share `multiId: 'trash'` so a
+ *                     mixed selection can still be thrown away.
+ *   Hide from desktop yes — one settings write for the whole set.
+ *   Rename…           no  — one name, one thing.
+ *   Navigate into     no  — a dossier is about one entity.
+ *   Download          no  — browsers block multi-navigation; the
+ *                     folder .zip entry is the real answer.
+ */
+
+import { applyFilters } from '../hooks';
+import { osConfirm } from '../os-confirm';
+import type { SelectionAction } from '../selection';
+import { openCreateFolderDialog } from './create-folder-dialog';
+import { rest, store as filesStoreApi } from './layer-deps';
+import { openFile } from './open';
+import { resolve as resolveFileType } from './registry';
+import { hidePromotedDockItems, readSynthSource } from './synthetic';
+import type { TileMenuItem } from './tile-menu';
+import {
+	trashFolderWithUndo,
+	trashManyWithUndo,
+	trashPlacementWithUndo,
+} from './trash';
+import type { RestPlacementShape } from './rest';
+
+/**
+ * How many windows we'll open from one gesture before asking. Past
+ * this the user has almost certainly mis-selected, and N windows is
+ * a mess to undo by hand.
+ */
+const OPEN_CONFIRM_THRESHOLD = 5;
+
+/** Open every placement in a set, checking first if the set is large. */
+async function openMany( placements: readonly RestPlacementShape[] ): Promise< void > {
+	if ( placements.length > OPEN_CONFIRM_THRESHOLD ) {
+		const ok = await osConfirm( {
+			title: `Open ${ placements.length } items?`,
+			message: `This opens ${ placements.length } windows at once.`,
+			confirmLabel: 'Open all',
+		} );
+		if ( ! ok ) {
+			return;
+		}
+	}
+	for ( const placement of placements ) {
+		await openFile( resolveFileType( placement.file ) );
+	}
+}
+
+/** Open the rename dialog for a folder placement and persist the result. */
+function renameFolder( placement: RestPlacementShape ): void {
+	const folderId = parseInt( placement.file.ref, 10 );
+	if ( ! folderId ) {
+		return;
+	}
+	// Renaming is purely cosmetic — the folder's numeric `id` is the
+	// only thing placements, folder windows, and the auto-place orphan
+	// backfill ever reference. Updating `name` can never break a
+	// reference.
+	openCreateFolderDialog( {
+		title: 'Rename folder',
+		label: 'New name',
+		submitLabel: 'Rename',
+		initialName: placement.file.title,
+		onSubmit: async ( name ) => {
+			const trimmed = name.trim();
+			if ( ! trimmed || trimmed === placement.file.title ) {
+				return;
+			}
+			// Optimistic rename: patch the store so the tile + any open
+			// folder window retitle immediately, then sync to REST.
+			// Roll back on failure.
+			const previousTitle = placement.file.title;
+			const optimistic: RestPlacementShape = {
+				...placement,
+				file: { ...placement.file, title: trimmed },
+			};
+			filesStoreApi.upsertPlacement( optimistic );
+			try {
+				const folderUpdatedAtMs =
+					filesStoreApi.getState().folders.get( folderId )
+						?.updatedAtMs ?? 0;
+				const updated = await rest.updateFolder(
+					folderId,
+					{ name: trimmed },
+					folderUpdatedAtMs,
+				);
+				filesStoreApi.upsertFolder( updated );
+				// Refresh the placement list for the tile's parent so
+				// all folder views (root + open folder windows that
+				// contain this folder as a child) see the new label.
+				const refreshed = await rest.listPlacements( placement.parentId );
+				filesStoreApi.setFolderPlacements(
+					placement.parentId,
+					refreshed.placements,
+				);
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( '[openstation] rename folder failed:', err );
+				filesStoreApi.upsertPlacement( {
+					...placement,
+					file: { ...placement.file, title: previousTitle },
+				} );
+			}
+		},
+	} );
+}
+
+/** Route a "Navigate into" pick to My WordPress's detail dossier. */
+function navigateIntoPost( placement: RestPlacementShape ): void {
+	const postId = parseInt( placement.file.ref, 10 );
+	if ( ! postId ) {
+		return;
+	}
+	const api = (
+		window.wp as
+			| {
+					os?: {
+						myWordpress?: {
+							openDetail: ( a: {
+								entityId: string;
+								postId: number;
+								postTitle: string;
+							} ) => void;
+						};
+					};
+			}
+			| undefined
+	)?.os?.myWordpress;
+	// Map the post type → the My WordPress entity id. Pages live under
+	// `pages`; everything else (post + CPTs) defaults to `posts`.
+	const postType =
+		typeof placement.file.postType === 'string'
+			? ( placement.file.postType as string )
+			: 'post';
+	const entityId = postType === 'page' ? 'pages' : 'posts';
+	api?.openDetail( {
+		entityId,
+		postId,
+		postTitle: placement.file.title || `#${ postId }`,
+	} );
+}
+
+/**
+ * Build the action list for one placement, with the
+ * `os.files.tile-menu` filter applied.
+ *
+ * @public
+ */
+export function buildPlacementActions(
+	placement: RestPlacementShape,
+): SelectionAction< RestPlacementShape >[] {
+	const items: TileMenuItem[] = [
+		{
+			id: 'open',
+			label: 'Open',
+			icon: 'dashicons-external',
+			sort: 10,
+			multi: true,
+			bulkLabel: ( n ) => `Open ${ n } items`,
+			bulk: ( placements ) => openMany( placements ),
+			onClick: () => {
+				void openFile( resolveFileType( placement.file ) );
+			},
+		},
+	];
+
+	// "Navigate into" — drills into the entity's detail dossier
+	// (Author / Comments / Tags / Categories / Attached media /
+	// Revisions) via My WordPress's existing detail view.
+	if ( placement.file.type === 'post' ) {
+		items.push( {
+			id: 'navigate-into',
+			label: 'Navigate into',
+			icon: 'dashicons-category',
+			sort: 20,
+			onClick: () => navigateIntoPost( placement ),
+		} );
+	}
+
+	const isFolder = placement.file.type === 'folder';
+	if ( isFolder ) {
+		items.push( {
+			id: 'rename-folder',
+			label: 'Rename…',
+			icon: 'dashicons-edit',
+			sort: 30,
+			onClick: () => renameFolder( placement ),
+		} );
+		// Only surface "Move folder to Trash" when the server says the
+		// viewer is allowed to. For a recipient's root placement of a
+		// SHARED folder the share-trash gate returns false (the correct
+		// affordance is "Leave shared folder", added by
+		// `share-menu-items.ts`), so the destructive entry stays out of
+		// their menu entirely. `undefined` falls through for legacy
+		// payloads — the server REST 403 + toast still backstop those.
+		if ( placement.canTrash !== false ) {
+			items.push( {
+				id: 'delete-folder',
+				multiId: 'trash',
+				label: 'Move folder to Trash',
+				icon: 'dashicons-trash',
+				sort: 90,
+				danger: true,
+				multi: true,
+				bulkLabel: ( n ) => `Move ${ n } items to Trash`,
+				bulk: ( placements ) => trashManyWithUndo( placements ),
+				onClick: () => trashFolderWithUndo( placement ),
+			} );
+		}
+	} else {
+		// Two cases get "Hide from desktop" instead of "Move to Trash":
+		//
+		//   1. Synthetic shortcuts the user promoted from a dock item
+		//      via OpenStation Settings → Apps & Icons. They aren't real
+		//      placements — they're derived from the visibility map and
+		//      live only in the in-memory store, so trashing them would
+		//      404 on the REST endpoint.
+		//
+		//   2. Plugin-registered icons (file type `'shortcut'`) — Content
+		//      Graph, Recycle Bin, My WordPress, and any icon registered
+		//      via `openstation_register_icon()`. These are framework /
+		//      plugin shortcuts, not user data, and shouldn't be
+		//      deletable from the wallpaper. The user can hide them here
+		//      and restore via OpenStation Settings → Apps & Icons.
+		//
+		// Both write `itemVisibility[ id ] = 'dock'` — the layout
+		// dispatcher's settings subscription drops the desktop tile on
+		// the next tick.
+		const synthFromDockItem = readSynthSource( placement );
+		const isRegisteredIcon = placement.file.type === 'shortcut';
+		if ( synthFromDockItem || isRegisteredIcon ) {
+			const hideId = synthFromDockItem ?? placement.file.ref;
+			items.push( {
+				id: 'hide-from-desktop',
+				label: 'Hide from desktop',
+				icon: 'dashicons-hidden',
+				sort: 90,
+				multi: true,
+				bulkLabel: ( n ) => `Hide ${ n } items from desktop`,
+				bulk: ( placements ) => {
+					hidePromotedDockItems(
+						placements
+							.map(
+								( p ) => readSynthSource( p ) ?? p.file.ref,
+							)
+							.filter( ( id ): id is string => !! id ),
+					);
+				},
+				onClick: () => hidePromotedDockItems( [ hideId ] ),
+			} );
+		} else if ( placement.canTrash !== false ) {
+			// Only surface "Move to Trash" when the server says the
+			// viewer is allowed to. `canTrash === false` applies to
+			// placements inside a shared folder where the viewer lacks
+			// write capability — without this guard the user could pick
+			// the menu item, attempt the REST call, and only see the
+			// failure logged to the console while the tile sat un-moved.
+			// `undefined` (legacy payloads) falls through to "let it
+			// through" so older clients keep behaving as today.
+			items.push( {
+				id: 'remove',
+				multiId: 'trash',
+				label: 'Move to Trash',
+				icon: 'dashicons-trash',
+				sort: 90,
+				danger: true,
+				multi: true,
+				bulkLabel: ( n ) => `Move ${ n } items to Trash`,
+				bulk: ( placements ) => trashManyWithUndo( placements ),
+				onClick: () => trashPlacementWithUndo( placement ),
+			} );
+		}
+	}
+
+	const filtered = applyFilters< TileMenuItem[], [ RestPlacementShape ] >(
+		'os.files.tile-menu',
+		items,
+		placement,
+	);
+	const list = Array.isArray( filtered ) ? filtered : items;
+	return list as SelectionAction< RestPlacementShape >[];
+}

--- a/src/desktop-files/tile-menu.ts
+++ b/src/desktop-files/tile-menu.ts
@@ -1,46 +1,45 @@
 /**
  * OpenStation — File-tile right-click context menu.
  *
- * Sister of the wallpaper context menu, scoped to a single
- * placement. Built-in items: Open, Delete (or "Delete folder"
- * when the placement is a folder). Plugin authors extend the
- * list via the `os.files.tile-menu` filter.
+ * Sister of the wallpaper context menu, scoped to a placement — or,
+ * since multi-selection, to the placements the user currently holds.
+ * The built-in item set lives in `tile-actions.ts`; plugin authors
+ * extend it via the `os.files.tile-menu` filter, unchanged.
  *
- * Reuses the wallpaper-menu's CSS (`.os-wallpaper-menu*`)
- * so the two menus look identical.
+ * The DOM is built by the shared `openActionMenu` (deferred behind
+ * the shell-overlays loader, dismissable, viewport-clamped). This
+ * module keeps the placement-shaped entry points and the long-
+ * standing `os.files.tile-menu.opened` / `.closed` actions, which
+ * plugins subscribe to.
  */
 
 import { applyFilters, doAction } from '../hooks';
-import { openWithShellOverlays } from '../shell-overlays/loader';
-import { attachDismissable } from './dismissable';
+import {
+	closeActionMenu,
+	isActionMenuOpen,
+	openActionMenu,
+} from '../selection/menu';
+import type { SelectionAction } from '../selection/actions';
 import type { RestPlacementShape } from './rest';
 
-export interface TileMenuItem {
-	id: string;
-	label: string;
-	icon?: string;
-	sort?: number;
-	disabled?: boolean;
-	danger?: boolean;
-	onClick: ( e: MouseEvent ) => void | Promise< void >;
-}
-
-const MENU_CLASS = 'os-wallpaper-menu';
-
-let activeMenu: HTMLElement | null = null;
+/**
+ * One entry in a file-tile menu.
+ *
+ * The multi-selection fields (`multi`, `multiId`, `bulkLabel`,
+ * `bulk`) are optional and default to single-item-only: an entry
+ * added by a plugin keeps behaving exactly as it did, and appears
+ * only when one tile is selected, until it opts in.
+ *
+ * @public
+ */
+export type TileMenuItem = SelectionAction< RestPlacementShape >;
 
 export function isTileMenuOpen(): boolean {
-	return activeMenu !== null;
+	return isActionMenuOpen();
 }
 
 export function closeTileMenu(): void {
-	if ( ! activeMenu ) {
-		return;
-	}
-	activeMenu.dispatchEvent( new CustomEvent( 'tile-menu-closed' ) );
-	activeMenu.remove();
-	activeMenu = null;
-	doAction( 'os.files.tile-menu.closed', {} );
+	closeActionMenu();
 }
 
 export interface OpenTileMenuOptions {
@@ -48,28 +47,16 @@ export interface OpenTileMenuOptions {
 	items: TileMenuItem[];
 }
 
-let openGeneration = 0;
-
 /**
- * Open the tile context menu at viewport coordinates.
+ * Open the tile context menu for ONE placement, applying the
+ * `os.files.tile-menu` filter to `items` first.
  *
- * Construction is deferred behind the shell-overlays loader so the
- * `<os-context-menu>` / `<os-context-menu-option>` classes ship
- * in the lazy bundle rather than `desktop.min.js`.
+ * The layer no longer routes through here — it resolves the actions
+ * for the whole selection (which applies the filter per item) and
+ * calls {@link openPlacementActionMenu}. This entry point stays for
+ * plugins and tests that build a menu for a single placement.
  */
 export function openTileMenu(
-	pos: { x: number; y: number },
-	opts: OpenTileMenuOptions,
-): void {
-	closeTileMenu();
-	const myGen = ++openGeneration;
-	openWithShellOverlays(
-		() => myGen === openGeneration,
-		() => openTileMenuImmediate( pos, opts ),
-	);
-}
-
-function openTileMenuImmediate(
 	pos: { x: number; y: number },
 	{ placement, items }: OpenTileMenuOptions,
 ): void {
@@ -78,79 +65,60 @@ function openTileMenuImmediate(
 		items.slice(),
 		placement,
 	);
-	const sorted = ( Array.isArray( list ) ? list : items )
-		.slice()
-		.sort( ( a, b ) => {
-			const sa = typeof a.sort === 'number' ? a.sort : 100;
-			const sb = typeof b.sort === 'number' ? b.sort : 100;
-			if ( sa !== sb ) {
-				return sa - sb;
-			}
-			return a.label.localeCompare( b.label );
-		} );
+	const resolved = Array.isArray( list ) ? list : items;
+	openPlacementActionMenu( pos, resolved, {
+		placementIds: [ placement.id ],
+	} );
+}
 
+export interface PlacementActionMenuContext {
+	/** Placements the menu acts on. Drives the `opened` action payload. */
+	placementIds: number[];
+}
+
+/**
+ * Open a menu for an already-resolved action list.
+ *
+ * "Already resolved" means the `os.files.tile-menu` filter has run
+ * (per item) and, for a multi-selection, `resolveCommonActions` has
+ * intersected the results. Applying the filter again here would
+ * double every entry a plugin pushes.
+ */
+export function openPlacementActionMenu(
+	pos: { x: number; y: number },
+	actions: TileMenuItem[],
+	ctx: PlacementActionMenuContext,
+): void {
+	const sorted = actions.slice().sort( ( a, b ) => {
+		const sa = typeof a.sort === 'number' ? a.sort : 100;
+		const sb = typeof b.sort === 'number' ? b.sort : 100;
+		if ( sa !== sb ) {
+			return sa - sb;
+		}
+		return a.label.localeCompare( b.label );
+	} );
 	if ( sorted.length === 0 ) {
 		return;
 	}
 
-	const menu = document.createElement( 'os-context-menu' );
-	menu.setAttribute( 'open', '' );
-	menu.classList.add( MENU_CLASS );
-	( menu as HTMLElement ).dataset.placementId = String( placement.id );
-	menu.style.left = `${ pos.x }px`;
-	menu.style.top = `${ pos.y }px`;
-
-	const itemById = new Map< string, TileMenuItem >();
-	for ( const item of sorted ) {
-		itemById.set( item.id, item );
-		const opt = document.createElement( 'os-context-menu-option' );
-		opt.dataset.menuItemId = item.id;
-		opt.setAttribute( 'value', item.id );
-		if ( item.danger ) {
-			opt.setAttribute( 'danger', '' );
-		}
-		if ( item.disabled ) {
-			opt.setAttribute( 'disabled', '' );
-		}
-		if ( item.icon ) {
-			opt.setAttribute( 'icon', sanitizeClass( item.icon ) );
-		}
-		opt.textContent = item.label;
-		menu.appendChild( opt );
-	}
-
-	menu.addEventListener( 'os-context-menu-pick', ( e: Event ) => {
-		const detail = ( e as CustomEvent< { id: string; value: string } > ).detail;
-		const item = itemById.get( detail.id );
-		if ( ! item ) {
-			return;
-		}
-		closeTileMenu();
-		void item.onClick( new MouseEvent( 'click' ) );
+	openActionMenu( pos, {
+		actions: sorted,
+		scope: 'files.tile',
+		dataset: {
+			// Single-selection menus keep the exact attribute the old
+			// implementation set — tests and plugin CSS select on it.
+			placementId: String( ctx.placementIds[ 0 ] ?? '' ),
+			placementIds: ctx.placementIds.join( ',' ),
+		},
+		onOpened: ( ids ) => {
+			doAction( 'os.files.tile-menu.opened', {
+				placementId: ctx.placementIds[ 0 ],
+				placementIds: ctx.placementIds.slice(),
+				items: ids,
+			} );
+		},
+		onClosed: () => {
+			doAction( 'os.files.tile-menu.closed', {} );
+		},
 	} );
-
-	document.body.appendChild( menu );
-	activeMenu = menu;
-
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		menu.style.left = `${ Math.max( 0, window.innerWidth - rect.width - 8 ) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		menu.style.top = `${ Math.max( 0, window.innerHeight - rect.height - 8 ) }px`;
-	}
-
-	const detach = attachDismissable( menu, {
-		close: () => closeTileMenu(),
-	} );
-	menu.addEventListener( 'tile-menu-closed', detach );
-
-	doAction( 'os.files.tile-menu.opened', {
-		placementId: placement.id,
-		items: sorted.map( ( i ) => i.id ),
-	} );
-}
-
-function sanitizeClass( raw: string ): string {
-	return raw.replace( /[^a-zA-Z0-9_-]/g, '' );
 }

--- a/src/desktop-files/tile-spec.ts
+++ b/src/desktop-files/tile-spec.ts
@@ -197,6 +197,45 @@ export function buildTileFromSpec( spec: TileSpec ): HTMLElement {
 }
 
 /**
+ * Ghost for a multi-item drag: the grabbed tile, with the rest of the
+ * set implied by a stack behind it and stated by a count badge.
+ *
+ * A ghost showing only the grabbed tile would say "you are moving one
+ * thing" while five move — and the count is the part users check
+ * before releasing over the Trash.
+ *
+ * @public
+ */
+export function buildDragStackGhost(
+	tile: HTMLElement,
+	count: number,
+): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'os-drag-stack';
+	const rect = tile.getBoundingClientRect();
+	wrap.style.width = `${ rect.width }px`;
+	wrap.style.height = `${ rect.height }px`;
+
+	const clone = tile.cloneNode( true ) as HTMLElement;
+	clone.removeAttribute( 'id' );
+	// The clone is decoration — strip the state that would make it
+	// read as selected or interactive inside the ghost.
+	clone.removeAttribute( 'selected' );
+	clone.removeAttribute( 'aria-selected' );
+	clone.classList.remove( `${ TILE_CLASS }--selected` );
+	clone.style.left = '0px';
+	clone.style.top = '0px';
+	clone.style.position = 'relative';
+	wrap.appendChild( clone );
+
+	const badge = document.createElement( 'span' );
+	badge.className = 'os-drag-stack__count';
+	badge.textContent = String( count );
+	wrap.appendChild( badge );
+	return wrap;
+}
+
+/**
  * Drag-out payload — what the drag manager carries when the user
  * lifts a tile and drops it on a desktop-files surface (wallpaper,
  * folder window). The receiving drop target creates a placement
@@ -238,19 +277,31 @@ export interface TileDragOutPayload {
  *
  * @public
  *
- * @param tile    Tile element from `buildTileFromSpec`.
- * @param payload What the drop target receives.
- * @param onClick Optional hook fired on a sub-threshold gesture
- *                (pointerdown without a drag). Most My WordPress
- *                builders use it to hide the hover tooltip.
+ * @param tile            Tile element from `buildTileFromSpec`.
+ * @param payload         What the drop target receives.
+ * @param onClick         Optional hook fired on a sub-threshold gesture
+ *                        (pointerdown without a drag). Most My WordPress
+ *                        builders use it to hide the hover tooltip.
+ * @param opts            Multi-drag options.
+ * @param opts.resolveSet Asked, at lift time, for every entity the
+ *                        gesture should carry — the surface's current
+ *                        selection when this tile is part of it. Return an
+ *                        empty array (or omit it) for a single-item drag.
  */
 export function attachTileDragOut(
 	tile: HTMLElement,
 	payload: TileDragOutPayload,
 	onClick?: () => void,
+	opts: { resolveSet?: () => TileDragOutPayload[] } = {},
 ): void {
 	tile.addEventListener( 'pointerdown', ( e: PointerEvent ) => {
 		if ( e.button !== 0 ) {
+			return;
+		}
+		// A modifier means the user is composing a selection, not
+		// picking the tile up — see the same guard in the desktop
+		// layer's `attachTileDrag`.
+		if ( e.shiftKey || e.ctrlKey || e.metaKey ) {
 			return;
 		}
 		const dragManager = getDragManager();
@@ -258,6 +309,10 @@ export function attachTileDragOut(
 			return;
 		}
 		const rect = tile.getBoundingClientRect();
+		// The surface answers "is this tile part of a selection, and
+		// if so what's in it?" — the tile itself has no idea.
+		const set = opts.resolveSet?.() ?? [];
+		const many = set.length > 1 ? set : [];
 		dragManager.start( {
 			payload: {
 				type: 'shortcut',
@@ -269,10 +324,26 @@ export function attachTileDragOut(
 					icon: payload.icon,
 					entityId: payload.entityId,
 					bridgePayload: payload.bridgePayload,
+					// Only present for a real multi-drag, so single-item
+					// payloads stay byte-identical to what every
+					// existing drop target was written against.
+					...( many.length > 0 ? { items: many } : {} ),
 				} satisfies ShortcutDragData,
 				ghost: {
 					offsetX: e.clientX - rect.left,
 					offsetY: e.clientY - rect.top,
+					element:
+						many.length > 0
+							? buildDragStackGhost( tile, many.length )
+							: undefined,
+					hint:
+						many.length > 0
+							? {
+								accept: `Add ${ many.length } items here`,
+								reject: `Can’t drop ${ many.length } items here`,
+								neutral: `Dragging ${ many.length } items`,
+							}
+							: undefined,
 				},
 			},
 			origin: e,

--- a/src/desktop-files/trash.ts
+++ b/src/desktop-files/trash.ts
@@ -312,19 +312,48 @@ export async function trashManyWithUndo(
 			: `${ deleted.length } ${ noun } moved to Trash`;
 
 	showTrashedToast( message, async () => {
-		await Promise.allSettled(
+		const restores = await Promise.allSettled(
 			deleted.map( ( d ) =>
 				rest.restoreTrashedItem( d.restoreId, d.restoreKind ),
 			),
 		);
 		await rehydrate();
+
+		// Announce only what actually came back. Broadcasting the
+		// whole batch would tell the Recycle Bin's badge and every
+		// other listener that an item was restored while it is still
+		// sitting in the trash — a lie that survives until the next
+		// full refresh, and one the single-item undo paths don't tell
+		// because they only broadcast inside their success branch.
+		const restored = deleted.filter(
+			( _d, index ) => restores[ index ].status === 'fulfilled',
+		);
+		const stillTrashed = deleted.length - restored.length;
+		for ( const result of restores ) {
+			if ( result.status === 'rejected' ) {
+				// eslint-disable-next-line no-console
+				console.error(
+					'[openstation] restore (bulk) failed for one item:',
+					result.reason,
+				);
+			}
+		}
 		for ( const kind of [ 'placement', 'shortcut', 'folder' ] as const ) {
-			const ids = deleted
+			const ids = restored
 				.filter( ( d ) => d.kind === kind )
 				.map( ( d ) => d.id );
 			if ( ids.length > 0 ) {
 				broadcastFilesChange( kind, 'untrashed', ids );
 			}
+		}
+		if ( stillTrashed > 0 ) {
+			// The user pressed Undo and part of it didn't take. Saying
+			// nothing would leave them believing it did.
+			showTrashErrorToast(
+				new Error(
+					`${ stillTrashed } of ${ deleted.length } items could not be restored.`,
+				),
+			);
 		}
 	} );
 }

--- a/src/desktop-files/trash.ts
+++ b/src/desktop-files/trash.ts
@@ -182,6 +182,154 @@ export async function trashFolderWithUndo(
 }
 
 /**
+ * Soft-trash a whole selection in one gesture.
+ *
+ * Not a loop over `trashPlacementWithUndo` — that would stack N
+ * toasts, each with an Undo that restores exactly one item, and the
+ * user who selected twelve screenshots would have to press Undo
+ * twelve times to get back to where they were. The set is one
+ * action to the user, so it gets one optimistic eviction pass, one
+ * toast, one Undo, and one broadcast carrying every id.
+ *
+ * Failures are per-item (a shared folder the viewer may read but not
+ * write can 403 while its neighbours succeed), so the REST calls run
+ * through `allSettled` and the survivors still get their Undo. Any
+ * failure re-hydrates every touched folder — the server's version of
+ * the truth wins over the optimistic eviction.
+ */
+export async function trashManyWithUndo(
+	placements: readonly RestPlacementShape[],
+): Promise< void > {
+	if ( placements.length === 0 ) {
+		return;
+	}
+	if ( placements.length === 1 ) {
+		return trashByFileType( placements[ 0 ] );
+	}
+
+	const parentIds = new Set< number >();
+	for ( const placement of placements ) {
+		parentIds.add( placement.parentId );
+		// Optimistic eviction first, so the tiles disappear together
+		// rather than popping out one REST round-trip at a time.
+		filesStoreApi.removePlacement( placement.id );
+		if ( placement.file?.type === 'folder' ) {
+			const folderId = parseInt( placement.file.ref, 10 );
+			if ( folderId ) {
+				filesStoreApi.removeFolder( folderId );
+			}
+		}
+	}
+
+	const rehydrate = async (): Promise< void > => {
+		for ( const parentId of parentIds ) {
+			try {
+				const res = await rest.listPlacements( parentId );
+				filesStoreApi.setFolderPlacements( parentId, res.placements );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.error( '[openstation] files: re-hydrate failed:', err );
+			}
+		}
+	};
+
+	/** Per-item descriptor of what was deleted and how to bring it back. */
+	interface Deleted {
+		id: number;
+		kind: 'placement' | 'shortcut' | 'folder';
+		restoreId: number;
+		restoreKind: 'placement' | 'folder';
+	}
+
+	const results = await Promise.allSettled(
+		placements.map( async ( placement ): Promise< Deleted > => {
+			if ( placement.file?.type === 'folder' ) {
+				const folderId = parseInt( placement.file.ref, 10 );
+				if ( ! folderId ) {
+					throw new Error( 'folder placement without a folder id' );
+				}
+				await rest.deleteFolder( folderId );
+				return {
+					id: folderId,
+					kind: 'folder',
+					restoreId: folderId,
+					restoreKind: 'folder',
+				};
+			}
+			await rest.deletePlacement( placement.id );
+			return {
+				id: placement.id,
+				kind:
+					placement.file?.type === 'shortcut' ? 'shortcut' : 'placement',
+				restoreId: placement.id,
+				restoreKind: 'placement',
+			};
+		} ),
+	);
+
+	const deleted: Deleted[] = [];
+	let failed = 0;
+	for ( const result of results ) {
+		if ( result.status === 'fulfilled' ) {
+			deleted.push( result.value );
+		} else {
+			failed += 1;
+			// eslint-disable-next-line no-console
+			console.error(
+				'[openstation] trash (bulk) failed for one item:',
+				result.reason,
+			);
+		}
+	}
+
+	if ( failed > 0 ) {
+		void rehydrate();
+	}
+	if ( deleted.length === 0 ) {
+		showTrashErrorToast(
+			results.find( ( r ) => r.status === 'rejected' )?.reason,
+		);
+		return;
+	}
+
+	// One broadcast per kind — subscribers delta by `ids.length`, so a
+	// mixed set has to be split rather than flattened into one event.
+	for ( const kind of [ 'placement', 'shortcut', 'folder' ] as const ) {
+		const ids = deleted.filter( ( d ) => d.kind === kind ).map( ( d ) => d.id );
+		if ( ids.length > 0 ) {
+			broadcastFilesChange( kind, 'trashed', ids );
+		}
+	}
+
+	// A partial failure is normal enough to name rather than hide: a
+	// shared folder the viewer may read but not write 403s while its
+	// neighbours succeed, and "3 items moved" when only 2 moved is a
+	// lie the user finds out about later.
+	const noun = deleted.length === 1 ? 'item' : 'items';
+	const message =
+		failed > 0
+			? `${ deleted.length } ${ noun } moved to Trash · ${ failed } could not be moved`
+			: `${ deleted.length } ${ noun } moved to Trash`;
+
+	showTrashedToast( message, async () => {
+		await Promise.allSettled(
+			deleted.map( ( d ) =>
+				rest.restoreTrashedItem( d.restoreId, d.restoreKind ),
+			),
+		);
+		await rehydrate();
+		for ( const kind of [ 'placement', 'shortcut', 'folder' ] as const ) {
+			const ids = deleted
+				.filter( ( d ) => d.kind === kind )
+				.map( ( d ) => d.id );
+			if ( ids.length > 0 ) {
+				broadcastFilesChange( kind, 'untrashed', ids );
+			}
+		}
+	} );
+}
+
+/**
  * Trash an item by routing to the placement / folder helper based on
  * the file type. Convenience for drop targets that don't want to
  * branch on type.

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -177,6 +177,7 @@ import {
 	bootPresenceProbe,
 	type PresenceApi,
 } from './presence';
+import { recentlyMarqueed, type SelectionApi } from './selection';
 import { type ActivityApi } from './activity';
 import { bootHeartbeatBus, type HeartbeatBus } from './heartbeat';
 import { bootContentChangesHeartbeat } from './content-changes/heartbeat';
@@ -1557,6 +1558,22 @@ export interface OpenStationPublicApi {
 	 * ```
 	 */
 	presence: PresenceApi;
+	/**
+	 * Multi-selection framework. `active()` returns a snapshot of the
+	 * most recent selection change anywhere in the shell;
+	 * `resolveCommonActions()` is the rule that decides what a mixed
+	 * selection may offer (intersect by action id, keep only what
+	 * every item declares `multi: true` for); `createModel()` builds
+	 * a selection model for a tile canvas of your own.
+	 *
+	 * @example
+	 * ```js
+	 * document.addEventListener( 'os-selection-changed', ( e ) => {
+	 *     console.log( e.detail.count, 'selected in', e.detail.surface );
+	 * } );
+	 * ```
+	 */
+	selection: SelectionApi;
 	/**
 	 * Cross-plugin activity channels — a thin, named-channel layer
 	 * over `wp.hooks` for plugin-internal events that other
@@ -4137,6 +4154,12 @@ function init(): void {
 		// 500 ms covers the browser's pointerup→click gap with
 		// margin.
 		if ( dragManager.recentlyEndedDrag() ) {
+			return;
+		}
+		// Same story for a marquee: rubber-band-selecting icons ends
+		// with a synthesized click on the wallpaper, and minimizing
+		// every window is not what the user just asked for.
+		if ( recentlyMarqueed() ) {
 			return;
 		}
 		manager.toggleShowDesktop();

--- a/src/my-wordpress/bulk-actions.ts
+++ b/src/my-wordpress/bulk-actions.ts
@@ -62,8 +62,6 @@ import '../ui/components/os-button/os-button';
 import '../ui/components/os-category-picker/os-category-picker';
 import '../ui/components/os-tag-input/os-tag-input';
 import '../ui/components/os-notice/os-notice';
-import '../ui/components/os-role-picker/os-role-picker';
-import '../ui/components/os-spinner/os-spinner';
 import type { OsTagItem } from '../ui/components/os-tag-input/os-tag-input';
 
 /** Sentinel for every "— No change —" control in the bulk-edit modal. */
@@ -145,10 +143,16 @@ export function reportBulk(
 		message:
 			result.failed > 0
 				? sprintf(
-					/* translators: 1: what succeeded, e.g. "3 items updated". 2: number that failed. */
-					__( '%1$s · %2$d failed', 'desktop-mode' ),
+					/* translators: 1: what succeeded, e.g. "3 items updated". 2: number that failed. 3: the server's reason for the first failure. */
+					__( '%1$s · %2$d failed — %3$s', 'desktop-mode' ),
 					done,
 					result.failed,
+					// The reason matters most in exactly the case we
+					// used to drop it: a partial failure, where the
+					// user can see something worked and has no way to
+					// find out why the rest didn't.
+					result.firstError ||
+						__( 'no reason given', 'desktop-mode' ),
 				)
 				: done,
 		duration: result.failed > 0 ? 6000 : 4000,
@@ -451,7 +455,30 @@ export async function bulkEditEntities(
 		return [];
 	}
 
-	const byId = new Map( current.map( ( row ) => [ row.id, row ] ) );
+	/*
+	 * Re-read the taxonomy state now the modal has closed, but only
+	 * when the patch actually merges terms.
+	 *
+	 * The snapshot above was taken BEFORE a dialog that sits open for
+	 * as long as the user takes to fill it in. The merge is additive —
+	 * `body.categories = existing ∪ picked` — so a stale `existing`
+	 * silently deletes any term somebody else added in the meantime.
+	 * The window is narrow but it is exactly as long as the user is
+	 * thinking, which is not short.
+	 *
+	 * A failed re-read falls back to the snapshot: the merge is still
+	 * better than not applying the edit at all.
+	 */
+	let merged = current;
+	if ( patch.addCategories || patch.addTags ) {
+		try {
+			merged = await fetchEntityBulkFields( entity, ids );
+		} catch {
+			merged = current;
+		}
+	}
+
+	const byId = new Map( merged.map( ( row ) => [ row.id, row ] ) );
 	const result = await runBulk( ids, async ( id ) => {
 		const body: Record< string, unknown > = {};
 		if ( patch.status !== undefined ) {

--- a/src/my-wordpress/bulk-actions.ts
+++ b/src/my-wordpress/bulk-actions.ts
@@ -1,0 +1,978 @@
+/**
+ * My WordPress — WordPress's own bulk actions, on a selection.
+ *
+ * The list tables in wp-admin have had a bulk-actions dropdown since
+ * 2.7: pick rows, pick an action, Apply. This module is that set,
+ * re-expressed as multi-safe entries on the selection context menu —
+ * so what you can do to twelve posts here is what you can do to
+ * twelve posts there.
+ *
+ * | wp-admin                          | here                          |
+ * |-----------------------------------|-------------------------------|
+ * | Posts → Bulk actions → Edit       | **Edit…** (the same modal)    |
+ * | Posts → Bulk actions → Move to Trash | **Move to Trash**          |
+ * | Post row action → Publish / Draft | **Publish** / **Switch to Draft** |
+ * | Media row action → Detach         | **Detach**                    |
+ * | Media → Bulk actions → Delete     | **Delete permanently**        |
+ * | Users → Bulk actions → Change role to… | **Change role…**         |
+ * | Users → Bulk actions → Delete     | **Delete users…**             |
+ *
+ * Two things core does that we deliberately match:
+ *
+ *   - **Bulk edit only writes what you changed.** Every control
+ *     starts on "— No change —", and a field left alone is absent
+ *     from the request. This is why bulk edit can't be built out of
+ *     "read the first item, show its values, save them to all" — that
+ *     would silently overwrite eleven posts with the twelfth's data.
+ *   - **Categories and tags are additive.** Core adds the terms you
+ *     pick to whatever each post already has; it never replaces the
+ *     set. The REST API only accepts the full array, so we read each
+ *     post's current terms first and merge.
+ *
+ * Statuses that no longer appear in the list (trashed entries) have
+ * no Restore / Delete-permanently entries here, because the section's
+ * own query never surfaces them — an action nobody can reach is worse
+ * than an action that isn't there.
+ */
+
+import { __, sprintf } from '../i18n';
+import { showToast } from '../toast';
+import type { SelectionAction } from '../selection';
+import {
+	createTag,
+	deleteUser,
+	fetchAuthors,
+	fetchEntityBulkFields,
+	fetchTaxonomyTerms,
+	updateEntity,
+	updateUser,
+	type EntityBulkFields,
+	type TermOption,
+} from './rest';
+import { updateMediaItem } from './media-rest';
+import type {
+	EntityListItem,
+	MediaListItem,
+	MyWordPressEntity,
+	UserListItem,
+} from './types';
+import '../ui/components/os-modal/os-modal';
+import '../ui/components/os-select/os-select';
+import '../ui/components/os-button/os-button';
+import '../ui/components/os-category-picker/os-category-picker';
+import '../ui/components/os-tag-input/os-tag-input';
+import '../ui/components/os-notice/os-notice';
+import '../ui/components/os-role-picker/os-role-picker';
+import '../ui/components/os-spinner/os-spinner';
+import type { OsTagItem } from '../ui/components/os-tag-input/os-tag-input';
+
+/** Sentinel for every "— No change —" control in the bulk-edit modal. */
+const NO_CHANGE = '';
+
+/**
+ * Statuses a bulk edit may set. Mirrors core's dropdown, minus the
+ * ones it also hides (`trash` is reached by the Trash action, `auto-
+ * draft` and `inherit` are internal).
+ */
+const STATUS_OPTIONS: Array< { value: string; label: string } > = [
+	{ value: 'publish', label: __( 'Published', 'desktop-mode' ) },
+	{ value: 'pending', label: __( 'Pending Review', 'desktop-mode' ) },
+	{ value: 'draft', label: __( 'Draft', 'desktop-mode' ) },
+	{ value: 'private', label: __( 'Private', 'desktop-mode' ) },
+];
+
+/* ------------------------------------------------------------------ *
+ *  Shared plumbing — run one write per item, report once.
+ * ------------------------------------------------------------------ */
+
+export interface BulkRunResult {
+	succeeded: number[];
+	failed: number;
+	firstError: string;
+}
+
+/**
+ * Apply `run` to every id, in parallel, and collect the outcome.
+ *
+ * Partial failure is the normal case, not the exception: a
+ * contributor's selection can span posts they may edit and posts
+ * they may not, and the REST API answers per row. Reporting "12
+ * updated" when 3 were rejected is the kind of lie the user finds
+ * out about later, from the list.
+ */
+export async function runBulk(
+	ids: readonly number[],
+	run: ( id: number ) => Promise< void >,
+): Promise< BulkRunResult > {
+	const results = await Promise.allSettled( ids.map( ( id ) => run( id ) ) );
+	const succeeded: number[] = [];
+	let failed = 0;
+	let firstError = '';
+	results.forEach( ( result, index ) => {
+		if ( result.status === 'fulfilled' ) {
+			succeeded.push( ids[ index ] );
+			return;
+		}
+		failed += 1;
+		if ( ! firstError ) {
+			firstError =
+				result.reason instanceof Error
+					? result.reason.message
+					: String( result.reason );
+		}
+	} );
+	return { succeeded, failed, firstError };
+}
+
+/** One toast for the whole run, naming the failures when there are any. */
+export function reportBulk(
+	result: BulkRunResult,
+	singular: string,
+	plural: string,
+): void {
+	const n = result.succeeded.length;
+	if ( n === 0 ) {
+		showToast( {
+			message:
+				result.firstError ||
+				__( 'Nothing could be updated.', 'desktop-mode' ),
+			duration: 6000,
+		} );
+		return;
+	}
+	const done = sprintf( n === 1 ? singular : plural, n );
+	showToast( {
+		message:
+			result.failed > 0
+				? sprintf(
+					/* translators: 1: what succeeded, e.g. "3 items updated". 2: number that failed. */
+					__( '%1$s · %2$d failed', 'desktop-mode' ),
+					done,
+					result.failed,
+				)
+				: done,
+		duration: result.failed > 0 ? 6000 : 4000,
+	} );
+}
+
+/* ------------------------------------------------------------------ *
+ *  Bulk edit — the modal.
+ * ------------------------------------------------------------------ */
+
+interface BulkEditPatch {
+	status?: string;
+	author?: number;
+	comment_status?: string;
+	sticky?: boolean;
+	/** Term ids to ADD (core's semantics), merged per item. */
+	addCategories?: number[];
+	/** Term ids to ADD. */
+	addTags?: number[];
+}
+
+function labelled( label: string, control: HTMLElement ): HTMLElement {
+	const row = document.createElement( 'div' );
+	row.className = 'os-my-wordpress__bulk-row';
+	const caption = document.createElement( 'div' );
+	caption.className = 'os-my-wordpress__bulk-label';
+	caption.textContent = label;
+	row.append( caption, control );
+	return row;
+}
+
+function select(
+	options: Array< { value: string; label: string } >,
+): HTMLElement {
+	const el = document.createElement( 'os-select' );
+	el.setAttribute( 'value', NO_CHANGE );
+	const noChange = document.createElement( 'os-option' );
+	noChange.setAttribute( 'value', NO_CHANGE );
+	noChange.textContent = __( '— No change —', 'desktop-mode' );
+	el.appendChild( noChange );
+	for ( const option of options ) {
+		const opt = document.createElement( 'os-option' );
+		opt.setAttribute( 'value', option.value );
+		opt.textContent = option.label;
+		el.appendChild( opt );
+	}
+	return el;
+}
+
+function readSelect( el: HTMLElement ): string {
+	return el.getAttribute( 'value' ) ?? NO_CHANGE;
+}
+
+/**
+ * Open the bulk-edit modal. Resolves with the patch the user asked
+ * for, or `null` if they cancelled.
+ *
+ * The modal shape follows core's inline bulk-edit panel: the controls
+ * that apply to this post type, each defaulting to "no change", and a
+ * count of what's about to be touched.
+ */
+function openBulkEditModal( opts: {
+	count: number;
+	entityLabel: string;
+	authors: Array< { id: number; name: string } >;
+	categories: TermOption[] | null;
+	supportsTags: boolean;
+	supportsSticky: boolean;
+} ): Promise< BulkEditPatch | null > {
+	return new Promise( ( resolve ) => {
+		const modal = document.createElement( 'os-modal' );
+		modal.setAttribute( 'open', '' );
+		modal.setAttribute( 'size', 'md' );
+		modal.setAttribute(
+			'title',
+			sprintf(
+				/* translators: 1: number of entries, 2: entity label, e.g. "Posts". */
+				__( 'Edit %1$d %2$s', 'desktop-mode' ),
+				opts.count,
+				opts.entityLabel,
+			),
+		);
+		document.body.appendChild( modal );
+
+		let settled = false;
+		const finish = ( value: BulkEditPatch | null ): void => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			modal.remove();
+			resolve( value );
+		};
+
+		const hint = document.createElement( 'os-notice' );
+		hint.setAttribute( 'tone', 'info' );
+		hint.textContent = __(
+			'Only the fields you change are applied. Categories and tags are added to what each entry already has.',
+			'desktop-mode',
+		);
+		modal.appendChild( hint );
+
+		const statusEl = select( STATUS_OPTIONS );
+		modal.appendChild(
+			labelled( __( 'Status', 'desktop-mode' ), statusEl ),
+		);
+
+		const authorEl = select(
+			opts.authors.map( ( a ) => ( {
+				value: String( a.id ),
+				label: a.name,
+			} ) ),
+		);
+		if ( opts.authors.length > 0 ) {
+			modal.appendChild(
+				labelled( __( 'Author', 'desktop-mode' ), authorEl ),
+			);
+		}
+
+		const commentsEl = select( [
+			{ value: 'open', label: __( 'Allow', 'desktop-mode' ) },
+			{ value: 'closed', label: __( 'Do not allow', 'desktop-mode' ) },
+		] );
+		modal.appendChild(
+			labelled( __( 'Comments', 'desktop-mode' ), commentsEl ),
+		);
+
+		const stickyEl = select( [
+			{ value: 'sticky', label: __( 'Sticky', 'desktop-mode' ) },
+			{ value: 'not-sticky', label: __( 'Not sticky', 'desktop-mode' ) },
+		] );
+		if ( opts.supportsSticky ) {
+			modal.appendChild(
+				labelled( __( 'Sticky', 'desktop-mode' ), stickyEl ),
+			);
+		}
+
+		const categoryEl = document.createElement( 'os-category-picker' ) as
+			HTMLElement & { items: TermOption[]; value: number[] };
+		if ( opts.categories && opts.categories.length > 0 ) {
+			categoryEl.items = opts.categories;
+			categoryEl.value = [];
+			modal.appendChild(
+				labelled(
+					__( 'Add categories', 'desktop-mode' ),
+					categoryEl,
+				),
+			);
+		}
+
+		const tagEl = document.createElement( 'os-tag-input' ) as HTMLElement & {
+			value: OsTagItem[];
+			suggestions: OsTagItem[];
+		};
+		if ( opts.supportsTags ) {
+			tagEl.setAttribute( 'creatable', '' );
+			tagEl.setAttribute(
+				'placeholder',
+				__( 'Add tags…', 'desktop-mode' ),
+			);
+			tagEl.value = [];
+			tagEl.addEventListener( 'os-tag-suggest', ( e: Event ) => {
+				const query = ( e as CustomEvent< { query: string } > ).detail
+					.query;
+				void fetchTaxonomyTerms( 'tags', query ).then( ( terms ) => {
+					tagEl.suggestions = terms.map( ( t ) => ( {
+						id: t.id,
+						label: t.name,
+					} ) );
+				} );
+			} );
+			// A brand-new tag has no id until the server mints one; do
+			// it at pick time so the submit path only ever deals in ids.
+			tagEl.addEventListener( 'os-tag-add', ( e: Event ) => {
+				const detail = ( e as CustomEvent< {
+					tag: OsTagItem;
+					isNew: boolean;
+				} > ).detail;
+				if ( ! detail.isNew ) {
+					return;
+				}
+				void createTag( detail.tag.label ).then( ( created ) => {
+					if ( ! created ) {
+						return;
+					}
+					tagEl.value = tagEl.value.map( ( t ) =>
+						t.label === detail.tag.label && t.id === undefined
+							? { id: created.id, label: created.name }
+							: t,
+					);
+				} );
+			} );
+			modal.appendChild(
+				labelled( __( 'Add tags', 'desktop-mode' ), tagEl ),
+			);
+		}
+
+		const footer = document.createElement( 'div' );
+		footer.setAttribute( 'slot', 'footer' );
+
+		const cancel = document.createElement( 'os-button' );
+		cancel.setAttribute( 'variant', 'ghost' );
+		cancel.textContent = __( 'Cancel', 'desktop-mode' );
+		cancel.addEventListener( 'click', () => finish( null ) );
+
+		const apply = document.createElement( 'os-button' );
+		apply.setAttribute( 'variant', 'primary' );
+		apply.textContent = __( 'Update', 'desktop-mode' );
+		apply.addEventListener( 'click', () => {
+			const patch: BulkEditPatch = {};
+			const status = readSelect( statusEl );
+			if ( status !== NO_CHANGE ) {
+				patch.status = status;
+			}
+			const author = readSelect( authorEl );
+			if ( author !== NO_CHANGE ) {
+				patch.author = Number( author );
+			}
+			const comments = readSelect( commentsEl );
+			if ( comments !== NO_CHANGE ) {
+				patch.comment_status = comments;
+			}
+			const sticky = readSelect( stickyEl );
+			if ( opts.supportsSticky && sticky !== NO_CHANGE ) {
+				patch.sticky = sticky === 'sticky';
+			}
+			const cats = opts.categories ? categoryEl.value : [];
+			if ( cats.length > 0 ) {
+				patch.addCategories = cats.slice();
+			}
+			const tags = opts.supportsTags
+				? tagEl.value
+					.map( ( t ) => Number( t.id ) )
+					.filter( ( id ) => Number.isFinite( id ) && id > 0 )
+				: [];
+			if ( tags.length > 0 ) {
+				patch.addTags = tags;
+			}
+			finish( Object.keys( patch ).length > 0 ? patch : null );
+		} );
+
+		footer.append( cancel, apply );
+		modal.appendChild( footer );
+
+		modal.addEventListener( 'os-modal-cancel', () => finish( null ) );
+	} );
+}
+
+/**
+ * The "Edit…" bulk action for post-shaped entities.
+ *
+ * Reads the current taxonomy state for the selection first — which is
+ * both what makes the additive merge correct and how we discover
+ * whether this post type has categories or tags at all.
+ */
+export async function bulkEditEntities(
+	entity: MyWordPressEntity,
+	items: readonly EntityListItem[],
+): Promise< number[] > {
+	const ids = items.map( ( i ) => i.id );
+
+	let current: EntityBulkFields[] = [];
+	let authors: Array< { id: number; name: string } > = [];
+	try {
+		[ current, authors ] = await Promise.all( [
+			fetchEntityBulkFields( entity, ids ),
+			fetchAuthors(),
+		] );
+	} catch ( err ) {
+		showToast( {
+			message:
+				err instanceof Error
+					? err.message
+					: __( 'Could not read the selected entries.', 'desktop-mode' ),
+			duration: 6000,
+		} );
+		return [];
+	}
+
+	const supportsCategories = current.some( ( row ) =>
+		Array.isArray( row.categories ),
+	);
+	const supportsTags = current.some( ( row ) => Array.isArray( row.tags ) );
+	const categories = supportsCategories
+		? await fetchTaxonomyTerms( 'categories' )
+		: null;
+
+	const patch = await openBulkEditModal( {
+		count: items.length,
+		entityLabel: entity.label,
+		authors,
+		categories,
+		supportsTags,
+		// Only the built-in `post` type has sticky posts — core hides
+		// the control everywhere else, and the REST schema rejects the
+		// field outright.
+		supportsSticky: ( entity.post_type ?? 'post' ) === 'post',
+	} );
+	if ( ! patch ) {
+		return [];
+	}
+
+	const byId = new Map( current.map( ( row ) => [ row.id, row ] ) );
+	const result = await runBulk( ids, async ( id ) => {
+		const body: Record< string, unknown > = {};
+		if ( patch.status !== undefined ) {
+			body.status = patch.status;
+		}
+		if ( patch.author !== undefined ) {
+			body.author = patch.author;
+		}
+		if ( patch.comment_status !== undefined ) {
+			body.comment_status = patch.comment_status;
+		}
+		if ( patch.sticky !== undefined ) {
+			body.sticky = patch.sticky;
+		}
+		if ( patch.addCategories ) {
+			const existing = byId.get( id )?.categories ?? [];
+			body.categories = Array.from(
+				new Set( [ ...existing, ...patch.addCategories ] ),
+			);
+		}
+		if ( patch.addTags ) {
+			const existing = byId.get( id )?.tags ?? [];
+			body.tags = Array.from( new Set( [ ...existing, ...patch.addTags ] ) );
+		}
+		await updateEntity( entity, id, body );
+	} );
+
+	reportBulk(
+		result,
+		/* translators: %d: number of entries updated. */
+		__( '%d entry updated', 'desktop-mode' ),
+		/* translators: %d: number of entries updated. */
+		__( '%d entries updated', 'desktop-mode' ),
+	);
+	return result.succeeded;
+}
+
+/** Set the same status on every selected entry (Publish / Draft). */
+export async function bulkSetStatus(
+	entity: MyWordPressEntity,
+	items: readonly EntityListItem[],
+	status: string,
+): Promise< number[] > {
+	const result = await runBulk( items.map( ( i ) => i.id ), ( id ) =>
+		updateEntity( entity, id, { status } ),
+	);
+	reportBulk(
+		result,
+		/* translators: %d: number of entries updated. */
+		__( '%d entry updated', 'desktop-mode' ),
+		/* translators: %d: number of entries updated. */
+		__( '%d entries updated', 'desktop-mode' ),
+	);
+	return result.succeeded;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Post-shaped bulk actions.
+ * ------------------------------------------------------------------ */
+
+export interface EntityBulkContext {
+	entity: MyWordPressEntity;
+	/** Called with the ids that changed so the caller can repaint. */
+	onChanged: ( ids: number[] ) => void;
+}
+
+/**
+ * The status-changing entries core exposes as row actions, plus the
+ * bulk-edit modal it exposes as a bulk action.
+ *
+ * `item` is the ONE entry these are built for —
+ * `resolveCommonActions` calls this per selected tile and intersects
+ * — so each `onClick` closes over its own entry and each `bulk` takes
+ * the whole set.
+ */
+export function entityBulkActions(
+	ctx: EntityBulkContext,
+	item: EntityListItem,
+): SelectionAction< EntityListItem >[] {
+	const { entity, onChanged } = ctx;
+	const one = [ item ];
+
+	const actions: SelectionAction< EntityListItem >[] = [
+		{
+			id: 'bulk-edit',
+			label: __( 'Edit…', 'desktop-mode' ),
+			icon: 'dashicons-edit-large',
+			sort: 30,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					/* translators: %d: number of selected entries. */
+					__( 'Edit %d entries…', 'desktop-mode' ),
+					n,
+				),
+			bulk: async ( items ) =>
+				onChanged( await bulkEditEntities( entity, items ) ),
+			onClick: async () =>
+				onChanged( await bulkEditEntities( entity, one ) ),
+		},
+	];
+
+	// Publish / Switch to Draft mirror core's row actions, and each
+	// hides itself when it would be a no-op for the entry it's built
+	// for — so a selection of published posts offers Draft but not
+	// Publish, exactly as the intersection rule implies.
+	if ( item.status !== 'publish' ) {
+		actions.push( {
+			id: 'publish',
+			label: __( 'Publish', 'desktop-mode' ),
+			icon: 'dashicons-yes',
+			sort: 40,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					/* translators: %d: number of selected entries. */
+					__( 'Publish %d entries', 'desktop-mode' ),
+					n,
+				),
+			bulk: async ( items ) =>
+				onChanged( await bulkSetStatus( entity, items, 'publish' ) ),
+			onClick: async () =>
+				onChanged( await bulkSetStatus( entity, one, 'publish' ) ),
+		} );
+	}
+	if ( item.status !== 'draft' ) {
+		actions.push( {
+			id: 'to-draft',
+			label: __( 'Switch to Draft', 'desktop-mode' ),
+			icon: 'dashicons-edit-page',
+			sort: 45,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					/* translators: %d: number of selected entries. */
+					__( 'Switch %d entries to Draft', 'desktop-mode' ),
+					n,
+				),
+			bulk: async ( items ) =>
+				onChanged( await bulkSetStatus( entity, items, 'draft' ) ),
+			onClick: async () =>
+				onChanged( await bulkSetStatus( entity, one, 'draft' ) ),
+		} );
+	}
+
+	return actions;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Media.
+ * ------------------------------------------------------------------ */
+
+export interface MediaBulkContext {
+	onChanged: ( ids: number[] ) => void;
+}
+
+/**
+ * Core's media row actions that make sense over a set. "Detach" is
+ * the same operation the media list table offers per row — clear the
+ * attachment's parent post, leaving the file itself alone.
+ */
+export function mediaBulkActions(
+	ctx: MediaBulkContext,
+	media: MediaListItem,
+): SelectionAction< MediaListItem >[] {
+	const detach = async ( items: readonly MediaListItem[] ): Promise< void > => {
+		const result = await runBulk( items.map( ( m ) => m.id ), ( id ) =>
+			updateMediaItem( id, { post: 0 } ),
+		);
+		reportBulk(
+			result,
+			/* translators: %d: number of files detached. */
+			__( '%d file detached', 'desktop-mode' ),
+			/* translators: %d: number of files detached. */
+			__( '%d files detached', 'desktop-mode' ),
+		);
+		ctx.onChanged( result.succeeded );
+	};
+
+	const actions: SelectionAction< MediaListItem >[] = [];
+	// Only offer Detach for files that are actually attached to
+	// something — on an unattached file the action would be a no-op,
+	// and it disappears from a mixed selection for the same reason.
+	if ( Number( media.post ?? 0 ) > 0 ) {
+		actions.push( {
+			id: 'detach',
+			label: __( 'Detach', 'desktop-mode' ),
+			icon: 'dashicons-editor-unlink',
+			sort: 30,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					/* translators: %d: number of selected files. */
+					__( 'Detach %d files', 'desktop-mode' ),
+					n,
+				),
+			bulk: ( items ) => detach( items ),
+			onClick: () => detach( [ media ] ),
+		} );
+	}
+	return actions;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Users.
+ * ------------------------------------------------------------------ */
+
+/** Role slug → label, from the roles the shell already ships. */
+function eligibleRoles(): Array< { slug: string; label: string } > {
+	const cfg = (
+		window as unknown as {
+			openStationConfig?: {
+				shareEligibleRoles?: Array< { slug: string; name?: string; label?: string } >;
+			};
+		}
+	).openStationConfig;
+	const rows = cfg?.shareEligibleRoles ?? [];
+	return rows.map( ( r ) => ( {
+		slug: r.slug,
+		label: r.label ?? r.name ?? r.slug,
+	} ) );
+}
+
+/** Ask which role to set, then set it on every selected user. */
+async function promptRole(): Promise< string | null > {
+	const roles = eligibleRoles();
+	if ( roles.length === 0 ) {
+		showToast( {
+			message: __(
+				'No assignable roles are available on this site.',
+				'desktop-mode',
+			),
+		} );
+		return null;
+	}
+	return new Promise( ( resolve ) => {
+		const modal = document.createElement( 'os-modal' );
+		modal.setAttribute( 'open', '' );
+		modal.setAttribute( 'size', 'sm' );
+		modal.setAttribute( 'title', __( 'Change role', 'desktop-mode' ) );
+		document.body.appendChild( modal );
+
+		let settled = false;
+		const finish = ( value: string | null ): void => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			modal.remove();
+			resolve( value );
+		};
+
+		const picker = select(
+			roles.map( ( r ) => ( { value: r.slug, label: r.label } ) ),
+		);
+		modal.appendChild(
+			labelled( __( 'New role', 'desktop-mode' ), picker ),
+		);
+
+		const footer = document.createElement( 'div' );
+		footer.setAttribute( 'slot', 'footer' );
+		const cancel = document.createElement( 'os-button' );
+		cancel.setAttribute( 'variant', 'ghost' );
+		cancel.textContent = __( 'Cancel', 'desktop-mode' );
+		cancel.addEventListener( 'click', () => finish( null ) );
+		const apply = document.createElement( 'os-button' );
+		apply.setAttribute( 'variant', 'primary' );
+		apply.textContent = __( 'Change role', 'desktop-mode' );
+		apply.addEventListener( 'click', () => {
+			const value = readSelect( picker );
+			finish( value === NO_CHANGE ? null : value );
+		} );
+		footer.append( cancel, apply );
+		modal.appendChild( footer );
+		modal.addEventListener( 'os-modal-cancel', () => finish( null ) );
+	} );
+}
+
+/**
+ * Core's user-delete screen asks one question before it will proceed:
+ * what happens to the content these users wrote. Delete it with them,
+ * or attribute it to somebody else. The REST endpoint asks the same
+ * thing (`reassign`), and refuses without an answer.
+ */
+async function promptReassign(
+	count: number,
+	authors: Array< { id: number; name: string } >,
+	excludeIds: readonly number[],
+): Promise< { confirmed: boolean; reassign: number | null } > {
+	const candidates = authors.filter( ( a ) => ! excludeIds.includes( a.id ) );
+	return new Promise( ( resolve ) => {
+		const modal = document.createElement( 'os-modal' );
+		modal.setAttribute( 'open', '' );
+		modal.setAttribute( 'size', 'md' );
+		modal.setAttribute(
+			'title',
+			sprintf(
+				/* translators: %d: number of users about to be deleted. */
+				__( 'Delete %d users', 'desktop-mode' ),
+				count,
+			),
+		);
+		document.body.appendChild( modal );
+
+		let settled = false;
+		const finish = ( confirmed: boolean, reassign: number | null ): void => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			modal.remove();
+			resolve( { confirmed, reassign } );
+		};
+
+		const warning = document.createElement( 'os-notice' );
+		warning.setAttribute( 'tone', 'danger' );
+		warning.textContent = __(
+			'Users have no trash — this cannot be undone.',
+			'desktop-mode',
+		);
+		modal.appendChild( warning );
+
+		const picker = select( [
+			{
+				value: 'delete',
+				label: __( 'Delete all their content', 'desktop-mode' ),
+			},
+			...candidates.map( ( a ) => ( {
+				value: String( a.id ),
+				label: sprintf(
+					/* translators: %s: a user's display name. */
+					__( 'Attribute all content to %s', 'desktop-mode' ),
+					a.name,
+				),
+			} ) ),
+		] );
+		modal.appendChild(
+			labelled( __( 'Their content', 'desktop-mode' ), picker ),
+		);
+
+		const footer = document.createElement( 'div' );
+		footer.setAttribute( 'slot', 'footer' );
+		const cancel = document.createElement( 'os-button' );
+		cancel.setAttribute( 'variant', 'ghost' );
+		cancel.textContent = __( 'Cancel', 'desktop-mode' );
+		cancel.addEventListener( 'click', () => finish( false, null ) );
+		const apply = document.createElement( 'os-button' );
+		apply.setAttribute( 'variant', 'danger' );
+		apply.textContent = __( 'Delete', 'desktop-mode' );
+		apply.addEventListener( 'click', () => {
+			const value = readSelect( picker );
+			if ( value === NO_CHANGE ) {
+				// Nothing chosen — the question is mandatory, so treat
+				// Delete-without-an-answer as "not yet".
+				return;
+			}
+			finish( true, value === 'delete' ? null : Number( value ) );
+		} );
+		footer.append( cancel, apply );
+		modal.appendChild( footer );
+		modal.addEventListener( 'os-modal-cancel', () => finish( false, null ) );
+	} );
+}
+
+export interface UserBulkContext {
+	onChanged: ( ids: number[] ) => void;
+	/** Ids removed from the list entirely (deleted users). */
+	onRemoved: ( ids: number[] ) => void;
+}
+
+export function userBulkActions(
+	ctx: UserBulkContext,
+	user: UserListItem,
+): SelectionAction< UserListItem >[] {
+	const changeRole = async (
+		items: readonly UserListItem[],
+	): Promise< void > => {
+		const role = await promptRole();
+		if ( ! role ) {
+			return;
+		}
+		const result = await runBulk( items.map( ( u ) => u.id ), ( id ) =>
+			updateUser( id, { roles: [ role ] } ),
+		);
+		reportBulk(
+			result,
+			/* translators: %d: number of users updated. */
+			__( '%d user updated', 'desktop-mode' ),
+			/* translators: %d: number of users updated. */
+			__( '%d users updated', 'desktop-mode' ),
+		);
+		ctx.onChanged( result.succeeded );
+	};
+
+	const remove = async ( items: readonly UserListItem[] ): Promise< void > => {
+		const ids = items.map( ( u ) => u.id );
+		const authors = await fetchAuthors();
+		const { confirmed, reassign } = await promptReassign(
+			items.length,
+			authors,
+			ids,
+		);
+		if ( ! confirmed ) {
+			return;
+		}
+		const result = await runBulk( ids, ( id ) => deleteUser( id, reassign ) );
+		reportBulk(
+			result,
+			/* translators: %d: number of users deleted. */
+			__( '%d user deleted', 'desktop-mode' ),
+			/* translators: %d: number of users deleted. */
+			__( '%d users deleted', 'desktop-mode' ),
+		);
+		ctx.onRemoved( result.succeeded );
+	};
+
+	return [
+		{
+			id: 'change-role',
+			label: __( 'Change role…', 'desktop-mode' ),
+			icon: 'dashicons-groups',
+			sort: 40,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					/* translators: %d: number of selected users. */
+					__( 'Change role for %d users…', 'desktop-mode' ),
+					n,
+				),
+			bulk: ( items ) => changeRole( items ),
+			onClick: () => changeRole( [ user ] ),
+		},
+		{
+			id: 'delete-user',
+			label: __( 'Delete…', 'desktop-mode' ),
+			icon: 'dashicons-trash',
+			sort: 90,
+			danger: true,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					/* translators: %d: number of selected users. */
+					__( 'Delete %d users…', 'desktop-mode' ),
+					n,
+				),
+			bulk: ( items ) => remove( items ),
+			onClick: () => remove( [ user ] ),
+		},
+	];
+}
+
+/* ------------------------------------------------------------------ *
+ *  Shared: "Copy links".
+ * ------------------------------------------------------------------ */
+
+/**
+ * Put the URLs of a selection on the clipboard, one per line.
+ *
+ * Not a wp-admin bulk action, but the thing people leave wp-admin to
+ * do by hand: select the posts, copy their URLs, paste them into a
+ * newsletter. `urlOf` is per-surface because "the URL" isn't the same
+ * field everywhere — posts and users have a `link`, an attachment's
+ * useful address is its `source_url`.
+ */
+export async function copyLinks< T >(
+	items: readonly T[],
+	urlOf: ( item: T ) => string,
+): Promise< void > {
+	const links = items
+		.map( ( i ) => String( urlOf( i ) ?? '' ).trim() )
+		.filter( Boolean );
+	if ( links.length === 0 ) {
+		showToast( {
+			message: __( 'Nothing to copy — no links found.', 'desktop-mode' ),
+		} );
+		return;
+	}
+	try {
+		await navigator.clipboard.writeText( links.join( '\n' ) );
+		showToast( {
+			message:
+				links.length === 1
+					? __( 'Link copied.', 'desktop-mode' )
+					: sprintf(
+						/* translators: %d: number of links copied. */
+						__( '%d links copied.', 'desktop-mode' ),
+						links.length,
+					),
+		} );
+	} catch {
+		// Clipboard access is permission-gated and simply absent over
+		// plain HTTP; say so rather than failing mutely.
+		showToast( {
+			message: __(
+				'Could not reach the clipboard — copying needs a secure (https) connection.',
+				'desktop-mode',
+			),
+			duration: 6000,
+		} );
+	}
+}
+
+/** The "Copy link" entry, shared by every list whose rows have URLs. */
+export function copyLinksAction< T >(
+	item: T,
+	urlOf: ( row: T ) => string,
+	label: string = __( 'Copy link', 'desktop-mode' ),
+): SelectionAction< T > {
+	return {
+		id: 'copy-links',
+		label,
+		icon: 'dashicons-admin-links',
+		sort: 60,
+		multi: true,
+		bulkLabel: ( n ) =>
+			sprintf(
+				/* translators: %d: number of selected entries. */
+				__( 'Copy %d links', 'desktop-mode' ),
+				n,
+			),
+		bulk: ( items ) => copyLinks( items, urlOf ),
+		onClick: () => copyLinks( [ item ], urlOf ),
+	};
+}

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -24,7 +24,24 @@ import {
 	renderStatusBarSegments,
 	type StatusBarSegment,
 } from '../desktop-files/folder-status-bar';
-import { attachTileDragOut, buildTileFromSpec } from '../desktop-files/tile-spec';
+import {
+	attachTileDragOut,
+	buildTileFromSpec,
+	type TileDragOutPayload,
+} from '../desktop-files/tile-spec';
+import {
+	attachSelection,
+	closeActionMenu,
+	openActionMenu,
+	resolveCommonActions,
+	type SelectionAction,
+	type SelectionHandle,
+} from '../selection';
+import {
+	copyLinksAction,
+	entityBulkActions,
+	userBulkActions,
+} from './bulk-actions';
 import { getDragManager, stripTags } from './dom-utils';
 import {
 	getEntityRenderer,
@@ -50,6 +67,11 @@ import {
 	renderBreadcrumbs,
 	type BreadcrumbSegment,
 } from '../desktop-files/breadcrumbs';
+import {
+	GRID_METRICS,
+	GRID_METRICS_LARGE,
+	type GridMetrics,
+} from '../desktop-files/grid';
 import {
 	buildEditUrl,
 	buildEditUserUrl,
@@ -690,7 +712,17 @@ function renderFolderGrid(
 	grid.setAttribute( 'role', 'list' );
 
 	const layout = createTileLayout( grid, scope );
-	const select = createTileSelector();
+	// Folder tiles are navigation, not data — a multi-selection of
+	// them has nothing to act on, so the controller runs in
+	// single-select mode (no marquee) purely for the highlight.
+	const selection = attachSelection( grid, {
+		background: grid,
+		marquee: false,
+		surface: 'my-wordpress',
+		scope,
+		keyOf: ( el ) => el.dataset.tileKey ?? null,
+	} );
+	state.teardown.push( () => selection.destroy() );
 
 	const tilesByKey = new Map< string, HTMLElement >();
 
@@ -708,6 +740,7 @@ function renderFolderGrid(
 		if ( spec.groupId ) {
 			tile.dataset.groupId = spec.groupId;
 		}
+		tile.dataset.tileKey = spec.key;
 		tilesByKey.set( spec.key, tile );
 		// Folders have no real "date" — synthesize one from registry
 		// order so date-sort still produces a deterministic outcome.
@@ -719,9 +752,9 @@ function renderFolderGrid(
 		// Folder tiles use Finder-style semantics: single click
 		// selects (visual highlight only — no navigation, so a fast
 		// double-click can't race the tile out of the DOM), double
-		// click navigates. No drag-out: folder tiles aren't filed as
-		// shortcuts — only entity tiles are.
-		tile.addEventListener( 'click', () => select( tile ) );
+		// click navigates. Selection is the controller's job now. No
+		// drag-out: folder tiles aren't filed as shortcuts — only
+		// entity tiles are.
 		tile.addEventListener( 'dblclick', ( e ) => {
 			e.preventDefault();
 			navigate( state, spec.route );
@@ -959,8 +992,22 @@ interface ListContext {
 	tiles: HTMLElement;
 	sentinel: HTMLElement;
 	preview: HTMLElement;
+	/**
+	 * Id of the ONE selected entry, or null for none / several. The
+	 * async preview guards compare against it to drop a response whose
+	 * selection has moved on, so it has to mean "what the preview pane
+	 * is about" — which a set isn't.
+	 */
 	selectedId: number | null;
 	selectedTile: HTMLElement | null;
+	/** Multi-selection controller for this section's canvas(es). */
+	selection: SelectionHandle | null;
+	/**
+	 * Every rendered list item, by id. A context menu opened on a
+	 * multi-selection needs the item shapes for tiles it never had a
+	 * closure over.
+	 */
+	itemsById: Map< number, EntityListItem >;
 	observer: IntersectionObserver | null;
 	layout: TileLayout;
 	/**
@@ -1290,11 +1337,45 @@ function renderEntityList(
 		preview: right,
 		selectedId: null,
 		selectedTile: null,
+		selection: null,
+		itemsById: new Map(),
 		observer: null,
 		layout: tileLayout,
 		query: initialQuery,
 		abort: null,
 	};
+
+	// One controller for the whole section — `tiles` is the root even
+	// when banding splits it into several canvases, so a Shift+click
+	// range can run across bands.
+	ctx.selection = attachSelection( tiles, {
+		background: left,
+		surface: 'my-wordpress',
+		scope: entity.id,
+		keyOf: ( el ) =>
+			el.dataset.entryId ? el.dataset.entryId : null,
+		onChange: ( keys ) => {
+			const ids = keys
+				.map( ( k ) => parseInt( k, 10 ) )
+				.filter( ( n ) => Number.isFinite( n ) );
+			ctx.selectedId = ids.length === 1 ? ids[ 0 ] : null;
+			ctx.selectedTile =
+				ids.length === 1
+					? ctx.selection?.elementFor( String( ids[ 0 ] ) ) ?? null
+					: null;
+			if ( ids.length === 0 ) {
+				renderPreviewPlaceholder( ctx );
+			} else if ( ids.length > 1 ) {
+				ctx.preview.replaceChildren(
+					renderEntitySelectionSummary( ctx, ids ),
+				);
+			} else {
+				void renderPreview( state, ctx, entity, ids[ 0 ] );
+			}
+			repaintListStatus();
+		},
+	} );
+	state.teardown.push( () => ctx.selection?.destroy() );
 	state.teardown.push( () => tileLayout.dispose() );
 	// Cancel any in-flight page fetch on teardown — keeps the
 	// activity bus / loading spinner from showing a never-resolving
@@ -1326,6 +1407,21 @@ function renderEntityList(
 		const segments: StatusBarSegment[] = [
 			{ id: 'count', label: itemLabel, align: 'start', sort: 10 },
 		];
+		// Only while there IS a selection — a permanent "0 selected"
+		// is noise on a bar whose whole job is to be glanceable.
+		const selectedCount = ctx.selection?.keys().length ?? 0;
+		if ( selectedCount > 0 ) {
+			segments.push( {
+				id: 'selection',
+				label: sprintf(
+					// translators: %d: number of selected entries.
+					__( '%d selected', 'desktop-mode' ),
+					selectedCount,
+				),
+				align: 'end',
+				sort: 5,
+			} );
+		}
 		if ( ctx.totalPages > 1 ) {
 			segments.push( {
 				id: 'page',
@@ -1621,6 +1717,79 @@ function isAbortError( err: unknown ): boolean {
 	return err instanceof DOMException && err.name === 'AbortError';
 }
 
+/**
+ * Drag payloads for the current selection, or an empty array when
+ * fewer than two things are selected.
+ *
+ * The empty array is the signal `attachTileDragOut` reads as "this is
+ * an ordinary one-tile drag" — so a surface only ever opts into a
+ * multi-drag when there is genuinely a set to carry.
+ */
+function selectedDragPayloads< T extends { id: number } >(
+	ctx: { selection: SelectionHandle | null; itemsById: Map< number, T > },
+	toPayload: ( item: T ) => TileDragOutPayload,
+): TileDragOutPayload[] {
+	const keys = ctx.selection?.keys() ?? [];
+	if ( keys.length < 2 ) {
+		return [];
+	}
+	return keys
+		.map( ( key ) => ctx.itemsById.get( Number( key ) ) )
+		.filter( ( item ): item is T => !! item )
+		.map( toPayload );
+}
+
+/** The right pane's "nothing selected" state. */
+function renderPreviewPlaceholder( ctx: ListContext ): void {
+	ctx.preview.replaceChildren();
+	const empty = document.createElement( 'div' );
+	empty.className = 'os-my-wordpress__preview-empty';
+	empty.textContent = __(
+		'Select an entry to preview it here.',
+		'desktop-mode',
+	);
+	ctx.preview.appendChild( empty );
+}
+
+/**
+ * The right pane's multi-selection state. Previewing one arbitrary
+ * member of a set reads as "this is what you picked" when it isn't,
+ * so the pane says what the set IS instead — count, and the status
+ * breakdown, which is what decides whether a bulk action applies.
+ */
+function renderEntitySelectionSummary(
+	ctx: ListContext,
+	ids: number[],
+): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'os-my-wordpress__preview-empty';
+
+	const heading = document.createElement( 'strong' );
+	heading.textContent = sprintf(
+		// translators: %d: number of selected entries.
+		__( '%d items selected', 'desktop-mode' ),
+		ids.length,
+	);
+	wrap.appendChild( heading );
+
+	const counts = new Map< string, number >();
+	for ( const id of ids ) {
+		const status = ctx.itemsById.get( id )?.status || 'publish';
+		counts.set( status, ( counts.get( status ) ?? 0 ) + 1 );
+	}
+	const breakdown = Array.from( counts.entries() )
+		.sort( ( a, b ) => b[ 1 ] - a[ 1 ] || a[ 0 ].localeCompare( b[ 0 ] ) )
+		.map( ( [ status, n ] ) => `${ n } × ${ status }` )
+		.join( ' · ' );
+	if ( breakdown ) {
+		const detail = document.createElement( 'div' );
+		detail.className = 'os-my-wordpress__preview-selection-breakdown';
+		detail.textContent = breakdown;
+		wrap.appendChild( detail );
+	}
+	return wrap;
+}
+
 function renderListEmpty(
 	host: HTMLElement,
 	entity: MyWordPressEntity,
@@ -1807,6 +1976,30 @@ function buildEntityTile(
 			},
 		},
 		() => hideTooltip(),
+		{
+			// Multi-drag: when this tile is part of the selection, the
+			// gesture carries the whole set — drop three posts on a
+			// folder and three shortcuts are filed.
+			resolveSet: () =>
+				selectedDragPayloads( ctx, ( selected ) => ( {
+					kind: 'post',
+					ref: String( selected.id ),
+					title:
+						stripTags( selected.title?.rendered ?? '' ) ||
+						__( '(no title)', 'desktop-mode' ),
+					icon: entity.icon,
+					entityId: entity.id,
+					bridgePayload: {
+						kind: 'post',
+						id: selected.id,
+						postType: entity.id,
+						url: selected.link ?? '',
+						title:
+							stripTags( selected.title?.rendered ?? '' ) ||
+							__( '(no title)', 'desktop-mode' ),
+					},
+				} ) ),
+		},
 	);
 
 	// If another user is editing right now, surface that on the
@@ -1861,15 +2054,11 @@ function buildEntityTile(
 		name: titleText,
 		date: item.date || new Date( 0 ).toISOString(),
 	} );
-	// Click-to-select. The pointerdown handler above already routes
-	// drags through the DragManager, so a sub-threshold gesture
-	// (pointer-down, no movement, pointer-up) flows naturally:
-	// pointerdown fires manager.start(); manager treats it as a
-	// click on pointerup; the browser dispatches `click`; this
-	// listener selects.
-	tile.addEventListener( 'click', () => {
-		selectTile( state, ctx, tile, entity, item.id );
-	} );
+	// Selection (plain click, Ctrl/Cmd, Shift, marquee) is owned by
+	// the section's selection controller, which listens on the tile
+	// container — no per-tile click handler here. The preview pane
+	// repaints from that controller's `onChange`.
+	ctx.itemsById.set( item.id, item );
 
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
@@ -1879,8 +2068,16 @@ function buildEntityTile(
 
 	tile.addEventListener( 'contextmenu', ( e ) => {
 		e.preventDefault();
+		e.stopPropagation();
 		hideTooltip();
-		openTileMenu( state, ctx, entity, item, titleText, {
+		// Right-clicking a tile that isn't selected replaces the
+		// selection with it, the way Finder and Explorer do; one that
+		// IS selected leaves the set alone so the menu acts on all of
+		// it.
+		if ( ! ctx.selection?.model.has( String( item.id ) ) ) {
+			ctx.selection?.model.set( [ String( item.id ) ] );
+		}
+		openTileMenu( state, ctx, entity, item, {
 			x: e.clientX,
 			y: e.clientY,
 		} );
@@ -1951,24 +2148,6 @@ function positionTooltip( tip: HTMLElement, ev: MouseEvent ): void {
 	}
 	tip.style.left = `${ x }px`;
 	tip.style.top = `${ y }px`;
-}
-
-function selectTile(
-	state: RenderState,
-	ctx: ListContext,
-	tile: HTMLElement,
-	entity: MyWordPressEntity,
-	id: number,
-): void {
-	if ( ctx.selectedTile ) {
-		ctx.selectedTile.classList.remove(
-			'os-file-tile--selected',
-		);
-	}
-	tile.classList.add( 'os-file-tile--selected' );
-	ctx.selectedTile = tile;
-	ctx.selectedId = id;
-	void renderPreview( state, ctx, entity, id );
 }
 
 async function renderPreview(
@@ -2626,8 +2805,56 @@ function renderSubList(
 			return;
 		}
 
-		let selectedKey: string | null = null;
-		let selectedTile: HTMLElement | null = null;
+		const itemsById = new Map< string, SubItemView >();
+
+		// Selection lives on the controller here too, so a drill-in
+		// list behaves like every other canvas — Ctrl/Cmd, Shift, and
+		// marquee all work. There are no bulk actions on a dossier
+		// list (these rows are relations, not records you can act on),
+		// so a multi-selection is highlight-only and the preview says
+		// how many are held.
+		const selection = attachSelection( tiles, {
+			background: left,
+			surface: 'my-wordpress',
+			scope: `sub-list:${ entity.id }:${ postId }:${ relation }`,
+			keyOf: ( el ) =>
+				el.dataset.subItemId ? `sub:${ el.dataset.subItemId }` : null,
+			onChange: ( keys ) => {
+				if ( keys.length === 0 ) {
+					right.replaceChildren( renderSubListPreviewEmpty( 0 ) );
+					return;
+				}
+				if ( keys.length > 1 ) {
+					right.replaceChildren(
+						renderSubListPreviewEmpty( keys.length ),
+					);
+					return;
+				}
+				const key = keys[ 0 ];
+				const item = itemsById.get( key );
+				if ( ! item ) {
+					return;
+				}
+				showPreviewLoading( right );
+				Promise.resolve( item.preview() )
+					.then( ( node ) => {
+						// Selection may have moved on while the preview
+						// was resolving — compare against the live set,
+						// not the key we started with.
+						if ( selection.keys()[ 0 ] !== key ) {
+							return;
+						}
+						right.replaceChildren( node );
+					} )
+					.catch( ( err ) => {
+						if ( selection.keys()[ 0 ] !== key ) {
+							return;
+						}
+						showPreviewError( right, err );
+					} );
+			},
+		} );
+		state.teardown.push( () => selection.destroy() );
 
 		for ( const item of items ) {
 			const tile = buildIconTile( {
@@ -2637,36 +2864,10 @@ function renderSubList(
 			} );
 			tile.dataset.subItemId = item.id;
 			const tileKey = `sub:${ item.id }`;
+			itemsById.set( tileKey, item );
 			layout.place( tile, tileKey, {
 				name: item.label,
 				date: item.date,
-			} );
-			tile.addEventListener( 'click', () => {
-				if ( selectedTile ) {
-					selectedTile.classList.remove(
-						'os-file-tile--selected',
-					);
-				}
-				tile.classList.add(
-					'os-file-tile--selected',
-				);
-				selectedTile = tile;
-				selectedKey = tileKey;
-
-				showPreviewLoading( right );
-				Promise.resolve( item.preview() )
-					.then( ( node ) => {
-						if ( selectedKey !== tileKey ) {
-							return; // Selection moved on.
-						}
-						right.replaceChildren( node );
-					} )
-					.catch( ( err ) => {
-						if ( selectedKey !== tileKey ) {
-							return;
-						}
-						showPreviewError( right, err );
-					} );
 			} );
 			tiles.appendChild( tile );
 		}
@@ -2676,6 +2877,25 @@ function renderSubList(
 	// view doesn't need it inline today but the signature mirrors the
 	// other render functions for consistency.
 	void postTitle;
+}
+
+/**
+ * Right pane of a drill-in list with nothing — or several things —
+ * selected. These rows are relations rather than records, so a set
+ * has no useful preview beyond its size.
+ */
+function renderSubListPreviewEmpty( selectedCount: number ): HTMLElement {
+	const empty = document.createElement( 'div' );
+	empty.className = 'os-my-wordpress__preview-empty';
+	empty.textContent =
+		selectedCount > 1
+			? sprintf(
+				// translators: %d: number of selected items.
+				__( '%d items selected', 'desktop-mode' ),
+				selectedCount,
+			)
+			: __( 'Select an item to preview it here.', 'desktop-mode' );
+	return empty;
 }
 
 function renderListEmptyMessage(
@@ -4161,190 +4381,332 @@ function openEditor(
 	} );
 }
 
-function openTileMenu(
+/**
+ * One entry in an entity tile's context menu.
+ *
+ * Plugin-added entries must supply `onSelect`; the built-ins carry
+ * their own `onClick`. The multi-selection fields (`multi`,
+ * `bulkLabel`, `bulk`) are opt-in, so an entry written for one item
+ * keeps appearing only when one item is selected.
+ */
+interface TileMenuOption {
+	id: string;
+	label: string;
+	icon: string;
+	danger?: boolean;
+	/**
+	 * Lower sorts first. Only consulted for a multi-selection — a
+	 * single-item menu renders in the order the builder (and the
+	 * filter after it) left them, which is the order plugin authors
+	 * have been arranging for. The built-ins use the same 10/20/90
+	 * scale as the file-tile menu so destructive entries stay at the
+	 * bottom of both.
+	 */
+	sort?: number;
+	multi?: boolean;
+	bulkLabel?: ( count: number ) => string;
+	onSelect?: ( () => void ) | null;
+}
+
+/**
+ * Actions for ONE entry, with the `os.my-wordpress.tile-context-menu`
+ * filter applied. `resolveCommonActions` calls this once per selected
+ * tile and intersects the results.
+ *
+ * The filter's argument shape is unchanged — plugins have been adding
+ * entries to it since it shipped.
+ */
+function buildEntityActions(
 	state: RenderState,
 	ctx: ListContext,
 	entity: MyWordPressEntity,
 	item: EntityListItem,
 	title: string,
-	pos: { x: number; y: number },
-): void {
-	closeAnyTileMenu();
-
-	const menu = document.createElement( 'os-context-menu' );
-	menu.setAttribute( 'open', '' );
-	menu.classList.add( 'os-my-wordpress__menu' );
-	( menu as HTMLElement ).style.left = `${ pos.x }px`;
-	( menu as HTMLElement ).style.top = `${ pos.y }px`;
-
-	const addOption = (
-		id: string,
-		label: string,
-		icon: string,
-		danger = false,
-	) => {
-		const opt = document.createElement( 'os-context-menu-option' );
-		// `os-context-menu-option` emits the pick event with
-		// `detail.id = dataset.menuItemId ?? this.id ?? ''`. We MUST
-		// set `dataset.menuItemId` (the `value` attribute alone shows
-		// up under `detail.value`, which the handler below doesn't
-		// inspect). Forgetting this gave us the silent "Navigate
-		// into doesn't work" bug.
-		( opt as HTMLElement ).dataset.menuItemId = id;
-		opt.setAttribute( 'value', id );
-		opt.setAttribute( 'icon', sanitizeClass( icon ) );
-		if ( danger ) {
-			opt.setAttribute( 'danger', '' );
-		}
-		opt.textContent = label;
-		menu.appendChild( opt );
-	};
-
-	interface TileMenuOption {
-		id: string;
-		label: string;
-		icon: string;
-		danger?: boolean;
-		/**
-		 * Plugin-supplied click handler. Built-ins set this to null
-		 * so the static `os-context-menu-pick` switch below routes
-		 * them — keeps the existing semantics.
-		 */
-		onSelect?: ( () => void ) | null;
-	}
-
+): SelectionAction< EntityListItem >[] {
 	const baseOptions: TileMenuOption[] = [
 		{
 			id: 'open',
 			label: __( 'Open in editor', 'desktop-mode' ),
 			icon: 'dashicons-edit',
+			sort: 10,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: %d: number of selected entries.
+					__( 'Open %d items in the editor', 'desktop-mode' ),
+					n,
+				),
 		},
 		{
 			id: 'navigate-into',
 			label: __( 'Navigate into', 'desktop-mode' ),
 			icon: 'dashicons-category',
+			sort: 20,
 		},
 		{
 			id: 'trash',
 			label: __( 'Move to Trash', 'desktop-mode' ),
 			icon: 'dashicons-trash',
+			sort: 90,
 			danger: true,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: %d: number of selected entries.
+					__( 'Move %d items to Trash', 'desktop-mode' ),
+					n,
+				),
 		},
 	];
 
-	/**
-	 * Let plugins add / remove / reorder context-menu entries
-	 * uniformly across every section. Plugin-added entries must
-	 * supply an `onSelect` handler (built-ins are dispatched by
-	 * the static switch below).
-	 */
 	const ctxFilter = {
 		entityId: entity.id,
 		kind: entity.kind ?? 'post',
 		item: item as unknown as Record< string, unknown >,
 	};
-	const options = applyFilters<
-		TileMenuOption[],
-		[ typeof ctxFilter ]
-	>(
+	const options = applyFilters< TileMenuOption[], [ typeof ctxFilter ] >(
 		'os.my-wordpress.tile-context-menu',
 		baseOptions,
 		ctxFilter,
 	);
 	const finalOptions = Array.isArray( options ) ? options : baseOptions;
-	for ( const o of finalOptions ) {
-		addOption( o.id, o.label, o.icon, o.danger );
-	}
 
-	menu.addEventListener( 'os-context-menu-pick', ( e: Event ) => {
-		const detail = ( e as CustomEvent< { id: string } > ).detail;
-		closeAnyTileMenu();
-		if ( detail.id === 'open' ) {
-			openEditor( entity, item.id, title, item.editUrl );
-			return;
+	// wp-admin's own bulk actions and row actions — Edit… (the bulk
+	// edit modal), Publish, Switch to Draft, Copy link. They're built
+	// separately from `finalOptions` because they carry closures and
+	// batched runners rather than the flat descriptor shape the
+	// `tile-context-menu` filter passes around.
+	const extras: SelectionAction< EntityListItem >[] = [
+		...entityBulkActions(
+			{
+				entity,
+				onChanged: ( ids ) => {
+					if ( ids.length > 0 ) {
+						refreshAfterBulk( state, entity, ids );
+					}
+				},
+			},
+			item,
+		),
+		copyLinksAction( item, ( i ) => i.link ?? '' ),
+	];
+
+	const mapped = finalOptions.map( ( option ) => {
+		const action: SelectionAction< EntityListItem > = {
+			id: option.id,
+			label: option.label,
+			icon: option.icon,
+			sort: option.sort,
+			danger: option.danger,
+			multi: option.multi,
+			bulkLabel: option.bulkLabel,
+			onClick: () => {
+				if ( option.id === 'open' ) {
+					openEditor( entity, item.id, title, item.editUrl );
+					return;
+				}
+				if ( option.id === 'navigate-into' ) {
+					navigate( state, {
+						kind: 'detail',
+						entityId: entity.id,
+						postId: item.id,
+						postTitle: title,
+					} );
+					return;
+				}
+				if ( option.id === 'trash' ) {
+					void confirmTrash( state, ctx, entity, item.id, title );
+					return;
+				}
+				if ( typeof option.onSelect === 'function' ) {
+					try {
+						option.onSelect();
+					} catch ( err ) {
+						// eslint-disable-next-line no-console
+						console.error(
+							`[my-wordpress] tile-context-menu '${ option.id }' onSelect threw:`,
+							err,
+						);
+					}
+				}
+			},
+		};
+		// Trash gets a batched runner: one confirm for the set, one
+		// broadcast, one repaint. Fanning the single-item handler out
+		// would ask the user N times and emit N cross-window events.
+		if ( option.id === 'trash' ) {
+			action.bulk = ( items ) => trashManyEntities( ctx, entity, items );
 		}
-		if ( detail.id === 'navigate-into' ) {
-			navigate( state, {
-				kind: 'detail',
-				entityId: entity.id,
-				postId: item.id,
-				postTitle: title,
-			} );
-			return;
-		}
-		if ( detail.id === 'trash' ) {
-			void confirmTrash( state, ctx, entity, item.id, title );
-			return;
-		}
-		// Plugin-supplied entry — dispatch its `onSelect`.
-		const match = finalOptions.find( ( o ) => o.id === detail.id );
-		if ( match && typeof match.onSelect === 'function' ) {
-			try {
-				match.onSelect();
-			} catch ( err ) {
-				// eslint-disable-next-line no-console
-				console.error(
-					`[my-wordpress] tile-context-menu '${ detail.id }' onSelect threw:`,
-					err,
-				);
-			}
-		}
+		return action;
 	} );
 
-	document.body.appendChild( menu );
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		( menu as HTMLElement ).style.left = `${ Math.max(
-			0,
-			window.innerWidth - rect.width - 8,
-		) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		( menu as HTMLElement ).style.top = `${ Math.max(
-			0,
-			window.innerHeight - rect.height - 8,
-		) }px`;
-	}
+	// Slot the extras in by `sort` — "Edit…" lands after "Open in
+	// editor", the status actions after that, Trash stays last.
+	return [ ...mapped, ...extras ].sort( ( a, b ) => {
+		const sa = typeof a.sort === 'number' ? a.sort : 100;
+		const sb = typeof b.sort === 'number' ? b.sort : 100;
+		return sa - sb;
+	} );
+}
 
-	// Outside-click + Escape dismissers. Until now the only thing
-	// that closed the tile menu was a pick or another right-click —
-	// so a left-click on a *different* tile (which selects + previews)
-	// left the menu hovering. The dismissers run on the next
-	// microtask so the click that opened the menu doesn't immediately
-	// close it when the event bubbles up to document.
-	queueMicrotask( () => {
-		const onDocPointerDown = ( ev: PointerEvent ) => {
-			const target = ev.target;
-			if ( target instanceof Node && menu.contains( target ) ) {
-				return;
-			}
-			closeAnyTileMenu();
-		};
-		const onDocKey = ( ev: KeyboardEvent ) => {
-			if ( ev.key === 'Escape' ) {
-				closeAnyTileMenu();
-			}
-		};
-		document.addEventListener( 'pointerdown', onDocPointerDown, true );
-		document.addEventListener( 'keydown', onDocKey );
-		menu.addEventListener( 'tile-menu-closed', () => {
-			document.removeEventListener(
-				'pointerdown',
-				onDocPointerDown,
-				true,
-			);
-			document.removeEventListener( 'keydown', onDocKey );
+/**
+ * Re-read the current page after a bulk write so tiles show the new
+ * truth (a changed status flips the ribbon; a changed author changes
+ * nothing visible but the preview pane) — and tell the rest of the
+ * shell, so the Recycle Bin badge and any other window listening on
+ * the entity's topic catch up too.
+ */
+function refreshAfterBulk(
+	state: RenderState,
+	entity: MyWordPressEntity,
+	changedIds: readonly number[],
+): void {
+	const topic = getBroadcastTopicForEntity( entity );
+	if ( topic && changedIds.length > 0 ) {
+		// Only what actually changed. Subscribers delta by `ids`, so
+		// announcing the whole page would have every other window
+		// re-reading rows nothing touched.
+		window.wp?.os?.broadcast( topic, {
+			source: 'my-wordpress',
+			action: 'updated',
+			ids: changedIds.slice(),
 		} );
+	}
+	// Re-render the section from scratch. Cheaper options exist
+	// (patch each tile in place), but a bulk edit can change status,
+	// author, terms and stickiness at once, and half of that is
+	// invisible until the row is re-read.
+	navigate( state, { kind: 'list', entityId: entity.id } );
+}
+
+function openTileMenu(
+	state: RenderState,
+	ctx: ListContext,
+	entity: MyWordPressEntity,
+	item: EntityListItem,
+	pos: { x: number; y: number },
+): void {
+	closeAnyTileMenu();
+
+	const selectedIds = ( ctx.selection?.keys() ?? [] )
+		.map( ( k ) => parseInt( k, 10 ) )
+		.filter( ( n ) => Number.isFinite( n ) );
+	const targets = selectedIds
+		.map( ( id ) => ctx.itemsById.get( id ) )
+		.filter( ( i ): i is EntityListItem => !! i );
+	const items = targets.length > 0 ? targets : [ item ];
+
+	const actions = resolveCommonActions( items, ( listItem ) =>
+		buildEntityActions(
+			state,
+			ctx,
+			entity,
+			listItem,
+			stripTags( listItem.title?.rendered ?? '' ) ||
+				__( '(no title)', 'desktop-mode' ),
+		),
+	);
+
+	openActionMenu( pos, {
+		actions,
+		className: 'os-my-wordpress__menu',
+		scope: 'my-wordpress.tile',
+		dataset: { entryIds: items.map( ( i ) => i.id ).join( ',' ) },
 	} );
 }
 
 function closeAnyTileMenu(): void {
+	closeActionMenu();
+	// Belt and braces for menus this module didn't open (a plugin
+	// building its own with the shared class), which the shared
+	// closer doesn't track.
 	document
 		.querySelectorAll( 'os-context-menu.os-my-wordpress__menu' )
 		.forEach( ( n ) => {
 			n.dispatchEvent( new CustomEvent( 'tile-menu-closed' ) );
 			n.remove();
 		} );
+}
+
+/**
+ * Move several entries to Trash as one action: one confirm, parallel
+ * REST, one toast, one broadcast. Looping the single-item path would
+ * ask the user N times and emit N cross-window events for what they
+ * experienced as a single decision.
+ */
+async function trashManyEntities(
+	ctx: ListContext,
+	entity: MyWordPressEntity,
+	items: readonly EntityListItem[],
+): Promise< void > {
+	const ok = await osConfirmGlobal( {
+		title: __( 'Move to Trash', 'desktop-mode' ),
+		message: sprintf(
+			// translators: %d: number of selected entries.
+			__( 'Move %d items to Trash?', 'desktop-mode' ),
+			items.length,
+		),
+		confirmLabel: __( 'Move to Trash', 'desktop-mode' ),
+		cancelLabel: __( 'Cancel', 'desktop-mode' ),
+		danger: true,
+	} );
+	if ( ! ok ) {
+		return;
+	}
+
+	const results = await Promise.allSettled(
+		items.map( ( item ) => trashEntity( entity, item.id ) ),
+	);
+	const trashed: number[] = [];
+	let failed = 0;
+	results.forEach( ( result, index ) => {
+		if ( result.status === 'fulfilled' ) {
+			trashed.push( items[ index ].id );
+		} else {
+			failed += 1;
+		}
+	} );
+
+	for ( const id of trashed ) {
+		ctx.tiles
+			.querySelector< HTMLElement >( `[data-entry-id="${ id }"]` )
+			?.remove();
+		ctx.itemsById.delete( id );
+	}
+	ctx.selection?.refresh();
+	if ( ctx.selection?.keys().length === 0 ) {
+		renderPreviewPlaceholder( ctx );
+	}
+
+	if ( trashed.length > 0 ) {
+		const topic = getBroadcastTopicForEntity( entity );
+		if ( topic ) {
+			window.wp?.os?.broadcast( topic, {
+				source: 'my-wordpress',
+				action: 'trashed',
+				ids: trashed,
+			} );
+		}
+		showToast(
+			failed > 0
+				? sprintf(
+					// translators: 1: number moved to trash, 2: number that failed.
+					__(
+						'%1$d items moved to Trash · %2$d could not be moved',
+						'desktop-mode',
+					),
+					trashed.length,
+					failed,
+				)
+				: sprintf(
+					// translators: %d: number of entries moved to trash.
+					__( '%d items moved to Trash', 'desktop-mode' ),
+					trashed.length,
+				),
+		);
+	} else {
+		showToast( __( 'Nothing could be moved to Trash.', 'desktop-mode' ) );
+	}
 }
 
 /**
@@ -4506,8 +4868,13 @@ interface UserListContext {
 	tiles: HTMLElement;
 	sentinel: HTMLElement;
 	preview: HTMLElement;
+	/** Id of the ONE selected user, or null for none / several. */
 	selectedId: number | null;
 	selectedTile: HTMLElement | null;
+	/** Multi-selection controller for the users canvas. */
+	selection: SelectionHandle | null;
+	/** Every rendered user, by id — the menu builds actions from these. */
+	itemsById: Map< number, UserListItem >;
 	observer: IntersectionObserver | null;
 	layout: TileLayout;
 	query: string;
@@ -4582,11 +4949,40 @@ function renderUserEntityList(
 		preview: right,
 		selectedId: null,
 		selectedTile: null,
+		selection: null,
+		itemsById: new Map(),
 		observer: null,
 		layout: tileLayout,
 		query: initialQuery,
 		abort: null,
 	};
+
+	ctx.selection = attachSelection( tiles, {
+		background: left,
+		surface: 'my-wordpress',
+		scope: entity.id,
+		keyOf: ( el ) => ( el.dataset.entryId ? el.dataset.entryId : null ),
+		onChange: ( keys ) => {
+			const ids = keys
+				.map( ( k ) => parseInt( k, 10 ) )
+				.filter( ( n ) => Number.isFinite( n ) );
+			ctx.selectedId = ids.length === 1 ? ids[ 0 ] : null;
+			ctx.selectedTile =
+				ids.length === 1
+					? ctx.selection?.elementFor( String( ids[ 0 ] ) ) ?? null
+					: null;
+			if ( ids.length === 1 ) {
+				const item = ctx.itemsById.get( ids[ 0 ] );
+				if ( item ) {
+					void renderUserPreviewPane( state, ctx, entity, item );
+				}
+			} else {
+				ctx.preview.replaceChildren( renderUserPreviewEmpty( ids.length ) );
+			}
+			repaintListStatus();
+		},
+	} );
+	state.teardown.push( () => ctx.selection?.destroy() );
 	state.teardown.push( () => tileLayout.dispose() );
 	state.teardown.push( () => ctx.abort?.abort() );
 
@@ -4611,6 +5007,21 @@ function renderUserEntityList(
 		const segments: StatusBarSegment[] = [
 			{ id: 'count', label: itemLabel, align: 'start', sort: 10 },
 		];
+		// Only while there IS a selection — a permanent "0 selected"
+		// is noise on a bar whose whole job is to be glanceable.
+		const selectedCount = ctx.selection?.keys().length ?? 0;
+		if ( selectedCount > 0 ) {
+			segments.push( {
+				id: 'selection',
+				label: sprintf(
+					// translators: %d: number of selected entries.
+					__( '%d selected', 'desktop-mode' ),
+					selectedCount,
+				),
+				align: 'end',
+				sort: 5,
+			} );
+		}
 		if ( ctx.totalPages > 1 ) {
 			segments.push( {
 				id: 'page',
@@ -4842,13 +5253,18 @@ function renderUserEntityList(
  * The class list keeps `os-file-tile` so the existing
  * selection + canvas pointer plumbing applies unchanged.
  */
+/** Label for a user tile / menu — the same rule everywhere. */
+function userDisplayName( item: UserListItem ): string {
+	return item.name || item.slug || `#${ item.id }`;
+}
+
 function buildUserTile(
 	state: RenderState,
 	ctx: UserListContext,
 	entity: MyWordPressEntity,
 	item: UserListItem,
 ): HTMLElement {
-	const displayName = item.name || item.slug || `#${ item.id }`;
+	const displayName = userDisplayName( item );
 
 	const avatarUrl = pickAvatar( item.avatar_urls ) ?? '';
 	const tile = buildTileFromSpec( {
@@ -4956,6 +5372,22 @@ function buildUserTile(
 			},
 		},
 		() => hideTooltip(),
+		{
+			resolveSet: () =>
+				selectedDragPayloads( ctx, ( selected ) => ( {
+					kind: 'user',
+					ref: String( selected.id ),
+					title: userDisplayName( selected ),
+					icon: 'dashicons-admin-users',
+					entityId: entity.id,
+					bridgePayload: {
+						kind: 'user',
+						id: selected.id,
+						url: selected.link ?? '',
+						title: userDisplayName( selected ),
+					},
+				} ) ),
+		},
 	);
 
 	const tileKey = `entry:${ item.id }`;
@@ -4970,9 +5402,10 @@ function buildUserTile(
 			: new Date( 0 ).toISOString(),
 	} );
 
-	tile.addEventListener( 'click', () => {
-		selectUserTile( state, ctx, entity, tile, item );
-	} );
+	// Selection is owned by the list's selection controller; the tile
+	// only needs to be findable by id and to register its item shape
+	// so a multi-selection menu can build actions for it.
+	ctx.itemsById.set( item.id, item );
 
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
@@ -4994,8 +5427,12 @@ function buildUserTile(
 
 	tile.addEventListener( 'contextmenu', ( e ) => {
 		e.preventDefault();
+		e.stopPropagation();
 		hideTooltip();
-		openUserTileMenu( state, entity, item, displayName, {
+		if ( ! ctx.selection?.model.has( String( item.id ) ) ) {
+			ctx.selection?.model.set( [ String( item.id ) ] );
+		}
+		openUserTileMenu( state, ctx, entity, item, {
 			x: e.clientX,
 			y: e.clientY,
 		} );
@@ -5105,22 +5542,23 @@ function activateUserTile(
 	return handled === true;
 }
 
-function selectUserTile(
-	state: RenderState,
-	ctx: UserListContext,
-	entity: MyWordPressEntity,
-	tile: HTMLElement,
-	item: UserListItem,
-): void {
-	if ( ctx.selectedTile ) {
-		ctx.selectedTile.classList.remove(
-			'os-file-tile--selected',
-		);
-	}
-	tile.classList.add( 'os-file-tile--selected' );
-	ctx.selectedTile = tile;
-	ctx.selectedId = item.id;
-	void renderUserPreviewPane( state, ctx, entity, item );
+/**
+ * Right pane when the users list has nothing — or several things —
+ * selected. A profile dossier is about one person, so a set gets a
+ * count instead of one arbitrary member's face.
+ */
+function renderUserPreviewEmpty( selectedCount: number ): HTMLElement {
+	const empty = document.createElement( 'div' );
+	empty.className = 'os-my-wordpress__preview-empty';
+	empty.textContent =
+		selectedCount > 1
+			? sprintf(
+				// translators: %d: number of selected users.
+				__( '%d users selected', 'desktop-mode' ),
+				selectedCount,
+			)
+			: __( 'Select a user to see their profile here.', 'desktop-mode' );
+	return empty;
 }
 
 /**
@@ -5304,42 +5742,24 @@ async function renderUserPreviewPane(
 	ctx.preview.replaceChildren( node );
 }
 
-function openUserTileMenu(
+/**
+ * Actions for ONE user, with the shared
+ * `os.my-wordpress.tile-context-menu` filter applied (kind `'user'`).
+ *
+ * "Show profile" and "View author archive" are marked multi-safe —
+ * both open one window per user, which is what someone selecting
+ * three authors and asking for their profiles wants. "View activity
+ * footprint" is not: the footprint view replaces the window body, so
+ * three of them would be three fights over the same surface.
+ */
+function buildUserActions(
 	state: RenderState,
 	entity: MyWordPressEntity,
 	item: UserListItem,
 	name: string,
-	pos: { x: number; y: number },
-): void {
-	closeAnyTileMenu();
-
-	const menu = document.createElement( 'os-context-menu' );
-	menu.setAttribute( 'open', '' );
-	menu.classList.add( 'os-my-wordpress__menu' );
-	( menu as HTMLElement ).style.left = `${ pos.x }px`;
-	( menu as HTMLElement ).style.top = `${ pos.y }px`;
-
-	const addOption = (
-		id: string,
-		label: string,
-		icon: string,
-	) => {
-		const opt = document.createElement( 'os-context-menu-option' );
-		( opt as HTMLElement ).dataset.menuItemId = id;
-		opt.setAttribute( 'value', id );
-		opt.setAttribute( 'icon', sanitizeClass( icon ) );
-		opt.textContent = label;
-		menu.appendChild( opt );
-	};
-
-	interface TileMenuOption {
-		id: string;
-		label: string;
-		icon: string;
-		danger?: boolean;
-		onSelect?: ( () => void ) | null;
-	}
-
+): SelectionAction< UserListItem >[] {
+	// Same option shape the post/media grids use — one contract for
+	// the `os.my-wordpress.tile-context-menu` filter across kinds.
 	// Footprint is the primary (double-click) action; profile is the
 	// classic editor, demoted to "Show profile" to mirror the preview
 	// pane's button labels.
@@ -5348,11 +5768,20 @@ function openUserTileMenu(
 			id: 'footprint',
 			label: __( 'View activity footprint', 'desktop-mode' ),
 			icon: 'dashicons-chart-area',
+			sort: 10,
 		},
 		{
 			id: 'open-profile',
 			label: __( 'Show profile', 'desktop-mode' ),
 			icon: 'dashicons-id-alt',
+			sort: 20,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: %d: number of selected users.
+					__( 'Show %d profiles', 'desktop-mode' ),
+					n,
+				),
 		},
 	];
 	if ( item.link ) {
@@ -5360,6 +5789,14 @@ function openUserTileMenu(
 			id: 'author-archive',
 			label: __( 'View author archive', 'desktop-mode' ),
 			icon: 'dashicons-external',
+			sort: 30,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: %d: number of selected users.
+					__( 'View %d author archives', 'desktop-mode' ),
+					n,
+				),
 		} );
 	}
 
@@ -5375,83 +5812,101 @@ function openUserTileMenu(
 		ctxFilter,
 	);
 	const finalOptions = Array.isArray( options ) ? options : baseOptions;
-	for ( const o of finalOptions ) {
-		addOption( o.id, o.label, o.icon );
-	}
 
-	menu.addEventListener( 'os-context-menu-pick', ( e: Event ) => {
-		const detail = ( e as CustomEvent< { id: string } > ).detail;
-		closeAnyTileMenu();
-		if ( detail.id === 'footprint' ) {
-			navigate( state, {
-				kind: 'user-footprint',
-				entityId: entity.id,
-				userId: item.id,
-				userName: name,
-			} );
-			return;
-		}
-		if ( detail.id === 'open-profile' ) {
-			openUserEditWindow( item.id );
-			return;
-		}
-		if ( detail.id === 'author-archive' && item.link ) {
-			window.open( item.link, '_blank', 'noopener,noreferrer' );
-			return;
-		}
-		// Plugin-supplied entry — dispatch its `onSelect`.
-		const match = finalOptions.find( ( o ) => o.id === detail.id );
-		if ( match && typeof match.onSelect === 'function' ) {
-			try {
-				match.onSelect();
-			} catch ( err ) {
-				// eslint-disable-next-line no-console
-				console.error(
-					`[my-wordpress] tile-context-menu '${ detail.id }' onSelect threw:`,
-					err,
-				);
-			}
-		}
-	} );
-
-	document.body.appendChild( menu );
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		( menu as HTMLElement ).style.left = `${ Math.max(
-			0,
-			window.innerWidth - rect.width - 8,
-		) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		( menu as HTMLElement ).style.top = `${ Math.max(
-			0,
-			window.innerHeight - rect.height - 8,
-		) }px`;
-	}
-
-	queueMicrotask( () => {
-		const onDocPointerDown = ( ev: PointerEvent ) => {
-			const target = ev.target;
-			if ( target instanceof Node && menu.contains( target ) ) {
+	return finalOptions.map( ( option ) => ( {
+		id: option.id,
+		label: option.label,
+		icon: option.icon,
+		sort: option.sort,
+		danger: option.danger,
+		multi: option.multi,
+		bulkLabel: option.bulkLabel,
+		onClick: () => {
+			if ( option.id === 'footprint' ) {
+				navigate( state, {
+					kind: 'user-footprint',
+					entityId: entity.id,
+					userId: item.id,
+					userName: name,
+				} );
 				return;
 			}
-			closeAnyTileMenu();
-		};
-		const onDocKey = ( ev: KeyboardEvent ) => {
-			if ( ev.key === 'Escape' ) {
-				closeAnyTileMenu();
+			if ( option.id === 'open-profile' ) {
+				openUserEditWindow( item.id );
+				return;
 			}
-		};
-		document.addEventListener( 'pointerdown', onDocPointerDown, true );
-		document.addEventListener( 'keydown', onDocKey );
-		menu.addEventListener( 'tile-menu-closed', () => {
-			document.removeEventListener(
-				'pointerdown',
-				onDocPointerDown,
-				true,
-			);
-			document.removeEventListener( 'keydown', onDocKey );
-		} );
+			if ( option.id === 'author-archive' && item.link ) {
+				window.open( item.link, '_blank', 'noopener,noreferrer' );
+				return;
+			}
+			if ( typeof option.onSelect === 'function' ) {
+				try {
+					option.onSelect();
+				} catch ( err ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						`[my-wordpress] tile-context-menu '${ option.id }' onSelect threw:`,
+						err,
+					);
+				}
+			}
+		},
+	} ) );
+}
+
+function openUserTileMenu(
+	state: RenderState,
+	ctx: UserListContext,
+	entity: MyWordPressEntity,
+	item: UserListItem,
+	pos: { x: number; y: number },
+): void {
+	closeAnyTileMenu();
+
+	const ids = ( ctx.selection?.keys() ?? [] )
+		.map( ( k ) => parseInt( k, 10 ) )
+		.filter( ( n ) => Number.isFinite( n ) );
+	const targets = ids
+		.map( ( id ) => ctx.itemsById.get( id ) )
+		.filter( ( u ): u is UserListItem => !! u );
+	const items = targets.length > 0 ? targets : [ item ];
+
+	const actions = resolveCommonActions( items, ( user ) => [
+		...buildUserActions( state, entity, user, userDisplayName( user ) ),
+		// wp-admin's Users bulk actions: change role, delete (with the
+		// same "what happens to their content" question core asks).
+		...userBulkActions(
+			{
+				onChanged: () =>
+					navigate( state, { kind: 'list', entityId: entity.id } ),
+				onRemoved: ( removedIds ) => {
+					for ( const id of removedIds ) {
+						ctx.tiles
+							.querySelector< HTMLElement >(
+								`[data-entry-id="${ id }"]`,
+							)
+							?.remove();
+						ctx.itemsById.delete( id );
+					}
+					ctx.selection?.refresh();
+					ctx.loaded = Math.max( 0, ctx.loaded - removedIds.length );
+					ctx.total = Math.max( 0, ctx.total - removedIds.length );
+				},
+			},
+			user,
+		),
+		copyLinksAction(
+			user,
+			( u ) => u.link ?? '',
+			__( 'Copy author archive link', 'desktop-mode' ),
+		),
+	] );
+
+	openActionMenu( pos, {
+		actions,
+		className: 'os-my-wordpress__menu',
+		scope: 'my-wordpress.user-tile',
+		dataset: { entryIds: items.map( ( u ) => u.id ).join( ',' ) },
 	} );
 }
 
@@ -6440,44 +6895,25 @@ function createTileSelector(): ( tile: HTMLElement ) => void {
  *  click-vs-drag threshold, `--dragging` class).
  * ------------------------------------------------------------------ */
 
-// Cell pitch for the in-window absolute-positioned tile canvas used
-// by Posts / Pages / users / plugin sections. Tile visual is 88px
-// wide; the previous 96×92 cell pitch left only ~4px per side
-// between neighbours, so the selected tile's background ring abutted
-// adjacent corner ribbons and read as "spillover" (regression
-// surfaced once `<os-ribbon>` started rendering DRAFT/PENDING
-// banners). Widen the cell so the selection ring has
-// breathing room — and so wrapped 2-line labels don't push the next
-// row's tile into the cell above. Tile label is clamped to 2 lines
-// via CSS in `my-wordpress.css`; if you change that clamp, raise
-// `TILE_H` to match.
-/**
- * Grid cell pitch for a tile canvas. The tile visual itself is sized
- * in CSS; these are the cell dimensions the layout walks, and the two
- * have to move together — a wider tile in a cell that didn't grow
- * overlaps its neighbour.
- */
-interface TileMetrics {
-	w: number;
-	h: number;
-	pad: number;
-}
-
-/** Icon-led sections: posts, pages, users, plugin-defined kinds. */
-const TILE_METRICS: TileMetrics = { w: 108, h: 112, pad: 16 };
-
-/**
- * Image-led sections. A section whose rows carry a photograph — a
- * shop's products, most obviously — reads as a catalogue, not a file
- * list: the picture is the thing being scanned, and at 48px it's a
- * thumbnail of a thumbnail. Opted into per section with
- * `tileSize: 'large'`.
+/*
+ * Cell pitch for the in-window absolute-positioned tile canvas used
+ * by Posts / Pages / Users / plugin sections.
  *
- * Sized so a corner ribbon reads as a corner flash rather than
- * covering the subject. Cell pitch mirrors the regular metrics'
- * ~20px horizontal and ~24px vertical breathing room around the tile.
+ * These are NOT this module's numbers. There is one icon grid in the
+ * shell and it is declared in `assets/css/variables.css` and mirrored
+ * in `src/desktop-files/grid.ts`; a canvas here lays out on the same
+ * pitch as one in a folder window, because to the user they are the
+ * same grid seen through two windows.
+ *
+ * Image-led sections opt into the large metrics with
+ * `tileSize: 'large'` — a shop's products read as a catalogue rather
+ * than a file list, and at 48px the picture is a thumbnail of a
+ * thumbnail. Same gaps, bigger tile.
  */
-const TILE_METRICS_LARGE: TileMetrics = { w: 152, h: 176, pad: 16 };
+type TileMetrics = GridMetrics;
+
+const TILE_METRICS: TileMetrics = GRID_METRICS;
+const TILE_METRICS_LARGE: TileMetrics = GRID_METRICS_LARGE;
 
 export interface TileSortable {
 	/** Used by `name-asc` / `name-desc`. Compared with `localeCompare`. */

--- a/src/my-wordpress/media-detail.ts
+++ b/src/my-wordpress/media-detail.ts
@@ -21,6 +21,13 @@ import { __, _n, sprintf } from '../i18n';
 import { applyFilters } from '../hooks';
 import { renderStatusBarSegments, type StatusBarSegment } from '../desktop-files/folder-status-bar';
 import { attachTileDragOut, buildTileFromSpec } from '../desktop-files/tile-spec';
+import {
+	attachSelection,
+	closeActionMenu,
+	openActionMenu,
+	resolveCommonActions,
+	type SelectionAction,
+} from '../selection';
 import type { EntityRenderHost } from './kind-registry';
 import type { MediaListItem, MediaUsage } from './types';
 import { fetchMediaUsage } from './media-rest';
@@ -125,114 +132,94 @@ function buildUsageTile(
 	return tile;
 }
 
-let openContextMenu: HTMLElement | null = null;
-
 function closeContextMenu(): void {
-	if ( openContextMenu && openContextMenu.isConnected ) {
-		openContextMenu.remove();
+	closeActionMenu();
+}
+
+type UsageRow = MediaUsage[ 'usedIn' ][ number ];
+
+/**
+ * Actions for ONE usage row. All three open something per row, so
+ * all three are multi-safe: asking for three referencing posts in
+ * the editor and getting three editor windows is the expected
+ * outcome, and the shared resolver caps nothing here because the set
+ * is bounded by how many rows reference one file.
+ */
+function buildUsageActions(
+	row: UsageRow,
+): SelectionAction< UsageRow >[] {
+	const actions: SelectionAction< UsageRow >[] = [
+		{
+			id: 'navigate-into',
+			label: sprintf(
+				// translators: %s is the site title.
+				__( 'Open in %s', 'desktop-mode' ),
+				getSiteName(),
+			),
+			icon: 'dashicons-category',
+			sort: 10,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: 1: number of selected rows, 2: site title.
+					__( 'Open %1$d items in %2$s', 'desktop-mode' ),
+					n,
+					getSiteName(),
+				),
+			onClick: () => {
+				openDetailInWindow( {
+					entityId: entityIdForPostType( row.postType ),
+					postId: row.postId,
+					postTitle: row.title,
+				} );
+			},
+		},
+	];
+	if ( row.editLink ) {
+		actions.push( {
+			id: 'open-editor',
+			label: __( 'Open in editor', 'desktop-mode' ),
+			icon: 'dashicons-edit',
+			sort: 20,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: %d: number of selected rows.
+					__( 'Open %d items in the editor', 'desktop-mode' ),
+					n,
+				),
+			onClick: () => {
+				window.open( row.editLink, '_blank', 'noopener,noreferrer' );
+			},
+		} );
 	}
-	openContextMenu = null;
+	if ( row.link ) {
+		actions.push( {
+			id: 'open-front',
+			label: __( 'View on site', 'desktop-mode' ),
+			icon: 'dashicons-external',
+			sort: 30,
+			onClick: () => {
+				window.open( row.link, '_blank', 'noopener,noreferrer' );
+			},
+		} );
+	}
+	return actions;
 }
 
 /**
- * Minimal right-click context menu for a usage tile. Mirrors the
- * options the regular post-tile menu offers (open in editor,
- * navigate into) plus an "Open original URL" option that goes to
- * the post on the front-end.
+ * Right-click menu for the usage grid, acting on the current
+ * selection (one row, or several).
  */
 function openUsageTileMenu(
-	row: MediaUsage[ 'usedIn' ][ number ],
+	rows: readonly UsageRow[],
 	pos: { x: number; y: number },
 ): void {
-	closeContextMenu();
-	const menu = document.createElement( 'os-context-menu' );
-	menu.setAttribute( 'open', '' );
-	menu.classList.add( 'os-my-wordpress__menu' );
-	( menu as HTMLElement ).style.left = `${ pos.x }px`;
-	( menu as HTMLElement ).style.top = `${ pos.y }px`;
-
-	const addOption = ( id: string, label: string, icon: string ) => {
-		const opt = document.createElement( 'os-context-menu-option' );
-		( opt as HTMLElement ).dataset.menuItemId = id;
-		opt.setAttribute( 'value', id );
-		opt.setAttribute( 'icon', icon );
-		opt.textContent = label;
-		menu.appendChild( opt );
-	};
-
-	addOption(
-		'navigate-into',
-		sprintf(
-			// translators: %s is the site title.
-			__( 'Open in %s', 'desktop-mode' ),
-			getSiteName(),
-		),
-		'dashicons-category',
-	);
-	if ( row.editLink ) {
-		addOption( 'open-editor', __( 'Open in editor', 'desktop-mode' ), 'dashicons-edit' );
-	}
-	if ( row.link ) {
-		addOption( 'open-front', __( 'View on site', 'desktop-mode' ), 'dashicons-external' );
-	}
-
-	menu.addEventListener( 'os-context-menu-pick', ( e: Event ) => {
-		const detail = ( e as CustomEvent< { id: string } > ).detail;
-		closeContextMenu();
-		if ( detail.id === 'navigate-into' ) {
-			openDetailInWindow( {
-				entityId: entityIdForPostType( row.postType ),
-				postId: row.postId,
-				postTitle: row.title,
-			} );
-			return;
-		}
-		if ( detail.id === 'open-editor' && row.editLink ) {
-			window.open( row.editLink, '_blank', 'noopener,noreferrer' );
-			return;
-		}
-		if ( detail.id === 'open-front' && row.link ) {
-			window.open( row.link, '_blank', 'noopener,noreferrer' );
-		}
-	} );
-
-	document.body.appendChild( menu );
-	openContextMenu = menu;
-
-	// Reposition if menu overflows the viewport.
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		( menu as HTMLElement ).style.left = `${ Math.max(
-			0,
-			window.innerWidth - rect.width - 8,
-		) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		( menu as HTMLElement ).style.top = `${ Math.max(
-			0,
-			window.innerHeight - rect.height - 8,
-		) }px`;
-	}
-
-	queueMicrotask( () => {
-		const onDoc = ( ev: PointerEvent ) => {
-			const target = ev.target;
-			if ( target instanceof Node && menu.contains( target ) ) {
-				return;
-			}
-			closeContextMenu();
-			document.removeEventListener( 'pointerdown', onDoc, true );
-			document.removeEventListener( 'keydown', onKey );
-		};
-		const onKey = ( ev: KeyboardEvent ) => {
-			if ( ev.key === 'Escape' ) {
-				closeContextMenu();
-				document.removeEventListener( 'pointerdown', onDoc, true );
-				document.removeEventListener( 'keydown', onKey );
-			}
-		};
-		document.addEventListener( 'pointerdown', onDoc, true );
-		document.addEventListener( 'keydown', onKey );
+	const actions = resolveCommonActions( rows, buildUsageActions );
+	openActionMenu( pos, {
+		actions,
+		className: 'os-my-wordpress__menu',
+		scope: 'my-wordpress.usage-tile',
 	} );
 }
 
@@ -240,6 +227,7 @@ function paintStatus(
 	statusBar: HTMLElement,
 	count: number,
 	entityId: string,
+	selectedCount = 0,
 ): void {
 	const segments: StatusBarSegment[] = [
 		{
@@ -253,6 +241,18 @@ function paintStatus(
 			sort: 10,
 		},
 	];
+	if ( selectedCount > 0 ) {
+		segments.push( {
+			id: 'selection',
+			label: sprintf(
+				// translators: %d: number of selected rows.
+				__( '%d selected', 'desktop-mode' ),
+				selectedCount,
+			),
+			align: 'end',
+			sort: 5,
+		} );
+	}
 	const filtered = applyFilters<
 		StatusBarSegment[],
 		[ { view: 'media-detail'; entityId: string } ]
@@ -406,8 +406,25 @@ export async function renderMediaDetail(
 	const grid = document.createElement( 'div' );
 	grid.className = 'os-my-wordpress__media-grid os-my-wordpress__usage-grid';
 	grid.setAttribute( 'role', 'list' );
+	const rowsById = new Map< string, UsageRow >();
+	const selection = attachSelection( grid, {
+		background: left,
+		surface: 'my-wordpress',
+		scope: `media-usage:${ entityId }`,
+		keyOf: ( el ) => el.dataset.postId ?? null,
+		onChange: () =>
+			paintStatus(
+				statusBar,
+				usage.usedIn.length,
+				entityId,
+				selection.keys().length,
+			),
+	} );
+	host.addTeardown( () => selection.destroy() );
+
 	for ( const row of usage.usedIn ) {
 		const tile = buildUsageTile( row );
+		rowsById.set( String( row.postId ), row );
 		tile.addEventListener( 'dblclick', ( e ) => {
 			e.preventDefault();
 			openDetailInWindow( {
@@ -418,7 +435,18 @@ export async function renderMediaDetail(
 		} );
 		tile.addEventListener( 'contextmenu', ( e ) => {
 			e.preventDefault();
-			openUsageTileMenu( row, { x: e.clientX, y: e.clientY } );
+			e.stopPropagation();
+			if ( ! selection.model.has( String( row.postId ) ) ) {
+				selection.model.set( [ String( row.postId ) ] );
+			}
+			const rows = selection
+				.keys()
+				.map( ( key ) => rowsById.get( key ) )
+				.filter( ( r ): r is UsageRow => !! r );
+			openUsageTileMenu( rows.length > 0 ? rows : [ row ], {
+				x: e.clientX,
+				y: e.clientY,
+			} );
 		} );
 		grid.appendChild( tile );
 	}

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -20,6 +20,15 @@ import { addAction, applyFilters, removeAction } from '../hooks';
 import { FILE_DROP_HOOKS } from '../os-file-drop/hooks';
 import type { DropUploadResult } from '../os-file-drop/types';
 import { attachTileDragOut, buildTileFromSpec } from '../desktop-files/tile-spec';
+import {
+	attachSelection,
+	closeActionMenu,
+	openActionMenu,
+	resolveCommonActions,
+	type SelectionAction,
+	type SelectionHandle,
+} from '../selection';
+import { copyLinksAction, mediaBulkActions } from './bulk-actions';
 import { osConfirm } from '../ui/components/os-confirm-dialog/os-confirm-dialog';
 import { showToast } from '../toast';
 import type { EntityRenderHost } from './kind-registry';
@@ -49,8 +58,13 @@ interface MediaListContext {
 	tiles: HTMLElement;
 	sentinel: HTMLElement;
 	preview: HTMLElement;
+	/** Id of the ONE selected item, or null for none / several. */
 	selectedId: number | null;
 	selectedTile: HTMLElement | null;
+	/** Multi-selection controller for the media grid. */
+	selection: SelectionHandle | null;
+	/** Every rendered item, by id — the menu builds actions from these. */
+	itemsById: Map< number, MediaListItem >;
 	statusBar: HTMLElement;
 	entity: MyWordPressEntity;
 	host: EntityRenderHost;
@@ -79,7 +93,26 @@ function describeCount( ctx: MediaListContext ): string {
 	);
 }
 
+/**
+ * Right pane with nothing — or several things — selected. A media
+ * preview is about one file; a set gets a count instead.
+ */
+function renderMediaPreviewEmpty( selectedCount: number ): HTMLElement {
+	const empty = document.createElement( 'div' );
+	empty.className = 'os-my-wordpress__preview-empty';
+	empty.textContent =
+		selectedCount > 1
+			? sprintf(
+				// translators: %d: number of selected media items.
+				__( '%d files selected', 'desktop-mode' ),
+				selectedCount,
+			)
+			: __( 'Select a media item to preview it here.', 'desktop-mode' );
+	return empty;
+}
+
 function paintStatus( ctx: MediaListContext ): void {
+	const selectedCount = ctx.selection?.keys().length ?? 0;
 	const segments: StatusBarSegment[] = [
 		{
 			id: 'count',
@@ -88,6 +121,18 @@ function paintStatus( ctx: MediaListContext ): void {
 			sort: 10,
 		},
 	];
+	if ( selectedCount > 0 ) {
+		segments.push( {
+			id: 'selection',
+			label: sprintf(
+				// translators: %d: number of selected media items.
+				__( '%d selected', 'desktop-mode' ),
+				selectedCount,
+			),
+			align: 'end',
+			sort: 5,
+		} );
+	}
 	if ( ctx.totalPages > 1 ) {
 		segments.push( {
 			id: 'page',
@@ -144,30 +189,70 @@ function buildMediaTile(
 		],
 	} );
 
-	attachTileDragOut( tile, {
-		kind: 'attachment',
-		ref: String( media.id ),
-		title: titleText,
-		icon: dashiconForMime( media.mime_type ),
-		// Cross-frame bridge payload — lets the Gutenberg drop-
-		// receiver build a `core/image` / `core/video` / `core/audio`
-		// / `core/file` block when this tile is dropped on an open
-		// editor iframe. The full-size source URL is the right block
-		// attribute regardless of mime; the receiver picks the
-		// concrete block from the MIME prefix.
-		bridgePayload: {
+	attachTileDragOut(
+		tile,
+		{
 			kind: 'attachment',
-			id: media.id,
-			url: media.source_url,
+			ref: String( media.id ),
 			title: titleText,
-			alt: stripTags( media.alt_text ?? '' ),
-			mime: media.mime_type,
-			thumbnailUrl: thumbUrl || undefined,
-			sizes: media.media_details?.sizes,
+			icon: dashiconForMime( media.mime_type ),
+			// Cross-frame bridge payload — lets the Gutenberg drop-
+			// receiver build a `core/image` / `core/video` / `core/audio`
+			// / `core/file` block when this tile is dropped on an open
+			// editor iframe. The full-size source URL is the right block
+			// attribute regardless of mime; the receiver picks the
+			// concrete block from the MIME prefix.
+			bridgePayload: {
+				kind: 'attachment',
+				id: media.id,
+				url: media.source_url,
+				title: titleText,
+				alt: stripTags( media.alt_text ?? '' ),
+				mime: media.mime_type,
+				thumbnailUrl: thumbUrl || undefined,
+				sizes: media.media_details?.sizes,
+			},
 		},
-	} );
+		undefined,
+		{
+			// Multi-drag: drop a selection of files on a folder and
+			// every one of them is filed.
+			resolveSet: () => {
+				const keys = ctx.selection?.keys() ?? [];
+				if ( keys.length < 2 ) {
+					return [];
+				}
+				return keys
+					.map( ( key ) => ctx.itemsById.get( Number( key ) ) )
+					.filter( ( m ): m is MediaListItem => !! m )
+					.map( ( m ) => ( {
+						kind: 'attachment',
+						ref: String( m.id ),
+						title:
+							stripTags( m.title.rendered ) ||
+							__( '(no title)', 'desktop-mode' ),
+						icon: dashiconForMime( m.mime_type ),
+						entityId: ctx.entity.id,
+						bridgePayload: {
+							kind: 'attachment' as const,
+							id: m.id,
+							url: m.source_url,
+							title:
+								stripTags( m.title.rendered ) ||
+								__( '(no title)', 'desktop-mode' ),
+							alt: stripTags( m.alt_text ?? '' ),
+							mime: m.mime_type,
+							sizes: m.media_details?.sizes,
+						},
+					} ) );
+			},
+		},
+	);
 
-	tile.addEventListener( 'click', () => selectTile( ctx, tile, media ) );
+	// Selection is the controller's job; the tile only registers its
+	// shape so a multi-selection menu can build actions for it.
+	ctx.itemsById.set( media.id, media );
+	tile.dataset.mediaId = String( media.id );
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
 		ctx.host.navigate( {
@@ -180,7 +265,13 @@ function buildMediaTile(
 
 	tile.addEventListener( 'contextmenu', ( e ) => {
 		e.preventDefault();
-		openMediaTileMenu( ctx, tile, media, titleText, {
+		e.stopPropagation();
+		// Finder rule: right-clicking outside the selection replaces
+		// it; inside it, the set stands and the menu acts on all of it.
+		if ( ! ctx.selection?.model.has( String( media.id ) ) ) {
+			ctx.selection?.model.set( [ String( media.id ) ] );
+		}
+		openMediaTileMenu( ctx, media, {
 			x: ( e as MouseEvent ).clientX,
 			y: ( e as MouseEvent ).clientY,
 		} );
@@ -194,47 +285,54 @@ interface MediaTileMenuOption {
 	label: string;
 	icon: string;
 	danger?: boolean;
+	/** Lower sorts first. Only consulted for a multi-selection. */
+	sort?: number;
+	multi?: boolean;
+	bulkLabel?: ( count: number ) => string;
 	onSelect?: ( () => void ) | null;
 }
 
 /**
- * Build + position the right-click menu for a media tile. Mirrors
- * `openTileMenu()` in `my-wordpress/index.ts` — same `<os-context-menu>`
- * shape, same dismiss handling — so plugin authors only have to learn
- * one pattern.
+ * Actions for ONE media item, with the shared
+ * `os.my-wordpress.tile-context-menu` filter applied (kind
+ * `'attachment'`). `resolveCommonActions` calls this once per
+ * selected tile and intersects the results.
+ *
+ * "Open file in new tab" is deliberately single-item: browsers block
+ * a burst of `window.open` calls as a popup storm, so a multi-item
+ * version would silently open one file and drop the rest.
  */
-function openMediaTileMenu(
+function buildMediaActions(
 	ctx: MediaListContext,
-	tile: HTMLElement,
 	media: MediaListItem,
 	titleText: string,
-	pos: { x: number; y: number },
-): void {
-	closeAnyMediaTileMenu();
-	selectTile( ctx, tile, media );
-
-	const menu = document.createElement( 'os-context-menu' );
-	menu.setAttribute( 'open', '' );
-	menu.classList.add( 'os-my-wordpress__menu' );
-	( menu as HTMLElement ).style.left = `${ pos.x }px`;
-	( menu as HTMLElement ).style.top = `${ pos.y }px`;
-
+): SelectionAction< MediaListItem >[] {
 	const base: MediaTileMenuOption[] = [
 		{
 			id: 'navigate-into',
 			label: __( 'Navigate into', 'desktop-mode' ),
 			icon: 'dashicons-category',
+			sort: 10,
 		},
 		{
 			id: 'open-source',
 			label: __( 'Open file in new tab', 'desktop-mode' ),
 			icon: 'dashicons-external',
+			sort: 20,
 		},
 		{
 			id: 'delete',
 			label: __( 'Delete permanently', 'desktop-mode' ),
 			icon: 'dashicons-trash',
+			sort: 90,
 			danger: true,
+			multi: true,
+			bulkLabel: ( n ) =>
+				sprintf(
+					// translators: %d: number of selected media items.
+					__( 'Delete %d files permanently', 'desktop-mode' ),
+					n,
+				),
 		},
 	];
 
@@ -253,93 +351,133 @@ function openMediaTileMenu(
 	);
 	const finalOptions = Array.isArray( options ) ? options : base;
 
-	for ( const o of finalOptions ) {
-		const opt = document.createElement( 'os-context-menu-option' );
-		( opt as HTMLElement ).dataset.menuItemId = o.id;
-		opt.setAttribute( 'value', o.id );
-		opt.setAttribute( 'icon', o.icon );
-		if ( o.danger ) {
-			opt.setAttribute( 'danger', '' );
-		}
-		opt.textContent = o.label;
-		menu.appendChild( opt );
-	}
+	// Core's own media row actions that survive a set — Detach, plus
+	// the shared "Copy link". Built apart from `finalOptions` because
+	// they carry closures and batched runners.
+	const extras: SelectionAction< MediaListItem >[] = [
+		...mediaBulkActions(
+			{
+				onChanged: ( ids ) => {
+					// Detach doesn't remove the tile, but it changes
+					// what the preview says about the file.
+					for ( const id of ids ) {
+						const item = ctx.itemsById.get( id );
+						if ( item ) {
+							item.post = 0;
+						}
+					}
+					const selected = ctx.selection?.keys() ?? [];
+					if ( selected.length === 1 ) {
+						const item = ctx.itemsById.get(
+							Number( selected[ 0 ] ),
+						);
+						if ( item ) {
+							previewSelectedMedia( ctx, item );
+						}
+					}
+				},
+			},
+			media,
+		),
+		copyLinksAction(
+			media,
+			( m ) => m.source_url,
+			__( 'Copy file URL', 'desktop-mode' ),
+		),
+	];
 
-	menu.addEventListener( 'os-context-menu-pick', ( e: Event ) => {
-		const detail = ( e as CustomEvent< { id: string } > ).detail;
-		closeAnyMediaTileMenu();
-		if ( detail.id === 'navigate-into' ) {
-			ctx.host.navigate( {
-				kind: 'media-detail',
-				entityId: ctx.entity.id,
-				mediaId: media.id,
-				mediaTitle: titleText,
-			} );
-			return;
+	const mapped = finalOptions.map( ( option ) => {
+		const action: SelectionAction< MediaListItem > = {
+			id: option.id,
+			label: option.label,
+			icon: option.icon,
+			sort: option.sort,
+			danger: option.danger,
+			multi: option.multi,
+			bulkLabel: option.bulkLabel,
+			onClick: () => {
+				if ( option.id === 'navigate-into' ) {
+					ctx.host.navigate( {
+						kind: 'media-detail',
+						entityId: ctx.entity.id,
+						mediaId: media.id,
+						mediaTitle: titleText,
+					} );
+					return;
+				}
+				if ( option.id === 'open-source' ) {
+					window.open(
+						media.source_url,
+						'_blank',
+						'noopener,noreferrer',
+					);
+					return;
+				}
+				if ( option.id === 'delete' ) {
+					void confirmDeleteMedia( ctx, media, titleText );
+					return;
+				}
+				if ( typeof option.onSelect === 'function' ) {
+					try {
+						option.onSelect();
+					} catch ( err ) {
+						// eslint-disable-next-line no-console
+						console.error(
+							`[my-wordpress/media] tile-context-menu '${ option.id }' onSelect threw:`,
+							err,
+						);
+					}
+				}
+			},
+		};
+		if ( option.id === 'delete' ) {
+			action.bulk = ( items ) => deleteManyMedia( ctx, items );
 		}
-		if ( detail.id === 'open-source' ) {
-			window.open( media.source_url, '_blank', 'noopener,noreferrer' );
-			return;
-		}
-		if ( detail.id === 'delete' ) {
-			void confirmDeleteMedia( ctx, tile, media, titleText );
-			return;
-		}
-		const match = finalOptions.find( ( o ) => o.id === detail.id );
-		if ( match && typeof match.onSelect === 'function' ) {
-			try {
-				match.onSelect();
-			} catch ( err ) {
-				// eslint-disable-next-line no-console
-				console.error(
-					`[my-wordpress/media] tile-context-menu '${ detail.id }' onSelect threw:`,
-					err,
-				);
-			}
-		}
+		return action;
 	} );
 
-	document.body.appendChild( menu );
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		( menu as HTMLElement ).style.left = `${ Math.max(
-			0,
-			window.innerWidth - rect.width - 8,
-		) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		( menu as HTMLElement ).style.top = `${ Math.max(
-			0,
-			window.innerHeight - rect.height - 8,
-		) }px`;
-	}
+	return [ ...mapped, ...extras ].sort( ( a, b ) => {
+		const sa = typeof a.sort === 'number' ? a.sort : 100;
+		const sb = typeof b.sort === 'number' ? b.sort : 100;
+		return sa - sb;
+	} );
+}
 
-	queueMicrotask( () => {
-		const onDocPointerDown = ( ev: PointerEvent ) => {
-			if ( ev.target instanceof Node && menu.contains( ev.target ) ) {
-				return;
-			}
-			closeAnyMediaTileMenu();
-		};
-		const onDocKey = ( ev: KeyboardEvent ) => {
-			if ( ev.key === 'Escape' ) {
-				closeAnyMediaTileMenu();
-			}
-		};
-		document.addEventListener( 'pointerdown', onDocPointerDown, true );
-		document.addEventListener( 'keydown', onDocKey );
-		menu.addEventListener( 'tile-menu-closed', () => {
-			document.removeEventListener(
-				'pointerdown',
-				onDocPointerDown,
-				true,
-			);
-			document.removeEventListener( 'keydown', onDocKey );
-		} );
+/** Open the media context menu for the current selection. */
+function openMediaTileMenu(
+	ctx: MediaListContext,
+	media: MediaListItem,
+	pos: { x: number; y: number },
+): void {
+	closeAnyMediaTileMenu();
+
+	const ids = ( ctx.selection?.keys() ?? [] )
+		.map( ( k ) => parseInt( k, 10 ) )
+		.filter( ( n ) => Number.isFinite( n ) );
+	const targets = ids
+		.map( ( id ) => ctx.itemsById.get( id ) )
+		.filter( ( m ): m is MediaListItem => !! m );
+	const items = targets.length > 0 ? targets : [ media ];
+
+	const actions = resolveCommonActions( items, ( item ) =>
+		buildMediaActions(
+			ctx,
+			item,
+			stripTags( item.title.rendered ) ||
+				__( '(no title)', 'desktop-mode' ),
+		),
+	);
+
+	openActionMenu( pos, {
+		actions,
+		className: 'os-my-wordpress__menu',
+		scope: 'my-wordpress.media-tile',
+		dataset: { mediaIds: items.map( ( m ) => m.id ).join( ',' ) },
 	} );
 }
 
 function closeAnyMediaTileMenu(): void {
+	closeActionMenu();
 	document
 		.querySelectorAll( 'os-context-menu.os-my-wordpress__menu' )
 		.forEach( ( n ) => {
@@ -348,9 +486,76 @@ function closeAnyMediaTileMenu(): void {
 		} );
 }
 
+/**
+ * Delete several media items as one action: one confirm, parallel
+ * REST, one toast. Permanent deletion has no Undo, which is exactly
+ * why it must not ask N times — a user clicking through N dialogs
+ * stops reading them by the third.
+ */
+async function deleteManyMedia(
+	ctx: MediaListContext,
+	items: readonly MediaListItem[],
+): Promise< void > {
+	const ok = await osConfirm( {
+		title: __( 'Delete media?', 'desktop-mode' ),
+		message: sprintf(
+			// translators: %d: number of selected media items.
+			__(
+				'%d files will be permanently deleted. This cannot be undone.',
+				'desktop-mode',
+			),
+			items.length,
+		),
+		confirmLabel: __( 'Delete', 'desktop-mode' ),
+		cancelLabel: __( 'Cancel', 'desktop-mode' ),
+		danger: true,
+	} );
+	if ( ! ok ) {
+		return;
+	}
+
+	const results = await Promise.allSettled(
+		items.map( ( item ) => deleteMediaItem( item.id ) ),
+	);
+	let deleted = 0;
+	let failed = 0;
+	results.forEach( ( result, index ) => {
+		if ( result.status === 'fulfilled' ) {
+			deleted += 1;
+			const tile = ctx.tiles.querySelector< HTMLElement >(
+				`[data-media-id="${ items[ index ].id }"]`,
+			);
+			if ( tile ) {
+				removeMediaFromList( ctx, tile, items[ index ].id );
+			}
+		} else {
+			failed += 1;
+		}
+	} );
+	ctx.selection?.refresh();
+
+	showToast( {
+		message:
+			failed > 0
+				? sprintf(
+					// translators: 1: number deleted, 2: number that failed.
+					__(
+						'%1$d files deleted · %2$d could not be deleted',
+						'desktop-mode',
+					),
+					deleted,
+					failed,
+				)
+				: sprintf(
+					// translators: %d: number of files deleted.
+					__( '%d files deleted.', 'desktop-mode' ),
+					deleted,
+				),
+	} );
+}
+
 async function confirmDeleteMedia(
 	ctx: MediaListContext,
-	tile: HTMLElement,
 	media: MediaListItem,
 	titleText: string,
 ): Promise< void > {
@@ -370,7 +575,13 @@ async function confirmDeleteMedia(
 	}
 	try {
 		await deleteMediaItem( media.id );
-		removeMediaFromList( ctx, tile, media.id );
+		const tile = ctx.tiles.querySelector< HTMLElement >(
+			`[data-media-id="${ media.id }"]`,
+		);
+		if ( tile ) {
+			removeMediaFromList( ctx, tile, media.id );
+		}
+		ctx.selection?.refresh();
 		showToast( { message: __( 'Media deleted.', 'desktop-mode' ) } );
 	} catch ( err ) {
 		const message =
@@ -405,22 +616,15 @@ function removeMediaFromList(
 	paintStatus( ctx );
 }
 
-function selectTile(
+/**
+ * Paint the right pane for the ONE selected media item. Selection
+ * itself (and the `selected` attribute on tiles) belongs to the
+ * controller; this is only the preview half.
+ */
+function previewSelectedMedia(
 	ctx: MediaListContext,
-	tile: HTMLElement,
 	media: MediaListItem,
 ): void {
-	// Selected state lives on the `selected` attribute — `<os-tile>`
-	// derives the `--selected` class from it on every `_paint()`.
-	// Toggling the class directly would be wiped out by the next
-	// repaint (label edit, thumbnail swap, hover-title toggle…).
-	if ( ctx.selectedTile ) {
-		ctx.selectedTile.removeAttribute( 'selected' );
-	}
-	tile.setAttribute( 'selected', '' );
-	ctx.selectedTile = tile;
-	ctx.selectedId = media.id;
-
 	const titleText =
 		stripTags( media.title.rendered ) || __( '(no title)', 'desktop-mode' );
 	renderMediaPreview( ctx.preview, media, {
@@ -522,6 +726,8 @@ export function renderMediaList(
 		preview: right,
 		selectedId: null,
 		selectedTile: null,
+		selection: null,
+		itemsById: new Map(),
 		statusBar,
 		entity,
 		host,
@@ -529,6 +735,35 @@ export function renderMediaList(
 		query: initialQuery,
 		abort: null,
 	};
+
+	ctx.selection = attachSelection( tiles, {
+		background: left,
+		surface: 'my-wordpress',
+		scope: entity.id,
+		keyOf: ( el ) => el.dataset.mediaId ?? null,
+		onChange: ( keys ) => {
+			const ids = keys
+				.map( ( k ) => parseInt( k, 10 ) )
+				.filter( ( n ) => Number.isFinite( n ) );
+			ctx.selectedId = ids.length === 1 ? ids[ 0 ] : null;
+			ctx.selectedTile =
+				ids.length === 1
+					? ctx.selection?.elementFor( String( ids[ 0 ] ) ) ?? null
+					: null;
+			if ( ids.length === 1 ) {
+				const media = ctx.itemsById.get( ids[ 0 ] );
+				if ( media ) {
+					previewSelectedMedia( ctx, media );
+				}
+			} else {
+				ctx.preview.replaceChildren(
+					renderMediaPreviewEmpty( ids.length ),
+				);
+			}
+			paintStatus( ctx );
+		},
+	} );
+	host.addTeardown( () => ctx.selection?.destroy() );
 	host.addTeardown( () => ctx.abort?.abort() );
 
 	const sentinelIsVisible = (): boolean => {

--- a/src/my-wordpress/media-rest.ts
+++ b/src/my-wordpress/media-rest.ts
@@ -80,9 +80,12 @@ export async function fetchMediaPage(
 	const url = new URL( buildUrl( entity.restPath ) );
 	url.searchParams.set( 'page', String( params.page ) );
 	url.searchParams.set( 'per_page', String( params.perPage ) );
+	// `post` is the attachment's parent. It costs nothing to ask for
+	// and it is what decides whether the Detach action applies to a
+	// file — without it here, Detach could never appear.
 	url.searchParams.set(
 		'_fields',
-		'id,title,date,mime_type,source_url,alt_text,caption,description,author,media_details,_embedded',
+		'id,title,date,mime_type,source_url,alt_text,caption,description,author,post,media_details,_embedded',
 	);
 	url.searchParams.set( '_embed', 'author' );
 	url.searchParams.set( 'orderby', 'date' );
@@ -174,6 +177,37 @@ export async function deleteMediaItem( mediaId: number ): Promise< void > {
 	if ( ! response.ok ) {
 		throw new Error(
 			await readErrorMessage( response, 'Failed to delete media item' ),
+		);
+	}
+}
+
+/**
+ * Patch an attachment.
+ *
+ * Used by the bulk actions for two of core's own media operations:
+ * "Detach" (`post: 0`, the same thing the media list table's Detach
+ * row action does) and re-attributing an author.
+ *
+ * @public
+ */
+export async function updateMediaItem(
+	mediaId: number,
+	body: Record< string, unknown >,
+): Promise< void > {
+	const cfg = getConfig();
+	const response = await shellFetch( buildUrl( `wp/v2/media/${ mediaId }` ), {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( body ),
+	} );
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to update media item' ),
 		);
 	}
 }

--- a/src/my-wordpress/rest.ts
+++ b/src/my-wordpress/rest.ts
@@ -206,6 +206,269 @@ export async function trashEntity(
 	}
 }
 
+/**
+ * Fields a bulk edit needs to read before it can write.
+ *
+ * Categories and tags are ADDITIVE in WordPress's own bulk edit — the
+ * terms you pick are added to whatever each post already has, never
+ * replacing them. The REST API only takes the full array, so we have
+ * to know the current one per post. `sticky` and `comment_status`
+ * come along because the modal pre-reads nothing else about them.
+ */
+export interface EntityBulkFields {
+	id: number;
+	categories?: number[];
+	tags?: number[];
+	sticky?: boolean;
+	comment_status?: string;
+	author?: number;
+}
+
+/**
+ * Read the taxonomy + flag state for a set of entries in ONE request.
+ *
+ * A post type that has no categories or tags simply omits those keys
+ * from the response, which is how the bulk-edit modal decides whether
+ * to render those controls at all — no separate capability probe.
+ */
+export async function fetchEntityBulkFields(
+	entity: MyWordPressEntity,
+	ids: readonly number[],
+): Promise< EntityBulkFields[] > {
+	if ( ids.length === 0 ) {
+		return [];
+	}
+	const cfg = getConfig();
+	const read = async ( context: 'edit' | 'view' ): Promise< Response > => {
+		const url = new URL( buildUrl( entity.restPath ) );
+		url.searchParams.set( 'include', ids.join( ',' ) );
+		url.searchParams.set(
+			'per_page',
+			String( Math.min( ids.length, 100 ) ),
+		);
+		url.searchParams.set( 'context', context );
+		url.searchParams.set(
+			'_fields',
+			'id,categories,tags,sticky,comment_status,author',
+		);
+		url.searchParams.set(
+			'status',
+			'publish,future,draft,pending,private',
+		);
+		return shellFetch( url.toString(), {
+			method: 'GET',
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': cfg.restNonce,
+				Accept: 'application/json',
+			},
+		} );
+	};
+
+	// `context=edit` carries `sticky` and `comment_status`, but the
+	// collection endpoint refuses it outright for a viewer who may not
+	// edit the post type at all. Fall back to the view context rather
+	// than failing the whole bulk edit: the taxonomy merge only needs
+	// `categories` / `tags`, which come back either way, and any field
+	// the viewer may not write is rejected per-row at write time
+	// anyway.
+	let response = await read( 'edit' );
+	if ( response.status === 401 || response.status === 403 ) {
+		response = await read( 'view' );
+	}
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to read entries' ),
+		);
+	}
+	return ( await response.json() ) as EntityBulkFields[];
+}
+
+/**
+ * Patch one entry. WordPress's REST API takes POST for updates (not
+ * PATCH), which is what core's own editor sends.
+ */
+export async function updateEntity(
+	entity: MyWordPressEntity,
+	id: number,
+	body: Record< string, unknown >,
+): Promise< void > {
+	const cfg = getConfig();
+	const response = await shellFetch(
+		buildUrl( `${ entity.restPath }/${ id }` ),
+		{
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': cfg.restNonce,
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( body ),
+		},
+	);
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to update entry' ),
+		);
+	}
+}
+
+/** One term as the bulk-edit pickers need it. */
+export interface TermOption {
+	id: number;
+	name: string;
+	parent: number;
+}
+
+/**
+ * Load a taxonomy's terms for the bulk-edit pickers. Capped at 100 —
+ * the pickers are for choosing, not for browsing a folksonomy, and
+ * the tag input has its own search-as-you-type path for the tail.
+ */
+export async function fetchTaxonomyTerms(
+	taxonomy: 'categories' | 'tags',
+	search = '',
+): Promise< TermOption[] > {
+	const cfg = getConfig();
+	const url = new URL( buildUrl( `wp/v2/${ taxonomy }` ) );
+	url.searchParams.set( 'per_page', '100' );
+	url.searchParams.set( '_fields', 'id,name,parent' );
+	url.searchParams.set( 'orderby', 'name' );
+	url.searchParams.set( 'order', 'asc' );
+	if ( search ) {
+		url.searchParams.set( 'search', search );
+	}
+	const response = await shellFetch( url.toString(), {
+		method: 'GET',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+		},
+	} );
+	if ( ! response.ok ) {
+		return [];
+	}
+	const rows = ( await response.json() ) as Array< {
+		id: number;
+		name: string;
+		parent?: number;
+	} >;
+	return rows.map( ( r ) => ( {
+		id: r.id,
+		name: r.name,
+		parent: r.parent ?? 0,
+	} ) );
+}
+
+/** Create a tag by name, returning its id. Used by the tag input. */
+export async function createTag( name: string ): Promise< TermOption | null > {
+	const cfg = getConfig();
+	const response = await shellFetch( buildUrl( 'wp/v2/tags' ), {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( { name } ),
+	} );
+	if ( ! response.ok ) {
+		return null;
+	}
+	const row = ( await response.json() ) as { id: number; name: string };
+	return { id: row.id, name: row.name, parent: 0 };
+}
+
+/** Users who can be assigned as an author. */
+export async function fetchAuthors(): Promise<
+	Array< { id: number; name: string } >
+	> {
+	const cfg = getConfig();
+	const url = new URL( buildUrl( 'wp/v2/users' ) );
+	url.searchParams.set( 'per_page', '100' );
+	url.searchParams.set( '_fields', 'id,name' );
+	url.searchParams.set( 'orderby', 'name' );
+	url.searchParams.set( 'order', 'asc' );
+	// `who=authors` is deprecated in favour of a capability query;
+	// asking for the edit context keeps the list to users the viewer
+	// may actually assign.
+	url.searchParams.set( 'context', 'view' );
+	const response = await shellFetch( url.toString(), {
+		method: 'GET',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+		},
+	} );
+	if ( ! response.ok ) {
+		return [];
+	}
+	return ( await response.json() ) as Array< { id: number; name: string } >;
+}
+
+/** Patch a user (role changes). */
+export async function updateUser(
+	id: number,
+	body: Record< string, unknown >,
+): Promise< void > {
+	const cfg = getConfig();
+	const response = await shellFetch( buildUrl( `wp/v2/users/${ id }` ), {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( body ),
+	} );
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to update user' ),
+		);
+	}
+}
+
+/**
+ * Delete a user.
+ *
+ * WordPress has no trash for users, so the REST endpoint requires
+ * `force=true` — and it requires an answer to "what happens to their
+ * content": omit `reassign` and every post they wrote is deleted with
+ * them; pass a user id and it is attributed to that user instead.
+ * Core's own delete screen asks exactly this question, and so does
+ * ours.
+ */
+export async function deleteUser(
+	id: number,
+	reassign: number | null,
+): Promise< void > {
+	const cfg = getConfig();
+	const url = new URL( buildUrl( `wp/v2/users/${ id }` ) );
+	url.searchParams.set( 'force', 'true' );
+	url.searchParams.set(
+		'reassign',
+		reassign === null ? 'false' : String( reassign ),
+	);
+	const response = await shellFetch( url.toString(), {
+		method: 'DELETE',
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': cfg.restNonce,
+			Accept: 'application/json',
+		},
+	} );
+	if ( ! response.ok ) {
+		throw new Error(
+			await readErrorMessage( response, 'Failed to delete user' ),
+		);
+	}
+}
+
 async function readErrorMessage(
 	response: Response,
 	fallback: string,

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -470,6 +470,11 @@ export interface MediaListItem {
 	caption?: { rendered: string };
 	description?: { rendered: string };
 	author?: number;
+	/**
+	 * Parent post id — 0 when the file is unattached. Drives the
+	 * Detach action, which is meaningless for a file with no parent.
+	 */
+	post?: number;
 	media_details?: {
 		width?: number;
 		height?: number;

--- a/src/selection/actions.ts
+++ b/src/selection/actions.ts
@@ -173,21 +173,67 @@ export function resolveCommonActions< T >(
 			sort: Math.min( ...contributors.map( sortValue ) ),
 			multi: true,
 			onClick: async ( e: MouseEvent ) => {
-				if ( typeof primary.bulk === 'function' ) {
-					await primary.bulk( items.slice() );
-					return;
+				/*
+				 * Every item goes to the runner ITS OWN contributor
+				 * declared — never to whichever contributor happened
+				 * to be first.
+				 *
+				 * `multiId` merges actions that are the same deed
+				 * under different labels, and there is no rule that
+				 * they share an implementation: the folder tile's
+				 * "Move folder to Trash" and the file tile's "Move to
+				 * Trash" merge, and a plugin could merge a third with
+				 * a runner of its own. Handing the whole heterogeneous
+				 * set to `contributors[0].bulk` would push folders
+				 * through the file implementation — or silently drop
+				 * them — and which one "won" would depend on the
+				 * visual order the user happened to select in.
+				 *
+				 * So: group by runner identity, call each once with
+				 * the items it was declared for. Contributors that
+				 * ship no `bulk` fan out through their own `onClick`.
+				 * When every contributor points at the same function
+				 * — which is what the built-ins do — this is exactly
+				 * one call with the whole set, as before.
+				 */
+				const batches = new Map< NonNullable< SelectionAction< T >[ 'bulk' ] >, T[] >();
+				const singles: Array< SelectionAction< T > > = [];
+				contributors.forEach( ( contributor, index ) => {
+					const runner = contributor.bulk;
+					if ( typeof runner !== 'function' ) {
+						singles.push( contributor );
+						return;
+					}
+					const batch = batches.get( runner );
+					if ( batch ) {
+						batch.push( items[ index ] );
+					} else {
+						batches.set( runner, [ items[ index ] ] );
+					}
+				} );
+
+				for ( const [ runner, batch ] of batches ) {
+					try {
+						await runner( batch );
+					} catch ( err ) {
+						// eslint-disable-next-line no-console
+						console.error(
+							`[openstation] selection action '${ key }' failed for a batch:`,
+							err,
+						);
+					}
 				}
 				// Fan-out. Sequential, not parallel: these are the
 				// surface's own single-item handlers, and several of
 				// them open windows or write settings where ordering
 				// is visible to the user.
-				for ( const contributor of contributors ) {
+				for ( const contributor of singles ) {
 					try {
 						await contributor.onClick( e );
 					} catch ( err ) {
 						// eslint-disable-next-line no-console
 						console.error(
-							`[openstation] selection action '${ primary.id }' failed for one item:`,
+							`[openstation] selection action '${ key }' failed for one item:`,
 							err,
 						);
 					}

--- a/src/selection/actions.ts
+++ b/src/selection/actions.ts
@@ -1,0 +1,211 @@
+/**
+ * OpenStation — "what can I do with THESE?"
+ *
+ * The framework's half of the multi-selection contract. Each surface
+ * already knows how to answer *"what can be done to this one thing?"*
+ * — that's its existing tile-menu builder, filters and all. This
+ * module answers the other question, once, for every surface:
+ * *"what do these N things have in common?"*
+ *
+ * The rule, in full:
+ *
+ *   - One item selected → its own action list, untouched. Single-item
+ *     menus are exactly what they were before multi-selection existed.
+ *   - More than one → intersect by action `id`, and keep an id only
+ *     when EVERY contributing action declares `multi: true`.
+ *
+ * `multi` is opt-in on purpose. A third-party action written against
+ * one item — "Share folder…", "Rename…", anything that opens a modal
+ * — would misbehave run twelve times over, and the plugin author
+ * never agreed to that. Opting in is one field; opting in wrongly is
+ * a bug the author can see in their own code.
+ *
+ * Execution has two modes. An action that ships a `bulk( items )`
+ * runner gets called once with the whole set — that's how "Move to
+ * Trash" produces one toast with one Undo instead of N of each.
+ * Everything else fans out: each contributor's OWN `onClick` closure
+ * runs in turn. That closure already captured its item, which is why
+ * fan-out needs no cooperation from the surface that built it.
+ */
+
+import { applyFilters } from '../hooks';
+import { __, sprintf } from '../i18n';
+
+/**
+ * One action offered for one item. A superset of the `TileMenuItem`
+ * shape the file-tile menu has always used, so existing builders
+ * satisfy it as-is and only opt into the new fields when they mean
+ * to.
+ *
+ * @public
+ */
+export interface SelectionAction< T = unknown > {
+	/** Stable id. Also the intersection key unless `multiId` says otherwise. */
+	id: string;
+	/**
+	 * Identity to intersect on when several items are selected.
+	 * Defaults to `id`.
+	 *
+	 * This exists because the same *deed* can carry different
+	 * single-item labels: a folder tile offers `delete-folder`
+	 * ("Move folder to Trash") and a file tile offers `remove`
+	 * ("Move to Trash"). Selecting one of each is a perfectly
+	 * ordinary thing to do, and intersecting on the raw ids would
+	 * leave that selection with nothing to do. Both declare
+	 * `multiId: 'trash'` and merge.
+	 */
+	multiId?: string;
+	label: string;
+	/** Dashicon class. */
+	icon?: string;
+	/** Lower sorts first. Defaults to 100. */
+	sort?: number;
+	disabled?: boolean;
+	danger?: boolean;
+	/** Handler for this one item. Always present. */
+	onClick: ( e: MouseEvent ) => void | Promise< void >;
+	/**
+	 * Whether this action is safe to apply to a whole selection.
+	 * Defaults to `false` — an action reaches a multi-selection menu
+	 * only when it says so.
+	 */
+	multi?: boolean;
+	/**
+	 * Label for a set. Receives the count. Falls back to
+	 * `"<label> (N items)"`.
+	 */
+	bulkLabel?: ( count: number ) => string;
+	/**
+	 * Batched runner. When present it replaces the per-item fan-out
+	 * and is called ONCE with every selected item.
+	 */
+	bulk?: ( items: T[] ) => void | Promise< void >;
+}
+
+/** Context handed to the `os.selection.actions` filter. */
+export interface SelectionActionsContext< T > {
+	items: readonly T[];
+	count: number;
+}
+
+function sortValue( action: { sort?: number } ): number {
+	return typeof action.sort === 'number' ? action.sort : 100;
+}
+
+/**
+ * Default label for a set, used when an action ships no `bulkLabel`.
+ * Kept out of line so every surface pluralizes identically.
+ */
+function defaultBulkLabel( label: string, count: number ): string {
+	return sprintf(
+		/* translators: 1: action label, e.g. "Open". 2: number of selected items. */
+		__( '%1$s (%2$d items)', 'desktop-mode' ),
+		label,
+		count,
+	);
+}
+
+/**
+ * Resolve the actions to offer for a selection.
+ *
+ * `actionsFor` is called once per item — surfaces can build lazily
+ * and apply their own filters inside it without worrying about
+ * repeat work.
+ *
+ * @public
+ */
+export function resolveCommonActions< T >(
+	items: readonly T[],
+	actionsFor: ( item: T ) => SelectionAction< T >[],
+): SelectionAction< T >[] {
+	if ( items.length === 0 ) {
+		return [];
+	}
+
+	const lists = items.map( ( item ) => {
+		const list = actionsFor( item );
+		return Array.isArray( list ) ? list : [];
+	} );
+
+	// Single selection — hand back the surface's own list verbatim.
+	// No intersection, no relabelling, no filter: the single-item
+	// menu is the one that already existed.
+	if ( items.length === 1 ) {
+		return lists[ 0 ];
+	}
+
+	const count = items.length;
+	const common: SelectionAction< T >[] = [];
+	const keyOf = ( action: SelectionAction< T > ): string =>
+		action.multiId ?? action.id;
+
+	for ( const candidate of lists[ 0 ] ) {
+		const key = keyOf( candidate );
+		const contributors: SelectionAction< T >[] = [];
+		let missing = false;
+		for ( const list of lists ) {
+			const match = list.find( ( a ) => keyOf( a ) === key );
+			if ( ! match || match.multi !== true ) {
+				missing = true;
+				break;
+			}
+			contributors.push( match );
+		}
+		if ( missing || common.some( ( a ) => a.id === key ) ) {
+			continue;
+		}
+
+		const primary = contributors[ 0 ];
+		const label = primary.bulkLabel
+			? primary.bulkLabel( count )
+			: defaultBulkLabel( primary.label, count );
+
+		common.push( {
+			id: key,
+			label,
+			icon: primary.icon,
+			// Least-forgiving wins: one disabled contributor disables
+			// the set, one danger contributor marks the whole thing
+			// destructive. Both err toward telling the user less will
+			// happen than they asked for, never more.
+			disabled: contributors.some( ( a ) => a.disabled === true ),
+			danger: contributors.some( ( a ) => a.danger === true ),
+			sort: Math.min( ...contributors.map( sortValue ) ),
+			multi: true,
+			onClick: async ( e: MouseEvent ) => {
+				if ( typeof primary.bulk === 'function' ) {
+					await primary.bulk( items.slice() );
+					return;
+				}
+				// Fan-out. Sequential, not parallel: these are the
+				// surface's own single-item handlers, and several of
+				// them open windows or write settings where ordering
+				// is visible to the user.
+				for ( const contributor of contributors ) {
+					try {
+						await contributor.onClick( e );
+					} catch ( err ) {
+						// eslint-disable-next-line no-console
+						console.error(
+							`[openstation] selection action '${ primary.id }' failed for one item:`,
+							err,
+						);
+					}
+				}
+			},
+		} );
+	}
+
+	common.sort( ( a, b ) => {
+		const sa = sortValue( a );
+		const sb = sortValue( b );
+		return sa !== sb ? sa - sb : a.label.localeCompare( b.label );
+	} );
+
+	const filtered = applyFilters<
+		SelectionAction< T >[],
+		[ SelectionActionsContext< T > ]
+	>( 'os.selection.actions', common, { items, count } );
+
+	return Array.isArray( filtered ) ? filtered : common;
+}

--- a/src/selection/controller.ts
+++ b/src/selection/controller.ts
@@ -50,6 +50,32 @@ const MARQUEE_SCROLL_PX = 12;
 const MARQUEE_ACTIVE_ATTR = 'data-os-marquee';
 
 /**
+ * Whether `el` is a scroller the USER could scroll themselves.
+ *
+ * Overflowing content is not the question — the desktop area is
+ * `overflow: hidden` and its icons plus its 80px bottom padding
+ * overflow it constantly, so `scrollHeight > clientHeight` is true
+ * there and answering that question alone made a marquee dragged to
+ * the bottom of the screen scroll the WALLPAPER: a surface with no
+ * scrollbar, that nothing else can scroll, sliding under the user's
+ * band. The question is whether the box is a scroll container at
+ * all.
+ */
+function isUserScrollable( el: HTMLElement ): boolean {
+	if ( el.scrollHeight <= el.clientHeight ) {
+		return false;
+	}
+	const overflowY = el.ownerDocument?.defaultView
+		?.getComputedStyle( el )
+		?.overflowY;
+	return (
+		overflowY === 'auto' ||
+		overflowY === 'scroll' ||
+		overflowY === 'overlay'
+	);
+}
+
+/**
  * Stop the browser from running its OWN selection under ours.
  *
  * A tile can't start a native text selection — tiles are
@@ -234,6 +260,17 @@ export function attachSelection(
 		},
 	} );
 
+	/**
+	 * This controller's identity, for deciding whether the shared
+	 * `lastActive` snapshot is ours to clear on destroy.
+	 *
+	 * Not `surface` + `scope`: two folder windows open on the SAME
+	 * folder share both, and closing one would blank the snapshot the
+	 * other just wrote. An object reference is the only thing that
+	 * distinguishes two live controllers with identical descriptions.
+	 */
+	const identity = {};
+
 	const emitChanged = ( keys: string[] ): void => {
 		if ( typeof document === 'undefined' ) {
 			return;
@@ -244,6 +281,7 @@ export function attachSelection(
 			keys: keys.slice(),
 			count: keys.length,
 		};
+		lastActiveOwner = identity;
 		document.dispatchEvent(
 			new CustomEvent( 'os-selection-changed', { detail: lastActive } ),
 		);
@@ -533,8 +571,7 @@ export function attachSelection(
 				return;
 			}
 			const host = background.getBoundingClientRect();
-			const canScroll =
-				background.scrollHeight > background.clientHeight;
+			const canScroll = isUserScrollable( background );
 			if ( canScroll ) {
 				let delta = 0;
 				if ( lastPointer.y < host.top + MARQUEE_EDGE_PX ) {
@@ -698,8 +735,12 @@ export function attachSelection(
 				onBackgroundPointerDown,
 			);
 			root.removeEventListener( 'keydown', onKeyDown );
-			if ( lastActive && lastActive.surface === ( options.surface ?? '' ) ) {
+			// Only if the snapshot is still OURS. A controller that
+			// closes after another one has taken over must not blank
+			// the live window's selection out from under it.
+			if ( lastActiveOwner === identity ) {
 				lastActive = null;
+				lastActiveOwner = null;
 			}
 		},
 	};
@@ -736,6 +777,9 @@ let lastActive: {
 	keys: string[];
 	count: number;
 } | null = null;
+
+/** Which controller wrote {@link lastActive}. See `identity` above. */
+let lastActiveOwner: object | null = null;
 
 /** @public */
 export function activeSelection(): {

--- a/src/selection/controller.ts
+++ b/src/selection/controller.ts
@@ -1,0 +1,748 @@
+/**
+ * OpenStation — selection controller.
+ *
+ * Binds a {@link SelectionModel} to a canvas of tiles: the pointer
+ * and keyboard gestures on the way in, the `selected` attribute and
+ * the ARIA roles on the way out. Every tile surface in the shell —
+ * the wallpaper, folder windows, every My WordPress list — mounts
+ * one of these instead of tracking a `selectedId` of its own.
+ *
+ * Gestures, matching Finder and Explorer because that is what the
+ * muscle memory expects:
+ *
+ *   click                replace the selection
+ *   Ctrl / Cmd + click   toggle one tile
+ *   Shift + click        extend from the anchor
+ *   click on empty space clear
+ *   drag on empty space  marquee (additive with a modifier held)
+ *   Ctrl / Cmd + A       select all
+ *   Escape               clear
+ *   arrows               move and select; Shift extends
+ *
+ * Painting goes through the `selected` ATTRIBUTE, never the
+ * `--selected` class: `<os-tile>._paint()` derives the class from
+ * the attribute on every repaint, so a hand-set class survives only
+ * until the next attribute change and then silently vanishes. The
+ * class is set alongside purely so non-component tiles (plain
+ * elements in a drill-in list) still light up.
+ */
+
+import { createSelectionModel, type SelectionModel } from './model';
+
+/** Canonical tile class — the default item selector. */
+const DEFAULT_ITEM_SELECTOR = '.os-file-tile';
+const SELECTED_CLASS = 'os-file-tile--selected';
+const MARQUEE_CLASS = 'os-selection-marquee';
+
+/** Minimum drag distance before a background press becomes a marquee. */
+const MARQUEE_THRESHOLD_PX = 4;
+
+/** How close to a scrollable edge the pointer auto-scrolls the canvas. */
+const MARQUEE_EDGE_PX = 36;
+
+/** Pixels scrolled per frame while the band is held at the edge. */
+const MARQUEE_SCROLL_PX = 12;
+
+/**
+ * Marker on `<body>` while a band is live. CSS keys off it to turn
+ * text selection off shell-wide — see {@link suppressNativeSelection}.
+ */
+const MARQUEE_ACTIVE_ATTR = 'data-os-marquee';
+
+/**
+ * Stop the browser from running its OWN selection under ours.
+ *
+ * A tile can't start a native text selection — tiles are
+ * `user-select: none`. The bare canvas a marquee starts from is not,
+ * so the browser begins a text selection on the same press, and it
+ * keeps extending as the pointer travels. Inside our canvas there is
+ * nothing selectable for it to land on and it stays invisible; drag
+ * out past the window and it starts highlighting whatever is behind
+ * — another window's text, in blue, mid-gesture.
+ *
+ * Two measures, because they cover different moments: `selectstart`
+ * refuses any selection the browser tries to begin from here on, and
+ * the body marker turns `user-select` off shell-wide for anything
+ * that slipped through. Whatever the first few pixels already
+ * selected is dropped outright.
+ *
+ * Returns the teardown. `ref` is any node in the document being
+ * suppressed — the selection is read through its own view rather
+ * than a global, so a canvas mounted in another document (a
+ * chromeless iframe) suppresses ITS selection and not the shell's.
+ */
+function suppressNativeSelection( ref: HTMLElement ): () => void {
+	const doc = ref.ownerDocument;
+	if ( ! doc ) {
+		return () => undefined;
+	}
+	const onSelectStart = ( e: Event ): void => {
+		e.preventDefault();
+	};
+	doc.addEventListener( 'selectstart', onSelectStart, true );
+	doc.body?.setAttribute( MARQUEE_ACTIVE_ATTR, '' );
+	try {
+		doc.defaultView?.getSelection()?.removeAllRanges();
+	} catch {
+		// Some engines throw on an empty / detached selection. The
+		// listener above is the part that matters.
+	}
+	return () => {
+		doc.removeEventListener( 'selectstart', onSelectStart, true );
+		doc.body?.removeAttribute( MARQUEE_ACTIVE_ATTR );
+	};
+}
+
+/**
+ * Subtrees a marquee never starts from. Windows and widgets are
+ * children of the desktop area, so their pointer events bubble to the
+ * wallpaper's own listener; without this a drag on a title bar would
+ * both move the window and rubber-band the icons behind it.
+ */
+const DEFAULT_MARQUEE_EXCLUDE =
+	'.os-window, .os-widgets__list, .os-widgets__card, .os-widgets__add';
+
+export interface SelectionControllerOptions {
+	/** CSS selector for selectable items under `root`. */
+	itemSelector?: string;
+	/** Stable key for an item element. Return null to skip it. */
+	keyOf: ( el: HTMLElement ) => string | null;
+	/**
+	 * Element whose empty space clears the selection and hosts the
+	 * marquee. Defaults to `root`. Pass the scroll/canvas host when
+	 * the item container doesn't fill it.
+	 */
+	background?: HTMLElement;
+	/** Set false for surfaces where a drag means something else. */
+	marquee?: boolean;
+	/**
+	 * Subtrees inside `background` that a marquee must never start
+	 * from. Defaults to the shell's own floating furniture — windows
+	 * and widgets both live INSIDE the desktop area, so a press on a
+	 * title bar or a widget's resize handle bubbles to the wallpaper
+	 * and would otherwise rubber-band the icons underneath while the
+	 * user drags the window.
+	 */
+	marqueeExclude?: string;
+	/** Visual order override. Defaults to position-then-DOM order. */
+	order?: () => string[];
+	onChange?: ( keys: string[] ) => void;
+	/** Surface slug for the public `os-selection-changed` event. */
+	surface?: string;
+	/** Free-form scope within the surface (folder id, entity id). */
+	scope?: string;
+	/** Accessible name for the listbox container. */
+	ariaLabel?: string;
+}
+
+export interface SelectionHandle {
+	model: SelectionModel< string >;
+	/** Selected keys in visual order. */
+	keys: () => string[];
+	/** Live element for a key, or null when it isn't rendered. */
+	elementFor: ( key: string ) => HTMLElement | null;
+	/**
+	 * Re-apply selected state and drop keys whose tiles are gone.
+	 * Call after any repaint that rebuilds or reuses tile DOM.
+	 */
+	refresh: () => void;
+	destroy: () => void;
+}
+
+/**
+ * Attach a selection controller to `root`.
+ *
+ * @public
+ */
+export function attachSelection(
+	root: HTMLElement,
+	options: SelectionControllerOptions,
+): SelectionHandle {
+	const itemSelector = options.itemSelector ?? DEFAULT_ITEM_SELECTOR;
+	const background = options.background ?? root;
+	const marqueeEnabled = options.marquee !== false;
+	const marqueeExclude = options.marqueeExclude ?? DEFAULT_MARQUEE_EXCLUDE;
+
+	const itemElements = (): HTMLElement[] =>
+		Array.from( root.querySelectorAll< HTMLElement >( itemSelector ) ).filter(
+			( el ) => options.keyOf( el ) !== null,
+		);
+
+	/**
+	 * Visual order — what a Shift+click range walks.
+	 *
+	 * Tiles on these canvases are absolutely positioned from inline
+	 * styles, so (top, left) is what the user sees; DOM order is
+	 * arrival order and diverges the moment anything is dragged.
+	 *
+	 * Grouped by parent first, because a banded list (WooCommerce
+	 * Orders splits into "Needs attention" / "Settled") is several
+	 * canvases stacked vertically, each with its own coordinate space
+	 * starting at zero. Sorting all their tiles by raw `top` would
+	 * interleave the bands, and a range drawn across two of them would
+	 * pick up rows the user never dragged over. Groups appear in
+	 * document order, which is the order the bands are stacked.
+	 */
+	const defaultOrder = (): string[] => {
+		const groups: HTMLElement[] = [];
+		const byGroup = new Map<
+			HTMLElement,
+			Array< { key: string; top: number; left: number; index: number } >
+		>();
+		itemElements().forEach( ( el, index ) => {
+			const parent = el.parentElement ?? root;
+			let bucket = byGroup.get( parent );
+			if ( ! bucket ) {
+				bucket = [];
+				byGroup.set( parent, bucket );
+				groups.push( parent );
+			}
+			bucket.push( {
+				key: options.keyOf( el ) as string,
+				top: parseFloat( el.style.top ) || 0,
+				left: parseFloat( el.style.left ) || 0,
+				index,
+			} );
+		} );
+		const out: string[] = [];
+		for ( const group of groups ) {
+			const bucket = byGroup.get( group ) ?? [];
+			bucket.sort( ( a, b ) => {
+				if ( a.top !== b.top ) {
+					return a.top - b.top;
+				}
+				if ( a.left !== b.left ) {
+					return a.left - b.left;
+				}
+				return a.index - b.index;
+			} );
+			for ( const entry of bucket ) {
+				out.push( entry.key );
+			}
+		}
+		return out;
+	};
+
+	const order = options.order ?? defaultOrder;
+
+	const model = createSelectionModel< string >( {
+		order,
+		onChange: ( keys ) => {
+			paint();
+			options.onChange?.( keys );
+			emitChanged( keys );
+		},
+	} );
+
+	const emitChanged = ( keys: string[] ): void => {
+		if ( typeof document === 'undefined' ) {
+			return;
+		}
+		lastActive = {
+			surface: options.surface ?? '',
+			scope: options.scope ?? '',
+			keys: keys.slice(),
+			count: keys.length,
+		};
+		document.dispatchEvent(
+			new CustomEvent( 'os-selection-changed', { detail: lastActive } ),
+		);
+	};
+
+	const elementFor = ( key: string ): HTMLElement | null =>
+		itemElements().find( ( el ) => options.keyOf( el ) === key ) ?? null;
+
+	/**
+	 * Push the model's membership onto the DOM.
+	 *
+	 * Every write is guarded on the current value. Setting an
+	 * attribute to what it already holds still fires
+	 * `attributeChangedCallback`, and `<os-tile>._paint()` rebuilds
+	 * the tile's inner DOM on every one of those — so an unguarded
+	 * repaint of a 200-icon folder would rebuild 200 tiles to change
+	 * the state of one.
+	 */
+	const paint = (): void => {
+		for ( const el of itemElements() ) {
+			const key = options.keyOf( el ) as string;
+			const on = model.has( key );
+			if ( on !== el.hasAttribute( 'selected' ) ) {
+				if ( on ) {
+					el.setAttribute( 'selected', '' );
+				} else {
+					el.removeAttribute( 'selected' );
+				}
+			}
+			el.classList.toggle( SELECTED_CLASS, on );
+			// `selectable` flips `<os-tile>` from `listitem` to
+			// `option`, the only role allowed to carry aria-selected.
+			if ( ! el.hasAttribute( 'selectable' ) ) {
+				el.setAttribute( 'selectable', '' );
+			}
+			const ariaSelected = on ? 'true' : 'false';
+			if ( el.getAttribute( 'aria-selected' ) !== ariaSelected ) {
+				el.setAttribute( 'aria-selected', ariaSelected );
+			}
+		}
+	};
+
+	root.setAttribute( 'role', 'listbox' );
+	root.setAttribute( 'aria-multiselectable', 'true' );
+	if ( options.ariaLabel ) {
+		root.setAttribute( 'aria-label', options.ariaLabel );
+	}
+
+	// ── Pointer ────────────────────────────────────────────────────
+
+	/** Arrow-key cursor. See the keyboard handler for why it isn't the anchor. */
+	let lead: string | null = null;
+
+	const onClick = ( e: MouseEvent ): void => {
+		if ( ! ( e.target instanceof Element ) ) {
+			return;
+		}
+		const tile = e.target.closest< HTMLElement >( itemSelector );
+		if ( tile && root.contains( tile ) ) {
+			const key = options.keyOf( tile );
+			if ( key === null ) {
+				return;
+			}
+			lead = key;
+			// The tile is a focusable button; without this the click
+			// would also reach the background handler below and undo
+			// the selection we just made.
+			e.stopPropagation();
+			if ( e.shiftKey ) {
+				model.selectRange( key, e.ctrlKey || e.metaKey );
+				return;
+			}
+			if ( e.ctrlKey || e.metaKey ) {
+				model.toggle( key );
+				return;
+			}
+			model.set( [ key ] );
+			return;
+		}
+		// Empty space. A click that merely ended a marquee is not a
+		// "clear" gesture — the marquee already said what it selected.
+		if ( suppressNextBackgroundClick ) {
+			suppressNextBackgroundClick = false;
+			return;
+		}
+		model.clear();
+	};
+	background.addEventListener( 'click', onClick );
+
+	// ── Marquee ────────────────────────────────────────────────────
+
+	let marqueeEl: HTMLElement | null = null;
+	/**
+	 * Marquee origin, in the background's CONTENT coordinates — not
+	 * viewport ones.
+	 *
+	 * This is the whole trick to a marquee that survives scrolling.
+	 * The anchor belongs to the thing the user pressed on, and that
+	 * thing moves when the canvas scrolls. Stored in viewport space,
+	 * the box stays the same size while the content slides out from
+	 * under it: scroll during a drag and the selection freezes.
+	 */
+	let marqueeStart: { x: number; y: number } | null = null;
+	/** Latest pointer position, viewport coordinates. */
+	let lastPointer: { x: number; y: number } | null = null;
+	let marqueeBase: string[] = [];
+	let suppressNextBackgroundClick = false;
+	let autoScrollRaf = 0;
+	let releaseSelectionSuppression: ( () => void ) | null = null;
+	/** Pointer the band belongs to, while it holds capture. */
+	let capturedPointerId: number | null = null;
+
+	/**
+	 * Take pointer capture for the band.
+	 *
+	 * Without it, a release over an IFRAME strands the gesture: an
+	 * iframe window hosts its own document, so `pointerup` fires in
+	 * there and the listeners out here never hear it. The band keeps
+	 * following a button the user already let go of. (The WordPress
+	 * dashboard's draggable metaboxes are a reliable way to find
+	 * this — they swallow the event on their own side too.)
+	 *
+	 * Capture retargets every remaining event for this pointer to the
+	 * canvas, so the release comes home whatever it happens over.
+	 * They still bubble from there, so the document-level listeners
+	 * below are unaffected.
+	 *
+	 * The DragManager deliberately avoids pointer capture — it breaks
+	 * HTML5 `dragstart` detection on draggable tiles. A marquee never
+	 * starts on a tile and emits no HTML5 drag, so the objection
+	 * doesn't apply here.
+	 */
+	const capturePointer = ( pointerId: number ): void => {
+		if ( typeof background.setPointerCapture !== 'function' ) {
+			return;
+		}
+		try {
+			background.setPointerCapture( pointerId );
+			capturedPointerId = pointerId;
+		} catch {
+			// Unknown / already-released pointer id. The document
+			// listeners remain as the fallback path.
+		}
+	};
+
+	const releasePointer = (): void => {
+		if (
+			capturedPointerId === null ||
+			typeof background.releasePointerCapture !== 'function'
+		) {
+			capturedPointerId = null;
+			return;
+		}
+		try {
+			if ( background.hasPointerCapture?.( capturedPointerId ) ) {
+				background.releasePointerCapture( capturedPointerId );
+			}
+		} catch {
+			// Already gone — nothing to release.
+		}
+		capturedPointerId = null;
+	};
+
+	/** Viewport point → the background's content coordinate space. */
+	const toContent = (
+		clientX: number,
+		clientY: number,
+	): { x: number; y: number } => {
+		const host = background.getBoundingClientRect();
+		return {
+			x: clientX - host.left + background.scrollLeft,
+			y: clientY - host.top + background.scrollTop,
+		};
+	};
+
+	const endMarquee = (): void => {
+		marqueeEl?.remove();
+		marqueeEl = null;
+		marqueeStart = null;
+		lastPointer = null;
+		releaseSelectionSuppression?.();
+		releaseSelectionSuppression = null;
+		releasePointer();
+		if ( autoScrollRaf ) {
+			cancelAnimationFrame( autoScrollRaf );
+			autoScrollRaf = 0;
+		}
+		document.removeEventListener( 'pointermove', onMarqueeMove );
+		document.removeEventListener( 'pointerup', onMarqueeUp );
+		document.removeEventListener( 'pointercancel', onMarqueeCancel );
+		background.removeEventListener( 'lostpointercapture', onMarqueeCancel );
+		background.removeEventListener( 'scroll', renderMarquee );
+		window.removeEventListener( 'blur', onMarqueeCancel );
+	};
+
+	/**
+	 * Draw the band and re-run the hit-test from the current anchor +
+	 * pointer. Called on pointermove AND on scroll — a wheel tick
+	 * during a drag changes what the band covers just as surely as
+	 * moving the mouse does.
+	 */
+	function renderMarquee(): void {
+		if ( ! marqueeStart || ! lastPointer ) {
+			return;
+		}
+		const cursor = toContent( lastPointer.x, lastPointer.y );
+		const dx = cursor.x - marqueeStart.x;
+		const dy = cursor.y - marqueeStart.y;
+		if (
+			! marqueeEl &&
+			Math.abs( dx ) < MARQUEE_THRESHOLD_PX &&
+			Math.abs( dy ) < MARQUEE_THRESHOLD_PX
+		) {
+			return;
+		}
+		if ( ! marqueeEl ) {
+			marqueeEl = document.createElement( 'div' );
+			marqueeEl.className = MARQUEE_CLASS;
+			marqueeEl.setAttribute( 'aria-hidden', 'true' );
+			// The marquee is absolutely positioned inside the
+			// background so it clips with the canvas — a fixed overlay
+			// would paint over the window's own chrome. Absolute
+			// positioning also means content coordinates are exactly
+			// what `left` / `top` want, so the band scrolls WITH the
+			// icons it is drawn around.
+			if ( getComputedStyle( background ).position === 'static' ) {
+				background.style.position = 'relative';
+			}
+			background.appendChild( marqueeEl );
+			suppressNextBackgroundClick = true;
+			// From here the gesture is ours; the browser must not run
+			// a text selection alongside it.
+			releaseSelectionSuppression =
+				suppressNativeSelection( background );
+			startAutoScroll();
+		}
+		const left = Math.min( marqueeStart.x, cursor.x );
+		const top = Math.min( marqueeStart.y, cursor.y );
+		const width = Math.abs( dx );
+		const height = Math.abs( dy );
+		marqueeEl.style.left = `${ left }px`;
+		marqueeEl.style.top = `${ top }px`;
+		marqueeEl.style.width = `${ width }px`;
+		marqueeEl.style.height = `${ height }px`;
+
+		// Hit-testing reads element rects, which are viewport-space —
+		// so convert the band back on the way out.
+		const host = background.getBoundingClientRect();
+		const originX = host.left - background.scrollLeft;
+		const originY = host.top - background.scrollTop;
+		const box = {
+			left: left + originX,
+			top: top + originY,
+			right: left + width + originX,
+			bottom: top + height + originY,
+		};
+		const hits: string[] = [];
+		for ( const el of itemElements() ) {
+			const rect = el.getBoundingClientRect();
+			const intersects =
+				rect.left < box.right &&
+				rect.right > box.left &&
+				rect.top < box.bottom &&
+				rect.bottom > box.top;
+			if ( intersects ) {
+				hits.push( options.keyOf( el ) as string );
+			}
+		}
+		model.set( Array.from( new Set( [ ...marqueeBase, ...hits ] ) ) );
+	}
+
+	/**
+	 * Scroll the canvas when the band is dragged against its edge.
+	 *
+	 * Without it a marquee can only ever reach what is already on
+	 * screen, which on a long list is most of the reason to draw one.
+	 * Only runs while there is something to scroll, and stops with the
+	 * gesture.
+	 */
+	function startAutoScroll(): void {
+		if ( autoScrollRaf || typeof requestAnimationFrame !== 'function' ) {
+			return;
+		}
+		const step = (): void => {
+			autoScrollRaf = 0;
+			if ( ! marqueeEl || ! lastPointer ) {
+				return;
+			}
+			const host = background.getBoundingClientRect();
+			const canScroll =
+				background.scrollHeight > background.clientHeight;
+			if ( canScroll ) {
+				let delta = 0;
+				if ( lastPointer.y < host.top + MARQUEE_EDGE_PX ) {
+					delta = -MARQUEE_SCROLL_PX;
+				} else if ( lastPointer.y > host.bottom - MARQUEE_EDGE_PX ) {
+					delta = MARQUEE_SCROLL_PX;
+				}
+				if ( delta !== 0 ) {
+					const before = background.scrollTop;
+					background.scrollTop += delta;
+					if ( background.scrollTop !== before ) {
+						renderMarquee();
+					}
+				}
+			}
+			autoScrollRaf = requestAnimationFrame( step );
+		};
+		autoScrollRaf = requestAnimationFrame( step );
+	}
+
+	const onMarqueeMove = ( e: PointerEvent ): void => {
+		if ( ! marqueeStart ) {
+			return;
+		}
+		lastPointer = { x: e.clientX, y: e.clientY };
+		renderMarquee();
+	};
+
+	const onMarqueeUp = (): void => {
+		if ( marqueeEl ) {
+			lastMarqueeEndAt = Date.now();
+		}
+		endMarquee();
+	};
+
+	const onMarqueeCancel = (): void => {
+		endMarquee();
+	};
+
+	const onBackgroundPointerDown = ( e: PointerEvent ): void => {
+		if ( ! marqueeEnabled || e.button !== 0 ) {
+			return;
+		}
+		if ( ! ( e.target instanceof Element ) ) {
+			return;
+		}
+		if ( e.target.closest( itemSelector ) ) {
+			return; // Tile press — the drag manager owns that gesture.
+		}
+		// Floating furniture only counts when it sits INSIDE this
+		// canvas. Windows and widgets are children of the desktop
+		// area, so on the wallpaper this is what stops a title-bar
+		// drag from rubber-banding the icons behind it.
+		//
+		// A canvas that lives inside a window is the mirror image:
+		// the `.os-window` is an ANCESTOR of the background, and
+		// excluding it would kill the marquee in every folder window
+		// and every My WordPress list — which is exactly what it did.
+		// `background.contains()` tells the two apart. (A press on
+		// some other window can't reach this listener at all: the
+		// event has no path through `background` to bubble along.)
+		const foreign = e.target.closest< HTMLElement >( marqueeExclude );
+		if ( foreign && foreign !== background && background.contains( foreign ) ) {
+			return;
+		}
+		marqueeStart = toContent( e.clientX, e.clientY );
+		lastPointer = { x: e.clientX, y: e.clientY };
+		if ( typeof e.pointerId === 'number' ) {
+			capturePointer( e.pointerId );
+		}
+		// Ctrl / Cmd / Shift keeps what was already selected, so a
+		// marquee can add a second cluster to the first.
+		marqueeBase =
+			e.ctrlKey || e.metaKey || e.shiftKey ? model.keys() : [];
+		if ( marqueeBase.length === 0 ) {
+			model.clear();
+		}
+		document.addEventListener( 'pointermove', onMarqueeMove );
+		document.addEventListener( 'pointerup', onMarqueeUp );
+		document.addEventListener( 'pointercancel', onMarqueeCancel );
+		// Safety nets for a capture we never get to release cleanly:
+		// the browser handing it back (an alert, a context menu, a
+		// touch interruption), or focus leaving the shell entirely —
+		// which is what a click landing inside an iframe looks like
+		// from out here.
+		background.addEventListener( 'lostpointercapture', onMarqueeCancel );
+		window.addEventListener( 'blur', onMarqueeCancel );
+		// Wheel / trackpad scrolling mid-drag has to re-draw and
+		// re-hit-test, exactly like a pointermove.
+		background.addEventListener( 'scroll', renderMarquee, {
+			passive: true,
+		} );
+	};
+	background.addEventListener( 'pointerdown', onBackgroundPointerDown );
+
+	// ── Keyboard ───────────────────────────────────────────────────
+
+	const onKeyDown = ( e: KeyboardEvent ): void => {
+		if ( e.key === 'a' && ( e.ctrlKey || e.metaKey ) ) {
+			e.preventDefault();
+			model.selectAll();
+			return;
+		}
+		if ( e.key === 'Escape' ) {
+			if ( marqueeEl || marqueeStart ) {
+				endMarquee();
+				return;
+			}
+			if ( model.size() > 0 ) {
+				model.clear();
+			}
+			return;
+		}
+		const forward = e.key === 'ArrowRight' || e.key === 'ArrowDown';
+		const backward = e.key === 'ArrowLeft' || e.key === 'ArrowUp';
+		if ( ! forward && ! backward ) {
+			return;
+		}
+		const step = forward ? 1 : -1;
+		const all = order();
+		if ( all.length === 0 ) {
+			return;
+		}
+		// The lead is the cursor the arrows move; the anchor is where
+		// a range starts. They have to be separate — extending with
+		// Shift+arrow leaves the anchor put, so if the arrows moved the
+		// anchor too the range would never grow past one step.
+		const cursor = lead ?? model.anchor();
+		const from = cursor === null ? -1 : all.indexOf( cursor );
+		const next = Math.min(
+			all.length - 1,
+			Math.max( 0, from < 0 ? 0 : from + step ),
+		);
+		e.preventDefault();
+		const key = all[ next ];
+		lead = key;
+		if ( e.shiftKey ) {
+			model.selectRange( key );
+		} else {
+			model.set( [ key ] );
+		}
+		elementFor( key )?.focus();
+	};
+	root.addEventListener( 'keydown', onKeyDown );
+
+	paint();
+
+	return {
+		model,
+		keys: () => model.keys(),
+		elementFor,
+		refresh() {
+			model.prune();
+			paint();
+		},
+		destroy() {
+			endMarquee();
+			background.removeEventListener( 'click', onClick );
+			background.removeEventListener(
+				'pointerdown',
+				onBackgroundPointerDown,
+			);
+			root.removeEventListener( 'keydown', onKeyDown );
+			if ( lastActive && lastActive.surface === ( options.surface ?? '' ) ) {
+				lastActive = null;
+			}
+		},
+	};
+}
+
+/** When the last marquee finished. See {@link recentlyMarqueed}. */
+let lastMarqueeEndAt = 0;
+
+/**
+ * Whether a marquee ended within the last 500 ms.
+ *
+ * The browser synthesizes a `click` on the common ancestor after a
+ * drag-shaped gesture, and on the wallpaper that ancestor is the
+ * desktop area itself — the very element whose click handler runs
+ * "Show desktop". Rubber-band-selecting a few icons would then
+ * minimize every window. Mirrors `dragManager.recentlyEndedDrag()`,
+ * which exists for exactly the same reason.
+ *
+ * @public
+ */
+export function recentlyMarqueed(): boolean {
+	return lastMarqueeEndAt > 0 && Date.now() - lastMarqueeEndAt < 500;
+}
+
+/**
+ * Snapshot of the most recent selection change, for
+ * `wp.os.selection.active()`. Written by every controller; read by
+ * plugins that want to know what the user is holding without having
+ * to subscribe before the fact.
+ */
+let lastActive: {
+	surface: string;
+	scope: string;
+	keys: string[];
+	count: number;
+} | null = null;
+
+/** @public */
+export function activeSelection(): {
+	surface: string;
+	scope: string;
+	keys: string[];
+	count: number;
+} | null {
+	return lastActive ? { ...lastActive, keys: lastActive.keys.slice() } : null;
+}

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -1,0 +1,63 @@
+/**
+ * OpenStation — selection framework.
+ *
+ * Barrel + the `wp.os.selection` public surface. The three pieces:
+ *
+ *   - {@link createSelectionModel} — the set + anchor semantics.
+ *   - {@link attachSelection} — gestures and painting on a canvas.
+ *   - {@link resolveCommonActions} — what a heterogeneous selection
+ *     is allowed to offer.
+ *
+ * Plugin authors mostly want the last one plus the
+ * `os-selection-changed` document event; the first two matter when
+ * you are building a tile canvas of your own.
+ */
+
+export { createSelectionModel } from './model';
+export type { SelectionModel, SelectionModelOptions } from './model';
+export {
+	attachSelection,
+	activeSelection,
+	recentlyMarqueed,
+} from './controller';
+export type {
+	SelectionControllerOptions,
+	SelectionHandle,
+} from './controller';
+export { resolveCommonActions } from './actions';
+export type { SelectionAction, SelectionActionsContext } from './actions';
+export {
+	openActionMenu,
+	closeActionMenu,
+	isActionMenuOpen,
+} from './menu';
+export type { ActionMenuEntry, ActionMenuOptions } from './menu';
+
+import { activeSelection } from './controller';
+import { resolveCommonActions } from './actions';
+import { createSelectionModel } from './model';
+
+/**
+ * Shape installed at `wp.os.selection`.
+ *
+ * @public
+ */
+export interface SelectionApi {
+	/**
+	 * The most recent selection change anywhere in the shell —
+	 * `{ surface, scope, keys, count }` — or null when nothing is
+	 * selected. A snapshot, not a live handle.
+	 */
+	active: typeof activeSelection;
+	/** Intersect per-item action lists into the set's common actions. */
+	resolveCommonActions: typeof resolveCommonActions;
+	/** Build a standalone selection model for a canvas of your own. */
+	createModel: typeof createSelectionModel;
+}
+
+/** @public */
+export const selectionApi: SelectionApi = {
+	active: activeSelection,
+	resolveCommonActions,
+	createModel: createSelectionModel,
+};

--- a/src/selection/menu.ts
+++ b/src/selection/menu.ts
@@ -1,0 +1,193 @@
+/**
+ * OpenStation — the one context menu.
+ *
+ * Four surfaces had grown their own near-identical `<os-context-menu>`
+ * builder (file tiles, My WordPress entities, users, media). They
+ * drifted: one sorted its items and three didn't, two forgot the
+ * outside-click dismisser, and only one deferred construction behind
+ * the shell-overlays loader. This is that builder, once.
+ *
+ * Construction is deferred through `openWithShellOverlays` so the
+ * `<os-context-menu>` / `<os-context-menu-option>` classes stay in
+ * the lazy overlay bundle rather than in `desktop.min.js`. The
+ * generation counter makes a second right-click before the bundle
+ * lands cancel the first — otherwise two menus race to the DOM.
+ */
+
+import { doAction } from '../hooks';
+import { attachDismissable } from '../desktop-files/dismissable';
+import { openWithShellOverlays } from '../shell-overlays/loader';
+/**
+ * What the menu needs from an action — the structural subset of
+ * `SelectionAction` that has nothing to do with which item type the
+ * action came from. Typing the parameter this way lets a caller pass
+ * `SelectionAction< Post >[]` or `SelectionAction< User >[]` without
+ * a cast through `unknown`; the menu neither knows nor cares.
+ *
+ * @public
+ */
+export interface ActionMenuEntry {
+	id: string;
+	label: string;
+	icon?: string;
+	sort?: number;
+	danger?: boolean;
+	disabled?: boolean;
+	onClick: ( e: MouseEvent ) => void | Promise< void >;
+}
+
+const MENU_CLASS = 'os-wallpaper-menu';
+
+let activeMenu: HTMLElement | null = null;
+let activeOnClosed: ( () => void ) | null = null;
+let openGeneration = 0;
+
+export interface ActionMenuOptions {
+	/** Actions to render. Already resolved — this does no filtering. */
+	actions: ActionMenuEntry[];
+	/** Extra `data-*` pairs for the menu element (diagnostics, tests). */
+	dataset?: Record< string, string >;
+	/** Extra class on the menu element. */
+	className?: string;
+	/** Action slug fired as `os.<scope>.menu.opened` / `.closed`. */
+	scope?: string;
+	/**
+	 * Fired once the menu is in the DOM, with the rendered ids.
+	 * Surfaces with their own long-standing `doAction` contract pass
+	 * one of these to keep firing it verbatim.
+	 */
+	onOpened?: ( ids: string[] ) => void;
+	/** Fired when the menu closes, however it closed. */
+	onClosed?: () => void;
+}
+
+export function isActionMenuOpen(): boolean {
+	return activeMenu !== null;
+}
+
+export function closeActionMenu(): void {
+	if ( ! activeMenu ) {
+		return;
+	}
+	const scope = activeMenu.dataset.menuScope ?? 'selection';
+	const closed = activeOnClosed;
+	activeMenu.dispatchEvent( new CustomEvent( 'tile-menu-closed' ) );
+	activeMenu.remove();
+	activeMenu = null;
+	activeOnClosed = null;
+	closed?.();
+	doAction( `os.${ scope }.menu.closed`, {} );
+}
+
+/**
+ * Open a context menu at viewport coordinates.
+ *
+ * @public
+ */
+export function openActionMenu(
+	pos: { x: number; y: number },
+	opts: ActionMenuOptions,
+): void {
+	closeActionMenu();
+	const myGen = ++openGeneration;
+	openWithShellOverlays(
+		() => myGen === openGeneration,
+		() => openImmediate( pos, opts ),
+	);
+}
+
+function openImmediate(
+	pos: { x: number; y: number },
+	{
+		actions,
+		dataset,
+		className,
+		scope = 'selection',
+		onOpened,
+		onClosed,
+	}: ActionMenuOptions,
+): void {
+	if ( actions.length === 0 ) {
+		return;
+	}
+
+	const menu = document.createElement( 'os-context-menu' );
+	menu.setAttribute( 'open', '' );
+	menu.classList.add( MENU_CLASS );
+	if ( className ) {
+		menu.classList.add( className );
+	}
+	menu.dataset.menuScope = scope;
+	for ( const [ key, value ] of Object.entries( dataset ?? {} ) ) {
+		menu.dataset[ key ] = value;
+	}
+	menu.style.left = `${ pos.x }px`;
+	menu.style.top = `${ pos.y }px`;
+
+	const byId = new Map< string, ActionMenuEntry >();
+	for ( const action of actions ) {
+		byId.set( action.id, action );
+		const opt = document.createElement( 'os-context-menu-option' );
+		// `os-context-menu-option` reports `detail.id` from
+		// `dataset.menuItemId`; the `value` attribute alone lands under
+		// `detail.value`, which nothing here reads. Setting only
+		// `value` is the silent "the menu item does nothing" bug.
+		opt.dataset.menuItemId = action.id;
+		opt.setAttribute( 'value', action.id );
+		if ( action.danger ) {
+			opt.setAttribute( 'danger', '' );
+		}
+		if ( action.disabled ) {
+			opt.setAttribute( 'disabled', '' );
+		}
+		if ( action.icon ) {
+			opt.setAttribute( 'icon', sanitizeClass( action.icon ) );
+		}
+		opt.textContent = action.label;
+		menu.appendChild( opt );
+	}
+
+	menu.addEventListener( 'os-context-menu-pick', ( e: Event ) => {
+		const detail = ( e as CustomEvent< { id: string } > ).detail;
+		const action = byId.get( detail.id );
+		if ( ! action ) {
+			return;
+		}
+		closeActionMenu();
+		void Promise.resolve( action.onClick( new MouseEvent( 'click' ) ) ).catch(
+			( err: unknown ) => {
+				// eslint-disable-next-line no-console
+				console.error(
+					`[openstation] menu action '${ action.id }' threw:`,
+					err,
+				);
+			},
+		);
+	} );
+
+	document.body.appendChild( menu );
+	activeMenu = menu;
+	activeOnClosed = onClosed ?? null;
+
+	const rect = menu.getBoundingClientRect();
+	if ( rect.right > window.innerWidth ) {
+		menu.style.left = `${ Math.max( 0, window.innerWidth - rect.width - 8 ) }px`;
+	}
+	if ( rect.bottom > window.innerHeight ) {
+		menu.style.top = `${ Math.max( 0, window.innerHeight - rect.height - 8 ) }px`;
+	}
+
+	const detach = attachDismissable( menu, { close: () => closeActionMenu() } );
+	menu.addEventListener( 'tile-menu-closed', detach );
+
+	const ids = actions.map( ( a ) => a.id );
+	onOpened?.( ids );
+	doAction( `os.${ scope }.menu.opened`, {
+		items: ids,
+		count: actions.length,
+	} );
+}
+
+function sanitizeClass( raw: string ): string {
+	return raw.replace( /[^a-zA-Z0-9_-]/g, '' );
+}

--- a/src/selection/model.ts
+++ b/src/selection/model.ts
@@ -1,0 +1,212 @@
+/**
+ * OpenStation — selection model.
+ *
+ * A set of keys plus an anchor, with the four gestures every
+ * desktop file manager shares: replace, toggle, extend-from-anchor,
+ * select-all. Nothing here touches the DOM — `controller.ts` owns
+ * that half — so the semantics can be tested as plain data.
+ *
+ * Deliberately NOT a `createSharedStore`: a selection belongs to one
+ * canvas inside one window. Two folder windows showing the same
+ * folder each have their own, the same way two Finder windows do.
+ * Cross-bundle sharing would fuse them.
+ *
+ * `order()` is the surface's visual order — DOM order for flow
+ * lists, row-major geometry for absolute-positioned canvases. Range
+ * selection means "everything between the anchor and the clicked
+ * key IN THAT ORDER", so a surface that reports a different order
+ * than the user sees produces ranges that look arbitrary.
+ */
+
+export interface SelectionModelOptions< K > {
+	/** Current keys in visual order. Re-read on every range op. */
+	order: () => K[];
+	/** Fired after any mutation that actually changed the set. */
+	onChange?: ( keys: K[] ) => void;
+}
+
+export interface SelectionModel< K > {
+	/** Selected keys, in the order `order()` reports them. */
+	keys: () => K[];
+	has: ( key: K ) => boolean;
+	size: () => number;
+	/** The last key the user acted on — the origin for `selectRange`. */
+	anchor: () => K | null;
+	/** Replace the whole set. Anchor becomes the last key passed. */
+	set: ( keys: readonly K[] ) => void;
+	add: ( key: K ) => void;
+	remove: ( key: K ) => void;
+	/** Toggle one key (Ctrl / Cmd click). Anchor follows the key. */
+	toggle: ( key: K ) => void;
+	/**
+	 * Select everything between the anchor and `key` inclusive.
+	 * Without an anchor this degrades to selecting `key` alone.
+	 * `additive` keeps the pre-existing selection (Ctrl+Shift click).
+	 */
+	selectRange: ( key: K, additive?: boolean ) => void;
+	selectAll: () => void;
+	clear: () => void;
+	/**
+	 * Drop keys that are no longer in `order()` — called after a
+	 * repaint so a deleted item doesn't linger in the set.
+	 * Returns true when something was actually pruned.
+	 */
+	prune: () => boolean;
+	subscribe: ( cb: ( keys: K[] ) => void ) => () => void;
+}
+
+export function createSelectionModel< K >(
+	options: SelectionModelOptions< K >,
+): SelectionModel< K > {
+	type Listener = ( keys: K[] ) => void;
+	const selected = new Set< K >();
+	let anchorKey: K | null = null;
+	const listeners = new Set< Listener >();
+	if ( options.onChange ) {
+		listeners.add( options.onChange );
+	}
+
+	const orderedKeys = (): K[] =>
+		options.order().filter( ( k ) => selected.has( k ) );
+
+	const notify = (): void => {
+		const snapshot = orderedKeys();
+		for ( const cb of listeners ) {
+			try {
+				cb( snapshot );
+			} catch ( err ) {
+				// A misbehaving consumer must not strand the gesture —
+				// the tiles are already painted by the time we get here.
+				// eslint-disable-next-line no-console
+				console.error( '[openstation] selection listener threw:', err );
+			}
+		}
+	};
+
+	/** Run `mutate`, notify only when the membership actually moved. */
+	const commit = ( mutate: () => void ): void => {
+		const before = selected.size;
+		const beforeKeys = Array.from( selected );
+		mutate();
+		if (
+			selected.size === before &&
+			beforeKeys.every( ( k ) => selected.has( k ) )
+		) {
+			return;
+		}
+		notify();
+	};
+
+	return {
+		keys: orderedKeys,
+		has: ( key ) => selected.has( key ),
+		size: () => selected.size,
+		anchor: () => anchorKey,
+		set( keys ) {
+			commit( () => {
+				selected.clear();
+				for ( const k of keys ) {
+					selected.add( k );
+				}
+			} );
+			anchorKey = keys.length > 0 ? keys[ keys.length - 1 ] : null;
+		},
+		add( key ) {
+			commit( () => {
+				selected.add( key );
+			} );
+			anchorKey = key;
+		},
+		remove( key ) {
+			commit( () => {
+				selected.delete( key );
+			} );
+			if ( anchorKey === key ) {
+				anchorKey = null;
+			}
+		},
+		toggle( key ) {
+			commit( () => {
+				if ( selected.has( key ) ) {
+					selected.delete( key );
+				} else {
+					selected.add( key );
+				}
+			} );
+			anchorKey = key;
+		},
+		selectRange( key, additive = false ) {
+			const all = options.order();
+			const to = all.indexOf( key );
+			const from = anchorKey === null ? -1 : all.indexOf( anchorKey );
+			if ( to < 0 ) {
+				return;
+			}
+			// No usable anchor (first click of the session, or the
+			// anchor was deleted) — Shift+click behaves like a plain
+			// click rather than doing nothing, which is what both
+			// Finder and Explorer do.
+			if ( from < 0 ) {
+				commit( () => {
+					if ( ! additive ) {
+						selected.clear();
+					}
+					selected.add( key );
+				} );
+				anchorKey = key;
+				return;
+			}
+			const lo = Math.min( from, to );
+			const hi = Math.max( from, to );
+			commit( () => {
+				if ( ! additive ) {
+					selected.clear();
+				}
+				for ( let i = lo; i <= hi; i += 1 ) {
+					selected.add( all[ i ] );
+				}
+			} );
+			// Anchor deliberately stays put — successive Shift+clicks
+			// re-extend from the same origin instead of walking.
+		},
+		selectAll() {
+			const all = options.order();
+			commit( () => {
+				for ( const k of all ) {
+					selected.add( k );
+				}
+			} );
+			if ( anchorKey === null && all.length > 0 ) {
+				anchorKey = all[ 0 ];
+			}
+		},
+		clear() {
+			commit( () => {
+				selected.clear();
+			} );
+			anchorKey = null;
+		},
+		prune() {
+			const live = new Set( options.order() );
+			let pruned = false;
+			commit( () => {
+				for ( const k of Array.from( selected ) ) {
+					if ( ! live.has( k ) ) {
+						selected.delete( k );
+						pruned = true;
+					}
+				}
+			} );
+			if ( anchorKey !== null && ! live.has( anchorKey ) ) {
+				anchorKey = null;
+			}
+			return pruned;
+		},
+		subscribe( cb ) {
+			listeners.add( cb );
+			return () => {
+				listeners.delete( cb );
+			};
+		},
+	};
+}

--- a/src/ui/components/os-tile/os-tile.ts
+++ b/src/ui/components/os-tile/os-tile.ts
@@ -88,6 +88,7 @@ const REACTIVE_PROPS = [
 	'kind',
 	'status',
 	'selected',
+	'selectable',
 	'missing',
 	'access-gated',
 	'drag-kind',
@@ -114,6 +115,7 @@ export class OsTile extends Component {
 			{ name: 'kind', type: '`entry` | `folder`' },
 			{ name: 'status', type: '`draft` | `pending` | `private` | `future` | `publish`' },
 			{ name: 'selected', type: 'boolean' },
+			{ name: 'selectable', type: 'boolean', description: 'Set by the selection controller on a multi-select canvas. Switches the tile from `listitem` to `option` so it can carry `aria-selected`.' },
 			{ name: 'missing', type: 'boolean' },
 			{ name: 'access-gated', type: 'boolean' },
 			{ name: 'drag-kind', type: 'string', description: 'When set, the component wires pointerdown → DragManager.' },
@@ -230,6 +232,62 @@ export class OsTile extends Component {
 		this._paint();
 	}
 
+	/**
+	 * Selection state is repainted WITHOUT touching the tile's
+	 * children.
+	 *
+	 * `_paint()` replaces the visual, the label and the ribbon on
+	 * every call. That is fine for a content change and catastrophic
+	 * for a selection change, because selection changes land in the
+	 * middle of pointer gestures: destroy the node a `mousedown`
+	 * landed on and the browser will not synthesize the `click` when
+	 * the `mouseup` arrives on its replacement — so no `click`, no
+	 * `dblclick`, and a tile that can no longer be opened. (The same
+	 * hazard is documented for keyed lists in
+	 * `docs/javascript-reference.md`.)
+	 *
+	 * So the three selection attributes take a cheap path: classes
+	 * and ARIA only, children untouched. It is also what makes
+	 * Ctrl+A over a folder of two hundred icons cost two hundred
+	 * class toggles instead of two hundred subtree rebuilds.
+	 */
+	attributeChangedCallback(
+		name: string,
+		oldValue: string | null,
+		newValue: string | null,
+	): void {
+		if ( oldValue === newValue ) {
+			return;
+		}
+		if (
+			name === 'selected' ||
+			name === 'selectable' ||
+			name === 'aria-selected'
+		) {
+			this._paintSelection();
+			return;
+		}
+		super.attributeChangedCallback( name, oldValue, newValue );
+	}
+
+	/** Class + ARIA half of `_paint()`. Never touches children. */
+	private _paintSelection(): void {
+		const selected = this.hasAttribute( 'selected' );
+		const selectable = this.hasAttribute( 'selectable' );
+		this.classList.toggle( `${ TILE_CLASS }--selected`, selected );
+		this.setAttribute( 'role', selectable ? 'option' : 'listitem' );
+		if ( selectable ) {
+			// Guarded: writing `aria-selected` re-enters this callback,
+			// and an unguarded write would recurse once per paint.
+			const next = selected ? 'true' : 'false';
+			if ( this.getAttribute( 'aria-selected' ) !== next ) {
+				this.setAttribute( 'aria-selected', next );
+			}
+		} else {
+			this.removeAttribute( 'aria-selected' );
+		}
+	}
+
 	protected render() {
 		// Unreachable — `requestUpdate` is the only caller and we
 		// overrode it above. The Component base contract requires a
@@ -246,6 +304,7 @@ export class OsTile extends Component {
 		const kind = this.getAttribute( 'kind' ) ?? 'entry';
 		const status = this.getAttribute( 'status' ) ?? '';
 		const selected = this.hasAttribute( 'selected' );
+		const selectable = this.hasAttribute( 'selectable' );
 		const missing = this.hasAttribute( 'missing' );
 		const accessGated = this.hasAttribute( 'access-gated' );
 
@@ -286,8 +345,18 @@ export class OsTile extends Component {
 			this.dataset.role = kind;
 		}
 
-		// Accessibility — the host acts as a button.
-		this.setAttribute( 'role', 'listitem' );
+		// Accessibility — the host acts as a button. On a canvas that
+		// supports selection the tile becomes an `option` instead: a
+		// `listitem` may not carry `aria-selected`, so a multi-select
+		// grid of listitems announces nothing about what is picked.
+		// The selection controller sets `selectable` when it registers
+		// the tile, which is why this can't just key off `selected`.
+		this.setAttribute( 'role', selectable ? 'option' : 'listitem' );
+		if ( selectable ) {
+			this.setAttribute( 'aria-selected', selected ? 'true' : 'false' );
+		} else {
+			this.removeAttribute( 'aria-selected' );
+		}
 		this.setAttribute( 'aria-label', label );
 		if ( ! this.hasAttribute( 'tabindex' ) ) {
 			this.setAttribute( 'tabindex', '0' );

--- a/tests/vitest/desktop-files-bin-drop.test.ts
+++ b/tests/vitest/desktop-files-bin-drop.test.ts
@@ -198,6 +198,147 @@ describe( 'recycle-bin dock icon drop (user regression)', () => {
 		).toBe( false );
 	} );
 
+	test( 'dropping a SET on the bin trashes every item in it', async () => {
+		const { store, rest, binTargets } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( {
+			baseUrl: 'https://example.test/files',
+			nonce: 'n',
+		} );
+
+		const fetchSpy = vi.fn(
+			async () =>
+				new Response( JSON.stringify( { deleted: true } ), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				} ),
+		);
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+
+		const dockTile = document.createElement( 'div' );
+		dockTile.classList.add( 'os-dock__item', 'os-dock__item--system' );
+		dockTile.dataset.systemId = 'desktop-mode-recycle-bin';
+		const innerBtn = document.createElement( 'button' );
+		innerBtn.classList.add( 'os-dock__item-primary' );
+		dockTile.appendChild( innerBtn );
+		document.body.appendChild( dockTile );
+		binTargets.installRecycleBinDropTargets( manager );
+
+		const a = placement( 11, 'link' );
+		const b = placement( 12, 'link' );
+		const c = placement( 13, 'link' );
+		store.setFolderPlacements( 0, [ a, b, c ] );
+
+		const sourceTile = document.createElement( 'div' );
+		sourceTile.className = 'os-file-tile';
+		document.body.appendChild( sourceTile );
+		document.elementFromPoint = ( x, y ) =>
+			x >= 280 && x < 340 && y >= 280 && y < 340 ? innerBtn : null;
+
+		manager.start( {
+			payload: {
+				type: 'desktop-file',
+				source: sourceTile,
+				data: {
+					placement: a,
+					placements: [ a, b, c ],
+					sourceFolderId: 0,
+				},
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 100, 100, sourceTile ),
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 110, 100 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 300, 300 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 300, 300 ) );
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		const deleted = fetchSpy.mock.calls
+			.filter(
+				( call ) =>
+					( call[ 1 ] as RequestInit | undefined )?.method === 'DELETE',
+			)
+			.map( ( call ) => String( call[ 0 ] ) );
+		for ( const id of [ 11, 12, 13 ] ) {
+			expect(
+				deleted.some( ( u ) => u.endsWith( `/placements/${ id }` ) ),
+			).toBe( true );
+		}
+		// All three are gone locally, in one optimistic pass.
+		expect(
+			store.getFilesState().placementsByFolder.get( 0 )?.length,
+		).toBe( 0 );
+	} );
+
+	test( 'a set containing an un-trashable item is refused whole', async () => {
+		const { store, rest, binTargets } = await load();
+		store.__resetFilesStoreForTests();
+		rest.installRestDeps( {
+			baseUrl: 'https://example.test/files',
+			nonce: 'n',
+		} );
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response( '{}', {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					} ),
+			),
+		);
+
+		const manager = new DragManager();
+		installManagerOnWindow( manager );
+		const dockTile = document.createElement( 'div' );
+		dockTile.classList.add( 'os-dock__item', 'os-dock__item--system' );
+		dockTile.dataset.systemId = 'desktop-mode-recycle-bin';
+		const innerBtn = document.createElement( 'button' );
+		innerBtn.classList.add( 'os-dock__item-primary' );
+		dockTile.appendChild( innerBtn );
+		document.body.appendChild( dockTile );
+		binTargets.installRecycleBinDropTargets( manager );
+
+		const ok = placement( 21, 'link' );
+		// Server says this one may not be trashed — a shared folder's
+		// read-only item.
+		const denied = { ...placement( 22, 'link' ), canTrash: false };
+		const sourceTile = document.createElement( 'div' );
+		sourceTile.className = 'os-file-tile';
+		document.body.appendChild( sourceTile );
+		document.elementFromPoint = ( x, y ) =>
+			x >= 280 && x < 340 && y >= 280 && y < 340 ? innerBtn : null;
+
+		const onCommit = vi.fn();
+		manager.start( {
+			payload: {
+				type: 'desktop-file',
+				source: sourceTile,
+				data: {
+					placement: ok,
+					placements: [ ok, denied ],
+					sourceFolderId: 0,
+				},
+				ghost: { offsetX: 30, offsetY: 30 },
+			},
+			origin: pointerEvent( 'pointerdown', 100, 100, sourceTile ),
+			onCommit,
+		} );
+		document.dispatchEvent( pointerEvent( 'pointermove', 110, 100 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 300, 300 ) );
+		// Refused up front: no highlight, and the release commits
+		// nothing. Trashing the half that's allowed would report
+		// success for an operation that half-happened.
+		expect( dockTile.hasAttribute( 'data-os-trash-drop-active' ) ).toBe(
+			false,
+		);
+		document.dispatchEvent( pointerEvent( 'pointerup', 300, 300 ) );
+		expect( onCommit ).not.toHaveBeenCalled();
+	} );
+
 	test( 'dragging the recycle bin onto itself is rejected — no self-trash', async () => {
 		// Regression: the bin tile (a `'shortcut'` placement with
 		// `file.ref === 'desktop-mode-recycle-bin'`) is registered as

--- a/tests/vitest/desktop-files-drag.test.ts
+++ b/tests/vitest/desktop-files-drag.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
 import { DragManager } from '../../src/drag/manager';
 import { __resetRecoveryForTests } from '../../src/drag/recovery';
+import { GRID_CELL_H, GRID_PADDING } from '../../src/desktop-files/grid';
 
 type LayerModule = typeof import( '../../src/desktop-files/layer' );
 type StoreModule = typeof import( '../../src/desktop-files/store' );
@@ -491,9 +492,11 @@ describe( 'desktop-files drag (DragManager-backed)', () => {
 			( patch![ 1 ] as RequestInit ).body as string,
 		) as { x: number; y: number; parentId: number };
 		// Critical assertion: the snapped cell is (0, 1) — NOT (0, 0)
-		// which is My WordPress's pinned slot.
-		expect( body.x ).toBe( 16 );
-		expect( body.y ).toBe( 126 );
+		// which is My WordPress's pinned slot. Derived from the grid
+		// constants rather than spelled out, so retuning the gap
+		// doesn't read as this test failing.
+		expect( body.x ).toBe( GRID_PADDING );
+		expect( body.y ).toBe( GRID_PADDING + GRID_CELL_H );
 
 		handle.dispose();
 	} );

--- a/tests/vitest/desktop-files-folder-status-bar.test.ts
+++ b/tests/vitest/desktop-files-folder-status-bar.test.ts
@@ -9,6 +9,7 @@ async function load() {
 	return {
 		bar: await import( '../../src/desktop-files/folder-status-bar' ),
 		store: await import( '../../src/desktop-files/store' ),
+		hooks: await import( '../../src/hooks' ),
 	};
 }
 
@@ -128,6 +129,67 @@ describe( 'folder status bar', () => {
 			'[data-segment-id="count"] .os-folder-status-bar__label',
 		);
 		expect( seg?.textContent ).toBe( '1 file' );
+	} );
+
+	test( 'shows the selection size, and only while there is one', async () => {
+		const { bar, store } = await load();
+		store.__resetFilesStoreForTests();
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		let count = 0;
+		let notify: () => void = () => undefined;
+		bar.mountFolderStatusBar( host, 0, {
+			selection: {
+				count: () => count,
+				subscribe: ( cb ) => {
+					notify = cb;
+					return () => undefined;
+				},
+			},
+		} );
+		// Nothing selected — no segment at all. A permanent
+		// "0 selected" would be noise on a glanceable bar.
+		expect(
+			host.querySelector( '[data-segment-id="selection"]' ),
+		).toBeNull();
+
+		count = 3;
+		notify();
+		const seg = host.querySelector< HTMLElement >(
+			'[data-segment-id="selection"] .os-folder-status-bar__label',
+		);
+		expect( seg?.textContent ).toBe( '3 selected' );
+
+		count = 0;
+		notify();
+		expect(
+			host.querySelector( '[data-segment-id="selection"]' ),
+		).toBeNull();
+	} );
+
+	test( 'the status-bar filter sees the selection size', async () => {
+		const { bar, store, hooks } = await load();
+		store.__resetFilesStoreForTests();
+		hooks.addFilter(
+			'os.files.folder-window.status-bar',
+			'test/selection',
+			(
+				segs: unknown,
+				ctx: { selectedCount: number },
+			) => [
+				...( segs as Array< Record< string, unknown > > ),
+				{ id: 'echo', label: `saw ${ ctx.selectedCount }` },
+			],
+		);
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		bar.mountFolderStatusBar( host, 0, {
+			selection: { count: () => 2, subscribe: () => () => undefined },
+		} );
+		const seg = host.querySelector< HTMLElement >(
+			'[data-segment-id="echo"] .os-folder-status-bar__label',
+		);
+		expect( seg?.textContent ).toBe( 'saw 2' );
 	} );
 
 	test( 'dispose unmounts and stops repainting', async () => {

--- a/tests/vitest/desktop-files-multi-drag.test.ts
+++ b/tests/vitest/desktop-files-multi-drag.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Multi-item drag: lifting a selection carries the whole set, and the
+ * drop targets act on all of it.
+ *
+ * The payload half is asserted directly (what the manager is handed),
+ * because it is the contract every drop target — ours and a plugin's
+ * — reads. The end-to-end drop is asserted through the REST calls the
+ * canvas issues.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import {
+	dragPlacements,
+	dragShortcutItems,
+} from '../../src/desktop-files/drag-payloads';
+
+type LayerModule = typeof import( '../../src/desktop-files/layer' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+
+interface StartedDrag {
+	payload: {
+		type: string;
+		source: HTMLElement;
+		data: Record< string, unknown >;
+		ghost?: {
+			element?: HTMLElement;
+			hint?: { accept?: string; neutral?: string };
+		};
+	};
+}
+
+async function load(): Promise< {
+	layer: LayerModule;
+	store: StoreModule;
+	rest: RestModule;
+} > {
+	vi.resetModules();
+	return {
+		layer: await import( '../../src/desktop-files/layer' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+	};
+}
+
+const placement = (
+	id: number,
+	x: number,
+	y: number,
+	type: 'post' | 'folder' = 'post',
+) => ( {
+	id,
+	parentId: 0,
+	x,
+	y,
+	sortOrder: 0,
+	updatedAtMs: 1,
+	meta: null,
+	file: {
+		type,
+		ref: String( id ),
+		title: `Item ${ id }`,
+		icon: 'dashicons-admin-post',
+		previewUrl: '',
+		exists: true,
+	},
+} );
+
+function pointerEvent(
+	type: string,
+	clientX: number,
+	clientY: number,
+	target?: HTMLElement,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	if ( target ) {
+		Object.defineProperty( ev, 'target', { value: target } );
+	}
+	return ev as unknown as PointerEvent;
+}
+
+function rect( el: HTMLElement, x: number, y: number, w: number, h: number ) {
+	Object.defineProperty( el, 'getBoundingClientRect', {
+		configurable: true,
+		value: () =>
+			( {
+				left: x,
+				top: y,
+				right: x + w,
+				bottom: y + h,
+				width: w,
+				height: h,
+				x,
+				y,
+				toJSON: () => ( {} ),
+			} ) as DOMRect,
+	} );
+}
+
+/** A drag manager that records what it was asked to lift. */
+function installRecordingManager(): StartedDrag[] {
+	const started: StartedDrag[] = [];
+	const w = window as unknown as { wp: Record< string, unknown > };
+	w.wp = w.wp ?? {};
+	( w.wp as { os?: Record< string, unknown > } ).os = {
+		dragManager: {
+			start: ( session: StartedDrag ) => {
+				started.push( session );
+				return session;
+			},
+			registerDropTarget: () => () => undefined,
+			recentlyEndedDrag: () => false,
+		},
+	};
+	return started;
+}
+
+async function mount( placements: ReturnType< typeof placement >[] ) {
+	const { layer, store, rest } = await load();
+	store.__resetFilesStoreForTests();
+	rest.installRestDeps( {
+		baseUrl: 'https://example.test/files',
+		nonce: 'n',
+	} );
+	const fetchSpy = vi.fn(
+		async () =>
+			new Response( JSON.stringify( { placements: [], folderId: 0 } ), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			} ),
+	);
+	vi.stubGlobal( 'fetch', fetchSpy );
+	store.setFolderPlacements( 0, placements as never );
+
+	const host = document.createElement( 'div' );
+	Object.defineProperty( host, 'clientWidth', {
+		value: 1024,
+		configurable: true,
+	} );
+	Object.defineProperty( host, 'clientHeight', {
+		value: 768,
+		configurable: true,
+	} );
+	document.body.appendChild( host );
+	rect( host, 0, 0, 1024, 768 );
+	const handle = layer.mountFilesLayer( host, 0 );
+	const container = host.querySelector< HTMLElement >( '.os-files-layer' )!;
+	rect( container, 0, 0, 1024, 768 );
+	return { handle, host, container, fetchSpy, store };
+}
+
+function tileFor( host: HTMLElement, id: number ): HTMLElement {
+	return host.querySelector< HTMLElement >( `[data-placement-id="${ id }"]` )!;
+}
+
+function click( el: Element, init: MouseEventInit = {} ): void {
+	el.dispatchEvent( new MouseEvent( 'click', { bubbles: true, ...init } ) );
+}
+
+describe( 'multi-item drag', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		document.body.innerHTML = '';
+		delete ( window as unknown as { wp?: unknown } ).wp;
+	} );
+
+	test( 'a single-item drag carries no `placements` at all', async () => {
+		const started = installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+		] );
+		const tile = tileFor( host, 1 );
+		rect( tile, 0, 0, 88, 96 );
+		click( tile );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 40, 40, tile ) );
+
+		expect( started ).toHaveLength( 1 );
+		const data = started[ 0 ].payload.data;
+		// Byte-identical to what every pre-multi-drag target expects.
+		expect( data.placements ).toBeUndefined();
+		expect( ( data.placement as { id: number } ).id ).toBe( 1 );
+		// …and the shared reader still reports the one item.
+		expect( dragPlacements( data as never ).map( ( p ) => p.id ) ).toEqual( [
+			1,
+		] );
+		handle.dispose();
+	} );
+
+	test( 'grabbing a selected tile lifts the whole selection', async () => {
+		const started = installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+			placement( 3, 200, 0 ),
+		] );
+		const tile = tileFor( host, 2 );
+		rect( tile, 100, 0, 88, 96 );
+		click( tileFor( host, 1 ) );
+		click( tile, { metaKey: true } );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 140, 40, tile ) );
+
+		const data = started[ 0 ].payload.data;
+		expect( dragPlacements( data as never ).map( ( p ) => p.id ) ).toEqual( [
+			1, 2,
+		] );
+		// The grabbed tile stays the primary, so a target that only
+		// reads `placement` acts on what the user pointed at.
+		expect( ( data.placement as { id: number } ).id ).toBe( 2 );
+		handle.dispose();
+	} );
+
+	test( 'grabbing an unselected tile drags one and leaves the selection alone until the drag lifts', async () => {
+		const started = installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+			placement( 3, 200, 0 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+
+		const tile = tileFor( host, 3 );
+		rect( tile, 200, 0, 88, 96 );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 240, 40, tile ) );
+
+		const data = started[ 0 ].payload.data;
+		expect( dragPlacements( data as never ).map( ( p ) => p.id ) ).toEqual( [
+			3,
+		] );
+		// Crucially the selection has NOT moved yet: mutating it here
+		// repaints the tile mid-gesture and costs the user their
+		// click (and therefore their double-click).
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 1, 2 ] );
+
+		// Once the gesture proves itself a drag, the highlight catches
+		// up with what's moving.
+		document.dispatchEvent( new CustomEvent( 'os.drag.start' ) );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 3 ] );
+		handle.dispose();
+	} );
+
+	test( 'a press that turns out to be a click never moves the selection', async () => {
+		installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+		] );
+		click( tileFor( host, 1 ) );
+
+		const tile = tileFor( host, 2 );
+		rect( tile, 100, 0, 88, 96 );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 140, 40, tile ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 140, 40 ) );
+		// The armed sync must be dropped on pointerup, or an unrelated
+		// drag later in the session would apply it.
+		document.dispatchEvent( new CustomEvent( 'os.drag.start' ) );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 1 ] );
+		handle.dispose();
+	} );
+
+	test( 'a selection change never rebuilds the tile’s children', async () => {
+		// The regression this guards: `<os-tile>._paint()` replaces the
+		// visual + label on every attribute change. If that happens
+		// between `mousedown` and `mouseup`, the browser synthesizes no
+		// `click` — so no `dblclick`, and the tile can no longer be
+		// opened. A folder that had just been dropped on was the first
+		// place it showed up.
+		installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+		] );
+		const tile = tileFor( host, 1 );
+		const visualBefore = tile.querySelector( '.os-file-tile__visual' );
+		const labelBefore = tile.querySelector( '.os-file-tile__label' );
+		expect( visualBefore ).not.toBeNull();
+
+		click( tile );
+		expect( tile.hasAttribute( 'selected' ) ).toBe( true );
+		// Same nodes — only classes and ARIA moved.
+		expect( tile.querySelector( '.os-file-tile__visual' ) ).toBe(
+			visualBefore,
+		);
+		expect( tile.querySelector( '.os-file-tile__label' ) ).toBe(
+			labelBefore,
+		);
+		expect( tile.classList.contains( 'os-file-tile--selected' ) ).toBe(
+			true,
+		);
+		expect( tile.getAttribute( 'aria-selected' ) ).toBe( 'true' );
+
+		click( tileFor( host, 2 ) );
+		expect( tile.querySelector( '.os-file-tile__visual' ) ).toBe(
+			visualBefore,
+		);
+		expect( tile.getAttribute( 'aria-selected' ) ).toBe( 'false' );
+		handle.dispose();
+	} );
+
+	test( 'double-click still opens a tile that was not selected first', async () => {
+		installRecordingManager();
+		const { host, handle } = await mount( [ placement( 1, 0, 0, 'folder' ) ] );
+		const tile = tileFor( host, 1 );
+		const opened: unknown[] = [];
+		tile.addEventListener( 'dblclick', ( e ) => opened.push( e ) );
+
+		// The full gesture: press, release, click, click, dblclick.
+		// Nothing in it may destroy the node the events are landing on.
+		rect( tile, 0, 0, 88, 96 );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 40, 40, tile ) );
+		const visual = tile.querySelector( '.os-file-tile__visual' );
+		document.dispatchEvent( pointerEvent( 'pointerup', 40, 40 ) );
+		click( tile );
+		expect( tile.querySelector( '.os-file-tile__visual' ) ).toBe( visual );
+		click( tile );
+		tile.dispatchEvent( new MouseEvent( 'dblclick', { bubbles: true } ) );
+		expect( opened ).toHaveLength( 1 );
+		handle.dispose();
+	} );
+
+	test( 'a multi-drag ghost states the count and dims the whole set', async () => {
+		const started = installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+			placement( 3, 200, 0 ),
+		] );
+		const tile = tileFor( host, 1 );
+		rect( tile, 0, 0, 88, 96 );
+		click( tile );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		click( tileFor( host, 3 ), { metaKey: true } );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 40, 40, tile ) );
+
+		const ghost = started[ 0 ].payload.ghost;
+		expect(
+			ghost?.element?.querySelector( '.os-drag-stack__count' )?.textContent,
+		).toBe( '3' );
+		expect( ghost?.hint?.neutral ).toBe( 'Moving 3 items' );
+
+		// Dimming waits for the lift — a press that turns out to be a
+		// click must leave the canvas as it found it.
+		expect(
+			tileFor( host, 2 ).classList.contains( 'os-file-tile--dragging' ),
+		).toBe( false );
+		document.dispatchEvent( new CustomEvent( 'os.drag.start' ) );
+		// The other two tiles dim too — the manager only knows about
+		// the source.
+		expect(
+			tileFor( host, 2 ).classList.contains( 'os-file-tile--dragging' ),
+		).toBe( true );
+
+		document.dispatchEvent( new CustomEvent( 'os.drag.end' ) );
+		expect(
+			tileFor( host, 2 ).classList.contains( 'os-file-tile--dragging' ),
+		).toBe( false );
+		handle.dispose();
+	} );
+
+	test( 'the ghost clone never carries the selected state', async () => {
+		const started = installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+		] );
+		const tile = tileFor( host, 1 );
+		rect( tile, 0, 0, 88, 96 );
+		click( tile );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		tile.dispatchEvent( pointerEvent( 'pointerdown', 40, 40, tile ) );
+
+		const clone = started[ 0 ].payload.ghost?.element?.querySelector(
+			'.os-file-tile',
+		);
+		expect( clone?.hasAttribute( 'selected' ) ).toBe( false );
+		handle.dispose();
+	} );
+
+	test( 'a modifier-click never lifts anything', async () => {
+		const started = installRecordingManager();
+		const { host, handle } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 100, 0 ),
+		] );
+		const tile = tileFor( host, 2 );
+		rect( tile, 100, 0, 88, 96 );
+		const ev = pointerEvent( 'pointerdown', 140, 40, tile );
+		Object.defineProperty( ev, 'metaKey', { value: true } );
+		tile.dispatchEvent( ev );
+		expect( started ).toHaveLength( 0 );
+		handle.dispose();
+	} );
+
+	test( 'dropping a set on the canvas moves every item', async () => {
+		// Real manager this time, so the canvas drop target runs.
+		const { DragManager } = await import( '../../src/drag/manager' );
+		const { __resetRecoveryForTests } = await import(
+			'../../src/drag/recovery'
+		);
+		__resetRecoveryForTests();
+		const manager = new DragManager();
+		const w = window as unknown as { wp: Record< string, unknown > };
+		w.wp = w.wp ?? {};
+		( w.wp as { os?: Record< string, unknown > } ).os = {
+			dragManager: manager,
+		};
+
+		const { host, handle, fetchSpy } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 96, 0 ),
+		] );
+		const one = tileFor( host, 1 );
+		const two = tileFor( host, 2 );
+		rect( one, 0, 0, 88, 96 );
+		rect( two, 96, 0, 88, 96 );
+		document.elementFromPoint = () => host;
+
+		click( one );
+		click( two, { metaKey: true } );
+		fetchSpy.mockClear();
+
+		one.dispatchEvent( pointerEvent( 'pointerdown', 40, 40, one ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 400, 300 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 400, 300 ) );
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const patched = fetchSpy.mock.calls
+			.filter(
+				( call ) =>
+					( call[ 1 ] as RequestInit | undefined )?.method === 'PATCH',
+			)
+			.map( ( call ) => String( call[ 0 ] ) );
+		// BOTH placements were persisted, not just the grabbed one.
+		expect( patched.some( ( u ) => u.includes( '/placements/1' ) ) ).toBe(
+			true,
+		);
+		expect( patched.some( ( u ) => u.includes( '/placements/2' ) ) ).toBe(
+			true,
+		);
+		handle.dispose();
+	} );
+
+	test( 'a dropped set keeps its shape', async () => {
+		const { DragManager } = await import( '../../src/drag/manager' );
+		const { __resetRecoveryForTests } = await import(
+			'../../src/drag/recovery'
+		);
+		__resetRecoveryForTests();
+		const manager = new DragManager();
+		const w = window as unknown as { wp: Record< string, unknown > };
+		w.wp = w.wp ?? {};
+		( w.wp as { os?: Record< string, unknown > } ).os = {
+			dragManager: manager,
+		};
+
+		// Two tiles side by side, one grid cell apart.
+		const { host, handle, store } = await mount( [
+			placement( 1, 0, 0 ),
+			placement( 2, 96, 0 ),
+		] );
+		const one = tileFor( host, 1 );
+		const two = tileFor( host, 2 );
+		rect( one, 0, 0, 88, 96 );
+		rect( two, 96, 0, 88, 96 );
+		document.elementFromPoint = () => host;
+
+		click( one );
+		click( two, { metaKey: true } );
+		one.dispatchEvent( pointerEvent( 'pointerdown', 40, 40, one ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 400, 300 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 400, 300 ) );
+		await Promise.resolve();
+
+		const list = store.getFilesState().placementsByFolder.get( 0 ) ?? [];
+		const a = list.find( ( p ) => p.id === 1 )!;
+		const b = list.find( ( p ) => p.id === 2 )!;
+		// Still on the same row, still one cell apart — three icons
+		// dropped in a row give you three icons in a row.
+		expect( b.y ).toBe( a.y );
+		expect( b.x ).toBeGreaterThan( a.x );
+		handle.dispose();
+	} );
+
+	test( 'shortcut payloads expose their set the same way', () => {
+		// Single item: the top-level fields ARE the one item.
+		expect(
+			dragShortcutItems( { kind: 'post', ref: '7' } ).map( ( i ) => i.ref ),
+		).toEqual( [ '7' ] );
+		// Multi: the `items` array wins.
+		expect(
+			dragShortcutItems( {
+				kind: 'post',
+				ref: '7',
+				items: [
+					{ kind: 'post', ref: '7' },
+					{ kind: 'post', ref: '8' },
+				],
+			} ).map( ( i ) => i.ref ),
+		).toEqual( [ '7', '8' ] );
+	} );
+} );

--- a/tests/vitest/desktop-files-selection.test.ts
+++ b/tests/vitest/desktop-files-selection.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Multi-selection on the files layer: the Finder right-click rule,
+ * the intersected action set for a mixed selection, and selection
+ * survival across the layer's repaint paths.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+type LayerModule = typeof import( '../../src/desktop-files/layer' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+
+async function load(): Promise< {
+	layer: LayerModule;
+	store: StoreModule;
+	rest: RestModule;
+} > {
+	vi.resetModules();
+	return {
+		layer: await import( '../../src/desktop-files/layer' ),
+		store: await import( '../../src/desktop-files/store' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+	};
+}
+
+const placement = (
+	id: number,
+	type: 'post' | 'attachment' | 'folder' = 'post',
+	overrides: Record< string, unknown > = {},
+) => ( {
+	id,
+	parentId: 0,
+	x: id * 100,
+	y: 0,
+	sortOrder: 0,
+	updatedAtMs: 1,
+	meta: null,
+	file: {
+		type,
+		ref: String( id ),
+		title: `Item ${ id }`,
+		icon: 'dashicons-admin-post',
+		previewUrl: '',
+		exists: true,
+	},
+	...overrides,
+} );
+
+function stubRest() {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify( { placements: [], folderId: 0 } ),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				),
+		),
+	);
+}
+
+async function mount(
+	placements: ReturnType< typeof placement >[],
+): Promise< {
+	host: HTMLElement;
+	handle: ReturnType< LayerModule[ 'mountFilesLayer' ] >;
+	store: StoreModule;
+} > {
+	const { layer, store, rest } = await load();
+	store.__resetFilesStoreForTests();
+	rest.installRestDeps( {
+		baseUrl: 'https://example.test/files',
+		nonce: 'n',
+	} );
+	stubRest();
+	store.setFolderPlacements( 0, placements as never );
+	const host = document.createElement( 'div' );
+	document.body.appendChild( host );
+	const handle = layer.mountFilesLayer( host, 0 );
+	return { host, handle, store };
+}
+
+function tileFor( host: HTMLElement, id: number ): HTMLElement {
+	const el = host.querySelector< HTMLElement >(
+		`[data-placement-id="${ id }"]`,
+	);
+	if ( ! el ) {
+		throw new Error( `no tile for placement ${ id }` );
+	}
+	return el;
+}
+
+function click( el: Element, init: MouseEventInit = {} ): void {
+	el.dispatchEvent( new MouseEvent( 'click', { bubbles: true, ...init } ) );
+}
+
+function rightClick( el: Element ): void {
+	el.dispatchEvent(
+		new MouseEvent( 'contextmenu', {
+			bubbles: true,
+			clientX: 10,
+			clientY: 10,
+		} ),
+	);
+}
+
+function menuItemIds(): string[] {
+	const menu = document.querySelector( 'os-context-menu' );
+	return Array.from(
+		menu?.querySelectorAll( 'os-context-menu-option' ) ?? [],
+	).map( ( o ) => ( o as HTMLElement ).dataset.menuItemId ?? '' );
+}
+
+function menuLabels(): string[] {
+	const menu = document.querySelector( 'os-context-menu' );
+	return Array.from(
+		menu?.querySelectorAll( 'os-context-menu-option' ) ?? [],
+	).map( ( o ) => o.textContent ?? '' );
+}
+
+describe( 'files layer multi-selection', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'ctrl-click builds a selection the handle reports', async () => {
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+			placement( 3 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 1, 2 ] );
+		handle.dispose();
+	} );
+
+	test( 'onSelectionChange reports null for a multi-selection', async () => {
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+		] );
+		const single: unknown[] = [];
+		handle.onSelectionChange( ( p ) => single.push( p?.id ?? null ) );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		expect( single ).toEqual( [ 1, null ] );
+		handle.dispose();
+	} );
+
+	test( 'onSelectionChanged reports the whole set', async () => {
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+		] );
+		const sets: number[][] = [];
+		handle.onSelectionChanged( ( ps ) => sets.push( ps.map( ( p ) => p.id ) ) );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		expect( sets ).toEqual( [ [ 1 ], [ 1, 2 ] ] );
+		handle.dispose();
+	} );
+
+	test( 'right-click outside the selection replaces it', async () => {
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+			placement( 3 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		rightClick( tileFor( host, 3 ) );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 3 ] );
+		handle.dispose();
+	} );
+
+	test( 'right-click inside the selection keeps it', async () => {
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		rightClick( tileFor( host, 2 ) );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 1, 2 ] );
+		handle.dispose();
+	} );
+
+	test( 'a single-tile menu still lists the per-type actions', async () => {
+		const { host, handle } = await mount( [ placement( 1, 'post' ) ] );
+		rightClick( tileFor( host, 1 ) );
+		expect( menuItemIds() ).toEqual( [
+			'open',
+			'navigate-into',
+			'remove',
+		] );
+		handle.dispose();
+	} );
+
+	test( 'a post + an attachment keep Open and Trash, drop the rest', async () => {
+		const { host, handle } = await mount( [
+			placement( 1, 'post' ),
+			placement( 2, 'attachment' ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		rightClick( tileFor( host, 2 ) );
+		expect( menuItemIds() ).toEqual( [ 'open', 'trash' ] );
+		expect( menuLabels() ).toEqual( [
+			'Open 2 items',
+			'Move 2 items to Trash',
+		] );
+		handle.dispose();
+	} );
+
+	test( 'a folder + a post still share one Trash entry', async () => {
+		const { host, handle } = await mount( [
+			placement( 1, 'folder' ),
+			placement( 2, 'post' ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		rightClick( tileFor( host, 1 ) );
+		// `delete-folder` and `remove` merge on `multiId: 'trash'`;
+		// rename and navigate-into are single-item and drop out.
+		expect( menuItemIds() ).toEqual( [ 'open', 'trash' ] );
+		handle.dispose();
+	} );
+
+	test( 'the menu records every placement it acts on', async () => {
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		rightClick( tileFor( host, 1 ) );
+		const menu = document.querySelector< HTMLElement >( 'os-context-menu' );
+		expect( menu?.dataset.placementIds ).toBe( '1,2' );
+		handle.dispose();
+	} );
+
+	test( 'selection survives an incremental repaint', async () => {
+		const { host, handle, store } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+			placement( 3 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		// A peer adds a placement — the incremental path reuses the
+		// existing tiles.
+		store.upsertPlacement( placement( 4 ) as never, 'remote' );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 1, 2 ] );
+		expect( tileFor( host, 1 ).hasAttribute( 'selected' ) ).toBe( true );
+		handle.dispose();
+	} );
+
+	test( 'a deleted placement drops out of the selection', async () => {
+		const { host, handle, store } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+		] );
+		click( tileFor( host, 1 ) );
+		click( tileFor( host, 2 ), { metaKey: true } );
+		store.removePlacement( 2, 'remote' );
+		expect( handle.getSelection().map( ( p ) => p.id ) ).toEqual( [ 1 ] );
+		handle.dispose();
+	} );
+
+	test( 'a modifier click does not lift a drag', async () => {
+		const started = vi.fn();
+		// Attach to the existing `wp` (the hooks stub lives there);
+		// replacing it wholesale would strip `wp.hooks` and the tile
+		// renderer's filters would throw.
+		const wp = ( window as unknown as { wp: Record< string, unknown > } ).wp;
+		const previousOs = wp.os;
+		wp.os = {
+			dragManager: {
+				start: started,
+				registerDropTarget: () => () => undefined,
+			},
+		};
+		const { host, handle } = await mount( [
+			placement( 1 ),
+			placement( 2 ),
+		] );
+		const ev = new Event( 'pointerdown', { bubbles: true } );
+		Object.defineProperty( ev, 'button', { value: 0 } );
+		Object.defineProperty( ev, 'metaKey', { value: true } );
+		Object.defineProperty( ev, 'clientX', { value: 5 } );
+		Object.defineProperty( ev, 'clientY', { value: 5 } );
+		tileFor( host, 2 ).dispatchEvent( ev );
+		expect( started ).not.toHaveBeenCalled();
+		handle.dispose();
+		wp.os = previousOs;
+	} );
+} );

--- a/tests/vitest/desktop-files-trash-many.test.ts
+++ b/tests/vitest/desktop-files-trash-many.test.ts
@@ -159,6 +159,56 @@ describe( 'trashManyWithUndo', () => {
 		spy.mockRestore();
 	} );
 
+	test( 'Undo announces only what actually came back', async () => {
+		// Broadcasting the whole batch would tell the Recycle Bin's
+		// badge an item was restored while it is still in the trash —
+		// a lie that survives until the next full refresh.
+		const { trash, store } = await load();
+		const items = [ placement( 1 ), placement( 2 ), placement( 3 ) ];
+		store.setFolderPlacements( 0, items as never );
+		await trash.trashManyWithUndo( items as never );
+		const undo = toasts[ 0 ].action!.onClick;
+
+		const spy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		// One of the three restores fails.
+		rest.restoreTrashedItem.mockImplementationOnce( async () => {
+			throw new Error( 'network' );
+		} );
+		broadcasts.length = 0;
+		toasts.length = 0;
+		await undo();
+		spy.mockRestore();
+
+		const untrashed = broadcasts.filter(
+			( b ) => b.payload.action === 'untrashed',
+		);
+		// Two ids announced, not three.
+		expect( untrashed ).toHaveLength( 1 );
+		expect( untrashed[ 0 ].payload.ids ).toEqual( [ 2, 3 ] );
+		// …and the user is told the Undo didn't fully take.
+		expect( toasts[ 0 ]?.message ).toContain( 'could not be restored' );
+	} );
+
+	test( 'a fully successful Undo announces everything and says nothing', async () => {
+		const { trash, store } = await load();
+		const items = [ placement( 1 ), placement( 2 ) ];
+		store.setFolderPlacements( 0, items as never );
+		await trash.trashManyWithUndo( items as never );
+		const undo = toasts[ 0 ].action!.onClick;
+
+		broadcasts.length = 0;
+		toasts.length = 0;
+		await undo();
+
+		const untrashed = broadcasts.filter(
+			( b ) => b.payload.action === 'untrashed',
+		);
+		expect( untrashed[ 0 ].payload.ids ).toEqual( [ 1, 2 ] );
+		expect( toasts ).toHaveLength( 0 );
+	} );
+
 	test( 'an empty set does nothing at all', async () => {
 		const { trash } = await load();
 		await trash.trashManyWithUndo( [] );

--- a/tests/vitest/desktop-files-trash-many.test.ts
+++ b/tests/vitest/desktop-files-trash-many.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for `trashManyWithUndo` — trashing a selection as ONE action:
+ * one toast, one Undo, one broadcast per kind.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+type TrashModule = typeof import( '../../src/desktop-files/trash' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+
+const placement = (
+	id: number,
+	type: 'post' | 'folder' | 'shortcut' = 'post',
+	ref = String( id ),
+) => ( {
+	id,
+	parentId: 0,
+	x: 0,
+	y: 0,
+	sortOrder: 0,
+	updatedAtMs: 1,
+	meta: null,
+	file: {
+		type,
+		ref,
+		title: `Item ${ id }`,
+		icon: 'dashicons-admin-post',
+		previewUrl: '',
+		exists: true,
+	},
+} );
+
+interface Toast {
+	message: string;
+	action?: { label: string; onClick: () => void };
+}
+
+const rest = {
+	deletePlacement: vi.fn( async () => undefined ),
+	deleteFolder: vi.fn( async () => undefined ),
+	restoreTrashedItem: vi.fn( async () => undefined ),
+	listPlacements: vi.fn( async () => ( { placements: [], folderId: 0 } ) ),
+};
+
+let toasts: Toast[] = [];
+let broadcasts: Array< { topic: string; payload: Record< string, unknown > } > = [];
+
+async function load(): Promise< {
+	trash: TrashModule;
+	store: StoreModule;
+} > {
+	vi.resetModules();
+	toasts = [];
+	broadcasts = [];
+	for ( const fn of Object.values( rest ) ) {
+		fn.mockClear();
+	}
+	const wp = ( window as unknown as { wp: Record< string, unknown > } ).wp;
+	wp.os = {
+		showToast: ( t: Toast ) => toasts.push( t ),
+		broadcast: ( topic: string, payload: Record< string, unknown > ) =>
+			broadcasts.push( { topic, payload } ),
+	};
+	const store = await import( '../../src/desktop-files/store' );
+	store.__resetFilesStoreForTests();
+	// `trash.ts` reads REST + the store through `layer-deps`; swapping
+	// that one module is the whole seam.
+	vi.doMock( '../../src/desktop-files/layer-deps', () => ( {
+		rest,
+		store: {
+			getState: store.getFilesState,
+			subscribe: store.subscribeFilesStore,
+			setFolderPlacements: store.setFolderPlacements,
+			upsertPlacement: store.upsertPlacement,
+			upsertFolder: store.upsertFolder,
+			removePlacement: store.removePlacement,
+			removeFolder: store.removeFolder,
+			currentPlacement: store.currentPlacement,
+		},
+	} ) );
+	return { trash: await import( '../../src/desktop-files/trash' ), store };
+}
+
+describe( 'trashManyWithUndo', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		vi.doUnmock( '../../src/desktop-files/layer-deps' );
+		document.body.innerHTML = '';
+	} );
+
+	test( 'a single item routes to the per-item helper', async () => {
+		const { trash, store } = await load();
+		store.setFolderPlacements( 0, [ placement( 1 ) ] as never );
+		await trash.trashManyWithUndo( [ placement( 1 ) as never ] );
+		expect( rest.deletePlacement ).toHaveBeenCalledTimes( 1 );
+		expect( toasts ).toHaveLength( 1 );
+		expect( toasts[ 0 ].message ).toContain( '"Item 1" moved to Trash' );
+	} );
+
+	test( 'a set produces ONE toast with ONE undo', async () => {
+		const { trash, store } = await load();
+		const items = [ placement( 1 ), placement( 2 ), placement( 3 ) ];
+		store.setFolderPlacements( 0, items as never );
+		await trash.trashManyWithUndo( items as never );
+
+		expect( rest.deletePlacement ).toHaveBeenCalledTimes( 3 );
+		expect( toasts ).toHaveLength( 1 );
+		expect( toasts[ 0 ].message ).toBe( '3 items moved to Trash' );
+		// All three are gone from the store, optimistically.
+		expect( store.getFilesState().placementsByFolder.get( 0 ) ).toEqual( [] );
+
+		await toasts[ 0 ].action?.onClick();
+		expect( rest.restoreTrashedItem ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	test( 'folders go through the folder endpoint and broadcast separately', async () => {
+		const { trash, store } = await load();
+		const items = [ placement( 1, 'post' ), placement( 2, 'folder', '7' ) ];
+		store.setFolderPlacements( 0, items as never );
+		await trash.trashManyWithUndo( items as never );
+
+		expect( rest.deletePlacement ).toHaveBeenCalledWith( 1 );
+		expect( rest.deleteFolder ).toHaveBeenCalledWith( 7 );
+		// Subscribers delta by `ids.length`, so a mixed set has to be
+		// split by kind rather than flattened into one event.
+		const trashed = broadcasts.filter(
+			( b ) => b.payload.action === 'trashed',
+		);
+		expect( trashed.map( ( b ) => b.topic ).sort() ).toEqual( [
+			'os.folder.changed',
+			'os.placement.changed',
+		] );
+		expect(
+			trashed.find( ( b ) => b.topic === 'os.folder.changed' )?.payload.ids,
+		).toEqual( [ 7 ] );
+	} );
+
+	test( 'a partial failure still offers Undo for what survived', async () => {
+		const { trash, store } = await load();
+		rest.deletePlacement.mockImplementationOnce( async () => {
+			throw new Error( 'forbidden' );
+		} );
+		const spy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		const items = [ placement( 1 ), placement( 2 ) ];
+		store.setFolderPlacements( 0, items as never );
+		await trash.trashManyWithUndo( items as never );
+
+		expect( toasts ).toHaveLength( 1 );
+		expect( toasts[ 0 ].message ).toBe(
+			'1 item moved to Trash · 1 could not be moved',
+		);
+		// The optimistic eviction is reconciled against the server.
+		expect( rest.listPlacements ).toHaveBeenCalledWith( 0 );
+		spy.mockRestore();
+	} );
+
+	test( 'an empty set does nothing at all', async () => {
+		const { trash } = await load();
+		await trash.trashManyWithUndo( [] );
+		expect( rest.deletePlacement ).not.toHaveBeenCalled();
+		expect( toasts ).toHaveLength( 0 );
+	} );
+} );

--- a/tests/vitest/grid-metrics.test.ts
+++ b/tests/vitest/grid-metrics.test.ts
@@ -1,0 +1,189 @@
+/**
+ * One icon grid, two languages.
+ *
+ * The grid is declared in `assets/css/variables.css` (design tokens
+ * live there, and a desktop theme can retune them) and mirrored in
+ * `src/desktop-files/grid.ts`, because layout maths can't read CSS.
+ * A mirror nobody checks is just a second copy — this parses the
+ * stylesheet and proves the two agree.
+ *
+ * When this test fails it is telling you that you changed a number
+ * in one language and not the other. It names which.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+import {
+	GRID_CELL_H,
+	GRID_CELL_H_LARGE,
+	GRID_CELL_W,
+	GRID_CELL_W_LARGE,
+	GRID_GAP_X,
+	GRID_GAP_Y,
+	GRID_METRICS,
+	GRID_METRICS_LARGE,
+	GRID_PADDING,
+	TILE_H,
+	TILE_H_LARGE,
+	TILE_W,
+	TILE_W_LARGE,
+} from '../../src/desktop-files/grid';
+
+const ROOT = resolve( __dirname, '../..' );
+
+function css( file: string ): string {
+	return readFileSync( resolve( ROOT, file ), 'utf8' );
+}
+
+/** Read a `--token: 88px;` declaration as a number. */
+function token( source: string, name: string ): number {
+	const match = new RegExp(
+		`--${ name }:\\s*(-?[0-9.]+)px\\s*;`,
+	).exec( source );
+	if ( ! match ) {
+		throw new Error(
+			`variables.css declares no --${ name }. The grid tokens are ` +
+				'the source of truth for src/desktop-files/grid.ts; if you ' +
+				'removed one, remove its TS mirror too.',
+		);
+	}
+	return Number( match[ 1 ] );
+}
+
+describe( 'icon grid metrics', () => {
+	const variables = css( 'assets/css/variables.css' );
+
+	test( 'the TS mirror matches the CSS declaration', () => {
+		expect( TILE_W ).toBe( token( variables, 'os-tile-w' ) );
+		expect( TILE_H ).toBe( token( variables, 'os-tile-h' ) );
+		expect( GRID_GAP_X ).toBe( token( variables, 'os-grid-gap-x' ) );
+		expect( GRID_GAP_Y ).toBe( token( variables, 'os-grid-gap-y' ) );
+		expect( GRID_PADDING ).toBe( token( variables, 'os-grid-padding' ) );
+		expect( TILE_W_LARGE ).toBe( token( variables, 'os-tile-w-large' ) );
+		expect( TILE_H_LARGE ).toBe( token( variables, 'os-tile-h-large' ) );
+	} );
+
+	test( 'the cell is derived from tile + gap, never declared', () => {
+		expect( GRID_CELL_W ).toBe( TILE_W + GRID_GAP_X );
+		expect( GRID_CELL_H ).toBe( TILE_H + GRID_GAP_Y );
+		expect( GRID_CELL_W_LARGE ).toBe( TILE_W_LARGE + GRID_GAP_X );
+		expect( GRID_CELL_H_LARGE ).toBe( TILE_H_LARGE + GRID_GAP_Y );
+	} );
+
+	test( 'every canvas lays out on the same pitch', () => {
+		// The site folder used to declare its own `TILE_METRICS`; it
+		// now consumes these. If a surface reintroduces a private
+		// pitch, the grid stops being one grid.
+		expect( GRID_METRICS ).toEqual( {
+			w: GRID_CELL_W,
+			h: GRID_CELL_H,
+			pad: GRID_PADDING,
+		} );
+		expect( GRID_METRICS_LARGE ).toEqual( {
+			w: GRID_CELL_W_LARGE,
+			h: GRID_CELL_H_LARGE,
+			pad: GRID_PADDING,
+		} );
+	} );
+
+	test( 'there is a visible gap between neighbouring tiles', () => {
+		// The bug this pins: an 88px tile in a 96px cell reads as
+		// "8px of air" right up until the tile's own padding is added
+		// outside its declared width, at which point the tiles touch.
+		expect( GRID_GAP_X ).toBeGreaterThanOrEqual( 12 );
+		expect( GRID_GAP_Y ).toBeGreaterThanOrEqual( 12 );
+	} );
+
+	test( 'the tile is sized from the tokens, and sized inside its box', () => {
+		const files = css( 'assets/css/desktop-files.css' );
+		const rule = /\.os-file-tile \{([\s\S]*?)\n\}/.exec( files );
+		expect( rule ).not.toBeNull();
+		const body = rule![ 1 ];
+		// `border-box` is what makes the declared width the REAL
+		// width — without it the padding is added on top and eats the
+		// gap the grid thinks it left.
+		expect( body ).toMatch( /box-sizing:\s*border-box/ );
+		expect( body ).toMatch( /width:\s*var\(\s*--os-tile-w/ );
+		// FIXED height, not `min-height`. The tile box is the
+		// selection ring; a box that grows with its label gives a row
+		// of selected icons a ragged top edge.
+		expect( body ).toMatch( /\n\theight:\s*var\(\s*--os-tile-h/ );
+		expect( body ).not.toMatch( /min-height:\s*var\(\s*--os-tile-h/ );
+	} );
+
+	test( 'the fixed height fits the tallest a tile can be', () => {
+		// 8px padding + 48px icon well + 6px gap + two clamped label
+		// lines + 8px padding. If any of those grow, this is the test
+		// that says the token has to grow with them.
+		const files = css( 'assets/css/desktop-files.css' );
+		const label = /\.os-file-tile__label \{([\s\S]*?)\n\}/.exec( files );
+		const fontSize = Number(
+			/font-size:\s*([0-9.]+)px/.exec( label![ 1 ] )![ 1 ],
+		);
+		const lineHeight = Number(
+			/line-height:\s*([0-9.]+)/.exec( label![ 1 ] )![ 1 ],
+		);
+		const lines = Number(
+			/-webkit-line-clamp:\s*([0-9]+)/.exec( label![ 1 ] )![ 1 ],
+		);
+		const needed = 8 + 48 + 6 + fontSize * lineHeight * lines + 8;
+		expect( TILE_H ).toBeGreaterThanOrEqual( needed );
+	} );
+
+	test( 'flow-laid tiles opt OUT of the fixed height', () => {
+		// A media tile is a square thumbnail sized by its grid column,
+		// not an icon in a cell — inheriting 104px would crop it.
+		const mw = css( 'assets/css/my-wordpress.css' );
+		const rule = /\.os-my-wordpress__media-tile \{([\s\S]*?)\n\}/.exec( mw );
+		expect( rule ).not.toBeNull();
+		expect( rule![ 1 ] ).toMatch( /height:\s*auto/ );
+	} );
+
+	test( 'image-led sections re-point the tokens instead of overriding width', () => {
+		// Re-pointing means everything derived from the token follows
+		// — the label's max-width, the loading skeletons — rather than
+		// each needing its own `--large` override to stay in step.
+		const mw = css( 'assets/css/my-wordpress.css' );
+		const rule = /\.os-my-wordpress__tiles--large \{([\s\S]*?)\n\}/.exec( mw );
+		expect( rule ).not.toBeNull();
+		expect( rule![ 1 ] ).toMatch( /--os-tile-w:\s*var\(\s*--os-tile-w-large/ );
+		expect( rule![ 1 ] ).toMatch( /--os-tile-h:\s*var\(\s*--os-tile-h-large/ );
+	} );
+
+	test( 'flow-laid canvases use the same gaps as the absolute ones', () => {
+		// The media grid and the usage grid are CSS flow layouts, not
+		// the absolute canvas — but the air between two icons must not
+		// depend on which window you happen to be looking at.
+		const mw = css( 'assets/css/my-wordpress.css' );
+		for ( const selector of [
+			'os-my-wordpress__media-grid',
+			'os-my-wordpress__usage-grid',
+		] ) {
+			const rule = new RegExp( `\\.${ selector } \\{([\\s\\S]*?)\\n\\}` ).exec(
+				mw,
+			);
+			expect( rule, selector ).not.toBeNull();
+			expect( rule![ 1 ], selector ).toMatch(
+				/gap:\s*var\(\s*--os-grid-gap-y[^;]*var\(\s*--os-grid-gap-x/,
+			);
+			expect( rule![ 1 ], selector ).toMatch(
+				/padding:\s*var\(\s*--os-grid-padding/,
+			);
+		}
+	} );
+
+	test( 'the grid tokens are scoped to the shell, not :root', () => {
+		// `variables.css` also loads inside every chromeless iframe —
+		// a real wp-admin document. Grid tokens on `:root` would be
+		// inherited by Core's own UI in there.
+		const shellScope = variables.slice(
+			variables.indexOf( 'body.os-active {' ),
+		);
+		expect( shellScope ).toContain( '--os-tile-w:' );
+		const beforeShell = variables.slice(
+			0,
+			variables.indexOf( 'body.os-active {' ),
+		);
+		expect( beforeShell ).not.toContain( '--os-tile-w:' );
+	} );
+} );

--- a/tests/vitest/my-wordpress-bulk-actions.test.ts
+++ b/tests/vitest/my-wordpress-bulk-actions.test.ts
@@ -160,7 +160,10 @@ describe( 'my-wordpress bulk actions', () => {
 			'%d entry updated',
 			'%d entries updated',
 		);
-		expect( toasts[ 0 ] ).toBe( '2 entries updated · 1 failed' );
+		// The reason rides along — a partial failure is exactly the
+		// case where the user can see something worked and otherwise
+		// has no way to find out why the rest didn't.
+		expect( toasts[ 0 ] ).toBe( '2 entries updated · 1 failed — nope' );
 	} );
 
 	test( 'reportBulk surfaces the server error when nothing succeeded', async () => {
@@ -316,6 +319,73 @@ describe( 'my-wordpress bulk actions', () => {
 			expect( labels ).not.toContain( 'Sticky' );
 		}, 'Cancel' );
 		await run2;
+	} );
+
+	test( 'the additive merge re-reads terms after the modal closes', async () => {
+		// The pre-modal snapshot is taken before a dialog that stays
+		// open for as long as the user takes. The merge is additive, so
+		// a stale `existing` silently deletes any term somebody else
+		// added while they were thinking.
+		const mod = await load();
+		let reads = 0;
+		stubFetch( {
+			'wp/v2/posts?': () => {
+				reads += 1;
+				// A collaborator adds term 9 while the modal is open.
+				return json( [
+					{ id: 11, categories: reads === 1 ? [ 4 ] : [ 4, 9 ] },
+				] );
+			},
+			'wp/v2/users': () => json( [] ),
+			'wp/v2/categories': () =>
+				json( [ { id: 7, name: 'News', parent: 0 } ] ),
+		} );
+
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( ( modal ) => {
+			const picker = modal.querySelector( 'os-category-picker' ) as
+				HTMLElement & { value: number[] };
+			picker.value = [ 7 ];
+		} );
+		await run;
+
+		expect( reads ).toBe( 2 );
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		// 9 survives because the merge used the post-modal read.
+		expect( writes[ 0 ].body?.categories ).toEqual( [ 4, 9, 7 ] );
+	} );
+
+	test( 'no taxonomy change means no second read', async () => {
+		const mod = await load();
+		let reads = 0;
+		stubFetch( {
+			'wp/v2/posts?': () => {
+				reads += 1;
+				return json( [ { id: 11, categories: [ 4 ] } ] );
+			},
+			'wp/v2/users': () => json( [] ),
+			'wp/v2/categories': () => json( [] ),
+		} );
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( ( modal ) => setSelect( modal, 'Status', 'draft' ) );
+		await run;
+		expect( reads ).toBe( 1 );
+	} );
+
+	test( 'a partial failure says WHY, not just how many', async () => {
+		const mod = await load();
+		mod.reportBulk(
+			{
+				succeeded: [ 1 ],
+				failed: 1,
+				firstError: 'Sorry, you are not allowed to edit this post.',
+			},
+			'%d entry updated',
+			'%d entries updated',
+		);
+		expect( toasts[ 0 ] ).toBe(
+			'1 entry updated · 1 failed — Sorry, you are not allowed to edit this post.',
+		);
 	} );
 
 	test( 'a viewer refused the edit context still gets a bulk edit', async () => {

--- a/tests/vitest/my-wordpress-bulk-actions.test.ts
+++ b/tests/vitest/my-wordpress-bulk-actions.test.ts
@@ -1,0 +1,492 @@
+/**
+ * WordPress's own bulk actions, on a selection — the runners and the
+ * two rules that make bulk edit correct: only changed fields are
+ * written, and taxonomy terms are ADDED rather than replaced.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+type BulkModule = typeof import( '../../src/my-wordpress/bulk-actions' );
+
+const ENTITY = {
+	id: 'posts',
+	label: 'Posts',
+	icon: 'dashicons-admin-post',
+	restPath: 'wp/v2/posts',
+	kind: 'post' as const,
+	post_type: 'post',
+};
+
+interface Call {
+	url: string;
+	method: string;
+	body: Record< string, unknown > | null;
+}
+
+let calls: Call[] = [];
+let toasts: string[] = [];
+
+/**
+ * Route every REST call the module makes. Responses are the smallest
+ * shape each consumer reads.
+ */
+function stubFetch(
+	overrides: Record< string, () => Response > = {},
+): void {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn( ( input: unknown, init: RequestInit = {} ) => {
+			const url = String( input );
+			calls.push( {
+				url,
+				method: init.method ?? 'GET',
+				body: init.body
+					? ( JSON.parse( String( init.body ) ) as Record<
+							string,
+							unknown
+						> )
+					: null,
+			} );
+			for ( const [ match, make ] of Object.entries( overrides ) ) {
+				if ( url.includes( match ) ) {
+					return Promise.resolve( make() );
+				}
+			}
+			return Promise.resolve( json( [] ) );
+		} ),
+	);
+}
+
+function json( body: unknown, status = 200 ): Response {
+	return new Response( JSON.stringify( body ), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	} );
+}
+
+async function load(): Promise< BulkModule > {
+	vi.resetModules();
+	calls = [];
+	toasts = [];
+	// `showToast()` announces itself on the activity bus before it
+	// renders, and the render itself lives in the lazy overlay bundle
+	// that never loads under jsdom. The intent is the observable.
+	const { addFilter } = await import( '../../src/hooks' );
+	// The channel's slash is sanitized to a dot on its way to
+	// `wp.hooks` (see `hookName()` in `src/activity.ts`).
+	addFilter(
+		'os.activity.desktop-mode.toast-requested',
+		'test/capture',
+		( intent: { message?: string } ) => {
+			toasts.push( String( intent?.message ?? '' ) );
+			return intent;
+		},
+	);
+	( window as unknown as {
+		openStationWindowConfig?: Record< string, unknown >;
+	} ).openStationWindowConfig = {
+		[ WINDOW_ID ]: {
+			restRoot: 'http://example.test/wp-json/',
+			restNonce: 'nonce',
+			siteName: 'Example',
+			entities: [ ENTITY ],
+			groups: [],
+			perPage: 24,
+			mediaPerPage: 48,
+			previewActions: [],
+		},
+	};
+	return await import( '../../src/my-wordpress/bulk-actions' );
+}
+
+/** Drive the modal that `bulkEditEntities` opens. */
+async function withModal(
+	fill: ( modal: HTMLElement ) => void,
+	submit: 'Update' | 'Cancel' = 'Update',
+): Promise< void > {
+	await vi.waitFor( () => {
+		if ( ! document.querySelector( 'os-modal' ) ) {
+			throw new Error( 'modal not open yet' );
+		}
+	} );
+	const modal = document.querySelector< HTMLElement >( 'os-modal' )!;
+	fill( modal );
+	const button = [
+		...modal.querySelectorAll< HTMLElement >( 'os-button' ),
+	].find( ( b ) => ( b.textContent ?? '' ).trim() === submit );
+	button?.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+}
+
+function setSelect( modal: HTMLElement, label: string, value: string ): void {
+	const row = [
+		...modal.querySelectorAll< HTMLElement >( '.os-my-wordpress__bulk-row' ),
+	].find(
+		( r ) =>
+			r.querySelector( '.os-my-wordpress__bulk-label' )?.textContent ===
+			label,
+	);
+	const select = row?.querySelector< HTMLElement >( 'os-select' );
+	select?.setAttribute( 'value', value );
+}
+
+describe( 'my-wordpress bulk actions', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'runBulk collects successes and failures without stopping', async () => {
+		const mod = await load();
+		const result = await mod.runBulk( [ 1, 2, 3 ], async ( id ) => {
+			if ( id === 2 ) {
+				throw new Error( 'nope' );
+			}
+		} );
+		expect( result.succeeded ).toEqual( [ 1, 3 ] );
+		expect( result.failed ).toBe( 1 );
+		expect( result.firstError ).toBe( 'nope' );
+	} );
+
+	test( 'reportBulk names the failures', async () => {
+		const mod = await load();
+		mod.reportBulk(
+			{ succeeded: [ 1, 3 ], failed: 1, firstError: 'nope' },
+			'%d entry updated',
+			'%d entries updated',
+		);
+		expect( toasts[ 0 ] ).toBe( '2 entries updated · 1 failed' );
+	} );
+
+	test( 'reportBulk surfaces the server error when nothing succeeded', async () => {
+		const mod = await load();
+		mod.reportBulk(
+			{ succeeded: [], failed: 2, firstError: 'Sorry, you are not allowed' },
+			'%d entry updated',
+			'%d entries updated',
+		);
+		expect( toasts[ 0 ] ).toBe( 'Sorry, you are not allowed' );
+	} );
+
+	test( 'bulkSetStatus posts the status to every id', async () => {
+		const mod = await load();
+		stubFetch();
+		await mod.bulkSetStatus(
+			ENTITY,
+			[ { id: 11 }, { id: 12 } ] as never,
+			'publish',
+		);
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		expect( writes ).toHaveLength( 2 );
+		expect( writes[ 0 ].url ).toContain( 'wp/v2/posts/11' );
+		expect( writes[ 0 ].body ).toEqual( { status: 'publish' } );
+		expect( toasts[ 0 ] ).toBe( '2 entries updated' );
+	} );
+
+	test( 'bulk edit writes ONLY the fields the user changed', async () => {
+		const mod = await load();
+		stubFetch( {
+			'wp/v2/posts?': () =>
+				json( [
+					{ id: 11, categories: [ 5 ], tags: [] },
+					{ id: 12, categories: [], tags: [] },
+				] ),
+			'wp/v2/users': () => json( [ { id: 3, name: 'Ada' } ] ),
+			'wp/v2/categories': () => json( [] ),
+		} );
+
+		const run = mod.bulkEditEntities( ENTITY, [
+			{ id: 11 },
+			{ id: 12 },
+		] as never );
+		await withModal( ( modal ) => setSelect( modal, 'Status', 'draft' ) );
+		await run;
+
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		expect( writes ).toHaveLength( 2 );
+		// Author, comments and sticky were left on "— No change —", so
+		// they are absent — not sent as undefined, not sent as the
+		// first item's value.
+		expect( writes[ 0 ].body ).toEqual( { status: 'draft' } );
+		expect( writes[ 1 ].body ).toEqual( { status: 'draft' } );
+	} );
+
+	test( 'cancelling the modal writes nothing', async () => {
+		const mod = await load();
+		stubFetch( {
+			'wp/v2/posts?': () => json( [ { id: 11, categories: [] } ] ),
+			'wp/v2/users': () => json( [] ),
+			'wp/v2/categories': () => json( [] ),
+		} );
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( () => undefined, 'Cancel' );
+		expect( await run ).toEqual( [] );
+		expect( calls.filter( ( c ) => c.method === 'POST' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'a modal submitted with no changes writes nothing', async () => {
+		const mod = await load();
+		stubFetch( {
+			'wp/v2/posts?': () => json( [ { id: 11, categories: [] } ] ),
+			'wp/v2/users': () => json( [] ),
+			'wp/v2/categories': () => json( [] ),
+		} );
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( () => undefined );
+		expect( await run ).toEqual( [] );
+		expect( calls.filter( ( c ) => c.method === 'POST' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'categories are ADDED to each entry, not replaced', async () => {
+		const mod = await load();
+		stubFetch( {
+			'wp/v2/posts?': () =>
+				json( [
+					{ id: 11, categories: [ 5, 6 ], tags: [] },
+					{ id: 12, categories: [ 9 ], tags: [] },
+				] ),
+			'wp/v2/users': () => json( [] ),
+			'wp/v2/categories': () =>
+				json( [ { id: 7, name: 'News', parent: 0 } ] ),
+		} );
+
+		const run = mod.bulkEditEntities( ENTITY, [
+			{ id: 11 },
+			{ id: 12 },
+		] as never );
+		await withModal( ( modal ) => {
+			const picker = modal.querySelector( 'os-category-picker' ) as
+				HTMLElement & { value: number[] };
+			picker.value = [ 7 ];
+		} );
+		await run;
+
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		// Each post keeps its own terms and gains the picked one.
+		expect( writes[ 0 ].body?.categories ).toEqual( [ 5, 6, 7 ] );
+		expect( writes[ 1 ].body?.categories ).toEqual( [ 9, 7 ] );
+	} );
+
+	test( 'a post type without taxonomies renders no taxonomy controls', async () => {
+		const mod = await load();
+		stubFetch( {
+			// No `categories` / `tags` keys at all — the REST response
+			// for a post type that doesn't register them.
+			'wp/v2/posts?': () => json( [ { id: 11 } ] ),
+			'wp/v2/users': () => json( [] ),
+		} );
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( ( modal ) => {
+			expect( modal.querySelector( 'os-category-picker' ) ).toBeNull();
+			expect( modal.querySelector( 'os-tag-input' ) ).toBeNull();
+		}, 'Cancel' );
+		await run;
+		// …and no request went out for a term list we'd never show.
+		expect(
+			calls.some( ( c ) => c.url.includes( 'wp/v2/categories' ) ),
+		).toBe( false );
+	} );
+
+	test( 'sticky is offered for posts and withheld from other types', async () => {
+		const mod = await load();
+		stubFetch( {
+			'wp/v2/posts?': () => json( [ { id: 11 } ] ),
+			'wp/v2/users': () => json( [] ),
+		} );
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( ( modal ) => {
+			const labels = [
+				...modal.querySelectorAll( '.os-my-wordpress__bulk-label' ),
+			].map( ( n ) => n.textContent );
+			expect( labels ).toContain( 'Sticky' );
+		}, 'Cancel' );
+		await run;
+
+		const page = { ...ENTITY, id: 'pages', post_type: 'page' };
+		const run2 = mod.bulkEditEntities( page, [ { id: 11 } ] as never );
+		await withModal( ( modal ) => {
+			const labels = [
+				...modal.querySelectorAll( '.os-my-wordpress__bulk-label' ),
+			].map( ( n ) => n.textContent );
+			expect( labels ).not.toContain( 'Sticky' );
+		}, 'Cancel' );
+		await run2;
+	} );
+
+	test( 'a viewer refused the edit context still gets a bulk edit', async () => {
+		const mod = await load();
+		let firstRead = true;
+		stubFetch( {
+			'wp/v2/posts?': () => {
+				if ( firstRead ) {
+					firstRead = false;
+					// What the collection endpoint answers a viewer who
+					// may not edit this post type at all.
+					return json( { code: 'rest_forbidden_context' }, 403 );
+				}
+				return json( [ { id: 11, categories: [ 4 ] } ] );
+			},
+			'wp/v2/users': () => json( [] ),
+			'wp/v2/categories': () =>
+				json( [ { id: 7, name: 'News', parent: 0 } ] ),
+		} );
+
+		const run = mod.bulkEditEntities( ENTITY, [ { id: 11 } ] as never );
+		await withModal( ( modal ) => {
+			const picker = modal.querySelector( 'os-category-picker' ) as
+				HTMLElement & { value: number[] };
+			picker.value = [ 7 ];
+		} );
+		await run;
+
+		const reads = calls.filter(
+			( c ) => c.method === 'GET' && c.url.includes( 'wp/v2/posts?' ),
+		);
+		expect( reads[ 0 ].url ).toContain( 'context=edit' );
+		expect( reads[ 1 ].url ).toContain( 'context=view' );
+		// …and the merge still used the terms it read back.
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		expect( writes[ 0 ].body?.categories ).toEqual( [ 4, 7 ] );
+	} );
+
+	test( 'entity actions expose Edit / Publish / Switch to Draft', async () => {
+		const mod = await load();
+		const draft = mod.entityBulkActions(
+			{ entity: ENTITY, onChanged: () => undefined },
+			{ id: 11, status: 'draft' } as never,
+		);
+		// A draft can be published but is already a draft.
+		expect( draft.map( ( a ) => a.id ) ).toEqual( [
+			'bulk-edit',
+			'publish',
+		] );
+
+		const published = mod.entityBulkActions(
+			{ entity: ENTITY, onChanged: () => undefined },
+			{ id: 12, status: 'publish' } as never,
+		);
+		expect( published.map( ( a ) => a.id ) ).toEqual( [
+			'bulk-edit',
+			'to-draft',
+		] );
+		// Every one of them is multi-safe and carries a batched runner.
+		for ( const action of [ ...draft, ...published ] ) {
+			expect( action.multi ).toBe( true );
+			expect( typeof action.bulk ).toBe( 'function' );
+		}
+	} );
+
+	test( 'media Detach clears the parent, and only shows for attached files', async () => {
+		const mod = await load();
+		stubFetch();
+		const attached = mod.mediaBulkActions(
+			{ onChanged: () => undefined },
+			{ id: 21, post: 5 } as never,
+		);
+		expect( attached.map( ( a ) => a.id ) ).toEqual( [ 'detach' ] );
+
+		const loose = mod.mediaBulkActions(
+			{ onChanged: () => undefined },
+			{ id: 22, post: 0 } as never,
+		);
+		expect( loose ).toEqual( [] );
+
+		await attached[ 0 ].bulk!( [
+			{ id: 21 },
+			{ id: 23 },
+		] as never );
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		expect( writes ).toHaveLength( 2 );
+		expect( writes[ 0 ].body ).toEqual( { post: 0 } );
+		expect( toasts[ 0 ] ).toBe( '2 files detached' );
+	} );
+
+	test( 'deleting users asks what happens to their content', async () => {
+		const mod = await load();
+		stubFetch( { 'wp/v2/users': () => json( [ { id: 3, name: 'Ada' } ] ) } );
+		const removed: number[][] = [];
+		const actions = mod.userBulkActions(
+			{ onChanged: () => undefined, onRemoved: ( ids ) => removed.push( ids ) },
+			{ id: 7 } as never,
+		);
+		const del = actions.find( ( a ) => a.id === 'delete-user' )!;
+
+		const run = del.bulk!( [ { id: 7 }, { id: 8 } ] as never );
+		await withModal( ( modal ) => {
+			const labels = [
+				...modal.querySelectorAll( 'os-option' ),
+			].map( ( n ) => n.textContent );
+			// Core's two answers: delete the content, or reassign it.
+			expect( labels ).toContain( 'Delete all their content' );
+			expect( labels ).toContain( 'Attribute all content to Ada' );
+			setSelect( modal, 'Their content', '3' );
+		}, 'Delete' );
+		await run;
+
+		const deletes = calls.filter( ( c ) => c.method === 'DELETE' );
+		expect( deletes ).toHaveLength( 2 );
+		expect( deletes[ 0 ].url ).toContain( 'force=true' );
+		expect( deletes[ 0 ].url ).toContain( 'reassign=3' );
+		expect( removed[ 0 ] ).toEqual( [ 7, 8 ] );
+	} );
+
+	test( 'change role posts the picked role to every user', async () => {
+		const mod = await load();
+		stubFetch();
+		(
+			window as unknown as {
+				openStationConfig?: Record< string, unknown >;
+			}
+		).openStationConfig = {
+			shareEligibleRoles: [ { slug: 'editor', name: 'Editor' } ],
+		};
+		const actions = mod.userBulkActions(
+			{ onChanged: () => undefined, onRemoved: () => undefined },
+			{ id: 7 } as never,
+		);
+		const role = actions.find( ( a ) => a.id === 'change-role' )!;
+		const run = role.bulk!( [ { id: 7 }, { id: 8 } ] as never );
+		await withModal(
+			( modal ) => setSelect( modal, 'New role', 'editor' ),
+			'Change role',
+		);
+		await run;
+
+		const writes = calls.filter( ( c ) => c.method === 'POST' );
+		expect( writes ).toHaveLength( 2 );
+		expect( writes[ 0 ].body ).toEqual( { roles: [ 'editor' ] } );
+		expect( toasts[ 0 ] ).toBe( '2 users updated' );
+	} );
+
+	test( 'copy links puts one URL per line on the clipboard', async () => {
+		const mod = await load();
+		const writeText = vi.fn( async () => undefined );
+		vi.stubGlobal( 'navigator', { clipboard: { writeText } } );
+		await mod.copyLinks(
+			[ { link: 'https://a.test/1' }, { link: '' }, { link: 'https://a.test/2' } ],
+			( i ) => i.link,
+		);
+		expect( writeText ).toHaveBeenCalledWith(
+			'https://a.test/1\nhttps://a.test/2',
+		);
+		expect( toasts[ 0 ] ).toBe( '2 links copied.' );
+	} );
+
+	test( 'copy links explains itself when the clipboard is unreachable', async () => {
+		const mod = await load();
+		vi.stubGlobal( 'navigator', {
+			clipboard: {
+				writeText: async () => {
+					throw new Error( 'denied' );
+				},
+			},
+		} );
+		await mod.copyLinks( [ { link: 'https://a.test/1' } ], ( i ) => i.link );
+		expect( toasts[ 0 ] ).toContain( 'secure (https) connection' );
+	} );
+} );

--- a/tests/vitest/my-wordpress-selection.test.ts
+++ b/tests/vitest/my-wordpress-selection.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Multi-selection inside the My WordPress window: entity lists get
+ * the same gestures and the same intersected menu the desktop does.
+ *
+ * Same harness as `my-wordpress-groups.test.ts` — load the bundle,
+ * invoke the registered render callback, drive the painted tiles with
+ * real events.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+
+interface NativeWindowsGlobal {
+	openStationNativeWindows?: Record<
+		string,
+		( ( body: HTMLElement ) => void | ( () => void ) ) | undefined
+	>;
+	openStationWindowConfig?: Record< string, unknown >;
+}
+
+const POSTS = [
+	{
+		id: 11,
+		title: { rendered: 'First' },
+		status: 'publish',
+		date: '2024-01-01T00:00:00',
+		link: 'http://example.test/1',
+	},
+	{
+		id: 12,
+		title: { rendered: 'Second' },
+		status: 'draft',
+		date: '2024-01-02T00:00:00',
+		link: 'http://example.test/2',
+	},
+	{
+		id: 13,
+		title: { rendered: 'Third' },
+		status: 'publish',
+		date: '2024-01-03T00:00:00',
+		link: 'http://example.test/3',
+	},
+];
+
+function installTemplateMarkup( host: HTMLElement ): void {
+	host.innerHTML = `
+		<div class="desktop-mode-my-wordpress" data-os-my-wordpress-root>
+			<header data-os-my-wordpress-breadcrumbs></header>
+			<div class="os-my-wordpress__body" data-os-my-wordpress-body>
+				<div class="os-my-wordpress__loading" data-os-my-wordpress-loading hidden></div>
+			</div>
+			<div class="os-folder-status-bar" data-os-my-wordpress-status></div>
+		</div>
+	`;
+}
+
+function mountWindow(): HTMLElement {
+	const cb = ( window as unknown as NativeWindowsGlobal )
+		.openStationNativeWindows?.[ WINDOW_ID ];
+	if ( typeof cb !== 'function' ) {
+		throw new Error( 'render callback not registered' );
+	}
+	const body = document.createElement( 'div' );
+	body.className = 'os-window__body';
+	installTemplateMarkup( body );
+	document.body.appendChild( body );
+	cb( body );
+	return body;
+}
+
+function dblclickTile( body: HTMLElement, label: string ): void {
+	const tile = [ ...body.querySelectorAll< HTMLElement >( 'os-tile' ) ].find(
+		( t ) =>
+			(
+				t.querySelector( '.os-file-tile__label' )?.textContent ?? ''
+			).startsWith( label ),
+	);
+	if ( ! tile ) {
+		throw new Error( `no tile labelled ${ label }` );
+	}
+	tile.dispatchEvent( new MouseEvent( 'dblclick', { bubbles: true } ) );
+}
+
+function entryTile( body: HTMLElement, id: number ): HTMLElement {
+	const tile = body.querySelector< HTMLElement >( `[data-entry-id="${ id }"]` );
+	if ( ! tile ) {
+		throw new Error( `no entry tile ${ id }` );
+	}
+	return tile;
+}
+
+function click( el: Element, init: MouseEventInit = {} ): void {
+	el.dispatchEvent( new MouseEvent( 'click', { bubbles: true, ...init } ) );
+}
+
+function rightClick( el: Element ): void {
+	el.dispatchEvent(
+		new MouseEvent( 'contextmenu', {
+			bubbles: true,
+			clientX: 5,
+			clientY: 5,
+		} ),
+	);
+}
+
+function menuIds(): string[] {
+	const menu = document.querySelector( 'os-context-menu' );
+	return Array.from(
+		menu?.querySelectorAll( 'os-context-menu-option' ) ?? [],
+	).map( ( o ) => ( o as HTMLElement ).dataset.menuItemId ?? '' );
+}
+
+function statusLabels( body: HTMLElement ): string[] {
+	return Array.from(
+		body.querySelectorAll( '.os-folder-status-bar__label' ),
+	).map( ( n ) => n.textContent ?? '' );
+}
+
+/** Open the Posts section and wait for the first page to paint. */
+async function openPosts( body: HTMLElement ): Promise< void > {
+	dblclickTile( body, 'Posts' );
+	await vi.waitFor( () => {
+		if ( ! body.querySelector( '[data-entry-id]' ) ) {
+			throw new Error( 'entries not painted yet' );
+		}
+	} );
+}
+
+describe( 'my-wordpress — multi-selection', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		( window as unknown as NativeWindowsGlobal ).openStationWindowConfig = {
+			[ WINDOW_ID ]: {
+				restRoot: 'http://example.test/wp-json/',
+				restNonce: 'nonce',
+				editPostUrlBase: 'http://example.test/wp-admin/post.php',
+				editUserUrlBase: 'http://example.test/wp-admin/user-edit.php',
+				siteName: 'Example',
+				entities: [
+					{
+						id: 'posts',
+						label: 'Posts',
+						icon: 'dashicons-admin-post',
+						restPath: 'wp/v2/posts',
+						kind: 'post',
+						post_type: 'post',
+					},
+				],
+				groups: [],
+				perPage: 24,
+				mediaPerPage: 48,
+				previewActions: [],
+			},
+		};
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( ( url: unknown ) => {
+				const href = String( url );
+				const body = href.includes( 'wp/v2/posts' )
+					? JSON.stringify( POSTS )
+					: '[]';
+				return Promise.resolve(
+					new Response( body, {
+						status: 200,
+						headers: {
+							'X-WP-Total': String( POSTS.length ),
+							'X-WP-TotalPages': '1',
+							'Content-Type': 'application/json',
+						},
+					} ),
+				);
+			} ),
+		);
+		await import( '../../src/my-wordpress/index' );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'ctrl-click selects several entries', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 12 ), { metaKey: true } );
+		expect( entryTile( body, 11 ).hasAttribute( 'selected' ) ).toBe( true );
+		expect( entryTile( body, 12 ).hasAttribute( 'selected' ) ).toBe( true );
+		expect( entryTile( body, 13 ).hasAttribute( 'selected' ) ).toBe( false );
+	} );
+
+	test( 'shift-click extends the range', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 13 ), { shiftKey: true } );
+		expect( entryTile( body, 12 ).hasAttribute( 'selected' ) ).toBe( true );
+	} );
+
+	test( 'the status bar reports the selection size', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 12 ), { metaKey: true } );
+		expect( statusLabels( body ) ).toContain( '2 selected' );
+	} );
+
+	test( 'the preview pane summarizes a multi-selection', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 12 ), { metaKey: true } );
+		const preview = body.querySelector( '.os-my-wordpress__preview' );
+		expect( preview?.textContent ).toContain( '2 items selected' );
+		// Status breakdown is what decides which bulk actions apply.
+		expect( preview?.textContent ).toContain( 'publish' );
+		expect( preview?.textContent ).toContain( 'draft' );
+	} );
+
+	test( 'a multi-selection menu keeps only the multi-safe actions', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		// #11 is published, #12 is a draft.
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 12 ), { metaKey: true } );
+		rightClick( entryTile( body, 12 ) );
+		// `navigate-into` is single-item and drops out. So do the two
+		// status actions, but for a subtler reason: "Publish" is only
+		// offered for entries that aren't published and "Switch to
+		// Draft" only for entries that aren't drafts, so a set holding
+		// one of each has neither in common.
+		expect( menuIds() ).toEqual( [
+			'open',
+			'bulk-edit',
+			'copy-links',
+			'trash',
+		] );
+	} );
+
+	test( 'a status action survives a set that agrees about status', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		// #11 and #13 are both published.
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 13 ), { metaKey: true } );
+		rightClick( entryTile( body, 13 ) );
+		expect( menuIds() ).toContain( 'to-draft' );
+		expect( menuIds() ).not.toContain( 'publish' );
+	} );
+
+	test( 'a single-entry menu carries the full action set', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		rightClick( entryTile( body, 11 ) );
+		expect( menuIds() ).toEqual( [
+			'open',
+			'navigate-into',
+			'bulk-edit',
+			'to-draft',
+			'copy-links',
+			'trash',
+		] );
+	} );
+
+	test( 'right-clicking outside the selection replaces it', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		click( entryTile( body, 12 ), { metaKey: true } );
+		rightClick( entryTile( body, 13 ) );
+		expect( entryTile( body, 13 ).hasAttribute( 'selected' ) ).toBe( true );
+		expect( entryTile( body, 11 ).hasAttribute( 'selected' ) ).toBe( false );
+		// The menu is the single-entry one, for the tile just clicked.
+		expect( menuIds() ).toContain( 'navigate-into' );
+	} );
+
+	test( 'clicking the empty canvas clears the selection', async () => {
+		const body = mountWindow();
+		await openPosts( body );
+		click( entryTile( body, 11 ) );
+		const list = body.querySelector( '.os-my-wordpress__list' );
+		click( list! );
+		expect( entryTile( body, 11 ).hasAttribute( 'selected' ) ).toBe( false );
+	} );
+} );

--- a/tests/vitest/selection-actions.test.ts
+++ b/tests/vitest/selection-actions.test.ts
@@ -208,6 +208,122 @@ describe( 'resolveCommonActions', () => {
 		expect( perItem ).not.toHaveBeenCalled();
 	} );
 
+	test( 'merged contributors each get their OWN bulk, with their own items', async () => {
+		// `multiId` merges actions that are the same deed under
+		// different labels — and nothing says they share an
+		// implementation. Handing the whole heterogeneous set to
+		// `contributors[0].bulk` pushed folders through the file
+		// runner (or dropped them), and which one "won" depended on
+		// the order the user happened to select in.
+		const { resolveCommonActions } = await load();
+		const fileBulk = vi.fn();
+		const folderBulk = vi.fn();
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			item.type === 'folder'
+				? {
+						id: 'delete-folder',
+						multiId: 'trash',
+						label: 'Move folder to Trash',
+						multi: true,
+						bulk: folderBulk,
+						onClick: vi.fn(),
+					}
+				: {
+						id: 'remove',
+						multiId: 'trash',
+						label: 'Move to Trash',
+						multi: true,
+						bulk: fileBulk,
+						onClick: vi.fn(),
+					},
+		];
+
+		const [ action ] = resolveCommonActions(
+			[ post, folder, attachment ],
+			build,
+		);
+		await action.onClick( new MouseEvent( 'click' ) );
+
+		expect( fileBulk ).toHaveBeenCalledTimes( 1 );
+		expect( fileBulk.mock.calls[ 0 ][ 0 ] ).toEqual( [ post, attachment ] );
+		expect( folderBulk ).toHaveBeenCalledTimes( 1 );
+		expect( folderBulk.mock.calls[ 0 ][ 0 ] ).toEqual( [ folder ] );
+	} );
+
+	test( 'contributors sharing one runner still make a single call', async () => {
+		// What the built-ins do: the folder entry and the file entry
+		// point at the SAME function, so a mixed selection is one
+		// batch — one toast, one Undo — not two.
+		const { resolveCommonActions } = await load();
+		const shared = vi.fn();
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			{
+				id: item.type === 'folder' ? 'delete-folder' : 'remove',
+				multiId: 'trash',
+				label: 'Trash',
+				multi: true,
+				bulk: shared,
+				onClick: vi.fn(),
+			},
+		];
+		const [ action ] = resolveCommonActions( [ post, folder ], build );
+		await action.onClick( new MouseEvent( 'click' ) );
+		expect( shared ).toHaveBeenCalledTimes( 1 );
+		expect( shared.mock.calls[ 0 ][ 0 ] ).toEqual( [ post, folder ] );
+	} );
+
+	test( 'items whose contributor has no bulk still fan out', async () => {
+		const { resolveCommonActions } = await load();
+		const batched = vi.fn();
+		const single = vi.fn();
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			item.type === 'folder'
+				? {
+						id: 'act',
+						label: 'Act',
+						multi: true,
+						onClick: single,
+					}
+				: {
+						id: 'act',
+						label: 'Act',
+						multi: true,
+						bulk: batched,
+						onClick: vi.fn(),
+					},
+		];
+		const [ action ] = resolveCommonActions( [ post, folder ], build );
+		await action.onClick( new MouseEvent( 'click' ) );
+		expect( batched.mock.calls[ 0 ][ 0 ] ).toEqual( [ post ] );
+		expect( single ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'a throwing batch does not stop the other batches', async () => {
+		const spy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		const { resolveCommonActions } = await load();
+		const ok = vi.fn();
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			{
+				id: 'act',
+				label: 'Act',
+				multi: true,
+				bulk:
+					item.type === 'folder'
+						? () => {
+								throw new Error( 'boom' );
+							}
+						: ok,
+				onClick: vi.fn(),
+			},
+		];
+		const [ action ] = resolveCommonActions( [ folder, post ], build );
+		await action.onClick( new MouseEvent( 'click' ) );
+		expect( ok ).toHaveBeenCalledTimes( 1 );
+		spy.mockRestore();
+	} );
+
 	test( 'without a bulk runner it fans out to each item’s own handler', async () => {
 		const { resolveCommonActions } = await load();
 		const calls: number[] = [];

--- a/tests/vitest/selection-actions.test.ts
+++ b/tests/vitest/selection-actions.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for `resolveCommonActions` — the rule that decides what a
+ * mixed selection is allowed to offer.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import type { SelectionAction } from '../../src/selection/actions';
+
+async function load() {
+	vi.resetModules();
+	return await import( '../../src/selection/actions' );
+}
+
+interface Item {
+	id: number;
+	type: 'post' | 'attachment' | 'folder';
+}
+
+const post: Item = { id: 1, type: 'post' };
+const attachment: Item = { id: 2, type: 'attachment' };
+const folder: Item = { id: 3, type: 'folder' };
+
+/**
+ * Action lists modelled on the real file-tile menu: everything can be
+ * opened and trashed; only posts navigate-into; only folders rename;
+ * only attachments download.
+ */
+function actionsFor( item: Item ): SelectionAction< Item >[] {
+	const list: SelectionAction< Item >[] = [
+		{
+			id: 'open',
+			label: 'Open',
+			sort: 10,
+			multi: true,
+			onClick: vi.fn(),
+		},
+	];
+	if ( item.type === 'post' ) {
+		list.push( {
+			id: 'navigate-into',
+			label: 'Navigate into',
+			sort: 20,
+			onClick: vi.fn(),
+		} );
+	}
+	if ( item.type === 'folder' ) {
+		list.push( {
+			id: 'rename-folder',
+			label: 'Rename…',
+			sort: 30,
+			onClick: vi.fn(),
+		} );
+		list.push( {
+			id: 'delete-folder',
+			multiId: 'trash',
+			label: 'Move folder to Trash',
+			sort: 90,
+			danger: true,
+			multi: true,
+			bulkLabel: ( n ) => `Move ${ n } items to Trash`,
+			onClick: vi.fn(),
+		} );
+	} else {
+		list.push( {
+			id: 'remove',
+			multiId: 'trash',
+			label: 'Move to Trash',
+			sort: 90,
+			danger: true,
+			multi: true,
+			bulkLabel: ( n ) => `Move ${ n } items to Trash`,
+			onClick: vi.fn(),
+		} );
+	}
+	if ( item.type === 'attachment' ) {
+		list.push( {
+			id: 'download',
+			label: 'Download',
+			sort: 40,
+			onClick: vi.fn(),
+		} );
+	}
+	return list;
+}
+
+describe( 'resolveCommonActions', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+	} );
+
+	test( 'an empty selection has no actions', async () => {
+		const { resolveCommonActions } = await load();
+		expect( resolveCommonActions( [], actionsFor ) ).toEqual( [] );
+	} );
+
+	test( 'a single item gets its own list, untouched', async () => {
+		const { resolveCommonActions } = await load();
+		const own = actionsFor( post );
+		const resolved = resolveCommonActions( [ post ], () => own );
+		// Same array identity: the single-item menu is exactly what
+		// the surface built, with no relabelling and no filtering.
+		expect( resolved ).toBe( own );
+		expect( resolved.map( ( a ) => a.label ) ).toEqual( [
+			'Open',
+			'Navigate into',
+			'Move to Trash',
+		] );
+	} );
+
+	test( 'a post + an attachment keep only what both offer', async () => {
+		const { resolveCommonActions } = await load();
+		const resolved = resolveCommonActions(
+			[ post, attachment ],
+			actionsFor,
+		);
+		expect( resolved.map( ( a ) => a.id ) ).toEqual( [ 'open', 'trash' ] );
+		// Navigate-into is post-only; download is attachment-only.
+		expect( resolved.find( ( a ) => a.id === 'navigate-into' ) ).toBeUndefined();
+		expect( resolved.find( ( a ) => a.id === 'download' ) ).toBeUndefined();
+	} );
+
+	test( 'multiId merges the folder and file trash entries', async () => {
+		const { resolveCommonActions } = await load();
+		const resolved = resolveCommonActions( [ folder, post ], actionsFor );
+		const trash = resolved.find( ( a ) => a.id === 'trash' );
+		expect( trash ).toBeDefined();
+		expect( trash?.label ).toBe( 'Move 2 items to Trash' );
+		expect( trash?.danger ).toBe( true );
+		// Rename is folder-only and never reaches a mixed set.
+		expect( resolved.find( ( a ) => a.id === 'rename-folder' ) ).toBeUndefined();
+	} );
+
+	test( 'an action without multi never reaches a multi-selection', async () => {
+		const { resolveCommonActions } = await load();
+		const single = ( item: Item ): SelectionAction< Item >[] => [
+			{ id: 'shared', label: 'Shared', onClick: vi.fn() },
+			{ id: 'both', label: 'Both', multi: true, onClick: vi.fn() },
+			...( item.id === 1 ? [] : [] ),
+		];
+		const resolved = resolveCommonActions( [ post, attachment ], single );
+		expect( resolved.map( ( a ) => a.id ) ).toEqual( [ 'both' ] );
+	} );
+
+	test( 'one non-multi contributor disqualifies the whole id', async () => {
+		const { resolveCommonActions } = await load();
+		const mixed = ( item: Item ): SelectionAction< Item >[] => [
+			{
+				id: 'act',
+				label: 'Act',
+				multi: item.type === 'post',
+				onClick: vi.fn(),
+			},
+		];
+		expect(
+			resolveCommonActions( [ post, attachment ], mixed ),
+		).toEqual( [] );
+	} );
+
+	test( 'default bulk label falls back to "<label> (N items)"', async () => {
+		const { resolveCommonActions } = await load();
+		const resolved = resolveCommonActions(
+			[ post, attachment ],
+			actionsFor,
+		);
+		expect( resolved.find( ( a ) => a.id === 'open' )?.label ).toBe(
+			'Open (2 items)',
+		);
+	} );
+
+	test( 'disabled and danger take the least-forgiving contributor', async () => {
+		const { resolveCommonActions } = await load();
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			{
+				id: 'act',
+				label: 'Act',
+				multi: true,
+				sort: item.id === 1 ? 50 : 10,
+				disabled: item.id === 2,
+				danger: item.id === 2,
+				onClick: vi.fn(),
+			},
+		];
+		const [ action ] = resolveCommonActions( [ post, attachment ], build );
+		expect( action.disabled ).toBe( true );
+		expect( action.danger ).toBe( true );
+		// Sort takes the minimum so the merged entry sits where the
+		// earliest contributor would have put it.
+		expect( action.sort ).toBe( 10 );
+	} );
+
+	test( 'a bulk runner is called once with the whole set', async () => {
+		const { resolveCommonActions } = await load();
+		const bulk = vi.fn();
+		const perItem = vi.fn();
+		const build = (): SelectionAction< Item >[] => [
+			{ id: 'act', label: 'Act', multi: true, bulk, onClick: perItem },
+		];
+		const [ action ] = resolveCommonActions(
+			[ post, attachment ],
+			build,
+		);
+		await action.onClick( new MouseEvent( 'click' ) );
+		expect( bulk ).toHaveBeenCalledTimes( 1 );
+		expect( bulk.mock.calls[ 0 ][ 0 ] ).toEqual( [ post, attachment ] );
+		expect( perItem ).not.toHaveBeenCalled();
+	} );
+
+	test( 'without a bulk runner it fans out to each item’s own handler', async () => {
+		const { resolveCommonActions } = await load();
+		const calls: number[] = [];
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			{
+				id: 'act',
+				label: 'Act',
+				multi: true,
+				onClick: () => {
+					calls.push( item.id );
+				},
+			},
+		];
+		const [ action ] = resolveCommonActions(
+			[ post, attachment, folder ],
+			build,
+		);
+		await action.onClick( new MouseEvent( 'click' ) );
+		// Each contributor's OWN closure ran, in order.
+		expect( calls ).toEqual( [ 1, 2, 3 ] );
+	} );
+
+	test( 'one throwing handler does not abort the rest of the fan-out', async () => {
+		const spy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		const { resolveCommonActions } = await load();
+		const calls: number[] = [];
+		const build = ( item: Item ): SelectionAction< Item >[] => [
+			{
+				id: 'act',
+				label: 'Act',
+				multi: true,
+				onClick: () => {
+					if ( item.id === 1 ) {
+						throw new Error( 'boom' );
+					}
+					calls.push( item.id );
+				},
+			},
+		];
+		const [ action ] = resolveCommonActions( [ post, attachment ], build );
+		await action.onClick( new MouseEvent( 'click' ) );
+		expect( calls ).toEqual( [ 2 ] );
+		spy.mockRestore();
+	} );
+
+	test( 'the os.selection.actions filter can extend a multi-selection', async () => {
+		const { resolveCommonActions } = await load();
+		const { addFilter } = await import( '../../src/hooks' );
+		addFilter(
+			'os.selection.actions',
+			'test/extra',
+			( actions: SelectionAction< Item >[], ctx: { count: number } ) => [
+				...actions,
+				{
+					id: 'extra',
+					label: `Extra for ${ ctx.count }`,
+					onClick: vi.fn(),
+				},
+			],
+		);
+		const resolved = resolveCommonActions(
+			[ post, attachment ],
+			actionsFor,
+		);
+		expect( resolved.find( ( a ) => a.id === 'extra' )?.label ).toBe(
+			'Extra for 2',
+		);
+	} );
+
+	test( 'the filter does not run for a single selection', async () => {
+		const { resolveCommonActions } = await load();
+		const { addFilter } = await import( '../../src/hooks' );
+		const spy = vi.fn( ( actions: SelectionAction< Item >[] ) => actions );
+		addFilter( 'os.selection.actions', 'test/spy', spy );
+		resolveCommonActions( [ post ], actionsFor );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/vitest/selection-controller.test.ts
+++ b/tests/vitest/selection-controller.test.ts
@@ -3,7 +3,10 @@
  * and the `selected` attribute / ARIA roles on the way out.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { attachSelection } from '../../src/selection/controller';
+import {
+	activeSelection,
+	attachSelection,
+} from '../../src/selection/controller';
 
 let root: HTMLElement;
 let background: HTMLElement;
@@ -78,6 +81,7 @@ describe( 'selection controller', () => {
 	} );
 	afterEach( () => {
 		document.body.innerHTML = '';
+		vi.unstubAllGlobals();
 	} );
 
 	test( 'marks the container as a multi-selectable listbox', () => {
@@ -515,6 +519,110 @@ describe( 'selection controller', () => {
 		window.dispatchEvent( new Event( 'blur' ) );
 		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
 		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+	} );
+
+	/**
+	 * Drive the auto-scroll loop by hand — capture the rAF callbacks
+	 * and run a bounded number of frames.
+	 */
+	function withFrames(): { run: ( n: number ) => void } {
+		const queue: FrameRequestCallback[] = [];
+		vi.stubGlobal( 'requestAnimationFrame', ( cb: FrameRequestCallback ) => {
+			queue.push( cb );
+			return queue.length;
+		} );
+		vi.stubGlobal( 'cancelAnimationFrame', () => undefined );
+		return {
+			run: ( n: number ) => {
+				for ( let i = 0; i < n; i += 1 ) {
+					queue.shift()?.( 0 );
+				}
+			},
+		};
+	}
+
+	function makeScrollable( overflowY: string ): void {
+		Object.defineProperty( background, 'scrollHeight', {
+			value: 900,
+			configurable: true,
+		} );
+		Object.defineProperty( background, 'clientHeight', {
+			value: 200,
+			configurable: true,
+		} );
+		background.style.overflowY = overflowY;
+	}
+
+	test( 'a canvas the user cannot scroll is never auto-scrolled', () => {
+		// The desktop area is `overflow: hidden` and its icons plus its
+		// bottom padding overflow it constantly, so "content is taller
+		// than the box" is true there. Auto-scrolling on that alone
+		// slid the WALLPAPER under the user's band — a surface with no
+		// scrollbar that nothing else can scroll.
+		const frames = withFrames();
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 200 } );
+		makeScrollable( 'hidden' );
+		attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		// Pointer parked hard against the bottom edge.
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 199 ) );
+		frames.run( 5 );
+		expect( background.scrollTop ).toBe( 0 );
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 199 ) );
+	} );
+
+	test( 'a real scroller IS auto-scrolled at the edge', () => {
+		const frames = withFrames();
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 200 } );
+		makeScrollable( 'auto' );
+		attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 199 ) );
+		frames.run( 3 );
+		expect( background.scrollTop ).toBeGreaterThan( 0 );
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 199 ) );
+	} );
+
+	test( 'closing one controller does not blank another’s snapshot', () => {
+		// Two folder windows open on the SAME folder share both
+		// `surface` and `scope`, so neither identifies a controller.
+		const second = document.createElement( 'div' );
+		const secondRoot = document.createElement( 'div' );
+		second.appendChild( secondRoot );
+		document.body.appendChild( second );
+		const mk = ( parent: HTMLElement, key: string ) => {
+			const el = document.createElement( 'div' );
+			el.className = 'os-file-tile';
+			el.dataset.key = key;
+			parent.appendChild( el );
+			return el;
+		};
+		const a = tile( 'a' );
+		const b = mk( secondRoot, 'b' );
+
+		const first = attach( { surface: 'files', scope: '7' } );
+		const other = attachSelection( secondRoot, {
+			keyOf: ( el ) => el.dataset.key ?? null,
+			background: second,
+			surface: 'files',
+			scope: '7',
+		} );
+
+		click( a );
+		click( b );
+		expect( activeSelection()?.keys ).toEqual( [ 'b' ] );
+
+		// Close the window the user is NOT in.
+		first.destroy();
+		expect( activeSelection()?.keys ).toEqual( [ 'b' ] );
+
+		// Closing the one that owns the snapshot does clear it.
+		other.destroy();
+		expect( activeSelection() ).toBeNull();
 	} );
 
 	test( 'marquee can be disabled', () => {

--- a/tests/vitest/selection-controller.test.ts
+++ b/tests/vitest/selection-controller.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Tests for the selection controller — the gestures on the way in
+ * and the `selected` attribute / ARIA roles on the way out.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { attachSelection } from '../../src/selection/controller';
+
+let root: HTMLElement;
+let background: HTMLElement;
+
+function tile( key: string, x = 0, y = 0 ): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.className = 'os-file-tile';
+	el.dataset.key = key;
+	el.style.left = `${ x }px`;
+	el.style.top = `${ y }px`;
+	root.appendChild( el );
+	return el;
+}
+
+function attach( opts: Record< string, unknown > = {} ) {
+	return attachSelection( root, {
+		keyOf: ( el ) => el.dataset.key ?? null,
+		background,
+		...opts,
+	} );
+}
+
+function click( el: Element, init: MouseEventInit = {} ): void {
+	el.dispatchEvent(
+		new MouseEvent( 'click', { bubbles: true, ...init } ),
+	);
+}
+
+/**
+ * jsdom ships no `PointerEvent` constructor, so pointer gestures are
+ * synthesized the same way `desktop-files-drag.test.ts` does it.
+ */
+function pointerEvent(
+	type: string,
+	clientX: number,
+	clientY: number,
+): PointerEvent {
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperty( ev, 'pointerId', { value: 1 } );
+	Object.defineProperty( ev, 'button', { value: 0 } );
+	Object.defineProperty( ev, 'isPrimary', { value: true } );
+	Object.defineProperty( ev, 'clientX', { value: clientX } );
+	Object.defineProperty( ev, 'clientY', { value: clientY } );
+	return ev as unknown as PointerEvent;
+}
+
+/** Give an element a real rect — jsdom reports zeros for everything. */
+function withRect(
+	el: HTMLElement,
+	rect: { left: number; top: number; width: number; height: number },
+): void {
+	el.getBoundingClientRect = () =>
+		( {
+			left: rect.left,
+			top: rect.top,
+			right: rect.left + rect.width,
+			bottom: rect.top + rect.height,
+			width: rect.width,
+			height: rect.height,
+			x: rect.left,
+			y: rect.top,
+			toJSON: () => ( {} ),
+		} ) as DOMRect;
+}
+
+describe( 'selection controller', () => {
+	beforeEach( () => {
+		background = document.createElement( 'div' );
+		root = document.createElement( 'div' );
+		background.appendChild( root );
+		document.body.appendChild( background );
+	} );
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'marks the container as a multi-selectable listbox', () => {
+		attach();
+		expect( root.getAttribute( 'role' ) ).toBe( 'listbox' );
+		expect( root.getAttribute( 'aria-multiselectable' ) ).toBe( 'true' );
+	} );
+
+	test( 'plain click replaces the selection', () => {
+		const a = tile( 'a' );
+		const b = tile( 'b' );
+		const handle = attach();
+		click( a );
+		expect( handle.keys() ).toEqual( [ 'a' ] );
+		click( b );
+		expect( handle.keys() ).toEqual( [ 'b' ] );
+	} );
+
+	test( 'selected state rides the attribute, not a hand-set class', () => {
+		const a = tile( 'a' );
+		const handle = attach();
+		click( a );
+		expect( a.hasAttribute( 'selected' ) ).toBe( true );
+		expect( a.getAttribute( 'aria-selected' ) ).toBe( 'true' );
+		// `selectable` is what flips `<os-tile>` to role=option.
+		expect( a.hasAttribute( 'selectable' ) ).toBe( true );
+		handle.model.clear();
+		expect( a.hasAttribute( 'selected' ) ).toBe( false );
+		expect( a.getAttribute( 'aria-selected' ) ).toBe( 'false' );
+	} );
+
+	test( 'ctrl / meta click toggles', () => {
+		const a = tile( 'a' );
+		const b = tile( 'b' );
+		const handle = attach();
+		click( a );
+		click( b, { metaKey: true } );
+		expect( handle.keys() ).toEqual( [ 'a', 'b' ] );
+		click( a, { ctrlKey: true } );
+		expect( handle.keys() ).toEqual( [ 'b' ] );
+	} );
+
+	test( 'shift click extends from the anchor', () => {
+		const a = tile( 'a', 0, 0 );
+		tile( 'b', 100, 0 );
+		const c = tile( 'c', 200, 0 );
+		const handle = attach();
+		click( a );
+		click( c, { shiftKey: true } );
+		expect( handle.keys() ).toEqual( [ 'a', 'b', 'c' ] );
+	} );
+
+	test( 'visual order drives the range, not DOM order', () => {
+		// Appended out of visual order — 'c' is painted first.
+		const a = tile( 'a', 200, 0 );
+		const b = tile( 'b', 100, 0 );
+		tile( 'c', 0, 0 );
+		const handle = attach();
+		click( b );
+		click( a, { shiftKey: true } );
+		expect( handle.keys() ).toEqual( [ 'b', 'a' ] );
+		// ...and 'c', which sits to the left of both, is untouched.
+		expect( handle.keys() ).not.toContain( 'c' );
+	} );
+
+	test( 'ranges do not span two canvases in one step', () => {
+		// A banded list: two canvases, each with its own coordinate
+		// space starting at zero. Grouping by parent keeps a range
+		// from interleaving the bands.
+		const bandA = document.createElement( 'div' );
+		const bandB = document.createElement( 'div' );
+		root.append( bandA, bandB );
+		const mk = ( parent: HTMLElement, key: string, y: number ) => {
+			const el = document.createElement( 'div' );
+			el.className = 'os-file-tile';
+			el.dataset.key = key;
+			el.style.top = `${ y }px`;
+			el.style.left = '0px';
+			parent.appendChild( el );
+			return el;
+		};
+		mk( bandA, 'a1', 0 );
+		const a2 = mk( bandA, 'a2', 100 );
+		const b1 = mk( bandB, 'b1', 0 );
+		mk( bandB, 'b2', 100 );
+		const handle = attach();
+		click( a2 );
+		click( b1, { shiftKey: true } );
+		// Band A's rows come first as a group, so a2 → b1 is exactly
+		// those two — b2 (top: 0, same as b1) is not swept in.
+		expect( handle.keys() ).toEqual( [ 'a2', 'b1' ] );
+	} );
+
+	test( 'clicking empty background clears', () => {
+		const a = tile( 'a' );
+		const handle = attach();
+		click( a );
+		click( background );
+		expect( handle.keys() ).toEqual( [] );
+	} );
+
+	test( 'ctrl/cmd+A selects all and Escape clears', () => {
+		tile( 'a' );
+		tile( 'b' );
+		const handle = attach();
+		root.dispatchEvent(
+			new KeyboardEvent( 'keydown', {
+				key: 'a',
+				metaKey: true,
+				bubbles: true,
+			} ),
+		);
+		expect( handle.keys() ).toEqual( [ 'a', 'b' ] );
+		root.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ),
+		);
+		expect( handle.keys() ).toEqual( [] );
+	} );
+
+	test( 'arrow keys move a cursor that shift+arrow extends from', () => {
+		tile( 'a', 0, 0 );
+		tile( 'b', 100, 0 );
+		tile( 'c', 200, 0 );
+		const handle = attach();
+		const arrow = ( key: string, shiftKey = false ) =>
+			root.dispatchEvent(
+				new KeyboardEvent( 'keydown', { key, shiftKey, bubbles: true } ),
+			);
+		arrow( 'ArrowRight' );
+		expect( handle.keys() ).toEqual( [ 'a' ] );
+		arrow( 'ArrowRight' );
+		expect( handle.keys() ).toEqual( [ 'b' ] );
+		arrow( 'ArrowRight', true );
+		// Extends b..c rather than jumping — the lead moved, the
+		// anchor didn't.
+		expect( handle.keys() ).toEqual( [ 'b', 'c' ] );
+	} );
+
+	test( 'refresh prunes keys whose tiles are gone and re-paints the rest', () => {
+		const a = tile( 'a' );
+		const b = tile( 'b' );
+		const handle = attach();
+		click( a );
+		click( b, { metaKey: true } );
+		// Simulate a repaint that dropped one tile and rebuilt the
+		// other — a fresh node with no `selected` attribute.
+		a.remove();
+		b.removeAttribute( 'selected' );
+		handle.refresh();
+		expect( handle.keys() ).toEqual( [ 'b' ] );
+		expect( b.hasAttribute( 'selected' ) ).toBe( true );
+	} );
+
+	test( 'onChange reports the selection and a document event carries it', () => {
+		const a = tile( 'a' );
+		const onChange = vi.fn();
+		const seen: unknown[] = [];
+		document.addEventListener( 'os-selection-changed', ( e ) => {
+			seen.push( ( e as CustomEvent ).detail );
+		} );
+		attach( { onChange, surface: 'test', scope: '7' } );
+		click( a );
+		expect( onChange ).toHaveBeenCalledWith( [ 'a' ] );
+		expect( seen ).toEqual( [
+			{ surface: 'test', scope: '7', keys: [ 'a' ], count: 1 },
+		] );
+	} );
+
+	test( 'a marquee selects every tile it covers', () => {
+		const a = tile( 'a' );
+		const b = tile( 'b' );
+		const c = tile( 'c' );
+		withRect( background, { left: 0, top: 0, width: 500, height: 500 } );
+		withRect( a, { left: 10, top: 10, width: 50, height: 50 } );
+		withRect( b, { left: 100, top: 10, width: 50, height: 50 } );
+		withRect( c, { left: 300, top: 300, width: 50, height: 50 } );
+		const handle = attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		expect( handle.keys() ).toEqual( [ 'a', 'b' ] );
+		expect(
+			document.querySelector( '.os-selection-marquee' ),
+		).not.toBeNull();
+
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 200 ) );
+		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
+	} );
+
+	test( 'the click that ends a marquee does not clear the selection', () => {
+		const a = tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 500, height: 500 } );
+		withRect( a, { left: 10, top: 10, width: 50, height: 50 } );
+		const handle = attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 200 ) );
+		// The browser synthesizes this on the common ancestor.
+		click( background );
+		expect( handle.keys() ).toEqual( [ 'a' ] );
+	} );
+
+	test( 'a press on a window never starts a marquee', () => {
+		// Windows live INSIDE the desktop area, so their pointer
+		// events bubble to the wallpaper's own listener. Without the
+		// exclusion, dragging a title bar would rubber-band the icons
+		// behind the window.
+		const win = document.createElement( 'div' );
+		win.className = 'os-window';
+		const titleBar = document.createElement( 'div' );
+		win.appendChild( titleBar );
+		background.appendChild( win );
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 500, height: 500 } );
+		const handle = attach();
+
+		const down = pointerEvent( 'pointerdown', 5, 5 );
+		titleBar.dispatchEvent( down );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
+		expect( handle.keys() ).toEqual( [] );
+	} );
+
+	test( 'a canvas INSIDE a window still marquees', () => {
+		// Regression: the wallpaper exclusion (windows are children of
+		// the desktop area) also matched every canvas that lives
+		// inside a window, because there `.os-window` is an ancestor
+		// rather than a descendant. Folder windows and every My
+		// WordPress list lost the marquee entirely.
+		const win = document.createElement( 'div' );
+		win.className = 'os-window';
+		document.body.appendChild( win );
+		// Re-home the canvas inside the window.
+		win.appendChild( background );
+
+		const a = tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		withRect( a, { left: 10, top: 10, width: 50, height: 50 } );
+		const handle = attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		expect(
+			document.querySelector( '.os-selection-marquee' ),
+		).not.toBeNull();
+		expect( handle.keys() ).toEqual( [ 'a' ] );
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 200 ) );
+	} );
+
+	test( 'scrolling mid-marquee grows the band and catches what scrolls in', () => {
+		// The band's anchor belongs to the CONTENT, not the viewport.
+		// Held still while the canvas scrolls, it has to grow — and
+		// sweep up whatever slides into it. Stored in viewport space
+		// the box froze at its original size and the selection stopped
+		// changing, which is the bug this pins.
+		const a = tile( 'a' );
+		const b = tile( 'b' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 200 } );
+		// `a` starts inside the band's reach, `b` is below the fold.
+		withRect( a, { left: 10, top: 20, width: 50, height: 50 } );
+		withRect( b, { left: 10, top: 400, width: 50, height: 50 } );
+		Object.defineProperty( background, 'scrollHeight', {
+			value: 800,
+			configurable: true,
+		} );
+		Object.defineProperty( background, 'clientHeight', {
+			value: 200,
+			configurable: true,
+		} );
+		const handle = attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 150 ) );
+		expect( handle.keys() ).toEqual( [ 'a' ] );
+		const box = document.querySelector< HTMLElement >(
+			'.os-selection-marquee',
+		)!;
+		expect( box.style.height ).toBe( '145px' );
+
+		// Scroll 300px without moving the pointer. `b` rides up into
+		// view; the anchor stays pinned to the content it was drawn
+		// from, so the band is now 300px taller.
+		background.scrollTop = 300;
+		withRect( b, { left: 10, top: 100, width: 50, height: 50 } );
+		background.dispatchEvent( new Event( 'scroll' ) );
+
+		expect( box.style.height ).toBe( '445px' );
+		expect( handle.keys() ).toEqual( [ 'a', 'b' ] );
+
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 150 ) );
+	} );
+
+	test( 'the scroll listener is dropped with the gesture', () => {
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 200 } );
+		const handle = attach();
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 150 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 150 ) );
+		handle.model.clear();
+
+		// A scroll after the drag must not resurrect the band.
+		background.scrollTop = 300;
+		background.dispatchEvent( new Event( 'scroll' ) );
+		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
+		expect( handle.keys() ).toEqual( [] );
+	} );
+
+	test( 'the browser cannot run a text selection under the band', () => {
+		// Drag a band out past the window it started in and the
+		// browser's own selection — begun on the same press, because
+		// bare canvas is selectable where a tile is not — starts
+		// highlighting whatever is behind, in blue, mid-gesture.
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		attach();
+
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( true );
+		// Any selection the browser tries to begin from here is
+		// refused — including one starting in another window.
+		const attempt = new Event( 'selectstart', {
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.body.dispatchEvent( attempt );
+		expect( attempt.defaultPrevented ).toBe( true );
+
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 200 ) );
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+		// …and normal selection works again the moment the band drops.
+		const after = new Event( 'selectstart', {
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.body.dispatchEvent( after );
+		expect( after.defaultPrevented ).toBe( false );
+	} );
+
+	test( 'a press that never becomes a band leaves selection alone', () => {
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		attach();
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		// Sub-threshold: this is a click, and clicking must not stop
+		// the user selecting text on the surfaces around it.
+		document.dispatchEvent( pointerEvent( 'pointermove', 6, 6 ) );
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+		document.dispatchEvent( pointerEvent( 'pointerup', 6, 6 ) );
+	} );
+
+	test( 'suppression is released even when the band is cancelled', () => {
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		attach();
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( true );
+		// Escape mid-drag must not leave the shell unselectable.
+		root.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ),
+		);
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+	} );
+
+	test( 'the band takes pointer capture so the release comes home', () => {
+		// Release over an IFRAME — a chromeless admin window — and the
+		// `pointerup` fires in THAT document; the listeners out here
+		// never hear it and the band follows a button the user already
+		// let go of. Capture retargets the rest of the gesture to this
+		// canvas, whatever it happens over.
+		const captured: number[] = [];
+		const released: number[] = [];
+		background.setPointerCapture = ( id: number ) => {
+			captured.push( id );
+		};
+		background.releasePointerCapture = ( id: number ) => {
+			released.push( id );
+		};
+		background.hasPointerCapture = ( id: number ) =>
+			captured.includes( id ) && ! released.includes( id );
+
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		expect( captured ).toEqual( [ 1 ] );
+
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		document.dispatchEvent( pointerEvent( 'pointerup', 200, 200 ) );
+		expect( released ).toEqual( [ 1 ] );
+	} );
+
+	test( 'losing the capture ends the band rather than stranding it', () => {
+		background.setPointerCapture = () => undefined;
+		background.releasePointerCapture = () => undefined;
+		background.hasPointerCapture = () => false;
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		expect(
+			document.querySelector( '.os-selection-marquee' ),
+		).not.toBeNull();
+
+		// The browser can hand capture back on its own — an alert, a
+		// native context menu, a touch interruption.
+		background.dispatchEvent(
+			new Event( 'lostpointercapture', { bubbles: true } ),
+		);
+		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+	} );
+
+	test( 'focus leaving the shell ends the band', () => {
+		// What a click landing inside an iframe looks like from out
+		// here. Without this the band outlives the gesture.
+		background.setPointerCapture = () => undefined;
+		background.releasePointerCapture = () => undefined;
+		background.hasPointerCapture = () => false;
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 400, height: 400 } );
+		attach();
+
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		window.dispatchEvent( new Event( 'blur' ) );
+		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
+		expect( document.body.hasAttribute( 'data-os-marquee' ) ).toBe( false );
+	} );
+
+	test( 'marquee can be disabled', () => {
+		tile( 'a' );
+		withRect( background, { left: 0, top: 0, width: 500, height: 500 } );
+		attach( { marquee: false } );
+		background.dispatchEvent( pointerEvent( 'pointerdown', 5, 5 ) );
+		document.dispatchEvent( pointerEvent( 'pointermove', 200, 200 ) );
+		expect( document.querySelector( '.os-selection-marquee' ) ).toBeNull();
+	} );
+
+	test( 'destroy unbinds the gestures', () => {
+		const a = tile( 'a' );
+		const handle = attach();
+		handle.destroy();
+		click( a );
+		expect( handle.keys() ).toEqual( [] );
+	} );
+} );

--- a/tests/vitest/selection-model.test.ts
+++ b/tests/vitest/selection-model.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the selection model — the set + anchor semantics every
+ * tile canvas in the shell now shares.
+ */
+import { describe, expect, test, vi } from 'vitest';
+import { createSelectionModel } from '../../src/selection/model';
+
+const ORDER = [ 'a', 'b', 'c', 'd', 'e' ];
+
+function model( order: string[] = ORDER.slice() ) {
+	return createSelectionModel< string >( { order: () => order } );
+}
+
+describe( 'selection model', () => {
+	test( 'set replaces the selection and moves the anchor', () => {
+		const m = model();
+		m.set( [ 'b', 'c' ] );
+		expect( m.keys() ).toEqual( [ 'b', 'c' ] );
+		expect( m.anchor() ).toBe( 'c' );
+		m.set( [ 'a' ] );
+		expect( m.keys() ).toEqual( [ 'a' ] );
+		expect( m.anchor() ).toBe( 'a' );
+	} );
+
+	test( 'toggle adds then removes', () => {
+		const m = model();
+		m.toggle( 'b' );
+		m.toggle( 'd' );
+		expect( m.keys() ).toEqual( [ 'b', 'd' ] );
+		m.toggle( 'b' );
+		expect( m.keys() ).toEqual( [ 'd' ] );
+	} );
+
+	test( 'keys come back in the order the surface reports, not click order', () => {
+		const m = model();
+		m.toggle( 'd' );
+		m.toggle( 'a' );
+		m.toggle( 'c' );
+		expect( m.keys() ).toEqual( [ 'a', 'c', 'd' ] );
+	} );
+
+	test( 'selectRange covers the span between anchor and target', () => {
+		const m = model();
+		m.set( [ 'b' ] );
+		m.selectRange( 'd' );
+		expect( m.keys() ).toEqual( [ 'b', 'c', 'd' ] );
+	} );
+
+	test( 'selectRange works backwards too', () => {
+		const m = model();
+		m.set( [ 'd' ] );
+		m.selectRange( 'b' );
+		expect( m.keys() ).toEqual( [ 'b', 'c', 'd' ] );
+	} );
+
+	test( 'successive ranges re-extend from the same anchor rather than walking', () => {
+		const m = model();
+		m.set( [ 'b' ] );
+		m.selectRange( 'd' );
+		m.selectRange( 'c' );
+		// Anchor stayed at 'b', so the second range is b..c — NOT
+		// b..d plus c..d, and not d..c from a moved anchor.
+		expect( m.keys() ).toEqual( [ 'b', 'c' ] );
+		expect( m.anchor() ).toBe( 'b' );
+	} );
+
+	test( 'additive range keeps the previous selection', () => {
+		const m = model();
+		m.set( [ 'a' ] );
+		m.toggle( 'c' );
+		m.selectRange( 'd', true );
+		expect( m.keys() ).toEqual( [ 'a', 'c', 'd' ] );
+	} );
+
+	test( 'range with no usable anchor degrades to a plain click', () => {
+		const m = model();
+		m.selectRange( 'c' );
+		expect( m.keys() ).toEqual( [ 'c' ] );
+		expect( m.anchor() ).toBe( 'c' );
+	} );
+
+	test( 'selectAll and clear', () => {
+		const m = model();
+		m.selectAll();
+		expect( m.keys() ).toEqual( ORDER );
+		m.clear();
+		expect( m.keys() ).toEqual( [] );
+		expect( m.anchor() ).toBeNull();
+	} );
+
+	test( 'prune drops keys the surface no longer reports', () => {
+		const order = ORDER.slice();
+		const m = createSelectionModel< string >( { order: () => order } );
+		m.set( [ 'b', 'c', 'd' ] );
+		order.splice( order.indexOf( 'c' ), 1 );
+		expect( m.prune() ).toBe( true );
+		expect( m.keys() ).toEqual( [ 'b', 'd' ] );
+		// A second prune with nothing to do reports no change.
+		expect( m.prune() ).toBe( false );
+	} );
+
+	test( 'prune clears an anchor that no longer exists', () => {
+		const order = ORDER.slice();
+		const m = createSelectionModel< string >( { order: () => order } );
+		m.set( [ 'c' ] );
+		order.splice( order.indexOf( 'c' ), 1 );
+		m.prune();
+		expect( m.anchor() ).toBeNull();
+	} );
+
+	test( 'subscribers fire only when membership actually changes', () => {
+		const seen: string[][] = [];
+		const m = createSelectionModel< string >( {
+			order: () => ORDER.slice(),
+			onChange: ( keys ) => seen.push( keys ),
+		} );
+		m.set( [ 'a' ] );
+		m.set( [ 'a' ] ); // same membership — no notification
+		m.add( 'a' ); // already there — no notification
+		m.add( 'b' );
+		expect( seen ).toEqual( [ [ 'a' ], [ 'a', 'b' ] ] );
+	} );
+
+	test( 'a throwing subscriber does not strand the gesture', () => {
+		const spy = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => undefined );
+		const m = model();
+		m.subscribe( () => {
+			throw new Error( 'boom' );
+		} );
+		const other = vi.fn();
+		m.subscribe( other );
+		expect( () => m.set( [ 'a' ] ) ).not.toThrow();
+		expect( other ).toHaveBeenCalled();
+		spy.mockRestore();
+	} );
+
+	test( 'unsubscribe stops delivery', () => {
+		const m = model();
+		const cb = vi.fn();
+		const off = m.subscribe( cb );
+		m.set( [ 'a' ] );
+		off();
+		m.set( [ 'b' ] );
+		expect( cb ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
https://github.com/user-attachments/assets/beb7c0dc-272f-4d4f-907a-b242fee3c938


Every tile surface in the shell was single-select, and each one had re-implemented it — six selection states and four near-identical context-menu builders between the wallpaper, folder windows and the five canvases in the site folder. You could not act on two things at once anywhere.

This is one selection framework (`src/selection/`) that all of them use, and one rule for the hard part.

## The rule: who decides what a mixed set can do

- **The item's own adapter** answers *"what can be done to this one thing?"* — that's the tile-menu builder each surface already had, filters and all. Unchanged.
- **The framework** answers *"what do these N have in common?"* — intersect by action id, and keep an id only when **every** contributing action declares `multi: true`.

So selecting a post and an image leaves *Move to Trash* and drops *Navigate into* (post-only) and *Download* (image-only).

`multi` is opt-in on purpose: an action written against one item — *Rename…*, *Share folder…* — would misbehave run twelve times, and its author never agreed to that. **Existing menu entries keep working untouched** and simply stay single-item until they opt in. `multiId` merges the same deed under different labels, which is how a folder's `delete-folder` and a file's `remove` end up sharing one Trash entry.

Actions can ship a `bulk( items )` runner. That's what turns twelve REST calls, twelve toasts and twelve Undo buttons into one of each.

## What you get

**Selection** on every canvas — wallpaper, folder windows, and every My WordPress list: click, Ctrl/Cmd-click, Shift-click, rubber band, Cmd+A, Escape, arrow keys. Status bars gain a live "N selected"; preview panes summarise a set instead of previewing an arbitrary member.

**WordPress's own bulk actions** on the site folder's lists:

| Section | Actions |
|---|---|
| Posts / Pages / CPTs | **Edit…** (the bulk-edit modal), Publish, Switch to Draft, Copy link, Move to Trash |
| Media | Detach, Copy file URL, Delete permanently |
| Users | Change role…, Delete… , Copy author archive link |

Bulk edit matches core where it counts: **only the fields you changed are written** (every control starts on "— No change —"), and **categories and tags are added** to what each entry already has rather than replacing it. Deleting users asks core's "delete their content or reassign it" question first, because the REST endpoint refuses without an answer.

The status actions are the intersection rule in the wild: *Publish* only appears for entries that aren't published, *Switch to Draft* only for those that aren't drafts — select one of each and neither shows.

**Multi-item drag.** Three icons to the Trash is one toast with one Undo; three to a folder is one move; three posts from My WordPress onto the wallpaper is three shortcuts. The ghost is a stack with a count badge and the hover chip says the count.

## Compatibility

Drag payloads grew **one optional field per type** — `placements` on `desktop-file`, `items` on `shortcut` — both **absent for a single-item drag**. Every drop target written before this, ours and any plugin's, is untouched and correct: it reads `data.placement` and acts on the tile the user pointed at. Targets that want sets call `dragPlacements()` / `dragShortcutItems()`, which fall back to the grabbed item — one code path for "one" and "many".

Targets that do support sets apply their accept gates to **every** member and refuse the whole drop when any one fails. Accepting a set and handling part of it reports success for an operation that half-happened.

## Also: one icon grid

The grid had drifted into two — the desktop ran a 96×110 pitch and the site folder 108×112 — and the desktop's 8px of air was fiction: the tile had no `box-sizing`, so its padding fell outside its declared width, filled the cell, and icons touched.

There is now one grid, declared as tokens in `variables.css` (so a desktop theme can retune it) and mirrored in `grid.ts` for the layout maths, with a test that parses the stylesheet to prove the mirror stays faithful. **The cell is derived, never declared**: `cell = tile + gap`. Tile height is fixed rather than minimum, because the tile box *is* the selection ring and a box that grows with its label gives a row of selected icons a ragged edge.

> **Heads-up for reviewers:** stored icon coordinates were on the old pitch, so expect a one-time reshuffle. Icons snap to the new grid on the next drag or *Sort by → Clean up*.

## Four bugs found while building it

Each has the test that would have caught it:

- **`<os-tile>` rebuilt its children on any attribute change.** A selection change mid-gesture destroyed the node a `mousedown` landed on, so the browser synthesized no `click` — no `dblclick`, and tiles stopped opening. Selection attributes now take a children-preserving path (also: Cmd+A over 200 icons costs 200 class toggles, not 200 subtree rebuilds).
- **The marquee's `.os-window` exclusion** — added so a title-bar drag can't rubber-band the wallpaper behind it — also matched every canvas *inside* a window, where the window is an ancestor rather than a descendant. Scoped with `background.contains()`.
- **The marquee anchor was in viewport coordinates**, so scrolling mid-drag froze the band. It's content-space now, redraws on scroll, and auto-scrolls at the edges.
- **A marquee released over an iframe stranded the gesture**, because the `pointerup` fired in that document. The band takes pointer capture, with `lostpointercapture` and window `blur` as nets. It also suppresses native text selection while it runs — the bare canvas is selectable where a tile is not, so the browser was quietly running its own selection into whatever the pointer crossed.

## Testing

`npm run lint`, `npm run typecheck`, `npm run test:js` (**3904 tests, 317 files**) and `npm run build` all green. **9 new test files**: the selection model, the action resolver, the controller (gestures, marquee, scroll, capture, suppression), both surfaces, bulk trash, bulk actions, multi-drag, and grid metrics.

No PHP changed — this is entirely client-side over existing REST routes — so `lint:php` / `test:php` are unaffected.

Manual QA on a live site: multi-select and bulk actions across Posts, Users, Media and folder windows; drag-to-Trash and drag-to-folder with Undo; rubber band on the wallpaper, in folder windows, and mid-scroll.

## Docs

Updated in the same change: `javascript-reference.md` (the `wp.os.selection` surface, `os-selection-changed`, the `multi` / `multiId` / `bulkLabel` / `bulk` fields, the built-in bulk-action table, multi-item drag payloads), `files-on-desktop.md` (selection, dragging a selection, the grid), `components-reference.md`, `api-index.md`, `desktop-themes.md` (the grid tokens), and a new `examples/multi-selection-action.md`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-501-7ab895cfd0f41d75d0dbe2cb085dc47184efe4d7.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->