### PR TITLE
Readme: Bump "Tested up to" to 7.1

### DIFF
--- a/extensions/desktop-mode-popup-siege/readme.txt
+++ b/extensions/desktop-mode-popup-siege/readme.txt
@@ -2,7 +2,7 @@
 Contributors: nickhamze
 Tags: admin, dashboard, desktop, game, arcade
 Requires at least: 6.5
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 0.1.0
 Requires Plugins: desktop-mode

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, allterraindeveloper, epeicher, mmtr86, nickhamze
 Tags: admin, dashboard, desktop, productivity, ai
 Requires at least: 6.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 1.1.1
 License: GPLv2 or later


### PR DESCRIPTION
## Proposed changes

Bumps `Tested up to` from 7.0 to 7.1 in `readme.txt` and in `extensions/desktop-mode-popup-siege/readme.txt`.

## Why are these changes being made?

WordPress 7.1 shipped yesterday, so Plugin Check errors on the stale header:

```
outdated_tested_upto_header: Tested up to: 7.0 < 7.1. The "Tested up to" value in
your plugin is not set to the current version of WordPress.
```

It runs against the `wordpress:latest` container, so it started failing as soon as the runners picked up the 7.1 image, and it fails on every open PR. Popup Siege is checked in the same job and carries the same value, so it would fail on the next step once the main plugin passes.

## Testing instructions

1. Open any other PR against `trunk` and look at the `Plugin Check` job. Make sure it fails with `outdated_tested_upto_header`.
2. On this PR, make sure `Plugin Check` passes, including the `Run Plugin Check for Popup Siege` step.
3. Make sure `readme.txt` and `extensions/desktop-mode-popup-siege/readme.txt` both read `Tested up to: 7.1`, and that nothing else in either file changed.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-637-18ecce50cd57fac2b39d3a165c6b6a5a22b58076.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->