### PR TITLE
Perf: windows stop paying for a command palette they never show

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1803,6 +1803,56 @@ add_action( 'openstation_chromeless_trimmed_assets', static function () {
 
 ---
 
+### `openstation_chromeless_trim_command_palette` — Experimental
+
+Whether Core's command-palette runtime is dropped inside a window. Default `true` on every screen except block-editor screens.
+
+The shell owns ⌘K: the keystroke is handled in the parent frame, and the parent only asks a window for its commands when the palette is actually opened (`os-commands-subscribe`). The runtime that answers is nevertheless enqueued by Core on every admin page, so each window paid for it eagerly on the chance the user might one day press ⌘K while that window held focus. Measured on a live install opening **Settings** in a window, that was 43 files, **10.66 MB raw / 1.94 MB gzipped — 73.6% of everything the window downloaded** — parsed and executed again in each window's own JavaScript realm, where an HTTP cache hit buys nothing.
+
+`post.php`, `post-new.php`, the site editor and the widgets screen are exempt: they load the same Gutenberg chain for their own reasons, so the palette rides along for the cost of `commands.js` + `core-commands.js`, and those are exactly the screens whose stores hold commands worth harvesting ("Duplicate block", pattern commands). Everywhere else the store holds only the WordPress baseline, which the shell already publishes from its own lazily-loaded runtime.
+
+```php
+// Keep Core's palette (and its Gutenberg chain) inside windows.
+add_filter( 'openstation_chromeless_trim_command_palette', '__return_false' );
+```
+
+### `openstation_command_palette_root_handles` — Experimental
+
+The handles treated as command-palette roots. Defaults: `wp-commands` (the `core/commands` store package) and `wp-core-commands` (WordPress's baseline command set). A queued script whose dependency closure reaches one of these is considered a palette contributor.
+
+```php
+apply_filters( 'openstation_command_palette_root_handles', string[] $handles );
+```
+
+### `openstation_command_palette_family` — Experimental
+
+The full set of handles dropped by the palette trim: the roots plus every scanned handle that reaches one of them, directly or transitively.
+
+This is a family trim for the same reason the admin-bar trim above is: dropping the roots alone saves nothing while a single dependent survives, because `WP_Dependencies::all_deps()` pulls the whole chain back in on that dependent's behalf. Measured with only Core's enqueue deferred, a Settings window still pulled 14.28 MB of the original 14.49 MB — Astra's `command-palette.js` and WooCommerce's `command-palette.js` / `command-palette-analytics.js` each declare `wp-commands` and were still queued.
+
+Note that handles pulled in only *as dependencies of* a palette contributor need no special handling: they stop being requested once their last dependent leaves, and stay if anything else still needs them. WooCommerce's `wc-settings` (a 96 KB inline blob) disappears from a Settings window for exactly that reason, and remains on a WooCommerce screen that uses it.
+
+Use this filter as the escape hatch for a script that registers commands *and* renders part of its own admin screen — a distinction the dependency walk cannot make.
+
+```php
+// Keep a bundle that registers commands but also draws its own screen.
+add_filter( 'openstation_command_palette_family', static function ( array $family ) {
+    return array_values( array_diff( $family, array( 'my-plugin-admin-app' ) ) );
+} );
+```
+
+### `openstation_chromeless_trimmed_command_palette` — Experimental (action)
+
+Fires after the palette family is dropped in a window.
+
+```php
+add_action( 'openstation_chromeless_trimmed_command_palette', static function () {
+    wp_dequeue_script( 'my-plugin-palette-extras' );
+} );
+```
+
+---
+
 ### `openstation_native_window_allowed_html` — Experimental
 
 The `wp_kses`-shaped allowlist used when escaping native-window `<template>` payloads. The default extends `wp_kses_allowed_html( 'post' )` with form controls, `<os-*>` web components, dashicon spans, and permissive `data-*` / `aria-*` attributes. Plugins registering their own native windows can extend the list with custom tags or attributes if their templates need markup not covered by the default.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1809,7 +1809,9 @@ Whether Core's command-palette runtime is dropped inside a window. Default `true
 
 The shell owns ⌘K: the keystroke is handled in the parent frame, and the parent only asks a window for its commands when the palette is actually opened (`os-commands-subscribe`). The runtime that answers is nevertheless enqueued by Core on every admin page, so each window paid for it eagerly on the chance the user might one day press ⌘K while that window held focus. Measured on a live install opening **Settings** in a window, that was 43 files, **10.66 MB raw / 1.94 MB gzipped — 73.6% of everything the window downloaded** — parsed and executed again in each window's own JavaScript realm, where an HTTP cache hit buys nothing.
 
-`post.php`, `post-new.php`, the site editor and the widgets screen are exempt: they load the same Gutenberg chain for their own reasons, so the palette rides along for the cost of `commands.js` + `core-commands.js`, and those are exactly the screens whose stores hold commands worth harvesting ("Duplicate block", pattern commands). Everywhere else the store holds only the WordPress baseline, which the shell already publishes from its own lazily-loaded runtime.
+`post.php`, `post-new.php`, `site-editor.php` and `widgets.php` are exempt: they load the same Gutenberg chain for their own reasons, so the palette rides along for the cost of `commands.js` + `core-commands.js`, and those are exactly the screens whose stores hold commands worth harvesting ("Duplicate block", pattern commands). Everywhere else the store holds only the WordPress baseline, which the shell already publishes from its own lazily-loaded runtime.
+
+`customize.php` is **not** exempt. It was, on the assumption that the block-widgets panel made it an editor screen; measured, the exemption bought nothing. The Customizer's own consumers hold its Gutenberg chain either way, so the trim removes only the palette and the palette extensions there and leaves `wp-block-editor`, `wp-blocks`, `wp-components` and every plugin block script in place.
 
 ```php
 // Keep Core's palette (and its Gutenberg chain) inside windows.
@@ -1826,7 +1828,9 @@ apply_filters( 'openstation_command_palette_root_handles', string[] $handles );
 
 ### `openstation_command_palette_family` — Experimental
 
-The full set of handles dropped by the palette trim: the roots plus every scanned handle that reaches one of them, directly or transitively.
+The full set of handles dropped by the palette trim: the roots plus every scanned handle that reaches one of them **without routing through one of Core's own packages**.
+
+That second condition is load-bearing, not tidiness. `wp-block-editor` declares `wp-commands` directly — the editor *registers* commands, so the dependency runs the opposite way from a palette extension's — and `wp-editor` does the same. A plain closure walk therefore convicts the whole block-editor stack, and every plugin block script above it, of being palette contributors. Core packages are consequently never trimmed as dependents, and the walk will not travel through one to reach a root: a handle qualifies only when the palette appears in its own chain, the way Astra's and WooCommerce's palette scripts both name `wp-commands` themselves.
 
 This is a family trim for the same reason the admin-bar trim above is: dropping the roots alone saves nothing while a single dependent survives, because `WP_Dependencies::all_deps()` pulls the whole chain back in on that dependent's behalf. Measured with only Core's enqueue deferred, a Settings window still pulled 14.28 MB of the original 14.49 MB — Astra's `command-palette.js` and WooCommerce's `command-palette.js` / `command-palette-analytics.js` each declare `wp-commands` and were still queued.
 

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -780,10 +780,17 @@ add_action( 'admin_enqueue_scripts', 'openstation_enqueue_assets' );
  * capture the chain instead, and the shell loads it on the first
  * palette invocation.
  *
- * Deliberately scoped: chromeless iframes and classic-mode requests
- * keep Core's default — inside an iframe the runtime powers the
- * command harvest the bridge streams to the parent, and a classic
- * page is Core's own UI where Core's palette is the right one.
+ * Deliberately scoped: classic-mode requests keep Core's default,
+ * because a classic page is Core's own UI where Core's palette is the
+ * right one.
+ *
+ * Windows are handled separately by
+ * {@see openstation_chromeless_should_trim_command_palette()} in
+ * `includes/render/chromeless-trim.php` — same idea, but it has to
+ * drop the whole palette *family* rather than just unhook Core's
+ * callback, and it exempts block-editor screens. Unhooking alone is
+ * not enough there: a third-party palette extension that declares
+ * `wp-commands` keeps the entire chain queued as its dependency.
  *
  * Priority 0, ahead of Core's default 10, so the removal lands
  * before the callback fires. On WP 6.9 (function exists, no default

--- a/includes/render/chromeless-trim.php
+++ b/includes/render/chromeless-trim.php
@@ -209,43 +209,114 @@ function openstation_command_palette_root_handles() {
 }
 
 /**
+ * Whether a handle is one of Core's own bundled packages.
+ *
+ * **This is the line between a palette contributor and a library, and
+ * getting it wrong breaks the block editor.** `wp-block-editor` declares
+ * `wp-commands` directly:
+ *
+ *     wp-block-editor => …, wp-blocks, wp-commands, wp-components, …
+ *     wp-editor       => …, wp-block-editor, wp-commands, …
+ *
+ * It does so because the editor *registers* commands into the palette
+ * store — the dependency runs the opposite way from a palette extension,
+ * which *is* the palette. A closure walk cannot tell those apart, so
+ * without this exclusion the walk convicts the whole block-editor stack
+ * and drops it, taking every plugin's block-registration script with it.
+ * Measured on `customize.php` before this rule existed: the block-widgets
+ * panel lost `wp-block-editor`, and Contact Form 7's and MailPoet's block
+ * scripts went with it.
+ *
+ * Core packages are therefore never *dependents* to be trimmed. They are
+ * libraries, and `WP_Dependencies` already knows how to decide whether
+ * one is needed: if something still queued requires it, it resolves and
+ * stays; if the only thing that wanted it was the palette, it falls out
+ * on its own. The roots themselves are exempt from this rule — they are
+ * the palette, not a library it uses.
+ *
+ * @param WP_Dependencies $dependencies The scripts registry.
+ * @param string          $handle       Handle to test.
+ * @return bool
+ */
+function openstation_is_core_package_handle( $dependencies, $handle ) {
+	if ( ! isset( $dependencies->registered[ $handle ] ) ) {
+		return false;
+	}
+	$src = $dependencies->registered[ $handle ]->src;
+
+	return ( is_string( $src ) && false !== strpos( $src, '/wp-includes/js/dist/' ) );
+}
+
+/**
  * Whether `$handle`'s dependency closure reaches any of `$roots`.
  *
- * `$seen` is passed by reference so a diamond-shaped dependency graph
- * is walked once per node rather than once per path — the Gutenberg
- * chain is full of diamonds, and a by-value guard turns this into an
- * exponential walk.
+ * `$memo` is passed by reference and shared across every candidate in a
+ * single {@see openstation_command_palette_family()} call, so each node
+ * is decided once per call rather than once per candidate that happens
+ * to sit above it. The Gutenberg graph is dense with shared nodes, and
+ * the walk runs twice per request (dequeue, then print list), so a
+ * per-candidate guard re-walks the same subgraph repeatedly.
+ *
+ * A handle currently being walked is memoized as `null`, which reads as
+ * "not yet known" and breaks a dependency cycle the same way a visited
+ * set would.
  *
  * @param WP_Dependencies $dependencies The scripts registry.
  * @param string          $handle       Handle to test.
  * @param string[]        $roots        Root handles to look for.
- * @param array           $seen         Visited handles, by reference.
+ * @param array           $memo         Handle => verdict, by reference.
  * @return bool
  */
-function openstation_handle_depends_on( $dependencies, $handle, $roots, &$seen ) {
-	if ( isset( $seen[ $handle ] ) || ! isset( $dependencies->registered[ $handle ] ) ) {
+function openstation_handle_depends_on( $dependencies, $handle, $roots, &$memo ) {
+	if ( array_key_exists( $handle, $memo ) ) {
+		// `null` means "in progress" — a cycle, which reaches nothing new.
+		return ( true === $memo[ $handle ] );
+	}
+	if ( ! isset( $dependencies->registered[ $handle ] ) ) {
+		$memo[ $handle ] = false;
 		return false;
 	}
-	$seen[ $handle ] = true;
+
+	$memo[ $handle ] = null;
+	$result          = false;
 
 	foreach ( $dependencies->registered[ $handle ]->deps as $dep ) {
 		if ( in_array( $dep, $roots, true ) ) {
-			return true;
+			$result = true;
+			break;
 		}
-		if ( openstation_handle_depends_on( $dependencies, $dep, $roots, $seen ) ) {
-			return true;
+
+		/*
+		 * Never route through a Core package. Reaching the palette *via*
+		 * `wp-block-editor` says something about the editor, not about
+		 * this handle: Contact Form 7's block script declares
+		 * `wp-block-editor`, and traversing into it would convict the
+		 * block script of being a palette extension. A real palette
+		 * extension names the palette in its own chain — Astra's and
+		 * WooCommerce's both list `wp-commands` directly.
+		 */
+		if ( openstation_is_core_package_handle( $dependencies, $dep ) ) {
+			continue;
+		}
+		if ( openstation_handle_depends_on( $dependencies, $dep, $roots, $memo ) ) {
+			$result = true;
+			break;
 		}
 	}
-	return false;
+
+	$memo[ $handle ] = $result;
+	return $result;
 }
 
 /**
  * The command-palette family present in a given handle list.
  *
- * Returns the roots plus every handle in `$handles` that reaches one
- * of them — Astra's `astra-command-palette`, WooCommerce's
- * `wc-admin-command-palette`, and anything else a plugin registers
- * against the palette.
+ * Returns the roots plus every handle in `$handles` that reaches one of
+ * them without routing through a Core package — Astra's
+ * `astra-command-palette`, WooCommerce's `command-palette`, and anything
+ * else a plugin registers *against* the palette. See
+ * {@see openstation_is_core_package_handle()} for why that second
+ * condition is load-bearing rather than a tidiness rule.
  *
  * @param WP_Dependencies $dependencies The scripts registry.
  * @param string[]        $handles      Handles to scan.
@@ -254,13 +325,14 @@ function openstation_handle_depends_on( $dependencies, $handle, $roots, &$seen )
 function openstation_command_palette_family( $dependencies, $handles ) {
 	$roots  = openstation_command_palette_root_handles();
 	$family = $roots;
+	$memo   = array();
 
 	foreach ( $handles as $handle ) {
-		if ( in_array( $handle, $family, true ) ) {
+		if ( in_array( $handle, $family, true )
+			|| openstation_is_core_package_handle( $dependencies, $handle ) ) {
 			continue;
 		}
-		$seen = array();
-		if ( openstation_handle_depends_on( $dependencies, $handle, $roots, $seen ) ) {
+		if ( openstation_handle_depends_on( $dependencies, $handle, $roots, $memo ) ) {
 			$family[] = $handle;
 		}
 	}
@@ -335,12 +407,21 @@ function openstation_chromeless_should_trim_command_palette() {
  * The site editor and the block-based widgets screen load the same
  * runtime without setting that flag, so they are named explicitly.
  *
+ * **`customize.php` is deliberately not in this list.** It was, on the
+ * assumption that the block-widgets panel made it an editor screen.
+ * Measured, it is not one worth exempting: the Customizer keeps its own
+ * Gutenberg chain either way — that chain has real consumers there, and
+ * they hold it — so the trim removes only the palette and the palette
+ * extensions, and the exemption bought nothing. Verified on a live
+ * install that `wp-block-editor`, `wp-blocks`, `wp-components` and every
+ * plugin block script survive the trim on that screen.
+ *
  * @return bool
  */
 function openstation_chromeless_screen_uses_block_editor() {
 	global $pagenow;
 
-	if ( in_array( $pagenow, array( 'site-editor.php', 'widgets.php', 'customize.php' ), true ) ) {
+	if ( in_array( $pagenow, array( 'site-editor.php', 'widgets.php' ), true ) ) {
 		return true;
 	}
 	if ( ! function_exists( 'get_current_screen' ) ) {

--- a/includes/render/chromeless-trim.php
+++ b/includes/render/chromeless-trim.php
@@ -183,6 +183,282 @@ function openstation_chromeless_suppress_emoji() {
 add_action( 'admin_init', 'openstation_chromeless_suppress_emoji' );
 
 /**
+ * The Core command-palette root handles.
+ *
+ * `wp-commands` is the `core/commands` store package; `wp-core-commands`
+ * registers WordPress's baseline command set on top of it. Everything
+ * else in the family reaches the palette *through* one of these two, so
+ * they are both the things to drop and the marker that identifies a
+ * dependent as a palette contributor.
+ *
+ * @return string[]
+ */
+function openstation_command_palette_root_handles() {
+	/**
+	 * Filters the handles treated as command-palette roots.
+	 *
+	 * A queued script whose dependency closure reaches one of these is
+	 * considered a palette contributor and is trimmed inside windows.
+	 *
+	 * @param string[] $handles Root handles.
+	 */
+	return (array) apply_filters(
+		'openstation_command_palette_root_handles',
+		array( 'wp-commands', 'wp-core-commands' )
+	);
+}
+
+/**
+ * Whether `$handle`'s dependency closure reaches any of `$roots`.
+ *
+ * `$seen` is passed by reference so a diamond-shaped dependency graph
+ * is walked once per node rather than once per path — the Gutenberg
+ * chain is full of diamonds, and a by-value guard turns this into an
+ * exponential walk.
+ *
+ * @param WP_Dependencies $dependencies The scripts registry.
+ * @param string          $handle       Handle to test.
+ * @param string[]        $roots        Root handles to look for.
+ * @param array           $seen         Visited handles, by reference.
+ * @return bool
+ */
+function openstation_handle_depends_on( $dependencies, $handle, $roots, &$seen ) {
+	if ( isset( $seen[ $handle ] ) || ! isset( $dependencies->registered[ $handle ] ) ) {
+		return false;
+	}
+	$seen[ $handle ] = true;
+
+	foreach ( $dependencies->registered[ $handle ]->deps as $dep ) {
+		if ( in_array( $dep, $roots, true ) ) {
+			return true;
+		}
+		if ( openstation_handle_depends_on( $dependencies, $dep, $roots, $seen ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * The command-palette family present in a given handle list.
+ *
+ * Returns the roots plus every handle in `$handles` that reaches one
+ * of them — Astra's `astra-command-palette`, WooCommerce's
+ * `wc-admin-command-palette`, and anything else a plugin registers
+ * against the palette.
+ *
+ * @param WP_Dependencies $dependencies The scripts registry.
+ * @param string[]        $handles      Handles to scan.
+ * @return string[] Handles to drop.
+ */
+function openstation_command_palette_family( $dependencies, $handles ) {
+	$roots  = openstation_command_palette_root_handles();
+	$family = $roots;
+
+	foreach ( $handles as $handle ) {
+		if ( in_array( $handle, $family, true ) ) {
+			continue;
+		}
+		$seen = array();
+		if ( openstation_handle_depends_on( $dependencies, $handle, $roots, $seen ) ) {
+			$family[] = $handle;
+		}
+	}
+
+	/**
+	 * Filters the command-palette handles dropped inside windows.
+	 *
+	 * Remove a handle here to keep it inside windows — the escape hatch
+	 * for a script that registers commands *and* renders part of its own
+	 * admin screen, which the dependency walk cannot tell apart.
+	 *
+	 * @param string[] $family  Handles about to be dropped.
+	 * @param string[] $handles The handles that were scanned.
+	 */
+	return (array) apply_filters( 'openstation_command_palette_family', $family, $handles );
+}
+
+/**
+ * Whether this request should drop the Core command-palette runtime.
+ *
+ * **Why a window never needs it.** ⌘K inside a window belongs to the
+ * shell: the desktop owns the palette, the keystroke is handled in the
+ * parent frame, and the parent only asks a window for its commands when
+ * the palette is actually opened (`os-commands-subscribe`, sent from
+ * `onPaletteOpened()` in `src/commands/iframe-bridge.ts`). The runtime
+ * that answers that request was nevertheless loaded eagerly in every
+ * window, on the chance the user might one day press ⌘K while that
+ * window happened to hold focus.
+ *
+ * What that cost, measured on a live install opening Settings in a
+ * window: 43 files, 10.66 MB raw / 1.94 MB gzipped — react, react-dom,
+ * `components.js` (3.7 MB), `block-editor.js` (3.7 MB), `core-data`,
+ * `blocks`, `sync` — **73.6% of everything the window downloaded**, then
+ * parsed and executed again in each window's own JavaScript realm,
+ * where an HTTP cache hit buys nothing.
+ *
+ * **Block-editor screens are exempt.** `post.php`, `post-new.php`, the
+ * site editor and the widgets screen load that same chain for their own
+ * reasons, so the palette rides along for the cost of `commands.js` +
+ * `core-commands.js` (~150 KB) — and those are exactly the screens whose
+ * stores hold commands worth harvesting ("Duplicate block", pattern
+ * commands). Trimming there would cost real functionality and save
+ * nothing. Everywhere else the store only ever holds the WordPress
+ * baseline, which the shell already publishes itself from its own
+ * lazily-loaded runtime (`src/commands/shell-harvester.ts`).
+ *
+ * @return bool
+ */
+function openstation_chromeless_should_trim_command_palette() {
+	if ( ! openstation_is_chromeless_request() ) {
+		return false;
+	}
+
+	$trim = ! openstation_chromeless_screen_uses_block_editor();
+
+	/**
+	 * Filters whether the Core command-palette runtime is dropped in a
+	 * window.
+	 *
+	 * Return `false` to keep Core's palette — and its Gutenberg
+	 * dependency chain — inside windows on this screen.
+	 *
+	 * @param bool $trim Whether to trim. Defaults to true off block-editor screens.
+	 */
+	return (bool) apply_filters( 'openstation_chromeless_trim_command_palette', $trim );
+}
+
+/**
+ * Whether the current admin screen renders the block editor.
+ *
+ * `WP_Screen::is_block_editor()` covers `post.php` / `post-new.php`.
+ * The site editor and the block-based widgets screen load the same
+ * runtime without setting that flag, so they are named explicitly.
+ *
+ * @return bool
+ */
+function openstation_chromeless_screen_uses_block_editor() {
+	global $pagenow;
+
+	if ( in_array( $pagenow, array( 'site-editor.php', 'widgets.php', 'customize.php' ), true ) ) {
+		return true;
+	}
+	if ( ! function_exists( 'get_current_screen' ) ) {
+		return false;
+	}
+	$screen = get_current_screen();
+
+	return ( $screen instanceof WP_Screen && $screen->is_block_editor() );
+}
+
+/**
+ * Keeps Core's boot-time palette enqueue off window pages.
+ *
+ * Removing the callback rather than dequeuing its handles afterwards
+ * also skips the work it does *before* enqueuing anything: a walk of
+ * `$menu` and `$submenu` running `current_user_can()` and
+ * `menu_page_url()` per entry, serialized into a 19.6 KB inline
+ * `wp.coreCommands.initializeCommandPalette( … )` blob — per window.
+ *
+ * Priority 0, ahead of Core's default 10. The shell's own deferral
+ * lives in {@see openstation_defer_core_command_palette()}; this is
+ * the window half of the same idea.
+ */
+function openstation_chromeless_defer_command_palette() {
+	if ( ! openstation_chromeless_should_trim_command_palette() ) {
+		return;
+	}
+	remove_action( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' );
+}
+add_action( 'admin_enqueue_scripts', 'openstation_chromeless_defer_command_palette', 0 );
+
+/**
+ * Drops the command-palette family inside windows.
+ *
+ * Unhooking Core's enqueue above is necessary but nowhere near
+ * sufficient, and a live measurement showed exactly why: with Core's
+ * palette deferred, a Settings window still pulled 14.28 MB of the
+ * original 14.49 MB, because Astra's `command-palette.js` and
+ * WooCommerce's `command-palette.js` / `command-palette-analytics.js`
+ * each declare `wp-commands` as a dependency and were still queued.
+ * `WP_Dependencies::all_deps()` then pulls the entire chain back in on
+ * their behalf. Dropping the roots alone saves nothing while a single
+ * dependent survives — which is the same lesson the admin-bar trim
+ * above records, and the reason both are family trims.
+ *
+ * Runs at `PHP_INT_MAX` so it sees the queue after every plugin has
+ * had its say. Dequeue, never deregister: a handle that stays
+ * registered can still be resolved as a dependency by something that
+ * genuinely needs it.
+ */
+function openstation_chromeless_trim_command_palette() {
+	if ( ! openstation_chromeless_should_trim_command_palette() ) {
+		return;
+	}
+
+	$scripts = wp_scripts();
+	if ( ! $scripts ) {
+		return;
+	}
+
+	foreach ( openstation_command_palette_family( $scripts, $scripts->queue ) as $handle ) {
+		wp_dequeue_script( $handle );
+	}
+	foreach ( openstation_command_palette_root_handles() as $handle ) {
+		wp_dequeue_style( $handle );
+	}
+
+	/**
+	 * Fires after OpenStation drops the command-palette family in a window.
+	 */
+	do_action( 'openstation_chromeless_trimmed_command_palette' );
+}
+add_action( 'admin_enqueue_scripts', 'openstation_chromeless_trim_command_palette', PHP_INT_MAX );
+
+/**
+ * Second pass: strip the palette family from the actual print list.
+ *
+ * Same two survivors as the named trim below — late enqueues and
+ * dependency pull-back — but the family has to be recomputed here
+ * rather than reused, because a handle enqueued after
+ * `admin_enqueue_scripts` was never in the queue the dequeue pass
+ * scanned. The walk runs against the to-print list, which is the last
+ * word before output.
+ *
+ * @param string[] $handles Script handles about to print.
+ * @return string[]
+ */
+function openstation_chromeless_filter_palette_print_list( $handles ) {
+	if ( ! is_array( $handles ) || ! openstation_chromeless_should_trim_command_palette() ) {
+		return $handles;
+	}
+	$scripts = wp_scripts();
+	if ( ! $scripts ) {
+		return $handles;
+	}
+	$family = openstation_command_palette_family( $scripts, $handles );
+
+	return array_values( array_diff( $handles, $family ) );
+}
+add_filter( 'print_scripts_array', 'openstation_chromeless_filter_palette_print_list' );
+
+/**
+ * Second pass: strip the palette style roots from the print list.
+ *
+ * @param string[] $handles Style handles about to print.
+ * @return string[]
+ */
+function openstation_chromeless_filter_palette_style_print_list( $handles ) {
+	if ( ! is_array( $handles ) || ! openstation_chromeless_should_trim_command_palette() ) {
+		return $handles;
+	}
+	return array_values(
+		array_diff( $handles, openstation_command_palette_root_handles() )
+	);
+}
+add_filter( 'print_styles_array', 'openstation_chromeless_filter_palette_style_print_list' );
+
+/**
  * Second pass: strip trimmed handles from the actual print list.
  *
  * The dequeue above cannot be the whole story, and a live install

--- a/tests/phpunit/tests/openStationChromelessCommandPalette.php
+++ b/tests/phpunit/tests/openStationChromelessCommandPalette.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Tests for the command-palette trim inside windows.
+ *
+ * The shell owns ⌘K, and the parent only asks a window for its
+ * commands when the palette is actually opened — yet every window
+ * loaded the palette runtime (the Gutenberg chain) eagerly. These
+ * tests pin the family walk that drops it, and the block-editor
+ * exemption that keeps it where the chain loads anyway.
+ *
+ * @package OpenStation
+ *
+ * @group openstation
+ */
+class Tests_OpenStation_ChromelessCommandPalette extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function tear_down() {
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+		unset( $_GET['openstation_chromeless'] );
+		remove_all_filters( 'openstation_chromeless_trim_command_palette' );
+		remove_all_filters( 'openstation_command_palette_family' );
+		remove_all_filters( 'openstation_command_palette_root_handles' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Puts the request into the chromeless state a window creates.
+	 */
+	private function enter_chromeless() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['openstation_chromeless'] = '1';
+	}
+
+	/**
+	 * Registers a throwaway script graph:
+	 *
+	 *   os-test-direct    -> wp-commands          (a palette contributor)
+	 *   os-test-indirect  -> os-test-direct       (reaches it transitively)
+	 *   os-test-unrelated -> jquery               (must be left alone)
+	 */
+	private function register_graph() {
+		wp_register_script( 'os-test-direct', 'https://example.org/d.js', array( 'wp-commands' ), '1', true );
+		wp_register_script( 'os-test-indirect', 'https://example.org/i.js', array( 'os-test-direct' ), '1', true );
+		wp_register_script( 'os-test-unrelated', 'https://example.org/u.js', array( 'jquery' ), '1', true );
+	}
+
+	/**
+	 * @covers ::openstation_command_palette_root_handles
+	 */
+	public function test_roots_are_the_two_core_palette_packages() {
+		$roots = openstation_command_palette_root_handles();
+
+		$this->assertContains( 'wp-commands', $roots );
+		$this->assertContains( 'wp-core-commands', $roots );
+	}
+
+	/**
+	 * The whole point of a family walk: dropping the roots while a
+	 * dependent stays queued saves nothing, because `all_deps()` pulls
+	 * the chain straight back in on the dependent's behalf.
+	 *
+	 * @covers ::openstation_command_palette_family
+	 */
+	public function test_family_covers_direct_and_transitive_dependents() {
+		$this->register_graph();
+		$scripts = wp_scripts();
+
+		$family = openstation_command_palette_family(
+			$scripts,
+			array( 'os-test-direct', 'os-test-indirect', 'os-test-unrelated' )
+		);
+
+		$this->assertContains( 'wp-commands', $family );
+		$this->assertContains( 'os-test-direct', $family );
+		$this->assertContains( 'os-test-indirect', $family );
+		$this->assertNotContains( 'os-test-unrelated', $family );
+	}
+
+	/**
+	 * @covers ::openstation_command_palette_family
+	 */
+	public function test_family_is_filterable_to_protect_a_handle() {
+		$this->register_graph();
+		add_filter(
+			'openstation_command_palette_family',
+			static function ( $family ) {
+				return array_values( array_diff( $family, array( 'os-test-direct' ) ) );
+			}
+		);
+
+		$family = openstation_command_palette_family( wp_scripts(), array( 'os-test-direct' ) );
+
+		$this->assertNotContains( 'os-test-direct', $family );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_should_trim_command_palette
+	 */
+	public function test_no_trim_outside_a_window() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		// No chromeless flag: this is the shell, which has its own deferral.
+
+		$this->assertFalse( openstation_chromeless_should_trim_command_palette() );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_should_trim_command_palette
+	 */
+	public function test_trims_on_an_ordinary_window_screen() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+
+		$this->assertTrue( openstation_chromeless_should_trim_command_palette() );
+	}
+
+	/**
+	 * On a block-editor screen the Gutenberg chain loads for the
+	 * editor's own sake, so the palette rides along nearly free — and
+	 * those are the screens whose commands are worth harvesting.
+	 *
+	 * @covers ::openstation_chromeless_should_trim_command_palette
+	 * @covers ::openstation_chromeless_screen_uses_block_editor
+	 */
+	public function test_block_editor_screens_keep_the_palette() {
+		$this->enter_chromeless();
+		set_current_screen( 'post' );
+		get_current_screen()->is_block_editor( true );
+
+		$this->assertFalse( openstation_chromeless_should_trim_command_palette() );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_screen_uses_block_editor
+	 */
+	public function test_site_editor_is_treated_as_a_block_editor_screen() {
+		global $pagenow;
+		$this->enter_chromeless();
+		$previous = $pagenow;
+		$pagenow  = 'site-editor.php';
+
+		$uses_editor = openstation_chromeless_screen_uses_block_editor();
+
+		$pagenow = $previous;
+		$this->assertTrue( $uses_editor );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_should_trim_command_palette
+	 */
+	public function test_trim_can_be_filtered_off() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+		add_filter( 'openstation_chromeless_trim_command_palette', '__return_false' );
+
+		$this->assertFalse( openstation_chromeless_should_trim_command_palette() );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_trim_command_palette
+	 */
+	public function test_dequeues_the_family_in_a_window() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+		$this->register_graph();
+		wp_enqueue_script( 'os-test-direct' );
+		wp_enqueue_script( 'os-test-indirect' );
+		wp_enqueue_script( 'os-test-unrelated' );
+
+		openstation_chromeless_trim_command_palette();
+
+		$this->assertFalse( wp_script_is( 'os-test-direct', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'os-test-indirect', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'os-test-unrelated', 'enqueued' ) );
+	}
+
+	/**
+	 * Dequeue, never deregister — a handle something genuinely needs
+	 * must still resolve as a dependency.
+	 *
+	 * @covers ::openstation_chromeless_trim_command_palette
+	 */
+	public function test_trim_dequeues_without_deregistering() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+		$this->register_graph();
+		wp_enqueue_script( 'os-test-direct' );
+
+		openstation_chromeless_trim_command_palette();
+
+		$this->assertTrue( wp_script_is( 'os-test-direct', 'registered' ) );
+	}
+
+	/**
+	 * The last word before output: late enqueues and dependency
+	 * pull-back both survive the dequeue pass.
+	 *
+	 * @covers ::openstation_chromeless_filter_palette_print_list
+	 */
+	public function test_print_list_filter_strips_the_family() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+		$this->register_graph();
+
+		$filtered = openstation_chromeless_filter_palette_print_list(
+			array( 'os-test-direct', 'os-test-unrelated', 'wp-commands' )
+		);
+
+		$this->assertSame( array( 'os-test-unrelated' ), $filtered );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_filter_palette_print_list
+	 */
+	public function test_print_list_filter_is_inert_outside_a_window() {
+		wp_set_current_user( self::$admin_id );
+		$handles = array( 'os-test-direct', 'wp-commands' );
+
+		$this->assertSame(
+			$handles,
+			openstation_chromeless_filter_palette_print_list( $handles )
+		);
+	}
+
+	/**
+	 * Unhooking Core's callback also skips the `$menu` / `$submenu`
+	 * walk it runs before enqueuing anything, and the inline blob it
+	 * serializes from it.
+	 *
+	 * @covers ::openstation_chromeless_defer_command_palette
+	 */
+	public function test_core_palette_enqueue_is_unhooked_in_a_window() {
+		if ( ! function_exists( 'wp_enqueue_command_palette_assets' ) ) {
+			$this->markTestSkipped( 'This WordPress has no Core command palette.' );
+		}
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+		add_action( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' );
+
+		openstation_chromeless_defer_command_palette();
+
+		$this->assertFalse(
+			has_action( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' )
+		);
+	}
+}

--- a/tests/phpunit/tests/openStationChromelessCommandPalette.php
+++ b/tests/phpunit/tests/openStationChromelessCommandPalette.php
@@ -84,6 +84,84 @@ class Tests_OpenStation_ChromelessCommandPalette extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The regression this whole design turns on.
+	 *
+	 * `wp-block-editor` declares `wp-commands` directly — the editor
+	 * *registers* commands, so the dependency runs opposite to a palette
+	 * extension's. A naive closure walk therefore convicts the entire
+	 * block-editor stack, and every plugin block script above it, of
+	 * being palette contributors and drops them.
+	 *
+	 * @covers ::openstation_command_palette_family
+	 * @covers ::openstation_is_core_package_handle
+	 */
+	public function test_core_packages_are_never_trimmed_as_dependents() {
+		$scripts = wp_scripts();
+		// Stand in for Core's real registration, which declares
+		// `wp-commands` among `wp-block-editor`'s deps.
+		wp_register_script(
+			'os-test-core-pkg',
+			includes_url( 'js/dist/block-editor.js' ),
+			array( 'wp-commands' ),
+			'1',
+			true
+		);
+
+		$family = openstation_command_palette_family( $scripts, array( 'os-test-core-pkg' ) );
+
+		$this->assertNotContains( 'os-test-core-pkg', $family );
+	}
+
+	/**
+	 * A plugin's block script reaches `wp-commands` only by way of
+	 * `wp-block-editor`. That says something about the editor, not about
+	 * the block script — so the walk must not route through a Core
+	 * package to convict it. Contact Form 7's block script is the real
+	 * case this was found on.
+	 *
+	 * @covers ::openstation_command_palette_family
+	 */
+	public function test_a_plugin_script_is_not_convicted_through_a_core_package() {
+		wp_register_script(
+			'os-test-core-pkg',
+			includes_url( 'js/dist/block-editor.js' ),
+			array( 'wp-commands' ),
+			'1',
+			true
+		);
+		wp_register_script(
+			'os-test-block-script',
+			'https://example.org/block.js',
+			array( 'os-test-core-pkg' ),
+			'1',
+			true
+		);
+
+		$family = openstation_command_palette_family(
+			wp_scripts(),
+			array( 'os-test-block-script' )
+		);
+
+		$this->assertNotContains( 'os-test-block-script', $family );
+	}
+
+	/**
+	 * The other half of the same rule: a genuine palette extension names
+	 * the palette in its own dependency chain, without a Core package in
+	 * between, and must still be caught. Astra and WooCommerce both do.
+	 *
+	 * @covers ::openstation_command_palette_family
+	 */
+	public function test_a_palette_extension_behind_its_own_script_is_still_caught() {
+		wp_register_script( 'os-test-base', 'https://example.org/b.js', array( 'wp-commands' ), '1', true );
+		wp_register_script( 'os-test-ext', 'https://example.org/e.js', array( 'os-test-base' ), '1', true );
+
+		$family = openstation_command_palette_family( wp_scripts(), array( 'os-test-ext' ) );
+
+		$this->assertContains( 'os-test-ext', $family );
+	}
+
+	/**
 	 * @covers ::openstation_command_palette_family
 	 */
 	public function test_family_is_filterable_to_protect_a_handle() {
@@ -214,6 +292,47 @@ class Tests_OpenStation_ChromelessCommandPalette extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( array( 'os-test-unrelated' ), $filtered );
+	}
+
+	/**
+	 * The style counterpart of the print-list pass. Today it only ever
+	 * removes the roots, but the moment a root or a family member ships
+	 * a stylesheet this is the thing that has to catch it.
+	 *
+	 * @covers ::openstation_chromeless_filter_palette_style_print_list
+	 */
+	public function test_style_print_list_filter_strips_the_roots() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+
+		$filtered = openstation_chromeless_filter_palette_style_print_list(
+			array( 'wp-commands', 'common', 'wp-core-commands', 'forms' )
+		);
+
+		$this->assertSame( array( 'common', 'forms' ), $filtered );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_filter_palette_style_print_list
+	 */
+	public function test_style_print_list_filter_is_inert_outside_a_window() {
+		wp_set_current_user( self::$admin_id );
+		$handles = array( 'wp-commands', 'common' );
+
+		$this->assertSame(
+			$handles,
+			openstation_chromeless_filter_palette_style_print_list( $handles )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_filter_palette_style_print_list
+	 */
+	public function test_style_print_list_filter_survives_a_non_array() {
+		$this->enter_chromeless();
+		set_current_screen( 'options-general' );
+
+		$this->assertSame( 'nope', openstation_chromeless_filter_palette_style_print_list( 'nope' ) );
 	}
 
 	/**


### PR DESCRIPTION
> **Numbers corrected in `bca279bc`.** The first revision of this PR claimed a Settings window went from 137 requests / 14.49 MB to 80 / 3.36 on a WooCommerce-heavy site. That build was misclassifying Core's block-editor stack as palette contributors and dropping it — the saving was substantially collateral damage. The measurements below are from the corrected walk. Earlier browser-timing figures are withdrawn for the same reason.

## The finding

Opening **Settings** in a window pulls a contiguous Gutenberg dependency chain — react, react-dom, `components.js`, `block-editor.js`, `core-data`, `blocks`, `sync` — terminating at `core-commands.js`.

All of it exists to power **Core's ⌘K command palette**, which the shell replaces.

The shell handles the keystroke in the parent frame and only asks a window for its commands when the palette is actually opened — `onPaletteOpened()` in `src/commands/iframe-bridge.ts` is the only caller of `os-commands-subscribe`. **The harvest was already strictly on demand; the runtime that answers it was loaded eagerly, in every window**, on the chance the user might one day press ⌘K while that window held focus. An iframe is its own JavaScript realm, so an HTTP cache hit buys nothing — every window parses and executes all of it again.

The shell already defers this (#664). Windows were excluded on the reasoning that the iframe runtime feeds the harvest — true, but it doesn't require paying at boot.

## Why it has to be a family trim

Unhooking Core's enqueue alone recovers almost nothing. Astra's `command-palette.js` and WooCommerce's `command-palette.js` / `command-palette-analytics.js` each declare `wp-commands`, so `all_deps()` pulls the chain straight back in on their behalf. That is the same lesson the admin-bar trim in this file already records, so this follows the same shape.

## Why it must also stop at Core's own packages

This is the correction in `bca279bc`, and it is the subtle part of the change.

`wp-block-editor` declares `wp-commands` **directly**:

```
wp-block-editor => …, wp-blocks, wp-commands, wp-components, …
wp-editor       => …, wp-block-editor, wp-commands, …
```

It does so because the editor *registers* commands into the palette store — the dependency runs the **opposite way** from a palette extension, which *is* the palette. A plain closure walk cannot tell those apart, so the first revision convicted the entire block-editor stack and dropped it, taking every plugin block-registration script above it along. Measured on `customize.php`: the block-widgets panel lost `wp-block-editor`, and Contact Form 7's and MailPoet's block scripts went with it.

Two rules fix it:

1. **Core packages are never trimmed as dependents.** They are libraries; `WP_Dependencies` already knows whether one is needed — if something queued requires it, it resolves and stays; if the palette was its only consumer, it falls out on its own.
2. **The walk never travels *through* a Core package to reach a root.** Reaching the palette via `wp-block-editor` says something about the editor, not about the handle under test. A genuine palette extension names the palette in its own chain, which is exactly what Astra's and WooCommerce's scripts do.

## Exemptions

`post.php`, `post-new.php`, `site-editor.php` and `widgets.php` are exempt: they load the Gutenberg chain for their own reasons, so the palette rides along for the cost of `commands.js` + `core-commands.js`, and those are the screens whose stores hold commands worth harvesting ("Duplicate block", pattern commands).

`customize.php` **was** exempt and no longer is. It was added on the assumption that the block-widgets panel made it an editor screen; measured, the exemption bought nothing. With the corrected walk the Customizer keeps its own chain either way, so the trim removes only the palette there. Verified on that screen: `wp-block-editor`, `wp-blocks`, `wp-components` and all three plugin block scripts survive; only `commands`, `core-commands` and the two palette extensions go.

---

# Measurements

`npm run perf:boot-cost` — deterministic, measures what the server printed rather than what a cache happened to hold. **The size of the win depends entirely on whether anything else on the site pulls the Gutenberg runtime**, so both shapes are reported.

## Clean install — WordPress + OpenStation only

The palette is the sole consumer, so the whole chain goes. `options-general.php` in a window:

| | Requests | Raw | Gzipped |
|---|---|---|---|
| Before | 85 | 4.06 MB | 1.26 MB |
| After | **43** | **0.83 MB** | **0.25 MB** |
| | **−49%** | **−80%** | **−80%** |

## A plugin-heavy install — WooCommerce, ACF, Astra, Contact Form 7, MailPoet

WooCommerce enqueues its data packages on every admin screen and those pull the Gutenberg runtime **independently of the palette**, so the chain stays and the remaining win is modest. Nothing breaks, which is the point of the correction.

| Screen | Before | After | |
|---|---|---|---|
| `options-general.php` | 137 req / 14.49 MB | 127 req / 14.14 MB | −10 req |
| `tools.php` | 109 req / 13.19 MB | 99 req / 12.83 MB | −10 req |
| `edit.php` | 115 req / 13.32 MB | 105 req / 12.96 MB | −10 req |
| `customize.php` | 340 req / 32.57 MB | 332 req / 32.36 MB | −8 req |

What is removed on such a site is Core's palette runtime, the two third-party palette extensions, the 19.6 KB inline `initializeCommandPalette( … )` blob, and the `$menu` / `$submenu` walk (a `current_user_can()` and `menu_page_url()` per entry) that PHP runs to build it — per window.

## Verified on a production install

Checked on a live WordPress.com site: `core-commands.js`, `commands.js` and `block-editor.js` are absent from a Settings window. `components.min.js` is still loaded there — by a genuine non-palette consumer, not the palette — which is the dependency walk behaving as intended. No A/B was run against production, since that would mean editing a live site.

---

## New hooks

Documented in `docs/hooks-reference.md`:

- `openstation_chromeless_trim_command_palette` — whether to trim (default `true` off block-editor screens)
- `openstation_command_palette_root_handles` — what counts as a palette root
- `openstation_command_palette_family` — the resolved family; the escape hatch for a bundle that registers commands *and* draws its own screen
- `openstation_chromeless_trimmed_command_palette` (action)

## Testing

- Full PHPUnit: **2516 tests, 0 failures**; 19 in `openStationChromelessCommandPalette.php`, including regression tests for the Core-package rule (a core handle declaring `wp-commands` is never trimmed; a plugin block script reaching the palette only via `wp-block-editor` is never trimmed; a palette extension behind its own script still is) and both directions of the style-side print-list pass
- `npm run lint:php` (phpcs -n): clean
- `npm run build`: no drift

**Manual check requested:** open Settings / Tools / Users in windows and confirm they render and behave normally; press ⌘K with a window focused to confirm the shell palette still works; open a post in a window to confirm block commands still reach the palette; and open the Customizer in a window to confirm the block-widgets panel still loads.

## Follow-up, not in this PR

The same family still anchors the **shell boot**. Probed and reverted: trimming it on shell pages took boot from 190 req / 15.74 MB to 142 / 5.19 on the plugin-heavy site — but that probe predates the Core-package correction, so treat the figure as an upper bound until re-measured. Left out because it touches the palette-replay/harvester architecture rather than the established chromeless-trim pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-682-bca279bc2d010d6c91168fa1e0bc311ff97933e4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->