### PR TITLE
Windows: Stop the loading spinner from fading over painted content

### DIFF
--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -926,15 +926,12 @@ os-tab-chip + os-tab-chip {
  * output) and kept aria-hidden so the spinner's own SR-label is
  * the only loading announcement.
  *
- * The `--visible` modifier is what turns the overlay on, and JS adds
- * it ~120ms into the load (`LOADING_OVERLAY_SHOW_DELAY_MS`), so a
- * render that lands inside that window never paints the spinner at
- * all. The delay cannot live here as a `transition-delay`: the
- * overlay is appended into a body that already carries `--loading`,
- * so its first computed style would be the visible one and there is
- * no before-change value for a transition to run from. Keeping the
- * affordance off entirely on fast loads is the point — it still
- * covers the slow production iframe boots that motivated it.
+ * The `--visible` modifier turns the overlay on. JS adds it ~120ms
+ * into the load (`LOADING_OVERLAY_SHOW_DELAY_MS`), so a fast render
+ * never paints a spinner. The delay cannot be a `transition-delay`
+ * here: the overlay is appended into a body that already carries
+ * `--loading`, so its first computed style is the visible one and the
+ * transition never runs.
  */
 .os-window__loading {
 	position: absolute;
@@ -972,26 +969,20 @@ os-tab-chip + os-tab-chip {
 }
 
 /*
- * Content hand-off. `--loading` drops the instant the content reports
- * ready, but the overlay sitting above it still needs its 250ms to
- * fade out — and a spinner dissolving over text that has already
- * painted is both layers on screen at once, which reads as a flash of
- * overlapping artwork rather than as a transition.
+ * Content hand-off. `--loading` drops as soon as the content is ready,
+ * but the overlay above it still needs 250ms to fade out. Without this
+ * both layers are on screen at once, which reads as a flash.
  *
- * This modifier keeps the content exactly where `--loading` left it
- * (transparent) for the length of that fade, then fades it in. The
- * delay in the shorthand is what does the holding: the content's
- * before-change opacity is 0, so nothing moves until the delay is up.
+ * This modifier holds the content transparent for the length of that
+ * fade, then fades it in. The delay in the shorthand does the holding.
  *
- * Only added when the spinner ACTUALLY painted. A load that finishes
+ * Only added when the spinner actually painted. A load that finishes
  * inside the show delay never reached `--visible`, so the shell drops
- * the overlay in the same tick and the content appears with nothing
- * to wait for.
+ * the overlay in the same tick instead.
  *
- * `--revealing` declares the same selector at the same specificity
- * and comes later in the file, so a window playing a reveal keeps its
- * content pinned to full opacity under the opaque reveal surface —
- * which is that layer's job, not this one's.
+ * `--revealing` declares the same selector at the same specificity and
+ * comes later in the file, so a window playing a reveal keeps its
+ * content opaque under the reveal surface.
  */
 .os-window__body--loading-out > .os-window__iframe,
 .os-window__body--loading-out

--- a/assets/css/window-chrome.css
+++ b/assets/css/window-chrome.css
@@ -926,12 +926,15 @@ os-tab-chip + os-tab-chip {
  * output) and kept aria-hidden so the spinner's own SR-label is
  * the only loading announcement.
  *
- * `transition-delay` on the overlay's fade-in means a render
- * that lands within ~120ms never paints the spinner — the
- * overlay only becomes visible when there's actually a wait
- * worth surfacing. This keeps the affordance from flashing on
- * fast local-dev loads while still covering the slow production
- * iframe boots that motivated it.
+ * The `--visible` modifier is what turns the overlay on, and JS adds
+ * it ~120ms into the load (`LOADING_OVERLAY_SHOW_DELAY_MS`), so a
+ * render that lands inside that window never paints the spinner at
+ * all. The delay cannot live here as a `transition-delay`: the
+ * overlay is appended into a body that already carries `--loading`,
+ * so its first computed style would be the visible one and there is
+ * no before-change value for a transition to run from. Keeping the
+ * affordance off entirely on fast loads is the point — it still
+ * covers the slow production iframe boots that motivated it.
  */
 .os-window__loading {
 	position: absolute;
@@ -964,13 +967,37 @@ os-tab-chip + os-tab-chip {
 	transition: opacity 0.25s ease;
 }
 
-.os-window__body--loading > .os-window__loading {
+.os-window__body--loading > .os-window__loading--visible {
 	opacity: 1;
-	/* Entry transition with a small delay — loads that finish in
-	 * under ~120ms never paint the spinner, so fast local-dev /
-	 * hot-cache fires don't flash. Slow production iframe boots
-	 * still see the spinner. */
-	transition-delay: 0.12s;
+}
+
+/*
+ * Content hand-off. `--loading` drops the instant the content reports
+ * ready, but the overlay sitting above it still needs its 250ms to
+ * fade out — and a spinner dissolving over text that has already
+ * painted is both layers on screen at once, which reads as a flash of
+ * overlapping artwork rather than as a transition.
+ *
+ * This modifier keeps the content exactly where `--loading` left it
+ * (transparent) for the length of that fade, then fades it in. The
+ * delay in the shorthand is what does the holding: the content's
+ * before-change opacity is 0, so nothing moves until the delay is up.
+ *
+ * Only added when the spinner ACTUALLY painted. A load that finishes
+ * inside the show delay never reached `--visible`, so the shell drops
+ * the overlay in the same tick and the content appears with nothing
+ * to wait for.
+ *
+ * `--revealing` declares the same selector at the same specificity
+ * and comes later in the file, so a window playing a reveal keeps its
+ * content pinned to full opacity under the opaque reveal surface —
+ * which is that layer's job, not this one's.
+ */
+.os-window__body--loading-out > .os-window__iframe,
+.os-window__body--loading-out
+	> :not(.os-window__loading):not(.os-window__reveal) {
+	opacity: 1;
+	transition: opacity 0.25s ease 0.25s;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
@@ -978,6 +1005,9 @@ os-tab-chip + os-tab-chip {
 	.os-window__loading,
 	.os-window__body--loading > .os-window__iframe,
 	.os-window__body--loading
+		> :not(.os-window__loading):not(.os-window__reveal),
+	.os-window__body--loading-out > .os-window__iframe,
+	.os-window__body--loading-out
 		> :not(.os-window__loading):not(.os-window__reveal) {
 		transition: none;
 	}

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -132,7 +132,7 @@ Companion `wp.hooks` action: `HOOKS.WINDOW_CONTENT_LOADING` (`os.window.content-
 
 Fires when a window's body content becomes ready — for iframe windows the moment the chromeless bridge announces `os-ready`, for native windows after the user's `render( body )` callback (or its returned Promise) resolves, and whenever a plugin calls `Window.markContentLoaded()` or `ctx.window.markReady()` mid-life. The shell removes the loading overlay and fades the body content in on this transition.
 
-**The overlay and the content are never on screen together.** If the spinner never painted (the load finished inside the 120 ms show delay), the overlay is removed in the same tick and the content appears with no wait. If it did paint, it gets its 250 ms fade-out to itself and the content fades in after that, not underneath it.
+**The overlay and the content are never on screen together.** If the spinner never painted (the load finished inside the 120 ms show delay), the overlay is removed in the same tick, so nothing is held back. A native body appears immediately; an iframe still fades in over 250 ms via its own base rule. If it did paint, it gets its 250 ms fade-out to itself and the content fades in after that, not underneath it.
 
 **Use this instead of branching on iframe vs. native.** The unified signal across both render strategies. Iframe-only consumers can still subscribe to `os.iframe.ready`, which fires alongside this event for iframe windows.
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -110,6 +110,8 @@ Fires every time a window enters the **loading** state — at construction (ever
 
 The shell paints a `<os-spinner>` overlay over the body while the window is loading and fades the body content out. The overlay's spinner is sized responsively (`clamp(96px, 14vw, 192px)`) so it scales with the window's width.
 
+The overlay element is attached immediately (so `config.loading.render` and the `WINDOW_LOADING_OVERLAY` filter always have a host) but stays **invisible for the first 120 ms**. A load that finishes inside that window never paints a spinner at all.
+
 **Edge-triggered.** Idempotent calls don't re-fire — a plugin that calls `markLoading()` twice in a row sees the event exactly once.
 
 ```javascript
@@ -129,6 +131,8 @@ Companion `wp.hooks` action: `HOOKS.WINDOW_CONTENT_LOADING` (`os.window.content-
 ### `os-window-content-loaded` — Stable
 
 Fires when a window's body content becomes ready — for iframe windows the moment the chromeless bridge announces `os-ready`, for native windows after the user's `render( body )` callback (or its returned Promise) resolves, and whenever a plugin calls `Window.markContentLoaded()` or `ctx.window.markReady()` mid-life. The shell removes the loading overlay and fades the body content in on this transition.
+
+**The overlay and the content are never on screen together.** If the spinner never painted (the load finished inside the 120 ms show delay), the overlay is removed in the same tick and the content appears with no wait. If it did paint, it gets its 250 ms fade-out to itself and the content fades in after that, not underneath it.
 
 **Use this instead of branching on iframe vs. native.** The unified signal across both render strategies. Iframe-only consumers can still subscribe to `os.iframe.ready`, which fires alongside this event for iframe windows.
 
@@ -2843,11 +2847,13 @@ w.markContentLoading();
 await refetchData();
 w.appendBody( renderTable( data ) );
 
-// Hide the spinner, fade the content in.
+// Hide the spinner, then fade the content in.
 w.markContentLoaded();
 ```
 
 Idempotent: calling `markContentLoading()` twice in a row only fires `WINDOW_CONTENT_LOADING` once; the same edge-trigger logic applies to `markContentLoaded()`.
+
+A refetch that resolves inside the 120 ms show delay never paints a spinner, so the pair is cheap to reach for on work that is usually fast. When one does paint, the content waits for its fade-out rather than appearing under it.
 
 The framework calls `markContentLoaded()` automatically when:
 - An iframe window's chromeless bridge posts `os-ready`.

--- a/src/reveals/surface.ts
+++ b/src/reveals/surface.ts
@@ -122,16 +122,6 @@ export const REVEAL_CUSTOM_CLASS = 'os-window__reveal--custom';
 export const REVEALING_BODY_CLASS = 'os-window__body--revealing';
 
 /**
- * Timestamp (ms) when the surface was armed, stamped on the element
- * itself rather than held in a side map — the element is the thing
- * whose lifetime the value tracks, and a window torn down mid-load
- * takes its stamp with it instead of leaking an entry.
- *
- * @internal
- */
-const ARMED_AT_ATTR = 'data-os-reveal-armed';
-
-/**
  * Id of the reveal that armed this surface. Read back at play time so a
  * user who switches reveals while a window is mid-load still gets a
  * matched `from` / `to` pair — animating from the OLD shape to the NEW
@@ -450,7 +440,7 @@ function findLayers( body: HTMLElement ): HTMLElement[] {
 
 /**
  * Build one reveal layer, clipped to the reveal's `from` shape and
- * stamped with the reveal id + arm time.
+ * stamped with the reveal id.
  *
  * @internal
  */
@@ -458,7 +448,6 @@ function createLayer(
 	def: WindowRevealDef,
 	pair: WindowRevealLayer,
 	index: number,
-	armedAt: number,
 	edge: boolean,
 ): HTMLElement {
 	const layer = document.createElement( 'div' );
@@ -478,7 +467,6 @@ function createLayer(
 	layer.setAttribute( 'aria-hidden', 'true' );
 	layer.setAttribute( REVEAL_ID_ATTR, def.id );
 	layer.setAttribute( LAYER_INDEX_ATTR, String( index ) );
-	layer.setAttribute( ARMED_AT_ATTR, String( armedAt ) );
 	layer.style.clipPath = pair.from;
 	return layer;
 }
@@ -534,7 +522,6 @@ export function createRevealLayers(): HTMLElement[] {
 		host.setAttribute( 'aria-hidden', 'true' );
 		host.setAttribute( REVEAL_ID_ATTR, def.id );
 		host.setAttribute( LAYER_INDEX_ATTR, '0' );
-		host.setAttribute( ARMED_AT_ATTR, String( Date.now() ) );
 		rendered.set( host, built.play );
 		return [ host ];
 	}
@@ -543,7 +530,6 @@ export function createRevealLayers(): HTMLElement[] {
 	if ( pairs.length === 0 ) {
 		return [];
 	}
-	const armedAt = Date.now();
 	const layers: HTMLElement[] = [];
 	// Every edge first, then every surface: the two classes carry their
 	// own `z-index`, and keeping the groups contiguous means one
@@ -551,11 +537,11 @@ export function createRevealLayers(): HTMLElement[] {
 	// face.
 	if ( clampRevealEdgeLag( def.edgeLag ) > 0 ) {
 		pairs.forEach( ( pair, i ) =>
-			layers.push( createLayer( def, pair, i, armedAt, true ) ),
+			layers.push( createLayer( def, pair, i, true ) ),
 		);
 	}
 	pairs.forEach( ( pair, i ) =>
-		layers.push( createLayer( def, pair, i, armedAt, false ) ),
+		layers.push( createLayer( def, pair, i, false ) ),
 	);
 	return layers;
 }

--- a/src/reveals/surface.ts
+++ b/src/reveals/surface.ts
@@ -69,8 +69,9 @@
  */
 
 import {
+	LOADING_OVERLAY_CLASS,
 	LOADING_OVERLAY_FADE_OUT_MS,
-	LOADING_OVERLAY_SHOW_DELAY_MS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
 } from '../window/constants';
 import { createSharedStore } from '../shared-store';
 import { getActiveWindowReveal, getActiveWindowRevealDuration } from './engine';
@@ -627,14 +628,19 @@ export function playWindowReveal( windowEl: HTMLElement ): void {
 		return;
 	}
 
-	const armedAt = Number( surface.getAttribute( ARMED_AT_ATTR ) );
-	const elapsed = Number.isFinite( armedAt ) ? Date.now() - armedAt : 0;
-	// The spinner overlay only becomes visible once its entry delay has
-	// passed. When it did appear, hold the surface still until its
+	// When a spinner actually painted, hold the surface still until its
 	// fade-out has settled so the two transitions read as one sequence
 	// rather than as a cross-fade.
-	const delay =
-		elapsed >= LOADING_OVERLAY_SHOW_DELAY_MS ? LOADING_OVERLAY_FADE_OUT_MS : 0;
+	//
+	// Read the overlay's own class rather than re-deriving it from a
+	// clock. The loaded edge in `src/window/loading.ts` decides from
+	// this same signal, and a second guess drifts from it: a load
+	// landing either side of the show delay, or an overlay inherited
+	// from a previous cycle, made the two disagree.
+	const spinnerVisible = !! body
+		.querySelector( `:scope .${ LOADING_OVERLAY_CLASS }` )
+		?.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS );
+	const delay = spinnerVisible ? LOADING_OVERLAY_FADE_OUT_MS : 0;
 
 	const { duration, edgeLag } = resolveTiming( body, def );
 	const easingValue = def.easing ?? DEFAULT_REVEAL_EASING;

--- a/src/window/constants.ts
+++ b/src/window/constants.ts
@@ -55,33 +55,22 @@ export const EXTERNAL_IFRAME_READY_TIMEOUT_MS = 3000;
 export const LOADING_OVERLAY_FADE_OUT_MS = 250;
 
 /**
- * Entry delay before the loading overlay may fade IN. Owned by JS:
- * `ensureLoadingOverlay` waits this long before adding the
- * `os-window__loading--visible` modifier that the CSS rule keys off.
+ * How long to wait before the loading overlay may fade in. A load that
+ * finishes inside this window never paints a spinner at all.
  *
- * It cannot be a `transition-delay` on the overlay itself. The overlay
- * is appended into a body that ALREADY carries `os-window__body--loading`,
- * so its very first computed style is the visible one — there is no
- * before-change value for a transition to run from, and the delay is
- * skipped entirely. That made the spinner reach full strength on every
- * open regardless of how fast the content landed.
- *
- * Loads that finish inside this window never paint a spinner at all,
- * which is what the reveal surface checks to decide whether it has a
- * fade-out to wait for.
+ * Owned by JS, not a CSS `transition-delay`: the overlay is appended
+ * into a body that already carries `os-window__body--loading`, so its
+ * first computed style is the visible one and the transition never
+ * runs.
  */
 export const LOADING_OVERLAY_SHOW_DELAY_MS = 120;
 
 /**
- * How long the body content takes to fade in once the loading overlay
- * has finished fading out. Must match the `transition` duration on
- * `.os-window__body--loading-out > …` in
- * `assets/css/window-chrome.css`; the shell waits
- * {@link LOADING_OVERLAY_FADE_OUT_MS} plus this span before dropping
- * the hand-off modifier.
+ * How long the content takes to fade in after the overlay has faded
+ * out. Must match the `transition` on `.os-window__body--loading-out`
+ * in `assets/css/window-chrome.css`.
  *
- * The two spans are sequential, never concurrent: a spinner fading out
- * over content that has already painted puts both layers on screen at
- * once, which is the flash this hand-off exists to prevent.
+ * The two fades run back to back, never together, so the spinner and
+ * the content are never both on screen.
  */
 export const LOADING_CONTENT_FADE_IN_MS = 250;

--- a/src/window/constants.ts
+++ b/src/window/constants.ts
@@ -55,12 +55,33 @@ export const EXTERNAL_IFRAME_READY_TIMEOUT_MS = 3000;
 export const LOADING_OVERLAY_FADE_OUT_MS = 250;
 
 /**
- * Entry delay before the loading overlay fades IN. Must match the
- * `transition-delay` on `.os-window__body--loading >
- * .os-window__loading` in `assets/css/window-chrome.css`.
+ * Entry delay before the loading overlay may fade IN. Owned by JS:
+ * `ensureLoadingOverlay` waits this long before adding the
+ * `os-window__loading--visible` modifier that the CSS rule keys off.
+ *
+ * It cannot be a `transition-delay` on the overlay itself. The overlay
+ * is appended into a body that ALREADY carries `os-window__body--loading`,
+ * so its very first computed style is the visible one — there is no
+ * before-change value for a transition to run from, and the delay is
+ * skipped entirely. That made the spinner reach full strength on every
+ * open regardless of how fast the content landed.
  *
  * Loads that finish inside this window never paint a spinner at all,
  * which is what the reveal surface checks to decide whether it has a
  * fade-out to wait for.
  */
 export const LOADING_OVERLAY_SHOW_DELAY_MS = 120;
+
+/**
+ * How long the body content takes to fade in once the loading overlay
+ * has finished fading out. Must match the `transition` duration on
+ * `.os-window__body--loading-out > …` in
+ * `assets/css/window-chrome.css`; the shell waits
+ * {@link LOADING_OVERLAY_FADE_OUT_MS} plus this span before dropping
+ * the hand-off modifier.
+ *
+ * The two spans are sequential, never concurrent: a spinner fading out
+ * over content that has already painted puts both layers on screen at
+ * once, which is the flash this hand-off exists to prevent.
+ */
+export const LOADING_CONTENT_FADE_IN_MS = 250;

--- a/src/window/constants.ts
+++ b/src/window/constants.ts
@@ -67,10 +67,23 @@ export const LOADING_OVERLAY_SHOW_DELAY_MS = 120;
 
 /**
  * How long the content takes to fade in after the overlay has faded
- * out. Must match the `transition` on `.os-window__body--loading-out`
- * in `assets/css/window-chrome.css`.
+ * out. The `transition` on `.os-window__body--loading-out` in
+ * `assets/css/window-chrome.css` encodes both halves of the hand-off:
+ * its duration is this constant, its delay is
+ * {@link LOADING_OVERLAY_FADE_OUT_MS}. Keep all three in step.
  *
  * The two fades run back to back, never together, so the spinner and
  * the content are never both on screen.
  */
 export const LOADING_CONTENT_FADE_IN_MS = 250;
+
+/** The loading overlay element's own class. */
+export const LOADING_OVERLAY_CLASS = 'os-window__loading';
+
+/**
+ * Marks a spinner as on screen. This is the single answer to "did the
+ * spinner paint?": both the loaded edge in `src/window/loading.ts` and
+ * the reveal surface in `src/reveals/surface.ts` read it, so they
+ * cannot disagree. Do not re-derive it from a clock.
+ */
+export const LOADING_OVERLAY_VISIBLE_CLASS = 'os-window__loading--visible';

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -24,6 +24,101 @@ import {
 } from '../window-channels';
 import { HOOKS, applyFilters } from '../hooks';
 import { createRevealLayers } from '../reveals/surface';
+import { LOADING_OVERLAY_SHOW_DELAY_MS } from './constants';
+
+/**
+ * Body modifier while a window's content is loading. The overlay's
+ * visibility, the content's hidden state and the re-arm sweep all key
+ * off this one class.
+ *
+ * @internal
+ */
+export const LOADING_BODY_CLASS = 'os-window__body--loading';
+
+/**
+ * Body modifier during the hand-off from a PAINTED spinner to the
+ * content underneath it: the content stays transparent while the
+ * overlay fades out, then fades in. Never added when the spinner
+ * stayed invisible — that load has nothing to hand off from.
+ *
+ * @internal
+ */
+export const LOADING_HANDOFF_BODY_CLASS = 'os-window__body--loading-out';
+
+/**
+ * Overlay modifier meaning "this spinner is on screen". Added by
+ * {@link scheduleLoadingOverlayShow} once the show delay has
+ * elapsed, and read on the loaded edge to decide whether there is a
+ * fade-out to sequence the content behind.
+ *
+ * @internal
+ */
+export const LOADING_OVERLAY_VISIBLE_CLASS = 'os-window__loading--visible';
+
+/**
+ * Wall-clock stamp (ms) of when the body entered the loading state.
+ * Lives on the body element rather than in a side map so it is torn
+ * down with the window, and so a repaint of the overlay mid-load can
+ * resume the same clock instead of restarting it (which would blink a
+ * spinner that was already on screen).
+ *
+ * @internal
+ */
+export const LOADING_STARTED_ATTR = 'data-os-loading-at';
+
+/**
+ * Stamp the moment a body entered the loading state. Called wherever
+ * {@link LOADING_BODY_CLASS} is added — construction here, the
+ * `WINDOW_CONTENT_LOADING` edge in `./loading.ts`.
+ *
+ * @internal
+ */
+export function stampLoadingStart( body: HTMLElement ): void {
+	body.setAttribute( LOADING_STARTED_ATTR, String( Date.now() ) );
+}
+
+/**
+ * Turn an overlay visible once the show delay has elapsed, so a load
+ * that finishes inside that delay never paints a spinner.
+ *
+ * The delay is owned here rather than by a CSS `transition-delay`
+ * because the overlay is appended into a body that already carries
+ * `--loading`: its first computed style is the visible one, no
+ * transition runs, and the delay is skipped. The result was a spinner
+ * at full strength on every window open, cross-fading out over content
+ * that had already painted.
+ *
+ * Resumes the body's existing clock, so `repaintLoadingOverlays()`
+ * mid-load hands the replacement overlay straight back to visible.
+ *
+ * @internal
+ */
+export function scheduleLoadingOverlayShow(
+	body: HTMLElement,
+	overlay: HTMLElement,
+): void {
+	const startedAt = Number( body.getAttribute( LOADING_STARTED_ATTR ) );
+	const elapsed =
+		Number.isFinite( startedAt ) && startedAt > 0 ? Date.now() - startedAt : 0;
+	const remaining = LOADING_OVERLAY_SHOW_DELAY_MS - elapsed;
+	if ( remaining <= 0 ) {
+		overlay.classList.add( LOADING_OVERLAY_VISIBLE_CLASS );
+		return;
+	}
+	// No cancellation bookkeeping: the two conditions that make the
+	// promotion wrong (overlay torn down, window no longer loading)
+	// are both readable at fire time, and a stray timer on a closed
+	// window costs one no-op.
+	window.setTimeout( () => {
+		if ( ! overlay.isConnected ) {
+			return;
+		}
+		if ( ! body.classList.contains( LOADING_BODY_CLASS ) ) {
+			return;
+		}
+		overlay.classList.add( LOADING_OVERLAY_VISIBLE_CLASS );
+	}, remaining );
+}
 
 /**
  * Carrier symbol used to stash a window's config on its outer
@@ -209,11 +304,14 @@ function createLoadingOverlay( config: WindowConfig ): HTMLElement {
 }
 
 /**
- * Remove the loading overlay element from a window's body. Call
- * AFTER the fade-out transition has settled so the spinner doesn't
- * pop. The matching CSS rule sets `transition: opacity` on the
- * overlay; the Window class waits the same duration before
- * invoking this helper.
+ * Remove the loading overlay element from a window's body.
+ *
+ * Call it in the same tick when the overlay never reached
+ * {@link LOADING_OVERLAY_VISIBLE_CLASS} — there is no fade to
+ * interrupt, and leaving an invisible element to "fade" is what let
+ * the spinner and the content share the screen. Otherwise wait out the
+ * fade-out (`LOADING_OVERLAY_FADE_OUT_MS`, the same duration the
+ * matching CSS rule transitions over) so the spinner doesn't pop.
  *
  * Idempotent — a window whose overlay was already removed (e.g.
  * because `markContentLoaded` was called twice in a row) silently
@@ -253,7 +351,11 @@ export function ensureLoadingOverlay( windowEl: HTMLElement ): void {
 		return;
 	}
 	const config = getWindowConfigFromElement( windowEl );
-	body.appendChild( config ? createLoadingOverlay( config ) : buildDefaultLoadingOverlay() );
+	const overlay = config
+		? createLoadingOverlay( config )
+		: buildDefaultLoadingOverlay();
+	body.appendChild( overlay );
+	scheduleLoadingOverlayShow( body, overlay );
 }
 
 /**
@@ -540,7 +642,12 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 	}
 
 	const body = document.createElement( 'div' );
-	body.className = 'os-window__body os-window__body--loading';
+	body.className = `os-window__body ${ LOADING_BODY_CLASS }`;
+	// Start the show-delay clock here, not when the overlay is
+	// appended: `repaintLoadingOverlays()` replaces the overlay
+	// element mid-load and must resume this clock rather than restart
+	// it.
+	stampLoadingStart( body );
 
 	// Native windows own the body contents via {@link WindowConfig.render}
 	// — called from the Window constructor after mount. Skip the iframe
@@ -579,16 +686,20 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 
 	// Loading overlay — sits above the body content (iframe or native
 	// render output) until the window's content reports ready. The
-	// shell drives the visibility via the `--loading` body modifier;
-	// the overlay element itself is removed once the fade-out
-	// transition lands so it doesn't intercept pointer events on a
-	// "ready" window. Painted unconditionally for every window type so
-	// production lag (slow iframe boot, async native data fetch)
-	// always has the same affordance. Customization is plumbed via
+	// element is built for every window type so production lag (slow
+	// iframe boot, async native data fetch) always has the same
+	// affordance, but it stays INVISIBLE until
+	// `scheduleLoadingOverlayShow` promotes it: a load that lands
+	// inside the show delay never paints a spinner, and therefore
+	// never has one to fade out over its own content. The element is
+	// removed once the fade-out lands so it doesn't intercept pointer
+	// events on a "ready" window. Customization is plumbed via
 	// `config.loading.render` (per-window) and the
 	// `WINDOW_LOADING_OVERLAY` filter (global) — see
 	// `createLoadingOverlay` above.
-	body.appendChild( createLoadingOverlay( config ) );
+	const loadingOverlay = createLoadingOverlay( config );
+	body.appendChild( loadingOverlay );
+	scheduleLoadingOverlayShow( body, loadingOverlay );
 
 	// Reveal layers — the opaque surface the window's content is
 	// uncovered from once it reports ready, plus its trailing edge.

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -27,49 +27,40 @@ import { createRevealLayers } from '../reveals/surface';
 import { LOADING_OVERLAY_SHOW_DELAY_MS } from './constants';
 
 /**
- * Body modifier while a window's content is loading. The overlay's
- * visibility, the content's hidden state and the re-arm sweep all key
- * off this one class.
+ * Body modifier while a window's content is loading.
  *
  * @internal
  */
 export const LOADING_BODY_CLASS = 'os-window__body--loading';
 
 /**
- * Body modifier during the hand-off from a PAINTED spinner to the
- * content underneath it: the content stays transparent while the
- * overlay fades out, then fades in. Never added when the spinner
- * stayed invisible — that load has nothing to hand off from.
+ * Body modifier while a painted spinner hands off to the content: the
+ * content stays transparent through the overlay's fade-out, then fades
+ * in. Not used when the spinner never became visible.
  *
  * @internal
  */
 export const LOADING_HANDOFF_BODY_CLASS = 'os-window__body--loading-out';
 
 /**
- * Overlay modifier meaning "this spinner is on screen". Added by
- * {@link scheduleLoadingOverlayShow} once the show delay has
- * elapsed, and read on the loaded edge to decide whether there is a
- * fade-out to sequence the content behind.
+ * Marks a spinner as on screen. The loaded edge reads it to decide
+ * whether there is a fade-out to wait for.
  *
  * @internal
  */
 export const LOADING_OVERLAY_VISIBLE_CLASS = 'os-window__loading--visible';
 
 /**
- * Wall-clock stamp (ms) of when the body entered the loading state.
- * Lives on the body element rather than in a side map so it is torn
- * down with the window, and so a repaint of the overlay mid-load can
- * resume the same clock instead of restarting it (which would blink a
- * spinner that was already on screen).
+ * When the body entered the loading state, in ms. Kept on the element
+ * so it dies with the window, and so repainting the overlay mid-load
+ * resumes the clock instead of restarting it.
  *
  * @internal
  */
 export const LOADING_STARTED_ATTR = 'data-os-loading-at';
 
 /**
- * Stamp the moment a body entered the loading state. Called wherever
- * {@link LOADING_BODY_CLASS} is added — construction here, the
- * `WINDOW_CONTENT_LOADING` edge in `./loading.ts`.
+ * Record when a body entered the loading state.
  *
  * @internal
  */
@@ -78,18 +69,9 @@ export function stampLoadingStart( body: HTMLElement ): void {
 }
 
 /**
- * Turn an overlay visible once the show delay has elapsed, so a load
- * that finishes inside that delay never paints a spinner.
- *
- * The delay is owned here rather than by a CSS `transition-delay`
- * because the overlay is appended into a body that already carries
- * `--loading`: its first computed style is the visible one, no
- * transition runs, and the delay is skipped. The result was a spinner
- * at full strength on every window open, cross-fading out over content
- * that had already painted.
- *
- * Resumes the body's existing clock, so `repaintLoadingOverlays()`
- * mid-load hands the replacement overlay straight back to visible.
+ * Make the overlay visible once the show delay has passed, so a fast
+ * load never paints a spinner. Resumes the body's existing clock, so a
+ * mid-load repaint does not restart the delay.
  *
  * @internal
  */
@@ -105,10 +87,8 @@ export function scheduleLoadingOverlayShow(
 		overlay.classList.add( LOADING_OVERLAY_VISIBLE_CLASS );
 		return;
 	}
-	// No cancellation bookkeeping: the two conditions that make the
-	// promotion wrong (overlay torn down, window no longer loading)
-	// are both readable at fire time, and a stray timer on a closed
-	// window costs one no-op.
+	// No cancel bookkeeping: both reasons to skip (overlay gone,
+	// window no longer loading) are readable at fire time.
 	window.setTimeout( () => {
 		if ( ! overlay.isConnected ) {
 			return;
@@ -306,12 +286,10 @@ function createLoadingOverlay( config: WindowConfig ): HTMLElement {
 /**
  * Remove the loading overlay element from a window's body.
  *
- * Call it in the same tick when the overlay never reached
- * {@link LOADING_OVERLAY_VISIBLE_CLASS} — there is no fade to
- * interrupt, and leaving an invisible element to "fade" is what let
- * the spinner and the content share the screen. Otherwise wait out the
- * fade-out (`LOADING_OVERLAY_FADE_OUT_MS`, the same duration the
- * matching CSS rule transitions over) so the spinner doesn't pop.
+ * Call in the same tick if the overlay never became visible: there is
+ * no fade to wait for. Otherwise wait `LOADING_OVERLAY_FADE_OUT_MS`,
+ * the duration the matching CSS rule transitions over, so the spinner
+ * does not pop.
  *
  * Idempotent — a window whose overlay was already removed (e.g.
  * because `markContentLoaded` was called twice in a row) silently

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -24,7 +24,11 @@ import {
 } from '../window-channels';
 import { HOOKS, applyFilters } from '../hooks';
 import { createRevealLayers } from '../reveals/surface';
-import { LOADING_OVERLAY_SHOW_DELAY_MS } from './constants';
+import {
+	LOADING_OVERLAY_CLASS,
+	LOADING_OVERLAY_SHOW_DELAY_MS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
+} from './constants';
 
 /**
  * Body modifier while a window's content is loading.
@@ -43,14 +47,6 @@ export const LOADING_BODY_CLASS = 'os-window__body--loading';
 export const LOADING_HANDOFF_BODY_CLASS = 'os-window__body--loading-out';
 
 /**
- * Marks a spinner as on screen. The loaded edge reads it to decide
- * whether there is a fade-out to wait for.
- *
- * @internal
- */
-export const LOADING_OVERLAY_VISIBLE_CLASS = 'os-window__loading--visible';
-
-/**
  * When the body entered the loading state, in ms. Kept on the element
  * so it dies with the window, and so repainting the overlay mid-load
  * resumes the clock instead of restarting it.
@@ -60,12 +56,35 @@ export const LOADING_OVERLAY_VISIBLE_CLASS = 'os-window__loading--visible';
 export const LOADING_STARTED_ATTR = 'data-os-loading-at';
 
 /**
- * Record when a body entered the loading state.
+ * Which load cycle the body is on. Bumped on every loading edge so a
+ * hand-off timer left over from an earlier cycle can tell it is stale
+ * and bail, instead of stripping a later cycle's state.
+ *
+ * @internal
+ */
+export const LOADING_CYCLE_ATTR = 'data-os-loading-cycle';
+
+/**
+ * The body's current load-cycle token. Capture it when scheduling a
+ * timer, compare it when the timer fires.
+ *
+ * @internal
+ */
+export function loadingCycle( body: HTMLElement ): string {
+	return body.getAttribute( LOADING_CYCLE_ATTR ) ?? '0';
+}
+
+/**
+ * Record when a body entered the loading state, and open a new cycle.
  *
  * @internal
  */
 export function stampLoadingStart( body: HTMLElement ): void {
 	body.setAttribute( LOADING_STARTED_ATTR, String( Date.now() ) );
+	body.setAttribute(
+		LOADING_CYCLE_ATTR,
+		String( Number( loadingCycle( body ) ) + 1 ),
+	);
 }
 
 /**
@@ -192,7 +211,7 @@ export function updateFullscreenBodyClass(): void {
  */
 function buildDefaultLoadingOverlay(): HTMLElement {
 	const overlay = document.createElement( 'div' );
-	overlay.className = 'os-window__loading';
+	overlay.className = LOADING_OVERLAY_CLASS;
 	// `aria-hidden` so screen readers don't announce the spinner —
 	// the window's title bar already has a `role="dialog"` + label,
 	// and the spinner's own `<svg role="img" aria-label="Loading">`
@@ -277,8 +296,8 @@ function createLoadingOverlay( config: WindowConfig ): HTMLElement {
 	// replacing children. Re-add it so the CSS rules that drive
 	// the fade transition + positioning still apply. The class is
 	// what `os-window__body--loading` selectors depend on.
-	if ( overlay && ! overlay.classList.contains( 'os-window__loading' ) ) {
-		overlay.classList.add( 'os-window__loading' );
+	if ( overlay && ! overlay.classList.contains( LOADING_OVERLAY_CLASS ) ) {
+		overlay.classList.add( LOADING_OVERLAY_CLASS );
 	}
 	return overlay;
 }

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -2572,9 +2572,9 @@ export class Window {
 	 *   - Adds the `os-window__body--loading` modifier to
 	 *     the body (CSS fades the content out).
 	 *   - Re-attaches the overlay element if it was already torn
-	 *     down by a prior `markContentLoaded` call, and fades the
-	 *     spinner in only once the work has run past the show delay
-	 *     — a refetch that lands quickly never paints one.
+	 *     down by a prior `markContentLoaded` call. The spinner
+	 *     only fades in past the show delay, so a quick refetch
+	 *     never paints one.
 	 *   - Fires the {@link HOOKS.WINDOW_CONTENT_LOADING} action +
 	 *     dispatches `os-window-content-loading` on
 	 *     `document` (idempotent — no re-fire when already
@@ -2587,12 +2587,11 @@ export class Window {
 	}
 
 	/**
-	 * Tell the shell this window's body content is ready — fades
-	 * the spinner overlay out, then fades the content in, and removes
-	 * the overlay element once the transition lands. The two run back
-	 * to back, never together. A spinner that never painted (the work
-	 * finished inside the show delay) is dropped in the same tick and
-	 * the content appears with no wait at all.
+	 * Tell the shell this window's body content is ready — fades the
+	 * spinner out, then fades the content in, and removes the overlay
+	 * once the transition lands. The two run back to back, never
+	 * together. A spinner that never painted is dropped in the same
+	 * tick, so the content appears with no wait.
 	 *
 	 * Iframe windows mark themselves ready automatically on the
 	 * `os-ready` postMessage from the chromeless bridge.

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -2570,10 +2570,11 @@ export class Window {
 	 *
 	 * The shell:
 	 *   - Adds the `os-window__body--loading` modifier to
-	 *     the body (CSS fades the content out, fades the overlay
-	 *     in).
+	 *     the body (CSS fades the content out).
 	 *   - Re-attaches the overlay element if it was already torn
-	 *     down by a prior `markContentLoaded` call.
+	 *     down by a prior `markContentLoaded` call, and fades the
+	 *     spinner in only once the work has run past the show delay
+	 *     — a refetch that lands quickly never paints one.
 	 *   - Fires the {@link HOOKS.WINDOW_CONTENT_LOADING} action +
 	 *     dispatches `os-window-content-loading` on
 	 *     `document` (idempotent — no re-fire when already
@@ -2587,8 +2588,11 @@ export class Window {
 
 	/**
 	 * Tell the shell this window's body content is ready — fades
-	 * the spinner overlay out, fades the content in, removes the
-	 * overlay element after the transition lands.
+	 * the spinner overlay out, then fades the content in, and removes
+	 * the overlay element once the transition lands. The two run back
+	 * to back, never together. A spinner that never painted (the work
+	 * finished inside the show delay) is dropped in the same tick and
+	 * the content appears with no wait at all.
 	 *
 	 * Iframe windows mark themselves ready automatically on the
 	 * `os-ready` postMessage from the chromeless bridge.

--- a/src/window/loading.ts
+++ b/src/window/loading.ts
@@ -28,13 +28,15 @@ import { HOOKS, addAction } from './../hooks';
 import { armWindowReveal, playWindowReveal } from '../reveals/surface';
 import {
 	LOADING_CONTENT_FADE_IN_MS,
+	LOADING_OVERLAY_CLASS,
 	LOADING_OVERLAY_FADE_OUT_MS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
 } from './constants';
 import {
 	ensureLoadingOverlay,
+	loadingCycle,
 	LOADING_BODY_CLASS,
 	LOADING_HANDOFF_BODY_CLASS,
-	LOADING_OVERLAY_VISIBLE_CLASS,
 	LOADING_STARTED_ATTR,
 	removeLoadingOverlay,
 	stampLoadingStart,
@@ -145,7 +147,7 @@ function _installSubscriptions(): void {
 			// Only a spinner that actually painted has a fade to
 			// sequence the content behind.
 			const spinnerWasVisible = !! body
-				.querySelector( ':scope .os-window__loading' )
+				.querySelector( `:scope .${ LOADING_OVERLAY_CLASS }` )
 				?.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS );
 
 			body.classList.remove( LOADING_BODY_CLASS );
@@ -162,6 +164,11 @@ function _installSubscriptions(): void {
 			// Hold the content transparent through the overlay's
 			// fade-out, then fade it in. The CSS rule owns both.
 			body.classList.add( LOADING_HANDOFF_BODY_CLASS );
+			// Both timers below belong to THIS cycle. A load that
+			// starts before they fire opens a new one, and a stale
+			// timer that stripped the new cycle's hold would put the
+			// content back on screen mid fade-out.
+			const cycle = loadingCycle( body );
 			// Start the reveal in the SAME tick the loading modifier is
 			// dropped. `playWindowReveal` adds the `--revealing` class,
 			// whose rule pins the content to full opacity with no
@@ -174,6 +181,9 @@ function _installSubscriptions(): void {
 			// same frame the modifier flips off and the spinner
 			// pops out of view instead of fading.
 			window.setTimeout( () => {
+				if ( loadingCycle( body ) !== cycle ) {
+					return;
+				}
 				// Re-check the DOM — the user might have triggered
 				// `markContentLoading()` again in the interim, in
 				// which case the overlay should stay.
@@ -184,6 +194,9 @@ function _installSubscriptions(): void {
 			// Drop the modifier once the content's fade has landed, so
 			// its delayed transition does not linger.
 			window.setTimeout( () => {
+				if ( loadingCycle( body ) !== cycle ) {
+					return;
+				}
 				if ( ! body.classList.contains( LOADING_BODY_CLASS ) ) {
 					body.classList.remove( LOADING_HANDOFF_BODY_CLASS );
 				}

--- a/src/window/loading.ts
+++ b/src/window/loading.ts
@@ -8,6 +8,17 @@
  * the spinner overlay, and swallow strays from windows that have
  * already torn down.
  *
+ * ## The loading indicator never shares the screen with content
+ *
+ * Two rules, both enforced here:
+ *
+ *   - A spinner that never became visible (the load finished inside
+ *     `LOADING_OVERLAY_SHOW_DELAY_MS`) is removed in the same tick the
+ *     content is uncovered. There is nothing to fade.
+ *   - A spinner that DID paint gets its fade-out to itself: the
+ *     `--loading-out` modifier holds the content transparent for that
+ *     span and then fades it in, so the two never overlap.
+ *
  * A single global `addAction` per edge (loading + loaded) reads
  * the window id from the payload and looks up the element via
  * the canonical `id="wp-window-${ id }"` attribute. Per-window
@@ -19,8 +30,19 @@
 
 import { HOOKS, addAction } from './../hooks';
 import { armWindowReveal, playWindowReveal } from '../reveals/surface';
-import { LOADING_OVERLAY_FADE_OUT_MS } from './constants';
-import { ensureLoadingOverlay, removeLoadingOverlay } from './dom';
+import {
+	LOADING_CONTENT_FADE_IN_MS,
+	LOADING_OVERLAY_FADE_OUT_MS,
+} from './constants';
+import {
+	ensureLoadingOverlay,
+	LOADING_BODY_CLASS,
+	LOADING_HANDOFF_BODY_CLASS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
+	LOADING_STARTED_ATTR,
+	removeLoadingOverlay,
+	stampLoadingStart,
+} from './dom';
 
 /**
  * Duration of the body-content fade-out before the overlay element is
@@ -93,7 +115,14 @@ function _installSubscriptions(): void {
 			if ( ! body ) {
 				return;
 			}
-			body.classList.add( 'os-window__body--loading' );
+			// A re-arm cancels any hand-off still running from the
+			// previous load — the content is about to be covered
+			// again, so a delayed fade-in of it is stale.
+			body.classList.remove( LOADING_HANDOFF_BODY_CLASS );
+			body.classList.add( LOADING_BODY_CLASS );
+			// Stamp before painting: `ensureLoadingOverlay` reads the
+			// clock to decide how much of the show delay is left.
+			stampLoadingStart( body );
 			ensureLoadingOverlay( el );
 			// Re-arm the reveal surface. The FIRST arm happens in
 			// `createWindowElement`, because the construction-time
@@ -119,7 +148,36 @@ function _installSubscriptions(): void {
 			if ( ! body ) {
 				return;
 			}
-			body.classList.remove( 'os-window__body--loading' );
+			// Whether there is anything on screen to fade. An overlay
+			// that never reached the `--visible` modifier is a
+			// zero-opacity element: fading it out would be 250 ms of
+			// nothing, and letting the content paint underneath it in
+			// the meantime is what put a half-faded spinner over
+			// finished text on every fast open.
+			const spinnerWasVisible = !! body
+				.querySelector( ':scope .os-window__loading' )
+				?.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS );
+
+			body.classList.remove( LOADING_BODY_CLASS );
+			body.removeAttribute( LOADING_STARTED_ATTR );
+
+			if ( ! spinnerWasVisible ) {
+				// Nothing painted, nothing to sequence: drop the
+				// overlay in the same tick so it can never be on
+				// screen at the same time as the content it covers.
+				removeLoadingOverlay( el );
+				// Same-tick reveal — see the note below; it applies to
+				// both branches.
+				playWindowReveal( el );
+				return;
+			}
+
+			// The spinner is on screen. Hold the content transparent
+			// for the length of the overlay's fade-out, then fade it
+			// in — the two transitions run back to back rather than on
+			// top of each other. The CSS rule for this modifier owns
+			// both the hold and the fade.
+			body.classList.add( LOADING_HANDOFF_BODY_CLASS );
 			// Start the reveal in the SAME tick the loading modifier is
 			// dropped. `playWindowReveal` adds the `--revealing` class,
 			// whose rule pins the content to full opacity with no
@@ -135,10 +193,18 @@ function _installSubscriptions(): void {
 				// Re-check the DOM — the user might have triggered
 				// `markContentLoading()` again in the interim, in
 				// which case the overlay should stay.
-				if ( ! body.classList.contains( 'os-window__body--loading' ) ) {
+				if ( ! body.classList.contains( LOADING_BODY_CLASS ) ) {
 					removeLoadingOverlay( el );
 				}
 			}, FADE_OUT_MS );
+			// Drop the hand-off modifier once the content's own fade
+			// has landed, so the delayed transition it declares does
+			// not linger on a window that is done loading.
+			window.setTimeout( () => {
+				if ( ! body.classList.contains( LOADING_BODY_CLASS ) ) {
+					body.classList.remove( LOADING_HANDOFF_BODY_CLASS );
+				}
+			}, FADE_OUT_MS + LOADING_CONTENT_FADE_IN_MS );
 		},
 	);
 
@@ -185,6 +251,10 @@ function _installSubscriptions(): void {
  * in the DOM and re-runs `ensureLoadingOverlay`. Windows whose
  * overlays were already torn down by a `markContentLoaded()` call
  * in the meantime are not affected.
+ *
+ * The replacement overlay resumes the body's show-delay clock rather
+ * than restarting it, so a repaint of a spinner that is already on
+ * screen does not blink it off for another 120 ms.
  *
  * Called automatically by the post-`INIT` sweep above — most
  * plugins never need to invoke this directly.

--- a/src/window/loading.ts
+++ b/src/window/loading.ts
@@ -8,16 +8,12 @@
  * the spinner overlay, and swallow strays from windows that have
  * already torn down.
  *
- * ## The loading indicator never shares the screen with content
+ * ## The spinner and the content never share the screen
  *
- * Two rules, both enforced here:
- *
- *   - A spinner that never became visible (the load finished inside
- *     `LOADING_OVERLAY_SHOW_DELAY_MS`) is removed in the same tick the
- *     content is uncovered. There is nothing to fade.
- *   - A spinner that DID paint gets its fade-out to itself: the
- *     `--loading-out` modifier holds the content transparent for that
- *     span and then fades it in, so the two never overlap.
+ *   - Spinner never became visible: drop it in the same tick, there is
+ *     nothing to fade.
+ *   - Spinner did paint: hold the content transparent through its
+ *     fade-out, then fade the content in.
  *
  * A single global `addAction` per edge (loading + loaded) reads
  * the window id from the payload and looks up the element via
@@ -115,13 +111,11 @@ function _installSubscriptions(): void {
 			if ( ! body ) {
 				return;
 			}
-			// A re-arm cancels any hand-off still running from the
-			// previous load — the content is about to be covered
-			// again, so a delayed fade-in of it is stale.
+			// Cancel any hand-off still running: the content is about
+			// to be covered again, so fading it in is stale.
 			body.classList.remove( LOADING_HANDOFF_BODY_CLASS );
 			body.classList.add( LOADING_BODY_CLASS );
-			// Stamp before painting: `ensureLoadingOverlay` reads the
-			// clock to decide how much of the show delay is left.
+			// Stamp first: `ensureLoadingOverlay` reads the clock.
 			stampLoadingStart( body );
 			ensureLoadingOverlay( el );
 			// Re-arm the reveal surface. The FIRST arm happens in
@@ -148,12 +142,8 @@ function _installSubscriptions(): void {
 			if ( ! body ) {
 				return;
 			}
-			// Whether there is anything on screen to fade. An overlay
-			// that never reached the `--visible` modifier is a
-			// zero-opacity element: fading it out would be 250 ms of
-			// nothing, and letting the content paint underneath it in
-			// the meantime is what put a half-faded spinner over
-			// finished text on every fast open.
+			// Only a spinner that actually painted has a fade to
+			// sequence the content behind.
 			const spinnerWasVisible = !! body
 				.querySelector( ':scope .os-window__loading' )
 				?.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS );
@@ -162,21 +152,15 @@ function _installSubscriptions(): void {
 			body.removeAttribute( LOADING_STARTED_ATTR );
 
 			if ( ! spinnerWasVisible ) {
-				// Nothing painted, nothing to sequence: drop the
-				// overlay in the same tick so it can never be on
-				// screen at the same time as the content it covers.
+				// Nothing painted, nothing to sequence.
 				removeLoadingOverlay( el );
-				// Same-tick reveal — see the note below; it applies to
-				// both branches.
+				// Same-tick reveal, for the reason noted below.
 				playWindowReveal( el );
 				return;
 			}
 
-			// The spinner is on screen. Hold the content transparent
-			// for the length of the overlay's fade-out, then fade it
-			// in — the two transitions run back to back rather than on
-			// top of each other. The CSS rule for this modifier owns
-			// both the hold and the fade.
+			// Hold the content transparent through the overlay's
+			// fade-out, then fade it in. The CSS rule owns both.
 			body.classList.add( LOADING_HANDOFF_BODY_CLASS );
 			// Start the reveal in the SAME tick the loading modifier is
 			// dropped. `playWindowReveal` adds the `--revealing` class,
@@ -197,9 +181,8 @@ function _installSubscriptions(): void {
 					removeLoadingOverlay( el );
 				}
 			}, FADE_OUT_MS );
-			// Drop the hand-off modifier once the content's own fade
-			// has landed, so the delayed transition it declares does
-			// not linger on a window that is done loading.
+			// Drop the modifier once the content's fade has landed, so
+			// its delayed transition does not linger.
 			window.setTimeout( () => {
 				if ( ! body.classList.contains( LOADING_BODY_CLASS ) ) {
 					body.classList.remove( LOADING_HANDOFF_BODY_CLASS );

--- a/tests/vitest/window-loading.test.ts
+++ b/tests/vitest/window-loading.test.ts
@@ -27,13 +27,13 @@ import {
 } from '../../src/window/loading';
 import {
 	LOADING_HANDOFF_BODY_CLASS,
-	LOADING_OVERLAY_VISIBLE_CLASS,
 	LOADING_STARTED_ATTR,
 } from '../../src/window/dom';
 import {
 	LOADING_CONTENT_FADE_IN_MS,
 	LOADING_OVERLAY_FADE_OUT_MS,
 	LOADING_OVERLAY_SHOW_DELAY_MS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
 } from '../../src/window/constants';
 
 const tick = (): Promise< void > => Promise.resolve();
@@ -539,6 +539,70 @@ describe( 'loading → ready hand-off — the spinner never overlaps content', a
 		expect( body.classList.contains( 'os-window__body--loading' ) ).toBe(
 			true,
 		);
+	} );
+
+	test( "a second cycle's hold survives the first cycle's timers", async () => {
+		await manager.open( {
+			id: 'twocycle',
+			url: '#twocycle',
+			title: 'Two cycles',
+		} );
+		paintSpinner( 'twocycle' );
+		const body = bodyOf( 'twocycle' );
+
+		vi.useFakeTimers();
+
+		// Cycle A: ready with a painted spinner. Its teardown timers are
+		// now pending at FADE_OUT_MS and FADE_OUT_MS + FADE_IN_MS.
+		markWindowContentReady( 'twocycle' );
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+
+		// Cycle B starts before either fires. The title-bar reload path
+		// allows this: its guard only blocks while `--loading` is set,
+		// and cycle A dropped that on ready.
+		vi.advanceTimersByTime( 50 );
+		markWindowContentLoading( 'twocycle' );
+		paintSpinner( 'twocycle' );
+
+		// Cycle B lands, opening its own hold.
+		vi.advanceTimersByTime( 350 );
+		markWindowContentReady( 'twocycle' );
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+
+		// Advance past cycle A's teardown timers but not yet to cycle
+		// B's. Scoped to their own cycle they are no-ops here; unscoped,
+		// A's second timer strips B's hold mid fade-out and puts the
+		// content back on screen under a spinner that is still fading.
+		vi.advanceTimersByTime( 150 );
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+		expect( body.querySelector( '.os-window__loading' ) ).not.toBeNull();
+	} );
+
+	test( 'a detached overlay never gets promoted to visible', async () => {
+		await manager.open( {
+			id: 'detached',
+			url: '#detached',
+			title: 'Detached',
+		} );
+		const body = bodyOf( 'detached' );
+		const overlay = body.querySelector< HTMLElement >(
+			'.os-window__loading',
+		)!;
+
+		vi.useFakeTimers();
+		// Tear the window down mid-load, then let the show delay pass.
+		overlay.remove();
+		vi.advanceTimersByTime( LOADING_OVERLAY_SHOW_DELAY_MS + 1 );
+
+		expect(
+			overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+		).toBe( false );
 	} );
 } );
 

--- a/tests/vitest/window-loading.test.ts
+++ b/tests/vitest/window-loading.test.ts
@@ -25,6 +25,16 @@ import {
 	installWindowLoadingTransitions,
 	repaintLoadingOverlays,
 } from '../../src/window/loading';
+import {
+	LOADING_HANDOFF_BODY_CLASS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
+	LOADING_STARTED_ATTR,
+} from '../../src/window/dom';
+import {
+	LOADING_CONTENT_FADE_IN_MS,
+	LOADING_OVERLAY_FADE_OUT_MS,
+	LOADING_OVERLAY_SHOW_DELAY_MS,
+} from '../../src/window/constants';
 
 const tick = (): Promise< void > => Promise.resolve();
 const raf = (): Promise< void > =>
@@ -126,6 +136,63 @@ describe( 'createWindowElement — loading overlay', async () => {
 		} );
 		const spinner = el.querySelector( 'os-spinner' );
 		expect( spinner!.getAttribute( 'size' ) ).toBe( 'clamp(96px, 14vw, 192px)' );
+	} );
+
+	test( 'the overlay mounts INVISIBLE and only shows past the delay', async () => {
+		vi.useFakeTimers();
+		try {
+			const el = createWindowElement( {
+				id: 'probe-delay',
+				url: '#probe-delay',
+				title: 'Probe',
+				icon: 'dashicons-admin-post',
+				x: 0,
+				y: 0,
+				width: 400,
+				height: 320,
+			} );
+			document.body.appendChild( el );
+			const overlay = el.querySelector( '.os-window__loading' )!;
+
+			// The whole point: a body built with the loading modifier
+			// already on it gives its overlay no before-change style to
+			// transition from, so the visible state has to be withheld
+			// by JS rather than delayed by CSS.
+			expect(
+				overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+			).toBe( false );
+
+			vi.advanceTimersByTime( LOADING_OVERLAY_SHOW_DELAY_MS - 1 );
+			expect(
+				overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+			).toBe( false );
+
+			vi.advanceTimersByTime( 1 );
+			expect(
+				overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+			).toBe( true );
+
+			el.remove();
+		} finally {
+			vi.useRealTimers();
+		}
+	} );
+
+	test( 'construction stamps the show-delay clock on the body', async () => {
+		const el = createWindowElement( {
+			id: 'probe-stamp',
+			url: '#probe-stamp',
+			title: 'Probe',
+			icon: 'dashicons-admin-post',
+			x: 0,
+			y: 0,
+			width: 400,
+			height: 320,
+		} );
+		const body = el.querySelector< HTMLElement >( '.os-window__body' )!;
+		expect( Number( body.getAttribute( LOADING_STARTED_ATTR ) ) ).toBeGreaterThan(
+			0,
+		);
 	} );
 } );
 
@@ -302,11 +369,176 @@ describe( 'installWindowLoadingTransitions — visual side', async () => {
 		expect( body!.classList.contains( 'os-window__body--loading' ) ).toBe(
 			true,
 		);
-		// Overlay is still in the DOM at this moment — the
-		// fade-out timer hasn't fired yet (default jsdom timing).
-		// Either way, `ensureLoadingOverlay` paints a fresh one.
+		// The previous overlay never became visible, so the ready
+		// edge dropped it in the same tick; `ensureLoadingOverlay`
+		// paints a fresh one for the re-arm.
 		const overlays = body!.querySelectorAll( '.os-window__loading' );
 		expect( overlays.length ).toBeGreaterThanOrEqual( 1 );
+	} );
+} );
+
+/**
+ * The spinner and the content must never be on screen together. Two
+ * cases, and the visible-modifier on the overlay is what tells them
+ * apart: a load that finished inside the show delay has no spinner to
+ * clear, and a load that painted one owes it an uninterrupted fade-out
+ * before the content underneath may appear.
+ */
+describe( 'loading → ready hand-off — the spinner never overlaps content', async () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	const bodyOf = ( id: string ): HTMLElement =>
+		document.querySelector< HTMLElement >(
+			`#wp-window-${ id } .os-window__body`,
+		)!;
+
+	/**
+	 * Put a still-loading window in the state it would be in after the
+	 * show delay elapsed: back-date the body's clock and repaint, which
+	 * promotes the overlay synchronously instead of waiting on a timer
+	 * registered before the fake clock was installed.
+	 */
+	const paintSpinner = ( id: string ): HTMLElement => {
+		const body = bodyOf( id );
+		body.setAttribute(
+			LOADING_STARTED_ATTR,
+			String( Date.now() - LOADING_OVERLAY_SHOW_DELAY_MS - 1 ),
+		);
+		repaintLoadingOverlays();
+		return body.querySelector< HTMLElement >( '.os-window__loading' )!;
+	};
+
+	beforeEach( async () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		manager = new WindowManager( desktop );
+		installWindowLoadingTransitions();
+	} );
+	afterEach( async () => {
+		vi.useRealTimers();
+		for ( const win of manager.getAll() ) {
+			win.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+		_resetWindowChannelsForTests();
+		_resetWindowLoadingTransitionsForTests();
+	} );
+
+	test( 'a repaint mid-load resumes the clock instead of restarting it', async () => {
+		await manager.open( {
+			id: 'resume',
+			url: '#resume',
+			title: 'Resume',
+		} );
+		const overlay = paintSpinner( 'resume' );
+		expect( overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ) ).toBe(
+			true,
+		);
+	} );
+
+	test( 'a spinner that never painted is dropped in the same tick', async () => {
+		await manager.open( {
+			id: 'fast',
+			url: '#fast',
+			title: 'Fast',
+		} );
+		const body = bodyOf( 'fast' );
+		expect( body.querySelector( '.os-window__loading' ) ).not.toBeNull();
+
+		markWindowContentReady( 'fast' );
+
+		// No fade to wait out: the overlay is gone before the content
+		// is uncovered, so the two are never both on screen.
+		expect( body.querySelector( '.os-window__loading' ) ).toBeNull();
+		// And no hand-off, because there is nothing to hand off from.
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			false,
+		);
+		expect( body.hasAttribute( LOADING_STARTED_ATTR ) ).toBe( false );
+	} );
+
+	test( 'a painted spinner keeps the content back for its fade-out', async () => {
+		await manager.open( {
+			id: 'slow',
+			url: '#slow',
+			title: 'Slow',
+		} );
+		paintSpinner( 'slow' );
+		const body = bodyOf( 'slow' );
+
+		vi.useFakeTimers();
+		markWindowContentReady( 'slow' );
+
+		// The loading modifier is off, but the content is still held
+		// transparent by the hand-off while the spinner fades.
+		expect( body.classList.contains( 'os-window__body--loading' ) ).toBe(
+			false,
+		);
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+		expect( body.querySelector( '.os-window__loading' ) ).not.toBeNull();
+
+		// One tick short of the fade-out: the overlay is still there,
+		// so the content must still be held.
+		vi.advanceTimersByTime( LOADING_OVERLAY_FADE_OUT_MS - 1 );
+		expect( body.querySelector( '.os-window__loading' ) ).not.toBeNull();
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+
+		// Fade-out done — the overlay leaves, the content fades in.
+		vi.advanceTimersByTime( 1 );
+		expect( body.querySelector( '.os-window__loading' ) ).toBeNull();
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+
+		// Content fade-in done — the hand-off modifier retires with it
+		// rather than leaving a delayed transition on the body.
+		vi.advanceTimersByTime( LOADING_CONTENT_FADE_IN_MS );
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'a re-arm during the hand-off cancels it', async () => {
+		await manager.open( {
+			id: 'rearm',
+			url: '#rearm',
+			title: 'Re-arm',
+		} );
+		paintSpinner( 'rearm' );
+		const body = bodyOf( 'rearm' );
+
+		vi.useFakeTimers();
+		markWindowContentReady( 'rearm' );
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			true,
+		);
+
+		markWindowContentLoading( 'rearm' );
+
+		// The content is about to be covered again — a delayed fade-in
+		// of it would be stale.
+		expect( body.classList.contains( LOADING_HANDOFF_BODY_CLASS ) ).toBe(
+			false,
+		);
+		expect( body.classList.contains( 'os-window__body--loading' ) ).toBe(
+			true,
+		);
+
+		// The pending teardown timers must not strip the re-armed
+		// overlay or the fresh loading state.
+		vi.advanceTimersByTime(
+			LOADING_OVERLAY_FADE_OUT_MS + LOADING_CONTENT_FADE_IN_MS,
+		);
+		expect( body.querySelector( '.os-window__loading' ) ).not.toBeNull();
+		expect( body.classList.contains( 'os-window__body--loading' ) ).toBe(
+			true,
+		);
 	} );
 } );
 

--- a/tests/vitest/window-reveal-surface.test.ts
+++ b/tests/vitest/window-reveal-surface.test.ts
@@ -256,17 +256,6 @@ describe( 'reveals/surface.ts — createRevealLayers', () => {
 		);
 	} );
 
-	test( 'stamps both layers with the same arm time', async () => {
-		vi.useFakeTimers();
-		vi.setSystemTime( 1_700_000_000_000 );
-		const { surface, engine } = await load();
-		engine.setActiveWindowRevealId( 'sweep' );
-		for ( const layer of surface.createRevealLayers() ) {
-			expect( layer.getAttribute( 'data-os-reveal-armed' ) ).toBe(
-				'1700000000000',
-			);
-		}
-	} );
 } );
 
 describe( 'reveals/surface.ts — armWindowReveal', () => {

--- a/tests/vitest/window-reveal-surface.test.ts
+++ b/tests/vitest/window-reveal-surface.test.ts
@@ -69,6 +69,18 @@ function bodyOf( el: HTMLElement ): HTMLElement {
 	return el.querySelector< HTMLElement >( '.os-window__body' )!;
 }
 
+/**
+ * Put a painted spinner in the window's body. The reveal surface reads
+ * the overlay's own `--visible` class to decide whether it has a
+ * fade-out to wait for, the same signal the loaded edge uses, so the
+ * fixture has to carry it rather than back-date a clock.
+ */
+function paintSpinner( el: HTMLElement ): void {
+	const overlay = document.createElement( 'div' );
+	overlay.className = 'os-window__loading os-window__loading--visible';
+	bodyOf( el ).appendChild( overlay );
+}
+
 /** The covering surface — the reveal layer that is NOT the edge. */
 function surfaceOf( el: HTMLElement ): HTMLElement | null {
 	return el.querySelector< HTMLElement >(
@@ -326,6 +338,8 @@ describe( 'reveals/surface.ts — playWindowReveal timing', () => {
 
 		surface.armWindowReveal( win );
 		vi.advanceTimersByTime( 40 ); // under the 120 ms spinner delay
+		// No overlay ever reached `--visible`, so there is nothing to
+		// wait for even though time has passed.
 		surface.playWindowReveal( win );
 
 		expect( calls.every( ( c ) => c.options.delay === 0 ) ).toBe( true );
@@ -340,6 +354,7 @@ describe( 'reveals/surface.ts — playWindowReveal timing', () => {
 
 		surface.armWindowReveal( win );
 		vi.advanceTimersByTime( 900 ); // a genuinely slow load
+		paintSpinner( win );
 		surface.playWindowReveal( win );
 
 		// Both layers wait together, so the edge does not start peeking


### PR DESCRIPTION
## Proposed Changes

The window loading spinner no longer shares the screen with the content it covers.

The overlay now mounts invisible and only turns on once the load has run past the 120ms show delay, so a window that paints quickly (Trash, Posts, most native windows on a warm cache) shows no spinner at all. When one does show, it gets its 250ms fade-out to itself: the content stays hidden until the overlay is gone, then fades in.

Also updates `docs/javascript-reference.md` where it describes the loading overlay and the `os-window-content-loading` / `os-window-content-loaded` pair.

## Why are these changes being made?

Opening Trash flashed the big pink WordPress mark on top of the already painted empty state, so "The Trash is empty." and its description were briefly illegible under the watermark.

The 120ms grace period was a `transition-delay` on the overlay's fade-in, and it never ran. The overlay is appended into a body that already carries `os-window__body--loading`, so the visible state is its *first* computed style, and a CSS transition needs a before-change value to run from. The spinner therefore hit full opacity on every open, and dropping the loading modifier cross-faded it out over content that had already painted.

Whether you saw it depended on whether anything forced a style flush during the render, which is why it is worse on windows with heavy templates. Trash is one: `<os-segmented>` in its toolbar measures itself with `getBoundingClientRect()` while the body hydrates.

This is pre-existing, not new this cycle. The overlay has been built this way since before `v0.9.8`; the only commits touching these files since the tag are the three rebrand ones, which renamed classes and changed nothing about the sequence.

The delay now lives in JS. The overlay gains a `--visible` modifier 120ms in, keyed off a clock stamped on the body so `repaintLoadingOverlays()` mid-load resumes it instead of restarting it. On the ready edge, an overlay that never became visible is removed in the same tick (nothing to fade), and one that did paint gets the new `os-window__body--loading-out` modifier holding the content transparent for the length of its fade-out. Windows playing a reveal are unaffected: `--revealing` still wins on the shared selector.

Covered by six new cases in `tests/vitest/window-loading.test.ts`.

## Testing Instructions

### See the flash before the fix

1. Check out `trunk`, run `npm run build`, and load `/wp-admin`.
2. Click `Trash` in the dock. Watch the moment the window opens.
3. Make sure you see the large pink WordPress mark fading out on top of the empty state, with "The Trash is empty." readable through it. It lasts about a quarter of a second, so slow it down if you need to: open DevTools > Animations, set the speed to 25%, then reopen the window. Screen recording at 60fps also catches it.
4. Try the same on `Posts` and on any admin page window (`Plugins`, `Settings`). The same fade happens; it is just less obvious against an iframe that is still white.

### Confirm it is gone

1. Check out this branch, run `npm run build`, hard-refresh `/wp-admin`.
2. Open `Trash` again, with the same 25% animation speed. Make sure no spinner appears at all: the window opens and the empty state is simply there.
3. Open `Posts`, `Plugins`, `Media`. Make sure none of them paint a spinner over content, on first open or on reopen.

### Confirm the spinner still shows when there is a real wait

1. In DevTools > Network, set throttling to `Slow 4G`.
2. Open `Plugins` (an iframe window, so the throttle applies).
3. Make sure the spinner does appear, and that when the page lands the spinner fades out first and the content appears after it, not underneath it.
4. Remove the throttle, close and reopen the same window. Make sure the spinner does not appear now.

### Regressions worth a look

1. `OpenStation Preferences > Effects`, pick a window reveal (`sweep`, `iris`, `obturator`) and give it a colour if your theme leaves it transparent. Open a few windows. Make sure the reveal still plays and still waits for the spinner when there was one.
2. Turn on reduced motion (macOS: `System Settings > Accessibility > Display > Reduce motion`). Open a window. Make sure the content appears immediately with no hold and no fade.
3. Trigger a mid-life reload: open an admin page window and use the title bar menu's `Reload`. Make sure the spinner behaves the same way (absent on a fast reload, sequenced on a slow one).
4. `npm run test:js`, `npm run lint`, `npm run typecheck`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-525-a0a8012ad82455a653bd5c570123a13ff04e77a8.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->