### PR TITLE
Unfocus effects: split view is not "behind"

### DIFF
--- a/docs/examples/custom-unfocus-effect.md
+++ b/docs/examples/custom-unfocus-effect.md
@@ -12,11 +12,23 @@ public hook a plugin would use. This page shows a plugin adding its own.
 ## How it works
 
 The framework owns *when* the chosen effect runs — it watches focus
-changes, the user's selection, and excludes minimized windows — and
-toggles your effect on every unfocused window's root element
-(`.os-window`). Your def owns *what* the effect is: either a
-CSS class to toggle (the cheap path) or `apply`/`clear` callbacks for
-anything a static class can't express.
+changes, the user's selection, and window state — and toggles your
+effect on every unfocused window's root element (`.os-window`). Your
+def owns *what* the effect is: either a CSS class to toggle (the cheap
+path) or `apply`/`clear` callbacks for anything a static class can't
+express.
+
+Three kinds of window are exempt, whatever effect is selected:
+
+- **Minimized windows** — nothing is on screen to treat.
+- **Split-view tiles** (`snapped-left` / `snapped-right`) — snapping is
+  the "work on these side by side" gesture, so the half that doesn't
+  hold focus stays untouched. The exemption is per-window and
+  partner-blind: a tile is exempt whether or not the opposite half is
+  filled.
+- **Windows hosting a `<canvas>` in the parent document** — a CSS
+  `filter` over a live WebGL surface can cost the context, which would
+  crash the native Pixi scenes.
 
 The user picks among registered effects (plus a "None" option) in
 OpenStation Preferences; the choice persists per-user as the `unfocusEffect`

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -2998,7 +2998,7 @@ Remove a title-bar button by id, or read a snapshot of every registered button d
 
 ### `registerUnfocusEffect( def )` — Experimental
 
-Register a visual treatment applied to every window that **isn't** focused — surfaced in **OpenStation Preferences → Effects → "Unfocused windows"**. The built-in effects (`darken` dims, `frost` blurs to frosted glass, `grayscale` drains colour) are registered through this same hook; plugins add their own the identical way. The framework owns *when* the effect runs (focus changes, the user's selection, minimized-window exclusion); your def owns *what* it does.
+Register a visual treatment applied to every window that **isn't** focused — surfaced in **OpenStation Preferences → Effects → "Unfocused windows"**. The built-in effects (`darken` dims, `frost` blurs to frosted glass, `grayscale` drains colour) are registered through this same hook; plugins add their own the identical way. The framework owns *when* the effect runs (focus changes, the user's selection, and the exclusions below); your def owns *what* it does. Exempt, whatever effect is selected: **minimized** windows, **split-view tiles** (`snapped-left` / `snapped-right` — the half that doesn't hold focus stays untouched so both sides of a split stay workable; the exemption is partner-blind, a tile qualifies whether or not the opposite half is filled), and windows hosting a `<canvas>` in the parent document (filtering a live WebGL surface can cost its context).
 
 **Throws** a `RegistrationError` on validation failure (bad/missing `id`, the reserved id `'none'`, or neither `className` nor `apply` provided).
 

--- a/src/effects/unfocus-engine.ts
+++ b/src/effects/unfocus-engine.ts
@@ -24,6 +24,7 @@ import {
 } from './registry';
 import type { UnfocusEffectDef } from './types';
 import type { OsSettings } from '../settings';
+import type { Window as DesktopWindow } from '../window';
 import type { WindowManager } from '../window-manager';
 
 /** Data attribute stamped on a window root carrying the active effect id. */
@@ -60,6 +61,28 @@ let _started = false;
  */
 function hostsCanvas( el: HTMLElement ): boolean {
 	return el.querySelector( 'canvas' ) !== null;
+}
+
+/**
+ * True when the window is a half-screen split tile (`snapped-left` /
+ * `snapped-right`). Split view is exempt from unfocus effects.
+ *
+ * Snapping a window to an edge is the gesture that says "I want to
+ * work on these side by side" — the shell even follows it with the
+ * split-overview picker for the opposite half. Darkening, frosting or
+ * draining the colour out of one half of that arrangement defeats the
+ * whole point: only one tile can hold focus, so the other would sit
+ * permanently degraded while the user reads it. The effect is for
+ * windows that are *behind* the one you're working in, not beside it.
+ *
+ * The rule is deliberately per-window and partner-blind — a tile is
+ * exempt whether or not the opposite half is filled. That matches how
+ * `window-links` treats snapped windows (a half-screen tile is "in
+ * split view", full stop), and it keeps the exemption from flickering
+ * as the partner opens, closes or un-snaps.
+ */
+function isSplitTile( win: DesktopWindow ): boolean {
+	return win.state === 'snapped-left' || win.state === 'snapped-right';
 }
 
 export interface UnfocusEngineDeps {
@@ -144,6 +167,11 @@ export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps )
 			if ( ! def || win.isFocused() || win.state === 'minimized' ) {
 				continue;
 			}
+			// Split view is a "work on both at once" arrangement —
+			// never degrade the half that doesn't hold focus.
+			if ( isSplitTile( win ) ) {
+				continue;
+			}
 			// Never paint an unfocus effect over a window that hosts a
 			// WebGL `<canvas>` — the native Pixi scenes (content graph,
 			// posts mind-map / tag-cloud). A CSS `filter`
@@ -171,6 +199,19 @@ export function startUnfocusEngine( { manager, osSettings }: UnfocusEngineDeps )
 	] ) {
 		document.addEventListener( name, () => recompute() );
 	}
+
+	// Snapping into (or out of) split view changes a window's
+	// exemption without changing which window has focus — restoring a
+	// snapped tile back to `normal` while another window holds focus
+	// has to re-apply the effect, and snapping an already-unfocused
+	// window has to drop it. `os-window-changed` is chatty (it also
+	// carries every move and resize), so only the `state` reason
+	// reaches `recompute`.
+	document.addEventListener( 'os-window-changed', ( e: Event ) => {
+		if ( ( e as CustomEvent< { reason?: string } > ).detail?.reason === 'state' ) {
+			recompute();
+		}
+	} );
 
 	osSettings.subscribeOsSettings( ( snapshot ) => {
 		currentId = snapshot.unfocusEffect;

--- a/tests/vitest/unfocus-engine.test.ts
+++ b/tests/vitest/unfocus-engine.test.ts
@@ -141,6 +141,100 @@ describe( 'effects/unfocus-engine.ts', () => {
 		);
 	} );
 
+	test( 'does not apply to windows in split view', async () => {
+		const { engine } = await loadModules();
+		// Split view: two half-screen tiles, one focused. The user is
+		// working on both at once — the unfocused half must stay
+		// legible.
+		const left = makeWin( 'left', true, 'snapped-left' );
+		const right = makeWin( 'right', false, 'snapped-right' );
+		const floating = makeWin( 'floating', false );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ left, right, floating ] ),
+			osSettings,
+		} );
+
+		expect( right.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			false,
+		);
+		expect(
+			right.element.hasAttribute( 'data-desktop-unfocus-effect' ),
+		).toBe( false );
+		// A window that is merely behind the pair still gets the effect.
+		expect( floating.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			true,
+		);
+	} );
+
+	test( 'a half-screen tile is exempt even with the opposite half empty', async () => {
+		const { engine } = await loadModules();
+		const snapped = makeWin( 'snapped', false, 'snapped-left' );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ makeWin( 'a', true ), snapped ] ),
+			osSettings,
+		} );
+
+		expect( snapped.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			false,
+		);
+	} );
+
+	test( 'recomputes on a state change (un-snapping restores the effect)', async () => {
+		const { engine } = await loadModules();
+		const snapped = makeWin( 'b', false, 'snapped-right' );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( {
+			manager: makeManager( [ makeWin( 'a', true ), snapped ] ),
+			osSettings,
+		} );
+		expect( snapped.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			false,
+		);
+
+		// Dragged out of split view while another window holds focus:
+		// no focus event fires, only `os-window-changed`.
+		snapped.state = 'normal';
+		document.dispatchEvent(
+			new CustomEvent( 'os-window-changed', {
+				detail: { windowId: 'b', reason: 'state', state: 'normal' },
+			} ),
+		);
+
+		expect( snapped.element.classList.contains( DARKEN_CLASS ) ).toBe(
+			true,
+		);
+	} );
+
+	test( 'ignores the chatty geometry reasons on os-window-changed', async () => {
+		const { engine } = await loadModules();
+		const b = makeWin( 'b', false );
+		const manager = makeManager( [ makeWin( 'a', true ), b ] );
+		const getAll = vi.spyOn( manager, 'getAll' );
+		const { osSettings } = makeOsSettings( 'darken' );
+
+		engine.startUnfocusEngine( { manager, osSettings } );
+		const afterBoot = getAll.mock.calls.length;
+
+		document.dispatchEvent(
+			new CustomEvent( 'os-window-changed', {
+				detail: { windowId: 'b', reason: 'moved' },
+			} ),
+		);
+		document.dispatchEvent(
+			new CustomEvent( 'os-window-changed', {
+				detail: { windowId: 'b', reason: 'resized' },
+			} ),
+		);
+
+		expect( getAll.mock.calls.length ).toBe( afterBoot );
+		getAll.mockRestore();
+	} );
+
 	test( 'clears the effect when the setting switches to "none"', async () => {
 		const { engine } = await loadModules();
 		const unfocused = makeWin( 'b', false );


### PR DESCRIPTION
Snapping a window to an edge is the gesture that says *"I want to work on these side by side"* — the shell even follows it with the split overview so the user can fill the opposite half. But only one tile can hold focus, so the other sat permanently darkened, frosted or drained of colour while the user was reading it. The unfocus effect is for windows that are *behind* the one you're working in, not *beside* it.

## What changed

`src/effects/unfocus-engine.ts`:

1. **Half-screen tiles are exempt.** `snapped-left` / `snapped-right` windows join minimized windows and WebGL-canvas hosts on the list of windows the engine never paints.
2. **The engine recomputes on state changes.** It now also listens to `os-window-changed` filtered to `reason === 'state'`. The exemption turns on state rather than focus, so without this trigger, dragging a tile out of split view while the other half holds focus fires no focus event and the window would keep its exemption for as long as it stayed unfocused. The chatty reasons that event also carries — every move, every resize — are filtered out rather than recomputed against.

The rule is deliberately **partner-blind**: a tile qualifies whether or not the opposite half is filled. That is how `src/window-links/render-host.ts` already reads a snapped window ("in split view, full stop"), and it keeps the exemption from flickering as the partner opens, closes or un-snaps.

## Tests

Four new cases in `tests/vitest/unfocus-engine.test.ts`: the split pair stays clean while a window behind it still darkens; a lone tile is exempt; un-snapping restores the effect through the state event; `moved` / `resized` do not trigger a recompute.

`npm run lint`, `npm run typecheck`, `npm run test:js` (4842 passing) and `npm run build` are green. No PHP touched.

## Docs

`docs/javascript-reference.md` (`registerUnfocusEffect`) and `docs/examples/custom-unfocus-effect.md` now list all three exemptions rather than only the minimized one — plugin-registered effects are governed by the same engine, so the exclusion set is part of their contract.

## Manual QA

1. OpenStation Preferences → Effects → set "Unfocused windows" to **Frost**.
2. Open two windows, drag one to the left edge until the snap preview appears, release, then pick the second from the split overview.
3. Click back and forth between the halves — neither frosts.
4. Open a third floating window on top and click it: both tiles stay clean, but a fourth floating unfocused window still frosts.
5. Drag one tile out of split view by its title bar while the other half is focused — it picks the effect back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-657-ddaca88a1a3083ab9a255a15cb37602e49df1ded.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->