### PR TITLE
Add the missing Domain Path header

### DIFF
--- a/desktop-mode.php
+++ b/desktop-mode.php
@@ -11,6 +11,7 @@
  * License:           GPLv2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       desktop-mode
+ * Domain Path:       /languages
  *
  * @package OpenStation
  */


### PR DESCRIPTION
## Proposed changes

Adds `Domain Path: /languages` to the plugin header.

## Why are these changes being made?

Without it, WordPress resolves the plugin's translations to the plugin root, so just-in-time loading looks for `desktop-mode-<locale>.mo` next to `desktop-mode.php`. The file ships in `languages/`, so it finds nothing, `is_textdomain_loaded( 'desktop-mode' )` stays false, and every `__()` in PHP returns its msgid.

No PHP string in the plugin has ever translated. The `.mo` files we ship have never been read.

## Testing instructions

1. Check out this branch on a site with the plugin active.
2. Build a translation for a locale you can read, for example French:
   ```
   wp i18n make-pot . languages/desktop-mode.pot
   ```
   Then translate a handful of entries in `languages/desktop-mode-fr_FR.po` and compile:
   ```
   wp i18n make-mo languages/desktop-mode-fr_FR.po languages/
   ```
3. Set your user's language to that locale in > Users > Profile.
4. Check the registry now points inside `languages/`:
   ```
   wp eval 'global $wp_textdomain_registry; echo $wp_textdomain_registry->get( "desktop-mode", "fr_FR" );'
   ```
   Make sure the path ends in `/languages/`.
5. Load the admin and find one of the strings you translated. Make sure it renders in your locale.
6. Switch back to trunk with the same `.mo` in place and reload. Make sure the same string renders in English, which is the bug.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-572-40bdc63248e4e81c6aee537c4a6fe47611f8dd00.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->