### PR TITLE
fix: set empty state heading color in feed-buddy

### DIFF
--- a/extensions/desktop-mode-feed-buddy/assets/css/feed-buddy.css
+++ b/extensions/desktop-mode-feed-buddy/assets/css/feed-buddy.css
@@ -171,6 +171,11 @@
 	margin: 0 0 8px;
 }
 
+.feed-buddy-reader__empty h2 {
+	color: var(--feed-buddy-ink);
+}
+
+
 .feed-buddy-transcript {
 	display: grid;
 	gap: 0;

--- a/extensions/desktop-mode-feed-buddy/assets/css/feed-buddy.css
+++ b/extensions/desktop-mode-feed-buddy/assets/css/feed-buddy.css
@@ -175,7 +175,6 @@
 	color: var(--feed-buddy-ink);
 }
 
-
 .feed-buddy-transcript {
 	display: grid;
 	gap: 0;


### PR DESCRIPTION
Closes #558

### Description
This PR resolves a visual bug in the SOL Inbound Monologue (Feed Buddy) extension where the empty-state heading disappears (rendering white text on a white background) when a dark desktop theme is active on a light-background window body.

### Root Causes & Fixes
The heading element (`h2`) color was leaking from the outer window chrome theme rules (which default heading colors to `--os-ui-fg`, resolving to white under dark themes). I have  set `.feed-buddy-reader__empty h2` color explicitly to `var(--feed-buddy-ink)` to preserve contrast.

**Before fix**
<img width="1033" height="722" alt="Screenshot 2026-08-12 at 7 44 28 PM" src="https://github.com/user-attachments/assets/3f46348f-e2cd-4723-b00d-d32b41bbfa6e" />

**After fix**
<img width="1020" height="719" alt="Screenshot 2026-08-13 at 12 54 16 PM" src="https://github.com/user-attachments/assets/26c6436c-5234-45e5-941c-2dd7ae84972c" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-599-1907ffd302c3643f6dff47220ab98a097e6fff58.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->