### PR TITLE
Use the theme outline token for dock status indicators

### DIFF
--- a/assets/css/dock.css
+++ b/assets/css/dock.css
@@ -633,7 +633,7 @@
 	width: 4px;
 	height: 4px;
 	border-radius: 50%;
-	background: var( --os-ui-surface, #fff );
+	background: var( --os-dock-item-outline, #fff );
 }
 
 .os-dock[ data-os-dock-placement="left" ]
@@ -659,7 +659,7 @@
 	height: 6px;
 	border-radius: 50%;
 	background: transparent;
-	border: 1px solid rgba( 255, 255, 255, 0.85 );
+	border: 1px solid var( --os-dock-item-outline, rgba( 255, 255, 255, 0.85 ) );
 }
 
 /* Right dock: indicator on the opposite edge (inside-facing). */
@@ -673,7 +673,7 @@
 	width: 4px;
 	height: 4px;
 	border-radius: 50%;
-	background: var( --os-ui-surface, #fff );
+	background: var( --os-dock-item-outline, #fff );
 }
 
 .os-dock[ data-os-dock-placement="right" ]
@@ -689,7 +689,7 @@
 	height: 6px;
 	border-radius: 50%;
 	background: transparent;
-	border: 1px solid rgba( 255, 255, 255, 0.85 );
+	border: 1px solid var( --os-dock-item-outline, rgba( 255, 255, 255, 0.85 ) );
 }
 
 /* "Open another" chip — left: right of tile; right: left of tile. */
@@ -908,7 +908,7 @@
 	width: 4px;
 	height: 4px;
 	border-radius: 50%;
-	background: var( --os-ui-surface, #fff );
+	background: var( --os-dock-item-outline, #fff );
 }
 
 .os-dock[ data-os-dock-placement="bottom" ]
@@ -929,7 +929,7 @@
 	height: 6px;
 	border-radius: 50%;
 	background: transparent;
-	border: 1px solid rgba( 255, 255, 255, 0.85 );
+	border: 1px solid var( --os-dock-item-outline, rgba( 255, 255, 255, 0.85 ) );
 }
 
 /*

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -630,7 +630,7 @@ sits *on* it:
 | `--os-dock-icon-color` | The glyph at rest |
 | `--os-dock-icon-color-hover` | The glyph on hover / peek |
 | `--os-dock-item-bg-hover` | The wash behind a hovered tile |
-| `--os-dock-item-outline` | The keyboard focus ring |
+| `--os-dock-item-outline` | The keyboard focus ring and the tile status indicator (active dot, all-minimized ring) |
 
 ```json
 "tokens": {
@@ -644,10 +644,13 @@ sits *on* it:
 
 **Set them whenever your dock is pale.** The four literals behind
 these tokens are all white — a glyph at 70%, brightening to full on
-hover, over a 15% white wash, with a 70% white focus ring. That reads
-against the default translucent-black strip and disappears the moment
-you give the dock a light background. Recolouring the strip alone is
-the most common way a first theme ends up with an invisible dock.
+hover, over a 15% white wash, with a 70% white focus ring, which also
+paints the status marks on the tile: the solid dot under the running
+or focused tile and the hollow ring under one whose windows are all
+minimized. That reads against the default translucent-black strip and
+disappears the moment you give the dock a light background.
+Recolouring the strip alone is the most common way a first theme ends
+up with an invisible dock.
 
 `--os-dock-icon-color` is a **colour**, not a fill, which
 matters if your iconset uses

--- a/tests/vitest/dock-and-titlebar-glyph-tokens.test.ts
+++ b/tests/vitest/dock-and-titlebar-glyph-tokens.test.ts
@@ -115,6 +115,29 @@ describe( 'dock glyph tokens', () => {
 		);
 	} );
 
+	test( 'the active-tile indicator family reads --os-dock-item-outline on all three placements', () => {
+		// The status dot / pill under the running and focused tile,
+		// plus the hollow ring under a tile whose windows are all
+		// minimized, were painted from `--os-ui-surface` and a
+		// hardcoded white — the dot resolved to the dock's own dark
+		// glass once the brand palette declared it, and the ring
+		// stayed unreachable by themes. Both now share the
+		// focus-ring token, so the accent paints them on the station
+		// and a theme's ring colour paints them everywhere else.
+		const css = readCss( 'dock.css' );
+
+		expect(
+			css.match(
+				/background: var\( --os-dock-item-outline, #fff \);/g
+			)
+		).toHaveLength( 3 );
+		expect(
+			css.match(
+				/border: 1px solid var\( --os-dock-item-outline, rgba\( 255, 255, 255, 0\.85 \) \);/g
+			)
+		).toHaveLength( 3 );
+	} );
+
 	test( 'system tiles follow the same token, keeping their brighter literal', () => {
 		const body = ruleBody(
 			readCss( 'dock.css' ),


### PR DESCRIPTION
This PR fixes the near-invisible dock active-window indicator.

The active status dot (and the all-minimized hollow ring) were previously painted from `--os-ui-surface`, which resolves to the dock's own dark glass tone on the default Station palette rather than the theme's intended indicator color. As a result, the active indicator had almost no visual contrast.

Both indicators now read `--os-dock-item-outline`:

* **OpenStation** uses Pulse (`#f252fc`).
* **Custom themes** use the theme's configured outline/ring color.
* **Legacy** continues to render white via its frozen manifest and remains unchanged.

Each indicator also retains its original literal fallback, ensuring an unthemed or stylesheet-free shell renders exactly as before.

A regression test now pins both the active dot and minimized ring (across all three dock placements) to the theme token.

Closes #508 

## Why?

### Accessibility

* Restores the intended state hierarchy. The active ("currently in use") indicator had become the weakest visual signal on the dock (~1.06:1 against the dock glass, failing WCAG 2.1 SC 1.4.11 Non-text Contrast), while the minimized ring was more prominent.
* The active indicator is once again the strongest state marker.

### Consistency

* Aligns dock indicators with the rest of the shell.
* Focus rings, hover washes, and dock status indicators now all communicate state using the same accent/outline token, reinforcing a consistent visual language.

### Themeability

* Removes hardcoded styling.
* Pale or custom dock themes no longer end up with invisible status indicators.
* Both indicators now follow a single themeable token for the dock surface.

---

## What's Changed?

### CSS

**`assets/css/dock.css`**

* Active/focused status dot (left, right, and bottom docks) now uses:

  ```css
  var(--os-dock-item-outline, #fff)
  ```
* All-minimized hollow ring (left, right, and bottom docks) now uses:

  ```css
  var(--os-dock-item-outline, rgba(255,255,255,0.85))
  ```

### Tests

**`tests/vitest/dock-and-titlebar-glyph-tokens.test.ts`**

* Adds regression coverage ensuring:

  * the active/focused dot reads `--os-dock-item-outline` with the exact `#fff` fallback.
  * the all-minimized ring reads `--os-dock-item-outline` with the exact `rgba(255,255,255,0.85)` fallback.
  * all three dock placements are covered.

### Documentation

**`docs/desktop-themes.md`**

* Documents the dock status indicators in the dock glyph token table.
* Adds guidance for pale/custom dock themes.