### PR TITLE
Chromeless: fix in-page title actions a plugin has grouped

### DIFF
--- a/assets/css/chromeless.css
+++ b/assets/css/chromeless.css
@@ -244,6 +244,32 @@ html.wp-toolbar:has( body.os-chromeless ) {
 	display: none;
 }
 
+/*
+ * Core offsets every title action by `top: -3px` (common.css) so it
+ * sits on the H1's baseline. Chromeless hides the H1, and the first
+ * thing in the frame has nothing above it to overlap: the offset
+ * pulls the button's top border under the window's content edge and
+ * it renders cropped. The offset has no baseline left to meet here,
+ * so drop it.
+ *
+ * The margins are the same 12px the rule above gives a lone button,
+ * applied to whatever element a plugin grouped its buttons in. On a
+ * Jetpack site that is `div.wpcom-media-library-action-buttons`
+ * (external-media moves core's "Add Media File" into it so it can
+ * append "Import Media"; Big Sky adds "Generate Image" beside them),
+ * and a group is not a `.page-title-action`, so it picks up neither
+ * the margin nor the block layout and lands flush against the top.
+ * `:has()` reaches the group whatever a plugin decided to call it.
+ */
+.os-chromeless .wrap .page-title-action {
+	top: 0;
+}
+
+.os-chromeless .wrap :has( > .page-title-action ) {
+	margin-top: 12px;
+	margin-bottom: 12px;
+}
+
 /* ---------------------------------------------------------------
  * WooCommerce "embed page" header overlay — page-scoped.
  *

--- a/docs/plugin-compat-layer.md
+++ b/docs/plugin-compat-layer.md
@@ -160,13 +160,15 @@ WordPress renders a `.page-title-action` button beside the page `<h1>` on most l
 **Fix**: on chromeless requests the module walks `$submenu[ $parent_file ]`, resolves each entry through `openstation_menu_item_url()`, and adds one inline rule per URL to the `os-chromeless` stylesheet:
 
 ```css
-.os-chromeless .wrap > .page-title-action[href="https://example.com/wp-admin/post-new.php"],
-.os-chromeless .wrap > .page-title-action[href="post-new.php"] {
+.os-chromeless .wrap .page-title-action[href="https://example.com/wp-admin/post-new.php"],
+.os-chromeless .wrap .page-title-action[href="post-new.php"] {
     display: none;
 }
 ```
 
 Both spellings, because a CSS attribute selector compares the attribute's parsed value, which is entity-decoded but not resolved against the document URL: core writes the absolute URL, plenty of plugins hand-write the admin-relative one. Inline CSS rather than a DOM pass so the rule is in `<head>` before first paint (no button that appears and then vanishes) and the element stays in the DOM for the core scripts that toggle it.
+
+**The button is matched at any depth inside `.wrap`.** Core renders it as a direct child of the wrap, but a plugin is free to re-parent it, and on a Jetpack site one does: the external-media package lifts core's "Add Media File" anchor into a `div.wpcom-media-library-action-buttons` of its own so it can append "Import Media" beside it, and Big Sky's image studio inserts "Generate Image" into the same box. A child combinator stops at that wrapper, so a Media window shows a row of buttons under a tab strip that already leads to the same places. Depth says nothing about where a button goes, so it is not part of the test.
 
 **Matching is on the exact href**, and that is the entire design. What the rule does *not* hide:
 

--- a/includes/render/chromeless-title-actions.php
+++ b/includes/render/chromeless-title-actions.php
@@ -11,6 +11,16 @@
  * menu, matching `.page-title-action` on its `href`. A button is
  * hidden only when its destination is a tab in the same window.
  *
+ * The match is on `href`, at any depth inside `.wrap`. Core renders
+ * the button as a direct child, but a plugin is free to move it: on
+ * a Jetpack site the external-media package lifts core's "Add Media
+ * File" out of `.wrap` into a `div.wpcom-media-library-action-buttons`
+ * of its own so it can append "Import Media" beside it, and Big Sky
+ * inserts "Generate Image" into the same box. A `>` combinator stops
+ * at the wrapper and every one of those buttons survives next to the
+ * tab that already leads there. Depth says nothing about where a
+ * button goes, so it is not part of the test.
+ *
  * Matching is on the exact href, never a partial path compare. A
  * missed match leaves a redundant button; a loose match takes away
  * the only route to a page. So these all stay visible:
@@ -172,7 +182,7 @@ function openstation_chromeless_title_action_css( $tab_urls ) {
 		}
 
 		foreach ( $hrefs as $href ) {
-			$selectors[] = '.os-chromeless .wrap > .page-title-action[href="'
+			$selectors[] = '.os-chromeless .wrap .page-title-action[href="'
 				. openstation_chromeless_css_attr_value( $href ) . '"]' . $exclusions;
 		}
 	}

--- a/tests/phpunit/tests/openStationChromelessTitleActions.php
+++ b/tests/phpunit/tests/openStationChromelessTitleActions.php
@@ -148,6 +148,40 @@ class Tests_OpenStation_ChromelessTitleActions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A plugin may re-parent the button, and it still duplicates the
+	 * tab when it does.
+	 *
+	 * Jetpack's external-media package moves core's "Add Media File"
+	 * anchor into a `div.wpcom-media-library-action-buttons` so it can
+	 * put "Import Media" beside it, and Big Sky drops "Generate Image"
+	 * into the same box. With a `>` combinator none of the three is
+	 * reached, so a Media window shows the row of buttons under a tab
+	 * strip that already carries the same three destinations.
+	 */
+	public function test_matches_buttons_a_plugin_has_moved_out_of_the_wrap() {
+		$this->set_menu(
+			'upload.php',
+			array(
+				array( 'Library', 'upload_files', 'upload.php' ),
+				array( 'Add Media File', 'upload_files', 'media-new.php' ),
+			)
+		);
+
+		$css = $this->css();
+
+		$this->assertNotEmpty( $this->selectors( $css ) );
+		$this->assertStringNotContainsString( '.wrap > .page-title-action', $css );
+
+		foreach ( explode( ',', trim( strtok( $css, '{' ) ) ) as $selector ) {
+			$this->assertStringStartsWith(
+				'.os-chromeless .wrap .page-title-action[',
+				trim( $selector ),
+				'Depth inside .wrap says nothing about where a button goes.'
+			);
+		}
+	}
+
+	/**
 	 * The regression this module exists to prevent.
 	 *
 	 * On `plugin-install.php` the parent menu is `plugins.php`, whose


### PR DESCRIPTION
## What?

On a Jetpack site the Media window shows action buttons that repeat the tabs right above them, with their top border cut off by the window's content edge.

`jetpack-external-media` moves core's "Add Media File" anchor into a `div` of its own so it can append "Import Media", and wp-calypso's `image-studio` adds "Generate Image" to the same box. Two rules that assumed `.wrap > .page-title-action` then stop reaching it: the de-duplication that hides a button whose destination is already a tab, and the margin that keeps it clear of core's `top: -3px` baseline offset.

So match the button at any depth inside `.wrap`, drop an offset that has no baseline left to meet once chromeless hides the H1, and give a plugin's group the same margins a lone button gets. Still exact-href matching and still skipping the in-page toggles, so "Upload Plugin" and WooCommerce's "Add order" are untouched.

**Reproducing needs Jetpack with a connected user.** Jetpack registers the Import Media page and its button only for a connected user, so a clean install or a Playground demo shows a correct Media screen either way.

## Screenshots

| Before | After |
|---|---|
| <img width="2130" height="418" alt="Screenshot 2026-09-03 at 19 44 56" src="https://github.com/user-attachments/assets/e627ef29-1eec-4dad-b8f1-c694ff17336a" /> | <img width="2130" height="418" alt="Screenshot 2026-09-03 at 19 46 13" src="https://github.com/user-attachments/assets/3b495fcf-7129-4580-b93b-33abb741b177" /> |

## Testing instructions

1. On a site with Jetpack connected, open Media in a window narrower than about 780px, where WordPress switches to its small-screen admin layout.
2. Before: four buttons in a row, three repeating tabs, all missing their top border. After: only the buttons with no tab of their own, drawn in full, 12px below the tab strip.
3. "Generate Image" stays: it is a `<button>` with no destination to compare. In grid mode "Add Media File" stays too, since there it is core's drop-zone toggle, not a link to `media-new.php`.
4. Without Jetpack, check nothing moved: Plugins then Add Plugin still offers "Upload Plugin", and the "Add New" button on Posts, Pages and Users is still hidden by its tab.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-750-72871d743a107dd481c3b0aa3715cd36b868ceb7.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->