### PR TITLE
Perf: a window stops building the admin bar it never draws

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -1746,6 +1746,22 @@ Controls the `Sec-Fetch-*` fallback in chromeless detection: when a request arri
 apply_filters( 'openstation_chromeless_sec_fetch_fallback', bool $allow );
 ```
 
+### `openstation_chromeless_silence_admin_bar` — Experimental
+
+Whether a window skips **building** the admin bar it never draws. Default `true` inside windows.
+
+Suppressing the render stops the markup, not the work. `_wp_admin_bar_init()` is hooked on `admin_init`, `is_admin_bar_showing()` short-circuits to true for any admin request, and so every window still instantiated `WP_Admin_Bar` and called `add_menus()` — which fires `admin_bar_menu` and runs **every** registered callback, core's twenty-odd nodes and every plugin's, each resolving links and checking capabilities — before dropping the finished object on the floor. The shell draws a real bar once; a window drawing none should pay for none.
+
+The class is swapped rather than the init unhooked, deliberately. `remove_action( 'admin_init', '_wp_admin_bar_init' )` would leave `$wp_admin_bar` null, and a plugin that touches the global outside the hook would fatal on it. Core exposes `wp_admin_bar_class` for exactly this, so a window gets a real `WP_Admin_Bar` subclass that works in every respect — `add_node()`, `get_nodes()`, the global is still an object — except that it never solicits nodes.
+
+How much this saves is a property of the site's admin bar: roughly 1.5% of a window's server time on a stock-ish install, and materially more wherever the bar is expensive (a WordPress.com masterbar, a plugin adding counted nodes).
+
+```php
+// Let a window build the bar, for a plugin that relies on
+// `admin_bar_menu` firing for a side effect rather than a node.
+add_filter( 'openstation_chromeless_silence_admin_bar', '__return_false' );
+```
+
 ---
 
 ### `openstation_chromeless_admin_bar_top_values` — Experimental

--- a/includes/core/class-openstation-silent-admin-bar.php
+++ b/includes/core/class-openstation-silent-admin-bar.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * OpenStation — the admin bar a window builds instead of the real one.
+ *
+ * **This file is required lazily, not at bootstrap.** It extends
+ * `WP_Admin_Bar`, which WordPress only loads inside
+ * `_wp_admin_bar_init()` — requiring this at plugin load would fatal
+ * on a missing parent. The `wp_admin_bar_class` filter runs *after*
+ * that require, which is the one moment the parent is guaranteed
+ * present, so {@see openstation_chromeless_silence_admin_bar()} pulls
+ * this file in there.
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A `WP_Admin_Bar` that never asks anyone for nodes.
+ *
+ * Fully functional in every other respect — `add_node()` works,
+ * `get_nodes()` answers, `$wp_admin_bar` stays a real object — so a
+ * plugin that touches the global outside the `admin_bar_menu` hook
+ * finds what it expects. Only the solicitation is skipped.
+ */
+class OpenStation_Silent_Admin_Bar extends WP_Admin_Bar {
+
+	/**
+	 * Skips the `admin_bar_menu` hook.
+	 *
+	 * The parent's `add_menus()` registers core's twenty-odd node
+	 * callbacks and then fires `admin_bar_menu`, running every
+	 * callback any plugin has on it — each resolving links, counting
+	 * things, checking capabilities — to build a bar this window
+	 * never draws.
+	 */
+	public function add_menus() {}
+}

--- a/includes/core/routing.php
+++ b/includes/core/routing.php
@@ -400,6 +400,10 @@ add_action( 'admin_init', 'openstation_chromeless_suppress_admin_bar' );
  *
  * `initialize()` is deliberately left alone — it sets up the object's
  * own state and costs nothing worth reclaiming.
+ *
+ * @param string $class_name Admin bar class WordPress intends to instantiate.
+ * @return string The silent subclass inside a window; `$class_name` untouched
+ *                everywhere else, and whenever the parent class is unavailable.
  */
 function openstation_chromeless_silence_admin_bar( $class_name ) {
 	if ( ! openstation_is_chromeless_request() ) {

--- a/includes/core/routing.php
+++ b/includes/core/routing.php
@@ -370,6 +370,70 @@ function openstation_chromeless_suppress_admin_bar() {
 add_action( 'admin_init', 'openstation_chromeless_suppress_admin_bar' );
 
 /**
+ * Stops a window from BUILDING the admin bar it never draws.
+ *
+ * Removing the render above stops the markup. It does not stop the
+ * work: `_wp_admin_bar_init()` is hooked on `admin_init`,
+ * `is_admin_bar_showing()` short-circuits to true for any admin
+ * request, and so every window still instantiates `WP_Admin_Bar`,
+ * calls `initialize()`, and — the expensive part — calls
+ * `add_menus()`, which fires `admin_bar_menu` and runs **every**
+ * registered callback. Core's twenty-odd nodes, WooCommerce's,
+ * Jetpack's, a host masterbar's: each one resolving links, counting
+ * things, checking capabilities. The finished object is then dropped
+ * on the floor, because nothing renders it.
+ *
+ * The shell draws a real admin bar, once. A window drawing none
+ * should pay for none — this is the same asymmetry the asset trims
+ * exploit, on the server side.
+ *
+ * **Swapping the class rather than unhooking the init** is the
+ * careful way to do it. `remove_action( 'admin_init',
+ * '_wp_admin_bar_init' )` would leave `$wp_admin_bar` null, and a
+ * plugin that touches the global outside the `admin_bar_menu` hook —
+ * bad practice, entirely real — would fatal on it. Core exposes
+ * `wp_admin_bar_class` precisely for this, so a window gets a real
+ * `WP_Admin_Bar` subclass that is fully functional in every respect
+ * except that it never solicits nodes. `add_node()` still works,
+ * `get_nodes()` still answers, the global is still an object; the
+ * hook simply never fires.
+ *
+ * `initialize()` is deliberately left alone — it sets up the object's
+ * own state and costs nothing worth reclaiming.
+ */
+function openstation_chromeless_silence_admin_bar( $class_name ) {
+	if ( ! openstation_is_chromeless_request() ) {
+		return $class_name;
+	}
+
+	/**
+	 * Filters whether a window skips building the admin bar.
+	 *
+	 * Return false to let a window construct the bar as WordPress
+	 * normally would — for a plugin that (unusually) relies on
+	 * `admin_bar_menu` firing for a side effect rather than for the
+	 * node it adds.
+	 *
+	 * @param bool $silence Defaults to true inside windows.
+	 */
+	if ( ! apply_filters( 'openstation_chromeless_silence_admin_bar', true ) ) {
+		return $class_name;
+	}
+
+	// `_wp_admin_bar_init()` requires `class-wp-admin-bar.php` before
+	// it applies this filter, so the parent is guaranteed loaded here
+	// — and only here, which is why the subclass is required lazily
+	// rather than at bootstrap.
+	if ( ! class_exists( 'WP_Admin_Bar' ) ) {
+		return $class_name;
+	}
+	require_once __DIR__ . '/class-openstation-silent-admin-bar.php';
+
+	return 'OpenStation_Silent_Admin_Bar';
+}
+add_filter( 'wp_admin_bar_class', 'openstation_chromeless_silence_admin_bar' );
+
+/**
  * Detaches core's update / maintenance nags inside chromeless iframes so
  * they don't repeat in every window — the shell surfaces the update once
  * instead.

--- a/tests/phpunit/tests/openStationChromelessAdminBar.php
+++ b/tests/phpunit/tests/openStationChromelessAdminBar.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests for the admin-bar suppression inside windows.
+ *
+ * Removing the render stops the markup; it does not stop the work.
+ * `_wp_admin_bar_init()` still runs on `admin_init` because
+ * `is_admin_bar_showing()` short-circuits to true in admin, so every
+ * window built a full `WP_Admin_Bar` — firing `admin_bar_menu` and
+ * every callback on it — and threw it away. These pin the class swap
+ * that stops that without leaving the global null.
+ *
+ * @package OpenStation
+ *
+ * @group openstation
+ */
+class Tests_OpenStation_ChromelessAdminBar extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function tear_down() {
+		delete_user_meta( self::$admin_id, 'desktop_mode_mode' );
+		unset( $_GET['openstation_chromeless'] );
+		remove_all_filters( 'openstation_chromeless_silence_admin_bar' );
+		parent::tear_down();
+	}
+
+	private function enter_chromeless() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		$_GET['openstation_chromeless'] = '1';
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_silence_admin_bar
+	 */
+	public function test_shell_keeps_the_real_admin_bar_class() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$admin_id, 'desktop_mode_mode', '1' );
+		// No chromeless flag: the shell draws a real bar.
+
+		$this->assertSame(
+			'WP_Admin_Bar',
+			openstation_chromeless_silence_admin_bar( 'WP_Admin_Bar' )
+		);
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_silence_admin_bar
+	 */
+	public function test_window_gets_the_silent_class() {
+		$this->enter_chromeless();
+		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+
+		$this->assertSame(
+			'OpenStation_Silent_Admin_Bar',
+			openstation_chromeless_silence_admin_bar( 'WP_Admin_Bar' )
+		);
+	}
+
+	/**
+	 * The whole point: `add_menus()` is what fires `admin_bar_menu`
+	 * and runs every core and plugin callback.
+	 *
+	 * @covers OpenStation_Silent_Admin_Bar::add_menus
+	 */
+	public function test_the_silent_class_never_fires_admin_bar_menu() {
+		$this->enter_chromeless();
+		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		openstation_chromeless_silence_admin_bar( 'WP_Admin_Bar' );
+
+		$fired = 0;
+		add_action(
+			'admin_bar_menu',
+			static function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		$bar = new OpenStation_Silent_Admin_Bar();
+		$bar->initialize();
+		$bar->add_menus();
+
+		$this->assertSame( 0, $fired );
+	}
+
+	/**
+	 * Swapping the class rather than unhooking the init is what keeps
+	 * `$wp_admin_bar` a real object. A plugin touching the global
+	 * outside the hook — bad practice, entirely real — must not fatal.
+	 *
+	 * @covers OpenStation_Silent_Admin_Bar::add_menus
+	 */
+	public function test_the_silent_class_is_still_a_working_admin_bar() {
+		$this->enter_chromeless();
+		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		openstation_chromeless_silence_admin_bar( 'WP_Admin_Bar' );
+
+		$bar = new OpenStation_Silent_Admin_Bar();
+		$bar->initialize();
+		$bar->add_node(
+			array(
+				'id'    => 'os-test-node',
+				'title' => 'Test',
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Admin_Bar', $bar );
+		$this->assertNotNull( $bar->get_node( 'os-test-node' ) );
+	}
+
+	/**
+	 * @covers ::openstation_chromeless_silence_admin_bar
+	 */
+	public function test_silencing_can_be_filtered_off() {
+		$this->enter_chromeless();
+		add_filter( 'openstation_chromeless_silence_admin_bar', '__return_false' );
+
+		$this->assertSame(
+			'WP_Admin_Bar',
+			openstation_chromeless_silence_admin_bar( 'WP_Admin_Bar' )
+		);
+	}
+}


### PR DESCRIPTION
Removing the render stopped the markup. It never stopped the work.

`_wp_admin_bar_init()` is hooked on `admin_init`, and `is_admin_bar_showing()` short-circuits to true for any admin request — the same short-circuit this codebase already documents as the reason the `show_admin_bar` filter cannot hide the bar on its own. So every window still instantiated `WP_Admin_Bar` and called `add_menus()`, which fires `admin_bar_menu` and runs **every** registered callback — core's twenty-odd nodes plus every plugin's, each resolving links, counting things, checking capabilities — then dropped the finished object on the floor, because nothing renders it.

The shell draws a real admin bar, once. A window drawing none should pay for none.

**The class is swapped, not the init unhooked.** `remove_action( 'admin_init', '_wp_admin_bar_init' )` would leave `$wp_admin_bar` null, and a plugin touching the global outside the hook — bad practice, entirely real — would fatal on it. Core exposes `wp_admin_bar_class` for precisely this, so a window gets a real `WP_Admin_Bar` subclass that works in every respect (`add_node()`, `get_nodes()`, the global is still an object) except that it never solicits nodes.

Measured interleaved A/B on one Settings window, 12 pairs: **728 ms → 717 ms median, 11 ms / 1.5%**. Modest on this install because it has no expensive masterbar; the saving scales with what the site's bar actually costs, and the handles the chromeless trim already names (`wpcom-notes-admin-bar`, `a8c-faux-inline-help`) are exactly where it is not modest.

---

## Where a window's time actually goes

Profiled while working on this, because it changes what is worth optimising next. **This section is context, not a claim about this PR** — the change above moves server time, not bytes.

### Assets are already free; the document is not

Measured in Chrome against the live shell, opening screens as real windows:

| window | requests | **from cache** | over the wire | transferred |
|---|---:|---:|---:|---:|
| Settings (`options-general.php`) | 132 | **129** | 3 | 283 KB |
| Tools (`tools.php`, never visited) | 101 | **99** | 2 | 163 KB |
| Media Library (`upload.php`) | 250 | 160 | 90 | 2,274 KB |

A window pulls 13–14 MB of assets and **transfers essentially none of it** — the shared admin-asset cache and the SW have it all. What a window actually costs on the wire is **its HTML document**, every time, uncacheable.

### So on a slow connection, per-window cost is document size

Modelled from measured gzip sizes at standard profiles (Slow 3G 400 Kbps, Fast 3G 1.6 Mbps, 4G ~9 Mbps). Steady state = warm shell, the case that happens all day:

| scenario | transferred | Slow 3G | Fast 3G | 4G |
|---|---:|---:|---:|---:|
| **Window open, warm shell** (today) | 68 KB gz | ~1.3 s | ~0.34 s | ~0.06 s |
| First window, cold cache — palette-only site, **before** #682/#683 | 2.87 MB gz | ~57 s | ~14.7 s | ~2.6 s |
| First window, cold cache — palette-only site, **after** | ~0.93 MB gz | **~19 s** | **~4.8 s** | **~0.85 s** |
| First window, cold cache — WooCommerce site, after | 2.79 MB gz | ~56 s | ~14.3 s | ~2.5 s |

The cold-cache rows are where the merged palette work pays: on a site where the palette is the sole consumer of the Gutenberg chain, first load drops by 1.94 MB gz — **3× faster on any connection**. On a WooCommerce site the chain has other legitimate consumers and correctly stays, so the win is small; that asymmetry is documented in `hooks-reference.md`.

### What that leaves

Since only the document transfers per window, document size is now the lever. Of the 282 KB Settings document: **96 KB is one WooCommerce `wcSettings` inline blob, 55 KB is media modal templates (19.7%), 28 KB is admin-menu markup rendered purely to be hidden by CSS.** That is 179 KB of 282 KB, re-sent in every window.

And the ceiling behind all of it: `admin-ajax.php` with a **no-op action** costs 515 ms on this install versus 606 ms for a full Settings window — **~85% of a window is WordPress + plugin bootstrap**, before any page work. No asset trimming reaches that; only not re-requesting the document does, and `isCacheableResponse()` currently rejects `no-store`/`private`, which is every admin response. Proposal for a session-scoped document cache to follow separately.

## Testing

- PHPUnit **2529 tests, 0 failures** — 5 new in `Tests_OpenStation_ChromelessAdminBar`, covering the class swap, that `admin_bar_menu` never fires, that the subclass is still a working `WP_Admin_Bar` (the null-global regression), and the filter opt-out
- `npm run lint:php` (phpcs -n) clean — the subclass lives in its own `class-*.php` per WPCS, required lazily from the filter since `WP_Admin_Bar` only exists inside `_wp_admin_bar_init()`
- `npm run build` clean, no drift

**Worth a human pass:** confirm windows still render with no admin bar and nothing regresses on screens whose plugins add admin-bar nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-684-143fa7e3c2e1808a4ceaa181d0b151b1aecc6a33.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->