### PR TITLE
CI: pin every action to a commit SHA, prune closed PRs' zips from ci-artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint · Types · Vitest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Don't leave the GITHUB_TOKEN in .git/config; later steps run
           # PR-authored code (npm scripts, build) and this job never needs
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -87,7 +87,7 @@ jobs:
         php: [ '8.3', '8.4' ]
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Don't leave the GITHUB_TOKEN in .git/config; later steps run
           # PR-authored code (npm scripts, build) and this job never needs
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -158,7 +158,7 @@ jobs:
     name: Plugin Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Don't leave the GITHUB_TOKEN in .git/config; later steps run
           # PR-authored code (npm scripts, build) and this job never needs
@@ -166,7 +166,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -22,10 +22,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Don't leave the GITHUB_TOKEN in .git/config; later steps run
+          # PR-authored code (npm scripts, build) and this job never needs
+          # git auth after checkout.
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -37,7 +42,7 @@ jobs:
           npm run build
           npm run package
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: built-plugin
           path: openstation.zip

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -98,6 +98,79 @@ jobs:
             core.setOutput('pr-number', String(pr.number));
             core.setOutput('head-sha', headSha);
 
+      - name: Prune preview zips of closed PRs
+        # The expose step below keeps 20 zips per PR, but nothing removed a
+        # PR's zips once it closed, and the `ci-artifacts` release hit
+        # GitHub's 1000-assets-per-release cap that way: every upload (this
+        # one and trunk-build.yml's) then failed with HTTP 422. Sweep before
+        # uploading so a full release frees room instead of failing.
+        # Fail-open on purpose: a cleanup hiccup must never cost a preview.
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CURRENT_PR: ${{ steps.meta.outputs.pr-number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const currentPr = Number(process.env.CURRENT_PR);
+            const release = (await github.rest.repos.getReleaseByTag({ owner, repo, tag: 'ci-artifacts' })).data;
+            const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
+              owner,
+              repo,
+              release_id: release.id,
+              per_page: 100,
+            });
+            // Only preview zips are candidates. trunk.zip / trunk.json and
+            // anything else that does not match the pr-N-sha name stay.
+            const pattern = /^pr-(\d+)-[0-9a-f]{40}\.zip$/;
+            const byPr = new Map();
+            for (const asset of assets) {
+              const m = pattern.exec(asset.name);
+              if (!m) continue;
+              const number = Number(m[1]);
+              if (number === currentPr) continue;
+              if (!byPr.has(number)) byPr.set(number, []);
+              byPr.get(number).push(asset);
+            }
+            // Resolve PR states in batches of aliased GraphQL lookups. Delete
+            // only what is positively known to be closed or merged: an
+            // unresolved number (a partial response, or a number that isn't a
+            // PR) is left alone.
+            const numbers = [...byPr.keys()];
+            const closed = [];
+            for (let i = 0; i < numbers.length; i += 50) {
+              const batch = numbers.slice(i, i + 50);
+              const fields = batch.map((n) => `pr${n}: pullRequest(number: ${n}) { state }`).join(' ');
+              const query = `query($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { ${fields} } }`;
+              let data;
+              try {
+                data = await github.graphql(query, { owner, repo });
+              } catch (error) {
+                // A GraphqlResponseError still carries the fields that did resolve.
+                data = error.data;
+                if (!data?.repository) {
+                  core.warning(`PR state lookup failed for a batch: ${error.message}`);
+                  continue;
+                }
+              }
+              for (const n of batch) {
+                const pr = data.repository[`pr${n}`];
+                if (pr && pr.state !== 'OPEN') closed.push(n);
+              }
+            }
+            let deleted = 0;
+            for (const n of closed) {
+              for (const asset of byPr.get(n)) {
+                try {
+                  await github.rest.repos.deleteReleaseAsset({ owner, repo, asset_id: asset.id });
+                  deleted++;
+                } catch (error) {
+                  core.warning(`Could not delete ${asset.name}: ${error.message}`);
+                }
+              }
+            }
+            core.info(`${assets.length} assets on ci-artifacts; ${closed.length} closed PRs; deleted ${deleted} zip(s).`);
+
       - name: Expose built artifact on a public URL
         id: expose
         uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@43fc435558bc6cee69f5b214d6b8ca4f9f80c31d # v3

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -34,11 +34,11 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve PR from trusted workflow_run data
         id: meta
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // PR identity is never taken from the build run's artifacts — that
@@ -110,7 +110,7 @@ jobs:
           artifact-source-run-id: ${{ github.event.workflow_run.id }}
 
       - name: Build blueprint
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: blueprint
         env:
           ARTIFACT_URL: ${{ steps.expose.outputs.artifact-url }}


### PR DESCRIPTION
## What it does

Every `uses:` in the repo now references a commit SHA, and the PR preview publisher deletes the preview zips of closed PRs before it uploads a new one, so the `ci-artifacts` release can't fill up again. Also records the repo-settings decisions from the hardening plan.

## Rationale

The CI security audit on #425 left `ci.yml`, `pr-preview-build.yml` and `pr-preview-publish.yml` on version tags (`actions/checkout@v7.0.1`, `actions/setup-node@v7`, `actions/upload-artifact@v7`, `actions/github-script@v9`). A moved tag is a supply-chain hole, and the repo-level "require SHA pinning" switch can't be turned on while any workflow still uses one.

Separately, the `ci-artifacts` release hit GitHub's 1000-assets-per-release cap today: 981 of the 1000 zips belonged to 441 closed PRs. The expose step keeps 20 zips per PR, but nothing ever removed a PR's zips once it closed. At the cap, every upload (previews and `trunk-build.yml`) failed with HTTP 422 and open PRs sat on "Build pending". A one-off prune cleared the backlog; this PR stops it from recurring.

## Implementation

**Pinning.** Same SHAs `release.yml` already uses (`actions/checkout@3d3c42e5` v7.0.1, `actions/setup-node@82076278` v7.0.0), plus `actions/upload-artifact@043fb46d` v7.0.1 and `actions/github-script@3a2844b7` v9.0.0. The preview build checkout also gets `persist-credentials: false`, matching the comment and setting in `ci.yml` (parity; that token is read-only for forks anyway).

**Pruning.** A `github-script` step in `pr-preview-publish.yml`, placed *before* the expose/upload step so a full release frees room instead of failing first:

- lists the `ci-artifacts` assets and keeps only names matching `^pr-(\d+)-[0-9a-f]{40}\.zip$` (`trunk.zip`, `trunk.json` and anything else are never candidates), skipping the PR being published;
- resolves PR states in batches of 50 aliased GraphQL `pullRequest(number:)` lookups, one request per batch;
- deletes only zips whose PR is positively `CLOSED` or `MERGED`. An unresolved number (a partial GraphQL response, or a number that isn't a PR) is left alone.

It runs with `continue-on-error: true` and a per-delete `try/catch`: a cleanup hiccup must never cost a preview. It never checks out or runs PR code, in keeping with the trust model in the file header.

**Settings.** Applied outside this PR, via the API: default workflow token is read-only and Actions can't approve PRs; fork PR runs from all outside collaborators need approval; a `Release tags` ruleset restricts `v*` to Maintain/Admin; `allowed_actions` is `selected` (GitHub-owned plus `WordPress/action-wp-playground-pr-preview`, `anthropics/claude-code-action`, `10up/action-wordpress-plugin-deploy`). Zero required reviews on trunk stays, on purpose. `sha_pinning_required` gets flipped on after this merges, with `gh api -X PUT repos/WordPress/openstation/actions/permissions -F enabled=true -f allowed_actions=selected -F sha_pinning_required=true` (`selected`, not `all`, or the PUT resets the allow-list).

## Testing instructions

1. This PR's own CI is the pinning test: all three `ci.yml` jobs and the preview build run on the pinned SHAs.
2. Once merged, open or push to any PR and check the `PR Preview Publish` run: the `Prune preview zips of closed PRs` step logs `N assets on ci-artifacts; M closed PRs; deleted K zip(s).`, and the preview comment still lands.
3. `gh release view ci-artifacts --json assets --jq '.assets | length'` should stay at roughly 20 × open PRs plus the two trunk files, and never climb toward 1000 again.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-698-560a6bd3f6eb1f3f3f77004b580a8f4d70d099a0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
