### PR TITLE
App Framework: find an app's client bundle without its TypeScript source, so packaged installs open client-view apps

### DIFF
--- a/docs/app-framework.md
+++ b/docs/app-framework.md
@@ -149,6 +149,8 @@ Three action names are built in: **`mount`** (the first render), **`set`** (a bo
 
 `style( $path )` names a stylesheet for the body. Omit it and the framework looks for `<app dir>/<id>.css`, then `<app dir>/<file>.css` (the definition file's name without `.os.php`). The sheet is injected on the window's first open, after the runtime's own, and never reaches chromeless iframes.
 
+`client( $path )` names the built client view the same way. Omit it and, for an app inside OpenStation's own `apps/`, the framework loads `assets/js/apps/<file>[.min].js`, the bundle `npm run build:apps` compiles from the `<file>.os.ts` beside the definition. The lookup is keyed on the definition file's name, never on the TypeScript being present: the source is export-ignored from the release zip and only the bundle ships, so a packaged install resolves the same script a checkout does. An app shipped from another plugin declares its bundle with `client( $path )`; a shared file name never hands it OpenStation's.
+
 The runtime sheet also carries the **tone contract**: inside an app root, any element with `data-tone` set to `danger`, `warning`, `neutral` or `info` can read the matching status colour back through `var( --os-app-tone, <fallback> )` — a severity swatch, a row's accent border. The mapping is scoped to `.os-app`, so it never retints shell chrome or admin pages outside an app window. It also ships `.os-app__spacer` (`flex: 1`), the toolbar gap filler, so apps stop re-declaring it.
 
 ### Readers

--- a/includes/framework/class-app.php
+++ b/includes/framework/class-app.php
@@ -968,6 +968,7 @@ final class App {
 			'watch'             => $this->watch,
 			'client'            => $this->client_path(),
 			'client_source'     => $this->client_source(),
+			'file'              => $this->file,
 			'has_data'          => $this->has_data(),
 			'prefetch'          => $this->prefetches(),
 			'lifecycle'         => array_values( array_intersect( self::LIFECYCLE_ACTIONS, $this->action_names() ) ),

--- a/includes/framework/wordpress.php
+++ b/includes/framework/wordpress.php
@@ -234,9 +234,10 @@ function openstation_apps_style_handle( $id ) {
 /**
  * The built client-view bundle for an app, or '' when it has none.
  *
- * An explicit `App::client( $path )` wins. Otherwise an app that
- * ships `<file>.os.ts` beside its `.os.php` inside this plugin is
- * built by `npm run build:apps` into `assets/js/apps/<file>[.min].js`.
+ * An explicit `App::client( $path )` wins. Otherwise an app inside
+ * this plugin's own `apps/` is looked up by convention: `npm run
+ * build:apps` compiles `apps/<dir>/<file>.os.ts` into
+ * `assets/js/apps/<file>[.min].js`, and that bundle is what ships.
  *
  * @param array<string,mixed> $manifest Filtered manifest.
  * @return string Absolute path of the built script, or ''.
@@ -245,12 +246,62 @@ function openstation_apps_client_bundle( array $manifest ) {
 	if ( ! empty( $manifest['client'] ) ) {
 		return is_file( $manifest['client'] ) ? (string) $manifest['client'] : '';
 	}
-	if ( empty( $manifest['client_source'] ) ) {
+	$base = openstation_apps_client_base( $manifest );
+	if ( '' === $base ) {
 		return '';
 	}
-	$name  = preg_replace( '/\.os\.ts$/', '', basename( (string) $manifest['client_source'] ) );
-	$built = OPENSTATION_DIR . 'assets/js/apps/' . $name . openstation_asset_suffix() . '.js';
+	$built = OPENSTATION_DIR . 'assets/js/apps/' . $base . openstation_asset_suffix() . '.js';
 	return is_file( $built ) ? $built : '';
+}
+
+/**
+ * The name an app's by-convention client bundle is built under, or ''
+ * for an app that has no such bundle.
+ *
+ * The bundle is named after the definition file: `<file>.os.php` and
+ * `<file>.os.ts` share a base, and the build writes
+ * `assets/js/apps/<file>[.min].js`. So the name is read off the
+ * `.os.php`, the one file a release install is guaranteed to have.
+ * The `.os.ts` is source: `.gitattributes` export-ignores every `.ts`
+ * under `apps/`, and `bin/package.sh` splices the built bundle into
+ * the zip in its place. Keying the lookup on the source's presence is
+ * how every client-view window (Preferences, WP Explorer, Code Blue,
+ * the Recycle Bin) came to open empty on a packaged site: the host
+ * shipped `client: false`, and the runtime asked the server for a
+ * view those apps do not have.
+ *
+ * Only apps under this plugin's `apps/` qualify. That is the directory
+ * the build walks, and an app another plugin ships through
+ * `openstation_apps_directories` declares its bundle with
+ * `App::client()`: a shared file name must never hand it ours.
+ *
+ * @param array<string,mixed> $manifest Filtered manifest.
+ * @return string Bundle base name (`code-blue`), or ''.
+ */
+function openstation_apps_client_base( array $manifest ) {
+	$file = '';
+	foreach ( array( 'client_source', 'file' ) as $key ) {
+		if ( ! empty( $manifest[ $key ] ) && is_string( $manifest[ $key ] ) ) {
+			$file = $manifest[ $key ];
+			break;
+		}
+	}
+	if ( '' === $file ) {
+		return '';
+	}
+
+	$apps = realpath( OPENSTATION_DIR . 'apps' );
+	$dir  = realpath( dirname( $file ) );
+	if ( false === $apps || false === $dir ) {
+		return '';
+	}
+	$apps = trailingslashit( wp_normalize_path( $apps ) );
+	$dir  = trailingslashit( wp_normalize_path( $dir ) );
+	if ( 0 !== strpos( $dir, $apps ) ) {
+		return '';
+	}
+
+	return (string) preg_replace( '/\.os\.(php|ts)$/', '', basename( $file ) );
 }
 
 /**

--- a/tests/phpunit/tests/appFramework.php
+++ b/tests/phpunit/tests/appFramework.php
@@ -795,4 +795,108 @@ class Tests_OpenStation_AppFramework extends WP_UnitTestCase {
 		$this->assertSame( 'Demo', $whole['manifest']['title'] );
 		$this->assertStringContainsString( '<os-display value="9">', $whole['html'] );
 	}
+
+	// ---------------------------------------------------- client bundles
+
+	/**
+	 * The manifest names the definition file: the one thing about an
+	 * app's location a release install still has.
+	 *
+	 * @covers \OpenStation\App::manifest
+	 */
+	public function test_manifest_carries_the_definition_file() {
+		$this->assertSame( '', $this->demo_app()->manifest()['file'], 'Built in code: no file.' );
+
+		$dir = trailingslashit( get_temp_dir() ) . 'os-apps-' . wp_generate_password( 6, false );
+		mkdir( $dir );
+		$this->temp_paths[] = $dir;
+		file_put_contents( $dir . '/on-disk.os.php', '<?php return OpenStation\App::define( "on-disk-app" )->title( "Disk" )->view( static function () { echo "x"; } );' );
+		$this->temp_paths[] = $dir . '/on-disk.os.php';
+
+		$registry = new Registry();
+		$registry->load_dir( $dir );
+
+		$this->assertSame( realpath( $dir . '/on-disk.os.php' ), $registry->get( 'on-disk-app' )->manifest()['file'] );
+	}
+
+	/**
+	 * A release install ships no `.os.ts` (`.gitattributes` export-ignores
+	 * every `.ts` under `apps/`) but does ship the bundle `bin/package.sh`
+	 * splices in, so the bundle has to resolve from the `.os.php` alone.
+	 * This is the shape that broke Preferences, WP Explorer and Code Blue
+	 * on a packaged site: every client-view window opened empty, because
+	 * the host shipped `client: false` and the runtime asked the server
+	 * for a view the app does not have.
+	 *
+	 * @covers ::openstation_apps_client_bundle
+	 * @covers ::openstation_apps_client_base
+	 */
+	public function test_client_bundle_resolves_from_the_definition_file_when_the_source_is_absent() {
+		$file = realpath( OPENSTATION_DIR . 'apps/code-blue/code-blue.os.php' );
+		$this->assertNotFalse( $file );
+
+		$bundle = openstation_apps_client_bundle(
+			array(
+				'client'        => '',
+				'client_source' => '',
+				'file'          => $file,
+			)
+		);
+
+		// Real build output: CI runs `npm run build:apps` before PHPUnit.
+		$this->assertStringContainsString(
+			'assets/js/apps/code-blue',
+			wp_normalize_path( $bundle ),
+			'No built client view found — run `npm run build:apps` (or `npm run build`) first.'
+		);
+		$this->assertFileExists( $bundle );
+	}
+
+	/**
+	 * A checkout (with the source) and a release (without) resolve the
+	 * same bundle for every shipped app.
+	 *
+	 * @covers ::openstation_apps_client_bundle
+	 */
+	public function test_every_shipped_client_view_resolves_without_its_source() {
+		$checked = 0;
+		foreach ( openstation_apps_registry()->all() as $app ) {
+			$manifest = $app->manifest();
+			if ( '' === $manifest['client_source'] ) {
+				continue;
+			}
+			$with    = openstation_apps_client_bundle( $manifest );
+			$without = openstation_apps_client_bundle( array( 'client_source' => '' ) + $manifest );
+			$this->assertNotSame( '', $with, $app->id() . ': no built client view — run `npm run build:apps` first.' );
+			$this->assertSame( $with, $without, $app->id() . ': a release install must find the same bundle as a checkout.' );
+			++$checked;
+		}
+		$this->assertGreaterThan( 0, $checked, 'At least one shipped app has a client view.' );
+	}
+
+	/**
+	 * The by-convention bundle belongs to OpenStation's own `apps/`. An app
+	 * shipped from elsewhere declares its bundle with `App::client()` and
+	 * is never handed ours on the strength of a shared file name.
+	 *
+	 * @covers ::openstation_apps_client_base
+	 */
+	public function test_client_bundle_is_not_resolved_for_a_foreign_definition_file() {
+		$dir = trailingslashit( get_temp_dir() ) . 'os-apps-' . wp_generate_password( 6, false );
+		mkdir( $dir );
+		$this->temp_paths[] = $dir;
+		file_put_contents( $dir . '/code-blue.os.php', '<?php return OpenStation\App::define( "foreign-code-blue" )->title( "Foreign" )->view( static function () { echo "x"; } );' );
+		file_put_contents( $dir . '/code-blue.os.ts', '' );
+		$this->temp_paths[] = $dir . '/code-blue.os.php';
+		$this->temp_paths[] = $dir . '/code-blue.os.ts';
+
+		$registry = new Registry();
+		$registry->load_dir( $dir );
+		$manifest = $registry->get( 'foreign-code-blue' )->manifest();
+
+		$this->assertStringEndsWith( 'code-blue.os.ts', $manifest['client_source'], 'The source beside it is still reported.' );
+		$this->assertSame( '', openstation_apps_client_base( $manifest ) );
+		$this->assertSame( '', openstation_apps_client_bundle( $manifest ) );
+		$this->assertSame( '', openstation_apps_client_base( array( 'client' => '', 'client_source' => '', 'file' => '' ) ), 'Built in code: nothing to look up.' );
+	}
 }


### PR DESCRIPTION
## What it does

On a release install, OpenStation Preferences, WP Explorer, Code Blue and the Recycle Bin open again. Their windows were opening with an empty body: the host told the runtime the app had no client view (`client: false`), the runtime asked the server for a view those apps do not have, and nothing mounted.

## Rationale

The release zip is packaged correctly. `.gitattributes` export-ignores every `.ts` under `apps/`, and `bin/package.sh` splices the built `assets/js/apps/<name>.min.js` in instead. On the affected site all four bundles are present and served.

But `openstation_apps_client_bundle()` only looked for the bundle when the `.os.ts` source sat beside the `.os.php`:

```php
if ( empty( $manifest['client_source'] ) ) {
	return '';
}
$name  = preg_replace( '/\.os\.ts$/', '', basename( (string) $manifest['client_source'] ) );
```

`App::client_source()` returns `''` unless the file exists. No source on disk, no lookup, no client view. A git checkout always has the source, which is why local dev, CI and the test suite never showed it. It surfaced now because Preferences, WP Explorer and Code Blue only recently moved to the App Framework, so every packaged build since then has shipped blank client-view windows.

## Implementation

The bundle is resolved from the definition file instead. A new `openstation_apps_client_base()` in `includes/framework/wordpress.php` reads the name off the `.os.php` (or the `.os.ts`, same base, when it is there), and `openstation_apps_client_bundle()` resolves through it:

```php
$base  = openstation_apps_client_base( $manifest );
$built = OPENSTATION_DIR . 'assets/js/apps/' . $base . openstation_asset_suffix() . '.js';
return is_file( $built ) ? $built : '';
```

The by-convention lookup is restricted to apps under OpenStation's own `apps/` directory, compared through `realpath()` so a symlinked plugin directory still matches. That is the directory `npm run build:apps` walks. An app another plugin ships through `openstation_apps_directories` declares its bundle with `App::client()` and is never handed ours on the strength of a shared file name. Before this change a third-party `code-blue.os.ts` beside a third-party `code-blue.os.php` would have mapped to OpenStation's bundle; it no longer does.

`App::manifest()` gains `file`, the definition path, so the host has that fact on a release install. The Assets section of `docs/app-framework.md` now states the convention and that it never depends on the TypeScript shipping.

## Testing instructions

```bash
npm run test:php -- --filter='AppFramework|CodeBlue'
```

Four new tests in `Tests_OpenStation_AppFramework`: the manifest carries `file`; the bundle resolves from the `.os.php` with `client_source` blank; a foreign definition file with a `.os.ts` beside it stays unresolved; and a parity check that blanks every shipped app's `client_source` and asserts the same bundle resolves.

To rehearse the release layout, move the sources out of the tree and run the existing Code Blue host test, which asserts the window registers its client bundle:

```bash
mkdir -p /tmp/ts-aside && for f in apps/*/*.os.ts; do mv "$f" "/tmp/ts-aside/$(echo "$f" | tr / _)"; done
npm run test:php -- --filter='test_host_ships_the_client_view_with_the_window'
for f in /tmp/ts-aside/*; do mv "$f" "$(basename "$f" | tr _ /)"; done
```

On trunk the test fails with "No built client view found"; on this branch it passes.

On a packaged install (a zip from `bin/package.sh`), open Preferences, WP Explorer or the Recycle Bin: the body renders instead of staying blank.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-743-38005431d9fffea359bd1376a99ae131cce5994d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->