### PR TITLE
Chromeless: keep Quick Edit and Bulk Edit alive across a soft reload

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2553,10 +2553,14 @@ survive, and Core's inline editors are bound that way
 (`$( '#the-list' ).on( 'click', '.editinline', … )` and friends).
 The bridge therefore re-runs Core's own init entry points after
 each swap — `inlineEditPost.init()`, `inlineEditTax.init()`,
-`setCommentsList()`, `commentReply.init()` — which restores Quick
-Edit, Bulk Edit, comment Quick Edit / Reply and the comment row
-actions. Custom list tables that enqueue `inline-edit-post` get
-this for free.
+`commentReply.init()` — which restores Quick Edit, Bulk Edit and
+comment Quick Edit / Reply. Custom list tables that enqueue
+`inline-edit-post` get this for free.
+
+Only an init whose every binding lands inside the replaced subtree
+is safe to re-run. `setCommentsList()` is not, and is deliberately
+left out: it re-runs `wpList`, which binds on `document`, so each
+call would stack another set of comment row-action handlers.
 
 If your own code binds to an element inside the list table, bind
 it on `document` (best), or re-bind on `os-soft-reloaded`, which

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2517,11 +2517,12 @@ emitters identifying themselves for echo suppression).
 **Iframe-side default behaviour: soft reload.** The chromeless
 bridge installs a built-in subscriber that, when the topic
 matches the iframe's current page, *fetches the URL it's already
-on* and replaces `#wpbody-content` in place. The user sees the
-list update — restored post appears, trashed media disappears —
-without the WP loading spinner that `location.reload()` would
-show. Matching is generic: the page's list type is
-derived from the URL and compared to the `<type>` in the topic —
+on* and replaces the contents of `#wpbody-content` in place. The
+user sees the list update — restored post appears, trashed media
+disappears — without the WP loading spinner that
+`location.reload()` would show. Matching is generic: the page's
+list type is derived from the URL and compared to the `<type>` in
+the topic —
 
 | List page | Reacts to |
 |---|---|
@@ -2542,10 +2543,26 @@ destroy unsaved editor state. Plugins wanting specific behaviour
 for those pages subscribe to the same topic themselves and decide
 how to react.
 
-After every successful soft-reload the bridge dispatches
-`os-soft-reloaded` on the iframe's `document` so plugins
-that need to re-bind state (e.g. their own custom widgets in the
-list table) have a single signal to listen for.
+**What survives the swap, and what the bridge re-binds.** The
+`#wpbody-content` element itself is kept and only its children are
+replaced, so anything delegated on `document`, `body` or
+`#wpbody-content` keeps working untouched — that covers wp-lists,
+`updates.js`, and Core's select-all checkboxes and row-actions
+focus reveal. Handlers bound to elements *inside* it do not
+survive, and Core's inline editors are bound that way
+(`$( '#the-list' ).on( 'click', '.editinline', … )` and friends).
+The bridge therefore re-runs Core's own init entry points after
+each swap — `inlineEditPost.init()`, `inlineEditTax.init()`,
+`setCommentsList()`, `commentReply.init()` — which restores Quick
+Edit, Bulk Edit, comment Quick Edit / Reply and the comment row
+actions. Custom list tables that enqueue `inline-edit-post` get
+this for free.
+
+If your own code binds to an element inside the list table, bind
+it on `document` (best), or re-bind on `os-soft-reloaded`, which
+the bridge dispatches on the iframe's `document` after every
+successful soft-reload — and after the Core re-init above, so a
+listener always sees a working list table.
 
 **Plugin extension.** Subscribers from anywhere (parent shell,
 native windows, iframes) can use the bus directly:

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -2606,13 +2606,10 @@ function openstation_chromeless_bridge_script() {
 	 * returns the full admin page and we just pluck the body.
 	 *
 	 * Most WP list-table JS delegates on `document`/`body` and
-	 * survives `replaceWith`. The inline editors do NOT — they
-	 * delegate on `#the-list` / `#the-comment-list`, which live
-	 * inside the swapped subtree — so `_openstationReinitListTables()`
-	 * below re-runs Core's own init entry points after the swap. A
-	 * page that needs anything beyond that should listen for
-	 * `os-soft-reloaded` and rebind; the event fires after the
-	 * Core re-init, so a listener sees a sane list table.
+	 * survives the swap. The inline editors don't, so
+	 * `_openstationReinitListTables()` below re-runs Core's init
+	 * entry points afterwards. A page needing more than that should
+	 * listen for `os-soft-reloaded`, which fires after that re-init.
 	 * ----------------------------------------------------------------- */
 	var OPENSTATION_SOFT_RELOAD_EXTRAS = /*__OPENSTATION_SOFT_RELOAD_EXTRAS__*/;
 
@@ -2687,49 +2684,28 @@ function openstation_chromeless_bridge_script() {
 	/*
 	 * Re-init Core's list-table editors after a soft reload.
 	 *
-	 * The swap above replaces everything inside `#wpbody-content`,
-	 * and Core's inline editors bind to elements in there rather
-	 * than delegating on `document`:
+	 * Core's inline editors bind to elements inside `#wpbody-content`
+	 * instead of delegating on `document`: `#the-list` for Quick Edit
+	 * (inline-edit-post.js, inline-edit-tax.js), `#doaction` for Bulk
+	 * Edit, `#the-comment-list` for the comment inline editors. The
+	 * swap above throws those elements away, so the buttons keep
+	 * rendering and stop working.
 	 *
-	 *   inline-edit-post.js  $( '#the-list' ).on( 'click', '.editinline', … )
-	 *                        $( '#doaction' ).on( 'click', … )   ← Bulk Edit
-	 *   inline-edit-tax.js   $( '#the-list' ).on( 'click', '.editinline', … )
-	 *   edit-comments.js     $( '#the-comment-list' ).on( 'click', '.comment-inline', … )
-	 *                        plus the `wpList` wiring for row actions
+	 * Only re-run an init whose every binding lands inside the
+	 * replaced subtree — then the fresh DOM gets it exactly once and
+	 * nothing accumulates. `setCommentsList()` fails that test and is
+	 * NOT called here: it re-runs `wpList`, whose `process()` binds on
+	 * `document` (which survives), so each call stacks another set of
+	 * comment row-action handlers and one Approve click ends up firing
+	 * N moderation requests. Those handlers were never broken by the
+	 * swap; only the closure state behind them goes stale, which costs
+	 * a stale total count until the next reload.
 	 *
-	 * The swap throws away the elements those handlers were bound
-	 * to, so without this the buttons still render, still take
-	 * focus, and do nothing. That is what "Quick Edit doesn't work"
-	 * looks like from the outside: it works on a freshly opened
-	 * window and dies the first time anything on the site records a
-	 * content change.
-	 *
-	 * Every element these init functions touch (`#the-list`,
-	 * `#inline-edit`, `#bulk-edit`, `#doaction`, `#replyrow`,
-	 * `#the-comment-list`) lives inside the subtree we just
-	 * replaced, so on the fresh DOM they bind exactly once — no
-	 * double-binding, and no need to unbind first. Anything Core
-	 * delegates on `document`, `body` or `#wpbody-content` itself
-	 * (wp-lists, updates.js, the select-all checkboxes and the
-	 * row-actions focus reveal in common.js) is untouched by the
-	 * swap and deliberately not re-run here.
-	 *
-	 * Guarded per-global rather than per-screen: the globals only
-	 * exist where their script is enqueued, which is a better
-	 * screen test than anything we could derive from the URL, and
-	 * it keeps custom list tables that enqueue `inline-edit-post`
-	 * working for free.
-	 *
-	 * Not restored, deliberately, because each would mean copying
-	 * dozens of lines of `common.js` in here to buy back a
-	 * degraded-but-working affordance rather than a dead one:
-	 * the empty-bulk-action guard (`$( '.bulkactions' ).parents(
-	 * 'form' ).on( 'submit', … )` — an unselected bulk action
-	 * submits and the page simply comes back instead of showing
-	 * "Please select at least one item"), and the search-box
-	 * mousedown that clears a stale value. Both are worth a
-	 * follow-up upstream: none of these bindings would need
-	 * re-running at all if Core delegated them on `document`.
+	 * Also left alone: `common.js`'s empty-bulk-action guard and
+	 * search-box mousedown, and `$.table_hotkeys` (comment moderation
+	 * shortcuts stop navigating; re-running it would double-register).
+	 * All degraded rather than dead, and each would mean copying
+	 * dozens of lines of Core in here.
 	 */
 	function _openstationReinitListTables() {
 		var $ = window.jQuery;
@@ -2738,12 +2714,13 @@ function openstation_chromeless_bridge_script() {
 		}
 
 		/*
-		 * Mobile row expander. `common.js` binds it per-`tbody`
-		 * (`$( 'tbody' ).on( 'click', '.toggle-row', … )`), and every
-		 * list-table `tbody` is inside the subtree we just replaced.
-		 * Narrow windows are the norm in the shell, so this is the
-		 * one row-actions affordance most likely to be the ONLY one
-		 * on screen.
+		 * Mobile row expander. `common.js` binds it per-`tbody`, all
+		 * of which we just replaced. Narrow windows are the norm in
+		 * the shell, so it is often the only row affordance on screen.
+		 *
+		 * Per-`tbody` on purpose. Delegating on the now-surviving
+		 * `#wpbody-content` would stack with Core's own binding on
+		 * first load and toggle the row twice, back to closed.
 		 */
 		$( '#wpbody-content tbody' ).on( 'click', '.toggle-row', function () {
 			$( this ).closest( 'tr' ).toggleClass( 'is-expanded' );
@@ -2762,44 +2739,39 @@ function openstation_chromeless_bridge_script() {
 			} catch ( err ) { _openstationWarnReinit( 'inline-edit-tax', err ); }
 		}
 
-		if ( document.getElementById( 'the-comment-list' ) ) {
+		if ( document.getElementById( 'the-comment-list' ) && window.commentReply ) {
 			try {
-				if ( typeof window.setCommentsList === 'function' ) {
-					window.setCommentsList();
-				}
-				if ( window.commentReply && typeof window.commentReply.init === 'function' ) {
+				if ( typeof window.commentReply.init === 'function' ) {
 					window.commentReply.init();
-					/*
-					 * The `.comment-inline` delegation (Quick Edit /
-					 * Reply / Edit on a comment row) is the one binding
-					 * with no re-callable entry point — edit-comments.js
-					 * does it inline in its own `$( document ).ready`,
-					 * outside `commentReply.init`. Mirror it here. Kept
-					 * byte-for-byte equivalent to Core's handler so a
-					 * future Core change is a visible diff rather than a
-					 * silent behaviour drift.
-					 */
-					$( '#the-comment-list' ).on( 'click', '.comment-inline', function () {
-						var $el = $( this ),
-							action = 'replyto';
-
-						if ( 'undefined' !== typeof $el.data( 'action' ) ) {
-							action = $el.data( 'action' );
-						}
-
-						$( this ).attr( 'aria-expanded', 'true' );
-						window.commentReply.open( $el.data( 'commentId' ), $el.data( 'postId' ), action );
-					} );
 				}
-			} catch ( err ) { _openstationWarnReinit( 'edit-comments', err ); }
+			} catch ( err ) { _openstationWarnReinit( 'comment-reply', err ); }
+			try {
+				/*
+				 * Quick Edit / Reply / Edit on a comment row.
+				 * edit-comments.js binds this in its own doc-ready
+				 * rather than in `commentReply.init`, so there is
+				 * nothing to re-call. Mirror Core's handler.
+				 */
+				$( '#the-comment-list' ).on( 'click', '.comment-inline', function () {
+					var $el = $( this ),
+						action = 'replyto';
+
+					if ( 'undefined' !== typeof $el.data( 'action' ) ) {
+						action = $el.data( 'action' );
+					}
+
+					$( this ).attr( 'aria-expanded', 'true' );
+					window.commentReply.open( $el.data( 'commentId' ), $el.data( 'postId' ), action );
+				} );
+			} catch ( err ) { _openstationWarnReinit( 'comment-inline', err ); }
 		}
 	}
 
 	/*
-	 * A re-init that throws must not take the rest of the re-init —
-	 * or the `os-soft-reloaded` listeners after it — down with it.
-	 * Warn loudly instead: a silent catch here would present as the
-	 * exact bug this function exists to fix.
+	 * One failing re-init must not take the others, or the
+	 * `os-soft-reloaded` listeners after them, down with it. Warn
+	 * rather than swallow: a silent catch here looks exactly like the
+	 * bug this function exists to fix.
 	 */
 	function _openstationWarnReinit( which, err ) {
 		if ( window.console && window.console.warn ) {
@@ -2832,20 +2804,12 @@ function openstation_chromeless_bridge_script() {
 				return;
 			}
 			/*
-			 * Swap the CONTENTS of `#wpbody-content`, not the
-			 * element itself. `#wpbody-content`'s own markup is
-			 * static (`id`, `aria-label`, `tabindex`), so nothing
-			 * is lost by keeping the node — and keeping it keeps
-			 * every handler delegated ON it, which Core relies on
-			 * for the row-actions focus reveal in `common.js`
-			 * (`$( '#wpbody-content' ).on( { focusin, focusout },
-			 * '.table-view-list .has-row-actions' )`). `replaceWith`
-			 * silently dropped that one on every soft reload.
-			 *
-			 * Nodes parsed into another document are adopted on
-			 * insert, same as they were under `replaceWith`. The
-			 * slice is load-bearing: `childNodes` is live, and it
-			 * empties out from under the iteration otherwise.
+			 * Swap the CONTENTS of `#wpbody-content`, keeping the
+			 * node. Keeping it preserves handlers delegated on it,
+			 * which is where `common.js` puts the row-actions focus
+			 * reveal. Core emits the container as a bare
+			 * `<div id="wpbody-content">`, so the only thing this
+			 * discards is any attribute a plugin added to `fresh`.
 			 */
 			live.replaceChildren.apply( live, Array.prototype.slice.call( fresh.childNodes ) );
 			_openstationReinitListTables();

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -2605,10 +2605,14 @@ function openstation_chromeless_bridge_script() {
 	 * minimal partial response if we want to optimise; for now WP
 	 * returns the full admin page and we just pluck the body.
 	 *
-	 * WP list-table JS uses event delegation on `document`/`body`,
-	 * which survives `replaceWith`. If a specific page breaks after
-	 * a swap (e.g. inline-edit double-binding), that page's plugin
-	 * should listen for `os-soft-reloaded` and rebind.
+	 * Most WP list-table JS delegates on `document`/`body` and
+	 * survives `replaceWith`. The inline editors do NOT — they
+	 * delegate on `#the-list` / `#the-comment-list`, which live
+	 * inside the swapped subtree — so `_openstationReinitListTables()`
+	 * below re-runs Core's own init entry points after the swap. A
+	 * page that needs anything beyond that should listen for
+	 * `os-soft-reloaded` and rebind; the event fires after the
+	 * Core re-init, so a listener sees a sane list table.
 	 * ----------------------------------------------------------------- */
 	var OPENSTATION_SOFT_RELOAD_EXTRAS = /*__OPENSTATION_SOFT_RELOAD_EXTRAS__*/;
 
@@ -2680,6 +2684,129 @@ function openstation_chromeless_bridge_script() {
 	var _openstationSoftReloadInFlight = false;
 	var _openstationSoftReloadQueued = false;
 
+	/*
+	 * Re-init Core's list-table editors after a soft reload.
+	 *
+	 * The swap above replaces everything inside `#wpbody-content`,
+	 * and Core's inline editors bind to elements in there rather
+	 * than delegating on `document`:
+	 *
+	 *   inline-edit-post.js  $( '#the-list' ).on( 'click', '.editinline', … )
+	 *                        $( '#doaction' ).on( 'click', … )   ← Bulk Edit
+	 *   inline-edit-tax.js   $( '#the-list' ).on( 'click', '.editinline', … )
+	 *   edit-comments.js     $( '#the-comment-list' ).on( 'click', '.comment-inline', … )
+	 *                        plus the `wpList` wiring for row actions
+	 *
+	 * The swap throws away the elements those handlers were bound
+	 * to, so without this the buttons still render, still take
+	 * focus, and do nothing. That is what "Quick Edit doesn't work"
+	 * looks like from the outside: it works on a freshly opened
+	 * window and dies the first time anything on the site records a
+	 * content change.
+	 *
+	 * Every element these init functions touch (`#the-list`,
+	 * `#inline-edit`, `#bulk-edit`, `#doaction`, `#replyrow`,
+	 * `#the-comment-list`) lives inside the subtree we just
+	 * replaced, so on the fresh DOM they bind exactly once — no
+	 * double-binding, and no need to unbind first. Anything Core
+	 * delegates on `document`, `body` or `#wpbody-content` itself
+	 * (wp-lists, updates.js, the select-all checkboxes and the
+	 * row-actions focus reveal in common.js) is untouched by the
+	 * swap and deliberately not re-run here.
+	 *
+	 * Guarded per-global rather than per-screen: the globals only
+	 * exist where their script is enqueued, which is a better
+	 * screen test than anything we could derive from the URL, and
+	 * it keeps custom list tables that enqueue `inline-edit-post`
+	 * working for free.
+	 *
+	 * Not restored, deliberately, because each would mean copying
+	 * dozens of lines of `common.js` in here to buy back a
+	 * degraded-but-working affordance rather than a dead one:
+	 * the empty-bulk-action guard (`$( '.bulkactions' ).parents(
+	 * 'form' ).on( 'submit', … )` — an unselected bulk action
+	 * submits and the page simply comes back instead of showing
+	 * "Please select at least one item"), and the search-box
+	 * mousedown that clears a stale value. Both are worth a
+	 * follow-up upstream: none of these bindings would need
+	 * re-running at all if Core delegated them on `document`.
+	 */
+	function _openstationReinitListTables() {
+		var $ = window.jQuery;
+		if ( ! $ ) {
+			return;
+		}
+
+		/*
+		 * Mobile row expander. `common.js` binds it per-`tbody`
+		 * (`$( 'tbody' ).on( 'click', '.toggle-row', … )`), and every
+		 * list-table `tbody` is inside the subtree we just replaced.
+		 * Narrow windows are the norm in the shell, so this is the
+		 * one row-actions affordance most likely to be the ONLY one
+		 * on screen.
+		 */
+		$( '#wpbody-content tbody' ).on( 'click', '.toggle-row', function () {
+			$( this ).closest( 'tr' ).toggleClass( 'is-expanded' );
+		} );
+
+		if ( document.getElementById( 'the-list' ) ) {
+			try {
+				if ( window.inlineEditPost && typeof window.inlineEditPost.init === 'function' ) {
+					window.inlineEditPost.init();
+				}
+			} catch ( err ) { _openstationWarnReinit( 'inline-edit-post', err ); }
+			try {
+				if ( window.inlineEditTax && typeof window.inlineEditTax.init === 'function' ) {
+					window.inlineEditTax.init();
+				}
+			} catch ( err ) { _openstationWarnReinit( 'inline-edit-tax', err ); }
+		}
+
+		if ( document.getElementById( 'the-comment-list' ) ) {
+			try {
+				if ( typeof window.setCommentsList === 'function' ) {
+					window.setCommentsList();
+				}
+				if ( window.commentReply && typeof window.commentReply.init === 'function' ) {
+					window.commentReply.init();
+					/*
+					 * The `.comment-inline` delegation (Quick Edit /
+					 * Reply / Edit on a comment row) is the one binding
+					 * with no re-callable entry point — edit-comments.js
+					 * does it inline in its own `$( document ).ready`,
+					 * outside `commentReply.init`. Mirror it here. Kept
+					 * byte-for-byte equivalent to Core's handler so a
+					 * future Core change is a visible diff rather than a
+					 * silent behaviour drift.
+					 */
+					$( '#the-comment-list' ).on( 'click', '.comment-inline', function () {
+						var $el = $( this ),
+							action = 'replyto';
+
+						if ( 'undefined' !== typeof $el.data( 'action' ) ) {
+							action = $el.data( 'action' );
+						}
+
+						$( this ).attr( 'aria-expanded', 'true' );
+						window.commentReply.open( $el.data( 'commentId' ), $el.data( 'postId' ), action );
+					} );
+				}
+			} catch ( err ) { _openstationWarnReinit( 'edit-comments', err ); }
+		}
+	}
+
+	/*
+	 * A re-init that throws must not take the rest of the re-init —
+	 * or the `os-soft-reloaded` listeners after it — down with it.
+	 * Warn loudly instead: a silent catch here would present as the
+	 * exact bug this function exists to fix.
+	 */
+	function _openstationWarnReinit( which, err ) {
+		if ( window.console && window.console.warn ) {
+			window.console.warn( '[openstation] soft-reload re-init failed for ' + which + ':', err );
+		}
+	}
+
 	function _openstationSoftReload() {
 		if ( _openstationSoftReloadInFlight ) {
 			_openstationSoftReloadQueued = true;
@@ -2704,7 +2831,24 @@ function openstation_chromeless_bridge_script() {
 				 * than show a spinner the user told us not to. */
 				return;
 			}
-			live.replaceWith( fresh );
+			/*
+			 * Swap the CONTENTS of `#wpbody-content`, not the
+			 * element itself. `#wpbody-content`'s own markup is
+			 * static (`id`, `aria-label`, `tabindex`), so nothing
+			 * is lost by keeping the node — and keeping it keeps
+			 * every handler delegated ON it, which Core relies on
+			 * for the row-actions focus reveal in `common.js`
+			 * (`$( '#wpbody-content' ).on( { focusin, focusout },
+			 * '.table-view-list .has-row-actions' )`). `replaceWith`
+			 * silently dropped that one on every soft reload.
+			 *
+			 * Nodes parsed into another document are adopted on
+			 * insert, same as they were under `replaceWith`. The
+			 * slice is load-bearing: `childNodes` is live, and it
+			 * empties out from under the iteration otherwise.
+			 */
+			live.replaceChildren.apply( live, Array.prototype.slice.call( fresh.childNodes ) );
+			_openstationReinitListTables();
 			try {
 				document.dispatchEvent( new CustomEvent( 'os-soft-reloaded' ) );
 			} catch ( _err ) {}

--- a/tests/phpunit/tests/openStationRender.php
+++ b/tests/phpunit/tests/openStationRender.php
@@ -397,6 +397,42 @@ class Tests_OpenStation_Render extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A soft reload swaps the CONTENTS of `#wpbody-content` and then
+	 * re-runs Core's list-table init entry points. Both halves are
+	 * load-bearing and both are invisible until a user clicks:
+	 * Core's inline editors delegate on `#the-list` /
+	 * `#the-comment-list`, inside the swapped subtree, so a
+	 * `replaceWith` of the container (or a missing re-init) leaves
+	 * Quick Edit and Bulk Edit rendering, focusable, and dead.
+	 *
+	 * @covers ::openstation_chromeless_bridge_script
+	 */
+	public function test_bridge_script_reinits_list_tables_after_soft_reload() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['openstation_chromeless'] = '1';
+
+		ob_start();
+		openstation_chromeless_bridge_script();
+		$output = ob_get_clean();
+
+		// The container node survives; only its children are swapped.
+		$this->assertStringContainsString( 'live.replaceChildren.apply', $output );
+		$this->assertStringNotContainsString( 'live.replaceWith', $output );
+
+		// …and the re-init runs before `os-soft-reloaded` listeners.
+		$this->assertStringContainsString( '_openstationReinitListTables();', $output );
+		$this->assertStringContainsString( 'window.inlineEditPost.init()', $output );
+		$this->assertStringContainsString( 'window.inlineEditTax.init()', $output );
+		$this->assertStringContainsString( 'window.setCommentsList()', $output );
+		$this->assertStringContainsString( 'window.commentReply.init()', $output );
+		$this->assertLessThan(
+			strpos( $output, "new CustomEvent( 'os-soft-reloaded' )" ),
+			strpos( $output, '_openstationReinitListTables();' ),
+			'Core re-init must run before the os-soft-reloaded listeners it exists to unblock.'
+		);
+	}
+
+	/**
 	 * Link interceptor must be inside the bridge script so stray clicks on
 	 * `<a href="/wp-admin/...">` don't kick the iframe out of chromeless mode.
 	 *

--- a/tests/phpunit/tests/openStationRender.php
+++ b/tests/phpunit/tests/openStationRender.php
@@ -423,8 +423,20 @@ class Tests_OpenStation_Render extends WP_UnitTestCase {
 		$this->assertStringContainsString( '_openstationReinitListTables();', $output );
 		$this->assertStringContainsString( 'window.inlineEditPost.init()', $output );
 		$this->assertStringContainsString( 'window.inlineEditTax.init()', $output );
-		$this->assertStringContainsString( 'window.setCommentsList()', $output );
 		$this->assertStringContainsString( 'window.commentReply.init()', $output );
+
+		/*
+		 * `setCommentsList()` must stay out. It re-runs `wpList`,
+		 * which binds on `document` — a node the swap does not
+		 * replace — so every call stacks another set of comment
+		 * row-action handlers and one Approve click fires N
+		 * moderation requests. Those handlers survive the swap on
+		 * their own and never needed re-running.
+		 *
+		 * Matched on the call form, not the bare name: the comment
+		 * above the re-init names it too, and should keep saying why.
+		 */
+		$this->assertStringNotContainsString( 'window.setCommentsList(', $output );
 		$this->assertLessThan(
 			strpos( $output, "new CustomEvent( 'os-soft-reloaded' )" ),
 			strpos( $output, '_openstationReinitListTables();' ),


### PR DESCRIPTION
Fixes #419

## Proposed changes

Quick Edit, Bulk Edit and the comment inline editors keep working in classic list windows after the list soft-reloads itself.

Three affordances stay degraded and are noted in the code: an empty bulk action submits instead of showing "Please select at least one item", the search box no longer clears a stale value on mousedown, and comment moderation keyboard shortcuts stop navigating.

## Why are these changes being made?

The soft reload added in #388 replaced the whole list body. Core's inline editors bind inside it, so the swap left them dead: the buttons still render and take focus, and clicking does nothing.

It only starts after the first content-change broadcast, so a freshly opened window works and then quietly stops. Any change on the site triggers it, including ones made by another user or a background process, which is why it reads as "Quick Edit doesn't work" rather than "Quick Edit broke after I did X".

## Testing instructions

Native Posts and Pages windows must stay off (the default) so these windows render as classic iframes: OpenStation Settings > Features.

Pages:

1. Open the Pages window, hover a row, click **Quick Edit**. It opens.
2. Force a refresh from the browser console: `wp.os.broadcast( 'os.page.changed', { source: 'test', action: 'updated', ids: [ 2 ] } )`. The list updates in place, no spinner.
3. Click **Quick Edit** again. Make sure it opens. On trunk the button takes focus and nothing appears.
4. Repeat step 2 a few more times. Make sure Quick Edit keeps working and only one editor row opens each time.

Posts, for Bulk Edit:

1. Tick a row, choose **Edit** in Bulk actions, click **Apply**. The bulk editor opens.
2. Broadcast `os.post.changed` as above, then repeat. Make sure it still opens, with exactly one Categories column and one Tags field.

Comments (switch the native Comments window off in OpenStation Settings > Features to get the classic screen):

1. Broadcast `os.comment.changed` three or four times.
2. Hover a comment row. Make sure **Quick Edit** and **Reply** open the inline editor.
3. With the Network tab open, click **Approve**. Make sure it sends exactly one `dim-comment` request and the comment stays approved, not one request per broadcast.

Narrow windows:

1. Resize the Pages window until the list collapses to its mobile layout.
2. Broadcast, then click the **Show more details** toggle on a row. Make sure it expands, once.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-502-9baf3591fffe333d44c35e936274739de04a1190.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->