### PR TITLE
Pages window: Use page wording in the pager, and cover it with tests

### DIFF
--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -120,6 +120,20 @@ function osConfirmGlobal( options: ConfirmOptions ): Promise< boolean > {
 }
 
 /**
+ * Window mode, defaulting to `'posts'`. The fallback covers the
+ * pre-render call sites (the kebab column-toggle menu mounts from the
+ * table descriptor before render) that can reach here before a config
+ * blob is available.
+ */
+function windowMode( client: PostsWindowClient ): 'posts' | 'pages' {
+	try {
+		return client.getConfig().mode === 'pages' ? 'pages' : 'posts';
+	} catch {
+		return 'posts';
+	}
+}
+
+/**
  * Posts-window first-open intro. Mirrors the seen-intros surface in
  * `includes/seen-intros.php`: gated on `config.introSeen`, marks
  * itself seen on dismiss via `POST config.introUrl`. Runs once per
@@ -494,17 +508,7 @@ function _buildBaseColumns(
 	// pages without the column hook bus knowing the difference.
 	// Plugins that filter `openstation.postsWindow.columns` see the
 	// already-mode-appropriate base list and append/replace from there.
-	let mode: 'posts' | 'pages' = 'posts';
-	try {
-		const cfg = client.getConfig();
-		if ( cfg.mode === 'pages' ) {
-			mode = 'pages';
-		}
-	} catch {
-		// Pre-render code paths (the kebab column-toggle menu mounts
-		// from the table descriptor before render) might call this
-		// before a config is available — fall back to posts mode.
-	}
+	const mode = windowMode( client );
 
 	const titleCol: OsTableColumn< PostListItem > = {
 		key: 'title',
@@ -1074,14 +1078,13 @@ function defaultStatusSegments(): StatusSegment[] {
  * out by id) for read-only views.
  */
 function defaultBulkActions( client: PostsWindowClient ): BulkAction[] {
-	const isPages = client.getConfig().mode === 'pages';
+	const isPages = windowMode( client ) === 'pages';
 	return [
 		{
 			id: 'trash',
 			label: __( 'Move to trash' ),
 			icon: 'dashicons-trash',
 			variant: 'danger',
-			/* translators: %d: row count. */
 			confirm: isPages
 				? /* translators: %d: row count. */ __( 'Move %d page(s) to the trash?' )
 				: /* translators: %d: row count. */ __( 'Move %d post(s) to the trash?' ),
@@ -2369,13 +2372,18 @@ export async function renderPostsWindow(
 	}
 
 	const updatePager = (): void => {
+		const isPagesMode = cfg.mode === 'pages';
 		if ( indicator ) {
 			if ( totalRows === 0 ) {
-				indicator.textContent = __( 'No posts' );
+				indicator.textContent = isPagesMode
+					? __( 'No pages' )
+					: __( 'No posts' );
 			} else {
+				const fmt = isPagesMode
+					? /* translators: 1: current page, 2: total pages, 3: total pages found. */ __( 'Page %1$d of %2$d · %3$d pages' )
+					: /* translators: 1: current page, 2: total pages, 3: total posts. */ __( 'Page %1$d of %2$d · %3$d posts' );
 				indicator.textContent = sprintf(
-					/* translators: 1: current page, 2: total pages, 3: total posts. */
-					__( 'Page %1$d of %2$d · %3$d posts' ),
+					fmt,
 					view.page,
 					Math.max( totalPages, 1 ),
 					totalRows,

--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -120,10 +120,11 @@ function osConfirmGlobal( options: ConfirmOptions ): Promise< boolean > {
 }
 
 /**
- * Window mode, defaulting to `'posts'`. The fallback covers the
- * pre-render call sites (the kebab column-toggle menu mounts from the
- * table descriptor before render) that can reach here before a config
- * blob is available.
+ * Window mode, defaulting to `'posts'`. For the call sites that build
+ * things before render, when the config blob may not exist yet (the
+ * kebab column-toggle menu mounts from the table descriptor). Inside
+ * `renderPostsWindow` read `isPagesMode` instead — the config is
+ * already resolved there, so the fallback would be dead weight.
  */
 function windowMode( client: PostsWindowClient ): 'posts' | 'pages' {
 	try {
@@ -2298,6 +2299,9 @@ export async function renderPostsWindow(
 	}
 
 	const cfg = client.getConfig();
+	// Every mode-dependent string below reads this. `windowMode()` is
+	// for the call sites that have no resolved config to read.
+	const isPagesMode = cfg.mode === 'pages';
 	const view: ViewState = {
 		page: 1,
 		perPage: Math.max( 1, cfg.defaultPerPage || 20 ),
@@ -2372,7 +2376,6 @@ export async function renderPostsWindow(
 	}
 
 	const updatePager = (): void => {
-		const isPagesMode = cfg.mode === 'pages';
 		if ( indicator ) {
 			if ( totalRows === 0 ) {
 				indicator.textContent = isPagesMode
@@ -2574,10 +2577,11 @@ export async function renderPostsWindow(
 			return;
 		}
 		if ( target.closest( NEW_BTN ) ) {
-			const isPages = cfg.mode === 'pages';
 			openAdminUrl( cfg.newPostUrl, {
-				title: isPages ? __( 'Add New Page' ) : __( 'Add New Post' ),
-				icon: isPages ? 'dashicons-admin-page' : 'dashicons-admin-post',
+				title: isPagesMode ? __( 'Add New Page' ) : __( 'Add New Post' ),
+				icon: isPagesMode
+					? 'dashicons-admin-page'
+					: 'dashicons-admin-post',
 			} );
 			return;
 		}

--- a/tests/vitest/posts-window-mode-copy.test.ts
+++ b/tests/vitest/posts-window-mode-copy.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The Posts and Pages windows share one renderer, so every string it
+ * builds has to pick its noun off `config.mode` — otherwise the Pages
+ * window tells the user it is about to trash "1 post(s)". The PHP
+ * templates already do this for the markup they own (search
+ * placeholder, empty state); these are the strings the bundle owns.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	createPostsWindowClient,
+	type PostsWindowConfig,
+} from '../../src/posts-window/rest';
+import type { BulkAction } from '../../src/posts-window/types';
+import { renderPostsWindow } from '../../src/posts-window/index';
+
+const POSTS_URL = 'http://example.test/wp-json/wp/v2/posts';
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	interface Window {
+		openStationWindowConfig?: Record< string, unknown >;
+	}
+}
+
+function installConfig( windowId: string, mode: 'posts' | 'pages' ): void {
+	const cfg: PostsWindowConfig = {
+		restRoot: 'http://example.test/wp-json/',
+		restNonce: 'nonce-1',
+		postsUrl: POSTS_URL,
+		editPostUrlBase: 'http://example.test/wp-admin/post.php',
+		newPostUrl: 'http://example.test/wp-admin/post-new.php',
+		usersUrl: 'http://example.test/wp-json/wp/v2/users',
+		currentUserId: 1,
+		defaultPerPage: 20,
+		mode,
+		introSeen: true,
+		queryArgs: {},
+	};
+	window.openStationWindowConfig = window.openStationWindowConfig ?? {};
+	window.openStationWindowConfig[ windowId ] = cfg;
+}
+
+/**
+ * Minimal stand-in for the PHP template — only the hooks the renderer
+ * reaches for in this test.
+ */
+function buildBody(): HTMLElement {
+	const body = document.createElement( 'div' );
+	body.innerHTML = `
+		<div data-os-posts-root>
+			<os-table data-os-posts-table selectable="multi"></os-table>
+			<span data-os-posts-bulk-actions></span>
+			<span data-os-posts-page-indicator></span>
+		</div>
+	`;
+	document.body.appendChild( body );
+	return body;
+}
+
+/**
+ * Capture the shipped defaults through the same filter plugins use —
+ * `defaultBulkActions()` is module-private on purpose.
+ */
+function captureBulkActions(): () => BulkAction[] {
+	let captured: BulkAction[] = [];
+	( window as unknown as { wp: Record< string, unknown > } ).wp = {
+		hooks: {
+			applyFilters: ( _name: string, value: unknown ) => {
+				if ( Array.isArray( value ) && value[ 0 ]?.id === 'trash' ) {
+					captured = value as BulkAction[];
+				}
+				return value;
+			},
+		},
+	};
+	return () => captured;
+}
+
+async function render(
+	windowId: string,
+	mode: 'posts' | 'pages',
+	rows: unknown[],
+): Promise< { body: HTMLElement; bulkActions: () => BulkAction[] } > {
+	installConfig( windowId, mode );
+	const bulkActions = captureBulkActions();
+	// A fresh Response per call — the renderer fires several fetches
+	// and a single instance's body can only be read once.
+	vi.spyOn( global, 'fetch' as never ).mockImplementation( ( () =>
+		Promise.resolve(
+			new Response( JSON.stringify( rows ), {
+				status: 200,
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Total': String( rows.length ),
+					'X-WP-TotalPages': rows.length ? '1' : '0',
+				},
+			} ),
+		) ) as never );
+	const body = buildBody();
+	await renderPostsWindow( body, createPostsWindowClient( windowId ) );
+	return { body, bulkActions };
+}
+
+const row = ( id: number ) => ( {
+	id,
+	title: { rendered: `Row ${ id }` },
+	status: 'publish',
+	date_gmt: '2026-01-01T00:00:00',
+	author: 1,
+} );
+
+beforeEach( () => {
+	document.body.replaceChildren();
+} );
+
+afterEach( () => {
+	delete window.openStationWindowConfig;
+	delete ( window as unknown as { wp?: unknown } ).wp;
+	vi.restoreAllMocks();
+} );
+
+describe( 'bulk-trash confirmation', () => {
+	test( 'posts mode says post(s)', async () => {
+		const { bulkActions } = await render(
+			'desktop-mode-posts',
+			'posts',
+			[ row( 1 ) ],
+		);
+		expect( bulkActions()[ 0 ].confirm ).toBe(
+			'Move %d post(s) to the trash?',
+		);
+	} );
+
+	test( 'pages mode says page(s)', async () => {
+		const { bulkActions } = await render(
+			'desktop-mode-pages',
+			'pages',
+			[ row( 1 ) ],
+		);
+		expect( bulkActions()[ 0 ].confirm ).toBe(
+			'Move %d page(s) to the trash?',
+		);
+	} );
+} );
+
+describe( 'pager indicator', () => {
+	test( 'posts mode counts posts', async () => {
+		const { body } = await render(
+			'desktop-mode-posts',
+			'posts',
+			[ row( 1 ), row( 2 ) ],
+		);
+		expect(
+			body.querySelector( '[data-os-posts-page-indicator]' )?.textContent,
+		).toBe( 'Page 1 of 1 · 2 posts' );
+	} );
+
+	test( 'pages mode counts pages', async () => {
+		const { body } = await render(
+			'desktop-mode-pages',
+			'pages',
+			[ row( 1 ), row( 2 ) ],
+		);
+		expect(
+			body.querySelector( '[data-os-posts-page-indicator]' )?.textContent,
+		).toBe( 'Page 1 of 1 · 2 pages' );
+	} );
+
+	test( 'pages mode empty state counts pages', async () => {
+		const { body } = await render( 'desktop-mode-pages', 'pages', [] );
+		expect(
+			body.querySelector( '[data-os-posts-page-indicator]' )?.textContent,
+		).toBe( 'No pages' );
+	} );
+} );


### PR DESCRIPTION
Follow-up to #550, which fixed the bulk-trash confirm reported in #543.

## Proposed changes

Two more strings in the shared Posts/Pages renderer were hardcoded to the post noun. In Pages mode they now read:

- Pager count: `Page 1 of 3 · 47 pages` (was `47 posts`)
- Empty pager label: `No pages` (was `No posts`)

Before | After
--- | ---
<img width="230" height="506" alt="Screenshot 2026-08-11 at 15 45 47" src="https://github.com/user-attachments/assets/34733149-7582-4d52-8441-8501c7f08f3c" /> | <img width="283" height="533" alt="Screenshot 2026-08-11 at 15 46 20" src="https://github.com/user-attachments/assets/a44bcce0-4ac0-4f92-9f57-289df9e5ebe0" />
<img width="243" height="506" alt="Screenshot 2026-08-11 at 15 47 00" src="https://github.com/user-attachments/assets/93af8037-5bf9-4318-be4d-29b3f18b7d4f" /> | <img width="198" height="508" alt="Screenshot 2026-08-11 at 15 47 02" src="https://github.com/user-attachments/assets/e7d614a8-e315-48f4-9e11-d89dc3946d7b" />



## Why are these changes being made?

Same bug as #543, same window, two strings further down. 

## Testing instructions

1. Go to OpenStation Preferences > Features
2. Activate the "Use the native Pages window" feature
3. Open Pages
4. Make sure the footer reads `Page 1 of N · M pages`.
5. Filter to a status with no results, or search for gibberish. Make sure the footer reads `No pages`.

## Not in scope

`%d page(s)` is not pluralized, so languages with non-trivial plural rules cannot render it. `_n()` cannot apply without widening `BulkAction.confirm` from `string`, because the row count is not known until click time. Pre-existing, and the plugin-facing example in [`docs/examples/native-posts.md`](docs/examples/native-posts.md) teaches the same pattern. Worth its own PR.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-548-8a228bde0284c69c9dad3ecfc916104c95d431da.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->