### PR TITLE
Dashboard: Stop the welcome panel dismiss opening a stray window

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -269,6 +269,8 @@ The class doesn't promise a handler, though. The Media list table stamps it on T
 
 Links owned by core's `wp-admin/js/updates.js` are also left alone: the card-style `install-now` / `update-link` / `update-now` / `delete-plugin` / `delete-theme` / `install-theme` buttons, the plugins-list-table row Delete (`[data-plugin] a.delete`), and the network themes row Delete (`.themes-php.network-admin a.delete`). updates.js `preventDefault`s these itself and runs an in-place AJAX operation; if the bridge hijacked them, the parent-driven navigation would race the AJAX call (a `wp.updates.beforeunload` "Leave site?" prompt followed by the no-JS fallback screen for an already-deleted plugin).
 
+The Dashboard's welcome panel is the same story with no marker class at all: `dashboard.js` binds the dismiss on the anchor and `preventDefault`s it, and `?welcome=0` is a dead no-JS fallback. The interceptor yields `.welcome-panel-close` and `.welcome-panel-dismiss a` inside `#welcome-panel`, matching core's own selector. Routing them opened a second Dashboard window titled **Dismiss** on top of the one being dismissed.
+
 Forms submit through a separate `submit` listener that only rewrites the action URL (to keep `openstation_chromeless=1`) and never `preventDefault`s. Same-origin form posts to a different page would currently navigate the iframe in place; if that becomes a UX problem it can join this protocol as a `os-iframe-admin-form-submit` message.
 
 ### Window titles the shell had to guess

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -1456,6 +1456,21 @@ function openstation_chromeless_bridge_script() {
 			}
 		}
 		/*
+		 * Same shape as the toggles above: dashboard.js binds the
+		 * dismiss on the anchor and preventDefaults, so our capture
+		 * handler gets there first and routes `?welcome=0` (a dead
+		 * no-JS fallback) into a second Dashboard window titled
+		 * "Dismiss". Scoped like core's own selector, so a
+		 * `welcome-panel-close` elsewhere still routes.
+		 */
+		if (
+			link.closest( '#welcome-panel' ) &&
+			( link.classList.contains( 'welcome-panel-close' ) ||
+				link.closest( '.welcome-panel-dismiss' ) )
+		) {
+			return;
+		}
+		/*
 		 * WordPress core's wp-admin/js/updates.js owns the click on these
 		 * AJAX-driven plugin/theme management buttons — it binds in bubble
 		 * phase and calls preventDefault to take over with an in-place

--- a/tests/vitest/chromeless-bridge-links.test.ts
+++ b/tests/vitest/chromeless-bridge-links.test.ts
@@ -150,6 +150,24 @@ describe( 'chromeless bridge: which clicks reach the shell', () => {
 		expect( adminLinkMessages() ).toHaveLength( 0 );
 	} );
 
+	// The Dashboard's welcome panel. dashboard.js binds the dismiss on
+	// the anchor itself, and `?welcome=0` is a no-JS fallback nothing
+	// in core reads any more — routing it opened a second Dashboard
+	// window, titled "Dismiss", on top of the one being dismissed.
+	test( 'the welcome panel dismiss links stay with dashboard.js', () => {
+		clickLink(
+			'<div id="welcome-panel"><a class="welcome-panel-close" href="/wp-admin/?welcome=0" aria-label="Dismiss the welcome panel">Dismiss</a></div>'
+		);
+
+		expect( adminLinkMessages() ).toHaveLength( 0 );
+
+		clickLink(
+			'<div id="welcome-panel"><p class="welcome-panel-dismiss"><a href="/wp-admin/?welcome=0">Dismiss</a></p></div>'
+		);
+
+		expect( adminLinkMessages() ).toHaveLength( 0 );
+	} );
+
 	// On `?tab=upload` core skips that binding on purpose ("let the
 	// link behave like a link"), so the href IS the navigation and the
 	// shell has to route it like any other admin link.


### PR DESCRIPTION
## Proposed Changes

- The chromeless bridge's link interceptor now yields clicks on the Dashboard welcome panel's dismiss links, `.welcome-panel-close` and `.welcome-panel-dismiss a` inside `#welcome-panel`, which is core's own selector.
- Covers it in the bridge link harness.

## Why are these changes being made?

Clicking `Dismiss` on the `Welcome to WordPress!` panel dismissed the panel and also opened a second window on top of it, rendering the Dashboard again, titled `Dismiss`.

## Testing Instructions

1. Enable OpenStation and open the Dashboard window from the dock.
2. If the welcome panel is not visible, open `Screen Options` at the top right and tick `Welcome`.
3. Click `Dismiss` at the top right of the panel.
4. Make sure the panel collapses and nothing else happens. No second window opens.
5. Reload the shell. Make sure the panel is still dismissed.
6. Open `Screen Options` and tick `Welcome` again. Make sure the panel comes back.

On trunk, step 3 also opens a window titled `Dismiss` rendering the Dashboard.

Regression check that Dashboard links still route normally:

1. In the Dashboard window, click a link in the `At a Glance` widget (for example the posts or comments count).
2. Make sure it opens in a window as it does on trunk.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-565-0c503416fe5606c55b32ce7ef6e499fb0fb6449a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->