### PR TITLE
Rewrite the WordPress.org readme around multitasking

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== OpenStation — Desktop Windows, Dock & Virtual Desktops for WP Admin ===
+=== OpenStation: Desktop Windows, Dock & Virtual Desktops for WP Admin ===
 Contributors: automattic, allterraindeveloper, epeicher, mmtr86, nickhamze
 Tags: admin, dashboard, desktop, productivity, ai
 Requires at least: 6.0
@@ -8,59 +8,93 @@ Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Turn wp-admin into a desktop OS — windows, dock, virtual desktops, and an AI assistant. Per-user opt-in, zero Core changes. By Automattic.
+A windowed workspace for wp-admin. Open posts, media, and settings side by side, with a dock, virtual desktops, and a Cmd+K palette.
 
 == Description ==
 
-**Your WordPress admin, reimagined as a desktop.** Every admin screen opens as a draggable, resizable window — edit a post, browse the Media Library, and moderate comments side by side instead of one page at a time.
+**wp-admin forgets. OpenStation doesn't.**
+
+You know the moment. You're deep in a post and you need one image from the Media Library. You click over, find it, click back, and everything you had going is gone. Your scroll position, your half-typed thought, the three other things you had queued up in your head.
+
+That's not a bug you hit. That's the design. wp-admin shows you one screen at a time, and every navigation throws the last one away. It has worked this way since 2003, like a fridge that empties itself every time you close the door.
+
+WordPress has rebuilt almost everything else. The editor, the site editor, the patterns, the styles. The admin's one-screen-at-a-time model is the layer nobody touched.
+
+OpenStation touches it.
 
 https://www.youtube.com/watch?v=jii_gGbqUx4
 
-OpenStation is opt-in per user: one click in the admin bar switches you in, one click switches you back. Nobody else on the site sees any change, and deactivating the plugin restores the classic admin exactly. Zero Core patches — every feature runs through public WordPress hooks.
+Install it and admin screens become draggable, resizable windows. Edit a post while the Media Library sits open next to it. Drag an image from one window straight into the other. Keep comments open in the corner. Reload the browser and your window layout — open pages, positions, sizes, and window states — comes back where you left it.
+
+OpenStation itself is free, GPL, and opt-in per user. One click in the admin bar turns it on for you. One click turns it off. Nobody else on your site sees anything change, and deactivating the plugin restores the classic admin exactly. No Core patches and no lock-in. Optional AI providers may charge for their service.
 
 Built and maintained by [Automattic](https://automattic.com), the company behind WordPress.com, Jetpack, WooCommerce, and Tumblr.
 
-= A real desktop =
+= Work on more than one thing at once =
 
-* **Windows** — drag, resize, minimize, maximize, snap, tile. Every admin page works, including plugin pages.
-* **Dock & taskbar** — the admin menu becomes an icon dock; open windows live in a macOS-style taskbar.
-* **Virtual desktops (Spaces)** — one desktop for writing, another for the store, another for moderation.
-* **Files on the desktop** — drop posts, media, and links onto the wallpaper, organize them into folders, trash them to the Trash.
-* **Session restore** — reload the browser and every window comes back exactly where you left it.
+Admin pages open as windows, including pages added by most other plugins. Drag them, resize them, snap them, tile them, minimize them to a taskbar. The admin menu becomes a dock of icons. Two editors open at once is one click away.
+
+= Never lose your place =
+
+Moving between open windows leaves each page in place. Across reloads, OpenStation remembers your open pages, window positions, sizes and states, virtual desktops, and focus. Closing a window with unsaved changes warns you first.
+
+= A desk you can actually put things on =
+
+Drop posts, media, and links right onto the wallpaper. Sort them into folders. Trash them to a Trash that actually holds things. The stuff you're working on this week can just sit out where you can see it.
+
+= One desktop per job =
+
+Virtual desktops, the way your operating system does them. One for writing. One for the store. One for comment triage. One for that redesign you keep poking at. Switch between them without closing anything.
+
+= Find anything with Cmd+K =
+
+The full WordPress command palette, plus slash commands from your plugins, all under one keystroke. Turn on the optional AI assistant and you can ask it things like "which post had the comment asking for the recipe?" and it searches your own content to answer. (Requires an AI provider configured in Settings → Connectors on WordPress 7.0+. Details under "External services" below.)
+
+= See how your site fits together =
+
+The Corkboard is an interactive, zoomable map of how your posts, pages, and products link to each other. Pan around it. Find the orphans. Find the hubs.
+
+= Running a store? =
+
+Orders, Products, Coupons, and Customers become browsable folders with stock and sale ribbons. Open a customer to see their lifetime spend and what they buy most. Follow a product to its buyers, or a coupon to who redeemed it.
 
 = Make it yours =
 
-* **Wallpapers** — color presets, animated scenes, or your own image.
-* **Widgets & desktop icons** — pin live widgets and shortcuts to the wallpaper; plugins can register their own.
+Wallpapers, from color presets to animated scenes to your own photo. Live widgets pinned to the desktop: drafts, stats, recent comments, a focus timer. Uploadable desktop themes, including a built-in Legacy theme that brings the old WordPress blue back in one click. And Mio, a soft-body desk companion that drifts across your wallpaper and gets bumped around by your windows. Off by default. You'll turn it on.
 
-= Superpowers =
+= For developers =
 
-* **AI Assistant (optional)** — press Cmd+K and ask *"Which post had the comment asking for the recipe?"* It searches your own content. Requires an AI provider configured in **Settings → Connectors** (WordPress 7.0+); see "External services" below.
-* **Corkboard** — an interactive, zoomable map of how your posts, pages, and products link together.
-* **Cross-window drag & drop** — drag an image from the Media Library window straight into the editor in another window.
-* **Command palette** — the full WordPress command palette plus slash commands from plugins, all under Cmd+K.
-
-= Built to be extended =
-
-Every significant behavior is hookable. Register windows, dock items, wallpapers, widgets, desktop icons, commands, settings tabs, and AI tools from your own plugin — stable `openstation_register_*` PHP APIs, a typed JavaScript API, and copy-paste examples in the [developer docs on GitHub](https://github.com/WordPress/openstation/tree/trunk/docs).
+Extend OpenStation through documented PHP and JavaScript APIs. Register windows, icons, wallpapers, widgets, commands, and settings tabs through stable `openstation_register_*` PHP APIs and a typed JavaScript API; customize dock items through documented hooks; add AI tools with the WordPress Abilities API. Copy-paste examples live in the [developer docs on GitHub](https://github.com/WordPress/openstation/tree/trunk/docs).
 
 = External services =
 
-This plugin's optional **AI Assistant** sends data to the **AI provider you configure in WordPress's Settings → Connectors** (for example OpenAI, Anthropic, or Google). Generation is routed through WordPress 7.0's built-in AI Client, which supplies the credentials stored in Connectors — the plugin never handles an API key itself. With no provider configured in Connectors, no external AI requests are made.
+No external service is required for OpenStation's desktop interface. The optional AI Assistant and two user-initiated enrichment features make the external requests described below.
+
+**AI Assistant**
+
+The optional AI Assistant sends data to the **AI provider you configure in WordPress's Settings → Connectors** (for example OpenAI, Anthropic, or Google). Generation is routed through WordPress 7.0's built-in AI Client, which supplies the credentials stored in Connectors. The plugin never handles an API key itself. With no provider configured in Connectors, no external AI requests are made.
 
 When the AI Assistant is enabled and a user invokes it (via Cmd+K or the slash-command palette):
 
 * **What is sent:** the user's prompt, the conversation history for the active session, and tool-call metadata. The plugin's built-in tools (`search_posts`, `search_pages`, `search_comments`) run WordPress's native keyword search and may include excerpts of the matching posts/pages/comments in tool results, which are then sent back to the provider as part of the agentic loop.
 * **When it is sent:** on user-initiated AI requests, and (if an administrator enables "Score new comments with AI") on comment-save hooks for spam analysis. Posts, pages, and taxonomy terms are not sent automatically.
 * **Why it is sent:** to obtain model completions and tool-call decisions that drive the AI Assistant.
-* **Who provides the service:** whichever provider you configured in Settings → Connectors. Which provider (and endpoint) receives the data depends entirely on that configuration — review the chosen provider's own terms and privacy policy (e.g. OpenAI, Anthropic, or Google).
+* **Who provides the service:** whichever provider you configured in Settings → Connectors. Which provider (and endpoint) receives the data depends entirely on that configuration. Review the chosen provider's own terms and privacy policy (e.g. OpenAI, Anthropic, or Google).
 
-No other external services are contacted by this plugin.
+**URL shortcut favicons**
+
+When an authorized user creates a desktop shortcut to an external URL, OpenStation asks that URL for its page HTML and favicon so the shortcut can display the site's icon. The request is made from your WordPress server and sends the requested URL, the server's IP address, an OpenStation user-agent string, and normal HTTP request metadata to the operator of that site. This happens only when a user creates the shortcut. The destination site's terms and privacy policy apply.
+
+**WordPress.org plugin information**
+
+When an authorized user opens or refreshes parts of OpenStation's Plugins window, OpenStation may request public plugin details, update metadata, and review excerpts from WordPress.org. These requests send plugin slugs, the site's locale, and normal HTTP request metadata to WordPress.org. This information is used only to display and manage plugins. Review the [WordPress.org Privacy Policy](https://wordpress.org/about/privacy/).
+
+OpenStation's OAuth relay does not contact a service by itself. Third-party plugins that configure the relay may contact their own providers and are responsible for disclosing those services.
 
 == Installation ==
 
-1. Upload the plugin folder to `/wp-content/plugins/`, or install via **Plugins → Add New → Upload Plugin**.
-2. Activate the plugin through the **Plugins** screen in WordPress.
+1. Install via **Plugins → Add New** (search for "OpenStation"), or upload the plugin folder to `/wp-content/plugins/`.
+2. Activate the plugin through the **Plugins** screen.
 3. Click the **desktop** icon in the admin bar's top-right corner. The admin reloads inside the desktop shell.
 4. Click the same icon again at any time to return to the classic admin.
 
@@ -72,21 +106,33 @@ No other external services are contacted by this plugin.
 
 == Frequently Asked Questions ==
 
+= Isn't this just a gimmick? =
+
+The desktop look is the visible part, so it's a fair question. But the look is a consequence, and the mechanism underneath is the point: windows hold their state, so switching tasks stops costing you your place. wp-admin is a single-document interface where every navigation destroys the last screen. OpenStation replaces that with the same concurrency model your operating system has used for decades. The research behind it goes back to Henderson and Card's "Rooms" paper at Xerox PARC in 1986. The wallpaper is just what that model looks like when you build it.
+
+= Will this slow down my site? =
+
+OpenStation's desktop interface and browser assets are loaded only inside wp-admin, and only for users who have turned it on. Its PHP integration still participates in normal WordPress request handling where needed, including tracking content changes, but visitors never receive the desktop UI.
+
 = Does this change anything for users who don't opt in? =
 
 No. The classic admin is untouched until a user toggles OpenStation on for themselves. Deactivating the plugin restores vanilla Core exactly.
 
+= Does it work with my other plugins? =
+
+Most plugin admin pages open as windows without special integration. Plugins that depend on running in the top-level browser context or use unusual navigation may need compatibility work. Plugins can also register their own native windows, widgets, and commands for a deeper integration.
+
 = Does the plugin require an external service to function? =
 
-No. The desktop shell, windowing, dock, taskbar, virtual desktops, widgets, wallpapers, and all extension APIs work entirely on-site. The AI Assistant is the only feature that contacts an external service, and it stays inert until an administrator configures an AI provider in Settings → Connectors. See "External services" in the description.
+No. The desktop shell, windowing, dock, taskbar, virtual desktops, widgets, wallpapers, and extension APIs work without an external service. The optional AI Assistant requires a configured AI provider. OpenStation also makes limited, user-initiated requests to resolve URL-shortcut favicons and display WordPress.org plugin information. See "External services" in the description.
 
 = Does it patch WordPress core? =
 
 No. Every feature is wired through public WordPress actions and filters.
 
-= How do I disable OpenStation for my user? =
+= How do I turn OpenStation off for my user? =
 
-Click the desktop icon in the admin bar a second time to flip the toggle off. The plugin can also be deactivated globally from the Plugins screen.
+Click the desktop icon in the admin bar a second time. The plugin can also be deactivated globally from the Plugins screen.
 
 = Where is the developer documentation? =
 
@@ -94,12 +140,12 @@ In `docs/` inside the plugin, and on [GitHub](https://github.com/WordPress/opens
 
 == Screenshots ==
 
-1. Real multitasking — Users, Media, and content editing open side by side as windows.
-2. Your admin, your desktop — custom wallpapers and live widgets registered by plugins.
-3. The AI Assistant (Cmd+K) answers questions about your own posts, pages, and comments.
-4. Corkboard — an interactive map of how your content links together.
-5. OpenStation Preferences — pick a wallpaper preset, an animated scene, or upload your own image.
-6. Files on the desktop — drag posts, media, and links onto the wallpaper and into folders.
+1. Real multitasking: Users, Media, and a post you're editing, open side by side as windows.
+2. Your admin, your desktop: custom wallpapers and live widgets registered by plugins.
+3. Ask the AI Assistant (Cmd+K) about your own posts, pages, and comments.
+4. Corkboard: a zoomable map of how your content links together.
+5. OpenStation Preferences: wallpaper presets, animated scenes, or your own image.
+6. Files on the desktop: drag posts, media, and links onto the wallpaper and into folders.
 7. The Trash collects trashed posts, media, folders, and shortcuts in one window.
 
 == Credits ==
@@ -136,293 +182,28 @@ The **Inkfall** game's word list (`assets/games/inkfall/words.txt`) is generated
 * The site folder is now WP Explorer, and OS Settings is now OpenStation Preferences.
 * A new palette and typography, with four wallpapers: Galaxy (the new default), Space, Holomesh and Pulsemesh.
 * Desktop Mode (Legacy) — a built-in desktop theme that puts the previous look back in one click, WordPress blue included.
-* Mio — a soft-body desk companion that drifts across the wallpaper and gets pushed around by your windows. Off by default; turn it on from the dock. It also ships as a standalone script you can drop on any page, WordPress or not.
-* Holographic controls — switches, primary buttons and selected items catch an iridescent mesh on hover and press.
-* New Switch component, and a searchable Components tab in OpenStation Preferences.
-* Select more than one thing at a time — click, Ctrl-click, Shift-click, marquee and Cmd+A on the desktop and in every folder window, with WordPress's own bulk actions and multi-item drag.
-* Custom post types now appear in WP Explorer, grouped into a folder named after the plugin or theme that registered them.
-* Post tiles show their featured image instead of a generic icon, which turns a catalogue into a photo grid.
-* WooCommerce — Orders, Products, Coupons and Customers as browsable folders, with out-of-stock, low-stock, backorder and sale ribbons, and a details pane showing price, stock, order totals, line items and coupon usage.
-* Open a customer for their lifetime spend, what they buy most and their recent orders, and follow a product to its buyers or a coupon to who redeemed it.
+* Mio — a soft-body desk companion that drifts across the wallpaper and gets pushed around by your windows. Off by default; turn it on from the dock.
+* Holographic controls, a new Switch component, and a searchable Components tab in OpenStation Preferences.
+* Multi-select everywhere: click, Ctrl-click, Shift-click, marquee and Cmd+A, with WordPress's own bulk actions and multi-item drag.
+* Custom post types now appear in WP Explorer, grouped by the plugin or theme that registered them.
+* Post tiles show their featured image instead of a generic icon.
+* WooCommerce — Orders, Products, Coupons and Customers as browsable folders, with stock and sale ribbons, customer lifetime spend, and coupon redemption views.
 * The editor's preview companion follows your typing in the classic editor too, and opens straight away instead of waiting on a save.
-* Plugins can accept files dropped onto their own desktop icon, via `wp.os.files.registerTilePayloadHandler()`.
-* The Games leaderboard refreshes the moment a run finishes, instead of waiting for a reload.
-* Fix the Media Library's uploader button opening a window instead of the inline uploader, and uploaded files not reaching the grid until the window was reopened.
-* Fix context menus opened near the bottom of the screen running off the edge, which put most of their options out of reach.
-* Fix Quick Edit and Bulk Edit going dead once a list refreshed in place.
-* Fix the classic revisions screen opening in a browser tab instead of a window, and restoring a revision leaving a stale editor behind.
-* Fix closed windows reappearing after a refresh, and window state being lost when several windows were closed in quick succession.
-* Fix the widget column rendering empty.
-* Desktop icons and file tiles now fade out in Overview, so they no longer collide with window thumbnails.
-* Fix `wp.os.activity.subscribe()` never receiving events — channel names containing a slash were silently rejected.
+* Many fixes: Media Library uploads, context menus near the screen edge, Quick Edit after list refreshes, revisions opening in-window, window state across refreshes.
 * The portal URL moved from `/desktop-mode/` to `/openstation/`. Reinstall the app if you added OpenStation to your home screen.
-* For plugin authors: `wp.desktop` is now `wp.os`, `<wpd-*>` components are `<os-*>`, PHP functions and hooks use the `openstation_` prefix, and activity channels moved from `desktop-mode/<event>` to `os/<event>`. Stored data — options, meta, custom tables, REST namespaces and the WordPress.org slug — is unchanged.
+* For plugin authors: `wp.desktop` is now `wp.os`, `<wpd-*>` components are `<os-*>`, PHP functions and hooks use the `openstation_` prefix, and activity channels moved to `os/<event>`. Stored data — options, meta, custom tables, REST namespaces and the WordPress.org slug — is unchanged.
 
 = 0.9.8 =
 * Desktop Themes — uploadable ZIP theme system
-* Add a Drafts widget
-* Add a window corner-radius setting (Sharp / Default / Round)
-* Add editor-preview eye button with live split-view preview
-* Correct the AI Copilot and settings tab references
-* Update wp-coding-standards/wpcs to 3.4.1
-* Strip version-history annotations across PHP, TS, and Markdown
-* Fix invisible context menus and confirm dialogs (transparent panel background)
-* Let a desktop theme recommend OS settings
-* Fix window id plumbing, and restore native windows across a reload
-* Decode html entities in post excerpts
-* Fix Recycle Bin Sync
-* Add Aero Peek preview with snap-back to dock peek
-* Fix Cmd+K entity search not finding posts in Commands mode
-* Make the command palette follow the active desktop theme
-* Redesign the native Comments window as a two-pane conversation view
-* Keep menu edit links inside the current window
-* Name desktop objects after things, not after the software
-* Give tooltips their own two theming tokens
-* Add an AI writing assistant to the Drafts widget
-* Fix active tab underline highlight in Appearance Add Theme view
-* Show the whole component kit in OpenStation Preferences, and make it searchable
-* Expose dock glyph and focused window control colours as tokens
-* Overview: show minimized windows in grid to fix badge count mismatch
-* Decode html entities in recycle bin
-* Add an admin-bar presentation mode to OpenStation Preferences and the theme system
-* AI Agents framework: agents as WordPress users, abilities runner, chat with persisted conversations, drag & drop and Send to triggers
-* Close privilege-escalation and session-bypass paths
-* Enforce strict structured-output schemas at the provider boundary
-* Add window reveal animations
-* Add Popup Siege as a OpenStation game extension
-* Add SOL Inbound Monologue RSS reader extension
-* Drop the esbuild CSS syntax warning in the drafts widget
-* Improve the agents chat and Agents section UX
-* Contain window-reveal play failures and stop over-promising `owner`
-* Enhance agent capabilities and HTTP timeout management
-* Provider robustness — OpenAI strict schema, Anthropic refusals, retries, real request timeout
+* Drafts widget with an AI writing assistant, window corner-radius setting, live split-view editor preview
+* AI Agents framework: agents as WordPress users, abilities runner, chat with persisted conversations
+* Redesigned two-pane Comments window, Aero Peek dock previews, window reveal animations
+* Security: closed privilege-escalation and session-bypass paths; strict structured-output schemas at the provider boundary
+* Many smaller fixes and polish
 
-= 0.9.7 =
-* Add Drafts widget
-* Add Focus Timer widget
-* Fix window title bar pushed off-screen during top-edge resize
-* Enforce viewport boundaries during window resize
-* Fix hiding a dock-placed native window's tile via Apps & Icons
-* Fix window dragging allowing windows to disappear off right/bottom edges
-* Folder-upload desktop refresh + inline upload previews
-* Reset the plugin-update notifiers live after updates run
-* Decode html entities in widget titles
-* Fix window drag bounds
-* Focus Timer: react to the linked window closing
-* Make the games framework an opt-in Extended option (off by default)
-* Cut idle server load, boot weight, and package size
-* Live-refresh Plugins window after install/activate/deactivate
-
-= 0.9.6 =
-* Improved button accessibility and visual feedback by implementing the missing busy spinner and aria-busy attributes on the Button component
-* AI assistant as the shell's ⌘K palette (Commands + Ask AI)
-* Add pinned notes: paper notes with a pushpin, composed in a Note Pad widget
-* Improve minimized window UX with restore support and count badges
-* Surface core admin notices once in the desktop shell
-* Convert pinned notes into draft posts
-* Normalize AI Copilot tool schemas for the provider
-* Add a game system: Games hub, unified scoreboard, challenges, and Inkfall
-* Keep URL-style menu slugs (ACF) as direct admin links
-* Add Alphabet Soup game; generalize game infra out of Inkfall
-* Fix 404 from wallpaper Sort By when a synthetic tile is on the desktop
-* Fix illegible text fields inside os-modal dialogs
-* Fix empty custom-gradient editor after re-selecting the wallpaper
-* Add Related-entities title-bar navigation with open PHP/JS filter surface
-* Admin bar visibility when fullscreen window is minimized
-* Allow selecting window from Overview view
-* Show open window indicators for bottom dock tiles
-* Add busy state and spinner to os-button
-* Redesign session-expiry recovery: one login prompt, in-place recovery
-* Fix folder rename not reflected on the desktop until refresh
-* Live-refresh list windows on content changes (posts, CPTs, comments, WooCommerce orders)
-* Add real file/folder storage on the desktop
-* Fix gamepad icon missing from the window title bar (data-URI window icons)
-* Fix content graph taxonomy fallback
-
-= 0.9.5 =
-* AI Copilot now uses WordPress 7.0 providers: configure a provider once in Settings → Connectors and the assistant uses it — no more per-plugin keys
-* AI Copilot tools are now WordPress Abilities, so the assistant works across any configured provider; plugin authors add their own tools with the Abilities API (`openstation_register_ai_tool()` was removed)
-* Removed the OpenStation Preferences → AI tab; the per-user "AI assistant" toggle now lives in OpenStation Preferences → Features next to "Score new comments with AI"
-* Requires WordPress 7.0 for the AI assistant only; on older WordPress the assistant is hidden and the rest of OpenStation is unaffected
-* Stored AI keys are deleted from the database on upgrade
-* Five new built-in widgets: Recent Comments, Post Stats, Site Views, Jazz Quote, and Starter
-* Widgets can now be resized, and docked widget heights persist across sessions
-* Two new wallpapers, Living Tree and Snow, plus per-wallpaper settings dialogs
-* Window links: windows showing related content are visually connected, with pluggable link renderers for plugin authors
-* Spring-loading: hovering a window while dragging anything brings it to the front
-* New developer mode setting (OpenStation Preferences → Features) unlocks developer-facing surfaces
-* WordPress update notices now surface once in the desktop shell instead of repeating in every window
-* Desktop shortcuts stay in sync and core icons follow the spatial layout
-* Extended options merged into the OpenStation Preferences → Features tab
-* Fixed selection bugs that could point destructive actions at the wrong files
-* Closing a window with unsaved changes now warns instead of silently losing work
-* Fixed windows and dock state leaking across virtual desktops
-* Fixed Overview keyboard navigation and focus trapping
-* The dock now refreshes live when a plugin registers a new post type
-* Fixed dock icon alignment, "Add New" window titles and icons, and count-label pluralization
-
-= 0.9.3 =
-* Rewrite WordPress.org plugin page, leaner copy, video embed, screenshots
-* Review: doc/comment accuracy, security hardening, and cleanups across the plugin
-
-= 0.9.2 =
-* Persist welcome-dialog dismissal when OpenStation is disabled
-* Welcome dialog reappears on every page when the admin is served from an origin that differs from `site_url`
-
-= 0.9.1 =
-* Make native list windows opt-in (Beta) instead of opt-out
-* Scope AI to comment spam + native-search assistant
-* Feat/unfocus window effects
-* Fix placement, gear/Help, and dock⇄desktop visibility bugs
-* Fix Guidelines-experiment 404 noise, duplicate welcome dialog, and unused-preload warnings
-* Add "View activity footprint" row action in Users list
-
-= 0.9.0 =
-* Gate per-user REST routes on OpenStation enabled
-* Refine recycle bin badge styling and sync on stop
-* Clear comments selection after applying action
-* Don't let a failing sync block the agent
-* Make the AI-disabled error link to AI Settings
-
-= 0.8.9 =
-* Improve drag-and-drop handling in chromeless bridge and iframe bridge
-* The whole shell loads faster, especially the first time you open wp-admin
-* Open an app from the wallpaper or from the dock — it's the same window now (no more two copies floating around)
-* Minimize a window and the dock icon shows it's minimized — even if you opened it from the desktop icon
-* Click "+ New" twice and you get two editors. Drafting a post and want to start another? Just click again
-* "Switch to OpenStation" always takes you to the dashboard, so you know where you're starting from
-* Resizing a window and accidentally letting go over the desktop no longer minimizes everything
-* WooCommerce: the "Add Order" button is back on the Orders page
-* "Add New" buttons (Add Post, Add Order, Add anything) stay visible inside every plugin page
-* After we ship a fix, you get it on your next page load — no more "try refreshing twice"
-
-= 0.8.8 =
-* Align dock badge with in-window update count
-* Make every dock scrollable, keep system tiles pinned
-* No more flash when you create, move, or delete a file or shortcut on the desktop
-* Trashing a folder that contained other folders now works (used to silently fail)
-* Drag an image from the Media Library straight into a Gutenberg post, it now inserts
-* Edit User screen: the form is centered instead of pinned to the left
-* Title-bar icons (Help, etc.) are now visually centered
-* Sticky notes powered by WP Guidelines
-
-= 0.8.7 =
-* Bump Tested up to WordPress 7.0
-* Fix plugins window stale-nonce 'Cookie check failed' on long-running sessions
-* Fix plugin .zip drop routing to Media Library uploader
-* Add server-side search to entity list views
-* Rename Browse tab to Add Plugin
-* Drag and drop improvements
-
-= 0.8.6 =
-* Light indicators for native-window-target dock icons
-* Additional fixes and polish
-* Add compatibility layer for Divi script dependencies and tests
-* Show plugin icons
-* Open off-site menu items in a new browser tab
-
-= 0.8.6-rc1 =
-* Tag cloud & category mindmap: search, clustering, server cache
-* Drag & Drop from local desktop
-* Implement loading skeletons and staggered animations for file tiles
-* Arrow-key shortcuts + Overview-from-Show-Desktop fix
-* Shortcuts popover, dock-style tooltips, reorder
-* Add Featured Plugins View and Ribbon Component
-* Add "Automatic Updates" column and related functionality to Plugins window
-* Add window notices feature with persistent dismissal and server sync
-* Polish four framework surfaces for plugin authors
-* Disable focus on other window actions
-* Add Media section to "My WordPress" + uniform preview-pane hook surface
-* Refactor My WordPress to use `<os-tile>` + add post status ribbons
-* Allow deactivating plugins in CMO desktop & dock
-* OS-file drop — progress UI, live refresh, cancel cleanup, CMO
-* Group-by selector + click-to-deselect + focused-icon centering
-* Test against PHP 8.3 and 8.4
-* Enhance minimize/restore behavior to preserve pre-minimize state and add cross-state transition tests
-
-= 0.8.5 =
-* Shared folders, heartbeat widget, and heartbeat-pipeline hardening
-* Recycle Bin: show item type badges inline next to title
-* Plugins window: expandable rows with rich plugin details
-* Remember native window size across opens
-* Fix blank plugin icons in the Plugins window
-* Restore "Show desktop on wallpaper click" as an opt-in setting
-* Fix plugin update refresh, dock badge, and stuck-row failures
-* Trash bin polish: URL badge, live placement badge, no media auto-trash
-* Throw on empty REST body to avoid TypeError after self-replace
-* Hide Media filter tab when MEDIA_TRASH is off
-* Sequence openCurrentPage after restoreSession to avoid duplicate windows
-* Fix window refresh issue on new sessions
-
-= 0.8.4 =
-* Faster OpenStation, main bundle cut by 59 %
-* "Edit Post" from the front-end admin bar opens nothing
-* Cross-page admin-link clicks: state, destructive actions, referer hint
-* Warn loudly when a `<os-*>` tag is used without being imported
-* Support re-uploading existing plugins, add post-install Activate panel
-* Restore the full WordPress command palette inside Cmd+K
-
-= 0.8.3 =
-* Feat comments as native windows
-* Chrome <111 titlebars + duplicate-placement REST 500s
-* SW navigation interception caused window-in-window after core update
-* Open each post as its own window from the Posts window
-* Fix Users window data + live-refresh, plus per-window REST clients
-* Session-expiry cascade + Plugins window sync
-* Narrow scope to /wp-admin/ and throttle SW reloads
-* Plugins window: real updates, not just a phantom badge
-* Support plain permalinks for REST URL construction
-* Hide registered icons from desktop instead of trashing
-
-= 0.8.2 =
-* Many fixes and new features
-* Add unit test to ensure bridge script skips core AJAX update buttons
-* Native Plugins window + `<os-card>`
-* Appearance window polish + dock-peek fixes
-* Fix upload theme
-* Implement favicon resolver and associated tests for OpenStation
-* Auto-inject X-WP-Nonce for REST API requests
-* Enhance user management functionality in WordPress REST API
-* Fix user role updates
-* Fix plugin native issues
-* Enhance color scheme preview functionality by adding shell scheme flipping
-* Fix rearrange icons out of desktop
-* Open each post in its own window
-* Add item visibility and dock order settings
-* Add first-run welcome dialog for OpenStation
-* Fix dock management
-* Refetch desktop placements on Recycle Bin restore
-
-= 0.8.1 =
-* Framework rework and stability improvements — significant internals refactor, smoother window lifecycle, and more reliable bridging between iframe and native windows.
-* Drag and drop reworked end-to-end: calmer pointer behavior, more accurate hit-testing, and reliable handoff across windows.
-* Posts, Pages, and Users now open as native desktop windows — direct DOM rendering inside the shell instead of an iframe, faster open, instant interaction, and UI tailored to the windowing model.
-* New Content Graph tool — an interactive map of how your content links together. Pan, zoom, and focus a node to explore its neighborhood.
-* Cross-page admin link routing in the chromeless bridge so links across the admin stay inside the desktop shell.
-* Many bug fixes across the admin bar, Fullscreen toggle, resize handles over iframes, real-time icon refresh on plugin activation, and the PWA shell.
-
-= 0.5.1 =
-* Code editor and framework improvements.
-* Enhanced AI provider integration: third-party providers may register through `openstation_register_ai_provider()`.
-* Title-bar button registry with icon painting for plugin authors.
-* OpenStation Preferences tabs are now extensible via `openstation_register_settings_tab_script()` / `openstation_register_settings_tab()`.
-* AI Copilot extensibility: server-side tool registry (`openstation_register_ai_tool()`) and client-side `wp.os.ai.ask()` programmatic entry point.
-* UI component kit expansion (~25 `<os-*>` web components).
-* Backtick hotkey to cycle window focus.
-* Unified command palettes via the palette registry.
-* OpenStation Preferences Help tab.
-
-= 0.5.0 =
-* Command registration APIs (`openstation_register_command_script()` / `openstation_register_command()`) with live install/activate refresh.
-* Media-library enhancement enabled by default, with opt-out.
-* Dock CSS selectors updated; overflow handling improved.
-
-See the [GitHub releases page](https://github.com/WordPress/openstation/releases) for the full history.
+Earlier releases are on the [GitHub releases page](https://github.com/WordPress/openstation/releases).
 
 == Upgrade Notice ==
 
-= 0.8.1 =
-Framework and stability rework, reworked drag and drop, native Posts/Pages/Users windows, and a new Content Graph tool. Backwards-compatible.
-
-= 0.5.1 =
-Adds AI Copilot extensibility (server-side tools, multi-provider support) and a title-bar button registry. Backwards-compatible.
+= 1.0.0 =
+Desktop Mode is now OpenStation. Everything carries over: settings, files, sessions, desktop layouts. Plugin authors: `wp.desktop` is now `wp.os`; see the changelog for the rename map.


### PR DESCRIPTION
## Summary

- rewrite the WordPress.org description around the concrete cost of wp-admin's one-screen-at-a-time workflow
- present multitasking, session restore, desktop files, virtual desktops, AI, Corkboard, WooCommerce, customization, and extension APIs in task-oriented sections
- add practical FAQs and condense the historical changelog, linking older releases to GitHub
- preserve the proposed voice while narrowing claims to what OpenStation actually guarantees

## Why these corrections are necessary

The rewrite surfaced several claims that needed to match the implementation before publishing:

- **Session restore:** OpenStation persists open URLs, geometry, window state, desktops, and focus. It does not promise to serialize arbitrary form contents or in-page scroll state, so the copy now describes the persisted layout precisely.
- **Plugin compatibility:** most admin pages work without integration, but a universal guarantee is not supportable for plugins that assume a top-level browser context or use unusual navigation.
- **Frontend loading:** the desktop rendering layer and browser assets are admin-only, while PHP integration still participates in some normal WordPress requests to track frontend-originated content changes.
- **Developer API:** `openstation_register_ai_tool()` was removed in 0.9.4. AI tools now use the WordPress Abilities API; the readme no longer advertises a removed PHP API.
- **External services:** URL shortcuts resolve remote favicons, and the Plugins window requests public WordPress.org information. The previous statement that AI was the only external communication was inaccurate. The new disclosure explains what is requested, when, why, and what metadata is sent.
- **Cost:** OpenStation itself is free, but a configured AI provider may charge for usage.

The external-service detail also aligns the readme with [WordPress.org Plugin Directory guideline 7](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#7-plugins-may-not-track-users-without-their-consent), which calls for documenting external communication and how data is used.

## Validation

- passes the official WordPress.org readme validator (the only note is the optional absence of a donation link)
- short description is 132 characters, below the 150-character limit
- `git diff --check` passes
- readme shrinks from about 30 KB to 16 KB

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-575-f37de8d7800e898b1873aa651abc0752bb77593c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->