### PR TITLE
Docs: Fill the filter reference gaps, and drop the brand-map filter

### DIFF
--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -193,6 +193,19 @@ shared-store + registries. Index:
 | `desktop-mode/agents-chat` shared-store key + `desktop-mode-agent-run` window | [`javascript-reference.md`](./javascript-reference.md#ai-agents--client-surface-experimental) | Experimental |
 | `agent` WP Explorer entity kind | `registerEntityKind()` seam | Experimental |
 
+### WooCommerce integration *(Experimental — inert unless WooCommerce is active)*
+
+No `wp.os.woo` namespace. The surface is PHP filters + REST + a
+native window, all hanging off WP Explorer. Index:
+
+| Surface | Where | Status |
+|---|---|---|
+| What the integration renders, and why | [`plugin-compat-layer.md`](./plugin-compat-layer.md#the-site-window-side-woocommerce) | Experimental |
+| `openstation_my_wordpress_woo_*` filters (orders, products, coupons, store, summaries, customers) | [`hooks-reference.md`](./hooks-reference.md#woocommerce-integration--experimental-filters) | Experimental |
+| `desktop-mode/v1/woocommerce/{orders, store, summary/<type>/<id>, customers, customers/<id>}` | `includes/my-wordpress/integrations/` | Experimental |
+| `openstation_woo_customer` REST field on the core `user` resource | [`hooks-reference.md`](./hooks-reference.md#customers) | Experimental |
+| `desktop-mode-woo-customer` native window *(retargetable singleton, `customerId` param)* | [`hooks-reference.md`](./hooks-reference.md#the-customer-window) | Experimental |
+
 ## CustomEvents on `document`
 
 Every event bubbles from `document`. See [`javascript-reference.md`](./javascript-reference.md#1-customevents) for `detail` shapes.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1034,6 +1034,20 @@ Return `false` to suppress the dialog — useful for managed-host onboarding flo
 
 ---
 
+### `openstation_brand_migration_map` — Experimental
+
+The pre-brand to brand value map the one-time rebrand migration applies, keyed by OS-settings field. Each entry is `array( 'from' => <old default>, 'to' => <new default> )`. The default map moves `accent` from `wp-blue` to `pulse`, and `wallpaper` from `dark` to `galaxy`.
+
+```php
+apply_filters( 'openstation_brand_migration_map', array $map );
+```
+
+The migration exists because the stored OS-settings snapshot outranks the shipped default, so changing the default alone reaches new accounts and nobody else. Only a value still equal to its `from` entry is rewritten: a user who picked Indigo, or the Snow wallpaper, expressed a preference and keeps it, and users with no stored settings are skipped entirely because they already read the new defaults.
+
+Return an empty array to skip the migration and leave every stored preference alone. Adding entries is how a plugin that shipped its own pre-brand defaults can ride the same pass.
+
+---
+
 ### `openstation_shell_config` — Stable
 
 The JS configuration blob injected as `window.openStationConfig`. Powers the window manager, dock, and session restore. Filter this to inject custom payloads the shell can read at boot.
@@ -1632,6 +1646,20 @@ The list of plugin files to cascade-deactivate when OpenStation itself is deacti
 ```php
 apply_filters( 'openstation_cascade_deactivate_dependents', string[] $dependents, string $slug );
 ```
+
+---
+
+### `openstation_track_type_registrants` — Experimental
+
+Whether this request records which plugin, mu-plugin or theme registered each non-builtin post type and taxonomy. Defaults to `is_admin()`.
+
+```php
+apply_filters( 'openstation_track_type_registrants', bool $track );
+```
+
+The recorded map is what lets the dock offer `Deactivate <plugin>` on a menu item, and what files a custom post type under its plugin's folder in WP Explorer (see [`openstation_my_wordpress_post_type_group`](#openstation_my_wordpress_post_type_group--experimental-filter)). Both consumers are admin-side, so the gate is admin-side too.
+
+Recording costs one bounded `debug_backtrace()` per non-builtin type registration, and a front-end page view registers exactly the same types (WooCommerce alone brings several) for a map nothing there reads. Return `true` on the front end only if something there does read it.
 
 ---
 
@@ -3219,6 +3247,32 @@ Active only when WooCommerce is. See
 [Plugin compat layer](./plugin-compat-layer.md#the-site-window-side-woocommerce)
 for what the integration does and why.
 
+Every filter here is Experimental. The integration is young and its
+payload shapes are still moving, so treat the argument lists as
+liable to grow. Index, in the order they are documented below:
+
+| Filter | Shapes |
+|---|---|
+| `openstation_my_wordpress_woo_order_args` | the `wc_get_orders()` args behind the Orders section |
+| `openstation_my_wordpress_woo_summary` | the merchant summary rendered in the right pane |
+| `openstation_my_wordpress_woo_summary_type` | the summary payload for a type the plugin doesn't know |
+| `openstation_my_wordpress_woo_summary_capability` | who may read a summary of that type |
+| `openstation_my_wordpress_woo_store` | the store headline numbers on the Woo folder |
+| `openstation_my_wordpress_woo_order_bands` | the status bands the Orders section groups by |
+| `openstation_my_wordpress_woo_product_bands` | the stock / category bands the Products section groups by |
+| `openstation_my_wordpress_woo_coupon_bands` | the bands the Coupons section groups by |
+| `openstation_my_wordpress_woo_section_icons` | post type slug to dashicon for the Woo sections |
+| `openstation_my_wordpress_woo_customer_spend_map` | the per-customer order aggregate the Customers section is built from |
+| `openstation_my_wordpress_woo_customer_bands` | the bands the Customers section groups by |
+| `openstation_my_wordpress_woo_customer_band` | which band one aggregate lands in |
+| `openstation_my_wordpress_woo_vip_threshold` | the spend a customer clears to count as VIP |
+| `openstation_my_wordpress_woo_customer_lapse_days` | how long since the last order counts as lapsed |
+| `openstation_my_wordpress_woo_customer_ids` | the candidate set the Customers section draws from |
+| `openstation_my_wordpress_woo_customer_query_args` | the `WP_User_Query` args behind the customers route |
+| `openstation_my_wordpress_woo_customer_facts` | the fact payload carried on every customer row |
+| `openstation_my_wordpress_woo_customer_window_template_html` | the Customer window's static template body |
+| `openstation_my_wordpress_woo_customer_window_args` | the Customer window's registration args |
+
 ```php
 apply_filters( 'openstation_my_wordpress_woo_order_args', array $args, WP_REST_Request $request ): array
 ```
@@ -3288,6 +3342,20 @@ uncategorised catch-all. Each entry declares `id`, `label`, `order`,
 and one matcher — `stock` (a stock-status slug) or `category` (a term
 slug). Stock bands win over category bands, so an empty shelf surfaces
 wherever the product is filed.
+
+```php
+apply_filters( 'openstation_my_wordpress_woo_coupon_bands', array[] $bands ): array[]
+```
+
+The bands the Coupons section groups tiles into, ordered so the codes
+still worth handing out come first: `coupon:active`,
+`coupon:expiring`, `coupon:used-up`, `coupon:expired`. Each entry
+declares `id`, `label`, `order`, and an optional `tone` (`warn` on
+expiring, `danger` on a code that has hit its usage limit).
+
+Membership is not filterable, unlike the customer bands: a coupon is
+expiring within 30 days of its expiry date, used-up once its usage
+count reaches its usage limit, and expired once the date has passed.
 
 ```php
 apply_filters( 'openstation_my_wordpress_woo_section_icons', array $icons ): array

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1034,20 +1034,6 @@ Return `false` to suppress the dialog — useful for managed-host onboarding flo
 
 ---
 
-### `openstation_brand_migration_map` — Experimental
-
-The pre-brand to brand value map the one-time rebrand migration applies, keyed by OS-settings field. Each entry is `array( 'from' => <old default>, 'to' => <new default> )`. The default map moves `accent` from `wp-blue` to `pulse`, and `wallpaper` from `dark` to `galaxy`.
-
-```php
-apply_filters( 'openstation_brand_migration_map', array $map );
-```
-
-The migration exists because the stored OS-settings snapshot outranks the shipped default, so changing the default alone reaches new accounts and nobody else. Only a value still equal to its `from` entry is rewritten: a user who picked Indigo, or the Snow wallpaper, expressed a preference and keeps it, and users with no stored settings are skipped entirely because they already read the new defaults.
-
-Return an empty array to skip the migration and leave every stored preference alone. Adding entries is how a plugin that shipped its own pre-brand defaults can ride the same pass.
-
----
-
 ### `openstation_shell_config` — Stable
 
 The JS configuration blob injected as `window.openStationConfig`. Powers the window manager, dock, and session restore. Filter this to inject custom payloads the shell can read at boot.

--- a/includes/migrations.php
+++ b/includes/migrations.php
@@ -323,29 +323,21 @@ function openstation_should_show_rebrand_notice() {
  * @return void
  */
 function openstation_migrate_brand_defaults() {
-	/**
-	 * Filters the pre-brand => brand value map the rebrand migration
-	 * applies, keyed by OS-settings field. Return an empty array to skip
-	 * the migration entirely and leave every stored preference alone.
-	 *
-	 * @param array $map Map of setting key => array( 'from' => old, 'to' => new ).
-	 */
-	$map = (array) apply_filters(
-		'openstation_brand_migration_map',
-		array(
-			'accent'    => array(
-				'from' => 'wp-blue',
-				'to'   => 'pulse',
-			),
-			'wallpaper' => array(
-				'from' => 'dark',
-				'to'   => 'galaxy',
-			),
-		)
+	// The pre-brand => brand value map, keyed by OS-settings field.
+	// Deliberately not filterable: this runs once, against one release's
+	// stored defaults, and a third party rewriting which values get
+	// migrated would leave desks in a state no later migration accounts
+	// for.
+	$map = array(
+		'accent'    => array(
+			'from' => 'wp-blue',
+			'to'   => 'pulse',
+		),
+		'wallpaper' => array(
+			'from' => 'dark',
+			'to'   => 'galaxy',
+		),
 	);
-	if ( empty( $map ) ) {
-		return;
-	}
 
 	$user_ids = get_users(
 		array(


### PR DESCRIPTION
## Proposed Changes

* Documents three filters that were fired but never reached `docs/hooks-reference.md`: `openstation_brand_migration_map`, `openstation_track_type_registrants` and `openstation_my_wordpress_woo_coupon_bands`.
* Adds an index table at the head of the WooCommerce section listing all nineteen `openstation_my_wordpress_woo_*` filters and what each one shapes.
* Adds a WooCommerce block to `docs/api-index.md` pointing at the filters, the REST routes, the `openstation_woo_customer` REST field and the Customer window.

Docs only, no code changes.

## Why are these changes being made?

Because the three filters carry full `@param` docblocks, so they read as public API, but a plugin author had no way to find them.

The rest of the WooCommerce filters were already written up, but only as bare signatures grouped under one heading, with no backticked hook name anywhere. Searching the doc for a hook name returned nothing, and there was no anchor to link to. The index table fixes both without rewriting the prose that was already there.

## Testing Instructions

This is a docs-only change, so the check is that nothing fired is missing from the contract.

1. Check out the branch and run:

```bash
git grep -h -A1 -E "(apply_filters|do_action)\(" HEAD | grep -oE "'(openstation)_[a-z0-9_]+'" | tr -d "'" | sort -u > /tmp/now.txt
git grep -h -A1 -E "(apply_filters|do_action)\(" v0.9.8 | grep -oE "'(openstation|desktop_mode)_[a-z0-9_]+'" | tr -d "'" | sed -E 's/^desktop_mode_/openstation_/' | sort -u > /tmp/old.txt
comm -13 /tmp/old.txt /tmp/now.txt | while read -r h; do grep -q "\`$h\`" docs/hooks-reference.md || echo "MISSING: $h"; done
```

   Make sure it prints nothing. On `trunk` it prints twenty lines.

2. Open `docs/hooks-reference.md` and find the three new entries. Make sure each one matches the code:
   * `openstation_brand_migration_map` against `openstation_migrate_brand_defaults()` in `includes/migrations.php`.
   * `openstation_track_type_registrants` against `openstation_should_track_type_registrants()` in `includes/core/payload.php`.
   * `openstation_my_wordpress_woo_coupon_bands` against `openstation_my_wordpress_woo_coupon_bands()` and `openstation_my_wordpress_woo_coupon_band_id()` in `includes/my-wordpress/integrations/woocommerce.php`.

3. Preview both files on GitHub. Make sure the tables render, and that the three cross-doc links in the new API index rows and the one in the `openstation_track_type_registrants` entry all land on the right heading.

4. Run `npm run build`. Make sure `git status` is clean afterwards.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-521-16dd3279b1d0de2a22f534ffe49c5d9cc7d32805.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->