### PR TITLE
Shell: exit OpenStation when the plugin stops being active

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,11 @@ The server cannot announce this, because the next request no longer loads OpenSt
 
 Triggers are cheap and allowed to be wrong: an iframe loading on an admin path whose `<body>` lacks `os-chromeless` (catches deactivate and delete from the classic `plugins.php`, row and bulk), or a Heartbeat tick without the `desktop_mode_nonces` field (catches another tab or WP-CLI). Neither is conclusive, since `wp_die()` screens carry no `admin_body_class` and core skips `heartbeat_received` on a tick with no client data.
 
-Confirmation is a `GET` of the `desktop-mode/v1` REST namespace index, which answers `200` while the plugin is active and `404 rest_no_route` once it is not, needing neither nonce nor capability. Only a 404 evicts, so a false trigger costs one silent request and a dropped connection never throws the user out. On a confirmed absence the shell toasts and navigates the top frame to `adminUrl`.
+Confirmation is a `GET` of the `desktop-mode/v1` REST namespace index, needing neither nonce nor capability. Only a `404` carrying WordPress's own `rest_no_route` body evicts, because a bare 404 is also what a REST-hardening plugin or a firewall rule on `/wp-json` returns while OpenStation is perfectly healthy. A network error, a non-JSON body, or a shell config with no `restUrl` all leave the shell up. On a confirmed absence the shell toasts and navigates the top frame to `adminUrl` via `leaveForClassicAdmin()`, the same helper the native Plugins window's `reloadOutOfOpenStation()` uses.
+
+The watcher stops pinging after three consecutive "still here" answers, and any proof the plugin is alive (a chromeless page, a tick carrying the field) resets that. The Heartbeat field is gated on `openstation_is_enabled()`, not on the plugin being loaded, so a user who turns OpenStation off in another tab would otherwise make every later tick a trigger forever.
+
+State lives in a `createSharedStore` because this module compiles into both the main bundle and the lazy `window-system` one.
 
 The native Plugins window keeps its own faster path (`isOpenStationSelf()` / `reloadOutOfOpenStation()` in `src/plugins-window/rest.ts`), since it knows which plugin the user just acted on.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,21 @@ Key server-side entry points:
 6. The iframe renders WordPress normally, but the chromeless stylesheet hides the admin bar, side menu, and wp-footer.
 7. The iframe `postMessage`s its title, navigation, and screen-meta state up to the parent.
 
+### When OpenStation stops being active underneath the shell
+
+Deactivating or deleting the plugin while a shell tab is open is the one transition the server cannot announce: the next request no longer loads OpenStation, so there is no payload, no bridge and no hook left to fire. `src/plugin-presence.ts` handles it client side, in two halves.
+
+**Triggers** are cheap and allowed to be wrong:
+
+- an iframe finishing a load on an admin path whose `<body>` lacks `os-chromeless` (catches deactivate / delete from the classic `plugins.php` in a window, single-row and bulk alike, without knowing which plugin was acted on);
+- a Heartbeat tick arriving without the `desktop_mode_nonces` field (catches deactivation from another tab or WP-CLI, which no iframe load would ever see).
+
+**Confirmation** is authoritative: a `GET` of the `desktop-mode/v1` REST namespace index, which answers `200` while the plugin is active and `404 rest_no_route` once it is not, needing neither nonce nor capability. Only a 404 evicts; a network error deliberately does not, because an offline shell is still a working shell. On a confirmed absence the shell toasts and navigates the top frame to `adminUrl`.
+
+The split is the point: a false trigger costs one silent request, which is what makes it safe to trigger on signals that are merely suggestive. `wp_die()` screens carry no `admin_body_class` at all, and core skips `heartbeat_received` on a tick with no client data — both would otherwise be false positives.
+
+The native Plugins window keeps its own faster path (`isOpenStationSelf()` / `reloadOutOfOpenStation()` in `src/plugins-window/rest.ts`): it knows which plugin the user just acted on, so it can skip the round trip.
+
 ## Desktop layout modes
 
 OpenStation Preferences → Appearance lets the user pick one of four top-level layouts. The shell root reflects the choice in `data-os-layout`; the layout dispatcher (`src/desktop-layout.ts`) owns every dock instance and the synthesized desktop-icon list, tearing down and rebuilding when the user switches.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,18 +98,13 @@ Key server-side entry points:
 
 ### When OpenStation stops being active underneath the shell
 
-Deactivating or deleting the plugin while a shell tab is open is the one transition the server cannot announce: the next request no longer loads OpenStation, so there is no payload, no bridge and no hook left to fire. `src/plugin-presence.ts` handles it client side, in two halves.
+The server cannot announce this, because the next request no longer loads OpenStation. `src/plugin-presence.ts` detects it client side instead, in two halves.
 
-**Triggers** are cheap and allowed to be wrong:
+Triggers are cheap and allowed to be wrong: an iframe loading on an admin path whose `<body>` lacks `os-chromeless` (catches deactivate and delete from the classic `plugins.php`, row and bulk), or a Heartbeat tick without the `desktop_mode_nonces` field (catches another tab or WP-CLI). Neither is conclusive, since `wp_die()` screens carry no `admin_body_class` and core skips `heartbeat_received` on a tick with no client data.
 
-- an iframe finishing a load on an admin path whose `<body>` lacks `os-chromeless` (catches deactivate / delete from the classic `plugins.php` in a window, single-row and bulk alike, without knowing which plugin was acted on);
-- a Heartbeat tick arriving without the `desktop_mode_nonces` field (catches deactivation from another tab or WP-CLI, which no iframe load would ever see).
+Confirmation is a `GET` of the `desktop-mode/v1` REST namespace index, which answers `200` while the plugin is active and `404 rest_no_route` once it is not, needing neither nonce nor capability. Only a 404 evicts, so a false trigger costs one silent request and a dropped connection never throws the user out. On a confirmed absence the shell toasts and navigates the top frame to `adminUrl`.
 
-**Confirmation** is authoritative: a `GET` of the `desktop-mode/v1` REST namespace index, which answers `200` while the plugin is active and `404 rest_no_route` once it is not, needing neither nonce nor capability. Only a 404 evicts; a network error deliberately does not, because an offline shell is still a working shell. On a confirmed absence the shell toasts and navigates the top frame to `adminUrl`.
-
-The split is the point: a false trigger costs one silent request, which is what makes it safe to trigger on signals that are merely suggestive. `wp_die()` screens carry no `admin_body_class` at all, and core skips `heartbeat_received` on a tick with no client data — both would otherwise be false positives.
-
-The native Plugins window keeps its own faster path (`isOpenStationSelf()` / `reloadOutOfOpenStation()` in `src/plugins-window/rest.ts`): it knows which plugin the user just acted on, so it can skip the round trip.
+The native Plugins window keeps its own faster path (`isOpenStationSelf()` / `reloadOutOfOpenStation()` in `src/plugins-window/rest.ts`), since it knows which plugin the user just acted on.
 
 ## Desktop layout modes
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -3700,10 +3700,7 @@ function init(): void {
 	// if init() ever fires again.
 	bootHeartbeatBus();
 
-	// Notice OpenStation being deactivated from somewhere the shell
-	// can't see (another tab, WP-CLI) and walk the user out. The
-	// in-window path is covered by the iframe-load trigger in
-	// `window/dom.ts`.
+	// Notice OpenStation being deactivated from another tab, WP-CLI, etc.
 	bootPluginPresenceWatch();
 
 	// Challenge delivery rides the bus above — lives in the main

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -184,6 +184,7 @@ import {
 import { recentlyMarqueed, type SelectionApi } from './selection';
 import { type ActivityApi } from './activity';
 import { bootHeartbeatBus, type HeartbeatBus } from './heartbeat';
+import { bootPluginPresenceWatch } from './plugin-presence';
 import { bootContentChangesHeartbeat } from './content-changes/heartbeat';
 import { bootNonceRefresh } from './nonce-refresh';
 import { bootAuthRecovery } from './auth-recovery';
@@ -3698,6 +3699,12 @@ function init(): void {
 	// contributor / subscriber. Idempotent — safe to run twice
 	// if init() ever fires again.
 	bootHeartbeatBus();
+
+	// Notice OpenStation being deactivated from somewhere the shell
+	// can't see (another tab, WP-CLI) and walk the user out. The
+	// in-window path is covered by the iframe-load trigger in
+	// `window/dom.ts`.
+	bootPluginPresenceWatch();
 
 	// Challenge delivery rides the bus above — lives in the main
 	// bundle (like the recycle-bin badge) so an incoming challenge

--- a/src/exit-openstation.ts
+++ b/src/exit-openstation.ts
@@ -101,8 +101,40 @@ export async function exitOpenStation(): Promise< void > {
  */
 function navigateTop( url: string ): void {
 	try {
-		window.top!.location.href = url;
+		( window.top ?? window ).location.assign( url );
 	} catch {
-		window.location.href = url;
+		window.location.assign( url );
 	}
+}
+
+/**
+ * Delay before leaving, so the toast explaining why is readable.
+ */
+export const LEAVE_DELAY_MS = 800;
+
+/**
+ * Leave the shell for the classic admin. Shared by every "OpenStation
+ * is gone, get the user out" path so the delay and the fallback can't
+ * drift apart.
+ *
+ * `adminUrl` rather than a reload because the current URL may be a
+ * now-unroutable `admin.php?page=…`.
+ */
+export function leaveForClassicAdmin(
+	adminUrl: string,
+	delayMs: number = LEAVE_DELAY_MS,
+): void {
+	window.setTimeout( () => {
+		if ( adminUrl ) {
+			navigateTop( adminUrl );
+			return;
+		}
+		// No admin URL (older registration / test harness). A reload
+		// still beats sitting on a dead shell.
+		try {
+			( window.top ?? window ).location.reload();
+		} catch {
+			window.location.reload();
+		}
+	}, delayMs );
 }

--- a/src/plugin-presence.ts
+++ b/src/plugin-presence.ts
@@ -1,39 +1,12 @@
 /**
- * Notices that OpenStation itself stopped being active, and walks the
- * user out of the shell.
+ * Notices OpenStation being deactivated or deleted under a running
+ * shell, and walks the user out.
  *
- * Deactivating (or deleting) OpenStation from the classic
- * `plugins.php` inside a window leaves the shell running on top of a
- * plugin that no longer loads: the desktop, dock and windows stay up,
- * every `desktop-mode/v1` call 404s, and the window where the action
- * happened repaints as a full classic admin page inside the frame.
- * The native Plugins window already handles its own case
- * (`isOpenStationSelf()` / `reloadOutOfOpenStation()` in
- * `src/plugins-window/rest.ts`), but that window is opt-in and off by
- * default, so the default path had no guard at all.
- *
- * The server cannot help after the fact — the next request no longer
- * loads OpenStation, so there is no payload, no bridge and no hook to
- * fire. Detection has to be client side, and it is split in two:
- *
- *   - **Triggers** are cheap and allowed to be wrong. A chromeless
- *     admin iframe that loads *without* the `os-chromeless` body class
- *     (see `includes/render/body-classes.php`), or a Heartbeat tick
- *     that arrives without the `desktop_mode_nonces` field (see
- *     `includes/nonce-refresh.php`), both mean "OpenStation might be
- *     gone". Neither is conclusive: `wp_die()` screens render no
- *     `admin_body_class` at all, and core skips `heartbeat_received`
- *     entirely on a tick that carries no client data.
- *
- *   - **Confirmation** is authoritative and cheap enough to be worth
- *     the round trip. The `desktop-mode/v1` REST namespace index
- *     answers 200 while the plugin is active and 404 `rest_no_route`
- *     once it is not. It needs no nonce and no capability, so it
- *     survives exactly the situation being tested for.
- *
- * That split is the whole design: a false trigger costs one silent
- * request and nothing else, which is what makes it safe to trigger on
- * signals that are merely suggestive.
+ * The server cannot announce it: the next request no longer loads the
+ * plugin. So triggers are cheap and allowed to be wrong (an admin
+ * iframe without the `os-chromeless` body class, a Heartbeat tick
+ * without `desktop_mode_nonces`), and a REST namespace ping is what
+ * actually decides. A false trigger then costs one silent request.
  */
 
 import { __ } from './i18n';
@@ -44,27 +17,13 @@ import { joinRestUrl } from './rest-url';
 /** Matches `OPENSTATION_NONCE_REFRESH_FIELD` in `includes/nonce-refresh.php`. */
 const NONCE_FIELD = 'desktop_mode_nonces';
 
-/**
- * The REST namespace whose existence IS the plugin's existence. Its
- * index route is registered by WordPress for any namespace that has
- * routes, and disappears with them.
- */
+/** The REST namespace whose existence means that the plugin is active. */
 const NAMESPACE_PATH = 'desktop-mode/v1';
 
-/**
- * Minimum spacing between confirmation pings. Triggers are allowed to
- * be noisy (a Heartbeat tick without client data fires one every
- * interval), so the throttle — not the trigger — is what bounds the
- * request rate.
- */
+/** Triggers are allowed to be noisy, so the throttle is what bounds the request rate. */
 const CONFIRM_COOLDOWN_MS = 30_000;
 
-/**
- * How long the toast is on screen before the navigation. Long enough
- * to read, short enough that the page swap still reads as a
- * consequence of the click that caused it. Matches the native Plugins
- * window's own delay.
- */
+/** Time to read the toast before the navigation. */
 const EXIT_DELAY_MS = 2000;
 
 let confirmInFlight = false;
@@ -86,10 +45,8 @@ function readConfig(): ShellConfig {
 }
 
 /**
- * Admin path prefix used to tell "an admin page lost its chromeless
- * marker" from "a front-end page, which never had one". `body_class`
- * is not `admin_body_class`: a window showing the site's front end
- * carries no `os-chromeless` and is perfectly healthy.
+ * Admin path prefix. The marker comes from `admin_body_class`, so a
+ * front-end page in a window never carries it and is fine.
  */
 function adminPath(): string {
 	const raw = readConfig().adminUrl || '/wp-admin/';
@@ -108,14 +65,7 @@ function namespaceUrl(): string {
 	return joinRestUrl( root, NAMESPACE_PATH );
 }
 
-/**
- * Confirm — or dismiss — a suspicion that the plugin is gone.
- *
- * Only a 404 counts. A network error is deliberately NOT treated as
- * absence: an offline shell is still a working shell, and evicting the
- * user out of it on a dropped connection would be worse than the bug
- * this module exists to fix.
- */
+/** Confirm, or dismiss, a suspicion that the plugin is gone. */
 async function confirmAbsence(): Promise< void > {
 	if ( exiting || confirmInFlight ) {
 		return;
@@ -143,16 +93,8 @@ async function confirmAbsence(): Promise< void > {
 }
 
 /**
- * Announce the eviction and navigate the top frame to the classic
- * Dashboard.
- *
- * The navigation is on a plain timer rather than chained off the
- * toast: when OpenStation was *deleted* rather than deactivated, the
- * lazy `shell-overlays` bundle the toast renders through is no longer
- * on disk and never resolves. The user still has to get out.
- *
- * `adminUrl` is the destination rather than a reload because the
- * current URL may itself be a now-unroutable `admin.php?page=…`.
+ * Navigate the top frame to the classic Dashboard. Not a reload,
+ * because the current URL may be a now-unroutable `admin.php?page=…`.
  */
 function exitToClassicAdmin(): void {
 	if ( exiting ) {
@@ -160,10 +102,9 @@ function exitToClassicAdmin(): void {
 	}
 	exiting = true;
 
-	// Armed FIRST, and the toast is allowed to fail: on a *delete*
-	// the lazy `shell-overlays` bundle it renders through is no
-	// longer on disk. Losing the message is survivable; losing the
-	// way out is the bug this module exists to fix.
+	// Armed before the toast, and the toast is allowed to fail: on a
+	// delete, the lazy `shell-overlays` bundle it renders through is
+	// no longer on disk.
 	const dest = readConfig().adminUrl || '/wp-admin/';
 	window.setTimeout( () => {
 		const target = window.top ?? window;
@@ -188,14 +129,9 @@ function exitToClassicAdmin(): void {
 }
 
 /**
- * Trigger: a window iframe finished loading. Same-origin admin pages
- * are the only ones that carry the chromeless marker, so everything
- * else is left alone.
- *
- * Called on every iframe `load`, which includes in-place navigations —
- * that is what catches the classic `plugins.php` row action, both the
- * single-row and the bulk form, without knowing anything about which
- * plugin was acted on.
+ * Trigger: a window iframe finished loading. Fires on in-place
+ * navigations too, which is what catches the classic `plugins.php`
+ * row and bulk actions.
  */
 export function noteFrameLoaded( frame: HTMLIFrameElement ): void {
 	if ( exiting ) {
@@ -227,13 +163,10 @@ interface JQueryLike {
 }
 
 /**
- * Trigger: a Heartbeat tick came back without OpenStation's nonce
- * field. Covers the case no iframe load can — the plugin deactivated
- * from another tab, or over WP-CLI, while the shell sits idle.
- *
- * Bound directly rather than through `src/heartbeat.ts`: that bus
- * deliberately skips subscribers when a field is `undefined`, and
- * `undefined` is precisely the signal here.
+ * Trigger: a Heartbeat tick without OpenStation's nonce field, which
+ * catches deactivation from another tab or WP-CLI. Bound directly
+ * rather than through `src/heartbeat.ts`, because that bus skips
+ * subscribers on `undefined` and `undefined` is the signal here.
  */
 export function bootPluginPresenceWatch(): void {
 	if ( booted ) {

--- a/src/plugin-presence.ts
+++ b/src/plugin-presence.ts
@@ -1,0 +1,266 @@
+/**
+ * Notices that OpenStation itself stopped being active, and walks the
+ * user out of the shell.
+ *
+ * Deactivating (or deleting) OpenStation from the classic
+ * `plugins.php` inside a window leaves the shell running on top of a
+ * plugin that no longer loads: the desktop, dock and windows stay up,
+ * every `desktop-mode/v1` call 404s, and the window where the action
+ * happened repaints as a full classic admin page inside the frame.
+ * The native Plugins window already handles its own case
+ * (`isOpenStationSelf()` / `reloadOutOfOpenStation()` in
+ * `src/plugins-window/rest.ts`), but that window is opt-in and off by
+ * default, so the default path had no guard at all.
+ *
+ * The server cannot help after the fact — the next request no longer
+ * loads OpenStation, so there is no payload, no bridge and no hook to
+ * fire. Detection has to be client side, and it is split in two:
+ *
+ *   - **Triggers** are cheap and allowed to be wrong. A chromeless
+ *     admin iframe that loads *without* the `os-chromeless` body class
+ *     (see `includes/render/body-classes.php`), or a Heartbeat tick
+ *     that arrives without the `desktop_mode_nonces` field (see
+ *     `includes/nonce-refresh.php`), both mean "OpenStation might be
+ *     gone". Neither is conclusive: `wp_die()` screens render no
+ *     `admin_body_class` at all, and core skips `heartbeat_received`
+ *     entirely on a tick that carries no client data.
+ *
+ *   - **Confirmation** is authoritative and cheap enough to be worth
+ *     the round trip. The `desktop-mode/v1` REST namespace index
+ *     answers 200 while the plugin is active and 404 `rest_no_route`
+ *     once it is not. It needs no nonce and no capability, so it
+ *     survives exactly the situation being tested for.
+ *
+ * That split is the whole design: a false trigger costs one silent
+ * request and nothing else, which is what makes it safe to trigger on
+ * signals that are merely suggestive.
+ */
+
+import { __ } from './i18n';
+import { showToast } from './toast';
+import { trackedFetch } from './tracked-fetch';
+import { joinRestUrl } from './rest-url';
+
+/** Matches `OPENSTATION_NONCE_REFRESH_FIELD` in `includes/nonce-refresh.php`. */
+const NONCE_FIELD = 'desktop_mode_nonces';
+
+/**
+ * The REST namespace whose existence IS the plugin's existence. Its
+ * index route is registered by WordPress for any namespace that has
+ * routes, and disappears with them.
+ */
+const NAMESPACE_PATH = 'desktop-mode/v1';
+
+/**
+ * Minimum spacing between confirmation pings. Triggers are allowed to
+ * be noisy (a Heartbeat tick without client data fires one every
+ * interval), so the throttle — not the trigger — is what bounds the
+ * request rate.
+ */
+const CONFIRM_COOLDOWN_MS = 30_000;
+
+/**
+ * How long the toast is on screen before the navigation. Long enough
+ * to read, short enough that the page swap still reads as a
+ * consequence of the click that caused it. Matches the native Plugins
+ * window's own delay.
+ */
+const EXIT_DELAY_MS = 2000;
+
+let confirmInFlight = false;
+/** `null` until the first ping — distinct from "pinged at epoch 0". */
+let lastConfirmAt: number | null = null;
+let exiting = false;
+let booted = false;
+
+interface ShellConfig {
+	adminUrl?: string;
+	restUrl?: string;
+}
+
+function readConfig(): ShellConfig {
+	return (
+		( window as unknown as { wp?: { os?: { config?: ShellConfig } } } ).wp
+			?.os?.config ?? {}
+	);
+}
+
+/**
+ * Admin path prefix used to tell "an admin page lost its chromeless
+ * marker" from "a front-end page, which never had one". `body_class`
+ * is not `admin_body_class`: a window showing the site's front end
+ * carries no `os-chromeless` and is perfectly healthy.
+ */
+function adminPath(): string {
+	const raw = readConfig().adminUrl || '/wp-admin/';
+	let path: string;
+	try {
+		path = new URL( raw, window.location.href ).pathname;
+	} catch {
+		path = '/wp-admin/';
+	}
+	return path.endsWith( '/' ) ? path : `${ path }/`;
+}
+
+function namespaceUrl(): string {
+	const root =
+		readConfig().restUrl || `${ window.location.origin }/wp-json/`;
+	return joinRestUrl( root, NAMESPACE_PATH );
+}
+
+/**
+ * Confirm — or dismiss — a suspicion that the plugin is gone.
+ *
+ * Only a 404 counts. A network error is deliberately NOT treated as
+ * absence: an offline shell is still a working shell, and evicting the
+ * user out of it on a dropped connection would be worse than the bug
+ * this module exists to fix.
+ */
+async function confirmAbsence(): Promise< void > {
+	if ( exiting || confirmInFlight ) {
+		return;
+	}
+	const now = Date.now();
+	if ( lastConfirmAt !== null && now - lastConfirmAt < CONFIRM_COOLDOWN_MS ) {
+		return;
+	}
+	lastConfirmAt = now;
+	confirmInFlight = true;
+	try {
+		const res = await trackedFetch(
+			namespaceUrl(),
+			{ credentials: 'same-origin' },
+			{ silent: true, source: 'desktop-mode/plugin-presence' },
+		);
+		if ( res.status === 404 ) {
+			exitToClassicAdmin();
+		}
+	} catch {
+		/* Offline or blocked — say nothing, keep the shell up. */
+	} finally {
+		confirmInFlight = false;
+	}
+}
+
+/**
+ * Announce the eviction and navigate the top frame to the classic
+ * Dashboard.
+ *
+ * The navigation is on a plain timer rather than chained off the
+ * toast: when OpenStation was *deleted* rather than deactivated, the
+ * lazy `shell-overlays` bundle the toast renders through is no longer
+ * on disk and never resolves. The user still has to get out.
+ *
+ * `adminUrl` is the destination rather than a reload because the
+ * current URL may itself be a now-unroutable `admin.php?page=…`.
+ */
+function exitToClassicAdmin(): void {
+	if ( exiting ) {
+		return;
+	}
+	exiting = true;
+
+	// Armed FIRST, and the toast is allowed to fail: on a *delete*
+	// the lazy `shell-overlays` bundle it renders through is no
+	// longer on disk. Losing the message is survivable; losing the
+	// way out is the bug this module exists to fix.
+	const dest = readConfig().adminUrl || '/wp-admin/';
+	window.setTimeout( () => {
+		const target = window.top ?? window;
+		try {
+			target.location.assign( dest );
+		} catch {
+			// Cross-origin top frame — land this frame at least.
+			window.location.assign( dest );
+		}
+	}, EXIT_DELAY_MS );
+
+	try {
+		showToast( {
+			message: __(
+				'OpenStation is no longer active. Returning to the WordPress dashboard…',
+			),
+			duration: EXIT_DELAY_MS,
+		} );
+	} catch {
+		/* No toast — the navigation above still stands. */
+	}
+}
+
+/**
+ * Trigger: a window iframe finished loading. Same-origin admin pages
+ * are the only ones that carry the chromeless marker, so everything
+ * else is left alone.
+ *
+ * Called on every iframe `load`, which includes in-place navigations —
+ * that is what catches the classic `plugins.php` row action, both the
+ * single-row and the bulk form, without knowing anything about which
+ * plugin was acted on.
+ */
+export function noteFrameLoaded( frame: HTMLIFrameElement ): void {
+	if ( exiting ) {
+		return;
+	}
+	let doc: Document | null = null;
+	try {
+		doc = frame.contentDocument;
+	} catch {
+		// Cross-origin — not a chromeless admin page by definition.
+		return;
+	}
+	if ( ! doc?.body || ! doc.location ) {
+		return;
+	}
+	if ( ! doc.location.pathname.startsWith( adminPath() ) ) {
+		return;
+	}
+	if ( doc.body.classList.contains( 'os-chromeless' ) ) {
+		return;
+	}
+	void confirmAbsence();
+}
+
+interface JQueryLike {
+	( selector: Document ): {
+		on: ( event: string, handler: ( ...args: unknown[] ) => void ) => void;
+	};
+}
+
+/**
+ * Trigger: a Heartbeat tick came back without OpenStation's nonce
+ * field. Covers the case no iframe load can — the plugin deactivated
+ * from another tab, or over WP-CLI, while the shell sits idle.
+ *
+ * Bound directly rather than through `src/heartbeat.ts`: that bus
+ * deliberately skips subscribers when a field is `undefined`, and
+ * `undefined` is precisely the signal here.
+ */
+export function bootPluginPresenceWatch(): void {
+	if ( booted ) {
+		return;
+	}
+	booted = true;
+	const $ = ( window as unknown as { jQuery?: JQueryLike } ).jQuery;
+	if ( ! $ ) {
+		return;
+	}
+	$( document ).on( 'heartbeat-tick', ( ...args: unknown[] ) => {
+		const response = args[ 1 ] as Record< string, unknown > | undefined;
+		if ( ! response || response[ NONCE_FIELD ] !== undefined ) {
+			return;
+		}
+		void confirmAbsence();
+	} );
+}
+
+/**
+ * Test-only reset.
+ *
+ * @internal
+ */
+export function _resetPluginPresenceForTests(): void {
+	confirmInFlight = false;
+	lastConfirmAt = null;
+	exiting = false;
+	booted = false;
+}

--- a/src/plugin-presence.ts
+++ b/src/plugin-presence.ts
@@ -13,6 +13,8 @@ import { __ } from './i18n';
 import { showToast } from './toast';
 import { trackedFetch } from './tracked-fetch';
 import { joinRestUrl } from './rest-url';
+import { createSharedStore } from './shared-store';
+import { leaveForClassicAdmin, LEAVE_DELAY_MS } from './exit-openstation';
 
 /** Matches `OPENSTATION_NONCE_REFRESH_FIELD` in `includes/nonce-refresh.php`. */
 const NONCE_FIELD = 'desktop_mode_nonces';
@@ -23,14 +25,41 @@ const NAMESPACE_PATH = 'desktop-mode/v1';
 /** Triggers are allowed to be noisy, so the throttle is what bounds the request rate. */
 const CONFIRM_COOLDOWN_MS = 30_000;
 
-/** Time to read the toast before the navigation. */
-const EXIT_DELAY_MS = 2000;
+/**
+ * Consecutive "actually still here" answers before the watcher gives
+ * up. Some sites sit in a permanent trigger state: the Heartbeat
+ * field is gated on `openstation_is_enabled()`, so a user who turns
+ * OpenStation off in another tab makes every later tick a trigger.
+ * Without a cap that is a ping every cooldown, forever, for nothing.
+ * Proof the plugin is alive resets it.
+ */
+const MAX_NEGATIVE_CONFIRMS = 3;
 
-let confirmInFlight = false;
-/** `null` until the first ping — distinct from "pinged at epoch 0". */
-let lastConfirmAt: number | null = null;
-let exiting = false;
-let booted = false;
+interface PresenceState {
+	confirmInFlight: boolean;
+	/** `null` until the first ping — distinct from "pinged at epoch 0". */
+	lastConfirmAt: number | null;
+	exiting: boolean;
+	booted: boolean;
+	negativeConfirms: number;
+}
+
+/**
+ * Shared because this module compiles into BOTH the main bundle
+ * (via `desktop.ts`) and the lazy `window-system` bundle (via
+ * `window/dom.ts`). Module-level state would give each copy its own
+ * flags: two exits racing, and a cooldown that bounds nothing.
+ */
+const store = createSharedStore< PresenceState >(
+	'desktop-mode/plugin-presence',
+	() => ( {
+		confirmInFlight: false,
+		lastConfirmAt: null,
+		exiting: false,
+		booted: false,
+		negativeConfirms: 0,
+	} ),
+);
 
 interface ShellConfig {
 	adminUrl?: string;
@@ -59,69 +88,91 @@ function adminPath(): string {
 	return path.endsWith( '/' ) ? path : `${ path }/`;
 }
 
-function namespaceUrl(): string {
-	const root =
-		readConfig().restUrl || `${ window.location.origin }/wp-json/`;
+/**
+ * `null` when the shell config carries no REST root. Guessing one
+ * gets subdirectory installs and plain permalinks wrong, and a wrong
+ * guess 404s every time, which would be a guaranteed false eviction.
+ * Not pinging at all is the safe answer.
+ */
+function namespaceUrl(): string | null {
+	const root = readConfig().restUrl;
+	if ( ! root ) {
+		return null;
+	}
 	return joinRestUrl( root, NAMESPACE_PATH );
+}
+
+/** The plugin answered, so stop distrusting the triggers. */
+function noteStillPresent(): void {
+	store.state.negativeConfirms = 0;
 }
 
 /** Confirm, or dismiss, a suspicion that the plugin is gone. */
 async function confirmAbsence(): Promise< void > {
-	if ( exiting || confirmInFlight ) {
+	const s = store.state;
+	if ( s.exiting || s.confirmInFlight ) {
+		return;
+	}
+	if ( s.negativeConfirms >= MAX_NEGATIVE_CONFIRMS ) {
+		return;
+	}
+	const url = namespaceUrl();
+	if ( ! url ) {
 		return;
 	}
 	const now = Date.now();
-	if ( lastConfirmAt !== null && now - lastConfirmAt < CONFIRM_COOLDOWN_MS ) {
+	if ( s.lastConfirmAt !== null && now - s.lastConfirmAt < CONFIRM_COOLDOWN_MS ) {
 		return;
 	}
-	lastConfirmAt = now;
-	confirmInFlight = true;
+	s.lastConfirmAt = now;
+	s.confirmInFlight = true;
 	try {
 		const res = await trackedFetch(
-			namespaceUrl(),
+			url,
 			{ credentials: 'same-origin' },
 			{ silent: true, source: 'desktop-mode/plugin-presence' },
 		);
-		if ( res.status === 404 ) {
-			exitToClassicAdmin();
+		if ( res.status !== 404 ) {
+			s.negativeConfirms += 1;
+			return;
 		}
+		// A bare 404 is not enough. Plenty of things return one while
+		// OpenStation is perfectly healthy: a REST-hardening plugin
+		// that unregisters namespaces, a firewall or CDN rule on
+		// `/wp-json`. Only WordPress's own "no such route" body means
+		// the routes are genuinely gone. A non-JSON body (an HTML
+		// block page) throws out to the catch, which is the same
+		// answer.
+		const body = ( await res.json() ) as { code?: string } | null;
+		if ( body?.code !== 'rest_no_route' ) {
+			s.negativeConfirms += 1;
+			return;
+		}
+		exitToClassicAdmin();
 	} catch {
 		/* Offline or blocked — say nothing, keep the shell up. */
 	} finally {
-		confirmInFlight = false;
+		s.confirmInFlight = false;
 	}
 }
 
-/**
- * Navigate the top frame to the classic Dashboard. Not a reload,
- * because the current URL may be a now-unroutable `admin.php?page=…`.
- */
 function exitToClassicAdmin(): void {
-	if ( exiting ) {
+	if ( store.state.exiting ) {
 		return;
 	}
-	exiting = true;
+	store.state.exiting = true;
 
 	// Armed before the toast, and the toast is allowed to fail: on a
 	// delete, the lazy `shell-overlays` bundle it renders through is
 	// no longer on disk.
-	const dest = readConfig().adminUrl || '/wp-admin/';
-	window.setTimeout( () => {
-		const target = window.top ?? window;
-		try {
-			target.location.assign( dest );
-		} catch {
-			// Cross-origin top frame — land this frame at least.
-			window.location.assign( dest );
-		}
-	}, EXIT_DELAY_MS );
+	leaveForClassicAdmin( readConfig().adminUrl || '' );
 
 	try {
 		showToast( {
 			message: __(
 				'OpenStation is no longer active. Returning to the WordPress dashboard…',
 			),
-			duration: EXIT_DELAY_MS,
+			duration: LEAVE_DELAY_MS,
 		} );
 	} catch {
 		/* No toast — the navigation above still stands. */
@@ -134,7 +185,7 @@ function exitToClassicAdmin(): void {
  * row and bulk actions.
  */
 export function noteFrameLoaded( frame: HTMLIFrameElement ): void {
-	if ( exiting ) {
+	if ( store.state.exiting ) {
 		return;
 	}
 	let doc: Document | null = null;
@@ -147,10 +198,13 @@ export function noteFrameLoaded( frame: HTMLIFrameElement ): void {
 	if ( ! doc?.body || ! doc.location ) {
 		return;
 	}
+	// Also where `about:blank` frames (a window before its real src
+	// lands) drop out.
 	if ( ! doc.location.pathname.startsWith( adminPath() ) ) {
 		return;
 	}
 	if ( doc.body.classList.contains( 'os-chromeless' ) ) {
+		noteStillPresent();
 		return;
 	}
 	void confirmAbsence();
@@ -169,17 +223,21 @@ interface JQueryLike {
  * subscribers on `undefined` and `undefined` is the signal here.
  */
 export function bootPluginPresenceWatch(): void {
-	if ( booted ) {
+	if ( store.state.booted ) {
 		return;
 	}
-	booted = true;
+	store.state.booted = true;
 	const $ = ( window as unknown as { jQuery?: JQueryLike } ).jQuery;
 	if ( ! $ ) {
 		return;
 	}
 	$( document ).on( 'heartbeat-tick', ( ...args: unknown[] ) => {
 		const response = args[ 1 ] as Record< string, unknown > | undefined;
-		if ( ! response || response[ NONCE_FIELD ] !== undefined ) {
+		if ( ! response ) {
+			return;
+		}
+		if ( response[ NONCE_FIELD ] !== undefined ) {
+			noteStillPresent();
 			return;
 		}
 		void confirmAbsence();
@@ -192,8 +250,5 @@ export function bootPluginPresenceWatch(): void {
  * @internal
  */
 export function _resetPluginPresenceForTests(): void {
-	confirmInFlight = false;
-	lastConfirmAt = null;
-	exiting = false;
-	booted = false;
+	store.reset();
 }

--- a/src/plugins-window/rest.ts
+++ b/src/plugins-window/rest.ts
@@ -20,6 +20,7 @@
 
 import { trackedFetch } from '../tracked-fetch';
 import { joinRestUrl } from '../rest-url';
+import { leaveForClassicAdmin } from '../exit-openstation';
 import type {
 	BrowseFilter,
 	InstalledPlugin,
@@ -643,51 +644,17 @@ export function isOpenStationSelf( pluginFile: string ): boolean {
 }
 
 /**
- * Navigate the top-level window to the classic wp-admin Dashboard
- * after a brief delay so the user can read the "OpenStation
- * deactivated" toast. Drives navigation against `config.adminUrl`
- * (the server-localized `admin_url()`) instead of `location.reload()`
- * because the current URL may be a deactivated plugin's
- * `admin.php?page=…` route — reloading that lands the user on
- * "Sorry, you are not allowed to access this page." Going to the
- * Dashboard is the WordPress-default landing the user expects when
- * OpenStation is off.
- *
- * The top frame is targeted (not just this window) because every
- * other open openstation window is also iframing into a now-stale
- * shell context.
- *
- * The delay is short enough that the page swap feels like a natural
- * consequence of the click; long enough for the toast text to be
- * legible.
+ * Leave the shell for the classic Dashboard after the caller's
+ * "OpenStation deactivated" toast. The top frame is targeted, not
+ * just this window, because every other open window is iframing into
+ * a now-stale shell context.
  */
 export function reloadOutOfOpenStation(): void {
-	const target = window.top ?? window;
 	let dest: string;
 	try {
 		dest = getConfig().adminUrl;
 	} catch {
 		dest = '';
 	}
-	window.setTimeout( () => {
-		if ( dest ) {
-			try {
-				target.location.assign( dest );
-				return;
-			} catch {
-				// Cross-origin top frame — fall through to a local
-				// navigation. The caller has already shown a toast.
-			}
-			window.location.assign( dest );
-			return;
-		}
-		// No admin URL in config (older registration / test harness) —
-		// fall back to a plain reload. Better than getting stuck on
-		// the now-stale shell.
-		try {
-			target.location.reload();
-		} catch {
-			window.location.reload();
-		}
-	}, 800 );
+	leaveForClassicAdmin( dest );
 }

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -688,9 +688,6 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 		// idempotent loading → ready transition.
 		const onIframeLoad = (): void => {
 			markWindowContentReady( config.id );
-			// Fires on in-place navigations too — which is how
-			// deactivating OpenStation from the classic `plugins.php`
-			// in this window gets noticed.
 			noteFrameLoaded( iframe );
 		};
 		iframe.addEventListener( 'load', onIframeLoad );

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -23,6 +23,7 @@ import {
 	markWindowContentReady,
 } from '../window-channels';
 import { HOOKS, applyFilters } from '../hooks';
+import { noteFrameLoaded } from '../plugin-presence';
 import { createRevealLayers } from '../reveals/surface';
 import {
 	LOADING_OVERLAY_CLASS,
@@ -687,6 +688,10 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 		// idempotent loading → ready transition.
 		const onIframeLoad = (): void => {
 			markWindowContentReady( config.id );
+			// Fires on in-place navigations too — which is how
+			// deactivating OpenStation from the classic `plugins.php`
+			// in this window gets noticed.
+			noteFrameLoaded( iframe );
 		};
 		iframe.addEventListener( 'load', onIframeLoad );
 	} else {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -48,6 +48,7 @@ import {
 	handleFinishedScreenHandoff,
 	handleWindowMessage,
 } from './iframe-bridge';
+import { noteFrameLoaded } from '../plugin-presence';
 import {
 	buttonsForWindow,
 	subscribeTitleBarButtons,
@@ -2321,6 +2322,7 @@ export class Window {
 				// has ready content: mark it so. A no-op in the common
 				// case where the overlay already cleared.
 				markWindowContentReady( this.id );
+				noteFrameLoaded( buffer );
 
 				// Keep the overlay contract alive for FUTURE classic
 				// reloads: the original frame got this wiring in
@@ -2329,6 +2331,7 @@ export class Window {
 				// clears.
 				buffer.addEventListener( 'load', () => {
 					markWindowContentReady( this.id );
+					noteFrameLoaded( buffer );
 				} );
 
 				// Same for the focus forwarder — the click-to-focus

--- a/tests/vitest/plugin-presence.test.ts
+++ b/tests/vitest/plugin-presence.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for the "OpenStation stopped being active" watcher.
  *
  * The whole point of the module is that triggers may be wrong and the
- * confirmation ping is what decides, so most of these assert the
- * NEGATIVE: a healthy page, a front-end page, a cross-origin frame and
- * a network error must all leave the shell alone.
+ * confirmation is what decides, so most of these assert the NEGATIVE:
+ * a healthy page, a front-end page, a cross-origin frame, a bare 404
+ * and a network error must all leave the shell alone.
  *
  * `fetch` is stubbed on the global rather than mocking the
  * `tracked-fetch` module, so the real helper (and its `wp.os.fetch`
@@ -20,9 +20,22 @@ import {
 
 const ADMIN_URL = 'http://localhost/wp-admin/';
 const REST_URL = 'http://localhost/wp-json/';
+const NAMESPACE_URL = 'http://localhost/wp-json/desktop-mode/v1';
 
 let fetchMock: ReturnType< typeof vi.fn >;
 let assign: ReturnType< typeof vi.fn >;
+
+/** The body WordPress returns for an unregistered namespace. */
+function goneResponse(): unknown {
+	return {
+		status: 404,
+		json: () => Promise.resolve( { code: 'rest_no_route' } ),
+	};
+}
+
+function aliveResponse(): unknown {
+	return { status: 200, json: () => Promise.resolve( {} ) };
+}
 
 /** Stand-in for an iframe whose document we control. */
 function frameWith( options: {
@@ -49,10 +62,34 @@ function crossOriginFrame(): HTMLIFrameElement {
 	} as unknown as HTMLIFrameElement;
 }
 
+function adminFrame(): HTMLIFrameElement {
+	return frameWith( {
+		pathname: '/wp-admin/plugins.php',
+		chromeless: false,
+	} );
+}
+
+/** Install a jQuery stub and return the registered `heartbeat-tick` handler. */
+function bootWithHeartbeat(): ( ...args: unknown[] ) => void {
+	let handler: ( ( ...args: unknown[] ) => void ) | null = null;
+	( window as unknown as { jQuery?: unknown } ).jQuery = () => ( {
+		on: ( event: string, cb: ( ...args: unknown[] ) => void ) => {
+			if ( event === 'heartbeat-tick' ) {
+				handler = cb;
+			}
+		},
+	} );
+	bootPluginPresenceWatch();
+	if ( ! handler ) {
+		throw new Error( 'heartbeat-tick handler was never registered' );
+	}
+	return handler;
+}
+
 describe( 'plugin-presence', () => {
 	beforeEach( () => {
 		_resetPluginPresenceForTests();
-		fetchMock = vi.fn().mockResolvedValue( { status: 200 } );
+		fetchMock = vi.fn().mockResolvedValue( aliveResponse() );
 		( globalThis as unknown as { fetch: unknown } ).fetch = fetchMock;
 		assign = vi.fn();
 		Object.defineProperty( window, 'top', {
@@ -91,74 +128,134 @@ describe( 'plugin-presence', () => {
 	} );
 
 	test( 'an admin page missing the marker pings the namespace', () => {
-		noteFrameLoaded(
-			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
-		);
+		noteFrameLoaded( adminFrame() );
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
-		expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toBe(
-			'http://localhost/wp-json/desktop-mode/v1',
-		);
+		expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toBe( NAMESPACE_URL );
+	} );
+
+	test( 'no REST root in config means no ping at all', () => {
+		( window as unknown as { wp?: unknown } ).wp = {
+			os: { config: { adminUrl: ADMIN_URL } },
+		};
+		noteFrameLoaded( adminFrame() );
+		expect( fetchMock ).not.toHaveBeenCalled();
 	} );
 
 	test( 'a 200 from the namespace leaves the shell alone', async () => {
-		noteFrameLoaded(
-			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
-		);
+		noteFrameLoaded( adminFrame() );
 		await vi.waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		await Promise.resolve();
 		expect( assign ).not.toHaveBeenCalled();
 	} );
 
-	test( 'a 404 navigates the top frame to the dashboard', async () => {
+	test( 'a 404 without rest_no_route leaves the shell alone', async () => {
+		// A hardening plugin or a firewall rule on /wp-json.
+		fetchMock.mockResolvedValue( {
+			status: 404,
+			json: () => Promise.resolve( { code: 'rest_forbidden' } ),
+		} );
+		vi.useFakeTimers();
+		noteFrameLoaded( adminFrame() );
+		await vi.runAllTimersAsync();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a 404 with a non-JSON body leaves the shell alone', async () => {
+		fetchMock.mockResolvedValue( {
+			status: 404,
+			json: () => Promise.reject( new Error( 'not json' ) ),
+		} );
+		vi.useFakeTimers();
+		noteFrameLoaded( adminFrame() );
+		await vi.runAllTimersAsync();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	test( 'rest_no_route navigates the top frame to the dashboard', async () => {
 		// Fake timers so the read-the-toast delay before the
 		// navigation doesn't have to be waited out for real.
 		vi.useFakeTimers();
-		fetchMock.mockResolvedValue( { status: 404 } );
-		noteFrameLoaded(
-			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
-		);
+		fetchMock.mockResolvedValue( goneResponse() );
+		noteFrameLoaded( adminFrame() );
 		await vi.runAllTimersAsync();
 		expect( assign ).toHaveBeenCalledWith( ADMIN_URL );
 	} );
 
+	test( 'a second trigger after an exit cannot queue a second navigation', async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValue( goneResponse() );
+		noteFrameLoaded( adminFrame() );
+		await vi.runAllTimersAsync();
+		expect( assign ).toHaveBeenCalledTimes( 1 );
+
+		noteFrameLoaded( adminFrame() );
+		bootWithHeartbeat()( {}, { 'wp-auth-check': true } );
+		await vi.runAllTimersAsync();
+		expect( assign ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	test( 'a network error leaves the shell alone', async () => {
 		fetchMock.mockRejectedValue( new Error( 'offline' ) );
-		noteFrameLoaded(
-			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
-		);
+		noteFrameLoaded( adminFrame() );
 		await vi.waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		await Promise.resolve();
 		expect( assign ).not.toHaveBeenCalled();
 	} );
 
-	test( 'repeat triggers are throttled to one ping', async () => {
-		const frame = frameWith( {
-			pathname: '/wp-admin/plugins.php',
-			chromeless: false,
-		} );
-		noteFrameLoaded( frame );
+	test( 'repeat triggers inside the cooldown are throttled to one ping', async () => {
+		noteFrameLoaded( adminFrame() );
 		await vi.waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
-		noteFrameLoaded( frame );
-		noteFrameLoaded( frame );
+		noteFrameLoaded( adminFrame() );
+		noteFrameLoaded( adminFrame() );
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( 'a heartbeat tick without the nonce field pings the namespace', () => {
-		let tick: ( ( ...args: unknown[] ) => void ) | null = null;
-		( window as unknown as { jQuery?: unknown } ).jQuery = () => ( {
-			on: ( event: string, handler: ( ...args: unknown[] ) => void ) => {
-				if ( event === 'heartbeat-tick' ) {
-					tick = handler;
-				}
-			},
-		} );
-		bootPluginPresenceWatch();
+	test( 'a trigger after the cooldown expires pings again', async () => {
+		vi.useFakeTimers();
+		noteFrameLoaded( adminFrame() );
+		await vi.runAllTimersAsync();
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 
-		const fire = tick as unknown as ( ...args: unknown[] ) => void;
-		fire( {}, { desktop_mode_nonces: { wp_rest: 'abc' } } );
+		await vi.advanceTimersByTimeAsync( 31_000 );
+		noteFrameLoaded( adminFrame() );
+		await vi.runAllTimersAsync();
+		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'the watcher gives up after repeated "still here" answers', async () => {
+		vi.useFakeTimers();
+		for ( let i = 0; i < 5; i++ ) {
+			noteFrameLoaded( adminFrame() );
+			await vi.runAllTimersAsync();
+			await vi.advanceTimersByTimeAsync( 31_000 );
+		}
+		expect( fetchMock ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	test( 'proof the plugin is alive resets the give-up counter', async () => {
+		vi.useFakeTimers();
+		for ( let i = 0; i < 5; i++ ) {
+			noteFrameLoaded( adminFrame() );
+			await vi.runAllTimersAsync();
+			await vi.advanceTimersByTimeAsync( 31_000 );
+			// A healthy chromeless page in between.
+			noteFrameLoaded(
+				frameWith( {
+					pathname: '/wp-admin/index.php',
+					chromeless: true,
+				} ),
+			);
+		}
+		expect( fetchMock ).toHaveBeenCalledTimes( 5 );
+	} );
+
+	test( 'a heartbeat tick without the nonce field pings the namespace', () => {
+		const tick = bootWithHeartbeat();
+
+		tick( {}, { desktop_mode_nonces: { wp_rest: 'abc' } } );
 		expect( fetchMock ).not.toHaveBeenCalled();
 
-		fire( {}, { 'wp-auth-check': true } );
+		tick( {}, { 'wp-auth-check': true } );
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/tests/vitest/plugin-presence.test.ts
+++ b/tests/vitest/plugin-presence.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the "OpenStation stopped being active" watcher.
+ *
+ * The whole point of the module is that triggers may be wrong and the
+ * confirmation ping is what decides, so most of these assert the
+ * NEGATIVE: a healthy page, a front-end page, a cross-origin frame and
+ * a network error must all leave the shell alone.
+ *
+ * `fetch` is stubbed on the global rather than mocking the
+ * `tracked-fetch` module, so the real helper (and its `wp.os.fetch`
+ * lookup) stays in the path — same approach as
+ * `agents-dispatch.test.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	noteFrameLoaded,
+	bootPluginPresenceWatch,
+	_resetPluginPresenceForTests,
+} from '../../src/plugin-presence';
+
+const ADMIN_URL = 'http://localhost/wp-admin/';
+const REST_URL = 'http://localhost/wp-json/';
+
+let fetchMock: ReturnType< typeof vi.fn >;
+let assign: ReturnType< typeof vi.fn >;
+
+/** Stand-in for an iframe whose document we control. */
+function frameWith( options: {
+	pathname: string;
+	chromeless: boolean;
+} ): HTMLIFrameElement {
+	const body = document.createElement( 'body' );
+	if ( options.chromeless ) {
+		body.classList.add( 'os-chromeless' );
+	}
+	// A plain stand-in rather than a real Document: jsdom's
+	// `document.location` is non-configurable, so it can't be pointed
+	// at an arbitrary path.
+	const doc = { body, location: { pathname: options.pathname } };
+	return { contentDocument: doc } as unknown as HTMLIFrameElement;
+}
+
+/** An iframe that throws on `contentDocument`, like a cross-origin one. */
+function crossOriginFrame(): HTMLIFrameElement {
+	return {
+		get contentDocument(): Document {
+			throw new Error( 'cross-origin' );
+		},
+	} as unknown as HTMLIFrameElement;
+}
+
+describe( 'plugin-presence', () => {
+	beforeEach( () => {
+		_resetPluginPresenceForTests();
+		fetchMock = vi.fn().mockResolvedValue( { status: 200 } );
+		( globalThis as unknown as { fetch: unknown } ).fetch = fetchMock;
+		assign = vi.fn();
+		Object.defineProperty( window, 'top', {
+			value: { location: { assign } },
+			configurable: true,
+			writable: true,
+		} );
+		( window as unknown as { wp?: unknown } ).wp = {
+			os: { config: { adminUrl: ADMIN_URL, restUrl: REST_URL } },
+		};
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+		delete ( window as unknown as { wp?: unknown } ).wp;
+		delete ( window as unknown as { jQuery?: unknown } ).jQuery;
+	} );
+
+	test( 'a chromeless admin page pings nothing', () => {
+		noteFrameLoaded(
+			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: true } ),
+		);
+		expect( fetchMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a front-end page without the marker pings nothing', () => {
+		noteFrameLoaded(
+			frameWith( { pathname: '/2026/08/hello-world/', chromeless: false } ),
+		);
+		expect( fetchMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a cross-origin frame pings nothing', () => {
+		noteFrameLoaded( crossOriginFrame() );
+		expect( fetchMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'an admin page missing the marker pings the namespace', () => {
+		noteFrameLoaded(
+			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
+		);
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toBe(
+			'http://localhost/wp-json/desktop-mode/v1',
+		);
+	} );
+
+	test( 'a 200 from the namespace leaves the shell alone', async () => {
+		noteFrameLoaded(
+			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
+		);
+		await vi.waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		await Promise.resolve();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a 404 navigates the top frame to the dashboard', async () => {
+		// Fake timers so the read-the-toast delay before the
+		// navigation doesn't have to be waited out for real.
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValue( { status: 404 } );
+		noteFrameLoaded(
+			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
+		);
+		await vi.runAllTimersAsync();
+		expect( assign ).toHaveBeenCalledWith( ADMIN_URL );
+	} );
+
+	test( 'a network error leaves the shell alone', async () => {
+		fetchMock.mockRejectedValue( new Error( 'offline' ) );
+		noteFrameLoaded(
+			frameWith( { pathname: '/wp-admin/plugins.php', chromeless: false } ),
+		);
+		await vi.waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		await Promise.resolve();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	test( 'repeat triggers are throttled to one ping', async () => {
+		const frame = frameWith( {
+			pathname: '/wp-admin/plugins.php',
+			chromeless: false,
+		} );
+		noteFrameLoaded( frame );
+		await vi.waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		noteFrameLoaded( frame );
+		noteFrameLoaded( frame );
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'a heartbeat tick without the nonce field pings the namespace', () => {
+		let tick: ( ( ...args: unknown[] ) => void ) | null = null;
+		( window as unknown as { jQuery?: unknown } ).jQuery = () => ( {
+			on: ( event: string, handler: ( ...args: unknown[] ) => void ) => {
+				if ( event === 'heartbeat-tick' ) {
+					tick = handler;
+				}
+			},
+		} );
+		bootPluginPresenceWatch();
+
+		const fire = tick as unknown as ( ...args: unknown[] ) => void;
+		fire( {}, { desktop_mode_nonces: { wp_rest: 'abc' } } );
+		expect( fetchMock ).not.toHaveBeenCalled();
+
+		fire( {}, { 'wp-auth-check': true } );
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

Detects OpenStation being deactivated or deleted while the shell is open, and walks the user back to the classic Dashboard with a toast, the same landing the native Plugins window already gives.

Covers the paths that had no guard before:

* Deactivate and Delete from the classic `plugins.php` in a window, single row and bulk.
* Deactivation from outside the shell (another tab, WP-CLI) while a shell tab sits open.

The native Plugins window keeps its own faster path. 

## Why are these changes being made?

The classic `plugins.php` window is the default (`Native Plugins window` is off by default), and deactivating from it left the shell running on top of a plugin that no longer loads. The desktop, dock and windows stayed up, the window where the click happened repainted as a full classic admin page inside the frame, and every `desktop-mode/v1` call started 404ing, so session saving, presence, the recycle bin badge and file operations failed silently. The only way out was a manual reload.

## Testing instructions

Leave `OS Settings > Features > Native Plugins window` off (the default) for all of these.

1. Enter OpenStation and open a few windows.
2. Open Plugins from the dock. It opens the classic `plugins.php` in a window.
3. Deactivate OpenStation from that list. Make sure a toast appears saying OpenStation is no longer active, and that the whole tab lands on the classic wp-admin Dashboard a couple of seconds later. Before this change the shell stayed up and `plugins.php` repainted with the full admin sidebar and admin bar inside the window frame.
4. Reactivate, enter OpenStation again, and repeat step 3 with the bulk action (tick OpenStation, pick `Deactivate` from the bulk dropdown, Apply). Same result.
5. Reactivate, enter OpenStation, then deactivate it from a second browser tab (or `wp plugin deactivate desktop-mode`). Leave the shell tab alone. Within one Heartbeat interval (up to 60s) make sure the shell tab toasts and lands on the Dashboard on its own.

Now the cases that must NOT eject you:

6. Enter OpenStation and open a window on the site's front end (a post permalink, or `Visit Site`). Make sure nothing happens: front-end pages never carry the chromeless marker and must not be read as the plugin being gone.
7. Open a window and trigger a `wp_die()` screen inside it, for example by visiting `/wp-admin/options.php?foo=bar` with a bad nonce, or any "Are you sure you want to do this?" page. Make sure the shell stays up. There should be one request to `/wp-json/desktop-mode/v1` in the network tab returning 200, and nothing else.
8. With the shell open, go offline in DevTools and reload a window. Make sure you are not thrown out of the shell.
9. Delete OpenStation (deactivate, then Delete) from the classic Plugins window. Make sure you still land on the Dashboard, with or without the toast rendering.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-566-644033b0f158512bc093b4bca63fbbbb93fa6ed3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->