### PR TITLE
Add docblocks to desktop-file type classes and REST handlers

### DIFF
--- a/includes/desktop-files/types/class-openstation-attachment-file.php
+++ b/includes/desktop-files/types/class-openstation-attachment-file.php
@@ -12,14 +12,30 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Attachment_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'attachment';
 	}
 
+	/**
+	 * Whether the attachment post still exists.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return $this->attachment() instanceof WP_Post;
 	}
 
+	/**
+	 * Get a label from the attachment title or fall back to the
+	 * filename.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$post = $this->attachment();
 		if ( ! $post ) {
@@ -29,6 +45,12 @@ class OpenStation_Attachment_File extends OpenStation_File {
 		return wp_strip_all_tags( '' !== $title ? $title : basename( (string) get_attached_file( $post->ID ) ) );
 	}
 
+	/**
+	 * Resolve a Dashicon class based on the attachment's mime-type
+	 * category.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		$post = $this->attachment();
 		if ( ! $post ) {
@@ -47,6 +69,11 @@ class OpenStation_Attachment_File extends OpenStation_File {
 		}
 	}
 
+	/**
+	 * Get the attachment's thumbnail URL for tile previews.
+	 *
+	 * @return string Empty string when no image source is available.
+	 */
 	public function preview_url(): string {
 		$post = $this->attachment();
 		if ( ! $post ) {
@@ -56,6 +83,12 @@ class OpenStation_Attachment_File extends OpenStation_File {
 		return is_array( $src ) ? (string) $src[0] : '';
 	}
 
+	/**
+	 * Check whether the given user can read this attachment.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		$post = $this->attachment();
 		if ( ! $post ) {
@@ -64,6 +97,12 @@ class OpenStation_Attachment_File extends OpenStation_File {
 		return user_can( $user_id, 'read_post', $post->ID );
 	}
 
+	/**
+	 * Augment the base serialized shape with mime type, source URL,
+	 * and alt text for block-editor drag handlers.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape         = parent::serialize();
 		$post          = $this->attachment();
@@ -78,6 +117,12 @@ class OpenStation_Attachment_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the underlying WP_Post, verifying it is an
+	 * attachment.
+	 *
+	 * @return WP_Post|null Null when the attachment is gone or the ref is invalid.
+	 */
 	private function attachment(): ?WP_Post {
 		$id = (int) $this->ref;
 		if ( $id <= 0 ) {

--- a/includes/desktop-files/types/class-openstation-bookmark-file.php
+++ b/includes/desktop-files/types/class-openstation-bookmark-file.php
@@ -18,14 +18,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Bookmark_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'bookmark';
 	}
 
+	/**
+	 * Whether the bookmark URL is non-empty.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return '' !== $this->url();
 	}
 
+	/**
+	 * Get a label from the bookmark URL's host.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$url = $this->url();
 		if ( '' === $url ) {
@@ -35,16 +50,31 @@ class OpenStation_Bookmark_File extends OpenStation_File {
 		return is_string( $host ) && '' !== $host ? $host : $url;
 	}
 
+	/**
+	 * Get the Dashicon class for bookmark tiles.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		return 'dashicons-admin-links';
 	}
 
+	/**
+	 * Augment the base serialized shape with the bookmark URL.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape        = parent::serialize();
 		$shape['url'] = $this->url();
 		return $shape;
 	}
 
+	/**
+	 * Sanitize the stored ref into a valid URL.
+	 *
+	 * @return string Empty string when the ref is not a valid URL.
+	 */
 	private function url(): string {
 		$url = esc_url_raw( $this->ref );
 		return is_string( $url ) ? $url : '';

--- a/includes/desktop-files/types/class-openstation-comment-file.php
+++ b/includes/desktop-files/types/class-openstation-comment-file.php
@@ -12,14 +12,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Comment_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'comment';
 	}
 
+	/**
+	 * Whether the comment still exists.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return $this->comment() instanceof WP_Comment;
 	}
 
+	/**
+	 * Get a label combining author name and a content excerpt.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$c = $this->comment();
 		if ( ! $c ) {
@@ -30,10 +45,22 @@ class OpenStation_Comment_File extends OpenStation_File {
 		return sprintf( '%s — %s', $author, $excerpt );
 	}
 
+	/**
+	 * Get the Dashicon class for comment tiles.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		return 'dashicons-admin-comments';
 	}
 
+	/**
+	 * Approved comments are public; unapproved comments require
+	 * the `moderate_comments` capability.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		$c = $this->comment();
 		if ( ! $c ) {
@@ -47,6 +74,12 @@ class OpenStation_Comment_File extends OpenStation_File {
 		return user_can( $user_id, 'moderate_comments' );
 	}
 
+	/**
+	 * Augment the base serialized shape with post id and approval
+	 * status.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape             = parent::serialize();
 		$c                 = $this->comment();
@@ -55,6 +88,11 @@ class OpenStation_Comment_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the underlying WP_Comment from the stored ref.
+	 *
+	 * @return WP_Comment|null Null when the comment is gone or the ref is invalid.
+	 */
 	private function comment(): ?WP_Comment {
 		$id = (int) $this->ref;
 		if ( $id <= 0 ) {

--- a/includes/desktop-files/types/class-openstation-embed-file.php
+++ b/includes/desktop-files/types/class-openstation-embed-file.php
@@ -21,14 +21,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Embed_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'embed';
 	}
 
+	/**
+	 * Whether the embed URL is non-empty.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return '' !== $this->url();
 	}
 
+	/**
+	 * Get a label from the embed URL's host.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$url = $this->url();
 		if ( '' === $url ) {
@@ -38,16 +53,31 @@ class OpenStation_Embed_File extends OpenStation_File {
 		return is_string( $host ) && '' !== $host ? $host : $url;
 	}
 
+	/**
+	 * Get the Dashicon class for embed tiles.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		return 'dashicons-welcome-view-site';
 	}
 
+	/**
+	 * Augment the base serialized shape with the embed URL.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape        = parent::serialize();
 		$shape['url'] = $this->url();
 		return $shape;
 	}
 
+	/**
+	 * Sanitize the stored ref into a valid URL.
+	 *
+	 * @return string Empty string when the ref is not a valid URL.
+	 */
 	private function url(): string {
 		$url = esc_url_raw( $this->ref );
 		return is_string( $url ) ? $url : '';

--- a/includes/desktop-files/types/class-openstation-folder-file.php
+++ b/includes/desktop-files/types/class-openstation-folder-file.php
@@ -17,14 +17,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Folder_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'folder';
 	}
 
+	/**
+	 * Whether the folder row still exists in the database.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return null !== $this->folder();
 	}
 
+	/**
+	 * Get the folder name, falling back to a generic label.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$row = $this->folder();
 		if ( ! $row ) {
@@ -33,10 +48,22 @@ class OpenStation_Folder_File extends OpenStation_File {
 		return '' !== (string) $row['name'] ? (string) $row['name'] : __( 'Folder', 'desktop-mode' );
 	}
 
+	/**
+	 * Get the Dashicon class for folder tiles.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		return 'dashicons-portfolio';
 	}
 
+	/**
+	 * Check whether the user owns the folder, has a direct share,
+	 * or reaches it via cascade from a parent folder.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		$row = $this->folder();
 		if ( ! $row ) {
@@ -60,6 +87,11 @@ class OpenStation_Folder_File extends OpenStation_File {
 		return in_array( (int) $row['id'], array_map( 'intval', (array) $visible_ids ), true );
 	}
 
+	/**
+	 * Augment the base serialized shape with owner id and share mode.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape              = parent::serialize();
 		$row                = $this->folder();
@@ -68,6 +100,11 @@ class OpenStation_Folder_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the folder row from the stored ref.
+	 *
+	 * @return array|null Null when the folder is gone or the ref is invalid.
+	 */
 	private function folder(): ?array {
 		$id = (int) $this->ref;
 		if ( $id <= 0 ) {

--- a/includes/desktop-files/types/class-openstation-link-file.php
+++ b/includes/desktop-files/types/class-openstation-link-file.php
@@ -18,14 +18,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Link_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'link';
 	}
 
+	/**
+	 * Whether the link URL is non-empty.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return '' !== $this->url();
 	}
 
+	/**
+	 * Get a label from the link URL's host.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$url = $this->url();
 		if ( '' === $url ) {
@@ -35,16 +50,31 @@ class OpenStation_Link_File extends OpenStation_File {
 		return is_string( $host ) && '' !== $host ? $host : $url;
 	}
 
+	/**
+	 * Get the Dashicon class for link tiles.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		return 'dashicons-admin-links';
 	}
 
+	/**
+	 * Augment the base serialized shape with the link URL.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape        = parent::serialize();
 		$shape['url'] = $this->url();
 		return $shape;
 	}
 
+	/**
+	 * Sanitize the stored ref into a valid URL.
+	 *
+	 * @return string Empty string when the ref is not a valid URL.
+	 */
 	private function url(): string {
 		$url = esc_url_raw( $this->ref );
 		return is_string( $url ) ? $url : '';

--- a/includes/desktop-files/types/class-openstation-post-file.php
+++ b/includes/desktop-files/types/class-openstation-post-file.php
@@ -17,14 +17,30 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Post_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'post';
 	}
 
+	/**
+	 * Whether the underlying post still exists.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return $this->post() instanceof WP_Post;
 	}
 
+	/**
+	 * Get a human-readable label, falling back to a placeholder
+	 * when the post is missing or has no title.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$post = $this->post();
 		if ( ! $post ) {
@@ -37,6 +53,12 @@ class OpenStation_Post_File extends OpenStation_File {
 		return '' !== $title ? $title : __( '(no title)', 'desktop-mode' );
 	}
 
+	/**
+	 * Resolve a Dashicon class for the post, preferring the
+	 * post-type's registered menu icon.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		$post = $this->post();
 		if ( ! $post ) {
@@ -49,6 +71,11 @@ class OpenStation_Post_File extends OpenStation_File {
 		return 'page' === $post->post_type ? 'dashicons-page' : 'dashicons-admin-post';
 	}
 
+	/**
+	 * Get the post's featured-image thumbnail URL, if any.
+	 *
+	 * @return string Empty string when no thumbnail is set.
+	 */
 	public function preview_url(): string {
 		$post = $this->post();
 		if ( ! $post ) {
@@ -62,6 +89,12 @@ class OpenStation_Post_File extends OpenStation_File {
 		return is_array( $src ) ? (string) $src[0] : '';
 	}
 
+	/**
+	 * Check whether the given user can read this post.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		$post = $this->post();
 		if ( ! $post ) {
@@ -70,6 +103,12 @@ class OpenStation_Post_File extends OpenStation_File {
 		return user_can( $user_id, 'read_post', $post->ID );
 	}
 
+	/**
+	 * Augment the base serialized shape with post type, status,
+	 * and permalink for cross-frame drag handlers.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape             = parent::serialize();
 		$post              = $this->post();
@@ -83,6 +122,11 @@ class OpenStation_Post_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the underlying WP_Post from the stored ref.
+	 *
+	 * @return WP_Post|null Null when the post is gone or the ref is invalid.
+	 */
 	private function post(): ?WP_Post {
 		$id = (int) $this->ref;
 		if ( $id <= 0 ) {

--- a/includes/desktop-files/types/class-openstation-shortcut-file.php
+++ b/includes/desktop-files/types/class-openstation-shortcut-file.php
@@ -23,14 +23,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Shortcut_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'shortcut';
 	}
 
+	/**
+	 * Whether the shortcut's registration entry still exists.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return null !== $this->entry();
 	}
 
+	/**
+	 * Get the shortcut title from the registration entry.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$entry = $this->entry();
 		if ( ! $entry ) {
@@ -39,6 +54,11 @@ class OpenStation_Shortcut_File extends OpenStation_File {
 		return (string) $entry['title'];
 	}
 
+	/**
+	 * Get the Dashicon class from the registration entry.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		$entry = $this->entry();
 		if ( ! $entry ) {
@@ -47,6 +67,13 @@ class OpenStation_Shortcut_File extends OpenStation_File {
 		return (string) $entry['icon'];
 	}
 
+	/**
+	 * Shortcut visibility is determined at registration time;
+	 * if the entry is in the registry for this request, it's visible.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		// Shortcut visibility = registration visibility. The
 		// `openstation_register_icon` capability gate already
@@ -55,6 +82,12 @@ class OpenStation_Shortcut_File extends OpenStation_File {
 		return null !== $this->entry();
 	}
 
+	/**
+	 * Augment the base serialized shape with the open target
+	 * (window id or URL) and pinned flag.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape = parent::serialize();
 		$entry = $this->entry();
@@ -70,6 +103,11 @@ class OpenStation_Shortcut_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the registration entry from the icon registry.
+	 *
+	 * @return array|null Null when the entry is gone or the ref is invalid.
+	 */
 	private function entry(): ?array {
 		$id = (string) $this->ref;
 		if ( '' === $id ) {

--- a/includes/desktop-files/types/class-openstation-term-file.php
+++ b/includes/desktop-files/types/class-openstation-term-file.php
@@ -13,14 +13,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Term_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'term';
 	}
 
+	/**
+	 * Whether the term still exists.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return $this->term() instanceof WP_Term;
 	}
 
+	/**
+	 * Get the term name.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$term = $this->term();
 		if ( ! $term ) {
@@ -29,6 +44,11 @@ class OpenStation_Term_File extends OpenStation_File {
 		return wp_strip_all_tags( $term->name );
 	}
 
+	/**
+	 * Resolve a Dashicon class based on the taxonomy.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		$term = $this->term();
 		if ( ! $term ) {
@@ -44,6 +64,13 @@ class OpenStation_Term_File extends OpenStation_File {
 		}
 	}
 
+	/**
+	 * Check whether the user can edit terms in this taxonomy or
+	 * has the base `read` capability.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		$term = $this->term();
 		if ( ! $term ) {
@@ -56,6 +83,12 @@ class OpenStation_Term_File extends OpenStation_File {
 		return user_can( $user_id, $tax->cap->edit_terms ) || user_can( $user_id, 'read' );
 	}
 
+	/**
+	 * Augment the base serialized shape with taxonomy and post
+	 * count.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape             = parent::serialize();
 		$term              = $this->term();
@@ -64,6 +97,11 @@ class OpenStation_Term_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the underlying WP_Term from the stored ref.
+	 *
+	 * @return WP_Term|null Null when the term is gone or the ref is invalid.
+	 */
 	private function term(): ?WP_Term {
 		[ $taxonomy, $term_id ] = $this->parse_ref();
 		if ( '' === $taxonomy || $term_id <= 0 ) {

--- a/includes/desktop-files/types/class-openstation-upload-file.php
+++ b/includes/desktop-files/types/class-openstation-upload-file.php
@@ -17,14 +17,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_Upload_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'upload';
 	}
 
+	/**
+	 * Whether the stored-file row still exists in the database.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return null !== $this->row();
 	}
 
+	/**
+	 * Get the display name, falling back to a generic label.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$row = $this->row();
 		if ( ! $row ) {
@@ -33,6 +48,11 @@ class OpenStation_Upload_File extends OpenStation_File {
 		return '' !== (string) $row['display_name'] ? (string) $row['display_name'] : __( 'file', 'desktop-mode' );
 	}
 
+	/**
+	 * Resolve a Dashicon class based on the coarse mime category.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		switch ( $this->kind() ) {
 			case 'image':
@@ -52,6 +72,12 @@ class OpenStation_Upload_File extends OpenStation_File {
 		}
 	}
 
+	/**
+	 * Delegate to the stored-file capability resolver.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		$row = $this->row();
 		if ( ! $row ) {
@@ -60,6 +86,12 @@ class OpenStation_Upload_File extends OpenStation_File {
 		return openstation_stored_file_user_can_read( (int) $row['id'], $user_id );
 	}
 
+	/**
+	 * Augment the base serialized shape with owner id, size, mime,
+	 * and kind slug.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape              = parent::serialize();
 		$row                = $this->row();
@@ -98,6 +130,11 @@ class OpenStation_Upload_File extends OpenStation_File {
 		return 'file';
 	}
 
+	/**
+	 * Lazily resolve the stored-file row from the database.
+	 *
+	 * @return array|null Null when the row is gone or the ref is invalid.
+	 */
 	private function row(): ?array {
 		$id = (int) $this->ref;
 		if ( $id <= 0 || ! function_exists( 'openstation_stored_files_get' ) ) {

--- a/includes/desktop-files/types/class-openstation-user-file.php
+++ b/includes/desktop-files/types/class-openstation-user-file.php
@@ -12,14 +12,29 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenStation_User_File extends OpenStation_File {
 
+	/**
+	 * Get the file type identifier.
+	 *
+	 * @return string
+	 */
 	public static function type(): string {
 		return 'user';
 	}
 
+	/**
+	 * Whether the underlying user account still exists.
+	 *
+	 * @return bool
+	 */
 	public function exists(): bool {
 		return $this->user() instanceof WP_User;
 	}
 
+	/**
+	 * Get the user's display name.
+	 *
+	 * @return string
+	 */
 	public function title(): string {
 		$user = $this->user();
 		if ( ! $user ) {
@@ -28,10 +43,20 @@ class OpenStation_User_File extends OpenStation_File {
 		return (string) $user->display_name;
 	}
 
+	/**
+	 * Get the Dashicon class for user tiles.
+	 *
+	 * @return string
+	 */
 	public function icon(): string {
 		return 'dashicons-admin-users';
 	}
 
+	/**
+	 * Get the user's avatar URL for tile previews.
+	 *
+	 * @return string Empty string when no avatar is available.
+	 */
 	public function preview_url(): string {
 		$user = $this->user();
 		if ( ! $user ) {
@@ -41,6 +66,13 @@ class OpenStation_User_File extends OpenStation_File {
 		return is_string( $avatar ) ? $avatar : '';
 	}
 
+	/**
+	 * Gate visibility on the `list_users` capability so shared
+	 * folders don't leak the user roster.
+	 *
+	 * @param int $user_id
+	 * @return bool
+	 */
 	public function can_read( int $user_id ): bool {
 		// Reading the existence of another user is gated on
 		// `list_users` to avoid leaking the user roster via shared
@@ -49,6 +81,12 @@ class OpenStation_User_File extends OpenStation_File {
 		return user_can( $user_id, 'list_users' );
 	}
 
+	/**
+	 * Augment the base serialized shape with roles, author archive
+	 * URL, and agent metadata when applicable.
+	 *
+	 * @return array
+	 */
 	public function serialize(): array {
 		$shape          = parent::serialize();
 		$user           = $this->user();
@@ -115,6 +153,11 @@ class OpenStation_User_File extends OpenStation_File {
 		return $shape;
 	}
 
+	/**
+	 * Lazily resolve the underlying WP_User from the stored ref.
+	 *
+	 * @return WP_User|null Null when the user is gone or the ref is invalid.
+	 */
 	private function user(): ?WP_User {
 		$id = (int) $this->ref;
 		if ( $id <= 0 ) {

--- a/includes/posts-window/window.php
+++ b/includes/posts-window/window.php
@@ -454,6 +454,15 @@ function openstation_posts_window_register_term_counts_route() {
 }
 add_action( 'rest_api_init', 'openstation_posts_window_register_term_counts_route' );
 
+/**
+ * REST callback: return post counts for a batch of term IDs.
+ *
+ * Uses a cached full-taxonomy map so multiple windows with
+ * different ID subsets share the same transient.
+ *
+ * @param WP_REST_Request $request Request with `taxonomy` and `ids`.
+ * @return array|WP_Error Map of `term_id => count`, or error on bad taxonomy.
+ */
 function openstation_posts_window_term_counts_callback( $request ) {
 	global $wpdb;
 	$taxonomy = sanitize_key( (string) $request->get_param( 'taxonomy' ) );
@@ -589,6 +598,14 @@ function openstation_posts_window_register_tag_cooccurrence_route() {
 }
 add_action( 'rest_api_init', 'openstation_posts_window_register_tag_cooccurrence_route' );
 
+/**
+ * REST callback: return tag co-occurrence data for the pixi
+ * cloud. For each tag, returns its top-N most frequently
+ * co-occurring sibling tags with the shared post count.
+ *
+ * @param WP_REST_Request $request Request with `taxonomy` and `limit`.
+ * @return WP_REST_Response|WP_Error
+ */
 function openstation_posts_window_tag_cooccurrence_callback( $request ) {
 	global $wpdb;
 

--- a/includes/user-edit-window/rest.php
+++ b/includes/user-edit-window/rest.php
@@ -137,6 +137,16 @@ function openstation_user_edit_window_destroy_sessions_route() {
 }
 add_action( 'rest_api_init', 'openstation_user_edit_window_destroy_sessions_route' );
 
+/**
+ * REST handler: destroy some or all sessions for a user.
+ *
+ * When editing another user or when `scope=all`, every session is
+ * destroyed. When editing self with the default scope, all sessions
+ * except the current one are destroyed.
+ *
+ * @param WP_REST_Request $req Request with `id` and optional `scope`.
+ * @return WP_REST_Response|WP_Error
+ */
 function openstation_user_edit_window_rest_destroy_sessions( $req ) {
 	$id    = (int) $req->get_param( 'id' );
 	$scope = (string) $req->get_param( 'scope' );
@@ -246,6 +256,12 @@ function openstation_user_edit_window_app_pw_unavailable( $user_id ) {
 	return null;
 }
 
+/**
+ * REST handler: list application passwords for a user.
+ *
+ * @param WP_REST_Request $req Request with `id`.
+ * @return WP_REST_Response|WP_Error
+ */
 function openstation_user_edit_window_rest_app_pw_list( $req ) {
 	if ( ! class_exists( 'WP_Application_Passwords' ) ) {
 		return rest_ensure_response( array( 'items' => array() ) );
@@ -259,6 +275,12 @@ function openstation_user_edit_window_rest_app_pw_list( $req ) {
 	return rest_ensure_response( array( 'items' => $apps ) );
 }
 
+/**
+ * REST handler: create a new application password for a user.
+ *
+ * @param WP_REST_Request $req Request with `id` and `name`.
+ * @return WP_REST_Response|WP_Error
+ */
 function openstation_user_edit_window_rest_app_pw_create( $req ) {
 	if ( ! class_exists( 'WP_Application_Passwords' ) ) {
 		return new WP_Error(
@@ -295,6 +317,12 @@ function openstation_user_edit_window_rest_app_pw_create( $req ) {
 	);
 }
 
+/**
+ * REST handler: revoke a single application password by UUID.
+ *
+ * @param WP_REST_Request $req Request with `id` and `uuid`.
+ * @return WP_REST_Response|WP_Error
+ */
 function openstation_user_edit_window_rest_app_pw_revoke( $req ) {
 	if ( ! class_exists( 'WP_Application_Passwords' ) ) {
 		return new WP_Error(


### PR DESCRIPTION
## Summary

Adds docblocks to 70 PHP functions across 13 files in `includes/`.

The desktop-files type classes (post, attachment, user, folder, comment, term, upload, shortcut, embed, link, bookmark) each had every method undocumented. The user-edit-window and posts-window REST callbacks were also missing docblocks.

JS functions embedded in PHP heredoc/string literals (chromeless-bridge.php, welcome-dialog.php, themes-tabs.php, divi.php, classic-link-interceptor.php) are intentionally skipped — they are not real PHP functions.

## Testing instructions

- [x] `npm run build` passes
- [x] `phpcs -n --standard=phpcs.xml.dist` passes on all 13 modified files
- [x] No logic changes — docblocks only

## Does this PR change what data or activity we track or use?

No.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-546-077f5346e10dd2ee16fcd976675a07bd2347f690.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->