### PR TITLE
PR previews: Resolve fork pull requests when publishing

### DIFF
--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -44,23 +44,45 @@ jobs:
             // The `pr-meta` artifact is written by the fork-controlled build
             // run, so its contents are untrusted — a malicious PR could point
             // the preview comment at any PR. Derive the identity from the
-            // `workflow_run` event instead: GitHub sets `head_sha` and it
-            // cannot be spoofed by PR code. `workflow_run.pull_requests` is
-            // empty for fork PRs, so resolve the PR number via the API and
-            // require its head SHA to match before publishing anything.
-            const headSha = context.payload.workflow_run.head_sha;
+            // `workflow_run` event instead: GitHub sets `head_sha`,
+            // `head_repository` and `head_branch`, and PR code cannot spoof
+            // any of them.
+            //
+            // Resolve the PR by head repo + branch. `workflow_run.pull_requests`
+            // is empty for fork PRs, and so is
+            // `listPullRequestsAssociatedWithCommit` — that endpoint does not
+            // resolve commits living in a fork, which left every fork PR
+            // without a preview. The head filter works for both, and the head
+            // SHA must still match before anything is published, so a fork
+            // cannot aim the preview at a PR it doesn't own.
+            const run = context.payload.workflow_run;
+            const headSha = run.head_sha;
             if (!/^[0-9a-f]{40}$/.test(headSha)) {
               core.setFailed(`Unexpected workflow_run head SHA: ${headSha}`);
               return;
             }
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            const headOwner = run.head_repository?.owner?.login;
+            const headBranch = run.head_branch;
+            if (!headOwner || !headBranch) {
+              core.setFailed(`Incomplete workflow_run head data: owner=${headOwner} branch=${headBranch}`);
+              return;
+            }
+            // `state: 'all'` because a PR can merge between the build finishing
+            // and this run starting; the old lookup published in that window
+            // and there's no reason to start failing there. A branch reused
+            // across several PRs can match more than once, so prefer the open
+            // one.
+            const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: headSha,
+              state: 'all',
+              head: `${headOwner}:${headBranch}`,
+              per_page: 100,
             });
-            const pr = prs.find((p) => p.head.sha === headSha);
+            const matches = prs.filter((p) => p.head.sha === headSha);
+            const pr = matches.find((p) => p.state === 'open') ?? matches[0];
             if (!pr) {
-              core.setFailed(`No pull request found with head SHA ${headSha}; refusing to publish a preview.`);
+              core.setFailed(`No pull request for ${headOwner}:${headBranch} at head SHA ${headSha}; refusing to publish a preview.`);
               return;
             }
             core.setOutput('pr-number', String(pr.number));

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -41,20 +41,24 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // The `pr-meta` artifact is written by the fork-controlled build
-            // run, so its contents are untrusted — a malicious PR could point
-            // the preview comment at any PR. Derive the identity from the
-            // `workflow_run` event instead: GitHub sets `head_sha`,
-            // `head_repository` and `head_branch`, and PR code cannot spoof
-            // any of them.
+            // PR identity is never taken from the build run's artifacts — that
+            // run executes fork-controlled code and can write whatever it
+            // likes, so a malicious PR could aim the preview comment at any
+            // PR. Derive it from the `workflow_run` event instead: GitHub sets
+            // `head_sha`, `head_repository` and `head_branch`, and PR code
+            // cannot spoof any of them.
             //
             // Resolve the PR by head repo + branch. `workflow_run.pull_requests`
             // is empty for fork PRs, and so is
             // `listPullRequestsAssociatedWithCommit` — that endpoint does not
             // resolve commits living in a fork, which left every fork PR
-            // without a preview. The head filter works for both, and the head
-            // SHA must still match before anything is published, so a fork
-            // cannot aim the preview at a PR it doesn't own.
+            // without a preview.
+            //
+            // The `head` filter is server-side and fails open: a value GitHub
+            // does not recognise is ignored rather than rejected, and the call
+            // then returns every PR. Re-check owner, branch and SHA against the
+            // payload below so ownership is an invariant enforced here, not a
+            // bet on that filter's behaviour.
             const run = context.payload.workflow_run;
             const headSha = run.head_sha;
             if (!/^[0-9a-f]{40}$/.test(headSha)) {
@@ -79,7 +83,13 @@ jobs:
               head: `${headOwner}:${headBranch}`,
               per_page: 100,
             });
-            const matches = prs.filter((p) => p.head.sha === headSha);
+            // `head.repo` is null when the head fork has been deleted.
+            const matches = prs.filter(
+              (p) =>
+                p.head.sha === headSha &&
+                p.head.repo?.owner?.login === headOwner &&
+                p.head.ref === headBranch
+            );
             const pr = matches.find((p) => p.state === 'open') ?? matches[0];
             if (!pr) {
               core.setFailed(`No pull request for ${headOwner}:${headBranch} at head SHA ${headSha}; refusing to publish a preview.`);


### PR DESCRIPTION
## Proposed Changes

`pr-preview-publish.yml` now resolves the pull request by head repository and branch instead of by commit. The lookup moves from `listPullRequestsAssociatedWithCommit` to `pulls.list` with a `head=owner:branch` filter.

Owner, branch and head SHA are then re-checked locally against the `workflow_run` payload, so the resolved PR has to match on all three before the artifact is exposed or the comment posted.

The query uses `state: 'all'` rather than open PRs only, so a PR that merges between the build finishing and this run starting still publishes, as it did before. When a branch matches more than one PR, the open one wins.

## Why are these changes being made?

Because fork pull requests never got a Playground preview. `listPullRequestsAssociatedWithCommit` does not resolve commits that live in a fork, so the resolve step failed and every later step was skipped:

```
No pull request found with head SHA 00dba781c2747209cf17be014ab65a1364cc4e49; refusing to publish a preview.
```

The endpoint returns nothing for fork heads and one result for same-repo heads:

| PR | Fork | Results |
|---|---|---|
| #513 (nuriapenya) | yes | 0 |
| #443 (CookieDarb) | yes | 0 |
| #525 (WordPress) | no | 1 |

Neither #513 nor #443 has ever received a preview comment. This is not a regression from the recent action bumps: the same error hit a run on 6 August, and in the failing run above the `actions/checkout` step succeeded and only the resolve step failed.

The workflow already knew about half of this. Its comment notes that `workflow_run.pull_requests` is empty for fork PRs and reaches for the commits API as the workaround, but that API has the same blind spot.

### Why ownership is checked locally

`head_repository` and `head_branch` are set by GitHub on the `workflow_run` payload, exactly like `head_sha`, and PR code cannot spoof them. The owner segment of the filter is what stops a fork from matching someone else's PR, and it is enforced:

```
head=WordPress:app-icons-one-family              -> 0
head=nuriapenya:fix/pr-preview-resolve-fork-prs  -> 0
```

But the filter is server-side and fails open. A value GitHub does not parse is ignored rather than rejected, and the call returns everything:

```
head=app-icons-one-family   -> 100
head=totally-bogus-value    -> 100
```

The `!headOwner || !headBranch` guard makes a malformed value impossible today, since git refs cannot contain `:` and logins are alphanumeric, so this is not a live bug. It is still the whole ownership guarantee resting on remote filter behaviour that nothing local would notice changing. Re-checking `head.repo.owner.login`, `head.ref` and `head.sha` against the payload turns it into a local invariant for one line. `head.repo` is nullable when the head fork has been deleted, hence the optional chaining.

The comment block also drops its reference to a `pr-meta` artifact. No such artifact exists: `pr-preview-build.yml` uploads only `built-plugin`, and its own header says it deliberately emits no PR metadata. The reasoning it was making is kept, without naming a file that is not produced.

## Testing Instructions

The `workflow_run` trigger always runs the copy of this file that is on the default branch, so the end-to-end path can only be exercised after merge. Steps 1 to 4 can be run now.

**1. The new lookup resolves both fork and same-repo PRs**

Run each of these and make sure a PR number and head SHA come back:

```bash
gh api "repos/WordPress/openstation/pulls?state=all&per_page=100&head=nuriapenya:app-icons-one-family" -q '.[] | "#" + (.number|tostring) + "  " + .head.sha'
```

```bash
gh api "repos/WordPress/openstation/pulls?state=all&per_page=100&head=CookieDarb:fix/redundant-add-button" -q '.[] | "#" + (.number|tostring) + "  " + .head.sha'
```

Then pick any open same-repo PR and run the same call with `head=WordPress:<its branch>`. Make sure it also returns one row. That is the regression check: same-repo PRs must keep working.

**2. The old lookup is the thing that was broken**

```bash
gh api repos/WordPress/openstation/commits/00dba781c2747209cf17be014ab65a1364cc4e49/pulls -q 'length'
```

Make sure it prints `0`, while step 1 resolved the same branch to #513.

**3. The local check survives a fail-open response**

Fetch the worst case, where the filter is ignored and every PR comes back, then run the resolution logic against it:

```bash
gh api "repos/WordPress/openstation/pulls?state=all&per_page=100&head=totally-bogus-value" > /tmp/allprs.json
```

```bash
node -e "const prs=require('/tmp/allprs.json');const r=(o,b,s)=>{const m=prs.filter(p=>p.head.sha===s&&p.head.repo?.owner?.login===o&&p.head.ref===b);const p=m.find(x=>x.state==='open')??m[0];return p?'#'+p.number:'REFUSED'};const t=prs.find(p=>p.number===513);console.log('size',prs.length);console.log('correct   ->',r(t.head.repo.owner.login,t.head.ref,t.head.sha));console.log('bad owner ->',r('attacker',t.head.ref,t.head.sha));console.log('bad branch->',r(t.head.repo.owner.login,'other',t.head.sha));console.log('bad sha   ->',r(t.head.repo.owner.login,t.head.ref,'0'.repeat(40)))"
```

Make sure the response size is 100, the correct triple resolves to `#513`, and all three tampered variants print `REFUSED`.

**4. The file still parses**

```bash
node -e "const y=require('js-yaml'),f=require('fs');const d=y.load(f.readFileSync('.github/workflows/pr-preview-publish.yml','utf8'));const s=d.jobs.publish.steps.find(x=>x.name&&x.name.startsWith('Resolve PR'));f.writeFileSync('/tmp/s.js','(async()=>{'+s.with.script+'})()');console.log('yaml ok')" && node --check /tmp/s.js && echo "js ok"
```

**5. After merge, a fork PR publishes**

1. Push any commit to #513 or #443 (a merge of `trunk` into the branch is enough).
2. Wait for **PR Preview Build** to finish, then open the **PR Preview Publish** run it triggers.
3. Make sure the run is green and no step is skipped.
4. Make sure a Playground preview comment appears on the fork PR, and that the button opens a Playground with the plugin from that PR installed.

**6. After merge, a same-repo PR still publishes**

1. Push a commit to any open PR on a `WordPress/openstation` branch.
2. Make sure its preview comment is posted or updated as before.

**7. After merge, a stale run still refuses**

1. Push twice to a PR in quick succession so the first publish run resolves against a superseded head SHA.
2. Make sure the earlier run fails with `No pull request for <owner>:<branch> at head SHA ...` and publishes nothing, and that the run for the newer SHA succeeds.

**Automated**

```bash
npm run build
```

Make sure `git status` is clean afterwards. No source files change here, so the build is only a sync check.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-528-876a4922e08ce30e4fb6c9fbba60af75a9e0946b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->