### PR TITLE
Station Home: stop claiming Dashboard subpages

### DIFF
--- a/src/station-home/model.test.ts
+++ b/src/station-home/model.test.ts
@@ -35,6 +35,14 @@ describe( 'Station Home URL remap', () => {
 		).toBe( false );
 	} );
 
+	test( 'does not claim a Dashboard subpage', () => {
+		expect(
+			matchesStationHomeUrl(
+				new URL( 'https://example.test/wp-admin/index.php?page=my-analytics' ),
+			),
+		).toBe( false );
+	} );
+
 	test( 'does not claim another admin screen', () => {
 		expect(
 			matchesStationHomeUrl( new URL( 'https://example.test/wp-admin/edit.php' ) ),

--- a/src/station-home/model.ts
+++ b/src/station-home/model.ts
@@ -11,11 +11,14 @@ import { __, sprintf } from '../i18n';
 export const CLASSIC_DASHBOARD_FLAG = 'desktop_mode_classic';
 
 /**
- * Claim the ordinary WordPress Dashboard, but never its classic escape URL.
+ * Claim the ordinary WordPress Dashboard, but never its classic escape URL
+ * nor a Dashboard subpage — index.php?page=<slug> is a different destination
+ * that happens to share the Dashboard's path.
  */
 export function matchesStationHomeUrl( parsed: URL ): boolean {
 	return (
 		parsed.pathname.endsWith( '/index.php' ) &&
+		! parsed.searchParams.has( 'page' ) &&
 		! parsed.searchParams.has( CLASSIC_DASHBOARD_FLAG )
 	);
 }


### PR DESCRIPTION
Fixes #650.

## Problem

`matchesStationHomeUrl()` matched on pathname alone, so any `index.php?page=<slug>` URL — a Dashboard subpage registered via core's `add_dashboard_page()` — opened Station Home instead of the plugin's page. The subpage was unreachable from inside the shell.

## Fix

Require the absence of a `page` query param before claiming the URL:

- The bare Dashboard keeps its URL contract and still opens Station Home.
- `index.php?desktop_mode_classic=1` remains the untouched classic escape.
- Anything carrying a `page` slug falls through to the iframe path, as it did before the Station Home remap landed.

This matches the discrimination style the remap registry already documents (`parsed.searchParams.get( 'page' ) === 'wc-orders'` in its own docblock example).

## Tests

New case in the existing `Station Home URL remap` block pins `index.php?page=my-analytics` → not claimed. `npm run build`, `lint`, `test:js` (4806 tests) and `typecheck` all green.

Manually verified on a dev site with an mu-plugin registering **Dashboard → Analytics** via `add_dashboard_page()`: the subpage now opens its own window; bare Dashboard still opens Station Home; the classic escape still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-651-5f2a7283ca7c53064ceaef07bd541c4058726971.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->