### PR TITLE
Files: paint a dropped folder's tile as soon as it exists

### DIFF
--- a/docs/examples/os-file-drop.md
+++ b/docs/examples/os-file-drop.md
@@ -220,8 +220,8 @@ drop (the earlier, unconfirmed batch is discarded — one dialog,
 never stacked modals, never mixed batches). Both sinks fire the same
 `os.drop.*` chain — your subscribers keep working
 unchanged; the `after-upload` payload's `result` is
-`{ placement, storedFileId }` for the desktop sink instead of the
-attachment shape. See
+`{ placement, storedFileId, createdFolders }` for the desktop sink
+instead of the attachment shape. See
 [files-on-desktop.md → Real file storage](../files-on-desktop.md#real-file-storage-upload--experimental).
 
 ## Hooks reference

--- a/docs/files-on-desktop.md
+++ b/docs/files-on-desktop.md
@@ -923,8 +923,20 @@ All under `/wp-json/desktop-mode/v1/files`, cookie + nonce auth:
 
 | Method | Path | Purpose |
 |---|---|---|
-| `POST` | `/uploads` | Multipart intake, ONE file per request: `file` + `parentId` + optional `relativePath` (`a/b/c.ext` — directory segments are created mkdir-p style, deduped) + optional `x`/`y` (omit both → next free grid slot). Returns `{ placement, storedFileId }`. |
-| `POST` | `/uploads/paths` | mkdir-p a directory path with no file (`parentId`, `relativePath`). Preserves empty directories from tree drops. |
+| `POST` | `/uploads` | Multipart intake, ONE file per request: `file` + `parentId` + optional `relativePath` (`a/b/c.ext` — directory segments are created mkdir-p style, deduped, each placed at the next free grid slot of its parent) + optional `x`/`y` (omit both → next free grid slot). Returns `{ placement, storedFileId, createdFolders }`. |
+| `POST` | `/uploads/paths` | mkdir-p a directory path with no file (`parentId`, `relativePath`). Preserves empty directories from tree drops. Returns `{ folderId, createdFolders }`. |
+
+`createdFolders` lists the folders **this request** created from
+`relativePath`, outermost first, as `{ folder, placement }` pairs —
+the folder row plus the placement that shows it in its parent.
+Segments that already existed are not listed, so it is `[]` for flat
+uploads and for every file after the first in a tree. The client
+ingests it on receipt (`ingestCreatedFolders()` in
+`src/desktop-files/store.ts`): the `placement` in the same response
+describes the file *inside* the leaf folder, so without this the
+wallpaper tile for a dropped folder only appeared after the whole
+batch had uploaded and the dialog re-pulled the parent — or, if that
+resync failed, on the next Heartbeat delta.
 | `PATCH` | `/uploads/<id>` | Rename the display name (owner only). |
 | `GET` | `/uploads/<id>/download` | Stream the bytes, unmodified. `_wpnonce` accepted as a query param so plain `<a>` navigations work. |
 | `GET` | `/folders/<id>/download` | On-demand `.zip` of the folder's stored files (reference-type placements are skipped; empty sub-folders round-trip). Requires the PHP zip extension — 501 + a hidden affordance otherwise. Caps filterable via `openstation_stored_files_zip_caps` (default 1000 entries / 500 MB input). |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -6499,8 +6499,11 @@ interface DesktopStorageConfig {
 does (`files-detected`, `dialog-fields`, `before-upload`,
 `upload-started`, `upload-progress`, `after-upload`,
 `upload-failed`) — subscribers don't branch on the destination. The
-`AFTER_UPLOAD` payload's `result` is `{ placement, storedFileId }`
-for the desktop sink (vs. the attachment shape for media). The
+`AFTER_UPLOAD` payload's `result` is `{ placement, storedFileId,
+createdFolders }` for the desktop sink (vs. the attachment shape for
+media); `createdFolders` is the `{ folder, placement }` list of
+directories that upload created from its `relativePath`, already
+ingested into the files store by the time the action fires. The
 upload dialog's destination default follows the drop's intent:
 folder-targeted drops and the desktop pickers → Desktop; WordPress
 admin windows → Media Library; flat desk drops → Media Library when

--- a/includes/desktop-files/rest-uploads.php
+++ b/includes/desktop-files/rest-uploads.php
@@ -214,15 +214,22 @@ function openstation_files_rest_ensure_upload_path( WP_REST_Request $req ) {
 	if ( '/' !== substr( $rel, -1 ) ) {
 		$rel .= '/'; // Whole string is a directory path.
 	}
+	$created   = array();
 	$folder_id = openstation_files_resolve_relative_path(
 		get_current_user_id(),
 		(int) $req->get_param( 'parentId' ),
-		$rel
+		$rel,
+		$created
 	);
 	if ( is_wp_error( $folder_id ) ) {
 		return $folder_id;
 	}
-	return rest_ensure_response( array( 'folderId' => (int) $folder_id ) );
+	return rest_ensure_response(
+		array(
+			'folderId'       => (int) $folder_id,
+			'createdFolders' => openstation_files_shape_created_folders( $created ),
+		)
+	);
 }
 
 /**
@@ -324,10 +331,45 @@ function openstation_files_rest_upload( WP_REST_Request $req ) {
 	$row = openstation_files_get_placement( $registered['placement_id'] );
 	return rest_ensure_response(
 		array(
-			'placement'    => openstation_files_shape_placement( $row ),
-			'storedFileId' => (int) $registered['file_id'],
+			'placement'      => openstation_files_shape_placement( $row ),
+			'storedFileId'   => (int) $registered['file_id'],
+			'createdFolders' => openstation_files_shape_created_folders( $registered['created_folders'] ),
 		)
 	);
+}
+
+/**
+ * Shape the folders a request created mkdir-p style so the client
+ * can paint their tiles the moment they exist. Each entry carries
+ * the folder row AND its placement in the parent the client is
+ * looking at — the per-file `placement` in the same response only
+ * describes the file inside the leaf folder, which is why the
+ * wallpaper tile used to wait for the end-of-batch resync (or the
+ * next Heartbeat delta) after a folder-tree drop.
+ *
+ * @internal
+ *
+ * @param array $created `{ folder_id, placement_id }` rows from
+ *                       `openstation_files_resolve_relative_path()`.
+ * @return array<int,array{folder:array,placement:array}>
+ */
+function openstation_files_shape_created_folders( $created ) {
+	$out = array();
+	foreach ( (array) $created as $entry ) {
+		if ( empty( $entry['folder_id'] ) || empty( $entry['placement_id'] ) ) {
+			continue;
+		}
+		$folder    = openstation_files_get_folder( (int) $entry['folder_id'] );
+		$placement = openstation_files_get_placement( (int) $entry['placement_id'] );
+		if ( ! $folder || ! $placement ) {
+			continue;
+		}
+		$out[] = array(
+			'folder'    => openstation_files_shape_folder( $folder ),
+			'placement' => openstation_files_shape_placement( $placement ),
+		);
+	}
+	return $out;
 }
 
 /**
@@ -477,13 +519,18 @@ function openstation_files_upload_receive( $file, $user_id ) {
  *                                  segments are resolved under `$parent_id`.
  * @param array|null $coords        `x`, `y` for the placement, or null
  *                                  to auto-place at the next free slot.
- * @return array|WP_Error `{ file_id, placement_id }`.
+ * @return array|WP_Error `{ file_id, placement_id, created_folders }` —
+ *                        `created_folders` lists the `{ folder_id,
+ *                        placement_id }` pairs the relative path
+ *                        created (empty for flat uploads and for
+ *                        segments that already existed).
  */
 function openstation_files_upload_register( $user_id, $received, $parent_id, $relative_path = '', $coords = null ) {
 	$parent_id = max( 0, (int) $parent_id );
+	$created   = array();
 
 	if ( '' !== (string) $relative_path ) {
-		$resolved = openstation_files_resolve_relative_path( (int) $user_id, $parent_id, (string) $relative_path );
+		$resolved = openstation_files_resolve_relative_path( (int) $user_id, $parent_id, (string) $relative_path, $created );
 		if ( is_wp_error( $resolved ) ) {
 			return $resolved;
 		}
@@ -545,8 +592,9 @@ function openstation_files_upload_register( $user_id, $received, $parent_id, $re
 	do_action( 'openstation_stored_file_uploaded', (int) $file_id, (int) $placement_id, (int) $user_id );
 
 	return array(
-		'file_id'      => (int) $file_id,
-		'placement_id' => (int) $placement_id,
+		'file_id'         => (int) $file_id,
+		'placement_id'    => (int) $placement_id,
+		'created_folders' => $created,
 	);
 }
 
@@ -564,9 +612,16 @@ function openstation_files_upload_register( $user_id, $received, $parent_id, $re
  * @param string $relative_path  `a/b/c.ext` or `a/b/` (trailing
  *                               slash = pure directory path, e.g.
  *                               an empty folder from a drag).
+ * @param array  $created        Optional, by reference. Receives one
+ *                               `{ folder_id, placement_id }` entry per
+ *                               folder this call created, outermost
+ *                               first, so the caller can hand the new
+ *                               tiles to the client in the same
+ *                               response. Reused segments are not
+ *                               listed.
  * @return int|WP_Error Folder id to place the file in.
  */
-function openstation_files_resolve_relative_path( $user_id, $base_parent_id, $relative_path ) {
+function openstation_files_resolve_relative_path( $user_id, $base_parent_id, $relative_path, &$created = null ) {
 	global $wpdb;
 	$user_id   = (int) $user_id;
 	$parent_id = max( 0, (int) $base_parent_id );
@@ -628,9 +683,19 @@ function openstation_files_resolve_relative_path( $user_id, $base_parent_id, $re
 		if ( is_wp_error( $folder_id ) ) {
 			return $folder_id;
 		}
-		$placement = openstation_files_place( $user_id, $parent_id, 'folder', (string) $folder_id );
+		// Next free slot, same as the file placements below: a bare
+		// `openstation_files_place()` pins the tile at 0,0, which the
+		// layer only displaces client-side — the stored coordinates
+		// stay wrong and the tile jumps on the next repaint.
+		$placement = openstation_files_place_at_next_free_slot( $user_id, $parent_id, 'folder', (string) $folder_id );
 		if ( is_wp_error( $placement ) ) {
 			return $placement;
+		}
+		if ( is_array( $created ) ) {
+			$created[] = array(
+				'folder_id'    => (int) $folder_id,
+				'placement_id' => (int) $placement,
+			);
 		}
 		$parent_id = (int) $folder_id;
 	}

--- a/src/desktop-files/rest.ts
+++ b/src/desktop-files/rest.ts
@@ -563,18 +563,34 @@ export function renameUpload(
 }
 
 /**
+ * A folder a request created mkdir-p style, with the placement that
+ * shows it in the parent the client is looking at. Carried by the
+ * upload and `ensureUploadPath()` responses so the tile can be
+ * ingested the moment the folder exists, instead of waiting for the
+ * end-of-batch resync (or a Heartbeat delta) after a tree drop.
+ */
+export interface RestCreatedFolderShape {
+	folder: RestFolderShape;
+	placement: RestPlacementShape;
+}
+
+/**
  * Ensure a directory path exists under `parentId` (mkdir-p) and
  * return the leaf folder id. Used by tree drops to preserve empty
- * directories.
+ * directories. `createdFolders` lists the segments this call
+ * created (outermost first); reused segments are not listed.
  */
 export function ensureUploadPath(
 	parentId: number,
 	relativePath: string,
-): Promise< { folderId: number } > {
-	return call< { folderId: number } >( '/uploads/paths', {
-		method: 'POST',
-		body: JSON.stringify( { parentId, relativePath } ),
-	} );
+): Promise< { folderId: number; createdFolders?: RestCreatedFolderShape[] } > {
+	return call< { folderId: number; createdFolders?: RestCreatedFolderShape[] } >(
+		'/uploads/paths',
+		{
+			method: 'POST',
+			body: JSON.stringify( { parentId, relativePath } ),
+		},
+	);
 }
 
 /**

--- a/src/desktop-files/store.ts
+++ b/src/desktop-files/store.ts
@@ -22,7 +22,7 @@
  */
 
 import { createSharedStore, type SharedStore } from '../shared-store';
-import type { RestFolderShape, RestPlacementShape } from './rest';
+import type { RestCreatedFolderShape, RestFolderShape, RestPlacementShape } from './rest';
 
 export interface FilesState {
 	placementsByFolder: Map< number, RestPlacementShape[] >;
@@ -160,6 +160,31 @@ export function upsertFolder( folder: RestFolderShape, source: 'local' | 'remote
 	store.state = { ...store.state, folders: next };
 	store.notify();
 	fireChanged( { kind: 'folder-upserted', folderRowId: folder.id, source } );
+}
+
+/**
+ * Ingest the folders a request created mkdir-p style (upload and
+ * `ensureUploadPath()` responses). Folder row first, then its
+ * placement, so a tile never paints for a folder the store cannot
+ * name. Malformed entries are skipped — the end-of-batch resync
+ * still covers them.
+ */
+export function ingestCreatedFolders(
+	created: RestCreatedFolderShape[] | undefined | null,
+	source: 'local' | 'remote' = 'local',
+): void {
+	if ( ! Array.isArray( created ) ) {
+		return;
+	}
+	for ( const entry of created ) {
+		if ( ! entry || ! entry.folder || typeof entry.folder.id !== 'number' ) {
+			continue;
+		}
+		upsertFolder( entry.folder, source );
+		if ( entry.placement ) {
+			upsertPlacement( entry.placement, source );
+		}
+	}
 }
 
 /** Remove a folder + clear its placements bucket. */

--- a/src/os-file-drop/desktop-upload.ts
+++ b/src/os-file-drop/desktop-upload.ts
@@ -20,8 +20,8 @@
 import { applyFilters, doAction } from '../hooks';
 import { FILE_DROP_HOOKS } from './hooks';
 import { UploadAbortedError, UploadCancelledError } from './upload';
-import { upsertPlacement } from '../desktop-files/store';
-import type { RestPlacementShape } from '../desktop-files/rest';
+import { ingestCreatedFolders, upsertPlacement } from '../desktop-files/store';
+import type { RestCreatedFolderShape, RestPlacementShape } from '../desktop-files/rest';
 import type { DropContext, DropDialogFields } from './types';
 
 interface DesktopUploadArgs {
@@ -46,6 +46,12 @@ interface DesktopUploadArgs {
 export interface DesktopUploadResult {
 	placement: RestPlacementShape;
 	storedFileId: number;
+	/**
+	 * Folders this request created from `relativePath` (outermost
+	 * first), each with its placement in the parent. Empty for flat
+	 * uploads and for path segments that already existed.
+	 */
+	createdFolders: RestCreatedFolderShape[];
 }
 
 export async function uploadFileToDesktop(
@@ -142,7 +148,11 @@ export async function uploadFileToDesktop(
 				fail( new Error( extractMessage( xhr, filtered.file.name ) ) );
 				return;
 			}
-			let data: { placement?: RestPlacementShape; storedFileId?: number };
+			let data: {
+				placement?: RestPlacementShape;
+				storedFileId?: number;
+				createdFolders?: RestCreatedFolderShape[];
+			};
 			try {
 				data = JSON.parse( xhr.responseText ) as typeof data;
 			} catch {
@@ -153,11 +163,19 @@ export async function uploadFileToDesktop(
 				fail( new Error( 'Unexpected server response.' ) );
 				return;
 			}
-			// Paint the tile now — no heartbeat wait.
+			const createdFolders = Array.isArray( data.createdFolders )
+				? data.createdFolders
+				: [];
+			// Paint the tiles now — no heartbeat wait. Folders first:
+			// a tree drop's file lands INSIDE the folder this same
+			// request created, and only the folder is visible from
+			// the surface the user dropped on.
+			ingestCreatedFolders( createdFolders, 'local' );
 			upsertPlacement( data.placement, 'local' );
 			const result: DesktopUploadResult = {
 				placement: data.placement,
 				storedFileId: data.storedFileId,
+				createdFolders,
 			};
 			doAction( FILE_DROP_HOOKS.AFTER_UPLOAD, {
 				file: filtered.file,

--- a/src/os-file-drop/dialog.ts
+++ b/src/os-file-drop/dialog.ts
@@ -29,7 +29,11 @@ import {
 	listFolders,
 	listPlacements,
 } from '../desktop-files/rest';
-import { setFolderPlacements, setFolders } from '../desktop-files/store';
+import {
+	ingestCreatedFolders,
+	setFolderPlacements,
+	setFolders,
+} from '../desktop-files/store';
 import type {
 	DesktopStorageConfig,
 	DropContext,
@@ -421,7 +425,10 @@ export async function openUploadDialog( args: OpenDialogArgs ): Promise< void > 
 		if ( destination === 'desktop' && args.emptyDirs?.length ) {
 			for ( const dir of args.emptyDirs ) {
 				try {
-					await ensureUploadPath( parentId, dir );
+					const res = await ensureUploadPath( parentId, dir );
+					// Same immediacy as the file responses: the new
+					// folder tile paints as soon as it exists.
+					ingestCreatedFolders( res.createdFolders, 'local' );
 				} catch {
 					// Non-fatal: the tree's files made it; an empty
 					// stub folder failing is cosmetic.

--- a/tests/phpunit/tests/desktopFilesRestUploads.php
+++ b/tests/phpunit/tests/desktopFilesRestUploads.php
@@ -252,6 +252,64 @@ class Tests_OpenStation_RestUploads extends WP_UnitTestCase {
 		$p2 = $res2->get_data()['placement']['parentId'];
 		$this->assertSame( $p1, $p2 );
 		$this->assertGreaterThan( 0, $p1 );
+
+		// The first request reports the folders it created, outermost
+		// first, each with the placement that shows it in its parent —
+		// the client paints the `docs` tile from this, without waiting
+		// for the end-of-batch resync.
+		$created = $res1->get_data()['createdFolders'];
+		$this->assertCount( 2, $created );
+		$this->assertSame( 'docs', $created[0]['folder']['name'] );
+		$this->assertSame( 0, $created[0]['placement']['parentId'] );
+		$this->assertSame( 'folder', $created[0]['placement']['file']['type'] );
+		$this->assertSame( (string) $created[0]['folder']['id'], $created[0]['placement']['file']['ref'] );
+		$this->assertSame( 'reports', $created[1]['folder']['name'] );
+		$this->assertSame( $created[0]['folder']['id'], $created[1]['placement']['parentId'] );
+		$this->assertSame( $created[1]['folder']['id'], $p1 );
+
+		// Reused segments are not reported again.
+		$this->assertSame( array(), $res2->get_data()['createdFolders'] );
+	}
+
+	public function test_flat_upload_reports_no_created_folders() {
+		$res = openstation_files_rest_upload( $this->upload_request( 'flat.pdf', '%PDF-1.4 fake' ) );
+		$this->assertNotWPError( $res );
+		$this->assertSame( array(), $res->get_data()['createdFolders'] );
+	}
+
+	public function test_created_folders_take_distinct_grid_slots() {
+		// A bare `openstation_files_place()` pinned every mkdir-p
+		// folder at 0,0; sibling trees must land on different cells.
+		$res_a = openstation_files_rest_upload( $this->upload_request( 'a.pdf', '%PDF-1.4 fake', array( 'relativePath' => 'alpha/a.pdf' ) ) );
+		$res_b = openstation_files_rest_upload( $this->upload_request( 'b.pdf', '%PDF-1.4 fake', array( 'relativePath' => 'beta/b.pdf' ) ) );
+		$this->assertNotWPError( $res_a );
+		$this->assertNotWPError( $res_b );
+		$slot_a = $res_a->get_data()['createdFolders'][0]['placement'];
+		$slot_b = $res_b->get_data()['createdFolders'][0]['placement'];
+		$this->assertNotSame(
+			array( $slot_a['x'], $slot_a['y'] ),
+			array( $slot_b['x'], $slot_b['y'] ),
+			'sibling folders must not stack on the same cell'
+		);
+	}
+
+	public function test_ensure_upload_path_reports_created_folders() {
+		$req = new WP_REST_Request( 'POST', '/desktop-mode/v1/files/uploads/paths' );
+		$req->set_param( 'parentId', 0 );
+		$req->set_param( 'relativePath', 'empty/nested' );
+		$res = openstation_files_rest_ensure_upload_path( $req );
+		$this->assertNotWPError( $res );
+		$data = $res->get_data();
+		$this->assertCount( 2, $data['createdFolders'] );
+		$this->assertSame( 'empty', $data['createdFolders'][0]['folder']['name'] );
+		$this->assertSame( 'nested', $data['createdFolders'][1]['folder']['name'] );
+		$this->assertSame( $data['createdFolders'][1]['folder']['id'], $data['folderId'] );
+
+		// Second call: everything exists, nothing reported.
+		$again = openstation_files_rest_ensure_upload_path( $req );
+		$this->assertNotWPError( $again );
+		$this->assertSame( $data['folderId'], $again->get_data()['folderId'] );
+		$this->assertSame( array(), $again->get_data()['createdFolders'] );
 	}
 
 	public function test_relative_path_rejects_dot_segments() {

--- a/tests/vitest/desktop-files-store.test.ts
+++ b/tests/vitest/desktop-files-store.test.ts
@@ -115,6 +115,65 @@ describe( 'desktop-files store', () => {
 	} );
 } );
 
+describe( 'ingestCreatedFolders', () => {
+	beforeEach( () => {
+		installHooksStub();
+	} );
+	afterEach( () => {
+		clearHooksStub();
+	} );
+
+	const folderRow = ( id: number, name: string ) => ( {
+		id,
+		ownerId: 1,
+		name,
+		shareMode: 'private',
+		shareMeta: null,
+		updatedAtMs: 1,
+	} );
+
+	test( 'registers each folder row and its placement, outermost first', async () => {
+		const store = await loadStore();
+		store.__resetFilesStoreForTests();
+		store.ingestCreatedFolders( [
+			{
+				folder: folderRow( 10, 'docs' ),
+				placement: samplePlacement( {
+					id: 100,
+					parentId: 0,
+					file: { type: 'folder', ref: '10', title: 'docs', icon: 'dashicons-portfolio', previewUrl: '', exists: true },
+				} ),
+			},
+			{
+				folder: folderRow( 11, 'reports' ),
+				placement: samplePlacement( {
+					id: 101,
+					parentId: 10,
+					file: { type: 'folder', ref: '11', title: 'reports', icon: 'dashicons-portfolio', previewUrl: '', exists: true },
+				} ),
+			},
+		] );
+		const state = store.getFilesState();
+		expect( state.folders.get( 10 )?.name ).toBe( 'docs' );
+		expect( state.folders.get( 11 )?.name ).toBe( 'reports' );
+		expect( ( state.placementsByFolder.get( 0 ) ?? [] ).some( ( p ) => p.id === 100 ) ).toBe( true );
+		expect( ( state.placementsByFolder.get( 10 ) ?? [] ).some( ( p ) => p.id === 101 ) ).toBe( true );
+	} );
+
+	test( 'tolerates a missing list and skips malformed entries', async () => {
+		const store = await loadStore();
+		store.__resetFilesStoreForTests();
+		expect( () => store.ingestCreatedFolders( undefined ) ).not.toThrow();
+		store.ingestCreatedFolders( [
+			null as unknown as import( '../../src/desktop-files/rest' ).RestCreatedFolderShape,
+			{ folder: folderRow( 12, 'ok' ), placement: null as unknown as import( '../../src/desktop-files/rest' ).RestPlacementShape },
+		] );
+		const state = store.getFilesState();
+		expect( state.folders.get( 12 )?.name ).toBe( 'ok' );
+		expect( state.placementsByFolder.size ).toBe( 0 );
+	} );
+} );
+
 describe( 'desktop-files REST client', () => {
 	beforeEach( () => {
 		installHooksStub();

--- a/tests/vitest/os-file-drop-desktop-upload.test.ts
+++ b/tests/vitest/os-file-drop-desktop-upload.test.ts
@@ -147,6 +147,80 @@ describe( 'uploadFileToDesktop', () => {
 		expect( rows.some( ( r ) => r.id === 4242 ) ).toBe( true );
 	} );
 
+	test( 'createdFolders from a tree upload are ingested before the file placement', async () => {
+		const mod = await load();
+		const store = await import( '../../src/desktop-files/store' );
+		store.__resetFilesStoreForTests();
+
+		const promise = mod.uploadFileToDesktop( { ...baseArgs(), relativePath: 'docs/a.txt' } );
+		const folderPlacement = {
+			id: 900,
+			parentId: 0,
+			x: 16,
+			y: 16,
+			sortOrder: 0,
+			updatedAtMs: 5,
+			meta: null,
+			file: { type: 'folder', ref: '3', title: 'docs', icon: 'dashicons-portfolio', previewUrl: '', exists: true },
+		};
+		const filePlacement = {
+			id: 901,
+			parentId: 3,
+			x: 16,
+			y: 16,
+			sortOrder: 0,
+			updatedAtMs: 5,
+			meta: null,
+			file: { type: 'upload', ref: '77', title: 'a.txt', icon: 'dashicons-media-text', previewUrl: '', exists: true },
+		};
+		FakeXhr.last!.respond(
+			201,
+			JSON.stringify( {
+				placement: filePlacement,
+				storedFileId: 77,
+				createdFolders: [
+					{
+						folder: { id: 3, ownerId: 1, name: 'docs', shareMode: 'private', shareMeta: null, updatedAtMs: 5 },
+						placement: folderPlacement,
+					},
+				],
+			} ),
+		);
+		const result = await promise;
+		expect( result.createdFolders ).toHaveLength( 1 );
+		expect( result.createdFolders[ 0 ].folder.name ).toBe( 'docs' );
+
+		// The wallpaper tile is in the store the moment the first file
+		// of the tree lands — no end-of-batch resync, no heartbeat.
+		const state = store.getFilesState();
+		expect( state.folders.get( 3 )?.name ).toBe( 'docs' );
+		expect( ( state.placementsByFolder.get( 0 ) ?? [] ).some( ( p ) => p.id === 900 ) ).toBe( true );
+		expect( ( state.placementsByFolder.get( 3 ) ?? [] ).some( ( p ) => p.id === 901 ) ).toBe( true );
+	} );
+
+	test( 'a response without createdFolders yields an empty list', async () => {
+		const mod = await load();
+		const promise = mod.uploadFileToDesktop( baseArgs() );
+		FakeXhr.last!.respond(
+			201,
+			JSON.stringify( {
+				placement: {
+					id: 4243,
+					parentId: 0,
+					x: 0,
+					y: 0,
+					sortOrder: 0,
+					updatedAtMs: 5,
+					meta: null,
+					file: { type: 'upload', ref: '78', title: 'a.txt', icon: 'dashicons-media-text', previewUrl: '', exists: true },
+				},
+				storedFileId: 78,
+			} ),
+		);
+		const result = await promise;
+		expect( result.createdFolders ).toEqual( [] );
+	} );
+
 	test( 'coords ride along only when provided', async () => {
 		const mod = await load();
 		const args = { ...baseArgs(), coords: { x: 112, y: 126 } };


### PR DESCRIPTION
## Problem

Dropping a folder from Finder onto the desktop: the files uploaded fine (the HUD showed the transfer), but the **folder tile took a long time to appear** — sometimes a full minute.

The server created the folder and its wallpaper placement during the **first** file's request (mkdir-p in `openstation_files_resolve_relative_path()`), but that response only carried the file's own placement, which lives *inside* the new folder. The client learned about the folder from the end-of-batch resync in `src/os-file-drop/dialog.ts` — after every file had uploaded one at a time and the empty directories had been created — or, if that resync threw (swallowed), from the next Heartbeat delta (15–60 s by the Preferences rate).

A second issue hid behind it: mkdir-p folders were persisted at `0,0` via a bare `openstation_files_place()`; the layer displaced the collision client-side, but the stored coordinates stayed wrong and the tile could jump after a reload.

## Change

- `POST /files/uploads` and `POST /files/uploads/paths` now return `createdFolders`: a `{ folder, placement }` pair per folder the request created, outermost first. Reused segments are not listed, so it is `[]` for flat uploads and for every file after the first in a tree.
- The desktop uploader and the empty-dir path ingest them on receipt through the new `ingestCreatedFolders()` store helper — folder row before the file's own placement. The end-of-batch resync stays as a safety net.
- mkdir-p folders take the next free grid slot in their parent (`openstation_files_place_at_next_free_slot()`), the same as file placements.
- `DesktopUploadResult` gains `createdFolders`, visible on the `os.drop.after-upload` payload.

Additive payload change; no hook signatures touched.

## Tests

- PHPUnit: created-folder payload + dedupe on the second file, flat uploads report nothing, sibling trees land on distinct cells, the paths endpoint reports and then dedupes.
- vitest: store ingest ordering and malformed entries, uploader ingests the folder before the file placement, absent list yields `[]`.
- Full `test:js` (5847 tests), `os-files` PHPUnit group (251 tests), typecheck, lint, lint:php, build — all green.

## Docs

`docs/files-on-desktop.md` REST table, `docs/javascript-reference.md` after-upload result, `docs/examples/os-file-drop.md`.

## QA

Drop a folder with several files onto the wallpaper: the folder tile should appear as soon as the first file finishes. A folder containing only empty subfolders should appear immediately too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-768-b7d379d869677201262c41cf51e60c53d42ff0b4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->