### PR TITLE
PWA: the shell never reloads itself — a waiting worker, a build stamp, and a Reload the user takes

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -95,29 +95,63 @@ the icon is tapped, and there is no reload button to ask for a newer
 one. Three things together close that gap:
 
 1. **Every release is a new worker.** The served `sw.js` carries the
-   plugin version in its `self.__OS_SW_CONFIG` preamble. The bundle
-   itself is content-hashed, so without this a release that touched
-   nothing under `src/pwa/` would serve byte-identical script and the
-   browser — which only installs a worker whose bytes differ — would
-   have nothing to install.
+   plugin version and the shell-build stamp in its `self.__OS_SW_CONFIG`
+   preamble. The bundle itself is content-hashed, so without these a
+   release that touched nothing under `src/pwa/` would serve
+   byte-identical script and the browser — which only installs a worker
+   whose bytes differ — would have nothing to install.
 2. **The shell checks on every return.** `registerServiceWorker()`
    calls `registration.update()` when the page comes back to the
    foreground (`visibilitychange` to visible, and `pageshow` from the
    back-forward cache), at most once every five minutes and never while
    hidden. The script is served `no-cache` and registered with
    `updateViaCache: 'none'`, so the check always compares real bytes.
-3. **The new worker takes over and the shell reloads once.** The worker
-   `skipWaiting()`s on install and claims its clients on activate; the
-   shell's `controllerchange` handler reloads the page (throttled to
-   one reload per 30 s, and never on the very first activation, when
-   the bundle was fetched fresh anyway).
+3. **The new worker waits; the shell asks, and at most offers.** The
+   worker never `skipWaiting()`s on its own — it installs and sits in
+   `waiting` (the standard prompt-for-update shape). The shell finds it
+   there (`registration.waiting` at boot, or `updatefound` →
+   `installed` mid-session) and asks which shell build it was served
+   with (`os-sw-get-build` → `os-sw-build`). Same stamp as the one the
+   page booted with (`PwaConfig.shellBuild`), or unknown on either
+   side: the shell tells it to take over (`os-sw-skip-waiting`),
+   silently — caches refresh, nothing is shown. A different stamp —
+   the shell's own files really changed on the server — shows a
+   persistent toast with a **Reload** action, and the worker keeps
+   waiting until the user takes it. A release that changed nothing
+   under `assets/`, a worker-only change, or a preamble that moved for
+   another reason is a new worker and not a word to the user.
 
-So a phone picked up after a deploy checks within a second of waking
-and, when a release landed, reloads onto it. A shell running during a
-deploy is handled by the same handler. Between releases a rebuild that
-changed only `desktop.min.js` does not produce a new worker (that is the
-point of the content hash: no phantom reloads after `npm run build`);
-a cold launch of the app, or a navigation, is what picks those up.
+**The shell never reloads itself.** A desktop is somebody's work in
+progress; the reload is the user's to take, from the toast, when they
+are ready. Taking it does three things in order: the waiting worker is
+told to take over and the shell waits for `controllerchange` (bounded
+by a short timeout, so a worker that will not swap cannot hold the
+reload hostage); the session is written to the server and the
+navigation waits for the answer — an unload beacon racing the request
+that reads the session back is how two open windows once came back as
+none; then the page reloads, served by the worker that matches it.
+
+Why waiting rather than taking over on install: the activate handler
+drops the previous version's caches, so a worker that claimed a page
+still running the previous bundle left that page able to ask for a
+lazy bundle from a bucket that no longer existed. A page and its worker
+now change together. The one case where they cannot is another tab
+consenting first — the new worker claims every tab; a page that sees a
+`controllerchange` it did not ask for runs the same comparison against
+the new controller and, when the shell changed, makes the same offer.
+A first install (no controller yet) activates on its own and is never a
+takeover: the bundle came straight from the network and there is
+nothing to compare.
+
+The stamp is `openstation_shell_build_stamp()`: a content hash over
+every stylesheet in `assets/css/` and every bundle in `assets/js/`,
+memoised behind the files' (path, size, mtime) signature. Bytes, not
+clocks — a deploy rewrites every mtime whether or not the contents
+moved, and the plugin version moves on releases that never touched the
+shell. Between releases a rebuild that changed only `desktop.min.js`
+does not produce a new worker (that is the point of the worker's own
+content hash: no phantom activity after `npm run build`); a cold launch
+of the app, or a navigation, is what picks those up.
 
 ## Caching policy
 
@@ -224,6 +258,23 @@ Both messages are posted to `navigator.serviceWorker.controller` and are ignored
 
 The shell-side helpers are `speculateDocument( url )` and `rememberRestoreTargets( urls )` in `src/pwa/speculate.ts`. Policy lives in `src/pwa/sw-policy.ts` (`isSpeculatableDocument`) and the store in `src/pwa/speculative-store.ts`; both are pure and unit-tested.
 
+Three more are not gated on any opt-in — they are how a new worker and the shell agree on a takeover (see [How a release reaches an installed app](#how-a-release-reaches-an-installed-app)). The first two are posted to the WAITING worker (`registration.waiting`), not the controller:
+
+```js
+// Shell → worker: which shell build were you served with?
+{ type: 'os-sw-get-build' }
+
+// Worker → the asking client. `shellBuild` is the preamble's stamp, or
+// '' for a body served without one — which the shell reads as
+// "unknown", never as "changed".
+{ type: 'os-sw-build', shellBuild: '<16 hex chars>' }
+
+// Shell → waiting worker: take over now. The only thing that makes the
+// worker skipWaiting(); sent silently when the shell did not change,
+// and on the user's Reload when it did.
+{ type: 'os-sw-skip-waiting' }
+```
+
 ## PHP surface
 
 | Symbol | Role |
@@ -234,6 +285,7 @@ The shell-side helpers are `speculateDocument( url )` and `rememberRestoreTarget
 | `openstation_pwa_get_user_state( $user_id = 0 )` | Read the per-user PWA UI state. |
 | `openstation_pwa_update_user_state( array $patch, $user_id = 0 )` | Merge a partial update into the state. |
 | `openstation_pwa_admin_asset_cache_enabled()` | Whether the shared admin-asset cache is on (resolves the filter below). |
+| `openstation_shell_build_stamp()` | Content hash of the shell's built files (`assets/css/*.css`, `assets/js/*.js`); 16 hex characters, `''` when nothing is built. Carried by `openStationConfig.pwa.shellBuild` and by the worker preamble. |
 | `openstation_pwa_manifest` (filter) | Mutate manifest fields before encoding. |
 | `openstation_pwa_admin_asset_cache` (filter) | Force or veto the shared admin-asset cache site-wide. Default: the requesting user's `adminAssetCacheEnabled` preference (off until they opt in). |
 

--- a/includes/pwa.php
+++ b/includes/pwa.php
@@ -246,12 +246,101 @@ function openstation_pwa_sw_config_preamble() {
 	 * app on a phone rarely navigates; the shell re-checks the script on
 	 * every return to the foreground (`src/pwa/sw-register.ts`), and the
 	 * version in the preamble is what makes that check find a release.
+	 *
+	 * `shellBuild` is the content hash of the shell's own built files
+	 * ({@see openstation_shell_build_stamp()}). It makes a deploy that
+	 * changed the shell a new worker too, and — more importantly — it
+	 * tells the shell, when that worker takes over mid-session, whether
+	 * the shell it is running is the one the server now serves. A new
+	 * worker is never a reason to reload on its own: a release that
+	 * changed nothing under `assets/` produces a worker whose
+	 * `shellBuild` equals the running shell's, and the shell stays put.
 	 */
 	$config = array(
-		'pluginUrl' => OPENSTATION_URL,
-		'version'   => OPENSTATION_VERSION,
+		'pluginUrl'  => OPENSTATION_URL,
+		'version'    => OPENSTATION_VERSION,
+		'shellBuild' => openstation_shell_build_stamp(),
 	);
 	return sprintf( "self.__OS_SW_CONFIG = %s;\n", wp_json_encode( $config ) );
+}
+
+/**
+ * Content hash of the shell's built front-end: every stylesheet under
+ * `assets/css/` and every bundle under `assets/js/`.
+ *
+ * "Did the shell change?" answered from bytes, not clocks. A deploy
+ * rewrites every file's mtime whether or not its contents moved, and
+ * the plugin version moves on releases that never touched the shell;
+ * neither is a reason to disturb a desktop someone is working in. The
+ * stamp changes exactly when a shell file's bytes do.
+ *
+ * Two readers: `openStationConfig.pwa.shellBuild`, which the shell
+ * boots with, and the served service worker's preamble, so the worker
+ * knows which shell it was served alongside. When a worker takes over
+ * a running shell the two are compared, and only a difference — a real
+ * change in the shell files — earns the user an offer to reload. See
+ * `src/pwa/sw-register.ts`.
+ *
+ * Hashing a few megabytes of bundles on every shell request would be
+ * wasteful, so the stamp is memoised in one transient behind the cheap
+ * signature of the same files (path, size, mtime). A deploy changes
+ * the signature and the hash is recomputed once; identical bytes come
+ * out as the identical stamp, and a touched-but-unchanged file costs a
+ * single rehash.
+ *
+ * @param string|null $dir Plugin directory to read. `OPENSTATION_DIR` by
+ *                         default; tests hand in a fixture.
+ * @return string Sixteen hex characters, or '' when nothing is built.
+ */
+function openstation_shell_build_stamp( $dir = null ) {
+	static $memo = array();
+
+	$dir = null === $dir ? OPENSTATION_DIR : trailingslashit( $dir );
+
+	$files = array();
+	foreach ( array( 'assets/css/*.css', 'assets/js/*.js' ) as $pattern ) {
+		$matches = glob( $dir . $pattern );
+		if ( is_array( $matches ) ) {
+			$files = array_merge( $files, $matches );
+		}
+	}
+	sort( $files );
+	if ( empty( $files ) ) {
+		return '';
+	}
+
+	$signature = array( $dir );
+	foreach ( $files as $file ) {
+		$signature[] = substr( $file, strlen( $dir ) ) . ':' . filesize( $file ) . ':' . filemtime( $file );
+	}
+	$signature = md5( implode( "\n", $signature ) );
+
+	if ( isset( $memo[ $signature ] ) ) {
+		return $memo[ $signature ];
+	}
+
+	$cached = get_transient( 'openstation_shell_build' );
+	if ( is_array( $cached ) && isset( $cached['signature'], $cached['stamp'] ) && $cached['signature'] === $signature && is_string( $cached['stamp'] ) ) {
+		$memo[ $signature ] = $cached['stamp'];
+		return $cached['stamp'];
+	}
+
+	$hashes = array();
+	foreach ( $files as $file ) {
+		$hashes[] = substr( $file, strlen( $dir ) ) . ':' . md5_file( $file );
+	}
+	$stamp = substr( md5( implode( "\n", $hashes ) ), 0, 16 );
+
+	$memo[ $signature ] = $stamp;
+	set_transient(
+		'openstation_shell_build',
+		array(
+			'signature' => $signature,
+			'stamp'     => $stamp,
+		),
+		DAY_IN_SECONDS
+	);
+	return $stamp;
 }
 
 /**
@@ -580,15 +669,15 @@ function openstation_pwa_serve_service_worker() {
 	// `npm run build` rewrites `sw.min.js` on every run, bumping its
 	// mtime even when the SW source is byte-identical. Each rebuild
 	// produced a different stamp → different SW response → browser
-	// installed a "new" SW → `controllerchange` fired → the
-	// `bindControllerChangeReload` hook in `src/pwa/sw-register.ts`
-	// auto-reloaded the page. The user observed a "phantom reload"
-	// 2–3s after every `npm run build`, even when only an unrelated
-	// bundle (e.g. `desktop.min.js`) had changed.
+	// installed a "new" SW → `controllerchange` fired → the shell of
+	// the day auto-reloaded the page. The user observed a "phantom
+	// reload" 2–3s after every `npm run build`, even when only an
+	// unrelated bundle (e.g. `desktop.min.js`) had changed.
 	//
 	// A content hash collapses identical bodies onto identical stamps
-	// — only a *real* change in `src/pwa/sw.ts` triggers the SW
-	// update / reload pipeline. `md5` is plenty for an integrity
+	// — only a *real* change in `src/pwa/sw.ts` installs a new worker.
+	// (The shell no longer reloads on a new worker at all; see
+	// `src/pwa/sw-register.ts`.) `md5` is plenty for an integrity
 	// stamp here (no security implications) and short enough that the
 	// inline comment stays under one line.
 	$stamp = substr( md5( $body ), 0, 16 );

--- a/includes/render/assets.php
+++ b/includes/render/assets.php
@@ -772,10 +772,9 @@ function openstation_enqueue_assets() {
 				// preferences, so putting them in the script bytes made
 				// the body differ between an anonymous and a logged-in
 				// request — and any in-scope logged-out navigation then
-				// installed a "new" worker and tripped the shell's
-				// `controllerchange` reload. The bytes are identical for
-				// everyone now; the shell posts these to the worker at
-				// boot.
+				// installed a "new" worker, which at the time reloaded
+				// the shell. The bytes are identical for everyone now;
+				// the shell posts these to the worker at boot.
 				//
 				// Computed server-side, not read from the settings
 				// snapshot client-side, because
@@ -786,6 +785,12 @@ function openstation_enqueue_assets() {
 					'adminAssetCache' => (bool) openstation_pwa_admin_asset_cache_enabled(),
 					'windowPrewarm'   => ! empty( openstation_get_os_settings( get_current_user_id() )['windowPrewarmEnabled'] ),
 				),
+				// The build this shell document belongs to. When a new
+				// worker takes over mid-session the shell asks it for
+				// the stamp it was served with and compares; only a
+				// difference — the shell's own files changed on the
+				// server — offers the user a reload. Never automatic.
+				'shellBuild'     => openstation_shell_build_stamp(),
 				'stateUrl'       => esc_url_raw( rest_url( 'desktop-mode/v1/pwa-state' ) ),
 				'state'          => openstation_pwa_get_user_state( get_current_user_id() ),
 				// Mirrors the manifest's `name` field — used by the

--- a/src/boot/session-saver.ts
+++ b/src/boot/session-saver.ts
@@ -101,13 +101,27 @@ function noteRestoreTargets( payload: Session ): void {
 	}
 }
 
+/**
+ * The saver. Calling it schedules a debounced write; `flush()` writes
+ * now and resolves once the server has answered.
+ */
+export type SessionSaver = ( () => void ) & {
+	flush: () => Promise< void >;
+};
+
 export function createSessionSaver(
 	manager: WindowManager,
 	config: DesktopConfig,
-): () => void {
+): SessionSaver {
 	let debounceTimer: number | null = null;
 	let inFlight = false;
 	let dirty = false;
+	/**
+	 * The write on the wire, while there is one. `flush()` waits on it
+	 * before taking its own snapshot, so a save that predates the state
+	 * being flushed is never the last word.
+	 */
+	let activeSave: Promise< void > | null = null;
 	/** When the last network write started. 0 = none yet. */
 	let lastSaveStartedAt = 0;
 	/**
@@ -125,7 +139,7 @@ export function createSessionSaver(
 	 */
 	let lastAccepted: string | null = null;
 
-	const doSave = async (): Promise< void > => {
+	const doSave = (): Promise< void > => {
 		if ( inFlight ) {
 			// A save is already on the wire, and this call was
 			// triggered by state the in-flight payload predates.
@@ -138,7 +152,7 @@ export function createSessionSaver(
 			// quick succession on a slow connection, reload, and the
 			// second one is back.
 			dirty = true;
-			return;
+			return Promise.resolve();
 		}
 		// Snapshot as late as possible — after the in-flight guard —
 		// so the payload reflects the state at send time, not at the
@@ -149,56 +163,86 @@ export function createSessionSaver(
 			// Nothing changed since the server last heard from us.
 			// The rate-limit clock stays where it was: no write went
 			// out, so the next real change owes nothing to this one.
-			return;
+			return Promise.resolve();
 		}
 		inFlight = true;
 		lastSaveStartedAt = Date.now();
 
 		noteRestoreTargets( payload );
 
-		try {
-			// Session save is a debounced background ping — silent
-			// so the user doesn't see a spinner every time they
-			// move a window.
-			const response = await trackedFetch(
-				manager,
-				config.sessionUrl,
-				{
-					method: 'POST',
-					credentials: 'same-origin',
-					headers: {
-						'Content-Type': 'application/json',
-						'X-WP-Nonce': config.restNonce,
+		activeSave = ( async () => {
+			try {
+				// Session save is a debounced background ping — silent
+				// so the user doesn't see a spinner every time they
+				// move a window.
+				const response = await trackedFetch(
+					manager,
+					config.sessionUrl,
+					{
+						method: 'POST',
+						credentials: 'same-origin',
+						headers: {
+							'Content-Type': 'application/json',
+							'X-WP-Nonce': config.restNonce,
+						},
+						body: JSON.stringify( { session: payload } ),
+						// Best-effort: we don't block the UI on persistence.
+						keepalive: true,
 					},
-					body: JSON.stringify( { session: payload } ),
-					// Best-effort: we don't block the UI on persistence.
-					keepalive: true,
-				},
-				{ silent: true },
-			);
-			// Only a write the server took counts. A 403 from an
-			// expired nonce, or a 5xx, leaves the server on the older
-			// session, and the next change must carry this one again.
-			if ( response?.ok ) {
-				lastAccepted = current;
+					{ silent: true },
+				);
+				// Only a write the server took counts. A 403 from an
+				// expired nonce, or a 5xx, leaves the server on the older
+				// session, and the next change must carry this one again.
+				if ( response?.ok ) {
+					lastAccepted = current;
+				}
+			} catch ( err ) {
+				/* Network error is non-fatal — next change triggers
+				 * another save. Still worth surfacing to monitor widgets
+				 * so a connectivity regression doesn't go silent under
+				 * the session-beacon path. */
+				doAction( HOOKS.SHELL_ERROR, { scope: 'session-save', error: err } );
+			} finally {
+				inFlight = false;
+				activeSave = null;
+				if ( dirty ) {
+					dirty = false;
+					// Back through `schedule()`, not straight into another
+					// `doSave()`. Handing over directly would let a slow
+					// request chain into an immediate second write and
+					// sidestep both the debounce and the rate limit.
+					schedule();
+				}
 			}
-		} catch ( err ) {
-			/* Network error is non-fatal — next change triggers
-			 * another save. Still worth surfacing to monitor widgets
-			 * so a connectivity regression doesn't go silent under
-			 * the session-beacon path. */
-			doAction( HOOKS.SHELL_ERROR, { scope: 'session-save', error: err } );
-		} finally {
-			inFlight = false;
-			if ( dirty ) {
-				dirty = false;
-				// Back through `schedule()`, not straight into another
-				// `doSave()`. Handing over directly would let a slow
-				// request chain into an immediate second write and
-				// sidestep both the debounce and the rate limit.
-				schedule();
-			}
+		} )();
+		return activeSave;
+	};
+
+	/**
+	 * Write now, and resolve once the server has answered.
+	 *
+	 * For the one caller about to leave the page on purpose — the
+	 * reload the shell offers after a deploy changed its files. The
+	 * unload beacon is fire-and-forget, and a navigation started in
+	 * the same breath can have the server read the session back before
+	 * the beacon's write lands; the desktop then comes back as the
+	 * older snapshot. Waiting for the answer is the whole difference.
+	 * A write already on the wire finishes first, since its snapshot
+	 * may predate the state being flushed. Never rejects: a failed
+	 * write is the same best-effort it always was, and the caller
+	 * navigates either way.
+	 */
+	const flush = async (): Promise< void > => {
+		if ( debounceTimer !== null ) {
+			clearTimeout( debounceTimer );
+			debounceTimer = null;
 		}
+		while ( activeSave ) {
+			await activeSave;
+		}
+		dirty = false;
+		await doSave();
 	};
 
 	const flushImmediately = (): void => {
@@ -294,5 +338,5 @@ export function createSessionSaver(
 		}
 	} );
 
-	return schedule;
+	return Object.assign( schedule, { flush } );
 }

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -5105,7 +5105,17 @@ function init(): void {
 	// callback can immediately call `wp.os.pwa.*` or the
 	// `wp.os.notify` API. No-op when `config.pwa` is absent
 	// (chromeless context, classic admin, older PHP build).
-	bootstrapPwa( config, showToast );
+	//
+	// The reload handed in is the only one the shell ever performs,
+	// and only because the user asked for it from the toast. The
+	// session goes to the server first and the navigation waits for
+	// the answer, so the desktop comes back exactly as it was left —
+	// an unload beacon racing the request that reads the session back
+	// is how two open windows once came back as none.
+	bootstrapPwa( config, showToast, async () => {
+		await saveSession.flush();
+		window.location.reload();
+	} );
 
 	// Pre-load the shell-overlays bundle (toast + confirm-dialog +
 	// context-menu component classes) in the background once we're

--- a/src/pwa/index.ts
+++ b/src/pwa/index.ts
@@ -19,13 +19,25 @@
 
 import type { DesktopConfig } from '../types';
 import type { ToastOptions } from '../toast';
+import { __ } from '../i18n';
 import { initPwaState } from './state';
 import { installPwaInstallAffordance } from './install';
-import { registerServiceWorker } from './sw-register';
+import { applyPendingUpdate, registerServiceWorker } from './sw-register';
 
+/**
+ * @param config      The boot config; a no-op without `config.pwa`.
+ * @param showToast   The shell's toast.
+ * @param reloadShell Reloads the desktop on the user's say-so, after
+ *                    the session has reached the server. Offered — in
+ *                    a toast with a Reload action — when a deploy
+ *                    changed the shell's own files while this desktop
+ *                    was open. The shell never reloads itself; without
+ *                    this, a changed build is simply not mentioned.
+ */
 export function bootstrapPwa(
 	config: DesktopConfig,
 	showToast: ( opts: ToastOptions ) => () => void,
+	reloadShell?: () => void | Promise< void >,
 ): void {
 	if ( ! config.pwa ) {
 		return;
@@ -35,10 +47,30 @@ export function bootstrapPwa(
 		config.pwa.appName || 'WordPress',
 		showToast,
 	);
+	// A deploy changed the shell's own files while this desktop was
+	// open: say so, once, and leave the reload to the user. Taking the
+	// offer swaps the waiting worker in first, so the page that comes
+	// back is served by the worker that matches it.
+	const onShellUpdated = reloadShell
+		? (): void => {
+			showToast( {
+				message: __( 'A new version of OpenStation is available.' ),
+				action: {
+					label: __( 'Reload' ),
+					onClick: () => {
+						void applyPendingUpdate().then( () => reloadShell() );
+					},
+				},
+				persistent: true,
+				dismissible: true,
+			} );
+		}
+		: undefined;
 	// Fire-and-forget — registration is async but the rest of the
 	// shell doesn't gate on it.
 	void registerServiceWorker( config.pwa, {
 		forceReplace: !! config.pwa.forceReplaceSw,
+		onShellUpdated,
 	} );
 }
 

--- a/src/pwa/sw-policy.ts
+++ b/src/pwa/sw-policy.ts
@@ -41,7 +41,18 @@ export interface SwConfig {
 	 * `wp-content` layout (Bedrock, moved `WP_CONTENT_DIR`, …).
 	 */
 	pluginUrl: string;
+	/**
+	 * Content hash of the shell's built files at the moment this worker
+	 * was served (`openstation_shell_build_stamp()`). The shell asks a
+	 * worker that takes over mid-session for it and compares it with
+	 * its own boot-time stamp: a difference means the shell files on the
+	 * server really changed. Empty for a body served without one.
+	 */
+	shellBuild: string;
 }
+
+/** What a shell-build stamp looks like: short hex, nothing else. */
+const SHELL_BUILD_RE = /^[a-f0-9]{8,64}$/;
 
 /**
  * How the fetch handler should treat a same-origin GET:
@@ -93,6 +104,7 @@ export function readSwConfig(
 		adminAssetCache: false,
 		windowPrewarm: false,
 		pluginUrl: fallbackPluginUrl,
+		shellBuild: '',
 	};
 	if ( ! raw || typeof raw !== 'object' ) {
 		return cfg;
@@ -100,6 +112,9 @@ export function readSwConfig(
 	const obj = raw as Record< string, unknown >;
 	cfg.adminAssetCache = obj.adminAssetCache === true;
 	cfg.windowPrewarm = obj.windowPrewarm === true;
+	if ( typeof obj.shellBuild === 'string' && SHELL_BUILD_RE.test( obj.shellBuild ) ) {
+		cfg.shellBuild = obj.shellBuild;
+	}
 	if (
 		typeof obj.pluginUrl === 'string' &&
 		obj.pluginUrl.startsWith( 'http' )

--- a/src/pwa/sw-register.ts
+++ b/src/pwa/sw-register.ts
@@ -57,74 +57,230 @@ export type SwRegistrationStatus =
 
 let _registration: ServiceWorkerRegistration | null = null;
 let _registrationFailed = false;
-let _controllerChangeBound = false;
-let _reloadingForSwUpdate = false;
+let _updatesBound = false;
+let _shellUpdateAnnounced = false;
+/** The installed worker waiting for the shell's consent, if any. */
+let _waitingWorker: ServiceWorker | null = null;
+/** A swap this page asked for; the next `controllerchange` is it. */
+let _swapExpected = false;
+/** Resolvers waiting on that `controllerchange`. */
+let _swapListeners: Array< () => void > = [];
 let _status: SwRegistrationStatus = 'pending';
 
+/** What the shell is told when a new worker carries a new shell build. */
+export interface ShellUpdateInfo {
+	/** The stamp this document booted with. */
+	current: string;
+	/** The stamp the new worker was served with. */
+	served: string;
+}
+
 /**
- * Wire up the auto-reload on SW takeover. Two scenarios distinguished:
- *
- *   - **Cold start** — page loaded with NO prior SW controller, then
- *     just registered + activated one. No reload: the bundle was
- *     fetched directly from the network (the SW couldn't have
- *     intercepted requests it didn't yet exist for), so it's already
- *     fresh. Reloading here would be a gratuitous flicker on every
- *     first PWA open.
- *
- *   - **Deploy mid-session** — page was already controlled by an
- *     older SW, the new SW just activated and replaced it. Reload
- *     once so subsequent fetches go through the new SW (which is
- *     network-first for JS) and the freshly-deployed bundle takes
- *     effect immediately.
- *
- * The discriminator is `navigator.serviceWorker.controller` at bind
- * time: truthy → already controlled (any future controllerchange is
- * a deploy); falsy → cold start (the upcoming controllerchange is
- * the first activation, no reload needed).
- *
- * Idempotent — guarded by `_controllerChangeBound` /
- * `_reloadingForSwUpdate` so a second controllerchange event (rare,
- * but spec-permitted) doesn't loop.
+ * How long a worker gets to answer `os-sw-get-build`. A worker that
+ * never answers is treated as "unknown".
  */
-function bindControllerChangeReload(): void {
-	if ( _controllerChangeBound ) {
+const BUILD_REPLY_TIMEOUT_MS = 5000;
+
+/**
+ * How long {@link applyPendingUpdate} waits for the swap it asked for.
+ * The reload it precedes is the user's; if the worker never takes
+ * over, the reload still happens, onto the old worker, and the new one
+ * is found waiting again on the next boot.
+ */
+const SWAP_TIMEOUT_MS = 3000;
+
+/**
+ * Watch the registration for a new worker, and decide what to do with
+ * one — the update policy, in one place.
+ *
+ * A new worker installs and then WAITS (the worker never
+ * `skipWaiting()`s on its own — see `src/pwa/sw.ts`). Waiting is where
+ * the shell finds it, on two paths: `registration.waiting` already set
+ * when this page registers (a deploy that landed before this boot, or
+ * a boot on a tab that never consented), and `updatefound` →
+ * `installed` for one arriving mid-session. Either way the shell asks
+ * the worker which shell build it was served with, and compares that
+ * with its own (`PwaConfig.shellBuild`):
+ *
+ *   - **Same stamp**, or unknown on either side (an older server, a
+ *     body served without a preamble, a worker that does not answer):
+ *     the shell's files did not change, or nobody can tell. The worker
+ *     is told to take over silently. Caches refresh; nothing is shown;
+ *     nothing reloads.
+ *   - **Different stamp**: the shell's files really changed on the
+ *     server. `onShellUpdated` runs — once per page — so the shell can
+ *     *offer* a reload. The worker keeps waiting until the user takes
+ *     the offer ({@link applyPendingUpdate}) or every tab closes.
+ *
+ * Nothing here reloads. The shell never reloads itself: a desktop is
+ * somebody's work in progress.
+ *
+ * `controllerchange` is the swap having happened. When this page asked
+ * for it, that is the signal {@link applyPendingUpdate} waits on. When
+ * it did not — another tab consented, and the new worker claimed this
+ * one too — the page is now running an old bundle under a new worker,
+ * which is exactly the situation the waiting pattern avoids on a single
+ * tab; the same comparison runs against the controller and, when the
+ * shell changed, the same offer is made.
+ *
+ * A first install — no controller when the worker installs — activates
+ * on its own and is never a takeover: this page's bundle came straight
+ * from the network, and there is nothing to compare.
+ */
+function watchForUpdates(
+	registration: ServiceWorkerRegistration,
+	config: Pick< PwaConfig, 'shellBuild' >,
+	onShellUpdated?: ( info: ShellUpdateInfo ) => void,
+): void {
+	if ( _updatesBound ) {
 		return;
 	}
-	_controllerChangeBound = true;
-	const hadInitialController = !! navigator.serviceWorker.controller;
+	_updatesBound = true;
+	const current = typeof config.shellBuild === 'string' ? config.shellBuild : '';
+
+	const consider = ( worker: ServiceWorker, waiting: boolean ): void => {
+		void askWorkerForBuild( worker ).then( ( served ) => {
+			const changed = current !== '' && served !== '' && served !== current;
+			if ( ! changed ) {
+				if ( waiting ) {
+					requestSwap( worker );
+				}
+				return;
+			}
+			if ( waiting ) {
+				_waitingWorker = worker;
+			}
+			if ( _shellUpdateAnnounced || ! onShellUpdated ) {
+				return;
+			}
+			_shellUpdateAnnounced = true;
+			onShellUpdated( { current, served } );
+		} );
+	};
+
+	// The worker in `installing` reports through `statechange`; only
+	// one that reaches `installed` while this page is controlled is a
+	// waiting update (a first install activates on its own).
+	const track = ( worker: ServiceWorker | null ): void => {
+		if ( ! worker || typeof worker.addEventListener !== 'function' ) {
+			return;
+		}
+		worker.addEventListener( 'statechange', () => {
+			if ( worker.state === 'installed' && navigator.serviceWorker.controller ) {
+				consider( worker, true );
+			}
+		} );
+	};
+
+	if ( registration.waiting && navigator.serviceWorker.controller ) {
+		consider( registration.waiting, true );
+	}
+	track( registration.installing ?? null );
+	if ( typeof registration.addEventListener === 'function' ) {
+		registration.addEventListener( 'updatefound', () => {
+			track( registration.installing ?? null );
+		} );
+	}
+
 	navigator.serviceWorker.addEventListener( 'controllerchange', () => {
-		if ( ! hadInitialController ) {
-			// Cold start — first-ever SW activation for this page.
-			// Bundle is already fresh; no reload.
+		_waitingWorker = null;
+		if ( _swapExpected ) {
+			_swapExpected = false;
+			const listeners = _swapListeners;
+			_swapListeners = [];
+			for ( const done of listeners ) {
+				done();
+			}
 			return;
 		}
-		if ( _reloadingForSwUpdate ) {
-			return;
+		// A swap this page did not ask for. Not a first activation —
+		// `updatefound` never led here without a controller — but
+		// another tab's consent, or a worker that activated because
+		// every other tab closed. Compare, and offer if it matters.
+		const controller = navigator.serviceWorker.controller;
+		if ( controller ) {
+			consider( controller, false );
 		}
-		// Throttle reloads to prevent infinite cycles under DevTools'
-		// "Application → Service Workers → Update on reload". That flag
-		// forces an install + activate on every page load even when the
-		// SW bytes are byte-identical, so every reload we trigger here
-		// causes ANOTHER `controllerchange` on the next load, which
-		// triggers another reload, ad infinitum.
-		//
-		// Window: 30s. Real-deploy reloads coalesce across rapid
-		// successive activations; the user picks up the new bundle on
-		// the next reload past the window.
-		if ( wasRecentlyReloadedForSwUpdate() ) {
-			return;
-		}
-		markReloadedForSwUpdate();
-		_reloadingForSwUpdate = true;
-		// One-frame delay so any in-flight UI work has a chance to
-		// settle before the navigation. Not strictly required, but
-		// avoids a class of "click → reload races input" surprises.
-		setTimeout( () => window.location.reload(), 0 );
 	} );
 }
 
-const SW_RELOAD_THROTTLE_KEY = 'os-sw-reload-ts';
-const SW_RELOAD_THROTTLE_MS = 30_000;
+/**
+ * Tell a waiting worker to take over. The `controllerchange` that
+ * follows is expected, and {@link applyPendingUpdate} may be waiting on
+ * it.
+ */
+function requestSwap( worker: ServiceWorker ): void {
+	_swapExpected = true;
+	try {
+		worker.postMessage( { type: 'os-sw-skip-waiting' } );
+	} catch {
+		_swapExpected = false;
+	}
+}
+
+/**
+ * Take the offered update: make the waiting worker current, and
+ * resolve once it is (or after {@link SWAP_TIMEOUT_MS}). Resolves at
+ * once when there is nothing waiting — the new worker already took over
+ * through another tab. Never reloads; the caller does that, after the
+ * session has reached the server.
+ */
+export function applyPendingUpdate(): Promise< void > {
+	const worker = _waitingWorker;
+	if ( ! worker ) {
+		return Promise.resolve();
+	}
+	return new Promise( ( resolve ) => {
+		let done = false;
+		const finish = (): void => {
+			if ( done ) {
+				return;
+			}
+			done = true;
+			window.clearTimeout( timer );
+			resolve();
+		};
+		const timer = window.setTimeout( finish, SWAP_TIMEOUT_MS );
+		_swapListeners.push( finish );
+		requestSwap( worker );
+		if ( ! _swapExpected ) {
+			finish();
+		}
+	} );
+}
+
+/**
+ * Ask a worker which shell build it was served with. Resolves `''` on
+ * no answer in time, or an answer without a usable stamp.
+ */
+function askWorkerForBuild( worker: ServiceWorker ): Promise< string > {
+	return new Promise( ( resolve ) => {
+		let done = false;
+		let timer = 0;
+		const onMessage = ( ev: MessageEvent ): void => {
+			const data = ev.data as { type?: unknown; shellBuild?: unknown } | null;
+			if ( data && data.type === 'os-sw-build' ) {
+				finish( typeof data.shellBuild === 'string' ? data.shellBuild : '' );
+			}
+		};
+		const finish = ( value: string ): void => {
+			if ( done ) {
+				return;
+			}
+			done = true;
+			window.clearTimeout( timer );
+			navigator.serviceWorker.removeEventListener( 'message', onMessage );
+			resolve( value );
+		};
+		timer = window.setTimeout( () => finish( '' ), BUILD_REPLY_TIMEOUT_MS );
+		navigator.serviceWorker.addEventListener( 'message', onMessage );
+		try {
+			worker.postMessage( { type: 'os-sw-get-build' } );
+		} catch {
+			finish( '' );
+		}
+	} );
+}
 
 /**
  * Least time between two resume-time update checks.
@@ -158,10 +314,12 @@ let _lastResumeCheckAt = 0;
  * `pageshow` (the back-forward cache), throttled to
  * {@link SW_RESUME_CHECK_MIN_INTERVAL_MS}. `registration.update()`
  * fetches the script and compares bytes; when they differ the new
- * worker installs, `skipWaiting()`s, claims the page, and the
- * `controllerchange` handler above reloads once. The served bytes carry
- * the plugin version in their preamble, so every release IS a byte
- * change — no release goes unnoticed for want of a navigation.
+ * worker installs and waits, and {@link watchForUpdates} asks it
+ * whether the shell's own files changed. The served bytes carry the
+ * plugin version and the shell-build stamp in their preamble, so every
+ * release IS a byte change — no release goes unnoticed for want of a
+ * navigation — and only a release that changed the shell is ever
+ * mentioned to the user.
  *
  * Best-effort throughout: `update()` rejecting (offline, a 503 from a
  * host mid-deploy) is the browser saying "not now", and the next return
@@ -198,32 +356,6 @@ function bindResumeUpdateCheck( registration: ServiceWorkerRegistration ): void 
 		document.removeEventListener( 'visibilitychange', check );
 		window.removeEventListener( 'pageshow', check );
 	};
-}
-
-function wasRecentlyReloadedForSwUpdate(): boolean {
-	try {
-		const raw = sessionStorage.getItem( SW_RELOAD_THROTTLE_KEY );
-		const last = raw ? Number.parseInt( raw, 10 ) : 0;
-		if ( ! Number.isFinite( last ) || last <= 0 ) {
-			return false;
-		}
-		return Date.now() - last < SW_RELOAD_THROTTLE_MS;
-	} catch {
-		// sessionStorage may be unavailable (private mode, blocked
-		// storage). Without it we can't throttle, so default to
-		// "no recent reload" and let the reload fire. The infinite-
-		// loop scenario it guards against requires DevTools, which is
-		// itself unlikely to coincide with storage being blocked.
-		return false;
-	}
-}
-
-function markReloadedForSwUpdate(): void {
-	try {
-		sessionStorage.setItem( SW_RELOAD_THROTTLE_KEY, String( Date.now() ) );
-	} catch {
-		// See `wasRecentlyReloadedForSwUpdate` — swallow.
-	}
 }
 
 /**
@@ -316,7 +448,17 @@ function sendCurrentConfigToWorker(): void {
 
 export async function registerServiceWorker(
 	config: PwaConfig | undefined,
-	options: { forceReplace?: boolean } = {},
+	options: {
+		forceReplace?: boolean;
+		/**
+		 * Runs once when a new worker reports a shell-build stamp
+		 * different from the one this page booted with — the shell's
+		 * files really changed on the server. See
+		 * {@link watchForUpdates}. The shell offers a reload; it never
+		 * performs one. Taking the offer is {@link applyPendingUpdate}.
+		 */
+		onShellUpdated?: ( info: ShellUpdateInfo ) => void;
+	} = {},
 ): Promise< ServiceWorkerRegistration | null > {
 	if ( typeof navigator === 'undefined' || ! ( 'serviceWorker' in navigator ) ) {
 		_status = 'unsupported';
@@ -390,10 +532,10 @@ export async function registerServiceWorker(
 			_registration = await attempt( config.swFallbackUrl );
 		}
 		_status = 'registered';
-		// Auto-reload when the new SW takes control. Bound only after a
-		// successful registration so we never reload a page that has no
-		// SW relationship in the first place.
-		bindControllerChangeReload();
+		// Learn about a new worker. Bound only after a successful
+		// registration so a page with no SW relationship is never asked
+		// anything.
+		watchForUpdates( _registration, config, options.onShellUpdated );
 		// A phone that never navigates still learns about a release the
 		// next time the app comes to the front.
 		bindResumeUpdateCheck( _registration );
@@ -500,8 +642,11 @@ export function getServiceWorkerRegistration(): ServiceWorkerRegistration | null
 export function _resetSwRegistration(): void {
 	_registration = null;
 	_registrationFailed = false;
-	_controllerChangeBound = false;
-	_reloadingForSwUpdate = false;
+	_updatesBound = false;
+	_shellUpdateAnnounced = false;
+	_waitingWorker = null;
+	_swapExpected = false;
+	_swapListeners = [];
 	_unbindResumeCheck?.();
 	_unbindResumeCheck = null;
 	_lastResumeCheckAt = 0;

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -91,6 +91,8 @@ interface SWExtendableEvent {
 }
 interface SWMessageEvent {
 	data?: unknown;
+	/** The window client that posted the message, when there is one. */
+	source?: { postMessage: ( data: unknown ) => void } | null;
 	waitUntil: ( p: Promise< unknown > ) => void;
 }
 interface SWEventMap {
@@ -184,13 +186,13 @@ let windowPrewarmEnabled = CONFIG.windowPrewarm;
  * between an anonymous and a logged-in request — so any in-scope
  * logged-out navigation (the interim-login iframe, logging out) served
  * a different script, which the browser treats as an update, installs,
- * and activates. The shell's `controllerchange` handler then hard-
- * reloads the desktop out from under the user.
+ * and activates. At the time the shell hard-reloaded the desktop on
+ * every such takeover.
  *
- * The served bytes are now identical for everyone (`pluginUrl` only)
- * and the shell pushes the per-user values at boot. Starting both off
- * is the safe default: until the message lands the worker simply does
- * less.
+ * The served bytes are now identical for everyone (site-level values
+ * only) and the shell pushes the per-user values at boot. Starting
+ * both off is the safe default: until the message lands the worker
+ * simply does less.
  */
 let adminAssetCacheEnabled = CONFIG.adminAssetCache;
 
@@ -230,9 +232,17 @@ const PRECACHE_PATHS: readonly string[] = [
 	'assets/images/wp-logo.png',
 ];
 
+// No `skipWaiting()` here, on purpose. A new worker installs and then
+// WAITS; it takes over only when the shell tells it to
+// (`os-sw-skip-waiting`), which the shell does silently when the
+// shell's own files did not change and on the user's click when they
+// did. Taking over on install swapped the worker under a page still
+// running the previous bundle — and the activate handler below drops
+// the previous version's caches, so that page could ask for a lazy
+// bundle from a bucket that no longer existed. The page and its
+// worker now change together, or not at all.
 sw.addEventListener( 'install', ( event: SWExtendableEvent ) => {
 	event.waitUntil( precache() );
-	void sw.skipWaiting();
 } );
 
 sw.addEventListener( 'activate', ( event: SWExtendableEvent ) => {
@@ -535,6 +545,30 @@ sw.addEventListener( 'message', ( event: SWMessageEvent ) => {
 	const data = event.data as
 		| { type?: string; url?: string; urls?: unknown }
 		| undefined;
+
+	// "Which shell were you served with?" — asked of a worker that has
+	// just installed and is waiting, so the shell can tell a deploy that
+	// changed its own files from one that changed nothing it is
+	// running. The answer is the preamble's stamp; a body served without
+	// one answers '' and the shell treats that as "unknown", never as
+	// "changed".
+	if ( data && data.type === 'os-sw-get-build' ) {
+		try {
+			event.source?.postMessage( {
+				type: 'os-sw-build',
+				shellBuild: CONFIG.shellBuild,
+			} );
+		} catch {
+			// A client gone between the ask and the answer.
+		}
+		return;
+	}
+
+	// The shell's consent to take over — see the install handler.
+	if ( data && data.type === 'os-sw-skip-waiting' ) {
+		void sw.skipWaiting();
+		return;
+	}
 
 	// The two per-user flags: the prewarm toggle applied to the RUNNING
 	// worker, and the boot-time sync of both. Neither is in the served

--- a/src/types.ts
+++ b/src/types.ts
@@ -2663,6 +2663,16 @@ export interface PwaConfig {
 	 * openstation installability.
 	 */
 	forceReplaceSw?: boolean;
+	/**
+	 * Content hash of the shell's built files this document was served
+	 * with (`openstation_shell_build_stamp()`). Compared against the
+	 * stamp a service worker taking over mid-session reports, so the
+	 * shell can tell a deploy that changed its own files from one that
+	 * did not. Optional: absent on payloads from older servers, in which
+	 * case no comparison is possible and the shell never offers a
+	 * reload.
+	 */
+	shellBuild?: string;
 }
 
 /**

--- a/tests/phpunit/tests/openStationPwaAdminAssetCache.php
+++ b/tests/phpunit/tests/openStationPwaAdminAssetCache.php
@@ -116,6 +116,21 @@ class Tests_OpenStation_PwaAdminAssetCache extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The worker carries the shell-build stamp it was served with, so a
+	 * shell it takes over mid-session can tell whether the shell's own
+	 * files changed — the only change that is ever mentioned to the
+	 * user. Same value the shell boots with, same source.
+	 *
+	 * @covers ::openstation_pwa_sw_config_preamble
+	 */
+	public function test_preamble_carries_the_shell_build_stamp() {
+		$config = $this->decode_preamble( openstation_pwa_sw_config_preamble() );
+
+		$this->assertArrayHasKey( 'shellBuild', $config );
+		$this->assertSame( openstation_shell_build_stamp(), $config['shellBuild'] );
+	}
+
+	/**
 	 * The served bytes must NOT depend on who is asking.
 	 *
 	 * A service worker is origin-wide, but `adminAssetCache` and
@@ -123,9 +138,9 @@ class Tests_OpenStation_PwaAdminAssetCache extends WP_UnitTestCase {
 	 * script made the body differ between an anonymous and a logged-in
 	 * request, so any in-scope logged-out navigation — the interim-login
 	 * iframe, logging out — served a different script. The browser
-	 * treats different bytes as an update, installs it, activates it,
-	 * and the shell's `controllerchange` handler hard-reloads the
-	 * desktop. The shell posts both flags to the running worker instead.
+	 * treats different bytes as an update, installs it, and activates
+	 * it — which, at the time, hard-reloaded the desktop. The shell
+	 * posts both flags to the running worker instead.
 	 *
 	 * @covers ::openstation_pwa_sw_config_preamble
 	 */

--- a/tests/phpunit/tests/openStationShellBuildStamp.php
+++ b/tests/phpunit/tests/openStationShellBuildStamp.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests for `openstation_shell_build_stamp()`.
+ *
+ * The stamp answers "did the shell's files change?" from bytes, not
+ * clocks: a deploy rewrites every mtime whether or not the contents
+ * moved, and a stamp that followed mtimes would have every deploy
+ * offering the user a reload for nothing. What the shell compares
+ * across a worker takeover has to be content, and content only.
+ *
+ * @package OpenStation
+ *
+ * @group openstation
+ */
+class Tests_OpenStation_ShellBuildStamp extends WP_UnitTestCase {
+
+	/** @var string Fixture plugin directory. */
+	private $dir;
+
+	public function set_up() {
+		parent::set_up();
+		$this->dir = trailingslashit( get_temp_dir() ) . 'os-shell-build-' . wp_generate_password( 8, false ) . '/';
+		wp_mkdir_p( $this->dir . 'assets/css' );
+		wp_mkdir_p( $this->dir . 'assets/js' );
+		delete_transient( 'openstation_shell_build' );
+	}
+
+	public function tear_down() {
+		foreach ( array( 'assets/css', 'assets/js' ) as $sub ) {
+			foreach ( (array) glob( $this->dir . $sub . '/*' ) as $file ) {
+				unlink( $file );
+			}
+			rmdir( $this->dir . $sub );
+		}
+		rmdir( $this->dir . 'assets' );
+		rmdir( $this->dir );
+		delete_transient( 'openstation_shell_build' );
+		parent::tear_down();
+	}
+
+	private function write( $relative, $contents ) {
+		file_put_contents( $this->dir . $relative, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	}
+
+	/**
+	 * @covers ::openstation_shell_build_stamp
+	 */
+	public function test_is_sixteen_hex_characters_and_stable() {
+		$this->write( 'assets/css/desktop.css', 'body { color: red; }' );
+		$this->write( 'assets/js/desktop.min.js', 'console.log( 1 );' );
+
+		$stamp = openstation_shell_build_stamp( $this->dir );
+
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{16}$/', $stamp );
+		$this->assertSame( $stamp, openstation_shell_build_stamp( $this->dir ) );
+	}
+
+	/**
+	 * A deploy touches every file. Same bytes, same stamp — this is the
+	 * property the whole function exists for.
+	 *
+	 * @covers ::openstation_shell_build_stamp
+	 */
+	public function test_a_changed_mtime_with_the_same_bytes_is_the_same_stamp() {
+		$this->write( 'assets/css/desktop.css', 'body { color: red; }' );
+		$this->write( 'assets/js/desktop.min.js', 'console.log( 1 );' );
+		$before = openstation_shell_build_stamp( $this->dir );
+
+		touch( $this->dir . 'assets/css/desktop.css', time() + 3600 );
+		touch( $this->dir . 'assets/js/desktop.min.js', time() + 3600 );
+		clearstatcache();
+
+		$this->assertSame( $before, openstation_shell_build_stamp( $this->dir ) );
+	}
+
+	/**
+	 * @covers ::openstation_shell_build_stamp
+	 */
+	public function test_changed_bytes_are_a_different_stamp() {
+		$this->write( 'assets/css/desktop.css', 'body { color: red; }' );
+		$this->write( 'assets/js/desktop.min.js', 'console.log( 1 );' );
+		$before = openstation_shell_build_stamp( $this->dir );
+
+		$this->write( 'assets/js/desktop.min.js', 'console.log( 2 ); /* a real change */' );
+		clearstatcache();
+
+		$this->assertNotSame( $before, openstation_shell_build_stamp( $this->dir ) );
+	}
+
+	/**
+	 * A file appearing or disappearing is a change too — a new lazy
+	 * bundle is as much "the shell changed" as an edit to an old one.
+	 *
+	 * @covers ::openstation_shell_build_stamp
+	 */
+	public function test_an_added_file_is_a_different_stamp() {
+		$this->write( 'assets/css/desktop.css', 'body { color: red; }' );
+		$before = openstation_shell_build_stamp( $this->dir );
+
+		$this->write( 'assets/js/mobile.min.js', 'console.log( "phone" );' );
+		clearstatcache();
+
+		$this->assertNotSame( $before, openstation_shell_build_stamp( $this->dir ) );
+	}
+
+	/**
+	 * @covers ::openstation_shell_build_stamp
+	 */
+	public function test_nothing_built_is_the_empty_string() {
+		$this->assertSame( '', openstation_shell_build_stamp( $this->dir ) );
+	}
+
+	/**
+	 * The real plugin directory has a build in it during the suite, so
+	 * the default argument produces a stamp — and the one the shell
+	 * config and the worker preamble carry is that same stamp.
+	 *
+	 * @covers ::openstation_shell_build_stamp
+	 */
+	public function test_default_directory_is_the_plugin() {
+		$stamp = openstation_shell_build_stamp();
+		if ( '' === $stamp ) {
+			$this->markTestSkipped( 'No built assets in the plugin directory.' );
+		}
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{16}$/', $stamp );
+	}
+}

--- a/tests/vitest/session-saver-flush.test.ts
+++ b/tests/vitest/session-saver-flush.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `SessionSaver.flush()` — write now, resolve when the server answers.
+ *
+ * The one caller is the reload the shell offers after a deploy changed
+ * its files: the navigation must wait for the session to land, or the
+ * request that reads it back can beat the write and the desktop comes
+ * back as the older snapshot.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createSessionSaver } from '../../src/boot/session-saver';
+import { clearHooksStub, installHooksStub } from './helpers/hooks-stub';
+import type { WindowManager } from '../../src/window-manager';
+import type { DesktopConfig, Session } from '../../src/types';
+
+const trackedFetchMock = vi.hoisted( () => vi.fn() );
+
+vi.mock( '../../src/boot/tracked-fetch', () => ( {
+	trackedFetch: trackedFetchMock,
+} ) );
+
+function deferred< T >() {
+	let resolve!: ( v: T ) => void;
+	const promise = new Promise< T >( ( r ) => {
+		resolve = r;
+	} );
+	return { promise, resolve };
+}
+
+function fakeManager( openIds: string[] ) {
+	return {
+		snapshot: (): Session => ( {
+			windows: openIds.map( ( id ) => ( {
+				id,
+				url: `https://example.test/wp-admin/${ id }.php`,
+				title: id,
+				icon: 'dashicons-admin-generic',
+				state: 'normal',
+				x: 0,
+				y: 0,
+				width: 800,
+				height: 600,
+			} ) ) as Session[ 'windows' ],
+			desktops: [ { id: 'desktop-1', label: 'Desktop 1' } ],
+			activeDesktop: 'desktop-1',
+			focused: openIds[ openIds.length - 1 ] || '',
+			updated: Date.now(),
+		} ),
+	} as unknown as WindowManager;
+}
+
+function fakeConfig(): DesktopConfig {
+	return {
+		sessionUrl: 'https://example.test/wp-json/desktop-mode/v1/session',
+		restNonce: 'nonce-abc',
+	} as unknown as DesktopConfig;
+}
+
+function windowIdsOfCall( call: number ): string[] {
+	const init = trackedFetchMock.mock.calls[ call ][ 2 ] as RequestInit;
+	const parsed = JSON.parse( init.body as string ) as { session: Session };
+	return parsed.session.windows.map( ( w ) => w.id );
+}
+
+describe( 'session saver — flush()', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		installHooksStub();
+		trackedFetchMock.mockReset();
+		trackedFetchMock.mockResolvedValue( new Response( '{}' ) );
+	} );
+
+	afterEach( () => {
+		clearHooksStub();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'writes immediately, ahead of the debounce, and resolves after the response', async () => {
+		const save = createSessionSaver( fakeManager( [ 'a', 'b' ] ), fakeConfig() );
+		const response = deferred< Response >();
+		trackedFetchMock.mockReturnValueOnce( response.promise );
+
+		save();
+		let settled = false;
+		const flushing = save.flush().then( () => {
+			settled = true;
+		} );
+		await vi.advanceTimersByTimeAsync( 0 );
+
+		// The debounced write was folded into the flush: one request,
+		// sent at once, carrying the current desktop.
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( windowIdsOfCall( 0 ) ).toEqual( [ 'a', 'b' ] );
+		expect( settled ).toBe( false );
+
+		response.resolve( new Response( '{}' ) );
+		await flushing;
+		expect( settled ).toBe( true );
+
+		// The debounce timer was cleared, not left to fire a duplicate.
+		await vi.advanceTimersByTimeAsync( 5_000 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'lets a write already on the wire finish, then sends the latest state', async () => {
+		const openIds = [ 'a', 'b' ];
+		const save = createSessionSaver( fakeManager( openIds ), fakeConfig() );
+		const first = deferred< Response >();
+		trackedFetchMock.mockReturnValueOnce( first.promise );
+
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		// A window closes while the first save is in flight; the flush
+		// must carry that, not the state the first save took.
+		openIds.pop();
+		const flushing = save.flush();
+		await vi.advanceTimersByTimeAsync( 0 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		first.resolve( new Response( '{}' ) );
+		await flushing;
+
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 2 );
+		expect( windowIdsOfCall( 1 ) ).toEqual( [ 'a' ] );
+	} );
+
+	test( 'sends nothing when the server already holds this session', async () => {
+		const save = createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+		save();
+		await vi.advanceTimersByTimeAsync( 500 );
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+
+		await save.flush();
+		expect( trackedFetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'never rejects — a failed write is best-effort, and the caller moves on', async () => {
+		const save = createSessionSaver( fakeManager( [ 'a' ] ), fakeConfig() );
+		trackedFetchMock.mockRejectedValueOnce( new TypeError( 'offline' ) );
+
+		await expect( save.flush() ).resolves.toBeUndefined();
+	} );
+} );

--- a/tests/vitest/sw-policy.test.ts
+++ b/tests/vitest/sw-policy.test.ts
@@ -166,6 +166,7 @@ describe( 'readSwConfig', () => {
 			adminAssetCache: false,
 			windowPrewarm: false,
 			pluginUrl: FALLBACK,
+			shellBuild: '',
 		} );
 		expect( readSwConfig( 'garbage', FALLBACK ).adminAssetCache ).toBe(
 			false,
@@ -206,5 +207,18 @@ describe( 'readSwConfig', () => {
 		expect(
 			readSwConfig( { pluginUrl: '/relative/only/' }, FALLBACK ).pluginUrl,
 		).toBe( FALLBACK );
+	} );
+
+	it( 'reads a hex shell-build stamp and nothing else', () => {
+		expect(
+			readSwConfig( { shellBuild: '0123456789abcdef' }, FALLBACK ).shellBuild,
+		).toBe( '0123456789abcdef' );
+		// A body without a stamp, or with something that is not one,
+		// reports '' — "unknown", which the shell never reads as a change.
+		expect( readSwConfig( {}, FALLBACK ).shellBuild ).toBe( '' );
+		expect( readSwConfig( { shellBuild: 42 }, FALLBACK ).shellBuild ).toBe( '' );
+		expect(
+			readSwConfig( { shellBuild: '<script>' }, FALLBACK ).shellBuild,
+		).toBe( '' );
 	} );
 } );

--- a/tests/vitest/sw-register-takeover.test.ts
+++ b/tests/vitest/sw-register-takeover.test.ts
@@ -1,0 +1,332 @@
+/**
+ * A new service worker, and what the shell does with it.
+ *
+ * The worker installs and WAITS; it never takes over on its own. The
+ * shell asks it which shell build it was served with and compares that
+ * with the page's own boot-time stamp. Same or unknown: the worker is
+ * told to take over silently — caches refresh, nothing is shown. A real
+ * difference — the shell's files changed on the server — reaches
+ * `onShellUpdated`, once, and the worker keeps waiting until
+ * `applyPendingUpdate()` (the user's Reload). Nothing in this module
+ * reloads; the shell never reloads itself.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	_resetSwRegistration,
+	applyPendingUpdate,
+	registerServiceWorker,
+	type ShellUpdateInfo,
+} from '../../src/pwa/sw-register';
+import type { PwaConfig } from '../../src/types';
+
+const SW_URL = 'https://example.test/openstation/sw.js';
+const CURRENT = 'aaaaaaaaaaaaaaaa';
+const NEWER = 'bbbbbbbbbbbbbbbb';
+
+/** `null` builds a payload from a server that sends no stamp at all. */
+function makeConfig( shellBuild: string | null = CURRENT ): PwaConfig {
+	return {
+		manifestUrl: 'https://example.test/openstation/manifest.webmanifest',
+		swUrl: SW_URL,
+		swFallbackUrl: 'https://example.test/?openstation_sw=1',
+		stateUrl: 'https://example.test/wp-json/desktop-mode/v1/pwa-state',
+		state: { installHintDismissed: false, notificationsEnabled: false },
+		...( shellBuild === null ? {} : { shellBuild } ),
+	} as PwaConfig;
+}
+
+type Listener = ( ev: unknown ) => void;
+
+/** A `ServiceWorker` stand-in whose state can be moved by hand. */
+function makeWorker( state = 'installed' ) {
+	const listeners = new Set< Listener >();
+	const worker = {
+		state,
+		scriptURL: SW_URL,
+		postMessage: vi.fn(),
+		addEventListener: ( _type: string, cb: Listener ) => {
+			listeners.add( cb );
+		},
+		setState( next: string ) {
+			worker.state = next;
+			for ( const cb of listeners ) {
+				cb( {} );
+			}
+		},
+		/** Messages of one type this worker was sent. */
+		sent( type: string ) {
+			return worker.postMessage.mock.calls.filter(
+				( [ msg ] ) => ( msg as { type?: string } )?.type === type,
+			).length;
+		},
+	};
+	return worker;
+}
+type Worker = ReturnType< typeof makeWorker >;
+
+/**
+ * A `navigator.serviceWorker` + registration whose events can be fired
+ * by hand. `controlled` decides whether the page starts with a
+ * controller; `waiting` plants a worker already installed and waiting
+ * when the page registers.
+ */
+function installSwStub( opts: { controlled?: boolean; waiting?: Worker | null } = {} ) {
+	const controlled = opts.controlled ?? true;
+	const containerListeners = new Map< string, Set< Listener > >();
+	const registrationListeners = new Map< string, Set< Listener > >();
+	const on = ( map: Map< string, Set< Listener > > ) => ( type: string, cb: Listener ) => {
+		if ( ! map.has( type ) ) {
+			map.set( type, new Set() );
+		}
+		map.get( type )!.add( cb );
+	};
+	const controller = controlled ? makeWorker( 'activated' ) : null;
+	const reg = {
+		scope: '/',
+		active: { scriptURL: SW_URL, state: 'activated' },
+		installing: null as Worker | null,
+		waiting: opts.waiting ?? null,
+		update: vi.fn( async () => undefined ),
+		addEventListener: on( registrationListeners ),
+	};
+	Object.defineProperty( window, 'isSecureContext', { value: true, configurable: true } );
+	Object.defineProperty( navigator, 'serviceWorker', {
+		value: {
+			register: vi.fn( async () => reg ),
+			getRegistrations: vi.fn( async () => [] ),
+			controller,
+			addEventListener: on( containerListeners ),
+			removeEventListener: ( type: string, cb: Listener ) => {
+				containerListeners.get( type )?.delete( cb );
+			},
+		},
+		configurable: true,
+	} );
+	const fire = ( map: Map< string, Set< Listener > >, type: string, ev: unknown = {} ): void => {
+		for ( const cb of map.get( type ) ?? [] ) {
+			cb( ev );
+		}
+	};
+	return {
+		reg,
+		controller,
+		/** The worker answers the build question. */
+		reply: ( shellBuild: string ) =>
+			fire( containerListeners, 'message', { data: { type: 'os-sw-build', shellBuild } } ),
+		/** The swap happened: a worker took control of this page. */
+		controllerChange: ( next?: Worker ) => {
+			if ( next ) {
+				( navigator.serviceWorker as unknown as { controller: Worker } ).controller = next;
+			}
+			fire( containerListeners, 'controllerchange' );
+		},
+		/** The browser found a new script and started installing it. */
+		updateFound: ( installing: Worker ) => {
+			reg.installing = installing;
+			fire( registrationListeners, 'updatefound' );
+		},
+	};
+}
+
+async function settle(): Promise< void > {
+	await vi.advanceTimersByTimeAsync( 0 );
+}
+
+describe( 'registerServiceWorker — a new worker', () => {
+	beforeEach( () => {
+		_resetSwRegistration();
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		delete ( navigator as unknown as { serviceWorker?: unknown } ).serviceWorker;
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	} );
+
+	test( 'a waiting worker with a new shell build is offered, once, and keeps waiting', async () => {
+		const waiting = makeWorker();
+		const stub = installSwStub( { waiting } );
+		const onShellUpdated = vi.fn< ( info: ShellUpdateInfo ) => void >();
+		await registerServiceWorker( makeConfig(), { onShellUpdated } );
+
+		expect( waiting.sent( 'os-sw-get-build' ) ).toBe( 1 );
+		stub.reply( NEWER );
+		await settle();
+
+		expect( onShellUpdated ).toHaveBeenCalledTimes( 1 );
+		expect( onShellUpdated ).toHaveBeenCalledWith( { current: CURRENT, served: NEWER } );
+		// Not told to take over: that is the user's call.
+		expect( waiting.sent( 'os-sw-skip-waiting' ) ).toBe( 0 );
+
+		// Taking the offer: the worker is told, and the promise settles
+		// on the swap — before which the caller must not reload.
+		let swapped = false;
+		const applying = applyPendingUpdate().then( () => {
+			swapped = true;
+		} );
+		expect( waiting.sent( 'os-sw-skip-waiting' ) ).toBe( 1 );
+		await settle();
+		expect( swapped ).toBe( false );
+		stub.controllerChange( waiting );
+		await applying;
+		expect( swapped ).toBe( true );
+		// The expected swap is not a takeover to investigate.
+		expect( waiting.sent( 'os-sw-get-build' ) ).toBe( 1 );
+	} );
+
+	test( 'a waiting worker with the same shell build takes over silently', async () => {
+		const waiting = makeWorker();
+		const stub = installSwStub( { waiting } );
+		const onShellUpdated = vi.fn();
+		await registerServiceWorker( makeConfig(), { onShellUpdated } );
+
+		stub.reply( CURRENT );
+		await settle();
+
+		expect( onShellUpdated ).not.toHaveBeenCalled();
+		expect( waiting.sent( 'os-sw-skip-waiting' ) ).toBe( 1 );
+
+		// The swap it asked for is not a takeover to investigate either.
+		stub.controllerChange( waiting );
+		await settle();
+		expect( waiting.sent( 'os-sw-get-build' ) ).toBe( 1 );
+		expect( onShellUpdated ).not.toHaveBeenCalled();
+	} );
+
+	test( 'an unknown build — no stamp, or no answer — is never a change, and swaps silently', async () => {
+		const waiting = makeWorker();
+		const stub = installSwStub( { waiting } );
+		const onShellUpdated = vi.fn();
+		await registerServiceWorker( makeConfig(), { onShellUpdated } );
+
+		stub.reply( '' );
+		await settle();
+		expect( onShellUpdated ).not.toHaveBeenCalled();
+		expect( waiting.sent( 'os-sw-skip-waiting' ) ).toBe( 1 );
+
+		// A worker that never answers: the ask times out into the same.
+		const silent = makeWorker();
+		stub.updateFound( silent );
+		silent.setState( 'installed' );
+		await vi.advanceTimersByTimeAsync( 10_000 );
+		expect( onShellUpdated ).not.toHaveBeenCalled();
+		expect( silent.sent( 'os-sw-skip-waiting' ) ).toBe( 1 );
+	} );
+
+	test( 'a page from an older server, with no stamp of its own, swaps silently', async () => {
+		const waiting = makeWorker();
+		const stub = installSwStub( { waiting } );
+		const onShellUpdated = vi.fn();
+		await registerServiceWorker( makeConfig( null ), { onShellUpdated } );
+
+		stub.reply( NEWER );
+		await settle();
+
+		expect( onShellUpdated ).not.toHaveBeenCalled();
+		expect( waiting.sent( 'os-sw-skip-waiting' ) ).toBe( 1 );
+	} );
+
+	test( 'a worker arriving mid-session is considered once it has installed', async () => {
+		const stub = installSwStub();
+		const onShellUpdated = vi.fn();
+		await registerServiceWorker( makeConfig(), { onShellUpdated } );
+
+		const arriving = makeWorker( 'installing' );
+		stub.updateFound( arriving );
+		expect( arriving.sent( 'os-sw-get-build' ) ).toBe( 0 );
+
+		arriving.setState( 'installed' );
+		expect( arriving.sent( 'os-sw-get-build' ) ).toBe( 1 );
+		stub.reply( NEWER );
+		await settle();
+
+		expect( onShellUpdated ).toHaveBeenCalledWith( { current: CURRENT, served: NEWER } );
+		expect( arriving.sent( 'os-sw-skip-waiting' ) ).toBe( 0 );
+	} );
+
+	test( 'a first install is not a takeover', async () => {
+		const stub = installSwStub( { controlled: false } );
+		const onShellUpdated = vi.fn();
+		await registerServiceWorker( makeConfig(), { onShellUpdated } );
+
+		const first = makeWorker( 'installing' );
+		stub.updateFound( first );
+		first.setState( 'installed' );
+		await settle();
+
+		expect( first.sent( 'os-sw-get-build' ) ).toBe( 0 );
+		expect( onShellUpdated ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a swap another tab caused is compared against the new controller, and offered', async () => {
+		const stub = installSwStub();
+		const onShellUpdated = vi.fn();
+		await registerServiceWorker( makeConfig(), { onShellUpdated } );
+
+		const next = makeWorker( 'activated' );
+		stub.controllerChange( next );
+		expect( next.sent( 'os-sw-get-build' ) ).toBe( 1 );
+		stub.reply( NEWER );
+		await settle();
+
+		expect( onShellUpdated ).toHaveBeenCalledTimes( 1 );
+		// Nothing is waiting: taking the offer has nothing to swap and
+		// settles at once, with no message sent.
+		await applyPendingUpdate();
+		expect( next.sent( 'os-sw-skip-waiting' ) ).toBe( 0 );
+	} );
+
+	test( 'taking the offer gives up on a swap that never comes, so the reload still happens', async () => {
+		const waiting = makeWorker();
+		const stub = installSwStub( { waiting } );
+		await registerServiceWorker( makeConfig(), { onShellUpdated: vi.fn() } );
+		stub.reply( NEWER );
+		await settle();
+
+		let swapped = false;
+		const applying = applyPendingUpdate().then( () => {
+			swapped = true;
+		} );
+		await vi.advanceTimersByTimeAsync( 2_000 );
+		expect( swapped ).toBe( false );
+		await vi.advanceTimersByTimeAsync( 1_500 );
+		await applying;
+		expect( swapped ).toBe( true );
+	} );
+} );
+
+describe( 'the shell never reloads itself', () => {
+	/**
+	 * The rule, pinned at the source: nothing under `src/pwa/` may call
+	 * `location.reload()`. The one reload the shell performs after a
+	 * deploy is the user's, from the toast's action, and it lives with
+	 * the session flush in `src/desktop.ts`.
+	 */
+	test( 'nothing under src/pwa/ calls location.reload()', () => {
+		const dir = join( __dirname, '..', '..', 'src', 'pwa' );
+		const offenders: string[] = [];
+		const walk = ( d: string ): void => {
+			for ( const name of readdirSync( d ) ) {
+				const full = join( d, name );
+				if ( statSync( full ).isDirectory() ) {
+					walk( full );
+				} else if ( /\.ts$/.test( name ) && /location\.reload\(/.test( readFileSync( full, 'utf8' ) ) ) {
+					offenders.push( full );
+				}
+			}
+		};
+		walk( dir );
+		expect( offenders ).toEqual( [] );
+	} );
+
+	/** And the worker never takes over uninvited. */
+	test( 'the worker only skipWaiting()s on the shell\'s message', () => {
+		const source = readFileSync( join( __dirname, '..', '..', 'src', 'pwa', 'sw.ts' ), 'utf8' );
+		const calls = source.match( /\bsw\.skipWaiting\(\)/g ) ?? [];
+		expect( calls ).toHaveLength( 1 );
+		expect( source ).toMatch( /os-sw-skip-waiting[\s\S]{0,120}sw\.skipWaiting\(\)/ );
+	} );
+} );


### PR DESCRIPTION
## What happened

A deploy landed on openstation.blog while a desktop with two windows was open. The new service worker installed, the shell's `controllerchange` handler hard-reloaded the page, and both windows were gone when it came back.

Two things made that routine rather than rare: every release is a byte change in the served worker (the plugin version rides in its preamble), and the resume-time update check (#749) finds it the moment the tab returns to the foreground. So every release reloaded the desktop, whether or not the shell itself had changed.

## The rule

**The shell never reloads itself.** Not on a worker takeover, not on an interval, not on a version bump. At most it *offers* a reload, and only when the shell's own built files really changed on the server.

## How

**The worker waits.** `sw.ts` no longer calls `skipWaiting()` on install — the standard prompt-for-update shape. The only thing that makes it take over is an `os-sw-skip-waiting` message from the shell. Taking over on install had a second problem beyond the reload: the activate handler drops the previous version's caches, so a worker that claimed a page still running the old bundle left it able to ask for a lazy bundle from a bucket that no longer existed. A page and its worker now change together.

**The shell asks.** `registerServiceWorker()` watches for a waiting worker (`registration.waiting` at boot, `updatefound` → `installed` mid-session) and asks it which shell build it was served with (`os-sw-get-build` → `os-sw-build`).

- Same stamp, or unknown on either side: the worker is told to take over silently. Caches refresh; nothing is shown; nothing reloads.
- Different stamp: a persistent toast — *A new version of OpenStation is available* — with a **Reload** action. The worker keeps waiting until the user takes it.

Taking it does three things in order: swap the waiting worker in and wait for `controllerchange` (bounded by a short timeout), flush the session and wait for the server's answer, then reload. The unload beacon racing the request that reads the session back is how the windows were lost; `createSessionSaver()` grows `flush()` for exactly this.

A swap another tab caused is handled too: the page compares against the new controller and makes the same offer when the shell changed. A first install is never a takeover.

**The stamp.** `openstation_shell_build_stamp()` is a content hash over `assets/css/*.css` and `assets/js/*.js`, memoised in one transient behind the files' (path, size, mtime) signature. Bytes, not clocks: a deploy that rewrites every mtime without changing contents is not a change, and neither is a version bump. It rides in `openStationConfig.pwa.shellBuild` and in the worker preamble — so a deploy that changed the shell is also, finally, a new worker.

## Tests

- `sw-register-takeover.test.ts` — the waiting flow end to end, the silent swap, unknown build, older server with no stamp, mid-session arrival, first install, another tab's swap, the swap timeout; plus two source scans: nothing under `src/pwa/` calls `location.reload()`, and `sw.ts` has exactly one `skipWaiting()`, under the shell's message.
- `session-saver-flush.test.ts` — `flush()` writes ahead of the debounce, lets an in-flight write finish, sends nothing when the server already holds the session, never rejects.
- `openStationShellBuildStamp.php` — stable across calls, unchanged by mtime, changed by bytes and by a new file, `''` when nothing is built.
- `openStationPwaAdminAssetCache.php` — the preamble carries the stamp.

Docs: `docs/pwa.md` (release flow, message surface, PHP surface).

## Gates

typecheck, eslint, build, phpcs clean · vitest 5690 passed · PHPUnit 2840 passed.

## Manual test

Open two windows. DevTools → Application → Service Workers → **Update**: the new worker installs and swaps silently, nothing visible happens. Add a comment to `assets/css/desktop.css`, **Update** again: the worker shows as *waiting* and the toast appears. **Reload** from it: both windows come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-751-75dd7dae02433483a6fbfe260a5bba00af2bb129.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->