### PR TITLE
Mobile: one desk on a phone — fold every desktop, switch workspaces off

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -904,6 +904,7 @@ manager.getPrimaryDesktopId(): string;
 manager.createDesktop(): Desktop;
 manager.switchDesktop( id: string ): void;
 manager.closeDesktop( id: string ): void;
+manager.moveWindowToDesktop( windowId: string, desktopId: string ): boolean;
 ```
 
 **`config` shape passed to `open()` / `openNew()`:**
@@ -1712,15 +1713,18 @@ manager.createDesktop( init? ): Desktop;   // append a new one + return it; `ini
 manager.switchDesktop( id ): void;         // make `id` the active desktop
 manager.closeDesktop( id ): void;          // delete `id`; windows migrate to the neighbour — except a scoped desktop's own admin's windows, which close with it
 manager.renameDesktop( id, label ): boolean;  // relabel `id`; see below
+manager.moveWindowToDesktop( windowId, desktopId ): boolean;  // one window to another desk; see below
 ```
 
 `scope` marks a **site Space** — a desktop hosting another admin of the same origin, expressed as an admin-scope path (`/site2/wp-admin/`, `/wp-admin/network/`; the rule lives in `src/admin-scope.ts`). It is what lets the desktop's cross-admin windows persist through the per-admin session scoping, quarantines their menu payloads, and makes closing the desktop close them. Set it through `createDesktop( { label, scope } )` — normally only by the shared cross-admin opener; see [multisite.md](./multisite.md#site-spaces).
+
+`moveWindowToDesktop()` moves one window and nothing else about it — geometry, state, focus order and iframe stay as they are; it shows or hides at once according to whether its new desk is the active one. `false` when either id is unknown, `true` (and nothing fired) when it is already there. The phone layer uses it to fold every desk onto the active one while the mode is `mobile` (see [`docs/mobile.md`](./mobile.md#the-session-on-a-phone)) — the session still records each window on the desk it came from, which is what keeps a site Space's windows through the per-admin session scoping; a plugin can use it for a "move to desk" action.
 
 **Workspaces** build on this: a desktop plus the answer to what it is FOR — which apps show on it, which widgets sit on it, what it looks like, what it opens with. `wp.os.workspaces.*` creates them, `wp.os.workspaces.registerPreset()` adds a template, and three ship: Commerce, Learning and Publishing — named for the job, built around the products that do it. The `+` in the **overview top bar** opens a wizard whose first step is a blank desk one Enter away; Edit under a tile opens the same wizard on that desk. Overview is already the Spaces surface, and the desk itself belongs to the user's windows.
 
 The one rule the whole feature rests on: **a workspace is a view, never a write.** The rails, the widget column and the appearance are all computed on top of the user's own state and restored the moment they leave, so a workspace they delete costs them nothing. See **[Workspaces](./workspaces.md)** for the whole surface: it is documented there rather than here because it is a layer above Spaces, not a change to them.
 
-Lifecycle hooks fire on each operation: `HOOKS.DESKTOP_CREATED`, `HOOKS.DESKTOP_CLOSED { desktopId, migratedTo }`, `HOOKS.DESKTOP_SWITCHED { from, to }`, `HOOKS.DESKTOP_RENAMED { desktopId, label, previousLabel }`.
+Lifecycle hooks fire on each operation: `HOOKS.DESKTOP_CREATED`, `HOOKS.DESKTOP_CLOSED { desktopId, migratedTo }`, `HOOKS.DESKTOP_SWITCHED { from, to }`, `HOOKS.DESKTOP_RENAMED { desktopId, label, previousLabel }`, `HOOKS.WINDOW_DESKTOP_CHANGED { windowId, from, to }`.
 
 `renameDesktop()` trims the label and caps it at **64 characters**, matching the session sanitizer, and returns `false` without firing the hook when the id is unknown or the name is blank or unchanged. It persists through the normal session save. Users reach it from the overview top bar: hovering a tile reveals a rename pencil beside the close ×, and clicking it edits in place (Enter commits, Escape reverts, blur commits).
 
@@ -4907,6 +4911,7 @@ Each user can have multiple desktops, each owning its own set of windows. Switch
 | `os.os.closed` | action | Stable | `{ desktopId, migratedTo }` — `migratedTo` is the desktop that received any orphaned windows |
 | `os.os.switched` | action | Stable | `{ from, to }` — the active desktop changed |
 | `os.os.renamed` | action | Stable | `{ desktopId, label, previousLabel }` — the user renamed a desktop |
+| `os.os.window-moved` | action | Experimental | `{ windowId, from, to }` — one window moved to another desktop through `manager.moveWindowToDesktop()`; the bulk migration of a closed desktop is `os.os.closed` instead |
 
 Closing the last remaining desktop is rejected silently (the shell needs at least one). Closing a desktop that has windows migrates them to the surviving desktop on its left (falling back to the right when the leftmost is closed) — no work is silently destroyed.
 

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -59,6 +59,8 @@ The layer ships as its own bundle, `mobile[.min].js`, fetched only when the mode
 
 Restoring a desktop's worth of windows on a phone would mean a desktop's worth of iframes. A phone boot restores **one** window, the session's focused one, and parks the rest. The phone does not list them: they belong to the desktop, and the switcher shows only what is open on the phone.
 
+**A phone has one desk.** Virtual desktops and workspaces are a desktop's way of putting things side by side, and a phone has no side. While the mode is `mobile`, every window is on the active desk: a window that arrives carrying another desk — the session's focused window restored from the desk it was on, a parked recent reopened from the switcher — is moved onto the active one as it opens (`manager.moveWindowToDesktop()`, which fires `os.os.window-moved`), and everything already open is moved on the crossing into the band. Nothing else a workspace does happens on a phone: its narrowed app list is not applied (the home grid shows every app whatever desk is active), its look is not painted over the user's settings, its widget column is not put up, and its launch list is not opened. The desk each window came from is remembered and written back into every session save, and on the crossing out every window goes back to its desk, the desk's look and launch list are applied, and the rails narrow again — so the desktop finds its desks exactly as it left them, and a desk that never had its launch list opened on the phone gets it on arrival.
+
 The desktop is not degraded by this. `WindowManager.snapshot()` runs the `os.session.snapshot` filter last, and the phone layer uses it to hand the desktop its own numbers back: a window the phone forced full-screen is written with the geometry and state it had before, and the parked windows are folded back into every save. A window the phone opened itself has no desktop geometry to keep (a fresh open on a 390px viewport gets phone-sized defaults), so it is saved as `unplaced` and the desktop places it as it would a fresh open: its own default size, cascaded. Widening a phone-sized browser back past the breakpoint does the same. A desktop reload after a phone visit finds exactly what it left, plus what the phone opened, at desktop sizes.
 
 The filter is public. A plugin can use it to redact a window it owns from the saved session, or to pin one it never wants restored:
@@ -98,6 +100,7 @@ JavaScript — see [javascript-reference.md](./javascript-reference.md):
 | `os.mode.changed` | action |
 | `os-mode-changed` | CustomEvent |
 | `os.session.snapshot` | filter |
+| `os.os.window-moved` | action — a window folded onto the phone's one desk, or handed back |
 | `data-os-mode` on `<html>` | the CSS hook |
 
 Settings: `mobileLayout`, `mobileTabs` — both through `wp.os.updateOsSettings()` like every other key.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -95,6 +95,8 @@ Two things a workspace may never hide, structurally rather than by default:
 
 An **open window always keeps its tile**, even on a desk that hides its app. `computeNav` mints an ephemeral tile for any window with nowhere to minimize back into, so narrowing can never strand a window you are looking at.
 
+**On a phone there is no workspace.** While the mode is `mobile` the navigation is computed with no profile at all, so the home grid shows every app whatever desk is active; the desk's look, widget column and launch list are not applied either, and every window is on the one desk the phone shows. The desks and their profiles are untouched — they are all back on the crossing out of the band, and the session keeps recording each window on the desk it came from. See [`docs/mobile.md`](mobile.md#the-session-on-a-phone).
+
 ## Widgets are a layout, not a filter
 
 A workspace's widget column follows a **different rule from its apps**, deliberately.

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2600,6 +2600,39 @@ function init(): void {
 	// narrows the navigation, so there is nothing for it to do before
 	// there is a navigation.
 	let workspaceDeps: WorkspaceDeps | null = null;
+
+	/*
+	 * A phone has one desk and no workspace. The windows are folded
+	 * onto the active desk by `installMobileConstraints`; here the
+	 * rest of what a workspace does is switched off for as long as the
+	 * mode is `mobile`: the desk's look is not painted over the user's
+	 * settings, its widget column is not put up (there is no column),
+	 * and its launch list is not opened (a desktop's worth of iframes
+	 * on a phone that restores one window). Every workspace caller
+	 * goes through these two so the mode decides in one place, and the
+	 * crossing subscription near the phone layer's mount re-applies or
+	 * clears the view when the answer changes.
+	 */
+	const applyWorkspaceViewForMode = (
+		deps: WorkspaceDeps,
+		desktopId: string,
+	): void => {
+		if ( modeController.api.isMobile() ) {
+			deps.setAppearance?.( null );
+			deps.setVisibleWidgets?.( null );
+			return;
+		}
+		applyWorkspaceView( deps, desktopId );
+	};
+	const provisionWorkspaceForMode = (
+		deps: WorkspaceDeps,
+		desktopId: string,
+	): void => {
+		if ( modeController.api.isMobile() ) {
+			return;
+		}
+		provisionWorkspace( deps, desktopId );
+	};
 	// Answered asynchronously by `isLikelyInstalled()` (Chromium only),
 	// and read by the System menu's install row each time it is built.
 	let pwaAlreadyInstalled = false;
@@ -3135,7 +3168,15 @@ function init(): void {
 				// repaint. The dispatcher adds it to the placement map
 				// it computes from and never writes it back — see
 				// `src/workspaces/visibility.ts`.
-				getWorkspaceProfile: () => getActiveWorkspaceProfile( manager ),
+				//
+				// A phone has one desk and no workspace: its home grid
+				// shows every app whatever desk happens to be active.
+				// The crossing subscription below repaints the rails
+				// when the answer changes.
+				getWorkspaceProfile: () =>
+					modeController.api.isMobile()
+						? null
+						: getActiveWorkspaceProfile( manager ),
 			},
 			initialLayout,
 			config.dockItems,
@@ -3262,8 +3303,8 @@ function init(): void {
 				// The desk's look and furniture first, so its windows
 				// land on the surface they belong to rather than on
 				// the previous workspace's.
-				applyWorkspaceView( workspaceDeps, payload.to );
-				provisionWorkspace( workspaceDeps, payload.to );
+				applyWorkspaceViewForMode( workspaceDeps, payload.to );
+				provisionWorkspaceForMode( workspaceDeps, payload.to );
 			},
 		);
 		// Adding a widget while a workspace's column is in force is a
@@ -3306,8 +3347,8 @@ function init(): void {
 		// view state the session does not carry.
 		if ( workspaceDeps ) {
 			const bootDesktop = manager.getActiveDesktopId();
-			applyWorkspaceView( workspaceDeps, bootDesktop );
-			provisionWorkspace( workspaceDeps, bootDesktop );
+			applyWorkspaceViewForMode( workspaceDeps, bootDesktop );
+			provisionWorkspaceForMode( workspaceDeps, bootDesktop );
 		}
 		// Tracked by the dispatcher so it re-attaches automatically
 		// after a layout rebuild. `'core'` classifies it as a
@@ -3832,8 +3873,12 @@ function init(): void {
 		const deps = workspaceDeps;
 		void sessionRestore.then( () => {
 			const bootDesktop = manager.getActiveDesktopId();
-			reopenWorkspaceWindows( deps, bootDesktop );
-			applyWorkspaceView( deps, bootDesktop );
+			// Not on a phone: a desk's launch list is a desktop's worth
+			// of iframes, and the phone boot restores one window.
+			if ( ! modeController.api.isMobile() ) {
+				reopenWorkspaceWindows( deps, bootDesktop );
+			}
+			applyWorkspaceViewForMode( deps, bootDesktop );
 		} );
 	}
 
@@ -4765,6 +4810,25 @@ function init(): void {
 	};
 	syncMobileLayer();
 	modeController.api.subscribe( syncMobileLayer );
+
+	// A crossing into or out of the phone band changes what a
+	// workspace is allowed to do (see `applyWorkspaceViewForMode`):
+	// the rails narrow or widen, the desk's look goes on or comes off,
+	// and a desk never provisioned on the phone gets its launch list
+	// on arrival at the desktop. The window fold itself is the
+	// constraints module's, subscribed earlier so it runs first.
+	modeController.api.subscribe( ( change ) => {
+		if ( change.mode !== 'mobile' && change.previous !== 'mobile' ) {
+			return;
+		}
+		layoutDispatcher?.refresh();
+		if ( ! workspaceDeps ) {
+			return;
+		}
+		const active = manager.getActiveDesktopId();
+		applyWorkspaceViewForMode( workspaceDeps, active );
+		provisionWorkspaceForMode( workspaceDeps, active );
+	} );
 
 	// Now that `wp.os.dragManager` is on the window, register
 	// the recycle-bin drop targets (dock icon + window body). The

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1343,6 +1343,13 @@ export const HOOKS = {
 	/** Action, fires when a desktop is renamed. Payload `{ desktopId, label, previousLabel }`. */
 	DESKTOP_RENAMED: 'os.os.renamed',
 	/**
+	 * Action, fires when one window is moved to another desktop
+	 * (`manager.moveWindowToDesktop()`). Payload `{ windowId, from, to }`.
+	 * Not fired for the bulk migration a closed desktop performs —
+	 * that is `DESKTOP_CLOSED { migratedTo }`.
+	 */
+	WINDOW_DESKTOP_CHANGED: 'os.os.window-moved',
+	/**
 	 * Filter. Returns the id of the "primary" desktop — the one the
 	 * shell treats as canonical for batch operations. Receives the
 	 * default (first desktop's id) and the full `Desktop[]` list.

--- a/src/mobile/constraints.ts
+++ b/src/mobile/constraints.ts
@@ -3,7 +3,7 @@
  *
  * Ships in the main bundle (it has to be in place before the first
  * `open()`, which session restore fires long before the lazy phone
- * layer could arrive). Two jobs:
+ * layer could arrive). Three jobs:
  *
  * 1. **Every window is full-screen on a phone.** One
  *    `os.window.geometry` filter forces `state: 'maximized'` on
@@ -13,7 +13,17 @@
  *    un-maximized by a plugin is re-maximized while the mode is
  *    `mobile`; a mode change re-maximizes or releases in bulk.
  *
- * 2. **A phone boot restores one window.** `trimSessionForMobile()`
+ * 2. **A phone has one desk.** A window on any other desktop is
+ *    folded onto the active one as it opens (a session restore
+ *    carries the desk a window was on; so does a parked recent), and
+ *    everything already open is folded on the crossing into
+ *    `mobile`. The desk each window came from is remembered, written
+ *    back into every session save, and handed back on the crossing
+ *    out — so the desktop finds its desks exactly as it left them.
+ *    Without this the phone restored a window `display: none` on a
+ *    desk it never shows, and a tap on its tile focused it invisibly.
+ *
+ * 3. **A phone boot restores one window.** `trimSessionForMobile()`
  *    keeps only the focused session window; the rest are parked (the
  *    phone does not list them) and the `os.session.snapshot` filter
  *    folds them back into every save with their desktop geometry
@@ -68,6 +78,8 @@ export interface MobileConstraints {
 	trimSessionForMobile( config: DesktopConfig ): DesktopConfig;
 	/** Ids the filter has forced full-screen (test seam). */
 	forcedIds(): string[];
+	/** Ids folded onto the active desk from another one (test seam). */
+	foldedIds(): string[];
 	dispose(): void;
 }
 
@@ -92,6 +104,8 @@ export function splitSessionForMobile( session: Session | undefined ): {
 export function installMobileConstraints( deps: MobileConstraintsDeps ): MobileConstraints {
 	const { manager, mode } = deps;
 	const displaced = new Map< string, DisplacedGeometry >();
+	/** The desktop a folded window belongs to, by window id. */
+	const folded = new Map< string, string >();
 	let recents: SessionWindow[] = [];
 	const recentListeners = new Set< RecentsListener >();
 	const notifyRecents = (): void => {
@@ -120,6 +134,64 @@ export function installMobileConstraints( deps: MobileConstraintsDeps ): MobileC
 			} );
 		}
 		win.maximize();
+	};
+
+	/**
+	 * Bring a window on another desktop onto the active one, keeping
+	 * the desk it came from. The first fold wins: a window folded, then
+	 * moved by a plugin, then folded again still goes back to the desk
+	 * the desktop knew.
+	 */
+	const foldIfNeeded = ( windowId: string ): void => {
+		if ( ! mode.isMobile() ) {
+			return;
+		}
+		const win = manager.getById( windowId );
+		if ( ! win ) {
+			return;
+		}
+		const active = manager.getActiveDesktopId();
+		const own = win.config.desktopId || active;
+		if ( own === active ) {
+			return;
+		}
+		if ( ! folded.has( windowId ) ) {
+			folded.set( windowId, own );
+		}
+		manager.moveWindowToDesktop( windowId, active );
+	};
+
+	/**
+	 * Hand every folded window back to its desk. A desk closed in the
+	 * meantime (a plugin, another tab's session) keeps the window on
+	 * the active one, as `closeDesktop` would have. Focus is repaired
+	 * the way `switchDesktop` repairs it: if the window in front just
+	 * left the desk, the topmost one still on it takes over.
+	 */
+	const unfoldAll = (): void => {
+		if ( folded.size === 0 ) {
+			return;
+		}
+		const desks = new Set( manager.getDesktops().map( ( d ) => d.id ) );
+		for ( const [ windowId, desktopId ] of folded ) {
+			if ( desks.has( desktopId ) ) {
+				manager.moveWindowToDesktop( windowId, desktopId );
+			}
+		}
+		folded.clear();
+		const active = manager.getActiveDesktopId();
+		const focused = manager.getFocused();
+		if ( focused && ( focused.config.desktopId || active ) !== active ) {
+			const topOnActive = [ ...manager.getAll() ]
+				.reverse()
+				.find(
+					( w ) =>
+						( w.config.desktopId || active ) === active && ! w.isMinimized(),
+				);
+			if ( topOnActive ) {
+				manager.focus( topOnActive );
+			}
+		}
 	};
 
 	/**
@@ -191,20 +263,31 @@ export function installMobileConstraints( deps: MobileConstraintsDeps ): MobileC
 	};
 	addAction( HOOKS.WINDOW_RESTORED, NS, onWindowState );
 	addAction( HOOKS.WINDOW_UNMAXIMIZED, NS, onWindowState );
-	addAction( HOOKS.WINDOW_OPENED, NS, onWindowState );
+	// An open lands on the active desk first, then goes full-screen:
+	// a restore or a parked recent arrives carrying the desk it was on.
+	addAction( HOOKS.WINDOW_OPENED, NS, ( payload: unknown ) => {
+		const id = ( payload as { windowId?: string } | null )?.windowId;
+		if ( id ) {
+			foldIfNeeded( id );
+			maximizeIfNeeded( id );
+		}
+	} );
 	addAction( HOOKS.WINDOW_CLOSED, NS, ( payload: unknown ) => {
 		const id = ( payload as { windowId?: string } | null )?.windowId;
 		if ( id ) {
 			displaced.delete( id );
+			folded.delete( id );
 		}
 	} );
 
 	// A mode change is a bulk re-state: into `mobile`, every open
-	// window goes full-screen; out of it, every window the phone
-	// forced (and only those) floats again where it was.
+	// window comes onto the one desk and goes full-screen; out of it,
+	// every window the phone forced (and only those) floats again
+	// where it was, on the desk it was on.
 	const unsubscribeMode = mode.subscribe( ( change: OsModeChange ) => {
 		if ( change.mode === 'mobile' ) {
 			for ( const win of manager.getAll() ) {
+				foldIfNeeded( win.id );
 				maximizeIfNeeded( win.id );
 			}
 			return;
@@ -212,6 +295,7 @@ export function installMobileConstraints( deps: MobileConstraintsDeps ): MobileC
 		if ( change.previous !== 'mobile' ) {
 			return;
 		}
+		unfoldAll();
 		let cascade = 0;
 		for ( const win of manager.getAll() ) {
 			const before = displaced.get( win.id );
@@ -231,28 +315,38 @@ export function installMobileConstraints( deps: MobileConstraintsDeps ): MobileC
 		displaced.clear();
 	} );
 
-	// 2. The session: hand the desktop its own numbers back, and
-	// keep carrying what this phone chose not to open.
+	// 2. The session: hand the desktop its own numbers and its own
+	// desks back, and keep carrying what this phone chose not to open.
 	addFilter< Session >( HOOKS.SESSION_SNAPSHOT, NS, ( session ) => {
 		const openIds = new Set( session.windows.map( ( w ) => w.id ) );
 		const windows = session.windows.map( ( w ) => {
 			const before = displaced.get( w.id );
-			if ( ! before || ! mode.isMobile() ) {
+			const desk = folded.get( w.id );
+			if ( ! mode.isMobile() || ( ! before && ! desk ) ) {
 				return w;
 			}
 			return {
 				...w,
-				x: before.x,
-				y: before.y,
-				width: before.width,
-				height: before.height,
-				// "Home" on a phone is every window minimized; the
-				// desktop should not wake up to that, so the state
-				// written is the one the window had before the phone.
-				state: before.state,
-				// The desktop's restore path places an `unplaced`
-				// window itself instead of trusting the pixels above.
-				...( before.unplaced ? { unplaced: true } : {} ),
+				...( before
+					? {
+						x: before.x,
+						y: before.y,
+						width: before.width,
+						height: before.height,
+						// "Home" on a phone is every window minimized;
+						// the desktop should not wake up to that, so the
+						// state written is the one the window had before
+						// the phone.
+						state: before.state,
+						// The desktop's restore path places an
+						// `unplaced` window itself instead of trusting
+						// the pixels above.
+						...( before.unplaced ? { unplaced: true } : {} ),
+					}
+					: {} ),
+				// The desk the window was on, not the one the phone
+				// folded it onto.
+				...( desk ? { desktopId: desk } : {} ),
 			};
 		} );
 		const parked = recents.filter( ( r ) => ! openIds.has( r.id ) );
@@ -342,6 +436,7 @@ export function installMobileConstraints( deps: MobileConstraintsDeps ): MobileC
 			};
 		},
 		forcedIds: () => Array.from( displaced.keys() ),
+		foldedIds: () => Array.from( folded.keys() ),
 		dispose() {
 			unsubscribeMode();
 			recentListeners.clear();

--- a/src/window-manager/desktops.ts
+++ b/src/window-manager/desktops.ts
@@ -73,6 +73,45 @@ export function refreshDesktopVisibility( mgr: WindowManager ): void {
 }
 
 /**
+ * Move one window to another desktop, keeping everything else about
+ * it — geometry, state, focus order, iframe — exactly as it is. The
+ * window shows or hides at once according to whether its new desktop
+ * is the active one.
+ *
+ * `false` when either id is unknown; a no-op `true` when the window
+ * is already there. The one caller in-tree is the phone layer, which
+ * folds every desktop onto the active one while the mode is `mobile`
+ * and hands each window back on the way out; a plugin can use it for
+ * a "move to desk" action of its own.
+ */
+export function moveWindowToDesktop(
+	mgr: WindowManager,
+	windowId: string,
+	desktopId: string,
+): boolean {
+	const win = mgr._stack.find( ( w ) => w.id === windowId );
+	if ( ! win || ! mgr._desktops.some( ( d ) => d.id === desktopId ) ) {
+		return false;
+	}
+	const from = win.config.desktopId || mgr._activeDesktopId;
+	if ( from === desktopId ) {
+		return true;
+	}
+	win.config.desktopId = desktopId;
+	if ( mgr._overviewActive ) {
+		relayoutOverviewForActiveDesktop( mgr );
+	} else {
+		applyDesktopVisibility( mgr, win );
+	}
+	doAction( HOOKS.WINDOW_DESKTOP_CHANGED, {
+		windowId,
+		from,
+		to: desktopId,
+	} );
+	return true;
+}
+
+/**
  * Append a brand-new desktop and return it. The new desktop's label
  * is auto-numbered (`Desktop 2`, `Desktop 3`, …) using the monotonic
  * seq counter so closing + reopening doesn't reuse the same id

--- a/src/window-manager/index.ts
+++ b/src/window-manager/index.ts
@@ -48,6 +48,7 @@ import {
 	getActiveDesktop,
 	getActiveDesktopId,
 	getDesktops,
+	moveWindowToDesktop,
 	renameDesktop,
 	seedDesktops,
 	switchDesktop,
@@ -2174,6 +2175,14 @@ export class WindowManager {
 	}
 	public renameDesktop( id: string, label: string ): boolean {
 		return renameDesktop( this, id, label );
+	}
+	/**
+	 * Move one window to another desktop; it shows or hides at once
+	 * according to whether that desktop is the active one. `false`
+	 * when either id is unknown.
+	 */
+	public moveWindowToDesktop( windowId: string, desktopId: string ): boolean {
+		return moveWindowToDesktop( this, windowId, desktopId );
 	}
 
 	/**

--- a/tests/vitest/desktops.test.ts
+++ b/tests/vitest/desktops.test.ts
@@ -146,6 +146,33 @@ describe( 'WindowManager — virtual desktops', async () => {
 		expect( b.element.style.display ).toBe( 'none' );
 	} );
 
+	test( 'moveWindowToDesktop re-homes one window, shows or hides it at once, fires window-moved', async () => {
+		const a = await manager.open( openConfig( 'a' ) );
+		const second = manager.createDesktop();
+		const log = recordActions( hooks, [ 'os.os.window-moved' ] );
+
+		expect( manager.moveWindowToDesktop( 'a', second.id ) ).toBe( true );
+		expect( a.config.desktopId ).toBe( second.id );
+		expect( a.element.style.display ).toBe( 'none' );
+		expect( log ).toEqual( [
+			{ name: 'os.os.window-moved', args: [ { windowId: 'a', from: 'desktop-1', to: second.id } ] },
+		] );
+
+		// Back onto the active desk: visible again.
+		expect( manager.moveWindowToDesktop( 'a', 'desktop-1' ) ).toBe( true );
+		expect( a.element.style.display ).toBe( '' );
+		expect( log ).toHaveLength( 2 );
+
+		// Already there: a no-op that reports success and fires nothing.
+		expect( manager.moveWindowToDesktop( 'a', 'desktop-1' ) ).toBe( true );
+		expect( log ).toHaveLength( 2 );
+
+		// Unknown window or desk: refused.
+		expect( manager.moveWindowToDesktop( 'nope', second.id ) ).toBe( false );
+		expect( manager.moveWindowToDesktop( 'a', 'desktop-99' ) ).toBe( false );
+		expect( a.config.desktopId ).toBe( 'desktop-1' );
+	} );
+
 	test( 'switchDesktop fires desktop.switched with from + to ids', async () => {
 		const second = manager.createDesktop();
 		const log = recordActions( hooks, DESKTOP_HOOKS );

--- a/tests/vitest/mobile-constraints.test.ts
+++ b/tests/vitest/mobile-constraints.test.ts
@@ -10,7 +10,10 @@
  *   folds the parked recents in until they are opened;
  * - `splitSessionForMobile` restores the focused window only;
  * - a crossing out of `mobile` un-maximizes exactly the windows the
- *   phone forced.
+ *   phone forced;
+ * - a window on another desk is folded onto the active one as it
+ *   opens and on the crossing in, the session records the desk it
+ *   came from, and the crossing out hands it back.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { HOOKS, applyFilters, doAction } from '../../src/hooks';
@@ -47,7 +50,7 @@ function fakeMode( initial: OsMode ) {
 
 interface FakeWin {
 	id: string;
-	config: { baseId?: string };
+	config: { baseId?: string; desktopId?: string };
 	minimized: boolean;
 	maximized: boolean;
 	isMinimized: () => boolean;
@@ -81,20 +84,37 @@ function fakeWin( id: string, over: Partial< FakeWin > = {} ): FakeWin {
 	return w;
 }
 
-function fakeManager( wins: FakeWin[] ) {
-	const openNew = vi.fn( async ( cfg: { id: string } ) => {
+function fakeManager( wins: FakeWin[], desks: string[] = [ 'desktop-1' ] ) {
+	const openNew = vi.fn( async ( cfg: { id: string; desktopId?: string } ) => {
 		const w = fakeWin( cfg.id );
+		w.config.desktopId = cfg.desktopId ?? 'desktop-1';
 		wins.push( w );
 		return w;
 	} );
 	const seedWindowRestoreState = vi.fn();
+	// The manager's own rule: a move re-homes the window and nothing
+	// else; the stack order stands for focus order, last is in front.
+	const moveWindowToDesktop = vi.fn( ( id: string, desktopId: string ) => {
+		const w = wins.find( ( x ) => x.id === id );
+		if ( ! w || ! desks.includes( desktopId ) ) {
+			return false;
+		}
+		w.config.desktopId = desktopId;
+		return true;
+	} );
+	const focus = vi.fn();
 	const manager = {
 		getAll: () => wins.slice(),
 		getById: ( id: string ) => wins.find( ( w ) => w.id === id ),
+		getFocused: () => wins[ wins.length - 1 ],
+		getActiveDesktopId: () => 'desktop-1',
+		getDesktops: () => desks.map( ( id ) => ( { id, label: id } ) ),
+		moveWindowToDesktop,
+		focus,
 		openNew,
 		seedWindowRestoreState,
 	} as unknown as WindowManager;
-	return { manager, openNew, seedWindowRestoreState };
+	return { manager, openNew, seedWindowRestoreState, moveWindowToDesktop, focus };
 }
 
 const sessionWin = ( id: string, over: Partial< SessionWindow > = {} ): SessionWindow => ( {
@@ -289,6 +309,91 @@ describe( 'installMobileConstraints', () => {
 			width: 1120,
 			height: 720,
 		} );
+		c.dispose();
+	} );
+
+	test( 'a window opened on another desk is folded onto the active one; the session records its own desk', () => {
+		const mode = fakeMode( 'mobile' );
+		// The session's focused window, restored on the desk it was on.
+		const restored = fakeWin( 'r', { config: { baseId: 'r', desktopId: 'desktop-2' } } );
+		const here = fakeWin( 'h', { config: { baseId: 'h', desktopId: 'desktop-1' } } );
+		const wins = [ restored, here ];
+		const { manager, moveWindowToDesktop } = fakeManager( wins, [ 'desktop-1', 'desktop-2' ] );
+		const c = installMobileConstraints( { manager, mode: mode.api, openNative: () => false } );
+
+		doAction( HOOKS.WINDOW_OPENED, { windowId: 'r' } );
+		doAction( HOOKS.WINDOW_OPENED, { windowId: 'h' } );
+		expect( moveWindowToDesktop ).toHaveBeenCalledTimes( 1 );
+		expect( moveWindowToDesktop ).toHaveBeenCalledWith( 'r', 'desktop-1' );
+		expect( restored.config.desktopId ).toBe( 'desktop-1' );
+		expect( c.foldedIds() ).toEqual( [ 'r' ] );
+
+		// Every save writes the desk the window came from, not the
+		// phone's; a window that was already here is untouched.
+		const snapshot: Session = {
+			windows: [
+				sessionWin( 'r', { desktopId: 'desktop-1', state: 'maximized' } ),
+				sessionWin( 'h', { desktopId: 'desktop-1' } ),
+			],
+			desktops: [ { id: 'desktop-1', label: 'Desktop 1' }, { id: 'desktop-2', label: 'Desktop 2' } ],
+			activeDesktop: 'desktop-1',
+			focused: 'r',
+			updated: 2,
+		};
+		const saved = applyFilters( HOOKS.SESSION_SNAPSHOT, snapshot );
+		// The desk it came from, with the geometry the full-screen
+		// belt-and-braces displaced (its snapshot said `normal`).
+		expect( saved.windows[ 0 ] ).toMatchObject( { id: 'r', desktopId: 'desktop-2', state: 'normal', x: 10, y: 20 } );
+		// A window that was already on this desk keeps its desk; only
+		// its geometry is handed back.
+		expect( saved.windows[ 1 ] ).toMatchObject( { id: 'h', desktopId: 'desktop-1', x: 10, y: 20 } );
+
+		// Closed on the phone: nothing left to hand back.
+		doAction( HOOKS.WINDOW_CLOSED, { windowId: 'r' } );
+		expect( c.foldedIds() ).toEqual( [] );
+
+		// Not on a phone, the desk a window opens on is its own.
+		mode.set( 'desktop' );
+		const later = fakeWin( 'd', { config: { baseId: 'd', desktopId: 'desktop-2' } } );
+		wins.push( later );
+		doAction( HOOKS.WINDOW_OPENED, { windowId: 'd' } );
+		expect( moveWindowToDesktop ).toHaveBeenCalledTimes( 1 );
+		c.dispose();
+	} );
+
+	test( 'crossing into mobile folds every desk; crossing out hands each window back and repairs focus', () => {
+		const mode = fakeMode( 'desktop' );
+		const away = fakeWin( 'a', { config: { baseId: 'a', desktopId: 'desktop-2' } } );
+		const gone = fakeWin( 'g', { config: { baseId: 'g', desktopId: 'desktop-3' } } );
+		const here = fakeWin( 'h', { config: { baseId: 'h', desktopId: 'desktop-1' } } );
+		// `away` last: it is the window in front when the phone leaves.
+		const desks = [ 'desktop-1', 'desktop-2', 'desktop-3' ];
+		const { manager, moveWindowToDesktop, focus } = fakeManager( [ here, gone, away ], desks );
+		const c = installMobileConstraints( { manager, mode: mode.api, openNative: () => false } );
+
+		mode.set( 'mobile' );
+		// `h` is already on the active desk and is left alone.
+		expect( moveWindowToDesktop.mock.calls ).toEqual( [
+			[ 'g', 'desktop-1' ],
+			[ 'a', 'desktop-1' ],
+		] );
+		expect( c.foldedIds() ).toEqual( [ 'g', 'a' ] );
+		expect( manager.getAll().every( ( w ) => w.config.desktopId === 'desktop-1' ) ).toBe( true );
+
+		// A desk closed while the phone had its window: the window
+		// stays where the desktop would have migrated it anyway.
+		desks.splice( desks.indexOf( 'desktop-3' ), 1 );
+
+		mode.set( 'desktop' );
+		expect( away.config.desktopId ).toBe( 'desktop-2' );
+		expect( gone.config.desktopId ).toBe( 'desktop-1' );
+		expect( here.config.desktopId ).toBe( 'desktop-1' );
+		expect( c.foldedIds() ).toEqual( [] );
+		// The window in front went back to desktop-2, so the topmost
+		// window still on the active desk takes the focus — as a
+		// desktop switch would have done.
+		expect( focus ).toHaveBeenCalledTimes( 1 );
+		expect( ( focus.mock.calls[ 0 ][ 0 ] as FakeWin ).id ).toBe( 'g' );
 		c.dispose();
 	} );
 


### PR DESCRIPTION
## Summary

On a phone, a window left on another desk was restored `display: none` and a tap on its home tile focused it invisibly. Code Blue was the one that showed it, because it is the window most likely to be parked on a second desk — but any window on any desk did the same.

This makes the phone layer's documented contract ("one screen, no virtual desktops") true, and switches workspaces off on the phone.

- **`WindowManager.moveWindowToDesktop( windowId, desktopId )`** — new. Re-homes one window, shows or hides it at once, fires the new `os.os.window-moved { windowId, from, to }` action.
- **Every window is on the one desk while the mode is `mobile`.** `src/mobile/constraints.ts` folds a window onto the active desk as it opens (a restored window and a parked recent both arrive carrying their desk), and folds everything already open on the crossing into the band. The desk each window came from is remembered, written back into every session save, and handed back on the crossing out — focus repaired the way `switchDesktop` repairs it. A desk closed in the meantime keeps the window on the active one.
- **Workspaces do nothing on a phone.** Navigation is computed with no profile, so the home grid shows every app; the desk's look is not painted over the user's settings, its widget column is not put up, its launch list is not opened. All of it comes back on the crossing out, and a desk never provisioned on the phone gets its launch list on arrival at the desktop.

Docs: `docs/mobile.md`, `docs/workspaces.md`, `docs/javascript-reference.md`.

## Test plan

- [ ] Open Code Blue on Desk 2, switch to Desk 1, load at phone width: the tile opens it on the first tap.
- [ ] Widen past the breakpoint: Code Blue leaves Desk 1 and is back on Desk 2, floating at its old size.
- [ ] Reload the desktop after a phone visit: Code Blue is still on Desk 2.
- [ ] With a Commerce or Publishing workspace active, go to phone width: the home grid shows every app, and the desk's accent or wallpaper is not applied.
- [x] `npm run typecheck`, `npm run lint`, `npm run test:js` (5626 passing), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-746-e01d0f9a42701d25b4a1ec72456ef07a1c8669a1.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->