### PR TITLE
Windows: Fix the accessibility semantics of controls, tabs and loading

### DIFF
--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -112,6 +112,12 @@ from a desktop theme — the same trap described in
 | `<os-button>` | `OsButton` | `os-button/os-button.ts` | Primary / secondary / ghost button. |
 | `<os-window-button>` | `OsWindowButton` | `os-window-button/os-window-button.ts` | Title-bar icon button (minimize / maximize / close / custom). |
 
+`<os-window-button>` paints an `aria-hidden` glyph inside a shadow
+`<button>`, so it has no accessible name of its own — **always set
+`aria-label` on the host**. The component forwards it onto that inner
+button (which is the element focus lands on) and keeps it in sync when
+you relabel the host, e.g. Maximize ⇄ Restore.
+
 ## Menus & overlays
 
 | Tag | Class | Source | Purpose |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -112,6 +112,8 @@ The shell paints a `<os-spinner>` overlay over the body while the window is load
 
 The overlay element is attached immediately (so `config.loading.render` and the `WINDOW_LOADING_OVERLAY` filter always have a host) but stays **invisible for the first 120 ms**. A load that finishes inside that window never paints a spinner at all.
 
+**Assistive tech.** The window element carries `aria-busy="true"` for the duration of the loading state (stamped at construction, cleared on the ready edge), and the overlay is a `role="status"` / `aria-live="polite"` region whose spinner supplies the announced text. A custom overlay supplied via `config.loading.render` or the `WINDOW_LOADING_OVERLAY` filter inherits the region — keep some text or a labelled indicator inside it, and don't set `aria-hidden` on the host.
+
 **Edge-triggered.** Idempotent calls don't re-fire — a plugin that calls `markLoading()` twice in a row sees the event exactly once.
 
 ```javascript
@@ -801,6 +803,8 @@ manager.closeDesktop( id: string ): void;
 > **`open()` requires a config object.** Passing a URL string used to silently produce a window stuck on a loading spinner with no error in the console. The manager throws `TypeError` at the call site if `config` isn't an object, or if `id` / `url` / `title` are missing or wrong-typed. Build the config; don't shorthand it.
 
 **`config.submenu`** — when present, the shell renders the array as an in-window tab strip below the title bar so the user can navigate child pages without leaving the window. Pass `item.submenu` whenever you open a window from a dock context — `openItem` and `openSubmenuPick` (in custom rail renderers) propagate it for you. Skip it for native windows that don't have admin sub-pages. The shell strips WordPress's auto-prepended self-link entry server-side, so `submenu.length > 0` reliably means "has real children" (no defensive filtering needed in your code). The shell prepends a synthetic "back to parent" tab (label = `config.title`, URL = `config.url`) as the first tab so the user can return to the parent listing without closing the window. If a caller-supplied submenu entry already points at `config.url` the synthetic tab is suppressed to avoid two tabs claiming the same URL.
+
+Every iframe window gets the strip element, whether or not it has a submenu, because external sub-tabs can be added to it later. Its navigation semantics follow its contents: `role="tablist"` plus an `aria-label` of `"<title> sub-pages"` while it holds tabs, `role="presentation"` while it is empty — so a window with no sub-pages never advertises an empty tab list to assistive tech.
 
 The active tab is re-matched against the iframe's URL after every navigation. An exact URL match wins; otherwise the shell lights the tab whose *page* the current URL belongs to, so a screen's own sub-views keep their tab highlighted (`nav-menus.php?action=locations` stays on Menus, `edit.php?post_type=post&paged=2` stays on All Posts). A tab owns a URL when the page-identity params agree (`post_type`, `taxonomy`, `page`, `path`, …) **and** every param the tab's own URL declares is present with the same value — so `admin.php?page=x&tab=test` never claims `admin.php?page=x&tab=logs`, which falls back to the `admin.php?page=x` entry. When two entries both qualify, the more specific one (more params declared) wins. Exactly one tab is ever active.
 
@@ -5162,7 +5166,7 @@ wp.os.listWindowThemes();
 wp.os.applyWindowTheme( windowId, override );
 
 // Layer 2 — Controls (Stable)
-wp.os.registerWindowControl( def );
+wp.os.registerWindowControl( def );        // `label` becomes the button's accessible name
 wp.os.unregisterWindowControl( id );       // pass 'core/close' to hide globally
 wp.os.listWindowControls();
 wp.os.applyWindowControls( windowId, override );

--- a/src/ui/components/os-window-button/os-window-button.test.ts
+++ b/src/ui/components/os-window-button/os-window-button.test.ts
@@ -77,6 +77,48 @@ describe( '<os-window-button>', () => {
 		expect( saw ).toBe( true );
 	} );
 
+	test( 'forwards the host aria-label onto the shadow button', async () => {
+		host.innerHTML = `<os-window-button icon="minimize" aria-label="Minimize"></os-window-button>`;
+		await tick();
+		await tick();
+		const el = host.querySelector( 'os-window-button' )!;
+		const btn = el.shadowRoot!.querySelector( 'button' )!;
+		// The focusable element is the shadow button; a label only on
+		// the (role-less) host is invisible to assistive tech.
+		expect( btn.getAttribute( 'aria-label' ) ).toBe( 'Minimize' );
+	} );
+
+	test( 'forwards the label for themed (icon-src) buttons too', async () => {
+		host.innerHTML =
+			`<os-window-button icon-src="https://example.com/x.png" aria-label="Close"></os-window-button>`;
+		await tick();
+		await tick();
+		const el = host.querySelector( 'os-window-button' )!;
+		const btn = el.shadowRoot!.querySelector( 'button' )!;
+		expect( btn.getAttribute( 'aria-label' ) ).toBe( 'Close' );
+	} );
+
+	test( 'relabelling the host relabels the shadow button', async () => {
+		host.innerHTML = `<os-window-button icon="maximize" aria-label="Maximize"></os-window-button>`;
+		await tick();
+		await tick();
+		const el = host.querySelector( 'os-window-button' )!;
+		el.setAttribute( 'aria-label', 'Restore' );
+		await tick();
+		await tick();
+		const btn = el.shadowRoot!.querySelector( 'button' )!;
+		expect( btn.getAttribute( 'aria-label' ) ).toBe( 'Restore' );
+	} );
+
+	test( 'no aria-label on the host leaves the button unlabelled, not empty-labelled', async () => {
+		host.innerHTML = `<os-window-button icon="close"></os-window-button>`;
+		await tick();
+		await tick();
+		const el = host.querySelector( 'os-window-button' )!;
+		const btn = el.shadowRoot!.querySelector( 'button' )!;
+		expect( btn.hasAttribute( 'aria-label' ) ).toBe( false );
+	} );
+
 	test( 'switching the icon attribute repaints the svg', async () => {
 		host.innerHTML = `<os-window-button icon="minimize"></os-window-button>`;
 		await tick();

--- a/src/ui/components/os-window-button/os-window-button.ts
+++ b/src/ui/components/os-window-button/os-window-button.ts
@@ -35,6 +35,9 @@
  *     theme authors: **control glyphs are monochrome silhouettes** —
  *     only the alpha channel of the source image is used. Wins over
  *     `icon`, which in turn wins over slotted content.
+ *   - `aria-label="…"` — the button's accessible name. Set it on the
+ *     host; the component forwards it onto the shadow `<button>`,
+ *     which is the element that actually takes focus.
  *   - `active` — boolean, applies the pressed-down look
  *   - `danger` — boolean, swaps hover to a red wash (used by the
  *     close button)
@@ -132,6 +135,25 @@ export class OsWindowButton extends Component {
 	static props = [ 'icon', 'icon-src', 'active', 'danger' ] as const;
 	static styles = [ styles ];
 
+	/**
+	 * `aria-label` is observed but deliberately NOT a prop.
+	 *
+	 * The focusable element is the `<button>` inside the shadow root,
+	 * and the host is a custom element with no role — an `aria-label`
+	 * sitting on it is ignored by assistive tech, so every control in
+	 * the title bar announced as an unnamed button. The label has to
+	 * be forwarded onto the shadow `<button>`, and observing the
+	 * attribute is what re-renders when a caller retitles a control
+	 * mid-life (e.g. maximize ⇄ restore).
+	 *
+	 * It stays out of `static props` so the base class doesn't install
+	 * a prop accessor over `HTMLElement.prototype.ariaLabel` and break
+	 * the native ARIA reflection.
+	 */
+	static get observedAttributes(): string[] {
+		return [ ...super.observedAttributes, 'aria-label' ];
+	}
+
 	static help = {
 		title: 'Window button',
 		summary:
@@ -142,6 +164,11 @@ export class OsWindowButton extends Component {
 				name: 'icon',
 				type: "'minimize' | 'maximize' | 'fullscreen' | 'fullscreen-exit' | 'detach' | 'reload' | 'close' | 'menu'",
 				description: 'Which built-in inline SVG to paint. Omit to supply your own via the slot.',
+			},
+			{
+				name: 'aria-label',
+				type: 'string',
+				description: 'Accessible name, forwarded onto the shadow <button> that takes focus. Required — the glyph is aria-hidden.',
 			},
 			{
 				name: 'active',
@@ -195,13 +222,18 @@ export class OsWindowButton extends Component {
 		// is known. The wrapper has no dynamic content; the slot
 		// shows what the consumer provides for custom icons.
 		const svgInner = ICONS[ iconKey ] || '';
+		// Forward the host's accessible name onto the shadow `<button>`
+		// — that is the element focus lands on, and its only content is
+		// an `aria-hidden` glyph. An empty value removes the attribute
+		// rather than writing `aria-label=""`.
+		const label = this.getAttribute( 'aria-label' ) || '';
 		if ( iconSrc ) {
 			// CSS `mask` + `background-color: currentColor` rather than
 			// an `<img>`: an image would paint its own colours and go
 			// deaf to `--os-ui-btn-color`, so a themed close button would
 			// stop turning white on a focused title bar.
 			return html`
-				<button type="button">
+				<button type="button" aria-label="${ label }">
 					<span
 						class="themed-icon"
 						aria-hidden="true"
@@ -212,7 +244,7 @@ export class OsWindowButton extends Component {
 			`;
 		}
 		return html`
-			<button type="button">
+			<button type="button" aria-label="${ label }">
 				<svg
 					width="14"
 					height="14"

--- a/src/window-chrome/controls/render.ts
+++ b/src/window-chrome/controls/render.ts
@@ -166,7 +166,11 @@ function buildControlElement(
 	win: DesktopWindow,
 ): { element: HTMLElement; teardown?: () => void } {
 	const host = document.createElement( 'os-window-button' );
-	host.setAttribute( 'aria-label', def.label );
+	// The component forwards this onto the focusable shadow `<button>`,
+	// whose only other content is an `aria-hidden` glyph. Fall back to
+	// the control id so a plugin that forgot a label still produces a
+	// named button rather than an anonymous one.
+	host.setAttribute( 'aria-label', def.label || def.id );
 	host.classList.add( 'os-window__btn' );
 
 	// Variant class — `core/close` → `close`, `plug/star` → `plug-star`.

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -212,12 +212,16 @@ export function updateFullscreenBodyClass(): void {
 function buildDefaultLoadingOverlay(): HTMLElement {
 	const overlay = document.createElement( 'div' );
 	overlay.className = LOADING_OVERLAY_CLASS;
-	// `aria-hidden` so screen readers don't announce the spinner —
-	// the window's title bar already has a `role="dialog"` + label,
-	// and the spinner's own `<svg role="img" aria-label="Loading">`
-	// is the per-spinner SR signal. Keeping the overlay aria-hidden
-	// avoids double-announcement when the window opens.
-	overlay.setAttribute( 'aria-hidden', 'true' );
+	// The overlay is the ONLY thing on screen while a window loads, so
+	// it has to be reachable by assistive tech — `aria-hidden` here
+	// left a screen-reader user with a `role="dialog"` that appeared
+	// to be simply empty. `role="status"` announces the spinner's own
+	// label politely when it paints and, being a live region, stays
+	// quiet for loads fast enough that the spinner never shows. The
+	// window element carries `aria-busy` for the duration; see
+	// `src/window/loading.ts`.
+	overlay.setAttribute( 'role', 'status' );
+	overlay.setAttribute( 'aria-live', 'polite' );
 
 	const spinner = document.createElement( 'os-spinner' );
 	// `classic` — canonical WordPress mark, three concentric arcs,
@@ -373,6 +377,40 @@ function createSlotHost( name: string ): HTMLElement {
 }
 
 /**
+ * Apply (or strip) the tab strip's navigation semantics based on
+ * whether it currently holds any tabs.
+ *
+ * Every iframe window gets a strip element, because external sub-tabs
+ * can be added at runtime to a window that opened with no submenu. A
+ * strip that is still empty must not advertise itself: an empty
+ * `role="tablist"` is announced as a tab list with no tabs, and a bare
+ * `<nav>` is a navigation landmark with nothing to navigate. Both are
+ * noise in a landmark/rotor listing. `role="presentation"` drops the
+ * element out of the accessibility tree without touching layout.
+ *
+ * Call after any mutation of the strip's children — `tabs.ts` does so
+ * when external tabs are added, when the synthetic "Main" tab is
+ * injected, and when either is removed.
+ *
+ * @internal
+ */
+export function syncTabStripSemantics( strip: HTMLElement | null ): void {
+	if ( ! strip ) {
+		return;
+	}
+	if ( strip.querySelector( ':scope > .os-window__tab' ) ) {
+		strip.setAttribute( 'role', 'tablist' );
+		const label = strip.dataset.tablistLabel;
+		if ( label ) {
+			strip.setAttribute( 'aria-label', label );
+		}
+		return;
+	}
+	strip.setAttribute( 'role', 'presentation' );
+	strip.removeAttribute( 'aria-label' );
+}
+
+/**
  * Build a title-bar control button via the `<os-window-button>` web
  * component. The component ships the SVG icon, variant styling,
  * focused-/unfocused-aware coloring (via custom properties set on the
@@ -408,6 +446,12 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 	el.id = `wp-window-${ config.id }`;
 	el.setAttribute( 'role', 'dialog' );
 	el.setAttribute( 'aria-labelledby', `wp-window-title-${ config.id }` );
+	// A window is born loading. Stamped here rather than left to the
+	// `WINDOW_CONTENT_LOADING` subscriber in `src/window/loading.ts`,
+	// because the `markWindowContentLoading()` call at the end of this
+	// function fires while this element is still detached and that
+	// subscriber resolves windows by `document.getElementById`.
+	el.setAttribute( 'aria-busy', 'true' );
 	el.style.left = `${ config.x }px`;
 	el.style.top = `${ config.y }px`;
 	el.style.width = `${ config.width }px`;
@@ -759,12 +803,17 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 	// Each submenu tab is marked `data-kind="submenu"` so the runtime
 	// tab-switching code can tell submenu tabs apart from closeable
 	// external tabs.
+	//
+	// The strip's accessible name is stashed on a data attribute rather
+	// than applied here: navigation semantics are only switched on once
+	// the strip actually holds tabs (see `syncTabStripSemantics`), and
+	// by that point the config object is out of reach of the runtime
+	// tab code in `tabs.ts`.
 	if ( ! config.native ) {
 		const tabs = document.createElement( 'nav' );
 		tabs.className = 'os-window__tabs';
-		tabs.setAttribute( 'role', 'tablist' );
 		// translators: %s is the window's admin-page title (e.g., "Posts")
-		tabs.setAttribute( 'aria-label', sprintf( __( '%s sub-pages' ), config.title ) );
+		tabs.dataset.tablistLabel = sprintf( __( '%s sub-pages' ), config.title );
 
 		if ( config.submenu && config.submenu.length > 0 && config.url ) {
 			const initialKey = urlMatchKey( config.url );
@@ -816,6 +865,7 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 				tabs.appendChild( tab );
 			}
 		}
+		syncTabStripSemantics( tabs );
 		el.appendChild( tabs );
 	}
 

--- a/src/window/loading.ts
+++ b/src/window/loading.ts
@@ -113,6 +113,10 @@ function _installSubscriptions(): void {
 			if ( ! body ) {
 				return;
 			}
+			// Tell assistive tech the dialog's content is in flux, so a
+			// screen reader doesn't read a half-built (or empty) window
+			// as if it were finished.
+			el.setAttribute( 'aria-busy', 'true' );
 			// Cancel any hand-off still running: the content is about
 			// to be covered again, so fading it in is stale.
 			body.classList.remove( LOADING_HANDOFF_BODY_CLASS );
@@ -144,6 +148,11 @@ function _installSubscriptions(): void {
 			if ( ! body ) {
 				return;
 			}
+			// Content is settled — clear the busy state on the same edge
+			// the loading modifier drops, not on the fade timers below
+			// (those are cosmetic; the content is already there).
+			el.removeAttribute( 'aria-busy' );
+
 			// Only a spinner that actually painted has a fade to
 			// sequence the content behind.
 			const spinnerWasVisible = !! body

--- a/src/window/tabs.ts
+++ b/src/window/tabs.ts
@@ -17,7 +17,7 @@ import { __, sprintf } from '../i18n';
 import { showToast } from '../toast';
 import { pageIdentityKey, urlMatchKey } from '../utils';
 import { EXTERNAL_IFRAME_READY_TIMEOUT_MS } from './constants';
-import { withChromelessParam } from './dom';
+import { syncTabStripSemantics, withChromelessParam } from './dom';
 import type { Window } from './index';
 // Pre-registered globally by the lazy shell-overlays bundle (Stage 10) — see src/shell-overlays/entry.ts.
 
@@ -219,6 +219,9 @@ export function addExternalTab(
 	tabEl.appendChild( closeBtn );
 
 	tabStrip.appendChild( tabEl );
+	// The strip may have opened empty (a window with no submenu); it is
+	// a real tab list from here on.
+	syncTabStripSemantics( tabStrip );
 
 	// Build the iframe. Hidden until we switch to it. `sandbox`
 	// intentionally omitted — external sites often need scripts,
@@ -295,6 +298,7 @@ function ensureMainTab( win: Window, tabStrip: HTMLElement ): void {
 	main.setAttribute( 'aria-selected', 'true' );
 	main.textContent = win.config.title || 'Main';
 	tabStrip.prepend( main );
+	syncTabStripSemantics( tabStrip );
 }
 
 /**
@@ -364,6 +368,11 @@ export function closeExternalTab( win: Window, tabId: string ): void {
 		);
 		main?.remove();
 	}
+	// Back to an empty strip on a submenu-less window — drop the tab
+	// list semantics again.
+	syncTabStripSemantics(
+		win.element.querySelector< HTMLElement >( '.os-window__tabs' ),
+	);
 	// Poke the session saver so the closed tab doesn't resurrect on
 	// reload.
 	win._emitChange( 'state' );

--- a/tests/vitest/window-a11y-semantics.test.ts
+++ b/tests/vitest/window-a11y-semantics.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Accessibility semantics of the window shell.
+ *
+ * Three things a screen-reader user relies on, none of which are
+ * visible and all of which regressed silently before:
+ *
+ *   1. Every window-control button has to have an accessible name.
+ *      The label lives on the `<os-window-button>` host, but focus
+ *      lands on a `<button>` inside its shadow root — the component
+ *      forwards it.
+ *   2. A window with no sub-pages must not advertise an empty tab
+ *      list (nor a `<nav>` landmark with nothing in it).
+ *   3. A window whose content is still loading has to say so.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { createWindowElement, syncTabStripSemantics } from '../../src/window/dom';
+import {
+	_resetWindowChannelsForTests,
+	markWindowContentLoading,
+	markWindowContentReady,
+} from '../../src/window-channels';
+import {
+	_resetWindowLoadingTransitionsForTests,
+	installWindowLoadingTransitions,
+} from '../../src/window/loading';
+import { paintWindowControls } from '../../src/window-chrome/controls/render';
+import { registerBuiltInControls } from '../../src/window-chrome/controls/built-ins';
+import type { Window as DesktopWindow } from '../../src/window';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+// Side-effect import — defines `<os-window-button>` so the painted
+// controls upgrade and expose a shadow root to assert against.
+import '../../src/ui/components/os-window-button/os-window-button';
+
+const tick = (): Promise< void > => Promise.resolve();
+
+const BASE_CONFIG = {
+	url: '#a11y',
+	title: 'Posts',
+	icon: 'dashicons-admin-post',
+	x: 0,
+	y: 0,
+	width: 800,
+	height: 600,
+};
+
+describe( 'window-control buttons — accessible names', () => {
+	beforeEach( () => {
+		installHooksStub();
+		registerBuiltInControls();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		_resetWindowChannelsForTests();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'every painted control names its focusable shadow button, uniquely', async () => {
+		const el = createWindowElement( { ...BASE_CONFIG, id: 'a11y-controls' } );
+		document.body.appendChild( el );
+		const win = {
+			id: 'a11y-controls',
+			config: { ...BASE_CONFIG, id: 'a11y-controls' },
+			element: el,
+		} as unknown as DesktopWindow;
+
+		const host = document.createElement( 'div' );
+		el.appendChild( host );
+		paintWindowControls( win, host );
+
+		await tick();
+		await tick();
+
+		const buttons = Array.from(
+			host.querySelectorAll( 'os-window-button' ),
+		);
+		expect( buttons.length ).toBeGreaterThan( 0 );
+
+		const names = buttons.map( ( b ) => {
+			const inner = b.shadowRoot!.querySelector( 'button' )!;
+			return inner.getAttribute( 'aria-label' ) ?? '';
+		} );
+
+		// Named…
+		for ( const name of names ) {
+			expect( name.length ).toBeGreaterThan( 0 );
+		}
+		// …and distinguishable from one another.
+		expect( new Set( names ).size ).toBe( names.length );
+	} );
+} );
+
+describe( 'tab strip — no empty tablist', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		_resetWindowChannelsForTests();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'a window with no submenu exposes no tablist and no nav landmark', () => {
+		const el = createWindowElement( { ...BASE_CONFIG, id: 'a11y-no-subs' } );
+		const strip = el.querySelector< HTMLElement >( '.os-window__tabs' )!;
+		// The element still exists — external sub-tabs can arrive later.
+		expect( strip.getAttribute( 'role' ) ).toBe( 'presentation' );
+		expect( strip.hasAttribute( 'aria-label' ) ).toBe( false );
+	} );
+
+	test( 'a window with a submenu exposes a labelled tablist', () => {
+		const el = createWindowElement( {
+			...BASE_CONFIG,
+			id: 'a11y-subs',
+			submenu: [ { title: 'Categories', url: '#cats' } ],
+		} );
+		const strip = el.querySelector< HTMLElement >( '.os-window__tabs' )!;
+		expect( strip.getAttribute( 'role' ) ).toBe( 'tablist' );
+		expect( strip.getAttribute( 'aria-label' ) ).toBe( 'Posts sub-pages' );
+		expect( strip.querySelectorAll( '[role="tab"]' ).length ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'syncTabStripSemantics flips both ways as tabs come and go', () => {
+		const el = createWindowElement( { ...BASE_CONFIG, id: 'a11y-flip' } );
+		const strip = el.querySelector< HTMLElement >( '.os-window__tabs' )!;
+		expect( strip.getAttribute( 'role' ) ).toBe( 'presentation' );
+
+		const tab = document.createElement( 'button' );
+		tab.className = 'os-window__tab';
+		tab.setAttribute( 'role', 'tab' );
+		strip.appendChild( tab );
+		syncTabStripSemantics( strip );
+		expect( strip.getAttribute( 'role' ) ).toBe( 'tablist' );
+		expect( strip.getAttribute( 'aria-label' ) ).toBe( 'Posts sub-pages' );
+
+		tab.remove();
+		syncTabStripSemantics( strip );
+		expect( strip.getAttribute( 'role' ) ).toBe( 'presentation' );
+		expect( strip.hasAttribute( 'aria-label' ) ).toBe( false );
+	} );
+} );
+
+describe( 'loading state — exposed, not hidden', () => {
+	beforeEach( () => {
+		installHooksStub();
+		installWindowLoadingTransitions();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+		_resetWindowChannelsForTests();
+		_resetWindowLoadingTransitionsForTests();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'the overlay is a polite status region, not aria-hidden', () => {
+		const el = createWindowElement( { ...BASE_CONFIG, id: 'a11y-loading' } );
+		const overlay = el.querySelector( '.os-window__loading' )!;
+		expect( overlay.getAttribute( 'aria-hidden' ) ).toBeNull();
+		expect( overlay.getAttribute( 'role' ) ).toBe( 'status' );
+		expect( overlay.getAttribute( 'aria-live' ) ).toBe( 'polite' );
+		// The spinner carries the announced text.
+		expect(
+			overlay.querySelector( 'os-spinner' )!.getAttribute( 'label' ),
+		).toBe( 'Loading window content' );
+	} );
+
+	test( 'aria-busy tracks the loading → ready → loading cycle', () => {
+		const el = createWindowElement( { ...BASE_CONFIG, id: 'a11y-busy' } );
+		document.body.appendChild( el );
+		// Born busy — construction marks the window loading before it
+		// is in the document.
+		expect( el.getAttribute( 'aria-busy' ) ).toBe( 'true' );
+
+		markWindowContentReady( 'a11y-busy' );
+		expect( el.hasAttribute( 'aria-busy' ) ).toBe( false );
+
+		markWindowContentLoading( 'a11y-busy' );
+		expect( el.getAttribute( 'aria-busy' ) ).toBe( 'true' );
+
+		markWindowContentReady( 'a11y-busy' );
+		expect( el.hasAttribute( 'aria-busy' ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Three invisible accessibility bugs in the window shell.

## What was wrong

- **Control buttons had no accessible name.** The label sat on the `<os-window-button>` host, but focus lands on a `<button>` inside its shadow root whose only content is an `aria-hidden` glyph — so Minimize, Maximize, Fullscreen and Close all announced as unnamed buttons.
- **Empty tab lists.** Every iframe window exposed `role="tablist"` whether or not it had sub-pages, announcing a tab list with no tabs.
- **The loading overlay was `aria-hidden`.** A loading window read as a `role="dialog"` that was simply empty.

## What changed

- `<os-window-button>` forwards `aria-label` onto the shadow `<button>`, and observes the attribute so relabelling the host relabels the button.
- The tab strip carries `role="tablist"` + its label only while it holds tabs, `role="presentation"` while empty. `tabs.ts` re-syncs it as external sub-tabs are added and removed.
- The overlay is a `role="status"` / `aria-live="polite"` region, and the window element carries `aria-busy="true"` for the duration of the load.

No CSS touched — visuals are unchanged.

## Repro steps

Open any window in the desktop shell, then in the console:

1. **Control names** — `[ ...document.querySelectorAll( '.os-window__controls os-window-button' ) ].map( b => b.shadowRoot.querySelector( 'button' ).getAttribute( 'aria-label' ) )`
   Before: `[ null, null, null, null ]`. After: `[ "Minimize", "Maximize", "Enter fullscreen", "Close" ]`.
2. **Tab strip** — open a window with no sub-pages (Media) and one with them (Posts), then `[ ...document.querySelectorAll( '.os-window__tabs' ) ].map( n => [ n.getAttribute( 'role' ), n.getAttribute( 'aria-label' ) ] )`
   Before: both `"tablist"`. After: Media is `"presentation", null`; Posts is `"tablist", "Posts sub-pages"`.
3. **Loading** — reload a window from the ⋯ menu with `document.querySelector( '.os-window' )` under a `MutationObserver` on `aria-busy`: `true` on reload, gone when the content lands. `document.querySelector( '.os-window__loading' ).getAttribute( 'role' )` is `"status"`, and no longer `aria-hidden`.

## Tests

New `tests/vitest/window-a11y-semantics.test.ts` (6 tests) plus 4 cases on `<os-window-button>`. Full suite, lint, typecheck and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-570-e3232f137eb0d4b8afccd8395b7569af43769e85.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->