### PR TITLE
Admin bar: stop the snap-checkbox poll from running forever

### DIFF
--- a/assets/js/admin-bar.js
+++ b/assets/js/admin-bar.js
@@ -84,10 +84,26 @@
 	// then mirror the persisted snap preference. Polled rather than
 	// hooked because the inline script ships with the admin bar
 	// (loads early) and the shell's WindowManager arrives later.
+	//
+	// Bounded, because a poll with no exit is a timer that runs for
+	// the life of the page. The manager lands within a frame or two of
+	// the shell bundle executing; if it has not arrived in ten seconds
+	// it is not coming — the shell failed to boot, or a plugin
+	// surfaced this admin bar somewhere the shell never loads — and
+	// repainting one checkbox does not justify waking the event loop
+	// sixteen times a second until the tab closes. Giving up leaves
+	// the server-rendered box exactly as it is, which is what polling
+	// forever achieves anyway.
+	var SNAP_POLL_INTERVAL_MS = 60;
+	var SNAP_POLL_TIMEOUT_MS = 10000;
+	var snapPollWaited = 0;
 	function initFromManager() {
 		var wm = getManager();
 		if ( ! wm || typeof wm.isSnapEnabled !== 'function' ) {
-			window.setTimeout( initFromManager, 60 );
+			snapPollWaited += SNAP_POLL_INTERVAL_MS;
+			if ( snapPollWaited < SNAP_POLL_TIMEOUT_MS ) {
+				window.setTimeout( initFromManager, SNAP_POLL_INTERVAL_MS );
+			}
 			return;
 		}
 		paintSnapCheckbox( wm.isSnapEnabled() );

--- a/tests/vitest/admin-bar-fullscreen-label.test.ts
+++ b/tests/vitest/admin-bar-fullscreen-label.test.ts
@@ -19,8 +19,17 @@
  * server as a `<script>`, and it's one of the two hand-written files
  * under `assets/js/`), so we mount the admin-bar markup the server
  * renders and evaluate the real shipped source against it.
+ *
+ * Evaluating it means we also inherit its side effects — notably the
+ * snap-checkbox poll, which re-arms every 60ms until `wp.os
+ * .windowManager` appears. A fixture without one left that poll
+ * running after the file finished, and the first tick past teardown
+ * dereferenced a `window` that no longer existed: an unhandled
+ * `ReferenceError` that vitest reports against the whole run. So the
+ * fixture publishes a manager, the way the shell does. That is both
+ * the honest fixture and the fix.
  */
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -43,6 +52,10 @@ const I18N = {
  * returns early without either, and the server renders all three
  * together whenever the shell is active. The Fullscreen button's only
  * label is the `title` on its `.ab-item`.
+ *
+ * The snap item is here for the same reason the manager stub is —
+ * the script paints it on startup, and a fixture that omits it is a
+ * page the script never actually runs against.
  */
 function mountAdminBar(): void {
 	document.body.innerHTML = `
@@ -58,11 +71,27 @@ function mountAdminBar(): void {
 				</li>
 				<li id="wp-admin-bar-desktop-layout-menu">
 					<a class="ab-item" href="#" title="Arrange windows"></a>
-					<div class="ab-sub-wrapper"><ul></ul></div>
+					<div class="ab-sub-wrapper"><ul>
+						<li id="wp-admin-bar-desktop-layout-snap" class="os-layout-snap">
+							<a class="ab-item" href="#"
+								>Snap to grid <span class="os-layout-checkbox">☐</span></a
+							>
+						</li>
+					</ul></div>
 				</li>
 			</ul>
 		</div>
 	`;
+}
+
+/**
+ * Publish the slice of `wp.os` the script polls for. Without this the
+ * poll never terminates — see the note at the top of the file.
+ */
+function publishManager( snapEnabled: boolean ): void {
+	( window as unknown as Record< string, unknown > ).wp = {
+		os: { windowManager: { isSnapEnabled: () => snapEnabled } },
+	};
 }
 
 function fsLink(): HTMLAnchorElement {
@@ -94,6 +123,7 @@ describe( 'admin-bar Fullscreen button label', () => {
 	beforeEach( () => {
 		( window as unknown as Record< string, unknown > )
 			.openStationAdminBar = { i18n: I18N };
+		publishManager( false );
 		mountAdminBar();
 	} );
 
@@ -102,6 +132,7 @@ describe( 'admin-bar Fullscreen button label', () => {
 		document.body.className = '';
 		delete ( window as unknown as Record< string, unknown > )
 			.openStationAdminBar;
+		delete ( window as unknown as Record< string, unknown > ).wp;
 	} );
 
 	test( 'wiring moves the server title onto the tooltip + aria-label', () => {
@@ -154,5 +185,71 @@ describe( 'admin-bar Fullscreen button label', () => {
 		);
 		expect( link.getAttribute( 'aria-label' ) ).toBe( 'Enter fullscreen' );
 		expect( link.hasAttribute( 'title' ) ).toBe( false );
+	} );
+} );
+
+/**
+ * The snap-checkbox poll waits for the shell to publish
+ * `wp.os.windowManager`. It has to give up: on a page where the shell
+ * never boots, an unbounded poll is a 60ms timer that outlives
+ * everything, and in this suite it outlived the jsdom environment and
+ * threw `ReferenceError: window is not defined` from a torn-down
+ * global.
+ */
+describe( 'admin-bar snap-checkbox poll', () => {
+	beforeEach( () => {
+		( window as unknown as Record< string, unknown > )
+			.openStationAdminBar = { i18n: I18N };
+		mountAdminBar();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+		document.body.innerHTML = '';
+		delete ( window as unknown as Record< string, unknown > )
+			.openStationAdminBar;
+		delete ( window as unknown as Record< string, unknown > ).wp;
+	} );
+
+	function checkbox(): HTMLElement {
+		return document.querySelector(
+			'#wp-admin-bar-desktop-layout-snap .os-layout-checkbox'
+		) as HTMLElement;
+	}
+
+	test( 'paints the persisted preference once the manager appears', () => {
+		vi.useFakeTimers();
+		runAdminBarScript();
+
+		// Nothing to read yet, so the box keeps its server-rendered
+		// state and the poll re-arms.
+		expect( checkbox().textContent ).toBe( '☐' );
+		expect( vi.getTimerCount() ).toBe( 1 );
+
+		publishManager( true );
+		vi.advanceTimersByTime( 60 );
+
+		expect( checkbox().textContent ).toBe( '☑' );
+		expect(
+			document
+				.getElementById( 'wp-admin-bar-desktop-layout-snap' )
+				?.getAttribute( 'aria-checked' )
+		).toBe( 'true' );
+		// Resolved — nothing left waking the event loop.
+		expect( vi.getTimerCount() ).toBe( 0 );
+	} );
+
+	test( 'gives up when the shell never publishes a manager', () => {
+		vi.useFakeTimers();
+		runAdminBarScript();
+
+		expect( vi.getTimerCount() ).toBe( 1 );
+		// Well past the ten-second bound.
+		vi.advanceTimersByTime( 30000 );
+
+		expect( vi.getTimerCount() ).toBe( 0 );
+		// Never painted — which is exactly what polling forever would
+		// have achieved, minus the timer.
+		expect( checkbox().textContent ).toBe( '☐' );
 	} );
 } );


### PR DESCRIPTION
Fixes the CI failure seen on #503 (and reachable from any branch — it is latent on trunk, not caused by that PR).

## The unhandled error

```
⎯⎯⎯ Uncaught Exception ⎯⎯⎯
ReferenceError: window is not defined
 ❯ getManager tests/vitest/admin-bar-fullscreen-label.test.ts:90:2
 ❯ Timeout.initFromManager [as _onTimeout]
 ❯ listOnTimeout node:internal/timers:605:17
```

Vitest reports this against the **whole run** — "this might cause false positive tests" — so it fails CI regardless of which suite was actually running.

## Why

`assets/js/admin-bar.js` polls for the shell's window manager so it can mirror the persisted snap-to-grid preference onto the layout menu's checkbox:

```js
function initFromManager() {
    var wm = getManager();
    if ( ! wm || typeof wm.isSnapEnabled !== 'function' ) {
        window.setTimeout( initFromManager, 60 );   // ← no exit
        return;
    }
    paintSnapCheckbox( wm.isSnapEnabled() );
}
```

**No exit condition.** On any page where the manager never arrives — the shell failed to boot, or a plugin surfaced this admin bar somewhere the shell does not load — that wakes the event loop ~16×/second for the life of the tab, to paint a checkbox that is never going to change.

The fullscreen-label suite evaluates the shipped IIFE to test it (it has no exports), and its fixture published no manager. So each of its four tests left a poll running past the end of the file, and the first tick after vitest tore down jsdom dereferenced a `window` that no longer existed. It only fires when teardown lands before the next 60ms tick — which is why it passes locally on a fast machine and fails in CI.

## The fix

**Product:** bound the poll at ten seconds. The manager lands within a frame or two of the shell bundle executing, so nothing real waits that long; giving up leaves the server-rendered checkbox exactly as it was, which is what polling forever achieved anyway.

**Fixture:** publish a manager the way the shell does. That terminates the poll on its first call — no timer is ever scheduled — and is the more faithful fixture besides. It also now renders the snap menu item the script paints on startup, which the fixture had been omitting entirely.

## Tests

Two new ones, in a suite for the poll itself:

- paints the persisted preference once the manager appears, and leaves **zero** timers behind (`vi.getTimerCount()`)
- stops re-arming past the bound

The second one **fails against the unpatched source** — verified by stashing the `admin-bar.js` change:

```
× gives up when the shell never publishes a manager
  Tests  1 failed | 5 passed (6)
```

`npm run lint` / `typecheck` / `test:js` (3952) / `build` all green.

## Note

`assets/js/admin-bar.js` is one of the two hand-written files under `assets/js/` (re-included in `.gitignore`), so it is edited directly rather than built from `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-504-9766da4b72304dc03c268316f44f6beae960450d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->