### PR TITLE
Widgets: raise the frame's chrome buttons to the 24px target-size floor

### DIFF
--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -1157,7 +1157,8 @@ body.os-has-fullscreen-window .os-shell {
  * no-op). The DOM node stays mounted either way so state flips
  * don't rebuild chrome.
  *
- * Styling mirrors the inline close button: 20×20 round tile,
+ * Styling mirrors the inline close button: 24×24 round tile
+ * (the WCAG 2.2 SC 2.5.8 target-size floor),
  * dimmed by default, full-opacity on hover / focus. Distinct hover
  * color (theme accent, not red) signals "put back" vs. "remove."
  */

--- a/assets/css/desktop.css
+++ b/assets/css/desktop.css
@@ -1050,8 +1050,10 @@ body.os-has-fullscreen-window .os-shell {
 	position: absolute;
 	top: 6px;
 	inset-inline-end: 6px;
-	width: 22px;
-	height: 22px;
+	/* 24px is the WCAG 2.2 SC 2.5.8 floor. The glyph inside is unchanged;
+	   only the target grows. */
+	width: 24px;
+	height: 24px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -1138,8 +1140,8 @@ body.os-has-fullscreen-window .os-shell {
 .os-widgets__chrome .os-widgets__card-close {
 	position: static;
 	opacity: 0.7;
-	width: 20px;
-	height: 20px;
+	width: 24px;
+	height: 24px;
 }
 
 .os-widgets__chrome .os-widgets__card-close:hover,
@@ -1168,8 +1170,8 @@ body.os-has-fullscreen-window .os-shell {
 	background: var( --os-ui-scrim, rgba( 0, 0, 0, 0.55 ) );
 	color: rgba( 255, 255, 255, 0.75 );
 	border-radius: 50%;
-	width: 20px;
-	height: 20px;
+	width: 24px;
+	height: 24px;
 	cursor: pointer;
 	opacity: 0.7;
 	transition:

--- a/tests/vitest/widget-chrome-tap-target.test.ts
+++ b/tests/vitest/widget-chrome-tap-target.test.ts
@@ -16,12 +16,14 @@
  * buttons, not inline in a sentence; the size is not user-agent
  * controlled; and no equivalent control is offered elsewhere in the view.
  *
- * The spacing exception does not save them either. Redock and close are
- * adjacent flex siblings inside `.os-widgets__chrome` (`gap: 8px`), so at
- * their old sizes a 24px circle centred on one intersected the circle on
- * the other. At 24px each the centres sit 32px apart — clear of the 24px
- * the exception requires — which is why raising the size fixes the
- * spacing limb as well as the size limb.
+ * The spacing exception does not save them either, though not for the
+ * reason first claimed. Redock and close are adjacent flex siblings inside
+ * `.os-widgets__chrome` (`gap: 8px`); at the old sizes their centres were
+ * already 28px apart, so the spacing limb was satisfied. What carries this
+ * change is the size limb alone: the corner close at 22px fails it with no
+ * exception available, and `.os-widgets__chrome` is itself a pointer
+ * target (the drag handle) enclosing both buttons, so leaning on spacing
+ * there would be unwise even where the arithmetic works.
  *
  * Raising the box rather than adding an invisible hit area is deliberate:
  * `.os-widgets__chrome` is the drag handle (`cursor: grab`,
@@ -64,7 +66,9 @@ describe( 'widget chrome tap targets', () => {
 
 	test( 'the two chrome siblings stay clear of each other', () => {
 		// SC 2.5.8's spacing limb: 24px circles centred on adjacent targets
-		// must not intersect, i.e. centres at least 24px apart.
+		// must not intersect, i.e. centres at least 24px apart. This held on
+		// trunk too (10 + 8 + 10 = 28) — it is a standing guard on the gap,
+		// not a pin on anything this change fixed.
 		const chrome = /^\.os-widgets__chrome\s*\{([^}]*)\}/m.exec( DESKTOP );
 		expect( chrome, 'no .os-widgets__chrome rule' ).not.toBeNull();
 		const gap = /(?<!-)gap\s*:\s*([\d.]+)px/.exec( chrome![ 1 ] );
@@ -78,11 +82,8 @@ describe( 'widget chrome tap targets', () => {
 	} );
 
 	test( 'the reader can tell a short box from a tall one', () => {
-		// Negative control. Without it, a regex that stopped matching would
-		// report a clean sweep over nothing, and every pin above would pass
-		// while the stylesheet said 20px.
-		const short = /^\.os-widgets__grip\s*\{([^}]*)\}/m.exec( DESKTOP );
-		expect( short, 'no .os-widgets__grip rule to control against' ).not.toBeNull();
-		expect( boxOf( '.os-widgets__card-redock' ).width ).toBe( 24 );
+		// Negative control: the extractor must report a small box as small.
+		// A pin that only ever sees 24s cannot show it would notice a 20.
+		expect( boxOf( '.os-widgets__grip' ) ).toEqual( { width: 10, height: 16 } );
 	} );
 } );

--- a/tests/vitest/widget-chrome-tap-target.test.ts
+++ b/tests/vitest/widget-chrome-tap-target.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The widget frame's chrome buttons meet the WCAG 2.2 target-size floor.
+ *
+ * SC 2.5.8 (Target Size, Minimum) puts a 24x24 CSS-pixel floor under a
+ * pointer target. Three rules in `desktop.css` sized the widget frame's
+ * own controls below it — measured on a running instance at desktop
+ * viewport, `box-sizing: border-box` and `padding: 0` on all of them, so
+ * the declared size *is* the target size and no padding made up the
+ * difference:
+ *
+ *   .os-widgets__card-redock                     20x20   (8 instances)
+ *   .os-widgets__chrome .os-widgets__card-close  20x20
+ *   .os-widgets__card-close (corner)             22x22   (12 instances)
+ *
+ * None of the spec's exceptions reach them. They are standalone icon
+ * buttons, not inline in a sentence; the size is not user-agent
+ * controlled; and no equivalent control is offered elsewhere in the view.
+ *
+ * The spacing exception does not save them either. Redock and close are
+ * adjacent flex siblings inside `.os-widgets__chrome` (`gap: 8px`), so at
+ * their old sizes a 24px circle centred on one intersected the circle on
+ * the other. At 24px each the centres sit 32px apart — clear of the 24px
+ * the exception requires — which is why raising the size fixes the
+ * spacing limb as well as the size limb.
+ *
+ * Raising the box rather than adding an invisible hit area is deliberate:
+ * `.os-widgets__chrome` is the drag handle (`cursor: grab`,
+ * `touch-action: none`), and a pseudo-element overlay there would sit
+ * between the pointer and the drag it is meant to start.
+ */
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join( __dirname, '../..' );
+const DESKTOP = readFileSync( join( ROOT, 'assets/css/desktop.css' ), 'utf8' );
+
+/** WCAG 2.2 SC 2.5.8, in CSS pixels. */
+const TARGET_MIN = 24;
+
+/** The declared width/height of the first rule with this exact selector. */
+function boxOf( selector: string ): { width: number; height: number } {
+	const escaped = selector.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+	const rule = new RegExp( `^${ escaped }\\s*\\{([^}]*)\\}`, 'm' ).exec( DESKTOP );
+	expect( rule, `no rule found for ${ selector }` ).not.toBeNull();
+	const body = rule![ 1 ];
+	const width = /(?<!-)width\s*:\s*([\d.]+)px/.exec( body );
+	const height = /(?<!-)height\s*:\s*([\d.]+)px/.exec( body );
+	expect( width, `${ selector } declares no width` ).not.toBeNull();
+	expect( height, `${ selector } declares no height` ).not.toBeNull();
+	return { width: Number( width![ 1 ] ), height: Number( height![ 1 ] ) };
+}
+
+describe( 'widget chrome tap targets', () => {
+	test.each( [
+		'.os-widgets__card-redock',
+		'.os-widgets__chrome .os-widgets__card-close',
+		'.os-widgets__card-close',
+	] )( '%s is at least 24x24', ( selector ) => {
+		const { width, height } = boxOf( selector );
+		expect( width ).toBeGreaterThanOrEqual( TARGET_MIN );
+		expect( height ).toBeGreaterThanOrEqual( TARGET_MIN );
+	} );
+
+	test( 'the two chrome siblings stay clear of each other', () => {
+		// SC 2.5.8's spacing limb: 24px circles centred on adjacent targets
+		// must not intersect, i.e. centres at least 24px apart.
+		const chrome = /^\.os-widgets__chrome\s*\{([^}]*)\}/m.exec( DESKTOP );
+		expect( chrome, 'no .os-widgets__chrome rule' ).not.toBeNull();
+		const gap = /(?<!-)gap\s*:\s*([\d.]+)px/.exec( chrome![ 1 ] );
+		expect( gap, '.os-widgets__chrome declares no gap' ).not.toBeNull();
+
+		const redock = boxOf( '.os-widgets__card-redock' );
+		const close = boxOf( '.os-widgets__chrome .os-widgets__card-close' );
+		const centres = redock.width / 2 + Number( gap![ 1 ] ) + close.width / 2;
+
+		expect( centres ).toBeGreaterThanOrEqual( TARGET_MIN );
+	} );
+
+	test( 'the reader can tell a short box from a tall one', () => {
+		// Negative control. Without it, a regex that stopped matching would
+		// report a clean sweep over nothing, and every pin above would pass
+		// while the stylesheet said 20px.
+		const short = /^\.os-widgets__grip\s*\{([^}]*)\}/m.exec( DESKTOP );
+		expect( short, 'no .os-widgets__grip rule to control against' ).not.toBeNull();
+		expect( boxOf( '.os-widgets__card-redock' ).width ).toBe( 24 );
+	} );
+} );


### PR DESCRIPTION
Fixes #790.

## The change

Three rules in `assets/css/desktop.css` sized the widget frame's own controls below the WCAG 2.2 SC 2.5.8 floor of 24×24 CSS pixels:

| rule | was | now |
|---|---|---|
| `.os-widgets__card-redock` | 20×20 | 24×24 |
| `.os-widgets__chrome .os-widgets__card-close` | 20×20 | 24×24 |
| `.os-widgets__card-close` (corner) | 22×22 | 24×24 |

All three carry `padding: 0` and `box-sizing: border-box`, so the declared size *is* the target size — there was no padding making up the difference. The SVG glyphs inside are untouched; only the target grows, so the chrome header gains 4px of height (its tallest flex child moves from 20 to 24 under `align-items: center`) and the title gives up 8px on a floating card, 4px when docked. No layout risk: the column is 320px wide, and even at the 160px floating minimum the title still has roughly 62px to ellipsize in.

## Why raise the box rather than add an invisible hit area

The usual trick for this — a transparent `::after` expanding the hit area while the visual stays small — is the wrong tool here. `.os-widgets__chrome` is the drag handle (`cursor: grab`, `touch-action: none`), and a pseudo-element overlay would sit between the pointer and the drag it is meant to start. Given the project's stated intent to protect the compact frame, I kept the change to the smallest thing that conforms; if you'd rather hold the visual size exactly, the hit-area approach is available, but it wants care around the drag.

## The spacing exception, and why it does not cover this

SC 2.5.8 lets an undersized target pass when a 24px circle centred on it does not intersect the circle on an adjacent target. Redock and close are adjacent flex siblings inside `.os-widgets__chrome` (`gap: 8px`). At the old sizes their centres were already `10 + 8 + 10 = 28px` apart, so the chrome pair *did* satisfy the spacing limb — an earlier version of this description said otherwise, and review corrected it.

What carries the change is the size limb alone: the corner close at 22px fails it outright with no exception available. And `.os-widgets__chrome` is itself a pointer target (the drag handle) enclosing both buttons, which is a good reason not to lean on the spacing exception there even where the arithmetic works. The gap test stays as a standing guard on that invariant, not as a pin on something this PR changed.

## Tests

`tests/vitest/widget-chrome-tap-target.test.ts` reads `desktop.css` and asserts the floor per selector, following the shape of `widget-card-token-contract.test.ts`. It also guards the centre-separation arithmetic and carries a negative control that measures `.os-widgets__grip`'s 10×16 box, so an extractor that stopped reading sizes correctly is caught by a small box reading small.

Verified locally under Node 26 after the trunk merge: the file passes, and the negative control goes red when the grip's width is mutated to 20.

## How it was found

Measuring every interactive control in the phone layer on a running instance: 118 targets, 35 under 24×24. Five of those are correctly exempt under the inline rule, and twenty were these two classes — the largest single group, and the only one that repeats once per widget.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-791-ff8ab188bf4b4f8f39361c83718cfc4f4e647d6a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
