### PR TITLE
Redesign the WordPress Themes workspace

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -606,8 +606,14 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	border-radius: 7px;
 }
 
+/* Searching a library of one is noise, so the field goes away in Core's
+ * single-theme state. The general sibling combinator rather than `+`:
+ * themes.php emits `wp_admin_notice()` output between the search form and
+ * `.theme-browser` on `?activated`, `?deleted`, `?broken` and
+ * `?delete-active-child` — exactly the loads that follow activating or
+ * deleting a theme — which breaks strict adjacency. */
 .os-chromeless.themes-php
-	.search-form:has(+ .theme-browser .themes.single-theme) {
+	.search-form:has(~ .theme-browser .themes.single-theme) {
 	display: none;
 }
 

--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -491,3 +491,558 @@ html.wp-toolbar:has( body.os-chromeless ) {
 .os-chromeless .commands-command-menu {
 	display: none !important;
 }
+
+/* ---------------------------------------------------------------
+ * Appearance → Themes workspace
+ *
+ * Core's one-theme state renders the Theme Details dialog inline and
+ * removes its header. Inside a short desktop window that leaves a large,
+ * unexplained panel whose actions fall below the fold. Treat it as an
+ * active-site identity card instead: screenshot first, useful context at
+ * the side, and actions kept in the card's visible edge.
+ *
+ * With multiple installed themes the native cards become a deliberate
+ * library grid and Core's details view remains a dialog. All selectors are
+ * scoped to the chromeless Themes screen; the classic wp-admin page keeps
+ * Core's own presentation and the shell's palette cannot leak in here.
+ * --------------------------------------------------------------- */
+.os-chromeless.themes-php #wpbody-content {
+	padding: 16px;
+	background: #f6f7f7;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 32px;
+	margin: 0 0 16px;
+	padding: 20px 24px;
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 12px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	box-sizing: border-box;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro__copy {
+	max-width: 680px;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro__eyebrow {
+	margin: 0 0 5px;
+	color: var(--wp-admin-theme-color, #2271b1);
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	line-height: 1.4;
+	text-transform: uppercase;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro h1 {
+	margin: 0;
+	color: #1d2327;
+	font-size: clamp(22px, 2.8vw, 30px);
+	font-weight: 650;
+	letter-spacing: -0.025em;
+	line-height: 1.12;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro__copy > p:last-child {
+	max-width: 650px;
+	margin: 8px 0 0;
+	color: #50575e;
+	font-size: 13px;
+	line-height: 1.45;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro__count {
+	display: grid;
+	flex: 0 0 auto;
+	min-width: 104px;
+	margin: 0;
+	padding: 12px 16px;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 9px;
+	box-sizing: border-box;
+	text-align: center;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro__count strong {
+	color: #1d2327;
+	font-size: 24px;
+	font-weight: 650;
+	letter-spacing: -0.03em;
+	line-height: 1;
+}
+
+.os-chromeless.themes-php .openstation-themes-intro__count span {
+	margin-top: 5px;
+	color: #646970;
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	line-height: 1.25;
+	text-transform: uppercase;
+}
+
+.os-chromeless.themes-php .wrap {
+	margin: 0;
+}
+
+.os-chromeless.themes-php .search-form {
+	display: flex;
+	margin: 0 0 16px;
+	padding: 0;
+}
+
+.os-chromeless.themes-php .wp-filter-search {
+	width: min(320px, 100%);
+	min-height: 36px;
+	padding-inline: 12px;
+	background: #fff;
+	border-color: #8c8f94;
+	border-radius: 7px;
+}
+
+.os-chromeless.themes-php
+	.search-form:has(+ .theme-browser .themes.single-theme) {
+	display: none;
+}
+
+/* Installed-theme library. The Add Theme destination already has its own
+ * persistent window tab, so Core's duplicate dashed card is unnecessary. */
+.os-chromeless.themes-php .theme-browser .themes:not(.single-theme) {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
+	gap: 18px;
+	clear: both;
+}
+
+.os-chromeless.themes-php .theme-browser .themes:not(.single-theme) > .theme {
+	float: none;
+	width: auto;
+	margin: 0;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 10px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	overflow: hidden;
+	transition:
+		border-color 120ms ease,
+		box-shadow 120ms ease,
+		transform 120ms ease;
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	> .theme:hover,
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	> .theme.focus {
+	border-color: #8c8f94;
+	box-shadow: 0 7px 20px rgba(0, 0, 0, 0.1);
+	transform: translateY(-2px);
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	> .theme.active {
+	border-color: var(--wp-admin-theme-color, #2271b1);
+	box-shadow:
+		0 0 0 1px var(--wp-admin-theme-color, #2271b1),
+		0 7px 20px rgba(0, 0, 0, 0.08);
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	> .add-new-theme {
+	display: none;
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	.theme-screenshot {
+	background: #f0f0f1;
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	.theme-id-container {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 58px;
+	background: #fff;
+}
+
+.os-chromeless.themes-php .theme-browser .themes:not(.single-theme) .theme-name,
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	.theme.active
+	.theme-name {
+	flex: 1 1 auto;
+	height: auto;
+	min-width: 0;
+	margin: 0;
+	padding: 14px 12px 14px 14px;
+	background: #fff;
+	box-shadow: none;
+	color: #1d2327;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	.theme.active
+	.theme-name
+	span {
+	display: block;
+	margin-bottom: 2px;
+	color: var(--wp-admin-theme-color, #2271b1);
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	.theme-actions,
+.os-chromeless.themes-php
+	.theme-browser
+	.themes:not(.single-theme)
+	.theme.active
+	.theme-actions {
+	display: flex;
+	align-items: center;
+	flex: 0 0 auto;
+	position: static;
+	opacity: 1;
+	padding: 10px 12px 10px 0;
+	background: #fff;
+	border: 0;
+	box-shadow: none;
+	transform: none;
+}
+
+/* Multiple-theme details remain a modal, but fit the iframe rather than
+ * reserving the classic admin sidebar's 160px gutter. */
+.os-chromeless.themes-php .theme-overlay.active .theme-backdrop {
+	position: fixed;
+	left: 0;
+	background: rgba(29, 35, 39, 0.62);
+	backdrop-filter: blur(2px);
+}
+
+.os-chromeless.themes-php .theme-overlay.active .theme-wrap {
+	top: 18px;
+	right: 18px;
+	bottom: 18px;
+	left: 18px;
+	border: 1px solid #c3c4c7;
+	border-radius: 12px;
+	box-shadow: 0 20px 55px rgba(0, 0, 0, 0.28);
+	overflow: hidden;
+}
+
+.os-chromeless.themes-php .theme-overlay.active .theme-header {
+	background: #fff;
+}
+
+.os-chromeless.themes-php .theme-overlay.active .theme-about {
+	padding: 24px;
+}
+
+.os-chromeless.themes-php .theme-overlay.active .theme-actions {
+	justify-content: flex-end;
+	padding: 10px 16px 5px;
+}
+
+/* Single-theme mode is a workspace card, not a stranded modal. */
+.os-chromeless.themes-php .themes.single-theme {
+	display: block;
+	margin: 0;
+}
+
+.os-chromeless.themes-php .themes.single-theme .theme-overlay.active {
+	display: block;
+	position: static;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-backdrop,
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-header {
+	display: none;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-wrap {
+	display: grid;
+	grid-template-columns: minmax(320px, 0.95fr) minmax(300px, 1.05fr);
+	grid-template-rows: minmax(0, auto) auto;
+	grid-template-areas:
+		"screenshot info"
+		"screenshot actions";
+	column-gap: 28px;
+	row-gap: 14px;
+	align-items: start;
+	position: relative;
+	top: auto;
+	right: auto;
+	bottom: auto;
+	left: auto;
+	min-height: 0;
+	padding: 20px;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 12px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+	overflow: visible;
+	z-index: 10;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-about {
+	display: contents;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-screenshots {
+	grid-area: screenshot;
+	float: none;
+	width: 100%;
+	max-width: none;
+	margin: 0;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.screenshot {
+	background: #f0f0f1;
+	border: 0;
+	border-radius: 8px;
+	box-shadow: 0 0 0 1px #dcdcde;
+	overflow: hidden;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-info {
+	grid-area: info;
+	float: none;
+	width: auto;
+	max-height: 300px;
+	padding: 2px 10px 2px 0;
+	overflow: auto;
+	scrollbar-gutter: stable;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.current-label {
+	margin: 0 0 10px;
+	padding: 4px 9px;
+	background: #e7f5ed;
+	border: 1px solid #9ad7b5;
+	border-radius: 999px;
+	color: #0a5c36;
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	line-height: 1.4;
+	text-transform: uppercase;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-name {
+	margin: 0;
+	color: #1d2327;
+	font-size: clamp(25px, 3vw, 34px);
+	font-weight: 650;
+	letter-spacing: -0.03em;
+	line-height: 1.12;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-version {
+	margin-left: 8px;
+	color: #646970;
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-author {
+	margin: 8px 0 14px;
+	color: #646970;
+	font-size: 13px;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-autoupdate {
+	margin: 0 0 14px;
+	padding: 9px 10px;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 6px;
+	font-size: 12px;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-description {
+	margin: 0;
+	color: #3c434a;
+	font-size: 13px;
+	line-height: 1.55;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-tags,
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.parent-theme {
+	margin-top: 16px;
+	padding-top: 12px;
+	border-top-width: 1px;
+	color: #646970;
+	font-size: 11px;
+	line-height: 1.5;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-actions {
+	display: flex;
+	grid-area: actions;
+	align-items: center;
+	justify-content: flex-start;
+	position: static;
+	padding: 14px 0 0;
+	background: transparent;
+	border-top: 1px solid #dcdcde;
+	text-align: left;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-actions
+	> div {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 7px;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-actions
+	.button {
+	margin: 0;
+}
+
+@media (max-width: 760px) {
+	.os-chromeless.themes-php #wpbody-content {
+		padding: 12px;
+	}
+
+	.os-chromeless.themes-php .openstation-themes-intro {
+		align-items: flex-start;
+		gap: 16px;
+		padding: 16px;
+	}
+
+	.os-chromeless.themes-php .openstation-themes-intro__copy > p:last-child {
+		display: none;
+	}
+
+	.os-chromeless.themes-php
+		.themes.single-theme
+		.theme-overlay.active
+		.theme-wrap {
+		grid-template-columns: minmax(0, 1fr);
+		grid-template-areas:
+			"screenshot"
+			"info"
+			"actions";
+		padding: 16px;
+	}
+
+	.os-chromeless.themes-php
+		.themes.single-theme
+		.theme-overlay.active
+		.theme-info {
+		max-height: none;
+		padding-right: 0;
+		overflow: visible;
+	}
+
+	.os-chromeless.themes-php .theme-overlay.active .theme-wrap {
+		top: 10px;
+		right: 10px;
+		bottom: 10px;
+		left: 10px;
+	}
+}
+
+@media (max-width: 480px) {
+	.os-chromeless.themes-php .openstation-themes-intro__count {
+		display: none;
+	}
+
+	.os-chromeless.themes-php .openstation-themes-intro h1 {
+		font-size: 21px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.os-chromeless.themes-php
+		.theme-browser
+		.themes:not(.single-theme)
+		> .theme {
+		transition: none;
+	}
+}

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -134,6 +134,8 @@ Core does not register `theme-install.php` as a submenu of `themes.php` — clas
 
 Resulting tab order: Appearance | Add Theme | Editor | Fonts | …
 
+The chromeless `themes.php` presentation also adapts Core's two native states without replacing its behavior. A single visible theme becomes a screenshot-led active-site workspace with its actions pinned beside the details, rather than Core's headerless inline Theme Details dialog. With multiple themes, the cards use a responsive library grid and Theme Details stays a closable modal sized to the iframe instead of reserving the classic admin sidebar gutter. The markup, actions, Backbone views, AJAX updates, and keyboard behavior remain Core-owned; the adaptation is page-scoped CSS plus a small orientation header emitted by `openstation_render_themes_workspace_intro()`.
+
 ### In-page "Add New" buttons that duplicate a window tab
 
 **File**: `includes/render/chromeless-title-actions.php`.

--- a/includes/themes-tabs.php
+++ b/includes/themes-tabs.php
@@ -75,6 +75,52 @@ function openstation_inject_appearance_tabs( $dock_item, $menu_slug ) {
 add_filter( 'openstation_dock_item', 'openstation_inject_appearance_tabs', 10, 2 );
 
 /**
+ * Renders the orientation header for the chromeless Themes workspace.
+ *
+ * Core's page heading is intentionally hidden inside OpenStation because the
+ * window chrome already names the screen. The Themes page still needs a little
+ * more context than a generic list screen, though: a theme changes the public
+ * face of the site, and Core's single-theme state otherwise opens directly on
+ * an unexplained details panel.
+ *
+ * The markup is emitted through `admin_notices`, which places it immediately
+ * before the page's `.wrap`. Core continues to own the theme cards, details
+ * overlay, actions, AJAX updates, and keyboard behavior.
+ */
+function openstation_render_themes_workspace_intro() {
+	if ( ! openstation_is_chromeless_request() ) {
+		return;
+	}
+	if ( ! isset( $GLOBALS['pagenow'] ) || 'themes.php' !== $GLOBALS['pagenow'] ) {
+		return;
+	}
+
+	$themes      = current_user_can( 'switch_themes' )
+		? wp_prepare_themes_for_js()
+		: wp_prepare_themes_for_js( array( wp_get_theme() ) );
+	$theme_count = count( $themes );
+	$count_label = sprintf(
+		/* translators: %s: Number of installed themes visible to the current user. */
+		_n( '%s theme installed', '%s themes installed', $theme_count, 'desktop-mode' ),
+		number_format_i18n( $theme_count )
+	);
+	?>
+	<section class="openstation-themes-intro" aria-labelledby="openstation-themes-intro-title">
+		<div class="openstation-themes-intro__copy">
+			<p class="openstation-themes-intro__eyebrow"><?php esc_html_e( 'Site appearance', 'desktop-mode' ); ?></p>
+			<h1 id="openstation-themes-intro-title"><?php esc_html_e( 'Choose how your site greets the world.', 'desktop-mode' ); ?></h1>
+			<p><?php esc_html_e( 'Your theme shapes the templates, typography, colours, and layout visitors see. Your posts and pages stay in place when you switch.', 'desktop-mode' ); ?></p>
+		</div>
+		<p class="openstation-themes-intro__count" aria-label="<?php echo esc_attr( $count_label ); ?>">
+			<strong aria-hidden="true"><?php echo esc_html( number_format_i18n( $theme_count ) ); ?></strong>
+			<span aria-hidden="true"><?php echo esc_html( _n( 'Theme installed', 'Themes installed', $theme_count, 'desktop-mode' ) ); ?></span>
+		</p>
+	</section>
+	<?php
+}
+add_action( 'admin_notices', 'openstation_render_themes_workspace_intro', 0 );
+
+/**
  * Fixes the visible "active tab" state inside chromeless
  * theme-install.php iframes.
  *

--- a/includes/themes-tabs.php
+++ b/includes/themes-tabs.php
@@ -86,24 +86,44 @@ add_filter( 'openstation_dock_item', 'openstation_inject_appearance_tabs', 10, 2
  * The markup is emitted through `admin_notices`, which places it immediately
  * before the page's `.wrap`. Core continues to own the theme cards, details
  * overlay, actions, AJAX updates, and keyboard behavior.
+ *
+ * The screen is identified by `get_current_screen()`, not `$pagenow`. Every
+ * page registered with `add_theme_page()` also reports `themes.php` as its
+ * `$pagenow`, but its body class comes from the hook suffix
+ * (`appearance_page_<slug>`) and so matches none of the workspace CSS, which
+ * is scoped to `.themes-php`. Gating on `$pagenow` would emit this header
+ * unstyled on top of unrelated Appearance screens. The screen ID also keeps
+ * network admin (`themes-network`, a different list table entirely) out.
  */
 function openstation_render_themes_workspace_intro() {
 	if ( ! openstation_is_chromeless_request() ) {
 		return;
 	}
-	if ( ! isset( $GLOBALS['pagenow'] ) || 'themes.php' !== $GLOBALS['pagenow'] ) {
+
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( ! $screen || 'themes' !== $screen->id ) {
 		return;
 	}
 
-	$themes      = current_user_can( 'switch_themes' )
-		? wp_prepare_themes_for_js()
-		: wp_prepare_themes_for_js( array( wp_get_theme() ) );
-	$theme_count = count( $themes );
-	$count_label = sprintf(
-		/* translators: %s: Number of installed themes visible to the current user. */
-		_n( '%s theme installed', '%s themes installed', $theme_count, 'desktop-mode' ),
-		number_format_i18n( $theme_count )
-	);
+	/*
+	 * Mirrors how `wp_prepare_themes_for_js()` builds its own list, without
+	 * paying for the preparation itself. Core already called that function
+	 * on this request before `admin-header.php` ran, and calling it again
+	 * would re-resolve every screenshot, tag and author URL and fire
+	 * `pre_prepare_themes_for_js` / `wp_prepare_themes_for_js` a second
+	 * time — so any third-party callback hanging off them would run twice
+	 * per page load. `wp_get_themes()` is cached, so this is a lookup.
+	 */
+	if ( current_user_can( 'switch_themes' ) ) {
+		$themes     = wp_get_themes( array( 'allowed' => true ) );
+		$stylesheet = get_stylesheet();
+		if ( ! isset( $themes[ $stylesheet ] ) ) {
+			$themes[ $stylesheet ] = wp_get_theme();
+		}
+		$theme_count = count( $themes );
+	} else {
+		$theme_count = 1;
+	}
 	?>
 	<section class="openstation-themes-intro" aria-labelledby="openstation-themes-intro-title">
 		<div class="openstation-themes-intro__copy">
@@ -111,9 +131,20 @@ function openstation_render_themes_workspace_intro() {
 			<h1 id="openstation-themes-intro-title"><?php esc_html_e( 'Choose how your site greets the world.', 'desktop-mode' ); ?></h1>
 			<p><?php esc_html_e( 'Your theme shapes the templates, typography, colours, and layout visitors see. Your posts and pages stay in place when you switch.', 'desktop-mode' ); ?></p>
 		</div>
-		<p class="openstation-themes-intro__count" aria-label="<?php echo esc_attr( $count_label ); ?>">
-			<strong aria-hidden="true"><?php echo esc_html( number_format_i18n( $theme_count ) ); ?></strong>
-			<span aria-hidden="true"><?php echo esc_html( _n( 'Theme installed', 'Themes installed', $theme_count, 'desktop-mode' ) ); ?></span>
+		<?php
+		/*
+		 * Left readable rather than labelled: `aria-label` is ignored on a
+		 * `<p>` (the paragraph role prohibits an author-supplied name), so
+		 * pairing it with `aria-hidden` children hid the count from
+		 * assistive tech entirely — and Core's own `.title-count` inside
+		 * the page `<h1>` is display:none in chromeless mode, making this
+		 * the only count on the screen. Read in DOM order the two spans
+		 * announce as "3 Themes installed" on their own.
+		 */
+		?>
+		<p class="openstation-themes-intro__count">
+			<strong><?php echo esc_html( number_format_i18n( $theme_count ) ); ?></strong>
+			<span><?php echo esc_html( _n( 'Theme installed', 'Themes installed', $theme_count, 'desktop-mode' ) ); ?></span>
 		</p>
 	</section>
 	<?php

--- a/tests/phpunit/tests/openStationInjectAppearanceTabs.php
+++ b/tests/phpunit/tests/openStationInjectAppearanceTabs.php
@@ -32,6 +32,18 @@ class Tests_OpenStation_InjectAppearanceTabs extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Unconditional cleanup: the chromeless flag and the opt-in meta are
+	 * request-global, so a mid-test failure would otherwise leak them into
+	 * every sibling test in the suite.
+	 */
+	public function tear_down() {
+		unset( $_GET['openstation_chromeless'], $GLOBALS['pagenow'] );
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+		set_current_screen( 'front' );
+		parent::tear_down();
+	}
+
+	/**
 	 * Helper: a minimal dock-item shape matching what
 	 * `openstation_build_dock_items()` hands to the filter.
 	 */
@@ -165,32 +177,60 @@ class Tests_OpenStation_InjectAppearanceTabs extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_themes_workspace_intro_only_renders_in_chromeless_themes_screen() {
-		$_GET['openstation_chromeless'] = '1';
-		$GLOBALS['pagenow']              = 'themes.php';
-		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
-
+	/**
+	 * Helper: renders the intro and returns the captured markup.
+	 */
+	private function capture_themes_workspace_intro() {
 		ob_start();
 		openstation_render_themes_workspace_intro();
-		$output = ob_get_clean();
+
+		return ob_get_clean();
+	}
+
+	public function test_themes_workspace_intro_renders_on_the_chromeless_themes_screen() {
+		$_GET['openstation_chromeless'] = '1';
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		set_current_screen( 'themes' );
+
+		$output = $this->capture_themes_workspace_intro();
 
 		$this->assertStringContainsString( 'class="openstation-themes-intro"', $output );
 		$this->assertStringContainsString( 'Choose how your site greets the world.', $output );
 		$this->assertStringContainsString( 'openstation-themes-intro__count', $output );
+	}
 
-		$GLOBALS['pagenow'] = 'plugins.php';
-		ob_start();
-		openstation_render_themes_workspace_intro();
-		$this->assertSame( '', ob_get_clean() );
+	/**
+	 * Pages registered with `add_theme_page()` share themes.php's `$pagenow`
+	 * but get their own hook-suffix body class, so none of the workspace CSS
+	 * (scoped to `.themes-php`) reaches them. Emitting the header there would
+	 * drop unstyled marketing copy on top of an unrelated Appearance screen.
+	 */
+	public function test_themes_workspace_intro_skips_appearance_subpages() {
+		$_GET['openstation_chromeless'] = '1';
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		set_current_screen( 'appearance_page_custom-header' );
 
-		unset( $_GET['openstation_chromeless'] );
+		// The condition that made the `$pagenow` gate wrong: an
+		// `add_theme_page()` screen reports themes.php as its $pagenow while
+		// carrying an `appearance_page_*` body class.
 		$GLOBALS['pagenow'] = 'themes.php';
-		ob_start();
-		openstation_render_themes_workspace_intro();
-		$this->assertSame( '', ob_get_clean() );
 
-		unset( $GLOBALS['pagenow'] );
-		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+		$this->assertSame( '', $this->capture_themes_workspace_intro() );
+	}
+
+	public function test_themes_workspace_intro_skips_unrelated_screens() {
+		$_GET['openstation_chromeless'] = '1';
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		set_current_screen( 'plugins' );
+
+		$this->assertSame( '', $this->capture_themes_workspace_intro() );
+	}
+
+	public function test_themes_workspace_intro_skips_non_chromeless_requests() {
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		set_current_screen( 'themes' );
+
+		$this->assertSame( '', $this->capture_themes_workspace_intro() );
 	}
 
 	/**

--- a/tests/phpunit/tests/openStationInjectAppearanceTabs.php
+++ b/tests/phpunit/tests/openStationInjectAppearanceTabs.php
@@ -13,6 +13,7 @@
  * @group openstation
  *
  * @covers ::openstation_inject_appearance_tabs
+ * @covers ::openstation_render_themes_workspace_intro
  * @covers ::openstation_theme_install_active_tab_script
  */
 class Tests_OpenStation_InjectAppearanceTabs extends WP_UnitTestCase {
@@ -155,6 +156,41 @@ class Tests_OpenStation_InjectAppearanceTabs extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 10, $priority );
+	}
+
+	public function test_themes_workspace_intro_is_registered_at_priority_zero() {
+		$this->assertSame(
+			0,
+			has_action( 'admin_notices', 'openstation_render_themes_workspace_intro' )
+		);
+	}
+
+	public function test_themes_workspace_intro_only_renders_in_chromeless_themes_screen() {
+		$_GET['openstation_chromeless'] = '1';
+		$GLOBALS['pagenow']              = 'themes.php';
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+
+		ob_start();
+		openstation_render_themes_workspace_intro();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'class="openstation-themes-intro"', $output );
+		$this->assertStringContainsString( 'Choose how your site greets the world.', $output );
+		$this->assertStringContainsString( 'openstation-themes-intro__count', $output );
+
+		$GLOBALS['pagenow'] = 'plugins.php';
+		ob_start();
+		openstation_render_themes_workspace_intro();
+		$this->assertSame( '', ob_get_clean() );
+
+		unset( $_GET['openstation_chromeless'] );
+		$GLOBALS['pagenow'] = 'themes.php';
+		ob_start();
+		openstation_render_themes_workspace_intro();
+		$this->assertSame( '', ob_get_clean() );
+
+		unset( $GLOBALS['pagenow'] );
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
 	}
 
 	/**

--- a/tests/vitest/wordpress-themes-workspace.test.ts
+++ b/tests/vitest/wordpress-themes-workspace.test.ts
@@ -68,14 +68,23 @@ describe("WordPress Themes workspace", () => {
 		);
 	});
 
-	test("the orientation header is gated to chromeless themes.php requests", () => {
+	test("the orientation header is gated to the chromeless Themes screen", () => {
 		expect(PHP).toContain(
 			"function openstation_render_themes_workspace_intro()",
 		);
-		expect(PHP).toContain("'themes.php' !== $GLOBALS['pagenow']");
 		expect(PHP).toContain(
 			"add_action( 'admin_notices', 'openstation_render_themes_workspace_intro', 0 )",
 		);
 		expect(PHP).toContain('class="openstation-themes-intro"');
+	});
+
+	/**
+	 * `$pagenow` is `themes.php` on every `add_theme_page()` screen too, but
+	 * those carry an `appearance_page_*` body class that matches none of the
+	 * CSS above — so the header must key off the screen ID, not `$pagenow`.
+	 */
+	test("the header keys off the screen ID rather than $pagenow", () => {
+		expect(PHP).toContain("'themes' !== $screen->id");
+		expect(PHP).not.toContain("'themes.php' !== $GLOBALS['pagenow']");
 	});
 });

--- a/tests/vitest/wordpress-themes-workspace.test.ts
+++ b/tests/vitest/wordpress-themes-workspace.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Contract checks for the chromeless Appearance → Themes redesign.
+ *
+ * WordPress owns this screen's dynamic markup, so the integration is kept
+ * deliberately shallow: one server-rendered orientation header and CSS that
+ * reshapes Core's single-theme, library, and details-dialog states. These
+ * assertions protect the page boundary and the behaviors that are easiest to
+ * accidentally lose during a future Core CSS adjustment.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const ROOT = resolve(__dirname, "../..");
+const CSS = readFileSync(resolve(ROOT, "assets/css/chromeless.css"), "utf8");
+const PHP = readFileSync(resolve(ROOT, "includes/themes-tabs.php"), "utf8");
+
+const WORKSPACE_MARKER = CSS.indexOf("Appearance → Themes workspace");
+const WORKSPACE_START = CSS.lastIndexOf("/*", WORKSPACE_MARKER);
+const WORKSPACE_CSS = CSS.slice(WORKSPACE_START);
+const COMPACT_WORKSPACE_CSS = WORKSPACE_CSS.replace(/\s+/g, " ");
+
+describe("WordPress Themes workspace", () => {
+	test("the redesign is present and cannot leak into classic admin", () => {
+		expect(WORKSPACE_START).toBeGreaterThan(-1);
+
+		const withoutComments = WORKSPACE_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+		const selectors = Array.from(
+			withoutComments.matchAll(/([^{}]+)\{/g),
+			(match) => match[1].trim(),
+		).filter((selector) => selector && !selector.startsWith("@"));
+
+		for (const selector of selectors) {
+			for (const part of selector.split(",")) {
+				expect(part.trim()).toMatch(/^\.os-chromeless\.themes-php\b/);
+			}
+		}
+	});
+
+	test("single-theme mode becomes a screenshot-led workspace with visible actions", () => {
+		expect(COMPACT_WORKSPACE_CSS).toContain(
+			".themes.single-theme .theme-overlay.active .theme-wrap",
+		);
+		expect(COMPACT_WORKSPACE_CSS).toContain('"screenshot info"');
+		expect(COMPACT_WORKSPACE_CSS).toContain('"screenshot actions"');
+		expect(COMPACT_WORKSPACE_CSS).toMatch(
+			/\.themes\.single-theme[^{]+\.theme-actions\s*\{[^}]*position:\s*static;/s,
+		);
+	});
+
+	test("multiple themes use a responsive grid and retain a fitted details dialog", () => {
+		expect(COMPACT_WORKSPACE_CSS).toContain(".themes:not(.single-theme)");
+		expect(COMPACT_WORKSPACE_CSS).toContain(
+			"grid-template-columns: repeat(auto-fit",
+		);
+		expect(COMPACT_WORKSPACE_CSS).toContain(
+			".theme-overlay.active .theme-header",
+		);
+		expect(COMPACT_WORKSPACE_CSS).toMatch(
+			/\.theme-overlay\.active \.theme-wrap\s*\{[^}]*left:\s*18px;/s,
+		);
+	});
+
+	test("the page keeps WordPress admin colours instead of shell theme tokens", () => {
+		expect(WORKSPACE_CSS).not.toContain("--os-ui-");
+		expect(COMPACT_WORKSPACE_CSS).toContain(
+			"var(--wp-admin-theme-color, #2271b1)",
+		);
+	});
+
+	test("the orientation header is gated to chromeless themes.php requests", () => {
+		expect(PHP).toContain(
+			"function openstation_render_themes_workspace_intro()",
+		);
+		expect(PHP).toContain("'themes.php' !== $GLOBALS['pagenow']");
+		expect(PHP).toContain(
+			"add_action( 'admin_notices', 'openstation_render_themes_workspace_intro', 0 )",
+		);
+		expect(PHP).toContain('class="openstation-themes-intro"');
+	});
+});


### PR DESCRIPTION
## Summary

- turn the WordPress Appearance → Themes screen into a screenshot-led active-site workspace when only one theme is visible
- replace the installed-theme float layout with a responsive library grid while preserving Core activation, preview, update, deletion, AJAX, keyboard, and modal behavior
- fit Theme Details to the OpenStation iframe instead of reserving the classic admin sidebar gutter
- add a compact, accessible orientation header plus narrow-window and reduced-motion treatments
- keep every visual rule scoped to chromeless themes.php and on WordPress admin colours, so classic wp-admin and desktop themes remain unchanged

## Test plan

- npm run build
- npm run lint
- npm run typecheck
- npm run test:js — 362 files / 4,501 tests passed
- vendor/bin/phpcs -n includes/themes-tabs.php tests/phpunit/tests/openStationInjectAppearanceTabs.php
- php -l includes/themes-tabs.php
- php -l tests/phpunit/tests/openStationInjectAppearanceTabs.php

Docker Desktop is unavailable locally, so the complete PHPUnit matrix and Plugin Check are left to CI.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-627-e55087c292fe146b40303f8c550496ba56d6d23e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->