### PR TITLE
Fix wporg username for Nuria

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === OpenStation: Desktop Windows, Dock & Virtual Desktops for WP Admin ===
-Contributors: automattic, allterraindeveloper, epeicher, mmtr86, nickhamze, nuriapenya
+Contributors: automattic, allterraindeveloper, epeicher, mmtr86, nickhamze, nuriapena
 Tags: admin, dashboard, desktop, productivity, ai
 Requires at least: 6.0
 Tested up to: 7.1


### PR DESCRIPTION
Fixes WordPress.org username for @nuriapenya as the following error is returned:


> The following contributors listed were ignored, as the WordPress.org user could not be found. nuriapenya. The Contributors field should only contain WordPress.org usernames.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-666-9615a91c49810f19b383fcecc1c9c9ecb1e3dc17.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->