### PR TITLE
My WordPress: gate the comment dossier on the window capability and parent-post readability

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -3722,7 +3722,19 @@ The window and its pinned icon are **titled "WP Explorer"**. Its *root folder* i
 apply_filters( 'openstation_my_wordpress_user_can_use', bool $can ): bool
 ```
 
-Gates icon registration and window registration in one shot. Default `current_user_can( 'edit_posts' )`. Return `false` to hide the entry point for a role; return `true` to opt a role back in.
+The module's one capability gate. Default `current_user_can( 'edit_posts' )`. Return `false` to close the module for a role; return `true` to opt a role back in.
+
+**This is a server-side authorization gate, not only a visibility one** — narrowing or widening it changes what a role can reach over REST. It decides:
+
+| Surface | Where |
+|---|---|
+| Whether the non-REST post-type bridge routes register at all — `desktop-mode/v1/post-type/<slug>` | `includes/my-wordpress/rest-post-type.php` |
+| The per-comment dossier route `desktop-mode/v1/comment-stats/<id>`, which then also checks that the caller can read the comment's parent post | `includes/my-wordpress/comment-stats.php` |
+| Whether the WooCommerce integration's boot config ships, so the client can reach the order / customer / product surfaces at all — those routes still enforce their own Woo capabilities on top | `includes/my-wordpress/integrations/woocommerce.php` |
+| Whether preview-action scripts registered by plugins are enqueued | `includes/my-wordpress/preview-actions.php` |
+| Whether Station Home offers the "WP Explorer" quick action | `apps/station-home/parts/snapshot.php` |
+
+It does **not** gate WP Explorer's own window or pinned launcher. The app declares `->capabilities( 'edit_posts' )` itself, so `true` here opens the surfaces above without opening the window — filter [`openstation_app_manifest`](#openstation_app_manifest--experimental-filter) with `$id === 'my-wordpress'` to move the window too.
 
 ### Removed — the legacy explorer window's filters
 

--- a/includes/my-wordpress/comment-stats.php
+++ b/includes/my-wordpress/comment-stats.php
@@ -9,13 +9,16 @@
  * is selected.
  *
  * Permissions, in gate order:
- *   - The route wears the same (filterable) gate as the My
- *     WordPress window: `openstation_my_wordpress_user_can_use()`,
- *     `edit_posts` by default.
+ *   - The route wears the module's authorization gate,
+ *     `openstation_my_wordpress_user_can_use()` — `edit_posts` by
+ *     default, filterable. (That gate does *not* decide WP Explorer's
+ *     window or launcher; the app declares its own capabilities. See
+ *     the helper's docblock in `window.php`.)
  *   - The caller must be able to read the comment's parent post —
  *     see `openstation_my_wordpress_can_read_comment_post()` — so a
- *     low-capability author cannot read comments on private or
- *     password-protected posts they can't otherwise see.
+ *     low-capability author cannot read comments on posts they can't
+ *     otherwise see: private, sealed behind a password, or of a post
+ *     type with no readable front end at all.
  *   - Past those two gates, the comment itself must be visible:
  *     approved, OR the user can `moderate_comments`, OR they're
  *     the comment author.
@@ -38,10 +41,11 @@ function openstation_my_wordpress_register_comment_stats_route() {
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'openstation_my_wordpress_comment_stats_callback',
 			'permission_callback' => static function () {
-				// The dossier is an author's tool: it wears the same
-				// filterable gate as the My WordPress window itself.
-				// Bare is_user_logged_in() let any subscriber read
-				// it (OPENSTA-155).
+				// The dossier is an author's tool, so it wears the
+				// module's authorization gate rather than a gate of its
+				// own. Bare is_user_logged_in() let any subscriber read
+				// it (OPENSTA-155). WP Explorer's window and launcher
+				// are gated separately, by the app's own capabilities.
 				return openstation_my_wordpress_user_can_use();
 			},
 			'args'                => array(
@@ -59,11 +63,33 @@ add_action( 'rest_api_init', 'openstation_my_wordpress_register_comment_stats_ro
 /**
  * Whether the current user may read the post a comment belongs to.
  *
- * Mirrors `WP_REST_Comments_Controller::check_read_post_permission()`:
- * a password-protected parent needs `edit_post`; any other parent
- * needs `read_post`. An orphaned comment (its post is gone) is
- * moderators-only. Without this, an approved comment on a private or
- * password-protected post read exactly like one on a public post.
+ * Three gates, in order:
+ *
+ *   1. **No parent at all.** An orphaned comment (`comment_post_ID` of
+ *      0, or a post since deleted) has nothing to authorize against, so
+ *      it is moderators-only.
+ *   2. **A sealed parent** needs `edit_post` — the escape hatch
+ *      `WP_REST_Posts_Controller::check_password_required()` grants.
+ *      Note `post_password_required()` reads the `wp-postpass` cookie:
+ *      a caller who has already entered the password is *not* looking at
+ *      a sealed post, and falls through to the gates below like any
+ *      other reader.
+ *   3. **A parent whose post type has no readable front end** needs
+ *      `edit_post` too. This is the branch `read_post` alone misses:
+ *      `map_meta_cap()` resolves `read_post` on a *published* post to
+ *      the type's `read` capability, which is plain `read` on any post
+ *      type registered with `map_meta_cap`, and every logged-in user
+ *      holds it. So a published post of an internal post type — a
+ *      plugin's submission log, queue or internal note, none of which
+ *      a visitor can open — would otherwise read like a public post.
+ *      `openstation_ai_can_read_post()` takes the same position.
+ *
+ * Anything else is Core's `read_post`, matching
+ * `WP_REST_Comments_Controller::check_read_post_permission()`. Unlike
+ * the AI sibling this keeps `read_post` as the floor for viewable types
+ * rather than short-circuiting publicly viewable posts: that helper
+ * serves search, which is about public content, while this one mirrors
+ * Core's single-comment read.
  *
  * @param WP_Post|null $post Parent post, or null when it no longer exists.
  * @return bool
@@ -72,7 +98,11 @@ function openstation_my_wordpress_can_read_comment_post( $post ) {
 	if ( ! $post ) {
 		return current_user_can( 'moderate_comments' );
 	}
-	if ( post_password_required( $post ) ) {
+	if ( post_password_required( $post ) && ! current_user_can( 'edit_post', $post->ID ) ) {
+		return false;
+	}
+	$post_type = get_post_type_object( $post->post_type );
+	if ( ! $post_type || ! is_post_type_viewable( $post_type ) ) {
 		return current_user_can( 'edit_post', $post->ID );
 	}
 	return current_user_can( 'read_post', $post->ID );

--- a/includes/my-wordpress/comment-stats.php
+++ b/includes/my-wordpress/comment-stats.php
@@ -22,11 +22,16 @@
  *   - Past those two gates, the comment itself must be visible —
  *     `openstation_my_wordpress_comment_is_visible()`: approved, OR the
  *     user can `moderate_comments`, OR they're the comment author.
- *   - The thread around it (parent, replies) is scoped to the post
- *     those two gates just authorized, and each member runs the same
- *     visibility test. `comment_post_ID` and `comment_parent` are
- *     independent columns, so "the parent of a readable comment" is not
- *     by itself a readable comment.
+ *   - The thread around it is scoped to the post those two gates just
+ *     authorized: `comment_post_ID` and `comment_parent` are independent
+ *     columns, so "the parent of a readable comment" is not by itself a
+ *     readable comment. Within that post the two thread members are
+ *     filtered differently:
+ *       - the parent runs the same visibility test as the requested
+ *         comment (approved, moderator, or own);
+ *       - replies are approved only — plus pending ones for a
+ *         moderator, as a moderation aid. Spam and trash never ship,
+ *         and there is no own-reply exception.
  *   - Author email / IP / user-agent only ship to viewers with
  *     `moderate_comments`.
  *
@@ -123,7 +128,9 @@ function openstation_my_wordpress_can_read_comment_post( $post ) {
  *
  * Applied to the requested comment and to the thread parent alike —
  * the parent is reached by id, not by a query that filters on status,
- * so without this its excerpt would ship whatever its status.
+ * so without this its excerpt would ship whatever its status. Replies
+ * are NOT run through it: their query filters on status in SQL, with
+ * narrower rules (see the replies section of the callback).
  *
  * @param WP_Comment $comment Comment to test.
  * @return bool

--- a/includes/my-wordpress/comment-stats.php
+++ b/includes/my-wordpress/comment-stats.php
@@ -19,9 +19,14 @@
  *     low-capability author cannot read comments on posts they can't
  *     otherwise see: private, sealed behind a password, or of a post
  *     type with no readable front end at all.
- *   - Past those two gates, the comment itself must be visible:
- *     approved, OR the user can `moderate_comments`, OR they're
- *     the comment author.
+ *   - Past those two gates, the comment itself must be visible —
+ *     `openstation_my_wordpress_comment_is_visible()`: approved, OR the
+ *     user can `moderate_comments`, OR they're the comment author.
+ *   - The thread around it (parent, replies) is scoped to the post
+ *     those two gates just authorized, and each member runs the same
+ *     visibility test. `comment_post_ID` and `comment_parent` are
+ *     independent columns, so "the parent of a readable comment" is not
+ *     by itself a readable comment.
  *   - Author email / IP / user-agent only ship to viewers with
  *     `moderate_comments`.
  *
@@ -109,6 +114,32 @@ function openstation_my_wordpress_can_read_comment_post( $post ) {
 }
 
 /**
+ * Whether a comment's own moderation state lets the current user see it.
+ *
+ * The parent-post gate above decides whether the caller may see comments
+ * on that post at all; this decides whether they may see *this* comment:
+ * approved ones are public, anything pending, spam or trashed is for
+ * moderators and for the person who wrote it.
+ *
+ * Applied to the requested comment and to the thread parent alike —
+ * the parent is reached by id, not by a query that filters on status,
+ * so without this its excerpt would ship whatever its status.
+ *
+ * @param WP_Comment $comment Comment to test.
+ * @return bool
+ */
+function openstation_my_wordpress_comment_is_visible( $comment ) {
+	if ( '1' === (string) $comment->comment_approved ) {
+		return true;
+	}
+	if ( current_user_can( 'moderate_comments' ) ) {
+		return true;
+	}
+	$author_id = (int) $comment->user_id;
+	return $author_id > 0 && (int) get_current_user_id() === $author_id;
+}
+
+/**
  * Aggregator callback.
  *
  * @param WP_REST_Request $request REST request.
@@ -116,8 +147,13 @@ function openstation_my_wordpress_can_read_comment_post( $post ) {
  */
 function openstation_my_wordpress_comment_stats_callback( $request ) {
 	global $wpdb;
+	// `\d+` matches 0 and absint() keeps it, so the zero has to be
+	// refused here: get_comment( 0 ) falls back to $GLOBALS['comment'],
+	// which would answer /comment-stats/0 with whatever comment another
+	// plugin happened to leave in the global instead of the documented
+	// 404. Same hazard as get_post( 0 ) below, one level up.
 	$comment_id = (int) $request->get_param( 'id' );
-	$comment    = get_comment( $comment_id );
+	$comment    = $comment_id > 0 ? get_comment( $comment_id ) : null;
 	if ( ! $comment ) {
 		return new WP_Error(
 			'openstation_comment_not_found',
@@ -146,11 +182,8 @@ function openstation_my_wordpress_comment_stats_callback( $request ) {
 
 	$can_moderate = current_user_can( 'moderate_comments' );
 	$is_approved  = '1' === (string) $comment->comment_approved;
-	$is_self      = is_user_logged_in()
-		&& (int) get_current_user_id() === (int) $comment->user_id
-		&& (int) $comment->user_id > 0;
 
-	if ( ! $is_approved && ! $can_moderate && ! $is_self ) {
+	if ( ! openstation_my_wordpress_comment_is_visible( $comment ) ) {
 		return new WP_Error(
 			'openstation_comment_forbidden',
 			__( 'You do not have permission to view this comment.', 'desktop-mode' ),
@@ -238,10 +271,19 @@ function openstation_my_wordpress_comment_stats_callback( $request ) {
 	}
 
 	// ----- Parent comment (if this is a reply) -------------------------
+	// Only the thread above it on the SAME post, and only if its own
+	// status allows. The gates at the top authorized one post and one
+	// comment; `comment_post_ID` and `comment_parent` are independent
+	// columns, and wp_insert_comment() will happily write a parent that
+	// lives on another post, so an excerpt from an unreadable post could
+	// otherwise ride in here on a readable comment.
 	$parent_payload = null;
 	if ( (int) $comment->comment_parent > 0 ) {
 		$parent_comment = get_comment( (int) $comment->comment_parent );
-		if ( $parent_comment ) {
+		if ( $parent_comment
+			&& (int) $parent_comment->comment_post_ID === (int) $comment->comment_post_ID
+			&& openstation_my_wordpress_comment_is_visible( $parent_comment )
+		) {
 			$parent_payload = array(
 				'id'         => (int) $parent_comment->comment_ID,
 				'authorName' => (string) $parent_comment->comment_author,
@@ -255,6 +297,11 @@ function openstation_my_wordpress_comment_stats_callback( $request ) {
 	}
 
 	// ----- Replies (direct children) -----------------------------------
+	// Scoped to the authorized post for the same reason as the parent
+	// above: `comment_parent` alone would pull in a comment stored
+	// against a post the caller cannot read. A reply on another post is
+	// not a reply to this thread anyway.
+	//
 	// Static SQL literal — must not go through a %s placeholder, which
 	// would quote it into an adjacent string literal and break the clause.
 	$reply_status_sql = $can_moderate
@@ -267,10 +314,12 @@ function openstation_my_wordpress_comment_stats_callback( $request ) {
 				comment_date_gmt, comment_content, comment_approved, user_id
 			FROM {$wpdb->comments}
 			WHERE comment_parent = %d
+				AND comment_post_ID = %d
 				AND {$reply_status_sql}
 			ORDER BY comment_date_gmt ASC
 			LIMIT 20",
-			$comment->comment_ID
+			$comment->comment_ID,
+			$comment->comment_post_ID
 		),
 		ARRAY_A
 	);

--- a/includes/my-wordpress/comment-stats.php
+++ b/includes/my-wordpress/comment-stats.php
@@ -8,10 +8,17 @@
  * the right preview pane in the My WordPress folder when a comment
  * is selected.
  *
- * Permissions:
- *   - The comment must be readable by the current user (approved,
- *     OR the user can `moderate_comments`, OR they're the comment
- *     author).
+ * Permissions, in gate order:
+ *   - The route wears the same (filterable) gate as the My
+ *     WordPress window: `openstation_my_wordpress_user_can_use()`,
+ *     `edit_posts` by default.
+ *   - The caller must be able to read the comment's parent post —
+ *     see `openstation_my_wordpress_can_read_comment_post()` — so a
+ *     low-capability author cannot read comments on private or
+ *     password-protected posts they can't otherwise see.
+ *   - Past those two gates, the comment itself must be visible:
+ *     approved, OR the user can `moderate_comments`, OR they're
+ *     the comment author.
  *   - Author email / IP / user-agent only ship to viewers with
  *     `moderate_comments`.
  *
@@ -31,7 +38,11 @@ function openstation_my_wordpress_register_comment_stats_route() {
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => 'openstation_my_wordpress_comment_stats_callback',
 			'permission_callback' => static function () {
-				return is_user_logged_in();
+				// The dossier is an author's tool: it wears the same
+				// filterable gate as the My WordPress window itself.
+				// Bare is_user_logged_in() let any subscriber read
+				// it (OPENSTA-155).
+				return openstation_my_wordpress_user_can_use();
 			},
 			'args'                => array(
 				'id' => array(
@@ -44,6 +55,28 @@ function openstation_my_wordpress_register_comment_stats_route() {
 	);
 }
 add_action( 'rest_api_init', 'openstation_my_wordpress_register_comment_stats_route' );
+
+/**
+ * Whether the current user may read the post a comment belongs to.
+ *
+ * Mirrors `WP_REST_Comments_Controller::check_read_post_permission()`:
+ * a password-protected parent needs `edit_post`; any other parent
+ * needs `read_post`. An orphaned comment (its post is gone) is
+ * moderators-only. Without this, an approved comment on a private or
+ * password-protected post read exactly like one on a public post.
+ *
+ * @param WP_Post|null $post Parent post, or null when it no longer exists.
+ * @return bool
+ */
+function openstation_my_wordpress_can_read_comment_post( $post ) {
+	if ( ! $post ) {
+		return current_user_can( 'moderate_comments' );
+	}
+	if ( post_password_required( $post ) ) {
+		return current_user_can( 'edit_post', $post->ID );
+	}
+	return current_user_can( 'read_post', $post->ID );
+}
 
 /**
  * Aggregator callback.
@@ -60,6 +93,24 @@ function openstation_my_wordpress_comment_stats_callback( $request ) {
 			'openstation_comment_not_found',
 			__( 'Comment not found.', 'desktop-mode' ),
 			array( 'status' => 404 )
+		);
+	}
+
+	// Object-level authorization: refuse when the caller can't read
+	// the comment's parent post (OPENSTA-155). Fetched once here and
+	// reused for the parent-post payload below. The explicit zero
+	// check matters: get_post( 0 ) falls back to the global post, so
+	// an orphaned comment would be authorized against whatever post
+	// happened to be global instead of hitting the moderators-only
+	// branch.
+	$post = $comment->comment_post_ID
+		? get_post( (int) $comment->comment_post_ID )
+		: null;
+	if ( ! openstation_my_wordpress_can_read_comment_post( $post ) ) {
+		return new WP_Error(
+			'openstation_comment_forbidden',
+			__( 'You do not have permission to view this comment.', 'desktop-mode' ),
+			array( 'status' => 403 )
 		);
 	}
 
@@ -128,7 +179,6 @@ function openstation_my_wordpress_comment_stats_callback( $request ) {
 	}
 
 	// ----- Parent post -------------------------------------------------
-	$post         = get_post( (int) $comment->comment_post_ID );
 	$post_payload = null;
 	if ( $post ) {
 		$post_author  = $post->post_author > 0

--- a/includes/my-wordpress/window.php
+++ b/includes/my-wordpress/window.php
@@ -92,14 +92,37 @@ function openstation_my_wordpress_icon_svg() {
  * Mirrors the recycle-bin gate — anyone who can edit posts can
  * browse posts and pages.
  *
+ * This is the module's one capability gate, and it is a **server-side
+ * authorization** gate, not just a visibility one. It decides:
+ *
+ *   - The non-REST post-type bridge: whether
+ *     `desktop-mode/v1/post-type/<slug>` routes register at all
+ *     (`rest-post-type.php`).
+ *   - The per-comment dossier route
+ *     `desktop-mode/v1/comment-stats/<id>` (`comment-stats.php`).
+ *   - Whether the WooCommerce integration's boot config ships, so the
+ *     client can reach the order / customer / product surfaces at all
+ *     — those routes still enforce their own Woo capabilities on top
+ *     (`integrations/woocommerce.php`).
+ *   - Whether preview-action scripts registered by plugins are
+ *     enqueued (`preview-actions.php`).
+ *   - Whether Station Home offers the "WP Explorer" quick action
+ *     (`apps/station-home/parts/snapshot.php`).
+ *
+ * It does **not** gate the app's own window or pinned launcher: WP
+ * Explorer is an App Framework app and declares
+ * `->capabilities( 'edit_posts' )` itself (`apps/my-wordpress/`).
+ * Returning `true` here opens the surfaces above without opening the
+ * window; to move the window too, filter the app's manifest.
+ *
  * @return bool
  */
 function openstation_my_wordpress_user_can_use() {
 	$can = current_user_can( 'edit_posts' );
 
 	/**
-	 * Filter whether the current user can see the My WordPress
-	 * pinned icon and window.
+	 * Filter whether the current user can reach the My WordPress
+	 * module's surfaces — its REST routes included.
 	 *
 	 * @param bool $can Default: edit_posts capability.
 	 */

--- a/includes/rest/README.md
+++ b/includes/rest/README.md
@@ -43,7 +43,7 @@ All in-tree routes register under `desktop-mode/v1`. Extensions are expected to 
 | `/content-graph/nodes` | GET | `includes/content-graph/rest.php` | `edit_posts` (filterable via `openstation_content_graph_user_can_use`) |
 | `/content-graph/post/{id}` | GET | `includes/content-graph/rest.php` | `edit_posts` (filterable via `openstation_content_graph_user_can_use`) |
 | `/apps/(?P<app>[a-z0-9][a-z0-9_-]*)/dispatch` | POST | `includes/framework/wordpress.php` | Logged in + the app exists + `App::allows()` (its `capabilities()` and `can()` gate). Every `.os.php` window — Code Blue included, behind Developer mode + `manage_options` (`manage_network_options` on multisite), filterable via `openstation_code_blue_user_can_use` — is served by this one route; there are no per-app routes. |
-| `/comment-stats/{id}` | GET | `includes/my-wordpress/comment-stats.php` | `edit_posts` (filterable via `openstation_my_wordpress_user_can_use`) + parent post readable (`read_post`; `edit_post` when password-protected; `moderate_comments` when the post is gone) |
+| `/comment-stats/{id}` | GET | `includes/my-wordpress/comment-stats.php` | `edit_posts` (filterable via `openstation_my_wordpress_user_can_use`) + parent post readable: `read_post`, but `edit_post` when the parent is still sealed by a password (a caller who already entered it reads on `read_post` like anyone else) or when its post type has no readable front end, and `moderate_comments` when the parent is gone |
 | `/term-stats/{taxonomy}/{id}` | GET | `includes/my-wordpress/term-stats.php` | logged-in + `read` |
 | `/user-stats/{id}` | GET | `includes/my-wordpress/user-stats.php` | logged-in |
 | `/user-footprint/{id}` | GET | `includes/my-wordpress/user-footprint.php` | logged-in |

--- a/includes/rest/README.md
+++ b/includes/rest/README.md
@@ -43,7 +43,7 @@ All in-tree routes register under `desktop-mode/v1`. Extensions are expected to 
 | `/content-graph/nodes` | GET | `includes/content-graph/rest.php` | `edit_posts` (filterable via `openstation_content_graph_user_can_use`) |
 | `/content-graph/post/{id}` | GET | `includes/content-graph/rest.php` | `edit_posts` (filterable via `openstation_content_graph_user_can_use`) |
 | `/apps/(?P<app>[a-z0-9][a-z0-9_-]*)/dispatch` | POST | `includes/framework/wordpress.php` | Logged in + the app exists + `App::allows()` (its `capabilities()` and `can()` gate). Every `.os.php` window — Code Blue included, behind Developer mode + `manage_options` (`manage_network_options` on multisite), filterable via `openstation_code_blue_user_can_use` — is served by this one route; there are no per-app routes. |
-| `/comment-stats/{id}` | GET | `includes/my-wordpress/comment-stats.php` | logged-in |
+| `/comment-stats/{id}` | GET | `includes/my-wordpress/comment-stats.php` | `edit_posts` (filterable via `openstation_my_wordpress_user_can_use`) + parent post readable (`read_post`; `edit_post` when password-protected; `moderate_comments` when the post is gone) |
 | `/term-stats/{taxonomy}/{id}` | GET | `includes/my-wordpress/term-stats.php` | logged-in + `read` |
 | `/user-stats/{id}` | GET | `includes/my-wordpress/user-stats.php` | logged-in |
 | `/user-footprint/{id}` | GET | `includes/my-wordpress/user-footprint.php` | logged-in |

--- a/tests/phpunit/tests/myWordpressCommentStats.php
+++ b/tests/phpunit/tests/myWordpressCommentStats.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Tests for the `/desktop-mode/v1/comment-stats/<id>` REST
+ * endpoint's authorization model (OPENSTA-155).
+ *
+ * The route wears the My WordPress window's own filterable gate
+ * (`openstation_my_wordpress_user_can_use()`, `edit_posts` by
+ * default), and the handler additionally refuses when the caller
+ * can't read the comment's parent post. A low-capability account
+ * must not read comments on private or password-protected posts it
+ * can't otherwise see, and an orphaned comment (its post is gone)
+ * is moderators-only.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group desktop-mode-my-wordpress
+ */
+class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $subscriber_id;
+	protected static $author_id;
+
+	private $published_post_id;
+	private $published_comment_id;
+	private $private_comment_id;
+	private $protected_comment_id;
+	private $orphan_comment_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$author_id     = $factory->user->create( array( 'role' => 'author' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_id );
+		do_action( 'rest_api_init' );
+
+		// An administrator-owned published, private and
+		// password-protected post, each with one approved comment —
+		// plus one approved comment whose post is gone.
+		$this->published_post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$admin_id,
+				'post_status' => 'publish',
+			)
+		);
+		$private_post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$admin_id,
+				'post_status' => 'private',
+			)
+		);
+		$protected_post_id = self::factory()->post->create(
+			array(
+				'post_author'   => self::$admin_id,
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+
+		$this->published_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->published_post_id,
+				'comment_approved' => '1',
+			)
+		);
+		$this->private_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $private_post_id,
+				'comment_approved' => '1',
+			)
+		);
+		$this->protected_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $protected_post_id,
+				'comment_approved' => '1',
+			)
+		);
+		$this->orphan_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => 0,
+				'comment_approved' => '1',
+			)
+		);
+	}
+
+	/**
+	 * Dispatch a comment-stats request for the given comment.
+	 *
+	 * @param int $comment_id Comment id.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch( $comment_id ) {
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/comment-stats/' . (int) $comment_id );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Logged-out requests are rejected by the permission callback.
+	 *
+	 * @covers ::openstation_my_wordpress_register_comment_stats_route
+	 */
+	public function test_logged_out_request_is_rejected() {
+		wp_set_current_user( 0 );
+		$this->assertSame( 401, $this->dispatch( $this->published_comment_id )->get_status() );
+	}
+
+	/**
+	 * A subscriber has no `edit_posts` and is refused at the route,
+	 * even for a comment on a public post. This is the OPENSTA-155
+	 * reproduction: the subscriber used to read the full dossier.
+	 *
+	 * @covers ::openstation_my_wordpress_register_comment_stats_route
+	 */
+	public function test_subscriber_is_rejected_by_route() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertSame( 403, $this->dispatch( $this->published_comment_id )->get_status() );
+	}
+
+	/**
+	 * An author (has `edit_posts`, lacks `read_private_posts`) is
+	 * refused a comment on another user's private post.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_author_cannot_read_comment_on_private_post() {
+		wp_set_current_user( self::$author_id );
+		$this->assertSame( 403, $this->dispatch( $this->private_comment_id )->get_status() );
+	}
+
+	/**
+	 * An author is refused a comment on a password-protected post it
+	 * can't edit.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_author_cannot_read_comment_on_protected_post() {
+		wp_set_current_user( self::$author_id );
+		$this->assertSame( 403, $this->dispatch( $this->protected_comment_id )->get_status() );
+	}
+
+	/**
+	 * An author reads a comment on a public post normally.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_author_reads_comment_on_public_post() {
+		wp_set_current_user( self::$author_id );
+		$response = $this->dispatch( $this->published_comment_id );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $this->published_comment_id, $response->get_data()['comment']['id'] );
+	}
+
+	/**
+	 * An administrator reads comments on private and
+	 * password-protected posts.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_admin_reads_comment_on_restricted_posts() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame( 200, $this->dispatch( $this->private_comment_id )->get_status() );
+		$this->assertSame( 200, $this->dispatch( $this->protected_comment_id )->get_status() );
+	}
+
+	/**
+	 * An orphaned comment (its post is gone) is moderators-only —
+	 * even when a global post is set, which get_post( 0 ) would
+	 * otherwise silently substitute for the missing parent.
+	 *
+	 * @covers ::openstation_my_wordpress_can_read_comment_post
+	 */
+	public function test_orphaned_comment_is_moderators_only() {
+		wp_set_current_user( self::$author_id );
+		$this->assertSame( 403, $this->dispatch( $this->orphan_comment_id )->get_status() );
+
+		// A stray global post must not stand in for the missing parent.
+		$GLOBALS['post'] = get_post( $this->published_post_id );
+		$this->assertSame( 403, $this->dispatch( $this->orphan_comment_id )->get_status() );
+		unset( $GLOBALS['post'] );
+
+		wp_set_current_user( self::$admin_id );
+		$response = $this->dispatch( $this->orphan_comment_id );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $response->get_data()['post'] );
+	}
+
+	/**
+	 * A site that widens the window gate via the filter widens the
+	 * route with it — but the parent-post gate still holds on its
+	 * own, so private posts stay unreadable.
+	 *
+	 * @covers ::openstation_my_wordpress_register_comment_stats_route
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_filter_widened_route_still_enforces_parent_post_gate() {
+		add_filter( 'openstation_my_wordpress_user_can_use', '__return_true' );
+
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertSame( 200, $this->dispatch( $this->published_comment_id )->get_status() );
+		$this->assertSame( 403, $this->dispatch( $this->private_comment_id )->get_status() );
+		$this->assertSame( 403, $this->dispatch( $this->protected_comment_id )->get_status() );
+	}
+
+	/**
+	 * A site that narrows the window gate via the filter locks the
+	 * route down with it, administrators included.
+	 *
+	 * @covers ::openstation_my_wordpress_register_comment_stats_route
+	 */
+	public function test_filter_narrowed_route_refuses_admins() {
+		add_filter( 'openstation_my_wordpress_user_can_use', '__return_false' );
+
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame( 403, $this->dispatch( $this->published_comment_id )->get_status() );
+	}
+
+	/**
+	 * A missing comment is a 404, not a 403 — the not-found check runs
+	 * before the parent-post gate.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_missing_comment_is_not_found() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame( 404, $this->dispatch( 999999 )->get_status() );
+	}
+}

--- a/tests/phpunit/tests/myWordpressCommentStats.php
+++ b/tests/phpunit/tests/myWordpressCommentStats.php
@@ -3,12 +3,14 @@
  * Tests for the `/desktop-mode/v1/comment-stats/<id>` REST
  * endpoint's authorization model (OPENSTA-155).
  *
- * The route wears the My WordPress window's own filterable gate
+ * The route wears the My WordPress module's authorization gate
  * (`openstation_my_wordpress_user_can_use()`, `edit_posts` by
- * default), and the handler additionally refuses when the caller
- * can't read the comment's parent post. A low-capability account
- * must not read comments on private or password-protected posts it
- * can't otherwise see, and an orphaned comment (its post is gone)
+ * default — it does not gate WP Explorer's window or launcher, which
+ * the app's own capabilities decide), and the handler additionally
+ * refuses when the caller can't read the comment's parent post. A
+ * low-capability account must not read comments on a post it can't
+ * otherwise see: private, sealed behind a password, or of a post type
+ * with no readable front end. An orphaned comment (its post is gone)
  * is moderators-only.
  *
  * @package WordPress
@@ -23,10 +25,18 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 	protected static $subscriber_id;
 	protected static $author_id;
 
+	/**
+	 * An internal post type: not publicly queryable, so it has no
+	 * readable front end, but `map_meta_cap` is on — which is what makes
+	 * `read_post` on a *published* one resolve to plain `read`.
+	 */
+	const INTERNAL_TYPE = 'os_test_internal';
+
 	private $published_post_id;
 	private $published_comment_id;
 	private $private_comment_id;
 	private $protected_comment_id;
+	private $internal_comment_id;
 	private $orphan_comment_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -40,6 +50,20 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 
 		wp_set_current_user( self::$admin_id );
 		do_action( 'rest_api_init' );
+
+		// The shape a plugin's submission log / queue / internal note
+		// takes: comments, `publish` status, no front end. Unregistered
+		// again in tear_down — the test suite only resets post types for
+		// core's own tests.
+		register_post_type(
+			self::INTERNAL_TYPE,
+			array(
+				'public'             => false,
+				'publicly_queryable' => false,
+				'map_meta_cap'       => true,
+				'supports'           => array( 'title', 'editor', 'comments' ),
+			)
+		);
 
 		// An administrator-owned published, private and
 		// password-protected post, each with one approved comment —
@@ -63,6 +87,13 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 				'post_password' => 'secret',
 			)
 		);
+		$internal_post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$admin_id,
+				'post_status' => 'publish',
+				'post_type'   => self::INTERNAL_TYPE,
+			)
+		);
 
 		$this->published_comment_id = self::factory()->comment->create(
 			array(
@@ -82,12 +113,23 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 				'comment_approved' => '1',
 			)
 		);
+		$this->internal_comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $internal_post_id,
+				'comment_approved' => '1',
+			)
+		);
 		$this->orphan_comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => 0,
 				'comment_approved' => '1',
 			)
 		);
+	}
+
+	public function tear_down() {
+		unregister_post_type( self::INTERNAL_TYPE );
+		parent::tear_down();
 	}
 
 	/**
@@ -143,6 +185,62 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 	public function test_author_cannot_read_comment_on_protected_post() {
 		wp_set_current_user( self::$author_id );
 		$this->assertSame( 403, $this->dispatch( $this->protected_comment_id )->get_status() );
+	}
+
+	/**
+	 * ...but a caller who has already entered the password is no longer
+	 * looking at a sealed post: `post_password_required()` reads the
+	 * `wp-postpass` cookie, so the read falls through to `read_post` and
+	 * the `edit_post` requirement never applies.
+	 *
+	 * @covers ::openstation_my_wordpress_can_read_comment_post
+	 */
+	public function test_author_reads_comment_on_unlocked_protected_post() {
+		wp_set_current_user( self::$author_id );
+
+		// The same hasher and cookie name post_password_required() reads;
+		// it require_once's the class lazily, so pull it in first.
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher                                 = new PasswordHash( 8, true );
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( 'secret' );
+
+		$status = $this->dispatch( $this->protected_comment_id )->get_status();
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		$this->assertSame( 200, $status );
+	}
+
+	/**
+	 * An author is refused a comment on a *published* post of a post
+	 * type with no readable front end. This is the branch `read_post`
+	 * alone misses: it resolves to plain `read` on a published post, and
+	 * every logged-in user holds that, so without the post-type
+	 * viewability check an internal submission log or queue would read
+	 * like a public post.
+	 *
+	 * @covers ::openstation_my_wordpress_can_read_comment_post
+	 */
+	public function test_author_cannot_read_comment_on_internal_post_type() {
+		wp_set_current_user( self::$author_id );
+
+		// The leak this guards: the caller does hold the capability
+		// `read_post` resolves to here.
+		$this->assertTrue(
+			current_user_can( 'read_post', get_comment( $this->internal_comment_id )->comment_post_ID ),
+			'read_post alone would have authorized this read.'
+		);
+		$this->assertSame( 403, $this->dispatch( $this->internal_comment_id )->get_status() );
+	}
+
+	/**
+	 * An administrator can `edit_post` the internal parent, so the
+	 * dossier still opens for whoever actually administers the type.
+	 *
+	 * @covers ::openstation_my_wordpress_can_read_comment_post
+	 */
+	public function test_admin_reads_comment_on_internal_post_type() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame( 200, $this->dispatch( $this->internal_comment_id )->get_status() );
 	}
 
 	/**

--- a/tests/phpunit/tests/myWordpressCommentStats.php
+++ b/tests/phpunit/tests/myWordpressCommentStats.php
@@ -33,6 +33,7 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 	const INTERNAL_TYPE = 'os_test_internal';
 
 	private $published_post_id;
+	private $private_post_id;
 	private $published_comment_id;
 	private $private_comment_id;
 	private $protected_comment_id;
@@ -74,7 +75,7 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 				'post_status' => 'publish',
 			)
 		);
-		$private_post_id = self::factory()->post->create(
+		$this->private_post_id = self::factory()->post->create(
 			array(
 				'post_author' => self::$admin_id,
 				'post_status' => 'private',
@@ -103,7 +104,7 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 		);
 		$this->private_comment_id = self::factory()->comment->create(
 			array(
-				'comment_post_ID'  => $private_post_id,
+				'comment_post_ID'  => $this->private_post_id,
 				'comment_approved' => '1',
 			)
 		);
@@ -287,6 +288,102 @@ class Tests_OpenStation_MyWordpressCommentStats extends WP_UnitTestCase {
 		$response = $this->dispatch( $this->orphan_comment_id );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertNull( $response->get_data()['post'] );
+	}
+
+	/**
+	 * `comment_post_ID` and `comment_parent` are independent columns, so
+	 * a comment on a readable post can name a parent that lives on an
+	 * unreadable one. The thread payload is scoped to the authorized
+	 * post, so neither direction carries an excerpt across: not the
+	 * parent of the readable comment, and not a reply stored against the
+	 * private post.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_thread_does_not_cross_into_an_unreadable_post() {
+		$on_private = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->private_post_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Secret thread content.',
+			)
+		);
+		// A readable comment whose parent lives on the private post.
+		$child = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->published_post_id,
+				'comment_parent'   => $on_private,
+				'comment_approved' => '1',
+			)
+		);
+		// ...and a reply stored against the private post, pointing at a
+		// comment on the public one.
+		$cross_reply = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->private_post_id,
+				'comment_parent'   => $this->published_comment_id,
+				'comment_approved' => '1',
+				'comment_content'  => 'Secret reply content.',
+			)
+		);
+
+		wp_set_current_user( self::$author_id );
+
+		$data = $this->dispatch( $child )->get_data();
+		$this->assertNull( $data['parent'], 'A parent on another post is not this thread.' );
+
+		$data = $this->dispatch( $this->published_comment_id )->get_data();
+		$this->assertNotContains(
+			$cross_reply,
+			wp_list_pluck( $data['replies'], 'id' ),
+			'A reply stored against another post is not this thread.'
+		);
+	}
+
+	/**
+	 * The thread parent is reached by id, not by a query that filters on
+	 * status, so its own visibility has to be tested: a pending parent
+	 * stays out for a caller who cannot moderate.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_is_visible
+	 */
+	public function test_pending_thread_parent_is_hidden_from_non_moderators() {
+		$pending = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->published_post_id,
+				'comment_approved' => '0',
+			)
+		);
+		$child = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->published_post_id,
+				'comment_parent'   => $pending,
+				'comment_approved' => '1',
+			)
+		);
+
+		wp_set_current_user( self::$author_id );
+		$this->assertNull( $this->dispatch( $child )->get_data()['parent'] );
+
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame( $pending, $this->dispatch( $child )->get_data()['parent']['id'] );
+	}
+
+	/**
+	 * `/comment-stats/0` matches the route's `\d+`, and get_comment( 0 )
+	 * falls back to `$GLOBALS['comment']` — so a stray global must not
+	 * stand in for the comment that was asked for.
+	 *
+	 * @covers ::openstation_my_wordpress_comment_stats_callback
+	 */
+	public function test_zero_id_is_not_found_even_with_a_global_comment() {
+		wp_set_current_user( self::$admin_id );
+
+		$GLOBALS['comment'] = get_comment( $this->published_comment_id );
+		$status             = $this->dispatch( 0 )->get_status();
+		unset( $GLOBALS['comment'] );
+
+		$this->assertSame( 404, $status );
 	}
 
 	/**


### PR DESCRIPTION
## What it does

Tightens authorization on `GET /desktop-mode/v1/comment-stats/<id>` (the My WordPress per-comment dossier). The route now wears the same filterable gate as the My WordPress window itself — `openstation_my_wordpress_user_can_use()`, `edit_posts` by default — and the handler refuses when the caller cannot read the comment's parent post. Fixes OPENSTA-155.

## Rationale

The route's permission callback was bare `is_user_logged_in()`, and the in-handler gate only tested the comment's own moderation state (`comment_approved`) — never the readability of `comment_post_ID`. An approved comment was treated the same whether its parent post was published, private, or password-protected. Core's `WP_REST_Comments_Controller` takes the opposite position: every single-comment read runs `check_read_post_permission()` against the parent.

## Implementation

Two gates, in order:

1. **Route capability.** The `permission_callback` calls `openstation_my_wordpress_user_can_use()` rather than a raw capability, so sites that widen or narrow the window via the `openstation_my_wordpress_user_can_use` filter get a route that follows — matching how `rest-post-type.php` and `preview-actions.php` already gate.
2. **Parent-post readability.** New helper `openstation_my_wordpress_can_read_comment_post()`, mirroring core's `check_read_post_permission()`: a password-protected parent needs `edit_post`, any other parent needs `read_post`, and an orphaned comment (its post is gone) is `moderate_comments`-only.

The handler fetches the parent post once, runs the gate before assembling anything, and reuses that fetch for the parent-post payload. The fetch guards `comment_post_ID = 0` explicitly, because `get_post( 0 )` falls back to the global post — without the guard, an orphaned comment would be authorized against whatever post happened to be global instead of hitting the moderators-only branch.

The existing comment-level check (approved OR `moderate_comments` OR self) stays as the third gate, and it matters that the object-level check lives in the callback rather than the permission callback: the My WordPress app's `stats_payload` path invokes the callback directly.

The route's row in `includes/rest/README.md` is updated to state the new gates.

## Testing instructions

```bash
npm run env:start:tests
npm run test:php -- --filter='Tests_OpenStation_MyWordpressCommentStats'
npm run env:stop:tests
```

New test class covers: logged-out (401), subscriber at the route (403), author vs. private and password-protected parents (403), author on a public parent (200), admin on restricted parents (200), the orphaned-comment branch including the stray-global-post case, the filter-widened route still enforcing the parent-post gate, the filter-narrowed route refusing admins, and missing comment (404). The full `desktop-mode-my-wordpress` group passes (151 tests, 322 assertions).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-805-3883c7536c3f7fc16aea5dbbe54ba75d75d871c2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->