### PR TITLE
Multisite: the workspace hop — cross-admin clicks switch desktops in place

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -1525,3 +1525,52 @@ os-notice a:focus,
 os-notice a:active {
 	color: var(--os-ui-notice-link-hover, #fffbff);
 }
+
+/* --------------------------------------------------------------------
+ * The workspace hop — cross-document view transitions between shells.
+ *
+ * Loaded only on the SHELL screen (this sheet never reaches chromeless
+ * iframes), so only shell→shell navigations transition: hopping between
+ * a site's desktop and the network admin's crossfades the two desktops
+ * instead of hard-cutting, which is what makes the per-admin sessions
+ * read as workspaces. Classic admin pages never opt in, so entering or
+ * leaving the shell stays a plain navigation, and reloads are excluded
+ * by the spec. Browsers without cross-document view transitions ignore
+ * all of this and navigate plainly. See docs/multisite.md.
+ */
+@view-transition {
+	navigation: auto;
+}
+
+/* Reduced motion swaps instantly — the hop still happens, the
+ * animation does not. */
+@media ( prefers-reduced-motion: reduce ) {
+	@view-transition {
+		navigation: none;
+	}
+}
+
+/* A gentle zoom-through: the desktop being left recedes as the one
+ * arriving settles in. Subtle on purpose — this runs on a full page
+ * swap, and anything louder reads as a reload effect. */
+::view-transition-old(root) {
+	animation: os-workspace-hop-out 220ms cubic-bezier( 0.4, 0, 1, 1 ) both;
+}
+
+::view-transition-new(root) {
+	animation: os-workspace-hop-in 280ms cubic-bezier( 0, 0, 0.2, 1 ) both;
+}
+
+@keyframes os-workspace-hop-out {
+	to {
+		opacity: 0;
+		transform: scale( 0.985 );
+	}
+}
+
+@keyframes os-workspace-hop-in {
+	from {
+		opacity: 0;
+		transform: scale( 1.015 );
+	}
+}

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -5545,6 +5545,7 @@ Four things follow from a system tile's menu being *actions* rather than admin p
 - The panel is the same three sections an admin menu gets. The head shows the tile's icon and title and, having no landing page to open, runs the **first row** on click.
 - Live windows are resolved from the rows. An admin menu has one window key; an action menu has none, so each row that opens a window declares it with `windowId` and the section lists the union. Rows that open nothing leave it unset.
 - `onSelect` is **client-side only**. The server builds admin-menu submenus as JSON and a function cannot survive that trip; only JS-registered tiles can set it.
+- Both `onOpen` and `onSelect` receive the originating `MouseEvent` when there is one (keyboard activation and programmatic calls pass nothing), so a handler that navigates can honour the browser-tab gestures — cmd/ctrl/shift and middle click. The Network Admin tile's workspace hop (`src/multisite/hop.ts`, [multisite.md](./multisite.md#the-workspace-hop)) is the shipped example; handlers that ignore the argument are unaffected.
 - `dock-peek` stands down for the tile, the same way it does for menu tiles. Give the tile an `onOpen` that does something defensible on its own, because a keyboard or touch user never sees the menu.
 
 Declare `submenu` as a getter if the rows depend on live state — it is read fresh each time the flyout opens.

--- a/docs/multisite.md
+++ b/docs/multisite.md
@@ -18,11 +18,43 @@ every admin response carries `X-Frame-Options: SAMEORIGIN` and
 
 The network admin is on the **network's** domain (`network_site_url()`
 builds from `get_network()->domain`), never the current site's, so it is
-cross-origin from any subdomain or mapped site too. So anything leaving
-the current admin **opens a browser tab**: one behaviour on all three
-shapes, and it leaves the desktop the user is standing on intact.
-Cross-admin windows are therefore not supported, and neither is a
-network-wide desktop, since windows have no site identity.
+cross-origin from any subdomain or mapped site too. Cross-admin windows
+are therefore not supported, and neither is a network-wide desktop,
+since windows have no site identity. Anything leaving the current admin
+**hops** instead — see the next section — and cross-origin URLs, which
+cannot hop through a same-origin navigation's view transition, open a
+browser tab as they always did.
+
+## The workspace hop
+
+A same-origin click that leaves the current admin — the Network Admin
+tile and its flyout rows, the Sites list's "Dashboard" links inside a
+window — **navigates this tab** to the other admin's shell. Every admin
+keeps its own desktop under its own session key (see Storage scoping),
+so each side restores exactly as it was left: hopping between the
+network admin and a site reads as switching workspaces, spelled as a
+navigation. The raw admin URL is the right target on purpose — the
+`admin_init` redirect routes it to the matching shell screen exactly as
+if it had been typed.
+
+Three qualifiers, each deliberate:
+
+- **A modifier click (cmd/ctrl/shift) or a middle click keeps the
+  browser-tab behaviour** — the universal "open elsewhere" gesture, and
+  the way to stand two desktops side by side. `hopToAdmin()` in
+  `src/multisite/hop.ts` owns the split; the dock and the bridge both
+  route through the same rule.
+- **The swap animates through a cross-document view transition.** The
+  opt-in (`@view-transition { navigation: auto }`) lives in
+  `assets/css/desktop.css`, which only the SHELL loads — chromeless
+  iframes never opt in, so ordinary in-window navigations never
+  transition, and classic admin pages don't either, so entering or
+  leaving the shell stays a plain cut. Reduced motion swaps instantly;
+  browsers without the feature navigate plainly. Pinned by
+  `tests/vitest/workspace-hop.test.ts`.
+- **Cross-origin stays a tab.** A subdomain or mapped site's admin is
+  another origin; the bridge already classes those links `external` and
+  nothing about them changed.
 
 **Same origin is not the same admin.** The unit is the **admin scope**:
 the site root up to and including the first `/wp-admin/`, plus the
@@ -32,7 +64,7 @@ sits UNDER the main site's admin and shares its prefix, so
 `/wp-admin/index.php` and `/wp-admin/network/` would read as one place.
 `adminScope()` in `src/chromeless-bridge.js` is the only copy of that
 rule (a second one in the shell drifted out of sync within a day), and
-the bridge opens a tab for any link leaving its scope — which is what the
+the bridge hops for any link leaving its scope — which is what the
 Sites list does on each "Dashboard" link. If a window ever does show
 another admin, its `os-plugins-changed` payload repaints this dock with
 that admin's menu: the symptom to recognise.
@@ -73,7 +105,8 @@ bar's Network Admin node with core's own capability gates (copied from
 `wp_admin_bar_my_sites_menu()`), and hides itself inside the network
 admin where the dock already *is* that menu. It reads
 `wp.os.config.multisite` (`MultisiteConfig` in `src/types.ts`), null
-without the capability.
+without the capability. The tile and every flyout row are workspace
+hops (see above).
 
 It registers with `navKind: 'core'`
 ([javascript-reference.md](./javascript-reference.md)), so it paints with

--- a/src/chromeless-bridge.js
+++ b/src/chromeless-bridge.js
@@ -1096,7 +1096,10 @@
 	 * the browser navigate naturally (mailto, anchor, download, etc.).
 	 *
 	 *   'admin'       — same-origin /wp-admin/ URL we rewrite in place.
-	 *   'other-admin'  — another site, or the network admin. Browser tab.
+	 *   'other-admin'  — another site, or the network admin. The
+	 *                   workspace hop: the top tab navigates there.
+	 *                   (Modifier and middle clicks never get here —
+	 *                   the handler yields them to the browser.)
 	 *   'external'    — http(s) URL we want the parent shell to open
 	 *                   as a sub-tab instead of navigating the iframe
 	 *                   out of wp-admin. Covers both cross-origin
@@ -1492,9 +1495,16 @@
 		}
 		if ( kind === 'other-admin' ) {
 			/*
-			 * A different admin, opened in a BROWSER TAB. Not a window
-			 * (see isOtherAdmin), and not this tab: the user has windows
-			 * open on THIS one.
+			 * A different admin: the WORKSPACE HOP. Not a window (see
+			 * isOtherAdmin), and no longer a forced browser tab either —
+			 * every admin keeps its own desktop under its own session
+			 * key, so navigating the top tab there restores that
+			 * admin's desktop and leaves this one saved exactly as it
+			 * stands, with the shell stylesheet's cross-document view
+			 * transition covering the swap. A modifier or middle click
+			 * never reaches this branch — the handler yields those to
+			 * the browser, whose native new-tab behavior keeps the
+			 * side-by-side option. See docs/multisite.md.
 			 */
 			e.preventDefault();
 			var other;
@@ -1503,10 +1513,19 @@
 			} catch ( err ) {
 				return;
 			}
-			/* A stray flag would make the new tab a standalone
+			/* A stray flag would make the destination a standalone
 			 * chromeless page with no way out. */
 			other.searchParams.delete( 'openstation_chromeless' );
-			window.open( other.href, '_blank', 'noopener,noreferrer' );
+			/* No modifier check here: the handler's first guard yields
+			 * every modified and non-primary click to the browser, whose
+			 * native new-tab behavior IS the side-by-side path. */
+			try {
+				window.top.location.assign( other.href );
+			} catch ( err ) {
+				/* A host that forbids top navigation (a sandboxed
+				 * embed) still gets the tab. */
+				window.open( other.href, '_blank', 'noopener,noreferrer' );
+			}
 			return;
 		}
 		if ( kind === 'external' ) {

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2883,7 +2883,9 @@ function init(): void {
 			// The tile's own click opens Preferences: the flyout is
 			// a hover gesture, and keyboards and touch never fan it
 			// out, so the tile has to do something defensible alone.
-			onOpen: openOsSettings,
+			// Wrapped so the click event never lands in the options
+			// parameter openOsSettings actually takes.
+			onOpen: () => openOsSettings(),
 			get submenu() {
 				// `windowId` on the rows that open one is what lets
 				// the flyout list System's live windows the way it

--- a/src/dock-constellation/index.ts
+++ b/src/dock-constellation/index.ts
@@ -953,7 +953,7 @@ function buildHead(
 	// another level behind me", the one thing the head does NOT do.
 	// The row's own hover state is the whole affordance.
 
-	head.addEventListener( 'click', () => {
+	head.addEventListener( 'click', ( event ) => {
 		dismiss();
 		if ( item.menuItem ) {
 			openMenuItem( deps, item.menuItem );
@@ -962,7 +962,7 @@ function buildHead(
 		// An action menu has no landing page, so the head does what
 		// its first row does — the same thing the tile's own click
 		// does, and the reason a keyboard user is never stranded.
-		runRow( deps, item, item.submenu[ 0 ] );
+		runRow( deps, item, item.submenu[ 0 ], event );
 	} );
 
 	return head;
@@ -978,12 +978,15 @@ function runRow(
 	deps: DockConstellationDeps,
 	item: ConstellationMenu,
 	sub: SubmenuItem | undefined,
+	event?: MouseEvent,
 ): void {
 	if ( ! sub ) {
 		return;
 	}
 	if ( sub.onSelect ) {
-		sub.onSelect();
+		// The originating click, so a row that navigates can honour
+		// the browser-tab gestures (cmd/ctrl/shift, middle click).
+		sub.onSelect( event );
 		return;
 	}
 	if ( item.menuItem ) {
@@ -1128,9 +1131,9 @@ function buildSubmenuRow(
 		row.appendChild( note );
 	}
 
-	row.addEventListener( 'click', () => {
+	row.addEventListener( 'click', ( event ) => {
 		dismiss();
-		runRow( deps, item, sub );
+		runRow( deps, item, sub, event );
 	} );
 
 	return row;

--- a/src/dock.ts
+++ b/src/dock.ts
@@ -55,8 +55,14 @@ export interface SystemDockItem {
 	title: string;
 	/** Icon — dashicons class, data URI, or URL. */
 	icon: string;
-	/** Handler invoked on click. */
-	onOpen: () => void;
+	/**
+	 * Handler invoked on click. The originating mouse event, when there
+	 * is one, rides along so a tile that navigates can honour the
+	 * browser-tab gestures (cmd/ctrl/shift and middle click) — the
+	 * Network Admin tile's workspace hop is the shipped example.
+	 * Keyboard activation and programmatic opens pass nothing.
+	 */
+	onOpen: ( event?: MouseEvent ) => void;
 	/**
 	 * Optional predicate: returns true when the system item currently
 	 * has an open window. Drives the active-dot indicator on the tile.
@@ -215,7 +221,7 @@ export interface SubmenuItem {
 	 * "Fullscreen" — rather than admin pages. `url` stays the fallback
 	 * for anything that can express itself as one.
 	 */
-	onSelect?: () => void;
+	onSelect?: ( event?: MouseEvent ) => void;
 	/**
 	 * The window this row opens, when it opens one.
 	 *
@@ -1265,7 +1271,7 @@ export class Dock {
 		);
 		// System items don't have a native admin-menu counterpart; the
 		// third arg is intentionally omitted.
-		primary.addEventListener( 'click', () => item.onOpen() );
+		primary.addEventListener( 'click', ( event ) => item.onOpen( event ) );
 
 		tile.appendChild( primary );
 		this.bindTooltipFiltered( tile, item.title, ctx );

--- a/src/multisite/dock-tiles.ts
+++ b/src/multisite/dock-tiles.ts
@@ -1,14 +1,18 @@
 /**
  * The Network Admin dock tile: the admin bar's Network Admin node, on
- * the dock. Every row opens a BROWSER TAB — not a window, since the
- * network admin is on another domain and WordPress refuses to be framed
- * cross-origin, and not this tab, since the user has windows open here.
- * See docs/multisite.md.
+ * the dock. Every row HOPS — navigates this tab to the network admin's
+ * own shell — rather than opening a window: the network admin is on
+ * another domain and WordPress refuses to be framed cross-origin. The
+ * desktop being left behind is safe to leave: every admin keeps its own
+ * desktop under its own session key, so the hop restores each side
+ * exactly as it was, and a modifier click still opens the browser tab
+ * for standing the two desktops side by side. See docs/multisite.md.
  */
 
 import type { SystemDockItem } from '../dock';
 import type { MultisiteConfig } from '../types';
 import { __ } from '../i18n';
+import { hopToAdmin } from './hop';
 
 export const NETWORK_ADMIN_TILE_ID = 'os-network-admin';
 
@@ -31,11 +35,18 @@ export function getNetworkAdminTileDef(
 		// `computeNav` decides where in that run it lands.
 		navKind: 'core',
 		// Keyboards and touch never fan the flyout out, so the tile
-		// does what its first row does. A bare `url` with no `onSelect`
-		// is what the flyout links out.
-		onOpen: () => window.open( network.url, '_blank', 'noopener,noreferrer' ),
+		// does what its first row does: hop to the network dashboard.
+		onOpen: ( event? ) => hopToAdmin( network.url, event ),
 		get submenu() {
-			return network.rows.map( ( { title, url } ) => ( { title, url } ) );
+			// `url` stays on the row so surfaces that describe rows can
+			// keep doing so; the click routes through `onSelect`, which
+			// is what makes the row a hop rather than the generic
+			// bare-url link-out.
+			return network.rows.map( ( { title, url } ) => ( {
+				title,
+				url,
+				onSelect: ( event?: MouseEvent ) => hopToAdmin( url, event ),
+			} ) );
 		},
 	};
 }

--- a/src/multisite/hop.ts
+++ b/src/multisite/hop.ts
@@ -1,0 +1,37 @@
+/**
+ * The workspace hop: cross-admin navigation in the CURRENT tab.
+ *
+ * Every admin keeps its own desktop under its own session key, so
+ * navigating between the network admin's shell and a site's restores
+ * each one exactly as it was left — hopping IS switching workspaces,
+ * spelled as a navigation. The shell's stylesheet opts both documents
+ * into a cross-document view transition (see the workspace-hop block
+ * in `assets/css/desktop.css`), so on supporting browsers the two
+ * desktops crossfade instead of hard-cutting; elsewhere it is a plain
+ * navigation.
+ *
+ * A modifier click (cmd/ctrl/shift) or a middle click keeps the
+ * browser-tab behavior — the universal "open elsewhere" gesture, and
+ * the way to stand two desktops side by side.
+ *
+ * The raw admin URL is the right target on purpose: the `admin_init`
+ * redirect routes it to the matching shell screen with the URL as the
+ * boot target, exactly as if it had been typed. See docs/multisite.md.
+ */
+
+/** Whether a click asked for the browser-tab behavior instead. */
+export function wantsBrowserTab( event?: MouseEvent ): boolean {
+	return (
+		!! event &&
+		( event.metaKey || event.ctrlKey || event.shiftKey || 1 === event.button )
+	);
+}
+
+/** Navigate this tab to another admin, or a new tab on a modifier click. */
+export function hopToAdmin( url: string, event?: MouseEvent ): void {
+	if ( wantsBrowserTab( event ) ) {
+		window.open( url, '_blank', 'noopener,noreferrer' );
+		return;
+	}
+	window.location.assign( url );
+}

--- a/tests/vitest/chromeless-bridge-links.test.ts
+++ b/tests/vitest/chromeless-bridge-links.test.ts
@@ -284,24 +284,50 @@ describe( 'chromeless bridge: links that name another browsing context', () => {
 		expect( adminLinkMessages()[ 0 ].newContext ).toBe( false );
 	} );
 
-	test( 'another admin opens in a browser tab, not a window and not this one', () => {
-		// Subdirectory multisite: `/site2/wp-admin/` is the same origin,
-		// and `/wp-admin/network/` shares this admin's own prefix, so
-		// both used to be waved through as in-window navigations, which
-		// repainted this dock with the other admin's menu. Nor in THIS
-		// tab: the user has windows open here. The href is never stamped
-		// chromeless either, which would leave the tab with no way out.
+	test( 'another admin hops the top tab — the workspace hop', () => {
+		// `/site2/wp-admin/` shares this origin, and `/wp-admin/network/`
+		// shares this admin's own prefix, so both used to be waved
+		// through as in-window navigations, which repainted this dock
+		// with the other admin's menu. Not a window, then — but not a
+		// forced browser tab any more either: every admin keeps its own
+		// desktop under its own session key, so the top tab navigates
+		// there and each side restores as left. The href is never
+		// stamped chromeless, which would leave the destination with no
+		// way out.
+		const assign = vi.fn();
+		Object.defineProperty( window, 'top', {
+			value: { location: { assign } },
+			configurable: true,
+		} );
 		const open = vi.spyOn( window, 'open' ).mockReturnValue( null );
 
 		try {
 			for ( const path of [ '/site2/wp-admin/', '/wp-admin/network/sites.php' ] ) {
 				expect( clickLink( `<a href="${ path }">Go</a>` ) ).toBe( path );
-				expect( open ).toHaveBeenCalledWith(
-					`http://localhost${ path }`,
-					'_blank',
-					'noopener,noreferrer'
+				expect( assign ).toHaveBeenLastCalledWith(
+					`http://localhost${ path }`
 				);
 			}
+			expect( open ).not.toHaveBeenCalled();
+			expect( adminLinkMessages() ).toHaveLength( 0 );
+
+			// A modifier click is yielded whole — the handler's first
+			// guard hands it to the browser, whose native new-tab
+			// behavior is the way to stand two desktops side by side.
+			document.body.innerHTML =
+				'<a href="/wp-admin/network/sites.php">Go</a>';
+			const anchor = document.querySelector( 'a' ) as HTMLAnchorElement;
+			const modified = new MouseEvent( 'click', {
+				bubbles: true,
+				cancelable: true,
+				metaKey: true,
+			} );
+			anchor.dispatchEvent( modified );
+			// Yielded: no hop, no tab of ours, no message — the only
+			// preventDefault is the harness's own bubble-phase catch-all
+			// standing in for the browser's native new-tab handling.
+			expect( open ).not.toHaveBeenCalled();
+			expect( assign ).toHaveBeenCalledTimes( 2 );
 			expect( adminLinkMessages() ).toHaveLength( 0 );
 
 			// The rule is scope-to-scope, so everything inside THIS
@@ -310,6 +336,10 @@ describe( 'chromeless bridge: links that name another browsing context', () => {
 			expect( adminLinkMessages() ).toHaveLength( 1 );
 		} finally {
 			open.mockRestore();
+			Object.defineProperty( window, 'top', {
+				value: window,
+				configurable: true,
+			} );
 		}
 	} );
 

--- a/tests/vitest/multisite-dock-tiles.test.ts
+++ b/tests/vitest/multisite-dock-tiles.test.ts
@@ -1,24 +1,43 @@
 /**
- * The Network Admin dock tile. Two decisions worth pinning: the rows
- * link OUT (a `SubmenuItem` with a bare `url` and no `onSelect` is what
- * the flyout opens in a browser tab), and the tile is not offered where
- * it would be a lie.
+ * The Network Admin dock tile. Two decisions worth pinning: every
+ * activation HOPS — navigates this tab to the network admin's shell,
+ * with a modifier click keeping the browser-tab behavior — and the
+ * tile is not offered where it would be a lie.
  */
 
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { getNetworkAdminTileDef, NETWORK_ADMIN_TILE_ID } from '../../src/multisite/dock-tiles';
 import { zoneForSystemTile } from '../../src/dock';
 import type { MultisiteConfig } from '../../src/types';
 
 const NETWORK = 'http://example.test/wp-admin/network/';
+const SITES = 'http://example.test/wp-admin/network/sites.php';
 
 const config = ( over: Partial< MultisiteConfig > = {} ): MultisiteConfig => ( {
 	isNetworkAdmin: false,
 	networkAdmin: {
 		url: NETWORK,
-		rows: [ { title: 'Dashboard', url: NETWORK }, { title: 'Sites', url: NETWORK } ],
+		rows: [ { title: 'Dashboard', url: NETWORK }, { title: 'Sites', url: SITES } ],
 	},
 	...over,
+} );
+
+const realLocation = window.location;
+let assign: ReturnType< typeof vi.fn >;
+
+beforeEach( () => {
+	assign = vi.fn();
+	Object.defineProperty( window, 'location', {
+		value: { ...realLocation, assign },
+		configurable: true,
+	} );
+} );
+
+afterEach( () => {
+	Object.defineProperty( window, 'location', {
+		value: realLocation,
+		configurable: true,
+	} );
 } );
 
 describe( 'the Network Admin tile', () => {
@@ -40,18 +59,37 @@ describe( 'the Network Admin tile', () => {
 		] );
 	} );
 
-	test( 'mirrors the server rows, and everything links out', () => {
-		const open = vi.spyOn( window, 'open' ).mockReturnValue( null );
+	test( 'the tile and every row hop this tab to the network admin', () => {
 		const tile = getNetworkAdminTileDef( config() );
 		const rows = tile?.submenu ?? [];
 
 		expect( rows.map( ( r ) => r.title ) ).toEqual( [ 'Dashboard', 'Sites' ] );
-		// An `onSelect` here would take the tab the desktop is in.
-		expect( rows.every( ( r ) => r.url && ! r.onSelect ) ).toBe( true );
+		// `url` stays for surfaces that describe the row; the click
+		// routes through `onSelect`, which is the hop.
+		expect( rows.every( ( r ) => r.url && r.onSelect ) ).toBe( true );
 
 		// The tile's own click is the keyboard and touch path.
 		tile?.onOpen();
-		expect( open ).toHaveBeenCalledWith( NETWORK, '_blank', 'noopener,noreferrer' );
-		open.mockRestore();
+		rows[ 1 ].onSelect?.();
+		expect( assign.mock.calls ).toEqual( [ [ NETWORK ], [ SITES ] ] );
+	} );
+
+	test( 'a modifier click keeps the browser-tab behavior', () => {
+		const open = vi.spyOn( window, 'open' ).mockReturnValue( null );
+		const tile = getNetworkAdminTileDef( config() );
+
+		try {
+			tile?.onOpen( new MouseEvent( 'click', { metaKey: true } ) );
+			tile?.submenu?.[ 1 ].onSelect?.(
+				new MouseEvent( 'click', { ctrlKey: true } ),
+			);
+			expect( open.mock.calls ).toEqual( [
+				[ NETWORK, '_blank', 'noopener,noreferrer' ],
+				[ SITES, '_blank', 'noopener,noreferrer' ],
+			] );
+			expect( assign ).not.toHaveBeenCalled();
+		} finally {
+			open.mockRestore();
+		}
 	} );
 } );

--- a/tests/vitest/workspace-hop.test.ts
+++ b/tests/vitest/workspace-hop.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The workspace hop: the gesture split in `hopToAdmin()`, and the
+ * cross-document view-transition block in the SHELL stylesheet.
+ *
+ * The CSS pins matter because the whole feature degrades silently: a
+ * deleted opt-in, or one that migrated into a sheet chromeless iframes
+ * load, would not fail anything — hops would just hard-cut (or, worse,
+ * iframe navigations would start transitioning). Reduced motion must
+ * keep the hop and drop only the animation.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { hopToAdmin, wantsBrowserTab } from '../../src/multisite/hop';
+
+const ROOT = resolve( __dirname, '../..' );
+const URL = 'http://example.test/site2/wp-admin/';
+
+describe( 'hopToAdmin', () => {
+	const realLocation = window.location;
+	let assign: ReturnType< typeof vi.fn >;
+
+	beforeEach( () => {
+		assign = vi.fn();
+		Object.defineProperty( window, 'location', {
+			value: { ...realLocation, assign },
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: realLocation,
+			configurable: true,
+		} );
+	} );
+
+	test( 'a plain activation navigates this tab', () => {
+		hopToAdmin( URL );
+		hopToAdmin( URL, new MouseEvent( 'click' ) );
+		expect( assign.mock.calls ).toEqual( [ [ URL ], [ URL ] ] );
+	} );
+
+	test( 'every browser-tab gesture opens a tab instead', () => {
+		const open = vi.spyOn( window, 'open' ).mockReturnValue( null );
+		try {
+			for ( const init of [
+				{ metaKey: true },
+				{ ctrlKey: true },
+				{ shiftKey: true },
+				{ button: 1 },
+			] as MouseEventInit[] ) {
+				expect( wantsBrowserTab( new MouseEvent( 'click', init ) ) ).toBe(
+					true,
+				);
+				hopToAdmin( URL, new MouseEvent( 'click', init ) );
+			}
+			expect( open ).toHaveBeenCalledTimes( 4 );
+			expect( assign ).not.toHaveBeenCalled();
+		} finally {
+			open.mockRestore();
+		}
+	} );
+} );
+
+describe( 'the view-transition opt-in', () => {
+	const shell = readFileSync(
+		resolve( ROOT, 'assets/css/desktop.css' ),
+		'utf8',
+	);
+
+	test( 'the shell opts into cross-document transitions', () => {
+		expect( shell ).toMatch( /@view-transition\s*\{\s*navigation:\s*auto;/ );
+		// Both halves of the crossfade are declared — a missing side
+		// leaves the UA default on one and the custom curve on the
+		// other, a mismatched blink.
+		expect( shell ).toContain( '::view-transition-old(root)' );
+		expect( shell ).toContain( '::view-transition-new(root)' );
+	} );
+
+	test( 'reduced motion drops the animation, never the hop', () => {
+		const reduced = shell.slice(
+			shell.indexOf( '@media ( prefers-reduced-motion: reduce )', shell.indexOf( '@view-transition' ) ),
+		);
+		expect( reduced ).toMatch( /@view-transition\s*\{\s*navigation:\s*none;/ );
+	} );
+
+	test( 'chromeless iframes never opt in', () => {
+		// The opt-in in a sheet iframes load would make ordinary
+		// in-window navigations transition. `variables.css` is the
+		// chromeless dependency; `chromeless.css` is the iframe skin.
+		for ( const sheet of [ 'assets/css/variables.css', 'assets/css/chromeless.css' ] ) {
+			expect( readFileSync( resolve( ROOT, sheet ), 'utf8' ) ).not.toContain(
+				'@view-transition',
+			);
+		}
+	} );
+} );


### PR DESCRIPTION
## What it does

Cross-admin clicks now **switch desktops in the current tab** instead of forcing a new browser tab. Click the Network Admin tile (or one of its flyout rows) on a site's desktop and this tab travels to the network admin's shell; click a site's "Dashboard" link in the network's Sites window and it travels back. Every admin keeps its own desktop under its own session key (#704/#728), so each side restores exactly as it was left — hopping reads as switching workspaces, with a subtle cross-document view transition covering the swap (a gentle crossfade with a hint of zoom; instant under reduced motion; a plain navigation on browsers without the feature).

The browser-tab behavior survives as the side-by-side gesture: **cmd/ctrl/shift or middle click** still opens the other admin in a new tab.

## Rationale

#704 sent every cross-admin click to a new browser tab: one behavior on all three network shapes, and it never disturbed the desktop you were standing on. But with per-admin sessions in place, leaving a desktop costs nothing — it restores exactly as left — and the tab-per-hop model piles up tabs for what is conceptually one workspace switch. The follow-up idea was "open the other admin in a new Workspace with a subtle animation": this is that, built on the machinery that already exists rather than a multi-admin shell (which the doc's iframe-constraint section explains cannot generalize past subdirectory networks anyway).

## Implementation

- `hopToAdmin()` in `src/multisite/hop.ts` owns the gesture split: plain activation → `location.assign( rawAdminUrl )` (the `admin_init` redirect routes it to the matching shell screen exactly as if typed); modifier/middle click → `window.open`. The Network Admin tile and its flyout rows route through it.
- The chromeless bridge's `other-admin` link kind now assigns `window.top.location` instead of opening a tab (falling back to a tab if a host forbids top navigation). Modified clicks never reach that branch — the handler's first guard already yields them to the browser, whose native new-tab handling is the same gesture.
- The view-transition opt-in (`@view-transition { navigation: auto }` plus the two root animations) lives in `assets/css/desktop.css`, which only the **shell** loads — chromeless iframes never opt in, so ordinary in-window navigations never transition, and classic admin pages don't opt in either, so entering/leaving the shell stays a plain cut. Reduced motion sets `navigation: none`: the hop still happens, the animation does not.
- `SystemDockItem.onOpen` and `SubmenuItem.onSelect` now receive the originating `MouseEvent` when there is one (keyboard and programmatic activations pass nothing), threaded through the dock and the constellation so any navigating handler can honour the same gestures. Handlers that ignore the argument are unaffected.
- Cross-origin links (a subdomain or mapped site's admin) were never classed `other-admin` and keep opening tabs — the hop only exists where a same-origin navigation (and its view transition) can.

`docs/multisite.md` gains a "workspace hop" section replacing the tab contract; `tests/vitest/workspace-hop.test.ts` pins the gesture split and the CSS opt-ins (including that no iframe-loaded sheet ever carries one).

## Testing instructions

```bash
npm run test:js   # workspace-hop, multisite-dock-tiles, chromeless-bridge-links
```

On a subdirectory multisite (plugin network-activated, e.g. the `.wp-env.override.json` setup from #704):

1. On a site desktop, arrange a couple of windows, then click the **Network Admin** dock tile: this tab travels to the network desktop (crossfading in Chromium), restoring it as last left.
2. There, open **Sites → All Sites** and click a site's **Dashboard** row: the tab travels to that site's desktop, with your windows from step 1 intact.
3. Cmd/ctrl-click either of those: a new tab opens and the desktop you are on stays put.
4. Toggle "reduce motion" in the OS: hops still work, instantly.
5. Firefox/Safari: hops work as plain navigations.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-735-e707488255c7305f06fff657104353b8bc29ef77.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->