### PR TITLE
Fix Native Users tables action icons visibility

### DIFF
--- a/apps/trash/parts/table-visuals.ts
+++ b/apps/trash/parts/table-visuals.ts
@@ -25,6 +25,7 @@ import {
 	resolveThemedIconColor,
 } from '../../../src/desktop-themes/icons';
 import { DESKTOP_THEME_SLOTS } from '../../../src/desktop-themes/slots';
+import { makeRowActionButton } from '../../../src/ui/util/row-action-button';
 import type { RecycleBinItem, RecycleBinItemRef } from './types';
 import type { OsTableColumn } from '../../../src/ui/components/os-table/os-table';
 
@@ -136,75 +137,12 @@ const ICON_SVG: Record< string, string > = {
 };
 
 /**
- * Build a row-action button: icon + hidden label, every visual
- * property inline, click bound in place with propagation stopped
- * (`data-noclick` opts it out of `os-table-row-click`). Colours are
- * inline `var()` chains so themes reach through the table's shadow
- * boundary; hover / focus swap the relevant properties directly.
+ * Build a row-action button: the shared row button
+ * (`src/ui/util/row-action-button.ts` — inline colour chains, hover
+ * and focus faces, `data-noclick`) around this bin's glyph, which is
+ * a theme's mask when it maps the slot, and an inline SVG otherwise.
  */
 export function makeRowButton( opts: RowButtonOptions ): HTMLElement {
-	const btn = document.createElement( 'button' );
-	btn.type = 'button';
-	btn.setAttribute( 'data-noclick', '' );
-	btn.setAttribute( 'aria-label', opts.label );
-	btn.title = opts.label;
-
-	const isDanger = opts.variant === 'danger';
-
-	const restColor = isDanger
-		? 'var( --os-ui-danger, #d63638 )'
-		: 'var( --os-ui-fg-muted, #50575e )';
-	const restBorder = isDanger
-		? 'var( --os-ui-danger, #d63638 )'
-		: 'var( --os-ui-border, #c3c4c7 )';
-	const restBg = 'var( --os-ui-surface, #fff )';
-
-	const applyRest = (): void => {
-		btn.style.background = restBg;
-		btn.style.color = restColor;
-		btn.style.borderColor = restBorder;
-	};
-	const applyHover = (): void => {
-		if ( isDanger ) {
-			btn.style.background = 'var( --os-ui-danger, #d63638 )';
-			btn.style.color = 'var( --os-ui-fg-on-accent, #fff )';
-			btn.style.borderColor = 'var( --os-ui-danger, #d63638 )';
-		} else {
-			btn.style.background = 'var( --os-ui-hover, #f0f0f1 )';
-			btn.style.color = 'var( --os-ui-fg, #1d2327 )';
-			btn.style.borderColor = 'var( --os-ui-border-strong, #8c8f94 )';
-		}
-	};
-
-	const labelled = opts.labelled === true;
-	btn.style.cssText = [
-		'display: inline-flex',
-		'align-items: center',
-		'justify-content: center',
-		labelled ? 'gap: 6px' : '',
-		labelled ? 'flex: 0 0 auto' : 'flex: 0 0 30px',
-		labelled ? 'width: auto' : 'width: 30px',
-		labelled ? 'height: 36px' : 'height: 30px',
-		labelled ? 'padding: 0 12px' : 'padding: 0',
-		labelled ? 'font-size: 13px' : '',
-		labelled ? 'font-weight: 600' : '',
-		'margin: 0',
-		'border: 1px solid ' + restBorder,
-		'border-radius: 6px',
-		'background: ' + restBg,
-		'color: ' + restColor,
-		'cursor: pointer',
-		'box-sizing: border-box',
-		'line-height: 1',
-		'font: inherit',
-		'transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease',
-	].join( ';' );
-
-	btn.addEventListener( 'mouseenter', applyHover );
-	btn.addEventListener( 'mouseleave', applyRest );
-	btn.addEventListener( 'focus', applyHover );
-	btn.addEventListener( 'blur', applyRest );
-
 	// Desktop-theme override for the glyph, rendered as an 18x18 CSS
 	// MASK tinted with `currentColor` so hover / danger tinting keeps
 	// working. A theme that maps the slot to a DASHICON is ignored on
@@ -224,6 +162,7 @@ export function makeRowButton( opts: RowButtonOptions ): HTMLElement {
 		/^(https?:\/\/|data:image\/)/i.test( themed ) &&
 		! /['"()\\<>\s]/.test( themed );
 
+	let glyph: Element;
 	if ( maskSafe ) {
 		const mask = document.createElement( 'span' );
 		mask.setAttribute( 'aria-hidden', 'true' );
@@ -236,7 +175,7 @@ export function makeRowButton( opts: RowButtonOptions ): HTMLElement {
 			`-webkit-mask: url("${ themed }") center / contain no-repeat`,
 			`mask: url("${ themed }") center / contain no-repeat`,
 		].join( ';' );
-		btn.appendChild( mask );
+		glyph = mask;
 	} else {
 		const svgNs = 'http://www.w3.org/2000/svg';
 		const svg = document.createElementNS( svgNs, 'svg' );
@@ -247,22 +186,16 @@ export function makeRowButton( opts: RowButtonOptions ): HTMLElement {
 		svg.setAttribute( 'focusable', 'false' );
 		svg.style.display = 'block';
 		svg.innerHTML = ICON_SVG[ opts.icon ] ?? '';
-		btn.appendChild( svg );
+		glyph = svg;
 	}
 
-	if ( labelled ) {
-		const text = document.createElement( 'span' );
-		text.textContent = opts.label;
-		text.style.cssText = 'white-space: nowrap; line-height: 1;';
-		btn.appendChild( text );
-	}
-
-	btn.addEventListener( 'click', ( e: Event ) => {
-		e.stopPropagation();
-		opts.onClick();
+	return makeRowActionButton( {
+		label: opts.label,
+		glyph,
+		onClick: opts.onClick,
+		variant: opts.variant,
+		labelled: opts.labelled,
 	} );
-
-	return btn;
 }
 
 export interface RowActionHandlers {

--- a/apps/users/parts/table.ts
+++ b/apps/users/parts/table.ts
@@ -13,6 +13,7 @@
 import { __, copyText, formatDate } from '@openstation/app';
 import { isMobileStamped } from '../../../src/mode/stamp';
 import { applyAvatarSrc, pickAvatarUrl } from '../../../src/ui/util/avatar-resolve';
+import { makeRowActionButton } from '../../../src/ui/util/row-action-button';
 import { openUserEditWindow } from '../../../src/open-targets/user-edit-window';
 import '../../../src/ui/components/os-avatar/os-avatar';
 import '../../../src/ui/components/os-icon/os-icon';
@@ -103,7 +104,7 @@ export function forgetRow( cache: UserCellCache, id: number ): void {
 	}
 }
 
-const MUTED = 'var(--os-ui-fg-muted, #8c8f94)';
+const MUTED = 'var( --os-ui-fg-muted, #50575e )';
 const CHIP =
 	'display:inline-flex;align-items:center;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;background:var(--os-ui-badge-info-bg, rgba(34,113,177,0.10));color:var(--os-ui-info-fg, #0a4b78);white-space:nowrap;';
 
@@ -286,57 +287,14 @@ function buildActionsCell( row: UserListItem, cfg: ListConfig, actions: RowActio
 		cell.style.color = MUTED;
 		return cell;
 	}
-	const restColor = 'var( --os-ui-fg-muted, #50575e )';
-	const restBorder = 'var( --os-ui-border, #dcdcde )';
-	const restBg = 'var( --os-ui-surface, #fff )';
-
+	// The Recycle Bin's row button, so the two lists share one face
+	// and one colour chain. `<os-icon>` works inside the table's
+	// shadow tree where a bare dashicons class renders blank.
 	const mk = ( label: string, dashicon: string, fn: () => void ): HTMLElement => {
-		const btn = document.createElement( 'button' );
-		btn.type = 'button';
-		btn.title = label;
-		btn.setAttribute( 'aria-label', label );
-		btn.setAttribute( 'data-noclick', '' );
-
-		const applyRest = (): void => {
-			btn.style.background = restBg;
-			btn.style.color = restColor;
-			btn.style.borderColor = restBorder;
-		};
-		const applyHover = (): void => {
-			btn.style.background = 'var( --os-ui-hover, #f0f0f1 )';
-			btn.style.color = 'var( --os-ui-fg, #1d2327 )';
-			btn.style.borderColor = 'var( --os-ui-border-strong, #8c8f94 )';
-		};
-
-		btn.style.cssText = [
-			'appearance:none',
-			'border:1px solid ' + restBorder,
-			'background:' + restBg,
-			'color:' + restColor,
-			'padding:4px 6px',
-			'border-radius:4px',
-			'cursor:pointer',
-			'line-height:1',
-			'display:inline-flex',
-			'align-items:center',
-			'justify-content:center',
-			'transition:background-color 120ms ease, color 120ms ease, border-color 120ms ease',
-		].join( ';' );
-
-		btn.addEventListener( 'mouseenter', applyHover );
-		btn.addEventListener( 'mouseleave', applyRest );
-		btn.addEventListener( 'focus', applyHover );
-		btn.addEventListener( 'blur', applyRest );
-
 		const ic = document.createElement( 'os-icon' );
 		ic.setAttribute( 'name', dashicon );
-		ic.setAttribute( 'size', '14' );
-		btn.appendChild( ic );
-		btn.addEventListener( 'click', ( e ) => {
-			e.stopPropagation();
-			fn();
-		} );
-		return btn;
+		ic.setAttribute( 'size', '18' );
+		return makeRowActionButton( { label, glyph: ic, onClick: fn } );
 	};
 	cell.append(
 		mk( __( 'Send password reset' ), 'email-alt', () => actions.onSendReset( row ) ),

--- a/apps/users/parts/table.ts
+++ b/apps/users/parts/table.ts
@@ -286,13 +286,48 @@ function buildActionsCell( row: UserListItem, cfg: ListConfig, actions: RowActio
 		cell.style.color = MUTED;
 		return cell;
 	}
+	const restColor = 'var( --os-ui-fg-muted, #50575e )';
+	const restBorder = 'var( --os-ui-border, #dcdcde )';
+	const restBg = 'var( --os-ui-surface, #fff )';
+
 	const mk = ( label: string, dashicon: string, fn: () => void ): HTMLElement => {
 		const btn = document.createElement( 'button' );
 		btn.type = 'button';
 		btn.title = label;
 		btn.setAttribute( 'aria-label', label );
-		btn.style.cssText =
-			'appearance:none;border:1px solid var(--os-ui-border, #dcdcde);background:var(--os-ui-btn-bg, #fff);color:inherit;padding:4px 6px;border-radius:4px;cursor:pointer;line-height:1;';
+		btn.setAttribute( 'data-noclick', '' );
+
+		const applyRest = (): void => {
+			btn.style.background = restBg;
+			btn.style.color = restColor;
+			btn.style.borderColor = restBorder;
+		};
+		const applyHover = (): void => {
+			btn.style.background = 'var( --os-ui-hover, #f0f0f1 )';
+			btn.style.color = 'var( --os-ui-fg, #1d2327 )';
+			btn.style.borderColor = 'var( --os-ui-border-strong, #8c8f94 )';
+		};
+
+		btn.style.cssText = [
+			'appearance:none',
+			'border:1px solid ' + restBorder,
+			'background:' + restBg,
+			'color:' + restColor,
+			'padding:4px 6px',
+			'border-radius:4px',
+			'cursor:pointer',
+			'line-height:1',
+			'display:inline-flex',
+			'align-items:center',
+			'justify-content:center',
+			'transition:background-color 120ms ease, color 120ms ease, border-color 120ms ease',
+		].join( ';' );
+
+		btn.addEventListener( 'mouseenter', applyHover );
+		btn.addEventListener( 'mouseleave', applyRest );
+		btn.addEventListener( 'focus', applyHover );
+		btn.addEventListener( 'blur', applyRest );
+
 		const ic = document.createElement( 'os-icon' );
 		ic.setAttribute( 'name', dashicon );
 		ic.setAttribute( 'size', '14' );

--- a/apps/users/users.test.ts
+++ b/apps/users/users.test.ts
@@ -309,7 +309,18 @@ describe( 'the table parts', () => {
 		expect( cell( 'stats' ).textContent ).toBe( '312' );
 		expect( ( cell( 'email' ) as HTMLButtonElement ).textContent ).toBe( 'ada@example.com' );
 		expect( cell( 'identity' ).querySelector( 'os-avatar' )?.getAttribute( 'presence' ) ).toBe( 'offline' );
-		expect( cell( 'actions' ).querySelectorAll( 'button' ).length ).toBe( 2 );
+		const buttons = cell( 'actions' ).querySelectorAll( 'button' );
+		expect( buttons.length ).toBe( 2 );
+		// The face resolves through the palette, never an inherited
+		// colour on a white fallback — that painted white glyphs on a
+		// white chip under the dark palette.
+		for ( const btn of Array.from( buttons ) ) {
+			expect( btn.hasAttribute( 'data-noclick' ) ).toBe( true );
+			expect( btn.style.background ).toContain( '--os-ui-surface' );
+			expect( btn.style.color ).toContain( '--os-ui-fg-muted' );
+			expect( btn.style.color ).not.toBe( 'inherit' );
+			expect( btn.querySelector( 'os-icon' ) ).not.toBeNull();
+		}
 		const locked = cols.find( ( c ) => c.key === 'actions' )!.render!( undefined, user( { id: 5, openstation_can_edit: false } ), 0 ) as HTMLElement;
 		expect( locked.textContent ).toBe( '—' );
 	} );

--- a/src/ui/util/row-action-button.test.ts
+++ b/src/ui/util/row-action-button.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the shared row-action button.
+ *
+ * The load-bearing property is the colour chain: the button lives
+ * inside `<os-table>`'s shadow root, so its face has to be an inline
+ * `var()` that resolves through the palette, with the pre-brand
+ * literal as the floor. A face that inherits its text colour over a
+ * `#fff` fallback paints white glyphs on a white chip under the dark
+ * palette — which is how the Users list lost its action icons once.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { makeRowActionButton } from './row-action-button';
+
+function glyph(): HTMLElement {
+	const g = document.createElement( 'span' );
+	g.className = 'glyph';
+	return g;
+}
+
+describe( 'makeRowActionButton', () => {
+	it( 'is a labelled, row-click-exempt button carrying the glyph', () => {
+		const btn = makeRowActionButton( { label: 'Restore', glyph: glyph(), onClick: () => undefined } );
+		expect( btn.tagName ).toBe( 'BUTTON' );
+		expect( ( btn as HTMLButtonElement ).type ).toBe( 'button' );
+		expect( btn.hasAttribute( 'data-noclick' ) ).toBe( true );
+		expect( btn.getAttribute( 'aria-label' ) ).toBe( 'Restore' );
+		expect( btn.title ).toBe( 'Restore' );
+		expect( btn.querySelector( '.glyph' ) ).not.toBeNull();
+		expect( btn.textContent?.trim() ).toBe( '' );
+	} );
+
+	it( 'rests on the surface token with muted text, never on an inherited colour', () => {
+		const btn = makeRowActionButton( { label: 'Reset', glyph: glyph(), onClick: () => undefined } );
+		expect( btn.style.background ).toContain( '--os-ui-surface' );
+		expect( btn.style.color ).toContain( '--os-ui-fg-muted' );
+		expect( btn.style.border ).toContain( '--os-ui-border' );
+		expect( btn.style.color ).not.toBe( 'inherit' );
+		expect( btn.style.cssText ).not.toContain( '--os-ui-btn-bg' );
+	} );
+
+	it( 'keeps the pre-brand literals as fallbacks', () => {
+		const btn = makeRowActionButton( { label: 'Reset', glyph: glyph(), onClick: () => undefined } );
+		expect( btn.style.background ).toContain( '#fff' );
+		expect( btn.style.color ).toContain( '#50575e' );
+	} );
+
+	it( 'swaps to the hover wash under the pointer and on focus, and back', () => {
+		const btn = makeRowActionButton( { label: 'Reset', glyph: glyph(), onClick: () => undefined } );
+		btn.dispatchEvent( new Event( 'mouseenter' ) );
+		expect( btn.style.background ).toContain( '--os-ui-hover' );
+		expect( btn.style.color ).toContain( '--os-ui-fg' );
+		expect( btn.style.borderColor ).toContain( '--os-ui-border-strong' );
+		btn.dispatchEvent( new Event( 'mouseleave' ) );
+		expect( btn.style.background ).toContain( '--os-ui-surface' );
+		expect( btn.style.color ).toContain( '--os-ui-fg-muted' );
+		btn.dispatchEvent( new Event( 'focus' ) );
+		expect( btn.style.background ).toContain( '--os-ui-hover' );
+		btn.dispatchEvent( new Event( 'blur' ) );
+		expect( btn.style.background ).toContain( '--os-ui-surface' );
+	} );
+
+	it( 'paints the danger face through the danger token, filled on hover', () => {
+		const btn = makeRowActionButton( { label: 'Delete', glyph: glyph(), onClick: () => undefined, variant: 'danger' } );
+		expect( btn.style.color ).toContain( '--os-ui-danger' );
+		expect( btn.style.border ).toContain( '--os-ui-danger' );
+		btn.dispatchEvent( new Event( 'mouseenter' ) );
+		expect( btn.style.background ).toContain( '--os-ui-danger' );
+		expect( btn.style.color ).toContain( '--os-ui-fg-on-accent' );
+	} );
+
+	it( 'prints the label beside the glyph when labelled', () => {
+		const btn = makeRowActionButton( { label: 'Restore', glyph: glyph(), onClick: () => undefined, labelled: true } );
+		expect( btn.textContent?.trim() ).toBe( 'Restore' );
+		expect( btn.style.width ).toBe( 'auto' );
+	} );
+
+	it( 'runs the handler on click without letting the row see it', () => {
+		const onClick = vi.fn();
+		const row = document.createElement( 'div' );
+		const seen = vi.fn();
+		row.addEventListener( 'click', seen );
+		const btn = makeRowActionButton( { label: 'Reset', glyph: glyph(), onClick } );
+		row.appendChild( btn );
+		btn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+		expect( seen ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/ui/util/row-action-button.ts
+++ b/src/ui/util/row-action-button.ts
@@ -1,0 +1,126 @@
+/**
+ * A row-action button for a table cell: a glyph (and optionally its
+ * label) in a bordered square that swaps to the hover wash under the
+ * pointer or keyboard focus.
+ *
+ * Shared by every app that paints actions into an `<os-table>` row
+ * (the Recycle Bin's restore / delete, the Users list's password
+ * reset / welcome email). It exists because `<os-table>` renders its
+ * body into a shadow root that document stylesheets never reach:
+ * every visual property has to be an inline `style.*`, and every
+ * colour an inline `var()` chain that inherits THROUGH the boundary.
+ * Two apps carrying the same forty lines of inline styles drifted
+ * once — one set `color: inherit` on a `#fff` fallback and lost its
+ * glyphs on the dark palette — so the chains live here, once.
+ *
+ * The button owns the shell; the caller owns the glyph. An
+ * `<os-icon>`, an inline SVG or a themed mask span all work, as long
+ * as they draw in `currentColor` so the hover and danger tints reach
+ * them.
+ */
+
+export interface RowActionButtonOptions {
+	/** The accessible name; also the tooltip, and the text when `labelled`. */
+	label: string;
+	/** The glyph node. Drawn in `currentColor` so state tints reach it. */
+	glyph: Node;
+	onClick: () => void;
+	/** `'danger'` paints the destructive face; anything else is the default. */
+	variant?: string;
+	/**
+	 * Print the label beside the glyph, at a finger's height. A 30px
+	 * icon-only square is right in a row on a desk and wrong on a
+	 * card under a thumb: too small to hit, and a glyph alone has to
+	 * be learned.
+	 */
+	labelled?: boolean;
+}
+
+/**
+ * Build the button. Every visual property is inline, the click is
+ * bound in place with propagation stopped, and `data-noclick` opts
+ * the button out of `os-table-row-click`.
+ *
+ * Fallback literals are the pre-brand WordPress-admin values — the
+ * floor if the stylesheet fails to load, and what the Legacy theme
+ * declares.
+ */
+export function makeRowActionButton( opts: RowActionButtonOptions ): HTMLElement {
+	const btn = document.createElement( 'button' );
+	btn.type = 'button';
+	btn.setAttribute( 'data-noclick', '' );
+	btn.setAttribute( 'aria-label', opts.label );
+	btn.title = opts.label;
+
+	const isDanger = opts.variant === 'danger';
+
+	const restColor = isDanger
+		? 'var( --os-ui-danger, #d63638 )'
+		: 'var( --os-ui-fg-muted, #50575e )';
+	const restBorder = isDanger
+		? 'var( --os-ui-danger, #d63638 )'
+		: 'var( --os-ui-border, #c3c4c7 )';
+	const restBg = 'var( --os-ui-surface, #fff )';
+
+	const applyRest = (): void => {
+		btn.style.background = restBg;
+		btn.style.color = restColor;
+		btn.style.borderColor = restBorder;
+	};
+	const applyHover = (): void => {
+		if ( isDanger ) {
+			btn.style.background = 'var( --os-ui-danger, #d63638 )';
+			btn.style.color = 'var( --os-ui-fg-on-accent, #fff )';
+			btn.style.borderColor = 'var( --os-ui-danger, #d63638 )';
+		} else {
+			btn.style.background = 'var( --os-ui-hover, #f0f0f1 )';
+			btn.style.color = 'var( --os-ui-fg, #1d2327 )';
+			btn.style.borderColor = 'var( --os-ui-border-strong, #8c8f94 )';
+		}
+	};
+
+	const labelled = opts.labelled === true;
+	btn.style.cssText = [
+		'display: inline-flex',
+		'align-items: center',
+		'justify-content: center',
+		labelled ? 'gap: 6px' : '',
+		labelled ? 'flex: 0 0 auto' : 'flex: 0 0 30px',
+		labelled ? 'width: auto' : 'width: 30px',
+		labelled ? 'height: 36px' : 'height: 30px',
+		labelled ? 'padding: 0 12px' : 'padding: 0',
+		labelled ? 'font-size: 13px' : '',
+		labelled ? 'font-weight: 600' : '',
+		'margin: 0',
+		'border: 1px solid ' + restBorder,
+		'border-radius: 6px',
+		'background: ' + restBg,
+		'color: ' + restColor,
+		'cursor: pointer',
+		'box-sizing: border-box',
+		'line-height: 1',
+		'font: inherit',
+		'transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease',
+	].join( ';' );
+
+	btn.addEventListener( 'mouseenter', applyHover );
+	btn.addEventListener( 'mouseleave', applyRest );
+	btn.addEventListener( 'focus', applyHover );
+	btn.addEventListener( 'blur', applyRest );
+
+	btn.appendChild( opts.glyph );
+
+	if ( labelled ) {
+		const text = document.createElement( 'span' );
+		text.textContent = opts.label;
+		text.style.cssText = 'white-space: nowrap; line-height: 1;';
+		btn.appendChild( text );
+	}
+
+	btn.addEventListener( 'click', ( e: Event ) => {
+		e.stopPropagation();
+		opts.onClick();
+	} );
+
+	return btn;
+}


### PR DESCRIPTION
## What?
Closes #773 

Fixes invisible action icons in the Native Users list table under the default theme by adopting design system surface and text tokens.

## Why?
When the native Users list is enabled, the row action buttons ("Send password reset" and "Resend welcome email") previously set `background: var(--os-ui-btn-bg, #fff)` with `color: inherit`. 

The `--os-ui-btn-bg` resolved to `#fff` (white). In the default theme, table text inherits `--os-ui-fg` (`#fffbff`, white), rendering white icon glyphs on a solid white button background and making them completely invisible.

## How?
- `apps/users/parts/table.ts`:
  - Aligned action button styles in `mk()` with `apps/trash/parts/table-visuals.ts` using design tokens (`var(--os-ui-surface, #fff)`, `var(--os-ui-fg-muted, #50575e)`, `var(--os-ui-hover, #f0f0f1)`), and added hover/focus transitions with `data-noclick`.

## Testing Instructions
1. Enable Native Users table under **System > Openstation Preferences > Features**.
2. Navigate to the Users list in Desktop Mode.
3. Verify that the action buttons (Send password reset, Resend welcome email) are clearly visible with working hover/focus states.
4. Switch to the **Desktop Mode (Legacy)** theme and verify the buttons continue to display with dark icons on the light table surface.

## Screenshot
<img width="1249" height="673" alt="Screenshot 2026-09-07 at 4 16 59 PM" src="https://github.com/user-attachments/assets/37cbb111-cad1-437c-9f30-57fa8a5d6673" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-774-3d643ab21c9af5e5b963cf0c515fec89dfc1e28b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->