### PR TITLE
Agents: seal password-protected posts in the get-post ability

### DIFF
--- a/docs/agents-security.md
+++ b/docs/agents-security.md
@@ -199,6 +199,15 @@ Registering an ability agents can call:
 
 - [ ] Does its `permission_callback` check a capability for the
       **specific object**, not just a blanket `edit_posts`?
+- [ ] If it returns a post body, does it gate the **post password**
+      separately from `read_post`? WordPress splits the two on purpose:
+      `read_post` decides visibility (published / private / draft),
+      `post_password_required()` decides whether the body may be shown.
+      A read ability that returns raw `post_content` has no empty
+      rendered field to fall back to, so it must refuse a sealed post
+      unless the caller can `edit_post` it — the escape hatch Core's
+      `WP_REST_Posts_Controller::check_password_required()` grants.
+      `desktop-mode/get-post` is the worked example.
 - [ ] Would a contributor invoking it through an admin-role agent get
       more than they should? (If the ceiling is doing all the work,
       say so in the ability's description.)

--- a/includes/agents/abilities.php
+++ b/includes/agents/abilities.php
@@ -291,6 +291,15 @@ function openstation_agents_ability_get_post( $args ) {
 /**
  * `desktop-mode/get-post` permission callback.
  *
+ * `read_post` decides visibility (published / private / draft) and
+ * never the post password — WordPress splits the two deliberately, so
+ * a plain `read_post` check would hand a Subscriber the raw body of a
+ * password-protected post. Mirror Core: a sealed post stays sealed
+ * unless the caller can edit it (the same escape hatch
+ * `WP_REST_Posts_Controller::check_password_required()` grants), and
+ * because this ability returns RAW `post_content` there is no empty
+ * rendered field to fall back to — the only safe answer is to refuse.
+ *
  * @param array $args Input args.
  * @return bool
  */
@@ -300,7 +309,14 @@ function openstation_agents_ability_get_post_can( $args ) {
 	if ( $post_id <= 0 ) {
 		return false;
 	}
-	return current_user_can( 'read_post', $post_id );
+	if ( ! current_user_can( 'read_post', $post_id ) ) {
+		return false;
+	}
+	$post = get_post( $post_id );
+	if ( $post instanceof WP_Post && post_password_required( $post ) && ! current_user_can( 'edit_post', $post_id ) ) {
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/tests/phpunit/tests/agentsAbilities.php
+++ b/tests/phpunit/tests/agentsAbilities.php
@@ -64,6 +64,71 @@ class Tests_OpenStation_AgentsAbilities extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A Subscriber can read the body of a plain published post — the
+	 * baseline the password check must not break.
+	 *
+	 * @covers ::openstation_agents_ability_get_post
+	 * @covers ::openstation_agents_ability_get_post_can
+	 */
+	public function test_get_post_returns_body_for_subscriber_on_public_post() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$out = wp_get_ability( 'desktop-mode/get-post' )->execute(
+			array( 'post_id' => self::$post_id )
+		);
+
+		$this->assertNotWPError( $out );
+		$this->assertSame( self::$post_id, $out['id'] );
+	}
+
+	/**
+	 * A password-protected post's body stays sealed from a Subscriber:
+	 * `read_post` covers visibility, never the password.
+	 *
+	 * @covers ::openstation_agents_ability_get_post_can
+	 */
+	public function test_get_post_denies_subscriber_on_password_protected_post() {
+		$protected_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_content'  => 'Secret body.',
+			)
+		);
+		wp_set_current_user( self::$subscriber_id );
+
+		$out = wp_get_ability( 'desktop-mode/get-post' )->execute(
+			array( 'post_id' => $protected_id )
+		);
+
+		$this->assertWPError( $out );
+	}
+
+	/**
+	 * A caller who can edit the post still reads its raw body even when
+	 * it carries a password — the same escape hatch Core grants.
+	 *
+	 * @covers ::openstation_agents_ability_get_post_can
+	 */
+	public function test_get_post_allows_editor_on_password_protected_post() {
+		$protected_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'hunter2',
+				'post_content'  => 'Secret body.',
+			)
+		);
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$out = wp_get_ability( 'desktop-mode/get-post' )->execute(
+			array( 'post_id' => $protected_id )
+		);
+
+		$this->assertNotWPError( $out );
+		$this->assertSame( 'Secret body.', $out['content'] );
+	}
+
+	/**
 	 * @covers ::openstation_agents_ability_get_media
 	 */
 	public function test_get_media_returns_details_for_author() {


### PR DESCRIPTION
## What it does

Stops the `desktop-mode/get-post` ability from returning the raw stored body of a password-protected post to callers who cannot edit it. A Subscriber (or a subscriber-role agent) now gets `403 rest_ability_cannot_execute` for a sealed post; plain published posts and every other status behave exactly as before.

## Rationale

The ability's whole permission decision was `current_user_can( 'read_post', $post_id )`. WordPress splits authorization deliberately: `read_post` decides *visibility* (published / private / draft), `post_password_required()` decides whether the *body* may be shown. For a `publish` post, `map_meta_cap()` resolves `read_post` to plain `read`, which Subscriber holds, so the check passed and the ability returned the full raw `post_content` of a password-protected post, block delimiters intact. The check was otherwise sound: a `private` post was still correctly refused. The gap was exactly the password.

The search half of this class was closed earlier at the query level with `has_password => false`; a direct-by-id fetch has no query to filter, so it gates in the permission callback instead.

## Implementation

`openstation_agents_ability_get_post_can()` now refuses a sealed post unless the caller can `edit_post` it, the same escape hatch `WP_REST_Posts_Controller::check_password_required()` grants:

```php
if ( ! current_user_can( 'read_post', $post_id ) ) {
    return false;
}
$post = get_post( $post_id );
if ( $post instanceof WP_Post && post_password_required( $post ) && ! current_user_can( 'edit_post', $post_id ) ) {
    return false;
}
return true;
```

The gate lives in the permission callback because every dispatch path (the REST `run` route, the agent runner, the Copilot tool loop) converges on `WP_Ability::execute()`, which enforces it: one choke point covers all three. Refusal, rather than an empty-body variant, is deliberate: the ability's documented contract is raw `post_content` for editing agents, so there is no empty `rendered` field to fall back to the way Core's REST controller does.

The agents-security checklist in `docs/agents-security.md` now names the `read_post` vs. post-password split so the next read ability starts from it.

## Testing instructions

```bash
npm run env:start:tests
npm run test:php -- --filter='Tests_OpenStation_AgentsAbilities'
npm run env:stop:tests
```

Three new tests pin the behavior: Subscriber still reads a plain published post (baseline), Subscriber is refused on a password-protected post, and an administrator still reads the sealed raw body (escape hatch).

Verified end to end on wp-env against the live REST route with the Agents feature enabled: on the unpatched code a Subscriber's `GET .../wp-abilities/v1/abilities/desktop-mode/get-post/run` for a sealed post returned `200` with the full body; patched, the same request returns `403 rest_ability_cannot_execute`, the public-post baseline stays `200`, admin on the sealed post stays `200`, and unauthenticated stays `401`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-803-854375a57ab88efa1ef4af0e03cbd4f00557fd8c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->