### PR TITLE
OS Settings: let a registered settings tab name its sidebar glyph

### DIFF
--- a/apps/os-settings/os-settings.os.ts
+++ b/apps/os-settings/os-settings.os.ts
@@ -57,9 +57,8 @@ const DEFAULT_TAB = 'appearance';
 /** A row's sidebar glyph — one node per row, made once. */
 function glyph( ui: UiState, row: PageRow ): SVGSVGElement | unknown {
 	if ( ! row.icon ) {
-		// Third-party tabs have no glyph to render: the registry has
-		// no icon field. The spacer keeps their label on the same
-		// line as every other label.
+		// A registry tab that named no icon (or an unknown one). The
+		// spacer keeps its label on the same line as every other label.
 		return html`<span class="os-settings__nav-glyph-blank" aria-hidden="true"></span>`;
 	}
 	let node = ui.glyphs.get( row.id );

--- a/apps/os-settings/os-settings.test.ts
+++ b/apps/os-settings/os-settings.test.ts
@@ -122,6 +122,20 @@ describe( 'OpenStation Preferences — the frame', () => {
 		expect( tabCtx.getOsSettings() ).toMatchObject( { accent: 'pulse' } );
 	} );
 
+	test( 'a registry tab draws the icon-set glyph it names, and a spacer otherwise', () => {
+		registerSettingsTab( { id: 'acme', label: 'Acme', icon: 'bell', render: () => undefined } );
+		paint();
+		const named = root.querySelector( '#os-settings-nav > os-tab[value="ext-acme"]' );
+		expect( named?.querySelector( 'svg' ) ).not.toBeNull();
+		expect( named?.querySelector( '.os-settings__nav-glyph-blank' ) ).toBeNull();
+
+		registerSettingsTab( { id: 'acme', label: 'Acme', icon: 'not-an-icon', render: () => undefined } );
+		paint();
+		const unknown = root.querySelector( '#os-settings-nav > os-tab[value="ext-acme"]' );
+		expect( unknown?.querySelector( 'svg' ) ).toBeNull();
+		expect( unknown?.querySelector( '.os-settings__nav-glyph-blank' ) ).not.toBeNull();
+	} );
+
 	test( 'an admin-only registry tab is hidden from an editor', () => {
 		registerSettingsTab( { id: 'acme', label: 'Acme', capability: 'manage_options', render: () => undefined } );
 		paint( false );

--- a/apps/os-settings/parts/nav-icons.ts
+++ b/apps/os-settings/parts/nav-icons.ts
@@ -43,7 +43,7 @@
  * needing a second set of rules to keep the two in step.
  */
 
-import { osIcon } from '../../../src/ui/icons';
+import { isOsIconName, osIcon } from '../../../src/ui/icons';
 
 /**
  * Partial because most ids have no glyph: only the built-in pages
@@ -65,10 +65,10 @@ const NAV = { size: null } as const;
  * Tab id to glyph. Ids match the page table in `pages.ts`.
  *
  * A tab with no entry renders without a glyph and keeps its label
- * aligned with the rest, which is the case every third-party tab is
- * in: the settings-tab registry has no icon field, so a plugin cannot
- * supply one even if it wanted to. See the note on the empty-icon
- * spacer in `os-settings.css`.
+ * aligned with the rest. Registry tabs name their own glyph through
+ * `icon` on the registration — see `registryNavIcon()` — and land
+ * here only when they don't. See the note on the empty-icon spacer
+ * in `os-settings.css`.
  */
 export const NAV_ICONS: NavIconMap = {
 	/*
@@ -176,3 +176,14 @@ export const NAV_ICONS: NavIconMap = {
 	 */
 	about: () => osIcon( 'info', NAV ),
 };
+
+/**
+ * Glyph for a registry tab: the icon-set name it registered, else the
+ * shell's own table by raw id (File Associations), else none.
+ */
+export function registryNavIcon( id: string, icon?: string ): ( () => SVGSVGElement ) | undefined {
+	if ( icon && isOsIconName( icon ) ) {
+		return () => osIcon( icon, NAV );
+	}
+	return NAV_ICONS[ id ];
+}

--- a/apps/os-settings/parts/pages.ts
+++ b/apps/os-settings/parts/pages.ts
@@ -19,7 +19,7 @@ import { renderNavigation } from './navigation';
 import { renderMobile } from './mobile';
 import { renderComponents } from './components';
 import { renderAboutPage } from './about';
-import { NAV_ICONS } from './nav-icons';
+import { NAV_ICONS, registryNavIcon } from './nav-icons';
 import { settings, subscribe } from './store';
 import { uiOf, type Ctx } from './types';
 
@@ -189,9 +189,7 @@ export function pageRows( ctx: Ctx ): PageRow[] {
 			id: `ext-${ tab.id }`,
 			order: tab.order ?? 100,
 			label: tab.label,
-			// The registry has no icon field, but the shell may know its
-			// OWN registry-delivered tabs by raw id (File Associations).
-			icon: NAV_ICONS[ tab.id ],
+			icon: registryNavIcon( tab.id, tab.icon ),
 			tab,
 			panel: () => html`<div data-host=${ tabHostAttr( tab.id ) }></div>`,
 		} );

--- a/docs/javascript-reference.md
+++ b/docs/javascript-reference.md
@@ -3886,6 +3886,7 @@ Register a tab in the OpenStation Preferences window. The tab is appended (or so
 | `label` | `string` | yes | Tab label. |
 | `capability` | `string` | no | Gates visibility. `'manage_options'` → admin-only; any other value (including omitting) → visible to everyone. |
 | `order` | `number` | no | Default `100`. Built-ins: appearance=10, themes=12, windows=18, navigation=22, features=30, help=40 (Components is admin-only; About is pinned last with a sentinel order). |
+| `icon` | `string` | no | Sidebar glyph, as a name from the OS icon set (`settings`, `bell`, `apps`, … — see `src/ui/icons/set.ts`). Unknown names render no glyph, same as omitting it. |
 | `owner` | `string` | no | When set, plugin deactivation live-unregisters every tab with this owner. Typically matches the WordPress script handle registered with `openstation_register_settings_tab_script()`. |
 | `render( body, ctx )` | `function` | yes | Receives the tabpanel body element and a ctx object (see below). Runs once per registration — the host survives the Preferences app's repaints — and again after a re-register; closing and reopening the window rebuilds the tree, so it must be idempotent. |
 

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -83,6 +83,13 @@ export interface DesktopSettingsTab {
 	 */
 	order?: number;
 	/**
+	 * Sidebar glyph — a name from the OS icon set (`settings`, `bell`,
+	 * `apps`, …; see `src/ui/icons/set.ts`). Optional; an unknown name
+	 * renders no glyph, the same as omitting it. Names, not URLs: the
+	 * column draws 17px monoline glyphs, and a bitmap would not match.
+	 */
+	icon?: string;
+	/**
 	 * Owner tag — WordPress script handle that registered the tab.
 	 * Set this when plugin deactivation should live-unregister the
 	 * tab; the server-sync module walks the registry on every payload

--- a/tests/vitest/settings-nav-icons.test.ts
+++ b/tests/vitest/settings-nav-icons.test.ts
@@ -12,7 +12,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, test } from 'vitest';
-import { NAV_ICONS } from '../../apps/os-settings/parts/nav-icons';
+import { NAV_ICONS, registryNavIcon } from '../../apps/os-settings/parts/nav-icons';
 
 /**
  * The built-in pages the Preferences app lists, by id.
@@ -84,9 +84,14 @@ describe( 'settings nav icons', () => {
 		);
 		expect(
 			pagesSource,
-			'External rows must carry `icon: NAV_ICONS[ tab.id ]` so a ' +
-				'shell-owned registry tab can resolve its glyph by raw id.'
-		).toMatch( /icon:\s*NAV_ICONS\[\s*tab\.id\s*\]/ );
+			'External rows must resolve through `registryNavIcon( tab.id, … )` ' +
+				'so a shell-owned registry tab can resolve its glyph by raw id.'
+		).toMatch( /icon:\s*registryNavIcon\(\s*tab\.id\b/ );
+		// And the resolver must still honour that raw-id table when the
+		// registration named no icon of its own.
+		const fallback = registryNavIcon( 'os-file-associations' );
+		expect( fallback ).toBe( NAV_ICONS[ 'os-file-associations' ] );
+		expect( fallback?.().tagName.toLowerCase() ).toBe( 'svg' );
 	} );
 
 	test.each( BUILT_IN_TAB_IDS )( '%s is drawn in currentColor', ( id ) => {


### PR DESCRIPTION
Fixes #808

## What changes

A plugin-registered Preferences tab rendered with an empty icon column: the settings-tab registry had no `icon` field, so the sidebar could only draw glyphs for ids the shell knew by hand (File Associations).

- `DesktopSettingsTab` gains an optional `icon` — a name from the OS icon set (`settings`, `bell`, `apps`, …), the same vocabulary the core tabs already use. Names rather than URLs: the column draws 17px monoline glyphs from `currentColor`, so a bitmap or hard-coloured SVG would not match the theme (or, once Brand Studio lands, the brand).
- `registryNavIcon()` in `nav-icons.ts` resolves a row's glyph: the registered name if it is in the set, else the shell's own table by raw id, else none. `pages.ts` calls it in place of the bare `NAV_ICONS[ tab.id ]` lookup.
- An unknown or absent name still draws the spacer, so a plugin can set the field ahead of the release that reads it. `osIconDef()` already refuses inherited keys, so a plugin-supplied string cannot reach the prototype chain.
- Docs: one row in the `registerSettingsTab()` table in `docs/javascript-reference.md`.

The PHP `openstation_register_settings_tab()` is deliberately unchanged: the sidebar is painted from the JS registry, and the server entry is only consulted to unregister tabs on deactivation, so a PHP `icon` would be data nothing reads.

## Test

`apps/os-settings/os-settings.test.ts` — one new case: a tab registered with `icon: 'bell'` renders an `<svg>` and no spacer; re-registered with `icon: 'not-an-icon'` it renders the spacer and no `<svg>`. Run against trunk before the change it fails on the first assertion; with the change the file is 13/13.

`npm run typecheck` and `eslint` on the touched files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fopenstation%2F%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22siteOptions%22%3A%7B%22blogname%22%3A%22OpenStation%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fopenstation%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-809-35d499fb7df01d1bc677c78f4f73817415e33d18.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->