### PR TITLE
AI Copilot: keep password-protected posts out of the search abilities

### DIFF
--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -382,7 +382,7 @@ function openstation_ai_search_dispatch_tool( $tool_name, array $args ) {
  * (`WP_Query` `s=`), returning data rich enough for the agent to compare
  * AND for the UI to render links.
  *
- * No AI analysis is required — every published post/page is searchable.
+ * No AI analysis is required — every published, non-password-protected post/page is searchable.
  *
  * Password-protected posts are excluded (`has_password => false`): `publish`
  * is also the status of a password-protected post, and this tool emits the

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -384,6 +384,12 @@ function openstation_ai_search_dispatch_tool( $tool_name, array $args ) {
  *
  * No AI analysis is required — every published post/page is searchable.
  *
+ * Password-protected posts are excluded (`has_password => false`): `publish`
+ * is also the status of a password-protected post, and this tool emits the
+ * stored body as an excerpt without ever passing through `post_password_required()`.
+ * Filtering at the query level keeps them out of both `items` and `found_posts`,
+ * so the `total` counter cannot become an oracle for their contents either.
+ *
  * @param string $post_type 'post' | 'page'.
  * @param string $query     Keyword search terms (may be empty to list newest).
  * @param int    $offset
@@ -394,6 +400,7 @@ function openstation_ai_search_fetch_posts( $post_type, $query, $offset ) {
 		array(
 			'post_type'              => $post_type,
 			'post_status'            => 'publish',
+			'has_password'           => false,
 			's'                      => (string) $query,
 			'posts_per_page'         => OPENSTATION_AI_SEARCH_BATCH_SIZE,
 			'offset'                 => $offset,

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -79,6 +79,49 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A password-protected post is never returned — its body is content
+	 * WordPress withholds behind `post_password_required()`, and `publish`
+	 * is also the status of a password-protected post. It must not appear in
+	 * `items`, and it must not be counted in `total` (or the counter becomes
+	 * an oracle for the protected body).
+	 *
+	 * @covers ::openstation_ai_search_fetch_posts
+	 */
+	public function test_search_posts_excludes_password_protected_posts() {
+		$public_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Public paella recipe',
+				'post_content' => 'A Valencian rice dish, freely readable.',
+			)
+		);
+		$secret_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_title'    => 'Secret paella recipe',
+				'post_content'  => 'The paella secret nobody should read.',
+			)
+		);
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_posts',
+			array( 'query' => 'paella', 'offset' => 0 )
+		);
+
+		$ids = wp_list_pluck( $result['items'], 'id' );
+		$this->assertContains( $public_id, $ids, 'The public post should be found.' );
+		$this->assertNotContains( $secret_id, $ids, 'The password-protected post must not leak its body.' );
+
+		$this->assertSame( 1, $result['count'], 'Only the public post should be counted in the batch.' );
+		$this->assertSame(
+			1,
+			$result['total'],
+			'The protected post must not inflate total — that counter is an oracle for its contents.'
+		);
+	}
+
+	/**
 	 * Comments are found by their text with native comment search, with no
 	 * analysis meta present.
 	 *


### PR DESCRIPTION
## What it does

Stops the Copilot's `desktop-mode/search-posts` and `desktop-mode/search-pages` abilities from returning password-protected posts. Reported via HackerOne (Medium): any Subscriber could read the stored body of a protected post or page — content WordPress withholds behind `post_password_required()` everywhere else.

## The leak

`openstation_ai_search_fetch_posts()` treated `post_status = publish` as permission to read. But `publish` is also the status of a password-protected post, and the function emits `openstation_ai_search_excerpt( $post->post_content )` over the **stored** body — no `post_password_required()`, no `the_content` pass. Both abilities are `show_in_rest` + `readonly`, so Core dispatches them over plain `GET` behind the `read` capability (Subscriber):

```
GET /wp-json/wp-abilities/v1/abilities/desktop-mode--search-posts/run?query=<marker>
```

The first 300 characters of the protected body came back as the excerpt, and `found_posts` made the `total` counter answer "does the protected post contain this string?" — an oracle for recovering the rest.

## The fix

One line: `'has_password' => false` in the `WP_Query` args. Filtering at the query level keeps protected posts out of `items` **and** `found_posts` in the same set, so the excerpt leak and the counter oracle close together — a post-query row skip would have left `total` counting what it hides.

`private` posts were never affected (`post_status => 'publish'` already excludes them). The entity-builder path in `search.php` has the same shape and is tracked separately.

## Testing instructions

`Tests_OpenStation_AiNativeSearch::test_search_posts_excludes_password_protected_posts` pins the property: with a public and a protected post both matching the query, the protected one appears in neither `items` nor `total`, and the public one still does.

Also verified end-to-end through the real ability object (`wp_get_ability( 'desktop-mode/search-posts' )->execute()` as a Subscriber, via `wp eval-file` in the tests wp-env): on unpatched code the check fails on all four properties (body in items, marker in excerpt, `total` inflated, pages too); on this branch all pass and public content is unaffected.

- `npm run test:php -- --filter='Tests_OpenStation_Ai'` — 103 tests / 339 assertions green
- `phpcs -n` clean on the touched source; `npm run build` produces no diffs

Or by hand: create a password-protected post with a unique marker, log in as a Subscriber, run the `GET` above — the post no longer appears and `total` is 0.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-801-1f02fd4a70cc602e5835a57722cc478ade27242a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->