### PR TITLE
Drafts: name a draft's window after the draft, not the whole row

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4056,6 +4056,37 @@ Two extra args are identity-bearing **only on an `admin.php` URL carrying a `pag
 
 ---
 
+### `data-os-window-title` on an anchor — Stable
+
+Name the window an admin link opens, instead of letting the shell guess.
+
+The shell's top-window link interceptor claims every same-origin `/wp-admin/` anchor in the shell body and opens it as a window. Unless a dock entry owns the destination, it titles that window with the anchor's own text. That is right for a plain link and a guess for anything else, because `textContent` runs together across element boundaries. An anchor assembled from several elements, held apart by layout rather than by whitespace in the markup, arrives as one word:
+
+```html
+<!-- Window title: "Ginza after work356d ago" -->
+<a href="/wp-admin/post.php?post=42&action=edit">
+    <span class="title">Ginza after work</span><span class="stamp">356d ago</span>
+</a>
+```
+
+Say what the window is called and the guess is skipped:
+
+```html
+<!-- Window title: "Ginza after work • 356d ago" -->
+<a href="/wp-admin/post.php?post=42&action=edit"
+   data-os-window-title="Ginza after work • 356d ago">
+    <span class="title">Ginza after work</span><span class="stamp">356d ago</span>
+</a>
+```
+
+The attribute outranks both the link text and the dock entry that would otherwise name the window: it is the anchor stating what it opens, which is more specific than the dock's name for the whole destination. Whitespace-only values are ignored and fall through to the normal chain. Set it from JS with `link.dataset.osWindowTitle = …`.
+
+Deliberately opt-in rather than a cleverer reading of the DOM: joining every element boundary would break the far more common anchor whose markup is one sentence with a `<strong>` in the middle. Reach for it whenever a link's visible text is assembled from more than one element: a widget row, a card, a list item with a trailing badge or stamp.
+
+> **Inside a window this is a no-op.** Iframe content is a separate document realm; those clicks go through the chromeless bridge, which sends its own `label` (see [bridge-protocol.md](./bridge-protocol.md#admin-link-routing-inside-chromeless-iframes)). The attribute applies to anchors in the shell itself: widgets, desktop surfaces, rail renderers.
+
+---
+
 ### `listSystemTiles()` — Stable
 
 Snapshot of every JS-registered system tile across both rails. Returns `[]` when the layout dispatcher hasn't booted yet (rare; only happens before `os.init` fires).

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -4072,12 +4072,14 @@ The shell's top-window link interceptor claims every same-origin `/wp-admin/` an
 Say what the window is called and the guess is skipped:
 
 ```html
-<!-- Window title: "Ginza after work • 356d ago" -->
+<!-- Window title: "Ginza after work" -->
 <a href="/wp-admin/post.php?post=42&action=edit"
-   data-os-window-title="Ginza after work • 356d ago">
+   data-os-window-title="Ginza after work">
     <span class="title">Ginza after work</span><span class="stamp">356d ago</span>
 </a>
 ```
+
+Naming the window after the thing it opens, rather than after everything the row happens to show, is usually the right call: a window title is read in the taskbar and the overview long after the click, and a relative stamp captured at open time is stale by then.
 
 The attribute outranks both the link text and the dock entry that would otherwise name the window: it is the anchor stating what it opens, which is more specific than the dock's name for the whole destination. Whitespace-only values are ignored and fall through to the normal chain. Set it from JS with `link.dataset.osWindowTitle = …`.
 

--- a/src/boot/link-interceptor.ts
+++ b/src/boot/link-interceptor.ts
@@ -144,6 +144,22 @@ export function bindTopWindowLinkInterceptor(
 
 			const windowId = deriveWindowId( url.href, config.adminUrl );
 			const dockEntry = findDockEntryForUrl( url.href, config );
+			// An anchor can name the window it opens via
+			// `data-os-window-title`. Reading the link's own text is the
+			// right default for a plain admin link, but it is only ever a
+			// guess: `textContent` concatenates across element
+			// boundaries, so an anchor assembled from several elements
+			// runs them together. The drafts widget's rows are a title
+			// span beside a "356d ago" stamp span, held apart by
+			// `justify-content: space-between` rather than by any
+			// whitespace in the markup, so they came out as
+			// "Ginza after work356d ago".
+			//
+			// Deliberately an opt-in attribute rather than a smarter
+			// reading of the DOM: joining every element boundary would
+			// break the far more common anchor whose markup is one
+			// sentence with a `<strong>` in the middle.
+			const declaredTitle = ( anchor.dataset.osWindowTitle || '' ).trim();
 			const fallbackTitle =
 				( anchor.textContent || '' ).trim() || dockEntry?.title || '';
 
@@ -175,7 +191,10 @@ export function bindTopWindowLinkInterceptor(
 				multi: !! dockEntry?.multi || isAdminBarNew,
 				url: url.href,
 				parentUrl: dockEntry?.url ?? url.href,
-				title: dockEntry?.title || fallbackTitle,
+				// A declared title outranks the dock entry: it is the
+				// anchor stating what it opens, which is more specific
+				// than the dock's name for the whole destination.
+				title: declaredTitle || dockEntry?.title || fallbackTitle,
 				icon: dockEntry?.icon || 'dashicons-admin-generic',
 				submenu: dockEntry?.submenu,
 				selfLabel: dockEntry?.selfLabel,

--- a/src/plugins/drafts-widget/index.ts
+++ b/src/plugins/drafts-widget/index.ts
@@ -573,7 +573,6 @@ function render(
 		link.href = editUrl( d.id );
 
 		const titleText = draftTitle( d );
-		const stampText = timeAgo( d.modified_gmt );
 
 		const name = document.createElement( 'span' );
 		name.className = 'dm-drafts__name';
@@ -581,7 +580,7 @@ function render(
 
 		const time = document.createElement( 'span' );
 		time.className = 'dm-drafts__time';
-		time.textContent = stampText;
+		time.textContent = timeAgo( d.modified_gmt );
 
 		link.appendChild( name );
 		link.appendChild( time );
@@ -591,15 +590,11 @@ function render(
 		// two spans (they are spaced by `justify-content: space-between`)
 		// and so titles the window "Ginza after work356d ago".
 		//
-		// A whole placeholder rather than a concatenation, for the same
-		// reason `timeAgo` uses one: the separator is punctuation a
-		// locale may want to move, drop, or replace.
-		link.dataset.osWindowTitle = sprintf(
-			/* translators: 1: draft title. 2: how long ago the draft was last edited, e.g. "3d ago". */
-			__( '%1$s • %2$s' ),
-			titleText,
-			stampText,
-		);
+		// The window is named after the draft, and only the draft. The
+		// stamp is the row's own metadata: it belongs where it keeps
+		// ticking, not frozen into a title that would still claim
+		// "356d ago" after the draft had just been saved.
+		link.dataset.osWindowTitle = titleText;
 
 		// Trash button. The inner Dashicon is a light-DOM child so the
 		// global icon font reaches it, and pointer-events:none so the

--- a/src/plugins/drafts-widget/index.ts
+++ b/src/plugins/drafts-widget/index.ts
@@ -572,16 +572,34 @@ function render(
 		link.className = 'dm-drafts__link';
 		link.href = editUrl( d.id );
 
+		const titleText = draftTitle( d );
+		const stampText = timeAgo( d.modified_gmt );
+
 		const name = document.createElement( 'span' );
 		name.className = 'dm-drafts__name';
-		name.textContent = draftTitle( d );
+		name.textContent = titleText;
 
 		const time = document.createElement( 'span' );
 		time.className = 'dm-drafts__time';
-		time.textContent = timeAgo( d.modified_gmt );
+		time.textContent = stampText;
 
 		link.appendChild( name );
 		link.appendChild( time );
+
+		// Name the window this row opens. Left to itself the interceptor
+		// reads the anchor's text, which has no whitespace between the
+		// two spans (they are spaced by `justify-content: space-between`)
+		// and so titles the window "Ginza after work356d ago".
+		//
+		// A whole placeholder rather than a concatenation, for the same
+		// reason `timeAgo` uses one: the separator is punctuation a
+		// locale may want to move, drop, or replace.
+		link.dataset.osWindowTitle = sprintf(
+			/* translators: 1: draft title. 2: how long ago the draft was last edited, e.g. "3d ago". */
+			__( '%1$s • %2$s' ),
+			titleText,
+			stampText,
+		);
 
 		// Trash button. The inner Dashicon is a light-DOM child so the
 		// global icon font reaches it, and pointer-events:none so the

--- a/tests/vitest/drafts-widget.test.ts
+++ b/tests/vitest/drafts-widget.test.ts
@@ -214,6 +214,25 @@ describe( 'drafts widget — rendering', () => {
 		expect( link.getAttribute( 'href' ) ).toContain( 'post.php?post=99&action=edit' );
 	} );
 
+	test( 'names the window it opens, so the stamp cannot run into the title', async () => {
+		installShell( {
+			drafts: [
+				{
+					id: 99,
+					title: { rendered: 'Ginza after work' },
+					modified_gmt: agoIso( 356 * 86400 ),
+				},
+			],
+		} );
+		teardown = await getMount()( container, makeCtx() );
+
+		const link = container.querySelector( '.dm-drafts__link' ) as HTMLAnchorElement;
+		// Without this the interceptor reads the anchor's text, and the
+		// two spans have no whitespace between them to read.
+		expect( link.dataset.osWindowTitle ).toBe( 'Ginza after work • 356d ago' );
+		expect( link.textContent ).toBe( 'Ginza after work356d ago' );
+	} );
+
 	test( 'falls back to a placeholder when a draft has no title', async () => {
 		installShell( {
 			drafts: [ { id: 3, title: { rendered: '' }, modified_gmt: agoIso( 10 ) } ],

--- a/tests/vitest/drafts-widget.test.ts
+++ b/tests/vitest/drafts-widget.test.ts
@@ -228,8 +228,9 @@ describe( 'drafts widget — rendering', () => {
 
 		const link = container.querySelector( '.dm-drafts__link' ) as HTMLAnchorElement;
 		// Without this the interceptor reads the anchor's text, and the
-		// two spans have no whitespace between them to read.
-		expect( link.dataset.osWindowTitle ).toBe( 'Ginza after work • 356d ago' );
+		// two spans have no whitespace between them to read. The stamp
+		// stays in the row; the window is named after the draft.
+		expect( link.dataset.osWindowTitle ).toBe( 'Ginza after work' );
 		expect( link.textContent ).toBe( 'Ginza after work356d ago' );
 	} );
 

--- a/tests/vitest/link-interceptor-title.test.ts
+++ b/tests/vitest/link-interceptor-title.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Link interceptor: how the window it opens gets its name.
+ *
+ * Reading the anchor's own text is the default and stays that way,
+ * but it is only a guess: `textContent` runs together across element
+ * boundaries, so an anchor built from several elements (the drafts
+ * widget's title span beside its "356d ago" stamp span) produced
+ * "Ginza after work356d ago". `data-os-window-title` lets such an
+ * anchor say what the window is called instead.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bindTopWindowLinkInterceptor } from '../../src/boot/link-interceptor';
+import type { DesktopConfig } from '../../src/types';
+import type { WindowManager } from '../../src/window-manager';
+
+const ADMIN_URL = `${ window.location.origin }/wp-admin/`;
+
+/**
+ * One binding for the whole file, not one per test. The interceptor
+ * has no disposer, so a per-test binding would stack up on `document`.
+ * Since the first listener to run calls `preventDefault()`, every
+ * later one bails on its own `defaultPrevented` guard and the test's
+ * own stub never hears the click.
+ */
+const manager = { open: vi.fn(), openNew: vi.fn() };
+
+let container: HTMLElement;
+
+/** Config with an empty dock, so no dock entry can claim the title. */
+function makeConfig(): DesktopConfig {
+	return {
+		adminUrl: ADMIN_URL,
+		dockItems: [],
+	} as unknown as DesktopConfig;
+}
+
+/** The row markup the drafts widget builds: two spans, no whitespace. */
+function draftRowLink( title: string, stamp: string ): HTMLAnchorElement {
+	const link = document.createElement( 'a' );
+	link.href = `${ ADMIN_URL }post.php?post=42&action=edit`;
+
+	const name = document.createElement( 'span' );
+	name.textContent = title;
+	const time = document.createElement( 'span' );
+	time.textContent = stamp;
+
+	link.append( name, time );
+	return link;
+}
+
+/** A plain left click, cancelable so `preventDefault` actually bites. */
+function click( el: Element ): void {
+	el.dispatchEvent(
+		new MouseEvent( 'click', { bubbles: true, cancelable: true } ),
+	);
+}
+
+/** Title the interceptor handed the window manager for the last click. */
+function openedTitle(): string {
+	expect( manager.open ).toHaveBeenCalledTimes( 1 );
+	return ( manager.open.mock.calls[ 0 ][ 0 ] as { title: string } ).title;
+}
+
+beforeAll( () => {
+	bindTopWindowLinkInterceptor(
+		manager as unknown as WindowManager,
+		makeConfig(),
+	);
+} );
+
+beforeEach( () => {
+	manager.open.mockClear();
+	manager.openNew.mockClear();
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	container.remove();
+} );
+
+describe( 'link interceptor: window title', () => {
+	it( 'prefers the title the anchor declares', () => {
+		const link = draftRowLink( 'Ginza after work', '356d ago' );
+		link.dataset.osWindowTitle = 'Ginza after work • 356d ago';
+		container.appendChild( link );
+
+		click( link );
+
+		expect( openedTitle() ).toBe( 'Ginza after work • 356d ago' );
+	} );
+
+	it( 'falls back to the link text for a plain anchor', () => {
+		const link = document.createElement( 'a' );
+		link.href = `${ ADMIN_URL }edit.php`;
+		link.textContent = 'All Posts';
+		container.appendChild( link );
+
+		click( link );
+
+		expect( openedTitle() ).toBe( 'All Posts' );
+	} );
+
+	it( 'runs multi-element anchors together without a declared title', () => {
+		// Not the desired output: this is the bug the attribute exists
+		// to let an anchor opt out of, pinned so the fallback's
+		// behaviour stays a deliberate choice rather than an accident.
+		const link = draftRowLink( 'Ginza after work', '356d ago' );
+		container.appendChild( link );
+
+		click( link );
+
+		expect( openedTitle() ).toBe( 'Ginza after work356d ago' );
+	} );
+
+	it( 'ignores an attribute that is only whitespace', () => {
+		const link = document.createElement( 'a' );
+		link.href = `${ ADMIN_URL }edit.php`;
+		link.textContent = 'All Posts';
+		link.dataset.osWindowTitle = '   ';
+		container.appendChild( link );
+
+		click( link );
+
+		expect( openedTitle() ).toBe( 'All Posts' );
+	} );
+} );

--- a/tests/vitest/link-interceptor-title.test.ts
+++ b/tests/vitest/link-interceptor-title.test.ts
@@ -84,12 +84,12 @@ afterEach( () => {
 describe( 'link interceptor: window title', () => {
 	it( 'prefers the title the anchor declares', () => {
 		const link = draftRowLink( 'Ginza after work', '356d ago' );
-		link.dataset.osWindowTitle = 'Ginza after work • 356d ago';
+		link.dataset.osWindowTitle = 'Ginza after work';
 		container.appendChild( link );
 
 		click( link );
 
-		expect( openedTitle() ).toBe( 'Ginza after work • 356d ago' );
+		expect( openedTitle() ).toBe( 'Ginza after work' );
 	} );
 
 	it( 'falls back to the link text for a plain anchor', () => {


### PR DESCRIPTION
## What?

Opening a draft from the Drafts widget titled its window `Ginza after work356d ago`.

The shell's link interceptor names a window after the clicked anchor's text. A drafts row is two spans, the title and a `356d ago` stamp, held apart by CSS rather than by any whitespace in the markup, so `textContent` ran them together. The row itself always looked right; the window, taskbar and overview were the ones showing the jam.

Anchors can now name their own window with `data-os-window-title`, and the widget sets it to the draft's title. The stamp stays in the row, where it keeps ticking.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1440" height="386" alt="Screenshot 2026-09-03 at 10 40 07" src="https://github.com/user-attachments/assets/e8671898-0bf6-4777-bb46-a0d375638774" /> | <img width="1440" height="386" alt="Screenshot 2026-09-03 at 10 41 05" src="https://github.com/user-attachments/assets/69081faa-daa7-4a49-925a-a7d2743268d1" /> |

## Testing instructions

1. Add the Drafts widget to the desktop, with at least one draft a day or more old (so the row shows a `2d ago` style stamp, not `just now`).
2. Click a draft row. The window's title bar should read just the draft's title. Before this it read the title with the stamp stuck to it.
3. Check the taskbar and the window overview (F3) show the same title.
4. Click a normal admin link in the shell, say **Posts** in the admin bar. Its window should be titled the way it always was.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-742-d2d8ba9f90329e0965513e98fa50add0ec595973.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
