### PR TITLE
Tooling: mirror docs/ into the GitHub wiki on every trunk push

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,70 @@
+name: Sync docs to wiki
+
+# Mirror docs/ into the repository's GitHub wiki. A wiki is itself a git
+# repository (<repo>.wiki.git) with a flat page namespace; bin/build-wiki.mjs
+# flattens docs/ into that shape (page renames, link rewriting, generated
+# sidebar) and this workflow pushes the result. The wiki is therefore
+# generated output: edits made in the wiki UI are overwritten on the next
+# sync, and doc changes belong in docs/ via pull request.
+#
+# One-time prerequisite: the wiki repository does not exist until the first
+# page is saved through the GitHub UI. Enable the wiki, create any page
+# (its content will be replaced), then run this workflow via
+# workflow_dispatch.
+
+on:
+  push:
+    branches: [ trunk ]
+    paths:
+      - 'docs/**'
+      - 'bin/build-wiki.mjs'
+      - '.github/workflows/wiki.yml'
+  workflow_dispatch:
+
+# contents: write lets the GITHUB_TOKEN push to the wiki repository, which
+# shares the parent repository's permission model.
+permissions:
+  contents: write
+
+# Syncs are last-writer-wins over the same wiki; never run two at once, and
+# a queued older sync is useless once a newer docs state exists.
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Build pages · push to wiki
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build wiki pages
+        run: node bin/build-wiki.mjs "$RUNNER_TEMP/wiki-pages"
+
+      - name: Clone the wiki repository
+        run: |
+          git clone --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" \
+            "$RUNNER_TEMP/wiki-repo" || {
+            echo "::error::Could not clone ${GITHUB_REPOSITORY}.wiki.git. The wiki repository only exists once a first page has been created through the GitHub UI — enable the wiki, save any page, then re-run this workflow."
+            exit 1
+          }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Sync and push
+        run: |
+          rsync -a --delete --exclude=.git "$RUNNER_TEMP/wiki-pages/" "$RUNNER_TEMP/wiki-repo/"
+          cd "$RUNNER_TEMP/wiki-repo"
+          git add --all
+          if git diff --cached --quiet; then
+            echo "Wiki already matches docs/ — nothing to push."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --message "Sync docs from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push

--- a/bin/build-wiki.mjs
+++ b/bin/build-wiki.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Transform docs/ into a set of GitHub-wiki pages.
+ *
+ * A GitHub wiki is a flat page namespace: every page is addressed by its
+ * filename alone, directories are ignored, and links must be extension-less
+ * page names rather than relative .md paths. This script bridges the gap:
+ *
+ *   - docs/README.md            -> Home.md (the wiki front page)
+ *   - docs/examples/README.md   -> Examples.md
+ *   - docs/examples/<name>.md   -> example-<name>.md (prefix keeps the ~70
+ *                                  example pages grouped and prevents
+ *                                  basename collisions with top-level docs,
+ *                                  e.g. desktop-host.md exists in both)
+ *   - docs/<name>.md            -> <name>.md
+ *   - docs/plans/               -> excluded (internal planning docs)
+ *   - docs/assets/              -> copied verbatim; image links keep working
+ *
+ * Every relative link is rewritten: links between docs become wiki page
+ * links (anchors preserved), links that escape docs/ into the source tree
+ * become absolute GitHub blob URLs on trunk. A _Sidebar.md and _Footer.md
+ * are generated. Unresolvable relative links are reported as warnings but
+ * do not fail the build.
+ *
+ * Usage: node bin/build-wiki.mjs <output-dir>
+ *
+ * Consumed by .github/workflows/wiki.yml, which pushes the output to the
+ * repository's wiki on every docs change on trunk. The wiki is therefore a
+ * generated mirror: edits made in the wiki UI are overwritten on the next
+ * sync. See docs/DEVELOPMENT.md, "Docs → GitHub wiki".
+ */
+
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve( path.dirname( fileURLToPath( import.meta.url ) ), '..' );
+const DOCS_DIR = path.join( REPO_ROOT, 'docs' );
+const BLOB_BASE = 'https://github.com/WordPress/openstation/blob/trunk/';
+const EXCLUDED_DIRS = new Set( [ 'plans', 'assets' ] );
+
+const outDir = process.argv[ 2 ];
+if ( ! outDir ) {
+	console.error( 'Usage: node bin/build-wiki.mjs <output-dir>' );
+	process.exit( 1 );
+}
+
+const warnings = [];
+
+/**
+ * Map a docs-relative markdown path to its wiki page name (no extension).
+ */
+function pageName( relPath ) {
+	if ( relPath === 'README.md' ) {
+		return 'Home';
+	}
+	if ( relPath === 'examples/README.md' ) {
+		return 'Examples';
+	}
+	if ( relPath.startsWith( 'examples/' ) ) {
+		return 'example-' + path.basename( relPath, '.md' );
+	}
+	return path.basename( relPath, '.md' );
+}
+
+// ---------------------------------------------------------------------------
+// Collect pages. Only docs/ root and docs/examples/ may contain markdown; a
+// new subdirectory must be mapped here deliberately, so fail loudly on one.
+// ---------------------------------------------------------------------------
+
+const sources = [];
+for ( const entry of readdirSync( DOCS_DIR, { withFileTypes: true, recursive: true } ) ) {
+	if ( ! entry.isFile() || ! entry.name.endsWith( '.md' ) ) {
+		continue;
+	}
+	const rel = path.relative( DOCS_DIR, path.join( entry.parentPath, entry.name ) );
+	const topDir = rel.includes( path.sep ) ? rel.split( path.sep )[ 0 ] : null;
+	if ( topDir && EXCLUDED_DIRS.has( topDir ) ) {
+		continue;
+	}
+	if ( topDir && topDir !== 'examples' ) {
+		console.error( `Unexpected markdown location: docs/${ rel }` );
+		console.error( 'Teach bin/build-wiki.mjs how this directory maps into the flat wiki namespace.' );
+		process.exit( 1 );
+	}
+	sources.push( rel.split( path.sep ).join( '/' ) );
+}
+sources.sort();
+
+const pageByPath = new Map( sources.map( ( rel ) => [ rel, pageName( rel ) ] ) );
+
+const collisions = new Map();
+for ( const [ rel, page ] of pageByPath ) {
+	if ( collisions.has( page ) ) {
+		console.error( `Wiki page name collision: docs/${ collisions.get( page ) } and docs/${ rel } both map to "${ page }".` );
+		process.exit( 1 );
+	}
+	collisions.set( page, rel );
+}
+
+/**
+ * First H1 of a page, stripped of markdown decoration, as its display title.
+ */
+function pageTitle( rel, content ) {
+	const match = content.match( /^#\s+(.+)$/m );
+	if ( ! match ) {
+		return pageName( rel );
+	}
+	return match[ 1 ]
+		.replace( /\[([^\]]*)\]\([^)]*\)/g, '$1' )
+		.replace( /`/g, '' )
+		.trim()
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' );
+}
+
+// ---------------------------------------------------------------------------
+// Link rewriting.
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite one inline-link target found in the given source file.
+ *
+ * Returns the replacement target, or null to leave it untouched.
+ */
+function rewriteTarget( srcRel, target ) {
+	if ( /^([a-z][a-z0-9+.-]*:|\/\/|\/|#)/i.test( target ) ) {
+		return null; // Absolute URL, scheme, site-absolute path, or same-page anchor.
+	}
+
+	const hashIndex = target.indexOf( '#' );
+	const filePart = hashIndex === -1 ? target : target.slice( 0, hashIndex );
+	const anchor = hashIndex === -1 ? '' : target.slice( hashIndex );
+	if ( ! filePart ) {
+		return null;
+	}
+
+	// Resolve relative to the source file, then express relative to docs/.
+	const resolved = path.posix
+		.normalize( path.posix.join( path.posix.dirname( srcRel ), filePart ) )
+		.replace( /\/+$/, '' );
+
+	if ( pageByPath.has( resolved ) ) {
+		return pageByPath.get( resolved ) + anchor;
+	}
+
+	// A link to a directory lands on that directory's README page.
+	const dirReadme = resolved === '.' ? 'README.md' : resolved + '/README.md';
+	if ( pageByPath.has( dirReadme ) ) {
+		return pageByPath.get( dirReadme ) + anchor;
+	}
+
+	// Assets travel with the wiki; all pages live at the wiki root, so a
+	// root-relative assets/ path is correct from every page.
+	if ( resolved.startsWith( 'assets/' ) && existsSync( path.join( DOCS_DIR, resolved ) ) ) {
+		return resolved + anchor;
+	}
+
+	// Anything else that exists in the repository (source files, excluded
+	// docs like plans/) gets an absolute GitHub URL.
+	const repoRel = path.posix.normalize( path.posix.join( 'docs', path.posix.dirname( srcRel ), filePart ) );
+	if ( ! repoRel.startsWith( '..' ) && existsSync( path.join( REPO_ROOT, repoRel ) ) ) {
+		return BLOB_BASE + repoRel + anchor;
+	}
+
+	warnings.push( `docs/${ srcRel }: unresolved relative link "${ target }"` );
+	return null;
+}
+
+/**
+ * Rewrite every inline markdown link/image target in a page.
+ */
+function rewriteContent( srcRel, content ) {
+	return content.replace(
+		/\]\(\s*([^)\s]+)((?:\s+"[^"]*")?\s*)\)/g,
+		( full, target, title ) => {
+			const replacement = rewriteTarget( srcRel, target );
+			return replacement === null ? full : `](${ replacement }${ title })`;
+		}
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Emit.
+// ---------------------------------------------------------------------------
+
+rmSync( outDir, { recursive: true, force: true } );
+mkdirSync( outDir, { recursive: true } );
+
+const titles = new Map();
+for ( const rel of sources ) {
+	const content = readFileSync( path.join( DOCS_DIR, rel ), 'utf8' );
+	titles.set( rel, pageTitle( rel, content ) );
+	writeFileSync( path.join( outDir, pageByPath.get( rel ) + '.md' ), rewriteContent( rel, content ) );
+}
+
+const assetsDir = path.join( DOCS_DIR, 'assets' );
+if ( existsSync( assetsDir ) ) {
+	cpSync( assetsDir, path.join( outDir, 'assets' ), { recursive: true } );
+}
+
+// Sidebar: guides, then migration notes, then the examples behind a
+// disclosure so seventy-odd entries don't drown the navigation.
+const guides = [];
+const migrations = [];
+const examples = [];
+for ( const rel of sources ) {
+	const page = pageByPath.get( rel );
+	const line = `- [${ titles.get( rel ) }](${ page })`;
+	if ( page === 'Home' || page === 'Examples' ) {
+		continue;
+	} else if ( rel.startsWith( 'examples/' ) ) {
+		examples.push( line );
+	} else if ( rel.startsWith( 'migration-' ) ) {
+		migrations.push( line );
+	} else {
+		guides.push( line );
+	}
+}
+
+writeFileSync( path.join( outDir, '_Sidebar.md' ), [
+	'**[Home](Home)**',
+	'',
+	'**Guides**',
+	...guides,
+	'',
+	'**Migration notes**',
+	...migrations,
+	'',
+	'**[Examples](Examples)**',
+	'<details><summary>All examples</summary>',
+	'',
+	...examples,
+	'',
+	'</details>',
+	'',
+].join( '\n' ) );
+
+writeFileSync( path.join( outDir, '_Footer.md' ), [
+	`This wiki is generated from the [\`docs/\` directory](${ BLOB_BASE }docs) — edits made here are overwritten by the next sync.`,
+	`To change a page, open a pull request against \`docs/\`.`,
+	'',
+].join( '\n' ) );
+
+console.log( `Wrote ${ sources.length } pages (+ _Sidebar.md, _Footer.md) to ${ outDir }` );
+if ( warnings.length ) {
+	console.log( `\n${ warnings.length } warning(s):` );
+	for ( const warning of warnings ) {
+		console.log( `  - ${ warning }` );
+	}
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -315,6 +315,37 @@ file churn in the release commit:
 ./bin/release.sh 0.9.1 --skip-i18n
 ```
 
+## Docs → GitHub wiki
+
+The repository's GitHub wiki is a **generated mirror of `docs/`** — never
+edit it through the wiki UI; the next sync overwrites it. Doc changes go
+through pull requests against `docs/` like any other change.
+
+The pipeline is two pieces:
+
+- `bin/build-wiki.mjs` flattens `docs/` into the wiki's flat page
+  namespace: `docs/README.md` becomes `Home`, `docs/examples/README.md`
+  becomes `Examples`, every example page gets an `example-` prefix (which
+  is also what prevents basename collisions such as `desktop-host.md`
+  existing in both directories), `docs/plans/` is excluded, and
+  `docs/assets/` is copied verbatim. Relative `.md` links are rewritten to
+  wiki page names (anchors preserved); links escaping `docs/` into the
+  source tree become absolute GitHub `blob/trunk` URLs. It also generates
+  the `_Sidebar.md` navigation and a `_Footer.md` provenance note.
+  Unresolved relative links are printed as warnings — run
+  `node bin/build-wiki.mjs /tmp/wiki-out` locally to preview a sync or
+  check links.
+- `.github/workflows/wiki.yml` runs the script on every push to `trunk`
+  that touches `docs/**` (plus `workflow_dispatch` for manual runs) and
+  pushes the output to `<repo>.wiki.git` — a wiki is itself a git
+  repository — using the workflow's `GITHUB_TOKEN`. Deletes and renames
+  propagate; the sync is authoritative.
+
+One-time prerequisite: GitHub only creates the wiki repository when a
+first page is saved through the UI. If the sync job fails with "Could not
+clone", enable the wiki, save any page (its content will be replaced), and
+re-run the workflow.
+
 ## Where things are tested
 
 - **Vitest** — `tests/vitest/*.test.ts` + colocated


### PR DESCRIPTION
## What

Makes the repository's GitHub wiki an auto-updating mirror of `docs/`. Two pieces:

- **`bin/build-wiki.mjs`** — transforms `docs/` into the wiki's flat page namespace: `docs/README.md` → `Home`, `docs/examples/README.md` → `Examples`, example pages get an `example-` prefix (which also resolves the two real basename collisions: `README.md` and `desktop-host.md` exist in both directories), `docs/plans/` is excluded, `docs/assets/` is copied verbatim. Every relative `.md` link is rewritten to a wiki page name with anchors preserved; links that escape `docs/` into the source tree become absolute `blob/trunk` URLs; directory links land on that directory's README page. Generates `_Sidebar.md` (guides / migration notes / collapsible examples list) and a `_Footer.md` provenance note. Unresolved links are warnings, not failures — currently there are zero across all 104 pages.
- **`.github/workflows/wiki.yml`** — runs the script on every push to `trunk` touching `docs/**` (plus `workflow_dispatch`) and pushes the output to `<repo>.wiki.git` with the built-in `GITHUB_TOKEN` (`contents: write`). `rsync --delete` makes the sync authoritative: renames and deletions propagate, and wiki-UI edits are overwritten by design — doc changes go through PRs against `docs/`, which the generated footer says on every page.

`docs/DEVELOPMENT.md` gains a "Docs → GitHub wiki" section covering the pipeline and how to preview a sync locally.

## One-time setup after merge

The wiki is enabled on this repo but **uninitialized** — GitHub only creates `<repo>.wiki.git` once a first page is saved through the UI. Create any page (its content will be replaced), then run the **Sync docs to wiki** workflow manually. Until then the job fails with a clear error saying exactly this.

## Testing

- Converter run locally: 104 pages emitted, zero unresolved-link warnings, no relative `.md` links remain in the output.
- Full sync loop dry-run against a local bare repo standing in for the wiki: initial push replaces the seeded page, a second run with no doc changes correctly pushes nothing.
- Workflow YAML parse-validated; `npm run build` green with no spurious diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-672-2b5beec8a9a69ff2663357784dbd0e08efcade4a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->