### PR TITLE
Virtual desktops: rename in place, and four overview fixes

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -1090,6 +1090,16 @@ body.os-has-fullscreen-window .os-shell {
 	margin: 0;
 }
 
+/*
+ * A liberated card is reparented to the desktop area, so the column's
+ * overview fade above no longer reaches it. Direct children only: a
+ * card inside a window body belongs to that window's thumbnail.
+ */
+.os-area--overview > .os-widgets__card--floating {
+	opacity: 0;
+	pointer-events: none;
+}
+
 .os-widgets__card--dragging,
 .os-widgets__card--resizing {
 	transition: none;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -1589,6 +1589,13 @@ body.os-active {
 	 */
 	--os-z-mio: 190;
 	/*
+	 * The desktop-name caption. Same reasoning as Mio, one step up:
+	 * above every window so a maximized Dashboard cannot hide it, and
+	 * above the companion, since a momentary message should not be
+	 * the thing that gets perched on. Still under the dock (200).
+	 */
+	--os-z-desktop-name: 195;
+	/*
 	 * The notch — on the desk, under the windows (100 + stack index),
 	 * above the window-link wires (50) so a tie never draws across the
 	 * pill. It hangs over the strip a window's title bar occupies, and

--- a/assets/css/window-overview.css
+++ b/assets/css/window-overview.css
@@ -384,8 +384,15 @@
 }
 
 .os-overview-top-bar__tile:hover {
-	border-color: rgba( 255, 255, 255, 0.4 );
 	background: rgba( 255, 255, 255, 0.08 );
+}
+
+/*
+ * Excluded because `:hover` (0,2,0) outranks `--active` (0,1,0) — an
+ * unguarded hover border replaces the active tile's accent ring.
+ */
+.os-overview-top-bar__tile:hover:not( .os-overview-top-bar__tile--active ) {
+	border-color: rgba( 255, 255, 255, 0.4 );
 }
 
 .os-overview-top-bar__tile:focus-visible {
@@ -435,10 +442,12 @@
 	display: inline-block;
 }
 
-.os-overview-top-bar__tile-close {
+/* Tile corner buttons: rename on the leading edge, close on the
+ * trailing one, otherwise identical. */
+.os-overview-top-bar__tile-close,
+.os-overview-top-bar__tile-rename {
 	position: absolute;
 	top: 4px;
-	inset-inline-end: 4px;
 	width: 18px;
 	height: 18px;
 	display: flex;
@@ -457,11 +466,21 @@
 	padding: 0;
 }
 
-.os-overview-top-bar__tile-wrapper:hover
-	.os-overview-top-bar__tile-close,
-.os-overview-top-bar__tile-wrapper:focus-within
-	.os-overview-top-bar__tile-close,
-.os-overview-top-bar__tile-close:focus-visible {
+.os-overview-top-bar__tile-rename {
+	inset-inline-start: 4px;
+}
+
+.os-overview-top-bar__tile-close {
+	inset-inline-end: 4px;
+}
+
+.os-overview-top-bar__tile-wrapper:is( :hover, :focus-within )
+	:is(
+		.os-overview-top-bar__tile-close,
+		.os-overview-top-bar__tile-rename
+	),
+.os-overview-top-bar__tile-close:focus-visible,
+.os-overview-top-bar__tile-rename:focus-visible {
 	opacity: 1;
 }
 
@@ -469,6 +488,27 @@
 	background: var( --os-ui-danger, #d63638 );
 	color: var( --os-ui-fg-on-accent, #fff );
 }
+
+.os-overview-top-bar__tile-rename:hover {
+	background: var( --os-ui-accent, #f252fc );
+	color: var( --os-ui-fg-on-accent, #fff );
+}
+
+/*
+ * The label while it is being edited. Neutral hairline, not the
+ * accent: the active tile already wears an accent ring, and a second
+ * one reads as a rendering fault. `outline: none` is safe — the
+ * element is only editable while focused, so its treatment IS the
+ * focus indicator.
+ */
+.os-overview-top-bar__tile-label[contenteditable] {
+	outline: none;
+	cursor: text;
+	background: rgba( 0, 0, 0, 0.55 );
+	border-radius: 6px;
+	box-shadow: inset 0 0 0 1px rgba( 255, 255, 255, 0.28 );
+}
+
 
 /*
  * Hide the close X when there's only one tile left — the tile

--- a/assets/css/window-states.css
+++ b/assets/css/window-states.css
@@ -330,7 +330,7 @@
 	top: 50%;
 	left: 50%;
 	transform: translate( -50%, -50% );
-	z-index: 3;
+	z-index: var( --os-z-desktop-name, 195 );
 	max-width: min( 70%, 520px );
 	padding: 14px 28px;
 	border-radius: 16px;

--- a/assets/css/window-states.css
+++ b/assets/css/window-states.css
@@ -321,6 +321,49 @@
 }
 
 /*
+ * Desktop-name HUD. `pointer-events: none` is required, not cosmetic:
+ * it sits over the wallpaper's click surface, which minimizes every
+ * window.
+ */
+.os-desktop-name-hud {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	z-index: 3;
+	max-width: min( 70%, 520px );
+	padding: 14px 28px;
+	border-radius: 16px;
+	font-size: 20px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	text-align: center;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: var( --os-ui-fg-on-accent, #fff );
+	background-color: var( --os-ui-scrim, rgba( 0, 0, 0, 0.32 ) );
+	backdrop-filter: blur( 18px ) saturate( 140% );
+	-webkit-backdrop-filter: blur( 18px ) saturate( 140% );
+	box-shadow:
+		0 8px 28px rgba( 0, 0, 0, 0.35 ),
+		inset 0 0 0 1px rgba( 255, 255, 255, 0.08 );
+	pointer-events: none;
+	opacity: 1;
+	transition: opacity 0.26s ease;
+}
+
+.os-desktop-name-hud--out {
+	opacity: 0;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.os-desktop-name-hud {
+		transition: none;
+	}
+}
+
+/*
  * Minimized state — fade + scale down.
  * Uses opacity + pointer-events instead of display: none so the
  * CSS transition can animate the change. The window is invisible

--- a/assets/desktop-themes/legacy/theme.json
+++ b/assets/desktop-themes/legacy/theme.json
@@ -161,6 +161,7 @@
 		"--os-window-shadow-focused": "0 12px 48px rgba( 0, 0, 0, 0.4 ), 0 4px 12px rgba( 0, 0, 0, 0.2 )",
 		"--os-z-adminbar": "9991",
 		"--os-z-base": "100",
+		"--os-z-desktop-name": "195",
 		"--os-z-dock": "200",
 		"--os-z-fullscreen": "99999",
 		"--os-z-mio": "190",

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1641,9 +1641,14 @@ manager.getPrimaryDesktopId(): string;     // see below
 manager.createDesktop(): Desktop;          // append a new one + return it
 manager.switchDesktop( id ): void;         // make `id` the active desktop
 manager.closeDesktop( id ): void;          // delete `id`; its windows migrate to the active desktop
+manager.renameDesktop( id, label ): boolean;  // relabel `id`; see below
 ```
 
-Lifecycle hooks fire on each operation: `HOOKS.DESKTOP_CREATED`, `HOOKS.DESKTOP_CLOSED { desktopId, migratedTo }`, `HOOKS.DESKTOP_SWITCHED { from, to }`.
+Lifecycle hooks fire on each operation: `HOOKS.DESKTOP_CREATED`, `HOOKS.DESKTOP_CLOSED { desktopId, migratedTo }`, `HOOKS.DESKTOP_SWITCHED { from, to }`, `HOOKS.DESKTOP_RENAMED { desktopId, label, previousLabel }`.
+
+`renameDesktop()` trims the label and caps it at **64 characters**, matching the session sanitizer, and returns `false` without firing the hook when the id is unknown or the name is blank or unchanged. It persists through the normal session save. Users reach it from the overview top bar: hovering a tile reveals a rename pencil beside the close ×, and clicking it edits in place (Enter commits, Escape reverts, blur commits).
+
+Switching desktops shows the new desktop's name over the desk for a beat (`.os-desktop-name-hud`), except when the switch is made from overview — the top bar there already labels every desktop.
 
 ##### Primary desktop — `getPrimaryDesktopId()`
 
@@ -4600,9 +4605,10 @@ Each user can have multiple desktops, each owning its own set of windows. Switch
 
 | Hook | Kind | Status | Payload |
 |---|---|---|---|
-| `os.desktop.created` | action | Stable | `{ desktopId }` — fires after a new desktop joins the registry |
-| `os.desktop.closed` | action | Stable | `{ desktopId, migratedTo }` — `migratedTo` is the desktop that received any orphaned windows |
-| `os.desktop.switched` | action | Stable | `{ from, to }` — the active desktop changed |
+| `os.os.created` | action | Stable | `{ desktopId }` — fires after a new desktop joins the registry |
+| `os.os.closed` | action | Stable | `{ desktopId, migratedTo }` — `migratedTo` is the desktop that received any orphaned windows |
+| `os.os.switched` | action | Stable | `{ from, to }` — the active desktop changed |
+| `os.os.renamed` | action | Stable | `{ desktopId, label, previousLabel }` — the user renamed a desktop |
 
 Closing the last remaining desktop is rejected silently (the shell needs at least one). Closing a desktop that has windows migrates them to the surviving desktop on its left (falling back to the right when the leftmost is closed) — no work is silently destroyed.
 

--- a/src/boot/shell-lifecycle.ts
+++ b/src/boot/shell-lifecycle.ts
@@ -29,6 +29,7 @@ export function wireSessionEvents( save: () => void ): void {
 	addAction( HOOKS.DESKTOP_CREATED, 'desktop-mode/session-save', save );
 	addAction( HOOKS.DESKTOP_CLOSED, 'desktop-mode/session-save', save );
 	addAction( HOOKS.DESKTOP_SWITCHED, 'desktop-mode/session-save', save );
+	addAction( HOOKS.DESKTOP_RENAMED, 'desktop-mode/session-save', save );
 }
 
 /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1220,6 +1220,8 @@ export const HOOKS = {
 	DESKTOP_CLOSED: 'os.os.closed',
 	/** Action, fires when the active desktop changes. Payload `{ from, to }`. */
 	DESKTOP_SWITCHED: 'os.os.switched',
+	/** Action, fires when a desktop is renamed. Payload `{ desktopId, label, previousLabel }`. */
+	DESKTOP_RENAMED: 'os.os.renamed',
 	/**
 	 * Filter. Returns the id of the "primary" desktop — the one the
 	 * shell treats as canonical for batch operations. Receives the

--- a/src/window-manager/desktop-name-hud.ts
+++ b/src/window-manager/desktop-name-hud.ts
@@ -1,0 +1,55 @@
+/**
+ * OpenStation — the caption naming the Space after a desktop switch.
+ *
+ * Not shown for a switch made from overview: the top bar there already
+ * labels every desktop, and the caption would land on the exit
+ * animation. `switchDesktop` calls this from its non-overview branch.
+ */
+
+const HOLD_MS = 900;
+
+/** Must match the CSS fade on `--out`. */
+const FADE_MS = 260;
+
+const CLS = 'os-desktop-name-hud';
+
+/** One caption, reused: arrow-key switching outruns the fade. */
+let hud: HTMLElement | null = null;
+let timer: number | null = null;
+
+/** Show `label` over `area` for a beat, then fade it out. */
+export function showDesktopNameHud( area: HTMLElement, label: string ): void {
+	if ( ! label.trim() ) {
+		return;
+	}
+	if ( timer !== null ) {
+		window.clearTimeout( timer );
+	}
+	if ( ! hud ) {
+		hud = document.createElement( 'div' );
+		hud.className = CLS;
+		// The only cue a screen-reader user gets that the switch landed.
+		hud.setAttribute( 'role', 'status' );
+	}
+	hud.textContent = label;
+	hud.classList.remove( `${ CLS }--out` );
+	area.appendChild( hud );
+
+	timer = window.setTimeout( () => {
+		hud?.classList.add( `${ CLS }--out` );
+		timer = window.setTimeout( () => {
+			hud?.remove();
+			timer = null;
+		}, FADE_MS ) as unknown as number;
+	}, HOLD_MS ) as unknown as number;
+}
+
+/** Drop the caption so `destroy()` leaves no timer on detached DOM. */
+export function destroyDesktopNameHud(): void {
+	if ( timer !== null ) {
+		window.clearTimeout( timer );
+		timer = null;
+	}
+	hud?.remove();
+	hud = null;
+}

--- a/src/window-manager/desktops.ts
+++ b/src/window-manager/desktops.ts
@@ -11,6 +11,7 @@ import { doAction, HOOKS } from '../hooks';
 import { __, sprintf } from '../i18n';
 import type { Desktop } from '../types';
 import type { Window } from '../window';
+import { showDesktopNameHud } from './desktop-name-hud';
 import { computeOverviewLayout } from './geometry';
 import {
 	createOverviewLabel,
@@ -88,6 +89,37 @@ export function createDesktop( mgr: WindowManager ): Desktop {
 	return desktop;
 }
 
+/** Mirrors the cap `includes/session.php` enforces on save. */
+export const DESKTOP_LABEL_MAX_LENGTH = 64;
+
+/**
+ * Rename a desktop. Trims and caps; ignores a blank or unchanged
+ * name. Returns whether the label actually changed, so callers can
+ * skip a repaint.
+ */
+export function renameDesktop(
+	mgr: WindowManager,
+	id: string,
+	label: string,
+): boolean {
+	const desktop = mgr._desktops.find( ( d ) => d.id === id );
+	if ( ! desktop ) {
+		return false;
+	}
+	const next = label.trim().slice( 0, DESKTOP_LABEL_MAX_LENGTH );
+	if ( ! next || next === desktop.label ) {
+		return false;
+	}
+	const previousLabel = desktop.label;
+	desktop.label = next;
+	doAction( HOOKS.DESKTOP_RENAMED, {
+		desktopId: id,
+		label: next,
+		previousLabel,
+	} );
+	return true;
+}
+
 /**
  * Switch the active desktop. No-op if `id` is already active or
  * doesn't exist. Fires `os.os.switched` with both the
@@ -163,6 +195,11 @@ export function switchDesktop(
 			);
 		if ( topOnNew ) {
 			mgr.focus( topOnNew );
+		}
+
+		const landed = mgr._desktops.find( ( d ) => d.id === id );
+		if ( landed ) {
+			showDesktopNameHud( mgr._desktop, landed.label );
 		}
 	}
 

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -47,6 +47,7 @@ import {
 	getActiveDesktop,
 	getActiveDesktopId,
 	getDesktops,
+	renameDesktop,
 	seedDesktops,
 	switchDesktop,
 	type SwitchDesktopOptions,
@@ -62,6 +63,7 @@ import {
 	commitSnapIfPending,
 	updateSnapZoneForDrag,
 } from './snap-zones';
+import { destroyDesktopNameHud } from './desktop-name-hud';
 import { cancelOverviewTimers, enterOverview, exitOverview } from './overview';
 import { loadNativeWindowGeometry } from './native-window-geometry';
 import { clampWindowPosition } from '../window/pointer';
@@ -1823,6 +1825,9 @@ export class WindowManager {
 	public closeDesktop( id: string ): void {
 		closeDesktop( this, id );
 	}
+	public renameDesktop( id: string, label: string ): boolean {
+		return renameDesktop( this, id, label );
+	}
 
 	/**
 	 * Returns the "primary" desktop id — the one new sessions land on
@@ -2081,6 +2086,7 @@ export class WindowManager {
 			exitOverview( this );
 		}
 		cancelOverviewTimers( this );
+		destroyDesktopNameHud();
 	}
 
 	/**

--- a/src/window-manager/overview.ts
+++ b/src/window-manager/overview.ts
@@ -20,7 +20,12 @@ import { osIconSvg } from '../ui/icons';
 import type { Desktop } from '../types';
 import { computeOverviewLayout, type OverviewLayoutItem } from './geometry';
 import { OVERVIEW_TOP_BAR_RESERVE } from './overview-constants';
-import { closeDesktop, createDesktop, switchDesktop } from './desktops';
+import {
+	closeDesktop,
+	createDesktop,
+	renameDesktop,
+	switchDesktop,
+} from './desktops';
 import type { Window } from '../window';
 import { updateFullscreenBodyClass } from '../window/dom';
 import type { WindowManager } from './index';
@@ -155,6 +160,8 @@ export function enterOverview( mgr: WindowManager ): void {
 	mgr._overviewActive = true;
 
 	doAction( HOOKS.OVERVIEW_ENTERING, {} );
+	// The dock only re-reads system-tile predicates when told to.
+	doAction( HOOKS.DOCK_REFRESH_ACTIVE, {} );
 
 	// Make background left admin bar and the Dock inert so Tab focus doesn't traverse them.
 	// We deliberately leave the top admin bar (wpadminbar) active and reachable.
@@ -598,7 +605,28 @@ function buildDesktopTile( mgr: WindowManager, d: Desktop ): HTMLElement {
 	tile.addEventListener( 'click', ( e: MouseEvent ) => {
 		e.preventDefault();
 		e.stopPropagation();
+		// A space typed into the label activates this <button> — the
+		// browser synthesises a click. That is a default action, so no
+		// `stopPropagation` upstream reaches it; the click has to be
+		// refused here.
+		if ( label.hasAttribute( 'contenteditable' ) ) {
+			return;
+		}
 		exitOverviewToDesktop( mgr, d.id );
+	} );
+
+	// Wrapper, not tile: a control nested in the tile's <button> is
+	// invalid markup and unclickable.
+	const renameBtn = document.createElement( 'button' );
+	renameBtn.type = 'button';
+	renameBtn.className = 'os-overview-top-bar__tile-rename';
+	// translators: %s is the desktop label
+	renameBtn.setAttribute( 'aria-label', sprintf( __( 'Rename %s' ), d.label ) );
+	renameBtn.innerHTML = osIconSvg( 'edit', { size: 14 } );
+	renameBtn.addEventListener( 'click', ( e: MouseEvent ) => {
+		e.preventDefault();
+		e.stopPropagation();
+		beginRename( mgr, label, d );
 	} );
 
 	// Close X — hidden via CSS when only one desktop exists, so users
@@ -621,9 +649,82 @@ function buildDesktopTile( mgr: WindowManager, d: Desktop ): HTMLElement {
 	} );
 
 	wrapper.appendChild( tile );
+	wrapper.appendChild( renameBtn );
 	wrapper.appendChild( closeBtn );
 
 	return wrapper;
+}
+
+/**
+ * Edit a tile's label in place. Enter commits, Escape reverts, blur
+ * commits.
+ *
+ * The label itself becomes editable rather than being covered by an
+ * `<input>`: an overlay has to be re-measured onto the label's box and
+ * font to keep the name from moving, and never matched exactly.
+ */
+function beginRename(
+	mgr: WindowManager,
+	label: HTMLElement,
+	d: Desktop,
+): void {
+	if ( label.hasAttribute( 'contenteditable' ) ) {
+		return;
+	}
+	// Attribute first: it is what the re-entry guard and `finish` read,
+	// and the IDL setter below is a silent no-op on some engines.
+	// `plaintext-only` keeps pasted markup out where supported.
+	label.setAttribute( 'contenteditable', 'true' );
+	try {
+		label.contentEditable = 'plaintext-only';
+	} catch {
+		/* `true` stands. */
+	}
+	label.spellcheck = false;
+	label.focus();
+
+	const view = label.ownerDocument.defaultView;
+	const range = label.ownerDocument.createRange();
+	range.selectNodeContents( label );
+	const selection = view?.getSelection();
+	selection?.removeAllRanges();
+	selection?.addRange( range );
+
+	let settled = false;
+	const finish = ( commit: boolean ): void => {
+		if ( settled ) {
+			return;
+		}
+		settled = true;
+		label.removeAttribute( 'contenteditable' );
+		if ( commit ) {
+			renameDesktop( mgr, d.id, label.textContent ?? '' );
+		}
+		// Rebuild to restore the label from data, repaint the
+		// aria-labels that embed the name, and drop these listeners
+		// with the element. Not while closing: blur lands mid-teardown,
+		// and replacing the bar there throws out of the exit finaliser.
+		if ( mgr._overviewActive ) {
+			refreshOverviewTopBar( mgr );
+		}
+	};
+
+	label.addEventListener( 'keydown', ( e: KeyboardEvent ) => {
+		// Overview reads Escape as "leave" and Enter as "commit the
+		// cursor", both mid-edit. The shell's other bare-key shortcuts
+		// listen in the capture phase, where this cannot reach them —
+		// they guard themselves with `isTextEntryFocus`, which covers
+		// contenteditable.
+		e.stopPropagation();
+		if ( e.key === 'Enter' || e.key === 'Escape' ) {
+			e.preventDefault();
+			finish( e.key === 'Enter' );
+		}
+	} );
+	label.addEventListener( 'blur', () => finish( true ) );
+	// Clicking to place the caret must not reach the tile beneath,
+	// which switches desktops.
+	label.addEventListener( 'click', ( e: MouseEvent ) => e.stopPropagation() );
 }
 
 /**
@@ -736,6 +837,10 @@ export function exitOverview(
 		windowId: selected ? selected.id : undefined,
 		reason: selected ? 'select' : 'cancel',
 	} );
+	// Must fire AFTER the flag drops: an exit via desktop switch has
+	// already refreshed the dock from `switchDesktop`, while overview
+	// was still active, leaving the dot lit on a closed overview.
+	doAction( HOOKS.DOCK_REFRESH_ACTIVE, {} );
 
 	// Remove area + shell classes AT T=0 so the backdrop fades and
 	// the dock slides back in IN PARALLEL with the windows animating

--- a/tests/phpunit/tests/desktopThemesLegacy.php
+++ b/tests/phpunit/tests/desktopThemesLegacy.php
@@ -186,7 +186,7 @@ class Tests_OpenStation_DesktopThemesLegacy extends WP_UnitTestCase {
 		$tokens = $this->manifest()['tokens'];
 		$why    = 'Legacy is a frozen snapshot — mint a new theme instead of moving it.';
 
-		$this->assertCount( 464, $tokens, $why );
+		$this->assertCount( 465, $tokens, $why );
 		foreach ( array(
 			'--os-bg'             => 'linear-gradient( 135deg, #1d2327 0%, #2c3338 50%, #1d2327 100% )',
 			'--os-titlebar-bg'    => '#f0f0f1',

--- a/tests/vitest/desktop-rename.test.ts
+++ b/tests/vitest/desktop-rename.test.ts
@@ -11,7 +11,14 @@ import {
 	DESKTOP_LABEL_MAX_LENGTH,
 	renameDesktop,
 } from '../../src/window-manager/desktops';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+const tokens = readFileSync(
+	resolve( __dirname, '../..', 'assets/css/variables.css' ),
+	'utf8',
+);
 
 describe( 'virtual desktops — overview tiles', () => {
 	let desktopArea: HTMLElement;
@@ -147,6 +154,18 @@ describe( 'virtual desktops — overview tiles', () => {
 
 		manager.switchDesktop( second.id );
 		expect( hud()?.textContent ).toBe( 'Writing' );
+
+		// Windows run from `--os-z-base` (100) upward, so the caption
+		// has to clear them or a maximized Dashboard hides it.
+		const layer = ( name: string ): number =>
+			Number( new RegExp( `--${ name }:\\s*(\\d+)` ).exec( tokens )![ 1 ] );
+		expect( layer( 'os-z-desktop-name' ) ).toBeGreaterThan(
+			layer( 'os-z-base' ),
+		);
+		// …and stays under the dock, so it never covers navigation.
+		expect( layer( 'os-z-desktop-name' ) ).toBeLessThan(
+			layer( 'os-z-dock' ),
+		);
 
 		hud()!.remove();
 		manager.enterOverview();

--- a/tests/vitest/desktop-rename.test.ts
+++ b/tests/vitest/desktop-rename.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Overview's desktop tiles: renaming, the caption shown after a
+ * switch, and the dock tile's active dot.
+ *
+ * @group desktops
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { Dock, type SystemDockItem } from '../../src/dock';
+import { WindowManager } from '../../src/window-manager';
+import {
+	DESKTOP_LABEL_MAX_LENGTH,
+	renameDesktop,
+} from '../../src/window-manager/desktops';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+
+describe( 'virtual desktops — overview tiles', () => {
+	let desktopArea: HTMLElement;
+	let dockEl: HTMLElement;
+	let manager: WindowManager;
+
+	beforeEach( () => {
+		installHooksStub();
+		desktopArea = document.createElement( 'div' );
+		Object.defineProperty( desktopArea, 'getBoundingClientRect', {
+			value: () => ( { top: 0, left: 0, width: 1600, height: 900 } ) as DOMRect,
+		} );
+		document.body.appendChild( desktopArea );
+		manager = new WindowManager( desktopArea );
+
+		dockEl = document.createElement( 'nav' );
+		document.body.appendChild( dockEl );
+		// Mirrors the Overview tile's registration in `desktop.ts`.
+		const overview: SystemDockItem = {
+			id: 'os-overview',
+			title: 'Overview',
+			icon: 'dashicons-screenoptions',
+			navKind: 'control',
+			isOpen: () => manager._overviewActive,
+			onOpen: () =>
+				manager._overviewActive
+					? manager.exitOverview()
+					: manager.enterOverview(),
+		};
+		new Dock( dockEl, manager, [], '/wp-admin/', 'bottom' ).appendSystemItem(
+			overview,
+		);
+	} );
+
+	afterEach( () => {
+		manager.destroy();
+		clearHooksStub();
+		document.body.innerHTML = '';
+	} );
+
+	/** First tile's `<part>` in the live top bar. */
+	const part = < T extends HTMLElement >( name: string ): T | null =>
+		manager._overviewTopBar!.querySelector< T >(
+			`.os-overview-top-bar__tile-${ name }`,
+		);
+	const renameButton = () => part( 'rename' )!;
+	const labelEl = () => part( 'label' )!;
+	const editing = (): boolean => labelEl().hasAttribute( 'contenteditable' );
+	const press = ( key: string ): void => {
+		labelEl().dispatchEvent(
+			new KeyboardEvent( 'keydown', { key, bubbles: true } ),
+		);
+	};
+
+	// Capped client-side rather than left to the server: a name that
+	// looked accepted and came back shortened on reload reads as data
+	// loss. 64 mirrors `includes/session.php`.
+	test( 'renameDesktop trims, caps, and rejects blank / unknown', () => {
+		expect( renameDesktop( manager, 'desktop-1', '  Writing  ' ) ).toBe( true );
+		expect( manager.getDesktops()[ 0 ].label ).toBe( 'Writing' );
+
+		renameDesktop( manager, 'desktop-1', 'x'.repeat( 200 ) );
+		expect( manager.getDesktops()[ 0 ].label ).toHaveLength(
+			DESKTOP_LABEL_MAX_LENGTH,
+		);
+
+		expect( renameDesktop( manager, 'desktop-1', '  ' ) ).toBe( false );
+		expect( renameDesktop( manager, 'nope', 'Writing' ) ).toBe( false );
+	} );
+
+	test( 'Enter commits, Escape reverts, and neither exits overview', () => {
+		manager.enterOverview();
+
+		renameButton().click();
+		expect( editing() ).toBe( true );
+		labelEl().textContent = 'Writing';
+		press( 'Enter' );
+
+		expect( manager.getDesktops()[ 0 ].label ).toBe( 'Writing' );
+		expect( labelEl().textContent ).toBe( 'Writing' );
+		expect( editing() ).toBe( false );
+		// Overview's own document-level handler reads Enter as "commit
+		// the cursor" and Escape as "leave overview"; both would tear
+		// the surface down mid-edit.
+		expect( manager._overviewActive ).toBe( true );
+
+		renameButton().click();
+		labelEl().textContent = 'Discarded';
+		press( 'Escape' );
+
+		// Rebuilt from data, so an abandoned edit leaves no trace.
+		expect( manager.getDesktops()[ 0 ].label ).toBe( 'Writing' );
+		expect( labelEl().textContent ).toBe( 'Writing' );
+		expect( manager._overviewActive ).toBe( true );
+	} );
+
+	// Typing a space into the label activates the tile <button> — the
+	// browser synthesises a click on it. That is a default action, not
+	// a listener, so it survives every `stopPropagation` upstream and
+	// used to switch desktop and close overview mid-rename.
+	test( 'a click synthesised while editing does not switch desktop', () => {
+		const second = manager.createDesktop();
+		manager.switchDesktop( second.id );
+		manager.enterOverview();
+
+		// Edit the FIRST tile's label; the space activates the button
+		// that contains it, so the click lands on that same tile.
+		const firstTile = (): HTMLElement =>
+			manager._overviewTopBar!.querySelector< HTMLElement >(
+				'.os-overview-top-bar__tile',
+			)!;
+		renameButton().click();
+		expect( editing() ).toBe( true );
+		// The pencil itself must not reach the tile beneath it either.
+		expect( manager.getActiveDesktopId() ).toBe( second.id );
+
+		firstTile().click();
+
+		expect( manager._overviewActive ).toBe( true );
+		expect( manager.getActiveDesktopId() ).toBe( second.id );
+
+		// Still switches once the edit is over.
+		press( 'Escape' );
+		firstTile().click();
+		expect( manager.getActiveDesktopId() ).toBe( 'desktop-1' );
+	} );
+
+	test( 'the caption names the desk, but not from overview', () => {
+		const second = manager.createDesktop();
+		renameDesktop( manager, second.id, 'Writing' );
+		const hud = (): HTMLElement | null =>
+			desktopArea.querySelector( '.os-desktop-name-hud' );
+
+		manager.switchDesktop( second.id );
+		expect( hud()?.textContent ).toBe( 'Writing' );
+
+		hud()!.remove();
+		manager.enterOverview();
+		manager.switchDesktop( 'desktop-1' );
+		// The top bar already labels every desktop there.
+		expect( hud() ).toBeNull();
+	} );
+
+	// The dock only repaints system-tile predicates when told to, and
+	// overview enter / exit never told it — so the dot was dark while
+	// overview was open, and latched ON after "+ add desktop", which
+	// refreshes the dock from `switchDesktop` one step before the flag
+	// drops.
+	test( 'the dock tile lights while overview is open, clears on exit', () => {
+		const tile = dockEl.querySelector< HTMLElement >(
+			'[data-system-id="os-overview"]',
+		)!;
+		const dot = (): boolean =>
+			tile.classList.contains( 'os-dock__item--active' );
+		const clickDockTile = (): void =>
+			tile.querySelector< HTMLElement >( 'button, a' )!.click();
+
+		clickDockTile();
+		expect( dot() ).toBe( true );
+
+		clickDockTile();
+		expect( dot() ).toBe( false );
+
+		clickDockTile();
+		document
+			.querySelector< HTMLElement >( '.os-overview-top-bar__tile--add' )!
+			.click();
+
+		expect( manager.getDesktops() ).toHaveLength( 2 );
+		expect( manager._overviewActive ).toBe( false );
+		expect( dot() ).toBe( false );
+	} );
+} );

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -941,7 +941,7 @@ describe( 'WindowManager — virtual desktops', async () => {
 		// inside it, making it unreachable by Tab. Fix: wrap the tile <button>
 		// and a sibling close <button> in a <div> wrapper so both are independently
 		// focusable. The "+" create-tile stays as a direct child (no close X).
-		test( 'each desktop tile has a wrapper with two sibling buttons', async () => {
+		test( 'each desktop tile has a wrapper with three sibling buttons', async () => {
 			const extraDesktops = [ manager.createDesktop(), manager.createDesktop() ];
 			try {
 				await manager.open( openConfig( 'a' ) );
@@ -954,22 +954,18 @@ describe( 'WindowManager — virtual desktops', async () => {
 				// 3 desktops = 3 wrappers (the "+" tile is a direct child, not wrapped)
 				expect( wrappers ).toHaveLength( 3 );
 
+				// Tile, rename pencil, close X — the latter two are
+				// SIBLINGS of the tile, which is itself a <button>.
 				for ( const wrapper of wrappers ) {
-					const buttons = wrapper.querySelectorAll( 'button' );
-					expect( buttons ).toHaveLength( 2 );
-
-					const tile = buttons[ 0 ];
 					expect(
-						tile.classList.contains( 'os-overview-top-bar__tile' ),
-					).toBe( true );
-
-					const close = buttons[ 1 ];
-					expect(
-						close.classList.contains(
-							'os-overview-top-bar__tile-close',
+						Array.from( wrapper.querySelectorAll( 'button' ) ).map(
+							( b ) => b.classList[ 0 ],
 						),
-					).toBe( true );
-					expect( close.tagName ).toBe( 'BUTTON' );
+					).toEqual( [
+						'os-overview-top-bar__tile',
+						'os-overview-top-bar__tile-rename',
+						'os-overview-top-bar__tile-close',
+					] );
 				}
 			} finally {
 				for ( const d of extraDesktops ) {


### PR DESCRIPTION
## What

Adds renaming for virtual desktops. Hovering a tile in the overview top bar reveals a rename pencil next to the close X, and clicking it edits the name in place.

Shows the name of a desktop over the desk for a moment after switching to it.

Fixes four bugs in the same surface:

- The Overview dock icon's active dot was inverted. It was off while overview was open, and stayed on after closing it.
- A widget dragged out of the widget column stayed visible during overview.
- Hovering the current desktop's tile replaced its accent border with a grey one.
- Typing a space into a desktop name closed overview.

## Why

Desktops are auto-numbered (`Desktop 1`, `Desktop 2`). Past three or four the numbers stop telling you which is which, and the overview top bar is where you look to find out.

The four bugs turned up while working on the tiles.

## Testing instructions

Enable OpenStation and open the desktop. Open two or three windows first so the overview grid is not empty.

### Overview dock icon

1. Click the Overview icon in the dock. Make sure overview opens and the icon shows its active dot.
2. Click the Overview icon again. Make sure overview closes and the dot goes away.
3. Open overview and click the `+` tile in the top bar. Make sure a second desktop is created, you land on it, and the Overview icon has no active dot.
4. Open overview and click a different desktop's tile. Make sure you switch to it, overview closes, and the Overview icon has no active dot.
5. Open overview and press `Escape`. Make sure the dot goes away here too.

### Renaming a desktop

6. Open overview and hover any desktop tile. Make sure a pencil appears in the top left corner and the close X in the top right.
7. Hover the tile of the desktop you are currently on (the one with the accent border). Make sure the border stays accent coloured and does not turn grey.
8. Click the pencil. Make sure the name becomes editable with all of its text selected, and that the name does not move or change size when it does.
9. Type `My Space` and press `Enter`. Make sure the tile shows `My Space`, the space is in it, and overview stays open.
10. Click the pencil again, type a different name, and press `Escape`. Make sure the previous name comes back.
11. Click the pencil again, type a different name, and click elsewhere in the top bar. Make sure the new name is kept.
12. Click the pencil, delete all the text, and press `Enter`. Make sure the previous name comes back instead of an empty tile.
13. Click the pencil and type more than 64 characters. Make sure the saved name is cut to 64.
14. Click the pencil on one tile, then click the pencil on another. Make sure only one name is editable at a time.
15. Reload the page. Make sure the renamed desktops keep their names.

### Desktop name after switching

16. Close overview. With at least two desktops, press the `Right` arrow key. Make sure the name of the desktop you land on fades in over the middle of the desk for about a second, then fades out.
17. Press `Left` and `Right` a few times quickly. Make sure only one name shows at a time and it follows the desktop you end on.
18. Rename a desktop, then switch away and back to it. Make sure the name shown is the new one.
19. Open overview and switch desktop from the top bar. Make sure no name is shown over the desk.
20. Click the wallpaper while a name is on screen. Make sure the click still minimizes the windows.

### Widgets during overview

21. Close overview. Drag a widget out of the right column and drop it in the middle of the desk.
22. Open overview. Make sure the widget fades out along with the desktop icons, and that clicking where it was does not interact with it.
23. Close overview. Make sure the widget is back where you left it.
24. Open overview with a widget still docked in the right column. Make sure it fades out as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-662-8d909ad5ce9299fcb2b4ee111ab45bb535db3175.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->