### PR TITLE
Native windows: Fix intro modal colours under the brand palette

### DIFF
--- a/assets/css/posts-window.css
+++ b/assets/css/posts-window.css
@@ -1252,11 +1252,21 @@
 	overflow: hidden;
 }
 
+/*
+ * The explicit `color` is load-bearing. Core's `common.css` ships a
+ * bare `h2, h3 { color: #1d2327 }`, and a declaration matching the
+ * element always beats the value it would otherwise inherit from
+ * `.os-intro` — so without this the title computes to near-black on
+ * the dark dialog surface. `window-chrome.css` already neutralises
+ * that collision, but only under `:where( .os-window__body )`, and
+ * this backdrop is appended to `document.body`.
+ */
 .os-intro__title {
 	margin: 0;
 	font-size: 20px;
 	font-weight: 600;
 	letter-spacing: -0.01em;
+	color: var( --os-ui-fg, #1d2327 );
 }
 
 .os-intro__lede {

--- a/src/plugins-window/intro-dialog.ts
+++ b/src/plugins-window/intro-dialog.ts
@@ -34,8 +34,7 @@ export async function showPluginsIntroDialog(): Promise< IntroResult > {
 		Object.assign( backdrop.style, {
 			position: 'fixed',
 			inset: '0',
-			background:
-				'color-mix(in srgb, var(--wp-admin-theme-color, #1d2327) 60%, transparent)',
+			background: 'rgba(15, 23, 42, 0.55)',
 			backdropFilter: 'blur(2px)',
 			WebkitBackdropFilter: 'blur(2px)',
 			zIndex: '100000',
@@ -51,8 +50,8 @@ export async function showPluginsIntroDialog(): Promise< IntroResult > {
 		dialog.setAttribute( 'aria-labelledby', 'os-plugins-intro-title' );
 		dialog.className = 'os-plugins-intro';
 		Object.assign( dialog.style, {
-			background: 'var(--wp-admin-theme-bg, #fff)',
-			color: 'var(--wp-admin-theme-fg, #1d2327)',
+			background: 'var(--os-ui-surface, #fff)',
+			color: 'var(--os-ui-fg, #1d2327)',
 			borderRadius: '14px',
 			boxShadow: '0 24px 60px rgba(0,0,0,.28)',
 			maxWidth: '560px',
@@ -158,15 +157,21 @@ function renderDialogMarkup(): string {
 
 	return `
 		<style>
+			/*
+			 * Explicit colour: core's bare "h2, h3 { color: #1d2327 }" beats
+			 * the value inherited from the dialog, which reads as near-black
+			 * on the palette's dark surface.
+			 */
 			.os-plugins-intro h2 {
 				margin: 0 0 8px;
 				font-size: 22px;
 				font-weight: 600;
 				letter-spacing: -0.01em;
+				color: var(--os-ui-fg, #1d2327);
 			}
 			.os-plugins-intro p.lede {
 				margin: 0 0 20px;
-				color: var(--wp-admin-theme-fg-muted, #50575e);
+				color: var(--os-ui-fg-muted, #50575e);
 				font-size: 14px;
 				line-height: 1.5;
 			}
@@ -199,8 +204,8 @@ function renderDialogMarkup(): string {
 			}
 			.os-plugins-intro__footer button {
 				appearance: none;
-				border: 1px solid var(--wp-admin-theme-border, #dcdcde);
-				background: var(--wp-admin-theme-bg, #fff);
+				border: 1px solid var(--os-ui-border, #dcdcde);
+				background: var(--os-ui-hover, rgba(0, 0, 0, 0.04));
 				color: inherit;
 				padding: 8px 14px;
 				border-radius: 6px;
@@ -210,7 +215,7 @@ function renderDialogMarkup(): string {
 			.os-plugins-intro__footer button.primary {
 				border-color: var(--wp-admin-theme-color, #2271b1);
 				background: var(--wp-admin-theme-color, #2271b1);
-				color: #fff;
+				color: var(--os-ui-fg-on-accent, #fff);
 				font-weight: 500;
 			}
 			.os-plugins-intro__footer button:hover {

--- a/src/posts-window/pages-intro-dialog.ts
+++ b/src/posts-window/pages-intro-dialog.ts
@@ -33,7 +33,7 @@ export async function showPagesIntroDialog(): Promise< IntroResult > {
 		Object.assign( backdrop.style, {
 			position: 'fixed',
 			inset: '0',
-			background: 'color-mix(in srgb, var(--wp-admin-theme-color, #1d2327) 60%, transparent)',
+			background: 'rgba(15, 23, 42, 0.55)',
 			backdropFilter: 'blur(2px)',
 			zIndex: '100000',
 			display: 'flex',
@@ -48,8 +48,8 @@ export async function showPagesIntroDialog(): Promise< IntroResult > {
 		dialog.setAttribute( 'aria-labelledby', 'os-pages-intro-title' );
 		dialog.className = 'os-pages-intro';
 		Object.assign( dialog.style, {
-			background: 'var(--wp-admin-theme-bg, #fff)',
-			color: 'var(--wp-admin-theme-fg, #1d2327)',
+			background: 'var(--os-ui-surface, #fff)',
+			color: 'var(--os-ui-fg, #1d2327)',
 			borderRadius: '14px',
 			boxShadow: '0 24px 60px rgba(0,0,0,.28)',
 			maxWidth: '520px',
@@ -132,15 +132,21 @@ function renderDialogMarkup(): string {
 
 	return `
 		<style>
+			/*
+			 * Explicit colour: core's bare "h2, h3 { color: #1d2327 }" beats
+			 * the value inherited from the dialog, which reads as near-black
+			 * on the palette's dark surface.
+			 */
 			.os-pages-intro h2 {
 				margin: 0 0 8px;
 				font-size: 22px;
 				font-weight: 600;
 				letter-spacing: -0.01em;
+				color: var(--os-ui-fg, #1d2327);
 			}
 			.os-pages-intro p.lede {
 				margin: 0 0 20px;
-				color: var(--wp-admin-theme-fg-muted, #50575e);
+				color: var(--os-ui-fg-muted, #50575e);
 				font-size: 14px;
 				line-height: 1.5;
 			}
@@ -173,8 +179,8 @@ function renderDialogMarkup(): string {
 			}
 			.os-pages-intro__footer button {
 				appearance: none;
-				border: 1px solid var(--wp-admin-theme-border, #dcdcde);
-				background: var(--wp-admin-theme-bg, #fff);
+				border: 1px solid var(--os-ui-border, #dcdcde);
+				background: var(--os-ui-hover, rgba(0, 0, 0, 0.04));
 				color: inherit;
 				padding: 8px 14px;
 				border-radius: 6px;
@@ -184,7 +190,7 @@ function renderDialogMarkup(): string {
 			.os-pages-intro__footer button.primary {
 				border-color: var(--wp-admin-theme-color, #2271b1);
 				background: var(--wp-admin-theme-color, #2271b1);
-				color: #fff;
+				color: var(--os-ui-fg-on-accent, #fff);
 				font-weight: 500;
 			}
 			.os-pages-intro__footer button:hover { filter: brightness(1.05); }

--- a/src/posts-window/users-intro-dialog.ts
+++ b/src/posts-window/users-intro-dialog.ts
@@ -22,8 +22,7 @@ export async function showUsersIntroDialog(): Promise< IntroResult > {
 		Object.assign( backdrop.style, {
 			position: 'fixed',
 			inset: '0',
-			background:
-				'color-mix(in srgb, var(--wp-admin-theme-color, #1d2327) 60%, transparent)',
+			background: 'rgba(15, 23, 42, 0.55)',
 			backdropFilter: 'blur(2px)',
 			zIndex: '100000',
 			display: 'flex',
@@ -41,8 +40,8 @@ export async function showUsersIntroDialog(): Promise< IntroResult > {
 		);
 		dialog.className = 'os-users-intro';
 		Object.assign( dialog.style, {
-			background: 'var(--wp-admin-theme-bg, #fff)',
-			color: 'var(--wp-admin-theme-fg, #1d2327)',
+			background: 'var(--os-ui-surface, #fff)',
+			color: 'var(--os-ui-fg, #1d2327)',
 			borderRadius: '14px',
 			boxShadow: '0 24px 60px rgba(0,0,0,.28)',
 			maxWidth: '520px',
@@ -121,15 +120,21 @@ function renderDialogMarkup(): string {
 
 	return `
 		<style>
+			/*
+			 * Explicit colour: core's bare "h2, h3 { color: #1d2327 }" beats
+			 * the value inherited from the dialog, which reads as near-black
+			 * on the palette's dark surface.
+			 */
 			.os-users-intro h2 {
 				margin: 0 0 8px;
 				font-size: 22px;
 				font-weight: 600;
 				letter-spacing: -0.01em;
+				color: var(--os-ui-fg, #1d2327);
 			}
 			.os-users-intro p.lede {
 				margin: 0 0 20px;
-				color: var(--wp-admin-theme-fg-muted, #50575e);
+				color: var(--os-ui-fg-muted, #50575e);
 				font-size: 14px;
 				line-height: 1.5;
 			}
@@ -162,8 +167,8 @@ function renderDialogMarkup(): string {
 			}
 			.os-users-intro__footer button {
 				appearance: none;
-				border: 1px solid var(--wp-admin-theme-border, #dcdcde);
-				background: var(--wp-admin-theme-bg, #fff);
+				border: 1px solid var(--os-ui-border, #dcdcde);
+				background: var(--os-ui-hover, rgba(0, 0, 0, 0.04));
 				color: inherit;
 				padding: 8px 14px;
 				border-radius: 6px;
@@ -173,7 +178,7 @@ function renderDialogMarkup(): string {
 			.os-users-intro__footer button.primary {
 				border-color: var(--wp-admin-theme-color, #2271b1);
 				background: var(--wp-admin-theme-color, #2271b1);
-				color: #fff;
+				color: var(--os-ui-fg-on-accent, #fff);
 				font-weight: 500;
 			}
 			.os-users-intro__footer button:hover { filter: brightness(1.05); }

--- a/tests/vitest/intro-dialog-palette.test.ts
+++ b/tests/vitest/intro-dialog-palette.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The four native-window intro dialogs must reach the palette.
+ *
+ * Every native window ships a first-open intro, and each one is
+ * appended to `document.body` rather than into a window body. That
+ * placement is what makes them a distinct hazard, and it is the
+ * source of both bugs this test pins:
+ *
+ * 1. **Undeclared tokens.** These dialogs used to read
+ *    `--wp-admin-theme-bg`, `--wp-admin-theme-fg`,
+ *    `--wp-admin-theme-fg-muted` and `--wp-admin-theme-border`. None
+ *    of those four names is declared anywhere in the plugin, so every
+ *    one silently resolved to its pre-brand literal and the dialogs
+ *    rendered as white cards that neither the palette nor any desktop
+ *    theme could reach. A `var()` on a name nobody declares fails
+ *    open, which is exactly why nothing caught it.
+ *
+ * 2. **The accent used as a scrim.** The backdrops were
+ *    `color-mix( … var( --wp-admin-theme-color, #1d2327 ) 60% … )`.
+ *    That token IS declared — the palette sets it to Pulse — so the
+ *    neutral `#1d2327` fallback never applied and the scrim came out
+ *    60% pink over the whole desktop. An accent colour is not a scrim
+ *    colour.
+ *
+ * The third guard covers the heading collision. Core's `common.css`
+ * ships a bare `h2, h3 { color: #1d2327 }`, and a declaration
+ * matching the element always beats a value the element would
+ * otherwise inherit from the dialog — so a title rule that sets size
+ * and weight but no `color` computes to near-black on the palette's
+ * dark surface. `window-chrome.css` already neutralises this, but
+ * only under `:where( .os-window__body )`, which a body-level
+ * backdrop never matches.
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve( __dirname, '../..' );
+
+/**
+ * The three inline-styled dialogs. The Posts one is styled from
+ * `posts-window.css` instead and is checked separately below.
+ */
+const INLINE_DIALOGS = [
+	'src/posts-window/pages-intro-dialog.ts',
+	'src/posts-window/users-intro-dialog.ts',
+	'src/plugins-window/intro-dialog.ts',
+] as const;
+
+/** Names no stylesheet in the plugin declares. */
+const UNDECLARED = [
+	'--wp-admin-theme-bg',
+	'--wp-admin-theme-fg',
+	'--wp-admin-theme-fg-muted',
+	'--wp-admin-theme-border',
+] as const;
+
+const read = ( rel: string ): string =>
+	readFileSync( resolve( ROOT, rel ), 'utf8' );
+
+describe( 'native-window intro dialogs', () => {
+	test.each( INLINE_DIALOGS )( '%s reads only declared tokens', ( rel ) => {
+		const src = read( rel );
+
+		for ( const name of UNDECLARED ) {
+			// Word-boundary the name so `--wp-admin-theme-fg` does not
+			// also match `--wp-admin-theme-fg-muted`.
+			expect(
+				new RegExp( `${ name }(?![\\w-])` ).test( src ),
+				`${ rel } reads ${ name }, which nothing declares — it will fall back to its pre-brand literal and the palette can never reach it. Use the --os-ui-* equivalent.`
+			).toBe( false );
+		}
+	} );
+
+	test.each( INLINE_DIALOGS )( '%s uses a neutral scrim', ( rel ) => {
+		const src = read( rel );
+
+		expect(
+			/color-mix\([^)]*--wp-admin-theme-color/.test( src ),
+			`${ rel } derives its backdrop from the admin accent. The palette sets that token to Pulse, so the neutral fallback never applies and the scrim renders 60% pink over the desktop. Use a neutral scrim.`
+		).toBe( false );
+	} );
+
+	test.each( INLINE_DIALOGS )( '%s gives its heading a colour', ( rel ) => {
+		const src = read( rel );
+		const heading = /\.os-[a-z-]+-intro h2 \{([^}]*)\}/.exec( src );
+
+		expect( heading, `${ rel } has no intro heading rule` ).not.toBeNull();
+		expect(
+			/(^|\W)color:/.test( heading![ 1 ] ),
+			`${ rel } styles its intro h2 without a color. Core's bare "h2, h3 { color: #1d2327 }" beats the value inherited from the dialog, so the title renders near-black on the dark surface.`
+		).toBe( true );
+	} );
+
+	test( 'the Posts intro title declares a colour', () => {
+		const css = read( 'assets/css/posts-window.css' );
+		const rule = /\.os-intro__title \{([^}]*)\}/.exec( css );
+
+		expect( rule, 'no .os-intro__title rule in posts-window.css' ).not.toBeNull();
+		expect(
+			/(^|\W)color:/.test( rule![ 1 ] ),
+			'.os-intro__title sets no color, so core\'s bare "h2, h3 { color: #1d2327 }" wins over the value inherited from .os-intro and the heading renders near-black on the dark dialog. The window-chrome.css fix is scoped to :where( .os-window__body ) and this backdrop is appended to document.body, so it never reaches here.'
+		).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

The four native-window intro modals now read the palette.

* Posts: `.os-intro__title` declares a colour, so the heading stops rendering near-black on the dark dialog.
* Pages, Users and Plugins: the backdrop is a neutral scrim instead of 60% of the admin accent, and the dialog surfaces read `--os-ui-surface`, `--os-ui-fg`, `--os-ui-fg-muted` and `--os-ui-border` instead of four names nothing declares. Their `h2` gets an explicit colour too, since moving them onto the dark surface exposes the same core-heading collision Posts had.

Before | After
--- | ---
<img width="2550" height="1840" alt="image" src="https://github.com/user-attachments/assets/482ede96-9a48-4211-bd13-02b3dcb0e42c" /> | <img width="1275" height="1172" alt="Screenshot 2026-08-12 at 14 11 48" src="https://github.com/user-attachments/assets/f4f03549-0439-4f0e-b5cf-da5d44f614a7" />
<img width="2564" height="1538" alt="image" src="https://github.com/user-attachments/assets/3a38edc3-9399-4978-8a4b-d96f2619c6e3" /> | <img width="1279" height="1168" alt="Screenshot 2026-08-12 at 14 12 04" src="https://github.com/user-attachments/assets/0ae7baf4-1a7f-47fb-96fc-3799bbaf9b53" />

## Why are these changes being made?

Because the modals were inconsistent and also off-brand.

## Testing instructions

The intro shows once per user per window, gated on `desktop_mode_seen_intros` user meta. Dismissing with Escape or a backdrop click deliberately does *not* mark it seen, so you can reopen each dialog as many times as you need by closing it that way instead of clicking "Got it".

1. Open OpenStation Preferences > Features and turn on "Use the native Posts window", "Use the native Pages window", "Use the native Users window" and "Use the native Plugins window".
2. Open Pages. Make sure the dialog sits on a neutral dark scrim, not a pink wash, and that the card itself matches the shell rather than being a white card.
3. Make sure the heading, the lede and the two buttons are all readable against that surface, and that the bullet dots and the "Got it" button still carry the accent colour.
4. Press Escape to close, then repeat steps 2 and 3 for Users and for Plugins.
5. Open Posts. Make sure "Welcome to the new Posts" is readable, not near-black on the dark dialog.
6. Switch the admin colour scheme (Users > Profile) and reopen a couple of the dialogs. Make sure nothing turns unreadable.
7. Install and activate a desktop theme, then reopen the dialogs and make sure they follow it.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-562-9cabc8ec9b51bee9112e8ec63256ceef747f3443.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->