### PR TITLE
Files: drop the marching-ants frame from the wallpaper drop highlight

### DIFF
--- a/assets/css/desktop-files.css
+++ b/assets/css/desktop-files.css
@@ -32,56 +32,17 @@
  * is set on the FilesLayer host (desktop area or folder window
  * body) while a shortcut payload is being dragged over it.
  *
- * Marching-ants animation makes the affordance unmissable even
- * against the busiest wallpaper, and the soft inner glow draws
- * the eye when the user is "shopping" for a drop target. Both
- * effects respect prefers-reduced-motion below.
- *
- * @since 0.18.0; visuals strengthened in 0.20.0.
+ * A quiet inner glow only. This used to be a dashed, animated
+ * marching-ants frame around the whole wallpaper, and on a full
+ * desktop that read as a large moving grid behind the tile in hand
+ * — loud, and design asked for it to go. The ghost's accept /
+ * reject chip and the per-cell drop preview already say where the
+ * tile will land; the glow just confirms the surface is listening.
  */
-@keyframes os-drop-marching-ants {
-	to {
-		background-position: 24px 0, -24px 0, 0 24px, 0 -24px;
-	}
-}
-
 [ data-files-drop-active ] {
 	position: relative;
-	outline: 3px dashed var( --wp-admin-theme-color, #2271b1 );
-	outline-offset: -8px;
-	background-image:
-		linear-gradient(
-			90deg,
-			rgba( 34, 113, 177, 0.45 ) 50%,
-			transparent 0
-		),
-		linear-gradient(
-			90deg,
-			rgba( 34, 113, 177, 0.45 ) 50%,
-			transparent 0
-		),
-		linear-gradient(
-			0deg,
-			rgba( 34, 113, 177, 0.45 ) 50%,
-			transparent 0
-		),
-		linear-gradient(
-			0deg,
-			rgba( 34, 113, 177, 0.45 ) 50%,
-			transparent 0
-		);
-	background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
-	background-size: 12px 3px, 12px 3px, 3px 12px, 3px 12px;
-	background-position: 0 6px, 0 calc( 100% - 6px ), 6px 0, calc( 100% - 6px ) 0;
 	box-shadow: inset 0 0 32px 4px rgba( 34, 113, 177, 0.12 );
-	animation: os-drop-marching-ants 0.6s linear infinite;
 	transition: box-shadow 0.18s ease-out;
-}
-
-@media ( prefers-reduced-motion: reduce ) {
-	[ data-files-drop-active ] {
-		animation: none;
-	}
 }
 
 .os-files-layer {


### PR DESCRIPTION
## Summary

- While a tile was dragged over the wallpaper, the `data-files-drop-active` host wore a thick dashed outline plus four looping gradient stripes along every edge. On a full desktop that read as a large animated grid behind the tile in hand; design asked for it to be removed.
- The animated frame and its reduced-motion override are gone. A quiet inner glow stays so the surface still acknowledges the drag. The ghost's accept/reject chip and the per-cell drop preview already show where the tile will land.
- The `data-files-drop-active` attribute itself is untouched: it is documented in `docs/files-on-desktop.md` and pinned by `tests/vitest/desktop-files-cross-frame-drop.test.ts`.

CSS only, no TS or PHP changes.

## Test plan

- [ ] Drag a desktop icon around the wallpaper: only a soft glow at the edges, no dashed frame, nothing moving.
- [ ] Drag a post out of My WordPress onto the wallpaper: same, and the drop still creates the shortcut.
- [ ] `npm run build` passes; `npx vitest run tests/vitest/desktop-files-cross-frame-drop.test.ts` is green (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-770-54d62d14379be76defca80eeb4375635241676c1.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->