### PR TITLE
Segmented control: Fix the selected pill size on first paint

### DIFF
--- a/src/ui/components/os-segmented/os-segmented.test.ts
+++ b/src/ui/components/os-segmented/os-segmented.test.ts
@@ -68,11 +68,34 @@ describe( '<os-segmented> + <os-segment>', () => {
 	 * jsdom has no layout, so every box measures zero. These give the
 	 * group and its segments a pretend geometry: the group starts at
 	 * x=100 with 3px of padding, and three 60px segments sit inside it.
+	 *
+	 * `scale` stands in for an ancestor transform — every reading comes
+	 * back multiplied, exactly as getBoundingClientRect reports it.
+	 *
+	 * `offsetWidth` is set too, and separately from the host rect: the
+	 * component divides one by the other, and in a browser the first is
+	 * integer-rounded while the second is not. Leaving it at jsdom's 0
+	 * is what an unlaid-out group looks like, so a test that wants a
+	 * measurable group has to opt in here.
 	 */
-	function layOut( group: Element ): void {
-		const rect = ( left: number, width: number ) =>
-			( { left, width, right: left + width, top: 0, bottom: 24, height: 24, x: left, y: 0, toJSON: () => ( {} ) } ) as DOMRect;
-		group.getBoundingClientRect = () => rect( 100, 189 );
+	function layOut(
+		group: Element,
+		{
+			scale = 1,
+			hostWidth = 189,
+			offsetWidth = 189,
+		}: { scale?: number; hostWidth?: number; offsetWidth?: number } = {},
+	): void {
+		const rect = ( left: number, width: number ) => {
+			const l = left * scale;
+			const w = width * scale;
+			return { left: l, width: w, right: l + w, top: 0, bottom: 24, height: 24, x: l, y: 0, toJSON: () => ( {} ) } as DOMRect;
+		};
+		group.getBoundingClientRect = () => rect( 100, hostWidth );
+		Object.defineProperty( group, 'offsetWidth', {
+			configurable: true,
+			value: offsetWidth,
+		} );
 		const segs = Array.from( group.querySelectorAll( ':scope > os-segment' ) );
 		segs.forEach( ( seg, i ) => {
 			seg.getBoundingClientRect = () => rect( 103 + i * 62, 60 );
@@ -128,6 +151,97 @@ describe( '<os-segmented> + <os-segment>', () => {
 
 		// Third segment: 103 + 124 = 227, minus 100.
 		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '127px' );
+	} );
+
+	test( 'a fractional layout width does not drift the thumb off the segment', async () => {
+		// The production case: no transform anywhere, but offsetWidth is
+		// integer-rounded and the group is inline-flex and content-sized,
+		// so its real width is fractional. The ratio between the two is
+		// therefore never quite 1, and dividing by it would walk the pill
+		// off its label by a fraction of a pixel on every group in the
+		// app — the same sub-pixel class the rounding below guards.
+		host.innerHTML = `
+			<os-segmented value="c">
+				<os-segment value="a">A</os-segment>
+				<os-segment value="b">B</os-segment>
+				<os-segment value="c">C</os-segment>
+			</os-segmented>
+		`;
+		await tick();
+		const group = host.querySelector( 'os-segmented' ) as HTMLElement;
+		// 189.4 / 189 = 1.0021…, which is rounding, not a transform.
+		layOut( group, { hostWidth: 189.4, offsetWidth: 189 } );
+
+		group.setAttribute( 'value', 'c' );
+		( group as HTMLElement & { value: string } ).value = 'c';
+		await tick();
+		await tick();
+
+		// The rect readings, untouched: third segment at 103 + 124 = 227,
+		// minus the group's own 100.
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '127px' );
+		expect( group.style.getPropertyValue( '--_thumb-w' ) ).toBe( '60px' );
+	} );
+
+	test( 'the thumb ignores an ancestor scale instead of shrinking with it', async () => {
+		// A window playing `os-window--opening` is mid `scale(0.92)` on
+		// the frame the panel first renders. getBoundingClientRect reads
+		// the shrunken boxes; offsetWidth does not. Without dividing the
+		// scale back out the pill lands narrow and left of its label and
+		// stays there, because a transform never resizes the border box
+		// and so never wakes the ResizeObserver.
+		host.innerHTML = `
+			<os-segmented value="b">
+				<os-segment value="a">A</os-segment>
+				<os-segment value="b">B</os-segment>
+				<os-segment value="c">C</os-segment>
+			</os-segmented>
+		`;
+		await tick();
+		const group = host.querySelector( 'os-segmented' ) as HTMLElement;
+		layOut( group, { scale: 0.92 } );
+
+		group.setAttribute( 'value', 'b' );
+		( group as HTMLElement & { value: string } ).value = 'b';
+		await tick();
+		await tick();
+
+		// Identical to the untransformed case: the thumb is placed in
+		// the group's own coordinates, which the transform does not move.
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '65px' );
+		expect( group.style.getPropertyValue( '--_thumb-w' ) ).toBe( '60px' );
+	} );
+
+	test( 'a collapsed ancestor keeps the last placement instead of hiding the thumb', async () => {
+		// scale(0) makes every rect zero, which is indistinguishable from
+		// "never laid out" if you test the rect. Hiding here would be
+		// permanent — nothing re-measures when a transform ends — so the
+		// last good geometry has to survive it.
+		host.innerHTML = `
+			<os-segmented value="b">
+				<os-segment value="a">A</os-segment>
+				<os-segment value="b">B</os-segment>
+				<os-segment value="c">C</os-segment>
+			</os-segmented>
+		`;
+		await tick();
+		const group = host.querySelector( 'os-segmented' ) as HTMLElement;
+		layOut( group );
+		( group as HTMLElement & { value: string } ).value = 'b';
+		await tick();
+		await tick();
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '65px' );
+
+		// The group collapses; offsetWidth is untouched by the transform.
+		layOut( group, { scale: 0 } );
+		group.setAttribute( 'value', 'b' );
+		( group as HTMLElement & { value: string } ).value = 'b';
+		await tick();
+		await tick();
+
+		expect( group.hasAttribute( 'data-thumb' ) ).toBe( true );
+		expect( group.style.getPropertyValue( '--_thumb-x' ) ).toBe( '65px' );
+		expect( group.style.getPropertyValue( '--_thumb-w' ) ).toBe( '60px' );
 	} );
 
 	test( 'an unmeasurable group hides the thumb rather than smearing it at the origin', async () => {

--- a/src/ui/components/os-segmented/os-segmented.ts
+++ b/src/ui/components/os-segmented/os-segmented.ts
@@ -161,11 +161,11 @@ export class OsSegmented extends Component {
 	 * two differ, and the pill would sit a border-width off — visible
 	 * on exactly the themes that add one.
 	 *
-	 * A zero-width measurement means the group has not been laid out
-	 * yet (display:none, a collapsed panel, a tab that has never been
-	 * opened). Leaving the thumb hidden is right in every one of those
-	 * cases; the ResizeObserver brings it back the moment there is a
-	 * box to measure.
+	 * `offsetWidth` is the not-laid-out test rather than a zero-width
+	 * rect (display:none, a collapsed panel, a tab that has never been
+	 * opened). It is transform-immune, so a group measured under a
+	 * near-zero scale is not mistaken for one of those and hidden for
+	 * good — a transform change does not wake the ResizeObserver.
 	 */
 	private _placeThumb(): void {
 		const thumb = this.shadowRoot?.querySelector(
@@ -178,14 +178,39 @@ export class OsSegmented extends Component {
 		const selected = Array.from(
 			this.querySelectorAll( ':scope > os-segment' ),
 		).find( ( el ) => el.getAttribute( 'value' ) === current );
-		const box = selected?.getBoundingClientRect();
-		if ( ! box || box.width === 0 ) {
+		if ( ! selected || this.offsetWidth === 0 ) {
 			this.removeAttribute( 'data-thumb' );
 			return;
 		}
 		const host = this.getBoundingClientRect();
-		this.style.setProperty( '--_thumb-x', `${ box.left - host.left }px` );
-		this.style.setProperty( '--_thumb-w', `${ box.width }px` );
+		// Rects come back through every ancestor transform, and a group
+		// is routinely measured inside one: a window plays
+		// `os-window--opening` (scale 0.92 to 1) while the panel renders.
+		// `offsetWidth` is the untransformed border box, so their ratio
+		// maps the reading back into the group's own coordinates, which
+		// is the space the thumb is positioned in. A transform never
+		// resizes the border box, so the ResizeObserver would not fix
+		// this up when the animation lands.
+		const raw = host.width / this.offsetWidth;
+		// offsetWidth is integer-rounded and the group is content-sized,
+		// so its laid-out width is nearly always fractional and the ratio
+		// lands a hair off 1 with no transform in play at all. Treat that
+		// band as 1: 0.02 sits above the rounding error for any realistic
+		// group width and well below the animation's 0.08.
+		const scale = Math.abs( raw - 1 ) < 0.02 ? 1 : raw;
+		if ( ! ( scale > 0 ) ) {
+			// A fully collapsed ancestor. There is nothing to divide by,
+			// and no event will bring us back, so keep the last good
+			// placement rather than hide a thumb that would never return.
+			return;
+		}
+		const box = selected.getBoundingClientRect();
+		// Two decimals keeps the pill on the sub-pixel edge the browser
+		// laid the segment on, without the float noise the division
+		// leaves behind (65.00000000000001px).
+		const px = ( v: number ) => `${ Math.round( v * 100 ) / 100 }px`;
+		this.style.setProperty( '--_thumb-x', px( ( box.left - host.left ) / scale ) );
+		this.style.setProperty( '--_thumb-w', px( box.width / scale ) );
 		this.setAttribute( 'data-thumb', '' );
 		// One frame later than the first placement, so the pill does
 		// not animate in from the origin on page load. See the note on


### PR DESCRIPTION
## Proposed Changes

Fixes the lit pill behind the selected option in a segmented control rendering smaller than its label on first paint, so the text overhangs it on both sides. Visible on OpenStation Preferences > Appearance (Desktop layout, Dock size, Window corners, Admin bar). Picking any option corrects it, and it stays correct.

Before | After
--- | ---
<img width="806" height="486" alt="Screenshot 2026-08-06 at 17 47 14" src="https://github.com/user-attachments/assets/1fab3eef-22c4-4c2f-ab0d-35bbde49d006" /> | <img width="802" height="478" alt="Screenshot 2026-08-06 at 17 59 19" src="https://github.com/user-attachments/assets/bb9d17e3-cca4-4ce1-876a-c4f4aa51e4f6" />


## Why are these changes being made?

Because the UI looked broken.

## Testing Instructions

1. Load `/wp-admin` and open `OpenStation Preferences` from the dock, then the `Appearance` tab.
2. Without clicking anything, make sure the lit pill wraps its label exactly on `Desktop layout`, `Dock size` and `Window corners`. The label must not stick out on either side.
3. Scroll to `Admin bar` further down the tab and make sure the same holds there.
4. Close the window and reopen it five or six times. Make sure the pill is right on every open, not just some.
5. Click through the options in each control. Make sure the pill slides across and lands wrapping the new label.
6. Drag the window's bottom-right corner to make the panel reflow. Make sure the pill follows its label.
7. Reload the page so the session restores the window. Make sure the pills are still right.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-515-76dbeb4a461e45dbe8d62136f9e3c4d0d56ead3f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->