### PR TITLE
Files: make the conflict toast's "View folder" actually open the folder

### DIFF
--- a/docs/folder-sharing.md
+++ b/docs/folder-sharing.md
@@ -286,6 +286,14 @@ display names or folder names.
 The JS client throws `FilesConflictError` and the layer surfaces a
 toast: *"Alice moved this to 'Backlog' just now. [View folder]"*.
 
+**View folder** opens the destination folder's window — the same
+window a double-click on that folder's tile opens, because the action
+dispatches through the registered `folder` opener rather than building
+a window of its own. An already-open folder window is focused instead
+of reopened. The button follows the viewer-scoping above: when
+`current.parentId` degrades to `0` there is no folder to point at, so
+the toast carries the message alone.
+
 Clients that omit the header retain last-write-wins semantics for
 back-compat. The OpenStation shell always sends the header.
 

--- a/src/desktop-files/built-in-types.ts
+++ b/src/desktop-files/built-in-types.ts
@@ -16,6 +16,19 @@
 
 import { registerType } from './registry';
 
+/**
+ * The folder tile's icon, mirroring
+ * `OpenStation_Folder_File::icon()` on the PHP side.
+ *
+ * Same rationale as the labels above: the server sends this on every
+ * serialized placement, so anything rendering a folder the server
+ * described uses **that** value and never this one. This is the
+ * fallback for the one case where a folder has to be addressed
+ * without a placement to describe it — see `folderFileById()` in
+ * `folder-ref.ts`.
+ */
+export const FOLDER_FILE_ICON = 'dashicons-portfolio';
+
 export function registerBuiltInFileTypes(): void {
 	registerType( { type: 'shortcut', label: 'Plugin shortcut', sort: 1 } );
 	registerType( { type: 'folder', label: 'Folder', sort: 5 } );

--- a/src/desktop-files/conflict-toast.ts
+++ b/src/desktop-files/conflict-toast.ts
@@ -10,26 +10,8 @@
 
 import { showToast } from '../toast';
 import { FilesConflictError } from './rest';
-
-/**
- * Structural slice of the public window manager, read off `wp.os`.
- *
- * `window.openStation` — which an earlier version of this module
- * declared and reached for — is not a global the shell ever defines;
- * the public namespace is `wp.os`. The optional chaining meant the
- * mismatch never threw, it just made "View folder" a button that did
- * nothing.
- */
-interface WindowManagerSlice {
-	getById?: ( id: string ) => { id: string } | undefined;
-	focus?: ( winOrId: string ) => void;
-}
-
-function windowManager(): WindowManagerSlice | undefined {
-	return (
-		window.wp as { os?: { windowManager?: WindowManagerSlice } } | undefined
-	)?.os?.windowManager;
-}
+import { folderFileById } from './folder-ref';
+import { openFile } from './open';
 
 export function isConflict( err: unknown ): err is FilesConflictError {
 	return err instanceof FilesConflictError;
@@ -59,22 +41,30 @@ export function showConflictToast( err: FilesConflictError ): void {
 	const reason = buildReason( err );
 	const targetParentId = err.detail.current.parentId;
 	let action: { label: string; onClick: () => void } | undefined;
-	const winId = `os-folder-${ targetParentId }`;
-	const mgr = windowManager();
-	// Only offer the action when that folder's window is actually
-	// open, so the button always does something. Opening a folder
-	// window from scratch needs the full native render config that
-	// `built-in-openers` owns, and that isn't reachable from a
-	// `parentId` alone — the toast's message already names the
-	// folder for that case.
-	if (
-		targetParentId > 0 &&
-		typeof mgr?.focus === 'function' &&
-		mgr.getById?.( winId )
-	) {
+	// Folder 0 is the desktop root — already on screen, nothing to
+	// open, so no button. Every real folder gets one.
+	if ( targetParentId > 0 ) {
 		action = {
 			label: 'View folder',
-			onClick: () => mgr.focus?.( winId ),
+			// Dispatched through the ordinary opener registry, so the
+			// folder window this builds is the same one a double-click
+			// on the folder's tile builds — breadcrumb stack, split
+			// preview pane, "· Shared" title cue and all. Reusing the
+			// registered opener is also what makes an already-open
+			// folder window focus rather than reopen: `openFile()` ends
+			// at `windowManager.open()`, which reuses by id.
+			//
+			// `folderFileById` is the bridge from what a conflict knows
+			// (an id and a name) to what an opener wants (a
+			// DesktopFile).
+			onClick: () => {
+				void openFile(
+					folderFileById(
+						targetParentId,
+						err.detail.current.parentName,
+					),
+				);
+			},
 		};
 	}
 

--- a/src/desktop-files/folder-ref.ts
+++ b/src/desktop-files/folder-ref.ts
@@ -1,0 +1,98 @@
+/**
+ * OpenStation — Address a folder by id alone.
+ *
+ * Most code reaches a folder through the placement that renders it:
+ * the tile carries a server-serialized {@link DesktopFileShape}, and
+ * everything downstream — the opener registry, the window title, the
+ * icon — reads it from there.
+ *
+ * Some code only ever learns a folder's **id**. A 409 conflict says
+ * "someone moved this into folder 12"; a deep link names a folder
+ * nobody has a tile for. This module is the bridge for those: give it
+ * an id, get back a {@link DesktopFile} the normal machinery accepts,
+ * so `openFile()` opens a folder window through exactly the same
+ * registered opener a double-click goes through.
+ *
+ * Deliberately a leaf. It imports the store, the registry and the
+ * type constants and nothing else — no layer, no opener
+ * implementation — so callers on the far side of the files feature
+ * (`conflict-toast`, itself imported *by* `layer`) can use it without
+ * an import cycle.
+ */
+
+import { FOLDER_FILE_ICON } from './built-in-types';
+import { getFilesStore } from './store';
+import { resolve } from './registry';
+import type { DesktopFile } from './file';
+import type { DesktopFileShape } from './types';
+
+/**
+ * Find the server's own description of a folder among the placements
+ * currently in the store.
+ *
+ * Preferred over anything synthesized: it carries the real title and
+ * icon the server serialized, including whatever a plugin's
+ * `openstation_files_serialize_file` filter did to them. A folder the
+ * viewer has a tile for anywhere in loaded state — the common case,
+ * since a conflict arises from moving something around these very
+ * folders — resolves here.
+ *
+ * @param folderId Folder to describe.
+ * @return The server shape, or undefined when no loaded placement
+ *         represents this folder.
+ */
+function findServerShape( folderId: number ): DesktopFileShape | undefined {
+	const ref = String( folderId );
+	const { placementsByFolder } = getFilesStore().state;
+	for ( const placements of placementsByFolder.values() ) {
+		for ( const placement of placements ) {
+			if (
+				placement.file?.type === 'folder' &&
+				placement.file.ref === ref
+			) {
+				return placement.file as DesktopFileShape;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Build a {@link DesktopFile} for a folder from its id.
+ *
+ * Resolution order, best source first:
+ *   1. A loaded placement's server shape (real title + icon).
+ *   2. The folder row in the store (authoritative name, no icon).
+ *   3. `fallbackTitle`, then a generic label.
+ *
+ * `exists: true` is asserted rather than checked — the caller has an
+ * id because something server-side just referred to the folder. If it
+ * has since been deleted, the opener's own REST calls fail and report
+ * that; a client-side guess here would only ever be staler.
+ *
+ * @param folderId      Folder to address. Must be a positive id;
+ *                      folder 0 is the desktop root, which is not a
+ *                      window.
+ * @param fallbackTitle Title to use when neither the placements nor
+ *                      the folder rows in the store know this folder.
+ * @return A DesktopFile of type `folder`, ready for `openFile()`.
+ */
+export function folderFileById(
+	folderId: number,
+	fallbackTitle?: string,
+): DesktopFile {
+	const serverShape = findServerShape( folderId );
+	if ( serverShape ) {
+		return resolve( serverShape );
+	}
+
+	const row = getFilesStore().state.folders.get( folderId );
+	return resolve( {
+		type: 'folder',
+		ref: String( folderId ),
+		title: row?.name || fallbackTitle || 'Folder',
+		icon: FOLDER_FILE_ICON,
+		previewUrl: '',
+		exists: true,
+	} );
+}

--- a/tests/vitest/desktop-files-folder-ref.test.ts
+++ b/tests/vitest/desktop-files-folder-ref.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Addressing a folder by id alone — `folderFileById()` and the
+ * conflict toast's "View folder" action that depends on it.
+ *
+ * The toast learns about a folder from a 409 response: an id and a
+ * name, no tile, no serialized shape. It still has to open the same
+ * folder window a double-click on that folder's tile would open, and
+ * it gets there by building a `DesktopFile` and handing it to the
+ * ordinary opener registry rather than by reconstructing the window
+ * itself.
+ *
+ * These tests pin the resolution order (server shape > store row >
+ * caller fallback) and the dispatch — including that an already-open
+ * folder window is reused rather than rebuilt, which comes free from
+ * routing through the registered opener.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+type FolderRefModule = typeof import( '../../src/desktop-files/folder-ref' );
+type StoreModule = typeof import( '../../src/desktop-files/store' );
+type OpenersModule = typeof import( '../../src/desktop-files/openers' );
+type OpenModule = typeof import( '../../src/desktop-files/open' );
+type TypesModule = typeof import( '../../src/desktop-files/built-in-types' );
+type ConflictModule = typeof import( '../../src/desktop-files/conflict-toast' );
+type RestModule = typeof import( '../../src/desktop-files/rest' );
+type ToastModule = typeof import( '../../src/toast' );
+
+async function load(): Promise< {
+	folderRef: FolderRefModule;
+	store: StoreModule;
+	openers: OpenersModule;
+	open: OpenModule;
+	types: TypesModule;
+	conflict: ConflictModule;
+	rest: RestModule;
+	toast: ToastModule;
+} > {
+	vi.resetModules();
+	const modules = {
+		folderRef: await import( '../../src/desktop-files/folder-ref' ),
+		store: await import( '../../src/desktop-files/store' ),
+		openers: await import( '../../src/desktop-files/openers' ),
+		open: await import( '../../src/desktop-files/open' ),
+		types: await import( '../../src/desktop-files/built-in-types' ),
+		conflict: await import( '../../src/desktop-files/conflict-toast' ),
+		rest: await import( '../../src/desktop-files/rest' ),
+		toast: await import( '../../src/toast' ),
+	};
+	modules.types.registerBuiltInFileTypes();
+	return modules;
+}
+
+/** A server-serialized placement whose file IS the given folder. */
+function folderPlacement( folderId: number, title: string, icon: string ) {
+	return {
+		id: 900 + folderId,
+		parentId: 0,
+		x: 0,
+		y: 0,
+		sortOrder: 0,
+		updatedAtMs: 1,
+		meta: null,
+		file: {
+			type: 'folder',
+			ref: String( folderId ),
+			title,
+			icon,
+			previewUrl: '',
+			exists: true,
+		},
+	};
+}
+
+/**
+ * The files store is a `createSharedStore`, so it lives on a global
+ * and `vi.resetModules()` does NOT clear it — state would leak from
+ * one test into the next and a fallback assertion would read the
+ * previous test's placement. Reset it explicitly.
+ */
+async function resetStore(): Promise< void > {
+	const store = await import( '../../src/desktop-files/store' );
+	store.__resetFilesStoreForTests();
+}
+
+describe( 'folderFileById — resolution order', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		await resetStore();
+	} );
+
+	afterEach( async () => {
+		await resetStore();
+		clearHooksStub();
+	} );
+
+	test( "prefers the server's own shape from a loaded placement", async () => {
+		const { folderRef, store } = await load();
+		// A plugin's serialize filter renamed it and gave it a custom
+		// icon — the server is authoritative and we must not
+		// second-guess it.
+		store.setFolderPlacements( 0, [
+			folderPlacement( 12, 'Q3 Campaign', 'dashicons-megaphone' ),
+		] );
+
+		const file = folderRef.folderFileById( 12, 'ignored fallback' );
+
+		expect( file.type() ).toBe( 'folder' );
+		expect( file.ref() ).toBe( '12' );
+		expect( file.title() ).toBe( 'Q3 Campaign' );
+		expect( file.icon() ).toBe( 'dashicons-megaphone' );
+	} );
+
+	test( 'finds the placement wherever in the tree it is loaded', async () => {
+		const { folderRef, store } = await load();
+		// Nested, not on the desktop root — the search has to walk
+		// every loaded folder, not just folder 0.
+		store.setFolderPlacements( 7, [
+			folderPlacement( 12, 'Nested', 'dashicons-portfolio' ),
+		] );
+
+		expect( folderRef.folderFileById( 12 ).title() ).toBe( 'Nested' );
+	} );
+
+	test( 'falls back to the folder row name when no placement is loaded', async () => {
+		const { folderRef, store } = await load();
+		store.setFolders( [
+			{
+				id: 12,
+				ownerId: 1,
+				name: 'Named by the row',
+				shareMode: 'private',
+				shareMeta: null,
+				updatedAtMs: 1,
+			},
+		] );
+
+		const file = folderRef.folderFileById( 12, 'ignored fallback' );
+
+		expect( file.title() ).toBe( 'Named by the row' );
+		expect( file.icon() ).toBe( 'dashicons-portfolio' );
+	} );
+
+	test( "falls back to the caller's title when the store knows nothing", async () => {
+		const { folderRef } = await load();
+
+		const file = folderRef.folderFileById( 99, 'From the conflict' );
+
+		expect( file.ref() ).toBe( '99' );
+		expect( file.title() ).toBe( 'From the conflict' );
+	} );
+
+	test( 'still produces a usable file with no title at all', async () => {
+		const { folderRef } = await load();
+
+		const file = folderRef.folderFileById( 99 );
+
+		expect( file.type() ).toBe( 'folder' );
+		expect( file.title() ).toBeTruthy();
+	} );
+
+	test( 'ignores a placement of a different type with the same ref', async () => {
+		const { folderRef, store } = await load();
+		// Post 12 is not folder 12. Matching on ref alone would open a
+		// folder window titled after a post.
+		store.setFolderPlacements( 0, [
+			{
+				...folderPlacement( 12, 'A post', 'dashicons-admin-post' ),
+				file: {
+					type: 'post',
+					ref: '12',
+					title: 'A post',
+					icon: 'dashicons-admin-post',
+					previewUrl: '',
+					exists: true,
+				},
+			},
+		] );
+
+		expect( folderRef.folderFileById( 12, 'Real folder' ).title() ).toBe(
+			'Real folder',
+		);
+	} );
+
+	test( 'the fallback icon matches the folder type', async () => {
+		const { folderRef, types } = await load();
+
+		expect( folderRef.folderFileById( 5 ).icon() ).toBe(
+			types.FOLDER_FILE_ICON,
+		);
+	} );
+} );
+
+describe( 'conflict toast — "View folder" dispatches through the opener', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		await resetStore();
+	} );
+
+	afterEach( async () => {
+		await resetStore();
+		clearHooksStub();
+		document.body.replaceChildren();
+	} );
+
+	/** Build a 409 the REST client would have thrown. */
+	function conflictError(
+		rest: RestModule,
+		parentId: number,
+		parentName = 'Somewhere else',
+	) {
+		return new rest.FilesConflictError( {
+			actor: { id: 2, name: 'Ada' },
+			reason: 'moved',
+			current: {
+				parentId,
+				parentName,
+			},
+		} as never );
+	}
+
+	/**
+	 * Capture the toast's action button instead of rendering it —
+	 * `<os-toast>` lives in the lazily loaded overlays bundle, and the
+	 * action's behavior is what these tests are about.
+	 */
+	function captureAction( toast: ToastModule ) {
+		const captured: { label: string; onClick: () => void }[] = [];
+		const spy = vi
+			.spyOn( toast, 'showToast' )
+			.mockImplementation( ( opts ) => {
+				if ( opts.action ) {
+					captured.push( opts.action );
+				}
+				return () => undefined;
+			} );
+		return { captured, spy };
+	}
+
+	test( 'opens the folder window through the registered folder opener', async () => {
+		const { conflict, openers, open, rest, toast, store } = await load();
+		store.setFolderPlacements( 0, [
+			folderPlacement( 12, 'Q3 Campaign', 'dashicons-megaphone' ),
+		] );
+
+		const opened = vi.fn();
+		openers.registerOpener( {
+			id: 'test-folder-window',
+			label: 'Open folder',
+			types: [ 'folder' ],
+			isDefault: true,
+			sort: 1,
+			handler: { kind: 'js', open: opened },
+		} );
+		open.installOpenDeps( {
+			openUrl: () => true,
+			openNativeWindow: () => true,
+			deriveWindowId: ( url: string ) => url,
+		} );
+
+		const { captured } = captureAction( toast );
+		conflict.showConflictToast( conflictError( rest, 12 ) );
+
+		expect( captured ).toHaveLength( 1 );
+		expect( captured[ 0 ].label ).toBe( 'View folder' );
+
+		captured[ 0 ].onClick();
+		await vi.waitFor( () => expect( opened ).toHaveBeenCalled() );
+
+		// The opener received a real folder DesktopFile — which is what
+		// lets it build the same window a tile double-click builds,
+		// rather than the toast reconstructing one.
+		const file = opened.mock.calls[ 0 ][ 0 ];
+		expect( file.type() ).toBe( 'folder' );
+		expect( file.ref() ).toBe( '12' );
+		expect( file.title() ).toBe( 'Q3 Campaign' );
+	} );
+
+	test( 'offers no action for the desktop root', async () => {
+		const { conflict, rest, toast } = await load();
+
+		const { captured, spy } = captureAction( toast );
+		conflict.showConflictToast( conflictError( rest, 0 ) );
+
+		// Folder 0 is the desktop itself — already on screen.
+		expect( captured ).toHaveLength( 0 );
+		expect( spy ).toHaveBeenCalled();
+	} );
+
+	test( 'offers the action even when no folder window is open yet', async () => {
+		const { conflict, rest, toast } = await load();
+
+		const { captured } = captureAction( toast );
+		conflict.showConflictToast( conflictError( rest, 12, 'Archive' ) );
+
+		// The regression this replaces: the button was only offered
+		// when that folder's window already happened to be open, so in
+		// the common case the toast had no way to act on itself.
+		expect( captured ).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
Follow-up to #615, which left this one open deliberately.

## The bug

The conflict toast's **View folder** button has never worked, since the file was added in #217. It was written against `window.desktopMode.windowManager.focus( id )` — a global the shell has never defined, with a signature matching no method the manager has. The rebrand (#475) find-and-replaced it to `window.openStation` and carried the dead reference forward. Optional chaining meant it threw nothing and did nothing: the button rendered, the user clicked it, and the desktop sat there.

#615 routed it through the real `wp.os` namespace, but without a way to open a folder window from a `parentId` alone it could only offer the button when that folder's window happened to *already* be open. Correct, and never wrong — but the affordance vanished in the common case, which isn't what the original author intended.

## The fix

The missing piece was never the window. It was a way to **name a folder** that the existing machinery already accepts.

A 409 knows two things: a folder id and a folder name. The opener registry wants a `DesktopFile`. `folderFileById()` is that bridge — so the toast dispatches through the ordinary `openFile()` and gets the registered `folder` opener, which means the window it opens is *the same window a tile double-click opens*: breadcrumb route stack, split preview pane, `· Shared` title cue, all of it.

```js
onClick: () => {
    void openFile(
        folderFileById( targetParentId, err.detail.current.parentName ),
    );
},
```

Reuse of an already-open folder window comes free: `openFile()` ends at `windowManager.open()`, which reuses by id. So the focus-if-open case that #615 special-cased is now just the default behavior, with no branch for it.

**What this avoids:** duplicating the window-building logic, and equally, extracting the opener's ~300-line inline render closure into a shared module just to call it from one more place. Neither was necessary — the indirection to do this already existed.

## `folderFileById`

Resolution order, best source first:

1. **The server's own serialized shape**, found among any loaded placement for that folder — real title and icon, including whatever a plugin's `openstation_files_serialize_file` filter did to them. This is the common case: a conflict arises from moving something around these very folders, so a tile for the destination is usually in loaded state.
2. **The folder row** in the store (authoritative name).
3. **The caller's fallback title**, then a generic label.

It's deliberately a **leaf** — store, registry, type constants, nothing else. `conflict-toast` is imported *by* `layer`, so reaching the opener implementation directly would have been an import cycle (`conflict-toast → … → layer → conflict-toast`). Going through the registry inverts the dependency, which is what that registry is for. Verified: no rollup circular-dependency warnings.

The folder icon fallback lives in `built-in-types.ts`, next to the folder type registration — a file whose docblock already explains why the PHP metadata is mirrored there ("a hard-coded fallback keeps pickers usable in the brief gap before the payload arrives"). It's only ever reached when no server payload describes the folder.

Both modules were already in `desktop.min.js`, so this adds no bundle weight.

## Edge case worth noting

Folder `0` stays button-less — it's the desktop itself, already on screen. That also covers the viewer-scoping in the 409 contract, where `current.parentId` degrades to `0` for viewers outside the actor's collaboration scope, so an out-of-scope viewer gets the message with no button rather than a button pointing at a folder they can't see. Documented in `docs/folder-sharing.md`, which already promised this button existed.

## Testing

10 new tests in `tests/vitest/desktop-files-folder-ref.test.ts` — resolution order (including a placement of a *different type* sharing the same ref, which naive ref-matching would open a folder window titled after a post), and the dispatch asserted against a genuinely registered opener rather than a mocked `openFile`.

One trap the tests document: the files store is a `createSharedStore`, so it lives on a global and `vi.resetModules()` does **not** clear it. Without an explicit `__resetFilesStoreForTests()` the fallback assertions read the previous test's placement — which is how I found it.

- `npm run test:js` — 4477 pass
- `npm run lint` / `npm run typecheck` — clean
- `npm run build` — clean, no circular-dependency warnings

No PHP touched.

**Manual check worth doing:** trigger a real 409 (move a placement in a shared folder from a second browser session, then move it from the first) and confirm **View folder** opens the destination with its breadcrumb and preview pane intact. I haven't driven a browser for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-616-83fe469f2aa55beb5873db8df377bfaf0d07dfc2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->