### PR TITLE
Recent Comments: render decoded commenter names

### DIFF
--- a/src/plugins/recent-comments-widget/index.ts
+++ b/src/plugins/recent-comments-widget/index.ts
@@ -112,10 +112,11 @@ function render( container: HTMLElement, comments: CommentRow[] | null, error: b
 	for ( const c of comments ) {
 		const row = document.createElement( 'div' );
 		row.className = 'dm-comments__row';
+		const authorName = decodeHTML( c.author_name || '' );
 
 		const avatar = document.createElement( 'div' );
 		avatar.className = 'dm-comments__avatar';
-		avatar.textContent = ( c.author_name || '?' ).trim().charAt( 0 ).toUpperCase();
+		avatar.textContent = ( authorName || '?' ).trim().charAt( 0 ).toUpperCase();
 
 		const body = document.createElement( 'div' );
 		body.className = 'dm-comments__body';
@@ -125,7 +126,7 @@ function render( container: HTMLElement, comments: CommentRow[] | null, error: b
 
 		const author = document.createElement( 'span' );
 		author.className = 'dm-comments__author';
-		author.textContent = c.author_name || 'Anonymous';
+		author.textContent = authorName || 'Anonymous';
 
 		const sm = STATUS_META[ c.status ] ?? STATUS_META.hold;
 		const statusEl = document.createElement( 'span' );

--- a/tests/vitest/recent-comments-widget.test.ts
+++ b/tests/vitest/recent-comments-widget.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { WidgetContext } from '../../src/widgets/types';
+
+import '../../src/plugins/recent-comments-widget/index';
+
+type MountFn = (
+	container: HTMLElement,
+	ctx: WidgetContext,
+) => Promise< () => void >;
+
+const WIDGET_ID = 'desktop-mode/recent-comments';
+
+function getMount(): MountFn {
+	const widgets = (
+		window as unknown as {
+			openStationWidgets?: Record< string, MountFn >;
+		}
+	).openStationWidgets;
+	const mount = widgets?.[ WIDGET_ID ];
+	if ( ! mount ) {
+		throw new Error( 'recent comments widget did not register its mount' );
+	}
+	return mount;
+}
+
+function makeContext(): WidgetContext {
+	return {
+		id: WIDGET_ID,
+		pluginUrl: 'https://example.test/plugin',
+	} as unknown as WidgetContext;
+}
+
+describe( 'recent comments widget', () => {
+	let container: HTMLElement;
+	let teardown: ( () => void ) | null = null;
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		const fetch = vi.fn( async () => ( {
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve( [
+				{
+					id: 1,
+					status: 'approved',
+					author_name: '&#81;&amp;A Guest',
+					date_gmt: '2026-08-05T12:00:00',
+					post: 42,
+				},
+			] ),
+		} ) as Response );
+		( window as unknown as { wp: unknown } ).wp = { os: { fetch } };
+	} );
+
+	afterEach( () => {
+		teardown?.();
+		teardown = null;
+		container.remove();
+		delete ( window as unknown as { wp?: unknown } ).wp;
+		vi.restoreAllMocks();
+	} );
+
+	test( 'decodes commenter names before rendering text and initials', async () => {
+		teardown = await getMount()( container, makeContext() );
+
+		expect(
+			container.querySelector( '.dm-comments__author' )?.textContent,
+		).toBe( 'Q&A Guest' );
+		expect(
+			container.querySelector( '.dm-comments__avatar' )?.textContent,
+		).toBe( 'Q' );
+	} );
+} );


### PR DESCRIPTION
Fixes #496.

## The bug

The WordPress REST API can return HTML-encoded comment author names. The Recent Comments widget assigned that raw value to `textContent`, so a name such as `Q&amp;A Guest` appeared with the entity still visible.

The avatar initial was derived from the same raw value, which could also select the first character of an entity instead of the commenter's initial.

## The fix

Decode each author name once with the existing `decodeHTML()` utility, then use that value for both the visible name and the avatar initial. The decoded value is still assigned through `textContent`, so it cannot be interpreted as markup.

## Tests

A new widget test mounts the real Recent Comments bundle, returns an encoded author name from the REST stub, and checks both rendered outputs:

- visible name: `Q&A Guest`
- avatar initial: `Q`

`npm run build`, `npm run lint`, `npm run test:js` (3,962 tests), and `npm run typecheck` are all green.

## To verify

1. Add or quick-edit a comment whose author name is `Q&A Guest`.
2. Open OpenStation and add the Recent Comments widget.
3. Confirm the widget shows `Q&A Guest`, not `Q&amp;A Guest`, and the avatar shows `Q`.