### PR TITLE
Code Blue: read the error without resizing, and a read-only skill that investigates it

### DIFF
--- a/apps/code-blue/code-blue.css
+++ b/apps/code-blue/code-blue.css
@@ -134,9 +134,17 @@
 	border-block-end: none;
 }
 
+/*
+ * The whole row is the control — an error list is scanned, and asking
+ * for a chevron would be asking for aim. It stays a `<button>`, which
+ * means the text inside it cannot be selected: every engine suppresses
+ * selection inside a form control. Copying is the detail panel's job
+ * instead, where the message and the trace are `<os-code copy>` and
+ * plain selectable markup rather than button content.
+ */
 .os-cb-issue__row {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	gap: 10px;
 	inline-size: 100%;
 	padding: 8px 12px;
@@ -163,6 +171,7 @@
 	gap: 6px;
 	flex: none;
 	inline-size: 150px;
+	min-block-size: 18px;
 	overflow: hidden;
 }
 
@@ -176,14 +185,20 @@
 	text-overflow: ellipsis;
 }
 
+/*
+ * The message wraps rather than ellipsising. A fatal error is
+ * routinely longer than any window anyone wants to open, and reading
+ * one should not cost a resize — the row grows by a line or two
+ * instead, which a list that scrolls can afford.
+ */
 .os-cb-issue__message {
 	flex: 1;
 	min-inline-size: 0;
 	font-family: var( --os-ui-font-mono, ui-monospace, Menlo, Consolas, monospace );
 	font-size: 12px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	line-height: 18px;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
 }
 
 .os-cb-issue__meta {
@@ -191,6 +206,7 @@
 	align-items: center;
 	gap: 10px;
 	flex: none;
+	min-block-size: 18px;
 	color: var( --os-ui-fg-muted, #646970 );
 	font-size: 12px;
 }
@@ -222,11 +238,34 @@
 	}
 }
 
+/*
+ * The origin badge outlives the file path at narrow widths: "which
+ * plugin" survives a resize that "which file" does not, and it is the
+ * more useful half of the pair when only one fits.
+ */
+@container ( max-width: 480px ) {
+	.os-cb-issue__origin {
+		display: none;
+	}
+}
+
 .os-cb-issue__detail {
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
 	padding: 4px 14px 14px 22px;
+}
+
+/*
+ * The message again, in full and with a copy button — the row above
+ * shows the same text, but that row is a `<button>`, so this is the
+ * only place a reader can take the error away with them. Everything in
+ * the detail panel is plain markup outside the control: selectable by
+ * drag, and copyable by button for the two things anyone ever copies.
+ */
+.os-cb-issue__full {
+	font-size: 12px;
+	--os-ui-code-block-max-block-size: 220px;
 }
 
 .os-cb-issue__facts {
@@ -235,6 +274,19 @@
 	gap: 2px 14px;
 	margin: 0;
 	font-size: 12px;
+	align-items: baseline;
+}
+
+/*
+ * The file path is a copy target too (it is what gets pasted into an
+ * editor), but it sits in a definition list, not a snippet box — so
+ * the badge chrome comes off and only the copy affordance stays.
+ */
+.os-cb-issue__facts os-code {
+	--os-ui-code-bg: transparent;
+	--os-ui-code-border: none;
+	--os-ui-code-padding: 0;
+	--os-ui-code-font-size: 1em;
 }
 
 .os-cb-issue__facts dt {
@@ -247,6 +299,26 @@
 	overflow-wrap: anywhere;
 }
 
+/*
+ * The two things anyone does with an error they cannot immediately
+ * fix: hand it to someone else, or go and look it up.
+ */
+.os-cb-issue__actions {
+	margin-block-start: 2px;
+}
+
+.os-cb-issue__search {
+	font-size: 12px;
+	align-self: center;
+	color: var( --os-ui-accent, #2271b1 );
+	text-decoration: none;
+}
+
+.os-cb-issue__search:hover,
+.os-cb-issue__search:focus-visible {
+	text-decoration: underline;
+}
+
 .os-cb-issue__times {
 	font-size: 11px;
 }
@@ -257,8 +329,7 @@
 
 .os-cb-issue__trace {
 	font-size: 11px;
-	max-block-size: 320px;
-	overflow: auto;
+	--os-ui-code-block-max-block-size: 320px;
 }
 
 /* ---------- Footer -------------------------------------------------- */

--- a/apps/code-blue/code-blue.os.php
+++ b/apps/code-blue/code-blue.os.php
@@ -136,6 +136,7 @@ return App::define( 'openstation-code-blue' )
 				'truncated'   => $read ? $read['truncated'] : false,
 				'readError'   => $read ? $read['error'] : '',
 				'now'         => time(),
+				'searchUrl'   => search_url( $os ),
 			);
 		}
 	);

--- a/apps/code-blue/code-blue.os.ts
+++ b/apps/code-blue/code-blue.os.ts
@@ -14,7 +14,7 @@
  * then the view. `code-blue.test.ts` exercises the model directly.
  */
 
-import { __, _n, defineApp, formatBytes, formatDate, html, sprintf } from '@openstation/app';
+import { __, _n, copyText, defineApp, formatBytes, formatDate, html, sprintf } from '@openstation/app';
 
 // ------------------------------------------------------------ types
 
@@ -33,6 +33,14 @@ export interface LogEntry {
 	line: number;
 	trace: string;
 	signature: string;
+	/** Whose code the file belongs to — classified server-side by `log-reader.php`. */
+	origin: Origin;
+}
+
+/** Whose code a file belongs to. `slug` is a directory name, not a plugin title. */
+export interface Origin {
+	kind: 'plugin' | 'mu-plugin' | 'theme' | 'core' | 'unknown';
+	slug: string;
 }
 
 interface LogSource {
@@ -72,6 +80,7 @@ interface Data {
 	truncated: boolean;
 	readError: string;
 	now: number;
+	searchUrl: string;
 }
 
 export interface IssueGroup {
@@ -87,6 +96,7 @@ export interface IssueGroup {
 	lastTs: number | null;
 	trace: string;
 	occurrences: number[];
+	origin: Origin;
 }
 
 // ------------------------------------------------------------ model
@@ -153,6 +163,7 @@ export function groupEntries( entries: readonly LogEntry[] ): IssueGroup[] {
 				lastTs: e.timestamp,
 				trace: e.trace,
 				occurrences: e.timestamp === null ? [] : [ e.timestamp ],
+				origin: e.origin ?? UNKNOWN_ORIGIN,
 			} );
 			continue;
 		}
@@ -165,6 +176,7 @@ export function groupEntries( entries: readonly LogEntry[] ): IssueGroup[] {
 		g.message = e.message;
 		g.file = e.file;
 		g.line = e.line;
+		g.origin = e.origin ?? UNKNOWN_ORIGIN;
 		if ( e.trace.length > g.trace.length ) {
 			g.trace = e.trace;
 		}
@@ -205,6 +217,8 @@ export function bucketize( entries: readonly LogEntry[], since: number | null, n
 	return { start, end, columns };
 }
 
+const UNKNOWN_ORIGIN: Origin = { kind: 'unknown', slug: '' };
+
 const rowKey = ( g: IssueGroup ): string => g.signature; // Signatures are already the stable identity.
 const envTone = ( on: boolean | null ): string => {
 	if ( on === null ) {
@@ -221,6 +235,52 @@ const emptyCopy = ( hasSource: boolean, filtered: boolean ): [ string, string ] 
 	}
 	return [ __( 'The log is clean' ), __( 'No entries were recorded in this time range.' ) ];
 };
+const originKindLabel = ( kind: Origin[ 'kind' ] ): string =>
+	( {
+		plugin: __( 'Plugin' ),
+		'mu-plugin': __( 'Must-use plugin' ),
+		theme: __( 'Theme' ),
+		core: __( 'WordPress core' ),
+		unknown: __( 'Unknown' ),
+	} )[ kind ];
+
+const originLabel = ( o: Origin ): string =>
+	o.slug === ''
+		? originKindLabel( o.kind )
+		: sprintf( /* translators: 1: origin kind, e.g. "Plugin". 2: directory slug, e.g. "woocommerce". */ __( '%1$s — %2$s' ), originKindLabel( o.kind ), o.slug );
+
+/**
+ * One issue as a paste-ready Markdown report — the thing that actually
+ * gets typed by hand into a GitHub issue or a support thread, assembled
+ * from what this window already knows: the message, where it came from,
+ * how often, and the environment it happened in. Copying an error
+ * without its PHP version and its debug flags is how a bug report
+ * becomes a conversation about what the reporter forgot to include.
+ */
+export function buildReport( g: IssueGroup, origin: Origin, environment: readonly EnvRow[] ): string {
+	const facts: string[] = [];
+	if ( g.file !== '' ) {
+		facts.push( `- **File:** \`${ g.line > 0 ? `${ g.file }:${ g.line }` : g.file }\`` );
+	}
+	if ( 'unknown' !== origin.kind ) {
+		facts.push( `- **Source:** ${ originLabel( origin ) }` );
+	}
+	facts.push( `- **Occurrences:** ${ g.count }` );
+	if ( g.firstTs !== null ) {
+		facts.push( `- **First seen:** ${ fullTime( g.firstTs ) }` );
+	}
+	if ( g.lastTs !== null ) {
+		facts.push( `- **Last seen:** ${ fullTime( g.lastTs ) }` );
+	}
+	facts.push( `- **Environment:** ${ environment.map( ( r ) => `${ r.label } ${ r.value }` ).join( ' · ' ) }` );
+
+	const blocks = [ `### ${ g.label }`, g.message, facts.join( '\n' ) ];
+	if ( g.trace !== '' ) {
+		blocks.push( `\`\`\`\n${ g.trace }\n\`\`\`` );
+	}
+	return `${ blocks.join( '\n\n' ) }\n`;
+}
+
 const fullTime = ( sec: number ): string => formatDate( sec * 1000, 'datetime' );
 const fileBase = ( path: string ): string => path.split( /[\\/]/ ).pop() || path;
 const iso = ( sec: number ): string => formatDate( sec * 1000, 'iso' );
@@ -238,7 +298,7 @@ export default defineApp< State, Data >( 'openstation-code-blue', {
 		},
 	},
 
-	view: ( { state, data } ) => {
+	view: ( { state, data, host } ) => {
 		const labels: Record< Bucket, string > = { error: __( 'Errors' ), warning: __( 'Warnings' ), deprecated: __( 'Deprecated' ), info: __( 'Info' ) };
 		const span = RANGE_SECONDS[ state.range ] ?? 86400;
 		const since = span > 0 ? data.now - span : null;
@@ -254,15 +314,25 @@ export default defineApp< State, Data >( 'openstation-code-blue', {
 		const clearDisabled = ! source || ( source.exists && ! source.writable );
 		const empty = emptyCopy( !! source, filtered );
 
+		const copyReport = ( g: IssueGroup, origin: Origin ) => {
+			void copyText( buildReport( g, origin, data.environment ) ).then( ( ok ) =>
+				host.toast?.( { message: ok ? __( 'Report copied to the clipboard.' ) : __( 'Copying the report failed.' ) } ),
+			);
+		};
+
 		const issue = ( g: IssueGroup ) => {
 			const key = rowKey( g );
 			const open = state.expanded.includes( key );
+			const origin = g.origin;
 			return html`
-				<li class="os-cb-issue" data-tone=${ TONES[ g.bucket ] }>
+				<li class="os-cb-issue" os-key=${ key } data-tone=${ TONES[ g.bucket ] }>
 					<button type="button" class="os-cb-issue__row" os-action="toggle" os-arg-key=${ key } aria-expanded=${ open ? 'true' : 'false' }>
 						<span class="os-cb-issue__level"><span class="os-cb-swatch" data-tone=${ TONES[ g.bucket ] }></span><span class="os-cb-issue__label">${ g.label }</span></span>
-						<span class="os-cb-issue__message" title=${ g.message }>${ g.message }</span>
+						<span class="os-cb-issue__message">${ g.message }</span>
 						<span class="os-cb-issue__meta">
+							${ 'unknown' !== origin.kind
+								? html`<os-badge no-dot tone="neutral" class="os-cb-issue__origin" title=${ originLabel( origin ) }>${ origin.slug !== '' ? origin.slug : originKindLabel( origin.kind ) }</os-badge>`
+								: '' }
 							${ g.file !== '' ? html`<span class="os-cb-issue__file">${ g.line > 0 ? `${ fileBase( g.file ) }:${ g.line }` : fileBase( g.file ) }</span>` : '' }
 							<os-badge no-dot>×${ g.count.toLocaleString() }</os-badge>
 							${ g.lastTs !== null ? html`<os-relative-time compact class="os-cb-issue__when" datetime=${ iso( g.lastTs ) }></os-relative-time>` : '' }
@@ -271,8 +341,10 @@ export default defineApp< State, Data >( 'openstation-code-blue', {
 					${ open
 						? html`
 							<div class="os-cb-issue__detail">
+								<os-code block copy wrap class="os-cb-issue__full">${ g.message }</os-code>
 								<dl class="os-cb-issue__facts">
-									${ g.file !== '' ? html`<dt>${ __( 'File' ) }</dt><dd>${ g.line > 0 ? `${ g.file }:${ g.line }` : g.file }</dd>` : '' }
+									${ g.file !== '' ? html`<dt>${ __( 'File' ) }</dt><dd><os-code copy wrap>${ g.line > 0 ? `${ g.file }:${ g.line }` : g.file }</os-code></dd>` : '' }
+									${ 'unknown' !== origin.kind ? html`<dt>${ __( 'Source' ) }</dt><dd>${ originLabel( origin ) }</dd>` : '' }
 									${ g.firstTs !== null ? html`<dt>${ __( 'First seen' ) }</dt><dd>${ fullTime( g.firstTs ) }</dd>` : '' }
 									${ g.lastTs !== null ? html`<dt>${ __( 'Last seen' ) }</dt><dd>${ fullTime( g.lastTs ) }</dd>` : '' }
 									<dt>${ __( 'Occurrences' ) }</dt><dd>${ g.count.toLocaleString() }</dd>
@@ -283,7 +355,14 @@ export default defineApp< State, Data >( 'openstation-code-blue', {
 										${ g.occurrences.slice( 0, 8 ).map( ( ts ) => html`<os-badge no-dot tone="neutral">${ fullTime( ts ) }</os-badge>` ) }
 									</os-cluster>`
 									: '' }
-								${ g.trace !== '' ? html`<os-code block class="os-cb-issue__trace">${ g.trace }</os-code>` : '' }
+								${ g.trace !== '' ? html`<os-code block copy wrap class="os-cb-issue__trace">${ g.trace }</os-code>` : '' }
+								<os-cluster gap="8" class="os-cb-issue__actions">
+									<os-button variant="secondary" @click=${ () => copyReport( g, origin ) }>${ __( 'Copy report' ) }</os-button>
+									${ data.searchUrl !== ''
+										? html`<a class="os-cb-issue__search" target="_blank" rel="noreferrer noopener"
+											href=${ data.searchUrl.replace( '%s', encodeURIComponent( g.message ) ) }>${ __( 'Search the web ↗' ) }</a>`
+										: '' }
+								</os-cluster>
 							</div>`
 						: '' }
 				</li>`;

--- a/apps/code-blue/code-blue.test.ts
+++ b/apps/code-blue/code-blue.test.ts
@@ -7,6 +7,7 @@ import { formatBytes } from '@openstation/app';
 import { mockViewContext } from '../../src/app-runtime/testing';
 import app, {
 	BUCKETS,
+	buildReport,
 	bucketOf,
 	bucketize,
 	countBuckets,
@@ -26,6 +27,7 @@ function entry( over: Partial< LogEntry > ): LogEntry {
 		line: 1,
 		trace: '',
 		signature: 'sig',
+		origin: { kind: 'unknown', slug: '' },
 		...over,
 	};
 }
@@ -86,6 +88,29 @@ describe( 'model', () => {
 		expect( bucketize( [ entry( { timestamp: null } ) ], null, now, 12 ).columns ).toEqual( [] );
 	} );
 
+	it( 'carries the server-classified origin onto the group', () => {
+		// Attribution is `log-reader.php`'s job (`Tests_OpenStation_CodeBlue`
+		// pins the classification); the client only has to keep it.
+		const woo = { kind: 'plugin', slug: 'woocommerce' } as const;
+		const groups = groupEntries( [
+			entry( { timestamp: 1, signature: 's', origin: woo } ),
+			entry( { timestamp: 2, signature: 's', origin: woo } ),
+		] );
+		expect( groups[ 0 ].origin ).toEqual( woo );
+	} );
+
+	it( 'builds a paste-ready report carrying the environment', () => {
+		const group = groupEntries( [ entry( { timestamp: 100, level: 'fatal', label: 'PHP Fatal error', message: 'Boom', trace: '#0 {main}' } ) ] )[ 0 ];
+		const report = buildReport( group, { kind: 'plugin', slug: 'woocommerce' }, [ { label: 'PHP', value: '8.3', on: null } ] );
+		expect( report ).toContain( '### PHP Fatal error' );
+		expect( report ).toContain( 'Boom' );
+		expect( report ).toContain( '- **File:** `/a.php:1`' );
+		expect( report ).toContain( '- **Source:** Plugin — woocommerce' );
+		expect( report ).toContain( '- **Occurrences:** 1' );
+		expect( report ).toContain( '- **Environment:** PHP 8.3' );
+		expect( report ).toContain( '```\n#0 {main}\n```' );
+	} );
+
 	it( 'formats bytes like the shell', () => {
 		expect( formatBytes( 563200 ) ).toBe( '550 KB' );
 		expect( formatBytes( 1024 * 1024 * 1.25 ) ).toBe( '1.3 MB' );
@@ -113,6 +138,7 @@ describe( 'app', () => {
 		truncated: false,
 		readError: '',
 		now: 100,
+		searchUrl: 'https://duckduckgo.com/?q=%s',
 	} );
 
 	it( 'declares the instant actions as local', () => {
@@ -134,10 +160,26 @@ describe( 'app', () => {
 		expect( root.querySelector( 'os-histogram' )?.getAttribute( 'hidden-series' ) ?? '' ).toBe( '' );
 		expect( root.querySelector( '.os-cb-issue__detail' ) ).toBeNull();
 
+		// The whole row is the toggle — an error list is scanned, so
+		// expanding must not ask for aim at a chevron.
+		const row = root.querySelector( '.os-cb-issue__row' )!;
+		expect( row.tagName ).toBe( 'BUTTON' );
+		expect( row.getAttribute( 'os-action' ) ).toBe( 'toggle' );
+
 		const stack = root.querySelector( 'os-stack' );
 		app.render( { ...ctx, state: { ...state(), expanded: [ 'n' ], hidden: [ 'warning' ] } } );
 		expect( root.querySelector( 'os-stack' ) ).toBe( stack );
 		expect( root.querySelector( '.os-cb-issue__detail' ) ).not.toBeNull();
 		expect( root.querySelector( 'os-histogram' )?.getAttribute( 'hidden-series' ) ).toBe( 'warning' );
+
+		// The detail is where the error can be taken away: the full
+		// message and the file path both carry a copy button, and
+		// neither sits inside the row's button.
+		const full = root.querySelector( '.os-cb-issue__full' )!;
+		expect( full.textContent ).toBe( 'Needle' );
+		expect( full.hasAttribute( 'copy' ) && full.hasAttribute( 'wrap' ) ).toBe( true );
+		expect( full.closest( 'button' ) ).toBeNull();
+		expect( root.querySelector( '.os-cb-issue__facts os-code' )?.textContent ).toBe( '/a.php:1' );
+		expect( root.querySelector< HTMLAnchorElement >( '.os-cb-issue__search' )?.href ).toBe( 'https://duckduckgo.com/?q=Needle' );
 	} );
 } );

--- a/apps/code-blue/log-reader.php
+++ b/apps/code-blue/log-reader.php
@@ -119,6 +119,57 @@ function make_entry( $timestamp, $level, $label, $message ) {
 }
 
 /**
+ * Whose code is this? The first question anyone asks of a log line,
+ * and the last one the log itself answers — the path is right there in
+ * every entry, and reading `wp-content/plugins/<slug>/` off it turns
+ * "some fatal error" into "WooCommerce's fatal error", which is the
+ * difference between triage and archaeology.
+ *
+ * Deliberately conservative: a path that is not clearly under the
+ * content directory or clearly inside core answers `unknown` rather
+ * than guessing, because a wrong attribution sends someone into the
+ * wrong codebase. Single-file plugins and mu-plugins keep their
+ * basename as the slug; there is no directory to name them by.
+ *
+ * This is the ONLY implementation. The window renders what it returns
+ * and the debugging abilities report it verbatim — a second copy of
+ * this classification would let the two disagree about whose bug it is.
+ *
+ * @param string $file        Absolute path from a log entry, may be ''.
+ * @param string $content_dir The install's `wp-content` equivalent.
+ * @return array{kind:string,slug:string} `kind` is one of `plugin`,
+ *                                        `mu-plugin`, `theme`, `core`, `unknown`.
+ */
+function origin( $file, $content_dir ) {
+	$path    = str_replace( '\\', '/', (string) $file );
+	$content = rtrim( str_replace( '\\', '/', (string) $content_dir ), '/' );
+	if ( '' !== $content && 0 === strpos( $path, $content . '/' ) ) {
+		$rest = substr( $path, strlen( $content ) + 1 );
+		if ( preg_match( '#^(plugins|mu-plugins|themes)/([^/]+)#', $rest, $m ) ) {
+			$kinds = array(
+				'plugins'    => 'plugin',
+				'mu-plugins' => 'mu-plugin',
+				'themes'     => 'theme',
+			);
+			return array(
+				'kind' => $kinds[ $m[1] ],
+				'slug' => preg_replace( '/\.php$/', '', $m[2] ),
+			);
+		}
+	}
+	if ( preg_match( '#/wp-(admin|includes)/#', $path ) ) {
+		return array(
+			'kind' => 'core',
+			'slug' => '',
+		);
+	}
+	return array(
+		'kind' => 'unknown',
+		'slug' => '',
+	);
+}
+
+/**
  * Parse `22-Aug-2026 09:14:02 UTC` (or the same without a zone,
  * read as UTC).
  *
@@ -380,6 +431,14 @@ function read( Os $os, array $source ) {
 	 * @param string  $raw     The scanned tail.
 	 */
 	$entries = (array) $os->filter( 'openstation_code_blue_entries', parse( $tail['raw'] ), $source, $tail['raw'] );
+
+	// Attribution runs AFTER the filter so entries a plugin's own parser
+	// contributed are attributed too — `parse()` never sees them.
+	$content_dir = $os->env->content_dir();
+	foreach ( $entries as $index => $entry ) {
+		$entries[ $index ]['origin'] = origin( isset( $entry['file'] ) ? $entry['file'] : '', $content_dir );
+	}
+
 	$dropped = max( 0, count( $entries ) - $max_entries );
 	if ( $dropped > 0 ) {
 		$entries = array_slice( $entries, -$max_entries );
@@ -421,6 +480,28 @@ function clear( Os $os, array $source ) {
 	 */
 	$os->action( 'openstation_code_blue_log_cleared', $source['id'], $source['path'] );
 	return true;
+}
+
+/**
+ * The URL template the "Search the web" link on an issue resolves
+ * against — `%s` is the URL-encoded message. Looking an unfamiliar
+ * error up is the next thing anyone does after reading it, and where
+ * they look is a house style: an agency may want its own wiki, a
+ * hosting platform its own knowledge base.
+ *
+ * Return an empty string to drop the link entirely.
+ *
+ * @param Os $os Host handle.
+ * @return string URL template containing `%s`, or '' for no link.
+ */
+function search_url( Os $os ) {
+	/**
+	 * Filter the search URL template for a log message.
+	 *
+	 * @param string $template `%s` is replaced with the URL-encoded
+	 *                         message. Empty string hides the link.
+	 */
+	return (string) $os->filter( 'openstation_code_blue_search_url', 'https://duckduckgo.com/?q=%s' );
 }
 
 /**

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -185,7 +185,7 @@ you relabel the host, e.g. Maximize ⇄ Restore.
 | `<os-ribbon>` | `OsRibbon` | `os-ribbon/os-ribbon.ts` | Corner ribbon for tiles. |
 | `<os-chip>` | `OsChip` | `os-chip/os-chip.ts` | Tag/category chip with tone. |
 | `<os-key>` | `OsKey` | `os-key/os-key.ts` | Keyboard shortcut display. |
-| `<os-code>` | `OsCode` | `os-code/os-code.ts` | Inline / block monospace code with copy. |
+| `<os-code>` | `OsCode` | `os-code/os-code.ts` | Inline / block monospace code with copy; `wrap` folds long lines instead of scrolling them sideways. |
 | `<os-spinner>` | `OsSpinner` | `os-spinner/os-spinner.ts` | Loading spinner with preset variants; `preset="inline"` is a bare arc for text-adjacent use. |
 | `<os-progress-bar>` | `OsProgressBar` | `os-progress-bar/os-progress-bar.ts` | Determinate or indeterminate progress. |
 | `<os-save-status>` | `OsSaveStatus` | `os-save-status/os-save-status.ts` | Save indicator (idle / saving / saved / failed). `variant="ring"` is the window title bar's status ring: outline for every phase but success, which fills. |

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -520,7 +520,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'home-assistant-commands' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_command_script( 'home-assistant-commands' );
 ```
 
@@ -567,7 +567,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'my-plugin-titlebar' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_titlebar_button_script( 'my-plugin-titlebar' );
 ```
 
@@ -597,7 +597,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'my-plugin-window-actions' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_window_action_script( 'my-plugin-window-actions' );
 ```
 
@@ -627,7 +627,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'my-plugin-effects' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_unfocus_effect_script( 'my-plugin-effects' );
 ```
 
@@ -818,7 +818,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'my-plugin-link-renderer' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_window_link_renderer_script( 'my-plugin-link-renderer' );
 ```
 
@@ -858,7 +858,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'my-plugin-settings' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_settings_tab_script( 'my-plugin-settings' );
 ```
 
@@ -920,7 +920,7 @@ add_action( 'admin_enqueue_scripts', function () {
         true
     );
     wp_enqueue_script( 'my-plugin-rail' );
-} );
+}, 5 ); // Before the shell harvests the payload at priority 10.
 openstation_register_dock_rail_renderer_script( 'my-plugin-rail' );
 ```
 
@@ -2498,6 +2498,25 @@ On an ability-execution failure the payload is `{ stage: 'tool_execute', tool_na
 The Copilot's tools are [WordPress Abilities](https://developer.wordpress.org/apis/abilities-api/) — its own search/navigation abilities (`search_posts`, `search_comments`, `list_admin_pages`, …) plus **any read-only ability registered on the site** (Core's, or another plugin's), listed at `GET /wp-abilities/v1/abilities`. To give the assistant a new tool, just register a read-only ability with `wp_register_ability()` on `wp_abilities_api_init` — no opt-in step. The agent loop advertises every read-only ability and dispatches calls through `wp_get_ability()->execute()`, so its `permission_callback` and input/output schemas are enforced by Core.
 
 Only read-only abilities are offered on purpose: a search turn can be steered by attacker-controlled content (comment / post text in a tool result), so the model is never handed an ability that can change the site. See [`examples/ai-ask.md`](examples/ai-ask.md) for a full ability recipe.
+
+---
+
+### The error-investigation skill — Experimental
+
+Four abilities (`includes/ai-copilot/abilities-debugging.php`) that give an assistant — or an agent — enough to do what a developer does with a stack trace, plus a system-prompt appendix that turns them into a method. They read through Code Blue's own log model, so the assistant and the window can never disagree about what the log says or whose plugin a file belongs to.
+
+| Ability | Model-facing name | Returns |
+|---|---|---|
+| `desktop-mode/list-log-issues` | `list_log_issues` | The log parsed into **distinct issues** rather than raw lines — a fatal that fired 400 times is one entry with `count: 400`. Each carries `signature` (the id for the next call), severity, message, `file`/`line`, and `origin` (`{ kind, slug, name, version }` — whose plugin, theme or core it is). No traces: the list is triage. |
+| `desktop-mode/get-log-issue` | `get_log_issue` | One issue by `signature`, stack trace included. |
+| `desktop-mode/read-source-excerpt` | `read_source_excerpt` | Numbered source lines around a line the log named. |
+| `desktop-mode/get-site-context` | `get_site_context` | WordPress and PHP versions, debug constants, environment type, active theme, every active plugin with its version. No credentials. |
+
+**The skill proposes; it never repairs.** That is structural rather than a matter of prompting: all four are `readonly` and no writing counterpart exists, so a model handed the whole set can read the evidence and describe a patch and has no route to apply one. The prompt appendix says so in words too, because a model that does not know it cannot edit files tends to answer as though it had.
+
+**Gating.** The skill uses Code Blue's own gate — site management plus Developer mode, moved by [`openstation_code_blue_user_can_use`](#openstation_code_blue_user_can_use--experimental-filter). A user who cannot open the log window cannot read the log through an assistant either, and one filter moves both. None of the four is `mcp.public`: this site's log and source are not an external agent's business.
+
+**`read_source_excerpt` is the one to read carefully before changing.** It refuses (as errors, not empty results) any path the *current log* does not name, anything resolving outside the install (`realpath()` before the prefix test), any non-source extension, and `wp-config.php` / `.env` outright — a parse error inside `wp-config.php` does name it, and that file is the database password. Bounding reads to files the install already wrote into its own error log is what keeps this a debugging tool rather than a general file reader reachable through whatever text the model happens to be reading. `tests/phpunit/tests/aiDebuggingAbilities.php` pins every refusal; read [`agents-security.md`](./agents-security.md) before widening any of them.
 
 ---
 
@@ -4280,6 +4299,20 @@ apply_filters( 'openstation_code_blue_environment', array[] $rows ): array[]
 ```
 
 The environment rows shown as badges in the window. Each: `label`, `value` (string), `on` (bool renders an on/off tone, null renders neutral).
+
+### `openstation_code_blue_search_url` — Experimental (filter)
+
+```php
+apply_filters( 'openstation_code_blue_search_url', string $template ): string
+```
+
+The URL template behind the **Search the web** link on an expanded issue — `%s` is replaced with the URL-encoded message. Default `https://duckduckgo.com/?q=%s`. Point it at an internal wiki, a hosting knowledge base, or a support desk; return an empty string to drop the link entirely.
+
+```php
+add_filter( 'openstation_code_blue_search_url', function () {
+    return 'https://wiki.example.com/search?q=%s';
+} );
+```
 
 ### `openstation_code_blue_max_bytes` / `openstation_code_blue_max_entries` — Experimental (filter)
 

--- a/extensions/openstation-beta/includes/settings-tab.php
+++ b/extensions/openstation-beta/includes/settings-tab.php
@@ -27,6 +27,12 @@ function openstation_beta_register_settings_tab() {
 	if ( ! function_exists( 'openstation_register_settings_tab' ) ) {
 		return;
 	}
+	// The tab and its script answer to the same capability. Declaring
+	// the tab for a user who will never get the script leaves the
+	// shell's payload builder looking for a handle nobody registered.
+	if ( ! current_user_can( 'update_plugins' ) ) {
+		return;
+	}
 	openstation_register_settings_tab(
 		array(
 			'id'         => 'beta',
@@ -49,12 +55,10 @@ function openstation_beta_shell_assets() {
 	if ( ! function_exists( 'openstation_is_enabled' ) || ! openstation_is_enabled() ) {
 		return;
 	}
-	if ( function_exists( 'openstation_is_chromeless_request' ) && openstation_is_chromeless_request() ) {
-		return;
-	}
 	if ( ! current_user_can( 'update_plugins' ) ) {
 		return;
 	}
+
 	wp_register_script(
 		'openstation-beta-settings',
 		OPENSTATION_BETA_URL . 'assets/beta.js',
@@ -63,6 +67,26 @@ function openstation_beta_shell_assets() {
 		true
 	);
 	wp_localize_script( 'openstation-beta-settings', 'openStationBetaConfig', openstation_beta_script_config( 'shell' ) );
+
+	// Inside a chromeless iframe the tab has no shell to render into,
+	// so the script is never ENQUEUED here — but it stays REGISTERED,
+	// because this is also where OpenStation harvests the settings-tab
+	// payload it posts up to the parent after a plugin is activated.
+	// An unregistered handle resolves to an empty URL there: the tab is
+	// dropped from that payload (so activating anything from inside a
+	// window took the Beta tab away until the next reload) and
+	// `openstation_register_settings_tab_script()` reports the missing
+	// registration through `_doing_it_wrong()`.
+	if ( function_exists( 'openstation_is_chromeless_request' ) && openstation_is_chromeless_request() ) {
+		return;
+	}
+
 	wp_enqueue_script( 'openstation-beta-settings' );
 }
-add_action( 'admin_enqueue_scripts', 'openstation_beta_shell_assets' );
+// Priority 5, not the default 10: OpenStation harvests the settings-tab
+// payload from `openstation_enqueue_assets()` at priority 10, and a
+// handle registered after the harvest is a handle the harvest could not
+// resolve — an empty `scriptUrl` in the payload and a `_doing_it_wrong()`
+// notice naming this file's handle. Same contract the lazy native-window
+// config follows (`Tests_OpenStation_LazyWindowConfigPriority`).
+add_action( 'admin_enqueue_scripts', 'openstation_beta_shell_assets', 5 );

--- a/includes/ai-copilot/abilities-debugging.php
+++ b/includes/ai-copilot/abilities-debugging.php
@@ -1,0 +1,778 @@
+<?php
+/**
+ * OpenStation — the error-investigation skill.
+ *
+ * Four read-only WordPress Abilities that together give an assistant or
+ * an agent enough to do what a developer does with a stack trace: find
+ * out what is failing, read the code at the line that failed, learn
+ * whose code it is and what version of everything it is running on —
+ * and then say what it thinks the fix is.
+ *
+ *   list_log_issues      what is failing, grouped and counted
+ *   get_log_issue        one issue in full, with its stack trace
+ *   read_source_excerpt  the code around a line the log named
+ *   get_site_context     versions, debug flags, active plugins + theme
+ *
+ * **The skill proposes; it never repairs.** That is structural, not a
+ * matter of prompting: every ability here is `readonly`, and no writing
+ * counterpart exists, so a model handed this whole set can read the
+ * evidence and describe a patch and has no route to apply one. The
+ * prompt appendix below says the same thing in words, because a model
+ * that does not know it cannot edit files tends to answer as though it
+ * already had.
+ *
+ * All four read through Code Blue's own model (`log-reader.php`), so
+ * the assistant and the window can never disagree about what the log
+ * says or whose plugin a file belongs to.
+ *
+ * Read `docs/agents-security.md` before adding to this file. The
+ * dangerous one is `read_source_excerpt` — see the guards on
+ * {@see openstation_ai_debug_resolve_source_path()}.
+ *
+ * @package OpenStation
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use function OpenStation\Apps\CodeBlue\can_use;
+use function OpenStation\Apps\CodeBlue\read as read_log;
+use function OpenStation\Apps\CodeBlue\sources as log_sources;
+use function OpenStation\Apps\CodeBlue\usable as log_usable;
+
+/** Longest excerpt `read_source_excerpt` will return, in lines. */
+const OPENSTATION_AI_DEBUG_MAX_EXCERPT = 200;
+
+/**
+ * Who may use the debugging skill: whoever may open Code Blue.
+ *
+ * Deliberately the same gate rather than a new one. These abilities are
+ * the window's contents addressed by an assistant instead of a pointer,
+ * and a site where the log window is off is a site that has said it
+ * does not want its error log read — through the UI or otherwise.
+ * `openstation_code_blue_user_can_use` moves both at once.
+ *
+ * @return bool
+ */
+function openstation_ai_debug_can_use() {
+	if ( ! function_exists( 'openstation_apps_os' ) ) {
+		return false;
+	}
+	return can_use( openstation_apps_os() );
+}
+
+/**
+ * Every parsed entry from a log source, newest first.
+ *
+ * @param string $source_id Source id, or '' for the first usable one.
+ * @return array{source:array<string,mixed>|null,entries:array[],error:string}
+ */
+function openstation_ai_debug_entries( $source_id = '' ) {
+	$os      = openstation_apps_os();
+	$sources = log_sources( $os );
+	$source  = null;
+	foreach ( $sources as $candidate ) {
+		if ( ! log_usable( $candidate ) ) {
+			continue;
+		}
+		if ( '' === $source_id || $candidate['id'] === $source_id ) {
+			$source = $candidate;
+			break;
+		}
+	}
+	if ( null === $source ) {
+		return array(
+			'source'  => null,
+			'entries' => array(),
+			'error'   => '' === $source_id
+				? __( 'No readable log file was found on this install.', 'desktop-mode' )
+				: __( 'No readable log file matches that source id.', 'desktop-mode' ),
+		);
+	}
+
+	$read = read_log( $os, $source );
+	return array(
+		'source'  => $source,
+		'entries' => array_reverse( $read['entries'] ),
+		'error'   => (string) $read['error'],
+	);
+}
+
+/**
+ * Fold entries into issues by signature — same key the window groups
+ * on, computed once in `log-reader.php`, so an issue the assistant
+ * names is the issue the user is looking at.
+ *
+ * This is not the window's `groupEntries()`: that one folds what
+ * survived the user's range and search filters, in the browser, and
+ * exists so those filters cost nothing. This one folds the whole read.
+ *
+ * @param array[] $entries Parsed entries.
+ * @param int     $since   Unix seconds floor, or 0 for no floor.
+ * @return array[] Issues, most recent first.
+ */
+function openstation_ai_debug_group( array $entries, $since = 0 ) {
+	$issues = array();
+	foreach ( $entries as $entry ) {
+		$stamp = isset( $entry['timestamp'] ) ? $entry['timestamp'] : null;
+		if ( $since > 0 && ( null === $stamp || $stamp < $since ) ) {
+			continue;
+		}
+		$key = (string) $entry['signature'];
+		if ( ! isset( $issues[ $key ] ) ) {
+			$issues[ $key ] = array(
+				'signature'  => $key,
+				'level'      => (string) $entry['level'],
+				'label'      => (string) $entry['label'],
+				'message'    => (string) $entry['message'],
+				'file'       => (string) $entry['file'],
+				'line'       => (int) $entry['line'],
+				'origin'     => isset( $entry['origin'] ) ? $entry['origin'] : array(
+					'kind' => 'unknown',
+					'slug' => '',
+				),
+				'count'      => 0,
+				'first_seen' => $stamp,
+				'last_seen'  => $stamp,
+				'trace'      => (string) $entry['trace'],
+			);
+		}
+		$issue = &$issues[ $key ];
+		++$issue['count'];
+		// The longest trace wins: a fatal is logged repeatedly and only
+		// some occurrences carry the full frame list.
+		if ( strlen( (string) $entry['trace'] ) > strlen( $issue['trace'] ) ) {
+			$issue['trace'] = (string) $entry['trace'];
+		}
+		if ( null !== $stamp ) {
+			$issue['first_seen'] = null === $issue['first_seen'] ? $stamp : min( $issue['first_seen'], $stamp );
+			$issue['last_seen']  = null === $issue['last_seen'] ? $stamp : max( $issue['last_seen'], $stamp );
+		}
+		unset( $issue );
+	}
+	return array_values( $issues );
+}
+
+/**
+ * Attach the human name behind an origin slug — "woocommerce" is what
+ * the path says, "WooCommerce 9.4.2" is what the developer knows it
+ * as, and the version is half of every compatibility answer.
+ *
+ * Lives here rather than in the app because resolving it needs
+ * WordPress; `log-reader.php` runs on hosts that have no `get_plugins()`.
+ *
+ * @param array<string,string> $origin `kind` + `slug` from the log model.
+ * @return array<string,string> The same, plus `name` and `version` when known.
+ */
+function openstation_ai_debug_name_origin( array $origin ) {
+	$origin += array(
+		'kind' => 'unknown',
+		'slug' => '',
+	);
+	$origin['name']    = '';
+	$origin['version'] = '';
+
+	if ( 'core' === $origin['kind'] ) {
+		$origin['name']    = 'WordPress';
+		$origin['version'] = (string) get_bloginfo( 'version' );
+		return $origin;
+	}
+	if ( '' === $origin['slug'] ) {
+		return $origin;
+	}
+
+	if ( 'theme' === $origin['kind'] ) {
+		$theme = wp_get_theme( $origin['slug'] );
+		if ( $theme->exists() ) {
+			$origin['name']    = (string) $theme->get( 'Name' );
+			$origin['version'] = (string) $theme->get( 'Version' );
+		}
+		return $origin;
+	}
+
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$plugins = 'mu-plugin' === $origin['kind'] ? get_mu_plugins() : get_plugins();
+	foreach ( $plugins as $file => $data ) {
+		$slug = false === strpos( $file, '/' ) ? preg_replace( '/\.php$/', '', $file ) : dirname( $file );
+		if ( $slug === $origin['slug'] ) {
+			$origin['name']    = (string) $data['Name'];
+			$origin['version'] = (string) $data['Version'];
+			break;
+		}
+	}
+	return $origin;
+}
+
+/**
+ * Every file path the current log names — in an entry's `file` field or
+ * anywhere inside a stack trace.
+ *
+ * This set is the allowlist `read_source_excerpt` resolves against, and
+ * it is the guard that matters. Bounding source reads to "files this
+ * install has already written into its own error log" means the
+ * ability can never widen what the caller can see: a path only enters
+ * the set because something already failed there, and the log itself
+ * is readable to exactly the same people. An ability that took any
+ * path under ABSPATH would instead be a general file-read tool wearing
+ * a debugging label — reachable, through the assistant, by whatever
+ * text the model happens to be reading.
+ *
+ * @param array[] $entries Parsed entries.
+ * @return array<string,true> Paths as keys.
+ */
+function openstation_ai_debug_known_paths( array $entries ) {
+	$paths = array();
+	foreach ( $entries as $entry ) {
+		if ( ! empty( $entry['file'] ) ) {
+			$paths[ str_replace( '\\', '/', (string) $entry['file'] ) ] = true;
+		}
+		if ( empty( $entry['trace'] ) ) {
+			continue;
+		}
+		// Stack-trace frames: `#0 /abs/path/file.php(123): fn()`, and
+		// the `thrown in /abs/path` tail.
+		if ( preg_match_all( '#(/[^\s:()\'"]+\.(?:php|inc))#', (string) $entry['trace'], $found ) ) {
+			foreach ( $found[1] as $path ) {
+				$paths[ $path ] = true;
+			}
+		}
+	}
+	return $paths;
+}
+
+/**
+ * Resolve a requested source path, or explain why not.
+ *
+ * Four gates, in order of what each one closes:
+ *
+ *   1. The path must be one the current log names — see
+ *      {@see openstation_ai_debug_known_paths()}. This is the real
+ *      boundary; the rest are belt and braces for the day someone
+ *      relaxes it.
+ *   2. It must resolve (symlinks included) inside the WordPress root
+ *      or the content directory. `realpath()` before the prefix test,
+ *      so `../` cannot walk out.
+ *   3. It must be a source file by extension. A log can name a `.log`
+ *      or a `.sql`; those are data, and data is where secrets live.
+ *   4. Configuration is refused outright even when the log names it —
+ *      and a fatal inside `wp-config.php` does name it. That file is
+ *      the database password, the salts and the keys; nobody debugging
+ *      a stack trace needs it echoed back through a language model.
+ *
+ * @param string             $file    Requested absolute path.
+ * @param array<string,true> $allowed Paths the log names.
+ * @return string|WP_Error Real path, or the reason it was refused.
+ */
+function openstation_ai_debug_resolve_source_path( $file, array $allowed ) {
+	$requested = str_replace( '\\', '/', (string) $file );
+	if ( ! isset( $allowed[ $requested ] ) ) {
+		return new WP_Error(
+			'openstation_ai_debug_unknown_file',
+			__( 'That file is not named anywhere in the current log. Only files an entry or a stack trace mentions can be read.', 'desktop-mode' )
+		);
+	}
+
+	$real = realpath( $requested );
+	if ( false === $real || ! is_file( $real ) || ! is_readable( $real ) ) {
+		return new WP_Error( 'openstation_ai_debug_unreadable', __( 'That file does not exist on disk or cannot be read.', 'desktop-mode' ) );
+	}
+	$real = str_replace( '\\', '/', $real );
+
+	$roots = array( realpath( ABSPATH ), realpath( WP_CONTENT_DIR ) );
+	$in    = false;
+	foreach ( $roots as $root ) {
+		if ( false !== $root && 0 === strpos( $real, rtrim( str_replace( '\\', '/', $root ), '/' ) . '/' ) ) {
+			$in = true;
+			break;
+		}
+	}
+	if ( ! $in ) {
+		return new WP_Error( 'openstation_ai_debug_outside_root', __( 'That file lives outside the WordPress installation.', 'desktop-mode' ) );
+	}
+
+	if ( ! preg_match( '/\.(php|inc|js|jsx|ts|tsx|css|scss)$/i', $real ) ) {
+		return new WP_Error( 'openstation_ai_debug_not_source', __( 'Only source files can be read — not logs, dumps, or data files.', 'desktop-mode' ) );
+	}
+
+	$base = strtolower( basename( $real ) );
+	if ( in_array( $base, array( 'wp-config.php', 'wp-config-sample.php' ), true ) || preg_match( '/^\.env/', $base ) ) {
+		return new WP_Error(
+			'openstation_ai_debug_secret_file',
+			__( 'Configuration files are never readable through this tool — they hold database credentials and salts. Describe what you need from it instead.', 'desktop-mode' )
+		);
+	}
+
+	return $real;
+}
+
+/**
+ * Read `$context` lines either side of `$line`.
+ *
+ * @param string $path    Resolved real path.
+ * @param int    $line    Centre line, 1-based; 0 reads from the top.
+ * @param int    $context Lines either side.
+ * @return array<string,mixed>
+ */
+function openstation_ai_debug_excerpt( $path, $line, $context ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file -- Reading a source file already resolved and allowlisted above; WP_Filesystem adds nothing here and is not available this early on every host.
+	$all = file( $path, FILE_IGNORE_NEW_LINES );
+	if ( false === $all ) {
+		return array(
+			'file'  => $path,
+			'lines' => array(),
+			'error' => __( 'The file could not be read.', 'desktop-mode' ),
+		);
+	}
+
+	$total = count( $all );
+	$line  = max( 0, min( (int) $line, $total ) );
+	$start = $line > 0 ? max( 1, $line - $context ) : 1;
+	$end   = $line > 0 ? min( $total, $line + $context ) : min( $total, OPENSTATION_AI_DEBUG_MAX_EXCERPT );
+
+	$lines = array();
+	for ( $n = $start; $n <= $end; $n++ ) {
+		$lines[] = array(
+			'number' => $n,
+			'text'   => $all[ $n - 1 ],
+		);
+	}
+
+	return array(
+		'file'        => $path,
+		'total_lines' => $total,
+		'start_line'  => $start,
+		'end_line'    => $end,
+		'lines'       => $lines,
+		'error'       => '',
+	);
+}
+
+/**
+ * Registers the debugging abilities.
+ *
+ * @return void
+ */
+function openstation_ai_register_debug_abilities() {
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		return;
+	}
+
+	// Never `mcp.public`: the log and the source behind it are this
+	// site's internals, and an external agent has no business in them
+	// however read-only the tools are.
+	$meta = array(
+		'annotations'  => array(
+			'readonly'   => true,
+			'idempotent' => true,
+		),
+		'show_in_rest' => true,
+	);
+
+	wp_register_ability(
+		'desktop-mode/list-log-issues',
+		array(
+			'label'               => __( 'List error-log issues', 'desktop-mode' ),
+			'description'         => 'Lists what is currently failing on this site: the PHP error log parsed into DISTINCT issues rather than raw lines, so a fatal that fired 400 times is one entry with count 400. Start every debugging investigation here. Each issue carries { signature, level, label, message, file, line, count, first_seen, last_seen, origin } where `origin` says whose code it is ({ kind: plugin|mu-plugin|theme|core|unknown, slug, name, version }) and `signature` is the id you pass to get_log_issue and quote back to the user. Stack traces are NOT included — call get_log_issue for the one you are working on. Administrators with Developer mode on only.',
+			'category'            => OPENSTATION_AI_ABILITY_CATEGORY,
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'required'             => array( 'limit' ),
+				'properties'           => array(
+					'limit'  => array(
+						'type'        => 'integer',
+						'description' => 'How many issues to return, most recently seen first (1-50). Use 10 unless the user asked for a survey.',
+					),
+					'range'  => array(
+						'type'        => 'string',
+						'enum'        => array( '1h', '24h', '7d', '30d', 'all' ),
+						'description' => 'How far back to look. Defaults to `all`. Narrow it when the user says "since I updated" or "today".',
+					),
+					'source' => array(
+						'type'        => 'string',
+						'description' => 'Log source id. Omit for the first readable one, which is what the user sees by default.',
+					),
+					'level'  => array(
+						'type'        => 'string',
+						'enum'        => array( 'fatal', 'error', 'warning', 'deprecated', 'notice', 'info' ),
+						'description' => 'Only issues at this severity. Omit for all. `fatal` is what breaks a site; `deprecated` is usually noise.',
+					),
+				),
+			),
+			'output_schema'       => openstation_ai_ability_output_schema(
+				array(
+					'issues'  => array(
+						'type'        => 'array',
+						'description' => 'Grouped issues, most recently seen first.',
+					),
+					'count'   => array( 'type' => 'integer' ),
+					'source'  => array(
+						'type'        => 'object',
+						'description' => 'The log that was read: { id, label, path, size }.',
+					),
+					'message' => array(
+						'type'        => 'string',
+						'description' => 'Set when no log could be read — explain it to the user rather than guessing.',
+					),
+				)
+			),
+			'execute_callback'    => 'openstation_ai_debug_list_issues',
+			'permission_callback' => 'openstation_ai_debug_can_use',
+			'meta'                => $meta,
+		)
+	);
+
+	wp_register_ability(
+		'desktop-mode/get-log-issue',
+		array(
+			'label'               => __( 'Get one error-log issue', 'desktop-mode' ),
+			'description'         => 'Returns ONE issue from the error log in full, including its stack trace, by the `signature` you got from list_log_issues. Call this on the issue you are actually investigating — the trace names the file and line where the failure started and the chain of calls that reached it, which is what you read the source at. The trace is verbatim server output: paths in it are real paths you may pass to read_source_excerpt.',
+			'category'            => OPENSTATION_AI_ABILITY_CATEGORY,
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'required'             => array( 'signature' ),
+				'properties'           => array(
+					'signature' => array(
+						'type'        => 'string',
+						'description' => 'The issue id from a prior list_log_issues call. Pass it exactly as given.',
+					),
+					'source'    => array(
+						'type'        => 'string',
+						'description' => 'Log source id, if you passed one to list_log_issues.',
+					),
+				),
+			),
+			'output_schema'       => openstation_ai_ability_output_schema(
+				array(
+					'issue'   => array(
+						'type'        => 'object',
+						'description' => 'The issue with its `trace`, or absent when the signature is unknown.',
+					),
+					'message' => array( 'type' => 'string' ),
+				)
+			),
+			'execute_callback'    => 'openstation_ai_debug_get_issue',
+			'permission_callback' => 'openstation_ai_debug_can_use',
+			'meta'                => $meta,
+		)
+	);
+
+	wp_register_ability(
+		'desktop-mode/read-source-excerpt',
+		array(
+			'label'               => __( 'Read source around a logged line', 'desktop-mode' ),
+			'description'         => 'Reads the PHP (or JS/CSS) source around a line the error log named, so you can see the code that failed instead of guessing at it. Pass a `file` path and `line` taken from an issue or from its stack trace. Returns numbered lines so you can quote them precisely. IMPORTANT LIMITS, and they are refusals rather than empty results: only files the CURRENT log actually mentions can be read, only inside this WordPress install, only source extensions, and never wp-config.php or a .env — if you need a value from configuration, ask the user for it. You are reading this file to EXPLAIN and to PROPOSE a change; you have no ability to write it, so give the user the edit to make.',
+			'category'            => OPENSTATION_AI_ABILITY_CATEGORY,
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'required'             => array( 'file', 'line' ),
+				'properties'           => array(
+					'file'    => array(
+						'type'        => 'string',
+						'description' => 'Absolute path exactly as the log wrote it — from an issue\'s `file` or a path inside its stack trace.',
+					),
+					'line'    => array(
+						'type'        => 'integer',
+						'description' => 'The line to centre on. Use 0 to read from the top of the file (a class or function you need the shape of).',
+					),
+					'context' => array(
+						'type'        => 'integer',
+						'description' => 'Lines either side of `line` (1-100). Defaults to 25 — enough for the enclosing function. Widen once if the cause is clearly further up.',
+					),
+				),
+			),
+			'output_schema'       => openstation_ai_ability_output_schema(
+				array(
+					'file'        => array( 'type' => 'string' ),
+					'total_lines' => array( 'type' => 'integer' ),
+					'start_line'  => array( 'type' => 'integer' ),
+					'end_line'    => array( 'type' => 'integer' ),
+					'lines'       => array(
+						'type'        => 'array',
+						'description' => 'Numbered source lines: { number, text }.',
+					),
+				)
+			),
+			'execute_callback'    => 'openstation_ai_debug_read_source',
+			'permission_callback' => 'openstation_ai_debug_can_use',
+			'meta'                => $meta,
+		)
+	);
+
+	wp_register_ability(
+		'desktop-mode/get-site-context',
+		array(
+			'label'               => __( 'Get site debugging context', 'desktop-mode' ),
+			'description'         => 'Returns what this site is actually running: WordPress and PHP versions, the debug constants, the environment type, the active theme, and every active plugin with its version. Call this before proposing a fix — most WordPress errors are a version story ("that function was removed in PHP 8.1", "that plugin has not been updated since 2021"), and the answer is not in the log. Contains no credentials.',
+			'category'            => OPENSTATION_AI_ABILITY_CATEGORY,
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'required'             => array(),
+				'properties'           => (object) array(),
+			),
+			'output_schema'       => openstation_ai_ability_output_schema(
+				array(
+					'wordpress'   => array( 'type' => 'object' ),
+					'php'         => array( 'type' => 'object' ),
+					'debug'       => array( 'type' => 'object' ),
+					'theme'       => array( 'type' => 'object' ),
+					'plugins'     => array(
+						'type'        => 'array',
+						'description' => 'Active plugins: { name, slug, version }.',
+					),
+					'mu_plugins'  => array( 'type' => 'array' ),
+				)
+			),
+			'execute_callback'    => 'openstation_ai_debug_site_context',
+			'permission_callback' => 'openstation_ai_debug_can_use',
+			'meta'                => $meta,
+		)
+	);
+}
+add_action( 'wp_abilities_api_init', 'openstation_ai_register_debug_abilities', 11 );
+
+/**
+ * `list_log_issues` — grouped issues from a log source.
+ *
+ * @param array<string,mixed> $input Validated input.
+ * @return array<string,mixed>
+ */
+function openstation_ai_debug_list_issues( $input ) {
+	$input += array(
+		'limit'  => 10,
+		'range'  => 'all',
+		'source' => '',
+		'level'  => '',
+	);
+
+	$read = openstation_ai_debug_entries( (string) $input['source'] );
+	if ( null === $read['source'] ) {
+		return array(
+			'issues'  => array(),
+			'count'   => 0,
+			'message' => $read['error'],
+		);
+	}
+
+	$spans  = array(
+		'1h'  => HOUR_IN_SECONDS,
+		'24h' => DAY_IN_SECONDS,
+		'7d'  => WEEK_IN_SECONDS,
+		'30d' => MONTH_IN_SECONDS,
+		'all' => 0,
+	);
+	$span   = isset( $spans[ $input['range'] ] ) ? $spans[ $input['range'] ] : 0;
+	$issues = openstation_ai_debug_group( $read['entries'], $span > 0 ? time() - $span : 0 );
+
+	$level = (string) $input['level'];
+	if ( '' !== $level ) {
+		$issues = array_values(
+			array_filter(
+				$issues,
+				static function ( $issue ) use ( $level ) {
+					return $issue['level'] === $level;
+				}
+			)
+		);
+	}
+
+	$limit  = max( 1, min( 50, (int) $input['limit'] ) );
+	$issues = array_slice( $issues, 0, $limit );
+	foreach ( $issues as $index => $issue ) {
+		// The list is a triage view: the trace is the expensive half and
+		// only the issue being worked on needs it.
+		unset( $issues[ $index ]['trace'] );
+		$issues[ $index ]['origin'] = openstation_ai_debug_name_origin( (array) $issue['origin'] );
+	}
+
+	return array(
+		'issues'  => $issues,
+		'count'   => count( $issues ),
+		'source'  => array(
+			'id'    => $read['source']['id'],
+			'label' => $read['source']['label'],
+			'path'  => $read['source']['path'],
+			'size'  => $read['source']['size'],
+		),
+		'message' => $read['error'],
+	);
+}
+
+/**
+ * `get_log_issue` — one issue, trace included.
+ *
+ * @param array<string,mixed> $input Validated input.
+ * @return array<string,mixed>
+ */
+function openstation_ai_debug_get_issue( $input ) {
+	$signature = isset( $input['signature'] ) ? (string) $input['signature'] : '';
+	$read      = openstation_ai_debug_entries( isset( $input['source'] ) ? (string) $input['source'] : '' );
+	if ( null === $read['source'] ) {
+		return array( 'message' => $read['error'] );
+	}
+
+	foreach ( openstation_ai_debug_group( $read['entries'] ) as $issue ) {
+		if ( $issue['signature'] === $signature ) {
+			$issue['origin'] = openstation_ai_debug_name_origin( (array) $issue['origin'] );
+			return array(
+				'issue'   => $issue,
+				'message' => '',
+			);
+		}
+	}
+
+	return array(
+		'message' => __( 'No issue in the current log has that signature — it may have been cleared or aged out. Call list_log_issues again.', 'desktop-mode' ),
+	);
+}
+
+/**
+ * `read_source_excerpt` — code around a logged line.
+ *
+ * @param array<string,mixed> $input Validated input.
+ * @return array<string,mixed>|WP_Error
+ */
+function openstation_ai_debug_read_source( $input ) {
+	$read = openstation_ai_debug_entries();
+	if ( null === $read['source'] ) {
+		return new WP_Error( 'openstation_ai_debug_no_log', $read['error'] );
+	}
+
+	$path = openstation_ai_debug_resolve_source_path(
+		isset( $input['file'] ) ? (string) $input['file'] : '',
+		openstation_ai_debug_known_paths( $read['entries'] )
+	);
+	if ( is_wp_error( $path ) ) {
+		return $path;
+	}
+
+	$context = isset( $input['context'] ) ? (int) $input['context'] : 25;
+	return openstation_ai_debug_excerpt( $path, isset( $input['line'] ) ? (int) $input['line'] : 0, max( 1, min( 100, $context ) ) );
+}
+
+/**
+ * `get_site_context` — versions, flags, active code.
+ *
+ * @return array<string,mixed>
+ */
+function openstation_ai_debug_site_context() {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$active  = array();
+	$plugins = get_plugins();
+	foreach ( $plugins as $file => $data ) {
+		if ( ! is_plugin_active( $file ) && ! ( is_multisite() && is_plugin_active_for_network( $file ) ) ) {
+			continue;
+		}
+		$active[] = array(
+			'name'    => (string) $data['Name'],
+			'slug'    => false === strpos( $file, '/' ) ? preg_replace( '/\.php$/', '', $file ) : dirname( $file ),
+			'version' => (string) $data['Version'],
+		);
+	}
+
+	$mu = array();
+	foreach ( get_mu_plugins() as $file => $data ) {
+		$mu[] = array(
+			'name'    => (string) $data['Name'],
+			'slug'    => preg_replace( '/\.php$/', '', $file ),
+			'version' => (string) $data['Version'],
+		);
+	}
+
+	$theme = wp_get_theme();
+	$debug = array();
+	foreach ( array( 'WP_DEBUG', 'WP_DEBUG_LOG', 'WP_DEBUG_DISPLAY', 'SCRIPT_DEBUG', 'SAVEQUERIES', 'WP_DISABLE_FATAL_ERROR_HANDLER' ) as $constant ) {
+		$debug[ $constant ] = defined( $constant ) ? (bool) constant( $constant ) : false;
+	}
+
+	return array(
+		'wordpress'  => array(
+			'version'          => (string) get_bloginfo( 'version' ),
+			'multisite'        => is_multisite(),
+			'environment_type' => function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production',
+			'locale'           => (string) get_locale(),
+		),
+		'php'        => array(
+			'version'       => PHP_VERSION,
+			'memory_limit'  => (string) ini_get( 'memory_limit' ),
+			'max_execution' => (string) ini_get( 'max_execution_time' ),
+			'extensions'    => array_values( array_intersect( get_loaded_extensions(), array( 'curl', 'gd', 'imagick', 'intl', 'mbstring', 'mysqli', 'openssl', 'zip' ) ) ),
+		),
+		'debug'      => $debug,
+		'theme'      => array(
+			'name'     => (string) $theme->get( 'Name' ),
+			'slug'     => (string) $theme->get_stylesheet(),
+			'version'  => (string) $theme->get( 'Version' ),
+			'template' => (string) $theme->get_template(),
+		),
+		'plugins'    => $active,
+		'mu_plugins' => $mu,
+	);
+}
+
+/**
+ * The behavioural half of the skill.
+ *
+ * The abilities make investigation possible; this makes it a method,
+ * and it states the one rule the tools cannot state for themselves. A
+ * model that does not know it is unable to edit files will happily
+ * answer "I've fixed that for you" — the ceiling is real either way,
+ * but the sentence is a lie the user then has to discover.
+ *
+ * Only added for callers who can actually use the tools: a subscriber
+ * asking about a post has no use for a debugging protocol, and every
+ * unused line in a system prompt is paid for on every turn.
+ *
+ * @param string              $appendix Appendix so far.
+ * @param array<string,mixed> $ctx      Request context.
+ * @return string
+ */
+function openstation_ai_debug_prompt_appendix( $appendix, $ctx = array() ) {
+	unset( $ctx );
+	if ( ! openstation_ai_debug_can_use() ) {
+		return $appendix;
+	}
+
+	$skill = <<<'PROMPT'
+## Investigating an error
+
+When the user reports something broken, asks about errors, or shows you
+a log message, work the evidence rather than guessing from the message
+alone:
+
+1. `list_log_issues` — what is failing, and how often. A fatal error
+   with a high count is the story; deprecation notices usually are not.
+2. `get_log_issue` — the stack trace for the one you are working on.
+   Read it from the bottom up: the last frame is where it broke, the
+   frames above it are who asked.
+3. `read_source_excerpt` — the actual code at that line, and at the
+   caller if the line alone does not explain it. Never describe code you
+   have not read.
+4. `get_site_context` — versions and debug flags. A large share of
+   WordPress fatals are a PHP-version or plugin-version story.
+
+Then answer with: what is failing, in one sentence; whose code it is
+(name the plugin or theme, with its version); why it happens, citing the
+lines you read; and the change you would make, as a short diff or a
+precise "in FILE, line N, replace X with Y".
+
+**You can read this site but you cannot change it.** Every tool here is
+read-only — there is no ability that edits a file, deactivates a plugin,
+or runs an update. So propose the fix and let the user apply it. Never
+say you have fixed, changed, patched or disabled anything; if the safest
+next step is deactivating a plugin or rolling back a version, say so as
+a recommendation and let them decide. Where a fix carries risk — a
+change inside a plugin that an update will overwrite, an edit to a theme
+without a child theme — say that too.
+PROMPT;
+
+	return '' === $appendix ? $skill : $appendix . "\n\n" . $skill;
+}
+add_filter( 'openstation_ai_system_prompt_appendix', 'openstation_ai_debug_prompt_appendix', 10, 2 );

--- a/includes/ai-copilot/bootstrap.php
+++ b/includes/ai-copilot/bootstrap.php
@@ -18,3 +18,4 @@ require_once __DIR__ . '/jobs.php';
 require_once __DIR__ . '/hooks.php';
 require_once __DIR__ . '/search.php';
 require_once __DIR__ . '/abilities.php';
+require_once __DIR__ . '/abilities-debugging.php';

--- a/includes/commands.php
+++ b/includes/commands.php
@@ -41,7 +41,7 @@ defined( 'ABSPATH' ) || exit;
  *         true
  *     );
  *     wp_enqueue_script( 'home-assistant-commands' );
- * } );
+ * }, 5 ); // Before the shell harvests the payload at priority 10.
  * openstation_register_command_script( 'home-assistant-commands' );
  * ```
  *

--- a/includes/core/payload.php
+++ b/includes/core/payload.php
@@ -2303,7 +2303,7 @@ function openstation_warn_unresolvable_script_handle( $function_name, $kind, $ha
 		esc_html( $function_name ),
 		sprintf(
 			/* translators: 1: kind ("Command"/"Settings-tab"/"Title-bar button"), 2: handle. */
-			esc_html__( '%1$s script handle "%2$s" is not registered with WordPress (no `wp_register_script` call found). The script will not load.', 'desktop-mode' ),
+			esc_html__( '%1$s script handle "%2$s" could not be resolved: no `wp_register_script( \'%2$s\', … )` call had run by the time the shell harvested its payload. Register the handle on `admin_enqueue_scripts` at priority 5 or earlier — the harvest itself runs at priority 10, and a handle registered alongside it may or may not exist yet depending on plugin load order. Until then the script will not load.', 'desktop-mode' ),
 			esc_html( $kind ),
 			esc_html( $handle )
 		),

--- a/includes/settings-tabs.php
+++ b/includes/settings-tabs.php
@@ -43,7 +43,7 @@ defined( 'ABSPATH' ) || exit;
  *         true
  *     );
  *     wp_enqueue_script( 'my-plugin-settings' );
- * } );
+ * }, 5 ); // Before the shell harvests the payload at priority 10.
  * openstation_register_settings_tab_script( 'my-plugin-settings' );
  * ```
  *

--- a/includes/title-bar-buttons.php
+++ b/includes/title-bar-buttons.php
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || exit;
  *         true
  *     );
  *     wp_enqueue_script( 'my-plugin-titlebar' );
- * } );
+ * }, 5 ); // Before the shell harvests the payload at priority 10.
  * openstation_register_titlebar_button_script( 'my-plugin-titlebar' );
  * ```
  *

--- a/includes/unfocus-effects.php
+++ b/includes/unfocus-effects.php
@@ -36,7 +36,7 @@ defined( 'ABSPATH' ) || exit;
  *         true
  *     );
  *     wp_enqueue_script( 'my-plugin-effects' );
- * } );
+ * }, 5 ); // Before the shell harvests the payload at priority 10.
  * openstation_register_unfocus_effect_script( 'my-plugin-effects' );
  * ```
  *

--- a/includes/window-actions.php
+++ b/includes/window-actions.php
@@ -43,7 +43,7 @@ defined( 'ABSPATH' ) || exit;
  *         true
  *     );
  *     wp_enqueue_script( 'my-plugin-window-actions' );
- * } );
+ * }, 5 ); // Before the shell harvests the payload at priority 10.
  * openstation_register_window_action_script( 'my-plugin-window-actions' );
  * ```
  *

--- a/src/ui/components/os-code/os-code.styles.ts
+++ b/src/ui/components/os-code/os-code.styles.ts
@@ -41,11 +41,36 @@ export const styles = css`
 	:host( [ block ] ) {
 		display: block;
 	}
+	/*
+	 * The scroll box is the \`code\` element, not the host: the copy
+	 * button is positioned against the host, so a host that scrolled
+	 * would carry the button away with the content and leave a long
+	 * snippet with no way to copy it except from the top.
+	 */
 	:host( [ block ] ) code {
 		display: block;
 		padding: var( --os-ui-code-block-padding, 10px 12px );
 		white-space: pre;
-		overflow-x: auto;
+		max-block-size: var( --os-ui-code-block-max-block-size, none );
+		overflow: auto;
+	}
+
+	/*
+	 * Wrap variant — set \`wrap\` to fold long lines instead of
+	 * scrolling them sideways. Declared AFTER the block rules and at
+	 * the same specificity, so source order is what makes it win; a
+	 * snippet in a narrow window (a stack trace in a window a third of
+	 * the screen wide) is then readable where it stands rather than
+	 * only after the window is dragged out to fit its longest line.
+	 *
+	 * The content's own line breaks still stand — this is \`pre-wrap\`,
+	 * not \`normal\` — and \`anywhere\` is what stops a single unbroken
+	 * token (a long path, a base64 blob) from reintroducing the
+	 * sideways scroll the attribute was asked to remove.
+	 */
+	:host( [ wrap ] ) code {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
 	}
 
 	/*
@@ -60,38 +85,64 @@ export const styles = css`
 	:host( [ copy ] ):not( [ block ] ) {
 		display: inline-flex;
 		align-items: center;
-		gap: 4px;
+		gap: var( --os-ui-code-copy-gap, 8px );
 	}
+	/*
+	 * Sized as a real control — a 24px square with its own hit area —
+	 * rather than a bare glyph. A copy affordance that covers only its
+	 * own character is a target you have to aim at, and it sits by
+	 * definition right against text you may be trying to select
+	 * instead, so neither the size nor the gap is decoration.
+	 */
 	.copy {
 		appearance: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: none;
+		inline-size: var( --os-ui-code-copy-size, 24px );
+		block-size: var( --os-ui-code-copy-size, 24px );
 		background: transparent;
 		border: 0;
+		border-radius: 4px;
 		padding: 0;
 		margin: 0;
 		font: inherit;
 		cursor: pointer;
 		color: var( --os-ui-code-copy-color, var( --os-ui-fg-muted, #57606a ) );
 		opacity: var( --os-ui-code-copy-opacity, 0.6 );
-		transition: opacity 120ms ease, color 120ms ease;
+		transition: opacity 120ms ease, color 120ms ease, background-color 120ms ease;
 		line-height: 1;
-		font-size: 0.95em;
+		font-size: 1.05em;
 	}
 	.copy:hover,
 	.copy:focus-visible {
 		opacity: 1;
 		color: var( --os-ui-code-copy-color-hover, var( --wp-admin-theme-color, #007cba ) );
+		background: var( --os-ui-code-copy-bg, var( --os-ui-hover, rgba( 0, 0, 0, 0.06 ) ) );
 	}
+	/*
+	 * Dimmed rather than absent until hover: a control nobody can see
+	 * is a control nobody uses, and a snippet box is exactly where
+	 * someone arrives already wanting to copy.
+	 */
 	:host( [ block ] ) .copy {
 		position: absolute;
 		top: 6px;
-		inset-inline-end: 8px;
-		padding: 4px 6px;
-		background: var( --os-ui-code-copy-bg, var( --os-ui-hover, rgba( 255, 255, 255, 0.6 ) ) );
-		border-radius: 4px;
-		opacity: 0;
+		inset-inline-end: 6px;
+		background: var( --os-ui-code-copy-bg, var( --os-ui-hover, rgba( 0, 0, 0, 0.06 ) ) );
+		opacity: var( --os-ui-code-copy-opacity, 0.6 );
 	}
 	:host( [ block ] ):hover .copy,
 	:host( [ block ] ):focus-within .copy {
 		opacity: 1;
+	}
+	/*
+	 * Reserve the button's corner so it never lands on the first line
+	 * of the snippet. Declared apart from the block padding above
+	 * because that token is a shorthand this cannot compose with.
+	 */
+	:host( [ block ][ copy ] ) code {
+		padding-inline-end: var( --os-ui-code-copy-inset, 42px );
 	}
 `;

--- a/src/ui/components/os-code/os-code.test.ts
+++ b/src/ui/components/os-code/os-code.test.ts
@@ -5,7 +5,7 @@
  * visual; here we just verify the attribute plumbs through).
  */
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
-import './os-code';
+import { OsCode } from './os-code';
 
 const tick = (): Promise< void > => Promise.resolve();
 
@@ -30,6 +30,14 @@ describe( '<os-code>', () => {
 		await tick();
 		const code = host.querySelector( 'os-code' )!;
 		expect( code.hasAttribute( 'block' ) ).toBe( true );
+	} );
+
+	test( 'wrap attribute survives on the host for CSS to target', async () => {
+		host.innerHTML = `<os-code block wrap>foo bar</os-code>`;
+		await tick();
+		const code = host.querySelector( 'os-code' )!;
+		expect( code.hasAttribute( 'wrap' ) ).toBe( true );
+		expect( OsCode.props ).toContain( 'wrap' );
 	} );
 
 	test( 'does not install global keypress listeners', async () => {

--- a/src/ui/components/os-code/os-code.ts
+++ b/src/ui/components/os-code/os-code.ts
@@ -22,13 +22,16 @@
  *   <os-code block copy>
  *     SELECT * FROM wp_posts WHERE post_status = 'publish';
  *   </os-code>
+ *
+ *   <!-- Long lines fold instead of scrolling sideways -->
+ *   <os-code block wrap>…a stack trace…</os-code>
  */
 
 import { Component, defineComponent, html } from '../../core';
 import { styles } from './os-code.styles';
 
 export class OsCode extends Component {
-	static props = [ 'block', 'copy' ] as const;
+	static props = [ 'block', 'copy', 'wrap' ] as const;
 	static styles = [ styles ];
 
 	static help = {
@@ -47,7 +50,13 @@ export class OsCode extends Component {
 				name: 'copy',
 				type: 'boolean',
 				description:
-					'When present, adds a copy-to-clipboard button. Always visible (dimmed) on inline variants; hover/focus-revealed in the top-right corner on `block`. Fires a `os-copy` event after a successful copy.',
+					'When present, adds a copy-to-clipboard button — a 24px control, dimmed until hover, beside the code inline and in the top-right corner on `block` (where the snippet reserves that corner so the button never covers its first line). Fires a `os-copy` event after a successful copy.',
+			},
+			{
+				name: 'wrap',
+				type: 'boolean',
+				description:
+					'When present, long lines fold instead of scrolling sideways — the content’s own line breaks still stand. Reach for it on `block` snippets that live in a narrow surface (a stack trace in a window a third of the screen wide) where the alternative is asking the reader to widen the window.',
 			},
 		],
 		slots: [
@@ -66,6 +75,15 @@ export class OsCode extends Component {
 			{ name: '--os-ui-code-border', default: '1px solid rgba(0,0,0,0.08)' },
 			{ name: '--os-ui-code-padding', default: '0.1em 0.4em' },
 			{ name: '--os-ui-code-block-padding', default: '10px 12px' },
+			{ name: '--os-ui-code-copy-size', default: '24px' },
+			{ name: '--os-ui-code-copy-gap', default: '8px', description: 'Inline variant — distance between the code and its copy button.' },
+			{ name: '--os-ui-code-copy-inset', default: '42px', description: 'Block variant — the end padding that keeps the first line clear of the copy button.' },
+			{
+				name: '--os-ui-code-block-max-block-size',
+				default: 'none',
+				description:
+					'Block variant only — cap the snippet box and let it scroll past that height. The `code` element is what scrolls, so the copy button stays put.',
+			},
 			{ name: '--os-ui-code-border-radius', default: '4px' },
 			{ name: '--os-ui-code-font-family', default: 'ui-monospace, …' },
 			{ name: '--os-ui-code-font-size', default: '0.92em' },
@@ -174,6 +192,7 @@ export class OsCode extends Component {
 						class="copy"
 						part="copy"
 						aria-label="${ this._copied ? 'Copied' : 'Copy code to clipboard' }"
+						title="${ this._copied ? 'Copied' : 'Copy to clipboard' }"
 						@click=${ this._onCopy }
 				  >
 						${ this._copied ? '✓' : '⧉' }

--- a/tests/phpunit/tests/aiDebuggingAbilities.php
+++ b/tests/phpunit/tests/aiDebuggingAbilities.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * Tests for the error-investigation skill — the four read-only
+ * abilities that let an assistant or an agent work a stack trace.
+ *
+ * The properties worth pinning are the boundaries, not the happy path:
+ * that the whole skill is read-only (it may propose a fix and can never
+ * apply one), that it is gated exactly like the window it reads for,
+ * and that `read_source_excerpt` refuses everything it is supposed to
+ * refuse. A regression in any of those is a security regression, and
+ * the last one would be a file-read tool wearing a debugging label.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group os-ai
+ * @group code-blue
+ */
+class Tests_OpenStation_AiDebuggingAbilities extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $editor_id;
+
+	/** @var string[] */
+	protected $temp_files = array();
+
+	/** The ability names this skill contributes. */
+	const ABILITIES = array(
+		'desktop-mode/list-log-issues',
+		'desktop-mode/get-log-issue',
+		'desktop-mode/read-source-excerpt',
+		'desktop-mode/get-site-context',
+	);
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+		openstation_save_os_settings( self::$admin_id, array( 'developerModeEnabled' => true ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available (requires WordPress 7.0+).' );
+		}
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		foreach ( $this->temp_files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+		$this->temp_files = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Offer a temp file as the only Code Blue log source.
+	 *
+	 * @param string $contents Log text.
+	 * @return string Absolute path.
+	 */
+	protected function make_temp_log( $contents ) {
+		$path = wp_tempnam( 'code-blue-abilities-log' );
+		file_put_contents( $path, $contents );
+		$this->temp_files[] = $path;
+		add_filter(
+			'openstation_code_blue_log_sources',
+			static function () use ( $path ) {
+				return array(
+					array(
+						'id'    => 'test-log',
+						'label' => 'Test log',
+						'path'  => $path,
+					),
+				);
+			},
+			20
+		);
+		return $path;
+	}
+
+	/**
+	 * A log naming a real file inside the install, so the source-reading
+	 * ability has something it is allowed to open.
+	 *
+	 * @return string The file the log names.
+	 */
+	protected function log_naming_a_core_file() {
+		$file = ABSPATH . 'wp-includes/version.php';
+		$this->make_temp_log(
+			"[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function boom() in {$file}:12\n"
+				. "Stack trace:\n#0 {main}\n  thrown in {$file} on line 12\n"
+		);
+		return $file;
+	}
+
+	/**
+	 * The skill's whole safety story: a model handed these tools can
+	 * describe a fix and has no route to apply one. If a mutating
+	 * ability ever joins this list, that stops being true silently.
+	 */
+	public function test_every_ability_in_the_skill_is_read_only() {
+		foreach ( self::ABILITIES as $name ) {
+			$ability = wp_get_ability( $name );
+			$this->assertInstanceOf( 'WP_Ability', $ability, "{$name} should be registered." );
+			$meta = (array) $ability->get_meta();
+			$this->assertTrue(
+				! empty( $meta['annotations']['readonly'] ),
+				"{$name} must be read-only: the skill proposes fixes, it never applies them."
+			);
+			$this->assertArrayNotHasKey(
+				'mcp',
+				$meta,
+				"{$name} must not be exposed over MCP: this site's log and source are not an external agent's business."
+			);
+			$this->assertSame( 'openstation', $ability->get_category() );
+			$this->assertNotEmpty( $ability->get_description() );
+			$this->assertNotEmpty( $ability->get_input_schema() );
+			$this->assertNotEmpty( $ability->get_output_schema() );
+		}
+	}
+
+	/**
+	 * Being read-only is what gets them offered to the Copilot's model
+	 * at all — the loop advertises every read-only ability.
+	 */
+	public function test_the_skill_is_offered_to_the_copilot() {
+		$names = openstation_ai_search_ability_names();
+		foreach ( self::ABILITIES as $name ) {
+			$this->assertContains( $name, $names );
+		}
+	}
+
+	/**
+	 * The gate is Code Blue's, not a new one: a user who cannot open
+	 * the log window cannot read the log through an assistant either.
+	 */
+	public function test_gate_matches_the_code_blue_window() {
+		$this->assertTrue( openstation_ai_debug_can_use() );
+
+		wp_set_current_user( self::$editor_id );
+		$this->assertFalse( openstation_ai_debug_can_use(), 'An editor cannot use the debugging skill.' );
+
+		// An administrator with Developer mode off is refused too — the
+		// window is hidden for them, and so is its tool surface.
+		wp_set_current_user( self::$admin_id );
+		openstation_save_os_settings( self::$admin_id, array( 'developerModeEnabled' => false ) );
+		$this->assertFalse( openstation_ai_debug_can_use() );
+		openstation_save_os_settings( self::$admin_id, array( 'developerModeEnabled' => true ) );
+	}
+
+	/**
+	 * The filter that moves the window moves the tools with it.
+	 */
+	public function test_the_code_blue_filter_moves_both() {
+		add_filter( 'openstation_code_blue_user_can_use', '__return_false' );
+		$this->assertFalse( openstation_ai_debug_can_use() );
+	}
+
+	public function test_list_groups_repeated_failures_into_one_issue() {
+		$this->make_temp_log(
+			"[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function boom() in /var/www/html/wp-content/plugins/acme/acme.php:12\n"
+				. "[01-Sep-2026 10:00:05 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function boom() in /var/www/html/wp-content/plugins/acme/acme.php:12\n"
+				. "[01-Sep-2026 10:00:09 UTC] PHP Warning:  Undefined variable \$x in /var/www/html/wp-content/themes/acme-theme/functions.php on line 4\n"
+		);
+
+		$out = wp_get_ability( 'desktop-mode/list-log-issues' )->execute( array( 'limit' => 10 ) );
+
+		$this->assertCount( 2, $out['issues'], 'Two occurrences of one error are one issue.' );
+		// Issues come back most-recently-seen first, so the warning
+		// leads here — pick the fatal by what it is, not by position.
+		$this->assertSame( 'warning', $out['issues'][0]['level'] );
+		$fatal = $out['issues'][1];
+		$this->assertSame( 2, $fatal['count'] );
+		$this->assertSame( 'fatal', $fatal['level'] );
+		$this->assertSame( 'plugin', $fatal['origin']['kind'] );
+		$this->assertSame( 'acme', $fatal['origin']['slug'] );
+		$this->assertArrayNotHasKey( 'trace', $fatal, 'The triage list leaves the trace to get_log_issue.' );
+		$this->assertSame( 'test-log', $out['source']['id'] );
+	}
+
+	public function test_list_filters_by_level() {
+		$this->make_temp_log(
+			"[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Boom in /a/b.php:1\n"
+				. "[01-Sep-2026 10:00:01 UTC] PHP Deprecated:  Old thing in /a/b.php:2\n"
+		);
+
+		$out = wp_get_ability( 'desktop-mode/list-log-issues' )->execute(
+			array(
+				'limit' => 10,
+				'level' => 'fatal',
+			)
+		);
+		$this->assertCount( 1, $out['issues'] );
+		$this->assertSame( 'fatal', $out['issues'][0]['level'] );
+	}
+
+	/**
+	 * No log is an answer, not an error: the assistant has to be able to
+	 * tell the user their install is not writing one.
+	 */
+	public function test_list_explains_a_missing_log_instead_of_failing() {
+		add_filter( 'openstation_code_blue_log_sources', '__return_empty_array', 20 );
+
+		$out = wp_get_ability( 'desktop-mode/list-log-issues' )->execute( array( 'limit' => 10 ) );
+
+		$this->assertSame( array(), $out['issues'] );
+		$this->assertNotEmpty( $out['message'] );
+	}
+
+	public function test_get_issue_returns_the_trace_for_one_signature() {
+		$this->make_temp_log(
+			"[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Uncaught Error: Boom in /a/b.php:12\n"
+				. "Stack trace:\n#0 /a/c.php(4): boom()\n#1 {main}\n"
+		);
+
+		$list      = wp_get_ability( 'desktop-mode/list-log-issues' )->execute( array( 'limit' => 10 ) );
+		$signature = $list['issues'][0]['signature'];
+
+		$out = wp_get_ability( 'desktop-mode/get-log-issue' )->execute( array( 'signature' => $signature ) );
+
+		$this->assertSame( $signature, $out['issue']['signature'] );
+		$this->assertStringContainsString( '#0 /a/c.php(4): boom()', $out['issue']['trace'] );
+	}
+
+	public function test_get_issue_says_so_when_the_signature_is_gone() {
+		$this->make_temp_log( "[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Boom in /a/b.php:1\n" );
+
+		$out = wp_get_ability( 'desktop-mode/get-log-issue' )->execute( array( 'signature' => 'nope' ) );
+
+		$this->assertArrayNotHasKey( 'issue', $out );
+		$this->assertNotEmpty( $out['message'] );
+	}
+
+	public function test_read_source_returns_numbered_lines_around_the_logged_line() {
+		$file = $this->log_naming_a_core_file();
+
+		$out = wp_get_ability( 'desktop-mode/read-source-excerpt' )->execute(
+			array(
+				'file'    => $file,
+				'line'    => 12,
+				'context' => 3,
+			)
+		);
+
+		$this->assertSame( 9, $out['start_line'] );
+		$this->assertSame( 15, $out['end_line'] );
+		$this->assertCount( 7, $out['lines'] );
+		$this->assertSame( 9, $out['lines'][0]['number'] );
+		$this->assertArrayHasKey( 'text', $out['lines'][0] );
+	}
+
+	/**
+	 * The boundary that makes this a debugging tool rather than a file
+	 * reader: a path only becomes readable because the install already
+	 * wrote it into its own error log.
+	 */
+	public function test_read_source_refuses_a_file_the_log_never_named() {
+		$this->log_naming_a_core_file();
+
+		$out = wp_get_ability( 'desktop-mode/read-source-excerpt' )->execute(
+			array(
+				'file' => ABSPATH . 'wp-settings.php',
+				'line' => 1,
+			)
+		);
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'openstation_ai_debug_unknown_file', $out->get_error_code() );
+	}
+
+	/**
+	 * A fatal inside wp-config.php names wp-config.php, so the log
+	 * allowlist alone would hand over the database password. It is
+	 * refused on its own account.
+	 */
+	public function test_read_source_refuses_configuration_even_when_the_log_names_it() {
+		$config = ABSPATH . 'wp-config.php';
+		$this->make_temp_log( "[01-Sep-2026 10:00:00 UTC] PHP Parse error:  syntax error in {$config} on line 3\n" );
+
+		$out = wp_get_ability( 'desktop-mode/read-source-excerpt' )->execute(
+			array(
+				'file' => $config,
+				'line' => 3,
+			)
+		);
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'openstation_ai_debug_secret_file', $out->get_error_code() );
+	}
+
+	/**
+	 * `realpath()` runs before the prefix test, so a traversal that the
+	 * log happens to contain still lands outside and is refused.
+	 */
+	public function test_read_source_refuses_a_path_outside_the_install() {
+		$outside = dirname( ABSPATH ) . '/outside.php';
+		$this->make_temp_log( "[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Boom in {$outside}:1\n" );
+
+		$out = wp_get_ability( 'desktop-mode/read-source-excerpt' )->execute(
+			array(
+				'file' => $outside,
+				'line' => 1,
+			)
+		);
+
+		$this->assertWPError( $out );
+		// Missing on disk or outside the root — either refusal is correct
+		// here; what must never happen is a successful read.
+		$this->assertContains(
+			$out->get_error_code(),
+			array( 'openstation_ai_debug_unreadable', 'openstation_ai_debug_outside_root' )
+		);
+	}
+
+	/**
+	 * A log can name a `.log` or a `.sql`. Those are data, and data is
+	 * where credentials end up.
+	 */
+	public function test_read_source_refuses_a_non_source_extension() {
+		$dump = WP_CONTENT_DIR . '/uploads/dump.sql';
+		$this->make_temp_log( "[01-Sep-2026 10:00:00 UTC] PHP Fatal error:  Boom in {$dump}:1\n" );
+
+		$out = wp_get_ability( 'desktop-mode/read-source-excerpt' )->execute(
+			array(
+				'file' => $dump,
+				'line' => 1,
+			)
+		);
+
+		$this->assertWPError( $out );
+	}
+
+	public function test_site_context_carries_versions_and_no_credentials() {
+		$out = wp_get_ability( 'desktop-mode/get-site-context' )->execute( array() );
+
+		$this->assertSame( get_bloginfo( 'version' ), $out['wordpress']['version'] );
+		$this->assertSame( PHP_VERSION, $out['php']['version'] );
+		$this->assertArrayHasKey( 'WP_DEBUG', $out['debug'] );
+		$this->assertArrayHasKey( 'name', $out['theme'] );
+		$this->assertIsArray( $out['plugins'] );
+
+		$encoded = wp_json_encode( $out );
+		foreach ( array( DB_PASSWORD, DB_USER, AUTH_KEY ) as $secret ) {
+			if ( '' !== (string) $secret ) {
+				$this->assertStringNotContainsString( (string) $secret, $encoded );
+			}
+		}
+	}
+
+	/**
+	 * The instructions reach a caller who can use the tools, and only
+	 * that caller — an unused protocol is paid for on every turn.
+	 */
+	public function test_prompt_appendix_is_added_only_for_users_who_hold_the_tools() {
+		$appendix = apply_filters( 'openstation_ai_system_prompt_appendix', '', array() );
+		$this->assertStringContainsString( 'list_log_issues', $appendix );
+		$this->assertStringContainsString( 'read-only', $appendix );
+
+		wp_set_current_user( self::$editor_id );
+		$this->assertSame( '', apply_filters( 'openstation_ai_system_prompt_appendix', '', array() ) );
+	}
+
+	/**
+	 * The appendix stacks rather than replaces — another plugin's
+	 * appendix must survive ours.
+	 */
+	public function test_prompt_appendix_stacks() {
+		$out = openstation_ai_debug_prompt_appendix( 'Existing house rules.', array() );
+		$this->assertStringStartsWith( 'Existing house rules.', $out );
+		$this->assertStringContainsString( 'Investigating an error', $out );
+	}
+}

--- a/tests/phpunit/tests/codeBlue.php
+++ b/tests/phpunit/tests/codeBlue.php
@@ -14,6 +14,7 @@
 use OpenStation\App\State;
 use function OpenStation\Apps\CodeBlue\level_map;
 use function OpenStation\Apps\CodeBlue\make_entry;
+use function OpenStation\Apps\CodeBlue\origin;
 use function OpenStation\Apps\CodeBlue\parse;
 use function OpenStation\Apps\CodeBlue\read;
 use function OpenStation\Apps\CodeBlue\signature;
@@ -173,6 +174,86 @@ class Tests_OpenStation_CodeBlue extends WP_UnitTestCase {
 		$this->assertSame( array( 'info', 'info', 'info' ), array_column( $entries, 'level' ) );
 		$this->assertNull( $entries[0]['timestamp'] );
 		$this->assertSame( 'custom message', $entries[2]['message'] );
+	}
+
+	/**
+	 * Attribution has one implementation. The window renders what this
+	 * returns and the debugging abilities report it verbatim, so a
+	 * second copy anywhere would let the two disagree about whose bug
+	 * a fatal is.
+	 *
+	 * @covers \OpenStation\Apps\CodeBlue\origin
+	 */
+	public function test_origin_reads_ownership_off_the_path() {
+		$content = '/var/www/html/wp-content';
+
+		$this->assertSame(
+			array(
+				'kind' => 'plugin',
+				'slug' => 'woocommerce',
+			),
+			origin( $content . '/plugins/woocommerce/includes/class-wc.php', $content )
+		);
+		// Single-file plugins and mu-plugins have no directory to be
+		// named by, so the basename is the slug.
+		$this->assertSame(
+			array(
+				'kind' => 'plugin',
+				'slug' => 'hello',
+			),
+			origin( $content . '/plugins/hello.php', $content )
+		);
+		$this->assertSame(
+			array(
+				'kind' => 'mu-plugin',
+				'slug' => 'loader',
+			),
+			origin( $content . '/mu-plugins/loader.php', $content )
+		);
+		$this->assertSame(
+			array(
+				'kind' => 'theme',
+				'slug' => 'twentytwentyfour',
+			),
+			origin( $content . '/themes/twentytwentyfour/functions.php', $content )
+		);
+		$this->assertSame( 'core', origin( '/var/www/html/wp-includes/post.php', $content )['kind'] );
+		$this->assertSame( 'plugin', origin( 'C:\\www\\wp-content\\plugins\\acf\\acf.php', 'C:\\www\\wp-content' )['kind'] );
+
+		// A wrong attribution sends someone into the wrong codebase, so
+		// anything unclear answers `unknown` rather than guessing.
+		$this->assertSame( 'unknown', origin( '/opt/vendor/thing.php', $content )['kind'] );
+		$this->assertSame( 'unknown', origin( '', $content )['kind'] );
+		$this->assertSame( 'unknown', origin( $content . '/plugins/woocommerce/x.php', '' )['kind'] );
+	}
+
+	/**
+	 * Entries carry their attribution, including entries a plugin's own
+	 * parser contributed through the filter — `parse()` never sees those.
+	 *
+	 * @covers \OpenStation\Apps\CodeBlue\read
+	 */
+	public function test_read_attributes_every_entry_including_filtered_ones() {
+		$this->make_temp_log( "[22-Aug-2026 09:14:02 UTC] PHP Warning:  Boom in /a.php on line 1\n" );
+		add_filter(
+			'openstation_code_blue_entries',
+			static function ( $entries ) {
+				$entries[] = make_entry( 1, 'error', 'Custom', 'Other in ' . WP_CONTENT_DIR . '/themes/mine/x.php on line 2' );
+				return $entries;
+			}
+		);
+
+		$entries = read( openstation_apps_os(), $this->source( 'test-log' ) )['entries'];
+
+		$this->assertCount( 2, $entries );
+		$this->assertSame( 'unknown', $entries[0]['origin']['kind'] );
+		$this->assertSame(
+			array(
+				'kind' => 'theme',
+				'slug' => 'mine',
+			),
+			$entries[1]['origin']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Reading an error shouldn't cost a resize

Code Blue truncated every message to one line, so reading a fatal meant dragging the window out to the length of the longest line. And the text couldn't be selected — the row that expands an issue is a `<button>`, and every engine suppresses text selection inside a form control.

Messages and stack traces now **wrap**. Copying moved to **buttons**, which is the honest answer when the click target has to stay the whole row (an error list is scanned; asking for aim at a chevron is asking for misses). The detail panel carries:

- the **full message**, wrapping, in a `<os-code block copy wrap>`
- the **file path**, flattened to plain mono text with just the copy affordance
- the **stack trace**, wrapping, with copy
- **Copy report** — paste-ready Markdown: heading, message, `file:line`, source, occurrence count, first/last seen, the whole environment row, trace in a fence. The thing that otherwise gets retyped by hand into a GitHub issue.
- **Search the web** — filterable via the new `openstation_code_blue_search_url`

## Every log line already said whose code failed

…and the window threw it away. Paths are now classified once, in `log-reader.php` — plugin / must-use / theme / core — and ride on every entry. It shows as a badge in the row and a **Source** row in the detail, with the plugin's real name and version resolved server-side.

Deliberately conservative: a path that isn't clearly under the content directory or clearly inside core answers `unknown` rather than guessing, because a wrong attribution sends someone into the wrong codebase.

## The error-investigation skill

`includes/ai-copilot/abilities-debugging.php` — four read-only WordPress Abilities on `wp_abilities_api_init`, plus a system-prompt appendix that turns them into a method.

| Ability | Returns |
|---|---|
| `list_log_issues` | The log as **distinct issues**, not raw lines — a fatal that fired 400 times is one entry with `count: 400`. Carries `signature`, severity, message, file/line, and `origin` (`{ kind, slug, name, version }`). No traces: the list is triage. |
| `get_log_issue` | One issue by signature, stack trace included. |
| `read_source_excerpt` | Numbered source lines around a line the log named. |
| `get_site_context` | WP + PHP versions, debug constants, environment type, active theme, every active plugin with its version. No credentials. |

That set is chosen so a model can reach a real conclusion: what's failing → the trace → **the actual code at that line** → the versions it's running on. Most WordPress fatals are a version story, and that story is nowhere in the log.

### It proposes; it never repairs

Structural, not prompted: all four are `readonly` and **no writing counterpart exists**, so a model handed the whole set can describe a patch and has no route to apply one. The appendix says so in words too, because a model that doesn't know it can't edit files tends to answer as though it had — and asks for the fix as a diff or a precise "in FILE, line N, replace X with Y", flagging when a change carries risk (a plugin edit an update will overwrite, a theme with no child theme).

### Security

`docs/agents-security.md` read first; these reach agents too, ceilinged at the invoker's capabilities.

**`read_source_excerpt` is bounded to files the *current log* names** — an entry's `file`, or a path inside a stack trace. A path only becomes readable because something already failed there, and the log is readable to exactly the same people, so the tool can never widen what the caller can see. Without that bound it's a general file-read tool wearing a debugging label, reachable through whatever text the model happens to be reading. Behind it: `realpath()` before the root prefix test, a source-extension allowlist, and `wp-config.php` / `.env` refused outright — a parse error inside `wp-config.php` *does* name it, and that file is the database password.

Gate is Code Blue's own (site management + Developer mode, moved by `openstation_code_blue_user_can_use`): a user who can't open the log window can't read the log through an assistant either. None of the four is `mcp.public`.

`tests/phpunit/tests/aiDebuggingAbilities.php` pins every refusal, the read-only property, the absent MCP exposure, and the gate.

## `<os-code>`

- **`wrap`** — long lines fold instead of scrolling sideways
- **copy button sized as a real control** — 24px square with its own hit area, hover background and tooltip, 8px gap; on `block` the snippet reserves its corner so it can never land on the first line. Dimmed-but-visible rather than hover-only: a copy affordance nobody can see is one nobody uses.
- **`--os-ui-code-block-max-block-size`** — the `code` element scrolls, not the host. A scrolling host carried the copy button away with the content.

## Also here, and separable

Unrelated to the above — happy to split it out if you'd rather.

`openstation-beta` registered its settings-tab script at `admin_enqueue_scripts` **priority 10**, the same priority the shell harvests its payload at, so plugin load order decided whether the handle existed yet. It also skipped registration entirely inside chromeless iframes — which is where the payload is harvested after a plugin activation. Result: the `_doing_it_wrong` notice, and a Beta tab that disappeared until the next reload. Priority 5 now, and registration no longer skipped.

The notice text was misleading too ("no `wp_register_script` call found" — there *was* one, just later), and the five PHP docblock examples plus seven in `hooks-reference.md` taught the same trap. All now show priority 5.

## Testing

`npm run build`, `typecheck`, `lint` (0 errors), `lint:php` (PHPCS clean), **5577 JS tests**, **2809 PHPUnit tests** — green on both single-site and multisite.

Not yet exercised by hand on a live install; worth a pass on a real `debug.log` for the badge rendering and the Copilot turn.

## Docs

- `hooks-reference.md` — the skill's abilities table, its gating and refusal list, `openstation_code_blue_search_url`, priority-5 in every script-handle example
- `components-reference.md` — `<os-code>`'s `wrap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-745-4e261fbf8089fe44c02927450a432d478a727d82.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->