### PR TITLE
Perf: the shell asks the service worker for a screen before you click it

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -79,6 +79,7 @@ OpenStation and you want OpenStation to take over the install path.
 | `/wp-content/plugins/desktop-mode/assets/**.js` | Network-first with `cache: 'reload'` + cache fallback | JS bundles change per deploy — a fresh deploy reaches online users on the next load, with no stale-revalidate window where a freshly-pushed fix is invisible. The cache still serves offline users. |
 | **Opt-in** — versioned Core statics (`/wp-admin/**`, `/wp-includes/**` with `?ver=`) and `load-scripts.php` / `load-styles.php` | Exact-URL cache-first (`os-admin` bucket) | The `ver` query embeds the WordPress version, so bytes behind a URL only change when the URL changes — the same contract Core expresses by serving the loader endpoints with a one-year `Cache-Control`. A warm window-open costs zero HTTP requests for these. Requires the `openstation_pwa_admin_asset_cache` filter (default off). |
 | **Opt-in** — versioned plugin/theme statics (`/wp-content/plugins|themes/**` with `?ver=`) | Stale-while-revalidate (`os-admin` bucket) | Same `ver` contract in principle, but authors edit files without bumping versions often enough that cache-first would pin stale bytes; SWR serves instantly and self-heals on the next load. Uploads are excluded (quota, thumbnail regeneration keeps the URL). |
+| **Opt-in** — an iframe navigation to a document the shell asked for early | Served from the held response (never re-fetched) | The document is the one thing that can never be cached — admin HTML carries nonces — and it is the majority of a window open. Speculation does not make it cacheable; it moves the wait to before the click. See [Speculative documents](#speculative-documents-opt-in). |
 | Navigation requests under our scope | Network-first with offline fallback | wp-admin HTML carries nonces and per-request screen state; caching it would desynchronise the user. The fallback is a tiny inline placeholder so an offline user sees something coherent. |
 | REST / AJAX / non-asset GETs / unversioned asset URLs | Pass-through (no SW handling) | Same reason as navigation — auth-bound dynamic content must hit the network; an asset URL without a `ver` cache-buster carries no immutability contract. |
 | `install`-time precache | A handful of CSS files, the three critical-path JS bundles (`desktop.min.js`, `window-system.min.js`, `shell-overlays.min.js`), and the plugin logo | Just enough to render the offline shell skeleton. Anything else is picked up at runtime by the caching paths above. |
@@ -134,6 +135,46 @@ The cache is keyed by version (`os-static-<v>`,
 `os-runtime-<v>`). The `activate` step deletes any cache whose
 key doesn't carry the current version, so a deploy doesn't accumulate
 stale buckets.
+
+## Speculative documents (opt-in)
+
+The shared asset cache removes the network from a window's **assets**. It can never touch the **document**: admin HTML carries nonces and per-request screen state, so it is uncacheable by construction — and it is the majority of a window open (measured at ~2.1 s of a ~3.8 s tab click on production hosting).
+
+That wait does not have to happen *after* the click. The shell knows every URL a window can reach; the worker sees every iframe navigation. Connecting them lets a document be fetched **while the user is still deciding**, and the navigation that follows is answered from those bytes.
+
+This is not "keep the window alive": nothing rendered is retained. No DOM, no live iframe, no memory beyond a response body dropped after 30 seconds. The page is still built fresh — just early.
+
+Two triggers, one mechanism:
+
+| Trigger | What happens |
+|---|---|
+| **Hovering a submenu tab** | The shell posts `os-speculate-doc`; the worker fetches that screen and holds it. |
+| **Booting the shell** | The worker replays the previous session's restore list the moment the shell's own navigation arrives — *before* the server has finished building the shell document, so the two renders overlap instead of running back to back. The list is persisted from `os-remember-session`, which the session saver posts on every save. |
+
+Measured on production hosting: window-document TTFB **1,353 ms → ~1 ms**, whole shell boot **6,492 ms → ~4,700 ms**, a hovered tab click **~3,600 ms → ~1,000 ms**.
+
+### Rules
+
+- **Speculation never acts.** A URL carrying `action`, `action2`, `_wpnonce`, `nonce` or `delete_all` is refused, so a hover can never activate a plugin or empty a trash. Same-origin, `/wp-admin/` only, and the `openstation_chromeless` flag must be present.
+- **Held documents are single-use and expire after 30 s**, capped at 6 with oldest-first eviction. A document is a moment-in-time view carrying nonces; replaying one twice would show a superseded page.
+- **The store holds the in-flight promise, not the settled response**, so a navigation landing mid-fetch joins the request already running instead of starting a second one for the same screen.
+- **Answering an iframe navigation is safe only because the response is never re-fetched.** The worker otherwise refuses iframe navigations: re-fetching one makes Chrome send `Sec-Fetch-Dest: empty`, the server's chromeless detection falls through, and the whole desktop renders inside a window. A speculative document is fetched once, ahead of time, from a URL carrying the chromeless flag — which the server reads *before* it consults Sec-Fetch.
+- The speculative fetch is a plain same-origin GET and does not forward `Referer` or `Accept-Language` from the navigation it stands in for. Admin screens do not branch on either (locale comes from the user's profile, server-side).
+- Gated on the **hover-prewarm** opt-in (`windowPrewarmEnabled`), delivered to the worker as `windowPrewarm` in the `self.__OS_SW_CONFIG` preamble. Off by default.
+
+### Worker message surface
+
+Both messages are posted to `navigator.serviceWorker.controller` and are ignored unless the opt-in is on.
+
+```js
+// Fetch this screen now; hold it for the navigation that follows.
+{ type: 'os-speculate-doc', url: '<absolute same-origin chromeless URL>' }
+
+// Remember these screens for the NEXT boot's replay.
+{ type: 'os-remember-session', urls: [ '<absolute>', … ] }
+```
+
+The shell-side helpers are `speculateDocument( url )` and `rememberRestoreTargets( urls )` in `src/pwa/speculate.ts`. Policy lives in `src/pwa/sw-policy.ts` (`isSpeculatableDocument`) and the store in `src/pwa/speculative-store.ts`; both are pure and unit-tested.
 
 ## PHP surface
 

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -149,7 +149,7 @@ Two triggers, one mechanism:
 | Trigger | What happens |
 |---|---|
 | **Hovering a submenu tab** | The shell posts `os-speculate-doc`; the worker fetches that screen and holds it. |
-| **Booting the shell** | The worker replays the previous session's restore list the moment the shell's own navigation arrives — *before* the server has finished building the shell document, so the two renders overlap instead of running back to back. The list is persisted from `os-remember-session`, which the session saver posts on every save. |
+| **Booting the shell** | The worker replays the previous session's restore list the moment the shell's own navigation arrives — *before* the server has finished building the shell document, so the two renders overlap instead of running back to back. The list is persisted from `os-remember-session`, which the session saver posts from **both** of its paths: the debounced save and the `pagehide` beacon. The unload path matters most — it carries the state at the moment the tab closed, which is exactly the "close it and come straight back" case this is for. |
 
 Measured on production hosting: window-document TTFB **1,353 ms → ~1 ms**, whole shell boot **6,492 ms → ~4,700 ms**, a hovered tab click **~3,600 ms → ~1,000 ms**.
 
@@ -160,7 +160,7 @@ Measured on production hosting: window-document TTFB **1,353 ms → ~1 ms**, who
 - **The store holds the in-flight promise, not the settled response**, so a navigation landing mid-fetch joins the request already running instead of starting a second one for the same screen.
 - **Answering an iframe navigation is safe only because the response is never re-fetched.** The worker otherwise refuses iframe navigations: re-fetching one makes Chrome send `Sec-Fetch-Dest: empty`, the server's chromeless detection falls through, and the whole desktop renders inside a window. A speculative document is fetched once, ahead of time, from a URL carrying the chromeless flag — which the server reads *before* it consults Sec-Fetch.
 - The speculative fetch is a plain same-origin GET and does not forward `Referer` or `Accept-Language` from the navigation it stands in for. Admin screens do not branch on either (locale comes from the user's profile, server-side).
-- Gated on the **hover-prewarm** opt-in (`windowPrewarmEnabled`), delivered to the worker as `windowPrewarm` in the `self.__OS_SW_CONFIG` preamble. Off by default.
+- Gated on the **hover-prewarm** opt-in (`windowPrewarmEnabled`), delivered to the worker as `windowPrewarm` in the `self.__OS_SW_CONFIG` preamble. Off by default, and checked on both sides: the shell skips the `postMessage` entirely, and the worker ignores either message if the flag is off. A user who never touches the setting does not pay so much as a message.
 
 ### Worker message surface
 

--- a/includes/pwa.php
+++ b/includes/pwa.php
@@ -199,8 +199,13 @@ function openstation_pwa_admin_asset_cache_enabled() {
  * @return string One line of JavaScript, newline-terminated.
  */
 function openstation_pwa_sw_config_preamble() {
-	$config = array(
+	$settings = openstation_get_os_settings( get_current_user_id() );
+	$config   = array(
 		'adminAssetCache' => openstation_pwa_admin_asset_cache_enabled(),
+		// Hover prewarming, the same toggle the dock reads. The worker
+		// needs it because the speculative-document hand-off lives on
+		// its side: the shell asks, the worker fetches and holds.
+		'windowPrewarm'   => ! empty( $settings['windowPrewarmEnabled'] ),
 		'pluginUrl'       => OPENSTATION_URL,
 	);
 	return sprintf( "self.__OS_SW_CONFIG = %s;\n", wp_json_encode( $config ) );

--- a/src/boot/session-saver.ts
+++ b/src/boot/session-saver.ts
@@ -17,7 +17,7 @@ import { trackedFetch } from './tracked-fetch';
 import { rememberRestoreTargets } from '../pwa/speculate';
 import { withChromelessParam } from '../window/dom';
 import type { WindowManager } from '../window-manager';
-import type { DesktopConfig } from '../types';
+import type { DesktopConfig, Session } from '../types';
 
 /** Trailing-edge debounce window (ms) for the foreground saver. */
 const SESSION_SAVE_DEBOUNCE_MS = 500;
@@ -43,6 +43,47 @@ const SESSION_SAVE_MIN_INTERVAL_MS = 1500;
  * Also exposed on `wp.os.saveSession()` for plugins that want
  * to flush.
  */
+/**
+ * Hand the worker the list of screens this session would restore.
+ *
+ * It cannot use them now — it uses them on the NEXT boot, where it is
+ * woken by the shell's own navigation and can start fetching these
+ * documents in parallel with the server building the shell, instead of
+ * ~3.9s later once the shell's JavaScript exists to ask. See
+ * `rememberRestoreTargets()`.
+ *
+ * Gated on the same opt-in every other speculation call site reads, so
+ * "off by default" means a user who never touched the setting does not
+ * even pay the postMessage. Called from both save paths: the debounced
+ * one and the unload beacon.
+ *
+ * @param payload The session snapshot about to be persisted.
+ */
+function noteRestoreTargets( payload: Session ): void {
+	try {
+		const os = (
+			window as unknown as {
+				wp?: {
+					os?: {
+						getOsSettings?: () => { windowPrewarmEnabled?: boolean };
+					};
+				};
+			}
+		).wp?.os;
+		if ( ! os?.getOsSettings?.().windowPrewarmEnabled ) {
+			return;
+		}
+		rememberRestoreTargets(
+			payload.windows
+				.filter( ( w ) => ! w.native && w.url )
+				.map( ( w ) => withChromelessParam( w.url ) || '' )
+				.filter( Boolean ),
+		);
+	} catch {
+		// Never let a speculation hint break a session save.
+	}
+}
+
 export function createSessionSaver(
 	manager: WindowManager,
 	config: DesktopConfig,
@@ -75,22 +116,7 @@ export function createSessionSaver(
 		// moment the save was queued.
 		const payload = manager.snapshot();
 
-		// Hand the worker the list of screens this session will
-		// restore. It cannot use them now — it uses them on the NEXT
-		// boot, where it is woken by the shell's own navigation and can
-		// start fetching these documents in parallel with the server
-		// building the shell, instead of ~3.9s later once the shell's
-		// JavaScript exists to ask. See `rememberRestoreTargets()`.
-		try {
-			rememberRestoreTargets(
-				payload.windows
-					.filter( ( w ) => ! w.native && w.url )
-					.map( ( w ) => withChromelessParam( w.url ) || '' )
-					.filter( Boolean ),
-			);
-		} catch {
-			// Never let a speculation hint break a session save.
-		}
+		noteRestoreTargets( payload );
 
 		try {
 			// Session save is a debounced background ping — silent
@@ -149,6 +175,15 @@ export function createSessionSaver(
 		// and the session on disk stays at its pre-close state.
 		// Symptom: close a window, reload fast, window reappears.
 		const payload = manager.snapshot();
+		// The unload snapshot is the most accurate one there is — it is
+		// taken as the tab goes away, after the last window the user
+		// closed or opened. Skipping it here would leave the worker
+		// replaying whichever debounced save happened to land last, so
+		// a window closed just before exit would still be speculated on
+		// the next boot (and one opened just before exit would not be).
+		// That is precisely the "close it and come straight back"
+		// moment this is for.
+		noteRestoreTargets( payload );
 		const body = new Blob(
 			[ JSON.stringify( { session: payload } ) ],
 			{ type: 'application/json' },

--- a/src/boot/session-saver.ts
+++ b/src/boot/session-saver.ts
@@ -14,6 +14,8 @@
 
 import { HOOKS, doAction } from '../hooks';
 import { trackedFetch } from './tracked-fetch';
+import { rememberRestoreTargets } from '../pwa/speculate';
+import { withChromelessParam } from '../window/dom';
 import type { WindowManager } from '../window-manager';
 import type { DesktopConfig } from '../types';
 
@@ -72,6 +74,24 @@ export function createSessionSaver(
 		// so the payload reflects the state at send time, not at the
 		// moment the save was queued.
 		const payload = manager.snapshot();
+
+		// Hand the worker the list of screens this session will
+		// restore. It cannot use them now — it uses them on the NEXT
+		// boot, where it is woken by the shell's own navigation and can
+		// start fetching these documents in parallel with the server
+		// building the shell, instead of ~3.9s later once the shell's
+		// JavaScript exists to ask. See `rememberRestoreTargets()`.
+		try {
+			rememberRestoreTargets(
+				payload.windows
+					.filter( ( w ) => ! w.native && w.url )
+					.map( ( w ) => withChromelessParam( w.url ) || '' )
+					.filter( Boolean ),
+			);
+		} catch {
+			// Never let a speculation hint break a session save.
+		}
+
 		try {
 			// Session save is a debounced background ping — silent
 			// so the user doesn't see a spinner every time they

--- a/src/pwa/speculate.ts
+++ b/src/pwa/speculate.ts
@@ -75,3 +75,62 @@ export function speculateDocument( url: string ): void {
 export function _resetSpeculation(): void {
 	asked.clear();
 }
+
+/** The worker persists this list and replays it on the next boot. */
+const REMEMBER_MESSAGE = 'os-remember-session';
+
+/**
+ * Tell the worker which screens this session will restore, so it can
+ * start fetching them on the *next* boot without waiting to be asked.
+ *
+ * This is the boot's serial problem, measured on a live install:
+ *
+ *     0ms ─── shell document requested
+ *   3172ms ─── shell HTML arrives (the server spent 3.2s building it)
+ *   3876ms ─── only now does a window document get requested
+ *   6491ms ─── everything ready
+ *
+ * The window's document does not depend on a single byte of the
+ * shell's, yet it cannot even be *asked for* until the shell's HTML has
+ * arrived and its JavaScript has run and built an iframe. Two
+ * independent server renders, run strictly one after the other.
+ *
+ * The shell cannot fix this from inside itself — by the time its code
+ * is running, the 3.2 seconds are already spent. The worker can:
+ * it is woken by the shell's own navigation, before any of that, and
+ * it can start the window fetches right then. But it only knows what
+ * to fetch if it was told last time, which is what this does.
+ *
+ * Sent on every session save, so the list tracks whatever the user
+ * actually has open.
+ *
+ * @param urls Chromeless URLs of the windows to restore.
+ */
+export function rememberRestoreTargets( urls: string[] ): void {
+	if (
+		typeof navigator === 'undefined' ||
+		! ( 'serviceWorker' in navigator ) ||
+		! navigator.serviceWorker.controller
+	) {
+		return;
+	}
+	const absolute: string[] = [];
+	for ( const url of urls ) {
+		try {
+			const parsed = new URL( url, window.location.href );
+			if ( parsed.origin === window.location.origin ) {
+				absolute.push( parsed.toString() );
+			}
+		} catch {
+			// Skip anything unparseable.
+		}
+	}
+	try {
+		navigator.serviceWorker.controller.postMessage( {
+			type: REMEMBER_MESSAGE,
+			urls: absolute,
+		} );
+	} catch {
+		// Best-effort, exactly like the speculation itself.
+	}
+}

--- a/src/pwa/speculate.ts
+++ b/src/pwa/speculate.ts
@@ -23,11 +23,30 @@
 const SPECULATE_MESSAGE = 'os-speculate-doc';
 
 /**
- * URLs asked for in this page's lifetime, so repeated hovers over the
- * same tab cost one request rather than one per pointer entry. The
- * worker de-duplicates too; this saves the postMessage.
+ * When each URL was last asked about, so a pointer crossing a tab's
+ * icon and label does not post a message per child node.
+ *
+ * **Deliberately a throttle, not a "seen" set.** A permanent set looks
+ * like the obvious de-duplication and silently disables the feature:
+ * the worker's held document is single-use and expires, so the moment
+ * a hover is consumed by a click — or simply times out — every later
+ * hover over that same tab would fall through to a plain navigation
+ * with no speculation at all. Users bounce between the same handful of
+ * screens constantly (Writing → Permalinks → back to Writing), so the
+ * repeat visits are exactly the ones worth accelerating, and they are
+ * exactly the ones a permanent set would abandon.
+ *
+ * The worker remains the real de-duplicator: `beginSpeculation()`
+ * ignores a URL it is already holding. This map only damps the burst.
  */
-const asked = new Set< string >();
+const lastAskedAt = new Map< string, number >();
+
+/**
+ * How long to sit on repeat asks for the same URL. Long enough to
+ * absorb a pointer crossing one tab, far shorter than the worker's
+ * 30-second hold, so a genuine second visit always gets through.
+ */
+const ASK_THROTTLE_MS = 1_000;
 
 /**
  * Ask the service worker to fetch `url` ahead of a likely navigation.
@@ -56,10 +75,12 @@ export function speculateDocument( url: string ): void {
 	} catch {
 		return;
 	}
-	if ( asked.has( absolute ) ) {
+	const now = Date.now();
+	const previous = lastAskedAt.get( absolute );
+	if ( previous !== undefined && now - previous < ASK_THROTTLE_MS ) {
 		return;
 	}
-	asked.add( absolute );
+	lastAskedAt.set( absolute, now );
 	try {
 		navigator.serviceWorker.controller.postMessage( {
 			type: SPECULATE_MESSAGE,
@@ -71,9 +92,9 @@ export function speculateDocument( url: string ): void {
 	}
 }
 
-/** Test seam — clears the per-page de-duplication set. */
+/** Test seam — clears the per-page throttle. */
 export function _resetSpeculation(): void {
-	asked.clear();
+	lastAskedAt.clear();
 }
 
 /** The worker persists this list and replays it on the next boot. */

--- a/src/pwa/speculate.ts
+++ b/src/pwa/speculate.ts
@@ -1,0 +1,77 @@
+/**
+ * OpenStation — speculative document requests.
+ *
+ * The shell's half of the hand-off described in `src/pwa/sw.ts`: ask
+ * the service worker to fetch a window's document while the user is
+ * still deciding, so the click that follows is answered from bytes
+ * that already arrived.
+ *
+ * This is the one cost nothing else could reach. The shared asset
+ * cache took the network out of a window's assets, but the document
+ * itself carries nonces and per-request screen state, so it can never
+ * be cached — and it is the majority of a window open (~2.1 s of a
+ * ~3.8 s tab click on a live install). Fetching it early does not make
+ * it cacheable; it makes the waiting happen before the click instead
+ * of after it.
+ *
+ * Deliberately not "keep the tab alive": nothing rendered is retained.
+ * No DOM, no live iframe, no memory beyond a response body the worker
+ * drops after 30 seconds. The page is still built fresh — just early.
+ */
+
+/** Same shape the worker's message handler matches on. */
+const SPECULATE_MESSAGE = 'os-speculate-doc';
+
+/**
+ * URLs asked for in this page's lifetime, so repeated hovers over the
+ * same tab cost one request rather than one per pointer entry. The
+ * worker de-duplicates too; this saves the postMessage.
+ */
+const asked = new Set< string >();
+
+/**
+ * Ask the service worker to fetch `url` ahead of a likely navigation.
+ *
+ * Silent no-op when there is no controlling worker (the feature is a
+ * bonus, never a dependency), when the URL was already requested, or
+ * when the URL is not same-origin.
+ *
+ * @param url Absolute or relative URL of the document to pre-fetch.
+ */
+export function speculateDocument( url: string ): void {
+	if (
+		typeof navigator === 'undefined' ||
+		! ( 'serviceWorker' in navigator ) ||
+		! navigator.serviceWorker.controller
+	) {
+		return;
+	}
+	let absolute: string;
+	try {
+		const parsed = new URL( url, window.location.href );
+		if ( parsed.origin !== window.location.origin ) {
+			return;
+		}
+		absolute = parsed.toString();
+	} catch {
+		return;
+	}
+	if ( asked.has( absolute ) ) {
+		return;
+	}
+	asked.add( absolute );
+	try {
+		navigator.serviceWorker.controller.postMessage( {
+			type: SPECULATE_MESSAGE,
+			url: absolute,
+		} );
+	} catch {
+		// A worker mid-update can reject a post; speculation is
+		// best-effort and the click still works without it.
+	}
+}
+
+/** Test seam — clears the per-page de-duplication set. */
+export function _resetSpeculation(): void {
+	asked.clear();
+}

--- a/src/pwa/speculative-store.ts
+++ b/src/pwa/speculative-store.ts
@@ -1,0 +1,103 @@
+/**
+ * OpenStation — the speculative document store.
+ *
+ * Split out of `sw.ts` so it can be tested directly: the worker file
+ * reaches for `self`, `fetch` and `caches` at module scope, which a
+ * unit test cannot host, while everything that actually decides
+ * behaviour here is a Map, a clock and a few rules.
+ *
+ * Three of those rules are load-bearing, and each exists because
+ * getting it wrong is invisible until it is expensive:
+ *
+ *   - **Entries hold a promise, not a settled response.** A navigation
+ *     that lands mid-fetch must join the request already running. The
+ *     first implementation stored only finished responses, so a click
+ *     arriving early found nothing and issued a *second* request for
+ *     the same screen — full price for the user, double load for the
+ *     server. Measured at the time: 5 ms when the fetch had landed,
+ *     1,001 ms when it had not.
+ *   - **Taking is single-use.** A document carries nonces and a
+ *     moment-in-time view of a screen; replaying it twice would show
+ *     someone a page that has already been superseded.
+ *   - **Entries expire.** Same reason, bounded by wall-clock instead
+ *     of by use.
+ */
+
+/** How long a fetched document may sit before it is stale. */
+export const SPECULATIVE_TTL_MS = 30_000;
+
+/** Cap on held documents — the shell only ever asks for a handful. */
+export const SPECULATIVE_MAX = 6;
+
+interface Entry {
+	at: number;
+	res: Promise< Response | null >;
+}
+
+/**
+ * A bounded, expiring, single-use store of in-flight documents.
+ *
+ * `now` is injected so tests can move the clock without waiting.
+ */
+export class SpeculativeStore {
+	private entries = new Map< string, Entry >();
+
+	private now: () => number;
+
+	constructor( now: () => number = () => Date.now() ) {
+		this.now = now;
+	}
+
+	/** Whether a document for this exact URL is already on its way. */
+	public has( url: string ): boolean {
+		return this.entries.has( url );
+	}
+
+	public get size(): number {
+		return this.entries.size;
+	}
+
+	/**
+	 * Record an in-flight fetch. Registering before it resolves is the
+	 * whole point — see the class docblock.
+	 */
+	public put( url: string, res: Promise< Response | null > ): void {
+		this.entries.set( url, { at: this.now(), res } );
+		this.prune();
+	}
+
+	/**
+	 * Claim the document waiting for this URL, if any.
+	 *
+	 * Removes the entry whether or not it turned out to be fresh: a
+	 * stale entry has no second chance either.
+	 */
+	public take( url: string ): Promise< Response | null > | null {
+		const entry = this.entries.get( url );
+		if ( ! entry ) {
+			return null;
+		}
+		this.entries.delete( url );
+		if ( this.now() - entry.at > SPECULATIVE_TTL_MS ) {
+			return null;
+		}
+		return entry.res;
+	}
+
+	/** Drop expired entries, then the oldest until back under the cap. */
+	public prune(): void {
+		const now = this.now();
+		for ( const [ url, entry ] of this.entries ) {
+			if ( now - entry.at > SPECULATIVE_TTL_MS ) {
+				this.entries.delete( url );
+			}
+		}
+		while ( this.entries.size > SPECULATIVE_MAX ) {
+			const oldest = this.entries.keys().next().value;
+			if ( oldest === undefined ) {
+				break;
+			}
+			this.entries.delete( oldest );
+		}
+	}
+}

--- a/src/pwa/sw-policy.ts
+++ b/src/pwa/sw-policy.ts
@@ -169,6 +169,53 @@ export function classifyAdminAssetRequest(
 }
 
 /**
+ * Query keys that mean a URL *does something*.
+ *
+ * Speculation must never act. Anything carrying an action or a nonce
+ * is a request to change state — activating a plugin, emptying a
+ * trash, applying an update — and fetching it ahead of a click the
+ * user has not made yet would perform it.
+ */
+const ACTING_QUERY_KEYS = [
+	'action',
+	'action2',
+	'_wpnonce',
+	'nonce',
+	'delete_all',
+] as const;
+
+/**
+ * Whether a URL is a plain admin screen safe to fetch early.
+ *
+ * Three conditions, all required: it is an admin page, it is the
+ * chromeless variant a window actually loads, and it does nothing.
+ *
+ * The chromeless flag is not incidental. It is what makes serving the
+ * result to an iframe navigation safe at all — the server reads that
+ * query flag before it consults `Sec-Fetch-Dest`, so a document
+ * fetched this way is already correctly chromeless, and the hazard
+ * that stops the worker answering iframe navigations generally (a
+ * re-fetch arriving as `Sec-Fetch-Dest: empty`, collapsing the whole
+ * desktop into a window) cannot apply.
+ *
+ * @param url Parsed, same-origin URL.
+ */
+export function isSpeculatableDocument( url: URL ): boolean {
+	if ( ! url.pathname.includes( '/wp-admin/' ) ) {
+		return false;
+	}
+	if ( ! url.searchParams.has( 'openstation_chromeless' ) ) {
+		return false;
+	}
+	for ( const key of ACTING_QUERY_KEYS ) {
+		if ( url.searchParams.has( key ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
  * Whether a fetched response is safe to put in the admin-asset cache.
  *
  * Rejects partial content (`cache.put` throws on 206, but we don't

--- a/src/pwa/sw-policy.ts
+++ b/src/pwa/sw-policy.ts
@@ -26,6 +26,13 @@ export interface SwConfig {
 	 */
 	adminAssetCache: boolean;
 	/**
+	 * Whether hover prewarming is on for this user. Gates the
+	 * speculative-document hand-off: the shell asks for a screen on
+	 * hover, the worker fetches and holds it, and the iframe's
+	 * navigation is answered from those bytes.
+	 */
+	windowPrewarm: boolean;
+	/**
 	 * Absolute URL of the plugin directory (trailing slash). Lets the
 	 * SW resolve its own asset paths on hosts with a non-default
 	 * `wp-content` layout (Bedrock, moved `WP_CONTENT_DIR`, …).
@@ -81,6 +88,7 @@ export function readSwConfig(
 ): SwConfig {
 	const cfg: SwConfig = {
 		adminAssetCache: false,
+		windowPrewarm: false,
 		pluginUrl: fallbackPluginUrl,
 	};
 	if ( ! raw || typeof raw !== 'object' ) {
@@ -88,6 +96,7 @@ export function readSwConfig(
 	}
 	const obj = raw as Record< string, unknown >;
 	cfg.adminAssetCache = obj.adminAssetCache === true;
+	cfg.windowPrewarm = obj.windowPrewarm === true;
 	if (
 		typeof obj.pluginUrl === 'string' &&
 		obj.pluginUrl.startsWith( 'http' )

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -81,6 +81,7 @@ interface SWPushEvent {
 interface SWFetchEvent {
 	request: Request;
 	respondWith: ( r: Response | Promise< Response > ) => void;
+	waitUntil: ( p: Promise< unknown > ) => void;
 }
 interface SWExtendableEvent {
 	waitUntil: ( p: Promise< unknown > ) => void;
@@ -300,6 +301,11 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
 	}
 
 	if ( req.mode === 'navigate' && req.destination === 'document' ) {
+		// The shell is being loaded. Start its windows' documents now,
+		// in parallel with the server building this one, instead of
+		// after it — see `replayRestoreTargets()`. Fire-and-forget:
+		// the navigation below must not wait on speculation.
+		event.waitUntil( replayRestoreTargets() );
 		// Only intercept TOP-LEVEL navigations. Iframe navigations
 		// (`req.destination === 'iframe'`) pass through directly to
 		// the browser. If the SW called `fetch( req )` for an iframe
@@ -420,8 +426,92 @@ function takeSpeculative(
 	return entry.res;
 }
 
+/**
+ * Where the restore list lives between visits.
+ *
+ * A Cache entry rather than IndexedDB because the worker already owns
+ * caches, and this is one small JSON blob read once per boot. The key
+ * is a synthetic same-origin URL that nothing ever navigates to.
+ */
+const SESSION_CACHE = `os-session-${ VERSION }`;
+const SESSION_KEY = '/__openstation_restore_targets__';
+
+/** Guard so one boot fires the replay once, not per intercepted request. */
+let replayedThisBoot = false;
+
+/**
+ * Start fetching the windows this session will restore, without
+ * waiting to be asked.
+ *
+ * Called the moment the shell's own top-level navigation reaches the
+ * worker — which is *before* the server has finished building the
+ * shell document, and long before the shell's JavaScript exists to ask
+ * for anything. That is the entire point: the two server renders are
+ * independent, and this is the only place in the system that can see
+ * the second one coming early enough to overlap them.
+ */
+async function replayRestoreTargets(): Promise< void > {
+	if ( replayedThisBoot || ! CONFIG.windowPrewarm ) {
+		return;
+	}
+	replayedThisBoot = true;
+	try {
+		const cache = await caches.open( SESSION_CACHE );
+		const stored = await cache.match( SESSION_KEY );
+		if ( ! stored ) {
+			return;
+		}
+		const urls = ( await stored.json() ) as unknown;
+		if ( ! Array.isArray( urls ) ) {
+			return;
+		}
+		for ( const raw of urls.slice( 0, SPECULATIVE_MAX ) ) {
+			if ( typeof raw !== 'string' ) {
+				continue;
+			}
+			try {
+				const url = new URL( raw );
+				if (
+					url.origin === sw.location.origin &&
+					isSpeculatableDocument( url )
+				) {
+					beginSpeculation( url.toString() );
+				}
+			} catch {
+				// Skip anything unparseable.
+			}
+		}
+	} catch {
+		// Best-effort: a boot must never fail because speculation did.
+	}
+}
+
 sw.addEventListener( 'message', ( event: SWMessageEvent ) => {
-	const data = event.data as { type?: string; url?: string } | undefined;
+	const data = event.data as
+		| { type?: string; url?: string; urls?: unknown }
+		| undefined;
+
+	// The restore list for the NEXT boot.
+	if ( data && data.type === 'os-remember-session' ) {
+		const urls = Array.isArray( data.urls ) ? data.urls : [];
+		event.waitUntil(
+			( async () => {
+				try {
+					const cache = await caches.open( SESSION_CACHE );
+					await cache.put(
+						SESSION_KEY,
+						new Response( JSON.stringify( urls.slice( 0, SPECULATIVE_MAX ) ), {
+							headers: { 'Content-Type': 'application/json' },
+						} ),
+					);
+				} catch {
+					// Best-effort.
+				}
+			} )(),
+		);
+		return;
+	}
+
 	if ( ! data || data.type !== 'os-speculate-doc' || ! data.url ) {
 		return;
 	}
@@ -439,14 +529,26 @@ sw.addEventListener( 'message', ( event: SWMessageEvent ) => {
 	if ( url.origin !== sw.location.origin || ! isSpeculatableDocument( url ) ) {
 		return;
 	}
-	const href = url.toString();
-	if ( speculative.has( href ) ) {
-		return;
+	const started = beginSpeculation( url.toString() );
+	if ( started ) {
+		event.waitUntil( started );
 	}
+} );
 
-	// Registered before the fetch resolves, so a click that lands
-	// mid-flight finds the promise and waits on it rather than
-	// starting a duplicate request.
+/**
+ * Fetch a document now and hold it for the navigation that follows.
+ *
+ * Returns the in-flight promise, or `null` when this URL is already
+ * being held — the caller only needs it to keep the worker alive.
+ *
+ * The entry is registered *before* the fetch resolves, so a navigation
+ * that lands mid-flight finds the promise and waits on it rather than
+ * starting a duplicate request for the same screen.
+ */
+function beginSpeculation( href: string ): Promise< Response | null > | null {
+	if ( speculative.has( href ) ) {
+		return null;
+	}
 	const inFlight = ( async () => {
 		try {
 			// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.os` global available; raw fetch is the API.
@@ -470,8 +572,8 @@ sw.addEventListener( 'message', ( event: SWMessageEvent ) => {
 
 	speculative.set( href, { at: Date.now(), res: inFlight } );
 	pruneSpeculative();
-	event.waitUntil( inFlight );
-} );
+	return inFlight;
+}
 
 /**
  * Whether a URL is a plain admin screen we may fetch early.

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -46,8 +46,10 @@
 import {
 	classifyAdminAssetRequest,
 	isCacheableResponse,
+	isSpeculatableDocument,
 	readSwConfig,
 } from './sw-policy';
+import { SPECULATIVE_MAX, SpeculativeStore } from './speculative-store';
 
 // Minimal local typings for the service-worker global scope. We
 // intentionally don't pull in `lib.webworker.d.ts` — it re-declares
@@ -278,7 +280,7 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
 	// Exact-URL, single-use; anything not waiting falls through to the
 	// normal pass-through for iframes.
 	if ( req.mode === 'navigate' && speculative.size > 0 ) {
-		const held = takeSpeculative( url.toString() );
+		const held = speculative.take( url.toString() );
 		if ( held ) {
 			event.respondWith(
 				held.then( ( res ) => {
@@ -367,64 +369,14 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
  * and only within {@link SPECULATIVE_TTL_MS}.
  * ---------------------------------------------------------------------- */
 
-const SPECULATIVE_TTL_MS = 30_000;
-
-/** Cap on held documents — the shell only ever asks for a handful. */
-const SPECULATIVE_MAX = 6;
-
 /**
  * Held documents, keyed by exact URL.
  *
- * The entry holds the **promise**, not the settled response, and that
- * is the difference between the feature helping sometimes and helping
- * always. A user who hovers and clicks half a second later would
- * otherwise arrive while the fetch is still in flight, find nothing
- * waiting, and start a *second* request for the same screen — paying
- * full price and costing the server double. Awaiting the in-flight
- * promise instead means the click inherits whatever head start the
- * hover bought, from a few hundred milliseconds up to the whole load.
+ * The store itself lives in `speculative-store.ts` so its rules — hold
+ * the promise rather than the settled response, take once, expire —
+ * can be tested without a service-worker global scope.
  */
-const speculative = new Map<
-	string,
-	{ at: number; res: Promise< Response | null > }
->();
-
-function pruneSpeculative(): void {
-	const now = Date.now();
-	for ( const [ url, entry ] of speculative ) {
-		if ( now - entry.at > SPECULATIVE_TTL_MS ) {
-			speculative.delete( url );
-		}
-	}
-	// Oldest-first eviction if the shell over-asks.
-	while ( speculative.size > SPECULATIVE_MAX ) {
-		const oldest = speculative.keys().next().value;
-		if ( oldest === undefined ) {
-			break;
-		}
-		speculative.delete( oldest );
-	}
-}
-
-/**
- * Take a held document if one is waiting for this exact URL.
- *
- * Exact-match only: a speculative document is the answer to one
- * question, and a near-miss is a different screen.
- */
-function takeSpeculative(
-	url: string,
-): Promise< Response | null > | null {
-	const entry = speculative.get( url );
-	if ( ! entry ) {
-		return null;
-	}
-	speculative.delete( url );
-	if ( Date.now() - entry.at > SPECULATIVE_TTL_MS ) {
-		return null;
-	}
-	return entry.res;
-}
+const speculative = new SpeculativeStore();
 
 /**
  * Where the restore list lives between visits.
@@ -565,6 +517,15 @@ function beginSpeculation( href: string ): Promise< Response | null > | null {
 	}
 	const inFlight = ( async () => {
 		try {
+			// A plain same-origin GET: no `Referer`, no `Accept-Language`
+			// carried over from the navigation this stands in for.
+			// Deliberate — an admin screen's HTML does not branch on
+			// either (locale comes from the user's profile, server
+			// side), and forwarding request headers we did not receive
+			// would be guessing. If a screen ever did vary by them, the
+			// symptom would be a speculative copy differing from the
+			// real navigation, which is a reason to exclude that screen
+			// rather than to fabricate headers here.
 			// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.os` global available; raw fetch is the API.
 			const res = await fetch( href, {
 				credentials: 'same-origin',
@@ -584,32 +545,8 @@ function beginSpeculation( href: string ): Promise< Response | null > | null {
 		}
 	} )();
 
-	speculative.set( href, { at: Date.now(), res: inFlight } );
-	pruneSpeculative();
+	speculative.put( href, inFlight );
 	return inFlight;
-}
-
-/**
- * Whether a URL is a plain admin screen we may fetch early.
- *
- * Speculation must never *do* anything. Anything carrying an action or
- * a nonce is a request to change something — activating a plugin,
- * emptying the trash, applying an update — and fetching it ahead of a
- * click the user has not made yet would perform it. Screens only.
- */
-function isSpeculatableDocument( url: URL ): boolean {
-	if ( ! url.pathname.includes( '/wp-admin/' ) ) {
-		return false;
-	}
-	if ( ! url.searchParams.has( 'openstation_chromeless' ) ) {
-		return false;
-	}
-	for ( const key of [ 'action', 'action2', '_wpnonce', 'nonce', 'delete_all' ] ) {
-		if ( url.searchParams.has( key ) ) {
-			return false;
-		}
-	}
-	return true;
 }
 
 sw.addEventListener( 'push', ( event: SWPushEvent ) => {

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -436,8 +436,21 @@ function takeSpeculative(
 const SESSION_CACHE = `os-session-${ VERSION }`;
 const SESSION_KEY = '/__openstation_restore_targets__';
 
-/** Guard so one boot fires the replay once, not per intercepted request. */
-let replayedThisBoot = false;
+/**
+ * When the restore list was last replayed.
+ *
+ * Deliberately a timestamp rather than a "done" flag. A worker outlives
+ * any single page load — it stays resident across navigations and can
+ * be reused for hours — so a boolean would fire on the first shell load
+ * this worker ever saw and never again, leaving every later boot
+ * unaccelerated. That is exactly what the first live measurement
+ * showed: one window's TTFB halved, the other untouched.
+ *
+ * The throttle only exists to stop a burst of navigations stacking
+ * duplicate work; `beginSpeculation()` already de-duplicates by URL.
+ */
+let lastReplayAt = 0;
+const REPLAY_THROTTLE_MS = 3_000;
 
 /**
  * Start fetching the windows this session will restore, without
@@ -451,10 +464,11 @@ let replayedThisBoot = false;
  * the second one coming early enough to overlap them.
  */
 async function replayRestoreTargets(): Promise< void > {
-	if ( replayedThisBoot || ! CONFIG.windowPrewarm ) {
+	const now = Date.now();
+	if ( ! CONFIG.windowPrewarm || now - lastReplayAt < REPLAY_THROTTLE_MS ) {
 		return;
 	}
-	replayedThisBoot = true;
+	lastReplayAt = now;
 	try {
 		const cache = await caches.open( SESSION_CACHE );
 		const stored = await cache.match( SESSION_KEY );

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -85,12 +85,17 @@ interface SWFetchEvent {
 interface SWExtendableEvent {
 	waitUntil: ( p: Promise< unknown > ) => void;
 }
+interface SWMessageEvent {
+	data?: unknown;
+	waitUntil: ( p: Promise< unknown > ) => void;
+}
 interface SWEventMap {
 	install: SWExtendableEvent;
 	activate: SWExtendableEvent;
 	fetch: SWFetchEvent;
 	push: SWPushEvent;
 	notificationclick: SWNotificationEvent;
+	message: SWMessageEvent;
 }
 interface SWGlobal {
 	addEventListener< K extends keyof SWEventMap >(
@@ -266,6 +271,34 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
 		return;
 	}
 
+	// A window navigating to a document the shell asked us to fetch
+	// early. Answered from the held response — never re-fetched, which
+	// is what keeps the Sec-Fetch hazard described below out of play.
+	// Exact-URL, single-use; anything not waiting falls through to the
+	// normal pass-through for iframes.
+	if ( req.mode === 'navigate' && speculative.size > 0 ) {
+		const held = takeSpeculative( url.toString() );
+		if ( held ) {
+			event.respondWith(
+				held.then( ( res ) => {
+					if ( res ) {
+						return res;
+					}
+					// The speculative fetch failed or came back
+					// unusable. Re-fetching is safe for exactly these
+					// URLs — every one carries
+					// `openstation_chromeless=1`, which the server
+					// reads before it ever consults Sec-Fetch, so the
+					// hazard the navigate branch below guards against
+					// cannot bite here.
+					// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.os` global available; raw fetch is the API.
+					return fetch( req );
+				} ),
+			);
+			return;
+		}
+	}
+
 	if ( req.mode === 'navigate' && req.destination === 'document' ) {
 		// Only intercept TOP-LEVEL navigations. Iframe navigations
 		// (`req.destination === 'iframe'`) pass through directly to
@@ -288,6 +321,180 @@ sw.addEventListener( 'fetch', ( event: SWFetchEvent ) => {
 	// don't want to cache REST / AJAX (they carry nonces, per-request
 	// screen state) and HTML in admin pages is never safe to cache.
 } );
+
+/* -------------------------------------------------------------------------
+ * Speculative documents.
+ *
+ * The asset cache took the network out of a window's *assets*. What it
+ * cannot touch is the document: admin HTML carries nonces and
+ * per-request screen state, so it is never cacheable, and on this
+ * install it is the majority of a window open — measured at ~2.1 s of
+ * a ~3.8 s tab click, against ~1.7 s for everything the browser then
+ * does with it.
+ *
+ * That cost does not have to be paid *after* the click. The shell
+ * knows every URL a window can reach (dock items and submenu tabs come
+ * straight from the menu payload) and already reads hover intent. What
+ * was missing is the hand-off: the shell asks for a document ahead of
+ * time, the worker fetches it once and holds it, and the iframe's own
+ * navigation is answered from that held response.
+ *
+ * This is deliberately NOT keeping the tab alive. Nothing rendered is
+ * retained — no DOM, no live iframe, no memory beyond a Response body
+ * that expires in seconds. The page is still built fresh; it is simply
+ * built while the user is still deciding.
+ *
+ * **Why answering an iframe navigation is safe here, when the fetch
+ * handler otherwise refuses to.** The hazard it avoids (see the
+ * navigate branch above, and issue #171) is the worker *re-fetching*
+ * an iframe request: Chrome then sends `Sec-Fetch-Dest: empty`, the
+ * server's chromeless detection falls through, and the whole desktop
+ * renders inside a window. A speculative document is never re-fetched.
+ * It is fetched once, ahead of time, from a URL the shell built with
+ * `openstation_chromeless=1` present — and the server checks that
+ * query flag first, treating Sec-Fetch only as a fallback. So the
+ * bytes held here are already correctly chromeless, and serving them
+ * involves no second request at all.
+ *
+ * Single-use and short-lived on purpose: a document carries nonces and
+ * a moment-in-time view of the screen, so it is served at most once
+ * and only within {@link SPECULATIVE_TTL_MS}.
+ * ---------------------------------------------------------------------- */
+
+const SPECULATIVE_TTL_MS = 30_000;
+
+/** Cap on held documents — the shell only ever asks for a handful. */
+const SPECULATIVE_MAX = 6;
+
+/**
+ * Held documents, keyed by exact URL.
+ *
+ * The entry holds the **promise**, not the settled response, and that
+ * is the difference between the feature helping sometimes and helping
+ * always. A user who hovers and clicks half a second later would
+ * otherwise arrive while the fetch is still in flight, find nothing
+ * waiting, and start a *second* request for the same screen — paying
+ * full price and costing the server double. Awaiting the in-flight
+ * promise instead means the click inherits whatever head start the
+ * hover bought, from a few hundred milliseconds up to the whole load.
+ */
+const speculative = new Map<
+	string,
+	{ at: number; res: Promise< Response | null > }
+>();
+
+function pruneSpeculative(): void {
+	const now = Date.now();
+	for ( const [ url, entry ] of speculative ) {
+		if ( now - entry.at > SPECULATIVE_TTL_MS ) {
+			speculative.delete( url );
+		}
+	}
+	// Oldest-first eviction if the shell over-asks.
+	while ( speculative.size > SPECULATIVE_MAX ) {
+		const oldest = speculative.keys().next().value;
+		if ( oldest === undefined ) {
+			break;
+		}
+		speculative.delete( oldest );
+	}
+}
+
+/**
+ * Take a held document if one is waiting for this exact URL.
+ *
+ * Exact-match only: a speculative document is the answer to one
+ * question, and a near-miss is a different screen.
+ */
+function takeSpeculative(
+	url: string,
+): Promise< Response | null > | null {
+	const entry = speculative.get( url );
+	if ( ! entry ) {
+		return null;
+	}
+	speculative.delete( url );
+	if ( Date.now() - entry.at > SPECULATIVE_TTL_MS ) {
+		return null;
+	}
+	return entry.res;
+}
+
+sw.addEventListener( 'message', ( event: SWMessageEvent ) => {
+	const data = event.data as { type?: string; url?: string } | undefined;
+	if ( ! data || data.type !== 'os-speculate-doc' || ! data.url ) {
+		return;
+	}
+	if ( ! CONFIG.windowPrewarm ) {
+		// Same opt-in the dock's hover prewarming uses — this is that
+		// feature, applied to the document instead of a whole window.
+		return;
+	}
+	let url: URL;
+	try {
+		url = new URL( data.url );
+	} catch {
+		return;
+	}
+	if ( url.origin !== sw.location.origin || ! isSpeculatableDocument( url ) ) {
+		return;
+	}
+	const href = url.toString();
+	if ( speculative.has( href ) ) {
+		return;
+	}
+
+	// Registered before the fetch resolves, so a click that lands
+	// mid-flight finds the promise and waits on it rather than
+	// starting a duplicate request.
+	const inFlight = ( async () => {
+		try {
+			// eslint-disable-next-line no-restricted-syntax -- service-worker context, no `wp.os` global available; raw fetch is the API.
+			const res = await fetch( href, {
+				credentials: 'same-origin',
+				redirect: 'follow',
+			} );
+			// Only a clean, non-redirected 200 is worth holding: a
+			// redirect means the server wanted to send the user
+			// somewhere else, and replaying the destination under the
+			// original URL would hide that.
+			if ( res.status !== 200 || res.redirected ) {
+				return null;
+			}
+			return res;
+		} catch {
+			// Speculation is best-effort by definition.
+			return null;
+		}
+	} )();
+
+	speculative.set( href, { at: Date.now(), res: inFlight } );
+	pruneSpeculative();
+	event.waitUntil( inFlight );
+} );
+
+/**
+ * Whether a URL is a plain admin screen we may fetch early.
+ *
+ * Speculation must never *do* anything. Anything carrying an action or
+ * a nonce is a request to change something — activating a plugin,
+ * emptying the trash, applying an update — and fetching it ahead of a
+ * click the user has not made yet would perform it. Screens only.
+ */
+function isSpeculatableDocument( url: URL ): boolean {
+	if ( ! url.pathname.includes( '/wp-admin/' ) ) {
+		return false;
+	}
+	if ( ! url.searchParams.has( 'openstation_chromeless' ) ) {
+		return false;
+	}
+	for ( const key of [ 'action', 'action2', '_wpnonce', 'nonce', 'delete_all' ] ) {
+		if ( url.searchParams.has( key ) ) {
+			return false;
+		}
+	}
+	return true;
+}
 
 sw.addEventListener( 'push', ( event: SWPushEvent ) => {
 	// v1: no-op. Phase 4 will populate this from the push payload.

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -457,8 +457,14 @@ sw.addEventListener( 'message', ( event: SWMessageEvent ) => {
 		| { type?: string; url?: string; urls?: unknown }
 		| undefined;
 
-	// The restore list for the NEXT boot.
+	// The restore list for the NEXT boot. Gated like everything else
+	// here: the shell already checks the opt-in before posting, and
+	// checking again means a stray message can never make an
+	// opted-out browser start writing caches.
 	if ( data && data.type === 'os-remember-session' ) {
+		if ( ! CONFIG.windowPrewarm ) {
+			return;
+		}
 		const urls = Array.isArray( data.urls ) ? data.urls : [];
 		event.waitUntil(
 			( async () => {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -132,6 +132,36 @@ import {
 	toggleActionsMenu,
 } from './menus';
 import { handleDragStart, handleResizeStart } from './pointer';
+import { speculateDocument } from '../pwa/speculate';
+
+/**
+ * Ask the service worker to fetch a submenu tab's screen ahead of the
+ * click, when the user has opted into hover prewarming.
+ *
+ * The URL has to be the one the iframe will actually request — the
+ * worker matches exactly, and a tab's raw `data-url` is missing the
+ * chromeless flag `withChromelessParam()` adds on navigation.
+ *
+ * @param rawUrl The tab's declared admin URL.
+ */
+function speculateTabDocument( rawUrl: string ): void {
+	const os = (
+		window as unknown as {
+			wp?: {
+				os?: {
+					getOsSettings?: () => { windowPrewarmEnabled?: boolean };
+				};
+			};
+		}
+	).wp?.os;
+	if ( ! os?.getOsSettings?.().windowPrewarmEnabled ) {
+		return;
+	}
+	const target = withChromelessParam( rawUrl );
+	if ( target ) {
+		speculateDocument( target );
+	}
+}
 
 /** Animation mode accepted by `Window.requestAttention()`. */
 export type WindowAttentionMode = 'pulse' | 'shake' | 'bounce' | null;
@@ -1252,6 +1282,31 @@ export class Window {
 			tabs.addEventListener( 'keydown', ( e: Event ) =>
 				handleTabStripKeydown( tabs, e ),
 			);
+			/*
+			 * Hover intent → ask the service worker to fetch that
+			 * screen's document now. A submenu tab is a real page load
+			 * (the window navigates in place), and on a live install
+			 * the server rendering that page is the majority of the
+			 * wait — the part no cache can remove, because admin HTML
+			 * carries nonces. Fetching it while the pointer is still
+			 * on the tab moves that wait off the click.
+			 *
+			 * Delegated like the handlers above, and pointer-only:
+			 * touch has no hover, so there is no intent to read.
+			 */
+			tabs.addEventListener( 'pointerover', ( e: Event ) => {
+				const ev = e as PointerEvent;
+				if ( ev.pointerType !== 'mouse' ) {
+					return;
+				}
+				const tab = ( ev.target as HTMLElement | null )?.closest?.(
+					'.os-window__tab[data-url]',
+				) as HTMLElement | null;
+				const href = tab?.dataset.url;
+				if ( href ) {
+					speculateTabDocument( href );
+				}
+			} );
 			// Paint the edge fades only where scrolling would
 			// actually reveal another tab.
 			this._tabOverflowTeardown = observeTabOverflow( tabs );

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1293,6 +1293,14 @@ export class Window {
 			 *
 			 * Delegated like the handlers above, and pointer-only:
 			 * touch has no hover, so there is no intent to read.
+			 *
+			 * `pointerover` rather than `pointerenter` is deliberate:
+			 * `pointerenter` does not bubble, so it cannot be used from
+			 * a delegated listener, and the tabs come and go too often
+			 * to bind per tab. The cost is that this fires again as the
+			 * pointer crosses a tab's icon and label; both the shell's
+			 * ask-throttle and the worker's own de-duplication absorb
+			 * that, so the extra events are noise rather than work.
 			 */
 			tabs.addEventListener( 'pointerover', ( e: Event ) => {
 				const ev = e as PointerEvent;

--- a/tests/vitest/speculative-documents.test.ts
+++ b/tests/vitest/speculative-documents.test.ts
@@ -241,6 +241,49 @@ describe( 'rememberRestoreTargets', () => {
 			.serviceWorker;
 	} );
 
+	test( 'sends nothing at all when the opt-in is off', async () => {
+		// "Off by default" has to mean a user who never touched the
+		// setting does not pay so much as a postMessage. The gate lives
+		// in the session saver, so exercise it the way the saver does.
+		const { createSessionSaver } = await import(
+			'../../src/boot/session-saver'
+		);
+		const { installHooksStub, clearHooksStub } = await import(
+			'./helpers/hooks-stub'
+		);
+		installHooksStub();
+		const wp = ( window as unknown as { wp?: Record< string, unknown > } )
+			.wp as Record< string, unknown >;
+		// Merge rather than replace — the saver's error path needs the
+		// hooks stub installed above to still be reachable.
+		wp.os = {
+			getOsSettings: () => ( { windowPrewarmEnabled: false } ),
+			// The saver persists through `wp.os.fetch`; stub it so this
+			// test exercises the gate, not the network.
+			fetch: async () => new Response( '{}' ),
+		};
+		const manager = {
+			snapshot: () => ( {
+				windows: [ { id: 'a', url: '/wp-admin/index.php', native: false } ],
+				desktops: [],
+				activeDesktop: '',
+				focused: '',
+				updated: 0,
+			} ),
+		};
+		const save = createSessionSaver(
+			manager as never,
+			{ sessionUrl: '/x', restNonce: 'n' } as never,
+		);
+		save();
+		await new Promise( ( r ) => setTimeout( r, 800 ) );
+
+		expect( posted.filter( ( m ) => m.type === 'os-remember-session' ) )
+			.toHaveLength( 0 );
+		clearHooksStub();
+		delete ( wp as { os?: unknown } ).os;
+	} );
+
 	test( 'sends the restore list absolute, dropping foreign origins', () => {
 		rememberRestoreTargets( [
 			'/wp-admin/index.php' + CHROMELESS,

--- a/tests/vitest/speculative-documents.test.ts
+++ b/tests/vitest/speculative-documents.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Speculative documents — the load-bearing parts.
+ *
+ * Three things here are the difference between the feature working and
+ * quietly not working, and none of them are visible in a screenshot:
+ *
+ *   1. **The safety predicate.** Speculation fetches a URL before the
+ *      user has clicked anything. If it ever accepted a URL that
+ *      *acts*, a hover would activate a plugin or empty a trash.
+ *   2. **The store's promise semantics.** Holding the settled response
+ *      instead of the in-flight promise made a click landing mid-fetch
+ *      issue a second request for the same screen — the "5 ms vs
+ *      1,001 ms" split that burned the first implementation.
+ *   3. **The shell-side throttle.** A permanent "already asked" set is
+ *      the obvious de-duplication and silently disables the feature
+ *      after first use, because the worker's copy is single-use and
+ *      expires. Repeat visits to the same screen are exactly what the
+ *      feature is for.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { isSpeculatableDocument } from '../../src/pwa/sw-policy';
+import {
+	SPECULATIVE_MAX,
+	SPECULATIVE_TTL_MS,
+	SpeculativeStore,
+} from '../../src/pwa/speculative-store';
+import {
+	_resetSpeculation,
+	rememberRestoreTargets,
+	speculateDocument,
+} from '../../src/pwa/speculate';
+
+const CHROMELESS = '?openstation_chromeless=1';
+
+describe( 'isSpeculatableDocument', () => {
+	test( 'accepts a plain chromeless admin screen', () => {
+		expect(
+			isSpeculatableDocument(
+				new URL( 'https://site.test/wp-admin/options-writing.php' + CHROMELESS ),
+			),
+		).toBe( true );
+	} );
+
+	test( 'requires the chromeless flag', () => {
+		// Without it the server may not render the chromeless variant,
+		// and serving the result to an iframe would be unsafe.
+		expect(
+			isSpeculatableDocument(
+				new URL( 'https://site.test/wp-admin/options-writing.php' ),
+			),
+		).toBe( false );
+	} );
+
+	test( 'refuses anything outside wp-admin', () => {
+		expect(
+			isSpeculatableDocument( new URL( 'https://site.test/' + CHROMELESS ) ),
+		).toBe( false );
+	} );
+
+	test( 'refuses every URL that acts', () => {
+		// A hover must never activate a plugin, empty a trash, or apply
+		// an update.
+		const acting = [
+			'action=activate&plugin=foo/foo.php',
+			'action2=delete',
+			'_wpnonce=abc123',
+			'nonce=abc123',
+			'delete_all=1',
+		];
+		for ( const query of acting ) {
+			const url = new URL(
+				`https://site.test/wp-admin/plugins.php${ CHROMELESS }&${ query }`,
+			);
+			expect(
+				isSpeculatableDocument( url ),
+				`${ query } must never be speculated`,
+			).toBe( false );
+		}
+	} );
+} );
+
+describe( 'SpeculativeStore', () => {
+	const res = ( tag: string ) =>
+		Promise.resolve( new Response( tag ) as Response | null );
+
+	test( 'holds the in-flight promise, not the settled response', async () => {
+		const store = new SpeculativeStore();
+		let settle: ( r: Response | null ) => void = () => undefined;
+		const pending = new Promise< Response | null >( ( r ) => {
+			settle = r;
+		} );
+
+		store.put( '/a', pending );
+		// Claimed while still in flight — this is the case that used to
+		// start a duplicate request.
+		const taken = store.take( '/a' );
+		expect( taken ).not.toBeNull();
+
+		settle( new Response( 'late' ) );
+		expect( await ( taken as Promise< Response | null > )?.then( ( r ) => r?.text() ) ).toBe(
+			'late',
+		);
+	} );
+
+	test( 'a document is served once and only once', async () => {
+		const store = new SpeculativeStore();
+		store.put( '/a', res( 'one' ) );
+
+		expect( store.take( '/a' ) ).not.toBeNull();
+		// A document carries nonces and a moment-in-time view; replaying
+		// it would show a page that has already been superseded.
+		expect( store.take( '/a' ) ).toBeNull();
+	} );
+
+	test( 'an expired document is refused and dropped', () => {
+		let now = 1_000;
+		const store = new SpeculativeStore( () => now );
+		store.put( '/a', res( 'one' ) );
+
+		now += SPECULATIVE_TTL_MS + 1;
+		expect( store.take( '/a' ) ).toBeNull();
+		expect( store.has( '/a' ) ).toBe( false );
+	} );
+
+	test( 'reports what it is already holding, so callers do not refetch', () => {
+		const store = new SpeculativeStore();
+		store.put( '/a', res( 'one' ) );
+		expect( store.has( '/a' ) ).toBe( true );
+		expect( store.has( '/b' ) ).toBe( false );
+	} );
+
+	test( 'evicts oldest-first past the cap', () => {
+		let now = 1_000;
+		const store = new SpeculativeStore( () => now );
+		for ( let i = 0; i < SPECULATIVE_MAX + 2; i++ ) {
+			now += 1;
+			store.put( `/u${ i }`, res( String( i ) ) );
+		}
+
+		expect( store.size ).toBe( SPECULATIVE_MAX );
+		expect( store.has( '/u0' ) ).toBe( false );
+		expect( store.has( '/u1' ) ).toBe( false );
+		expect( store.has( `/u${ SPECULATIVE_MAX + 1 }` ) ).toBe( true );
+	} );
+
+	test( 'prunes expired entries without being asked for them', () => {
+		let now = 1_000;
+		const store = new SpeculativeStore( () => now );
+		store.put( '/old', res( 'old' ) );
+		now += SPECULATIVE_TTL_MS + 1;
+		store.put( '/new', res( 'new' ) );
+
+		expect( store.has( '/old' ) ).toBe( false );
+		expect( store.has( '/new' ) ).toBe( true );
+	} );
+} );
+
+describe( 'speculateDocument', () => {
+	let posted: Array< Record< string, unknown > >;
+
+	beforeEach( () => {
+		posted = [];
+		_resetSpeculation();
+		Object.defineProperty( navigator, 'serviceWorker', {
+			value: {
+				controller: {
+					postMessage: ( m: Record< string, unknown > ) => posted.push( m ),
+				},
+			},
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		delete ( navigator as unknown as { serviceWorker?: unknown } )
+			.serviceWorker;
+		vi.useRealTimers();
+	} );
+
+	test( 'asks the worker for a same-origin document', () => {
+		speculateDocument( '/wp-admin/options-writing.php' + CHROMELESS );
+
+		expect( posted ).toHaveLength( 1 );
+		expect( posted[ 0 ].type ).toBe( 'os-speculate-doc' );
+		expect( String( posted[ 0 ].url ) ).toContain( 'options-writing.php' );
+	} );
+
+	test( 'throttles a burst over one tab, then lets a later visit through', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime( new Date( 2_000_000 ) );
+		const url = '/wp-admin/options-writing.php' + CHROMELESS;
+
+		// A pointer crossing a tab's icon and label fires repeatedly.
+		speculateDocument( url );
+		speculateDocument( url );
+		speculateDocument( url );
+		expect( posted ).toHaveLength( 1 );
+
+		// The worker's copy is single-use and expires, so a genuine
+		// return visit must be able to ask again. A permanent "seen"
+		// set would silently make every repeat visit a no-op.
+		vi.advanceTimersByTime( 5_000 );
+		speculateDocument( url );
+		expect( posted ).toHaveLength( 2 );
+	} );
+
+	test( 'never asks about another origin', () => {
+		speculateDocument( 'https://evil.test/wp-admin/index.php' + CHROMELESS );
+		expect( posted ).toHaveLength( 0 );
+	} );
+
+	test( 'is a silent no-op with no controlling worker', () => {
+		Object.defineProperty( navigator, 'serviceWorker', {
+			value: { controller: null },
+			configurable: true,
+		} );
+		expect( () =>
+			speculateDocument( '/wp-admin/index.php' + CHROMELESS ),
+		).not.toThrow();
+		expect( posted ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'rememberRestoreTargets', () => {
+	let posted: Array< Record< string, unknown > >;
+
+	beforeEach( () => {
+		posted = [];
+		Object.defineProperty( navigator, 'serviceWorker', {
+			value: {
+				controller: {
+					postMessage: ( m: Record< string, unknown > ) => posted.push( m ),
+				},
+			},
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		delete ( navigator as unknown as { serviceWorker?: unknown } )
+			.serviceWorker;
+	} );
+
+	test( 'sends the restore list absolute, dropping foreign origins', () => {
+		rememberRestoreTargets( [
+			'/wp-admin/index.php' + CHROMELESS,
+			'https://evil.test/wp-admin/index.php' + CHROMELESS,
+			'/wp-admin/options-general.php' + CHROMELESS,
+		] );
+
+		expect( posted ).toHaveLength( 1 );
+		expect( posted[ 0 ].type ).toBe( 'os-remember-session' );
+		const urls = posted[ 0 ].urls as string[];
+		expect( urls ).toHaveLength( 2 );
+		expect( urls.every( ( u ) => u.startsWith( 'http://localhost' ) ) ).toBe(
+			true,
+		);
+	} );
+} );

--- a/tests/vitest/sw-policy.test.ts
+++ b/tests/vitest/sw-policy.test.ts
@@ -164,6 +164,7 @@ describe( 'readSwConfig', () => {
 	it( 'defaults to off + fallback URL on a missing preamble', () => {
 		expect( readSwConfig( undefined, FALLBACK ) ).toEqual( {
 			adminAssetCache: false,
+			windowPrewarm: false,
 			pluginUrl: FALLBACK,
 		} );
 		expect( readSwConfig( 'garbage', FALLBACK ).adminAssetCache ).toBe(
@@ -177,6 +178,18 @@ describe( 'readSwConfig', () => {
 		).toBe( true );
 		expect(
 			readSwConfig( { adminAssetCache: '1' }, FALLBACK ).adminAssetCache,
+		).toBe( false );
+	} );
+
+	it( 'reads the hover-prewarm flag independently of the cache flag', () => {
+		const cfg = readSwConfig(
+			{ adminAssetCache: false, windowPrewarm: true },
+			FALLBACK,
+		);
+		expect( cfg.windowPrewarm ).toBe( true );
+		expect( cfg.adminAssetCache ).toBe( false );
+		expect(
+			readSwConfig( { windowPrewarm: 1 }, FALLBACK ).windowPrewarm,
 		).toBe( false );
 	} );
 


### PR DESCRIPTION
The shared asset cache from #676 took the network out of a window's **assets**. It could never touch the **document** — admin HTML carries nonces and per-request screen state, so it is uncacheable by construction. And on a live install the document is the majority of a window open: measured at **~2.1 s of a ~3.8 s tab click**, against ~1.7 s for everything the browser then does with it.

That cost does not have to be paid *after* the click.

## The gap this closes

Two halves existed and were never connected:

- The **shell** already knows every URL a window can reach (dock items and submenu tabs come straight from the menu payload) and already reads hover intent.
- The **service worker** already receives the `fetch` event for every iframe navigation — and deliberately declines to answer it.

Now a hover on a submenu tab posts `os-speculate-doc` to the worker, which fetches that screen **once** and holds it; the iframe's own navigation is then answered from those bytes.

**This is explicitly not "keep the tab alive."** Nothing rendered is retained: no DOM, no live iframe, no memory beyond a response body dropped after 30 s. The page is still built fresh — it is simply built while the user is still deciding.

## Measured on openstation.blog (production WordPress.com hosting, real network)

| Tab click | Time from click to screen ready |
|---|---|
| No hover (control) | **1,997 ms** / **3,605 ms** |
| ~3 s hover | **961 ms** / **1,000 ms** / **1,002 ms** / **1,014 ms** |
| 600 ms hover (partial head start) | **1,014 ms** (from a 3,605 ms control) |

Roughly **2–3.5× faster**, and strikingly consistent once the document is in hand. The residual ~1 s is the browser parsing and executing that page's JavaScript — the half no prefetch can remove, and exactly what the earlier breakdown predicted:

| Where a tab click's time went (measured before this change) | | |
|---|---|---|
| Server building the document | 2,119 ms | 56% |
| Browser running the page's JavaScript | 1,671 ms | 44% |
| Downloading assets | 0 ms | 0% (already handled by #676) |

This PR removes the first row from the user's wait. The second row is untouched and honestly out of reach without retaining the rendered page, which we deliberately are not doing.

## The bug the first measurement caught

The first implementation held only the **settled** response. Two runs disagreed wildly — 5 ms in one, 1,001 ms in another — and the reason mattered: a click landing while the fetch was still in flight found nothing waiting and **started a second request for the same screen**. Full price for the user, double load for the server.

The store now holds the **promise**, so a mid-flight click awaits the request already running and inherits whatever head start the hover bought. That is why 600 ms of hover was enough to turn a 3,605 ms click into 1,014 ms.

## Why answering an iframe navigation is safe here

The fetch handler otherwise refuses to answer iframe navigations, and that guard stays. The hazard it exists for (#171) is the worker **re-fetching** an iframe request: Chrome then sends `Sec-Fetch-Dest: empty`, the server's chromeless detection falls through, and the entire desktop renders inside a window.

A speculative document is never re-fetched. It is fetched once, ahead of time, from a URL the shell built with `openstation_chromeless=1` present — and the server checks that query flag **before** it consults Sec-Fetch. So the held bytes are already correctly chromeless, and the fallback path (speculative fetch failed → fetch normally) is safe for exactly the same reason.

## Safety

- **Speculation never acts.** Any URL carrying `action`, `action2`, `_wpnonce`, `nonce` or `delete_all` is refused, so a hover can never activate a plugin, empty a trash, or apply an update.
- Same-origin, `/wp-admin/` only, and the chromeless flag must be present.
- **Single-use, exact-URL match, 30 s TTL**, capped at 6 held documents with oldest-first eviction.
- Redirected or non-200 responses are never held — a redirect means the server wanted the user somewhere else, and replaying the destination under the original URL would hide that.
- Gated on the existing **hover-prewarm** opt-in (`windowPrewarmEnabled`), delivered to the worker through the same `self.__OS_SW_CONFIG` preamble the asset cache uses. Off by default; zero behaviour change until a user opts in.
- Pointer-only (`pointerType === 'mouse'`) — touch has no hover, so there is no intent to read.

## Testing

`npm run typecheck`, `lint`, `lint:php`, `build` green. Full suites: **4,972 JS**, **2,495 PHP**. New coverage for the config flag's independent parsing in `sw-policy.test.ts`. Verified live on openstation.blog throughout: correct screens rendered (`Writing Settings`, `Media Settings`, `Discussion Settings`, `Permalink Settings` all confirmed by heading), forms intact, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-678-e41f84a016660bab3a6099e21ebe861ec7c64d1e.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->