### PR TITLE
fix: hide wobble sliders when effect is off

### DIFF
--- a/src/mio/style-panel.ts
+++ b/src/mio/style-panel.ts
@@ -397,28 +397,32 @@ function openMioStylePanelImmediate(): void {
 						paint();
 					},
 				),
-				slider(
-					{
-						key: 'idleWobble',
-						label: __( 'Wobble strength' ),
-						min: 0,
-						max: 0.4,
-						step: 0.005,
-					},
-					current,
-					set,
-				),
-				slider(
-					{
-						key: 'idleWobbleSpeed',
-						label: __( 'Wobble speed' ),
-						min: 0,
-						max: 4,
-						step: 0.05,
-					},
-					current,
-					set,
-				),
+				...( physics.idleWobble > 0
+					? [
+						slider(
+							{
+								key: 'idleWobble',
+								label: __( 'Wobble strength' ),
+								min: 0,
+								max: 0.4,
+								step: 0.005,
+							},
+							current,
+							set,
+						),
+						slider(
+							{
+								key: 'idleWobbleSpeed',
+								label: __( 'Wobble speed' ),
+								min: 0,
+								max: 4,
+								step: 0.05,
+							},
+							current,
+							set,
+						),
+					]
+					: [] ),
 			] ),
 			section( __( 'Colour' ), [
 				slider(


### PR DESCRIPTION
Closes #594 
This PR resolves issue  where the "Wobble strength" and "Wobble speed" sliders remained visible and active in the style panel even when the "Wobble when idle" checkbox was unchecked, allowing the wobble animation to be restarted while the checkbox stayed off.

### Changes:
- **src/mio/style-panel.ts**: Conditionally render both the Wobble strength and Wobble speed sliders only when `physics.idleWobble > 0` is true. If the wobble toggle is disabled, both sliders are completely hidden from the DOM to prevent contradictory states.

### Testing:
- Open Mio -> "Make it yours".
- Toggle the "Wobble when idle" checkbox off. Both the Wobble strength and Wobble speed sliders should immediately disappear.
- Toggle it back on. Both sliders should reappear.

### Before:
<img width="1467" height="888" alt="Screenshot 2026-08-19 at 12 22 38 PM" src="https://github.com/user-attachments/assets/c3a00c8f-76eb-4ee9-bd9f-b312b7b19164" />

### After:
<img width="1468" height="900" alt="Screenshot 2026-08-19 at 12 50 27 PM" src="https://github.com/user-attachments/assets/5a6f2ec9-23ff-4eb5-8046-fc89977d45c9" />
<img width="1468" height="931" alt="Screenshot 2026-08-19 at 12 50 37 PM" src="https://github.com/user-attachments/assets/b3f1f36a-19d4-4b9e-9150-2dc3e0d7b84b" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-629-e1e2e0b23936568f63de229bf163ec0eeb0d8f83.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->