### PR TITLE
AI Copilot: authorize the model-named entity id before building the entity card

### DIFF
--- a/docs/agents-security.md
+++ b/docs/agents-security.md
@@ -208,6 +208,14 @@ Registering an ability agents can call:
       unless the caller can `edit_post` it — the escape hatch Core's
       `WP_REST_Posts_Controller::check_password_required()` grants.
       `desktop-mode/get-post` is the worked example.
+- [ ] If it returns a **child** object, does it gate the **parent** too?
+      A comment record carries its post's title and permalink, so
+      approval alone does not make it public: an approved comment
+      outlives its post being switched to private or back to draft, and
+      returning it hands out exactly what the post's own gate withholds.
+      Gate the parent by the same rule as the post itself, and prefer
+      the query (`post_status` on `WP_Comment_Query`) over a per-row
+      skip so the batch's `total` cannot report what `items` hides.
 - [ ] Would a contributor invoking it through an admin-role agent get
       more than they should? (If the ceiling is doing all the work,
       say so in the ability's description.)

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -378,6 +378,39 @@ function openstation_ai_search_dispatch_tool( $tool_name, array $args ) {
 }
 
 /**
+ * Whether the current user is allowed to read a post's content.
+ *
+ * Two gates, because WordPress hides content two different ways:
+ *
+ * - **Status.** A publicly viewable post is public. Anything else — private,
+ *   draft, pending, future — needs `read_post`, which resolves to the
+ *   author's own edit rights or to `read_private_posts`.
+ * - **Password.** A published password-protected post IS publicly viewable
+ *   and every logged-in user passes `read_post` on it, yet its body is
+ *   exactly what the password withholds. `post_password_required()` answers
+ *   for the visitor's password cookie; editing the post is the other way in,
+ *   which is how core decides the same question.
+ *
+ * @param WP_Post|null $post Resolved post object.
+ * @return bool
+ */
+function openstation_ai_search_can_read_post( $post ) {
+	if ( ! $post instanceof WP_Post ) {
+		return false;
+	}
+
+	if ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post->ID ) ) {
+		return false;
+	}
+
+	if ( post_password_required( $post ) && ! current_user_can( 'edit_post', $post->ID ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Keyword-searches published posts or pages with WordPress's native search
  * (`WP_Query` `s=`), returning data rich enough for the agent to compare
  * AND for the UI to render links.
@@ -405,6 +438,13 @@ function openstation_ai_search_fetch_posts( $post_type, $query, $offset ) {
 
 	$items = array();
 	foreach ( $wp_query->posts as $post ) {
+		// `publish` is not the whole story: a password-protected post is
+		// published, and handing its body to the model leaks it right back
+		// through the answer prose. The corpus is what this user may read.
+		if ( ! openstation_ai_search_can_read_post( $post ) ) {
+			continue;
+		}
+
 		$items[] = array(
 			// Identity — used to build the final entity detail.
 			'id'       => $post->ID,
@@ -492,8 +532,16 @@ function openstation_ai_search_fetch_comments( $query, $offset ) {
 
 	$items = array();
 	foreach ( $comments as $comment ) {
-		$parent_post  = get_post( $comment->comment_post_ID );
-		$parent_title = $parent_post ? wp_strip_all_tags( $parent_post->post_title ) : '';
+		$parent_post = get_post( $comment->comment_post_ID );
+
+		// Approval is not publication. An approved comment outlives its post
+		// being switched to private or back to draft, and every item below
+		// carries the parent's title and permalink.
+		if ( ! openstation_ai_search_can_read_post( $parent_post ) ) {
+			continue;
+		}
+
+		$parent_title = wp_strip_all_tags( $parent_post->post_title );
 
 		$items[] = array(
 			'id'         => (int) $comment->comment_ID,
@@ -505,7 +553,7 @@ function openstation_ai_search_fetch_comments( $query, $offset ) {
 			'url'        => (string) get_comment_link( $comment ),
 			'edit_url'   => admin_url( 'comment.php?action=editcomment&c=' . (int) $comment->comment_ID ),
 			'post_id'    => (int) $comment->comment_post_ID,
-			'post_url'   => $parent_post ? (string) get_permalink( $parent_post ) : '',
+			'post_url'   => (string) get_permalink( $parent_post ),
 		);
 	}
 
@@ -554,6 +602,23 @@ function openstation_ai_search_fetch_comments_by_post( $post_id, $query, $offset
 		);
 	}
 
+	// The model picks the post id, so it is untrusted the same way an entity
+	// id is. Comments inherit their parent's reach: a thread on a private,
+	// draft or password-protected post is not this user's to read.
+	$parent_post = get_post( $post_id );
+	if ( ! openstation_ai_search_can_read_post( $parent_post ) ) {
+		return array(
+			'tool'     => 'search_comments_by_post',
+			'post_id'  => $post_id,
+			'offset'   => $offset,
+			'items'    => array(),
+			'count'    => 0,
+			'total'    => 0,
+			'has_more' => false,
+			'error'    => 'No readable post matches that post_id.',
+		);
+	}
+
 	$base_args = array(
 		'post_id' => $post_id,
 		'status'  => 'approve',
@@ -574,8 +639,7 @@ function openstation_ai_search_fetch_comments_by_post( $post_id, $query, $offset
 
 	$total = (int) get_comments( array_merge( $base_args, array( 'count' => true ) ) );
 
-	$parent_post  = get_post( $post_id );
-	$parent_title = $parent_post ? wp_strip_all_tags( $parent_post->post_title ) : '';
+	$parent_title = wp_strip_all_tags( $parent_post->post_title );
 
 	$items = array();
 	foreach ( $comments as $comment ) {
@@ -622,11 +686,14 @@ function openstation_ai_search_fetch_comments_by_post( $post_id, $query, $offset
  * whether or not a search tool ever surfaced it. Every branch therefore
  * re-checks the current user's authorization against the resolved object
  * before emitting anything. The id must resolve to a real post or page (not
- * a CPT row of some other plugin); a private/draft/pending/future post is
- * withheld unless the user can `read_post` it; an unapproved comment (and its
- * moderation verdicts) is withheld unless the user can `moderate_comments`.
- * The edit link follows the matching edit capability. Model output is never
- * an authorization decision.
+ * a CPT row of some other plugin), and that post has to pass
+ * `openstation_ai_search_can_read_post()`. A comment adds two more gates: an
+ * unapproved comment (and the moderation verdicts on any comment) is withheld
+ * unless the user can `moderate_comments`, and the record carries its parent's
+ * title and permalink, so the parent has to pass the same read check — an
+ * approved comment outlives its post being switched to private or back to
+ * draft, and approval is not publication. The edit link follows the matching
+ * edit capability. Model output is never an authorization decision.
  *
  * @param string $entity_type 'post' | 'page' | 'comment'.
  * @param int    $entity_id
@@ -639,15 +706,16 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 		$post = get_post( $entity_id );
 
 		// The id must resolve to an actual post or page — the only types the
-		// search tools surface. Without this, a model-named id could resolve
-		// a plugin's non-public CPT row, whose `publish` status would satisfy
-		// the viewability check below even though the type is never queryable.
+		// search tools surface. Without this, a model-named id could resolve a
+		// plugin's non-public CPT row: its type fails `is_post_publicly_viewable()`,
+		// but `read_post` on a `publish` status maps to plain `read`, which every
+		// logged-in user holds, so the gate below would wave the row through.
 		if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
 			return null;
 		}
 
-		// A publicly viewable post is public; anything else needs read authorization.
-		if ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $entity_id ) ) {
+		// Status and password both decide whether this user may see the body.
+		if ( ! openstation_ai_search_can_read_post( $post ) ) {
 			return null;
 		}
 
@@ -675,15 +743,23 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 			return null;
 		}
 
-		$meta        = $can_moderate ? openstation_ai_get_meta( 'comment', $entity_id ) : null;
+		// Approval is not publication. An approved comment survives its post
+		// being switched to private or back to draft, and this record carries
+		// the parent's title and permalink — so without this check, naming a
+		// comment id would walk straight around the post branch's gate above.
 		$parent_post = get_post( $comment->comment_post_ID );
-		$entity      = array(
+		if ( ! openstation_ai_search_can_read_post( $parent_post ) ) {
+			return null;
+		}
+
+		$meta   = $can_moderate ? openstation_ai_get_meta( 'comment', $entity_id ) : null;
+		$entity = array(
 			'id'         => $entity_id,
 			'type'       => 'comment',
 			'excerpt'    => openstation_ai_search_excerpt( $comment->comment_content ),
 			'post_id'    => (int) $comment->comment_post_ID,
-			'post_title' => $parent_post ? wp_strip_all_tags( $parent_post->post_title ) : '',
-			'post_url'   => $parent_post ? (string) get_permalink( $parent_post ) : '',
+			'post_title' => wp_strip_all_tags( $parent_post->post_title ),
+			'post_url'   => (string) get_permalink( $parent_post ),
 			'url'        => (string) get_comment_link( $comment ),
 			'edit_url'   => current_user_can( 'edit_comment', $entity_id )
 				? admin_url( 'comment.php?action=editcomment&c=' . $entity_id )

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -445,13 +445,6 @@ function openstation_ai_search_fetch_posts( $post_type, $query, $offset ) {
 
 	$items = array();
 	foreach ( $wp_query->posts as $post ) {
-		// `publish` is not the whole story: a password-protected post is
-		// published, and handing its body to the model leaks it right back
-		// through the answer prose. The corpus is what this user may read.
-		if ( ! openstation_ai_search_can_read_post( $post ) ) {
-			continue;
-		}
-
 		$items[] = array(
 			// Identity — used to build the final entity detail.
 			'id'       => $post->ID,
@@ -505,9 +498,15 @@ function openstation_ai_search_excerpt( $content ) {
  */
 function openstation_ai_search_fetch_comments( $query, $offset ) {
 	$base_args = array(
-		'status' => 'approve',
-		'type'   => 'comment',
-		'search' => (string) $query,
+		'status'      => 'approve',
+		'type'        => 'comment',
+		'search'      => (string) $query,
+		// Every item below carries its parent's title and permalink, and
+		// approval is not publication — an approved comment outlives its post
+		// being switched to private or back to draft. Filtering the parent
+		// status in the query keeps those threads out of `total` as well as
+		// out of `items`, so the counter cannot report what the batch hides.
+		'post_status' => 'publish',
 	);
 
 	$comments = get_comments(
@@ -541,9 +540,9 @@ function openstation_ai_search_fetch_comments( $query, $offset ) {
 	foreach ( $comments as $comment ) {
 		$parent_post = get_post( $comment->comment_post_ID );
 
-		// Approval is not publication. An approved comment outlives its post
-		// being switched to private or back to draft, and every item below
-		// carries the parent's title and permalink.
+		// `publish` is also the status of a password-protected post, and the
+		// query above cannot express that — WP_Comment_Query has no
+		// `has_password`. The parent's own read gate answers it.
 		if ( ! openstation_ai_search_can_read_post( $parent_post ) ) {
 			continue;
 		}

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -380,16 +380,22 @@ function openstation_ai_search_dispatch_tool( $tool_name, array $args ) {
 /**
  * Whether the current user is allowed to read a post's content.
  *
- * Two gates, because WordPress hides content two different ways:
+ * Three gates, because WordPress hides content three different ways and only
+ * one of them is a capability `read_post` can answer:
  *
- * - **Status.** A publicly viewable post is public. Anything else — private,
- *   draft, pending, future — needs `read_post`, which resolves to the
- *   author's own edit rights or to `read_private_posts`.
  * - **Password.** A published password-protected post IS publicly viewable
  *   and every logged-in user passes `read_post` on it, yet its body is
  *   exactly what the password withholds. `post_password_required()` answers
  *   for the visitor's password cookie; editing the post is the other way in,
- *   which is how core decides the same question.
+ *   the escape hatch Core's
+ *   `WP_REST_Posts_Controller::check_password_required()` grants.
+ * - **Type.** `read_post` on a `publish` status maps to plain `read`, which
+ *   every logged-in user holds, whatever the post type's visibility — so a
+ *   plugin's internal CPT row would read as public. A type the front end
+ *   never renders needs `edit_post` instead.
+ * - **Status.** A publicly viewable post is public. Anything else — private,
+ *   draft, pending, future — needs `read_post`, which resolves to the
+ *   author's own edit rights or to `read_private_posts`.
  *
  * @param WP_Post|null $post Resolved post object.
  * @return bool
@@ -399,15 +405,33 @@ function openstation_ai_search_can_read_post( $post ) {
 		return false;
 	}
 
-	if ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post->ID ) ) {
-		return false;
-	}
-
 	if ( post_password_required( $post ) && ! current_user_can( 'edit_post', $post->ID ) ) {
 		return false;
 	}
 
-	return true;
+	if ( is_post_publicly_viewable( $post ) ) {
+		return true;
+	}
+
+	if ( ! is_post_type_viewable( $post->post_type ) ) {
+		return current_user_can( 'edit_post', $post->ID );
+	}
+
+	return current_user_can( 'read_post', $post->ID );
+}
+
+/**
+ * Post types whose comments the search tools may surface.
+ *
+ * The front end never renders a non-viewable type, so a discussion hanging
+ * off one is internal plugin data — WooCommerce order notes are comments on
+ * `shop_order`. Passing this to `WP_Comment_Query` as `post_type` filters
+ * those threads out of `total` as well as out of the batch.
+ *
+ * @return string[]
+ */
+function openstation_ai_search_commentable_post_types() {
+	return array_values( array_filter( get_post_types( array(), 'names' ), 'is_post_type_viewable' ) );
 }
 
 /**
@@ -497,17 +521,32 @@ function openstation_ai_search_excerpt( $content ) {
  * @return array
  */
 function openstation_ai_search_fetch_comments( $query, $offset ) {
+	// Every item below carries its parent's title and permalink, and approval
+	// is a moderation decision, not a visibility one — an approved comment
+	// outlives its post being switched to private or back to draft. The
+	// parent's reach therefore has to bound the corpus, and it has to do so IN
+	// THE QUERY: a skip in the loop below would leave `total` counting rows
+	// `items` withholds (a keyword oracle over content the caller cannot read)
+	// and let hidden rows eat the batch size.
 	$base_args = array(
 		'status'      => 'approve',
 		'type'        => 'comment',
 		'search'      => (string) $query,
-		// Every item below carries its parent's title and permalink, and
-		// approval is not publication — an approved comment outlives its post
-		// being switched to private or back to draft. Filtering the parent
-		// status in the query keeps those threads out of `total` as well as
-		// out of `items`, so the counter cannot report what the batch hides.
 		'post_status' => 'publish',
+		'post_type'   => openstation_ai_search_commentable_post_types(),
 	);
+
+	// The password is the one gate with no query var — `WP_Comment_Query` has
+	// no `has_password`. Both query vars above join the posts table, so the
+	// clause has somewhere to land, and this filter runs for the count query
+	// as well as the batch.
+	$exclude_sealed_parents = static function ( $clauses ) {
+		global $wpdb;
+		$clauses['where'] .= ( '' !== $clauses['where'] ? ' AND ' : '' ) . "{$wpdb->posts}.post_password = ''";
+		return $clauses;
+	};
+
+	add_filter( 'comments_clauses', $exclude_sealed_parents );
 
 	$comments = get_comments(
 		array_merge(
@@ -521,6 +560,8 @@ function openstation_ai_search_fetch_comments( $query, $offset ) {
 	);
 
 	$total = (int) get_comments( array_merge( $base_args, array( 'count' => true ) ) );
+
+	remove_filter( 'comments_clauses', $exclude_sealed_parents );
 
 	// Prime the parent posts in a single query so the per-comment
 	// get_post() calls below are cache hits, not N+1 round-trips.
@@ -538,15 +579,9 @@ function openstation_ai_search_fetch_comments( $query, $offset ) {
 
 	$items = array();
 	foreach ( $comments as $comment ) {
-		$parent_post = get_post( $comment->comment_post_ID );
-
-		// `publish` is also the status of a password-protected post, and the
-		// query above cannot express that — WP_Comment_Query has no
-		// `has_password`. The parent's own read gate answers it.
-		if ( ! openstation_ai_search_can_read_post( $parent_post ) ) {
-			continue;
-		}
-
+		// The query joined the posts table on every gate, so the parent exists
+		// and is one this caller may read.
+		$parent_post  = get_post( $comment->comment_post_ID );
 		$parent_title = wp_strip_all_tags( $parent_post->post_title );
 
 		$items[] = array(
@@ -711,11 +746,11 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 	if ( in_array( $entity_type, array( 'post', 'page' ), true ) ) {
 		$post = get_post( $entity_id );
 
-		// The id must resolve to an actual post or page — the only types the
-		// search tools surface. Without this, a model-named id could resolve a
-		// plugin's non-public CPT row: its type fails `is_post_publicly_viewable()`,
-		// but `read_post` on a `publish` status maps to plain `read`, which every
-		// logged-in user holds, so the gate below would wave the row through.
+		// The id must resolve to an actual post or page. The gate below answers
+		// type visibility on its own, so this is the contract rather than the
+		// lock: the record's `type` is what the client renders the card from,
+		// and post/page is what the search tools surface. A viewable CPT row
+		// would pass the gate and still have no card to land in.
 		if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
 			return null;
 		}
@@ -753,7 +788,11 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 		// being switched to private or back to draft, and this record carries
 		// the parent's title and permalink — so without this check, naming a
 		// comment id would walk straight around the post branch's gate above.
-		$parent_post = get_post( $comment->comment_post_ID );
+		// An orphaned comment is resolved explicitly rather than through
+		// get_post( 0 ), which falls back to the global $post and would judge
+		// the comment against whatever else the request happens to be showing.
+		$parent_id   = (int) $comment->comment_post_ID;
+		$parent_post = $parent_id > 0 ? get_post( $parent_id ) : null;
 		if ( ! openstation_ai_search_can_read_post( $parent_post ) ) {
 			return null;
 		}

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -617,6 +617,17 @@ function openstation_ai_search_fetch_comments_by_post( $post_id, $query, $offset
  * verdict when the comment-moderation analysis happens to have run, but
  * its absence never blocks the entity from being returned.
  *
+ * The `$entity_id` arrives from the model's structured answer, not from a
+ * server-side search result, so it is untrusted: the model can name any id
+ * whether or not a search tool ever surfaced it. Every branch therefore
+ * re-checks the current user's authorization against the resolved object
+ * before emitting anything. The id must resolve to a real post or page (not
+ * a CPT row of some other plugin); a private/draft/pending/future post is
+ * withheld unless the user can `read_post` it; an unapproved comment (and its
+ * moderation verdicts) is withheld unless the user can `moderate_comments`.
+ * The edit link follows the matching edit capability. Model output is never
+ * an authorization decision.
+ *
  * @param string $entity_type 'post' | 'page' | 'comment'.
  * @param int    $entity_id
  * @return array|null
@@ -626,9 +637,20 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 
 	if ( in_array( $entity_type, array( 'post', 'page' ), true ) ) {
 		$post = get_post( $entity_id );
-		if ( ! $post instanceof WP_Post ) {
+
+		// The id must resolve to an actual post or page — the only types the
+		// search tools surface. Without this, a model-named id could resolve
+		// a plugin's non-public CPT row, whose `publish` status would satisfy
+		// the viewability check below even though the type is never queryable.
+		if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
 			return null;
 		}
+
+		// A publicly viewable post is public; anything else needs read authorization.
+		if ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $entity_id ) ) {
+			return null;
+		}
+
 		return array(
 			'id'       => $entity_id,
 			'type'     => $post->post_type,
@@ -646,9 +668,16 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 		if ( ! $comment instanceof WP_Comment ) {
 			return null;
 		}
-		$meta        = openstation_ai_get_meta( 'comment', $entity_id );
+
+		// An approved comment is public; unapproved/spam needs moderation rights.
+		$can_moderate = current_user_can( 'moderate_comments' );
+		if ( '1' !== $comment->comment_approved && ! $can_moderate ) {
+			return null;
+		}
+
+		$meta        = $can_moderate ? openstation_ai_get_meta( 'comment', $entity_id ) : null;
 		$parent_post = get_post( $comment->comment_post_ID );
-		return array(
+		$entity      = array(
 			'id'         => $entity_id,
 			'type'       => 'comment',
 			'excerpt'    => openstation_ai_search_excerpt( $comment->comment_content ),
@@ -656,10 +685,18 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 			'post_title' => $parent_post ? wp_strip_all_tags( $parent_post->post_title ) : '',
 			'post_url'   => $parent_post ? (string) get_permalink( $parent_post ) : '',
 			'url'        => (string) get_comment_link( $comment ),
-			'edit_url'   => admin_url( 'comment.php?action=editcomment&c=' . $entity_id ),
-			'harmful'    => $meta ? (bool) ( $meta['harmful'] ?? false ) : false,
-			'spam'       => $meta ? (bool) ( $meta['spam'] ?? false ) : false,
+			'edit_url'   => current_user_can( 'edit_comment', $entity_id )
+				? admin_url( 'comment.php?action=editcomment&c=' . $entity_id )
+				: '',
 		);
+
+		// Moderation verdicts are for moderators only.
+		if ( $can_moderate ) {
+			$entity['harmful'] = $meta ? (bool) ( $meta['harmful'] ?? false ) : false;
+			$entity['spam']    = $meta ? (bool) ( $meta['spam'] ?? false ) : false;
+		}
+
+		return $entity;
 	}
 
 	return null;

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -580,4 +580,207 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 		$this->assertSame( '', (string) ( $result['post_title'] ?? '' ), 'The parent title must not be echoed back.' );
 		$this->assertArrayHasKey( 'error', $result );
 	}
+
+	/**
+	 * A comment hanging off a non-public CPT row is internal plugin data —
+	 * WooCommerce order notes are comments on `shop_order`. The parent's
+	 * `publish` status resolves `read_post` to plain `read`, so the type has
+	 * to be gated separately or the note text and the row's title leak.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_comment_on_non_public_cpt_parent() {
+		register_post_type( 'os_secret_cpt', array( 'public' => false ) );
+		$post_id    = self::factory()->post->create(
+			array(
+				'post_type'   => 'os_secret_cpt',
+				'post_status' => 'publish',
+				'post_title'  => 'Internal record',
+			)
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Refunded via gateway, ref 8812.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'comment', $comment_id ),
+			'A non-public CPT parent must not leak through its comments.'
+		);
+
+		_unregister_post_type( 'os_secret_cpt' );
+	}
+
+	/**
+	 * The same row is out of the comment-search corpus, and out of `total`
+	 * with it — a keyword that matches only there must report nothing.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 */
+	public function test_search_comments_excludes_non_public_cpt_parent() {
+		register_post_type( 'os_secret_cpt', array( 'public' => false ) );
+		$post_id    = self::factory()->post->create(
+			array( 'post_type' => 'os_secret_cpt', 'post_status' => 'publish' )
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Refunded via gateway, saffron ref 8812.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'saffron', 'offset' => 0 )
+		);
+
+		$this->assertNotContains( $comment_id, wp_list_pluck( $result['items'], 'id' ) );
+		$this->assertSame( 0, $result['total'], 'The row must not be counted either.' );
+
+		_unregister_post_type( 'os_secret_cpt' );
+	}
+
+	/**
+	 * A password-protected parent is `publish`, so only the clause filter
+	 * keeps it out. `total` has to drop with `items` or the counter answers
+	 * keyword questions about a body the caller cannot read.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 */
+	public function test_search_comments_excludes_comment_on_password_protected_parent() {
+		$post_id    = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_title'    => 'Members only',
+			)
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'The saffron tip was the best part.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'saffron', 'offset' => 0 )
+		);
+
+		$this->assertNotContains( $comment_id, wp_list_pluck( $result['items'], 'id' ) );
+		$this->assertSame(
+			0,
+			$result['total'],
+			'A sealed parent must not leave its comments countable.'
+		);
+	}
+
+	/**
+	 * The gates live in the query, so a batch is never thinned after the
+	 * fact: `count` agrees with `items`, and a readable comment is not
+	 * displaced from its page by a hidden neighbour.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 */
+	public function test_search_comments_batch_is_not_thinned_by_hidden_rows() {
+		$sealed_id = self::factory()->post->create(
+			array( 'post_status' => 'publish', 'post_password' => 'hunter2' )
+		);
+		foreach ( range( 1, 12 ) as $n ) {
+			self::factory()->comment->create(
+				array(
+					'comment_post_ID'  => $sealed_id,
+					'comment_approved' => '1',
+					'comment_content'  => "Hidden saffron note {$n}.",
+				)
+			);
+		}
+
+		$public_id  = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$visible_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $public_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Public saffron note.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'saffron', 'offset' => 0 )
+		);
+
+		$this->assertSame(
+			array( $visible_id ),
+			wp_list_pluck( $result['items'], 'id' ),
+			'Twelve hidden rows must not push the one readable comment off the first page.'
+		);
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 1, $result['total'] );
+		$this->assertFalse( $result['has_more'] );
+	}
+
+	/**
+	 * The `by post` tool refuses a non-public CPT parent for the same reason
+	 * the entity card does.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments_by_post
+	 */
+	public function test_search_comments_by_post_refuses_non_public_cpt_parent() {
+		register_post_type( 'os_secret_cpt', array( 'public' => false ) );
+		$post_id = self::factory()->post->create(
+			array( 'post_type' => 'os_secret_cpt', 'post_status' => 'publish' )
+		);
+		self::factory()->comment->create(
+			array( 'comment_post_ID' => $post_id, 'comment_approved' => '1' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments_by_post',
+			array( 'post_id' => $post_id, 'query' => '', 'offset' => 0 )
+		);
+
+		$this->assertSame( 0, $result['count'] );
+		$this->assertArrayHasKey( 'error', $result );
+
+		_unregister_post_type( 'os_secret_cpt' );
+	}
+
+	/**
+	 * A comment whose parent post is gone resolves to nothing rather than to
+	 * whatever `get_post( 0 )` hands back from the global.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_orphaned_comment() {
+		$post_id    = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$comment_id = self::factory()->comment->create(
+			array( 'comment_post_ID' => $post_id, 'comment_approved' => '1' )
+		);
+		wp_update_comment(
+			array( 'comment_ID' => $comment_id, 'comment_post_ID' => 0 )
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull( openstation_ai_search_build_entity( 'comment', $comment_id ) );
+
+		unset( $GLOBALS['post'] );
+	}
 }

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -519,62 +519,6 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The search corpus is gated the same way the entity card is. Otherwise
-	 * the model reads the protected body and repeats it in the answer prose,
-	 * which is the same disclosure by a longer route.
-	 *
-	 * @covers ::openstation_ai_search_fetch_posts
-	 */
-	public function test_search_posts_excludes_password_protected_post_for_subscriber() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_status'   => 'publish',
-				'post_password' => 'hunter2',
-				'post_title'    => 'Paella for members',
-				'post_content'  => 'A Valencian rice dish with saffron and rabbit.',
-			)
-		);
-
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
-
-		$result = openstation_ai_search_dispatch_tool(
-			'search_posts',
-			array( 'query' => 'paella', 'offset' => 0 )
-		);
-
-		$this->assertNotContains(
-			$post_id,
-			wp_list_pluck( $result['items'], 'id' ),
-			'A protected post must not reach the model as a searchable excerpt.'
-		);
-	}
-
-	/**
-	 * An editor searching the same corpus still gets the protected post.
-	 *
-	 * @covers ::openstation_ai_search_fetch_posts
-	 */
-	public function test_search_posts_includes_password_protected_post_for_editor() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_status'   => 'publish',
-				'post_password' => 'hunter2',
-				'post_title'    => 'Paella for members',
-				'post_content'  => 'A Valencian rice dish with saffron and rabbit.',
-			)
-		);
-
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
-
-		$result = openstation_ai_search_dispatch_tool(
-			'search_posts',
-			array( 'query' => 'paella', 'offset' => 0 )
-		);
-
-		$this->assertContains( $post_id, wp_list_pluck( $result['items'], 'id' ) );
-	}
-
-	/**
 	 * Comment search carries the parent's title and permalink on every item,
 	 * so it inherits the parent's read gate.
 	 *
@@ -603,6 +547,11 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 			$comment_id,
 			wp_list_pluck( $result['items'], 'id' ),
 			'A private parent must not leak its title through comment search.'
+		);
+		$this->assertSame(
+			0,
+			$result['total'],
+			'The comment must not inflate total either — that counter reports what items hides.'
 		);
 	}
 

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -201,4 +201,162 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 			'A duplicate label means a resumable tool fell through to the default post wording.'
 		);
 	}
+
+	/**
+	 * The model can name any id; a Subscriber must not read a private post
+	 * through it. The entity builder re-checks authorization instead of
+	 * trusting the model-supplied id.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_private_post_from_subscriber() {
+		$post_id = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret plans' )
+		);
+
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'post', $post_id ),
+			'A Subscriber must not read a private post through the entity builder.'
+		);
+	}
+
+	/**
+	 * A draft/pending/future post is equally withheld — the guard keys off
+	 * read authorization, not the single `private` status.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_draft_post_from_subscriber() {
+		$post_id = self::factory()->post->create(
+			array( 'post_status' => 'draft', 'post_title' => 'Unpublished' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull( openstation_ai_search_build_entity( 'post', $post_id ) );
+	}
+
+	/**
+	 * An administrator, who can read private content, still gets the record.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_returns_private_post_for_administrator() {
+		$post_id = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret plans' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$entity = openstation_ai_search_build_entity( 'post', $post_id );
+		$this->assertIsArray( $entity );
+		$this->assertSame( 'private', $entity['status'] );
+		$this->assertSame( 'Secret plans', $entity['title'] );
+	}
+
+	/**
+	 * A model-named id resolving to a non-public CPT row is withheld even
+	 * though its status is `publish` — the branch pins the actual post type
+	 * to post/page, because a non-viewable type's public status would
+	 * otherwise satisfy both the viewability check and `read_post`.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_non_public_cpt_row() {
+		register_post_type( 'os_secret_cpt', array( 'public' => false ) );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'os_secret_cpt',
+				'post_status'  => 'publish',
+				'post_title'   => 'Internal record',
+				'post_content' => 'Plugin-private data.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'post', $post_id ),
+			'A non-public CPT row must not be readable through the entity builder.'
+		);
+
+		_unregister_post_type( 'os_secret_cpt' );
+	}
+
+	/**
+	 * An unapproved comment (its content and moderation verdicts) is
+	 * withheld from a Subscriber.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_unapproved_comment_from_subscriber() {
+		$post_id    = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '0',
+				'comment_content'  => 'Pending moderation.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'comment', $comment_id ),
+			'A Subscriber must not read an unapproved comment through the entity builder.'
+		);
+	}
+
+	/**
+	 * A non-moderator viewing an approved comment gets the public record but
+	 * neither the moderation verdicts nor the wp-admin edit link.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_suppresses_moderation_fields_for_non_moderator() {
+		$post_id    = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Great write-up.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$entity = openstation_ai_search_build_entity( 'comment', $comment_id );
+		$this->assertIsArray( $entity );
+		$this->assertArrayNotHasKey( 'harmful', $entity, 'Verdicts are moderator-only.' );
+		$this->assertArrayNotHasKey( 'spam', $entity, 'Verdicts are moderator-only.' );
+		$this->assertSame( '', $entity['edit_url'], 'The edit link needs edit_comment.' );
+	}
+
+	/**
+	 * A moderator viewing an approved comment still sees the verdicts and
+	 * the edit link — the gate withholds nothing they are entitled to.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_exposes_moderation_fields_to_moderator() {
+		$post_id    = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Great write-up.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$entity = openstation_ai_search_build_entity( 'comment', $comment_id );
+		$this->assertIsArray( $entity );
+		$this->assertArrayHasKey( 'harmful', $entity );
+		$this->assertArrayHasKey( 'spam', $entity );
+		$this->assertNotSame( '', $entity['edit_url'] );
+	}
 }

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -260,8 +260,8 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 	/**
 	 * A model-named id resolving to a non-public CPT row is withheld even
 	 * though its status is `publish` — the branch pins the actual post type
-	 * to post/page, because a non-viewable type's public status would
-	 * otherwise satisfy both the viewability check and `read_post`.
+	 * to post/page, because `read_post` on a `publish` status maps to plain
+	 * `read`, which every logged-in user holds.
 	 *
 	 * @covers ::openstation_ai_search_build_entity
 	 */
@@ -358,5 +358,234 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'harmful', $entity );
 		$this->assertArrayHasKey( 'spam', $entity );
 		$this->assertNotSame( '', $entity['edit_url'] );
+	}
+
+	/**
+	 * A published post is publicly viewable even when it carries a password,
+	 * and every logged-in user passes `read_post` on it — so the password
+	 * gate has to be asked separately or the body leaks in the excerpt.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_password_protected_post_from_subscriber() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_title'    => 'Members only',
+				'post_content'  => 'The members-only body.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'post', $post_id ),
+			'A Subscriber without the password must not read a protected post.'
+		);
+	}
+
+	/**
+	 * Being able to edit the post is the other way past the password, which
+	 * is how core answers the same question.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_returns_password_protected_post_to_editor() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_title'    => 'Members only',
+				'post_content'  => 'The members-only body.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$entity = openstation_ai_search_build_entity( 'post', $post_id );
+		$this->assertIsArray( $entity );
+		$this->assertStringContainsString( 'members-only body', $entity['excerpt'] );
+	}
+
+	/**
+	 * Approval is not publication: an approved comment outlives its post
+	 * being switched to private, and the record carries the parent's title
+	 * and permalink. Naming a comment id must not walk around the post gate.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_comment_on_private_parent() {
+		$post_id    = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret plans' )
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Looks good to me.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'comment', $comment_id ),
+			'A private parent must not leak its title through an approved comment.'
+		);
+	}
+
+	/**
+	 * The same comment on a draft parent, same answer — the gate keys off
+	 * read authorization on the parent, not one status.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_withholds_comment_on_draft_parent() {
+		$post_id    = self::factory()->post->create(
+			array( 'post_status' => 'draft', 'post_title' => 'Unpublished' )
+		);
+		$comment_id = self::factory()->comment->create(
+			array( 'comment_post_ID' => $post_id, 'comment_approved' => '1' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull( openstation_ai_search_build_entity( 'comment', $comment_id ) );
+	}
+
+	/**
+	 * An administrator reads private content, so the same comment still
+	 * resolves for them — the gate withholds nothing they are entitled to.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_returns_comment_on_private_parent_for_administrator() {
+		$post_id    = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret plans' )
+		);
+		$comment_id = self::factory()->comment->create(
+			array( 'comment_post_ID' => $post_id, 'comment_approved' => '1' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$entity = openstation_ai_search_build_entity( 'comment', $comment_id );
+		$this->assertIsArray( $entity );
+		$this->assertSame( 'Secret plans', $entity['post_title'] );
+	}
+
+	/**
+	 * The search corpus is gated the same way the entity card is. Otherwise
+	 * the model reads the protected body and repeats it in the answer prose,
+	 * which is the same disclosure by a longer route.
+	 *
+	 * @covers ::openstation_ai_search_fetch_posts
+	 */
+	public function test_search_posts_excludes_password_protected_post_for_subscriber() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_title'    => 'Paella for members',
+				'post_content'  => 'A Valencian rice dish with saffron and rabbit.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_posts',
+			array( 'query' => 'paella', 'offset' => 0 )
+		);
+
+		$this->assertNotContains(
+			$post_id,
+			wp_list_pluck( $result['items'], 'id' ),
+			'A protected post must not reach the model as a searchable excerpt.'
+		);
+	}
+
+	/**
+	 * An editor searching the same corpus still gets the protected post.
+	 *
+	 * @covers ::openstation_ai_search_fetch_posts
+	 */
+	public function test_search_posts_includes_password_protected_post_for_editor() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_title'    => 'Paella for members',
+				'post_content'  => 'A Valencian rice dish with saffron and rabbit.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_posts',
+			array( 'query' => 'paella', 'offset' => 0 )
+		);
+
+		$this->assertContains( $post_id, wp_list_pluck( $result['items'], 'id' ) );
+	}
+
+	/**
+	 * Comment search carries the parent's title and permalink on every item,
+	 * so it inherits the parent's read gate.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 */
+	public function test_search_comments_excludes_comment_on_private_parent() {
+		$post_id    = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret plans' )
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Absolutely loved the saffron tip.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'saffron', 'offset' => 0 )
+		);
+
+		$this->assertNotContains(
+			$comment_id,
+			wp_list_pluck( $result['items'], 'id' ),
+			'A private parent must not leak its title through comment search.'
+		);
+	}
+
+	/**
+	 * `search_comments_by_post` takes its post id from the model, so it is
+	 * untrusted the same way an entity id is.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments_by_post
+	 */
+	public function test_search_comments_by_post_refuses_unreadable_parent() {
+		$post_id = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret plans' )
+		);
+		self::factory()->comment->create(
+			array( 'comment_post_ID' => $post_id, 'comment_approved' => '1' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments_by_post',
+			array( 'post_id' => $post_id, 'query' => '', 'offset' => 0 )
+		);
+
+		$this->assertSame( 0, $result['count'] );
+		$this->assertSame( '', (string) ( $result['post_title'] ?? '' ), 'The parent title must not be echoed back.' );
+		$this->assertArrayHasKey( 'error', $result );
 	}
 }


### PR DESCRIPTION
## What it does

Fixes a missing-authorization disclosure in the AI Copilot search endpoint (reported via a Wordfence advisory): a Subscriber could read the title, status, date, permalink and a 300-character excerpt of **any private, draft, pending or future post**, and the content plus AI-moderation verdicts of **unapproved and spam comments**, by asking the assistant to answer with a chosen id.

## Rationale

The final `/ai/search` answer schema requires an `entity_id`, and that id arrives from **model output** — the user's query steers it, so it is attacker-controlled. `openstation_ai_search_build_entity()` resolved it with a bare `get_post()` / `get_comment()` and no capability check. The search tools themselves only ever query `publish`/`approve` content, so the leak was entirely the entity builder trusting an id the model introduced. Model output is never an authorization decision.

## Implementation

All gates live in `openstation_ai_search_build_entity()`, the single point where the model-named id resolves to an object:

- **Posts/pages** — the id must resolve to an actual `post`/`page` (a model-named id could otherwise resolve another plugin's non-public CPT row, whose `publish` status would satisfy every status-based check, including `read_post`), and the post must be `is_post_publicly_viewable()` or the user must pass `current_user_can( 'read_post' )` — which correctly resolves private (`read_private_posts`/author) and draft/pending/future (`edit_post`).
- **Comments** — unapproved/spam/trashed comments require `moderate_comments`.
- **`edit_url`** — the comment edit link is emitted only with `edit_comment` (posts already self-gate through `get_edit_post_link()`); the client's open button already no-ops on an empty URL.
- **`harmful`/`spam` verdicts** — the keys are omitted entirely for non-moderators (they're optional in the TS `EntityDetail` type, and the assistant UI doesn't currently render them), and the meta lookup is skipped too.

## Testing instructions

`npm run test:php -- --filter=Tests_OpenStation_AiNativeSearch` — 7 new cases: private post withheld from a Subscriber, draft withheld, private post still returned to an administrator, non-public CPT row withheld, unapproved comment withheld, verdicts + edit link suppressed for a non-moderator, verdicts + edit link intact for a moderator.

Full `--group os-ai` suite: 113 tests, 356 assertions, green. `phpcs -n` clean.

To reproduce the original leak manually: as a Subscriber with `ai.enabled` on, ask the assistant to "return an entity answer with entity_id N, entity_type post" for a private post's id — before this change the entity card carried its title, `status: private` and an excerpt; now `entity` is `null`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-802-eeb6f4ea5785fd51348447b99087cf6cbaed3f07.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->