### PR TITLE
Two low-contrast fixes in native windows: the shell document leaves quirks mode, and a neutral crumb stops pinning its paint inline

### DIFF
--- a/includes/shell-screen.php
+++ b/includes/shell-screen.php
@@ -238,7 +238,7 @@ function openstation_is_shell_request() {
  * can enter the desktop can reach its screen.
  */
 function openstation_register_shell_screen() {
-	add_submenu_page(
+	$hook = add_submenu_page(
 		'',
 		__( 'OpenStation', 'desktop-mode' ),
 		__( 'OpenStation', 'desktop-mode' ),
@@ -246,28 +246,45 @@ function openstation_register_shell_screen() {
 		OPENSTATION_SHELL_PAGE_SLUG,
 		'openstation_render_shell_screen'
 	);
+
+	if ( $hook ) {
+		add_action( "load-{$hook}", 'openstation_shell_screen_set_title' );
+	}
 }
 add_action( 'admin_menu', 'openstation_register_shell_screen' );
 
 /**
- * Names the shell document.
+ * Names the shell document, before `admin-header.php` asks for a name.
  *
- * `get_admin_page_title()` finds no title for a page whose parent is
- * the empty menu, so the shell's `<title>` came out as "‹ Site —
- * WordPress". The host screen used to supply the word before the
- * chevron; now the screen does.
+ * `get_admin_page_title()` finds no title for a page whose parent is the
+ * empty menu — it walks `$menu` and `$submenu` for an entry that paints,
+ * and this screen deliberately has none. So the global `$title` stayed
+ * null, and `admin-header.php` line 41 runs `strip_tags( $title )` on it
+ * unconditionally.
  *
- * @param string $admin_title The page title, with the site name appended.
- * @param string $title       The original page title.
- * @return string
+ * On PHP 8.1+ that is a deprecation notice, and with `WP_DEBUG_DISPLAY`
+ * on it PRINTS — before `<!DOCTYPE html>`, because the header has not
+ * emitted it yet. A document whose first bytes are not the doctype loads
+ * in QUIRKS MODE, and quirks mode is not a cosmetic difference here: the
+ * quirks UA stylesheet stops `<table>` inheriting `color` and `font-*`
+ * from its ancestors. Every `<os-table>` in a native window therefore
+ * dropped the palette's `--os-ui-fg` and fell back to core's
+ * `body { color: #3c434a }` — near-black text on the station's dark
+ * surfaces, at 1.3:1 against a table header (#697 → the Pages window).
+ *
+ * `load-{$hook}` fires in `admin.php` before `admin-header.php` is
+ * required, so a real string is in place by the time core reads it.
+ * `get_admin_page_title()` then returns early on its own `! empty()`
+ * check, which is also what gives the document the word before the
+ * chevron: "OpenStation ‹ Site — WordPress".
+ *
+ * Set unconditionally: the screen wants its name whether or not the
+ * shell paints on this request ({@see openstation_render_shell_screen()}
+ * answers with a pointer at the portal when it does not).
  */
-function openstation_shell_screen_admin_title( $admin_title, $title ) {
-	if ( '' !== trim( (string) $title ) || ! openstation_is_shell_screen_request() ) {
-		return $admin_title;
-	}
-	return __( 'OpenStation', 'desktop-mode' ) . $admin_title;
+function openstation_shell_screen_set_title() {
+	$GLOBALS['title'] = __( 'OpenStation', 'desktop-mode' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- naming an admin screen IS writing $title; every core screen does it (options-general.php, edit.php), and admin-header.php reads it moments later.
 }
-add_filter( 'admin_title', 'openstation_shell_screen_admin_title', 10, 2 );
 
 /**
  * The shell screen's page callback.

--- a/src/ui/components/os-crumb-chain/os-crumb-chain.styles.ts
+++ b/src/ui/components/os-crumb-chain/os-crumb-chain.styles.ts
@@ -10,10 +10,16 @@
  * one merged shape with internal "tear lines" separating each
  * hierarchy level.
  *
- * Each segment's color is set inline via the `--os-ui-crumb-bg` /
- * `--os-ui-crumb-fg` custom properties so the consumer can vary
- * lightness per depth (root darkest, leaf brightest) while keeping
- * one hashed hue for the whole chain.
+ * A segment that CARRIES ITS OWN COLOUR sets `--os-ui-crumb-bg` /
+ * `--os-ui-crumb-fg` inline, so the consumer can vary lightness per
+ * depth (root darkest, leaf brightest) while keeping one hashed hue
+ * for the whole chain.
+ *
+ * A segment with no colour sets neither, deliberately: an inline
+ * custom property outranks the palette and every desktop theme, so a
+ * neutral default written there is unreachable by both. The `var()`
+ * chain below is the neutral default instead — theme first, palette
+ * next, the pre-brand literal last.
  */
 import { css } from '../../core';
 

--- a/src/ui/components/os-crumb-chain/os-crumb-chain.test.ts
+++ b/src/ui/components/os-crumb-chain/os-crumb-chain.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `<os-crumb-chain>` — how a segment gets its paint.
+ *
+ * The one rule worth pinning: an inline custom property outranks the
+ * palette AND every desktop theme, so the chain may only write one for
+ * a segment that genuinely carries its own colour. A neutral default
+ * written inline is unreachable by both, which is how a light-mode
+ * `rgba( 0, 0, 0, 0.08 )` wash with `#1d2327` ink survived the brand
+ * and painted the Posts window's Categories column at 1.2:1.
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import './os-crumb-chain';
+// eslint-disable-next-line no-duplicate-imports
+import type { OsCrumbChain } from './os-crumb-chain';
+
+const tick = (): Promise< void > =>
+	new Promise( ( r ) => queueMicrotask( () => queueMicrotask( () => r() ) ) );
+
+async function mount(
+	segments: OsCrumbChain[ 'segments' ],
+): Promise< HTMLElement > {
+	document.body.innerHTML = '';
+	const chain = document.createElement( 'os-crumb-chain' ) as OsCrumbChain;
+	document.body.appendChild( chain );
+	chain.segments = segments;
+	await tick();
+	return chain as unknown as HTMLElement;
+}
+
+const crumbs = ( chain: HTMLElement ): HTMLElement[] => [
+	...( ( chain as unknown as { shadowRoot: ShadowRoot } ).shadowRoot.querySelectorAll(
+		'.os-crumb',
+	) as NodeListOf< HTMLElement > ),
+];
+
+describe( '<os-crumb-chain> segment paint', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'a segment with its own colour writes both tokens inline', async () => {
+		const chain = await mount( [ { id: 1, name: 'Tech', color: '#4b3eff' } ] );
+		const style = crumbs( chain )[ 0 ].getAttribute( 'style' ) ?? '';
+
+		expect( style ).toContain( '--os-ui-crumb-bg: #4b3eff' );
+		// The ink is derived from that background, not inherited.
+		expect( style ).toContain( '--os-ui-crumb-fg:' );
+	} );
+
+	test( 'a segment with no colour writes no inline paint at all', async () => {
+		const chain = await mount( [ { id: 1, name: 'Notes' } ] );
+		const crumb = crumbs( chain )[ 0 ];
+
+		// Not "an empty style attribute" — none, so nothing can outrank
+		// the stylesheet's var() chain.
+		expect( crumb.hasAttribute( 'style' ) ).toBe( false );
+		expect( crumb.style.getPropertyValue( '--os-ui-crumb-bg' ) ).toBe( '' );
+		expect( crumb.style.getPropertyValue( '--os-ui-crumb-fg' ) ).toBe( '' );
+	} );
+
+	test( 'the pre-brand literals never reach an uncoloured segment', async () => {
+		const chain = await mount( [
+			{ id: 1, name: 'Notes' },
+			{ id: 2, name: 'Drafts' },
+		] );
+
+		for ( const crumb of crumbs( chain ) ) {
+			const style = crumb.getAttribute( 'style' ) ?? '';
+			expect( style ).not.toContain( '#1d2327' );
+			expect( style ).not.toContain( 'rgba( 0, 0, 0, 0.08 )' );
+		}
+	} );
+
+	test( 'a mixed chain only pins the segments that are coloured', async () => {
+		const chain = await mount( [
+			{ id: 1, name: 'Tech', color: '#4b3eff' },
+			{ id: 2, name: 'Notes' },
+		] );
+		const [ coloured, neutral ] = crumbs( chain );
+
+		expect( coloured.hasAttribute( 'style' ) ).toBe( true );
+		expect( neutral.hasAttribute( 'style' ) ).toBe( false );
+	} );
+} );

--- a/src/ui/components/os-crumb-chain/os-crumb-chain.ts
+++ b/src/ui/components/os-crumb-chain/os-crumb-chain.ts
@@ -48,7 +48,12 @@ import { styles } from './os-crumb-chain.styles';
 export interface OsCrumbSegment {
 	id?: number | string;
 	name: string;
-	/** Background color. Falls back to a neutral grey when unset. */
+	/**
+	 * Background color. Left unset, the segment paints the neutral
+	 * crumb from `--os-ui-crumb-bg` / `--os-ui-crumb-fg` — which a
+	 * desktop theme and the palette can both re-point, and an inline
+	 * default could not.
+	 */
 	color?: string;
 }
 
@@ -139,9 +144,33 @@ export class OsCrumbChain extends Component {
 			<div class="os-crumb-chain" role="group">
 				${ segments.map( ( seg, idx ) => {
 					const variant = pickVariant( idx, segments.length );
-					const bg = seg.color ?? 'rgba( 0, 0, 0, 0.08 )';
-					const fg = pickForegroundColor( bg );
-					const styleStr = `--os-ui-crumb-bg: ${ bg }; --os-ui-crumb-fg: ${ fg };`;
+					/*
+					 * A segment WITHOUT a colour of its own carries no
+					 * inline paint at all — an empty attribute value is
+					 * removed outright, so the stylesheet's
+					 * `var( --os-ui-crumb-bg, … )` chain is what answers,
+					 * and a desktop theme or the palette can reach it.
+					 *
+					 * It used to hard-code `rgba( 0, 0, 0, 0.08 )` here
+					 * and let `pickForegroundColor()` derive `#1d2327`
+					 * ink for that (correct arithmetic — the wash IS
+					 * light, on a white page). Inline custom properties
+					 * outrank every document-tree declaration, so both
+					 * survived the brand: a black wash on Obsidian with
+					 * near-black ink on top, 1.2:1, which is what the
+					 * Posts window's Categories column was painting.
+					 *
+					 * Nothing downstream needed adding. The palette has
+					 * named `--os-ui-crumb-bg` since the rebrand, in the
+					 * "fills that must stay fills" block, and the Legacy
+					 * manifest declares both — neither had ever reached
+					 * this component. The ink falls through to
+					 * `--os-ui-fg` and always did.
+					 */
+					const own = seg.color;
+					const styleStr = own
+						? `--os-ui-crumb-bg: ${ own }; --os-ui-crumb-fg: ${ pickForegroundColor( own ) };`
+						: '';
 					return html`
 						<span
 							class=${ `os-crumb os-crumb--${ variant }` }
@@ -282,10 +311,14 @@ function buildDragGhost( segments: readonly OsCrumbSegment[] ): HTMLElement {
 		'z-index: 2147483647',
 	].join( '; ' );
 	const total = segments.length;
+	// The ghost is rasterised by the browser from a detached snapshot,
+	// so it cannot defer to the stylesheet the way a rendered chain
+	// does — it has to resolve the neutral tokens itself.
+	const neutral = neutralCrumbPaint();
 	segments.forEach( ( seg, idx ) => {
 		const span = document.createElement( 'span' );
-		const bg = seg.color ?? 'rgba( 0, 0, 0, 0.08 )';
-		const fg = pickForegroundColor( bg );
+		const bg = seg.color ?? neutral.bg;
+		const fg = seg.color ? pickForegroundColor( seg.color ) : neutral.fg;
 		const variant = pickVariant( idx, total );
 		const styleParts: string[] = [
 			'display: inline-flex',
@@ -324,6 +357,35 @@ function buildDragGhost( segments: readonly OsCrumbSegment[] ): HTMLElement {
 		wrap.appendChild( span );
 	} );
 	return wrap;
+}
+
+/*
+ * The pre-brand paint for a segment with no colour of its own, and the
+ * floor under the tokens below. These are the literals the component
+ * shipped with, so an unstyled page lands exactly where it always did.
+ */
+const NEUTRAL_CRUMB_BG = 'rgba( 0, 0, 0, 0.08 )';
+const NEUTRAL_CRUMB_FG = '#1d2327';
+
+/**
+ * Resolve the neutral crumb's paint from the document.
+ *
+ * Only the drag ghost needs this: a rendered chain leaves an
+ * uncoloured segment's `style` attribute off entirely and lets the
+ * stylesheet's `var( --os-ui-crumb-bg, … )` chain resolve, which is
+ * what keeps the palette and every desktop theme in reach. The ghost
+ * is built detached and snapshotted, so it reads the same two tokens
+ * directly and falls back to the literals when nothing declares them.
+ */
+function neutralCrumbPaint(): { bg: string; fg: string } {
+	if ( typeof document === 'undefined' || ! document.body ) {
+		return { bg: NEUTRAL_CRUMB_BG, fg: NEUTRAL_CRUMB_FG };
+	}
+	const style = getComputedStyle( document.body );
+	return {
+		bg: style.getPropertyValue( '--os-ui-crumb-bg' ).trim() || NEUTRAL_CRUMB_BG,
+		fg: style.getPropertyValue( '--os-ui-crumb-fg' ).trim() || NEUTRAL_CRUMB_FG,
+	};
 }
 
 function pickVariant(

--- a/tests/phpunit/tests/openStationShellScreen.php
+++ b/tests/phpunit/tests/openStationShellScreen.php
@@ -273,26 +273,53 @@ class Tests_OpenStation_ShellScreen extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The document is named after the desktop, not left as
-	 * "‹ Site — WordPress".
+	 * The screen names itself before `admin-header.php` reads the name.
 	 *
-	 * @covers ::openstation_shell_screen_admin_title
+	 * A null `$title` there is `strip_tags( null )`, which prints a
+	 * deprecation ahead of `<!DOCTYPE html>` and drops the whole shell
+	 * into quirks mode — where `<table>` stops inheriting `color` and
+	 * every `<os-table>` in a native window falls back to core's
+	 * `body { color: #3c434a }`. The name is also what puts "OpenStation"
+	 * before the chevron in the document title.
+	 *
+	 * @covers ::openstation_shell_screen_set_title
 	 */
-	public function test_admin_title_names_the_shell_document() {
-		set_current_screen( OPENSTATION_SHELL_SCREEN_ID );
-		$this->assertSame(
-			'OpenStation ‹ Site — WordPress',
-			openstation_shell_screen_admin_title( ' ‹ Site — WordPress', '' )
+	public function test_screen_sets_a_title_for_admin_header() {
+		$GLOBALS['title'] = null;
+		openstation_shell_screen_set_title();
+
+		$this->assertIsString( $GLOBALS['title'] );
+		$this->assertSame( 'OpenStation', $GLOBALS['title'] );
+
+		// `get_admin_page_title()` returns early on a non-empty title,
+		// so core never walks the menus it cannot find this page in.
+		$this->assertSame( 'OpenStation', get_admin_page_title() );
+
+		unset( $GLOBALS['title'] );
+	}
+
+	/**
+	 * …and it is wired to the hook that fires before the header runs.
+	 *
+	 * `load-{$hook}` is the only point between `add_submenu_page()` and
+	 * `require admin-header.php`; setting the title anywhere later is
+	 * too late to stop the notice.
+	 *
+	 * @covers ::openstation_register_shell_screen
+	 */
+	public function test_screen_registration_wires_the_title_to_its_load_hook() {
+		remove_action(
+			'load-' . OPENSTATION_SHELL_SCREEN_ID,
+			'openstation_shell_screen_set_title'
 		);
-		// A screen with its own title, and any other screen, are left alone.
-		$this->assertSame(
-			'Posts ‹ Site — WordPress',
-			openstation_shell_screen_admin_title( 'Posts ‹ Site — WordPress', 'Posts' )
-		);
-		set_current_screen( 'dashboard' );
-		$this->assertSame(
-			' ‹ Site — WordPress',
-			openstation_shell_screen_admin_title( ' ‹ Site — WordPress', '' )
+
+		openstation_register_shell_screen();
+
+		$this->assertNotFalse(
+			has_action(
+				'load-' . OPENSTATION_SHELL_SCREEN_ID,
+				'openstation_shell_screen_set_title'
+			)
 		);
 	}
 


### PR DESCRIPTION
Two low-contrast regressions in native windows, reported together and fixed
together. They look like one bug and share no cause: one is a document in
quirks mode, the other an inline custom property. Neither is a colour value
being wrong — in both cases the palette had the right answer and could not
reach the element.

---

## 1. The shell document was loading in quirks mode

Reported as "the Pages native window has lost its colours" — titles, column
headers, authors, templates and slugs all near-black on the dark station,
1.3:1 against a table header.

The first bytes of `admin.php?page=openstation` were not the doctype:

```
<br />
<b>Deprecated</b>: strip_tags(): Passing null to parameter #1 ($string) of type string
is deprecated in <b>/var/www/src/wp-admin/admin-header.php</b> on line <b>41</b><br />
<!DOCTYPE html>
```

so the document loaded in **quirks mode** (`document.compatMode ===
"BackCompat"`, `document.doctype === null`). The quirks UA stylesheet stops
`<table>` inheriting `color` and `font-*` from its ancestors, so every
`<os-table>` in a native window dropped the palette's `--os-ui-fg` and took
core's `body { color: #3c434a }`.

The cascade was never wrong, which is what made this read as a CSS
regression: walking up from the table, `.desktop-mode-posts` and
`.os-window__body--native` both computed `rgb(255, 251, 255)`. Only the
`<table>` inside the shadow root refused to inherit it — which is also why
the same token resolved correctly two elements away, in the pager's
`<select>`.

**Why this screen.** It registers with `add_submenu_page( '', … )`,
deliberately, so it paints nowhere in the menu. `get_admin_page_title()`
walks `$menu` and `$submenu` for an entry to take a name from, finds none,
and leaves `$title` null — and `admin-header.php` line 41 runs
`strip_tags( $title )` on it unconditionally. #700 hit the visible half of
this (the document title came out as "‹ Site — WordPress") and patched it
with an `admin_title` filter, but that filter runs *after* line 41.

**Fix.** Set `$title` on `load-{$hook}`, the one point between
`add_submenu_page()` and `require admin-header.php`.
`get_admin_page_title()` then returns early on its own `! empty()` check,
which is also what puts "OpenStation" before the chevron — so the
`admin_title` filter goes away with its cause.

**Scope.** Every native window that renders an `<os-table>`: Posts, Pages,
Users, Profile, Comments, Plugins, Recycle Bin. Only reproducible with
`display_errors` on, so a production install never painted it and a dev box
always did.

---

## 2. The Categories column pinned a light-mode pair inline

The category chips in the Posts window were near-invisible: a black wash
carrying near-black ink, 1.2:1.

`<os-crumb-chain>` gave every **uncoloured** segment a hard-coded
`rgba( 0, 0, 0, 0.08 )` background and derived `#1d2327` ink for it through
`pickForegroundColor()` — correct arithmetic, that wash really is light on a
white page — and wrote both as **inline custom properties**. Inline custom
properties outrank every document-tree declaration, so the pair survived the
brand untouched. WordPress terms carry no colour, so that was every segment
in the column.

**The paint was never missing.** The palette has named `--os-ui-crumb-bg`
since the rebrand — `#33303a`, in the "fills that must stay fills" block,
put there for exactly this shape — and the frozen Legacy manifest declares
both `--os-ui-crumb-bg` and `--os-ui-crumb-fg`. Neither had ever reached the
component.

**Fix.** An uncoloured segment writes no `style` attribute at all (an empty
attribute value is removed outright), so the stylesheet's own
`var( --os-ui-crumb-bg, … )` chain answers: theme first, palette next, the
pre-brand literal last. **No token added, no value changed.** The ink falls
through to `--os-ui-fg` and always could have. Starlight on Obsidian,
11.4:1. A segment that *does* carry a colour still pins both properties
inline, which is what the hook was built for. The drag ghost is the one
place that cannot defer to the stylesheet — it is a detached snapshot the
browser rasterises — so it reads the same two tokens itself, with the old
literals as its floor.

This is the inline-style form of the `:host` rule in AGENTS.md ("never
declare a themeable token where the palette can't reach it"), and
`component-token-reachability.test.ts` does not cover it — it inspects
`:host` blocks, not render output.

---

## Testing

Verified live on the QA instance, before and after:

| | before | after |
|---|---|---|
| `document.compatMode` | `BackCompat` | `CSS1Compat` |
| `document.doctype` | `null` | present |
| `body.php-error` | yes | no |
| `<os-table>` host colour | `rgb(255, 251, 255)` | `rgb(255, 251, 255)` |
| shadow `table` / `th` / `td` | `rgb(60, 67, 74)` | `rgb(255, 251, 255)` |
| `.os-crumb` inline `style` | present | absent |
| `.os-crumb` paint | `#1d2327` on `rgba(0,0,0,0.08)` | `#fffbff` on `#33303a` |
| `<title>` | `OpenStation ‹ Site — WordPress` | unchanged |

**PHP.** Two tests replace the one that covered the `admin_title` filter:
that the screen sets a string title (and that `get_admin_page_title()`
returns early on it), and that registration wires it to the load hook —
setting it anywhere later is too late to stop the notice.

**JS.** New `os-crumb-chain.test.ts` pins the rule the regression broke: a
coloured segment writes both tokens inline, an uncoloured one writes no
`style` attribute at all, the pre-brand literals never appear inline, and a
mixed chain only pins the segments that are coloured.

`npm run lint` · `npm run lint:php` · `npm run typecheck` clean ·
`npm run test:php` 2634 / 20442 green · `npm run test:js` 417 files / 5248
tests green · `npm run build` no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-710-e3e3065f428e222eb9a42706aa0322d976b82ef6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->