### PR TITLE
Menu-refresh probe: attach script data before the payload harvest

### DIFF
--- a/includes/my-wordpress/integrations/woocommerce.php
+++ b/includes/my-wordpress/integrations/woocommerce.php
@@ -1900,23 +1900,32 @@ add_action( 'rest_api_init', 'openstation_my_wordpress_woo_register_routes' );
 /**
  * Register the integration bundle.
  *
+ * Cache-busted by `filemtime`, like the window bundle it rides along
+ * with (see `openstation_my_wordpress_register_assets()`). The bundle
+ * is fetched lazily by URL, so a `ver` that only moves on release
+ * would let a browser's cached copy outlive builds within one — a
+ * stale companion against a fresh WP Explorer bundle is a contract
+ * drift no error message points at.
+ *
  * @return void
  */
 function openstation_my_wordpress_woo_register_assets() {
+	$js_path = OPENSTATION_DIR . 'assets/js/my-wordpress-woocommerce' . openstation_asset_suffix() . '.js';
 	wp_register_script(
 		'os-my-wordpress-woocommerce',
-		OPENSTATION_URL . 'assets/js/my-wordpress-woocommerce' . ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min' ) . '.js',
+		OPENSTATION_URL . 'assets/js/my-wordpress-woocommerce' . openstation_asset_suffix() . '.js',
 		array( 'wp-hooks' ),
-		OPENSTATION_VERSION,
+		file_exists( $js_path ) ? (string) filemtime( $js_path ) : OPENSTATION_VERSION,
 		true
 	);
 	wp_set_script_translations( 'os-my-wordpress-woocommerce', 'desktop-mode' );
 
+	$css_path = OPENSTATION_DIR . 'assets/css/my-wordpress-woocommerce.css';
 	wp_register_style(
 		'os-my-wordpress-woocommerce',
 		OPENSTATION_URL . 'assets/css/my-wordpress-woocommerce.css',
 		array( 'desktop-mode-my-wordpress' ),
-		OPENSTATION_VERSION
+		file_exists( $css_path ) ? (string) filemtime( $css_path ) : OPENSTATION_VERSION
 	);
 }
 add_action( 'init', 'openstation_my_wordpress_woo_register_assets', 5 );

--- a/includes/render/chromeless-bridge.php
+++ b/includes/render/chromeless-bridge.php
@@ -246,7 +246,7 @@ function openstation_emit_menu_refresh_probe() {
 		return;
 	}
 
-	$payload = openstation_build_menu_payload();
+	$payload = openstation_menu_refresh_probe_payload();
 	$encoded = wp_json_encode( $payload );
 	if ( false === $encoded ) {
 		return;
@@ -267,6 +267,55 @@ function openstation_emit_menu_refresh_probe() {
 	exit;
 }
 add_action( 'admin_init', 'openstation_emit_menu_refresh_probe', 99 );
+
+/**
+ * Build the menu payload the refresh probe emits, with the script
+ * data the harvest depends on attached first.
+ *
+ * `openstation_build_menu_payload()` harvests every lazy native
+ * window's handle-attached data — `wp_localize_script` blobs and
+ * `wp_add_inline_script` snippets — via
+ * `openstation_resolve_script_payload()`. Modules attach that data on
+ * `admin_enqueue_scripts` at priority ≤ 5 (the contract
+ * `Tests_OpenStation_LazyWindowConfigPriority` pins), which holds on
+ * every payload producer except this one: the probe short-circuits
+ * `admin.php` on `admin_init`, long before Core would fire the
+ * enqueue hook, so nothing was ever attached and the harvested
+ * entries shipped with empty `scriptBefore` / `scriptL10n` arrays.
+ *
+ * The shell refreshes its native-window index from every payload it
+ * receives, so one probe response silently downgraded windows the
+ * boot payload had delivered complete — the first lazy open of WP
+ * Explorer after a menu refresh found the WooCommerce companion with
+ * no `openStationWooConfig`, and the store's order bands and preview
+ * panels went dark with nothing in the console to say why.
+ *
+ * Replaying the hook here makes the probe's request faithful to the
+ * real admin page it stands in for. The output buffer guards the
+ * short-circuit response: an enqueue callback that echoes must not
+ * beat our `header()` calls. Enqueued handles are never printed —
+ * the probe exits before any print pipeline runs.
+ *
+ * @return array Menu payload, same shape as `openstation_build_menu_payload()`.
+ */
+function openstation_menu_refresh_probe_payload() {
+	if ( ! did_action( 'admin_enqueue_scripts' ) ) {
+		// `admin.php` calls `set_current_screen()` AFTER `admin_init`,
+		// so at probe time there is no screen yet — and Core's own
+		// enqueue callbacks (the block-editor script loader among
+		// them) read `get_current_screen()->id` unguarded. Build the
+		// screen the real flow would have had before the hook fires.
+		if ( function_exists( 'set_current_screen' ) && function_exists( 'get_current_screen' ) && ! get_current_screen() ) {
+			set_current_screen( 'admin' );
+		}
+		ob_start();
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- deliberate replay of Core's own hook so handle-attached script data exists before the harvest below.
+		do_action( 'admin_enqueue_scripts', 'admin.php' );
+		ob_end_clean();
+	}
+
+	return openstation_build_menu_payload();
+}
 
 /**
  * Outputs the chromeless screen-meta bridge script.

--- a/tests/phpunit/tests/nativeWindowLazyScript.php
+++ b/tests/phpunit/tests/nativeWindowLazyScript.php
@@ -393,4 +393,64 @@ class Tests_OpenStation_NativeWindowLazyScript extends WP_UnitTestCase {
 			wp_list_pluck( $entry['companionScripts'], 'scriptHandle' )
 		);
 	}
+
+	// --------------------------------------------------------------
+	// The menu-refresh probe's payload
+	// --------------------------------------------------------------
+
+	/**
+	 * The refresh probe emits the same payload shape as the boot
+	 * harvest, and the shell overwrites its native-window index with
+	 * whichever payload arrived last — so the probe's copy must carry
+	 * the handle-attached data too. The probe runs on `admin_init`,
+	 * before Core fires `admin_enqueue_scripts`, which is where every
+	 * module attaches that data (priority ≤ 5, the contract
+	 * `Tests_OpenStation_LazyWindowConfigPriority` pins). Without the
+	 * replay inside `openstation_menu_refresh_probe_payload()`, one
+	 * `wp.os.refreshMenu()` cycle downgraded every lazy window the
+	 * boot payload had delivered complete: WP Explorer's WooCommerce
+	 * companion lost `openStationWooConfig`, and the store's order
+	 * bands and preview panels went dark until a full reload.
+	 *
+	 * @covers ::openstation_menu_refresh_probe_payload
+	 */
+	public function test_probe_payload_carries_data_attached_on_admin_enqueue_scripts() {
+		$this->register_demo_script( 'demo-main', 'https://example.test/main.js' );
+		$this->register_demo_script( 'demo-extra', 'https://example.test/extra.js' );
+		$this->register_demo_window(
+			'demo-probe-window',
+			array(
+				'script'  => 'demo-main',
+				'scripts' => array( 'demo-extra' ),
+			)
+		);
+
+		// Attach config the way the in-tree modules do — on
+		// `admin_enqueue_scripts` at priority 5, which a bare
+		// `admin_init`-time payload build never fires.
+		add_action(
+			'admin_enqueue_scripts',
+			static function () {
+				wp_add_inline_script( 'demo-extra', 'window.demoProbeConfig={b:2};', 'before' );
+			},
+			5
+		);
+
+		$this->assertSame( 0, did_action( 'admin_enqueue_scripts' ) );
+
+		$payload = openstation_menu_refresh_probe_payload();
+
+		$entry = null;
+		foreach ( $payload['nativeWindows'] as $row ) {
+			if ( 'demo-probe-window' === $row['id'] ) {
+				$entry = $row;
+			}
+		}
+		$this->assertNotNull( $entry );
+		$this->assertCount( 1, $entry['companionScripts'] );
+		$this->assertSame(
+			array( 'window.demoProbeConfig={b:2};' ),
+			$entry['companionScripts'][0]['scriptBefore']
+		);
+	}
 }


### PR DESCRIPTION
## What broke

Since #613, WP Explorer's WooCommerce integration rides the Explorer window as a lazy **companion script**, delivered through the native-windows payload together with its `openStationWooConfig` inline blob (attached to the handle at `admin_enqueue_scripts` ≤ 5, harvested into the payload at 10 — the contract #656 pinned).

That chain holds for the boot payload and the admin-footer bridge — but not for the **menu-refresh probe**. `wp.os.refreshMenu()` (auto-fired on plugin activation/deactivation and on any `os-menu-signature` drift) spawns a hidden iframe whose handler short-circuits `admin.php` on **`admin_init` @ 99 — before Core ever fires `admin_enqueue_scripts`**. Nothing was ever attached, so the probe's payload shipped every window's companion with empty `scriptBefore` / `scriptL10n` arrays. The shell refreshes its native-window index from every payload it receives, so one menu refresh silently downgraded entries the boot payload had delivered complete.

The visible casualty: after any menu refresh, the first lazy open of WP Explorer loaded the Woo companion with no config — **order bands gone, merchant preview panels dark**, nothing in the console to say why. The recycle-bin and games configs were stripped from probe payloads the same way. Pre-#613 none of this mattered because the bundles and their config were printed eagerly at boot.

## The fix

- **`openstation_menu_refresh_probe_payload()`** (new, `chromeless-bridge.php`): the probe now replays `admin_enqueue_scripts` before building its payload — inside a discarded output buffer (an echoing callback must not beat the short-circuit's `header()` calls), with the current screen set first, because `admin.php` only calls `set_current_screen()` *after* `admin_init` and Core's own block-editor enqueue callbacks read `get_current_screen()->id` unguarded. Guarded by `did_action()`, so any request where Core fired the hook is a pure pass-through. Fixes Woo, recycle bin, games, and any third-party window following the documented attach-at-≤5 contract in one move — no new hook, no parallel contract.
- **Woo assets cache-bust by `filemtime`** like the Explorer assets they ride with. They're fetched lazily by URL, so a `ver` that only moves on release let a browser's cached copy outlive builds within one — stale-companion contract drift with no error pointing at it.

## Scope / risk

The replay lives only in the probe request — a throwaway hidden iframe that exits before any print pipeline runs. Enqueue callbacks it fires are the same ones every real admin page already runs; anything they echo is buffered and discarded. Worst case (a callback fataling in the unusual context) breaks only the probe, degrading to `refreshMenu()`'s pre-existing timeout path.

## Verification

- Regression test pins that the probe payload carries handle-attached inline data (`Tests_OpenStation_NativeWindowLazyScript`).
- Full PHPUnit suite green (2384 tests), `phpcs -n` clean, `npm run build` clean.
- Live before/after on a real store: the unpatched probe response contains neither `openStationWooConfig` nor `openStationRecycleBinConfig`; the patched one carries both, and the Explorer's Woo bands/previews survive a menu refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-659-a77b9f538cc97ce5d8a4dbe264f58dd668333183.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->