### PR TITLE
Update notice: show the vinyl card when the release post lands late

### DIFF
--- a/src/release-art.test.ts
+++ b/src/release-art.test.ts
@@ -76,6 +76,22 @@ describe( 'resolveReleaseArt', () => {
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	test( 'retries a miss sooner while the announcement is still pending', async () => {
+		fetchMock.mockResolvedValue( { ok: true, json: async () => [ post( 'Unrelated', '' ) ] } );
+		// A miss recorded 45 minutes ago: still fresh for a settled
+		// branch, stale for one whose announcement hasn't landed yet.
+		localStorage.setItem(
+			'desktop-mode/release-art:v1:7.1',
+			JSON.stringify( { ok: false, ts: Date.now() - 45 * 60 * 1000 } ),
+		);
+
+		expect( await resolveReleaseArt( '7.1' ) ).toBeNull();
+		expect( fetchMock ).not.toHaveBeenCalled();
+
+		expect( await resolveReleaseArt( '7.1', true ) ).toBeNull();
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	test( 'returns null on a non-ok response', async () => {
 		fetchMock.mockResolvedValue( { ok: false, json: async () => [] } );
 		expect( await resolveReleaseArt( '7.0' ) ).toBeNull();

--- a/src/release-art.ts
+++ b/src/release-art.ts
@@ -15,6 +15,11 @@ export interface ReleaseArt {
 // changes so stale hits/misses from an older algorithm are discarded.
 const CACHE_PREFIX = 'desktop-mode/release-art:v1:';
 const MISS_TTL_MS = 6 * 60 * 60 * 1000; // retry a miss after 6h
+// A new major is offered as an update hours before its announcement
+// post goes up, so a miss there means "not published yet" rather than
+// "nothing to find" — retry it soon enough that the card replaces the
+// fallback toast the same day.
+const PENDING_MISS_TTL_MS = 30 * 60 * 1000;
 
 function str( v: unknown ): string {
 	return typeof v === 'string' ? v : '';
@@ -77,7 +82,10 @@ export function parseReleaseArt(
 	return null;
 }
 
-function readCache( branch: string ): ReleaseArt | 'miss' | null {
+function readCache(
+	branch: string,
+	missTtlMs: number,
+): ReleaseArt | 'miss' | null {
 	try {
 		const raw = localStorage.getItem( CACHE_PREFIX + branch );
 		if ( ! raw ) {
@@ -90,7 +98,7 @@ function readCache( branch: string ): ReleaseArt | 'miss' | null {
 		if (
 			v.ok === false &&
 			typeof v.ts === 'number' &&
-			Date.now() - v.ts < MISS_TTL_MS
+			Date.now() - v.ts < missTtlMs
 		) {
 			return 'miss';
 		}
@@ -112,14 +120,22 @@ function writeCache( branch: string, value: object ): void {
  * Resolve `{ name, artUrl }` for a branch, from cache or the news feed.
  * Returns `null` when no announcement/art is found (the shell then falls
  * back to the plain toast).
+ *
+ * Pass `announcementPending` for a branch whose announcement is still
+ * expected (a major that just landed) to cache a miss for minutes
+ * instead of hours.
  */
 export async function resolveReleaseArt(
 	branch: string,
+	announcementPending = false,
 ): Promise< ReleaseArt | null > {
 	if ( ! branch ) {
 		return null;
 	}
-	const cached = readCache( branch );
+	const cached = readCache(
+		branch,
+		announcementPending ? PENDING_MISS_TTL_MS : MISS_TTL_MS,
+	);
 	if ( cached === 'miss' ) {
 		return null;
 	}

--- a/src/update-notice.test.ts
+++ b/src/update-notice.test.ts
@@ -74,7 +74,8 @@ describe( 'maybeShowUpdate', () => {
 			openUrl, resolveArt, loadImage, showCard,
 		} );
 		expect( toastMock ).not.toHaveBeenCalled();
-		expect( resolveArt ).toHaveBeenCalledWith( '7.0' );
+		// Crossing → the resolver may retry a missing announcement sooner.
+		expect( resolveArt ).toHaveBeenCalledWith( '7.0', true );
 		const c = lastCard();
 		// Crossing → branch version + codename in the message.
 		expect( c.message ).toBe( 'WordPress 7.0 "Armstrong" is available.' );
@@ -104,15 +105,30 @@ describe( 'maybeShowUpdate', () => {
 		expect( lastToast().dismissible ).toBe( true );
 	} );
 
-	test( 'dismissing the fallback toast persists on the exact-version key', async () => {
+	test( 'dismissing the fallback toast persists on its own key, not the card\'s', async () => {
 		resolveArt.mockResolvedValue( null );
-		await maybeShowUpdate( {
-			update: { version: '7.0.1', available: '7.0.1', branch: '7.0', url: '/u', crossing: false },
-			openUrl, resolveArt, loadImage, showCard,
-		} );
-		expect( isNoticeDismissed( 'desktop-mode/core-update:7.0.1' ) ).toBe( false );
+		const update = { version: '7.0.1', available: '7.0.1', branch: '7.0', url: '/u', crossing: false };
+		await maybeShowUpdate( { update, openUrl, resolveArt, loadImage, showCard } );
 		lastToast().onDismiss!();
-		expect( isNoticeDismissed( 'desktop-mode/core-update:7.0.1' ) ).toBe( true );
+		expect( isNoticeDismissed( 'desktop-mode/core-update:7.0.1:no-art' ) ).toBe( true );
+		expect( isNoticeDismissed( 'desktop-mode/core-update:7.0.1' ) ).toBe( false );
+
+		// Dismissed → the toast doesn't come back.
+		toastMock.mockClear();
+		await maybeShowUpdate( { update, openUrl, resolveArt, loadImage, showCard } );
+		expect( toastMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'the card still shows after the art-less toast was dismissed', async () => {
+		resolveArt.mockResolvedValue( null );
+		const update = { version: '7.1', available: '7.1', branch: '7.1', url: '/u', crossing: true };
+		await maybeShowUpdate( { update, openUrl, resolveArt, loadImage, showCard } );
+		lastToast().onDismiss!();
+
+		// The announcement post lands later, so the art now resolves.
+		resolveArt.mockResolvedValue( ART );
+		await maybeShowUpdate( { update, openUrl, resolveArt, loadImage, showCard } );
+		expect( lastCard().dismissKey ).toBe( 'desktop-mode/core-update:7.1' );
 	} );
 
 	test( 'art resolves but image fails to load → toast fallback', async () => {

--- a/src/update-notice.ts
+++ b/src/update-notice.ts
@@ -24,7 +24,10 @@ import { __, sprintf } from './i18n';
 /** What the lazy bundle publishes on `window.openStationReleaseCard`. */
 interface ReleaseCardApi {
 	showReleaseCard: ( opts: ReleaseCardOptions ) => unknown;
-	resolveReleaseArt: ( branch: string ) => Promise< ReleaseArt | null >;
+	resolveReleaseArt: (
+		branch: string,
+		announcementPending?: boolean,
+	) => Promise< ReleaseArt | null >;
 	preloadImage: ( url: string ) => Promise< boolean >;
 }
 
@@ -73,7 +76,10 @@ export interface UpdateNoticeDeps {
 	/** Open an admin URL as a window (the "Update now" action). */
 	openUrl: ( args: { url: string; title: string } ) => void;
 	/** Resolve release art for a branch. Defaults to the lazy bundle's resolver. */
-	resolveArt?: ( branch: string ) => Promise< ReleaseArt | null >;
+	resolveArt?: (
+		branch: string,
+		announcementPending?: boolean,
+	) => Promise< ReleaseArt | null >;
 	/** Preload an image, resolving true when ready. Defaults to the lazy bundle's preloader. */
 	loadImage?: ( url: string ) => Promise< boolean >;
 	/** Show the vinyl card. Defaults to the lazy bundle's `showReleaseCard`. */
@@ -129,6 +135,10 @@ export async function maybeShowUpdate( deps: UpdateNoticeDeps ): Promise< void >
 	if ( isNoticeDismissed( dismissKey ) ) {
 		return;
 	}
+	// The art-less toast dismisses on its own key. Closing a fallback
+	// the user was only shown because the art wasn't ready yet must not
+	// also bury the card once it is.
+	const toastDismissKey = `${ dismissKey }:no-art`;
 
 	const openUpdateScreen = (): void =>
 		openUrl( { url: update.url, title: __( 'WordPress Updates' ) } );
@@ -144,7 +154,9 @@ export async function maybeShowUpdate( deps: UpdateNoticeDeps ): Promise< void >
 
 	// Resolve + preload the art before showing anything, so the vinyl
 	// appears once (already painted) instead of flashing a toast first.
-	const art = resolveArt ? await resolveArt( branch ) : null;
+	// `crossing` marks a major whose announcement post (and its art) may
+	// not be published yet, which shortens how long a miss is cached.
+	const art = resolveArt ? await resolveArt( branch, crossing ) : null;
 	if ( art && art.artUrl && load && showCard && ( await load( art.artUrl ) ) ) {
 		showCard( {
 			message: updateMessage( version, crossing ? art.name : '' ),
@@ -156,13 +168,14 @@ export async function maybeShowUpdate( deps: UpdateNoticeDeps ): Promise< void >
 	}
 
 	// No art (unknown release / offline / image failed) → plain toast.
-	// Dismissible + persisted on the same key as the card, so closing it
-	// keeps it closed for this exact version.
+	if ( isNoticeDismissed( toastDismissKey ) ) {
+		return;
+	}
 	showToast( {
 		message: updateMessage( version, '' ),
 		persistent: true,
 		dismissible: true,
-		onDismiss: () => markNoticeDismissed( dismissKey ),
+		onDismiss: () => markNoticeDismissed( toastDismissKey ),
 		action: {
 			label: __( 'Update now' ),
 			onClick: openUpdateScreen,


### PR DESCRIPTION
## Proposed changes

- Cache a release-art miss for 30 minutes instead of 6 hours while the release announcement is still pending (an update crossing into a new major).
- Give the art-less fallback toast its own dismissal key, so closing it no longer suppresses the release card for the same version.

## Why are these changes being made?

WordPress 7.1 was offered as an update about an hour before `WordPress 7.1 "Mary Lou"` was published on wordpress.org/news, so there was no art to show and the notice fell back to the plain toast. That part is by design, but the card then stayed hidden for five more hours after the post went up, because the miss was cached for 6 hours. A branch that just crossed into a new major is missing its art because the announcement isn't published yet, not because there is nothing to find, so it deserves a shorter retry.

The dismissal key was the sharper edge: the toast and the card shared `desktop-mode/core-update:<version>`, so anyone who closed the art-less toast that night would never have seen the card for 7.1 at all.

## Testing instructions

The notice only shows to users who can `update_core`, and only when core reports a pending update.

Fake a pending update by dropping this in a plugin or `functions.php`:

```php
add_filter( 'site_transient_update_core', function ( $t ) {
    $t = is_object( $t ) ? $t : new stdClass();
    $t->updates = array( (object) array( 'response' => 'upgrade', 'current' => '9.0', 'locale' => 'en_US', 'php_version' => '5.6', 'mysql_version' => '5.0' ) );
    return $t;
} );
```

**The card still works**

1. Load the desktop.
2. Make sure the vinyl card appears with the codename, and that "Update now" opens the WordPress Updates window.

**A pending announcement retries soon**

1. Change `'current' => '9.0'` to a released major that has no news post yet, or keep `9.0` (nothing matches it).
2. Load the desktop. Make sure the plain toast appears.
3. In DevTools, check `localStorage.getItem( 'desktop-mode/release-art:v1:9.0' )`. Make sure it holds `{"ok":false,"ts":…}`.
4. Reload. Make sure no new request to `wordpress.org/news` goes out (the miss is still fresh).
5. Set the entry's `ts` back by 45 minutes:
   `localStorage.setItem( 'desktop-mode/release-art:v1:9.0', JSON.stringify( { ok: false, ts: Date.now() - 45 * 60 * 1000 } ) )`
6. Reload. Make sure the news request goes out again. On `trunk` it does not, for 6 hours.

**Dismissing the toast doesn't bury the card**

1. With the toast showing, close it.
2. Reload. Make sure the toast stays closed.
3. Point the fake update at a major that does have art (for example `'current' => '7.0'`), leaving the dismissal in place.
4. Reload. Make sure the vinyl card appears. On `trunk` nothing appears.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-636-db6fed72dfc28be1f71deaf1b3547fac6389e430.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->