### PR TITLE
My WordPress: let the entity hover card follow the desktop theme

### DIFF
--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -276,7 +276,11 @@
 		--os-media-tile-bg,
 		rgba( 0, 0, 0, 0.05 )
 	);
-	box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, 0.12 );
+	/* The hairline was a flat 12%-alpha black — right on the pre-brand
+	 * white canvas, and nothing at all on a dark one, where a black
+	 * line over a near-black surface leaves the photo edgeless. It
+	 * follows the border token now, so it inverts with the theme. */
+	box-shadow: inset 0 0 0 1px var( --os-ui-border, rgba( 0, 0, 0, 0.12 ) );
 }
 
 /* Banded list views. A section can split its tiles into labelled
@@ -407,7 +411,10 @@
 	pointer-events: none;
 }
 
-/* Tooltip lock banner — shown above the excerpt when present. */
+/* Hover-card lock banner — shown above the excerpt when present. The
+ * wash was a fixed 8%-alpha red, which on a dark card was a smear too
+ * faint to read as a banner at all; it follows the badge-danger token
+ * now, so it lands at the alpha the active theme picked. */
 .os-my-wordpress__tooltip-lock {
 	display: flex;
 	align-items: center;
@@ -415,7 +422,10 @@
 	margin: 0 0 8px;
 	padding: 6px 8px;
 	border-radius: 4px;
-	background: rgba( 179, 45, 46, 0.08 );
+	background: var(
+		--os-my-wordpress-card-lock-bg,
+		rgba( 179, 45, 46, 0.08 )
+	);
 	color: var( --os-danger, var( --os-ui-danger, #b32d2e ) );
 	font-size: 12px;
 	font-weight: 600;
@@ -702,24 +712,47 @@
 	color: var( --os-danger, var( --os-ui-danger, #b32d2e ) );
 }
 
-/* ----- Hover tooltip (floats over body) ----- */
+/* ----- Hover card (floats over body) -----
+ *
+ * The card is summoned from a tile and belongs to the window that
+ * tile is in, so it follows the active desktop theme rather than the
+ * shell's tooltip chip. Every colour chains
+ * `--os-my-wordpress-card-*` first — derived in `variables.css` from
+ * the window family, so a theme that repaints the window repaints the
+ * card with it — then the chip tokens, then the pre-brand literal.
+ *
+ * It is appended to `document.body`, not to the window, because it is
+ * `position: fixed` and a window with `overflow: hidden` would clip
+ * it. Theme tokens still reach it: a desktop theme declares on
+ * `body.os-desktop-theme-<slug>`, an ancestor of both. What does NOT
+ * reach it is anything scoped to `.desktop-mode-my-wordpress`, which
+ * is why the card family is declared at palette level. */
 
 .os-my-wordpress__tooltip {
 	position: fixed;
 	z-index: 100000;
 	max-width: 320px;
 	background: var(
-		--os-tooltip-bg,
-		var( --os-surface, var( --os-ui-surface, #fff ) )
+		--os-my-wordpress-card-bg,
+		var(
+			--os-tooltip-bg,
+			var( --os-surface, var( --os-ui-surface, #fff ) )
+		)
 	);
 	color: var(
-		--os-tooltip-fg,
-		var( --os-fg, #1d2327 )
+		--os-my-wordpress-card-fg,
+		var( --os-tooltip-fg, var( --os-fg, #1d2327 ) )
 	);
-	border: 1px solid var( --os-ui-border, #dcdcde );
+	/* The card lands on the same colour as the window under it — the
+	 * border and the shadow are the only reason it reads as a separate
+	 * object, so neither is decoration. */
+	border: 1px solid var( --os-my-wordpress-card-border, #dcdcde );
 	border-radius: 6px;
 	padding: 12px;
-	box-shadow: 0 6px 24px rgba( 0, 0, 0, 0.18 );
+	box-shadow: var(
+		--os-my-wordpress-card-shadow,
+		0 6px 24px rgba( 0, 0, 0, 0.18 )
+	);
 	font-size: 12px;
 	pointer-events: none;
 }
@@ -730,17 +763,26 @@
 	font-size: 13px;
 }
 
+/* Same neutral well the entry and media tiles give their thumbnails:
+ * a transparent PNG or a still-loading image would otherwise show the
+ * card straight through, and a photo whose edge matches the card
+ * would have no boundary. */
 .os-my-wordpress__tooltip-thumb {
 	display: block;
 	max-width: 100%;
 	height: auto;
 	border-radius: 4px;
 	margin: 6px 0;
+	background: var( --os-my-wordpress-card-thumb-bg, rgba( 0, 0, 0, 0.05 ) );
+	box-shadow: inset 0 0 0 1px var(
+		--os-my-wordpress-card-border,
+		#dcdcde
+	);
 }
 
 .os-my-wordpress__tooltip-excerpt {
 	margin: 0;
-	color: var( --os-ui-fg-muted, #50575e );
+	color: var( --os-my-wordpress-card-fg-muted, #50575e );
 	line-height: 1.4;
 }
 

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -1105,9 +1105,8 @@ body.os-active {
 	/*
 	 * ---- Tooltips ---------------------------------------------
 	 *
-	 * Two tokens own every tooltip in the shell — the dock tile
-	 * tooltip, the content-graph satellite tooltip, and the My
-	 * WordPress entity hover card.
+	 * Two tokens own every tooltip CHIP in the shell — the dock tile
+	 * tooltip and the content-graph satellite tooltip.
 	 *
 	 * They are worth naming rather than leaving derived. Without them
 	 * tooltips borrow their colours from unrelated families —
@@ -1117,8 +1116,14 @@ body.os-active {
 	 * palette `--os-ui-fg-on-accent` is Void, which would have rendered
 	 * near-black text on a near-black chip.
 	 *
-	 * Secondary text inside the richer tooltips — the hover card's
-	 * excerpt — still follows `--os-ui-fg-muted`.
+	 * A chip is deliberately the SAME dark lozenge on every desktop
+	 * theme, which is why these two are flat values and not derived
+	 * from anything. That is right for one line of text pinned to a
+	 * control, and wrong for a rich card: the My WordPress entity
+	 * hover card used to read them and showed up Obsidian over a white
+	 * Legacy window. It has its own derived family now —
+	 * `--os-my-wordpress-card-*`, further down — and it still names
+	 * these two as its last fallback.
 	 */
 	--os-tooltip-bg: #33303a;
 	--os-tooltip-fg: #fffbff;
@@ -1265,6 +1270,51 @@ body.os-active {
 	--os-my-wordpress-bg: #1a1721;
 	--os-my-wordpress-fg: #fffbff;
 	--os-my-wordpress-surface: rgba(255, 251, 255, 0.06);
+	/*
+	 * The entity hover card — the "thumb" that floats over a tile with
+	 * a title, a featured image and an excerpt.
+	 *
+	 * It is NOT a dock chip, and it used to be painted as one.
+	 * `--os-tooltip-bg` is a fixed dark lozenge on every theme by
+	 * design — one line of text, always the same object, no reason to
+	 * follow anything. The card borrowed it, so a light desktop theme
+	 * summoned an Obsidian card over a white window, with a border in
+	 * `--os-ui-border` and an excerpt in `--os-ui-fg-muted` that both
+	 * followed the WINDOW instead. Three families, one surface.
+	 *
+	 * The card is window furniture: it belongs to the surface it was
+	 * summoned from, so it follows the theme that paints that surface.
+	 * Every value below is DERIVED rather than declared flat, which is
+	 * what makes that true — a theme that names only
+	 * `--os-my-wordpress-bg` (Legacy names exactly that, `#fff`) moves
+	 * the card with the window for free, and a theme that wants the
+	 * card alone names a `-card-` token.
+	 *
+	 * A card lands on the same colour as the window under it, so the
+	 * border and the shadow are the whole reason it reads as a
+	 * separate object. Neither is decoration here and neither may
+	 * collapse into the background — which is exactly what the border
+	 * did: `--os-ui-border` is #33303a on this palette, the SAME value
+	 * `--os-tooltip-bg` had, so the card had no edge at all.
+	 *
+	 * The shadow is the one flat value in the family. A drop shadow is
+	 * cast light, dark on a light theme and dark on a dark one, so
+	 * there is no window token for it to follow; it is named so a
+	 * theme can still reach it.
+	 */
+	--os-my-wordpress-card-bg: var(--os-my-wordpress-bg, #1a1721);
+	--os-my-wordpress-card-fg: var(--os-my-wordpress-fg, #fffbff);
+	--os-my-wordpress-card-fg-muted: var(--os-ui-fg-muted, #b3afb5);
+	--os-my-wordpress-card-border: var(--os-ui-border, #33303a);
+	--os-my-wordpress-card-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+	--os-my-wordpress-card-thumb-bg: var(
+		--os-media-tile-bg,
+		rgba(255, 251, 255, 0.05)
+	);
+	--os-my-wordpress-card-lock-bg: var(
+		--os-ui-badge-danger-bg,
+		rgba(255, 90, 90, 0.16)
+	);
 	--os-ai-panel-bg: rgba(26, 23, 33, 0.97);
 	/*
 	 * ---- Window tab strip ---------------------------------------

--- a/docs/desktop-themes.md
+++ b/docs/desktop-themes.md
@@ -162,6 +162,15 @@ than reproduce it:
 If you want one of them, name it in your own theme — Legacy leaving
 it undeclared is a statement about *defaults*, not a restriction.
 
+Leaving `--os-tooltip-bg` out is why every tooltip chip stays the same
+dark lozenge under Legacy, which is intended: a chip is one line of
+text pinned to a control, not a surface that belongs to a window. The
+[WP Explorer hover card](#the-wp-explorer-hover-card) used to be
+painted as one and looked wrong for exactly that reason — Obsidian,
+floating over Legacy's white window. It derives from
+`--os-my-wordpress-bg` now, which Legacy *does* declare, so it comes
+back light without the frozen manifest changing.
+
 ### Two honest caveats
 
 **It is a canonical snapshot, not a byte-for-byte one.** A handful of
@@ -588,13 +597,12 @@ a theme's `--os-window-radius`. Their choice stays theirs.
 
 #### Tooltips
 
-Two shell tokens own every tooltip in the shell — the dock tile
-tooltip, the content-graph satellite tooltip, and WP Explorer
-entity hover card:
+Two shell tokens own every tooltip **chip** — the dock tile tooltip
+and the content-graph satellite tooltip:
 
 | Token | Role |
 |---|---|
-| `--os-tooltip-bg` | The tooltip chip / card surface |
+| `--os-tooltip-bg` | The tooltip chip surface |
 | `--os-tooltip-fg` | Its primary text |
 
 ```json
@@ -618,9 +626,50 @@ accent-filled buttons.
 Both tokens are **undeclared by default**, so a theme that ignores
 them keeps the tooltip look the shell has always had.
 
-Secondary text inside the richer tooltips — the hover card's excerpt —
-still follows `--os-ui-fg-muted`; these two cover the surface and the
-primary text on it.
+A chip is deliberately the same lozenge under every theme — one line of
+text pinned to a control. The WP Explorer hover card is a different
+object and has its own family, below.
+
+#### The WP Explorer hover card
+
+Hovering a tile in WP Explorer summons a card with a title, a featured
+image and an excerpt. It is window furniture rather than a chip: it
+**follows the theme that paints the window it was summoned from**, and
+you get that for free.
+
+| Token | Role | Derived from |
+|---|---|---|
+| `--os-my-wordpress-card-bg` | The card surface | `--os-my-wordpress-bg` |
+| `--os-my-wordpress-card-fg` | Its primary text | `--os-my-wordpress-fg` |
+| `--os-my-wordpress-card-fg-muted` | The excerpt and any secondary line | `--os-ui-fg-muted` |
+| `--os-my-wordpress-card-border` | The edge that lifts it off the window | `--os-ui-border` |
+| `--os-my-wordpress-card-shadow` | Its drop shadow | — (flat) |
+| `--os-my-wordpress-card-thumb-bg` | The well behind the featured image | `--os-media-tile-bg` |
+| `--os-my-wordpress-card-lock-bg` | The wash behind the "someone is editing" banner | `--os-ui-badge-danger-bg` |
+
+**Most themes should set none of these.** Every one except the shadow
+is *derived* from a token you are likely setting anyway — name
+`--os-my-wordpress-bg` and `--os-ui-border` and the card arrives
+matching your window, with a visible edge, without a line of extra
+manifest. Set a `-card-` token only when you want the card to differ
+from the window it belongs to.
+
+```json
+"tokens": {
+  "--os-my-wordpress-card-bg": "#1e1c44",
+  "--os-my-wordpress-card-border": "rgba( 233, 231, 255, 0.16 )"
+}
+```
+
+Two things worth knowing if you do:
+
+- **The card's surface is the window's surface**, so the border and the
+  shadow are the only reason it reads as a separate object. If you
+  repoint `--os-my-wordpress-card-border`, keep it distinct from
+  `--os-my-wordpress-card-bg` or the card loses its edge entirely.
+- **The shadow is flat, not derived.** A drop shadow is cast light —
+  dark under a light theme and dark under a dark one — so there is no
+  window token for it to follow. It is named so you can still reach it.
 
 #### Dock glyphs
 

--- a/tests/vitest/tooltip-tokens.test.ts
+++ b/tests/vitest/tooltip-tokens.test.ts
@@ -19,6 +19,14 @@
  *      feature stylesheet would pin the tooltip for that one surface
  *      and put it out of reach of the palette and of every theme.
  *
+ * A chip is deliberately the same dark lozenge under every desktop
+ * theme — one line of text pinned to a control, always the same
+ * object. That is wrong for a rich card, and the My WordPress entity
+ * hover card used to be painted as one: Obsidian, over a white Legacy
+ * window, with a border and an excerpt that followed the window
+ * instead. It has its own derived family now and is covered by the
+ * second describe below.
+ *
  * These are asserted against the stylesheet text because the rules
  * live in plain CSS with no module to import — jsdom does not resolve
  * a nested `var()` chain against undeclared properties, so a computed
@@ -73,13 +81,6 @@ const TOOLTIPS: Array< {
 		bgFallback: 'var( --os-ui-surface-elevated, #1a1f2b )',
 		fgFallback: 'var( --os-ui-fg-on-accent, #fff )',
 	},
-	{
-		label: 'My WordPress entity hover card',
-		file: 'my-wordpress.css',
-		selector: '.os-my-wordpress__tooltip',
-		bgFallback: 'var( --os-surface, var( --os-ui-surface, #fff ) )',
-		fgFallback: 'var( --os-fg, #1d2327 )',
-	},
 ];
 
 describe( 'tooltip tokens', () => {
@@ -101,7 +102,13 @@ describe( 'tooltip tokens', () => {
 		// A declaration is `--name:`; a read is `var( --name,`. A
 		// declaration in a consuming sheet would pin that one tooltip
 		// and defeat both the palette and every desktop theme.
-		for ( const file of TOOLTIPS.map( ( t ) => t.file ) ) {
+		// `my-wordpress.css` no longer paints a chip, but it still
+		// names both tokens as its last fallback, so it stays covered.
+		const consumers = [
+			...TOOLTIPS.map( ( t ) => t.file ),
+			'my-wordpress.css',
+		];
+		for ( const file of consumers ) {
 			const css = readCss( file );
 
 			expect(
@@ -120,5 +127,96 @@ describe( 'tooltip tokens', () => {
 
 		expect( css ).toContain( '--os-tooltip-bg' );
 		expect( css ).toContain( '--os-tooltip-fg' );
+	} );
+} );
+
+/**
+ * The My WordPress entity hover card.
+ *
+ * A card is not a chip. It carries a title, a featured image and an
+ * excerpt, it is summoned from a tile inside a window, and it reads as
+ * that window's furniture — so it follows the desktop theme the window
+ * follows. Painting it with `--os-tooltip-bg` made it the one surface
+ * in the shell that ignored the active theme: Obsidian, floating over
+ * a white window, under Legacy.
+ *
+ * What makes "follows the theme" true is that every value in the family
+ * is DERIVED. A theme only has to name the tokens it already knows —
+ * Legacy names `--os-my-wordpress-bg` (`#fff`) and `--os-ui-border`
+ * (`#dcdcde`) — and the card moves with the window for free. Declare
+ * any of these flat and the card is stranded on the palette's value
+ * again, which is the exact bug this file exists to prevent, one
+ * family over.
+ *
+ * The shadow is the deliberate exception: a drop shadow is cast light,
+ * dark under a light theme and dark under a dark one, so there is no
+ * window token for it to follow.
+ */
+describe( 'My WordPress hover card tokens', () => {
+	/** Card token → the window/palette token it must resolve through. */
+	const DERIVED: Array< [ string, string ] > = [
+		[ '--os-my-wordpress-card-bg', '--os-my-wordpress-bg' ],
+		[ '--os-my-wordpress-card-fg', '--os-my-wordpress-fg' ],
+		[ '--os-my-wordpress-card-fg-muted', '--os-ui-fg-muted' ],
+		[ '--os-my-wordpress-card-border', '--os-ui-border' ],
+		[ '--os-my-wordpress-card-thumb-bg', '--os-media-tile-bg' ],
+		[ '--os-my-wordpress-card-lock-bg', '--os-ui-badge-danger-bg' ],
+	];
+
+	test.each( DERIVED )(
+		'%s is derived from %s, so a theme moves it',
+		( token, source ) => {
+			const vars = flat( readCss( 'variables.css' ) );
+
+			expect( vars ).toMatch(
+				new RegExp( `${ token }:\\s*var\\( ?${ source }[,)]` )
+			);
+		}
+	);
+
+	test( 'the card does not read the chip tokens first', () => {
+		const body = flat(
+			ruleBody( readCss( 'my-wordpress.css' ), '.os-my-wordpress__tooltip' )
+		);
+
+		expect( body ).toContain( 'background: var( --os-my-wordpress-card-bg,' );
+		expect( body ).toContain( 'color: var( --os-my-wordpress-card-fg,' );
+		// The chip tokens survive as the fallback, so a theme that only
+		// knows the old names still lands somewhere sensible.
+		expect( body ).toContain( '--os-tooltip-bg' );
+		expect( body ).toContain( '--os-tooltip-fg' );
+	} );
+
+	test( 'the border and the shadow are what lift the card off the window', () => {
+		// The card's background IS the window's background. Lose either
+		// of these and it stops reading as a separate object — which is
+		// what happened when the border resolved to `--os-ui-border`
+		// (#33303a) against a `--os-tooltip-bg` (#33303a) card.
+		const body = flat(
+			ruleBody( readCss( 'my-wordpress.css' ), '.os-my-wordpress__tooltip' )
+		);
+
+		expect( body ).toContain( 'var( --os-my-wordpress-card-border,' );
+		expect( body ).toContain( 'var( --os-my-wordpress-card-shadow,' );
+
+		const vars = flat( readCss( 'variables.css' ) );
+		const bg = vars.match( /--os-my-wordpress-card-bg:\s*var\( ?([^,)]+)/ );
+		const border = vars.match(
+			/--os-my-wordpress-card-border:\s*var\( ?([^,)]+)/
+		);
+		expect( bg?.[ 1 ] ).not.toBe( border?.[ 1 ] );
+	} );
+
+	test( 'no feature stylesheet declares a card token', () => {
+		// Same rule as the chip: one declaration, in the palette. A
+		// declaration in `my-wordpress.css` would sit on an ancestor of
+		// nothing useful anyway — the card is appended to
+		// `document.body`, outside `.desktop-mode-my-wordpress`.
+		for ( const file of [ 'my-wordpress.css', 'desktop-files.css' ] ) {
+			expect(
+				/--os-my-wordpress-card-[a-z-]+\s*:/.test( readCss( file ) ),
+				`${ file } declares a card token`
+			).toBe( false );
+		}
 	} );
 } );


### PR DESCRIPTION
Hovering a tile in WP Explorer summons a card with a title, a featured image and an excerpt. It was painted as a **tooltip chip**, and a chip is deliberately the same dark lozenge under every desktop theme — right for one line of text pinned to a control, wrong for a surface that belongs to a window. Under Legacy the card came up Obsidian, floating over a white window.

## What was actually wrong

It was three token families on one surface, not one:

| Part | Token | Follows the window? |
|---|---|---|
| Surface + primary text | `--os-tooltip-bg` / `-fg` | no — fixed dark on every theme |
| Border | `--os-ui-border` | yes |
| Excerpt | `--os-ui-fg-muted` | yes |

So the card could never agree with itself. The border was worse than inconsistent: `--os-ui-border` is `#33303a` on this palette — the **same value** `--os-tooltip-bg` had — so the card had no edge at all, only a shadow.

## The fix

`--os-my-wordpress-card-*`, **derived** in `variables.css` from the window family rather than declared flat. The derivation is what makes "follows the theme" true without asking theme authors for anything:

| Token | Derived from |
|---|---|
| `--os-my-wordpress-card-bg` | `--os-my-wordpress-bg` |
| `--os-my-wordpress-card-fg` | `--os-my-wordpress-fg` |
| `--os-my-wordpress-card-fg-muted` | `--os-ui-fg-muted` |
| `--os-my-wordpress-card-border` | `--os-ui-border` |
| `--os-my-wordpress-card-thumb-bg` | `--os-media-tile-bg` |
| `--os-my-wordpress-card-lock-bg` | `--os-ui-badge-danger-bg` |
| `--os-my-wordpress-card-shadow` | — (flat; a drop shadow is cast light, dark under either theme) |

Legacy already names `--os-my-wordpress-bg` (`#fff`) and `--os-ui-border` (`#dcdcde`), so the card comes back light, with a visible edge, and **the frozen manifest does not change**. A theme that wants the card to differ from its window names a `-card-` token; most themes should set none of these.

The card's surface is now the window's surface, so the border and the shadow are the only reason it reads as a separate object — neither is decoration, and the test pins `bg` staying distinct from `border`.

## Also tokenized while in there

All were colour literals declared next to the thing they paint, out of reach of the palette *and* of every desktop theme:

- the card's drop shadow — a flat `rgba( 0, 0, 0, 0.18 )`
- the lock banner's wash — a flat 8%-alpha red, a smear too faint to read as a banner on a dark card
- the featured-image thumbnails' hairline — `inset 0 0 0 1px rgba( 0, 0, 0, 0.12 )`: right on the pre-brand white canvas, nothing at all on a dark one, where it left photos edgeless
- the hover card's thumbnail gains the same neutral well the entry and media tiles already give theirs, so a transparent PNG or a still-loading image stops showing the card straight through

## Tests

`tests/vitest/tooltip-tokens.test.ts` drops the card from the chip list and gains a describe of its own: each derivation, the chip tokens surviving as the fallback (so a theme that only knows the old names still lands somewhere sensible), `bg` distinct from `border`, and no feature stylesheet declaring a card token.

`npm run build`, `lint`, `typecheck` clean; `test:js` 4319 passing. No PHP touched.

## To verify

On Legacy, open WP Explorer → Posts and hover a post with a featured image. The card should be **light, matching the window**, with a visible hairline border and a readable excerpt. Switch to the default station look and it should be Obsidian, still with an edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-610-08de7a235d2118877c82649cff1815d5977f1b14.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->