### PR TITLE
Register --wp-admin-theme-color so chromeless documents never compute it to transparent

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -83,6 +83,36 @@
 }
 
 /*
+ * ---- Registered, so "undeclared" never means transparent ---------
+ *
+ * The scope note below keeps this palette out of iframe documents on
+ * purpose: an admin page inside a window renders with the values its
+ * own stylesheets were written with. That promise has one hole CSS
+ * digs by itself — a stylesheet that consumes
+ * `var(--wp-admin-theme-color)` with no fallback, in a document where
+ * nothing declares it, does not fall back to an earlier declaration
+ * in the cascade. An unresolved `var()` is invalid at computed-value
+ * time, so the property computes to `initial` — and an unregistered
+ * custom property's initial value is the guaranteed-invalid value,
+ * which for a `background` means transparent. Core's own scheme files
+ * declare the property, but a third-party admin scheme that consumes
+ * it without declaring it renders `.button-primary` white-on-white
+ * inside every chromeless window (#702).
+ *
+ * Registering the property gives "undeclared" a real answer:
+ * WordPress's default admin colour, the same value Core's fallbacks
+ * reach for. Declarations are untouched — a scheme, the palette
+ * below, or the accent picker's inline style all keep winning exactly
+ * as before. Registration only decides what the absence of all of
+ * them computes to.
+ */
+@property --wp-admin-theme-color {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: #3858e9;
+}
+
+/*
  * ---- Scope: the shell document, and nothing else -----------------
  *
  * `body.os-active` rather than `:root`, and that is


### PR DESCRIPTION
Fixes #702.

**What breaks.** In a chromeless window under an admin colour scheme that consumes `var(--wp-admin-theme-color)` without a fallback and without declaring it, `.button-primary` renders white-on-white — the unresolved `var()` is invalid at computed-value time and the background computes to `transparent`. Full mechanism and live-DOM measurements in #702.

**Why not the fix the issue originally suggested.** Widening the palette's selector to also match `body.os-chromeless` would push the accent into Core's buttons, links and focus rings inside every window — exactly what `variables.css`'s own scope note rules out ("the station is the chrome around the page, not a reskin of the page"). This PR follows the scope note instead of fighting it.

**What this does.** Registers the property with `@property`, giving "undeclared" a real initial value — WordPress's default `#3858e9`, the same literal Core's own fallbacks use. Registration changes nothing for any document where the property *is* declared: a core scheme, a third-party scheme that declares it, and the accent picker's inline style on the shell's `<html>` all keep winning exactly as before. It only decides what total absence computes to — the Core default instead of transparent.

**Verified** in a minimal reproduction of the exact two-rule cascade from the issue: computed background `rgba(0, 0, 0, 0)` before registration, `rgb(56, 88, 233)` after, and a subsequently declared value still wins (`rgb(225, 29, 72)` for a `#e11d48` declaration).

**Support.** `@property` is Baseline (Chrome 85, Safari 16.4, Firefox 128). In older browsers the rule is ignored and behaviour is exactly today's.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-706-648d63e1015d3cc21d03cf716a22e323d0f801a5.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->