### PR TITLE
Pass VERSION explicitly to the wp.org deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,12 @@ jobs:
             echo "::error::Version mismatch — tag '$tag' vs package.json=$pkg header=$header OPENSTATION_VERSION=$constant readme.txt Stable tag=$stable"
             exit 1
           fi
+          # The deploy action derives VERSION from GITHUB_REF, which is only a
+          # tag ref on a tag push — on a dispatch it resolves to the branch ref
+          # and the SVN tag copy becomes `tags/refs/heads/trunk`. Publish the
+          # version that was just checked against all four locations, so the
+          # deploy uses a verified value however the workflow was triggered.
+          echo "VERSION=$tag" >> "$GITHUB_ENV"
 
       - name: Build
         run: npm run build
@@ -107,3 +113,6 @@ jobs:
           # doing so when this repo was renamed to `openstation`.
           SLUG: desktop-mode
           BUILD_DIR: ./build/desktop-mode
+          # VERSION comes from the verify step via $GITHUB_ENV — see the note
+          # there. Both it and SLUG default off a GitHub context that is only
+          # correct for a tag push, so neither is left implicit.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,6 +24,8 @@ Requires the `gh` CLI authenticated (`gh auth status`).
 
 The last step of `release.yml` unpacks the zip and hands `build/desktop-mode/` to [`10up/action-wordpress-plugin-deploy`](https://github.com/10up/action-wordpress-plugin-deploy), which commits it to SVN trunk and tags it. Pre-releases are skipped — the step is gated on the tag having no hyphen.
 
+Two of the action's inputs default off a GitHub context that is only correct for a tag push, so the workflow sets both explicitly rather than leaving them implicit — `SLUG` (below) and `VERSION`, which the action derives from `GITHUB_REF` and which would resolve to the *branch* ref on a manual dispatch, producing an SVN tag called `refs/heads/trunk`. `VERSION` is exported from the version-gate step, so the deploy publishes the string that was just verified against all four version locations.
+
 **`SLUG` is set explicitly to `desktop-mode` and must stay that way.** It is the published plugin's SVN path (`plugins.svn.wordpress.org/desktop-mode/`) and its install directory, so it is frozen for the same reason as every other `desktop_mode_*` value in [AGENTS.md](../AGENTS.md): changing it doesn't migrate anything, it points the deploy at a repository that doesn't exist and orphans every installed copy's update check. The action defaults `SLUG` to the GitHub repository name when unset — that default silently matched while the repo was named `desktop-mode`, and broke the moment it was renamed to `openstation`. Never rely on it.
 
 Assets (banners, icons, screenshots) come from `.wordpress-org/`, the action's default `ASSETS_DIR`.


### PR DESCRIPTION
Follow-up to #534. That PR fixed `SLUG` and the deploy got much further — the SVN checkout of `desktop-mode` succeeded and picked up every published tag through `0.9.8`, confirming the slug fix — then failed at the tag copy:

```
svn: E155010: Path '/home/runner/svn-desktop-mode/tags/refs/heads' is not a directory
```

Same shape as the `SLUG` bug, one variable over. The action derives:

```sh
VERSION="${GITHUB_REF#refs/tags/}"
VERSION="${VERSION#v}"
```

`GITHUB_REF` is a tag ref only on a tag push. On a `workflow_dispatch` it is `refs/heads/trunk`, the prefix strip is a no-op, and `svn cp trunk "tags/$VERSION"` tries to create `tags/refs/heads/trunk`.

## Fix

Export `VERSION` from the version-gate step via `$GITHUB_ENV`. That step already computes the tag string and checks it against `package.json`, the plugin header, `OPENSTATION_VERSION` and `readme.txt` `Stable tag:` — so the deploy now publishes a *verified* version rather than one re-derived from a context that means different things per trigger.

`SLUG` and `VERSION` were the only two inputs left defaulting off a GitHub context; both are now explicit.

## Nothing was published by the failed run

`deploy.sh` runs under `set -eo` and contains exactly one `svn commit`, at line 234 — after the `svn cp` at line 208 that aborted. Confirmed against the wp.org API: still `0.9.8`, slug `desktop-mode`, no partial `1.0.0` tag.

The `v1.0.0` tag and its GitHub Release remain untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-535-4b8d1929680cd47975e106b713aaeea02bfb8c7b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->