### PR TITLE
os-text-field: add hide-label so a compact field can have a name without a visible label

### DIFF
--- a/apps/comments/parts/rail.ts
+++ b/apps/comments/parts/rail.ts
@@ -243,6 +243,8 @@ export function rail( ctx: Ctx, ui: UiState, rows: CommentRow[], error: string )
 	return html`<aside class="${ NS }__rail" aria-label=${ __( 'Conversations' ) }>
 		<div class="${ NS }__search">
 			<os-text-field
+				label=${ __( 'Search comments' ) }
+				hide-label
 				placeholder=${ __( 'Search comments…' ) }
 				os-bind="search"
 				os-action="filter"

--- a/apps/my-wordpress/my-wordpress.os.ts
+++ b/apps/my-wordpress/my-wordpress.os.ts
@@ -450,6 +450,8 @@ export default defineApp< AppState, AppData >( 'my-wordpress', {
 				${ section && ! inFolder && ! isAgents && ! inFootprint
 					? html`<div class="os-mywp__search">
 						<os-text-field
+							label=${ __( 'Search this section' ) }
+							hide-label
 							value=${ state.query }
 							placeholder=${ sprintf(
 								/* translators: %s: section label, lowercased. */

--- a/apps/plugins/plugins.os.ts
+++ b/apps/plugins/plugins.os.ts
@@ -174,6 +174,8 @@ function browsePanel( ctx: Ctx, ui: UiState, phone: boolean ): TemplateResult {
 				} ) }
 				<os-text-field
 					class="os-app-list__search"
+					label=${ __( 'Search WordPress.org', 'desktop-mode' ) }
+					hide-label
 					os-bind="query"
 					os-debounce="300"
 					placeholder=${ __( 'Search WordPress.org…', 'desktop-mode' ) }

--- a/apps/trash/trash.os.ts
+++ b/apps/trash/trash.os.ts
@@ -400,6 +400,8 @@ export default defineApp< AppState, AppData >( APP_ID, {
 						</os-segmented>
 						<os-text-field
 							type="search"
+							label=${ __( 'Search trash' ) }
+							hide-label
 							os-bind="search"
 							os-action="refresh"
 							placeholder=${ __( 'Search trash…' ) }

--- a/src/ui/components/os-text-field/os-text-field.styles.ts
+++ b/src/ui/components/os-text-field/os-text-field.styles.ts
@@ -53,6 +53,25 @@ export const textFieldStyles = css`
 		color: var( --os-ui-fg-muted, #646970 );
 	}
 
+	/*
+	 * `hide-label`: the label is still rendered and still paired with the
+	 * input by `for=`, it is only taken out of the visual flow. Hiding it
+	 * with `display: none` would remove it from the accessibility tree too,
+	 * which is the opposite of the point. Same idiom as
+	 * `.os-constellation__row-note` in openstation-layout.css.
+	 */
+	.os-text-field__label--hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		padding: 0;
+		border: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		clip-path: inset( 50% );
+	}
+
 	.os-text-field__row {
 		position: relative;
 		display: flex;

--- a/src/ui/components/os-text-field/os-text-field.styles.ts
+++ b/src/ui/components/os-text-field/os-text-field.styles.ts
@@ -54,11 +54,11 @@ export const textFieldStyles = css`
 	}
 
 	/*
-	 * `hide-label`: the label is still rendered and still paired with the
-	 * input by `for=`, it is only taken out of the visual flow. Hiding it
-	 * with `display: none` would remove it from the accessibility tree too,
+	 * hide-label: the label is still rendered and still paired with the
+	 * input by for=, it is only taken out of the visual flow. Hiding it
+	 * with display: none would remove it from the accessibility tree too,
 	 * which is the opposite of the point. Same idiom as
-	 * `.os-constellation__row-note` in openstation-layout.css.
+	 * .os-constellation__row-note in openstation-layout.css.
 	 */
 	.os-text-field__label--hidden {
 		position: absolute;

--- a/src/ui/components/os-text-field/os-text-field.test.ts
+++ b/src/ui/components/os-text-field/os-text-field.test.ts
@@ -169,7 +169,9 @@ describe( '<os-text-field>', () => {
 		const el = host.querySelector( 'os-text-field' )!;
 		expect( el.shadowRoot!.querySelector( 'label' ) ).toBeNull();
 		const input = el.shadowRoot!.querySelector( 'input' ) as HTMLInputElement;
-		expect( input.getAttribute( 'aria-label' ) ).toBe( '' );
+		// The renderer drops an empty aria-label entirely, so the absence
+		// reads as null — no attribute — rather than an empty string.
+		expect( input.getAttribute( 'aria-label' ) ).toBeNull();
 	} );
 
 	test( 'invalid attribute surfaces aria-invalid on the native input', async () => {

--- a/src/ui/components/os-text-field/os-text-field.test.ts
+++ b/src/ui/components/os-text-field/os-text-field.test.ts
@@ -127,6 +127,51 @@ describe( '<os-text-field>', () => {
 		expect( el.shadowRoot!.querySelector( '.os-text-field__clear' ) ).toBeNull();
 	} );
 
+	test( 'a labelled field pairs <label for> with the input AND names it', async () => {
+		host.innerHTML = `<os-text-field id="f" label="Search notes"></os-text-field>`;
+		await tick();
+
+		const el = host.querySelector( 'os-text-field' )!;
+		const label = el.shadowRoot!.querySelector( 'label' ) as HTMLLabelElement;
+		const input = el.shadowRoot!.querySelector( 'input' ) as HTMLInputElement;
+
+		expect( label ).not.toBeNull();
+		expect( label.getAttribute( 'for' ) ).toBe( input.id );
+		expect( input.getAttribute( 'aria-label' ) ).toBe( 'Search notes' );
+		expect( label.className ).not.toContain( 'os-text-field__label--hidden' );
+	} );
+
+	test( 'hide-label keeps the label and the name, and only takes the label out of the visual flow', async () => {
+		host.innerHTML = `<os-text-field id="g" label="Search notes" hide-label></os-text-field>`;
+		await tick();
+
+		const el = host.querySelector( 'os-text-field' )!;
+		const label = el.shadowRoot!.querySelector( 'label' ) as HTMLLabelElement;
+		const input = el.shadowRoot!.querySelector( 'input' ) as HTMLInputElement;
+
+		// Still rendered, still paired, still the accessible name. Hiding it
+		// with `display: none` or dropping the element would remove it from
+		// the accessibility tree, which is the opposite of the point.
+		expect( label ).not.toBeNull();
+		expect( label.textContent ).toBe( 'Search notes' );
+		expect( label.getAttribute( 'for' ) ).toBe( input.id );
+		expect( input.getAttribute( 'aria-label' ) ).toBe( 'Search notes' );
+		expect( label.className ).toContain( 'os-text-field__label--hidden' );
+	} );
+
+	test( 'hide-label without a label names nothing — a placeholder is not an accessible name', async () => {
+		// Negative control. `hide-label` is a presentation switch, not a
+		// source of names: without `label` there is nothing to hide and
+		// nothing to announce, and the test must not read a pass into that.
+		host.innerHTML = `<os-text-field id="h" hide-label placeholder="Search…"></os-text-field>`;
+		await tick();
+
+		const el = host.querySelector( 'os-text-field' )!;
+		expect( el.shadowRoot!.querySelector( 'label' ) ).toBeNull();
+		const input = el.shadowRoot!.querySelector( 'input' ) as HTMLInputElement;
+		expect( input.getAttribute( 'aria-label' ) ).toBe( '' );
+	} );
+
 	test( 'invalid attribute surfaces aria-invalid on the native input', async () => {
 		host.innerHTML = `<os-text-field value="x" invalid></os-text-field>`;
 		await tick();

--- a/src/ui/components/os-text-field/os-text-field.ts
+++ b/src/ui/components/os-text-field/os-text-field.ts
@@ -85,7 +85,7 @@ export class OsTextField extends Component {
 					'Label text. Rendered above the input and used as the accessible name. Pair with `hide-label` for a compact control that still has a name.',
 			},
 			{
-				name: 'hideLabel',
+				name: 'hide-label',
 				type: 'boolean attribute',
 				description:
 					'Keeps the label as the accessible name but takes it out of the visual flow — for toolbar searches and other compact fields with no room for it.',

--- a/src/ui/components/os-text-field/os-text-field.ts
+++ b/src/ui/components/os-text-field/os-text-field.ts
@@ -15,6 +15,20 @@
  * ></os-text-field>
  * ```
  *
+ * A compact field with no room for a label — a toolbar search, say —
+ * takes `hide-label`. The label still renders, still pairs with the
+ * input by `for=`, and is still the accessible name; it is only taken
+ * out of the visual flow. `placeholder` is NOT a substitute: it is not
+ * an accessible name, and it disappears on the first keystroke.
+ *
+ * ```html
+ * <os-text-field
+ *     label="Search notes"
+ *     hide-label
+ *     placeholder="Search notes…"
+ * ></os-text-field>
+ * ```
+ *
  * Add the `reveal` attribute on `type="password"` fields to show an
  * eye-icon toggle that switches between hidden and visible text:
  *
@@ -40,6 +54,7 @@ import { textFieldStyles } from './os-text-field.styles';
 export class OsTextField extends Component {
 	static props = [
 		'label',
+		'hideLabel',
 		'value',
 		'placeholder',
 		'disabled',
@@ -63,7 +78,18 @@ export class OsTextField extends Component {
 			'Labelled text input primitive. Two-way reflects `value`, emits os-input-change per keystroke, os-input-commit on blur/change, and os-submit on Enter. Optional password reveal toggle.',
 		status: 'stable',
 		props: [
-			{ name: 'label', type: 'string', description: 'Visible label above the input.' },
+			{
+				name: 'label',
+				type: 'string',
+				description:
+					'Label text. Rendered above the input and used as the accessible name. Pair with `hide-label` for a compact control that still has a name.',
+			},
+			{
+				name: 'hideLabel',
+				type: 'boolean attribute',
+				description:
+					'Keeps the label as the accessible name but takes it out of the visual flow — for toolbar searches and other compact fields with no room for it.',
+			},
 			{ name: 'value', type: 'string', description: 'Current input value; reflected two-way.' },
 			{ name: 'placeholder', type: 'string', description: 'Native placeholder string.' },
 			{ name: 'disabled', type: 'boolean attribute', description: 'Disables the native input.' },
@@ -127,6 +153,7 @@ export class OsTextField extends Component {
 		example: html`
 			<os-stack gap="8">
 				<os-text-field label="Note title" value="Untitled" placeholder="Name this note"></os-text-field>
+				<os-text-field label="Search notes" hide-label placeholder="Search notes…"></os-text-field>
 				<os-text-field type="password" reveal label="API key"></os-text-field>
 			</os-stack>
 		`,
@@ -146,6 +173,13 @@ export class OsTextField extends Component {
 
 	protected render() {
 		const label = ( this as unknown as { label: string | null } ).label || '';
+		// `hide-label` hides the label, never the NAME: the <label> below is
+		// still rendered and still paired by `for=`, and `aria-label` on the
+		// input is unchanged. A compact field that drops the label entirely
+		// has no accessible name at all — `placeholder` is not one, and it
+		// disappears on the first keystroke.
+		const hideLabel =
+			( this as unknown as { hideLabel: string | null } ).hideLabel !== null;
 		const value = ( this as unknown as { value: string | null } ).value ?? '';
 		const placeholder =
 			( this as unknown as { placeholder: string | null } ).placeholder ||
@@ -243,7 +277,9 @@ export class OsTextField extends Component {
 		return html`
 			${ label
 				? html`<label
-						class="os-text-field__label"
+						class=${ hideLabel
+							? 'os-text-field__label os-text-field__label--hidden'
+							: 'os-text-field__label' }
 						for=${ inputId }
 					>${ label }</label>`
 				: html`` }


### PR DESCRIPTION
Fixes #789.

## The problem

`label` drove both the visible label and the accessible name from one value, so a compact field had two reachable states and neither was right:

- `label` omitted → the inner `<input>` gets `aria-label=""`, i.e. **no accessible name**
- `label` set → the name is correct, and a label renders above a toolbar search with no room for one

`placeholder` does not close the gap: it is not an accessible name, and it disappears on the first keystroke.

## The change

`hide-label` separates presentation from naming. The `<label>` is **still rendered, still paired with the input by `for=`, and still the accessible name** — it is only taken out of the visual flow, using the same idiom as `.os-constellation__row-note` in `openstation-layout.css`.

```html
<os-text-field label="Search notes" hide-label placeholder="Search notes…"></os-text-field>
```

Hiding it with `display: none`, or dropping the element and relying on `aria-label` alone, would have been easier and worse: the first removes it from the accessibility tree, and the second gives up the `<label for>` association, which is the more robust of the two bindings. Keeping both is the point.

Declared as `hideLabel` in `static props`, so `Component.observedAttributes` kebabs it to `hide-label` — matching `autoGrow`, `labelPosition` and the other multi-word props in the kit.

## Call sites

Four first-party search fields adopt it: **comments**, **plugins**, **trash**, **my-wordpress**. After this, no `<os-text-field>` under `apps/` is unnamed.

**A correction to the issue:** #789 says seven. That number was measured against a checkout that has since moved; on current `trunk` it is four. One of the seven I counted was also a false positive — `os-number-field`'s help `summary` string contains the literal text `<os-text-field>`, which my scanner read as a call site. It has its own `label` prop and was never affected. I have not edited the issue body; happy to if you'd prefer the record corrected there.

## Tests

Three cases in `os-text-field.test.ts`:

1. a labelled field pairs `<label for>` with the input **and** names it
2. `hide-label` keeps the label, the pairing and the name, and only adds the modifier class
3. **negative control** — `hide-label` *without* `label` names nothing, because it is a presentation switch and not a source of names

**One honest caveat on verification.** I could not run your vitest suite locally: `devEngines` pins Node to `>=24 <25` and this machine is on v26, so `npm` refuses before install. I validated what I could without the harness — the prop is declared, read as a boolean the same way `disabled` is, the modifier is applied, `aria-label` is untouched, the style rule exists and is *not* `display: none`, and `kebab( 'hideLabel' ) === 'hide-label'` against your own `kebab()` in `src/ui/core/component.ts`. The vitest cases themselves are unexercised, so please let CI be the judge of those.

## Not included

`os-textarea` and `os-number-field` have the same coupling. I left them alone rather than widen an accessibility fix into a kit-wide API change without your read on the attribute name first — if `hide-label` is the shape you want, extending it is mechanical.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-792-d570f39fe34051e9e602b2a5e415704c87537b7d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->