### PR TITLE
Tooling: admit Node 26 alongside Node 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "desktop-mode",
+	"name": "openstation",
 	"version": "1.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "desktop-mode",
+			"name": "openstation",
 			"version": "1.1.7",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -28,7 +28,7 @@
 				"vitest": "^4.1.4"
 			},
 			"engines": {
-				"node": ">=24.0.0 <25.0.0"
+				"node": "^24.0.0 || ^26.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
 		}
 	},
 	"engines": {
-		"node": ">=24.0.0 <25.0.0"
+		"node": "^24.0.0 || ^26.0.0"
 	},
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": ">=24.0.0 <25.0.0",
+			"version": "^24.0.0 || ^26.0.0",
 			"onFail": "error"
 		}
 	},


### PR DESCRIPTION
## What it does

Widens the Node pin in `package.json` from `>=24 <25` to `^24.0.0 || ^26.0.0` (both `engines` and `devEngines`).

## Rationale

`devEngines` with `onFail: error` makes npm refuse `npm ci` on a Node 26 machine before anything installs, so a reviewer on the current release line could not run the vitest suite at all. The pin exists to fail fast instead of silently churning the lockfile on a different Node major. Measured on Node 26.8.2, the lockfile rewrite is byte-for-byte the same one Node 24.16.0 produces, and build, lint, typecheck and the full vitest suite pass on both, so the reason for excluding 26 does not hold.

The range admits the two current release lines and skips Node 25, the odd line that is already end-of-life. `onFail: error` stays, so an unvalidated major (27) still fails fast.

## Implementation

- `package.json`: `engines` and `devEngines.runtime.version` become `^24.0.0 || ^26.0.0`. `.nvmrc` and CI stay on 24, so shipped bundles are unchanged.
- `package-lock.json`: regenerated. Besides mirroring the new `engines` value, this picks up the package name that was renamed to `openstation` in `package.json` but never in the lock, which is what made any `npm install` on trunk dirty the lockfile.

## Testing instructions

- On Node 24 (`nvm use`): `npm ci && npm run build && npm run lint && npm run typecheck && npm run test:js` all pass.
- On Node 26 (`nvm install 26 && nvm use 26`): `npm ci` now succeeds where it previously failed with `EBADDEVENGINES`; the same four gates pass (500 test files, 6091 tests).
- On either version, `npm install --package-lock-only` leaves the lockfile clean.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-794-6ed488dd242f80c566f6c8d63f3f6b53a4a5fa65.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
