### PR TITLE
AI: add a filter for the model config sent to the provider

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -44,6 +44,7 @@ defined( 'ABSPATH' ) || exit;
 - [Register a desktop icon (Jorvy)](./register-icon.md)
 - [Register a slash-command for the AI palette](./register-command.md)
 - [Programmatic AI Copilot — `wp.os.ai.ask()`](./ai-ask.md)
+- [Tune the AI model config (tokens, temperature, reasoning)](./ai-model-config.md)
 - [AI Agents — extend and invoke from a plugin](./agents.md)
 - [Retune the Drafts widget's AI writing assistant (Experimental)](./drafts-ai-suggestions.md)
 - [Connect to a window — title-bar button + iframe pub/sub](./connect-to-window.md)

--- a/docs/examples/ai-model-config.md
+++ b/docs/examples/ai-model-config.md
@@ -1,6 +1,6 @@
 # Tune the AI model config
 
-Every AI turn OpenStation generates — Copilot search, the command follow-up, the comment scorer, the Agents runner — passes its model config through [`openstation_ai_model_config`](../hooks-reference.md#openstation_ai_model_config--experimental) first. It defaults to empty: OpenStation pins neither provider nor model.
+Every AI turn OpenStation generates (Copilot search, the command follow-up, the comment scorer, the Agents runner, the Drafts writing assistant) passes its model config through [`openstation_ai_model_config`](../hooks-reference.md#openstation_ai_model_config--experimental) first. It defaults to empty: OpenStation pins neither provider nor model.
 
 ```php
 apply_filters( 'openstation_ai_model_config', array $config, array $context );
@@ -8,10 +8,10 @@ apply_filters( 'openstation_ai_model_config', array $config, array $context );
 
 | Key | Type | Notes |
 |---|---|---|
-| `model` | `string\|ModelInterface` | Model id, or an SDK model instance. |
+| `model` | `string\|ModelInterface` | Model id, or an SDK model instance. Anything else is ignored. |
 | `max_tokens` | `int` | Output-token ceiling. Must be > 0. |
 | `temperature` | `float` | Sampling randomness. `0.0` is valid. |
-| `custom_options` | `array<string, mixed>` | Provider-native parameters, forwarded verbatim. |
+| `custom_options` | `array<string, mixed>` | Provider-native parameters, forwarded verbatim. Also feeds model discovery. |
 
 ## Model, ceiling and temperature
 
@@ -81,4 +81,4 @@ add_filter(
 );
 ```
 
-The rest of `$context`: `user_id`, `request_id` (the `/ai/search` correlation UUID, `''` where the path mints none), `has_tools`, `has_schema`.
+`source` is one of `ai-copilot/search`, `ai-copilot/followup`, `ai-copilot/comment-analysis`, `agents/runner`, `widgets/drafts-suggestions`. The rest of `$context`: `user_id`, `request_id` (the `/ai/search` correlation UUID, `''` where the path mints none), `has_tools`, `has_schema`.

--- a/docs/examples/ai-model-config.md
+++ b/docs/examples/ai-model-config.md
@@ -1,0 +1,84 @@
+# Tune the AI model config
+
+Every AI turn OpenStation generates — Copilot search, the command follow-up, the comment scorer, the Agents runner — passes its model config through [`openstation_ai_model_config`](../hooks-reference.md#openstation_ai_model_config--experimental) first. It defaults to empty: OpenStation pins neither provider nor model.
+
+```php
+apply_filters( 'openstation_ai_model_config', array $config, array $context );
+```
+
+| Key | Type | Notes |
+|---|---|---|
+| `model` | `string\|ModelInterface` | Model id, or an SDK model instance. |
+| `max_tokens` | `int` | Output-token ceiling. Must be > 0. |
+| `temperature` | `float` | Sampling randomness. `0.0` is valid. |
+| `custom_options` | `array<string, mixed>` | Provider-native parameters, forwarded verbatim. |
+
+## Model, ceiling and temperature
+
+```php
+add_filter(
+	'openstation_ai_model_config',
+	function ( $config, $context ) {
+		$config['model']       = 'claude-sonnet-5';
+		$config['max_tokens']  = 6144;
+		$config['temperature'] = 0.2;
+
+		return $config;
+	},
+	10,
+	2
+);
+```
+
+## Reasoning effort (`custom_options`)
+
+```php
+add_filter(
+	'openstation_ai_model_config',
+	function ( $config, $context ) {
+		$config['max_tokens']     = 6144;
+		$config['custom_options'] = array(
+			'thinking'      => array( 'type' => 'adaptive' ),
+			'output_config' => array( 'effort' => 'low' ),
+		);
+
+		return $config;
+	},
+	10,
+	2
+);
+```
+
+That pair is the Anthropic Claude 5 shape; older Anthropic models reject it and want `thinking: { type: 'enabled', budget_tokens: N }` instead. Check your provider's reference before copying — this is why OpenStation ships no default.
+
+## Spend effort only where it pays
+
+`$context['source']` names the calling path, so a long agent run and the background comment scorer need not share a setting:
+
+```php
+add_filter(
+	'openstation_ai_model_config',
+	function ( $config, $context ) {
+		// Short, schema-constrained classification. Nothing to think about.
+		if ( 'ai-copilot/comment-analysis' === $context['source'] ) {
+			$config['temperature'] = 0.0;
+
+			return $config;
+		}
+
+		$deep = 'agents/runner' === $context['source'];
+
+		$config['max_tokens']     = $deep ? 8192 : 6144;
+		$config['custom_options'] = array(
+			'thinking'      => array( 'type' => 'adaptive' ),
+			'output_config' => array( 'effort' => $deep ? 'medium' : 'low' ),
+		);
+
+		return $config;
+	},
+	10,
+	2
+);
+```
+
+The rest of `$context`: `user_id`, `request_id` (the `/ai/search` correlation UUID, `''` where the path mints none), `has_tools`, `has_schema`.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1790,7 +1790,7 @@ apply_filters( 'openstation_ai_error_log_candidates', string[] $candidates );
 
 ### `openstation_ai_model_config` — Experimental
 
-Model config for one AI turn. Fires on every path that generates: the Copilot search loop, the command follow-up, the comment scorer, and the Agents runner.
+Model config for one AI turn. Fires on every path that generates: the Copilot search loop, the command follow-up, the comment scorer, the Agents runner, and the Drafts widget's writing assistant.
 
 ```php
 apply_filters( 'openstation_ai_model_config', array $config, array $context );
@@ -1798,7 +1798,9 @@ apply_filters( 'openstation_ai_model_config', array $config, array $context );
 // $context = { user_id, request_id, source, has_tools, has_schema }
 ```
 
-`custom_options` keys are **provider-native parameter names**, forwarded verbatim into the request body; nothing there is validated, and a bad key fails the turn as a `WP_Error`. `source` is one of `ai-copilot/search`, `ai-copilot/followup`, `ai-copilot/comment-analysis`, `agents/runner`.
+`model` takes a model id or an SDK `ModelInterface`; anything else is ignored. `custom_options` keys are **provider-native parameter names**, forwarded verbatim into the request body; nothing there is validated, and a bad key fails the turn as a `WP_Error`. `source` is one of `ai-copilot/search`, `ai-copilot/followup`, `ai-copilot/comment-analysis`, `agents/runner`, `widgets/drafts-suggestions`.
+
+`custom_options` also feeds model discovery, not just the request body: the AI Client turns each key into a required option when it picks a model, so on a multi-provider connector an option only one model supports narrows the selection to it (or fails to match any).
 
 **Defaults to empty.** OpenStation pins neither provider nor model, since the keys that control reasoning depth are model-family-specific.
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1788,6 +1788,22 @@ Filter the ordered list of log-file paths the `get_php_error_log` AI tool probes
 apply_filters( 'openstation_ai_error_log_candidates', string[] $candidates );
 ```
 
+### `openstation_ai_model_config` — Experimental
+
+Model config for one AI turn. Fires on every path that generates: the Copilot search loop, the command follow-up, the comment scorer, and the Agents runner.
+
+```php
+apply_filters( 'openstation_ai_model_config', array $config, array $context );
+// $config  = { model?: string|ModelInterface, max_tokens?: int, temperature?: float, custom_options?: array<string, mixed> }
+// $context = { user_id, request_id, source, has_tools, has_schema }
+```
+
+`custom_options` keys are **provider-native parameter names**, forwarded verbatim into the request body; nothing there is validated, and a bad key fails the turn as a `WP_Error`. `source` is one of `ai-copilot/search`, `ai-copilot/followup`, `ai-copilot/comment-analysis`, `agents/runner`.
+
+**Defaults to empty.** OpenStation pins neither provider nor model, since the keys that control reasoning depth are model-family-specific.
+
+Recipe: [`examples/ai-model-config.md`](./examples/ai-model-config.md).
+
 ---
 
 ## Drafts widget — AI writing assistant (Experimental)

--- a/includes/agents/runner.php
+++ b/includes/agents/runner.php
@@ -968,7 +968,8 @@ function openstation_agent_runner_generate( $agent_user_id, array $history, arra
 				// requests. Tool-call turns are unaffected — the model either
 				// calls a function or emits the JSON answer.
 				openstation_agent_answer_schema(),
-				(string) $instructions . "\n\n" . openstation_agent_answer_prompt_appendix()
+				(string) $instructions . "\n\n" . openstation_agent_answer_prompt_appendix(),
+				array( 'source' => 'agents/runner' )
 			);
 		}
 	);

--- a/includes/ai-copilot/client.php
+++ b/includes/ai-copilot/client.php
@@ -21,6 +21,8 @@
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
@@ -144,6 +146,78 @@ function openstation_ai_empty_answer_error( $detail ) {
 }
 
 /**
+ * Applies the site's model config to a prompt builder.
+ *
+ * @param mixed $builder WP_AI_Client_Prompt_Builder.
+ * @param array $context Partial filter context; missing keys are defaulted.
+ * @return mixed
+ */
+function openstation_ai_apply_model_config( $builder, array $context ) {
+	$context = array_merge(
+		array(
+			'user_id'    => 0,
+			'request_id' => '',
+			'source'     => '',
+			'has_tools'  => false,
+			'has_schema' => false,
+		),
+		$context
+	);
+
+	/**
+	 * Filters the model config for one AI turn.
+	 *
+	 * Defaults to empty. Recipe: `docs/examples/ai-model-config.md`.
+	 *
+	 * @param array $config  { model?: string|ModelInterface, max_tokens?: int, temperature?: float, custom_options?: array<string, mixed> }.
+	 * @param array $context { user_id, request_id, source, has_tools, has_schema }.
+	 */
+	$config = apply_filters( 'openstation_ai_model_config', array(), $context );
+	if ( ! is_array( $config ) ) {
+		return $builder;
+	}
+
+	$model_config = new ModelConfig();
+
+	if ( isset( $config['max_tokens'] ) && is_numeric( $config['max_tokens'] ) && (int) $config['max_tokens'] > 0 ) {
+		$model_config->setMaxTokens( (int) $config['max_tokens'] );
+	}
+
+	// Unlike max_tokens, 0.0 is a legitimate temperature (deterministic).
+	if ( isset( $config['temperature'] ) && is_numeric( $config['temperature'] ) && (float) $config['temperature'] >= 0.0 ) {
+		$model_config->setTemperature( (float) $config['temperature'] );
+	}
+
+	$custom_options = array();
+	if ( isset( $config['custom_options'] ) && is_array( $config['custom_options'] ) ) {
+		foreach ( $config['custom_options'] as $key => $value ) {
+			// A list would reach the provider as parameters named `0`, `1`, ….
+			if ( is_string( $key ) && '' !== $key ) {
+				$custom_options[ $key ] = $value;
+			}
+		}
+	}
+
+	if ( ! empty( $custom_options ) ) {
+		$model_config->setCustomOptions( $custom_options );
+	}
+
+	$builder = $builder->using_model_config( $model_config );
+
+	// After the config: `using_model()` merges the model's own defaults under
+	// whatever the builder already carries, so ours has to land first.
+	if ( isset( $config['model'] ) ) {
+		// `using_model()` needs a ModelInterface; a bare model id has to go
+		// through `using_model_preference()`.
+		$builder = $config['model'] instanceof ModelInterface
+			? $builder->using_model( $config['model'] )
+			: $builder->using_model_preference( $config['model'] );
+	}
+
+	return $builder;
+}
+
+/**
  * Runs one generation turn through the AI Client.
  *
  * Rebuilds the prompt from the full ordered message list each turn (the
@@ -153,17 +227,16 @@ function openstation_ai_empty_answer_error( $detail ) {
  * to the shape the loop consumes; `message` has thought-channel parts stripped
  * ({@see openstation_ai_strip_thought_parts()}) so it is safe to replay.
  *
- * @param int        $user_id       Requesting user id. Currently unused — the
- *                                  provider comes from Connectors and no
- *                                  per-user preference is applied; retained for
- *                                  signature stability and future attribution.
+ * @param int        $user_id       Requesting user id.
  * @param array      $messages      Ordered conversation as SDK Message objects.
  * @param array      $tool_defs     Tool definitions to advertise.
  * @param array|null $answer_schema JSON Schema for the final answer, or null.
  * @param string     $instructions  System instruction.
+ * @param array      $context       Optional. `{ source?: string, request_id?: string }`
+ *                                  for the model-config filter.
  * @return array{ text: ?string, function_calls: array, message: mixed, usage: ?array, model: ?array }|WP_Error
  */
-function openstation_ai_client_generate( $user_id, array $messages, array $tool_defs, $answer_schema, $instructions ) {
+function openstation_ai_client_generate( $user_id, array $messages, array $tool_defs, $answer_schema, $instructions, array $context = array() ) {
 	$builder = wp_ai_client_prompt( $messages );
 
 	if ( is_string( $instructions ) && '' !== $instructions ) {
@@ -184,6 +257,18 @@ function openstation_ai_client_generate( $user_id, array $messages, array $tool_
 		// whole turn. Normalize here so no schema author has to know that.
 		$builder = $builder->as_json_response( openstation_ai_normalize_response_schema( $answer_schema ) );
 	}
+
+	$builder = openstation_ai_apply_model_config(
+		$builder,
+		array_merge(
+			$context,
+			array(
+				'user_id'    => (int) $user_id,
+				'has_tools'  => ! empty( $declarations ),
+				'has_schema' => is_array( $answer_schema ),
+			)
+		)
+	);
 
 	$result = $builder->generate_result();
 	if ( is_wp_error( $result ) ) {

--- a/includes/ai-copilot/client.php
+++ b/includes/ai-copilot/client.php
@@ -183,8 +183,10 @@ function openstation_ai_apply_model_config( $builder, array $context ) {
 		$model_config->setMaxTokens( (int) $config['max_tokens'] );
 	}
 
-	// Unlike max_tokens, 0.0 is a legitimate temperature (deterministic).
-	if ( isset( $config['temperature'] ) && is_numeric( $config['temperature'] ) && (float) $config['temperature'] >= 0.0 ) {
+	// Unlike max_tokens, 0.0 is a legitimate temperature (deterministic). The
+	// 2.0 ceiling is the range the SDK's own schema declares.
+	if ( isset( $config['temperature'] ) && is_numeric( $config['temperature'] )
+		&& (float) $config['temperature'] >= 0.0 && (float) $config['temperature'] <= 2.0 ) {
 		$model_config->setTemperature( (float) $config['temperature'] );
 	}
 
@@ -206,12 +208,14 @@ function openstation_ai_apply_model_config( $builder, array $context ) {
 
 	// After the config: `using_model()` merges the model's own defaults under
 	// whatever the builder already carries, so ours has to land first.
-	if ( isset( $config['model'] ) ) {
-		// `using_model()` needs a ModelInterface; a bare model id has to go
-		// through `using_model_preference()`.
-		$builder = $config['model'] instanceof ModelInterface
-			? $builder->using_model( $config['model'] )
-			: $builder->using_model_preference( $config['model'] );
+	$model = isset( $config['model'] ) ? $config['model'] : null;
+	if ( $model instanceof ModelInterface ) {
+		$builder = $builder->using_model( $model );
+	} elseif ( is_string( $model ) && '' !== trim( $model ) ) {
+		// `using_model()` needs a ModelInterface, so a bare model id goes
+		// through `using_model_preference()`, which throws on anything that
+		// isn't a non-empty string.
+		$builder = $builder->using_model_preference( trim( $model ) );
 	}
 
 	return $builder;
@@ -243,8 +247,8 @@ function openstation_ai_client_generate( $user_id, array $messages, array $tool_
 		$builder = $builder->using_system_instruction( $instructions );
 	}
 
-	// Provider + model selection is delegated entirely to the Core AI Client
-	// (Connector-backed); OpenStation pins neither.
+	// Provider + model selection is delegated to the Core AI Client
+	// (Connector-backed) unless the model-config filter says otherwise.
 
 	$declarations = openstation_ai_build_function_declarations( $tool_defs );
 	if ( ! empty( $declarations ) ) {

--- a/includes/ai-copilot/jobs.php
+++ b/includes/ai-copilot/jobs.php
@@ -101,7 +101,8 @@ function openstation_ai_analyze_comment_now( WP_Comment $comment, $user_id ) {
 	if ( '' !== $system ) {
 		$builder = $builder->using_system_instruction( $system );
 	}
-	// Provider + model are chosen by the Core AI Client; OpenStation pins neither.
+	// Provider + model are chosen by the Core AI Client unless the
+	// model-config filter says otherwise.
 
 	$builder = $builder->as_json_response( openstation_ai_normalize_response_schema( $schema ) );
 	$builder = openstation_ai_apply_model_config(

--- a/includes/ai-copilot/jobs.php
+++ b/includes/ai-copilot/jobs.php
@@ -79,10 +79,7 @@ add_action( 'desktop_mode_ai_analyze_comment', 'openstation_ai_job_analyze_comme
  * comment schema, and decodes the result.
  *
  * @param WP_Comment $comment The comment to analyze.
- * @param int        $user_id Requesting user id. Currently unused — the builder
- *                            is built from the prompt alone and the provider
- *                            comes from Connectors; retained for signature
- *                            stability and future attribution.
+ * @param int        $user_id Requesting user id.
  * @return array|WP_Error Structured `{ topic, ai_summary, harmful, spam }` or an error.
  */
 function openstation_ai_analyze_comment_now( WP_Comment $comment, $user_id ) {
@@ -106,7 +103,17 @@ function openstation_ai_analyze_comment_now( WP_Comment $comment, $user_id ) {
 	}
 	// Provider + model are chosen by the Core AI Client; OpenStation pins neither.
 
-	$json = $builder->as_json_response( openstation_ai_normalize_response_schema( $schema ) )->generate_text();
+	$builder = $builder->as_json_response( openstation_ai_normalize_response_schema( $schema ) );
+	$builder = openstation_ai_apply_model_config(
+		$builder,
+		array(
+			'user_id'    => (int) $user_id,
+			'source'     => 'ai-copilot/comment-analysis',
+			'has_schema' => true,
+		)
+	);
+
+	$json = $builder->generate_text();
 	if ( is_wp_error( $json ) ) {
 		return $json;
 	}

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -1167,7 +1167,12 @@ The message field is always a friendly sentence or two shown directly to the use
 	// -----------------------------------------------------------------------
 	$messages = array( openstation_ai_user_text_message( $query ) );
 
-	$turn = openstation_ai_client_generate( $user_id, $messages, $tools, $answer_schema, $instructions );
+	$generation_context = array(
+		'source'     => 'ai-copilot/search',
+		'request_id' => $request_id,
+	);
+
+	$turn = openstation_ai_client_generate( $user_id, $messages, $tools, $answer_schema, $instructions, $generation_context );
 
 	if ( is_wp_error( $turn ) ) {
 		return $turn;
@@ -1473,7 +1478,7 @@ The message field is always a friendly sentence or two shown directly to the use
 		$messages[] = $turn['message'];
 		$messages[] = openstation_ai_tool_result_message( $tool_outputs );
 
-		$turn = openstation_ai_client_generate( $user_id, $messages, $tools, $answer_schema, $instructions );
+		$turn = openstation_ai_client_generate( $user_id, $messages, $tools, $answer_schema, $instructions, $generation_context );
 
 		if ( is_wp_error( $turn ) ) {
 			return $turn;
@@ -1761,7 +1766,11 @@ Rules:
 		array( openstation_ai_user_text_message( $user_message ) ),
 		array(), // no tools — we want a plain reply
 		null,    // no JSON schema — free-form text
-		$instructions
+		$instructions,
+		array(
+			'source'     => 'ai-copilot/followup',
+			'request_id' => $request_id,
+		)
 	);
 
 	// `openstation_ai_empty_answer` is the one generation error this path

--- a/includes/widgets/widget-drafts.php
+++ b/includes/widgets/widget-drafts.php
@@ -318,10 +318,18 @@ function openstation_rest_draft_suggestions( WP_REST_Request $request ) {
 	// scorer uses. The SDK can throw as well as return a WP_Error, so both
 	// paths land on the same 502.
 	try {
-		$json = wp_ai_client_prompt( openstation_drafts_ai_prompt_text( $post ) )
+		$builder = wp_ai_client_prompt( openstation_drafts_ai_prompt_text( $post ) )
 			->using_system_instruction( openstation_drafts_ai_instructions( $post ) )
-			->as_json_response( openstation_ai_normalize_response_schema( openstation_drafts_ai_schema( $post ) ) )
-			->generate_text();
+			->as_json_response( openstation_ai_normalize_response_schema( openstation_drafts_ai_schema( $post ) ) );
+
+		$json = openstation_ai_apply_model_config(
+			$builder,
+			array(
+				'user_id'    => get_current_user_id(),
+				'source'     => 'widgets/drafts-suggestions',
+				'has_schema' => true,
+			)
+		)->generate_text();
 	} catch ( \Throwable $e ) {
 		$json = new WP_Error( 'openstation_ai_failed', $e->getMessage() );
 	}

--- a/tests/phpunit/tests/aiModelConfig.php
+++ b/tests/phpunit/tests/aiModelConfig.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Tests for the model-config opt-in.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group os-ai
+ */
+
+class Tests_OpenStation_AiModelConfig extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'openstation_ai_model_config' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Records the setter calls the config makes on a prompt builder.
+	 */
+	private function builder() {
+		return new class() {
+			public $model_config = null;
+			public $preference   = null;
+
+			public function using_model_config( $config ) {
+				$this->model_config = $config;
+				return $this;
+			}
+
+			public function using_model_preference( ...$models ) {
+				$this->preference = $models;
+				return $this;
+			}
+		};
+	}
+
+	private function filter_returns( $config ) {
+		add_filter(
+			'openstation_ai_model_config',
+			static function () use ( $config ) {
+				return $config;
+			}
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+		if ( ! class_exists( 'WordPress\AiClient\Providers\Models\DTO\ModelConfig' ) ) {
+			$this->markTestSkipped( 'AI Client SDK not available (requires WordPress 7.0+).' );
+		}
+	}
+
+	/**
+	 * The default is nothing: a site that adds no filter sends exactly what it
+	 * sent before. This is what keeps the plugin provider-agnostic.
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_default_config_is_empty() {
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( array(), $builder->model_config->toArray() );
+	}
+
+	/**
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_max_tokens_and_temperature_are_coerced() {
+		$this->filter_returns(
+			array(
+				'max_tokens'  => '6144',
+				'temperature' => '0.2',
+			)
+		);
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( 6144, $builder->model_config->getMaxTokens() );
+		$this->assertSame( 0.2, $builder->model_config->getTemperature() );
+	}
+
+	/**
+	 * Unlike max_tokens, 0.0 is a legitimate temperature.
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_zero_temperature_is_kept() {
+		$this->filter_returns( array( 'temperature' => 0.0 ) );
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( 0.0, $builder->model_config->getTemperature() );
+	}
+
+	/**
+	 * @dataProvider data_unusable_config
+	 * @covers ::openstation_ai_apply_model_config
+	 *
+	 * @param mixed $config Filter return value.
+	 */
+	public function test_unusable_config_is_ignored( $config ) {
+		$this->filter_returns( $config );
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( array(), $builder->model_config->toArray() );
+	}
+
+	/**
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function data_unusable_config() {
+		return array(
+			'zero ceiling'           => array( array( 'max_tokens' => 0 ) ),
+			'negative ceiling'       => array( array( 'max_tokens' => -1 ) ),
+			'non-numeric ceiling'    => array( array( 'max_tokens' => 'lots' ) ),
+			'negative temperature'   => array( array( 'temperature' => -1 ) ),
+			'non-numeric temperature' => array( array( 'temperature' => 'hot' ) ),
+			'empty options'          => array( array( 'custom_options' => array() ) ),
+			'non-array options'      => array( array( 'custom_options' => 'thinking' ) ),
+			// Provider parameters belong under `custom_options`; a top-level
+			// key is a typo that would otherwise fail silently at the provider.
+			'top-level provider key' => array( array( 'thinking' => array( 'type' => 'adaptive' ) ) ),
+		);
+	}
+
+	/**
+	 * A filter returning the wrong type leaves the builder alone entirely.
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_non_array_filter_return_is_ignored() {
+		$this->filter_returns( false );
+		$builder = $this->builder();
+
+		$this->assertSame( $builder, openstation_ai_apply_model_config( $builder, array() ) );
+		$this->assertNull( $builder->model_config );
+	}
+
+	/**
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_custom_options_reach_the_model_config() {
+		$options = array(
+			'thinking'      => array( 'type' => 'adaptive' ),
+			'output_config' => array( 'effort' => 'low' ),
+		);
+		$this->filter_returns( array( 'custom_options' => $options ) );
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( $options, $builder->model_config->getCustomOptions() );
+	}
+
+	/**
+	 * A bare model id is not a ModelInterface, so it has to route through
+	 * using_model_preference() or the SDK raises a TypeError.
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_model_id_routes_through_model_preference() {
+		$this->filter_returns( array( 'model' => 'claude-sonnet-5' ) );
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( array( 'claude-sonnet-5' ), $builder->preference );
+	}
+
+	/**
+	 * The filter's own ceiling must survive the model's default, which means
+	 * the config has to be applied before the model.
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_config_is_applied_before_the_model() {
+		$this->filter_returns(
+			array(
+				'model'      => 'claude-sonnet-5',
+				'max_tokens' => 6144,
+			)
+		);
+		$builder = new class() {
+			public $order = array();
+
+			public function using_model_config( $config ) {
+				$this->order[] = 'config';
+				return $this;
+			}
+
+			public function using_model_preference( ...$models ) {
+				$this->order[] = 'model';
+				return $this;
+			}
+		};
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame( array( 'config', 'model' ), $builder->order );
+	}
+
+	/**
+	 * A list would reach the provider as parameters named `0`, `1`, ….
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_non_string_option_keys_are_dropped() {
+		$this->filter_returns(
+			array(
+				'custom_options' => array(
+					'thinking' => array( 'type' => 'adaptive' ),
+					'stray',
+				),
+			)
+		);
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertSame(
+			array( 'thinking' => array( 'type' => 'adaptive' ) ),
+			$builder->model_config->getCustomOptions()
+		);
+	}
+
+	/**
+	 * Every documented key is present whatever the caller passed, so a
+	 * subscriber can branch on `$context['source']` without guarding.
+	 *
+	 * @covers ::openstation_ai_apply_model_config
+	 */
+	public function test_context_is_filled_with_defaults() {
+		$seen = null;
+		add_filter(
+			'openstation_ai_model_config',
+			static function ( $config, $context ) use ( &$seen ) {
+				$seen = $context;
+				return $config;
+			},
+			10,
+			2
+		);
+
+		openstation_ai_apply_model_config( $this->builder(), array( 'source' => 'agents/runner' ) );
+
+		$this->assertSame(
+			array(
+				'user_id'    => 0,
+				'request_id' => '',
+				'source'     => 'agents/runner',
+				'has_tools'  => false,
+				'has_schema' => false,
+			),
+			$seen
+		);
+	}
+}

--- a/tests/phpunit/tests/aiModelConfig.php
+++ b/tests/phpunit/tests/aiModelConfig.php
@@ -118,16 +118,17 @@ class Tests_OpenStation_AiModelConfig extends WP_UnitTestCase {
 	 */
 	public function data_unusable_config() {
 		return array(
-			'zero ceiling'           => array( array( 'max_tokens' => 0 ) ),
-			'negative ceiling'       => array( array( 'max_tokens' => -1 ) ),
-			'non-numeric ceiling'    => array( array( 'max_tokens' => 'lots' ) ),
-			'negative temperature'   => array( array( 'temperature' => -1 ) ),
+			'zero ceiling'            => array( array( 'max_tokens' => 0 ) ),
+			'negative ceiling'        => array( array( 'max_tokens' => -1 ) ),
+			'non-numeric ceiling'     => array( array( 'max_tokens' => 'lots' ) ),
+			'negative temperature'    => array( array( 'temperature' => -1 ) ),
+			'over-max temperature'    => array( array( 'temperature' => 47 ) ),
 			'non-numeric temperature' => array( array( 'temperature' => 'hot' ) ),
-			'empty options'          => array( array( 'custom_options' => array() ) ),
-			'non-array options'      => array( array( 'custom_options' => 'thinking' ) ),
+			'empty options'           => array( array( 'custom_options' => array() ) ),
+			'non-array options'       => array( array( 'custom_options' => 'thinking' ) ),
 			// Provider parameters belong under `custom_options`; a top-level
 			// key is a typo that would otherwise fail silently at the provider.
-			'top-level provider key' => array( array( 'thinking' => array( 'type' => 'adaptive' ) ) ),
+			'top-level provider key'  => array( array( 'thinking' => array( 'type' => 'adaptive' ) ) ),
 		);
 	}
 
@@ -173,6 +174,40 @@ class Tests_OpenStation_AiModelConfig extends WP_UnitTestCase {
 		openstation_ai_apply_model_config( $builder, array() );
 
 		$this->assertSame( array( 'claude-sonnet-5' ), $builder->preference );
+	}
+
+	/**
+	 * `using_model_preference()` throws on anything that isn't a non-empty
+	 * string, so an unusable model has to be dropped like every other key
+	 * rather than failing the whole turn.
+	 *
+	 * @dataProvider data_unusable_model
+	 * @covers ::openstation_ai_apply_model_config
+	 *
+	 * @param mixed $model Filter-supplied model.
+	 */
+	public function test_unusable_model_is_ignored( $model ) {
+		$this->filter_returns( array( 'model' => $model ) );
+		$builder = $this->builder();
+
+		openstation_ai_apply_model_config( $builder, array() );
+
+		$this->assertNull( $builder->preference );
+	}
+
+	/**
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function data_unusable_model() {
+		return array(
+			'empty string'    => array( '' ),
+			'whitespace only' => array( "  \t " ),
+			'integer'         => array( 0 ),
+			'null'            => array( null ),
+			// usingModelPreference() accepts [provider, model] tuples, but we
+			// deliberately don't: the documented surface is id or instance.
+			'tuple'           => array( array( 'anthropic', 'claude-sonnet-5' ) ),
+		);
 	}
 
 	/**
@@ -261,5 +296,87 @@ class Tests_OpenStation_AiModelConfig extends WP_UnitTestCase {
 			),
 			$seen
 		);
+	}
+
+	/**
+	 * Captures the context of the next turn any call site generates.
+	 *
+	 * @return object
+	 */
+	private function capture_source() {
+		$capture = new stdClass();
+		$capture->source = null;
+
+		add_filter(
+			'openstation_ai_model_config',
+			static function ( $config, $context ) use ( $capture ) {
+				$capture->source = $context['source'];
+				return $config;
+			},
+			10,
+			2
+		);
+
+		return $capture;
+	}
+
+	/**
+	 * The `source` strings are the documented contract, so drive each entry
+	 * point for real rather than asserting them at the helper. Generation
+	 * fails afterwards (no provider is configured in tests) and that is fine:
+	 * the filter runs first.
+	 *
+	 * @covers ::openstation_ai_client_generate
+	 */
+	public function test_client_generate_forwards_the_callers_source() {
+		$capture = $this->capture_source();
+
+		openstation_ai_client_generate(
+			1,
+			array( openstation_ai_user_text_message( 'hello' ) ),
+			array(),
+			null,
+			'',
+			array( 'source' => 'agents/runner' )
+		);
+
+		$this->assertSame( 'agents/runner', $capture->source );
+	}
+
+	/**
+	 * @covers ::openstation_ai_run_followup
+	 */
+	public function test_followup_reports_its_source() {
+		$capture = $this->capture_source();
+
+		openstation_ai_run_followup( 'turn on the light', array( 'slug' => 'noop' ), array( 'ok' => true ) );
+
+		$this->assertSame( 'ai-copilot/followup', $capture->source );
+	}
+
+	/**
+	 * @covers ::openstation_ai_analyze_comment_now
+	 */
+	public function test_comment_analysis_reports_its_source() {
+		$capture    = $this->capture_source();
+		$comment_id = self::factory()->comment->create( array( 'comment_content' => 'Nice post!' ) );
+
+		openstation_ai_analyze_comment_now( get_comment( $comment_id ), 1 );
+
+		$this->assertSame( 'ai-copilot/comment-analysis', $capture->source );
+	}
+
+	/**
+	 * @covers ::openstation_rest_draft_suggestions
+	 */
+	public function test_draft_suggestions_report_their_source() {
+		$capture = $this->capture_source();
+		$post_id = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		$request = new WP_REST_Request( 'POST', '/desktop-mode/v1/draft-suggestions' );
+		$request->set_param( 'post_id', $post_id );
+		openstation_rest_draft_suggestions( $request );
+
+		$this->assertSame( 'widgets/drafts-suggestions', $capture->source );
 	}
 }


### PR DESCRIPTION
Fixes #531

## Proposed changes

Adds `openstation_ai_model_config`, a filter over the model config for one generation turn. It defaults to empty, so nothing changes unless a site opts in.

```php
apply_filters( 'openstation_ai_model_config', array $config, array $context );
// $config  = { model?: string|ModelInterface, max_tokens?: int, temperature?: float, custom_options?: array<string, mixed> }
// $context = { user_id, request_id, source, has_tools, has_schema }
```

It runs on every path that generates: Copilot search, the command follow-up, the comment scorer, the Agents runner, and the Drafts widget's writing assistant. `$context['source']` names the path, so a site can configure long agent runs and the background comment scorer differently.

`openstation_ai_client_generate()` takes an optional sixth `$context` argument so callers can identify themselves. Existing callers keep working.

Docs: new [`examples/ai-model-config.md`](https://github.com/WordPress/openstation/blob/claude/openstation-issue-531-34cb25/docs/examples/ai-model-config.md) plus a `hooks-reference.md` entry.

## Why are these changes being made?

Reasoning models bill thinking against the same output budget as the answer text. With no effort configured, a hard turn can spend the whole ceiling thinking and return no text, which surfaces as the `openstation_ai_empty_answer` error added in #530. Raising `max_tokens` alone only moves the truncation point, as measured in #517.

We can't ship a default, because the keys are model-family-specific. Claude 5 rejects `thinking: { type: 'enabled', budget_tokens: N }` with a 400 and wants `thinking: { type: 'adaptive' }` plus `output_config: { effort: ... }`, while older families want the opposite. Either default would break the other family.

`custom_options` maps to the AI Client's own pass-through bag, so no upstream change is needed for this.

Two implementation notes, both non-obvious:

* A bare model id goes through `using_model_preference()`, not `using_model()`, which takes a `ModelInterface` and would `TypeError` on a string. An unusable `model` is ignored rather than passed on, since `using_model_preference()` throws on anything that isn't a non-empty string and would fail the whole turn.
* The config is applied before the model, because `usingModel()` merges the model's own defaults with the builder's values winning, so a filter's `max_tokens` would otherwise lose to the model default. There's a test pinning that order.

One thing I could not verify locally: the Core-bundled AI Client ships no Anthropic provider, so I confirmed `custom_options` forwarding against the SDK's OpenAI-compatible base class. Step 4 below is the check that matters.

## Testing instructions

1. Configure a text-generation provider in `Settings > Connectors`.
2. Open the AI palette and run a search. Make sure it answers exactly as before: the filter defaults to empty, so nothing should change.
3. Drop this into a plugin file:

   ```php
   add_filter( 'openstation_ai_model_config', function ( $config, $context ) {
       error_log( 'AI turn from ' . $context['source'] );
       $config['max_tokens'] = 6144;
       return $config;
   }, 10, 2 );
   ```

   Run a search again. Make sure the answer still renders and the log shows `ai-copilot/search` once per turn. Approve a comment with the Comments window moderation option on and make sure the log shows `ai-copilot/comment-analysis`. Open the Drafts widget on a draft and ask for suggestions, and make sure the log shows `widgets/drafts-suggestions`.
4. On Anthropic Claude 5, add the effort config to the same filter:

   ```php
   $config['custom_options'] = array(
       'thinking'      => array( 'type' => 'adaptive' ),
       'output_config' => array( 'effort' => 'low' ),
   );
   ```

   Enable the `agents` extended option, then ask an agent for an edit-planning task (the shape that fails in #517, for example "propose a revision to post X splitting sentence Y"). Make sure it returns a full answer instead of "The AI provider returned no answer text."
5. Set `$config['model']` to a model id your connector serves. Make sure generation still works.
6. Set `$config['max_tokens'] = 0`, `$config['temperature'] = 47`, and `$config['model'] = ''`. Make sure all three are ignored and generation still works.
7. Run `npm run lint:php` and `npm run test:php`. Make sure both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-549-79380d135fd7e46e88a4a122d48a96d8f8d3cc61.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->