### PR TITLE
Tests: End the About CSS slice at the next section, not a named one

### DIFF
--- a/tests/vitest/os-settings-about-theme.test.ts
+++ b/tests/vitest/os-settings-about-theme.test.ts
@@ -14,11 +14,6 @@ import { describe, expect, test } from 'vitest';
 const root = join( __dirname, '../..' );
 const css = readFileSync( join( root, 'assets/css/os-settings.css' ), 'utf8' );
 const aboutStart = css.indexOf( '/*\n * About tab' );
-// The About block runs until the next top-level section comment. Naming
-// the section that follows is what broke this test: it pointed at
-// "Apps & Icons section", which #640 renamed while this file was in
-// flight, so the slice came back empty and the assertions below passed
-// over nothing. Whatever sits after About can be renamed again.
 const nextSection = css.indexOf( '\n/*', aboutStart + 1 );
 const aboutEnd = -1 === nextSection ? css.length : nextSection;
 const aboutCss = css.slice( aboutStart, aboutEnd );

--- a/tests/vitest/os-settings-about-theme.test.ts
+++ b/tests/vitest/os-settings-about-theme.test.ts
@@ -14,7 +14,13 @@ import { describe, expect, test } from 'vitest';
 const root = join( __dirname, '../..' );
 const css = readFileSync( join( root, 'assets/css/os-settings.css' ), 'utf8' );
 const aboutStart = css.indexOf( '/*\n * About tab' );
-const aboutEnd = css.indexOf( '/* Apps & Icons section', aboutStart );
+// The About block runs until the next top-level section comment. Naming
+// the section that follows is what broke this test: it pointed at
+// "Apps & Icons section", which #640 renamed while this file was in
+// flight, so the slice came back empty and the assertions below passed
+// over nothing. Whatever sits after About can be renamed again.
+const nextSection = css.indexOf( '\n/*', aboutStart + 1 );
+const aboutEnd = -1 === nextSection ? css.length : nextSection;
 const aboutCss = css.slice( aboutStart, aboutEnd );
 
 describe( 'OS Settings — About theme contract', () => {


### PR DESCRIPTION
## Proposed changes

Ends the About CSS slice in `os-settings-about-theme.test.ts` at the next top-level section comment instead of a named one.

## Why are these changes being made?

Trunk is red on this test. It slices `assets/css/os-settings.css` between the About tab comment and `/* Apps & Icons section`:

```js
const aboutStart = css.indexOf( '/*\n * About tab' );
const aboutEnd = css.indexOf( '/* Apps & Icons section', aboutStart );
```

That section no longer exists. #640 renamed it to "Navigation section" while #631 was in flight, so `aboutEnd` comes back `-1` and `css.slice( aboutStart, -1 )` yields an empty string. `expect( aboutEnd ).toBeGreaterThan( aboutStart )` fails.

The empty slice also meant the second test in the file, the one checking the About block does not bypass theme tokens with raw brand meshes or hardcoded ink, was asserting against nothing and passing for free. It inspects the real block again now.

Naming the following section couples the test to whatever happens to sit after About, which is exactly how it broke. The next top-level comment is stable under a rename.

## Testing instructions

1. Check out `trunk` and run `npx vitest run tests/vitest/os-settings-about-theme.test.ts`. Make sure it fails with `expected -1 to be greater than <n>`.
2. Check out this branch and run the same command. Make sure both tests pass.
3. In `assets/css/os-settings.css`, rename `/* Navigation section — per-item placement chooser. */` to anything else and run the test again. Make sure it still passes, which is the regression this guards against.
4. To confirm the second test is no longer vacuous: add `color: #fff;` inside the About block in `assets/css/os-settings.css` and run the test. Make sure "does not bypass theme substitutions with a raw brand mesh or ink" now fails. Revert.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-646-0c4201f6f35689969d16fb816e2f756477e458f8.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->