### PR TITLE
About tab: show the credits while the particle scene loads

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -1235,16 +1235,16 @@
 }
 
 /*
- * The poster — the same copy the scene paints inside the canvas,
+ * The poster. The same copy the scene paints inside the canvas,
  * as plain HTML, on the first frame. Three network round-trips (the
  * PixiJS vendor bundle, the about-scene bundle, the logotype PNG)
  * plus a pixel-sampling pass sit between opening this tab and the
  * canvas having anything on it; this is what the reader looks at
  * meanwhile.
  *
- * Proportions echo `computeLayout()` in about-scene.ts — eyebrow near
+ * Proportions echo `computeLayout()` in about-scene.ts: eyebrow near
  * the top tenth, title under it, then the band the logotype fills,
- * with byline and version stacked below — so the cross-fade lands the
+ * with byline and version stacked below, so the cross-fade lands the
  * text close to where the canvas is about to draw it. Close, not
  * pixel-exact: the scene measures its own text and the fade covers
  * the difference.
@@ -1262,7 +1262,7 @@
 	align-items: center;
 	padding-inline: 24px;
 	text-align: center;
-	/* Never in the way of the swarm — the canvas below owns the
+	/* Never in the way of the swarm. The canvas below owns the
 	 * pointer once it is live. */
 	pointer-events: none;
 	font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', roboto,
@@ -1292,7 +1292,7 @@
 /*
  * Faded, not hidden. `visibility: hidden` or `display: none` would
  * take it out of the accessibility tree, and the canvas exposes no
- * text at all — the poster is the only readable copy of what this
+ * text at all, so the poster is the only readable copy of what this
  * tab says.
  */
 .os-settings__about.is-scene-ready .os-settings__about-poster {

--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -1157,15 +1157,16 @@
 /*
  * About tab — full-tabpanel PixiJS canvas. Every credit string and
  * the AUTOMATTIC logotype (formed by particles) render inside Pixi
- * itself; this stylesheet only sizes the host so the canvas fills
- * the available height + width without any HTML chrome around it.
+ * itself, so this stylesheet does two things: it sizes the host so
+ * the canvas fills the available height + width without any HTML
+ * chrome around it, and it lays out the poster that stands in for
+ * the canvas until the scene is live (see about.ts).
  *
  * The chain is: tabpanel → os-panel → .about (flex column) →
  * .about-stage-host (the canvas mounts here). Each link sets
  * `flex: 1; min-height: 0;` so the canvas inherits the tabpanel's
- * full inner height instead of hugging an intrinsic minimum.
- *
- * @since 0.8.0
+ * full inner height instead of hugging an intrinsic minimum. The
+ * poster is absolutely positioned over that host.
  */
 .os-settings
 	> os-tabpanel[ for='about' ]:not( [ hidden ] ) {
@@ -1184,6 +1185,7 @@
 }
 
 .os-settings__about {
+	position: relative;
 	flex: 1;
 	min-height: 0;
 	display: flex;
@@ -1191,10 +1193,16 @@
 	margin: 0;
 	/* Edge-to-edge — no border-radius / box-shadow framing — so the
 	 * canvas (and the logotype centred inside it) consume the entire
-	 * tabpanel surface. The gradient is just the colour-of-last-resort
-	 * underneath while Pixi initialises; once the canvas is rendering
-	 * it covers every pixel of this element anyway. */
-	background: linear-gradient( 180deg, #060a1c 0%, #0c1733 100% );
+	 * tabpanel surface. The gradient is the scene's own backdrop
+	 * (BACKDROP_CSS in about-scene.ts) so the poster below already
+	 * sits on the final background and the canvas fade-in doesn't
+	 * swap it out under the reader. */
+	background: radial-gradient(
+		circle at 50% 35%,
+		#1b3461 0%,
+		#0c1733 55%,
+		#050918 100%
+	);
 	overflow: hidden;
 }
 
@@ -1204,12 +1212,154 @@
 	width: 100%;
 	overflow: hidden;
 	cursor: crosshair;
+	/* Held back until the scene is live, then cross-faded over the
+	 * poster. Without this the canvas pops in mid-sentence. */
+	opacity: 0;
+	transition: opacity 500ms ease;
+}
+
+.os-settings__about.is-scene-ready .os-settings__about-stage-host {
+	opacity: 1;
+}
+
+/* No scene, no swarm to point at: drop the host so the crosshair
+ * cursor stops promising interactivity that isn't coming. */
+.os-settings__about.is-scene-failed .os-settings__about-stage-host {
+	display: none;
 }
 
 .os-settings__about-stage-host canvas {
 	display: block;
 	width: 100%;
 	height: 100%;
+}
+
+/*
+ * The poster — the same copy the scene paints inside the canvas,
+ * as plain HTML, on the first frame. Three network round-trips (the
+ * PixiJS vendor bundle, the about-scene bundle, the logotype PNG)
+ * plus a pixel-sampling pass sit between opening this tab and the
+ * canvas having anything on it; this is what the reader looks at
+ * meanwhile.
+ *
+ * Proportions echo `computeLayout()` in about-scene.ts — eyebrow near
+ * the top tenth, title under it, then the band the logotype fills,
+ * with byline and version stacked below — so the cross-fade lands the
+ * text close to where the canvas is about to draw it. Close, not
+ * pixel-exact: the scene measures its own text and the fade covers
+ * the difference.
+ *
+ * Colours are the scene's own text fills, spelled out rather than
+ * tokenised: the About scene is deliberately outside the desktop-
+ * theme surface (see docs/desktop-themes.md, "What stays fixed"),
+ * and the poster has to match the canvas it hands over to.
+ */
+.os-settings__about-poster {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding-inline: 24px;
+	text-align: center;
+	/* Never in the way of the swarm — the canvas below owns the
+	 * pointer once it is live. */
+	pointer-events: none;
+	font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', roboto,
+		'Helvetica Neue', arial, sans-serif;
+	transition: opacity 500ms ease;
+}
+
+/*
+ * Vertical rhythm as flex spacers rather than padding: a percentage
+ * flex-basis in a column resolves against the container's HEIGHT,
+ * which is what the scene's own layout is a fraction of. Percentage
+ * padding would resolve against the width and slide the whole poster
+ * around as the panel gets wider.
+ */
+.os-settings__about-poster::before {
+	content: '';
+	flex: 0 0 9%;
+}
+
+.os-settings__about-poster::after {
+	content: '';
+	/* Roughly the band the scene keeps for the interaction hint,
+	 * which the poster has nothing to say about yet. */
+	flex: 0 0 12%;
+}
+
+/*
+ * Faded, not hidden. `visibility: hidden` or `display: none` would
+ * take it out of the accessibility tree, and the canvas exposes no
+ * text at all — the poster is the only readable copy of what this
+ * tab says.
+ */
+.os-settings__about.is-scene-ready .os-settings__about-poster {
+	opacity: 0;
+}
+
+.os-settings__about-eyebrow {
+	margin: 0;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 4px;
+	color: #9bb5ff;
+}
+
+.os-settings__about-title {
+	margin: 16px 0 0;
+	font-size: clamp( 23px, 5vw, 38px );
+	font-weight: 300;
+	letter-spacing: -0.4px;
+	color: #fff;
+}
+
+/* Occupies the band the logotype particles will fill, so the
+ * spinner reads as "the artwork is on its way" rather than as a
+ * detached widget. */
+.os-settings__about-loader {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: #9bb5ff;
+}
+
+.os-settings__about-loader os-spinner {
+	--os-ui-spinner-color: #9bb5ff;
+	--os-ui-spinner-accent: #0c1733;
+}
+
+.os-settings__about-byline {
+	margin: 0;
+	font-size: 14px;
+	font-style: italic;
+	letter-spacing: 0.3px;
+	color: #c0caea;
+}
+
+.os-settings__about-version {
+	margin: 12px 0 0;
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 1px;
+	color: #6f7eb0;
+}
+
+/* `pluginVersion` can be missing from the shell config; don't leave
+ * a line of empty space where the version would have been. */
+.os-settings__about-version:empty {
+	display: none;
+}
+
+/* Nothing here is load-bearing motion: the canvas still arrives, it
+ * just arrives without a fade. */
+@media ( prefers-reduced-motion: reduce ) {
+	.os-settings__about-stage-host,
+	.os-settings__about-poster {
+		transition: none;
+	}
 }
 
 

--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -1235,16 +1235,16 @@
 }
 
 /*
- * The poster. The same copy the scene paints inside the canvas,
+ * The poster — the same copy the scene paints inside the canvas,
  * as plain HTML, on the first frame. Three network round-trips (the
  * PixiJS vendor bundle, the about-scene bundle, the logotype PNG)
  * plus a pixel-sampling pass sit between opening this tab and the
  * canvas having anything on it; this is what the reader looks at
  * meanwhile.
  *
- * Proportions echo `computeLayout()` in about-scene.ts: eyebrow near
+ * Proportions echo `computeLayout()` in about-scene.ts — eyebrow near
  * the top tenth, title under it, then the band the logotype fills,
- * with byline and version stacked below, so the cross-fade lands the
+ * with byline and version stacked below — so the cross-fade lands the
  * text close to where the canvas is about to draw it. Close, not
  * pixel-exact: the scene measures its own text and the fade covers
  * the difference.
@@ -1262,7 +1262,7 @@
 	align-items: center;
 	padding-inline: 24px;
 	text-align: center;
-	/* Never in the way of the swarm. The canvas below owns the
+	/* Never in the way of the swarm — the canvas below owns the
 	 * pointer once it is live. */
 	pointer-events: none;
 	font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', roboto,
@@ -1292,7 +1292,7 @@
 /*
  * Faded, not hidden. `visibility: hidden` or `display: none` would
  * take it out of the accessibility tree, and the canvas exposes no
- * text at all, so the poster is the only readable copy of what this
+ * text at all — the poster is the only readable copy of what this
  * tab says.
  */
 .os-settings__about.is-scene-ready .os-settings__about-poster {

--- a/src/settings/sections/about.ts
+++ b/src/settings/sections/about.ts
@@ -10,6 +10,9 @@
  * job is to:
  *
  *   - render a full-size canvas host into the tabpanel
+ *   - paint the poster (the same eyebrow / title / byline / version
+ *     the scene draws inside the canvas, plus an `<os-spinner>`)
+ *     synchronously, so the tab never shows a blank void
  *   - kick off `wp.os.loadModules(['pixijs'])` so the vendor
  *     script is in memory before the scene mounts
  *   - mount on first attach, tear down when the wrapper leaves the
@@ -17,10 +20,30 @@
  *     removal via a `MutationObserver` on `document.body` so we don't
  *     leak the WebGL context across re-renders triggered by the
  *     settings-tab registry, save-failure rollbacks, or a Reset.
+ *
+ * ## Why a poster and not just a spinner
+ *
+ * Every word on this tab — the product name, the credit line, the
+ * plugin version — is painted inside the WebGL canvas, so all of it
+ * used to be gated on three separate network round-trips (the PixiJS
+ * vendor bundle, the about-scene bundle, the logotype PNG) plus a
+ * pixel-sampling pass over that PNG. The poster is plain HTML with
+ * the same copy, laid out to roughly the same proportions the scene
+ * uses, so the useful information is on screen on the first frame
+ * and the canvas cross-fades in over it once it is live.
+ *
+ * The poster is never removed from the DOM and never gets
+ * `visibility: hidden` — it fades to `opacity: 0` and stays
+ * `pointer-events: none`. The canvas exposes no text to assistive
+ * technology, so the faded poster is the only accessible copy of
+ * what this tab says. It also means a scene that fails to load (no
+ * WebGL, blocked bundle) degrades to a readable About tab rather
+ * than to the blank panel it degraded to before.
  */
 
 import { __ } from '../../i18n';
 import { html, render } from '../../ui/core';
+import '../../ui/components/os-spinner/os-spinner';
 import {
 	mountAboutSceneLazy,
 	type AboutScene,
@@ -59,11 +82,17 @@ function waitForSize( el: HTMLElement ): Promise<void> {
 
 /**
  * Builder — returns the About section element ready to drop into the
- * OS Settings tabpanel. The Pixi mount is deferred until the wrapper
- * is in the DOM (next animation frame), so the section can be safely
- * embedded inside a hidden tabpanel without spinning up a canvas on
- * a zero-size host. A ResizeObserver picks up the visibility flip
- * once the user activates the tab.
+ * OS Settings tabpanel. The poster renders synchronously; the Pixi
+ * mount is deferred until the wrapper is in the DOM (next animation
+ * frame), so the section can be safely embedded inside a hidden
+ * tabpanel without spinning up a canvas on a zero-size host. A
+ * ResizeObserver picks up the visibility flip once the user activates
+ * the tab.
+ *
+ * The wrapper carries the hand-over state as a class: none while the
+ * scene is loading, `is-scene-ready` once the canvas is live (cross-
+ * fade), `is-scene-failed` if it never arrives (poster stays, canvas
+ * host goes).
  */
 export function buildAboutSection(): HTMLElement {
 	const wrapper = document.createElement( 'div' );
@@ -79,18 +108,61 @@ export function buildAboutSection(): HTMLElement {
 	const desktopApi = ( window.wp as { os?: DesktopApiShape } | undefined )
 		?.os;
 
+	const labels = {
+		eyebrow: __( 'WordPress OpenStation' ),
+		title: __( 'Crafted with curiosity' ),
+		byline: __( 'an experiment by Automattic' ),
+		version: version ? `${ __( 'Version' ) } ${ version }` : '',
+		hint: __( 'Move your cursor through the swarm · click for a spark' ),
+	};
+
 	render(
 		html`
 			<div
 				class="os-settings__about-stage-host"
 				data-about-stage
 			></div>
+			<div class="os-settings__about-poster" data-about-poster>
+				<p class="os-settings__about-eyebrow">${ labels.eyebrow }</p>
+				<p class="os-settings__about-title">${ labels.title }</p>
+				<div class="os-settings__about-loader" data-about-loader>
+					<os-spinner
+						preset="orbit"
+						size="44"
+						label=${ __( 'Loading the About scene' ) }
+					></os-spinner>
+				</div>
+				<p class="os-settings__about-byline">${ labels.byline }</p>
+				<p class="os-settings__about-version">${ labels.version }</p>
+			</div>
 		`,
 		wrapper,
 	);
 
 	let scene: AboutScene | null = null;
 	let aborted = false;
+
+	/**
+	 * Drop the spinner. Called both when the scene goes live (the
+	 * canvas takes over) and when it fails (nothing is coming, so a
+	 * spinner would be a lie). The box around it stays as a spacer so
+	 * the byline and version keep their place either way.
+	 */
+	const stopLoading = (): void => {
+		wrapper
+			.querySelector< HTMLElement >( '[data-about-loader] os-spinner' )
+			?.remove();
+	};
+
+	const markSceneReady = (): void => {
+		stopLoading();
+		wrapper.classList.add( 'is-scene-ready' );
+	};
+
+	const markSceneFailed = (): void => {
+		stopLoading();
+		wrapper.classList.add( 'is-scene-failed' );
+	};
 
 	const tearDown = (): void => {
 		aborted = true;
@@ -137,15 +209,7 @@ export function buildAboutSection(): HTMLElement {
 					prefersReducedMotion:
 						typeof window.matchMedia === 'function' &&
 						window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches,
-					labels: {
-						eyebrow: __( 'WordPress OpenStation' ),
-						title: __( 'Crafted with curiosity' ),
-						byline: __( 'an experiment by Automattic' ),
-						version: version
-							? `${ __( 'Version' ) } ${ version }`
-							: '',
-						hint: __( 'Move your cursor through the swarm · click for a spark' ),
-					},
+					labels,
 				},
 				aboutSceneBundleUrl,
 			);
@@ -154,7 +218,9 @@ export function buildAboutSection(): HTMLElement {
 				return;
 			}
 			scene = built;
+			markSceneReady();
 		} catch ( err ) {
+			markSceneFailed();
 			if ( typeof console !== 'undefined' ) {
 				// eslint-disable-next-line no-console
 				console.error( '[desktop-mode/about] scene mount failed:', err );

--- a/src/settings/sections/about.ts
+++ b/src/settings/sections/about.ts
@@ -23,8 +23,8 @@
  *
  * ## Why a poster and not just a spinner
  *
- * Every word on this tab (the product name, the credit line, the
- * plugin version) is painted inside the WebGL canvas, so all of it
+ * Every word on this tab — the product name, the credit line, the
+ * plugin version — is painted inside the WebGL canvas, so all of it
  * used to be gated on three separate network round-trips (the PixiJS
  * vendor bundle, the about-scene bundle, the logotype PNG) plus a
  * pixel-sampling pass over that PNG. The poster is plain HTML with
@@ -33,7 +33,7 @@
  * and the canvas cross-fades in over it once it is live.
  *
  * The poster is never removed from the DOM and never gets
- * `visibility: hidden`. It fades to `opacity: 0` and stays
+ * `visibility: hidden` — it fades to `opacity: 0` and stays
  * `pointer-events: none`. The canvas exposes no text to assistive
  * technology, so the faded poster is the only accessible copy of
  * what this tab says. It also means a scene that fails to load (no

--- a/src/settings/sections/about.ts
+++ b/src/settings/sections/about.ts
@@ -23,8 +23,8 @@
  *
  * ## Why a poster and not just a spinner
  *
- * Every word on this tab — the product name, the credit line, the
- * plugin version — is painted inside the WebGL canvas, so all of it
+ * Every word on this tab (the product name, the credit line, the
+ * plugin version) is painted inside the WebGL canvas, so all of it
  * used to be gated on three separate network round-trips (the PixiJS
  * vendor bundle, the about-scene bundle, the logotype PNG) plus a
  * pixel-sampling pass over that PNG. The poster is plain HTML with
@@ -33,7 +33,7 @@
  * and the canvas cross-fades in over it once it is live.
  *
  * The poster is never removed from the DOM and never gets
- * `visibility: hidden` — it fades to `opacity: 0` and stays
+ * `visibility: hidden`. It fades to `opacity: 0` and stays
  * `pointer-events: none`. The canvas exposes no text to assistive
  * technology, so the faded poster is the only accessible copy of
  * what this tab says. It also means a scene that fails to load (no

--- a/tests/vitest/about-tab-poster.test.ts
+++ b/tests/vitest/about-tab-poster.test.ts
@@ -1,5 +1,5 @@
 /**
- * About tab: the poster that stands in for the PixiJS scene.
+ * About tab — the poster that stands in for the PixiJS scene.
  *
  * The scene is gated on the PixiJS vendor bundle, the about-scene
  * bundle and the logotype PNG, so there is a real window where the
@@ -17,7 +17,7 @@ vi.mock( '../../src/settings/sections/about-scene-loader', () => ( {
 		mountAboutSceneLazy( ...args ),
 } ) );
 
-/** Sized-element getters. jsdom reports every box as 0x0. */
+/** Sized-element getters — jsdom reports every box as 0×0. */
 let sizeSpies: Array< () => void > = [];
 
 function stubLayoutBoxes( width: number, height: number ): void {
@@ -100,7 +100,7 @@ describe( 'About tab poster', () => {
 		mountAboutSceneLazy.mockReturnValue( new Promise( () => {} ) );
 		const el = await buildSection();
 
-		// Synchronous, no awaiting and no rAF: this is the first frame.
+		// Synchronous — no awaiting, no rAF: this is the first frame.
 		const poster = el.querySelector( '[data-about-poster]' );
 		expect( poster ).not.toBeNull();
 		expect( poster?.textContent ).toContain( 'Crafted with curiosity' );

--- a/tests/vitest/about-tab-poster.test.ts
+++ b/tests/vitest/about-tab-poster.test.ts
@@ -1,5 +1,5 @@
 /**
- * About tab — the poster that stands in for the PixiJS scene.
+ * About tab: the poster that stands in for the PixiJS scene.
  *
  * The scene is gated on the PixiJS vendor bundle, the about-scene
  * bundle and the logotype PNG, so there is a real window where the
@@ -17,7 +17,7 @@ vi.mock( '../../src/settings/sections/about-scene-loader', () => ( {
 		mountAboutSceneLazy( ...args ),
 } ) );
 
-/** Sized-element getters — jsdom reports every box as 0×0. */
+/** Sized-element getters. jsdom reports every box as 0x0. */
 let sizeSpies: Array< () => void > = [];
 
 function stubLayoutBoxes( width: number, height: number ): void {
@@ -100,7 +100,7 @@ describe( 'About tab poster', () => {
 		mountAboutSceneLazy.mockReturnValue( new Promise( () => {} ) );
 		const el = await buildSection();
 
-		// Synchronous — no awaiting, no rAF: this is the first frame.
+		// Synchronous, no awaiting and no rAF: this is the first frame.
 		const poster = el.querySelector( '[data-about-poster]' );
 		expect( poster ).not.toBeNull();
 		expect( poster?.textContent ).toContain( 'Crafted with curiosity' );

--- a/tests/vitest/about-tab-poster.test.ts
+++ b/tests/vitest/about-tab-poster.test.ts
@@ -1,0 +1,165 @@
+/**
+ * About tab — the poster that stands in for the PixiJS scene.
+ *
+ * The scene is gated on the PixiJS vendor bundle, the about-scene
+ * bundle and the logotype PNG, so there is a real window where the
+ * tabpanel has nothing to show. These tests pin what the user sees
+ * during that window (the credits, the version, a spinner), and what
+ * happens to it on both exits: the scene going live, and the scene
+ * failing to load at all.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mountAboutSceneLazy = vi.fn();
+
+vi.mock( '../../src/settings/sections/about-scene-loader', () => ( {
+	mountAboutSceneLazy: ( ...args: unknown[] ) =>
+		mountAboutSceneLazy( ...args ),
+} ) );
+
+/** Sized-element getters — jsdom reports every box as 0×0. */
+let sizeSpies: Array< () => void > = [];
+
+function stubLayoutBoxes( width: number, height: number ): void {
+	for ( const prop of [ 'clientWidth', 'clientHeight' ] as const ) {
+		const original = Object.getOwnPropertyDescriptor(
+			HTMLElement.prototype,
+			prop,
+		);
+		Object.defineProperty( HTMLElement.prototype, prop, {
+			configurable: true,
+			get: () => ( prop === 'clientWidth' ? width : height ),
+		} );
+		sizeSpies.push( () => {
+			if ( original ) {
+				Object.defineProperty( HTMLElement.prototype, prop, original );
+			} else {
+				delete ( HTMLElement.prototype as unknown as Record<
+					string,
+					unknown
+				> )[ prop ];
+			}
+		} );
+	}
+}
+
+/** Flush the deferred mount (rAF) plus the promise chain inside it. */
+async function flushMount(): Promise< void > {
+	for ( let i = 0; i < 8; i++ ) {
+		await new Promise( ( resolve ) => {
+			requestAnimationFrame( () => resolve( null ) );
+		} );
+		await Promise.resolve();
+	}
+}
+
+async function buildSection(): Promise< HTMLElement > {
+	const { buildAboutSection } = await import(
+		'../../src/settings/sections/about'
+	);
+	const el = buildAboutSection();
+	document.body.appendChild( el );
+	return el;
+}
+
+describe( 'About tab poster', () => {
+	beforeEach( () => {
+		vi.resetModules();
+		mountAboutSceneLazy.mockReset();
+		sizeSpies = [];
+		stubLayoutBoxes( 800, 600 );
+		( window as unknown as { openStationConfig?: unknown } ).openStationConfig =
+			{
+				pluginUrl: 'https://example.test/plugin',
+				pluginVersion: '1.2.3',
+				aboutSceneBundleUrl: 'https://example.test/about-scene.js',
+			};
+		( window as unknown as { ResizeObserver?: unknown } ).ResizeObserver =
+			class {
+				constructor( private readonly cb: () => void ) {}
+				observe(): void {
+					this.cb();
+				}
+				disconnect(): void {}
+				unobserve(): void {}
+			};
+	} );
+
+	afterEach( () => {
+		for ( const restore of sizeSpies ) {
+			restore();
+		}
+		sizeSpies = [];
+		document.body.innerHTML = '';
+		delete ( window as unknown as { openStationConfig?: unknown } )
+			.openStationConfig;
+		vi.restoreAllMocks();
+	} );
+
+	test( 'paints the credits and the version before the scene loads', async () => {
+		mountAboutSceneLazy.mockReturnValue( new Promise( () => {} ) );
+		const el = await buildSection();
+
+		// Synchronous — no awaiting, no rAF: this is the first frame.
+		const poster = el.querySelector( '[data-about-poster]' );
+		expect( poster ).not.toBeNull();
+		expect( poster?.textContent ).toContain( 'Crafted with curiosity' );
+		expect( poster?.textContent ).toContain( 'an experiment by Automattic' );
+		expect( poster?.textContent ).toContain( 'Version 1.2.3' );
+		expect( el.querySelector( '[data-about-loader] os-spinner' ) ).not.toBeNull();
+		expect( el.classList.contains( 'is-scene-ready' ) ).toBe( false );
+	} );
+
+	test( 'hands over to the canvas once the scene mounts', async () => {
+		const destroy = vi.fn();
+		mountAboutSceneLazy.mockResolvedValue( {
+			destroy,
+			setAnimating: vi.fn(),
+		} );
+		const el = await buildSection();
+		await flushMount();
+
+		expect( mountAboutSceneLazy ).toHaveBeenCalledTimes( 1 );
+		expect( el.classList.contains( 'is-scene-ready' ) ).toBe( true );
+		// Spinner gone, poster still in the DOM: the canvas exposes no
+		// text, so the faded poster stays the accessible copy.
+		expect( el.querySelector( '[data-about-loader] os-spinner' ) ).toBeNull();
+		expect( el.querySelector( '[data-about-poster]' ) ).not.toBeNull();
+		expect(
+			el.querySelector( '[data-about-poster]' )?.textContent,
+		).toContain( 'Version 1.2.3' );
+	} );
+
+	test( 'keeps the credits readable when the scene fails to load', async () => {
+		vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		mountAboutSceneLazy.mockRejectedValue( new Error( 'no webgl' ) );
+		const el = await buildSection();
+		await flushMount();
+
+		expect( el.classList.contains( 'is-scene-failed' ) ).toBe( true );
+		expect( el.classList.contains( 'is-scene-ready' ) ).toBe( false );
+		// A spinner that spins forever would be a lie.
+		expect( el.querySelector( '[data-about-loader] os-spinner' ) ).toBeNull();
+		expect(
+			el.querySelector( '[data-about-poster]' )?.textContent,
+		).toContain( 'Crafted with curiosity' );
+	} );
+
+	test( 'forwards one set of labels to the poster and the scene', async () => {
+		mountAboutSceneLazy.mockResolvedValue( {
+			destroy: vi.fn(),
+			setAnimating: vi.fn(),
+		} );
+		const el = await buildSection();
+		await flushMount();
+
+		const opts = mountAboutSceneLazy.mock.calls[ 0 ][ 0 ] as {
+			labels: Record< string, string >;
+		};
+		const posterText =
+			el.querySelector( '[data-about-poster]' )?.textContent ?? '';
+		for ( const key of [ 'eyebrow', 'title', 'byline', 'version' ] ) {
+			expect( posterText ).toContain( opts.labels[ key ] );
+		}
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

OpenStation Preferences > About now paints its credits on the first frame instead of showing an empty dark panel for about three seconds while the PixiJS scene loads.

The tab renders a poster (the same eyebrow, title, byline and version the scene draws inside the canvas, as plain HTML) with an `<os-spinner>` in the band the logotype will fill. The canvas cross-fades in over it once the scene is live.

Two side effects worth calling out:

- The poster fades out but stays in the DOM. The canvas exposes no text to assistive technology, so the faded poster is the only accessible copy of what the tab says.
- A scene that never loads (no WebGL, blocked bundle) now leaves a readable About tab instead of a blank panel. The spinner goes and so does the dead canvas host.

The tabpanel background is now the scene's own radial backdrop rather than a different linear gradient, so the fade-in doesn't swap the background under the reader.

## Why are these changes being made?

Because every word on that tab was gated on a graphics bundle. Three network round-trips plus a pixel-sampling pass sit between clicking the tab and the canvas having anything on it, and there was nothing on screen meanwhile, so a first click read as broken.

## Testing Instructions

1. Load `/wp-admin`, open `OpenStation Preferences` from the dock, then the `About` tab.
2. Make sure the panel is never blank. "WordPress OpenStation", "Crafted with curiosity", "an experiment by Automattic", the version line and a spinner must all be there from the first frame.
3. Wait for the particle scene. Make sure the spinner disappears, the canvas fades in rather than popping, and the text lands close to where the poster had it (a small shift is expected, a jump across the panel is not).
4. Move the cursor over the swarm and click it. Make sure the magnetic pull and the click shockwave still work, so the faded poster is not eating pointer events.
5. Hard-reload with the network throttled (DevTools > Network > Slow 3G) and reopen the tab. Make sure the poster holds the screen for the whole wait rather than flashing.
6. Simulate a failure: with DevTools open, block `**/about-scene*.js` (Network > right-click a request > Block request URL), then reopen `OpenStation Preferences` and the `About` tab. Make sure the credits and version stay readable, the spinner is gone, and the crosshair cursor is gone too. The console logs `[desktop-mode/about] scene mount failed`.
7. Resize the OS Settings window narrow and wide while the scene is still loading. Make sure the poster stays centred and the title scales instead of wrapping badly.
8. Turn on `prefers-reduced-motion` (macOS: System Settings > Accessibility > Display > Reduce motion) and reopen the tab. Make sure the canvas still arrives, just without the fade.
9. Switch to another tab and back a few times, and close and reopen the window. Make sure the scene still mounts every time and the poster does not reappear over a live canvas.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-524-ec4027ba76832756cd0494f2a372fc0cc8c5d6ec.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->