### PR TITLE
Windows: Preserve fullscreen state after leaving Overview

### DIFF
--- a/src/window-manager/desktops.ts
+++ b/src/window-manager/desktops.ts
@@ -53,6 +53,9 @@ export function getActiveDesktopId( mgr: WindowManager ): string {
 export function applyDesktopVisibility( mgr: WindowManager, win: Window ): void {
 	const visible = win.config.desktopId === mgr._activeDesktopId;
 	win.element.style.display = visible ? '' : 'none';
+	if ( visible && ! mgr._overviewActive ) {
+		restoreWindowAfterOverviewLayout( win );
+	}
 }
 
 /**
@@ -297,7 +300,10 @@ export function relayoutOverviewForActiveDesktop( mgr: WindowManager ): void {
 			w.element.style.transform = snap.transform;
 			w.element.style.transition = snap.transition;
 			w.element.classList.remove( 'os-window--overview' );
-			restoreWindowAfterOverviewLayout( w );
+			restoreWindowAfterOverviewLayout(
+				w,
+				w.config.desktopId === mgr._activeDesktopId,
+			);
 		}
 	}
 	for ( const label of mgr._overviewLabels.values() ) {

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -21,6 +21,7 @@ import { computeOverviewLayout, type OverviewLayoutItem } from './geometry';
 import { OVERVIEW_TOP_BAR_RESERVE } from './overview-constants';
 import { closeDesktop, createDesktop, switchDesktop } from './desktops';
 import type { Window } from '../window';
+import { updateFullscreenBodyClass } from '../window/dom';
 import type { WindowManager } from './index';
 
 /**
@@ -45,10 +46,19 @@ const OVERVIEW_INERT_ELEMENTS = [
 const OVERVIEW_FULLSCREEN_DATA_KEY = 'osHadFullscreenBeforeOverview';
 
 /**
- * Make a minimized window usable as an overview thumbnail without
- * changing its logical minimized state.
+ * Make a window usable as an overview thumbnail without changing its
+ * logical state. Fullscreen styling and minimized render suppression
+ * are restored when the window returns to its desktop layout.
  */
 export function prepareWindowForOverviewLayout( w: Window ): void {
+	if (
+		w.state === 'fullscreen' ||
+		w.element.classList.contains( 'os-window--fullscreen' )
+	) {
+		w.element.classList.remove( 'os-window--fullscreen' );
+		w.element.dataset[ OVERVIEW_FULLSCREEN_DATA_KEY ] = 'true';
+		updateFullscreenBodyClass();
+	}
 	if ( w.state !== 'minimized' ) {
 		return;
 	}
@@ -56,23 +66,30 @@ export function prepareWindowForOverviewLayout( w: Window ): void {
 	if ( w.iframe ) {
 		w.iframe.style.visibility = '';
 	}
-	if ( w.element.classList.contains( 'os-window--fullscreen' ) ) {
-		w.element.classList.remove( 'os-window--fullscreen' );
-		w.element.dataset[ OVERVIEW_FULLSCREEN_DATA_KEY ] = 'true';
-	}
 }
 
-function restoreOverviewFullscreenClass( w: Window ): void {
+function restoreOverviewFullscreenState( w: Window ): void {
 	if ( w.element.dataset[ OVERVIEW_FULLSCREEN_DATA_KEY ] !== 'true' ) {
+		return;
+	}
+	if ( w.state !== 'fullscreen' && w.state !== 'minimized' ) {
+		delete w.element.dataset[ OVERVIEW_FULLSCREEN_DATA_KEY ];
+		updateFullscreenBodyClass();
 		return;
 	}
 	w.element.classList.add( 'os-window--fullscreen' );
 	delete w.element.dataset[ OVERVIEW_FULLSCREEN_DATA_KEY ];
+	updateFullscreenBodyClass();
 }
 
 /** Restore any render-suppression / state-class changes made for overview. */
-export function restoreWindowAfterOverviewLayout( w: Window ): void {
-	restoreOverviewFullscreenClass( w );
+export function restoreWindowAfterOverviewLayout(
+	w: Window,
+	restoreFullscreen = true,
+): void {
+	if ( restoreFullscreen ) {
+		restoreOverviewFullscreenState( w );
+	}
 	if ( w.state === 'minimized' ) {
 		w.element.style.setProperty( 'content-visibility', 'hidden' );
 		if ( w.iframe ) {
@@ -162,12 +179,10 @@ export function enterOverview( mgr: WindowManager ): void {
 	}
 
 	// Fullscreen-state windows escape the shell's stacking context;
-	// bring them back into the normal flow before computing layout
-	// so the transform math stays consistent.
+	// suspend their visual class before computing layout so the
+	// transform math stays consistent without changing their logical
+	// state or saved geometry.
 	for ( const w of eligible ) {
-		if ( w.state === 'fullscreen' ) {
-			w.toggleFullscreen();
-		}
 		prepareWindowForOverviewLayout( w );
 	}
 
@@ -720,12 +735,11 @@ export function exitOverview(
 		}
 		w.element.style.transform = snap.transform;
 	}
-
 	if ( selected ) {
 		// Restore minimized windows before focusing so the user lands
 		// on a visible window, not an invisible-but-focused one.
 		if ( selected.state === 'minimized' ) {
-			restoreOverviewFullscreenClass( selected );
+			restoreOverviewFullscreenState( selected );
 			selected.restore();
 		}
 		// Focus first so z-index and focused-class are right from the
@@ -773,7 +787,10 @@ export function exitOverview(
 		mgr._overviewExitTimeoutId = null;
 		for ( const w of mgr._stack ) {
 			w.element.classList.remove( 'os-window--overview' );
-			restoreWindowAfterOverviewLayout( w );
+			restoreWindowAfterOverviewLayout(
+				w,
+				w.config.desktopId === mgr._activeDesktopId,
+			);
 		}
 		for ( const label of mgr._overviewLabels.values() ) {
 			label.remove();

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -12,6 +12,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
 import { closeDesktop } from '../../src/window-manager/desktops';
+import { HOOKS } from '../../src/hooks';
 import {
 	clearHooksStub,
 	installHooksStub,
@@ -83,6 +84,7 @@ describe( 'WindowManager — virtual desktops', async () => {
 		// none of them fire later and reach for `window.wp.hooks`
 		// after `clearHooksStub()` below has removed it.
 		manager.destroy();
+		vi.useRealTimers();
 		for ( const win of manager.getAll() ) {
 			win.destroy();
 		}
@@ -373,6 +375,134 @@ describe( 'WindowManager — virtual desktops', async () => {
 		manager.exitOverview( a );
 
 		expect( a.state ).toBe( 'fullscreen' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( true );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( true );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBeUndefined();
+	} );
+
+	test( 'canceling overview preserves a visible fullscreen window', async () => {
+		vi.useFakeTimers();
+		const a = await manager.open( openConfig( 'a' ) );
+		a.toggleFullscreen();
+		const fullscreenActions = recordActions( hooks, [
+			HOOKS.WINDOW_FULLSCREEN_ENTERED,
+			HOOKS.WINDOW_FULLSCREEN_EXITED,
+		] );
+
+		manager.enterOverview();
+		expect( a.state ).toBe( 'fullscreen' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( false );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBe( 'true' );
+		manager.exitOverview();
+
+		expect( a.state ).toBe( 'fullscreen' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( false );
+
+		vi.advanceTimersByTime( 280 );
+
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( true );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( true );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBeUndefined();
+		expect( fullscreenActions ).toHaveLength( 0 );
+	} );
+
+	test( 'selecting a fullscreen thumbnail preserves fullscreen state', async () => {
+		vi.useFakeTimers();
+		const a = await manager.open( openConfig( 'a' ) );
+		a.toggleFullscreen();
+
+		manager.enterOverview();
+		manager.exitOverview( a );
+
+		expect( a.state ).toBe( 'fullscreen' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+
+		vi.advanceTimersByTime( 280 );
+
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( true );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( true );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBeUndefined();
+	} );
+
+	test( 'selecting another window clears a stale fullscreen marker', async () => {
+		vi.useFakeTimers();
+		const a = await manager.open( openConfig( 'a' ) );
+		const b = await manager.open( openConfig( 'b' ) );
+		manager.focus( a );
+		a.toggleFullscreen();
+
+		manager.enterOverview();
+		expect( a.state ).toBe( 'fullscreen' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+
+		manager.exitOverview( b );
+		expect( a.state ).toBe( 'normal' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+
+		vi.advanceTimersByTime( 280 );
+
+		expect( a.state ).toBe( 'normal' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( false );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBeUndefined();
+	} );
+
+	test( 'fullscreen styling stays suspended on an inactive desktop after overview', async () => {
+		vi.useFakeTimers();
+		const a = await manager.open( openConfig( 'a' ) );
+		const second = manager.createDesktop();
+		a.toggleFullscreen();
+
+		manager.enterOverview();
+		manager.switchDesktop( second.id );
+		manager.exitOverview();
+		vi.advanceTimersByTime( 280 );
+
+		expect( a.state ).toBe( 'fullscreen' );
+		expect( a.element.style.display ).toBe( 'none' );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( false );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBe( 'true' );
+
+		manager.switchDesktop( 'desktop-1' );
+
+		expect( a.element.style.display ).toBe( '' );
 		expect(
 			a.element.classList.contains( 'os-window--fullscreen' ),
 		).toBe( true );


### PR DESCRIPTION
## Proposed Changes

Overview now suspends fullscreen presentation while laying out thumbnails without changing the window's logical state or saved geometry.

- Removes the fullscreen class only while a window participates in Overview.
- Restores the class and body state after the exit animation finishes.
- Keeps fullscreen styling suspended on inactive desktops until their window becomes visible again.
- Avoids firing fullscreen enter or exit hooks during the transition.

Regression coverage includes canceling Overview, selecting the fullscreen window, selecting another window, and switching desktops during Overview.

## Why are these changes being made?

Entering Overview called `toggleFullscreen()` for visible fullscreen windows. That changed the window state from `fullscreen` to `normal`, and leaving Overview had no path that restored it.

The thumbnail layout only needs the fullscreen CSS class removed temporarily. Keeping the logical state intact lets the window return to the same immersive state after Overview closes.

Fixes #526.

## Testing Instructions

1. Open a window and enter fullscreen mode.
2. Enter Overview, then leave it with Escape or by selecting the fullscreen window.
3. Confirm the window returns fullscreen and the admin bar remains hidden.
4. Repeat, selecting another window from Overview. Confirm the original window does not regain stale fullscreen styling.
5. While Overview is open, switch to another desktop and leave Overview. Confirm the hidden fullscreen window does not affect the active desktop, then switch back and confirm fullscreen is restored.

Automated checks:

```bash
npm run lint
npm run typecheck
npm run test:js
npm run build
```

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-536-4b8165a189248ba17b8d157e7e27cb6f9ea329ac.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->