### PR TITLE
Allow Agents customisation by changing its profile picture

### DIFF
--- a/assets/css/my-wordpress.css
+++ b/assets/css/my-wordpress.css
@@ -2207,6 +2207,48 @@ os-tile[ status='future' ] .os-file-tile__icon {
 	flex: none;
 }
 
+/* Profile pictures are ordinary Media Library images, but the served
+   avatar has the AGENT ribbon baked in. This editor shows that final
+   asset beside the upload controls so the saved identity is never a
+   surprise. */
+.dm-agents__profile-picture-setting {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	padding: 12px;
+	border: 1px solid var( --os-border, rgba( 0, 0, 0, 0.08 ) );
+	border-radius: var( --os-ui-card-radius, 10px );
+	background: var( --os-ui-surface-sunken, #f6f7f7 );
+}
+
+.dm-agents__profile-picture-preview {
+	width: 112px;
+	height: 112px;
+	flex: none;
+}
+
+.dm-agents__profile-picture-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	min-width: 0;
+}
+
+.dm-agents__profile-picture-copy p {
+	margin: 0;
+}
+
+.dm-agents__profile-picture-input {
+	display: none;
+}
+
+.dm-agents__profile-picture-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
 .dm-agents__detail-title {
 	flex: 1;
 	min-width: 0;
@@ -2810,6 +2852,36 @@ summary.dm-agents__category:focus-visible {
 	margin-top: -12px;
 }
 
+/* Unsaved custom pictures have no ribboned server asset yet. The
+   existing `<os-ribbon>` previews the exact identity mark the server
+   bakes into the final avatar. */
+.dm-agents__portrait-media {
+	position: relative;
+	width: 176px;
+	height: 176px;
+	max-width: 100%;
+	margin-top: -12px;
+	flex: none;
+}
+
+.dm-agents__portrait-media .dm-agents__portrait-face {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+}
+
+.dm-agents__portrait-media.is-custom,
+.dm-agents__summary-media.is-custom {
+	overflow: hidden;
+	border-radius: 50%;
+}
+
+.dm-agents__portrait-media.is-custom img,
+.dm-agents__summary-media.is-custom img {
+	object-fit: cover;
+	border-radius: 50%;
+}
+
 /* What this face is, in two words. */
 .dm-agents__portrait-chips {
 	display: flex;
@@ -2879,6 +2951,26 @@ summary.dm-agents__category:focus-visible {
 	flex: none;
 }
 
+.dm-agents__summary-media {
+	position: relative;
+	width: 106px;
+	height: 106px;
+	flex: none;
+}
+
+.dm-agents__summary-media .dm-agents__summary-face {
+	width: 100%;
+	height: 100%;
+}
+
+.dm-agents__summary-media os-ribbon {
+	--os-ui-ribbon-size: 72px;
+	--os-ui-ribbon-banner-width: 110px;
+	--os-ui-ribbon-banner-offset: 15px;
+	--os-ui-ribbon-banner-pull: -30px;
+	--os-ui-ribbon-font: 700 8px/1.4 var( --os-font, system-ui );
+}
+
 .dm-agents__summary-text h4 {
 	margin: 0 0 2px;
 	font-size: 17px;
@@ -2943,6 +3035,17 @@ summary.dm-agents__category:focus-visible {
 	.dm-agents__portrait-face {
 		width: 128px;
 		height: 128px;
+	}
+	.dm-agents__portrait-media {
+		width: 128px;
+		height: 128px;
+	}
+	.dm-agents__profile-picture-setting {
+		align-items: flex-start;
+	}
+	.dm-agents__profile-picture-preview {
+		width: 88px;
+		height: 88px;
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -488,11 +488,19 @@ across exactly two layers:
   application passwords), the address is a never-delivered synthetic
   email, and the wp-admin Users list labels the row "Agent".
 - **Definition — user meta on that row.** Description, instructions
-  (system prompt), ability allowlist, triggers, model override, and
-  rate limit live in the `_openstation_agent_*` key family
+  (system prompt), ability allowlist, triggers, model override, rate
+  limit, generated face, and optional profile-picture attachment live
+  in the `_openstation_agent_*` key family
   (`includes/agents/store.php` owns every key). User meta has no
   revisions, so the `openstation_agent_{created,updated,deleted}`
   actions carry before/after values and ARE the audit trail.
+
+An uploaded profile picture remains a Media Library attachment. The
+avatar writer crops it into the same static SVG path used by generated
+faces and bakes an **AGENT** corner ribbon into that file, so WP Admin,
+comments, desktop tiles, chat, and plugin `get_avatar()` consumers all
+receive the same unambiguous identity. Deleting the attachment restores
+the generated face.
 
 **Tools are the WordPress Abilities API.** The Tools picker is a view
 over `wp_get_abilities()` (with honest read-only vs mutating badges

--- a/docs/examples/agents.md
+++ b/docs/examples/agents.md
@@ -12,7 +12,7 @@ An agent is a login-blocked `wp_users` row whose definition
 override, rate limit) lives as user meta on that row. Full contract:
 [Hooks Reference — AI Agents](../hooks-reference.md#ai-agents).
 
-Alongside the definition an agent carries two identity fields, which is
+Alongside the definition an agent carries identity fields, which is
 what makes a roster of them readable rather than a list of settings:
 
 | Field | What it is |
@@ -20,8 +20,9 @@ what makes a roster of them readable rather than a list of settings:
 | `vibes` | One short line of voice, capped at 120 characters. Appended to the instructions before a run, and after them so a workflow beats a personality. |
 | `face` | A partial Mio look. Rendered to an SVG on disk and served as the agent's avatar everywhere `get_avatar()` runs, including the wp-admin Users list and comment attribution. See [Mio is a species](../mio.md#mio-is-a-species). |
 | `faceSeed` | The seed the face was rolled from. Provenance, not the face itself. |
+| `avatarAttachmentId` | Optional Media Library image that replaces the generated face. OpenStation crops it and bakes an **AGENT** ribbon into the served avatar, so human and agent accounts remain distinguishable everywhere `get_avatar()` is used. Set it to `0` to restore the generated face. |
 
-Both travel through `createAgent` / `updateAgent` like any other field.
+All travel through `createAgent` / `updateAgent` like any other field.
 **Abilities and triggers both go in the create call.** There is no need
 for a second request to attach either.
 

--- a/includes/agents/bootstrap.php
+++ b/includes/agents/bootstrap.php
@@ -55,9 +55,10 @@ require_once OPENSTATION_DIR . 'includes/agents/guard.php';
  * `wp_allowed_protocols()` — the data URI silently becomes an empty
  * string and the avatar renders broken.
  *
- * With an agent id, this is that agent's own Mio portrait when one has
- * been written. Without one, or before the face file exists, it is the
- * shipped robot glyph, which is what every agent wore before faces.
+ * With an agent id, this is that agent's profile picture (with its
+ * permanent AGENT ribbon) or Mio portrait when one has been written.
+ * Without one, or before the face file exists, it is the shipped robot
+ * glyph, which is what every agent wore before faces.
  *
  * @param int $user_id Agent user id, or 0 for the generic glyph.
  * @return string

--- a/includes/agents/face.php
+++ b/includes/agents/face.php
@@ -19,11 +19,14 @@
  * be a write during a front-end GET.
  *
  * **The files are SVG in uploads, which is only safe because of what
- * the renderer refuses to emit.** `openstation_mio_portrait_svg()`
- * writes numbers and a fixed vocabulary of elements: no text nodes, no
- * caller-supplied string anywhere. The directory is hardened exec-off
- * rather than deny-all, because unlike a theme's PHP these files have
- * to stay servable.
+ * the renderers refuse to emit.** Mio portraits use a fixed vocabulary
+ * of numeric shapes. Custom profile pictures accept raster Media
+ * Library attachments only, re-encode or base64-wrap their bytes, and
+ * place that inert data URI behind a fixed AGENT ribbon. No source URL,
+ * filename, alt text, SVG markup, or other caller string is copied into
+ * the generated document. The directory is hardened exec-off rather
+ * than deny-all, because unlike a theme's PHP these files have to stay
+ * servable.
  *
  * **The .htaccess is the second line, not the first.** It is Apache
  * only: the `php_flag` and `<FilesMatch>` rules do nothing on nginx,
@@ -52,6 +55,12 @@ defined( 'ABSPATH' ) || exit;
  * dimensions falls back to. 96 matches what `get_avatar()` asks for.
  */
 const OPENSTATION_AGENT_FACE_SIZE = 96;
+
+/** Square raster size embedded behind a custom profile-picture ribbon. */
+const OPENSTATION_AGENT_PROFILE_PICTURE_RASTER_SIZE = 256;
+
+/** Largest original image embedded when WordPress cannot resize it. */
+const OPENSTATION_AGENT_PROFILE_PICTURE_SOURCE_MAX_BYTES = 5242880;
 
 /**
  * Absolute path to the face directory.
@@ -142,11 +151,18 @@ function openstation_agent_faces_ensure_dir() {
  * @return string Filename, or '' when the agent has no face.
  */
 function openstation_agent_face_filename( $user_id ) {
-	$raw = (string) get_user_meta( (int) $user_id, OPENSTATION_AGENT_FACE_META, true );
-	if ( '' === $raw ) {
+	$user_id       = (int) $user_id;
+	$raw           = (string) get_user_meta( $user_id, OPENSTATION_AGENT_FACE_META, true );
+	$attachment_id = openstation_agent_get_avatar_attachment_id( $user_id );
+	if ( '' === $raw && 0 === $attachment_id ) {
 		return '';
 	}
-	return (int) $user_id . '-' . substr( md5( $raw ), 0, 8 ) . '.svg';
+	$fingerprint = $raw;
+	if ( $attachment_id > 0 ) {
+		$fingerprint .= '|avatar:' . $attachment_id . ':'
+			. (int) get_post_modified_time( 'U', true, $attachment_id );
+	}
+	return $user_id . '-' . substr( md5( $fingerprint ), 0, 8 ) . '.svg';
 }
 
 /**
@@ -199,8 +215,21 @@ function openstation_agent_face_write( $user_id ) {
 		return $path;
 	}
 
-	$look = openstation_mio_clamp_look( openstation_agent_get_face( $user_id ) );
-	$svg  = openstation_mio_portrait_svg( $look, OPENSTATION_AGENT_FACE_SIZE );
+	$attachment_id = openstation_agent_get_avatar_attachment_id( $user_id );
+	if ( $attachment_id > 0 ) {
+		$svg = openstation_agent_profile_picture_svg(
+			$attachment_id,
+			OPENSTATION_AGENT_FACE_SIZE,
+			$base,
+			$user_id
+		);
+		if ( is_wp_error( $svg ) ) {
+			return $svg;
+		}
+	} else {
+		$look = openstation_mio_clamp_look( openstation_agent_get_face( $user_id ) );
+		$svg  = openstation_mio_portrait_svg( $look, OPENSTATION_AGENT_FACE_SIZE );
+	}
 
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 	$written = file_put_contents( $path, $svg );
@@ -214,6 +243,105 @@ function openstation_agent_face_write( $user_id ) {
 
 	openstation_agent_face_delete( $user_id, $file );
 	return $path;
+}
+
+/**
+ * Read a custom profile picture into an inert raster data URI.
+ *
+ * WordPress's image editor is preferred: it crops the source to a
+ * small square and strips format-specific payloads before those bytes
+ * enter the avatar SVG. Hosts without an available editor may still
+ * use a reasonably sized, allowlisted raster file directly.
+ *
+ * @param int    $attachment_id Image attachment id.
+ * @param string $base          Writable agent-face directory.
+ * @param int    $user_id       Agent user id, used in the temp name.
+ * @return string|WP_Error Raster data URI, or an error.
+ */
+function openstation_agent_profile_picture_data_uri( $attachment_id, $base, $user_id ) {
+	$attachment_id = openstation_agent_sanitize_avatar_attachment_id( $attachment_id );
+	$source        = $attachment_id > 0 ? get_attached_file( $attachment_id ) : false;
+	$mime          = $attachment_id > 0 ? (string) get_post_mime_type( $attachment_id ) : '';
+	if ( ! is_string( $source ) || '' === $source || ! is_readable( $source ) ) {
+		return new WP_Error(
+			'openstation_agent_profile_picture_missing',
+			__( 'The selected agent profile picture is unavailable.', 'desktop-mode' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$editor = wp_get_image_editor( $source );
+	if ( ! is_wp_error( $editor ) ) {
+		$resized = $editor->resize(
+			OPENSTATION_AGENT_PROFILE_PICTURE_RASTER_SIZE,
+			OPENSTATION_AGENT_PROFILE_PICTURE_RASTER_SIZE,
+			true
+		);
+		if ( ! is_wp_error( $resized ) ) {
+			$temp  = trailingslashit( $base ) . wp_unique_filename(
+				$base,
+				'.' . (int) $user_id . '-profile-picture.png'
+			);
+			$saved = $editor->save( $temp, 'image/png' );
+			if ( ! is_wp_error( $saved ) && isset( $saved['path'], $saved['mime'] ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading the raster this function just rendered.
+				$bytes = file_get_contents( $saved['path'] );
+				wp_delete_file( $saved['path'] );
+				if ( false !== $bytes ) {
+					return 'data:' . (string) $saved['mime'] . ';base64,' . base64_encode( $bytes );
+				}
+			}
+		}
+	}
+
+	$size = filesize( $source );
+	if ( false === $size || $size > OPENSTATION_AGENT_PROFILE_PICTURE_SOURCE_MAX_BYTES ) {
+		return new WP_Error(
+			'openstation_agent_profile_picture_too_large',
+			__( 'The selected agent profile picture could not be resized.', 'desktop-mode' ),
+			array( 'status' => 400 )
+		);
+	}
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading an allowlisted local raster attachment.
+	$bytes = file_get_contents( $source );
+	if ( false === $bytes ) {
+		return new WP_Error(
+			'openstation_agent_profile_picture_unreadable',
+			__( 'The selected agent profile picture could not be read.', 'desktop-mode' ),
+			array( 'status' => 400 )
+		);
+	}
+	return 'data:' . $mime . ';base64,' . base64_encode( $bytes );
+}
+
+/**
+ * Compose a profile picture and the permanent AGENT identity ribbon.
+ *
+ * The ribbon is in the served image rather than CSS so it survives
+ * every `get_avatar()` consumer: WP Admin lists, comments, desktop
+ * user tiles, chat, and plugin surfaces all receive the same identity.
+ *
+ * @param int    $attachment_id Image attachment id.
+ * @param int    $size          Intrinsic SVG size.
+ * @param string $base          Writable agent-face directory.
+ * @param int    $user_id       Agent user id.
+ * @return string|WP_Error SVG document, or an error.
+ */
+function openstation_agent_profile_picture_svg( $attachment_id, $size, $base, $user_id ) {
+	$data = openstation_agent_profile_picture_data_uri( $attachment_id, $base, $user_id );
+	if ( is_wp_error( $data ) ) {
+		return $data;
+	}
+	$size = max( 24, min( 1024, (int) $size ) );
+	return '<svg xmlns="http://www.w3.org/2000/svg" width="' . $size . '" height="' . $size . '" viewBox="0 0 96 96">'
+		. '<defs><clipPath id="avatar-clip"><circle cx="48" cy="48" r="46"/></clipPath></defs>'
+		. '<circle cx="48" cy="48" r="48" fill="#f0f0f1"/>'
+		. '<image href="' . $data . '" x="2" y="2" width="92" height="92" preserveAspectRatio="xMidYMid slice" clip-path="url(#avatar-clip)"/>'
+		. '<circle cx="48" cy="48" r="46" fill="none" stroke="#ffffff" stroke-opacity=".55" stroke-width="2"/>'
+		. '<g clip-path="url(#avatar-clip)"><g transform="rotate(45 72 18)">'
+		. '<rect x="34" y="8" width="76" height="18" fill="#f252fc"/>'
+		. '<text x="72" y="21" fill="#050505" font-family="Arial,sans-serif" font-size="9" font-weight="700" letter-spacing="1" text-anchor="middle">AGENT</text>'
+		. '</g></g></svg>';
 }
 
 /**
@@ -248,7 +376,10 @@ function openstation_agent_face_delete( $user_id, $keep = '' ) {
  * @return void
  */
 function openstation_agent_face_sync_on_update( $user_id, $changed ) {
-	if ( ! is_array( $changed ) || ! array_key_exists( 'face', $changed ) ) {
+	if (
+		! is_array( $changed )
+		|| ( ! array_key_exists( 'face', $changed ) && ! array_key_exists( 'avatarAttachmentId', $changed ) )
+	) {
 		return;
 	}
 	openstation_agent_face_write( $user_id );
@@ -276,3 +407,43 @@ function openstation_agent_face_cleanup( $user_id ) {
 	openstation_agent_face_delete( $user_id );
 }
 add_action( 'openstation_agent_deleted', 'openstation_agent_face_cleanup', 10, 1 );
+
+/**
+ * Re-render agents that use an attachment whose image changed.
+ *
+ * @param int $attachment_id Attachment id.
+ * @return void
+ */
+function openstation_agent_profile_picture_attachment_updated( $attachment_id ) {
+	$agent_ids = get_users(
+		array(
+			'fields'     => 'ids',
+			'meta_key'   => OPENSTATION_AGENT_AVATAR_ATTACHMENT_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_value' => (string) (int) $attachment_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		)
+	);
+	foreach ( $agent_ids as $agent_id ) {
+		openstation_agent_face_write( (int) $agent_id );
+	}
+}
+add_action( 'edit_attachment', 'openstation_agent_profile_picture_attachment_updated' );
+
+/**
+ * Fall back to the generated face when a chosen picture is deleted.
+ *
+ * @param int $attachment_id Attachment id being deleted.
+ * @return void
+ */
+function openstation_agent_profile_picture_attachment_deleted( $attachment_id ) {
+	$agent_ids = get_users(
+		array(
+			'fields'     => 'ids',
+			'meta_key'   => OPENSTATION_AGENT_AVATAR_ATTACHMENT_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_value' => (string) (int) $attachment_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		)
+	);
+	foreach ( $agent_ids as $agent_id ) {
+		openstation_agent_update( (int) $agent_id, array( 'avatarAttachmentId' => 0 ) );
+	}
+}
+add_action( 'delete_attachment', 'openstation_agent_profile_picture_attachment_deleted' );

--- a/includes/agents/my-wordpress.php
+++ b/includes/agents/my-wordpress.php
@@ -136,6 +136,7 @@ function openstation_agents_my_wordpress_window_args( $window_args ) {
 		'enabled'       => $enabled,
 		'canEnable'     => current_user_can( 'manage_options' ),
 		'canManage'     => openstation_agents_user_can_manage(),
+		'canUpload'     => current_user_can( 'upload_files' ),
 		'canInvoke'     => openstation_agents_user_can_invoke(),
 		'aiAvailable'   => function_exists( 'openstation_ai_is_available' ) && openstation_ai_is_available(),
 		'aiStatusUrl'   => esc_url_raw( rest_url( 'desktop-mode/v1/ai/status' ) ),

--- a/includes/agents/privacy.php
+++ b/includes/agents/privacy.php
@@ -123,6 +123,14 @@ function openstation_agents_personal_data_exporter( $email_address, $page = 1 ) 
 		);
 	}
 
+	$avatar_id = openstation_agent_get_avatar_attachment_id( (int) $user->ID );
+	if ( $avatar_id > 0 ) {
+		$rows[] = array(
+			'name'  => __( 'Profile picture attachment ID', 'desktop-mode' ),
+			'value' => (string) $avatar_id,
+		);
+	}
+
 	return array(
 		'data' => array(
 			array(

--- a/includes/agents/rest.php
+++ b/includes/agents/rest.php
@@ -101,6 +101,11 @@ function openstation_agents_register_rest_routes() {
 						'default'           => 0,
 						'sanitize_callback' => 'absint',
 					),
+					'avatarAttachmentId' => array(
+						'type'              => 'integer',
+						'default'           => 0,
+						'sanitize_callback' => 'absint',
+					),
 				),
 			),
 		)
@@ -336,11 +341,11 @@ function openstation_agents_rest_get( WP_REST_Request $request ) {
  * @return WP_REST_Response|WP_Error
  */
 function openstation_agents_rest_create( WP_REST_Request $request ) {
-	// Every field the route declares is forwarded. `vibes`, `face` and
-	// `faceSeed` are the character half of an agent, and a create that
-	// took the name and dropped the portrait is how an agent ends up
-	// wearing the fallback glyph seconds after someone picked a face
-	// for it. `openstation_agent_create()` sanitizes each one.
+	// Every field the route declares is forwarded. The character fields
+	// must land in the same create as the definition: dropping the face
+	// or uploaded profile picture would make the newly created agent wear
+	// a fallback seconds after somebody explicitly picked its identity.
+	// `openstation_agent_create()` sanitizes each one.
 	$user = openstation_agent_create(
 		array(
 			'name'         => (string) $request['name'],
@@ -352,6 +357,7 @@ function openstation_agents_rest_create( WP_REST_Request $request ) {
 			'vibes'        => (string) $request['vibes'],
 			'face'         => $request['face'],
 			'faceSeed'     => (int) $request['faceSeed'],
+			'avatarAttachmentId' => (int) $request['avatarAttachmentId'],
 		)
 	);
 	if ( is_wp_error( $user ) ) {
@@ -404,6 +410,7 @@ function openstation_agents_rest_patch( WP_REST_Request $request ) {
 		'vibes',
 		'face',
 		'faceSeed',
+		'avatarAttachmentId',
 	);
 	foreach ( $allowed as $field ) {
 		if ( array_key_exists( $field, $body ) ) {
@@ -614,6 +621,7 @@ function openstation_agents_rest_shape_user( $user ) {
 		'vibes'        => openstation_agent_get_vibes( (int) $user->ID ),
 		'face'         => openstation_agent_get_face( (int) $user->ID ),
 		'faceSeed'     => openstation_agent_get_face_seed( (int) $user->ID ),
+		'avatarAttachmentId' => openstation_agent_get_avatar_attachment_id( (int) $user->ID ),
 		'avatarUrl'    => $avatar,
 	);
 }

--- a/includes/agents/store.php
+++ b/includes/agents/store.php
@@ -15,6 +15,7 @@
  *                                        exposes model selection)
  *   - `_desktop_mode_agent_rate_limit`   invocations/hour, 0 = default
  *   - `_desktop_mode_agent_created_by`   creating user id (audit aid)
+ *   - `_desktop_mode_agent_avatar_attachment` media-library profile picture
  *
  * User meta has no revisions — the audit trail for definition changes
  * is the `openstation_agent_{created,updated,deleted}` actions fired
@@ -127,6 +128,14 @@ const OPENSTATION_AGENT_FACE_META = '_desktop_mode_agent_face';
  * deliberate — it is NOT a half-finished rename.
  */
 const OPENSTATION_AGENT_FACE_SEED_META = '_desktop_mode_agent_face_seed';
+/**
+ * The VALUE keeps its pre-rebrand spelling on purpose: it is a
+ * persisted or externally-visible identifier, so renaming it would
+ * orphan data already written by live installs (or break a live
+ * URL). The mismatch between this constant's name and its value is
+ * deliberate — it is NOT a half-finished rename.
+ */
+const OPENSTATION_AGENT_AVATAR_ATTACHMENT_META = '_desktop_mode_agent_avatar_attachment';
 
 /**
  * Every meta key the store writes — the privacy eraser and any future
@@ -147,6 +156,7 @@ function openstation_agent_meta_keys() {
 		OPENSTATION_AGENT_VIBES_META,
 		OPENSTATION_AGENT_FACE_META,
 		OPENSTATION_AGENT_FACE_SEED_META,
+		OPENSTATION_AGENT_AVATAR_ATTACHMENT_META,
 	);
 }
 
@@ -272,6 +282,18 @@ function openstation_agents_register_user_meta() {
 			'auth_callback'     => $auth,
 		)
 	);
+	register_meta(
+		'user',
+		OPENSTATION_AGENT_AVATAR_ATTACHMENT_META,
+		array(
+			'type'              => 'integer',
+			'single'            => true,
+			'default'           => 0,
+			'show_in_rest'      => false,
+			'sanitize_callback' => 'openstation_agent_sanitize_avatar_attachment_id',
+			'auth_callback'     => $auth,
+		)
+	);
 }
 add_action( 'init', 'openstation_agents_register_user_meta' );
 
@@ -376,6 +398,30 @@ function openstation_agent_sanitize_face_json( $value ) {
 }
 
 /**
+ * Keep only a Media Library image as an agent profile picture.
+ *
+ * The attachment id, rather than its URL, is stored so deletion and
+ * replacement remain WordPress-owned lifecycle events. SVG is not
+ * accepted here even when another plugin enables SVG uploads: the
+ * ribboned avatar embeds the source bytes and only raster formats are
+ * safe to carry into that generated file.
+ *
+ * @param mixed $value Incoming attachment id.
+ * @return int Valid image attachment id, or 0.
+ */
+function openstation_agent_sanitize_avatar_attachment_id( $value ) {
+	$attachment_id = absint( $value );
+	if ( $attachment_id <= 0 || 'attachment' !== get_post_type( $attachment_id ) ) {
+		return 0;
+	}
+	$mime = (string) get_post_mime_type( $attachment_id );
+	if ( ! in_array( $mime, array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif' ), true ) ) {
+		return 0;
+	}
+	return $attachment_id;
+}
+
+/**
  * Read an agent's voice line.
  *
  * @param int $user_id Agent user id.
@@ -421,6 +467,20 @@ function openstation_agent_get_face( $user_id ) {
  */
 function openstation_agent_get_face_seed( $user_id ) {
 	return (int) get_user_meta( (int) $user_id, OPENSTATION_AGENT_FACE_SEED_META, true );
+}
+
+/**
+ * Read the Media Library image used as an agent's profile picture.
+ *
+ * A zero id means the generated Mio face remains active.
+ *
+ * @param int $user_id Agent user id.
+ * @return int Attachment id, or 0.
+ */
+function openstation_agent_get_avatar_attachment_id( $user_id ) {
+	return openstation_agent_sanitize_avatar_attachment_id(
+		get_user_meta( (int) $user_id, OPENSTATION_AGENT_AVATAR_ATTACHMENT_META, true )
+	);
 }
 
 /**
@@ -982,7 +1042,7 @@ function openstation_agent_get_agents( $args = array() ) {
 /**
  * Create an agent: synthetic user row + definition meta.
  *
- * @param array{name:string, role:string, slug?:string, description?:string, instructions?:string, abilities?:array, triggers?:array, vibes?:string, face?:array|string, faceSeed?:int} $args Creation args.
+ * @param array{name:string, role:string, slug?:string, description?:string, instructions?:string, abilities?:array, triggers?:array, vibes?:string, face?:array|string, faceSeed?:int, avatarAttachmentId?:int} $args Creation args.
  * @return WP_User|WP_Error
  */
 function openstation_agent_create( $args ) {
@@ -1006,6 +1066,9 @@ function openstation_agent_create( $args ) {
 	$triggers     = isset( $args['triggers'] ) ? openstation_agent_sanitize_triggers( $args['triggers'] ) : array();
 	$vibes        = isset( $args['vibes'] ) ? openstation_agent_sanitize_vibes( $args['vibes'] ) : '';
 	$face         = isset( $args['face'] ) ? openstation_agent_sanitize_face_json( $args['face'] ) : '';
+	$avatar_id    = isset( $args['avatarAttachmentId'] )
+		? openstation_agent_sanitize_avatar_attachment_id( $args['avatarAttachmentId'] )
+		: 0;
 	// Every agent gets a seed even when nobody chose a face, so the
 	// backfill has something deterministic to roll from and two admins
 	// racing it land on the same portrait. `crc32` of the login is
@@ -1034,6 +1097,9 @@ function openstation_agent_create( $args ) {
 		update_user_meta( $user->ID, OPENSTATION_AGENT_FACE_META, $face );
 	}
 	update_user_meta( $user->ID, OPENSTATION_AGENT_FACE_SEED_META, $seed );
+	if ( $avatar_id > 0 ) {
+		update_user_meta( $user->ID, OPENSTATION_AGENT_AVATAR_ATTACHMENT_META, $avatar_id );
+	}
 	update_user_meta( $user->ID, OPENSTATION_AGENT_CREATED_BY_META, get_current_user_id() );
 
 	/**
@@ -1056,6 +1122,7 @@ function openstation_agent_create( $args ) {
 			'vibes'        => $vibes,
 			'face'         => $face,
 			'faceSeed'     => $seed,
+			'avatarAttachmentId' => $avatar_id,
 		),
 		get_current_user_id()
 	);
@@ -1070,7 +1137,7 @@ function openstation_agent_create( $args ) {
  *
  * Recognized fields: `name`, `role`, `description`, `instructions`,
  * `abilities`, `triggers`, `model`, `rateLimit`, `vibes`, `face`,
- * `faceSeed`.
+ * `faceSeed`, `avatarAttachmentId`.
  *
  * @param int   $user_id Agent user id.
  * @param array $fields  Field map.
@@ -1249,6 +1316,22 @@ function openstation_agent_update( $user_id, array $fields ) {
 				'to'   => $seed,
 			);
 			update_user_meta( $user->ID, OPENSTATION_AGENT_FACE_SEED_META, $seed );
+		}
+	}
+
+	if ( isset( $fields['avatarAttachmentId'] ) ) {
+		$avatar_id = openstation_agent_sanitize_avatar_attachment_id( $fields['avatarAttachmentId'] );
+		$before    = openstation_agent_get_avatar_attachment_id( $user->ID );
+		if ( $avatar_id !== $before ) {
+			$changed['avatarAttachmentId'] = array(
+				'from' => $before,
+				'to'   => $avatar_id,
+			);
+			if ( 0 === $avatar_id ) {
+				delete_user_meta( $user->ID, OPENSTATION_AGENT_AVATAR_ATTACHMENT_META );
+			} else {
+				update_user_meta( $user->ID, OPENSTATION_AGENT_AVATAR_ATTACHMENT_META, $avatar_id );
+			}
 		}
 	}
 

--- a/src/my-wordpress/agents-renderer.ts
+++ b/src/my-wordpress/agents-renderer.ts
@@ -43,6 +43,7 @@ import {
 	fetchRoles,
 	fetchTriggerKinds,
 	listAgents,
+	uploadAgentProfilePicture,
 	updateAgent,
 } from './agents-rest';
 import type {
@@ -83,6 +84,7 @@ import '../ui/components/os-checkbox-label/os-checkbox-label';
 import '../ui/components/os-empty-state/os-empty-state';
 import '../ui/components/os-field-row/os-field-row';
 import '../ui/components/os-notice/os-notice';
+import '../ui/components/os-ribbon/os-ribbon';
 import '../ui/components/os-select/os-select';
 import '../ui/components/os-spinner/os-spinner';
 import '../ui/components/os-text-field/os-text-field';
@@ -170,6 +172,12 @@ interface CastDraft {
 	face: MioLook;
 	/** First seed of the strip the picker is showing. */
 	stripSeed: number;
+	/** Media Library image that overrides the generated face. */
+	avatarAttachmentId: number;
+	/** Direct upload URL used only before the agent has been created. */
+	avatarPreviewUrl: string;
+	/** True while the wizard is uploading a profile picture. */
+	avatarUploading: boolean;
 	/** True while the AI draft request is in flight. */
 	drafting: boolean;
 }
@@ -190,6 +198,9 @@ function emptyCast( role: string, seed: number ): CastDraft {
 		faceSeed: seed,
 		face: faceFromSeed( seed ),
 		stripSeed: seed,
+		avatarAttachmentId: 0,
+		avatarPreviewUrl: '',
+		avatarUploading: false,
 		drafting: false,
 	};
 }
@@ -207,6 +218,15 @@ const ENTITY_KIND_CHOICES = [ 'post', 'page', 'media', 'user', 'comment' ];
  * says when that stops being true.
  */
 const ABILITY_COLLAPSE_THRESHOLD = 12;
+
+/** Raster formats the server can safely embed behind the AGENT ribbon. */
+const PROFILE_PICTURE_MIME_TYPES = new Set( [
+	'image/jpeg',
+	'image/png',
+	'image/gif',
+	'image/webp',
+	'image/avif',
+] );
 
 /**
  * A starting point for a new face.
@@ -234,9 +254,12 @@ function newSeed(): number {
  * deterministic, so the face is the same one the write would produce.
  */
 function agentFaceSrc(
-	agent: Pick< Agent, 'face' | 'faceSeed' | 'avatarUrl' >,
+	agent: Pick< Agent, 'face' | 'faceSeed' | 'avatarUrl' | 'avatarAttachmentId' >,
 	size: number,
 ): string {
+	if ( ( agent.avatarAttachmentId ?? 0 ) > 0 && agent.avatarUrl !== '' ) {
+		return agent.avatarUrl;
+	}
 	if ( hasFace( agent.face ) && agent.avatarUrl !== '' ) {
 		return agent.avatarUrl;
 	}
@@ -258,6 +281,7 @@ function agentsConfig(): AgentsSectionConfig {
 			enabled: false,
 			canEnable: false,
 			canManage: false,
+			canUpload: false,
 			canInvoke: false,
 			aiAvailable: false,
 			aiStatusUrl: '',
@@ -886,6 +910,76 @@ export function renderAgents( host: EntityRenderHost ): void {
 		}
 	};
 
+	const profilePictureError = ( file: File ): string => {
+		if ( ! PROFILE_PICTURE_MIME_TYPES.has( file.type ) ) {
+			return __(
+				'Choose a JPEG, PNG, GIF, WebP, or AVIF image.',
+				'desktop-mode',
+			);
+		}
+		return '';
+	};
+
+	/** Upload a picture for a not-yet-created wizard draft. */
+	const uploadCastProfilePicture = async ( file: File ): Promise< void > => {
+		const invalid = profilePictureError( file );
+		if ( invalid ) {
+			state.notice = invalid;
+			paint();
+			return;
+		}
+		const cast = state.cast;
+		cast.avatarUploading = true;
+		state.notice = '';
+		paint();
+		try {
+			const uploaded = await uploadAgentProfilePicture( file );
+			if ( state.cast === cast ) {
+				cast.avatarAttachmentId = uploaded.id;
+				cast.avatarPreviewUrl = uploaded.url;
+			}
+		} catch ( err ) {
+			state.notice = err instanceof Error ? err.message : String( err );
+		}
+		cast.avatarUploading = false;
+		if ( ! disposed ) {
+			paint();
+		}
+	};
+
+	/** Upload and immediately assign a picture to an existing agent. */
+	const uploadSavedProfilePicture = async (
+		agent: Agent,
+		file: File,
+	): Promise< void > => {
+		const invalid = profilePictureError( file );
+		if ( invalid ) {
+			state.notice = invalid;
+			paint();
+			return;
+		}
+		state.saving = true;
+		state.notice = '';
+		paint();
+		try {
+			const uploaded = await uploadAgentProfilePicture( file );
+			const updated = await updateAgent( agent.id, {
+				avatarAttachmentId: uploaded.id,
+			} );
+			state.agents = state.agents.map( ( candidate ) =>
+				candidate.id === updated.id ? updated : candidate,
+			);
+			refreshSendToAgents();
+			state.notice = __( 'Profile picture saved.', 'desktop-mode' );
+		} catch ( err ) {
+			state.notice = err instanceof Error ? err.message : String( err );
+		}
+		state.saving = false;
+		if ( ! disposed ) {
+			paint();
+		}
+	};
+
 	const onDelete = async ( agent: Agent ): Promise< void > => {
 		const ok = await osConfirm( {
 			title: __( 'Delete agent?', 'desktop-mode' ),
@@ -1270,6 +1364,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 
 	const definePane = ( agent: Agent ) => {
 		const readOnly = ! cfg.canManage;
+		const pictureInputId = `dm-agent-profile-picture-${ mountId }-${ agent.id }`;
 		const dirty =
 			state.draft.name !== agent.name ||
 			state.draft.description !== agent.description ||
@@ -1277,6 +1372,82 @@ export function renderAgents( host: EntityRenderHost ): void {
 			state.draft.role !== agent.role;
 		return html`
 			<div class="dm-agents__pane">
+				${ readOnly
+					? html``
+					: html`
+							<div class="dm-agents__profile-picture-setting">
+								<img
+									class="dm-agents__profile-picture-preview"
+									src=${ agentFaceSrc( agent, 112 ) }
+									alt=""
+									width="112"
+									height="112"
+								/>
+								<div class="dm-agents__profile-picture-copy">
+									<strong>${ __( 'Profile picture', 'desktop-mode' ) }</strong>
+									<p class="dm-agents__hint">
+										${ __(
+											'Use any photo or illustration. OpenStation adds an AGENT ribbon so it cannot be mistaken for a human account.',
+											'desktop-mode',
+										) }
+									</p>
+									<input
+										id=${ pictureInputId }
+										class="dm-agents__profile-picture-input"
+										type="file"
+										accept="image/jpeg,image/png,image/gif,image/webp,image/avif"
+										@change=${ ( event: Event ) => {
+											const input = event.currentTarget as HTMLInputElement;
+											const file = input.files?.[ 0 ];
+											if ( file ) {
+												void uploadSavedProfilePicture( agent, file );
+											}
+											input.value = '';
+										} }
+									/>
+									<div class="dm-agents__profile-picture-actions">
+										<os-button
+											variant="secondary"
+											?disabled=${ state.saving || ! cfg.canUpload }
+											@click=${ () =>
+												root
+													.querySelector< HTMLInputElement >(
+														`#${ pictureInputId }`,
+													)
+													?.click() }
+										>
+											${ ( agent.avatarAttachmentId ?? 0 ) > 0
+												? __( 'Choose another picture', 'desktop-mode' )
+												: __( 'Upload a picture', 'desktop-mode' ) }
+										</os-button>
+										${ ( agent.avatarAttachmentId ?? 0 ) > 0
+											? html`
+													<os-button
+														variant="ghost"
+														?disabled=${ state.saving }
+														@click=${ () =>
+															void applyPatch(
+																agent.id,
+																{ avatarAttachmentId: 0 },
+																__( 'Generated face restored.', 'desktop-mode' ),
+															) }
+													>
+														${ __( 'Use generated face', 'desktop-mode' ) }
+													</os-button>
+											  `
+											: html`` }
+									</div>
+									${ cfg.canUpload
+										? html``
+										: html`<p class="dm-agents__hint">
+												${ __(
+													'You need permission to upload files to choose a new picture.',
+													'desktop-mode',
+												) }
+										  </p>` }
+								</div>
+							</div>
+					  ` }
 				<os-text-field
 					label=${ __( 'Name', 'desktop-mode' ) }
 					value=${ state.draft.name }
@@ -2061,33 +2232,93 @@ export function renderAgents( host: EntityRenderHost ): void {
 	/** Step 1 — meet them: the face, the name, the voice. */
 	const meetStep = () => {
 		const strip = faceCandidates( state.cast.stripSeed, FACE_CANDIDATES );
+		const customPicture =
+			state.cast.avatarAttachmentId > 0 && state.cast.avatarPreviewUrl !== '';
+		const pictureInputId = `dm-agent-new-profile-picture-${ mountId }`;
 		return html`
 			<div class="dm-agents__meet">
 				<div class="dm-agents__portrait">
-					<img
-						class="dm-agents__portrait-face"
-						src=${ faceSrc( state.cast.face, 176 ) }
-						alt=""
-						width="176"
-						height="176"
+					<div class="dm-agents__portrait-media ${ customPicture ? 'is-custom' : '' }">
+						<img
+							class="dm-agents__portrait-face"
+							src=${ customPicture
+								? state.cast.avatarPreviewUrl
+								: faceSrc( state.cast.face, 176 ) }
+							alt=""
+							width="176"
+							height="176"
+						/>
+						${ customPicture ? html`<os-ribbon>Agent</os-ribbon>` : html`` }
+					</div>
+					<input
+						id=${ pictureInputId }
+						class="dm-agents__profile-picture-input"
+						type="file"
+						accept="image/jpeg,image/png,image/gif,image/webp,image/avif"
+						@change=${ ( event: Event ) => {
+							const input = event.currentTarget as HTMLInputElement;
+							const file = input.files?.[ 0 ];
+							if ( file ) {
+								void uploadCastProfilePicture( file );
+							}
+							input.value = '';
+						} }
 					/>
+					${ cfg.canUpload
+						? html`
+								<div class="dm-agents__profile-picture-actions">
+									<os-button
+										variant="secondary"
+										?busy=${ state.cast.avatarUploading }
+										@click=${ () =>
+											root
+												.querySelector< HTMLInputElement >(
+													`#${ pictureInputId }`,
+												)
+												?.click() }
+									>
+										${ customPicture
+											? __( 'Choose another picture', 'desktop-mode' )
+											: __( 'Upload a picture', 'desktop-mode' ) }
+									</os-button>
+									${ customPicture
+										? html`
+												<os-button
+													variant="ghost"
+													?disabled=${ state.cast.avatarUploading }
+													@click=${ () => {
+														state.cast.avatarAttachmentId = 0;
+														state.cast.avatarPreviewUrl = '';
+														paint();
+													} }
+												>
+													${ __( 'Use generated face', 'desktop-mode' ) }
+												</os-button>
+										  `
+										: html`` }
+								</div>
+						  `
+						: html`` }
 					<div class="dm-agents__faces" role="radiogroup"
 						aria-label=${ __( 'Face', 'desktop-mode' ) }>
 						${ strip.map(
 							( candidate ) => html`
 								<button
 									type="button"
-									class="dm-agents__face-pick ${ candidate.seed ===
+									class="dm-agents__face-pick ${ ! customPicture && candidate.seed ===
 									state.cast.faceSeed
 										? 'is-picked'
 										: '' }"
 									role="radio"
-									aria-checked=${ candidate.seed === state.cast.faceSeed
+									?disabled=${ state.cast.avatarUploading }
+									aria-checked=${ ! customPicture && candidate.seed === state.cast.faceSeed
 										? 'true'
 										: 'false' }
 									@click=${ () => {
 										state.cast.faceSeed = candidate.seed;
 										state.cast.face = candidate.look;
+										state.cast.avatarAttachmentId = 0;
+										state.cast.avatarPreviewUrl = '';
 										paint();
 									} }
 								>
@@ -2098,6 +2329,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 					</div>
 					<os-button
 						variant="secondary"
+						?disabled=${ state.cast.avatarUploading }
 						@click=${ () => {
 							state.cast.stripSeed += FACE_CANDIDATES;
 							paint();
@@ -2106,14 +2338,21 @@ export function renderAgents( host: EntityRenderHost ): void {
 						${ __( 'Surprise me', 'desktop-mode' ) }
 					</os-button>
 					<div class="dm-agents__portrait-chips">
-						<os-chip
-							size="compact"
-							label=${ faceShapeName( state.cast.face ) }
-						></os-chip>
-						<os-chip
-							size="compact"
-							label=${ faceHueName( state.cast.face ) }
-						></os-chip>
+						${ customPicture
+							? html`<os-chip
+									size="compact"
+									label=${ __( 'Custom picture', 'desktop-mode' ) }
+								></os-chip>`
+							: html`
+									<os-chip
+										size="compact"
+										label=${ faceShapeName( state.cast.face ) }
+									></os-chip>
+									<os-chip
+										size="compact"
+										label=${ faceHueName( state.cast.face ) }
+									></os-chip>
+							  ` }
 					</div>
 				</div>
 				<div class="dm-agents__meet-fields">
@@ -2174,7 +2413,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 				<span class="dm-agents__spacer"></span>
 				<os-button
 					variant="primary"
-					?disabled=${ ! meetReady() }
+					?disabled=${ ! meetReady() || state.cast.avatarUploading }
 					@click=${ () => goStep( 2 ) }
 				>
 					${ __( 'Continue', 'desktop-mode' ) }
@@ -2296,6 +2535,8 @@ export function renderAgents( host: EntityRenderHost ): void {
 	/** Step 4, launch. */
 	const launchStep = () => {
 		const canChat = cfg.canInvoke && state.aiReady === true;
+		const customPicture =
+			state.cast.avatarAttachmentId > 0 && state.cast.avatarPreviewUrl !== '';
 		const abilityLabel = ( slug: string ): string =>
 			state.abilities?.find( ( a ) => a.slug === slug )?.label ?? slug;
 		const triggerLabel = ( kind: string ): string =>
@@ -2312,13 +2553,18 @@ export function renderAgents( host: EntityRenderHost ): void {
 				);
 		return html`
 			<os-card class="dm-agents__summary">
-				<img
-					class="dm-agents__summary-face"
-					src=${ faceSrc( state.cast.face, 96 ) }
-					alt=""
-					width="96"
-					height="96"
-				/>
+				<div class="dm-agents__summary-media ${ customPicture ? 'is-custom' : '' }">
+					<img
+						class="dm-agents__summary-face"
+						src=${ customPicture
+							? state.cast.avatarPreviewUrl
+							: faceSrc( state.cast.face, 96 ) }
+						alt=""
+						width="96"
+						height="96"
+					/>
+					${ customPicture ? html`<os-ribbon>Agent</os-ribbon>` : html`` }
+				</div>
 				<div class="dm-agents__summary-text">
 					<h4>${ state.cast.name }</h4>
 					${ state.cast.vibes
@@ -2365,7 +2611,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 				<span class="dm-agents__spacer"></span>
 				<os-button
 					variant=${ canChat ? 'secondary' : 'primary' }
-					?disabled=${ state.saving }
+					?disabled=${ state.saving || state.cast.avatarUploading }
 					@click=${ () => void castCreate( false ) }
 				>
 					${ __( 'Create agent', 'desktop-mode' ) }
@@ -2374,7 +2620,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 					? html`
 							<os-button
 								variant="primary"
-								?disabled=${ state.saving }
+								?disabled=${ state.saving || state.cast.avatarUploading }
 								@click=${ () => void castCreate( true ) }
 							>
 								${ __( 'Create and chat', 'desktop-mode' ) }
@@ -2389,7 +2635,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 	const cancelButton = () => html`
 		<os-button
 			variant="ghost"
-			?disabled=${ state.saving || state.cast.drafting }
+			?disabled=${ state.saving || state.cast.drafting || state.cast.avatarUploading }
 			@click=${ () => {
 				state.creating = false;
 				state.notice = '';
@@ -2429,6 +2675,7 @@ export function renderAgents( host: EntityRenderHost ): void {
 				vibes: c.vibes.trim(),
 				face: c.face,
 				faceSeed: c.faceSeed,
+				avatarAttachmentId: c.avatarAttachmentId,
 			} );
 			state.agents = [ ...state.agents, created ].sort( ( a, b ) =>
 				a.name.localeCompare( b.name ),

--- a/src/my-wordpress/agents-rest.ts
+++ b/src/my-wordpress/agents-rest.ts
@@ -10,6 +10,7 @@
  */
 
 import { trackedFetch } from '../tracked-fetch';
+import { sanitizeFilename } from '../settings/utils';
 import { getConfig } from './rest';
 import type {
 	AgentDraft,
@@ -85,6 +86,7 @@ export interface CreateAgentPayload {
 	vibes?: string;
 	face?: MioLook;
 	faceSeed?: number;
+	avatarAttachmentId?: number;
 }
 
 export function createAgent( payload: CreateAgentPayload ): Promise< Agent > {
@@ -119,6 +121,7 @@ export interface UpdateAgentPayload {
 	vibes?: string;
 	face?: MioLook;
 	faceSeed?: number;
+	avatarAttachmentId?: number;
 }
 
 export function updateAgent(
@@ -129,6 +132,52 @@ export function updateAgent(
 		method: 'POST',
 		body: JSON.stringify( patch ),
 	} );
+}
+
+/**
+ * Upload a profile picture to the site's Media Library.
+ *
+ * The attachment id is what agent create/update stores. Its direct URL
+ * is returned only for the unsaved wizard preview; once saved, callers
+ * use the ribboned `avatarUrl` from the canonical agent response.
+ */
+export async function uploadAgentProfilePicture(
+	file: File,
+): Promise< { id: number; url: string } > {
+	const root = getConfig().restRoot.replace( /\/+$/, '' );
+	const res = await trackedFetch(
+		`${ root }/wp/v2/media`,
+		{
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': getConfig().restNonce,
+				'Content-Type': file.type,
+				'Content-Disposition': `attachment; filename="${ sanitizeFilename( file.name ) }"`,
+			},
+			body: file,
+		},
+		{ source: 'desktop-mode/agents/profile-picture' },
+	);
+	const body = ( await res.json().catch( () => null ) ) as
+		| { id?: number; source_url?: string; message?: string }
+		| null;
+	if ( ! res.ok ) {
+		throw new Error(
+			body && typeof body.message === 'string'
+				? body.message
+				: `HTTP ${ res.status }`,
+		);
+	}
+	if (
+		! body ||
+		typeof body.id !== 'number' ||
+		typeof body.source_url !== 'string' ||
+		body.source_url === ''
+	) {
+		throw new Error( 'The uploaded profile picture response was incomplete.' );
+	}
+	return { id: body.id, url: body.source_url };
 }
 
 export function deleteAgent(

--- a/src/my-wordpress/agents-types.ts
+++ b/src/my-wordpress/agents-types.ts
@@ -45,6 +45,12 @@ export interface Agent {
 	 * without stranding anyone on an old palette.
 	 */
 	faceSeed: number;
+	/**
+	 * Media Library image used as the profile picture. Zero or absent
+	 * keeps the generated Mio face. The server bakes the AGENT ribbon
+	 * into `avatarUrl`, so every avatar consumer gets the identity mark.
+	 */
+	avatarAttachmentId?: number;
 	avatarUrl: string;
 }
 
@@ -150,6 +156,8 @@ export interface AgentsSectionConfig {
 	/** Whether this user may flip that option (`manage_options`). */
 	canEnable: boolean;
 	canManage: boolean;
+	/** Whether the current user may upload a new profile picture. */
+	canUpload?: boolean;
 	canInvoke: boolean;
 	aiAvailable: boolean;
 	aiStatusUrl: string;

--- a/tests/phpunit/tests/agentsIdentity2.php
+++ b/tests/phpunit/tests/agentsIdentity2.php
@@ -12,6 +12,7 @@
 class Tests_OpenStation_AgentsIdentity2 extends WP_UnitTestCase {
 
 	protected static $admin_id;
+	private $profile_picture_ids = array();
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
@@ -23,6 +24,12 @@ class Tests_OpenStation_AgentsIdentity2 extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		foreach ( $this->profile_picture_ids as $attachment_id ) {
+			if ( get_post( $attachment_id ) ) {
+				wp_delete_attachment( $attachment_id, true );
+			}
+		}
+		$this->profile_picture_ids = array();
 		$dir = openstation_agent_faces_dir();
 		if ( is_dir( $dir ) ) {
 			foreach ( (array) glob( $dir . '/*.svg' ) as $file ) {
@@ -42,6 +49,26 @@ class Tests_OpenStation_AgentsIdentity2 extends WP_UnitTestCase {
 				$args
 			)
 		);
+	}
+
+	private function make_profile_picture() {
+		$png = base64_decode(
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z2s8AAAAASUVORK5CYII=',
+			true
+		);
+		$upload = wp_upload_bits( 'agent-profile-picture.png', null, $png );
+		$this->assertEmpty( $upload['error'] );
+		$attachment_id = self::factory()->attachment->create_object(
+			$upload['file'],
+			0,
+			array(
+				'post_mime_type' => 'image/png',
+				'post_title'     => 'Agent profile picture',
+			)
+		);
+		update_attached_file( $attachment_id, $upload['file'] );
+		$this->profile_picture_ids[] = $attachment_id;
+		return $attachment_id;
 	}
 
 	// -----------------------------------------------------------------
@@ -170,6 +197,73 @@ class Tests_OpenStation_AgentsIdentity2 extends WP_UnitTestCase {
 			openstation_agent_face_url( $user->ID ),
 			get_avatar_url( $user->ID )
 		);
+	}
+
+	public function test_a_custom_profile_picture_is_served_with_an_agent_ribbon() {
+		$attachment_id = $this->make_profile_picture();
+		$user          = $this->make_agent(
+			array(
+				'face'               => array( 'physics' => array( 'shapePreset' => 'ghost' ) ),
+				'avatarAttachmentId' => $attachment_id,
+			)
+		);
+
+		$this->assertSame(
+			$attachment_id,
+			openstation_agent_get_avatar_attachment_id( $user->ID )
+		);
+		$this->assertSame( openstation_agent_face_url( $user->ID ), get_avatar_url( $user->ID ) );
+		$svg = file_get_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading the avatar this test just wrote.
+			openstation_agent_faces_dir() . '/' . openstation_agent_face_filename( $user->ID )
+		);
+		$this->assertStringContainsString( 'data:image/png;base64,', $svg );
+		$this->assertStringContainsString( '>AGENT</text>', $svg );
+	}
+
+	public function test_removing_a_custom_picture_restores_the_generated_face() {
+		$attachment_id = $this->make_profile_picture();
+		$user          = $this->make_agent(
+			array(
+				'face'               => array( 'physics' => array( 'shapePreset' => 'star' ) ),
+				'avatarAttachmentId' => $attachment_id,
+			)
+		);
+		$custom_url = get_avatar_url( $user->ID );
+
+		openstation_agent_update( $user->ID, array( 'avatarAttachmentId' => 0 ) );
+
+		$this->assertSame( 0, openstation_agent_get_avatar_attachment_id( $user->ID ) );
+		$this->assertNotSame( $custom_url, get_avatar_url( $user->ID ) );
+		$svg = file_get_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading the avatar this test just wrote.
+			openstation_agent_faces_dir() . '/' . openstation_agent_face_filename( $user->ID )
+		);
+		$this->assertStringNotContainsString( '>AGENT</text>', $svg );
+	}
+
+	public function test_deleting_a_custom_picture_restores_the_generated_face() {
+		$attachment_id = $this->make_profile_picture();
+		$user          = $this->make_agent(
+			array(
+				'face'               => array( 'physics' => array( 'shapePreset' => 'cloud' ) ),
+				'avatarAttachmentId' => $attachment_id,
+			)
+		);
+
+		wp_delete_attachment( $attachment_id, true );
+
+		$this->assertSame( 0, openstation_agent_get_avatar_attachment_id( $user->ID ) );
+		$this->assertNotSame( '', openstation_agent_face_url( $user->ID ) );
+	}
+
+	public function test_svg_attachments_are_not_accepted_as_profile_pictures() {
+		$attachment_id = self::factory()->attachment->create_object(
+			'agent.svg',
+			0,
+			array( 'post_mime_type' => 'image/svg+xml' )
+		);
+		$user = $this->make_agent( array( 'avatarAttachmentId' => $attachment_id ) );
+
+		$this->assertSame( 0, openstation_agent_get_avatar_attachment_id( $user->ID ) );
 	}
 
 	public function test_an_agent_without_a_face_keeps_the_shipped_glyph() {

--- a/tests/phpunit/tests/agentsMyWordpress.php
+++ b/tests/phpunit/tests/agentsMyWordpress.php
@@ -98,6 +98,7 @@ class Tests_OpenStation_AgentsMyWordpress extends WP_UnitTestCase {
 		$this->assertTrue( $config['enabled'] );
 		$this->assertTrue( $config['canEnable'] );
 		$this->assertTrue( $config['canManage'] );
+		$this->assertTrue( $config['canUpload'] );
 		$this->assertTrue( $config['canInvoke'] );
 	}
 

--- a/tests/phpunit/tests/agentsRest.php
+++ b/tests/phpunit/tests/agentsRest.php
@@ -120,6 +120,7 @@ class Tests_OpenStation_AgentsRest extends WP_UnitTestCase {
 		$this->assertSame( array(), $shape['triggers'] );
 		$this->assertSame( '', $shape['model'] );
 		$this->assertSame( 0, $shape['rateLimit'] );
+		$this->assertSame( 0, $shape['avatarAttachmentId'] );
 		$this->assertNotEmpty( $shape['avatarUrl'] );
 		$this->assertTrue( openstation_agent_is_agent( $shape['id'] ) );
 	}
@@ -162,6 +163,29 @@ class Tests_OpenStation_AgentsRest extends WP_UnitTestCase {
 			'',
 			openstation_agent_face_url( (int) $data['id'] ),
 			'the created agent has no face file'
+		);
+	}
+
+	/**
+	 * The Media Library reference belongs in the initial create so the
+	 * first canonical response already carries the ribboned identity.
+	 *
+	 * @covers ::openstation_agents_rest_create
+	 */
+	public function test_create_keeps_the_profile_picture_attachment() {
+		$attachment_id = self::factory()->attachment->create_object(
+			'profile-picture.jpg',
+			0,
+			array( 'post_mime_type' => 'image/jpeg' )
+		);
+		$data = $this->create_agent_via_rest(
+			array( 'avatarAttachmentId' => $attachment_id )
+		);
+
+		$this->assertSame( $attachment_id, $data['avatarAttachmentId'] );
+		$this->assertSame(
+			$attachment_id,
+			openstation_agent_get_avatar_attachment_id( (int) $data['id'] )
 		);
 	}
 

--- a/tests/vitest/agents-renderer.test.ts
+++ b/tests/vitest/agents-renderer.test.ts
@@ -75,6 +75,7 @@ function installConfig( overrides: Record< string, unknown > = {} ): void {
 				enabled: true,
 				canEnable: true,
 				canManage: true,
+				canUpload: true,
 				canInvoke: true,
 				aiAvailable: false,
 				aiStatusUrl: '',
@@ -176,6 +177,59 @@ describe( 'agents entity kind', () => {
 
 		const nameField = host.body.querySelector( 'os-text-field' );
 		expect( nameField?.getAttribute( 'value' ) ).toBe( 'Audit Agent' );
+	} );
+
+	test( 'an existing custom picture can be restored to the generated face', async () => {
+		const custom = {
+			...AGENT,
+			avatarAttachmentId: 44,
+			avatarUrl: 'https://example.test/ribboned-agent.svg',
+		};
+		const patches: Array< Record< string, unknown > > = [];
+		const fn = vi.fn( async ( input: RequestInfo, init?: RequestInit ) => {
+			if ( String( input ).endsWith( '/agents/12' ) && init?.method === 'POST' ) {
+				const body = JSON.parse( String( init.body ) ) as Record< string, unknown >;
+				patches.push( body );
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ( {
+						...custom,
+						...body,
+						avatarUrl: 'https://example.test/generated-agent.svg',
+					} ),
+				} as unknown as Response;
+			}
+			return {
+				ok: true,
+				status: 200,
+				json: async () => [ custom ],
+			} as unknown as Response;
+		} );
+		( globalThis as unknown as { fetch: FetchMock } ).fetch = fn;
+		const host = makeHost();
+
+		getEntityRenderer( 'agent' )!( host, ENTITY );
+		await flush();
+		host.body
+			.querySelector< HTMLElement >( '.dm-agents__cast-card' )!
+			.dispatchEvent( new CustomEvent( 'os-card-click', { bubbles: true } ) );
+		await flush();
+
+		expect(
+			host.body.querySelector( '.dm-agents__profile-picture-preview' )?.getAttribute( 'src' ),
+		).toBe( 'https://example.test/ribboned-agent.svg' );
+		const restore = [ ...host.body.querySelectorAll( 'os-button' ) ].find(
+			( button ) => ( button.textContent ?? '' ).trim() === 'Use generated face',
+		);
+		expect( restore ).toBeDefined();
+		restore!.click();
+		await flush();
+
+		expect( patches ).toEqual( [ { avatarAttachmentId: 0 } ] );
+		expect(
+			host.body.querySelector( '.dm-agents__profile-picture-preview' )?.getAttribute( 'src' ),
+		).toBe( 'https://example.test/generated-agent.svg' );
 	} );
 
 	test( 'empty list paints the empty state with a create CTA', async () => {

--- a/tests/vitest/agents-rest.test.ts
+++ b/tests/vitest/agents-rest.test.ts
@@ -10,6 +10,7 @@ import {
 	fetchAbilitiesCatalogue,
 	invokeAgent,
 	listAgents,
+	uploadAgentProfilePicture,
 	updateAgent,
 } from '../../src/my-wordpress/agents-rest';
 
@@ -102,6 +103,36 @@ describe( 'agents REST client', () => {
 		expect( JSON.parse( String( init.body ) ) ).toEqual( {
 			instructions: 'Be nice.',
 		} );
+	} );
+
+	test( 'uploads a profile picture to the Media Library', async () => {
+		const fetchMock = mockFetch( {
+			id: 81,
+			source_url: 'https://example.test/uploads/avatar.jpg',
+		} );
+		const file = new File( [ 'image bytes' ], 'Agent Portrait.jpg', {
+			type: 'image/jpeg',
+		} );
+
+		const uploaded = await uploadAgentProfilePicture( file );
+
+		expect( uploaded ).toEqual( {
+			id: 81,
+			url: 'https://example.test/uploads/avatar.jpg',
+		} );
+		const [ url, init ] = fetchMock.mock.calls[ 0 ] as [
+			string,
+			RequestInit,
+		];
+		expect( url ).toBe( 'https://example.test/wp-json/wp/v2/media' );
+		expect( init.method ).toBe( 'POST' );
+		expect( init.body ).toBe( file );
+		expect( ( init.headers as Record< string, string > )[ 'Content-Type' ] ).toBe(
+			'image/jpeg',
+		);
+		expect(
+			( init.headers as Record< string, string > )[ 'Content-Disposition' ],
+		).toBe( 'attachment; filename="Agent-Portrait.jpg"' );
 	} );
 
 	test( 'deleteAgent uses the DELETE verb', async () => {

--- a/tests/vitest/agents-wizard.test.ts
+++ b/tests/vitest/agents-wizard.test.ts
@@ -61,6 +61,7 @@ function installConfig( overrides: Record< string, unknown > = {} ): void {
 				enabled: true,
 				canEnable: true,
 				canManage: true,
+				canUpload: true,
 				canInvoke: true,
 				aiAvailable: false,
 				aiStatusUrl: '',
@@ -192,6 +193,12 @@ function mockRoutes( agents: Agent[], onCreate?: ( body: unknown ) => void ) {
 				} );
 			}
 			return json( draftResponse ?? {} );
+		}
+		if ( url.endsWith( '/wp/v2/media' ) && init?.method === 'POST' ) {
+			return json( {
+				id: 77,
+				source_url: 'https://example.test/uploads/profile-picture.jpg',
+			} );
 		}
 		if ( url.match( /\/agents\/?$/ ) && init?.method === 'POST' ) {
 			const body = JSON.parse( String( init.body ) );
@@ -339,6 +346,74 @@ describe( 'the guided create flow', () => {
 		expect(
 			after[ 0 ].querySelector( 'img' )!.getAttribute( 'src' ),
 		).not.toBe( firstSrc );
+	} );
+
+	test( 'uploads a custom profile picture and carries it into create', async () => {
+		const { host, created } = await openWizard();
+		press( host, 'Continue' );
+		await flush();
+
+		const input = host.body.querySelector< HTMLInputElement >(
+			'.dm-agents__profile-picture-input',
+		);
+		expect( input ).not.toBeNull();
+		const file = new File( [ 'picture' ], 'portrait.jpg', {
+			type: 'image/jpeg',
+		} );
+		Object.defineProperty( input!, 'files', { value: [ file ] } );
+		input!.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await flush();
+
+		expect(
+			host.body
+				.querySelector( '.dm-agents__portrait-face' )
+				?.getAttribute( 'src' ),
+		).toBe( 'https://example.test/uploads/profile-picture.jpg' );
+		expect( host.body.querySelector( '.dm-agents__portrait os-ribbon' )?.textContent ).toContain(
+			'Agent',
+		);
+
+		setField( host, 'Name', 'Portrait Agent' );
+		press( host, 'Continue' );
+		await flush();
+		press( host, 'Continue' );
+		await flush();
+		press( host, 'Continue' );
+		await flush();
+		expect( host.body.querySelector( '.dm-agents__summary os-ribbon' ) ).not.toBeNull();
+		press( host, 'Create agent' );
+		await flush();
+
+		expect( created ).toHaveLength( 1 );
+		expect(
+			( created[ 0 ] as Record< string, unknown > ).avatarAttachmentId,
+		).toBe( 77 );
+	} );
+
+	test( 'picking a generated face removes the custom-picture override', async () => {
+		const { host } = await openWizard();
+		press( host, 'Continue' );
+		await flush();
+		const input = host.body.querySelector< HTMLInputElement >(
+			'.dm-agents__profile-picture-input',
+		)!;
+		Object.defineProperty( input, 'files', {
+			value: [ new File( [ 'picture' ], 'portrait.png', { type: 'image/png' } ) ],
+		} );
+		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await flush();
+		expect( host.body.querySelector( '.dm-agents__portrait os-ribbon' ) ).not.toBeNull();
+
+		host.body
+			.querySelector< HTMLButtonElement >( '.dm-agents__face-pick' )!
+			.click();
+		await flush();
+		expect( host.body.querySelector( '.dm-agents__portrait os-ribbon' ) ).toBeNull();
+		expect(
+			host.body
+				.querySelector( '.dm-agents__portrait-face' )
+				?.getAttribute( 'src' ),
+		).toContain( 'data:image/svg+xml' );
 	} );
 
 	test( 'Powers shows the abilities grouped, described, and badged', async () => {


### PR DESCRIPTION
## Context

Recent agent-customization work may already cover the original need, so this is not proposed for merge yet. This draft keeps the optional profile-picture implementation available for hands-on evaluation and comparison with the existing generated Mio faces.

## What it does

- Adds optional Media Library profile pictures to agent creation and editing.
- Crops raster uploads into the existing generated avatar asset.
- Bakes a permanent **AGENT** ribbon into the served avatar so the identity marker appears in every `get_avatar()` consumer.
- Supports restoring the generated Mio face and automatically falls back when the source attachment is deleted.
- Restricts embedded sources to JPEG, PNG, GIF, WebP, and AVIF images.

## Test plan

1. Create an agent and upload a custom picture in the guided flow.
2. Confirm the preview and saved avatar show an AGENT ribbon.
3. Change the picture from the agent's Define pane.
4. Choose **Use generated face** and confirm the Mio face returns.
5. Delete an assigned source image from the Media Library and confirm the generated face is restored.
6. Check the agent avatar in another WordPress surface that uses `get_avatar()`.

## Automated checks

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run test:js` — 5,005 tests passed
- `npm run lint:php`
- `npm run test:php` — 2,534 tests and 20,189 assertions passed (5 existing skips)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-686-e3968410e32e146ecf33c94b19d857f6a0a34e21.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->