### PR TITLE
Windows: guard focus(), unstick the opening class, add child windows

### DIFF
--- a/docs/api-index.md
+++ b/docs/api-index.md
@@ -225,6 +225,7 @@ Every event bubbles from `document`. See [`javascript-reference.md`](./javascrip
 | `os-window-content-loaded` | Stable |
 | `os-window-focused` | Stable |
 | `os-window-blurred` | Stable |
+| `os-window-child-blocked` | Stable |
 | `os-window-closing` | Stable |
 | `os-window-closed` | Stable |
 | `os-window-changed` | Experimental |

--- a/docs/event-driven-framework.md
+++ b/docs/event-driven-framework.md
@@ -103,12 +103,14 @@ stateDiagram-v2
 | `os-window-reopened`    | `{ windowId, baseId, wasMinimized, navigated }` — `navigated`: the request carried a URL the window wasn't showing, so the existing iframe navigated to it in place |
 | `os-window-focused`     | `{ windowId }` |
 | `os-window-blurred`     | `{ windowId, focusedTo }` |
+| `os-window-child-blocked` | `{ windowId, childWindowId }` — a focus request for `windowId` went to its child window instead; the owner cannot come to the front while the child is open |
 | `os-window-closing`     | `{ windowId, element }` |
 | `os-window-closed`      | `{ windowId }` |
 | `os-window-changed`     | `{ windowId?: string, reason: 'moved' \| 'resized' \| 'state' \| 'cascade' \| 'tile', state?: WindowState }` — batch-arrange dispatches (`'cascade'` / `'tile'`) omit `windowId`/`state` |
 
 Same payloads on `wp.hooks` actions:
-`HOOKS.WINDOW_OPENED`, `…_FOCUSED`, `…_BLURRED`, `…_CLOSED`,
+`HOOKS.WINDOW_OPENED`, `…_FOCUSED`, `…_BLURRED`, `…_CHILD_BLOCKED`,
+`…_CLOSED`,
 `…_MINIMIZED`, `…_RESTORED`, `…_MAXIMIZED`, `…_UNMAXIMIZED`,
 `…_FULLSCREEN_ENTERED/EXITED`, `…_REOPENED`, plus geometry events
 (`…_RESIZED`, `…_BODY_RESIZED`, `…_BOUNDS_CHANGED`,

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
 - [Accept drops on your desktop icon](./tile-drop-handler.md)
 - [Add an action that works on a whole selection](./multi-selection-action.md)
 - [Window lifecycle hooks (one subscriber per state)](./window-lifecycle.md)
+- [Open a child window its owner can't cover](./child-windows.md)
 - [Custom arrange-menu action](./arrange-action.md)
 - [Style a specific admin page inside the iframe](./chromeless-style-override.md)
 - [Window themes — per-window CSS variables](./window-theme.md)

--- a/docs/examples/child-windows.md
+++ b/docs/examples/child-windows.md
@@ -26,11 +26,21 @@ const child = await wp.os.windowManager.openChild( 'edit-post-42', {
 } );
 ```
 
-That's it. The child centers over its owner's current position, opens on the owner's virtual desktop, and from then on the post window cannot be raised above it.
+That's it. The child opens on the owner's virtual desktop, and from then on the post window cannot be raised above it.
 
 `openChild()` **throws** if `parentWindowId` names no open window — a child of nothing has nothing to block, so failing loudly beats quietly opening a standalone window.
 
-Everything `open()` accepts works here too (`native`, `render`, `params`, `width`, `initialState`, …). Pass `x` / `y` to place the child yourself instead of centering it.
+Everything `open()` accepts works here too (`native`, `render`, `params`, `initialState`, …).
+
+### Where it opens
+
+In precedence order:
+
+1. **Whatever you pass** — `x`, `y`, `width`, `height`.
+2. **What the user last left it at.** A child is a real window and gets the same geometry memory as any other, keyed by `baseId`. Drag it aside and resize it, and that's where it comes back — not re-centered.
+3. **Centered over the owner**, at 80% of the owner's *current* size, clamped to the desktop area.
+
+The size defaults matter here: on the centering path, `openChild()` pins width and height alongside x and y. It has to — a position computed for an assumed size, applied to a window that opens at a different one, isn't centered. If you want a specific size, pass `width` / `height` and the centering follows them.
 
 ## Registering it from a title-bar button
 
@@ -108,6 +118,7 @@ mgr.blockingChildOf( postWindow );       // the deepest child holding focus, or 
 | **Minimized children stop blocking** | The user put it away on purpose, so the owner is theirs again until they bring it back. Don't build a flow that depends on the child being unreachable — it isn't a security boundary, it's an affordance. |
 | **Unrelated windows** | Ownership constrains owner-vs-child and nothing else. Any other window can still be focused over both. |
 | **Session** | Children are **not** persisted across a reload. A restored child whose owner failed to come back (deactivated plugin, dead URL) would block a window that doesn't exist. If your child holds state worth keeping, save it yourself and reopen from the owner. |
+| **Event cadence** | A cascade emits **one** focus change, not one per window it moves — so `os-window-focused` / `os-window-blurred` subscribers don't see transitions the user never made. `os-window-minimized` / `-restored` still fire per window; they describe the windows, not the focus. |
 
 ## When you want the other thing
 

--- a/docs/examples/child-windows.md
+++ b/docs/examples/child-windows.md
@@ -1,0 +1,116 @@
+# Open a child window its owner can't cover
+
+**Stable.**
+
+A **child window** is a real window — own chrome, drag, resize, minimize, taskbar entry — with one rule layered on top: **its owner can never sit above it.** Clicking the owner shakes the child and leaves focus there.
+
+Use it where you would otherwise reach for a modal dialog but what you actually want is a window, because the user needs to keep reading what's behind it: a full editor for one row of a list, a wizard beside the page it configures, a diff over the revision it belongs to.
+
+The owner stays completely usable throughout — scrollable, draggable, resizable, minimizable. Only its z-order is constrained.
+
+## The whole recipe
+
+```js
+// Open an audit panel owned by the post window it belongs to.
+const child = await wp.os.windowManager.openChild( 'edit-post-42', {
+	id: 'my-plugin-seo-audit-42',
+	url: '#seo-audit-42',
+	title: 'SEO audit',
+	icon: 'dashicons-chart-line',
+	width: 480,
+	height: 560,
+	native: true,
+	render: ( body ) => {
+		body.innerHTML = '<h2>Fix these before publishing</h2>';
+	},
+} );
+```
+
+That's it. The child centers over its owner's current position, opens on the owner's virtual desktop, and from then on the post window cannot be raised above it.
+
+`openChild()` **throws** if `parentWindowId` names no open window — a child of nothing has nothing to block, so failing loudly beats quietly opening a standalone window.
+
+Everything `open()` accepts works here too (`native`, `render`, `params`, `width`, `initialState`, …). Pass `x` / `y` to place the child yourself instead of centering it.
+
+## Registering it from a title-bar button
+
+The natural trigger — a button on the owner's own title bar:
+
+```js
+wp.os.registerTitleBarButton( {
+	id: 'my-plugin/seo-audit',
+	label: 'SEO audit',
+	icon: 'dashicons-chart-line',
+	placement: 'right',
+	match: ( win ) => !! win.config.url?.includes( 'post.php' ),
+	onClick: ( win ) => {
+		const id = `my-plugin-seo-audit-${ win.id }`;
+		// Already open? `openChild` reuses by id exactly as `open`
+		// does, and focus lands on the child either way.
+		void wp.os.windowManager.openChild( win.id, {
+			id,
+			url: `#${ id }`,
+			title: 'SEO audit',
+			icon: 'dashicons-chart-line',
+			native: true,
+			render: ( body ) => renderAudit( body, win.id ),
+		} );
+	},
+} );
+```
+
+## Reacting when the user tries to leave
+
+Every blocked focus attempt fires an event. The child already shakes; this is for adding your own nudge on top.
+
+```js
+document.addEventListener( 'os-window-child-blocked', ( e ) => {
+	const { windowId, childWindowId } = e.detail;
+	if ( childWindowId !== 'my-plugin-seo-audit-42' ) {
+		return;
+	}
+	wp.os.showToast( {
+		message: 'Finish the audit — it saves when you close it.',
+	} );
+	console.log( `${ windowId } stayed put` );
+} );
+```
+
+Same payload on the `os.window.child-blocked` action if you prefer the hook bus:
+
+```js
+wp.hooks.addAction(
+	'os.window.child-blocked',
+	'my-plugin/audit-nudge',
+	( { windowId, childWindowId } ) => { /* … */ },
+);
+```
+
+## Inspecting ownership
+
+```js
+const mgr = wp.os.windowManager;
+
+mgr.childrenOf( 'edit-post-42' );        // [ Window ] — direct children, z-order
+mgr.ownerOf( child );                    // the post window
+mgr.blockingChildOf( postWindow );       // the deepest child holding focus, or undefined
+```
+
+`childrenOf()` includes minimized children (you need them to answer "what does closing this take with it"). `blockingChildOf()` does not — see below.
+
+## The behaviors worth knowing before you ship
+
+| | |
+|---|---|
+| **Chains** | A child can own a child. Focus goes to the deepest link; the middle ones are blocked in turn. |
+| **Close** | Closing an owner closes its children. A child with unsaved changes still gets to ask — one that vetoes outlives its owner and becomes an ordinary window, which beats discarding the user's work. |
+| **Minimize** | Minimizing an owner minimizes its children; restoring brings back exactly the ones the cascade put away. A child the user had already minimized themselves stays minimized. |
+| **Minimized children stop blocking** | The user put it away on purpose, so the owner is theirs again until they bring it back. Don't build a flow that depends on the child being unreachable — it isn't a security boundary, it's an affordance. |
+| **Unrelated windows** | Ownership constrains owner-vs-child and nothing else. Any other window can still be focused over both. |
+| **Session** | Children are **not** persisted across a reload. A restored child whose owner failed to come back (deactivated plugin, dead URL) would block a window that doesn't exist. If your child holds state worth keeping, save it yourself and reopen from the owner. |
+
+## When you want the other thing
+
+If what you actually want is a *visual* relationship between peer windows — a post and its comments, tied together with lines drawn on the desktop, either one focusable — that's [content relations](./window-links.md), not ownership. Ownership is specifically about z-order and focus.
+
+And if the surface really is a dialog (short, answer-then-dismiss, nothing to read behind it), use [`<os-confirm-dialog>` / `wp.os.confirm`](../components-reference.md) instead. A window has a title bar, a taskbar entry and a resize grip; a yes/no question doesn't need any of them.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -870,7 +870,15 @@ await wp.os.windowManager.openChild( 'edit-post-42', {
 
 The owner stays **fully usable** — scrollable, readable, draggable, resizable, minimizable. Only its z-order is constrained. This is deliberately not an inert, dimmed parent: the reason to use a window instead of a dialog is usually that you need to keep reading the thing behind it.
 
-`openChild()` centers the child over its owner's **live** rect (not its opening geometry — owners get dragged) and puts it on the owner's virtual desktop. Pass `x`/`y` to place it yourself. Every other `open()` option behaves identically. An owner id that isn't open **throws** rather than quietly opening a standalone window.
+`openChild()` puts the child on the owner's virtual desktop, and places it by this order of precedence:
+
+1. **Anything you pass.** `x` / `y` / `width` / `height` are used as given.
+2. **The child's remembered geometry.** A child is a real window, so it gets the same per-`baseId` geometry memory as any other — resize it or drag it aside and it comes back that way, not re-centered.
+3. **Centered over the owner**, at 80% of the owner's current size. Measured from the owner's **live** rect, not its opening config (owners get dragged), and clamped to the desktop area so a child of an owner hanging off an edge still opens on screen.
+
+Size and position are resolved **together** on that third path. Handing `open()` a position computed for one size while letting it pick a different one produces a child centered for dimensions it doesn't have.
+
+Every other `open()` option behaves identically. An owner id that isn't open **throws** rather than quietly opening a standalone window.
 
 The rules that follow from ownership:
 
@@ -883,6 +891,7 @@ The rules that follow from ownership:
 | **Minimize** | Minimizing an owner minimizes its children; restoring brings back exactly the ones the cascade put away. A child the user had already minimized themselves stays minimized. |
 | **Minimized children** | A minimized child **stops blocking** — the user put it away, so the owner is theirs again until they bring it back. |
 | **Session** | Children are left out of session snapshots. A restored child whose owner failed to come back (deactivated plugin, dead URL) would block a window that does not exist. |
+| **Event cadence** | A cascade is one user action and emits **one** focus change, not one per window moved. Minimizing an owner with three children fires a single `os-window-focused` / `WINDOW_FOCUSED` pair, so an activity feed built on those doesn't see transitions the user never made. `WINDOW_MINIMIZED` / `WINDOW_RESTORED` still fire per window — those describe the windows, not the focus. |
 
 Ownership is about z-order and focus. For a *visual* relationship between peer windows — a post and its comments, drawn with ties on the desktop — you want [content relations](#window-content-relations) instead.
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -224,6 +224,34 @@ Companion `wp.hooks` action: `HOOKS.WINDOW_BLURRED` (`os.window.blurred`).
 
 ---
 
+### `os-window-child-blocked` — Stable
+
+Fires when a focus request for a window that owns an open [child window](#child-windows--stable) was redirected to that child — the user tried to bring an owner to the front and could not.
+
+Observational only: the redirect has already happened, and the child has already been shaken. Subscribe to add your own "answer this first" affordance — a toast, a pulse on the field that still needs filling in.
+
+```javascript
+document.addEventListener( 'os-window-child-blocked', ( e ) => {
+    const { windowId, childWindowId } = e.detail;
+    if ( childWindowId === 'my-plugin-wizard' ) {
+        wp.os.showToast( { message: 'Finish the wizard to get back to the post.' } );
+    }
+} );
+```
+
+**`detail` shape:**
+
+```typescript
+{
+    windowId:      string,   // the owner that stayed put
+    childWindowId: string,   // the child that kept focus
+}
+```
+
+Companion `wp.hooks` action: `HOOKS.WINDOW_CHILD_BLOCKED` (`os.window.child-blocked`).
+
+---
+
 ### `os-window-closing` — Stable
 Fires when the user closes a window, BEFORE the outer element is detached from the DOM. Subscribers needing an element reference (wallpaper overlays anchored to specific windows, snow that has piled on the window top, measurement caches) should listen here rather than to `os-window-closed` — by the time the `closed` handler runs the element may be mid-fade-out.
 
@@ -756,8 +784,14 @@ Exposed instance of the `WindowManager` class.
 // Open / focus
 manager.open( config ): Promise< Window >;
 manager.openNew( config ): Promise< Window >;
-manager.focus( win: Window ): void;
+manager.focus( winOrId: Window | string ): void;                         // id or instance; unknown ids are a no-op
 manager.raise( windowId: string ): void;                                 // restack to just below the top WITHOUT focusing; no focus/blur events
+
+// Child windows (ownership)
+manager.openChild( parentWindowId: string, config ): Promise< Window >;   // a real window its owner can never sit above
+manager.ownerOf( win: Window ): Window | undefined;
+manager.childrenOf( winOrId: Window | string ): Window[];                // direct children, z-order, minimized included
+manager.blockingChildOf( win: Window ): Window | undefined;              // deepest open descendant withholding focus
 
 // Lookup
 manager.getById( id: string ): Window | undefined;
@@ -814,6 +848,45 @@ manager.closeDesktop( id: string ): void;
 ```
 
 > **`open()` requires a config object.** Passing a URL string used to silently produce a window stuck on a loading spinner with no error in the console. The manager throws `TypeError` at the call site if `config` isn't an object, or if `id` / `url` / `title` are missing or wrong-typed. Build the config; don't shorthand it.
+
+**`focus()` takes a window or an id.** `focus( 'jorvy' )` and `focus( someWindow )` are equivalent. An id with no open window is a silent no-op — a window closing between the moment you captured its id and the moment you ask for focus is a routine race, not an error. Anything that is neither a window nor a string is refused with a `console.warn` and changes nothing.
+
+#### Child windows — Stable
+
+A **child window** is a real window — own chrome, drag, resize, minimize, taskbar entry — with one rule layered on top: **its owner can never sit above it.** Clicking the owner hands focus to the child and shakes it rather than raising the owner.
+
+Reach for it where you would otherwise reach for a modal dialog but what you actually want is a window: a full editor for one row of a list, a wizard beside the page it configures, a diff over the revision it belongs to.
+
+```javascript
+await wp.os.windowManager.openChild( 'edit-post-42', {
+    id: 'my-plugin-seo-audit-42',
+    url: '#seo-audit-42',
+    title: 'SEO audit',
+    icon: 'dashicons-chart-line',
+    native: true,
+    render: ( body ) => { /* … */ },
+} );
+```
+
+The owner stays **fully usable** — scrollable, readable, draggable, resizable, minimizable. Only its z-order is constrained. This is deliberately not an inert, dimmed parent: the reason to use a window instead of a dialog is usually that you need to keep reading the thing behind it.
+
+`openChild()` centers the child over its owner's **live** rect (not its opening geometry — owners get dragged) and puts it on the owner's virtual desktop. Pass `x`/`y` to place it yourself. Every other `open()` option behaves identically. An owner id that isn't open **throws** rather than quietly opening a standalone window.
+
+The rules that follow from ownership:
+
+| | |
+|---|---|
+| **Focus** | Any focus request for the owner is redirected to the deepest open descendant. Covers click-to-focus, dock, taskbar, alt-tab and open-reuse — the redirect lives in `focus()`, so no call site can miss it. |
+| **Z-order** | Every open child is kept above its owner on every restack, including `raise()`. Unrelated windows are unaffected and can be focused over both. |
+| **Chains** | A child can own a child. Focus goes to the last link; the middle ones are blocked in turn. |
+| **Close** | Closing an owner closes its children (and their children). A child with unsaved changes still gets to ask — one that vetoes outlives its owner and becomes an ordinary window. |
+| **Minimize** | Minimizing an owner minimizes its children; restoring brings back exactly the ones the cascade put away. A child the user had already minimized themselves stays minimized. |
+| **Minimized children** | A minimized child **stops blocking** — the user put it away, so the owner is theirs again until they bring it back. |
+| **Session** | Children are left out of session snapshots. A restored child whose owner failed to come back (deactivated plugin, dead URL) would block a window that does not exist. |
+
+Ownership is about z-order and focus. For a *visual* relationship between peer windows — a post and its comments, drawn with ties on the desktop — you want [content relations](#window-content-relations) instead.
+
+To react to a blocked focus attempt, subscribe to [`os-window-child-blocked`](#os-window-child-blocked) or the `os.window.child-blocked` action.
 
 **`config.submenu`** — when present, the shell renders the array as an in-window tab strip below the title bar so the user can navigate child pages without leaving the window. Pass `item.submenu` whenever you open a window from a dock context — `openItem` and `openSubmenuPick` (in custom rail renderers) propagate it for you. Skip it for native windows that don't have admin sub-pages. The shell strips WordPress's auto-prepended self-link entry server-side, so `submenu.length > 0` reliably means "has real children" (no defensive filtering needed in your code). The shell prepends a synthetic "back to parent" tab (label = `config.title`, URL = `config.url`) as the first tab so the user can return to the parent listing without closing the window. If a caller-supplied submenu entry already points at `config.url` the synthetic tab is suppressed to avoid two tabs claiming the same URL.
 

--- a/src/desktop-files/conflict-toast.ts
+++ b/src/desktop-files/conflict-toast.ts
@@ -10,17 +10,25 @@
 
 import { showToast } from '../toast';
 import { FilesConflictError } from './rest';
-import type { Window as DesktopWindow } from '../window';
 
-declare global {
-	interface Window {
-		openStation?: {
-			windowManager?: {
-				focus?: ( id: string ) => DesktopWindow | null;
-				open?: ( id: string ) => Promise< DesktopWindow | null >;
-			};
-		};
-	}
+/**
+ * Structural slice of the public window manager, read off `wp.os`.
+ *
+ * `window.openStation` — which an earlier version of this module
+ * declared and reached for — is not a global the shell ever defines;
+ * the public namespace is `wp.os`. The optional chaining meant the
+ * mismatch never threw, it just made "View folder" a button that did
+ * nothing.
+ */
+interface WindowManagerSlice {
+	getById?: ( id: string ) => { id: string } | undefined;
+	focus?: ( winOrId: string ) => void;
+}
+
+function windowManager(): WindowManagerSlice | undefined {
+	return (
+		window.wp as { os?: { windowManager?: WindowManagerSlice } } | undefined
+	)?.os?.windowManager;
 }
 
 export function isConflict( err: unknown ): err is FilesConflictError {
@@ -51,22 +59,22 @@ export function showConflictToast( err: FilesConflictError ): void {
 	const reason = buildReason( err );
 	const targetParentId = err.detail.current.parentId;
 	let action: { label: string; onClick: () => void } | undefined;
-	if ( targetParentId > 0 ) {
+	const winId = `os-folder-${ targetParentId }`;
+	const mgr = windowManager();
+	// Only offer the action when that folder's window is actually
+	// open, so the button always does something. Opening a folder
+	// window from scratch needs the full native render config that
+	// `built-in-openers` owns, and that isn't reachable from a
+	// `parentId` alone — the toast's message already names the
+	// folder for that case.
+	if (
+		targetParentId > 0 &&
+		typeof mgr?.focus === 'function' &&
+		mgr.getById?.( winId )
+	) {
 		action = {
 			label: 'View folder',
-			onClick: () => {
-				const winId = `os-folder-${ targetParentId }`;
-				const mgr = window.openStation?.windowManager;
-				if ( mgr?.focus ) {
-					const w = mgr.focus( winId );
-					if ( w ) {
-						return;
-					}
-				}
-				if ( mgr?.open ) {
-					void mgr.open( winId );
-				}
-			},
+			onClick: () => mgr.focus?.( winId ),
 		};
 	}
 

--- a/src/desktop-files/share-menu-items.ts
+++ b/src/desktop-files/share-menu-items.ts
@@ -34,6 +34,36 @@ function viewerId(): number {
 }
 
 /**
+ * Close an open window by id, via the public `wp.os` namespace.
+ *
+ * Reached structurally rather than by importing the manager: this
+ * file ships in `desktop.min.js` and the window system is a lazily
+ * loaded bundle.
+ *
+ * Closing lives on the Window, not on the manager. An earlier version
+ * of this call read `window.openStation.windowManager.close( id )` —
+ * a global the shell never defines, and a method that does not exist
+ * on the manager either. Optional chaining meant it threw nothing and
+ * did nothing, so leaving a shared folder quietly left its window
+ * open.
+ *
+ * @param id Window id to close. Unknown ids are a no-op.
+ */
+function closeWindowById( id: string ): void {
+	const manager = (
+		window.wp as
+			| { os?: { windowManager?: WindowManagerSlice } }
+			| undefined
+	)?.os?.windowManager;
+	manager?.getById?.( id )?.close?.();
+}
+
+/** The slice of the public window manager {@link closeWindowById} needs. */
+interface WindowManagerSlice {
+	getById?: ( id: string ) => { close?: () => void } | undefined;
+}
+
+/**
  * Reads the per-user kill switch from the live OS Settings
  * snapshot. Defaults to `true` so the share UI keeps working in
  * the (unusual) window between bundle boot and the first
@@ -162,17 +192,15 @@ export function installShareMenuItems(): void {
 							// Also close any open folder window for
 							// this folder — the user just left it,
 							// no point keeping it open.
+							// Reached through `wp.os` — the public
+							// namespace. This read used to go via
+							// `window.openStation.windowManager.close`,
+							// neither of which exists (the global is
+							// never defined, and closing is a method on
+							// the Window, not the manager), so the
+							// window was silently left open.
 							const winId = `os-folder-${ folderId }`;
-							const mgr = (
-								window as unknown as {
-									openStation?: {
-										windowManager?: {
-											close?: ( id: string ) => void;
-										};
-									};
-								}
-							).openStation?.windowManager;
-							mgr?.close?.( winId );
+							closeWindowById( winId );
 							showToast( { message: 'You left the shared folder.' } );
 						} catch ( err ) {
 							showToast( {

--- a/src/drag/focus-window-on-drag-hover.ts
+++ b/src/drag/focus-window-on-drag-hover.ts
@@ -95,7 +95,13 @@ export interface FocusableWindow {
  */
 export interface WindowFocusHost< W extends FocusableWindow = FocusableWindow > {
 	getById( id: string ): W | undefined;
-	focus( win: W ): void;
+	/**
+	 * The `| string` mirrors the real `WindowManager.focus()`, which
+	 * takes a window or its id. Without it this slice is narrower than
+	 * the thing it describes and the manager stops being assignable
+	 * to it.
+	 */
+	focus( win: W | string ): void;
 }
 
 let _installed = false;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -557,6 +557,19 @@ export const HOOKS = {
 	 */
 	WINDOW_RESTORED: 'os.window.restored',
 	/**
+	 * Action, fires when a focus request for an OWNER window was
+	 * redirected to its child instead — the user tried to raise a
+	 * window that has a child window open. Payload:
+	 * `{ windowId: string, childWindowId: string }`, where `windowId`
+	 * is the owner that stayed put.
+	 *
+	 * Subscribe to add your own "answer this first" affordance beyond
+	 * the child's shake (a toast, a pulse on the child's field).
+	 * Purely observational — the redirect has already happened by the
+	 * time this fires, and returning anything does not change it.
+	 */
+	WINDOW_CHILD_BLOCKED: 'os.window.child-blocked',
+	/**
 	 * Action, fires when a window is maximized (fills desktop area).
 	 * Payload: `{ windowId: string, element: HTMLElement }`.
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,6 +265,33 @@ export interface WindowConfig {
 	 */
 	ephemeral?: boolean;
 	/**
+	 * Id of the window that OWNS this one — makes this a **child
+	 * window**.
+	 *
+	 * A child is a real window (own chrome, drag, resize, minimize,
+	 * taskbar entry), not a dialog. What ownership adds is one rule:
+	 * **the owner can never sit above its child.** Clicking the owner
+	 * hands focus to the child and shakes it instead of raising the
+	 * owner — the "finish here first" affordance a modal sheet gives,
+	 * without taking the owner's content away. The owner stays
+	 * scrollable, draggable and resizable throughout.
+	 *
+	 * Consequences worth knowing before you set this:
+	 *   - Closing the owner closes its children (they are owned, not
+	 *     merely related — an orphan would keep blocking nothing).
+	 *   - Minimizing the owner minimizes them; restoring restores them.
+	 *   - A MINIMIZED child stops blocking. The user put it away on
+	 *     purpose; the owner is theirs again until they bring it back.
+	 *   - Children are left out of session snapshots, so a reload never
+	 *     restores a child whose owner failed to come back with it.
+	 *
+	 * For a *visual* relationship between peer windows (a post and its
+	 * comments) you want content relations instead — see
+	 * `src/window-links/types.ts`. Ownership is about z-order and
+	 * focus; relations are about drawing ties between equals.
+	 */
+	parentWindowId?: string;
+	/**
 	 * Open-time arguments for a **native** window — what it is showing
 	 * this time, as opposed to what it is.
 	 *

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -155,6 +155,25 @@ export class WindowManager {
 	private _cascadeMinimized: WeakSet< Window > = new WeakSet();
 
 	/**
+	 * Re-entrancy depth of an ownership cascade (minimize / restore /
+	 * close of a window that owns children).
+	 *
+	 * A cascade is one user action, and it should emit one focus
+	 * change. Without this, each child's own `minimize()` re-enters
+	 * `onMinimize` and settles focus on an intermediate window before
+	 * the cascade finishes, so minimizing an owner with three children
+	 * fired four `WINDOW_FOCUSED` / `WINDOW_BLURRED` pairs. The end
+	 * state was right, but anything building an activity feed or
+	 * analytics off those actions saw transitions the user never made.
+	 *
+	 * Non-zero means "an outer cascade is still running and will settle
+	 * focus when it is done" — intermediate focus work is skipped.
+	 * Incremented and decremented in `finally` so a throwing child
+	 * cannot wedge the desktop in a state where clicks stop focusing.
+	 */
+	private _cascadeDepth = 0;
+
+	/**
 	 * The desktop area element where windows are rendered.
 	 * @internal
 	 */
@@ -892,20 +911,48 @@ export class WindowManager {
 		] );
 		const win = system.createWindow( fullConfig );
 
-		win.onFocusRequest = ( w: Window ) => this.focus( w );
+		win.onFocusRequest = ( w: Window ) => {
+			// Mid-cascade, the window asking for focus is one the
+			// cascade is moving, not one the user picked. Let the
+			// cascade settle focus once at the end.
+			if ( this._cascadeDepth > 0 ) {
+				return;
+			}
+			this.focus( w );
+		};
 		win.onClose = ( w: Window ) => this.remove( w );
 		win.onMinimize = ( w: Window ) => {
 			// Children go away with their owner — a child left floating
 			// over the gap where its owner used to be reads as a
 			// detached dialog, and it would go on blocking a window the
 			// user can no longer see.
-			this.cascadeMinimize( w );
+			this._cascadeDepth++;
+			try {
+				this.cascadeMinimize( w );
+			} finally {
+				this._cascadeDepth--;
+			}
+			if ( this._cascadeDepth > 0 ) {
+				return;
+			}
 			const visible = this._stack.filter( ( x ) => x.state !== 'minimized' );
 			if ( visible.length > 0 ) {
 				this.focus( visible[ visible.length - 1 ] );
 			}
 		};
-		win.onRestore = ( w: Window ) => this.cascadeRestore( w );
+		win.onRestore = ( w: Window ) => {
+			// No focus call here on purpose. `Window.restore()` fires
+			// this BEFORE its own `onFocusRequest`, so once the children
+			// are back the request that follows resolves through the
+			// normal redirect and the whole group costs one focus
+			// change.
+			this._cascadeDepth++;
+			try {
+				this.cascadeRestore( w );
+			} finally {
+				this._cascadeDepth--;
+			}
+		};
 		win.onOpenAnother = ( w: Window ) => {
 			// Native windows: route through the public-API
 			// `openNewWindow( id )` so the registry's template clone
@@ -1288,18 +1335,56 @@ export class WindowManager {
 			);
 		}
 
-		// Center over the owner unless the caller placed it. Read the
-		// owner's live rect rather than its config: it has very likely
-		// been dragged or resized since it opened, and a child centered
-		// on where the owner *started* can land off-screen.
-		let placement: { x?: number; y?: number } = {};
-		if ( config.x === undefined && config.y === undefined ) {
+		// Does this child already have a place the user chose? `open()`
+		// falls back to per-baseId localStorage geometry when the caller
+		// pins nothing, and that memory has to win over centering — a
+		// child the user dragged aside and resized should come back
+		// where they left it, exactly like any other window.
+		const savedGeometry = loadNativeWindowGeometry(
+			config.baseId || config.id,
+		);
+		const hasSavedPlacement =
+			!! savedGeometry &&
+			typeof savedGeometry.x === 'number' &&
+			typeof savedGeometry.y === 'number';
+
+		// Center over the owner when nothing else has an opinion. Read
+		// the owner's live rect rather than its config: it has very
+		// likely been dragged or resized since it opened, and a child
+		// centered on where the owner *started* can land off-screen.
+		//
+		// Size and position are pinned TOGETHER or not at all. Sending
+		// x/y derived from an assumed size while letting `open()` resolve
+		// the real size from its own desktop-based defaults produces a
+		// child centered for dimensions it does not have — which is to
+		// say, not centered.
+		let placement: Partial< WindowConfig > = {};
+		if (
+			config.x === undefined &&
+			config.y === undefined &&
+			! hasSavedPlacement
+		) {
 			const owner = parent.getSnapshot();
 			const width = config.width ?? Math.round( owner.width * 0.8 );
 			const height = config.height ?? Math.round( owner.height * 0.8 );
+			// Keep the child inside the desktop area even when its owner
+			// is hanging off an edge. `open()` clamps saved geometry but
+			// trusts caller-pinned coordinates, and this counts as
+			// caller-pinned.
+			const desktopRect = this._desktop.getBoundingClientRect();
+			const maxX = Math.max( 0, desktopRect.width - width );
+			const maxY = Math.max( 0, desktopRect.height - height );
 			placement = {
-				x: Math.max( 0, Math.round( owner.x + ( owner.width - width ) / 2 ) ),
-				y: Math.max( 0, Math.round( owner.y + ( owner.height - height ) / 2 ) ),
+				width,
+				height,
+				x: Math.min(
+					maxX,
+					Math.max( 0, Math.round( owner.x + ( owner.width - width ) / 2 ) ),
+				),
+				y: Math.min(
+					maxY,
+					Math.max( 0, Math.round( owner.y + ( owner.height - height ) / 2 ) ),
+				),
 			};
 		}
 
@@ -1488,9 +1573,22 @@ export class WindowManager {
 		// owner and becomes an ordinary window (`ownerOf` returns
 		// undefined once the owner is gone), which is a better outcome
 		// than discarding the user's work.
-		for ( const child of this.childrenOf( win ).slice() ) {
-			this._cascadeMinimized.delete( child );
-			child.close();
+		//
+		// Depth-guarded like the minimize cascade: each `close()`
+		// re-enters `remove()`, which would otherwise run the
+		// focus-next-window pass below once per child and emit a focus
+		// change for every intermediate window on the way down.
+		const children = this.childrenOf( win ).slice();
+		if ( children.length > 0 ) {
+			this._cascadeDepth++;
+			try {
+				for ( const child of children ) {
+					this._cascadeMinimized.delete( child );
+					child.close();
+				}
+			} finally {
+				this._cascadeDepth--;
+			}
 		}
 
 		// Focus the next topmost FOCUSABLE window — walk the stack
@@ -1503,7 +1601,12 @@ export class WindowManager {
 		// the active-desktop filter used by `getByBaseIdOnActiveDesktop`.
 		// If nothing qualifies (only minimized / off-desktop windows
 		// remain), we focus nothing rather than force-restore one.
-		for ( let i = this._stack.length - 1; i >= 0; i-- ) {
+		//
+		// Skipped while an ownership cascade is unwinding — the owner's
+		// own `remove()` runs this pass once the whole group is gone,
+		// and doing it per child would hand focus through every
+		// intermediate window first.
+		for ( let i = this._stack.length - 1; this._cascadeDepth === 0 && i >= 0; i-- ) {
 			const candidate = this._stack[ i ];
 			if ( candidate.state === 'minimized' ) {
 				continue;

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -144,6 +144,17 @@ export class WindowManager {
 	public _stack: Window[] = [];
 
 	/**
+	 * Child windows that a `cascadeMinimize` put away, so restoring
+	 * the owner brings back exactly those and leaves alone the ones
+	 * the user had minimized themselves.
+	 *
+	 * A `WeakSet` because membership must not keep a closed window
+	 * alive — a child that closes while minimized is never restored,
+	 * so nothing would ever remove it from a strong collection.
+	 */
+	private _cascadeMinimized: WeakSet< Window > = new WeakSet();
+
+	/**
 	 * The desktop area element where windows are rendered.
 	 * @internal
 	 */
@@ -883,12 +894,18 @@ export class WindowManager {
 
 		win.onFocusRequest = ( w: Window ) => this.focus( w );
 		win.onClose = ( w: Window ) => this.remove( w );
-		win.onMinimize = () => {
-			const visible = this._stack.filter( ( w ) => w.state !== 'minimized' );
+		win.onMinimize = ( w: Window ) => {
+			// Children go away with their owner — a child left floating
+			// over the gap where its owner used to be reads as a
+			// detached dialog, and it would go on blocking a window the
+			// user can no longer see.
+			this.cascadeMinimize( w );
+			const visible = this._stack.filter( ( x ) => x.state !== 'minimized' );
 			if ( visible.length > 0 ) {
 				this.focus( visible[ visible.length - 1 ] );
 			}
 		};
+		win.onRestore = ( w: Window ) => this.cascadeRestore( w );
 		win.onOpenAnother = ( w: Window ) => {
 			// Native windows: route through the public-API
 			// `openNewWindow( id )` so the registry's template clone
@@ -1036,8 +1053,71 @@ export class WindowManager {
 		return `${ baseId }-${ n }`;
 	}
 
-	/** Focus a window: bring it to top of z-stack. */
-	public focus( win: Window ): void {
+	/**
+	 * Focus a window: bring it to top of z-stack.
+	 *
+	 * Accepts either a `Window` or its id — `focus( 'jorvy' )` is the
+	 * form the docs and `built-in-commands` already show, and the
+	 * natural one for a plugin author holding only an id.
+	 *
+	 * The runtime guard is load-bearing, not decoration. `focus()`
+	 * pushes its argument onto `_stack` and then calls `setZIndex()`
+	 * on every member, so an unresolvable argument used to leave a
+	 * non-Window wedged in the stack and every LATER focus() —
+	 * click-to-focus, dock activation, open-reuse — threw on it. One
+	 * bad call bricked the desktop until a reload. Resolve ids and
+	 * reject anything that isn't a Window BEFORE touching the stack.
+	 *
+	 * Unknown ids are a silent no-op (matching `raise()`): a window
+	 * closing between an id being captured and focus being requested
+	 * is a routine race, not a programming error. A non-Window,
+	 * non-string argument IS a programming error, so it warns.
+	 *
+	 * A window that OWNS an open child cannot be focused — focus goes
+	 * to the child instead (see {@link blockingChildOf}). That is the
+	 * whole of child-window modality, and it lives here rather than at
+	 * the call sites so every focus path is covered by construction:
+	 * click-to-focus, dock activation, taskbar, alt-tab, open-reuse.
+	 *
+	 * @param winOrId Window to focus, or its id.
+	 */
+	public focus( winOrId: Window | string ): void {
+		const requested =
+			typeof winOrId === 'string' ? this.getById( winOrId ) : winOrId;
+		if ( ! requested || typeof requested.setZIndex !== 'function' ) {
+			if ( winOrId && typeof winOrId !== 'string' ) {
+				// eslint-disable-next-line no-console -- Surfacing a call that would otherwise corrupt the z-stack silently.
+				console.warn(
+					'[openstation] windowManager.focus() expects a Window or a window id; received',
+					winOrId,
+				);
+			}
+			return;
+		}
+
+		// Child-window modality. Redirect to the DEEPEST open
+		// descendant so a chain (owner → child → grandchild) hands
+		// focus to the one actually on top rather than to a middle
+		// link that is itself blocked.
+		const win = this.blockingChildOf( requested ) ?? requested;
+		if ( win !== requested ) {
+			// Nudge the child so the click reads as "answer this
+			// first" instead of as a dead click on the owner.
+			win.shake?.();
+			doAction( HOOKS.WINDOW_CHILD_BLOCKED, {
+				windowId: requested.id,
+				childWindowId: win.id,
+			} );
+			document.dispatchEvent(
+				new CustomEvent( 'os-window-child-blocked', {
+					detail: { windowId: requested.id, childWindowId: win.id },
+				} ),
+			);
+			// Fall through: the child is focused exactly as if it had
+			// been the argument, so it lands on top and fires the
+			// normal blur/focus pair.
+		}
+
 		// Capture the previously-focused window BEFORE the splice/push
 		// changes the stack — needed so we can fire `WINDOW_BLURRED`
 		// for it. No-op when this `focus()` is hitting the already-
@@ -1082,6 +1162,13 @@ export class WindowManager {
 			this._stack.splice( idx, 1 );
 		}
 		this._stack.push( win );
+
+		// Lift every open child back above its owner. Focusing an
+		// owner is already redirected, but plenty of other paths move
+		// the stack — restore-from-minimize, desktop switch, session
+		// restore — and each could otherwise bury a child under the
+		// window it is supposed to be blocking.
+		this.enforceOwnershipOrder();
 
 		// Update z-indices and focused state.
 		this._stack.forEach( ( w, i ) => {
@@ -1140,9 +1227,249 @@ export class WindowManager {
 		}
 		this._stack.splice( idx, 1 );
 		this._stack.splice( this._stack.length - 1, 0, win );
+		this.enforceOwnershipOrder();
 		this._stack.forEach( ( w, i ) => {
 			w.setZIndex( BASE_Z_INDEX + i );
 		} );
+	}
+
+	/**
+	 * Open a **child window** owned by `parentWindowId`.
+	 *
+	 * A child is a real window — its own chrome, drag, resize,
+	 * minimize, taskbar entry — with one rule layered on top: its
+	 * owner can never sit above it. Clicking the owner shakes the
+	 * child and leaves focus there. Use it for the "finish this before
+	 * going back" shapes a modal dialog is normally reached for, when
+	 * what you actually want is a window: a full editor for one row of
+	 * a list, a wizard beside the page it configures, a diff over the
+	 * revision it belongs to.
+	 *
+	 * The owner keeps working throughout — scrollable, readable,
+	 * draggable, resizable. Only its z-order is constrained.
+	 *
+	 * Centers over the owner by default, which is what makes the
+	 * relationship legible at a glance; pass `x`/`y` to override.
+	 * Every other `open()` option (`native`, `render`, `width`,
+	 * `params`, …) behaves exactly as it does there.
+	 *
+	 * ```js
+	 * await wp.os.windowManager.openChild( 'edit-post-42', {
+	 *     id: 'my-plugin-seo-audit-42',
+	 *     url: '#seo-audit-42',
+	 *     title: 'SEO audit',
+	 *     icon: 'dashicons-chart-line',
+	 *     native: true,
+	 *     render: ( body ) => { … },
+	 * } );
+	 * ```
+	 *
+	 * @param parentWindowId Owner window's id. Must be open — a child
+	 *                       of nothing has nothing to block, so an
+	 *                       unknown id rejects rather than quietly
+	 *                       opening a normal window.
+	 * @param config         Window config, exactly as for `open()`.
+	 *                       Any `parentWindowId` in here is ignored in
+	 *                       favour of the argument.
+	 * @return The opened child window.
+	 */
+	public async openChild(
+		parentWindowId: string,
+		config: Partial< WindowConfig > & {
+			id: string;
+			url: string;
+			title: string;
+		},
+	): Promise< Window > {
+		const parent = this.getById( parentWindowId );
+		if ( ! parent ) {
+			throw new Error(
+				`windowManager.openChild(): no open window with id "${ parentWindowId }". Open the owner first, or use open() for a standalone window.`,
+			);
+		}
+
+		// Center over the owner unless the caller placed it. Read the
+		// owner's live rect rather than its config: it has very likely
+		// been dragged or resized since it opened, and a child centered
+		// on where the owner *started* can land off-screen.
+		let placement: { x?: number; y?: number } = {};
+		if ( config.x === undefined && config.y === undefined ) {
+			const owner = parent.getSnapshot();
+			const width = config.width ?? Math.round( owner.width * 0.8 );
+			const height = config.height ?? Math.round( owner.height * 0.8 );
+			placement = {
+				x: Math.max( 0, Math.round( owner.x + ( owner.width - width ) / 2 ) ),
+				y: Math.max( 0, Math.round( owner.y + ( owner.height - height ) / 2 ) ),
+			};
+		}
+
+		return this.open( {
+			...config,
+			...placement,
+			// Children live on their owner's desktop — a child stranded
+			// on another virtual desktop would block a window nobody
+			// can see next to it.
+			desktopId: parent.config.desktopId,
+			parentWindowId,
+		} );
+	}
+
+	/**
+	 * The window that owns `win`, or undefined when it is not a child
+	 * (or its owner has since closed — an orphan is a normal window).
+	 *
+	 * @param win Window to look up the owner of.
+	 */
+	public ownerOf( win: Window ): Window | undefined {
+		const parentId = win.config.parentWindowId;
+		return parentId ? this.getById( parentId ) : undefined;
+	}
+
+	/**
+	 * Every open child of `winOrId`, in z-order (lowest first).
+	 *
+	 * Direct children only — walk the result to reach grandchildren.
+	 * Includes minimized children: they do not block focus, but a
+	 * caller counting "what does closing this take with it" needs
+	 * them.
+	 *
+	 * @param winOrId Owner window, or its id.
+	 */
+	public childrenOf( winOrId: Window | string ): Window[] {
+		const id = typeof winOrId === 'string' ? winOrId : winOrId.id;
+		return this._stack.filter( ( w ) => w.config.parentWindowId === id );
+	}
+
+	/**
+	 * The child that stands between `win` and the front, or undefined
+	 * when `win` is free to take focus.
+	 *
+	 * Walks to the DEEPEST open descendant, because a child can own a
+	 * child of its own and only the last link is actually on top.
+	 *
+	 * Minimized children are skipped deliberately: the user put that
+	 * child away, and a window that cannot be seen has no business
+	 * withholding focus from the one that can. Bringing the child back
+	 * restores the block.
+	 *
+	 * @param win Window a focus request came in for.
+	 */
+	public blockingChildOf( win: Window ): Window | undefined {
+		let current = win;
+		let blocker: Window | undefined;
+		// `seen` guards against a cycle in plugin-declared ownership
+		// (A owns B, B owns A). Without it a bad pair would spin here
+		// forever on the first click.
+		const seen = new Set< Window >( [ win ] );
+		for ( ;; ) {
+			const open = this.childrenOf( current ).filter(
+				( w ) => w.state !== 'minimized' && ! seen.has( w ),
+			);
+			if ( open.length === 0 ) {
+				return blocker;
+			}
+			// Topmost of several siblings — `childrenOf` returns
+			// z-order, so the last one is the one in front.
+			current = open[ open.length - 1 ];
+			seen.add( current );
+			blocker = current;
+		}
+	}
+
+	/**
+	 * Reorder `_stack` so no open child sits below its owner, then
+	 * leave the z-index rewrite to the caller.
+	 *
+	 * A stable topological pass: walk the stack bottom-up and emit
+	 * each window only after its owner, preserving existing order
+	 * everywhere ownership says nothing. Stability matters — this runs
+	 * on every focus, and an unstable sort would shuffle unrelated
+	 * windows behind each other on every click.
+	 *
+	 * Minimized windows are exempt from the constraint. Not cosmetic:
+	 * without the exemption, focusing an owner whose only child is
+	 * minimized would hoist that invisible child to the top of the
+	 * stack, and `setFocused( i === length - 1 )` would hand focus to
+	 * a window the user cannot see.
+	 */
+	private enforceOwnershipOrder(): void {
+		// Nothing declares ownership on most desktops — skip the whole
+		// pass rather than rebuild the array on every single focus.
+		if ( ! this._stack.some( ( w ) => w.config.parentWindowId ) ) {
+			return;
+		}
+
+		const ordered: Window[] = [];
+		const placed = new Set< Window >();
+
+		const place = ( win: Window, chain: Set< Window > ): void => {
+			if ( placed.has( win ) || chain.has( win ) ) {
+				return;
+			}
+			chain.add( win );
+			if ( win.state !== 'minimized' ) {
+				const owner = this.ownerOf( win );
+				if ( owner && owner !== win ) {
+					place( owner, chain );
+				}
+			}
+			if ( ! placed.has( win ) ) {
+				placed.add( win );
+				ordered.push( win );
+			}
+		};
+
+		for ( const win of this._stack ) {
+			place( win, new Set() );
+		}
+
+		// Mutate in place — `_stack` is public and long-lived, so
+		// reassigning it would strand any reference taken elsewhere.
+		this._stack.length = 0;
+		this._stack.push( ...ordered );
+	}
+
+	/**
+	 * Minimize every open child of `win`, remembering which ones this
+	 * cascade put away so {@link cascadeRestore} can tell them from
+	 * children the user had already minimized themselves.
+	 *
+	 * @param win Owner being minimized.
+	 */
+	private cascadeMinimize( win: Window ): void {
+		for ( const child of this.childrenOf( win ) ) {
+			if ( child.state === 'minimized' ) {
+				continue;
+			}
+			this._cascadeMinimized.add( child );
+			// `minimize()` fires the child's own `onMinimize`, which
+			// re-enters here for a grandchild — so a whole ownership
+			// chain folds away without an explicit recursive walk.
+			child.minimize();
+		}
+	}
+
+	/**
+	 * Bring back the children that went away with `win`, and only
+	 * those.
+	 *
+	 * A child the user minimized on their own before minimizing the
+	 * owner stays minimized: they put it away deliberately, and
+	 * un-minimizing it here would also silently re-block the owner
+	 * they just came back to.
+	 *
+	 * @param win Owner being restored.
+	 */
+	private cascadeRestore( win: Window ): void {
+		for ( const child of this.childrenOf( win ) ) {
+			if ( ! this._cascadeMinimized.has( child ) ) {
+				continue;
+			}
+			this._cascadeMinimized.delete( child );
+			// Mirrors `cascadeMinimize`: the child's own `onRestore`
+			// carries the cascade down to its grandchildren.
+			child.restore();
+		}
 	}
 
 	/** Remove a window from the stack and DOM. */
@@ -1150,6 +1477,20 @@ export class WindowManager {
 		const idx = this._stack.indexOf( win );
 		if ( idx > -1 ) {
 			this._stack.splice( idx, 1 );
+		}
+
+		// An owned window has no life of its own — close the children
+		// with their owner. Snapshot first: each `close()` re-enters
+		// `remove()` and mutates `_stack` underneath us.
+		//
+		// `close()` rather than `destroy()` so a child with unsaved
+		// changes still gets to ask. A child that vetoes outlives its
+		// owner and becomes an ordinary window (`ownerOf` returns
+		// undefined once the owner is gone), which is a better outcome
+		// than discarding the user's work.
+		for ( const child of this.childrenOf( win ).slice() ) {
+			this._cascadeMinimized.delete( child );
+			child.close();
 		}
 
 		// Focus the next topmost FOCUSABLE window — walk the stack
@@ -1731,7 +2072,17 @@ export class WindowManager {
 		// Ephemeral windows are the real opt-out: their URL doesn't
 		// survive a session (editor-preview nonces), so they're skipped
 		// from both the window list and the focused id.
-		const persistable = this._stack.filter( ( w ) => ! w.config.ephemeral );
+		//
+		// Child windows are skipped for a different reason: restoring
+		// one is only safe if its owner comes back too, and owners can
+		// fail to restore for reasons this side knows nothing about (a
+		// deactivated plugin's native window, a URL that 404s now). A
+		// restored child whose owner never arrived would sit there
+		// blocking a window that does not exist. Losing a child across
+		// a reload is the cheaper failure.
+		const persistable = this._stack.filter(
+			( w ) => ! w.config.ephemeral && ! w.config.parentWindowId,
+		);
 		const windows: SessionWindow[] = persistable.map( ( w ) => {
 			const snap = w.getSnapshot();
 			const externalTabs = w.getExternalTabsSnapshot();
@@ -1770,7 +2121,15 @@ export class WindowManager {
 				...( externalTabs.length > 0 ? { externalTabs } : {} ),
 			};
 		} );
-		const focusedId = focused && ! focused.config.ephemeral ? focused.id : '';
+		// Same two exclusions as `persistable` — a focused id pointing
+		// at a window that was never written to the snapshot restores
+		// as "focus nothing", so it has to be filtered here too.
+		const focusedId =
+			focused &&
+			! focused.config.ephemeral &&
+			! focused.config.parentWindowId
+				? focused.id
+				: '';
 
 		return {
 			windows,

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1756,13 +1756,22 @@ export class Window {
 				this.updateFocusButtonState();
 			}
 		}
+		if ( wasMinimized ) {
+			// Bring owned child windows back BEFORE requesting focus.
+			// Ordering is load-bearing: while the children are still
+			// minimized none of them blocks, so a focus request here
+			// would land on this window and then have to be corrected
+			// once they reappear — two focus changes for one user
+			// action. Restore first and the single request below
+			// resolves straight to the child that should hold focus.
+			this.onRestore?.( this );
+		}
 		this.onFocusRequest?.( this );
 		this._emitChange( 'state' );
 		if ( wasMinimized ) {
-			// Before `WINDOW_RESTORED`, so a subscriber that inspects
-			// the desktop sees this window's children already back
-			// rather than a half-restored ownership group.
-			this.onRestore?.( this );
+			// After `onRestore`, so a subscriber that inspects the
+			// desktop sees this window's children already back rather
+			// than a half-restored ownership group.
 			doAction( HOOKS.WINDOW_RESTORED, {
 				windowId: this.id,
 				element: this.element,

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -85,6 +85,33 @@ import {
  * `window.location` after boot can't relax the check.
  */
 const INITIAL_ORIGIN = window.location.origin;
+
+/**
+ * The `@keyframes` name behind `.os-window--opening` in
+ * `window-states.css`. `animationend` BUBBLES, so the listener that
+ * clears the class has to check this — a spinner, skeleton shimmer
+ * or holo drift finishing anywhere inside the window body would
+ * otherwise consume the once-only listener and cut the open
+ * animation short.
+ */
+const OPENING_ANIMATION_NAME = 'os-window-open';
+
+/**
+ * Deadline for clearing `.os-window--opening` regardless of what the
+ * compositor did — the CSS animation is 0.2s, this leaves margin.
+ *
+ * Why a timer at all: CSS animations do not advance while the
+ * document is hidden, so `animationend` never fires for a window
+ * opened in a backgrounded tab (session restore the user tabs away
+ * from, an `os-open-requested` from another surface, automation).
+ * The class is what applies `opacity: 0` / `scale(0.92)` via the
+ * animation's `from` frame, so a stuck class means a window that is
+ * in the DOM, focused, and invisible. Background tabs also throttle
+ * timers to >=1s, so this fires late there rather than on time —
+ * late still unsticks it, which is the whole point.
+ */
+const OPENING_FALLBACK_MS = 300;
+
 import {
 	activatePanelTab,
 	addExternalTab,
@@ -438,6 +465,12 @@ export class Window {
 	public onClose: ( ( win: Window ) => void ) | null = null;
 	public onMinimize: ( ( win: Window ) => void ) | null = null;
 	/**
+	 * Invoked after this window comes back from minimized. The manager
+	 * wires it to bring any child windows back with their owner — the
+	 * counterpart to the cascade in `onMinimize`.
+	 */
+	public onRestore: ( ( win: Window ) => void ) | null = null;
+	/**
 	 * Invoked when the title-bar menu's "Open another" item is clicked.
 	 * The window manager wires this to `openNew()`.
 	 */
@@ -654,10 +687,15 @@ export class Window {
 
 		// Fresh open (or restored to a visible state). Play the opening
 		// animation, then remove the class.
-		this.element.classList.add( 'os-window--opening' );
-		this.element.addEventListener( 'animationend', () => {
-			this.element.classList.remove( 'os-window--opening' );
-		}, { once: true } );
+		//
+		// Nothing to animate for a document nobody is looking at, and
+		// a hidden document never advances the animation — so skip the
+		// class entirely rather than open invisible and wait for the
+		// fallback timer to rescue it.
+		if ( ! document.hidden ) {
+			this.element.classList.add( 'os-window--opening' );
+			this._armOpeningClassRemoval();
+		}
 
 		// Maximized/fullscreen restores go through the class-driven path
 		// after the geometry renders, so the state transition animates.
@@ -666,6 +704,55 @@ export class Window {
 		if ( config.initialState && config.initialState !== 'normal' ) {
 			requestAnimationFrame( () => this.applyInitialState( config.initialState! ) );
 		}
+	}
+
+	/**
+	 * Clear `.os-window--opening` once the open animation is done —
+	 * belt and braces, because the class is not cosmetic. Its
+	 * animation's `from` frame is what makes the window transparent
+	 * and undersized, so a class that never comes off is a window
+	 * that never becomes visible.
+	 *
+	 * Three ways out, because the animation alone is not a guarantee:
+	 *   - `animationend`, filtered on `animationName` + `target` so a
+	 *     bubbling animation from the window's own content can't
+	 *     claim it (see `OPENING_ANIMATION_NAME`).
+	 *   - `animationcancel`, for a class or stylesheet swap that
+	 *     tears the animation down mid-flight.
+	 *   - a `setTimeout` deadline, for the case where no animation
+	 *     event is ever coming (see `OPENING_FALLBACK_MS`).
+	 *
+	 * Whichever fires first wins and detaches the other two.
+	 */
+	private _armOpeningClassRemoval(): void {
+		const el = this.element;
+		let timer = 0;
+		let cleared = false;
+
+		const clear = (): void => {
+			if ( cleared ) {
+				return;
+			}
+			cleared = true;
+			window.clearTimeout( timer );
+			el.removeEventListener( 'animationend', onAnimationDone );
+			el.removeEventListener( 'animationcancel', onAnimationDone );
+			el.classList.remove( 'os-window--opening' );
+		};
+
+		const onAnimationDone = ( event: AnimationEvent ): void => {
+			if (
+				event.target !== el ||
+				event.animationName !== OPENING_ANIMATION_NAME
+			) {
+				return;
+			}
+			clear();
+		};
+
+		el.addEventListener( 'animationend', onAnimationDone );
+		el.addEventListener( 'animationcancel', onAnimationDone );
+		timer = window.setTimeout( clear, OPENING_FALLBACK_MS );
 	}
 
 	/**
@@ -1672,6 +1759,10 @@ export class Window {
 		this.onFocusRequest?.( this );
 		this._emitChange( 'state' );
 		if ( wasMinimized ) {
+			// Before `WINDOW_RESTORED`, so a subscriber that inspects
+			// the desktop sees this window's children already back
+			// rather than a half-restored ownership group.
+			this.onRestore?.( this );
 			doAction( HOOKS.WINDOW_RESTORED, {
 				windowId: this.id,
 				element: this.element,

--- a/tests/vitest/window-child-ownership.test.ts
+++ b/tests/vitest/window-child-ownership.test.ts
@@ -12,8 +12,10 @@
  * escape hatches: a minimized child stops blocking, and children stay
  * out of session snapshots.
  */
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { WindowManager } from '../../src/window-manager';
+import { NATIVE_GEOMETRY_STORAGE_KEY } from '../../src/window-manager/native-window-geometry';
+import { HOOKS } from '../../src/hooks';
 import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
 
 function cfg( id: string, extra: Record< string, unknown > = {} ) {
@@ -183,6 +185,56 @@ describe( 'child windows — the owner cannot come to the front', () => {
 		expect( child.config.y ).toBe( 200 + ( 400 - 200 ) / 2 );
 	} );
 
+	test( 'openChild centers with NO explicit size — the documented call shape', async () => {
+		const owner = await manager.open(
+			cfg( 'owner', { x: 100, y: 100, width: 800, height: 600 } ),
+		);
+		owner.element.style.left = '300px';
+		owner.element.style.top = '150px';
+		owner.element.style.width = '600px';
+		owner.element.style.height = '400px';
+
+		// No width/height — exactly what docs/examples/child-windows.md
+		// shows. This used to compute x/y for an assumed 80%-of-owner
+		// size and then let `open()` pick a completely different size
+		// from the desktop rect, so the child landed nowhere near
+		// centered. Size and position have to be pinned together.
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		const width = Math.round( 600 * 0.8 );
+		const height = Math.round( 400 * 0.8 );
+		expect( child.config.width ).toBe( width );
+		expect( child.config.height ).toBe( height );
+		expect( child.config.x ).toBe( 300 + ( 600 - width ) / 2 );
+		expect( child.config.y ).toBe( 150 + ( 400 - height ) / 2 );
+
+		// The real invariant behind the arithmetic: concentric.
+		expect( child.config.x + width / 2 ).toBe( 300 + 600 / 2 );
+		expect( child.config.y + height / 2 ).toBe( 150 + 400 / 2 );
+	} );
+
+	test( 'a centered child stays inside the desktop when its owner hangs off an edge', async () => {
+		const owner = await manager.open(
+			cfg( 'owner', { width: 800, height: 600 } ),
+		);
+		// Dragged mostly off the right/bottom of the 1600x900 desktop.
+		owner.element.style.left = '1500px';
+		owner.element.style.top = '800px';
+		owner.element.style.width = '800px';
+		owner.element.style.height = '600px';
+
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		expect( child.config.x ).toBeLessThanOrEqual(
+			1600 - ( child.config.width ?? 0 ),
+		);
+		expect( child.config.y ).toBeLessThanOrEqual(
+			900 - ( child.config.height ?? 0 ),
+		);
+		expect( child.config.x ).toBeGreaterThanOrEqual( 0 );
+		expect( child.config.y ).toBeGreaterThanOrEqual( 0 );
+	} );
+
 	test( 'openChild honours an explicit position', async () => {
 		await manager.open(
 			cfg( 'owner', { x: 100, y: 100, width: 800, height: 600 } ),
@@ -195,6 +247,157 @@ describe( 'child windows — the owner cannot come to the front', () => {
 
 		expect( child.config.x ).toBe( 12 );
 		expect( child.config.y ).toBe( 34 );
+	} );
+
+	test( "a child's remembered geometry wins over centering", async () => {
+		// The user dragged this child aside and resized it last time.
+		// Centering must not overrule that — a child is a real window
+		// and gets the same geometry memory as any other.
+		window.localStorage.setItem(
+			NATIVE_GEOMETRY_STORAGE_KEY,
+			JSON.stringify( {
+				child: { x: 25, y: 45, width: 333, height: 222 },
+			} ),
+		);
+
+		await manager.open(
+			cfg( 'owner', { x: 100, y: 100, width: 800, height: 600 } ),
+		);
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		expect( child.config.x ).toBe( 25 );
+		expect( child.config.y ).toBe( 45 );
+		expect( child.config.width ).toBe( 333 );
+		expect( child.config.height ).toBe( 222 );
+
+		window.localStorage.removeItem( NATIVE_GEOMETRY_STORAGE_KEY );
+	} );
+} );
+
+describe( 'child windows — a cascade is one focus change', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	/**
+	 * Count `os-window-focused` dispatches for one user action.
+	 *
+	 * The end state was always correct; what these guard is event
+	 * churn. A plugin building an activity feed off WINDOW_FOCUSED /
+	 * WINDOW_BLURRED saw a transition per cascaded window, none of
+	 * which the user performed.
+	 */
+	function countFocusEvents( run: () => void ): number {
+		const seen = vi.fn();
+		document.addEventListener( 'os-window-focused', seen );
+		try {
+			run();
+		} finally {
+			document.removeEventListener( 'os-window-focused', seen );
+		}
+		return seen.mock.calls.length;
+	}
+
+	test( 'minimizing an owner with three children fires one focus change', async () => {
+		const other = await manager.open( cfg( 'other' ) );
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'c1' ) );
+		await manager.openChild( 'owner', cfg( 'c2' ) );
+		await manager.openChild( 'owner', cfg( 'c3' ) );
+
+		const focusEvents = countFocusEvents( () => owner.minimize() );
+
+		expect( focusEvents ).toBe( 1 );
+		// And it landed somewhere real.
+		expect( other.isFocused() ).toBe( true );
+	} );
+
+	test( 'closing an owner with three children fires one focus change', async () => {
+		const other = await manager.open( cfg( 'other' ) );
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'c1' ) );
+		await manager.openChild( 'owner', cfg( 'c2' ) );
+		await manager.openChild( 'owner', cfg( 'c3' ) );
+
+		const focusEvents = countFocusEvents( () => owner.close() );
+
+		expect( focusEvents ).toBe( 1 );
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [ 'other' ] );
+		expect( other.isFocused() ).toBe( true );
+	} );
+
+	test( 'restoring an owner with three children fires one focus change', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'c1' ) );
+		await manager.openChild( 'owner', cfg( 'c2' ) );
+		const c3 = await manager.openChild( 'owner', cfg( 'c3' ) );
+		owner.minimize();
+
+		const focusEvents = countFocusEvents( () => owner.restore() );
+
+		expect( focusEvents ).toBe( 1 );
+		// The owner cannot hold focus while a child is open, so the one
+		// focus change resolves to a restored child.
+		expect( owner.isFocused() ).toBe( false );
+		expect( c3.state ).not.toBe( 'minimized' );
+		expect( manager.blockingChildOf( owner ) ).toBeDefined();
+	} );
+
+	test( 'the blur side is quiet too', async () => {
+		await manager.open( cfg( 'other' ) );
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'c1' ) );
+		await manager.openChild( 'owner', cfg( 'c2' ) );
+
+		const blurs: string[] = [];
+		const onBlur = ( e: Event ): void => {
+			blurs.push( ( e as CustomEvent ).detail.windowId );
+		};
+		document.addEventListener( 'os-window-blurred', onBlur );
+		owner.minimize();
+		document.removeEventListener( 'os-window-blurred', onBlur );
+
+		expect( blurs.length ).toBeLessThanOrEqual( 1 );
+	} );
+
+	test( 'a normal minimize still settles focus', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+
+		// No ownership in play — the depth guard must not suppress the
+		// ordinary path.
+		const focusEvents = countFocusEvents( () => b.minimize() );
+
+		expect( focusEvents ).toBe( 1 );
+		expect( a.isFocused() ).toBe( true );
+	} );
+
+	test( 'the hook action fires alongside the event, once', async () => {
+		await manager.open( cfg( 'other' ) );
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'c1' ) );
+		await manager.openChild( 'owner', cfg( 'c2' ) );
+
+		const seen = vi.fn();
+		window.wp.hooks.addAction( HOOKS.WINDOW_FOCUSED, 'test/churn', seen );
+		owner.minimize();
+		window.wp.hooks.removeAction( HOOKS.WINDOW_FOCUSED, 'test/churn' );
+
+		expect( seen ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 

--- a/tests/vitest/window-child-ownership.test.ts
+++ b/tests/vitest/window-child-ownership.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Child-window ownership.
+ *
+ * A child is a real window with one rule attached: **its owner can
+ * never sit above it.** Clicking the owner hands focus to the child
+ * instead of raising the owner. Everything else about the owner keeps
+ * working — this is z-order and focus modality, not an inert parent.
+ *
+ * The tests below pin the rule itself, the paths that could quietly
+ * bury a child under its owner (raise, restore-from-minimize), the
+ * cascades (close, minimize, restore), and the two deliberate
+ * escape hatches: a minimized child stops blocking, and children stay
+ * out of session snapshots.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+function cfg( id: string, extra: Record< string, unknown > = {} ) {
+	return {
+		id,
+		url: `http://example.test/${ id }.php`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+		...extra,
+	};
+}
+
+function makeDesktop(): HTMLElement {
+	const desktop = document.createElement( 'div' );
+	desktop.id = 'os-area';
+	Object.defineProperty( desktop, 'getBoundingClientRect', {
+		value: () =>
+			( {
+				left: 0,
+				top: 0,
+				right: 1600,
+				bottom: 900,
+				width: 1600,
+				height: 900,
+				x: 0,
+				y: 0,
+				toJSON: () => ( {} ),
+			} ) as DOMRect,
+	} );
+	Object.defineProperty( desktop, 'clientWidth', {
+		value: 1600,
+		configurable: true,
+	} );
+	Object.defineProperty( desktop, 'clientHeight', {
+		value: 900,
+		configurable: true,
+	} );
+	return desktop;
+}
+
+/** Window ids in z-order, lowest first. */
+function zOrder( manager: WindowManager ): string[] {
+	return manager._stack.map( ( w ) => w.id );
+}
+
+describe( 'child windows — the owner cannot come to the front', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'focusing the owner focuses the child instead', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+		expect( child.isFocused() ).toBe( true );
+
+		manager.focus( owner );
+
+		expect( child.isFocused() ).toBe( true );
+		expect( owner.isFocused() ).toBe( false );
+		// And the child is still the one in front.
+		expect( zOrder( manager ).at( -1 ) ).toBe( 'child' );
+	} );
+
+	test( 'the owner still cannot be raised above the child', async () => {
+		await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'child' ) );
+
+		manager.raise( 'owner' );
+
+		const order = zOrder( manager );
+		expect( order.indexOf( 'child' ) ).toBeGreaterThan(
+			order.indexOf( 'owner' ),
+		);
+	} );
+
+	test( 'an unrelated window can still be focused over both', async () => {
+		await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'child' ) );
+		const other = await manager.open( cfg( 'other' ) );
+
+		expect( other.isFocused() ).toBe( true );
+		// Ownership constrains owner-vs-child, nothing else. The
+		// stack pass must not drag unrelated windows around.
+		const order = zOrder( manager );
+		expect( order.indexOf( 'child' ) ).toBeGreaterThan(
+			order.indexOf( 'owner' ),
+		);
+		expect( order.at( -1 ) ).toBe( 'other' );
+	} );
+
+	test( 'focus redirects to the DEEPEST descendant in a chain', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'child' ) );
+		const grandchild = await manager.openChild( 'child', cfg( 'grandchild' ) );
+
+		manager.focus( owner );
+
+		// Not the middle link — it is blocked in turn.
+		expect( grandchild.isFocused() ).toBe( true );
+		const order = zOrder( manager );
+		expect( order ).toEqual( [ 'owner', 'child', 'grandchild' ] );
+	} );
+
+	test( 'a cycle in declared ownership does not hang the focus path', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b', { parentWindowId: 'a' } ) );
+		// A plugin declaring both directions. Nonsense, but it must
+		// not spin on the first click.
+		a.config.parentWindowId = 'b';
+
+		expect( () => manager.focus( a ) ).not.toThrow();
+		expect( () => manager.focus( b ) ).not.toThrow();
+	} );
+
+	test( 'reports ownership both ways', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		expect( manager.ownerOf( child ) ).toBe( owner );
+		expect( manager.ownerOf( owner ) ).toBeUndefined();
+		expect( manager.childrenOf( 'owner' ).map( ( w ) => w.id ) ).toEqual( [
+			'child',
+		] );
+		expect( manager.childrenOf( 'child' ) ).toEqual( [] );
+	} );
+
+	test( 'openChild refuses an owner that is not open', async () => {
+		await expect(
+			manager.openChild( 'nope', cfg( 'child' ) ),
+		).rejects.toThrow( /no open window with id "nope"/ );
+	} );
+
+	test( 'openChild centers over the live owner rect, not its config', async () => {
+		const owner = await manager.open(
+			cfg( 'owner', { x: 100, y: 100, width: 800, height: 600 } ),
+		);
+		// The user drags/resizes it after opening — which is the case
+		// that made reading `config` wrong.
+		owner.element.style.left = '400px';
+		owner.element.style.top = '200px';
+		owner.element.style.width = '600px';
+		owner.element.style.height = '400px';
+
+		const child = await manager.openChild(
+			'owner',
+			cfg( 'child', { width: 300, height: 200 } ),
+		);
+
+		// jsdom reports offsetParent as null, so getSnapshot() parses
+		// the inline styles — the same path a window on an inactive
+		// desktop takes.
+		expect( child.config.x ).toBe( 400 + ( 600 - 300 ) / 2 );
+		expect( child.config.y ).toBe( 200 + ( 400 - 200 ) / 2 );
+	} );
+
+	test( 'openChild honours an explicit position', async () => {
+		await manager.open(
+			cfg( 'owner', { x: 100, y: 100, width: 800, height: 600 } ),
+		);
+
+		const child = await manager.openChild(
+			'owner',
+			cfg( 'child', { x: 12, y: 34, width: 300, height: 200 } ),
+		);
+
+		expect( child.config.x ).toBe( 12 );
+		expect( child.config.y ).toBe( 34 );
+	} );
+} );
+
+describe( 'child windows — minimized children stop blocking', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'the owner is focusable again once the child is minimized', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		child.minimize();
+		manager.focus( owner );
+
+		// The user put the child away; the owner is theirs again.
+		expect( owner.isFocused() ).toBe( true );
+		expect( manager.blockingChildOf( owner ) ).toBeUndefined();
+	} );
+
+	test( 'a minimized child is never hoisted above its owner', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		child.minimize();
+		manager.focus( owner );
+
+		// The regression this guards: the ownership pass hoisting an
+		// invisible window to the top of the stack, where
+		// `setFocused( i === length - 1 )` hands focus to a window
+		// nobody can see.
+		expect( zOrder( manager ).at( -1 ) ).toBe( 'owner' );
+		expect( child.isFocused() ).toBe( false );
+	} );
+
+	test( 'restoring the child restores the block', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		child.minimize();
+		child.restore();
+		manager.focus( owner );
+
+		expect( child.isFocused() ).toBe( true );
+		expect( owner.isFocused() ).toBe( false );
+	} );
+} );
+
+describe( 'child windows — cascades', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'closing the owner closes its children', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'child' ) );
+
+		owner.close();
+
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [] );
+	} );
+
+	test( 'closing the owner closes a whole chain', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'child' ) );
+		await manager.openChild( 'child', cfg( 'grandchild' ) );
+
+		owner.close();
+
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [] );
+	} );
+
+	test( 'closing a child leaves the owner alone and focusable again', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		child.close();
+
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [ 'owner' ] );
+		manager.focus( owner );
+		expect( owner.isFocused() ).toBe( true );
+	} );
+
+	test( 'minimizing the owner minimizes its children, restoring brings them back', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		owner.minimize();
+		expect( child.state ).toBe( 'minimized' );
+
+		owner.restore();
+		expect( child.state ).not.toBe( 'minimized' );
+	} );
+
+	test( 'restoring the owner leaves a child the user had minimized alone', async () => {
+		const owner = await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+
+		// The user puts the child away FIRST, then minimizes the owner.
+		child.minimize();
+		owner.minimize();
+		owner.restore();
+
+		// Bringing it back would silently re-block the owner they just
+		// returned to.
+		expect( child.state ).toBe( 'minimized' );
+	} );
+} );
+
+describe( 'child windows — session persistence', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'children are left out of the snapshot', async () => {
+		await manager.open( cfg( 'owner' ) );
+		await manager.openChild( 'owner', cfg( 'child' ) );
+
+		const snap = manager.snapshot();
+
+		// A restored child whose owner failed to come back would block
+		// a window that does not exist.
+		expect( snap.windows.map( ( w ) => w.id ) ).toEqual( [ 'owner' ] );
+	} );
+
+	test( 'a focused child does not become the persisted focus id', async () => {
+		await manager.open( cfg( 'owner' ) );
+		const child = await manager.openChild( 'owner', cfg( 'child' ) );
+		expect( child.isFocused() ).toBe( true );
+
+		// Pointing `focused` at a window that was never written would
+		// restore as "focus nothing".
+		expect( manager.snapshot().focused ).toBe( '' );
+	} );
+} );

--- a/tests/vitest/window-focus-guard-and-opening-class.test.ts
+++ b/tests/vitest/window-focus-guard-and-opening-class.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Two shell-integrity guards that share a symptom — a window that is
+ * in the DOM but cannot be used — and nothing else.
+ *
+ * 1. `WindowManager.focus()` accepts an id, and refuses anything that
+ *    is neither an id nor a Window. It pushes its argument onto
+ *    `_stack` and then calls `setZIndex()` across every member, so an
+ *    unresolvable argument used to leave a non-Window wedged in the
+ *    stack — after which EVERY later focus() threw on it and the
+ *    whole desktop went unclickable until a reload.
+ *
+ * 2. `.os-window--opening` always comes off. Its animation's `from`
+ *    frame is what makes a window transparent and undersized, so a
+ *    class whose removal hangs on a single unfiltered `animationend`
+ *    is a window that can stay invisible — which is exactly what a
+ *    hidden document (no animation frames, no `animationend`) does to
+ *    it.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+function cfg( id: string ) {
+	return {
+		id,
+		url: `http://example.test/${ id }.php`,
+		title: id,
+		icon: 'dashicons-admin-generic',
+	};
+}
+
+function makeDesktop(): HTMLElement {
+	const desktop = document.createElement( 'div' );
+	desktop.id = 'os-area';
+	Object.defineProperty( desktop, 'getBoundingClientRect', {
+		value: () =>
+			( {
+				left: 0,
+				top: 0,
+				right: 1600,
+				bottom: 900,
+				width: 1600,
+				height: 900,
+				x: 0,
+				y: 0,
+				toJSON: () => ( {} ),
+			} ) as DOMRect,
+	} );
+	Object.defineProperty( desktop, 'clientWidth', {
+		value: 1600,
+		configurable: true,
+	} );
+	Object.defineProperty( desktop, 'clientHeight', {
+		value: 900,
+		configurable: true,
+	} );
+	return desktop;
+}
+
+/**
+ * jsdom implements no CSS animations and ships no `AnimationEvent`
+ * constructor, so build the event by hand: a plain `Event` of the
+ * right type carrying an `animationName`. That is the whole surface
+ * the listener reads (`event.type`, `event.target`,
+ * `event.animationName`).
+ */
+function animationEvent(
+	type: 'animationend' | 'animationcancel',
+	animationName: string,
+	bubbles = false,
+): Event {
+	const event = new Event( type, { bubbles } );
+	Object.defineProperty( event, 'animationName', {
+		value: animationName,
+		configurable: true,
+	} );
+	return event;
+}
+
+/** Force `document.hidden` for the duration of one test. */
+function setHidden( hidden: boolean ): void {
+	Object.defineProperty( document, 'hidden', {
+		value: hidden,
+		configurable: true,
+	} );
+}
+
+describe( 'WindowManager.focus() — argument guard', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+	let warn: ReturnType< typeof vi.spyOn >;
+
+	beforeEach( () => {
+		installHooksStub();
+		setHidden( false );
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+		warn = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		warn.mockRestore();
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'focuses by window id', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+		expect( b.isFocused() ).toBe( true );
+
+		manager.focus( 'a' );
+
+		expect( a.isFocused() ).toBe( true );
+		expect( b.isFocused() ).toBe( false );
+	} );
+
+	test( 'an unknown id is a silent no-op and leaves focus intact', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+
+		expect( () => manager.focus( 'nope' ) ).not.toThrow();
+
+		expect( b.isFocused() ).toBe( true );
+		expect( a.isFocused() ).toBe( false );
+		// A closed-window race is routine, not a programming error.
+		expect( warn ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a bad argument does not poison the stack for later focus calls', async () => {
+		const a = await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+
+		// The regression: this pushed a junk entry, then threw on it
+		// here and on every subsequent focus() call.
+		expect( () =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			manager.focus( { id: 'fake' } as any ),
+		).not.toThrow();
+
+		// The stack still holds exactly the two real windows...
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [ 'a', 'b' ] );
+		// ...and normal focusing still works, which is the part that
+		// used to be permanently broken.
+		expect( () => manager.focus( a ) ).not.toThrow();
+		expect( a.isFocused() ).toBe( true );
+		expect( () => manager.focus( b ) ).not.toThrow();
+		expect( b.isFocused() ).toBe( true );
+		expect( warn ).toHaveBeenCalled();
+	} );
+
+	test( 'unknown ids stay no-ops for raise() too', async () => {
+		await manager.open( cfg( 'a' ) );
+		const b = await manager.open( cfg( 'b' ) );
+
+		expect( () => manager.raise( 'nope' ) ).not.toThrow();
+
+		expect( manager.getAll().map( ( w ) => w.id ) ).toEqual( [ 'a', 'b' ] );
+		expect( b.isFocused() ).toBe( true );
+	} );
+} );
+
+describe( 'Window — the opening class always comes off', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		setHidden( false );
+		vi.useFakeTimers();
+		desktop = makeDesktop();
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+		for ( const w of manager.getAll() ) {
+			w.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'the animation clears it', async () => {
+		const win = await manager.open( cfg( 'a' ) );
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			true,
+		);
+
+		win.element.dispatchEvent(
+			animationEvent( 'animationend', 'os-window-open' ),
+		);
+
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'a bubbling animation from the content does not claim the listener', async () => {
+		const win = await manager.open( cfg( 'a' ) );
+		const body = win.element.querySelector(
+			'.os-window__body',
+		) as HTMLElement;
+		expect( body ).toBeTruthy();
+
+		// A spinner / shimmer / holo drift inside the window finishing
+		// first. `animationend` bubbles, so before the animationName +
+		// target filter this consumed the once-only listener and cut
+		// the open animation short.
+		body.dispatchEvent(
+			animationEvent( 'animationend', 'os-spinner-rotate', true ),
+		);
+
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			true,
+		);
+
+		win.element.dispatchEvent(
+			animationEvent( 'animationend', 'os-window-open' ),
+		);
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'animationcancel clears it', async () => {
+		const win = await manager.open( cfg( 'a' ) );
+
+		win.element.dispatchEvent(
+			animationEvent( 'animationcancel', 'os-window-open' ),
+		);
+
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'the timer clears it when no animation event ever arrives', async () => {
+		const win = await manager.open( cfg( 'a' ) );
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			true,
+		);
+
+		// The reported failure: no compositor, so no `animationend`,
+		// ever. The window stayed at the animation's `from` frame —
+		// present, focused, invisible.
+		vi.advanceTimersByTime( 1000 );
+
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'a window opened in a hidden document never gets the class', async () => {
+		setHidden( true );
+
+		const win = await manager.open( cfg( 'a' ) );
+
+		expect( win.element.classList.contains( 'os-window--opening' ) ).toBe(
+			false,
+		);
+	} );
+} );


### PR DESCRIPTION
Three related pieces of window-integrity work. The first two are fixes for reported bugs, both of which produced the same symptom — a window that is present, painted and unusable. The third is a new API that came out of the same conversation.

## `WindowManager.focus()` — argument guard

`focus()` took a `Window` with no runtime check, and pushed its argument onto `_stack` **before** calling `setZIndex()` across every member. So `focus( 'some-id' )` — the form [`javascript-reference.md`](docs/javascript-reference.md) and the comment in `src/built-in-commands.ts` already show — left a non-`Window` wedged in the stack, and *every later* `focus()` threw on it. Click-to-focus, dock activation and open-reuse were all dead until a reload, with nothing in the console pointing at the original bad call.

It now accepts `Window | string`, resolves ids, and rejects anything else **before** touching the stack. An unknown *id* stays a silent no-op, matching `raise()`: a window closing between the moment its id was captured and the moment focus is requested is a routine race, not a programming error. A non-Window, non-string argument warns.

Two corrections to the report this came from:

- **`raise()` is not affected.** It already takes a `string`, resolves via `getById()`, and returns early on `idx === -1`. The described `splice( -1, 1 )` on a miss cannot happen.
- **`conflict-toast.ts` was broken, but not by this.** It declared its own `declare global` asserting `window.openStation.windowManager.focus( id ) => Window` — a global the shell never defines (the namespace is `wp.os`) with a signature that matches nothing. Optional chaining meant it never threw and never poisoned the stack; "View folder" just silently did nothing. `share-menu-items.ts` carried the identical fabricated global, calling a `close()` that doesn't exist on the manager either, so leaving a shared folder quietly left its window open. Both now go through `wp.os`, and the folder close goes through the `Window`, where `close()` actually lives.

## `.os-window--opening` always comes off

Removal hung on a single once-only, unfiltered `animationend` listener. Two ways that fails:

1. **`animationend` bubbles.** A spinner, shimmer or holo drift finishing anywhere inside the window body consumed the listener and cut the open animation short.
2. **A hidden document never advances the animation**, so the event never arrives at all. The class is not cosmetic — its animation's `from` frame is `opacity: 0; scale(0.92)` — so a window opened in a backgrounded tab (session restore the user tabs away from, an `os-open-requested` from another surface, automation) stays painted invisible.

Now filtered on `animationName` + `target`, paired with `animationcancel`, backed by a timeout deadline, and skipped outright while `document.hidden` — nothing to animate for a document nobody is watching, so the stuck state can't arise at the source.

One correction here too: `.os-window--opening` carries **no `pointer-events: none`** in our CSS, and neither do unfocused windows. The reported "unclickable" framing isn't ours — that's either the third-party plugin's own CSS or the focus-stack poisoning above. The stuck-class hazard is real regardless; it just makes the window *invisible* rather than inert.

## New: child windows

`openChild( parentWindowId, config )` opens a **real** window — own chrome, drag, resize, minimize, taskbar entry — with one rule layered on top: **its owner can never sit above it.** Clicking the owner shakes the child and leaves focus there.

For the shapes a modal dialog gets reached for when what you actually want is a window: a full editor for one row of a list, a wizard beside the page it configures, a diff over the revision it belongs to.

```js
await wp.os.windowManager.openChild( 'edit-post-42', {
    id: 'my-plugin-seo-audit-42',
    url: '#seo-audit-42',
    title: 'SEO audit',
    icon: 'dashicons-chart-line',
    native: true,
    render: ( body ) => { /* … */ },
} );
```

The owner stays **fully usable** — scrollable, draggable, resizable, minimizable. Only its z-order is constrained; that's the reason to use a window rather than a dialog in the first place. The redirect lives inside `focus()`, so click-to-focus, dock, taskbar, alt-tab and open-reuse are covered by construction rather than per call site.

Surface: `openChild`, `ownerOf`, `childrenOf`, `blockingChildOf`, the `os-window-child-blocked` event, the `os.window.child-blocked` action, and `WindowConfig.parentWindowId` as the primitive.

Behaviors, each with a test:

| | |
|---|---|
| **Chains** | A child can own a child; focus goes to the deepest link. |
| **Close** | Closing an owner closes its children. A child with unsaved changes still gets to veto and becomes an ordinary window — better than discarding the user's work. |
| **Minimize** | Cascades down, and restore brings back *only* what the cascade put away. A child the user minimized themselves stays minimized. |
| **Minimized children** | Stop blocking. The user put it away on purpose, so the owner is theirs again. |
| **Session** | Children are excluded from snapshots, so a reload can't restore a child blocking an owner that failed to come back. |

Two subtleties carry comments where they live: the ownership stack pass **exempts minimized windows**, or hoisting an invisible child to the top would make `setFocused( i === length - 1 )` hand focus to a window nobody can see; and `blockingChildOf` carries a **cycle guard**, since a plugin declaring A-owns-B-owns-A would otherwise spin on the first click.

## Testing

28 new tests in `tests/vitest/window-focus-guard-and-opening-class.test.ts` and `tests/vitest/window-child-ownership.test.ts`.

- `npm run test:js` — 4458 pass
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — run

No PHP touched.

**Worth a manual pass before merge:** that the opening animation still looks right on an ordinary open, and that a child window's shake-on-blocked-focus reads as helpful rather than annoying. Those two are feel, not logic, and no browser was driven for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-615-a6fef11e2402eacbd623e5a3e18db41d805683cf.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->