### PR TITLE
Always show the Agents section in WP Explorer

### DIFF
--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -2115,20 +2115,13 @@ os-tile[ status='future' ] .os-file-tile__icon {
 }
 
 /* The framework is opt-in but the section is always listed, so with
-   the option off the whole surface paints inert rather than vanishing.
-   The notice above it carries the way to switch it on, which is why
-   the notice itself keeps full opacity. */
-.dm-agents.is-disabled .dm-agents__layout {
+   the option off the surface paints inert rather than vanishing.
+   Only the sidebar dims: the detail pane holds the empty state
+   explaining why, and the one button that undoes it — dimming the way
+   out along with everything else is how a disabled screen becomes a
+   dead end. */
+.dm-agents.is-disabled .dm-agents__sidebar {
 	opacity: 0.6;
-}
-
-/* The button sits inside the notice's label slot, so it lays out
-   inline with the sentence rather than as a flex sibling of the
-   tone icon — hence the alignment here rather than on the host,
-   whose own flex layout the component owns. */
-.dm-agents__off-notice .dm-agents__enable {
-	vertical-align: middle;
-	margin-inline-start: 4px;
 }
 
 /* Section-level loading — same scale curve as the My WordPress

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -2114,6 +2114,23 @@ os-tile[ status='future' ] .os-file-tile__icon {
 	box-sizing: border-box;
 }
 
+/* The framework is opt-in but the section is always listed, so with
+   the option off the whole surface paints inert rather than vanishing.
+   The notice above it carries the way to switch it on, which is why
+   the notice itself keeps full opacity. */
+.dm-agents.is-disabled .dm-agents__layout {
+	opacity: 0.6;
+}
+
+/* The button sits inside the notice's label slot, so it lays out
+   inline with the sentence rather than as a flex sibling of the
+   tone icon — hence the alignment here rather than on the host,
+   whose own flex layout the component owns. */
+.dm-agents__off-notice .dm-agents__enable {
+	vertical-align: middle;
+	margin-inline-start: 4px;
+}
+
 /* Section-level loading — same scale curve as the My WordPress
    preview loader and the window-loading overlay, instead of the bare
    48px component default. */

--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -2243,6 +2243,16 @@ os-tile[ status='future' ] .os-file-tile__icon {
 	gap: 10px;
 }
 
+/* `<os-empty-state>` owns the icon + copy and centres them within
+   itself; the host is still a flex item that shrinks to its content,
+   so without this it sits at the top of a pane that is mostly empty
+   space. Auto margins on both axes absorb the slack — placement only,
+   same as the comments window. Covers the framework-off state and
+   "No agents yet" alike. */
+.dm-agents__detail > os-empty-state {
+	margin: auto;
+}
+
 .dm-agents__detail-head {
 	display: flex;
 	align-items: center;

--- a/docs/examples/agents.md
+++ b/docs/examples/agents.md
@@ -3,7 +3,9 @@
 **Status: Experimental.** The whole module sits behind the
 `agents` extended option (OpenStation Preferences → Features → Extended options,
 admin-only). While the flag is off none of these hooks or routes
-exist.
+exist — the one thing that stays is the WP Explorer **Agents** section,
+which is always listed and renders read-only, with a way into the
+Features tab for admins.
 
 An agent is a login-blocked `wp_users` row whose definition
 (description, system prompt, ability allowlist, triggers, model

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -4515,12 +4515,22 @@ Features → Extended options, admin-only, default off). While the flag
 is off none of these hooks exist — `includes/agents/bootstrap.php`
 skips every module file.
 
-**One exception**: `includes/agents/guard.php` loads unconditionally,
-ahead of the flag. It owns `openstation_agent_is_agent()` and every
-login/session block. Disabling the feature does not delete agent user
-rows, and a row whose blocks unloaded with the feature would accept
-application passwords and password resets again — so the blocks are a
-property of the rows, not of the feature.
+**Two exceptions** load unconditionally, ahead of the flag:
+
+- `includes/agents/guard.php` owns `openstation_agent_is_agent()` and
+  every login/session block. Disabling the feature does not delete
+  agent user rows, and a row whose blocks unloaded with the feature
+  would accept application passwords and password resets again — so
+  the blocks are a property of the rows, not of the feature.
+- `includes/agents/my-wordpress.php` adds the Agents section to WP
+  Explorer, so the section is always listed for anyone who passes
+  `openstation_agents_user_can_read`. While the flag is off the
+  section config carries `enabled => false` and the bundle paints it
+  read-only without issuing a single request — the REST routes below
+  genuinely do not exist then. The three capability filters and
+  `openstation_agent_avatar_url()` live in `bootstrap.php` for the
+  same reason: the section descriptor needs them while `rest.php` and
+  `identity.php` are unloaded.
 
 An agent is a synthetic `wp_users` row (login-blocked) whose entire
 definition lives as user meta on that row: description, instructions
@@ -4786,11 +4796,16 @@ add_filter( 'openstation_agent_http_timeout', fn() => 300 );
 The three permission gates on the REST surface and the UI. Defaults:
 read `edit_posts`, manage `edit_users`, invoke `edit_posts`.
 
+All three are available even when the agents feature is off
+(bootstrap.php) — `openstation_agents_user_can_read` decides whether
+the always-listed WP Explorer section appears at all.
+
 - **Param** `bool $can`
 
 ### PHP helpers — Experimental
 
 - `openstation_agent_is_agent( $user )` — marker-meta test. Available even when the agents feature is off (guard.php).
+- `openstation_agent_avatar_url()` — the bot avatar file URL. Available even when the agents feature is off (bootstrap.php).
 - `openstation_agent_create( $args )` / `openstation_agent_update( $user_id, $fields )` / `openstation_agent_delete( $user_id, $reassign )` — the orchestrators (the only write paths; each fires its audit action). These are **privileged internal APIs**: they enforce role assignment (see `openstation_agent_actor_can_assign_role`) but assume the caller already checked who is asking. The REST surface does that with `edit_users`; a direct caller must do the same.
 - `openstation_agent_get_agents( $args )` — list every agent.
 - `openstation_agent_get_{description,instructions,abilities,triggers,model,rate_limit}( $user_id )` — definition getters.

--- a/includes/agents/bootstrap.php
+++ b/includes/agents/bootstrap.php
@@ -19,8 +19,9 @@
  * section inside WP Explorer (my-wordpress.php).
  *
  * The module is opt-in behind the `agents` extended option — while
- * off, no user-meta registration, no REST routes, no window, no
- * WP Explorer entity. The one exception is guard.php: see below.
+ * off, no user-meta registration, no REST routes and no chat window.
+ * Two files load regardless of the flag: guard.php and
+ * my-wordpress.php. See below for why.
  *
  * @package OpenStation
  */
@@ -35,6 +36,72 @@ defined( 'ABSPATH' ) || exit;
  * blocks are a property of the rows, not of the feature.
  */
 require_once OPENSTATION_DIR . 'includes/agents/guard.php';
+
+// ---------------------------------------------------------------------------
+// Always-available helpers
+//
+// The capability helpers and the avatar URL live here rather than in
+// rest.php / identity.php because the WP Explorer integration needs
+// all four to build its entity descriptor, and it now loads while the
+// feature flag is off — when neither of those files is loaded.
+// ---------------------------------------------------------------------------
+
+/**
+ * URL of the bot avatar as a real static file.
+ *
+ * The avatar MUST be a file URL, not the data URI: consumers routinely
+ * run avatar URLs through `esc_url()` (wp-admin's `get_avatar()`, the
+ * desktop user-tile renderer), and `data` is not in
+ * `wp_allowed_protocols()` — the data URI silently becomes an empty
+ * string and the avatar renders broken.
+ *
+ * @return string
+ */
+function openstation_agent_avatar_url() {
+	return OPENSTATION_URL . 'assets/images/agent-avatar.svg';
+}
+
+/**
+ * Whether the current user can see agents.
+ *
+ * @return bool
+ */
+function openstation_agents_user_can_read() {
+	/**
+	 * Filter whether the current user can read OpenStation agents.
+	 *
+	 * @param bool $can Default: `edit_posts` capability.
+	 */
+	return (bool) apply_filters( 'openstation_agents_user_can_read', current_user_can( 'edit_posts' ) );
+}
+
+/**
+ * Whether the current user can create / edit / delete agents.
+ *
+ * @return bool
+ */
+function openstation_agents_user_can_manage() {
+	/**
+	 * Filter whether the current user can manage OpenStation agents.
+	 *
+	 * @param bool $can Default: `edit_users` capability.
+	 */
+	return (bool) apply_filters( 'openstation_agents_user_can_manage', current_user_can( 'edit_users' ) );
+}
+
+/**
+ * Whether the current user can invoke agents.
+ *
+ * @return bool
+ */
+function openstation_agents_user_can_invoke() {
+	/**
+	 * Filter whether the current user can invoke OpenStation agents.
+	 *
+	 * @param bool $can Default: `edit_posts` capability.
+	 */
+	return (bool) apply_filters( 'openstation_agents_user_can_invoke', current_user_can( 'edit_posts' ) );
+}
 
 /**
  * Whether the Agents framework is enabled site-wide.
@@ -61,6 +128,21 @@ function openstation_agents_enabled() {
 }
 
 /**
+ * The WP Explorer integration also loads unconditionally, so the Agents
+ * section is always discoverable: a site that has never turned the
+ * framework on still shows the tile, and the section explains how to
+ * switch it on instead of hiding the feature from the one person who
+ * could enable it. Everything inside renders inert while the flag is
+ * off — `openstation_agents_my_wordpress_window_args()` ships
+ * `enabled => false`, and the renderer disables every control and skips
+ * every fetch (the REST routes genuinely do not exist while off).
+ *
+ * Loaded after the helpers above, which it needs to build the entity
+ * descriptor and the section config.
+ */
+require_once OPENSTATION_DIR . 'includes/agents/my-wordpress.php';
+
+/**
  * Loads the agents module when the framework is enabled.
  *
  * @access private
@@ -79,6 +161,5 @@ function openstation_agents_load() {
 	require_once OPENSTATION_DIR . 'includes/agents/conversations.php';
 	require_once OPENSTATION_DIR . 'includes/agents/privacy.php';
 	require_once OPENSTATION_DIR . 'includes/agents/run-window.php';
-	require_once OPENSTATION_DIR . 'includes/agents/my-wordpress.php';
 }
 add_action( 'plugins_loaded', 'openstation_agents_load', 5 );

--- a/includes/agents/identity.php
+++ b/includes/agents/identity.php
@@ -171,22 +171,11 @@ function openstation_agent_delete( $user_id, $reassign = null ) {
 
 // ---------------------------------------------------------------------------
 // Identity surface
+//
+// `openstation_agent_avatar_url()` lives in bootstrap.php: the WP
+// Explorer integration needs it for the entity icon and loads while the
+// feature flag is off, when this file does not.
 // ---------------------------------------------------------------------------
-
-/**
- * URL of the bot avatar as a real static file.
- *
- * The avatar MUST be a file URL, not the data URI: consumers routinely
- * run avatar URLs through `esc_url()` (wp-admin's `get_avatar()`, the
- * desktop user-tile renderer), and `data` is not in
- * `wp_allowed_protocols()` — the data URI silently becomes an empty
- * string and the avatar renders broken.
- *
- * @return string
- */
-function openstation_agent_avatar_url() {
-	return OPENSTATION_URL . 'assets/images/agent-avatar.svg';
-}
 
 /**
  * Substitute the bot glyph for agent avatars across the WP admin.

--- a/includes/agents/my-wordpress.php
+++ b/includes/agents/my-wordpress.php
@@ -8,6 +8,12 @@
  * `openstation_my_wordpress_window_args`). The bundle side registers
  * the `agent` entity-kind renderer.
  *
+ * This file loads regardless of the `agents` extended option (see
+ * bootstrap.php) so the section is always discoverable. While the flag
+ * is off the config carries `enabled => false` and the renderer paints
+ * the section read-only — no REST call is attempted, because the
+ * routes are not registered.
+ *
  * @package OpenStation
  */
 
@@ -39,6 +45,14 @@ add_filter( 'openstation_my_wordpress_entities', 'openstation_agents_my_wordpres
 /**
  * Ship the agents section config on the WP Explorer window config.
  *
+ * `enabled` mirrors the `agents` extended option. When it is false the
+ * section still renders — every control disabled, nothing fetched —
+ * and offers `canEnable` users a way into the Features tab that turns
+ * the framework on. `canManage` / `canInvoke` stay the raw capability
+ * answers so that shell renders the same controls it would when the
+ * flag is on, just inert; the real gate is that the REST routes do not
+ * exist while off.
+ *
  * `aiAvailable` is the cheap structural check (WP 7.0 AI Client +
  * Abilities API present); whether a connector is actually configured
  * is probed live by the renderer against `aiStatusUrl`, mirroring the
@@ -58,6 +72,8 @@ function openstation_agents_my_wordpress_window_args( $window_args ) {
 	}
 
 	$window_args['config']['agents'] = array(
+		'enabled'       => openstation_agents_enabled(),
+		'canEnable'     => current_user_can( 'manage_options' ),
 		'canManage'     => openstation_agents_user_can_manage(),
 		'canInvoke'     => openstation_agents_user_can_invoke(),
 		'aiAvailable'   => function_exists( 'openstation_ai_is_available' ) && openstation_ai_is_available(),

--- a/includes/agents/rest.php
+++ b/includes/agents/rest.php
@@ -186,49 +186,12 @@ add_action( 'rest_api_init', 'openstation_agents_register_rest_routes' );
 
 // ---------------------------------------------------------------------------
 // Permissions
+//
+// The three capability gates themselves (`openstation_agents_user_can_read`
+// / `_manage` / `_invoke`) live in bootstrap.php: the WP Explorer
+// integration loads while the feature flag is off, and this file does
+// not.
 // ---------------------------------------------------------------------------
-
-/**
- * Whether the current user can see agents.
- *
- * @return bool
- */
-function openstation_agents_user_can_read() {
-	/**
-	 * Filter whether the current user can read OpenStation agents.
-	 *
-	 * @param bool $can Default: `edit_posts` capability.
-	 */
-	return (bool) apply_filters( 'openstation_agents_user_can_read', current_user_can( 'edit_posts' ) );
-}
-
-/**
- * Whether the current user can create / edit / delete agents.
- *
- * @return bool
- */
-function openstation_agents_user_can_manage() {
-	/**
-	 * Filter whether the current user can manage OpenStation agents.
-	 *
-	 * @param bool $can Default: `edit_users` capability.
-	 */
-	return (bool) apply_filters( 'openstation_agents_user_can_manage', current_user_can( 'edit_users' ) );
-}
-
-/**
- * Whether the current user can invoke agents.
- *
- * @return bool
- */
-function openstation_agents_user_can_invoke() {
-	/**
-	 * Filter whether the current user can invoke OpenStation agents.
-	 *
-	 * @param bool $can Default: `edit_posts` capability.
-	 */
-	return (bool) apply_filters( 'openstation_agents_user_can_invoke', current_user_can( 'edit_posts' ) );
-}
 
 /**
  * Read-route permission callback.

--- a/includes/desktop-files/types/class-openstation-user-file.php
+++ b/includes/desktop-files/types/class-openstation-user-file.php
@@ -63,19 +63,43 @@ class OpenStation_User_File extends OpenStation_File {
 		// handler can gate synchronously without an agents REST
 		// roundtrip: null = no drag trigger configured (tile rejects
 		// drops), [] = drag trigger with no filter (accepts every
-		// entity kind). Guarded — the agents module is behind the
-		// `agents` extended option.
+		// entity kind).
+		//
+		// The two guards test DIFFERENT things and both are load-
+		// bearing. `openstation_agent_is_agent()` lives in the agents
+		// guard, which loads unconditionally — being an agent is a
+		// property of the user row, and the row survives the feature
+		// being switched off. The definition getters live in store.php,
+		// which does NOT load then. Turning the `agents` extended
+		// option off while an agent tile sits on someone's desktop
+		// otherwise fatals the whole admin on the next boot payload.
 		if (
 			$user
 			&& function_exists( 'openstation_agent_is_agent' )
 			&& openstation_agent_is_agent( $user->ID )
 		) {
 			$shape['isAgent'] = true;
+
+			// Named one by one rather than probing a single getter as
+			// a proxy for "store.php loaded": the proxy reads as an
+			// unguarded call at every other site, and this is a rule a
+			// test has to be able to check mechanically.
+			$has_definition = function_exists( 'openstation_agent_get_description' )
+				&& function_exists( 'openstation_agent_get_triggers' );
 			// The "when to use" line — the chat window's subtitle when
 			// the tile opener starts a conversation.
-			$shape['agentDescription'] = openstation_agent_get_description( (int) $user->ID );
-			$drag_kinds                = null;
-			foreach ( openstation_agent_get_triggers( (int) $user->ID ) as $trigger ) {
+			$shape['agentDescription'] = $has_definition
+				? openstation_agent_get_description( (int) $user->ID )
+				: '';
+
+			// Null while the framework is off: the tile still reads as
+			// an agent, but rejects every drop, because nothing can run
+			// to receive it.
+			$drag_kinds = null;
+			$triggers   = $has_definition
+				? openstation_agent_get_triggers( (int) $user->ID )
+				: array();
+			foreach ( $triggers as $trigger ) {
 				if ( 'drag' !== ( isset( $trigger['kind'] ) ? $trigger['kind'] : '' ) ) {
 					continue;
 				}

--- a/src/my-wordpress/agents-renderer.ts
+++ b/src/my-wordpress/agents-renderer.ts
@@ -100,6 +100,8 @@ function agentsConfig(): AgentsSectionConfig {
 	};
 	return (
 		cfg.agents ?? {
+			enabled: false,
+			canEnable: false,
 			canManage: false,
 			canInvoke: false,
 			aiAvailable: false,
@@ -108,6 +110,18 @@ function agentsConfig(): AgentsSectionConfig {
 			runWindowId: 'desktop-mode-agent-run',
 		}
 	);
+}
+
+/**
+ * Open OpenStation Preferences on the Features tab, where the `agents`
+ * extended option lives. Resolved off `wp.os` at call time — the
+ * shell bundle owns the opener and this bundle must not import it.
+ */
+function openAgentsFeatureSetting(): void {
+	const api = ( window as unknown as {
+		wp?: { os?: { openOsSettings?: ( opts?: { tabId?: string } ) => void } };
+	} ).wp?.os;
+	api?.openOsSettings?.( { tabId: 'features' } );
 }
 
 /**
@@ -307,13 +321,17 @@ function draftFromAgent( agent: Agent | null ): AgentsState[ 'draft' ] {
 
 export function renderAgents( host: EntityRenderHost ): void {
 	const cfg = agentsConfig();
+	// The framework is opt-in, but the section is always listed. With
+	// the option off the whole surface paints disabled: nothing to
+	// load, nothing to probe, and every control inert.
+	const off = ! cfg.enabled;
 	const root = document.createElement( 'div' );
-	root.className = 'dm-agents';
+	root.className = 'dm-agents' + ( off ? ' is-disabled' : '' );
 	host.body.replaceChildren( root );
 
 	const state: AgentsState = {
 		agents: [],
-		loading: true,
+		loading: ! off,
 		error: '',
 		selectedId: null,
 		pane: 'define',
@@ -625,8 +643,41 @@ export function renderAgents( host: EntityRenderHost ): void {
 	// Templates
 	// -----------------------------------------------------------------
 
+	/**
+	 * Shown in place of every other notice while the framework is off.
+	 * The AI-provider warning below is deliberately suppressed then —
+	 * a connector is the second thing to fix, and stacking both makes
+	 * neither read as the actionable one.
+	 */
+	const offNotice = () => {
+		const askAdmin = __(
+			'An administrator can turn it on in OpenStation Preferences → Features.',
+			'desktop-mode',
+		);
+		const enableAction = cfg.canEnable
+			? html`
+					<os-button
+						class="dm-agents__enable"
+						variant="primary"
+						@click=${ () => openAgentsFeatureSetting() }
+					>
+						${ __( 'Turn on Agents', 'desktop-mode' ) }
+					</os-button>
+			  `
+			: html`${ askAdmin }`;
+		return html`
+			<os-notice tone="warning" class="dm-agents__off-notice">
+				${ __(
+					'The Agents framework is turned off, so this section is read-only.',
+					'desktop-mode',
+				) }
+				${ enableAction }
+			</os-notice>
+		`;
+	};
+
 	const aiNotice = () => {
-		if ( state.aiReady === true || state.aiReady === null ) {
+		if ( off || state.aiReady === true || state.aiReady === null ) {
 			return html``;
 		}
 		const noProvider = __(
@@ -660,7 +711,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 							<os-button
 								class="dm-agents__create"
 								variant="primary"
-								?disabled=${ state.saving }
+								?disabled=${ state.saving || off }
 								@click=${ () => {
 									state.creating = true;
 									state.notice = '';
@@ -1119,6 +1170,24 @@ export function renderAgents( host: EntityRenderHost ): void {
 		}
 		const agent = selected();
 		if ( ! agent ) {
+			if ( off ) {
+				const offDescription = cfg.canEnable
+					? __(
+						'Turn the Agents framework on in OpenStation Preferences → Features to create agents, give them abilities, and chat with them.',
+						'desktop-mode',
+					)
+					: __(
+						'Ask an administrator to turn the Agents framework on in OpenStation Preferences → Features.',
+						'desktop-mode',
+					);
+				return html`
+					<os-empty-state
+						icon="superhero"
+						heading=${ __( 'Agents are turned off', 'desktop-mode' ) }
+						description=${ offDescription }
+					></os-empty-state>
+				`;
+			}
 			let emptyDescription = __(
 				'An administrator has not created any agents on this site yet.',
 				'desktop-mode',
@@ -1231,6 +1300,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 		}
 		render(
 			html`
+				${ off ? offNotice() : html`` }
 				${ aiNotice() }
 				${ state.notice
 					? html`<os-notice class="dm-agents__notice">${ state.notice }</os-notice>`
@@ -1246,12 +1316,15 @@ export function renderAgents( host: EntityRenderHost ): void {
 	};
 
 	paint();
-	void load();
-	void probeAi();
-	// The Define pane's role picker needs the catalogue as soon as an
-	// agent is selected, which happens the moment the list resolves —
-	// fetch alongside the list rather than on the first click.
-	void ensureRoles();
+	if ( ! off ) {
+		void load();
+		void probeAi();
+		// The Define pane's role picker needs the catalogue as soon as
+		// an agent is selected, which happens the moment the list
+		// resolves — fetch alongside the list rather than on the first
+		// click.
+		void ensureRoles();
+	}
 }
 
 registerEntityKind( 'agent', renderAgents );

--- a/src/my-wordpress/agents-renderer.ts
+++ b/src/my-wordpress/agents-renderer.ts
@@ -644,38 +644,11 @@ export function renderAgents( host: EntityRenderHost ): void {
 	// -----------------------------------------------------------------
 
 	/**
-	 * Shown in place of every other notice while the framework is off.
-	 * The AI-provider warning below is deliberately suppressed then —
-	 * a connector is the second thing to fix, and stacking both makes
-	 * neither read as the actionable one.
+	 * Silent while the framework is off: a connector is the SECOND
+	 * thing to fix, and the empty state is already saying what the
+	 * first one is. Two warnings and neither reads as the actionable
+	 * one.
 	 */
-	const offNotice = () => {
-		const askAdmin = __(
-			'An administrator can turn it on in OpenStation Preferences → Features.',
-			'desktop-mode',
-		);
-		const enableAction = cfg.canEnable
-			? html`
-					<os-button
-						class="dm-agents__enable"
-						variant="primary"
-						@click=${ () => openAgentsFeatureSetting() }
-					>
-						${ __( 'Turn on Agents', 'desktop-mode' ) }
-					</os-button>
-			  `
-			: html`${ askAdmin }`;
-		return html`
-			<os-notice tone="warning" class="dm-agents__off-notice">
-				${ __(
-					'The Agents framework is turned off, so this section is read-only.',
-					'desktop-mode',
-				) }
-				${ enableAction }
-			</os-notice>
-		`;
-	};
-
 	const aiNotice = () => {
 		if ( off || state.aiReady === true || state.aiReady === null ) {
 			return html``;
@@ -1170,6 +1143,12 @@ export function renderAgents( host: EntityRenderHost ): void {
 		}
 		const agent = selected();
 		if ( ! agent ) {
+			// The whole off-state message lives here rather than in a
+			// banner above the layout. While the framework is off there
+			// is nothing to list, so this pane always renders — a
+			// banner as well would say the same thing twice, and a
+			// full-window bar carrying one sentence reads as mostly
+			// dead space.
 			if ( off ) {
 				const offDescription = cfg.canEnable
 					? __(
@@ -1185,7 +1164,20 @@ export function renderAgents( host: EntityRenderHost ): void {
 						icon="superhero"
 						heading=${ __( 'Agents are turned off', 'desktop-mode' ) }
 						description=${ offDescription }
-					></os-empty-state>
+					>
+						${ cfg.canEnable
+							? html`
+									<os-button
+										slot="cta"
+										class="dm-agents__enable"
+										variant="primary"
+										@click=${ () => openAgentsFeatureSetting() }
+									>
+										${ __( 'Turn on Agents', 'desktop-mode' ) }
+									</os-button>
+							  `
+							: html`` }
+					</os-empty-state>
 				`;
 			}
 			let emptyDescription = __(
@@ -1300,7 +1292,6 @@ export function renderAgents( host: EntityRenderHost ): void {
 		}
 		render(
 			html`
-				${ off ? offNotice() : html`` }
 				${ aiNotice() }
 				${ state.notice
 					? html`<os-notice class="dm-agents__notice">${ state.notice }</os-notice>`

--- a/src/my-wordpress/agents-send-to.ts
+++ b/src/my-wordpress/agents-send-to.ts
@@ -43,13 +43,19 @@ interface TileMenuCtx {
 let cache: Agent[] | null = null;
 let warming = false;
 
+/**
+ * The section config ships on every WP Explorer window the user may
+ * read agents in — including sites where the framework itself is off,
+ * so the section can render its "turn it on" state. `enabled` is the
+ * half that says whether the REST routes exist; without it the warm-up
+ * below would fetch a 404 on every such site.
+ */
 function agentsConfigured(): boolean {
 	try {
-		return Boolean(
-			( getConfig() as MyWordPressConfig & {
-				agents?: AgentsSectionConfig;
-			} ).agents,
-		);
+		const agents = ( getConfig() as MyWordPressConfig & {
+			agents?: AgentsSectionConfig;
+		} ).agents;
+		return Boolean( agents?.enabled );
 	} catch {
 		return false;
 	}

--- a/src/my-wordpress/agents-types.ts
+++ b/src/my-wordpress/agents-types.ts
@@ -96,6 +96,15 @@ export interface AgentInvokeResult {
  * `openstation_agents_my_wordpress_window_args()`.
  */
 export interface AgentsSectionConfig {
+	/**
+	 * The `agents` extended option. False means the framework is off:
+	 * the section still renders (and the tile is still listed) but every
+	 * control is disabled and no REST call is attempted, because the
+	 * `/desktop-mode/v1/agents` routes are not registered while off.
+	 */
+	enabled: boolean;
+	/** Whether this user may flip that option (`manage_options`). */
+	canEnable: boolean;
 	canManage: boolean;
 	canInvoke: boolean;
 	aiAvailable: boolean;

--- a/tests/phpunit/tests/agentsMyWordpress.php
+++ b/tests/phpunit/tests/agentsMyWordpress.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Tests for the agents ↔ WP Explorer integration.
+ * Tests for the agents ↔ WP Explorer integration, and for the wider
+ * contract that a site with the `agents` extended option OFF still
+ * boots.
  *
- * The integration loads regardless of the `agents` extended option so
- * the section is always discoverable; what the flag decides is whether
- * the section arrives live or read-only. Both halves are pinned here,
- * because a regression on either one is invisible until someone opens
- * the window on a site that never turned agents on.
+ * The integration loads regardless of the flag so the section is
+ * always discoverable; what the flag decides is whether the section
+ * arrives live or read-only. Both halves are pinned here, because a
+ * regression on either one is invisible until someone opens the window
+ * on a site that never turned agents on.
  *
  * @package WordPress
  * @subpackage UnitTests
@@ -173,6 +175,69 @@ class Tests_OpenStation_AgentsMyWordpress extends WP_UnitTestCase {
 		$this->assertStringContainsString(
 			'agent-avatar.svg',
 			openstation_agent_avatar_url()
+		);
+	}
+
+	/**
+	 * Every agents function called from OUTSIDE `includes/agents/` must
+	 * either be declared in a file that loads unconditionally, or be
+	 * wrapped in `function_exists()` at the call site.
+	 *
+	 * This is the one class of agents bug the rest of the suite cannot
+	 * see: the bootstrap forces the framework ON, so a call into
+	 * store.php resolves fine here and fatals only on a real install
+	 * with the option off. It shipped once exactly that way —
+	 * `OpenStation_User_File::serialize()` guarded on
+	 * `openstation_agent_is_agent()` (guard.php, always loaded) and
+	 * then called `openstation_agent_get_description()` (store.php,
+	 * not loaded), so turning agents off with an agent tile on the
+	 * desktop fataled the whole admin.
+	 *
+	 * @coversNothing
+	 */
+	public function test_no_unguarded_agents_calls_from_outside_the_module() {
+		$always_loaded = array( 'guard.php', 'bootstrap.php' );
+		$root          = dirname( __DIR__, 3 ) . '/includes';
+		$files         = new RegexIterator(
+			new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $root ) ),
+			'/\.php$/'
+		);
+
+		$unguarded = array();
+		foreach ( $files as $file ) {
+			$path = $file->getPathname();
+			if ( false !== strpos( $path, '/includes/agents/' ) ) {
+				continue;
+			}
+			$source = file_get_contents( $path );
+			if ( ! preg_match_all( '/\b(openstation_agents?_[a-z0-9_]+)\s*\(/', $source, $matches ) ) {
+				continue;
+			}
+
+			foreach ( array_unique( $matches[1] ) as $function ) {
+				if ( ! function_exists( $function ) ) {
+					continue;
+				}
+				$declared_in = basename( ( new ReflectionFunction( $function ) )->getFileName() );
+				if ( in_array( $declared_in, $always_loaded, true ) ) {
+					continue;
+				}
+				// `function_exists( 'name' )` anywhere in the file is
+				// accepted — the call sites are short enough that a
+				// per-file guard is the honest granularity here.
+				if ( false !== strpos( $source, "function_exists( '{$function}' )" ) ) {
+					continue;
+				}
+				$unguarded[] = str_replace( $root, 'includes', $path ) . " → {$function}()";
+			}
+		}
+
+		$this->assertSame(
+			array(),
+			$unguarded,
+			"Agents functions reached from outside the module without a function_exists() guard.\n"
+				. "These fatal on any site with the `agents` extended option off:\n  "
+				. implode( "\n  ", $unguarded )
 		);
 	}
 }

--- a/tests/phpunit/tests/agentsMyWordpress.php
+++ b/tests/phpunit/tests/agentsMyWordpress.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Tests for the agents ↔ WP Explorer integration.
+ *
+ * The integration loads regardless of the `agents` extended option so
+ * the section is always discoverable; what the flag decides is whether
+ * the section arrives live or read-only. Both halves are pinned here,
+ * because a regression on either one is invisible until someone opens
+ * the window on a site that never turned agents on.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group os-agents
+ */
+class Tests_OpenStation_AgentsMyWordpress extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $editor_id;
+	protected static $subscriber_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Turn the framework off for the duration of one test. The suite
+	 * bootstrap forces it on; the test framework restores hooks after
+	 * every test, so this only affects the caller.
+	 */
+	private function disable_agents() {
+		remove_all_filters( 'openstation_agents_enabled' );
+		add_filter( 'openstation_agents_enabled', '__return_false' );
+	}
+
+	private function agents_config() {
+		$args = openstation_agents_my_wordpress_window_args( array( 'config' => array() ) );
+		return isset( $args['config']['agents'] ) ? $args['config']['agents'] : null;
+	}
+
+	private function entity_ids() {
+		return wp_list_pluck(
+			openstation_agents_my_wordpress_entity( array() ),
+			'id'
+		);
+	}
+
+	/**
+	 * @covers ::openstation_agents_my_wordpress_entity
+	 */
+	public function test_entity_is_appended_for_a_reader() {
+		$entities = openstation_agents_my_wordpress_entity( array() );
+
+		$this->assertCount( 1, $entities );
+		$this->assertSame( 'agents', $entities[0]['id'] );
+		$this->assertSame( 'agent', $entities[0]['kind'] );
+		$this->assertSame( 'desktop-mode/v1/agents', $entities[0]['restPath'] );
+		$this->assertNotEmpty( $entities[0]['icon'] );
+	}
+
+	/**
+	 * The whole point of the change: a site that has never enabled the
+	 * framework still lists the section.
+	 *
+	 * @covers ::openstation_agents_my_wordpress_entity
+	 */
+	public function test_entity_is_listed_while_the_framework_is_off() {
+		$this->disable_agents();
+
+		$this->assertSame( array( 'agents' ), $this->entity_ids() );
+	}
+
+	/**
+	 * @covers ::openstation_agents_my_wordpress_entity
+	 */
+	public function test_entity_is_withheld_from_users_who_cannot_read_agents() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertSame( array(), $this->entity_ids() );
+	}
+
+	/**
+	 * @covers ::openstation_agents_my_wordpress_window_args
+	 */
+	public function test_window_config_reports_enabled_when_the_flag_is_on() {
+		$config = $this->agents_config();
+
+		$this->assertTrue( $config['enabled'] );
+		$this->assertTrue( $config['canEnable'] );
+		$this->assertTrue( $config['canManage'] );
+		$this->assertTrue( $config['canInvoke'] );
+	}
+
+	/**
+	 * `enabled` is what tells the bundle not to fetch — the REST routes
+	 * are genuinely absent while the flag is off, so a section that
+	 * tried would 404 on every paint.
+	 *
+	 * @covers ::openstation_agents_my_wordpress_window_args
+	 */
+	public function test_window_config_reports_disabled_when_the_flag_is_off() {
+		$this->disable_agents();
+		$config = $this->agents_config();
+
+		$this->assertIsArray( $config );
+		$this->assertFalse( $config['enabled'] );
+	}
+
+	/**
+	 * An editor sees the section but cannot flip the option — the
+	 * Extended options section of the Features tab is admin-only.
+	 *
+	 * @covers ::openstation_agents_my_wordpress_window_args
+	 */
+	public function test_can_enable_tracks_manage_options() {
+		wp_set_current_user( self::$editor_id );
+		$config = $this->agents_config();
+
+		$this->assertIsArray( $config );
+		$this->assertFalse( $config['canEnable'] );
+		$this->assertFalse( $config['canManage'] );
+		$this->assertTrue( $config['canInvoke'] );
+	}
+
+	/**
+	 * @covers ::openstation_agents_my_wordpress_window_args
+	 */
+	public function test_window_config_is_withheld_from_users_who_cannot_read_agents() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertNull( $this->agents_config() );
+	}
+
+	/**
+	 * The entity descriptor is built from helpers that used to live in
+	 * rest.php / identity.php — neither of which is loaded while the
+	 * flag is off, so moving one back there would fatal the WP Explorer
+	 * window on exactly the sites this change exists for.
+	 *
+	 * The suite bootstrap forces the framework ON, so `function_exists`
+	 * proves nothing here; the declaring file is the real assertion.
+	 *
+	 * @covers ::openstation_agent_avatar_url
+	 * @covers ::openstation_agents_user_can_read
+	 * @covers ::openstation_agents_user_can_manage
+	 * @covers ::openstation_agents_user_can_invoke
+	 */
+	public function test_descriptor_helpers_are_declared_in_the_always_loaded_bootstrap() {
+		$always_loaded = array(
+			'openstation_agent_avatar_url',
+			'openstation_agents_user_can_read',
+			'openstation_agents_user_can_manage',
+			'openstation_agents_user_can_invoke',
+		);
+
+		foreach ( $always_loaded as $function ) {
+			$reflection = new ReflectionFunction( $function );
+			$this->assertSame(
+				'bootstrap.php',
+				basename( $reflection->getFileName() ),
+				"{$function}() must stay in the unconditionally loaded agents bootstrap."
+			);
+		}
+
+		$this->assertStringContainsString(
+			'agent-avatar.svg',
+			openstation_agent_avatar_url()
+		);
+	}
+}

--- a/tests/vitest/agents-renderer.test.ts
+++ b/tests/vitest/agents-renderer.test.ts
@@ -44,6 +44,8 @@ function installConfig( overrides: Record< string, unknown > = {} ): void {
 			perPage: 24,
 			editPostUrlBase: '',
 			agents: {
+				enabled: true,
+				canEnable: true,
 				canManage: true,
 				canInvoke: true,
 				aiAvailable: false,
@@ -156,6 +158,93 @@ describe( 'agents entity kind', () => {
 		await flush();
 
 		expect( host.body.querySelector( '.dm-agents__create' ) ).toBeNull();
+	} );
+
+	describe( 'framework turned off', () => {
+		test( 'renders the section without fetching anything', async () => {
+			installConfig( { enabled: false } );
+			const fetchMock = mockAgentList( [] );
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			// The REST routes are not registered while the option is
+			// off — a fetch here would be a guaranteed 404.
+			expect( fetchMock ).not.toHaveBeenCalled();
+			expect( host.body.querySelector( '.dm-agents__layout' ) ).not.toBeNull();
+			expect(
+				host.body.querySelector( '.dm-agents.is-disabled' ),
+			).not.toBeNull();
+		} );
+
+		test( 'disables the create button rather than hiding it', async () => {
+			installConfig( { enabled: false } );
+			mockAgentList( [] );
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			const create = host.body.querySelector( '.dm-agents__create' );
+			expect( create ).not.toBeNull();
+			expect( create!.hasAttribute( 'disabled' ) ).toBe( true );
+		} );
+
+		test( 'offers an admin the Features tab, and suppresses the AI notice', async () => {
+			installConfig( { enabled: false } );
+			mockAgentList( [] );
+			const openOsSettings = vi.fn();
+			( window as unknown as Record< string, unknown > ).wp = {
+				os: { openOsSettings },
+			};
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			const notice = host.body.querySelector( '.dm-agents__off-notice' );
+			expect( notice ).not.toBeNull();
+			expect( notice!.textContent ).toContain( 'turned off' );
+			// Only the off notice — the connector warning would compete
+			// with the one action that actually unblocks the user.
+			expect( notice!.textContent ).not.toContain( 'AI Client' );
+
+			host.body
+				.querySelector< HTMLElement >( '.dm-agents__enable' )!
+				.click();
+			expect( openOsSettings ).toHaveBeenCalledWith( { tabId: 'features' } );
+
+			delete ( window as unknown as Record< string, unknown > ).wp;
+		} );
+
+		test( 'without manage_options it points at an administrator instead', async () => {
+			installConfig( { enabled: false, canEnable: false } );
+			mockAgentList( [] );
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			expect( host.body.querySelector( '.dm-agents__enable' ) ).toBeNull();
+			expect(
+				host.body.querySelector( '.dm-agents__off-notice' )!.textContent,
+			).toContain( 'administrator' );
+		} );
+
+		test( 'the empty state explains the feature is off, not that agents are missing', async () => {
+			installConfig( { enabled: false } );
+			mockAgentList( [] );
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			const empty = host.body.querySelector( 'os-empty-state' );
+			expect( empty?.getAttribute( 'heading' ) ).toBe(
+				'Agents are turned off',
+			);
+		} );
 	} );
 
 	test( 'missing AI client paints the warning notice', async () => {

--- a/tests/vitest/agents-renderer.test.ts
+++ b/tests/vitest/agents-renderer.test.ts
@@ -191,7 +191,7 @@ describe( 'agents entity kind', () => {
 			expect( create!.hasAttribute( 'disabled' ) ).toBe( true );
 		} );
 
-		test( 'offers an admin the Features tab, and suppresses the AI notice', async () => {
+		test( 'offers an admin the Features tab from the empty state CTA', async () => {
 			installConfig( { enabled: false } );
 			mockAgentList( [] );
 			const openOsSettings = vi.fn();
@@ -203,19 +203,33 @@ describe( 'agents entity kind', () => {
 			getEntityRenderer( 'agent' )!( host, ENTITY );
 			await flush();
 
-			const notice = host.body.querySelector( '.dm-agents__off-notice' );
-			expect( notice ).not.toBeNull();
-			expect( notice!.textContent ).toContain( 'turned off' );
-			// Only the off notice — the connector warning would compete
-			// with the one action that actually unblocks the user.
-			expect( notice!.textContent ).not.toContain( 'AI Client' );
-
-			host.body
-				.querySelector< HTMLElement >( '.dm-agents__enable' )!
-				.click();
+			const cta = host.body.querySelector< HTMLElement >(
+				'.dm-agents__enable',
+			);
+			expect( cta ).not.toBeNull();
+			expect( cta!.getAttribute( 'slot' ) ).toBe( 'cta' );
+			cta!.click();
 			expect( openOsSettings ).toHaveBeenCalledWith( { tabId: 'features' } );
 
 			delete ( window as unknown as Record< string, unknown > ).wp;
+		} );
+
+		test( 'says it once — no banner duplicating the empty state', async () => {
+			installConfig( { enabled: false } );
+			mockAgentList( [] );
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			// The pane always renders while off (nothing is fetched, so
+			// the list is always empty), which is exactly why a banner
+			// on top would be the same sentence twice. It also carried
+			// a dismiss button that could not dismiss anything.
+			expect( host.body.querySelector( 'os-notice' ) ).toBeNull();
+			expect( host.body.querySelectorAll( 'os-empty-state' ) ).toHaveLength(
+				1,
+			);
 		} );
 
 		test( 'without manage_options it points at an administrator instead', async () => {
@@ -228,7 +242,9 @@ describe( 'agents entity kind', () => {
 
 			expect( host.body.querySelector( '.dm-agents__enable' ) ).toBeNull();
 			expect(
-				host.body.querySelector( '.dm-agents__off-notice' )!.textContent,
+				host.body
+					.querySelector( 'os-empty-state' )!
+					.getAttribute( 'description' ),
 			).toContain( 'administrator' );
 		} );
 
@@ -244,6 +260,23 @@ describe( 'agents entity kind', () => {
 			expect( empty?.getAttribute( 'heading' ) ).toBe(
 				'Agents are turned off',
 			);
+		} );
+
+		test( 'dims the sidebar but never the way out', async () => {
+			installConfig( { enabled: false } );
+			mockAgentList( [] );
+			const host = makeHost();
+
+			getEntityRenderer( 'agent' )!( host, ENTITY );
+			await flush();
+
+			// `.is-disabled` scopes its opacity to the sidebar — a
+			// greyed-out CTA in a greyed-out pane is a dead end.
+			const root = host.body.querySelector( '.dm-agents' );
+			expect( root!.classList.contains( 'is-disabled' ) ).toBe( true );
+			expect(
+				host.body.querySelector( '.dm-agents__detail .dm-agents__enable' ),
+			).not.toBeNull();
 		} );
 	} );
 

--- a/tests/vitest/agents-send-to.test.ts
+++ b/tests/vitest/agents-send-to.test.ts
@@ -73,7 +73,7 @@ const AGENTS = [
 	} ),
 ];
 
-function installConfig(): void {
+function installConfig( overrides: Record< string, unknown > = {} ): void {
 	( window as unknown as Record< string, unknown > ).openStationWindowConfig = {
 		[ WINDOW_ID ]: {
 			restRoot: 'https://example.test/wp-json/',
@@ -82,12 +82,15 @@ function installConfig(): void {
 			perPage: 24,
 			editPostUrlBase: '',
 			agents: {
+				enabled: true,
+				canEnable: true,
 				canManage: true,
 				canInvoke: true,
 				aiAvailable: true,
 				aiStatusUrl: '',
 				connectorsUrl: '',
 				runWindowId: 'desktop-mode-agent-run',
+				...overrides,
 			},
 		},
 	};
@@ -150,6 +153,20 @@ afterEach( () => {
 } );
 
 describe( 'agents send-to menu', () => {
+	test( 'does not warm while the framework is off', async () => {
+		// The section config now ships even with the `agents` extended
+		// option off, so the tile stays visible — `enabled` is what
+		// says the REST routes exist.
+		installConfig( { enabled: false } );
+		const fetchMock = stubListFetch();
+		sendTo.refreshSendToAgents();
+		await sendTo.warmSendToAgents();
+		await flush();
+
+		expect( fetchMock ).not.toHaveBeenCalled();
+		expect( sendTo.sendToTargetsFor( 'post' ) ).toEqual( [] );
+	} );
+
 	test( 'maps menu contexts onto trigger entity kinds', () => {
 		expect(
 			sendTo.entityKindForMenuCtx( { entityId: 'posts', kind: 'post' } ),


### PR DESCRIPTION
## Why
<img width="1331" height="833" alt="image" src="https://github.com/user-attachments/assets/25fe8617-104b-45df-981b-5b187608280b" />

The Agents framework is opt-in behind the `agents` extended option (default **off**), and the WP Explorer integration lived *inside* the gated module load. So on every site that had never turned agents on, the section simply did not exist — and the one person who could enable it had no way to discover it from the window it belongs to.

## What changed

`includes/agents/my-wordpress.php` now loads unconditionally, alongside `guard.php`. The section config gained two fields:

- **`enabled`** — mirrors the extended option. False means the REST routes are not registered, so the bundle must not fetch.
- **`canEnable`** — `manage_options`, since the Extended options block of the Features tab is admin-only.

With the flag off the section still opens and renders the same layout, entirely inert:

- warning notice at the top, with a **Turn on Agents** button that opens Preferences → Features (non-admins get "ask an administrator" instead)
- **+ Create agent** rendered but `disabled`
- empty state reads *"Agents are turned off"* rather than *"No agents yet"*
- no `listAgents()`, no AI-status probe, no roles fetch — nothing that would 404
- the AI-connector warning is suppressed while off, so the one actionable notice isn't competing with a second one

Two helpers moved so the entity descriptor can be built while `rest.php` and `identity.php` are unloaded:

| Helper | From | To |
|---|---|---|
| `openstation_agents_user_can_{read,manage,invoke}()` | `rest.php` | `bootstrap.php` |
| `openstation_agent_avatar_url()` | `identity.php` | `bootstrap.php` |

Both files keep a comment at the old site explaining why, and a PHPUnit test asserts the declaring filename so they don't drift back.

Also: `agentsConfigured()` in the Send-to-agent menu now requires `enabled`, not just the presence of the config block — otherwise the cache warm-up would fire a guaranteed 404 on every site with the flag off.

## What did *not* change

The read gate. `openstation_agents_user_can_read` (`edit_posts`) still decides whether the section is listed at all — subscribers and contributors see nothing, exactly as before.

## Known limitation

Flipping the option from the notice does not live-refresh the open WP Explorer window; the section config is baked into the window payload, and the extended-options save is not one of the payloads the menu-refresh bridge diffs. The user needs a reload to see the section come alive. Worth a follow-up if it grates.

## Tests

- `tests/phpunit/tests/agentsMyWordpress.php` (new, 8 tests) — entity listed with the flag off, withheld from non-readers, `enabled` / `canEnable` / `canManage` / `canInvoke` per role, helpers declared in the always-loaded bootstrap.
- `tests/vitest/agents-renderer.test.ts` — new `framework turned off` block: no fetch, `is-disabled` class, create button disabled-not-hidden, notice wiring to `openOsSettings({ tabId: 'features' })`, admin vs non-admin copy, empty-state heading.
- `tests/vitest/agents-send-to.test.ts` — does not warm while off.

Gates: `npm run build`, `lint`, `typecheck`, `test:js` (4013 passed), `lint:php`, `test:php` (2069 passed) all green.

## Docs

`docs/hooks-reference.md` — the "one exception" note is now two, with the reasoning; the capability filters and `openstation_agent_avatar_url()` are marked as available while the feature is off. `docs/examples/agents.md` — the intro no longer says nothing survives the flag being off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-540-da2553035c1d853f3fcbc6bdb50942fe3f50f91d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->