### PR TITLE
Woo relations: a refund is not a purchase; user tiles: carry their key

### DIFF
--- a/includes/my-wordpress/integrations/woocommerce-relations.php
+++ b/includes/my-wordpress/integrations/woocommerce-relations.php
@@ -60,6 +60,25 @@ defined( 'ABSPATH' ) || exit;
 const OPENSTATION_WOO_RELATION_ITEM_CAP = 20;
 
 /**
+ * How many orders the product and coupon groups list.
+ */
+const OPENSTATION_WOO_RELATION_ORDER_CAP = 10;
+
+/**
+ * How many order-item rows to read to fill that list.
+ *
+ * The id lists come out of `woocommerce_order_items`, which holds
+ * refund rows alongside order rows — and refunds sort *first* there,
+ * since the query orders by descending id and a refund is created
+ * after the order it refunds. A `LIMIT 10` on a much-refunded product
+ * could therefore come back as ten refunds and no orders at all, and
+ * the group would render empty on the one product whose history a
+ * merchant most wants to read. Reading a few times the budget and
+ * stopping at the cap costs one bounded query.
+ */
+const OPENSTATION_WOO_RELATION_ORDER_CANDIDATES = 40;
+
+/**
  * Query flag marking a person-URL as a request for a *particular*
  * view of that person rather than for the profile editor.
  *
@@ -128,6 +147,44 @@ function openstation_my_wordpress_woo_current_order() {
  */
 function openstation_my_wordpress_woo_can_read_orders() {
 	return true === openstation_my_wordpress_woo_orders_permission();
+}
+
+/**
+ * Whether an object read back from an order-item row is a purchase.
+ *
+ * Refunds keep their own line items in the same
+ * `woocommerce_order_items` tables, under the refund's id — so a
+ * lookup that asks those tables "which orders contain product X"
+ * answers with refund ids too, for any product that has ever been
+ * refunded. `WC_Order_Refund` extends `WC_Abstract_Order`, so the
+ * usual guard waves it through, and the next line asks it for
+ * `get_order_number()`: a `WC_Order` method the abstract base does
+ * not declare, and therefore a fatal on the product edit screen.
+ *
+ * Dropping refunds is also the truer answer. "Who bought this" and
+ * "where was this coupon used" are questions about purchases, and a
+ * refund is the undoing of one.
+ *
+ * Deliberately *not* `instanceof WC_Order`. The abstract base is the
+ * type every order class actually extends, including HPOS's overrides
+ * and whatever custom order type a store registers — testing against
+ * `WC_Order` has already been tried elsewhere in this integration and
+ * silently emptied lists on stores that use them. So this excludes the
+ * one known-hostile subclass and then asks the object directly for the
+ * accessors these lists call, which keeps an exotic order type that
+ * extends the base without them out of a fatal too.
+ *
+ * @param mixed $order Whatever `wc_get_order()` returned.
+ * @return bool
+ */
+function openstation_my_wordpress_woo_is_purchase( $order ) {
+	if ( ! $order instanceof WC_Abstract_Order ) {
+		return false;
+	}
+	if ( $order instanceof WC_Order_Refund ) {
+		return false;
+	}
+	return method_exists( $order, 'get_order_number' );
 }
 
 /**
@@ -730,11 +787,16 @@ function openstation_my_wordpress_woo_product_related( $product_id ) {
 	// not read orders must not read them sideways.
 	if ( openstation_my_wordpress_woo_can_read_orders() ) {
 		$customers = array();
-		foreach ( openstation_my_wordpress_woo_orders_with_product( $product_id, 10 ) as $order_id ) {
+		$listed    = 0;
+		foreach ( openstation_my_wordpress_woo_orders_with_product( $product_id, OPENSTATION_WOO_RELATION_ORDER_CANDIDATES ) as $order_id ) {
+			if ( $listed >= OPENSTATION_WOO_RELATION_ORDER_CAP ) {
+				break;
+			}
 			$order = wc_get_order( $order_id );
-			if ( ! $order instanceof WC_Abstract_Order ) {
+			if ( ! openstation_my_wordpress_woo_is_purchase( $order ) ) {
 				continue;
 			}
+			++$listed;
 
 			$name  = method_exists( $order, 'get_formatted_billing_full_name' )
 				? trim( $order->get_formatted_billing_full_name() )
@@ -926,11 +988,16 @@ function openstation_my_wordpress_woo_coupon_related( $coupon_id ) {
 	// a question you currently answer by exporting orders.
 	if ( openstation_my_wordpress_woo_can_read_orders() ) {
 		$customers = array();
-		foreach ( openstation_my_wordpress_woo_orders_with_coupon( $coupon->get_code(), 10 ) as $order_id ) {
+		$listed    = 0;
+		foreach ( openstation_my_wordpress_woo_orders_with_coupon( $coupon->get_code(), OPENSTATION_WOO_RELATION_ORDER_CANDIDATES ) as $order_id ) {
+			if ( $listed >= OPENSTATION_WOO_RELATION_ORDER_CAP ) {
+				break;
+			}
 			$order = wc_get_order( $order_id );
-			if ( ! $order instanceof WC_Abstract_Order ) {
+			if ( ! openstation_my_wordpress_woo_is_purchase( $order ) ) {
 				continue;
 			}
+			++$listed;
 
 			$name  = method_exists( $order, 'get_formatted_billing_full_name' )
 				? trim( $order->get_formatted_billing_full_name() )

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -1142,6 +1142,10 @@ function renderEntityList(
 	const tiles = document.createElement( 'div' );
 	tiles.className =
 		'os-my-wordpress__tiles os-my-wordpress__canvas';
+	// Which section these tiles belong to. An entry id is only unique
+	// within its section — a post and a user can both be 12 — so the
+	// live-trash pruner needs this to tell one canvas from another.
+	tiles.dataset.entityId = entity.id;
 	tiles.setAttribute( 'role', 'list' );
 	left.appendChild( tiles );
 
@@ -4908,6 +4912,9 @@ function renderUserEntityList(
 	const tiles = document.createElement( 'div' );
 	tiles.className =
 		'os-my-wordpress__tiles os-my-wordpress__canvas os-my-wordpress__canvas--users';
+	// See the entity list's canvas: user ids and post ids share one
+	// numeric namespace, and the trash pruner walks every live body.
+	tiles.dataset.entityId = entity.id;
 	tiles.setAttribute( 'role', 'list' );
 	left.appendChild( tiles );
 
@@ -5277,7 +5284,14 @@ function buildUserTile(
 		// replaces that icon as a richer fallback.
 		icon: avatarUrl ? undefined : 'dashicons-admin-users',
 		role: 'entry',
-		dataset: { userId: item.id, role: 'user' },
+		// `entryId` is what the section's selection controller keys on
+		// (`keyOf` reads `data-entry-id`) and what the trash / bulk-remove
+		// paths query tiles by. Without it a user tile is invisible to
+		// every one of them: the click lands, the controller finds no key
+		// for the element, and nothing is selected — which on the
+		// WooCommerce Customers section reads as a dead grid, since the
+		// preview pane only paints from a selection.
+		dataset: { entryId: item.id, userId: item.id, role: 'user' },
 		extraClasses: [
 			'os-my-wordpress__tile',
 			'os-my-wordpress__tile--user',
@@ -7899,7 +7913,19 @@ if ( desktopGlobal ) {
 				const tile = state.body.querySelector< HTMLElement >(
 					`[data-entry-id="${ detail.id }"]`,
 				);
-				tile?.remove();
+				if ( ! tile ) {
+					continue;
+				}
+				// Entry ids are unique per section, not per site: post 12
+				// and user 12 both exist, and this listener sees every
+				// live body. Without the section check, trashing a post in
+				// one window would silently delete a stranger's tile from
+				// the Users grid in another.
+				const canvas = tile.closest< HTMLElement >( '[data-entity-id]' );
+				if ( canvas && canvas.dataset.entityId !== detail.entityId ) {
+					continue;
+				}
+				tile.remove();
 			}
 		},
 	);

--- a/tests/phpunit/tests/myWordpressWoocommerce.php
+++ b/tests/phpunit/tests/myWordpressWoocommerce.php
@@ -240,4 +240,84 @@ class Tests_OpenStation_MyWordpressWoocommerce extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '#a2aab2', $svg );
 		$this->assertStringContainsString( '<svg', $svg );
 	}
+
+	/**
+	 * A refund is not a purchase, and asking it for an order number is
+	 * fatal.
+	 *
+	 * The "who bought it" / "used on" lists read their ids out of
+	 * `woocommerce_order_items`, where a refund keeps its own line
+	 * items under its own id — so a refunded product's id list names
+	 * refunds. `WC_Order_Refund` extends `WC_Abstract_Order` and sails
+	 * through the usual guard; the `get_order_number()` call two lines
+	 * later then takes down the whole Product edit screen, because that
+	 * method belongs to `WC_Order`.
+	 *
+	 * @covers ::openstation_my_wordpress_woo_is_purchase
+	 */
+	public function test_refunds_are_not_purchases() {
+		$this->assertTrue(
+			openstation_my_wordpress_woo_is_purchase(
+				new OpenStation_Test_Woo_Order()
+			),
+			'an order is a purchase'
+		);
+
+		$this->assertFalse(
+			openstation_my_wordpress_woo_is_purchase(
+				new OpenStation_Test_Woo_Refund()
+			),
+			'a refund must never reach get_order_number()'
+		);
+
+		// An order type that extends the abstract base without the
+		// accessors these lists call would fatal the same way.
+		$this->assertFalse(
+			openstation_my_wordpress_woo_is_purchase(
+				new OpenStation_Test_Woo_Bare_Order()
+			)
+		);
+
+		$this->assertFalse( openstation_my_wordpress_woo_is_purchase( null ) );
+		$this->assertFalse(
+			openstation_my_wordpress_woo_is_purchase( new stdClass() )
+		);
+	}
 }
+
+/*
+ * WooCommerce isn't loaded in the test suite, so the class hierarchy
+ * the guard reasons about is stubbed here — the shapes only, since the
+ * guard asks nothing of them beyond their type and their methods. The
+ * `class_exists` checks keep this inert on a site that does have
+ * WooCommerce.
+ */
+
+if ( ! class_exists( 'WC_Abstract_Order' ) ) {
+	/** Stand-in for WooCommerce's abstract order. */
+	abstract class WC_Abstract_Order {}
+}
+
+if ( ! class_exists( 'WC_Order' ) ) {
+	/** Stand-in for a shop order. */
+	class WC_Order extends WC_Abstract_Order {
+		/** @return string */
+		public function get_order_number() {
+			return '1234';
+		}
+	}
+}
+
+if ( ! class_exists( 'WC_Order_Refund' ) ) {
+	/** Stand-in for a refund — deliberately without an order number. */
+	class WC_Order_Refund extends WC_Abstract_Order {}
+}
+
+/** A shop order, as the store's data store would hand one back. */
+class OpenStation_Test_Woo_Order extends WC_Order {}
+
+/** A refund, which the order-items tables can name as an "order". */
+class OpenStation_Test_Woo_Refund extends WC_Order_Refund {}
+
+/** An order type that extends the base and declares none of it. */
+class OpenStation_Test_Woo_Bare_Order extends WC_Abstract_Order {}

--- a/tests/vitest/my-wordpress-selection.test.ts
+++ b/tests/vitest/my-wordpress-selection.test.ts
@@ -43,6 +43,25 @@ const POSTS = [
 	},
 ];
 
+const USERS = [
+	{
+		id: 21,
+		name: 'Ada Lovelace',
+		slug: 'ada',
+		description: '',
+		link: 'http://example.test/author/ada',
+		avatar_urls: { '96': 'http://example.test/ada.png' },
+	},
+	{
+		id: 22,
+		name: 'Grace Hopper',
+		slug: 'grace',
+		description: '',
+		link: 'http://example.test/author/grace',
+		avatar_urls: { '96': 'http://example.test/grace.png' },
+	},
+];
+
 function installTemplateMarkup( host: HTMLElement ): void {
 	host.innerHTML = `
 		<div class="desktop-mode-my-wordpress" data-os-my-wordpress-root>
@@ -127,9 +146,43 @@ async function openPosts( body: HTMLElement ): Promise< void > {
 	} );
 }
 
+/**
+ * Wait for the preview pane to finish painting a person.
+ *
+ * Also what keeps the harness honest: the dossier render is async and
+ * ends by firing hooks, so a test that returns while one is in flight
+ * has it land after `afterEach` has torn `window.wp` down.
+ */
+async function awaitUserPreview(
+	body: HTMLElement,
+	name: string,
+): Promise< void > {
+	await vi.waitFor( () => {
+		const preview = body.querySelector( '.os-my-wordpress__preview' );
+		if ( ! preview?.textContent?.includes( name ) ) {
+			throw new Error( 'preview not painted yet' );
+		}
+	} );
+}
+
+/** Open the People section and wait for the first page to paint. */
+async function openPeople( body: HTMLElement ): Promise< void > {
+	dblclickTile( body, 'People' );
+	await vi.waitFor( () => {
+		if ( ! body.querySelector( '[data-entry-id]' ) ) {
+			throw new Error( 'people not painted yet' );
+		}
+	} );
+}
+
 describe( 'my-wordpress — multi-selection', () => {
 	beforeEach( async () => {
 		installHooksStub();
+		// The bundle registers its document-level listeners (the
+		// live-trash pruner among them) only when the shell namespace
+		// exists, so the harness has to supply one.
+		( window as unknown as { wp: { os: Record< string, unknown > } } ).wp.os =
+			{};
 		( window as unknown as NativeWindowsGlobal ).openStationWindowConfig = {
 			[ WINDOW_ID ]: {
 				restRoot: 'http://example.test/wp-json/',
@@ -146,6 +199,16 @@ describe( 'my-wordpress — multi-selection', () => {
 						kind: 'post',
 						post_type: 'post',
 					},
+					// A `user`-kind section — the shape the built-in Users
+					// list and WooCommerce's Customers list both render
+					// through.
+					{
+						id: 'people',
+						label: 'People',
+						icon: 'dashicons-admin-users',
+						restPath: 'wp/v2/users',
+						kind: 'user',
+					},
 				],
 				groups: [],
 				perPage: 24,
@@ -157,14 +220,32 @@ describe( 'my-wordpress — multi-selection', () => {
 			'fetch',
 			vi.fn( ( url: unknown ) => {
 				const href = String( url );
-				const body = href.includes( 'wp/v2/posts' )
-					? JSON.stringify( POSTS )
-					: '[]';
+				let body = '[]';
+				let total = 0;
+				if ( href.includes( 'desktop-mode/v1/user-stats/' ) ) {
+					// No dossier stats in the harness. The preview pane
+					// has a documented fallback for exactly this (a site
+					// where the route is unavailable), and it is the path
+					// under test here: it still has to name the person.
+					return Promise.resolve(
+						new Response( '{}', {
+							status: 404,
+							headers: { 'Content-Type': 'application/json' },
+						} ),
+					);
+				}
+				if ( href.includes( 'wp/v2/posts' ) ) {
+					body = JSON.stringify( POSTS );
+					total = POSTS.length;
+				} else if ( href.includes( 'wp/v2/users' ) ) {
+					body = JSON.stringify( USERS );
+					total = USERS.length;
+				}
 				return Promise.resolve(
 					new Response( body, {
 						status: 200,
 						headers: {
-							'X-WP-Total': String( POSTS.length ),
+							'X-WP-Total': String( total ),
 							'X-WP-TotalPages': '1',
 							'Content-Type': 'application/json',
 						},
@@ -285,5 +366,70 @@ describe( 'my-wordpress — multi-selection', () => {
 		const list = body.querySelector( '.os-my-wordpress__list' );
 		click( list! );
 		expect( entryTile( body, 11 ).hasAttribute( 'selected' ) ).toBe( false );
+	} );
+
+	// A user tile is keyed the same way an entry tile is — the section's
+	// selection controller reads `data-entry-id` and nothing else. When
+	// the tile didn't carry one, every click on a person was swallowed:
+	// no highlight, no status count, and a preview pane that stayed on
+	// its placeholder, which is how the WooCommerce Customers grid read
+	// as broken.
+	test( 'a user tile carries the key its canvas selects by', async () => {
+		const body = mountWindow();
+		await openPeople( body );
+		const tile = [
+			...body.querySelectorAll< HTMLElement >( 'os-tile[type="user"]' ),
+		].find( ( t ) => t.dataset.userId === '21' );
+		expect( tile?.dataset.entryId ).toBe( '21' );
+	} );
+
+	test( 'single-clicking a user selects it', async () => {
+		const body = mountWindow();
+		await openPeople( body );
+		click( entryTile( body, 21 ) );
+		expect( entryTile( body, 21 ).hasAttribute( 'selected' ) ).toBe( true );
+		expect( entryTile( body, 22 ).hasAttribute( 'selected' ) ).toBe( false );
+		expect( statusLabels( body ) ).toContain( '1 selected' );
+		await awaitUserPreview( body, 'Ada Lovelace' );
+	} );
+
+	test( 'selecting a user paints the preview pane', async () => {
+		const body = mountWindow();
+		await openPeople( body );
+		click( entryTile( body, 21 ) );
+		await awaitUserPreview( body, 'Ada Lovelace' );
+	} );
+
+	test( 'ctrl-click selects several users', async () => {
+		const body = mountWindow();
+		await openPeople( body );
+		click( entryTile( body, 21 ) );
+		click( entryTile( body, 22 ), { metaKey: true } );
+		expect( entryTile( body, 21 ).hasAttribute( 'selected' ) ).toBe( true );
+		expect( entryTile( body, 22 ).hasAttribute( 'selected' ) ).toBe( true );
+		expect( statusLabels( body ) ).toContain( '2 selected' );
+	} );
+
+	// Entry ids are unique per section, not per site. The trash
+	// broadcast reaches every live list body, so a post id must not
+	// take out the same-numbered user tile.
+	test( 'a trash broadcast prunes only its own section', async () => {
+		const body = mountWindow();
+		await openPeople( body );
+		document.dispatchEvent(
+			new CustomEvent( 'os-my-wordpress-entity-trashed', {
+				detail: { entityId: 'posts', id: 21 },
+			} ),
+		);
+		expect( entryTile( body, 21 ) ).toBeTruthy();
+
+		document.dispatchEvent(
+			new CustomEvent( 'os-my-wordpress-entity-trashed', {
+				detail: { entityId: 'people', id: 21 },
+			} ),
+		);
+		expect(
+			body.querySelector( '[data-entry-id="21"]' ),
+		).toBeNull();
 	} );
 } );


### PR DESCRIPTION
Two unrelated bugs, both in My WordPress.

## The Product edit screen fatals on any refunded product

Fixes #598.

Refunds keep their own line items in the same `woocommerce_order_items` tables, under the refund's id, so the lookup that asks those tables *"which orders contain product X"* answers with refund ids too. `WC_Order_Refund` extends `WC_Abstract_Order` and sails through the guard; the `get_order_number()` call two lines later is a `WC_Order` method the abstract base does not declare.

It fires during `admin_footer`, so the screen half-renders: no **Add New**, the description editor stuck on raw HTML with no Visual/Code tabs, Save dead. Same shape in `openstation_my_wordpress_woo_coupon_related()`.

**Not** fixed by tightening the guard to `instanceof WC_Order`, which is what the report suggested — that exact test is already documented one file over (`woocommerce.php:1260`) as having silently emptied the Orders folder on stores with custom order types:

> `WC_Abstract_Order`, not `WC_Order`: that's the type every order class actually extends […] Testing against `WC_Order` silently dropped every row on some stores while `total` still reported hundreds — an empty folder with a confident count on its tile.

So `openstation_my_wordpress_woo_is_purchase()` excludes the one known-hostile subclass and then asks the object whether it declares the accessor these lists call. An exotic order type extending the base without one is dropped rather than fatal, and every normal order type still lists.

Dropping refunds is also the truer answer: *"who bought it"* and *"where was this coupon used"* are questions about purchases, and a refund is the undoing of one.

### One thing beyond the report

The id list is `ORDER BY order_id DESC`, and a refund always outranks the order it refunds, so **refunds sort first**. A `LIMIT 10` on a much-refunded product could come back as ten refunds and — once filtered — an empty "who bought it" group, on exactly the product whose history a merchant most wants to read. The loops now read 40 candidates and stop at 10 kept. Group budgets are unchanged.

## Clicking a person in the WP Explorer does nothing

Reported separately: in **WOO → Customers**, a single click on a customer leaves the right pane empty and doesn't even highlight the tile.

The users canvas keys its selection on `data-entry-id`, and `buildUserTile()` only ever set `data-user-id`. So `keyOf` returned null for every person tile, the controller never recognised it as an item, and the click fell through to the background handler *that clears the selection*. No highlight, no status count, and a preview pane that never paints, because it only paints from a selection.

Nothing Woo-specific about it — Customers renders through the built-in `user` kind, so **the built-in Users list has the same bug**. Regression from #501, which moved these canvases onto the shared selection framework.

The trash and bulk-remove paths query the same attribute, so they were quietly no-oping on users too.

Giving user tiles an entry id does make post 12 and user 12 collide on the `os-my-wordpress-entity-trashed` broadcast, which walks every live window body — trashing a post in one window would have removed a stranger's tile from a Users grid in another. The canvases carry `data-entity-id` now and the pruner checks the section before removing anything.

## Tests

- `tests/vitest/my-wordpress-selection.test.ts` — a `user`-kind section in the harness: the tile carries its key, single click selects and reports "1 selected", the preview pane paints the person, ctrl-click holds two, and a trash broadcast prunes only its own section. All five red before the fix.
- `tests/phpunit/tests/myWordpressWoocommerce.php` — the purchase guard against a stubbed `WC_Abstract_Order` hierarchy (the suite has no WooCommerce): an order passes, a refund doesn't, a bare subclass doesn't, and neither do `null` or a stray object.

Full suites green: `test:js` (4217), `test:php` (2165), `lint`, `lint:php`, `typecheck`, `build`.

## Manual QA

1. **WP Explorer → WOO → Customers** — single click a customer: tile highlights, status bar says "1 selected", right pane shows the dossier plus the customer panel. Ctrl/Cmd-click a second → "2 selected".
2. **WP Explorer → Users** — same behaviour.
3. **Product edit for a product with a refund** — screen renders fully, Add New present, editor has its Visual/Code tabs, Save works, and the orders group lists orders only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-601-0ac556a03bd363c5fdfaa086e05f759bce715e07.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->