### PR TITLE
Fix the WordPress.org deploy after the repo rename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,30 @@
 name: Release
 
-# Triggered by pushing a vX.Y.Z tag. Builds the plugin zip and creates a
-# GitHub Release with it attached. Use `bin/release.sh` locally to cut a
-# release end-to-end (bump + commit + tag + push).
+# Triggered by pushing a vX.Y.Z tag. Builds the plugin zip, creates a GitHub
+# Release with it attached, then deploys stable tags to WordPress.org. Use
+# `bin/release.sh` locally to cut a release end-to-end (bump + commit + tag
+# + push).
+#
+# Also runnable manually against an already-published tag, which re-attempts
+# the WordPress.org deploy and leaves the GitHub Release untouched:
+#
+#     gh workflow run release.yml --ref trunk -f tag=v1.0.0
+#
+# That exists because a tag push runs the workflow definition frozen into
+# that tag's commit, so a deploy that fails for a workflow-level reason can
+# never be fixed by re-running it. Dispatching from trunk runs the current
+# definition instead.
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Published tag to deploy to WordPress.org (e.g. v1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,8 +33,15 @@ jobs:
   release:
     name: Build & publish release
     runs-on: ubuntu-latest
+    env:
+      # The tag being released: the pushed ref, or the dispatch input.
+      # Consumed as a shell variable rather than interpolated into `run:`
+      # bodies, so the dispatch input can't inject into the script.
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -31,8 +55,7 @@ jobs:
 
       - name: Verify tag matches plugin version
         run: |
-          tag="${{ github.ref_name }}"
-          tag="${tag#v}"
+          tag="${TAG#v}"
           pkg=$(node -p "require('./package.json').version")
           header=$(grep -oP '^\s*\*\s*Version:\s*\K\S+' desktop-mode.php)
           constant=$(grep -oP "OPENSTATION_VERSION',\s*'\K[^']+" desktop-mode.php)
@@ -48,27 +71,30 @@ jobs:
       - name: Package plugin zip
         run: bin/package.sh
 
+      # Skipped on a manual dispatch: the Release already exists, and
+      # `gh release create` is not idempotent — it would fail the job
+      # before it ever reached the deploy.
       - name: Create GitHub Release
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${{ github.ref_name }}"
           flags=()
-          if [[ "$tag" == *-* ]]; then
+          if [[ "$TAG" == *-* ]]; then
             flags+=(--prerelease)
           fi
-          gh release create "$tag" \
-            --title "$tag" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes \
             "${flags[@]}" \
             openstation.zip
 
       - name: Unpack zip for wp.org deploy
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ !contains(env.TAG, '-') }}
         run: unzip -q openstation.zip -d build/
 
       - name: Deploy to WordPress.org
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ !contains(env.TAG, '-') }}
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,11 @@ jobs:
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          # The wp.org slug is frozen at `desktop-mode` (see AGENTS.md) — it is
+          # the published plugin's SVN path and install directory, and renaming
+          # it would orphan every existing install's update check. Set it
+          # explicitly: the action otherwise defaults SLUG to the GitHub repo
+          # name, which used to coincide with the wp.org slug and stopped
+          # doing so when this repo was renamed to `openstation`.
+          SLUG: desktop-mode
           BUILD_DIR: ./build/desktop-mode

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,9 +16,17 @@ Flags:
 - `--skip-changelog` — skip drafting the `readme.txt` changelog block. Use when you've already hand-written it, or for hotfixes with nothing notable to log. The interactive changelog confirmation still runs; only the drafting step is skipped.
 - `--dry-run-changelog` — print the changelog draft that would be inserted into `readme.txt`, then exit without modifying any files or pushing.
 
-The tag push fires [`.github/workflows/release.yml`](../.github/workflows/release.yml), which builds and publishes a GitHub Release with `openstation.zip` attached.
+The tag push fires [`.github/workflows/release.yml`](../.github/workflows/release.yml), which builds and publishes a GitHub Release with `openstation.zip` attached, then — for stable tags only — deploys to WordPress.org.
 
 Requires the `gh` CLI authenticated (`gh auth status`).
+
+## The WordPress.org deploy
+
+The last step of `release.yml` unpacks the zip and hands `build/desktop-mode/` to [`10up/action-wordpress-plugin-deploy`](https://github.com/10up/action-wordpress-plugin-deploy), which commits it to SVN trunk and tags it. Pre-releases are skipped — the step is gated on the tag having no hyphen.
+
+**`SLUG` is set explicitly to `desktop-mode` and must stay that way.** It is the published plugin's SVN path (`plugins.svn.wordpress.org/desktop-mode/`) and its install directory, so it is frozen for the same reason as every other `desktop_mode_*` value in [AGENTS.md](../AGENTS.md): changing it doesn't migrate anything, it points the deploy at a repository that doesn't exist and orphans every installed copy's update check. The action defaults `SLUG` to the GitHub repository name when unset — that default silently matched while the repo was named `desktop-mode`, and broke the moment it was renamed to `openstation`. Never rely on it.
+
+Assets (banners, icons, screenshots) come from `.wordpress-org/`, the action's default `ASSETS_DIR`.
 
 ## Pre-releases
 
@@ -35,7 +43,7 @@ Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps 
 | `bin/bump-version.sh <version>` | Syncs `package.json`, `package-lock.json`, plugin header, `OPENSTATION_VERSION`, `readme.txt` `Stable tag:`. |
 | `bin/package.sh` | Packages `openstation.zip` from HEAD + current built JS. The ZIP keeps the internal `desktop-mode/` directory so WordPress.org upgrades and dependent plugins continue to resolve the established plugin slug. Derives the expected bundle list from `vite.config.js` TARGETS and ships each target's `<fileBase>.min.js` **only** — the unminified dev bundles (~4–5 MB) stay out of the zip; `openstation_asset_suffix()` falls back to `.min` on installs where they're absent, so a `SCRIPT_DEBUG` site degrades gracefully. Errors if any expected `.min.js` is missing under `assets/js/`, or if a stale gitignored `.js` not produced by any Vite target is left behind there. |
 | `bin/release.sh <version>` | Full end-to-end release. |
-| `release.yml` — `push: tags: v*` | Build + publish the GitHub Release. |
+| `release.yml` — `push: tags: v*` | Build + publish the GitHub Release, then deploy stable tags to WordPress.org. |
 
 ## Version locations
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,6 +28,16 @@ The last step of `release.yml` unpacks the zip and hands `build/desktop-mode/` t
 
 Assets (banners, icons, screenshots) come from `.wordpress-org/`, the action's default `ASSETS_DIR`.
 
+### Re-deploying a published tag
+
+A tag push runs the workflow definition **frozen into that tag's commit**, so a deploy that failed for a workflow-level reason cannot be fixed by re-running it — the re-run replays the same broken definition. Dispatch the workflow from `trunk` instead, which runs the current definition against an existing tag:
+
+```bash
+gh workflow run release.yml --repo WordPress/openstation --ref trunk -f tag=v1.0.0
+```
+
+The GitHub Release is left untouched: `gh release create` is not idempotent, so that step is gated on `github.event_name == 'push'` and skipped on dispatch. Everything else — checkout of the tag, the version gate, build, package, deploy — runs identically. The action itself is idempotent against SVN: a version already published is detected and skipped rather than re-committed.
+
 ## Pre-releases
 
 Hyphenated versions publish as GitHub pre-releases, so `/releases/latest` keeps pointing at the last stable. The workflow detects the hyphen and sets `--prerelease` automatically:


### PR DESCRIPTION
The `v1.0.0` deploy failed with:

```
ℹ︎ SLUG is openstation
svn: E170000: URL 'https://plugins.svn.wordpress.org/openstation' doesn't exist
```

Nothing on WordPress.org was renamed — the plugin is still published at slug `desktop-mode`, version `0.9.8`. The deploy step simply never set `SLUG`, so [`10up/action-wordpress-plugin-deploy`](https://github.com/10up/action-wordpress-plugin-deploy) fell through to its default:

```sh
if [[ -z "$SLUG" ]]; then
    SLUG=${GITHUB_REPOSITORY#*/}
fi
SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
```

That default happened to equal the wp.org slug while this repo was named `desktop-mode`, and stopped doing so the moment it was renamed to `openstation`.

## Changes

**Pin `SLUG: desktop-mode`.** The wp.org slug is frozen alongside every other `desktop_mode_*` value in `AGENTS.md` — it is the published plugin's SVN path and its install directory, so it cannot track the GitHub repo name. Setting it explicitly decouples the two permanently.

**Add a `workflow_dispatch` recovery path.** A tag push runs the workflow definition *frozen into that tag's commit*, so the failed `v1.0.0` run cannot be fixed by re-running it — it would replay the same slug-less definition. Without this, recovering `v1.0.0` means moving a published tag *and* deleting its GitHub Release (`gh release create` is not idempotent), which 404s `/releases/latest/download/openstation.zip` in the meantime. Dispatching from `trunk` instead runs the current definition against the existing tag:

```bash
gh workflow run release.yml --ref trunk -f tag=v1.0.0
```

Release creation is gated on `github.event_name == 'push'` so a dispatch never touches the existing Release. `TAG` is a job-level env var rather than an expression interpolated into `run:` bodies, so the dispatch input reaches the shell as data and cannot inject into the script.

**Document both** in `docs/RELEASE.md`, which described `release.yml` as publishing only the GitHub Release and never mentioned wp.org or the slug.

## Verification

- `release.yml` parses; triggers, the `TAG` fallback, all three step gates and the deploy env resolve as intended.
- The tag `v1.0.0` currently points at `b6474ad1`, whose `release.yml` has no `SLUG` line — confirming a plain re-run would fail identically.
- The version gate still passes at that tag: `package.json`, the plugin header, `OPENSTATION_VERSION` and `readme.txt` `Stable tag:` are all `1.0.0`.

After merge, `v1.0.0` goes to wp.org via the dispatch command above — no tag or Release is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-534-29c90a0128861d545a5a603a8ef536f141a2183a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->