### PR TITLE
Tooling: a deterministic boot-cost measurement for the shell document

### DIFF
--- a/bin/boot-cost.mjs
+++ b/bin/boot-cost.mjs
@@ -1,0 +1,462 @@
+#!/usr/bin/env node
+/**
+ * Measure what a shell boot document actually costs, deterministically.
+ *
+ * Logs into a local WordPress, fetches one document, then fetches every
+ * `<script src>` and `<link rel=stylesheet>` the SERVER printed into it and
+ * reports request count plus raw and gzipped bytes, grouped by owner
+ * (WordPress core / a plugin / this plugin).
+ *
+ * The point is that it measures the server's output, not the browser's
+ * behaviour. DevTools' footer totals move with cache state, how long the tab
+ * sat there polling, and how many windows you opened, which makes them
+ * useless for comparing two builds. This does not: same code in, same
+ * numbers out.
+ *
+ * Two modes:
+ *
+ *   measure   node bin/boot-cost.mjs --out before.json
+ *   diff      node bin/boot-cost.mjs --diff before.json after.json
+ *
+ * See docs/DEVELOPMENT.md, "Measuring boot cost", for the trunk-vs-branch
+ * workflow and the traps worth knowing about.
+ */
+
+import { gzipSync } from 'node:zlib';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const DEFAULTS = {
+	base: 'http://localhost:8890',
+	path: '/wp-admin/',
+	user: 'admin',
+	password: 'password',
+	label: 'boot',
+	concurrency: 8,
+};
+
+/** Owner buckets, in match order. First hit wins. */
+const OWNERS = [
+	[ /\/plugins\/desktop-mode\//, 'desktop-mode' ],
+	[ /\/wp-content\/plugins\/([^/]+)\//, ( m ) => `plugin: ${ m[ 1 ] }` ],
+	[ /\/wp-content\/themes\/([^/]+)\//, ( m ) => `theme: ${ m[ 1 ] }` ],
+	[ /\/wp-(includes|admin)\//, 'wp-core' ],
+];
+
+function ownerOf( url ) {
+	for ( const [ re, name ] of OWNERS ) {
+		const m = re.exec( url );
+		if ( m ) {
+			return typeof name === 'function' ? name( m ) : name;
+		}
+	}
+	return 'other';
+}
+
+/* -------------------------------------------------------------------------
+ * A cookie jar just big enough for wp-login. `fetch()` has none of its own,
+ * and the login flow needs the test cookie from the GET to survive into the
+ * POST, and the auth cookies from the POST to survive the redirect chain.
+ * ---------------------------------------------------------------------- */
+
+const jar = new Map();
+
+function jarHeader() {
+	return [ ...jar ].map( ( [ k, v ] ) => `${ k }=${ v }` ).join( '; ' );
+}
+
+function jarStore( response ) {
+	for ( const cookie of response.headers.getSetCookie() ) {
+		const pair = cookie.split( ';' )[ 0 ];
+		const eq = pair.indexOf( '=' );
+		if ( eq > 0 ) {
+			jar.set( pair.slice( 0, eq ).trim(), pair.slice( eq + 1 ).trim() );
+		}
+	}
+}
+
+/**
+ * fetch() with the jar wired in and redirects followed by hand, so cookies
+ * set mid-chain are carried forward.
+ *
+ * @param {string} url
+ * @param {RequestInit} init
+ * @param {number} maxHops
+ * @return {Promise<{ response: Response, url: string }>}
+ */
+async function hop( url, init = {}, maxHops = 10 ) {
+	let current = url;
+	for ( let i = 0; i <= maxHops; i++ ) {
+		const headers = { ...( init.headers || {} ) };
+		if ( jar.size ) {
+			headers.cookie = jarHeader();
+		}
+		const response = await fetch( current, {
+			...init,
+			headers,
+			redirect: 'manual',
+		} );
+		jarStore( response );
+
+		const location = response.headers.get( 'location' );
+		if ( ! location || response.status < 300 || response.status >= 400 ) {
+			return { response, url: current };
+		}
+		current = new URL( location, current ).toString();
+		// Only the first request carries the body; a redirected POST
+		// becomes a GET, which is what a browser does too.
+		init = { method: 'GET' };
+	}
+	throw new Error( `too many redirects starting at ${ url }` );
+}
+
+async function login( base, user, password ) {
+	// Priming GET: this is what sets the test cookie the POST is checked
+	// against. Skipping it makes the login silently fail.
+	await hop( `${ base }/wp-login.php` );
+
+	const body = new URLSearchParams( {
+		log: user,
+		pwd: password,
+		'wp-submit': 'Log In',
+		redirect_to: '/wp-admin/',
+		testcookie: '1',
+	} );
+
+	const { url } = await hop( `${ base }/wp-login.php`, {
+		method: 'POST',
+		body,
+		headers: { 'content-type': 'application/x-www-form-urlencoded' },
+	} );
+
+	if ( url.includes( 'wp-login.php' ) ) {
+		throw new Error(
+			`login failed at ${ base } (landed back on ${ url }). Wrong credentials, or the site is not the wp-env instance you think it is.`,
+		);
+	}
+}
+
+/* ---------------------------------------------------------------------- */
+
+const STYLE_TAG = /<link\b[^>]*?rel=(['"])stylesheet\1[^>]*?>/gi;
+const HREF = /href=(['"])(.*?)\1/i;
+const SCRIPT_SRC = /<script\b[^>]*?\bsrc=(['"])(.*?)\1[^>]*?>/gi;
+const INLINE_SCRIPT = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
+const INLINE_STYLE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+function sumInline( html, re ) {
+	let total = 0;
+	for ( const m of html.matchAll( re ) ) {
+		total += Buffer.byteLength( m[ 1 ], 'utf8' );
+	}
+	return total;
+}
+
+/** Fetch one asset uncompressed, and gzip it locally so the number is ours. */
+async function sizeOf( url ) {
+	try {
+		const { response } = await hop( url, {
+			headers: { 'accept-encoding': 'identity' },
+		} );
+		if ( ! response.ok ) {
+			process.stderr.write( `  ! ${ response.status } ${ url }\n` );
+			return { raw: 0, gz: 0 };
+		}
+		const buf = Buffer.from( await response.arrayBuffer() );
+		return { raw: buf.length, gz: gzipSync( buf, { level: 6 } ).length };
+	} catch ( err ) {
+		process.stderr.write( `  ! ${ url } -> ${ err.message }\n` );
+		return { raw: 0, gz: 0 };
+	}
+}
+
+/** Run `jobs` with a fixed worker count, preserving input order. */
+async function pool( jobs, workers ) {
+	const out = new Array( jobs.length );
+	let next = 0;
+	await Promise.all(
+		Array.from( { length: Math.min( workers, jobs.length ) }, async () => {
+			while ( next < jobs.length ) {
+				const i = next++;
+				out[ i ] = await jobs[ i ]();
+			}
+		} ),
+	);
+	return out;
+}
+
+async function measure( opts ) {
+	await login( opts.base, opts.user, opts.password );
+
+	const { response, url: finalUrl } = await hop( opts.base + opts.path );
+	const html = await response.text();
+
+	const assets = [];
+	for ( const tag of html.matchAll( STYLE_TAG ) ) {
+		const href = HREF.exec( tag[ 0 ] );
+		if ( href ) {
+			assets.push( {
+				kind: 'css',
+				url: new URL( href[ 2 ], finalUrl ).toString(),
+			} );
+		}
+	}
+	for ( const m of html.matchAll( SCRIPT_SRC ) ) {
+		assets.push( {
+			kind: 'js',
+			url: new URL( m[ 2 ], finalUrl ).toString(),
+		} );
+	}
+
+	const sizes = await pool(
+		assets.map( ( a ) => () => sizeOf( a.url ) ),
+		opts.concurrency,
+	);
+
+	return {
+		label: opts.label,
+		base: opts.base,
+		requested: opts.path,
+		finalUrl,
+		htmlBytes: Buffer.byteLength( html, 'utf8' ),
+		htmlGzBytes: gzipSync( Buffer.from( html, 'utf8' ), { level: 6 } )
+			.length,
+		inlineJsBytes: sumInline( html, INLINE_SCRIPT ),
+		inlineCssBytes: sumInline( html, INLINE_STYLE ),
+		assets: assets.map( ( a, i ) => ( {
+			...a,
+			owner: ownerOf( a.url ),
+			...sizes[ i ],
+		} ) ),
+	};
+}
+
+/* ---------------------------------------------------------------------- */
+
+const kb = ( n ) => ( n / 1024 ).toFixed( 1 );
+const mb = ( n ) => ( n / 1024 / 1024 ).toFixed( 2 );
+
+function totals( rows ) {
+	return rows.reduce(
+		( acc, r ) => ( {
+			requests: acc.requests + 1,
+			raw: acc.raw + r.raw,
+			gz: acc.gz + r.gz,
+		} ),
+		{ requests: 0, raw: 0, gz: 0 },
+	);
+}
+
+function groupBy( rows, key ) {
+	const out = new Map();
+	for ( const r of rows ) {
+		const k = r[ key ];
+		const b = out.get( k ) || { requests: 0, raw: 0, gz: 0 };
+		b.requests++;
+		b.raw += r.raw;
+		b.gz += r.gz;
+		out.set( k, b );
+	}
+	return [ ...out ].sort( ( a, b ) => b[ 1 ].gz - a[ 1 ].gz );
+}
+
+function report( result ) {
+	const t = totals( result.assets );
+	process.stdout.write(
+		`\n=== ${ result.label }\n` +
+			`    ${ result.finalUrl }\n\n` +
+			`document            ${ kb( result.htmlBytes ) } KB  ` +
+			`(${ kb( result.htmlGzBytes ) } KB gz)\n` +
+			`  inline JS / CSS   ${ kb( result.inlineJsBytes ) } KB / ` +
+			`${ kb( result.inlineCssBytes ) } KB\n` +
+			`assets              ${ t.requests } requests  ` +
+			`${ mb( t.raw ) } MB raw  ${ mb( t.gz ) } MB gz\n`,
+	);
+	for ( const [ kind, b ] of groupBy( result.assets, 'kind' ) ) {
+		process.stdout.write(
+			`  ${ kind.padEnd( 16 ) }  ${ String( b.requests ).padStart( 3 ) }  ` +
+				`${ kb( b.raw ).padStart( 9 ) } KB  ${ kb( b.gz ).padStart( 8 ) } KB gz\n`,
+		);
+	}
+	process.stdout.write( '  by owner:\n' );
+	for ( const [ owner, b ] of groupBy( result.assets, 'owner' ) ) {
+		process.stdout.write(
+			`  ${ owner.padEnd( 16 ) }  ${ String( b.requests ).padStart( 3 ) }  ` +
+				`${ kb( b.raw ).padStart( 9 ) } KB  ${ kb( b.gz ).padStart( 8 ) } KB gz\n`,
+		);
+	}
+}
+
+/** Strip `?ver=` so the same file across two builds compares equal. */
+const identity = ( url ) => url.replace( /\?ver=[^&]*/, '' );
+
+function diff( beforeFile, afterFile ) {
+	const a = JSON.parse( readFileSync( beforeFile, 'utf8' ) );
+	const b = JSON.parse( readFileSync( afterFile, 'utf8' ) );
+	const at = totals( a.assets );
+	const bt = totals( b.assets );
+
+	const pct = ( from, to ) =>
+		from === 0 ? 'n/a' : `${ ( ( ( to - from ) / from ) * 100 ).toFixed( 2 ) }%`;
+
+	const row = ( label, x, y, fmt = kb, unit = 'KB' ) =>
+		`${ label.padEnd( 24 ) }${ fmt( x ).padStart( 11 ) }${ fmt( y ).padStart(
+			11,
+		) }${ ( ( y - x >= 0 ? '+' : '' ) + fmt( y - x ) ).padStart( 12 ) } ${ unit }` +
+		`  ${ pct( x, y ).padStart( 9 ) }\n`;
+
+	process.stdout.write(
+		`\n=== ${ a.label }  ->  ${ b.label }\n\n` +
+			`${ ''.padEnd( 24 ) }${ 'before'.padStart( 11 ) }${ 'after'.padStart(
+				11,
+			) }${ 'delta'.padStart( 12 ) }\n` +
+			row(
+				'asset requests',
+				at.requests,
+				bt.requests,
+				( n ) => String( n ),
+				'',
+			) +
+			row( 'assets raw', at.raw, bt.raw, mb, 'MB' ) +
+			row( 'assets gzipped', at.gz, bt.gz, mb, 'MB' ) +
+			row( 'document', a.htmlBytes, b.htmlBytes ) +
+			row( 'document gzipped', a.htmlGzBytes, b.htmlGzBytes ) +
+			row( '  inline JS', a.inlineJsBytes, b.inlineJsBytes ),
+	);
+
+	const beforeMap = new Map(
+		a.assets.map( ( r ) => [ identity( r.url ), r ] ),
+	);
+	const afterMap = new Map( b.assets.map( ( r ) => [ identity( r.url ), r ] ) );
+	const gone = [ ...beforeMap.keys() ].filter( ( k ) => ! afterMap.has( k ) );
+	const added = [ ...afterMap.keys() ].filter( ( k ) => ! beforeMap.has( k ) );
+
+	const list = ( title, keys, map ) => {
+		if ( ! keys.length ) {
+			return;
+		}
+		const sum = keys.reduce(
+			( acc, k ) => ( {
+				raw: acc.raw + map.get( k ).raw,
+				gz: acc.gz + map.get( k ).gz,
+			} ),
+			{ raw: 0, gz: 0 },
+		);
+		process.stdout.write(
+			`\n${ title }: ${ keys.length } files, ` +
+				`${ mb( sum.raw ) } MB raw / ${ mb( sum.gz ) } MB gz\n`,
+		);
+		for ( const k of keys
+			.sort( ( x, y ) => map.get( y ).raw - map.get( x ).raw )
+			.slice( 0, 20 ) ) {
+			const r = map.get( k );
+			process.stdout.write(
+				`  ${ kb( r.raw ).padStart( 9 ) } KB  ${ new URL( k ).pathname }\n`,
+			);
+		}
+		if ( keys.length > 20 ) {
+			process.stdout.write( `  … and ${ keys.length - 20 } more\n` );
+		}
+	};
+
+	list( 'REMOVED from the boot document', gone, beforeMap );
+	list( 'ADDED to the boot document', added, afterMap );
+}
+
+/* ---------------------------------------------------------------------- */
+
+function parseArgs( argv ) {
+	const opts = { ...DEFAULTS, out: null, diff: null };
+	for ( let i = 0; i < argv.length; i++ ) {
+		const arg = argv[ i ];
+		const value = () => {
+			const v = argv[ ++i ];
+			if ( v === undefined ) {
+				throw new Error( `${ arg } needs a value` );
+			}
+			return v;
+		};
+		switch ( arg ) {
+			case '--diff':
+				opts.diff = [ value(), value() ];
+				break;
+			case '--base':
+				opts.base = value().replace( /\/$/, '' );
+				break;
+			case '--path':
+				opts.path = value();
+				break;
+			case '--label':
+				opts.label = value();
+				break;
+			case '--user':
+				opts.user = value();
+				break;
+			case '--password':
+				opts.password = value();
+				break;
+			case '--out':
+				opts.out = value();
+				break;
+			case '--concurrency':
+				opts.concurrency = Number( value() );
+				break;
+			case '-h':
+			case '--help':
+				opts.help = true;
+				break;
+			default:
+				throw new Error( `unknown argument: ${ arg }` );
+		}
+	}
+	return opts;
+}
+
+const USAGE = `
+Measure the boot cost of an OpenStation shell document.
+
+  node bin/boot-cost.mjs [--base URL] [--path PATH] [--label NAME] [--out FILE]
+  node bin/boot-cost.mjs --diff BEFORE.json AFTER.json
+
+Options
+  --base URL         Site to measure (default ${ DEFAULTS.base })
+  --path PATH        Document to fetch (default ${ DEFAULTS.path })
+  --label NAME       Name for this run, shown in the report
+  --out FILE         Write the full per-asset result as JSON, for --diff
+  --user / --password  Credentials (default ${ DEFAULTS.user } / ${ DEFAULTS.password })
+  --concurrency N    Parallel asset fetches (default ${ DEFAULTS.concurrency })
+  --diff A B         Compare two --out files and list what moved
+`;
+
+async function main() {
+	let opts;
+	try {
+		opts = parseArgs( process.argv.slice( 2 ) );
+	} catch ( err ) {
+		process.stderr.write( `${ err.message }\n${ USAGE }` );
+		process.exitCode = 1;
+		return;
+	}
+
+	if ( opts.help ) {
+		process.stdout.write( USAGE );
+		return;
+	}
+
+	if ( opts.diff ) {
+		diff( opts.diff[ 0 ], opts.diff[ 1 ] );
+		return;
+	}
+
+	const result = await measure( opts );
+	report( result );
+
+	if ( opts.out ) {
+		writeFileSync( opts.out, JSON.stringify( result, null, 1 ) );
+		process.stdout.write( `\nwrote ${ opts.out }\n` );
+	}
+}
+
+main().catch( ( err ) => {
+	process.stderr.write( `${ err.stack || err.message }\n` );
+	process.exitCode = 1;
+} );

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,6 +55,42 @@ Notes:
 - **Cost.** Each instance is three containers (WordPress, CLI, database). `npm run env:stop` / `env:stop:tests` parks an instance and keeps its data; `npm run env:destroy` / `env:destroy:tests` deletes it.
 - `npm run test:php` in a worktree runs inside that worktree's own tests instance, so PHPUnit is isolated per worktree too.
 
+## Measuring boot cost
+
+`bin/boot-cost.mjs` answers one question deterministically: what does the shell's boot document actually cost, and what changed between two builds. It logs into a local WordPress, fetches one document, then fetches every `<script src>` and `<link rel=stylesheet>` the **server** printed into it, and reports request count plus raw and gzipped bytes grouped by owner.
+
+Measuring the server's output rather than the browser's behaviour is the whole point. DevTools' footer totals (`N requests / X MB transferred / Finish: Y`) move with cache state, with how long the tab sat there polling, and with how many windows you opened, so two recordings of the same build routinely disagree by more than the change being measured. Same code in, same numbers out.
+
+It needs a running instance (see [Manual QA and per-worktree instances](#manual-qa-and-per-worktree-instances-wp-env)); it will not start one for you.
+
+```bash
+npm run perf:boot-cost -- --label trunk --out /tmp/trunk.json
+npm run perf:boot-cost -- --diff /tmp/trunk.json /tmp/branch.json
+```
+
+Defaults are the QA instance (`http://localhost:8890`, `admin` / `password`) and the shell boot document (`/wp-admin/`, which redirects into the portal). `--base` points at another port, `--path` at another document, so `--path '/wp-admin/edit.php?openstation_chromeless=1'` measures what a page opened inside a window costs. `--out` writes the per-asset detail that `--diff` consumes, and `--diff` prints the delta table plus the list of files that left or joined the document.
+
+### Comparing two branches
+
+Use **one** instance and switch the code under it. The mount serves the start directory live, so a branch switch is enough for PHP, and `assets/js/` is committed, so the bundles switch with it:
+
+```bash
+git switch trunk
+npm run perf:boot-cost -- --label trunk --out /tmp/trunk.json
+git switch my-branch
+npm run perf:boot-cost -- --label my-branch --out /tmp/branch.json
+npm run perf:boot-cost -- --diff /tmp/trunk.json /tmp/branch.json
+```
+
+Running two wp-env instances instead is the obvious alternative and it is a trap: each keeps its own database, so they disagree about active plugins, theme and content, and the gap between the two sites will swamp the gap between the two branches.
+
+Four things that will bite you:
+
+- **`SCRIPT_DEBUG` decides whether you are measuring production.** It is on by default in wp-env, which serves unminified core assets and unminified plugin bundles; numbers taken that way have the right shape but run roughly 3x the production figure. For a number destined for a PR description, `wp config set SCRIPT_DEBUG false --raw` inside the instance first and set it back afterwards. Turning it off also switches core to concatenated `load-scripts.php` bundles, so request counts change shape as well as size.
+- **What else is active can change the answer completely.** `bin/setup-wp-env.sh` installs and activates Gutenberg on every fresh instance, and Gutenberg's Dashboard page (`build/pages/dashboard/page-wp-admin.php`) enqueues the entire editor package chain on the Dashboard screen, which is the screen the shell boots on. Work that defers part of that same chain measures as approximately zero on such an instance and as several megabytes without it. When a boot-cost change looks far smaller than expected, find out what else on the page enqueues the same handles before concluding the change did nothing.
+- **Deferral moves cost, it does not delete it.** Do not open windows during a run. A deferral is supposed to make the boot document cheaper and the first open more expensive, so measure the two separately or the second effect hides the first.
+- **Only compare like with like.** Absolute totals from a Gutenberg-active instance and a Gutenberg-inactive one are not comparable to each other. Only the trunk-versus-branch delta *within* one configuration means anything.
+
 ## Coding standards (PHPCS)
 
 `phpcs.xml.dist` inherits the full `WordPress` standard. It scans **PHP only** — the `extensions` arg is load-bearing, because without it PHPCS applies its CSS and JS sniffs to `assets/`, walks ~70 minified bundles and exhausts a 1GB memory limit on any checkout where `npm run build` has run.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"test": "npm run test:js",
 		"test:js": "vitest run",
 		"test:js:watch": "vitest",
+		"perf:boot-cost": "node bin/boot-cost.mjs",
 		"env:start": "wp-env start",
 		"env:start:tests": "wp-env start --config=.wp-env.tests.json",
 		"env:stop": "wp-env stop",


### PR DESCRIPTION
## What it does

Adds `npm run perf:boot-cost`, which measures what the shell's boot document actually costs and what changed between two builds.

```bash
# measure one side
npm run perf:boot-cost -- --label trunk --out /tmp/trunk.json

# compare two
npm run perf:boot-cost -- --diff /tmp/trunk.json /tmp/branch.json
```

It logs into a local WordPress, fetches one document, then fetches every `<script src>` and `<link rel=stylesheet>` the **server** printed into it, and reports request count plus raw and gzipped bytes grouped by owner:

```
assets              159 requests  19.69 MB raw  3.81 MB gz
  by owner:
  plugin: gutenberg   62    16246.5 KB    2891.3 KB gz
  desktop-mode        32     2057.4 KB     530.0 KB gz
  wp-core             64     1857.8 KB     478.8 KB gz
```

## Rationale

DevTools' footer totals cannot compare two builds, and we found that out the expensive way while reviewing #664. Two local environments running **byte-identical** plugin code reported:

| | env A | env B |
|---|---|---|
| Requests | 344 | 429 |
| Transferred | 18.8 MB | 6.5 MB |
| Finish | 2 min | 3.1 min |

None of that spread was code. `Finish` is wall clock to the last request, so it tracks how long the tab sat there polling. `transferred` collapses with a warm cache, which is why the environment serving *more* bytes reported a third as many. `requests` grows with session length and with every window opened. Two recordings of the same build routinely disagree by more than the change being measured.

Measuring the server's output instead removes all three variables. Same code in, same numbers out.

The tool paid for itself immediately. On #664 it showed the deferral saving **-2 requests / -15 KB gz** on a default wp-env instance and **-38 requests / -0.97 MB gz** on the same instance with Gutenberg deactivated, then `--diff` named the reason: `dashboard-wp-admin-prerequisites`, a src-less aggregator Gutenberg enqueues on the Dashboard screen, which is the screen the shell boots on. It re-imports the same dependency closure the PR defers, so both roots have to go before either helps. That is not a conclusion any browser recording was going to hand us.

## Implementation

`bin/boot-cost.mjs`, Node ESM, no dependencies beyond `fetch` and `node:zlib`. Follows `bin/build-game-words.mjs` as the precedent for non-trivial tooling in this repo.

Three details worth knowing:

**Assets are fetched with `Accept-Encoding: identity` and gzipped locally**, so the compressed figure is ours rather than whatever the dev server happened to negotiate, and it stays comparable across environments.

**There is a small hand-rolled cookie jar.** `fetch` has none, and the login flow genuinely needs one: the test cookie set by the priming `GET /wp-login.php` has to survive into the `POST`, and the auth cookies from the `POST` have to survive the redirect chain. Redirects are therefore followed manually (`redirect: 'manual'`) so cookies set mid-chain are carried forward.

**`--diff` reports which files moved, not just how many.** The delta table answers "did it get better", the file list answers "why", which is the half that turned out to matter:

```
REMOVED from the boot document: 39 files, 3.02 MB raw / 0.97 MB gz
     1378.0 KB  /wp-includes/js/dist/block-editor.min.js
      817.1 KB  /wp-includes/js/dist/components.min.js
      226.5 KB  /wp-includes/js/dist/core-data.min.js
      143.0 KB  /wp-includes/js/dist/blocks.min.js
```

`?ver=` is stripped when matching, so the same file across two builds compares equal.

`docs/DEVELOPMENT.md` gains a `## Measuring boot cost` section covering the two modes, the one-instance branch-switching workflow, and four traps we walked into:

- **`SCRIPT_DEBUG` decides whether you are measuring production.** On by default in wp-env, it inflates every figure roughly 3x. Turning it off also switches core to concatenated `load-scripts.php` bundles, so request counts change shape as well as size.
- **`bin/setup-wp-env.sh` activates Gutenberg on every fresh instance**, which is what made the #664 win invisible. The section names the file and the screen.
- **Deferral moves cost to first open rather than deleting it**, so opening windows mid-run hides the effect being measured.
- **Absolute totals under different plugin sets are not comparable.** Only the trunk-versus-branch delta within one configuration means anything.

The doc also spells out that two wp-env instances are the wrong way to A/B: each keeps its own database, so they disagree about active plugins, theme and content, and the gap between the two sites swamps the gap between the two branches. Use one instance and switch the code under it; the mount serves the start directory live and `assets/js/` is committed, so `git switch` is enough.

## Testing instructions

Needs a running QA instance; the script will not start one.

```bash
npm run env:start
npm run perf:boot-cost -- --label a --out /tmp/a.json
npm run perf:boot-cost -- --label b --out /tmp/b.json
npm run perf:boot-cost -- --diff /tmp/a.json /tmp/b.json
```

Two runs against an unchanged site should diff to `0.00%` on every row, which is the determinism claim. Then verify it detects a real change:

```bash
npm run perf:boot-cost -- --label shell   --out /tmp/shell.json
npm run perf:boot-cost -- --label iframe  --out /tmp/iframe.json \
  --path '/wp-admin/edit.php?openstation_chromeless=1'
npm run perf:boot-cost -- --diff /tmp/shell.json /tmp/iframe.json
```

The chromeless document should come out substantially cheaper and the `REMOVED` list should be dominated by shell chrome (`desktop.js`, `window-chrome.css`, `dock.css`).

Other ports with `--base http://localhost:8894`, non-default credentials with `--user` / `--password`, full options with `--help`.

No runtime code is touched, so there is nothing to regress in the plugin itself. `npm run build` passes with zero churn in `assets/js/`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-667-5e32fb31a2c6d03b8829612670a15b8b298d9d8b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->