### PR TITLE
AI Copilot: gate comment search on parent-post readability

### DIFF
--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3067,6 +3067,8 @@ Programmatic access to the AI Copilot — same endpoint the built-in overlay tal
 
 The built-in content tools (`search_posts`, `search_pages`, `search_comments`, `search_comments_by_post`) run WordPress's native keyword search — the model derives a `query` from the user's request and the tools return matching titles + excerpts. (Posts, pages, and terms are no longer pre-analyzed; comment spam scoring is the only automatic AI analysis.) When you continue an exhausted search with `resumeTool` / `startOffset`, the original query is reused automatically.
 
+Results are scoped to what the requesting user may read. The comment tools drop every comment whose parent post the caller cannot access (private, draft, or password-protected parents, and non-viewable post types), and `search_comments_by_post` returns an empty batch — without the parent title — when the target post itself is unreadable. As in Core's comments REST controller, this filtering happens per row after the query, so a batch can carry fewer items than `total` implies; treat `total` / `has_more` as pagination hints, not as an exact count of readable matches. The final `entity` record applies the same readability check to the model-chosen id, resolving unreadable entities to `null` exactly like nonexistent ones.
+
 ```javascript
 const res = await wp.os.ai.ask( 'where do I manage categories?' );
 // res = { answer_type: 'navigation', message: '…', admin_links: [ … ], request_id: '…' }

--- a/includes/ai-copilot/abilities.php
+++ b/includes/ai-copilot/abilities.php
@@ -241,7 +241,7 @@ function openstation_ai_register_abilities() {
 		'desktop-mode/search-comments',
 		array(
 			'label'               => __( 'Search comments', 'desktop-mode' ),
-			'description'         => 'Keyword-searches approved WordPress comments across ALL posts by their text (WordPress native search). Use this when the user remembers something a reader said but does not know which post it was on. Pass the distinctive words from the comment as `query`. Returns up to 10 matching comments with an excerpt, parent post title, and URLs. If has_more is true, call again with the next offset.',
+			'description'         => 'Keyword-searches approved WordPress comments by their text (WordPress native search), across all posts the requesting user is allowed to read — comments on private, draft, or password-protected posts the user cannot access are excluded. Use this when the user remembers something a reader said but does not know which post it was on. Pass the distinctive words from the comment as `query`. Returns up to 10 matching comments with an excerpt, parent post title, and URLs. If has_more is true, call again with the next offset.',
 			'category'            => OPENSTATION_AI_ABILITY_CATEGORY,
 			'input_schema'        => $query_offset_input,
 			'output_schema'       => $search_output,
@@ -257,7 +257,7 @@ function openstation_ai_register_abilities() {
 		'desktop-mode/search-comments-by-post',
 		array(
 			'label'               => __( 'Search comments on a post', 'desktop-mode' ),
-			'description'         => 'Keyword-searches approved comments on a SPECIFIC post by its WordPress ID. Use this when you have already identified a post (via search-posts) and the user\'s query also mentions something a reader said on that post — e.g. "I remember a comment on my Málaga post asking about the Alcazaba at night." Call search-posts first to find the post ID, then call this tool with that ID and the distinctive words as `query`. Much more precise than search-comments when the parent post is known. If has_more is true, call again with the next offset.',
+			'description'         => 'Keyword-searches approved comments on a SPECIFIC post by its WordPress ID (the post must be readable by the requesting user; an unreadable or nonexistent post returns an empty result). Use this when you have already identified a post (via search-posts) and the user\'s query also mentions something a reader said on that post — e.g. "I remember a comment on my Málaga post asking about the Alcazaba at night." Call search-posts first to find the post ID, then call this tool with that ID and the distinctive words as `query`. Much more precise than search-comments when the parent post is known. If has_more is true, call again with the next offset.',
 			'category'            => OPENSTATION_AI_ABILITY_CATEGORY,
 			'input_schema'        => array(
 				'type'                 => 'object',

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -459,7 +459,13 @@ function openstation_ai_search_excerpt( $content ) {
  *
  * - a password-protected parent is readable only by someone who could edit it
  *   (there is no way to supply the password over the ability's GET dispatch);
- * - a non-published parent needs the `read_post` capability for that post.
+ * - a publicly viewable parent (public status AND viewable post type) is
+ *   readable by anyone the ability admits;
+ * - a parent whose post TYPE is not viewable (an internal/admin-only CPT)
+ *   needs `edit_post` — `read_post` cannot stand in, because a public status
+ *   resolves it to plain `read` whatever the type's visibility, which is how
+ *   Core's REST layer needs its own post-type gate too;
+ * - any other parent (private, draft, pending, …) needs `read_post`.
  *
  * @param int|WP_Post $post Post ID or object.
  * @return bool
@@ -480,11 +486,16 @@ function openstation_ai_can_read_post( $post ) {
 		return false;
 	}
 
-	if ( 'publish' !== $post->post_status && ! current_user_can( 'read_post', $post->ID ) ) {
-		return false;
+	if ( is_post_publicly_viewable( $post ) ) {
+		return true;
 	}
 
-	return true;
+	$post_type = get_post_type_object( $post->post_type );
+	if ( ! $post_type || ! is_post_type_viewable( $post_type ) ) {
+		return current_user_can( 'edit_post', $post->ID );
+	}
+
+	return current_user_can( 'read_post', $post->ID );
 }
 
 /**
@@ -698,6 +709,16 @@ function openstation_ai_search_fetch_comments_by_post( $post_id, $query, $offset
  * verdict when the comment-moderation analysis happens to have run, but
  * its absence never blocks the entity from being returned.
  *
+ * The id arrives from the MODEL's final answer, and model output is
+ * untrusted — a search turn can be driven by attacker-controlled content, so
+ * an injected instruction could name an entity the search tools never
+ * surfaced. Hydration therefore re-checks readability itself instead of
+ * trusting that the id came out of a filtered tool result: posts/pages go
+ * through {@see openstation_ai_can_read_post()}, comments additionally
+ * require approved status (or `edit_comment`), mirroring Core's
+ * `WP_REST_Comments_Controller::check_read_permission()`. Unreadable ids
+ * resolve to null, indistinguishable from nonexistent ones.
+ *
  * @param string $entity_type 'post' | 'page' | 'comment'.
  * @param int    $entity_id
  * @return array|null
@@ -707,7 +728,7 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 
 	if ( in_array( $entity_type, array( 'post', 'page' ), true ) ) {
 		$post = get_post( $entity_id );
-		if ( ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof WP_Post || ! openstation_ai_can_read_post( $post ) ) {
 			return null;
 		}
 		return array(
@@ -724,7 +745,10 @@ function openstation_ai_search_build_entity( $entity_type, $entity_id ) {
 
 	if ( 'comment' === $entity_type ) {
 		$comment = get_comment( $entity_id );
-		if ( ! $comment instanceof WP_Comment ) {
+		if ( ! $comment instanceof WP_Comment || ! openstation_ai_can_read_comment_parent( $comment ) ) {
+			return null;
+		}
+		if ( '1' !== (string) $comment->comment_approved && ! current_user_can( 'edit_comment', $entity_id ) ) {
 			return null;
 		}
 		$meta        = openstation_ai_get_meta( 'comment', $entity_id );

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -464,8 +464,13 @@ function openstation_ai_search_excerpt( $content ) {
  * comment text or the parent title. Mirrors Core's
  * `WP_REST_Comments_Controller::check_read_post_permission()`:
  *
- * - a password-protected parent is readable only by someone who could edit it
- *   (there is no way to supply the password over the ability's GET dispatch);
+ * - a password-protected parent needs the password satisfied or `edit_post`.
+ *   `post_password_required()` honours the `wp-postpass` cookie Core's
+ *   password form sets, and that is deliberate Core parity, not a gap: the
+ *   cookie only exists because the caller already entered the correct
+ *   password, and Core's comments controller reads the same cookie. The
+ *   ability itself has no password input, so a caller who never unlocked
+ *   the post front-end is refused;
  * - a publicly viewable parent (public status AND viewable post type) is
  *   readable by anyone the ability admits;
  * - a parent whose post TYPE is not viewable (an internal/admin-only CPT)

--- a/includes/ai-copilot/search.php
+++ b/includes/ai-copilot/search.php
@@ -447,6 +447,64 @@ function openstation_ai_search_excerpt( $content ) {
 }
 
 /**
+ * Whether the current user may read a post the comment tools are about to
+ * surface.
+ *
+ * A comment being `approved` is a moderation decision — it says nothing about
+ * who may see the discussion. An approved comment can hang on a private,
+ * draft, or password-protected post the caller cannot reach, so the comment
+ * search tools must gate on the PARENT POST's visibility before returning the
+ * comment text or the parent title. Mirrors Core's
+ * `WP_REST_Comments_Controller::check_read_post_permission()`:
+ *
+ * - a password-protected parent is readable only by someone who could edit it
+ *   (there is no way to supply the password over the ability's GET dispatch);
+ * - a non-published parent needs the `read_post` capability for that post.
+ *
+ * @param int|WP_Post $post Post ID or object.
+ * @return bool
+ */
+function openstation_ai_can_read_post( $post ) {
+	// An id of 0 must stay unreadable: get_post( 0 ) falls back to the global
+	// $post, which would judge an orphaned comment against an unrelated post.
+	if ( is_numeric( $post ) && (int) $post <= 0 ) {
+		return false;
+	}
+
+	$post = get_post( $post );
+	if ( ! $post instanceof WP_Post ) {
+		return false;
+	}
+
+	if ( post_password_required( $post ) && ! current_user_can( 'edit_post', $post->ID ) ) {
+		return false;
+	}
+
+	if ( 'publish' !== $post->post_status && ! current_user_can( 'read_post', $post->ID ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Whether the current user may read the post a comment is attached to.
+ *
+ * Used to drop comments on posts the caller cannot see from the comment
+ * search results. See {@see openstation_ai_can_read_post()}.
+ *
+ * @param int|WP_Comment $comment Comment ID or object.
+ * @return bool
+ */
+function openstation_ai_can_read_comment_parent( $comment ) {
+	$comment = get_comment( $comment );
+	if ( ! $comment instanceof WP_Comment ) {
+		return false;
+	}
+	return openstation_ai_can_read_post( (int) $comment->comment_post_ID );
+}
+
+/**
  * Keyword-searches approved comments across all posts with WordPress's
  * native comment search (`get_comments` `search=`).
  *
@@ -489,6 +547,12 @@ function openstation_ai_search_fetch_comments( $query, $offset ) {
 	if ( $parent_ids ) {
 		_prime_post_caches( $parent_ids, false, false );
 	}
+
+	// "Approved" is a moderation decision, not a visibility one: drop comments
+	// whose parent post the caller cannot read (private / draft / password),
+	// so the comment text and the parent title never leak. See
+	// openstation_ai_can_read_comment_parent().
+	$comments = array_values( array_filter( $comments, 'openstation_ai_can_read_comment_parent' ) );
 
 	$items = array();
 	foreach ( $comments as $comment ) {
@@ -551,6 +615,23 @@ function openstation_ai_search_fetch_comments_by_post( $post_id, $query, $offset
 			'total'    => 0,
 			'has_more' => false,
 			'error'    => 'post_id must be a positive integer.',
+		);
+	}
+
+	// Gate on the parent post's visibility before touching its comments or
+	// title: an approved comment on a private / password-protected post must
+	// not leak through the "by post" tool either. See
+	// openstation_ai_can_read_post().
+	if ( ! openstation_ai_can_read_post( $post_id ) ) {
+		return array(
+			'tool'     => 'search_comments_by_post',
+			'post_id'  => $post_id,
+			'offset'   => $offset,
+			'items'    => array(),
+			'count'    => 0,
+			'total'    => 0,
+			'has_more' => false,
+			'error'    => 'Post not found or not readable.',
 		);
 	}
 

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -336,4 +336,163 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 		$this->assertSame( 0, $result['count'] );
 		$this->assertArrayNotHasKey( 'post_title', $result, 'The private parent title must not leak.' );
 	}
+
+	/**
+	 * An orphaned comment (comment_post_ID of 0) is never readable — even
+	 * with a readable post in the global $post. get_post( 0 ) falls back to
+	 * that global, so without the explicit id guard the orphan would be
+	 * judged against an unrelated post and leak.
+	 *
+	 * @covers ::openstation_ai_can_read_post
+	 * @covers ::openstation_ai_can_read_comment_parent
+	 */
+	public function test_search_comments_hides_orphaned_comments_despite_global_post() {
+		$public_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$orphan    = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => 0,
+				'comment_approved' => '1',
+				'comment_content'  => 'Orphan marker driftwood with no parent post.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		// The trap the guard defuses: a readable post sitting in the global.
+		$GLOBALS['post'] = get_post( $public_id );
+		try {
+			$result = openstation_ai_search_dispatch_tool(
+				'search_comments',
+				array( 'query' => 'driftwood', 'offset' => 0 )
+			);
+		} finally {
+			unset( $GLOBALS['post'] );
+		}
+
+		$ids = wp_list_pluck( $result['items'], 'id' );
+		$this->assertNotContains( $orphan, $ids, 'An orphaned comment must not be judged against the global $post.' );
+	}
+
+	/**
+	 * A published post of a NON-VIEWABLE post type (an internal/admin-only
+	 * CPT) is not readable to a Subscriber: `publish` alone is not
+	 * visibility, and `read_post` resolves to plain `read` for any public
+	 * status, so the gate falls back to `edit_post` for such types.
+	 *
+	 * @covers ::openstation_ai_can_read_post
+	 */
+	public function test_search_comments_hides_comments_on_non_viewable_post_types() {
+		register_post_type(
+			'os_internal',
+			array(
+				'public'       => false,
+				'map_meta_cap' => true,
+			)
+		);
+
+		try {
+			$cpt_id = self::factory()->post->create(
+				array( 'post_type' => 'os_internal', 'post_status' => 'publish' )
+			);
+			$hidden = self::factory()->comment->create(
+				array(
+					'comment_post_ID'  => $cpt_id,
+					'comment_approved' => '1',
+					'comment_content'  => 'Internal marker backstage on an admin-only type.',
+				)
+			);
+
+			wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+			$result = openstation_ai_search_dispatch_tool(
+				'search_comments',
+				array( 'query' => 'backstage', 'offset' => 0 )
+			);
+			$this->assertNotContains(
+				$hidden,
+				wp_list_pluck( $result['items'], 'id' ),
+				'A Subscriber must not see comments on a non-viewable post type.'
+			);
+
+			wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+			$result = openstation_ai_search_dispatch_tool(
+				'search_comments',
+				array( 'query' => 'backstage', 'offset' => 0 )
+			);
+			$this->assertContains(
+				$hidden,
+				wp_list_pluck( $result['items'], 'id' ),
+				'Someone who can edit the post still sees its discussion.'
+			);
+		} finally {
+			_unregister_post_type( 'os_internal' );
+		}
+	}
+
+	/**
+	 * The entity builder re-checks readability on the id it is handed: the
+	 * id comes from the model's final answer, and model output is untrusted,
+	 * so a hidden id must hydrate to null exactly like a nonexistent one —
+	 * for the comment branch AND the post branch.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_hides_unreadable_targets_from_subscriber() {
+		$private_id     = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret roadmap' )
+		);
+		$hidden_comment = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $private_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'A comment on the secret roadmap.',
+			)
+		);
+		$password_id    = self::factory()->post->create(
+			array( 'post_status' => 'publish', 'post_password' => 'hunter2' )
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'comment', $hidden_comment ),
+			'A model-supplied comment id on a private post must not hydrate.'
+		);
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'post', $private_id ),
+			'A model-supplied private post id must not hydrate.'
+		);
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'post', $password_id ),
+			'A model-supplied password-protected post id must not hydrate.'
+		);
+	}
+
+	/**
+	 * Entity hydration also honours the comment's own moderation status —
+	 * an unapproved comment is only readable by someone who could edit it.
+	 *
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_build_entity_hides_unapproved_comments_from_non_moderators() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$pending = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '0',
+				'comment_content'  => 'A pending comment awaiting moderation.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		$this->assertNull(
+			openstation_ai_search_build_entity( 'comment', $pending ),
+			'A Subscriber must not hydrate an unapproved comment.'
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertIsArray(
+			openstation_ai_search_build_entity( 'comment', $pending ),
+			'A moderator still hydrates the pending comment.'
+		);
+	}
 }

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -288,9 +288,9 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A Subscriber must not read a comment on a PASSWORD-PROTECTED post
-	 * through `search_comments` — there is no way to supply the password over
-	 * the ability's GET dispatch.
+	 * A Subscriber who never satisfied the post password must not read a
+	 * comment on a PASSWORD-PROTECTED post through `search_comments` — the
+	 * ability itself has no password input.
 	 *
 	 * @covers ::openstation_ai_search_fetch_comments
 	 * @covers ::openstation_ai_can_read_comment_parent
@@ -317,6 +317,55 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 
 		$ids = wp_list_pluck( $result['items'], 'id' );
 		$this->assertNotContains( $hidden, $ids, 'A Subscriber must not see a comment on a password-protected post.' );
+	}
+
+	/**
+	 * A caller who HAS satisfied the post password — the `wp-postpass`
+	 * cookie Core's password form sets after the correct password is
+	 * entered — reads the discussion again. Deliberate Core parity, not a
+	 * bypass: `post_password_required()` honours that cookie everywhere,
+	 * including `WP_REST_Comments_Controller::check_read_post_permission()`,
+	 * and refusing cookie-holders would lock out readers the author gave
+	 * the password to.
+	 *
+	 * @covers ::openstation_ai_can_read_post
+	 * @covers ::openstation_ai_search_build_entity
+	 */
+	public function test_search_comments_honours_a_satisfied_post_password() {
+		$protected_id = self::factory()->post->create(
+			array( 'post_status' => 'publish', 'post_password' => 'hunter2' )
+		);
+		$comment_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $protected_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Unlocked marker greenhouse behind a password.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		// The cookie wp-login.php?action=postpass sets for the correct password.
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher = new PasswordHash( 8, true );
+
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( 'hunter2' );
+		try {
+			$result = openstation_ai_search_dispatch_tool(
+				'search_comments',
+				array( 'query' => 'greenhouse', 'offset' => 0 )
+			);
+			$entity = openstation_ai_search_build_entity( 'comment', $comment_id );
+		} finally {
+			unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+		}
+
+		$this->assertContains(
+			$comment_id,
+			wp_list_pluck( $result['items'], 'id' ),
+			'A caller who entered the post password reads its discussion, as on the front end.'
+		);
+		$this->assertIsArray( $entity, 'Entity hydration honours the satisfied password too.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/aiNativeSearch.php
+++ b/tests/phpunit/tests/aiNativeSearch.php
@@ -201,4 +201,139 @@ class Tests_OpenStation_AiNativeSearch extends WP_UnitTestCase {
 			'A duplicate label means a resumable tool fell through to the default post wording.'
 		);
 	}
+
+	/**
+	 * A Subscriber must not read a comment on a PRIVATE post through
+	 * `search_comments`. "Approved" is a moderation decision, not a grant of
+	 * visibility on the parent discussion.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 * @covers ::openstation_ai_can_read_comment_parent
+	 */
+	public function test_search_comments_hides_comments_on_private_posts_from_subscriber() {
+		$author_id  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$private_id = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_author' => $author_id )
+		);
+		$public_id  = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$hidden  = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $private_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Secret marker paellamarker on a private post.',
+			)
+		);
+		$visible = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $public_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Public marker paellamarker on a published post.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'paellamarker', 'offset' => 0 )
+		);
+
+		$ids = wp_list_pluck( $result['items'], 'id' );
+		$this->assertNotContains( $hidden, $ids, 'A Subscriber must not see a comment on a private post.' );
+		$this->assertContains( $visible, $ids, 'A comment on a published post is still returned.' );
+	}
+
+	/**
+	 * A Subscriber must not read a comment on a PASSWORD-PROTECTED post
+	 * through `search_comments` — there is no way to supply the password over
+	 * the ability's GET dispatch.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 * @covers ::openstation_ai_can_read_comment_parent
+	 */
+	public function test_search_comments_hides_comments_on_password_posts_from_subscriber() {
+		$protected_id = self::factory()->post->create(
+			array( 'post_status' => 'publish', 'post_password' => 'hunter2' )
+		);
+
+		$hidden = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $protected_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Secret marker walledgarden behind a password.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'walledgarden', 'offset' => 0 )
+		);
+
+		$ids = wp_list_pluck( $result['items'], 'id' );
+		$this->assertNotContains( $hidden, $ids, 'A Subscriber must not see a comment on a password-protected post.' );
+	}
+
+	/**
+	 * An Administrator, who holds `read_private_posts`, still finds comments
+	 * on private posts — the gate is per-caller readability, not a blanket
+	 * publish-only filter.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments
+	 * @covers ::openstation_ai_can_read_comment_parent
+	 */
+	public function test_search_comments_still_shows_private_comments_to_admin() {
+		$private_id = self::factory()->post->create( array( 'post_status' => 'private' ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $private_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Admin-visible marker paellamarker on a private post.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments',
+			array( 'query' => 'paellamarker', 'offset' => 0 )
+		);
+
+		$ids = wp_list_pluck( $result['items'], 'id' );
+		$this->assertContains( $comment_id, $ids, 'An administrator can read comments on private posts.' );
+	}
+
+	/**
+	 * `search_comments_by_post` on a private post returns nothing — and never
+	 * the parent title — for a Subscriber.
+	 *
+	 * @covers ::openstation_ai_search_fetch_comments_by_post
+	 * @covers ::openstation_ai_can_read_post
+	 */
+	public function test_search_comments_by_post_hides_private_post_from_subscriber() {
+		$private_id = self::factory()->post->create(
+			array( 'post_status' => 'private', 'post_title' => 'Secret roadmap' )
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $private_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'A comment on the secret roadmap.',
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$result = openstation_ai_search_dispatch_tool(
+			'search_comments_by_post',
+			array( 'post_id' => $private_id, 'query' => '', 'offset' => 0 )
+		);
+
+		$ids = wp_list_pluck( $result['items'], 'id' );
+		$this->assertNotContains( $comment_id, $ids, 'A Subscriber must not read comments on a private post.' );
+		$this->assertSame( 0, $result['count'] );
+		$this->assertArrayNotHasKey( 'post_title', $result, 'The private parent title must not leak.' );
+	}
 }


### PR DESCRIPTION
A Subscriber can no longer read comments attached to private, draft, or password-protected posts through the Copilot's comment search abilities.

`desktop-mode/search-comments` and `desktop-mode/search-comments-by-post` authorized on the comment's moderation status alone: `get_comments()` ran with `status => approve` and nothing about the parent post. Both abilities are read-only and REST-exposed, so Core dispatches them over `GET` to any logged-in user, who received the comment text and the private parent's title. Approval is a moderation decision about the comment; it has never meant the discussion is visible.

Comment results are now gated on the parent post's readability, mirroring Core's `WP_REST_Comments_Controller::check_read_post_permission()`:

- `search_comments` drops every row whose parent the caller cannot read. A password-protected parent requires the password satisfied or `edit_post` (`post_password_required()` honours the `wp-postpass` cookie Core's password form sets after the correct password is entered, matching Core's comments controller; the ability itself has no password input), a publicly viewable parent passes, a parent of a non-viewable post type (an internal/admin-only CPT) requires `edit_post` (for a public status, `read_post` resolves to plain `read`, so the capability alone cannot gate those), and any other parent requires `read_post`.
- `search_comments_by_post` refuses the whole request up front when the target post is not readable, returning an empty batch without the parent title, and with the same error shape for a nonexistent and an unreadable post.
- Orphaned comments (`comment_post_ID` of 0) are dropped rather than judged against the global `$post` that `get_post( 0 )` falls back to.
- The final `entity` record re-checks readability on the model-supplied id, for the comment branch and the post/page branch. Model output is untrusted (a search turn can be driven by attacker-controlled content), so hydration cannot assume the id came out of a filtered tool result. Unapproved comments hydrate only for callers with `edit_comment`. Unreadable ids resolve to `null`, indistinguishable from nonexistent ones.

The gate is per-caller, not a blanket publish filter: an administrator still finds comments on private posts. The abilities GET path and the Copilot's own search loop run through the same fetch handlers, so both are covered at the source. As in Core's comments controller, rows are filtered after the query, so `total` still counts all approved matches; the returned items and titles are what carry content. The ability descriptions and `docs/javascript-reference.md` document the caller-scoped filtering and the pagination semantics.

### Validation

- 8 regression tests: a Subscriber against private, password-protected, and non-viewable-CPT parents, an administrator still seeing private-post comments, the by-post tool on a private post returning no items and no title, the orphaned-comment guard against a seeded global `$post`, and entity hydration refusing unreadable posts, hidden comments, and unapproved comments.
- Full PHPUnit suite green: 3,044 tests, 23,091 assertions (13 pre-existing skips).
- Password, status, and post-type semantics verified line by line against Core's `WP_REST_Comments_Controller` as the reference behavior.
- `phpcs -n` clean on the touched source; `npm run build` produced no further diffs.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-804-d67113b9b81f491b32979fcb6ad0e2fcb8a2a6cf.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->

