### PR TITLE
Trash: Hide the list chrome while the bin is empty

### DIFF
--- a/assets/css/recycle-bin.css
+++ b/assets/css/recycle-bin.css
@@ -38,11 +38,14 @@
 /*
  * Honour the `hidden` attribute. The browser's UA stylesheet
  * sets `[hidden] { display: none }`, but our explicit
- * `display: flex` above wins on specificity. This rule restores
- * the expected behaviour so `bulk.hidden = true` from JS
- * actually hides the bulk action group when nothing is selected.
+ * `display: flex` above wins on specificity. These rules restore
+ * the expected behaviour for every group the JS hides: the bulk
+ * actions (nothing selected), and the whole toolbar plus the
+ * standalone empty state (nothing in the bin).
  */
-.os-recycle-bin__toolbar-right[hidden] {
+.os-recycle-bin__toolbar[hidden],
+.os-recycle-bin__toolbar-right[hidden],
+.os-recycle-bin__empty[hidden] {
 	display: none;
 }
 
@@ -80,9 +83,11 @@
  */
 
 .os-recycle-bin__empty {
+	flex: 1 1 auto;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	justify-content: center;
 	gap: 8px;
 	padding: 32px 16px;
 	color: var( --os-ui-fg-muted, #50575e );

--- a/assets/css/recycle-bin.css
+++ b/assets/css/recycle-bin.css
@@ -39,13 +39,12 @@
  * Honour the `hidden` attribute. The browser's UA stylesheet
  * sets `[hidden] { display: none }`, but our explicit
  * `display: flex` above wins on specificity. These rules restore
- * the expected behaviour for every group the JS hides: the bulk
- * actions (nothing selected), and the whole toolbar plus the
- * standalone empty state (nothing in the bin).
+ * the expected behaviour for the two groups the JS hides: the bulk
+ * actions (nothing selected) and the whole toolbar (nothing in the
+ * bin). `<os-empty-state>` handles its own.
  */
 .os-recycle-bin__toolbar[hidden],
-.os-recycle-bin__toolbar-right[hidden],
-.os-recycle-bin__empty[hidden] {
+.os-recycle-bin__toolbar-right[hidden] {
 	display: none;
 }
 
@@ -82,28 +81,10 @@
  * live in the bin window's light-DOM template.
  */
 
-.os-recycle-bin__empty {
+/* `<os-empty-state>` centres its own contents; this makes it fill
+ * the body once the table beside it is hidden. */
+.os-recycle-bin__body os-empty-state {
 	flex: 1 1 auto;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	padding: 32px 16px;
-	color: var( --os-ui-fg-muted, #50575e );
-	text-align: center;
-}
-
-.os-recycle-bin__empty .dashicons {
-	font-size: 32px;
-	width: 32px;
-	height: 32px;
-	opacity: 0.6;
-}
-
-.os-recycle-bin__empty-hint {
-	font-size: 12px;
-	max-width: 360px;
 }
 
 /*

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2784,7 +2784,7 @@ The bin registers **no desktop icon**, so it lands on the dock and nowhere else.
 
 The full template body before it's emitted into the native-window template element. Keep the `data-os-recycle-bin-*` hooks intact so the JS bundle can find its mount points.
 
-Two are visibility hooks rather than mount points: while the bin is empty the JS hides `[data-os-recycle-bin-toolbar]` and the `<os-table>`, and shows `[data-os-recycle-bin-empty-state]`. Put added toolbar controls inside the toolbar element or they stay visible over an empty bin. A filter or search that matches nothing keeps the toolbar and shows the table's own `empty` text instead.
+Some are visibility hooks rather than mount points: while the bin is empty the JS hides `[data-os-recycle-bin-toolbar]` and the `<os-table>`, and shows `[data-os-recycle-bin-empty-state]`. Put added toolbar controls inside the toolbar element or they stay visible over an empty bin. A filter or search that matches nothing keeps the toolbar and shows the table's own `empty` text instead; so does a failed load, which swaps that text for a retry message.
 
 ### `openstation_recycle_bin_empty_chunk_size` — Experimental (filter)
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -2784,6 +2784,8 @@ The bin registers **no desktop icon**, so it lands on the dock and nowhere else.
 
 The full template body before it's emitted into the native-window template element. Keep the `data-os-recycle-bin-*` hooks intact so the JS bundle can find its mount points.
 
+Two are visibility hooks rather than mount points: while the bin is empty the JS hides `[data-os-recycle-bin-toolbar]` and the `<os-table>`, and shows `[data-os-recycle-bin-empty-state]`. Put added toolbar controls inside the toolbar element or they stay visible over an empty bin. A filter or search that matches nothing keeps the toolbar and shows the table's own `empty` text instead.
+
 ### `openstation_recycle_bin_empty_chunk_size` — Experimental (filter)
 
 ```php

--- a/includes/recycle-bin/window.php
+++ b/includes/recycle-bin/window.php
@@ -195,13 +195,14 @@ function openstation_recycle_bin_render_template() {
 			</div>
 		</header>
 		<div class="os-recycle-bin__body" data-os-recycle-bin-body>
-			<div class="os-recycle-bin__empty" data-os-recycle-bin-empty-state hidden>
-				<span class="dashicons dashicons-trash" aria-hidden="true"></span>
-				<p><?php esc_html_e( 'The Trash is empty.', 'desktop-mode' ); ?></p>
-				<p class="os-recycle-bin__empty-hint">
-					<?php esc_html_e( 'Deleted posts, pages, and media show up here. Restoring puts them back where they were.', 'desktop-mode' ); ?>
-				</p>
-			</div>
+			<os-empty-state
+				data-os-recycle-bin-empty-state
+				role="status"
+				icon="trash"
+				heading="<?php esc_attr_e( 'The Trash is empty.', 'desktop-mode' ); ?>"
+				description="<?php esc_attr_e( 'Deleted posts, pages, and media show up here. Restoring puts them back where they were.', 'desktop-mode' ); ?>"
+				hidden
+			></os-empty-state>
 			<os-table
 				data-os-recycle-bin-table
 				selectable="multi"

--- a/includes/recycle-bin/window.php
+++ b/includes/recycle-bin/window.php
@@ -195,6 +195,13 @@ function openstation_recycle_bin_render_template() {
 			</div>
 		</header>
 		<div class="os-recycle-bin__body" data-os-recycle-bin-body>
+			<div class="os-recycle-bin__empty" data-os-recycle-bin-empty-state hidden>
+				<span class="dashicons dashicons-trash" aria-hidden="true"></span>
+				<p><?php esc_html_e( 'The Trash is empty.', 'desktop-mode' ); ?></p>
+				<p class="os-recycle-bin__empty-hint">
+					<?php esc_html_e( 'Deleted posts, pages, and media show up here. Restoring puts them back where they were.', 'desktop-mode' ); ?>
+				</p>
+			</div>
 			<os-table
 				data-os-recycle-bin-table
 				selectable="multi"
@@ -202,15 +209,8 @@ function openstation_recycle_bin_render_template() {
 				hover
 				striped
 				loading
-			>
-				<div slot="empty" class="os-recycle-bin__empty">
-					<span class="dashicons dashicons-trash" aria-hidden="true"></span>
-					<p><?php esc_html_e( 'The Trash is empty.', 'desktop-mode' ); ?></p>
-					<p class="os-recycle-bin__empty-hint">
-						<?php esc_html_e( 'Deleted posts, pages, and media show up here. Restoring puts them back where they were.', 'desktop-mode' ); ?>
-					</p>
-				</div>
-			</os-table>
+				empty="<?php esc_attr_e( 'No items match the current filter or search.', 'desktop-mode' ); ?>"
+			></os-table>
 		</div>
 	</div>
 	<?php

--- a/includes/registries/native-windows.php
+++ b/includes/registries/native-windows.php
@@ -518,6 +518,7 @@ function openstation_native_window_allowed_html() {
 			'compact'        => true,
 			'loading'        => true,
 			'loading-rows'   => true,
+			'empty'          => true,
 			'columns'        => true,
 			'rows'           => true,
 			'sortable'       => true,

--- a/includes/registries/native-windows.php
+++ b/includes/registries/native-windows.php
@@ -525,6 +525,7 @@ function openstation_native_window_allowed_html() {
 			'expandable'     => true,
 			'preset'         => true,
 			'label'          => true,
+			'heading'        => true,
 			'description'    => true,
 			'orientation'    => true,
 			'level'          => true,

--- a/src/recycle-bin/icon-state.ts
+++ b/src/recycle-bin/icon-state.ts
@@ -151,7 +151,8 @@ export function adjustRecycleBinCount( delta: number ): void {
 }
 
 /**
- * Read the current value (mostly for tests / debug).
+ * Read the current value. The bin window reads it at render time to
+ * pick its initial chrome state, before the first `/list` lands.
  *
  * @internal
  */

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -34,7 +34,7 @@ import {
 	resolveThemedIconColor,
 } from '../desktop-themes/icons';
 import { DESKTOP_THEME_SLOTS } from '../desktop-themes/slots';
-import { setRecycleBinCount } from './icon-state';
+import { _currentRecycleBinCount, setRecycleBinCount } from './icon-state';
 import { runEmptyLoop } from './empty-loop';
 import * as realtime from './realtime';
 import {
@@ -164,6 +164,8 @@ function makeTypeBadge( row: RecycleBinItem ): HTMLElement {
 }
 
 const ROOT = '[data-os-recycle-bin-root]';
+const TOOLBAR = '[data-os-recycle-bin-toolbar]';
+const EMPTY_STATE = '[data-os-recycle-bin-empty-state]';
 const FILTER = '[data-os-recycle-bin-filter]';
 const SEARCH = '[data-os-recycle-bin-search]';
 const REFRESH = '[data-os-recycle-bin-refresh]';
@@ -245,7 +247,6 @@ function buildColumns(): OsTableColumn< RecycleBinItem >[] {
 			key: 'title',
 			label: __( 'Title' ),
 			sortable: true,
-			filter: 'text',
 			render: ( _v, row ) => {
 				// One-cell layout: optional thumbnail (image
 				// attachments only) sits inline at the start, then
@@ -324,7 +325,6 @@ function buildColumns(): OsTableColumn< RecycleBinItem >[] {
 			key: 'deleted_by',
 			label: __( 'By' ),
 			sortable: true,
-			filter: 'text',
 			width: '160px',
 			render: ( _v, row ) => row.deleted_by || '—',
 		},
@@ -611,6 +611,29 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	// reserved for tables where dragging IS the primary
 	// affordance (e.g. plugin-authored picker UIs).
 
+	const toolbar = root.querySelector< HTMLElement >( TOOLBAR );
+	const emptyState = root.querySelector< HTMLElement >( EMPTY_STATE );
+
+	/**
+	 * Show or hide everything that only makes sense against a list.
+	 * The table goes too — its header row carries the sort controls.
+	 *
+	 * Callers pass the list endpoint's `total`, which counts the whole
+	 * bin regardless of the active filter or search: a search matching
+	 * nothing must keep the toolbar, or there is no way back out of
+	 * it. That case shows the table's own `empty` text instead.
+	 */
+	const setChromeVisible = ( hasItems: boolean ): void => {
+		toolbar?.toggleAttribute( 'hidden', ! hasItems );
+		emptyState?.toggleAttribute( 'hidden', hasItems );
+		table.hidden = ! hasItems;
+	};
+
+	// The badge count is seeded from the shell config on boot, so an
+	// empty bin opens straight into its empty state rather than a
+	// skeleton and a toolbar that both vanish a moment later.
+	setChromeVisible( _currentRecycleBinCount() > 0 );
+
 	// If we have a cached snapshot from a previous open, paint it
 	// synchronously — the user sees the data they expect on
 	// reopen, no skeleton, no flash. The fingerprint becomes the
@@ -669,8 +692,8 @@ export function renderRecycleBin( body: HTMLElement ): void {
 				cachedItems = items;
 				// Prune selection keys whose row is no longer VISIBLE —
 				// it left the list (purged / restored elsewhere) or a
-				// data-driven change hid it behind an active column
-				// filter. `collectSelectedItems()` already resolves
+				// data-driven change hid it behind a `table.filters`
+				// entry. `collectSelectedItems()` resolves
 				// against the visible rows, so this is not load-bearing
 				// for safety — it keeps the bulk bar's "N selected"
 				// count truthful instead of overcounting ghosts.
@@ -697,6 +720,7 @@ export function renderRecycleBin( body: HTMLElement ): void {
 			// way to keep the badge truthful: we already paid for
 			// the round-trip, so we may as well consume the count.
 			setRecycleBinCount( total );
+			setChromeVisible( total > 0 );
 		} catch ( err ) {
 			if ( mySeq !== refreshSeq ) {
 				return;
@@ -753,8 +777,8 @@ export function renderRecycleBin( body: HTMLElement ): void {
 	//
 	// Resolve against the VISIBLE rows, not the full `data` buffer:
 	// a data-driven change (e.g. a realtime refresh replacing a row
-	// whose new title no longer matches an active Title column filter)
-	// can hide a selected row without any filter event firing — and a
+	// whose new title no longer matches a `table.filters` entry) can
+	// hide a selected row without any filter event firing — and a
 	// row the user cannot see must never ride into a purge.
 	const collectSelectedItems = (): RecycleBinItemRef[] => {
 		const sel = new Set( Array.from( table.selection ?? [], String ) );
@@ -1075,16 +1099,6 @@ export function renderRecycleBin( body: HTMLElement ): void {
 
 	table.addEventListener( 'os-table-selection-change', () => {
 		refreshBulkBar();
-	} );
-
-	// The Title / "By" columns declare client-side `filter: 'text'`
-	// filters. A row ticked BEFORE the user types into one stays
-	// selected while hidden — and it's still in `table.data`, so
-	// `collectSelectedItems()` would sweep it into a bulk purge the
-	// user can't see coming. Same hygiene as the toolbar filter /
-	// search: any visibility change starts with a clean selection.
-	table.addEventListener( 'os-table-filter-change', () => {
-		table.clearSelection();
 	} );
 
 	// Default sort: most-recently-deleted first. Users can change it.

--- a/src/recycle-bin/index.ts
+++ b/src/recycle-bin/index.ts
@@ -28,6 +28,8 @@ import '../ui/components/os-relative-time/os-relative-time';
 // `createElement('os-*')` doesn't see it. Register the compound
 // class set explicitly so the server-rendered toolbar works.
 import '../ui/components/os-segmented/os-segmented';
+// Same story for `<os-empty-state>`, which the template emits.
+import '../ui/components/os-empty-state/os-empty-state';
 import { DESKTOP_THEME_CHANGED_EVENT } from '../desktop-themes/apply';
 import {
 	resolveThemedIcon,
@@ -613,6 +615,7 @@ export function renderRecycleBin( body: HTMLElement ): void {
 
 	const toolbar = root.querySelector< HTMLElement >( TOOLBAR );
 	const emptyState = root.querySelector< HTMLElement >( EMPTY_STATE );
+	const noMatchText = table.getAttribute( 'empty' ) ?? '';
 
 	/**
 	 * Show or hide everything that only makes sense against a list.
@@ -720,20 +723,26 @@ export function renderRecycleBin( body: HTMLElement ): void {
 			// way to keep the badge truthful: we already paid for
 			// the round-trip, so we may as well consume the count.
 			setRecycleBinCount( total );
+			table.setAttribute( 'empty', noMatchText );
 			setChromeVisible( total > 0 );
 		} catch ( err ) {
 			if ( mySeq !== refreshSeq ) {
 				return;
 			}
 			console.error( '[recycle-bin] list failed', err );
-			// On the first-load failure with no cache, render an
-			// empty table so the slotted empty state shows. On
-			// subsequent failures with a cache, keep stale data —
-			// better UX than flashing "empty" because the network
-			// blipped.
+			// With a cache, keep the stale rows — better than
+			// flashing "empty" because the network blipped. With
+			// none, show an empty table, and force the chrome on
+			// whatever the seeded count said: the failure copy
+			// below points at Refresh, which lives in the toolbar.
 			if ( showSkeleton ) {
 				table.data = [];
 				currentFingerprint = '';
+				table.setAttribute(
+					'empty',
+					__( 'Could not load the Trash. Try Refresh.' ),
+				);
+				setChromeVisible( true );
 			}
 		} finally {
 			// Only the latest in-flight refresh gets to flip the

--- a/tests/phpunit/tests/recycleBinEmptyState.php
+++ b/tests/phpunit/tests/recycleBinEmptyState.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Test that `<os-table empty>` survives the Recycle Bin template's
+ * own `wp_kses` pass.
+ *
+ * The template is escaped on output against
+ * `openstation_native_window_allowed_html()`, and kses drops any
+ * attribute the allowlist doesn't name — silently, so a stripped one
+ * reads as working markup that quietly does nothing. Here that would
+ * cost the translated "nothing matched" line and fall back to the
+ * component's hardcoded "No data".
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group desktop-mode-recycle-bin
+ */
+class Tests_OpenStation_RecycleBinEmptyState extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::openstation_recycle_bin_render_template
+	 * @covers ::openstation_native_window_allowed_html
+	 */
+	public function test_table_keeps_its_empty_text_through_kses() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		ob_start();
+		openstation_recycle_bin_render_template();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString(
+			'empty="No items match the current filter or search."',
+			$html
+		);
+	}
+}

--- a/tests/phpunit/tests/recycleBinEmptyState.php
+++ b/tests/phpunit/tests/recycleBinEmptyState.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * Test that `<os-table empty>` survives the Recycle Bin template's
- * own `wp_kses` pass.
+ * Test that the Recycle Bin's two text-carrying attributes survive
+ * the template's own `wp_kses` pass.
  *
  * The template is escaped on output against
  * `openstation_native_window_allowed_html()`, and kses drops any
  * attribute the allowlist doesn't name — silently, so a stripped one
- * reads as working markup that quietly does nothing. Here that would
- * cost the translated "nothing matched" line and fall back to the
- * component's hardcoded "No data".
+ * reads as working markup that quietly does nothing. `empty` and
+ * `heading` were both missing, which would have cost the translated
+ * "nothing matched" line (falling back to the component's hardcoded
+ * "No data") and the empty state's whole first line.
  *
  * @package WordPress
  * @subpackage UnitTests
@@ -19,19 +20,30 @@
 class Tests_OpenStation_RecycleBinEmptyState extends WP_UnitTestCase {
 
 	/**
+	 * @dataProvider data_text_attributes
+	 *
 	 * @covers ::openstation_recycle_bin_render_template
 	 * @covers ::openstation_native_window_allowed_html
+	 *
+	 * @param string $needle Attribute markup that must survive kses.
 	 */
-	public function test_table_keeps_its_empty_text_through_kses() {
+	public function test_text_attributes_survive_kses( $needle ) {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		ob_start();
 		openstation_recycle_bin_render_template();
 		$html = (string) ob_get_clean();
 
-		$this->assertStringContainsString(
-			'empty="No items match the current filter or search."',
-			$html
+		$this->assertStringContainsString( $needle, $html );
+	}
+
+	/**
+	 * @return array<string,array{0:string}>
+	 */
+	public function data_text_attributes() {
+		return array(
+			'table no-match text' => array( 'empty="No items match the current filter or search."' ),
+			'empty state heading' => array( 'heading="The Trash is empty."' ),
 		);
 	}
 }

--- a/tests/vitest/recycle-bin-empty-chrome.test.ts
+++ b/tests/vitest/recycle-bin-empty-chrome.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Recycle Bin — chrome hides while the bin is empty.
+ *
+ * Filters, search, sorting and Empty Trash all act on a list. With
+ * nothing in the bin there is no list, so the toolbar and the table
+ * (whose header carries the sort controls) both go.
+ *
+ * What the suite really guards is which count drives that: the
+ * endpoint's `total` counts the whole bin, not the slice the active
+ * filter or search returned. A search that matches nothing has to
+ * keep the toolbar, or there is no way back out of it.
+ */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted( () => ( {
+	fetchList: vi.fn(),
+	purgeItems: vi.fn(),
+	restoreItems: vi.fn(),
+	emptyBin: vi.fn(),
+} ) );
+
+vi.mock( '../../src/recycle-bin/rest', () => mocks );
+vi.mock( '../../src/recycle-bin/icon-state', () => ( {
+	setRecycleBinCount: vi.fn(),
+	_currentRecycleBinCount: () => 0,
+} ) );
+vi.mock( '../../src/recycle-bin/realtime', () => ( {
+	start: vi.fn(),
+	stop: vi.fn(),
+} ) );
+
+import { renderRecycleBin } from '../../src/recycle-bin/index';
+import type { RecycleBinItem } from '../../src/recycle-bin/rest';
+
+const settle = async (): Promise< void > => {
+	for ( let i = 0; i < 6; i++ ) {
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+	}
+};
+
+const ITEM = { id: 7, type: 'post', title: 'Trashed post' } as RecycleBinItem;
+
+const TEMPLATE = `
+	<div data-os-recycle-bin-root>
+		<header data-os-recycle-bin-toolbar>
+			<os-segmented data-os-recycle-bin-filter></os-segmented>
+			<os-text-field data-os-recycle-bin-search></os-text-field>
+			<button data-os-recycle-bin-refresh></button>
+			<button data-os-recycle-bin-empty></button>
+		</header>
+		<div data-os-recycle-bin-empty-state hidden></div>
+		<os-table data-os-recycle-bin-table selectable="multi" loading></os-table>
+	</div>
+`;
+
+describe( 'recycle-bin empty-state chrome', () => {
+	let body: HTMLElement;
+
+	/** `[ toolbar.hidden, table.hidden, emptyState.hidden ]`. */
+	const shown = (): boolean[] =>
+		[
+			'[data-os-recycle-bin-toolbar]',
+			'[data-os-recycle-bin-table]',
+			'[data-os-recycle-bin-empty-state]',
+		].map( ( sel ) => body.querySelector< HTMLElement >( sel )!.hidden );
+
+	/** Re-fetch with whatever `fetchList` is currently mocked to return. */
+	const refresh = async (): Promise< void > => {
+		body
+			.querySelector( '[data-os-recycle-bin-refresh]' )!
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		await settle();
+	};
+
+	beforeEach( async () => {
+		vi.clearAllMocks();
+		( window as unknown as { wp: unknown } ).wp = {
+			os: { confirm: async () => true },
+		};
+		mocks.fetchList.mockResolvedValue( { items: [ ITEM ], total: 1 } );
+
+		document.body.innerHTML = '';
+		body = document.createElement( 'div' );
+		body.innerHTML = TEMPLATE;
+		document.body.appendChild( body );
+		renderRecycleBin( body );
+		await settle();
+	} );
+
+	test( 'a bin with items shows the toolbar and the table', () => {
+		expect( shown() ).toEqual( [ false, false, true ] );
+	} );
+
+	test( 'emptying the bin leaves the empty state and nothing else', async () => {
+		mocks.fetchList.mockResolvedValue( { items: [], total: 0 } );
+		await refresh();
+
+		expect( shown() ).toEqual( [ true, true, false ] );
+	} );
+
+	test( 'a search matching nothing keeps the toolbar reachable', async () => {
+		// `total` still reports the whole bin; only the returned slice
+		// is empty. Hiding the toolbar here would strand the user in a
+		// search they can no longer clear.
+		mocks.fetchList.mockResolvedValue( { items: [], total: 1 } );
+		await refresh();
+
+		expect( shown() ).toEqual( [ false, false, true ] );
+	} );
+} );

--- a/tests/vitest/recycle-bin-empty-chrome.test.ts
+++ b/tests/vitest/recycle-bin-empty-chrome.test.ts
@@ -17,20 +17,27 @@ const mocks = vi.hoisted( () => ( {
 	purgeItems: vi.fn(),
 	restoreItems: vi.fn(),
 	emptyBin: vi.fn(),
+	currentCount: vi.fn( () => 0 ),
 } ) );
 
 vi.mock( '../../src/recycle-bin/rest', () => mocks );
 vi.mock( '../../src/recycle-bin/icon-state', () => ( {
 	setRecycleBinCount: vi.fn(),
-	_currentRecycleBinCount: () => 0,
+	_currentRecycleBinCount: mocks.currentCount,
 } ) );
 vi.mock( '../../src/recycle-bin/realtime', () => ( {
 	start: vi.fn(),
 	stop: vi.fn(),
 } ) );
 
-import { renderRecycleBin } from '../../src/recycle-bin/index';
+import type { OsTable } from '../../src/ui/components/os-table/os-table';
 import type { RecycleBinItem } from '../../src/recycle-bin/rest';
+
+// Re-imported per test. `cachedItems` lives at module scope so a
+// reopened window can repaint without a skeleton, which also means a
+// test that loads rows leaves the next one warm — and "warm" is the
+// one thing the cold-load cases here are about.
+let renderRecycleBin: ( body: HTMLElement ) => void;
 
 const settle = async (): Promise< void > => {
 	for ( let i = 0; i < 6; i++ ) {
@@ -40,6 +47,8 @@ const settle = async (): Promise< void > => {
 
 const ITEM = { id: 7, type: 'post', title: 'Trashed post' } as RecycleBinItem;
 
+const NO_MATCH = 'No items match the current filter or search.';
+
 const TEMPLATE = `
 	<div data-os-recycle-bin-root>
 		<header data-os-recycle-bin-toolbar>
@@ -48,63 +57,120 @@ const TEMPLATE = `
 			<button data-os-recycle-bin-refresh></button>
 			<button data-os-recycle-bin-empty></button>
 		</header>
-		<div data-os-recycle-bin-empty-state hidden></div>
-		<os-table data-os-recycle-bin-table selectable="multi" loading></os-table>
+		<os-empty-state data-os-recycle-bin-empty-state hidden></os-empty-state>
+		<os-table data-os-recycle-bin-table selectable="multi" loading
+			empty="${ NO_MATCH }"></os-table>
 	</div>
 `;
 
 describe( 'recycle-bin empty-state chrome', () => {
 	let body: HTMLElement;
 
-	/** `[ toolbar.hidden, table.hidden, emptyState.hidden ]`. */
+	const el = ( sel: string ): HTMLElement =>
+		body.querySelector< HTMLElement >( `[data-os-recycle-bin-${ sel }]` )!;
+
+	/** `[ toolbar, table, emptyState ]` — true means visible. */
 	const shown = (): boolean[] =>
-		[
-			'[data-os-recycle-bin-toolbar]',
-			'[data-os-recycle-bin-table]',
-			'[data-os-recycle-bin-empty-state]',
-		].map( ( sel ) => body.querySelector< HTMLElement >( sel )!.hidden );
+		[ 'toolbar', 'table', 'empty-state' ].map( ( s ) => ! el( s ).hidden );
 
-	/** Re-fetch with whatever `fetchList` is currently mocked to return. */
-	const refresh = async (): Promise< void > => {
-		body
-			.querySelector( '[data-os-recycle-bin-refresh]' )!
-			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
-		await settle();
-	};
-
-	beforeEach( async () => {
-		vi.clearAllMocks();
-		( window as unknown as { wp: unknown } ).wp = {
-			os: { confirm: async () => true },
-		};
-		mocks.fetchList.mockResolvedValue( { items: [ ITEM ], total: 1 } );
-
+	/** Render without waiting, so the pre-fetch paint can be asserted. */
+	const mount = (): void => {
 		document.body.innerHTML = '';
 		body = document.createElement( 'div' );
 		body.innerHTML = TEMPLATE;
 		document.body.appendChild( body );
 		renderRecycleBin( body );
+	};
+
+	/** Re-fetch with whatever `fetchList` is currently mocked to return. */
+	const refresh = async (): Promise< void > => {
+		el( 'refresh' ).dispatchEvent(
+			new MouseEvent( 'click', { bubbles: true } ),
+		);
 		await settle();
+	};
+
+	beforeEach( async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		( { renderRecycleBin } = await import( '../../src/recycle-bin/index' ) );
+		mocks.currentCount.mockReturnValue( 0 );
+		( window as unknown as { wp: unknown } ).wp = {
+			os: { confirm: async () => true },
+		};
+		mocks.fetchList.mockResolvedValue( { items: [ ITEM ], total: 1 } );
 	} );
 
-	test( 'a bin with items shows the toolbar and the table', () => {
-		expect( shown() ).toEqual( [ false, false, true ] );
-	} );
-
-	test( 'emptying the bin leaves the empty state and nothing else', async () => {
-		mocks.fetchList.mockResolvedValue( { items: [], total: 0 } );
-		await refresh();
+	test( 'a bin with items shows the toolbar and the table', async () => {
+		mount();
+		await settle();
 
 		expect( shown() ).toEqual( [ true, true, false ] );
 	} );
 
+	test( 'emptying the bin leaves the empty state and nothing else', async () => {
+		mount();
+		await settle();
+
+		mocks.fetchList.mockResolvedValue( { items: [], total: 0 } );
+		await refresh();
+
+		expect( shown() ).toEqual( [ false, false, true ] );
+	} );
+
 	test( 'a search matching nothing keeps the toolbar reachable', async () => {
+		mount();
+		await settle();
+
 		// `total` still reports the whole bin; only the returned slice
 		// is empty. Hiding the toolbar here would strand the user in a
 		// search they can no longer clear.
 		mocks.fetchList.mockResolvedValue( { items: [], total: 1 } );
 		await refresh();
 
-		expect( shown() ).toEqual( [ false, false, true ] );
+		expect( shown() ).toEqual( [ true, true, false ] );
+		expect( el( 'table' ).getAttribute( 'empty' ) ).toBe( NO_MATCH );
+	} );
+
+	describe( 'before the first response lands', () => {
+		test( 'a seeded count of zero opens straight into the empty state', () => {
+			mount();
+
+			expect( shown() ).toEqual( [ false, false, true ] );
+		} );
+
+		test( 'a seeded count above zero opens with the chrome up', () => {
+			mocks.currentCount.mockReturnValue( 3 );
+			mount();
+
+			// No skeleton-then-vanish: the toolbar is up on the first
+			// paint, before `fetchList` has resolved.
+			expect( shown() ).toEqual( [ true, true, false ] );
+			expect( el( 'table' ).hasAttribute( 'loading' ) ).toBe( true );
+		} );
+	} );
+
+	test( 'a failed cold load keeps Refresh reachable and says so', async () => {
+		// Seeded at zero, so without the catch-path override the user
+		// would be looking at "The Trash is empty." with no toolbar and
+		// therefore no way to retry.
+		mocks.fetchList.mockRejectedValue( new Error( 'offline' ) );
+		vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		mount();
+		await settle();
+
+		expect( shown() ).toEqual( [ true, true, false ] );
+		expect( el( 'table' ).getAttribute( 'empty' ) ).toBe(
+			'Could not load the Trash. Try Refresh.',
+		);
+
+		// And a successful retry puts the filter copy back.
+		mocks.fetchList.mockResolvedValue( { items: [ ITEM ], total: 1 } );
+		await refresh();
+
+		expect( el( 'table' ).getAttribute( 'empty' ) ).toBe( NO_MATCH );
+		expect(
+			( el( 'table' ) as OsTable< RecycleBinItem > ).data,
+		).toHaveLength( 1 );
 	} );
 } );

--- a/tests/vitest/recycle-bin-selection-identity.test.ts
+++ b/tests/vitest/recycle-bin-selection-identity.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted( () => ( {
 vi.mock( '../../src/recycle-bin/rest', () => mocks );
 vi.mock( '../../src/recycle-bin/icon-state', () => ( {
 	setRecycleBinCount: vi.fn(),
+	_currentRecycleBinCount: () => 0,
 } ) );
 vi.mock( '../../src/recycle-bin/realtime', () => ( {
 	start: vi.fn(),
@@ -135,27 +136,13 @@ describe( 'recycle-bin selection identity', () => {
 		expect( Array.from( table.selection ) ).toEqual( [ 'post:5' ] );
 	} );
 
-	test( 'changing a client-side column filter clears the selection', async () => {
-		const postCb = table.shadowRoot!.querySelector< HTMLInputElement >(
-			'tr[data-row-id="post:5"] input.select-row-checkbox',
-		)!;
-		postCb.checked = true;
-		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
-		await settle();
-		expect( table.selection.size ).toBe( 1 );
-
-		// Type into the Title column filter — the previously selected
-		// row may now be hidden while still present in `data`, so the
-		// app must drop the selection rather than let it ride into a
-		// bulk purge the user can't see.
-		const input = table.shadowRoot!.querySelector< HTMLInputElement >(
-			'.filter-input',
-		)!;
-		input.value = 'comment';
-		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
-		await settle();
-
-		expect( table.selection.size ).toBe( 0 );
+	test( 'no column renders its own filter input', () => {
+		// One search box: the toolbar's. A per-column "Filter…" input
+		// under Title and under By sat directly beneath it and only
+		// narrowed the rows already fetched.
+		expect(
+			table.shadowRoot!.querySelector( '.filter-input' ),
+		).toBeNull();
 	} );
 
 	test( 'a refresh prunes selection keys whose row left the list', async () => {
@@ -211,11 +198,11 @@ describe( 'recycle-bin selection identity', () => {
 		postCb.dispatchEvent( new Event( 'change', { bubbles: true } ) );
 		await settle();
 
-		// Programmatic filter assignment does NOT fire
-		// `os-table-filter-change` — this simulates a data-driven
+		// `<os-table>` applies `filters` whether or not a column
+		// declares a control, so this simulates a data-driven
 		// visibility change (e.g. a realtime refresh replaced the row
-		// with a title that no longer matches an already-active column
-		// filter). The selected post is now hidden but still in `data`.
+		// with a title that no longer matches a filter a plugin set).
+		// The selected post is now hidden but still in `data`.
 		table.filters = { title: 'comment' };
 		await settle();
 


### PR DESCRIPTION
## Proposed Changes

- An empty Trash shows only its empty state. The toolbar (type filters, search, Refresh, Empty Trash) and the table stay hidden until the bin holds something.
- The Title and By columns drop their per-column "Filter…" inputs. The toolbar's search box is the only one now.
- A filter or search that matches nothing keeps the toolbar and reads "No items match the current filter or search." instead of claiming the Trash is empty.

Before | After
--- | ---
<img width="880" height="559" alt="Screenshot 2026-08-27 at 13 37 13" src="https://github.com/user-attachments/assets/d2acbb62-9532-4b4f-99ae-804dbe533f25" /> | <img width="880" height="562" alt="Screenshot 2026-08-27 at 13 37 24" src="https://github.com/user-attachments/assets/45f9719f-21d8-4deb-8915-9ca63a69c4f9" />
<img width="887" height="558" alt="Screenshot 2026-08-27 at 13 37 52" src="https://github.com/user-attachments/assets/d8941df3-5a7f-47a4-a956-d9b3c87a2faf" /> | <img width="887" height="560" alt="Screenshot 2026-08-27 at 13 38 00" src="https://github.com/user-attachments/assets/738290fc-2924-487e-9ad9-1b02092655c6" />



## Why are these changes being made?

Filters, sorting and a destructive Empty Trash button all acted on a list that wasn't there, and the loudest control on screen did nothing.

## Testing Instructions

1. Start with an empty Trash, then open Trash from the dock. Make sure the window shows only the bin glyph and "The Trash is empty.", with no toolbar, no column headers and no Empty Trash button.
2. Leave the window open and trash a few posts from Posts. Make sure the toolbar and the table appear without a reload.
3. Type something in the search box that matches nothing. Make sure the toolbar stays put and the table reads "No items match the current filter or search.", then clear the search and make sure the rows come back.
4. Pick the Comments filter tab on a bin with no trashed comments. Same thing: toolbar stays, table says nothing matched.
5. Look at the Title and By column headers. Make sure neither has its own "Filter…" input, and that clicking either header still sorts.
6. Tick a row. Make sure Restore, Pin to desktop and Delete forever appear, and that Restore still works.
7. Click Empty Trash and confirm. Make sure the window lands back on the empty state with no toolbar.
8. With the Trash window open and empty, drag a post from WP Explorer onto it. Make sure the drop still trashes the item and the chrome comes back.
9. Reopen the Trash on an empty bin a second time. Make sure it opens straight into the empty state, with no flash of skeleton rows or toolbar first.
