### PR TITLE
Settings: open the Custom accent's colour wheel on its own swatch

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -567,21 +567,35 @@
  * The invisible anchor for the Custom accent's colour wheel.
  *
  * There is no visible colour field: picking the Custom swatch opens
- * the native picker directly, and the picker anchors to THIS input,
- * which `accent.ts` parks just under the swatch (absolute against
- * the section wrapper, measured at click time) before calling
- * showPicker(). Absolute rather than fixed because a dragged window
- * carries a transform, and a transform turns fixed positioning into
- * a lie while getBoundingClientRect keeps telling viewport truth.
+ * the native picker directly, and the picker anchors to THIS input.
+ * So the input is laid over the Custom swatch. The last cell of the
+ * accent row is its containing block and the input fills it exactly,
+ * so the wheel opens on the square it belongs to.
+ *
+ * Anchoring it in CSS rather than measuring it in JS is the whole
+ * fix: the browser places the popup from the box it has already laid
+ * out, so an input moved by an inline style in the same tick as
+ * showPicker() is placed from its PREVIOUS box, which put the wheel
+ * under the first swatch. A cell that owns the input has no such
+ * moment, and it survives resize and grid reflow for free.
+ *
+ * Absolute rather than fixed because a dragged window carries a
+ * transform, and a transform turns fixed positioning into a lie.
  *
  * It stays out of the tab order and off the accessibility tree: the
  * Custom swatch is the control, and activating it (pointer or
  * keyboard) is what opens the wheel.
  */
+.os-settings__accent-custom {
+	position: relative;
+	display: inline-flex;
+}
+
 .os-settings__accent-picker {
 	position: absolute;
-	width: 28px;
-	height: 1px;
+	inset: 0;
+	width: 100%;
+	height: 100%;
 	margin: 0;
 	padding: 0;
 	border: 0;

--- a/src/settings/sections/accent.ts
+++ b/src/settings/sections/accent.ts
@@ -5,10 +5,10 @@
  *
  * The last swatch is Custom, and it is not one of the presets: it
  * carries {@link CUSTOM_ACCENT_ID} and opens the native colour wheel
- * directly, anchored just under the swatch. A site's brand colour is
- * rarely one of ten we picked, and before this the only way to get
- * it was a PHP filter, which is not a thing you ask a person
- * choosing a wallpaper to write.
+ * on the swatch itself. A site's brand colour is rarely one of ten we
+ * picked, and before this the only way to get it was a PHP filter,
+ * which is not a thing you ask a person choosing a wallpaper to
+ * write.
  */
 
 import { __ } from '../../i18n';
@@ -35,29 +35,31 @@ export function buildAccentSection( ctx: SettingsCtx ): HTMLElement {
 	// refresh after plugin activation), the picker picks up the new
 	// values on the next repaint.
 	/*
-	 * Opens the native colour wheel anchored under the Custom swatch.
+	 * Opens the native colour wheel on the Custom swatch.
 	 *
-	 * The picker anchors to the input element's box, so the hidden
-	 * input is moved to sit just below the swatch before showPicker()
-	 * is called. Measured at click time rather than kept in place,
-	 * because the swatch's position changes with every window resize
-	 * and grid reflow, and a stale anchor opens the wheel somewhere
-	 * arbitrary (top corner of the screen, in practice).
+	 * Where the wheel appears is not something `showPicker()` takes an
+	 * argument for: it is a browser popup anchored to the box of the
+	 * `<input type="color">` it belongs to. So the input is laid out
+	 * over the Custom swatch in CSS (`.os-settings__accent-custom`
+	 * gives the cell its containing block, `.os-settings__accent-picker`
+	 * fills it) and the wheel follows the swatch for free, through
+	 * every window resize and grid reflow, with nothing to measure.
+	 *
+	 * It used to be measured and moved here instead, one line before
+	 * the call, and the wheel opened under the FIRST swatch: an inline
+	 * `left`/`top` written in the same tick leaves layout dirty, and
+	 * the popup is placed from the box the browser has already
+	 * computed: the input's static position, at the start of the row.
+	 * The DOM looked correct afterwards either way, which is what made
+	 * that one hard to see.
 	 */
 	const openWheel = (): void => {
-		const swatch = wrapper.querySelector< HTMLElement >(
-			`os-swatch[value='${ CUSTOM_ACCENT_ID }']`,
-		);
 		const input = wrapper.querySelector< HTMLInputElement >(
 			'.os-settings__accent-picker',
 		);
-		if ( ! swatch || ! input ) {
+		if ( ! input ) {
 			return;
 		}
-		const swatchRect = swatch.getBoundingClientRect();
-		const hostRect = wrapper.getBoundingClientRect();
-		input.style.left = `${ swatchRect.left - hostRect.left }px`;
-		input.style.top = `${ swatchRect.bottom - hostRect.top + 6 }px`;
 		try {
 			input.showPicker();
 		} catch {
@@ -100,9 +102,6 @@ export function buildAccentSection( ctx: SettingsCtx ): HTMLElement {
 	};
 
 	const wrapper = document.createElement( 'div' );
-	// The containing block for the hidden picker anchor; see
-	// `.os-settings__accent-picker` in os-settings.css.
-	wrapper.style.position = 'relative';
 	const paint = (): void => {
 		const isCustom = ctx.state.accent === CUSTOM_ACCENT_ID;
 		render(
@@ -128,25 +127,27 @@ export function buildAccentSection( ctx: SettingsCtx ): HTMLElement {
 								?selected=${ ctx.state.accent === a.id }
 							></os-swatch>`,
 						) }
-						<os-swatch
-							value=${ CUSTOM_ACCENT_ID }
-							label=${ __( 'Custom' ) }
-							preview=${ isCustom
-								? ctx.state.customAccent
-								: CUSTOM_PREVIEW }
-							size="small"
-							variant="accent"
-							?selected=${ isCustom }
-						></os-swatch>
+						<span class="os-settings__accent-custom">
+							<os-swatch
+								value=${ CUSTOM_ACCENT_ID }
+								label=${ __( 'Custom' ) }
+								preview=${ isCustom
+									? ctx.state.customAccent
+									: CUSTOM_PREVIEW }
+								size="small"
+								variant="accent"
+								?selected=${ isCustom }
+							></os-swatch>
+							<input
+								type="color"
+								class="os-settings__accent-picker"
+								tabindex="-1"
+								aria-hidden="true"
+								.value=${ ctx.state.customAccent }
+								@input=${ onCustomColor }
+							/>
+						</span>
 					</os-swatch-grid>
-					<input
-						type="color"
-						class="os-settings__accent-picker"
-						tabindex="-1"
-						aria-hidden="true"
-						.value=${ ctx.state.customAccent }
-						@input=${ onCustomColor }
-					/>
 				</os-section>
 			`,
 			wrapper,

--- a/tests/vitest/accent-custom-picker-anchor.test.ts
+++ b/tests/vitest/accent-custom-picker-anchor.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Accent color → the Custom swatch's colour wheel, and where it opens.
+ *
+ * The wheel is a browser popup and it anchors to the box of the
+ * `<input type="color">` it belongs to. There is no argument to
+ * `showPicker()` that says where to put it, so the only way to open it
+ * on the Custom swatch is for the input to BE on the Custom swatch.
+ *
+ * It used to be a sibling of the swatch grid that JS measured and moved
+ * with an inline `left`/`top` one line before calling `showPicker()`,
+ * and the wheel opened under the FIRST swatch: a style written in the
+ * same tick leaves layout dirty, and the popup is placed from the box
+ * the browser has already computed: the input's static position, at
+ * the start of the row. Nothing in the DOM looked wrong afterwards.
+ *
+ * jsdom has no layout, so these tests pin the two things that make the
+ * CSS anchor work and that a refactor could quietly undo: the input
+ * lives inside the Custom swatch's cell, and nothing writes inline
+ * coordinates onto it.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { buildAccentSection } from '../../src/settings/sections/accent';
+import { CUSTOM_ACCENT_ID } from '../../src/settings/constants';
+import type { SettingsCtx } from '../../src/settings/types';
+
+const CELL = '.os-settings__accent-custom';
+const PICKER = '.os-settings__accent-picker';
+
+function ctxStub(): SettingsCtx {
+	return {
+		state: { accent: 'pulse', customAccent: '#f252fc' },
+		save: vi.fn(),
+		apply: vi.fn(),
+	} as unknown as SettingsCtx;
+}
+
+/** Pick a swatch the way `<os-swatch>` does when a user clicks it. */
+function pick( el: HTMLElement, value: string ): void {
+	el.querySelector( 'os-swatch-grid' )!.dispatchEvent(
+		new CustomEvent( 'os-pick', {
+			detail: { value },
+			bubbles: true,
+			composed: true,
+		} ),
+	);
+}
+
+let showPicker: ReturnType< typeof vi.fn >;
+
+beforeEach( () => {
+	showPicker = vi.fn();
+	// jsdom ships no showPicker; the section falls back to click()
+	// without it, which would hide a broken call site.
+	(
+		HTMLInputElement.prototype as unknown as { showPicker: unknown }
+	 ).showPicker = showPicker;
+} );
+
+describe( 'the picker sits in the Custom swatch cell', () => {
+	test( 'the cell is the last item of the accent row', () => {
+		const el = buildAccentSection( ctxStub() );
+		const grid = el.querySelector( 'os-swatch-grid' )!;
+
+		const last = grid.lastElementChild!;
+		expect( last.matches( CELL ) ).toBe( true );
+		expect(
+			last.querySelector( 'os-swatch' )!.getAttribute( 'value' ),
+		).toBe( CUSTOM_ACCENT_ID );
+	} );
+
+	test( 'the colour input is inside that cell, not beside the grid', () => {
+		const el = buildAccentSection( ctxStub() );
+		const input = el.querySelector< HTMLInputElement >( PICKER )!;
+
+		expect( input.type ).toBe( 'color' );
+		expect( input.closest( CELL ) ).not.toBeNull();
+		// The old shape: a sibling of the grid, anchored to the section
+		// wrapper. Anything positioned against the wrapper is one
+		// reflow away from pointing at the wrong swatch.
+		expect( input.parentElement!.matches( CELL ) ).toBe( true );
+	} );
+
+	test( 'the input stays out of the tab order and the a11y tree', () => {
+		const el = buildAccentSection( ctxStub() );
+		const input = el.querySelector< HTMLInputElement >( PICKER )!;
+
+		// The Custom swatch is the control; the input is its anchor.
+		expect( input.getAttribute( 'tabindex' ) ).toBe( '-1' );
+		expect( input.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+	} );
+} );
+
+describe( 'picking Custom opens the wheel without moving anything', () => {
+	test( 'showPicker() is called on the anchored input', () => {
+		const el = buildAccentSection( ctxStub() );
+
+		pick( el, CUSTOM_ACCENT_ID );
+
+		expect( showPicker ).toHaveBeenCalledTimes( 1 );
+		expect( showPicker.mock.instances[ 0 ] ).toBe(
+			el.querySelector( PICKER ),
+		);
+	} );
+
+	test( 'no inline coordinates are written on the input', () => {
+		const el = buildAccentSection( ctxStub() );
+
+		pick( el, CUSTOM_ACCENT_ID );
+
+		const input = el.querySelector< HTMLInputElement >( PICKER )!;
+		expect( input.style.left ).toBe( '' );
+		expect( input.style.top ).toBe( '' );
+	} );
+
+	test( 'a preset leaves the wheel closed', () => {
+		const el = buildAccentSection( ctxStub() );
+
+		pick( el, 'teal' );
+
+		expect( showPicker ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'the stylesheet holds up its half', () => {
+	const css = readFileSync(
+		join( __dirname, '../../assets/css/os-settings.css' ),
+		'utf8',
+	);
+
+	test( 'the cell is a containing block and the input fills it', () => {
+		// Without `position` on the cell, the input resolves against
+		// whatever ancestor is positioned instead and lands somewhere
+		// arbitrary: the bug, back again, with the DOM still correct.
+		expect( css ).toMatch(
+			/\.os-settings__accent-custom\s*\{[^}]*position:\s*relative/,
+		);
+		expect( css ).toMatch(
+			/\.os-settings__accent-picker\s*\{[^}]*position:\s*absolute/,
+		);
+		expect( css ).toMatch(
+			/\.os-settings__accent-picker\s*\{[^}]*inset:\s*0/,
+		);
+	} );
+} );


### PR DESCRIPTION
## What

Open the Custom accent's colour wheel on the Custom swatch, instead of at the bottom left of the **Accent color** section.

| Before | After |
|---|---|
|<img width="1812" height="984" alt="Screenshot 2026-08-18 at 19 50 36" src="https://github.com/user-attachments/assets/f65476b9-2cb3-4522-b648-e75b0b7a9bf5" /> | <img width="1812" height="984" alt="Screenshot 2026-08-18 at 19 52 06" src="https://github.com/user-attachments/assets/9d75a78f-dce7-4c66-a2e9-06c45877c46b" /> |

The Custom swatch and its input now share a cell that is the last item of the accent row, anchored in CSS. The input is on the swatch from first paint, and it follows the swatch through window resize and grid reflow with nothing to measure.

## Testing Instructions

1. Open OpenStation Preferences, then Appearance, then **Accent color**.
2. Click the last swatch, Custom. The wheel should open on that square.
3. Pick a colour and confirm it applies to focused title bars, buttons and focus rings.
4. Narrow the window until the accent row wraps onto two lines, then click Custom again. The wheel should still open on the swatch.


