### PR TITLE
Add the OpenStation desktop layout

### DIFF
--- a/assets/css/openstation-layout.css
+++ b/assets/css/openstation-layout.css
@@ -260,6 +260,14 @@ body.os-constellation-open .os-dock__tooltip {
 	min-width: 232px;
 	max-width: min( 340px, calc( 100vw - 24px ) );
 	/*
+	 * The vertical clamp. `--os-cn-max-h` is written by the JS on
+	 * every placement: the distance from this panel's bottom edge up
+	 * to the top of the viewport. The panel cannot be nudged
+	 * downwards to fit — that would push it over the dock — so it is
+	 * capped instead, and the group below takes the scroll.
+	 */
+	max-height: var( --os-cn-max-h, min( 78vh, 620px ) );
+	/*
 	 * The surface itself never scrolls. A long menu (WooCommerce's
 	 * fifteen children, a CPT with every taxonomy under it) puts the
 	 * scroll on its own group instead, which keeps the head and the
@@ -427,6 +435,10 @@ body.os-constellation-open .os-dock__tooltip {
 	align-items: center;
 	gap: 10px;
 	width: 100%;
+	/* The head and the new-window row are direct flex children of a
+	 * height-capped surface; without this they would be squashed
+	 * before the scrollable group in the middle gave way. */
+	flex: 0 0 auto;
 	padding: 8px 10px;
 	border: none;
 	border-radius: 9px;
@@ -593,7 +605,16 @@ body.os-constellation-open .os-dock__tooltip {
 	 * The scroll lives here rather than on the surface, so the head
 	 * and the new-window row stay pinned while a long submenu rolls
 	 * under them.
+	 *
+	 * `min-height: 0` is what lets the surface's `max-height` reach
+	 * this: a flex item's default `min-height: auto` refuses to
+	 * shrink below its content, so without it a tall submenu would
+	 * simply overflow the capped surface instead of scrolling inside
+	 * it. `flex: 0 1 auto` says this is the part that gives — the
+	 * head and the new-window row do not.
 	 */
+	flex: 0 1 auto;
+	min-height: 0;
 	max-height: min( 46vh, 360px );
 	overflow-y: auto;
 	overflow-x: hidden;

--- a/assets/css/openstation-layout.css
+++ b/assets/css/openstation-layout.css
@@ -189,6 +189,55 @@ body.os-constellation-open .os-dock__tooltip {
 	pointer-events: auto;
 }
 
+/*
+ * The exit, and it is NOT the entrance in reverse.
+ *
+ * Arriving is an event and gets a spring that overshoots. Leaving is
+ * the user having already moved on: it eases IN (accelerating away
+ * rather than settling), runs in under half the time, and — because
+ * `transform-origin` is `bottom center`, where the beam meets the
+ * tile — the shrink plus the few pixels of downward travel read as
+ * the panel dropping back into the rail it came out of.
+ *
+ * `pointer-events: none` from the first frame. A panel that is
+ * visibly leaving must not still be clickable, or a fast pointer
+ * lands a row the user has already dismissed.
+ */
+.os-constellation.os-constellation--closing {
+	transform: translate(
+			calc( -50% + var( --os-cn-shift, 0px ) ),
+			calc( -100% + 8px )
+		)
+		scale( 0.96 );
+	opacity: 0;
+	pointer-events: none;
+	transition:
+		transform 160ms var( --os-ui-ease-in, cubic-bezier( 0.4, 0, 1, 1 ) ),
+		opacity 140ms var( --os-ui-ease-in, cubic-bezier( 0.4, 0, 1, 1 ) );
+}
+
+/*
+ * The panel leaves as ONE object. Without this the rows revert to
+ * their pre-entrance state and each plays its own staggered exit
+ * inside a panel that is itself shrinking — two motions at two
+ * speeds, which reads as the menu coming apart rather than closing.
+ */
+.os-constellation--closing .os-constellation__row {
+	opacity: 1;
+	transform: none;
+	transition: none;
+}
+
+/*
+ * The beam goes first, and faster. It is the thread to the tile, so
+ * cutting it a beat before the panel lands sells the panel as
+ * falling rather than fading.
+ */
+.os-constellation--closing .os-constellation__beam {
+	opacity: 0;
+	transition: opacity 90ms ease-in;
+}
+
 /* The panel body. */
 .os-constellation__surface {
 	position: relative;
@@ -628,8 +677,15 @@ body.os-constellation-open .os-dock__tooltip {
 		transition-delay: 0s;
 	}
 
+	/*
+	 * No travel, in either direction. The exit is also removed from
+	 * the document immediately under this preference (the JS reads
+	 * the same media query), so `--closing` is listed here only to
+	 * cover the frame between the class landing and the node going.
+	 */
 	.os-constellation,
-	.os-constellation--open {
+	.os-constellation--open,
+	.os-constellation--closing {
 		transform: translate(
 			calc( -50% + var( --os-cn-shift, 0px ) ),
 			-100%

--- a/assets/css/openstation-layout.css
+++ b/assets/css/openstation-layout.css
@@ -1,0 +1,672 @@
+/**
+ * OpenStation — the OpenStation desktop layout.
+ *
+ * Two surfaces, both scoped so they cost nothing in any other layout:
+ *
+ * 1. **The seam.** The rail is one bottom dock holding every menu,
+ *    core cluster first, plugins second, with a single divider on the
+ *    boundary. The layout dispatcher guarantees the ordering; this
+ *    file gives the divider something to say. It is Pulse at the
+ *    waist, falling away to nothing at both ends, with a diamond node
+ *    on the centre line — a seam in the rail rather than a rule
+ *    drawn on it.
+ *
+ * 2. **The constellation.** The flyout that fans a menu's submenu out
+ *    of its tile on hover. Body-attached (it has to escape the dock's
+ *    stacking context and its `overflow`), so its selectors are
+ *    rooted on `.os-constellation` rather than on the shell.
+ *
+ * Colour discipline, per the palette rule: every declaration here
+ * reads `var( --token, <literal> )`, and every literal is a plain
+ * value that stands on its own if `variables.css` never loads. The
+ * mesh appears in exactly two places — the hovered/focused row and
+ * the head's icon halo — because those are the moments the panel is
+ * answering the user. Everywhere else is Obsidian.
+ */
+
+/* ==================================================================
+ * 1. The seam — core ends, plugins begin
+ * ================================================================== */
+
+/*
+ * Extra breathing room around the boundary. The clusters need to read
+ * as two groups before the divider between them means anything; at
+ * the dock's default 6px gap they read as one row with a scratch in
+ * it.
+ */
+.os-shell[ data-os-layout="openstation" ]
+	.os-dock[ data-os-dock-placement="bottom" ]
+	.os-dock__separator--group {
+	position: relative;
+	width: 2px;
+	height: 34px;
+	margin: auto 14px;
+	margin-inline-start: 14px;
+	border-radius: 2px;
+	/*
+	 * A gradient, not a flat fill. The seam is brightest where the eye
+	 * lands (the tiles' own centre line) and gone by the time it
+	 * reaches the pill's padding, so it never terminates in a visible
+	 * stub against the glass.
+	 */
+	background: linear-gradient(
+		to bottom,
+		transparent 0%,
+		var( --os-cn-seam, rgba( 217, 46, 227, 0.7 ) ) 28%,
+		var( --os-cn-seam, rgba( 217, 46, 227, 0.7 ) ) 72%,
+		transparent 100%
+	);
+	box-shadow: 0 0 10px
+		color-mix(
+			in srgb,
+			var( --os-cn-seam, rgba( 217, 46, 227, 0.7 ) ) 45%,
+			transparent
+		);
+	flex-shrink: 0;
+}
+
+/*
+ * The node. A 5px diamond on the seam's waist — the one piece of the
+ * divider that survives at a glance, and the thing that stops the
+ * seam reading as a rendering artefact.
+ */
+.os-shell[ data-os-layout="openstation" ]
+	.os-dock[ data-os-dock-placement="bottom" ]
+	.os-dock__separator--group::after {
+	content: "";
+	position: absolute;
+	inset-inline-start: 50%;
+	top: 50%;
+	width: 5px;
+	height: 5px;
+	transform: translate( -50%, -50% ) rotate( 45deg );
+	background: var( --os-cn-seam-node, #f252fc );
+	box-shadow: 0 0 8px var( --os-cn-seam-node, #f252fc );
+	animation: os-cn-seam-breathe 4.5s var( --os-ui-ease-loop, ease-in-out )
+		infinite;
+}
+
+@keyframes os-cn-seam-breathe {
+	0%,
+	100% {
+		opacity: 0.55;
+		transform: translate( -50%, -50% ) rotate( 45deg ) scale( 1 );
+	}
+	50% {
+		opacity: 1;
+		transform: translate( -50%, -50% ) rotate( 45deg ) scale( 1.35 );
+	}
+}
+
+/*
+ * The rail's own signature. Everything the user can reach lives on
+ * this one pill in this layout, so it earns a little more presence
+ * than the shared chrome gives it: a faint accent bloom under the
+ * glass, and nothing else. A wash, not a border — the pill already
+ * has its hairline from `dock.css`, and a second outline here would
+ * fight it.
+ *
+ * `--os-ui-accent-dim` rather than `--os-ui-accent`: this is ambient,
+ * and ambient uses of the accent all route through the dimmed token
+ * so "tone the station down" stays one edit.
+ */
+.os-shell[ data-os-layout="openstation" ]
+	.os-dock[ data-os-dock-placement="bottom" ] {
+	box-shadow:
+		0 8px 32px rgba( 0, 0, 0, 0.45 ),
+		0 0 26px -6px
+			color-mix(
+				in srgb,
+				var( --os-ui-accent-dim, #d92ee3 ) 28%,
+				transparent
+			);
+}
+
+/*
+ * Tile lift. In this layout a tile is a menu you can open *into*, not
+ * just a page you can open — so hovering one lifts it clear of the
+ * rail rather than just tinting it, and the tile the flyout is
+ * currently anchored to stays lifted for as long as the panel is up.
+ */
+.os-shell[ data-os-layout="openstation" ]
+	.os-dock__item-primary:hover {
+	transform: translateY( -3px ) scale( 1.12 );
+}
+
+.os-shell[ data-os-layout="openstation" ]
+	.os-dock__item[ data-constellation-open ]
+	.os-dock__item-primary {
+	background-color: var(
+		--os-dock-item-bg-hover,
+		rgba( 242, 82, 252, 0.18 )
+	);
+	color: var( --os-dock-icon-color-hover, #fffbff );
+	transform: translateY( -3px ) scale( 1.12 );
+}
+
+/*
+ * The dock tooltip stands down while a flyout is open. The panel's
+ * head carries the same label, larger and attached to the thing it
+ * names; the tooltip on top of it is a second hover surface saying
+ * the same word twice.
+ */
+body.os-constellation-open .os-dock__tooltip {
+	opacity: 0;
+	pointer-events: none;
+}
+
+/* ==================================================================
+ * 2. The constellation
+ * ================================================================== */
+
+.os-constellation {
+	position: fixed;
+	z-index: 2147483000;
+	/*
+	 * `--os-cn-shift` is written by the clamp when the panel would
+	 * have overflowed a viewport edge; the beam compensates with
+	 * `--os-cn-beam-x` so it stays pointed at the tile. Both default
+	 * to 0, which is the un-clamped case.
+	 */
+	transform: translate(
+			calc( -50% + var( --os-cn-shift, 0px ) ),
+			-100%
+		)
+		scale( 0.94 );
+	transform-origin: bottom center;
+	opacity: 0;
+	pointer-events: none;
+	transition:
+		transform var( --os-ui-motion-slow, 340ms )
+			var( --os-ui-ease-spring, cubic-bezier( 0.32, 1.5, 0.55, 1 ) ),
+		opacity var( --os-ui-motion-fast, 140ms ) ease-out;
+}
+
+.os-constellation.os-constellation--open {
+	transform: translate( calc( -50% + var( --os-cn-shift, 0px ) ), -100% )
+		scale( 1 );
+	opacity: 1;
+	pointer-events: auto;
+}
+
+/* The panel body. */
+.os-constellation__surface {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	min-width: 232px;
+	max-width: min( 340px, calc( 100vw - 24px ) );
+	/*
+	 * The surface itself never scrolls. A long menu (WooCommerce's
+	 * fifteen children, a CPT with every taxonomy under it) puts the
+	 * scroll on its own group instead, which keeps the head and the
+	 * new-window row pinned AND keeps this element a stable
+	 * containing block for the spotlight + edge overlays — an
+	 * absolutely-positioned child of a scroll container scrolls with
+	 * the content, so the hairline would slide off the top.
+	 */
+	padding: 6px;
+	border-radius: var( --os-cn-radius, 14px );
+	background-color: var( --os-cn-surface, rgba( 26, 23, 33, 0.82 ) );
+	backdrop-filter: blur( 28px ) saturate( 170% );
+	-webkit-backdrop-filter: blur( 28px ) saturate( 170% );
+	box-shadow: var(
+		--os-cn-shadow,
+		0 24px 64px rgba( 0, 0, 0, 0.62 ),
+		0 2px 8px rgba( 0, 0, 0, 0.4 )
+	);
+	color: var( --os-cn-fg, #fffbff );
+}
+
+/*
+ * Cursor spotlight. The JS writes `--os-cn-x` / `--os-cn-y` on
+ * pointermove; this paints a soft bloom there so the panel lights up
+ * under the pointer instead of sitting inert. Additive (`screen`) so
+ * it brightens the surface without washing the text.
+ *
+ * `::before`, not `::after`, so it sits BELOW the rows in paint
+ * order — the rows are positioned, and a spotlight painted over the
+ * mesh of a hovered row would flatten exactly the moment it is
+ * meant to reward.
+ */
+.os-constellation__surface::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+	background: radial-gradient(
+		220px circle at var( --os-cn-x, 50% ) var( --os-cn-y, 0% ),
+		hsl( var( --os-cn-hue, 300 ) 90% 70% / 0.14 ) 0%,
+		transparent 70%
+	);
+	mix-blend-mode: screen;
+	pointer-events: none;
+}
+
+/*
+ * The iridescent hairline. Painted as a gradient on a padding-box
+ * mask rather than as a `border-color`, because a border cannot hold
+ * a gradient and `border-image` loses the corner radius — the same
+ * trick `holoEdge` uses inside the component kit.
+ */
+.os-constellation__surface::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+	padding: 1px;
+	background: var(
+		--os-ui-holo-edge-quiet,
+		linear-gradient(
+			124deg,
+			rgba( 154, 242, 255, 0.22 ) 0%,
+			rgba( 236, 155, 255, 0.28 ) 38%,
+			rgba( 242, 82, 252, 0.22 ) 62%,
+			rgba( 159, 152, 255, 0.2 ) 100%
+		)
+	);
+	-webkit-mask:
+		linear-gradient( #000 0 0 ) content-box,
+		linear-gradient( #000 0 0 );
+	mask:
+		linear-gradient( #000 0 0 ) content-box,
+		linear-gradient( #000 0 0 );
+	-webkit-mask-composite: xor;
+	mask-composite: exclude;
+	pointer-events: none;
+}
+
+/*
+ * The sheen. One diagonal band of light crossing the panel, once, as
+ * it opens.
+ *
+ * An element rather than a pseudo, and a child of the ROOT rather
+ * than of the surface: the surface has already spent `::before` on
+ * the spotlight and `::after` on the edge mask (the pseudo budget is
+ * exactly two), and hanging it off the root is what lets it sweep
+ * over the rows instead of under them.
+ */
+.os-constellation__sheen {
+	position: absolute;
+	inset: 0;
+	border-radius: var( --os-cn-radius, 14px );
+	overflow: hidden;
+	pointer-events: none;
+	opacity: 0;
+}
+
+.os-constellation--open .os-constellation__sheen {
+	animation: os-cn-sheen 900ms var( --os-ui-ease-out, ease-out ) 60ms 1;
+}
+
+.os-constellation__sheen::before {
+	content: "";
+	position: absolute;
+	inset: -40% -120%;
+	background: linear-gradient(
+		104deg,
+		transparent 42%,
+		rgba( 255, 253, 255, 0.42 ) 50%,
+		transparent 58%
+	);
+	transform: translateX( -60% );
+}
+
+@keyframes os-cn-sheen {
+	0% {
+		opacity: 0;
+	}
+	18% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+		transform: translateX( 120% );
+	}
+}
+
+/* ---- The beam ---------------------------------------------------- */
+
+/*
+ * The thread from the panel's underside down to the tile it belongs
+ * to. Its only real job is the clamped case: once the panel has been
+ * nudged sideways to stay on screen, the beam is the only thing left
+ * saying which tile it came out of.
+ */
+.os-constellation__beam {
+	position: absolute;
+	inset-inline-start: 50%;
+	top: 100%;
+	width: 2px;
+	height: 14px;
+	transform: translateX(
+		calc( -50% + var( --os-cn-beam-x, 0px ) )
+	);
+	background: linear-gradient(
+		to bottom,
+		var( --os-cn-beam, rgba( 217, 46, 227, 0.8 ) ) 0%,
+		transparent 100%
+	);
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity var( --os-ui-motion-fast, 140ms ) ease-out 80ms;
+}
+
+.os-constellation--open .os-constellation__beam {
+	opacity: 1;
+}
+
+/* ---- Rows -------------------------------------------------------- */
+
+.os-constellation__row {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	padding: 8px 10px;
+	border: none;
+	border-radius: 9px;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	font-size: 13px;
+	line-height: 1.3;
+	text-align: start;
+	cursor: pointer;
+	/*
+	 * Staggered entrance. `--os-cn-row` is the row's index, written by
+	 * the JS, so the list unfurls top-down instead of appearing all at
+	 * once. Capped at 8 legs of delay: a 30-item submenu that took
+	 * 30 × 26ms to finish would read as sluggish, not as choreography.
+	 */
+	opacity: 0;
+	transform: translateY( 6px );
+	transition:
+		background-color var( --os-ui-motion-fast, 140ms ) ease-out,
+		color var( --os-ui-motion-fast, 140ms ) ease-out,
+		opacity 220ms ease-out,
+		transform 220ms
+			var( --os-ui-ease-spring, cubic-bezier( 0.32, 1.5, 0.55, 1 ) );
+	transition-delay: 0s, 0s,
+		calc( min( var( --os-cn-row, 0 ), 8 ) * 26ms ),
+		calc( min( var( --os-cn-row, 0 ), 8 ) * 26ms );
+}
+
+.os-constellation--open .os-constellation__row {
+	opacity: 1;
+	transform: translateY( 0 );
+}
+
+.os-constellation__row:hover,
+.os-constellation__row:focus-visible {
+	outline: none;
+	/*
+	 * The identity moment. The row under the pointer is "selected",
+	 * which is exactly the state the brand reserves the mesh for — so
+	 * this is where the panel spends it, and the ink flips to Void
+	 * because every mesh in the brand is a LIGHT surface.
+	 */
+	background-image: var(
+		--os-cn-row-fill,
+		var( --os-ui-holo-fill, linear-gradient( 124deg, #afa2e8, #c3b8ef ) )
+	);
+	color: var( --os-cn-row-ink, var( --os-ui-holo-ink, #0c0b0f ) );
+}
+
+.os-constellation__row:focus-visible {
+	box-shadow: var(
+		--os-ui-focus-ring,
+		0 0 0 2px rgba( 12, 11, 15, 0.9 ),
+		0 0 0 4px #f252fc
+	);
+}
+
+.os-constellation__row:active {
+	transform: scale( 0.985 );
+}
+
+.os-constellation__row-label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.os-constellation__row-meta {
+	flex: 0 0 auto;
+	font-size: 11px;
+	opacity: 0.6;
+}
+
+/* ---- Head -------------------------------------------------------- */
+
+.os-constellation__head {
+	gap: 12px;
+	padding: 10px;
+	margin-bottom: 4px;
+}
+
+.os-constellation__head-icon {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	width: 34px;
+	height: 34px;
+	border-radius: 10px;
+	color: var( --os-ui-holo-ink, #0c0b0f );
+	/*
+	 * The head's icon is the panel's second identity moment — the
+	 * menu, stated. It wears the mesh permanently (unlike the rows,
+	 * which earn it under the pointer) because there is exactly one
+	 * head per panel and it is the thing the panel is about.
+	 */
+	background-image: var(
+		--os-cn-row-fill,
+		var( --os-ui-holo-fill, linear-gradient( 124deg, #afa2e8, #c3b8ef ) )
+	);
+	box-shadow: var(
+		--os-ui-holo-glow,
+		0 0 0 1px rgba( 217, 46, 227, 0.2 ),
+		0 2px 10px rgba( 217, 46, 227, 0.15 )
+	);
+}
+
+.os-constellation__head-icon .dashicons {
+	width: 20px;
+	height: 20px;
+	font-size: 20px;
+	line-height: 20px;
+}
+
+/*
+ * The head's own hover state deliberately does NOT take the row mesh
+ * — the icon beside it is already wearing it, and two meshes touching
+ * is where iridescence stops reading as emphasis. It gets a plain
+ * raised wash instead.
+ */
+.os-constellation__head:hover,
+.os-constellation__head:focus-visible {
+	background-image: none;
+	background-color: var(
+		--os-ui-surface-raised,
+		rgba( 255, 251, 255, 0.06 )
+	);
+	color: var( --os-cn-fg, #fffbff );
+}
+
+.os-constellation__head-text {
+	display: flex;
+	flex: 1 1 auto;
+	min-width: 0;
+	flex-direction: column;
+	gap: 1px;
+}
+
+.os-constellation__head-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.os-constellation__head-hint {
+	font-size: 11px;
+	color: var( --os-cn-fg-muted, rgba( 255, 251, 255, 0.62 ) );
+}
+
+.os-constellation__head-chevron {
+	flex: 0 0 auto;
+	width: 16px;
+	height: 16px;
+	font-size: 16px;
+	line-height: 16px;
+	opacity: 0;
+	transform: translateX( -4px );
+	transition:
+		opacity var( --os-ui-motion-fast, 140ms ) ease-out,
+		transform var( --os-ui-motion-fast, 140ms ) ease-out;
+}
+
+.os-constellation__head:hover .os-constellation__head-chevron,
+.os-constellation__head:focus-visible .os-constellation__head-chevron {
+	opacity: 0.8;
+	transform: translateX( 0 );
+}
+
+/* ---- Groups ------------------------------------------------------ */
+
+.os-constellation__group {
+	display: flex;
+	flex-direction: column;
+	padding-top: 4px;
+	border-top: 1px solid var( --os-cn-divider, rgba( 255, 251, 255, 0.1 ) );
+	/*
+	 * The scroll lives here rather than on the surface, so the head
+	 * and the new-window row stay pinned while a long submenu rolls
+	 * under them.
+	 */
+	max-height: min( 46vh, 360px );
+	overflow-y: auto;
+	overflow-x: hidden;
+	scrollbar-width: thin;
+}
+
+.os-constellation__legend {
+	padding: 4px 10px 3px;
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var( --os-cn-legend, rgba( 255, 251, 255, 0.4 ) );
+}
+
+/* ---- Submenu rows ------------------------------------------------ */
+
+/*
+ * The orbit dot. Each row's hue comes from its own title, so a long
+ * submenu reads as a spectrum rather than as fifteen identical grey
+ * bullets — and "Menus" is the same colour on every site, every
+ * session, because the hue is hashed from the string.
+ */
+.os-constellation__orbit {
+	position: relative;
+	flex: 0 0 auto;
+	width: 8px;
+	height: 8px;
+	margin-inline-start: 3px;
+	border-radius: 50%;
+	background: hsl( var( --os-cn-row-hue, 300 ) 80% 70% );
+	box-shadow: 0 0 0 3px hsl( var( --os-cn-row-hue, 300 ) 80% 70% / 0.16 );
+	transition: box-shadow var( --os-ui-motion-fast, 140ms ) ease-out;
+}
+
+.os-constellation__row--sub:hover .os-constellation__orbit,
+.os-constellation__row--sub:focus-visible .os-constellation__orbit {
+	/* On the mesh the halo would disappear; a Void ring reads instead. */
+	box-shadow: 0 0 0 3px rgba( 12, 11, 15, 0.25 );
+}
+
+/* ---- Live-window rows -------------------------------------------- */
+
+.os-constellation__pip {
+	flex: 0 0 auto;
+	width: 8px;
+	height: 8px;
+	margin-inline-start: 3px;
+	border-radius: 50%;
+	background: var( --os-ui-accent, #f252fc );
+	box-shadow: 0 0 8px var( --os-ui-accent-dim, #d92ee3 );
+}
+
+/* A minimized window's pip is hollow — same cue the dock's own
+ * indicator uses for "open, but put away". */
+.os-constellation__row--live[ data-state="minimized" ] .os-constellation__pip {
+	background: transparent;
+	border: 1px solid var( --os-ui-accent, #f252fc );
+	box-shadow: none;
+}
+
+/* ---- New-window row ---------------------------------------------- */
+
+.os-constellation__row--new {
+	margin-top: 2px;
+	border-top: 1px solid var( --os-cn-divider, rgba( 255, 251, 255, 0.1 ) );
+	border-radius: 0 0 9px 9px;
+	color: var( --os-cn-fg-muted, rgba( 255, 251, 255, 0.62 ) );
+}
+
+.os-constellation__plus {
+	flex: 0 0 auto;
+	width: 14px;
+	margin-inline-start: 0;
+	font-size: 15px;
+	line-height: 1;
+	text-align: center;
+	opacity: 0.5;
+}
+
+/* ==================================================================
+ * 3. Motion budget
+ * ================================================================== */
+
+/*
+ * Reduced motion stops the travel, never the surface. The panel still
+ * appears, the seam node still glows, the hovered row still wears the
+ * mesh — losing those would lose STATE, not animation. What goes is
+ * the flight: the spring, the stagger, the sheen sweep, the breathing.
+ */
+@media ( prefers-reduced-motion: reduce ) {
+	.os-constellation,
+	.os-constellation__row {
+		transition-duration: 1ms;
+		transition-delay: 0s;
+	}
+
+	.os-constellation,
+	.os-constellation--open {
+		transform: translate(
+			calc( -50% + var( --os-cn-shift, 0px ) ),
+			-100%
+		);
+	}
+
+	.os-constellation__row {
+		transform: none;
+	}
+
+	.os-constellation--open .os-constellation__sheen {
+		animation: none;
+	}
+
+	.os-shell[ data-os-layout="openstation" ]
+		.os-dock[ data-os-dock-placement="bottom" ]
+		.os-dock__separator--group::after {
+		animation: none;
+		opacity: 1;
+	}
+}

--- a/assets/css/openstation-layout.css
+++ b/assets/css/openstation-layout.css
@@ -238,6 +238,73 @@ body.os-constellation-open .os-dock__tooltip {
 	transition: opacity 90ms ease-in;
 }
 
+/* ---- Hand-off ---------------------------------------------------- */
+
+/*
+ * Moving from one menu to the next is not a close followed by an
+ * open. It is the same menu changing what it is about — which is how
+ * every menu bar since 1984 has behaved, and why a rail of them that
+ * blinks between tiles feels broken rather than fast.
+ *
+ * So both panels wear `--handoff` and share one transition: the new
+ * one is born at the old one's x, both walk to the new anchor on the
+ * same curve, and they cross-fade on the way. The menu never leaves
+ * the screen and the eye tracks one object along the rail instead of
+ * watching two separate events.
+ *
+ * `left` is in the transition list ONLY here. In every other state
+ * the panel is placed, not moved, and animating a placement would
+ * turn each re-position (a clamp, a re-anchor) into a visible glide.
+ */
+.os-constellation.os-constellation--handoff {
+	transition:
+		left var( --os-cn-handoff-ms, 200ms )
+			var( --os-ui-ease-out, cubic-bezier( 0.22, 0.9, 0.28, 1 ) ),
+		transform var( --os-cn-handoff-ms, 200ms )
+			var( --os-ui-ease-out, cubic-bezier( 0.22, 0.9, 0.28, 1 ) ),
+		opacity 130ms linear;
+}
+
+/*
+ * Incoming: a cross-fade, with no scale. A panel that springs up from
+ * 0.94 while sliding reads as a second, different menu arriving —
+ * exactly the impression the hand-off exists to avoid.
+ */
+.os-constellation.os-constellation--handoff:not( .os-constellation--open ) {
+	transform: translate( calc( -50% + var( --os-cn-shift, 0px ) ), -100% );
+}
+
+/*
+ * Outgoing: fade while travelling. Overrides `--closing`'s fall — it
+ * is not going back into the rail, it is going with its replacement.
+ */
+.os-constellation.os-constellation--closing.os-constellation--handoff {
+	transform: translate( calc( -50% + var( --os-cn-shift, 0px ) ), -100% );
+	opacity: 0;
+	pointer-events: none;
+}
+
+/*
+ * Rows stay solid on both sides. A staggered entrance inside a 200ms
+ * cross-fade is flicker, not choreography — and the beam stays lit
+ * because the thread to the rail is the one thing that should never
+ * break mid-travel.
+ */
+.os-constellation--handoff .os-constellation__row {
+	opacity: 1;
+	transform: none;
+	transition: none;
+}
+
+.os-constellation--handoff .os-constellation__sheen {
+	animation: none;
+}
+
+.os-constellation--handoff .os-constellation__beam {
+	opacity: 1;
+	transition: none;
+}
+
 /* The panel body. */
 .os-constellation__surface {
 	position: relative;
@@ -685,7 +752,8 @@ body.os-constellation-open .os-dock__tooltip {
 	 */
 	.os-constellation,
 	.os-constellation--open,
-	.os-constellation--closing {
+	.os-constellation--closing,
+	.os-constellation--handoff {
 		transform: translate(
 			calc( -50% + var( --os-cn-shift, 0px ) ),
 			-100%

--- a/assets/css/openstation-layout.css
+++ b/assets/css/openstation-layout.css
@@ -161,7 +161,7 @@ body.os-constellation-open .os-dock__tooltip {
 
 .os-constellation {
 	position: fixed;
-	z-index: 2147483000;
+	z-index: var( --os-cn-z, 2147483000 );
 	/*
 	 * `--os-cn-shift` is written by the clamp when the panel would
 	 * have overflowed a viewport edge; the beam compensates with
@@ -238,71 +238,18 @@ body.os-constellation-open .os-dock__tooltip {
 	transition: opacity 90ms ease-in;
 }
 
-/* ---- Hand-off ---------------------------------------------------- */
-
 /*
- * Moving from one menu to the next is not a close followed by an
- * open. It is the same menu changing what it is about — which is how
- * every menu bar since 1984 has behaved, and why a rail of them that
- * blinks between tiles feels broken rather than fast.
+ * A retiring panel never paints over a live one.
  *
- * So both panels wear `--handoff` and share one transition: the new
- * one is born at the old one's x, both walk to the new anchor on the
- * same curve, and they cross-fade on the way. The menu never leaves
- * the screen and the eye tracks one object along the rail instead of
- * watching two separate events.
- *
- * `left` is in the transition list ONLY here. In every other state
- * the panel is placed, not moved, and animating a placement would
- * turn each re-position (a clamp, a re-anchor) into a visible glide.
+ * Moving along the rail leaves two panels on screen at once — the one
+ * you left finishing its dismissal above its own tile, the one you
+ * arrived at rising above its. Adjacent dock tiles are ~46px apart
+ * and a panel is 230px+ wide, so they overlap heavily, and without an
+ * explicit order the outgoing one wins on source order and fades out
+ * ON TOP of the menu the user is actually looking at.
  */
-.os-constellation.os-constellation--handoff {
-	transition:
-		left var( --os-cn-handoff-ms, 200ms )
-			var( --os-ui-ease-out, cubic-bezier( 0.22, 0.9, 0.28, 1 ) ),
-		transform var( --os-cn-handoff-ms, 200ms )
-			var( --os-ui-ease-out, cubic-bezier( 0.22, 0.9, 0.28, 1 ) ),
-		opacity 130ms linear;
-}
-
-/*
- * Incoming: a cross-fade, with no scale. A panel that springs up from
- * 0.94 while sliding reads as a second, different menu arriving —
- * exactly the impression the hand-off exists to avoid.
- */
-.os-constellation.os-constellation--handoff:not( .os-constellation--open ) {
-	transform: translate( calc( -50% + var( --os-cn-shift, 0px ) ), -100% );
-}
-
-/*
- * Outgoing: fade while travelling. Overrides `--closing`'s fall — it
- * is not going back into the rail, it is going with its replacement.
- */
-.os-constellation.os-constellation--closing.os-constellation--handoff {
-	transform: translate( calc( -50% + var( --os-cn-shift, 0px ) ), -100% );
-	opacity: 0;
-	pointer-events: none;
-}
-
-/*
- * Rows stay solid on both sides. A staggered entrance inside a 200ms
- * cross-fade is flicker, not choreography — and the beam stays lit
- * because the thread to the rail is the one thing that should never
- * break mid-travel.
- */
-.os-constellation--handoff .os-constellation__row {
-	opacity: 1;
-	transform: none;
-	transition: none;
-}
-
-.os-constellation--handoff .os-constellation__sheen {
-	animation: none;
-}
-
-.os-constellation--handoff .os-constellation__beam {
-	opacity: 1;
-	transition: none;
+.os-constellation--closing {
+	z-index: calc( var( --os-cn-z, 2147483000 ) - 1 );
 }
 
 /* The panel body. */
@@ -752,8 +699,7 @@ body.os-constellation-open .os-dock__tooltip {
 	 */
 	.os-constellation,
 	.os-constellation--open,
-	.os-constellation--closing,
-	.os-constellation--handoff {
+	.os-constellation--closing {
 		transform: translate(
 			calc( -50% + var( --os-cn-shift, 0px ) ),
 			-100%

--- a/assets/css/openstation-layout.css
+++ b/assets/css/openstation-layout.css
@@ -519,25 +519,6 @@ body.os-constellation-open .os-dock__tooltip {
 	color: var( --os-cn-fg-muted, rgba( 255, 251, 255, 0.62 ) );
 }
 
-.os-constellation__head-chevron {
-	flex: 0 0 auto;
-	width: 16px;
-	height: 16px;
-	font-size: 16px;
-	line-height: 16px;
-	opacity: 0;
-	transform: translateX( -4px );
-	transition:
-		opacity var( --os-ui-motion-fast, 140ms ) ease-out,
-		transform var( --os-ui-motion-fast, 140ms ) ease-out;
-}
-
-.os-constellation__head:hover .os-constellation__head-chevron,
-.os-constellation__head:focus-visible .os-constellation__head-chevron {
-	opacity: 0.8;
-	transform: translateX( 0 );
-}
-
 /* ---- Groups ------------------------------------------------------ */
 
 .os-constellation__group {

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -671,6 +671,14 @@ body.os-active {
 	--os-ui-ease-spring: cubic-bezier(0.32, 1.5, 0.55, 1);
 	/* Decelerating. The default for anything arriving. */
 	--os-ui-ease-out: cubic-bezier(0.22, 0.9, 0.28, 1);
+	/*
+	 * Accelerating — the mirror of `out`, and the default for anything
+	 * LEAVING. A surface that eases out on the way in and eases in on
+	 * the way out is the difference between "dismissed" and "undone":
+	 * decelerating into nothing reads as the thing hesitating, which
+	 * is the wrong note when the user has already moved on.
+	 */
+	--os-ui-ease-in: cubic-bezier(0.4, 0, 1, 1);
 	/* Symmetric, for a loop that has to come back where it started. */
 	--os-ui-ease-loop: cubic-bezier(0.45, 0, 0.55, 1);
 

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -1111,6 +1111,13 @@ body.os-active {
 	/* Beam: the thread from the panel's underside down to the tile. */
 	--os-cn-beam: color-mix(in srgb, var(--os-ui-accent-dim) 80%, transparent);
 	--os-cn-radius: 14px;
+	/*
+	 * Above every window and above the dock. Two panels coexist while
+	 * the pointer moves along the rail — one dismissing, one arriving
+	 * — and the retiring one is painted one step below so it can
+	 * never fade out on top of the menu being read.
+	 */
+	--os-cn-z: 2147483000;
 
 	/*
 	 * ---- Shell surfaces ----------------------------------------

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -1067,6 +1067,44 @@ body.os-active {
 	--os-dock-floating-shadow: rgba(0, 0, 0, 0.55);
 
 	/*
+	 * ---- The OpenStation layout ---------------------------------
+	 *
+	 * Two surfaces that only exist while `data-os-layout` is
+	 * `openstation`: the core→plugin seam on the rail, and the
+	 * constellation — the flyout that fans a menu's submenu out of
+	 * its tile on hover.
+	 *
+	 * The seam is not a hairline. It is the layout's one structural
+	 * claim — "WordPress ends here, your plugins begin here" — and a
+	 * 1px 22%-white rule says that about as loudly as a comma. So it
+	 * gets Pulse at its waist, falling away to nothing at both ends,
+	 * with a diamond node on the centre line.
+	 *
+	 * The constellation's SURFACE is Obsidian, deliberately. The mesh
+	 * is spent on the row under the pointer and on the head's icon
+	 * halo — the two moments where the panel is answering the user —
+	 * and nowhere else. A flyout that was iridescent edge to edge
+	 * would have nothing left to say when you actually pointed at
+	 * something in it.
+	 */
+	--os-cn-seam: color-mix(in srgb, var(--os-ui-accent-dim) 70%, transparent);
+	--os-cn-seam-node: var(--os-ui-accent);
+	--os-cn-surface: rgba(26, 23, 33, 0.82);
+	--os-cn-border: rgba(255, 251, 255, 0.14);
+	--os-cn-shadow: 0 24px 64px rgba(0, 0, 0, 0.62),
+		0 2px 8px rgba(0, 0, 0, 0.4);
+	--os-cn-fg: #fffbff;
+	--os-cn-fg-muted: rgba(255, 251, 255, 0.62);
+	--os-cn-legend: rgba(255, 251, 255, 0.4);
+	--os-cn-divider: rgba(255, 251, 255, 0.1);
+	/* The row under the pointer — the panel's identity moment. */
+	--os-cn-row-fill: var(--os-ui-holo-fill);
+	--os-cn-row-ink: var(--os-ui-holo-ink);
+	/* Beam: the thread from the panel's underside down to the tile. */
+	--os-cn-beam: color-mix(in srgb, var(--os-ui-accent-dim) 80%, transparent);
+	--os-cn-radius: 14px;
+
+	/*
 	 * ---- Shell surfaces ----------------------------------------
 	 *
 	 * The panels, tab strips and washes that belong to the shell

--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -58,7 +58,7 @@ The full surface is documented in [`javascript-reference.md`](./javascript-refer
 |---|---|---|
 | `dock` | `Dock \| null` *(primary / bottom rail)* | Stable |
 | `sideDock` | `Dock \| null` *(left rail; classic only)* | Stable |
-| `desktopLayout` | `'classic' \| 'unified' \| 'spatial'` | Stable |
+| `desktopLayout` | `'classic' \| 'unified' \| 'spatial' \| 'openstation'` | Stable |
 | `Dock.setBadge` | `( id: string, count: number ) => void` | Stable |
 | `Dock.removeSystemItem` | `( id: string ) => void` | Stable |
 | `icons` | `IconsApi` *(see `icons.setBadge`)* | Stable |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,13 +98,16 @@ Key server-side entry points:
 
 ## Desktop layout modes
 
-OpenStation Preferences → Appearance lets the user pick one of three top-level layouts. The shell root reflects the choice in `data-os-layout`; the layout dispatcher (`src/desktop-layout.ts`) owns every dock instance and the synthesized desktop-icon list, tearing down and rebuilding when the user switches.
+OpenStation Preferences → Appearance lets the user pick one of four top-level layouts. The shell root reflects the choice in `data-os-layout`; the layout dispatcher (`src/desktop-layout.ts`) owns every dock instance and the synthesized desktop-icon list, tearing down and rebuilding when the user switches.
 
 | Mode | Default? | Bottom dock | Left side dock (`wp.os.sideDock`) | Wallpaper icons |
 |---|---|---|---|---|
 | **Classic** | ✅ | Plugin-contributed top-level menus (`isCore: false`) | Core admin menus (Dashboard, Posts, Media, Settings, …) | Plugin-registered icons only |
 | **Unified** | — | Every menu sharing one rail | — *(no side dock)* | Plugin-registered icons only |
 | **Spatial** | — | Plugin menus only | — *(no side dock)* | Plugin-registered icons + **synthesized core icons** (one per core menu, prefixed `dock-core:`) |
+| **OpenStation** | — | Every menu, **re-sorted core-first** with one divider on the boundary | — *(no side dock)* | Plugin-registered icons only |
+
+**OpenStation** is Unified plus two commitments. First, the dispatcher re-sorts the rail so every `isCore` tile precedes every plugin tile: `Dock.render()` drops its `.os-dock__separator--group` divider at the first non-core tile, so grouping the list is what makes that one divider land — reliably — on the "WordPress ends here, your plugins begin here" boundary. `partition()` preserves relative order inside each cluster, so drag-to-reorder still holds within a group. Second, it is the only layout that surfaces a menu's **submenu** at the rail: hovering a menu tile fans out the *constellation* (`src/dock-constellation/`), a flyout carrying the menu's own page, its live windows, one row per submenu entry, and a new-window row. `dock-peek` stands down for menu tiles while that layout is active (the shared predicate lives in `src/dock-constellation/active.ts`) so the two hover surfaces never stack; system tiles keep the peek everywhere. Styling for both surfaces is in `assets/css/openstation-layout.css` behind `--os-cn-*` tokens; the JS hooks are `os.constellation.panel` / `.opened` / `.closed`.
 
 A user-meta value (`desktopLayout` inside the OpenStation Preferences JSON blob, REST-synced via the existing `/wp-json/desktop-mode/v1/os-settings` endpoint) is the persistence layer. The dispatcher partitions the live dock-items list by the `isCore` flag the menu builder already stamps on every entry; no PHP API additions were needed for the layout modes.
 

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -946,7 +946,7 @@ still apply.
 | Field | Values |
 |---|---|
 | `dockSize` | `compact`, `default`, `large` |
-| `desktopLayout` | `classic`, `unified`, `spatial` |
+| `desktopLayout` | `classic`, `unified`, `spatial`, `openstation` |
 | `windowRadius` | `sharp`, `default`, `round` |
 | `adminBarMode` | `static`, `dynamic`, `hidden` — how the WordPress admin bar presents above the shell. `dynamic` parks it off the top edge behind a peek strip that reveals on hover or keyboard focus; `hidden` removes it, leaving the dock's **Exit OpenStation** tile as the route back to classic admin. A theme wanting an edge-to-edge desk recommends one of the two. |
 | `dockRailRenderer` | A registered dock rail renderer id. Core ships `default`; plugins register their own. |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -886,15 +886,16 @@ Mouse and keyboard, not touch. `ArrowUp` on a focused tile fans the panel open a
 Three hooks:
 
 - `os.constellation.panel` — **filter**, runs once per flyout right before it's appended. Receives the fully-built panel root and `{ item, instances, tile }`. Return a mutated node or a replacement. A replacement owns the `os-constellation` class (positioning + the transitions), `role="menu"`, and the `os-constellation__row` class on anything that should take part in arrow-key roving.
-- `os.constellation.opened` — **action**, `{ menuSlug, item, instances }`.
+- `os.constellation.opened` — **action**, `{ menuSlug, item, instances, handoff }`. `handoff` is `true` when this panel replaced one that was already up (the pointer moved along the rail) rather than arriving on an empty desk — the same flag the matching `closed` carries.
 - `os.constellation.closed` — **action**, `{ menuSlug, handoff }`. Fires when the panel is dismissed, **not** when its node leaves the DOM: the panel stays in the document under `.os-constellation--closing` (inert, `pointer-events: none`) until it has finished leaving. Query `.os-constellation:not( .os-constellation--closing )` if you need "is a flyout actually open". `handoff` is `true` when another tile is already taking over, so you can tell "the menu closed" from "the menu moved" without diffing against the next `opened`.
 
-**Leaving, three ways.** Which one runs is most of what makes the rail feel solid:
+**More than one panel can be on screen.** `wp.os` never exposes a "the flyout" singleton for exactly this reason: a dismissed panel keeps its own anchor and finishes its own exit while the next one is already rising over a different tile. Moving along the rail is **two** panels, each animating where it belongs — the one you left playing its dismissal, the one you arrived at playing its entrance — not one panel sliding across and swapping contents. Each panel is a menu bound to a specific tile; morphing one into another would claim they are the same object and would drag a beam across the rail pointing at a tile its panel has nothing to do with. The retiring panel is painted one z-index step below the live one so it can never fade out on top of the menu being read.
+
+**Two ways to leave:**
 
 | | When | What happens |
 |---|---|---|
-| **Exit** | Ordinary dismissal — pointer left, Escape, a row activated | Falls back into the rail: shrinks toward `bottom center` (where the beam meets the tile) on an ease-**in** curve, beam cutting first. Rows are pinned so the panel leaves as one object. |
-| **Hand-off** | The pointer moved to another menu tile | The panel does **not** close. The incoming panel is born at the outgoing one's x, both walk to the new anchor on the same curve, and they cross-fade — one menu travelling and changing contents, the way a menu bar behaves. Both wear `.os-constellation--handoff`; the class is dropped once the slide lands. |
+| **Exit** | Any dismissal — pointer left, Escape, a row activated, or another tile taking over | Falls back into the rail: shrinks toward `bottom center` (where the beam meets its own tile) on an ease-**in** curve, beam cutting first. Rows are pinned so the panel leaves as one object. |
 | **Cut** | The anchor rect was invalidated (scroll, resize, layout switch), or `prefers-reduced-motion: reduce` | The node is removed outright. A panel gliding away from a tile that has already moved points at nothing. |
 
 ```javascript
@@ -918,7 +919,7 @@ window.wp.hooks.addFilter(
 );
 ```
 
-**Theming.** The panel reads `--os-cn-*` (surface, border, shadow, text, legend, divider, row fill + ink, beam, radius) plus the seam tokens `--os-cn-seam` / `--os-cn-seam-node` for the rail's core→plugin divider. All are declared in `variables.css` and re-pointable by a desktop theme like any other token. The mesh is spent deliberately in exactly two places — the row under the pointer, and the head's icon — because those are the moments the panel is answering the user; the surface itself stays Obsidian.
+**Theming.** The panel reads `--os-cn-*` (surface, border, shadow, text, legend, divider, row fill + ink, beam, radius, stacking order) plus the seam tokens `--os-cn-seam` / `--os-cn-seam-node` for the rail's core→plugin divider. All are declared in `variables.css` and re-pointable by a desktop theme like any other token. The mesh is spent deliberately in exactly two places — the row under the pointer, and the head's icon — because those are the moments the panel is answering the user; the surface itself stays Obsidian.
 
 ```javascript
 // Open a second Posts list alongside the first.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -881,7 +881,11 @@ One panel, up to four sections, top to bottom:
 
 Rows route through the same window ids a dock click would address, so the flyout and the tile share one window between them rather than opening two. A submenu row pins `parentUrl` to the **menu's** landing page, not to the child — that is what keeps a way back to the parent screen in the window's tab strip.
 
-Mouse and keyboard, not touch. `ArrowUp` on a focused tile fans the panel open and lands focus on the first row; `ArrowUp`/`ArrowDown` rove, `Home`/`End` jump, `Enter` activates, `Escape` collapses and hands focus back to the tile, `Tab` collapses and moves on. System tiles (OpenStation Preferences, Recycle Bin, plugin-registered native windows) have no submenu and keep the ordinary hover-peek in every layout.
+Mouse and keyboard, not touch. `ArrowUp` on a focused tile fans the panel open and lands focus on the first row; `ArrowUp`/`ArrowDown` rove, `Home`/`End` jump, `Enter` activates, `Escape` collapses and hands focus back to the tile. System tiles (OpenStation Preferences, Recycle Bin, plugin-registered native windows) have no submenu and keep the ordinary hover-peek in every layout.
+
+**The flyout is one tab stop, not one per row** — the conventional ARIA menu pattern. Every `.os-constellation__row` is given `tabindex="-1"` (including rows a plugin appended through the filter below, which are normalised after it runs), arrow keys do the moving, and `Tab` collapses the panel and returns focus to the tile *without* preventing the default, so the browser then continues from the rail's own place in the document order. Without that a fifteen-child submenu would put fifteen stops between the dock and whatever follows it.
+
+**Vertical sizing.** The panel hangs off the top of the dock and is never nudged downward to fit — that would push it over the rail and under the pointer. Instead the JS writes `--os-cn-max-h` on every placement (the distance from the panel's bottom edge to the top of the viewport, floored at 160px) and the surface reads it as a `max-height`; a menu too tall for the space shrinks and its submenu group takes the scroll, leaving the head and the new-window row pinned. Horizontally it *is* nudged, with `--os-cn-beam-x` keeping the beam pointed at the tile.
 
 Three hooks:
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -887,7 +887,15 @@ Three hooks:
 
 - `os.constellation.panel` — **filter**, runs once per flyout right before it's appended. Receives the fully-built panel root and `{ item, instances, tile }`. Return a mutated node or a replacement. A replacement owns the `os-constellation` class (positioning + the transitions), `role="menu"`, and the `os-constellation__row` class on anything that should take part in arrow-key roving.
 - `os.constellation.opened` — **action**, `{ menuSlug, item, instances }`.
-- `os.constellation.closed` — **action**, `{ menuSlug }`. Fires when the panel is dismissed, **not** when its node leaves the DOM: the panel stays in the document under `.os-constellation--closing` (inert, `pointer-events: none`) until its exit has played. Query `.os-constellation:not( .os-constellation--closing )` if you need "is a flyout actually open". Two dismissals skip the exit and remove the node outright — a hand-off to another tile, and anything that invalidated the anchor rect (scroll, resize, layout switch) — as does `prefers-reduced-motion: reduce`.
+- `os.constellation.closed` — **action**, `{ menuSlug, handoff }`. Fires when the panel is dismissed, **not** when its node leaves the DOM: the panel stays in the document under `.os-constellation--closing` (inert, `pointer-events: none`) until it has finished leaving. Query `.os-constellation:not( .os-constellation--closing )` if you need "is a flyout actually open". `handoff` is `true` when another tile is already taking over, so you can tell "the menu closed" from "the menu moved" without diffing against the next `opened`.
+
+**Leaving, three ways.** Which one runs is most of what makes the rail feel solid:
+
+| | When | What happens |
+|---|---|---|
+| **Exit** | Ordinary dismissal — pointer left, Escape, a row activated | Falls back into the rail: shrinks toward `bottom center` (where the beam meets the tile) on an ease-**in** curve, beam cutting first. Rows are pinned so the panel leaves as one object. |
+| **Hand-off** | The pointer moved to another menu tile | The panel does **not** close. The incoming panel is born at the outgoing one's x, both walk to the new anchor on the same curve, and they cross-fade — one menu travelling and changing contents, the way a menu bar behaves. Both wear `.os-constellation--handoff`; the class is dropped once the slide lands. |
+| **Cut** | The anchor rect was invalidated (scroll, resize, layout switch), or `prefers-reduced-motion: reduce` | The node is removed outright. A panel gliding away from a tile that has already moved points at nothing. |
 
 ```javascript
 // Add a "recently edited" row to the Posts flyout.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -322,7 +322,7 @@ document.addEventListener( 'os-layout-changed', ( e ) => {
 
 ```typescript
 {
-    layout: 'classic' | 'unified' | 'spatial',
+    layout: 'classic' | 'unified' | 'spatial' | 'openstation',
     primary: Dock | null,   // bottom dock — always present
     side:    Dock | null,   // left side bar — non-null only in classic
 }
@@ -673,7 +673,7 @@ window.wp.os = {
     // Surfaces
     dock:              Dock | null,                            // primary (bottom)
     sideDock:          Dock | null,                            // left, classic only
-    desktopLayout:     'classic' | 'unified' | 'spatial',
+    desktopLayout:     'classic' | 'unified' | 'spatial' | 'openstation',
     icons:             IconsApi,
     saveSession:       () => void,
 
@@ -865,6 +865,52 @@ window.wp.hooks.addFilter(
     }
 );
 ```
+
+#### The constellation — OpenStation layout only
+
+The `openstation` desktop layout replaces the hover-peek **on menu tiles** with a richer surface: the **constellation**, a flyout that fans a menu's *submenu* out of its tile. Every other layout drops the submenu at the dock — the tile opens the landing page and the child pages are only reachable from inside the window, through its tab strip. The tab strip is unchanged; this is the shortcut in front of it.
+
+One panel, up to four sections, top to bottom:
+
+| Section | Class | What it does |
+|---|---|---|
+| Head | `.os-constellation__head` | The menu's own page + a page count. Click = a dock click. |
+| Open windows | `.os-constellation__row--live` | One row per live instance **on the active virtual desktop**. Click focuses (restoring a minimized window first). |
+| Go to | `.os-constellation__row--sub` | One row per submenu entry, each with a hue derived from its own title. |
+| New window | `.os-constellation__row--new` | Spawns a fresh instance, same as the peek's Ghost Card. |
+
+Rows route through the same window ids a dock click would address, so the flyout and the tile share one window between them rather than opening two. A submenu row pins `parentUrl` to the **menu's** landing page, not to the child — that is what keeps a way back to the parent screen in the window's tab strip.
+
+Mouse and keyboard, not touch. `ArrowUp` on a focused tile fans the panel open and lands focus on the first row; `ArrowUp`/`ArrowDown` rove, `Home`/`End` jump, `Enter` activates, `Escape` collapses and hands focus back to the tile, `Tab` collapses and moves on. System tiles (OpenStation Preferences, Recycle Bin, plugin-registered native windows) have no submenu and keep the ordinary hover-peek in every layout.
+
+Three hooks:
+
+- `os.constellation.panel` — **filter**, runs once per flyout right before it's appended. Receives the fully-built panel root and `{ item, instances, tile }`. Return a mutated node or a replacement. A replacement owns the `os-constellation` class (positioning + the open transition), `role="menu"`, and the `os-constellation__row` class on anything that should take part in arrow-key roving.
+- `os.constellation.opened` — **action**, `{ menuSlug, item, instances }`.
+- `os.constellation.closed` — **action**, `{ menuSlug }`.
+
+```javascript
+// Add a "recently edited" row to the Posts flyout.
+window.wp.hooks.addFilter(
+    'os.constellation.panel',
+    'my-plugin/recent',
+    ( panel, { item } ) => {
+        if ( item.id !== 'edit.php' ) {
+            return panel;
+        }
+        const row = document.createElement( 'button' );
+        row.type = 'button';
+        row.className = 'os-constellation__row';
+        row.setAttribute( 'role', 'menuitem' );
+        row.textContent = 'Recently edited';
+        row.addEventListener( 'click', () => openRecent() );
+        panel.querySelector( '.os-constellation__surface' ).append( row );
+        return panel;
+    }
+);
+```
+
+**Theming.** The panel reads `--os-cn-*` (surface, border, shadow, text, legend, divider, row fill + ink, beam, radius) plus the seam tokens `--os-cn-seam` / `--os-cn-seam-node` for the rail's core→plugin divider. All are declared in `variables.css` and re-pointable by a desktop theme like any other token. The mesh is spent deliberately in exactly two places — the row under the pointer, and the head's icon — because those are the moments the panel is answering the user; the surface itself stays Obsidian.
 
 ```javascript
 // Open a second Posts list alongside the first.
@@ -1307,7 +1353,14 @@ wp.os.sideDock?.setBadge( 'edit.php', 3 );
 ---
 
 ### `desktopLayout` — Stable
-Currently-active top-level layout. One of `'classic' | 'unified' | 'spatial'`. Mirrors the user's OpenStation Preferences → Appearance pick and the `data-os-layout` attribute on the shell root.
+Currently-active top-level layout. One of `'classic' | 'unified' | 'spatial' | 'openstation'`. Mirrors the user's OpenStation Preferences → Appearance pick and the `data-os-layout` attribute on the shell root.
+
+| Layout | Rails | Where core menus live |
+|---|---|---|
+| `classic` | side + bottom | left side bar (`sideDock`) |
+| `unified` | bottom | the one rail, interleaved with plugins |
+| `spatial` | bottom | wallpaper icons |
+| `openstation` | bottom | the one rail, **grouped first**, then a divider, then plugins |
 
 ```js
 if ( wp.os.desktopLayout === 'spatial' ) {
@@ -1316,6 +1369,8 @@ if ( wp.os.desktopLayout === 'spatial' ) {
 ```
 
 Listen for `os-layout-changed` to react to a switch.
+
+**`openstation` in particular** re-sorts the rail so every `isCore` tile precedes every plugin tile, which is what makes the single `.os-dock__separator--group` divider land on the core→plugin boundary. It is also the only layout that fans a menu's submenu out of its tile on hover — see [the constellation](#the-constellation--openstation-layout-only) below.
 
 ---
 
@@ -6321,7 +6376,7 @@ wp.os.desktopThemes.applyRecommendedOsSettings(
 | Field | Type | Values |
 |---|---|---|
 | `dockSize` | `string` | `compact` \| `default` \| `large` |
-| `desktopLayout` | `string` | `classic` \| `unified` \| `spatial` |
+| `desktopLayout` | `string` | `classic` \| `unified` \| `spatial` \| `openstation` |
 | `windowRadius` | `string` | `sharp` \| `default` \| `round` |
 | `adminBarMode` | `string` | `static` \| `dynamic` \| `hidden` |
 | `dockRailRenderer` | `string` | A registered dock rail renderer id. |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -885,9 +885,9 @@ Mouse and keyboard, not touch. `ArrowUp` on a focused tile fans the panel open a
 
 Three hooks:
 
-- `os.constellation.panel` — **filter**, runs once per flyout right before it's appended. Receives the fully-built panel root and `{ item, instances, tile }`. Return a mutated node or a replacement. A replacement owns the `os-constellation` class (positioning + the open transition), `role="menu"`, and the `os-constellation__row` class on anything that should take part in arrow-key roving.
+- `os.constellation.panel` — **filter**, runs once per flyout right before it's appended. Receives the fully-built panel root and `{ item, instances, tile }`. Return a mutated node or a replacement. A replacement owns the `os-constellation` class (positioning + the transitions), `role="menu"`, and the `os-constellation__row` class on anything that should take part in arrow-key roving.
 - `os.constellation.opened` — **action**, `{ menuSlug, item, instances }`.
-- `os.constellation.closed` — **action**, `{ menuSlug }`.
+- `os.constellation.closed` — **action**, `{ menuSlug }`. Fires when the panel is dismissed, **not** when its node leaves the DOM: the panel stays in the document under `.os-constellation--closing` (inert, `pointer-events: none`) until its exit has played. Query `.os-constellation:not( .os-constellation--closing )` if you need "is a flyout actually open". Two dismissals skip the exit and remove the node outright — a hand-off to another tile, and anything that invalidated the anchor rect (scroll, resize, layout switch) — as does `prefers-reduced-motion: reduce`.
 
 ```javascript
 // Add a "recently edited" row to the Posts flyout.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -876,7 +876,7 @@ One panel, up to four sections, top to bottom:
 |---|---|---|
 | Head | `.os-constellation__head` | The menu's own page + a page count. Click = a dock click. |
 | Open windows | `.os-constellation__row--live` | One row per live instance **on the active virtual desktop**. Click focuses (restoring a minimized window first). |
-| Go to | `.os-constellation__row--sub` | One row per submenu entry, each with a hue derived from its own title. |
+| Open | `.os-constellation__row--sub` | One row per submenu entry, each with a hue derived from its own title. |
 | New window | `.os-constellation__row--new` | Spawns a fresh instance, same as the peek's Ghost Card. |
 
 Rows route through the same window ids a dock click would address, so the flyout and the tile share one window between them rather than opening two. A submenu row pins `parentUrl` to the **menu's** landing page, not to the child — that is what keeps a way back to the parent screen in the window's tab strip.

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -194,6 +194,19 @@ function openstation_register_assets() {
 		array( 'os-dock' ),
 		$built_version( 'assets/css/dock-peek.css' )
 	);
+	// The OpenStation desktop layout — the core/plugin seam on the rail
+	// plus the constellation hover-submenu flyout. Both surfaces are
+	// scoped (`[data-os-layout="openstation"]` / `.os-constellation`),
+	// so the sheet is inert in every other layout and is loaded
+	// unconditionally rather than gated on the user's current pick:
+	// the layout is switchable live from OpenStation Preferences, and a
+	// conditional enqueue would leave the first switch unstyled.
+	wp_register_style(
+		'os-openstation-layout',
+		OPENSTATION_URL . 'assets/css/openstation-layout.css',
+		array( 'os-dock' ),
+		$built_version( 'assets/css/openstation-layout.css' )
+	);
 	// `filemtime`-stamped — the chromeless overrides iterate faster
 	// than the plugin-wide version bumps (per-page compat shims and
 	// page-title-action exceptions land in patches), and a stale

--- a/includes/os-settings.php
+++ b/includes/os-settings.php
@@ -41,7 +41,7 @@ const OPENSTATION_OS_SETTINGS_WINDOW_RADII = array( 'sharp', 'default', 'round' 
 const OPENSTATION_OS_SETTINGS_ADMIN_BAR_MODES = array( 'static', 'dynamic', 'hidden' );
 
 /** Valid desktop-layout IDs — mirrors the TS `DESKTOP_LAYOUTS` constant. */
-const OPENSTATION_OS_SETTINGS_DESKTOP_LAYOUTS = array( 'classic', 'unified', 'spatial' );
+const OPENSTATION_OS_SETTINGS_DESKTOP_LAYOUTS = array( 'classic', 'unified', 'spatial', 'openstation' );
 
 /**
  * Playable range for the window-reveal duration override, in ms.
@@ -326,8 +326,8 @@ function openstation_sanitize_os_settings( $raw ) {
 		? (string) $raw['adminBarMode']
 		: $defaults['adminBarMode'];
 
-	// Desktop layout — must be one of the three known values
-	// (`classic`, `unified`, `spatial`). Default `classic`.
+	// Desktop layout — must be one of the known values
+	// (`classic`, `unified`, `spatial`, `openstation`). Default `classic`.
 	$desktop_layout = isset( $raw['desktopLayout'] )
 		&& in_array( $raw['desktopLayout'], OPENSTATION_OS_SETTINGS_DESKTOP_LAYOUTS, true )
 		? (string) $raw['desktopLayout']

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -85,6 +85,7 @@ function openstation_enqueue_assets() {
 	wp_enqueue_style( 'os-settings' );
 	wp_enqueue_style( 'os-dock' );
 	wp_enqueue_style( 'os-dock-peek' );
+	wp_enqueue_style( 'os-openstation-layout' );
 	wp_enqueue_style( 'desktop-mode-ai-assistant' );
 	wp_enqueue_style( 'desktop-mode-bug-report' );
 	wp_enqueue_style( 'os-files' );
@@ -876,6 +877,7 @@ function openstation_defer_non_critical_styles( $html, $handle, $href, $media ) 
 		'openstation_deferred_styles',
 		array(
 			'os-dock-peek',
+			'os-openstation-layout',
 			'desktop-mode-ai-assistant',
 			'desktop-mode-bug-report',
 			'os-window-overview',

--- a/src/desktop-layout.ts
+++ b/src/desktop-layout.ts
@@ -12,6 +12,15 @@
  * - **Spatial** — a single bottom `Dock` instance with plugin menus
  *   only. Core menus are synthesized into desktop-icon entries and
  *   handed to `renderDesktopIcons` so they appear on the wallpaper.
+ * - **OpenStation** — a single bottom `Dock` instance holding every
+ *   menu, but *re-sorted* so the WordPress core cluster leads and the
+ *   plugin cluster follows. That sort is what makes the rail's single
+ *   core→plugin divider deterministic: `Dock.render()` drops its
+ *   `--group` separator at the first `isCore === false` tile, so any
+ *   interleaved order (a user drag, a plugin's `dockOrder` filter)
+ *   would otherwise scatter the boundary or lose it entirely. Desktop
+ *   icons behave exactly as they do in Classic/Unified — the wallpaper
+ *   stays available, it just isn't load-bearing.
  *
  * Two surfaces drive this module:
  *
@@ -373,6 +382,23 @@ export function createLayoutDispatcher(
 		return { core, plugin };
 	};
 
+	/**
+	 * The OpenStation rail: every menu on one bottom dock, core
+	 * cluster first, plugin cluster second.
+	 *
+	 * The re-sort is deliberate and is the whole reason the layout's
+	 * divider works. `Dock` inserts its `--group` separator at the
+	 * first tile whose `isCore` is `false`, so it only produces one
+	 * clean boundary when the list is already grouped. `partition()`
+	 * preserves each item's relative order inside its own cluster, so
+	 * a user's drag-to-reorder still holds — it just can't drag a
+	 * plugin into the middle of WordPress.
+	 */
+	const openStationRailItems = (): DockItem[] => {
+		const { core, plugin } = partition();
+		return [ ...core, ...plugin ];
+	};
+
 	const repaintIcons = (): void => {
 		const settings = readSettings();
 		if ( layout !== 'spatial' ) {
@@ -603,6 +629,16 @@ export function createLayoutDispatcher(
 				buildMountDeps( deps.bottomDockEl, effectiveDockItems(), 'bottom' ),
 			);
 			primaryDock = unwrapDefaultDock( primary );
+		} else if ( layout === 'openstation' ) {
+			removeSideDockEl();
+			primary = mountRail(
+				buildMountDeps(
+					deps.bottomDockEl,
+					openStationRailItems(),
+					'bottom',
+				),
+			);
+			primaryDock = unwrapDefaultDock( primary );
 		} else {
 			// Spatial — bottom dock holds plugins; core items are
 			// emitted as wallpaper icons by `repaintIcons()` below.
@@ -657,6 +693,8 @@ export function createLayoutDispatcher(
 				primary?.replaceItems( plugin );
 			} else if ( layout === 'unified' ) {
 				primary?.replaceItems( effectiveDockItems() );
+			} else if ( layout === 'openstation' ) {
+				primary?.replaceItems( [ ...core, ...plugin ] );
 			} else {
 				primary?.replaceItems( plugin );
 			}
@@ -716,6 +754,8 @@ export function createLayoutDispatcher(
 				primary?.replaceItems( plugin );
 			} else if ( layout === 'unified' ) {
 				primary?.replaceItems( effectiveDockItems() );
+			} else if ( layout === 'openstation' ) {
+				primary?.replaceItems( [ ...core, ...plugin ] );
 			} else {
 				primary?.replaceItems( plugin );
 			}

--- a/src/desktop-themes/recommended.ts
+++ b/src/desktop-themes/recommended.ts
@@ -37,7 +37,7 @@ import type { RecommendedOsSettings } from './types';
 /** Closed enums, keyed by the OS-settings field they belong to. */
 const ENUMS: Record< string, readonly string[] > = {
 	dockSize: [ 'compact', 'default', 'large' ],
-	desktopLayout: [ 'classic', 'unified', 'spatial' ],
+	desktopLayout: [ 'classic', 'unified', 'spatial', 'openstation' ],
 	windowRadius: [ 'sharp', 'default', 'round' ],
 	adminBarMode: [ 'static', 'dynamic', 'hidden' ],
 };

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -97,6 +97,7 @@ import { createWindowLinkRendererRegistrySync } from './window-links/server-sync
 import { startUnfocusEngine } from './effects/unfocus-engine';
 import { startWindowRevealEngine } from './reveals/engine';
 import { createDockRailRendererSync } from './dock-rail/server-sync';
+import { mountDockConstellation } from './dock-constellation';
 import {
 	type WindowThemeDef,
 } from './window-chrome/themes/registry';
@@ -439,7 +440,8 @@ export interface OpenStationPublicApi {
 	/**
 	 * Side (left) dock instance — only non-null when the active
 	 * layout is `classic`. Holds core admin menus while the bottom
-	 * dock holds plugin menus. `null` in `unified` and `spatial`.
+	 * dock holds plugin menus. `null` in `unified`, `spatial` and
+	 * `openstation`.
 	 */
 	sideDock: Dock | null;
 	/**
@@ -448,7 +450,7 @@ export interface OpenStationPublicApi {
 	 * `data-os-layout` on the shell root with this value so
 	 * plugins can also key off the attribute via CSS.
 	 */
-	desktopLayout: 'classic' | 'unified' | 'spatial';
+	desktopLayout: 'classic' | 'unified' | 'spatial' | 'openstation';
 	/**
 	 * Wallpaper-icon rail — the second badge surface alongside the
 	 * dock. Mirrors `Dock.setBadge` exactly:
@@ -2486,6 +2488,17 @@ function init(): void {
 			config.dockItems,
 			config.desktopIcons,
 		);
+		// Constellation — the hover-submenu flyout. Mounted once and
+		// left mounted: it is a single delegated listener that
+		// self-gates on `data-os-layout`, so a user flipping between
+		// layouts never needs it re-wired, and a user who never picks
+		// the OpenStation layout pays for one `pointerover` handler
+		// that early-returns on its first line.
+		mountDockConstellation( {
+			windowManager: manager,
+			adminUrl: config.adminUrl,
+			getMenuItems: () => layoutDispatcher?.getMenuItems() ?? [],
+		} );
 		// OpenStation Preferences tile — `'core'` affinity so it lands on
 		// the side dock in Classic (with core admin menus, where users
 		// expect a shell-owned affordance) and on the primary rail in

--- a/src/dock-constellation/active.ts
+++ b/src/dock-constellation/active.ts
@@ -1,0 +1,25 @@
+/**
+ * Is the hover-submenu layout currently painted?
+ *
+ * A deliberate leaf module with zero imports. Two very different
+ * consumers ask this question — the constellation itself, and
+ * `dock-peek`, which has to stand down for menu tiles while the
+ * constellation owns the hover gesture — and routing the answer
+ * through either of them would put an import edge between two
+ * modules that otherwise know nothing about each other.
+ *
+ * The shell root carries the active layout in `data-os-layout`
+ * (written by the layout dispatcher on every `setLayout`), so the
+ * DOM is the source of truth here rather than a cached copy that
+ * could drift out of sync with a live layout switch.
+ */
+
+/** The layout id whose dock fans submenus out on hover. */
+export const CONSTELLATION_LAYOUT = 'openstation';
+
+export function isConstellationLayoutActive(): boolean {
+	const shell = document.querySelector( '.os-shell' );
+	return (
+		shell?.getAttribute( 'data-os-layout' ) === CONSTELLATION_LAYOUT
+	);
+}

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -15,15 +15,18 @@
  * Hovering a menu tile fans a flyout out of the rail:
  *
  *   ┌──────────────────────────────┐
- *   │ ◈  Appearance          Open →│   ← head: the menu's own page
+ *   │ ◈  Appearance                │   ← head: the menu's own page
+ *   │    3 pages                   │
  *   ├──────────────────────────────┤
- *   │ ● Editing 2 windows          │   ← live instances, click to focus
+ *   │ OPEN WINDOWS                 │
+ *   │ ● Appearance          Open   │   ← live instances, click to focus
  *   ├──────────────────────────────┤
+ *   │ OPEN                         │
  *   │ ◦ Themes                     │   ← the submenu, one row per link
  *   │ ◦ Customize                  │
  *   │ ◦ Menus                      │
  *   ├──────────────────────────────┤
- *   │ ＋ New window                 │
+ *   │ ＋ New Appearance window      │
  *   └──────────────────────────────┘
  *          ╲ beam ╱
  *           [tile]
@@ -483,11 +486,11 @@ function buildHead(
 	text.appendChild( hint );
 	head.appendChild( text );
 
-	const chev = document.createElement( 'span' );
-	chev.className =
-		'os-constellation__head-chevron dashicons dashicons-arrow-right-alt2';
-	chev.setAttribute( 'aria-hidden', 'true' );
-	head.appendChild( chev );
+	// No trailing chevron. It read as "there is another level behind
+	// me" — the one thing the head does NOT do. It opens a window,
+	// same as clicking the tile; the row's own hover state is the
+	// affordance, and a directional glyph on top of it was a promise
+	// the panel could not keep.
 
 	head.addEventListener( 'click', () => {
 		dismiss();
@@ -571,7 +574,7 @@ function buildSubmenuGroup(
 	group.className = 'os-constellation__group';
 	group.setAttribute( 'role', 'group' );
 	group.setAttribute( 'aria-label', item.title );
-	group.appendChild( legend( __( 'Go to' ) ) );
+	group.appendChild( legend( __( 'Open' ) ) );
 
 	for ( const sub of item.submenu ) {
 		group.appendChild(

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -45,6 +45,13 @@
  * 3. **It routes through the same window ids the dock does** (see
  *    `routing.ts`), so the flyout and the tile address one window
  *    between them rather than two.
+ * 4. **A dismissed panel outlives its dismissal.** It is detached from
+ *    the module's state immediately but stays in the document,
+ *    marked `--closing`, until its exit has played. Two dismissals
+ *    skip the exit outright rather than play it: a hand-off to
+ *    another tile (two panels at two anchors reads as a glitch) and
+ *    anything that invalidated the anchor rect (a panel gliding away
+ *    from a tile that already moved points at nothing).
  *
  * Pointer AND keyboard. The tile is a `<button>` the rail already
  * focuses; ArrowUp (or Enter on a tile with children) fans the
@@ -78,6 +85,16 @@ const SHOW_DELAY_MS = 130;
  * tight timer turns that into a flicker.
  */
 const HIDE_DELAY_MS = 240;
+/**
+ * How long the exit plays before the node is removed. Must match the
+ * longest transition on `.os-constellation--closing` in
+ * `openstation-layout.css`.
+ *
+ * Deliberately less than half the entrance. A panel arriving is an
+ * event worth a spring; a panel leaving is the user having already
+ * moved on, and anything slower reads as the menu not letting go.
+ */
+const EXIT_MS = 160;
 /** Gap between the tile's top edge and the panel's bottom edge. */
 const BEAM_GAP_PX = 14;
 /** Keep-out margin from every viewport edge. */
@@ -89,6 +106,22 @@ const VIEWPORT_MARGIN_PX = 12;
  * and the flyout's head carries the same label.
  */
 const OPEN_BODY_CLASS = 'os-constellation-open';
+
+/**
+ * Whether the user has asked for less motion.
+ *
+ * Read at dismissal rather than cached: the exit is driven from JS
+ * (a timer decides when the node leaves the document), so unlike the
+ * CSS-side reductions it can't just be overridden by a media query.
+ * A user who flips the OS setting mid-session gets the new answer on
+ * the next dismissal.
+ */
+function prefersReducedMotion(): boolean {
+	return (
+		typeof window.matchMedia === 'function' &&
+		window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches
+	);
+}
 
 /** Wiring the constellation needs from the shell boot path. */
 export interface DockConstellationDeps extends ConstellationRouting {
@@ -164,19 +197,73 @@ export function mountDockConstellation(
 		return tile;
 	};
 
-	const close = ( restoreFocus = false ): void => {
+	/**
+	 * Panels that have been dismissed and are playing their exit, no
+	 * longer reachable through `panel`. Tracked so `teardown()` can
+	 * take them with it and so the body flag can stay set until the
+	 * last one is actually gone.
+	 */
+	const closing = new Set< HTMLElement >();
+
+	/**
+	 * The dock tooltip stays muted for as long as ANY panel is on
+	 * screen, including one mid-exit — otherwise the tooltip pops back
+	 * under a panel that is still visibly fading over it.
+	 */
+	const syncBodyFlag = (): void => {
+		document.body.classList.toggle(
+			OPEN_BODY_CLASS,
+			panel !== null || closing.size > 0,
+		);
+	};
+
+	/**
+	 * Dismiss the current flyout.
+	 *
+	 * @param restoreFocus Move focus back to the anchor tile. Set for
+	 *                     keyboard dismissals, where losing focus to
+	 *                     `<body>` would strand the user.
+	 * @param immediate    Skip the exit animation and remove the node
+	 *                     now. Used when animating would be actively
+	 *                     wrong rather than merely skippable: a
+	 *                     hand-off to another tile (two panels visible
+	 *                     at once, at different anchors), and any
+	 *                     event that invalidated the anchor rect
+	 *                     (scroll, resize, layout switch) — a panel
+	 *                     gliding away from a tile that has already
+	 *                     moved is worse than a cut.
+	 */
+	const close = ( restoreFocus = false, immediate = false ): void => {
 		cancelShow();
 		cancelHide();
 		if ( ! panel ) {
 			return;
 		}
 		const previousAnchor = anchor;
-		panel.remove();
+		const dying = panel;
+		// Detach from the module's state FIRST. Everything below —
+		// including a synchronous re-open from the hand-off path — has
+		// to see "no panel is current" even though a node is still in
+		// the document playing its exit.
 		panel = null;
 		anchor = null;
 		anchorSlug = '';
-		document.body.classList.remove( OPEN_BODY_CLASS );
 		previousAnchor?.removeAttribute( 'data-constellation-open' );
+
+		if ( immediate || prefersReducedMotion() ) {
+			dying.remove();
+		} else {
+			dying.classList.remove( 'os-constellation--open' );
+			dying.classList.add( 'os-constellation--closing' );
+			closing.add( dying );
+			window.setTimeout( () => {
+				dying.remove();
+				closing.delete( dying );
+				syncBodyFlag();
+			}, EXIT_MS );
+		}
+		syncBodyFlag();
+
 		if ( restoreFocus && previousAnchor ) {
 			previousAnchor
 				.querySelector< HTMLElement >( '.os-dock__item-primary' )
@@ -195,7 +282,10 @@ export function mountDockConstellation(
 			}
 			return;
 		}
-		close();
+		// Hand-off to a different tile: cut, don't fade. Two panels
+		// on screen at two different anchors reads as a glitch, not
+		// as choreography.
+		close( false, true );
 		const item = deps.getMenuItems().find( ( i ) => i.id === slug );
 		if ( ! item ) {
 			return;
@@ -208,7 +298,7 @@ export function mountDockConstellation(
 		anchor = tile;
 		anchorSlug = slug;
 		document.body.appendChild( panel );
-		document.body.classList.add( OPEN_BODY_CLASS );
+		syncBodyFlag();
 		tile.setAttribute( 'data-constellation-open', '' );
 		inheritShellVars( panel );
 		position( panel, tile );
@@ -318,8 +408,12 @@ export function mountDockConstellation(
 		}
 	};
 
-	/** Any layout / viewport change invalidates the anchor rect. */
-	const onInvalidate = (): void => close();
+	/**
+	 * Any layout / viewport change invalidates the anchor rect, so the
+	 * panel is cut rather than animated out — an exit that glides away
+	 * from a tile which has already moved points at nothing.
+	 */
+	const onInvalidate = (): void => close( false, true );
 
 	document.addEventListener( 'pointerover', onPointerOver );
 	document.addEventListener( 'pointerout', onPointerOut );
@@ -333,7 +427,15 @@ export function mountDockConstellation(
 	document.addEventListener( 'scroll', onInvalidate, true );
 
 	return (): void => {
-		close();
+		close( false, true );
+		// Take any in-flight exits with us. Their removal timers would
+		// otherwise fire against a module nobody is listening to any
+		// more, leaving an inert panel painted over the shell.
+		for ( const ghost of closing ) {
+			ghost.remove();
+		}
+		closing.clear();
+		syncBodyFlag();
 		document.removeEventListener( 'pointerover', onPointerOver );
 		document.removeEventListener( 'pointerout', onPointerOut );
 		document.removeEventListener( 'keydown', onKeyDown );

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -47,11 +47,17 @@
  *    between them rather than two.
  * 4. **A dismissed panel outlives its dismissal.** It is detached from
  *    the module's state immediately but stays in the document,
- *    marked `--closing`, until its exit has played. Two dismissals
- *    skip the exit outright rather than play it: a hand-off to
- *    another tile (two panels at two anchors reads as a glitch) and
- *    anything that invalidated the anchor rect (a panel gliding away
- *    from a tile that already moved points at nothing).
+ *    marked `--closing`, until it has finished leaving. There are
+ *    three ways to leave, and picking the right one is most of what
+ *    makes the rail feel solid:
+ *      - *exit* — the ordinary dismissal. Falls back into the rail.
+ *      - *hand-off* — another tile is taking over. The panel does NOT
+ *        close: it slides to the new anchor alongside its
+ *        replacement and cross-fades, so the menu never leaves the
+ *        screen. Anything else reads as a blink.
+ *      - *cut* — the anchor rect was invalidated (scroll, resize,
+ *        layout switch). A panel gliding away from a tile that has
+ *        already moved points at nothing, so the node just goes.
  *
  * Pointer AND keyboard. The tile is a `<button>` the rail already
  * focuses; ArrowUp (or Enter on a tile with children) fans the
@@ -95,6 +101,17 @@ const HIDE_DELAY_MS = 240;
  * moved on, and anything slower reads as the menu not letting go.
  */
 const EXIT_MS = 160;
+/**
+ * How long the slide between two tiles runs. Must match the
+ * `.os-constellation--handoff` transition in
+ * `openstation-layout.css`.
+ *
+ * Longer than the exit and shorter than the entrance: the panel is
+ * neither arriving nor leaving, it is travelling, and the distance
+ * between two adjacent dock tiles is short enough that anything
+ * slower turns a flick along the rail into a queue.
+ */
+const HANDOFF_MS = 200;
 /** Gap between the tile's top edge and the panel's bottom edge. */
 const BEAM_GAP_PX = 14;
 /** Keep-out margin from every viewport edge. */
@@ -218,49 +235,59 @@ export function mountDockConstellation(
 	};
 
 	/**
-	 * Dismiss the current flyout.
+	 * How a retiring panel should leave.
 	 *
-	 * @param restoreFocus Move focus back to the anchor tile. Set for
-	 *                     keyboard dismissals, where losing focus to
-	 *                     `<body>` would strand the user.
-	 * @param immediate    Skip the exit animation and remove the node
-	 *                     now. Used when animating would be actively
-	 *                     wrong rather than merely skippable: a
-	 *                     hand-off to another tile (two panels visible
-	 *                     at once, at different anchors), and any
-	 *                     event that invalidated the anchor rect
-	 *                     (scroll, resize, layout switch) — a panel
-	 *                     gliding away from a tile that has already
-	 *                     moved is worse than a cut.
+	 * - `exit` — the ordinary dismissal: fall back into the rail.
+	 * - `handoff` — another tile is taking over. The panel slides to
+	 *   the new anchor alongside its replacement and cross-fades, so
+	 *   the menu never leaves the screen.
+	 * - `cut` — remove the node now. For dismissals where animating
+	 *   would be actively wrong rather than merely skippable: the
+	 *   anchor rect has been invalidated (scroll, resize, layout
+	 *   switch) and a panel gliding away from a tile that already
+	 *   moved points at nothing.
 	 */
-	const close = ( restoreFocus = false, immediate = false ): void => {
-		cancelShow();
-		cancelHide();
+	type RetireMode = 'exit' | 'handoff' | 'cut';
+
+	/**
+	 * Detach a panel from the module's state and start it leaving.
+	 *
+	 * The state detach is unconditional and happens first: everything
+	 * downstream — including the synchronous re-open in the hand-off
+	 * path — has to see "no panel is current" even while a node is
+	 * still in the document playing its exit.
+	 */
+	const retire = ( mode: RetireMode, restoreFocus = false ): void => {
 		if ( ! panel ) {
 			return;
 		}
 		const previousAnchor = anchor;
 		const dying = panel;
-		// Detach from the module's state FIRST. Everything below —
-		// including a synchronous re-open from the hand-off path — has
-		// to see "no panel is current" even though a node is still in
-		// the document playing its exit.
 		panel = null;
 		anchor = null;
 		anchorSlug = '';
 		previousAnchor?.removeAttribute( 'data-constellation-open' );
 
-		if ( immediate || prefersReducedMotion() ) {
+		if ( mode === 'cut' || prefersReducedMotion() ) {
 			dying.remove();
 		} else {
 			dying.classList.remove( 'os-constellation--open' );
+			// `--closing` marks every retiring panel (it is what
+			// `:not( --closing )` queries key off, ours and plugins');
+			// `--handoff` then overrides the fall with the slide.
 			dying.classList.add( 'os-constellation--closing' );
+			if ( mode === 'handoff' ) {
+				dying.classList.add( 'os-constellation--handoff' );
+			}
 			closing.add( dying );
-			window.setTimeout( () => {
-				dying.remove();
-				closing.delete( dying );
-				syncBodyFlag();
-			}, EXIT_MS );
+			window.setTimeout(
+				() => {
+					dying.remove();
+					closing.delete( dying );
+					syncBodyFlag();
+				},
+				mode === 'handoff' ? HANDOFF_MS : EXIT_MS,
+			);
 		}
 		syncBodyFlag();
 
@@ -271,10 +298,25 @@ export function mountDockConstellation(
 		}
 		doAction( HOOKS.CONSTELLATION_CLOSED, {
 			menuSlug: previousAnchor?.dataset.menuSlug ?? '',
+			// `true` when another tile is already taking over, so a
+			// subscriber can tell "the menu closed" from "the menu
+			// moved" without diffing against the next opened event.
+			handoff: mode === 'handoff',
 		} );
 	};
 
+	const close = ( restoreFocus = false, immediate = false ): void => {
+		cancelShow();
+		cancelHide();
+		retire( immediate ? 'cut' : 'exit', restoreFocus );
+	};
+
 	const open = ( tile: HTMLElement, focusFirst = false ): void => {
+		// A pending dismissal must not fire onto the panel we are about
+		// to put up. `onPointerOver` already cancels, but the keyboard
+		// path reaches here directly.
+		cancelShow();
+		cancelHide();
 		const slug = tile.dataset.menuSlug as string;
 		if ( panel && anchorSlug === slug ) {
 			if ( focusFirst ) {
@@ -282,34 +324,68 @@ export function mountDockConstellation(
 			}
 			return;
 		}
-		// Hand-off to a different tile: cut, don't fade. Two panels
-		// on screen at two different anchors reads as a glitch, not
-		// as choreography.
-		close( false, true );
 		const item = deps.getMenuItems().find( ( i ) => i.id === slug );
 		if ( ! item ) {
+			// Nothing to hand off TO — this is a plain dismissal.
+			close();
 			return;
 		}
+
+		/*
+		 * Hand-off. Moving from one menu to the next is not a close
+		 * followed by an open — it is the same menu changing what it
+		 * is about, which is how every menu bar since 1984 has
+		 * behaved. So the outgoing panel does not fall away and the
+		 * incoming one does not spring up: the new panel is born at
+		 * the OLD panel's x, both slide to the new anchor together on
+		 * the same curve, and they cross-fade on the way. The menu
+		 * never leaves the screen, and the eye tracks one object
+		 * across the rail instead of watching two events.
+		 */
+		const handingOff = panel !== null && ! prefersReducedMotion();
+		const fromX = handingOff ? readLeft( panel as HTMLElement ) : null;
+		const outgoing = panel;
+
+		retire( handingOff ? 'handoff' : 'cut' );
+
 		const instances =
 			deps.windowManager.getAllByBaseIdOnActiveDesktop(
 				resolveBaseId( deps, item ),
 			);
 		panel = buildPanel( deps, item, instances, tile, close );
+		if ( handingOff ) {
+			panel.classList.add( 'os-constellation--handoff' );
+		}
 		anchor = tile;
 		anchorSlug = slug;
 		document.body.appendChild( panel );
 		syncBodyFlag();
 		tile.setAttribute( 'data-constellation-open', '' );
 		inheritShellVars( panel );
-		position( panel, tile );
+		const targetX = position( panel, tile, fromX );
+		// Walk the outgoing panel to the same destination so the pair
+		// travels as one. Its own transition (declared on `--handoff`)
+		// carries it; nothing else about it changes.
+		if ( outgoing && handingOff && targetX !== null ) {
+			outgoing.style.left = `${ targetX }px`;
+		}
 		// One frame late so the CSS start state is a real painted frame
-		// and the spring transition has something to animate FROM.
+		// and the transition has something to animate FROM.
 		requestAnimationFrame( () => {
 			panel?.classList.add( 'os-constellation--open' );
 			if ( focusFirst && panel ) {
 				focusRow( panel, 0 );
 			}
 		} );
+		if ( handingOff ) {
+			// Drop back to the ordinary transitions once the slide is
+			// done, so the NEXT dismissal gets the fall-into-the-rail
+			// exit rather than a slide to nowhere.
+			const settling = panel;
+			window.setTimeout( () => {
+				settling.classList.remove( 'os-constellation--handoff' );
+			}, HANDOFF_MS );
+		}
 		doAction( HOOKS.CONSTELLATION_OPENED, {
 			menuSlug: slug,
 			item,
@@ -837,11 +913,27 @@ function inheritShellVars( panel: HTMLElement ): void {
  * nudged sideways back to the tile it belongs to, so it has to track
  * the anchor independently of the surface.
  */
-function position( panel: HTMLElement, tile: HTMLElement ): void {
+function position(
+	panel: HTMLElement,
+	tile: HTMLElement,
+	fromX: number | null = null,
+): number {
 	const rect = tile.getBoundingClientRect();
 	const centre = rect.left + rect.width / 2;
-	panel.style.left = `${ centre }px`;
 	panel.style.top = `${ rect.top - BEAM_GAP_PX }px`;
+
+	if ( fromX === null ) {
+		panel.style.left = `${ centre }px`;
+	} else {
+		// Hand-off: born where the outgoing panel is standing, then
+		// walked to the new anchor a frame later so the assignment is
+		// a transition rather than an initial value (an element's
+		// first computed value never animates).
+		panel.style.left = `${ fromX }px`;
+		requestAnimationFrame( () => {
+			panel.style.left = `${ centre }px`;
+		} );
+	}
 
 	requestAnimationFrame( () => {
 		const panelRect = panel.getBoundingClientRect();
@@ -857,4 +949,17 @@ function position( panel: HTMLElement, tile: HTMLElement ): void {
 			panel.style.setProperty( '--os-cn-beam-x', `${ -dx }px` );
 		}
 	} );
+
+	return centre;
+}
+
+/**
+ * The panel's current `left`, in px. Read off the inline style rather
+ * than `getBoundingClientRect()` because that box has already been
+ * moved by the `translate( -50%, … )`, and the hand-off needs the
+ * anchor point the transition interpolates, not the painted edge.
+ */
+function readLeft( panel: HTMLElement ): number | null {
+	const raw = parseFloat( panel.style.left );
+	return Number.isFinite( raw ) ? raw : null;
 }

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -1,0 +1,755 @@
+/**
+ * OpenStation — the Constellation.
+ *
+ * The hover-submenu surface that gives the `openstation` desktop
+ * layout its reason to exist.
+ *
+ * Every other layout throws a menu's submenu away at the dock: the
+ * tile opens the landing page and the child pages are only reachable
+ * once you are already inside the window, through its tab strip. That
+ * is a real navigational cost — "Appearance → Menus" is two screens
+ * away from a rail that already knows the link exists. The tab strip
+ * stays exactly as it is; this adds the missing shortcut in front of
+ * it.
+ *
+ * Hovering a menu tile fans a flyout out of the rail:
+ *
+ *   ┌──────────────────────────────┐
+ *   │ ◈  Appearance          Open →│   ← head: the menu's own page
+ *   ├──────────────────────────────┤
+ *   │ ● Editing 2 windows          │   ← live instances, click to focus
+ *   ├──────────────────────────────┤
+ *   │ ◦ Themes                     │   ← the submenu, one row per link
+ *   │ ◦ Customize                  │
+ *   │ ◦ Menus                      │
+ *   ├──────────────────────────────┤
+ *   │ ＋ New window                 │
+ *   └──────────────────────────────┘
+ *          ╲ beam ╱
+ *           [tile]
+ *
+ * Three things are worth knowing about the implementation:
+ *
+ * 1. **It is delegated, not per-tile.** One `pointerover` listener on
+ *    `document` serves every tile on the rail, so a live menu refresh
+ *    (plugin activated, tiles rebuilt) can't leave a stale listener
+ *    behind on a detached node — the failure mode that made the
+ *    hover-peek leak popovers before it grew a teardown map.
+ * 2. **It owns the hover gesture in this layout.** `dock-peek` stands
+ *    down for menu tiles here (see `active.ts`), and the dock tooltip
+ *    is suppressed by CSS while the flyout is open, because the head
+ *    already says the tile's name — louder, and in the right place.
+ * 3. **It routes through the same window ids the dock does** (see
+ *    `routing.ts`), so the flyout and the tile address one window
+ *    between them rather than two.
+ *
+ * Pointer AND keyboard. The tile is a `<button>` the rail already
+ * focuses; ArrowUp (or Enter on a tile with children) fans the
+ * constellation open and moves focus into it, arrows rove, Escape
+ * collapses and hands focus back. Touch is deliberately excluded —
+ * hover has no touch equivalent, and a tap that opened a menu instead
+ * of the page would break the one gesture every other layout shares.
+ */
+
+import { __, _n, sprintf } from '../i18n';
+import { applyFilters, doAction, HOOKS } from '../hooks';
+import type { DockItem, SubmenuItem } from '../dock';
+import type { Window as OsWindow } from '../window';
+import { hashTitleToHue } from '../ui/util/hash-hue';
+import { deriveWindowId, sanitizeClassName } from '../utils';
+import { isConstellationLayoutActive } from './active';
+import {
+	openMenuItem,
+	openNewMenuItem,
+	openSubmenuItem,
+	type ConstellationRouting,
+} from './routing';
+
+export { isConstellationLayoutActive, CONSTELLATION_LAYOUT } from './active';
+
+/** Dwell before the flyout fans out. Short enough to feel instant. */
+const SHOW_DELAY_MS = 130;
+/**
+ * Grace period after the pointer leaves both surfaces. Generous,
+ * because the trip from tile to panel crosses the beam gap and a
+ * tight timer turns that into a flicker.
+ */
+const HIDE_DELAY_MS = 240;
+/** Gap between the tile's top edge and the panel's bottom edge. */
+const BEAM_GAP_PX = 14;
+/** Keep-out margin from every viewport edge. */
+const VIEWPORT_MARGIN_PX = 12;
+
+/**
+ * Body class set while a flyout is open. CSS uses it to mute the dock
+ * tooltip — two hover surfaces stacked on one tile is one too many,
+ * and the flyout's head carries the same label.
+ */
+const OPEN_BODY_CLASS = 'os-constellation-open';
+
+/** Wiring the constellation needs from the shell boot path. */
+export interface DockConstellationDeps extends ConstellationRouting {
+	/**
+	 * The complete admin-menu list, read fresh on every hover. The
+	 * layout dispatcher's `getMenuItems()` is the intended source —
+	 * reading it late means a plugin activated seconds ago is already
+	 * in the flyout without the constellation subscribing to anything.
+	 */
+	getMenuItems: () => DockItem[];
+}
+
+/**
+ * Context handed to the {@link HOOKS.CONSTELLATION_PANEL} filter.
+ *
+ * @public
+ */
+export interface ConstellationPanelContext {
+	/** The menu the flyout was opened for. */
+	item: DockItem;
+	/** Live windows currently open for this menu. */
+	instances: OsWindow[];
+	/** The dock tile the flyout is anchored to. */
+	tile: HTMLElement;
+}
+
+/**
+ * Mount the constellation. Returns a teardown that detaches every
+ * listener and removes any open flyout.
+ */
+export function mountDockConstellation(
+	deps: DockConstellationDeps,
+): () => void {
+	let panel: HTMLElement | null = null;
+	let anchor: HTMLElement | null = null;
+	let anchorSlug = '';
+	let showTimer: number | null = null;
+	let hideTimer: number | null = null;
+
+	const cancelShow = (): void => {
+		if ( showTimer !== null ) {
+			window.clearTimeout( showTimer );
+			showTimer = null;
+		}
+	};
+	const cancelHide = (): void => {
+		if ( hideTimer !== null ) {
+			window.clearTimeout( hideTimer );
+			hideTimer = null;
+		}
+	};
+
+	/**
+	 * Resolve the menu tile an event landed on, or null when the event
+	 * has nothing to do with us. Guards on the layout, on the tile
+	 * being menu-derived (system tiles keep the hover-peek), and on the
+	 * tile living on a rail rather than in some plugin's own markup.
+	 */
+	const tileFrom = ( target: EventTarget | null ): HTMLElement | null => {
+		if ( ! isConstellationLayoutActive() ) {
+			return null;
+		}
+		if ( ! ( target instanceof Element ) ) {
+			return null;
+		}
+		const tile = target.closest< HTMLElement >( '.os-dock__item' );
+		if ( ! tile || ! tile.dataset.menuSlug ) {
+			return null;
+		}
+		if ( ! tile.closest( '.os-dock' ) ) {
+			return null;
+		}
+		return tile;
+	};
+
+	const close = ( restoreFocus = false ): void => {
+		cancelShow();
+		cancelHide();
+		if ( ! panel ) {
+			return;
+		}
+		const previousAnchor = anchor;
+		panel.remove();
+		panel = null;
+		anchor = null;
+		anchorSlug = '';
+		document.body.classList.remove( OPEN_BODY_CLASS );
+		previousAnchor?.removeAttribute( 'data-constellation-open' );
+		if ( restoreFocus && previousAnchor ) {
+			previousAnchor
+				.querySelector< HTMLElement >( '.os-dock__item-primary' )
+				?.focus();
+		}
+		doAction( HOOKS.CONSTELLATION_CLOSED, {
+			menuSlug: previousAnchor?.dataset.menuSlug ?? '',
+		} );
+	};
+
+	const open = ( tile: HTMLElement, focusFirst = false ): void => {
+		const slug = tile.dataset.menuSlug as string;
+		if ( panel && anchorSlug === slug ) {
+			if ( focusFirst ) {
+				focusRow( panel, 0 );
+			}
+			return;
+		}
+		close();
+		const item = deps.getMenuItems().find( ( i ) => i.id === slug );
+		if ( ! item ) {
+			return;
+		}
+		const instances =
+			deps.windowManager.getAllByBaseIdOnActiveDesktop(
+				resolveBaseId( deps, item ),
+			);
+		panel = buildPanel( deps, item, instances, tile, close );
+		anchor = tile;
+		anchorSlug = slug;
+		document.body.appendChild( panel );
+		document.body.classList.add( OPEN_BODY_CLASS );
+		tile.setAttribute( 'data-constellation-open', '' );
+		inheritShellVars( panel );
+		position( panel, tile );
+		// One frame late so the CSS start state is a real painted frame
+		// and the spring transition has something to animate FROM.
+		requestAnimationFrame( () => {
+			panel?.classList.add( 'os-constellation--open' );
+			if ( focusFirst && panel ) {
+				focusRow( panel, 0 );
+			}
+		} );
+		doAction( HOOKS.CONSTELLATION_OPENED, {
+			menuSlug: slug,
+			item,
+			instances,
+		} );
+	};
+
+	const onPointerOver = ( e: PointerEvent ): void => {
+		// Touch and pen never fan the flyout — see the module header.
+		if ( e.pointerType && e.pointerType !== 'mouse' ) {
+			return;
+		}
+		if ( panel && e.target instanceof Node && panel.contains( e.target ) ) {
+			cancelHide();
+			return;
+		}
+		const tile = tileFrom( e.target );
+		if ( ! tile ) {
+			return;
+		}
+		cancelHide();
+		if ( panel && anchorSlug === tile.dataset.menuSlug ) {
+			return;
+		}
+		cancelShow();
+		showTimer = window.setTimeout( () => {
+			showTimer = null;
+			open( tile );
+		}, panel ? 0 : SHOW_DELAY_MS );
+	};
+
+	const onPointerOut = ( e: PointerEvent ): void => {
+		const to = e.relatedTarget;
+		const stillInside =
+			to instanceof Node &&
+			( ( panel && panel.contains( to ) ) ||
+				( anchor && anchor.contains( to ) ) ||
+				!! tileFrom( to ) );
+		if ( stillInside ) {
+			return;
+		}
+		cancelShow();
+		cancelHide();
+		hideTimer = window.setTimeout( () => {
+			hideTimer = null;
+			close();
+		}, HIDE_DELAY_MS );
+	};
+
+	const onKeyDown = ( e: KeyboardEvent ): void => {
+		// Inside an open flyout: rove, activate, collapse.
+		if ( panel && e.target instanceof Node && panel.contains( e.target ) ) {
+			const rows = rowsOf( panel );
+			const current = rows.indexOf( e.target as HTMLElement );
+			if ( e.key === 'Escape' ) {
+				e.preventDefault();
+				close( true );
+			} else if ( e.key === 'ArrowDown' ) {
+				e.preventDefault();
+				focusRow( panel, current + 1 );
+			} else if ( e.key === 'ArrowUp' ) {
+				e.preventDefault();
+				// Rolling off the top of the list returns to the rail
+				// rather than wrapping — the dock is "above" nothing,
+				// so wrapping would strand the keyboard in the panel.
+				if ( current <= 0 ) {
+					close( true );
+				} else {
+					focusRow( panel, current - 1 );
+				}
+			} else if ( e.key === 'Home' ) {
+				e.preventDefault();
+				focusRow( panel, 0 );
+			} else if ( e.key === 'End' ) {
+				e.preventDefault();
+				focusRow( panel, rows.length - 1 );
+			} else if ( e.key === 'Tab' ) {
+				// Tab means "leave this menu" — collapse and let the
+				// browser move on rather than trapping focus in a
+				// transient hover surface.
+				close();
+			}
+			return;
+		}
+		// On a tile: ArrowUp fans the constellation out (the rail is at
+		// the bottom edge, so "up" is where the panel appears).
+		const tile = tileFrom( e.target );
+		if ( ! tile ) {
+			return;
+		}
+		if ( e.key === 'ArrowUp' ) {
+			e.preventDefault();
+			open( tile, true );
+		} else if ( e.key === 'Escape' ) {
+			close();
+		}
+	};
+
+	/** Any layout / viewport change invalidates the anchor rect. */
+	const onInvalidate = (): void => close();
+
+	document.addEventListener( 'pointerover', onPointerOver );
+	document.addEventListener( 'pointerout', onPointerOut );
+	document.addEventListener( 'keydown', onKeyDown );
+	window.addEventListener( 'resize', onInvalidate );
+	window.addEventListener( 'blur', onInvalidate );
+	document.addEventListener( 'os-layout-changed', onInvalidate );
+	// Capture: a scroll inside the dock's own overflow container never
+	// bubbles to `window`, and that is exactly the scroll that moves
+	// the tile out from under the panel.
+	document.addEventListener( 'scroll', onInvalidate, true );
+
+	return (): void => {
+		close();
+		document.removeEventListener( 'pointerover', onPointerOver );
+		document.removeEventListener( 'pointerout', onPointerOut );
+		document.removeEventListener( 'keydown', onKeyDown );
+		window.removeEventListener( 'resize', onInvalidate );
+		window.removeEventListener( 'blur', onInvalidate );
+		document.removeEventListener( 'os-layout-changed', onInvalidate );
+		document.removeEventListener( 'scroll', onInvalidate, true );
+	};
+}
+
+/**
+ * Window-manager key for a menu tile. Mirrors `Dock.resolveItemBaseId`
+ * closely enough for the instance lookup: an explicit `windowId` wins,
+ * otherwise the URL-derived id.
+ */
+function resolveBaseId(
+	deps: DockConstellationDeps,
+	item: DockItem,
+): string {
+	if ( item.windowId ) {
+		return item.windowId;
+	}
+	return deriveWindowId( item.url, deps.adminUrl );
+}
+
+/* -------------------------------------------------------------------
+ * Panel construction
+ * ---------------------------------------------------------------- */
+
+function buildPanel(
+	deps: DockConstellationDeps,
+	item: DockItem,
+	instances: OsWindow[],
+	tile: HTMLElement,
+	dismiss: () => void,
+): HTMLElement {
+	const root = document.createElement( 'div' );
+	root.className = 'os-constellation';
+	root.setAttribute( 'role', 'menu' );
+	root.setAttribute(
+		'aria-label',
+		sprintf(
+			// translators: %s is an admin menu title (e.g. "Appearance").
+			__( '%s menu' ),
+			item.title,
+		),
+	);
+	// Every hue in the panel — orbit dots, the head's halo, the beam —
+	// derives from the menu's own title, so "Appearance" is the same
+	// colour every session on every site. Free identity, zero art.
+	root.style.setProperty( '--os-cn-hue', String( hashTitleToHue( item.title ) ) );
+
+	const surface = document.createElement( 'div' );
+	surface.className = 'os-constellation__surface';
+	root.appendChild( surface );
+
+	surface.appendChild( buildHead( deps, item, dismiss ) );
+
+	let rowIndex = 0;
+	const nextIndex = (): number => rowIndex++;
+
+	if ( instances.length > 0 ) {
+		surface.appendChild(
+			buildInstancesGroup( deps, item, instances, dismiss, nextIndex ),
+		);
+	}
+
+	if ( item.submenu.length > 0 ) {
+		surface.appendChild(
+			buildSubmenuGroup( deps, item, dismiss, nextIndex ),
+		);
+	}
+
+	surface.appendChild( buildFooter( deps, item, dismiss, nextIndex() ) );
+
+	// Cursor spotlight — the surface paints a soft radial highlight at
+	// `--os-cn-x` / `--os-cn-y`, so the panel lights up under the
+	// pointer instead of sitting inert.
+	surface.addEventListener( 'pointermove', ( e: PointerEvent ) => {
+		const rect = surface.getBoundingClientRect();
+		if ( ! rect.width || ! rect.height ) {
+			return;
+		}
+		surface.style.setProperty(
+			'--os-cn-x',
+			`${ ( ( e.clientX - rect.left ) / rect.width ) * 100 }%`,
+		);
+		surface.style.setProperty(
+			'--os-cn-y',
+			`${ ( ( e.clientY - rect.top ) / rect.height ) * 100 }%`,
+		);
+	} );
+
+	// Sheen and beam hang off the ROOT, not the surface. The surface's
+	// two pseudo-elements are already spent (`::before` spotlight,
+	// `::after` edge mask), and a root-level overlay is what lets the
+	// sheen sweep OVER the rows rather than under them.
+	const sheen = document.createElement( 'span' );
+	sheen.className = 'os-constellation__sheen';
+	sheen.setAttribute( 'aria-hidden', 'true' );
+	root.appendChild( sheen );
+
+	const beam = document.createElement( 'span' );
+	beam.className = 'os-constellation__beam';
+	beam.setAttribute( 'aria-hidden', 'true' );
+	root.appendChild( beam );
+
+	const ctx: ConstellationPanelContext = { item, instances, tile };
+	return applyFilters< HTMLElement, [ ConstellationPanelContext ] >(
+		HOOKS.CONSTELLATION_PANEL,
+		root,
+		ctx,
+	);
+}
+
+/** The head row — icon, title, and the menu's own page behind it. */
+function buildHead(
+	deps: DockConstellationDeps,
+	item: DockItem,
+	dismiss: () => void,
+): HTMLElement {
+	const head = document.createElement( 'button' );
+	head.type = 'button';
+	head.className = 'os-constellation__head os-constellation__row';
+	head.setAttribute( 'role', 'menuitem' );
+
+	const iconHost = document.createElement( 'span' );
+	iconHost.className = 'os-constellation__head-icon';
+	iconHost.setAttribute( 'aria-hidden', 'true' );
+	iconHost.appendChild( glyph( item.icon ) );
+	head.appendChild( iconHost );
+
+	const text = document.createElement( 'span' );
+	text.className = 'os-constellation__head-text';
+	const title = document.createElement( 'span' );
+	title.className = 'os-constellation__head-title';
+	title.textContent = item.title;
+	text.appendChild( title );
+	const hint = document.createElement( 'span' );
+	hint.className = 'os-constellation__head-hint';
+	if ( item.submenu.length > 0 ) {
+		hint.textContent = sprintf(
+			// translators: %d is the number of pages inside an admin menu.
+			_n( '%d page', '%d pages', item.submenu.length ),
+			item.submenu.length,
+		);
+	} else {
+		hint.textContent = __( 'Open' );
+	}
+	text.appendChild( hint );
+	head.appendChild( text );
+
+	const chev = document.createElement( 'span' );
+	chev.className =
+		'os-constellation__head-chevron dashicons dashicons-arrow-right-alt2';
+	chev.setAttribute( 'aria-hidden', 'true' );
+	head.appendChild( chev );
+
+	head.addEventListener( 'click', () => {
+		dismiss();
+		openMenuItem( deps, item );
+	} );
+
+	return head;
+}
+
+/** Live windows for this menu, newest chrome first. */
+function buildInstancesGroup(
+	deps: DockConstellationDeps,
+	item: DockItem,
+	instances: OsWindow[],
+	dismiss: () => void,
+	nextIndex: () => number,
+): HTMLElement {
+	const group = document.createElement( 'div' );
+	group.className =
+		'os-constellation__group os-constellation__group--live';
+	group.setAttribute( 'role', 'group' );
+	group.setAttribute( 'aria-label', __( 'Open windows' ) );
+	group.appendChild(
+		legend(
+			sprintf(
+				// translators: %d is a count of currently-open windows.
+				_n( '%d open window', '%d open windows', instances.length ),
+				instances.length,
+			),
+		),
+	);
+
+	for ( const win of instances ) {
+		const row = document.createElement( 'button' );
+		row.type = 'button';
+		row.className =
+			'os-constellation__row os-constellation__row--live';
+		row.setAttribute( 'role', 'menuitem' );
+		row.style.setProperty( '--os-cn-row', String( nextIndex() ) );
+		if ( win.state === 'minimized' ) {
+			row.dataset.state = 'minimized';
+		}
+
+		const pip = document.createElement( 'span' );
+		pip.className = 'os-constellation__pip';
+		pip.setAttribute( 'aria-hidden', 'true' );
+		row.appendChild( pip );
+
+		const label = document.createElement( 'span' );
+		label.className = 'os-constellation__row-label';
+		label.textContent = win.config.title || item.title;
+		row.appendChild( label );
+
+		const state = document.createElement( 'span' );
+		state.className = 'os-constellation__row-meta';
+		state.textContent =
+			win.state === 'minimized' ? __( 'Minimized' ) : __( 'Open' );
+		row.appendChild( state );
+
+		row.addEventListener( 'click', () => {
+			dismiss();
+			if ( win.state === 'minimized' ) {
+				win.restore();
+			}
+			deps.windowManager.focus( win );
+		} );
+
+		group.appendChild( row );
+	}
+	return group;
+}
+
+/** The submenu proper — the whole point of the layout. */
+function buildSubmenuGroup(
+	deps: DockConstellationDeps,
+	item: DockItem,
+	dismiss: () => void,
+	nextIndex: () => number,
+): HTMLElement {
+	const group = document.createElement( 'div' );
+	group.className = 'os-constellation__group';
+	group.setAttribute( 'role', 'group' );
+	group.setAttribute( 'aria-label', item.title );
+	group.appendChild( legend( __( 'Go to' ) ) );
+
+	for ( const sub of item.submenu ) {
+		group.appendChild(
+			buildSubmenuRow( deps, item, sub, dismiss, nextIndex() ),
+		);
+	}
+	return group;
+}
+
+function buildSubmenuRow(
+	deps: DockConstellationDeps,
+	item: DockItem,
+	sub: SubmenuItem,
+	dismiss: () => void,
+	index: number,
+): HTMLElement {
+	const row = document.createElement( 'button' );
+	row.type = 'button';
+	row.className = 'os-constellation__row os-constellation__row--sub';
+	row.setAttribute( 'role', 'menuitem' );
+	row.style.setProperty( '--os-cn-row', String( index ) );
+	// Per-row hue, so a long submenu reads as a spectrum rather than
+	// fifteen identical grey bullets.
+	row.style.setProperty(
+		'--os-cn-row-hue',
+		String( hashTitleToHue( sub.title ) ),
+	);
+
+	const orbit = document.createElement( 'span' );
+	orbit.className = 'os-constellation__orbit';
+	orbit.setAttribute( 'aria-hidden', 'true' );
+	row.appendChild( orbit );
+
+	const label = document.createElement( 'span' );
+	label.className = 'os-constellation__row-label';
+	label.textContent = sub.title;
+	row.appendChild( label );
+
+	row.addEventListener( 'click', () => {
+		dismiss();
+		openSubmenuItem( deps, item, sub );
+	} );
+
+	return row;
+}
+
+/** The trailing "open another" affordance. */
+function buildFooter(
+	deps: DockConstellationDeps,
+	item: DockItem,
+	dismiss: () => void,
+	index: number,
+): HTMLElement {
+	const row = document.createElement( 'button' );
+	row.type = 'button';
+	row.className = 'os-constellation__row os-constellation__row--new';
+	row.setAttribute( 'role', 'menuitem' );
+	row.style.setProperty( '--os-cn-row', String( index ) );
+
+	const plus = document.createElement( 'span' );
+	plus.className = 'os-constellation__plus';
+	plus.setAttribute( 'aria-hidden', 'true' );
+	plus.textContent = '+';
+	row.appendChild( plus );
+
+	const label = document.createElement( 'span' );
+	label.className = 'os-constellation__row-label';
+	label.textContent = sprintf(
+		// translators: %s is an admin menu title (e.g. "Posts").
+		__( 'New %s window' ),
+		item.title,
+	);
+	row.appendChild( label );
+
+	row.addEventListener( 'click', () => {
+		dismiss();
+		openNewMenuItem( deps, item );
+	} );
+
+	return row;
+}
+
+function legend( text: string ): HTMLElement {
+	const el = document.createElement( 'span' );
+	el.className = 'os-constellation__legend';
+	el.textContent = text;
+	return el;
+}
+
+/** Dashicon span, falling back to the generic cog for anything else. */
+function glyph( icon: string ): HTMLElement {
+	const el = document.createElement( 'span' );
+	el.className = 'dashicons';
+	el.classList.add(
+		icon.startsWith( 'dashicons-' )
+			? sanitizeClassName( icon )
+			: 'dashicons-admin-generic',
+	);
+	return el;
+}
+
+/* -------------------------------------------------------------------
+ * Focus + geometry
+ * ---------------------------------------------------------------- */
+
+function rowsOf( panel: HTMLElement ): HTMLElement[] {
+	return Array.from(
+		panel.querySelectorAll< HTMLElement >( '.os-constellation__row' ),
+	);
+}
+
+function focusRow( panel: HTMLElement, index: number ): void {
+	const rows = rowsOf( panel );
+	if ( rows.length === 0 ) {
+		return;
+	}
+	const clamped = Math.max( 0, Math.min( rows.length - 1, index ) );
+	rows[ clamped ].focus();
+}
+
+/**
+ * CSS custom properties whose RESOLVED value has to be copied from the
+ * shell onto the body-attached panel.
+ *
+ * The palette is declared on `body.os-active` and per-scheme overrides
+ * are scoped to `.os-shell`, so a panel appended to `document.body`
+ * inherits the former but not the latter. Copying these by hand keeps
+ * the flyout's chrome matched to the live windows under the user's
+ * selected admin colour scheme — the same problem, and the same fix,
+ * as the hover-peek's `inheritShellSchemeVars`.
+ */
+const SHELL_VARS = [
+	'--wp-admin-theme-color',
+	'--os-titlebar-bg-focused',
+	'--os-titlebar-color-focused',
+] as const;
+
+function inheritShellVars( panel: HTMLElement ): void {
+	const shell = document.querySelector< HTMLElement >( '.os-shell' );
+	if ( ! shell ) {
+		return;
+	}
+	const computed = window.getComputedStyle( shell );
+	for ( const name of SHELL_VARS ) {
+		const value = computed.getPropertyValue( name ).trim();
+		if ( value ) {
+			panel.style.setProperty( name, value );
+		}
+	}
+}
+
+/**
+ * Anchor the panel above the tile, then pull it back inside the
+ * viewport and slide the beam to stay pointed at the tile's centre.
+ *
+ * The clamp writes `--os-cn-beam-x` rather than moving the beam
+ * element: the beam is the only thing tying a panel that has been
+ * nudged sideways back to the tile it belongs to, so it has to track
+ * the anchor independently of the surface.
+ */
+function position( panel: HTMLElement, tile: HTMLElement ): void {
+	const rect = tile.getBoundingClientRect();
+	const centre = rect.left + rect.width / 2;
+	panel.style.left = `${ centre }px`;
+	panel.style.top = `${ rect.top - BEAM_GAP_PX }px`;
+
+	requestAnimationFrame( () => {
+		const panelRect = panel.getBoundingClientRect();
+		const vw = window.innerWidth;
+		let dx = 0;
+		if ( panelRect.left < VIEWPORT_MARGIN_PX ) {
+			dx = VIEWPORT_MARGIN_PX - panelRect.left;
+		} else if ( panelRect.right > vw - VIEWPORT_MARGIN_PX ) {
+			dx = vw - VIEWPORT_MARGIN_PX - panelRect.right;
+		}
+		if ( dx !== 0 ) {
+			panel.style.setProperty( '--os-cn-shift', `${ dx }px` );
+			panel.style.setProperty( '--os-cn-beam-x', `${ -dx }px` );
+		}
+	} );
+}

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -112,6 +112,12 @@ const EXIT_MS = 160;
 const BEAM_GAP_PX = 14;
 /** Keep-out margin from every viewport edge. */
 const VIEWPORT_MARGIN_PX = 12;
+/**
+ * Floor for the vertical cap. Below roughly this, a panel has stopped
+ * being a menu and become a scrollbar with a title on it, so on a
+ * viewport that short we let it overflow slightly instead.
+ */
+const MIN_PANEL_HEIGHT_PX = 160;
 
 /**
  * Body class set while a flyout is open. CSS uses it to mute the dock
@@ -352,6 +358,18 @@ export function mountDockConstellation(
 				resolveBaseId( deps, item ),
 			);
 		panel = buildPanel( deps, item, instances, tile, close );
+		// Roving tabindex: the flyout is ONE tab stop, not one per row.
+		// Arrow keys move between rows and Tab leaves the menu — the
+		// conventional ARIA menu pattern, and the reason it matters
+		// here is that a fifteen-child submenu would otherwise put
+		// fifteen stops between the dock and whatever follows it.
+		//
+		// Applied after the panel filter rather than in each builder so
+		// rows a plugin appended are covered too; `focus()` still works
+		// on a `tabindex="-1"` element, which is all the roving needs.
+		for ( const row of rowsOf( panel ) ) {
+			row.tabIndex = -1;
+		}
 		anchor = tile;
 		anchorSlug = slug;
 		document.body.appendChild( panel );
@@ -445,10 +463,14 @@ export function mountDockConstellation(
 				e.preventDefault();
 				focusRow( panel, rows.length - 1 );
 			} else if ( e.key === 'Tab' ) {
-				// Tab means "leave this menu" — collapse and let the
-				// browser move on rather than trapping focus in a
-				// transient hover surface.
-				close();
+				// Tab means "leave this menu". Collapse it and hand
+				// focus back to the tile WITHOUT preventing the
+				// default, so the browser then tabs onward from the
+				// tile — the rail's own position in the document
+				// order. Closing without restoring focus would drop
+				// the user on `<body>` and restart their traversal
+				// from the top of the page.
+				close( true );
 			}
 			return;
 		}
@@ -887,19 +909,41 @@ function inheritShellVars( panel: HTMLElement ): void {
 }
 
 /**
- * Anchor the panel above the tile, then pull it back inside the
- * viewport and slide the beam to stay pointed at the tile's centre.
+ * Anchor the panel above the tile, cap it to the room actually
+ * available there, then pull it back inside the viewport horizontally
+ * and slide the beam to stay pointed at the tile's centre.
  *
- * The clamp writes `--os-cn-beam-x` rather than moving the beam
- * element: the beam is the only thing tying a panel that has been
- * nudged sideways back to the tile it belongs to, so it has to track
- * the anchor independently of the surface.
+ * The two axes are clamped differently on purpose.
+ *
+ * **Horizontally** the panel is nudged, because sliding it sideways
+ * costs nothing — it still points at its tile, and the beam tracks
+ * the anchor independently via `--os-cn-beam-x` so the thread stays
+ * honest.
+ *
+ * **Vertically it cannot be nudged at all.** The panel hangs off the
+ * top of the dock; moving it down to fit would push it over the rail
+ * and under the pointer, which is worse than the overflow. So the
+ * height is capped instead: `--os-cn-max-h` is the distance from the
+ * panel's bottom edge to the top of the viewport, and the surface
+ * reads it as a `max-height`. A menu too tall for the space shrinks
+ * to fit and its submenu group takes the scroll — which is why the
+ * group is the flex item that shrinks, not the head or the
+ * new-window row.
  */
 function position( panel: HTMLElement, tile: HTMLElement ): void {
 	const rect = tile.getBoundingClientRect();
 	const centre = rect.left + rect.width / 2;
 	panel.style.left = `${ centre }px`;
 	panel.style.top = `${ rect.top - BEAM_GAP_PX }px`;
+
+	// `MIN_PANEL_HEIGHT_PX` is a floor rather than a hard truth: on a
+	// viewport so short that even that doesn't fit, a panel that
+	// overflows slightly beats one collapsed to a sliver.
+	const available = rect.top - BEAM_GAP_PX - VIEWPORT_MARGIN_PX;
+	panel.style.setProperty(
+		'--os-cn-max-h',
+		`${ Math.max( MIN_PANEL_HEIGHT_PX, available ) }px`,
+	);
 
 	requestAnimationFrame( () => {
 		const panelRect = panel.getBoundingClientRect();

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -45,19 +45,26 @@
  * 3. **It routes through the same window ids the dock does** (see
  *    `routing.ts`), so the flyout and the tile address one window
  *    between them rather than two.
- * 4. **A dismissed panel outlives its dismissal.** It is detached from
- *    the module's state immediately but stays in the document,
- *    marked `--closing`, until it has finished leaving. There are
- *    three ways to leave, and picking the right one is most of what
- *    makes the rail feel solid:
- *      - *exit* — the ordinary dismissal. Falls back into the rail.
- *      - *hand-off* — another tile is taking over. The panel does NOT
- *        close: it slides to the new anchor alongside its
- *        replacement and cross-fades, so the menu never leaves the
- *        screen. Anything else reads as a blink.
- *      - *cut* — the anchor rect was invalidated (scroll, resize,
- *        layout switch). A panel gliding away from a tile that has
- *        already moved points at nothing, so the node just goes.
+ * 4. **A dismissed panel outlives its dismissal, and there can be
+ *    more than one on screen.** `panel` is the panel you can still
+ *    interact with, not the only one in the document: a dismissed
+ *    panel is detached from the module's state immediately but stays
+ *    painted, marked `--closing`, until its exit has finished.
+ *
+ *    That decoupling is the whole reason moving along the rail looks
+ *    right. It is TWO panels, each animating at its own tile — the
+ *    one you left playing its dismissal above the tile it belongs
+ *    to, the one you arrived at rising above its own — rather than
+ *    one panel that slides across and swaps its contents. Each is a
+ *    menu anchored to a specific tile; turning one into the other
+ *    would claim they are the same object, and it would drag a beam
+ *    across the rail pointing at a tile its panel has nothing to do
+ *    with.
+ *
+ *    The one dismissal that skips its animation is `cut`, for when
+ *    the anchor rect has been invalidated (scroll, resize, layout
+ *    switch): a panel gliding away from a tile that has already
+ *    moved points at nothing, so the node just goes.
  *
  * Pointer AND keyboard. The tile is a `<button>` the rail already
  * focuses; ArrowUp (or Enter on a tile with children) fans the
@@ -101,17 +108,6 @@ const HIDE_DELAY_MS = 240;
  * moved on, and anything slower reads as the menu not letting go.
  */
 const EXIT_MS = 160;
-/**
- * How long the slide between two tiles runs. Must match the
- * `.os-constellation--handoff` transition in
- * `openstation-layout.css`.
- *
- * Longer than the exit and shorter than the entrance: the panel is
- * neither arriving nor leaving, it is travelling, and the distance
- * between two adjacent dock tiles is short enough that anything
- * slower turns a flick along the rail into a queue.
- */
-const HANDOFF_MS = 200;
 /** Gap between the tile's top edge and the panel's bottom edge. */
 const BEAM_GAP_PX = 14;
 /** Keep-out margin from every viewport edge. */
@@ -238,16 +234,15 @@ export function mountDockConstellation(
 	 * How a retiring panel should leave.
 	 *
 	 * - `exit` — the ordinary dismissal: fall back into the rail.
-	 * - `handoff` — another tile is taking over. The panel slides to
-	 *   the new anchor alongside its replacement and cross-fades, so
-	 *   the menu never leaves the screen.
-	 * - `cut` — remove the node now. For dismissals where animating
-	 *   would be actively wrong rather than merely skippable: the
-	 *   anchor rect has been invalidated (scroll, resize, layout
-	 *   switch) and a panel gliding away from a tile that already
-	 *   moved points at nothing.
+	 * - `cut` — remove the node now. Used wherever an animation would
+	 *   be pointless or wrong rather than merely skippable: the anchor
+	 *   rect has been invalidated (scroll, resize, layout switch) and
+	 *   a panel gliding away from a tile that already moved points at
+	 *   nothing; or a hand-off is under way and the node is about to
+	 *   be covered pixel-for-pixel by its replacement, so nothing of
+	 *   it would ever be seen uncovered.
 	 */
-	type RetireMode = 'exit' | 'handoff' | 'cut';
+	type RetireMode = 'exit' | 'cut';
 
 	/**
 	 * Detach a panel from the module's state and start it leaving.
@@ -257,7 +252,10 @@ export function mountDockConstellation(
 	 * path — has to see "no panel is current" even while a node is
 	 * still in the document playing its exit.
 	 */
-	const retire = ( mode: RetireMode, restoreFocus = false ): void => {
+	const retire = (
+		mode: RetireMode,
+		opts: { restoreFocus?: boolean; handoff?: boolean } = {},
+	): void => {
 		if ( ! panel ) {
 			return;
 		}
@@ -272,26 +270,19 @@ export function mountDockConstellation(
 			dying.remove();
 		} else {
 			dying.classList.remove( 'os-constellation--open' );
-			// `--closing` marks every retiring panel (it is what
-			// `:not( --closing )` queries key off, ours and plugins');
-			// `--handoff` then overrides the fall with the slide.
+			// `--closing` marks every retiring panel — it is what
+			// `:not( --closing )` queries key off, ours and plugins'.
 			dying.classList.add( 'os-constellation--closing' );
-			if ( mode === 'handoff' ) {
-				dying.classList.add( 'os-constellation--handoff' );
-			}
 			closing.add( dying );
-			window.setTimeout(
-				() => {
-					dying.remove();
-					closing.delete( dying );
-					syncBodyFlag();
-				},
-				mode === 'handoff' ? HANDOFF_MS : EXIT_MS,
-			);
+			window.setTimeout( () => {
+				dying.remove();
+				closing.delete( dying );
+				syncBodyFlag();
+			}, EXIT_MS );
 		}
 		syncBodyFlag();
 
-		if ( restoreFocus && previousAnchor ) {
+		if ( opts.restoreFocus && previousAnchor ) {
 			previousAnchor
 				.querySelector< HTMLElement >( '.os-dock__item-primary' )
 				?.focus();
@@ -301,14 +292,14 @@ export function mountDockConstellation(
 			// `true` when another tile is already taking over, so a
 			// subscriber can tell "the menu closed" from "the menu
 			// moved" without diffing against the next opened event.
-			handoff: mode === 'handoff',
+			handoff: opts.handoff === true,
 		} );
 	};
 
 	const close = ( restoreFocus = false, immediate = false ): void => {
 		cancelShow();
 		cancelHide();
-		retire( immediate ? 'cut' : 'exit', restoreFocus );
+		retire( immediate ? 'cut' : 'exit', { restoreFocus } );
 	};
 
 	const open = ( tile: HTMLElement, focusFirst = false ): void => {
@@ -332,64 +323,55 @@ export function mountDockConstellation(
 		}
 
 		/*
-		 * Hand-off. Moving from one menu to the next is not a close
-		 * followed by an open — it is the same menu changing what it
-		 * is about, which is how every menu bar since 1984 has
-		 * behaved. So the outgoing panel does not fall away and the
-		 * incoming one does not spring up: the new panel is born at
-		 * the OLD panel's x, both slide to the new anchor together on
-		 * the same curve, and they cross-fade on the way. The menu
-		 * never leaves the screen, and the eye tracks one object
-		 * across the rail instead of watching two events.
+		 * Moving from one menu to the next is TWO panels, each
+		 * animating at its own tile: the one you left plays its
+		 * dismissal above the tile it belongs to, the one you arrived
+		 * at plays its entrance above its own.
+		 *
+		 * This deliberately is not a morph. A single panel that slid
+		 * along the rail and swapped its contents was the other
+		 * candidate, and it is wrong for what these are: each panel is
+		 * a menu, anchored to a specific tile, and turning one into
+		 * another says they are the same object when the whole point
+		 * of the rail is that they are not. What the eye needs to see
+		 * is Appearance closing and Settings opening — which also
+		 * means the beam stays honest, since each panel's thread runs
+		 * to the tile it actually belongs to for as long as it exists.
+		 *
+		 * That is only possible because a retiring panel is decoupled
+		 * from `panel` rather than being the same node re-used: the
+		 * outgoing one keeps its own anchor and finishes its own exit
+		 * while the incoming one is already rising elsewhere.
 		 */
-		const handingOff = panel !== null && ! prefersReducedMotion();
-		const fromX = handingOff ? readLeft( panel as HTMLElement ) : null;
-		const outgoing = panel;
+		const handingOff = panel !== null;
 
-		retire( handingOff ? 'handoff' : 'cut' );
+		retire( 'exit', { handoff: handingOff } );
 
 		const instances =
 			deps.windowManager.getAllByBaseIdOnActiveDesktop(
 				resolveBaseId( deps, item ),
 			);
 		panel = buildPanel( deps, item, instances, tile, close );
-		if ( handingOff ) {
-			panel.classList.add( 'os-constellation--handoff' );
-		}
 		anchor = tile;
 		anchorSlug = slug;
 		document.body.appendChild( panel );
 		syncBodyFlag();
 		tile.setAttribute( 'data-constellation-open', '' );
 		inheritShellVars( panel );
-		const targetX = position( panel, tile, fromX );
-		// Walk the outgoing panel to the same destination so the pair
-		// travels as one. Its own transition (declared on `--handoff`)
-		// carries it; nothing else about it changes.
-		if ( outgoing && handingOff && targetX !== null ) {
-			outgoing.style.left = `${ targetX }px`;
-		}
-		// One frame late so the CSS start state is a real painted frame
-		// and the transition has something to animate FROM.
+		position( panel, tile );
+		// One frame late so the CSS start state is a real painted
+		// frame and the entrance has something to animate FROM.
 		requestAnimationFrame( () => {
 			panel?.classList.add( 'os-constellation--open' );
 			if ( focusFirst && panel ) {
 				focusRow( panel, 0 );
 			}
 		} );
-		if ( handingOff ) {
-			// Drop back to the ordinary transitions once the slide is
-			// done, so the NEXT dismissal gets the fall-into-the-rail
-			// exit rather than a slide to nowhere.
-			const settling = panel;
-			window.setTimeout( () => {
-				settling.classList.remove( 'os-constellation--handoff' );
-			}, HANDOFF_MS );
-		}
 		doAction( HOOKS.CONSTELLATION_OPENED, {
 			menuSlug: slug,
 			item,
 			instances,
+			handoff: handingOff,
 		} );
 	};
 
@@ -913,27 +895,11 @@ function inheritShellVars( panel: HTMLElement ): void {
  * nudged sideways back to the tile it belongs to, so it has to track
  * the anchor independently of the surface.
  */
-function position(
-	panel: HTMLElement,
-	tile: HTMLElement,
-	fromX: number | null = null,
-): number {
+function position( panel: HTMLElement, tile: HTMLElement ): void {
 	const rect = tile.getBoundingClientRect();
 	const centre = rect.left + rect.width / 2;
+	panel.style.left = `${ centre }px`;
 	panel.style.top = `${ rect.top - BEAM_GAP_PX }px`;
-
-	if ( fromX === null ) {
-		panel.style.left = `${ centre }px`;
-	} else {
-		// Hand-off: born where the outgoing panel is standing, then
-		// walked to the new anchor a frame later so the assignment is
-		// a transition rather than an initial value (an element's
-		// first computed value never animates).
-		panel.style.left = `${ fromX }px`;
-		requestAnimationFrame( () => {
-			panel.style.left = `${ centre }px`;
-		} );
-	}
 
 	requestAnimationFrame( () => {
 		const panelRect = panel.getBoundingClientRect();
@@ -949,17 +915,5 @@ function position(
 			panel.style.setProperty( '--os-cn-beam-x', `${ -dx }px` );
 		}
 	} );
-
-	return centre;
 }
 
-/**
- * The panel's current `left`, in px. Read off the inline style rather
- * than `getBoundingClientRect()` because that box has already been
- * moved by the `translate( -50%, … )`, and the hand-off needs the
- * anchor point the transition interpolates, not the painted edge.
- */
-function readLeft( panel: HTMLElement ): number | null {
-	const raw = parseFloat( panel.style.left );
-	return Number.isFinite( raw ) ? raw : null;
-}

--- a/src/dock-constellation/routing.ts
+++ b/src/dock-constellation/routing.ts
@@ -1,0 +1,130 @@
+/**
+ * Window routing for the constellation flyout.
+ *
+ * The flyout is a second front door onto exactly the windows a dock
+ * click already opens, so it MUST address them by the same ids —
+ * otherwise hovering "Appearance → Themes" and clicking the
+ * Appearance tile would produce two windows of the same page, and
+ * neither the dock indicator nor the hover-peek would recognise the
+ * other's.
+ *
+ * Everything here mirrors `Dock.openPage()` and the layout
+ * dispatcher's `buildMountDeps().openSubmenuPick()`: same
+ * `deriveWindowId( url, adminUrl )` key, same external-URL escape,
+ * same native-window remap consult, same `parentUrl` pinning. The
+ * duplication is deliberate — both of those live inside closures we
+ * can't reach from here, and forwarding through the dispatcher would
+ * mean widening its public interface for one internal caller.
+ */
+
+import type { DockItem, SubmenuItem } from '../dock';
+import { tryOpenExternalUrl } from '../external-url';
+import {
+	resolveNativeUrlRemap,
+	tryNativeUrlRemap,
+} from '../native-url-remap';
+import { deriveWindowId } from '../utils';
+import type { WindowManager } from '../window-manager';
+
+/** Dashicons pass through; anything else falls back to the generic cog. */
+function safeIcon( icon: string ): string {
+	return icon.startsWith( 'dashicons-' ) ? icon : 'dashicons-admin-generic';
+}
+
+export interface ConstellationRouting {
+	windowManager: WindowManager;
+	adminUrl: string;
+}
+
+/**
+ * Open (or focus) a menu's own landing page — what clicking the dock
+ * tile does.
+ */
+export function openMenuItem(
+	deps: ConstellationRouting,
+	item: DockItem,
+): void {
+	if ( item.url && tryOpenExternalUrl( item.url ) ) {
+		return;
+	}
+	if ( item.url && tryNativeUrlRemap( item.url ) ) {
+		return;
+	}
+	const baseId = deriveWindowId( item.url, deps.adminUrl );
+	deps.windowManager.open( {
+		id: baseId,
+		baseId,
+		url: item.url,
+		parentUrl: item.url,
+		title: item.title,
+		icon: safeIcon( item.icon ),
+		submenu: item.submenu,
+		multi: !! item.multi,
+	} );
+}
+
+/**
+ * Open a submenu entry.
+ *
+ * `parentUrl` pins to the PARENT's landing page rather than to the
+ * sub-page, so the window's tab strip still offers a way back to the
+ * menu's own screen — the same reason the dispatcher's
+ * `openSubmenuPick` does it.
+ */
+export function openSubmenuItem(
+	deps: ConstellationRouting,
+	item: DockItem,
+	sub: SubmenuItem,
+): void {
+	if ( tryOpenExternalUrl( sub.url ) ) {
+		return;
+	}
+	if ( tryNativeUrlRemap( sub.url ) ) {
+		return;
+	}
+	deps.windowManager.open( {
+		id: deriveWindowId( sub.url, deps.adminUrl ),
+		baseId: deriveWindowId( item.url, deps.adminUrl ),
+		url: sub.url,
+		parentUrl: item.url,
+		title: item.title,
+		icon: safeIcon( item.icon ),
+		submenu: item.submenu,
+		multi: !! item.multi,
+	} );
+}
+
+/** Spawn a fresh instance of the menu's landing page. */
+export function openNewMenuItem(
+	deps: ConstellationRouting,
+	item: DockItem,
+): void {
+	if ( item.url && tryOpenExternalUrl( item.url ) ) {
+		return;
+	}
+	const openNewWindow = window.wp?.os?.openNewWindow;
+	if ( item.windowId && ! item.url ) {
+		if ( openNewWindow?.( item.windowId, { source: 'dock-constellation' } ) ) {
+			return;
+		}
+	}
+	// A URL claimed by a native window has to spawn a duplicate of THAT
+	// window, not a chromeless iframe of the URL it replaced.
+	const remappedId = resolveNativeUrlRemap( item.url );
+	if ( remappedId ) {
+		if ( openNewWindow?.( remappedId, { source: 'dock-constellation' } ) ) {
+			return;
+		}
+	}
+	const baseId = deriveWindowId( item.url, deps.adminUrl );
+	void deps.windowManager.openNew( {
+		id: baseId,
+		baseId,
+		url: item.url,
+		parentUrl: item.url,
+		title: item.title,
+		icon: safeIcon( item.icon ),
+		submenu: item.submenu,
+		multi: true,
+	} );
+}

--- a/src/dock-peek/index.ts
+++ b/src/dock-peek/index.ts
@@ -29,6 +29,7 @@ import type { DockOrientation } from '../dock';
 import { sanitizeClassName } from '../utils';
 import { hashTitleToHue } from '../ui/util/hash-hue';
 import { applyFilters, HOOKS } from '../hooks';
+import { isConstellationLayoutActive } from '../dock-constellation/active';
 
 /**
  * Detail passed to the {@link HOOKS.DOCK_PEEK_CARD_CONTENT} filter.
@@ -149,6 +150,15 @@ export function attachDockPeek( deps: DockPeekDeps ): () => void {
 	const onPointerEnterTile = ( e: PointerEvent ): void => {
 		// Touch / pen → no peek. Mobile shell owns these gestures.
 		if ( e.pointerType !== 'mouse' ) {
+			return;
+		}
+		// The OpenStation layout hands the hover gesture on menu tiles
+		// to the constellation flyout, which already surfaces the open
+		// instances the peek would have shown — plus the submenu the
+		// peek has no way to reach. Two popovers on one tile is a
+		// flicker, not a feature. System tiles have no submenu and keep
+		// the peek in every layout.
+		if ( isConstellationLayoutActive() && tile.dataset.menuSlug ) {
 			return;
 		}
 		// Re-evaluate on every enter — open windows might have changed

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1014,6 +1014,45 @@ export const HOOKS = {
 	DOCK_PEEK_CARD_ELEMENT: 'os.dock.peek-card-element',
 
 	// ------------------------------------------------------------------
+	// Constellation — the hover-submenu flyout that the `openstation`
+	// desktop layout fans out of a dock tile. Inert in every other
+	// layout, so a subscriber can register unconditionally and simply
+	// never hear from it while the user is on Classic.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Filter, runs once per flyout right before it's appended to the
+	 * document. Receives the fully-built panel root — head, live-window
+	 * group, submenu group, footer, beam — and can return the same
+	 * node, a mutated version, or a replacement.
+	 *
+	 * Signature:
+	 *   ( panel: HTMLElement, detail: ConstellationPanelContext )
+	 *     => HTMLElement
+	 *
+	 * `detail` carries `{ item, instances, tile }`: the `DockItem` the
+	 * flyout was opened for, the live windows currently open for it,
+	 * and the dock tile it is anchored to.
+	 *
+	 * A plugin returning a brand-new node owns everything the flyout
+	 * relies on: the `os-constellation` class (positioning + the
+	 * open transition), `role="menu"`, and the `os-constellation__row`
+	 * class on anything that should take part in arrow-key roving.
+	 */
+	CONSTELLATION_PANEL: 'os.constellation.panel',
+	/**
+	 * Action, fires immediately after a flyout is appended. Detail:
+	 * `{ menuSlug: string, item: DockItem, instances: Window[] }`.
+	 */
+	CONSTELLATION_OPENED: 'os.constellation.opened',
+	/**
+	 * Action, fires after a flyout is removed. Detail:
+	 * `{ menuSlug: string }` — the menu whose flyout closed, or `''`
+	 * if the anchor tile had already been torn down.
+	 */
+	CONSTELLATION_CLOSED: 'os.constellation.closed',
+
+	// ------------------------------------------------------------------
 	// Overview / Arrange lifecycle actions.
 	//
 	// The "Arrange" admin-bar menu drives two layout algorithms —

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1046,9 +1046,15 @@ export const HOOKS = {
 	 */
 	CONSTELLATION_OPENED: 'os.constellation.opened',
 	/**
-	 * Action, fires after a flyout is removed. Detail:
-	 * `{ menuSlug: string }` — the menu whose flyout closed, or `''`
-	 * if the anchor tile had already been torn down.
+	 * Action, fires when a flyout is dismissed — not when its node
+	 * leaves the document, which happens once its exit has played.
+	 *
+	 * Detail: `{ menuSlug: string, handoff: boolean }`. `menuSlug` is
+	 * the menu whose flyout closed, or `''` if the anchor tile had
+	 * already been torn down. `handoff` is `true` when another tile is
+	 * already taking over, so a subscriber can tell "the menu closed"
+	 * from "the menu moved" without diffing against the next
+	 * {@link CONSTELLATION_OPENED}.
 	 */
 	CONSTELLATION_CLOSED: 'os.constellation.closed',
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1042,7 +1042,10 @@ export const HOOKS = {
 	CONSTELLATION_PANEL: 'os.constellation.panel',
 	/**
 	 * Action, fires immediately after a flyout is appended. Detail:
-	 * `{ menuSlug: string, item: DockItem, instances: Window[] }`.
+	 * `{ menuSlug: string, item: DockItem, instances: Window[],
+	 * handoff: boolean }`. `handoff` is `true` when this panel
+	 * replaced one that was already up — the pointer moved along the
+	 * rail — rather than arriving on an empty desk.
 	 */
 	CONSTELLATION_OPENED: 'os.constellation.opened',
 	/**

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -181,6 +181,7 @@ export const DESKTOP_LAYOUTS = [
 	{ id: 'classic', label: 'Classic' },
 	{ id: 'unified', label: 'Unified' },
 	{ id: 'spatial', label: 'Spatial' },
+	{ id: 'openstation', label: 'OpenStation' },
 ] as const;
 
 export const DEFAULTS: OsSettingsState = {

--- a/src/settings/labels.ts
+++ b/src/settings/labels.ts
@@ -108,6 +108,8 @@ export function translateDesktopLayoutLabel(
 			return __( 'Unified' );
 		case 'spatial':
 			return __( 'Spatial' );
+		case 'openstation':
+			return __( 'OpenStation' );
 		default:
 			return fallback;
 	}
@@ -128,6 +130,10 @@ export function translateDesktopLayoutDescription(
 		case 'spatial':
 			return __(
 				'Bottom dock for plugin apps; core admin menus appear as icons on the wallpaper.',
+			);
+		case 'openstation':
+			return __(
+				'One bottom dock: WordPress first, a divider, then your plugins. Hover any tile to fan its submenu out as a holographic flyout.',
 			);
 		default:
 			return '';

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -60,8 +60,10 @@ export interface OsSettingsSnapshot {
 	 * - `unified` — single bottom dock with every menu.
 	 * - `spatial` — bottom dock with plugins; core menus rendered as
 	 *   icons on the wallpaper.
+	 * - `openstation` — single bottom dock, core cluster then a
+	 *   divider then plugins, with hover-reveal submenu flyouts.
 	 */
-	desktopLayout: 'classic' | 'unified' | 'spatial';
+	desktopLayout: 'classic' | 'unified' | 'spatial' | 'openstation';
 	/**
 	 * Active dock rail-renderer id; mirrors the dock-rail registry's
 	 * resolution. `'default'` is the shipped icon-strip renderer.

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -33,8 +33,17 @@ export type DockPlacementId = 'left' | 'right' | 'bottom';
  * - `spatial` — bottom dock with plugin menus + core menus rendered as
  *   icons on the wallpaper. One `Dock` instance, plus synthesized
  *   desktop icons.
+ * - `openstation` — single bottom dock holding every menu, sorted so the
+ *   WordPress core cluster leads and the plugin cluster follows, with
+ *   one luminous divider on the boundary. Hovering a tile fans out the
+ *   menu's submenu as a holographic flyout instead of hiding it behind
+ *   the in-window tab strip. Wallpaper icons are still allowed.
  */
-export type DesktopLayoutId = 'classic' | 'unified' | 'spatial';
+export type DesktopLayoutId =
+	| 'classic'
+	| 'unified'
+	| 'spatial'
+	| 'openstation';
 
 /** Two endpoints on the gradient, plus an angle in degrees (0–360). */
 export interface CustomGradient {

--- a/tests/phpunit/tests/adminBarDesktopToggle.php
+++ b/tests/phpunit/tests/adminBarDesktopToggle.php
@@ -38,7 +38,10 @@ class Tests_OpenStation_AdminBarDesktopToggle extends WP_UnitTestCase {
 		// `os-windows` as a dependency, and
 		// `wp_style_is( …, 'enqueued' )` walks queued handles' deps —
 		// a leftover queue entry would report windows as enqueued.
-		foreach ( array( 'openstation', 'os-windows', 'os-window-overview', 'os-settings', 'os-dock', 'os-dock-peek', 'os-chromeless' ) as $handle ) {
+		// Same reason for `os-openstation-layout`, which depends on
+		// `os-dock`: adding a stylesheet that hangs off one of the
+		// handles asserted below means adding it here too.
+		foreach ( array( 'openstation', 'os-windows', 'os-window-overview', 'os-settings', 'os-dock', 'os-dock-peek', 'os-openstation-layout', 'os-chromeless' ) as $handle ) {
 			wp_dequeue_style( $handle );
 			wp_dequeue_script( $handle );
 		}

--- a/tests/phpunit/tests/osSettings.php
+++ b/tests/phpunit/tests/osSettings.php
@@ -66,7 +66,7 @@ class Tests_OpenStation_OsSettings extends WP_UnitTestCase {
 	 * @covers ::openstation_sanitize_os_settings
 	 */
 	public function test_sanitize_keeps_known_layout_value() {
-		foreach ( array( 'classic', 'unified', 'spatial' ) as $layout ) {
+		foreach ( array( 'classic', 'unified', 'spatial', 'openstation' ) as $layout ) {
 			$clean = openstation_sanitize_os_settings( array( 'desktopLayout' => $layout ) );
 			$this->assertSame( $layout, $clean['desktopLayout'], "layout '{$layout}' should round-trip" );
 		}

--- a/tests/vitest/desktop-layout.test.ts
+++ b/tests/vitest/desktop-layout.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for `src/desktop-layout.ts` — the layout dispatcher that owns
  * the `Dock` instance(s) and the synthesized desktop icons across
- * Classic / Unified / Spatial.
+ * Classic / Unified / Spatial / OpenStation.
  *
  * Pins down the user-visible shape of each layout:
  *
@@ -14,6 +14,10 @@
  *   are synthesized into the desktop-icons list and pushed through
  *   `renderIcons`. Server-registered icons are PRESERVED and concatenated
  *   ahead of synthesized ones so plugin icons aren't shadowed.
+ * - OpenStation: ONE dock at the bottom holding every menu, but
+ *   RE-SORTED core-first so the rail's single `--group` separator
+ *   always lands on the core→plugin boundary. Icons behave as they do
+ *   in Classic / Unified.
  *
  * Also pins layout transitions: switching layouts tears down the old
  * docks (no leaked DOM, no leaked side-dock element on switch away
@@ -254,6 +258,158 @@ describe( 'desktop-layout dispatcher', () => {
 		);
 		expect( bottomTiles ).not.toContain( 'index.php' );
 		expect( bottomTiles ).not.toContain( 'edit.php' );
+	} );
+
+	/**
+	 * OpenStation is Unified plus one structural promise: the rail is
+	 * always WordPress-then-divider-then-plugins. `Dock.render()` drops
+	 * its `--group` separator at the first `isCore === false` tile, so
+	 * the promise is only kept if the dispatcher hands it an already-
+	 * grouped list — these tests are what stop a future ordering change
+	 * from silently scattering the divider.
+	 */
+	describe( 'openstation layout', () => {
+		/** Menu-tile slugs in DOM order, separators marked as `--`. */
+		function railSequence(): string[] {
+			const host = document.getElementById( 'os-dock' )!;
+			return Array.from(
+				host.querySelectorAll(
+					'[data-menu-slug], .os-dock__separator--group',
+				),
+			).map( ( el ) =>
+				( el as HTMLElement ).dataset.menuSlug ?? '--',
+			);
+		}
+
+		test( 'single bottom dock holds every item, no side dock element', () => {
+			const { deps } = makeDeps();
+			createLayoutDispatcher(
+				deps,
+				'openstation',
+				[ dashboard, posts, yoast, woo ],
+				[],
+			);
+			expect( document.getElementById( 'os-side-dock' ) ).toBeNull();
+			expect(
+				document
+					.getElementById( 'os-dock' )
+					?.getAttribute( 'data-os-dock-placement' ),
+			).toBe( 'bottom' );
+			expect( railSequence() ).toContain( 'index.php' );
+			expect( railSequence() ).toContain( 'woocommerce' );
+		} );
+
+		test( 'core cluster leads, plugin cluster follows, one divider between', () => {
+			const { deps } = makeDeps();
+			// Deliberately interleaved input: a plugin first, then core,
+			// then another plugin. A naive pass-through would emit the
+			// separator before `index.php` and never again.
+			createLayoutDispatcher(
+				deps,
+				'openstation',
+				[ yoast, dashboard, woo, posts ],
+				[],
+			);
+			expect( railSequence() ).toEqual( [
+				'index.php',
+				'edit.php',
+				'--',
+				'wpseo_dashboard',
+				'woocommerce',
+			] );
+		} );
+
+		test( 'no divider when the rail has only one kind of tile', () => {
+			const { deps } = makeDeps();
+			createLayoutDispatcher(
+				deps,
+				'openstation',
+				[ dashboard, posts ],
+				[],
+			);
+			expect( railSequence() ).toEqual( [ 'index.php', 'edit.php' ] );
+		} );
+
+		test( 'applyDockItems keeps the grouping and the single divider', () => {
+			const { deps } = makeDeps();
+			const dispatcher = createLayoutDispatcher(
+				deps,
+				'openstation',
+				[ dashboard, yoast ],
+				[],
+			);
+			dispatcher.applyDockItems( [ woo, posts, yoast, dashboard ] );
+			expect( railSequence() ).toEqual( [
+				'edit.php',
+				'index.php',
+				'--',
+				'woocommerce',
+				'wpseo_dashboard',
+			] );
+		} );
+
+		test( 'renderIcons gets the server list — no Spatial-style synthesis', () => {
+			const { deps, renderIcons } = makeDeps();
+			const serverIcon: DesktopIconServerEntry = {
+				id: 'jorvy',
+				title: 'Jorvy',
+				icon: 'dashicons-star-filled',
+				window: 'jorvy',
+				url: '',
+				position: 10,
+			};
+			createLayoutDispatcher(
+				deps,
+				'openstation',
+				[ dashboard, posts, yoast ],
+				[ serverIcon ],
+			);
+			const painted = renderIcons.mock.calls.at( -1 )?.[ 0 ] as
+				| DesktopIconServerEntry[]
+				| undefined;
+			expect( painted?.map( ( i ) => i.id ) ).toEqual( [ 'jorvy' ] );
+			// No `dock-core:*` entries — the wallpaper is available in
+			// this layout, but it is not where core menus live.
+			expect(
+				painted?.some( ( i ) => i.id.startsWith( 'dock-core:' ) ),
+			).toBe( false );
+		} );
+
+		test( 'core-affinity system tiles land on the primary rail', () => {
+			const { deps } = makeDeps();
+			const dispatcher = createLayoutDispatcher(
+				deps,
+				'openstation',
+				[ dashboard ],
+				[],
+			);
+			dispatcher.appendSystemTile( noopTile, 'core' );
+			expect(
+				document
+					.getElementById( 'os-dock' )!
+					.querySelector( '[data-system-id="desktop-mode-os-settings"]' ),
+			).not.toBeNull();
+			expect( document.getElementById( 'os-side-dock' ) ).toBeNull();
+		} );
+
+		test( 'setLayout: classic → openstation tears the side dock down', () => {
+			const { deps } = makeDeps();
+			const dispatcher = createLayoutDispatcher(
+				deps,
+				'classic',
+				[ dashboard, yoast ],
+				[],
+			);
+			expect( document.getElementById( 'os-side-dock' ) ).not.toBeNull();
+			dispatcher.setLayout( 'openstation' );
+			expect( document.getElementById( 'os-side-dock' ) ).toBeNull();
+			expect( dispatcher.getLayout() ).toBe( 'openstation' );
+			expect( railSequence() ).toEqual( [
+				'index.php',
+				'--',
+				'wpseo_dashboard',
+			] );
+		} );
 	} );
 
 	test( 'spatial: drops non-pinned server icons without an override', () => {

--- a/tests/vitest/dock-constellation.test.ts
+++ b/tests/vitest/dock-constellation.test.ts
@@ -113,12 +113,21 @@ function pointerOver(): Event {
 	return ev;
 }
 
+/**
+ * Hover a tile and let the flyout come up — but NOT long enough for
+ * any exit or hand-off already in flight to finish. Time is advanced
+ * rather than flushed precisely so a test can observe both panels
+ * during a hand-off; `flushExit()` is how you get to "and then it's
+ * gone".
+ */
 function hover( tile: HTMLElement ): void {
 	tile.dispatchEvent( pointerOver() );
-	vi.runOnlyPendingTimers();
-	// The open transition is applied on the next frame; jsdom's rAF is
-	// a timer, so flushing again lands the `--open` class too.
-	vi.runOnlyPendingTimers();
+	// Past the show dwell (130ms), short of the exit (160) and the
+	// hand-off (200).
+	vi.advanceTimersByTime( 140 );
+	// The open class + the slide land on the next frame; jsdom's rAF
+	// is a timer here, so step once more to paint them.
+	vi.advanceTimersByTime( 5 );
 }
 
 /**
@@ -139,16 +148,27 @@ function ghost(): HTMLElement | null {
 	);
 }
 
-/** Let any in-flight exit finish and its node leave the document. */
+/** Let any in-flight exit or hand-off finish and its node leave. */
 function flushExit(): void {
-	vi.runOnlyPendingTimers();
+	vi.advanceTimersByTime( 400 );
+}
+
+/**
+ * Query inside the LIVE panel. Every row query has to be scoped: a
+ * retiring panel is still in the document with a full set of rows,
+ * and an unscoped `querySelectorAll` would collect both.
+ */
+function rows( selector: string ): HTMLElement[] {
+	const live = panel();
+	if ( ! live ) {
+		return [];
+	}
+	return Array.from( live.querySelectorAll< HTMLElement >( selector ) );
 }
 
 function rowLabels(): string[] {
-	return Array.from(
-		document.querySelectorAll< HTMLElement >(
-			'.os-constellation__row--sub .os-constellation__row-label',
-		),
+	return rows(
+		'.os-constellation__row--sub .os-constellation__row-label',
 	).map( ( el ) => el.textContent ?? '' );
 }
 
@@ -176,11 +196,46 @@ describe( 'dock constellation', () => {
 		document.body.className = '';
 	} );
 
-	function mount(): void {
+	function mountWith( items: DockItem[] ): void {
 		teardown = mountDockConstellation( {
 			windowManager: makeManagerStub(),
 			adminUrl: '/wp-admin/',
-			getMenuItems: () => [ appearance ],
+			getMenuItems: () => items,
+		} );
+	}
+
+	function mount(): void {
+		mountWith( [ appearance ] );
+	}
+
+	/** Append a second menu tile to the rail. */
+	function addTile( slug: string ): HTMLElement {
+		const tile = document.createElement( 'div' );
+		tile.className = 'os-dock__item';
+		tile.dataset.menuSlug = slug;
+		tile.appendChild( document.createElement( 'button' ) );
+		document.querySelector( '.os-dock' )!.appendChild( tile );
+		return tile;
+	}
+
+	/**
+	 * jsdom reports a zero rect for every element, which would put two
+	 * adjacent tiles at the same x and make "did the panel travel?"
+	 * unanswerable. Give a tile a real box.
+	 */
+	function placeTile( tile: HTMLElement, left: number ): void {
+		Object.defineProperty( tile, 'getBoundingClientRect', {
+			configurable: true,
+			value: () => ( {
+				left,
+				right: left + 40,
+				top: 600,
+				bottom: 640,
+				width: 40,
+				height: 40,
+				x: left,
+				y: 600,
+			} ),
 		} );
 	}
 
@@ -215,17 +270,13 @@ describe( 'dock constellation', () => {
 		mount();
 		hover( tile );
 
-		document
-			.querySelector< HTMLElement >( '.os-constellation__head' )!
-			.click();
+		rows( '.os-constellation__head' )[ 0 ].click();
 		expect( opened.at( -1 )?.url ).toBe( '/wp-admin/themes.php' );
 		expect( panel() ).toBeNull();
 
+		flushExit();
 		hover( tile );
-		const rows = document.querySelectorAll< HTMLElement >(
-			'.os-constellation__row--sub',
-		);
-		rows[ 1 ].click();
+		rows( '.os-constellation__row--sub' )[ 1 ].click();
 		// `parentUrl` pins to the MENU's landing page, not the child —
 		// otherwise the window's tab strip has no way back to Themes.
 		expect( opened.at( -1 )?.url ).toBe( '/wp-admin/site-editor.php' );
@@ -236,11 +287,9 @@ describe( 'dock constellation', () => {
 		const tile = setupShell( 'openstation' );
 		mount();
 		hover( tile );
-		const newRow = document.querySelector< HTMLElement >(
-			'.os-constellation__row--new',
-		);
-		expect( newRow?.textContent ).toContain( 'Appearance' );
-		newRow!.click();
+		const newRow = rows( '.os-constellation__row--new' )[ 0 ];
+		expect( newRow.textContent ).toContain( 'Appearance' );
+		newRow.click();
 		expect( opened.at( -1 )?.multi ).toBe( true );
 	} );
 
@@ -254,10 +303,10 @@ describe( 'dock constellation', () => {
 		primary.dispatchEvent(
 			new KeyboardEvent( 'keydown', { key: 'ArrowUp', bubbles: true } ),
 		);
-		vi.runOnlyPendingTimers();
+		vi.advanceTimersByTime( 5 );
 		expect( panel() ).not.toBeNull();
 		expect( document.activeElement ).toBe(
-			document.querySelector( '.os-constellation__row' ),
+			rows( '.os-constellation__row' )[ 0 ],
 		);
 	} );
 
@@ -265,9 +314,7 @@ describe( 'dock constellation', () => {
 		const tile = setupShell( 'openstation' );
 		mount();
 		hover( tile );
-		const row = document.querySelector< HTMLElement >(
-			'.os-constellation__row',
-		)!;
+		const row = rows( '.os-constellation__row' )[ 0 ];
 		row.focus();
 		row.dispatchEvent(
 			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ),
@@ -287,9 +334,7 @@ describe( 'dock constellation', () => {
 			const tile = setupShell( 'openstation' );
 			mount();
 			hover( tile );
-			document
-				.querySelector< HTMLElement >( '.os-constellation__head' )!
-				.click();
+			rows( '.os-constellation__head' )[ 0 ].click();
 
 			// No longer the live panel, but still painted — marked
 			// `--closing` so CSS can run the exit, and no longer the
@@ -316,9 +361,7 @@ describe( 'dock constellation', () => {
 			const tile = setupShell( 'openstation' );
 			mount();
 			hover( tile );
-			document
-				.querySelector< HTMLElement >( '.os-constellation__head' )!
-				.click();
+			rows( '.os-constellation__head' )[ 0 ].click();
 			// The `--open` class is what drives the per-row staggered
 			// entrance; dropping it without `--closing` taking over
 			// would send every row back through its own exit inside a
@@ -332,34 +375,76 @@ describe( 'dock constellation', () => {
 			).toBe( true );
 		} );
 
-		test( 'a hand-off to another tile cuts instead of fading', () => {
+		/**
+		 * The hand-off is the case a plain close-then-open gets wrong:
+		 * moving along the rail read as the menu blinking out and a
+		 * different one blinking in. It has to read as ONE menu
+		 * travelling and changing contents.
+		 */
+		test( 'a hand-off slides and cross-fades instead of blinking', () => {
 			const tile = setupShell( 'openstation' );
-			const dock = document.querySelector( '.os-dock' )!;
-			const other = document.createElement( 'div' );
-			other.className = 'os-dock__item';
-			other.dataset.menuSlug = 'options-general.php';
-			other.appendChild( document.createElement( 'button' ) );
-			dock.appendChild( other );
-
-			teardown = mountDockConstellation( {
-				windowManager: makeManagerStub(),
-				adminUrl: '/wp-admin/',
-				getMenuItems: () => [ appearance, settings ],
-			} );
+			const other = addTile( 'options-general.php' );
+			placeTile( tile, 100 );
+			placeTile( other, 160 );
+			mountWith( [ appearance, settings ] );
 
 			hover( tile );
 			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
 				'Appearance',
 			);
+			const fromX = panel()!.style.left;
+
 			hover( other );
-			// One panel on screen, not two at two different anchors.
+
+			// Both panels are on screen mid-travel: the outgoing one
+			// marked as retiring, the incoming one live and already
+			// showing the new menu.
+			const dying = ghost()!;
+			expect( dying ).not.toBeNull();
+			expect(
+				dying.classList.contains( 'os-constellation--handoff' ),
+			).toBe( true );
+			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
+				'Settings',
+			);
+			expect(
+				panel()?.classList.contains( 'os-constellation--handoff' ),
+			).toBe( true );
+
+			// They travel together: the outgoing panel has been walked
+			// to the incoming one's anchor, so the pair moves as one
+			// object rather than one vanishing beside another.
+			expect( panel()!.style.left ).not.toBe( fromX );
+			expect( dying.style.left ).toBe( panel()!.style.left );
+
+			flushExit();
 			expect( ghost() ).toBeNull();
 			expect(
 				document.querySelectorAll( '.os-constellation' ),
 			).toHaveLength( 1 );
-			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
-				'Settings',
-			);
+			// And once it has landed it stops being a hand-off, so the
+			// NEXT dismissal gets the fall-into-the-rail exit.
+			expect(
+				panel()?.classList.contains( 'os-constellation--handoff' ),
+			).toBe( false );
+		} );
+
+		test( 'the incoming panel is born at the outgoing one’s anchor', () => {
+			const tile = setupShell( 'openstation' );
+			const other = addTile( 'options-general.php' );
+			placeTile( tile, 100 );
+			placeTile( other, 160 );
+			mountWith( [ appearance, settings ] );
+
+			hover( tile );
+			const fromX = panel()!.style.left;
+			expect( fromX ).toBe( '120px' );
+
+			// Step far enough to run the show timer but stop before the
+			// frame that walks the new panel to its own anchor.
+			other.dispatchEvent( pointerOver() );
+			vi.advanceTimersByTime( 0 );
+			expect( panel()!.style.left ).toBe( fromX );
 		} );
 
 		test( 'a stale anchor cuts too — scroll invalidates the position', () => {

--- a/tests/vitest/dock-constellation.test.ts
+++ b/tests/vitest/dock-constellation.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for `src/dock-constellation` — the hover-submenu flyout that
+ * gives the OpenStation desktop layout its reason to exist.
+ *
+ * What is pinned here is the CONTRACT, not the choreography:
+ *
+ * - It only fans out while `data-os-layout="openstation"`. Every
+ *   other layout keeps the hover-peek, and the peek's stand-down
+ *   check reads the same predicate, so a regression in either
+ *   direction shows up as two popovers on one tile or none.
+ * - It surfaces the submenu — the whole point. A menu with children
+ *   gets one row per child, wired to the same window ids a dock click
+ *   would address.
+ * - It is delegated, so a tile rebuilt by a live menu refresh still
+ *   works without re-mounting anything.
+ * - Keyboard reaches it: ArrowUp from a tile fans it open and lands
+ *   focus on the first row; Escape collapses it and hands focus back.
+ *
+ * Timers are faked because the flyout deliberately dwells before it
+ * opens — a hover that fired instantly would fan a panel out every
+ * time the pointer crossed the rail on its way somewhere else.
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from 'vitest';
+import { mountDockConstellation } from '../../src/dock-constellation';
+import { isConstellationLayoutActive } from '../../src/dock-constellation/active';
+import type { DockItem } from '../../src/dock';
+import type { WindowManager } from '../../src/window-manager';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+const appearance: DockItem = {
+	id: 'themes.php',
+	title: 'Appearance',
+	icon: 'dashicons-admin-appearance',
+	url: '/wp-admin/themes.php',
+	badge: 0,
+	isCore: true,
+	multi: false,
+	submenu: [
+		{ title: 'Themes', url: '/wp-admin/themes.php' },
+		{ title: 'Editor', url: '/wp-admin/site-editor.php' },
+	],
+};
+
+const opened: Array< Record< string, unknown > > = [];
+
+function makeManagerStub(): WindowManager {
+	return {
+		getAllByBaseIdOnActiveDesktop: () => [],
+		getActiveDesktopId: () => 'default-1',
+		getFocused: () => null,
+		getById: () => undefined,
+		focus: () => {},
+		open: ( cfg: Record< string, unknown > ) => {
+			opened.push( cfg );
+		},
+		openNew: ( cfg: Record< string, unknown > ) => {
+			opened.push( cfg );
+			return Promise.resolve( null );
+		},
+	} as unknown as WindowManager;
+}
+
+/** Build a shell with one menu tile on the bottom rail. */
+function setupShell( layout: string ): HTMLElement {
+	document.body.innerHTML = '';
+	const shell = document.createElement( 'div' );
+	shell.className = 'os-shell';
+	shell.setAttribute( 'data-os-layout', layout );
+
+	const dock = document.createElement( 'nav' );
+	dock.className = 'os-dock';
+	dock.setAttribute( 'data-os-dock-placement', 'bottom' );
+
+	const tile = document.createElement( 'div' );
+	tile.className = 'os-dock__item';
+	tile.dataset.menuSlug = 'themes.php';
+	const primary = document.createElement( 'button' );
+	primary.className = 'os-dock__item-primary';
+	tile.appendChild( primary );
+
+	dock.appendChild( tile );
+	shell.appendChild( dock );
+	document.body.appendChild( shell );
+	return tile;
+}
+
+/**
+ * jsdom ships no `PointerEvent`, so synthesize one: a bubbling
+ * `Event` with `pointerType` bolted on, which is the only
+ * pointer-specific field the constellation reads.
+ */
+function pointerOver(): Event {
+	const ev = new Event( 'pointerover', { bubbles: true } );
+	Object.defineProperty( ev, 'pointerType', { value: 'mouse' } );
+	return ev;
+}
+
+function hover( tile: HTMLElement ): void {
+	tile.dispatchEvent( pointerOver() );
+	vi.runOnlyPendingTimers();
+	// The open transition is applied on the next frame; jsdom's rAF is
+	// a timer, so flushing again lands the `--open` class too.
+	vi.runOnlyPendingTimers();
+}
+
+function panel(): HTMLElement | null {
+	return document.querySelector< HTMLElement >( '.os-constellation' );
+}
+
+function rowLabels(): string[] {
+	return Array.from(
+		document.querySelectorAll< HTMLElement >(
+			'.os-constellation__row--sub .os-constellation__row-label',
+		),
+	).map( ( el ) => el.textContent ?? '' );
+}
+
+describe( 'dock constellation', () => {
+	let teardown: () => void;
+
+	beforeEach( () => {
+		opened.length = 0;
+		installHooksStub();
+		vi.useFakeTimers();
+		// jsdom has no rAF by default under fake timers; route it
+		// through a timer so `runOnlyPendingTimers` flushes the frame
+		// the open transition waits for.
+		vi.stubGlobal( 'requestAnimationFrame', ( cb: FrameRequestCallback ) =>
+			setTimeout( () => cb( 0 ), 0 ) as unknown as number,
+		);
+	} );
+
+	afterEach( () => {
+		teardown?.();
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		clearHooksStub();
+		document.body.innerHTML = '';
+		document.body.className = '';
+	} );
+
+	function mount(): void {
+		teardown = mountDockConstellation( {
+			windowManager: makeManagerStub(),
+			adminUrl: '/wp-admin/',
+			getMenuItems: () => [ appearance ],
+		} );
+	}
+
+	test( 'is inert outside the OpenStation layout', () => {
+		const tile = setupShell( 'classic' );
+		mount();
+		hover( tile );
+		expect( panel() ).toBeNull();
+		expect( isConstellationLayoutActive() ).toBe( false );
+	} );
+
+	test( 'fans out on hover and lists the submenu', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+		expect( panel() ).not.toBeNull();
+		expect( rowLabels() ).toEqual( [ 'Themes', 'Editor' ] );
+		expect( panel()?.getAttribute( 'role' ) ).toBe( 'menu' );
+		expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
+			'Appearance',
+		);
+		// The tile is marked so CSS can keep it lifted, and the body
+		// flag mutes the dock tooltip underneath.
+		expect( tile.hasAttribute( 'data-constellation-open' ) ).toBe( true );
+		expect(
+			document.body.classList.contains( 'os-constellation-open' ),
+		).toBe( true );
+	} );
+
+	test( 'head opens the menu; a submenu row opens its child page', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+
+		document
+			.querySelector< HTMLElement >( '.os-constellation__head' )!
+			.click();
+		expect( opened.at( -1 )?.url ).toBe( '/wp-admin/themes.php' );
+		expect( panel() ).toBeNull();
+
+		hover( tile );
+		const rows = document.querySelectorAll< HTMLElement >(
+			'.os-constellation__row--sub',
+		);
+		rows[ 1 ].click();
+		// `parentUrl` pins to the MENU's landing page, not the child —
+		// otherwise the window's tab strip has no way back to Themes.
+		expect( opened.at( -1 )?.url ).toBe( '/wp-admin/site-editor.php' );
+		expect( opened.at( -1 )?.parentUrl ).toBe( '/wp-admin/themes.php' );
+	} );
+
+	test( 'offers a trailing new-window row', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+		const newRow = document.querySelector< HTMLElement >(
+			'.os-constellation__row--new',
+		);
+		expect( newRow?.textContent ).toContain( 'Appearance' );
+		newRow!.click();
+		expect( opened.at( -1 )?.multi ).toBe( true );
+	} );
+
+	test( 'ArrowUp from a tile opens it and lands focus on the first row', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		const primary = tile.querySelector< HTMLElement >(
+			'.os-dock__item-primary',
+		)!;
+		primary.focus();
+		primary.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'ArrowUp', bubbles: true } ),
+		);
+		vi.runOnlyPendingTimers();
+		expect( panel() ).not.toBeNull();
+		expect( document.activeElement ).toBe(
+			document.querySelector( '.os-constellation__row' ),
+		);
+	} );
+
+	test( 'Escape collapses the flyout and hands focus back to the tile', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+		const row = document.querySelector< HTMLElement >(
+			'.os-constellation__row',
+		)!;
+		row.focus();
+		row.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ),
+		);
+		expect( panel() ).toBeNull();
+		expect( document.activeElement ).toBe(
+			tile.querySelector( '.os-dock__item-primary' ),
+		);
+		expect(
+			document.body.classList.contains( 'os-constellation-open' ),
+		).toBe( false );
+	} );
+
+	test( 'survives a tile rebuilt under it — the listener is delegated', () => {
+		setupShell( 'openstation' );
+		mount();
+		// Simulate a live menu refresh: throw the rail's tiles away and
+		// build a fresh one. A per-tile listener would be gone by now.
+		const dock = document.querySelector( '.os-dock' )!;
+		dock.innerHTML = '';
+		const rebuilt = document.createElement( 'div' );
+		rebuilt.className = 'os-dock__item';
+		rebuilt.dataset.menuSlug = 'themes.php';
+		rebuilt.appendChild( document.createElement( 'button' ) );
+		dock.appendChild( rebuilt );
+
+		hover( rebuilt );
+		expect( rowLabels() ).toEqual( [ 'Themes', 'Editor' ] );
+	} );
+
+	test( 'teardown removes the flyout and stops responding', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+		expect( panel() ).not.toBeNull();
+		teardown();
+		expect( panel() ).toBeNull();
+		hover( tile );
+		expect( panel() ).toBeNull();
+	} );
+} );

--- a/tests/vitest/dock-constellation.test.ts
+++ b/tests/vitest/dock-constellation.test.ts
@@ -329,7 +329,7 @@ describe( 'dock constellation', () => {
 		).toBe( false );
 	} );
 
-	describe( 'exit', () => {
+	describe( 'leaving', () => {
 		test( 'plays an exit before the node leaves the document', () => {
 			const tile = setupShell( 'openstation' );
 			mount();
@@ -376,12 +376,13 @@ describe( 'dock constellation', () => {
 		} );
 
 		/**
-		 * The hand-off is the case a plain close-then-open gets wrong:
-		 * moving along the rail read as the menu blinking out and a
-		 * different one blinking in. It has to read as ONE menu
-		 * travelling and changing contents.
+		 * Moving along the rail is TWO panels, each animating at its
+		 * own tile — not one panel sliding across and swapping its
+		 * contents. The outgoing one has to get a real dismissal, and
+		 * it has to keep its own anchor while it plays, or its beam
+		 * ends up pointing at a tile it has nothing to do with.
 		 */
-		test( 'a hand-off slides and cross-fades instead of blinking', () => {
+		test( 'moving to another tile dismisses the old menu where it stands', () => {
 			const tile = setupShell( 'openstation' );
 			const other = addTile( 'options-general.php' );
 			placeTile( tile, 100 );
@@ -392,59 +393,53 @@ describe( 'dock constellation', () => {
 			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
 				'Appearance',
 			);
-			const fromX = panel()!.style.left;
 
 			hover( other );
 
-			// Both panels are on screen mid-travel: the outgoing one
-			// marked as retiring, the incoming one live and already
-			// showing the new menu.
-			const dying = ghost()!;
+			// The old menu is still on screen, playing its exit, and
+			// still anchored over the tile it belongs to.
+			const dying = ghost();
 			expect( dying ).not.toBeNull();
-			expect(
-				dying.classList.contains( 'os-constellation--handoff' ),
-			).toBe( true );
+			expect( dying?.getAttribute( 'aria-label' ) ).toContain(
+				'Appearance',
+			);
+			expect( dying!.style.left ).toBe( '120px' );
+
+			// The new one is live over ITS tile, playing its entrance.
 			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
 				'Settings',
 			);
+			expect( panel()!.style.left ).toBe( '180px' );
 			expect(
-				panel()?.classList.contains( 'os-constellation--handoff' ),
+				panel()?.classList.contains( 'os-constellation--open' ),
 			).toBe( true );
-
-			// They travel together: the outgoing panel has been walked
-			// to the incoming one's anchor, so the pair moves as one
-			// object rather than one vanishing beside another.
-			expect( panel()!.style.left ).not.toBe( fromX );
-			expect( dying.style.left ).toBe( panel()!.style.left );
 
 			flushExit();
 			expect( ghost() ).toBeNull();
 			expect(
 				document.querySelectorAll( '.os-constellation' ),
 			).toHaveLength( 1 );
-			// And once it has landed it stops being a hand-off, so the
-			// NEXT dismissal gets the fall-into-the-rail exit.
-			expect(
-				panel()?.classList.contains( 'os-constellation--handoff' ),
-			).toBe( false );
 		} );
 
-		test( 'the incoming panel is born at the outgoing one’s anchor', () => {
+		test( 'the tile being left un-lifts while its menu is still leaving', () => {
 			const tile = setupShell( 'openstation' );
 			const other = addTile( 'options-general.php' );
-			placeTile( tile, 100 );
-			placeTile( other, 160 );
 			mountWith( [ appearance, settings ] );
 
 			hover( tile );
-			const fromX = panel()!.style.left;
-			expect( fromX ).toBe( '120px' );
+			expect( tile.hasAttribute( 'data-constellation-open' ) ).toBe(
+				true,
+			);
 
-			// Step far enough to run the show timer but stop before the
-			// frame that walks the new panel to its own anchor.
-			other.dispatchEvent( pointerOver() );
-			vi.advanceTimersByTime( 0 );
-			expect( panel()!.style.left ).toBe( fromX );
+			hover( other );
+			// Only one tile is ever marked as hosting the menu, even
+			// while two panels are painted.
+			expect( tile.hasAttribute( 'data-constellation-open' ) ).toBe(
+				false,
+			);
+			expect( other.hasAttribute( 'data-constellation-open' ) ).toBe(
+				true,
+			);
 		} );
 
 		test( 'a stale anchor cuts too — scroll invalidates the position', () => {

--- a/tests/vitest/dock-constellation.test.ts
+++ b/tests/vitest/dock-constellation.test.ts
@@ -48,6 +48,17 @@ const appearance: DockItem = {
 	],
 };
 
+const settings: DockItem = {
+	id: 'options-general.php',
+	title: 'Settings',
+	icon: 'dashicons-admin-settings',
+	url: '/wp-admin/options-general.php',
+	badge: 0,
+	isCore: true,
+	multi: false,
+	submenu: [ { title: 'Writing', url: '/wp-admin/options-writing.php' } ],
+};
+
 const opened: Array< Record< string, unknown > > = [];
 
 function makeManagerStub(): WindowManager {
@@ -110,8 +121,27 @@ function hover( tile: HTMLElement ): void {
 	vi.runOnlyPendingTimers();
 }
 
+/**
+ * The LIVE panel. A dismissed panel stays in the document for the
+ * length of its exit, so "is a flyout open?" has to exclude anything
+ * already on its way out.
+ */
 function panel(): HTMLElement | null {
-	return document.querySelector< HTMLElement >( '.os-constellation' );
+	return document.querySelector< HTMLElement >(
+		'.os-constellation:not( .os-constellation--closing )',
+	);
+}
+
+/** A panel mid-exit — present, marked, and no longer interactive. */
+function ghost(): HTMLElement | null {
+	return document.querySelector< HTMLElement >(
+		'.os-constellation--closing',
+	);
+}
+
+/** Let any in-flight exit finish and its node leave the document. */
+function flushExit(): void {
+	vi.runOnlyPendingTimers();
 }
 
 function rowLabels(): string[] {
@@ -246,9 +276,117 @@ describe( 'dock constellation', () => {
 		expect( document.activeElement ).toBe(
 			tile.querySelector( '.os-dock__item-primary' ),
 		);
+		flushExit();
 		expect(
 			document.body.classList.contains( 'os-constellation-open' ),
 		).toBe( false );
+	} );
+
+	describe( 'exit', () => {
+		test( 'plays an exit before the node leaves the document', () => {
+			const tile = setupShell( 'openstation' );
+			mount();
+			hover( tile );
+			document
+				.querySelector< HTMLElement >( '.os-constellation__head' )!
+				.click();
+
+			// No longer the live panel, but still painted — marked
+			// `--closing` so CSS can run the exit, and no longer the
+			// anchor's business.
+			expect( panel() ).toBeNull();
+			expect( ghost() ).not.toBeNull();
+			expect( tile.hasAttribute( 'data-constellation-open' ) ).toBe(
+				false,
+			);
+			// The tooltip stays muted while a panel is still visible,
+			// or it pops back underneath one that is fading over it.
+			expect(
+				document.body.classList.contains( 'os-constellation-open' ),
+			).toBe( true );
+
+			flushExit();
+			expect( ghost() ).toBeNull();
+			expect(
+				document.body.classList.contains( 'os-constellation-open' ),
+			).toBe( false );
+		} );
+
+		test( 'rows do not animate independently while the panel leaves', () => {
+			const tile = setupShell( 'openstation' );
+			mount();
+			hover( tile );
+			document
+				.querySelector< HTMLElement >( '.os-constellation__head' )!
+				.click();
+			// The `--open` class is what drives the per-row staggered
+			// entrance; dropping it without `--closing` taking over
+			// would send every row back through its own exit inside a
+			// panel that is itself shrinking.
+			const dying = ghost()!;
+			expect( dying.classList.contains( 'os-constellation--open' ) ).toBe(
+				false,
+			);
+			expect(
+				dying.classList.contains( 'os-constellation--closing' ),
+			).toBe( true );
+		} );
+
+		test( 'a hand-off to another tile cuts instead of fading', () => {
+			const tile = setupShell( 'openstation' );
+			const dock = document.querySelector( '.os-dock' )!;
+			const other = document.createElement( 'div' );
+			other.className = 'os-dock__item';
+			other.dataset.menuSlug = 'options-general.php';
+			other.appendChild( document.createElement( 'button' ) );
+			dock.appendChild( other );
+
+			teardown = mountDockConstellation( {
+				windowManager: makeManagerStub(),
+				adminUrl: '/wp-admin/',
+				getMenuItems: () => [ appearance, settings ],
+			} );
+
+			hover( tile );
+			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
+				'Appearance',
+			);
+			hover( other );
+			// One panel on screen, not two at two different anchors.
+			expect( ghost() ).toBeNull();
+			expect(
+				document.querySelectorAll( '.os-constellation' ),
+			).toHaveLength( 1 );
+			expect( panel()?.getAttribute( 'aria-label' ) ).toContain(
+				'Settings',
+			);
+		} );
+
+		test( 'a stale anchor cuts too — scroll invalidates the position', () => {
+			const tile = setupShell( 'openstation' );
+			mount();
+			hover( tile );
+			document.dispatchEvent( new Event( 'scroll', { bubbles: true } ) );
+			// Animating away from a tile that has already moved points
+			// at nothing, so this path removes the node outright.
+			expect( ghost() ).toBeNull();
+			expect( panel() ).toBeNull();
+		} );
+
+		test( 'teardown takes an in-flight exit with it', () => {
+			const tile = setupShell( 'openstation' );
+			mount();
+			hover( tile );
+			document
+				.querySelector< HTMLElement >( '.os-constellation__head' )!
+				.click();
+			expect( ghost() ).not.toBeNull();
+			teardown();
+			expect( document.querySelector( '.os-constellation' ) ).toBeNull();
+			expect(
+				document.body.classList.contains( 'os-constellation-open' ),
+			).toBe( false );
+		} );
 	} );
 
 	test( 'survives a tile rebuilt under it — the listener is delegated', () => {

--- a/tests/vitest/dock-constellation.test.ts
+++ b/tests/vitest/dock-constellation.test.ts
@@ -223,18 +223,22 @@ describe( 'dock constellation', () => {
 	 * adjacent tiles at the same x and make "did the panel travel?"
 	 * unanswerable. Give a tile a real box.
 	 */
-	function placeTile( tile: HTMLElement, left: number ): void {
+	function placeTile(
+		tile: HTMLElement,
+		left: number,
+		top = 600,
+	): void {
 		Object.defineProperty( tile, 'getBoundingClientRect', {
 			configurable: true,
 			value: () => ( {
 				left,
 				right: left + 40,
-				top: 600,
-				bottom: 640,
+				top,
+				bottom: top + 40,
 				width: 40,
 				height: 40,
 				x: left,
-				y: 600,
+				y: top,
 			} ),
 		} );
 	}
@@ -467,6 +471,70 @@ describe( 'dock constellation', () => {
 				document.body.classList.contains( 'os-constellation-open' ),
 			).toBe( false );
 		} );
+	} );
+
+	test( 'is one tab stop, not one per row', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+		// Roving tabindex. Arrow keys move between rows; Tab leaves the
+		// menu. Without this a fifteen-child submenu would put fifteen
+		// stops between the dock and whatever follows it.
+		const all = rows( '.os-constellation__row' );
+		expect( all.length ).toBeGreaterThan( 1 );
+		expect( all.every( ( r ) => r.tabIndex === -1 ) ).toBe( true );
+	} );
+
+	test( 'Tab leaves the menu and puts focus back on the rail', () => {
+		const tile = setupShell( 'openstation' );
+		mount();
+		hover( tile );
+		const row = rows( '.os-constellation__row' )[ 0 ];
+		row.focus();
+		const ev = new KeyboardEvent( 'keydown', {
+			key: 'Tab',
+			bubbles: true,
+			cancelable: true,
+		} );
+		row.dispatchEvent( ev );
+
+		expect( panel() ).toBeNull();
+		// Focus lands on the tile, not `<body>` — the browser then
+		// continues tabbing from the rail's own place in the document
+		// rather than restarting at the top of the page. And the
+		// default is NOT prevented, or that onward move never happens.
+		expect( document.activeElement ).toBe(
+			tile.querySelector( '.os-dock__item-primary' ),
+		);
+		expect( ev.defaultPrevented ).toBe( false );
+	} );
+
+	test( 'caps its height to the room above the tile', () => {
+		const tile = setupShell( 'openstation' );
+		// A dock 700px down a viewport: 700 − 14 beam gap − 12 margin.
+		placeTile( tile, 100, 700 );
+		mount();
+		hover( tile );
+		// The panel hangs off the top of the dock and cannot be nudged
+		// downwards to fit — that would push it over the rail — so a
+		// menu too tall for the space is capped and its submenu group
+		// takes the scroll instead.
+		expect(
+			panel()!.style.getPropertyValue( '--os-cn-max-h' ),
+		).toBe( '674px' );
+	} );
+
+	test( 'never caps below a usable height on a short viewport', () => {
+		const tile = setupShell( 'openstation' );
+		// A tile 60px from the top leaves 34px — at which point a panel
+		// has stopped being a menu and become a scrollbar with a title
+		// on it, so the floor wins and it overflows slightly instead.
+		placeTile( tile, 100, 60 );
+		mount();
+		hover( tile );
+		expect(
+			panel()!.style.getPropertyValue( '--os-cn-max-h' ),
+		).toBe( '160px' );
 	} );
 
 	test( 'survives a tile rebuilt under it — the listener is delegated', () => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/5a8b6f28-d297-4339-852b-25d598e2bf3d

A fourth desktop layout, picked from **OpenStation Preferences → Appearance**.

## Everything on the bottom dock, in two groups

One rail holds every menu. WordPress core comes first, then a divider, then your plugins — a luminous seam with a breathing node on it, rather than a hairline. The wallpaper is still available for icons; it just isn't load-bearing the way it is in Spatial.

## Submenus, on hover

Every other layout drops a menu's submenu at the dock: the tile opens the landing page, and the child pages are only reachable once you're already inside the window, through its tab strip. The tab strip is untouched — this adds the shortcut in front of it.

Hovering a tile fans out a **constellation**: the menu's own page, its open windows, one row per submenu entry, and a "new window" row. It routes through the same window ids a dock click does, so the flyout and the tile share one window rather than opening two.

Mouse and keyboard — `ArrowUp` from a focused tile opens it, arrows rove, `Escape` collapses and hands focus back.

## Screens

| | |
|---|---|
| Rail | WordPress cluster → seam → plugin cluster → system tiles |
| Hover | Panel fans up over the tile, beam tying it to the rail |
| Moving along the rail | Old menu dismisses over its tile, new one rises over its own |

## Notes

- Scoped to this layout: the constellation self-gates on `data-os-layout`, so every other layout pays one early-returning listener and an inert stylesheet.
- New JS hooks: `os.constellation.panel` (filter), `.opened` / `.closed` (actions).
- Themeable via `--os-cn-*` tokens in `variables.css`.
- Docs updated: `javascript-reference.md`, `architecture.md`, `api-index.md`, `desktop-themes.md`.

## Testing

- 4088 vitest ✅ · 2132 PHPUnit ✅ · eslint ✅ · tsc ✅ · phpcs ✅
- 21 new cases across the layout dispatcher and the constellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-544-c76d335751e1158f62c0d14cb594819081a82249.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->