### PR TITLE
Posts window: Pluralize the bulk-action confirm text

### DIFF
--- a/docs/examples/native-posts.md
+++ b/docs/examples/native-posts.md
@@ -148,7 +148,15 @@ wp.hooks.addFilter(
             label: 'Duplicate',
             icon: 'dashicons-admin-page',
             variant: 'secondary',
-            confirm: 'Duplicate %d post(s)?',
+            confirm: ( count ) =>
+                wp.i18n.sprintf(
+                    wp.i18n._n(
+                        'Duplicate %d post?',
+                        'Duplicate %d posts?',
+                        count
+                    ),
+                    count
+                ),
             run: async ( ids ) => {
                 await fetch( '/wp-json/myplugin/v1/duplicate', {
                     method: 'POST',
@@ -167,7 +175,9 @@ wp.hooks.addFilter(
 );
 ```
 
-`confirm` is interpolated with the row count via `%d`. Returning `false` from `run()` opts out of the auto-refresh — useful when the action navigates away or shows its own modal.
+`confirm` takes either a function or a string. Prefer the function: it receives the row count, which is what `_n()` needs to pick a plural form. A plain string still works and is interpolated with the count via `%d`, but it can only carry one form, so it cannot be translated into languages that have more than two.
+
+Returning `false` from `run()` opts out of the auto-refresh — useful when the action navigates away or shows its own modal.
 
 To remove the default trash action (read-only views, audit-style mirrors), filter it out by id:
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2719,7 +2719,7 @@ Every JS hook below is also documented on `wp.hooks` so plugins can register wit
 |---|---|---|---|
 | `openstation.postsWindow.columns` | filter | built-in 5 columns | `OsTableColumn< PostListItem >[]` — append, replace, or remove cells. |
 | `openstation.postsWindow.statusSegments` | filter | All / Published / Drafts / Pending / Scheduled / Trash | `StatusSegment[]` — `{ value, label }` pairs. `value` is sent verbatim as `?status=…`; use `''` for "All" (the bundle remaps to `?status=any`). |
-| `openstation.postsWindow.bulkActions` | filter | one entry: "Move to trash" | `BulkAction[]` — `{ id, label, icon?, variant?, confirm?, run( ids, ctx ) }`. Filter out by id to remove. |
+| `openstation.postsWindow.bulkActions` | filter | one entry: "Move to trash" | `BulkAction[]` — `{ id, label, icon?, variant?, confirm?, run( ids, ctx ) }`. `confirm` is `string \| ( count: number ) => string`; the function form is the one `_n()` can pluralize. Filter out by id to remove. |
 | `openstation.postsWindow.toolbarTrailing` | filter | `[]` | `HTMLElement[]` rendered before Refresh + Add New. Receives the live `PostsWindowContext` as the second arg. |
 | `openstation.postsWindow.opened` | action | — | `( ctx: PostsWindowContext )` — fired after the first paint with a populated table. |
 | `openstation.postsWindow.dataLoaded` | action | — | `( payload: { items, total, totalPages, page } )` — fired after every successful refresh. |

--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -1086,9 +1086,28 @@ function defaultBulkActions( client: PostsWindowClient ): BulkAction[] {
 			label: __( 'Move to trash' ),
 			icon: 'dashicons-trash',
 			variant: 'danger',
-			confirm: isPages
-				? /* translators: %d: row count. */ __( 'Move %d page(s) to the trash?' )
-				: /* translators: %d: row count. */ __( 'Move %d post(s) to the trash?' ),
+			confirm: ( count: number ) => {
+				if ( isPages ) {
+					return sprintf(
+						/* translators: %d: row count. */
+						_n(
+							'Move %d page to the trash?',
+							'Move %d pages to the trash?',
+							count,
+						),
+						count,
+					);
+				}
+				return sprintf(
+					/* translators: %d: row count. */
+					_n(
+						'Move %d post to the trash?',
+						'Move %d posts to the trash?',
+						count,
+					),
+					count,
+				);
+			},
 			run: async ( ids, ctx ) => {
 				// Don't try to trash rows already in trash — a `DELETE`
 				// without `force` would hard-delete them.
@@ -2696,13 +2715,21 @@ export async function renderPostsWindow(
 		if ( ids.length === 0 ) {
 			return;
 		}
-		if ( action.confirm ) {
+		const { confirm } = action;
+		if ( confirm ) {
+			// A function builds the message from the count, which is the
+			// only form `_n()` can be used in. A plain string keeps the
+			// original `%d` interpolation.
+			const message =
+				typeof confirm === 'function'
+					? confirm( ids.length )
+					: sprintf(
+						/* translators: %d: row count. */
+						confirm,
+						ids.length,
+					);
 			const ok = await osConfirmGlobal( {
-				message: sprintf(
-					/* translators: %d: row count. */
-					action.confirm,
-					ids.length,
-				),
+				message,
 				danger: true,
 			} );
 			if ( ! ok ) {

--- a/src/posts-window/types.ts
+++ b/src/posts-window/types.ts
@@ -65,11 +65,13 @@ export interface BulkAction {
 	 */
 	variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
 	/**
-	 * Optional confirmation prompt. When set, clicking the button shows
-	 * a `window.confirm()` with the message (interpolated with the row
-	 * count via `%d`) before invoking `run`.
+	 * Optional confirmation prompt shown before `run` is invoked. Pass a
+	 * function to build the message from the row count — that is the only
+	 * form `_n()` can be used in, since the plural form has to be picked
+	 * once the count is known. A plain string keeps working and is
+	 * interpolated with the count via `%d`.
 	 */
-	confirm?: string;
+	confirm?: string | ( ( count: number ) => string );
 	/**
 	 * Action runner. Receives the selected row ids and the window
 	 * context. May return a Promise; the bulk bar disables itself

--- a/tests/vitest/posts-window-mode-copy.test.ts
+++ b/tests/vitest/posts-window-mode-copy.test.ts
@@ -120,26 +120,41 @@ afterEach( () => {
 	vi.restoreAllMocks();
 } );
 
+/** The shipped `confirm` is a builder — resolve it at a given count. */
+function confirmAt( action: BulkAction, count: number ): string {
+	const { confirm } = action;
+	if ( typeof confirm !== 'function' ) {
+		throw new Error( 'expected the trash confirm to be a builder' );
+	}
+	return confirm( count );
+}
+
 describe( 'bulk-trash confirmation', () => {
-	test( 'posts mode says post(s)', async () => {
+	test( 'posts mode says post, and pluralizes', async () => {
 		const { bulkActions } = await render(
 			'desktop-mode-posts',
 			'posts',
 			[ row( 1 ) ],
 		);
-		expect( bulkActions()[ 0 ].confirm ).toBe(
-			'Move %d post(s) to the trash?',
+		expect( confirmAt( bulkActions()[ 0 ], 1 ) ).toBe(
+			'Move 1 post to the trash?',
+		);
+		expect( confirmAt( bulkActions()[ 0 ], 3 ) ).toBe(
+			'Move 3 posts to the trash?',
 		);
 	} );
 
-	test( 'pages mode says page(s)', async () => {
+	test( 'pages mode says page, and pluralizes', async () => {
 		const { bulkActions } = await render(
 			'desktop-mode-pages',
 			'pages',
 			[ row( 1 ) ],
 		);
-		expect( bulkActions()[ 0 ].confirm ).toBe(
-			'Move %d page(s) to the trash?',
+		expect( confirmAt( bulkActions()[ 0 ], 1 ) ).toBe(
+			'Move 1 page to the trash?',
+		);
+		expect( confirmAt( bulkActions()[ 0 ], 3 ) ).toBe(
+			'Move 3 pages to the trash?',
 		);
 	} );
 } );


### PR DESCRIPTION
Follow-up to #550 and #548, which fixed the Pages window wording but kept the `(s)` form.

## Proposed changes

Widens `BulkAction.confirm` in the native Posts and Pages windows so the message can be built from the row count:

```ts
confirm?: string | ( ( count: number ) => string );
```

The shipped trash action moves to `_n()`, so the confirm now reads "Move 1 post to the trash?" or "Move 3 posts to the trash?" instead of "Move 3 post(s) to the trash?".

Plain strings keep working and are still interpolated with `%d`, so bulk actions registered through `openstation.postsWindow.bulkActions` are unaffected.

Docs: the `bulkActions` row in `hooks-reference.md` and the `confirm` example in `examples/native-posts.md`, which taught `'Duplicate %d post(s)?'` and so passed the same problem on to third-party actions.

## Why are these changes being made?

`(s)` stands in for real pluralization and does not translate. Polish has 3 plural forms and Arabic has 6, and none of them can be expressed as an optional trailing `s`. Even in English it reads like a placeholder.

`_n()` is the right tool but could not apply: `confirm` was a plain `string` built in `defaultBulkActions()`, while the row count only exists later, at click time, in the bulk-action runner.

## Testing instructions

Both native windows are beta and off by default, so turn them on first.

1. Open **OpenStation Preferences > Features > Beta features** and enable **Use the native Posts window** and **Use the native Pages window**. Both are per-account and apply immediately, no reload needed.
2. Open Posts from the dock. Make sure you get the table-driven native window, not the classic list iframe. If you still see the classic screen, the toggle did not take.
3. Select one post with the row checkbox and click **Move to trash**. Make sure the confirm reads "Move 1 post to the trash?".
4. Select three posts and click **Move to trash**. Make sure it reads "Move 3 posts to the trash?", and that confirming still trashes all three.
5. Repeat steps 3 and 4 in the Pages window. Make sure the wording says "page" and "pages", not "post".
6. Check that actions passing a string are unchanged. This filter does not change the trash button, it adds a **second** button next to it, so the thing to click is the new one.

   Fully close the Posts window first (the X, not minimise). `manager.open()` focuses an existing window instead of rebuilding it, so the filter only runs on a fresh open. Then in the browser console:

   ```js
   wp.hooks.addFilter(
       'openstation.postsWindow.bulkActions',
       'test/string-confirm',
       ( actions ) => [
           ...actions,
           {
               id: 'test',
               label: 'Test',
               confirm: 'Archive %d item(s)?',
               run: () => {},
           },
       ]
   );
   ```

   Reopen the Posts window and select two posts. Make sure the bulk bar now shows two buttons, **Move to trash** and **Test**. If **Test** is missing, the filter ran too late, so close the window and reopen it again. Click **Test**, not **Move to trash**, and make sure the confirm reads "Archive 2 item(s)?", so a registered action that predates this change still interpolates.
To check the plural forms in a language with more than two, switch the user locale to Polish under **Users > Profile** and repeat step 4 with 1, 2, and 5 posts selected. This needs the translations to be built, which this PR does not do (i18n re-extraction is a separate batched step), so untranslated English is the expected result on a dev install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
