### PR TITLE
Explorer: render preview actions in every section, pass the entity to onSelect, and let a section own editing

### DIFF
--- a/docs/examples/my-wordpress-media-action.md
+++ b/docs/examples/my-wordpress-media-action.md
@@ -2,11 +2,12 @@
 
 **Status: Experimental**
 
-The WP Explorer native window (Posts / Pages / Users / Media)
-exposes a uniform right-pane action surface. Plugins declare a
-descriptor on the **PHP** side (capability + MIME + script handle)
-and wire the JS handler via a `wp.hooks` filter. This recipe walks
-through both halves.
+The WP Explorer native window (Posts / Pages / Users / Media, and
+every plugin-added section) exposes a uniform action surface: one
+descriptor becomes a button in the right pane **and** an entry in the
+tile context menu. Plugins declare the descriptor on the **PHP** side
+(capability + MIME + script handle) and wire the JS handler via a
+`wp.hooks` filter. This recipe walks through both halves.
 
 The scenario: a "Compress this image" button that appears only on
 image items in the Media section, hits a plugin-owned REST route,
@@ -46,10 +47,19 @@ What you got for free:
 - `capability` is enforced before the descriptor ships to the
   bundle, so the button never appears for users who can't run it.
 - `mime` is re-evaluated client-side per item — the button stays
-  hidden on non-image rows.
+  hidden on non-image rows, and a MIME-scoped action never leaks
+  into a non-media section.
 - `sections` scopes the button. Omit it to show the button on every
-  section, or pass `array( 'media', 'posts' )` to opt in to more.
+  section, or pass an array to opt in: entries match a section's
+  **id** (`'media'`, `'posts'`), a section's **post type slug**
+  (`'atf-form'` — handy because an auto-registered CPT section's id
+  is `cpt-<post_type>`), or `'*'`.
 - `script` is auto-enqueued for users who can see the action.
+- The same descriptor also appears in the tile's right-click menu,
+  between the navigation entries and the destructive ones.
+- Timing is forgiving: descriptors are collected when the window
+  config is emitted, so registering the filter on `init`,
+  `admin_init`, or plain plugin bootstrap all work.
 
 ## JS — wire the click handler
 
@@ -94,12 +104,88 @@ The handler's `ctx` argument:
 
 ```ts
 {
-    entityId: 'media',     // section slug
+    entityId: 'media',     // section id
     kind: 'media',         // render kind
+    postType: 'attachment',// the section's post type slug, when declared
     mime: 'image/png',     // present on media items
-    item: { /* full server record */ },
+    item: { /* the selected entity, as the server sent it */ },
+    itemId: 42,            // Number( item.id ) when numeric
+    surface: 'pane',       // or 'context-menu'
 }
 ```
+
+`item` is the detail record in the right pane and the list row in the
+context menu — `item.id` is present on both, so deep-link from that.
+
+## Deep-link from a custom section (non-media)
+
+The same two halves give a CPT section a "open THIS entry in my app"
+action. A forms plugin whose post type is `atf-form`:
+
+```php
+add_filter( 'openstation_my_wordpress_preview_actions', function ( $actions ) {
+    $actions[] = array(
+        'id'         => 'atf/open-builder',
+        'label'      => __( 'Open in form builder', 'atf' ),
+        'icon'       => 'dashicons-feedback',
+        'capability' => 'edit_posts',
+        'sections'   => array( 'atf-form' ), // post type slug — matches
+                                             // the auto section cpt-atf-form
+        'script'     => 'atf-explorer-actions',
+    );
+    return $actions;
+} );
+```
+
+```js
+wp.hooks.addFilter(
+    'os.my-wordpress.preview-actions',
+    'atf/open-builder',
+    ( actions, ctx ) =>
+        actions.map( ( a ) =>
+            a.id === 'atf/open-builder'
+                ? {
+                    ...a,
+                    onSelect: ( c ) =>
+                        wp.os.openWindow( 'atf-builder', {
+                            source: 'atf/explorer',
+                            // c.item is THE selected form.
+                        } ),
+                }
+                : a,
+        ),
+);
+```
+
+The button appears in the Forms section's pane and context menu, and
+nowhere else — `sections` did the scoping, `ctx.item` carries the
+form the user clicked on.
+
+### Make it the section's editor
+
+If the type has no classic-editor screen (a native window owns
+editing), promote that action to be the section's editor via the
+section descriptor's `editAction`:
+
+```php
+add_filter( 'openstation_my_wordpress_entities', function ( $entities ) {
+    $entities[] = array(
+        'id'         => 'atf-forms',
+        'label'      => __( 'Forms', 'atf' ),
+        'icon'       => 'dashicons-feedback',
+        'restPath'   => 'wp/v2/atf-form',
+        'post_type'  => 'atf-form',
+        'editAction' => 'atf/open-builder', // this action IS the editor
+    );
+    return $entities;
+} );
+```
+
+Now "Open in form builder" replaces "Open in editor" on the pane's
+primary button, the context menu's open entry, and tile double-click
+(a double-clicked form opens the builder, not a 404ing `post.php`).
+Set `editAction => false` instead to remove editing entirely —
+double-click then navigates into the entry's detail dossier.
 
 ## Inject HTML into the right pane
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -104,6 +104,29 @@ add_action( 'openstation_native_window_registered', function ( $id, $entry ) {
 
 ---
 
+### `openstation_native_window_config` — Experimental (filter)
+
+```php
+apply_filters( 'openstation_native_window_config', array $config, string $window_id ): array
+```
+
+A native window's `config` blob, at emit time. The registry snapshots `config` when `openstation_register_window()` runs (usually `init`); this filter runs when the blob is serialized for the browser — at enqueue time for preloaded bundles, at payload-build time for lazy ones — so values that depend on hooks registered later in the bootstrap can be refreshed without moving the whole registration. Runs per request after the current user is determined, so capability-gated values are safe to compute here. Return value must be an array; anything else ships nothing.
+
+The WP Explorer uses it to re-collect its `previewActions` (see [`openstation_my_wordpress_preview_actions`](#openstation_my_wordpress_preview_actions--experimental-filter)) so action descriptors registered after `init` 99 still reach the bundle.
+
+```php
+add_filter( 'openstation_native_window_config', function ( $config, $window_id ) {
+    if ( 'my-plugin-window' === $window_id ) {
+        $config['launchCount'] = (int) get_user_option( 'my_plugin_launches' );
+    }
+    return $config;
+}, 10, 2 );
+```
+
+Mid-session caveat: the blob is delivered alongside the window's script, and an already-loaded bundle keeps the copy it booted with until the next full page load.
+
+---
+
 ### `openstation_widget_registered` — Stable
 
 Fires after `openstation_register_widget()` successfully stores a widget. Same contract as the native-window action.
@@ -3232,8 +3255,9 @@ The list of entity types rendered as folder tiles in the window's root view. Eac
 - `post_type` *(optional)* — WP post-type slug used to build the cross-window broadcast topic `os.<slug>.changed`. Omit for entities without trash/restore support (e.g. Users). CPT entities registered via this filter should set `post_type` so list views refresh reactively on trash/restore.
 - `kind` *(optional)* — `'post'` (default for back-compat), `'user'`, or `'media'`. Drives the in-window render path: `'post'`-shaped entities use the title/excerpt/featured-image tile + rendered-HTML preview; `'user'`-shaped entities use the avatar-tile, the dossier preview, and the activity-footprint surface; `'media'`-shaped entities use the media-grid tile and the media drill-in preview ("used in" view). Omit the field to inherit the post path — works for any REST collection that ships `title.rendered` + `content.rendered`. Plugins can register further kinds on the JS side via `wp.os.myWordpress.registerEntityKind()`.
 - `listQuery` *(optional)* — extra query parameters sent with this section's list requests, as `key => value`. Lets a server-side query filter scope itself to the site window instead of rewriting every REST caller's query — `rest_product_query` fires for the Product Collection block too, so the WooCommerce sections mark their own requests rather than reordering everyone's.
-- `listFields` *(optional)* — extra REST field names to request for this section's list rows. The window sends an explicit `_fields` list, so a custom key your endpoint returns is stripped before the bundle sees it unless it's named here. Used by the WooCommerce sections to carry the order status and product stock their tiles are banded and badged by.
+- `listFields` *(optional)* — extra REST field names to request for this section's rows, on list **and** detail requests. The window sends an explicit `_fields` list, so a custom key your endpoint returns is stripped before the bundle sees it unless it's named here. Used by the WooCommerce sections to carry the order status and product stock their tiles are banded and badged by.
 - `thumbnails` *(optional)* — `false` keeps the section icon on every tile. Defaults to on: a `'post'`-kind entry that has a featured image renders it in place of the icon (the list request already asks for `_embed=wp:featuredmedia`, so this costs no extra round trip). Entries without one fall back to `icon`.
+- `editAction` *(optional)* — who edits this section's rows. A preview-action **id** (declared via [`openstation_my_wordpress_preview_actions`](#openstation_my_wordpress_preview_actions--experimental-filter), so it stays capability-gated and its script auto-enqueues) replaces "Open in editor" at every edit surface: the pane's primary button, the context menu's open entry (and its bulk fan-out — the action's `onSelect( ctx )` runs once per selected item), and tile double-click. The named action stops rendering in the generic action row/menu. If it didn't ship for this user or no JS wired its `onSelect`, the edit affordances hide rather than fall back — for a type without an editor screen, the classic URL is known-broken. **`false`** removes every edit affordance; double-click falls back to the detail dossier and the bulk "Edit…" modal is suppressed (a *string* keeps that modal: it PATCHes over REST and doesn't involve the classic editor). Omit for the classic editor, where a row-supplied `editUrl` field still wins when present.
 - `group` *(optional)* — id of the root-level folder this section nests under. Sections sharing a group id collapse into one folder tile at the root that drills into its members. Omit or pass `null` to render the section loose at the root next to Posts and Pages.
 - `groupLabel` / `groupIcon` / `groupOrder` *(optional)* — folder label, icon, and sort weight. Every member of a group should carry the same values; the first entry seen wins.
 
@@ -3626,7 +3650,7 @@ Lifetime (seconds) of the per-attachment media-usage transient. Lower it on site
 apply_filters( 'openstation_my_wordpress_preview_actions', array[] $actions ): array[]
 ```
 
-Server-declared descriptors for the right-pane action button row that appears in every WP Explorer section (posts, pages, users, media, plugin-defined kinds). Each entry:
+Server-declared descriptors for plugin actions on a selected Explorer entry. Each descriptor renders twice, from the one declaration: as a button in the right-pane action row and as an entry in the tile context menu — in every WP Explorer section (posts, pages, users, media, plugin-defined kinds). Each entry:
 
 ```php
 array(
@@ -3640,7 +3664,11 @@ array(
 )
 ```
 
-`capability` is enforced server-side before the descriptor ships to the bundle, so an action the current user can't run never appears in their UI. `script`, if registered, is auto-enqueued. Wire the click handler on the JS side via `wp.hooks.addFilter('os.my-wordpress.preview-actions', …)` — see [`examples/my-wordpress-media-action.md`](./examples/my-wordpress-media-action.md).
+`capability` is enforced server-side before the descriptor ships to the bundle, so an action the current user can't run never appears in their UI. `script`, if registered, is auto-enqueued. Wire the click handler on the JS side via `wp.hooks.addFilter('os.my-wordpress.preview-actions', …)` — the handler receives a context object carrying the selected entity; see [`examples/my-wordpress-media-action.md`](./examples/my-wordpress-media-action.md) and the [JS reference](./javascript-reference.md#filter--osmy-wordpresspreview-actions).
+
+**`sections` matching.** An entry in `sections` matches a section's **id**, its declared **post type slug**, or `'*'` (every section). Note the id shapes: the built-ins are `'posts'`, `'pages'`, `'users'`, `'media'`, while a custom post type the Explorer auto-registers gets the id `cpt-<post_type>` (e.g. post type `atf-form` → section `cpt-atf-form`); hand-registered sections choose their own ids. When in doubt, scope by post type slug — it matches wherever that type's section came from. A `mime` pattern additionally fails closed outside media contexts: a MIME-scoped action never appears on a post/user pane.
+
+**Timing.** Descriptors are re-collected when the window config is serialized for the browser (the same late pass that enqueues declared `script` handles), so registering this filter any time during a normal bootstrap — `init`, `admin_init`, plugin bootstrap order regardless — works. One caveat: on a mid-session plugin activation the already-loaded Explorer bundle keeps its config until the next full page load (F5).
 
 ---
 

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -6151,7 +6151,7 @@ interface EntityRenderHost {
     previewActionRow( args: {
         item: Record< string, unknown >;
         mime?: string;
-        surface?: 'pane' | 'context-menu' | 'dblclick' | 'bulk';
+        surface?: 'pane' | 'context-menu' | 'dblclick';
     } ): HTMLElement | null;
 }
 ```
@@ -6207,9 +6207,14 @@ interface PreviewActionContext {
     /** Convenience — `Number( item.id )` when numeric. */
     itemId?: number;
     /** Where the action was invoked. */
-    surface?: 'pane' | 'context-menu' | 'dblclick' | 'bulk';
+    surface?: 'pane' | 'context-menu' | 'dblclick';
 }
 ```
+
+A multi-select run reports `'context-menu'` rather than a surface of
+its own — the selection layer fans a bulk choice out by replaying each
+row's own single-item handler, so `onSelect` runs once per item with
+that row's `item` and the menu surface it was built for.
 
 A descriptor's `sections` list matches the section **id**, the
 section's **post type slug**, or `'*'` (auto-registered CPT sections

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -6141,16 +6141,37 @@ interface EntityRenderHost {
     route: Route;
     navigate( route: Route ): void;
     addTeardown( fn: () => void ): void;
+    /**
+     * The section's server-declared preview actions, resolved
+     * against one item and returned as the same ready-made button
+     * row the built-in panes render — or null when none apply.
+     * Runs the full pipeline (section/MIME scoping + the
+     * `os.my-wordpress.preview-actions` filter) in one call.
+     */
+    previewActionRow( args: {
+        item: Record< string, unknown >;
+        mime?: string;
+        surface?: 'pane' | 'context-menu' | 'dblclick' | 'bulk';
+    } ): HTMLElement | null;
 }
 ```
 
 ### Filter — `os.my-wordpress.preview-actions`
 
-Decorate the right-pane action button row. Receives the
-server-declared descriptors (already capability-gated) merged with
-any client-only entries the filter chain has added on prior calls.
-Wire the `onSelect` handler here — server descriptors only carry
-metadata.
+Decorate the plugin action set for a selected entry. Receives the
+server-declared descriptors (already capability-gated and scoped to
+the section) merged with any client-only entries the filter chain has
+added on prior calls. Wire the `onSelect` handler here — server
+descriptors only carry metadata.
+
+The resolved set renders in two places from the one declaration: the
+right-pane action row (buttons after the built-ins) and the tile
+context menu (entries between the navigation built-ins and the
+destructive ones, visible to the `os.my-wordpress.tile-context-menu`
+filter like any built-in). It fires for **every** section kind —
+media, post, user, and custom kinds — so guard unscoped additions
+with `ctx.kind` / `ctx.entityId`, or scope the server descriptor via
+its `sections` field.
 
 ```ts
 wp.hooks.addFilter(
@@ -6165,8 +6186,44 @@ wp.hooks.addFilter(
 );
 ```
 
-Context shape: `{ entityId, kind, mime?, item }`. `item` is the
-raw server record (a `MediaListItem`, post `EntityListItem`, etc.).
+Context shape (also what `onSelect` / `isVisible` receive):
+
+```ts
+interface PreviewActionContext {
+    /** Section id — `'media'`, `'posts'`, `'cpt-atf-form'`, … */
+    entityId: string;
+    /** Render kind — `'post'`, `'user'`, `'media'`, or a custom one. */
+    kind: string;
+    /** The section's declared post type slug, when it has one. */
+    postType?: string;
+    /** MIME type — media contexts only. */
+    mime?: string;
+    /**
+     * The selected entity, as the server sent it: the detail record
+     * in the right pane, the list row in context menus. `item.id`
+     * is present on both — deep-link from that.
+     */
+    item: Record< string, unknown >;
+    /** Convenience — `Number( item.id )` when numeric. */
+    itemId?: number;
+    /** Where the action was invoked. */
+    surface?: 'pane' | 'context-menu' | 'dblclick' | 'bulk';
+}
+```
+
+A descriptor's `sections` list matches the section **id**, the
+section's **post type slug**, or `'*'` (auto-registered CPT sections
+have ids shaped `cpt-<post_type>`). A `mime` pattern fails closed
+outside media contexts.
+
+A registered kind receives **detail routes too**: double-clicking a tile
+(or `host.navigate({ kind: 'detail', entityId, postId, postTitle })`) keeps
+the window's own breadcrumb — `Site › Section › Title` — while the body stays
+the plugin's to draw. The three in-tree kinds keep their dossier.
+
+Custom-kind renderers get the same pipeline from one call:
+`host.previewActionRow( { item } )` on the `EntityRenderHost` returns
+the ready-made button row (or `null` when no action applies).
 
 ### Action — `os.my-wordpress.preview-extras`
 
@@ -6319,6 +6376,12 @@ interface UserPreviewAction {
 Context: `{ entityId: string; kind: string; item: Record< string, unknown > }`.
 Entries without a callable `onSelect` are dropped; returning an empty
 array removes the action row entirely rather than leaving an empty bar.
+
+This filter manages the **built-ins** of a user pane. Server-declared
+preview actions (`openstation_my_wordpress_preview_actions`) render
+after the row it builds, from the shared pipeline — remove those at
+the source (their `sections` scoping, or the
+`os.my-wordpress.preview-actions` filter), not here.
 
 ### Filter — `os.my-wordpress.list-bands`
 
@@ -6491,6 +6554,12 @@ menu (`kind` from the entity, default `'post'`), the media tile menu
 (`kind: 'attachment'`), and the user tile menu (`kind: 'user'`) —
 write the filter as if the hook fires for every section.
 
+Server-declared preview actions
+(`openstation_my_wordpress_preview_actions`) arrive in `options`
+already resolved — between the navigation built-ins and the
+destructive entries, `sort: 50` — so this filter can reorder or
+remove them by id like any built-in.
+
 **Multi-selection.** These lists are multi-select, and an entry you
 add here appears only while ONE tile is selected until it opts in.
 Add `multi: true` (plus optionally `sort`, `bulkLabel( n )`, and a
@@ -6565,11 +6634,11 @@ Its members are the sections whose descriptor carries that id; the
 breadcrumb reads `Site › WooCommerce › Products`, and a grouped
 section's parent route is its group rather than the root.
 
-### Section descriptors — grouping and thumbnails
+### Section descriptors — grouping, thumbnails, editing
 
 Entity descriptors reaching the bundle (from
 `openstation_my_wordpress_entities` server-side, or appended in JS)
-carry four optional fields beyond the documented core set:
+carry these optional fields beyond the documented core set:
 
 ```ts
 interface MyWordPressEntity {
@@ -6582,17 +6651,36 @@ interface MyWordPressEntity {
     groupIcon?: string | null;
     groupOrder?: number | null;
     /**
-     * Extra REST fields to keep on this section's list rows —
-     * anything outside the built-in `_fields` set, `editUrl`
-     * included.
+     * Extra REST fields to keep on this section's rows — anything
+     * outside the built-in `_fields` set, `editUrl` included. Sent
+     * on list AND detail requests.
      */
     listFields?: string[];
     /** Extra query params sent with this section's list requests. */
     listQuery?: Record< string, string >;
     /** `'large'` roughly doubles the icon well. Default `'regular'`. */
     tileSize?: 'regular' | 'large';
+    /**
+     * Who edits this section's rows. A preview-action id replaces
+     * "Open in editor" everywhere (pane primary button, context-menu
+     * open entry + its bulk fan-out, tile double-click); `false`
+     * removes every edit affordance. Omit for the classic editor.
+     */
+    editAction?: string | false;
 }
 ```
+
+`editAction: '<action-id>'` names a descriptor from
+`openstation_my_wordpress_preview_actions`, so the replacement editor
+stays capability-gated and its script auto-enqueues. The named action
+stops rendering in the generic action row/menu (it IS the edit
+affordance now). If the action didn't ship for this user or no JS
+wired its `onSelect`, the edit affordances hide — for a section whose
+type has no editor screen, the classic URL is known-broken. With
+`editAction: false`, double-click navigates into the detail dossier
+instead, and the bulk "Edit…" modal is suppressed; with a string it is
+**kept** — that modal PATCHes over REST (status/author/terms) and
+doesn't touch the classic editor.
 
 Groups from the server and groups derived from entity descriptors are
 **merged**, not either-or: a section appended from JS with a `group` the

--- a/docs/native-windows-proposal.md
+++ b/docs/native-windows-proposal.md
@@ -96,7 +96,7 @@ openstation_register_window( 'jorvy', array(
 ) );
 ```
 
-Behind the scenes this populates a registry exposed to the shell via `openstation_shell_config` → `nativeWindows`. There is no registry-level filter; the shipped extension points are the `openstation_native_window_registered` action (fires after every successful registration) and the `openstation_native_window_allowed_html` filter (the kses allowlist used to escape `<template>` payloads).
+Behind the scenes this populates a registry exposed to the shell via `openstation_shell_config` → `nativeWindows`. The shipped extension points are the `openstation_native_window_registered` action (fires after every successful registration), the `openstation_native_window_allowed_html` filter (the kses allowlist used to escape `<template>` payloads), and the `openstation_native_window_config` filter (a window's `config` blob at emit time — see below).
 
 #### Shipping config to the bundle
 
@@ -122,6 +122,8 @@ const cfg = wp.os.getWindowConfig( 'my/window' );
 Why this matters: native-window scripts may be loaded **eagerly** (via `wp_enqueue_script` at boot) or **lazily** (the shell appends a `<script>` after a payload-refresh, e.g. mid-session plugin activation). The lazy path bypasses `wp_print_scripts()` entirely. Without the `'config'` arg's delivery path, any data attached via `wp_localize_script` / `wp_add_inline_script` / `wp_set_script_translations` would be silently dropped on the lazy path.
 
 The shell harvests that `extra` data into the payload and re-injects it inline alongside the lazy `<script>` tag, so existing `wp_localize_script` callers continue to work — but the `'config'` arg is the discoverable, supported way and is recommended for new windows. See [`examples/window-with-config.md`](./examples/window-with-config.md).
+
+The registry snapshots `'config'` when `openstation_register_window()` runs. When a value has to be computed later than the registration hook (it depends on filters other plugins add during bootstrap), refresh it at emit time via the `openstation_native_window_config` filter — `apply_filters( 'openstation_native_window_config', array $config, string $window_id )`, run at both serialization points (eager enqueue and lazy payload build). Full entry in [`hooks-reference.md`](./hooks-reference.md#openstation_native_window_config--experimental-filter).
 
 For diagnostics, `wp.os.debug.window( id )` (read-only) reports the load path, whether the tag is in the DOM, and whether the config global landed.
 

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -1705,11 +1705,12 @@ function openstation_build_native_windows_payload() {
 		// `wp_localize_script`. The bundle reads
 		// `window.openStationWindowConfig[id]` (or via
 		// `wp.os.getWindowConfig(id)`).
-		if ( ! empty( $entry['config'] ) && is_array( $entry['config'] ) ) {
+		$window_config = openstation_filter_native_window_config( $entry );
+		if ( ! empty( $window_config ) ) {
 			$script_payload['l10n'][] = sprintf(
 				'window.openStationWindowConfig=window.openStationWindowConfig||{};window.openStationWindowConfig[%s]=%s;',
 				wp_json_encode( $entry['id'] ),
-				wp_json_encode( $entry['config'] )
+				wp_json_encode( $window_config )
 			);
 		}
 

--- a/includes/my-wordpress/preview-actions.php
+++ b/includes/my-wordpress/preview-actions.php
@@ -27,6 +27,17 @@
  *     'script'     => 'my-plugin-actions',         // optional handle
  *   ]
  *
+ * `sections` entries match a section's **id** (`'media'`,
+ * `'cpt-atf-forms'` — auto-registered CPT sections are prefixed
+ * `cpt-`), a section's declared **post type slug** (`'atf-forms'`),
+ * or `'*'` for every section. Matching happens client-side.
+ *
+ * Timing: descriptors are re-collected when the window config is
+ * serialized for the browser (see
+ * `openstation_my_wordpress_refresh_window_config()`), the same late
+ * pass that enqueues declared `script` handles — registering the
+ * filter any time during a normal bootstrap is fine.
+ *
  * @package OpenStation
  */
 

--- a/includes/my-wordpress/window.php
+++ b/includes/my-wordpress/window.php
@@ -183,6 +183,13 @@ function openstation_my_wordpress_entities() {
 	 *   - `post_type`  — WP post-type slug for cross-window broadcast topic `os.<slug>.changed`.
 	 *   - `thumbnails` — set false to keep the section icon on every tile
 	 *                    instead of the entity's featured image.
+	 *   - `editAction` — who edits this section's rows. A preview-action id
+	 *                    (see `openstation_my_wordpress_preview_actions`)
+	 *                    replaces "Open in editor" everywhere — pane button,
+	 *                    context-menu open entry, tile double-click. `false`
+	 *                    removes every edit affordance (double-click falls
+	 *                    back to the detail dossier; the bulk "Edit…" modal
+	 *                    is suppressed). Omit for the classic editor.
 	 *   - `group`      — folder id this section nests under at the root
 	 *                    (null / omitted renders it loose at the root).
 	 *   - `groupLabel` — folder label. `groupIcon`, `groupOrder` follow.
@@ -232,7 +239,10 @@ function openstation_my_wordpress_render_template() {
  * enough that every plugin's `register_post_type()` call has already
  * run. The entity list is frozen into the window config here and only
  * emitted later on `admin_enqueue_scripts`, so a CPT registered after
- * this point would never reach the bundle.
+ * this point would never reach the bundle. `previewActions` is the
+ * exception: it is re-collected at emit time via
+ * `openstation_my_wordpress_refresh_window_config()` below, so the
+ * value snapshotted here is only the fallback.
  */
 function openstation_my_wordpress_register_window() {
 	if ( ! openstation_my_wordpress_user_can_use() ) {
@@ -310,6 +320,37 @@ function openstation_my_wordpress_register_window() {
 	openstation_register_icon( 'desktop-mode-my-wordpress', $icon_args );
 }
 add_action( 'init', 'openstation_my_wordpress_register_window', 99 );
+
+/**
+ * Re-collect the preview-action descriptors when the window config is
+ * serialized for the browser, replacing the `init` 99 snapshot taken
+ * at registration time.
+ *
+ * The action SCRIPTS were always collected late (`admin_enqueue_scripts`
+ * 40, `openstation_my_wordpress_enqueue_preview_action_scripts()`), so
+ * a plugin registering its `openstation_my_wordpress_preview_actions`
+ * callback after `init` 99 used to get its JS delivered with no
+ * descriptor to attach to — the button simply never rendered. Emitting
+ * both legs from the same late collection closes that trap: any
+ * registration during a normal bootstrap now ships both.
+ *
+ * The entity list deliberately stays frozen at `init` 99 — see the
+ * registration docblock above.
+ *
+ * @param array  $config    Window config blob about to be emitted.
+ * @param string $window_id Native window id.
+ * @return array Config with fresh `previewActions` for our window.
+ */
+function openstation_my_wordpress_refresh_window_config( $config, $window_id ) {
+	if ( 'desktop-mode-my-wordpress' !== $window_id || ! is_array( $config ) ) {
+		return $config;
+	}
+	if ( function_exists( 'openstation_my_wordpress_collect_preview_actions' ) ) {
+		$config['previewActions'] = openstation_my_wordpress_collect_preview_actions();
+	}
+	return $config;
+}
+add_filter( 'openstation_native_window_config', 'openstation_my_wordpress_refresh_window_config', 10, 2 );
 
 /**
  * Enqueue the bundle's CSS in admin context. The script is lazy-

--- a/includes/registries/native-windows.php
+++ b/includes/registries/native-windows.php
@@ -835,6 +835,51 @@ function openstation_build_native_window_template_html( $entry ) {
 }
 
 /**
+ * Run a native window's registered `config` through the
+ * `openstation_native_window_config` filter, normalized to an array.
+ *
+ * Called at BOTH serialization points — the eager inline-script
+ * attach in `openstation_enqueue_native_window_scripts()` and the
+ * lazy `scriptL10n` synthesis in
+ * `openstation_build_native_windows_payload()` — so the filter sees
+ * every copy of the blob that can reach a browser.
+ *
+ * @param array $entry Registry entry (needs `id`; `config` optional).
+ * @return array Filtered config. Empty array when nothing to ship.
+ */
+function openstation_filter_native_window_config( $entry ) {
+	$config = isset( $entry['config'] ) && is_array( $entry['config'] )
+		? $entry['config']
+		: array();
+
+	/**
+	 * Filter a native window's config blob at emit time.
+	 *
+	 * The registry snapshots `config` when `openstation_register_window()`
+	 * runs — usually `init`. This filter runs when the blob is
+	 * serialized for the browser (enqueue time on the eager path,
+	 * payload-build time on the lazy path), so values that depend on
+	 * hooks registered later in the bootstrap can be refreshed without
+	 * moving the whole registration. The WP Explorer uses it to
+	 * re-collect `previewActions` so plugins may add
+	 * `openstation_my_wordpress_preview_actions` callbacks any time
+	 * during a normal bootstrap, not just before `init` 99.
+	 *
+	 * Runs per request, after the current user is determined —
+	 * capability-gated values are safe to compute here.
+	 *
+	 * **Status: Experimental**
+	 *
+	 * @param array  $config    Config blob as registered (empty array
+	 *                          when the window registered none).
+	 * @param string $window_id Native window id.
+	 */
+	$config = apply_filters( 'openstation_native_window_config', $config, (string) $entry['id'] );
+
+	return is_array( $config ) ? $config : array();
+}
+
+/**
  * Attach every registered native window's script data, and enqueue
  * the handful of bundles that asked to load at boot.
  *
@@ -927,13 +972,14 @@ function openstation_enqueue_native_window_scripts() {
 		// twice: once as `before`, once as `l10n`. The bundle reads it
 		// via `wp.os.getWindowConfig( id )` or directly at
 		// `window.openStationWindowConfig[ id ]`.
-		if ( $preload && ! empty( $entry['config'] ) && is_array( $entry['config'] ) ) {
+		$config = openstation_filter_native_window_config( $entry );
+		if ( $preload && ! empty( $config ) ) {
 			wp_add_inline_script(
 				$entry['script'],
 				sprintf(
 					'window.openStationWindowConfig=window.openStationWindowConfig||{};window.openStationWindowConfig[%s]=%s;',
 					wp_json_encode( $entry['id'] ),
-					wp_json_encode( $entry['config'] )
+					wp_json_encode( $config )
 				),
 				'before'
 			);

--- a/src/my-wordpress/bulk-actions.ts
+++ b/src/my-wordpress/bulk-actions.ts
@@ -561,8 +561,14 @@ export function entityBulkActions(
 	const { entity, onChanged } = ctx;
 	const one = [ item ];
 
-	const actions: SelectionAction< EntityListItem >[] = [
-		{
+	const actions: SelectionAction< EntityListItem >[] = [];
+
+	// The bulk-edit modal is a REST PATCH surface (status / author /
+	// terms), not the classic editor, so a section that ROUTES
+	// editing elsewhere (`editAction: '<action-id>'`) keeps it. Only
+	// `editAction: false` — editing is off — suppresses it.
+	if ( entity.editAction !== false ) {
+		actions.push( {
 			id: 'bulk-edit',
 			label: __( 'Edit…', 'desktop-mode' ),
 			icon: 'dashicons-edit-large',
@@ -578,8 +584,8 @@ export function entityBulkActions(
 				onChanged( await bulkEditEntities( entity, items ) ),
 			onClick: async () =>
 				onChanged( await bulkEditEntities( entity, one ) ),
-		},
-	];
+		} );
+	}
 
 	// Publish / Switch to Draft mirror core's row actions, and each
 	// hides itself when it would be a no-op for the entry it's built

--- a/src/my-wordpress/index.ts
+++ b/src/my-wordpress/index.ts
@@ -53,6 +53,16 @@ import { renderListToolbar } from './list-toolbar';
 import { renderMediaList } from './media-list';
 import { renderMediaDetail } from './media-detail';
 import {
+	appendActionButtons,
+	buildPreviewActionContext,
+	buildPreviewActionRow,
+	previewActionsToMenuOptions,
+	resolveEditAction,
+	resolvePreviewActions,
+	runPreviewAction,
+	withoutEditAction,
+} from './preview-actions';
+import {
 	clearFootprintTarget,
 	openUserFootprintWindow,
 	readFootprintTarget,
@@ -337,6 +347,18 @@ function navigate(
 		return;
 	}
 	if ( route.kind === 'detail' ) {
+		// A plugin-registered kind owns its detail views too: the folder a
+		// form opens into is the plugin's to draw, while the route — and the
+		// breadcrumb derived from it — stays the shell's. The three in-tree
+		// kinds keep the dossier below; their registry entries are list
+		// renderers, not detail ones.
+		if ( entity.kind && ! [ 'post', 'user', 'media' ].includes( entity.kind ) ) {
+			const renderer = getEntityRenderer( entity.kind );
+			if ( renderer ) {
+				renderer( makeRenderHost( state ), entity );
+				return;
+			}
+		}
 		renderDetail( state, entity, route.postId, route.postTitle );
 		return;
 	}
@@ -376,6 +398,23 @@ function makeRenderHost( state: RenderState ): EntityRenderHost {
 		route: state.route,
 		navigate: ( route ) => navigate( state, route ),
 		addTeardown: ( fn ) => state.teardown.push( fn ),
+		previewActionRow: ( args ) => {
+			// The host's route is frozen at dispatch time, so its
+			// entityId names the section this renderer serves.
+			const entityId = (
+				state.route as { entityId?: string }
+			).entityId;
+			const entity = getConfig().entities.find(
+				( e ) => e.id === entityId,
+			);
+			if ( ! entity ) {
+				return null;
+			}
+			return buildPreviewActionRow( entity, args.item, {
+				surface: args.surface,
+				mime: args.mime,
+			} );
+		},
 	};
 }
 
@@ -2067,7 +2106,7 @@ function buildEntityTile(
 	tile.addEventListener( 'dblclick', ( e ) => {
 		e.preventDefault();
 		hideTooltip();
-		openEditor( entity, item.id, titleText, item.editUrl );
+		openEntityEditor( state, entity, item, titleText, 'dblclick' );
 	} );
 
 	tile.addEventListener( 'contextmenu', ( e ) => {
@@ -2302,18 +2341,62 @@ function appendPostArticle(
 		footer.appendChild( exploreBtn );
 	}
 
-	const editBtn = document.createElement( 'os-button' );
-	editBtn.setAttribute( 'variant', 'primary' );
-	editBtn.textContent = __( 'Open in editor', 'desktop-mode' );
-	editBtn.addEventListener( 'click', () => {
-		openEditor(
-			entity,
-			detail.id,
-			stripTags( detail.title?.rendered ?? '' ),
-			detail.editUrl,
+	// The primary button is whatever edits this section's rows: the
+	// classic editor by default, the section's declared `editAction`
+	// when it named one, nothing when editing is off (`false`, or the
+	// named action is unavailable — a classic URL would 404 there).
+	const editResolution = resolveEditAction(
+		entity,
+		detail as unknown as Record< string, unknown >,
+		'pane',
+	);
+	if ( editResolution.mode === 'classic' ) {
+		const editBtn = document.createElement( 'os-button' );
+		editBtn.setAttribute( 'variant', 'primary' );
+		editBtn.textContent = __( 'Open in editor', 'desktop-mode' );
+		editBtn.addEventListener( 'click', () => {
+			openEditor(
+				entity,
+				detail.id,
+				stripTags( detail.title?.rendered ?? '' ),
+				detail.editUrl,
+			);
+		} );
+		footer.appendChild( editBtn );
+	} else if ( editResolution.mode === 'action' ) {
+		const editBtn = document.createElement( 'os-button' );
+		editBtn.setAttribute( 'variant', 'primary' );
+		editBtn.dataset.actionId = editResolution.action.id;
+		if ( editResolution.action.icon ) {
+			editBtn.setAttribute( 'icon', editResolution.action.icon );
+		}
+		editBtn.textContent = editResolution.action.label;
+		editBtn.addEventListener( 'click', () =>
+			runPreviewAction( editResolution.action, editResolution.ctx ),
 		);
-	} );
-	footer.appendChild( editBtn );
+		footer.appendChild( editBtn );
+	}
+
+	// Server-declared preview actions land after the built-ins —
+	// same descriptors, same `os.my-wordpress.preview-actions`
+	// filter the media pane and the tile context menu run. The
+	// section's `editAction` is excluded: it just rendered above.
+	const actionCtx = buildPreviewActionContext(
+		entity,
+		detail as unknown as Record< string, unknown >,
+		{ surface: 'pane' },
+	);
+	appendActionButtons(
+		footer,
+		withoutEditAction(
+			entity,
+			resolvePreviewActions(
+				getConfig().previewActions ?? [],
+				actionCtx,
+			),
+		),
+		actionCtx,
+	);
 
 	article.appendChild( footer );
 
@@ -4386,6 +4469,41 @@ function openEditor(
 }
 
 /**
+ * Edit one row the way its section says rows are edited — the
+ * classic editor, the declared `editAction`, or (editing off) fall
+ * back to navigating into the detail dossier so the gesture still
+ * lands somewhere. The tile dblclick and the menu's open entry both
+ * dispatch through here.
+ */
+function openEntityEditor(
+	state: RenderState,
+	entity: MyWordPressEntity,
+	item: EntityListItem,
+	title: string,
+	surface: 'dblclick' | 'context-menu',
+): void {
+	const resolution = resolveEditAction(
+		entity,
+		item as unknown as Record< string, unknown >,
+		surface,
+	);
+	if ( resolution.mode === 'action' ) {
+		runPreviewAction( resolution.action, resolution.ctx );
+		return;
+	}
+	if ( resolution.mode === 'none' ) {
+		navigate( state, {
+			kind: 'detail',
+			entityId: entity.id,
+			postId: item.id,
+			postTitle: title,
+		} );
+		return;
+	}
+	openEditor( entity, item.id, title, item.editUrl );
+}
+
+/**
  * One entry in an entity tile's context menu.
  *
  * Plugin-added entries must supply `onSelect`; the built-ins carry
@@ -4427,8 +4545,18 @@ function buildEntityActions(
 	item: EntityListItem,
 	title: string,
 ): SelectionAction< EntityListItem >[] {
-	const baseOptions: TileMenuOption[] = [
-		{
+	// The open entry mirrors the section's edit affordance: the
+	// classic-editor label by default, the declared `editAction`'s
+	// label/icon when the section named one, absent when editing is
+	// off (`false`, or the named action is unavailable).
+	const editResolution = resolveEditAction(
+		entity,
+		item as unknown as Record< string, unknown >,
+		'context-menu',
+	);
+	const baseOptions: TileMenuOption[] = [];
+	if ( editResolution.mode === 'classic' ) {
+		baseOptions.push( {
 			id: 'open',
 			label: __( 'Open in editor', 'desktop-mode' ),
 			icon: 'dashicons-edit',
@@ -4440,13 +4568,33 @@ function buildEntityActions(
 					__( 'Open %d items in the editor', 'desktop-mode' ),
 					n,
 				),
-		},
+		} );
+	} else if ( editResolution.mode === 'action' ) {
+		baseOptions.push( {
+			id: 'open',
+			label: editResolution.action.label,
+			icon: editResolution.action.icon ?? 'dashicons-edit',
+			sort: 10,
+			// Per-item fan-out on a set; the selection layer's default
+			// bulk label ("<label> (N items)") already reads right.
+			multi: true,
+		} );
+	}
+	baseOptions.push(
 		{
 			id: 'navigate-into',
 			label: __( 'Navigate into', 'desktop-mode' ),
 			icon: 'dashicons-category',
 			sort: 20,
 		},
+		// Server-declared preview actions ride the same menu the
+		// filter below extends, so `tile-context-menu` callbacks see
+		// (and may reorder / remove) them like any built-in. Ahead of
+		// the destructive entry: array order IS the single-item menu.
+		...previewActionsToMenuOptions(
+			entity,
+			item as unknown as Record< string, unknown >,
+		),
 		{
 			id: 'trash',
 			label: __( 'Move to Trash', 'desktop-mode' ),
@@ -4461,7 +4609,7 @@ function buildEntityActions(
 					n,
 				),
 		},
-	];
+	);
 
 	const ctxFilter = {
 		entityId: entity.id,
@@ -4506,7 +4654,13 @@ function buildEntityActions(
 			bulkLabel: option.bulkLabel,
 			onClick: () => {
 				if ( option.id === 'open' ) {
-					openEditor( entity, item.id, title, item.editUrl );
+					openEntityEditor(
+						state,
+						entity,
+						item,
+						title,
+						'context-menu',
+					);
 					return;
 				}
 				if ( option.id === 'navigate-into' ) {
@@ -5746,6 +5900,20 @@ async function renderUserPreviewPane(
 		footer.appendChild( btn );
 	}
 
+	// Server-declared preview actions land after the filter-built
+	// row. `user-preview-actions` keeps managing the built-ins; the
+	// descriptors are the same ones every other pane renders.
+	const actionCtx = buildPreviewActionContext(
+		entity,
+		item as unknown as Record< string, unknown >,
+		{ surface: 'pane' },
+	);
+	appendActionButtons(
+		footer,
+		resolvePreviewActions( getConfig().previewActions ?? [], actionCtx ),
+		actionCtx,
+	);
+
 	if ( footer.childElementCount > 0 ) {
 		node.appendChild( footer );
 	}
@@ -5813,6 +5981,15 @@ function buildUserActions(
 				),
 		} );
 	}
+
+	// Server-declared preview actions ride the same menu the filter
+	// below extends — the descriptors every other surface renders.
+	baseOptions.push(
+		...previewActionsToMenuOptions(
+			entity,
+			item as unknown as Record< string, unknown >,
+		),
+	);
 
 	// Same plugin seam the posts/media grids run — kind 'user'.
 	const ctxFilter = {

--- a/src/my-wordpress/kind-registry.ts
+++ b/src/my-wordpress/kind-registry.ts
@@ -16,7 +16,11 @@
  * @public
  */
 
-import type { MyWordPressEntity, Route } from './types';
+import type {
+	MyWordPressEntity,
+	PreviewActionSurface,
+	Route,
+} from './types';
 
 /**
  * Surface passed to every renderer. The renderer paints into
@@ -41,6 +45,22 @@ export interface EntityRenderHost {
 	 * subscription / observer / timer they create.
 	 */
 	addTeardown: ( fn: () => void ) => void;
+	/**
+	 * Resolve the section's server-declared preview actions
+	 * (`openstation_my_wordpress_preview_actions`) against one item
+	 * and return the same ready-made action row the built-in panes
+	 * render — or null when none apply. Runs the
+	 * `os.my-wordpress.preview-actions` JS filter, so a custom-kind
+	 * renderer gets the whole pipeline from one call.
+	 */
+	previewActionRow: ( args: {
+		/** The selected item, as the server sent it. */
+		item: Record< string, unknown >;
+		/** MIME type, when the item is a media file. */
+		mime?: string;
+		/** Invocation surface. Default `'pane'`. */
+		surface?: PreviewActionSurface;
+	} ) => HTMLElement | null;
 }
 
 /**

--- a/src/my-wordpress/media-detail.ts
+++ b/src/my-wordpress/media-detail.ts
@@ -384,6 +384,8 @@ export async function renderMediaDetail(
 	renderMediaPreview( previewHost, mediaItem, {
 		entityId,
 		previewActions: getConfig().previewActions ?? [],
+		postType: getConfig().entities.find( ( e ) => e.id === entityId )
+			?.post_type,
 	} );
 	right.appendChild( previewHost );
 

--- a/src/my-wordpress/media-list.ts
+++ b/src/my-wordpress/media-list.ts
@@ -37,6 +37,7 @@ import type { MediaListItem, MyWordPressEntity, MediaPreviewAction } from './typ
 import { deleteMediaItem, fetchMediaItem, fetchMediaPage } from './media-rest';
 import { getConfig } from './rest';
 import { dashiconForMime, renderMediaPreview } from './media-preview';
+import { previewActionsToMenuOptions } from './preview-actions';
 import { stripTags } from './dom-utils';
 
 /**
@@ -320,6 +321,15 @@ function buildMediaActions(
 			icon: 'dashicons-external',
 			sort: 20,
 		},
+		// Server-declared preview actions ride the same menu the
+		// filter below extends, so `tile-context-menu` callbacks see
+		// (and may reorder / remove) them like any built-in. Ahead of
+		// the destructive entry: array order IS the single-item menu.
+		...previewActionsToMenuOptions(
+			ctx.entity,
+			media as unknown as Record< string, unknown >,
+			{ mime: media.mime_type },
+		),
 		{
 			id: 'delete',
 			label: __( 'Delete permanently', 'desktop-mode' ),
@@ -630,6 +640,7 @@ function previewSelectedMedia(
 	renderMediaPreview( ctx.preview, media, {
 		entityId: ctx.entity.id,
 		previewActions: ctx.previewActions,
+		postType: ctx.entity.post_type,
 		onOpenDetail: () => {
 			ctx.host.navigate( {
 				kind: 'media-detail',

--- a/src/my-wordpress/media-preview.ts
+++ b/src/my-wordpress/media-preview.ts
@@ -21,14 +21,20 @@
  */
 
 import { __ } from '../i18n';
-import { applyFilters, doAction } from '../hooks';
+import { doAction } from '../hooks';
 import { stripTags } from './dom-utils';
+import { buildActionRow, resolvePreviewActions } from './preview-actions';
 import type {
 	MediaListItem,
 	MediaPreviewAction,
 	MediaPreviewActionContext,
 	MediaPreviewSlot,
 } from './types';
+
+// The scoping/filter pipeline lives in `./preview-actions` now that
+// every section kind renders the same descriptors; re-exported so
+// pre-split importers keep resolving.
+export { resolvePreviewActions } from './preview-actions';
 
 const MIME_DASHICON_FALLBACK = 'dashicons-media-default';
 
@@ -263,85 +269,6 @@ function fireSlot(
 }
 
 /**
- * Resolve which action descriptors apply to the given context and
- * call the JS-filter so plugins can attach handlers / hide entries.
- */
-export function resolvePreviewActions(
-	descriptors: MediaPreviewAction[],
-	ctx: MediaPreviewActionContext,
-): MediaPreviewAction[] {
-	const scoped = descriptors.filter( ( a ) => {
-		if ( a.sections && a.sections.length > 0 ) {
-			if ( ! a.sections.includes( ctx.entityId ) && ! a.sections.includes( '*' ) ) {
-				return false;
-			}
-		}
-		if ( a.mime ) {
-			// MIME-scoped descriptor: fail closed on the
-			// non-media-context call site so a `^image/` action
-			// doesn't leak into a Posts preview pane.
-			if ( ! ctx.mime ) {
-				return false;
-			}
-			try {
-				const re = new RegExp( a.mime );
-				if ( ! re.test( ctx.mime ) ) {
-					return false;
-				}
-			} catch {
-				// Malformed regex from PHP — skip the action.
-				return false;
-			}
-		}
-		return true;
-	} );
-	const merged = applyFilters<
-		MediaPreviewAction[],
-		[ MediaPreviewActionContext ]
-	>( 'os.my-wordpress.preview-actions', scoped, ctx );
-	return Array.isArray( merged ) ? merged : scoped;
-}
-
-function buildActionRow(
-	actions: MediaPreviewAction[],
-	ctx: MediaPreviewActionContext,
-): HTMLElement | null {
-	const visible = actions.filter( ( a ) =>
-		typeof a.isVisible === 'function' ? a.isVisible( ctx ) : true,
-	);
-	if ( visible.length === 0 ) {
-		return null;
-	}
-	const row = document.createElement( 'div' );
-	row.className = 'os-my-wordpress__media-actions';
-	row.setAttribute( 'role', 'toolbar' );
-	for ( const action of visible ) {
-		const btn = document.createElement( 'os-button' );
-		btn.setAttribute( 'variant', 'secondary' );
-		btn.dataset.actionId = action.id;
-		if ( action.icon ) {
-			btn.setAttribute( 'icon', action.icon );
-		}
-		btn.textContent = action.label;
-		btn.addEventListener( 'click', () => {
-			if ( typeof action.onSelect === 'function' ) {
-				try {
-					void action.onSelect( ctx );
-				} catch {
-					// Handler is plugin code — log via console only.
-					// eslint-disable-next-line no-console
-					console.error(
-						`[my-wordpress] preview action ${ action.id } threw.`,
-					);
-				}
-			}
-		} );
-		row.appendChild( btn );
-	}
-	return row;
-}
-
-/**
  * Paint the right-pane preview for a media item. Replaces any
  * existing content under `host`.
  *
@@ -353,6 +280,8 @@ export function renderMediaPreview(
 	opts: {
 		entityId: string;
 		previewActions: MediaPreviewAction[];
+		/** The section's declared post type slug, when it has one. */
+		postType?: string;
 		onOpenDetail?: () => void;
 	},
 ): void {
@@ -370,11 +299,16 @@ export function renderMediaPreview(
 	pane.appendChild( header );
 
 	const item = media as unknown as Record< string, unknown >;
+	// `kind` stays 'media' even when the drill-in was entered from a
+	// non-media section — the rendered item IS an attachment.
 	const ctx: MediaPreviewActionContext = {
 		entityId: opts.entityId,
 		kind: 'media',
+		postType: opts.postType,
 		mime: media.mime_type,
 		item,
+		itemId: media.id,
+		surface: 'pane',
 	};
 
 	fireSlot( header, 'header', opts.entityId, 'media', item );

--- a/src/my-wordpress/preview-actions.ts
+++ b/src/my-wordpress/preview-actions.ts
@@ -1,0 +1,311 @@
+/**
+ * My WordPress — preview actions, the one pipeline.
+ *
+ * Server descriptors collected via the PHP filter
+ * `openstation_my_wordpress_preview_actions` become buttons in the
+ * right pane and entries in the tile context menu — in every section,
+ * whatever its render kind. This module owns the whole client side of
+ * that contract: section/MIME scoping, the
+ * `os.my-wordpress.preview-actions` JS filter, and the button/menu
+ * builders each surface calls.
+ *
+ * A descriptor's `sections` list matches the section **id**
+ * (`'media'`, `'cpt-atf-forms'`), the section's declared **post type
+ * slug** (`'atf-forms'`), or `'*'` for every section. Plugin authors
+ * know their post type; the `cpt-` id prefix is our derivation — both
+ * spellings work so neither has to be looked up.
+ *
+ * @public
+ */
+
+import { applyFilters } from '../hooks';
+import { getConfig } from './rest';
+import type {
+	MyWordPressEntity,
+	PreviewAction,
+	PreviewActionContext,
+	PreviewActionSurface,
+} from './types';
+
+/**
+ * Build the context handed to `onSelect` / `isVisible` and the JS
+ * filter for an item selected in the given section.
+ *
+ * @public
+ */
+export function buildPreviewActionContext(
+	entity: MyWordPressEntity,
+	item: Record< string, unknown >,
+	opts: { surface: PreviewActionSurface; mime?: string } = { surface: 'pane' },
+): PreviewActionContext {
+	const id = Number( item.id );
+	return {
+		entityId: entity.id,
+		kind: entity.kind ?? 'post',
+		postType: entity.post_type,
+		mime: opts.mime,
+		item,
+		itemId: Number.isFinite( id ) ? id : undefined,
+		surface: opts.surface,
+	};
+}
+
+/**
+ * Resolve which action descriptors apply to the given context and
+ * call the JS-filter so plugins can attach handlers / hide entries.
+ *
+ * @public
+ */
+export function resolvePreviewActions(
+	descriptors: PreviewAction[],
+	ctx: PreviewActionContext,
+): PreviewAction[] {
+	const scoped = descriptors.filter( ( a ) => {
+		if ( a.sections && a.sections.length > 0 ) {
+			const matches =
+				a.sections.includes( ctx.entityId ) ||
+				a.sections.includes( '*' ) ||
+				( !! ctx.postType && a.sections.includes( ctx.postType ) );
+			if ( ! matches ) {
+				return false;
+			}
+		}
+		if ( a.mime ) {
+			// MIME-scoped descriptor: fail closed on the
+			// non-media-context call site so a `^image/` action
+			// doesn't leak into a Posts preview pane.
+			if ( ! ctx.mime ) {
+				return false;
+			}
+			try {
+				const re = new RegExp( a.mime );
+				if ( ! re.test( ctx.mime ) ) {
+					return false;
+				}
+			} catch {
+				// Malformed regex from PHP — skip the action.
+				return false;
+			}
+		}
+		return true;
+	} );
+	const merged = applyFilters<
+		PreviewAction[],
+		[ PreviewActionContext ]
+	>( 'os.my-wordpress.preview-actions', scoped, ctx );
+	return Array.isArray( merged ) ? merged : scoped;
+}
+
+/**
+ * Invoke a preview action's handler, swallowing plugin-code throws.
+ *
+ * @public
+ */
+export function runPreviewAction(
+	action: PreviewAction,
+	ctx: PreviewActionContext,
+): void {
+	if ( typeof action.onSelect !== 'function' ) {
+		return;
+	}
+	try {
+		void action.onSelect( ctx );
+	} catch {
+		// Handler is plugin code — log via console only.
+		// eslint-disable-next-line no-console
+		console.error(
+			`[my-wordpress] preview action ${ action.id } threw.`,
+		);
+	}
+}
+
+/**
+ * Drop the action a section named as its `editAction` — it renders
+ * as the section's edit affordance instead of a generic row/menu
+ * entry, and rendering it in both places would be a duplicate.
+ *
+ * @public
+ */
+export function withoutEditAction(
+	entity: MyWordPressEntity,
+	actions: PreviewAction[],
+): PreviewAction[] {
+	return typeof entity.editAction === 'string'
+		? actions.filter( ( a ) => a.id !== entity.editAction )
+		: actions;
+}
+
+/**
+ * What "edit this row" means for a section — see
+ * `MyWordPressEntity.editAction`.
+ *
+ * @public
+ */
+export type EditActionResolution =
+	| { mode: 'classic' }
+	| { mode: 'none' }
+	| { mode: 'action'; action: PreviewAction; ctx: PreviewActionContext };
+
+/**
+ * Resolve the section's edit affordance for one item.
+ *
+ * `'classic'` — no declaration; the classic-editor URL applies.
+ * `'none'`   — editing is off: declared `false`, or the named action
+ *              is unavailable (dropped server-side, no `onSelect`
+ *              wired, or `isVisible` said no) — the classic URL is
+ *              known-broken for such a section, so hiding beats a
+ *              button that 404s.
+ * `'action'` — the named action, resolved through the full pipeline,
+ *              with the ctx to invoke it with.
+ *
+ * @public
+ */
+export function resolveEditAction(
+	entity: MyWordPressEntity,
+	item: Record< string, unknown >,
+	surface: PreviewActionSurface,
+): EditActionResolution {
+	if ( entity.editAction === undefined ) {
+		return { mode: 'classic' };
+	}
+	if ( entity.editAction === false ) {
+		return { mode: 'none' };
+	}
+	const ctx = buildPreviewActionContext( entity, item, { surface } );
+	const action = resolvePreviewActions(
+		getConfig().previewActions ?? [],
+		ctx,
+	).find( ( a ) => a.id === entity.editAction );
+	if (
+		! action ||
+		typeof action.onSelect !== 'function' ||
+		( typeof action.isVisible === 'function' && ! action.isVisible( ctx ) )
+	) {
+		return { mode: 'none' };
+	}
+	return { mode: 'action', action, ctx };
+}
+
+/**
+ * Append one `<os-button>` per visible action to `container`.
+ * Returns the number of buttons appended, so a caller that owns the
+ * container (the post pane's footer) can skip separators when zero.
+ *
+ * @public
+ */
+export function appendActionButtons(
+	container: HTMLElement,
+	actions: PreviewAction[],
+	ctx: PreviewActionContext,
+): number {
+	const visible = actions.filter( ( a ) =>
+		typeof a.isVisible === 'function' ? a.isVisible( ctx ) : true,
+	);
+	for ( const action of visible ) {
+		const btn = document.createElement( 'os-button' );
+		btn.setAttribute( 'variant', 'secondary' );
+		btn.dataset.actionId = action.id;
+		if ( action.icon ) {
+			btn.setAttribute( 'icon', action.icon );
+		}
+		btn.textContent = action.label;
+		btn.addEventListener( 'click', () =>
+			runPreviewAction( action, ctx ),
+		);
+		container.appendChild( btn );
+	}
+	return visible.length;
+}
+
+/**
+ * Wrap the visible actions in the standalone toolbar row the media
+ * pane renders, or null when none apply.
+ *
+ * @public
+ */
+export function buildActionRow(
+	actions: PreviewAction[],
+	ctx: PreviewActionContext,
+): HTMLElement | null {
+	const row = document.createElement( 'div' );
+	row.className = 'os-my-wordpress__media-actions';
+	row.setAttribute( 'role', 'toolbar' );
+	return appendActionButtons( row, actions, ctx ) > 0 ? row : null;
+}
+
+/**
+ * One-call convenience for section renderers (built-in and custom
+ * kinds): resolve the window config's descriptors against this
+ * section + item and return the ready action row, or null.
+ *
+ * @public
+ */
+export function buildPreviewActionRow(
+	entity: MyWordPressEntity,
+	item: Record< string, unknown >,
+	opts: { surface?: PreviewActionSurface; mime?: string } = {},
+): HTMLElement | null {
+	const ctx = buildPreviewActionContext( entity, item, {
+		surface: opts.surface ?? 'pane',
+		mime: opts.mime,
+	} );
+	const resolved = withoutEditAction(
+		entity,
+		resolvePreviewActions( getConfig().previewActions ?? [], ctx ),
+	);
+	return buildActionRow( resolved, ctx );
+}
+
+/**
+ * A context-menu entry derived from a preview-action descriptor.
+ * Structurally a `TileMenuOption` minus the built-in-only fields, so
+ * the menu builders can splice these straight into their base list
+ * before the `os.my-wordpress.tile-context-menu` filter runs.
+ *
+ * @public
+ */
+export interface PreviewActionMenuOption {
+	id: string;
+	label: string;
+	icon: string;
+	sort: number;
+	onSelect: () => void;
+}
+
+/**
+ * Sort slot for descriptor-derived menu entries: after the built-in
+ * navigation entries (10/20), before destructive ones (90).
+ */
+const MENU_SORT = 50;
+
+/**
+ * Map the section's applicable descriptors to context-menu entries.
+ * The zero-arg menu `onSelect` closes over the ctx-carrying handler.
+ *
+ * @public
+ */
+export function previewActionsToMenuOptions(
+	entity: MyWordPressEntity,
+	item: Record< string, unknown >,
+	opts: { mime?: string } = {},
+): PreviewActionMenuOption[] {
+	const ctx = buildPreviewActionContext( entity, item, {
+		surface: 'context-menu',
+		mime: opts.mime,
+	} );
+	const resolved = withoutEditAction(
+		entity,
+		resolvePreviewActions( getConfig().previewActions ?? [], ctx ),
+	);
+	return resolved
+		.filter( ( a ) =>
+			typeof a.isVisible === 'function' ? a.isVisible( ctx ) : true,
+		)
+		.map( ( action ) => ( {
+			id: action.id,
+			label: action.label,
+			icon: action.icon ?? 'dashicons-admin-generic',
+			sort: MENU_SORT,
+			onSelect: () => runPreviewAction( action, ctx ),
+		} ) );
+}

--- a/src/my-wordpress/rest.ts
+++ b/src/my-wordpress/rest.ts
@@ -162,9 +162,16 @@ export async function fetchEntityDetail(
 ): Promise< EntityDetail > {
 	const cfg = getConfig();
 	const url = new URL( buildUrl( `${ entity.restPath }/${ id }` ) );
+	// `editUrl` and the section's own `listFields` ride the detail
+	// request too — the row-supplied editor URL (the HPOS escape
+	// hatch, see `EntityListItem.editUrl`) has to reach the preview
+	// pane's "Open in editor" button, not just the list tiles.
 	url.searchParams.set(
 		'_fields',
-		'id,title,content,excerpt,date,modified,status,link,author,featured_media,categories,tags,comment_status,openstation_contributors,openstation_attached_media,_links,_embedded',
+		[
+			'id,title,content,excerpt,date,modified,status,link,author,featured_media,categories,tags,comment_status,openstation_contributors,openstation_attached_media,editUrl,_links,_embedded',
+			...( entity.listFields ?? [] ),
+		].join( ',' ),
 	);
 	url.searchParams.set( '_embed', 'author,wp:term,wp:featuredmedia,replies' );
 

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -75,6 +75,30 @@ export interface MyWordPressEntity {
 	 */
 	listQuery?: Record< string, string >;
 	/**
+	 * Who edits this section's rows.
+	 *
+	 * Omitted: the classic editor — "Open in editor" builds
+	 * `post.php?post=<id>&action=edit` (a row-supplied `editUrl`
+	 * field wins when present).
+	 *
+	 * A **string** names a preview action (declared via
+	 * `openstation_my_wordpress_preview_actions`, so it stays
+	 * capability-gated and its script auto-enqueues) that REPLACES
+	 * "Open in editor" everywhere the section offers editing: the
+	 * pane's primary button, the tile context menu's open entry (and
+	 * its bulk fan-out), and tile double-click. The action is removed
+	 * from the generic action row/menu so it doesn't render twice.
+	 * If the named action didn't ship (capability) or no JS wired its
+	 * `onSelect`, the edit affordances hide — for a type with no
+	 * editor screen the classic URL is known-broken, and a button
+	 * that 404s is worse than no button.
+	 *
+	 * **`false`** removes every edit affordance: no editor button, no
+	 * open entry, double-click falls back to the detail dossier, and
+	 * the bulk "Edit…" modal is suppressed too.
+	 */
+	editAction?: string | false;
+	/**
 	 * Folder this section nests under at the root of the window.
 	 * Sections registered by the same plugin or theme share a group
 	 * id, so they render as one folder that drills into its members.
@@ -139,24 +163,28 @@ export interface MyWordPressConfig {
 	 * gated — never present here unless the current user can run
 	 * the action.
 	 */
-	previewActions?: MediaPreviewAction[];
+	previewActions?: PreviewAction[];
 }
 
 /**
- * Server-declared descriptor for a right-pane action button.
- * Plugins push these via `openstation_my_wordpress_preview_actions`
- * (PHP) and complete the JS handler via the
- * `os.my-wordpress.preview-actions` filter.
+ * Server-declared descriptor for a preview action — a button in the
+ * right pane and an entry in the tile context menu, in every section
+ * regardless of kind. Plugins push these via
+ * `openstation_my_wordpress_preview_actions` (PHP) and complete the
+ * JS handler via the `os.my-wordpress.preview-actions` filter.
  *
  * @public
  */
-export interface MediaPreviewAction {
+export interface PreviewAction {
 	id: string;
 	label: string;
 	icon?: string;
 	/** PCRE — server-checked before shipping; client re-checks per item. */
 	mime?: string;
-	/** Section ids this action is visible in. Default: all. */
+	/**
+	 * Section ids and/or post type slugs this action is visible in
+	 * (`'*'` matches every section). Default: all.
+	 */
 	sections?: string[];
 	/** Optional `wp_register_script` handle the server enqueues. */
 	script?: string;
@@ -165,13 +193,20 @@ export interface MediaPreviewAction {
 	 * `os.my-wordpress.preview-actions` JS filter, never
 	 * by the server descriptor.
 	 */
-	onSelect?: ( ctx: MediaPreviewActionContext ) => void | Promise< void >;
+	onSelect?: ( ctx: PreviewActionContext ) => void | Promise< void >;
 	/**
 	 * Optional visibility predicate evaluated client-side after the
 	 * server-side `capability` / `mime` checks have already passed.
 	 */
-	isVisible?: ( ctx: MediaPreviewActionContext ) => boolean;
+	isVisible?: ( ctx: PreviewActionContext ) => boolean;
 }
+
+/**
+ * @deprecated Use {@link PreviewAction}. Alias kept while the surface
+ * was media-only.
+ * @public
+ */
+export type MediaPreviewAction = PreviewAction;
 
 /**
  * Slot identifier for plugin-injected DOM in the right pane.
@@ -185,20 +220,48 @@ export interface MediaPreviewAction {
 export type MediaPreviewSlot = 'header' | 'meta' | 'footer';
 
 /**
+ * Where a preview action was invoked from.
+ *
+ * @public
+ */
+export type PreviewActionSurface = 'pane' | 'context-menu' | 'dblclick' | 'bulk';
+
+/**
  * Context object passed to every preview-action handler.
  *
  * @public
  */
-export interface MediaPreviewActionContext {
-	/** Entity id (`'media'`, `'posts'`, `'users'`, …). */
+export interface PreviewActionContext {
+	/** Entity id (`'media'`, `'posts'`, `'cpt-atf-forms'`, …). */
 	entityId: string;
 	/** Section render-kind (`'media'`, `'post'`, `'user'`, …). */
 	kind: string;
+	/** The section's declared post type slug, when it has one. */
+	postType?: string;
 	/** MIME type for media items, undefined for non-media kinds. */
 	mime?: string;
-	/** The full server item record. */
+	/**
+	 * The selected entity, as the server sent it: the detail record
+	 * in the right pane, the list row in context menus. `item.id` is
+	 * present on both — deep-linking handlers should read that rather
+	 * than detail-only fields.
+	 */
 	item: Record< string, unknown >;
+	/** Convenience — `Number( item.id )` when numeric. */
+	itemId?: number;
+	/**
+	 * Invocation surface. Always set by the bundle; optional only so
+	 * pre-existing hand-built contexts stay type-valid.
+	 */
+	surface?: PreviewActionSurface;
 }
+
+/**
+ * @deprecated Use {@link PreviewActionContext}. Alias kept while the
+ * surface was media-only.
+ * @public
+ */
+export type MediaPreviewActionContext = PreviewActionContext;
 
 export interface EntityLock {
 	userId: number;

--- a/src/my-wordpress/types.ts
+++ b/src/my-wordpress/types.ts
@@ -222,9 +222,14 @@ export type MediaPreviewSlot = 'header' | 'meta' | 'footer';
 /**
  * Where a preview action was invoked from.
  *
+ * A multi-select run reports `'context-menu'`, not a surface of its
+ * own: the selection layer fans a bulk choice out by replaying each
+ * row's own single-item handler, so the handler genuinely is the
+ * context-menu one, called once per item.
+ *
  * @public
  */
-export type PreviewActionSurface = 'pane' | 'context-menu' | 'dblclick' | 'bulk';
+export type PreviewActionSurface = 'pane' | 'context-menu' | 'dblclick';
 
 /**
  * Context object passed to every preview-action handler.

--- a/tests/phpunit/tests/myWordpress.php
+++ b/tests/phpunit/tests/myWordpress.php
@@ -192,6 +192,43 @@ class Tests_OpenStation_MyWordpress extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The collector must pass descriptor fields through verbatim —
+	 * `editAction` (string or false) is consumed by the bundle, and a
+	 * future server-side "sanitizer" that dropped unknown keys would
+	 * silently re-enable the classic editor on sections that turned
+	 * it off.
+	 *
+	 * @covers ::openstation_my_wordpress_entities
+	 */
+	public function test_entities_filter_passes_edit_action_through() {
+		add_filter( 'openstation_my_wordpress_entities', static function ( $entities ) {
+			$entities[] = array(
+				'id'         => 'atf-forms',
+				'label'      => 'Forms',
+				'icon'       => 'dashicons-feedback',
+				'restPath'   => 'wp/v2/atf-form',
+				'post_type'  => 'atf-form',
+				'editAction' => 'atf/open-builder',
+			);
+			$entities[] = array(
+				'id'         => 'atf-entries',
+				'label'      => 'Entries',
+				'icon'       => 'dashicons-email',
+				'restPath'   => 'desktop-mode/v1/post-type/atf-entry',
+				'editAction' => false,
+			);
+			return $entities;
+		} );
+
+		$by_id = array();
+		foreach ( openstation_my_wordpress_entities() as $entity ) {
+			$by_id[ $entity['id'] ] = $entity;
+		}
+		$this->assertSame( 'atf/open-builder', $by_id['atf-forms']['editAction'] );
+		$this->assertFalse( $by_id['atf-entries']['editAction'] );
+	}
+
+	/**
 	 * @covers ::openstation_my_wordpress_user_can_use
 	 */
 	public function test_subscriber_cannot_use_by_default() {

--- a/tests/phpunit/tests/myWordpressPreviewActions.php
+++ b/tests/phpunit/tests/myWordpressPreviewActions.php
@@ -60,6 +60,97 @@ class Tests_OpenStation_MyWordpressPreviewActions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `sections` is the plugin's scoping contract — it must reach the
+	 * bundle verbatim, post-type slugs and the `*` wildcard included
+	 * (matching is client-side).
+	 *
+	 * @covers ::openstation_my_wordpress_collect_preview_actions
+	 */
+	public function test_sections_pass_through_verbatim() {
+		add_filter(
+			'openstation_my_wordpress_preview_actions',
+			static function ( $actions ) {
+				$actions[] = array(
+					'id'       => 'scoped',
+					'label'    => 'Scoped',
+					'sections' => array( 'atf-forms', 'cpt-atf-forms', '*' ),
+				);
+				return $actions;
+			}
+		);
+		wp_set_current_user( $this->admin_id );
+		$actions = openstation_my_wordpress_collect_preview_actions();
+		$this->assertSame(
+			array( 'atf-forms', 'cpt-atf-forms', '*' ),
+			$actions[0]['sections']
+		);
+	}
+
+	/**
+	 * A plugin registering its filter AFTER `init` 99 (when the window
+	 * config was snapshotted) must still reach the emitted blob — the
+	 * emit-time refresh re-collects. This was the reported bug: the
+	 * action's script loaded (scripts were always collected late) but
+	 * its descriptor never shipped.
+	 *
+	 * @covers ::openstation_my_wordpress_refresh_window_config
+	 */
+	public function test_late_registered_action_reaches_emitted_config() {
+		wp_set_current_user( $this->admin_id );
+
+		// "Late": the snapshot below is taken before the filter exists,
+		// mirroring a window registered at init 99 and a plugin hooking
+		// on admin_init.
+		$snapshot = array( 'previewActions' => array() );
+
+		add_filter(
+			'openstation_my_wordpress_preview_actions',
+			static function ( $actions ) {
+				$actions[] = array(
+					'id'    => 'late',
+					'label' => 'Late',
+				);
+				return $actions;
+			}
+		);
+
+		$emitted = apply_filters(
+			'openstation_native_window_config',
+			$snapshot,
+			'desktop-mode-my-wordpress'
+		);
+		$ids = wp_list_pluck( $emitted['previewActions'], 'id' );
+		$this->assertContains( 'late', $ids );
+	}
+
+	/**
+	 * The refresh hook is scoped to the My WordPress window — every
+	 * other window's config passes through untouched.
+	 *
+	 * @covers ::openstation_my_wordpress_refresh_window_config
+	 */
+	public function test_refresh_leaves_other_windows_untouched() {
+		wp_set_current_user( $this->admin_id );
+		add_filter(
+			'openstation_my_wordpress_preview_actions',
+			static function ( $actions ) {
+				$actions[] = array(
+					'id'    => 'late',
+					'label' => 'Late',
+				);
+				return $actions;
+			}
+		);
+
+		$emitted = apply_filters(
+			'openstation_native_window_config',
+			array( 'previewActions' => array() ),
+			'some-other-window'
+		);
+		$this->assertSame( array(), $emitted['previewActions'] );
+	}
+
+	/**
 	 * @covers ::openstation_my_wordpress_collect_preview_actions
 	 */
 	public function test_invalid_entries_are_dropped() {

--- a/tests/phpunit/tests/nativeWindowLazyScript.php
+++ b/tests/phpunit/tests/nativeWindowLazyScript.php
@@ -229,6 +229,107 @@ class Tests_OpenStation_NativeWindowLazyScript extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The emit-time `openstation_native_window_config` filter reaches
+	 * the lazy path — the synthesized `scriptL10n` assignment carries
+	 * the filtered blob, not just the registration-time snapshot.
+	 *
+	 * @covers ::openstation_filter_native_window_config
+	 * @covers ::openstation_build_native_windows_payload
+	 */
+	public function test_config_filter_reaches_the_lazy_l10n() {
+		$this->register_demo_script( 'demo-main', 'https://example.test/main.js' );
+		$this->register_demo_window(
+			'demo-config-filter',
+			array(
+				'script' => 'demo-main',
+				'config' => array( 'stale' => 'snapshot' ),
+			)
+		);
+		add_filter(
+			'openstation_native_window_config',
+			static function ( $config, $window_id ) {
+				if ( 'demo-config-filter' === $window_id ) {
+					$config['fresh'] = 'emit-time';
+				}
+				return $config;
+			},
+			10,
+			2
+		);
+
+		$entry = $this->payload_entry( 'demo-config-filter' );
+		$this->assertNotNull( $entry );
+		$l10n = implode( "\n", $entry['scriptL10n'] );
+		$this->assertStringContainsString( 'emit-time', $l10n );
+		$this->assertStringContainsString( 'snapshot', $l10n );
+	}
+
+	/**
+	 * …and the eager path — the inline `before` attach on a preloaded
+	 * bundle serializes the same filtered blob.
+	 *
+	 * @covers ::openstation_filter_native_window_config
+	 * @covers ::openstation_enqueue_native_window_scripts
+	 */
+	public function test_config_filter_reaches_the_eager_inline() {
+		$this->register_demo_script( 'demo-main', 'https://example.test/main.js' );
+		$this->register_demo_window(
+			'demo-config-eager',
+			array(
+				'script'         => 'demo-main',
+				'preload_script' => true,
+				'config'         => array( 'stale' => 'snapshot' ),
+			)
+		);
+		add_filter(
+			'openstation_native_window_config',
+			static function ( $config, $window_id ) {
+				if ( 'demo-config-eager' === $window_id ) {
+					$config['fresh'] = 'emit-time';
+				}
+				return $config;
+			},
+			10,
+			2
+		);
+
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		openstation_enqueue_native_window_scripts();
+
+		$before = wp_scripts()->get_data( 'demo-main', 'before' );
+		$blob   = implode(
+			"\n",
+			array_filter( (array) $before, 'is_string' )
+		);
+		$this->assertStringContainsString( 'emit-time', $blob );
+	}
+
+	/**
+	 * A filter callback returning a non-array must not fatal the
+	 * payload build — the blob normalizes to "nothing to ship."
+	 *
+	 * @covers ::openstation_filter_native_window_config
+	 */
+	public function test_config_filter_non_array_return_ships_nothing() {
+		$this->register_demo_script( 'demo-main', 'https://example.test/main.js' );
+		$this->register_demo_window(
+			'demo-config-bogus',
+			array(
+				'script' => 'demo-main',
+				'config' => array( 'stale' => 'snapshot' ),
+			)
+		);
+		add_filter( 'openstation_native_window_config', '__return_false' );
+
+		$entry = $this->payload_entry( 'demo-config-bogus' );
+		$this->assertNotNull( $entry );
+		$this->assertStringNotContainsString(
+			'openStationWindowConfig',
+			implode( "\n", $entry['scriptL10n'] )
+		);
+	}
+
+	/**
 	 * The attach has to beat `openstation_enqueue_assets()` at
 	 * priority 10, which is where the boot payload is built.
 	 *

--- a/tests/vitest/agents-renderer.test.ts
+++ b/tests/vitest/agents-renderer.test.ts
@@ -77,6 +77,7 @@ function makeHost(): EntityRenderHost & { teardowns: Array< () => void > } {
 		route: { kind: 'list', entityId: 'agents' },
 		navigate: () => void 0,
 		addTeardown: ( fn: () => void ) => teardowns.push( fn ),
+		previewActionRow: () => null,
 		teardowns,
 	};
 }

--- a/tests/vitest/my-wordpress-edit-action.test.ts
+++ b/tests/vitest/my-wordpress-edit-action.test.ts
@@ -1,0 +1,398 @@
+/**
+ * `editAction` — a section chooses who edits its rows.
+ *
+ * A preview-action id replaces "Open in editor" at the pane button,
+ * the menu's open entry, and tile double-click; `false` removes the
+ * affordances (double-click falls back to the detail dossier, bulk
+ * "Edit…" is suppressed). The detail request must also carry
+ * `editUrl` + the section's `listFields`, so the pane's classic
+ * button honors a row-supplied editor URL.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { addFilter, removeFilter } from '../../src/hooks';
+import {
+	buildPreviewActionRow,
+	previewActionsToMenuOptions,
+	resolveEditAction,
+} from '../../src/my-wordpress/preview-actions';
+import { entityBulkActions } from '../../src/my-wordpress/bulk-actions';
+import { fetchEntityDetail } from '../../src/my-wordpress/rest';
+import type {
+	EntityListItem,
+	MyWordPressEntity,
+	PreviewAction,
+} from '../../src/my-wordpress/types';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+const NS = 'test/edit-action';
+
+interface NativeWindowsGlobal {
+	openStationNativeWindows?: Record<
+		string,
+		( ( body: HTMLElement ) => void | ( () => void ) ) | undefined
+	>;
+	openStationWindowConfig?: Record< string, unknown >;
+}
+
+function makeEntity(
+	overrides: Partial< MyWordPressEntity > = {},
+): MyWordPressEntity {
+	return {
+		id: 'cpt-atf-form',
+		label: 'Forms',
+		icon: 'dashicons-feedback',
+		restPath: 'wp/v2/atf-form',
+		kind: 'post',
+		post_type: 'atf-form',
+		...overrides,
+	};
+}
+
+const DETAIL: Record< string, unknown > = {
+	id: 7,
+	title: { rendered: 'Contact form' },
+	content: { rendered: '<p>A form.</p>' },
+	excerpt: { rendered: '' },
+	date: '2026-01-01T00:00:00',
+	status: 'publish',
+	link: 'http://example.test/?p=7',
+	featured_media: 0,
+};
+
+const BUILDER_ACTION: PreviewAction = {
+	id: 'atf/open-builder',
+	label: 'Open in form builder',
+	icon: 'dashicons-feedback',
+	sections: [ 'atf-form' ],
+};
+
+function installConfig(
+	entity: MyWordPressEntity,
+	previewActions: PreviewAction[],
+): void {
+	( window as unknown as NativeWindowsGlobal ).openStationWindowConfig = {
+		[ WINDOW_ID ]: {
+			restRoot: 'http://example.test/wp-json/',
+			restNonce: 'nonce',
+			editPostUrlBase: 'http://example.test/wp-admin/post.php',
+			editUserUrlBase: 'http://example.test/wp-admin/user-edit.php',
+			siteName: 'Example',
+			entities: [ entity ],
+			groups: [],
+			perPage: 24,
+			mediaPerPage: 48,
+			previewActions,
+		},
+	};
+}
+
+/** Wire onSelect onto the builder action via the JS filter. */
+function wireBuilder( onSelect: () => void ): void {
+	addFilter(
+		'os.my-wordpress.preview-actions',
+		NS,
+		( actions: PreviewAction[] ) =>
+			actions.map( ( a ) =>
+				a.id === 'atf/open-builder' ? { ...a, onSelect } : a,
+			),
+	);
+}
+
+describe( 'my-wordpress — editAction resolution', () => {
+	beforeEach( () => installHooksStub() );
+	afterEach( () => {
+		removeFilter( 'os.my-wordpress.preview-actions', NS );
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'undefined → classic; false → none', () => {
+		installConfig( makeEntity(), [] );
+		expect(
+			resolveEditAction( makeEntity(), DETAIL, 'pane' ).mode,
+		).toBe( 'classic' );
+		expect(
+			resolveEditAction(
+				makeEntity( { editAction: false } ),
+				DETAIL,
+				'pane',
+			).mode,
+		).toBe( 'none' );
+	} );
+
+	test( 'a wired, visible named action resolves with its ctx', () => {
+		const onSelect = vi.fn();
+		installConfig(
+			makeEntity( { editAction: 'atf/open-builder' } ),
+			[ BUILDER_ACTION ],
+		);
+		wireBuilder( onSelect );
+		const res = resolveEditAction(
+			makeEntity( { editAction: 'atf/open-builder' } ),
+			DETAIL,
+			'dblclick',
+		);
+		expect( res.mode ).toBe( 'action' );
+		if ( res.mode === 'action' ) {
+			expect( res.action.label ).toBe( 'Open in form builder' );
+			expect( res.ctx.surface ).toBe( 'dblclick' );
+			expect( res.ctx.itemId ).toBe( 7 );
+		}
+	} );
+
+	test( 'a named action that is missing or unwired hides editing', () => {
+		// Not in the config (server dropped it — capability).
+		installConfig(
+			makeEntity( { editAction: 'atf/open-builder' } ),
+			[],
+		);
+		expect(
+			resolveEditAction(
+				makeEntity( { editAction: 'atf/open-builder' } ),
+				DETAIL,
+				'pane',
+			).mode,
+		).toBe( 'none' );
+
+		// Shipped, but no JS wired onSelect.
+		installConfig(
+			makeEntity( { editAction: 'atf/open-builder' } ),
+			[ BUILDER_ACTION ],
+		);
+		expect(
+			resolveEditAction(
+				makeEntity( { editAction: 'atf/open-builder' } ),
+				DETAIL,
+				'pane',
+			).mode,
+		).toBe( 'none' );
+	} );
+
+	test( 'the named action leaves the generic row and menu', () => {
+		const entity = makeEntity( { editAction: 'atf/open-builder' } );
+		installConfig( entity, [
+			BUILDER_ACTION,
+			{ id: 'atf/export', label: 'Export', sections: [ 'atf-form' ] },
+		] );
+		wireBuilder( () => undefined );
+
+		const row = buildPreviewActionRow( entity, DETAIL );
+		expect( row ).not.toBeNull();
+		expect(
+			row!.querySelector( '[data-action-id="atf/open-builder"]' ),
+		).toBeNull();
+		expect(
+			row!.querySelector( '[data-action-id="atf/export"]' ),
+		).not.toBeNull();
+
+		const menuIds = previewActionsToMenuOptions( entity, DETAIL ).map(
+			( o ) => o.id,
+		);
+		expect( menuIds ).toEqual( [ 'atf/export' ] );
+	} );
+
+	test( 'bulk "Edit…" is suppressed only by editAction: false', () => {
+		const item = DETAIL as unknown as EntityListItem;
+		const onChanged = () => undefined;
+
+		const withFalse = entityBulkActions(
+			{ entity: makeEntity( { editAction: false } ), onChanged },
+			item,
+		).map( ( a ) => a.id );
+		expect( withFalse ).not.toContain( 'bulk-edit' );
+
+		const withAction = entityBulkActions(
+			{
+				entity: makeEntity( { editAction: 'atf/open-builder' } ),
+				onChanged,
+			},
+			item,
+		).map( ( a ) => a.id );
+		expect( withAction ).toContain( 'bulk-edit' );
+
+		const classic = entityBulkActions(
+			{ entity: makeEntity(), onChanged },
+			item,
+		).map( ( a ) => a.id );
+		expect( classic ).toContain( 'bulk-edit' );
+	} );
+
+	test( 'detail requests carry editUrl and the section listFields', async () => {
+		const entity = makeEntity( { listFields: [ 'atfEntries' ] } );
+		installConfig( entity, [] );
+		const fetchSpy = vi.fn( () =>
+			Promise.resolve(
+				new Response( JSON.stringify( DETAIL ), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				} ),
+			),
+		);
+		vi.stubGlobal( 'fetch', fetchSpy );
+
+		await fetchEntityDetail( entity, 7 );
+
+		const url = String( fetchSpy.mock.calls[ 0 ][ 0 ] );
+		const fields =
+			new URL( url ).searchParams.get( '_fields' )?.split( ',' ) ?? [];
+		expect( fields ).toContain( 'editUrl' );
+		expect( fields ).toContain( 'atfEntries' );
+	} );
+} );
+
+describe( 'my-wordpress — editAction in the mounted window', () => {
+	beforeEach( () => {
+		installHooksStub();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( ( input: RequestInfo ) => {
+				const url = String( input );
+				const body = /\/atf-form\/7\b/.test( url )
+					? JSON.stringify( DETAIL )
+					: JSON.stringify( [ DETAIL ] );
+				return Promise.resolve(
+					new Response( body, {
+						status: 200,
+						headers: {
+							'Content-Type': 'application/json',
+							'X-WP-Total': '1',
+							'X-WP-TotalPages': '1',
+						},
+					} ),
+				);
+			} ),
+		);
+	} );
+
+	afterEach( () => {
+		removeFilter( 'os.my-wordpress.preview-actions', NS );
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	async function mountIntoForms(
+		entity: MyWordPressEntity,
+		previewActions: PreviewAction[],
+	): Promise< HTMLElement > {
+		installConfig( entity, previewActions );
+		await import( '../../src/my-wordpress/index' );
+		const cb = ( window as unknown as NativeWindowsGlobal )
+			.openStationNativeWindows?.[ WINDOW_ID ];
+		if ( typeof cb !== 'function' ) {
+			throw new Error( 'render callback not registered' );
+		}
+		const body = document.createElement( 'div' );
+		body.className = 'os-window__body';
+		body.innerHTML = `
+			<div class="desktop-mode-my-wordpress" data-os-my-wordpress-root>
+				<header data-os-my-wordpress-breadcrumbs></header>
+				<div class="os-my-wordpress__body" data-os-my-wordpress-body>
+					<div class="os-my-wordpress__loading" data-os-my-wordpress-loading hidden></div>
+				</div>
+				<div class="os-folder-status-bar" data-os-my-wordpress-status></div>
+			</div>
+		`;
+		document.body.appendChild( body );
+		cb( body );
+
+		const sectionTile = [
+			...body.querySelectorAll< HTMLElement >( 'os-tile' ),
+		].find( ( t ) =>
+			(
+				t.querySelector( '.os-file-tile__label' )?.textContent ?? ''
+			).startsWith( 'Forms' ),
+		);
+		if ( ! sectionTile ) {
+			throw new Error( 'no Forms tile' );
+		}
+		sectionTile.dispatchEvent(
+			new MouseEvent( 'dblclick', { bubbles: true } ),
+		);
+		await vi.waitFor( () => {
+			if ( ! body.querySelector( '[data-entry-id="7"]' ) ) {
+				throw new Error( 'tiles not painted' );
+			}
+		} );
+		return body;
+	}
+
+	test( 'the pane primary button is the declared editor', async () => {
+		const onSelect = vi.fn();
+		wireBuilder( onSelect );
+		const body = await mountIntoForms(
+			makeEntity( { editAction: 'atf/open-builder' } ),
+			[ BUILDER_ACTION ],
+		);
+
+		body.querySelector< HTMLElement >( '[data-entry-id="7"]' )?.click();
+
+		let btn: HTMLElement | null = null;
+		await vi.waitFor( () => {
+			btn = body.querySelector< HTMLElement >(
+				'.os-my-wordpress__article-footer [data-action-id="atf/open-builder"]',
+			);
+			if ( ! btn ) {
+				throw new Error( 'editor button not painted' );
+			}
+		} );
+		expect(
+			( btn as unknown as HTMLElement ).getAttribute( 'variant' ),
+		).toBe( 'primary' );
+		expect( ( btn as unknown as HTMLElement ).textContent ).toBe(
+			'Open in form builder',
+		);
+
+		( btn as unknown as HTMLElement ).dispatchEvent(
+			new Event( 'click', { bubbles: true } ),
+		);
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onSelect.mock.calls[ 0 ][ 0 ].surface ).toBe( 'pane' );
+
+		// No classic "Open in editor" alongside it.
+		const labels = [
+			...body.querySelectorAll(
+				'.os-my-wordpress__article-footer os-button',
+			),
+		].map( ( b ) => b.textContent );
+		expect( labels ).not.toContain( 'Open in editor' );
+	} );
+
+	test( 'editAction: false hides the button and dblclick opens the dossier', async () => {
+		const body = await mountIntoForms(
+			makeEntity( { editAction: false } ),
+			[],
+		);
+
+		body.querySelector< HTMLElement >( '[data-entry-id="7"]' )?.click();
+		await vi.waitFor( () => {
+			if ( ! body.querySelector( '.os-my-wordpress__article-footer' ) ) {
+				throw new Error( 'pane not painted' );
+			}
+		} );
+		const labels = [
+			...body.querySelectorAll(
+				'.os-my-wordpress__article-footer os-button',
+			),
+		].map( ( b ) => b.textContent );
+		expect( labels ).not.toContain( 'Open in editor' );
+
+		// Double-click falls back to navigating INTO the entry (the
+		// detail dossier renders sub-folder tiles) instead of opening
+		// a classic-editor window that would 404.
+		body.querySelector< HTMLElement >( '[data-entry-id="7"]' )
+			?.dispatchEvent( new MouseEvent( 'dblclick', { bubbles: true } ) );
+		await vi.waitFor( () => {
+			if (
+				! body.querySelector( '.os-my-wordpress__article' ) &&
+				! body.querySelector( '[data-relation]' )
+			) {
+				throw new Error( 'detail view not painted' );
+			}
+		} );
+	} );
+} );

--- a/tests/vitest/my-wordpress-kind-registry.test.ts
+++ b/tests/vitest/my-wordpress-kind-registry.test.ts
@@ -22,6 +22,7 @@ describe( 'my-wordpress kind-registry', () => {
 				route: { kind: 'list', entityId: 'foo' },
 				navigate: () => {},
 				addTeardown: () => {},
+				previewActionRow: () => null,
 			},
 			{ id: 'foo', label: 'Foo', icon: 'dashicons-star-filled', restPath: 'wp/v2/foo', kind: 'test-kind' },
 		);

--- a/tests/vitest/my-wordpress-media-preview.test.ts
+++ b/tests/vitest/my-wordpress-media-preview.test.ts
@@ -156,6 +156,34 @@ describe( 'media-preview', () => {
 		expect( onSelect ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	test( 'onSelect ctx keeps the media contract and gains the new fields', () => {
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		const onSelect = vi.fn();
+		window.wp!.hooks!.addFilter(
+			'os.my-wordpress.preview-actions',
+			'test/ctx-shape',
+			( actions: MediaPreviewAction[] ) =>
+				actions.map( ( a ) => ( { ...a, onSelect } ) ),
+		);
+		renderMediaPreview( host, makeMedia(), {
+			entityId: 'media',
+			previewActions: [ { id: 'inspect', label: 'Inspect' } ],
+		} );
+		host.querySelector< HTMLElement >( '[data-action-id="inspect"]' )!
+			.dispatchEvent( new Event( 'click', { bubbles: true } ) );
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		const ctx = onSelect.mock.calls[ 0 ][ 0 ] as Record< string, unknown >;
+		// Pre-existing contract — unchanged.
+		expect( ctx.entityId ).toBe( 'media' );
+		expect( ctx.kind ).toBe( 'media' );
+		expect( ctx.mime ).toBe( 'image/jpeg' );
+		expect( ( ctx.item as { id: number } ).id ).toBe( 42 );
+		// Additive fields.
+		expect( ctx.itemId ).toBe( 42 );
+		expect( ctx.surface ).toBe( 'pane' );
+	} );
+
 	test( 'preview-extras action fires for each slot', () => {
 		const host = document.createElement( 'div' );
 		document.body.appendChild( host );

--- a/tests/vitest/my-wordpress-preview-actions.test.ts
+++ b/tests/vitest/my-wordpress-preview-actions.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Preview actions — the one pipeline across every Explorer surface.
+ *
+ * Server descriptors (`openstation_my_wordpress_preview_actions`)
+ * must render in the post-kind right pane and the tile context menu,
+ * not just the media pane; `sections` must match the post type slug
+ * as well as the section id; and `onSelect` must receive the selected
+ * entity.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { installHooksStub, clearHooksStub } from './helpers/hooks-stub';
+import { addFilter, removeFilter } from '../../src/hooks';
+import {
+	buildPreviewActionContext,
+	buildPreviewActionRow,
+	previewActionsToMenuOptions,
+	resolvePreviewActions,
+} from '../../src/my-wordpress/preview-actions';
+import type {
+	MyWordPressEntity,
+	PreviewAction,
+	PreviewActionContext,
+} from '../../src/my-wordpress/types';
+
+const WINDOW_ID = 'desktop-mode-my-wordpress';
+const NS = 'test/preview-actions';
+
+interface NativeWindowsGlobal {
+	openStationNativeWindows?: Record<
+		string,
+		( ( body: HTMLElement ) => void | ( () => void ) ) | undefined
+	>;
+	openStationWindowConfig?: Record< string, unknown >;
+}
+
+const ENTITY: MyWordPressEntity = {
+	id: 'cpt-atf-form',
+	label: 'Forms',
+	icon: 'dashicons-feedback',
+	restPath: 'wp/v2/atf-form',
+	kind: 'post',
+	post_type: 'atf-form',
+};
+
+const DETAIL: Record< string, unknown > = {
+	id: 7,
+	title: { rendered: 'Contact form' },
+	content: { rendered: '<p>A form.</p>' },
+	excerpt: { rendered: '' },
+	date: '2026-01-01T00:00:00',
+	status: 'publish',
+	link: 'http://example.test/?p=7',
+	featured_media: 0,
+};
+
+function installConfig( previewActions: PreviewAction[] ): void {
+	( window as unknown as NativeWindowsGlobal ).openStationWindowConfig = {
+		[ WINDOW_ID ]: {
+			restRoot: 'http://example.test/wp-json/',
+			restNonce: 'nonce',
+			editPostUrlBase: 'http://example.test/wp-admin/post.php',
+			editUserUrlBase: 'http://example.test/wp-admin/user-edit.php',
+			siteName: 'Example',
+			entities: [ ENTITY ],
+			groups: [],
+			perPage: 24,
+			mediaPerPage: 48,
+			previewActions,
+		},
+	};
+}
+
+describe( 'my-wordpress — preview actions across kinds', () => {
+	beforeEach( () => {
+		installHooksStub();
+		installConfig( [] );
+	} );
+
+	afterEach( () => {
+		removeFilter( 'os.my-wordpress.preview-actions', NS );
+		removeFilter( 'os.my-wordpress.tile-context-menu', NS );
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'sections match the post type slug and the wildcard, not just the id', () => {
+		const actions: PreviewAction[] = [
+			{ id: 'by-id', label: 'A', sections: [ 'cpt-atf-form' ] },
+			{ id: 'by-post-type', label: 'B', sections: [ 'atf-form' ] },
+			{ id: 'wildcard', label: 'C', sections: [ '*' ] },
+			{ id: 'other', label: 'D', sections: [ 'media' ] },
+		];
+		const ctx = buildPreviewActionContext( ENTITY, DETAIL, {
+			surface: 'pane',
+		} );
+		const ids = resolvePreviewActions( actions, ctx ).map( ( a ) => a.id );
+		expect( ids ).toEqual( [ 'by-id', 'by-post-type', 'wildcard' ] );
+	} );
+
+	test( 'buildPreviewActionContext carries the entity and the item', () => {
+		const ctx = buildPreviewActionContext( ENTITY, DETAIL, {
+			surface: 'context-menu',
+		} );
+		expect( ctx.entityId ).toBe( 'cpt-atf-form' );
+		expect( ctx.kind ).toBe( 'post' );
+		expect( ctx.postType ).toBe( 'atf-form' );
+		expect( ctx.item ).toBe( DETAIL );
+		expect( ctx.itemId ).toBe( 7 );
+		expect( ctx.surface ).toBe( 'context-menu' );
+	} );
+
+	test( 'buildPreviewActionRow resolves config descriptors for a section', () => {
+		installConfig( [
+			{ id: 'atf/open-builder', label: 'Open in builder', sections: [ 'atf-form' ] },
+		] );
+		const row = buildPreviewActionRow( ENTITY, DETAIL );
+		expect( row ).not.toBeNull();
+		expect(
+			row!.querySelector( '[data-action-id="atf/open-builder"]' ),
+		).not.toBeNull();
+
+		// A section the descriptor doesn't name gets no row at all.
+		const other: MyWordPressEntity = {
+			id: 'posts',
+			label: 'Posts',
+			icon: 'dashicons-admin-post',
+			restPath: 'wp/v2/posts',
+			kind: 'post',
+			post_type: 'post',
+		};
+		expect( buildPreviewActionRow( other, DETAIL ) ).toBeNull();
+	} );
+
+	test( 'menu options wrap onSelect with the ctx-carrying handler', () => {
+		const onSelect = vi.fn();
+		installConfig( [
+			{ id: 'atf/open-builder', label: 'Open in builder', sections: [ 'atf-form' ] },
+		] );
+		addFilter(
+			'os.my-wordpress.preview-actions',
+			NS,
+			( actions: PreviewAction[] ) =>
+				actions.map( ( a ) => ( { ...a, onSelect } ) ),
+		);
+		const options = previewActionsToMenuOptions( ENTITY, DETAIL );
+		expect( options ).toHaveLength( 1 );
+		expect( options[ 0 ].id ).toBe( 'atf/open-builder' );
+		expect( options[ 0 ].sort ).toBe( 50 );
+		// No icon declared — menu entries need one, so a default fills in.
+		expect( options[ 0 ].icon ).toBe( 'dashicons-admin-generic' );
+
+		options[ 0 ].onSelect();
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		const ctx = onSelect.mock.calls[ 0 ][ 0 ] as PreviewActionContext;
+		expect( ctx.surface ).toBe( 'context-menu' );
+		expect( ctx.itemId ).toBe( 7 );
+		expect( ctx.item ).toBe( DETAIL );
+	} );
+
+	test( 'isVisible( ctx ) === false drops the entry from menus', () => {
+		installConfig( [
+			{ id: 'shown', label: 'Shown', sections: [ '*' ] },
+		] );
+		addFilter(
+			'os.my-wordpress.preview-actions',
+			NS,
+			( actions: PreviewAction[] ) =>
+				actions.map( ( a ) => ( { ...a, isVisible: () => false } ) ),
+		);
+		expect( previewActionsToMenuOptions( ENTITY, DETAIL ) ).toHaveLength( 0 );
+	} );
+
+	test( 'MIME-scoped descriptors stay out of post-kind contexts', () => {
+		const actions: PreviewAction[] = [
+			{ id: 'img-only', label: 'Compress', mime: '^image/', sections: [ '*' ] },
+		];
+		const ctx = buildPreviewActionContext( ENTITY, DETAIL, {
+			surface: 'pane',
+		} );
+		expect( resolvePreviewActions( actions, ctx ) ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'my-wordpress — post pane renders preview actions', () => {
+	beforeEach( async () => {
+		installHooksStub();
+		installConfig( [
+			{
+				id: 'atf/open-builder',
+				label: 'Open in builder',
+				icon: 'dashicons-feedback',
+				sections: [ 'atf-form' ],
+			},
+		] );
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( ( input: RequestInfo ) => {
+				const url = String( input );
+				const body = /\/atf-form\/7\b/.test( url )
+					? JSON.stringify( DETAIL )
+					: JSON.stringify( [ DETAIL ] );
+				return Promise.resolve(
+					new Response( body, {
+						status: 200,
+						headers: {
+							'Content-Type': 'application/json',
+							'X-WP-Total': '1',
+							'X-WP-TotalPages': '1',
+						},
+					} ),
+				);
+			} ),
+		);
+		await import( '../../src/my-wordpress/index' );
+	} );
+
+	afterEach( () => {
+		removeFilter( 'os.my-wordpress.preview-actions', NS );
+		document.body.innerHTML = '';
+		clearHooksStub();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	function mount(): HTMLElement {
+		const cb = ( window as unknown as NativeWindowsGlobal )
+			.openStationNativeWindows?.[ WINDOW_ID ];
+		if ( typeof cb !== 'function' ) {
+			throw new Error( 'render callback not registered' );
+		}
+		const body = document.createElement( 'div' );
+		body.className = 'os-window__body';
+		body.innerHTML = `
+			<div class="desktop-mode-my-wordpress" data-os-my-wordpress-root>
+				<header data-os-my-wordpress-breadcrumbs></header>
+				<div class="os-my-wordpress__body" data-os-my-wordpress-body>
+					<div class="os-my-wordpress__loading" data-os-my-wordpress-loading hidden></div>
+				</div>
+				<div class="os-folder-status-bar" data-os-my-wordpress-status></div>
+			</div>
+		`;
+		document.body.appendChild( body );
+		cb( body );
+		return body;
+	}
+
+	function dblclickTile( body: HTMLElement, label: string ): void {
+		const tile = [
+			...body.querySelectorAll< HTMLElement >( 'os-tile' ),
+		].find( ( t ) =>
+			(
+				t.querySelector( '.os-file-tile__label' )?.textContent ?? ''
+			).startsWith( label ),
+		);
+		if ( ! tile ) {
+			throw new Error( `no tile labelled ${ label }` );
+		}
+		tile.dispatchEvent( new MouseEvent( 'dblclick', { bubbles: true } ) );
+	}
+
+	test( 'the pane shows the descriptor button and onSelect gets the entity', async () => {
+		const onSelect = vi.fn();
+		addFilter(
+			'os.my-wordpress.preview-actions',
+			NS,
+			( actions: PreviewAction[] ) =>
+				actions.map( ( a ) =>
+					a.id === 'atf/open-builder' ? { ...a, onSelect } : a,
+				),
+		);
+
+		const body = mount();
+		dblclickTile( body, 'Forms' );
+
+		await vi.waitFor( () => {
+			if ( ! body.querySelector( '[data-entry-id="7"]' ) ) {
+				throw new Error( 'tiles not painted' );
+			}
+		} );
+		body.querySelector< HTMLElement >( '[data-entry-id="7"]' )?.click();
+
+		let btn: HTMLElement | null = null;
+		await vi.waitFor( () => {
+			btn = body.querySelector< HTMLElement >(
+				'[data-action-id="atf/open-builder"]',
+			);
+			if ( ! btn ) {
+				throw new Error( 'descriptor button not painted' );
+			}
+		} );
+
+		// Rendered inside the article footer, after the built-ins.
+		const footer = ( btn as unknown as HTMLElement ).closest(
+			'.os-my-wordpress__article-footer',
+		);
+		expect( footer ).not.toBeNull();
+
+		( btn as unknown as HTMLElement ).dispatchEvent(
+			new Event( 'click', { bubbles: true } ),
+		);
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		const ctx = onSelect.mock.calls[ 0 ][ 0 ] as PreviewActionContext;
+		expect( ctx.entityId ).toBe( 'cpt-atf-form' );
+		expect( ctx.kind ).toBe( 'post' );
+		expect( ctx.postType ).toBe( 'atf-form' );
+		expect( ctx.surface ).toBe( 'pane' );
+		expect( ctx.itemId ).toBe( 7 );
+		expect( ( ctx.item as { id: number } ).id ).toBe( 7 );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes the bug cluster found while user-testing the WP Explorer with a third-party plugin (AllTerrain Forms), plus the entity-argument ask that fell out of it:

- **Preview actions render everywhere.** Descriptors from `openstation_my_wordpress_preview_actions` used to render only in the media pane — a plugin scoping actions to its own section got nothing. The resolver/renderer pipeline now lives in a shared module (`src/my-wordpress/preview-actions.ts`) and renders in the post pane, the user pane, all three tile context menus (as entries the `os.my-wordpress.tile-context-menu` filter can still reorder/remove), and custom-kind renderers via a new `host.previewActionRow()` on `EntityRenderHost`.
- **`sections` matches post type slugs.** Auto-registered CPT sections have ids shaped `cpt-<post_type>`, which plugin authors had no way to know. `sections` now matches the section id, the section's declared post type slug, or `*`.
- **The init:99 snapshot trap is closed.** New Experimental filter `openstation_native_window_config` — a native window's `config` blob at emit time, applied at both serialization points (eager enqueue, lazy payload build). The Explorer uses it to re-collect `previewActions`, so a plugin adding its filter on `admin_init` now ships descriptor and script together instead of the script-without-descriptor symptom.
- **`onSelect( ctx )` carries the selected entity** — `ctx.item` (detail record in the pane, list row in menus), plus `itemId`, `postType`, and `surface`. All additive; the documented media contract is unchanged and pinned by a back-compat test. `MediaPreviewAction*` types stay as deprecated aliases.
- **`editAction` on the section descriptor** (`string | false`). A preview-action id replaces "Open in editor" at the pane's primary button, the menu's open entry (bulk fan-out runs `onSelect( ctx )` per item), and tile double-click — for types edited by a native window instead of `post.php`. `false` removes every edit affordance, reroutes double-click to the detail dossier, and suppresses the bulk "Edit…" modal (a *string* keeps that modal: it PATCHes over REST and doesn't involve the classic editor). If the named action didn't ship (capability) or was never wired, the edit affordances hide — the classic URL is known-broken for these sections.
- **Latent fix:** `fetchEntityDetail()` never requested `editUrl` or the section's `listFields`, so the pane's "Open in editor" ignored row-supplied editor URLs (the HPOS escape hatch). Detail requests now carry both.

## Behavior notes (all surfaces involved are Experimental)

- `os.my-wordpress.preview-actions` now fires for every kind — callbacks appending unscoped entries should guard on `ctx.kind` / use `sections`. Docs call this out.
- Tile context menus now include descriptor-derived entries (`sort: 50`, between navigation and destructive built-ins).
- Mid-session caveat documented: an already-loaded Explorer bundle keeps its config until F5 (`scriptL10n` executes only on first script load).

## Docs

`hooks-reference.md` (rewritten `preview_actions` entry with matching rules + timing; new `native_window_config` entry; `editAction` + `listFields` on the entities filter), `javascript-reference.md` (full `PreviewActionContext` shape, `previewActionRow`, descriptor table, cross-notes on the user-actions and tile-menu filters), `native-windows-proposal.md`, and `examples/my-wordpress-media-action.md` (non-media deep-link recipe + form-builder `editAction` walkthrough).

## Tests

- vitest: new `my-wordpress-preview-actions.test.ts` (matching by id/post-type/`*`, MIME fail-closed outside media, mounted post-pane render, `onSelect` ctx shape, menu wrapping, `isVisible`) and `my-wordpress-edit-action.test.ts` (resolution modes, row/menu exclusion, bulk "Edit…" gating, detail `_fields`, mounted pane replacement + dblclick fallback); back-compat ctx assertions in `my-wordpress-media-preview.test.ts`. Full suite 4519 passing.
- PHPUnit: late-registered filter reaches both emit paths and stays scoped to the Explorer window; `openstation_filter_native_window_config` on eager/lazy/non-array; `sections` and `editAction` pass through the collectors verbatim. Full suite green (2225 tests).
- `npm run build`, `lint`, `typecheck`, `lint:php` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-634-3f9f3571ccf4573ab1dca73ec13d3729704fe289.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->