### PR TITLE
Components: the missing-import demo shows the code it talks about

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -1022,6 +1022,90 @@
 }
 
 /*
+ * Missing-import warner demo — the sentence and the snippet it talks
+ * about, in the section box.
+ *
+ * The snippet is shown because the section's whole subject is three
+ * tags and it used to show none of them: the live copies have to be
+ * real elements for the warner to fire, and a real element is exactly
+ * what cannot be read, so the box sat empty under a sentence pointing
+ * at nothing.
+ *
+ * One column by default; two equal halves once the window is wide
+ * enough for the prose to still have a paragraph's worth of room
+ * beside the code.
+ *
+ * Both tracks are `1fr` — the split is the box in half, and neither
+ * side carries a fixed width. A hard cap on the prose would leave a
+ * gutter of nothing between two columns that both had more to say.
+ * `minmax( 0, … )` on each so a long line of code shrinks the track to
+ * its share and scrolls inside the `<pre>` rather than pushing the
+ * grid wider than the section box.
+ *
+ * The container is the OS Settings WINDOW (`container-type` further
+ * down this file), not the viewport: this panel is a window inside the
+ * shell, so window width is the only width that moves here.
+ */
+.os-settings__help-warner {
+	display: grid;
+	gap: 16px;
+	align-items: start;
+}
+
+@container (min-width: 1350px) {
+	.os-settings__help-warner {
+		grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr );
+	}
+}
+
+.os-settings__help-warner-text {
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.55;
+	color: var( --os-ui-fg-muted, #646970 );
+}
+
+/*
+ * `overflow-x: auto` rather than wrapping: the first tag is 56
+ * characters of deliberately absurd component name, and breaking a tag
+ * across lines turns the one thing the reader is here to recognise
+ * into two things. The section box clips (`::part( body )` sets
+ * `overflow: hidden`), so the scroll has to live on the `<pre>`.
+ */
+.os-settings__help-warner-code {
+	margin: 0;
+	padding: 12px 14px;
+	overflow-x: auto;
+	background: var( --os-ui-surface, #fff );
+	border: 1px solid var( --os-ui-border, #dcdcde );
+	border-radius: 6px;
+	font-family: var( --os-ui-font-mono, Menlo, Consolas, monospace );
+	font-size: 12px;
+	line-height: 1.6;
+	color: var( --os-ui-fg, #1d2327 );
+	tab-size: 2;
+}
+
+/*
+ * The `<code>` inside is the whole block, not a run of inline code.
+ *
+ * Left inline it inherits wp-admin's own `code` chip — a wash and a
+ * padding meant for a word mid-sentence — and an inline box wrapped
+ * over nine lines paints that wash once per LINE BOX, so the two blank
+ * lines in the snippet cut it into three chips and the one code block
+ * read as three. `display: block` gives it a single box, and the
+ * `<pre>` above is the only surface.
+ */
+.os-settings__help-warner-code code {
+	display: block;
+	padding: 0;
+	border: 0;
+	background: none;
+	font: inherit;
+	color: inherit;
+}
+
+/*
  * Search box + nav share one column so the field stays pinned while
  * the component list below it scrolls.
  */

--- a/src/settings/sections/help.ts
+++ b/src/settings/sections/help.ts
@@ -149,6 +149,30 @@ function runExampleInit(
 }
 
 /**
+ * The demo markup, as text, for the snippet the section shows.
+ *
+ * Deliberately a separate string from the live copies rendered below
+ * it: the live ones have to be real elements for the warner to fire,
+ * and real elements are exactly what cannot be read. A section whose
+ * whole subject is its tags used to show none of them — the body box
+ * sat empty and the sentence pointed "below" at nothing.
+ *
+ * Two cases, because the warner only has two answers: a name it can
+ * suggest a fix for, and one it cannot. A third unregistered tag
+ * demonstrated the same branch as the first with a different spelling.
+ *
+ * Not translated. It is source, not prose, comments included.
+ */
+const WARNER_DEMO_SNIPPET = [
+	'<!-- 1 — invented name, nothing close in the registry. -->',
+	'<os-example-console-fail-due-to-unregistered-component>',
+	'</os-example-console-fail-due-to-unregistered-component>',
+	'',
+	'<!-- 2 — typo within edit distance of a real tag. -->',
+	'<os-buton></os-buton>',
+].join( '\n' );
+
+/**
  * Module-level guard so the "intentional demo" console banner is
  * logged exactly once per page lifetime, no matter how many times
  * the Components tab is opened or repainted.
@@ -177,12 +201,11 @@ function logDemoBanner(): void {
 	// eslint-disable-next-line no-console
 	console.log(
 		'%c⚠ wp.os — INTENTIONAL DEMO%c\n' +
-			'The next three console.error entries are fired ON PURPOSE by the\n' +
+			'The next two console.error entries are fired ON PURPOSE by the\n' +
 			'OpenStation Preferences → Components tab to demonstrate the <os-*> missing-\n' +
 			'import warner. They are not real bugs.\n\n' +
 			'  1. <os-example-console-fail-due-to-unregistered-component>\n' +
-			'  2. <os-buton>   (typo of <os-button>)\n' +
-			'  3. <os-totally-made-up-thing>\n\n' +
+			'  2. <os-buton>   (typo of <os-button>)\n\n' +
 			'Source: src/settings/sections/help.ts — the "Missing-import\n' +
 			'warner — live demo" section. Remove that section in your fork\n' +
 			'if you want a quieter Components tab.',
@@ -236,34 +259,49 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 				-->
 				${ ctx.state.developerModeEnabled
 					? html`
+						<!--
+							The sentence lives in the body rather than on the
+							description attribute because it has to sit BESIDE
+							the snippet on a wide window, and the description
+							renders in the os-section shadow tree — nothing in
+							the slot can share a row with it.
+						-->
 						<os-section
 							heading=${ __( 'Missing-import warner — live demo' ) }
-							description=${ __(
-								'The three <os-*> tags below are intentionally bogus. Open the browser console: within ~2 seconds you should see three console.error entries from the framework, each pointing the developer at the fix (typo with "did you mean", and unknown tags). The tags are kept off-screen so they do not affect layout. Remove this section in your fork if you want a quieter Components tab.',
-							) }
 						>
+							<div class="os-settings__help-warner">
+								<p class="os-settings__help-warner-text">
+									${ __(
+										'Both <os-*> tags in the next piece of code are intentionally bogus, one per answer the warner has. Open the browser console: within ~2 seconds you should see two console.error entries from the framework, each pointing the developer at the fix — a name nothing in the registry comes close to, and a typo the warner can suggest a fix for ("did you mean"). Live copies of the same two tags are rendered off-screen, so the demo fires without affecting layout. Remove this section in your fork if you want a quieter Components tab.',
+									) }
+								</p>
+								<pre
+									class="os-settings__help-warner-code"
+								><code>${ WARNER_DEMO_SNIPPET }</code></pre>
+							</div>
+
+							<!--
+								The live copies. Real elements, because the
+								warner watches the document for tags nothing
+								registered — a snippet of text cannot trigger
+								it. Clipped rather than display:none so the
+								upgrade path runs exactly as it would on a
+								visible element.
+
+								Case 1 — invented name, nothing close in the
+								registry: the "no component by that name
+								exists" branch.
+								Case 2 — typo within Levenshtein distance of a
+								real tag: the "Did you mean <os-button>?"
+								branch.
+							-->
 							<div
 								class="os-settings__help-warner-demo"
 								aria-hidden="true"
 								style="position:absolute;width:0;height:0;overflow:hidden;clip:rect(0 0 0 0);"
 							>
-								<!--
-									Case 1 — invented name, nothing close in the registry.
-									Triggers the "no component by that name exists" branch.
-								-->
 								<os-example-console-fail-due-to-unregistered-component></os-example-console-fail-due-to-unregistered-component>
-
-								<!--
-									Case 2 — typo within Levenshtein distance of a real tag.
-									Triggers the "Did you mean <os-button>?" branch.
-								-->
 								<os-buton></os-buton>
-
-								<!--
-									Case 3 — looks plausible but is not in the registry.
-									Triggers the unknown-tag branch with no suggestion.
-								-->
-								<os-totally-made-up-thing></os-totally-made-up-thing>
 							</div>
 						</os-section>
 					`


### PR DESCRIPTION
OS Settings → Components → **Missing-import warner — live demo** (Developer mode on).

The section's whole subject is a pair of bogus `<os-*>` tags, and it showed neither. The live copies have to be real elements for the warner to fire, and a real element is exactly what cannot be read — so the body box sat empty under a sentence pointing "below" at nothing.

## What changed

**The snippet is visible.** The demo markup is now also a string (`WARNER_DEMO_SNIPPET`), rendered in a `<pre><code>` beside the sentence. Two separate things on purpose: text to read, elements to trigger the warner. The live copies are unchanged — still clipped, still real.

**The sentence moved into the section body.** It has to sit *beside* the snippet, and `<os-section>` renders `description=` in its shadow tree, where nothing in the slot can share a row with it. So the section is now heading → box containing *sentence | snippet*, rather than heading → sentence → empty box.

**Layout.** One column, two equal halves at `@container (min-width: 1350px)`. The container is the OS Settings **window** (`.os-window--native:has( .os-settings )`, already `container-type: inline-size`), not the viewport — this panel is a window inside the shell, so window width is the only width that moves here. Neither track carries a fixed width; `minmax( 0, 1fr )` keeps a long code line scrolling inside the `<pre>` instead of pushing the grid past the section box.

**One code block, not three.** The `<code>` is now `display: block`. Left inline it inherits wp-admin's own `code` chip — a wash meant for a word mid-sentence — and an inline box wrapped over several lines paints that wash once per *line box*, so the blank lines in the snippet cut it into three chips.

**Third case dropped.** `<os-totally-made-up-thing>` hit the same unknown-tag branch as case 1 with a different spelling. The warner has exactly two answers — a name it can suggest a fix for, and one it cannot — so the demo has two tags. The console banner and the sentence say two.

## Testing

`npm run build`, `lint`, `typecheck` green; `test:js` 4806 passing. Manually: OS Settings → Features → Developer mode on, open Components, drag the window across 1350px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-654-85265023ad4f5522613d6d1f55adc4d0300906a6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->