### PR TITLE
Corkboard: disc nodes by default, pins one row away

### DIFF
--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -25,7 +25,7 @@ The full surface is documented in [`javascript-reference.md`](./javascript-refer
 | `HOOKS` | `typeof HOOKS` *(typed hook-name constants)* | Stable |
 | `hooks` | `wp.hooks` bridge | Stable |
 | `saveSession` | `() => void` | Stable |
-| `registerWindowAction` / `unregisterWindowAction` / `listWindowActions` | `( def: WindowActionDef ) => void` *(rows in every window's ⋯ menu; `label`/`icon`/`isVisible` may be per-window functions)* | Experimental |
+| `registerWindowAction` / `unregisterWindowAction` / `listWindowActions` | `( def: WindowActionDef ) => void` *(rows in every window's ⋯ menu, as verbs or checkboxes; `label`/`icon`/`isVisible`/`checked` may be per-window functions)* | Experimental |
 | [`electron`](./desktop-host.md) | `ElectronAdapterApi` *(set a window free into a real OS window; published by the Electron Adapter extension, absent in a browser)* | Experimental |
 
 ### HTTP & UI primitives — must-know

--- a/docs/examples/window-action.md
+++ b/docs/examples/window-action.md
@@ -71,6 +71,46 @@ wp.os.registerWindowAction( {
 whatever it depends on — a capability, a connection, the page the window
 has navigated to — without your plugin re-registering anything.
 
+## A checkbox row for a per-window preference
+
+A verb runs and the menu closes. A **checkbox** reports a setting the
+window either has or does not, and stays open when clicked so the user
+watches the tick land:
+
+```js
+const KEY = 'my-plugin/show-gridlines';
+
+wp.os.registerWindowAction( {
+    id: 'my-plugin/show-gridlines',
+    label: 'Show gridlines',
+    checkable: true,
+    checked: () => localStorage.getItem( KEY ) === '1',
+    isVisible: ( win ) => win.id === 'my-plugin-canvas',
+    onSelect: () => {
+        const next = localStorage.getItem( KEY ) === '1' ? '0' : '1';
+        localStorage.setItem( KEY, next );
+        repaintCanvas();
+    },
+    owner: 'my-plugin-shell',
+} );
+```
+
+`checked` is **asked, never told**. It runs on every menu open, so you
+persist the value and repaint nothing — and the row cannot disagree
+with your plugin for longer than one open, however the value changed
+(a second window, a settings panel, a REST response landing late).
+This is how the built-in Corkboard's "Show pins" works.
+
+`closeOnSelect` overrides the defaults in either direction: `false` on
+a verb keeps the menu up, `true` on a checkbox dismisses it after the
+flip.
+
+**Checkbox or relabelling verb?** Use the relabelling `label` above
+when the two states are two *places* the window can be — the row names
+the move. Use a checkbox when they are one setting: a tick says "there
+is a thing here, and it is currently off", which a label reading "Show
+gridlines" alone cannot.
+
 ## Ordering
 
 `order` sorts your row against other plugins' rows; the built-in items
@@ -82,16 +122,19 @@ order: 60,   // earlier than most
 
 ## What the framework guarantees
 
-- **The menu closes before `onSelect` runs**, so a handler that opens a
-  dialog or navigates is not competing with a still-painted popover.
+- **The menu closes before `onSelect` runs** for a verb row, so a
+  handler that opens a dialog or navigates is not competing with a
+  still-painted popover. A checkbox instead flips its tick
+  optimistically and leaves the menu open.
 - **A throwing resolver or handler is contained.** A row whose `label`
-  or `isVisible` throws simply does not appear; a handler that throws is
-  logged. The ⋯ menu is shared surface — one plugin's bug must not cost
-  the user their "Reload".
+  or `isVisible` throws simply does not appear; a `checked` that throws
+  paints unchecked rather than dropping the row; a handler that throws
+  is logged. The ⋯ menu is shared surface — one plugin's bug must not
+  cost the user their "Reload".
 - **Registration is validated loudly.** A bad `id`, a missing
-  `onSelect`, a non-function `isVisible` throws a `RegistrationError`
-  naming the field, at registration time, rather than silently painting
-  nothing.
+  `onSelect`, a non-function `isVisible`, or `checkable` without
+  `checked` throws a `RegistrationError` naming the field, at
+  registration time, rather than silently painting nothing.
 
 ## Deciding when the menu opens
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -3762,6 +3762,8 @@ An interactive PixiJS map of post links — every public post type participates 
 
 The window and icon are titled **Corkboard** — a thing you can have on a desk, rather than the name of the data structure behind it. The module directory, window id, REST routes, and every hook below keep the `content_graph` slug.
 
+Nodes are drawn as **discs coloured by post type**, using the same palette the relationship satellites use so a focused post and the bubbles fanned around it read as one system. The original **pin** look — the post type's Dashicon glyph as the node body — is one row away in the window's ⋯ menu ("Show pins"), and the choice persists in `localStorage` under `desktop-mode/corkboard-node-style`. Either way the focused node reveals its glyph, so focus never costs the user the type information. The row is an ordinary checkbox registered through the public [`registerWindowAction`](./javascript-reference.md#wposregisterwindowaction--experimental) surface — see [`examples/window-action.md`](./examples/window-action.md) to add your own.
+
 ### `openstation_content_graph_user_can_use` — Experimental (filter)
 
 ```php

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -7350,11 +7350,53 @@ wp.os.registerWindowAction( {
 | `icon` | `string \| ( win ) => string` | Dashicons class. Optional; also re-read per open. |
 | `order` | `number` | Sort order among registered rows. Default `100`. |
 | `isVisible` | `( win ) => boolean` | Optional. Re-read per open; omit to show everywhere. |
-| `onSelect` | `( win ) => void` | Required. The menu is closed before it is called. |
+| `checkable` | `boolean` | Paint the row as a checkbox instead of a verb. Requires `checked`. |
+| `checked` | `( win ) => boolean` | Required with `checkable`. Re-read per open. |
+| `closeOnSelect` | `boolean` | Whether selecting closes the menu. Defaults to `true` for a verb, `false` for a checkbox. |
+| `onSelect` | `( win ) => void` | Required. For a verb the menu is closed before it is called; for a checkbox the tick flips first and the menu stays open. |
 | `owner` | `string` | Script handle, for live unregistration on deactivation. See below. |
 
 Also: `wp.os.unregisterWindowAction( id )` and
 `wp.os.listWindowActions()`.
+
+**Checkbox rows.** Set `checkable` with a `checked` reader and the row
+reports a preference instead of running a verb:
+
+```js
+wp.os.registerWindowAction( {
+    id: 'my-plugin/show-pins',
+    label: 'Show pins',
+    checkable: true,
+    checked: () => localStorage.getItem( 'my-plugin/pins' ) === '1',
+    isVisible: ( win ) => win.id === 'my-plugin-board',
+    onSelect: () => {
+        const next = localStorage.getItem( 'my-plugin/pins' ) === '1' ? '0' : '1';
+        localStorage.setItem( 'my-plugin/pins', next );
+        repaint();
+    },
+} );
+```
+
+`checked` is asked on every open, never told — so persist the value
+and repaint nothing; the row cannot go stale for longer than one open,
+however the value changed (another window, a settings panel, a REST
+response landing late). The shell flips the tick optimistically on
+click and leaves the menu open, so the user sees it land and can flip
+it back without reopening. A `checked` that throws paints the row
+unchecked rather than dropping it: losing the indicator is recoverable,
+losing the row is not.
+
+Registering `checkable` without `checked` throws — a checkbox nobody
+can ask renders permanently unticked, which reads as broken
+persistence in your plugin rather than a missing field here.
+
+**Checkbox or relabelling verb?** Both express a two-state thing, and
+they are not interchangeable. Use a relabelling `label` function when
+the two states are two *places* the window can be ("Send to your Mac"
+/ "Bring back into OpenStation") — the row names the move. Use a
+checkbox when they are one setting the window either has or does not:
+a tick says "there is a thing here, and it is currently off", which a
+label reading "Show pins" alone cannot.
 
 **Making `owner` mean something.** Pair it with the PHP opt-in
 [`openstation_register_window_action_script( 'my-plugin-shell' )`](./hooks-reference.md#openstation_register_window_action_script-handle--experimental-php-function)
@@ -7368,7 +7410,7 @@ inert: the row stays until the next page reload. That is deliberate
 backwards-compat, the same bargain commands and title-bar buttons
 offer, but it does mean `owner` alone is not the whole opt-in.
 
-**Why `label` / `icon` / `isVisible` may be functions.** They are read
+**Why `label` / `icon` / `isVisible` / `checked` may be functions.** They are read
 fresh every time the menu opens, not once at registration. That is what
 lets one row express a toggle whose meaning depends on state — "Send to
 your Mac" becoming "Bring back into OpenStation" for the same window —

--- a/src/content-graph/index.ts
+++ b/src/content-graph/index.ts
@@ -16,10 +16,11 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { registerWindowAction } from '../window-actions/registry';
 import { fetchGraph, fetchPostDetail, fetchPostTypes, getConfig } from './rest';
 import { renderToolbar } from './toolbar';
 import { renderPanel } from './panel';
-import { GraphScene } from './scene';
+import { GraphScene, type NodeStyle } from './scene';
 import type { SatelliteRef } from './satellites';
 import type { DesktopApiLike } from './pixi-types';
 import type { GraphNode, GroupFacet } from './types';
@@ -39,6 +40,74 @@ declare global {
 }
 
 const WINDOW_ID = 'desktop-mode-content-graph';
+
+/**
+ * Web-storage key for the node-body preference. Frozen `desktop-mode`
+ * prefix — see AGENTS.md ("`desktop_mode_*` values are frozen").
+ */
+const NODE_STYLE_KEY = 'desktop-mode/corkboard-node-style';
+
+/**
+ * Every live Corkboard scene. The ⋯ menu row is registered once at
+ * module load — not per render — because the row's identity is "the
+ * Corkboard's node style", not "this particular mount's node style".
+ * Registering per render would replace the entry (same id) on every
+ * reopen and leave the toggle reaching for a scene that had already
+ * been destroyed.
+ */
+const liveScenes = new Set< GraphScene >();
+
+/** Session + across-session node-body preference. */
+let nodeStyle: NodeStyle = readNodeStyle();
+
+function readNodeStyle(): NodeStyle {
+	try {
+		return window.localStorage.getItem( NODE_STYLE_KEY ) === 'icon'
+			? 'icon'
+			: 'disc';
+	} catch {
+		// Private-mode / blocked storage — fall back to the default.
+		return 'disc';
+	}
+}
+
+function writeNodeStyle( style: NodeStyle ): void {
+	try {
+		window.localStorage.setItem( NODE_STYLE_KEY, style );
+	} catch {
+		// Non-fatal: the preference just doesn't survive the session.
+	}
+}
+
+/**
+ * "Show pins" in the Corkboard's ⋯ menu — the way back to the
+ * dashicon-glyph nodes the window shipped with. Registered at module
+ * load, which happens the first time the window opens (the bundle is
+ * lazy-loaded by the native-window sync); the menu repaints its plugin
+ * rows on every open, and while open on every registry change, so the
+ * row lands in the menu of the window that just loaded this bundle.
+ *
+ * Registered once for the window kind rather than per mount: the
+ * preference belongs to "the Corkboard", not to one instance of it.
+ * Re-registering per render would replace the entry (same id) on every
+ * reopen and leave `checked` closing over a scene already destroyed.
+ */
+registerWindowAction( {
+	id: 'desktop-mode/corkboard-pins',
+	label: __( 'Show pins' ),
+	checkable: true,
+	checked: () => nodeStyle === 'icon',
+	isVisible: ( win ) =>
+		( ( win.config as { baseId?: string } ).baseId ?? win.id ) ===
+		WINDOW_ID,
+	onSelect: () => {
+		nodeStyle = nodeStyle === 'icon' ? 'disc' : 'icon';
+		writeNodeStyle( nodeStyle );
+		for ( const scene of liveScenes ) {
+			scene.setNodeStyle( nodeStyle );
+		}
+	},
+} );
 
 interface ActiveState {
 	abort: () => void;
@@ -230,7 +299,9 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 		},
 		handleSatelliteClick,
 		cfg.postTypes,
+		nodeStyle,
 	);
+	liveScenes.add( scene );
 
 	try {
 		await scene.mount( desktopApi );
@@ -238,6 +309,7 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 		stageHost.textContent = __( 'Could not initialise the graph renderer.' );
 		// eslint-disable-next-line no-console
 		console.warn( '[content-graph] scene mount failed', err );
+		liveScenes.delete( scene );
 		return { abort: () => {} };
 	}
 
@@ -261,7 +333,10 @@ async function renderContentGraph( body: HTMLElement ): Promise< ActiveState > {
 			aborted = true;
 			toolbar.destroy();
 			panel.destroy();
-			scene?.destroy();
+			if ( scene ) {
+				liveScenes.delete( scene );
+				scene.destroy();
+			}
 			scene = null;
 		},
 	};

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -5,8 +5,10 @@
  * transform), and the four child layers:
  *
  *   1. `edgeLayer`      — line per `GraphEdge` (very thin, low alpha).
- *   2. `nodeLayer`      — small `Graphics` halo + dashicon glyph per
- *      `GraphNode`. The glyph IS the node, sized by degree.
+ *   2. `nodeLayer`      — per `GraphNode`: a `Graphics` halo, a
+ *      `Graphics` disc, and a dashicon glyph, sized by degree. Which
+ *      of the last two is the visible body depends on the node style
+ *      (see {@link NodeStyle}); the halo is state-only.
  *   3. `labelLayer`     — text label per node, culled when zoomed out.
  *   4. `satelliteLayer` — `SatelliteLayer` instance fanning out
  *      relationship satellites around the focused node (see
@@ -19,10 +21,13 @@
  * toward the targets each frame so zoom and recenter feel continuous
  * rather than stepped.
  *
- * Visual policy: dashicon glyph nodes (matching WP admin), dot-grid
- * background (CSS), Obsidian-style sparse mid-zoom layout. Focused
- * node + 1-hop neighbourhood pop in blue; the focused node is
- * *pinned* during focus so it doesn't drift around under the camera.
+ * Visual policy: disc nodes coloured by post type (the same palette
+ * the satellite bubbles use, so a focused post and its relationships
+ * read as one system), dot-grid background (CSS), Obsidian-style
+ * sparse mid-zoom layout. Dashicon-glyph nodes remain available via
+ * `setNodeStyle( 'icon' )`. Focused node + 1-hop neighbourhood pop;
+ * the focused node is *pinned* during focus so it doesn't drift
+ * around under the camera.
  *
  * Interactions:
  *   - **Wheel** smoothly zooms with the cursor as the focal point.
@@ -67,6 +72,60 @@ const NODE_FILL_FOCUS = 0x2c6be5;
 const NODE_FILL_NEIGHBOUR = 0x4f8bf3;
 const EDGE_BASE = 0x9aa6b6;
 const EDGE_HOT = 0x2c6be5;
+
+/**
+ * Node body colours, assigned to post types in the order the window
+ * config lists them (so `post` — always first — is stable at the
+ * leading blue, and a site's CPTs get consistent colours across
+ * sessions without anyone having to configure anything).
+ *
+ * Deliberately the same five hues the satellite bubbles use in
+ * `satellites.ts`, extended by two, so a focused post and the
+ * relationship bubbles fanned around it read as one palette rather
+ * than two systems sharing a canvas. Wraps by modulo past the end —
+ * a site with eight public post types repeats a colour rather than
+ * inventing an unvetted one.
+ */
+const TYPE_PALETTE = [
+	0x3a6df0, // blue
+	0x2ca97a, // green
+	0xe8893a, // orange
+	0xa05ed4, // purple
+	0x2fa5b8, // teal
+	0xd4508f, // pink
+	0x6b7785, // slate
+];
+
+/**
+ * Ring drawn around every disc node, matching the satellite discs'
+ * white keyline. It is what keeps two overlapping nodes readable as
+ * two nodes — without it a cluster at low zoom fuses into one blob.
+ */
+const DISC_RING = 0xffffff;
+
+/**
+ * How the node body is drawn.
+ *
+ *   - `'disc'`  — filled circle + keyline, coloured by post type. The
+ *     default: at overview zoom a canvas of discs reads as a
+ *     constellation, which is what the graph *is*.
+ *   - `'icon'`  — the post type's Dashicon glyph IS the node (the
+ *     original look). Kept because the glyph carries type identity at
+ *     a glance in a way colour alone can't for someone who can't
+ *     separate the hues, and because on a small graph the pushpin is
+ *     genuinely charming. Reachable from the window's ⋯ menu.
+ *
+ * The focused node reveals its glyph in either style — inside the
+ * disc for `'disc'`, at full size for `'icon'` — so focus never costs
+ * the user the type information.
+ */
+export type NodeStyle = 'disc' | 'icon';
+
+/**
+ * Focused discs scale up by this factor. Enough to read as "this
+ * one", small enough that the layout around it doesn't feel shoved.
+ */
+const FOCUS_DISC_SCALE = 1.3;
 
 /**
  * Per-dashicon visual-centre nudge applied on top of the
@@ -136,12 +195,25 @@ interface NodeView {
 	node: GraphNode;
 	container: PixiContainer;
 	halo: PixiGraphics;
+	disc: PixiGraphics;
 	icon: PixiText;
 	labelBox: PixiContainer;
 	labelBg: PixiGraphics;
 	label: PixiText;
 	iconCharCode: string | null;
 	iconName: string;
+	/** Post-type body colour — see {@link TYPE_PALETTE}. */
+	typeColor: number;
+	/**
+	 * Signature of the last disc paint. The per-frame loop repaints a
+	 * disc only when this changes, which in steady state means never:
+	 * a `Graphics` fill + stroke per node per frame is affordable for
+	 * a demo graph and is not for a real site's few hundred posts.
+	 * (The halo above gets away with an unconditional `clear()`
+	 * because it draws nothing at all for the ~all-but-two nodes that
+	 * are neither focused nor hovered.)
+	 */
+	discKey: string;
 }
 
 interface EdgeView {
@@ -263,22 +335,37 @@ export class GraphScene {
 	private onSatelliteClick: SatelliteOnClick;
 	private postTypeIcon: PostTypeIconLookup;
 	private postTypeBySlug: Map< string, PostTypeDescriptor >;
+	private postTypeColor = new Map< string, number >();
+	/** Active node body style. See {@link NodeStyle}. */
+	private nodeStyle: NodeStyle = 'disc';
 
 	constructor(
 		host: HTMLElement,
 		callbacks: SceneCallbacks,
 		onSatelliteClick: SatelliteOnClick,
 		postTypes: PostTypeDescriptor[],
+		nodeStyle: NodeStyle = 'disc',
 	) {
 		this.host = host;
 		this.callbacks = callbacks;
 		this.onSatelliteClick = onSatelliteClick;
+		this.nodeStyle = nodeStyle;
 		const map = new Map< string, string >();
 		this.postTypeBySlug = new Map();
 		for ( const t of postTypes ) {
 			map.set( t.slug, normalizeDashiconName( t.icon ) );
 			this.postTypeBySlug.set( t.slug, t );
 		}
+		// Colour by declaration order, wrapping past the palette's
+		// end. Assigned once here rather than at paint time so a
+		// type's colour can't shift when the filter chips change
+		// which types are on screen.
+		postTypes.forEach( ( t, i ) => {
+			this.postTypeColor.set(
+				t.slug,
+				TYPE_PALETTE[ i % TYPE_PALETTE.length ],
+			);
+		} );
 		// Always seeded so unknown CPTs without a registered menu_icon
 		// still pick up a sensible default.
 		this.postTypeIcon = ( slug ) =>
@@ -529,6 +616,12 @@ export class GraphScene {
 			const halo = new this.pixi.Graphics();
 			container.addChild( halo );
 
+			// Disc sits between the halo and the glyph: the halo is a
+			// soft wash *behind* the body, the glyph is revealed
+			// *inside* it on focus.
+			const disc = new this.pixi.Graphics();
+			container.addChild( disc );
+
 			const iconName = this.postTypeIcon( n.type );
 			const iconChar = resolveDashicon( iconName );
 			const icon = new this.pixi.Text( {
@@ -589,12 +682,17 @@ export class GraphScene {
 				node: n,
 				container,
 				halo,
+				disc,
 				icon,
 				labelBox,
 				labelBg,
 				label,
 				iconCharCode: iconChar,
 				iconName,
+				typeColor:
+					this.postTypeColor.get( n.type ) ?? TYPE_PALETTE[ 0 ],
+				// Empty so the first `draw()` always paints.
+				discKey: '',
 			} );
 		}
 	}
@@ -1235,8 +1333,9 @@ export class GraphScene {
 		// fully present; in between the alpha eases via smoothstep so
 		// pinch-zoom doesn't pop them in/out.
 		const zoomFade = smoothstep( 0.55, 0.95, this.world.scale.x );
+		const discs = this.nodeStyle === 'disc';
 		for ( const v of this.nodeViews.values() ) {
-			const { node, container, halo, icon, labelBox } = v;
+			const { node, container, halo, disc, icon, labelBox } = v;
 			const isFocus = node.id === focusId;
 			const isHover = node.id === hoverId;
 			const isNeighbour =
@@ -1248,23 +1347,58 @@ export class GraphScene {
 			container.y = node.y;
 			container.alpha = baseAlpha;
 
+			// In icon style the glyph itself carries the state colour
+			// (the original behaviour). In disc style the *body*
+			// carries post-type identity and only focus overrides it —
+			// a neighbour keeps its own colour and is distinguished by
+			// the un-dimmed alpha above, which is what makes a focused
+			// neighbourhood read as "these, in their own colours"
+			// rather than "these, repainted blue".
 			let fill = NODE_FILL;
 			if ( isFocus ) {
 				fill = NODE_FILL_FOCUS;
 			} else if ( isNeighbour ) {
 				fill = NODE_FILL_NEIGHBOUR;
 			}
+			const discFill = isFocus ? NODE_FILL_FOCUS : v.typeColor;
 
 			halo.clear();
 			if ( isFocus || isHover ) {
 				halo.circle( 0, 0, node.radius + 8 ).fill( {
-					color: fill,
+					color: discs ? discFill : fill,
 					alpha: 0.18,
 				} );
 			}
 
-			icon.style.fill = fill;
-			const fontSize = 2 * node.radius;
+			// Disc body — repainted only when its signature changes.
+			const discRadius = isFocus
+				? node.radius * FOCUS_DISC_SCALE
+				: node.radius;
+			const ringWidth = isFocus || isHover ? 2.5 : 1.5;
+			const discKey = discs
+				? `${ discFill }|${ discRadius }|${ ringWidth }`
+				: 'off';
+			if ( v.discKey !== discKey ) {
+				v.discKey = discKey;
+				disc.clear();
+				if ( discs ) {
+					disc.circle( 0, 0, discRadius )
+						.fill( { color: discFill, alpha: 0.95 } )
+						.stroke( {
+							color: DISC_RING,
+							width: ringWidth,
+							alpha: 1,
+						} );
+				}
+			}
+
+			// The glyph is the node in icon style; in disc style it is
+			// the reveal on the node the user is pointing at or has
+			// focused, drawn in the ring colour so it reads as cut out
+			// of the disc rather than stacked on top of it.
+			icon.visible = ! discs || isFocus || isHover;
+			icon.style.fill = discs ? DISC_RING : fill;
+			const fontSize = discs ? discRadius * 1.35 : 2 * node.radius;
 			icon.style.fontSize = fontSize;
 			// Nudge the glyph onto the visible disc centre. Without this
 			// the bbox-centred anchor leaves glyphs (notably `admin-post`
@@ -1275,7 +1409,12 @@ export class GraphScene {
 			icon.y = ( ( nudge?.y ?? ICON_NUDGE_Y_ASCENT ) ) * fontSize;
 
 			labelBox.x = node.x;
-			labelBox.y = node.y + node.radius + 4;
+			// Clear the body, whichever body that is: a focused disc
+			// has grown past `node.radius`, and in icon style the
+			// glyph's visible height is about the same as the disc's
+			// diameter, so the un-scaled radius is the right floor for
+			// both.
+			labelBox.y = node.y + ( discs ? discRadius : node.radius ) + 4;
 			labelBox.scale.set( inverseScale );
 			let baseLabelAlpha: number;
 			if ( isFocus ) {
@@ -1708,6 +1847,31 @@ export class GraphScene {
 
 	getNodes(): GraphNode[] {
 		return this.nodes;
+	}
+
+	/**
+	 * Switch how node bodies are drawn. Safe to call before `mount()`
+	 * — the style is stored and the first paint honours it.
+	 *
+	 * Invalidates every disc signature so the next frame repaints all
+	 * of them; nothing else needs to happen, since the tick loop is
+	 * already running and the glyphs' visibility is derived per frame.
+	 *
+	 * @param style Body style. See {@link NodeStyle}.
+	 */
+	setNodeStyle( style: NodeStyle ): void {
+		if ( this.nodeStyle === style ) {
+			return;
+		}
+		this.nodeStyle = style;
+		for ( const v of this.nodeViews.values() ) {
+			v.discKey = '';
+		}
+	}
+
+	/** Active node body style. */
+	getNodeStyle(): NodeStyle {
+		return this.nodeStyle;
 	}
 
 	/**

--- a/src/content-graph/scene.ts
+++ b/src/content-graph/scene.ts
@@ -74,6 +74,45 @@ const EDGE_BASE = 0x9aa6b6;
 const EDGE_HOT = 0x2c6be5;
 
 /**
+ * Supersample factor applied on top of the display's device-pixel
+ * ratio. `1` renders at native density (what the scene did before);
+ * `1.5` renders 2.25× the pixels and lets the browser resolve them
+ * down on composite.
+ *
+ * MSAA alone is not enough for this scene, and the discs are why.
+ * `antialias: true` gives the renderer multisampling on the default
+ * framebuffer, which cleans up a *large* shape's silhouette nicely —
+ * but a node is 8–16 world units across and wears a keyline 1.5 units
+ * wide, and the camera routinely sits at 0.5× in the overview. At
+ * that zoom the keyline is under a device pixel: MSAA has nothing to
+ * average and the ring breaks into a dotted shimmer, which is exactly
+ * the artefact the ring exists to prevent (it is what keeps two
+ * overlapping nodes reading as two nodes). Supersampling gives the
+ * subpixel ring real samples to be resolved from.
+ */
+const RENDER_SUPERSAMPLE = 1.5;
+
+/**
+ * Backing-store density for the canvas and for every `Text` in it.
+ *
+ * Clamped at 3 because the cost is quadratic in this number and the
+ * canvas is full-window: a 1400×800 stage is 10M pixels at 3 and 18M
+ * at 4, and past 3 nobody can see the difference on the one detail
+ * that motivated it.
+ *
+ * Read once at module load rather than per node — `Text` objects pin
+ * their raster at construction, and a glyph left at a lower density
+ * than the canvas around it is *upscaled*, which would make the
+ * focus/hover glyph reveal the softest thing on a screen that just
+ * got sharper everywhere else.
+ */
+const RENDER_RESOLUTION = Math.min(
+	( ( typeof window !== 'undefined' && window.devicePixelRatio ) || 1 ) *
+		RENDER_SUPERSAMPLE,
+	3,
+);
+
+/**
  * Node body colours, assigned to post types in the order the window
  * config lists them (so `post` — always first — is stable at the
  * leading blue, and a site's CPTs get consistent colours across
@@ -402,7 +441,11 @@ export class GraphScene {
 			backgroundAlpha: 0,
 			antialias: true,
 			autoDensity: true,
-			resolution: Math.min( window.devicePixelRatio || 1, 2 ),
+			// Above the display's own density on purpose — see
+			// `RENDER_SUPERSAMPLE`. `autoDensity` keeps the canvas at
+			// its CSS size, so the extra pixels are resolved down on
+			// composite rather than making the stage bigger.
+			resolution: RENDER_RESOLUTION,
 			// Dedicated ticker, NOT the shared one. Other openstation
 			// bundles (posts-window, recycle-bin, …) also load Pixi via
 			// `loadModules('pixijs')` — sharing `Ticker.shared` across
@@ -631,7 +674,7 @@ export class GraphScene {
 					fontSize: 2 * n.radius,
 					fill: NODE_FILL,
 				},
-				resolution: 2,
+				resolution: RENDER_RESOLUTION,
 				anchor: { x: 0.5, y: 0.5 },
 			} );
 			container.addChild( icon );
@@ -656,7 +699,7 @@ export class GraphScene {
 						'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
 					fontWeight: '500',
 				},
-				resolution: 2,
+				resolution: RENDER_RESOLUTION,
 				anchor: { x: 0.5, y: 0 },
 			} );
 			labelBox.addChild( label );

--- a/src/window-actions/registry.ts
+++ b/src/window-actions/registry.ts
@@ -23,6 +23,22 @@
  * item that answers "what does this do right now?" is the honest
  * shape for a toggle: a window is in one place or the other, never
  * both, so two competing items would misdescribe it.
+ *
+ * ## Two row shapes
+ *
+ * A **verb** row runs and closes the menu — "Send to your Mac",
+ * "Reload". A **checkbox** row (`checkable`, with a `checked`
+ * predicate) reports a persistent per-window preference and stays
+ * open when clicked, so the user sees the indicator flip where they
+ * are looking. `checked` is re-read on every open alongside `label`
+ * and `isVisible`, which is what lets a plugin persist a preference
+ * and repaint nothing: the row asks, it is never told.
+ *
+ * A relabelling verb and a checkbox are not interchangeable. Use the
+ * former when the two states are two *places* the window can be, and
+ * the latter when they are one setting the window either has or does
+ * not — a checkbox says "there is a thing here, and it is currently
+ * off", which a label reading "Show pins" alone cannot.
  */
 
 import { throwOnRegistrationErrors } from '../registration-errors';
@@ -61,9 +77,33 @@ export interface WindowActionDef {
 	 */
 	isVisible?: ( window: DesktopWindow ) => boolean;
 	/**
-	 * Handler. The shell closes the menu before calling it, so a
-	 * handler that opens a dialog or navigates does not have to
-	 * compete with a still-painted popover.
+	 * Paint this row as a checkbox rather than a verb. Requires
+	 * `checked`; the pair is what turns the row into a report of a
+	 * preference instead of a button.
+	 */
+	checkable?: boolean;
+	/**
+	 * Current check state, read on every menu open. Required when
+	 * `checkable` is set — a checkbox with no reader would be a row
+	 * that can be flipped but never asked, and would go stale the
+	 * moment anything but this menu changed the value.
+	 *
+	 * A throwing reader paints the row unchecked rather than dropping
+	 * it: losing the indicator is recoverable, losing the row is not.
+	 */
+	checked?: ( window: DesktopWindow ) => boolean;
+	/**
+	 * Whether selecting the row closes the menu. Defaults to `true`
+	 * for a verb and `false` for a checkbox, which is the behaviour
+	 * each shape wants; set it explicitly to override either.
+	 */
+	closeOnSelect?: boolean;
+	/**
+	 * Handler. For a verb the shell closes the menu before calling it,
+	 * so a handler that opens a dialog or navigates does not have to
+	 * compete with a still-painted popover. For a checkbox the shell
+	 * flips the indicator optimistically first and leaves the menu
+	 * open, then calls this.
 	 */
 	onSelect: ( window: DesktopWindow ) => void;
 	/**
@@ -143,6 +183,15 @@ export function registerWindowAction( def: WindowActionDef ): void {
 			typeof def.isVisible !== 'function'
 		) {
 			errors.push( 'isVisible (must be a function when set)' );
+		}
+		if ( def.checked !== undefined && typeof def.checked !== 'function' ) {
+			errors.push( 'checked (must be a function when set)' );
+		} else if ( def.checkable && typeof def.checked !== 'function' ) {
+			// Caught here rather than papered over at paint time: a
+			// checkbox with no reader renders as permanently unchecked,
+			// which looks like a bug in the plugin's persistence and is
+			// not one.
+			errors.push( 'checked (required when checkable is set)' );
 		}
 	}
 
@@ -245,6 +294,33 @@ export function resolveActionIcon(
 		}
 	}
 	return def.icon ?? '';
+}
+
+/**
+ * Whether a checkable action's box is currently ticked.
+ *
+ * Read on every menu open, never cached: the plugin owns the value
+ * and may change it from anywhere (another window's row, a settings
+ * panel, a REST response landing late). Asking on open is what keeps
+ * "what the row says" and "what the plugin thinks" from drifting
+ * apart for longer than one open.
+ *
+ * @param def    Action.
+ * @param window The window the menu belongs to.
+ * @return True to paint the row ticked. Always false for a verb row.
+ */
+export function isActionChecked(
+	def: WindowActionDef,
+	window: DesktopWindow,
+): boolean {
+	if ( ! def.checkable || typeof def.checked !== 'function' ) {
+		return false;
+	}
+	try {
+		return !! def.checked( window );
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -126,7 +126,7 @@ import {
 import type { PanelTabEntry } from './tabs';
 import {
 	closeActionsMenu,
-	flipStartupCheckOptimistically,
+	flipMenuItemCheckOptimistically,
 	openActionsMenu,
 	refreshStartupCheckState,
 	toggleActionsMenu,
@@ -1181,7 +1181,7 @@ export class Window {
 					// optimistic flip + the server-confirmation refresh
 					// feels instant.
 					e.stopPropagation();
-					flipStartupCheckOptimistically( startup );
+					flipMenuItemCheckOptimistically( startup );
 					this.onToggleStartup?.( this );
 				} );
 				// Refresh the check state whenever the public

--- a/src/window/menus.ts
+++ b/src/window/menus.ts
@@ -6,13 +6,15 @@
  * optional "Open another <page>" for multi-capable pages, and — iframe
  * windows only — "Open in new window", "Reload", "Open in browser tab".
  * Plugin-registered rows (`wp.os.registerWindowAction`) are appended
- * after those on every open by {@link paintWindowActions}.
+ * after those on every open by {@link paintWindowActions}, as verbs
+ * or as checkboxes of their own.
  * Each free function here takes the `Window` instance as its first arg.
  */
 
 import { HOOKS, doAction } from '../hooks';
 import { urlMatchKey } from '../utils';
 import {
+	isActionChecked,
 	isActionVisible,
 	listWindowActions,
 	resolveActionIcon,
@@ -156,14 +158,19 @@ export function closeActionsMenu( win: Window ): void {
 }
 
 /**
- * Flip the "Open on startup" check state immediately on click so the
- * user sees instant feedback — the REST round-trip confirms shortly
- * after via the `os-default-window-changed` event, which
- * calls `refreshStartupCheckState` with the canonical state. If the
- * REST fails the optimistic flip stays (wrong) until the next menu
- * open, where the canonical check takes over.
+ * Flip a checkbox row's check state immediately on click so the user
+ * sees instant feedback where they are looking, before whatever the
+ * handler does to make it true has finished.
+ *
+ * For "Open on startup" that is a REST round-trip, confirmed shortly
+ * after via the `os-default-window-changed` event, which calls
+ * `refreshStartupCheckState` with the canonical state; if the REST
+ * fails the optimistic flip stays (wrong) until the next menu open,
+ * where the canonical check takes over. For a plugin's checkable
+ * action the same bargain holds against its `checked()` reader, which
+ * is re-read on every open.
  */
-export function flipStartupCheckOptimistically( item: HTMLElement ): void {
+export function flipMenuItemCheckOptimistically( item: HTMLElement ): void {
 	const isChecked = item.hasAttribute( 'checked' );
 	if ( isChecked ) {
 		item.removeAttribute( 'checked' );
@@ -215,16 +222,22 @@ export function refreshStartupCheckState(
  *
  * Rebuilt from scratch on every open rather than kept in sync, and
  * that is the cheap correct choice rather than a lazy one: an action's
- * label, icon and visibility are all allowed to be functions of the
- * window's current state, so "keeping them in sync" would mean
- * re-evaluating every predicate on every state change of every window
- * to catch the one menu that happens to be open. A menu opens rarely
- * and holds a handful of rows; rebuilding it costs nothing and cannot
- * drift.
+ * label, icon, visibility and check state are all allowed to be
+ * functions of the window's current state, so "keeping them in sync"
+ * would mean re-evaluating every predicate on every state change of
+ * every window to catch the one menu that happens to be open. A menu
+ * opens rarely and holds a handful of rows; rebuilding it costs
+ * nothing and cannot drift. It is also what lets a plugin persist a
+ * checkbox's value and repaint nothing — the row asks on open.
  *
  * A row whose handler throws is contained: the menu still closes and
  * the other rows still work. The ⋯ menu is shared surface, and one
  * plugin's bug must not cost the user their "Reload".
+ *
+ * The optimistic flip on a checkbox happens before the handler, so a
+ * handler that throws leaves the tick where the user put it until the
+ * next open re-reads `checked()` — the same bargain "Open on startup"
+ * makes against a failed REST call.
  *
  * @param win   The window the menu belongs to.
  * @param panel The `<os-menu>` panel element.
@@ -250,20 +263,41 @@ export function paintWindowActions( win: Window, panel: HTMLElement ): void {
 		}
 
 		const item = document.createElement( 'os-menu-item' );
-		item.setAttribute( 'role', 'menuitem' );
 		item.setAttribute( 'value', def.id );
-		const icon = resolveActionIcon( def, win );
-		if ( icon ) {
-			item.setAttribute( 'icon', icon );
-		}
 		item.classList.add( 'os-window__menu-item' );
 		item.classList.add( 'os-window__menu-item--action' );
 		item.setAttribute( 'data-action-id', def.id );
 		item.textContent = label;
 
+		if ( def.checkable ) {
+			// A checkbox reports state, so it gets the checkbox role and
+			// the tick — and no leading glyph, which would compete with
+			// the indicator for the same edge of the row.
+			item.setAttribute( 'role', 'menuitemcheckbox' );
+			if ( isActionChecked( def, win ) ) {
+				item.setAttribute( 'checked', '' );
+			}
+		} else {
+			item.setAttribute( 'role', 'menuitem' );
+			const icon = resolveActionIcon( def, win );
+			if ( icon ) {
+				item.setAttribute( 'icon', icon );
+			}
+		}
+
+		// A verb closes the menu, like every built-in one. A checkbox
+		// stays open so the user watches the tick land — and so a row
+		// they meant to flip twice does not cost them two menu opens.
+		const closeOnSelect = def.closeOnSelect ?? ! def.checkable;
+
 		item.addEventListener( 'os-menu-item-click', ( e: Event ) => {
 			e.stopPropagation();
-			closeActionsMenu( win );
+			if ( def.checkable ) {
+				flipMenuItemCheckOptimistically( item );
+			}
+			if ( closeOnSelect ) {
+				closeActionsMenu( win );
+			}
 			try {
 				def.onSelect( win );
 			} catch ( err ) {

--- a/tests/vitest/content-graph-node-style.test.ts
+++ b/tests/vitest/content-graph-node-style.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Content Graph — node body style contract.
+ *
+ * Pins the two things the ⋯ "Show pins" toggle depends on: that the
+ * scene defaults to disc bodies, and that `setNodeStyle()` both flips
+ * the style and invalidates every cached disc signature so the next
+ * frame actually repaints. Without that invalidation the toggle would
+ * be a no-op on a settled graph — the discs are painted once and then
+ * skipped every frame, which is the whole point of the cache.
+ *
+ * Renderer-free: the scene constructor builds no Pixi objects, all
+ * the heavy work lives in `mount()`.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { GraphScene, type NodeStyle } from '../../src/content-graph/scene';
+import type { PostTypeDescriptor } from '../../src/content-graph/types';
+
+const POST_TYPES: PostTypeDescriptor[] = [
+	{
+		slug: 'post',
+		label: 'Posts',
+		icon: 'dashicons-admin-post',
+		count: 3,
+		taxonomies: { category: true, post_tag: true },
+	},
+	{
+		slug: 'page',
+		label: 'Pages',
+		icon: 'dashicons-admin-page',
+		count: 2,
+		taxonomies: { category: false, post_tag: false },
+	},
+];
+
+// Private state reached through a structural cast — same approach as
+// the grouping test, so the contract stays testable without widening
+// the public API.
+interface SceneInternals {
+	postTypeColor: Map< string, number >;
+	nodeViews: Map< number, { discKey: string } >;
+}
+
+function makeScene( style?: NodeStyle ): GraphScene {
+	return new GraphScene(
+		document.createElement( 'div' ),
+		{},
+		() => {},
+		POST_TYPES,
+		style,
+	);
+}
+
+describe( 'node style', () => {
+	test( 'defaults to disc bodies', () => {
+		expect( makeScene().getNodeStyle() ).toBe( 'disc' );
+	} );
+
+	test( 'honours the style passed at construction', () => {
+		// The host reads the persisted preference before the scene
+		// exists, so the very first paint must already be right —
+		// a disc flashing before the pins appear would be a visible
+		// regression for anyone who picked pins.
+		expect( makeScene( 'icon' ).getNodeStyle() ).toBe( 'icon' );
+	} );
+
+	test( 'setNodeStyle switches the style', () => {
+		const scene = makeScene();
+		scene.setNodeStyle( 'icon' );
+		expect( scene.getNodeStyle() ).toBe( 'icon' );
+		scene.setNodeStyle( 'disc' );
+		expect( scene.getNodeStyle() ).toBe( 'disc' );
+	} );
+
+	test( 'setNodeStyle invalidates cached disc signatures', () => {
+		const scene = makeScene();
+		const internals = scene as unknown as SceneInternals;
+		internals.nodeViews.set( 1, { discKey: 'painted' } );
+		internals.nodeViews.set( 2, { discKey: 'painted' } );
+
+		scene.setNodeStyle( 'icon' );
+
+		expect(
+			Array.from( internals.nodeViews.values() ).map( ( v ) => v.discKey ),
+		).toEqual( [ '', '' ] );
+	} );
+
+	test( 'setNodeStyle to the current style leaves the cache alone', () => {
+		// A redundant call must not force a full repaint of every
+		// disc on the next frame.
+		const scene = makeScene();
+		const internals = scene as unknown as SceneInternals;
+		internals.nodeViews.set( 1, { discKey: 'painted' } );
+
+		scene.setNodeStyle( 'disc' );
+
+		expect( internals.nodeViews.get( 1 )?.discKey ).toBe( 'painted' );
+	} );
+
+	test( 'assigns a distinct palette colour per post type, in order', () => {
+		const internals = makeScene() as unknown as SceneInternals;
+		const post = internals.postTypeColor.get( 'post' );
+		const page = internals.postTypeColor.get( 'page' );
+		expect( post ).toBeTypeOf( 'number' );
+		expect( page ).toBeTypeOf( 'number' );
+		expect( post ).not.toBe( page );
+	} );
+} );

--- a/tests/vitest/window-actions-menu.test.ts
+++ b/tests/vitest/window-actions-menu.test.ts
@@ -217,6 +217,131 @@ describe( 'paintWindowActions', () => {
 		spy.mockRestore();
 	} );
 
+	test( 'a checkable row paints as a checkbox, glyphless, from its reader', () => {
+		const { win, panel } = harness();
+		registerWindowAction( {
+			id: 'my/pins',
+			label: 'Show pins',
+			icon: 'dashicons-sticky',
+			checkable: true,
+			checked: () => true,
+			onSelect: () => {},
+		} );
+
+		paintWindowActions( win, panel );
+
+		const row = rows( panel )[ 0 ];
+		expect( row.getAttribute( 'role' ) ).toBe( 'menuitemcheckbox' );
+		expect( row.hasAttribute( 'checked' ) ).toBe( true );
+		// The tick owns the leading edge of the row; a glyph there
+		// would compete with it.
+		expect( row.hasAttribute( 'icon' ) ).toBe( false );
+	} );
+
+	test( 'a repaint follows a preference the plugin changed elsewhere', () => {
+		// The whole point of `checked` being a reader: the plugin
+		// persists and repaints nothing.
+		const { win, panel } = harness();
+		let on = false;
+		registerWindowAction( {
+			id: 'my/pins',
+			label: 'Show pins',
+			checkable: true,
+			checked: () => on,
+			onSelect: () => {},
+		} );
+
+		paintWindowActions( win, panel );
+		expect( rows( panel )[ 0 ].hasAttribute( 'checked' ) ).toBe( false );
+
+		on = true;
+		paintWindowActions( win, panel );
+
+		expect( rows( panel )[ 0 ].hasAttribute( 'checked' ) ).toBe( true );
+	} );
+
+	test( 'clicking a checkbox flips it optimistically and keeps the menu open', () => {
+		const { win, panel } = harness();
+		let on = false;
+		registerWindowAction( {
+			id: 'my/pins',
+			label: 'Show pins',
+			checkable: true,
+			checked: () => on,
+			onSelect: () => {
+				on = ! on;
+			},
+		} );
+
+		panel.hidden = false;
+		paintWindowActions( win, panel );
+		rows( panel )[ 0 ].dispatchEvent(
+			new CustomEvent( 'os-menu-item-click', { bubbles: true } ),
+		);
+
+		expect( rows( panel )[ 0 ].hasAttribute( 'checked' ) ).toBe( true );
+		expect( on ).toBe( true );
+		// Staying open is what lets the user watch the tick land — and
+		// flip it back without reopening.
+		expect( panel.hidden ).toBe( false );
+	} );
+
+	test( 'a verb closes the menu, and `closeOnSelect` overrides either default', () => {
+		const { win, panel } = harness();
+		registerWindowAction( {
+			id: 'my/verb',
+			label: 'Do it',
+			onSelect: () => {},
+		} );
+		registerWindowAction( {
+			id: 'my/sticky-verb',
+			label: 'Stay',
+			order: 200,
+			closeOnSelect: false,
+			onSelect: () => {},
+		} );
+
+		panel.hidden = false;
+		paintWindowActions( win, panel );
+		rows( panel )[ 0 ].dispatchEvent(
+			new CustomEvent( 'os-menu-item-click', { bubbles: true } ),
+		);
+		expect( panel.hidden ).toBe( true );
+
+		panel.hidden = false;
+		paintWindowActions( win, panel );
+		rows( panel )[ 1 ].dispatchEvent(
+			new CustomEvent( 'os-menu-item-click', { bubbles: true } ),
+		);
+		expect( panel.hidden ).toBe( false );
+	} );
+
+	test( 'a checkbox whose handler throws keeps the optimistic flip', () => {
+		// Same bargain "Open on startup" makes against a failed REST
+		// call: the tick stays where the user put it until the next
+		// open re-reads `checked()`.
+		const { win, panel } = harness();
+		registerWindowAction( {
+			id: 'my/bad-check',
+			label: 'Show pins',
+			checkable: true,
+			checked: () => false,
+			onSelect: () => {
+				throw new Error( 'boom' );
+			},
+		} );
+		const spy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		paintWindowActions( win, panel );
+		rows( panel )[ 0 ].dispatchEvent(
+			new CustomEvent( 'os-menu-item-click', { bubbles: true } ),
+		);
+
+		expect( rows( panel )[ 0 ].hasAttribute( 'checked' ) ).toBe( true );
+		expect( spy ).toHaveBeenCalled();
+		spy.mockRestore();
+	} );
+
 	test( 'a row unregistered between opens disappears', () => {
 		const { win, panel } = harness();
 		registerWindowAction( { id: 'my/act', label: 'Do it', onSelect: () => {} } );

--- a/tests/vitest/window-actions-registry.test.ts
+++ b/tests/vitest/window-actions-registry.test.ts
@@ -10,6 +10,7 @@
  */
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
+	isActionChecked,
 	isActionVisible,
 	listWindowActions,
 	registerWindowAction,
@@ -127,6 +128,29 @@ describe( 'validation', () => {
 			registerWindowAction( def( { label: () => 'Computed' } ) ),
 		).not.toThrow();
 	} );
+
+	test( 'rejects checkable without a checked reader', () => {
+		// A checkbox nobody can ask renders permanently unticked, which
+		// reads as broken persistence in the plugin rather than a
+		// missing field here.
+		expect( () =>
+			registerWindowAction( def( { checkable: true } ) ),
+		).toThrow();
+	} );
+
+	test( 'rejects a non-function checked', () => {
+		expect( () =>
+			registerWindowAction( def( { checked: true as never } ) ),
+		).toThrow();
+	} );
+
+	test( 'accepts a complete checkbox row', () => {
+		expect( () =>
+			registerWindowAction(
+				def( { checkable: true, checked: () => true } ),
+			),
+		).not.toThrow();
+	} );
 } );
 
 describe( 'resolvers', () => {
@@ -185,6 +209,41 @@ describe( 'visibility', () => {
 			throw new Error( 'boom' );
 		};
 		expect( isActionVisible( def( { isVisible } ), WIN ) ).toBe( false );
+	} );
+} );
+
+describe( 'check state', () => {
+	test( 'a verb row is never checked', () => {
+		expect( isActionChecked( def( { checked: () => true } ), WIN ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'the reader decides, and receives the window', () => {
+		const checked = vi.fn( ( w: DesktopWindow ) => w.id === 'edit-php' );
+		expect(
+			isActionChecked( def( { checkable: true, checked } ), WIN ),
+		).toBe( true );
+		expect( checked ).toHaveBeenCalledWith( WIN );
+	} );
+
+	test( 'a throwing reader paints unchecked rather than dropping the row', () => {
+		// Losing the indicator is recoverable on the next open; losing
+		// the row is not.
+		const checked = () => {
+			throw new Error( 'boom' );
+		};
+		expect(
+			isActionChecked( def( { checkable: true, checked } ), WIN ),
+		).toBe( false );
+	} );
+
+	test( 'the reader is re-read, never cached', () => {
+		let on = false;
+		const entry = def( { checkable: true, checked: () => on } );
+		expect( isActionChecked( entry, WIN ) ).toBe( false );
+		on = true;
+		expect( isActionChecked( entry, WIN ) ).toBe( true );
 	} );
 } );
 


### PR DESCRIPTION
<img width="1286" height="754" alt="image" src="https://github.com/user-attachments/assets/3969a00b-6508-4901-93a9-f117a18465d2" />


## Why

Every Corkboard node was the post type's Dashicon glyph — for posts, the pushpin. The loudest possible mark on the most common node, and it didn't sit with the rest of the app.

## What

**Nodes are discs coloured by post type.** Same palette the relationship satellites already use, so a focused post and the bubbles fanned around it read as one system rather than two. Sizing is unchanged (`8 + √degree × 2.4`); a keyline keeps overlapping nodes readable at low zoom. Focus scales the disc, fills it with the accent, and reveals the glyph inside — hover does too — so neither costs the user the type information.

Discs repaint only when their signature changes. A fill + stroke per node per frame is fine for a demo graph and not for a real site's few hundred posts; in steady state it's zero repaints.

**Pins are one row away.** "Show pins" in the window's ⋯ menu, persisted in `localStorage` (`desktop-mode/corkboard-node-style`).

## Checkbox rows for `registerWindowAction()`

*(This replaces the `registerWindowMenuItem()` API the first draft of this PR proposed. `registerWindowAction()` landed on trunk in the meantime and is the better-developed surface — it has a PHP opt-in, a server-sync module, and a working owner sweep. Shipping a second parallel registry alongside it would have been a mistake, so the new API is gone and its one genuinely new capability moved across.)*

Window actions had only ever been verbs. "Show pins" is a preference, so `WindowActionDef` grows a second row shape:

- `checkable: true` + `checked( win )` — painted as `role="menuitemcheckbox"`, ticked from the reader. `checkable` without `checked` throws: a checkbox nobody can ask renders permanently unticked, which reads as broken persistence in the plugin rather than a missing field in the def.
- `checked()` is **asked, never told** — re-read on every menu open, so a plugin persists its preference and repaints nothing, and the row can't disagree with the plugin for longer than one open.
- Clicking flips the tick optimistically and leaves the menu open, so the user watches it land and can flip back without reopening. `closeOnSelect` overrides the per-shape default in either direction.

`flipStartupCheckOptimistically` → `flipMenuItemCheckOptimistically`. The body was always generic; plugin checkboxes now share it with "Open on startup".

The docs make the choice between the two shapes explicit, because they aren't interchangeable: a relabelling `label` function is right when the two states are two *places* the window can be ("Send to your Mac" / "Bring back into OpenStation") — the row names the move. A checkbox is right when they're one setting the window either has or doesn't: a tick says "there is a thing here, and it is currently off", which a label reading "Show pins" alone cannot.

## Supersampling the canvas

Second commit, and separable if you'd rather it went on its own.

The scene asked for `antialias: true` and rendered at `min(devicePixelRatio, 2)` — native density on any Retina display, so MSAA and no supersampling. Enough for a large shape; not for these. A node is 8–16 world units across wearing a 1.5-unit keyline, and the overview sits near 0.5× zoom. There the keyline is *under a device pixel*: MSAA has nothing to average and the ring breaks into a dotted shimmer — losing exactly the thing the ring is for, which is keeping two overlapping nodes readable as two nodes.

So: render 1.5× above DPR, clamped at 3 (the cost is quadratic and the canvas is full-window; a 1400×800 stage is 10M pixels at 3 and 18M at 4). `autoDensity` already holds the canvas at its CSS size, so nothing about the layout moves. `RENDER_SUPERSAMPLE = 1` restores the old behaviour.

Both `Text` layers move off their pinned `resolution: 2` onto the same number. A glyph rasterised below the density of the canvas around it gets *upscaled*, and the icon is now the focus/hover reveal **inside** the disc — it would have been the one soft thing on a screen that just got sharper everywhere else.

If it's still not clean enough the next step is different in kind: bake one white circle+ring into a `RenderTexture` and use tinted `Sprite`s, which gives free filtering at every zoom and collapses every disc into one draw call. The trade is that the keyline then scales with the disc instead of holding a constant world width.

## Tests

`typecheck` / `lint` / `build` clean, `test:js` green (380 files, 4838 tests). New coverage: checkable-row validation (including the `checkable`-without-`checked` throw), the `checked` resolver's re-read-never-cache contract and its throwing-reader containment, checkbox painting and the glyphless leading edge, the optimistic flip surviving a throwing handler, `closeOnSelect` in both directions; plus node-style default, constructor-passed style, cache invalidation on toggle and non-invalidation on a redundant call.

No PHP changed. Docs updated in the same change: `javascript-reference.md`, `api-index.md`, the Corkboard section of `hooks-reference.md`, and a checkbox section in the existing `examples/window-action.md`.

Rebased onto trunk (was 101 commits behind).

## Manual check

Open Corkboard, confirm discs on first paint, ⋯ → **Show pins** and back — the tick should flip with the menu staying open — then reload to confirm it sticks. Worth an eye on whether the keyline reads cleanly at overview zoom now, and on whether disc sizes work at that zoom — the one thing tests can't tell you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-510-f034a5876a542b9cc0cb1bd974938e9d330247d5.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
