### PR TITLE
Fix: a spinner from one tab painted over another tab's finished page

### DIFF
--- a/src/window/loading.ts
+++ b/src/window/loading.ts
@@ -39,6 +39,7 @@ import {
 	LOADING_HANDOFF_BODY_CLASS,
 	LOADING_STARTED_ATTR,
 	removeLoadingOverlay,
+	scheduleLoadingOverlayShow,
 	stampLoadingStart,
 } from './dom';
 
@@ -266,6 +267,61 @@ function _installSubscriptions(): void {
  *
  * @public
  */
+/**
+ * Show or suppress a window's loading overlay for the tab on screen.
+ *
+ * **The overlay belongs to the primary iframe alone.** It is a single
+ * element on the window body, armed when that iframe starts a
+ * navigation and cleared when it settles — but the body hosts every
+ * tab's iframe, and switching tabs only toggles their `display`.
+ * Nothing reconciled the overlay with the tab you were actually
+ * looking at, so a navigation in the primary painted a spinner over a
+ * kept-alive external tab whose content had been ready for minutes.
+ * Observed live: body `--loading` already cleared, overlay still
+ * visible, sitting on top of a finished page until the fade timer
+ * happened to end.
+ *
+ * External tabs never drive this overlay — they load in their own
+ * iframe, hidden, and their readiness is their own business — so the
+ * rule is simply: show it only while the primary tab is the one on
+ * screen, and restore it on the way back if that iframe is still
+ * loading.
+ *
+ * @param windowEl The window's outer element.
+ * @param visible  Whether the primary tab is the active one.
+ */
+export function syncLoadingOverlayToTab(
+	windowEl: HTMLElement,
+	visible: boolean,
+): void {
+	const body = windowEl.querySelector< HTMLElement >(
+		':scope .os-window__body',
+	);
+	if ( ! body ) {
+		return;
+	}
+	const overlay = body.querySelector< HTMLElement >(
+		`:scope .${ LOADING_OVERLAY_CLASS }`,
+	);
+	if ( ! overlay ) {
+		return;
+	}
+	if ( ! visible ) {
+		// Leave the body's loading class alone — it is the primary
+		// iframe's own state, and the handler that clears it needs to
+		// find it. Only the painted spinner is hidden.
+		overlay.classList.remove( LOADING_OVERLAY_VISIBLE_CLASS );
+		return;
+	}
+	// Back on the primary tab: re-arm only if it is genuinely still
+	// loading. `scheduleLoadingOverlayShow` re-reads the elapsed time,
+	// so a navigation that started long enough ago paints immediately
+	// and a fresh one still gets its grace period.
+	if ( body.classList.contains( LOADING_BODY_CLASS ) ) {
+		scheduleLoadingOverlayShow( body, overlay );
+	}
+}
+
 export function repaintLoadingOverlays(): void {
 	const bodies = document.querySelectorAll< HTMLElement >(
 		'.os-window__body--loading',

--- a/src/window/tabs.ts
+++ b/src/window/tabs.ts
@@ -18,6 +18,7 @@ import { showToast } from '../toast';
 import { pageIdentityKey, urlMatchKey } from '../utils';
 import { EXTERNAL_IFRAME_READY_TIMEOUT_MS } from './constants';
 import { syncTabStripSemantics, withChromelessParam } from './dom';
+import { syncLoadingOverlayToTab } from './loading';
 import {
 	activatePanelTab,
 	positionTabPlate,
@@ -374,6 +375,12 @@ export function switchToTab( win: Window, tabId: 'primary' | string ): void {
 		return;
 	}
 	win._activeTabId = tabId;
+
+	// The loading overlay tracks the primary iframe, but lives on the
+	// body every tab shares. Reconcile it with what is actually on
+	// screen, or a navigation in the primary paints a spinner over a
+	// kept-alive external tab that finished loading long ago.
+	syncLoadingOverlayToTab( win.element, tabId === 'primary' );
 
 	// Primary iframe visibility.
 	if ( win.iframe ) {

--- a/tests/vitest/tab-switch-loading-overlay.test.ts
+++ b/tests/vitest/tab-switch-loading-overlay.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The loading overlay has to belong to the tab you are looking at.
+ *
+ * A window's overlay is a single element on the body, armed when the
+ * PRIMARY iframe starts a navigation. But the body hosts every tab's
+ * iframe, and switching tabs only toggles their `display`. Nothing
+ * reconciled the two, so this happened in real use:
+ *
+ *   1. Click a submenu tab — the primary iframe starts loading, the
+ *      spinner paints.
+ *   2. Switch to a kept-alive external tab whose content has been
+ *      ready for minutes.
+ *   3. Sit under a spinner that belongs to a different tab until a
+ *      fade timer happens to end.
+ *
+ * Observed live before the fix: body `--loading` already cleared, the
+ * overlay still carrying its visible class, on top of a finished page.
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import { syncLoadingOverlayToTab } from '../../src/window/loading';
+import {
+	LOADING_OVERLAY_CLASS,
+	LOADING_OVERLAY_VISIBLE_CLASS,
+} from '../../src/window/constants';
+import { LOADING_BODY_CLASS, LOADING_STARTED_ATTR } from '../../src/window/dom';
+
+/**
+ * A window element shaped the way `createWindowElement` builds one.
+ *
+ * `startedAgoMs` matters: the overlay has a 120 ms grace period so a
+ * fast load never paints a spinner, and the schedule re-reads the
+ * stamp rather than restarting the clock. A load already past that
+ * window paints immediately; a fresh one still waits.
+ */
+function makeWindow( {
+	loading,
+	startedAgoMs = 5_000,
+}: {
+	loading: boolean;
+	startedAgoMs?: number;
+} ): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.className = 'os-window';
+	const body = document.createElement( 'div' );
+	body.className = 'os-window__body';
+	if ( loading ) {
+		body.classList.add( LOADING_BODY_CLASS );
+		body.setAttribute(
+			LOADING_STARTED_ATTR,
+			String( Date.now() - startedAgoMs ),
+		);
+	}
+	const overlay = document.createElement( 'div' );
+	overlay.className = LOADING_OVERLAY_CLASS;
+	body.appendChild( overlay );
+	el.appendChild( body );
+	document.body.appendChild( el );
+	return el;
+}
+
+const overlayOf = ( el: HTMLElement ) =>
+	el.querySelector< HTMLElement >( `.${ LOADING_OVERLAY_CLASS }` )!;
+
+describe( 'syncLoadingOverlayToTab', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'hides a painted spinner when a non-primary tab takes the screen', () => {
+		const el = makeWindow( { loading: true } );
+		overlayOf( el ).classList.add( LOADING_OVERLAY_VISIBLE_CLASS );
+
+		// The user switches to a kept-alive external tab.
+		syncLoadingOverlayToTab( el, false );
+
+		expect(
+			overlayOf( el ).classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+		).toBe( false );
+	} );
+
+	test( 'leaves the primary iframe’s own loading state alone', () => {
+		// The body class is the primary's truth, and the handler that
+		// clears it has to still find it. Suppressing the spinner must
+		// not fake "finished loading".
+		const el = makeWindow( { loading: true } );
+		overlayOf( el ).classList.add( LOADING_OVERLAY_VISIBLE_CLASS );
+
+		syncLoadingOverlayToTab( el, false );
+
+		const body = el.querySelector( '.os-window__body' )!;
+		expect( body.classList.contains( LOADING_BODY_CLASS ) ).toBe( true );
+	} );
+
+	test( 'restores the spinner when returning to a still-loading primary', () => {
+		const el = makeWindow( { loading: true } );
+		const overlay = overlayOf( el );
+		overlay.classList.add( LOADING_OVERLAY_VISIBLE_CLASS );
+		syncLoadingOverlayToTab( el, false );
+		expect(
+			overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+		).toBe( false );
+
+		// Back to the primary tab, which never finished.
+		syncLoadingOverlayToTab( el, true );
+
+		expect( overlay.classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ) )
+			.toBe( true );
+	} );
+
+	test( 'does not conjure a spinner for a primary that has settled', () => {
+		const el = makeWindow( { loading: false } );
+
+		syncLoadingOverlayToTab( el, true );
+
+		expect(
+			overlayOf( el ).classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+		).toBe( false );
+	} );
+
+	test( 'returning during a just-started load still respects the grace period', () => {
+		// The 120 ms delay exists so a fast navigation never flashes a
+		// spinner. Coming back to the primary must not skip it.
+		const el = makeWindow( { loading: true, startedAgoMs: 0 } );
+
+		syncLoadingOverlayToTab( el, true );
+
+		expect(
+			overlayOf( el ).classList.contains( LOADING_OVERLAY_VISIBLE_CLASS ),
+		).toBe( false );
+	} );
+
+	test( 'is a no-op on a window with no overlay yet', () => {
+		const el = document.createElement( 'div' );
+		const body = document.createElement( 'div' );
+		body.className = 'os-window__body';
+		el.appendChild( body );
+		document.body.appendChild( el );
+
+		expect( () => syncLoadingOverlayToTab( el, false ) ).not.toThrow();
+		expect( () => syncLoadingOverlayToTab( el, true ) ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
## The bug

A window's loading overlay is a **single element on the window body**, armed when the **primary** iframe starts a navigation. But the body hosts *every* tab's iframe, and `switchToTab()` only toggles their `display` — nothing reconciled the overlay with the tab actually on screen.

So:

1. Click a submenu tab → the primary iframe starts loading, the spinner paints.
2. Switch to a kept-alive external tab whose content has been ready for minutes.
3. Sit under a spinner belonging to a *different* tab until a fade timer happens to end.

Reproduced live on openstation.blog before the fix — body `--loading` already cleared, overlay still carrying its visible class, sitting on top of a finished page:

| Moment | overlay visible |
|---|---|
| Primary tab mid-navigation | true *(correct)* |
| Switched to a fully-loaded external tab | **true** ← the bug |
| ~3 s later, when the fade timer ended | false |

## The fix

External tabs never drive this overlay — they load in their own iframe, hidden, and their readiness is their own business. So the rule is simply: **show the spinner only while the primary tab is the one on screen**, and restore it on the way back if that iframe is still loading.

`syncLoadingOverlayToTab()` deliberately **leaves the body's loading class alone** — that class is the primary iframe's own state, and the handler that clears it needs to find it there. Only the painted spinner is suppressed, so nothing is faked into looking "finished". Coming back re-arms through `scheduleLoadingOverlayShow()`, which re-reads the load-start stamp: a navigation already past the 120 ms grace period paints at once, a fresh one still waits it out.

Verified live after the fix, same scenario:

| Moment | overlay visible |
|---|---|
| Primary tab mid-navigation | true *(unchanged — correct feedback)* |
| Switched to a loaded external tab | **false** |
| Still on that tab 1.5 s later | **false** |
| Switched back while the primary is still loading | **true** *(restored)* |
| After the primary settled | false |

## Not a bug: the two kinds of tab

Worth writing down, because the report's premise is a reasonable misreading of the UI:

- **Submenu tabs** (General / Writing / Reading in a Settings window) share **one** iframe and genuinely navigate it — the window I inspected had 11 tabs and exactly 1 iframe. They are *not* kept in memory, and a loader there is honest.
- **External tabs** (a link that opened as a tab inside the window) each get **their own** iframe and stay alive. Switching between those is a `display` toggle, and correctly showed no loader.

## Testing

6 new cases in `tests/vitest/tab-switch-loading-overlay.test.ts`: suppression on switching away, the body class being left intact, restoration on returning to a still-loading primary, no spinner conjured for a settled primary, the grace period still honoured on return, and a no-op on a window without an overlay yet.

One of them caught a real subtlety while I was writing it — an early fixture omitted the load-start stamp, so the restore path silently deferred behind the 120 ms delay instead of painting. The fixture now mirrors what `createWindowElement` actually builds.

Full suites green: **4,994 JS**, typecheck, lint, build. Deployed to openstation.blog and verified there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-680-d229c80cdf4b723bc65c08ed93835c9f1928cd38.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->