### PR TITLE
fix: preserve and forward select host aria-label

### DIFF
--- a/src/ui/components/os-select/os-select.ts
+++ b/src/ui/components/os-select/os-select.ts
@@ -318,10 +318,9 @@ export class OsSelect extends Component {
 		// the group name when focus reaches the shell.
 		if ( label ) {
 			this.setAttribute( 'aria-label', label );
-		} else {
-			this.removeAttribute( 'aria-label' );
 		}
-		const triggerAriaLabel = label || placeholder;
+		const hostAriaLabel = this.getAttribute( 'aria-label' ) || '';
+		const triggerAriaLabel = label || hostAriaLabel || placeholder;
 
 		const options = this._readOptions();
 		const currentOption = options.find( ( o ) => o.value === current );


### PR DESCRIPTION
closes #591 

This PR resolves the  issue where `<os-select>` dropdowns in the **File Associations** settings tab were unnamed in the accessibility tree, making them indistinguishable for screen readers.

### Changes:
- **src/ui/components/os-select/os-select.ts**: Modified the component to retrieve the host's existing `aria-label` attribute and forward it to the focusable inner `<button>` and popover. It also removes the logic that deleted `aria-label` from the host when the visible text `label` prop was empty.

### Testing:
- Open Preferences -> File Associations.
- Inspect any dropdown. 
- Verify the inner `<button class="os-select__trigger" ...>` has the correct `aria-label` attribute (e.g. `aria-label="Default app for Plugin shortcut"`).

### Before:
<img width="1468" height="920" alt="Screenshot 2026-08-21 at 10 43 47 AM" src="https://github.com/user-attachments/assets/7934e484-473c-446f-b87d-6de76a95126a" />

### After:
<img width="1470" height="926" alt="Screenshot 2026-08-21 at 11 37 24 AM" src="https://github.com/user-attachments/assets/a3d41256-fcfe-4370-994a-1261dde13665" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-642-71b31fc44ff9d9fa8fb0535bdaaa2508254aab6a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->