### PR TITLE
Post Stats: draw the chart chrome in tokens instead of hardcoded black

### DIFF
--- a/src/plugins/post-stats-widget/index.ts
+++ b/src/plugins/post-stats-widget/index.ts
@@ -113,6 +113,21 @@ function drawChart( canvas: HTMLCanvasElement, buckets: Bucket[] ): void {
 	}
 	ctx.scale( dpr, dpr );
 
+	// Canvas ink, read from the same custom properties this widget's own
+	// stylesheet already uses for its DOM text. The chrome was hardcoded
+	// black, which is why the bars survived and everything drawn as text or
+	// rule did not: `.os-widgets__card` is a fixed dark glass in every
+	// desktop theme, so black measured 1.01:1 on it.
+	//
+	// The fallbacks are the dark-glass values from variables.css, NOT the
+	// old black — a widget that renders before the tokens resolve should
+	// fail toward legible rather than back into the bug.
+	const ink = getComputedStyle( canvas );
+	const inkOf = ( token: string, fallback: string ): string =>
+		ink.getPropertyValue( token ).trim() || fallback;
+	const RULE = inkOf( '--os-ui-color-border', 'rgba( 255, 251, 255, 0.12 )' );
+	const LABEL = inkOf( '--os-ui-color-text-subtle', 'rgba( 255, 251, 255, 0.7 )' );
+
 	const W = rect.width;
 	const H = rect.height;
 	const PAD = { top: 18, right: 10, bottom: 22, left: 28 };
@@ -128,7 +143,7 @@ function drawChart( canvas: HTMLCanvasElement, buckets: Bucket[] ): void {
 	const barPad = barGroupW * 0.2;
 	const barW = Math.max( 1, barGroupW - barPad * 2 );
 
-	ctx.strokeStyle = 'rgba(0,0,0,0.07)';
+	ctx.strokeStyle = RULE;
 	ctx.lineWidth = 1;
 	for ( let i = 0; i <= 3; i++ ) {
 		const y = PAD.top + chartH - ( chartH * i / 3 );
@@ -136,7 +151,7 @@ function drawChart( canvas: HTMLCanvasElement, buckets: Bucket[] ): void {
 		ctx.moveTo( PAD.left, y );
 		ctx.lineTo( PAD.left + chartW, y );
 		ctx.stroke();
-		ctx.fillStyle = 'rgba(0,0,0,0.35)';
+		ctx.fillStyle = LABEL;
 		ctx.font = '9px -apple-system, sans-serif';
 		ctx.textAlign = 'right';
 		ctx.fillText( String( Math.round( maxVal * i / 3 ) ), PAD.left - 4, y + 3 );
@@ -163,7 +178,7 @@ function drawChart( canvas: HTMLCanvasElement, buckets: Bucket[] ): void {
 			ctx.fill();
 		}
 
-		ctx.fillStyle = 'rgba(0,0,0,0.5)';
+		ctx.fillStyle = LABEL;
 		ctx.font = '9px -apple-system, sans-serif';
 		ctx.textAlign = 'center';
 		ctx.fillText( b.label, x + barW / 2, PAD.top + chartH + 13 );

--- a/src/plugins/post-stats-widget/index.ts
+++ b/src/plugins/post-stats-widget/index.ts
@@ -113,6 +113,16 @@ function drawChart( canvas: HTMLCanvasElement, buckets: Bucket[] ): void {
 	}
 	ctx.scale( dpr, dpr );
 
+	const W = rect.width;
+	const H = rect.height;
+	const PAD = { top: 18, right: 10, bottom: 22, left: 28 };
+	const chartW = W - PAD.left - PAD.right;
+	const chartH = H - PAD.top - PAD.bottom;
+
+	if ( chartW <= 0 || chartH <= 0 ) {
+		return;
+	}
+
 	// Canvas ink, read from the same custom properties this widget's own
 	// stylesheet already uses for its DOM text. The chrome was hardcoded
 	// black, which is why the bars survived and everything drawn as text or
@@ -127,16 +137,6 @@ function drawChart( canvas: HTMLCanvasElement, buckets: Bucket[] ): void {
 		ink.getPropertyValue( token ).trim() || fallback;
 	const RULE = inkOf( '--os-ui-color-border', 'rgba( 255, 251, 255, 0.12 )' );
 	const LABEL = inkOf( '--os-ui-color-text-subtle', 'rgba( 255, 251, 255, 0.7 )' );
-
-	const W = rect.width;
-	const H = rect.height;
-	const PAD = { top: 18, right: 10, bottom: 22, left: 28 };
-	const chartW = W - PAD.left - PAD.right;
-	const chartH = H - PAD.top - PAD.bottom;
-
-	if ( chartW <= 0 || chartH <= 0 ) {
-		return;
-	}
 
 	const maxVal = Math.max( 1, ...buckets.map( ( b ) => b.published + b.pending + b.draft ) );
 	const barGroupW = chartW / buckets.length;

--- a/tests/vitest/widget-card-token-contract.test.ts
+++ b/tests/vitest/widget-card-token-contract.test.ts
@@ -29,6 +29,10 @@ import { join } from 'node:path';
 const ROOT = join( __dirname, '../..' );
 const VARIABLES = readFileSync( join( ROOT, 'assets/css/variables.css' ), 'utf8' );
 const DESKTOP = readFileSync( join( ROOT, 'assets/css/desktop.css' ), 'utf8' );
+const POST_STATS = readFileSync(
+	join( ROOT, 'src/plugins/post-stats-widget/index.ts' ),
+	'utf8'
+);
 const STARTER = readFileSync(
 	join( ROOT, 'src/plugins/starter-widget/styles.css' ),
 	'utf8'
@@ -207,6 +211,33 @@ describe( 'the widget card token contract', () => {
 		expect( PALETTE.get( '--os-ui-color-accent' ) ).toContain(
 			'var(--os-ui-accent'
 		);
+	} );
+
+	test( 'canvas ink follows the tokens too, not a hardcoded value', () => {
+		// The contract is about what a widget READS, and a <canvas> reads
+		// nothing by itself. Post Stats painted its grid, y-axis ticks and
+		// month labels with literal black — `rgba(0,0,0,0.07)` / `0.35` /
+		// `0.5` — so on the card's dark glass they measured 1.01:1 and
+		// 1.02:1 while the widget's own DOM text, which does use the
+		// tokens, stayed legible. The bars survived only because they use
+		// the explicit COLORS map.
+		expect( POST_STATS ).not.toMatch( /rgba\(\s*0\s*,\s*0\s*,\s*0/ );
+		expect( POST_STATS ).toContain( '--os-ui-color-border' );
+		expect( POST_STATS ).toContain( '--os-ui-color-text-subtle' );
+	} );
+
+	test( 'the canvas fallbacks are legible on the glass, not the old black', () => {
+		// A fallback is the value that ships when the token does not
+		// resolve, so a black one would restore the bug in exactly the
+		// case the token was meant to cover. Both fallbacks here are the
+		// dark-glass values from variables.css.
+		const ink = POST_STATS.slice(
+			POST_STATS.indexOf( 'const RULE =' ),
+			POST_STATS.indexOf( '\n', POST_STATS.indexOf( 'const LABEL =' ) )
+		);
+		expect( ink ).not.toBe( '' );
+		expect( ink ).toContain( '255, 251, 255' );
+		expect( ink ).not.toMatch( /0\s*,\s*0\s*,\s*0/ );
 	} );
 
 	test( 'the card paints the surface token it publishes', () => {


### PR DESCRIPTION
Fixes #762.

## The change

Three canvas paints in `src/plugins/post-stats-widget/index.ts` were literal black:

| line | draws | was | now |
|---|---|---|---|
| 131 | horizontal grid lines | `rgba(0,0,0,0.07)` | `--os-ui-color-border` |
| 139 | y-axis tick numbers | `rgba(0,0,0,0.35)` | `--os-ui-color-text-subtle` |
| 166 | month labels | `rgba(0,0,0,0.5)` | `--os-ui-color-text-subtle` |

These are the same two custom properties the widget's **own stylesheet already uses** for its DOM text — which is precisely why the title, the `39 posts in 6 mo` metadata and the legend were legible while everything on the canvas was not. The bars survived because they use the explicit `COLORS` map.

## Two decisions worth flagging

**The ad-hoc alphas go with the black.** `0.07 / 0.35 / 0.5` were compensating for black ink on a light assumption; the tokens already encode the rule-vs-label hierarchy, and a canvas cannot cheaply apply an alpha to an arbitrary colour string without parsing it. If you'd rather keep a weight difference between the ticks and the month labels, `globalAlpha` around the tick pass is the clean way and I'm happy to take direction on it.

**The fallbacks are deliberately not black.** `getPropertyValue()` returns `''` when a token has not resolved, so the fallback is what ships in exactly the case the token exists to cover. Falling back to black would restore the bug there. Both fallbacks are the dark-glass values from `variables.css`.

## Tests

Two cases added to `tests/vitest/widget-card-token-contract.test.ts`, which already exists for this class of bug. One asserts the source carries no literal black and reads both tokens; the other asserts the *fallbacks* are legible on the glass — without that, a future edit could satisfy the first pin and still ship black as the fallback.

A canvas cannot be asserted in jsdom without a 2D context, so these are source-level pins rather than rendered-pixel ones. That is a real limitation of the check and worth knowing when reading it.

**Verification caveat, same as my other PRs:** I could not run your vitest suite — `devEngines` pins Node to `>=24 <25` and this machine is on v26, so npm refuses before install. I ran each pin's logic in plain node against the real file in both directions: it passes on the patched source and **trips on the pre-patch source**, so the guard is failable rather than vacuous. The vitest harness itself is unexercised.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-793-07596f1dc1aeb83c8ba88f3d79d7b1c3a59aee4f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->