### PR TITLE
Tooling: boot-cost never sends auth cookies off the measured origin

### DIFF
--- a/bin/boot-cost.mjs
+++ b/bin/boot-cost.mjs
@@ -58,18 +58,48 @@ function ownerOf( url ) {
  * POST, and the auth cookies from the POST to survive the redirect chain.
  * ---------------------------------------------------------------------- */
 
+/**
+ * The jar is bound to ONE origin: the site being measured. Cookies are
+ * only sent to, and only accepted from, that origin, and a `Secure`
+ * cookie only travels over https. Assets frequently live on another host
+ * (a CDN, a different hostname for the same site), and the WordPress
+ * auth cookies must never go there. A static asset needs no cookie anyway.
+ *
+ * Map of name -> { value, secure }.
+ */
 const jar = new Map();
+let jarOrigin = null;
 
-function jarHeader() {
-	return [ ...jar ].map( ( [ k, v ] ) => `${ k }=${ v }` ).join( '; ' );
+function jarBind( base ) {
+	jarOrigin = new URL( base ).origin;
+	jar.clear();
 }
 
-function jarStore( response ) {
+function jarHeader( url ) {
+	const target = new URL( url );
+	if ( target.origin !== jarOrigin ) {
+		return '';
+	}
+	return [ ...jar ]
+		.filter( ( [ , c ] ) => ! c.secure || target.protocol === 'https:' )
+		.map( ( [ name, c ] ) => `${ name }=${ c.value }` )
+		.join( '; ' );
+}
+
+function jarStore( url, response ) {
+	if ( new URL( url ).origin !== jarOrigin ) {
+		return;
+	}
 	for ( const cookie of response.headers.getSetCookie() ) {
-		const pair = cookie.split( ';' )[ 0 ];
+		const [ pair, ...attrs ] = cookie.split( ';' );
 		const eq = pair.indexOf( '=' );
 		if ( eq > 0 ) {
-			jar.set( pair.slice( 0, eq ).trim(), pair.slice( eq + 1 ).trim() );
+			jar.set( pair.slice( 0, eq ).trim(), {
+				value: pair.slice( eq + 1 ).trim(),
+				secure: attrs.some(
+					( a ) => a.trim().toLowerCase() === 'secure',
+				),
+			} );
 		}
 	}
 }
@@ -87,15 +117,16 @@ async function hop( url, init = {}, maxHops = 10 ) {
 	let current = url;
 	for ( let i = 0; i <= maxHops; i++ ) {
 		const headers = { ...( init.headers || {} ) };
-		if ( jar.size ) {
-			headers.cookie = jarHeader();
+		const cookie = jarHeader( current );
+		if ( cookie ) {
+			headers.cookie = cookie;
 		}
 		const response = await fetch( current, {
 			...init,
 			headers,
 			redirect: 'manual',
 		} );
-		jarStore( response );
+		jarStore( current, response );
 
 		const location = response.headers.get( 'location' );
 		if ( ! location || response.status < 300 || response.status >= 400 ) {
@@ -110,6 +141,8 @@ async function hop( url, init = {}, maxHops = 10 ) {
 }
 
 async function login( base, user, password ) {
+	jarBind( base );
+
 	// Priming GET: this is what sets the test cookie the POST is checked
 	// against. Skipping it makes the login silently fail.
 	await hop( `${ base }/wp-login.php` );
@@ -364,8 +397,16 @@ function diff( beforeFile, afterFile ) {
 
 /* ---------------------------------------------------------------------- */
 
-function parseArgs( argv ) {
-	const opts = { ...DEFAULTS, out: null, diff: null };
+function parseArgs( argv, env = process.env ) {
+	// Credentials: flag beats environment beats the wp-env default. The
+	// environment route keeps a password out of shell history and `ps`.
+	const opts = {
+		...DEFAULTS,
+		user: env.BOOT_COST_USER ?? DEFAULTS.user,
+		password: env.BOOT_COST_PASSWORD ?? DEFAULTS.password,
+		out: null,
+		diff: null,
+	};
 	for ( let i = 0; i < argv.length; i++ ) {
 		const arg = argv[ i ];
 		const value = () => {
@@ -425,6 +466,13 @@ Options
   --user / --password  Credentials (default ${ DEFAULTS.user } / ${ DEFAULTS.password })
   --concurrency N    Parallel asset fetches (default ${ DEFAULTS.concurrency })
   --diff A B         Compare two --out files and list what moved
+
+Environment
+  BOOT_COST_USER, BOOT_COST_PASSWORD
+                     Credentials without putting them on the command line.
+
+Cookies are only ever sent to the --base origin. Assets on another host
+are fetched anonymously, which is all a static asset needs.
 `;
 
 async function main() {


### PR DESCRIPTION
## What it does

`bin/boot-cost.mjs` now only ever sends auth cookies to the `--base` origin. Credentials can also come from the environment instead of the command line.

## Rationale

`hop()` attached the whole cookie jar to every request it made, and asset fetches go through `hop()` too. Against a wp-env instance that is invisible: every URL is the same host. But nothing in the script requires that. Any document whose assets resolve to a different host (a second hostname for the same install, a CDN) would have received the **WordPress auth cookies** on every one of ~150 asset requests. It also ignored `Secure`.

The script is only used against local wp-env today. This closes the hole so that stays a choice rather than a requirement.

## Implementation

The jar is bound to one origin at login. Cookies are only sent to, and only accepted from, that origin; a `Secure` cookie only travels over https:

```js
function jarHeader( url ) {
	const target = new URL( url );
	if ( target.origin !== jarOrigin ) {
		return '';
	}
	return [ ...jar ]
		.filter( ( [ , c ] ) => ! c.secure || target.protocol === 'https:' )
		.map( ( [ name, c ] ) => `${ name }=${ c.value }` )
		.join( '; ' );
}
```

Assets on any other host are fetched anonymously, which is all a static asset ever needed.

Credentials also come from `BOOT_COST_USER` / `BOOT_COST_PASSWORD`, so a password never has to land in shell history or `ps`. Precedence is flag, then environment, then the wp-env default.

## Testing instructions

The leak has a local reproduction. A wp-env instance's site URL is `localhost`, so logging in at `127.0.0.1` makes WordPress redirect **across origins** on the way into the admin:

```bash
WP_ENV_PORT=8895 npm run env:start
node bin/boot-cost.mjs --base http://127.0.0.1:8895
```

| | trunk | this branch |
|---|---|---|
| Result | Logs in and measures 159 requests | `login failed … landed back on http://localhost:8895/wp-login.php` |

Trunk only "succeeds" because it carries the cookies issued by `127.0.0.1` over to `localhost`. This branch stops at exactly that hop, which is what a browser does. To see the old behaviour side by side: `git show origin/trunk:bin/boot-cost.mjs > /tmp/old.mjs && node /tmp/old.mjs --base http://127.0.0.1:8895`.

Same-origin measurement is unchanged (`--base http://localhost:8895` still reports 159 requests). Also verified: wrong `BOOT_COST_PASSWORD` fails the login, `--password` overrides it, env alone works.

`npm run build` passes with no churn in `assets/js/`. No runtime code is touched.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-679-11ad92c7660101d8cac39eced6552c3d5b26d0a0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
