### PR TITLE
fix: refresh folder share action on settings save

### DIFF
--- a/src/desktop-files/share-menu-items.ts
+++ b/src/desktop-files/share-menu-items.ts
@@ -209,6 +209,9 @@ export function installShareMenuItems(): void {
 			return folderOwnerId( folderId ) === viewerId();
 		},
 		onClick: ( w: DesktopWindow ): void => {
+			if ( ! sharingEnabled() ) {
+				return;
+			}
 			const base = ( w.config as { baseId?: string } ).baseId ?? w.id;
 			const folderId = folderIdFromBaseId( base );
 			if ( folderId === null ) {

--- a/src/title-bar-buttons/registry.ts
+++ b/src/title-bar-buttons/registry.ts
@@ -274,3 +274,13 @@ function notify(): void {
 		}
 	}
 }
+
+if ( typeof document !== 'undefined' ) {
+	document.addEventListener( 'os-settings-save-lifecycle', ( e: Event ) => {
+		const detail = ( e as CustomEvent ).detail;
+		if ( detail && detail.phase === 'saved' ) {
+			notify();
+		}
+	} );
+}
+


### PR DESCRIPTION
Closes #553 

This PR resolves issue where turning off Folder Sharing in Preferences failed to update folder windows that were already open, leaving the "Share folder" action visible and active.

### Changes Made
1. **Title-Bar Registry Update:** Added a listener to the `os-settings-save-lifecycle` event in `src/title-bar-buttons/registry.ts`. When a settings save successfully completes (`phase === 'saved'`), it triggers `notify()`, forcing all open window chromes to re-evaluate and repaint their custom title-bar buttons in real-time.
2. **Action Click Guard:** Updated the click handler in `src/desktop-files/share-menu-items.ts` to check `sharingEnabled()` and return early if the feature has been turned off, preventing the modal from being opened even if the button is in a stale state.

### How to Verify/Test
1. Go to **Preferences** -> **Features** and toggle **Folder Sharing** to **ON**.
2. Open a folder on your desktop and leave its window open (notice the **Share** button in the title bar).
3. Go back to **Preferences** and toggle **Folder Sharing** to **OFF**.
4. Observe the open folder window: the **Share** button will immediately disappear from the title bar in real-time.

**Before fix** 

https://github.com/user-attachments/assets/1476cf2a-fc81-434d-af1a-7bddd7da7c17


**After fix**

https://github.com/user-attachments/assets/4cda8b9e-ff76-46e1-a7e7-1378734f0311

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-604-36e003c58e82b9e8aa381d429a9f70fe554d310d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->