### PR TITLE
Files: a drag out of the Media Library lands on the desktop

### DIFF
--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -414,6 +414,16 @@ Drop-receiver iframes have two ways to consume the payload:
 
 2. **Pull** — any iframe can postMessage `{ type: 'os-drag-payload-request' }` and the parent replies (directly to `event.source`) with `{ type: 'os-drag-payload', payload }`. Useful for iframes that bind their own native `drop` handler and need the rich payload after the browser has stripped the custom MIME from DataTransfer.
 
+### Drops the bridge declines
+
+While an iframe-sourced session is live, the intercept in `src/drag/iframe-drop-targets.ts` listens for `drop` on `document` in the **capture** phase — it has to, because the gesture is native HTML5 and has to be re-routed by hand into whichever iframe the cursor ended over.
+
+That reach stops at the iframe boundary. When there is no iframe window under the cursor — the drop landed on the wallpaper, a folder window's canvas, the dock — the intercept **declines**: it cancels the browser default and tears the session down, but leaves propagation alone so shell-side handlers get their turn. The files canvas uses exactly that opening to file an attachment dragged out of the Media Library as a desktop shortcut (see [`files-on-desktop.md`](files-on-desktop.md#drops-arriving-from-inside-a-window)).
+
+Cancelling the default is not optional even when the shell has nothing to do with the drop: a media drag carries `text/uri-list`, and the default action for that on a plain document is to navigate — a photo dropped on the desktop would otherwise replace the whole shell with the image.
+
+If you register your own drop handling on a shell surface, expect the event in the bubble phase and claim it with `preventDefault()` + `stopPropagation()`.
+
 ### Payload union
 
 ```ts

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -503,6 +503,59 @@ window opts INTO accepting drops by registering a target on its own
 body — the Trash's `[data-os-recycle-bin-root]` is
 the canonical example.
 
+### Drops arriving from inside a window
+
+A drag lifted *inside* an iframe window — an image in the core Media
+Library — never becomes a `DragManager` session. The gesture belongs
+to the browser's native HTML5 drag machinery in the child document,
+and the shell sees no `pointerdown` and no `dragstart`. What the
+parent document does receive, the moment the pointer crosses out of
+the iframe, is an ordinary `dragover` / `drop` pair.
+
+The files canvas accepts those too. Drop an attachment on the
+wallpaper, on a folder window's canvas, or on a closed folder tile and
+it files as a shortcut exactly as a drag from WP Explorer would —
+same row-major packing, same optimistic store upsert, same
+`os.files.shortcut-dropped` action.
+
+The payload is read from whichever channel carries it:
+
+1. **`wp.os.dragBridge`** — authoritative. The source frame
+   postMessages `os-drag-start` before the pointer leaves it, so the
+   shell already holds a typed payload by the time the drop lands.
+   Survives browsers that strip custom MIME types across a frame
+   boundary. Bridge kinds `attachment`, `post` and `user` map onto the
+   file types of the same name; any other kind is refused rather than
+   guessed at.
+2. **`application/x-wp-media-attachment`** on the `DataTransfer` —
+   fallback, for a source that fills the transfer but never talks to
+   the shell. Readable only on `drop`; during `dragover` the spec
+   exposes the type list but not the values, which is why acceptance
+   is decided from `types` and the payload resolved a moment later.
+
+A drag carrying `Files` is an upload, not a shortcut, and is left to
+the OS-file-drop manager untouched.
+
+Two boundaries worth knowing if you build on this:
+
+- **The canvas only claims drops aimed at itself.** Windows and the
+  widget column float above `#os-area` and share its subtree; a drop
+  on a window's title bar is not a drop on the wallpaper. The check
+  walks up from the event target and stops at the first answer, and it
+  is relative to the canvas host — a folder window's canvas lives
+  *inside* a `.wp-window` and must still accept.
+- **Drops over an iframe window belong to the bridge**, which routes
+  them into that iframe as `os-drop` (this is how Gutenberg receives
+  an insertion). When there is no iframe window under the cursor the
+  bridge declines the gesture and leaves the event to the shell, only
+  cancelling the browser default — a media drag also carries
+  `text/uri-list`, whose default action would navigate the tab away
+  from the shell.
+
+Dragging attachments out of the core Media Library requires the
+**Media Library enhancement** extended option, which is what marks
+`.attachment` tiles draggable and opens the bridge channel.
+
 Cancellation: `Escape`, `window.blur`, `document.visibilitychange` to
 hidden, and `pointercancel` all cancel the active session and run a
 single idempotent cleanup (`--dragging`, `--drop-target`,

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -337,12 +337,15 @@ function openstation_register_assets() {
 
 	// Pinned-notes layer styles (paper, pushpin, pastel tokens, pin
 	// animations). Same `filemtime` cache-bust posture as the other
-	// fast-iterating feature stylesheets above.
+	// fast-iterating feature stylesheets above. Depends on `os-files`
+	// because a pinned note dresses the canonical `.os-file-tile`
+	// chrome — anything that restyles a tile has to print after the
+	// file that declares one.
 	$notes_css = OPENSTATION_DIR . 'assets/css/notes.css';
 	wp_register_style(
 		'os-notes',
 		OPENSTATION_URL . 'assets/css/notes.css',
-		array( 'os-variables', 'dashicons' ),
+		array( 'os-variables', 'dashicons', 'os-files' ),
 		file_exists( $notes_css ) ? (string) filemtime( $notes_css ) : $version
 	);
 

--- a/includes/my-wordpress/assets.php
+++ b/includes/my-wordpress/assets.php
@@ -18,11 +18,32 @@ function openstation_my_wordpress_register_assets() {
 	$version = OPENSTATION_VERSION;
 	$suffix  = openstation_asset_suffix();
 
+	/*
+	 * `os-files` is a real dependency, not decoration. Every tile in
+	 * this window is an `<os-tile>` wearing the canonical
+	 * `.os-file-tile` chrome that `desktop-files.css` declares, and
+	 * this stylesheet overrides a handful of those declarations at
+	 * EQUAL specificity — most visibly `.os-my-wordpress__media-tile`,
+	 * which has to undo `position: absolute` + the fixed 88×104 box so
+	 * media thumbnails flow inside their CSS Grid.
+	 *
+	 * Equal specificity means source order decides, and source order is
+	 * not ours to assume: any handle depending on this one that is
+	 * enqueued before `openstation_enqueue_assets()` runs (the
+	 * WooCommerce integration enqueues its companion stylesheet at
+	 * `admin_enqueue_scripts` priority 5) pulls this file into
+	 * `WP_Dependencies::$to_do` ahead of `os-files`. The overrides then
+	 * lose, every media tile is absolutely positioned with no offsets,
+	 * and the whole grid stacks in one corner.
+	 *
+	 * Declaring the dependency makes the order a fact rather than a
+	 * coincidence. `Tests_OpenStation_TileStylesheetOrder` holds it.
+	 */
 	$css_path = OPENSTATION_DIR . 'assets/css/my-wordpress.css';
 	wp_register_style(
 		'desktop-mode-my-wordpress',
 		OPENSTATION_URL . 'assets/css/my-wordpress.css',
-		array( 'os-variables', 'dashicons' ),
+		array( 'os-variables', 'dashicons', 'os-files' ),
 		file_exists( $css_path ) ? (string) filemtime( $css_path ) : $version
 	);
 

--- a/includes/widgets/widget-notes.php
+++ b/includes/widgets/widget-notes.php
@@ -27,10 +27,14 @@ function openstation_register_notes_widget_assets() {
 	$js_path  = OPENSTATION_DIR . 'assets/js/widget-notes' . $suffix . '.js';
 	$css_path = OPENSTATION_DIR . 'assets/js/widget-notes' . $suffix . '.css';
 
+	// Depends on `os-files` because the pad's sheets wear the
+	// canonical `.os-file-tile` chrome while being dragged — anything
+	// that restyles a tile has to print after the file that declares
+	// one, whatever order the two handles were enqueued in.
 	wp_register_style(
 		'os-notes-widget',
 		OPENSTATION_URL . 'assets/js/widget-notes' . $suffix . '.css',
-		array(),
+		array( 'os-files' ),
 		file_exists( $css_path ) ? (string) filemtime( $css_path ) : $version
 	);
 

--- a/src/desktop-files/cross-frame-drop.ts
+++ b/src/desktop-files/cross-frame-drop.ts
@@ -1,0 +1,336 @@
+/**
+ * OpenStation — cross-frame drops onto a files canvas.
+ *
+ * The shell's own tile gestures are pointer-driven: `DragManager`
+ * owns the lift, the ghost, the hit-test and the drop, and a canvas
+ * accepts them by registering a `DropTarget`. A drag that starts
+ * inside an iframe cannot join that pipeline — the gesture belongs to
+ * the browser's native HTML5 drag machinery in the child document,
+ * and the parent shell never sees a `pointerdown`, let alone a
+ * `dragstart`. What the parent DOES see, the moment the pointer
+ * leaves the iframe and crosses onto shell chrome, is a normal
+ * `dragenter` / `dragover` / `drop` sequence on its own document.
+ *
+ * This module is the sink for exactly that. It teaches one files
+ * canvas — the wallpaper, or a folder window's body — to accept a
+ * native drag carrying a WordPress entity and turn it into a
+ * placement, which is what makes "drag an image out of the Media
+ * Library and drop it on the desktop" file a shortcut instead of
+ * navigating the tab to the image.
+ *
+ * Two channels carry the payload, and we read whichever is available:
+ *
+ *   1. `wp.os.dragBridge` — the authoritative one. The source iframe
+ *      postMessages `os-drag-start` with the full record before the
+ *      pointer ever leaves it, so by the time the drag reaches us the
+ *      bridge already holds a typed payload. This is the channel the
+ *      Gutenberg drop-receiver reads, and it survives browsers that
+ *      strip custom MIME types across the frame boundary.
+ *   2. `application/x-wp-media-attachment` on the `DataTransfer` —
+ *      the fallback, for a source that fills the DataTransfer but
+ *      never talks to the shell (a third-party media grid, an older
+ *      copy of the Media Library shim). Note it can only be READ on
+ *      `drop`: during `dragover` the spec exposes `types` but not
+ *      values, which is why acceptance is decided from the type list
+ *      and the payload is resolved a moment later.
+ *
+ * What this module deliberately does NOT do is claim OS file drags.
+ * A drag carrying `Files` is a real upload and belongs to
+ * `src/os-file-drop/` — we bail before touching it.
+ */
+
+import type { DragBridgePayload } from '../drag-bridge';
+import type { ShortcutDragItem } from './drag-payloads';
+import { TILE_CLASS } from './file-tile';
+
+/**
+ * Custom MIME the Media Library shim
+ * (`assets/js/media-library-enhanced.js`) stamps on the
+ * `DataTransfer` alongside `text/plain` / `text/uri-list` /
+ * `text/html`. Carries the full attachment record as JSON.
+ *
+ * @public
+ */
+export const ATTACHMENT_DROP_MIME = 'application/x-wp-media-attachment';
+
+/** Marker the canvas wears while a cross-frame drag hovers it. */
+const CANVAS_ACTIVE_ATTR = 'data-files-drop-active';
+
+/**
+ * What the canvas does with a resolved drop.
+ *
+ * The module owns the DOM and the event plumbing; the caller owns the
+ * store, the REST client and the grid maths. Keeping the split here
+ * means this file can be tested with nothing but a document.
+ */
+export interface CrossFrameDropContext {
+	/** Element whose bounds define the canvas — `#os-area`, or a folder body. */
+	host: HTMLElement;
+	/** The layer container the tiles live in. */
+	container: HTMLElement;
+	/** Folder the canvas is showing. `0` is the desktop root. */
+	folderId: number;
+	/**
+	 * File the entities as shortcuts under `parentId`. Called once
+	 * per drop with at least one entity.
+	 */
+	fileEntities: (
+		entities: ReadonlyArray< ShortcutDragItem >,
+		parentId: number,
+	) => void;
+}
+
+/** Read the shell's bridge, if it has booted. */
+function bridgePayload(): DragBridgePayload | null {
+	const bridge = (
+		window as {
+			wp?: { os?: { dragBridge?: { getPayload(): DragBridgePayload | null } } };
+		}
+	).wp?.os?.dragBridge;
+	if ( ! bridge ) {
+		return null;
+	}
+	try {
+		return bridge.getPayload();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Turn a bridge payload into the `{ kind, ref }` pair a placement is
+ * created from. Returns `null` for a payload shape this canvas has no
+ * file type for — better to let the drag fall through than to POST a
+ * placement the registry can't render.
+ */
+function payloadToEntity(
+	payload: DragBridgePayload | null,
+): ShortcutDragItem | null {
+	if ( ! payload || typeof payload.id !== 'number' ) {
+		return null;
+	}
+	// The bridge's union and the file-type registry happen to agree on
+	// every slug (`attachment`, `post`, `user`), so `kind` maps across
+	// unchanged. A new bridge kind without a registered file type
+	// lands in the default and is refused.
+	switch ( payload.kind ) {
+		case 'attachment':
+		case 'post':
+		case 'user':
+			return {
+				kind: payload.kind,
+				ref: String( payload.id ),
+				title: payload.title,
+			};
+		default:
+			return null;
+	}
+}
+
+/** Parse the DataTransfer fallback. */
+function entityFromDataTransfer(
+	dt: DataTransfer | null,
+): ShortcutDragItem | null {
+	if ( ! dt ) {
+		return null;
+	}
+	let raw = '';
+	try {
+		raw = dt.getData( ATTACHMENT_DROP_MIME );
+	} catch {
+		return null;
+	}
+	if ( ! raw ) {
+		return null;
+	}
+	try {
+		const record = JSON.parse( raw ) as { id?: unknown; title?: unknown };
+		const id = typeof record.id === 'number' ? record.id : Number( record.id );
+		if ( ! Number.isFinite( id ) || id <= 0 ) {
+			return null;
+		}
+		return {
+			kind: 'attachment',
+			ref: String( id ),
+			title: typeof record.title === 'string' ? record.title : undefined,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/** Does this native drag carry something we can file? */
+function dragCarriesEntity( ev: DragEvent ): boolean {
+	const types = ev.dataTransfer?.types;
+	const list = types ? Array.from( types ) : [];
+	// An OS file drag is an upload, not a shortcut. `src/os-file-drop/`
+	// owns those, and claiming them here would swap the upload dialog
+	// for a broken placement.
+	if ( list.includes( 'Files' ) ) {
+		return false;
+	}
+	if ( list.includes( ATTACHMENT_DROP_MIME ) ) {
+		return true;
+	}
+	return payloadToEntity( bridgePayload() ) !== null;
+}
+
+/**
+ * Is the event aimed at the canvas, rather than at something floating
+ * above it?
+ *
+ * The wallpaper's host is `#os-area`, which also contains every open
+ * window and the widget column — a drop on a window's title bar
+ * bubbles to the same host as a drop on bare wallpaper. Walk up from
+ * the target and stop at the first thing that answers the question:
+ * reaching the layer container means a tile, reaching the host means
+ * open canvas, and hitting a window or the widget column on the way
+ * means this drop was never ours.
+ *
+ * The walk is deliberately relative to `host`: a folder window's
+ * canvas lives INSIDE a `.wp-window`, so an absolute
+ * `closest( '.wp-window' )` would reject every drop in a folder.
+ */
+function isCanvasSurface(
+	target: EventTarget | null,
+	host: HTMLElement,
+	container: HTMLElement,
+): boolean {
+	if ( ! ( target instanceof Element ) || ! host.contains( target ) ) {
+		return false;
+	}
+	let node: Element | null = target;
+	while ( node && node !== host ) {
+		if ( node === container ) {
+			return true;
+		}
+		if ( node.classList.contains( 'wp-window' ) || node.id === 'os-widgets' ) {
+			return false;
+		}
+		node = node.parentElement;
+	}
+	return node === host;
+}
+
+/**
+ * Folder tile under the pointer, if any — dropping onto a closed
+ * folder files into it, matching what a pointer-driven shortcut drag
+ * onto the same tile does.
+ */
+function folderTileAt(
+	target: EventTarget | null,
+	container: HTMLElement,
+): HTMLElement | null {
+	if ( ! ( target instanceof Element ) ) {
+		return null;
+	}
+	const tile = target.closest( `.${ TILE_CLASS }` );
+	if ( ! ( tile instanceof HTMLElement ) || ! container.contains( tile ) ) {
+		return null;
+	}
+	return tile.dataset.fileType === 'folder' ? tile : null;
+}
+
+/**
+ * Wire native drag events on a files canvas so cross-frame drags can
+ * land on it. Returns a dispose function.
+ *
+ * @public
+ */
+export function attachCrossFrameDrop( ctx: CrossFrameDropContext ): () => void {
+	const { host, container, folderId } = ctx;
+	let hoveredFolderTile: HTMLElement | null = null;
+
+	const clearHover = (): void => {
+		host.removeAttribute( CANVAS_ACTIVE_ATTR );
+		if ( hoveredFolderTile ) {
+			hoveredFolderTile.classList.remove( `${ TILE_CLASS }--drop-target` );
+			hoveredFolderTile = null;
+		}
+	};
+
+	const onDragOver = ( ev: DragEvent ): void => {
+		if ( ! dragCarriesEntity( ev ) ) {
+			return;
+		}
+		if ( ! isCanvasSurface( ev.target, host, container ) ) {
+			clearHover();
+			return;
+		}
+		// Both halves are mandatory: without `preventDefault()` on
+		// EVERY dragover the browser keeps the "no drop allowed"
+		// cursor and never fires `drop`; without `dropEffect` the
+		// pointer says "move" over a gesture that copies.
+		ev.preventDefault();
+		if ( ev.dataTransfer ) {
+			ev.dataTransfer.dropEffect = 'copy';
+		}
+
+		host.setAttribute( CANVAS_ACTIVE_ATTR, '' );
+		const tile = folderTileAt( ev.target, container );
+		if ( tile !== hoveredFolderTile ) {
+			hoveredFolderTile?.classList.remove( `${ TILE_CLASS }--drop-target` );
+			tile?.classList.add( `${ TILE_CLASS }--drop-target` );
+			hoveredFolderTile = tile;
+		}
+	};
+
+	const onDragLeave = ( ev: DragEvent ): void => {
+		// `dragleave` fires on every internal boundary crossing too, so
+		// only treat it as an exit when the pointer actually left the
+		// host subtree.
+		const next = ev.relatedTarget;
+		if ( next instanceof Node && host.contains( next ) ) {
+			return;
+		}
+		clearHover();
+	};
+
+	const onDrop = ( ev: DragEvent ): void => {
+		if ( ! dragCarriesEntity( ev ) ) {
+			return;
+		}
+		if ( ! isCanvasSurface( ev.target, host, container ) ) {
+			clearHover();
+			return;
+		}
+		clearHover();
+
+		// Claim the drop before resolving the payload. A media drag
+		// also carries `text/uri-list`, and the browser's default for
+		// that on a plain document is to NAVIGATE — dropping a photo
+		// on the desktop would replace the whole shell with the image.
+		ev.preventDefault();
+		ev.stopPropagation();
+
+		const entity =
+			payloadToEntity( bridgePayload() ) ??
+			entityFromDataTransfer( ev.dataTransfer );
+		if ( ! entity ) {
+			return;
+		}
+
+		// Read the folder tile from the event, not from the hover
+		// bookkeeping `clearHover()` just reset.
+		const tile = folderTileAt( ev.target, container );
+		let parentId = folderId;
+		if ( tile ) {
+			const ref = parseInt( tile.getAttribute( 'ref' ) ?? '', 10 );
+			if ( ! Number.isNaN( ref ) && ref > 0 ) {
+				parentId = ref;
+			}
+		}
+		ctx.fileEntities( [ entity ], parentId );
+	};
+
+	host.addEventListener( 'dragover', onDragOver );
+	host.addEventListener( 'dragleave', onDragLeave );
+	host.addEventListener( 'drop', onDrop );
+
+	return () => {
+		clearHover();
+		host.removeEventListener( 'dragover', onDragOver );
+		host.removeEventListener( 'dragleave', onDragLeave );
+		host.removeEventListener( 'drop', onDrop );
+	};
+}

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -59,7 +59,9 @@ import {
 	dragShortcutItems,
 	type DesktopFileDragData,
 	type ShortcutDragData,
+	type ShortcutDragItem,
 } from './drag-payloads';
+import { attachCrossFrameDrop } from './cross-frame-drop';
 
 /**
  * Build a cross-frame bridge payload from a placement, or return
@@ -920,33 +922,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				// where the user released the cursor. Cursor-position
 				// snap is wrong for shortcut creates because users
 				// rarely aim precisely; row-major is the "tidy" outcome.
-				const occupied = buildVisualOccupiedSet( peers );
-				for ( const entity of dragShortcutItems( data ) ) {
-					const cell = nextRowMajorCell( occupied, host );
-					occupied.add( cellKey( cell.col, cell.row ) );
-					void rest
-						.createPlacement( {
-							parentId: folderId,
-							type: entity.kind,
-							ref: entity.ref,
-							x: cell.x,
-							y: cell.y,
-						} )
-						.then( ( placement ) => {
-							filesStoreApi.upsertPlacement( placement );
-							doAction( 'os.files.shortcut-dropped', {
-								folderId,
-								placement,
-							} );
-						} )
-						.catch( ( err: unknown ) => {
-							// eslint-disable-next-line no-console
-							console.error(
-								'[openstation] shortcut drop failed:',
-								err,
-							);
-						} );
-				}
+				fileShortcutEntities( dragShortcutItems( data ), folderId, host );
 				// `rawX` / `rawY` retained for parity with desktop-file
 				// case logging if a future hook needs the cursor pos.
 				void rawX;
@@ -960,6 +936,28 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 			dragManagerForLayer.registerDropTarget( canvasDropTarget ),
 		);
 	}
+
+	// Cross-frame arrivals. A drag lifted inside an iframe — an image
+	// in the core Media Library — never becomes a DragManager session,
+	// so the target above can't see it. This wires the native drag
+	// events the parent document DOES receive once the pointer crosses
+	// out of the iframe onto the canvas, and routes the drop through
+	// the same shortcut-creation path a pointer drag uses. Registered
+	// unconditionally: it needs no drag manager, only a document.
+	dropTargetDeregisters.push(
+		attachCrossFrameDrop( {
+			host,
+			container,
+			folderId,
+			fileEntities: ( entities, parentId ) => {
+				fileShortcutEntities(
+					entities,
+					parentId,
+					parentId === folderId ? host : null,
+				);
+			},
+		} ),
+	);
 
 	// Click, Ctrl/Cmd-click, Shift-click, marquee, Ctrl/Cmd+A and
 	// Escape are all owned by the selection controller attached
@@ -1395,6 +1393,62 @@ function buildVisualOccupiedSet(
 		}
 	}
 	return set;
+}
+
+/**
+ * File a set of external entities as new shortcuts under `parentId`.
+ *
+ * Every route that creates a shortcut lands here: a pointer drag
+ * released on a canvas, the same drag released on a closed folder
+ * tile, and a cross-frame native drag arriving from an iframe. They
+ * differ only in where the entities came from, and having one
+ * implementation is what keeps them agreeing on the parts users
+ * notice — row-major packing, the optimistic store upsert, and the
+ * `os.files.shortcut-dropped` action plugins listen to.
+ *
+ * Packing is row-major rather than cursor-snapped on purpose: a
+ * shortcut CREATE has no tile on screen for the user to have aimed
+ * with, so "tidy, top-left, and visible" beats "wherever the pointer
+ * happened to be". Pass `host` when the destination canvas is the one
+ * on screen so the column count is measured from it; omit it when
+ * filing into a folder whose window probably isn't mounted, and
+ * `nextRowMajorCell` falls back to a four-column grid.
+ *
+ * @param entities Entities to file. Each becomes one placement.
+ * @param parentId Destination folder id. `0` is the desktop root.
+ * @param host     Destination canvas, when it is the mounted one.
+ */
+function fileShortcutEntities(
+	entities: ReadonlyArray< ShortcutDragItem >,
+	parentId: number,
+	host?: HTMLElement | null,
+): void {
+	const peers =
+		filesStoreApi.getState().placementsByFolder.get( parentId ) ?? [];
+	const occupied = buildVisualOccupiedSet( peers );
+	for ( const entity of entities ) {
+		const cell = nextRowMajorCell( occupied, host );
+		occupied.add( cellKey( cell.col, cell.row ) );
+		void rest
+			.createPlacement( {
+				parentId,
+				type: entity.kind,
+				ref: entity.ref,
+				x: cell.x,
+				y: cell.y,
+			} )
+			.then( ( placement ) => {
+				filesStoreApi.upsertPlacement( placement );
+				doAction( 'os.files.shortcut-dropped', {
+					folderId: parentId,
+					placement,
+				} );
+			} )
+			.catch( ( err: unknown ) => {
+				// eslint-disable-next-line no-console
+				console.error( '[openstation] shortcut drop failed:', err );
+			} );
+	}
 }
 
 /**
@@ -1851,42 +1905,13 @@ function registerFolderDropTarget(
 			}
 			if ( session.payload.type === 'shortcut' ) {
 				const data = session.payload.data as unknown as ShortcutDragData;
-				const peers =
-					filesStoreApi
-						.getState()
-						.placementsByFolder.get( targetFolderId ) ?? [];
 				// Row-major pack so newly-filed shortcuts land at the
 				// top of the (likely-not-yet-mounted) folder window.
 				// We can't read the destination folder window's host
-				// width from here, so default to 4 cols inside
-				// `nextRowMajorCell` — sensible for any folder window.
-				const occupied = buildVisualOccupiedSet( peers );
-				for ( const entity of dragShortcutItems( data ) ) {
-					const cell = nextRowMajorCell( occupied );
-					occupied.add( cellKey( cell.col, cell.row ) );
-					void rest
-						.createPlacement( {
-							parentId: targetFolderId,
-							type: entity.kind,
-							ref: entity.ref,
-							x: cell.x,
-							y: cell.y,
-						} )
-						.then( ( placement ) => {
-							filesStoreApi.upsertPlacement( placement );
-							doAction( 'os.files.shortcut-dropped', {
-								folderId: targetFolderId,
-								placement,
-							} );
-						} )
-						.catch( ( err: unknown ) => {
-							// eslint-disable-next-line no-console
-							console.error(
-								'[openstation] shortcut drop into folder failed:',
-								err,
-							);
-						} );
-				}
+				// width from here, so no host is passed and
+				// `nextRowMajorCell` defaults to 4 cols — sensible for
+				// any folder window.
+				fileShortcutEntities( dragShortcutItems( data ), targetFolderId );
 			}
 		},
 	};

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -327,6 +327,50 @@ function deriveWindowIdFromIframe( iframe: HTMLIFrameElement ): string {
 	return `unknown-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
 }
 
+/**
+ * Verbose drag-start trace — silent unless
+ * `localStorage.openStationDragDebug` is set.
+ *
+ * `onDragStart` runs on EVERY DragManager session, and repositioning
+ * a desktop icon is by far the most common drag in the shell — so an
+ * unconditional line here means the console fills up during ordinary
+ * use, with the whole drag payload dumped alongside it. Same shape as
+ * the recycle-bin badge's trace: type
+ * `localStorage.openStationDragDebug = '1'` in DevTools, reload, and
+ * the wiring narrates itself again.
+ *
+ * For a one-off look at the current state rather than a running
+ * commentary, `window.__openStationIframeDropDebug()` reports the same
+ * facts on demand and needs no flag.
+ *
+ * @param iframeCount  Iframe windows about to have pointer-events suppressed.
+ * @param isBridgeable Whether the payload carries a cross-frame `bridgePayload`.
+ * @param payload      The DragManager payload, logged verbatim.
+ */
+function debugLog(
+	iframeCount: number,
+	isBridgeable: boolean,
+	payload: unknown,
+): void {
+	try {
+		if ( ! window.localStorage?.getItem( 'openStationDragDebug' ) ) {
+			return;
+		}
+	} catch {
+		// localStorage blocked (private mode, strict cookie policy) —
+		// treat as "not debugging" rather than throwing mid-drag.
+		return;
+	}
+	// `console.info` is in the lint allowlist; `console.log` would
+	// need an inline disable.
+	console.info(
+		'[openstation] drag-start: suppressing %d iframe(s); bridgeable=%s',
+		iframeCount,
+		isBridgeable,
+		payload,
+	);
+}
+
 function onDragStart( payload: unknown ): void {
 	const dragManager = _dragManager;
 	if ( ! dragManager ) {
@@ -341,16 +385,7 @@ function onDragStart( payload: unknown ): void {
 	// payload kind via the registered DropTarget's `accept()`.
 	const iframes = document.querySelectorAll< HTMLIFrameElement >( IFRAME_SELECTOR );
 	const isBridgeable = !! extractBridgePayload( payload );
-	// Diagnostic — visible in DevTools console at every drag start.
-	// Helps narrow down which side of the wiring is breaking when a
-	// regression bubbles up. `console.info` is in the lint
-	// allowlist; `console.log` would need an inline disable.
-	console.info(
-		'[openstation] drag-start: suppressing %d iframe(s); bridgeable=%s',
-		iframes.length,
-		isBridgeable,
-		payload,
-	);
+	debugLog( iframes.length, isBridgeable, payload );
 	iframes.forEach( ( iframe ) => {
 		// Suppress pointer-events idempotently. If the bridge
 		// intercept already suppressed this iframe (shell-side

--- a/src/drag/iframe-drop-targets.ts
+++ b/src/drag/iframe-drop-targets.ts
@@ -147,17 +147,43 @@ const onBridgeDrop = ( e: DragEvent ): void => {
 	if ( ! _bridgeInterceptPayload ) {
 		return;
 	}
+	const iframe = findIframeAtCursor( e.clientX, e.clientY );
+	if ( ! iframe ) {
+		/*
+		 * Nothing to deliver into: the cursor is over the shell's own
+		 * chrome — the wallpaper, a folder window's canvas, the dock.
+		 *
+		 * Leave the event completely alone. This handler runs in the
+		 * CAPTURE phase on `document`, so the `stopImmediatePropagation`
+		 * below reaches every shell handler before any of them see the
+		 * drop; claiming a gesture we then have nowhere to send made
+		 * every cross-frame drop outside a window vanish silently. That
+		 * is precisely what stopped an image dragged out of the Media
+		 * Library from landing on the desktop as a shortcut — the files
+		 * canvas's own drop handler was never reached.
+		 *
+		 * Tearing the intercept down here (rather than waiting for the
+		 * source frame's `os-drag-end`) also restores iframe
+		 * pointer-events before the next gesture starts.
+		 *
+		 * `preventDefault()` still fires, and only that: a media drag
+		 * also carries `text/uri-list`, whose default action on a
+		 * plain document is to navigate. Cancelling the default keeps
+		 * a drop the shell declines from replacing the whole shell
+		 * with the dragged image; propagation is untouched, so
+		 * handlers further along still get their turn.
+		 */
+		e.preventDefault();
+		stopBridgeIntercept();
+		return;
+	}
 	e.preventDefault();
 	e.stopPropagation();
 	if ( typeof e.stopImmediatePropagation === 'function' ) {
 		e.stopImmediatePropagation();
 	}
-	const iframe = findIframeAtCursor( e.clientX, e.clientY );
 	const payload = _bridgeInterceptPayload;
 	stopBridgeIntercept();
-	if ( ! iframe ) {
-		return;
-	}
 	const rect = iframe.getBoundingClientRect();
 	postIntoIframe( iframe, {
 		type: 'os-drop',

--- a/tests/phpunit/tests/tileStylesheetOrder.php
+++ b/tests/phpunit/tests/tileStylesheetOrder.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Tile stylesheet cascade order.
+ *
+ * `desktop-files.css` declares the canonical `.os-file-tile` chrome —
+ * `position: absolute`, a fixed 88x104 box, a 48px visual. Surfaces
+ * that reuse `<os-tile>` in a different layout override those
+ * declarations from their own stylesheet, and they do it at EQUAL
+ * specificity (`.os-my-wordpress__media-tile` vs `.os-file-tile`).
+ *
+ * Equal specificity means the later stylesheet wins, so "later" has to
+ * be guaranteed rather than assumed. It is not guaranteed by enqueue
+ * priority: `WP_Dependencies::all_deps()` walks the queue in order and
+ * pushes each handle's dependencies ahead of it, so a handle enqueued
+ * at priority 5 that depends on a tile-restyling stylesheet drags that
+ * stylesheet into `$to_do` before `openstation_enqueue_assets()` (at
+ * priority 10) ever gets to enqueue `os-files`.
+ *
+ * That is not hypothetical. `os-my-wordpress-woocommerce` is enqueued
+ * at priority 5 and depends on `desktop-mode-my-wordpress`; on a store
+ * it printed `my-wordpress.css` first, `desktop-files.css` second, and
+ * every tile in the Explorer's Media grid went back to
+ * `position: absolute` with no offsets — the whole grid stacked in one
+ * corner, one icon over another.
+ *
+ * The fix is a declared dependency. These tests hold it, and the last
+ * one generalises it to any future stylesheet that touches a tile.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group os-tile-styles
+ */
+class Tests_OpenStation_TileStylesheetOrder extends WP_UnitTestCase {
+
+	/** Handle that declares the canonical tile chrome. */
+	const TILE_CHROME_HANDLE = 'os-files';
+
+	public function set_up() {
+		parent::set_up();
+		$this->ensure_styles_registered();
+	}
+
+	/**
+	 * The plugin registers its handles on `init`, which has already
+	 * fired by the time a test runs — but a sibling test class may
+	 * have emptied the registry, so re-run the registrars when the
+	 * handles we care about are gone.
+	 */
+	private function ensure_styles_registered() {
+		if ( wp_style_is( self::TILE_CHROME_HANDLE, 'registered' )
+			&& wp_style_is( 'desktop-mode-my-wordpress', 'registered' ) ) {
+			return;
+		}
+		if ( function_exists( 'openstation_register_assets' ) ) {
+			openstation_register_assets();
+		}
+		if ( function_exists( 'openstation_my_wordpress_register_assets' ) ) {
+			openstation_my_wordpress_register_assets();
+		}
+	}
+
+	/**
+	 * Every handle `$handle` depends on, directly or through another
+	 * dependency.
+	 *
+	 * @param string $handle Style handle.
+	 * @param array  $seen   Recursion guard.
+	 * @return string[] Dependency handles.
+	 */
+	private function transitive_deps( $handle, &$seen = array() ) {
+		$styles = wp_styles();
+		if ( isset( $seen[ $handle ] ) || ! isset( $styles->registered[ $handle ] ) ) {
+			return array();
+		}
+		$seen[ $handle ] = true;
+
+		$deps = (array) $styles->registered[ $handle ]->deps;
+		foreach ( $deps as $dep ) {
+			$deps = array_merge( $deps, $this->transitive_deps( $dep, $seen ) );
+		}
+
+		return array_values( array_unique( $deps ) );
+	}
+
+	/**
+	 * Local filesystem path for a style registered from this plugin,
+	 * or an empty string for core / third-party handles.
+	 *
+	 * @param string $handle Style handle.
+	 * @return string Absolute path, or '' when the handle isn't ours.
+	 */
+	private function plugin_css_path( $handle ) {
+		$styles = wp_styles();
+		if ( ! isset( $styles->registered[ $handle ] ) ) {
+			return '';
+		}
+		$src = (string) $styles->registered[ $handle ]->src;
+		if ( '' === $src || 0 !== strpos( $src, OPENSTATION_URL ) ) {
+			return '';
+		}
+
+		$path = OPENSTATION_DIR . substr( $src, strlen( OPENSTATION_URL ) );
+		return file_exists( $path ) ? $path : '';
+	}
+
+	/**
+	 * CSS with comments stripped, so a `.os-file-tile` mentioned in a
+	 * docblock doesn't read as a rule that restyles one.
+	 *
+	 * @param string $path Absolute path to a stylesheet.
+	 * @return string
+	 */
+	private function css_without_comments( $path ) {
+		$css = (string) file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local test fixture read, not an HTTP request.
+		return (string) preg_replace( '#/\*.*?\*/#s', '', $css );
+	}
+
+	/**
+	 * Order the handles would print in, given a queue.
+	 *
+	 * Mirrors what `WP_Styles::do_items()` does: resolve the queue
+	 * through `all_deps()` and read back `$to_do`.
+	 *
+	 * @param string[] $queue Handles in enqueue order.
+	 * @return string[] Handles in print order.
+	 */
+	private function print_order( array $queue ) {
+		$styles        = wp_styles();
+		$saved_to_do   = $styles->to_do;
+		$saved_done    = $styles->done;
+		$styles->to_do = array();
+		$styles->done  = array();
+
+		$styles->all_deps( $queue );
+		$order = $styles->to_do;
+
+		$styles->to_do = $saved_to_do;
+		$styles->done  = $saved_done;
+
+		return $order;
+	}
+
+	// --------------------------------------------------------------
+	// The declared dependency
+	// --------------------------------------------------------------
+
+	/**
+	 * @covers ::openstation_my_wordpress_register_assets
+	 */
+	public function test_my_wordpress_style_declares_the_tile_chrome_dependency() {
+		$this->assertContains(
+			self::TILE_CHROME_HANDLE,
+			$this->transitive_deps( 'desktop-mode-my-wordpress' ),
+			'my-wordpress.css overrides `.os-file-tile` at equal specificity, so it must declare `os-files` as a dependency to be guaranteed to print after it.'
+		);
+	}
+
+	// --------------------------------------------------------------
+	// The order that dependency buys
+	// --------------------------------------------------------------
+
+	/**
+	 * The plain case: the shell enqueues `os-files` first, the window
+	 * stylesheet later. This order was always fine — pinned so the
+	 * hostile case below can be read as the delta.
+	 */
+	public function test_tile_chrome_prints_before_the_window_stylesheet() {
+		$order = $this->print_order(
+			array( self::TILE_CHROME_HANDLE, 'desktop-mode-my-wordpress' )
+		);
+
+		$this->assertLessThan(
+			array_search( 'desktop-mode-my-wordpress', $order, true ),
+			array_search( self::TILE_CHROME_HANDLE, $order, true ),
+			'desktop-files.css must print before my-wordpress.css.'
+		);
+	}
+
+	/**
+	 * The regression: a companion stylesheet enqueued EARLIER than the
+	 * shell's own assets, declaring the window stylesheet as its
+	 * dependency. This is the WooCommerce integration's shape
+	 * (`admin_enqueue_scripts` priority 5, deps
+	 * `desktop-mode-my-wordpress`), and before the declared dependency
+	 * it inverted the cascade.
+	 */
+	public function test_tile_chrome_still_prints_first_when_a_dependent_is_enqueued_ahead_of_the_shell() {
+		wp_register_style(
+			'os-test-my-wordpress-companion',
+			OPENSTATION_URL . 'assets/css/my-wordpress-woocommerce.css',
+			array( 'desktop-mode-my-wordpress' ),
+			'1.0.0'
+		);
+
+		// Priority 5 companion, then the shell's priority 10 batch,
+		// then the window's own priority 30 enqueue.
+		$order = $this->print_order(
+			array(
+				'os-test-my-wordpress-companion',
+				self::TILE_CHROME_HANDLE,
+				'desktop-mode-my-wordpress',
+			)
+		);
+
+		$chrome = array_search( self::TILE_CHROME_HANDLE, $order, true );
+		$window = array_search( 'desktop-mode-my-wordpress', $order, true );
+
+		$this->assertNotFalse( $chrome, 'os-files did not make it into the print queue.' );
+		$this->assertNotFalse( $window, 'desktop-mode-my-wordpress did not make it into the print queue.' );
+		$this->assertLessThan(
+			$window,
+			$chrome,
+			'A companion stylesheet enqueued before the shell pulled my-wordpress.css ahead of desktop-files.css — the Explorer media grid stacks in one corner when that happens.'
+		);
+
+		wp_deregister_style( 'os-test-my-wordpress-companion' );
+	}
+
+	// --------------------------------------------------------------
+	// The general invariant
+	// --------------------------------------------------------------
+
+	/**
+	 * Any of the plugin's own stylesheets that writes a rule against
+	 * `.os-file-tile` is restyling a tile, and therefore has to print
+	 * after the file that declares one. Generalises the two tests
+	 * above to stylesheets that don't exist yet.
+	 */
+	public function test_every_stylesheet_that_restyles_a_tile_depends_on_the_tile_chrome() {
+		$offenders = array();
+
+		foreach ( array_keys( wp_styles()->registered ) as $handle ) {
+			if ( self::TILE_CHROME_HANDLE === $handle ) {
+				continue;
+			}
+			$path = $this->plugin_css_path( $handle );
+			if ( '' === $path ) {
+				continue;
+			}
+			if ( false === strpos( $this->css_without_comments( $path ), '.os-file-tile' ) ) {
+				continue;
+			}
+			if ( in_array( self::TILE_CHROME_HANDLE, $this->transitive_deps( $handle ), true ) ) {
+				continue;
+			}
+			$offenders[] = $handle . ' (' . basename( $path ) . ')';
+		}
+
+		$this->assertSame(
+			array(),
+			$offenders,
+			"These stylesheets write `.os-file-tile` rules but don't declare `os-files` as a dependency, so whether their overrides win depends on enqueue order. Add 'os-files' to the handle's deps:\n" . implode( "\n", $offenders )
+		);
+	}
+}

--- a/tests/vitest/desktop-files-cross-frame-drop.test.ts
+++ b/tests/vitest/desktop-files-cross-frame-drop.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Unit tests for `src/desktop-files/cross-frame-drop.ts` — the sink
+ * that lets a drag lifted inside an iframe (an image in the core
+ * Media Library) land on a files canvas as a shortcut.
+ *
+ * The gesture never becomes a DragManager session, so none of the
+ * pointer-driven drop-target machinery applies. What the parent
+ * document receives is a plain native `dragover` / `drop` pair, and
+ * these tests drive exactly that.
+ *
+ * jsdom implements neither `DragEvent` nor `DataTransfer`, so both are
+ * synthesised — the module only ever reads `types`, `getData()` and
+ * writes `dropEffect`, which is a small enough surface to fake
+ * honestly.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	attachCrossFrameDrop,
+	ATTACHMENT_DROP_MIME,
+} from '../../src/desktop-files/cross-frame-drop';
+import type { ShortcutDragItem } from '../../src/desktop-files/drag-payloads';
+
+interface FakeDataTransfer {
+	types: string[];
+	dropEffect: string;
+	getData( mime: string ): string;
+}
+
+function dataTransfer(
+	types: string[],
+	data: Record< string, string > = {},
+): FakeDataTransfer {
+	return {
+		types,
+		dropEffect: 'none',
+		getData: ( mime: string ) => data[ mime ] ?? '',
+	};
+}
+
+function fireDrag(
+	type: 'dragover' | 'drop' | 'dragleave',
+	target: Element,
+	dt: FakeDataTransfer | null,
+	extra: Record< string, unknown > = {},
+): Event {
+	const ev = new Event( type, { bubbles: true, cancelable: true } );
+	Object.defineProperty( ev, 'dataTransfer', { value: dt } );
+	for ( const [ key, value ] of Object.entries( extra ) ) {
+		Object.defineProperty( ev, key, { value } );
+	}
+	target.dispatchEvent( ev );
+	return ev;
+}
+
+/** Build a canvas that mirrors the shell's shape: host > container. */
+function mountCanvas() {
+	const host = document.createElement( 'div' );
+	host.id = 'os-area';
+	const container = document.createElement( 'div' );
+	container.className = 'os-files-layer';
+	host.appendChild( container );
+	document.body.appendChild( host );
+	return { host, container };
+}
+
+/**
+ * A tile as this module sees one: the canonical class, the file-type
+ * dataset stamp, and the entity `ref`. Deliberately a plain element
+ * rather than a real `<os-tile>` — the contract under test is that
+ * DOM shape, and constructing the component would drag its whole
+ * render path (and a `wp.hooks` global) into a test about drag events.
+ */
+function folderTile( ref: string ): HTMLElement {
+	const tile = document.createElement( 'div' );
+	tile.className = 'os-file-tile';
+	tile.dataset.fileType = 'folder';
+	tile.setAttribute( 'ref', ref );
+	return tile;
+}
+
+type Filed = { entities: ReadonlyArray< ShortcutDragItem >; parentId: number };
+
+describe( 'cross-frame drops onto a files canvas', () => {
+	let host: HTMLElement;
+	let container: HTMLElement;
+	let filed: Filed[];
+	let dispose: () => void;
+
+	beforeEach( () => {
+		( { host, container } = mountCanvas() );
+		filed = [];
+		dispose = attachCrossFrameDrop( {
+			host,
+			container,
+			folderId: 0,
+			fileEntities: ( entities, parentId ) =>
+				filed.push( { entities, parentId } ),
+		} );
+	} );
+
+	afterEach( () => {
+		dispose();
+		document.body.innerHTML = '';
+		delete ( window as { wp?: unknown } ).wp;
+	} );
+
+	/** Publish a bridge payload the way an iframe-source drag would. */
+	function bridgeHolds( payload: unknown ): void {
+		( window as { wp?: unknown } ).wp = {
+			os: { dragBridge: { getPayload: () => payload } },
+		};
+	}
+
+	// ------------------------------------------------------------
+	// Accepting the drag
+	// ------------------------------------------------------------
+
+	test( 'dragover over the canvas is accepted and marked copy', () => {
+		bridgeHolds( { kind: 'attachment', id: 7, url: 'x', title: 'Photo' } );
+		const dt = dataTransfer( [ 'text/uri-list' ] );
+
+		const ev = fireDrag( 'dragover', host, dt );
+
+		expect( ev.defaultPrevented ).toBe( true );
+		expect( dt.dropEffect ).toBe( 'copy' );
+		expect( host.hasAttribute( 'data-files-drop-active' ) ).toBe( true );
+	} );
+
+	test( 'the custom MIME alone is enough — no bridge needed', () => {
+		const dt = dataTransfer( [ ATTACHMENT_DROP_MIME ] );
+
+		const ev = fireDrag( 'dragover', host, dt );
+
+		expect( ev.defaultPrevented ).toBe( true );
+	} );
+
+	test( 'a drag carrying nothing we can file is left alone', () => {
+		const ev = fireDrag( 'dragover', host, dataTransfer( [ 'text/plain' ] ) );
+
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( host.hasAttribute( 'data-files-drop-active' ) ).toBe( false );
+	} );
+
+	test( 'an OS file drag is left to the upload manager', () => {
+		// Bridge payload present AND `Files` on the transfer: the file
+		// drag wins, because claiming it here would swap the upload
+		// dialog for a placement pointing at nothing. The `Files` test
+		// runs FIRST for exactly this case — a stale bridge payload
+		// from an earlier gesture must not capture a real upload.
+		bridgeHolds( { kind: 'attachment', id: 7, url: 'x', title: 'Photo' } );
+		const dt = dataTransfer( [ 'Files', ATTACHMENT_DROP_MIME ] );
+
+		const ev = fireDrag( 'dragover', host, dt );
+
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( host.hasAttribute( 'data-files-drop-active' ) ).toBe( false );
+	} );
+
+	test( 'a file dropped from the OS still reaches the upload manager', () => {
+		// `src/os-file-drop/` listens on `window`, above this canvas in
+		// the bubble path. Dropping a photo out of Finder onto the
+		// desktop has to arrive there untouched — no `preventDefault`,
+		// no `stopPropagation` — or the upload dialog never opens.
+		bridgeHolds( { kind: 'attachment', id: 7, url: 'x', title: 'Photo' } );
+		const uploadManager = vi.fn();
+		window.addEventListener( 'drop', uploadManager );
+
+		const ev = fireDrag( 'drop', host, dataTransfer( [ 'Files' ] ) );
+
+		window.removeEventListener( 'drop', uploadManager );
+		expect( uploadManager ).toHaveBeenCalledTimes( 1 );
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( filed ).toHaveLength( 0 );
+	} );
+
+	// ------------------------------------------------------------
+	// Surfaces that are not the canvas
+	// ------------------------------------------------------------
+
+	test( 'a drop on a window floating over the canvas is not claimed', () => {
+		bridgeHolds( { kind: 'attachment', id: 7, url: 'x', title: 'Photo' } );
+		const win = document.createElement( 'div' );
+		win.className = 'wp-window';
+		const titleBar = document.createElement( 'div' );
+		win.appendChild( titleBar );
+		host.appendChild( win );
+
+		const ev = fireDrag( 'drop', titleBar, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( filed ).toHaveLength( 0 );
+	} );
+
+	test( 'a drop on the widget column is not claimed', () => {
+		bridgeHolds( { kind: 'attachment', id: 7, url: 'x', title: 'Photo' } );
+		const widgets = document.createElement( 'aside' );
+		widgets.id = 'os-widgets';
+		host.appendChild( widgets );
+
+		const ev = fireDrag( 'drop', widgets, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( filed ).toHaveLength( 0 );
+	} );
+
+	test( 'a folder window canvas inside a window still accepts', () => {
+		// The host itself lives inside `.wp-window` for a folder
+		// window. The window check has to be relative to the host or
+		// every folder drop is refused.
+		dispose();
+		document.body.innerHTML = '';
+		const win = document.createElement( 'div' );
+		win.className = 'wp-window';
+		const body = document.createElement( 'div' );
+		const layer = document.createElement( 'div' );
+		body.appendChild( layer );
+		win.appendChild( body );
+		document.body.appendChild( win );
+		const inner: Filed[] = [];
+		dispose = attachCrossFrameDrop( {
+			host: body,
+			container: layer,
+			folderId: 12,
+			fileEntities: ( entities, parentId ) =>
+				inner.push( { entities, parentId } ),
+		} );
+		bridgeHolds( { kind: 'attachment', id: 7, url: 'x', title: 'Photo' } );
+
+		fireDrag( 'drop', body, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( inner ).toHaveLength( 1 );
+		expect( inner[ 0 ].parentId ).toBe( 12 );
+	} );
+
+	// ------------------------------------------------------------
+	// Filing the drop
+	// ------------------------------------------------------------
+
+	test( 'a bridge attachment drop files a shortcut in this folder', () => {
+		bridgeHolds( {
+			kind: 'attachment',
+			id: 42,
+			url: 'https://example.test/a.png',
+			title: 'A photo',
+			mime: 'image/png',
+		} );
+
+		const ev = fireDrag( 'drop', host, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( ev.defaultPrevented ).toBe( true );
+		expect( filed ).toEqual( [
+			{
+				entities: [ { kind: 'attachment', ref: '42', title: 'A photo' } ],
+				parentId: 0,
+			},
+		] );
+	} );
+
+	test( 'the DataTransfer record is the fallback when no bridge ran', () => {
+		const dt = dataTransfer( [ ATTACHMENT_DROP_MIME ], {
+			[ ATTACHMENT_DROP_MIME ]: JSON.stringify( {
+				id: 9,
+				url: 'https://example.test/b.jpg',
+				title: 'B',
+			} ),
+		} );
+
+		fireDrag( 'drop', host, dt );
+
+		expect( filed ).toEqual( [
+			{ entities: [ { kind: 'attachment', ref: '9', title: 'B' } ], parentId: 0 },
+		] );
+	} );
+
+	test( 'post and user bridge payloads file too', () => {
+		bridgeHolds( {
+			kind: 'post',
+			id: 5,
+			postType: 'page',
+			url: 'https://example.test/p',
+			title: 'About',
+		} );
+
+		fireDrag( 'drop', host, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( filed[ 0 ].entities[ 0 ] ).toEqual( {
+			kind: 'post',
+			ref: '5',
+			title: 'About',
+		} );
+	} );
+
+	test( 'a bridge kind with no file type is refused, not guessed', () => {
+		bridgeHolds( { kind: 'comment', id: 3, url: 'x', title: 'Nope' } );
+
+		const ev = fireDrag( 'drop', host, dataTransfer( [ 'text/plain' ] ) );
+
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( filed ).toHaveLength( 0 );
+	} );
+
+	test( 'a malformed DataTransfer record does not create a placement', () => {
+		const dt = dataTransfer( [ ATTACHMENT_DROP_MIME ], {
+			[ ATTACHMENT_DROP_MIME ]: '{ not json',
+		} );
+
+		fireDrag( 'drop', host, dt );
+
+		expect( filed ).toHaveLength( 0 );
+	} );
+
+	// ------------------------------------------------------------
+	// Folder tiles
+	// ------------------------------------------------------------
+
+	test( 'dropping on a closed folder tile files into that folder', () => {
+		bridgeHolds( { kind: 'attachment', id: 42, url: 'x', title: 'A photo' } );
+		const tile = folderTile( '31' );
+		container.appendChild( tile );
+
+		fireDrag( 'drop', tile, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( filed ).toHaveLength( 1 );
+		expect( filed[ 0 ].parentId ).toBe( 31 );
+	} );
+
+	test( 'a hovered folder tile gets the drop-target class, then loses it', () => {
+		bridgeHolds( { kind: 'attachment', id: 42, url: 'x', title: 'A photo' } );
+		const tile = folderTile( '31' );
+		container.appendChild( tile );
+
+		fireDrag( 'dragover', tile, dataTransfer( [ 'text/uri-list' ] ) );
+		expect( tile.classList.contains( 'os-file-tile--drop-target' ) ).toBe(
+			true,
+		);
+
+		fireDrag( 'dragover', host, dataTransfer( [ 'text/uri-list' ] ) );
+		expect( tile.classList.contains( 'os-file-tile--drop-target' ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'a non-folder tile files into the canvas, not into itself', () => {
+		bridgeHolds( { kind: 'attachment', id: 42, url: 'x', title: 'A photo' } );
+		const tile = folderTile( '31' );
+		tile.dataset.fileType = 'post';
+		container.appendChild( tile );
+
+		fireDrag( 'drop', tile, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( filed[ 0 ].parentId ).toBe( 0 );
+	} );
+
+	// ------------------------------------------------------------
+	// Teardown
+	// ------------------------------------------------------------
+
+	test( 'leaving the host clears the affordance', () => {
+		bridgeHolds( { kind: 'attachment', id: 42, url: 'x', title: 'A photo' } );
+		fireDrag( 'dragover', host, dataTransfer( [ 'text/uri-list' ] ) );
+		expect( host.hasAttribute( 'data-files-drop-active' ) ).toBe( true );
+
+		fireDrag( 'dragleave', host, dataTransfer( [ 'text/uri-list' ] ), {
+			relatedTarget: document.body,
+		} );
+
+		expect( host.hasAttribute( 'data-files-drop-active' ) ).toBe( false );
+	} );
+
+	test( 'dragleave onto a child of the host is not an exit', () => {
+		bridgeHolds( { kind: 'attachment', id: 42, url: 'x', title: 'A photo' } );
+		fireDrag( 'dragover', host, dataTransfer( [ 'text/uri-list' ] ) );
+
+		fireDrag( 'dragleave', host, dataTransfer( [ 'text/uri-list' ] ), {
+			relatedTarget: container,
+		} );
+
+		expect( host.hasAttribute( 'data-files-drop-active' ) ).toBe( true );
+	} );
+
+	test( 'dispose unbinds every listener', () => {
+		bridgeHolds( { kind: 'attachment', id: 42, url: 'x', title: 'A photo' } );
+		dispose();
+
+		const ev = fireDrag( 'drop', host, dataTransfer( [ 'text/uri-list' ] ) );
+
+		expect( ev.defaultPrevented ).toBe( false );
+		expect( filed ).toHaveLength( 0 );
+	} );
+
+	test( 'a bridge that throws does not break the canvas', () => {
+		( window as { wp?: unknown } ).wp = {
+			os: {
+				dragBridge: {
+					getPayload: vi.fn( () => {
+						throw new Error( 'bridge exploded' );
+					} ),
+				},
+			},
+		};
+
+		expect( () =>
+			fireDrag( 'dragover', host, dataTransfer( [ 'text/plain' ] ) ),
+		).not.toThrow();
+		expect( filed ).toHaveLength( 0 );
+	} );
+} );

--- a/tests/vitest/iframe-drop-targets-bridge-drop.test.ts
+++ b/tests/vitest/iframe-drop-targets-bridge-drop.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for the cross-frame drop intercept in
+ * `src/drag/iframe-drop-targets.ts`.
+ *
+ * While a bridge session is live the module listens for `drop` on
+ * `document` in the CAPTURE phase, because a drag lifted inside an
+ * iframe has to be re-routed by hand into whichever iframe the cursor
+ * ended over. Capture-phase plus `stopImmediatePropagation()` is a
+ * very large hammer: it decides the fate of every drop in the shell,
+ * including ones aimed at the shell's own surfaces.
+ *
+ * These tests pin the boundary. A drop over an iframe window is the
+ * intercept's business and gets claimed. A drop anywhere else — the
+ * wallpaper, a folder window's canvas — is not, and has to reach the
+ * handlers underneath: swallowing it is what made an image dragged
+ * out of the Media Library disappear instead of filing itself on the
+ * desktop.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	installIframeDropTargets,
+	__resetIframeDropTargetsForTests,
+} from '../../src/drag/iframe-drop-targets';
+import { DRAG_BRIDGE_EVENTS } from '../../src/drag-bridge';
+import type { DragManagerApi } from '../../src/drag';
+
+const PAYLOAD = {
+	kind: 'attachment' as const,
+	id: 42,
+	url: 'https://example.test/a.png',
+	title: 'A photo',
+	alt: '',
+	mime: 'image/png',
+};
+
+function stubWpHooks(): void {
+	( window as { wp?: unknown } ).wp = {
+		hooks: {
+			addAction: vi.fn(),
+			removeAction: vi.fn(),
+			doAction: vi.fn(),
+			addFilter: vi.fn(),
+			removeFilter: vi.fn(),
+			applyFilters: ( _name: string, value: unknown ) => value,
+		},
+	};
+}
+
+const dragManagerStub = {
+	start: vi.fn(),
+	registerDropTarget: vi.fn( () => () => undefined ),
+	getSession: vi.fn( () => null ),
+} as unknown as DragManagerApi;
+
+/** Fire a native drop at the document, as the browser would. */
+function fireDrop(): Event {
+	const ev = new Event( 'drop', { bubbles: true, cancelable: true } );
+	Object.defineProperty( ev, 'clientX', { value: 120 } );
+	Object.defineProperty( ev, 'clientY', { value: 90 } );
+	Object.defineProperty( ev, 'dataTransfer', {
+		value: { types: [ 'text/uri-list' ], dropEffect: 'none' },
+	} );
+	document.body.dispatchEvent( ev );
+	return ev;
+}
+
+/** Build an iframe window and point `elementFromPoint` at it. */
+function mountIframeWindowUnderCursor(): HTMLIFrameElement {
+	const win = document.createElement( 'div' );
+	win.className = 'os-window';
+	win.id = 'wp-window-edit-php';
+	const iframe = document.createElement( 'iframe' );
+	iframe.className = 'os-window__iframe';
+	win.appendChild( iframe );
+	document.body.appendChild( win );
+	document.elementFromPoint = () => iframe;
+	return iframe;
+}
+
+describe( 'bridge drop intercept', () => {
+	let downstream: ReturnType< typeof vi.fn >;
+
+	beforeEach( () => {
+		stubWpHooks();
+		installIframeDropTargets( dragManagerStub );
+		// Stands in for every shell-side drop handler that sits below
+		// the capture-phase intercept — the files canvas, above all.
+		downstream = vi.fn();
+		document.body.addEventListener( 'drop', downstream );
+		document.elementFromPoint = () => null;
+	} );
+
+	afterEach( () => {
+		document.body.removeEventListener( 'drop', downstream );
+		__resetIframeDropTargetsForTests();
+		document.body.innerHTML = '';
+		delete ( window as { wp?: unknown } ).wp;
+		vi.restoreAllMocks();
+	} );
+
+	function startBridgeSession(): void {
+		document.dispatchEvent(
+			new CustomEvent( DRAG_BRIDGE_EVENTS.START, {
+				detail: { payload: PAYLOAD },
+			} ),
+		);
+	}
+
+	test( 'a drop with no iframe window under the cursor reaches the shell', () => {
+		startBridgeSession();
+
+		const ev = fireDrop();
+
+		expect( downstream ).toHaveBeenCalledTimes( 1 );
+		// Still cancelled: a media drag carries `text/uri-list`, whose
+		// default action would navigate the tab away from the shell.
+		expect( ev.defaultPrevented ).toBe( true );
+	} );
+
+	test( 'a drop over an iframe window is claimed and delivered', () => {
+		const iframe = mountIframeWindowUnderCursor();
+		const post = vi.fn();
+		Object.defineProperty( iframe, 'contentWindow', {
+			value: { postMessage: post },
+			configurable: true,
+		} );
+		startBridgeSession();
+
+		fireDrop();
+
+		expect( downstream ).not.toHaveBeenCalled();
+		expect( post ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'os-drop',
+				payload: PAYLOAD,
+			} ),
+			expect.anything(),
+		);
+	} );
+
+	test( 'declining a drop ends the session, so the next drag starts clean', () => {
+		startBridgeSession();
+		fireDrop();
+
+		// Second drop, no session in flight: the intercept must be
+		// fully unwired rather than lingering with a stale payload.
+		const iframe = mountIframeWindowUnderCursor();
+		const post = vi.fn();
+		Object.defineProperty( iframe, 'contentWindow', {
+			value: { postMessage: post },
+			configurable: true,
+		} );
+		fireDrop();
+
+		expect( post ).not.toHaveBeenCalled();
+		expect( downstream ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'with no session in flight the intercept is inert', () => {
+		const ev = fireDrop();
+
+		expect( downstream ).toHaveBeenCalledTimes( 1 );
+		expect( ev.defaultPrevented ).toBe( false );
+	} );
+
+	test( 'iframe pointer-events are restored when a drop is declined', () => {
+		const iframe = mountIframeWindowUnderCursor();
+		document.elementFromPoint = () => null;
+		startBridgeSession();
+		expect( iframe.style.pointerEvents ).toBe( 'none' );
+
+		fireDrop();
+
+		expect( iframe.style.pointerEvents ).toBe( '' );
+	} );
+} );

--- a/tests/vitest/iframe-drop-targets-bridge-drop.test.ts
+++ b/tests/vitest/iframe-drop-targets-bridge-drop.test.ts
@@ -22,7 +22,7 @@ import {
 	__resetIframeDropTargetsForTests,
 } from '../../src/drag/iframe-drop-targets';
 import { DRAG_BRIDGE_EVENTS } from '../../src/drag-bridge';
-import type { DragManagerApi } from '../../src/drag';
+import { DRAG_EVENTS, type DragManagerApi } from '../../src/drag';
 
 const PAYLOAD = {
 	kind: 'attachment' as const,
@@ -172,5 +172,55 @@ describe( 'bridge drop intercept', () => {
 		fireDrop();
 
 		expect( iframe.style.pointerEvents ).toBe( '' );
+	} );
+} );
+
+/**
+ * `onDragStart` runs on every DragManager session — repositioning a
+ * desktop icon included, which is the most common drag in the shell.
+ * Its trace has to stay behind the debug flag, or ordinary use fills
+ * the console and dumps the drag payload with it.
+ */
+describe( 'drag-start trace', () => {
+	let info: ReturnType< typeof vi.spyOn >;
+
+	beforeEach( () => {
+		stubWpHooks();
+		installIframeDropTargets( dragManagerStub );
+		info = vi.spyOn( console, 'info' ).mockImplementation( () => undefined );
+	} );
+
+	afterEach( () => {
+		__resetIframeDropTargetsForTests();
+		window.localStorage.removeItem( 'openStationDragDebug' );
+		delete ( window as { wp?: unknown } ).wp;
+		vi.restoreAllMocks();
+	} );
+
+	function startDrag(): void {
+		document.dispatchEvent(
+			new CustomEvent( DRAG_EVENTS.START, {
+				detail: { payload: { type: 'desktop-file', data: {} } },
+			} ),
+		);
+	}
+
+	test( 'an ordinary drag says nothing', () => {
+		startDrag();
+
+		expect( info ).not.toHaveBeenCalled();
+	} );
+
+	test( 'the debug flag turns the trace back on', () => {
+		window.localStorage.setItem( 'openStationDragDebug', '1' );
+
+		startDrag();
+
+		expect( info ).toHaveBeenCalledWith(
+			expect.stringContaining( 'drag-start' ),
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+		);
 	} );
 } );


### PR DESCRIPTION
Two fixes that turn up in the same place — the Media Library — and share a test surface.

## 1. The Explorer's Media grid stacked in one corner

`my-wordpress.css` overrides the canonical `.os-file-tile` chrome (`position: absolute`, a fixed 88×104 box) so media thumbnails can flow inside their CSS Grid. It does that at **equal specificity**, which means source order decides — and source order was left to chance.

`WP_Dependencies::all_deps()` walks the queue in order and pushes each handle's dependencies ahead of it, so a handle enqueued before the shell's own assets drags whatever it depends on along with it. `os-my-wordpress-woocommerce` is exactly that shape: `admin_enqueue_scripts` priority 5, dependent on `desktop-mode-my-wordpress`. On a store it printed `my-wordpress.css` first and `desktop-files.css` second, the overrides lost, and every tile in the Media grid went back to `position: absolute` with no offsets — one icon over another.

Declare the dependency instead, on all three stylesheets that write `.os-file-tile` rules.

`Tests_OpenStation_TileStylesheetOrder` replays the hostile enqueue order and asserts the chrome still prints first. Its last test generalises the rule to stylesheets that don't exist yet: any of the plugin's own CSS whose text (comments stripped) targets `.os-file-tile` must reach `os-files` through its dependency chain. That is what found the notes widget.

## 2. Dragging an image out of the Media Library did nothing on the wallpaper

Into Gutenberg it inserted a block. Onto the desktop it vanished. One cause.

A drag lifted inside an iframe never becomes a `DragManager` session — it belongs to the browser's native HTML5 machinery in the child document, so the shell sees no `pointerdown` and no `dragstart`. To deliver those gestures into another iframe, `iframe-drop-targets.ts` listens for `drop` on `document` in the **capture** phase. It claimed every drop it saw — `preventDefault` + `stopPropagation` + `stopImmediatePropagation` — and only then looked for an iframe under the cursor, returning silently when there wasn't one. Over Gutenberg there is an iframe. Over the wallpaper the gesture went in the bin before a single shell handler could see it.

Now the intercept resolves the iframe first and claims the drop only when it has somewhere to deliver it. With no iframe under the cursor it **declines**: cancels the browser default, tears the session down, leaves propagation alone. Cancelling the default is not optional even then — a media drag carries `text/uri-list`, whose default action on a plain document is to navigate, so a photo dropped on the desktop would otherwise replace the whole shell with the image.

`src/desktop-files/cross-frame-drop.ts` fills that opening: a files canvas — the wallpaper, a folder window's body — now accepts a native drag carrying a WordPress entity and files it as a shortcut, on the canvas or into a closed folder tile, the same as a pointer drag from WP Explorer. The payload comes from `wp.os.dragBridge` when the source announced itself and from the `application/x-wp-media-attachment` DataTransfer record when it didn't; a bridge kind with no registered file type is refused rather than guessed at.

`fileShortcutEntities()` is extracted from the two drop branches that already existed, so all three routes agree on row-major packing, the optimistic store upsert, and `os.files.shortcut-dropped`.

### The OS upload flow is untouched

A drag carrying `Files` is an upload, not a shortcut: the canvas returns before touching the event — no `preventDefault`, no `stopPropagation` — so it bubbles to `src/os-file-drop/` exactly as before. The `Files` check runs *ahead* of the bridge-payload check on purpose, so a stale payload from an earlier gesture can never capture a real upload. The intercept change can't affect Finder drags either: it only runs while a bridge session is in flight, and an OS file drag never starts one.

### Two boundaries that needed care

- Windows and the widget column float above `#os-area` and share its subtree, so a drop on a title bar is not a drop on the wallpaper. The surface check walks up from the event target and stops at the first answer.
- That check is **relative to the canvas host** — a folder window's canvas lives inside a `.wp-window` and must still accept.

## Tests

- `tests/vitest/desktop-files-cross-frame-drop.test.ts` — 20 tests: acceptance, the OS-file exclusion (both `dragover` and `drop`), surfaces that must not claim, folder windows, both payload channels, folder-tile targeting, teardown.
- `tests/vitest/iframe-drop-targets-bridge-drop.test.ts` — 5 tests on the intercept boundary. Verified as a real guard: reverting the source change fails 2 of them.
- `tests/phpunit/tests/tileStylesheetOrder.php` — 4 tests, including the generalised invariant.

4597 JS tests, 2239 PHP tests, `lint` / `typecheck` / `phpcs -n` clean.

Docs updated in the same change: a "Drops arriving from inside a window" section in `docs/files-on-desktop.md`, and "Drops the bridge declines" in `docs/bridge-protocol.md`.

## Verified manually

Media grid lays out; Media Library → wallpaper, → closed folder tile, and → open folder window all file a shortcut; Finder → wallpaper still opens the upload dialog; Media Library → Gutenberg still inserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-638-0967cc37c11314fdf3662e09f8e801cb9a47a59d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->