### PR TITLE
fix: preserve preferences on theme switch

### DIFF
--- a/src/api/facade.ts
+++ b/src/api/facade.ts
@@ -514,15 +514,10 @@ export function buildPublicApi( deps: BuildPublicApiDeps ): OpenStationPublicApi
 			resolveIcon: resolveThemedIcon,
 			resolveIconColor: resolveThemedIconColor,
 			applyRecommendedOsSettings: ( themeId ) => {
-				const target = themeId ?? getActiveDesktopThemeId() ?? '';
-				if ( target === '' ) {
-					return {};
-				}
+				const target = themeId !== undefined ? themeId : ( getActiveDesktopThemeId() ?? '' );
 				// Forced, because this entry point IS the deliberate
-				// re-apply. First-activation seeding happens when the
-				// theme is activated (`updateOsSettings( { desktopTheme } )`
-				// or the Themes tab); a caller reaching for this is
-				// asking for the author's arrangement back.
+				// re-apply. A caller reaching for this is asking for the
+				// author's arrangement back (including OpenStation's system default).
 				return osSettings.applyThemeRecommendations( target );
 			},
 		},

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -546,16 +546,6 @@ export class OsSettings {
 		const next = sanitizeSettings( incoming, this.state );
 		const touched = OS_SETTINGS_KEYS.filter( ( key ) => key in incoming );
 
-		let seeded = false;
-		if (
-			touched.includes( 'desktopTheme' ) &&
-			next.desktopTheme !== this.state.desktopTheme
-		) {
-			seeded =
-				Object.keys( applyThemeRecommendations( next, next.desktopTheme ) )
-					.length > 0;
-		}
-
 		Object.assign( this.state, next );
 
 		// The running service worker keeps its own copy of the
@@ -570,7 +560,7 @@ export class OsSettings {
 		}
 
 		this.save( opts );
-		if ( seeded || touched.some( ( key ) => PRESENTATION_KEYS.has( key ) ) ) {
+		if ( touched.some( ( key ) => PRESENTATION_KEYS.has( key ) ) ) {
 			this.apply();
 		}
 	}

--- a/tests/vitest/api-update-os-settings.test.ts
+++ b/tests/vitest/api-update-os-settings.test.ts
@@ -172,28 +172,28 @@ describe( 'updateOsSettings — persist and apply', () => {
 } );
 
 describe( 'updateOsSettings — theme activation', () => {
-	test( 'activating the system default seeds its recommended accent once', () => {
+	test( 'activating a theme preserves user preferences and does not silently overwrite accent or layout', () => {
 		h.api.updateOsSettings( { accent: 'teal', desktopTheme: 'acme-neon' } );
 		expect( h.store.state.accent ).toBe( 'teal' );
-		// Back to the shell's own look: it recommends Pulse, the accent
-		// its palette was drawn against, and records the offer.
+		expect( h.store.state.desktopTheme ).toBe( 'acme-neon' );
+		// Switching to another theme preserves the custom accent.
 		h.api.updateOsSettings( { desktopTheme: '' } );
-		expect( h.store.state.accent ).toBe( 'pulse' );
-		expect( h.store.state.appliedThemeRecommendations ).toEqual( [ 'system-default' ] );
-		// A second activation never overwrites a choice made since.
-		h.api.updateOsSettings( { accent: 'teal', desktopTheme: 'acme-neon' } );
-		h.api.updateOsSettings( { desktopTheme: '' } );
+		expect( h.store.state.desktopTheme ).toBe( '' );
 		expect( h.store.state.accent ).toBe( 'teal' );
 	} );
 
 	test( 'the deliberate re-apply goes through desktopThemes.applyRecommendedOsSettings', () => {
 		h.api.updateOsSettings( { desktopTheme: '' } );
-		h.api.updateOsSettings( { accent: 'teal' } );
+		h.api.updateOsSettings( { accent: 'teal', desktopLayout: 'classic', dockPlacement: 'left' } );
 		const applied = h.api.desktopThemes.applyRecommendedOsSettings( '' );
-		// '' is the system default, which the facade reads as "the
-		// active theme, if any" — nothing to re-apply for no theme.
-		expect( applied ).toEqual( {} );
-		expect( h.store.state.accent ).toBe( 'teal' );
+		expect( applied ).toEqual( {
+			accent: 'pulse',
+			desktopLayout: 'unified',
+			dockPlacement: 'bottom',
+		} );
+		expect( h.store.state.accent ).toBe( 'pulse' );
+		expect( h.store.state.desktopLayout ).toBe( 'unified' );
+		expect( h.store.state.dockPlacement ).toBe( 'bottom' );
 	} );
 } );
 


### PR DESCRIPTION
## Description
Fixes #582.

When selecting a desktop theme, the theme switch was previously auto-applying the theme's recommended OS settings (such as accent color, layout, and dock placement) in the background on first selection without user consent. Subsequent selections preserved preferences due to a hidden `appliedThemeRecommendations` ledger, leading to surprising and inconsistent behavior.

This PR decouples theme selection from preference overrides:
1. **Preserve User Preferences on Theme Switch:** Selecting a theme now only switches `desktopTheme` and applies the theme stylesheet. Custom accent colors, dock position, and desktop layout are kept intact.
2. **Explicit Recommendation Application:** Applying recommendations remains available as an intentional user action via the *"Apply [Theme Name]’s recommended layout and effects"* button in OpenStation Preferences.
3. **Fix System Default Recommendations:** Fixed `desktopThemes.applyRecommendedOsSettings()` in `src/api/facade.ts` to allow applying OpenStation system default recommendations (`pulse` accent, `unified` layout, `bottom` dock) when explicitly triggered.

## How to Test
1. Go to **OpenStation Preferences → Appearance & Layout**.
2. Select a custom **Accent Color** (e.g. Amber/Teal) and set **Desktop Layout** to *Sidebar (Classic)*.
3. Go to the **Themes** tab and select another theme (e.g. *Desktop Mode (Legacy)* or *OpenStation*).
4. Verify that the visual theme changes immediately while your custom accent and dock placement remain untouched.
5. Click **"Apply [Theme Name]’s recommended layout and effects"** below the theme grid.
6. Verify that the theme's recommended settings are applied upon clicking the button.

## After  Fix


https://github.com/user-attachments/assets/2c2a2759-758e-442b-9fbe-e626cb9d52d0

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-781-3f5681e799f96044be2e092b9122a97af0190313.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->