### PR TITLE
Window: the open-animation deadline must not outlive its window

### DIFF
--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -411,6 +411,19 @@ export class Window {
 	public _closeSafetyNetTimer: ReturnType< typeof setTimeout > | null = null;
 
 	/**
+	 * Teardown for `_armOpeningClassRemoval()` — cancels its fallback
+	 * timer and detaches its two animation listeners. Captured on the
+	 * instance so `_finalizeClose()` can run it: a window destroyed
+	 * inside the fallback deadline used to leave a live timer behind,
+	 * pointed at a document that was already going away.
+	 *
+	 * `null` once it has run (or before the window ever opened).
+	 *
+	 * @internal
+	 */
+	private _clearOpeningClassRemoval: ( () => void ) | null = null;
+
+	/**
 	 * Bound `transitionend` listener installed by `close()` so the
 	 * normal animation path can finalise. Captured so
 	 * `_finalizeClose()` can detach it (the previous closure-only
@@ -722,11 +735,14 @@ export class Window {
 	 *   - a `setTimeout` deadline, for the case where no animation
 	 *     event is ever coming (see `OPENING_FALLBACK_MS`).
 	 *
-	 * Whichever fires first wins and detaches the other two.
+	 * Whichever fires first wins and detaches the other two — and
+	 * `_finalizeClose()` runs the same teardown if the window is torn
+	 * down before any of them, so the deadline never outlives the
+	 * window it was arming.
 	 */
 	private _armOpeningClassRemoval(): void {
 		const el = this.element;
-		let timer = 0;
+		let timer: number | null = null;
 		let cleared = false;
 
 		const clear = (): void => {
@@ -734,7 +750,15 @@ export class Window {
 				return;
 			}
 			cleared = true;
-			window.clearTimeout( timer );
+			this._clearOpeningClassRemoval = null;
+			// `null` when the deadline itself is the caller: it has
+			// already fired, so there is nothing to cancel — and
+			// reaching for `window` from a timer that outlived its
+			// document is precisely the failure this avoids.
+			if ( timer !== null ) {
+				window.clearTimeout( timer );
+				timer = null;
+			}
 			el.removeEventListener( 'animationend', onAnimationDone );
 			el.removeEventListener( 'animationcancel', onAnimationDone );
 			el.classList.remove( 'os-window--opening' );
@@ -752,7 +776,11 @@ export class Window {
 
 		el.addEventListener( 'animationend', onAnimationDone );
 		el.addEventListener( 'animationcancel', onAnimationDone );
-		timer = window.setTimeout( clear, OPENING_FALLBACK_MS );
+		timer = window.setTimeout( () => {
+			timer = null;
+			clear();
+		}, OPENING_FALLBACK_MS );
+		this._clearOpeningClassRemoval = clear;
 	}
 
 	/**
@@ -3658,6 +3686,21 @@ export class Window {
 		if ( this._closeSafetyNetTimer !== null ) {
 			clearTimeout( this._closeSafetyNetTimer );
 			this._closeSafetyNetTimer = null;
+		}
+		// The pre-close bridge query's safety net. Its callback is a
+		// no-op post-destroy (`_isDestroyed` guard), but an armed timer
+		// still outlives the window — and a window closed within its
+		// 500ms is the common case, not the rare one.
+		if ( this._iframeCloseTimeout !== null ) {
+			clearTimeout( this._iframeCloseTimeout );
+			this._iframeCloseTimeout = null;
+		}
+		// Cancel the open animation's fallback deadline. Windows that
+		// open and close inside 300ms (test harnesses, plugin
+		// deactivation flows) would otherwise leave it running against
+		// a torn-down document.
+		if ( this._clearOpeningClassRemoval ) {
+			this._clearOpeningClassRemoval();
 		}
 		if ( this._onCloseTransitionEnd ) {
 			this.element.removeEventListener(

--- a/tests/vitest/window-focus-guard-and-opening-class.test.ts
+++ b/tests/vitest/window-focus-guard-and-opening-class.test.ts
@@ -256,6 +256,46 @@ describe( 'Window — the opening class always comes off', () => {
 		);
 	} );
 
+	test( 'the deadline never reaches for `window` when it is the one firing', async () => {
+		await manager.open( cfg( 'a' ) );
+		const clearSpy = vi.spyOn( window, 'clearTimeout' );
+
+		vi.advanceTimersByTime( 1000 );
+
+		// The deadline has already fired — there is nothing to cancel,
+		// and cancelling anyway is what made this flaky. A timer that
+		// outlives its document (a torn-down jsdom environment, a
+		// closing tab) finds no `window` global to reach for, and the
+		// callback dies with a ReferenceError nobody catches.
+		expect( clearSpy ).not.toHaveBeenCalled();
+		clearSpy.mockRestore();
+	} );
+
+	test( 'destroying the window cancels the pending deadline', async () => {
+		// Watch for the deadline specifically rather than counting
+		// pending timers: a window arms several on the way up, and
+		// one of them (`scheduleLoadingOverlayShow`'s) deliberately
+		// keeps no cancel bookkeeping at all.
+		const setSpy = vi.spyOn( window, 'setTimeout' );
+		const win = await manager.open( cfg( 'a' ) );
+		const deadlineIds = setSpy.mock.results
+			.filter( ( _r, i ) => setSpy.mock.calls[ i ][ 1 ] === 300 )
+			.map( ( r ) => r.value );
+		setSpy.mockRestore();
+		expect( deadlineIds ).toHaveLength( 1 );
+
+		const clearSpy = vi.spyOn( window, 'clearTimeout' );
+		win.destroy();
+
+		// A 300ms callback surviving a destroy is scheduled against a
+		// document on its way out — in this suite, a jsdom
+		// environment torn down the moment the file's last test
+		// returns.
+		expect( clearSpy ).toHaveBeenCalledWith( deadlineIds[ 0 ] );
+		clearSpy.mockRestore();
+		expect( () => vi.advanceTimersByTime( 1000 ) ).not.toThrow();
+	} );
+
 	test( 'a window opened in a hidden document never gets the class', async () => {
 		setHidden( true );
 


### PR DESCRIPTION
## The flake

```
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
ReferenceError: window is not defined
 ❯ Timeout.clear [as _onTimeout] src/window/index.ts:737:4
 ❯ listOnTimeout node:internal/timers:635:17

This error originated in "tests/vitest/window-manager-geometry-replay.test.ts"
```

The attribution is a red herring — that file is just whichever one happened to be running when someone else's orphaned timer fired.

## What's actually wrong

`_armOpeningClassRemoval()` arms a 300 ms `setTimeout` as the last of three ways `.os-window--opening` can come off (the class is not cosmetic — its animation's `from` frame is what makes a window transparent and undersized, so a class that never comes off is a window that never becomes visible).

Two problems, and the crash needs both:

1. **Nothing cancels the deadline.** A window destroyed inside 300 ms leaves it running against a document that is already going away. In Vitest that document is a jsdom environment torn down the moment a test file's last test returns.
2. **The deadline path cancels itself.** `clear()` called `window.clearTimeout( timer )` unconditionally, including when the timer *is* the caller. That's a global lookup from a callback that, by then, may have no `window` to find.

## The fix

- The deadline nulls its id before calling `clear()`, so the one caller that provably cannot need a `clearTimeout` no longer performs a global lookup to make one.
- `_finalizeClose()` runs the teardown — cancelling the deadline and detaching the two animation listeners — so the timer never survives the window.

The same block also clears `_iframeCloseTimeout`, a field whose docblock says it's captured for cancellation and which nothing ever cancelled. Its callback is already `_isDestroyed`-guarded, so this is tidiness rather than a second bug.

`scheduleLoadingOverlayShow()`'s timer is deliberately left alone: its comment explains why it keeps no cancel bookkeeping ("both reasons to skip are readable at fire time"), and it reads only captured elements, so an orphan is inert.

## Tests

Two added to `tests/vitest/window-focus-guard-and-opening-class.test.ts`, one per half. Both fail on `trunk` and pass here:

- *the deadline never reaches for `window` when it is the one firing* — spies `clearTimeout`, advances past the deadline, asserts no call.
- *destroying the window cancels the pending deadline* — captures the 300 ms timer id at open, asserts `destroy()` clears that specific id.

Full suite: **362 files, 4505 tests, 0 errors** — and no `Unhandled Errors` section, across two consecutive runs. `npm run typecheck`, `npm run lint` and `npm run build` are clean; no build-output diff. No PHP touched, and no documented surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-630-bc7fda4f841a4ca4c769f6ffef8c9293b4e8435e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->