### PR TITLE
Desktop icons: one reading order per canvas, and a bounded scan

### DIFF
--- a/assets/css/os-settings.css
+++ b/assets/css/os-settings.css
@@ -1022,6 +1022,90 @@
 }
 
 /*
+ * Missing-import warner demo — the sentence and the snippet it talks
+ * about, in the section box.
+ *
+ * The snippet is shown because the section's whole subject is three
+ * tags and it used to show none of them: the live copies have to be
+ * real elements for the warner to fire, and a real element is exactly
+ * what cannot be read, so the box sat empty under a sentence pointing
+ * at nothing.
+ *
+ * One column by default; two equal halves once the window is wide
+ * enough for the prose to still have a paragraph's worth of room
+ * beside the code.
+ *
+ * Both tracks are `1fr` — the split is the box in half, and neither
+ * side carries a fixed width. A hard cap on the prose would leave a
+ * gutter of nothing between two columns that both had more to say.
+ * `minmax( 0, … )` on each so a long line of code shrinks the track to
+ * its share and scrolls inside the `<pre>` rather than pushing the
+ * grid wider than the section box.
+ *
+ * The container is the OS Settings WINDOW (`container-type` further
+ * down this file), not the viewport: this panel is a window inside the
+ * shell, so window width is the only width that moves here.
+ */
+.os-settings__help-warner {
+	display: grid;
+	gap: 16px;
+	align-items: start;
+}
+
+@container (min-width: 1350px) {
+	.os-settings__help-warner {
+		grid-template-columns: minmax( 0, 1fr ) minmax( 0, 1fr );
+	}
+}
+
+.os-settings__help-warner-text {
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.55;
+	color: var( --os-ui-fg-muted, #646970 );
+}
+
+/*
+ * `overflow-x: auto` rather than wrapping: the first tag is 56
+ * characters of deliberately absurd component name, and breaking a tag
+ * across lines turns the one thing the reader is here to recognise
+ * into two things. The section box clips (`::part( body )` sets
+ * `overflow: hidden`), so the scroll has to live on the `<pre>`.
+ */
+.os-settings__help-warner-code {
+	margin: 0;
+	padding: 12px 14px;
+	overflow-x: auto;
+	background: var( --os-ui-surface, #fff );
+	border: 1px solid var( --os-ui-border, #dcdcde );
+	border-radius: 6px;
+	font-family: var( --os-ui-font-mono, Menlo, Consolas, monospace );
+	font-size: 12px;
+	line-height: 1.6;
+	color: var( --os-ui-fg, #1d2327 );
+	tab-size: 2;
+}
+
+/*
+ * The `<code>` inside is the whole block, not a run of inline code.
+ *
+ * Left inline it inherits wp-admin's own `code` chip — a wash and a
+ * padding meant for a word mid-sentence — and an inline box wrapped
+ * over nine lines paints that wash once per LINE BOX, so the two blank
+ * lines in the snippet cut it into three chips and the one code block
+ * read as three. `display: block` gives it a single box, and the
+ * `<pre>` above is the only surface.
+ */
+.os-settings__help-warner-code code {
+	display: block;
+	padding: 0;
+	border: 0;
+	background: none;
+	font: inherit;
+	color: inherit;
+}
+
+/*
  * Search box + nav share one column so the field stays pinned while
  * the component list below it scrolls.
  */

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -371,8 +371,46 @@ A gap you can see is the thing worth tuning; the pitch just follows.
 `src/desktop-files/grid.ts` mirrors these numbers for the layout
 maths (which can't read CSS) and exports `GRID_METRICS` /
 `GRID_METRICS_LARGE` so no surface has to restate them.
-`tests/vitest/grid-metrics.test.ts` parses the stylesheet and fails
-if the two ever drift.
+`includes/desktop-files/grid.php` mirrors them again, because the
+server picks cells for tiles it will never see rendered.
+`tests/vitest/grid-metrics.test.ts` parses the stylesheet and
+`Tests_OpenStation_DesktopFilesGrid` parses the TypeScript, so a
+number that moves in one language and not the others fails a test
+that names the other one.
+
+### Reading order
+
+The other half of "one grid" is which way a canvas reads.
+
+| Canvas | Order | Why |
+|---|---|---|
+| The desktop root (`folderId` 0) | **column** — fill a column top-to-bottom, then start the next | It is tall, it is the surface users hold a mental map of, and every desktop metaphor worth copying fills a column first. |
+| A folder window | **row** — fill a row left-to-right, then drop | It is wide and short; a column-major fill runs a two-item folder off the bottom of its own window. |
+
+**The order belongs to the canvas, not to the operation.** Every path
+that allocates a cell asks the same question — a drop, a sort, the
+displacement of a collision on repaint, the rescue of tiles that
+drifted out of view — via `orderForFolder()` on the client and
+`openstation_files_grid_order()` on the server. When they each
+answered for themselves, the desktop arrived as a row of icons on
+some page loads and as columns on others, depending on which pass ran
+last.
+
+Two rules follow, both tested:
+
+- **A scan is bounded by the canvas it packs.** `nextFreeCell()`
+  wraps at `gridRows()` for a column and `gridCols()` for a row. The
+  layer is `position: absolute; inset: 0` and does not scroll, so a
+  cell allocated past the edge isn't below the fold — there is no
+  fold — it is unreachable.
+- **An unmeasurable canvas is not a one-cell canvas.** A host that
+  hasn't been laid out yet reports `0`; believing it is exactly how a
+  column turns into a row, since a column-major scan one row tall
+  *is* a row. `GRID_FALLBACK_ROWS` / `GRID_FALLBACK_COLS` are what a
+  caller with nothing to measure gets — the server always, the client
+  before first layout. They are deliberately small: wrapping one cell
+  early costs a column the canvas had room for, wrapping one cell
+  late loses a tile.
 
 Two consequences worth knowing, both learned the hard way:
 
@@ -515,8 +553,9 @@ the iframe, is an ordinary `dragover` / `drop` pair.
 The files canvas accepts those too. Drop an attachment on the
 wallpaper, on a folder window's canvas, or on a closed folder tile and
 it files as a shortcut exactly as a drag from WP Explorer would —
-same row-major packing, same optimistic store upsert, same
-`os.files.shortcut-dropped` action.
+same packing in the destination's [reading order](#reading-order),
+same optimistic store upsert, same `os.files.shortcut-dropped`
+action.
 
 The payload is read from whichever channel carries it:
 
@@ -593,22 +632,32 @@ targets:
   - Each folder tile — accepts the same payloads but routes them
     INTO that folder (sets `parentId` on the move, or POSTs a new
     placement with `parentId = folderId`). Both branches also
-    **re-pack row-major** into the destination's first free cells
-    rather than carrying the coordinates the tile had outside. The
-    destination window is usually not mounted, so there is nothing
-    to measure and aim at; landing at the top-left is the outcome
-    that's visible whatever size the folder turns out to be. A tile
-    filed from low down a tall desktop would otherwise keep a `y`
-    no folder canvas reaches.
+    **re-pack into the destination's first free cells**, in that
+    canvas's [reading order](#reading-order), rather than carrying
+    the coordinates the tile had outside. The destination window is
+    usually not mounted, so there is nothing to measure and aim at;
+    the declared fallback bounds keep the landing slot visible
+    whatever size the folder turns out to be. A tile filed from low
+    down a tall desktop would otherwise keep a `y` no folder canvas
+    reaches.
 
 A layer is `position: absolute; inset: 0` and does **not** scroll,
 so a tile positioned past an edge isn't below a fold — there is no
 fold — it is unreachable. `FilesLayer.reflow()` is the safety net:
 after every paint, and on every host resize, any tile whose stored
-cell falls outside the canvas (either edge) is packed into view.
+box falls outside the canvas (either edge) is packed into view.
 The reflow is **visual only** — nothing is persisted until the user
 drags or sorts — so a layout that merely doesn't fit the current
 window size is restored the moment there's room for it again.
+
+Because it is visual only, a rescue re-derives its verdict on every
+load, which makes two properties load-bearing rather than nice to
+have. It packs in the canvas's own reading order, so a rescue can
+never be what turns a column of icons into a row. And it measures
+the **tile** box, not the cell box: a cell carries the gap that
+separates it from the next one, and a tile in the last row has
+nothing after it, so asking whether its gap fits condemns a
+fully-visible tile and repacks the whole canvas around it.
 
 Pinned tiles (registered with `pinned: true` via
 `openstation_register_icon`) skip drag wiring entirely. A pointerdown

--- a/includes/desktop-files/bootstrap.php
+++ b/includes/desktop-files/bootstrap.php
@@ -32,6 +32,7 @@ require_once OPENSTATION_DIR . 'includes/desktop-files/types/class-openstation-u
 require_once OPENSTATION_DIR . 'includes/desktop-files/built-in-types.php';
 require_once OPENSTATION_DIR . 'includes/desktop-files/openers.php';
 require_once OPENSTATION_DIR . 'includes/desktop-files/built-in-openers.php';
+require_once OPENSTATION_DIR . 'includes/desktop-files/grid.php';
 require_once OPENSTATION_DIR . 'includes/desktop-files/schema.php';
 require_once OPENSTATION_DIR . 'includes/desktop-files/store.php';
 require_once OPENSTATION_DIR . 'includes/desktop-files/folders-store.php';

--- a/includes/desktop-files/grid.php
+++ b/includes/desktop-files/grid.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * OpenStation — the icon grid, server side.
+ *
+ * The PHP mirror of `src/desktop-files/grid.ts`. Same pitch, same
+ * fallbacks, same reading order — because the server picks cells for
+ * tiles the client then has to lay out, and the two disagreeing is
+ * visible on the wallpaper.
+ *
+ * It disagreed for a while. The client's grid was retuned to a
+ * 108 × 120 pitch and this side kept the 96 × 110 one it was written
+ * against, so every coordinate the server minted landed off-grid;
+ * from the seventh row down two server rows aliased onto the same
+ * client cell and the tiles had to be displaced on sight. Worse, the
+ * server packed a column to unbounded depth — it has no viewport and
+ * asked nothing about one — so a desktop with more icons than fit in
+ * one column always had a tile stored past the bottom edge of a layer
+ * that doesn't scroll. The client's rescue pass then repacked the
+ * whole wallpaper to bring it back, and the desktop the user knew
+ * came back rearranged.
+ *
+ * Hence {@see openstation_files_grid_fallback_rows()}: the server
+ * can't measure the canvas, so it assumes a small one and wraps
+ * early. Wrapping one cell early costs a column the desktop had room
+ * for. Wrapping one cell late loses a tile.
+ *
+ * `Tests_OpenStation_DesktopFilesGrid` parses the TypeScript and
+ * fails if either side moves without the other.
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Gutter from the top / inline-start edge of an icon canvas.
+ *
+ * Mirrors `GRID_PADDING` / `--os-grid-padding`.
+ */
+const OPENSTATION_GRID_PADDING = 16;
+
+/**
+ * Cell pitch — the tile box plus the air after it.
+ *
+ * Mirrors `GRID_CELL_W` / `GRID_CELL_H`, which are themselves derived
+ * (`--os-tile-w` + `--os-grid-gap-x`, `--os-tile-h` + `--os-grid-gap-y`).
+ * Declared here rather than derived because PHP has no reason to know
+ * a cell is made of two things; the test proves the total agrees.
+ */
+const OPENSTATION_GRID_CELL_W = 108;
+const OPENSTATION_GRID_CELL_H = 120;
+
+/**
+ * How far a scan runs along the axis it wraps on.
+ *
+ * The server never measures a canvas, so it always uses these.
+ * Mirrors `GRID_FALLBACK_ROWS` / `GRID_FALLBACK_COLS`.
+ */
+const OPENSTATION_GRID_FALLBACK_ROWS = 5;
+const OPENSTATION_GRID_FALLBACK_COLS = 4;
+
+/**
+ * Upper bound on a scan's unbounded axis. Packing 999 columns of
+ * icons is not a layout, it's a runaway loop.
+ */
+const OPENSTATION_GRID_SCAN_LIMIT = 999;
+
+/**
+ * Which way a canvas reads.
+ *
+ * The desktop root reads in columns — it is tall, and every desktop
+ * metaphor worth copying fills a column before starting the next. A
+ * folder reads in rows: it is wide and short, and a column-major fill
+ * would run a two-item folder off the bottom of its own window.
+ *
+ * The same rule as `orderForFolder()` in `src/desktop-files/layer.ts`.
+ *
+ * @param int $parent_id Folder id. `0` is the desktop root.
+ * @return string `'column'` or `'row'`.
+ */
+function openstation_files_grid_order( $parent_id ) {
+	return 0 === (int) $parent_id ? 'column' : 'row';
+}
+
+/**
+ * Snap a stored pixel coordinate to the cell it belongs to.
+ *
+ * Rounds rather than floors, so a coordinate that predates a pitch
+ * change — or that a plugin wrote by hand — is read as the cell it is
+ * nearest to instead of leaving a phantom hole one cell up and left.
+ * The client's `pointToCell()` does the same, which is what keeps an
+ * occupancy set built here and one built there describing the same
+ * canvas.
+ *
+ * @param int $x Horizontal pixel offset.
+ * @param int $y Vertical pixel offset.
+ * @return array{0:int,1:int} `array( $col, $row )`, both >= 0.
+ */
+function openstation_files_grid_point_to_cell( $x, $y ) {
+	$col = (int) round( ( (int) $x - OPENSTATION_GRID_PADDING ) / OPENSTATION_GRID_CELL_W );
+	$row = (int) round( ( (int) $y - OPENSTATION_GRID_PADDING ) / OPENSTATION_GRID_CELL_H );
+	return array( max( 0, $col ), max( 0, $row ) );
+}
+
+/**
+ * The pixel coordinate of a cell.
+ *
+ * @param int $col Column index.
+ * @param int $row Row index.
+ * @return array{x:int,y:int} Placement coordinates.
+ */
+function openstation_files_grid_cell_to_point( $col, $row ) {
+	return array(
+		'x' => OPENSTATION_GRID_PADDING + max( 0, (int) $col ) * OPENSTATION_GRID_CELL_W,
+		'y' => OPENSTATION_GRID_PADDING + max( 0, (int) $row ) * OPENSTATION_GRID_CELL_H,
+	);
+}
+
+/**
+ * Build an occupancy set from rows carrying `x` / `y`.
+ *
+ * Keys are `"<col>,<row>"`, the same convention `cellKey()` uses on
+ * the client.
+ *
+ * @param array $rows Rows with `x` and `y` keys.
+ * @return array<string,bool> Occupancy set.
+ */
+function openstation_files_grid_occupied( $rows ) {
+	$occupied = array();
+	foreach ( (array) $rows as $row ) {
+		if ( ! isset( $row['x'], $row['y'] ) ) {
+			continue;
+		}
+		list( $col, $r )         = openstation_files_grid_point_to_cell( $row['x'], $row['y'] );
+		$occupied[ "$col,$r" ]   = true;
+	}
+	return $occupied;
+}
+
+/**
+ * First free cell in `$order`, wrapping at the assumed canvas edge.
+ *
+ * Marks the cell it returns, so a caller allocating several in a row
+ * gets consecutive slots without bookkeeping of its own.
+ *
+ * @param array<string,bool> $occupied Occupancy set, by reference.
+ * @param string             $order    `'column'` or `'row'`.
+ * @return array{0:int,1:int} `array( $col, $row )`.
+ */
+function openstation_files_grid_next_free( &$occupied, $order = 'column' ) {
+	if ( 'row' === $order ) {
+		$outer = OPENSTATION_GRID_SCAN_LIMIT;
+		$inner = OPENSTATION_GRID_FALLBACK_COLS;
+	} else {
+		$outer = OPENSTATION_GRID_SCAN_LIMIT;
+		$inner = OPENSTATION_GRID_FALLBACK_ROWS;
+	}
+	for ( $o = 0; $o < $outer; $o++ ) {
+		for ( $i = 0; $i < $inner; $i++ ) {
+			$col = 'row' === $order ? $i : $o;
+			$row = 'row' === $order ? $o : $i;
+			if ( ! isset( $occupied[ "$col,$row" ] ) ) {
+				$occupied[ "$col,$row" ] = true;
+				return array( $col, $row );
+			}
+		}
+	}
+	$occupied['0,0'] = true;
+	return array( 0, 0 );
+}

--- a/includes/desktop-files/shares-store.php
+++ b/includes/desktop-files/shares-store.php
@@ -1569,10 +1569,13 @@ function openstation_files_share_inject_shell_config( $config ) {
 add_filter( 'openstation_shell_config', 'openstation_files_share_inject_shell_config', 20 );
 
 /**
- * Place an icon at the next free row-major slot in a user's view
- * of `$parent_id`. Internal helper used by share-accept and
- * fan-out. Mirrors the grid math in `src/desktop-files/grid.ts`
- * (padding 16 + col 96 + row 110).
+ * Place an icon at the next free slot in a user's view of
+ * `$parent_id`. Internal helper used by share-accept and fan-out.
+ *
+ * "Next free" follows the destination's own reading order — columns
+ * on the desktop, rows in a folder — so a shared thing arriving
+ * unannounced lands where the next tile the user created would have.
+ * Grid math lives in `includes/desktop-files/grid.php`.
  *
  * @param int    $user_id   Viewer.
  * @param int    $parent_id Folder id (0 = desktop root).
@@ -1597,33 +1600,18 @@ function openstation_files_place_at_next_free_slot( $user_id, $parent_id, $type,
 		),
 		ARRAY_A
 	);
-	$occupied = array();
-	foreach ( (array) $existing as $row ) {
-		$col                   = max( 0, (int) round( ( (int) $row['x'] - 16 ) / 96 ) );
-		$r                     = max( 0, (int) round( ( (int) $row['y'] - 16 ) / 110 ) );
-		$occupied[ "$col,$r" ] = true;
-	}
+	$occupied = openstation_files_grid_occupied( $existing );
 
-	$pick_col = 0;
-	$pick_row = 0;
-	for ( $r = 0; $r < 999; $r++ ) {
-		for ( $col = 0; $col < 999; $col++ ) {
-			if ( ! isset( $occupied[ "$col,$r" ] ) ) {
-				$pick_col = $col;
-				$pick_row = $r;
-				break 2;
-			}
-		}
-	}
+	list( $pick_col, $pick_row ) = openstation_files_grid_next_free(
+		$occupied,
+		openstation_files_grid_order( $parent_id )
+	);
 
 	return openstation_files_place(
 		$user_id,
 		$parent_id,
 		$type,
 		$ref,
-		array(
-			'x' => 16 + $pick_col * 96,
-			'y' => 16 + $pick_row * 110,
-		)
+		openstation_files_grid_cell_to_point( $pick_col, $pick_row )
 	);
 }

--- a/includes/desktop-files/store.php
+++ b/includes/desktop-files/store.php
@@ -605,8 +605,10 @@ function openstation_files_get_for_user_folder( $user_id, $parent_id = 0 ) {
  *      other tile (drag, sort, right-click, clean up).
  *
  * Idempotent on both axes: a folder/shortcut that already has
- * any placement is left alone. Coordinates use the column-major
- * grid that `src/desktop-files/grid.ts` mirrors on the JS side.
+ * any placement is left alone. Coordinates come from
+ * `includes/desktop-files/grid.php`, which mirrors
+ * `src/desktop-files/grid.ts` — pitch, reading order, and the
+ * assumed canvas the scan wraps at.
  *
  * Called by the placements list endpoint when the requested
  * folder is the root (`parent_id=0`).
@@ -683,8 +685,9 @@ function openstation_files_auto_place_orphans( $user_id ) {
 
 	// Build an occupied set from EXISTING root placements so
 	// we never drop an orphan on top of a tile the user
-	// already has. Cell math mirrors `src/desktop-files/grid.ts`
-	// (padding 16 + col 96 + row 110).
+	// already has. Cell math lives in
+	// `includes/desktop-files/grid.php`, the mirror of
+	// `src/desktop-files/grid.ts`.
 	$existing = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT x, y FROM {$tables['placements']}
@@ -695,45 +698,31 @@ function openstation_files_auto_place_orphans( $user_id ) {
 		),
 		ARRAY_A
 	);
-	$occupied = array();
-	foreach ( (array) $existing as $row ) {
-		$col                         = max( 0, (int) round( ( (int) $row['x'] - 16 ) / 96 ) );
-		$row_idx                     = max( 0, (int) round( ( (int) $row['y'] - 16 ) / 110 ) );
-		$occupied[ "$col,$row_idx" ] = true;
-	}
+	$occupied = openstation_files_grid_occupied( $existing );
 
-	$find_next = function () use ( &$occupied ) {
-		for ( $col = 0; $col < 999; $col++ ) {
-			for ( $row = 0; $row < 999; $row++ ) {
-				$key = "$col,$row";
-				if ( ! isset( $occupied[ $key ] ) ) {
-					$occupied[ $key ] = true;
-					return array( $col, $row );
-				}
-			}
-		}
-		return array( 0, 0 );
-	};
+	// The desktop reads in columns, and the scan wraps to the next one
+	// at the assumed canvas height rather than running a column 999
+	// cells deep. The server has no viewport; a slot it invents below
+	// the fold is a tile the user cannot reach, because the layer that
+	// renders it does not scroll.
+	$order = openstation_files_grid_order( 0 );
 
-	$placed    = 0;
-	$emit_at   = function ( $type, $ref, $col, $row ) use ( $user_id, &$occupied, &$placed ) {
+	$placed  = 0;
+	$emit_at = function ( $type, $ref, $col, $row ) use ( $user_id, &$occupied, &$placed ) {
 		$occupied[ "$col,$row" ] = true;
 		$result                  = openstation_files_place(
 			$user_id,
 			0,
 			$type,
 			(string) $ref,
-			array(
-				'x' => 16 + $col * 96,
-				'y' => 16 + $row * 110,
-			)
+			openstation_files_grid_cell_to_point( $col, $row )
 		);
 		if ( ! is_wp_error( $result ) ) {
 			++$placed;
 		}
 	};
-	$emit_next = function ( $type, $ref ) use ( $find_next, $emit_at ) {
-		list( $col, $row ) = $find_next();
+	$emit_next = function ( $type, $ref ) use ( &$occupied, $order, $emit_at ) {
+		list( $col, $row ) = openstation_files_grid_next_free( $occupied, $order );
 		$emit_at( $type, $ref, $col, $row );
 	};
 

--- a/src/desktop-files/built-in-openers.ts
+++ b/src/desktop-files/built-in-openers.ts
@@ -19,7 +19,7 @@ import { __ } from '../i18n';
 import { registerOpener } from './openers';
 import type { DesktopFile } from './file';
 import { openAgentChatWindow } from '../agents-dispatch';
-import { mountFilesLayer } from './layer';
+import { mountFilesLayer, orderForFolder } from './layer';
 import { mountFolderStatusBar } from './folder-status-bar';
 import { attachIconCanvasMenu } from '../icon-canvas/menu';
 import {
@@ -449,6 +449,9 @@ export function registerBuiltInFileOpeners(): void {
 														GRID_PADDING,
 														occupied,
 														layerHost,
+														orderForFolder(
+															route.folderId,
+														),
 													);
 													const placement =
 														await filesRest.createPlacement( {

--- a/src/desktop-files/grid.ts
+++ b/src/desktop-files/grid.ts
@@ -23,6 +23,20 @@
  *
  * The CELL is derived, never declared. A gap you can see is the
  * thing worth tuning; the pitch is just tile + gap.
+ *
+ * **The other half of "one grid" is the reading order.** A canvas
+ * reads in columns or in rows ({@link GridOrder}), it picks once, and
+ * every path that allocates a cell on it — a drop, a sort, a rescue
+ * of tiles that drifted out of view — goes through
+ * {@link nextFreeCell} with that order. The desktop turning itself
+ * into rows on some page loads and not others was three code paths
+ * disagreeing about this: the server packed columns without a bound,
+ * the client packed columns with one, and the rescue pass packed
+ * rows. Whichever ran last won.
+ *
+ * `includes/desktop-files/grid.php` is the PHP mirror — same pitch,
+ * same fallbacks, same order semantics — and
+ * `Tests_OpenStation_DesktopFilesGrid` parses this file to prove it.
  */
 
 /** Gutter from the top / inline-start edge of an icon canvas. */
@@ -106,81 +120,153 @@ export function cellToPos( col: number, row: number ): GridPos {
 }
 
 /**
- * Snap `(x, y)` to the nearest empty grid cell. If the nearest
- * cell is occupied, scans column-major (down each column then
- * across) for the first empty one — same convention macOS
- * Finder uses for "Clean Up".
+ * Which way a canvas reads.
  *
- * `occupied` is the set of `"<col>,<row>"` strings already in
- * use; the caller is responsible for building it from the
- * current placement list.
+ * `'column'` fills the first column top-to-bottom then starts the
+ * next one — the desktop's convention, and macOS Finder's. `'row'`
+ * fills the top row left-to-right then drops to the next — the right
+ * order for a folder window, which is wide and short.
  *
- * `host` is optional — when provided, the scan respects the
- * host's height so tiles wrap to a new column when the bottom
- * is hit. Without it, columns extend infinitely (which is
- * fine for desktop windows that don't have a definite height).
+ * **An auto-pack must never change a canvas's order.** Repacking is
+ * a rescue (a tile drifted out of view, the user asked for a sort);
+ * the user reads it as the desktop rearranging itself. One order per
+ * canvas, chosen at mount and passed to every allocator call.
+ *
+ * @public
  */
-export function snapToEmptyCell(
-	x: number,
-	y: number,
-	occupied: Set< string >,
-	host?: HTMLElement | null,
-): GridPos {
-	const target = pointToCell( x, y );
-	if ( ! occupied.has( cellKey( target.col, target.row ) ) ) {
-		return target;
-	}
+export type GridOrder = 'column' | 'row';
 
-	const maxRows = host
-		? Math.max( 1, Math.floor( ( host.clientHeight - GRID_PADDING ) / GRID_CELL_H ) )
-		: 999;
+/**
+ * How far a scan runs along the axis it wraps on when the canvas
+ * can't be measured — no host, a host that isn't laid out yet, or a
+ * caller with no DOM at all (PHP's auto-placer picks slots for a
+ * viewport it will never see; `includes/desktop-files/grid.php`
+ * mirrors both numbers).
+ *
+ * The two failure modes are not symmetric, which is why these are
+ * deliberately small. Wrapping one cell early costs a column the
+ * canvas had room for — the user sees a slightly wider spread and
+ * nothing else. Wrapping one cell late puts a tile past the edge of a
+ * layer that has no scrollbar, so it isn't below the fold, it is
+ * gone. `GRID_FALLBACK_ROWS` fits a 616px canvas — a small laptop
+ * with the devtools open — and the measured path takes over the
+ * moment there is something to measure.
+ */
+export const GRID_FALLBACK_ROWS = 5;
+export const GRID_FALLBACK_COLS = 4;
 
-	// Column-major scan starting at column 0 — guarantees
-	// deterministic packing regardless of where the user
-	// dropped the new tile.
-	for ( let col = 0; col < 999; col++ ) {
-		for ( let row = 0; row < maxRows; row++ ) {
-			if ( ! occupied.has( cellKey( col, row ) ) ) {
-				return cellToPos( col, row );
-			}
-		}
+/** Rows that fit in `host`, or {@link GRID_FALLBACK_ROWS}. */
+export function gridRows( host?: HTMLElement | null ): number {
+	const h = host?.clientHeight ?? 0;
+	if ( h <= 0 ) {
+		// An unmeasurable host is not a one-row host. Reading `0` off
+		// a canvas that hasn't been laid out yet and believing it is
+		// how a column of icons turns into a row.
+		return GRID_FALLBACK_ROWS;
 	}
-	// Fallback: target cell anyway. Should be unreachable
-	// unless the desktop has 999 × 999 placements.
-	return target;
+	return Math.max( 1, Math.floor( ( h - GRID_PADDING ) / GRID_CELL_H ) );
+}
+
+/** Columns that fit in `host`, or {@link GRID_FALLBACK_COLS}. */
+export function gridCols( host?: HTMLElement | null ): number {
+	const w = host?.clientWidth ?? 0;
+	if ( w <= 0 ) {
+		return GRID_FALLBACK_COLS;
+	}
+	return Math.max( 1, Math.floor( ( w - GRID_PADDING ) / GRID_CELL_W ) );
 }
 
 /**
- * Find the first empty grid cell in row-major order — fills row 0
- * across all columns first, then row 1, etc. This is the right pack
- * order for "drop a new shortcut into a folder" because new tiles
- * land at the TOP of the visible canvas instead of piling down
- * column 0 (where they may fall below a short folder window's
- * fold). `cols` defaults to 4 when no host is supplied.
- *
- * Different from {@link snapToEmptyCell}, which is column-major and
- * is the right order for "clean up" / sort. Both share the
- * `cellKey()` occupancy convention.
+ * Upper bound on a scan's unbounded axis. Packing 999 columns of
+ * icons is not a layout, it's a runaway loop.
  */
-export function nextRowMajorCell(
+const SCAN_LIMIT = 999;
+
+/**
+ * First empty cell in `order`, wrapping at the canvas's edge.
+ *
+ * `occupied` is the set of `"<col>,<row>"` keys already in use — the
+ * caller builds it from the current placement list, and is free to
+ * add each returned cell to keep allocating.
+ *
+ * The wrap axis is bounded by the canvas ({@link gridRows} for
+ * `'column'`, {@link gridCols} for `'row'`) so a tile can never be
+ * allocated past the edge of a layer that doesn't scroll. The other
+ * axis runs to {@link SCAN_LIMIT}.
+ */
+export function nextFreeCell(
 	occupied: Set< string >,
+	order: GridOrder = 'column',
 	host?: HTMLElement | null,
 ): GridPos {
-	const cols = host
-		? Math.max(
-			1,
-			Math.floor( ( host.clientWidth - GRID_PADDING ) / GRID_CELL_W ),
-		)
-		: 4;
-	const maxCols = Math.max( 1, cols );
-	for ( let row = 0; row < 999; row++ ) {
-		for ( let col = 0; col < maxCols; col++ ) {
+	if ( 'row' === order ) {
+		const cols = gridCols( host );
+		for ( let row = 0; row < SCAN_LIMIT; row++ ) {
+			for ( let col = 0; col < cols; col++ ) {
+				if ( ! occupied.has( cellKey( col, row ) ) ) {
+					return cellToPos( col, row );
+				}
+			}
+		}
+		return cellToPos( 0, 0 );
+	}
+	const rows = gridRows( host );
+	for ( let col = 0; col < SCAN_LIMIT; col++ ) {
+		for ( let row = 0; row < rows; row++ ) {
 			if ( ! occupied.has( cellKey( col, row ) ) ) {
 				return cellToPos( col, row );
 			}
 		}
 	}
 	return cellToPos( 0, 0 );
+}
+
+/**
+ * Consecutive cells for `count` tiles, in `order`, skipping anything
+ * `occupied` already holds.
+ *
+ * The engine behind both bulk layout passes — "sort by name" and the
+ * rescue of tiles that drifted off the canvas. They used to carry a
+ * copy each of the same allocator loop, which is how one of them
+ * ended up row-major on a surface that reads in columns.
+ *
+ * `occupied` is not mutated; the reserved cells (pinned tiles) stay
+ * the caller's to describe.
+ */
+export function packCells(
+	count: number,
+	occupied: Set< string >,
+	order: GridOrder = 'column',
+	host?: HTMLElement | null,
+): GridPos[] {
+	const taken = new Set( occupied );
+	const out: GridPos[] = [];
+	for ( let i = 0; i < count; i++ ) {
+		const cell = nextFreeCell( taken, order, host );
+		taken.add( cellKey( cell.col, cell.row ) );
+		out.push( cell );
+	}
+	return out;
+}
+
+/**
+ * Snap `(x, y)` to the nearest empty grid cell. When the nearest cell
+ * is taken, falls through to {@link nextFreeCell} in the canvas's own
+ * `order` — a tile displaced by a collision lands where the next tile
+ * would have, not somewhere the canvas doesn't otherwise pack.
+ */
+export function snapToEmptyCell(
+	x: number,
+	y: number,
+	occupied: Set< string >,
+	host?: HTMLElement | null,
+	order: GridOrder = 'column',
+): GridPos {
+	const target = pointToCell( x, y );
+	if ( ! occupied.has( cellKey( target.col, target.row ) ) ) {
+		return target;
+	}
+	return nextFreeCell( occupied, order, host );
 }
 
 /**

--- a/src/desktop-files/layer.ts
+++ b/src/desktop-files/layer.ts
@@ -41,12 +41,13 @@ import {
 import {
 	cellKey,
 	cellToPos,
-	GRID_CELL_H,
-	GRID_CELL_W,
-	GRID_PADDING,
-	nextRowMajorCell,
+	nextFreeCell,
+	packCells,
 	pointToCell,
 	snapToEmptyCell,
+	TILE_H,
+	TILE_W,
+	type GridOrder,
 } from './grid';
 import type { RestPlacementShape } from './rest';
 import type { FilesState } from './store';
@@ -135,6 +136,25 @@ function getDragManager(): DragManagerApi | null {
 }
 
 const LAYER_CLASS = 'os-files-layer';
+
+/**
+ * Which way a canvas reads.
+ *
+ * The wallpaper (`folderId` 0) reads in columns: it is tall, it is
+ * the surface users hold a mental map of, and every desktop metaphor
+ * worth copying fills a column before starting the next. A folder
+ * window reads in rows: it is wide and short, and a column-major fill
+ * would run a two-item folder off the bottom of its own window.
+ *
+ * **It is a property of the canvas, not of the operation.** Every
+ * path that allocates a cell asks here — a drop, a sort, a rescue of
+ * tiles that drifted out of view, the displacement of a collision on
+ * repaint. When they each answered for themselves, the desktop
+ * rearranged itself depending on which one ran last.
+ */
+export function orderForFolder( folderId: number ): GridOrder {
+	return 0 === folderId ? 'column' : 'row';
+}
 
 /**
  * Sort modes accepted by `FilesLayer.sort()`. Same keys the icon-
@@ -236,6 +256,8 @@ function takeBootPlacements( folderId: number ): RestPlacementShape[] | null {
 }
 
 export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
+	const order = orderForFolder( folderId );
+
 	const container = document.createElement( 'div' );
 	container.className = LAYER_CLASS;
 	container.setAttribute( 'role', 'list' );
@@ -355,6 +377,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				placement.y,
 				occupiedCells,
 				host,
+				order,
 			);
 			occupiedCells.add( cellKey( free.col, free.row ) );
 			displaced.set( placement.id, { x: free.x, y: free.y } );
@@ -365,6 +388,22 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	/**
 	 * Apply final position to an existing tile based on the pinned /
 	 * displaced / stored coordinates. Pure DOM mutation — no rebuild.
+	 *
+	 * **A stored coordinate is a pixel here, and the tile renders at
+	 * it.** Tempting to resolve it through `pointToCell()` on the way
+	 * to the DOM — the occupancy set already reads it that way, and it
+	 * would quietly land coordinates written on an older, tighter
+	 * pitch back on today's grid. It would also take away something
+	 * the layer offers on purpose: `buildOccupiedSet()` goes out of
+	 * its way to record an off-grid placement against the cell it
+	 * snaps to precisely so "a manual position doesn't leave a phantom
+	 * hole", and a plugin that `POST`s `{ x, y }` is entitled to those
+	 * pixels.
+	 *
+	 * So the two readings coexist deliberately: cells decide what is
+	 * FREE, pixels decide where a tile IS. Moving an old coordinate
+	 * onto the current pitch means moving the stored value — a
+	 * migration, not a render-time reinterpretation.
 	 */
 	const applyTilePosition = (
 		tile: HTMLElement,
@@ -579,7 +618,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 
 		// Fastest path: position-only changes (intra-folder drag,
 		// auto-arrange). Same set, same structure, no rewiring.
-		if ( tryPatchPositions( list, container, host ) ) {
+		if ( tryPatchPositions( list, container, host, order ) ) {
 			return;
 		}
 
@@ -711,7 +750,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 					.getState()
 					.placementsByFolder.get( folderId ) ?? [];
 			const occupied = buildVisualOccupiedSet( peers, movingId );
-			const cell = snapToEmptyCell( rawX, rawY, occupied, host );
+			const cell = snapToEmptyCell( rawX, rawY, occupied, host, order );
 			previewEl.style.transform = `translate3d(${ cell.x }px, ${ cell.y }px, 0)`;
 		};
 
@@ -830,7 +869,13 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 				// Every tile in the set vacates its cell, so none of
 				// them counts as occupied while we place the others.
 				const occupied = buildVisualOccupiedSet( peers, movingIds );
-				const primaryCell = snapToEmptyCell( rawX, rawY, occupied, host );
+				const primaryCell = snapToEmptyCell(
+					rawX,
+					rawY,
+					occupied,
+					host,
+					order,
+				);
 				occupied.add( cellKey( primaryCell.col, primaryCell.row ) );
 
 				for ( const placement of moving ) {
@@ -848,6 +893,7 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 							Math.max( 0, primaryCell.y + dy ),
 							occupied,
 							host,
+							order,
 						);
 						occupied.add( cellKey( cell.col, cell.row ) );
 					}
@@ -1019,14 +1065,17 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	}
 
 	/**
-	 * Compute how many tile columns fit in the current canvas
-	 * width. Used by both `sort` and `reflow`. Falls back to a
-	 * sensible 4-col default when the host hasn't been measured
-	 * yet (cold render, before the layout pass).
+	 * The cells a bulk layout pass must not hand out: column 0, rows
+	 * `0..count-1`, where the pinned tiles live. Same reservation
+	 * `computeLayout` makes on every repaint, so a sort and a rescue
+	 * land the rest of the canvas around them identically.
 	 */
-	const colsForWidth = (): number => {
-		const w = host.clientWidth > 0 ? host.clientWidth : 4 * GRID_CELL_W;
-		return Math.max( 1, Math.floor( ( w - GRID_PADDING ) / GRID_CELL_W ) );
+	const reservedCells = ( count: number ): Set< string > => {
+		const out = new Set< string >();
+		for ( let i = 0; i < count; i += 1 ) {
+			out.add( cellKey( 0, i ) );
+		}
+		return out;
 	};
 
 	const sortPlacements = (
@@ -1066,29 +1115,17 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		const draggable = live.filter( ( p ) => ! isPinned( p ) );
 		const sorted = sortPlacements( draggable, mode );
 
-		const cols = colsForWidth();
-		// Reserve column 0, rows 0..pinnedCount-1 for pinned tiles.
-		const occupied = new Set< string >();
-		for ( let i = 0; i < pinned.length; i += 1 ) {
-			occupied.add( cellKey( 0, i ) );
-		}
-		// Row-major fill, skipping pinned-occupied cells.
-		let idx = 0;
-		const nextCell = (): { col: number; row: number } => {
-			while ( true ) {
-				const row = Math.floor( idx / cols );
-				const col = idx % cols;
-				idx += 1;
-				if ( ! occupied.has( cellKey( col, row ) ) ) {
-					return { col, row };
-				}
-			}
-		};
+		// Fill in the canvas's own order, skipping the column-0 slots
+		// the pinned tiles hold.
+		const cells = packCells(
+			sorted.length,
+			reservedCells( pinned.length ),
+			order,
+			host,
+		);
 
 		sorted.forEach( ( p, i ) => {
-			const cell = nextCell();
-			const x = GRID_PADDING + cell.col * GRID_CELL_W;
-			const y = GRID_PADDING + cell.row * GRID_CELL_H;
+			const { x, y } = cells[ i ];
 			const next: RestPlacementShape = {
 				...p,
 				x,
@@ -1116,11 +1153,10 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 
 	/**
 	 * If any tile would render past the canvas's edge given its
-	 * stored (x, y), do an in-memory row-major reflow so the user
-	 * sees them all. Doesn't persist — once the user drags a tile
-	 * after the reflow, that single drag is what sticks. Repaints
-	 * clobber the visual reflow on the next store change, so we
-	 * apply positions directly via DOM mutation.
+	 * stored (x, y), compact them all back into view. Doesn't persist
+	 * — once the user drags a tile after the reflow, that single drag
+	 * is what sticks. Repaints clobber the visual reflow on the next
+	 * store change, so we apply positions directly via DOM mutation.
 	 *
 	 * Both edges count. The layer is `position: absolute; inset: 0`
 	 * and does not scroll, so a tile past the BOTTOM edge isn't
@@ -1130,6 +1166,14 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 	 * tall enough to show. Filing now re-packs (see the folder-tile
 	 * drop handler), but rows written before that, or by any other
 	 * route, still need rescuing on sight.
+	 *
+	 * **A rescue keeps the canvas's reading order.** This used to
+	 * pack row-major whatever it was rescuing, so a wallpaper with
+	 * one tile out of range came back as a row of icons across the
+	 * top — and because the pass is deliberately not persisted, it
+	 * re-derived that verdict on every load, flipping between rows
+	 * and columns as the window height crossed the threshold. The
+	 * user is entitled to see the same desktop twice.
 	 */
 	const reflow = (): void => {
 		const live = filesStoreApi.getState().placementsByFolder.get( folderId );
@@ -1138,43 +1182,36 @@ export function mountFilesLayer( host: HTMLElement, folderId = 0 ): FilesLayer {
 		}
 		const w = host.clientWidth > 0 ? host.clientWidth : Infinity;
 		const h = host.clientHeight > 0 ? host.clientHeight : Infinity;
+		// The TILE box, not the cell box. A cell carries the gap that
+		// separates it from the next one, and a tile in the last row
+		// has nothing after it — asking whether its gap fits condemns
+		// a fully-visible tile and repacks the whole canvas around it.
+		// That off-by-one-gap is most of how a desktop that fit
+		// perfectly well decided it was overflowing.
 		const overflowing = live.some(
-			( p ) => p.x + GRID_CELL_W > w || p.y + GRID_CELL_H > h,
+			( p ) => p.x + TILE_W > w || p.y + TILE_H > h,
 		);
 		if ( ! overflowing ) {
 			return;
 		}
-		const cols = colsForWidth();
 		// Pinned tiles keep their slot — see `sort` above for the
 		// same recipe.
 		const pinned = live.filter( ( p ) => isPinned( p ) );
 		const draggable = live.filter( ( p ) => ! isPinned( p ) );
-		const occupied = new Set< string >();
-		for ( let i = 0; i < pinned.length; i += 1 ) {
-			occupied.add( cellKey( 0, i ) );
-		}
-		let idx = 0;
-		const nextCell = (): { col: number; row: number } => {
-			while ( true ) {
-				const row = Math.floor( idx / cols );
-				const col = idx % cols;
-				idx += 1;
-				if ( ! occupied.has( cellKey( col, row ) ) ) {
-					return { col, row };
-				}
-			}
-		};
-		for ( const p of draggable ) {
-			const cell = nextCell();
-			const x = GRID_PADDING + cell.col * GRID_CELL_W;
-			const y = GRID_PADDING + cell.row * GRID_CELL_H;
+		const cells = packCells(
+			draggable.length,
+			reservedCells( pinned.length ),
+			order,
+			host,
+		);
+		draggable.forEach( ( p, i ) => {
 			const tile = container.querySelector< HTMLElement >(
 				`[data-placement-id="${ p.id }"]`,
 			);
 			if ( tile ) {
-				setTilePosition( tile, x, y );
+				setTilePosition( tile, cells[ i ].x, cells[ i ].y );
 			}
-		}
+		} );
 	};
 
 	// Watch the host for size changes — fire `reflow` whenever a
@@ -1403,16 +1440,16 @@ function buildVisualOccupiedSet(
  * tile, and a cross-frame native drag arriving from an iframe. They
  * differ only in where the entities came from, and having one
  * implementation is what keeps them agreeing on the parts users
- * notice — row-major packing, the optimistic store upsert, and the
+ * notice — the packing, the optimistic store upsert, and the
  * `os.files.shortcut-dropped` action plugins listen to.
  *
- * Packing is row-major rather than cursor-snapped on purpose: a
- * shortcut CREATE has no tile on screen for the user to have aimed
- * with, so "tidy, top-left, and visible" beats "wherever the pointer
- * happened to be". Pass `host` when the destination canvas is the one
- * on screen so the column count is measured from it; omit it when
- * filing into a folder whose window probably isn't mounted, and
- * `nextRowMajorCell` falls back to a four-column grid.
+ * Packing follows the destination's own reading order rather than
+ * the cursor on purpose: a shortcut CREATE has no tile on screen for
+ * the user to have aimed with, so "the next slot this canvas would
+ * use" beats "wherever the pointer happened to be". Pass `host` when
+ * the destination canvas is the one on screen so the wrap is measured
+ * from it; omit it when filing into a folder whose window probably
+ * isn't mounted and {@link nextFreeCell} uses the declared fallback.
  *
  * @param entities Entities to file. Each becomes one placement.
  * @param parentId Destination folder id. `0` is the desktop root.
@@ -1426,8 +1463,9 @@ function fileShortcutEntities(
 	const peers =
 		filesStoreApi.getState().placementsByFolder.get( parentId ) ?? [];
 	const occupied = buildVisualOccupiedSet( peers );
+	const order = orderForFolder( parentId );
 	for ( const entity of entities ) {
-		const cell = nextRowMajorCell( occupied, host );
+		const cell = nextFreeCell( occupied, order, host );
 		occupied.add( cellKey( cell.col, cell.row ) );
 		void rest
 			.createPlacement( {
@@ -1603,6 +1641,7 @@ function tryPatchPositions(
 	list: readonly RestPlacementShape[],
 	container: HTMLElement,
 	host: HTMLElement,
+	order: GridOrder,
 ): boolean {
 	const tiles = Array.from(
 		container.querySelectorAll< HTMLElement >( '[data-placement-id]' ),
@@ -1675,6 +1714,7 @@ function tryPatchPositions(
 			placement.y,
 			occupiedCells,
 			host,
+			order,
 		);
 		occupiedCells.add( cellKey( free.col, free.row ) );
 		displaced.set( placement.id, { x: free.x, y: free.y } );
@@ -1685,15 +1725,13 @@ function tryPatchPositions(
 		if ( ! tile ) {
 			continue; // unreachable — guarded above; keeps the typechecker happy.
 		}
-		const pinned = pinnedSlots.get( placement.id );
-		const disp = displaced.get( placement.id );
-		if ( pinned ) {
-			setTilePosition( tile, pinned.x, pinned.y );
-		} else if ( disp ) {
-			setTilePosition( tile, disp.x, disp.y );
-		} else {
-			setTilePosition( tile, placement.x, placement.y );
-		}
+		const at =
+			pinnedSlots.get( placement.id ) ??
+			displaced.get( placement.id ) ?? {
+				x: placement.x,
+				y: placement.y,
+			};
+		setTilePosition( tile, at.x, at.y );
 		syncTileLabel( tile, placement );
 	}
 
@@ -1856,18 +1894,19 @@ function registerFolderDropTarget(
 				// wasn't merely below the fold, it was unreachable.
 				// The file looked like it had swallowed the icon.
 				//
-				// Row-major for the same reason the shortcut branch
-				// below packs that way: the destination window is
-				// probably not mounted, so we can't measure it and
-				// aim — landing at the top-left of a folder is the
-				// outcome that's visible whatever its size.
+				// In the destination's reading order, not this one's:
+				// the tile is joining that canvas. The window is
+				// probably not mounted, so we can't measure it — the
+				// declared fallback keeps the landing slot visible
+				// whatever size it opens at.
 				const peers =
 					filesStoreApi
 						.getState()
 						.placementsByFolder.get( targetFolderId ) ?? [];
 				const occupied = buildVisualOccupiedSet( peers );
+				const targetOrder = orderForFolder( targetFolderId );
 				for ( const placement of dragPlacements( data ) ) {
-					const cell = nextRowMajorCell( occupied );
+					const cell = nextFreeCell( occupied, targetOrder );
 					occupied.add( cellKey( cell.col, cell.row ) );
 					filesStoreApi.upsertPlacement( {
 						...placement,
@@ -1905,12 +1944,11 @@ function registerFolderDropTarget(
 			}
 			if ( session.payload.type === 'shortcut' ) {
 				const data = session.payload.data as unknown as ShortcutDragData;
-				// Row-major pack so newly-filed shortcuts land at the
-				// top of the (likely-not-yet-mounted) folder window.
-				// We can't read the destination folder window's host
-				// width from here, so no host is passed and
-				// `nextRowMajorCell` defaults to 4 cols — sensible for
-				// any folder window.
+				// No host: we can't read the destination folder
+				// window's box from here, so the pack falls back to
+				// the declared column count — sensible for any folder
+				// window, and small enough that the landing slot is
+				// visible whatever size it opens at.
 				fileShortcutEntities( dragShortcutItems( data ), targetFolderId );
 			}
 		},

--- a/src/settings/sections/help.ts
+++ b/src/settings/sections/help.ts
@@ -149,6 +149,30 @@ function runExampleInit(
 }
 
 /**
+ * The demo markup, as text, for the snippet the section shows.
+ *
+ * Deliberately a separate string from the live copies rendered below
+ * it: the live ones have to be real elements for the warner to fire,
+ * and real elements are exactly what cannot be read. A section whose
+ * whole subject is its tags used to show none of them — the body box
+ * sat empty and the sentence pointed "below" at nothing.
+ *
+ * Two cases, because the warner only has two answers: a name it can
+ * suggest a fix for, and one it cannot. A third unregistered tag
+ * demonstrated the same branch as the first with a different spelling.
+ *
+ * Not translated. It is source, not prose, comments included.
+ */
+const WARNER_DEMO_SNIPPET = [
+	'<!-- 1 — invented name, nothing close in the registry. -->',
+	'<os-example-console-fail-due-to-unregistered-component>',
+	'</os-example-console-fail-due-to-unregistered-component>',
+	'',
+	'<!-- 2 — typo within edit distance of a real tag. -->',
+	'<os-buton></os-buton>',
+].join( '\n' );
+
+/**
  * Module-level guard so the "intentional demo" console banner is
  * logged exactly once per page lifetime, no matter how many times
  * the Components tab is opened or repainted.
@@ -177,12 +201,11 @@ function logDemoBanner(): void {
 	// eslint-disable-next-line no-console
 	console.log(
 		'%c⚠ wp.os — INTENTIONAL DEMO%c\n' +
-			'The next three console.error entries are fired ON PURPOSE by the\n' +
+			'The next two console.error entries are fired ON PURPOSE by the\n' +
 			'OpenStation Preferences → Components tab to demonstrate the <os-*> missing-\n' +
 			'import warner. They are not real bugs.\n\n' +
 			'  1. <os-example-console-fail-due-to-unregistered-component>\n' +
-			'  2. <os-buton>   (typo of <os-button>)\n' +
-			'  3. <os-totally-made-up-thing>\n\n' +
+			'  2. <os-buton>   (typo of <os-button>)\n\n' +
 			'Source: src/settings/sections/help.ts — the "Missing-import\n' +
 			'warner — live demo" section. Remove that section in your fork\n' +
 			'if you want a quieter Components tab.',
@@ -236,34 +259,49 @@ export function buildHelpSection( ctx: SettingsCtx ): HTMLElement {
 				-->
 				${ ctx.state.developerModeEnabled
 					? html`
+						<!--
+							The sentence lives in the body rather than on the
+							description attribute because it has to sit BESIDE
+							the snippet on a wide window, and the description
+							renders in the os-section shadow tree — nothing in
+							the slot can share a row with it.
+						-->
 						<os-section
 							heading=${ __( 'Missing-import warner — live demo' ) }
-							description=${ __(
-								'The three <os-*> tags below are intentionally bogus. Open the browser console: within ~2 seconds you should see three console.error entries from the framework, each pointing the developer at the fix (typo with "did you mean", and unknown tags). The tags are kept off-screen so they do not affect layout. Remove this section in your fork if you want a quieter Components tab.',
-							) }
 						>
+							<div class="os-settings__help-warner">
+								<p class="os-settings__help-warner-text">
+									${ __(
+										'Both <os-*> tags in the next piece of code are intentionally bogus, one per answer the warner has. Open the browser console: within ~2 seconds you should see two console.error entries from the framework, each pointing the developer at the fix — a name nothing in the registry comes close to, and a typo the warner can suggest a fix for ("did you mean"). Live copies of the same two tags are rendered off-screen, so the demo fires without affecting layout. Remove this section in your fork if you want a quieter Components tab.',
+									) }
+								</p>
+								<pre
+									class="os-settings__help-warner-code"
+								><code>${ WARNER_DEMO_SNIPPET }</code></pre>
+							</div>
+
+							<!--
+								The live copies. Real elements, because the
+								warner watches the document for tags nothing
+								registered — a snippet of text cannot trigger
+								it. Clipped rather than display:none so the
+								upgrade path runs exactly as it would on a
+								visible element.
+
+								Case 1 — invented name, nothing close in the
+								registry: the "no component by that name
+								exists" branch.
+								Case 2 — typo within Levenshtein distance of a
+								real tag: the "Did you mean <os-button>?"
+								branch.
+							-->
 							<div
 								class="os-settings__help-warner-demo"
 								aria-hidden="true"
 								style="position:absolute;width:0;height:0;overflow:hidden;clip:rect(0 0 0 0);"
 							>
-								<!--
-									Case 1 — invented name, nothing close in the registry.
-									Triggers the "no component by that name exists" branch.
-								-->
 								<os-example-console-fail-due-to-unregistered-component></os-example-console-fail-due-to-unregistered-component>
-
-								<!--
-									Case 2 — typo within Levenshtein distance of a real tag.
-									Triggers the "Did you mean <os-button>?" branch.
-								-->
 								<os-buton></os-buton>
-
-								<!--
-									Case 3 — looks plausible but is not in the registry.
-									Triggers the unknown-tag branch with no suggestion.
-								-->
-								<os-totally-made-up-thing></os-totally-made-up-thing>
 							</div>
 						</os-section>
 					`

--- a/tests/phpunit/tests/desktopFilesGrid.php
+++ b/tests/phpunit/tests/desktopFilesGrid.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * One icon grid, three languages.
+ *
+ * `assets/css/variables.css` declares the grid, `src/desktop-files/grid.ts`
+ * mirrors it for the layout maths (a vitest suite proves that half), and
+ * `includes/desktop-files/grid.php` mirrors it again because the server
+ * picks cells for tiles it will never see rendered.
+ *
+ * The PHP mirror is the one that drifted. It kept a 96 × 110 pitch after
+ * the client moved to 108 × 120, and it packed a column 999 cells deep
+ * for a viewport it had never asked about — so a desktop with more icons
+ * than fit in one column always had one stored past the bottom edge, and
+ * the client's rescue pass repacked the whole wallpaper to bring it back.
+ * The user's icons arrived in rows.
+ *
+ * This parses the TypeScript. When it fails it is telling you a number
+ * moved in one language and not the other, and it names which.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group os-files
+ */
+class Tests_OpenStation_DesktopFilesGrid extends WP_UnitTestCase {
+
+	/** @var string */
+	protected static $grid_ts;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		$path = dirname( dirname( dirname( __DIR__ ) ) ) . '/src/desktop-files/grid.ts';
+		self::assertFileExists(
+			$path,
+			'src/desktop-files/grid.ts is the source this mirror tracks. If it moved, ' .
+			'point this test at the new path — do not delete the check.'
+		);
+		self::$grid_ts = (string) file_get_contents( $path );
+	}
+
+	/**
+	 * Read an `export const NAME = 123;` declaration out of the TS.
+	 *
+	 * @param string $name Exported constant name.
+	 * @return int Declared value.
+	 */
+	protected function ts_const( $name ) {
+		$matched = preg_match(
+			'/export const ' . preg_quote( $name, '/' ) . '\s*=\s*(-?\d+)\s*;/',
+			self::$grid_ts,
+			$m
+		);
+		$this->assertSame(
+			1,
+			$matched,
+			"src/desktop-files/grid.ts declares no $name. The TS grid is the source " .
+			'of truth for includes/desktop-files/grid.php; if you removed a constant, ' .
+			'remove its PHP mirror too.'
+		);
+		return (int) $m[1];
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_cell_to_point
+	 */
+	public function test_pitch_mirrors_the_typescript() {
+		$tile_w = $this->ts_const( 'TILE_W' );
+		$tile_h = $this->ts_const( 'TILE_H' );
+		$gap_x  = $this->ts_const( 'GRID_GAP_X' );
+		$gap_y  = $this->ts_const( 'GRID_GAP_Y' );
+
+		$this->assertSame( $this->ts_const( 'GRID_PADDING' ), OPENSTATION_GRID_PADDING );
+		// The cell is tile + gap on both sides. PHP declares the total
+		// because it has no reason to know a cell is made of two things;
+		// this is where that shortcut gets checked.
+		$this->assertSame( $tile_w + $gap_x, OPENSTATION_GRID_CELL_W );
+		$this->assertSame( $tile_h + $gap_y, OPENSTATION_GRID_CELL_H );
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_next_free
+	 */
+	public function test_fallback_bounds_mirror_the_typescript() {
+		$this->assertSame(
+			$this->ts_const( 'GRID_FALLBACK_ROWS' ),
+			OPENSTATION_GRID_FALLBACK_ROWS
+		);
+		$this->assertSame(
+			$this->ts_const( 'GRID_FALLBACK_COLS' ),
+			OPENSTATION_GRID_FALLBACK_COLS
+		);
+		// A one-cell bound is a row wearing a column's name — the exact
+		// degeneracy this whole mirror exists to prevent.
+		$this->assertGreaterThan( 1, OPENSTATION_GRID_FALLBACK_ROWS );
+		$this->assertGreaterThan( 1, OPENSTATION_GRID_FALLBACK_COLS );
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_order
+	 */
+	public function test_the_desktop_reads_in_columns_and_a_folder_in_rows() {
+		$this->assertSame( 'column', openstation_files_grid_order( 0 ) );
+		$this->assertSame( 'row', openstation_files_grid_order( 7 ) );
+		// Same rule as `orderForFolder()` on the client.
+		$this->assertSame(
+			1,
+			preg_match(
+				'/return 0 === folderId \? \'column\' : \'row\';/',
+				(string) file_get_contents(
+					dirname( dirname( dirname( __DIR__ ) ) ) . '/src/desktop-files/layer.ts'
+				)
+			),
+			'orderForFolder() in src/desktop-files/layer.ts and ' .
+			'openstation_files_grid_order() have to answer the same question the ' .
+			'same way, or the server files a tile somewhere the client never packs.'
+		);
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_point_to_cell
+	 * @covers ::openstation_files_grid_cell_to_point
+	 */
+	public function test_a_cell_round_trips_through_pixels() {
+		foreach ( array( array( 0, 0 ), array( 0, 4 ), array( 3, 2 ) ) as $cell ) {
+			list( $col, $row ) = $cell;
+			$point             = openstation_files_grid_cell_to_point( $col, $row );
+			$this->assertSame(
+				array( $col, $row ),
+				openstation_files_grid_point_to_cell( $point['x'], $point['y'] )
+			);
+		}
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_point_to_cell
+	 */
+	public function test_off_grid_coordinates_snap_to_the_nearest_cell() {
+		// Rows written under the old 96 × 110 pitch, and anything a
+		// plugin wrote by hand, still have to resolve to the cell they
+		// LOOK like they are in — otherwise the occupancy set has a
+		// phantom hole and the next tile is filed on top of one.
+		$this->assertSame(
+			array( 0, 1 ),
+			openstation_files_grid_point_to_cell( 16, 126 )
+		);
+		$this->assertSame(
+			array( 1, 0 ),
+			openstation_files_grid_point_to_cell( 112, 16 )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_next_free
+	 */
+	public function test_the_desktop_scan_fills_a_column_then_wraps() {
+		$occupied = array();
+		$cells    = array();
+		for ( $i = 0; $i < OPENSTATION_GRID_FALLBACK_ROWS + 2; $i++ ) {
+			$cells[] = openstation_files_grid_next_free( $occupied, 'column' );
+		}
+		// Column 0, top to bottom …
+		for ( $row = 0; $row < OPENSTATION_GRID_FALLBACK_ROWS; $row++ ) {
+			$this->assertSame( array( 0, $row ), $cells[ $row ] );
+		}
+		// … then the next column, back at the top.
+		$this->assertSame(
+			array( 1, 0 ),
+			$cells[ OPENSTATION_GRID_FALLBACK_ROWS ]
+		);
+		$this->assertSame(
+			array( 1, 1 ),
+			$cells[ OPENSTATION_GRID_FALLBACK_ROWS + 1 ]
+		);
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_next_free
+	 */
+	public function test_a_folder_scan_fills_a_row_then_wraps() {
+		$occupied = array();
+		$cells    = array();
+		for ( $i = 0; $i < OPENSTATION_GRID_FALLBACK_COLS + 1; $i++ ) {
+			$cells[] = openstation_files_grid_next_free( $occupied, 'row' );
+		}
+		for ( $col = 0; $col < OPENSTATION_GRID_FALLBACK_COLS; $col++ ) {
+			$this->assertSame( array( $col, 0 ), $cells[ $col ] );
+		}
+		$this->assertSame(
+			array( 0, 1 ),
+			$cells[ OPENSTATION_GRID_FALLBACK_COLS ]
+		);
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_next_free
+	 */
+	public function test_no_slot_is_ever_invented_past_the_assumed_canvas() {
+		// The defect in one assertion: the server has no viewport, so
+		// every slot it hands out has to sit inside the canvas it is
+		// entitled to assume. A tile below that line is not below the
+		// fold — the layer does not scroll — it is gone, and the
+		// client's rescue repacks the whole desktop to find it.
+		$occupied = array();
+		$max_y    = OPENSTATION_GRID_PADDING
+			+ ( OPENSTATION_GRID_FALLBACK_ROWS - 1 ) * OPENSTATION_GRID_CELL_H;
+		for ( $i = 0; $i < 40; $i++ ) {
+			list( $col, $row ) = openstation_files_grid_next_free( $occupied, 'column' );
+			$point             = openstation_files_grid_cell_to_point( $col, $row );
+			$this->assertLessThanOrEqual( $max_y, $point['y'] );
+		}
+	}
+
+	/**
+	 * @covers ::openstation_files_grid_occupied
+	 */
+	public function test_occupancy_is_built_from_stored_coordinates() {
+		$occupied = openstation_files_grid_occupied(
+			array(
+				array( 'x' => 16, 'y' => 16 ),
+				array( 'x' => 16, 'y' => 136 ),
+				array( 'x' => 'nonsense' ), // Missing `y` — skipped, not fatal.
+			)
+		);
+		$this->assertArrayHasKey( '0,0', $occupied );
+		$this->assertArrayHasKey( '0,1', $occupied );
+		$this->assertCount( 2, $occupied );
+
+		// And the next free slot steps over both.
+		$this->assertSame(
+			array( 0, 2 ),
+			openstation_files_grid_next_free( $occupied, 'column' )
+		);
+	}
+}

--- a/tests/vitest/grid-order.test.ts
+++ b/tests/vitest/grid-order.test.ts
@@ -1,0 +1,185 @@
+/**
+ * One canvas, one reading order.
+ *
+ * The desktop used to arrive as a row of icons across the top on some
+ * page loads and as columns on others. Three allocators disagreed:
+ * the server packed columns without a bound, the client packed
+ * columns with one, and the out-of-view rescue packed rows. Whichever
+ * ran last decided what the user saw, and the rescue ran on every
+ * boot — so the verdict flipped as the window height crossed the
+ * threshold that made one tile look out of range.
+ *
+ * These pin the three properties that make that impossible to
+ * reintroduce: an order is a property of the canvas, a scan is
+ * bounded by the canvas, and an unmeasurable canvas is not a
+ * one-cell-tall canvas.
+ */
+import { describe, expect, test } from 'vitest';
+import {
+	GRID_CELL_H,
+	GRID_CELL_W,
+	GRID_FALLBACK_COLS,
+	GRID_FALLBACK_ROWS,
+	GRID_PADDING,
+	cellKey,
+	gridCols,
+	gridRows,
+	nextFreeCell,
+	packCells,
+	snapToEmptyCell,
+} from '../../src/desktop-files/grid';
+import { orderForFolder } from '../../src/desktop-files/layer';
+
+/** A host that reports a fixed box, the way a laid-out canvas does. */
+function host( width: number, height: number ): HTMLElement {
+	const el = document.createElement( 'div' );
+	Object.defineProperty( el, 'clientWidth', { value: width } );
+	Object.defineProperty( el, 'clientHeight', { value: height } );
+	return el;
+}
+
+/** Cells for `count` tiles on an empty canvas. */
+function pack(
+	count: number,
+	order: 'column' | 'row',
+	el?: HTMLElement | null,
+) {
+	return packCells( count, new Set< string >(), order, el );
+}
+
+describe( 'reading order belongs to the canvas', () => {
+	test( 'the desktop root reads in columns, a folder in rows', () => {
+		expect( orderForFolder( 0 ) ).toBe( 'column' );
+		expect( orderForFolder( 1 ) ).toBe( 'row' );
+		expect( orderForFolder( 4291 ) ).toBe( 'row' );
+	} );
+
+	test( 'a column-major pack fills a column before starting the next', () => {
+		// Tall enough for six rows: 16 + 6 × 120 = 736.
+		const cells = pack( 8, 'column', host( 1200, 760 ) );
+		expect( cells.map( ( c ) => `${ c.col },${ c.row }` ) ).toEqual( [
+			'0,0',
+			'0,1',
+			'0,2',
+			'0,3',
+			'0,4',
+			'0,5',
+			'1,0',
+			'1,1',
+		] );
+	} );
+
+	test( 'a row-major pack fills a row before dropping to the next', () => {
+		// Wide enough for four columns: 16 + 4 × 108 = 448.
+		const cells = pack( 6, 'row', host( 460, 800 ) );
+		expect( cells.map( ( c ) => `${ c.col },${ c.row }` ) ).toEqual( [
+			'0,0',
+			'1,0',
+			'2,0',
+			'3,0',
+			'0,1',
+			'1,1',
+		] );
+	} );
+
+	test( 'a displaced tile lands where the next tile would have', () => {
+		// The bug shape: a collision resolved in the WRONG order puts
+		// one tile somewhere the canvas never otherwise packs, and the
+		// column the user reads down has a hole in it.
+		const occupied = new Set( [ cellKey( 0, 0 ) ] );
+		const displaced = snapToEmptyCell(
+			GRID_PADDING,
+			GRID_PADDING,
+			occupied,
+			host( 1200, 760 ),
+			'column',
+		);
+		expect( [ displaced.col, displaced.row ] ).toEqual( [ 0, 1 ] );
+	} );
+} );
+
+describe( 'a scan is bounded by the canvas', () => {
+	test( 'a column wraps at the bottom edge rather than running past it', () => {
+		const canvas = host( 1200, 400 ); // three rows: 16 + 3 × 120 = 376.
+		expect( gridRows( canvas ) ).toBe( 3 );
+		const cells = pack( 4, 'column', canvas );
+		expect( cells[ 3 ].col ).toBe( 1 );
+		expect( cells[ 3 ].row ).toBe( 0 );
+		// Nothing allocated past the edge of a layer that can't scroll.
+		for ( const cell of cells ) {
+			expect( cell.y + GRID_CELL_H ).toBeLessThanOrEqual( 400 );
+		}
+	} );
+
+	test( 'a row wraps at the trailing edge', () => {
+		const canvas = host( 250, 800 ); // two columns: 16 + 2 × 108 = 232.
+		expect( gridCols( canvas ) ).toBe( 2 );
+		const cells = pack( 3, 'row', canvas );
+		expect( [ cells[ 2 ].col, cells[ 2 ].row ] ).toEqual( [ 0, 1 ] );
+		for ( const cell of cells ) {
+			expect( cell.x + GRID_CELL_W ).toBeLessThanOrEqual( 250 );
+		}
+	} );
+} );
+
+describe( 'an unmeasurable canvas', () => {
+	// This is the one that turned a column into a row. A host that
+	// isn't laid out yet reports 0, the old scan did
+	// `floor( ( 0 - 16 ) / 120 )` clamped up to 1, and a one-row
+	// column-major scan IS a row: (0,0), (1,0), (2,0), …
+	test( 'falls back to the declared bounds, never to one cell', () => {
+		for ( const canvas of [ undefined, null, host( 0, 0 ) ] ) {
+			expect( gridRows( canvas ) ).toBe( GRID_FALLBACK_ROWS );
+			expect( gridCols( canvas ) ).toBe( GRID_FALLBACK_COLS );
+			expect( GRID_FALLBACK_ROWS ).toBeGreaterThan( 1 );
+			expect( GRID_FALLBACK_COLS ).toBeGreaterThan( 1 );
+		}
+	} );
+
+	test( 'still packs a column, not a row', () => {
+		const cells = pack( 3, 'column', host( 0, 0 ) );
+		expect( cells.map( ( c ) => c.col ) ).toEqual( [ 0, 0, 0 ] );
+		expect( cells.map( ( c ) => c.row ) ).toEqual( [ 0, 1, 2 ] );
+	} );
+
+	test( 'the fallbacks are small enough to stay on a modest canvas', () => {
+		// The asymmetry that sets these numbers: wrapping early costs
+		// a column, wrapping late loses a tile. A 616 × 448 canvas is
+		// a small laptop with the devtools open.
+		const lastRowBottom =
+			GRID_PADDING + ( GRID_FALLBACK_ROWS - 1 ) * GRID_CELL_H + GRID_CELL_H;
+		const lastColEnd =
+			GRID_PADDING + ( GRID_FALLBACK_COLS - 1 ) * GRID_CELL_W + GRID_CELL_W;
+		expect( lastRowBottom ).toBeLessThanOrEqual( 616 );
+		expect( lastColEnd ).toBeLessThanOrEqual( 448 );
+	} );
+} );
+
+describe( 'packing respects reserved cells', () => {
+	test( 'pinned slots in column 0 are skipped, and not mutated away', () => {
+		// `sort` and the rescue both hand the pinned tiles' cells in
+		// as reserved; neither may hand one out, and neither may
+		// clobber the caller's set.
+		const reserved = new Set( [ cellKey( 0, 0 ), cellKey( 0, 1 ) ] );
+		const cells = packCells( 3, reserved, 'column', host( 1200, 760 ) );
+		expect( cells.map( ( c ) => `${ c.col },${ c.row }` ) ).toEqual( [
+			'0,2',
+			'0,3',
+			'0,4',
+		] );
+		expect( reserved.size ).toBe( 2 );
+	} );
+
+	test( 'nextFreeCell agrees with packCells one cell at a time', () => {
+		const occupied = new Set< string >();
+		const canvas = host( 1200, 760 );
+		const one = [ 0, 1, 2, 3 ].map( () => {
+			const cell = nextFreeCell( occupied, 'column', canvas );
+			occupied.add( cellKey( cell.col, cell.row ) );
+			return `${ cell.col },${ cell.row }`;
+		} );
+		expect( one ).toEqual(
+			pack( 4, 'column', canvas ).map( ( c ) => `${ c.col },${ c.row }` ),
+		);
+	} );
+} );


### PR DESCRIPTION
## The symptom

The wallpaper icons arrive **as a row across the top** on some page loads and as columns on others — same install, same icons, no setting changed.

## What was actually wrong

Three allocators disagreed about the desktop grid, and whichever ran last decided what the user saw.

**`FilesLayer.reflow()` is the visible half.** It rescues tiles whose stored coordinates fall outside the canvas — the layer is `position: absolute; inset: 0` and does not scroll, so a tile past an edge isn't below a fold, it's gone. But it repacked **row-major** whatever surface it was rescuing, so a single out-of-range tile flipped the entire wallpaper. It is deliberately not persisted, so it re-derived that verdict on every boot and every resize: the desktop flipped between rows and columns as the window height crossed the threshold.

**The server is why a tile was out of range at all.** `openstation_files_auto_place_orphans()` packed a column *999 cells deep* for a viewport it never asked about, so any desktop with more root items than fit in one visible column always had one stored below the bottom edge. It was also still on the **96 × 110** pitch the client left behind when the grid was unified at **108 × 120**, so its coordinates landed off-grid — and from the seventh row down two server rows aliased onto one client cell and had to be displaced on sight.

## The fix

- **An order is a property of the canvas, not of the operation.** `orderForFolder()` answers once — columns on the wallpaper, rows in a folder window — and every path that allocates a cell goes through it: drops, sorts, collision displacement on repaint, and the rescue. `nextFreeCell()` / `packCells()` replace the three hand-rolled allocator loops that each carried their own answer.
- **A scan is bounded by the canvas, and an unmeasurable canvas is not a one-cell canvas.** A host that isn't laid out yet reports `0`; the old `floor( ( 0 - 16 ) / 120 )` clamped up to `1`, and a column-major scan one row tall *is* a row. `GRID_FALLBACK_ROWS` / `GRID_FALLBACK_COLS` are what a caller with nothing to measure gets — the server always, the client before first layout. Small on purpose: wrapping a cell early costs a column, wrapping a cell late loses a tile.
- **`includes/desktop-files/grid.php`** is the PHP mirror of `src/desktop-files/grid.ts` — same pitch, same fallbacks, same order. `store.php` and `shares-store.php` had a copy of the maths each; both now consume it.
- **The rescue measures the tile box, not the cell box.** A cell carries the gap that separates it from the next one, and a tile in the last row has nothing after it — asking whether its gap fits condemned a fully-visible tile and repacked the canvas around it.

## Not changed, deliberately

A stored coordinate stays a **pixel** at render time. Resolving it through `pointToCell()` would land old-pitch rows on today's grid for free — and would also take away the off-grid manual positioning `buildOccupiedSet()` documents and the `tiles position from x/y` test pins. Coordinates written on the old pitch heal on the next drag, sort, or rescue; moving them wholesale needs a migration, not a render-time reinterpretation. Happy to write that migration as a follow-up if we want the tighter spacing gone immediately.

## Tests

- `tests/vitest/grid-order.test.ts` (new, 11 tests) — order per canvas, bounded scans, and the zero-height-host degeneracy that turned the column into a row.
- `tests/phpunit/tests/desktopFilesGrid.php` (new, 9 tests) — **parses the TypeScript**, so a number moving in one language and not the other fails a test that names the other one. Includes "no slot is ever invented past the assumed canvas", which is the server-side defect in one assertion.
- Full suites green: **4817 vitest**, **2381 PHPUnit**, `lint`, `lint:php`, `typecheck`, `build`.

## Docs

`docs/files-on-desktop.md` gains a **Reading order** section (the table, the two rules, and why the fallbacks are small), and the two places that described row-major packing as universal now point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-655-527840a801b8180167c491d3a3d49d3d1ed7cb10.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->