### PR TITLE
Keep WordPress theme actions in the first view

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -515,9 +515,9 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 32px;
-	margin: 0 0 16px;
-	padding: 20px 24px;
+	gap: 24px;
+	margin: 0 0 12px;
+	padding: 14px 18px;
 	background: #fff;
 	border: 1px solid #dcdcde;
 	border-radius: 12px;
@@ -550,7 +550,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
 
 .os-chromeless.themes-php .openstation-themes-intro__copy > p:last-child {
 	max-width: 650px;
-	margin: 8px 0 0;
+	margin: 6px 0 0;
 	color: #50575e;
 	font-size: 13px;
 	line-height: 1.45;
@@ -561,7 +561,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	flex: 0 0 auto;
 	min-width: 104px;
 	margin: 0;
-	padding: 12px 16px;
+	padding: 10px 14px;
 	background: #f6f7f7;
 	border: 1px solid #dcdcde;
 	border-radius: 9px;
@@ -571,7 +571,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
 
 .os-chromeless.themes-php .openstation-themes-intro__count strong {
 	color: #1d2327;
-	font-size: 24px;
+	font-size: 22px;
 	font-weight: 650;
 	letter-spacing: -0.03em;
 	line-height: 1;
@@ -806,12 +806,8 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	.theme-wrap {
 	display: grid;
 	grid-template-columns: minmax(320px, 0.95fr) minmax(300px, 1.05fr);
-	grid-template-rows: minmax(0, auto) auto;
-	grid-template-areas:
-		"screenshot info"
-		"screenshot actions";
-	column-gap: 28px;
-	row-gap: 14px;
+	grid-template-areas: "screenshot details";
+	column-gap: 24px;
 	align-items: start;
 	position: relative;
 	top: auto;
@@ -819,7 +815,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	bottom: auto;
 	left: auto;
 	min-height: 0;
-	padding: 20px;
+	padding: 16px;
 	background: #fff;
 	border: 1px solid #c3c4c7;
 	border-radius: 12px;
@@ -861,10 +857,11 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	.themes.single-theme
 	.theme-overlay.active
 	.theme-info {
-	grid-area: info;
+	grid-area: details;
+	align-self: start;
 	float: none;
 	width: auto;
-	max-height: 300px;
+	max-height: 240px;
 	padding: 2px 10px 2px 0;
 	overflow: auto;
 	scrollbar-gutter: stable;
@@ -962,8 +959,9 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	.theme-overlay.active
 	.theme-actions {
 	display: flex;
-	grid-area: actions;
+	grid-area: details;
 	align-items: center;
+	align-self: end;
 	justify-content: flex-start;
 	position: static;
 	padding: 14px 0 0;
@@ -976,10 +974,18 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	.themes.single-theme
 	.theme-overlay.active
 	.theme-actions
-	> div {
+	.active-theme {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 7px;
+}
+
+.os-chromeless.themes-php
+	.themes.single-theme
+	.theme-overlay.active
+	.theme-actions
+	.inactive-theme {
+	display: none;
 }
 
 .os-chromeless.themes-php
@@ -1021,9 +1027,17 @@ html.wp-toolbar:has( body.os-chromeless ) {
 		.themes.single-theme
 		.theme-overlay.active
 		.theme-info {
+		grid-area: info;
 		max-height: none;
 		padding-right: 0;
 		overflow: visible;
+	}
+
+	.os-chromeless.themes-php
+		.themes.single-theme
+		.theme-overlay.active
+		.theme-actions {
+		grid-area: actions;
 	}
 
 	.os-chromeless.themes-php .theme-overlay.active .theme-wrap {

--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -507,7 +507,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
  * Core's own presentation and the shell's palette cannot leak in here.
  * --------------------------------------------------------------- */
 .os-chromeless.themes-php #wpbody-content {
-	padding: 16px;
+	padding: 10px 16px;
 	background: #f6f7f7;
 }
 
@@ -516,7 +516,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	align-items: center;
 	justify-content: space-between;
 	gap: 24px;
-	margin: 0 0 12px;
+	margin: 0 0 8px;
 	padding: 14px 18px;
 	background: #fff;
 	border: 1px solid #dcdcde;
@@ -815,7 +815,7 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	bottom: auto;
 	left: auto;
 	min-height: 0;
-	padding: 16px;
+	padding: 12px 16px;
 	background: #fff;
 	border: 1px solid #c3c4c7;
 	border-radius: 12px;

--- a/includes/themes-tabs.php
+++ b/includes/themes-tabs.php
@@ -129,7 +129,7 @@ function openstation_render_themes_workspace_intro() {
 		<div class="openstation-themes-intro__copy">
 			<p class="openstation-themes-intro__eyebrow"><?php esc_html_e( 'Site appearance', 'desktop-mode' ); ?></p>
 			<h1 id="openstation-themes-intro-title"><?php esc_html_e( 'Choose how your site greets the world.', 'desktop-mode' ); ?></h1>
-			<p><?php esc_html_e( 'Your theme shapes the templates, typography, colours, and layout visitors see. Your posts and pages stay in place when you switch.', 'desktop-mode' ); ?></p>
+			<p><?php esc_html_e( 'Themes shape your site’s look. Switching keeps your posts and pages in place.', 'desktop-mode' ); ?></p>
 		</div>
 		<?php
 		/*

--- a/tests/phpunit/tests/openStationInjectAppearanceTabs.php
+++ b/tests/phpunit/tests/openStationInjectAppearanceTabs.php
@@ -196,6 +196,7 @@ class Tests_OpenStation_InjectAppearanceTabs extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'class="openstation-themes-intro"', $output );
 		$this->assertStringContainsString( 'Choose how your site greets the world.', $output );
+		$this->assertStringContainsString( 'Switching keeps your posts and pages in place.', $output );
 		$this->assertStringContainsString( 'openstation-themes-intro__count', $output );
 	}
 

--- a/tests/vitest/wordpress-themes-workspace.test.ts
+++ b/tests/vitest/wordpress-themes-workspace.test.ts
@@ -41,10 +41,12 @@ describe("WordPress Themes workspace", () => {
 		expect(COMPACT_WORKSPACE_CSS).toContain(
 			".themes.single-theme .theme-overlay.active .theme-wrap",
 		);
-		expect(COMPACT_WORKSPACE_CSS).toContain('"screenshot info"');
-		expect(COMPACT_WORKSPACE_CSS).toContain('"screenshot actions"');
+		expect(COMPACT_WORKSPACE_CSS).toContain('"screenshot details"');
 		expect(COMPACT_WORKSPACE_CSS).toMatch(
 			/\.themes\.single-theme[^{]+\.theme-actions\s*\{[^}]*position:\s*static;/s,
+		);
+		expect(COMPACT_WORKSPACE_CSS).toMatch(
+			/\.theme-actions \.inactive-theme\s*\{[^}]*display:\s*none;/s,
 		);
 	});
 

--- a/tests/vitest/wordpress-themes-workspace.test.ts
+++ b/tests/vitest/wordpress-themes-workspace.test.ts
@@ -39,6 +39,9 @@ describe("WordPress Themes workspace", () => {
 
 	test("single-theme mode becomes a screenshot-led workspace with visible actions", () => {
 		expect(COMPACT_WORKSPACE_CSS).toContain(
+			"#wpbody-content { padding: 10px 16px;",
+		);
+		expect(COMPACT_WORKSPACE_CSS).toContain(
 			".themes.single-theme .theme-overlay.active .theme-wrap",
 		);
 		expect(COMPACT_WORKSPACE_CSS).toContain('"screenshot details"');


### PR DESCRIPTION
## Summary

- follow up the merged WordPress Themes redesign from #627 with the two issues found in its exact Playground build
- keep the single-theme workspace short enough that Core can focus its details overlay without scrolling the orientation header away
- anchor the active theme actions inside the visible details column
- preserve Core active/inactive action visibility so an active theme no longer exposes Live Preview and Activate controls
- tighten the supporting copy to keep the useful controls in the first window view

## Test plan

- npm run build
- npm run lint
- npm run typecheck
- npm run test:js — 362 files / 4,503 tests passed
- vendor/bin/phpcs -n includes/themes-tabs.php tests/phpunit/tests/openStationInjectAppearanceTabs.php
- php -l includes/themes-tabs.php
- php -l tests/phpunit/tests/openStationInjectAppearanceTabs.php
- exact branch Playground QA at the default Appearance window size

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-628-4f7eb96413abacca3f28e93c88dde8236c1d2add.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D&mode=seamless" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->