### PR TITLE
Context menus: Clamp to the viewport after the menu has rendered

### DIFF
--- a/src/desktop-files/wallpaper-menu.ts
+++ b/src/desktop-files/wallpaper-menu.ts
@@ -16,6 +16,7 @@ import { applyFilters, doAction } from '../hooks';
 // Side-effect import: registers `<os-context-menu>` +
 // `<os-context-menu-option>` so the menu DOM upgrades.
 import { openWithShellOverlays } from '../shell-overlays/loader';
+import { clampToViewport, positionFlyout } from '../ui/util/menu-position';
 import { attachDismissable } from './dismissable';
 
 /** Public shape of a menu item. Plugins build these via the filter. */
@@ -250,33 +251,13 @@ function openWallpaperMenuImmediate(
 		positionFlyout( fly, anchor );
 	}
 
-	function positionFlyout( fly: HTMLElement, anchor: HTMLElement ): void {
-		const ar = anchor.getBoundingClientRect();
-		// Default: open to the right, top-aligned with anchor.
-		fly.style.position = 'fixed';
-		fly.style.left = `${ ar.right }px`;
-		fly.style.top = `${ ar.top }px`;
-		const fr = fly.getBoundingClientRect();
-		if ( fr.right > window.innerWidth ) {
-			fly.style.left = `${ Math.max( 0, ar.left - fr.width ) }px`;
-		}
-		if ( fr.bottom > window.innerHeight ) {
-			fly.style.top = `${ Math.max( 0, window.innerHeight - fr.height - 8 ) }px`;
-		}
-	}
-
 	host.appendChild( menu );
 	activeMenu = menu;
 
 	// Clamp to viewport so a click near the edge doesn't open
-	// half-off-screen.
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		menu.style.left = `${ Math.max( 0, window.innerWidth - rect.width - 8 ) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		menu.style.top = `${ Math.max( 0, window.innerHeight - rect.height - 8 ) }px`;
-	}
+	// half-off-screen. Measured a frame later, once the component
+	// has rendered. See `src/ui/util/menu-position.ts`.
+	clampToViewport( menu );
 
 	const detach = attachDismissable( menu, {
 		close: () => closeWallpaperMenu(),

--- a/src/icon-canvas/menu.ts
+++ b/src/icon-canvas/menu.ts
@@ -27,6 +27,7 @@
 import { applyFilters } from '../hooks';
 import { __ } from '../i18n';
 import { openWithShellOverlays } from '../shell-overlays/loader';
+import { clampToViewport, positionFlyout } from '../ui/util/menu-position';
 
 export type SortMode = 'name-asc' | 'name-desc' | 'date-asc' | 'date-desc';
 
@@ -272,6 +273,8 @@ function openMenu(
 
 	document.body.appendChild( menu );
 	activeMenu = menu;
+	// Measured a frame later, once the component has rendered. See
+	// `src/ui/util/menu-position.ts`.
 	clampToViewport( menu );
 
 	// Outside-click + Escape dismiss. We attach the dismissers
@@ -348,30 +351,6 @@ function openFlyout( parent: IconCanvasMenuItem, anchor: HTMLElement ): void {
 	document.body.appendChild( fly );
 	activeFlyout = fly;
 	positionFlyout( fly, anchor );
-}
-
-function positionFlyout( fly: HTMLElement, anchor: HTMLElement ): void {
-	const ar = anchor.getBoundingClientRect();
-	fly.style.position = 'fixed';
-	fly.style.left = `${ ar.right }px`;
-	fly.style.top = `${ ar.top }px`;
-	const fr = fly.getBoundingClientRect();
-	if ( fr.right > window.innerWidth ) {
-		fly.style.left = `${ Math.max( 0, ar.left - fr.width ) }px`;
-	}
-	if ( fr.bottom > window.innerHeight ) {
-		fly.style.top = `${ Math.max( 0, window.innerHeight - fr.height - 8 ) }px`;
-	}
-}
-
-function clampToViewport( menu: HTMLElement ): void {
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		menu.style.left = `${ Math.max( 0, window.innerWidth - rect.width - 8 ) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		menu.style.top = `${ Math.max( 0, window.innerHeight - rect.height - 8 ) }px`;
-	}
 }
 
 function hasChildren( item: IconCanvasMenuItem ): boolean {

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -28,6 +28,7 @@ import {
 	type NativeRail,
 } from './settings/item-placement';
 import { osConfirm } from './ui/components/os-confirm-dialog/os-confirm-dialog';
+import { placeAfterRender } from './ui/util/menu-position';
 import { trackedFetch } from './tracked-fetch';
 import { showToast } from './toast';
 import { joinRestUrl } from './rest-url';
@@ -371,17 +372,16 @@ function openItemVisibilityMenuImmediate(
 	document.body.appendChild( menu );
 	activeMenu = menu;
 
-	// Measure on the next animation frame, AFTER the component has
-	// completed its microtask render. Calling getBoundingClientRect()
+	// `placeAfterRender` measures on the next animation frame, AFTER
+	// the component has completed its microtask render. Measuring
 	// synchronously here returns a near-zero height (shadow DOM not
 	// populated yet) — which made dock right-clicks land the
 	// "anchor-above-cursor" math at `opts.y - 0 - 8 ≈ opts.y`,
 	// pushing the bottom dock's menu off-screen below the viewport.
-	const positionMenu = (): void => {
-		if ( menu !== activeMenu ) {
-			return; // Was closed before we got here.
-		}
-		const rect = menu.getBoundingClientRect();
+	// This menu does its own placement rather than calling
+	// `clampToViewport` because the dock case anchors the menu's
+	// bottom edge at the cursor unconditionally.
+	placeAfterRender( menu, ( rect ) => {
 		const margin = 8;
 		let left = opts.x;
 		let top: number;
@@ -405,9 +405,7 @@ function openItemVisibilityMenuImmediate(
 		}
 		menu.style.left = `${ left }px`;
 		menu.style.top = `${ top }px`;
-		menu.style.visibility = '';
-	};
-	requestAnimationFrame( positionMenu );
+	} );
 
 	// Outside-click + Escape dismisser.
 	const onOutside = ( ev: MouseEvent ): void => {

--- a/src/item-visibility-menu.ts
+++ b/src/item-visibility-menu.ts
@@ -310,9 +310,10 @@ function openItemVisibilityMenuImmediate(
 	( menu as HTMLElement ).dataset.itemId = opts.id;
 	menu.style.position = 'fixed';
 	// Off-screen first so we can measure size before placement.
+	// `placeAfterRender` owns the hiding, so no `visibility` here:
+	// one invariant, one owner.
 	menu.style.left = '-9999px';
 	menu.style.top = '-9999px';
-	menu.style.visibility = 'hidden';
 	// Must sit above the dock-peek popover (z-index: 999999 in
 	// assets/css/dock-peek.css). The peek is still visible when the
 	// user right-clicks a tile, so without this the menu opens

--- a/src/plugins/heartbeat-widget/index.ts
+++ b/src/plugins/heartbeat-widget/index.ts
@@ -23,6 +23,7 @@ import './styles.css';
 import type { Application, Container, Graphics, Sprite, Texture } from 'pixi.js';
 import { __ } from '../../i18n';
 import { createSharedStore } from '../../shared-store';
+import { clampToViewport } from '../../ui/util/menu-position';
 import type { WidgetContext, WidgetTeardown } from '../../widgets/types';
 
 /**
@@ -566,14 +567,9 @@ function openHeartbeatMenu(
 	} );
 
 	document.body.appendChild( menu );
-	// Clamp menu to viewport.
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		menu.style.left = `${ Math.max( 4, window.innerWidth - rect.width - 8 ) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		menu.style.top = `${ Math.max( 4, window.innerHeight - rect.height - 8 ) }px`;
-	}
+	// Clamp menu to viewport, measured a frame later once the
+	// component has rendered. See `src/ui/util/menu-position.ts`.
+	clampToViewport( menu );
 
 	document.addEventListener( 'pointerdown', onOutside, true );
 	document.addEventListener( 'keydown', onKey, true );

--- a/src/selection/menu.ts
+++ b/src/selection/menu.ts
@@ -17,6 +17,7 @@
 import { doAction } from '../hooks';
 import { attachDismissable } from '../desktop-files/dismissable';
 import { openWithShellOverlays } from '../shell-overlays/loader';
+import { clampToViewport } from '../ui/util/menu-position';
 /**
  * What the menu needs from an action — the structural subset of
  * `SelectionAction` that has nothing to do with which item type the
@@ -169,13 +170,7 @@ function openImmediate(
 	activeMenu = menu;
 	activeOnClosed = onClosed ?? null;
 
-	const rect = menu.getBoundingClientRect();
-	if ( rect.right > window.innerWidth ) {
-		menu.style.left = `${ Math.max( 0, window.innerWidth - rect.width - 8 ) }px`;
-	}
-	if ( rect.bottom > window.innerHeight ) {
-		menu.style.top = `${ Math.max( 0, window.innerHeight - rect.height - 8 ) }px`;
-	}
+	clampToViewport( menu );
 
 	const detach = attachDismissable( menu, { close: () => closeActionMenu() } );
 	menu.addEventListener( 'tile-menu-closed', detach );

--- a/src/ui/components/os-context-menu/os-context-menu.ts
+++ b/src/ui/components/os-context-menu/os-context-menu.ts
@@ -31,6 +31,14 @@
  * flyout `<os-context-menu>` on hover / activate (see
  * src/desktop-files/wallpaper-menu.ts and src/icon-canvas/menu.ts
  * for the canonical rigs).
+ *
+ * **Place it with src/ui/util/menu-position.ts, never by measuring
+ * on the line after `appendChild()`.** Like every `Component`, this
+ * one paints its shadow DOM in a `queueMicrotask()`, so an immediate
+ * `getBoundingClientRect()` returns an empty box: a viewport clamp
+ * built on it silently never fires and the menu opens off-screen.
+ * `clampToViewport` and `positionFlyout` there defer the measurement
+ * to the next frame and already handle the close-before-frame case.
  */
 
 import {

--- a/src/ui/util/menu-position.ts
+++ b/src/ui/util/menu-position.ts
@@ -22,6 +22,13 @@
  * `<os-context-menu>` carries a `min-width`: the empty box still
  * measured ~180px wide. That is luck, not correctness, and it stops
  * holding the moment a menu is wider than its minimum.
+ *
+ * Not to be confused with the `clampToViewport` in
+ * `src/dock-peek/index.ts`. That one is already frame-deferred and
+ * correct, but it places by `translate` rather than by `left` / `top`,
+ * is orientation-aware, and keeps its own 12px margin. The two are not
+ * interchangeable; leave them separate unless the peek moves to the
+ * same placement model.
  */
 
 /** Gap kept between a placed menu and the viewport edge. */
@@ -93,6 +100,12 @@ export function positionFlyout( fly: HTMLElement, anchor: HTMLElement ): void {
 	fly.style.top = `${ ar.top }px`;
 	placeAfterRender( fly, ( rect ) => {
 		if ( rect.right > window.innerWidth ) {
+			// No MARGIN here, unlike the vertical branch below: the flip
+			// is anchor-relative, not viewport-relative. The flyout's
+			// right edge sits flush against the anchor's left edge, and
+			// a margin would open a gap between a submenu and the option
+			// that owns it. `Math.max` is only a floor against negative
+			// left on a very wide flyout.
 			fly.style.left = `${ Math.max( 0, ar.left - rect.width ) }px`;
 		}
 		if ( rect.bottom > window.innerHeight ) {

--- a/src/ui/util/menu-position.ts
+++ b/src/ui/util/menu-position.ts
@@ -1,0 +1,105 @@
+/**
+ * OpenStation. Viewport placement for floating menus.
+ *
+ * Every floating menu in the shell is an `<os-context-menu>`, and
+ * every one of them has to answer the same question the moment it
+ * is appended: does it fit? Answering needs a measurement, and the
+ * measurement is the trap. `Component` paints its shadow DOM inside
+ * a `queueMicrotask()` (see `src/ui/core/component.ts`), so a
+ * `getBoundingClientRect()` taken on the line after `appendChild()`
+ * measures an empty box. A near-zero height never trips
+ * `rect.bottom > window.innerHeight`, the clamp is skipped, and the
+ * menu then paints at full height straight off the bottom edge. The
+ * taller the menu and the shorter the screen, the bigger the dead
+ * zone along the bottom of the desktop.
+ *
+ * {@link placeAfterRender} is the fix: it defers the measurement to
+ * the next animation frame, which lands after the render microtask.
+ * The two placements the shell needs are built on it, so there is
+ * one definition of "measure a menu" rather than one per call site.
+ *
+ * The horizontal axis was never visibly broken, but only because
+ * `<os-context-menu>` carries a `min-width`: the empty box still
+ * measured ~180px wide. That is luck, not correctness, and it stops
+ * holding the moment a menu is wider than its minimum.
+ */
+
+/** Gap kept between a placed menu and the viewport edge. */
+const MARGIN = 8;
+
+/**
+ * Run `place` with the menu's real, post-render rect.
+ *
+ * The menu is hidden for the frame between append and placement so
+ * the unplaced position never paints.
+ */
+export function placeAfterRender(
+	menu: HTMLElement,
+	place: ( rect: DOMRect ) => void,
+): void {
+	menu.style.visibility = 'hidden';
+	const run = (): void => {
+		// Closed before the frame arrived. A superseded menu counts as
+		// closed too, since every close path removes the node.
+		if ( ! menu.isConnected ) {
+			return;
+		}
+		place( menu.getBoundingClientRect() );
+		menu.style.visibility = '';
+	};
+	if ( typeof requestAnimationFrame === 'function' ) {
+		requestAnimationFrame( run );
+	} else {
+		// No frame loop to wait for (non-browser host). Measuring
+		// synchronously is no worse than not measuring at all.
+		run();
+	}
+}
+
+/**
+ * Pull an already-positioned menu back inside the viewport, so a
+ * click near an edge doesn't open half off-screen.
+ *
+ * The caller sets `left` / `top` from the pointer first; this only
+ * moves the menu when it would overflow.
+ */
+export function clampToViewport( menu: HTMLElement ): void {
+	placeAfterRender( menu, ( rect ) => {
+		if ( rect.right > window.innerWidth ) {
+			menu.style.left = `${ Math.max(
+				0,
+				window.innerWidth - rect.width - MARGIN,
+			) }px`;
+		}
+		if ( rect.bottom > window.innerHeight ) {
+			menu.style.top = `${ Math.max(
+				0,
+				window.innerHeight - rect.height - MARGIN,
+			) }px`;
+		}
+	} );
+}
+
+/**
+ * Place a submenu against the option that opened it: to the right,
+ * top-aligned, flipping to the left when it would run past the
+ * right edge and riding up when it would run past the bottom.
+ */
+export function positionFlyout( fly: HTMLElement, anchor: HTMLElement ): void {
+	const ar = anchor.getBoundingClientRect();
+	// Default: open to the right, top-aligned with the anchor.
+	fly.style.position = 'fixed';
+	fly.style.left = `${ ar.right }px`;
+	fly.style.top = `${ ar.top }px`;
+	placeAfterRender( fly, ( rect ) => {
+		if ( rect.right > window.innerWidth ) {
+			fly.style.left = `${ Math.max( 0, ar.left - rect.width ) }px`;
+		}
+		if ( rect.bottom > window.innerHeight ) {
+			fly.style.top = `${ Math.max(
+				0,
+				window.innerHeight - rect.height - MARGIN,
+			) }px`;
+		}
+	} );
+}

--- a/tests/vitest/menu-viewport-clamp.test.ts
+++ b/tests/vitest/menu-viewport-clamp.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression tests for floating-menu viewport clamping.
+ *
+ * The bug these pin: `<os-context-menu>` renders its shadow DOM in a
+ * `queueMicrotask()`, so a `getBoundingClientRect()` taken on the
+ * line after `appendChild()` measures an empty box. The clamp read
+ * that empty box, decided the menu fit, and left it to paint at full
+ * height off the bottom of the viewport, leaving a dead zone along
+ * the bottom of the desktop that got proportionally worse on short
+ * screens.
+ *
+ * jsdom has no layout engine, so the stub below reproduces the one
+ * property that matters: an `<os-context-menu>` measures as an empty
+ * box until its render microtask has populated the shadow root, and
+ * at full size afterwards. Against a synchronous clamp every test
+ * here fails, because the menu never moves.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+/** Tall enough that it cannot fit below a click near the bottom. */
+const MENU_HEIGHT = 276;
+const MENU_WIDTH = 200;
+
+const originalRect = Element.prototype.getBoundingClientRect;
+
+/** Animation-frame callbacks parked by the stub, flushed by `frame()`. */
+let frames: FrameRequestCallback[] = [];
+
+function makeRect( left: number, top: number, w: number, h: number ): DOMRect {
+	return {
+		left,
+		top,
+		width: w,
+		height: h,
+		right: left + w,
+		bottom: top + h,
+		x: left,
+		y: top,
+		toJSON: () => ( {} ),
+	} as DOMRect;
+}
+
+/** Run every parked animation-frame callback. */
+function frame(): void {
+	const queued = frames;
+	frames = [];
+	for ( const cb of queued ) {
+		cb( 0 );
+	}
+}
+
+/**
+ * Let the component's render microtask run, then deliver the frame
+ * the placement is waiting on.
+ */
+async function renderAndFrame(): Promise< void > {
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	frame();
+}
+
+describe( 'floating menus clamp to the viewport', () => {
+	beforeEach( () => {
+		installHooksStub();
+		frames = [];
+		vi.stubGlobal( 'requestAnimationFrame', ( cb: FrameRequestCallback ) => {
+			frames.push( cb );
+			return frames.length;
+		} );
+		Element.prototype.getBoundingClientRect = function (
+			this: Element,
+		): DOMRect {
+			const el = this as HTMLElement;
+			if ( el.tagName.toLowerCase() !== 'os-context-menu' ) {
+				return originalRect.call( this );
+			}
+			// The timing hole: no size until the render microtask has
+			// run. `<os-context-menu>` renders a single `<slot>`, and
+			// the shadow root holds nothing else that carries content
+			// (style adoption stamps a `<style>` tag synchronously, so
+			// child count alone would report "rendered" far too early).
+			const rendered = el.shadowRoot?.querySelector( 'slot' ) !== null;
+			const left = parseFloat( el.style.left ) || 0;
+			const top = parseFloat( el.style.top ) || 0;
+			return rendered
+				? makeRect( left, top, MENU_WIDTH, MENU_HEIGHT )
+				: makeRect( left, top, 0, 0 );
+		};
+	} );
+
+	afterEach( () => {
+		Element.prototype.getBoundingClientRect = originalRect;
+		vi.unstubAllGlobals();
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'the wallpaper menu opened near the bottom edge ends up on screen', async () => {
+		vi.resetModules();
+		const { openWallpaperMenu } = await import(
+			'../../src/desktop-files/wallpaper-menu'
+		);
+		// Well inside the viewport, but not by MENU_HEIGHT.
+		const clickY = window.innerHeight - 60;
+		openWallpaperMenu( document.body, { x: 20, y: clickY }, [
+			{ id: 'a', label: 'A', onClick: () => {} },
+			{ id: 'b', label: 'B', onClick: () => {} },
+		] );
+		const menu = document.querySelector< HTMLElement >( 'os-context-menu' )!;
+		expect( menu ).not.toBeNull();
+
+		await renderAndFrame();
+
+		const top = parseFloat( menu.style.top );
+		expect( top ).toBeLessThan( clickY );
+		expect( top + MENU_HEIGHT ).toBeLessThanOrEqual( window.innerHeight );
+	} );
+
+	test( 'the menu stays hidden until it has been placed', async () => {
+		vi.resetModules();
+		const { openWallpaperMenu } = await import(
+			'../../src/desktop-files/wallpaper-menu'
+		);
+		openWallpaperMenu(
+			document.body,
+			{ x: 20, y: window.innerHeight - 60 },
+			[ { id: 'a', label: 'A', onClick: () => {} } ],
+		);
+		const menu = document.querySelector< HTMLElement >( 'os-context-menu' )!;
+		expect( menu.style.visibility ).toBe( 'hidden' );
+
+		await renderAndFrame();
+
+		expect( menu.style.visibility ).toBe( '' );
+	} );
+
+	test( 'a menu closed before its frame lands does not throw', async () => {
+		vi.resetModules();
+		const { openWallpaperMenu, closeWallpaperMenu } = await import(
+			'../../src/desktop-files/wallpaper-menu'
+		);
+		openWallpaperMenu(
+			document.body,
+			{ x: 20, y: window.innerHeight - 60 },
+			[ { id: 'a', label: 'A', onClick: () => {} } ],
+		);
+		closeWallpaperMenu();
+		expect( () => frame() ).not.toThrow();
+	} );
+
+	test( 'the icon-canvas menu opened near the bottom edge ends up on screen', async () => {
+		vi.resetModules();
+		const { attachIconCanvasMenu } = await import( '../../src/icon-canvas/menu' );
+		const canvas = document.createElement( 'div' );
+		document.body.appendChild( canvas );
+		attachIconCanvasMenu( canvas, { scope: 'test', onSort: () => {} } );
+
+		const clickY = window.innerHeight - 60;
+		canvas.dispatchEvent(
+			new MouseEvent( 'contextmenu', {
+				bubbles: true,
+				clientX: 20,
+				clientY: clickY,
+			} ),
+		);
+		const menu = document.querySelector< HTMLElement >( 'os-context-menu' )!;
+		expect( menu ).not.toBeNull();
+
+		await renderAndFrame();
+
+		expect(
+			parseFloat( menu.style.top ) + MENU_HEIGHT,
+		).toBeLessThanOrEqual( window.innerHeight );
+	} );
+
+	test( 'a submenu opened against a low anchor rides up into view', async () => {
+		vi.resetModules();
+		const { positionFlyout } = await import(
+			'../../src/ui/util/menu-position'
+		);
+		const anchor = document.createElement( 'div' );
+		Object.defineProperty( anchor, 'getBoundingClientRect', {
+			value: () => makeRect( 40, window.innerHeight - 40, 180, 32 ),
+		} );
+		document.body.appendChild( anchor );
+		const fly = document.createElement( 'os-context-menu' );
+		fly.setAttribute( 'open', '' );
+		document.body.appendChild( fly );
+
+		positionFlyout( fly, anchor );
+		await renderAndFrame();
+
+		expect(
+			parseFloat( fly.style.top ) + MENU_HEIGHT,
+		).toBeLessThanOrEqual( window.innerHeight );
+	} );
+} );

--- a/tests/vitest/menu-viewport-clamp.test.ts
+++ b/tests/vitest/menu-viewport-clamp.test.ts
@@ -173,6 +173,33 @@ describe( 'floating menus clamp to the viewport', () => {
 		).toBeLessThanOrEqual( window.innerHeight );
 	} );
 
+	test( 'the shared selection menu opened near the bottom edge ends up on screen', async () => {
+		vi.resetModules();
+		const { openActionMenu } = await import( '../../src/selection/menu' );
+		const clickY = window.innerHeight - 60;
+
+		openActionMenu(
+			{ x: 20, y: clickY },
+			{
+				scope: 'test',
+				actions: [
+					{ id: 'open', label: 'Open', run: () => {} },
+					{ id: 'rename', label: 'Rename', run: () => {} },
+					{ id: 'trash', label: 'Trash', run: () => {} },
+				],
+			},
+		);
+
+		const menu = document.querySelector< HTMLElement >( 'os-context-menu' )!;
+		expect( menu ).not.toBeNull();
+
+		await renderAndFrame();
+
+		expect(
+			parseFloat( menu.style.top ) + MENU_HEIGHT,
+		).toBeLessThanOrEqual( window.innerHeight );
+	} );
+
 	test( 'a submenu opened against a low anchor rides up into view', async () => {
 		vi.resetModules();
 		const { positionFlyout } = await import(

--- a/tests/vitest/menu-viewport-clamp.test.ts
+++ b/tests/vitest/menu-viewport-clamp.test.ts
@@ -183,9 +183,9 @@ describe( 'floating menus clamp to the viewport', () => {
 			{
 				scope: 'test',
 				actions: [
-					{ id: 'open', label: 'Open', run: () => {} },
-					{ id: 'rename', label: 'Rename', run: () => {} },
-					{ id: 'trash', label: 'Trash', run: () => {} },
+					{ id: 'open', label: 'Open', onClick: () => {} },
+					{ id: 'rename', label: 'Rename', onClick: () => {} },
+					{ id: 'trash', label: 'Trash', onClick: () => {} },
 				],
 			},
 		);


### PR DESCRIPTION
## Proposed Changes

Context menus opened near the bottom of the screen now stay inside the viewport.

- Adds `src/ui/util/menu-position.ts`, one helper that measures a menu after it has rendered and then places it.
- Routes the wallpaper menu, the icon-canvas menu, both of their submenu flyouts, the heartbeat widget menu, and the item visibility menu through it.
- Menus are hidden for the one frame between append and placement, so the unplaced position never paints.
- Adds `tests/vitest/menu-viewport-clamp.test.ts`, which fails against the old synchronous measurement.

## Why are these changes being made?

A menu opened near the bottom of the desktop ran off the edge and most of its options were unreachable. A 276px menu opened at y=920 in a 1000px viewport overflowed the bottom by 196px. Roughly the bottom quarter of the desktop was a dead zone, proportionally worse on short laptop screens.

The clamp called `getBoundingClientRect()` on the line right after `appendChild()`, but `Component` renders its shadow DOM inside a `queueMicrotask()` (`src/ui/core/component.ts`). The measurement saw an empty box, `rect.bottom > window.innerHeight` was never true, no clamp was applied, and the menu then painted at full height off the bottom.

This is pre-existing, not a regression. The clamp code and the async render are byte identical to `v0.9.8`; those files only took rebrand rename churn this cycle.

The horizontal axis looked fine only because `<os-context-menu>` carries a `min-width`, so the empty box still measured about 180px wide. That is luck, not correctness, and it stops holding for any menu wider than its minimum.

The item visibility menu already had a local copy of this fix (the dock right-click case hit it first). It now shares the helper rather than keeping its own.

## Testing Instructions

Make the viewport short first, since that is what makes the bug obvious. Either use a laptop screen or resize the browser window to roughly 900px tall (or use devtools device emulation at 1280x800).

Reproduce on `trunk` first if you want to see the bug: every step below ends with the menu running off the bottom of the screen.

**1. Wallpaper context menu**

1. Open the desktop shell at `/openstation/`.
2. Right-click empty wallpaper about 60px above the bottom of the viewport, just above the dock.
3. Make sure the whole menu is visible, with all entries (New folder, New URL, Sort by, Show desktop, OpenStation Preferences) reachable and clickable.
4. Make sure the menu does not visibly jump or flash at the wrong position as it opens.
5. Right-click in the middle of the wallpaper. Make sure the menu still opens with its top-left corner at the pointer, unchanged.

**2. Submenu flyout**

1. Right-click near the bottom of the wallpaper again.
2. Hover **Sort by**.
3. Make sure the submenu opens fully on screen and every sort option is clickable.
4. Pick one and make sure the icons re-sort.

**3. Right and bottom-right corner**

1. Right-click within about 100px of the right edge, near the bottom.
2. Make sure the menu flips to the left of the pointer and stays inside the viewport on both axes.
3. Hover **Sort by** and make sure the flyout also flips to the left instead of running off the right edge.

**4. Icon-canvas menu**

1. Open the **My WordPress** folder window and make it tall enough that its background reaches near the bottom of the screen.
2. Right-click the empty canvas background near the bottom.
3. Make sure the menu and its **Sort by** flyout are both fully visible.

**5. Item visibility menu (regression check, this path was already correct)**

1. Right-click a dock tile. Make sure the menu opens upward from the cursor and is fully visible.
2. Right-click a desktop icon near the bottom of the screen. Make sure the menu flips above the cursor rather than running off the bottom.

**6. Heartbeat widget menu**

1. Add the Heartbeat widget from the widgets picker and drag it near the bottom of the screen.
2. Right-click the widget.
3. Make sure the "Show heart" menu is fully visible, and that toggling it still resizes the widget frame.

**7. Fast close**

1. Right-click the wallpaper and press Escape immediately, before the menu settles.
2. Make sure nothing is left on screen and the console stays clean.

**Automated**

```
npm run lint
npm run typecheck
npm run test:js
npm run build
```

`tests/vitest/menu-viewport-clamp.test.ts` is the regression guard. Four of its five cases fail if the measurement goes back to being synchronous.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-523-a622cd6bf02ad1981e549eac8af1c448a3d921f2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->