### PR TITLE
Trash: localize config before the lazy payload harvest

### DIFF
--- a/docs/event-driven-framework.md
+++ b/docs/event-driven-framework.md
@@ -279,6 +279,17 @@ but publish your events under your plugin's slug:
 | `os/game-score-recorded` | No | After a game's `submitScore()` write resolves (free play and challenge completion both). Games play in their own window, so this is how a leaderboard in another window learns it went stale. Payload carries `challengeId` on the completion path. |
 | `os/upload-hud-complete` | No | After a file dropped on the shell finishes uploading — `{ filename, attachmentId }`. Published by the progress HUD, not the uploader: the upload runs on XHR (the only transport that reports determinate progress) and so never routes through `wp.os.fetch`, which makes this the bus's only view of a completed drop. |
 
+**Content-change announcements.** The `os.<type>.changed` topic
+family is the bus's highest-traffic convention, and
+`wp.os.announceContentChange( type, action, ids, source? )` is its
+typed producer. The rule of thumb: **a window that mutates content
+through its own REST endpoints must announce** — the shell cannot
+see third-party REST traffic, so without the announcement the
+Recycle Bin, its dock badge and every other list window only learn
+of the change from the Heartbeat catch-all, 15–60 seconds later.
+See [javascript-reference.md → `announceContentChange`](./javascript-reference.md)
+for the envelope.
+
 **Activity ↔ broadcast mirror.** `wp.os.broadcast(topic, payload)`
 publishes both onto the broadcast bus (cross-iframe, cross-tab)
 AND onto the activity bus (in-tab) under the same topic name.

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -769,6 +769,7 @@ window.wp.os = {
     heartbeat:         HeartbeatBus,                           // wp Heartbeat bus
     broadcast:         < T >( topic, payload ) => void,        // cross-window
     subscribe:         ( topic, cb ) => () => void,            // cross-window
+    announceContentChange: ( type, action, ids, source? ) => void, // os.<type>.changed producer
 
     // Framework features
     presence:          PresenceApi,
@@ -2454,7 +2455,30 @@ wp.os.subscribe( 'posts/updated', ( { id } ) => {
 }
 ```
 
-Publishers: the server-side changelog relayed through the chromeless footer (`source: 'admin'`), the block-editor save-watcher (`'editor'`), the Heartbeat catch-all (`'heartbeat'` — may repeat a change delivered earlier by a faster path; treat refreshes as idempotent), and client-side emitters that identify themselves (`'recycle-bin'`, `'posts-window'`, your plugin). Subscribing to your type's topic is all a list window needs to stay live; publishing is one `openstation_content_changes_record()` call server-side (see [hooks-reference.md → Content-change realtime layer](./hooks-reference.md#content-change-realtime-layer)) or a direct `wp.os.broadcast()` client-side — set a distinctive `source` so you can skip your own echoes.
+Publishers: the server-side changelog relayed through the chromeless footer (`source: 'admin'`), the block-editor save-watcher (`'editor'`), the Heartbeat catch-all (`'heartbeat'` — may repeat a change delivered earlier by a faster path; treat refreshes as idempotent), and client-side emitters that identify themselves (`'recycle-bin'`, `'posts-window'`, your plugin). Subscribing to your type's topic is all a list window needs to stay live; publishing is one `openstation_content_changes_record()` call server-side (see [hooks-reference.md → Content-change realtime layer](./hooks-reference.md#content-change-realtime-layer)) or `wp.os.announceContentChange()` client-side — set a distinctive `source` so you can skip your own echoes.
+
+---
+
+### `announceContentChange( type, action, ids, source? )` — Stable
+
+The typed producer for the `os.<type>.changed` family — a wrapper over `broadcast()` that emits the exact envelope above, so producers stop hand-rolling it (a drifted payload fails silently: the bin just stops updating).
+
+**When you must call it:** whenever your window mutates content through **your own REST endpoints**. The shell sees its own mutations, and the server-side changelog covers chromeless admin pages — but a native window POSTing to `your-plugin/v1/...` is invisible to every other open window until the Heartbeat catch-all delivers the change 15–60 s later. Announcing is what makes the Recycle Bin, the bin's dock badge, and any list window showing your type update the moment your call resolves.
+
+```typescript
+wp.os.announceContentChange(
+    type:   string,                                                    // post type, or bin entity kind
+    action: 'created' | 'updated' | 'trashed' | 'untrashed' | 'deleted',
+    ids:    number | number[],                                         // invalid / empty → no-op
+    source?: string,                                                   // your emitter id
+): void;
+```
+
+```javascript
+// After your delete endpoint resolves:
+await apiDelete( `/my-plugin/v1/things/${ id }` );
+wp.os.announceContentChange( 'my_thing', 'trashed', id, 'my-plugin' );
+```
 
 **Heartbeat fields** — the shell contributes `openstation_content_changes_seen_ts` (server-ms high-water mark, `0` on the handshake tick) and consumes `openstation_content_changes: { ts, entries: [ { ts, type, action, ids } ] }`, re-broadcasting each fresh entry on this bus. Timestamps are server-clock; the first tick is a pure handshake so client/server skew can never drop changes.
 

--- a/includes/games/window.php
+++ b/includes/games/window.php
@@ -196,4 +196,7 @@ function openstation_games_localize_config() {
 
 	wp_enqueue_style( 'desktop-mode-games' );
 }
-add_action( 'admin_enqueue_scripts', 'openstation_games_localize_config', 30 );
+// Priority 5 for the same reason as the recycle bin: the lazy-load payload is
+// built at priority 10, and localize data attached after that never reaches a
+// bundle that loads on window open.
+add_action( 'admin_enqueue_scripts', 'openstation_games_localize_config', 5 );

--- a/includes/recycle-bin/window.php
+++ b/includes/recycle-bin/window.php
@@ -328,7 +328,13 @@ function openstation_recycle_bin_localize_config() {
 
 	wp_enqueue_style( 'desktop-mode-recycle-bin' );
 }
-add_action( 'admin_enqueue_scripts', 'openstation_recycle_bin_localize_config', 30 );
+// Priority 5, not an afterthought: `openstation_enqueue_assets()` (default 10)
+// harvests every lazy window's `wp_localize_script` data into the shell
+// payload, so config attached after 10 ships the bundle with no config — the
+// exact "openStationRecycleBinConfig is missing" failure the bundle warns
+// about. This ran at 30 and got away with it only while the bundle was
+// enqueued eagerly and WordPress printed the data itself at print time.
+add_action( 'admin_enqueue_scripts', 'openstation_recycle_bin_localize_config', 5 );
 
 /**
  * Inject the initial trash count and both bin drawings into the

--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -34,7 +34,7 @@ import {
 } from '../dock-helpers';
 import { renderIcon } from '../icon';
 import { deriveWindowId } from '../utils';
-import { broadcast, subscribe } from '../broadcast';
+import { announceContentChange, broadcast, subscribe } from '../broadcast';
 import { devtools } from '../devtools';
 import { showToast } from '../toast';
 import { activity } from '../activity';
@@ -239,7 +239,8 @@ export const RESERVED_NAMESPACE_KEYS: ReadonlySet< string > = new Set( [
 	'registerWindowChrome', 'unregisterWindowChrome', 'listWindowChromes',
 	'applyWindowChrome',
 	'connect', 'getConnection',
-	'broadcast', 'subscribe', 'registerPalette', 'unregisterPalette',
+	'broadcast', 'subscribe', 'announceContentChange',
+	'registerPalette', 'unregisterPalette',
 	'listPalettes', 'openPalette', 'devtools', 'createSharedStore',
 	'presence', 'selection', 'activity', 'heartbeat', 'showToast',
 	'renderKeyedList',
@@ -762,6 +763,7 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): OpenStationPublicApi
 		getConnection,
 		broadcast,
 		subscribe,
+		announceContentChange,
 		registerPalette,
 		unregisterPalette,
 		listPalettes,

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -235,3 +235,66 @@ export function installBroadcastReceiver(): void {
 		broadcast( data.topic, data.payload );
 	} );
 }
+
+/**
+ * The verbs the shell's content-change subscribers understand —
+ * the same set `includes/content-changes.php` records server-side.
+ */
+export type ContentChangeAction =
+	| 'created'
+	| 'updated'
+	| 'trashed'
+	| 'untrashed'
+	| 'deleted';
+
+/**
+ * Announce that content of one type changed — the cooperative half
+ * of the shell's real-time story.
+ *
+ * The shell can only see mutations it performs itself. A window
+ * that trashes, restores or deletes content through **its own REST
+ * endpoints** is invisible to every other open window until the
+ * Heartbeat catch-all drips the change in (15–60 s later): the
+ * Recycle Bin keeps listing a form the builder just trashed, the
+ * bin icon stays empty-looking while it is holding something.
+ * Announcing is how a window tells the rest of the desktop *now*.
+ *
+ * This is a thin, typed wrapper over
+ * `broadcast( 'os.<type>.changed', { source, action, ids } )` — the
+ * exact topic and payload the Recycle Bin window, the bin's dock
+ * icon, and the shell's iframe-reload subscriber already listen
+ * for. It exists so producers stop hand-rolling the envelope: two
+ * in-tree modules (pinned notes, files-on-desktop) and every
+ * third-party window need the same five lines, and a drifted
+ * payload fails silently.
+ *
+ * No-ops on an empty or invalid id list, so callers can pass a
+ * server response's ids straight through without guarding.
+ *
+ * @public
+ *
+ * @param type   Post type (or bin entity kind: `comment`,
+ *               `placement`, `shortcut`, `folder`) that changed.
+ * @param action What happened to it.
+ * @param ids    Affected id, or list of ids.
+ * @param source Optional producer tag (e.g. `'my-plugin'`), so a
+ *               producer that also subscribes can skip its own
+ *               emissions.
+ */
+export function announceContentChange(
+	type: string,
+	action: ContentChangeAction,
+	ids: number | number[],
+	source = '',
+): void {
+	const list = ( Array.isArray( ids ) ? ids : [ ids ] )
+		.map( ( id ) => Math.floor( Number( id ) ) )
+		.filter( ( id ) => Number.isFinite( id ) && id > 0 );
+	const slug = String( type ).trim();
+
+	if ( '' === slug || 0 === list.length ) {
+		return;
+	}
+
+	broadcast( `os.${ slug }.changed`, { source, action, ids: list } );
+}

--- a/src/desktop-files/trash.ts
+++ b/src/desktop-files/trash.ts
@@ -18,6 +18,7 @@
  * Extracted from `layer.ts` (drag-and-drop rework).
  */
 
+import { announceContentChange } from '../broadcast';
 import { rest, store as filesStoreApi } from './layer-deps';
 import type { RestPlacementShape } from './rest';
 
@@ -37,16 +38,7 @@ function broadcastFilesChange(
 	action: 'trashed' | 'untrashed' | 'deleted',
 	ids: number[],
 ): void {
-	const api = (
-		window as {
-			wp?: { os?: { broadcast?: ( topic: string, payload: unknown ) => void } };
-		}
-	).wp?.os;
-	api?.broadcast?.( `os.${ kind }.changed`, {
-		source: 'desktop-files',
-		action,
-		ids,
-	} );
+	announceContentChange( kind, action, ids, 'desktop-files' );
 }
 
 /**

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1595,6 +1595,22 @@ export interface OpenStationPublicApi {
 	 */
 	broadcast: < T = unknown >( topic: string, payload: T ) => void;
 	/**
+	 * Announce that content of one type was created, updated,
+	 * trashed, untrashed or deleted — the typed wrapper over
+	 * `broadcast( 'os.<type>.changed', { source, action, ids } )`
+	 * that the Recycle Bin, its dock icon and the shell's
+	 * iframe-reload subscriber all listen for. A window that
+	 * mutates content through its own REST endpoints must call
+	 * this, or its changes only reach other windows on the
+	 * Heartbeat cadence (15–60 s).
+	 */
+	announceContentChange: (
+		type: string,
+		action: 'created' | 'updated' | 'trashed' | 'untrashed' | 'deleted',
+		ids: number | number[],
+		source?: string,
+	) => void;
+	/**
 	 * Subscribe to broadcast topics. Returns an unsubscribe handle.
 	 * Use `'*'` to receive every payload.
 	 *

--- a/src/notes/broadcast.ts
+++ b/src/notes/broadcast.ts
@@ -10,26 +10,15 @@
  * `src/desktop-files/trash.ts`, so one subscriber handles both.
  */
 
+import { announceContentChange } from '../broadcast';
 import { NOTES_POST_TYPE } from './types';
 
 type NotesChangeAction = 'trashed' | 'untrashed' | 'deleted';
 
-/** No-ops before `wp.os` exists (boot ordering, tests). */
+/** Thin wrapper: one place owns the note type and the source tag. */
 export function broadcastNotesChange(
 	action: NotesChangeAction,
 	ids: number[],
 ): void {
-	if ( ids.length === 0 ) {
-		return;
-	}
-	const api = (
-		window as {
-			wp?: { os?: { broadcast?: ( topic: string, payload: unknown ) => void } };
-		}
-	).wp?.os;
-	api?.broadcast?.( `os.${ NOTES_POST_TYPE }.changed`, {
-		source: 'desktop-mode/notes',
-		action,
-		ids,
-	} );
+	announceContentChange( NOTES_POST_TYPE, action, ids, 'desktop-mode/notes' );
 }

--- a/tests/phpunit/tests/lazyWindowConfigPriority.php
+++ b/tests/phpunit/tests/lazyWindowConfigPriority.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Lazy-window config must attach before the payload harvest.
+ *
+ * `openstation_enqueue_assets()` (admin_enqueue_scripts, default priority 10)
+ * harvests every lazy native window's `wp_localize_script` data into the
+ * shell payload via `openstation_resolve_script_payload()`. A module that
+ * attaches its config later than that ships its bundle with no config at
+ * all on the lazy path — the browser-side "…Config is missing" failure —
+ * while looking perfectly healthy on any code path that still enqueues the
+ * bundle eagerly.
+ *
+ * The recycle bin shipped exactly that bug (config at priority 30, harvest
+ * at 10) after bundles went lazy in #613: the Trash window opened, listed
+ * nothing, and logged `openStationRecycleBinConfig is missing`. This test
+ * pins the ordering for every module that localizes config onto a lazy
+ * window handle, so the next module copies a working pattern.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ */
+class Tests_OpenStation_LazyWindowConfigPriority extends WP_UnitTestCase {
+
+	/**
+	 * Modules that attach `wp_localize_script` config to a lazy window
+	 * handle on `admin_enqueue_scripts`.
+	 *
+	 * @return array[]
+	 */
+	public function data_lazy_window_config_localizers() {
+		return array(
+			'recycle bin' => array( 'openstation_recycle_bin_localize_config' ),
+			'games'       => array( 'openstation_games_localize_config' ),
+		);
+	}
+
+	/**
+	 * Each localizer runs strictly before the payload harvest.
+	 *
+	 * @dataProvider data_lazy_window_config_localizers
+	 *
+	 * @param string $localizer Hooked function that calls `wp_localize_script`.
+	 */
+	public function test_config_attaches_before_the_payload_harvest( $localizer ) {
+		$harvest = has_action( 'admin_enqueue_scripts', 'openstation_enqueue_assets' );
+
+		$this->assertNotFalse( $harvest, 'The payload harvest must be hooked.' );
+
+		if ( ! function_exists( $localizer ) ) {
+			$this->markTestSkipped( "The {$localizer} module is not loaded in this environment." );
+		}
+
+		$priority = has_action( 'admin_enqueue_scripts', $localizer );
+
+		$this->assertNotFalse( $priority, "{$localizer} must be hooked." );
+		$this->assertLessThan(
+			$harvest,
+			$priority,
+			"{$localizer} attaches config after the payload harvest at priority {$harvest}: on the lazy path its bundle ships with no config."
+		);
+	}
+}

--- a/tests/vitest/announce-content-change.test.ts
+++ b/tests/vitest/announce-content-change.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `announceContentChange()` — the typed envelope every content-change
+ * producer shares.
+ *
+ * The topic (`os.<type>.changed`) and payload (`{ source, action,
+ * ids }`) are a load-bearing convention: the Recycle Bin window, its
+ * dock icon, and the shell's iframe-reload subscriber all parse this
+ * exact shape, and a producer that drifts fails silently — the bin
+ * just stops updating. These tests pin the envelope.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { announceContentChange, subscribe } from '../../src/broadcast';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+describe( 'announceContentChange', () => {
+	const unsubs: Array< () => void > = [];
+
+	beforeEach( () => {
+		installHooksStub();
+	} );
+
+	const capture = ( topic: string ): Array< Record< string, unknown > > => {
+		const seen: Array< Record< string, unknown > > = [];
+		unsubs.push(
+			subscribe( topic, ( payload ) => {
+				seen.push( payload as Record< string, unknown > );
+			} ),
+		);
+		return seen;
+	};
+
+	afterEach( () => {
+		while ( unsubs.length ) {
+			unsubs.pop()?.();
+		}
+		clearHooksStub();
+	} );
+
+	test( 'publishes the canonical envelope on the per-type topic', () => {
+		const seen = capture( 'os.alltfo_form.changed' );
+
+		announceContentChange( 'alltfo_form', 'trashed', [ 12, 34 ], 'allterrain-forms' );
+
+		expect( seen ).toEqual( [
+			{ source: 'allterrain-forms', action: 'trashed', ids: [ 12, 34 ] },
+		] );
+	} );
+
+	test( 'a bare id is wrapped, and source defaults to empty', () => {
+		const seen = capture( 'os.page.changed' );
+
+		announceContentChange( 'page', 'untrashed', 7 );
+
+		expect( seen ).toEqual( [ { source: '', action: 'untrashed', ids: [ 7 ] } ] );
+	} );
+
+	test( 'invalid ids are dropped; nothing valid means no broadcast', () => {
+		const seen = capture( 'os.post.changed' );
+
+		announceContentChange( 'post', 'deleted', [ 0, -3, NaN ] );
+		announceContentChange( 'post', 'deleted', [] );
+		announceContentChange( '', 'deleted', [ 5 ] );
+
+		expect( seen ).toEqual( [] );
+
+		announceContentChange( 'post', 'deleted', [ 0, 5 ] );
+
+		expect( seen ).toEqual( [ { source: '', action: 'deleted', ids: [ 5 ] } ] );
+	} );
+} );

--- a/tests/vitest/desktop-files-trash-many.test.ts
+++ b/tests/vitest/desktop-files-trash-many.test.ts
@@ -44,6 +44,7 @@ const rest = {
 
 let toasts: Toast[] = [];
 let broadcasts: Array< { topic: string; payload: Record< string, unknown > } > = [];
+let broadcastListener: ( ( e: Event ) => void ) | null = null;
 
 async function load(): Promise< {
 	trash: TrashModule;
@@ -58,9 +59,23 @@ async function load(): Promise< {
 	const wp = ( window as unknown as { wp: Record< string, unknown > } ).wp;
 	wp.os = {
 		showToast: ( t: Toast ) => toasts.push( t ),
-		broadcast: ( topic: string, payload: Record< string, unknown > ) =>
-			broadcasts.push( { topic, payload } ),
 	};
+	// The trash module announces through the module-level bus (via
+	// `announceContentChange`), so observe the real `os-broadcast`
+	// CustomEvent rather than a `wp.os.broadcast` mock. One listener,
+	// re-armed per load.
+	if ( broadcastListener ) {
+		document.removeEventListener( 'os-broadcast', broadcastListener );
+	}
+	broadcastListener = ( e: Event ): void => {
+		const detail = (
+			e as CustomEvent< { topic: string; payload: Record< string, unknown > } >
+		 ).detail;
+		if ( detail ) {
+			broadcasts.push( { topic: detail.topic, payload: detail.payload } );
+		}
+	};
+	document.addEventListener( 'os-broadcast', broadcastListener );
 	const store = await import( '../../src/desktop-files/store' );
 	store.__resetFilesStoreForTests();
 	// `trash.ts` reads REST + the store through `layer-deps`; swapping

--- a/tests/vitest/notes-broadcast.test.ts
+++ b/tests/vitest/notes-broadcast.test.ts
@@ -4,6 +4,8 @@
  * still looked empty after one was trashed.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { subscribe } from '../../src/broadcast';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
 import { trashNoteWithUndo } from '../../src/notes/trash';
 import { NOTES_POST_TYPE, type Note } from '../../src/notes/types';
 import {
@@ -28,17 +30,28 @@ const NOTE: Note = {
 };
 
 describe( 'notes bin broadcast', () => {
-	let broadcast: ReturnType< typeof vi.fn >;
+	// Observed on the real bus, not a `wp.os` mock: the notes module
+	// publishes through the shared `announceContentChange()` helper,
+	// which rides the module-level broadcast directly.
+	let published: Array< Record< string, unknown > >;
+	let unsubscribe: () => void;
 	let undoAction: ( () => void ) | null;
 
 	beforeEach( () => {
+		installHooksStub();
 		__resetNotesRestForTests();
 		installNotesRestDeps( { baseUrl: 'https://example.test/notes', nonce: 'n' } );
-		broadcast = vi.fn();
+		published = [];
+		unsubscribe = subscribe( `os.${ NOTES_POST_TYPE }.changed`, ( payload ) => {
+			published.push( payload as Record< string, unknown > );
+		} );
 		undoAction = null;
-		( window as unknown as { wp: { os: Record< string, unknown > } } ).wp = {
+		// Merge, never assign: `installHooksStub()` above parked
+		// `wp.hooks` on the same global, and the real bus reads it.
+		const w = window as unknown as { wp?: Record< string, unknown > };
+		w.wp = {
+			...( w.wp ?? {} ),
 			os: {
-				broadcast,
 				showToast: ( opts: { action?: { onClick: () => void } } ) => {
 					undoAction = opts.action?.onClick ?? null;
 				},
@@ -55,25 +68,25 @@ describe( 'notes bin broadcast', () => {
 	} );
 
 	afterEach( () => {
+		unsubscribe();
 		vi.unstubAllGlobals();
+		clearHooksStub();
 		delete ( window as unknown as { wp?: unknown } ).wp;
 	} );
 
 	test( 'trashing publishes a trashed delta the bin can count', async () => {
 		await trashNoteWithUndo( NOTE, { onEvict: () => undefined, onRestore: () => undefined } );
-		expect( broadcast ).toHaveBeenCalledWith(
-			`os.${ NOTES_POST_TYPE }.changed`,
+		expect( published ).toContainEqual(
 			expect.objectContaining( { action: 'trashed', ids: [ 7 ] } ),
 		);
 	} );
 
 	test( 'Undo publishes the matching untrashed delta', async () => {
 		await trashNoteWithUndo( NOTE, { onEvict: () => undefined, onRestore: () => undefined } );
-		broadcast.mockClear();
+		published.length = 0;
 		undoAction?.();
 		await new Promise( ( r ) => setTimeout( r, 10 ) );
-		expect( broadcast ).toHaveBeenCalledWith(
-			`os.${ NOTES_POST_TYPE }.changed`,
+		expect( published ).toContainEqual(
 			expect.objectContaining( { action: 'untrashed', ids: [ 7 ] } ),
 		);
 	} );
@@ -85,7 +98,7 @@ describe( 'notes bin broadcast', () => {
 		);
 		vi.spyOn( console, 'error' ).mockImplementation( () => undefined );
 		await trashNoteWithUndo( NOTE, { onEvict: () => undefined, onRestore: () => undefined } );
-		expect( broadcast ).not.toHaveBeenCalled();
+		expect( published ).toEqual( [] );
 	} );
 
 	test( 'the topic matches the slug the bin config ships', () => {

--- a/tests/vitest/notes-convert.test.ts
+++ b/tests/vitest/notes-convert.test.ts
@@ -15,6 +15,7 @@ vi.mock( '../../src/notes/rest', () => ( {
 } ) );
 
 // Imported after the mock is registered.
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
 import { convertNoteToPost } from '../../src/notes/convert';
 
 const NOTE: Note = {
@@ -40,13 +41,18 @@ describe( 'convertNoteToPost', () => {
 	let getById: ReturnType< typeof vi.fn >;
 
 	beforeEach( () => {
+		installHooksStub();
 		convertNoteMock.mockReset();
 		restoreNoteMock.mockReset();
 		showToast = vi.fn();
 		openWindow = vi.fn();
 		closeWindow = vi.fn();
 		getById = vi.fn( () => ( { close: closeWindow } ) );
-		( window as unknown as { wp: unknown } ).wp = {
+		// Merge, never assign: `installHooksStub()` above parked
+		// `wp.hooks` on the same global, and the real bus reads it.
+		const w = window as unknown as { wp?: Record< string, unknown > };
+		w.wp = {
+			...( w.wp ?? {} ),
 			os: {
 				showToast,
 				deriveWindowId: ( url: string ) => `win:${ url }`,
@@ -56,6 +62,7 @@ describe( 'convertNoteToPost', () => {
 	} );
 
 	afterEach( () => {
+		clearHooksStub();
 		delete ( window as unknown as { wp?: unknown } ).wp;
 	} );
 


### PR DESCRIPTION
Since bundles went lazy (#613), openstation_enqueue_assets() harvests every native window's wp_localize_script data into the shell payload at admin_enqueue_scripts priority 10. The recycle bin and the games window still attached their config at priority 30 — fine for as long as their bundles were enqueued eagerly and WordPress printed the data at print time, but on the lazy path the payload had already shipped without it. The visible failure: the Trash window opens, lists nothing, and logs "openStationRecycleBinConfig is missing".

Both localizers move to priority 5, alongside the native-window data attach, and a new test pins the contract for every module that localizes config onto a lazy window handle: attach before the harvest, or your bundle boots blind.


Claude-Session: https://claude.ai/code/session_0119U4sRRWGcTQdwYreTwpAp

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-656-6088a33ed0485f3fb7239ff1a1518cf0210214fe.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->