### PR TITLE
Shell: keep third-party scripts out of os-* fields and fixed panels out of the dynamic bar

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -167,24 +167,41 @@ body.os-active #wpadminbar {
  * the shell's way, so the shell reclaims the full viewport in each.
  *
  * Every selector here carries two body classes, so it outranks the
- * one-class pin rule above without needing to escalate anything.
+ * one-class pin rule above on specificity; the one property the pin
+ * marks `!important` (`inset-block-start`) is re-declared `!important`
+ * where a mode moves the bar, and wins the same way.
  */
 
 /*
  * Dynamic — the bar parks off the top edge leaving a peek strip, and
  * slides back in when the pointer reaches the top of the viewport or
  * something inside it takes keyboard focus. The classic Windows
- * auto-hide taskbar, and the reason `transform` is the right tool: a
- * transformed element keeps hit-testing at its PAINTED position, so
- * the parked remainder stops catching the pointer the moment it goes
- * off-screen. What DOES catch it is the peek strip plus the reveal
- * zone added below.
+ * auto-hide taskbar.
+ *
+ * It parks by moving its `inset-block-start`, NOT by a `transform`,
+ * and that is load-bearing. A transformed element becomes the
+ * containing block for every `position: fixed` descendant, and the
+ * bar has descendants like that which it does not own: the
+ * WordPress.com notifications panel is `position: fixed; top: 32px;
+ * bottom: 0` inside `#wp-admin-bar-notes`. Measured against a
+ * transformed 32px bar instead of the viewport, that panel computes to
+ * zero height — the button "did nothing" in this mode and worked in
+ * `static`. `translate`, `filter`, `perspective`, `contain` and
+ * `will-change: transform` all create the same containing block;
+ * `tests/vitest/admin-bar-dynamic.test.ts` keeps every one of them off
+ * this rule. Moving `inset-block-start` hit-tests the same way — the
+ * part above the viewport is simply outside it — so what catches the
+ * pointer is still only the peek strip plus the reveal zone below.
+ *
+ * The pin above sets `inset-block-start: 0 !important`; these carry
+ * `!important` too and win on specificity. The bar's height is Core's
+ * own token, so the parked offset follows the 46px mobile bar as well.
  */
 body.os-active.os-admin-bar-dynamic #wpadminbar {
-	transform: translateY(
-		calc(-100% + var(--os-admin-bar-peek, 4px))
-	);
-	transition: transform 180ms ease;
+	inset-block-start: calc(
+		var(--os-admin-bar-peek, 4px) - var(--wp-admin--admin-bar--height, 32px)
+	) !important;
+	transition: inset-block-start 180ms ease;
 }
 
 body.os-active.os-admin-bar-dynamic #wpadminbar:hover,
@@ -198,7 +215,7 @@ body.os-active.os-admin-bar-dynamic #wpadminbar:active,
  */
 body.os-active.os-admin-bar-dynamic:has( .os-notch:hover ) #wpadminbar,
 body.os-active.os-admin-bar-dynamic:has( .os-notch:focus-visible ) #wpadminbar {
-	transform: translateY(0);
+	inset-block-start: 0 !important;
 }
 
 /*

--- a/docs/components-reference.md
+++ b/docs/components-reference.md
@@ -144,6 +144,31 @@ wash over a dark row.
 If your surface is dark, you own every token that names a surface or a
 wash on one — not just the text.
 
+### Read characters off `input`, not `keydown`
+
+Shadow DOM has a second consequence, and the shell leans on it. A
+keydown typed into a component's inner `<input>` reaches `document`
+with its target retargeted to the host — `OS-TEXT-FIELD`, not
+`INPUT` — so any third-party script guarding a bare-letter shortcut
+with `e.target.tagName === 'INPUT'` fires while the user is typing.
+The shell's **text-entry guard** (`src/text-entry-guard.ts`, documented
+in [`javascript-reference.md`](javascript-reference.md#the-text-entry-guard--what-a-document-keydown-listener-sees--stable))
+stops a printable, unmodified keydown aimed at a text-entry element in
+a shadow root at `window`'s capture phase — before it reaches the
+input.
+
+For a component that means: **characters arrive through `input` /
+`beforeinput`; `keydown` carries everything else.** Enter for
+`os-submit`, Escape to close a popup, the arrows for a listbox,
+Backspace on an empty tag field, Tab — all of those still reach the
+input's listeners, because none of them is a single printable key
+without a modifier. A type-ahead on a **button** or listbox trigger
+(`<os-select>`) is untouched too; the guard only covers inputs,
+textareas and `contenteditable`. What will not work is a text field
+that watches `keydown` for the letter itself — `e.key === ','` to
+split a tag, say. Do that on `input`, where the character is already
+in the value, or on `beforeinput`, where it can still be refused.
+
 ## Buttons & actions
 
 | Tag | Class | Source | Purpose |

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -1806,6 +1806,19 @@ The confirmation carries a **"Don't ask again"** checkbox. Ticking it writes `co
 
 `Cmd/Ctrl+Shift+W` is deliberately not the binding — the browser owns it and a page can't take it back.
 
+#### The text-entry guard — what a `document` keydown listener sees — Stable
+
+Every `<os-*>` text control keeps its real `<input>` / `<textarea>` in a shadow root, and a keydown typed into one reaches `document` with `event.target` **retargeted to the host element** (`OS-TEXT-FIELD`, not `INPUT`). A script that guards a bare-letter shortcut with `e.target.tagName === 'INPUT'` — the WordPress.com notifications panel's `n`, for one — therefore fires while the user is typing, and steals focus mid-word.
+
+The shell closes that gap structurally in `src/text-entry-guard.ts`: one capture-phase listener on `window` calls `stopPropagation()` on a keydown that is **printable and unmodified** (`key.length === 1`, no Ctrl/Alt/Meta) and whose real target — the head of `composedPath()` — is a text-entry element **inside a shadow root**. The default action is untouched, so the character is still inserted. Consequences for anything listening on `document` or below:
+
+- A bare printable key typed into an `<os-*>` field is **never delivered** to a listener on `document`, `body`, or the shell — in either phase. Escape, Enter, Tab, the arrows, function keys and every chord are delivered exactly as before, so a dialog's Enter / Escape handling, `dismissable`, the window switcher and the palette shortcut are unaffected.
+- A light-DOM `<input>` is not covered — its keystrokes already read as `INPUT` to every tag-name guard, and the guard changes nothing for them.
+- A listener on `window` sees everything: `stopPropagation()` does not stop siblings on the same target. That is where the presence probe counts typing as activity, and where a plugin that needs raw keystrokes regardless of focus should listen — behind its own text-entry check, `composedPath()[ 0 ]` being the element to test.
+- The stop happens **before the event reaches the input itself**, so a component cannot read characters off `keydown` on a shadow input; it reads them off `input` / `beforeinput` (see [`components-reference.md`](./components-reference.md#read-characters-off-input-not-keydown)).
+
+`tests/vitest/text-entry-guard.test.ts` pins the policy; `isShadowTextEntryKeydown( e )` exported from the module *is* the policy, for anything that needs to agree with it.
+
 ---
 
 ### `dock` — Stable

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -14,6 +14,7 @@
 
 import { WindowManager } from './window-manager';
 import { installWindowSwitcherShortcut } from './window-manager/switcher';
+import { installTextEntryGuard } from './text-entry-guard';
 import { installDesktopArrowShortcuts } from './window-manager/desktop-shortcuts';
 import { installCloseAllShortcut } from './window-manager/close-all-shortcut';
 import {
@@ -2498,6 +2499,10 @@ function init(): void {
 		close: () => aiAssistant.close(),
 		isOpen: () => aiAssistant.isOpen,
 	} );
+	// Ahead of every shell shortcut: keeps a printable key typed into an
+	// `<os-*>` field from reaching document-level listeners that would
+	// mistake the shadow host for "not an input". See the module.
+	installTextEntryGuard();
 	installPaletteShortcut();
 	installWindowSwitcherShortcut( manager );
 	installDesktopArrowShortcuts( manager );

--- a/src/presence/index.ts
+++ b/src/presence/index.ts
@@ -168,7 +168,12 @@ export function bootPresenceProbe(): void {
 		capture: true,
 		passive: true,
 	} );
-	document.addEventListener( 'keydown', noteUserActivity, {
+	// On `window`, not `document`: the text-entry guard
+	// (`src/text-entry-guard.ts`) stops a printable key typed into an
+	// `<os-*>` field at the window's capture phase, and a listener on
+	// `document` would then never see the user's typing. Siblings on
+	// the same target still run, so this one always does.
+	window.addEventListener( 'keydown', noteUserActivity, {
 		capture: true,
 		passive: true,
 	} );

--- a/src/text-entry-guard.ts
+++ b/src/text-entry-guard.ts
@@ -1,0 +1,117 @@
+/**
+ * OpenStation — Text-entry guard.
+ *
+ * Every `<os-*>` text control keeps its real `<input>` / `<textarea>`
+ * inside a shadow root. That is what keeps core's `forms.css` out of
+ * it (see `components-reference.md`, "A raw input in the shell is not
+ * a styling choice"), and it has a cost that only shows up on a live
+ * site: by the time a keystroke typed into that input reaches a
+ * listener on `document`, the browser has retargeted `event.target`
+ * to the host element. A third-party script asking "is the user
+ * typing?" the way most of them do —
+ *
+ *     if ( e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' ) return;
+ *
+ * — sees `OS-TEXT-FIELD`, decides nobody is typing, and runs its
+ * single-letter shortcut. The WordPress.com notifications panel is
+ * the one that found this: its `n` toggles the panel and focuses the
+ * panel's iframe, so a folder named "New" could be typed on a local
+ * site and not on a wpcom one, running the same shell code.
+ *
+ * The guard is the structural answer, and it is deliberately narrow.
+ * One capture-phase listener on `window` — the only listener position
+ * that runs before anything registered on `document`, in either
+ * phase — stops the propagation of a keydown that is:
+ *
+ *   - **printable and unmodified** (`key.length === 1`, no Ctrl, Alt
+ *     or Meta). Escape, Enter, Tab, the arrows and every chord keep
+ *     propagating, so `dismissable`, the switcher, the palette
+ *     shortcut and a dialog's own Enter / Escape handling see exactly
+ *     what they always saw. A bare printable key typed into a focused
+ *     text field is text; nothing in the shell can legitimately want
+ *     it as a shortcut.
+ *   - **aimed at a text-entry element inside a shadow root.** The
+ *     head of `composedPath()` is the real leaf whatever the
+ *     retargeting says. A light-DOM input already reads as `INPUT` to
+ *     every tag-name guard out there; changing what listeners see for
+ *     those would widen the blast radius for nothing.
+ *
+ * `stopPropagation()` never cancels the default action, so the
+ * character is still inserted. Two consequences worth knowing:
+ *
+ *   - Capture runs outward-in, so the event is stopped before it
+ *     reaches the input's own listeners. A kit component therefore
+ *     cannot read *characters* off `keydown` on a shadow input — it
+ *     reads them off `input` / `beforeinput`, which is where every
+ *     component already reads them. Non-printable keys (Enter for
+ *     `os-submit`, arrows for a listbox, Backspace on an empty tag
+ *     field) still arrive.
+ *   - `stopPropagation()` does not stop other listeners on the same
+ *     target, so a listener on `window` keeps seeing everything. That
+ *     is where the presence probe counts typing as user activity.
+ *
+ * Bare keys arriving from a chromeless iframe are not this module's
+ * concern: native keydown never crosses a frame boundary, and the
+ * bridge's own forwarders apply their own text-entry gate before
+ * forwarding (`docs/bridge-protocol.md`, "Keyboard forwarders").
+ */
+
+import { isTextEntryElement } from './window-manager/switcher';
+
+let uninstall: ( () => void ) | null = null;
+
+/**
+ * Whether the guard should stop this keydown from propagating past
+ * `window`: a printable, unmodified key whose real target is a
+ * text-entry element inside a shadow root.
+ *
+ * Exported for tests and for anything else that needs to agree with
+ * the guard — the predicate is the whole policy.
+ */
+export function isShadowTextEntryKeydown( e: KeyboardEvent ): boolean {
+	if ( e.ctrlKey || e.metaKey || e.altKey ) {
+		return false;
+	}
+	// 'Enter', 'Escape', 'ArrowDown', 'Process' (an IME composing),
+	// 'Dead' (a dead key) — every named key is longer than one code
+	// unit. A space is `' '` and is text.
+	if ( e.key.length !== 1 ) {
+		return false;
+	}
+	const path = e.composedPath();
+	const leaf = path.length > 0 ? path[ 0 ] : null;
+	if ( ! ( leaf instanceof Element ) ) {
+		return false;
+	}
+	if ( ! ( leaf.getRootNode() instanceof ShadowRoot ) ) {
+		return false;
+	}
+	return isTextEntryElement( leaf );
+}
+
+/**
+ * Install the guard on `window`. Idempotent; returns the uninstaller
+ * (a no-op after the first call for the same install).
+ *
+ * @param target The window to guard. Defaults to the global one;
+ *               tests pass their own.
+ */
+export function installTextEntryGuard( target: Window = window ): () => void {
+	if ( uninstall ) {
+		return uninstall;
+	}
+	const onKeyDown = ( e: KeyboardEvent ): void => {
+		if ( isShadowTextEntryKeydown( e ) ) {
+			e.stopPropagation();
+		}
+	};
+	target.addEventListener( 'keydown', onKeyDown, true );
+	const off = (): void => {
+		target.removeEventListener( 'keydown', onKeyDown, true );
+		if ( uninstall === off ) {
+			uninstall = null;
+		}
+	};
+	uninstall = off;
+	return off;
+}

--- a/src/window-manager/switcher.ts
+++ b/src/window-manager/switcher.ts
@@ -120,6 +120,20 @@ export function isTextEntryFocus( doc: Document ): boolean {
 	while ( el && el.shadowRoot && el.shadowRoot.activeElement ) {
 		el = el.shadowRoot.activeElement;
 	}
+	return isTextEntryElement( el );
+}
+
+/**
+ * True when the given element consumes bare keystrokes as text — the
+ * element-level half of {@link isTextEntryFocus}, for callers that
+ * already hold the real leaf (the head of a keydown's `composedPath()`,
+ * say) rather than asking the document who has focus.
+ *
+ * `src/text-entry-guard.ts` is the other consumer: it has to agree
+ * with the switcher about what "typing" means, so the definition
+ * lives once.
+ */
+export function isTextEntryElement( el: Element | null ): boolean {
 	if ( ! el ) {
 		return false;
 	}

--- a/tests/vitest/admin-bar-dynamic.test.ts
+++ b/tests/vitest/admin-bar-dynamic.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The dynamic admin bar must never be transformed.
+ *
+ * `desktop.css` parks the bar off the top edge in `dynamic` mode. It
+ * used to do that with `transform: translateY(…)`, and a transformed
+ * element is the containing block for every `position: fixed`
+ * descendant — including ones the bar does not own. The WordPress.com
+ * notifications panel is `position: fixed; top: 32px; bottom: 0`
+ * inside `#wp-admin-bar-notes`; measured against a 32px bar instead of
+ * the viewport it computed to zero height, and the button "did
+ * nothing" in this mode while working in `static`.
+ *
+ * The bar now parks by `inset-block-start`. This test keeps every
+ * containing-block-creating property off the dynamic-mode rules, so
+ * the regression cannot come back through a tidy-up that "just"
+ * switches to `translate` or adds a `will-change`.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const ROOT = resolve( __dirname, '../..' );
+const CSS = readFileSync( resolve( ROOT, 'assets/css/desktop.css' ), 'utf8' );
+
+interface Rule {
+	selector: string;
+	body: string;
+}
+
+/** Every top-level `selector { body }` pair, comments stripped. */
+function rules( css: string ): Rule[] {
+	const stripped = css.replace( /\/\*[\s\S]*?\*\//g, '' );
+	const out: Rule[] = [];
+	const re = /([^{}]+)\{([^{}]*)\}/g;
+	let m: RegExpExecArray | null;
+	while ( ( m = re.exec( stripped ) ) ) {
+		out.push( {
+			selector: m[ 1 ].replace( /\s+/g, ' ' ).trim(),
+			body: m[ 2 ].replace( /\s+/g, ' ' ).trim(),
+		} );
+	}
+	return out;
+}
+
+/**
+ * The rules that place the bar itself in dynamic mode: selectors
+ * naming both the mode class and `#wpadminbar`, minus the ones that
+ * target a pseudo-element (the reveal zone) or something else under
+ * the same body class (the shell).
+ */
+const BAR_RULES = rules( CSS ).filter(
+	( r ) =>
+		r.selector.includes( 'os-admin-bar-dynamic' ) &&
+		/#wpadminbar(?![\w-])/.test( r.selector ) &&
+		! r.selector.includes( '::' ) &&
+		! r.selector.includes( '.os-shell' ),
+);
+
+/**
+ * Properties that make an element the containing block for its
+ * `position: fixed` descendants (CSS Transforms 1 §… / css-contain /
+ * filter-effects). Any of these on the bar breaks fixed-positioned
+ * panels rendered inside it.
+ */
+const CONTAINING_BLOCK_MAKERS = [
+	'transform',
+	'translate',
+	'rotate',
+	'scale',
+	'filter',
+	'backdrop-filter',
+	'perspective',
+	'contain',
+	'will-change',
+];
+
+describe( 'dynamic admin bar — never a containing block', () => {
+	test( 'the dynamic-mode bar rules exist', () => {
+		expect( BAR_RULES.length ).toBeGreaterThanOrEqual( 2 );
+	} );
+
+	test.each( CONTAINING_BLOCK_MAKERS )(
+		'no dynamic-mode bar rule declares `%s`',
+		( prop ) => {
+			const re = new RegExp( `(^|[;\\s])${ prop }\\s*:`, 'i' );
+			for ( const r of BAR_RULES ) {
+				expect(
+					re.test( r.body ),
+					`\`${ r.selector }\` declares \`${ prop }\` — a transformed bar is the containing block for the fixed-positioned panels inside it (the wpcom notifications panel collapses to 0px). Park the bar with inset-block-start instead.`,
+				).toBe( false );
+			}
+		},
+	);
+
+	test( 'the parked bar moves by inset-block-start, and outranks the visibility pin', () => {
+		const parked = BAR_RULES.find(
+			( r ) => r.selector === 'body.os-active.os-admin-bar-dynamic #wpadminbar',
+		);
+		expect( parked ).toBeDefined();
+		// The pin `body.os-active #wpadminbar` sets `inset-block-start: 0
+		// !important`; only another `!important` can move the bar.
+		expect( parked!.body ).toMatch( /inset-block-start\s*:[^;]*!important/ );
+		expect( parked!.body ).toMatch( /--os-admin-bar-peek/ );
+		expect( parked!.body ).toMatch( /--wp-admin--admin-bar--height/ );
+		expect( parked!.body ).toMatch( /transition\s*:\s*inset-block-start/ );
+	} );
+
+	test( 'the revealed bar returns to the top edge, also with !important', () => {
+		const revealed = BAR_RULES.find(
+			( r ) =>
+				r.selector.includes( '#wpadminbar:hover' ) &&
+				r.selector.includes( '#wpadminbar:focus-within' ),
+		);
+		expect( revealed ).toBeDefined();
+		expect( revealed!.body ).toMatch( /inset-block-start\s*:\s*0\s*!important/ );
+	} );
+} );

--- a/tests/vitest/os-settings-admin-bar-mode.test.ts
+++ b/tests/vitest/os-settings-admin-bar-mode.test.ts
@@ -4,8 +4,8 @@
  * The pick reaches CSS as a `os-admin-bar-<mode>` body
  * class, and it has to be the ONLY one of the three on the body —
  * `desktop.css` gives `hidden` a `display: none !important` and
- * `dynamic` a transform, so two classes at once is a bar that is
- * simultaneously gone and sliding.
+ * `dynamic` an off-screen inset, so two classes at once is a bar that
+ * is simultaneously gone and sliding.
  *
  * PHP writes the same class on `admin_body_class` for the first
  * paint; these tests cover the half that makes a change take effect

--- a/tests/vitest/text-entry-guard.test.ts
+++ b/tests/vitest/text-entry-guard.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the text-entry guard (`src/text-entry-guard.ts`).
+ *
+ * The scenario that produced the module: a third-party script binds a
+ * bare letter on `document` and guards it with `e.target.tagName ===
+ * 'INPUT'`. Typed into a light-DOM input that guard works; typed into
+ * the input inside an `<os-text-field>`'s shadow root it sees the
+ * host's tag name, fires, and moves focus — the WordPress.com
+ * notifications panel on `n`. The guard stops that keystroke at
+ * `window`'s capture phase; everything that is not a bare printable
+ * key into a shadow input keeps flowing.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+	installTextEntryGuard,
+	isShadowTextEntryKeydown,
+} from '../../src/text-entry-guard';
+import '../../src/ui/components/os-text-field/os-text-field';
+
+const tick = (): Promise< void > => Promise.resolve();
+
+/** A keydown as the browser would dispatch it: bubbling, composed, cancelable. */
+function keydown( init: KeyboardEventInit ): KeyboardEvent {
+	return new KeyboardEvent( 'keydown', {
+		bubbles: true,
+		composed: true,
+		cancelable: true,
+		...init,
+	} );
+}
+
+/** The third-party shape: a document listener with a tag-name guard. */
+function thirdPartyShortcut( letter: string ): {
+	fired: number;
+	off: () => void;
+} {
+	const state = { fired: 0, off: () => {} };
+	const listener = ( e: Event ): void => {
+		const target = e.target as HTMLElement;
+		if ( target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' ) {
+			return;
+		}
+		if ( ( e as KeyboardEvent ).key === letter ) {
+			state.fired++;
+		}
+	};
+	document.addEventListener( 'keydown', listener );
+	state.off = () => document.removeEventListener( 'keydown', listener );
+	return state;
+}
+
+/** A host with an open shadow root holding one text-entry element. */
+function shadowLeaf< T extends HTMLElement >( leaf: T ): T {
+	const host = document.createElement( 'div' );
+	document.body.appendChild( host );
+	host.attachShadow( { mode: 'open' } ).appendChild( leaf );
+	return leaf;
+}
+
+describe( 'text-entry guard', () => {
+	let off: () => void;
+
+	beforeEach( () => {
+		off = installTextEntryGuard();
+	} );
+
+	afterEach( () => {
+		off();
+		document.body.innerHTML = '';
+	} );
+
+	test( 'a bare letter typed into a shadow-root input never reaches a document listener', () => {
+		const shortcut = thirdPartyShortcut( 'n' );
+		const input = shadowLeaf( document.createElement( 'input' ) );
+
+		const seenByDocument: string[] = [];
+		const capture = ( e: Event ): void => {
+			seenByDocument.push( ( e as KeyboardEvent ).key );
+		};
+		document.addEventListener( 'keydown', capture, true );
+
+		const ev = keydown( { key: 'n' } );
+		input.dispatchEvent( ev );
+
+		expect( shortcut.fired ).toBe( 0 );
+		expect( seenByDocument ).toEqual( [] );
+		// Stopping propagation is not cancelling: the character still
+		// gets inserted.
+		expect( ev.defaultPrevented ).toBe( false );
+
+		document.removeEventListener( 'keydown', capture, true );
+		shortcut.off();
+	} );
+
+	test( 'the same script still sees a bare letter typed into a light-DOM input as INPUT', () => {
+		const shortcut = thirdPartyShortcut( 'n' );
+		const input = document.createElement( 'input' );
+		document.body.appendChild( input );
+
+		let reached = 0;
+		const bubble = (): void => {
+			reached++;
+		};
+		document.addEventListener( 'keydown', bubble );
+
+		input.dispatchEvent( keydown( { key: 'n' } ) );
+
+		// The guard is scoped to shadow roots: the light-DOM event
+		// propagates as before, and the script's own guard handles it.
+		expect( reached ).toBe( 1 );
+		expect( shortcut.fired ).toBe( 0 );
+
+		document.removeEventListener( 'keydown', bubble );
+		shortcut.off();
+	} );
+
+	test( 'a bare letter on a non-text element still fires the shortcut', () => {
+		const shortcut = thirdPartyShortcut( 'n' );
+		const button = document.createElement( 'button' );
+		document.body.appendChild( button );
+
+		button.dispatchEvent( keydown( { key: 'n' } ) );
+		expect( shortcut.fired ).toBe( 1 );
+		shortcut.off();
+	} );
+
+	test( 'named keys and chords from a shadow-root input keep propagating', () => {
+		const input = shadowLeaf( document.createElement( 'input' ) );
+		const seen: string[] = [];
+		const listener = ( e: Event ): void => {
+			const k = e as KeyboardEvent;
+			seen.push( `${ k.metaKey ? 'meta+' : '' }${ k.ctrlKey ? 'ctrl+' : '' }${ k.key }` );
+		};
+		document.addEventListener( 'keydown', listener );
+
+		input.dispatchEvent( keydown( { key: 'Escape' } ) );
+		input.dispatchEvent( keydown( { key: 'Enter' } ) );
+		input.dispatchEvent( keydown( { key: 'ArrowDown' } ) );
+		input.dispatchEvent( keydown( { key: 'Tab' } ) );
+		input.dispatchEvent( keydown( { key: 'k', metaKey: true } ) );
+		input.dispatchEvent( keydown( { key: 'n', ctrlKey: true } ) );
+		input.dispatchEvent( keydown( { key: 'Process' } ) );
+
+		expect( seen ).toEqual( [
+			'Escape',
+			'Enter',
+			'ArrowDown',
+			'Tab',
+			'meta+k',
+			'ctrl+n',
+			'Process',
+		] );
+		document.removeEventListener( 'keydown', listener );
+	} );
+
+	test( 'a listener on window still sees the keystroke (the presence probe)', () => {
+		const input = shadowLeaf( document.createElement( 'input' ) );
+		let seen = 0;
+		const probe = (): void => {
+			seen++;
+		};
+		window.addEventListener( 'keydown', probe, true );
+
+		input.dispatchEvent( keydown( { key: 'n' } ) );
+		expect( seen ).toBe( 1 );
+
+		window.removeEventListener( 'keydown', probe, true );
+	} );
+
+	test( 'the real <os-text-field>: n is hidden from the document, Enter still submits', async () => {
+		const shortcut = thirdPartyShortcut( 'n' );
+		const host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		host.innerHTML = '<os-text-field label="Folder name" value="Untitled folder"></os-text-field>';
+		await tick();
+
+		const field = host.querySelector( 'os-text-field' )!;
+		const input = field.shadowRoot!.querySelector( 'input' ) as HTMLInputElement;
+		let submitted = 0;
+		field.addEventListener( 'os-submit', () => {
+			submitted++;
+		} );
+
+		input.dispatchEvent( keydown( { key: 'n' } ) );
+		expect( shortcut.fired ).toBe( 0 );
+
+		input.dispatchEvent( keydown( { key: 'Enter' } ) );
+		expect( submitted ).toBe( 1 );
+
+		shortcut.off();
+	} );
+
+	test( 'uninstalling restores propagation', () => {
+		off();
+		const shortcut = thirdPartyShortcut( 'n' );
+		const input = shadowLeaf( document.createElement( 'input' ) );
+
+		input.dispatchEvent( keydown( { key: 'n' } ) );
+		expect( shortcut.fired ).toBe( 1 );
+
+		shortcut.off();
+		// `afterEach` calls `off()` again — it is a no-op by then.
+	} );
+
+	test( 'installing twice is one listener', () => {
+		const again = installTextEntryGuard();
+		expect( again ).toBe( off );
+	} );
+} );
+
+describe( 'isShadowTextEntryKeydown — the policy', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	function judge( leaf: HTMLElement, init: KeyboardEventInit ): boolean {
+		let verdict = false;
+		const listener = ( e: Event ): void => {
+			verdict = isShadowTextEntryKeydown( e as KeyboardEvent );
+		};
+		leaf.addEventListener( 'keydown', listener );
+		leaf.dispatchEvent( keydown( init ) );
+		leaf.removeEventListener( 'keydown', listener );
+		return verdict;
+	}
+
+	test( 'text-ish inputs, textareas and contenteditable in a shadow root qualify', () => {
+		expect( judge( shadowLeaf( document.createElement( 'input' ) ), { key: 'n' } ) ).toBe( true );
+		const search = document.createElement( 'input' );
+		search.type = 'search';
+		expect( judge( shadowLeaf( search ), { key: ' ' } ) ).toBe( true );
+		expect( judge( shadowLeaf( document.createElement( 'textarea' ) ), { key: 'n' } ) ).toBe( true );
+		const editable = document.createElement( 'div' );
+		editable.setAttribute( 'contenteditable', 'true' );
+		expect( judge( shadowLeaf( editable ), { key: 'n' } ) ).toBe( true );
+	} );
+
+	test( 'inputs that do not take characters do not qualify', () => {
+		const checkbox = document.createElement( 'input' );
+		checkbox.type = 'checkbox';
+		expect( judge( shadowLeaf( checkbox ), { key: 'n' } ) ).toBe( false );
+		expect( judge( shadowLeaf( document.createElement( 'button' ) ), { key: 'n' } ) ).toBe( false );
+	} );
+
+	test( 'a light-DOM input does not qualify', () => {
+		const input = document.createElement( 'input' );
+		document.body.appendChild( input );
+		expect( judge( input, { key: 'n' } ) ).toBe( false );
+	} );
+
+	test( 'modifiers and named keys do not qualify', () => {
+		const input = shadowLeaf( document.createElement( 'input' ) );
+		expect( judge( input, { key: 'n', metaKey: true } ) ).toBe( false );
+		expect( judge( input, { key: 'n', ctrlKey: true } ) ).toBe( false );
+		expect( judge( input, { key: 'n', altKey: true } ) ).toBe( false );
+		expect( judge( input, { key: 'N', shiftKey: true } ) ).toBe( true );
+		expect( judge( input, { key: 'Enter' } ) ).toBe( false );
+		expect( judge( input, { key: 'Dead' } ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Summary

Two bugs that only reproduce where the WordPress.com notifications script loads (wpcom / Atomic), with the same shell code working locally.

### 1. Typing `n` into an `<os-*>` field opened the notifications panel

Every `<os-*>` text control keeps its real `<input>` in a shadow root, so a keydown typed into one reaches `document` with `event.target` retargeted to the host (`OS-TEXT-FIELD`, not `INPUT`). The wpcom notes script guards its bare `n` shortcut with `e.target.tagName`, sees no input, toggles the panel and focuses its iframe mid-keystroke. A folder could not be named "New".

**Fix:** `src/text-entry-guard.ts`, one capture-phase keydown listener on `window` (the only position that runs ahead of every `document` listener). It stops the propagation of a keydown that is **printable and unmodified** (`key.length === 1`, no Ctrl/Alt/Meta) and whose real target (`composedPath()[0]`) is a text-entry element **inside a shadow root**. The default action is untouched, so the character is still inserted.

- Escape, Enter, Tab, arrows and every chord keep propagating, so `dismissable`, the switcher, the palette shortcut and dialogs' own handlers are unaffected.
- Light-DOM inputs are not covered; they already read as `INPUT` to tag-name guards.
- The presence probe moves from `document` to `window` so typing still counts as activity (`stopPropagation()` does not stop siblings on the same target).
- `isTextEntryElement()` is extracted from the switcher so the guard and `isTextEntryFocus()` share one definition of "typing".
- Audited every kit component with a shadow text input: none reads characters off `keydown`, so nothing existing changes behaviour.

### 2. Dynamic admin bar: the bell and other popup buttons did nothing

The bar parked off-screen with `transform: translateY(…)`. A transformed element becomes the containing block for every `position: fixed` descendant, and the wpcom notifications panel is `position: fixed; top: 32px; bottom: 0` inside `#wp-admin-bar-notes`. Measured against a 32px bar instead of the viewport, it computed to zero height. `static` has no transform, so it worked there.

**Fix:** the bar now parks by `inset-block-start` (with `!important`, matching the always-visible pin) and reads Core's admin-bar height token, so the 46px mobile bar parks correctly too. Hit-testing is unchanged.

## Tests

- `tests/vitest/text-entry-guard.test.ts`: a document listener with a tag-name guard never sees `n` typed into a shadow input, still sees it on a light-DOM input and a button, named keys and chords keep flowing, a window listener sees everything, the real `<os-text-field>` hides `n` but still submits on Enter, uninstall restores propagation.
- `tests/vitest/admin-bar-dynamic.test.ts`: parses `desktop.css` and fails if any dynamic-mode bar rule declares `transform`, `translate`, `rotate`, `scale`, `filter`, `backdrop-filter`, `perspective`, `contain` or `will-change`; pins the parked/revealed rules to `inset-block-start !important`.

`npm run build`, `npm run test:js` (5871), `npm run typecheck`, `npm run lint` (0 errors) all green.

## Docs

- `docs/javascript-reference.md`: new subsection beside the shell shortcuts on what a `document` keydown listener now observes, and where to listen (`window`) for raw keystrokes.
- `docs/components-reference.md`: component authors read characters off `input` / `beforeinput`; `keydown` carries everything else.

## Test plan

- [ ] On a wpcom site, Create folder → type a name containing `n`; panel must not open, Escape/Enter still cancel/submit.
- [ ] Press `n` with nothing focused; the notifications panel still toggles.
- [ ] Admin bar → Dynamic: hover the top edge, click the bell; panel opens at full height. Try Fullscreen and the layout menu.
- [ ] Hover the notch with the bar parked; bar rolls down, notch steps under it.
- [ ] Phone-width viewport: tap the top strip; the 46px bar reveals fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-769-207802224e3a4de6a5a113a1fb6035f614d6afa7.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->