### PR TITLE
fix: attribute columns save to active window id

### DIFF
--- a/src/posts-window/index.ts
+++ b/src/posts-window/index.ts
@@ -919,12 +919,12 @@ function mountKebabColumnToggles(
 		const next = Array.from( hidden ).sort();
 		const api = window.wp?.os;
 		if ( api && typeof api.updateOsSettings === 'function' ) {
-			// Attribute the in-flight save to the Posts window so the
+			// Attribute the in-flight save to the correct window so the
 			// title-bar activity dot blinks on this window, not on the
 			// (probably-closed) OS Settings window.
 			api.updateOsSettings(
 				{ nativePostsHiddenColumns: next },
-				{ windowId: 'desktop-mode-posts' },
+				{ windowId: client.windowId },
 			);
 		}
 		paintChecked();
@@ -2781,7 +2781,7 @@ export async function renderPostsWindow(
 
 	const onWindowClosed = ( e: Event ): void => {
 		const detail = ( e as CustomEvent< { windowId?: string } > ).detail;
-		if ( detail?.windowId !== 'desktop-mode-posts' ) {
+		if ( detail?.windowId !== client.windowId ) {
 			return;
 		}
 		document.removeEventListener( 'os-window-closed', onWindowClosed );


### PR DESCRIPTION

Closes [#593](https://github.com/WordPress/openstation/issues/593)

This PR resolves the issue where a failed columns settings save rolled back settings controls visually, but left the native Pages window out of sync and showing the rejected layout on screen. It also resolves a memory leak when closing the Pages window.

*(Note: The rollback and error indicators were already working for the **Posts** window because the original code hardcoded `'desktop-mode-posts'` for save attribution and close listeners; this PR preserves the Posts functionality while making the window ID resolution dynamic to cover the Pages window).*

Changes:
src/posts-window/index.ts: Replaced the hardcoded `'desktop-mode-posts'` strings with `client.windowId`. This attributes the column-saving background task correctly to the active window mode (Pages or Posts), so that save failure indicators are painted on the correct window and rollback notifications trigger the repaint. It also ensures the `onWindowClosed` listener is correctly matched and disposed of, resolving memory leaks on Pages window close.

Testing:
1. Open OS Settings -> Features, and enable native **Pages** window mode.
2. Open the native **Pages** window.
3. Open the kebab actions menu in the title bar -> **Show columns**.
4. Go offline using Chrome DevTools -> Network -> Throttling -> Offline.
5. Hide the **Parent** column (uncheck it).
6. Verify that the table columns and checkbox correctly revert back to their original states, and the Pages window's title-bar activity ring blinks and turns red on failure.

After Fix:- 

https://github.com/user-attachments/assets/b46add59-383c-41bb-b2fc-92aca8c879d5

