### PR TITLE
AI: Internationalize the Copilot's server-side messages

### DIFF
--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -680,21 +680,46 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 function openstation_ai_progress_message( $tool_name ) {
 	switch ( $tool_name ) {
 		case 'search_posts':
-			return 'Looking through your posts…';
+			return __( 'Looking through your posts…', 'desktop-mode' );
 		case 'search_pages':
-			return 'Checking your pages…';
+			return __( 'Checking your pages…', 'desktop-mode' );
 		case 'search_comments':
-			return 'Reading through comments…';
+			return __( 'Reading through comments…', 'desktop-mode' );
 		case 'search_comments_by_post':
-			return 'Scanning comments on that post…';
+			return __( 'Scanning comments on that post…', 'desktop-mode' );
 		case 'list_admin_pages':
-			return 'Finding the right admin page…';
+			return __( 'Finding the right admin page…', 'desktop-mode' );
 		case 'search_wporg_plugins':
-			return 'Searching the WordPress.org plugin directory…';
+			return __( 'Searching the WordPress.org plugin directory…', 'desktop-mode' );
 		case 'get_php_error_log':
-			return 'Tailing the PHP error log…';
+			return __( 'Tailing the PHP error log…', 'desktop-mode' );
 	}
-	return 'Thinking…';
+	return __( 'Thinking…', 'desktop-mode' );
+}
+
+/**
+ * Returns the label for the "keep looking" button on an exhausted search.
+ *
+ * One full sentence per resumable tool rather than interpolating a noun
+ * built from the tool slug: that only produced a word in English, and the
+ * slug is already plural, so the old `. 's'` rendered "postss".
+ *
+ * @param string $resume_tool Tool the client would resume from.
+ * @param int    $from_item   1-based index of the next item to search.
+ * @return string
+ */
+function openstation_ai_continue_label( $resume_tool, $from_item ) {
+	switch ( $resume_tool ) {
+		case 'search_pages':
+			/* translators: %d: 1-based index of the next page to search. */
+			return sprintf( __( 'Continue searching in pages (from item %d)', 'desktop-mode' ), $from_item );
+		case 'search_comments':
+			/* translators: %d: 1-based index of the next comment to search. */
+			return sprintf( __( 'Continue searching in comments (from item %d)', 'desktop-mode' ), $from_item );
+		default:
+			/* translators: %d: 1-based index of the next post to search. */
+			return sprintf( __( 'Continue searching in posts (from item %d)', 'desktop-mode' ), $from_item );
+	}
 }
 
 /**
@@ -1155,7 +1180,7 @@ The message field is always a friendly sentence or two shown directly to the use
 	$emit(
 		array(
 			'phase'   => 'start',
-			'message' => 'Thinking about your question…',
+			'message' => __( 'Thinking about your question…', 'desktop-mode' ),
 		)
 	);
 
@@ -1219,7 +1244,7 @@ The message field is always a friendly sentence or two shown directly to the use
 			$emit(
 				array(
 					'phase'   => 'composing',
-					'message' => 'Putting together your answer…',
+					'message' => __( 'Putting together your answer…', 'desktop-mode' ),
 				)
 			);
 			// A toolless turn with no extractable text never reaches here:
@@ -1230,7 +1255,7 @@ The message field is always a friendly sentence or two shown directly to the use
 
 			$answer = json_decode( $text, true );
 			if ( ! is_array( $answer ) ) {
-				return new WP_Error( 'openstation_ai_result_parse', 'Could not parse structured search answer.' );
+				return new WP_Error( 'openstation_ai_result_parse', __( 'Could not parse structured search answer.', 'desktop-mode' ) );
 			}
 
 			$answer_type = isset( $answer['answer_type'] ) && in_array( $answer['answer_type'], array( 'entity', 'navigation', 'chat' ), true )
@@ -1496,18 +1521,17 @@ The message field is always a friendly sentence or two shown directly to the use
 		// carries no post_id — so fall back to plain comment search,
 		// keeping `tool` inside openstation_ai_search_resumable_tools().
 		$resume_tool = 'search_comments_by_post' === $last_tool ? 'search_comments' : $last_tool;
-		$type_label  = str_replace( 'search_', '', $resume_tool ) . 's';
 		$continue    = array(
 			'tool'        => $resume_tool,
 			'entity_type' => rtrim( str_replace( 'search_', '', $resume_tool ), 's' ),
 			'offset'      => $next_offset,
-			'label'       => sprintf( 'Continue searching in %s (from item %d)', $type_label, $next_offset + 1 ),
+			'label'       => openstation_ai_continue_label( $resume_tool, $next_offset + 1 ),
 		);
 	}
 
 	$final = array(
 		'answer_type' => 'chat',
-		'message'     => 'I searched 100 items without finding a clear match. Want me to keep looking further?',
+		'message'     => __( 'I searched 100 items without finding a clear match. Want me to keep looking further?', 'desktop-mode' ),
 		'entity'      => null,
 		'admin_links' => null,
 		'iterations'  => OPENSTATION_AI_SEARCH_MAX_ITERATIONS,
@@ -1955,22 +1979,29 @@ function openstation_rest_ai_search_permission() {
 	if ( ! is_user_logged_in() || ! current_user_can( 'read' ) ) {
 		return new WP_Error(
 			'openstation_ai_forbidden',
-			'You must be logged in to use the AI assistant.',
+			__( 'You must be logged in to use the AI assistant.', 'desktop-mode' ),
 			array( 'status' => 403 )
 		);
 	}
 	if ( ! openstation_ai_is_available() ) {
 		return new WP_Error(
 			'openstation_ai_unavailable',
-			'The AI assistant is unavailable on this site.',
+			__( 'The AI assistant is unavailable on this site.', 'desktop-mode' ),
 			array( 'status' => 503 )
 		);
 	}
 	if ( ! openstation_ai_is_enabled( get_current_user_id() ) ) {
+		// `settings_tab` tells the overlay which OpenStation Preferences tab
+		// turns this back on, so it can offer a one-click recovery link. It
+		// used to find that by regex-matching the tab path out of this
+		// message, which stops working the moment the message is translated.
 		return new WP_Error(
 			'openstation_ai_disabled',
-			'The AI assistant is turned off. Enable it in OpenStation Preferences → Features.',
-			array( 'status' => 403 )
+			__( 'The AI assistant is turned off.', 'desktop-mode' ),
+			array(
+				'status'       => 403,
+				'settings_tab' => 'features',
+			)
 		);
 	}
 	return true;

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -700,9 +700,8 @@ function openstation_ai_progress_message( $tool_name ) {
 /**
  * Returns the label for the "keep looking" button on an exhausted search.
  *
- * One full sentence per resumable tool rather than interpolating a noun
- * built from the tool slug: that only produced a word in English, and the
- * slug is already plural, so the old `. 's'` rendered "postss".
+ * One full sentence per resumable tool: a noun interpolated into a shared
+ * template cannot be translated.
  *
  * @param string $resume_tool Tool the client would resume from.
  * @param int    $from_item   1-based index of the next item to search.
@@ -1992,9 +1991,8 @@ function openstation_rest_ai_search_permission() {
 	}
 	if ( ! openstation_ai_is_enabled( get_current_user_id() ) ) {
 		// `settings_tab` tells the overlay which OpenStation Preferences tab
-		// turns this back on, so it can offer a one-click recovery link. It
-		// used to find that by regex-matching the tab path out of this
-		// message, which stops working the moment the message is translated.
+		// turns this back on, so it can offer a one-click recovery link
+		// without parsing the tab path back out of the message.
 		return new WP_Error(
 			'openstation_ai_disabled',
 			__( 'The AI assistant is turned off.', 'desktop-mode' ),

--- a/src/ai-assistant/impl.ts
+++ b/src/ai-assistant/impl.ts
@@ -1618,11 +1618,9 @@ export class AiAssistant implements AiAssistantApi {
 	/**
 	 * Render an error, optionally with a one-click recovery link.
 	 *
-	 * `settingsTab` comes from the server's error data, so the server
-	 * names the tab that fixes the problem rather than the client
-	 * recovering it by pattern-matching the message. The old version
-	 * spliced a link over an "OpenStation Preferences → Features" match
-	 * in the prose, which only ever matched while the message was English.
+	 * `settingsTab` comes from the server's error data: the server names
+	 * the tab that fixes the problem, so the client never has to find it
+	 * by pattern-matching the message, which no translation would survive.
 	 */
 	private _showError( message: string, settingsTab?: string ): void {
 		this._resultsEl.hidden = false;

--- a/src/ai-assistant/impl.ts
+++ b/src/ai-assistant/impl.ts
@@ -17,6 +17,7 @@
  */
 
 import { HOOKS, doAction, applyFilters } from '../hooks';
+import { __, sprintf } from '../i18n';
 import { osConfirm } from '../os-confirm';
 import { trackedFetch } from '../tracked-fetch';
 import { decodeHTML } from '../utils';
@@ -147,12 +148,18 @@ interface DesktopShellLite {
 // Kept short so the panel stays compact.
 // ---------------------------------------------------------------------------
 
-const SUGGESTED_PROMPTS = [
-	'Find my post about…',
-	'Where can I see categories?',
-	'Do I have any spam comments?',
-	'Take me to plugin settings',
-];
+/**
+ * A function rather than a const array so the `__()` calls run at render
+ * time (and so the extract-pot pass still sees plain string literals).
+ */
+function suggestedPrompts(): string[] {
+	return [
+		__( 'Find my post about…' ),
+		__( 'Where can I see categories?' ),
+		__( 'Do I have any spam comments?' ),
+		__( 'Take me to plugin settings' ),
+	];
+}
 
 // ---------------------------------------------------------------------------
 // AiAssistant class
@@ -415,7 +422,7 @@ export class AiAssistant implements AiAssistantApi {
 			} );
 		}
 		this._input.placeholder =
-			this._mode === 'ai' ? 'How can I help?' : 'Search commands…';
+			this._mode === 'ai' ? __( 'How can I help?' ) : __( 'Search commands…' );
 		// The input glyph hints the mode: sparkle for AI, magnifier for
 		// Commands (where a sparkle would read as "AI").
 		const inputIcon = this._el.querySelector< HTMLElement >(
@@ -631,7 +638,8 @@ export class AiAssistant implements AiAssistantApi {
 					e.preventDefault();
 					if ( matches.length === 0 ) {
 						if ( parsed.isCommand ) {
-							this._showError( `Unknown command: /${ parsed.slug }` );
+							/* translators: %s: command slug, without the leading slash. */
+							this._showError( sprintf( __( 'Unknown command: /%s' ), parsed.slug ) );
 						}
 						// Commands mode with no match: nothing to run.
 						return;
@@ -767,7 +775,8 @@ export class AiAssistant implements AiAssistantApi {
 		if ( parsed.isCommand ) {
 			const cmd = findCommand( parsed.slug );
 			if ( ! cmd ) {
-				this._showError( `Unknown command: /${ parsed.slug }` );
+				/* translators: %s: command slug, without the leading slash. */
+				this._showError( sprintf( __( 'Unknown command: /%s' ), parsed.slug ) );
 				return;
 			}
 			await this._runCommand( cmd, parsed.args );
@@ -804,7 +813,9 @@ export class AiAssistant implements AiAssistantApi {
 		} );
 		if ( gate && gate.proceed === false ) {
 			this._showError(
-				gate.reason ?? `Command /${ cmd.slug } was cancelled.`,
+				gate.reason ??
+					/* translators: %s: command slug, without the leading slash. */
+					sprintf( __( 'Command /%s was cancelled.' ), cmd.slug ),
 			);
 			return;
 		}
@@ -812,7 +823,8 @@ export class AiAssistant implements AiAssistantApi {
 		this._isSearching = true;
 		this._submitBtn.disabled = true;
 		this._input.disabled = true;
-		this._showThinking( `Running /${ cmd.slug }…` );
+		/* translators: %s: command slug, without the leading slash. */
+		this._showThinking( sprintf( __( 'Running /%s…' ), cmd.slug ) );
 
 		const ctx: CommandContext = {
 			// Command-initiated close: skip the previousFocus restore.
@@ -845,7 +857,10 @@ export class AiAssistant implements AiAssistantApi {
 			} );
 		} catch ( err ) {
 			const msg = err instanceof Error ? err.message : String( err );
-			this._showError( `Command /${ cmd.slug } failed: ${ msg }` );
+			this._showError(
+				/* translators: 1: command slug, without the leading slash. 2: error message. */
+				sprintf( __( 'Command /%1$s failed: %2$s' ), cmd.slug, msg ),
+			);
 			doAction( HOOKS.COMMAND_ERROR, {
 				slug: cmd.slug,
 				args,
@@ -929,7 +944,7 @@ export class AiAssistant implements AiAssistantApi {
 		this._isSearching = true;
 		this._submitBtn.disabled = true;
 		this._input.disabled = true;
-		this._showThinking( 'Thinking…' );
+		this._showThinking( __( 'Thinking…' ) );
 
 		// Two transports, picked by the user in OpenStation Preferences → AI Settings:
 		//   - 'sse' — real-time progress ticks via EventSource. Preferred
@@ -1015,7 +1030,10 @@ export class AiAssistant implements AiAssistantApi {
 					finish();
 					break;
 				case 'error':
-					this._showError( data.message ?? 'Something went wrong.', data.code );
+					this._showError(
+						data.message ?? __( 'Something went wrong.' ),
+						data.code,
+					);
 					finish();
 					break;
 			}
@@ -1026,7 +1044,9 @@ export class AiAssistant implements AiAssistantApi {
 			// we need to show a user-visible error, otherwise the user
 			// would stare at a stale "Thinking…".
 			if ( this._currentStream === es ) {
-				this._showError( 'Lost connection to the assistant. Please try again.' );
+				this._showError(
+					__( 'Lost connection to the assistant. Please try again.' ),
+				);
 				finish();
 			}
 		};
@@ -1065,13 +1085,20 @@ export class AiAssistant implements AiAssistantApi {
 					message?: string;
 					code?: string;
 				};
-				this._showError( err.message ?? `Server returned ${ res.status }`, err.code );
+				this._showError(
+					err.message ??
+						/* translators: %d: HTTP status code. */
+						sprintf( __( 'Server returned %d' ), res.status ),
+					err.code,
+				);
 				return;
 			}
 
 			this._showResult( query, await res.json() as SearchResult );
 		} catch {
-			this._showError( 'Network error — please check your connection and try again.' );
+			this._showError(
+				__( 'Network error — please check your connection and try again.' ),
+			);
 		} finally {
 			this._isSearching = false;
 			this._submitBtn.disabled = false;
@@ -1130,13 +1157,13 @@ export class AiAssistant implements AiAssistantApi {
 				editUrl.searchParams.set( 'post', String( item.id ) );
 				editUrl.searchParams.set( 'action', 'edit' );
 				const href = editUrl.toString();
-				const title = decodeHTML( item.title || '(No title)' );
+				const title = decodeHTML( item.title || __( '(No title)' ) );
 				const icon = isPage ? 'dashicons-admin-page' : 'dashicons-admin-post';
 
 				return {
 					slug: `post-${ item.id }`,
 					label: title,
-					description: isPage ? 'Page' : 'Post',
+					description: this._entityTypeLabel( isPage ? 'page' : 'post' ),
 					icon,
 					eager: false,
 					run: ( _args, ctx ) => {
@@ -1240,9 +1267,14 @@ export class AiAssistant implements AiAssistantApi {
 
 		if ( matches.length === 0 ) {
 			const q = parsed.isCommand ? `/${ parsed.slug }` : this._input.value.trim();
+			const message = sprintf(
+				/* translators: %s: the text the user typed, wrapped in <strong>. */
+				__( 'No commands matching %s.' ),
+				`<strong>${ this._esc( q ) }</strong>`,
+			);
 			this._resultsEl.innerHTML = `
 				<div class="os-ai__state os-ai__state--empty">
-					<span>No commands matching <strong>${ this._esc( q ) }</strong>.</span>
+					<span>${ message }</span>
 				</div>
 			`;
 			return;
@@ -1292,7 +1324,9 @@ export class AiAssistant implements AiAssistantApi {
 		// contextual (eager) commands section above the assistant input.
 		const heading =
 			this._mode === 'ai' && listEagerCommands().length > 0
-				? '<p class="os-ai__suggestions-label">Suggested commands</p>'
+				? `<p class="os-ai__suggestions-label">${ this._esc(
+					__( 'Suggested commands' ),
+				) }</p>`
 				: '';
 		this._resultsEl.innerHTML = `
 			<div class="os-ai__cmd-list">
@@ -1436,7 +1470,11 @@ export class AiAssistant implements AiAssistantApi {
 						? `<span class="os-ai__cmd-desc">${ this._esc( cmd.description ) }</span>`
 						: '' }
 					${ standalone
-						? '<span class="os-ai__cmd-enter-hint">Press <kbd>↵</kbd> to run</span>'
+						? `<span class="os-ai__cmd-enter-hint">${ sprintf(
+							/* translators: %s: the Enter key, rendered as a <kbd> glyph. */
+							__( 'Press %s to run' ),
+							'<kbd>↵</kbd>',
+						) }</span>`
 						: '' }
 				</div>
 			</div>
@@ -1446,9 +1484,14 @@ export class AiAssistant implements AiAssistantApi {
 	/** Render the list of suggestions under the command header. */
 	private _renderSuggestionList( suggestions: CommandSuggestion[] ): string {
 		if ( suggestions.length === 0 ) {
+			const message = sprintf(
+				/* translators: %s: the Enter key, rendered as a <kbd> glyph. */
+				__( 'No suggestions — press %s to run with the text you typed.' ),
+				'<kbd>↵</kbd>',
+			);
 			return `
 				<div class="os-ai__state os-ai__state--empty">
-					<span>No suggestions — press <kbd>↵</kbd> to run with the text you typed.</span>
+					<span>${ message }</span>
 				</div>
 			`;
 		}
@@ -1537,9 +1580,9 @@ export class AiAssistant implements AiAssistantApi {
 		this._resultsEl.hidden = false;
 		this._resultsEl.innerHTML = `
 			<div class="os-ai__suggestions">
-				<p class="os-ai__suggestions-label">${ this._esc( 'Try asking' ) }</p>
+				<p class="os-ai__suggestions-label">${ this._esc( __( 'Try asking' ) ) }</p>
 				<div class="os-ai__suggestions-list">
-					${ SUGGESTED_PROMPTS.map(
+					${ suggestedPrompts().map(
 						( p ) => `<button type="button" class="os-ai__suggestion" data-prompt="${ this._esc( p ) }">
 							${ this._esc( p ) }
 						</button>`,
@@ -1561,7 +1604,7 @@ export class AiAssistant implements AiAssistantApi {
 			} );
 	}
 
-	private _showThinking( message: string = 'Thinking…' ): void {
+	private _showThinking( message: string = __( 'Thinking…' ) ): void {
 		this._resultsEl.hidden = false;
 		this._resultsEl.innerHTML = `
 			<div class="os-ai__state os-ai__state--thinking">
@@ -1587,7 +1630,7 @@ export class AiAssistant implements AiAssistantApi {
 			const phrase = /OpenStation Preferences.*?Features/;
 			const withLink = phrase.test( escaped )
 				? escaped.replace( phrase, ( match ) => linkify( match ) )
-				: `${ escaped } ${ linkify( 'Features' ) }`;
+				: `${ escaped } ${ linkify( this._esc( __( 'Features' ) ) ) }`;
 			this._resultsEl.innerHTML = `
 				<div class="os-ai__state os-ai__state--error">
 					<span>${ withLink }</span>
@@ -1685,13 +1728,44 @@ export class AiAssistant implements AiAssistantApi {
 		}
 	}
 
+	/**
+	 * Display name for an entity type. A lookup rather than capitalising
+	 * the server's type slug — that trick only produces a word in English.
+	 */
+	private _entityTypeLabel( type: EntityDetail[ 'type' ] ): string {
+		switch ( type ) {
+			case 'page':
+				return __( 'Page' );
+			case 'comment':
+				return __( 'Comment' );
+			default:
+				return __( 'Post' );
+		}
+	}
+
+	/** Label for the entity card's open button, one full sentence per type. */
+	private _entityOpenLabel( type: EntityDetail[ 'type' ] ): string {
+		switch ( type ) {
+			case 'page':
+				return __( 'Open page in desktop' );
+			case 'comment':
+				return __( 'Open comment in desktop' );
+			default:
+				return __( 'Open post in desktop' );
+		}
+	}
+
 	private _renderEntityCard( e: EntityDetail ): string {
 		const isComment = e.type === 'comment';
 		const title = isComment
-			? `Comment on “${ this._esc( e.post_title ?? 'post' ) }”`
-			: this._esc( e.title ?? 'Untitled' );
+			? sprintf(
+				/* translators: %s: title of the post the comment was left on. */
+				__( 'Comment on “%s”' ),
+				this._esc( e.post_title ?? __( 'post' ) ),
+			)
+			: this._esc( e.title ?? __( 'Untitled' ) );
 		const summary = this._esc( e.ai_summary || e.excerpt || '' );
-		const typeLabel = e.type.charAt( 0 ).toUpperCase() + e.type.slice( 1 );
+		const typeLabel = this._entityTypeLabel( e.type );
 		const topicChip = e.topic ? `<span class="os-ai__entity-topic">${ this._esc( e.topic ) }</span>` : '';
 
 		// Pick a Dashicon for the window icon based on entity type.
@@ -1717,7 +1791,7 @@ export class AiAssistant implements AiAssistantApi {
 					data-url="${ this._esc( e.edit_url ) }"
 					data-title="${ this._esc( e.title ?? e.post_title ?? typeLabel ) }"
 					data-icon="${ icon }">
-					<span>${ this._esc( `Open ${ typeLabel.toLowerCase() } in desktop` ) }</span>
+					<span>${ this._esc( this._entityOpenLabel( e.type ) ) }</span>
 					${ ICON_ARROW }
 				</button>
 			</div>
@@ -1762,7 +1836,7 @@ export class AiAssistant implements AiAssistantApi {
 		el.className = 'os-ai';
 		el.setAttribute( 'role', 'dialog' );
 		el.setAttribute( 'aria-modal', 'true' );
-		el.setAttribute( 'aria-label', 'Site Assistant' );
+		el.setAttribute( 'aria-label', __( 'Site Assistant' ) );
 		el.setAttribute( 'aria-hidden', 'true' );
 		el.setAttribute( 'hidden', '' );
 
@@ -1771,12 +1845,18 @@ export class AiAssistant implements AiAssistantApi {
 			<div class="os-ai__panel">
 				<div class="os-ai__header">
 					<span class="os-ai__header-icon">${ ICON_SITE_LOGO }</span>
-					<span class="os-ai__header-label">Site Assistant</span>
-					<div class="os-ai__modes" role="group" aria-label="Assistant mode" hidden>
-						<button type="button" class="os-ai__mode" data-mode="ai" aria-pressed="false">Ask AI</button>
-						<button type="button" class="os-ai__mode" data-mode="commands" aria-pressed="false">Commands</button>
+					<span class="os-ai__header-label">${ this._esc( __( 'Site Assistant' ) ) }</span>
+					<div class="os-ai__modes" role="group" aria-label="${ this._esc(
+						__( 'Assistant mode' ),
+					) }" hidden>
+						<button type="button" class="os-ai__mode" data-mode="ai" aria-pressed="false">${ this._esc(
+							__( 'Ask AI' ),
+						) }</button>
+						<button type="button" class="os-ai__mode" data-mode="commands" aria-pressed="false">${ this._esc(
+							__( 'Commands' ),
+						) }</button>
 					</div>
-					<button type="button" class="os-ai__close" aria-label="Close">
+					<button type="button" class="os-ai__close" aria-label="${ this._esc( __( 'Close' ) ) }">
 						${ ICON_CLOSE }
 					</button>
 				</div>
@@ -1785,19 +1865,23 @@ export class AiAssistant implements AiAssistantApi {
 					<input
 						class="os-ai__input"
 						type="text"
-						placeholder="How can I help?"
+						placeholder="${ this._esc( __( 'How can I help?' ) ) }"
 						autocomplete="off"
 						spellcheck="false"
-						aria-label="Ask the assistant"
+						aria-label="${ this._esc( __( 'Ask the assistant' ) ) }"
 					/>
-					<button type="button" class="os-ai__submit" aria-label="Send">
+					<button type="button" class="os-ai__submit" aria-label="${ this._esc( __( 'Send' ) ) }">
 						${ ICON_RETURN }
 					</button>
 				</div>
 				<div class="os-ai__results" hidden></div>
 				<div class="os-ai__footer">
 					<span class="os-ai__footer-hint">
-						Your assistant to quickly navigate and manage your entire site.
+						${ this._esc(
+							__(
+								'Your assistant to quickly navigate and manage your entire site.',
+							),
+						) }
 					</span>
 				</div>
 			</div>

--- a/src/ai-assistant/impl.ts
+++ b/src/ai-assistant/impl.ts
@@ -1030,10 +1030,10 @@ export class AiAssistant implements AiAssistantApi {
 					finish();
 					break;
 				case 'error':
-					this._showError(
-						data.message ?? __( 'Something went wrong.' ),
-						data.code,
-					);
+					// The SSE endpoint bails with a bare status header for
+					// every recoverable case, so no settings hint can arrive
+					// on this path.
+					this._showError( data.message ?? __( 'Something went wrong.' ) );
 					finish();
 					break;
 			}
@@ -1084,12 +1084,13 @@ export class AiAssistant implements AiAssistantApi {
 				const err = await res.json().catch( () => ( {} ) ) as {
 					message?: string;
 					code?: string;
+					data?: { settings_tab?: string };
 				};
 				this._showError(
 					err.message ??
 						/* translators: %d: HTTP status code. */
 						sprintf( __( 'Server returned %d' ), res.status ),
-					err.code,
+					err.data?.settings_tab,
 				);
 				return;
 			}
@@ -1194,17 +1195,17 @@ export class AiAssistant implements AiAssistantApi {
 	}
 
 	/**
-	 * Open OpenStation Preferences on the Features tab so the user can turn the
-	 * assistant on in one click from the "assistant is off" error state.
-	 * Closes the assistant first so the settings window isn't hidden behind
-	 * it, and drops the stored focus target so closing doesn't bounce
-	 * focus back to the launcher away from the settings window.
+	 * Open OpenStation Preferences on the tab the server named, so the user
+	 * can turn the assistant on in one click from the "assistant is off"
+	 * error state. Closes the assistant first so the settings window isn't
+	 * hidden behind it, and drops the stored focus target so closing doesn't
+	 * bounce focus back to the launcher away from the settings window.
 	 */
-	private _openAssistantSettings(): void {
+	private _openAssistantSettings( tabId: string ): void {
 		const shell = this._getDesktopShell();
 		this._previousFocus = null;
 		this.close();
-		shell?.openOsSettings?.( { tabId: 'features' } );
+		shell?.openOsSettings?.( { tabId } );
 	}
 
 	private _openInLegacyWindow( url: string, title: string, icon?: string ): void {
@@ -1614,31 +1615,32 @@ export class AiAssistant implements AiAssistantApi {
 		`;
 	}
 
-	private _showError( message: string, code?: string ): void {
+	/**
+	 * Render an error, optionally with a one-click recovery link.
+	 *
+	 * `settingsTab` comes from the server's error data, so the server
+	 * names the tab that fixes the problem rather than the client
+	 * recovering it by pattern-matching the message. The old version
+	 * spliced a link over an "OpenStation Preferences → Features" match
+	 * in the prose, which only ever matched while the message was English.
+	 */
+	private _showError( message: string, settingsTab?: string ): void {
 		this._resultsEl.hidden = false;
 
-		// The "assistant is off" case is recoverable in one click, so we
-		// turn the "OpenStation Preferences → Features" mention in the message into an
-		// inline link that opens OpenStation Preferences on the Features tab. Keyed on
-		// the server error code, not the wording, so the affordance survives
-		// copy tweaks; the regex spans whatever sits between the two anchors
-		// (arrow, spacing) and falls back to a trailing link if absent.
-		if ( code === 'openstation_ai_disabled' ) {
-			const escaped = this._esc( message );
-			const linkify = ( text: string ) =>
-				`<button type="button" class="os-ai__settings-link">${ text }</button>`;
-			const phrase = /OpenStation Preferences.*?Features/;
-			const withLink = phrase.test( escaped )
-				? escaped.replace( phrase, ( match ) => linkify( match ) )
-				: `${ escaped } ${ linkify( this._esc( __( 'Features' ) ) ) }`;
+		if ( settingsTab ) {
+			const link = `<button type="button" class="os-ai__settings-link">${ this._esc(
+				__( 'Turn it on in OpenStation Preferences' ),
+			) }</button>`;
 			this._resultsEl.innerHTML = `
 				<div class="os-ai__state os-ai__state--error">
-					<span>${ withLink }</span>
+					<span>${ this._esc( message ) } ${ link }</span>
 				</div>
 			`;
 			this._resultsEl
 				.querySelector< HTMLButtonElement >( '.os-ai__settings-link' )
-				?.addEventListener( 'click', () => this._openAssistantSettings() );
+				?.addEventListener( 'click', () =>
+					this._openAssistantSettings( settingsTab ),
+				);
 			return;
 		}
 

--- a/tests/phpunit/tests/aiCopilotStrings.php
+++ b/tests/phpunit/tests/aiCopilotStrings.php
@@ -2,17 +2,9 @@
 /**
  * Tests for the AI Copilot's user-facing strings.
  *
- * The Copilot's progress ticks, continue-search label and permission
- * errors all render inside the assistant overlay, so they have to be
- * translatable and they have to read as sentences. Two failure modes
- * these cover:
- *
- *   - A string that skips `__()` renders in English whatever the site
- *     locale is, and never reaches the POT to be translated at all.
- *   - A noun interpolated from a tool slug. `search_posts` is already
- *     plural, so appending an "s" produced "Continue searching in
- *     postss", and no translation could have fixed it because the noun
- *     was never part of a translatable string.
+ * The Copilot's progress ticks and continue-search label render inside
+ * the assistant overlay, so they have to be translatable, and every
+ * resumable tool has to get a label that names its own entity.
  *
  * @package WordPress
  * @subpackage UnitTests
@@ -23,51 +15,56 @@
 class Tests_OpenStation_AiCopilotStrings extends WP_UnitTestCase {
 
 	/**
-	 * Every resumable tool gets a correctly pluralised continue label.
+	 * Every resumable tool gets a label of its own.
+	 *
+	 * `openstation_ai_continue_label()` falls back to the post wording for
+	 * an unrecognised tool, so a tool added to the resumable list without a
+	 * matching case would silently tell the user it is searching posts.
+	 * Distinct labels are what catch that: the new tool would collide with
+	 * `search_posts`.
+	 *
+	 * @covers ::openstation_ai_continue_label
+	 */
+	public function test_every_resumable_tool_gets_its_own_label() {
+		$labels = array();
+		foreach ( openstation_ai_search_resumable_tools() as $tool ) {
+			$labels[ $tool ] = openstation_ai_continue_label( $tool, 11 );
+		}
+
+		$this->assertSame(
+			count( $labels ),
+			count( array_unique( $labels ) ),
+			'Each resumable tool needs its own case in openstation_ai_continue_label(); '
+				. 'a duplicate means one fell through to the default post wording.'
+		);
+	}
+
+	/**
+	 * The continue label names the entity, and names it once.
 	 *
 	 * @covers ::openstation_ai_continue_label
 	 */
 	public function test_continue_label_reads_as_a_sentence() {
-		$expected = array(
-			'search_posts'    => 'Continue searching in posts (from item 11)',
-			'search_pages'    => 'Continue searching in pages (from item 11)',
-			'search_comments' => 'Continue searching in comments (from item 11)',
+		$this->assertSame(
+			'Continue searching in posts (from item 11)',
+			openstation_ai_continue_label( 'search_posts', 11 )
 		);
-
-		foreach ( $expected as $tool => $label ) {
-			$this->assertSame(
-				$label,
-				openstation_ai_continue_label( $tool, 11 ),
-				"Continue label for {$tool} must name the entity in plain English."
-			);
-		}
+		$this->assertSame(
+			'Continue searching in comments (from item 4)',
+			openstation_ai_continue_label( 'search_comments', 4 )
+		);
 	}
 
 	/**
-	 * The label never doubles the plural, whatever tool it is handed.
+	 * Progress ticks and continue labels are translatable.
 	 *
-	 * @covers ::openstation_ai_continue_label
-	 */
-	public function test_continue_label_never_doubles_the_plural() {
-		foreach ( openstation_ai_search_resumable_tools() as $tool ) {
-			$this->assertStringNotContainsString(
-				'ss (',
-				openstation_ai_continue_label( $tool, 1 ),
-				"Continue label for {$tool} must not double the trailing s."
-			);
-		}
-	}
-
-	/**
-	 * Progress ticks are translatable.
-	 *
-	 * Swapping the locale through the `gettext` filter is enough: a
-	 * string that reaches `__()` comes back marked, a hardcoded literal
-	 * comes back untouched.
+	 * Marking through the `gettext` filter is enough to tell them apart: a
+	 * string that reaches `__()` comes back marked, a bare literal does not.
 	 *
 	 * @covers ::openstation_ai_progress_message
+	 * @covers ::openstation_ai_continue_label
 	 */
-	public function test_progress_messages_go_through_gettext() {
+	public function test_strings_go_through_gettext() {
 		$mark = static function ( $translated ) {
 			return '[xx]' . $translated;
 		};
@@ -89,6 +86,14 @@ class Tests_OpenStation_AiCopilotStrings extends WP_UnitTestCase {
 				'[xx]',
 				openstation_ai_progress_message( $tool ),
 				"Progress message for {$tool} must go through __()."
+			);
+		}
+
+		foreach ( openstation_ai_search_resumable_tools() as $tool ) {
+			$this->assertStringStartsWith(
+				'[xx]',
+				openstation_ai_continue_label( $tool, 1 ),
+				"Continue label for {$tool} must go through __()."
 			);
 		}
 

--- a/tests/phpunit/tests/aiCopilotStrings.php
+++ b/tests/phpunit/tests/aiCopilotStrings.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests for the AI Copilot's user-facing strings.
+ *
+ * The Copilot's progress ticks, continue-search label and permission
+ * errors all render inside the assistant overlay, so they have to be
+ * translatable and they have to read as sentences. Two failure modes
+ * these cover:
+ *
+ *   - A string that skips `__()` renders in English whatever the site
+ *     locale is, and never reaches the POT to be translated at all.
+ *   - A noun interpolated from a tool slug. `search_posts` is already
+ *     plural, so appending an "s" produced "Continue searching in
+ *     postss", and no translation could have fixed it because the noun
+ *     was never part of a translatable string.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group os-ai
+ */
+class Tests_OpenStation_AiCopilotStrings extends WP_UnitTestCase {
+
+	/**
+	 * Every resumable tool gets a correctly pluralised continue label.
+	 *
+	 * @covers ::openstation_ai_continue_label
+	 */
+	public function test_continue_label_reads_as_a_sentence() {
+		$expected = array(
+			'search_posts'    => 'Continue searching in posts (from item 11)',
+			'search_pages'    => 'Continue searching in pages (from item 11)',
+			'search_comments' => 'Continue searching in comments (from item 11)',
+		);
+
+		foreach ( $expected as $tool => $label ) {
+			$this->assertSame(
+				$label,
+				openstation_ai_continue_label( $tool, 11 ),
+				"Continue label for {$tool} must name the entity in plain English."
+			);
+		}
+	}
+
+	/**
+	 * The label never doubles the plural, whatever tool it is handed.
+	 *
+	 * @covers ::openstation_ai_continue_label
+	 */
+	public function test_continue_label_never_doubles_the_plural() {
+		foreach ( openstation_ai_search_resumable_tools() as $tool ) {
+			$this->assertStringNotContainsString(
+				'ss (',
+				openstation_ai_continue_label( $tool, 1 ),
+				"Continue label for {$tool} must not double the trailing s."
+			);
+		}
+	}
+
+	/**
+	 * Progress ticks are translatable.
+	 *
+	 * Swapping the locale through the `gettext` filter is enough: a
+	 * string that reaches `__()` comes back marked, a hardcoded literal
+	 * comes back untouched.
+	 *
+	 * @covers ::openstation_ai_progress_message
+	 */
+	public function test_progress_messages_go_through_gettext() {
+		$mark = static function ( $translated ) {
+			return '[xx]' . $translated;
+		};
+		add_filter( 'gettext', $mark, 10, 1 );
+
+		$tools = array(
+			'search_posts',
+			'search_pages',
+			'search_comments',
+			'search_comments_by_post',
+			'list_admin_pages',
+			'search_wporg_plugins',
+			'get_php_error_log',
+			'an_unknown_tool',
+		);
+
+		foreach ( $tools as $tool ) {
+			$this->assertStringStartsWith(
+				'[xx]',
+				openstation_ai_progress_message( $tool ),
+				"Progress message for {$tool} must go through __()."
+			);
+		}
+
+		remove_filter( 'gettext', $mark, 10 );
+	}
+}

--- a/tests/vitest/ai-assistant-i18n.test.ts
+++ b/tests/vitest/ai-assistant-i18n.test.ts
@@ -142,6 +142,71 @@ describe( 'AiAssistant — i18n', () => {
 		);
 	} );
 
+	test( 'the settings recovery link comes from the server hint, not the prose', async () => {
+		const openOsSettings = vi.fn();
+		const existing = ( window as unknown as Record< string, unknown > ).wp as
+			| Record< string, unknown >
+			| undefined;
+		( window as unknown as Record< string, unknown > ).wp = {
+			...existing,
+			os: { openOsSettings },
+		};
+
+		// A translated message with no English "OpenStation Preferences →
+		// Features" phrase in it. The old regex found nothing here.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () =>
+				Promise.resolve( {
+					ok: false,
+					status: 403,
+					json: async () => ( {
+						code: 'openstation_ai_disabled',
+						message: 'El asistente de IA está desactivado.',
+						data: { status: 403, settings_tab: 'features' },
+					} ),
+				} as Response ),
+			),
+		);
+
+		assistant.open();
+		await assistant[ '_runSearchFetch' ]( 'hola', null, 0 );
+
+		const link = document.querySelector< HTMLButtonElement >(
+			'.os-ai__settings-link',
+		);
+		expect( link ).not.toBeNull();
+		expect( link!.textContent ).toBe(
+			translate( 'Turn it on in OpenStation Preferences' ),
+		);
+
+		link!.click();
+		expect( openOsSettings ).toHaveBeenCalledWith( { tabId: 'features' } );
+	} );
+
+	test( 'an error with no settings hint renders no recovery link', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () =>
+				Promise.resolve( {
+					ok: false,
+					status: 500,
+					json: async () => ( { code: 'oops', message: 'Boom.' } ),
+				} as Response ),
+			),
+		);
+
+		assistant.open();
+		await assistant[ '_runSearchFetch' ]( 'hola', null, 0 );
+
+		expect(
+			document.querySelector( '.os-ai__settings-link' ),
+		).toBeNull();
+		expect(
+			document.querySelector( '.os-ai__state--error' )?.textContent?.trim(),
+		).toBe( 'Boom.' );
+	} );
+
 	test( 'the unknown-command error renders translated', () => {
 		assistant.open();
 		const input = document.querySelector< HTMLInputElement >(

--- a/tests/vitest/ai-assistant-i18n.test.ts
+++ b/tests/vitest/ai-assistant-i18n.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The AI assistant overlay's chrome has to render through `wp.i18n`.
+ *
+ * Every string here was hardcoded English at some point, which made the
+ * whole panel untranslatable — the strings never reached the POT, so no
+ * locale could override them however complete its translation was. The
+ * regression is silent: an untranslated literal renders perfectly in
+ * English and looks correct to anyone reviewing in English.
+ *
+ * So these tests install a `wp.i18n` stub that returns a marked string
+ * for every msgid and assert the marker reaches the DOM. A literal that
+ * skips `__()` renders the English source instead and fails here.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+import { AiAssistant } from '../../src/ai-assistant/impl';
+import type { AiAssistantConfig } from '../../src/ai-assistant/types';
+
+const BASE_CONFIG: AiAssistantConfig = {
+	aiSearchUrl: 'https://example.test/wp-json/desktop-mode/v1/ai/search',
+	aiSearchStreamUrl: '',
+	restNonce: 'test-nonce',
+	adminUrl: 'https://example.test/wp-admin/',
+	isAiAvailable: () => false,
+	isOverrideEnabled: () => false,
+	getTransport: () => 'off',
+};
+
+/** Marker wrapped around every msgid so a missed `__()` is visible. */
+function translate( text: string ): string {
+	return `[es]${ text }`;
+}
+
+/**
+ * Install a `wp.i18n` that translates everything, preserving the hooks
+ * stub already living under `window.wp`.
+ */
+function stubI18n(): void {
+	const existing = ( window as unknown as Record< string, unknown > ).wp ?? {};
+	( window as unknown as Record< string, unknown > ).wp = {
+		...existing,
+		i18n: {
+			__: ( text: string ) => translate( text ),
+			_x: ( text: string ) => translate( text ),
+			_n: ( single: string, plural: string, number: number ) =>
+				translate( number === 1 ? single : plural ),
+			_nx: ( single: string, plural: string, number: number ) =>
+				translate( number === 1 ? single : plural ),
+			sprintf: ( format: string, ...args: unknown[] ) => {
+				let i = 0;
+				return format.replace(
+					/%(?:(\d+)\$)?[sd]/g,
+					( _match, pos ) => {
+						const idx = pos ? Number.parseInt( pos, 10 ) - 1 : i++;
+						return String( args[ idx ] ?? '' );
+					},
+				);
+			},
+		},
+	};
+}
+
+describe( 'AiAssistant — i18n', () => {
+	let assistant: AiAssistant;
+
+	beforeEach( () => {
+		installHooksStub();
+		stubI18n();
+		assistant = new AiAssistant( BASE_CONFIG );
+	} );
+
+	afterEach( () => {
+		if ( assistant && assistant.isOpen ) {
+			assistant.close();
+		}
+		document.getElementById( 'desktop-mode-ai-assistant' )?.remove();
+		clearHooksStub();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'the panel chrome renders translated', () => {
+		const el = document.getElementById( 'desktop-mode-ai-assistant' )!;
+
+		expect( el.getAttribute( 'aria-label' ) ).toBe(
+			translate( 'Site Assistant' ),
+		);
+		expect(
+			el.querySelector( '.os-ai__header-label' )?.textContent?.trim(),
+		).toBe( translate( 'Site Assistant' ) );
+		expect(
+			el.querySelector( '.os-ai__modes' )?.getAttribute( 'aria-label' ),
+		).toBe( translate( 'Assistant mode' ) );
+		expect(
+			el.querySelector( '[data-mode="ai"]' )?.textContent?.trim(),
+		).toBe( translate( 'Ask AI' ) );
+		expect(
+			el.querySelector( '[data-mode="commands"]' )?.textContent?.trim(),
+		).toBe( translate( 'Commands' ) );
+		expect(
+			el.querySelector( '.os-ai__close' )?.getAttribute( 'aria-label' ),
+		).toBe( translate( 'Close' ) );
+		expect(
+			el.querySelector( '.os-ai__submit' )?.getAttribute( 'aria-label' ),
+		).toBe( translate( 'Send' ) );
+		expect(
+			el.querySelector( '.os-ai__footer-hint' )?.textContent?.trim(),
+		).toBe(
+			translate(
+				'Your assistant to quickly navigate and manage your entire site.',
+			),
+		);
+	} );
+
+	test( 'the input placeholder and aria-label render translated', () => {
+		const input = document.querySelector< HTMLInputElement >(
+			'.os-ai__input',
+		)!;
+
+		expect( input.getAttribute( 'aria-label' ) ).toBe(
+			translate( 'Ask the assistant' ),
+		);
+		// Commands is the default mode when AI is unavailable.
+		assistant.open();
+		expect( input.placeholder ).toBe( translate( 'Search commands…' ) );
+	} );
+
+	test( 'the empty-state message renders translated', () => {
+		assistant.open();
+		const input = document.querySelector< HTMLInputElement >(
+			'.os-ai__input',
+		)!;
+		input.value = 'nothing-matches-this';
+		input.dispatchEvent( new Event( 'input' ) );
+
+		const empty = document.querySelector( '.os-ai__state--empty' );
+		expect( empty?.textContent ).toContain(
+			translate( 'No commands matching %s.' ).replace( ' %s.', '' ),
+		);
+		expect( empty?.querySelector( 'strong' )?.textContent ).toBe(
+			'nothing-matches-this',
+		);
+	} );
+
+	test( 'the unknown-command error renders translated', () => {
+		assistant.open();
+		const input = document.querySelector< HTMLInputElement >(
+			'.os-ai__input',
+		)!;
+		input.value = '/definitely-not-a-command ';
+		input.dispatchEvent( new Event( 'input' ) );
+		input.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } ),
+		);
+
+		const error = document.querySelector( '.os-ai__state--error' );
+		expect( error?.textContent?.trim() ).toBe(
+			'[es]Unknown command: /definitely-not-a-command',
+		);
+	} );
+} );


### PR DESCRIPTION
Follow-up to #563, and stacked on it (base branch is `claude/internationalize-ai-overlay-517d20`, both PRs touch `_showError`). Merge #563 first.

## Proposed changes

#563 internationalized the overlay's own strings. The server still sent it hardcoded English, so the panel was half-translated. This wraps the strings the user actually reads:

- The SSE progress ticks ("Looking through your posts…", "Putting together your answer…", and the six others).
- The exhausted-search reply and the continue-search button label.
- The structured-answer parse error and the three permission errors.

Model-facing strings are deliberately left in English: the tool-error envelope in `openstation_ai_run_search()` and the `get_php_error_log` "no readable log" result both go back to the model as tool output, not to the screen, and the model is prompted in English.

Replaces the client's prose-matching recovery link. When the assistant is off, the overlay offers a one-click link to the settings tab that turns it back on. It found that tab by running `/OpenStation Preferences.*?Features/` over the error message, so translating the message would have silently dropped the affordance in every non-English locale. The server now names the tab as `settings_tab` in the `WP_Error` data and the client reads it, so `_showError` no longer parses prose.

Also fixes the continue label. `$type_label` was built as `str_replace( 'search_', '', $resume_tool ) . 's'`, but the tool slugs are already plural, so the button read "Continue searching in postss". It becomes one full sentence per entity type, which is also the only form that can be translated.

Adds `tests/phpunit/tests/aiCopilotStrings.php` (continue label wording, no doubled plural, progress ticks go through gettext) and two vitest cases covering the settings-hint contract.

## Why are these changes being made?

`languages/desktop-mode.pot` had none of these strings, so no locale could translate them however complete its translation was. `wp i18n make-pot` now extracts 18 from `includes/ai-copilot/`.

The regex change is the part worth reviewing closely. It is not a cleanup: keying a UI affordance on English prose meant that finishing the translation work would have broken the recovery link, and nothing would have failed loudly when it did.

## What is not in this PR

The admin page catalog in `openstation_ai_get_admin_page_catalog()` (about 30 title/description pairs) is still English. It is both user-facing and model-facing: the answer schema tells the model to copy entries "verbatim from the list_admin_pages tool result", and the model also matches the user's query against those descriptions. Translating it changes what the model sees on every navigation query, so it needs its own decision and its own testing rather than riding along here.

`includes/ai-copilot/jobs.php` has one untranslated error, but it belongs to the background comment-analysis job and never renders in the overlay.

## Testing instructions

1. Check out this branch and run `npm run build`.
2. Run `npm run test:js`. Make sure it passes, including the two new `ai-assistant-i18n` cases.
3. Run `npm run env:start:tests` then `npm run test:php`. Make sure `Tests_OpenStation_AiCopilotStrings` passes.
4. Run `npm run lint:php`. Make sure it is clean.
5. Verify the strings extract:
   ```
   wp i18n make-pot . /tmp/verify.pot --include=includes/ai-copilot --skip-js
   ```
   Make sure `/tmp/verify.pot` contains `Looking through your posts…`, `Thinking about your question…`, `Continue searching in posts (from item %d)` and `The AI assistant is turned off.`
6. On a site with the AI assistant configured but turned off for your user (OpenStation Preferences > Features), press `Cmd+K`, switch to Ask AI, and ask anything. Make sure the error reads "The AI assistant is turned off." followed by a "Turn it on in OpenStation Preferences" link, and that clicking the link opens Preferences on the Features tab.
7. Turn the assistant on. Ask a question and watch the progress text while it works. Make sure it moves through "Thinking about your question…", a per-tool tick, and "Putting together your answer…".
8. To check the continue label, ask something that forces a long search (a keyword that appears in many posts). If the budget runs out you get a continue button. Make sure it reads "Continue searching in posts (from item 11)" and not "postss".

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-569-6d59d34929e4fce8759ea7492c6c4d661c09dcb1.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->