### PR TITLE
fix: decode HTML entities in plugin install toast

### DIFF
--- a/src/plugins-window/browse-view.ts
+++ b/src/plugins-window/browse-view.ts
@@ -13,6 +13,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { decodeHTML } from '../utils';
 import { broadcast, subscribe } from '../broadcast';
 import {
 	buildCard,
@@ -366,7 +367,7 @@ export function mountBrowseView(
 					sprintf(
 						/* translators: %s: plugin name */
 						__( 'Installed %s.', 'desktop-mode' ),
-						plugin.name,
+						decodeHTML( plugin.name ),
 					),
 				);
 				repaintCardCta( card, plugin, state.installed, cardCallbacks );
@@ -407,7 +408,7 @@ export function mountBrowseView(
 					sprintf(
 						/* translators: %s: plugin name */
 						__( '%s activated.', 'desktop-mode' ),
-						updated.name || updated.plugin,
+						decodeHTML( updated.name || updated.plugin ),
 					),
 				);
 				const plugin = state.plugins.find(

--- a/src/plugins-window/featured-view.ts
+++ b/src/plugins-window/featured-view.ts
@@ -15,6 +15,7 @@
  */
 
 import { __, sprintf } from '../i18n';
+import { decodeHTML } from '../utils';
 import { broadcast, subscribe } from '../broadcast';
 import {
 	buildCard,
@@ -172,7 +173,7 @@ export function mountFeaturedView(
 					sprintf(
 						/* translators: %s: plugin name */
 						__( 'Installed %s.', 'desktop-mode' ),
-						plugin.name,
+						decodeHTML( plugin.name ),
 					),
 				);
 				repaintCardCta( card, plugin, state.installed, cardCallbacks );
@@ -213,7 +214,7 @@ export function mountFeaturedView(
 					sprintf(
 						/* translators: %s: plugin name */
 						__( '%s activated.', 'desktop-mode' ),
-						updated.name || updated.plugin,
+						decodeHTML( updated.name || updated.plugin ),
 					),
 				);
 				const plugin = state.plugins.find(


### PR DESCRIPTION
Closes #527

### Description
This PR fixes a visual bug where HTML entities in plugin names (such as `&amp;` or `&#8211;`) were rendered raw inside the successful installation and activation toast notifications on the desktop.

### Root Causes & Fixes
**Missing Entity Decoding in Plugin Toast Render**:
* **Issue**: The WordPress.org API returns plugin names containing HTML-encoded entities in the payload (e.g. `Direct Invoices &amp; Payment` or `FrontEdit &#8211; Live`). The native Plugins window set these directly inside toast notifications, which caused them to render literally on the screen.
* **Fix**: Updated both the **Add Plugin** (`browse-view.ts`) and **OpenStation plugins** (`featured-view.ts`) tabs to decode the plugin name using the existing `decodeHTML` utility from `src/utils.ts` before triggering the toast notifications.

### Verification
* **Build**: `npm run build` completed successfully.
* **Typecheck**: `npm run typecheck` completed successfully with zero errors.
* **Linter**: `npm run lint` completed successfully with zero errors.
* **Unit Tests**: `npm run test:js` completed successfully with all 3965/3965 Vitest tests passing.

### Before fix
<img width="748" height="335" alt="Screenshot 2026-08-07 at 7 08 00 PM" src="https://github.com/user-attachments/assets/5e279089-7498-43b1-b04f-857f94cb8233" />


### After fix
<img width="727" height="115" alt="Screenshot 2026-08-07 at 7 21 57 PM" src="https://github.com/user-attachments/assets/cce434b8-13d2-42f8-b4de-0a286c864f70" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-529-1d7204ddfbd61a1899a21013319f59f2291a6feb.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->