### PR TITLE
Activity channels: Drop the pre-rebrand desktop-mode prefix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,9 @@ If you are **building a plugin** that interacts with the desktop shell — opens
 13. **[Progressive Web App (PWA)](./pwa.md)** — *Stable.* Web app manifest, service worker (root-scope, narrow fetch handler), install affordance, and `wp.os.notify()` for local notifications. Phase-4 Web Push wiring lands later without breaking the v1 call surface.
 14. **[Migration 0.7 → 0.8.1](./migration-0.7-to-0.8.1.md)** — what landed in the architecture-0.8.1 refactor: the `@core` / `@api` / `@protocol` / `@layout` / `@ui` path aliases, the registry / server-sync / api-client primitives, the public-API facade home, and the PHP slicing of `helpers.php` / `components.php` / `render.php`. Read once before adopting any of the new modules in your plugin.
 15. **[Migration — AI comment-only + native search (0.11.0)](./migration-ai-comment-only.md)** — the AI Copilot is scoped to comment spam scoring; post/term auto-analysis and its hooks are removed, the assistant now finds content with native keyword search, and the bulk `/ai/reindex` endpoint is gone. Read if you depended on any `openstation_ai_*post*` / `*term*` hook or the reindex route.
-16. **[Register a widget — polling, storage, canvas charts](./register-widget.md)**
-17. **[The Living Tree — algorithm definition](./living-tree-algorithm.md)** — *Experimental.* The full normative spec for the `wp-living-tree` canvas wallpaper: WordPress emits hormones, the biology (Space Colonization) decides geometry inside age-bounded morphological constraints. Read before touching any part of the wallpaper.
+16. **[Migration — activity channels move to `os/` (0.9.9)](./migration-activity-channels.md)** — the ten framework-published activity channels drop the pre-rebrand `desktop-mode/` prefix. No alias ships: a subscriber left on an old slug stops firing silently. Read if you subscribe to or filter any built-in channel.
+17. **[Register a widget — polling, storage, canvas charts](./register-widget.md)**
+18. **[The Living Tree — algorithm definition](./living-tree-algorithm.md)** — *Experimental.* The full normative spec for the `wp-living-tree` canvas wallpaper: WordPress emits hormones, the biology (Space Colonization) decides geometry inside age-bounded morphological constraints. Read before touching any part of the wallpaper.
 
 ## Conventions used in this docs folder
 

--- a/docs/event-driven-framework.md
+++ b/docs/event-driven-framework.md
@@ -22,34 +22,16 @@ hook the app can subscribe to?**
 
 ## The three layers
 
-```
-                        ┌──────────────────────────────────────┐
-                        │  Layer 3 — Activity channels         │
-                        │  wp.os.activity.{publish,sub}   │
-                        │  wp.os.heartbeat.{contribute,…} │
-                        │  wp.os.broadcast / subscribe    │
-                        │  (peer-to-peer, named, type-safe)    │
-                        └──────────────┬───────────────────────┘
-                                       │
-                        ┌──────────────┴───────────────────────┐
-                        │  Layer 2 — Window lifecycle           │
-                        │  os-window-* CustomEvents    │
-                        │  wp.hooks WINDOW_* actions           │
-                        │  wp.os.onWindow( id, handlers ) │
-                        ├──────────────────────────────────────┤
-                        │  Layer 2a — Window-self channel      │
-                        │  Window.send / Window.on  (parent)   │
-                        │  wp.os.send / .on (window-side) │
-                        │  (iframe + native, same shape)       │
-                        └──────────────┬───────────────────────┘
-                                       │
-                        ┌──────────────┴───────────────────────┐
-                        │  Layer 1 — Synchronous state queries │
-                        │  windowManager.getById( id )         │
-                        │  windowManager.isActive( id )        │
-                        │  presence.getStatus( userId )        │
-                        │  shared stores via createSharedStore │
-                        └──────────────────────────────────────┘
+```mermaid
+%%{init: {'flowchart': {'wrappingWidth': 420}}}%%
+flowchart TB
+    L3["<b>Layer 3 — Activity channels</b><br>peer-to-peer, named, type-safe<br>wp.os.activity.publish / subscribe / filter<br>wp.os.heartbeat.contribute / subscribe<br>wp.os.broadcast / subscribe"]
+    L2["<b>Layer 2 — Window lifecycle</b><br>os-window-* CustomEvents<br>wp.hooks WINDOW_* actions<br>wp.os.onWindow( id, handlers )"]
+    L2a["<b>Layer 2a — Window-self channel</b><br>iframe + native, same shape<br>Window.send / Window.on — parent side<br>wp.os.send / wp.os.on — window side"]
+    L1["<b>Layer 1 — Synchronous state queries</b><br>windowManager.getById( id )<br>windowManager.isActive( id )<br>presence.getStatus( userId )<br>shared stores via createSharedStore"]
+    L3 --> L2
+    L2 --- L2a
+    L2a --> L1
 ```
 
 ### Layer 1 — synchronous state
@@ -87,16 +69,30 @@ Every native window emits this state machine on the action bus
 (`wp.hooks`) AND as document CustomEvents. Apps pick whichever
 flavour fits.
 
-```
-   opened ──► focused ◄────► blurred
-                ▲   │
-                │   ▼
-            restored ◄────► minimized
-                │
-   reopened ◄───┤      (every wp.os.openWindow on already-open id)
-                │
-                ▼
-            closing ──► closed
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> opened
+    opened --> focused
+    focused --> blurred
+    blurred --> focused
+    focused --> minimized
+    minimized --> restored
+    restored --> focused
+    focused --> reopened
+    blurred --> reopened
+    minimized --> reopened
+    reopened --> focused
+    focused --> closing
+    closing --> closed
+    closed --> [*]
+    note right of reopened
+        Every wp.os.openWindow call against an id
+        already open on the active desktop — from any
+        live state, focused included. The manager
+        focuses (and un-minimizes) before it fires,
+        so the window always lands back on focused.
+    end note
 ```
 
 **Custom events** (filter by `e.detail.windowId === MY_ID`):
@@ -247,13 +243,15 @@ bus, so devtools can list activity traffic as a discrete group.
 Hook names can't contain a slash (`@wordpress/hooks` rejects the
 registration), so the channel separator becomes a period there:
 `my-plugin/thing-happened` lands on
-`desktop-mode.activity.my-plugin.thing-happened`. Only relevant if
+`os.activity.my-plugin.thing-happened`. Only relevant if
 you register through raw `wp.hooks` instead of the API below.
 Type the payload by augmenting `ActivityChannelMap` in your own
 `.d.ts`:
 
 ```ts
-declare module 'desktop-mode/activity' {
+import type {} from 'openstation/activity';
+
+declare module 'openstation/activity' {
     interface ActivityChannelMap {
         'my-plugin/something-happened': { id: number; reason: string };
     }
@@ -261,20 +259,23 @@ declare module 'desktop-mode/activity' {
 ```
 
 **Built-in channels.** Every framework primitive that publishes
-mirrors here so plugins can subscribe through one unified API:
+mirrors here so plugins can subscribe through one unified API. The
+`os/` namespace is the shell's own — subscribe and filter freely,
+but publish your events under your plugin's slug:
 
 | Channel | Filterable? | When it fires |
 |---|---|---|
-| `desktop-mode/toast-requested` | Yes — `cancel: true` to drop, mutate to rewrite | Pre-show on every `showToast()`. |
-| `desktop-mode/toast-shown` | No (post-render) | After the toast lands in the DOM. |
-| `desktop-mode/notification-requested` | Yes — `cancel: true` to drop, mutate to rewrite | Pre-render on every `wp.os.notify()`. |
-| `desktop-mode/notification-shown` | No (post-render) | After the notification (or its toast fallback) renders — payload carries `fallback: 'toast' \| null`. |
-| `desktop-mode/window-attention-requested` | Yes — `cancel: true` for DND, mutate `mode`/`durationMs` to scale | Pre-attention on every `Window.requestAttention()` (which then routes the filtered result to the rails' `setAttention()`). Direct `dock.setAttention()` calls bypass the filter. |
-| `desktop-mode/badge-changed` | No | Every `setBadge()` on dock / taskbar / icons. Payload carries `rail: 'dock' \| 'taskbar' \| 'icon'` so a single subscriber can compose across surfaces. |
-| `desktop-mode/open-requested` | No | Every `wp.os.openWindow()`, BEFORE deciding `opened` vs `reopened`. Carries `source`. |
-| `desktop-mode/presence-changed` | No | Every presence transition (mirror of the `os-presence-changed` CustomEvent). |
-| `desktop-mode/presence-snapshot-applied` | No | After every presence batch — `{ applied, transitions }`. |
-| `desktop-mode/game-score-recorded` | No | After a game's `submitScore()` write resolves (free play and challenge completion both). Games play in their own window, so this is how a leaderboard in another window learns it went stale. Payload carries `challengeId` on the completion path. |
+| `os/toast-requested` | Yes — `cancel: true` to drop, mutate to rewrite | Pre-show on every `showToast()`. |
+| `os/toast-shown` | No (post-render) | After the toast lands in the DOM. |
+| `os/notification-requested` | Yes — `cancel: true` to drop, mutate to rewrite | Pre-render on every `wp.os.notify()`. |
+| `os/notification-shown` | No (post-render) | After the notification (or its toast fallback) renders — payload carries `fallback: 'toast' \| null`. |
+| `os/window-attention-requested` | Yes — `cancel: true` for DND, mutate `mode`/`durationMs` to scale | Pre-attention on every `Window.requestAttention()` (which then routes the filtered result to the rails' `setAttention()`). Direct `dock.setAttention()` calls bypass the filter. |
+| `os/badge-changed` | No | Every `setBadge()` on dock / taskbar / icons. Payload carries `rail: 'dock' \| 'taskbar' \| 'icon'` so a single subscriber can compose across surfaces. |
+| `os/open-requested` | No | Every `wp.os.openWindow()`, BEFORE deciding `opened` vs `reopened`. Carries `source`. |
+| `os/presence-changed` | No | Every presence transition (mirror of the `os-presence-changed` CustomEvent). |
+| `os/presence-snapshot-applied` | No | After every presence batch — `{ applied, transitions }`. |
+| `os/game-score-recorded` | No | After a game's `submitScore()` write resolves (free play and challenge completion both). Games play in their own window, so this is how a leaderboard in another window learns it went stale. Payload carries `challengeId` on the completion path. |
+| `os/upload-hud-complete` | No | After a file dropped on the shell finishes uploading — `{ filename, attachmentId }`. Published by the progress HUD, not the uploader: the upload runs on XHR (the only transport that reports determinate progress) and so never routes through `wp.os.fetch`, which makes this the bus's only view of a completed drop. |
 
 **Activity ↔ broadcast mirror.** `wp.os.broadcast(topic, payload)`
 publishes both onto the broadcast bus (cross-iframe, cross-tab)
@@ -283,6 +284,15 @@ Use `broadcast` when peers might be in another iframe / tab
 (the recycle bin's `os.data-changed` topic is the
 canonical example); use `activity.publish` when you only need
 in-tab fan-out.
+
+Because the mirror is verbatim and `hookName()` collapses `/` to
+`.`, a channel and a topic that differ only in that separator
+land on the same hook: `os/badge-changed` and a topic
+`os.badge-changed` both resolve to
+`os.activity.os.badge-changed`. The two namespaces have always
+shared one hook space — pre-rebrand it was `desktop-mode` on both
+sides — and nothing in-tree collides. Just don't name a broadcast
+topic after a built-in channel.
 
 ### Layer 3+ — the heartbeat bus
 
@@ -393,7 +403,7 @@ rails are `wp.os.dock` (the primary bottom rail),
 Unified / Spatial), and `wp.os.icons` (wallpaper shortcuts).
 The `rail` discriminator on emitted events is a separate axis:
 the bottom-anchored primary dock stamps `rail: 'taskbar'` onto
-the events it emits (e.g. `desktop-mode/badge-changed`), while
+the events it emits (e.g. `os/badge-changed`), while
 `sideDock` stamps `rail: 'dock'` and the icon rail `rail: 'icon'`.
 
 ## What NOT to do (anti-patterns)

--- a/docs/examples/dock-badge.md
+++ b/docs/examples/dock-badge.md
@@ -63,7 +63,7 @@ discriminator — one subscription, every rail composed:
 
 ```js
 wp.os.activity.subscribe(
-    'desktop-mode/badge-changed',
+    'os/badge-changed',
     ( { itemId, count, rail } ) => {
         console.log( `${ rail }:${ itemId } → ${ count }` );
     },

--- a/docs/examples/notify.md
+++ b/docs/examples/notify.md
@@ -72,7 +72,7 @@ that one was shown:
 
 ```js
 wp.hooks.addFilter(
-    'os.activity.desktop-mode.notification-requested',
+    'os.activity.os.notification-requested',
     'my-plugin/dnd',
     ( intent ) => {
         if ( isDoNotDisturbActive() ) {
@@ -83,7 +83,7 @@ wp.hooks.addFilter(
 );
 
 wp.os.activity.subscribe(
-    'desktop-mode/notification-shown',
+    'os/notification-shown',
     ( payload ) => {
         // payload.fallback === 'toast' means permission was denied
         // and the user only saw the in-shell toast version.

--- a/docs/examples/window-request-attention.md
+++ b/docs/examples/window-request-attention.md
@@ -65,7 +65,7 @@ wp.os.icons?.clearBadge?.(    'my-plugin-inbox' );
 
 Fan to all three rails — the rail that owns the id paints, the
 others silently no-op. Every applied change publishes
-`desktop-mode/badge-changed` on the activity bus with `rail`
+`os/badge-changed` on the activity bus with `rail`
 identifying the surface.
 
 ## Mute (Do Not Disturb) — JS hook

--- a/docs/folder-sharing.md
+++ b/docs/folder-sharing.md
@@ -365,11 +365,11 @@ the heartbeat ingest.
 **Planned** — `wp.os.activity` channels for the share
 lifecycle are not yet published:
 
-- `desktop-mode/folder-share-invited`
-- `desktop-mode/folder-share-accepted`
-- `desktop-mode/folder-share-denied`
-- `desktop-mode/folder-share-revoked`
-- `desktop-mode/folder-share-capability-changed`
+- `os/folder-share-invited`
+- `os/folder-share-accepted`
+- `os/folder-share-denied`
+- `os/folder-share-revoked`
+- `os/folder-share-capability-changed`
 
 Programmatic entry points (from `src/desktop-files/rest.ts`):
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -989,12 +989,12 @@ Goes through the same canonical opener as the dock click + the wallpaper-icon cl
 
 > **Render-callback registry — `window.openStationNativeWindows`.** A PHP-registered native window pairs its `<template>` with an optional JS render callback the plugin's `script` registers at `window.openStationNativeWindows[ <id> ]`; the shell looks it up by id and invokes it with the window body. `window.openStationNativeWindows` is a **deprecated compat alias** for bundles built before the rename — the shell merges both bags at read time when opening a native window, with the canonical `openStationNativeWindows` winning on id collisions. New code must register on `openStationNativeWindows`.
 
-**`opts.source`** — optional string identifying who triggered the open. The framework publishes `desktop-mode/open-requested` on the activity bus *before* the open is processed, so analytics, do-not-disturb modes, and audit subscribers can observe the user's intent independently of the outcome:
+**`opts.source`** — optional string identifying who triggered the open. The framework publishes `os/open-requested` on the activity bus *before* the open is processed, so analytics, do-not-disturb modes, and audit subscribers can observe the user's intent independently of the outcome:
 
 ```javascript
 wp.os.openWindow( 'my-plugin/inbox', { source: 'global-search' } );
 
-wp.os.activity.subscribe( 'desktop-mode/open-requested', ( { windowId, source } ) => {
+wp.os.activity.subscribe( 'os/open-requested', ( { windowId, source } ) => {
     track( 'window.open.requested', { windowId, source } );
 } );
 ```
@@ -1056,7 +1056,7 @@ wp.os.openNewWindow(
 
 Returns `true` when the registry matched the id (a fresh window with id `<base>-2` / `-3` / … is now mounted), `false` when no native window is registered with that id.
 
-Powers the dock-peek "+" button for native windows so they behave like iframe windows do: every "+" yields a duplicate. `opts.source` carries the same semantics as `openWindow`'s — it tags the `desktop-mode/open-requested` activity-bus publish.
+Powers the dock-peek "+" button for native windows so they behave like iframe windows do: every "+" yields a duplicate. `opts.source` carries the same semantics as `openWindow`'s — it tags the `os/open-requested` activity-bus publish.
 
 ---
 
@@ -1283,7 +1283,7 @@ The **primary (bottom) `Dock` instance** (or `null` if the dock element wasn't i
 - **Unified** — every menu, core and plugin alike, sharing one rail.
 - **Spatial** — plugin menus only (core menus are rendered as wallpaper icons).
 
-`setBadge( id, count )` is the canonical way to surface a numeric count on a tile; calls fire `desktop-mode/badge-changed` on the activity bus with the rail discriminator — `rail: 'taskbar'` for this bottom primary rail, `rail: 'dock'` for the Classic-layout side rail (`sideDock`). `Dock.removeSystemItem( id )` fires `HOOKS.DOCK_ITEM_REMOVED` — the symmetric counterpart of `HOOKS.DOCK_ITEM_APPENDED`. See [`docs/examples/dock-badge.md`](./examples/dock-badge.md).
+`setBadge( id, count )` is the canonical way to surface a numeric count on a tile; calls fire `os/badge-changed` on the activity bus with the rail discriminator — `rail: 'taskbar'` for this bottom primary rail, `rail: 'dock'` for the Classic-layout side rail (`sideDock`). `Dock.removeSystemItem( id )` fires `HOOKS.DOCK_ITEM_REMOVED` — the symmetric counterpart of `HOOKS.DOCK_ITEM_APPENDED`. See [`docs/examples/dock-badge.md`](./examples/dock-badge.md).
 
 > **Layout switching note** — the underlying instance is replaced when the user picks a new layout in OpenStation Preferences → Appearance. `wp.os.dock` is mutated in place so a fresh property read returns the current dock; plugins that **cache** the reference earlier should listen for `os-layout-changed` and refresh.
 
@@ -1331,7 +1331,7 @@ setOrdersBadge( 0 );  // clear
 
 Three calls; the rail that owns the id paints, the others bow out silently. Each call:
 
-- **Idempotent on the icon rail** — same count twice = no DOM mutation, no re-emit. The two Dock rails currently re-paint and re-publish `desktop-mode/badge-changed` on every call, so avoid hot-looping `setBadge` with an unchanged count.
+- **Idempotent on the icon rail** — same count twice = no DOM mutation, no re-emit. The two Dock rails currently re-paint and re-publish `os/badge-changed` on every call, so avoid hot-looping `setBadge` with an unchanged count.
 - **`0` clears** — and on the two Dock rails it also drops the client-side override so the server-declared `item.badge` resumes ownership on the next live menu refresh.
 - **`> 99` renders as `99+`**.
 - **Silent no-op when the id isn't on this rail** — keeps the fan-to-all-rails pattern from triple-emitting.
@@ -1339,7 +1339,7 @@ Three calls; the rail that owns the id paints, the others bow out silently. Each
 
 Every applied change publishes on:
 
-- `desktop-mode/badge-changed` activity channel with `{ itemId, count, rail: 'dock' | 'taskbar' | 'icon' }`.
+- `os/badge-changed` activity channel with `{ itemId, count, rail: 'dock' | 'taskbar' | 'icon' }`.
 - `HOOKS.ICON_BADGE_CHANGED` action with `{ iconId, count, previousCount }` *(icon rail only)*.
 
 The rails do NOT auto-suppress based on window state — that's per-app UX policy. The canonical "show 0 while my window is active" recipe lives in [`docs/examples/dock-badge.md`](./examples/dock-badge.md).
@@ -1685,23 +1685,26 @@ interface ActivityApi {
 }
 ```
 
-**Built-in channels** — every framework primitive that publishes mirrors here:
+**Built-in channels** — every framework primitive that publishes mirrors here. The `os/` namespace is the shell's own: subscribe and filter freely, but publish your own events under your plugin's slug.
 
 | Channel | Direction | Payload | Filterable? |
 |---|---|---|---|
-| `desktop-mode/toast-requested` | Pre-show — `showToast()` calls run through this. | `{ message, action?, duration?, persistent?, source?, meta?, cancel? }` | **Yes.** Set `cancel: true` to drop the toast. Mutate `message`/`duration`/`action`/`persistent` to rewrite. |
-| `desktop-mode/toast-shown` | Fire-and-forget — fires after the toast lands in the DOM. | Same shape as above. | No (filtering is too late). |
-| `desktop-mode/window-attention-requested` | Pre-attention — `Window.requestAttention()` runs through this filter, then routes the filtered result to the rails' `setAttention()`; direct `dock.setAttention()` / `taskbar.setAttention()` calls bypass it. | `{ windowId, mode, durationMs?, intensity?, source?, cancel? }` | **Yes.** Set `cancel: true` for DND. Mutate `mode`/`durationMs`/`intensity` to scale the animation. |
-| `desktop-mode/badge-changed` | Fire-and-forget — every `setBadge()` on dock / taskbar / icons mirrors here on every change. | `{ itemId, count, rail?: 'dock' \| 'taskbar' \| 'icon' }` *(rail)* | No. |
-| `desktop-mode/open-requested` | Fire-and-forget — `wp.os.openWindow()` publishes here BEFORE deciding `opened` vs `reopened`. | `{ windowId, source }` | No. |
-| `desktop-mode/presence-changed` | Per-transition mirror of the `os-presence-changed` CustomEvent. | `{ userId, oldStatus, newStatus, lastSeenMs, lastActiveMs }` | No. |
-| `desktop-mode/presence-snapshot-applied` | Batch-level — fires after every presence snapshot OR `applyPresenceBatch()`. | `{ applied: number, transitions: number }` | No. |
-| `desktop-mode/game-score-recorded` | Fire-and-forget. Fires after a game's `submitScore()` write resolves, on both the free-play and challenge-completion paths. | `{ game, score, meta, windowId, challengeId? }` | No. |
+| `os/toast-requested` | Pre-show — `showToast()` calls run through this. | `{ message, action?, duration?, persistent?, source?, meta?, cancel? }` | **Yes.** Set `cancel: true` to drop the toast. Mutate `message`/`duration`/`action`/`persistent` to rewrite. |
+| `os/toast-shown` | Fire-and-forget — fires after the toast lands in the DOM. | Same shape as above. | No (filtering is too late). |
+| `os/window-attention-requested` | Pre-attention — `Window.requestAttention()` runs through this filter, then routes the filtered result to the rails' `setAttention()`; direct `dock.setAttention()` / `taskbar.setAttention()` calls bypass it. | `{ windowId, mode, durationMs?, intensity?, source?, cancel? }` | **Yes.** Set `cancel: true` for DND. Mutate `mode`/`durationMs`/`intensity` to scale the animation. |
+| `os/badge-changed` | Fire-and-forget — every `setBadge()` on dock / taskbar / icons mirrors here on every change. | `{ itemId, count, rail?: 'dock' \| 'taskbar' \| 'icon' }` *(rail)* | No. |
+| `os/open-requested` | Fire-and-forget — `wp.os.openWindow()` publishes here BEFORE deciding `opened` vs `reopened`. | `{ windowId, source }` | No. |
+| `os/presence-changed` | Per-transition mirror of the `os-presence-changed` CustomEvent. | `{ userId, oldStatus, newStatus, lastSeenMs, lastActiveMs }` | No. |
+| `os/presence-snapshot-applied` | Batch-level — fires after every presence snapshot OR `applyPresenceBatch()`. | `{ applied: number, transitions: number }` | No. |
+| `os/game-score-recorded` | Fire-and-forget. Fires after a game's `submitScore()` write resolves, on both the free-play and challenge-completion paths. | `{ game, score, meta, windowId, challengeId? }` | No. |
+| `os/upload-hud-complete` | Fire-and-forget. Fires when a file dropped on the shell finishes uploading. Published by the progress HUD rather than the uploader — the upload runs on XHR (the only transport reporting determinate progress) and never routes through `wp.os.fetch`. | `{ filename, attachmentId }` | No. |
 
 **Plugin channels** — pick a `<plugin>/<event>` slug and publish. Augment `ActivityChannelMap` for compile-time payload checking:
 
 ```ts
-declare module 'desktop-mode/activity' {
+import type {} from 'openstation/activity';
+
+declare module 'openstation/activity' {
     interface ActivityChannelMap {
         'my-plugin/something-happened': { id: number; reason: string };
     }
@@ -1896,7 +1899,7 @@ window.openStationGames[ 'my-plugin-puzzle' ] = {
 
 `render` receives a `GameLaunchContext`: `container` (the window body), `config` (the PHP-registered blob), `challenge` (set when the run is an accepted score-to-beat challenge: `{ id, scoreToBeat, scoreMeta, challengerName }`), `submitScore( { score, meta } )` (routes to the leaderboard, or to the challenge-completion endpoint in challenge mode), and `close()`. The framework suspends the wallpaper for the window's lifetime and opens the window as `os-game-<id>` (no dock tile).
 
-**Score announcements.** Once a `submitScore()` write resolves, the launcher publishes `desktop-mode/game-score-recorded` on the activity bus with `{ game, score, meta, windowId, challengeId? }` (both paths publish; `challengeId` only on challenge completion). Games play in their own window, so this is how leaderboards elsewhere in the shell find out they went stale: the hub's scoreboard subscribes and reloads the page the viewer is on. Subscribe to it if your plugin paints anything derived from scores. A failed write publishes nothing.
+**Score announcements.** Once a `submitScore()` write resolves, the launcher publishes `os/game-score-recorded` on the activity bus with `{ game, score, meta, windowId, challengeId? }` (both paths publish; `challengeId` only on challenge completion). Games play in their own window, so this is how leaderboards elsewhere in the shell find out they went stale: the hub's scoreboard subscribes and reloads the page the viewer is on. Subscribe to it if your plugin paints anything derived from scores. A failed write publishes nothing.
 
 **Framework config keys**. For server-registered games, the payload merges framework-level keys underneath the game's own `config` (the game's keys win): **`config.wordsUrl`** is the URL of the shared ~20k-word dictionary asset (`assets/games/words.txt`) — identical for every player, so seeded games (Alphabet Soup's date-seeded daily puzzle) generate the same grid worldwide. Parse it with the framework loader (`src/games/dictionary.ts` — `loadDictionary( url )` → `{ size, pick( minLen, maxLen, rng ) }`); the PHP-side URL + filter is `openstation_games_words_url` in [hooks-reference.md](./hooks-reference.md).
 
@@ -1994,7 +1997,7 @@ const clear = wp.os.showToast( {
 
 A `persistent` toast has no auto-dismiss timer — clear it via the action button (which dismisses on click), the close (×) button when `dismissible` is set, or the returned dismiss callback. `duration` is ignored when `persistent` is set.
 
-Routes through the `desktop-mode/toast-requested` activity filter before painting; plugins can register a filter that returns `null` (or sets `cancel: true`) to suppress, or mutates the payload to amplify / quiet the toast.
+Routes through the `os/toast-requested` activity filter before painting; plugins can register a filter that returns `null` (or sets `cancel: true`) to suppress, or mutates the payload to amplify / quiet the toast.
 
 ---
 
@@ -4908,7 +4911,7 @@ JS filter: `os.window.attention( mode, { windowId, opts } )`
 — return `null` to mute the request (Do Not Disturb integration).
 
 All three rails (`dock`, `sideDock`, `icons`) emit on the
-activity bus channel `desktop-mode/badge-changed` with payload
+activity bus channel `os/badge-changed` with payload
 `{ itemId, count, rail }`. The icon rail also fires
 `HOOKS.ICON_BADGE_CHANGED` on the hook bus with
 `{ iconId, count, previousCount }` for callers that only care
@@ -4945,7 +4948,7 @@ wp.os.icons.getBadge(   'os-messages' ); // → 0 (after clear)
 
 Every applied change publishes on:
 
-- `desktop-mode/badge-changed` activity channel with
+- `os/badge-changed` activity channel with
   `{ itemId, count, rail: 'icon' }`.
 - `HOOKS.ICON_BADGE_CHANGED` action with
   `{ iconId, count, previousCount }`.
@@ -5149,8 +5152,8 @@ wp.os.notify( {
 ```
 
 Routes through the activity-bus filter
-`desktop-mode/notification-requested` (return `cancel: true` to
-suppress) and broadcasts on `desktop-mode/notification-shown` after
+`os/notification-requested` (return `cancel: true` to
+suppress) and broadcasts on `os/notification-shown` after
 rendering.
 
 ### `wp.os.pwa.*` — programmatic install + permission control

--- a/docs/migration-activity-channels.md
+++ b/docs/migration-activity-channels.md
@@ -1,0 +1,78 @@
+# Migration: built-in activity channels move to the `os/` namespace
+
+**Status:** shipped in 0.9.9. Affects plugins that subscribe to, or filter, one of the framework's own activity channels.
+
+## What changed
+
+The eleven channels the shell publishes on the activity bus were named `desktop-mode/<event>`. That prefix predates the OpenStation rebranding; the hook prefix (`os.activity.`), the broadcast topics (`os.data-changed`, `os.post.changed`, …) and the global (`wp.os`) had already moved. The channels now match:
+
+| Before | After |
+|---|---|
+| `desktop-mode/toast-requested` | `os/toast-requested` |
+| `desktop-mode/toast-shown` | `os/toast-shown` |
+| `desktop-mode/notification-requested` | `os/notification-requested` |
+| `desktop-mode/notification-shown` | `os/notification-shown` |
+| `desktop-mode/window-attention-requested` | `os/window-attention-requested` |
+| `desktop-mode/badge-changed` | `os/badge-changed` |
+| `desktop-mode/open-requested` | `os/open-requested` |
+| `desktop-mode/presence-changed` | `os/presence-changed` |
+| `desktop-mode/presence-snapshot-applied` | `os/presence-snapshot-applied` |
+| `desktop-mode/game-score-recorded` | `os/game-score-recorded` |
+| `desktop-mode/upload-hud-complete` | `os/upload-hud-complete` |
+
+**There is no alias.** The old names are not published and not filtered. A subscriber still registered against `desktop-mode/badge-changed` stops firing silently, because an activity subscription for a channel nobody publishes is not an error.
+
+Payload shapes are unchanged. Only the channel slug moved.
+
+Two adjacent renames ride along, both internal and neither part of the channel contract: the `createSharedStore` key backing the presence store (`desktop-mode/presence` → `os/presence`) and the five **planned**, not-yet-published folder-sharing channels in [`folder-sharing.md`](./folder-sharing.md).
+
+## What to change
+
+Rename the slug at every `subscribe` / `publish` / `filter` call site:
+
+```diff
+-wp.os.activity.subscribe( 'desktop-mode/badge-changed', repaint );
++wp.os.activity.subscribe( 'os/badge-changed', repaint );
+```
+
+If you register through raw `wp.hooks` instead of the activity API, the hook name changes with it — the channel's separator is a period on the hook bus, so the shell's own segment is now `os` rather than `desktop-mode`:
+
+```diff
+ wp.hooks.addFilter(
+-    'os.activity.desktop-mode.notification-requested',
++    'os.activity.os.notification-requested',
+     'my-plugin/dnd',
+     ( intent ) => ( isDndActive() ? { ...intent, cancel: true } : intent ),
+ );
+```
+
+**Search your whole project, not just the channels in the table above.** A plugin-owned channel of your own that happens to start with `desktop-mode/` is yours and must NOT be renamed; a blanket find-and-replace across a project will move it and break your own subscribers. Rename the eleven slugs by name.
+
+### Typed payloads — the augmentation only works in module form
+
+`ActivityChannelMap` is declared in `openstation/activity`. Augmenting it requires the `.d.ts` to be a **module**, which means at least one top-level `import` or `export`. Without one, TypeScript reads the block as an *ambient module declaration* — it invents a new, empty `openstation/activity` that shadows the real one, and you silently get no payload checking and no error saying so:
+
+```diff
++import type {} from 'openstation/activity';
++
+-declare module 'desktop-mode/activity' {
++declare module 'openstation/activity' {
+     interface ActivityChannelMap {
+         'my-plugin/something-happened': { id: number; reason: string };
+     }
+ }
+```
+
+The specifier moved with the package name (`openstation`), and `./activity` is now a declared `exports` subpath so it actually resolves. The bare `import type {}` line is load-bearing — with it, `publish( 'my-plugin/something-happened', { id: 'x' } )` is a compile error; without it, that call typechecks.
+
+## What did NOT change
+
+- **Your own channels.** The convention is still `<plugin>/<event>`; nothing about plugin-owned slugs moved. `os/` is now the shell's namespace — subscribe and filter freely, but publish under your own slug.
+- **REST namespaces, options, tables, upload directories, cron hooks, post types, query vars and web-storage keys.** Everything reading `desktop-mode` / `desktop_mode_` there is frozen data that live installs already depend on, and it stays.
+- **Broadcast topics.** `wp.os.broadcast()` topics were already `os.*`.
+- **`wp.hooks` handler namespaces and `wp.os.fetch` `source:` tags.** Strings like `desktop-mode/commands-registry` (the second argument to `addAction`) and `source: 'desktop-mode/release-art'` still carry the old prefix. They are labels, not addresses — nothing subscribes by them — so they are a separate cosmetic pass rather than part of this contract change.
+
+## Reference
+
+- [The event-driven framework](./event-driven-framework.md#layer-3--activity-channels) — the full channel table.
+- [JS reference — `activity`](./javascript-reference.md) — payload shapes and the hook-name mapping.

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -117,9 +117,9 @@ off();
 
 Activity-bus channels for plugins that want to mute / amplify / audit:
 
-- `desktop-mode/notification-requested` — filterable; set
+- `os/notification-requested` — filterable; set
   `cancel: true` to suppress the underlying notification.
-- `desktop-mode/notification-shown` — fire-and-forget; carries
+- `os/notification-shown` — fire-and-forget; carries
   `fallback: 'toast' | null` so analytics can distinguish the
   permission-denied path from the real-notification path.
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
 			"import": "./src/public-api.ts",
 			"default": "./src/public-api.ts"
 		},
+		"./activity": {
+			"types": "./src/activity.ts",
+			"import": "./src/activity.ts",
+			"default": "./src/activity.ts"
+		},
 		"./global": {
 			"types": "./src/global.d.ts"
 		}

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -40,7 +40,9 @@ import {
  * Type-extension hook for plugin authors. Augment via:
  *
  * ```ts
- * declare module 'desktop-mode/activity' {
+ * import type {} from 'openstation/activity';
+ *
+ * declare module 'openstation/activity' {
  *     interface ActivityChannelMap {
  *         'my-plugin/something-happened': { id: number; reason: string };
  *     }
@@ -63,7 +65,7 @@ export interface ActivityChannelMap {
 	 * BEFORE the toast appears in the DOM; subscribers shouldn't
 	 * use this for "show another toast" or you'll loop.
 	 */
-	'desktop-mode/toast-requested': {
+	'os/toast-requested': {
 		message: string;
 		action?: { label: string; onClick: () => void };
 		duration?: number;
@@ -76,7 +78,7 @@ export interface ActivityChannelMap {
 	 * for audit / aggregation widgets. Filtering this is a no-op —
 	 * by the time it fires, the toast is on screen.
 	 */
-	'desktop-mode/toast-shown': {
+	'os/toast-shown': {
 		message: string;
 		action?: { label: string; onClick: () => void };
 		duration?: number;
@@ -89,7 +91,7 @@ export interface ActivityChannelMap {
 	 * (`cancel: true`), mutate fields, or audit before the
 	 * Notification surface (or its toast fallback) is rendered.
 	 */
-	'desktop-mode/notification-requested': {
+	'os/notification-requested': {
 		title: string;
 		body?: string;
 		icon?: string;
@@ -106,7 +108,7 @@ export interface ActivityChannelMap {
 	 * from "user explicitly hides nothing." `fallback: null` means
 	 * a real OS-level notification went up.
 	 */
-	'desktop-mode/notification-shown': {
+	'os/notification-shown': {
 		title: string;
 		body?: string;
 		icon?: string;
@@ -124,7 +126,7 @@ export interface ActivityChannelMap {
 	 * reduced-motion, mutate `mode` / `durationMs` / `intensity`
 	 * to scale the animation, or audit.
 	 */
-	'desktop-mode/window-attention-requested': {
+	'os/window-attention-requested': {
 		windowId: string;
 		mode: 'pulse' | 'shake' | 'bounce' | null;
 		durationMs?: number;
@@ -144,7 +146,7 @@ export interface ActivityChannelMap {
 	 * compose a unified count without duplicating logic per
 	 * surface.
 	 */
-	'desktop-mode/badge-changed': {
+	'os/badge-changed': {
 		itemId: string;
 		count: number;
 		/** Which rail painted the change. */
@@ -162,7 +164,7 @@ export interface ActivityChannelMap {
 	 * Useful for analytics + DND that want "user requested" rather
 	 * than "framework completed".
 	 */
-	'desktop-mode/open-requested': {
+	'os/open-requested': {
 		windowId: string;
 		source: string;
 	};
@@ -171,7 +173,7 @@ export interface ActivityChannelMap {
 	 * `os-presence-changed` CustomEvent on the activity
 	 * bus so plugins can subscribe through the unified API.
 	 */
-	'desktop-mode/presence-changed': {
+	'os/presence-changed': {
 		userId: number;
 		oldStatus: 'online' | 'inactive' | 'offline' | null;
 		newStatus: 'online' | 'inactive' | 'offline';
@@ -185,7 +187,7 @@ export interface ActivityChannelMap {
 	 * everything that depends on presence" callers that don't
 	 * need per-user granularity.
 	 */
-	'desktop-mode/presence-snapshot-applied': {
+	'os/presence-snapshot-applied': {
 		applied: number;
 		transitions: number;
 	};
@@ -201,12 +203,24 @@ export interface ActivityChannelMap {
 	 * completion (completing a challenge writes a leaderboard row
 	 * too). `challengeId` is set only on the latter.
 	 */
-	'desktop-mode/game-score-recorded': {
+	'os/game-score-recorded': {
 		game: string;
 		score: number;
 		meta: Record< string, string | number >;
 		windowId: string;
 		challengeId?: number;
+	};
+	/**
+	 * Framework: a file dropped on the shell finished uploading.
+	 * Published by the floating progress HUD rather than by the
+	 * uploader — the upload itself runs on XHR (the only transport
+	 * that reports determinate progress) and so never routes
+	 * through `wp.os.fetch`, which makes this the activity bus's
+	 * only view of a completed drop.
+	 */
+	'os/upload-hud-complete': {
+		filename: string;
+		attachmentId: number;
 	};
 	// Plugin channels go here. The catch-all index signature lets
 	// third-party plugins fall through without explicit type
@@ -288,7 +302,7 @@ export const activity: ActivityApi = {
 		doAction( hookName( channel ), payload );
 	},
 	subscribe( channel, cb ) {
-		const ns = `desktop-mode/activity-sub/${ ++subscribeSeq }`;
+		const ns = `os/activity-sub/${ ++subscribeSeq }`;
 		const hook = hookName( channel );
 		addAction( hook, ns, ( payload: unknown ) =>
 			( cb as ( p: unknown ) => void )( payload ),

--- a/src/desktop-icons.ts
+++ b/src/desktop-icons.ts
@@ -10,7 +10,7 @@
  * **Badge surface.** The icon rail mirrors the
  * dock + taskbar API exactly: `setBadge( id, count )` is
  * idempotent, `0` clears, `>99` renders `99+`. Every change emits
- * `desktop-mode/badge-changed` with `rail: 'icon'` on the activity
+ * `os/badge-changed` with `rail: 'icon'` on the activity
  * bus and {@link HOOKS.ICON_BADGE_CHANGED} on the hook bus, so a
  * plugin author writing one badge wrapper for all three rails
  * sees one consistent shape across every surface.
@@ -120,9 +120,9 @@ function _safeBadge( count: number ): number {
  *
  * On every applied change this fires:
  *
- *   - `desktop-mode/badge-changed` on the activity bus with
+ *   - `os/badge-changed` on the activity bus with
  *     `{ itemId, count, rail: 'icon' }`. Subscribe via
- *     `wp.os.activity.subscribe( 'desktop-mode/badge-changed', cb )`
+ *     `wp.os.activity.subscribe( 'os/badge-changed', cb )`
  *     for global notification-center widgets that aggregate
  *     across rails.
  *   - {@link HOOKS.ICON_BADGE_CHANGED} on the hook bus with
@@ -159,7 +159,7 @@ export function setIconBadge( iconId: string, count: number ): void {
 		_badges.set( iconId, safe );
 	}
 	_paintBadgeNode( tile, safe );
-	activity.publish( 'desktop-mode/badge-changed', {
+	activity.publish( 'os/badge-changed', {
 		itemId: iconId,
 		count: safe,
 		rail: 'icon',

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -455,7 +455,7 @@ export interface OpenStationPublicApi {
 	 * wp.os.icons.setBadge( 'os-messages', 0 );  // clear
 	 * ```
 	 *
-	 * Every change publishes `desktop-mode/badge-changed` on the
+	 * Every change publishes `os/badge-changed` on the
 	 * activity bus with `rail: 'icon'` (the same channel the dock
 	 * publishes to with `rail: 'dock'`), and fires
 	 * {@link HOOKS.ICON_BADGE_CHANGED} on the hook bus with
@@ -1617,7 +1617,7 @@ export interface OpenStationPublicApi {
 	 * was reporting changes (e.g. dismiss inbound-message toasts the
 	 * moment the chat window mounts).
 	 *
-	 * Routes through the `desktop-mode/toast-requested` activity filter
+	 * Routes through the `os/toast-requested` activity filter
 	 * before painting; plugins can mutate or cancel the payload.
 	 */
 	showToast: ( opts: ToastOptions ) => () => void;
@@ -1702,9 +1702,9 @@ export interface OpenStationPublicApi {
 	/**
 	 * Show a system notification (or fall back to a toast when
 	 * permission is denied / unsupported). Returns a dismiss
-	 * callback. Routes through `desktop-mode/notification-requested`
+	 * callback. Routes through `os/notification-requested`
 	 * (filterable) and broadcasts on
-	 * `desktop-mode/notification-shown` after rendering. v1 is
+	 * `os/notification-shown` after rendering. v1 is
 	 * page-scoped local notifications only — phase 4 will extend
 	 * this to Web Push without breaking the call surface.
 	 */

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -256,7 +256,7 @@ export class Dock {
 	/**
 	 * Routing discriminator stamped onto every event this rail
 	 * publishes. `'left'` orientation carries `'dock'`; `'bottom'`
-	 * carries `'taskbar'`. Lets a single `desktop-mode/badge-changed`
+	 * carries `'taskbar'`. Lets a single `os/badge-changed`
 	 * subscriber tell the two visually-distinct rails apart
 	 * without inferring from id space.
 	 */
@@ -617,7 +617,7 @@ export class Dock {
 		// Single emission point — activity bus. `rail` is the
 		// routing discriminator so a single subscriber can
 		// compose dock + taskbar + icons under one shape.
-		activity.publish( 'desktop-mode/badge-changed', {
+		activity.publish( 'os/badge-changed', {
 			itemId,
 			count: safe,
 			rail: this.rail,

--- a/src/games/launch.ts
+++ b/src/games/launch.ts
@@ -18,7 +18,7 @@
  *      stops — on EVERY close path: normal close, crash inside
  *      render, failed script load.
  *
- * A finished run also publishes `desktop-mode/game-score-recorded`
+ * A finished run also publishes `os/game-score-recorded`
  * on the activity bus so the Games hub's scoreboard (a different
  * window) can refresh itself.
  *
@@ -251,7 +251,7 @@ export async function launchGame(
 		result: GameScoreSubmission,
 		challengeId?: number,
 	): void => {
-		desktop.activity?.publish( 'desktop-mode/game-score-recorded', {
+		desktop.activity?.publish( 'os/game-score-recorded', {
 			game: id,
 			score: result.score,
 			meta: result.meta ?? {},

--- a/src/games/scoreboard.ts
+++ b/src/games/scoreboard.ts
@@ -11,7 +11,7 @@
  * Hosted by the Games hub's detail panel (Steam-library style):
  * one instance per selected game, torn down on re-selection.
  *
- * Refreshes itself when `desktop-mode/game-score-recorded` names
+ * Refreshes itself when `os/game-score-recorded` names
  * the mounted game, so a run finishing in the game's own window
  * repaints the board here without a re-selection or an F5.
  */
@@ -222,7 +222,7 @@ export function renderScoreboard(
 	// top, but yanking them off page 3 to show it is worse than
 	// leaving them where they were.
 	const unsubscribe = activity.subscribe(
-		'desktop-mode/game-score-recorded',
+		'os/game-score-recorded',
 		( payload ) => {
 			if ( disposed || payload?.game !== game.id ) {
 				return;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -825,7 +825,7 @@ export const HOOKS = {
 	 * and the dock/taskbar `os-dock-item-badge-changed` CustomEvent
 	 * — the icon rail's lifecycle hook for badge transitions.
 	 *
-	 * Mirrors `desktop-mode/badge-changed` on the activity bus with
+	 * Mirrors `os/badge-changed` on the activity bus with
 	 * `rail: 'icon'`. Subscribe to whichever surface fits — the
 	 * activity channel composes across rails for global widgets,
 	 * this hook fires only for icon-rail badges with the previous

--- a/src/native-windows.ts
+++ b/src/native-windows.ts
@@ -1286,7 +1286,7 @@ export function createNativeWindowSync(
 		// or "show coachmark on first open" hook this independent
 		// of the WINDOW_OPENED / WINDOW_REOPENED branch the
 		// framework will take next.
-		activity.publish( 'desktop-mode/open-requested', {
+		activity.publish( 'os/open-requested', {
 			windowId: id,
 			source: opts.source ?? 'api',
 		} );
@@ -1305,7 +1305,7 @@ export function createNativeWindowSync(
 		if ( ! entry ) {
 			return false;
 		}
-		activity.publish( 'desktop-mode/open-requested', {
+		activity.publish( 'os/open-requested', {
 			windowId: id,
 			source: opts.source ?? 'api',
 		} );

--- a/src/os-file-drop/progress-hud.ts
+++ b/src/os-file-drop/progress-hud.ts
@@ -238,7 +238,7 @@ function onComplete(
 	r.lingerTimer = setTimeout( () => dismissRow( r ), 2500 );
 	updateHeader();
 
-	activity.publish( 'desktop-mode/upload-hud-complete', {
+	activity.publish( 'os/upload-hud-complete', {
 		filename: fields.filename || result.filename,
 		attachmentId: result.id,
 	} );

--- a/src/os-file-drop/upload.ts
+++ b/src/os-file-drop/upload.ts
@@ -21,7 +21,7 @@
  * based fetch upload-progress proposal isn't yet broadly supported,
  * and our floating HUD needs determinate bars). Activity-bus
  * visibility comes from the progress HUD (`progress-hud.ts`
- * publishes `desktop-mode/upload-hud-complete` on completion) —
+ * publishes `os/upload-hud-complete` on completion) —
  * XHR doesn't route through `wp.os.fetch` by design.
  */
 

--- a/src/presence/index.ts
+++ b/src/presence/index.ts
@@ -18,7 +18,7 @@
  *   - **offline**  — no heartbeat in `_offline_after` seconds.
  *
  * **Storage.** A `createSharedStore` keyed by
- * `'desktop-mode/presence'` so any number of bundles can subscribe to
+ * `'os/presence'` so any number of bundles can subscribe to
  * the same map of `{ status, lastSeenMs, lastActiveMs }` per user.
  *
  * **Wire.** A jQuery-Heartbeat probe sends
@@ -51,7 +51,7 @@ interface HeartbeatBlock {
 }
 
 const store: SharedStore< PresenceState > = createSharedStore< PresenceState >(
-	'desktop-mode/presence',
+	'os/presence',
 	() => ( { byUser: new Map(), serverTimeMs: 0 } ),
 );
 
@@ -133,12 +133,12 @@ function applySnapshot( block: HeartbeatBlock ): void {
 		);
 		// Mirror the per-transition event onto activity so plugins
 		// subscribe through the unified API.
-		activity.publish( 'desktop-mode/presence-changed', detail );
+		activity.publish( 'os/presence-changed', detail );
 	}
 	// Batch-level activity event — useful for "repaint everything
 	// that depends on presence" subscribers that don't need
 	// per-user granularity.
-	activity.publish( 'desktop-mode/presence-snapshot-applied', {
+	activity.publish( 'os/presence-snapshot-applied', {
 		applied: Object.keys( block.snapshot ).length,
 		transitions: transitions.length,
 	} );
@@ -339,9 +339,9 @@ export function applyPresenceBatch(
 		document.dispatchEvent(
 			new CustomEvent( 'os-presence-changed', { detail } ),
 		);
-		activity.publish( 'desktop-mode/presence-changed', detail );
+		activity.publish( 'os/presence-changed', detail );
 	}
-	activity.publish( 'desktop-mode/presence-snapshot-applied', {
+	activity.publish( 'os/presence-snapshot-applied', {
 		applied: updates.length,
 		transitions: transitions.length,
 	} );

--- a/src/pwa/notify.ts
+++ b/src/pwa/notify.ts
@@ -19,7 +19,7 @@
  *     dismiss function (same shape as `showToast`) means callers
  *     never have to branch on permission state in their own code.
  *   - **Activity bus parity with toast.** Mirrors
- *     `desktop-mode/toast-requested` / `desktop-mode/toast-shown` —
+ *     `os/toast-requested` / `os/toast-shown` —
  *     plugins that want to mute, amplify, or audit notifications
  *     register a filter and get the same lifecycle they already
  *     know from the toast surface.
@@ -55,7 +55,7 @@ export interface NotifyOptions {
 }
 
 /**
- * Activity-bus payload routed through `desktop-mode/notification-requested`.
+ * Activity-bus payload routed through `os/notification-requested`.
  * Plugins filter on this to mute/amplify/cancel.
  */
 export interface NotifyIntent extends NotifyOptions {
@@ -88,7 +88,7 @@ export interface NotifyIntent extends NotifyOptions {
  */
 export function notify( options: NotifyOptions ): () => void {
 	const intent: NotifyIntent = activity.filter(
-		'desktop-mode/notification-requested',
+		'os/notification-requested',
 		{ ...options },
 	) as NotifyIntent;
 
@@ -119,7 +119,7 @@ export function notify( options: NotifyOptions ): () => void {
 				? intent.title + ' — ' + intent.body
 				: intent.title,
 		} );
-		activity.publish( 'desktop-mode/notification-shown', {
+		activity.publish( 'os/notification-shown', {
 			...intent,
 			fallback: 'toast',
 		} );
@@ -197,7 +197,7 @@ function renderNative( intent: NotifyIntent ): ( () => void ) | null {
 		};
 	}
 
-	activity.publish( 'desktop-mode/notification-shown', {
+	activity.publish( 'os/notification-shown', {
 		...intent,
 		fallback: null,
 	} );

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -69,7 +69,7 @@ export interface ToastOptions {
 
 /**
  * Toast intent payload routed through the
- * `desktop-mode/toast-requested` filter. Plugins can mutate the
+ * `os/toast-requested` filter. Plugins can mutate the
  * fields, set `cancel: true` to suppress the render, or pass
  * through unchanged. Caller-supplied `meta` carries the
  * publishing app's context — useful for filters that want to
@@ -95,7 +95,7 @@ export interface ToastIntent extends ToastOptions {
  * Show a toast. Returns a dismiss callback the caller can invoke
  * early (e.g., when the state the toast was reporting changes).
  *
- * Routes through `desktop-mode/toast-requested` activity filter
+ * Routes through `os/toast-requested` activity filter
  * before painting — plugins can register a filter that returns
  * `null` (or sets `cancel: true`) to suppress, or mutates the
  * payload to amplify / quiet the toast. Without a registered
@@ -104,7 +104,7 @@ export interface ToastIntent extends ToastOptions {
  */
 export function showToast( options: ToastOptions ): () => void {
 	const intent: ToastIntent = activity.filter(
-		'desktop-mode/toast-requested',
+		'os/toast-requested',
 		{ ...options },
 	) as ToastIntent;
 	if ( ! intent || intent.cancel === true ) {
@@ -198,7 +198,7 @@ function renderToast( intent: ToastIntent ): () => void {
 	// telemetry plugins subscribe; the toast renderer doesn't wait
 	// for these handlers (publish is synchronous but consumers
 	// shouldn't lean on that).
-	activity.publish( 'desktop-mode/toast-shown', { ...intent } );
+	activity.publish( 'os/toast-shown', { ...intent } );
 
 	return dismiss;
 }

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -2882,13 +2882,13 @@ export class Window {
 		opts: WindowAttentionOptions = {},
 	): void {
 		// Primary policy hook: plugins filter
-		// `desktop-mode/window-attention-requested` to cancel
+		// `os/window-attention-requested` to cancel
 		// (`cancel: true`) for DND modes / reduced-motion, scale
 		// `durationMs`/`intensity`, or audit. The pre-0.5.5
 		// `os.window.attention` filter still runs below
 		// for back-compat.
 		const intent = activity.filter(
-			'desktop-mode/window-attention-requested',
+			'os/window-attention-requested',
 			{
 				windowId: this.id,
 				mode,

--- a/tests/vitest/activity.test.ts
+++ b/tests/vitest/activity.test.ts
@@ -75,10 +75,10 @@ describe( 'wp.os.activity', () => {
 		// in a browser: `addAction` bails on an invalid name, and
 		// `doAction` still "succeeds" against zero handlers.
 		const cb = vi.fn();
-		activity.subscribe( 'desktop-mode/game-score-recorded', cb );
+		activity.subscribe( 'os/game-score-recorded', cb );
 		// Reaching the same channel by its raw hook name proves the
 		// mapping, not just that publish/subscribe agree with itself.
-		doAction( 'os.activity.desktop-mode.game-score-recorded', {
+		doAction( 'os.activity.os.game-score-recorded', {
 			game: 'inkfall',
 		} );
 		expect( cb ).toHaveBeenCalledWith( { game: 'inkfall' } );

--- a/tests/vitest/desktop-icons-badge.test.ts
+++ b/tests/vitest/desktop-icons-badge.test.ts
@@ -80,7 +80,7 @@ describe( 'wp.os.icons.setBadge', () => {
 	test( 'is idempotent — same count does not emit twice', () => {
 		mountGrid( [ makeIcon() ] );
 		const cb = vi.fn();
-		const off = activity.subscribe( 'desktop-mode/badge-changed', cb );
+		const off = activity.subscribe( 'os/badge-changed', cb );
 		setIconBadge( 'os-messages', 5 );
 		setIconBadge( 'os-messages', 5 );
 		expect( cb ).toHaveBeenCalledTimes( 1 );
@@ -104,17 +104,17 @@ describe( 'wp.os.icons.setBadge', () => {
 	test( 'silent no-op when the id is not on the rail', () => {
 		mountGrid( [ makeIcon() ] );
 		const cb = vi.fn();
-		const off = activity.subscribe( 'desktop-mode/badge-changed', cb );
+		const off = activity.subscribe( 'os/badge-changed', cb );
 		setIconBadge( 'never-registered', 5 );
 		expect( cb ).not.toHaveBeenCalled();
 		expect( getIconBadge( 'never-registered' ) ).toBe( 0 );
 		off();
 	} );
 
-	test( 'publishes desktop-mode/badge-changed with rail: "icon"', () => {
+	test( 'publishes os/badge-changed with rail: "icon"', () => {
 		mountGrid( [ makeIcon() ] );
 		const cb = vi.fn();
-		const off = activity.subscribe( 'desktop-mode/badge-changed', cb );
+		const off = activity.subscribe( 'os/badge-changed', cb );
 		setIconBadge( 'os-messages', 7 );
 		expect( cb ).toHaveBeenCalledWith( {
 			itemId: 'os-messages',

--- a/tests/vitest/dock-badge.test.ts
+++ b/tests/vitest/dock-badge.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for `Dock.setBadge` — the rail discriminator on the
- * `desktop-mode/badge-changed` activity channel and the
+ * `os/badge-changed` activity channel and the
  * client-override map that lets `replaceItems()` (live menu
  * refresh) preserve a badge a plugin had already set.
  *
@@ -63,7 +63,7 @@ describe( 'Dock.setBadge — rail discriminator', () => {
 	test( 'left orientation publishes rail: "dock"', () => {
 		const { dock } = mount( [ makeItem() ], 'left' );
 		const cb = vi.fn();
-		const off = activity.subscribe( 'desktop-mode/badge-changed', cb );
+		const off = activity.subscribe( 'os/badge-changed', cb );
 		dock.setBadge( 'plugin-x', 4 );
 		expect( cb ).toHaveBeenCalledWith( {
 			itemId: 'plugin-x',
@@ -76,7 +76,7 @@ describe( 'Dock.setBadge — rail discriminator', () => {
 	test( 'bottom orientation publishes rail: "taskbar"', () => {
 		const { dock } = mount( [ makeItem() ], 'bottom' );
 		const cb = vi.fn();
-		const off = activity.subscribe( 'desktop-mode/badge-changed', cb );
+		const off = activity.subscribe( 'os/badge-changed', cb );
 		dock.setBadge( 'plugin-x', 2 );
 		expect( cb ).toHaveBeenCalledWith( {
 			itemId: 'plugin-x',
@@ -89,7 +89,7 @@ describe( 'Dock.setBadge — rail discriminator', () => {
 	test( 'silently no-ops for an id not on this rail', () => {
 		const { dock } = mount( [ makeItem() ], 'left' );
 		const cb = vi.fn();
-		const off = activity.subscribe( 'desktop-mode/badge-changed', cb );
+		const off = activity.subscribe( 'os/badge-changed', cb );
 		dock.setBadge( 'never-on-this-rail', 5 );
 		expect( cb ).not.toHaveBeenCalled();
 		off();

--- a/tests/vitest/games-launch.test.ts
+++ b/tests/vitest/games-launch.test.ts
@@ -298,7 +298,7 @@ describe( 'games/launch.ts', () => {
 		await capturedCtx!.submitScore( { score: 42, meta: { wpm: 61 } } );
 
 		expect( fake.activity.publish ).toHaveBeenCalledWith(
-			'desktop-mode/game-score-recorded',
+			'os/game-score-recorded',
 			{
 				game: 'test-game',
 				score: 42,
@@ -374,7 +374,7 @@ describe( 'games/launch.ts', () => {
 		await capturedCtx!.submitScore( { score: 120 } );
 
 		expect( fake.activity.publish ).toHaveBeenCalledWith(
-			'desktop-mode/game-score-recorded',
+			'os/game-score-recorded',
 			expect.objectContaining( { game: 'test-game', challengeId: 7 } ),
 		);
 	} );

--- a/tests/vitest/games-scoreboard.test.ts
+++ b/tests/vitest/games-scoreboard.test.ts
@@ -89,7 +89,7 @@ describe( 'games/scoreboard.ts', () => {
 			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 ),
 		);
 
-		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+		activity.activity.publish( 'os/game-score-recorded', {
 			game: 'inkfall',
 			score: 42,
 			meta: {},
@@ -109,7 +109,7 @@ describe( 'games/scoreboard.ts', () => {
 			expect( fetchScoresSpy ).toHaveBeenCalledTimes( 1 ),
 		);
 
-		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+		activity.activity.publish( 'os/game-score-recorded', {
 			game: 'alphabet-soup',
 			score: 42,
 			meta: {},
@@ -142,7 +142,7 @@ describe( 'games/scoreboard.ts', () => {
 			),
 		);
 
-		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+		activity.activity.publish( 'os/game-score-recorded', {
 			game: 'inkfall',
 			score: 42,
 			meta: {},
@@ -167,7 +167,7 @@ describe( 'games/scoreboard.ts', () => {
 		);
 
 		teardown();
-		activity.activity.publish( 'desktop-mode/game-score-recorded', {
+		activity.activity.publish( 'os/game-score-recorded', {
 			game: 'inkfall',
 			score: 42,
 			meta: {},

--- a/tests/vitest/my-wordpress-bulk-actions.test.ts
+++ b/tests/vitest/my-wordpress-bulk-actions.test.ts
@@ -77,7 +77,7 @@ async function load(): Promise< BulkModule > {
 	// The channel's slash is sanitized to a dot on its way to
 	// `wp.hooks` (see `hookName()` in `src/activity.ts`).
 	addFilter(
-		'os.activity.desktop-mode.toast-requested',
+		'os.activity.os.toast-requested',
 		'test/capture',
 		( intent: { message?: string } ) => {
 			toasts.push( String( intent?.message ?? '' ) );


### PR DESCRIPTION
Renames the eleven activity channels the shell publishes from `desktop-mode/<event>` to `os/<event>`. Leftover from the OpenStation rebranding, which moved the hook prefix (`os.activity.`), the broadcast topics and the `wp.os` global but left the channel names behind.

No alias ships, so a plugin left on an old name stops firing silently. Adds `docs/migration-activity-channels.md`.

Two doc bugs turned up on the way:

* The documented hook name said `desktop-mode.activity.<channel>`. The real prefix has been `os.activity.` since the rebrand.
* The `ActivityChannelMap` augmentation snippet never worked. It shadowed the real module instead of augmenting it, so authors got no payload checking and no error saying so. Fixed with a top-level `import type {}` and an `./activity` `exports` subpath.

Also converts the two ASCII diagrams in `docs/event-driven-framework.md` to Mermaid.

## Testing instructions

1. `npm run build && npm run lint && npm run typecheck && npm run test:js`. Make sure all pass.
2. Sync to a local install (`./bin/sync-to-wp-develop.sh`), open the desktop, and paste this in the console:

```js
[ 'toast-shown', 'badge-changed', 'open-requested', 'upload-hud-complete' ]
    .forEach( ( c ) => wp.os.activity.subscribe( `os/${ c }`, ( p ) => console.log( c, p ) ) );
wp.os.activity.subscribe( 'desktop-mode/badge-changed', () => console.error( 'OLD NAME FIRED' ) );
```

3. `wp.os.showToast( { message: 'hi' } )`. Make sure the toast appears and `toast-shown` logs.
4. `wp.os.dock.setBadge( 'desktop-mode-recycle-bin', 3 )`. Make sure the tile shows `3` and `badge-changed` logs.
5. `wp.os.openWindow( 'desktop-mode-recycle-bin' )`. Make sure `open-requested` logs.
6. Drag a file onto the wallpaper and upload it. Make sure the progress HUD runs and `upload-hud-complete` logs.
7. Make sure `OLD NAME FIRED` never appears.
8. Open `docs/event-driven-framework.md` on GitHub. Make sure both Mermaid diagrams render.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-512-ad79e9638c3a11e199d3866af14d730c5361fb73.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
