### PR TITLE
My WordPress: scope the term-stats endpoint to posts the caller may read

### DIFF
--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -4097,6 +4097,8 @@ apply_filters( 'openstation_my_wordpress_term_stats', array $payload, string $ta
 
 The per-term stats payload returned by `GET /desktop-mode/v1/term-stats/<taxonomy>/<id>` — profile, counts, recent posts, top authors, co-terms, activity, and milestones. Filter it to splice in extra metrics before it reaches the WP Explorer window.
 
+The payload is **viewer-dependent**: `counts.posts` and `recent` only cover post statuses the current user may read (unpublished rows are additionally filtered per-row through `current_user_can( 'read_post', … )`), so a subscriber's `counts.posts.total` counts published posts only while an editor's includes drafts, pending and scheduled ones. Never cache the filtered payload under a term-only key — a copy built for a privileged viewer would hand another author's unpublished posts to everyone else.
+
 ### `openstation_my_wordpress_post_contributors` — Experimental (filter)
 
 ```php

--- a/includes/my-wordpress/term-stats.php
+++ b/includes/my-wordpress/term-stats.php
@@ -14,6 +14,19 @@
  * stats. Author archives are also public so listing top authors is
  * not new disclosure.
  *
+ * That reasoning covers the term row and the aggregates over its
+ * *published* posts; it does not carry to the unpublished posts inside
+ * the term, nor to terms of a non-viewable taxonomy. So hidden
+ * taxonomies answer 400 unless the caller can manage their terms,
+ * every post-level query is scoped to the statuses the caller may
+ * read — resolved from each status's registered visibility flags and
+ * the post type's cap map, plus the caller's own posts — and the
+ * recent list is gated per row with `read_post`. Otherwise a
+ * subscriber could read an administrator's private and draft post
+ * titles, authors and dates, and the per-status counts would leak how
+ * many hidden posts a term holds. See
+ * `openstation_my_wordpress_term_stats_readable_status_clause()`.
+ *
  * @package OpenStation
  */
 
@@ -50,6 +63,82 @@ function openstation_my_wordpress_register_term_stats_route() {
 add_action( 'rest_api_init', 'openstation_my_wordpress_register_term_stats_route' );
 
 /**
+ * SQL clause matching the posts in a term the caller may actually read.
+ *
+ * The endpoint authorises on the *term* (public data), but the posts
+ * inside it are not public — a subscriber must never receive another
+ * author's private, draft, pending or scheduled post, nor a per-status
+ * count that betrays one exists. This returns a parenthesised boolean
+ * expression on the aliased posts table `p` admitting only statuses
+ * the caller may read, resolved from the registered status objects so
+ * a plugin's custom status follows its own visibility flags:
+ *
+ *   - public statuses, for everyone;
+ *   - private-flagged statuses with the post type's
+ *     `read_private_posts` capability;
+ *   - the remaining non-internal statuses (draft, pending, future and
+ *     any registered workflow status — trash and auto-draft are
+ *     internal) with `edit_others_posts`, because core maps reading
+ *     them to editing them; a scheduled post additionally needs
+ *     `edit_published_posts`, mirroring `map_meta_cap()`;
+ *   - the caller's own posts in any of those statuses — core grants
+ *     an author `read` on their own post whatever its status.
+ *
+ * The fragment is a static string of `%s` / `%d` placeholders; the
+ * caller splices it into a larger query and threads the returned args
+ * into the same `$wpdb->prepare()` call in position (right after the
+ * `term_taxonomy_id`). It is a close approximation of `read_post` used
+ * where a per-row gate is impossible (aggregate counts); the recent
+ * list re-checks `current_user_can( 'read_post' )` per row as the
+ * authoritative gate.
+ *
+ * @return array{0:string,1:array} SQL fragment and its prepare args, in order.
+ */
+function openstation_my_wordpress_term_stats_readable_status_clause() {
+	$type = get_post_type_object( 'post' );
+
+	$statuses = array_values( get_post_stati( array( 'public' => true ) ) );
+
+	$private_stati = array_values( get_post_stati( array( 'private' => true ) ) );
+	if ( current_user_can( $type->cap->read_private_posts ) ) {
+		$statuses = array_merge( $statuses, $private_stati );
+	}
+
+	$hidden_stati = array_values(
+		get_post_stati(
+			array(
+				'internal' => false,
+				'public'   => false,
+				'private'  => false,
+			)
+		)
+	);
+	if ( current_user_can( $type->cap->edit_others_posts ) ) {
+		foreach ( $hidden_stati as $status ) {
+			if ( 'future' === $status && ! current_user_can( $type->cap->edit_published_posts ) ) {
+				continue;
+			}
+			$statuses[] = $status;
+		}
+	}
+
+	$placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
+	$parts        = array( "p.post_status IN ( $placeholders )" );
+	$args         = $statuses;
+
+	$user_id = get_current_user_id();
+	$own     = array_values( array_diff( array_merge( $private_stati, $hidden_stati ), $statuses ) );
+	if ( $user_id > 0 && $own ) {
+		$own_ph  = implode( ', ', array_fill( 0, count( $own ), '%s' ) );
+		$parts[] = "( p.post_author = %d AND p.post_status IN ( $own_ph ) )";
+		$args[]  = $user_id;
+		$args    = array_merge( $args, $own );
+	}
+
+	return array( '( ' . implode( ' OR ', $parts ) . ' )', $args );
+}
+
+/**
  * Aggregator callback. See file docblock for return shape.
  *
  * @param WP_REST_Request $request REST request.
@@ -61,7 +150,12 @@ function openstation_my_wordpress_term_stats_callback( $request ) {
 	$term_id  = (int) $request->get_param( 'id' );
 
 	$tax_obj = get_taxonomy( $taxonomy );
-	if ( ! $tax_obj ) {
+	// A registered-but-hidden taxonomy (nav_menu, link_category, a
+	// plugin's internal one) is not public-facing data the way
+	// categories and tags are, so the file docblock's `read` reasoning
+	// does not cover it: answer exactly as if it were unregistered
+	// unless the caller can manage its terms.
+	if ( ! $tax_obj || ( ! is_taxonomy_viewable( $tax_obj ) && ! current_user_can( $tax_obj->cap->manage_terms ) ) ) {
 		return new WP_Error(
 			'openstation_invalid_taxonomy',
 			__( 'Unknown taxonomy.', 'desktop-mode' ),
@@ -103,8 +197,18 @@ function openstation_my_wordpress_term_stats_callback( $request ) {
 
 	$tt_id = (int) $term->term_taxonomy_id;
 
+	// Every query below that can touch unpublished posts is scoped to
+	// the statuses the caller may read (the remaining aggregates are
+	// publish-only). The endpoint gates on the term (public), but the
+	// posts inside it are not: without this, a subscriber gets the
+	// titles, authors and dates of administrator-owned drafts/private
+	// posts, and the per-status counts become an oracle for content
+	// they cannot see.
+	list( $status_clause, $status_args ) = openstation_my_wordpress_term_stats_readable_status_clause();
+
 	// ----- Counts ------------------------------------------------------
-	// Post-status breakdown for posts in this term.
+	// Post-status breakdown, restricted to the readable set so the
+	// counts never reveal how many hidden posts a term holds.
 	$status_rows = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT p.post_status, COUNT(DISTINCT p.ID) AS n
@@ -112,9 +216,9 @@ function openstation_my_wordpress_term_stats_callback( $request ) {
 			INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
 			WHERE tr.term_taxonomy_id = %d
 				AND p.post_type = 'post'
-				AND p.post_status NOT IN ( 'auto-draft', 'inherit', 'trash' )
+				AND {$status_clause}
 			GROUP BY p.post_status",
-			$tt_id
+			array_merge( array( $tt_id ), $status_args )
 		),
 		ARRAY_A
 	);
@@ -167,24 +271,37 @@ function openstation_my_wordpress_term_stats_callback( $request ) {
 		'distinctAuthors'  => $distinct_authors,
 	);
 
-	// ----- Recent posts (5 most recent) --------------------------------
+	// ----- Recent posts (5 most recent the caller may read) ------------
+	// The clause narrows the pool to readable statuses; the per-row
+	// read_post gate below is authoritative (it resolves the exact meta
+	// cap per post, and it is the hook where membership plugins restrict
+	// even published posts). Fetch headroom past 5 because the gate may
+	// drop rows the coarse clause admitted.
 	$recent_rows = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT DISTINCT p.ID, p.post_title, p.post_date_gmt, p.post_status, p.post_type, p.post_author
 			FROM {$wpdb->posts} p
 			INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
 			WHERE tr.term_taxonomy_id = %d
-				AND p.post_status IN ( 'publish', 'private', 'future', 'draft', 'pending' )
+				AND {$status_clause}
 				AND p.post_type = 'post'
 			ORDER BY p.post_date_gmt DESC
-			LIMIT 5",
-			$tt_id
+			LIMIT 15",
+			array_merge( array( $tt_id ), $status_args )
 		),
 		ARRAY_A
 	);
 	$recent      = array();
+	if ( $recent_rows ) {
+		// Bulk-warm the post cache — the read_post checks,
+		// get_the_title() and get_permalink() below all read from it.
+		_prime_post_caches( array_map( 'intval', wp_list_pluck( $recent_rows, 'ID' ) ), false, false );
+	}
 	foreach ( (array) $recent_rows as $row ) {
-		$post_id    = (int) $row['ID'];
+		$post_id = (int) $row['ID'];
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			continue;
+		}
 		$author_id  = (int) $row['post_author'];
 		$author     = $author_id > 0 ? get_userdata( $author_id ) : null;
 		$author_arr = $author
@@ -203,6 +320,9 @@ function openstation_my_wordpress_term_stats_callback( $request ) {
 			'link'   => (string) get_permalink( $post_id ),
 			'author' => $author_arr,
 		);
+		if ( count( $recent ) >= 5 ) {
+			break;
+		}
 	}
 
 	// ----- Top authors (most posts in this term) -----------------------

--- a/includes/my-wordpress/term-stats.php
+++ b/includes/my-wordpress/term-stats.php
@@ -24,8 +24,8 @@
  * recent list is gated per row with `read_post`. Otherwise a
  * subscriber could read an administrator's private and draft post
  * titles, authors and dates, and the per-status counts would leak how
- * many hidden posts a term holds. See
- * `openstation_my_wordpress_term_stats_readable_status_clause()`.
+ * many hidden posts a term holds. The readable-status clause is built
+ * in the callback, right above the queries that splice it in.
  *
  * @package OpenStation
  */
@@ -61,82 +61,6 @@ function openstation_my_wordpress_register_term_stats_route() {
 	);
 }
 add_action( 'rest_api_init', 'openstation_my_wordpress_register_term_stats_route' );
-
-/**
- * SQL clause matching the posts in a term the caller may actually read.
- *
- * The endpoint authorises on the *term* (public data), but the posts
- * inside it are not public — a subscriber must never receive another
- * author's private, draft, pending or scheduled post, nor a per-status
- * count that betrays one exists. This returns a parenthesised boolean
- * expression on the aliased posts table `p` admitting only statuses
- * the caller may read, resolved from the registered status objects so
- * a plugin's custom status follows its own visibility flags:
- *
- *   - public statuses, for everyone;
- *   - private-flagged statuses with the post type's
- *     `read_private_posts` capability;
- *   - the remaining non-internal statuses (draft, pending, future and
- *     any registered workflow status — trash and auto-draft are
- *     internal) with `edit_others_posts`, because core maps reading
- *     them to editing them; a scheduled post additionally needs
- *     `edit_published_posts`, mirroring `map_meta_cap()`;
- *   - the caller's own posts in any of those statuses — core grants
- *     an author `read` on their own post whatever its status.
- *
- * The fragment is a static string of `%s` / `%d` placeholders; the
- * caller splices it into a larger query and threads the returned args
- * into the same `$wpdb->prepare()` call in position (right after the
- * `term_taxonomy_id`). It is a close approximation of `read_post` used
- * where a per-row gate is impossible (aggregate counts); the recent
- * list re-checks `current_user_can( 'read_post' )` per row as the
- * authoritative gate.
- *
- * @return array{0:string,1:array} SQL fragment and its prepare args, in order.
- */
-function openstation_my_wordpress_term_stats_readable_status_clause() {
-	$type = get_post_type_object( 'post' );
-
-	$statuses = array_values( get_post_stati( array( 'public' => true ) ) );
-
-	$private_stati = array_values( get_post_stati( array( 'private' => true ) ) );
-	if ( current_user_can( $type->cap->read_private_posts ) ) {
-		$statuses = array_merge( $statuses, $private_stati );
-	}
-
-	$hidden_stati = array_values(
-		get_post_stati(
-			array(
-				'internal' => false,
-				'public'   => false,
-				'private'  => false,
-			)
-		)
-	);
-	if ( current_user_can( $type->cap->edit_others_posts ) ) {
-		foreach ( $hidden_stati as $status ) {
-			if ( 'future' === $status && ! current_user_can( $type->cap->edit_published_posts ) ) {
-				continue;
-			}
-			$statuses[] = $status;
-		}
-	}
-
-	$placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
-	$parts        = array( "p.post_status IN ( $placeholders )" );
-	$args         = $statuses;
-
-	$user_id = get_current_user_id();
-	$own     = array_values( array_diff( array_merge( $private_stati, $hidden_stati ), $statuses ) );
-	if ( $user_id > 0 && $own ) {
-		$own_ph  = implode( ', ', array_fill( 0, count( $own ), '%s' ) );
-		$parts[] = "( p.post_author = %d AND p.post_status IN ( $own_ph ) )";
-		$args[]  = $user_id;
-		$args    = array_merge( $args, $own );
-	}
-
-	return array( '( ' . implode( ' OR ', $parts ) . ' )', $args );
-}
 
 /**
  * Aggregator callback. See file docblock for return shape.
@@ -204,7 +128,57 @@ function openstation_my_wordpress_term_stats_callback( $request ) {
 	// titles, authors and dates of administrator-owned drafts/private
 	// posts, and the per-status counts become an oracle for content
 	// they cannot see.
-	list( $status_clause, $status_args ) = openstation_my_wordpress_term_stats_readable_status_clause();
+	//
+	// The sets come from the registered status objects, so a plugin's
+	// custom status follows its own visibility flags: public statuses
+	// for everyone; private-flagged ones with the post type's
+	// read_private_posts; the remaining non-internal statuses (draft,
+	// pending, future and any registered workflow status — trash and
+	// auto-draft are internal) with edit_others_posts, because core
+	// maps reading them to editing them, plus edit_published_posts for
+	// a scheduled post, mirroring map_meta_cap(); and the caller's own
+	// posts in any of those statuses, since core grants an author read
+	// on their own post whatever its status. The clause is a close
+	// approximation of read_post used where a per-row gate is
+	// impossible (the counts); the recent list re-checks read_post per
+	// row as the authoritative gate. It is built inline, from literal
+	// %s/%d placeholder lists only, so its values are visibly bound
+	// through prepare() at both use sites.
+	$type          = get_post_type_object( 'post' );
+	$statuses      = array_values( get_post_stati( array( 'public' => true ) ) );
+	$private_stati = array_values( get_post_stati( array( 'private' => true ) ) );
+	$hidden_stati  = array_values(
+		get_post_stati(
+			array(
+				'internal' => false,
+				'public'   => false,
+				'private'  => false,
+			)
+		)
+	);
+	if ( current_user_can( $type->cap->read_private_posts ) ) {
+		$statuses = array_merge( $statuses, $private_stati );
+	}
+	if ( current_user_can( $type->cap->edit_others_posts ) ) {
+		foreach ( $hidden_stati as $status ) {
+			if ( 'future' === $status && ! current_user_can( $type->cap->edit_published_posts ) ) {
+				continue;
+			}
+			$statuses[] = $status;
+		}
+	}
+
+	$placeholders  = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
+	$status_clause = "p.post_status IN ( {$placeholders} )";
+	$status_args   = $statuses;
+
+	$user_id = get_current_user_id();
+	$own     = array_values( array_diff( array_merge( $private_stati, $hidden_stati ), $statuses ) );
+	if ( $user_id > 0 && $own ) {
+		$own_ph        = implode( ', ', array_fill( 0, count( $own ), '%s' ) );
+		$status_clause = "( {$status_clause} OR ( p.post_author = %d AND p.post_status IN ( {$own_ph} ) ) )";
+		$status_args   = array_merge( $status_args, array( $user_id ), $own );
+	}
 
 	// ----- Counts ------------------------------------------------------
 	// Post-status breakdown, restricted to the readable set so the

--- a/tests/phpunit/tests/myWordpressTermStats.php
+++ b/tests/phpunit/tests/myWordpressTermStats.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Tests for the `/desktop-mode/v1/term-stats/<taxonomy>/<id>` REST
+ * endpoint's post-level permission model.
+ *
+ * The route is open to any logged-in user with `read` — terms are
+ * public data — but the posts inside a term are not. A subscriber must
+ * never receive another author's `private`, `draft`, `pending` or
+ * `future` post in the `recent` list, and the per-status `counts`
+ * breakdown must not betray how many hidden posts a term holds.
+ * Authors and editors keep their own (and, for editors, others')
+ * unpublished work, custom statuses follow their registered visibility
+ * flags, and terms of a hidden taxonomy are not served at all.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group openstation
+ * @group desktop-mode-my-wordpress
+ */
+class Tests_OpenStation_MyWordpressTermStats extends WP_UnitTestCase {
+
+	protected static $admin_id;
+	protected static $author_id;
+	protected static $subscriber_id;
+
+	private $tag_id;
+	private $published_id;
+	private $draft_id;
+	private $private_id;
+	private $pending_id;
+	private $future_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$author_id     = $factory->user->create( array( 'role' => 'author' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_id );
+		do_action( 'rest_api_init' );
+
+		$this->tag_id = self::factory()->tag->create();
+
+		$this->published_id = $this->make_post( 'publish', 'Public article' );
+		$this->draft_id     = $this->make_post( 'draft', 'Secret draft' );
+		$this->private_id   = $this->make_post( 'private', 'Private notes' );
+		$this->pending_id   = $this->make_post( 'pending', 'Pending review' );
+		$this->future_id    = $this->make_post( 'future', 'Scheduled scoop', null, '2036-01-01 00:00:00' );
+	}
+
+	private function make_post( $status, $title, $author_id = null, $date = null ) {
+		$args = array(
+			'post_author' => (int) ( $author_id ?? self::$admin_id ),
+			'post_status' => $status,
+			'post_title'  => $title,
+		);
+		if ( null !== $date ) {
+			$args['post_date']     = $date;
+			$args['post_date_gmt'] = $date;
+		}
+		$post_id = self::factory()->post->create( $args );
+		wp_set_object_terms( $post_id, array( $this->tag_id ), 'post_tag' );
+		return $post_id;
+	}
+
+	private function dispatch( $taxonomy = 'post_tag', $term_id = null ) {
+		$term_id = $term_id ?? $this->tag_id;
+		$request = new WP_REST_Request( 'GET', '/desktop-mode/v1/term-stats/' . $taxonomy . '/' . (int) $term_id );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	private function recent_ids( $response ) {
+		return wp_list_pluck( $response->get_data()['recent'], 'id' );
+	}
+
+	private function post_counts( $response ) {
+		return $response->get_data()['counts']['posts'];
+	}
+
+	/**
+	 * A subscriber only sees the published post in `recent` — the
+	 * admin's draft, private, pending and scheduled posts are dropped.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_callback
+	 */
+	public function test_subscriber_recent_excludes_unpublished() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$response = $this->dispatch();
+		$this->assertSame( 200, $response->get_status() );
+
+		$ids = $this->recent_ids( $response );
+		$this->assertContains( $this->published_id, $ids );
+		$this->assertNotContains( $this->draft_id, $ids );
+		$this->assertNotContains( $this->private_id, $ids );
+		$this->assertNotContains( $this->pending_id, $ids );
+		$this->assertNotContains( $this->future_id, $ids );
+	}
+
+	/**
+	 * The per-status counts a subscriber receives cover only the
+	 * published set — the unpublished statuses are zero, so the count
+	 * cannot act as an oracle for hidden content.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_callback
+	 */
+	public function test_subscriber_counts_hide_unpublished() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$counts = $this->post_counts( $this->dispatch() );
+		$this->assertSame( 1, $counts['publish'] );
+		$this->assertSame( 0, $counts['draft'] );
+		$this->assertSame( 0, $counts['private'] );
+		$this->assertSame( 0, $counts['pending'] );
+		$this->assertSame( 0, $counts['future'] );
+		$this->assertSame( 1, $counts['total'] );
+	}
+
+	/**
+	 * An administrator can read everything in the term, so both the
+	 * recent list and the counts include the unpublished posts.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_callback
+	 */
+	public function test_admin_sees_unpublished_in_recent_and_counts() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch();
+		$ids      = $this->recent_ids( $response );
+		$this->assertContains( $this->draft_id, $ids );
+		$this->assertContains( $this->private_id, $ids );
+		$this->assertContains( $this->pending_id, $ids );
+		$this->assertContains( $this->future_id, $ids );
+
+		$counts = $this->post_counts( $response );
+		$this->assertSame( 1, $counts['publish'] );
+		$this->assertSame( 1, $counts['draft'] );
+		$this->assertSame( 1, $counts['private'] );
+		$this->assertSame( 1, $counts['pending'] );
+		$this->assertSame( 1, $counts['future'] );
+		$this->assertSame( 5, $counts['total'] );
+	}
+
+	/**
+	 * An author sees their OWN draft in the term (they can read it),
+	 * but not another author's — the own-post scope widens no one
+	 * else's view.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_callback
+	 */
+	public function test_author_sees_own_draft_only() {
+		$own_draft = $this->make_post( 'draft', 'My own draft', self::$author_id );
+
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->dispatch();
+		$ids      = $this->recent_ids( $response );
+		$this->assertContains( $own_draft, $ids );
+		$this->assertNotContains( $this->draft_id, $ids ); // The admin's draft.
+		$this->assertNotContains( $this->private_id, $ids );
+		$this->assertNotContains( $this->future_id, $ids );
+
+		// The count reflects the one draft the author may read.
+		$counts = $this->post_counts( $response );
+		$this->assertSame( 1, $counts['draft'] );
+		$this->assertSame( 0, $counts['private'] );
+		$this->assertSame( 0, $counts['future'] );
+	}
+
+	/**
+	 * A status registered with `public => true` is front-end-visible
+	 * data, so it counts and lists for everyone — the readable set is
+	 * driven by the registered visibility flags, not a hardcoded
+	 * status list.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_readable_status_clause
+	 */
+	public function test_custom_public_status_is_visible_to_subscribers() {
+		register_post_status( 'showcase', array( 'public' => true ) );
+		$showcase_id = $this->make_post( 'showcase', 'Showcased piece' );
+
+		try {
+			wp_set_current_user( self::$subscriber_id );
+			$response = $this->dispatch();
+
+			$this->assertContains( $showcase_id, $this->recent_ids( $response ) );
+			// The breakdown has no key for the custom status, but the
+			// total covers every readable post.
+			$this->assertSame( 2, $this->post_counts( $response )['total'] );
+		} finally {
+			unset( $GLOBALS['wp_post_statuses']['showcase'] );
+		}
+	}
+
+	/**
+	 * The recent list is capped at five and keeps the five most
+	 * recent readable posts, newest first.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_callback
+	 */
+	public function test_recent_is_capped_at_five_newest_first() {
+		$extras = array();
+		for ( $i = 1; $i <= 6; $i++ ) {
+			$extras[ $i ] = $this->make_post( 'publish', "Extra $i", null, sprintf( '2020-01-%02d 00:00:00', $i ) );
+		}
+
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertSame(
+			array( $this->published_id, $extras[6], $extras[5], $extras[4], $extras[3] ),
+			$this->recent_ids( $this->dispatch() )
+		);
+	}
+
+	/**
+	 * Terms of a non-viewable taxonomy answer exactly like an
+	 * unregistered one unless the caller can manage its terms — a
+	 * subscriber must not enumerate nav menus or a plugin's internal
+	 * taxonomy through this endpoint.
+	 *
+	 * @covers ::openstation_my_wordpress_term_stats_callback
+	 */
+	public function test_hidden_taxonomy_is_not_served_to_subscribers() {
+		$menu = wp_insert_term( 'Primary menu', 'nav_menu' );
+		$this->assertNotWPError( $menu );
+
+		wp_set_current_user( self::$subscriber_id );
+		$response = $this->dispatch( 'nav_menu', $menu['term_id'] );
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'openstation_invalid_taxonomy', $response->get_data()['code'] );
+
+		// An admin holds nav_menu's manage cap (edit_theme_options).
+		wp_set_current_user( self::$admin_id );
+		$this->assertSame( 200, $this->dispatch( 'nav_menu', $menu['term_id'] )->get_status() );
+	}
+}

--- a/tests/phpunit/tests/myWordpressTermStats.php
+++ b/tests/phpunit/tests/myWordpressTermStats.php
@@ -177,7 +177,7 @@ class Tests_OpenStation_MyWordpressTermStats extends WP_UnitTestCase {
 	 * driven by the registered visibility flags, not a hardcoded
 	 * status list.
 	 *
-	 * @covers ::openstation_my_wordpress_term_stats_readable_status_clause
+	 * @covers ::openstation_my_wordpress_term_stats_callback
 	 */
 	public function test_custom_public_status_is_visible_to_subscribers() {
 		register_post_status( 'showcase', array( 'public' => true ) );


### PR DESCRIPTION
## What it does

Stops `GET /desktop-mode/v1/term-stats/<taxonomy>/<id>` from disclosing unpublished posts to low-capability users. A Subscriber no longer receives the titles, IDs, statuses, dates, permalinks and author identities of other users' `private`, `draft`, `pending` and `future` posts in the `recent` list, and the per-status count breakdown no longer reveals how many hidden posts a term holds. Terms of non-viewable taxonomies (`nav_menu`, `link_category`, a plugin's internal taxonomy) are also no longer served to callers who cannot manage them.

## Rationale

The endpoint authorises on the caller's site-wide `read` capability. That is the right gate for the *term* (terms are public-facing data, as the file docblock argues), but the payload is about the *posts inside the term*: the recent-posts query deliberately included `private`, `future`, `draft` and `pending` with no author scoping and no per-post readability test, and the counts were computed over every status. Any logged-in Subscriber could therefore read an administrator's unpublished work for any term id, and term ids are enumerable anonymously through core's categories and tags routes.

## Implementation

The callback builds a prepared SQL fragment admitting only the statuses the caller may read, resolved from the registered status objects and the post type's cap map rather than hardcoded lists, so a plugin's custom status follows its own visibility flags. It is constructed inline, from literal `%s`/`%d` placeholder lists bound through `prepare()` at both use sites, so Plugin Check's DirectDB taint tracking (which is per-scope) can verify it:

- public statuses, for everyone (a status registered with `public => true` keeps counting for all viewers, as it did before);
- private-flagged statuses with the post type's `read_private_posts`;
- the remaining non-internal statuses (draft, pending, future, and any registered workflow status) with `edit_others_posts`, because core maps reading them to editing them; a scheduled post additionally requires `edit_published_posts`, mirroring `map_meta_cap()`;
- the caller's own posts in any of those statuses, since core grants an author `read` on their own post whatever its status.

The counts query runs over that set, so statuses the viewer cannot read report zero instead of acting as an oracle. The recent list uses the same clause plus an authoritative per-row `current_user_can( 'read_post' )` gate (post cache bulk-warmed first), which is also the hook membership plugins use to restrict even published posts; it fetches headroom past five and caps the emitted list at five. The endpoint's `read` permission gate is unchanged, so the public term profile and published-post aggregates still work for every logged-in user.

The taxonomy check now answers exactly like an unregistered taxonomy unless the taxonomy is viewable or the caller holds its `manage_terms` cap, closing the same access-control class for hidden-taxonomy term data (name, description, counts).

`docs/hooks-reference.md` marks the `openstation_my_wordpress_term_stats` payload as viewer-dependent and warns against caching the filtered payload under a term-only key.

## Testing instructions

```bash
npm run env:start:tests
npm run test:php -- --filter='Tests_OpenStation_MyWordpressTermStats'
npm run env:stop:tests
```

Seven new tests pin the model: Subscriber sees no unpublished rows and publish-only counts; an administrator keeps everything; an author sees their own draft but not another author's; a custom `public => true` status stays visible to subscribers; the recent list caps at five, newest first; and a `nav_menu` term answers 400 to a Subscriber but 200 to an administrator.

Verified end to end on the live wp-env install against the real route: unpatched, a Subscriber's request returned `"Secret admin draft"` and `"Private: Private admin notes"` titles with `counts` of `draft: 1, private: 1, total: 3`; patched, the same request returns only the published post with `draft: 0, private: 0, total: 1`. Anonymous stays `401`, an administrator keeps the full view, and a Subscriber's `nav_menu` request returns `400 openstation_invalid_taxonomy`. Full PHPUnit suite green (3041 tests); `phpcs -n` clean.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-806-003bf65f775d2ae584f952a59f8b88fcf25e29c4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
