### PR TITLE
Windows: make Reload a common action for native windows too

### DIFF
--- a/docs/examples/render-ctx.md
+++ b/docs/examples/render-ctx.md
@@ -84,6 +84,8 @@ The framework stores the ctx's disposer on the `Window` instance and runs it pre
 
 The user's render-returned teardown runs AFTER the closing animation. So async paths inside the teardown that branch on `signal.aborted` already see the flipped value.
 
+**Close is not the only unmount.** The ⋯ menu's **Reload** row (and `wp.os.windowManager.getById( id ).reload()`) runs the same disposal on a native window and then renders again into an emptied body with a brand-new `ctx`. The ordering differs in one way that matters: on reload the render-returned teardown runs **before** the body is emptied, so a teardown that reads its own DOM still finds it. Everything the framework tracks — `signal`, `ch.on`, `onResize`/`onHide`/`onShow` — is torn down for you either way; anything you registered *outside* the body needs the teardown to return it, or you leak a copy per reload.
+
 ## Backwards compatibility
 
 - Existing unary `( body ) => …` callbacks: continue to work. JS ignores the extra arg.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -957,11 +957,26 @@ Calling `open()` with an id (or `baseId`) that's already on screen focuses the e
 
 **URL-aware reuse**: focusing is the whole story only when the requested URL is one the window is already showing — its live iframe URL, the URL it was opened with, or its home / dock landing URL (`parentUrl`); the comparison ignores the chromeless / portal flags, `_wp_http_referer`, and param order. Any *other* URL is treated as a real navigation request: the existing iframe navigates to it in place (via `location.assign()`, so in-frame Back still works) instead of the URL being silently dropped. This is what makes action links routed through `open()` — e.g. the post-install **Activate** link `plugins.php?action=activate&plugin=…&_wpnonce=…` while a Plugins window is already open — actually execute. Dock clicks keep their old behavior: clicking a tile whose window has sub-navigated only focuses it (the tile's URL is the window's home URL), never yanks it back to the landing page. The `os-window-reopened` detail reports the outcome via `navigated`.
 
-**Title-bar actions menu (iframe windows).** Every iframe-backed window renders a three-dots actions menu on the leading edge of its title bar. Built-in items:
+**Title-bar actions menu.** Every window — iframe *and* native — renders a three-dots actions menu on the leading edge of its title bar. Built-in items:
 
-- **"Open on startup"** — checkable; toggles this window as the user's default-window preference.
+- **"Open on startup"** — checkable; toggles this window as the user's default-window preference. Both window types.
 - **"Open another <Page>"** — only when the window was opened with `multi: true`. Calls `openNew()` with the window's *original* landing URL.
-- **"Open in new window"** — opens a fresh sibling window seeded with the *current* iframe URL (post in-window navigation). Useful when the user has drilled into a sub-page (e.g. editing a specific post) and wants to peel a copy off without losing their place. The new window cascades and uses the same multi-instance id suffixing as `openNew()`.
+- **"Open in new window"** — iframe windows only. Opens a fresh sibling window seeded with the *current* iframe URL (post in-window navigation). Useful when the user has drilled into a sub-page (e.g. editing a specific post) and wants to peel a copy off without losing their place. The new window cascades and uses the same multi-instance id suffixing as `openNew()`.
+- **"Reload"** — both window types; see below.
+- **"Open in browser tab"** — iframe windows only. Strips the chromeless flags and hands the page to a classic admin tab. A native window has no URL to hand off.
+
+**Reload is common to both window types.** "Put this back the way it loaded" is the same intent whether the content came from an admin page or from a plugin's render callback, so `Window.reload()` and its ⋯ row work on native windows too.
+
+- **Iframe windows** reload the active frame (the foregrounded external sub-tab, if there is one) and clear the loading overlay on the bridge's `os-ready`.
+- **Native windows** re-run the render callback in place. The framework disposes the render context, runs the teardown the previous render returned (**before** emptying the body, so a teardown that reads its own DOM still finds it), empties the body, and calls `render( body, ctx )` again with a **fresh** context — new `signal`, new channel subscriptions — surrounded by the same `NATIVE_WINDOW_BEFORE_RENDER` / `NATIVE_WINDOW_AFTER_RENDER` pair a first open fires.
+
+  The window does **not** close and reopen: the id, geometry, focus, z-order, `params` and session entry all survive, and no `os.window.closed` / `os.window.opened` pair fires for something the user experienced as a refresh. A render returning a `Promise` keeps the loading overlay up until it settles, so a callback that refetches gets spinner-while-loading for free. A throwing teardown is contained — it reports through `os.shell.error` and the reload proceeds anyway.
+
+  The one native window with no Reload row is one registered with no `render` callback at all, where the action would do nothing.
+
+`os.window.reloaded` fires for both paths, with `url` carrying the reloaded iframe URL or — for native windows — the window's configured `url`.
+
+A reload requested while the window's content is still loading is ignored (for native windows, that means a promise-returning render that hasn't settled), so a double-click can't leave a resolving render writing into a body a newer one owns.
 
 **Multi-instance windows.** When `multi: true` is passed, the window gets the "Open another" item described above. `openNew()` always creates a fresh window — even when one with the same `baseId` is already open — assigning a suffixed id (`${baseId}-2`, `${baseId}-3`, …) so every instance can be tracked independently while the dock still groups them under the same icon.
 

--- a/docs/native-windows-proposal.md
+++ b/docs/native-windows-proposal.md
@@ -231,6 +231,9 @@ Every native window sees the same shipped lifecycle surface, delivered through t
 | **hidden** | Window minimized. | `ctx.onHide( fn )`. |
 | **visible** | Window restored. | `ctx.onShow( fn )`. |
 | **unmount** | Window closed. | `ctx.signal` (an `AbortSignal`) aborts, then the teardown function returned from render is called. |
+| **remount** | User picks **Reload** from the ⋯ menu (or a plugin calls `win.reload()`). | Unmount, then mount again — the body is emptied and the render callback runs against a **fresh** `ctx`. The window itself never closes: id, geometry, focus, `params` and session entry survive, and no close/open pair fires. |
+
+**Write render so it can run twice.** A reload puts a native window through unmount-then-mount on the same live `Window`, so anything the callback set up outside the body — a global listener, an interval, a subscription — has to come back through the teardown it returns, or it leaks one copy per reload. Anything wired to `ctx` (its `signal`, `ctx.window.on`, `onResize` / `onHide` / `onShow`) is disposed for you.
 
 The `ctx` object also exposes the window-scoped channel pair (`ctx.window.send` / `ctx.window.on`) and the loading-overlay controls (`ctx.markLoading()` / `ctx.markReady()`). To rename a window after data loads, use the window handle: `wp.os.windowManager.getById( id ).setTitle( title )`. See [`examples/render-ctx.md`](./examples/render-ctx.md) for the full contract.
 

--- a/src/window/dom.ts
+++ b/src/window/dom.ts
@@ -444,8 +444,8 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 	//   - Open another <Page>    — only when `config.multi`.
 	//   - Open in new window     — opens the current iframe URL as a
 	//                              fresh sibling.
-	//   - Reload                 — reloads the iframe (no-op for
-	//                              native windows; harmless to show).
+	//   - Reload                 — reloads the iframe, or re-runs the
+	//                              render callback of a native window.
 	//   - Open in browser tab    — detach to a classic admin tab.
 	//                              Iframe-only — skipped for native.
 	const menuBtn = document.createElement( 'os-window-button' );
@@ -513,10 +513,21 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 		menuPanel.appendChild( openInNew );
 	}
 
-	// "Reload" — was a built-in title-bar control. Moved
-	// here because it's an infrequent action that didn't earn the
-	// permanent real estate. No-op for native windows; safe to show.
-	if ( ! config.native ) {
+	// "Reload" — was a built-in title-bar control. Moved here because
+	// it's an infrequent action that didn't earn the permanent real
+	// estate.
+	//
+	// Common to BOTH window types: "put this back the way it loaded"
+	// is the same user intent whether the content came from an admin
+	// page or from a plugin's render callback, and a native window
+	// that has drifted (a stale list, a half-applied optimistic
+	// update) had no way back short of close-and-reopen. Iframes
+	// reload the frame; native windows tear the render down and run
+	// it again — see `Window.reload()`.
+	//
+	// The only native window that doesn't get the row is one with no
+	// render callback at all, where the action would do nothing.
+	if ( ! config.native || config.render ) {
 		const reload = document.createElement( 'os-menu-item' );
 		reload.setAttribute( 'role', 'menuitem' );
 		reload.setAttribute( 'value', 'reload' );
@@ -525,7 +536,9 @@ export function createWindowElement( config: WindowConfig ): HTMLElement {
 		reload.classList.add( 'os-window__menu-item--reload' );
 		reload.textContent = __( 'Reload' );
 		menuPanel.appendChild( reload );
+	}
 
+	if ( ! config.native ) {
 		// "Open in browser tab" — was the title bar's detach button.
 		// Strips chromeless params and opens the page in a classic
 		// admin tab. Iframe-only — native windows have no URL to

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -2109,24 +2109,26 @@ export class Window {
 	 * reload that preserves scroll position semantics; cross-origin
 	 * external tabs fall back to re-assigning `iframe.src`.
 	 *
-	 * No-op for native windows — they own their DOM directly and the
-	 * title-bar menu's Reload item is only built for iframe windows
-	 * (`dom.ts` skips it when `config.native`), but this guard keeps
-	 * the contract honest if the method is called by other code paths
-	 * in the future.
+	 * Native windows reload too — see {@link _reloadNative}. They have
+	 * no frame to refresh, so the equivalent is tearing the previous
+	 * render down and running the render callback again.
 	 */
 	public reload(): void {
-		if ( this.config.native ) {
-			return;
-		}
 		// Guard against double-clicks during an in-flight reload — a
 		// second `location.reload()` while the first is still hydrating
 		// can desync the chromeless bridge's `os-ready`
 		// handshake. The body's `--loading` class is the upstream
 		// signal set by `markContentLoading()` and cleared on the
-		// next `os-ready` postMessage.
+		// next `os-ready` postMessage. Native windows are held to the
+		// same rule: a promise-returning render is still in flight
+		// while the class is on, and re-entering would leave its
+		// resolution writing into a body a newer render owns.
 		const body = this.element.querySelector( '.os-window__body' );
 		if ( body?.classList.contains( 'os-window__body--loading' ) ) {
+			return;
+		}
+		if ( this.config.native ) {
+			this._reloadNative();
 			return;
 		}
 		// Resolve the target surface and its URL up-front, before any
@@ -2175,6 +2177,84 @@ export class Window {
 		doAction( HOOKS.WINDOW_RELOADED, {
 			windowId: this.id,
 			url: reloadedUrl,
+		} );
+	}
+
+	/**
+	 * Reload a native window by re-running its render callback.
+	 *
+	 * A native window has no frame to refresh, so "reload" means the
+	 * closest honest equivalent: dispose the render context, run the
+	 * teardown the previous render returned, empty the body, and call
+	 * {@link hydrateNative} again. What the plugin author gets is the
+	 * same lifecycle a fresh open runs — `NATIVE_WINDOW_BEFORE_RENDER`,
+	 * `render( body, ctx )` with a **new** `ctx` (new `signal`, new
+	 * channel subscriptions), `NATIVE_WINDOW_AFTER_RENDER` — against
+	 * the same live `Window`. The window itself does not close and
+	 * reopen: id, geometry, focus, z-order, params and session entry
+	 * all survive, and no `WINDOW_CLOSED` / `WINDOW_OPENED` pair fires
+	 * for something the user experienced as a refresh.
+	 *
+	 * Teardown runs before the body is emptied, not after, so a
+	 * teardown that reads its own DOM (detaching a listener, reading a
+	 * final scroll offset) still finds it. Both callbacks are
+	 * contained: a throwing teardown reports through `SHELL_ERROR` and
+	 * the reload proceeds, because a plugin's cleanup bug must not
+	 * cost the user the reload they asked for.
+	 *
+	 * The loading overlay is armed here and cleared by the readiness
+	 * signal `hydrateNative()` already emits — immediately on the next
+	 * frame for a synchronous render, on settle for a promise-returning
+	 * one. So a render that refetches shows a spinner for exactly as
+	 * long as the refetch takes, with no extra plumbing.
+	 */
+	private _reloadNative(): void {
+		if ( ! this.config.render ) {
+			return;
+		}
+		const body = this.element.querySelector(
+			'.os-window__body',
+		) as HTMLElement | null;
+		if ( ! body ) {
+			return;
+		}
+
+		if ( this._nativeRenderCtxDispose ) {
+			try {
+				this._nativeRenderCtxDispose();
+			} catch ( err ) {
+				doAction( HOOKS.SHELL_ERROR, {
+					scope: 'native-window-ctx-dispose',
+					id: this.id,
+					error: err,
+				} );
+			}
+			this._nativeRenderCtxDispose = null;
+		}
+		if ( this._nativeRenderTeardown ) {
+			try {
+				this._nativeRenderTeardown();
+			} catch ( err ) {
+				doAction( HOOKS.SHELL_ERROR, {
+					scope: 'native-window-teardown',
+					id: this.id,
+					error: err,
+				} );
+			}
+			this._nativeRenderTeardown = null;
+		}
+
+		body.replaceChildren();
+
+		// Click feedback first (independent of how long the render
+		// takes), then arm the overlay, then render, then notify —
+		// the same order the iframe path uses.
+		this._spinReloadButton();
+		this.markContentLoading();
+		this.hydrateNative();
+		doAction( HOOKS.WINDOW_RELOADED, {
+			windowId: this.id,
+			url: this.config.url ?? '',
 		} );
 	}
 

--- a/tests/vitest/native-window-reload.test.ts
+++ b/tests/vitest/native-window-reload.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for "Reload" as a common action across BOTH window types.
+ *
+ * The ⋯ menu's Reload row used to be built only for iframe windows,
+ * and `Window.reload()` early-returned for native ones — so a native
+ * window that had drifted (a stale list, a half-applied optimistic
+ * update) had no way back short of close-and-reopen, which loses the
+ * window's geometry, focus and session entry.
+ *
+ * Native reload re-runs the render callback in place: teardown, empty
+ * body, `hydrateNative()` again, with a fresh `NativeRenderContext`.
+ * The window itself never closes, so nothing downstream of
+ * `WINDOW_CLOSED` / `WINDOW_OPENED` sees a refresh as a lifecycle
+ * event.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { WindowManager } from '../../src/window-manager';
+import { HOOKS } from '../../src/hooks';
+import {
+	_resetWindowLoadingTransitionsForTests,
+	installWindowLoadingTransitions,
+} from '../../src/window/loading';
+import type { NativeRenderContext } from '../../src/types';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+
+/** Let the `requestAnimationFrame` readiness signal land. */
+const settle = (): Promise< void > =>
+	new Promise( ( resolve ) => {
+		requestAnimationFrame( () => resolve() );
+	} );
+
+describe( 'native-window reload', async () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( async () => {
+		installHooksStub();
+		desktop = document.createElement( 'div' );
+		Object.defineProperty( desktop, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		Object.defineProperty( desktop, 'clientWidth', {
+			value: 1600,
+			configurable: true,
+		} );
+		Object.defineProperty( desktop, 'clientHeight', {
+			value: 900,
+			configurable: true,
+		} );
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+		// The `--loading` body class is hook-driven. The shell boot
+		// installs the transitions once; without them here the class
+		// set at construction never clears and every `reload()` would
+		// hit the in-flight guard.
+		_resetWindowLoadingTransitionsForTests();
+		installWindowLoadingTransitions();
+	} );
+
+	afterEach( async () => {
+		for ( const win of manager.getAll() ) {
+			win.destroy();
+		}
+		desktop.remove();
+		clearHooksStub();
+	} );
+
+	test( 'the ⋯ menu carries a Reload row for a native window', async () => {
+		const win = await manager.open( {
+			id: 'reload-row',
+			url: '#reload-row',
+			title: 'Reload row',
+			native: true,
+			render: () => {},
+		} );
+
+		expect(
+			win?.element.querySelector( '.os-window__menu-item--reload' ),
+		).not.toBeNull();
+	} );
+
+	test( 'a native window with no render callback gets no Reload row', async () => {
+		const win = await manager.open( {
+			id: 'no-render',
+			url: '#no-render',
+			title: 'No render',
+			native: true,
+		} );
+
+		// Nothing to re-run — an inert row would be worse than none.
+		expect(
+			win?.element.querySelector( '.os-window__menu-item--reload' ),
+		).toBeNull();
+	} );
+
+	test( 'iframe windows keep their Reload row', async () => {
+		const win = await manager.open( {
+			id: 'iframe-reload-row',
+			url: '/wp-admin/edit.php',
+			title: 'Posts',
+		} );
+
+		expect(
+			win?.element.querySelector( '.os-window__menu-item--reload' ),
+		).not.toBeNull();
+	} );
+
+	test( 'reload() re-runs the render callback into an emptied body', async () => {
+		let renders = 0;
+		const win = await manager.open( {
+			id: 'rerender',
+			url: '#rerender',
+			title: 'Rerender',
+			native: true,
+			render: ( body ) => {
+				renders += 1;
+				const p = document.createElement( 'p' );
+				p.className = 'probe';
+				p.textContent = `render ${ renders }`;
+				body.appendChild( p );
+			},
+		} );
+		await settle();
+
+		expect( renders ).toBe( 1 );
+
+		win?.reload();
+		await settle();
+
+		expect( renders ).toBe( 2 );
+		// Emptied, not appended to — one probe, carrying the second
+		// render's text.
+		const probes = win?.element.querySelectorAll( '.probe' );
+		expect( probes?.length ).toBe( 1 );
+		expect( probes?.[ 0 ].textContent ).toBe( 'render 2' );
+	} );
+
+	test( 'the previous render’s teardown runs before the re-render, with its DOM still in place', async () => {
+		const order: string[] = [];
+		let sawOwnDomAtTeardown: boolean | null = null;
+
+		const win = await manager.open( {
+			id: 'teardown-order',
+			url: '#teardown-order',
+			title: 'Teardown order',
+			native: true,
+			render: ( body ) => {
+				order.push( 'render' );
+				const marker = document.createElement( 'span' );
+				marker.className = 'marker';
+				body.appendChild( marker );
+				return () => {
+					order.push( 'teardown' );
+					sawOwnDomAtTeardown =
+						body.querySelector( '.marker' ) !== null;
+				};
+			},
+		} );
+		await settle();
+
+		win?.reload();
+		await settle();
+
+		expect( order ).toEqual( [ 'render', 'teardown', 'render' ] );
+		expect( sawOwnDomAtTeardown ).toBe( true );
+	} );
+
+	test( 'the re-render gets a fresh ctx and the old signal aborts', async () => {
+		const signals: AbortSignal[] = [];
+		const win = await manager.open( {
+			id: 'fresh-ctx',
+			url: '#fresh-ctx',
+			title: 'Fresh ctx',
+			native: true,
+			render: ( _body, ctx?: NativeRenderContext ) => {
+				if ( ctx ) {
+					signals.push( ctx.signal );
+				}
+			},
+		} );
+		await settle();
+
+		win?.reload();
+		await settle();
+
+		expect( signals ).toHaveLength( 2 );
+		expect( signals[ 1 ] ).not.toBe( signals[ 0 ] );
+		// The first render's in-flight work is cancelled…
+		expect( signals[ 0 ].aborted ).toBe( true );
+		// …and the replacement starts live.
+		expect( signals[ 1 ].aborted ).toBe( false );
+	} );
+
+	test( 'a throwing teardown still lets the reload through', async () => {
+		let renders = 0;
+		const errors: unknown[] = [];
+		window.wp?.hooks?.addAction(
+			HOOKS.SHELL_ERROR,
+			'test/native-reload',
+			( payload: unknown ) => {
+				errors.push( payload );
+			},
+		);
+
+		const win = await manager.open( {
+			id: 'bad-teardown',
+			url: '#bad-teardown',
+			title: 'Bad teardown',
+			native: true,
+			render: () => {
+				renders += 1;
+				return () => {
+					throw new Error( 'teardown blew up' );
+				};
+			},
+		} );
+		await settle();
+
+		win?.reload();
+		await settle();
+
+		// A plugin's cleanup bug must not cost the user their reload.
+		expect( renders ).toBe( 2 );
+		expect( errors.length ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'reload() fires WINDOW_RELOADED for a native window', async () => {
+		const payloads: Array< { windowId: string } > = [];
+		window.wp?.hooks?.addAction(
+			HOOKS.WINDOW_RELOADED,
+			'test/native-reload',
+			( payload: unknown ) => {
+				payloads.push( payload as { windowId: string } );
+			},
+		);
+
+		const win = await manager.open( {
+			id: 'reload-hook',
+			url: '#reload-hook',
+			title: 'Reload hook',
+			native: true,
+			render: () => {},
+		} );
+		await settle();
+
+		win?.reload();
+		await settle();
+
+		expect( payloads.map( ( p ) => p.windowId ) ).toContain(
+			'reload-hook',
+		);
+	} );
+
+	test( 'reload() does not close and reopen the window', async () => {
+		let closes = 0;
+		window.wp?.hooks?.addAction(
+			HOOKS.WINDOW_CLOSED,
+			'test/native-reload',
+			() => {
+				closes += 1;
+			},
+		);
+
+		const win = await manager.open( {
+			id: 'no-lifecycle',
+			url: '#no-lifecycle',
+			title: 'No lifecycle',
+			native: true,
+			render: () => {},
+		} );
+		await settle();
+		const elementBefore = win?.element;
+
+		win?.reload();
+		await settle();
+
+		expect( closes ).toBe( 0 );
+		// Same live instance, same element — geometry, focus and the
+		// session entry all ride through untouched.
+		expect( manager.getById( 'no-lifecycle' ) ).toBe( win );
+		expect( win?.element ).toBe( elementBefore );
+	} );
+
+	test( 'emptying the body does not cost the window its loading overlay', async () => {
+		// The body holds framework-owned children besides the render
+		// output — the loading overlay and the reveal layers. Emptying
+		// it takes those with it; `markContentLoading()` has to run
+		// after the wipe so the `WINDOW_CONTENT_LOADING` subscriber
+		// rebuilds both. Get the order wrong and a native window loses
+		// its spinner for good on the first reload.
+		const win = await manager.open( {
+			id: 'overlay-survives',
+			url: '#overlay-survives',
+			title: 'Overlay survives',
+			native: true,
+			render: () => {},
+		} );
+		await settle();
+
+		win?.reload();
+
+		// Checked synchronously — the overlay belongs to the load that
+		// is running right now, not to whatever is left after it.
+		const body = win?.element.querySelector( '.os-window__body' );
+		expect( body?.querySelector( '.os-window__loading' ) ).not.toBeNull();
+	} );
+
+	test( 'reload() is ignored while a render is still in flight', async () => {
+		let renders = 0;
+		const win = await manager.open( {
+			id: 'in-flight',
+			url: '#in-flight',
+			title: 'In flight',
+			native: true,
+			render: () => {
+				renders += 1;
+			},
+		} );
+		await settle();
+
+		// Re-arm the loading overlay the way a plugin doing
+		// event-listener-based async loading would.
+		win?.markContentLoading();
+		win?.reload();
+		await settle();
+
+		expect( renders ).toBe( 1 );
+	} );
+} );


### PR DESCRIPTION
## What

The ⋯ menu's **Reload** row was built only for iframe windows (`dom.ts` skipped it when `config.native`), and `Window.reload()` early-returned for native windows. A native window that had drifted — a stale list, a half-applied optimistic update — had no way back short of close-and-reopen, which loses the window's geometry, focus and session entry.

"Put this back the way it loaded" is the same user intent whichever way the content got there, so Reload now spans **both** window types.

- **Iframe windows** — unchanged: reload the active frame (the foregrounded external sub-tab, if there is one).
- **Native windows** — re-run the render callback in place: dispose the render context, run the previous render's teardown, empty the body, `hydrateNative()` again with a **fresh** `ctx` (new `signal`, new channel subscriptions), surrounded by the same `NATIVE_WINDOW_BEFORE_RENDER` / `NATIVE_WINDOW_AFTER_RENDER` pair a first open fires.

## Decisions worth reviewing

- **The window never closes.** Id, geometry, focus, z-order, `params` and session entry all survive, and no `WINDOW_CLOSED` / `WINDOW_OPENED` pair fires for something the user experienced as a refresh. `WINDOW_RELOADED` fires for both paths.
- **Teardown runs *before* the body is emptied**, so a teardown that reads its own DOM (detaching a listener, reading a final scroll offset) still finds it. This is the one ordering difference from close.
- **A throwing teardown is contained** — reports through `SHELL_ERROR`, and the reload proceeds. A plugin's cleanup bug must not cost the user the reload they asked for.
- **The in-flight guard now covers both types.** A promise-returning render that hasn't settled blocks a re-entry, so a double-click can't leave a resolving render writing into a body a newer one owns.
- **The only native window with no Reload row** is one registered with no `render` callback at all, where the action would do nothing.

## Sharp edge worth naming

The window body holds framework-owned children besides the render output — the loading overlay and the reveal layers. Emptying it takes those with it, so `markContentLoading()` has to run **after** the wipe for the `WINDOW_CONTENT_LOADING` subscriber to rebuild both. Reversed, a native window would silently lose its spinner for good on the first reload. There's a test pinning that ordering specifically.

## Docs

Updated in the same change:

- `docs/javascript-reference.md` — the ⋯ menu section, which had also been silently missing **Reload** and **"Open in browser tab"** from its built-in-items list, plus the per-type reload semantics.
- `docs/native-windows-proposal.md` — a **remount** row in the lifecycle table and a "write render so it can run twice" note.
- `docs/examples/render-ctx.md` — close is not the only unmount.

## Testing

New `tests/vitest/native-window-reload.test.ts` (11 tests): row presence per window type, re-render into an emptied body, teardown ordering + DOM visibility at teardown, fresh ctx with the old signal aborted, throwing teardown still reloads, `WINDOW_RELOADED` fires, no close/open lifecycle pair, in-flight guard, and the loading-overlay survival guard above.

`npm run typecheck` clean · `npm run lint` clean · `npm run build` clean · `npm run test:js` 4489 passed. No PHP touched.

## Manual QA

Open a native window (Files, Recycle Bin, OpenStation Preferences) → ⋯ → **Reload**. Content re-renders in place; the window stays exactly where it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-619-58203b695e4a92df64c1a7fe15ca1caf902ff6fc.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->