### PR TITLE
Tooling: skip the PR preview publish when the head has moved on

### DIFF
--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -92,7 +92,24 @@ jobs:
             );
             const pr = matches.find((p) => p.state === 'open') ?? matches[0];
             if (!pr) {
-              core.setFailed(`No pull request for ${headOwner}:${headBranch} at head SHA ${headSha}; refusing to publish a preview.`);
+              // Not a failure. The realistic causes are all benign races: a
+              // push or force-push landed while the build was still running, so
+              // the PR's head has moved past the commit this run built; or the
+              // head fork was deleted, leaving `head.repo` null. Either way the
+              // built commit is superseded and there is nothing worth
+              // publishing — the newer commit's own build/publish pair posts
+              // the preview, and a preview of the older code under the current
+              // PR would actively mislead a reviewer.
+              //
+              // Skipping keeps the security property intact: a preview is still
+              // only ever published to a PR positively identified from the
+              // trusted payload. What it stops is a red run in the trunk
+              // Actions tab (`workflow_run` runs are attributed to the default
+              // branch) every time someone pushes twice in quick succession.
+              // Genuine trouble still fails loudly: a malformed payload is
+              // caught above, and an API or permission error throws out of
+              // `paginate` rather than returning an empty list.
+              core.warning(`No pull request for ${headOwner}:${headBranch} at head SHA ${headSha}; the head has moved on, skipping the preview.`);
               return;
             }
             core.setOutput('pr-number', String(pr.number));
@@ -105,6 +122,11 @@ jobs:
         # one and trunk-build.yml's) then failed with HTTP 422. Sweep before
         # uploading so a full release frees room instead of failing.
         # Fail-open on purpose: a cleanup hiccup must never cost a preview.
+        #
+        # Gated on the PR number like every step below it: with no PR resolved
+        # there is no current-PR number to exclude, so the sweep would treat
+        # the PR being built as just another candidate.
+        if: steps.meta.outputs.pr-number != ''
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -172,6 +194,7 @@ jobs:
             core.info(`${assets.length} assets on ci-artifacts; ${closed.length} closed PRs; deleted ${deleted} zip(s).`);
 
       - name: Expose built artifact on a public URL
+        if: steps.meta.outputs.pr-number != ''
         id: expose
         uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@43fc435558bc6cee69f5b214d6b8ca4f9f80c31d # v3
         with:
@@ -183,6 +206,7 @@ jobs:
           artifact-source-run-id: ${{ github.event.workflow_run.id }}
 
       - name: Build blueprint
+        if: steps.meta.outputs.pr-number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: blueprint
         env:
@@ -198,6 +222,7 @@ jobs:
           result-encoding: string
 
       - name: Post preview to PR
+        if: steps.meta.outputs.pr-number != ''
         uses: WordPress/action-wp-playground-pr-preview@43fc435558bc6cee69f5b214d6b8ca4f9f80c31d # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What it does

Turns a benign race in `PR Preview Publish` from a red run into a green one with a warning annotation.

The workflow resolves the PR from the trusted `workflow_run` payload and requires the PR's head to still be the exact commit the build ran on. Push a second commit while the first preview build is running, and that commit is superseded before the publish job starts. The lookup matches nothing and the step calls `core.setFailed`.

## Rationale

Nothing is actually broken when it happens. The newer commit's own build/publish pair posts the preview, the job attaches no check run to the PR, and it is not among the trunk ruleset's required checks.

The cost is noise, in the one place noise is expensive. `workflow_run` runs are attributed to the default branch, so every race paints a red run in the **trunk** Actions tab. It fired twice in two days, on #794 and on a `codex/agent-async-jobs` push the day before, and it will fire whenever anyone pushes twice in quick succession. A red trunk run that routinely means nothing is a red trunk run people stop reading.

Timeline of the #794 case:

| Time (UTC) | Event |
|---|---|
| 08:33:16 | Preview build starts on `5d4b4f6d` |
| 08:34:56 | Force push, head becomes `a2d67cc5`, new build starts |
| 08:35:03 | Publish fires for the `5d4b4f6d` build, finds no matching head, fails |
| 08:36:34 | Publish for `a2d67cc5` succeeds and posts the preview |

## Implementation

`core.warning` and an early return replace `core.setFailed` in the no-match branch. The four steps that need a PR number are gated on `steps.meta.outputs.pr-number != ''`, so the job ends green with an annotation naming the branch and the SHA that moved on.

Two things deliberately not done:

- **The head SHA equality check stays.** Relaxing it to owner plus branch would make the race "succeed", but it would publish the superseded build under the current PR. A reviewer clicking that preview link would get older code than the PR shows. Skipping is the right outcome here, not a workaround for it.
- **The loud failures stay loud.** A malformed head SHA or incomplete head data still calls `setFailed`, and an API or permission error throws out of `paginate` rather than returning an empty list, so it surfaces as a step error and not as a silent skip.

The trust model is untouched: a preview is still only ever published to a PR positively identified from the `workflow_run` payload, never from artifact bytes.

## Testing instructions

The workflow only runs from the default branch, so the skip path is exercised after merge rather than on this PR.

- The preview build and publish pair for this PR should behave exactly as before, since its head is not racing anything.
- Next time a push lands while a preview build is running, the publish run should be green with a `No pull request for …; the head has moved on, skipping the preview.` annotation, and the later run should post the preview as usual.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-796-0980d8686cd18f6768176324965aae1b894790e6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->