### PR TITLE
Settle a pending Overview exit before re-entering

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4000,12 +4000,14 @@ The desk companion. Full documentation in [mio.md](./mio.md).
 
 Fired by the admin-bar "Arrange" menu's layout algorithms. The overview hooks come in pairs (enter/exit, hover/unhover) so plugins can maintain accurate state counts.
 
+The pairing holds even when a user re-enters overview inside the ~280 ms exit animation (a double-tap of the trigger): the outgoing session is settled first, so `exited` arrives ahead of the next `entering` rather than landing partway into the new session. A listener can rely on the sequence never interleaving.
+
 | Hook | Kind | Status | Payload |
 |---|---|---|---|
 | `os.overview.entering` | action | Stable | `{}` — before the enter animation starts |
 | `os.overview.entered` | action | Stable | `{}` — fires ~300 ms later, after the grid settles |
 | `os.overview.exiting` | action | Stable | `{ windowId?: string, reason: 'select' \| 'cancel' }` |
-| `os.overview.exited` | action | Stable | same payload as `exiting` |
+| `os.overview.exited` | action | Stable | same payload as `exiting` — fires ~280 ms later, once the windows have animated home |
 | `os.overview.window-hover` | action | Stable | `{ windowId }` |
 | `os.overview.window-unhover` | action | Stable | `{ windowId }` |
 | `os.overview.window-click` | action | Stable | `{ windowId }` — fires just before `exiting` when a thumbnail is clicked |

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -275,6 +275,17 @@ export class WindowManager {
 	 * @internal
 	 */
 	public _overviewExitTimeoutId: number | null = null;
+	/**
+	 * Cleanup for the exit animation scheduled by `exitOverview()`,
+	 * held so it can be run AHEAD of its timer rather than only by it.
+	 * Re-entering overview inside the 280 ms exit window has to settle
+	 * the outgoing session first — otherwise the stale timer fires
+	 * mid-session and undoes the new one's setup (stripping
+	 * `os-window--overview`, re-applying a suspended fullscreen class,
+	 * removing the freshly-built top bar).
+	 * @internal
+	 */
+	public _overviewExitFinalizer: ( () => void ) | null = null;
 
 	// ---- Snap-zone state (edge-snap + split overview) ----
 

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -136,6 +136,10 @@ export function enterOverview( mgr: WindowManager ): void {
 	if ( mgr._overviewActive ) {
 		return;
 	}
+	// A previous exit may still be mid-animation (the user double-tapped
+	// the trigger). Settle it now so its timer can't fire inside the
+	// session we're about to build. See `flushPendingOverviewExit`.
+	flushPendingOverviewExit( mgr );
 	// Overview shows windows on the active desktop, including minimized
 	// ones. Minimized windows are rendered with a visual indicator
 	// (lower opacity) so the user can see all their work at a glance.
@@ -448,6 +452,33 @@ export function enterOverview( mgr: WindowManager ): void {
 }
 
 /**
+ * Run the pending exit-animation cleanup now, cancelling its timer.
+ *
+ * The timer itself calls this; so does `enterOverview()`, because a
+ * re-entry inside the 280 ms exit window would otherwise leave a live
+ * timer that fires MID-session and undoes the new session's setup —
+ * stripping `os-window--overview` from every thumbnail, re-adding
+ * `os-window--fullscreen` to a window whose class was suspended for
+ * layout (blowing one thumbnail up to fullscreen size and hiding the
+ * admin bar with it), and removing the top bar that enter just built.
+ *
+ * Settling the outgoing session first is what makes double-tapping
+ * the overview trigger safe: `OVERVIEW_EXITED` lands before
+ * `OVERVIEW_ENTERING`, in the order a listener expects.
+ *
+ * No-op when nothing is pending.
+ */
+export function flushPendingOverviewExit( mgr: WindowManager ): void {
+	if ( mgr._overviewExitTimeoutId !== null ) {
+		window.clearTimeout( mgr._overviewExitTimeoutId );
+		mgr._overviewExitTimeoutId = null;
+	}
+	const finalize = mgr._overviewExitFinalizer;
+	mgr._overviewExitFinalizer = null;
+	finalize?.();
+}
+
+/**
  * Cancel any pending overview transition timers without running their
  * callbacks. Called from `WindowManager.destroy()` so a discarded
  * manager can never fire a delayed `doAction()` that reaches for
@@ -462,6 +493,9 @@ export function cancelOverviewTimers( mgr: WindowManager ): void {
 		window.clearTimeout( mgr._overviewExitTimeoutId );
 		mgr._overviewExitTimeoutId = null;
 	}
+	// Dropped, not run — `destroy()` wants the callback gone, and its
+	// `doAction()` would reach for globals this teardown is removing.
+	mgr._overviewExitFinalizer = null;
 }
 
 /** Build the overview top bar — a tile per virtual desktop plus "+". */
@@ -783,8 +817,7 @@ export function exitOverview(
 	// tracked so `destroy()` can cancel it if the manager is
 	// discarded before it fires.
 	const ANIMATION_MS = 280;
-	mgr._overviewExitTimeoutId = window.setTimeout( () => {
-		mgr._overviewExitTimeoutId = null;
+	mgr._overviewExitFinalizer = () => {
 		for ( const w of mgr._stack ) {
 			w.element.classList.remove( 'os-window--overview' );
 			restoreWindowAfterOverviewLayout(
@@ -818,7 +851,11 @@ export function exitOverview(
 			windowId: selected ? selected.id : undefined,
 			reason: selected ? 'select' : 'cancel',
 		} );
-	}, ANIMATION_MS ) as unknown as number;
+	};
+	mgr._overviewExitTimeoutId = window.setTimeout(
+		() => flushPendingOverviewExit( mgr ),
+		ANIMATION_MS,
+	) as unknown as number;
 
 	if ( mgr._overviewPointerDownHandler ) {
 		mgr._desktop.removeEventListener(

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -512,6 +512,85 @@ describe( 'WindowManager — virtual desktops', async () => {
 		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBeUndefined();
 	} );
 
+	test( 're-entering overview mid-exit does not re-fullscreen a thumbnail', async () => {
+		// Double-tapping the overview trigger lands the second enter
+		// inside the 280 ms exit animation. The outgoing session's timer
+		// must not survive into the new one — if it does, it fires
+		// mid-session and re-applies `--fullscreen` to a thumbnail that
+		// is currently laid out in the grid, blowing it up to full size
+		// and taking the admin bar with it (the body class hides it).
+		vi.useFakeTimers();
+		const a = await manager.open( openConfig( 'a' ) );
+		a.toggleFullscreen();
+
+		manager.enterOverview();
+		manager.exitOverview();
+		vi.advanceTimersByTime( 100 );
+		manager.enterOverview();
+
+		// The flush settled the first session, so the marker is back on
+		// for the SECOND session's layout — not a leftover of the first.
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBe( 'true' );
+
+		// Past the point the stale timer would have fired.
+		vi.advanceTimersByTime( 280 );
+
+		expect( manager._overviewActive ).toBe( true );
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( false );
+		expect(
+			document.body.classList.contains( 'os-has-fullscreen-window' ),
+		).toBe( false );
+		// The thumbnail is still laid out as one.
+		expect( a.element.classList.contains( 'os-window--overview' ) ).toBe(
+			true,
+		);
+
+		// And the second session still exits cleanly.
+		manager.exitOverview();
+		vi.advanceTimersByTime( 280 );
+
+		expect(
+			a.element.classList.contains( 'os-window--fullscreen' ),
+		).toBe( true );
+		expect( a.element.dataset.osHadFullscreenBeforeOverview ).toBeUndefined();
+	} );
+
+	test( 're-entering overview mid-exit settles the outgoing session first', async () => {
+		vi.useFakeTimers();
+		await manager.open( openConfig( 'a' ) );
+		const log = recordActions( hooks, [
+			HOOKS.OVERVIEW_EXITED,
+			HOOKS.OVERVIEW_ENTERING,
+		] );
+
+		manager.enterOverview();
+		const firstTopBar = manager._overviewTopBar;
+		manager.exitOverview();
+		vi.advanceTimersByTime( 100 );
+		manager.enterOverview();
+
+		// `exited` for session one lands BEFORE `entering` for session
+		// two — the order a listener expects, rather than arriving 180 ms
+		// into a session that is already up.
+		expect( log.map( ( e ) => e.name ) ).toEqual( [
+			HOOKS.OVERVIEW_ENTERING,
+			HOOKS.OVERVIEW_EXITED,
+			HOOKS.OVERVIEW_ENTERING,
+		] );
+		// The first session's top bar was torn down, not orphaned in the
+		// DOM behind the new one.
+		expect( firstTopBar?.isConnected ).toBe( false );
+		expect(
+			desktopArea.querySelectorAll( '.os-overview-top-bar' ),
+		).toHaveLength( 1 );
+
+		// The stale timer is gone — the new session's top bar survives.
+		vi.advanceTimersByTime( 280 );
+		expect( manager._overviewTopBar?.isConnected ).toBe( true );
+	} );
+
 	test( 'Enter key in overview exits without selecting a window', async () => {
 		await manager.open( openConfig( 'a' ) );
 		manager.enterOverview();


### PR DESCRIPTION
Follow-up to the review on #536 — the one regression edge the reviewer flagged and I merged without fixing.

## The bug

`enterOverview()` never cancelled a pending `_overviewExitTimeoutId`. Re-entering Overview inside the 280 ms exit animation (double-tapping the trigger) left the outgoing session's timer live, and it fired mid-way into the new session:

- strips `os-window--overview` from every thumbnail (pre-existing on trunk, milder)
- **re-adds `os-window--fullscreen`** to a window whose class was suspended for layout — the thumbnail blows up to fullscreen size inside the active Overview, and `os-has-fullscreen-window` comes back on the body, hiding the admin bar Overview depends on

The fullscreen half is new with #536, made reachable because the marker now applies to visible fullscreen windows and not just minimized ones.

## The fix

The exit cleanup moves out of the timeout callback into `mgr._overviewExitFinalizer`, and `flushPendingOverviewExit()` runs it while cancelling the timer. The timer calls it; so does `enterOverview()`, before it touches any state.

Flushing rather than guarding (`if ( mgr._overviewActive ) return`) is deliberate — a guard would skip the cleanup entirely, orphaning the first session's top bar in the DOM behind the new one and leaving its labels behind. Settling the outgoing session also puts `os.overview.exited` ahead of the next `os.overview.entering`, which is the order a listener maintaining enter/exit counts expects. This fixes the pre-existing trunk cousin too.

`destroy()` keeps dropping the finalizer unrun — its `doAction()` would reach for globals that teardown is removing.

## Tests

Two new tests in `tests/vitest/desktops.test.ts`, both confirmed red on this branch with the source fix stashed:

- `re-entering overview mid-exit does not re-fullscreen a thumbnail` — fails at the fullscreen-class assertion without the fix
- `re-entering overview mid-exit settles the outgoing session first` — pins the `entering → exited → entering` hook order and that only one top bar is ever in the DOM

`npm run lint`, `npm run typecheck`, `npm run test:js` (325 files, 4021 tests), `npm run build` all green.

## Docs

`docs/javascript-reference.md` — `os.overview.exited` now states its ~280 ms timing, plus a note that the enter/exit pairing holds across a mid-exit re-entry.

## Not in scope

The reviewer's third note stands and is untouched here: a fullscreen window on an inactive desktop reached *without* Overview keeps `os-has-fullscreen-window` on the body, because `updateFullscreenBodyClass()` counts `display: none` windows. Separate path, separate fix — happy to open an issue or a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-541-3b120ae62be02cbf9e1297fb9969254df2555417.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->