### PR TITLE
Widgets: reveal the add button on hover and snap floating widgets to a grid

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -1185,30 +1185,68 @@ body.os-has-fullscreen-window .os-shell {
 }
 
 /*
- * Add-widget tile — matches the "+" tile in the overview top bar.
- * Always visible at the bottom of the column; promoted to center
- * when the column is otherwise empty so first-run users see a
- * friendly target rather than an empty strip.
+ * Add-widget tile — a compact pill that trails the widget stack, not
+ * a full-width drop zone. Hidden until the pointer comes near the
+ * column (the layer toggles `--hovered`), so the desktop stays clean
+ * for people who never touch widgets.
+ *
+ * Absolute rather than in flow because "the bottom of the stack" is
+ * not something the column's layout knows: a widget dragged out of
+ * the column becomes a floating card parented to the desktop, so it
+ * leaves the flex flow while still sitting visually in the column.
+ * The layer measures those too and writes `top` — see
+ * `positionAddTile()`.
  */
 .os-widgets__add {
-	margin-top: auto;
-	padding: 14px 12px;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX( -50% );
+	padding: 8px 22px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	gap: 8px;
-	pointer-events: auto;
+	gap: 7px;
+	pointer-events: none;
 	background: transparent;
-	border: 2px dashed rgba( 255, 255, 255, 0.22 );
-	border-radius: 14px;
+	border: 1px dashed rgba( 255, 255, 255, 0.22 );
+	border-radius: 10px;
 	color: rgba( 255, 255, 255, 0.72 );
 	font: inherit;
 	font-weight: 500;
 	cursor: pointer;
+	opacity: 0;
 	transition:
+		opacity 0.15s ease,
 		border-color 0.15s ease,
 		background-color 0.15s ease,
 		color 0.15s ease;
+}
+
+/*
+ * Reveal conditions. An empty column is no exception — approaching
+ * the right side is the gesture, whether or not there's a card there
+ * to aim at. `:focus-visible` keeps it reachable by keyboard, where
+ * there is no pointer to bring near.
+ */
+.os-widgets--hovered .os-widgets__add,
+.os-widgets--picking .os-widgets__add,
+.os-widgets__add:focus-visible {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+/*
+ * Touch has no hover to approach the column with. The wallpaper's
+ * right-click menu carries an "Add widget" entry, but a long-press
+ * to reach it is a lot to ask of someone who just wants a clock, so
+ * on those devices the pill stays put.
+ */
+@media ( hover: none ) {
+	.os-widgets__add {
+		opacity: 1;
+		pointer-events: auto;
+	}
 }
 
 .os-widgets__add:hover {
@@ -1223,9 +1261,9 @@ body.os-has-fullscreen-window .os-shell {
 }
 
 .os-widgets__add-plus {
-	font-size: 20px;
+	font-size: 15px;
 	line-height: 1;
-	font-weight: 200;
+	font-weight: 300;
 }
 
 .os-widgets__add-label {

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -658,6 +658,7 @@ Clicking empty wallpaper used to call `windowManager.toggleShowDesktop()` direct
 | `create-folder` | New folder | Prompts for a name, then `POST /folders`. |
 | `new-url` | New URL | Prompts for a name + URL, then `POST /placements` with a `link` placement (the tile opens the URL in a new browser tab). |
 | `new-note` | New note | Pins an empty paper note where the click landed. Contributed by the pinned-notes layer via the filter below. |
+| `add-widget` | Add widget | Opens the widget picker, anchored to the add pill in the widget column. |
 | `sort-by` | Sort by | Submenu with checkable options: Name (A → Z), Name (Z → A), Date (newest first), Date (oldest first); re-sorts the desktop icons. |
 | `show-desktop` | Show desktop | Calls `windowManager.toggleShowDesktop()` (the legacy single-click gesture). |
 | `os-settings` | OpenStation Preferences | Opens the OpenStation Preferences window. |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4535,6 +4535,14 @@ for ( const id of wp.os.widgetLayer?.getEnabledIds() ?? [] ) {
 
 Equivalent legacy entry point: `wp.os.widgetLayer?.redock( id )`. New code should prefer `wp.os.widgets.redock`, which keeps a stable namespace as the widget surface grows.
 
+##### `wp.os.widgetLayer?.openPicker()` — Stable
+
+Open the widget picker. The panel anchors to the add pill in the widget column and reveals it for as long as the picker is open, so the entry point is the same wherever it's triggered from — the pill itself, or the wallpaper's right-click menu. No-op if a picker is already open.
+
+```js
+wp.os.widgetLayer?.openPicker();
+```
+
 | Hook | Kind | Status | Payload |
 |---|---|---|---|
 | `os.widgets` | filter | Stable | the registry array |

--- a/src/desktop-files/wallpaper-menu.ts
+++ b/src/desktop-files/wallpaper-menu.ts
@@ -316,6 +316,13 @@ export function buildMenuItems( deps: WallpaperMenuDeps ): WallpaperMenuItem[] {
 			onClick: () => deps.createUrl(),
 		},
 		{
+			id: 'add-widget',
+			label: deps.labels.addWidget,
+			icon: 'dashicons-screenoptions',
+			sort: 14,
+			onClick: () => deps.addWidget(),
+		},
+		{
 			id: 'sort-by',
 			label: deps.labels.sortHeading,
 			icon: 'dashicons-sort',
@@ -419,6 +426,8 @@ export type SortMode = 'name-asc' | 'name-desc' | 'date-asc' | 'date-desc';
 export interface WallpaperMenuDeps {
 	createFolder: () => void;
 	createUrl: () => void;
+	/** Opens the widget picker, same panel the add pill opens. */
+	addWidget: () => void;
 	toggleShowDesktop: () => void;
 	openOsSettings: () => void;
 	sortIcons: ( mode: SortMode ) => void;
@@ -448,6 +457,7 @@ export interface WallpaperMenuDeps {
 		sortDateAsc: string;
 		sortDateDesc: string;
 		newUrl: string;
+		addWidget: string;
 	};
 	serverItems?: ServerWallpaperMenuItem[];
 	serverCallbacks?: Record< string, () => void | Promise< void > >;

--- a/src/desktop-files/wallpaper-menu.ts
+++ b/src/desktop-files/wallpaper-menu.ts
@@ -319,7 +319,10 @@ export function buildMenuItems( deps: WallpaperMenuDeps ): WallpaperMenuItem[] {
 			id: 'add-widget',
 			label: deps.labels.addWidget,
 			icon: 'dashicons-screenoptions',
-			sort: 14,
+			// 15, not 14: the pinned-notes layer contributes
+			// `new-note` at 14 through the filter, and a tie would
+			// leave the order down to which list got merged first.
+			sort: 15,
 			onClick: () => deps.addWidget(),
 		},
 		{

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -4588,6 +4588,7 @@ function init(): void {
 						'New URL',
 						'Opens the URL in a new browser tab.',
 					),
+				addWidget: () => widgetLayer?.openPicker(),
 				toggleShowDesktop: () => manager.toggleShowDesktop(),
 				openOsSettings: () => openOsSettings(),
 				sortIcons: ( mode ) => {
@@ -4608,6 +4609,7 @@ function init(): void {
 					sortDateAsc: 'Date (oldest first)',
 					sortDateDesc: 'Date (newest first)',
 					newUrl: 'New URL',
+					addWidget: 'Add widget',
 				},
 				serverItems: ( config.serverWallpaperMenuItems as
 				| ServerWallpaperMenuItem[]

--- a/src/widgets/frame.ts
+++ b/src/widgets/frame.ts
@@ -467,8 +467,12 @@ function attachDrag(
 			commitDrag();
 		}
 
-		// Snap before clamping: the clamp bounds are multiples of the
-		// grid, so a snapped-then-clamped position is still on-grid.
+		// Snap on the way in, then again on the way out. Only the
+		// near bounds of the clamp are on-grid (they're
+		// `VIEWPORT_MARGIN`); the far ones are whatever the parent's
+		// size minus the card's leaves over, so a widget shoved
+		// against the right or bottom edge would land off-grid and
+		// persist there.
 		const clamped = clampToParent(
 			snapToGrid( initialLeft + dx ),
 			snapToGrid( initialTop + dy ),
@@ -476,8 +480,8 @@ function attachDrag(
 			card.offsetHeight,
 			ctx.floatingParent,
 		);
-		card.style.left = `${ clamped.x }px`;
-		card.style.top = `${ clamped.y }px`;
+		card.style.left = `${ snapWithin( clamped.x ) }px`;
+		card.style.top = `${ snapWithin( clamped.y ) }px`;
 	};
 
 	const onUp = ( e: PointerEvent ): void => {
@@ -702,6 +706,18 @@ function clampGeometryToParent(
 /** Round a coordinate onto the {@link SNAP_GRID}. */
 function snapToGrid( value: number ): number {
 	return Math.round( value / SNAP_GRID ) * SNAP_GRID;
+}
+
+/**
+ * Grid line at or below `value` — the post-clamp pass. Rounding to
+ * the *nearest* line here could push the card back out of the bounds
+ * the clamp just put it inside, so this one only ever moves inward.
+ * A card too big for its parent has no grid line to sit on and keeps
+ * the clamped value.
+ */
+function snapWithin( value: number ): number {
+	const snapped = Math.floor( value / SNAP_GRID ) * SNAP_GRID;
+	return snapped >= VIEWPORT_MARGIN ? snapped : Math.min( value, VIEWPORT_MARGIN );
 }
 
 function clampToParent(

--- a/src/widgets/frame.ts
+++ b/src/widgets/frame.ts
@@ -769,7 +769,21 @@ export function computeResize(
 	let height = startH;
 
 	if ( dir === 'e' || dir === 'ne' || dir === 'se' ) {
-		width = clamp( startW + dx, minW, Math.min( maxW, parentWidth - startLeft ) );
+		if ( floating ) {
+			// Same rule as the west handle, just the other edge: snap
+			// what the pointer is dragging. With the origin already
+			// on-grid the width comes out a whole number of cells, so
+			// two widgets can line up their right edges as well as
+			// their left.
+			const right = snapIntoRange(
+				snapToGrid( startLeft + startW + dx ),
+				startLeft + minW,
+				Math.min( startLeft + maxW, parentWidth ),
+			);
+			width = right - startLeft;
+		} else {
+			width = clamp( startW + dx, minW, Math.min( maxW, parentWidth - startLeft ) );
+		}
 	}
 	if ( dir === 'w' || dir === 'nw' || dir === 'sw' ) {
 		const right = startLeft + startW;
@@ -791,11 +805,24 @@ export function computeResize(
 		}
 	}
 	if ( dir === 's' || dir === 'se' || dir === 'sw' ) {
-		height = clamp(
-			startH + dy,
-			minH,
-			Math.min( maxH, parentHeight - startTop ),
-		);
+		if ( floating ) {
+			const bottom = snapIntoRange(
+				snapToGrid( startTop + startH + dy ),
+				startTop + minH,
+				Math.min( startTop + maxH, parentHeight ),
+			);
+			height = bottom - startTop;
+		} else {
+			// The column's own resize stays freehand. A docked card's
+			// top is pinned by the stack above it, so there's nothing
+			// to align it to, and stepping the height in whole cells
+			// would just make the drag feel coarse.
+			height = clamp(
+				startH + dy,
+				minH,
+				Math.min( maxH, parentHeight - startTop ),
+			);
+		}
 	}
 	if ( dir === 'n' || dir === 'ne' || dir === 'nw' ) {
 		const bottom = startTop + startH;
@@ -827,12 +854,12 @@ export function computeResize(
 
 /**
  * Grid line inside `[min, max]`, preferring the one at or below
- * `value`. Used for the origin of a resize, where the legal range is
- * set by the widget's min/max size rather than by the desktop edges,
- * so neither end is guaranteed to be on-grid. A range too narrow to
- * hold a grid line at all (a widget whose min and max sizes are
- * within 20 px of each other) keeps the plain clamped value — an
- * off-grid origin beats refusing to resize.
+ * `value`. Used for the edge under the pointer during a resize, where
+ * the legal range is set by the widget's min/max size rather than by
+ * the desktop edges, so neither end is guaranteed to be on-grid. A
+ * range too narrow to hold a grid line at all (a widget whose min and
+ * max sizes are within 20 px of each other) keeps the plain clamped
+ * value — an off-grid edge beats refusing to resize.
  */
 function snapIntoRange( value: number, min: number, max: number ): number {
 	const clamped = clamp( value, min, max );

--- a/src/widgets/frame.ts
+++ b/src/widgets/frame.ts
@@ -36,6 +36,16 @@ const DEFAULT_HEIGHT = 180;
 const VIEWPORT_MARGIN = 20;
 
 /**
+ * Grid a floating widget's position snaps to while being dragged.
+ * Two widgets dropped at roughly the same height land on the same
+ * multiple, which is the whole point — freehand placement never
+ * lines up. Deliberately equal to {@link VIEWPORT_MARGIN} so the
+ * clamped edge positions are themselves on-grid, and a widget parked
+ * against the margin stays aligned with everything else.
+ */
+const SNAP_GRID = 20;
+
+/**
  * Drag threshold (squared) — pointer must move this far from the
  * pointerdown origin before the drag gesture commits. Below this,
  * the press + release is treated as a click (no liberate, no geometry
@@ -457,9 +467,11 @@ function attachDrag(
 			commitDrag();
 		}
 
+		// Snap before clamping: the clamp bounds are multiples of the
+		// grid, so a snapped-then-clamped position is still on-grid.
 		const clamped = clampToParent(
-			initialLeft + dx,
-			initialTop + dy,
+			snapToGrid( initialLeft + dx ),
+			snapToGrid( initialTop + dy ),
 			card.offsetWidth,
 			card.offsetHeight,
 			ctx.floatingParent,
@@ -685,6 +697,11 @@ function clampGeometryToParent(
 		parent,
 	);
 	return { ...geometry, x: clamped.x, y: clamped.y };
+}
+
+/** Round a coordinate onto the {@link SNAP_GRID}. */
+function snapToGrid( value: number ): number {
+	return Math.round( value / SNAP_GRID ) * SNAP_GRID;
 }
 
 function clampToParent(

--- a/src/widgets/frame.ts
+++ b/src/widgets/frame.ts
@@ -772,9 +772,23 @@ export function computeResize(
 		width = clamp( startW + dx, minW, Math.min( maxW, parentWidth - startLeft ) );
 	}
 	if ( dir === 'w' || dir === 'nw' || dir === 'sw' ) {
-		const nextWidth = clamp( startW - dx, minW, Math.min( maxW, startLeft + startW ) );
-		x = startLeft + ( startW - nextWidth );
-		width = nextWidth;
+		const right = startLeft + startW;
+		if ( floating ) {
+			// Snap the edge under the pointer, then take the width
+			// from it. Doing it the other way round (snap the width,
+			// derive x) would move the right edge, which the user is
+			// not dragging.
+			x = snapIntoRange(
+				snapToGrid( startLeft + dx ),
+				Math.max( 0, right - Math.min( maxW, right ) ),
+				right - minW,
+			);
+			width = right - x;
+		} else {
+			const nextWidth = clamp( startW - dx, minW, Math.min( maxW, right ) );
+			x = startLeft + ( startW - nextWidth );
+			width = nextWidth;
+		}
 	}
 	if ( dir === 's' || dir === 'se' || dir === 'sw' ) {
 		height = clamp(
@@ -784,9 +798,19 @@ export function computeResize(
 		);
 	}
 	if ( dir === 'n' || dir === 'ne' || dir === 'nw' ) {
-		const nextHeight = clamp( startH - dy, minH, Math.min( maxH, startTop + startH ) );
-		y = startTop + ( startH - nextHeight );
-		height = nextHeight;
+		const bottom = startTop + startH;
+		if ( floating ) {
+			y = snapIntoRange(
+				snapToGrid( startTop + dy ),
+				Math.max( 0, bottom - Math.min( maxH, bottom ) ),
+				bottom - minH,
+			);
+			height = bottom - y;
+		} else {
+			const nextHeight = clamp( startH - dy, minH, Math.min( maxH, bottom ) );
+			y = startTop + ( startH - nextHeight );
+			height = nextHeight;
+		}
 	}
 
 	// Non-floating (column-docked) widgets ignore any width change —
@@ -799,6 +823,25 @@ export function computeResize(
 	}
 
 	return { x, y, width, height };
+}
+
+/**
+ * Grid line inside `[min, max]`, preferring the one at or below
+ * `value`. Used for the origin of a resize, where the legal range is
+ * set by the widget's min/max size rather than by the desktop edges,
+ * so neither end is guaranteed to be on-grid. A range too narrow to
+ * hold a grid line at all (a widget whose min and max sizes are
+ * within 20 px of each other) keeps the plain clamped value — an
+ * off-grid origin beats refusing to resize.
+ */
+function snapIntoRange( value: number, min: number, max: number ): number {
+	const clamped = clamp( value, min, max );
+	const down = Math.floor( clamped / SNAP_GRID ) * SNAP_GRID;
+	if ( down >= min ) {
+		return down;
+	}
+	const up = down + SNAP_GRID;
+	return up <= max ? up : clamped;
 }
 
 function clamp( value: number, min: number, max: number ): number {

--- a/src/widgets/layer.ts
+++ b/src/widgets/layer.ts
@@ -42,6 +42,17 @@ import type { WidgetGeometry, WidgetTeardown } from './types';
 /** First-run default — the clock. Removable like any other. */
 const DEFAULT_ENABLED_IDS = [ 'clock' ];
 
+/**
+ * How far outside the column the pointer still counts as "near" for
+ * the add-widget pill. Generous enough that approaching the column
+ * reveals the pill before the pointer lands on a card, tight enough
+ * that it stays out of the way of the rest of the desktop.
+ */
+const HOVER_PADDING = 40;
+
+/** Gap between the bottom of the widget stack and the add pill. */
+const ADD_TILE_GAP = 12;
+
 /** Internal record of a mounted widget. */
 interface MountedWidget {
 	id: string;
@@ -73,6 +84,9 @@ export class WidgetLayer {
 	 */
 	private generation = 0;
 
+	/** Teardown for the pointer-proximity watch. */
+	private unwatchPointer: ( () => void ) | null = null;
+
 	/**
 	 * @param root         The column element (`#os-widgets`).
 	 * @param pluginUrl    Absolute plugin URL — passed to widget ctx.
@@ -101,6 +115,7 @@ export class WidgetLayer {
 		this.root.appendChild( this.addTile );
 
 		this.paintEmptyState();
+		this.watchPointerProximity();
 	}
 
 	/**
@@ -185,6 +200,31 @@ export class WidgetLayer {
 	}
 
 	/**
+	 * Open the widget picker, anchored to the add pill. The pill is
+	 * the click target that normally does this, but it's also the
+	 * anchor the popover positions against, so the wallpaper's
+	 * right-click menu comes through here too rather than growing a
+	 * second, differently-placed panel.
+	 *
+	 * The `--picking` flag keeps the pill on screen for as long as
+	 * the popover is open. Without it, moving the pointer onto the
+	 * panel takes it out of the column's proximity zone and the
+	 * anchor fades out from under the menu.
+	 */
+	public openPicker(): void {
+		this.positionAddTile();
+		this.root.classList.add( 'os-widgets--picking' );
+		openWidgetPicker( {
+			anchor: this.addTile,
+			registry: () => registry.all(),
+			enabledIds: () => [ ...this.enabledIds ],
+			onAdd: ( id ) => this.add( id ),
+			onClose: () =>
+				this.root.classList.remove( 'os-widgets--picking' ),
+		} );
+	}
+
+	/**
 	 * Mount a widget ONLY if it's already in the user's enabled
 	 * list AND not currently mounted. No-op when the widget isn't
 	 * enabled (user never opted in) and no-op when it's already on
@@ -266,6 +306,8 @@ export class WidgetLayer {
 		for ( const id of Array.from( this.mounted.keys() ) ) {
 			this.unmountById( id );
 		}
+		this.unwatchPointer?.();
+		this.unwatchPointer = null;
 	}
 
 	// --- Internal ---------------------------------------------------
@@ -403,14 +445,80 @@ export class WidgetLayer {
 		tile.addEventListener( 'click', ( e ) => {
 			e.preventDefault();
 			e.stopPropagation();
-			openWidgetPicker( {
-				anchor: tile,
-				registry: () => registry.all(),
-				enabledIds: () => [ ...this.enabledIds ],
-				onAdd: ( id ) => this.add( id ),
-			} );
+			this.openPicker();
 		} );
 		return tile;
+	}
+
+	/**
+	 * Reveal the add-widget pill while the pointer is near the
+	 * column, hide it otherwise.
+	 *
+	 * Can't be a plain CSS `:hover` — the column is
+	 * `pointer-events: none` so a drag grazing its margin falls
+	 * through to the window underneath, and that also means it never
+	 * receives hover. So the proximity test runs off a passive
+	 * document-level `pointermove` instead, against a cached rect
+	 * (the column's box is CSS-fixed, so only a viewport resize can
+	 * move it).
+	 */
+	private watchPointerProximity(): void {
+		let rect: DOMRect | null = null;
+		let frame = 0;
+
+		const invalidate = (): void => {
+			rect = null;
+			this.positionAddTile();
+		};
+		// The reveal itself is a cached-rect comparison, cheap enough
+		// to run on every move. Re-measuring the stack is not — it
+		// reads layout — so it's collapsed to one pass per frame,
+		// which is all a repaint can show anyway.
+		const remeasure = (): void => {
+			if ( frame ) {
+				return;
+			}
+			frame = requestAnimationFrame( () => {
+				frame = 0;
+				this.positionAddTile();
+			} );
+		};
+		const onMove = ( e: PointerEvent ): void => {
+			if ( ! rect ) {
+				rect = this.root.getBoundingClientRect();
+			}
+			const near =
+				e.clientX >= rect.left - HOVER_PADDING &&
+				e.clientX <= rect.right + HOVER_PADDING &&
+				e.clientY >= rect.top - HOVER_PADDING &&
+				e.clientY <= rect.bottom + HOVER_PADDING;
+			this.root.classList.toggle( 'os-widgets--hovered', near );
+			if ( near ) {
+				// Follow a widget dragged over the column instead of
+				// waiting for the drop to catch up.
+				remeasure();
+			}
+		};
+		const onLeave = (): void => {
+			this.root.classList.remove( 'os-widgets--hovered' );
+		};
+
+		document.addEventListener( 'pointermove', onMove, { passive: true } );
+		document.documentElement.addEventListener( 'pointerleave', onLeave );
+		window.addEventListener( 'resize', invalidate );
+
+		this.unwatchPointer = () => {
+			if ( frame ) {
+				cancelAnimationFrame( frame );
+				frame = 0;
+			}
+			document.removeEventListener( 'pointermove', onMove );
+			document.documentElement.removeEventListener(
+				'pointerleave',
+				onLeave,
+			);
+			window.removeEventListener( 'resize', invalidate );
+		};
 	}
 
 	/**
@@ -492,6 +600,51 @@ export class WidgetLayer {
 	private persistGeometry( id: string, geometry: WidgetGeometry ): void {
 		this.geometry[ id ] = geometry;
 		saveGeometry( this.geometry );
+		this.positionAddTile();
+	}
+
+	/**
+	 * Park the add pill just under the lowest widget standing in the
+	 * column, so it always reads as the end of that stack.
+	 *
+	 * The docked cards are in the column's own flow, so their extent
+	 * is a plain `offsetHeight` read. Floating cards are not: dragging
+	 * a widget out of the column re-parents it to the desktop area,
+	 * and it can be dropped straight back over the column, where it
+	 * still looks like part of the stack but contributes nothing to
+	 * the column's layout. Those get measured and folded in — but only
+	 * when they cover at least half the column's width, so a widget
+	 * merely grazing the column's edge doesn't drag the pill down with
+	 * it.
+	 */
+	private positionAddTile(): void {
+		const colRect = this.root.getBoundingClientRect();
+		if ( ! colRect.height ) {
+			return;
+		}
+		let bottom = this.listEl.offsetTop + this.listEl.offsetHeight;
+		for ( const record of this.mounted.values() ) {
+			if ( ! record.floating ) {
+				continue;
+			}
+			const rect = record.frame.card.getBoundingClientRect();
+			const overlap =
+				Math.min( rect.right, colRect.right ) -
+				Math.max( rect.left, colRect.left );
+			if ( overlap < colRect.width / 2 ) {
+				continue;
+			}
+			bottom = Math.max(
+				bottom,
+				rect.bottom - colRect.top + this.root.scrollTop,
+			);
+		}
+		// Never past the column's visible foot — a tall stack pushes
+		// the pill onto the last card rather than off the screen.
+		const limit =
+			colRect.height + this.root.scrollTop - this.addTile.offsetHeight;
+		const top = Math.max( 0, Math.min( bottom + ADD_TILE_GAP, limit ) );
+		this.addTile.style.top = `${ top }px`;
 	}
 
 	private persistDockedHeight( id: string, height: number ): void {
@@ -522,6 +675,7 @@ export class WidgetLayer {
 			'os-widgets--has-widgets',
 			docked > 0,
 		);
+		this.positionAddTile();
 	}
 }
 

--- a/src/widgets/layer.ts
+++ b/src/widgets/layer.ts
@@ -25,7 +25,11 @@
 import { doAction, HOOKS } from '../hooks';
 import { __ } from '../i18n';
 import * as registry from './registry';
-import { openWidgetPicker, refreshWidgetPicker } from './picker';
+import {
+	openWidgetPicker,
+	refreshWidgetPicker,
+	repositionWidgetPicker,
+} from './picker';
 import { applyGeometry, buildFrame, type Frame } from './frame';
 import {
 	loadDockedHeights,
@@ -367,6 +371,11 @@ export class WidgetLayer {
 				return;
 			}
 			current.teardown = teardown;
+			// An async mount paints its content now, so the card can
+			// be taller than it was when the pill was last placed.
+			// On a hover device the next pointermove would fix it, but
+			// where the pill is always on (touch) nothing else would.
+			this.positionAddTile();
 			doAction( HOOKS.WIDGET_MOUNTED, { id, container: frame.body, ctx } );
 		};
 
@@ -458,9 +467,15 @@ export class WidgetLayer {
 	 * `pointer-events: none` so a drag grazing its margin falls
 	 * through to the window underneath, and that also means it never
 	 * receives hover. So the proximity test runs off a passive
-	 * document-level `pointermove` instead, against a cached rect
-	 * (the column's box is CSS-fixed, so only a viewport resize can
-	 * move it).
+	 * document-level `pointermove` instead, against a rect cached
+	 * between layout changes.
+	 *
+	 * The cache needs a `ResizeObserver`, not just a resize listener:
+	 * the column is absolute inside `.os-area`, which is a flex child
+	 * of `.os-shell__body` alongside the dock. Move the dock to the
+	 * left or right in Preferences and the area narrows, taking the
+	 * column with it, with no window resize to notice. A stale rect
+	 * leaves the reveal zone hovering over empty desktop.
 	 */
 	private watchPointerProximity(): void {
 		let rect: DOMRect | null = null;
@@ -507,11 +522,24 @@ export class WidgetLayer {
 		document.documentElement.addEventListener( 'pointerleave', onLeave );
 		window.addEventListener( 'resize', invalidate );
 
+		// The column itself keeps its 320 px whatever the dock does,
+		// so watch the desktop area too — that's the box that actually
+		// changes when the dock takes width out of the flex row.
+		let observer: ResizeObserver | null = null;
+		if ( typeof ResizeObserver === 'function' ) {
+			observer = new ResizeObserver( invalidate );
+			observer.observe( this.root );
+			if ( this.root.parentElement ) {
+				observer.observe( this.root.parentElement );
+			}
+		}
+
 		this.unwatchPointer = () => {
 			if ( frame ) {
 				cancelAnimationFrame( frame );
 				frame = 0;
 			}
+			observer?.disconnect();
 			document.removeEventListener( 'pointermove', onMove );
 			document.documentElement.removeEventListener(
 				'pointerleave',
@@ -644,7 +672,12 @@ export class WidgetLayer {
 		const limit =
 			colRect.height + this.root.scrollTop - this.addTile.offsetHeight;
 		const top = Math.max( 0, Math.min( bottom + ADD_TILE_GAP, limit ) );
+		if ( this.addTile.style.top === `${ top }px` ) {
+			return;
+		}
 		this.addTile.style.top = `${ top }px`;
+		// The picker anchors to the pill, so it has to come along.
+		repositionWidgetPicker();
 	}
 
 	private persistDockedHeight( id: string, height: number ): void {

--- a/src/widgets/layer.ts
+++ b/src/widgets/layer.ts
@@ -26,9 +26,9 @@ import { doAction, HOOKS } from '../hooks';
 import { __ } from '../i18n';
 import * as registry from './registry';
 import {
+	closeWidgetPicker,
 	openWidgetPicker,
 	refreshWidgetPicker,
-	repositionWidgetPicker,
 } from './picker';
 import { applyGeometry, buildFrame, type Frame } from './frame';
 import {
@@ -167,7 +167,6 @@ export class WidgetLayer {
 		this.mountById( id );
 		this.paintEmptyState();
 		doAction( HOOKS.WIDGET_ADDED, { id } );
-		refreshWidgetPicker();
 	}
 
 	/**
@@ -222,7 +221,18 @@ export class WidgetLayer {
 			anchor: this.addTile,
 			registry: () => registry.all(),
 			enabledIds: () => [ ...this.enabledIds ],
-			onAdd: ( id ) => this.add( id ),
+			onAdd: ( id ) => {
+				this.add( id );
+				// One pick per visit. Adding a second widget means
+				// opening the picker again, which keeps the panel
+				// from sitting over the column while the user looks
+				// at what they just added.
+				closeWidgetPicker();
+				// The picker took focus when it opened, so hand it
+				// back rather than dropping a keyboard user on
+				// `<body>`.
+				this.addTile.focus();
+			},
 			onClose: () =>
 				this.root.classList.remove( 'os-widgets--picking' ),
 		} );
@@ -676,8 +686,6 @@ export class WidgetLayer {
 			return;
 		}
 		this.addTile.style.top = `${ top }px`;
-		// The picker anchors to the pill, so it has to come along.
-		repositionWidgetPicker();
 	}
 
 	private persistDockedHeight( id: string, height: number ): void {

--- a/src/widgets/picker.ts
+++ b/src/widgets/picker.ts
@@ -121,6 +121,20 @@ export function refreshWidgetPicker(): void {
 	}
 }
 
+/**
+ * Re-run the open picker's positioning against its anchor. The add
+ * pill is not at a fixed spot in the column — it trails the widget
+ * stack — so adding a widget from the picker pushes the anchor down
+ * by the height of the card that just mounted. Without this the panel
+ * stays where it opened and drifts away from the pill it belongs to.
+ */
+export function repositionWidgetPicker(): void {
+	if ( ! active ) {
+		return;
+	}
+	positionPanel( active.panel, active.options.anchor );
+}
+
 /** Close the active picker. No-op if none is open. */
 export function closeWidgetPicker(): void {
 	if ( ! active ) {

--- a/src/widgets/picker.ts
+++ b/src/widgets/picker.ts
@@ -24,6 +24,11 @@ interface OpenPickerOptions {
 	enabledIds: () => string[];
 	/** Click handler — layer persists + mounts on call. */
 	onAdd: ( id: string ) => void;
+	/**
+	 * Fired once when the picker closes. The layer uses it to drop
+	 * the "keep the + pill visible" flag it sets on open.
+	 */
+	onClose?: () => void;
 }
 
 /**
@@ -128,7 +133,9 @@ export function closeWidgetPicker(): void {
 	);
 	document.removeEventListener( 'keydown', active.onKeyDown );
 	active.panel.remove();
+	const { onClose } = active.options;
 	active = null;
+	onClose?.();
 }
 
 // ------------------------------------------------------------------

--- a/src/widgets/picker.ts
+++ b/src/widgets/picker.ts
@@ -121,20 +121,6 @@ export function refreshWidgetPicker(): void {
 	}
 }
 
-/**
- * Re-run the open picker's positioning against its anchor. The add
- * pill is not at a fixed spot in the column — it trails the widget
- * stack — so adding a widget from the picker pushes the anchor down
- * by the height of the card that just mounted. Without this the panel
- * stays where it opened and drifts away from the pill it belongs to.
- */
-export function repositionWidgetPicker(): void {
-	if ( ! active ) {
-		return;
-	}
-	positionPanel( active.panel, active.options.anchor );
-}
-
 /** Close the active picker. No-op if none is open. */
 export function closeWidgetPicker(): void {
 	if ( ! active ) {
@@ -228,12 +214,10 @@ function paintList(
 			entry.addEventListener( 'click', ( e ) => {
 				e.preventDefault();
 				e.stopPropagation();
+				// Whether a pick closes the picker is the layer's
+				// call, not this component's — it owns the anchor
+				// and knows what happens to it afterwards.
 				options.onAdd( def.id );
-				// Picker stays OPEN so the user can add several
-				// widgets in a row without re-clicking `+`. Close
-				// is driven by Esc, outside click, or explicit UI
-				// (none today — one-at-a-time add-then-close is
-				// the v1 flow if they prefer).
 			} );
 		}
 

--- a/tests/vitest/desktop-files-wallpaper-menu.test.ts
+++ b/tests/vitest/desktop-files-wallpaper-menu.test.ts
@@ -14,6 +14,7 @@ async function load(): Promise< MenuModule > {
 const stubDeps = ( overrides: Partial< import( '../../src/desktop-files/wallpaper-menu' ).WallpaperMenuDeps > = {} ) => ( {
 	createFolder: vi.fn(),
 	createUrl: vi.fn(),
+	addWidget: vi.fn(),
 	toggleShowDesktop: vi.fn(),
 	openOsSettings: vi.fn(),
 	sortIcons: vi.fn(),
@@ -27,6 +28,7 @@ const stubDeps = ( overrides: Partial< import( '../../src/desktop-files/wallpape
 		sortDateAsc: 'Date (oldest first)',
 		sortDateDesc: 'Date (newest first)',
 		newUrl: 'New URL',
+		addWidget: 'Add widget',
 	},
 	...overrides,
 } );
@@ -47,6 +49,7 @@ describe( 'wallpaper context menu', () => {
 		expect( items.map( ( i ) => i.id ) ).toEqual( [
 			'create-folder',
 			'new-url',
+			'add-widget',
 			'sort-by',
 			'show-desktop',
 			'os-settings',
@@ -74,9 +77,22 @@ describe( 'wallpaper context menu', () => {
 		expect( items.map( ( i ) => i.id ) ).toEqual( [
 			'create-folder',
 			'new-url',
+			'add-widget',
 			'sort-by',
 			'os-settings',
 		] );
+	} );
+
+	test( 'clicking Add widget invokes deps.addWidget', async () => {
+		const { openWallpaperMenu, buildMenuItems } = await load();
+		const deps = stubDeps();
+		openWallpaperMenu( document.body, { x: 0, y: 0 }, buildMenuItems( deps ) );
+		document
+			.querySelector< HTMLButtonElement >(
+				'[data-menu-item-id="add-widget"]',
+			)!
+			.click();
+		expect( deps.addWidget ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'clicking New URL invokes deps.createUrl', async () => {

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -906,4 +906,224 @@ describe( 'widgets/layer', () => {
 
 		layer.disposeAll();
 	} );
+
+	test( 'the add-widget pill reveals only while the pointer is near the column', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'near',
+			label: 'Near',
+			description: '',
+			icon: 'dashicons-star-filled',
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem( 'desktop-mode-widgets', '["near"]' );
+
+		// jsdom lays nothing out — pin the column's box so the
+		// proximity test has real numbers to compare against.
+		host.getBoundingClientRect = (): DOMRect => ( {
+			x: 704, y: 16, width: 320, height: 736,
+			top: 16, left: 704, right: 1024, bottom: 752,
+			toJSON: () => ( {} ),
+		} );
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+		expect( host.classList.contains( 'os-widgets--hovered' ) ).toBe( false );
+
+		const move = ( x: number, y: number ): void => {
+			const e = new Event( 'pointermove', { bubbles: true } );
+			Object.defineProperty( e, 'clientX', { value: x } );
+			Object.defineProperty( e, 'clientY', { value: y } );
+			document.dispatchEvent( e );
+		};
+
+		// Far left of the desktop — nowhere near the column.
+		move( 120, 400 );
+		expect( host.classList.contains( 'os-widgets--hovered' ) ).toBe( false );
+
+		// Inside the column.
+		move( 800, 400 );
+		expect( host.classList.contains( 'os-widgets--hovered' ) ).toBe( true );
+
+		// Just outside, but within the approach padding.
+		move( 680, 400 );
+		expect( host.classList.contains( 'os-widgets--hovered' ) ).toBe( true );
+
+		// Past the padding — hidden again.
+		move( 600, 400 );
+		expect( host.classList.contains( 'os-widgets--hovered' ) ).toBe( false );
+
+		// After disposal the watch is gone and the class stops tracking.
+		layer.disposeAll();
+		move( 800, 400 );
+		expect( host.classList.contains( 'os-widgets--hovered' ) ).toBe( false );
+	} );
+
+	test( 'the add pill trails the lowest widget standing in the column', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'docked',
+			label: 'Docked',
+			description: '',
+			icon: 'dashicons-star-filled',
+			mount: () => () => undefined,
+		} );
+		registry.register( {
+			id: 'parked',
+			label: 'Parked',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			mount: () => () => undefined,
+		} );
+		registry.register( {
+			id: 'elsewhere',
+			label: 'Elsewhere',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem(
+			'desktop-mode-widgets',
+			'["docked","parked","elsewhere"]',
+		);
+		// `parked` sits over the column; `elsewhere` is lower down but
+		// off to the left, so it must not drag the pill with it.
+		window.localStorage.setItem(
+			'desktop-mode-widgets-geometry',
+			JSON.stringify( {
+				parked: { x: 704, y: 300, width: 320, height: 200 },
+				elsewhere: { x: 40, y: 600, width: 320, height: 200 },
+			} ),
+		);
+
+		const col = { top: 16, left: 704, right: 1024, bottom: 752 };
+		host.getBoundingClientRect = (): DOMRect => ( {
+			x: col.left, y: col.top, width: 320, height: 736,
+			...col, toJSON: () => ( {} ),
+		} );
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+
+		const list = host.querySelector< HTMLElement >(
+			'.os-widgets__list',
+		)!;
+		Object.defineProperty( list, 'offsetHeight', {
+			configurable: true,
+			get: () => 120,
+		} );
+		const rectFor = ( card: HTMLElement, box: DOMRect ) => {
+			card.getBoundingClientRect = (): DOMRect => box;
+		};
+		const byLabel = ( label: string ): HTMLElement =>
+			[
+				...document.body.querySelectorAll< HTMLElement >(
+					'.os-widgets__card--floating',
+				),
+			].find( ( c ) => c.textContent?.includes( label ) )!;
+
+		// Parked: viewport y 300→500, i.e. 284→484 in column space.
+		rectFor( byLabel( 'Parked' ), {
+			x: 704, y: 300, width: 320, height: 200,
+			top: 300, left: 704, right: 1024, bottom: 500,
+			toJSON: () => ( {} ),
+		} as DOMRect );
+		// Elsewhere: lower, but nowhere near the column's x range.
+		rectFor( byLabel( 'Elsewhere' ), {
+			x: 40, y: 600, width: 320, height: 200,
+			top: 600, left: 40, right: 360, bottom: 800,
+			toJSON: () => ( {} ),
+		} as DOMRect );
+
+		const tile = host.querySelector< HTMLElement >(
+			'.os-widgets__add',
+		)!;
+
+		// Re-run the measurement now that the stubs are in place.
+		const move = ( x: number, y: number ): void => {
+			const e = new Event( 'pointermove', { bubbles: true } );
+			Object.defineProperty( e, 'clientX', { value: x } );
+			Object.defineProperty( e, 'clientY', { value: y } );
+			document.dispatchEvent( e );
+		};
+		move( 800, 400 );
+		await new Promise( ( resolve ) =>
+			requestAnimationFrame( () => resolve( undefined ) ),
+		);
+
+		// Parked's bottom (484 in column space) wins over the docked
+		// list (120), plus the 12 px gap.
+		expect( tile.style.top ).toBe( '496px' );
+
+		layer.disposeAll();
+	} );
+
+	test( 'dragging a floating widget snaps its position to the grid', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		registry.register( {
+			id: 'snappy',
+			label: 'Snappy',
+			description: '',
+			icon: 'dashicons-star-filled',
+			movable: true,
+			mount: () => () => undefined,
+		} );
+		window.localStorage.setItem( 'desktop-mode-widgets', '["snappy"]' );
+		window.localStorage.setItem(
+			'desktop-mode-widgets-geometry',
+			JSON.stringify( {
+				snappy: { x: 100, y: 100, width: 240, height: 120 },
+			} ),
+		);
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+
+		const card = document.body.querySelector< HTMLElement >(
+			'.os-widgets__card',
+		)!;
+		Object.defineProperty( card, 'offsetWidth', {
+			configurable: true,
+			get: () => 240,
+		} );
+		Object.defineProperty( card, 'offsetHeight', {
+			configurable: true,
+			get: () => 120,
+		} );
+		document.body.getBoundingClientRect = (): DOMRect => ( {
+			x: 0, y: 0, width: 1024, height: 768,
+			top: 0, left: 0, right: 1024, bottom: 768,
+			toJSON: () => ( {} ),
+		} );
+
+		const ptr = ( type: string, x: number, y: number ): Event => {
+			const e = new Event( type, { bubbles: true } );
+			Object.defineProperty( e, 'pointerId', { value: 1 } );
+			Object.defineProperty( e, 'button', { value: 0 } );
+			Object.defineProperty( e, 'clientX', { value: x } );
+			Object.defineProperty( e, 'clientY', { value: y } );
+			return e;
+		};
+		const chrome = card.querySelector< HTMLElement >(
+			'.os-widgets__chrome',
+		)!;
+		( chrome as unknown as { setPointerCapture: () => void } ).setPointerCapture = () => undefined;
+		( chrome as unknown as { releasePointerCapture: () => void } ).releasePointerCapture = () => undefined;
+
+		// Drag by +37 / -23 — off-grid on both axes. From 100,100
+		// that's 137,77, which rounds to the nearest multiple of 20.
+		chrome.dispatchEvent( ptr( 'pointerdown', 0, 0 ) );
+		chrome.dispatchEvent( ptr( 'pointermove', 37, -23 ) );
+		chrome.dispatchEvent( ptr( 'pointerup', 37, -23 ) );
+
+		expect( card.style.left ).toBe( '140px' );
+		expect( card.style.top ).toBe( '80px' );
+
+		layer.disposeAll();
+	} );
 } );

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -1124,6 +1124,16 @@ describe( 'widgets/layer', () => {
 		expect( card.style.left ).toBe( '140px' );
 		expect( card.style.top ).toBe( '80px' );
 
+		// Shove it hard against the far edges. The clamp's far bounds
+		// are parent-minus-card, which is off-grid (1024 - 240 - 20 =
+		// 764), so the post-clamp pass has to pull it back to 760.
+		chrome.dispatchEvent( ptr( 'pointerdown', 0, 0 ) );
+		chrome.dispatchEvent( ptr( 'pointermove', 5000, 5000 ) );
+		chrome.dispatchEvent( ptr( 'pointerup', 5000, 5000 ) );
+
+		expect( card.style.left ).toBe( '760px' );
+		expect( card.style.top ).toBe( '620px' );
+
 		layer.disposeAll();
 	} );
 } );

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -990,6 +990,57 @@ describe( 'widgets/layer', () => {
 		layer.disposeAll();
 	} );
 
+	test( 'picking a widget closes the picker and hands focus back to the pill', async () => {
+		const registry = await import( '../../src/widgets/registry' );
+		const { WidgetLayer } = await import( '../../src/widgets/layer' );
+		for ( const id of [ 'pick-a', 'pick-b' ] ) {
+			registry.register( {
+				id,
+				label: id,
+				description: '',
+				icon: 'dashicons-star-filled',
+				mount: () => () => undefined,
+			} );
+		}
+		window.localStorage.setItem( 'desktop-mode-widgets', '[]' );
+
+		const layer = new WidgetLayer( host, '' );
+		layer.hydrate();
+		layer.openPicker();
+
+		expect( document.querySelector( '.os-widget-picker' ) ).not.toBeNull();
+		expect(
+			host.classList.contains( 'os-widgets--picking' ),
+		).toBe( true );
+
+		const entry = document.querySelector< HTMLButtonElement >(
+			'.os-widget-picker__entry:not([disabled])',
+		)!;
+		entry.click();
+
+		expect( layer.getEnabledIds() ).toEqual( [ 'pick-a' ] );
+		// Panel gone, and the flag that pinned the pill with it.
+		expect( document.querySelector( '.os-widget-picker' ) ).toBeNull();
+		expect(
+			host.classList.contains( 'os-widgets--picking' ),
+		).toBe( false );
+		expect( document.activeElement ).toBe(
+			host.querySelector( '.os-widgets__add' ),
+		);
+
+		// Adding a second one means opening it again.
+		layer.openPicker();
+		expect( document.querySelector( '.os-widget-picker' ) ).not.toBeNull();
+		document
+			.querySelector< HTMLButtonElement >(
+				'.os-widget-picker__entry:not([disabled])',
+			)!
+			.click();
+		expect( layer.getEnabledIds() ).toEqual( [ 'pick-a', 'pick-b' ] );
+
+		layer.disposeAll();
+	} );
+
 	test( 'the add-widget pill reveals only while the pointer is near the column', async () => {
 		const registry = await import( '../../src/widgets/registry' );
 		const { WidgetLayer } = await import( '../../src/widgets/layer' );

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -588,6 +588,59 @@ describe( 'widgets/layer', () => {
 		expect( docked.height ).toBe( 400 );
 	} );
 
+	test( 'computeResize keeps a floating widget origin on the snap grid', async () => {
+		const { computeResize } = await import( '../../src/widgets/frame' );
+		const parent = document.createElement( 'div' );
+		Object.defineProperty( parent, 'clientWidth', { value: 1000, configurable: true } );
+		Object.defineProperty( parent, 'clientHeight', { value: 600, configurable: true } );
+
+		const def = {
+			id: 'x',
+			label: 'X',
+			description: '',
+			icon: 'dashicons-star-filled',
+			minWidth: 120,
+			minHeight: 80,
+			mount: () => () => undefined,
+		};
+
+		// North-west drag by (-7, +9) from (140, 100). Freehand that
+		// lands at (133, 109); snapped it's (140, 100) again — and
+		// crucially the opposite edges (440, 300) don't move, so the
+		// size absorbs the difference.
+		const nudge = computeResize(
+			'nw', -7, 9, 140, 100, 300, 200, def, parent, true,
+		);
+		expect( nudge.x % 20 ).toBe( 0 );
+		expect( nudge.y % 20 ).toBe( 0 );
+		expect( nudge.x + nudge.width ).toBe( 440 );
+		expect( nudge.y + nudge.height ).toBe( 300 );
+
+		// Far enough to move a whole cell.
+		const west = computeResize(
+			'w', -33, 0, 140, 100, 300, 200, def, parent, true,
+		);
+		expect( west.x ).toBe( 100 );
+		expect( west.width ).toBe( 340 );
+
+		// Shrinking past minWidth. The naive stop is right - minW,
+		// which here is 445 - 120 = 325 and off-grid; the origin has
+		// to fall back to 320, giving 5 px more width than the
+		// minimum rather than an unaligned edge.
+		const squeezed = computeResize(
+			'w', 1000, 0, 140, 100, 305, 200, def, parent, true,
+		);
+		expect( squeezed.x ).toBe( 320 );
+		expect( squeezed.width ).toBe( 125 );
+
+		// Docked cards keep the old behaviour — no free position to
+		// align, and a chunky height drag would just feel worse.
+		const docked = computeResize(
+			'n', 0, -7, 140, 100, 300, 200, def, parent, false,
+		);
+		expect( docked.height ).toBe( 207 );
+	} );
+
 	test( 're-docking then resizing keeps the card in the column (no stale floating state)', async () => {
 		// Reproduces the "widget fully disappears while playing with
 		// drag / resize / re-attach" bug. The frame used to track

--- a/tests/vitest/widgets.test.ts
+++ b/tests/vitest/widgets.test.ts
@@ -633,12 +633,42 @@ describe( 'widgets/layer', () => {
 		expect( squeezed.x ).toBe( 320 );
 		expect( squeezed.width ).toBe( 125 );
 
+		// South-east: the origin holds, the far edges snap, so the
+		// size lands on whole cells too.
+		const corner = computeResize(
+			'se', 13, -6, 140, 100, 300, 200, def, parent, true,
+		);
+		expect( corner.x ).toBe( 140 );
+		expect( corner.y ).toBe( 100 );
+		expect( corner.width ).toBe( 320 );
+		expect( corner.height ).toBe( 200 );
+
+		// East drag far enough to cross a cell boundary.
+		const east = computeResize(
+			'e', 28, 0, 140, 100, 300, 200, def, parent, true,
+		);
+		expect( east.width ).toBe( 320 );
+		expect( east.x + east.width ).toBe( 460 );
+
+		// Growing past the parent's edge stops on the last grid line
+		// inside it. 1000 is on-grid, so squeeze the widget's own max
+		// to an off-grid stop instead.
+		const capped = computeResize(
+			'e', 1000, 0, 140, 100, 300, 200,
+			{ ...def, maxWidth: 265 }, parent, true,
+		);
+		expect( capped.width ).toBe( 260 );
+
 		// Docked cards keep the old behaviour — no free position to
 		// align, and a chunky height drag would just feel worse.
-		const docked = computeResize(
+		const dockedNorth = computeResize(
 			'n', 0, -7, 140, 100, 300, 200, def, parent, false,
 		);
-		expect( docked.height ).toBe( 207 );
+		expect( dockedNorth.height ).toBe( 207 );
+		const dockedSouth = computeResize(
+			's', 0, 7, 140, 100, 300, 200, def, parent, false,
+		);
+		expect( dockedSouth.height ).toBe( 207 );
 	} );
 
 	test( 're-docking then resizing keeps the card in the column (no stale floating state)', async () => {


### PR DESCRIPTION
## Proposed changes

- The "Add widget" drop zone becomes a small dashed pill that only appears while the pointer is near the widget column, and disappears when it leaves.
- The pill sits under the lowest widget standing in the column, whether that widget is docked or floating, so it always reads as the end of the stack.
- Floating widgets snap to a 20px grid, both while dragged and while resized from any handle, so widgets dropped outside the column line up with each other. Resizing a widget docked in the column is unchanged.
- The wallpaper's right-click menu gets an "Add widget" entry, between "New URL" and "Sort by". It opens the same picker anchored to the same pill.
- The picker closes once a widget is picked. It used to stay open for repeat adds.

Before | After
--- | ---
<img width="640" alt="Screenshot 2026-08-21 at 10 35 47" src="https://github.com/user-attachments/assets/300686da-b4a8-4a7c-ae92-258b6696921d" /> | <img width="640" alt="Aug-21-2026 10-34-54" src="https://github.com/user-attachments/assets/6a8ab710-78f3-4c20-860b-a156f241367d" />


## Why are these changes being made?

The old button was a full-width dashed box sitting on the desktop permanently, which is a lot of weight for something you use once. Hiding it behind a hover on the right side keeps the desktop clean. Putting it in the dock instead was the other option, but the dock already grows with every plugin that adds an item, so it is the wrong place for this.

Widgets dragged out of the column had no way to line up with each other, hence the grid.

## Testing instructions

### The pill

1. Load the desktop with at least one widget in the right-hand column (the clock is on by default).
2. Make sure no "Add widget" button is visible anywhere.
3. Move the pointer toward the widget column. Make sure a small dashed `+ Add widget` pill fades in under the last widget, and fades out again when you move the pointer back to the left of the desktop.
4. Click the pill. Make sure the picker opens above it, and that the pill stays visible for as long as the picker is open (move the pointer onto the picker panel to check).
5. Pick a widget. Make sure it lands in the column and the picker closes.
6. Click the pill again and pick a second widget. Make sure it lands below the first.
7. Remove every widget from the column. Make sure the pill still only appears on hover, not permanently.
8. Press Tab until the pill takes focus. Make sure it becomes visible and that Enter opens the picker. Pick a widget with Enter and make sure focus returns to the pill, so a second Enter reopens the picker.

### The pill follows the stack

1. With two or three widgets in the column, drag one out onto the middle of the wallpaper.
2. Hover the column. Make sure the pill sits under whatever is now lowest in the column, not where the dragged widget used to be.
3. Drag a widget out of the column and drop it back over the column, below the docked ones (the Focus Timer widget is a good size for this).
4. Hover the column. Make sure the pill sits below that floating widget rather than overlapping it.
5. Drag a widget out and park it on the left half of the desktop, lower down than anything in the column. Make sure the pill ignores it and stays where it was. Only widgets covering at least half the column's width count.
6. Start dragging a widget over the column and, without releasing, watch the pill. Make sure it follows the widget down instead of jumping into place after you drop it.

### Snapping

1. Drag a widget out of the column and drop it in the middle of the desktop.
2. Add a second widget and drag that one out too.
3. Try to line the two up side by side. Make sure the edges align without pixel-hunting.
4. In DevTools, run `JSON.parse( localStorage.getItem( 'desktop-mode-widgets-geometry' ) )`. Make sure every `x` and `y` is a multiple of 20.
5. Drag a widget hard against the left edge of the desktop, then against the right edge. Make sure both stop on the grid, and re-check the `x` values in step 4.
6. Resize a floating widget from each handle in turn. Make sure the dragged edge moves in 20px steps, the edge you are not dragging stays put, and `x`, `y`, `width` and `height` are all multiples of 20 afterwards.
7. Put two floating widgets side by side and resize them to the same width. Make sure their right edges line up exactly.
8. Resize a widget docked in the column from its bottom edge. Make sure it still resizes smoothly, one pixel at a time.

### Right-click menu

1. Right-click empty wallpaper. Make sure the menu lists "Add widget" between "New URL" and "Sort by".
2. Click it. Make sure the pill appears with the picker open above it, exactly as if you had hovered the column and clicked the pill.
3. Right-click a desktop icon instead of bare wallpaper. Make sure that menu is unchanged.

### Touch

1. Open DevTools, turn on device emulation, and reload.
2. Make sure the pill is visible without hovering. There is no hover on touch, and a long-press to reach the context menu is a lot of ceremony for adding a clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-639-830cea88b7ed5a3da4ab19216f04d1cf64a6c675.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->