### PR TITLE
Add MailPoet compatiblity

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -119,6 +119,34 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	width: 100% !important;
 }
 
+/*
+ * MailPoet top-bar overlap fix.
+ *
+ * MailPoet mounts a 64px-tall brand bar on its screens as
+ * `.wrap .mailpoet-top-bar { position: absolute; top: 0 }` —
+ * anchored to `#wpbody` (core's `position: relative`), overlaying
+ * whatever the page's first 64px contain. In classic admin nothing
+ * is visibly covered only by accident of geometry: the in-flow
+ * space above `.wrap` — the `#screen-meta-links` row plus `.wrap`'s
+ * own top margin — happens to add up to more than the bar's height,
+ * so the content starts below it (measured: `.wrap` at y=114 vs
+ * bar bottom at y=96).
+ *
+ * Chromeless collapses exactly that space on purpose — screen-meta
+ * links are hidden (the window title bar owns those buttons) and
+ * `.wrap` margins are trimmed — which slides MailPoet's content up
+ * underneath the overlaid bar. Symptom: the page's heading sits
+ * half-hidden behind the white logo bar inside the window.
+ *
+ * Reserve the bar's height in flow instead. `:has()` scopes the
+ * rule to precisely the pages that render the in-wrap bar —
+ * whatever MailPoet screen shape it is, present or future — and to
+ * nothing else.
+ */
+.os-chromeless .wrap:has( .mailpoet-top-bar ) {
+	padding-top: 64px;
+}
+
 /* ---------------------------------------------------------------
  * Screen Meta (Screen Options / Help panels)
  * The toggle buttons (#screen-meta-links) are hidden because

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -4442,6 +4442,44 @@ add_filter( 'openstation_deferred_styles', function ( $handles ) {
 } );
 ```
 
+### `openstation_guarded_styles` / `openstation_guarded_scripts` — Stable *(filters)*
+
+Filter the asset handles the **asset guard** re-asserts at print time.
+
+Some plugins force-dequeue every style and script that isn't on their
+own allowlist when one of their admin screens renders (MailPoet's
+`ConflictResolver` is the canonical example). Inside a chromeless
+iframe that would strip `os-chromeless` and put the raw admin chrome
+back inside the window; on a shell page it would strip the desktop
+itself. The guard snapshots every enqueued handle served from the
+OpenStation plugin URL and re-adds any that went missing via Core's
+`print_styles_array` / `print_scripts_array` filters — which run inside
+the print pass itself, after every dequeue at every priority has
+already happened.
+
+The snapshot only covers OpenStation's own handles. If your plugin
+enqueues chromeless overrides (via `openstation_chromeless_styles`) or
+iframe-side scripts and an asset-cleanup plugin strips them, add your
+handles here:
+
+```php
+apply_filters( 'openstation_guarded_styles', string[] $handles );
+apply_filters( 'openstation_guarded_scripts', string[] $handles );
+```
+
+```php
+add_filter( 'openstation_guarded_styles', function ( $handles ) {
+    $handles[] = 'my-plugin-chromeless-overrides';
+    return $handles;
+} );
+```
+
+- **Param** `string[] $handles` — default: every handle the current
+  page enqueued from the OpenStation plugin directory.
+- **Return** `string[]` — handles must be registered; unregistered
+  entries are skipped. Dependencies are re-added automatically.
+  Scripts are only re-asserted during the admin footer print pass.
+
 ---
 
 ## Desktop themes

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -300,6 +300,53 @@ Detection is by visible text content on the clicked element rather than by selec
 
 > **Note**: shims 1–3 remain in place. Shim 1 (deps fix) is needed so the Divi block actually *renders* with its "Use Divi Builder" button — that label is what the click handler matches on. Shims 2 (`__Cypress__`) and 3 (preloader bridge) remain as defense-in-depth for users who *don't* take the handoff and let VB load inside the iframe anyway (e.g., older Divi versions that don't show our match-text buttons, or third-party plugins that activate VB through an unintercepted path).
 
+## The asset side: force-dequeue plugins (the asset guard)
+
+**File**: `includes/render/asset-guard.php`.
+
+A class of plugins force-dequeues every admin style and script that
+isn't on their own allowlist when one of their screens renders, to
+protect their (usually React-heavy) UI from foreign CSS. The
+canonical example is **MailPoet's `ConflictResolver`**: on every
+MailPoet page it strips all styles/scripts whose `src` doesn't match
+its allowlist, hooked at `PHP_INT_MAX` on the enqueue hooks and
+`PHP_INT_MIN` on the print hooks. Several "asset cleanup" plugins
+ship the same pattern.
+
+Inside a chromeless iframe that strips `os-chromeless` — the sidebar
+menu and classic layout come back *inside the window* (the admin bar
+stays gone, because its suppression is PHP-side; the visual split is
+the tell for this bug class). On a shell page it would strip the
+desktop's own CSS/JS wholesale.
+
+No enqueue priority can win a war both sides fight with
+`PHP_INT_MAX`, so the guard doesn't fight there. It snapshots every
+queued handle served from the OpenStation plugin URL during
+`admin_enqueue_scripts`, then re-asserts any that went missing via
+Core's `print_styles_array` / `print_scripts_array` filters — which
+run *inside* `WP_Dependencies::do_items()`, after every dequeue at
+every priority has already had its say. Re-asserted styles land at
+the end of the print list, i.e. after the stripper's own sheets in
+the cascade — exactly where chromeless overrides want to be.
+
+The guard never re-asserts assets that aren't ours: the stripper is
+usually stripping for a reason, and undoing it wholesale would
+recreate the conflicts it resolves. Our sheets are scoped to the
+`os-chromeless` / `os-active` body classes, so re-asserting them
+can't bleed into the host page's UI. Third-party chromeless
+overrides can opt in via the `openstation_guarded_styles` /
+`openstation_guarded_scripts` filters (see
+[hooks-reference](./hooks-reference.md#openstation_guarded_styles--openstation_guarded_scripts--stable-filters)).
+
+**Plugins this addresses**: MailPoet (all admin screens), and any
+allowlist-based asset-cleanup plugin active on an admin page a
+OpenStation user opens.
+
+**Test**: `tests/phpunit/tests/assetGuard.php` — snapshot scoping and
+idempotence, dependency-ordered re-assertion, done/present/unregistered
+skips, the filter escape hatch, and the footer-pass-only rule for
+scripts.
+
 ## The site-window side: WooCommerce
 
 `includes/my-wordpress/integrations/woocommerce.php` plus the

--- a/includes/render.php
+++ b/includes/render.php
@@ -11,6 +11,8 @@
  *
  *   - body-classes.php           — admin_body_class filter
  *   - assets.php                 — openstation_enqueue_assets()
+ *   - asset-guard.php            — re-asserts our assets against
+ *                                  force-dequeue plugins
  *   - shell.php                  — openstation_render_shell()
  *   - chromeless-bridge.php      — chromeless iframe bridge +
  *                                  the offset-neutralizer script
@@ -27,6 +29,7 @@ defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/render/body-classes.php';
 require_once __DIR__ . '/render/assets.php';
+require_once __DIR__ . '/render/asset-guard.php';
 require_once __DIR__ . '/render/shell.php';
 require_once __DIR__ . '/render/chromeless-bridge.php';
 require_once __DIR__ . '/render/chromeless-title-actions.php';

--- a/includes/render/asset-guard.php
+++ b/includes/render/asset-guard.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * OpenStation — Asset guard.
+ *
+ * Guarantees that every OpenStation style and script that was
+ * enqueued for the current admin page actually prints, even when a
+ * third-party plugin force-dequeues foreign assets on its own
+ * screens.
+ *
+ * The canonical offender is MailPoet's `ConflictResolver`: on every
+ * MailPoet page it dequeues each style and script whose `src` does
+ * not match an internal allowlist, hooked at `PHP_INT_MAX` on the
+ * enqueue hooks and `PHP_INT_MIN` on the print hooks. Inside a
+ * chromeless iframe that strips `os-chromeless` (so the raw admin
+ * chrome — the sidebar menu, the classic layout — reappears inside
+ * the window), and on a full shell page it would strip the desktop
+ * itself. Several "admin cleanup" plugins ship the same pattern, so
+ * this is a class of conflict, not a single bug — and no enqueue
+ * priority can win a war both sides fight with `PHP_INT_MAX`.
+ *
+ * The guard therefore doesn't fight at enqueue time at all. It works
+ * in two moves:
+ *
+ *   1. Snapshot. On `admin_enqueue_scripts` it records every queued
+ *      handle whose registered `src` lives under `OPENSTATION_URL` —
+ *      "these are ours, and this page meant to load them". The
+ *      snapshot runs twice: right after our own enqueue callback
+ *      (priority 11), and again at `PHP_INT_MAX` so late legitimate
+ *      enqueues are seen too. Within the `PHP_INT_MAX` bucket our
+ *      callback is registered at plugin load, long before any
+ *      stripper registers its own, so it observes the queue first.
+ *
+ *   2. Re-assert. The `print_styles_array` / `print_scripts_array`
+ *      filters run inside `WP_Dependencies::do_items()` — after
+ *      every dequeue at every priority has already had its say.
+ *      Any snapshotted handle missing from the to-print list (and
+ *      not already printed) is appended there, dependencies first.
+ *
+ * Appending re-asserted styles at the end of the list also puts them
+ * after the stripper plugin's own stylesheets in the cascade, which
+ * is exactly where the chromeless overrides want to be.
+ *
+ * The guard never touches assets that aren't ours: a stripper is
+ * usually stripping for a reason (its screens break under foreign
+ * CSS), and re-asserting the whole queue would recreate the very
+ * conflicts it resolves. OpenStation's chromeless and shell sheets
+ * are scoped to the `os-chromeless` / `os-active` body classes, so
+ * re-asserting them cannot bleed into the host page's own UI.
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Accessor for the guard's snapshot of expected handles.
+ *
+ * @param array|null $set When given, replaces the stored snapshot.
+ * @return array {
+ *     Handles the current page enqueued from this plugin.
+ *
+ *     @type string[] $styles  Style handles.
+ *     @type string[] $scripts Script handles.
+ * }
+ */
+function openstation_asset_guard_store( $set = null ) {
+	static $expected = array(
+		'styles'  => array(),
+		'scripts' => array(),
+	);
+	if ( null !== $set ) {
+		$expected = $set;
+	}
+	return $expected;
+}
+
+/**
+ * Records every queued OpenStation handle as expected to print.
+ *
+ * A handle is ours when its registered `src` sits under
+ * `OPENSTATION_URL`. Third-party chromeless overrides (enqueued on
+ * `openstation_chromeless_styles`) deliberately don't match — a
+ * plugin that wants its own handles guarded adds them via the
+ * `openstation_guarded_styles` / `openstation_guarded_scripts`
+ * filters instead.
+ */
+function openstation_asset_guard_snapshot() {
+	$store = openstation_asset_guard_store();
+	$pools = array(
+		'styles'  => wp_styles(),
+		'scripts' => wp_scripts(),
+	);
+	foreach ( $pools as $type => $dependencies ) {
+		foreach ( $dependencies->queue as $handle ) {
+			if ( in_array( $handle, $store[ $type ], true ) ) {
+				continue;
+			}
+			if ( ! isset( $dependencies->registered[ $handle ] ) ) {
+				continue;
+			}
+			$src = $dependencies->registered[ $handle ]->src;
+			if ( is_string( $src ) && 0 === strpos( $src, OPENSTATION_URL ) ) {
+				$store[ $type ][] = $handle;
+			}
+		}
+	}
+	openstation_asset_guard_store( $store );
+}
+add_action( 'admin_enqueue_scripts', 'openstation_asset_guard_snapshot', 11 );
+add_action( 'admin_enqueue_scripts', 'openstation_asset_guard_snapshot', PHP_INT_MAX );
+
+/**
+ * Collects `$handle` (dependencies first) into `$missing` unless it
+ * is already queued to print, already printed, or unregistered.
+ *
+ * @param WP_Dependencies $dependencies The styles or scripts registry.
+ * @param string          $handle       Handle to collect.
+ * @param string[]        $to_do        Handles already queued to print.
+ * @param string[]        $missing      Collected handles, in print order. Passed by reference.
+ */
+function openstation_asset_guard_collect( $dependencies, $handle, $to_do, &$missing ) {
+	if (
+		in_array( $handle, $to_do, true )
+		|| in_array( $handle, $missing, true )
+		|| in_array( $handle, $dependencies->done, true )
+		|| ! isset( $dependencies->registered[ $handle ] )
+	) {
+		return;
+	}
+	foreach ( $dependencies->registered[ $handle ]->deps as $dep ) {
+		openstation_asset_guard_collect( $dependencies, $dep, $to_do, $missing );
+	}
+	$missing[] = $handle;
+}
+
+/**
+ * Appends any expected-but-missing handles to a to-print list.
+ *
+ * @param WP_Dependencies $dependencies The styles or scripts registry.
+ * @param string[]        $to_do        Handles about to be printed.
+ * @param string[]        $handles      Handles that must be among them.
+ * @return string[] The to-print list with missing handles appended.
+ */
+function openstation_asset_guard_merge( $dependencies, $to_do, $handles ) {
+	$missing = array();
+	foreach ( $handles as $handle ) {
+		if ( is_string( $handle ) && '' !== $handle ) {
+			openstation_asset_guard_collect( $dependencies, $handle, $to_do, $missing );
+		}
+	}
+	if ( empty( $missing ) ) {
+		return $to_do;
+	}
+	return array_merge( $to_do, $missing );
+}
+
+/**
+ * Re-asserts snapshotted OpenStation styles into the to-print list.
+ *
+ * Runs inside `WP_Styles::all_deps()`, after any force-dequeue has
+ * already happened — the last word before output.
+ *
+ * @param string[] $to_do Style handles about to be printed.
+ * @return string[]
+ */
+function openstation_asset_guard_print_styles( $to_do ) {
+	$store = openstation_asset_guard_store();
+
+	/**
+	 * Filters the style handles the asset guard re-asserts at print
+	 * time.
+	 *
+	 * Defaults to every style this plugin enqueued for the current
+	 * page. A plugin whose chromeless overrides are stripped by an
+	 * asset-cleanup plugin can append its own handles here.
+	 *
+	 * @param string[] $handles Style handles expected to print.
+	 */
+	$handles = apply_filters( 'openstation_guarded_styles', $store['styles'] );
+
+	if ( empty( $handles ) || ! is_array( $handles ) ) {
+		return $to_do;
+	}
+	return openstation_asset_guard_merge( wp_styles(), $to_do, $handles );
+}
+add_filter( 'print_styles_array', 'openstation_asset_guard_print_styles' );
+
+/**
+ * Re-asserts snapshotted OpenStation scripts into the to-print list.
+ *
+ * Only acts during the admin footer pass: every OpenStation bundle
+ * is registered `in_footer`, and handles appended during the head
+ * pass would print there without their group bookkeeping. Re-added
+ * handles are stamped into the footer group so
+ * `WP_Scripts::do_item()` finds the entry it expects.
+ *
+ * @param string[] $to_do Script handles about to be printed.
+ * @return string[]
+ */
+function openstation_asset_guard_print_scripts( $to_do ) {
+	if ( ! doing_action( 'admin_print_footer_scripts' ) ) {
+		return $to_do;
+	}
+	$store = openstation_asset_guard_store();
+
+	/**
+	 * Filters the script handles the asset guard re-asserts at print
+	 * time.
+	 *
+	 * Defaults to every script this plugin enqueued for the current
+	 * page. A plugin whose iframe-side scripts are stripped by an
+	 * asset-cleanup plugin can append its own handles here.
+	 *
+	 * @param string[] $handles Script handles expected to print.
+	 */
+	$handles = apply_filters( 'openstation_guarded_scripts', $store['scripts'] );
+
+	if ( empty( $handles ) || ! is_array( $handles ) ) {
+		return $to_do;
+	}
+	$scripts = wp_scripts();
+	$merged  = openstation_asset_guard_merge( $scripts, $to_do, $handles );
+	foreach ( array_diff( $merged, $to_do ) as $handle ) {
+		$scripts->groups[ $handle ] = 1;
+	}
+	return $merged;
+}
+add_filter( 'print_scripts_array', 'openstation_asset_guard_print_scripts' );

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === OpenStation: Desktop Windows, Dock & Virtual Desktops for WP Admin ===
-Contributors: automattic, allterraindeveloper, epeicher, mmtr86, nickhamze
+Contributors: automattic, allterraindeveloper, epeicher, mmtr86, nickhamze, nuriapenya
 Tags: admin, dashboard, desktop, productivity, ai
 Requires at least: 6.0
 Tested up to: 7.1

--- a/src/boot/geometry.ts
+++ b/src/boot/geometry.ts
@@ -30,7 +30,33 @@ export function findDockEntryForUrl(
 	url: string,
 	config: DesktopConfig,
 ): DesktopConfig[ 'dockItems' ][ number ] | undefined {
-	const windowId = deriveWindowId( url, config.adminUrl );
+	return findDockEntryForWindowId(
+		deriveWindowId( url, config.adminUrl ),
+		config,
+	);
+}
+
+/**
+ * Find the dock entry — top-level item or a submenu child — whose
+ * url derives `windowId`. Returns the *parent* top-level entry in
+ * either case, like {@link findDockEntryForUrl}.
+ *
+ * This is the session-restore fallback for windows whose CURRENT
+ * URL matches no menu entry: a page that redirected to an
+ * onboarding screen the menu doesn't list (MailPoet parks every
+ * page on `?page=mailpoet-landingpage` until its wizard is done).
+ * The saved window still carries its open-time identity in
+ * `baseId`, and matching THAT against the dock recovers the owning
+ * entry — so the window's submenu tab strip survives the reload
+ * instead of silently vanishing.
+ */
+export function findDockEntryForWindowId(
+	windowId: string,
+	config: DesktopConfig,
+): DesktopConfig[ 'dockItems' ][ number ] | undefined {
+	if ( ! windowId ) {
+		return undefined;
+	}
 	return ( config.dockItems || [] ).find(
 		( i ) =>
 			deriveWindowId( i.url, config.adminUrl ) === windowId ||

--- a/src/boot/session.ts
+++ b/src/boot/session.ts
@@ -14,7 +14,11 @@
 
 import { tryNativeUrlRemap } from '../native-url-remap';
 import { deriveWindowId } from '../utils';
-import { clampGeometryToViewport, findDockEntryForUrl } from './geometry';
+import {
+	clampGeometryToViewport,
+	findDockEntryForUrl,
+	findDockEntryForWindowId,
+} from './geometry';
 import type { WindowManager } from '../window-manager';
 import type { Window } from '../window';
 import type { DesktopConfig, Session, WindowConfig } from '../types';
@@ -199,7 +203,17 @@ export async function restoreSession(
 		}
 
 		const clamped = clampGeometryToViewport( win, rect );
-		const dockEntry = findDockEntryForUrl( win.url, config );
+		// Resolve the owning dock entry from the CURRENT URL first —
+		// a window navigated onto another menu's page belongs to that
+		// menu now. When the URL matches nothing (an off-menu
+		// onboarding redirect like MailPoet's landing page), fall
+		// back to the window's open-time identity: `baseId` was
+		// derived from the URL the window was opened with, so it
+		// still names the dock entry — and its submenu tab strip —
+		// the window came from.
+		const dockEntry =
+			findDockEntryForUrl( win.url, config ) ??
+			findDockEntryForWindowId( win.baseId || win.id, config );
 
 		// `openNew`, not `open`. Restore means "recreate exactly this
 		// set of windows", and `open()` is the wrong verb for that: it

--- a/src/window/tabs.test.ts
+++ b/src/window/tabs.test.ts
@@ -154,15 +154,71 @@ describe( 'syncActiveTab', () => {
 		expect( activeLabels( win ) ).toEqual( [ 'Mail' ] );
 	} );
 
-	test( 'a URL on no tab’s page leaves the strip blank', () => {
+	test( 'a URL on no tab’s page keeps the current highlight', () => {
 		const win = mockTabbedWindow( [
 			[ 'Appearance', ADMIN + 'themes.php' ],
 			[ 'Menus', ADMIN + 'nav-menus.php' ],
 		] );
 
+		// A fresh strip stays blank — there is nothing to keep.
 		syncActiveTab( win, ADMIN + 'upload.php' );
+		expect( activeLabels( win ) ).toEqual( [] );
+
+		// A lit strip stays lit through an off-menu landing page.
+		syncActiveTab( win, ADMIN + 'themes.php' );
+		syncActiveTab( win, ADMIN + 'upload.php' );
+		expect( activeLabels( win ) ).toEqual( [ 'Appearance' ] );
+	} );
+
+	test( 'a restored window on an off-menu plugin page lights its entry tab', () => {
+		// After an F5 the window comes back parked on the redirect's
+		// landing URL, with no optimistic click highlight to keep. An
+		// `admin.php?page=…` URL off the menu is the owning plugin's
+		// own onboarding surface, so the entry (first) tab lights.
+		const win = mockTabbedWindow( [
+			[ 'Home', ADMIN + 'admin.php?page=mailpoet-homepage' ],
+			[ 'Emails', ADMIN + 'admin.php?page=mailpoet-newsletters' ],
+		] );
+
+		syncActiveTab(
+			win,
+			ADMIN + 'admin.php?page=mailpoet-landingpage&openstation_chromeless=1',
+		);
+
+		expect( activeLabels( win ) ).toEqual( [ 'Home' ] );
+	} );
+
+	test( 'an off-menu non-plugin page lights nothing', () => {
+		// `post.php`, `revision.php`, … are genuinely outside every
+		// tab — a blank strip is the honest answer there.
+		const win = mockTabbedWindow( [
+			[ 'Home', ADMIN + 'admin.php?page=mailpoet-homepage' ],
+		] );
+
+		syncActiveTab( win, ADMIN + 'post.php?post=5&action=edit' );
 
 		expect( activeLabels( win ) ).toEqual( [] );
+	} );
+
+	test( 'an onboarding redirect keeps the clicked tab lit', () => {
+		// The MailPoet shape: until its welcome wizard is done, every
+		// MailPoet page redirects to `?page=mailpoet-landingpage`,
+		// which no submenu entry lists. The tab the user clicked has
+		// to survive the round trip.
+		const win = mockTabbedWindow( [
+			[ 'Home', ADMIN + 'admin.php?page=mailpoet-homepage' ],
+			[ 'Emails', ADMIN + 'admin.php?page=mailpoet-newsletters' ],
+		] );
+
+		// Click "Emails" — lit optimistically before the load.
+		syncActiveTab( win, ADMIN + 'admin.php?page=mailpoet-newsletters' );
+		// The load event reports the redirect's landing URL.
+		syncActiveTab(
+			win,
+			ADMIN + 'admin.php?page=mailpoet-landingpage&openstation_chromeless=1',
+		);
+
+		expect( activeLabels( win ) ).toEqual( [ 'Emails' ] );
 	} );
 
 	test( 'a foregrounded external tab clears every submenu tab', () => {

--- a/src/window/tabs.ts
+++ b/src/window/tabs.ts
@@ -126,6 +126,17 @@ function findPageOwnerTab(
  * so drilling into a screen's own sub-views (`nav-menus.php?action=
  * locations`, `edit.php?paged=2`) doesn't blank the strip.
  *
+ * When NEITHER matches, the strip keeps whatever was lit rather than
+ * clearing it. A URL matching no tab usually means the page
+ * redirected somewhere the menu doesn't list — an onboarding or
+ * welcome screen (MailPoet sends every one of its pages to
+ * `?page=mailpoet-landingpage` until its wizard is done; WooCommerce
+ * and Yoast have equivalents). The user is still "inside" the tab
+ * they clicked, and a blanked strip reads as broken. The cost is a
+ * stale highlight when an in-page link genuinely walks the window to
+ * some other menu's page — rarer, and the window title tracks the
+ * destination either way.
+ *
  * Only submenu tabs participate in URL-based matching. External
  * sub-tabs and the injected "main" tab manage their own active state
  * through `switchToTab` since their notion of "active" isn't a URL
@@ -159,6 +170,37 @@ export function syncActiveTab( win: Window, currentUrl: string ): void {
 	}
 	if ( ! active ) {
 		active = findPageOwnerTab( submenuTabs, currentUrl );
+	}
+	if ( ! active ) {
+		// Off-menu URL. Keep whatever is lit — the user is still
+		// "inside" the tab they came from.
+		const lit = Array.from( submenuTabs ).some( ( t ) =>
+			t.classList.contains( 'os-window__tab--active' ),
+		);
+		if ( lit ) {
+			return;
+		}
+		// Nothing lit either — a window RESTORED onto an off-menu
+		// page, where the optimistic click highlight never happened
+		// (MailPoet's landing page after an F5). For a plugin page
+		// (`admin.php?page=…`) the off-menu URL is that plugin's own
+		// onboarding surface, so its entry tab — the first — is the
+		// honest "where you are". Non-plugin files (`post.php`,
+		// `revision.php`, …) are genuinely outside every tab and
+		// stay unlit.
+		let isPluginPage = false;
+		try {
+			const parsed = new URL( currentUrl, window.location.origin );
+			isPluginPage =
+				parsed.pathname.endsWith( '/admin.php' ) &&
+				parsed.searchParams.has( 'page' );
+		} catch {
+			return;
+		}
+		if ( ! isPluginPage || ! submenuTabs[ 0 ] ) {
+			return;
+		}
+		active = submenuTabs[ 0 ];
 	}
 	for ( const tab of submenuTabs ) {
 		const isActive = tab === active;

--- a/tests/phpunit/tests/assetGuard.php
+++ b/tests/phpunit/tests/assetGuard.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Tests for the asset guard — the print-time re-assertion that keeps
+ * OpenStation styles and scripts alive on pages where a third-party
+ * plugin force-dequeues foreign assets (MailPoet's ConflictResolver
+ * being the canonical example).
+ *
+ * @package OpenStation
+ *
+ * @group openstation
+ */
+class Tests_OpenStation_AssetGuard extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		// Fresh snapshot per test — the store is a per-request static.
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array(),
+				'scripts' => array(),
+			)
+		);
+	}
+
+	public function tear_down() {
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array(),
+				'scripts' => array(),
+			)
+		);
+		foreach ( array( 'os-test-own', 'os-test-own-dep', 'os-test-foreign' ) as $handle ) {
+			wp_dequeue_style( $handle );
+			wp_deregister_style( $handle );
+			wp_dequeue_script( $handle );
+			wp_deregister_script( $handle );
+		}
+		remove_all_filters( 'openstation_guarded_styles' );
+		remove_all_filters( 'openstation_guarded_scripts' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The snapshot must collect exactly the queued handles served
+	 * from the plugin's own URL — foreign handles are somebody
+	 * else's business.
+	 *
+	 * @covers ::openstation_asset_guard_snapshot
+	 */
+	public function test_snapshot_records_only_openstation_handles() {
+		wp_register_style( 'os-test-own', OPENSTATION_URL . 'assets/css/test.css', array(), '1.0' );
+		wp_register_style( 'os-test-foreign', 'https://example.org/foreign.css', array(), '1.0' );
+		wp_enqueue_style( 'os-test-own' );
+		wp_enqueue_style( 'os-test-foreign' );
+		wp_register_script( 'os-test-own', OPENSTATION_URL . 'assets/js/test.js', array(), '1.0', true );
+		wp_enqueue_script( 'os-test-own' );
+
+		openstation_asset_guard_snapshot();
+
+		$store = openstation_asset_guard_store();
+		$this->assertContains( 'os-test-own', $store['styles'] );
+		$this->assertNotContains( 'os-test-foreign', $store['styles'] );
+		$this->assertContains( 'os-test-own', $store['scripts'] );
+	}
+
+	/**
+	 * Running the snapshot twice (priority 11 + PHP_INT_MAX both
+	 * fire it) must not duplicate handles.
+	 *
+	 * @covers ::openstation_asset_guard_snapshot
+	 */
+	public function test_snapshot_is_idempotent() {
+		wp_register_style( 'os-test-own', OPENSTATION_URL . 'assets/css/test.css', array(), '1.0' );
+		wp_enqueue_style( 'os-test-own' );
+
+		openstation_asset_guard_snapshot();
+		openstation_asset_guard_snapshot();
+
+		$store = openstation_asset_guard_store();
+		$this->assertSame(
+			array( 'os-test-own' ),
+			array_values( array_intersect( $store['styles'], array( 'os-test-own' ) ) )
+		);
+		$this->assertCount( 1, array_keys( $store['styles'], 'os-test-own', true ) );
+	}
+
+	/**
+	 * The MailPoet scenario: a snapshotted style was force-dequeued
+	 * before printing. The print filter has to put it back —
+	 * dependencies first, appended after the surviving handles so
+	 * the re-asserted sheet wins the cascade.
+	 *
+	 * @covers ::openstation_asset_guard_print_styles
+	 */
+	public function test_print_styles_reasserts_dequeued_handle_with_deps() {
+		wp_register_style( 'os-test-own-dep', OPENSTATION_URL . 'assets/css/dep.css', array(), '1.0' );
+		wp_register_style( 'os-test-own', OPENSTATION_URL . 'assets/css/test.css', array( 'os-test-own-dep' ), '1.0' );
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array( 'os-test-own' ),
+				'scripts' => array(),
+			)
+		);
+
+		$to_do = openstation_asset_guard_print_styles( array( 'mailpoet-admin' ) );
+
+		$this->assertSame(
+			array( 'mailpoet-admin', 'os-test-own-dep', 'os-test-own' ),
+			$to_do
+		);
+	}
+
+	/**
+	 * A handle already queued to print, or already printed, must not
+	 * be re-added.
+	 *
+	 * @covers ::openstation_asset_guard_print_styles
+	 */
+	public function test_print_styles_skips_present_and_done_handles() {
+		wp_register_style( 'os-test-own', OPENSTATION_URL . 'assets/css/test.css', array(), '1.0' );
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array( 'os-test-own' ),
+				'scripts' => array(),
+			)
+		);
+
+		// Already in the to-print list: unchanged.
+		$this->assertSame(
+			array( 'os-test-own' ),
+			openstation_asset_guard_print_styles( array( 'os-test-own' ) )
+		);
+
+		// Already printed (late-styles pass): not re-added.
+		wp_styles()->done[] = 'os-test-own';
+		$this->assertSame(
+			array(),
+			openstation_asset_guard_print_styles( array() )
+		);
+		wp_styles()->done = array_values( array_diff( wp_styles()->done, array( 'os-test-own' ) ) );
+	}
+
+	/**
+	 * An unregistered handle can't be printed — the guard must skip
+	 * it rather than feed `do_items()` a ghost.
+	 *
+	 * @covers ::openstation_asset_guard_print_styles
+	 */
+	public function test_print_styles_skips_unregistered_handles() {
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array( 'os-test-never-registered' ),
+				'scripts' => array(),
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			openstation_asset_guard_print_styles( array() )
+		);
+	}
+
+	/**
+	 * Third-party chromeless overrides don't live under
+	 * OPENSTATION_URL, so the snapshot skips them by design — the
+	 * filter is their way into the guard.
+	 *
+	 * @covers ::openstation_asset_guard_print_styles
+	 */
+	public function test_guarded_styles_filter_extends_the_snapshot() {
+		wp_register_style( 'os-test-foreign', 'https://example.org/foreign.css', array(), '1.0' );
+		add_filter(
+			'openstation_guarded_styles',
+			static function ( $handles ) {
+				$handles[] = 'os-test-foreign';
+				return $handles;
+			}
+		);
+
+		$this->assertSame(
+			array( 'os-test-foreign' ),
+			openstation_asset_guard_print_styles( array() )
+		);
+	}
+
+	/**
+	 * Scripts are only re-asserted during the admin footer pass —
+	 * outside it the filter must be a strict pass-through.
+	 *
+	 * @covers ::openstation_asset_guard_print_scripts
+	 */
+	public function test_print_scripts_is_inert_outside_the_footer_pass() {
+		wp_register_script( 'os-test-own', OPENSTATION_URL . 'assets/js/test.js', array(), '1.0', true );
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array(),
+				'scripts' => array( 'os-test-own' ),
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			openstation_asset_guard_print_scripts( array() )
+		);
+	}
+
+	/**
+	 * Inside the footer pass a dequeued script comes back, stamped
+	 * into the footer group so `WP_Scripts::do_item()` finds the
+	 * bookkeeping it expects.
+	 *
+	 * @covers ::openstation_asset_guard_print_scripts
+	 */
+	public function test_print_scripts_reasserts_in_footer_pass() {
+		wp_register_script( 'os-test-own', OPENSTATION_URL . 'assets/js/test.js', array(), '1.0', true );
+		openstation_asset_guard_store(
+			array(
+				'styles'  => array(),
+				'scripts' => array( 'os-test-own' ),
+			)
+		);
+
+		$result = null;
+		// Core's `_wp_footer_scripts` printer would run the real
+		// print pass — re-adding the handle itself (correct, but it
+		// marks the handle done before the probe). Detach it and run
+		// the probe first; other core printers on this hook (the
+		// script-modules import map) still emit markup, so the whole
+		// firing is buffered away. The hooks backup restores the
+		// printer after the test.
+		remove_action( 'admin_print_footer_scripts', '_wp_footer_scripts' );
+		add_action(
+			'admin_print_footer_scripts',
+			static function () use ( &$result ) {
+				$result = openstation_asset_guard_print_scripts( array() );
+			},
+			1
+		);
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		ob_end_clean();
+
+		$this->assertSame( array( 'os-test-own' ), $result );
+		$this->assertSame( 1, wp_scripts()->groups['os-test-own'] );
+	}
+}

--- a/tests/vitest/session-restore-dock-identity.test.ts
+++ b/tests/vitest/session-restore-dock-identity.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Session restore must recover a window's dock identity — and with it
+ * the submenu tab strip — even when the saved URL matches no menu
+ * entry.
+ *
+ * The MailPoet shape: until its welcome wizard is done, every
+ * MailPoet page redirects to `?page=mailpoet-landingpage`, a slug no
+ * dock item or submenu lists. The session saves the window's CURRENT
+ * URL (the landing page), so resolving the owning dock entry from the
+ * URL alone comes up empty and the window used to restore with no tab
+ * strip at all. The saved `baseId` still carries the open-time
+ * identity, and the restore path now falls back to it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { restoreSession } from '../../src/boot/session';
+import {
+	findDockEntryForUrl,
+	findDockEntryForWindowId,
+} from '../../src/boot/geometry';
+import { WindowManager } from '../../src/window-manager';
+import { deriveWindowId } from '../../src/utils';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import type {
+	DesktopConfig,
+	DockItemConfig,
+	Session,
+	SessionWindow,
+} from '../../src/types';
+
+const ORIGIN = window.location.origin;
+const ADMIN_URL = `${ ORIGIN }/wp-admin/`;
+const MP_HOME = `${ ADMIN_URL }admin.php?page=mailpoet-homepage`;
+const MP_EMAILS = `${ ADMIN_URL }admin.php?page=mailpoet-newsletters`;
+const MP_LANDING = `${ ADMIN_URL }admin.php?page=mailpoet-landingpage&openstation_chromeless=1`;
+const PAGES_URL = `${ ADMIN_URL }edit.php?post_type=page`;
+
+const MAILPOET_DOCK: DockItemConfig = {
+	id: 'mailpoet-homepage',
+	title: 'MailPoet',
+	icon: 'dashicons-email',
+	url: MP_HOME,
+	badge: 0,
+	submenu: [
+		{ title: 'Home', url: MP_HOME },
+		{ title: 'Emails', url: MP_EMAILS },
+	],
+};
+
+const PAGES_DOCK: DockItemConfig = {
+	id: 'edit-php-post-type-page',
+	title: 'Pages',
+	icon: 'dashicons-admin-page',
+	url: PAGES_URL,
+	badge: 0,
+	submenu: [ { title: 'All Pages', url: PAGES_URL } ],
+};
+
+function desktopConfig( windows: SessionWindow[] ): DesktopConfig {
+	const session: Session = {
+		windows,
+		desktops: [ { id: 'desktop-1', label: 'Desktop 1' } ],
+		activeDesktop: 'desktop-1',
+		focused: '',
+		updated: 123,
+	};
+	return {
+		adminUrl: ADMIN_URL,
+		currentPage: MP_HOME,
+		currentTitle: 'MailPoet',
+		currentIcon: 'dashicons-email',
+		dockItems: [ MAILPOET_DOCK, PAGES_DOCK ],
+		session,
+	} as unknown as DesktopConfig;
+}
+
+function mailpoetWindow( patch: Partial< SessionWindow > = {} ): SessionWindow {
+	const baseId = deriveWindowId( MP_HOME, ADMIN_URL );
+	return {
+		id: baseId,
+		baseId,
+		desktopId: 'desktop-1',
+		url: MP_LANDING,
+		title: 'MailPoet',
+		icon: 'dashicons-email',
+		state: 'normal',
+		x: 100,
+		y: 80,
+		width: 900,
+		height: 600,
+		...patch,
+	};
+}
+
+describe( 'findDockEntryForWindowId', () => {
+	test( 'matches a dock item by its derived window id', () => {
+		const config = desktopConfig( [] );
+		const id = deriveWindowId( MP_HOME, ADMIN_URL );
+		expect( findDockEntryForWindowId( id, config ) ).toBe( MAILPOET_DOCK );
+	} );
+
+	test( 'matches through a submenu child id', () => {
+		const config = desktopConfig( [] );
+		const id = deriveWindowId( MP_EMAILS, ADMIN_URL );
+		expect( findDockEntryForWindowId( id, config ) ).toBe( MAILPOET_DOCK );
+	} );
+
+	test( 'returns undefined for an off-menu id and an empty id', () => {
+		const config = desktopConfig( [] );
+		const id = deriveWindowId( MP_LANDING, ADMIN_URL );
+		expect( findDockEntryForWindowId( id, config ) ).toBeUndefined();
+		expect( findDockEntryForWindowId( '', config ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'restoreSession — dock identity fallback', () => {
+	let desktop: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktop = document.createElement( 'div' );
+		desktop.id = 'os-area';
+		Object.defineProperty( desktop, 'getBoundingClientRect', {
+			value: () =>
+				( {
+					left: 0,
+					top: 0,
+					right: 1600,
+					bottom: 900,
+					width: 1600,
+					height: 900,
+					x: 0,
+					y: 0,
+					toJSON: () => ( {} ),
+				} ) as DOMRect,
+		} );
+		document.body.appendChild( desktop );
+		manager = new WindowManager( desktop );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		clearHooksStub();
+	} );
+
+	test( 'a window parked on an off-menu URL keeps its submenu', async () => {
+		const win = mailpoetWindow();
+		// Sanity: the URL alone resolves nothing — this scenario is
+		// exactly the one the baseId fallback exists for.
+		const config = desktopConfig( [ win ] );
+		expect( findDockEntryForUrl( win.url, config ) ).toBeUndefined();
+
+		await restoreSession( manager, config, desktop );
+
+		const restored = manager.getById( win.id );
+		expect( restored ).toBeTruthy();
+		expect( restored?.config.submenu ).toEqual( MAILPOET_DOCK.submenu );
+		expect(
+			restored?.element.querySelectorAll(
+				'.os-window__tab[data-kind="submenu"]',
+			).length,
+		).toBeGreaterThan( 0 );
+	} );
+
+	test( 'a URL that matches another dock entry wins over baseId', async () => {
+		// The window was opened as MailPoet but navigated onto the
+		// Pages screen before the reload — it belongs to Pages now.
+		const win = mailpoetWindow( { url: PAGES_URL } );
+		const config = desktopConfig( [ win ] );
+
+		await restoreSession( manager, config, desktop );
+
+		const restored = manager.getById( win.id );
+		expect( restored?.config.submenu ).toEqual( PAGES_DOCK.submenu );
+	} );
+} );


### PR DESCRIPTION
MailPoet was opening windows with the left admin menu bar, and was taking 32px so the screen was partly visible due to windows not showing the master bar.

This is also adding a bit more of compatibility layer with other third party plugins.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-652-3b4a4ade1afac155795d36e7d5b20a2c3c045b18.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->